### PR TITLE
Fix two more corner cases of property paths with zero length

### DIFF
--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -2785,24 +2785,11 @@ void QueryPlanner::GraphPatternPlanner::visitTransitivePath(
   for (auto& sub : candidatesIn) {
     TransitivePathSide left;
     TransitivePathSide right;
-    auto getSideValue =
-        [this](const TripleComponent& side) -> std::variant<Id, Variable> {
-      if (isVariable(side)) {
-        return side.getVariable();
-      } else {
-        if (auto opt = side.toValueId(planner_._qec->getIndex().getVocab());
-            opt.has_value()) {
-          return opt.value();
-        } else {
-          AD_THROW("No vocabulary entry for " + side.toString());
-        }
-      }
-    };
 
     left.subCol_ = sub._qet->getVariableColumn(arg._innerLeft.getVariable());
-    left.value_ = getSideValue(arg._left);
+    left.value_ = arg._left;
     right.subCol_ = sub._qet->getVariableColumn(arg._innerRight.getVariable());
-    right.value_ = getSideValue(arg._right);
+    right.value_ = arg._right;
     size_t min = arg._min;
     size_t max = arg._max;
     if (planner_.activeGraphVariable_.has_value()) {

--- a/src/engine/TransitivePathBase.cpp
+++ b/src/engine/TransitivePathBase.cpp
@@ -109,9 +109,8 @@ std::shared_ptr<QueryExecutionTree> TransitivePathBase::joinWithIndexScan(
           SparqlTriple{TripleComponent{z}, PropertyPath::fromVariable(y),
                        TripleComponent{x}},
           activeGraphs))));
-  return ad_utility::makeExecutionTree<Distinct>(
-      qec, QueryExecutionTree::createSortedTree(std::move(allValues), {0}),
-      std::vector<ColumnIndex>{0});
+  return ad_utility::makeExecutionTree<Distinct>(qec, std::move(allValues),
+                                                 std::vector<ColumnIndex>{0});
 }
 
 // _____________________________________________________________________________
@@ -141,9 +140,8 @@ std::shared_ptr<QueryExecutionTree> TransitivePathBase::makeEmptyPathSide(
           SparqlTriple{TripleComponent{z}, PropertyPath::fromVariable(y),
                        TripleComponent{x}},
           activeGraphs)));
-  return ad_utility::makeExecutionTree<Distinct>(
-      qec, QueryExecutionTree::createSortedTree(std::move(allValues), {0}),
-      std::vector<ColumnIndex>{0});
+  return ad_utility::makeExecutionTree<Distinct>(qec, std::move(allValues),
+                                                 std::vector<ColumnIndex>{0});
 }
 
 // _____________________________________________________________________________

--- a/src/engine/TransitivePathBase.cpp
+++ b/src/engine/TransitivePathBase.cpp
@@ -398,9 +398,13 @@ std::shared_ptr<TransitivePathBase> TransitivePathBase::bindLeftOrRightSide(
   auto rhs = rhs_;
   if (isLeft) {
     lhs.treeAndCol_ = {leftOrRightOp, inputCol};
+    // Remove placeholder tree if binding actual tree.
+    if (!rhs.isVariable()) {
+      rhs.treeAndCol_ = std::nullopt;
+    }
   } else {
     // Remove placeholder tree if binding actual tree.
-    if (boundVariableIsForEmptyPath_) {
+    if (boundVariableIsForEmptyPath_ || !lhs.isVariable()) {
       lhs.treeAndCol_ = std::nullopt;
     }
     rhs.treeAndCol_ = {leftOrRightOp, inputCol};

--- a/src/engine/TransitivePathBase.h
+++ b/src/engine/TransitivePathBase.h
@@ -6,6 +6,8 @@
 #ifndef QLEVER_SRC_ENGINE_TRANSITIVEPATHBASE_H
 #define QLEVER_SRC_ENGINE_TRANSITIVEPATHBASE_H
 
+#include <absl/hash/hash.h>
+
 #include <functional>
 #include <memory>
 
@@ -70,14 +72,10 @@ struct TransitivePathSide {
 
 // We deliberately use the `std::` variants of a hash set and hash map because
 // `absl`s types are not exception safe.
-struct HashId {
-  auto operator()(Id id) const { return std::hash<uint64_t>{}(id.getBits()); }
-};
-
-using Set = std::unordered_set<Id, HashId, std::equal_to<Id>,
+using Set = std::unordered_set<Id, absl::Hash<Id>, std::equal_to<Id>,
                                ad_utility::AllocatorWithLimit<Id>>;
 using Map = std::unordered_map<
-    Id, Set, HashId, std::equal_to<Id>,
+    Id, Set, absl::Hash<Id>, std::equal_to<Id>,
     ad_utility::AllocatorWithLimit<std::pair<const Id, Set>>>;
 
 // Helper struct, that allows a generator to yield a a node and all its

--- a/src/engine/TransitivePathBase.h
+++ b/src/engine/TransitivePathBase.h
@@ -124,7 +124,9 @@ class TransitivePathBase : public Operation {
   size_t maxDist_;
   VariableToColumnMap variableColumns_;
   // Indicate that the variable is only bound because the path is empty, not
-  // because `bindLeftOrRightSide` was called.
+  // because `bindLeftOrRightSide` was called. This means that it is bound to a
+  // full scan of all subjects and objects in the knowledge graph, but can be
+  // re-bound to something cheaper later if the query permits it.
   bool boundVariableIsForEmptyPath_ = false;
 
  public:
@@ -250,6 +252,9 @@ class TransitivePathBase : public Operation {
                                           size_t targetSideCol, bool yieldOnce,
                                           size_t skipCol = 0) const;
 
+  // Return an execution tree, that "joins" the given `tripleComponent` with all
+  // of the subjects or objects in the knowledge graph, so if the graph does not
+  // contain this value it is filtered out.
   static std::shared_ptr<QueryExecutionTree> joinWithIndexScan(
       QueryExecutionContext* qec, Graphs activeGraphs,
       const TripleComponent& tripleComponent);

--- a/src/engine/TransitivePathBinSearch.h
+++ b/src/engine/TransitivePathBinSearch.h
@@ -54,6 +54,17 @@ struct BinSearchMap {
 
     return targetIds_.subspan(startIndex, range.size());
   }
+
+  // Retreive pointer to equal id from `startIds_`, or nullptr if not present.
+  // This is used to get `Id`s that do do not depend on a specific `LocalVocab`,
+  // but instead are backed by the index.
+  const Id* getEquivalentId(Id node) const {
+    auto range = ql::ranges::equal_range(startIds_, node);
+    if (range.empty()) {
+      return nullptr;
+    }
+    return &range.front();
+  }
 };
 
 /**

--- a/src/engine/TransitivePathBinSearch.h
+++ b/src/engine/TransitivePathBinSearch.h
@@ -55,7 +55,7 @@ struct BinSearchMap {
     return targetIds_.subspan(startIndex, range.size());
   }
 
-  // Retreive pointer to equal id from `startIds_`, or nullptr if not present.
+  // Retrieve pointer to equal id from `startIds_`, or nullptr if not present.
   // This is used to get `Id`s that do do not depend on a specific `LocalVocab`,
   // but instead are backed by the index.
   const Id* getEquivalentId(Id node) const {

--- a/src/engine/TransitivePathHashMap.h
+++ b/src/engine/TransitivePathHashMap.h
@@ -41,6 +41,17 @@ struct HashMapWrapper {
     }
     return iterator->second;
   }
+
+  // Retreive pointer to equal id from `map_`, or nullptr if not present.
+  // This is used to get `Id`s that do do not depend on a specific `LocalVocab`,
+  // but instead are backed by the index.
+  const Id* getEquivalentId(Id node) const {
+    auto iterator = map_.find(node);
+    if (iterator == map_.end()) {
+      return nullptr;
+    }
+    return &iterator->first;
+  }
 };
 
 /**

--- a/src/engine/TransitivePathHashMap.h
+++ b/src/engine/TransitivePathHashMap.h
@@ -8,10 +8,9 @@
 
 #include <memory>
 
-#include "engine/Operation.h"
-#include "engine/QueryExecutionTree.h"
 #include "engine/TransitivePathImpl.h"
 #include "engine/idTable/IdTable.h"
+#include "util/AllocatorWithLimit.h"
 
 /**
  * @class HashMapWrapper

--- a/src/engine/TransitivePathHashMap.h
+++ b/src/engine/TransitivePathHashMap.h
@@ -42,7 +42,7 @@ struct HashMapWrapper {
     return iterator->second;
   }
 
-  // Retreive pointer to equal id from `map_`, or nullptr if not present.
+  // Retrieve pointer to equal id from `map_`, or nullptr if not present.
   // This is used to get `Id`s that do do not depend on a specific `LocalVocab`,
   // but instead are backed by the index.
   const Id* getEquivalentId(Id node) const {

--- a/src/engine/TransitivePathImpl.h
+++ b/src/engine/TransitivePathImpl.h
@@ -74,10 +74,7 @@ class TransitivePathImpl : public TransitivePathBase {
 
     NodeGenerator hull =
         transitiveHull(edges, sub->getCopyOfLocalVocab(), std::move(nodes),
-                       targetSide.isVariable()
-                           ? std::nullopt
-                           : std::optional{std::get<Id>(targetSide.value_)},
-                       yieldOnce);
+                       targetSide.value_, yieldOnce);
 
     auto result = fillTableWithHull(
         std::move(hull), startSide.outputCol_, targetSide.outputCol_,
@@ -109,7 +106,7 @@ class TransitivePathImpl : public TransitivePathBase {
 
     auto edges = setupEdgesMap(sub->idTable(), startSide, targetSide);
     auto nodesWithDuplicates =
-        setupNodes(sub->idTable(), startSide, targetSide);
+        setupNodes(sub->idTable(), startSide, targetSide, edges);
     Set nodesWithoutDuplicates{allocator()};
     for (const auto& span : nodesWithDuplicates) {
       nodesWithoutDuplicates.insert(span.begin(), span.end());
@@ -122,12 +119,9 @@ class TransitivePathImpl : public TransitivePathBase {
     detail::TableColumnWithVocab<const Set&> tableInfo{
         nullptr, nodesWithoutDuplicates, LocalVocab{}};
 
-    NodeGenerator hull = transitiveHull(
-        edges, sub->getCopyOfLocalVocab(), std::span{&tableInfo, 1},
-        targetSide.isVariable()
-            ? std::nullopt
-            : std::optional{std::get<Id>(targetSide.value_)},
-        yieldOnce);
+    NodeGenerator hull =
+        transitiveHull(edges, sub->getCopyOfLocalVocab(),
+                       std::span{&tableInfo, 1}, targetSide.value_, yieldOnce);
 
     auto result = fillTableWithHull(std::move(hull), startSide.outputCol_,
                                     targetSide.outputCol_, yieldOnce);
@@ -222,8 +216,8 @@ class TransitivePathImpl : public TransitivePathBase {
    * @param edgesVocab The `LocalVocab` holding the vocabulary of the edges.
    * @param startNodes A range that yields an instantiation of
    * `TableColumnWithVocab` that can be consumed to create a transitive hull.
-   * @param target Optional target Id. If supplied, only paths which end
-   * in this Id are added to the hull.
+   * @param target Target `TripleComponent`. If it's not a variable, paths that
+   * don't end with a matching value are discarded.
    * @param yieldOnce This has to be set to the same value as the consuming
    * code. When set to true, this will prevent yielding the same LocalVocab over
    * and over again to make merging faster (because merging with an empty
@@ -232,15 +226,21 @@ class TransitivePathImpl : public TransitivePathBase {
    */
   CPP_template(typename Node)(requires ql::ranges::range<Node>) NodeGenerator
       transitiveHull(const T& edges, LocalVocab edgesVocab, Node startNodes,
-                     std::optional<Id> target, bool yieldOnce) const {
+                     TripleComponent target, bool yieldOnce) const {
     ad_utility::Timer timer{ad_utility::Timer::Stopped};
+    LocalVocab targetHelper;
+    std::optional<Id> targetId =
+        target.isVariable()
+            ? std::nullopt
+            : std::optional{std::move(target).toValueId(
+                  _executionContext->getIndex().getVocab(), targetHelper)};
     for (auto&& tableColumn : startNodes) {
       timer.cont();
       LocalVocab mergedVocab = std::move(tableColumn.vocab_);
       mergedVocab.mergeWith(edgesVocab);
       size_t currentRow = 0;
       for (Id startNode : tableColumn.column_) {
-        Set connectedNodes = findConnectedNodes(edges, startNode, target);
+        Set connectedNodes = findConnectedNodes(edges, startNode, targetId);
         if (!connectedNodes.empty()) {
           runtimeInfo().addDetail("Hull time", timer.msecs());
           timer.stop();
@@ -271,12 +271,23 @@ class TransitivePathImpl : public TransitivePathBase {
    */
   std::vector<std::span<const Id>> setupNodes(
       const IdTable& sub, const TransitivePathSide& startSide,
-      const TransitivePathSide& targetSide) const {
+      const TransitivePathSide& targetSide, const T& edges) const {
     std::vector<std::span<const Id>> result;
 
     // id -> var|id
     if (!startSide.isVariable()) {
-      result.emplace_back(&std::get<Id>(startSide.value_), 1);
+      AD_CORRECTNESS_CHECK(minDist_ != 0,
+                           "If minDist_ is 0 with a hardcoded side, we should "
+                           "call the overload for a bound transitive path.");
+      LocalVocab helperVocab;
+      Id startId = TripleComponent{startSide.value_}.toValueId(
+          _executionContext->getIndex().getVocab(), helperVocab);
+      // Make sure we retreive the Id from an IndexScan, so we don't have to
+      // pass this LocalVocab around. If it's not present then no result needs
+      // to be returned anyways.
+      if (const Id* id = edges.getEquivalentId(startId)) {
+        result.emplace_back(id, 1);
+      }
       // var -> var
     } else {
       std::span<const Id> startNodes = sub.getColumn(startSide.subCol_);

--- a/src/engine/TransitivePathImpl.h
+++ b/src/engine/TransitivePathImpl.h
@@ -282,7 +282,7 @@ class TransitivePathImpl : public TransitivePathBase {
       LocalVocab helperVocab;
       Id startId = TripleComponent{startSide.value_}.toValueId(
           _executionContext->getIndex().getVocab(), helperVocab);
-      // Make sure we retreive the Id from an IndexScan, so we don't have to
+      // Make sure we retrieve the Id from an IndexScan, so we don't have to
       // pass this LocalVocab around. If it's not present then no result needs
       // to be returned anyways.
       if (const Id* id = edges.getEquivalentId(startId)) {

--- a/src/engine/TransitivePathImpl.h
+++ b/src/engine/TransitivePathImpl.h
@@ -228,6 +228,8 @@ class TransitivePathImpl : public TransitivePathBase {
       transitiveHull(const T& edges, LocalVocab edgesVocab, Node startNodes,
                      TripleComponent target, bool yieldOnce) const {
     ad_utility::Timer timer{ad_utility::Timer::Stopped};
+    // `targetId` is only ever used for comparisons, and never stored in the
+    // result, so we use a separate local vocabulary.
     LocalVocab targetHelper;
     std::optional<Id> targetId =
         target.isVariable()

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -753,13 +753,12 @@ TEST(QueryPlanner, TransitivePathLeftId) {
   auto scan = h::IndexScanFromStrings;
   auto qec = ad_utility::testing::getQec("<s> <p> <o>");
 
-  auto getId = ad_utility::testing::makeGetId(qec->getIndex());
+  using ad_utility::triple_component::Iri;
 
-  TransitivePathSide left{std::nullopt, 0, getId("<s>"), 0};
+  TransitivePathSide left{std::nullopt, 0, Iri::fromIriref("<s>"), 0};
   TransitivePathSide right{std::nullopt, 1, Variable("?y"), 1};
   h::expect(
-      "SELECT ?y WHERE {"
-      "<s> <p>+ ?y }",
+      "SELECT ?y WHERE { <s> <p>+ ?y }",
       h::TransitivePath(left, right, 1, std::numeric_limits<size_t>::max(),
                         scan(internalVar(0), "<p>", internalVar(1))),
       qec);
@@ -769,13 +768,12 @@ TEST(QueryPlanner, TransitivePathRightId) {
   auto scan = h::IndexScanFromStrings;
   auto qec = ad_utility::testing::getQec("<s> <p> <o>");
 
-  auto getId = ad_utility::testing::makeGetId(qec->getIndex());
+  using ad_utility::triple_component::Iri;
 
   TransitivePathSide left{std::nullopt, 1, Variable("?x"), 0};
-  TransitivePathSide right{std::nullopt, 0, getId("<o>"), 1};
+  TransitivePathSide right{std::nullopt, 0, Iri::fromIriref("<o>"), 1};
   h::expect(
-      "SELECT ?y WHERE {"
-      "?x <p>+ <o> }",
+      "SELECT ?y WHERE { ?x <p>+ <o> }",
       h::TransitivePath(left, right, 1, std::numeric_limits<size_t>::max(),
                         scan(internalVar(0), "<p>", internalVar(1))),
       qec);
@@ -4026,21 +4024,21 @@ TEST(QueryPlanner, negatedPaths) {
 
 // _____________________________________________________________________________
 TEST(QueryPlanner, transitivePathWithoutVariables) {
-  TransitivePathSide left{std::nullopt, 1, Id::makeFromInt(1), 0};
-  TransitivePathSide right{std::nullopt, 0, Id::makeFromInt(1), 1};
+  TransitivePathSide left{std::nullopt, 1, 1, 0};
+  TransitivePathSide right{std::nullopt, 0, 1, 1};
   h::expect(
-      "SELECT * { 1 <a>* 1 }",
+      "SELECT * { 1 <a>+ 1 }",
       h::TransitivePath(
-          left, right, 0, std::numeric_limits<size_t>::max(),
+          left, right, 1, std::numeric_limits<size_t>::max(),
           h::IndexScanFromStrings("?_QLever_internal_variable_qp_0", "<a>",
                                   "?_QLever_internal_variable_qp_1")));
 
   h::expect(
-      "SELECT * { 1 <a>* 1 . 1 <a> 1 }",
+      "SELECT * { 1 <a>+ 1 . 1 <a> 1 }",
       h::CartesianProductJoin(
           h::IndexScan(1, TripleComponent::Iri::fromIriref("<a>"), 1),
           h::TransitivePath(
-              left, right, 0, std::numeric_limits<size_t>::max(),
+              left, right, 1, std::numeric_limits<size_t>::max(),
               h::IndexScanFromStrings("?_QLever_internal_variable_qp_0", "<a>",
                                       "?_QLever_internal_variable_qp_1"))));
 }

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -4045,17 +4045,23 @@ TEST(QueryPlanner, emptyPathWithLiterals) {
       "SELECT * { 1 <a>* ?var }",
       h::TransitivePath(
           left, right, 0, std::numeric_limits<size_t>::max(),
-          h::Join(h::Distinct(
-                      {0}, h::Union(h::IndexScanFromStrings(
-                                        "?internal_property_path_variable_x",
-                                        "?internal_property_path_variable_y",
-                                        "?internal_property_path_variable_z"),
-                                    h::IndexScanFromStrings(
-                                        "?internal_property_path_variable_z",
-                                        "?internal_property_path_variable_y",
-                                        "?internal_property_path_variable_x"))),
-                  h::Sort(h::ValuesClause(
-                      "VALUES (?internal_property_path_variable_x) { (1) }"))),
+          h::Distinct(
+              {0},
+              h::Union(
+                  h::Join(h::IndexScanFromStrings(
+                              "?internal_property_path_variable_x",
+                              "?internal_property_path_variable_y",
+                              "?internal_property_path_variable_z"),
+                          h::Sort(h::ValuesClause(
+                              "VALUES (?internal_property_path_variable_x) { "
+                              "(1) }"))),
+                  h::Join(h::IndexScanFromStrings(
+                              "?internal_property_path_variable_z",
+                              "?internal_property_path_variable_y",
+                              "?internal_property_path_variable_x"),
+                          h::Sort(h::ValuesClause(
+                              "VALUES (?internal_property_path_variable_x) { "
+                              "(1) }"))))),
           h::IndexScanFromStrings("?_QLever_internal_variable_qp_0", "<a>",
                                   "?_QLever_internal_variable_qp_1")));
 
@@ -4065,34 +4071,46 @@ TEST(QueryPlanner, emptyPathWithLiterals) {
       "SELECT * { 1 <a>* 1 }",
       h::TransitivePath(
           left2, right2, 0, std::numeric_limits<size_t>::max(),
-          h::Join(h::Distinct(
-                      {0}, h::Union(h::IndexScanFromStrings(
-                                        "?internal_property_path_variable_x",
-                                        "?internal_property_path_variable_y",
-                                        "?internal_property_path_variable_z"),
-                                    h::IndexScanFromStrings(
-                                        "?internal_property_path_variable_z",
-                                        "?internal_property_path_variable_y",
-                                        "?internal_property_path_variable_x"))),
-                  h::Sort(h::ValuesClause(
-                      "VALUES (?internal_property_path_variable_x) { (1) }"))),
+          h::Distinct(
+              {0},
+              h::Union(
+                  h::Join(h::IndexScanFromStrings(
+                              "?internal_property_path_variable_x",
+                              "?internal_property_path_variable_y",
+                              "?internal_property_path_variable_z"),
+                          h::Sort(h::ValuesClause(
+                              "VALUES (?internal_property_path_variable_x) { "
+                              "(1) }"))),
+                  h::Join(h::IndexScanFromStrings(
+                              "?internal_property_path_variable_z",
+                              "?internal_property_path_variable_y",
+                              "?internal_property_path_variable_x"),
+                          h::Sort(h::ValuesClause(
+                              "VALUES (?internal_property_path_variable_x) { "
+                              "(1) }"))))),
           h::IndexScanFromStrings("?_QLever_internal_variable_qp_0", "<a>",
                                   "?_QLever_internal_variable_qp_1")));
   h::expect(
       R"(PREFIX xsd: <http://www.w3.org/2001/XMLSchema#> SELECT * { 1 <a>* "1"^^xsd:integer })",
       h::TransitivePath(
           left2, right2, 0, std::numeric_limits<size_t>::max(),
-          h::Join(h::Distinct(
-                      {0}, h::Union(h::IndexScanFromStrings(
-                                        "?internal_property_path_variable_x",
-                                        "?internal_property_path_variable_y",
-                                        "?internal_property_path_variable_z"),
-                                    h::IndexScanFromStrings(
-                                        "?internal_property_path_variable_z",
-                                        "?internal_property_path_variable_y",
-                                        "?internal_property_path_variable_x"))),
-                  h::Sort(h::ValuesClause(
-                      "VALUES (?internal_property_path_variable_x) { (1) }"))),
+          h::Distinct(
+              {0},
+              h::Union(
+                  h::Join(h::IndexScanFromStrings(
+                              "?internal_property_path_variable_x",
+                              "?internal_property_path_variable_y",
+                              "?internal_property_path_variable_z"),
+                          h::Sort(h::ValuesClause(
+                              "VALUES (?internal_property_path_variable_x) { "
+                              "(1) }"))),
+                  h::Join(h::IndexScanFromStrings(
+                              "?internal_property_path_variable_z",
+                              "?internal_property_path_variable_y",
+                              "?internal_property_path_variable_x"),
+                          h::Sort(h::ValuesClause(
+                              "VALUES (?internal_property_path_variable_x) { "
+                              "(1) }"))))),
           h::IndexScanFromStrings("?_QLever_internal_variable_qp_0", "<a>",
                                   "?_QLever_internal_variable_qp_1")));
 }
@@ -4120,18 +4138,25 @@ TEST(QueryPlanner, emptyPathWithLiteralsBound) {
           h::Sort(h::ValuesClause("VALUES (?var) { (2) }")),
           h::Sort(h::TransitivePath(
               left, right, 0, std::numeric_limits<size_t>::max(),
-              h::Join(
-                  h::Distinct(
-                      {0}, h::Union(h::IndexScanFromStrings(
-                                        "?internal_property_path_variable_x",
-                                        "?internal_property_path_variable_y",
-                                        "?internal_property_path_variable_z"),
-                                    h::IndexScanFromStrings(
-                                        "?internal_property_path_variable_z",
-                                        "?internal_property_path_variable_y",
-                                        "?internal_property_path_variable_x"))),
-                  h::Sort(h::ValuesClause(
-                      "VALUES (?internal_property_path_variable_x) { (1) }"))),
+              h::Distinct(
+                  {0},
+                  h::Union(
+                      h::Join(
+                          h::IndexScanFromStrings(
+                              "?internal_property_path_variable_x",
+                              "?internal_property_path_variable_y",
+                              "?internal_property_path_variable_z"),
+                          h::Sort(h::ValuesClause(
+                              "VALUES (?internal_property_path_variable_x) { "
+                              "(1) }"))),
+                      h::Join(
+                          h::IndexScanFromStrings(
+                              "?internal_property_path_variable_z",
+                              "?internal_property_path_variable_y",
+                              "?internal_property_path_variable_x"),
+                          h::Sort(h::ValuesClause(
+                              "VALUES (?internal_property_path_variable_x) { "
+                              "(1) }"))))),
               h::IndexScanFromStrings("?_QLever_internal_variable_qp_0", "<a>",
                                       "?_QLever_internal_variable_qp_1")))));
 
@@ -4143,18 +4168,25 @@ TEST(QueryPlanner, emptyPathWithLiteralsBound) {
           h::Sort(h::ValuesClause("VALUES (?var) { (2) }")),
           h::Sort(h::TransitivePath(
               left2, right2, 0, std::numeric_limits<size_t>::max(),
-              h::Join(
-                  h::Distinct(
-                      {0}, h::Union(h::IndexScanFromStrings(
-                                        "?internal_property_path_variable_x",
-                                        "?internal_property_path_variable_y",
-                                        "?internal_property_path_variable_z"),
-                                    h::IndexScanFromStrings(
-                                        "?internal_property_path_variable_z",
-                                        "?internal_property_path_variable_y",
-                                        "?internal_property_path_variable_x"))),
-                  h::Sort(h::ValuesClause(
-                      "VALUES (?internal_property_path_variable_x) { (1) }"))),
+              h::Distinct(
+                  {0},
+                  h::Union(
+                      h::Join(
+                          h::IndexScanFromStrings(
+                              "?internal_property_path_variable_x",
+                              "?internal_property_path_variable_y",
+                              "?internal_property_path_variable_z"),
+                          h::Sort(h::ValuesClause(
+                              "VALUES (?internal_property_path_variable_x) { "
+                              "(1) }"))),
+                      h::Join(
+                          h::IndexScanFromStrings(
+                              "?internal_property_path_variable_z",
+                              "?internal_property_path_variable_y",
+                              "?internal_property_path_variable_x"),
+                          h::Sort(h::ValuesClause(
+                              "VALUES (?internal_property_path_variable_x) { "
+                              "(1) }"))))),
               h::IndexScanFromStrings("?_QLever_internal_variable_qp_0", "<a>",
                                       "?_QLever_internal_variable_qp_1")))));
 }

--- a/test/TransitivePathTest.cpp
+++ b/test/TransitivePathTest.cpp
@@ -702,6 +702,59 @@ TEST_P(TransitivePathTest, zeroLength) {
 }
 
 // _____________________________________________________________________________
+TEST_P(TransitivePathTest, zeroLengthWithLiteralsNotInIndex) {
+  std::string index = "<a> a 0 , 1 , 2 , 4 .";
+
+  auto sub = makeIdTableFromVector(
+      {
+          {0, 2},
+          {2, 4},
+      },
+      Id::makeFromInt);
+
+  auto expected = IdTable{2, ad_utility::testing::makeAllocator()};
+
+  {
+    TransitivePathSide left(std::nullopt, 0, 1337, 0);
+    TransitivePathSide right(std::nullopt, 1, 1337, 1);
+    auto T = makePathUnbound(
+        sub.clone(), {Variable{"?start"}, Variable{"?target"}}, left, right, 0,
+        std::numeric_limits<size_t>::max(), index);
+
+    EXPECT_TRUE(T->isBoundOrId());
+
+    auto resultTable = T->computeResultOnlyForTesting(requestLaziness());
+    assertResultMatchesIdTable(resultTable, expected);
+  }
+
+  {
+    TransitivePathSide left(std::nullopt, 0, 1337, 0);
+    TransitivePathSide right(std::nullopt, 1, Variable{"?target"}, 1);
+    auto T = makePathUnbound(
+        std::move(sub), {Variable{"?start"}, Variable{"?target"}}, left, right,
+        0, std::numeric_limits<size_t>::max(), std::move(index));
+
+    EXPECT_TRUE(T->isBoundOrId());
+
+    auto resultTable = T->computeResultOnlyForTesting(requestLaziness());
+    assertResultMatchesIdTable(resultTable, expected);
+  }
+
+  {
+    TransitivePathSide left(std::nullopt, 0, Variable{"?start"}, 0);
+    TransitivePathSide right(std::nullopt, 1, 1337, 1);
+    auto T = makePathUnbound(
+        std::move(sub), {Variable{"?start"}, Variable{"?target"}}, left, right,
+        0, std::numeric_limits<size_t>::max(), std::move(index));
+
+    EXPECT_TRUE(T->isBoundOrId());
+
+    auto resultTable = T->computeResultOnlyForTesting(requestLaziness());
+    assertResultMatchesIdTable(resultTable, expected);
+  }
+}
+
+// _____________________________________________________________________________
 TEST_P(TransitivePathTest, clone) {
   auto sub = makeIdTableFromVector({{0, 2}});
 

--- a/test/TransitivePathTest.cpp
+++ b/test/TransitivePathTest.cpp
@@ -731,8 +731,8 @@ TEST_P(TransitivePathTest, zeroLengthWithLiteralsNotInIndex) {
     TransitivePathSide left(std::nullopt, 0, 1337, 0);
     TransitivePathSide right(std::nullopt, 1, Variable{"?target"}, 1);
     auto T = makePathUnbound(
-        std::move(sub), {Variable{"?start"}, Variable{"?target"}}, left, right,
-        0, std::numeric_limits<size_t>::max(), std::move(index));
+        sub.clone(), {Variable{"?start"}, Variable{"?target"}}, left, right, 0,
+        std::numeric_limits<size_t>::max(), index);
 
     EXPECT_TRUE(T->isBoundOrId());
 
@@ -784,8 +784,8 @@ TEST_P(TransitivePathTest, literalsNotInIndex) {
     TransitivePathSide left(std::nullopt, 0, 1337, 0);
     TransitivePathSide right(std::nullopt, 1, Variable{"?target"}, 1);
     auto T = makePathUnbound(
-        std::move(sub), {Variable{"?start"}, Variable{"?target"}}, left, right,
-        1, std::numeric_limits<size_t>::max(), std::move(index));
+        sub.clone(), {Variable{"?start"}, Variable{"?target"}}, left, right, 1,
+        std::numeric_limits<size_t>::max(), index);
 
     EXPECT_TRUE(T->isBoundOrId());
 
@@ -796,6 +796,65 @@ TEST_P(TransitivePathTest, literalsNotInIndex) {
   {
     TransitivePathSide left(std::nullopt, 0, Variable{"?start"}, 0);
     TransitivePathSide right(std::nullopt, 1, 1337, 1);
+    auto T = makePathUnbound(
+        std::move(sub), {Variable{"?start"}, Variable{"?target"}}, left, right,
+        1, std::numeric_limits<size_t>::max(), std::move(index));
+
+    EXPECT_TRUE(T->isBoundOrId());
+
+    auto resultTable = T->computeResultOnlyForTesting(requestLaziness());
+    assertResultMatchesIdTable(resultTable, expected);
+  }
+}
+
+// _____________________________________________________________________________
+TEST_P(TransitivePathTest, literalsNotInIndexButInDeltaTriples) {
+  using ad_utility::triple_component::Literal;
+  std::string index = "<a> a 0 , 1 , 2 , 4 .";
+  std::string literal = "my-literal";
+
+  // Simulate entries in the delta triples by using entries that are not in the
+  // index
+  LocalVocab localVocab;
+  auto id = Id::makeFromLocalVocabIndex(localVocab.getIndexAndAddIfNotContained(
+      LocalVocabEntry{Literal::literalWithoutQuotes(literal)}));
+  auto sub = makeIdTableFromVector({
+      {id, id},
+  });
+
+  IdTable expected = sub.clone();
+
+  TripleComponent reference = Literal::literalWithoutQuotes(literal);
+
+  {
+    TransitivePathSide left(std::nullopt, 0, reference, 0);
+    TransitivePathSide right(std::nullopt, 1, reference, 1);
+    auto T = makePathUnbound(
+        sub.clone(), {Variable{"?start"}, Variable{"?target"}}, left, right, 1,
+        std::numeric_limits<size_t>::max(), index);
+
+    EXPECT_TRUE(T->isBoundOrId());
+
+    auto resultTable = T->computeResultOnlyForTesting(requestLaziness());
+    assertResultMatchesIdTable(resultTable, expected);
+  }
+
+  {
+    TransitivePathSide left(std::nullopt, 0, reference, 0);
+    TransitivePathSide right(std::nullopt, 1, Variable{"?target"}, 1);
+    auto T = makePathUnbound(
+        sub.clone(), {Variable{"?start"}, Variable{"?target"}}, left, right, 1,
+        std::numeric_limits<size_t>::max(), index);
+
+    EXPECT_TRUE(T->isBoundOrId());
+
+    auto resultTable = T->computeResultOnlyForTesting(requestLaziness());
+    assertResultMatchesIdTable(resultTable, expected);
+  }
+
+  {
+    TransitivePathSide left(std::nullopt, 0, Variable{"?start"}, 0);
+    TransitivePathSide right(std::nullopt, 1, reference, 1);
     auto T = makePathUnbound(
         std::move(sub), {Variable{"?start"}, Variable{"?target"}}, left, right,
         1, std::numeric_limits<size_t>::max(), std::move(index));


### PR DESCRIPTION
For a query like `SELECT * { ?x a* ... }` the result should be empty if `...` does not occur as a subject or object in any triple, and the result should be `...` if it does. However, the current behavior is not correct for `...` that do not occur as a subject or object in any triple and when one of the following two holds: (1) `...` is a value that can be folded into the `Id` (then the result is `...` but should be empty) or (2) `...` is a literal or IRI that does not exist in the original dataset (then an exception is thrown, even if the literal or IRI was added in an update operation). These corner cases are now fixed.

On the side, queries like `SELECT * { 1 a* 2 }` are now rewritten to the equivalent `SELECT * { 1 a+ 2 }`, which is much more efficient to compute (if the subject and object are fixed but different, there is no match for the "empty path").

The result for queries like `SELECT * { VALUES ?x { 1 } ?x a* ?x }` (one of the cases of the W3C test suite) is still incorrect. This will be fixed in one the next PRs.