### PR TITLE
Fix `SERVICE` request with no variables

### DIFF
--- a/src/engine/Service.cpp
+++ b/src/engine/Service.cpp
@@ -136,7 +136,7 @@ Result Service::computeResultImpl(bool requestLaziness) {
           : absl::StrJoin(variables, " ", Variable::AbslFormatter);
   std::string serviceQuery =
       absl::StrCat(parsedServiceClause_.prologue_, "\nSELECT ",
-                   variablesForSelectClause, " WHERE ", getGraphPattern());
+                   variablesForSelectClause, " ", getGraphPattern());
   LOG(INFO) << "Sending SERVICE query to remote endpoint "
             << "(protocol: " << serviceUrl.protocolAsString()
             << ", host: " << serviceUrl.host()

--- a/src/engine/Service.cpp
+++ b/src/engine/Service.cpp
@@ -129,8 +129,11 @@ Result Service::computeResultImpl(bool requestLaziness) {
       asStringViewUnsafe(parsedServiceClause_.serviceIri_.getContent())};
 
   // Construct the query to be sent to the SPARQL endpoint.
-  std::string variablesForSelectClause = absl::StrJoin(
-      parsedServiceClause_.visibleVariables_, " ", Variable::AbslFormatter);
+  const auto& variables = parsedServiceClause_.visibleVariables_;
+  std::string variablesForSelectClause =
+      variables.empty()
+          ? "*"
+          : absl::StrJoin(variables, " ", Variable::AbslFormatter);
   std::string serviceQuery =
       absl::StrCat(parsedServiceClause_.prologue_, "\nSELECT ",
                    variablesForSelectClause, " WHERE ", getGraphPattern());

--- a/test/ServiceTest.cpp
+++ b/test/ServiceTest.cpp
@@ -529,6 +529,25 @@ TEST_F(ServiceTest, computeResultWrapSubqueriesWithSibling) {
   EXPECT_NO_THROW(serviceOperation.computeResultOnlyForTesting());
 }
 
+// _____________________________________________________________________________
+TEST_F(ServiceTest, computeResultNoVariables) {
+  parsedQuery::Service parsedServiceClause{
+      {},
+      TripleComponent::Iri::fromIriref("<http://localhost/api>"),
+      "",
+      "{ <a> <b> <c> }",
+      false};
+
+  std::string_view expectedSparqlQuery = " SELECT * WHERE { <a> <b> <c> }";
+
+  Service serviceOperation{
+      testQec, parsedServiceClause,
+      getResultFunctionFactory("http://localhost:80/api", expectedSparqlQuery,
+                               genJsonResult({}, {{}}))};
+
+  EXPECT_NO_THROW(serviceOperation.computeResultOnlyForTesting());
+}
+
 TEST_F(ServiceTest, getCacheKey) {
   // Base query to check cache-keys against.
   parsedQuery::Service parsedServiceClause{

--- a/test/ServiceTest.cpp
+++ b/test/ServiceTest.cpp
@@ -200,7 +200,7 @@ TEST_F(ServiceTest, computeResult) {
     // query we expect.
     std::string_view expectedUrl = "http://localhorst:80/api";
     std::string_view expectedSparqlQuery =
-        "PREFIX doof: <http://doof.org> SELECT ?x ?y WHERE { }";
+        "PREFIX doof: <http://doof.org> SELECT ?x ?y { }";
 
     // Shorthand to run computeResult with the test parameters given above.
     auto runComputeResult =
@@ -444,7 +444,7 @@ TEST_F(ServiceTest, computeResult) {
 
     std::string_view expectedSparqlQuery5 =
         "PREFIX doof: <http://doof.org> SELECT ?x ?y ?z2 "
-        "WHERE { VALUES (?x ?y) { (<x> <y>) (<blu> <bla>) } . ?x <ble> ?y "
+        "{ VALUES (?x ?y) { (<x> <y>) (<blu> <bla>) } . ?x <ble> ?y "
         ". ?y "
         "<is-a> ?z2 . }";
 
@@ -517,7 +517,7 @@ TEST_F(ServiceTest, computeResultWrapSubqueriesWithSibling) {
       false};
 
   std::string_view expectedSparqlQuery =
-      " SELECT ?a WHERE { VALUES (?a) { (<a>) } . { SELECT ?obj WHERE { ?a ?b "
+      " SELECT ?a { VALUES (?a) { (<a>) } . { SELECT ?obj WHERE { ?a ?b "
       "?c } } }";
 
   Service serviceOperation{
@@ -538,7 +538,7 @@ TEST_F(ServiceTest, computeResultNoVariables) {
       "{ <a> <b> <c> }",
       false};
 
-  std::string_view expectedSparqlQuery = " SELECT * WHERE { <a> <b> <c> }";
+  std::string_view expectedSparqlQuery = " SELECT * { <a> <b> <c> }";
 
   Service serviceOperation{
       testQec, parsedServiceClause,
@@ -699,7 +699,7 @@ TEST_F(ServiceTest, precomputeSiblingResult) {
           true},
       getResultFunctionFactory(
           "http://localhorst:80/api",
-          "PREFIX doof: <http://doof.org> SELECT ?x ?y WHERE { }",
+          "PREFIX doof: <http://doof.org> SELECT ?x ?y { }",
           genJsonResult({"x", "y"}, {{"a", "b"}}),
           boost::beast::http::status::ok, "application/sparql-results+json"));
 


### PR DESCRIPTION
For a `SERVICE` request without visible variables (in particular, for an "empty" request like `SERVICE <iri> { }`), so far QLever sent an invalid query of the form `SELECT WHERE { ... }` to the respective endpoint. This special case is now fixed by sending `SELECT * { ... }` instead. The `WHERE` is now omitted, also for the general case, which saves six bytes. The unit tests were improved to provide better line numbers if they fail. Fixes #1765