### PR TITLE
Make the `CompactStringVectorWriter` movable

### DIFF
--- a/src/engine/CountAvailablePredicates.cpp
+++ b/src/engine/CountAvailablePredicates.cpp
@@ -292,7 +292,7 @@ void CountAvailablePredicates::computePatternTrick(
       // TODO<joka921> As soon as we have a better way of handling the
       // parallelism, the following block can become a simple AD_CONTRACT_CHECK.
       if (patternIndex >= patterns.size()) {
-        if (patternIndex != NO_PATTERN) {
+        if (patternIndex != Pattern::NoPattern) {
           illegalPatternIndexFound = true;
         }
         continue;

--- a/src/global/Pattern.h
+++ b/src/global/Pattern.h
@@ -26,10 +26,6 @@
 #include "util/Serializer/SerializeVector.h"
 #include "util/TypeTraits.h"
 
-typedef uint32_t PatternID;
-
-static const PatternID NO_PATTERN = std::numeric_limits<PatternID>::max();
-
 /**
  * @brief This represents a set of relations of a single entity.
  *        (e.g. a set of books that all have an author and a title).
@@ -38,6 +34,9 @@ static const PatternID NO_PATTERN = std::numeric_limits<PatternID>::max();
  *        while writing a query).
  */
 struct Pattern {
+  using PatternId = int32_t;
+  static constexpr PatternId NoPattern = std::numeric_limits<PatternId>::max();
+
   using value_type = Id;
   using ref = value_type&;
   using const_ref = const value_type&;

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -132,7 +132,7 @@ constexpr auto makePermutationFirstThirdSwitched = []() {
   return permutation;
 };
 // In the pattern column replace UNDEF (which is created by the optional join)
-// by the special `NO_PATTERN` ID and undo the permutation of the columns that
+// by the special `NoPattern` ID and undo the permutation of the columns that
 // was only needed for the join algorithm.
 auto fixBlockAfterPatternJoin(auto block) {
   // The permutation must be the inverse of the original permutation, which just
@@ -143,7 +143,9 @@ auto fixBlockAfterPatternJoin(auto block) {
   block.value().setColumnSubset(permutation);
   ql::ranges::for_each(
       block.value().getColumn(ADDITIONAL_COLUMN_INDEX_OBJECT_PATTERN),
-      [](Id& id) { id = id.isUndefined() ? Id::makeFromInt(NO_PATTERN) : id; });
+      [](Id& id) {
+        id = id.isUndefined() ? Id::makeFromInt(Pattern::NoPattern) : id;
+      });
   return std::move(block.value()).template toStatic<0>();
 }
 }  // namespace

--- a/src/index/PatternCreator.cpp
+++ b/src/index/PatternCreator.cpp
@@ -6,6 +6,8 @@
 
 #include "global/SpecialIds.h"
 
+using PatternId = Pattern::PatternId;
+
 // _________________________________________________________________________
 void PatternCreator::processTriple(
     std::array<Id, NumColumnsIndexBuilding> triple,
@@ -30,9 +32,9 @@ void PatternCreator::processTriple(
 }
 
 // _____________________________________________________________________________
-PatternID PatternCreator::finishPattern(const Pattern& pattern) {
+PatternId PatternCreator::finishPattern(const Pattern& pattern) {
   if (pattern.empty()) {
-    return NO_PATTERN;
+    return Pattern::NoPattern;
   }
   numDistinctSubjectPredicatePairs_ += pattern.size();
   auto it = patternToIdAndCount_.find(pattern);
@@ -43,7 +45,7 @@ PatternID PatternCreator::finishPattern(const Pattern& pattern) {
     return it->second.patternId_;
   }
   // This is a new pattern, assign a new pattern ID and a count of 1.
-  auto patternId = static_cast<PatternID>(patternToIdAndCount_.size());
+  auto patternId = static_cast<PatternId>(patternToIdAndCount_.size());
   patternToIdAndCount_[pattern] = PatternIdAndCount{patternId, 1UL};
 
   // Count the total number of distinct predicates that appear in the
@@ -57,7 +59,7 @@ PatternID PatternCreator::finishPattern(const Pattern& pattern) {
 // ________________________________________________________________________________
 void PatternCreator::finishSubject(Id subject, const Pattern& pattern) {
   // Write the pattern to disk and obtain its ID.
-  PatternID patternId = finishPattern(pattern);
+  PatternId patternId = finishPattern(pattern);
 
   // Write the triple `<subject> ql:has-pattern <patternId>`, but only if the
   // subject has a pattern.

--- a/src/index/PatternCreator.h
+++ b/src/index/PatternCreator.h
@@ -89,7 +89,7 @@ class PatternCreator {
   // Store the ID of a pattern, and the number of distinct subjects it occurs
   // with.
   struct PatternIdAndCount {
-    PatternID patternId_ = 0;
+    Pattern::PatternId patternId_ = 0;
     uint64_t count_ = 0;
   };
   using PatternToIdAndCount = ad_utility::HashMap<Pattern, PatternIdAndCount>;
@@ -183,7 +183,7 @@ class PatternCreator {
 
  private:
   void finishSubject(Id subject, const Pattern& pattern);
-  PatternID finishPattern(const Pattern& pattern);
+  Pattern::PatternId finishPattern(const Pattern& pattern);
 
   void printStatistics(PatternStatistics patternStatistics) const;
 

--- a/src/util/File.h
+++ b/src/util/File.h
@@ -59,15 +59,13 @@ class File {
       close();
     }
 
-    file_ = rhs.file_;
-    rhs.file_ = nullptr;
+    file_ = std::exchange(rhs.file_, nullptr);
     name_ = std::move(rhs.name_);
     return *this;
   }
 
-  File(File&& rhs) : name_{std::move(rhs.name_)}, file_{rhs.file_} {
-    rhs.file_ = nullptr;
-  }
+  File(File&& rhs) noexcept
+      : name_{std::move(rhs.name_)}, file_{std::exchange(rhs.file_, nullptr)} {}
 
   //! Destructor closes file if still open
   ~File() {

--- a/test/CompactStringVectorTest.cpp
+++ b/test/CompactStringVectorTest.cpp
@@ -139,9 +139,9 @@ TEST(CompactVectorOfStrings, SerializationWithPush) {
   testSerializationWithPush(CompactVectorInt{}, ints);
 }
 
-// Test that a `CompactStringVectorWriter` can be moved, even when writing has
-// already started.
-TEST(CompactVectorOfStrings, MoveWriterWhileWriting1) {
+// Test that a `CompactStringVectorWriter` can be correctly move-constructed and
+// move-assigned into an empty writer, even when writing has already started.
+TEST(CompactVectorOfStrings, MoveIntoEmptyWriter) {
   auto testSerializationWithPush = [](const auto& v, auto& inputVector) {
     using V = std::decay_t<decltype(v)>;
 
@@ -183,9 +183,9 @@ TEST(CompactVectorOfStrings, MoveWriterWhileWriting1) {
   testSerializationWithPush(CompactVectorInt{}, ints);
 }
 
-// Test the special case of moving into a `CompactStringVectorWriter` that has
-// already been written to.
-TEST(CompactVectorOfStrings, MoveWriterWhileWriting2) {
+// Test the special case of move-assigning a `CompactStringVectorWriter` where
+// the target of the move has already been written to.
+TEST(CompactVectorOfStrings, MoveIntoFullWriter) {
   auto testSerializationWithPush = [](const auto& v, const auto& input1,
                                       const auto& input2) {
     using V = std::decay_t<decltype(v)>;

--- a/test/HasPredicateScanTest.cpp
+++ b/test/HasPredicateScanTest.cpp
@@ -211,10 +211,10 @@ TEST_F(HasPredicateScanTest, patternTrickIllegalInput) {
   auto I = ad_utility::testing::IntId;
   auto Voc = ad_utility::testing::VocabId;
   // The subtree of the `CountAvailablePredicates` is illegal, because the
-  // pattern index column contains the entry `273` which is neither `NO_PATTERN`
+  // pattern index column contains the entry `273` which is neither `NoPattern`
   // nor a valid pattern index.
-  auto illegalInput =
-      makeIdTableFromVector({{Voc(0), I(273)}, {Voc(1), I(NO_PATTERN)}});
+  auto illegalInput = makeIdTableFromVector(
+      {{Voc(0), I(273)}, {Voc(1), I(Pattern::NoPattern)}});
   auto subtree = ad_utility::makeExecutionTree<ValuesForTesting>(
       qec, std::move(illegalInput),
       std::vector<std::optional<Variable>>{V{"?x"}, V{"?predicate"}});

--- a/test/LocalVocabTest.cpp
+++ b/test/LocalVocabTest.cpp
@@ -391,8 +391,8 @@ TEST(LocalVocab, propagation) {
   Values valuesPatternTrick(
       testQec,
       {{Variable{"?x"}, Variable{"?y"}},
-       {{TripleComponent{iri("<xN1>")}, TripleComponent{NO_PATTERN}},
-        {TripleComponent{iri("<xN1>")}, TripleComponent{NO_PATTERN}}}});
+       {{TripleComponent{iri("<xN1>")}, TripleComponent{Pattern::NoPattern}},
+        {TripleComponent{iri("<xN1>")}, TripleComponent{Pattern::NoPattern}}}});
   CountAvailablePredicates countAvailablePredictes(
       testQec, qet(valuesPatternTrick), 0, Variable{"?y"}, Variable{"?count"});
   checkLocalVocab(countAvailablePredictes, {"<xN1>"});

--- a/test/engine/IndexScanTest.cpp
+++ b/test/engine/IndexScanTest.cpp
@@ -424,7 +424,7 @@ TEST(IndexScan, additionalColumn) {
   // <x> is the only subject, so it has pattern 0, <z> doesn't appear as a
   // subject, so it has no pattern.
   auto exp = makeIdTableFromVector(
-      {{getId("<x>"), getId("<z>"), I(0), I(NO_PATTERN)}});
+      {{getId("<x>"), getId("<z>"), I(0), I(Pattern::NoPattern)}});
   EXPECT_THAT(res.idTable(), ::testing::ElementsAreArray(exp));
 }
 

--- a/test/index/PatternCreatorTest.cpp
+++ b/test/index/PatternCreatorTest.cpp
@@ -95,8 +95,8 @@ auto createExamplePatterns(PatternCreator& creator) {
 
   // All the triples for subject `V(2)` are ignored, so it will not have a
   // pattern.
-  push({V(2), V(13), V(18)}, true, NO_PATTERN);
-  push({V(2), V(14), V(18)}, true, NO_PATTERN);
+  push({V(2), V(13), V(18)}, true, Pattern::NoPattern);
+  push({V(2), V(14), V(18)}, true, Pattern::NoPattern);
 
   // New subject, but has the same predicate and therefore patterns as `V(0)`.
   // We have an ignored triple at the beginning, which doesn't count towards

--- a/test/util/IndexTestHelpers.cpp
+++ b/test/util/IndexTestHelpers.cpp
@@ -81,7 +81,8 @@ void checkConsistencyBetweenPatternPredicateAndAdditionalColumn(
     // appear as a subject in the knowledge graph.
     AD_CORRECTNESS_CHECK(scanResultHasPattern.numRows() <= 1);
     if (scanResultHasPattern.numRows() == 0) {
-      EXPECT_EQ(patternIdx, NO_PATTERN) << id << ' ' << NO_PATTERN;
+      EXPECT_EQ(patternIdx, Pattern::NoPattern)
+          << id << ' ' << Pattern::NoPattern;
     } else {
       auto actualPattern = scanResultHasPattern(0, 0).getInt();
       EXPECT_EQ(patternIdx, actualPattern) << id << ' ' << actualPattern;


### PR DESCRIPTION
Implement a move-constructor and move-assignment for `CompactStringVectorWriter`. Verify the desired behavior with an extensive unit test. We need this semantics as a preparation of #1740.