### PR TITLE
Unify interface of the different vocabulary `WordWriter`s

### DIFF
--- a/src/VocabularyMergerMain.cpp
+++ b/src/VocabularyMergerMain.cpp
@@ -20,8 +20,9 @@ int main(int argc, char** argv) {
 
   auto file = ad_utility::makeOfstream(basename + VOCAB_SUFFIX);
   uint64_t count = 0;
-  auto wordCallback = [&file, &count](const auto& word,
-                                      [[maybe_unused]] bool isExternal) {
+  auto wordCallback = [&file, &count](
+                          const auto& word,
+                          [[maybe_unused]] bool isExternalDummy = true) {
     file << RdfEscaping::escapeNewlinesAndBackslashes(word) << '\n';
     count++;
     return count - 1;

--- a/src/VocabularyMergerMain.cpp
+++ b/src/VocabularyMergerMain.cpp
@@ -24,8 +24,7 @@ int main(int argc, char** argv) {
                           const auto& word,
                           [[maybe_unused]] bool isExternalDummy = true) {
     file << RdfEscaping::escapeNewlinesAndBackslashes(word) << '\n';
-    count++;
-    return count - 1;
+    return count++;
   };
 
   VocabularyOnDisk vocab;

--- a/src/VocabularyMergerMain.cpp
+++ b/src/VocabularyMergerMain.cpp
@@ -19,10 +19,14 @@ int main(int argc, char** argv) {
   size_t numFiles = atoi(argv[2]);
 
   auto file = ad_utility::makeOfstream(basename + VOCAB_SUFFIX);
-  auto wordCallback = [&file](const auto& word,
-                              [[maybe_unused]] bool isExternal) {
+  uint64_t count = 0;
+  auto wordCallback = [&file, &count](const auto& word,
+                                      [[maybe_unused]] bool isExternal) {
     file << RdfEscaping::escapeNewlinesAndBackslashes(word) << '\n';
+    count++;
+    return count - 1;
   };
+
   VocabularyOnDisk vocab;
   ad_utility::vocabulary_merger::mergeVocabulary(
       basename, numFiles, TripleComponentComparator(), wordCallback, 4_GB);

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -552,9 +552,11 @@ IndexBuilderDataAsExternalVector IndexImpl::passFileForVocabulary(
     };
     auto wordCallback = vocab_.makeWordWriter(onDiskBase_ + VOCAB_SUFFIX);
     wordCallback.readableName() = "internal vocabulary";
-    return ad_utility::vocabulary_merger::mergeVocabulary(
+    auto mergedVocabMeta = ad_utility::vocabulary_merger::mergeVocabulary(
         onDiskBase_, numFiles, sortPred, wordCallback,
         memoryLimitIndexBuilding());
+    wordCallback.finish();
+    return mergedVocabMeta;
   }();
   AD_LOG_DEBUG << "Finished merging partial vocabularies" << std::endl;
   IndexBuilderDataAsExternalVector res;

--- a/src/index/VocabularyMerger.h
+++ b/src/index/VocabularyMerger.h
@@ -18,6 +18,7 @@
 #include "util/HashMap.h"
 #include "util/MmapVector.h"
 #include "util/ProgressBar.h"
+#include "util/TypeTraits.h"
 
 using IdPairMMapVec = ad_utility::MmapVector<std::pair<Id, Id>>;
 using IdPairMMapVecView = ad_utility::MmapVectorView<std::pair<Id, Id>>;
@@ -30,8 +31,10 @@ namespace ad_utility::vocabulary_merger {
 // If the `bool` is true, then the word is to be stored in the external
 // vocabulary else in the internal vocabulary.
 template <typename T>
-CPP_concept WordCallback = ranges::invocable<T, std::string_view, bool>;
-// Concept for a callable that compares to `string_view`s.
+CPP_concept WordCallback =
+    ad_utility::InvocableWithExactReturnType<T, uint64_t, std::string_view,
+                                             bool>;
+// Concept for a callable that compares two `string_view`s.
 template <typename T>
 CPP_concept WordComparator =
     ranges::predicate<T, std::string_view, std::string_view>;
@@ -213,10 +216,9 @@ class VocabularyMerger {
   // The `QueueWord`s must be passed in alphabetical order wrt `lessThan` (also
   // across multiple calls).
   // clang-format off
-  CPP_template(typename C, typename L)(
+    CPP_template(typename C, typename L)(
       requires WordCallback<C> CPP_and ranges::predicate<
-          L, TripleComponentWithIndex,
-          TripleComponentWithIndex>)
+          L, TripleComponentWithIndex, TripleComponentWithIndex>)
       // clang-format on
       void writeQueueWordsToIdVec(const std::vector<QueueWord>& buffer,
                                   C& wordCallback, const L& lessThan,

--- a/src/index/VocabularyMergerImpl.h
+++ b/src/index/VocabularyMergerImpl.h
@@ -19,6 +19,7 @@
 #include "index/Vocabulary.h"
 #include "index/VocabularyMerger.h"
 #include "parser/RdfEscaping.h"
+#include "parser/TripleComponent.h"
 #include "util/Conversions.h"
 #include "util/Exception.h"
 #include "util/HashMap.h"
@@ -177,11 +178,12 @@ CPP_template_def(typename C, typename L)(
       // idVecs to have a more useful external access pattern.
 
       // Write the new word to the vocabulary.
-      const auto& nextWord = lastTripleComponent_.value();
+      auto& nextWord = lastTripleComponent_.value();
       if (nextWord.isBlankNode()) {
-        lastTripleComponent_->index_ = metaData_.getNextBlankNodeIndex();
+        nextWord.index_ = metaData_.getNextBlankNodeIndex();
       } else {
-        wordCallback(nextWord.iriOrLiteral(), nextWord.isExternal());
+        nextWord.index_ =
+            wordCallback(nextWord.iriOrLiteral(), nextWord.isExternal());
         metaData_.addWord(top.iriOrLiteral(), nextWord.index_);
       }
       if (progressBar.update()) {

--- a/src/index/VocabularyOnDisk.cpp
+++ b/src/index/VocabularyOnDisk.cpp
@@ -61,9 +61,10 @@ VocabularyOnDisk::WordWriter::WordWriter(const std::string& outFilename)
                ad_utility::CreateTag{}} {}
 
 // _____________________________________________________________________________
-void VocabularyOnDisk::WordWriter::operator()(std::string_view word) {
+uint64_t VocabularyOnDisk::WordWriter::operator()(std::string_view word) {
   offsets_.push_back(currentOffset_);
   currentOffset_ += file_.write(word.data(), word.size());
+  return offsets_.size() - 1;
 }
 
 // _____________________________________________________________________________

--- a/src/index/VocabularyOnDisk.cpp
+++ b/src/index/VocabularyOnDisk.cpp
@@ -61,7 +61,8 @@ VocabularyOnDisk::WordWriter::WordWriter(const std::string& outFilename)
                ad_utility::CreateTag{}} {}
 
 // _____________________________________________________________________________
-uint64_t VocabularyOnDisk::WordWriter::operator()(std::string_view word) {
+uint64_t VocabularyOnDisk::WordWriter::operator()(
+    std::string_view word, [[maybe_unused]] bool isExternalDummy) {
   offsets_.push_back(currentOffset_);
   currentOffset_ += file_.write(word.data(), word.size());
   return offsets_.size() - 1;

--- a/src/index/VocabularyOnDisk.h
+++ b/src/index/VocabularyOnDisk.h
@@ -49,6 +49,7 @@ class VocabularyOnDisk : public VocabularyBinarySearchMixin<VocabularyOnDisk> {
     uint64_t currentOffset_ = 0;
     bool isFinished_ = false;
     ad_utility::ThrowInDestructorIfSafe throwInDestructorIfSafe_;
+    std::string readableName_ = "";
 
    public:
     // Constructor, used by `VocabularyOnDisk::wordWriter`.
@@ -59,6 +60,8 @@ class VocabularyOnDisk : public VocabularyBinarySearchMixin<VocabularyOnDisk> {
     void finish();
     // Destructor. Implicitly calls `finish` if it hasn't been called before.
     ~WordWriter();
+
+    std::string& readableName() { return readableName_; }
   };
 
   /// Build from a vector of pairs of `(string, id)`. This requires the IDs to

--- a/src/index/VocabularyOnDisk.h
+++ b/src/index/VocabularyOnDisk.h
@@ -53,8 +53,8 @@ class VocabularyOnDisk : public VocabularyBinarySearchMixin<VocabularyOnDisk> {
    public:
     // Constructor, used by `VocabularyOnDisk::wordWriter`.
     explicit WordWriter(const std::string& filename);
-    // Add the next word to the vocabulary.
-    void operator()(std::string_view word);
+    // Add the next word to the vocabulary and return its index.
+    uint64_t operator()(std::string_view word);
     // Finish the writing. After this no more calls to `operator()` are allowed.
     void finish();
     // Destructor. Implicitly calls `finish` if it hasn't been called before.

--- a/src/index/VocabularyOnDisk.h
+++ b/src/index/VocabularyOnDisk.h
@@ -54,7 +54,7 @@ class VocabularyOnDisk : public VocabularyBinarySearchMixin<VocabularyOnDisk> {
     // Constructor, used by `VocabularyOnDisk::wordWriter`.
     explicit WordWriter(const std::string& filename);
     // Add the next word to the vocabulary and return its index.
-    uint64_t operator()(std::string_view word);
+    uint64_t operator()(std::string_view word, bool isExternalDummy = true);
     // Finish the writing. After this no more calls to `operator()` are allowed.
     void finish();
     // Destructor. Implicitly calls `finish` if it hasn't been called before.

--- a/src/index/vocabulary/CompressedVocabulary.h
+++ b/src/index/vocabulary/CompressedVocabulary.h
@@ -160,8 +160,7 @@ CPP_template(typename UnderlyingVocabulary,
       if (wordBuffer_.size() == NumWordsPerBlock) {
         finishBlock();
       }
-      counter_++;
-      return counter_ - 1;
+      return counter_++;
     }
 
     /// Dump all the words that still might be contained in intermediate buffers

--- a/src/index/vocabulary/CompressedVocabulary.h
+++ b/src/index/vocabulary/CompressedVocabulary.h
@@ -142,6 +142,7 @@ CPP_template(typename UnderlyingVocabulary,
     }};
     std::atomic<size_t> queueIndex_ = 0;
     ad_utility::TaskQueue<false> compressQueue_{10, 10};
+    uint64_t counter_ = 0;
 
    public:
     /// Constructor.
@@ -151,14 +152,16 @@ CPP_template(typename UnderlyingVocabulary,
           filenameDecoders_{filenameDecoders} {}
 
     /// Compress the `uncompressedWord` and write it to disk.
-    void operator()(std::string_view uncompressedWord,
-                    bool isExternal = false) {
+    uint64_t operator()(std::string_view uncompressedWord,
+                        bool isExternal = false) {
       AD_CORRECTNESS_CHECK(!isFinished_);
       wordBuffer_.emplace_back(uncompressedWord);
       isExternalBuffer_.push_back(isExternal);
       if (wordBuffer_.size() == NumWordsPerBlock) {
         finishBlock();
       }
+      counter_++;
+      return counter_ - 1;
     }
 
     /// Dump all the words that still might be contained in intermediate buffers

--- a/src/index/vocabulary/VocabularyInMemory.h
+++ b/src/index/vocabulary/VocabularyInMemory.h
@@ -68,9 +68,12 @@ class VocabularyInMemory
   /// documentation of `CompactVectorOfStrings` for details.
   struct WordWriter {
     typename Words::Writer writer_;
+    uint64_t index_ = 0;
+
     explicit WordWriter(const std::string& filename) : writer_{filename} {}
-    void operator()(std::string_view str) {
+    uint64_t operator()(std::string_view str) {
       writer_.push(str.data(), str.size());
+      return index_++;
     }
 
     void finish() { writer_.finish(); }

--- a/src/index/vocabulary/VocabularyInMemory.h
+++ b/src/index/vocabulary/VocabularyInMemory.h
@@ -69,6 +69,7 @@ class VocabularyInMemory
   struct WordWriter {
     typename Words::Writer writer_;
     uint64_t index_ = 0;
+    std::string readableName_ = "";
 
     explicit WordWriter(const std::string& filename) : writer_{filename} {}
     uint64_t operator()(std::string_view str,
@@ -78,6 +79,7 @@ class VocabularyInMemory
     }
 
     void finish() { writer_.finish(); }
+    std::string& readableName() { return readableName_; }
   };
 
   // Return a `WordWriter` that directly writes the words to the given

--- a/src/index/vocabulary/VocabularyInMemory.h
+++ b/src/index/vocabulary/VocabularyInMemory.h
@@ -71,7 +71,8 @@ class VocabularyInMemory
     uint64_t index_ = 0;
 
     explicit WordWriter(const std::string& filename) : writer_{filename} {}
-    uint64_t operator()(std::string_view str) {
+    uint64_t operator()(std::string_view str,
+                        [[maybe_unused]] bool isExternalDummy = false) {
       writer_.push(str.data(), str.size());
       return index_++;
     }

--- a/src/index/vocabulary/VocabularyInMemoryBinSearch.cpp
+++ b/src/index/vocabulary/VocabularyInMemoryBinSearch.cpp
@@ -56,13 +56,14 @@ VocabularyInMemoryBinSearch::WordWriter::WordWriter(const std::string& filename)
     : writer_{filename}, offsetWriter_{filename + ".ids"} {}
 
 // _____________________________________________________________________________
-void VocabularyInMemoryBinSearch::WordWriter::operator()(std::string_view str,
-                                                         uint64_t idx) {
+uint64_t VocabularyInMemoryBinSearch::WordWriter::operator()(
+    std::string_view str, uint64_t idx) {
   // Check that the indices are ascending.
   AD_CONTRACT_CHECK(!lastIndex_.has_value() || lastIndex_.value() < idx);
   lastIndex_ = idx;
   writer_.push(str.data(), str.size());
   offsetWriter_.push(idx);
+  return idx;
 }
 
 // _____________________________________________________________________________

--- a/src/index/vocabulary/VocabularyInMemoryBinSearch.cpp
+++ b/src/index/vocabulary/VocabularyInMemoryBinSearch.cpp
@@ -57,7 +57,7 @@ VocabularyInMemoryBinSearch::WordWriter::WordWriter(const std::string& filename)
 
 // _____________________________________________________________________________
 uint64_t VocabularyInMemoryBinSearch::WordWriter::operator()(
-    std::string_view str, [[maybe_unused]] bool isExternalDummy, uint64_t idx) {
+    std::string_view str, uint64_t idx) {
   // Check that the indices are ascending.
   AD_CONTRACT_CHECK(!lastIndex_.has_value() || lastIndex_.value() < idx);
   lastIndex_ = idx;

--- a/src/index/vocabulary/VocabularyInMemoryBinSearch.cpp
+++ b/src/index/vocabulary/VocabularyInMemoryBinSearch.cpp
@@ -57,7 +57,7 @@ VocabularyInMemoryBinSearch::WordWriter::WordWriter(const std::string& filename)
 
 // _____________________________________________________________________________
 uint64_t VocabularyInMemoryBinSearch::WordWriter::operator()(
-    std::string_view str, uint64_t idx) {
+    std::string_view str, [[maybe_unused]] bool isExternalDummy, uint64_t idx) {
   // Check that the indices are ascending.
   AD_CONTRACT_CHECK(!lastIndex_.has_value() || lastIndex_.value() < idx);
   lastIndex_ = idx;

--- a/src/index/vocabulary/VocabularyInMemoryBinSearch.h
+++ b/src/index/vocabulary/VocabularyInMemoryBinSearch.h
@@ -75,7 +75,7 @@ class VocabularyInMemoryBinSearch
     explicit WordWriter(const std::string& filename);
     // Add the given `word` with the given `idx`. The `idx` must be greater than
     // all previous indices.
-    void operator()(std::string_view word, uint64_t idx);
+    uint64_t operator()(std::string_view word, uint64_t idx);
 
     // Finish writing and dump all contents that still reside in buffers to
     // disk.

--- a/src/index/vocabulary/VocabularyInMemoryBinSearch.h
+++ b/src/index/vocabulary/VocabularyInMemoryBinSearch.h
@@ -71,19 +71,15 @@ class VocabularyInMemoryBinSearch
         uint64_t, ad_utility::serialization::FileWriteSerializer>;
     OffsetWriter offsetWriter_;
     std::optional<uint64_t> lastIndex_ = std::nullopt;
-    std::string readableName_ = "";
     // Construct a `WordWriter` that will write to the given `filename`.
     explicit WordWriter(const std::string& filename);
     // Add the given `word` with the given `idx`. The `idx` must be greater than
     // all previous indices.
-    uint64_t operator()(std::string_view word, bool isExternalDummy = false,
-                        uint64_t idx = 0);
+    uint64_t operator()(std::string_view word, uint64_t idx);
 
     // Finish writing and dump all contents that still reside in buffers to
     // disk.
     void finish();
-
-    std::string& readableName() { return readableName_; }
   };
 
   // Clear the vocabulary.

--- a/src/index/vocabulary/VocabularyInMemoryBinSearch.h
+++ b/src/index/vocabulary/VocabularyInMemoryBinSearch.h
@@ -71,6 +71,7 @@ class VocabularyInMemoryBinSearch
         uint64_t, ad_utility::serialization::FileWriteSerializer>;
     OffsetWriter offsetWriter_;
     std::optional<uint64_t> lastIndex_ = std::nullopt;
+    std::string readableName_ = "";
     // Construct a `WordWriter` that will write to the given `filename`.
     explicit WordWriter(const std::string& filename);
     // Add the given `word` with the given `idx`. The `idx` must be greater than
@@ -81,6 +82,8 @@ class VocabularyInMemoryBinSearch
     // Finish writing and dump all contents that still reside in buffers to
     // disk.
     void finish();
+
+    std::string& readableName() { return readableName_; }
   };
 
   // Clear the vocabulary.

--- a/src/index/vocabulary/VocabularyInMemoryBinSearch.h
+++ b/src/index/vocabulary/VocabularyInMemoryBinSearch.h
@@ -75,7 +75,8 @@ class VocabularyInMemoryBinSearch
     explicit WordWriter(const std::string& filename);
     // Add the given `word` with the given `idx`. The `idx` must be greater than
     // all previous indices.
-    uint64_t operator()(std::string_view word, uint64_t idx);
+    uint64_t operator()(std::string_view word, bool isExternalDummy = false,
+                        uint64_t idx = 0);
 
     // Finish writing and dump all contents that still reside in buffers to
     // disk.

--- a/src/index/vocabulary/VocabularyInternalExternal.cpp
+++ b/src/index/vocabulary/VocabularyInternalExternal.cpp
@@ -25,12 +25,11 @@ uint64_t VocabularyInternalExternal::WordWriter::operator()(
     std::string_view str, bool isExternal) {
   externalWriter_(str);
   if (!isExternal || sinceMilestone_ >= milestoneDistance_ || idx_ == 0) {
-    internalWriter_(str, false, idx_);
+    internalWriter_(str, idx_);
     sinceMilestone_ = 0;
   }
-  ++idx_;
   ++sinceMilestone_;
-  return idx_ - 1;
+  return idx_++;
 }
 
 // _____________________________________________________________________________

--- a/src/index/vocabulary/VocabularyInternalExternal.cpp
+++ b/src/index/vocabulary/VocabularyInternalExternal.cpp
@@ -25,7 +25,7 @@ uint64_t VocabularyInternalExternal::WordWriter::operator()(
     std::string_view str, bool isExternal) {
   externalWriter_(str);
   if (!isExternal || sinceMilestone_ >= milestoneDistance_ || idx_ == 0) {
-    internalWriter_(str, idx_);
+    internalWriter_(str, false, idx_);
     sinceMilestone_ = 0;
   }
   ++idx_;

--- a/src/index/vocabulary/VocabularyInternalExternal.cpp
+++ b/src/index/vocabulary/VocabularyInternalExternal.cpp
@@ -21,8 +21,8 @@ VocabularyInternalExternal::WordWriter::WordWriter(const std::string& filename,
       milestoneDistance_{milestoneDistance} {}
 
 // _____________________________________________________________________________
-void VocabularyInternalExternal::WordWriter::operator()(std::string_view str,
-                                                        bool isExternal) {
+uint64_t VocabularyInternalExternal::WordWriter::operator()(
+    std::string_view str, bool isExternal) {
   externalWriter_(str);
   if (!isExternal || sinceMilestone_ >= milestoneDistance_ || idx_ == 0) {
     internalWriter_(str, idx_);
@@ -30,6 +30,7 @@ void VocabularyInternalExternal::WordWriter::operator()(std::string_view str,
   }
   ++idx_;
   ++sinceMilestone_;
+  return idx_ - 1;
 }
 
 // _____________________________________________________________________________

--- a/src/index/vocabulary/VocabularyInternalExternal.h
+++ b/src/index/vocabulary/VocabularyInternalExternal.h
@@ -104,6 +104,7 @@ class VocabularyInternalExternal {
     uint64_t idx_ = 0;
     size_t milestoneDistance_;
     size_t sinceMilestone_ = 0;
+    std::string readableName_ = "";
 
     // Construct from the `filename` to which the vocabulary will be serialized.
     // At least every `milestoneDistance`-th word will be cached in RAM.
@@ -116,6 +117,8 @@ class VocabularyInternalExternal {
 
     // Finish writing.
     void finish();
+
+    std::string& readableName() { return readableName_; }
   };
 
   /// Clear the vocabulary.

--- a/src/index/vocabulary/VocabularyInternalExternal.h
+++ b/src/index/vocabulary/VocabularyInternalExternal.h
@@ -112,7 +112,7 @@ class VocabularyInternalExternal {
 
     // Add the next word. If `isExternal` is true, then the word will only be
     // stored on disk, and not be cached in RAM.
-    void operator()(std::string_view word, bool isExternal = true);
+    uint64_t operator()(std::string_view word, bool isExternal = true);
 
     // Finish writing.
     void finish();

--- a/test/VocabularyGeneratorTest.cpp
+++ b/test/VocabularyGeneratorTest.cpp
@@ -159,6 +159,7 @@ TEST_F(MergeVocabularyTest, mergeVocabulary) {
     auto internalVocabularyAction =
         [&mergeResult](const auto& word, [[maybe_unused]] bool isExternal) {
           mergeResult.emplace_back(word, isExternal);
+          return mergeResult.size() - 1;
         };
     res = mergeVocabulary(_basePath, 2, TripleComponentComparator(),
                           internalVocabularyAction, 1_GB);

--- a/test/VocabularyGeneratorTest.cpp
+++ b/test/VocabularyGeneratorTest.cpp
@@ -157,10 +157,11 @@ TEST_F(MergeVocabularyTest, mergeVocabulary) {
   std::vector<std::pair<std::string, bool>> mergeResult;
   {
     auto internalVocabularyAction =
-        [&mergeResult](const auto& word, [[maybe_unused]] bool isExternal) {
-          mergeResult.emplace_back(word, isExternal);
-          return mergeResult.size() - 1;
-        };
+        [&mergeResult](const auto& word,
+                       [[maybe_unused]] bool isExternal) -> uint64_t {
+      mergeResult.emplace_back(word, isExternal);
+      return mergeResult.size() - 1;
+    };
     res = mergeVocabulary(_basePath, 2, TripleComponentComparator(),
                           internalVocabularyAction, 1_GB);
   }

--- a/test/index/vocabulary/CompressedVocabularyTest.cpp
+++ b/test/index/vocabulary/CompressedVocabularyTest.cpp
@@ -59,10 +59,12 @@ TEST(CompressedVocabulary, CompressionIsActuallyApplied) {
 
   CompressedVocabulary<VocabularyInMemory, DummyCompressionWrapper> v;
   auto writer = v.makeDiskWriter("vocabtmp.txt");
-  for (const auto& word : words) {
-    writer(word);
+  for (const auto& [i, word] : ::ranges::views::enumerate(words)) {
+    ASSERT_EQ(writer(word), static_cast<uint64_t>(i));
   }
   writer.finish();
+  writer.readableName() = "blabb";
+  EXPECT_EQ(writer.readableName(), "blabb");
 
   VocabularyInMemory simple;
   simple.open("vocabtmp.txt.words");

--- a/test/index/vocabulary/VocabularyInMemoryBinSearchTest.cpp
+++ b/test/index/vocabulary/VocabularyInMemoryBinSearchTest.cpp
@@ -44,7 +44,7 @@ class VocabularyCreator {
       size_t idx = 0;
       for (auto& word : words) {
         size_t actualIdx = ids.has_value() ? ids.value().at(idx) : idx;
-        writer(word, actualIdx);
+        writer(word, false, actualIdx);
         ++idx;
       }
       static std::atomic<unsigned> doFinish = 0;
@@ -63,7 +63,9 @@ class VocabularyCreator {
   auto createVocabularyFromDiskImpl(
       const std::vector<std::string>& words,
       std::optional<std::vector<uint64_t>> ids = std::nullopt) {
-    { createVocabularyImpl(words, std::move(ids)); }
+    {
+      createVocabularyImpl(words, std::move(ids));
+    }
     VocabularyInMemoryBinSearch vocabulary;
     vocabulary.open(vocabFilename_);
     return vocabulary;

--- a/test/index/vocabulary/VocabularyInMemoryBinSearchTest.cpp
+++ b/test/index/vocabulary/VocabularyInMemoryBinSearchTest.cpp
@@ -44,7 +44,7 @@ class VocabularyCreator {
       size_t idx = 0;
       for (auto& word : words) {
         size_t actualIdx = ids.has_value() ? ids.value().at(idx) : idx;
-        writer(word, false, actualIdx);
+        writer(word, actualIdx);
         ++idx;
       }
       static std::atomic<unsigned> doFinish = 0;

--- a/test/index/vocabulary/VocabularyInMemoryBinSearchTest.cpp
+++ b/test/index/vocabulary/VocabularyInMemoryBinSearchTest.cpp
@@ -41,10 +41,10 @@ class VocabularyCreator {
       if (ids.has_value()) {
         AD_CORRECTNESS_CHECK(ids.value().size() == words.size());
       }
-      size_t idx = 0;
+      uint64_t idx = 0;
       for (auto& word : words) {
         size_t actualIdx = ids.has_value() ? ids.value().at(idx) : idx;
-        writer(word, actualIdx);
+        EXPECT_EQ(writer(word, actualIdx), actualIdx);
         ++idx;
       }
       static std::atomic<unsigned> doFinish = 0;
@@ -63,9 +63,7 @@ class VocabularyCreator {
   auto createVocabularyFromDiskImpl(
       const std::vector<std::string>& words,
       std::optional<std::vector<uint64_t>> ids = std::nullopt) {
-    {
-      createVocabularyImpl(words, std::move(ids));
-    }
+    { createVocabularyImpl(words, std::move(ids)); }
     VocabularyInMemoryBinSearch vocabulary;
     vocabulary.open(vocabFilename_);
     return vocabulary;

--- a/test/index/vocabulary/VocabularyInternalExternalTest.cpp
+++ b/test/index/vocabulary/VocabularyInternalExternalTest.cpp
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 
 #include "./VocabularyTestHelpers.h"
+#include "backports/algorithm.h"
 #include "index/vocabulary/VocabularyInternalExternal.h"
 #include "util/Exception.h"
 #include "util/Forward.h"
@@ -35,11 +36,11 @@ class VocabularyCreator {
     VocabularyInternalExternal vocabulary;
     {
       auto writer = VocabularyInternalExternal::WordWriter(vocabFilename_);
-      size_t i = 0;
-      for (auto& word : words) {
-        writer(word, i % 2 == 0);
-        ++i;
+      for (const auto& [i, word] : ::ranges::views::enumerate(words)) {
+        EXPECT_EQ(writer(word, i % 2 == 0), static_cast<uint64_t>(i));
       }
+      writer.readableName() = "blabbiblu";
+      EXPECT_EQ(writer.readableName(), "blabbiblu");
       static std::atomic<unsigned> doFinish = 0;
       // In some tests, call `finish` explicitly, in others let the destructor
       // handle this.

--- a/test/index/vocabulary/VocabularyOnDiskTest.cpp
+++ b/test/index/vocabulary/VocabularyOnDiskTest.cpp
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 
 #include "./VocabularyTestHelpers.h"
+#include "backports/algorithm.h"
 #include "index/VocabularyOnDisk.h"
 #include "util/Forward.h"
 
@@ -38,9 +39,11 @@ class VocabularyCreator {
     if (!ids.has_value()) {
       {
         auto writer = VocabularyOnDisk::WordWriter(vocabFilename_);
-        for (auto& word : words) {
-          writer(word);
+        for (const auto& [i, word] : ::ranges::views::enumerate(words)) {
+          EXPECT_EQ(writer(word), static_cast<uint64_t>(i));
         }
+        writer.readableName() = "blubb";
+        EXPECT_EQ(writer.readableName(), "blubb");
         static std::atomic<unsigned> doFinish = 0;
         // In some tests, call `finish` expclitly, in others let the destructor
         // handle this.


### PR DESCRIPTION
The `WordWriter` types of all vocabulary implementations now return the index of an inserted word, support an argument `bool isExternal` (which mostly is a dummy)  and have a method `readableName()` to get/set a name. This unifies their interface such that we can easily exchange the different implementations.

The vocabulary merging now directly uses the index of a word according to the vocabulary. So far, it computed that index itself, which was redundant and error-prone.