### PR TITLE
Allow `SERVICE` result to be cached if explicitly so desired

### DIFF
--- a/src/ServerMain.cpp
+++ b/src/ServerMain.cpp
@@ -129,6 +129,10 @@ int main(int argc, char** argv) {
       optionFactory.getProgramOption<"request-body-limit">(),
       "Set the maximum size for the body of requests the server will process. "
       "Set to zero to disable the limit.");
+  add("cache-service", optionFactory.getProgramOption<"cache-service">(),
+      "SERVICE is not cached because we have to assume that any remote "
+      "endpoint might change at any point in time. If you control the "
+      "endpoints, you can override this setting.");
   add("persist-updates", po::bool_switch(&persistUpdates),
       "If set, then SPARQL UPDATES will be persisted on disk. Otherwise they "
       "will be lost when the engine is stopped");

--- a/src/ServerMain.cpp
+++ b/src/ServerMain.cpp
@@ -129,7 +129,8 @@ int main(int argc, char** argv) {
       optionFactory.getProgramOption<"request-body-limit">(),
       "Set the maximum size for the body of requests the server will process. "
       "Set to zero to disable the limit.");
-  add("cache-service", optionFactory.getProgramOption<"cache-service">(),
+  add("cache-service-results",
+      optionFactory.getProgramOption<"cache-service-results">(),
       "SERVICE is not cached because we have to assume that any remote "
       "endpoint might change at any point in time. If you control the "
       "endpoints, you can override this setting.");

--- a/src/ServerMain.cpp
+++ b/src/ServerMain.cpp
@@ -133,7 +133,8 @@ int main(int argc, char** argv) {
       optionFactory.getProgramOption<"cache-service-results">(),
       "SERVICE is not cached because we have to assume that any remote "
       "endpoint might change at any point in time. If you control the "
-      "endpoints, you can override this setting.");
+      "endpoints, you can override this setting. This will disable the sibling "
+      "optimization where VALUES are dynamically pushed into `SERVICE`.");
   add("persist-updates", po::bool_switch(&persistUpdates),
       "If set, then SPARQL UPDATES will be persisted on disk. Otherwise they "
       "will be lost when the engine is stopped");

--- a/src/engine/Service.cpp
+++ b/src/engine/Service.cpp
@@ -30,6 +30,13 @@ Service::Service(QueryExecutionContext* qec,
 
 // ____________________________________________________________________________
 std::string Service::getCacheKeyImpl() const {
+  if (RuntimeParameters().get<"cache-service">()) {
+    return absl::StrCat(
+        "SERVICE ", parsedServiceClause_.silent_ ? "SILENT " : "",
+        parsedServiceClause_.serviceIri_.toStringRepresentation(), " {\n",
+        parsedServiceClause_.prologue_, "\n",
+        parsedServiceClause_.graphPatternAsString_, "\n}");
+  }
   return absl::StrCat("SERVICE ", cacheBreaker_);
 }
 
@@ -521,11 +528,13 @@ void Service::precomputeSiblingResult(std::shared_ptr<Operation> left,
   auto b = std::dynamic_pointer_cast<Service>(right);
 
   // The sibling is only precomputed iff
+  // - SERVICE caching is disabled
   // - `rightOnly` is true and the right operation is a Service
   // - or exactly one of the operations is a Service. If we could estimate
   // the result size of a Service, the Service with the smaller result could
   // be used as a sibling here.
-  if ((rightOnly && !static_cast<bool>(b)) ||
+  if (RuntimeParameters().get<"cache-service">() ||
+      (rightOnly && !static_cast<bool>(b)) ||
       (!rightOnly && static_cast<bool>(a) == static_cast<bool>(b))) {
     return;
   }

--- a/src/engine/Service.cpp
+++ b/src/engine/Service.cpp
@@ -30,7 +30,7 @@ Service::Service(QueryExecutionContext* qec,
 
 // ____________________________________________________________________________
 std::string Service::getCacheKeyImpl() const {
-  if (RuntimeParameters().get<"cache-service">()) {
+  if (RuntimeParameters().get<"cache-service-results">()) {
     return absl::StrCat(
         "SERVICE ", parsedServiceClause_.silent_ ? "SILENT " : "",
         parsedServiceClause_.serviceIri_.toStringRepresentation(), " {\n",
@@ -536,7 +536,7 @@ void Service::precomputeSiblingResult(std::shared_ptr<Operation> left,
   // - or exactly one of the operations is a Service. If we could estimate
   // the result size of a Service, the Service with the smaller result could
   // be used as a sibling here.
-  if (RuntimeParameters().get<"cache-service">() ||
+  if (RuntimeParameters().get<"cache-service-results">() ||
       (rightOnly && !static_cast<bool>(b)) ||
       (!rightOnly && static_cast<bool>(a) == static_cast<bool>(b))) {
     return;

--- a/src/engine/Service.h
+++ b/src/engine/Service.h
@@ -166,7 +166,7 @@ class Service : public Operation {
 
   FRIEND_TEST(ServiceTest, computeResult);
   FRIEND_TEST(ServiceTest, computeResultWrapSubqueriesWithSibling);
-  FRIEND_TEST(ServiceTest, getCacheKey);
+  FRIEND_TEST(ServiceTest, precomputeSiblingResultDoesNotWorkWithCaching);
   FRIEND_TEST(ServiceTest, precomputeSiblingResult);
 };
 

--- a/src/global/RuntimeParameters.h
+++ b/src/global/RuntimeParameters.h
@@ -65,6 +65,8 @@ inline auto& RuntimeParameters() {
         Bool<"zero-cost-estimate-for-cached-subtree">{false},
         // Maximum size for the body of requests that the server will process.
         MemorySizeParameter<"request-body-limit">{100_MB},
+        // SERVICE operations are not cached by default, but can be enabled.
+        Bool<"cache-service">{false},
     };
   }();
   return params;

--- a/src/global/RuntimeParameters.h
+++ b/src/global/RuntimeParameters.h
@@ -67,7 +67,7 @@ inline auto& RuntimeParameters() {
         MemorySizeParameter<"request-body-limit">{100_MB},
         // SERVICE operations are not cached by default, but can be enabled
         // which has the downside that the sibling optimization where VALUES are
-        // dynamically pushed into `SERVICE` can no longer be used.
+        // dynamically pushed into `SERVICE` is no longer used.
         Bool<"cache-service-results">{false},
     };
   }();

--- a/src/global/RuntimeParameters.h
+++ b/src/global/RuntimeParameters.h
@@ -65,8 +65,10 @@ inline auto& RuntimeParameters() {
         Bool<"zero-cost-estimate-for-cached-subtree">{false},
         // Maximum size for the body of requests that the server will process.
         MemorySizeParameter<"request-body-limit">{100_MB},
-        // SERVICE operations are not cached by default, but can be enabled.
-        Bool<"cache-service">{false},
+        // SERVICE operations are not cached by default, but can be enabled
+        // which has the downside that the sibling optimization where VALUES are
+        // dynamically pushed into `SERVICE` can no longer be used.
+        Bool<"cache-service-results">{false},
     };
   }();
   return params;

--- a/test/ServiceTest.cpp
+++ b/test/ServiceTest.cpp
@@ -583,7 +583,7 @@ TEST_F(ServiceTest, getCacheKey) {
 // _____________________________________________________________________________
 TEST_F(ServiceTest, getCacheKeyWithCaching) {
   using namespace ::testing;
-  auto cleanup = setRuntimeParameterForTest<"cache-service">(true);
+  auto cleanup = setRuntimeParameterForTest<"cache-service-results">(true);
   {
     parsedQuery::Service parsedServiceClause{
         {Variable{"?x"}, Variable{"?y"}},
@@ -741,7 +741,7 @@ TEST_F(ServiceTest, idToValueForValuesClause) {
 
 // ____________________________________________________________________________
 TEST_F(ServiceTest, precomputeSiblingResultDoesNotWorkWithCaching) {
-  auto cleanup = setRuntimeParameterForTest<"cache-service">(true);
+  auto cleanup = setRuntimeParameterForTest<"cache-service-results">(true);
   auto service = std::make_shared<Service>(
       testQec,
       parsedQuery::Service{

--- a/test/ServiceTest.cpp
+++ b/test/ServiceTest.cpp
@@ -15,7 +15,6 @@
 #include "global/Constants.h"
 #include "global/IndexTypes.h"
 #include "global/RuntimeParameters.h"
-#include "gmock/gmock.h"
 #include "parser/GraphPatternOperation.h"
 #include "util/AllocatorWithLimit.h"
 #include "util/CancellationHandle.h"
@@ -23,6 +22,7 @@
 #include "util/IdTableHelpers.h"
 #include "util/IndexTestHelpers.h"
 #include "util/OperationTestHelpers.h"
+#include "util/RuntimeParametersTestHelpers.h"
 #include "util/TripleComponentTestHelpers.h"
 #include "util/http/HttpUtils.h"
 
@@ -553,6 +553,58 @@ TEST_F(ServiceTest, getCacheKey) {
   EXPECT_NE(service1.getCacheKey(), service2.getCacheKey());
 }
 
+// _____________________________________________________________________________
+TEST_F(ServiceTest, getCacheKeyWithCaching) {
+  using namespace ::testing;
+  auto cleanup = setRuntimeParameterForTest<"cache-service">(true);
+  {
+    parsedQuery::Service parsedServiceClause{
+        {Variable{"?x"}, Variable{"?y"}},
+        TripleComponent::Iri::fromIriref("<http://localhorst/api>"),
+        "PREFIX doof: <http://doof.org>",
+        "{ }",
+        false};
+
+    Service service{
+        testQec, parsedServiceClause,
+        getResultFunctionFactory(
+            "http://localhorst:80/api",
+            "PREFIX doof: <http://doof.org> SELECT ?x ?y WHERE { }",
+            genJsonResult(
+                {"x", "y"},
+                {{"x", "y"}, {"bla", "bli"}, {"blu", "bla"}, {"bli", "blu"}}))};
+
+    EXPECT_THAT(service.getCacheKey(),
+                AllOf(StartsWith("SERVICE"), Not(HasSubstr("SILENT")),
+                      HasSubstr("<http://localhorst/api>"),
+                      HasSubstr("PREFIX doof: <http://doof.org>"),
+                      HasSubstr(parsedServiceClause.graphPatternAsString_)));
+  }
+  {
+    parsedQuery::Service parsedServiceClause{
+        {Variable{"?x"}, Variable{"?y"}},
+        TripleComponent::Iri::fromIriref("<http://localhorst/api>"),
+        "PREFIX doof: <http://doof.org>",
+        "{ }",
+        true};
+
+    Service service{
+        testQec, parsedServiceClause,
+        getResultFunctionFactory(
+            "http://localhorst:80/api",
+            "PREFIX doof: <http://doof.org> SELECT ?x ?y WHERE { }",
+            genJsonResult(
+                {"x", "y"},
+                {{"x", "y"}, {"bla", "bli"}, {"blu", "bla"}, {"bli", "blu"}}))};
+
+    EXPECT_THAT(service.getCacheKey(),
+                AllOf(StartsWith("SERVICE"), HasSubstr("SILENT"),
+                      HasSubstr("<http://localhorst/api>"),
+                      HasSubstr("PREFIX doof: <http://doof.org>"),
+                      HasSubstr(parsedServiceClause.graphPatternAsString_)));
+  }
+}
+
 // Test that bindingToTripleComponent behaves as expected.
 TEST_F(ServiceTest, bindingToTripleComponent) {
   ad_utility::HashMap<std::string, Id> blankNodeMap;
@@ -658,6 +710,30 @@ TEST_F(ServiceTest, idToValueForValuesClause) {
       idToVc(index, Id::makeFromGeoPoint(GeoPoint(70.5, 130.2)), localVocab)
           .value(),
       absl::StrCat("\"POINT(130.200000 70.500000)\"^^<", GEO_WKT_LITERAL, ">"));
+}
+
+// ____________________________________________________________________________
+TEST_F(ServiceTest, precomputeSiblingResultDoesNotWorkWithCaching) {
+  auto cleanup = setRuntimeParameterForTest<"cache-service">(true);
+  auto service = std::make_shared<Service>(
+      testQec,
+      parsedQuery::Service{
+          {Variable{"?x"}, Variable{"?y"}},
+          TripleComponent::Iri::fromIriref("<http://localhorst/api>"),
+          "PREFIX doof: <http://doof.org>",
+          "{ }",
+          true},
+      getResultFunctionFactory(
+          "http://localhorst:80/api",
+          "PREFIX doof: <http://doof.org> SELECT ?x ?y WHERE { }",
+          genJsonResult({"x", "y"}, {{"a", "b"}}),
+          boost::beast::http::status::ok, "application/sparql-results+json"));
+
+  auto sibling = std::make_shared<AlwaysFailOperation>(testQec, Variable{"?x"});
+
+  EXPECT_NO_THROW(
+      Service::precomputeSiblingResult(sibling, service, true, false));
+  EXPECT_FALSE(service->siblingInfo_.has_value());
 }
 
 // ____________________________________________________________________________


### PR DESCRIPTION
With #1874, the results of `SERVICE` operations are no longer cached for two reasons: in order to guarantee correctness (in case the `SERVICE` endpoint is update between requests) and to enable the "VALUES" optimization described in #1874 (which can reduce the time for processing the operation significantly when the result from the `SERVICE` operation is large but is strongly constrained by the rest of the query).

However, in certain scenarios (in particular, when the `SERVICE` endpoint is under one's own control), caching the result of a `SERVICE` request can be desirable. This PR therefore introduces the command line flag `--cache-service-results`, which is off by default, that reverts to the old behavior before #1874. That is, with this flag the result of a `SERVICE` operations is cached just like the results of other operations, but there is no "VALUES" optimization when computing the result for the first time.

Fixes #1929