### PR TITLE
Template `Vocabulary` on `UnderlyingVocabulary` instead of on `StringType`

### DIFF
--- a/src/index/Vocabulary.h
+++ b/src/index/Vocabulary.h
@@ -37,11 +37,6 @@
 using std::string;
 using std::vector;
 
-template <class StringType>
-using AccessReturnType_t =
-    std::conditional_t<std::is_same_v<StringType, CompressedString>,
-                       std::string, std::string_view>;
-
 template <typename IndexT = WordVocabIndex>
 class IdRange {
  public:
@@ -65,10 +60,11 @@ inline std::ostream& operator<<(std::ostream& stream,
 }
 
 // A vocabulary. Wraps a vector of strings and provides additional methods for
-// retrieval. Template parameters that are supported are:
-// std::string -> no compression is applied
-// CompressedString -> prefix compression is applied
-template <typename StringType, typename ComparatorType, typename IndexT>
+// retrieval. It is templated on the type of the underlying vocabulary
+// implementation, which can be any of the implementations in the
+// `index/vocabulary` directory
+template <typename UnderlyingVocabulary, typename ComparatorType,
+          typename IndexT>
 class Vocabulary {
  public:
   // The index ranges for a prefix + a function to check whether a given index
@@ -95,17 +91,6 @@ class Vocabulary {
   // The different type of data that is stored in the vocabulary
   enum class Datatypes { Literal, Iri, Float, Date };
 
-  template <typename T, typename R = void>
-  using enable_if_compressed =
-      std::enable_if_t<std::is_same_v<T, CompressedString>>;
-
-  template <typename T, typename R = void>
-  using enable_if_uncompressed =
-      std::enable_if_t<!std::is_same_v<T, CompressedString>>;
-
-  static constexpr bool isCompressed_ =
-      std::is_same_v<StringType, CompressedString>;
-
   // If a literal uses one of these language tags or starts with one of these
   // prefixes, it will be externalized. By default, everything is externalized.
   // Both of these settings can be overridden using the `settings.json` file.
@@ -115,10 +100,6 @@ class Vocabulary {
   vector<std::string> internalizedLangs_;
   vector<std::string> externalizedPrefixes_{""};
 
-  using UnderlyingVocabulary =
-      std::conditional_t<isCompressed_,
-                         CompressedVocabulary<VocabularyInternalExternal>,
-                         VocabularyInMemory>;
   using VocabularyWithUnicodeComparator =
       UnicodeVocabulary<UnderlyingVocabulary, ComparatorType>;
 
@@ -132,12 +113,12 @@ class Vocabulary {
  public:
   using SortLevel = typename ComparatorType::Level;
   using IndexType = IndexT;
-  using AccessReturnType = AccessReturnType_t<StringType>;
+  // The type that is returned by the `operator[]` of this vocabulary. Typically
+  // either `std::string` or `std::string_view`.
+  using AccessReturnType =
+      decltype(std::declval<const UnderlyingVocabulary&>()[0]);
 
-  template <
-      typename = std::enable_if_t<std::is_same_v<StringType, string> ||
-                                  std::is_same_v<StringType, CompressedString>>>
-  Vocabulary() {}
+  Vocabulary() = default;
   Vocabulary& operator=(Vocabulary&&) noexcept = default;
   Vocabulary(Vocabulary&&) noexcept = default;
 
@@ -148,7 +129,7 @@ class Vocabulary {
 
   // Get the word with the given `idx`. Throw if the `idx` is not contained
   // in the vocabulary.
-  AccessReturnType_t<StringType> operator[](IndexType idx) const;
+  AccessReturnType operator[](IndexType idx) const;
 
   // AccessReturnType_t<StringType> at(IndexType idx) const { return
   // operator[](id); }
@@ -243,9 +224,15 @@ class Vocabulary {
   }
 };
 
-using RdfsVocabulary =
-    Vocabulary<CompressedString, TripleComponentComparator, VocabIndex>;
-using TextVocabulary =
-    Vocabulary<std::string, SimpleStringComparator, WordVocabIndex>;
+namespace detail {
+using UnderlyingVocabRdfsVocabulary =
+    CompressedVocabulary<VocabularyInternalExternal>;
+using UnderlyingVocabTextVocabulary = VocabularyInMemory;
+}  // namespace detail
+
+using RdfsVocabulary = Vocabulary<detail::UnderlyingVocabRdfsVocabulary,
+                                  TripleComponentComparator, VocabIndex>;
+using TextVocabulary = Vocabulary<detail::UnderlyingVocabTextVocabulary,
+                                  SimpleStringComparator, WordVocabIndex>;
 
 #endif  // QLEVER_SRC_INDEX_VOCABULARY_H


### PR DESCRIPTION
So far, the `Vocabulary` class was templated on its `StringType` , which was one of `std::string` or `CompressedString`. This was not the right interface because it required code in the `Vocabulary` class that was implementation details of the underlying vocabulary. The class is now templated by the `UnderlyingVocabulary`.