### PR TITLE
Fix transitive path with same variable on both sides

### DIFF
--- a/src/engine/TransitivePathBase.cpp
+++ b/src/engine/TransitivePathBase.cpp
@@ -242,7 +242,7 @@ std::string TransitivePathBase::getCacheKeyImpl() const {
   os << "TRANSITIVE PATH ";
   if (lhs_.isVariable() && lhs_.value_ == rhs_.value_) {
     // Use a different cache key if the same variable is used left and right,
-    // because that changes the behviour of this operation and variable names
+    // because that changes the behaviour of this operation and variable names
     // are not found in the children's cache keys.
     os << "symmetric ";
   }

--- a/src/engine/TransitivePathBase.cpp
+++ b/src/engine/TransitivePathBase.cpp
@@ -239,7 +239,14 @@ Result::Generator TransitivePathBase::fillTableWithHullImpl(
 // _____________________________________________________________________________
 std::string TransitivePathBase::getCacheKeyImpl() const {
   std::ostringstream os;
-  os << " minDist " << minDist_ << " maxDist " << maxDist_ << "\n";
+  os << "TRANSITIVE PATH ";
+  if (lhs_.isVariable() && lhs_.value_ == rhs_.value_) {
+    // Use a different cache key if the same variable is used left and right,
+    // because that changes the behviour of this operation and variable names
+    // are not found in the children's cache keys.
+    os << "symmetric ";
+  }
+  os << "minDist " << minDist_ << " maxDist " << maxDist_ << "\n";
 
   os << "Left side:\n";
   os << lhs_.getCacheKey();

--- a/src/engine/TransitivePathImpl.h
+++ b/src/engine/TransitivePathImpl.h
@@ -236,12 +236,17 @@ class TransitivePathImpl : public TransitivePathBase {
             ? std::nullopt
             : std::optional{std::move(target).toValueId(
                   _executionContext->getIndex().getVocab(), targetHelper)};
+    bool sameVariableOnBothSides =
+        !targetId.has_value() && lhs_.value_ == rhs_.value_;
     for (auto&& tableColumn : startNodes) {
       timer.cont();
       LocalVocab mergedVocab = std::move(tableColumn.vocab_);
       mergedVocab.mergeWith(edgesVocab);
       size_t currentRow = 0;
       for (Id startNode : tableColumn.column_) {
+        if (sameVariableOnBothSides) {
+          targetId = startNode;
+        }
         Set connectedNodes = findConnectedNodes(edges, startNode, targetId);
         if (!connectedNodes.empty()) {
           runtimeInfo().addDetail("Hull time", timer.msecs());

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -4190,3 +4190,16 @@ TEST(QueryPlanner, emptyPathWithLiteralsBound) {
               h::IndexScanFromStrings("?_QLever_internal_variable_qp_0", "<a>",
                                       "?_QLever_internal_variable_qp_1")))));
 }
+
+// _____________________________________________________________________________
+TEST(QueryPlanner, propertyPathWithSameVariableTwiceBound) {
+  TransitivePathSide left{std::nullopt, 1, Variable{"?x"}, 0};
+  TransitivePathSide right{std::nullopt, 0, Variable{"?x"}, 1};
+  h::expect("SELECT * { ?x <a>+ ?x . ?x <b> <c> }",
+            h::TransitivePath(std::move(left), std::move(right), 1,
+                              std::numeric_limits<size_t>::max(),
+                              h::IndexScanFromStrings("?x", "<b>", "<c>"),
+                              h::IndexScanFromStrings(
+                                  "?_QLever_internal_variable_qp_0", "<a>",
+                                  "?_QLever_internal_variable_qp_1")));
+}


### PR DESCRIPTION
So far, QLever produced the same result for `SELECT * { ?x a+ ?x }` as for `SELECT * { ?x a+ ?y }`, except that the result for the first query had only one column. The two queries also had the same cache key. These bugs are now fixed. Fixes #1964