### PR TITLE
Backport C++20 STL functions to C++17 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.27)
+cmake_policy(SET CMP0167 NEW)
 project(QLever C CXX)
 
 # C/C++ Versions

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,7 @@ FetchContent_Declare(
 FetchContent_Declare(
         range-v3
         GIT_REPOSITORY https://github.com/joka921/range-v3
-        GIT_TAG 01037d73a8d0eeb3f53b27f33f83ae9da1e6afde  # branch fork-for-qlever
+        GIT_TAG  b661537be421fee77df40bdffa8f221ead53bb8e  # branch fork-for-qlever
 )
 
 #################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,7 @@ FetchContent_Declare(
 FetchContent_Declare(
         range-v3
         GIT_REPOSITORY https://github.com/joka921/range-v3
-        GIT_TAG 1dc0b09abab1bdc7d085a78754abd5c6e37a5d0c # 0.12.0
+        GIT_TAG 01037d73a8d0eeb3f53b27f33f83ae9da1e6afde  # branch fork-for-qlever
 )
 
 #################################

--- a/benchmark/JoinAlgorithmBenchmark.cpp
+++ b/benchmark/JoinAlgorithmBenchmark.cpp
@@ -117,7 +117,7 @@ struct SetOfIdTableColumnElements {
   Set the member variables for the given column.
   */
   explicit SetOfIdTableColumnElements(
-      const std::span<const ValueId>& idTableColumnRef) {
+      const ql::span<const ValueId>& idTableColumnRef) {
     ql::ranges::for_each(idTableColumnRef, [this](const ValueId& id) {
       if (auto numOccurrencesIterator = numOccurrences_.find(id);
           numOccurrencesIterator != numOccurrences_.end()) {
@@ -795,11 +795,11 @@ class GeneralInterfaceImplementation : public BenchmarkInterface {
                OptionType, ad_utility::ConstConfigOptionProxy>>>(
             const OptionType& option, const auto& minimumValue,
             bool canBeEqual) {
-      return absl::StrCat("'", option.getConfigOption().getIdentifier(),
-                          "' must be bigger than",
-                          canBeEqual ? ", or equal to," : "", " ", minimumValue,
-                          ".");
-    };
+          return absl::StrCat("'", option.getConfigOption().getIdentifier(),
+                              "' must be bigger than",
+                              canBeEqual ? ", or equal to," : "", " ",
+                              minimumValue, ".");
+        };
 
     // Object with a `operator()` for the `<=` operator.
     auto lessEqualLambda = std::less_equal<size_t>{};
@@ -808,11 +808,11 @@ class GeneralInterfaceImplementation : public BenchmarkInterface {
            typename = std::enable_if_t<ad_utility::isInstantiation<
                OptionType, ad_utility::ConstConfigOptionProxy>>>(
             const OptionType& lhs, const OptionType& rhs) {
-      return absl::StrCat("'", lhs.getConfigOption().getIdentifier(),
-                          "' must be smaller than, or equal to, "
-                          "'",
-                          rhs.getConfigOption().getIdentifier(), "'.");
-    };
+          return absl::StrCat("'", lhs.getConfigOption().getIdentifier(),
+                              "' must be smaller than, or equal to, "
+                              "'",
+                              rhs.getConfigOption().getIdentifier(), "'.");
+        };
 
     // Adding the validators.
 

--- a/benchmark/JoinAlgorithmBenchmark.cpp
+++ b/benchmark/JoinAlgorithmBenchmark.cpp
@@ -117,7 +117,7 @@ struct SetOfIdTableColumnElements {
   Set the member variables for the given column.
   */
   explicit SetOfIdTableColumnElements(
-      const absl::Span<const ValueId>& idTableColumnRef) {
+      const std::span<const ValueId>& idTableColumnRef) {
     ql::ranges::for_each(idTableColumnRef, [this](const ValueId& id) {
       if (auto numOccurrencesIterator = numOccurrences_.find(id);
           numOccurrencesIterator != numOccurrences_.end()) {

--- a/benchmark/JoinAlgorithmBenchmark.cpp
+++ b/benchmark/JoinAlgorithmBenchmark.cpp
@@ -795,11 +795,11 @@ class GeneralInterfaceImplementation : public BenchmarkInterface {
                OptionType, ad_utility::ConstConfigOptionProxy>>>(
             const OptionType& option, const auto& minimumValue,
             bool canBeEqual) {
-          return absl::StrCat("'", option.getConfigOption().getIdentifier(),
-                              "' must be bigger than",
-                              canBeEqual ? ", or equal to," : "", " ",
-                              minimumValue, ".");
-        };
+      return absl::StrCat("'", option.getConfigOption().getIdentifier(),
+                          "' must be bigger than",
+                          canBeEqual ? ", or equal to," : "", " ", minimumValue,
+                          ".");
+    };
 
     // Object with a `operator()` for the `<=` operator.
     auto lessEqualLambda = std::less_equal<size_t>{};
@@ -808,11 +808,11 @@ class GeneralInterfaceImplementation : public BenchmarkInterface {
            typename = std::enable_if_t<ad_utility::isInstantiation<
                OptionType, ad_utility::ConstConfigOptionProxy>>>(
             const OptionType& lhs, const OptionType& rhs) {
-          return absl::StrCat("'", lhs.getConfigOption().getIdentifier(),
-                              "' must be smaller than, or equal to, "
-                              "'",
-                              rhs.getConfigOption().getIdentifier(), "'.");
-        };
+      return absl::StrCat("'", lhs.getConfigOption().getIdentifier(),
+                          "' must be smaller than, or equal to, "
+                          "'",
+                          rhs.getConfigOption().getIdentifier(), "'.");
+    };
 
     // Adding the validators.
 

--- a/benchmark/JoinAlgorithmBenchmark.cpp
+++ b/benchmark/JoinAlgorithmBenchmark.cpp
@@ -117,7 +117,7 @@ struct SetOfIdTableColumnElements {
   Set the member variables for the given column.
   */
   explicit SetOfIdTableColumnElements(
-      const std::span<const ValueId>& idTableColumnRef) {
+      const absl::Span<const ValueId>& idTableColumnRef) {
     ql::ranges::for_each(idTableColumnRef, [this](const ValueId& id) {
       if (auto numOccurrencesIterator = numOccurrences_.find(id);
           numOccurrencesIterator != numOccurrences_.end()) {

--- a/src/backports/span.h
+++ b/src/backports/span.h
@@ -8,18 +8,16 @@
 
 #include "backports/cppTemplate2.h"
 
-#ifndef QLEVER_CPP_17
-// In C++20 mode, use std::span
-#include <span>
-namespace ql {
-using std::span;
-}  // namespace ql
-
-#else
-// In C++17 mode, use range-v3's span implementation
+#ifdef QLEVER_CPP_17
 #include <range/v3/view/span.hpp>
 namespace ql {
 using ranges::span;
+}  // namespace ql
+
+#else
+#include <span>
+namespace ql {
+using std::span;
 }  // namespace ql
 
 #endif

--- a/src/backports/span.h
+++ b/src/backports/span.h
@@ -12,12 +12,14 @@
 #include <range/v3/view/span.hpp>
 namespace ql {
 using ::ranges::span;
+static constexpr auto dynamic_extent = ::ranges::dynamic_extent;
 }  // namespace ql
 
 #else
-#include <span>
+#include "backports/span.h"
 namespace ql {
 using std::span;
+static constexpr auto dynamic_extent = std::dynamic_extent;
 }  // namespace ql
 
 #endif

--- a/src/backports/span.h
+++ b/src/backports/span.h
@@ -3,15 +3,15 @@
 //
 // Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
-#ifndef QLEVER_SRC_BACKPORTS_SPAN
-#define QLEVER_SRC_BACKPORTS_SPAN
+#ifndef QLEVER_SRC_BACKPORTS_SPAN_H
+#define QLEVER_SRC_BACKPORTS_SPAN_H
 
 #include "backports/cppTemplate2.h"
 
 #ifdef QLEVER_CPP_17
 #include <range/v3/view/span.hpp>
 namespace ql {
-using ranges::span;
+using ::ranges::span;
 }  // namespace ql
 
 #else
@@ -22,4 +22,4 @@ using std::span;
 
 #endif
 
-#endif  // QLEVER_SRC_BACKPORTS_SPAN
+#endif  // QLEVER_SRC_BACKPORTS_SPAN_H

--- a/src/backports/span.h
+++ b/src/backports/span.h
@@ -1,0 +1,27 @@
+// Copyright 2024, University of Freiburg
+// Chair of Algorithms and Data Structures
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+
+#ifndef QLEVER_SRC_BACKPORTS_SPAN
+#define QLEVER_SRC_BACKPORTS_SPAN
+
+#include "backports/cppTemplate2.h"
+
+#ifndef QLEVER_CPP_17
+// In C++20 mode, use std::span
+#include <span>
+namespace ql {
+using std::span;
+}  // namespace ql
+
+#else
+// In C++17 mode, use range-v3's span implementation
+#include <range/v3/view/span.hpp>
+namespace ql {
+using ranges::span;
+}  // namespace ql
+
+#endif
+
+#endif  // QLEVER_SRC_BACKPORTS_SPAN

--- a/src/backports/span.h
+++ b/src/backports/span.h
@@ -6,7 +6,19 @@
 #ifndef QLEVER_SRC_BACKPORTS_SPAN_H
 #define QLEVER_SRC_BACKPORTS_SPAN_H
 
-#include "backports/cppTemplate2.h"
+// This header implements the following types and functions, all related to
+// spans:
+// - ql::span
+// - ql::as_bytes
+// - ql::as_writeable_bytes
+// - ql::dynamic_extent
+// In C++20 mode (by default) they are aliases for the corresponding types and
+// functions from the standard library, in C++17 mode (when `QLEVER_CPP_17` is
+// enabled) they are implemented using `range-v3`.
+// Note that we use a fork of range-v3 that makes the span implementations very
+// similar, but some small differences remain, In particular the deduction
+// guides for the construction from `std::array` which leads to a static extent
+// are missing.
 
 #ifdef QLEVER_CPP_17
 #include <cstddef>
@@ -21,7 +33,7 @@ span<std::byte const, ::ranges::detail::byte_size<T>(N)> as_bytes(
 }
 
 template <typename T, ::ranges::detail::span_index_t N>
-span<std::byte, ::ranges::detail::byte_size<T>(N)> as_writeable_bytes(
+span<std::byte, ::ranges::detail::byte_size<T>(N)> as_writable_bytes(
     span<T, N> s) noexcept {
   return {reinterpret_cast<std::byte*>(s.data()), s.size_bytes()};
 }
@@ -30,10 +42,10 @@ static constexpr auto dynamic_extent = ::ranges::dynamic_extent;
 }  // namespace ql
 
 #else
-#include "backports/span.h"
+#include <span>
 namespace ql {
 using std::as_bytes;
-using std::as_writeable_bytes;
+using std::as_writable_bytes;
 using std::span;
 static constexpr auto dynamic_extent = std::dynamic_extent;
 }  // namespace ql

--- a/src/backports/span.h
+++ b/src/backports/span.h
@@ -9,15 +9,31 @@
 #include "backports/cppTemplate2.h"
 
 #ifdef QLEVER_CPP_17
+#include <cstddef>
 #include <range/v3/view/span.hpp>
 namespace ql {
 using ::ranges::span;
+
+template <typename T, ::ranges::detail::span_index_t N>
+span<std::byte const, ::ranges::detail::byte_size<T>(N)> as_bytes(
+    span<T, N> s) noexcept {
+  return {reinterpret_cast<std::byte const*>(s.data()), s.size_bytes()};
+}
+
+template <typename T, ::ranges::detail::span_index_t N>
+span<std::byte, ::ranges::detail::byte_size<T>(N)> as_writeable_bytes(
+    span<T, N> s) noexcept {
+  return {reinterpret_cast<std::byte*>(s.data()), s.size_bytes()};
+}
+
 static constexpr auto dynamic_extent = ::ranges::dynamic_extent;
 }  // namespace ql
 
 #else
 #include "backports/span.h"
 namespace ql {
+using std::as_bytes;
+using std::as_writeable_bytes;
 using std::span;
 static constexpr auto dynamic_extent = std::dynamic_extent;
 }  // namespace ql

--- a/src/engine/CartesianProductJoin.cpp
+++ b/src/engine/CartesianProductJoin.cpp
@@ -93,8 +93,8 @@ bool CartesianProductJoin::knownEmptyResult() {
 }
 
 // ____________________________________________________________________________
-void CartesianProductJoin::writeResultColumn(std::span<Id> targetColumn,
-                                             std::span<const Id> inputColumn,
+void CartesianProductJoin::writeResultColumn(ql::span<Id> targetColumn,
+                                             ql::span<const Id> inputColumn,
                                              size_t groupSize,
                                              size_t offset) const {
   // Copy each element from the `inputColumn` `groupSize` times to

--- a/src/engine/CartesianProductJoin.cpp
+++ b/src/engine/CartesianProductJoin.cpp
@@ -93,8 +93,8 @@ bool CartesianProductJoin::knownEmptyResult() {
 }
 
 // ____________________________________________________________________________
-void CartesianProductJoin::writeResultColumn(absl::Span<Id> targetColumn,
-                                             absl::Span<const Id> inputColumn,
+void CartesianProductJoin::writeResultColumn(std::span<Id> targetColumn,
+                                             std::span<const Id> inputColumn,
                                              size_t groupSize,
                                              size_t offset) const {
   // Copy each element from the `inputColumn` `groupSize` times to

--- a/src/engine/CartesianProductJoin.cpp
+++ b/src/engine/CartesianProductJoin.cpp
@@ -93,8 +93,8 @@ bool CartesianProductJoin::knownEmptyResult() {
 }
 
 // ____________________________________________________________________________
-void CartesianProductJoin::writeResultColumn(std::span<Id> targetColumn,
-                                             std::span<const Id> inputColumn,
+void CartesianProductJoin::writeResultColumn(absl::Span<Id> targetColumn,
+                                             absl::Span<const Id> inputColumn,
                                              size_t groupSize,
                                              size_t offset) const {
   // Copy each element from the `inputColumn` `groupSize` times to

--- a/src/engine/CartesianProductJoin.h
+++ b/src/engine/CartesianProductJoin.h
@@ -89,8 +89,8 @@ class CartesianProductJoin : public Operation {
   // `targetColumn`. Repeat until the `targetColumn` is completely filled. Skip
   // the first `offset` write operations to the `targetColumn`. Call
   // `checkCancellation` after each write.
-  void writeResultColumn(std::span<Id> targetColumn,
-                         std::span<const Id> inputColumn, size_t groupSize,
+  void writeResultColumn(ql::span<Id> targetColumn,
+                         ql::span<const Id> inputColumn, size_t groupSize,
                          size_t offset) const;
 
   // Write all columns of the subresults into an `IdTable` and return it.

--- a/src/engine/CartesianProductJoin.h
+++ b/src/engine/CartesianProductJoin.h
@@ -89,8 +89,8 @@ class CartesianProductJoin : public Operation {
   // `targetColumn`. Repeat until the `targetColumn` is completely filled. Skip
   // the first `offset` write operations to the `targetColumn`. Call
   // `checkCancellation` after each write.
-  void writeResultColumn(absl::Span<Id> targetColumn,
-                         absl::Span<const Id> inputColumn, size_t groupSize,
+  void writeResultColumn(std::span<Id> targetColumn,
+                         std::span<const Id> inputColumn, size_t groupSize,
                          size_t offset) const;
 
   // Write all columns of the subresults into an `IdTable` and return it.

--- a/src/engine/CartesianProductJoin.h
+++ b/src/engine/CartesianProductJoin.h
@@ -89,8 +89,8 @@ class CartesianProductJoin : public Operation {
   // `targetColumn`. Repeat until the `targetColumn` is completely filled. Skip
   // the first `offset` write operations to the `targetColumn`. Call
   // `checkCancellation` after each write.
-  void writeResultColumn(std::span<Id> targetColumn,
-                         std::span<const Id> inputColumn, size_t groupSize,
+  void writeResultColumn(absl::Span<Id> targetColumn,
+                         absl::Span<const Id> inputColumn, size_t groupSize,
                          size_t offset) const;
 
   // Write all columns of the subresults into an `IdTable` and return it.

--- a/src/engine/Describe.cpp
+++ b/src/engine/Describe.cpp
@@ -98,7 +98,7 @@ VariableToColumnMap Describe::computeVariableToColumnMap() const {
 // with duplicates removed. The returned `Id`s are added to `alreadySeen`.
 static IdTable getNewBlankNodes(
     const auto& allocator, ad_utility::HashSetWithMemoryLimit<Id>& alreadySeen,
-    std::span<Id> input) {
+    absl::Span<Id> input) {
   IdTable result{1, allocator};
   result.resize(input.size());
   decltype(auto) resultColumn = result.getColumn(0);

--- a/src/engine/Describe.cpp
+++ b/src/engine/Describe.cpp
@@ -99,7 +99,7 @@ VariableToColumnMap Describe::computeVariableToColumnMap() const {
 template <typename Allocator>
 static IdTable getNewBlankNodes(
     const Allocator& allocator,
-    ad_utility::HashSetWithMemoryLimit<Id>& alreadySeen, absl::Span<Id> input) {
+    ad_utility::HashSetWithMemoryLimit<Id>& alreadySeen, ql::span<Id> input) {
   IdTable result{1, allocator};
   result.resize(input.size());
   decltype(auto) resultColumn = result.getColumn(0);

--- a/src/engine/Describe.cpp
+++ b/src/engine/Describe.cpp
@@ -98,8 +98,6 @@ VariableToColumnMap Describe::computeVariableToColumnMap() const {
 // with duplicates removed. The returned `Id`s are added to `alreadySeen`.
 template <typename Allocator>
 static IdTable getNewBlankNodes(
-    const auto& allocator, ad_utility::HashSetWithMemoryLimit<Id>& alreadySeen,
-    absl::Span<Id> input) {
     const Allocator& allocator,
     ad_utility::HashSetWithMemoryLimit<Id>& alreadySeen, absl::Span<Id> input) {
   IdTable result{1, allocator};

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -755,7 +755,7 @@ std::optional<IdTable> GroupBy::computeGroupByForFullIndexScan() const {
   auto table = permutation.getDistinctCol0IdsAndCounts(
       cancellationHandle_, locatedTriplesSnapshot());
   if (numCounts == 0) {
-    table.setColumnSubset(std::array{ColumnIndex(0)});
+    table.setColumnSubset({{0}});
   } else if (!variableIsBoundInSubtree) {
     // The variable inside the COUNT() is not part of the input, so it is always
     // unbound and has a count of 0 in each group.

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -1230,7 +1230,7 @@ GroupBy::substituteAllAggregates(
 template <size_t NUM_GROUP_COLUMNS>
 std::vector<size_t>
 GroupBy::HashMapAggregationData<NUM_GROUP_COLUMNS>::getHashEntries(
-    const ArrayOrVector<std::span<const Id>>& groupByCols) {
+    const ArrayOrVector<absl::Span<const Id>>& groupByCols) {
   AD_CONTRACT_CHECK(groupByCols.size() > 0);
 
   std::vector<size_t> hashEntries;
@@ -1560,7 +1560,7 @@ Result GroupBy::computeGroupByForHashMapOptimization(
 
       // Perform HashMap lookup once for all groups in current block
       using U = HashMapAggregationData<
-          NUM_GROUP_COLUMNS>::template ArrayOrVector<std::span<const Id>>;
+          NUM_GROUP_COLUMNS>::template ArrayOrVector<absl::Span<const Id>>;
       U groupValues;
       resizeIfVector(groupValues, columnIndices.size());
 

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -755,7 +755,7 @@ std::optional<IdTable> GroupBy::computeGroupByForFullIndexScan() const {
   auto table = permutation.getDistinctCol0IdsAndCounts(
       cancellationHandle_, locatedTriplesSnapshot());
   if (numCounts == 0) {
-    table.setColumnSubset({0});
+    table.setColumnSubset(std::array{ColumnIndex(0)});
   } else if (!variableIsBoundInSubtree) {
     // The variable inside the COUNT() is not part of the input, so it is always
     // unbound and has a count of 0 in each group.
@@ -1230,7 +1230,7 @@ GroupBy::substituteAllAggregates(
 template <size_t NUM_GROUP_COLUMNS>
 std::vector<size_t>
 GroupBy::HashMapAggregationData<NUM_GROUP_COLUMNS>::getHashEntries(
-    const ArrayOrVector<std::span<const Id>>& groupByCols) {
+    const ArrayOrVector<ql::span<const Id>>& groupByCols) {
   AD_CONTRACT_CHECK(groupByCols.size() > 0);
 
   std::vector<size_t> hashEntries;
@@ -1560,7 +1560,7 @@ Result GroupBy::computeGroupByForHashMapOptimization(
 
       // Perform HashMap lookup once for all groups in current block
       using U = HashMapAggregationData<
-          NUM_GROUP_COLUMNS>::template ArrayOrVector<std::span<const Id>>;
+          NUM_GROUP_COLUMNS>::template ArrayOrVector<ql::span<const Id>>;
       U groupValues;
       resizeIfVector(groupValues, columnIndices.size());
 

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -218,7 +218,7 @@ void GroupBy::processGroup(
   evaluationContext._previousResultsFromSameGroup.at(resultColumn) =
       sparqlExpression::copyExpressionResult(expressionResult);
 
-  auto visitor = CPP_template_lambda_mut(&)(typename T)(T && singleResult)(
+  auto visitor = CPP_template_lambda_mut (&)(typename T)(T && singleResult)(
       requires sparqlExpression::SingleExpressionResult<T>) {
     constexpr static bool isStrongId = std::is_same_v<T, Id>;
     AD_CONTRACT_CHECK(sparqlExpression::isConstantResult<T>);
@@ -755,7 +755,7 @@ std::optional<IdTable> GroupBy::computeGroupByForFullIndexScan() const {
   auto table = permutation.getDistinctCol0IdsAndCounts(
       cancellationHandle_, locatedTriplesSnapshot());
   if (numCounts == 0) {
-    table.setColumnSubset({{0}});
+    table.setColumnSubset({0});
   } else if (!variableIsBoundInSubtree) {
     // The variable inside the COUNT() is not part of the input, so it is always
     // unbound and has a count of 0 in each group.

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -1230,7 +1230,7 @@ GroupBy::substituteAllAggregates(
 template <size_t NUM_GROUP_COLUMNS>
 std::vector<size_t>
 GroupBy::HashMapAggregationData<NUM_GROUP_COLUMNS>::getHashEntries(
-    const ArrayOrVector<absl::Span<const Id>>& groupByCols) {
+    const ArrayOrVector<std::span<const Id>>& groupByCols) {
   AD_CONTRACT_CHECK(groupByCols.size() > 0);
 
   std::vector<size_t> hashEntries;
@@ -1560,7 +1560,7 @@ Result GroupBy::computeGroupByForHashMapOptimization(
 
       // Perform HashMap lookup once for all groups in current block
       using U = HashMapAggregationData<
-          NUM_GROUP_COLUMNS>::template ArrayOrVector<absl::Span<const Id>>;
+          NUM_GROUP_COLUMNS>::template ArrayOrVector<std::span<const Id>>;
       U groupValues;
       resizeIfVector(groupValues, columnIndices.size());
 

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -383,7 +383,7 @@ class GroupBy : public Operation {
     // Returns a vector containing the offsets for all ids of `groupByCols`,
     // inserting entries if necessary.
     std::vector<size_t> getHashEntries(
-        const ArrayOrVector<std::span<const Id>>& groupByCols);
+        const ArrayOrVector<ql::span<const Id>>& groupByCols);
 
     // Return the index of `id`.
     [[nodiscard]] size_t getIndex(const ArrayOrVector<Id>& ids) const {

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -383,7 +383,7 @@ class GroupBy : public Operation {
     // Returns a vector containing the offsets for all ids of `groupByCols`,
     // inserting entries if necessary.
     std::vector<size_t> getHashEntries(
-        const ArrayOrVector<absl::Span<const Id>>& groupByCols);
+        const ArrayOrVector<std::span<const Id>>& groupByCols);
 
     // Return the index of `id`.
     [[nodiscard]] size_t getIndex(const ArrayOrVector<Id>& ids) const {

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -383,7 +383,7 @@ class GroupBy : public Operation {
     // Returns a vector containing the offsets for all ids of `groupByCols`,
     // inserting entries if necessary.
     std::vector<size_t> getHashEntries(
-        const ArrayOrVector<std::span<const Id>>& groupByCols);
+        const ArrayOrVector<absl::Span<const Id>>& groupByCols);
 
     // Return the index of `id`.
     [[nodiscard]] size_t getIndex(const ArrayOrVector<Id>& ids) const {

--- a/src/engine/IndexScan.cpp
+++ b/src/engine/IndexScan.cpp
@@ -329,7 +329,7 @@ IndexScan::getSortedVariableAndMetadataColumnIndexForPrefiltering() const {
 }
 
 // _____________________________________________________________________________
-std::optional<std::span<const CompressedBlockMetadata>>
+std::optional<ql::span<const CompressedBlockMetadata>>
 IndexScan::getBlockMetadata() const {
   auto metadata = getMetadataForScan();
   if (metadata.has_value()) {
@@ -356,7 +356,7 @@ IndexScan::getBlockMetadataOptionallyPrefiltered() const {
 
 // _____________________________________________________________________________
 std::vector<CompressedBlockMetadata> IndexScan::applyPrefilter(
-    std::span<const CompressedBlockMetadata> blocks) const {
+    ql::span<const CompressedBlockMetadata> blocks) const {
   AD_CORRECTNESS_CHECK(prefilter_.has_value() && getLimit().isUnconstrained());
   // Apply the prefilter on given blocks.
   auto& [prefilterExpr, columnIndex] = prefilter_.value();
@@ -443,7 +443,7 @@ IndexScan::lazyScanForJoinOfTwoScans(const IndexScan& s1, const IndexScan& s2) {
 
 // _____________________________________________________________________________
 Permutation::IdTableGenerator IndexScan::lazyScanForJoinOfColumnWithScan(
-    std::span<const Id> joinColumn) const {
+    ql::span<const Id> joinColumn) const {
   AD_EXPENSIVE_CHECK(ql::ranges::is_sorted(joinColumn));
   AD_CORRECTNESS_CHECK(numVariables_ <= 3 && numVariables_ > 0);
   AD_CONTRACT_CHECK(joinColumn.empty() || !joinColumn[0].isUndefined());

--- a/src/engine/IndexScan.cpp
+++ b/src/engine/IndexScan.cpp
@@ -329,7 +329,7 @@ IndexScan::getSortedVariableAndMetadataColumnIndexForPrefiltering() const {
 }
 
 // _____________________________________________________________________________
-std::optional<absl::Span<const CompressedBlockMetadata>>
+std::optional<std::span<const CompressedBlockMetadata>>
 IndexScan::getBlockMetadata() const {
   auto metadata = getMetadataForScan();
   if (metadata.has_value()) {
@@ -356,7 +356,7 @@ IndexScan::getBlockMetadataOptionallyPrefiltered() const {
 
 // _____________________________________________________________________________
 std::vector<CompressedBlockMetadata> IndexScan::applyPrefilter(
-    absl::Span<const CompressedBlockMetadata> blocks) const {
+    std::span<const CompressedBlockMetadata> blocks) const {
   AD_CORRECTNESS_CHECK(prefilter_.has_value() && getLimit().isUnconstrained());
   // Apply the prefilter on given blocks.
   auto& [prefilterExpr, columnIndex] = prefilter_.value();
@@ -443,7 +443,7 @@ IndexScan::lazyScanForJoinOfTwoScans(const IndexScan& s1, const IndexScan& s2) {
 
 // _____________________________________________________________________________
 Permutation::IdTableGenerator IndexScan::lazyScanForJoinOfColumnWithScan(
-    absl::Span<const Id> joinColumn) const {
+    std::span<const Id> joinColumn) const {
   AD_EXPENSIVE_CHECK(ql::ranges::is_sorted(joinColumn));
   AD_CORRECTNESS_CHECK(numVariables_ <= 3 && numVariables_ > 0);
   AD_CONTRACT_CHECK(joinColumn.empty() || !joinColumn[0].isUndefined());

--- a/src/engine/IndexScan.cpp
+++ b/src/engine/IndexScan.cpp
@@ -329,7 +329,7 @@ IndexScan::getSortedVariableAndMetadataColumnIndexForPrefiltering() const {
 }
 
 // _____________________________________________________________________________
-std::optional<std::span<const CompressedBlockMetadata>>
+std::optional<absl::Span<const CompressedBlockMetadata>>
 IndexScan::getBlockMetadata() const {
   auto metadata = getMetadataForScan();
   if (metadata.has_value()) {
@@ -356,7 +356,7 @@ IndexScan::getBlockMetadataOptionallyPrefiltered() const {
 
 // _____________________________________________________________________________
 std::vector<CompressedBlockMetadata> IndexScan::applyPrefilter(
-    std::span<const CompressedBlockMetadata> blocks) const {
+    absl::Span<const CompressedBlockMetadata> blocks) const {
   AD_CORRECTNESS_CHECK(prefilter_.has_value() && getLimit().isUnconstrained());
   // Apply the prefilter on given blocks.
   auto& [prefilterExpr, columnIndex] = prefilter_.value();
@@ -443,7 +443,7 @@ IndexScan::lazyScanForJoinOfTwoScans(const IndexScan& s1, const IndexScan& s2) {
 
 // _____________________________________________________________________________
 Permutation::IdTableGenerator IndexScan::lazyScanForJoinOfColumnWithScan(
-    std::span<const Id> joinColumn) const {
+    absl::Span<const Id> joinColumn) const {
   AD_EXPENSIVE_CHECK(ql::ranges::is_sorted(joinColumn));
   AD_CORRECTNESS_CHECK(numVariables_ <= 3 && numVariables_ > 0);
   AD_CONTRACT_CHECK(joinColumn.empty() || !joinColumn[0].isUndefined());

--- a/src/engine/IndexScan.h
+++ b/src/engine/IndexScan.h
@@ -99,7 +99,7 @@ class IndexScan final : public Operation {
   // join between the first column of the result with the `joinColumn`.
   // Requires that the `joinColumn` is sorted, else the behavior is undefined.
   Permutation::IdTableGenerator lazyScanForJoinOfColumnWithScan(
-      std::span<const Id> joinColumn) const;
+      ql::span<const Id> joinColumn) const;
 
   // Return two generators, the first of which yields exactly the elements of
   // `input` and the second of which yields the matching blocks, skipping the
@@ -219,7 +219,7 @@ class IndexScan final : public Operation {
 
   // Retrieve all the relevant `CompressedBlockMetadata` for this scan without
   // applying any additional pre-filter procedure.
-  std::optional<std::span<const CompressedBlockMetadata>> getBlockMetadata()
+  std::optional<ql::span<const CompressedBlockMetadata>> getBlockMetadata()
       const;
 
   // This method retrieves all relevant `CompressedBlockMetadata` and performs
@@ -230,7 +230,7 @@ class IndexScan final : public Operation {
   // Apply the `prefilter_` to the `blocks`. May only be called if the limit is
   // unconstrained, and a `prefilter_` exists.
   std::vector<CompressedBlockMetadata> applyPrefilter(
-      std::span<const CompressedBlockMetadata> blocks) const;
+      ql::span<const CompressedBlockMetadata> blocks) const;
 
   // Helper functions for the public `getLazyScanFor...` methods and
   // `chunkedIndexScan` (see above).

--- a/src/engine/IndexScan.h
+++ b/src/engine/IndexScan.h
@@ -99,7 +99,7 @@ class IndexScan final : public Operation {
   // join between the first column of the result with the `joinColumn`.
   // Requires that the `joinColumn` is sorted, else the behavior is undefined.
   Permutation::IdTableGenerator lazyScanForJoinOfColumnWithScan(
-      std::span<const Id> joinColumn) const;
+      absl::Span<const Id> joinColumn) const;
 
   // Return two generators, the first of which yields exactly the elements of
   // `input` and the second of which yields the matching blocks, skipping the
@@ -219,7 +219,7 @@ class IndexScan final : public Operation {
 
   // Retrieve all the relevant `CompressedBlockMetadata` for this scan without
   // applying any additional pre-filter procedure.
-  std::optional<std::span<const CompressedBlockMetadata>> getBlockMetadata()
+  std::optional<absl::Span<const CompressedBlockMetadata>> getBlockMetadata()
       const;
 
   // This method retrieves all relevant `CompressedBlockMetadata` and performs
@@ -230,7 +230,7 @@ class IndexScan final : public Operation {
   // Apply the `prefilter_` to the `blocks`. May only be called if the limit is
   // unconstrained, and a `prefilter_` exists.
   std::vector<CompressedBlockMetadata> applyPrefilter(
-      std::span<const CompressedBlockMetadata> blocks) const;
+      absl::Span<const CompressedBlockMetadata> blocks) const;
 
   // Helper functions for the public `getLazyScanFor...` methods and
   // `chunkedIndexScan` (see above).

--- a/src/engine/IndexScan.h
+++ b/src/engine/IndexScan.h
@@ -99,7 +99,7 @@ class IndexScan final : public Operation {
   // join between the first column of the result with the `joinColumn`.
   // Requires that the `joinColumn` is sorted, else the behavior is undefined.
   Permutation::IdTableGenerator lazyScanForJoinOfColumnWithScan(
-      absl::Span<const Id> joinColumn) const;
+      std::span<const Id> joinColumn) const;
 
   // Return two generators, the first of which yields exactly the elements of
   // `input` and the second of which yields the matching blocks, skipping the
@@ -219,7 +219,7 @@ class IndexScan final : public Operation {
 
   // Retrieve all the relevant `CompressedBlockMetadata` for this scan without
   // applying any additional pre-filter procedure.
-  std::optional<absl::Span<const CompressedBlockMetadata>> getBlockMetadata()
+  std::optional<std::span<const CompressedBlockMetadata>> getBlockMetadata()
       const;
 
   // This method retrieves all relevant `CompressedBlockMetadata` and performs
@@ -230,7 +230,7 @@ class IndexScan final : public Operation {
   // Apply the `prefilter_` to the `blocks`. May only be called if the limit is
   // unconstrained, and a `prefilter_` exists.
   std::vector<CompressedBlockMetadata> applyPrefilter(
-      absl::Span<const CompressedBlockMetadata> blocks) const;
+      std::span<const CompressedBlockMetadata> blocks) const;
 
   // Helper functions for the public `getLazyScanFor...` methods and
   // `chunkedIndexScan` (see above).

--- a/src/engine/LocalVocab.cpp
+++ b/src/engine/LocalVocab.cpp
@@ -17,7 +17,7 @@ LocalVocab LocalVocab::clone() const {
 }
 
 // _____________________________________________________________________________
-LocalVocab LocalVocab::merge(std::span<const LocalVocab*> vocabs) {
+LocalVocab LocalVocab::merge(absl::Span<const LocalVocab*> vocabs) {
   LocalVocab result;
   result.mergeWith(vocabs | ql::views::transform(ad_utility::dereference));
   return result;

--- a/src/engine/LocalVocab.cpp
+++ b/src/engine/LocalVocab.cpp
@@ -17,7 +17,7 @@ LocalVocab LocalVocab::clone() const {
 }
 
 // _____________________________________________________________________________
-LocalVocab LocalVocab::merge(absl::Span<const LocalVocab*> vocabs) {
+LocalVocab LocalVocab::merge(ql::span<const LocalVocab*> vocabs) {
   LocalVocab result;
   result.mergeWith(vocabs | ql::views::transform(ad_utility::dereference));
   return result;
@@ -25,7 +25,7 @@ LocalVocab LocalVocab::merge(absl::Span<const LocalVocab*> vocabs) {
 
 // _____________________________________________________________________________
 void LocalVocab::mergeWith(const LocalVocab& other) {
-  mergeWith(std::span<const LocalVocab, 1>{&other, 1});
+  mergeWith(ql::span<const LocalVocab, 1>{&other, 1});
 }
 
 // _____________________________________________________________________________

--- a/src/engine/LocalVocab.h
+++ b/src/engine/LocalVocab.h
@@ -12,11 +12,11 @@
 #include <cstdlib>
 #include <memory>
 #include <ranges>
-#include <span>
 #include <string>
 #include <vector>
 
 #include "backports/algorithm.h"
+#include "backports/span.h"
 #include "index/LocalVocabEntry.h"
 #include "util/BlankNodeManager.h"
 #include "util/Exception.h"
@@ -165,7 +165,7 @@ class LocalVocab {
 
   // Create a new local vocab with empty set and other sets that are the union
   // of all sets (primary and other) of the given local vocabs.
-  static LocalVocab merge(absl::Span<const LocalVocab*> vocabs);
+  static LocalVocab merge(ql::span<const LocalVocab*> vocabs);
 
   // Return all the words from all the word sets as a vector. This is useful
   // for testing.

--- a/src/engine/LocalVocab.h
+++ b/src/engine/LocalVocab.h
@@ -165,7 +165,7 @@ class LocalVocab {
 
   // Create a new local vocab with empty set and other sets that are the union
   // of all sets (primary and other) of the given local vocabs.
-  static LocalVocab merge(std::span<const LocalVocab*> vocabs);
+  static LocalVocab merge(absl::Span<const LocalVocab*> vocabs);
 
   // Return all the words from all the word sets as a vector. This is useful
   // for testing.

--- a/src/engine/PathSearch.cpp
+++ b/src/engine/PathSearch.cpp
@@ -294,10 +294,10 @@ VariableToColumnMap PathSearch::computeVariableToColumnMap() const {
 };
 
 // _____________________________________________________________________________
-std::pair<std::span<const Id>, std::span<const Id>>
+std::pair<absl::Span<const Id>, absl::Span<const Id>>
 PathSearch::handleSearchSides() const {
-  std::span<const Id> sourceIds;
-  std::span<const Id> targetIds;
+  absl::Span<const Id> sourceIds;
+  absl::Span<const Id> targetIds;
 
   if (sourceAndTargetTree_.has_value()) {
     auto resultTable = sourceAndTargetTree_.value()->getResult();
@@ -387,7 +387,7 @@ PathsLimited PathSearch::findPaths(
 
 // _____________________________________________________________________________
 PathsLimited PathSearch::allPaths(
-    std::span<const Id> sources, std::span<const Id> targets,
+    absl::Span<const Id> sources, absl::Span<const Id> targets,
     const BinSearchWrapper& binSearch, bool cartesian,
     std::optional<uint64_t> numPathsPerTarget) const {
   PathsLimited paths{allocator()};

--- a/src/engine/PathSearch.cpp
+++ b/src/engine/PathSearch.cpp
@@ -405,7 +405,7 @@ PathsLimited PathSearch::allPaths(
       }
     }
   } else {
-    for (size_t i = 0; i < static_cast<size_t>(sources.size()); i++) {
+    for (size_t i = 0; i < sources.size(); i++) {
       for (const auto& path : findPaths(sources[i], {targets[i].getBits()},
                                         binSearch, numPathsPerTarget)) {
         paths.push_back(path);

--- a/src/engine/PathSearch.cpp
+++ b/src/engine/PathSearch.cpp
@@ -294,10 +294,10 @@ VariableToColumnMap PathSearch::computeVariableToColumnMap() const {
 };
 
 // _____________________________________________________________________________
-std::pair<absl::Span<const Id>, absl::Span<const Id>>
+std::pair<std::span<const Id>, std::span<const Id>>
 PathSearch::handleSearchSides() const {
-  absl::Span<const Id> sourceIds;
-  absl::Span<const Id> targetIds;
+  std::span<const Id> sourceIds;
+  std::span<const Id> targetIds;
 
   if (sourceAndTargetTree_.has_value()) {
     auto resultTable = sourceAndTargetTree_.value()->getResult();
@@ -387,7 +387,7 @@ PathsLimited PathSearch::findPaths(
 
 // _____________________________________________________________________________
 PathsLimited PathSearch::allPaths(
-    absl::Span<const Id> sources, absl::Span<const Id> targets,
+    std::span<const Id> sources, std::span<const Id> targets,
     const BinSearchWrapper& binSearch, bool cartesian,
     std::optional<uint64_t> numPathsPerTarget) const {
   PathsLimited paths{allocator()};

--- a/src/engine/PathSearch.cpp
+++ b/src/engine/PathSearch.cpp
@@ -294,10 +294,10 @@ VariableToColumnMap PathSearch::computeVariableToColumnMap() const {
 };
 
 // _____________________________________________________________________________
-std::pair<std::span<const Id>, std::span<const Id>>
+std::pair<ql::span<const Id>, ql::span<const Id>>
 PathSearch::handleSearchSides() const {
-  std::span<const Id> sourceIds;
-  std::span<const Id> targetIds;
+  ql::span<const Id> sourceIds;
+  ql::span<const Id> targetIds;
 
   if (sourceAndTargetTree_.has_value()) {
     auto resultTable = sourceAndTargetTree_.value()->getResult();
@@ -387,7 +387,7 @@ PathsLimited PathSearch::findPaths(
 
 // _____________________________________________________________________________
 PathsLimited PathSearch::allPaths(
-    std::span<const Id> sources, std::span<const Id> targets,
+    ql::span<const Id> sources, ql::span<const Id> targets,
     const BinSearchWrapper& binSearch, bool cartesian,
     std::optional<uint64_t> numPathsPerTarget) const {
   PathsLimited paths{allocator()};
@@ -405,7 +405,7 @@ PathsLimited PathSearch::allPaths(
       }
     }
   } else {
-    for (size_t i = 0; i < sources.size(); i++) {
+    for (size_t i = 0; i < static_cast<size_t>(sources.size()); i++) {
       for (const auto& path : findPaths(sources[i], {targets[i].getBits()},
                                         binSearch, numPathsPerTarget)) {
         paths.push_back(path);

--- a/src/engine/PathSearch.h
+++ b/src/engine/PathSearch.h
@@ -256,7 +256,7 @@ class PathSearch : public Operation {
  private:
   std::unique_ptr<Operation> cloneImpl() const override;
 
-  std::pair<std::span<const Id>, std::span<const Id>> handleSearchSides() const;
+  std::pair<ql::span<const Id>, ql::span<const Id>> handleSearchSides() const;
 
   /**
    * @brief Finds paths based on the configured algorithm.
@@ -272,7 +272,7 @@ class PathSearch : public Operation {
    * @return A vector of all paths.
    */
   pathSearch::PathsLimited allPaths(
-      std::span<const Id> sources, std::span<const Id> targets,
+      ql::span<const Id> sources, ql::span<const Id> targets,
       const pathSearch::BinSearchWrapper& binSearch, bool cartesian,
       std::optional<uint64_t> numPathsPerTarget) const;
 

--- a/src/engine/PathSearch.h
+++ b/src/engine/PathSearch.h
@@ -256,8 +256,7 @@ class PathSearch : public Operation {
  private:
   std::unique_ptr<Operation> cloneImpl() const override;
 
-  std::pair<absl::Span<const Id>, absl::Span<const Id>> handleSearchSides()
-      const;
+  std::pair<std::span<const Id>, std::span<const Id>> handleSearchSides() const;
 
   /**
    * @brief Finds paths based on the configured algorithm.
@@ -273,7 +272,7 @@ class PathSearch : public Operation {
    * @return A vector of all paths.
    */
   pathSearch::PathsLimited allPaths(
-      absl::Span<const Id> sources, absl::Span<const Id> targets,
+      std::span<const Id> sources, std::span<const Id> targets,
       const pathSearch::BinSearchWrapper& binSearch, bool cartesian,
       std::optional<uint64_t> numPathsPerTarget) const;
 

--- a/src/engine/PathSearch.h
+++ b/src/engine/PathSearch.h
@@ -7,10 +7,10 @@
 
 #include <memory>
 #include <optional>
-#include <span>
 #include <variant>
 #include <vector>
 
+#include "backports/span.h"
 #include "engine/Operation.h"
 #include "global/Id.h"
 #include "util/AllocatorWithLimit.h"

--- a/src/engine/PathSearch.h
+++ b/src/engine/PathSearch.h
@@ -256,7 +256,8 @@ class PathSearch : public Operation {
  private:
   std::unique_ptr<Operation> cloneImpl() const override;
 
-  std::pair<std::span<const Id>, std::span<const Id>> handleSearchSides() const;
+  std::pair<absl::Span<const Id>, absl::Span<const Id>> handleSearchSides()
+      const;
 
   /**
    * @brief Finds paths based on the configured algorithm.
@@ -272,7 +273,7 @@ class PathSearch : public Operation {
    * @return A vector of all paths.
    */
   pathSearch::PathsLimited allPaths(
-      std::span<const Id> sources, std::span<const Id> targets,
+      absl::Span<const Id> sources, absl::Span<const Id> targets,
       const pathSearch::BinSearchWrapper& binSearch, bool cartesian,
       std::optional<uint64_t> numPathsPerTarget) const;
 

--- a/src/engine/QueryExecutionTree.cpp
+++ b/src/engine/QueryExecutionTree.cpp
@@ -158,7 +158,7 @@ QueryExecutionTree::createSortedTreeAnyPermutation(
     std::shared_ptr<QueryExecutionTree> qet,
     const vector<ColumnIndex>& sortColumns) {
   const auto& sortedOn = qet->resultSortedOn();
-  ql::span relevantSortedCols{sortedOn.data(),
+  ql::span relevantSortedCols{sortedOn.begin(),
                               std::min(sortedOn.size(), sortColumns.size())};
   bool isSorted = ql::ranges::all_of(
       sortColumns, [relevantSortedCols](ColumnIndex distinctCol) {

--- a/src/engine/QueryExecutionTree.cpp
+++ b/src/engine/QueryExecutionTree.cpp
@@ -158,8 +158,8 @@ QueryExecutionTree::createSortedTreeAnyPermutation(
     std::shared_ptr<QueryExecutionTree> qet,
     const vector<ColumnIndex>& sortColumns) {
   const auto& sortedOn = qet->resultSortedOn();
-  std::span relevantSortedCols{sortedOn.begin(),
-                               std::min(sortedOn.size(), sortColumns.size())};
+  absl::Span relevantSortedCols{sortedOn.data(),
+                                std::min(sortedOn.size(), sortColumns.size())};
   bool isSorted = ql::ranges::all_of(
       sortColumns, [relevantSortedCols](ColumnIndex distinctCol) {
         return ad_utility::contains(relevantSortedCols, distinctCol);

--- a/src/engine/QueryExecutionTree.cpp
+++ b/src/engine/QueryExecutionTree.cpp
@@ -158,8 +158,8 @@ QueryExecutionTree::createSortedTreeAnyPermutation(
     std::shared_ptr<QueryExecutionTree> qet,
     const vector<ColumnIndex>& sortColumns) {
   const auto& sortedOn = qet->resultSortedOn();
-  absl::Span relevantSortedCols{sortedOn.data(),
-                                std::min(sortedOn.size(), sortColumns.size())};
+  std::span relevantSortedCols{sortedOn.begin(),
+                               std::min(sortedOn.size(), sortColumns.size())};
   bool isSorted = ql::ranges::all_of(
       sortColumns, [relevantSortedCols](ColumnIndex distinctCol) {
         return ad_utility::contains(relevantSortedCols, distinctCol);

--- a/src/engine/QueryExecutionTree.cpp
+++ b/src/engine/QueryExecutionTree.cpp
@@ -158,8 +158,14 @@ QueryExecutionTree::createSortedTreeAnyPermutation(
     std::shared_ptr<QueryExecutionTree> qet,
     const vector<ColumnIndex>& sortColumns) {
   const auto& sortedOn = qet->resultSortedOn();
-  std::span relevantSortedCols{sortedOn.begin(),
-                               std::min(sortedOn.size(), sortColumns.size())};
+#ifdef QLEVER_CPP_17
+  ql::span relevantSortedCols{
+      sortedOn.data(), static_cast<typename ql::span<ColumnIndex>::index_type>(
+                           std::min(sortedOn.size(), sortColumns.size()))};
+#else
+  ql::span relevantSortedCols{sortedOn.begin(),
+                              std::min(sortedOn.size(), sortColumns.size())};
+#endif
   bool isSorted = ql::ranges::all_of(
       sortColumns, [relevantSortedCols](ColumnIndex distinctCol) {
         return ad_utility::contains(relevantSortedCols, distinctCol);

--- a/src/engine/QueryExecutionTree.cpp
+++ b/src/engine/QueryExecutionTree.cpp
@@ -158,14 +158,8 @@ QueryExecutionTree::createSortedTreeAnyPermutation(
     std::shared_ptr<QueryExecutionTree> qet,
     const vector<ColumnIndex>& sortColumns) {
   const auto& sortedOn = qet->resultSortedOn();
-#ifdef QLEVER_CPP_17
-  ql::span relevantSortedCols{
-      sortedOn.data(), static_cast<typename ql::span<ColumnIndex>::index_type>(
-                           std::min(sortedOn.size(), sortColumns.size()))};
-#else
-  ql::span relevantSortedCols{sortedOn.begin(),
+  ql::span relevantSortedCols{sortedOn.data(),
                               std::min(sortedOn.size(), sortColumns.size())};
-#endif
   bool isSorted = ql::ranges::all_of(
       sortColumns, [relevantSortedCols](ColumnIndex distinctCol) {
         return ad_utility::contains(relevantSortedCols, distinctCol);

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -588,8 +588,7 @@ constexpr auto rewriteSingle = CPP_template_lambda()(typename T)(
 constexpr auto handleRepeatedVariablesImpl =
     [](const auto& triple, auto& addIndexScan,
        const auto& generateUniqueVarName, const auto& addFilter,
-       std::span<const Permutation::Enum> permutations,
-       auto... rewritePositions)
+       ql::span<const Permutation::Enum> permutations, auto... rewritePositions)
     -> CPP_ret(void)(
         requires(TriplePosition<decltype(rewritePositions)>&&...)) {
   auto scanTriple = triple;
@@ -632,7 +631,7 @@ void QueryPlanner::indexScanTwoVarsCase(
   auto generate = [this]() { return generateUniqueVarName(); };
   auto handleRepeatedVariables =
       [&triple, &addIndexScan, &addFilter, &generate](
-          std::span<const Permutation::Enum> permutations,
+          ql::span<const Permutation::Enum> permutations,
           auto... rewritePositions)
       -> CPP_ret(void)(
           requires(TriplePosition<decltype(rewritePositions)>&&...)) {
@@ -644,16 +643,21 @@ void QueryPlanner::indexScanTwoVarsCase(
   const auto& [s, p, o, _] = triple;
 
   using Tr = SparqlTripleSimple;
+
   if (!isVariable(s)) {
     if (p == o) {
-      handleRepeatedVariables({{SPO}}, &Tr::o_);
+      static const Permutation::Enum spoPerms[] = {SPO};
+      handleRepeatedVariables(ql::span<const Permutation::Enum>{spoPerms},
+                              &Tr::o_);
     } else {
       addIndexScan(SPO);
       addIndexScan(SOP);
     }
   } else if (!isVariable(p)) {
     if (s == o) {
-      handleRepeatedVariables({{PSO}}, &Tr::o_);
+      static const Permutation::Enum psoPerms[] = {PSO};
+      handleRepeatedVariables(ql::span<const Permutation::Enum>{psoPerms},
+                              &Tr::o_);
     } else {
       addIndexScan(PSO);
       addIndexScan(POS);
@@ -661,7 +665,9 @@ void QueryPlanner::indexScanTwoVarsCase(
   } else {
     AD_CORRECTNESS_CHECK(!isVariable(o));
     if (s == p) {
-      handleRepeatedVariables({{OPS}}, &Tr::s_);
+      static const Permutation::Enum opsPerms[] = {OPS};
+      handleRepeatedVariables(ql::span<const Permutation::Enum>{opsPerms},
+                              &Tr::s_);
     } else {
       addIndexScan(OSP);
       addIndexScan(OPS);
@@ -686,7 +692,7 @@ void QueryPlanner::indexScanThreeVarsCase(
   // add an index scan for the rewritten triple.
   auto handleRepeatedVariables =
       [&triple, &addIndexScan, &addFilter, &generate](
-          std::span<const Permutation::Enum> permutations,
+          ql::span<const Permutation::Enum> permutations,
           auto... rewritePositions)
       -> CPP_ret(void)(
           requires(TriplePosition<decltype(rewritePositions)>&&...)) {
@@ -700,14 +706,25 @@ void QueryPlanner::indexScanThreeVarsCase(
 
   if (s == o) {
     if (s == p) {
-      handleRepeatedVariables({{PSO}}, &Tr::o_, &Tr::s_);
+      static const Permutation::Enum psoPerms[] = {Permutation::Enum::PSO};
+      handleRepeatedVariables(ql::span<const Permutation::Enum>{psoPerms},
+                              &Tr::o_, &Tr::s_);
     } else {
-      handleRepeatedVariables({{POS, OPS}}, &Tr::s_);
+      static const Permutation::Enum posOpsPerms[] = {Permutation::Enum::POS,
+                                                      Permutation::Enum::OPS};
+      handleRepeatedVariables(ql::span<const Permutation::Enum>{posOpsPerms},
+                              &Tr::s_);
     }
   } else if (s == p) {
-    handleRepeatedVariables({{OPS, POS}}, &Tr::s_);
+    static const Permutation::Enum opsPosPerms[] = {Permutation::Enum::OPS,
+                                                    Permutation::Enum::POS};
+    handleRepeatedVariables(ql::span<const Permutation::Enum>{opsPosPerms},
+                            &Tr::s_);
   } else if (o == p) {
-    handleRepeatedVariables({{PSO, SPO}}, &Tr::o_);
+    static const Permutation::Enum psoSpoPerms[] = {Permutation::Enum::PSO,
+                                                    Permutation::Enum::SPO};
+    handleRepeatedVariables(ql::span<const Permutation::Enum>{psoSpoPerms},
+                            &Tr::o_);
   } else {
     // Three distinct variables
     // Add plans for all six permutations.
@@ -1030,7 +1047,7 @@ ParsedQuery::GraphPattern QueryPlanner::seedFromNegated(
     auto expression = makeNotEqualExpression(variable, iris.at(0));
     appendNotEqualString(descriptor, iris.at(0), variable);
     // Combine subsequent iris with a logical AND.
-    for (string_view iri : std::span{iris.begin() + 1, iris.end()}) {
+    for (const auto& iri : ql::views::drop(iris, 1)) {
       expression = makeAndExpression(std::move(expression),
                                      makeNotEqualExpression(variable, iri));
       descriptor << " && ";

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -1396,7 +1396,7 @@ size_t QueryPlanner::findUniqueNodeIds(
   // Check that all the `_idsOfIncludedNodes` are one-hot encodings of a single
   // value, i.e. they have exactly one bit set.
   AD_CORRECTNESS_CHECK(ql::ranges::all_of(
-      nodeIds, [](auto nodeId) { return std::popcount(nodeId) == 1; }));
+      nodeIds, [](auto nodeId) { return absl::popcount(nodeId) == 1; }));
   ql::ranges::copy(nodeIds, std::inserter(uniqueNodeIds, uniqueNodeIds.end()));
   return uniqueNodeIds.size();
 }

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -588,7 +588,7 @@ constexpr auto rewriteSingle = CPP_template_lambda()(typename T)(
 constexpr auto handleRepeatedVariablesImpl =
     [](const auto& triple, auto& addIndexScan,
        const auto& generateUniqueVarName, const auto& addFilter,
-       std::span<const Permutation::Enum> permutations,
+       absl::Span<const Permutation::Enum> permutations,
        auto... rewritePositions)
     -> CPP_ret(void)(
         requires(TriplePosition<decltype(rewritePositions)>&&...)) {
@@ -632,7 +632,7 @@ void QueryPlanner::indexScanTwoVarsCase(
   auto generate = [this]() { return generateUniqueVarName(); };
   auto handleRepeatedVariables =
       [&triple, &addIndexScan, &addFilter, &generate](
-          std::span<const Permutation::Enum> permutations,
+          absl::Span<const Permutation::Enum> permutations,
           auto... rewritePositions)
       -> CPP_ret(void)(
           requires(TriplePosition<decltype(rewritePositions)>&&...)) {
@@ -686,7 +686,7 @@ void QueryPlanner::indexScanThreeVarsCase(
   // add an index scan for the rewritten triple.
   auto handleRepeatedVariables =
       [&triple, &addIndexScan, &addFilter, &generate](
-          std::span<const Permutation::Enum> permutations,
+          absl::Span<const Permutation::Enum> permutations,
           auto... rewritePositions)
       -> CPP_ret(void)(
           requires(TriplePosition<decltype(rewritePositions)>&&...)) {
@@ -1030,7 +1030,7 @@ ParsedQuery::GraphPattern QueryPlanner::seedFromNegated(
     auto expression = makeNotEqualExpression(variable, iris.at(0));
     appendNotEqualString(descriptor, iris.at(0), variable);
     // Combine subsequent iris with a logical AND.
-    for (string_view iri : std::span{iris.begin() + 1, iris.end()}) {
+    for (string_view iri : absl::Span{iris.data() + 1, iris.size() - 1}) {
       expression = makeAndExpression(std::move(expression),
                                      makeNotEqualExpression(variable, iri));
       descriptor << " && ";

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -588,7 +588,7 @@ constexpr auto rewriteSingle = CPP_template_lambda()(typename T)(
 constexpr auto handleRepeatedVariablesImpl =
     [](const auto& triple, auto& addIndexScan,
        const auto& generateUniqueVarName, const auto& addFilter,
-       absl::Span<const Permutation::Enum> permutations,
+       std::span<const Permutation::Enum> permutations,
        auto... rewritePositions)
     -> CPP_ret(void)(
         requires(TriplePosition<decltype(rewritePositions)>&&...)) {
@@ -632,7 +632,7 @@ void QueryPlanner::indexScanTwoVarsCase(
   auto generate = [this]() { return generateUniqueVarName(); };
   auto handleRepeatedVariables =
       [&triple, &addIndexScan, &addFilter, &generate](
-          absl::Span<const Permutation::Enum> permutations,
+          std::span<const Permutation::Enum> permutations,
           auto... rewritePositions)
       -> CPP_ret(void)(
           requires(TriplePosition<decltype(rewritePositions)>&&...)) {
@@ -686,7 +686,7 @@ void QueryPlanner::indexScanThreeVarsCase(
   // add an index scan for the rewritten triple.
   auto handleRepeatedVariables =
       [&triple, &addIndexScan, &addFilter, &generate](
-          absl::Span<const Permutation::Enum> permutations,
+          std::span<const Permutation::Enum> permutations,
           auto... rewritePositions)
       -> CPP_ret(void)(
           requires(TriplePosition<decltype(rewritePositions)>&&...)) {
@@ -1030,7 +1030,7 @@ ParsedQuery::GraphPattern QueryPlanner::seedFromNegated(
     auto expression = makeNotEqualExpression(variable, iris.at(0));
     appendNotEqualString(descriptor, iris.at(0), variable);
     // Combine subsequent iris with a logical AND.
-    for (string_view iri : absl::Span{iris.data() + 1, iris.size() - 1}) {
+    for (string_view iri : std::span{iris.begin() + 1, iris.end()}) {
       expression = makeAndExpression(std::move(expression),
                                      makeNotEqualExpression(variable, iri));
       descriptor << " && ";

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -646,18 +646,14 @@ void QueryPlanner::indexScanTwoVarsCase(
 
   if (!isVariable(s)) {
     if (p == o) {
-      static const Permutation::Enum spoPerms[] = {SPO};
-      handleRepeatedVariables(ql::span<const Permutation::Enum>{spoPerms},
-                              &Tr::o_);
+      handleRepeatedVariables({{SPO}}, &Tr::o_);
     } else {
       addIndexScan(SPO);
       addIndexScan(SOP);
     }
   } else if (!isVariable(p)) {
     if (s == o) {
-      static const Permutation::Enum psoPerms[] = {PSO};
-      handleRepeatedVariables(ql::span<const Permutation::Enum>{psoPerms},
-                              &Tr::o_);
+      handleRepeatedVariables({{PSO}}, &Tr::o_);
     } else {
       addIndexScan(PSO);
       addIndexScan(POS);
@@ -665,9 +661,7 @@ void QueryPlanner::indexScanTwoVarsCase(
   } else {
     AD_CORRECTNESS_CHECK(!isVariable(o));
     if (s == p) {
-      static const Permutation::Enum opsPerms[] = {OPS};
-      handleRepeatedVariables(ql::span<const Permutation::Enum>{opsPerms},
-                              &Tr::s_);
+      handleRepeatedVariables({{OPS}}, &Tr::s_);
     } else {
       addIndexScan(OSP);
       addIndexScan(OPS);
@@ -706,25 +700,14 @@ void QueryPlanner::indexScanThreeVarsCase(
 
   if (s == o) {
     if (s == p) {
-      static const Permutation::Enum psoPerms[] = {Permutation::Enum::PSO};
-      handleRepeatedVariables(ql::span<const Permutation::Enum>{psoPerms},
-                              &Tr::o_, &Tr::s_);
+      handleRepeatedVariables({{PSO}}, &Tr::o_, &Tr::s_);
     } else {
-      static const Permutation::Enum posOpsPerms[] = {Permutation::Enum::POS,
-                                                      Permutation::Enum::OPS};
-      handleRepeatedVariables(ql::span<const Permutation::Enum>{posOpsPerms},
-                              &Tr::s_);
+      handleRepeatedVariables({{POS, OPS}}, &Tr::s_);
     }
   } else if (s == p) {
-    static const Permutation::Enum opsPosPerms[] = {Permutation::Enum::OPS,
-                                                    Permutation::Enum::POS};
-    handleRepeatedVariables(ql::span<const Permutation::Enum>{opsPosPerms},
-                            &Tr::s_);
+    handleRepeatedVariables({{OPS, POS}}, &Tr::s_);
   } else if (o == p) {
-    static const Permutation::Enum psoSpoPerms[] = {Permutation::Enum::PSO,
-                                                    Permutation::Enum::SPO};
-    handleRepeatedVariables(ql::span<const Permutation::Enum>{psoSpoPerms},
-                            &Tr::o_);
+    handleRepeatedVariables({{PSO, SPO}}, &Tr::o_);
   } else {
     // Three distinct variables
     // Add plans for all six permutations.

--- a/src/engine/Result.cpp
+++ b/src/engine/Result.cpp
@@ -117,7 +117,7 @@ void resizeIdTable(IdTable& idTable, const LimitOffsetClause& limitOffset) {
       idTable.getColumns(),
       [offset = limitOffset.actualOffset(idTable.numRows()),
        upperBound =
-           limitOffset.upperBound(idTable.numRows())](std::span<Id> column) {
+           limitOffset.upperBound(idTable.numRows())](ql::span<Id> column) {
         std::shift_left(column.begin(), column.begin() + upperBound, offset);
       });
   // Resize the `IdTable` if necessary.

--- a/src/engine/Result.cpp
+++ b/src/engine/Result.cpp
@@ -117,7 +117,7 @@ void resizeIdTable(IdTable& idTable, const LimitOffsetClause& limitOffset) {
       idTable.getColumns(),
       [offset = limitOffset.actualOffset(idTable.numRows()),
        upperBound =
-           limitOffset.upperBound(idTable.numRows())](absl::Span<Id> column) {
+           limitOffset.upperBound(idTable.numRows())](std::span<Id> column) {
         std::shift_left(column.begin(), column.begin() + upperBound, offset);
       });
   // Resize the `IdTable` if necessary.

--- a/src/engine/Result.cpp
+++ b/src/engine/Result.cpp
@@ -117,7 +117,7 @@ void resizeIdTable(IdTable& idTable, const LimitOffsetClause& limitOffset) {
       idTable.getColumns(),
       [offset = limitOffset.actualOffset(idTable.numRows()),
        upperBound =
-           limitOffset.upperBound(idTable.numRows())](std::span<Id> column) {
+           limitOffset.upperBound(idTable.numRows())](absl::Span<Id> column) {
         std::shift_left(column.begin(), column.begin() + upperBound, offset);
       });
   // Resize the `IdTable` if necessary.

--- a/src/engine/Result.h
+++ b/src/engine/Result.h
@@ -12,6 +12,7 @@
 #include <variant>
 #include <vector>
 
+#include "backports/span.h"
 #include "engine/LocalVocab.h"
 #include "engine/VariableToColumnMap.h"
 #include "engine/idTable/IdTable.h"
@@ -214,8 +215,7 @@ class Result {
     for (const Result& table : subResults) {
       vocabs.push_back(&table.localVocab());
     }
-    absl::Span<const LocalVocab*> vocabsSpan(vocabs.data(), vocabs.size());
-    return SharedLocalVocabWrapper{LocalVocab::merge(vocabsSpan)};
+    return SharedLocalVocabWrapper{LocalVocab::merge(vocabs)};
   }
 
   // Get a (deep) copy of the local vocabulary from the given result. Use this

--- a/src/engine/Result.h
+++ b/src/engine/Result.h
@@ -214,7 +214,8 @@ class Result {
     for (const Result& table : subResults) {
       vocabs.push_back(&table.localVocab());
     }
-    return SharedLocalVocabWrapper{LocalVocab::merge(vocabs)};
+    absl::Span<const LocalVocab*> vocabsSpan(vocabs.data(), vocabs.size());
+    return SharedLocalVocabWrapper{LocalVocab::merge(vocabsSpan)};
   }
 
   // Get a (deep) copy of the local vocabulary from the given result. Use this

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -3,6 +3,8 @@
 // Authors: Björn Buchhold <b.buchhold@gmail.com>
 //          Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
 //          Hannah Bast <bast@cs.uni-freiburg.de>
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #include "engine/Server.h"
 
@@ -10,6 +12,7 @@
 #include <sstream>
 #include <string>
 #include <vector>
+#include <absl/functional/bind_front.h>
 
 #include "GraphStoreProtocol.h"
 #include "engine/ExecuteUpdate.h"
@@ -300,7 +303,7 @@ CPP_template_2(typename RequestT, typename ResponseT)(
 
   // We always want to call `Server::checkParameter` with the same first
   // parameter.
-  auto checkParameter = std::bind_front(&ad_utility::url_parser::checkParameter,
+  auto checkParameter = absl::bind_front(&ad_utility::url_parser::checkParameter,
                                         std::cref(parameters));
 
   // Check the access token. If an access token is provided and the check fails,

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -12,6 +12,7 @@
 #include <sstream>
 #include <string>
 #include <vector>
+#include <absl/functional/bind_front.h>
 
 #include "GraphStoreProtocol.h"
 #include "engine/ExecuteUpdate.h"
@@ -302,8 +303,8 @@ CPP_template_2(typename RequestT, typename ResponseT)(
 
   // We always want to call `Server::checkParameter` with the same first
   // parameter.
-  auto checkParameter = absl::bind_front(
-      &ad_utility::url_parser::checkParameter, std::cref(parameters));
+  auto checkParameter = absl::bind_front(&ad_utility::url_parser::checkParameter,
+                                        std::cref(parameters));
 
   // Check the access token. If an access token is provided and the check fails,
   // throw an exception and do not process any part of the query (even if the

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -12,7 +12,6 @@
 #include <sstream>
 #include <string>
 #include <vector>
-#include <absl/functional/bind_front.h>
 
 #include "GraphStoreProtocol.h"
 #include "engine/ExecuteUpdate.h"
@@ -303,8 +302,8 @@ CPP_template_2(typename RequestT, typename ResponseT)(
 
   // We always want to call `Server::checkParameter` with the same first
   // parameter.
-  auto checkParameter = absl::bind_front(&ad_utility::url_parser::checkParameter,
-                                        std::cref(parameters));
+  auto checkParameter = absl::bind_front(
+      &ad_utility::url_parser::checkParameter, std::cref(parameters));
 
   // Check the access token. If an access token is provided and the check fails,
   // throw an exception and do not process any part of the query (even if the

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -8,11 +8,12 @@
 
 #include "engine/Server.h"
 
+#include <absl/functional/bind_front.h>
+
 #include <boost/url.hpp>
 #include <sstream>
 #include <string>
 #include <vector>
-#include <absl/functional/bind_front.h>
 
 #include "GraphStoreProtocol.h"
 #include "engine/ExecuteUpdate.h"
@@ -303,8 +304,8 @@ CPP_template_2(typename RequestT, typename ResponseT)(
 
   // We always want to call `Server::checkParameter` with the same first
   // parameter.
-  auto checkParameter = absl::bind_front(&ad_utility::url_parser::checkParameter,
-                                        std::cref(parameters));
+  auto checkParameter = absl::bind_front(
+      &ad_utility::url_parser::checkParameter, std::cref(parameters));
 
   // Check the access token. If an access token is provided and the check fails,
   // throw an exception and do not process any part of the query (even if the

--- a/src/engine/SortedUnionImpl.h
+++ b/src/engine/SortedUnionImpl.h
@@ -7,6 +7,7 @@
 
 #include <optional>
 
+#include "backports/span.h"
 #include "engine/LocalVocab.h"
 #include "engine/Result.h"
 #include "engine/Union.h"
@@ -118,7 +119,7 @@ struct SortedUnionImpl
                   bool requestLaziness,
                   const std::vector<std::array<size_t, 2>>& columnOrigins,
                   const ad_utility::AllocatorWithLimit<Id>& allocator,
-                  std::span<const ColumnIndex, SPAN_SIZE> comparatorView,
+                  ql::span<const ColumnIndex, SPAN_SIZE> comparatorView,
                   Func applyPermutation)
       : data1_{std::move(data1)},
         data2_{std::move(data2)},
@@ -139,7 +140,7 @@ struct SortedUnionImpl
   // Always inline makes makes a huge difference on large datasets.
   template <typename T1, typename T2>
   AD_ALWAYS_INLINE bool isSmaller(const T1& row1, const T2& row2) const {
-    using StaticRange = std::span<const std::array<size_t, 2>, SPAN_SIZE>;
+    using StaticRange = ql::span<const std::array<size_t, 2>, SPAN_SIZE>;
     for (auto [index1, index2] : StaticRange{targetOrder_}) {
       if (index1 == Union::NO_COLUMN) {
         return true;
@@ -243,7 +244,7 @@ template <size_t SPAN_SIZE, typename Range1, typename Range2, typename Func>
 SortedUnionImpl(IterationData<Range1>, IterationData<Range2>, bool,
                 const std::vector<std::array<size_t, 2>>&,
                 const ad_utility::AllocatorWithLimit<Id>&,
-                std::span<const ColumnIndex, SPAN_SIZE>, Func)
+                ql::span<const ColumnIndex, SPAN_SIZE>, Func)
     -> SortedUnionImpl<SPAN_SIZE, Range1, Range2, Func>;
 }  // namespace sortedUnion
 

--- a/src/engine/SortedUnionImpl.h
+++ b/src/engine/SortedUnionImpl.h
@@ -119,7 +119,7 @@ struct SortedUnionImpl
                   bool requestLaziness,
                   const std::vector<std::array<size_t, 2>>& columnOrigins,
                   const ad_utility::AllocatorWithLimit<Id>& allocator,
-                  ql::span<const ColumnIndex, SPAN_SIZE> comparatorView,
+                  std::span<const ColumnIndex, SPAN_SIZE> comparatorView,
                   Func applyPermutation)
       : data1_{std::move(data1)},
         data2_{std::move(data2)},
@@ -140,7 +140,7 @@ struct SortedUnionImpl
   // Always inline makes makes a huge difference on large datasets.
   template <typename T1, typename T2>
   AD_ALWAYS_INLINE bool isSmaller(const T1& row1, const T2& row2) const {
-    using StaticRange = ql::span<const std::array<size_t, 2>, SPAN_SIZE>;
+    using StaticRange = std::span<const std::array<size_t, 2>, SPAN_SIZE>;
     for (auto [index1, index2] : StaticRange{targetOrder_}) {
       if (index1 == Union::NO_COLUMN) {
         return true;
@@ -244,7 +244,7 @@ template <size_t SPAN_SIZE, typename Range1, typename Range2, typename Func>
 SortedUnionImpl(IterationData<Range1>, IterationData<Range2>, bool,
                 const std::vector<std::array<size_t, 2>>&,
                 const ad_utility::AllocatorWithLimit<Id>&,
-                ql::span<const ColumnIndex, SPAN_SIZE>, Func)
+                std::span<const ColumnIndex, SPAN_SIZE>, Func)
     -> SortedUnionImpl<SPAN_SIZE, Range1, Range2, Func>;
 }  // namespace sortedUnion
 

--- a/src/engine/SortedUnionImpl.h
+++ b/src/engine/SortedUnionImpl.h
@@ -119,7 +119,7 @@ struct SortedUnionImpl
                   bool requestLaziness,
                   const std::vector<std::array<size_t, 2>>& columnOrigins,
                   const ad_utility::AllocatorWithLimit<Id>& allocator,
-                  std::span<const ColumnIndex, SPAN_SIZE> comparatorView,
+                  ql::span<const ColumnIndex, SPAN_SIZE> comparatorView,
                   Func applyPermutation)
       : data1_{std::move(data1)},
         data2_{std::move(data2)},
@@ -140,7 +140,7 @@ struct SortedUnionImpl
   // Always inline makes makes a huge difference on large datasets.
   template <typename T1, typename T2>
   AD_ALWAYS_INLINE bool isSmaller(const T1& row1, const T2& row2) const {
-    using StaticRange = std::span<const std::array<size_t, 2>, SPAN_SIZE>;
+    using StaticRange = ql::span<const std::array<size_t, 2>, SPAN_SIZE>;
     for (auto [index1, index2] : StaticRange{targetOrder_}) {
       if (index1 == Union::NO_COLUMN) {
         return true;
@@ -244,7 +244,7 @@ template <size_t SPAN_SIZE, typename Range1, typename Range2, typename Func>
 SortedUnionImpl(IterationData<Range1>, IterationData<Range2>, bool,
                 const std::vector<std::array<size_t, 2>>&,
                 const ad_utility::AllocatorWithLimit<Id>&,
-                std::span<const ColumnIndex, SPAN_SIZE>, Func)
+                ql::span<const ColumnIndex, SPAN_SIZE>, Func)
     -> SortedUnionImpl<SPAN_SIZE, Range1, Range2, Func>;
 }  // namespace sortedUnion
 

--- a/src/engine/TransitivePathBase.h
+++ b/src/engine/TransitivePathBase.h
@@ -323,7 +323,7 @@ class TransitivePathBase : public Operation {
   // right side is bound. This is used by the `TransitivePathBinSearch` class,
   // which has to store both ways to sort the subtree until it knows which side
   // becomes bound.
-  virtual std::span<const std::shared_ptr<QueryExecutionTree>>
+  virtual ql::span<const std::shared_ptr<QueryExecutionTree>>
   alternativeSubtrees() const {
     return {};
   }

--- a/src/engine/TransitivePathBase.h
+++ b/src/engine/TransitivePathBase.h
@@ -323,7 +323,7 @@ class TransitivePathBase : public Operation {
   // right side is bound. This is used by the `TransitivePathBinSearch` class,
   // which has to store both ways to sort the subtree until it knows which side
   // becomes bound.
-  virtual std::span<const std::shared_ptr<QueryExecutionTree>>
+  virtual absl::Span<const std::shared_ptr<QueryExecutionTree>>
   alternativeSubtrees() const {
     return {};
   }

--- a/src/engine/TransitivePathBase.h
+++ b/src/engine/TransitivePathBase.h
@@ -323,7 +323,7 @@ class TransitivePathBase : public Operation {
   // right side is bound. This is used by the `TransitivePathBinSearch` class,
   // which has to store both ways to sort the subtree until it knows which side
   // becomes bound.
-  virtual absl::Span<const std::shared_ptr<QueryExecutionTree>>
+  virtual std::span<const std::shared_ptr<QueryExecutionTree>>
   alternativeSubtrees() const {
     return {};
   }

--- a/src/engine/TransitivePathBinSearch.h
+++ b/src/engine/TransitivePathBinSearch.h
@@ -35,8 +35,8 @@
  *
  */
 struct BinSearchMap {
-  std::span<const Id> startIds_;
-  std::span<const Id> targetIds_;
+  ql::span<const Id> startIds_;
+  ql::span<const Id> targetIds_;
 
   /**
    * @brief Return the successors for the given id.
@@ -44,7 +44,7 @@ struct BinSearchMap {
    * equal to the given id `node`.
    *
    * @param node The input id, which will be looked up in startIds_
-   * @return A std::span<Id>, which consists of all targetIds_ where
+   * @return A ql::span<Id>, which consists of all targetIds_ where
    * startIds_ == node.
    */
   auto successors(const Id node) const {
@@ -94,7 +94,7 @@ class TransitivePathBinSearch : public TransitivePathImpl<BinSearchMap> {
   // is bound. When the left side is bound, we already have the correct
   // ordering.
   std::shared_ptr<QueryExecutionTree> alternativelySortedSubtree_;
-  std::span<const std::shared_ptr<QueryExecutionTree>> alternativeSubtrees()
+  ql::span<const std::shared_ptr<QueryExecutionTree>> alternativeSubtrees()
       const override {
     return {&alternativelySortedSubtree_, 1};
   }

--- a/src/engine/TransitivePathBinSearch.h
+++ b/src/engine/TransitivePathBinSearch.h
@@ -35,8 +35,8 @@
  *
  */
 struct BinSearchMap {
-  std::span<const Id> startIds_;
-  std::span<const Id> targetIds_;
+  absl::Span<const Id> startIds_;
+  absl::Span<const Id> targetIds_;
 
   /**
    * @brief Return the successors for the given id.
@@ -44,7 +44,7 @@ struct BinSearchMap {
    * equal to the given id `node`.
    *
    * @param node The input id, which will be looked up in startIds_
-   * @return A std::span<Id>, which consists of all targetIds_ where
+   * @return A absl::Span<Id>, which consists of all targetIds_ where
    * startIds_ == node.
    */
   auto successors(const Id node) const {
@@ -94,7 +94,7 @@ class TransitivePathBinSearch : public TransitivePathImpl<BinSearchMap> {
   // is bound. When the left side is bound, we already have the correct
   // ordering.
   std::shared_ptr<QueryExecutionTree> alternativelySortedSubtree_;
-  std::span<const std::shared_ptr<QueryExecutionTree>> alternativeSubtrees()
+  absl::Span<const std::shared_ptr<QueryExecutionTree>> alternativeSubtrees()
       const override {
     return {&alternativelySortedSubtree_, 1};
   }

--- a/src/engine/TransitivePathBinSearch.h
+++ b/src/engine/TransitivePathBinSearch.h
@@ -35,8 +35,8 @@
  *
  */
 struct BinSearchMap {
-  absl::Span<const Id> startIds_;
-  absl::Span<const Id> targetIds_;
+  std::span<const Id> startIds_;
+  std::span<const Id> targetIds_;
 
   /**
    * @brief Return the successors for the given id.
@@ -44,7 +44,7 @@ struct BinSearchMap {
    * equal to the given id `node`.
    *
    * @param node The input id, which will be looked up in startIds_
-   * @return A absl::Span<Id>, which consists of all targetIds_ where
+   * @return A std::span<Id>, which consists of all targetIds_ where
    * startIds_ == node.
    */
   auto successors(const Id node) const {
@@ -94,7 +94,7 @@ class TransitivePathBinSearch : public TransitivePathImpl<BinSearchMap> {
   // is bound. When the left side is bound, we already have the correct
   // ordering.
   std::shared_ptr<QueryExecutionTree> alternativelySortedSubtree_;
-  absl::Span<const std::shared_ptr<QueryExecutionTree>> alternativeSubtrees()
+  std::span<const std::shared_ptr<QueryExecutionTree>> alternativeSubtrees()
       const override {
     return {&alternativelySortedSubtree_, 1};
   }

--- a/src/engine/TransitivePathImpl.h
+++ b/src/engine/TransitivePathImpl.h
@@ -122,10 +122,7 @@ class TransitivePathImpl : public TransitivePathBase {
     NodeGenerator hull = transitiveHull(
         edges, sub->getCopyOfLocalVocab(),
         absl::Span<detail::TableColumnWithVocab<const Set&>>(&tableInfo, 1),
-        targetSide.isVariable()
-            ? std::nullopt
-            : std::optional{std::get<Id>(targetSide.value_)},
-        yieldOnce);
+        targetSide.value_, yieldOnce);
 
     auto result = fillTableWithHull(std::move(hull), startSide.outputCol_,
                                     targetSide.outputCol_, yieldOnce);
@@ -277,7 +274,7 @@ class TransitivePathImpl : public TransitivePathBase {
    */
   std::vector<absl::Span<const Id>> setupNodes(
       const IdTable& sub, const TransitivePathSide& startSide,
-      const TransitivePathSide& targetSidem, const T& edges) const {
+      const TransitivePathSide& targetSide, const T& edges) const {
     std::vector<absl::Span<const Id>> result;
 
     // id -> var|id

--- a/src/engine/TransitivePathImpl.h
+++ b/src/engine/TransitivePathImpl.h
@@ -42,8 +42,7 @@ struct TableColumnWithVocab {
  */
 template <typename T>
 class TransitivePathImpl : public TransitivePathBase {
-  using TableColumnWithVocab =
-      detail::TableColumnWithVocab<std::span<const Id>>;
+  using TableColumnWithVocab = detail::TableColumnWithVocab<ql::span<const Id>>;
 
  public:
   using TransitivePathBase::TransitivePathBase;
@@ -123,7 +122,7 @@ class TransitivePathImpl : public TransitivePathBase {
 
     NodeGenerator hull =
         transitiveHull(edges, sub->getCopyOfLocalVocab(),
-                       std::span{&tableInfo, 1}, targetSide.value_, yieldOnce);
+                       ql::span{&tableInfo, 1}, targetSide.value_, yieldOnce);
 
     auto result = fillTableWithHull(std::move(hull), startSide.outputCol_,
                                     targetSide.outputCol_, yieldOnce);
@@ -270,13 +269,13 @@ class TransitivePathImpl : public TransitivePathBase {
    * @param sub The sub table result
    * @param startSide The TransitivePathSide where the edges start
    * @param targetSide The TransitivePathSide where the edges end
-   * @return std::vector<std::span<const Id>> An vector of spans of (nodes) for
-   * the transitive hull computation
+   * @return std::vector<ql::span<const Id>> An vector of spans of (nodes)
+   * for the transitive hull computation
    */
-  std::vector<std::span<const Id>> setupNodes(
+  std::vector<ql::span<const Id>> setupNodes(
       const IdTable& sub, const TransitivePathSide& startSide,
       const TransitivePathSide& targetSide, const T& edges) const {
-    std::vector<std::span<const Id>> result;
+    std::vector<ql::span<const Id>> result;
 
     // id -> var|id
     if (!startSide.isVariable()) {
@@ -294,10 +293,10 @@ class TransitivePathImpl : public TransitivePathBase {
       }
       // var -> var
     } else {
-      std::span<const Id> startNodes = sub.getColumn(startSide.subCol_);
+      ql::span<const Id> startNodes = sub.getColumn(startSide.subCol_);
       result.emplace_back(startNodes);
       if (minDist_ == 0) {
-        std::span<const Id> targetNodes = sub.getColumn(targetSide.subCol_);
+        ql::span<const Id> targetNodes = sub.getColumn(targetSide.subCol_);
         result.emplace_back(targetNodes);
       }
     }
@@ -320,14 +319,14 @@ class TransitivePathImpl : public TransitivePathBase {
       std::shared_ptr<const Result> startSideResult) {
     if (startSideResult->isFullyMaterialized()) {
       // Bound -> var|id
-      std::span<const Id> startNodes = startSideResult->idTable().getColumn(
+      ql::span<const Id> startNodes = startSideResult->idTable().getColumn(
           startSide.treeAndCol_.value().second);
       co_yield TableColumnWithVocab{&startSideResult->idTable(), startNodes,
                                     startSideResult->getCopyOfLocalVocab()};
     } else {
       for (auto& [idTable, localVocab] : startSideResult->idTables()) {
         // Bound -> var|id
-        std::span<const Id> startNodes =
+        ql::span<const Id> startNodes =
             idTable.getColumn(startSide.treeAndCol_.value().second);
         co_yield TableColumnWithVocab{&idTable, startNodes,
                                       std::move(localVocab)};

--- a/src/engine/TransitivePathImpl.h
+++ b/src/engine/TransitivePathImpl.h
@@ -1,6 +1,8 @@
 // Copyright 2024, University of Freiburg,
 // Chair of Algorithms and Data Structures.
 // Author: Johannes Herrmann (johannes.r.herrmann(at)gmail.com)
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_SRC_ENGINE_TRANSITIVEPATHIMPL_H
 #define QLEVER_SRC_ENGINE_TRANSITIVEPATHIMPL_H

--- a/src/engine/TransitivePathImpl.h
+++ b/src/engine/TransitivePathImpl.h
@@ -43,7 +43,7 @@ struct TableColumnWithVocab {
 template <typename T>
 class TransitivePathImpl : public TransitivePathBase {
   using TableColumnWithVocab =
-      detail::TableColumnWithVocab<absl::Span<const Id>>;
+      detail::TableColumnWithVocab<std::span<const Id>>;
 
  public:
   using TransitivePathBase::TransitivePathBase;
@@ -121,10 +121,9 @@ class TransitivePathImpl : public TransitivePathBase {
     detail::TableColumnWithVocab<const Set&> tableInfo{
         nullptr, nodesWithoutDuplicates, LocalVocab{}};
 
-    NodeGenerator hull = transitiveHull(
-        edges, sub->getCopyOfLocalVocab(),
-        absl::Span<detail::TableColumnWithVocab<const Set&>>(&tableInfo, 1),
-        targetSide.value_, yieldOnce);
+    NodeGenerator hull =
+        transitiveHull(edges, sub->getCopyOfLocalVocab(),
+                       std::span{&tableInfo, 1}, targetSide.value_, yieldOnce);
 
     auto result = fillTableWithHull(std::move(hull), startSide.outputCol_,
                                     targetSide.outputCol_, yieldOnce);
@@ -271,13 +270,13 @@ class TransitivePathImpl : public TransitivePathBase {
    * @param sub The sub table result
    * @param startSide The TransitivePathSide where the edges start
    * @param targetSide The TransitivePathSide where the edges end
-   * @return std::vector<absl::Span<const Id>> An vector of spans of (nodes) for
+   * @return std::vector<std::span<const Id>> An vector of spans of (nodes) for
    * the transitive hull computation
    */
-  std::vector<absl::Span<const Id>> setupNodes(
+  std::vector<std::span<const Id>> setupNodes(
       const IdTable& sub, const TransitivePathSide& startSide,
       const TransitivePathSide& targetSide, const T& edges) const {
-    std::vector<absl::Span<const Id>> result;
+    std::vector<std::span<const Id>> result;
 
     // id -> var|id
     if (!startSide.isVariable()) {
@@ -295,10 +294,10 @@ class TransitivePathImpl : public TransitivePathBase {
       }
       // var -> var
     } else {
-      absl::Span<const Id> startNodes = sub.getColumn(startSide.subCol_);
+      std::span<const Id> startNodes = sub.getColumn(startSide.subCol_);
       result.emplace_back(startNodes);
       if (minDist_ == 0) {
-        absl::Span<const Id> targetNodes = sub.getColumn(targetSide.subCol_);
+        std::span<const Id> targetNodes = sub.getColumn(targetSide.subCol_);
         result.emplace_back(targetNodes);
       }
     }
@@ -321,14 +320,14 @@ class TransitivePathImpl : public TransitivePathBase {
       std::shared_ptr<const Result> startSideResult) {
     if (startSideResult->isFullyMaterialized()) {
       // Bound -> var|id
-      absl::Span<const Id> startNodes = startSideResult->idTable().getColumn(
+      std::span<const Id> startNodes = startSideResult->idTable().getColumn(
           startSide.treeAndCol_.value().second);
       co_yield TableColumnWithVocab{&startSideResult->idTable(), startNodes,
                                     startSideResult->getCopyOfLocalVocab()};
     } else {
       for (auto& [idTable, localVocab] : startSideResult->idTables()) {
         // Bound -> var|id
-        absl::Span<const Id> startNodes =
+        std::span<const Id> startNodes =
             idTable.getColumn(startSide.treeAndCol_.value().second);
         co_yield TableColumnWithVocab{&idTable, startNodes,
                                       std::move(localVocab)};

--- a/src/engine/Union.cpp
+++ b/src/engine/Union.cpp
@@ -5,6 +5,7 @@
 //   2022-    Johannes Kalmbach (kalmbach@informatik.uni-freiburg.de)
 #include "Union.h"
 
+#include "backports/span.h"
 #include "engine/CallFixedSize.h"
 #include "engine/SortedUnionImpl.h"
 #include "util/ChunkedForLoop.h"
@@ -387,8 +388,8 @@ Result::LazyResult Union::computeResultKeepOrder(
     const auto& [left, right] = _columnOrigins.at(index);
     return left == NO_COLUMN || right == NO_COLUMN;
   });
-  std::span trimmedTargetOrder{targetOrder_.begin(),
-                               end == targetOrder_.end() ? end : end + 1};
+  ql::span trimmedTargetOrder{targetOrder_.begin(),
+                              end == targetOrder_.end() ? end : end + 1};
 
   auto applyPermutation = [this](IdTable idTable,
                                  const std::vector<ColumnIndex>& permutation) {
@@ -414,7 +415,7 @@ Result::LazyResult Union::computeResultKeepOrder(
               return Result::LazyResult{sortedUnion::SortedUnionImpl{
                   std::move(leftData), std::move(rightData), requestLaziness,
                   _columnOrigins, allocator(),
-                  std::span<const ColumnIndex, extent>{trimmedTargetOrder},
+                  ql::span<const ColumnIndex, extent>{trimmedTargetOrder},
                   std::move(applyPermutation)}};
             });
       },

--- a/src/engine/Union.cpp
+++ b/src/engine/Union.cpp
@@ -388,8 +388,11 @@ Result::LazyResult Union::computeResultKeepOrder(
     const auto& [left, right] = _columnOrigins.at(index);
     return left == NO_COLUMN || right == NO_COLUMN;
   });
-  std::span trimmedTargetOrder{targetOrder_.begin(),
-                               end == targetOrder_.end() ? end : end + 1};
+  // TODO<joka921> If we fix ql::span to accept also pairs of iterators, then
+  // the following can be much simpler.
+  ql::span trimmedTargetOrder{
+      targetOrder_.data(),
+      (end == targetOrder_.end() ? end : end + 1) - targetOrder_.begin()};
 
   auto applyPermutation = [this](IdTable idTable,
                                  const std::vector<ColumnIndex>& permutation) {
@@ -403,9 +406,8 @@ Result::LazyResult Union::computeResultKeepOrder(
             trimmedTargetOrder.size(),
             [this, requestLaziness, &result1, &result2, &left, &right,
              &trimmedTargetOrder, &applyPermutation]<int COMPARATOR_WIDTH>() {
-              constexpr size_t extent = COMPARATOR_WIDTH == 0
-                                            ? std::dynamic_extent
-                                            : COMPARATOR_WIDTH;
+              constexpr size_t extent =
+                  COMPARATOR_WIDTH == 0 ? ql::dynamic_extent : COMPARATOR_WIDTH;
               sortedUnion::IterationData leftData{std::move(result1),
                                                   std::move(left),
                                                   computePermutation<true>()};
@@ -415,7 +417,7 @@ Result::LazyResult Union::computeResultKeepOrder(
               return Result::LazyResult{sortedUnion::SortedUnionImpl{
                   std::move(leftData), std::move(rightData), requestLaziness,
                   _columnOrigins, allocator(),
-                  std::span<const ColumnIndex, extent>{trimmedTargetOrder},
+                  ql::span<const ColumnIndex, extent>{trimmedTargetOrder},
                   std::move(applyPermutation)}};
             });
       },

--- a/src/engine/Union.cpp
+++ b/src/engine/Union.cpp
@@ -388,11 +388,8 @@ Result::LazyResult Union::computeResultKeepOrder(
     const auto& [left, right] = _columnOrigins.at(index);
     return left == NO_COLUMN || right == NO_COLUMN;
   });
-  // TODO<joka921> If we fix ql::span to accept also pairs of iterators, then
-  // the following can be much simpler.
-  ql::span trimmedTargetOrder{
-      targetOrder_.data(),
-      (end == targetOrder_.end() ? end : end + 1) - targetOrder_.begin()};
+  ql::span trimmedTargetOrder{targetOrder_.begin(),
+                              end == targetOrder_.end() ? end : end + 1};
 
   auto applyPermutation = [this](IdTable idTable,
                                  const std::vector<ColumnIndex>& permutation) {

--- a/src/engine/Union.cpp
+++ b/src/engine/Union.cpp
@@ -388,8 +388,8 @@ Result::LazyResult Union::computeResultKeepOrder(
     const auto& [left, right] = _columnOrigins.at(index);
     return left == NO_COLUMN || right == NO_COLUMN;
   });
-  ql::span trimmedTargetOrder{targetOrder_.begin(),
-                              end == targetOrder_.end() ? end : end + 1};
+  std::span trimmedTargetOrder{targetOrder_.begin(),
+                               end == targetOrder_.end() ? end : end + 1};
 
   auto applyPermutation = [this](IdTable idTable,
                                  const std::vector<ColumnIndex>& permutation) {
@@ -415,7 +415,7 @@ Result::LazyResult Union::computeResultKeepOrder(
               return Result::LazyResult{sortedUnion::SortedUnionImpl{
                   std::move(leftData), std::move(rightData), requestLaziness,
                   _columnOrigins, allocator(),
-                  ql::span<const ColumnIndex, extent>{trimmedTargetOrder},
+                  std::span<const ColumnIndex, extent>{trimmedTargetOrder},
                   std::move(applyPermutation)}};
             });
       },

--- a/src/engine/idTable/CompressedExternalIdTable.h
+++ b/src/engine/idTable/CompressedExternalIdTable.h
@@ -130,10 +130,8 @@ class CompressedExternalIdTableWriter {
             auto& blockMetadata = blocksPerColumn_.at(i);
             decltype(auto) column = table.getColumn(i);
             // TODO<C++23> Use `ql::views::chunkd`
-            for (size_t lower = 0; lower < static_cast<size_t>(column.size());
-                 lower += blockSize) {
-              size_t upper = std::min<size_t>(
-                  lower + blockSize, static_cast<size_t>(column.size()));
+            for (size_t lower = 0; lower < column.size(); lower += blockSize) {
+              size_t upper = std::min<size_t>(lower + blockSize, column.size());
               auto thisBlockSizeUncompressed = (upper - lower) * sizeof(Id);
               auto compressed = ZstdWrapper::compress(
                   column.data() + lower, thisBlockSizeUncompressed);

--- a/src/engine/idTable/CompressedExternalIdTable.h
+++ b/src/engine/idTable/CompressedExternalIdTable.h
@@ -130,8 +130,10 @@ class CompressedExternalIdTableWriter {
             auto& blockMetadata = blocksPerColumn_.at(i);
             decltype(auto) column = table.getColumn(i);
             // TODO<C++23> Use `ql::views::chunkd`
-            for (size_t lower = 0; lower < column.size(); lower += blockSize) {
-              size_t upper = std::min(lower + blockSize, column.size());
+            for (size_t lower = 0; lower < static_cast<size_t>(column.size());
+                 lower += blockSize) {
+              size_t upper = std::min<size_t>(
+                  lower + blockSize, static_cast<size_t>(column.size()));
               auto thisBlockSizeUncompressed = (upper - lower) * sizeof(Id);
               auto compressed = ZstdWrapper::compress(
                   column.data() + lower, thisBlockSizeUncompressed);

--- a/src/engine/idTable/IdTable.h
+++ b/src/engine/idTable/IdTable.h
@@ -10,7 +10,6 @@
 #include <cstdlib>
 #include <functional>
 #include <initializer_list>
-#include <span>
 #include <variant>
 #include <vector>
 

--- a/src/engine/idTable/IdTable.h
+++ b/src/engine/idTable/IdTable.h
@@ -281,11 +281,9 @@ class IdTable {
       AD_CORRECTNESS_CHECK(numColumns == NumColumns);
     }
     AD_CORRECTNESS_CHECK(this->data().size() == numColumns_);
-    AD_CORRECTNESS_CHECK(
-        ql::ranges::all_of(this->data(), [this](const auto& column) {
-          return column.size() ==
-                 static_cast<decltype(column.size())>(numRows_);
-        }));
+    AD_CORRECTNESS_CHECK(ql::ranges::all_of(
+        this->data(),
+        [this](const auto& column) { return column.size() == numRows_; }));
   }
 
  public:
@@ -601,13 +599,12 @@ class IdTable {
     AD_CONTRACT_CHECK(ql::ranges::all_of(
         columnIndices, [this](size_t idx) { return idx < numColumns(); }));
     ViewSpans viewSpans;
-    viewSpans.reserve(static_cast<size_t>(columnIndices.size()));
+    viewSpans.reserve(columnIndices.size());
     for (auto idx : columnIndices) {
       viewSpans.push_back(getColumn(idx));
     }
     return IdTable<T, 0, ColumnStorage, IsView::True>{
-        std::move(viewSpans), static_cast<size_t>(columnIndices.size()),
-        numRows_, allocator_};
+        std::move(viewSpans), columnIndices.size(), numRows_, allocator_};
   }
 
   // Modify the table, such that it contains only the specified `subset` of the

--- a/src/engine/idTable/IdTable.h
+++ b/src/engine/idTable/IdTable.h
@@ -15,6 +15,7 @@
 #include <vector>
 
 #include "backports/algorithm.h"
+#include "backports/span.h"
 #include "engine/idTable/IdTableRow.h"
 #include "engine/idTable/VectorWithElementwiseMove.h"
 #include "global/Id.h"

--- a/src/engine/idTable/IdTable.h
+++ b/src/engine/idTable/IdTable.h
@@ -122,7 +122,7 @@ class IdTable {
   // The actual storage is a plain 1D vector with the logical columns
   // concatenated.
   using Storage = detail::VectorWithElementwiseMove<ColumnStorage>;
-  using ViewSpans = std::vector<absl::Span<const T>>;
+  using ViewSpans = std::vector<std::span<const T>>;
   using Data = std::conditional_t<isView, ViewSpans, Storage>;
   using Allocator = decltype(std::declval<ColumnStorage&>().get_allocator());
 
@@ -435,7 +435,7 @@ class IdTable {
 
   // Delete all the elements, but keep the allocated memory (`capacityRows_`
   // stays the same). Runs in O(1) time. To also free the allocated memory, call
-  // `shrinkToFit()` after calling `clear()`.
+  // `shrinkToFit()` after calling `clear()` .
   CPP_template(typename = void)(requires(!isView)) void clear() {
     numRows_ = 0;
     ql::ranges::for_each(data(), [](auto& column) { column.clear(); });
@@ -596,7 +596,7 @@ class IdTable {
   // the argument `columnIndices`.
   CPP_template(typename = void)(requires isDynamic)
       IdTable<T, 0, ColumnStorage, IsView::True> asColumnSubsetView(
-          absl::Span<const ColumnIndex> columnIndices) const {
+          std::span<const ColumnIndex> columnIndices) const {
     AD_CONTRACT_CHECK(ql::ranges::all_of(
         columnIndices, [this](size_t idx) { return idx < numColumns(); }));
     ViewSpans viewSpans;
@@ -618,7 +618,7 @@ class IdTable {
   // numColumns()` implies that the function applies a permutation to the table.
   // For example `setColumnSubset({1, 2, 0})` rotates the columns of a table
   // with three columns left by one element.
-  void setColumnSubset(absl::Span<const ColumnIndex> subset) {
+  void setColumnSubset(std::span<const ColumnIndex> subset) {
     // First check that the `subset` is indeed a subset of the column
     // indices.
     std::vector<ColumnIndex> check{subset.begin(), subset.end()};
@@ -800,17 +800,15 @@ class IdTable {
   }
 
   // Get the `i`-th column. It is stored contiguously in memory.
-  CPP_template(typename = void)(requires(!isView)) absl::Span<T> getColumn(
+  CPP_template(typename = void)(requires(!isView)) std::span<T> getColumn(
       size_t i) {
-    return absl::Span<T>(data().at(i));
+    return {data().at(i)};
   }
-  absl::Span<const T> getColumn(size_t i) const {
-    return absl::Span<const T>(data().at(i));
-  }
+  std::span<const T> getColumn(size_t i) const { return {data().at(i)}; }
 
   // Return all the columns as a `std::vector` (if `isDynamic`) or as a
-  // `std::array` (else). The elements of the vector/array are `absl::Span<T>`
-  // or `absl::Span<const T>`, depending on whether `this` is const.
+  // `std::array` (else). The elements of the vector/array are `std::span<T>`
+  // or `std::span<const T>`, depending on whether `this` is const.
   auto getColumns() { return getColumnsImpl(*this); }
   auto getColumns() const { return getColumnsImpl(*this); }
 

--- a/src/engine/sparqlExpressions/AggregateExpression.cpp
+++ b/src/engine/sparqlExpressions/AggregateExpression.cpp
@@ -156,7 +156,7 @@ AggregateExpression<AggregateOperation, FinalOperation>::evaluate(
 
 // _________________________________________________________________________
 template <typename AggregateOperation, typename FinalOperation>
-std::span<SparqlExpression::Ptr>
+ql::span<SparqlExpression::Ptr>
 AggregateExpression<AggregateOperation, FinalOperation>::childrenImpl() {
   return {&_child, 1};
 }

--- a/src/engine/sparqlExpressions/AggregateExpression.cpp
+++ b/src/engine/sparqlExpressions/AggregateExpression.cpp
@@ -2,6 +2,8 @@
 //                 Chair of Algorithms and Data Structures
 // Authors: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
 //          Hannah Bast <bast@cs.uni-freiburg.de>
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #include "engine/sparqlExpressions/AggregateExpression.h"
 

--- a/src/engine/sparqlExpressions/AggregateExpression.cpp
+++ b/src/engine/sparqlExpressions/AggregateExpression.cpp
@@ -154,9 +154,9 @@ AggregateExpression<AggregateOperation, FinalOperation>::evaluate(
 
 // _________________________________________________________________________
 template <typename AggregateOperation, typename FinalOperation>
-std::span<SparqlExpression::Ptr>
+absl::Span<SparqlExpression::Ptr>
 AggregateExpression<AggregateOperation, FinalOperation>::childrenImpl() {
-  return {&_child, 1};
+  return absl::Span<SparqlExpression::Ptr>(&_child, 1);
 }
 
 // __________________________________________________________________________

--- a/src/engine/sparqlExpressions/AggregateExpression.cpp
+++ b/src/engine/sparqlExpressions/AggregateExpression.cpp
@@ -156,9 +156,9 @@ AggregateExpression<AggregateOperation, FinalOperation>::evaluate(
 
 // _________________________________________________________________________
 template <typename AggregateOperation, typename FinalOperation>
-absl::Span<SparqlExpression::Ptr>
+std::span<SparqlExpression::Ptr>
 AggregateExpression<AggregateOperation, FinalOperation>::childrenImpl() {
-  return absl::Span<SparqlExpression::Ptr>(&_child, 1);
+  return {&_child, 1};
 }
 
 // __________________________________________________________________________

--- a/src/engine/sparqlExpressions/AggregateExpression.h
+++ b/src/engine/sparqlExpressions/AggregateExpression.h
@@ -87,7 +87,7 @@ class AggregateExpression : public SparqlExpression {
 
  private:
   // _________________________________________________________________________
-  std::span<SparqlExpression::Ptr> childrenImpl() override;
+  ql::span<SparqlExpression::Ptr> childrenImpl() override;
 
  protected:
   bool _distinct;

--- a/src/engine/sparqlExpressions/AggregateExpression.h
+++ b/src/engine/sparqlExpressions/AggregateExpression.h
@@ -87,7 +87,7 @@ class AggregateExpression : public SparqlExpression {
 
  private:
   // _________________________________________________________________________
-  std::span<SparqlExpression::Ptr> childrenImpl() override;
+  absl::Span<SparqlExpression::Ptr> childrenImpl() override;
 
  protected:
   bool _distinct;

--- a/src/engine/sparqlExpressions/AggregateExpression.h
+++ b/src/engine/sparqlExpressions/AggregateExpression.h
@@ -87,7 +87,7 @@ class AggregateExpression : public SparqlExpression {
 
  private:
   // _________________________________________________________________________
-  absl::Span<SparqlExpression::Ptr> childrenImpl() override;
+  std::span<SparqlExpression::Ptr> childrenImpl() override;
 
  protected:
   bool _distinct;

--- a/src/engine/sparqlExpressions/BlankNodeExpression.cpp
+++ b/src/engine/sparqlExpressions/BlankNodeExpression.cpp
@@ -175,7 +175,7 @@ class BlankNodeExpression : public SparqlExpression {
   }
 
  private:
-  std::span<Ptr> childrenImpl() override {
+  ql::span<Ptr> childrenImpl() override {
     if (label_.has_value()) {
       return {&label_.value(), 1};
     }

--- a/src/engine/sparqlExpressions/BlankNodeExpression.cpp
+++ b/src/engine/sparqlExpressions/BlankNodeExpression.cpp
@@ -175,9 +175,9 @@ class BlankNodeExpression : public SparqlExpression {
   }
 
  private:
-  absl::Span<Ptr> childrenImpl() override {
+  std::span<Ptr> childrenImpl() override {
     if (label_.has_value()) {
-      return absl::Span<Ptr>(&label_.value(), 1);
+      return {&label_.value(), 1};
     }
     return {};
   }

--- a/src/engine/sparqlExpressions/BlankNodeExpression.cpp
+++ b/src/engine/sparqlExpressions/BlankNodeExpression.cpp
@@ -175,9 +175,9 @@ class BlankNodeExpression : public SparqlExpression {
   }
 
  private:
-  std::span<Ptr> childrenImpl() override {
+  absl::Span<Ptr> childrenImpl() override {
     if (label_.has_value()) {
-      return {&label_.value(), 1};
+      return absl::Span<Ptr>(&label_.value(), 1);
     }
     return {};
   }

--- a/src/engine/sparqlExpressions/CountStarExpression.h
+++ b/src/engine/sparqlExpressions/CountStarExpression.h
@@ -30,7 +30,7 @@ class CountStarExpression : public SparqlExpression {
       [[maybe_unused]] const VariableToColumnMap& varColMap) const override;
 
   // ___________________________________________________________________________
-  std::span<SparqlExpression::Ptr> childrenImpl() override { return {}; }
+  ql::span<SparqlExpression::Ptr> childrenImpl() override { return {}; }
 };
 
 SparqlExpression::Ptr makeCountStarExpression(bool distinct);

--- a/src/engine/sparqlExpressions/CountStarExpression.h
+++ b/src/engine/sparqlExpressions/CountStarExpression.h
@@ -30,7 +30,7 @@ class CountStarExpression : public SparqlExpression {
       [[maybe_unused]] const VariableToColumnMap& varColMap) const override;
 
   // ___________________________________________________________________________
-  absl::Span<SparqlExpression::Ptr> childrenImpl() override { return {}; }
+  std::span<SparqlExpression::Ptr> childrenImpl() override { return {}; }
 };
 
 SparqlExpression::Ptr makeCountStarExpression(bool distinct);

--- a/src/engine/sparqlExpressions/CountStarExpression.h
+++ b/src/engine/sparqlExpressions/CountStarExpression.h
@@ -30,7 +30,7 @@ class CountStarExpression : public SparqlExpression {
       [[maybe_unused]] const VariableToColumnMap& varColMap) const override;
 
   // ___________________________________________________________________________
-  std::span<SparqlExpression::Ptr> childrenImpl() override { return {}; }
+  absl::Span<SparqlExpression::Ptr> childrenImpl() override { return {}; }
 };
 
 SparqlExpression::Ptr makeCountStarExpression(bool distinct);

--- a/src/engine/sparqlExpressions/ExistsExpression.h
+++ b/src/engine/sparqlExpressions/ExistsExpression.h
@@ -66,13 +66,13 @@ class ExistsExpression : public SparqlExpression {
   bool isExistsExpression() const override { return true; }
 
   // Return all the variables that are used in this expression.
-  std::span<const Variable> getContainedVariablesNonRecursive() const override {
+  ql::span<const Variable> getContainedVariablesNonRecursive() const override {
     return argument_.selectClause().getSelectedVariables();
   }
 
   // Set the `SELECT` of the argument of this exists expression to all the
   // variables that are visible in the argument AND contained in variables.
-  void selectVariables(std::span<const Variable> variables) {
+  void selectVariables(ql::span<const Variable> variables) {
     std::vector<parsedQuery::SelectClause::VarOrAlias> intersection;
     const auto& visibleVariables = argument_.getVisibleVariables();
     for (const auto& var : variables) {
@@ -84,7 +84,7 @@ class ExistsExpression : public SparqlExpression {
   }
 
  private:
-  std::span<Ptr> childrenImpl() override { return {}; }
+  ql::span<Ptr> childrenImpl() override { return {}; }
 };
 }  // namespace sparqlExpression
 

--- a/src/engine/sparqlExpressions/ExistsExpression.h
+++ b/src/engine/sparqlExpressions/ExistsExpression.h
@@ -66,14 +66,13 @@ class ExistsExpression : public SparqlExpression {
   bool isExistsExpression() const override { return true; }
 
   // Return all the variables that are used in this expression.
-  absl::Span<const Variable> getContainedVariablesNonRecursive()
-      const override {
+  std::span<const Variable> getContainedVariablesNonRecursive() const override {
     return argument_.selectClause().getSelectedVariables();
   }
 
   // Set the `SELECT` of the argument of this exists expression to all the
   // variables that are visible in the argument AND contained in variables.
-  void selectVariables(absl::Span<const Variable> variables) {
+  void selectVariables(std::span<const Variable> variables) {
     std::vector<parsedQuery::SelectClause::VarOrAlias> intersection;
     const auto& visibleVariables = argument_.getVisibleVariables();
     for (const auto& var : variables) {
@@ -85,7 +84,7 @@ class ExistsExpression : public SparqlExpression {
   }
 
  private:
-  absl::Span<Ptr> childrenImpl() override { return {}; }
+  std::span<Ptr> childrenImpl() override { return {}; }
 };
 }  // namespace sparqlExpression
 

--- a/src/engine/sparqlExpressions/ExistsExpression.h
+++ b/src/engine/sparqlExpressions/ExistsExpression.h
@@ -66,13 +66,14 @@ class ExistsExpression : public SparqlExpression {
   bool isExistsExpression() const override { return true; }
 
   // Return all the variables that are used in this expression.
-  std::span<const Variable> getContainedVariablesNonRecursive() const override {
+  absl::Span<const Variable> getContainedVariablesNonRecursive()
+      const override {
     return argument_.selectClause().getSelectedVariables();
   }
 
   // Set the `SELECT` of the argument of this exists expression to all the
   // variables that are visible in the argument AND contained in variables.
-  void selectVariables(std::span<const Variable> variables) {
+  void selectVariables(absl::Span<const Variable> variables) {
     std::vector<parsedQuery::SelectClause::VarOrAlias> intersection;
     const auto& visibleVariables = argument_.getVisibleVariables();
     for (const auto& var : variables) {
@@ -84,7 +85,7 @@ class ExistsExpression : public SparqlExpression {
   }
 
  private:
-  std::span<Ptr> childrenImpl() override { return {}; }
+  absl::Span<Ptr> childrenImpl() override { return {}; }
 };
 }  // namespace sparqlExpression
 

--- a/src/engine/sparqlExpressions/GroupConcatExpression.h
+++ b/src/engine/sparqlExpressions/GroupConcatExpression.h
@@ -80,7 +80,7 @@ class GroupConcatExpression : public SparqlExpression {
 
  private:
   // _________________________________________________________________________
-  std::span<SparqlExpression::Ptr> childrenImpl() override {
+  ql::span<SparqlExpression::Ptr> childrenImpl() override {
     return {&child_, 1};
   }
 };

--- a/src/engine/sparqlExpressions/GroupConcatExpression.h
+++ b/src/engine/sparqlExpressions/GroupConcatExpression.h
@@ -80,8 +80,8 @@ class GroupConcatExpression : public SparqlExpression {
 
  private:
   // _________________________________________________________________________
-  std::span<SparqlExpression::Ptr> childrenImpl() override {
-    return {&child_, 1};
+  absl::Span<SparqlExpression::Ptr> childrenImpl() override {
+    return absl::Span<SparqlExpression::Ptr>(&child_, 1);
   }
 };
 }  // namespace sparqlExpression

--- a/src/engine/sparqlExpressions/GroupConcatExpression.h
+++ b/src/engine/sparqlExpressions/GroupConcatExpression.h
@@ -80,8 +80,8 @@ class GroupConcatExpression : public SparqlExpression {
 
  private:
   // _________________________________________________________________________
-  absl::Span<SparqlExpression::Ptr> childrenImpl() override {
-    return absl::Span<SparqlExpression::Ptr>(&child_, 1);
+  std::span<SparqlExpression::Ptr> childrenImpl() override {
+    return {&child_, 1};
   }
 };
 }  // namespace sparqlExpression

--- a/src/engine/sparqlExpressions/LiteralExpression.h
+++ b/src/engine/sparqlExpressions/LiteralExpression.h
@@ -78,7 +78,7 @@ class LiteralExpression : public SparqlExpression {
   }
 
   // Variables and string constants add their values.
-  std::span<const Variable> getContainedVariablesNonRecursive() const override {
+  ql::span<const Variable> getContainedVariablesNonRecursive() const override {
     if constexpr (std::is_same_v<T, ::Variable>) {
       return {&_value, 1};
     } else {
@@ -186,7 +186,7 @@ class LiteralExpression : public SparqlExpression {
   }
 
   // Literal expressions don't have children
-  std::span<SparqlExpression::Ptr> childrenImpl() override { return {}; }
+  ql::span<SparqlExpression::Ptr> childrenImpl() override { return {}; }
 };
 
 // A simple expression that just returns an explicit result. It can only be used
@@ -214,7 +214,7 @@ struct SingleUseExpression : public SparqlExpression {
     AD_FAIL();
   }
 
-  std::span<SparqlExpression::Ptr> childrenImpl() override { return {}; }
+  ql::span<SparqlExpression::Ptr> childrenImpl() override { return {}; }
 };
 
 }  // namespace detail

--- a/src/engine/sparqlExpressions/LiteralExpression.h
+++ b/src/engine/sparqlExpressions/LiteralExpression.h
@@ -78,10 +78,9 @@ class LiteralExpression : public SparqlExpression {
   }
 
   // Variables and string constants add their values.
-  absl::Span<const Variable> getContainedVariablesNonRecursive()
-      const override {
+  std::span<const Variable> getContainedVariablesNonRecursive() const override {
     if constexpr (std::is_same_v<T, ::Variable>) {
-      return absl::Span<const Variable>(&_value, 1);
+      return {&_value, 1};
     } else {
       return {};
     }
@@ -187,7 +186,7 @@ class LiteralExpression : public SparqlExpression {
   }
 
   // Literal expressions don't have children
-  absl::Span<SparqlExpression::Ptr> childrenImpl() override { return {}; }
+  std::span<SparqlExpression::Ptr> childrenImpl() override { return {}; }
 };
 
 // A simple expression that just returns an explicit result. It can only be used
@@ -215,7 +214,7 @@ struct SingleUseExpression : public SparqlExpression {
     AD_FAIL();
   }
 
-  absl::Span<SparqlExpression::Ptr> childrenImpl() override { return {}; }
+  std::span<SparqlExpression::Ptr> childrenImpl() override { return {}; }
 };
 
 }  // namespace detail

--- a/src/engine/sparqlExpressions/LiteralExpression.h
+++ b/src/engine/sparqlExpressions/LiteralExpression.h
@@ -78,9 +78,10 @@ class LiteralExpression : public SparqlExpression {
   }
 
   // Variables and string constants add their values.
-  std::span<const Variable> getContainedVariablesNonRecursive() const override {
+  absl::Span<const Variable> getContainedVariablesNonRecursive()
+      const override {
     if constexpr (std::is_same_v<T, ::Variable>) {
-      return {&_value, 1};
+      return absl::Span<const Variable>(&_value, 1);
     } else {
       return {};
     }
@@ -186,7 +187,7 @@ class LiteralExpression : public SparqlExpression {
   }
 
   // Literal expressions don't have children
-  std::span<SparqlExpression::Ptr> childrenImpl() override { return {}; }
+  absl::Span<SparqlExpression::Ptr> childrenImpl() override { return {}; }
 };
 
 // A simple expression that just returns an explicit result. It can only be used
@@ -214,7 +215,7 @@ struct SingleUseExpression : public SparqlExpression {
     AD_FAIL();
   }
 
-  std::span<SparqlExpression::Ptr> childrenImpl() override { return {}; }
+  absl::Span<SparqlExpression::Ptr> childrenImpl() override { return {}; }
 };
 
 }  // namespace detail

--- a/src/engine/sparqlExpressions/NaryExpressionImpl.h
+++ b/src/engine/sparqlExpressions/NaryExpressionImpl.h
@@ -7,8 +7,9 @@
 #ifndef QLEVER_SRC_ENGINE_SPARQLEXPRESSIONS_NARYEXPRESSIONIMPL_H
 #define QLEVER_SRC_ENGINE_SPARQLEXPRESSIONS_NARYEXPRESSIONIMPL_H
 
-#include <ranges>
 #include <absl/functional/bind_front.h>
+
+#include <ranges>
 
 #include "engine/sparqlExpressions/SparqlExpressionGenerators.h"
 #include "engine/sparqlExpressions/SparqlExpressionValueGetters.h"
@@ -52,7 +53,7 @@ class NaryExpression : public SparqlExpression {
 
  private:
   // _________________________________________________________________________
-  std::span<SparqlExpression::Ptr> childrenImpl() override;
+  absl::Span<SparqlExpression::Ptr> childrenImpl() override;
 
   // Evaluate the `naryOperation` on the `operands` using the `context`.
   CPP_template(typename... Operands)(
@@ -181,7 +182,7 @@ ExpressionResult NaryExpression<NaryOperation>::evaluate(
 
 // _____________________________________________________________________________
 template <typename Op>
-std::span<SparqlExpression::Ptr> NaryExpression<Op>::childrenImpl() {
+absl::Span<SparqlExpression::Ptr> NaryExpression<Op>::childrenImpl() {
   return {children_.data(), children_.size()};
 }
 

--- a/src/engine/sparqlExpressions/NaryExpressionImpl.h
+++ b/src/engine/sparqlExpressions/NaryExpressionImpl.h
@@ -184,11 +184,7 @@ ExpressionResult NaryExpression<NaryOperation>::evaluate(
 // _____________________________________________________________________________
 template <typename Op>
 ql::span<SparqlExpression::Ptr> NaryExpression<Op>::childrenImpl() {
-#ifdef QLEVER_CPP_17
-  return {children_.data(), static_cast<std::ptrdiff_t>(children_.size())};
-#else
   return {children_.data(), children_.size()};
-#endif
 }
 
 // __________________________________________________________________________

--- a/src/engine/sparqlExpressions/NaryExpressionImpl.h
+++ b/src/engine/sparqlExpressions/NaryExpressionImpl.h
@@ -7,9 +7,8 @@
 #ifndef QLEVER_SRC_ENGINE_SPARQLEXPRESSIONS_NARYEXPRESSIONIMPL_H
 #define QLEVER_SRC_ENGINE_SPARQLEXPRESSIONS_NARYEXPRESSIONIMPL_H
 
-#include <absl/functional/bind_front.h>
-
 #include <ranges>
+#include <absl/functional/bind_front.h>
 
 #include "engine/sparqlExpressions/SparqlExpressionGenerators.h"
 #include "engine/sparqlExpressions/SparqlExpressionValueGetters.h"
@@ -53,7 +52,7 @@ class NaryExpression : public SparqlExpression {
 
  private:
   // _________________________________________________________________________
-  absl::Span<SparqlExpression::Ptr> childrenImpl() override;
+  std::span<SparqlExpression::Ptr> childrenImpl() override;
 
   // Evaluate the `naryOperation` on the `operands` using the `context`.
   CPP_template(typename... Operands)(
@@ -183,7 +182,7 @@ ExpressionResult NaryExpression<NaryOperation>::evaluate(
 
 // _____________________________________________________________________________
 template <typename Op>
-absl::Span<SparqlExpression::Ptr> NaryExpression<Op>::childrenImpl() {
+std::span<SparqlExpression::Ptr> NaryExpression<Op>::childrenImpl() {
   return {children_.data(), children_.size()};
 }
 

--- a/src/engine/sparqlExpressions/NaryExpressionImpl.h
+++ b/src/engine/sparqlExpressions/NaryExpressionImpl.h
@@ -8,6 +8,7 @@
 #define QLEVER_SRC_ENGINE_SPARQLEXPRESSIONS_NARYEXPRESSIONIMPL_H
 
 #include <ranges>
+#include <absl/functional/bind_front.h>
 
 #include "engine/sparqlExpressions/SparqlExpressionGenerators.h"
 #include "engine/sparqlExpressions/SparqlExpressionValueGetters.h"
@@ -171,7 +172,7 @@ ExpressionResult NaryExpression<NaryOperation>::evaluate(
 
   // A function that only takes several `ExpressionResult`s,
   // and evaluates the expression.
-  auto evaluateOnChildrenResults = std::bind_front(
+  auto evaluateOnChildrenResults = absl::bind_front(
       ad_utility::visitWithVariantsAndParameters,
       evaluateOnChildOperandsAsLambda, NaryOperation{}, context);
 

--- a/src/engine/sparqlExpressions/NaryExpressionImpl.h
+++ b/src/engine/sparqlExpressions/NaryExpressionImpl.h
@@ -7,8 +7,9 @@
 #ifndef QLEVER_SRC_ENGINE_SPARQLEXPRESSIONS_NARYEXPRESSIONIMPL_H
 #define QLEVER_SRC_ENGINE_SPARQLEXPRESSIONS_NARYEXPRESSIONIMPL_H
 
-#include <ranges>
 #include <absl/functional/bind_front.h>
+
+#include <ranges>
 
 #include "engine/sparqlExpressions/SparqlExpressionGenerators.h"
 #include "engine/sparqlExpressions/SparqlExpressionValueGetters.h"
@@ -52,7 +53,7 @@ class NaryExpression : public SparqlExpression {
 
  private:
   // _________________________________________________________________________
-  std::span<SparqlExpression::Ptr> childrenImpl() override;
+  ql::span<SparqlExpression::Ptr> childrenImpl() override;
 
   // Evaluate the `naryOperation` on the `operands` using the `context`.
   CPP_template(typename... Operands)(
@@ -182,8 +183,12 @@ ExpressionResult NaryExpression<NaryOperation>::evaluate(
 
 // _____________________________________________________________________________
 template <typename Op>
-std::span<SparqlExpression::Ptr> NaryExpression<Op>::childrenImpl() {
+ql::span<SparqlExpression::Ptr> NaryExpression<Op>::childrenImpl() {
+#ifdef QLEVER_CPP_17
+  return {children_.data(), static_cast<std::ptrdiff_t>(children_.size())};
+#else
   return {children_.data(), children_.size()};
+#endif
 }
 
 // __________________________________________________________________________

--- a/src/engine/sparqlExpressions/NowDatetimeExpression.h
+++ b/src/engine/sparqlExpressions/NowDatetimeExpression.h
@@ -32,7 +32,7 @@ class NowDatetimeExpression : public SparqlExpression {
   }
 
  private:
-  std::span<SparqlExpression::Ptr> childrenImpl() override { return {}; }
+  ql::span<SparqlExpression::Ptr> childrenImpl() override { return {}; }
 };
 
 }  // namespace sparqlExpression

--- a/src/engine/sparqlExpressions/NowDatetimeExpression.h
+++ b/src/engine/sparqlExpressions/NowDatetimeExpression.h
@@ -32,7 +32,7 @@ class NowDatetimeExpression : public SparqlExpression {
   }
 
  private:
-  absl::Span<SparqlExpression::Ptr> childrenImpl() override { return {}; }
+  std::span<SparqlExpression::Ptr> childrenImpl() override { return {}; }
 };
 
 }  // namespace sparqlExpression

--- a/src/engine/sparqlExpressions/NowDatetimeExpression.h
+++ b/src/engine/sparqlExpressions/NowDatetimeExpression.h
@@ -32,7 +32,7 @@ class NowDatetimeExpression : public SparqlExpression {
   }
 
  private:
-  std::span<SparqlExpression::Ptr> childrenImpl() override { return {}; }
+  absl::Span<SparqlExpression::Ptr> childrenImpl() override { return {}; }
 };
 
 }  // namespace sparqlExpression

--- a/src/engine/sparqlExpressions/PrefilterExpressionIndex.cpp
+++ b/src/engine/sparqlExpressions/PrefilterExpressionIndex.cpp
@@ -78,7 +78,7 @@ static bool checkBlockIsInconsistent(const CompressedBlockMetadata& block,
 // order. (3) Columns with `column index < evaluationColumn` must contain equal
 // values (`ValueId`s).
 static void checkRequirementsBlockMetadata(
-    absl::Span<const BlockMetadata> input, size_t evaluationColumn) {
+    absl::Span<const CompressedBlockMetadata> input, size_t evaluationColumn) {
   const auto throwRuntimeError = [](const std::string& errorMessage) {
     throw std::runtime_error(errorMessage);
   };
@@ -178,7 +178,7 @@ static BlockMetadataRange mapValueIdItPairToBlockRange(
   auto blockRangeBegin = blockRange.begin();
   // Each `CompressedBlockMetadata` value contains two bounding `ValueId`s, one
   // for `firstTriple_` and `lastTriple_` respectively. `ValueIdIt idRangeBegin`
-  // is the first valid iterator on our flattened `std::span<const
+  // is the first valid iterator on our flattened `absl::Span<const
   // CompressedBlockMetadata> blockRange` with respect to the contained
   // `ValueId`s.
   // `blockRange.begin()` represents the first valid iterator on our original

--- a/src/engine/sparqlExpressions/PrefilterExpressionIndex.cpp
+++ b/src/engine/sparqlExpressions/PrefilterExpressionIndex.cpp
@@ -78,7 +78,7 @@ static bool checkBlockIsInconsistent(const CompressedBlockMetadata& block,
 // order. (3) Columns with `column index < evaluationColumn` must contain equal
 // values (`ValueId`s).
 static void checkRequirementsBlockMetadata(
-    std::span<const CompressedBlockMetadata> input, size_t evaluationColumn) {
+    absl::Span<const BlockMetadata> input, size_t evaluationColumn) {
   const auto throwRuntimeError = [](const std::string& errorMessage) {
     throw std::runtime_error(errorMessage);
   };
@@ -182,15 +182,15 @@ static BlockMetadataRange mapValueIdItPairToBlockRange(
   // CompressedBlockMetadata> blockRange` with respect to the contained
   // `ValueId`s.
   // `blockRange.begin()` represents the first valid iterator on our original
-  // `std::span<const CompressedBlockMetadata> blockRange`.
+  // `absl::Span<const CompressedBlockMetadata> blockRange`.
   //
   //  EXAMPLE
-  // `CompressedBlockMetadata` view on `std::span<const CompressedBlockMetadata>
-  // blockRange`:
+  // `CompressedBlockMetadata` view on `absl::Span<const
+  // CompressedBlockMetadata> blockRange`:
   // `{[1021, 1082], [1083, 1115], [1121, 1140], [1140, 1148], [1150,
   // 1158]}`. Range for `BlockMetadataIt` values.
   //
-  // `ValueId` view on (flat) `std::span<const CompressedBlockMetadata>
+  // `ValueId` view on (flat) `absl::Span<const CompressedBlockMetadata>
   // blockRange`:
   //`{1021, 1082, 1083, 1115, 1121, 1140, 1140, 1148, 1150, 1158}`.
   // Range for `ValueIdIt` values.
@@ -420,7 +420,7 @@ static std::string getLogicalOpStr(const LogicalOperator logOp) {
 // CUSTOM VALUE-ID ACCESS (STRUCT) OPERATOR
 //______________________________________________________________________________
 // Enables access to the i-th `ValueId` regarding our containerized
-// `std::span<const CompressedBlockMetadata> inputSpan`.
+// `absl::Span<const CompressedBlockMetadata> inputSpan`.
 // Each `CompressedBlockMetadata` value holds exactly two bound `ValueId`s (one
 // in `firstTriple_` and `lastTriple_` respectively) over the specified column
 // `evaluationColumn_`.

--- a/src/engine/sparqlExpressions/PrefilterExpressionIndex.cpp
+++ b/src/engine/sparqlExpressions/PrefilterExpressionIndex.cpp
@@ -78,7 +78,7 @@ static bool checkBlockIsInconsistent(const CompressedBlockMetadata& block,
 // order. (3) Columns with `column index < evaluationColumn` must contain equal
 // values (`ValueId`s).
 static void checkRequirementsBlockMetadata(
-    absl::Span<const CompressedBlockMetadata> input, size_t evaluationColumn) {
+    std::span<const CompressedBlockMetadata> input, size_t evaluationColumn) {
   const auto throwRuntimeError = [](const std::string& errorMessage) {
     throw std::runtime_error(errorMessage);
   };
@@ -182,15 +182,15 @@ static BlockMetadataRange mapValueIdItPairToBlockRange(
   // CompressedBlockMetadata> blockRange` with respect to the contained
   // `ValueId`s.
   // `blockRange.begin()` represents the first valid iterator on our original
-  // `absl::Span<const CompressedBlockMetadata> blockRange`.
+  // `std::span<const CompressedBlockMetadata> blockRange`.
   //
   //  EXAMPLE
-  // `CompressedBlockMetadata` view on `absl::Span<const
-  // CompressedBlockMetadata> blockRange`:
+  // `CompressedBlockMetadata` view on `std::span<const CompressedBlockMetadata>
+  // blockRange`:
   // `{[1021, 1082], [1083, 1115], [1121, 1140], [1140, 1148], [1150,
   // 1158]}`. Range for `BlockMetadataIt` values.
   //
-  // `ValueId` view on (flat) `absl::Span<const CompressedBlockMetadata>
+  // `ValueId` view on (flat) `std::span<const CompressedBlockMetadata>
   // blockRange`:
   //`{1021, 1082, 1083, 1115, 1121, 1140, 1140, 1148, 1150, 1158}`.
   // Range for `ValueIdIt` values.
@@ -420,7 +420,7 @@ static std::string getLogicalOpStr(const LogicalOperator logOp) {
 // CUSTOM VALUE-ID ACCESS (STRUCT) OPERATOR
 //______________________________________________________________________________
 // Enables access to the i-th `ValueId` regarding our containerized
-// `absl::Span<const CompressedBlockMetadata> inputSpan`.
+// `std::span<const CompressedBlockMetadata> inputSpan`.
 // Each `CompressedBlockMetadata` value holds exactly two bound `ValueId`s (one
 // in `firstTriple_` and `lastTriple_` respectively) over the specified column
 // `evaluationColumn_`.

--- a/src/engine/sparqlExpressions/PrefilterExpressionIndex.cpp
+++ b/src/engine/sparqlExpressions/PrefilterExpressionIndex.cpp
@@ -178,7 +178,7 @@ static BlockMetadataRange mapValueIdItPairToBlockRange(
   auto blockRangeBegin = blockRange.begin();
   // Each `CompressedBlockMetadata` value contains two bounding `ValueId`s, one
   // for `firstTriple_` and `lastTriple_` respectively. `ValueIdIt idRangeBegin`
-  // is the first valid iterator on our flattened `absl::Span<const
+  // is the first valid iterator on our flattened `ql::span<const
   // CompressedBlockMetadata> blockRange` with respect to the contained
   // `ValueId`s.
   // `blockRange.begin()` represents the first valid iterator on our original
@@ -202,7 +202,7 @@ static BlockMetadataRange mapValueIdItPairToBlockRange(
   auto blockOffsetBegin = std::distance(idRangeBegin, beginIdIt) / 2;
   auto blockOffsetEnd = (std::distance(idRangeBegin, endIdIt) + 1) / 2;
   AD_CORRECTNESS_CHECK(static_cast<size_t>(blockOffsetEnd) <=
-                       static_cast<size_t>(blockRange.size()));
+                       blockRange.size());
   return {blockRangeBegin + blockOffsetBegin, blockRangeBegin + blockOffsetEnd};
 }
 
@@ -459,8 +459,7 @@ std::vector<CompressedBlockMetadata> PrefilterExpression::evaluate(
     AccessValueIdFromBlockMetadata accessValueIdOp(evaluationColumn);
     ValueIdSubrange idRange{
         ValueIdIt{&blockRange, 0, accessValueIdOp},
-        ValueIdIt{&blockRange, static_cast<uint64_t>(blockRange.size()) * 2,
-                  accessValueIdOp}};
+        ValueIdIt{&blockRange, blockRange.size() * 2, accessValueIdOp}};
     result =
         getRelevantBlocks(detail::logicalOps::mergeRelevantBlockItRanges<true>(
             evaluateImpl(idRange, blockRange),

--- a/src/engine/sparqlExpressions/PrefilterExpressionIndex.h
+++ b/src/engine/sparqlExpressions/PrefilterExpressionIndex.h
@@ -33,11 +33,11 @@ using IdOrLocalVocabEntry = std::variant<ValueId, LocalVocabEntry>;
 constexpr size_t maxInfoRecursion = 3;
 
 //______________________________________________________________________________
-// `std::span` containing `CompressedBlockMetadata` (defined in
+// `absl::Span` containing `CompressedBlockMetadata` (defined in
 // CompressedRelation.h) values.
-using BlockMetadataSpan = std::span<const CompressedBlockMetadata>;
+using BlockMetadataSpan = absl::Span<const CompressedBlockMetadata>;
 // Iterator with respect to a `CompressedBlockMetadata` value of
-// `std::span<const CompressedBlockMetadata>` (`BlockMetadataSpan`).
+// `absl::Span<const CompressedBlockMetadata>` (`BlockMetadataSpan`).
 using BlockMetadataIt = BlockMetadataSpan::iterator;
 // Section of relevant blocks as a subrange defined by `BlockMetadataIt`s.
 using BlockMetadataRange = ql::ranges::subrange<BlockMetadataIt>;
@@ -46,12 +46,12 @@ using BlockMetadataRanges = std::vector<BlockMetadataRange>;
 
 //______________________________________________________________________________
 // `AccessValueIdFromBlockMetadata` implements the `ValueId` access operator on
-// containerized `std::span<cont CompressedBlockMetadata>` objects. This
+// containerized `absl::Span<cont CompressedBlockMetadata>` objects. This
 // (indexable) containerization procedure allows us to efficiently define
 // relevant ranges by indices/iterators, instead of returning the relevant
-// `CompressedBlockMetadata` values itself. `operator()(std::span<const
+// `CompressedBlockMetadata` values itself. `operator()(absl::Span<const
 // CompressedBlockMetadata> randomAccessContainer,uint64_t i)` implements access
-// to the i-th `ValueId` regarding our containerized `std::span<const
+// to the i-th `ValueId` regarding our containerized `absl::Span<const
 // CompressedBlockMetadata> inputSpan`. Each `CompressedBlockMetadata` value
 // holds exactly two bound `ValueId`s (one in `firstTriple_` and `lastTriple_`
 // respectively) over the specified column `evaluationColumn_`. This leads to an
@@ -73,22 +73,22 @@ struct AccessValueIdFromBlockMetadata {
 };
 
 // Specialized `Iterator` with `ValueId` access (retrieve `ValueId`s from
-// corresponding `CompressedBlockMetadata`) on containerized `std::span<const
+// corresponding `CompressedBlockMetadata`) on containerized `absl::Span<const
 // CompressedBlockMetadata>` objects.
 using ValueIdIt = ad_utility::IteratorForAccessOperator<
-    std::span<const CompressedBlockMetadata>, AccessValueIdFromBlockMetadata,
+    absl::Span<const CompressedBlockMetadata>, AccessValueIdFromBlockMetadata,
     ad_utility::IsConst::True>;
 
 //______________________________________________________________________________
 // `ValueIdSubrange` represents a (sub) range of relevant `ValueId`s over
-// the containerized `std::span<const CompressedBlockMetadata> input`:
+// the containerized `absl::Span<const CompressedBlockMetadata> input`:
 using ValueIdSubrange = ql::ranges::subrange<ValueIdIt>;
 
 //______________________________________________________________________________
 // Required because `valueIdComparators::getRangesForId` directly returns pairs
 // of `ValueIdIt`s, and not sub ranges (`ValueIdSubrange`).
 // Remark: The pair defines a relevant range of `ValueId`s over containerized
-// `std::span<const CompressedBlockMetadata> input` by iterators.
+// `absl::Span<const CompressedBlockMetadata> input` by iterators.
 using ValueIdItPair = std::pair<ValueIdIt, ValueIdIt>;
 
 //______________________________________________________________________________
@@ -149,7 +149,7 @@ class PrefilterExpression {
 
   // `evaluateImpl` is internally used for the actual pre-filter procedure.
   // `ValueIdSubrange idRange` enables indirect access to all `ValueId`s at
-  // column index `evaluationColumn` over the containerized `std::span<const
+  // column index `evaluationColumn` over the containerized `absl::Span<const
   // CompressedBlockMetadata> input` (`BlockMetadataSpan`).
   virtual BlockMetadataRanges evaluateImpl(
       const ValueIdSubrange& idRange, BlockMetadataSpan blockRange) const = 0;
@@ -212,7 +212,7 @@ class IsDatatypeExpression : public PrefilterExpression {
 
  public:
   explicit IsDatatypeExpression(bool isNegated = false)
-      : isNegated_(isNegated){};
+      : isNegated_(isNegated) {};
   std::unique_ptr<PrefilterExpression> logicalComplement() const override;
   bool operator==(const PrefilterExpression& other) const override;
   std::unique_ptr<PrefilterExpression> clone() const override;
@@ -349,20 +349,20 @@ BlockMetadataRanges mergeRelevantBlockItRanges(const BlockMetadataRanges& r1,
 namespace mapping {
 // `This internal helper function is only exposed for unit tests!`
 // Map the complement of the given `ValueIdItPair`s, which directly refer to the
-// `ValueId`s held by the containerized `std::span<const
+// `ValueId`s held by the containerized `absl::Span<const
 // CompressedBlockMetadata>`, to their corresponding `BlockMetadataIt`s. The
 // ranges defined by those `BlockMetadataIt`s directly refer to the (relevant)
-// `CompressedBlockMetadata` values of `std::span<const
+// `CompressedBlockMetadata` values of `absl::Span<const
 // CompressedBlockMetadata>` (`BlockMetadataSpan`).
 BlockMetadataRanges mapValueIdItRangesToBlockItRangesComplemented(
     const std::vector<ValueIdItPair>& relevantIdRanges,
     const ValueIdSubrange& idRange, BlockMetadataSpan blockRange);
 // `This internal helper function is only exposed for unit tests!`
 // Map the given `ValueIdItPair`s, which directly refer to the
-// `ValueId`s held by the containerized `std::span<const
+// `ValueId`s held by the containerized `absl::Span<const
 // CompressedBlockMetadata>`, to their corresponding `BlockMetadataIt`s. The
 // ranges defined by those `BlockMetadataIt`s directly refer to the (relevant)
-// `CompressedBlockMetadata` values of `std::span<const
+// `CompressedBlockMetadata` values of `absl::Span<const
 // CompressedBlockMetadata>` (`BlockMetadataSpan`).
 BlockMetadataRanges mapValueIdItRangesToBlockItRanges(
     const std::vector<ValueIdItPair>& relevantIdRanges,

--- a/src/engine/sparqlExpressions/PrefilterExpressionIndex.h
+++ b/src/engine/sparqlExpressions/PrefilterExpressionIndex.h
@@ -33,11 +33,11 @@ using IdOrLocalVocabEntry = std::variant<ValueId, LocalVocabEntry>;
 constexpr size_t maxInfoRecursion = 3;
 
 //______________________________________________________________________________
-// `std::span` containing `CompressedBlockMetadata` (defined in
+// `ql::span` containing `CompressedBlockMetadata` (defined in
 // CompressedRelation.h) values.
-using BlockMetadataSpan = std::span<const CompressedBlockMetadata>;
+using BlockMetadataSpan = ql::span<const CompressedBlockMetadata>;
 // Iterator with respect to a `CompressedBlockMetadata` value of
-// `std::span<const CompressedBlockMetadata>` (`BlockMetadataSpan`).
+// `ql::span<const CompressedBlockMetadata>` (`BlockMetadataSpan`).
 using BlockMetadataIt = BlockMetadataSpan::iterator;
 // Section of relevant blocks as a subrange defined by `BlockMetadataIt`s.
 using BlockMetadataRange = ql::ranges::subrange<BlockMetadataIt>;
@@ -46,12 +46,12 @@ using BlockMetadataRanges = std::vector<BlockMetadataRange>;
 
 //______________________________________________________________________________
 // `AccessValueIdFromBlockMetadata` implements the `ValueId` access operator on
-// containerized `std::span<cont CompressedBlockMetadata>` objects. This
+// containerized `ql::span<cont CompressedBlockMetadata>` objects. This
 // (indexable) containerization procedure allows us to efficiently define
 // relevant ranges by indices/iterators, instead of returning the relevant
-// `CompressedBlockMetadata` values itself. `operator()(std::span<const
+// `CompressedBlockMetadata` values itself. `operator()(ql::span<const
 // CompressedBlockMetadata> randomAccessContainer,uint64_t i)` implements access
-// to the i-th `ValueId` regarding our containerized `std::span<const
+// to the i-th `ValueId` regarding our containerized `ql::span<const
 // CompressedBlockMetadata> inputSpan`. Each `CompressedBlockMetadata` value
 // holds exactly two bound `ValueId`s (one in `firstTriple_` and `lastTriple_`
 // respectively) over the specified column `evaluationColumn_`. This leads to an
@@ -73,22 +73,22 @@ struct AccessValueIdFromBlockMetadata {
 };
 
 // Specialized `Iterator` with `ValueId` access (retrieve `ValueId`s from
-// corresponding `CompressedBlockMetadata`) on containerized `std::span<const
+// corresponding `CompressedBlockMetadata`) on containerized `ql::span<const
 // CompressedBlockMetadata>` objects.
 using ValueIdIt = ad_utility::IteratorForAccessOperator<
-    std::span<const CompressedBlockMetadata>, AccessValueIdFromBlockMetadata,
+    ql::span<const CompressedBlockMetadata>, AccessValueIdFromBlockMetadata,
     ad_utility::IsConst::True>;
 
 //______________________________________________________________________________
 // `ValueIdSubrange` represents a (sub) range of relevant `ValueId`s over
-// the containerized `std::span<const CompressedBlockMetadata> input`:
+// the containerized `ql::span<const CompressedBlockMetadata> input`:
 using ValueIdSubrange = ql::ranges::subrange<ValueIdIt>;
 
 //______________________________________________________________________________
 // Required because `valueIdComparators::getRangesForId` directly returns pairs
 // of `ValueIdIt`s, and not sub ranges (`ValueIdSubrange`).
 // Remark: The pair defines a relevant range of `ValueId`s over containerized
-// `std::span<const CompressedBlockMetadata> input` by iterators.
+// `ql::span<const CompressedBlockMetadata> input` by iterators.
 using ValueIdItPair = std::pair<ValueIdIt, ValueIdIt>;
 
 //______________________________________________________________________________
@@ -149,7 +149,7 @@ class PrefilterExpression {
 
   // `evaluateImpl` is internally used for the actual pre-filter procedure.
   // `ValueIdSubrange idRange` enables indirect access to all `ValueId`s at
-  // column index `evaluationColumn` over the containerized `std::span<const
+  // column index `evaluationColumn` over the containerized `ql::span<const
   // CompressedBlockMetadata> input` (`BlockMetadataSpan`).
   virtual BlockMetadataRanges evaluateImpl(
       const ValueIdSubrange& idRange, BlockMetadataSpan blockRange) const = 0;
@@ -212,7 +212,7 @@ class IsDatatypeExpression : public PrefilterExpression {
 
  public:
   explicit IsDatatypeExpression(bool isNegated = false)
-      : isNegated_(isNegated){};
+      : isNegated_(isNegated) {};
   std::unique_ptr<PrefilterExpression> logicalComplement() const override;
   bool operator==(const PrefilterExpression& other) const override;
   std::unique_ptr<PrefilterExpression> clone() const override;
@@ -349,20 +349,20 @@ BlockMetadataRanges mergeRelevantBlockItRanges(const BlockMetadataRanges& r1,
 namespace mapping {
 // `This internal helper function is only exposed for unit tests!`
 // Map the complement of the given `ValueIdItPair`s, which directly refer to the
-// `ValueId`s held by the containerized `std::span<const
+// `ValueId`s held by the containerized `ql::span<const
 // CompressedBlockMetadata>`, to their corresponding `BlockMetadataIt`s. The
 // ranges defined by those `BlockMetadataIt`s directly refer to the (relevant)
-// `CompressedBlockMetadata` values of `std::span<const
+// `CompressedBlockMetadata` values of `ql::span<const
 // CompressedBlockMetadata>` (`BlockMetadataSpan`).
 BlockMetadataRanges mapValueIdItRangesToBlockItRangesComplemented(
     const std::vector<ValueIdItPair>& relevantIdRanges,
     const ValueIdSubrange& idRange, BlockMetadataSpan blockRange);
 // `This internal helper function is only exposed for unit tests!`
 // Map the given `ValueIdItPair`s, which directly refer to the
-// `ValueId`s held by the containerized `std::span<const
+// `ValueId`s held by the containerized `ql::span<const
 // CompressedBlockMetadata>`, to their corresponding `BlockMetadataIt`s. The
 // ranges defined by those `BlockMetadataIt`s directly refer to the (relevant)
-// `CompressedBlockMetadata` values of `std::span<const
+// `CompressedBlockMetadata` values of `ql::span<const
 // CompressedBlockMetadata>` (`BlockMetadataSpan`).
 BlockMetadataRanges mapValueIdItRangesToBlockItRanges(
     const std::vector<ValueIdItPair>& relevantIdRanges,

--- a/src/engine/sparqlExpressions/PrefilterExpressionIndex.h
+++ b/src/engine/sparqlExpressions/PrefilterExpressionIndex.h
@@ -33,11 +33,11 @@ using IdOrLocalVocabEntry = std::variant<ValueId, LocalVocabEntry>;
 constexpr size_t maxInfoRecursion = 3;
 
 //______________________________________________________________________________
-// `absl::Span` containing `CompressedBlockMetadata` (defined in
+// `std::span` containing `CompressedBlockMetadata` (defined in
 // CompressedRelation.h) values.
-using BlockMetadataSpan = absl::Span<const CompressedBlockMetadata>;
+using BlockMetadataSpan = std::span<const CompressedBlockMetadata>;
 // Iterator with respect to a `CompressedBlockMetadata` value of
-// `absl::Span<const CompressedBlockMetadata>` (`BlockMetadataSpan`).
+// `std::span<const CompressedBlockMetadata>` (`BlockMetadataSpan`).
 using BlockMetadataIt = BlockMetadataSpan::iterator;
 // Section of relevant blocks as a subrange defined by `BlockMetadataIt`s.
 using BlockMetadataRange = ql::ranges::subrange<BlockMetadataIt>;
@@ -46,12 +46,12 @@ using BlockMetadataRanges = std::vector<BlockMetadataRange>;
 
 //______________________________________________________________________________
 // `AccessValueIdFromBlockMetadata` implements the `ValueId` access operator on
-// containerized `absl::Span<cont CompressedBlockMetadata>` objects. This
+// containerized `std::span<cont CompressedBlockMetadata>` objects. This
 // (indexable) containerization procedure allows us to efficiently define
 // relevant ranges by indices/iterators, instead of returning the relevant
-// `CompressedBlockMetadata` values itself. `operator()(absl::Span<const
+// `CompressedBlockMetadata` values itself. `operator()(std::span<const
 // CompressedBlockMetadata> randomAccessContainer,uint64_t i)` implements access
-// to the i-th `ValueId` regarding our containerized `absl::Span<const
+// to the i-th `ValueId` regarding our containerized `std::span<const
 // CompressedBlockMetadata> inputSpan`. Each `CompressedBlockMetadata` value
 // holds exactly two bound `ValueId`s (one in `firstTriple_` and `lastTriple_`
 // respectively) over the specified column `evaluationColumn_`. This leads to an
@@ -73,22 +73,22 @@ struct AccessValueIdFromBlockMetadata {
 };
 
 // Specialized `Iterator` with `ValueId` access (retrieve `ValueId`s from
-// corresponding `CompressedBlockMetadata`) on containerized `absl::Span<const
+// corresponding `CompressedBlockMetadata`) on containerized `std::span<const
 // CompressedBlockMetadata>` objects.
 using ValueIdIt = ad_utility::IteratorForAccessOperator<
-    absl::Span<const CompressedBlockMetadata>, AccessValueIdFromBlockMetadata,
+    std::span<const CompressedBlockMetadata>, AccessValueIdFromBlockMetadata,
     ad_utility::IsConst::True>;
 
 //______________________________________________________________________________
 // `ValueIdSubrange` represents a (sub) range of relevant `ValueId`s over
-// the containerized `absl::Span<const CompressedBlockMetadata> input`:
+// the containerized `std::span<const CompressedBlockMetadata> input`:
 using ValueIdSubrange = ql::ranges::subrange<ValueIdIt>;
 
 //______________________________________________________________________________
 // Required because `valueIdComparators::getRangesForId` directly returns pairs
 // of `ValueIdIt`s, and not sub ranges (`ValueIdSubrange`).
 // Remark: The pair defines a relevant range of `ValueId`s over containerized
-// `absl::Span<const CompressedBlockMetadata> input` by iterators.
+// `std::span<const CompressedBlockMetadata> input` by iterators.
 using ValueIdItPair = std::pair<ValueIdIt, ValueIdIt>;
 
 //______________________________________________________________________________
@@ -149,7 +149,7 @@ class PrefilterExpression {
 
   // `evaluateImpl` is internally used for the actual pre-filter procedure.
   // `ValueIdSubrange idRange` enables indirect access to all `ValueId`s at
-  // column index `evaluationColumn` over the containerized `absl::Span<const
+  // column index `evaluationColumn` over the containerized `std::span<const
   // CompressedBlockMetadata> input` (`BlockMetadataSpan`).
   virtual BlockMetadataRanges evaluateImpl(
       const ValueIdSubrange& idRange, BlockMetadataSpan blockRange) const = 0;
@@ -349,20 +349,20 @@ BlockMetadataRanges mergeRelevantBlockItRanges(const BlockMetadataRanges& r1,
 namespace mapping {
 // `This internal helper function is only exposed for unit tests!`
 // Map the complement of the given `ValueIdItPair`s, which directly refer to the
-// `ValueId`s held by the containerized `absl::Span<const
+// `ValueId`s held by the containerized `std::span<const
 // CompressedBlockMetadata>`, to their corresponding `BlockMetadataIt`s. The
 // ranges defined by those `BlockMetadataIt`s directly refer to the (relevant)
-// `CompressedBlockMetadata` values of `absl::Span<const
+// `CompressedBlockMetadata` values of `std::span<const
 // CompressedBlockMetadata>` (`BlockMetadataSpan`).
 BlockMetadataRanges mapValueIdItRangesToBlockItRangesComplemented(
     const std::vector<ValueIdItPair>& relevantIdRanges,
     const ValueIdSubrange& idRange, BlockMetadataSpan blockRange);
 // `This internal helper function is only exposed for unit tests!`
 // Map the given `ValueIdItPair`s, which directly refer to the
-// `ValueId`s held by the containerized `absl::Span<const
+// `ValueId`s held by the containerized `std::span<const
 // CompressedBlockMetadata>`, to their corresponding `BlockMetadataIt`s. The
 // ranges defined by those `BlockMetadataIt`s directly refer to the (relevant)
-// `CompressedBlockMetadata` values of `absl::Span<const
+// `CompressedBlockMetadata` values of `std::span<const
 // CompressedBlockMetadata>` (`BlockMetadataSpan`).
 BlockMetadataRanges mapValueIdItRangesToBlockItRanges(
     const std::vector<ValueIdItPair>& relevantIdRanges,

--- a/src/engine/sparqlExpressions/PrefilterExpressionIndex.h
+++ b/src/engine/sparqlExpressions/PrefilterExpressionIndex.h
@@ -212,7 +212,7 @@ class IsDatatypeExpression : public PrefilterExpression {
 
  public:
   explicit IsDatatypeExpression(bool isNegated = false)
-      : isNegated_(isNegated) {};
+      : isNegated_(isNegated){};
   std::unique_ptr<PrefilterExpression> logicalComplement() const override;
   bool operator==(const PrefilterExpression& other) const override;
   std::unique_ptr<PrefilterExpression> clone() const override;

--- a/src/engine/sparqlExpressions/RandomExpression.h
+++ b/src/engine/sparqlExpressions/RandomExpression.h
@@ -49,7 +49,7 @@ class RandomExpression : public SparqlExpression {
 
  private:
   // Get the direct child expressions.
-  std::span<SparqlExpression::Ptr> childrenImpl() override { return {}; }
+  ql::span<SparqlExpression::Ptr> childrenImpl() override { return {}; }
 };
 
 }  // namespace sparqlExpression

--- a/src/engine/sparqlExpressions/RandomExpression.h
+++ b/src/engine/sparqlExpressions/RandomExpression.h
@@ -49,7 +49,7 @@ class RandomExpression : public SparqlExpression {
 
  private:
   // Get the direct child expressions.
-  absl::Span<SparqlExpression::Ptr> childrenImpl() override { return {}; }
+  std::span<SparqlExpression::Ptr> childrenImpl() override { return {}; }
 };
 
 }  // namespace sparqlExpression

--- a/src/engine/sparqlExpressions/RandomExpression.h
+++ b/src/engine/sparqlExpressions/RandomExpression.h
@@ -49,7 +49,7 @@ class RandomExpression : public SparqlExpression {
 
  private:
   // Get the direct child expressions.
-  std::span<SparqlExpression::Ptr> childrenImpl() override { return {}; }
+  absl::Span<SparqlExpression::Ptr> childrenImpl() override { return {}; }
 };
 
 }  // namespace sparqlExpression

--- a/src/engine/sparqlExpressions/RegexExpression.cpp
+++ b/src/engine/sparqlExpressions/RegexExpression.cpp
@@ -161,7 +161,7 @@ string PrefixRegexExpression::getCacheKey(
 }
 
 // _____________________________________________________________________________
-std::span<SparqlExpression::Ptr> PrefixRegexExpression::childrenImpl() {
+ql::span<SparqlExpression::Ptr> PrefixRegexExpression::childrenImpl() {
   return {&child_, 1};
 }
 

--- a/src/engine/sparqlExpressions/RegexExpression.cpp
+++ b/src/engine/sparqlExpressions/RegexExpression.cpp
@@ -161,8 +161,8 @@ string PrefixRegexExpression::getCacheKey(
 }
 
 // _____________________________________________________________________________
-absl::Span<SparqlExpression::Ptr> PrefixRegexExpression::childrenImpl() {
-  return absl::Span<SparqlExpression::Ptr>(&child_, 1);
+std::span<SparqlExpression::Ptr> PrefixRegexExpression::childrenImpl() {
+  return {&child_, 1};
 }
 
 // _____________________________________________________________________________

--- a/src/engine/sparqlExpressions/RegexExpression.cpp
+++ b/src/engine/sparqlExpressions/RegexExpression.cpp
@@ -161,8 +161,8 @@ string PrefixRegexExpression::getCacheKey(
 }
 
 // _____________________________________________________________________________
-std::span<SparqlExpression::Ptr> PrefixRegexExpression::childrenImpl() {
-  return {&child_, 1};
+absl::Span<SparqlExpression::Ptr> PrefixRegexExpression::childrenImpl() {
+  return absl::Span<SparqlExpression::Ptr>(&child_, 1);
 }
 
 // _____________________________________________________________________________

--- a/src/engine/sparqlExpressions/RegexExpression.h
+++ b/src/engine/sparqlExpressions/RegexExpression.h
@@ -58,7 +58,7 @@ class PrefixRegexExpression : public SparqlExpression {
       const std::optional<Variable>& firstSortedVariable) const override;
 
  private:
-  std::span<Ptr> childrenImpl() override;
+  ql::span<Ptr> childrenImpl() override;
 
   // Check if the `CancellationHandle` of `context` has been cancelled and throw
   // an exception if this is the case.

--- a/src/engine/sparqlExpressions/RegexExpression.h
+++ b/src/engine/sparqlExpressions/RegexExpression.h
@@ -58,7 +58,7 @@ class PrefixRegexExpression : public SparqlExpression {
       const std::optional<Variable>& firstSortedVariable) const override;
 
  private:
-  std::span<Ptr> childrenImpl() override;
+  absl::Span<Ptr> childrenImpl() override;
 
   // Check if the `CancellationHandle` of `context` has been cancelled and throw
   // an exception if this is the case.

--- a/src/engine/sparqlExpressions/RegexExpression.h
+++ b/src/engine/sparqlExpressions/RegexExpression.h
@@ -58,7 +58,7 @@ class PrefixRegexExpression : public SparqlExpression {
       const std::optional<Variable>& firstSortedVariable) const override;
 
  private:
-  absl::Span<Ptr> childrenImpl() override;
+  std::span<Ptr> childrenImpl() override;
 
   // Check if the `CancellationHandle` of `context` has been cancelled and throw
   // an exception if this is the case.

--- a/src/engine/sparqlExpressions/RelationalExpressions.cpp
+++ b/src/engine/sparqlExpressions/RelationalExpressions.cpp
@@ -289,11 +289,7 @@ string RelationalExpression<Comp>::getCacheKey(
 // _____________________________________________________________________________
 template <Comparison Comp>
 ql::span<SparqlExpression::Ptr> RelationalExpression<Comp>::childrenImpl() {
-#ifdef QLEVER_CPP_17
-  return {children_.data(), static_cast<std::ptrdiff_t>(children_.size())};
-#else
   return {children_.data(), children_.size()};
-#endif
 }
 
 // _____________________________________________________________________________

--- a/src/engine/sparqlExpressions/RelationalExpressions.cpp
+++ b/src/engine/sparqlExpressions/RelationalExpressions.cpp
@@ -288,8 +288,12 @@ string RelationalExpression<Comp>::getCacheKey(
 
 // _____________________________________________________________________________
 template <Comparison Comp>
-std::span<SparqlExpression::Ptr> RelationalExpression<Comp>::childrenImpl() {
+ql::span<SparqlExpression::Ptr> RelationalExpression<Comp>::childrenImpl() {
+#ifdef QLEVER_CPP_17
+  return {children_.data(), static_cast<std::ptrdiff_t>(children_.size())};
+#else
   return {children_.data(), children_.size()};
+#endif
 }
 
 // _____________________________________________________________________________
@@ -502,7 +506,7 @@ RelationalExpression<comp>::getPrefilterExpressionForMetadata(
 }
 
 // _____________________________________________________________________________
-std::span<SparqlExpression::Ptr> InExpression::childrenImpl() {
+ql::span<SparqlExpression::Ptr> InExpression::childrenImpl() {
   return children_;
 }
 

--- a/src/engine/sparqlExpressions/RelationalExpressions.cpp
+++ b/src/engine/sparqlExpressions/RelationalExpressions.cpp
@@ -288,8 +288,8 @@ string RelationalExpression<Comp>::getCacheKey(
 
 // _____________________________________________________________________________
 template <Comparison Comp>
-std::span<SparqlExpression::Ptr> RelationalExpression<Comp>::childrenImpl() {
-  return {children_.data(), children_.size()};
+absl::Span<SparqlExpression::Ptr> RelationalExpression<Comp>::childrenImpl() {
+  return absl::MakeSpan(children_.data(), children_.size());
 }
 
 // _____________________________________________________________________________
@@ -502,8 +502,8 @@ RelationalExpression<comp>::getPrefilterExpressionForMetadata(
 }
 
 // _____________________________________________________________________________
-std::span<SparqlExpression::Ptr> InExpression::childrenImpl() {
-  return children_;
+absl::Span<SparqlExpression::Ptr> InExpression::childrenImpl() {
+  return absl::MakeSpan(children_.data(), children_.size());
 }
 
 // _____________________________________________________________________________

--- a/src/engine/sparqlExpressions/RelationalExpressions.cpp
+++ b/src/engine/sparqlExpressions/RelationalExpressions.cpp
@@ -288,8 +288,8 @@ string RelationalExpression<Comp>::getCacheKey(
 
 // _____________________________________________________________________________
 template <Comparison Comp>
-absl::Span<SparqlExpression::Ptr> RelationalExpression<Comp>::childrenImpl() {
-  return absl::MakeSpan(children_.data(), children_.size());
+std::span<SparqlExpression::Ptr> RelationalExpression<Comp>::childrenImpl() {
+  return {children_.data(), children_.size()};
 }
 
 // _____________________________________________________________________________
@@ -502,8 +502,8 @@ RelationalExpression<comp>::getPrefilterExpressionForMetadata(
 }
 
 // _____________________________________________________________________________
-absl::Span<SparqlExpression::Ptr> InExpression::childrenImpl() {
-  return absl::MakeSpan(children_.data(), children_.size());
+std::span<SparqlExpression::Ptr> InExpression::childrenImpl() {
+  return children_;
 }
 
 // _____________________________________________________________________________

--- a/src/engine/sparqlExpressions/RelationalExpressions.h
+++ b/src/engine/sparqlExpressions/RelationalExpressions.h
@@ -53,7 +53,7 @@ class RelationalExpression : public SparqlExpression {
       const std::optional<Variable>& firstSortedVariable) const override;
 
  private:
-  std::span<SparqlExpression::Ptr> childrenImpl() override;
+  ql::span<SparqlExpression::Ptr> childrenImpl() override;
 };
 
 // Implementation of the `IN` expression
@@ -85,7 +85,7 @@ class InExpression : public SparqlExpression {
       const std::optional<Variable>& firstSortedVariable) const override;
 
  private:
-  std::span<SparqlExpression::Ptr> childrenImpl() override;
+  ql::span<SparqlExpression::Ptr> childrenImpl() override;
 };
 
 }  // namespace sparqlExpression::relational

--- a/src/engine/sparqlExpressions/RelationalExpressions.h
+++ b/src/engine/sparqlExpressions/RelationalExpressions.h
@@ -53,7 +53,7 @@ class RelationalExpression : public SparqlExpression {
       const std::optional<Variable>& firstSortedVariable) const override;
 
  private:
-  std::span<SparqlExpression::Ptr> childrenImpl() override;
+  absl::Span<SparqlExpression::Ptr> childrenImpl() override;
 };
 
 // Implementation of the `IN` expression
@@ -85,7 +85,7 @@ class InExpression : public SparqlExpression {
       const std::optional<Variable>& firstSortedVariable) const override;
 
  private:
-  std::span<SparqlExpression::Ptr> childrenImpl() override;
+  absl::Span<SparqlExpression::Ptr> childrenImpl() override;
 };
 
 }  // namespace sparqlExpression::relational

--- a/src/engine/sparqlExpressions/RelationalExpressions.h
+++ b/src/engine/sparqlExpressions/RelationalExpressions.h
@@ -53,7 +53,7 @@ class RelationalExpression : public SparqlExpression {
       const std::optional<Variable>& firstSortedVariable) const override;
 
  private:
-  absl::Span<SparqlExpression::Ptr> childrenImpl() override;
+  std::span<SparqlExpression::Ptr> childrenImpl() override;
 };
 
 // Implementation of the `IN` expression
@@ -85,7 +85,7 @@ class InExpression : public SparqlExpression {
       const std::optional<Variable>& firstSortedVariable) const override;
 
  private:
-  absl::Span<SparqlExpression::Ptr> childrenImpl() override;
+  std::span<SparqlExpression::Ptr> childrenImpl() override;
 };
 
 }  // namespace sparqlExpression::relational

--- a/src/engine/sparqlExpressions/SampleExpression.cpp
+++ b/src/engine/sparqlExpressions/SampleExpression.cpp
@@ -27,7 +27,7 @@ ExpressionResult SampleExpression::evaluate(EvaluationContext* context) const {
     } else if constexpr (std::is_same_v<T, ::Variable>) {
       // TODO<joka921> Can't this be a simpler function (getIdAt)
       AD_CORRECTNESS_CHECK(context->_endIndex > context->_beginIndex);
-      std::span<const ValueId> idOfFirstAsVector = detail::getIdsFromVariable(
+      ql::span<const ValueId> idOfFirstAsVector = detail::getIdsFromVariable(
           childResult, context, context->_beginIndex, context->_endIndex);
       return ExpressionResult{idOfFirstAsVector[0]};
     } else {

--- a/src/engine/sparqlExpressions/SampleExpression.cpp
+++ b/src/engine/sparqlExpressions/SampleExpression.cpp
@@ -27,7 +27,7 @@ ExpressionResult SampleExpression::evaluate(EvaluationContext* context) const {
     } else if constexpr (std::is_same_v<T, ::Variable>) {
       // TODO<joka921> Can't this be a simpler function (getIdAt)
       AD_CORRECTNESS_CHECK(context->_endIndex > context->_beginIndex);
-      absl::Span<const ValueId> idOfFirstAsVector = detail::getIdsFromVariable(
+      std::span<const ValueId> idOfFirstAsVector = detail::getIdsFromVariable(
           childResult, context, context->_beginIndex, context->_endIndex);
       return ExpressionResult{idOfFirstAsVector[0]};
     } else {

--- a/src/engine/sparqlExpressions/SampleExpression.cpp
+++ b/src/engine/sparqlExpressions/SampleExpression.cpp
@@ -27,7 +27,7 @@ ExpressionResult SampleExpression::evaluate(EvaluationContext* context) const {
     } else if constexpr (std::is_same_v<T, ::Variable>) {
       // TODO<joka921> Can't this be a simpler function (getIdAt)
       AD_CORRECTNESS_CHECK(context->_endIndex > context->_beginIndex);
-      std::span<const ValueId> idOfFirstAsVector = detail::getIdsFromVariable(
+      absl::Span<const ValueId> idOfFirstAsVector = detail::getIdsFromVariable(
           childResult, context, context->_beginIndex, context->_endIndex);
       return ExpressionResult{idOfFirstAsVector[0]};
     } else {

--- a/src/engine/sparqlExpressions/SampleExpression.h
+++ b/src/engine/sparqlExpressions/SampleExpression.h
@@ -25,7 +25,7 @@ class SampleExpression : public SparqlExpression {
   }
 
   // __________________________________________________________________________
-  std::span<Ptr> childrenImpl() override { return {&_child, 1}; }
+  ql::span<Ptr> childrenImpl() override { return {&_child, 1}; }
 
   // SAMPLE is an aggregate, the distinctness doesn't matter, so we return "not
   // distinct", because that allows for more efficient implementations in GROUP

--- a/src/engine/sparqlExpressions/SampleExpression.h
+++ b/src/engine/sparqlExpressions/SampleExpression.h
@@ -25,7 +25,9 @@ class SampleExpression : public SparqlExpression {
   }
 
   // __________________________________________________________________________
-  std::span<Ptr> childrenImpl() override { return {&_child, 1}; }
+  absl::Span<Ptr> childrenImpl() override {
+    return absl::Span<Ptr>(&_child, 1);
+  }
 
   // SAMPLE is an aggregate, the distinctness doesn't matter, so we return "not
   // distinct", because that allows for more efficient implementations in GROUP

--- a/src/engine/sparqlExpressions/SampleExpression.h
+++ b/src/engine/sparqlExpressions/SampleExpression.h
@@ -25,9 +25,7 @@ class SampleExpression : public SparqlExpression {
   }
 
   // __________________________________________________________________________
-  absl::Span<Ptr> childrenImpl() override {
-    return absl::Span<Ptr>(&_child, 1);
-  }
+  std::span<Ptr> childrenImpl() override { return {&_child, 1}; }
 
   // SAMPLE is an aggregate, the distinctness doesn't matter, so we return "not
   // distinct", because that allows for more efficient implementations in GROUP

--- a/src/engine/sparqlExpressions/SparqlExpression.cpp
+++ b/src/engine/sparqlExpressions/SparqlExpression.cpp
@@ -131,7 +131,7 @@ bool SparqlExpression::isConstantExpression() const { return false; }
 bool SparqlExpression::isStrExpression() const { return false; }
 
 // _____________________________________________________________________________
-std::span<const SparqlExpression::Ptr> SparqlExpression::childrenForTesting()
+absl::Span<const SparqlExpression::Ptr> SparqlExpression::childrenForTesting()
     const {
   return children();
 }
@@ -144,18 +144,19 @@ std::vector<SparqlExpression::Ptr> SparqlExpression::moveChildrenOut() && {
 }
 
 // _____________________________________________________________________________
-std::span<SparqlExpression::Ptr> SparqlExpression::children() {
+absl::Span<SparqlExpression::Ptr> SparqlExpression::children() {
   return childrenImpl();
 }
 
 // _____________________________________________________________________________
-std::span<const SparqlExpression::Ptr> SparqlExpression::children() const {
+absl::Span<const SparqlExpression::Ptr> SparqlExpression::children() const {
   auto children = const_cast<SparqlExpression&>(*this).children();
-  return {children.data(), children.size()};
+  return absl::Span<const SparqlExpression::Ptr>(children.data(),
+                                                 children.size());
 }
 
 // _____________________________________________________________________________
-std::span<const Variable> SparqlExpression::getContainedVariablesNonRecursive()
+absl::Span<const Variable> SparqlExpression::getContainedVariablesNonRecursive()
     const {
   // Default implementation: This expression adds no strings or variables.
   return {};

--- a/src/engine/sparqlExpressions/SparqlExpression.cpp
+++ b/src/engine/sparqlExpressions/SparqlExpression.cpp
@@ -131,7 +131,7 @@ bool SparqlExpression::isConstantExpression() const { return false; }
 bool SparqlExpression::isStrExpression() const { return false; }
 
 // _____________________________________________________________________________
-absl::Span<const SparqlExpression::Ptr> SparqlExpression::childrenForTesting()
+std::span<const SparqlExpression::Ptr> SparqlExpression::childrenForTesting()
     const {
   return children();
 }
@@ -144,19 +144,18 @@ std::vector<SparqlExpression::Ptr> SparqlExpression::moveChildrenOut() && {
 }
 
 // _____________________________________________________________________________
-absl::Span<SparqlExpression::Ptr> SparqlExpression::children() {
+std::span<SparqlExpression::Ptr> SparqlExpression::children() {
   return childrenImpl();
 }
 
 // _____________________________________________________________________________
-absl::Span<const SparqlExpression::Ptr> SparqlExpression::children() const {
+std::span<const SparqlExpression::Ptr> SparqlExpression::children() const {
   auto children = const_cast<SparqlExpression&>(*this).children();
-  return absl::Span<const SparqlExpression::Ptr>(children.data(),
-                                                 children.size());
+  return {children.data(), children.size()};
 }
 
 // _____________________________________________________________________________
-absl::Span<const Variable> SparqlExpression::getContainedVariablesNonRecursive()
+std::span<const Variable> SparqlExpression::getContainedVariablesNonRecursive()
     const {
   // Default implementation: This expression adds no strings or variables.
   return {};

--- a/src/engine/sparqlExpressions/SparqlExpression.cpp
+++ b/src/engine/sparqlExpressions/SparqlExpression.cpp
@@ -61,7 +61,7 @@ auto SparqlExpression::isAggregate() const -> AggregateStatus {
 // _____________________________________________________________________________
 std::unique_ptr<SparqlExpression> SparqlExpression::replaceChild(
     size_t childIndex, std::unique_ptr<SparqlExpression> newExpression) {
-  AD_CONTRACT_CHECK(childIndex < children().size());
+  AD_CONTRACT_CHECK(childIndex < static_cast<size_t>(children().size()));
   return std::exchange(children()[childIndex], std::move(newExpression));
 }
 
@@ -131,7 +131,7 @@ bool SparqlExpression::isConstantExpression() const { return false; }
 bool SparqlExpression::isStrExpression() const { return false; }
 
 // _____________________________________________________________________________
-std::span<const SparqlExpression::Ptr> SparqlExpression::childrenForTesting()
+ql::span<const SparqlExpression::Ptr> SparqlExpression::childrenForTesting()
     const {
   return children();
 }
@@ -144,18 +144,18 @@ std::vector<SparqlExpression::Ptr> SparqlExpression::moveChildrenOut() && {
 }
 
 // _____________________________________________________________________________
-std::span<SparqlExpression::Ptr> SparqlExpression::children() {
+ql::span<SparqlExpression::Ptr> SparqlExpression::children() {
   return childrenImpl();
 }
 
 // _____________________________________________________________________________
-std::span<const SparqlExpression::Ptr> SparqlExpression::children() const {
+ql::span<const SparqlExpression::Ptr> SparqlExpression::children() const {
   auto children = const_cast<SparqlExpression&>(*this).children();
   return {children.data(), children.size()};
 }
 
 // _____________________________________________________________________________
-std::span<const Variable> SparqlExpression::getContainedVariablesNonRecursive()
+ql::span<const Variable> SparqlExpression::getContainedVariablesNonRecursive()
     const {
   // Default implementation: This expression adds no strings or variables.
   return {};

--- a/src/engine/sparqlExpressions/SparqlExpression.cpp
+++ b/src/engine/sparqlExpressions/SparqlExpression.cpp
@@ -61,7 +61,7 @@ auto SparqlExpression::isAggregate() const -> AggregateStatus {
 // _____________________________________________________________________________
 std::unique_ptr<SparqlExpression> SparqlExpression::replaceChild(
     size_t childIndex, std::unique_ptr<SparqlExpression> newExpression) {
-  AD_CONTRACT_CHECK(childIndex < static_cast<size_t>(children().size()));
+  AD_CONTRACT_CHECK(childIndex < children().size());
   return std::exchange(children()[childIndex], std::move(newExpression));
 }
 

--- a/src/engine/sparqlExpressions/SparqlExpression.h
+++ b/src/engine/sparqlExpressions/SparqlExpression.h
@@ -144,14 +144,14 @@ class SparqlExpression {
 
   // Returns all the children of this expression. Typically only used for
   // testing
-  virtual std::span<const SparqlExpression::Ptr> childrenForTesting()
+  virtual ql::span<const SparqlExpression::Ptr> childrenForTesting()
       const final;
 
   virtual std::vector<SparqlExpression::Ptr> moveChildrenOut() && final;
 
   // Get the direct child expressions.
-  virtual std::span<SparqlExpression::Ptr> children() final;
-  virtual std::span<const SparqlExpression::Ptr> children() const final;
+  virtual ql::span<SparqlExpression::Ptr> children() final;
+  virtual ql::span<const SparqlExpression::Ptr> children() const final;
 
   // Return true if this expression or any of its ancestors in the expression
   // tree is an aggregate. For an example usage see the `LiteralExpression`
@@ -159,12 +159,12 @@ class SparqlExpression {
   bool isInsideAggregate() const;
 
  private:
-  virtual std::span<SparqlExpression::Ptr> childrenImpl() = 0;
+  virtual ql::span<SparqlExpression::Ptr> childrenImpl() = 0;
 
   // Helper function for strings(). Get all variables, iris, and string literals
   // that are included in this expression directly, ignoring possible child
   // expressions.
-  virtual std::span<const Variable> getContainedVariablesNonRecursive() const;
+  virtual ql::span<const Variable> getContainedVariablesNonRecursive() const;
 
  protected:
   // After calling this function, `isInsideAlias()` (see below) returns true for

--- a/src/engine/sparqlExpressions/SparqlExpression.h
+++ b/src/engine/sparqlExpressions/SparqlExpression.h
@@ -6,9 +6,9 @@
 #define QLEVER_SRC_ENGINE_SPARQLEXPRESSIONS_SPARQLEXPRESSION_H
 
 #include <memory>
-#include <span>
 #include <vector>
 
+#include "backports/span.h"
 #include "engine/sparqlExpressions/SparqlExpressionPimpl.h"
 #include "engine/sparqlExpressions/SparqlExpressionTypes.h"
 #include "parser/data/Variable.h"

--- a/src/engine/sparqlExpressions/SparqlExpression.h
+++ b/src/engine/sparqlExpressions/SparqlExpression.h
@@ -144,14 +144,14 @@ class SparqlExpression {
 
   // Returns all the children of this expression. Typically only used for
   // testing
-  virtual absl::Span<const SparqlExpression::Ptr> childrenForTesting()
+  virtual std::span<const SparqlExpression::Ptr> childrenForTesting()
       const final;
 
   virtual std::vector<SparqlExpression::Ptr> moveChildrenOut() && final;
 
   // Get the direct child expressions.
-  virtual absl::Span<SparqlExpression::Ptr> children() final;
-  virtual absl::Span<const SparqlExpression::Ptr> children() const final;
+  virtual std::span<SparqlExpression::Ptr> children() final;
+  virtual std::span<const SparqlExpression::Ptr> children() const final;
 
   // Return true if this expression or any of its ancestors in the expression
   // tree is an aggregate. For an example usage see the `LiteralExpression`
@@ -159,12 +159,12 @@ class SparqlExpression {
   bool isInsideAggregate() const;
 
  private:
-  virtual absl::Span<SparqlExpression::Ptr> childrenImpl() = 0;
+  virtual std::span<SparqlExpression::Ptr> childrenImpl() = 0;
 
   // Helper function for strings(). Get all variables, iris, and string literals
   // that are included in this expression directly, ignoring possible child
   // expressions.
-  virtual absl::Span<const Variable> getContainedVariablesNonRecursive() const;
+  virtual std::span<const Variable> getContainedVariablesNonRecursive() const;
 
  protected:
   // After calling this function, `isInsideAlias()` (see below) returns true for

--- a/src/engine/sparqlExpressions/SparqlExpression.h
+++ b/src/engine/sparqlExpressions/SparqlExpression.h
@@ -144,14 +144,14 @@ class SparqlExpression {
 
   // Returns all the children of this expression. Typically only used for
   // testing
-  virtual std::span<const SparqlExpression::Ptr> childrenForTesting()
+  virtual absl::Span<const SparqlExpression::Ptr> childrenForTesting()
       const final;
 
   virtual std::vector<SparqlExpression::Ptr> moveChildrenOut() && final;
 
   // Get the direct child expressions.
-  virtual std::span<SparqlExpression::Ptr> children() final;
-  virtual std::span<const SparqlExpression::Ptr> children() const final;
+  virtual absl::Span<SparqlExpression::Ptr> children() final;
+  virtual absl::Span<const SparqlExpression::Ptr> children() const final;
 
   // Return true if this expression or any of its ancestors in the expression
   // tree is an aggregate. For an example usage see the `LiteralExpression`
@@ -159,12 +159,12 @@ class SparqlExpression {
   bool isInsideAggregate() const;
 
  private:
-  virtual std::span<SparqlExpression::Ptr> childrenImpl() = 0;
+  virtual absl::Span<SparqlExpression::Ptr> childrenImpl() = 0;
 
   // Helper function for strings(). Get all variables, iris, and string literals
   // that are included in this expression directly, ignoring possible child
   // expressions.
-  virtual std::span<const Variable> getContainedVariablesNonRecursive() const;
+  virtual absl::Span<const Variable> getContainedVariablesNonRecursive() const;
 
  protected:
   // After calling this function, `isInsideAlias()` (see below) returns true for

--- a/src/engine/sparqlExpressions/SparqlExpressionGenerators.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionGenerators.h
@@ -17,7 +17,7 @@ namespace sparqlExpression::detail {
 
 /// Convert a variable to a vector of all the Ids it is bound to in the
 /// `context`.
-inline absl::Span<const ValueId> getIdsFromVariable(
+inline std::span<const ValueId> getIdsFromVariable(
     const ::Variable& variable, const EvaluationContext* context,
     size_t beginIndex, size_t endIndex) {
   const auto& inputTable = context->_inputTable;
@@ -28,17 +28,17 @@ inline absl::Span<const ValueId> getIdsFromVariable(
 
   const size_t columnIndex = it->second.columnIndex_;
 
-  absl::Span<const ValueId> completeColumn = inputTable.getColumn(columnIndex);
+  std::span<const ValueId> completeColumn = inputTable.getColumn(columnIndex);
 
   AD_CONTRACT_CHECK(beginIndex <= endIndex &&
                     endIndex <= completeColumn.size());
-  return absl::Span<const ValueId>(completeColumn.data() + beginIndex,
-                                   endIndex - beginIndex);
+  return {completeColumn.begin() + beginIndex,
+          completeColumn.begin() + endIndex};
 }
 
 // Overload that reads the `beginIndex` and the `endIndex` directly from the
 // `context
-inline absl::Span<const ValueId> getIdsFromVariable(
+inline std::span<const ValueId> getIdsFromVariable(
     const ::Variable& variable, const EvaluationContext* context) {
   return getIdsFromVariable(variable, context, context->_beginIndex,
                             context->_endIndex);

--- a/src/engine/sparqlExpressions/SparqlExpressionGenerators.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionGenerators.h
@@ -17,7 +17,7 @@ namespace sparqlExpression::detail {
 
 /// Convert a variable to a vector of all the Ids it is bound to in the
 /// `context`.
-inline std::span<const ValueId> getIdsFromVariable(
+inline absl::Span<const ValueId> getIdsFromVariable(
     const ::Variable& variable, const EvaluationContext* context,
     size_t beginIndex, size_t endIndex) {
   const auto& inputTable = context->_inputTable;
@@ -28,17 +28,17 @@ inline std::span<const ValueId> getIdsFromVariable(
 
   const size_t columnIndex = it->second.columnIndex_;
 
-  std::span<const ValueId> completeColumn = inputTable.getColumn(columnIndex);
+  absl::Span<const ValueId> completeColumn = inputTable.getColumn(columnIndex);
 
   AD_CONTRACT_CHECK(beginIndex <= endIndex &&
                     endIndex <= completeColumn.size());
-  return {completeColumn.begin() + beginIndex,
-          completeColumn.begin() + endIndex};
+  return absl::Span<const ValueId>(completeColumn.data() + beginIndex,
+                                   endIndex - beginIndex);
 }
 
 // Overload that reads the `beginIndex` and the `endIndex` directly from the
 // `context
-inline std::span<const ValueId> getIdsFromVariable(
+inline absl::Span<const ValueId> getIdsFromVariable(
     const ::Variable& variable, const EvaluationContext* context) {
   return getIdsFromVariable(variable, context, context->_beginIndex,
                             context->_endIndex);

--- a/src/engine/sparqlExpressions/SparqlExpressionGenerators.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionGenerators.h
@@ -31,7 +31,7 @@ inline ql::span<const ValueId> getIdsFromVariable(
   ql::span<const ValueId> completeColumn = inputTable.getColumn(columnIndex);
 
   AD_CONTRACT_CHECK(beginIndex <= endIndex &&
-                    endIndex <= static_cast<size_t>(completeColumn.size()));
+                    endIndex <= completeColumn.size());
   return {completeColumn.begin() + beginIndex,
           completeColumn.begin() + endIndex};
 }
@@ -65,7 +65,7 @@ CPP_template(typename T, typename Transformation = std::identity)(
     requires ql::ranges::input_range<
         T>) auto resultGenerator(T&& vector, size_t numItems,
                                  Transformation transformation = {}) {
-  AD_CONTRACT_CHECK(numItems == static_cast<size_t>(vector.size()));
+  AD_CONTRACT_CHECK(numItems == vector.size());
   return ad_utility::allView(AD_FWD(vector)) |
          ql::views::transform(std::move(transformation));
 }

--- a/src/engine/sparqlExpressions/SparqlExpressionGenerators.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionGenerators.h
@@ -17,7 +17,7 @@ namespace sparqlExpression::detail {
 
 /// Convert a variable to a vector of all the Ids it is bound to in the
 /// `context`.
-inline std::span<const ValueId> getIdsFromVariable(
+inline ql::span<const ValueId> getIdsFromVariable(
     const ::Variable& variable, const EvaluationContext* context,
     size_t beginIndex, size_t endIndex) {
   const auto& inputTable = context->_inputTable;
@@ -28,17 +28,17 @@ inline std::span<const ValueId> getIdsFromVariable(
 
   const size_t columnIndex = it->second.columnIndex_;
 
-  std::span<const ValueId> completeColumn = inputTable.getColumn(columnIndex);
+  ql::span<const ValueId> completeColumn = inputTable.getColumn(columnIndex);
 
   AD_CONTRACT_CHECK(beginIndex <= endIndex &&
-                    endIndex <= completeColumn.size());
+                    endIndex <= static_cast<size_t>(completeColumn.size()));
   return {completeColumn.begin() + beginIndex,
           completeColumn.begin() + endIndex};
 }
 
 // Overload that reads the `beginIndex` and the `endIndex` directly from the
 // `context
-inline std::span<const ValueId> getIdsFromVariable(
+inline ql::span<const ValueId> getIdsFromVariable(
     const ::Variable& variable, const EvaluationContext* context) {
   return getIdsFromVariable(variable, context, context->_beginIndex,
                             context->_endIndex);
@@ -65,7 +65,7 @@ CPP_template(typename T, typename Transformation = std::identity)(
     requires ql::ranges::input_range<
         T>) auto resultGenerator(T&& vector, size_t numItems,
                                  Transformation transformation = {}) {
-  AD_CONTRACT_CHECK(numItems == vector.size());
+  AD_CONTRACT_CHECK(numItems == static_cast<size_t>(vector.size()));
   return ad_utility::allView(AD_FWD(vector)) |
          ql::views::transform(std::move(transformation));
 }

--- a/src/engine/sparqlExpressions/SparqlExpressionGenerators.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionGenerators.h
@@ -8,6 +8,8 @@
 #ifndef QLEVER_SRC_ENGINE_SPARQLEXPRESSIONS_SPARQLEXPRESSIONGENERATORS_H
 #define QLEVER_SRC_ENGINE_SPARQLEXPRESSIONS_SPARQLEXPRESSIONGENERATORS_H
 
+#include <absl/functional/bind_front.h>
+
 #include "engine/sparqlExpressions/SparqlExpression.h"
 #include "util/Generator.h"
 
@@ -158,12 +160,12 @@ CPP_template(typename Operation, typename... Operands)(requires(
 
   // Function that takes a single operand and a single value getter and computes
   // the corresponding generator.
-  auto getValue = std::bind_front(valueGetterGenerator, numElements, context);
+  auto getValue = absl::bind_front(valueGetterGenerator, numElements, context);
 
   // Function that takes all the generators as a parameter pack and computes the
   // generator for the operation result;
   auto getResultFromGenerators =
-      std::bind_front(applyFunction, Function{}, numElements);
+      absl::bind_front(applyFunction, Function{}, numElements);
 
   /// The `ValueGetters` are stored in a `std::tuple`, so we have to extract
   /// them via `std::apply`. First set up a lambda that performs the actual

--- a/src/engine/sparqlExpressions/SparqlExpressionTypes.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionTypes.h
@@ -145,7 +145,7 @@ constexpr static bool isConstantResult =
 template <typename T>
 constexpr static bool isVectorResult =
     ad_utility::SimilarToAnyTypeIn<T, detail::ConstantTypesAsVector> ||
-    ad_utility::isSimilar<T, std::span<const ValueId>>;
+    ad_utility::isSimilar<T, ql::span<const ValueId>>;
 
 /// All the additional information which is needed to evaluate a SPARQL
 /// expression.

--- a/src/engine/sparqlExpressions/SparqlExpressionTypes.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionTypes.h
@@ -145,7 +145,7 @@ constexpr static bool isConstantResult =
 template <typename T>
 constexpr static bool isVectorResult =
     ad_utility::SimilarToAnyTypeIn<T, detail::ConstantTypesAsVector> ||
-    ad_utility::isSimilar<T, absl::Span<const ValueId>>;
+    ad_utility::isSimilar<T, std::span<const ValueId>>;
 
 /// All the additional information which is needed to evaluate a SPARQL
 /// expression.

--- a/src/engine/sparqlExpressions/SparqlExpressionTypes.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionTypes.h
@@ -145,7 +145,7 @@ constexpr static bool isConstantResult =
 template <typename T>
 constexpr static bool isVectorResult =
     ad_utility::SimilarToAnyTypeIn<T, detail::ConstantTypesAsVector> ||
-    ad_utility::isSimilar<T, std::span<const ValueId>>;
+    ad_utility::isSimilar<T, absl::Span<const ValueId>>;
 
 /// All the additional information which is needed to evaluate a SPARQL
 /// expression.

--- a/src/engine/sparqlExpressions/StdevExpression.h
+++ b/src/engine/sparqlExpressions/StdevExpression.h
@@ -49,7 +49,7 @@ class DeviationExpression : public SparqlExpression {
 
  private:
   // _________________________________________________________________________
-  std::span<SparqlExpression::Ptr> childrenImpl() override {
+  ql::span<SparqlExpression::Ptr> childrenImpl() override {
     return {&child_, 1};
   }
 };
@@ -66,7 +66,7 @@ class DeviationAggExpression
                          AggregateOperation aggregateOp = AggregateOperation{})
       : AggregateExpression<AggregateOperation, FinalOperation>(
             distinct, std::make_unique<DeviationExpression>(std::move(child)),
-            aggregateOp){};
+            aggregateOp) {};
 };
 
 // The final operation for dividing by degrees of freedom and calculation square

--- a/src/engine/sparqlExpressions/StdevExpression.h
+++ b/src/engine/sparqlExpressions/StdevExpression.h
@@ -49,8 +49,8 @@ class DeviationExpression : public SparqlExpression {
 
  private:
   // _________________________________________________________________________
-  std::span<SparqlExpression::Ptr> childrenImpl() override {
-    return {&child_, 1};
+  absl::Span<SparqlExpression::Ptr> childrenImpl() override {
+    return absl::Span<SparqlExpression::Ptr>(&child_, 1);
   }
 };
 
@@ -66,7 +66,7 @@ class DeviationAggExpression
                          AggregateOperation aggregateOp = AggregateOperation{})
       : AggregateExpression<AggregateOperation, FinalOperation>(
             distinct, std::make_unique<DeviationExpression>(std::move(child)),
-            aggregateOp){};
+            aggregateOp) {};
 };
 
 // The final operation for dividing by degrees of freedom and calculation square

--- a/src/engine/sparqlExpressions/StdevExpression.h
+++ b/src/engine/sparqlExpressions/StdevExpression.h
@@ -49,8 +49,8 @@ class DeviationExpression : public SparqlExpression {
 
  private:
   // _________________________________________________________________________
-  absl::Span<SparqlExpression::Ptr> childrenImpl() override {
-    return absl::Span<SparqlExpression::Ptr>(&child_, 1);
+  std::span<SparqlExpression::Ptr> childrenImpl() override {
+    return {&child_, 1};
   }
 };
 

--- a/src/engine/sparqlExpressions/StdevExpression.h
+++ b/src/engine/sparqlExpressions/StdevExpression.h
@@ -66,7 +66,7 @@ class DeviationAggExpression
                          AggregateOperation aggregateOp = AggregateOperation{})
       : AggregateExpression<AggregateOperation, FinalOperation>(
             distinct, std::make_unique<DeviationExpression>(std::move(child)),
-            aggregateOp) {};
+            aggregateOp){};
 };
 
 // The final operation for dividing by degrees of freedom and calculation square

--- a/src/engine/sparqlExpressions/StringExpressionsHelper.h
+++ b/src/engine/sparqlExpressions/StringExpressionsHelper.h
@@ -52,7 +52,7 @@ class StringExpressionImplImpl : public SparqlExpression {
   }
 
  private:
-  std::span<Ptr> childrenImpl() override { return impl_->children(); }
+  ql::span<Ptr> childrenImpl() override { return impl_->children(); }
 };
 
 // Impl class for expressions that work on plain strings.

--- a/src/engine/sparqlExpressions/StringExpressionsHelper.h
+++ b/src/engine/sparqlExpressions/StringExpressionsHelper.h
@@ -52,7 +52,9 @@ class StringExpressionImplImpl : public SparqlExpression {
   }
 
  private:
-  std::span<Ptr> childrenImpl() override { return impl_->children(); }
+  absl::Span<Ptr> childrenImpl() override {
+    return absl::MakeSpan(impl_->children().data(), impl_->children().size());
+  }
 };
 
 // Impl class for expressions that work on plain strings.

--- a/src/engine/sparqlExpressions/StringExpressionsHelper.h
+++ b/src/engine/sparqlExpressions/StringExpressionsHelper.h
@@ -52,9 +52,7 @@ class StringExpressionImplImpl : public SparqlExpression {
   }
 
  private:
-  absl::Span<Ptr> childrenImpl() override {
-    return absl::MakeSpan(impl_->children().data(), impl_->children().size());
-  }
+  std::span<Ptr> childrenImpl() override { return impl_->children(); }
 };
 
 // Impl class for expressions that work on plain strings.

--- a/src/engine/sparqlExpressions/UuidExpressions.h
+++ b/src/engine/sparqlExpressions/UuidExpressions.h
@@ -69,7 +69,7 @@ class UuidExpressionImpl : public SparqlExpression {
   }
 
  private:
-  std::span<SparqlExpression::Ptr> childrenImpl() override { return {}; }
+  ql::span<SparqlExpression::Ptr> childrenImpl() override { return {}; }
 };
 
 }  //  namespace detail::uuidExpression

--- a/src/engine/sparqlExpressions/UuidExpressions.h
+++ b/src/engine/sparqlExpressions/UuidExpressions.h
@@ -69,7 +69,7 @@ class UuidExpressionImpl : public SparqlExpression {
   }
 
  private:
-  std::span<SparqlExpression::Ptr> childrenImpl() override { return {}; }
+  absl::Span<SparqlExpression::Ptr> childrenImpl() override { return {}; }
 };
 
 }  //  namespace detail::uuidExpression

--- a/src/engine/sparqlExpressions/UuidExpressions.h
+++ b/src/engine/sparqlExpressions/UuidExpressions.h
@@ -69,7 +69,7 @@ class UuidExpressionImpl : public SparqlExpression {
   }
 
  private:
-  absl::Span<SparqlExpression::Ptr> childrenImpl() override { return {}; }
+  std::span<SparqlExpression::Ptr> childrenImpl() override { return {}; }
 };
 
 }  //  namespace detail::uuidExpression

--- a/src/engine/sparqlExpressions/VariadicExpression.h
+++ b/src/engine/sparqlExpressions/VariadicExpression.h
@@ -44,11 +44,7 @@ class VariadicExpression : public SparqlExpression {
  private:
   // ___________________________________________________
   ql::span<SparqlExpression::Ptr> childrenImpl() override {
-#ifdef QLEVER_CPP_17
-    return {children_.data(), static_cast<std::ptrdiff_t>(children_.size())};
-#else
     return {children_.data(), children_.size()};
-#endif
   }
 };
 

--- a/src/engine/sparqlExpressions/VariadicExpression.h
+++ b/src/engine/sparqlExpressions/VariadicExpression.h
@@ -43,8 +43,8 @@ class VariadicExpression : public SparqlExpression {
 
  private:
   // ___________________________________________________
-  std::span<SparqlExpression::Ptr> childrenImpl() override {
-    return {children_.data(), children_.size()};
+  absl::Span<SparqlExpression::Ptr> childrenImpl() override {
+    return absl::MakeSpan(children_.data(), children_.size());
   }
 };
 

--- a/src/engine/sparqlExpressions/VariadicExpression.h
+++ b/src/engine/sparqlExpressions/VariadicExpression.h
@@ -43,8 +43,8 @@ class VariadicExpression : public SparqlExpression {
 
  private:
   // ___________________________________________________
-  absl::Span<SparqlExpression::Ptr> childrenImpl() override {
-    return absl::MakeSpan(children_.data(), children_.size());
+  std::span<SparqlExpression::Ptr> childrenImpl() override {
+    return {children_.data(), children_.size()};
   }
 };
 

--- a/src/engine/sparqlExpressions/VariadicExpression.h
+++ b/src/engine/sparqlExpressions/VariadicExpression.h
@@ -43,8 +43,12 @@ class VariadicExpression : public SparqlExpression {
 
  private:
   // ___________________________________________________
-  std::span<SparqlExpression::Ptr> childrenImpl() override {
+  ql::span<SparqlExpression::Ptr> childrenImpl() override {
+#ifdef QLEVER_CPP_17
+    return {children_.data(), static_cast<std::ptrdiff_t>(children_.size())};
+#else
     return {children_.data(), children_.size()};
+#endif
   }
 };
 

--- a/src/global/Pattern.h
+++ b/src/global/Pattern.h
@@ -55,7 +55,7 @@ class CompactVectorOfStrings {
   using offset_type = uint64_t;
   using value_type =
       std::conditional_t<std::is_same_v<data_type, char>, std::string_view,
-                         std::span<const data_type>>;
+                         absl::Span<const data_type>>;
   using vector_type = std::conditional_t<std::is_same_v<data_type, char>,
                                          std::string, std::vector<data_type>>;
 

--- a/src/global/Pattern.h
+++ b/src/global/Pattern.h
@@ -123,15 +123,7 @@ class CompactVectorOfStrings {
     offset_type offset = offsets_[i];
     const data_type* ptr = data_.data() + offset;
     size_t size = offsets_[i + 1] - offset;
-#ifdef QLEVER_CPP_17
-    if constexpr (std::is_same_v<data_type, char>) {
-      return {ptr, size};
-    } else {
-      return {ptr, static_cast<std::ptrdiff_t>(size)};
-    }
-#else
     return {ptr, size};
-#endif
   }
 
   // Forward iterator for a `CompactVectorOfStrings` that reads directly from

--- a/src/global/Pattern.h
+++ b/src/global/Pattern.h
@@ -10,12 +10,12 @@
 #include <cstdlib>
 #include <cstring>
 #include <limits>
-#include <span>
 #include <stdexcept>
 #include <string>
 #include <vector>
 
 #include "backports/concepts.h"
+#include "backports/span.h"
 #include "global/Id.h"
 #include "util/ExceptionHandling.h"
 #include "util/File.h"
@@ -55,7 +55,7 @@ class CompactVectorOfStrings {
   using offset_type = uint64_t;
   using value_type =
       std::conditional_t<std::is_same_v<data_type, char>, std::string_view,
-                         std::span<const data_type>>;
+                         ql::span<const data_type>>;
   using vector_type = std::conditional_t<std::is_same_v<data_type, char>,
                                          std::string, std::vector<data_type>>;
 
@@ -123,7 +123,15 @@ class CompactVectorOfStrings {
     offset_type offset = offsets_[i];
     const data_type* ptr = data_.data() + offset;
     size_t size = offsets_[i + 1] - offset;
+#ifdef QLEVER_CPP_17
+    if constexpr (std::is_same_v<data_type, char>) {
+      return {ptr, size};
+    } else {
+      return {ptr, static_cast<std::ptrdiff_t>(size)};
+    }
+#else
     return {ptr, size};
+#endif
   }
 
   // Forward iterator for a `CompactVectorOfStrings` that reads directly from

--- a/src/global/Pattern.h
+++ b/src/global/Pattern.h
@@ -55,7 +55,7 @@ class CompactVectorOfStrings {
   using offset_type = uint64_t;
   using value_type =
       std::conditional_t<std::is_same_v<data_type, char>, std::string_view,
-                         absl::Span<const data_type>>;
+                         std::span<const data_type>>;
   using vector_type = std::conditional_t<std::is_same_v<data_type, char>,
                                          std::string, std::vector<data_type>>;
 

--- a/src/global/ValueId.h
+++ b/src/global/ValueId.h
@@ -91,7 +91,7 @@ class ValueId {
   /// loss of `FoldedId`. Symmetrically, `-minPositiveDouble` is the largest
   /// double <0 that will not be rounded to zero.
   static constexpr double minPositiveDouble =
-      std::bit_cast<double>(1ull << numDatatypeBits);
+      absl::bit_cast<double>(1ull << numDatatypeBits);
 
   // The largest representable integer value.
   static constexpr int64_t maxInt = IntegerType::max();
@@ -233,13 +233,13 @@ class ValueId {
   /// precision of the mantissa of an IEEE double precision floating point
   /// number from 53 to 49 significant bits.
   static ValueId makeFromDouble(double d) {
-    auto shifted = std::bit_cast<T>(d) >> numDatatypeBits;
+    auto shifted = absl::bit_cast<T>(d) >> numDatatypeBits;
     return addDatatypeBits(shifted, Datatype::Double);
   }
   /// Obtain the `double` that this `ValueId` encodes. If `getDatatype() !=
   /// Double` then the result is unspecified.
   [[nodiscard]] double getDouble() const noexcept {
-    return std::bit_cast<double>(_bits << numDatatypeBits);
+    return absl::bit_cast<double>(_bits << numDatatypeBits);
   }
 
   /// Create a `ValueId` for a signed integer value. Integers in the range
@@ -313,11 +313,11 @@ class ValueId {
 
   // Store or load a `Date` object.
   static ValueId makeFromDate(DateYearOrDuration d) noexcept {
-    return addDatatypeBits(std::bit_cast<uint64_t>(d), Datatype::Date);
+    return addDatatypeBits(absl::bit_cast<uint64_t>(d), Datatype::Date);
   }
 
   DateYearOrDuration getDate() const noexcept {
-    return std::bit_cast<DateYearOrDuration>(removeDatatypeBits(_bits));
+    return absl::bit_cast<DateYearOrDuration>(removeDatatypeBits(_bits));
   }
 
   // TODO<joka921> implement dates

--- a/src/global/ValueIdComparators.h
+++ b/src/global/ValueIdComparators.h
@@ -195,7 +195,7 @@ inline std::vector<std::pair<RandomIt, RandomIt>> getRangesForDouble(
   // In `ids` the negative number stand AFTER the positive numbers because of
   // the bitOrdering. First rotate the negative numbers to the beginning.
   auto doubleIdIsNegative = [](ValueId id) -> bool {
-    auto bits = std::bit_cast<uint64_t>(id.getDouble());
+    auto bits = absl::bit_cast<uint64_t>(id.getDouble());
     return bits & ad_utility::bitMaskForHigherBits(1);
   };
 

--- a/src/index/CompressedRelation.cpp
+++ b/src/index/CompressedRelation.cpp
@@ -429,7 +429,7 @@ struct BlockLessThanBlock {
 
 // _____________________________________________________________________________
 std::vector<CompressedBlockMetadata> CompressedRelationReader::getBlocksForJoin(
-    absl::Span<const Id> joinColumn,
+    std::span<const Id> joinColumn,
     const ScanSpecAndBlocksAndBounds& metadataAndBlocks) {
   // Get all the blocks where `col0FirstId_ <= col0Id <= col0LastId_`.
   auto relevantBlocks = getBlocksFromMetadata(metadataAndBlocks);
@@ -533,7 +533,7 @@ CompressedRelationReader::getBlocksForJoin(
 // _____________________________________________________________________________
 IdTable CompressedRelationReader::scan(
     const ScanSpecification& scanSpec,
-    absl::Span<const CompressedBlockMetadata> blocks,
+    std::span<const CompressedBlockMetadata> blocks,
     ColumnIndicesRef additionalColumns,
     const CancellationHandle& cancellationHandle,
     [[maybe_unused]] const LocatedTriplesPerBlock& locatedTriplesPerBlock,
@@ -784,7 +784,7 @@ CPP_template_def(typename IdGetter)(
   };
 
   // Get the blocks needed for the scan.
-  absl::Span<const CompressedBlockMetadata> relevantBlocksMetadata =
+  std::span<const CompressedBlockMetadata> relevantBlocksMetadata =
       getRelevantBlocks(scanSpec, allBlocksMetadata);
 
   // TODO<joka921> We have to read the other columns for the merging of the
@@ -972,7 +972,7 @@ CompressedRelationReader::readAndDecompressBlock(
 
 // ____________________________________________________________________________
 CompressedBlockMetadata::OffsetAndCompressedSize
-CompressedRelationWriter::compressAndWriteColumn(absl::Span<const Id> column) {
+CompressedRelationWriter::compressAndWriteColumn(std::span<const Id> column) {
   std::vector<char> compressedBlock = ZstdWrapper::compress(
       (void*)(column.data()), column.size() * sizeof(column[0]));
   auto compressedSize = compressedBlock.size();
@@ -1055,10 +1055,10 @@ void CompressedRelationWriter::compressAndWriteBlock(
 }
 
 // _____________________________________________________________________________
-absl::Span<const CompressedBlockMetadata>
+std::span<const CompressedBlockMetadata>
 CompressedRelationReader::getRelevantBlocks(
     const ScanSpecification& scanSpec,
-    absl::Span<const CompressedBlockMetadata> blockMetadata) {
+    std::span<const CompressedBlockMetadata> blockMetadata) {
   // Get all the blocks  that possibly might contain our pair of col0Id and
   // col1Id
   CompressedBlockMetadata key;
@@ -1092,7 +1092,7 @@ CompressedRelationReader::getRelevantBlocks(
 }
 
 // _____________________________________________________________________________
-absl::Span<const CompressedBlockMetadata>
+std::span<const CompressedBlockMetadata>
 CompressedRelationReader::getBlocksFromMetadata(
     const ScanSpecAndBlocks& metadata) {
   return getRelevantBlocks(metadata.scanSpec_, metadata.blockMetadata_);

--- a/src/index/CompressedRelation.cpp
+++ b/src/index/CompressedRelation.cpp
@@ -426,7 +426,7 @@ struct BlockLessThanBlock {
 
 // _____________________________________________________________________________
 std::vector<CompressedBlockMetadata> CompressedRelationReader::getBlocksForJoin(
-    std::span<const Id> joinColumn,
+    absl::Span<const Id> joinColumn,
     const ScanSpecAndBlocksAndBounds& metadataAndBlocks) {
   // Get all the blocks where `col0FirstId_ <= col0Id <= col0LastId_`.
   auto relevantBlocks = getBlocksFromMetadata(metadataAndBlocks);
@@ -530,7 +530,7 @@ CompressedRelationReader::getBlocksForJoin(
 // _____________________________________________________________________________
 IdTable CompressedRelationReader::scan(
     const ScanSpecification& scanSpec,
-    std::span<const CompressedBlockMetadata> blocks,
+    absl::Span<const CompressedBlockMetadata> blocks,
     ColumnIndicesRef additionalColumns,
     const CancellationHandle& cancellationHandle,
     [[maybe_unused]] const LocatedTriplesPerBlock& locatedTriplesPerBlock,
@@ -781,7 +781,7 @@ CPP_template_def(typename IdGetter)(
   };
 
   // Get the blocks needed for the scan.
-  std::span<const CompressedBlockMetadata> relevantBlocksMetadata =
+  absl::Span<const CompressedBlockMetadata> relevantBlocksMetadata =
       getRelevantBlocks(scanSpec, allBlocksMetadata);
 
   // TODO<joka921> We have to read the other columns for the merging of the
@@ -969,7 +969,7 @@ CompressedRelationReader::readAndDecompressBlock(
 
 // ____________________________________________________________________________
 CompressedBlockMetadata::OffsetAndCompressedSize
-CompressedRelationWriter::compressAndWriteColumn(std::span<const Id> column) {
+CompressedRelationWriter::compressAndWriteColumn(absl::Span<const Id> column) {
   std::vector<char> compressedBlock = ZstdWrapper::compress(
       (void*)(column.data()), column.size() * sizeof(column[0]));
   auto compressedSize = compressedBlock.size();
@@ -1052,10 +1052,10 @@ void CompressedRelationWriter::compressAndWriteBlock(
 }
 
 // _____________________________________________________________________________
-std::span<const CompressedBlockMetadata>
+absl::Span<const CompressedBlockMetadata>
 CompressedRelationReader::getRelevantBlocks(
     const ScanSpecification& scanSpec,
-    std::span<const CompressedBlockMetadata> blockMetadata) {
+    absl::Span<const CompressedBlockMetadata> blockMetadata) {
   // Get all the blocks  that possibly might contain our pair of col0Id and
   // col1Id
   CompressedBlockMetadata key;
@@ -1089,7 +1089,7 @@ CompressedRelationReader::getRelevantBlocks(
 }
 
 // _____________________________________________________________________________
-std::span<const CompressedBlockMetadata>
+absl::Span<const CompressedBlockMetadata>
 CompressedRelationReader::getBlocksFromMetadata(
     const ScanSpecAndBlocks& metadata) {
   return getRelevantBlocks(metadata.scanSpec_, metadata.blockMetadata_);

--- a/src/index/CompressedRelation.cpp
+++ b/src/index/CompressedRelation.cpp
@@ -429,7 +429,7 @@ struct BlockLessThanBlock {
 
 // _____________________________________________________________________________
 std::vector<CompressedBlockMetadata> CompressedRelationReader::getBlocksForJoin(
-    std::span<const Id> joinColumn,
+    ql::span<const Id> joinColumn,
     const ScanSpecAndBlocksAndBounds& metadataAndBlocks) {
   // Get all the blocks where `col0FirstId_ <= col0Id <= col0LastId_`.
   auto relevantBlocks = getBlocksFromMetadata(metadataAndBlocks);
@@ -533,7 +533,7 @@ CompressedRelationReader::getBlocksForJoin(
 // _____________________________________________________________________________
 IdTable CompressedRelationReader::scan(
     const ScanSpecification& scanSpec,
-    std::span<const CompressedBlockMetadata> blocks,
+    ql::span<const CompressedBlockMetadata> blocks,
     ColumnIndicesRef additionalColumns,
     const CancellationHandle& cancellationHandle,
     [[maybe_unused]] const LocatedTriplesPerBlock& locatedTriplesPerBlock,
@@ -784,7 +784,7 @@ CPP_template_def(typename IdGetter)(
   };
 
   // Get the blocks needed for the scan.
-  std::span<const CompressedBlockMetadata> relevantBlocksMetadata =
+  ql::span<const CompressedBlockMetadata> relevantBlocksMetadata =
       getRelevantBlocks(scanSpec, allBlocksMetadata);
 
   // TODO<joka921> We have to read the other columns for the merging of the
@@ -794,7 +794,8 @@ CPP_template_def(typename IdGetter)(
   // Iterate over the blocks and only read (and decompress) those which
   // contain more than one different `colId`. For the others, we can determine
   // the count from the metadata.
-  for (size_t i = 0; i < relevantBlocksMetadata.size(); ++i) {
+  for (auto i = decltype(relevantBlocksMetadata.size())(0);
+       i < relevantBlocksMetadata.size(); ++i) {
     const auto& blockMetadata = relevantBlocksMetadata[i];
     Id firstColId = std::invoke(idGetter, blockMetadata.firstTriple_);
     Id lastColId = std::invoke(idGetter, blockMetadata.lastTriple_);
@@ -972,7 +973,7 @@ CompressedRelationReader::readAndDecompressBlock(
 
 // ____________________________________________________________________________
 CompressedBlockMetadata::OffsetAndCompressedSize
-CompressedRelationWriter::compressAndWriteColumn(std::span<const Id> column) {
+CompressedRelationWriter::compressAndWriteColumn(ql::span<const Id> column) {
   std::vector<char> compressedBlock = ZstdWrapper::compress(
       (void*)(column.data()), column.size() * sizeof(column[0]));
   auto compressedSize = compressedBlock.size();
@@ -1055,10 +1056,10 @@ void CompressedRelationWriter::compressAndWriteBlock(
 }
 
 // _____________________________________________________________________________
-std::span<const CompressedBlockMetadata>
+ql::span<const CompressedBlockMetadata>
 CompressedRelationReader::getRelevantBlocks(
     const ScanSpecification& scanSpec,
-    std::span<const CompressedBlockMetadata> blockMetadata) {
+    ql::span<const CompressedBlockMetadata> blockMetadata) {
   // Get all the blocks  that possibly might contain our pair of col0Id and
   // col1Id
   CompressedBlockMetadata key;
@@ -1092,7 +1093,7 @@ CompressedRelationReader::getRelevantBlocks(
 }
 
 // _____________________________________________________________________________
-std::span<const CompressedBlockMetadata>
+ql::span<const CompressedBlockMetadata>
 CompressedRelationReader::getBlocksFromMetadata(
     const ScanSpecAndBlocks& metadata) {
   return getRelevantBlocks(metadata.scanSpec_, metadata.blockMetadata_);

--- a/src/index/CompressedRelation.cpp
+++ b/src/index/CompressedRelation.cpp
@@ -495,8 +495,8 @@ CompressedRelationReader::getBlocksForJoin(
               getRelevantIdFromTriple(block.firstTriple_, metadataAndBlocks),
               getRelevantIdFromTriple(block.lastTriple_, metadataAndBlocks)};
         };
-        auto blocks = getBlocksFromMetadata(metadataAndBlocks);
-        auto result = ql::views::transform(blocks, getSingleBlock);
+        auto result = ql::views::transform(
+            getBlocksFromMetadata(metadataAndBlocks), getSingleBlock);
         AD_CORRECTNESS_CHECK(ql::ranges::is_sorted(result, blockLessThanBlock));
         return result;
       };
@@ -794,8 +794,7 @@ CPP_template_def(typename IdGetter)(
   // Iterate over the blocks and only read (and decompress) those which
   // contain more than one different `colId`. For the others, we can determine
   // the count from the metadata.
-  for (auto i = decltype(relevantBlocksMetadata.size())(0);
-       i < relevantBlocksMetadata.size(); ++i) {
+  for (size_t i : ad_utility::integerRange(relevantBlocksMetadata.size())) {
     const auto& blockMetadata = relevantBlocksMetadata[i];
     Id firstColId = std::invoke(idGetter, blockMetadata.firstTriple_);
     Id lastColId = std::invoke(idGetter, blockMetadata.lastTriple_);

--- a/src/index/CompressedRelation.cpp
+++ b/src/index/CompressedRelation.cpp
@@ -492,8 +492,8 @@ CompressedRelationReader::getBlocksForJoin(
               getRelevantIdFromTriple(block.firstTriple_, metadataAndBlocks),
               getRelevantIdFromTriple(block.lastTriple_, metadataAndBlocks)};
         };
-        auto result = ql::views::transform(
-            getBlocksFromMetadata(metadataAndBlocks), getSingleBlock);
+        auto blocks = getBlocksFromMetadata(metadataAndBlocks);
+        auto result = ql::views::transform(blocks, getSingleBlock);
         AD_CORRECTNESS_CHECK(ql::ranges::is_sorted(result, blockLessThanBlock));
         return result;
       };

--- a/src/index/CompressedRelation.h
+++ b/src/index/CompressedRelation.h
@@ -261,7 +261,7 @@ class CompressedRelationWriter {
   // Two helper types used to make the interface of the function
   // `createPermutationPair` below safer and more explicit.
   using MetadataCallback =
-      std::function<void(std::span<const CompressedRelationMetadata>)>;
+      std::function<void(ql::span<const CompressedRelationMetadata>)>;
 
   struct WriterAndCallback {
     CompressedRelationWriter& writer_;
@@ -353,7 +353,7 @@ class CompressedRelationWriter {
   // Compress the `column` and write it to the `outfile_`. Return the offset and
   // size of the compressed column in the `outfile_`.
   CompressedBlockMetadata::OffsetAndCompressedSize compressAndWriteColumn(
-      std::span<const Id> column);
+      ql::span<const Id> column);
 
   // Return the number of columns that is stored inside the blocks.
   size_t numColumns() const { return numColumns_; }
@@ -418,7 +418,7 @@ class CompressedRelationReader {
 
  public:
   using Allocator = ad_utility::AllocatorWithLimit<Id>;
-  using ColumnIndicesRef = std::span<const ColumnIndex>;
+  using ColumnIndicesRef = ql::span<const ColumnIndex>;
   using ColumnIndices = std::vector<ColumnIndex>;
   using CancellationHandle = ad_utility::SharedCancellationHandle;
 
@@ -471,7 +471,7 @@ class CompressedRelationReader {
   // to be performed.
   struct ScanSpecAndBlocks {
     ScanSpecification scanSpec_;
-    const std::span<const CompressedBlockMetadata> blockMetadata_;
+    const ql::span<const CompressedBlockMetadata> blockMetadata_;
   };
 
   // This struct additionally contains the first and last triple of the scan
@@ -546,7 +546,7 @@ class CompressedRelationReader {
   // case the `metadataAndBlocks` doesn't contain a `col1Id`, or the last column
   // (col2) else.
   static std::vector<CompressedBlockMetadata> getBlocksForJoin(
-      std::span<const Id> joinColumn,
+      ql::span<const Id> joinColumn,
       const ScanSpecAndBlocksAndBounds& metadataAndBlocks);
 
   // For each of `metadataAndBlocks, metadataAndBlocks2` get the blocks (an
@@ -579,7 +579,7 @@ class CompressedRelationReader {
    * The same `CompressedRelationWriter` (see below).
    */
   IdTable scan(const ScanSpecification& scanSpec,
-               std::span<const CompressedBlockMetadata> blocks,
+               ql::span<const CompressedBlockMetadata> blocks,
                ColumnIndicesRef additionalColumns,
                const CancellationHandle& cancellationHandle,
                const LocatedTriplesPerBlock& locatedTriplesPerBlock,
@@ -644,13 +644,13 @@ class CompressedRelationReader {
   // that contain the triples that have the relationId/col0Id that was specified
   // by the `medata`. If the `col1Id` is specified (not `nullopt`), then the
   // blocks are additionally filtered by the given `col1Id`.
-  static std::span<const CompressedBlockMetadata> getRelevantBlocks(
+  static ql::span<const CompressedBlockMetadata> getRelevantBlocks(
       const ScanSpecification& blockA,
-      std::span<const CompressedBlockMetadata> blockB);
+      ql::span<const CompressedBlockMetadata> blockB);
 
   // The same function, but specify the arguments as the
   // `ScanSpecAndBlocksAndBounds` struct.
-  static std::span<const CompressedBlockMetadata> getBlocksFromMetadata(
+  static ql::span<const CompressedBlockMetadata> getBlocksFromMetadata(
       const ScanSpecAndBlocks& metadataAndBlocks);
 
   // Get the first and the last triple that the result of a `scan` with the

--- a/src/index/CompressedRelation.h
+++ b/src/index/CompressedRelation.h
@@ -261,7 +261,7 @@ class CompressedRelationWriter {
   // Two helper types used to make the interface of the function
   // `createPermutationPair` below safer and more explicit.
   using MetadataCallback =
-      std::function<void(absl::Span<const CompressedRelationMetadata>)>;
+      std::function<void(std::span<const CompressedRelationMetadata>)>;
 
   struct WriterAndCallback {
     CompressedRelationWriter& writer_;
@@ -353,7 +353,7 @@ class CompressedRelationWriter {
   // Compress the `column` and write it to the `outfile_`. Return the offset and
   // size of the compressed column in the `outfile_`.
   CompressedBlockMetadata::OffsetAndCompressedSize compressAndWriteColumn(
-      absl::Span<const Id> column);
+      std::span<const Id> column);
 
   // Return the number of columns that is stored inside the blocks.
   size_t numColumns() const { return numColumns_; }
@@ -418,7 +418,7 @@ class CompressedRelationReader {
 
  public:
   using Allocator = ad_utility::AllocatorWithLimit<Id>;
-  using ColumnIndicesRef = absl::Span<const ColumnIndex>;
+  using ColumnIndicesRef = std::span<const ColumnIndex>;
   using ColumnIndices = std::vector<ColumnIndex>;
   using CancellationHandle = ad_utility::SharedCancellationHandle;
 
@@ -471,7 +471,7 @@ class CompressedRelationReader {
   // to be performed.
   struct ScanSpecAndBlocks {
     ScanSpecification scanSpec_;
-    const absl::Span<const CompressedBlockMetadata> blockMetadata_;
+    const std::span<const CompressedBlockMetadata> blockMetadata_;
   };
 
   // This struct additionally contains the first and last triple of the scan
@@ -546,7 +546,7 @@ class CompressedRelationReader {
   // case the `metadataAndBlocks` doesn't contain a `col1Id`, or the last column
   // (col2) else.
   static std::vector<CompressedBlockMetadata> getBlocksForJoin(
-      absl::Span<const Id> joinColumn,
+      std::span<const Id> joinColumn,
       const ScanSpecAndBlocksAndBounds& metadataAndBlocks);
 
   // For each of `metadataAndBlocks, metadataAndBlocks2` get the blocks (an
@@ -579,7 +579,7 @@ class CompressedRelationReader {
    * The same `CompressedRelationWriter` (see below).
    */
   IdTable scan(const ScanSpecification& scanSpec,
-               absl::Span<const CompressedBlockMetadata> blocks,
+               std::span<const CompressedBlockMetadata> blocks,
                ColumnIndicesRef additionalColumns,
                const CancellationHandle& cancellationHandle,
                const LocatedTriplesPerBlock& locatedTriplesPerBlock,
@@ -644,13 +644,13 @@ class CompressedRelationReader {
   // that contain the triples that have the relationId/col0Id that was specified
   // by the `medata`. If the `col1Id` is specified (not `nullopt`), then the
   // blocks are additionally filtered by the given `col1Id`.
-  static absl::Span<const CompressedBlockMetadata> getRelevantBlocks(
+  static std::span<const CompressedBlockMetadata> getRelevantBlocks(
       const ScanSpecification& blockA,
-      absl::Span<const CompressedBlockMetadata> blockB);
+      std::span<const CompressedBlockMetadata> blockB);
 
   // The same function, but specify the arguments as the
   // `ScanSpecAndBlocksAndBounds` struct.
-  static absl::Span<const CompressedBlockMetadata> getBlocksFromMetadata(
+  static std::span<const CompressedBlockMetadata> getBlocksFromMetadata(
       const ScanSpecAndBlocks& metadataAndBlocks);
 
   // Get the first and the last triple that the result of a `scan` with the

--- a/src/index/CompressedRelation.h
+++ b/src/index/CompressedRelation.h
@@ -260,7 +260,7 @@ class CompressedRelationWriter {
   // Two helper types used to make the interface of the function
   // `createPermutationPair` below safer and more explicit.
   using MetadataCallback =
-      std::function<void(std::span<const CompressedRelationMetadata>)>;
+      std::function<void(absl::Span<const CompressedRelationMetadata>)>;
 
   struct WriterAndCallback {
     CompressedRelationWriter& writer_;
@@ -352,7 +352,7 @@ class CompressedRelationWriter {
   // Compress the `column` and write it to the `outfile_`. Return the offset and
   // size of the compressed column in the `outfile_`.
   CompressedBlockMetadata::OffsetAndCompressedSize compressAndWriteColumn(
-      std::span<const Id> column);
+      absl::Span<const Id> column);
 
   // Return the number of columns that is stored inside the blocks.
   size_t numColumns() const { return numColumns_; }
@@ -415,7 +415,7 @@ class CompressedRelationReader {
 
  public:
   using Allocator = ad_utility::AllocatorWithLimit<Id>;
-  using ColumnIndicesRef = std::span<const ColumnIndex>;
+  using ColumnIndicesRef = absl::Span<const ColumnIndex>;
   using ColumnIndices = std::vector<ColumnIndex>;
   using CancellationHandle = ad_utility::SharedCancellationHandle;
 
@@ -468,7 +468,7 @@ class CompressedRelationReader {
   // to be performed.
   struct ScanSpecAndBlocks {
     ScanSpecification scanSpec_;
-    const std::span<const CompressedBlockMetadata> blockMetadata_;
+    const absl::Span<const CompressedBlockMetadata> blockMetadata_;
   };
 
   // This struct additionally contains the first and last triple of the scan
@@ -543,7 +543,7 @@ class CompressedRelationReader {
   // case the `metadataAndBlocks` doesn't contain a `col1Id`, or the last column
   // (col2) else.
   static std::vector<CompressedBlockMetadata> getBlocksForJoin(
-      std::span<const Id> joinColumn,
+      absl::Span<const Id> joinColumn,
       const ScanSpecAndBlocksAndBounds& metadataAndBlocks);
 
   // For each of `metadataAndBlocks, metadataAndBlocks2` get the blocks (an
@@ -576,7 +576,7 @@ class CompressedRelationReader {
    * The same `CompressedRelationWriter` (see below).
    */
   IdTable scan(const ScanSpecification& scanSpec,
-               std::span<const CompressedBlockMetadata> blocks,
+               absl::Span<const CompressedBlockMetadata> blocks,
                ColumnIndicesRef additionalColumns,
                const CancellationHandle& cancellationHandle,
                const LocatedTriplesPerBlock& locatedTriplesPerBlock,
@@ -641,13 +641,13 @@ class CompressedRelationReader {
   // that contain the triples that have the relationId/col0Id that was specified
   // by the `medata`. If the `col1Id` is specified (not `nullopt`), then the
   // blocks are additionally filtered by the given `col1Id`.
-  static std::span<const CompressedBlockMetadata> getRelevantBlocks(
+  static absl::Span<const CompressedBlockMetadata> getRelevantBlocks(
       const ScanSpecification& blockA,
-      std::span<const CompressedBlockMetadata> blockB);
+      absl::Span<const CompressedBlockMetadata> blockB);
 
   // The same function, but specify the arguments as the
   // `ScanSpecAndBlocksAndBounds` struct.
-  static std::span<const CompressedBlockMetadata> getBlocksFromMetadata(
+  static absl::Span<const CompressedBlockMetadata> getBlocksFromMetadata(
       const ScanSpecAndBlocks& metadataAndBlocks);
 
   // Get the first and the last triple that the result of a `scan` with the

--- a/src/index/DeltaTriples.cpp
+++ b/src/index/DeltaTriples.cpp
@@ -46,8 +46,7 @@ DeltaTriples::locateAndAddTriples(CancellationHandle cancellationHandle,
             locatedTriples);
     cancellationHandle->throwIfCancelled();
   }
-  std::vector<DeltaTriples::LocatedTripleHandles> handles{
-      static_cast<size_t>(idTriples.size())};
+  std::vector<DeltaTriples::LocatedTripleHandles> handles{idTriples.size()};
   for (auto permutation : Permutation::ALL) {
     for (size_t i = 0; i < idTriples.size(); i++) {
       handles[i].forPermutation(permutation) =

--- a/src/index/DeltaTriples.cpp
+++ b/src/index/DeltaTriples.cpp
@@ -29,7 +29,7 @@ void DeltaTriples::clear() {
 // ____________________________________________________________________________
 std::vector<DeltaTriples::LocatedTripleHandles>
 DeltaTriples::locateAndAddTriples(CancellationHandle cancellationHandle,
-                                  std::span<const IdTriple<0>> idTriples,
+                                  absl::Span<const IdTriple<0>> idTriples,
                                   bool shouldExist) {
   std::array<std::vector<LocatedTriples::iterator>, Permutation::ALL.size()>
       intermediateHandles;

--- a/src/index/DeltaTriples.cpp
+++ b/src/index/DeltaTriples.cpp
@@ -29,7 +29,7 @@ void DeltaTriples::clear() {
 // ____________________________________________________________________________
 std::vector<DeltaTriples::LocatedTripleHandles>
 DeltaTriples::locateAndAddTriples(CancellationHandle cancellationHandle,
-                                  absl::Span<const IdTriple<0>> idTriples,
+                                  std::span<const IdTriple<0>> idTriples,
                                   bool shouldExist) {
   std::array<std::vector<LocatedTriples::iterator>, Permutation::ALL.size()>
       intermediateHandles;

--- a/src/index/DeltaTriples.cpp
+++ b/src/index/DeltaTriples.cpp
@@ -29,7 +29,7 @@ void DeltaTriples::clear() {
 // ____________________________________________________________________________
 std::vector<DeltaTriples::LocatedTripleHandles>
 DeltaTriples::locateAndAddTriples(CancellationHandle cancellationHandle,
-                                  std::span<const IdTriple<0>> idTriples,
+                                  ql::span<const IdTriple<0>> idTriples,
                                   bool shouldExist) {
   std::array<std::vector<LocatedTriples::iterator>, Permutation::ALL.size()>
       intermediateHandles;
@@ -46,7 +46,8 @@ DeltaTriples::locateAndAddTriples(CancellationHandle cancellationHandle,
             locatedTriples);
     cancellationHandle->throwIfCancelled();
   }
-  std::vector<DeltaTriples::LocatedTripleHandles> handles{idTriples.size()};
+  std::vector<DeltaTriples::LocatedTripleHandles> handles{
+      static_cast<size_t>(idTriples.size())};
   for (auto permutation : Permutation::ALL) {
     for (size_t i = 0; i < idTriples.size(); i++) {
       handles[i].forPermutation(permutation) =

--- a/src/index/DeltaTriples.h
+++ b/src/index/DeltaTriples.h
@@ -198,7 +198,7 @@ class DeltaTriples {
   // maps later).
   std::vector<LocatedTripleHandles> locateAndAddTriples(
       CancellationHandle cancellationHandle,
-      std::span<const IdTriple<0>> idTriples, bool shouldExist);
+      ql::span<const IdTriple<0>> idTriples, bool shouldExist);
 
   // Common implementation for `insertTriples` and `deleteTriples`.
   // `shouldExist` specifies the action: insert or delete. `targetMap` contains

--- a/src/index/DeltaTriples.h
+++ b/src/index/DeltaTriples.h
@@ -198,7 +198,7 @@ class DeltaTriples {
   // maps later).
   std::vector<LocatedTripleHandles> locateAndAddTriples(
       CancellationHandle cancellationHandle,
-      absl::Span<const IdTriple<0>> idTriples, bool shouldExist);
+      std::span<const IdTriple<0>> idTriples, bool shouldExist);
 
   // Common implementation for `insertTriples` and `deleteTriples`.
   // `shouldExist` specifies the action: insert or delete. `targetMap` contains

--- a/src/index/DeltaTriples.h
+++ b/src/index/DeltaTriples.h
@@ -198,7 +198,7 @@ class DeltaTriples {
   // maps later).
   std::vector<LocatedTripleHandles> locateAndAddTriples(
       CancellationHandle cancellationHandle,
-      std::span<const IdTriple<0>> idTriples, bool shouldExist);
+      absl::Span<const IdTriple<0>> idTriples, bool shouldExist);
 
   // Common implementation for `insertTriples` and `deleteTriples`.
   // `shouldExist` specifies the action: insert or delete. `targetMap` contains

--- a/src/index/LocatedTriples.cpp
+++ b/src/index/LocatedTriples.cpp
@@ -14,8 +14,8 @@
 
 // ____________________________________________________________________________
 std::vector<LocatedTriple> LocatedTriple::locateTriplesInPermutation(
-    std::span<const IdTriple<0>> triples,
-    std::span<const CompressedBlockMetadata> blockMetadata,
+    ql::span<const IdTriple<0>> triples,
+    ql::span<const CompressedBlockMetadata> blockMetadata,
     const qlever::KeyOrder& keyOrder, bool shouldExist,
     ad_utility::SharedCancellationHandle cancellationHandle) {
   std::vector<LocatedTriple> out;
@@ -213,7 +213,7 @@ IdTable LocatedTriplesPerBlock::mergeTriples(size_t blockIndex,
 
 // ____________________________________________________________________________
 std::vector<LocatedTriples::iterator> LocatedTriplesPerBlock::add(
-    std::span<const LocatedTriple> locatedTriples) {
+    ql::span<const LocatedTriple> locatedTriples) {
   std::vector<LocatedTriples::iterator> handles;
   handles.reserve(locatedTriples.size());
   for (auto triple : locatedTriples) {

--- a/src/index/LocatedTriples.cpp
+++ b/src/index/LocatedTriples.cpp
@@ -14,8 +14,8 @@
 
 // ____________________________________________________________________________
 std::vector<LocatedTriple> LocatedTriple::locateTriplesInPermutation(
-    std::span<const IdTriple<0>> triples,
-    std::span<const CompressedBlockMetadata> blockMetadata,
+    absl::Span<const IdTriple<0>> triples,
+    absl::Span<const CompressedBlockMetadata> blockMetadata,
     const qlever::KeyOrder& keyOrder, bool shouldExist,
     ad_utility::SharedCancellationHandle cancellationHandle) {
   std::vector<LocatedTriple> out;
@@ -211,7 +211,7 @@ IdTable LocatedTriplesPerBlock::mergeTriples(size_t blockIndex,
 
 // ____________________________________________________________________________
 std::vector<LocatedTriples::iterator> LocatedTriplesPerBlock::add(
-    std::span<const LocatedTriple> locatedTriples) {
+    absl::Span<const LocatedTriple> locatedTriples) {
   std::vector<LocatedTriples::iterator> handles;
   handles.reserve(locatedTriples.size());
   for (auto triple : locatedTriples) {

--- a/src/index/LocatedTriples.cpp
+++ b/src/index/LocatedTriples.cpp
@@ -14,8 +14,8 @@
 
 // ____________________________________________________________________________
 std::vector<LocatedTriple> LocatedTriple::locateTriplesInPermutation(
-    absl::Span<const IdTriple<0>> triples,
-    absl::Span<const CompressedBlockMetadata> blockMetadata,
+    std::span<const IdTriple<0>> triples,
+    std::span<const CompressedBlockMetadata> blockMetadata,
     const qlever::KeyOrder& keyOrder, bool shouldExist,
     ad_utility::SharedCancellationHandle cancellationHandle) {
   std::vector<LocatedTriple> out;
@@ -213,7 +213,7 @@ IdTable LocatedTriplesPerBlock::mergeTriples(size_t blockIndex,
 
 // ____________________________________________________________________________
 std::vector<LocatedTriples::iterator> LocatedTriplesPerBlock::add(
-    absl::Span<const LocatedTriple> locatedTriples) {
+    std::span<const LocatedTriple> locatedTriples) {
   std::vector<LocatedTriples::iterator> handles;
   handles.reserve(locatedTriples.size());
   for (auto triple : locatedTriples) {

--- a/src/index/LocatedTriples.h
+++ b/src/index/LocatedTriples.h
@@ -41,8 +41,8 @@ struct LocatedTriple {
 
   // Locate the given triples in the given permutation.
   static std::vector<LocatedTriple> locateTriplesInPermutation(
-      std::span<const IdTriple<0>> triples,
-      std::span<const CompressedBlockMetadata> blockMetadata,
+      ql::span<const IdTriple<0>> triples,
+      ql::span<const CompressedBlockMetadata> blockMetadata,
       const qlever::KeyOrder& keyOrder, bool shouldExist,
       ad_utility::SharedCancellationHandle cancellationHandle);
   bool operator==(const LocatedTriple&) const = default;
@@ -148,7 +148,7 @@ class LocatedTriplesPerBlock {
   // PRECONDITION: The `locatedTriples` must not already exist in
   // `LocatedTriplesPerBlock`.
   std::vector<LocatedTriples::iterator> add(
-      std::span<const LocatedTriple> locatedTriples);
+      ql::span<const LocatedTriple> locatedTriples);
 
   void erase(size_t blockIndex, LocatedTriples::iterator iter);
 

--- a/src/index/LocatedTriples.h
+++ b/src/index/LocatedTriples.h
@@ -41,8 +41,8 @@ struct LocatedTriple {
 
   // Locate the given triples in the given permutation.
   static std::vector<LocatedTriple> locateTriplesInPermutation(
-      absl::Span<const IdTriple<0>> triples,
-      absl::Span<const CompressedBlockMetadata> blockMetadata,
+      std::span<const IdTriple<0>> triples,
+      std::span<const CompressedBlockMetadata> blockMetadata,
       const qlever::KeyOrder& keyOrder, bool shouldExist,
       ad_utility::SharedCancellationHandle cancellationHandle);
   bool operator==(const LocatedTriple&) const = default;
@@ -148,7 +148,7 @@ class LocatedTriplesPerBlock {
   // PRECONDITION: The `locatedTriples` must not already exist in
   // `LocatedTriplesPerBlock`.
   std::vector<LocatedTriples::iterator> add(
-      absl::Span<const LocatedTriple> locatedTriples);
+      std::span<const LocatedTriple> locatedTriples);
 
   void erase(size_t blockIndex, LocatedTriples::iterator iter);
 

--- a/src/index/LocatedTriples.h
+++ b/src/index/LocatedTriples.h
@@ -41,8 +41,8 @@ struct LocatedTriple {
 
   // Locate the given triples in the given permutation.
   static std::vector<LocatedTriple> locateTriplesInPermutation(
-      std::span<const IdTriple<0>> triples,
-      std::span<const CompressedBlockMetadata> blockMetadata,
+      absl::Span<const IdTriple<0>> triples,
+      absl::Span<const CompressedBlockMetadata> blockMetadata,
       const qlever::KeyOrder& keyOrder, bool shouldExist,
       ad_utility::SharedCancellationHandle cancellationHandle);
   bool operator==(const LocatedTriple&) const = default;
@@ -148,7 +148,7 @@ class LocatedTriplesPerBlock {
   // PRECONDITION: The `locatedTriples` must not already exist in
   // `LocatedTriplesPerBlock`.
   std::vector<LocatedTriples::iterator> add(
-      std::span<const LocatedTriple> locatedTriples);
+      absl::Span<const LocatedTriple> locatedTriples);
 
   void erase(size_t blockIndex, LocatedTriples::iterator iter);
 

--- a/src/index/TextIndexReadWrite.cpp
+++ b/src/index/TextIndexReadWrite.cpp
@@ -8,7 +8,7 @@ namespace textIndexReadWrite {
 
 // ____________________________________________________________________________
 template <typename T>
-void compressAndWrite(std::span<const T> src, ad_utility::File& out,
+void compressAndWrite(ql::span<const T> src, ad_utility::File& out,
                       off_t& currentOffset) {
   auto compressed = ZstdWrapper::compress(src.data(), src.size() * sizeof(T));
   out.write(compressed.data(), compressed.size());
@@ -79,7 +79,7 @@ size_t writeCodebook(const vector<T>& codebook, ad_utility::File& file) {
 
 // ____________________________________________________________________________
 template <typename T>
-void encodeAndWriteSpanAndMoveOffset(std::span<const T> spanToWrite,
+void encodeAndWriteSpanAndMoveOffset(ql::span<const T> spanToWrite,
                                      ad_utility::File& file,
                                      off_t& currentOffset) {
   size_t bytes = 0;

--- a/src/index/TextIndexReadWrite.cpp
+++ b/src/index/TextIndexReadWrite.cpp
@@ -8,7 +8,7 @@ namespace textIndexReadWrite {
 
 // ____________________________________________________________________________
 template <typename T>
-void compressAndWrite(absl::Span<const T> src, ad_utility::File& out,
+void compressAndWrite(std::span<const T> src, ad_utility::File& out,
                       off_t& currentOffset) {
   auto compressed = ZstdWrapper::compress(src.data(), src.size() * sizeof(T));
   out.write(compressed.data(), compressed.size());
@@ -79,7 +79,7 @@ size_t writeCodebook(const vector<T>& codebook, ad_utility::File& file) {
 
 // ____________________________________________________________________________
 template <typename T>
-void encodeAndWriteSpanAndMoveOffset(absl::Span<const T> spanToWrite,
+void encodeAndWriteSpanAndMoveOffset(std::span<const T> spanToWrite,
                                      ad_utility::File& file,
                                      off_t& currentOffset) {
   size_t bytes = 0;

--- a/src/index/TextIndexReadWrite.cpp
+++ b/src/index/TextIndexReadWrite.cpp
@@ -8,7 +8,7 @@ namespace textIndexReadWrite {
 
 // ____________________________________________________________________________
 template <typename T>
-void compressAndWrite(std::span<const T> src, ad_utility::File& out,
+void compressAndWrite(absl::Span<const T> src, ad_utility::File& out,
                       off_t& currentOffset) {
   auto compressed = ZstdWrapper::compress(src.data(), src.size() * sizeof(T));
   out.write(compressed.data(), compressed.size());
@@ -79,7 +79,7 @@ size_t writeCodebook(const vector<T>& codebook, ad_utility::File& file) {
 
 // ____________________________________________________________________________
 template <typename T>
-void encodeAndWriteSpanAndMoveOffset(std::span<const T> spanToWrite,
+void encodeAndWriteSpanAndMoveOffset(absl::Span<const T> spanToWrite,
                                      ad_utility::File& file,
                                      off_t& currentOffset) {
   size_t bytes = 0;

--- a/src/index/TextIndexReadWrite.h
+++ b/src/index/TextIndexReadWrite.h
@@ -5,6 +5,7 @@
 #ifndef QLEVER_SRC_INDEX_TEXTINDEXREADWRITE_H
 #define QLEVER_SRC_INDEX_TEXTINDEXREADWRITE_H
 
+#include "backports/span.h"
 #include "global/Id.h"
 #include "global/IndexTypes.h"
 #include "index/Postings.h"
@@ -104,7 +105,7 @@ namespace textIndexReadWrite {
 // Compress src using zstd and write compressed bytes to file while advancing
 // currentOffset by the nofBytes written
 template <typename T>
-void compressAndWrite(std::span<const T> src, ad_utility::File& out,
+void compressAndWrite(ql::span<const T> src, ad_utility::File& out,
                       off_t& currentOffset);
 
 /**
@@ -142,7 +143,7 @@ size_t writeCodebook(const vector<T>& codebook, ad_utility::File& file);
  * @warning The elements of the list have to be able to be cast to uint64_t.
  */
 template <typename T>
-void encodeAndWriteSpanAndMoveOffset(std::span<const T> spanToWrite,
+void encodeAndWriteSpanAndMoveOffset(ql::span<const T> spanToWrite,
                                      ad_utility::File& file,
                                      off_t& currentOffset);
 

--- a/src/index/TextIndexReadWrite.h
+++ b/src/index/TextIndexReadWrite.h
@@ -104,7 +104,7 @@ namespace textIndexReadWrite {
 // Compress src using zstd and write compressed bytes to file while advancing
 // currentOffset by the nofBytes written
 template <typename T>
-void compressAndWrite(std::span<const T> src, ad_utility::File& out,
+void compressAndWrite(absl::Span<const T> src, ad_utility::File& out,
                       off_t& currentOffset);
 
 /**
@@ -142,7 +142,7 @@ size_t writeCodebook(const vector<T>& codebook, ad_utility::File& file);
  * @warning The elements of the list have to be able to be cast to uint64_t.
  */
 template <typename T>
-void encodeAndWriteSpanAndMoveOffset(std::span<const T> spanToWrite,
+void encodeAndWriteSpanAndMoveOffset(absl::Span<const T> spanToWrite,
                                      ad_utility::File& file,
                                      off_t& currentOffset);
 

--- a/src/index/TextIndexReadWrite.h
+++ b/src/index/TextIndexReadWrite.h
@@ -104,7 +104,7 @@ namespace textIndexReadWrite {
 // Compress src using zstd and write compressed bytes to file while advancing
 // currentOffset by the nofBytes written
 template <typename T>
-void compressAndWrite(absl::Span<const T> src, ad_utility::File& out,
+void compressAndWrite(std::span<const T> src, ad_utility::File& out,
                       off_t& currentOffset);
 
 /**
@@ -142,7 +142,7 @@ size_t writeCodebook(const vector<T>& codebook, ad_utility::File& file);
  * @warning The elements of the list have to be able to be cast to uint64_t.
  */
 template <typename T>
-void encodeAndWriteSpanAndMoveOffset(absl::Span<const T> spanToWrite,
+void encodeAndWriteSpanAndMoveOffset(std::span<const T> spanToWrite,
                                      ad_utility::File& file,
                                      off_t& currentOffset);
 

--- a/src/parser/RdfParser.cpp
+++ b/src/parser/RdfParser.cpp
@@ -8,6 +8,7 @@
 #include "parser/RdfParser.h"
 
 #include <absl/strings/charconv.h>
+#include <absl/functional/bind_front.h>
 
 #include <cstring>
 #include <exception>

--- a/src/parser/RdfParser.cpp
+++ b/src/parser/RdfParser.cpp
@@ -5,8 +5,8 @@
 
 #include "parser/RdfParser.h"
 
-#include <absl/strings/charconv.h>
 #include <absl/functional/bind_front.h>
+#include <absl/strings/charconv.h>
 
 #include <cstring>
 #include <exception>

--- a/src/parser/RdfParser.cpp
+++ b/src/parser/RdfParser.cpp
@@ -8,7 +8,6 @@
 #include "parser/RdfParser.h"
 
 #include <absl/strings/charconv.h>
-#include <absl/functional/bind_front.h>
 
 #include <cstring>
 #include <exception>

--- a/src/parser/RdfParser.cpp
+++ b/src/parser/RdfParser.cpp
@@ -2,10 +2,13 @@
 // Chair of Algorithms and Data Structures
 // Authors: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
 //          Hannah Bast <bast@cs.uni-freiburg.de>
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #include "parser/RdfParser.h"
 
 #include <absl/strings/charconv.h>
+#include <absl/functional/bind_front.h>
 
 #include <cstring>
 #include <exception>
@@ -1333,7 +1336,7 @@ RdfMultifileParser::RdfMultifileParser(
     for (const auto& file : files) {
       numActiveParsers_++;
       bool active =
-          parsingQueue_.push(std::bind_front(parseFile, file, bufferSize));
+          parsingQueue_.push(absl::bind_front(parseFile, file, bufferSize));
       if (!active) {
         // The queue was finished prematurely, stop this thread. This is
         // important to avoid deadlocks.

--- a/src/util/Date.h
+++ b/src/util/Date.h
@@ -93,30 +93,30 @@ class Date {
   static constexpr int minYear = -9999;
   static constexpr int maxYear = 9999;
   static constexpr uint8_t numBitsYear =
-      std::bit_width(unsigned{maxYear - minYear});
+      absl::bit_width(unsigned{maxYear - minYear});
 
   // The special month value `0` is used to encode "no month was specified" (i.e
   // "This is a `xsd:gYear`).
   static constexpr int minMonth = 0;
   static constexpr unsigned maxMonth = 12;
-  static constexpr uint8_t numBitsMonth = std::bit_width(maxMonth);
+  static constexpr uint8_t numBitsMonth = absl::bit_width(maxMonth);
 
   // The special day value `0` is used to encode "no day was specified" (i.e
   // "This is a `xsd:gYearMonth`).
   static constexpr int minDay = 0;
   static constexpr unsigned maxDay = 31;
-  static constexpr uint8_t numBitsDay = std::bit_width(maxDay);
+  static constexpr uint8_t numBitsDay = absl::bit_width(maxDay);
 
   // The special hour value `-1` is used to encode "no hour was specified" (i.e
   // "This is a `xsd:Date`).
   static constexpr int minHour = -1;
   static constexpr unsigned maxHour = 23;
   static constexpr uint8_t numBitsHour =
-      std::bit_width(unsigned{maxHour - minHour});
+      absl::bit_width(unsigned{maxHour - minHour});
 
   static constexpr int minMinute = 0;
   static constexpr unsigned maxMinute = 59;
-  static constexpr uint8_t numBitsMinute = std::bit_width(maxMinute);
+  static constexpr uint8_t numBitsMinute = absl::bit_width(maxMinute);
 
   // Seconds are imported and exported as double, but internally stored as fixed
   // point decimals with millisecond precision.
@@ -124,7 +124,7 @@ class Date {
   static constexpr double maxSecond = 60.0;
   static constexpr double secondMultiplier = 1024.0;
   static constexpr uint8_t numBitsSecond =
-      std::bit_width(static_cast<unsigned>(maxSecond * secondMultiplier));
+      absl::bit_width(static_cast<unsigned>(maxSecond * secondMultiplier));
 
   // The time zone is an hour in -23..23. It is shifted to the positive range
   // 0..22 (similar to the years). There are two additional "special" time
@@ -135,7 +135,7 @@ class Date {
   static constexpr int maxTimeZoneActually = 25;
   static constexpr int minTimeZone = -23;
   static constexpr int maxTimeZone = 23;
-  static constexpr uint8_t numBitsTimeZone = std::bit_width(
+  static constexpr uint8_t numBitsTimeZone = absl::bit_width(
       static_cast<unsigned>(maxTimeZoneActually - minTimeZoneActually));
 
   // The number of bits that are not needed for the encoding of the Date value.
@@ -188,14 +188,14 @@ class Date {
   /// Convert the `Date` to a `uint64_t`. This just casts the underlying
   /// representation.
   [[nodiscard]] constexpr uint64_t toBits() const {
-    return std::bit_cast<uint64_t>(*this);
+    return absl::bit_cast<uint64_t>(*this);
   }
 
   /// Convert a `uint64_t` to a `Date`. This is only valid if the `uint64_t` was
   /// obtained via a call to `Date::toBits()`. This just casts the underlying
   /// representation.
   static constexpr Date fromBits(uint64_t bytes) {
-    return std::bit_cast<Date>(bytes);
+    return absl::bit_cast<Date>(bytes);
   }
 
   /// Equality comparison is performed directly on the underlying

--- a/src/util/DateYearDuration.h
+++ b/src/util/DateYearDuration.h
@@ -52,12 +52,12 @@ class DateYearOrDuration {
 
   // Construct from a `Date`.
   explicit DateYearOrDuration(Date d) {
-    bits_ = std::bit_cast<uint64_t>(d) | (datetime << numPayloadDateBits);
+    bits_ = absl::bit_cast<uint64_t>(d) | (datetime << numPayloadDateBits);
   }
 
   // Construct a `DateYearOrDuration` given a `DayTimeDuration` object.
   explicit DateYearOrDuration(DayTimeDuration dayTimeDuration) {
-    bits_ = std::bit_cast<uint64_t>(dayTimeDuration) |
+    bits_ = absl::bit_cast<uint64_t>(dayTimeDuration) |
             (daytimeDuration << numPayloadDurationBits);
   }
 
@@ -86,7 +86,7 @@ class DateYearOrDuration {
 
   // Return the underlying `Date` object. The behavior is undefined if
   // `isDate()` is `false`.
-  Date getDateUnchecked() const { return std::bit_cast<Date>(bits_); }
+  Date getDateUnchecked() const { return absl::bit_cast<Date>(bits_); }
 
   // Return the underlying `Date` object. An assertion fails if `isDate()` is
   // `false`.
@@ -98,7 +98,7 @@ class DateYearOrDuration {
   // Return the underlying `DayTimeDuration` object. The behavior is undefined
   // if `isDayTimeDuration()` is `false`.
   DayTimeDuration getDayTimeDurationUnchecked() const {
-    return std::bit_cast<DayTimeDuration>(bits_);
+    return absl::bit_cast<DayTimeDuration>(bits_);
   }
 
   // Return the underlying `DayTimeDuration` object, with assertion check.

--- a/src/util/Duration.h
+++ b/src/util/Duration.h
@@ -91,7 +91,7 @@ class DayTimeDuration {
   // into the positive value range to store an unsigned value in
   // totalMilliseconds_.
   static constexpr uint8_t numMillisecondBits =
-      std::bit_width(boundTotalMilliseconds * 2);
+      absl::bit_width(boundTotalMilliseconds * 2);
   static constexpr uint8_t numUnusedBits = 64 - numMillisecondBits;
   static_assert(numUnusedBits == 16,
                 "The number of unused bits for Duration should be 16");
@@ -203,13 +203,13 @@ class DayTimeDuration {
   // Converts the underlying `dayTimeDuration` representation to a compact
   // bit representation (necessary for the == and <=> implementation).
   [[nodiscard]] constexpr uint64_t toBits() const {
-    return std::bit_cast<uint64_t>(*this);
+    return absl::bit_cast<uint64_t>(*this);
   }
 
   // From a given bit representation, retrieve the actual `dayTimeDuration`
   // object again.
   static constexpr DayTimeDuration fromBits(uint64_t bytes) {
-    return std::bit_cast<DayTimeDuration>(bytes);
+    return absl::bit_cast<DayTimeDuration>(bytes);
   }
 
   //____________________________________________________________________________

--- a/src/util/JoinAlgorithms/JoinAlgorithms.h
+++ b/src/util/JoinAlgorithms/JoinAlgorithms.h
@@ -13,6 +13,7 @@
 
 #include "backports/algorithm.h"
 #include "backports/concepts.h"
+#include "backports/span.h"
 #include "engine/idTable/IdTable.h"
 #include "global/Id.h"
 #include "util/Generator.h"
@@ -587,7 +588,7 @@ CPP_template(typename CompatibleActionT, typename NotFoundActionT,
 namespace detail {
 using Range = std::pair<size_t, size_t>;
 
-// Store a contiguous random-access range (e.g. `std::vector`or `std::span`,
+// Store a contiguous random-access range (e.g. `std::vector`or `ql::span`,
 // together with a pair of indices `[beginIndex, endIndex)` that denote a
 // contiguous subrange of the range. Note that this approach is more robust
 // than storing iterators or subranges directly instead of indices, because many

--- a/src/util/JoinAlgorithms/JoinAlgorithms.h
+++ b/src/util/JoinAlgorithms/JoinAlgorithms.h
@@ -489,9 +489,8 @@ CPP_template(typename CompatibleActionT, typename NotFoundActionT,
 
   // The last columns from the left and right input. Those will be dealt with
   // separately.
-  absl::Span<const Id> lastColumnLeft = left.getColumn(left.numColumns() - 1);
-  absl::Span<const Id> lastColumnRight =
-      right.getColumn(right.numColumns() - 1);
+  std::span<const Id> lastColumnLeft = left.getColumn(left.numColumns() - 1);
+  std::span<const Id> lastColumnRight = right.getColumn(right.numColumns() - 1);
 
   while (it1 < end1 && it2 < end2) {
     checkCancellation();
@@ -539,11 +538,13 @@ CPP_template(typename CompatibleActionT, typename NotFoundActionT,
 
     // Set up the corresponding sub-ranges of the last columns.
     auto beg = it1 - left.begin();
-    auto subRangeSize = static_cast<size_t>(endSame1 - it1);
-    absl::Span<const Id> leftSub{lastColumnLeft.data() + beg, subRangeSize};
+    auto end = endSame1 - left.begin();
+    std::span<const Id> leftSub{lastColumnLeft.begin() + beg,
+                                lastColumnLeft.begin() + end};
     beg = it2 - right.begin();
-    subRangeSize = static_cast<size_t>(endSame2 - it2);
-    absl::Span<const Id> rightSub{lastColumnRight.data() + beg, subRangeSize};
+    end = endSame2 - right.begin();
+    std::span<const Id> rightSub{lastColumnRight.begin() + beg,
+                                 lastColumnRight.begin() + end};
 
     // Set up the generator for the UNDEF values.
     // TODO<joka921> We could probably also apply this optimization if both

--- a/src/util/JoinAlgorithms/JoinAlgorithms.h
+++ b/src/util/JoinAlgorithms/JoinAlgorithms.h
@@ -489,8 +489,8 @@ CPP_template(typename CompatibleActionT, typename NotFoundActionT,
 
   // The last columns from the left and right input. Those will be dealt with
   // separately.
-  std::span<const Id> lastColumnLeft = left.getColumn(left.numColumns() - 1);
-  std::span<const Id> lastColumnRight = right.getColumn(right.numColumns() - 1);
+  ql::span<const Id> lastColumnLeft = left.getColumn(left.numColumns() - 1);
+  ql::span<const Id> lastColumnRight = right.getColumn(right.numColumns() - 1);
 
   while (it1 < end1 && it2 < end2) {
     checkCancellation();
@@ -539,12 +539,12 @@ CPP_template(typename CompatibleActionT, typename NotFoundActionT,
     // Set up the corresponding sub-ranges of the last columns.
     auto beg = it1 - left.begin();
     auto end = endSame1 - left.begin();
-    std::span<const Id> leftSub{lastColumnLeft.begin() + beg,
-                                lastColumnLeft.begin() + end};
+    ql::span<const Id> leftSub{lastColumnLeft.begin() + beg,
+                               lastColumnLeft.begin() + end};
     beg = it2 - right.begin();
     end = endSame2 - right.begin();
-    std::span<const Id> rightSub{lastColumnRight.begin() + beg,
-                                 lastColumnRight.begin() + end};
+    ql::span<const Id> rightSub{lastColumnRight.begin() + beg,
+                                lastColumnRight.begin() + end};
 
     // Set up the generator for the UNDEF values.
     // TODO<joka921> We could probably also apply this optimization if both

--- a/src/util/JoinAlgorithms/JoinAlgorithms.h
+++ b/src/util/JoinAlgorithms/JoinAlgorithms.h
@@ -488,8 +488,9 @@ CPP_template(typename CompatibleActionT, typename NotFoundActionT,
 
   // The last columns from the left and right input. Those will be dealt with
   // separately.
-  std::span<const Id> lastColumnLeft = left.getColumn(left.numColumns() - 1);
-  std::span<const Id> lastColumnRight = right.getColumn(right.numColumns() - 1);
+  absl::Span<const Id> lastColumnLeft = left.getColumn(left.numColumns() - 1);
+  absl::Span<const Id> lastColumnRight =
+      right.getColumn(right.numColumns() - 1);
 
   while (it1 < end1 && it2 < end2) {
     checkCancellation();
@@ -537,13 +538,11 @@ CPP_template(typename CompatibleActionT, typename NotFoundActionT,
 
     // Set up the corresponding sub-ranges of the last columns.
     auto beg = it1 - left.begin();
-    auto end = endSame1 - left.begin();
-    std::span<const Id> leftSub{lastColumnLeft.begin() + beg,
-                                lastColumnLeft.begin() + end};
+    auto subRangeSize = static_cast<size_t>(endSame1 - it1);
+    absl::Span<const Id> leftSub{lastColumnLeft.data() + beg, subRangeSize};
     beg = it2 - right.begin();
-    end = endSame2 - right.begin();
-    std::span<const Id> rightSub{lastColumnRight.begin() + beg,
-                                 lastColumnRight.begin() + end};
+    subRangeSize = static_cast<size_t>(endSame2 - it2);
+    absl::Span<const Id> rightSub{lastColumnRight.data() + beg, subRangeSize};
 
     // Set up the generator for the UNDEF values.
     // TODO<joka921> We could probably also apply this optimization if both

--- a/src/util/LambdaHelpers.h
+++ b/src/util/LambdaHelpers.h
@@ -57,7 +57,7 @@ struct AssignableLambdaImpl<Lambda, true, false>
   AssignableLambdaImpl& operator=(AssignableLambdaImpl&& other) noexcept
       QL_CONCEPT_OR_NOTHING(requires std::is_move_constructible_v<Lambda>) {
     std::destroy_at(&lambda());
-    std::construct_at(&lambda(), std::move(other.lambda()));
+    new (&lambda()) Lambda(std::move(other.lambda()));
     return *this;
   }
 
@@ -79,7 +79,7 @@ struct AssignableLambdaImpl<Lambda, true, true>
   AssignableLambdaImpl& operator=(const AssignableLambdaImpl& other)
       QL_CONCEPT_OR_NOTHING(requires std::is_copy_constructible_v<Lambda>) {
     std::destroy_at(&lambda());
-    std::construct_at(&lambda(), other.lambda());
+    new (&lambda()) Lambda(other.lambda());
     return *this;
   }
 

--- a/src/util/LazyJsonParser.cpp
+++ b/src/util/LazyJsonParser.cpp
@@ -38,10 +38,10 @@ LazyJsonParser::Generator LazyJsonParser::parse(
 
 // ____________________________________________________________________________
 LazyJsonParser::Generator LazyJsonParser::parse(
-    cppcoro::generator<std::span<std::byte>> partialJson,
+    cppcoro::generator<ql::span<std::byte>> partialJson,
     std::vector<std::string> arrayPath) {
   return parse(
-      [](cppcoro::generator<std::span<std::byte>> partialJson)
+      [](cppcoro::generator<ql::span<std::byte>> partialJson)
           -> cppcoro::generator<std::string_view> {
         for (const auto& bytes : partialJson) {
           co_yield std::string_view(reinterpret_cast<const char*>(bytes.data()),

--- a/src/util/LazyJsonParser.cpp
+++ b/src/util/LazyJsonParser.cpp
@@ -38,10 +38,10 @@ LazyJsonParser::Generator LazyJsonParser::parse(
 
 // ____________________________________________________________________________
 LazyJsonParser::Generator LazyJsonParser::parse(
-    cppcoro::generator<std::span<std::byte>> partialJson,
+    cppcoro::generator<absl::Span<std::byte>> partialJson,
     std::vector<std::string> arrayPath) {
   return parse(
-      [](cppcoro::generator<std::span<std::byte>> partialJson)
+      [](cppcoro::generator<absl::Span<std::byte>> partialJson)
           -> cppcoro::generator<std::string_view> {
         for (const auto& bytes : partialJson) {
           co_yield std::string_view(reinterpret_cast<const char*>(bytes.data()),

--- a/src/util/LazyJsonParser.cpp
+++ b/src/util/LazyJsonParser.cpp
@@ -38,10 +38,10 @@ LazyJsonParser::Generator LazyJsonParser::parse(
 
 // ____________________________________________________________________________
 LazyJsonParser::Generator LazyJsonParser::parse(
-    cppcoro::generator<absl::Span<std::byte>> partialJson,
+    cppcoro::generator<std::span<std::byte>> partialJson,
     std::vector<std::string> arrayPath) {
   return parse(
-      [](cppcoro::generator<absl::Span<std::byte>> partialJson)
+      [](cppcoro::generator<std::span<std::byte>> partialJson)
           -> cppcoro::generator<std::string_view> {
         for (const auto& bytes : partialJson) {
           co_yield std::string_view(reinterpret_cast<const char*>(bytes.data()),

--- a/src/util/LazyJsonParser.h
+++ b/src/util/LazyJsonParser.h
@@ -8,6 +8,7 @@
 #include <optional>
 #include <variant>
 
+#include "backports/span.h"
 #include "util/Generator.h"
 #include "util/json.h"
 
@@ -39,7 +40,7 @@ class LazyJsonParser {
                          std::vector<std::string> arrayPath);
 
   // Convenient alternative for the function above using bytes.
-  static Generator parse(cppcoro::generator<std::span<std::byte>> partialJson,
+  static Generator parse(cppcoro::generator<ql::span<std::byte>> partialJson,
                          std::vector<std::string> arrayPath);
 
  private:

--- a/src/util/LazyJsonParser.h
+++ b/src/util/LazyJsonParser.h
@@ -39,7 +39,7 @@ class LazyJsonParser {
                          std::vector<std::string> arrayPath);
 
   // Convenient alternative for the function above using bytes.
-  static Generator parse(cppcoro::generator<std::span<std::byte>> partialJson,
+  static Generator parse(cppcoro::generator<absl::Span<std::byte>> partialJson,
                          std::vector<std::string> arrayPath);
 
  private:

--- a/src/util/LazyJsonParser.h
+++ b/src/util/LazyJsonParser.h
@@ -39,7 +39,7 @@ class LazyJsonParser {
                          std::vector<std::string> arrayPath);
 
   // Convenient alternative for the function above using bytes.
-  static Generator parse(cppcoro::generator<absl::Span<std::byte>> partialJson,
+  static Generator parse(cppcoro::generator<std::span<std::byte>> partialJson,
                          std::vector<std::string> arrayPath);
 
  private:

--- a/src/util/ParallelMultiwayMerge.h
+++ b/src/util/ParallelMultiwayMerge.h
@@ -89,7 +89,7 @@ CPP_template(typename T, bool moveElements, typename SizeGetter,
 
   auto pushToBuffer =
       absl::bind_front(detail::pushSingleElement<moveElements, T, SizeGetter>,
-                       std::ref(buffer), std::ref(sizeOfCurrentBlock));
+                      std::ref(buffer), std::ref(sizeOfCurrentBlock));
 
   auto isBufferLargeEnough = [&] {
     return buffer.size() >= maxBlockSize || sizeOfCurrentBlock >= maxMem;

--- a/src/util/ParallelMultiwayMerge.h
+++ b/src/util/ParallelMultiwayMerge.h
@@ -89,7 +89,7 @@ CPP_template(typename T, bool moveElements, typename SizeGetter,
 
   auto pushToBuffer =
       absl::bind_front(detail::pushSingleElement<moveElements, T, SizeGetter>,
-                      std::ref(buffer), std::ref(sizeOfCurrentBlock));
+                       std::ref(buffer), std::ref(sizeOfCurrentBlock));
 
   auto isBufferLargeEnough = [&] {
     return buffer.size() >= maxBlockSize || sizeOfCurrentBlock >= maxMem;

--- a/src/util/ParallelMultiwayMerge.h
+++ b/src/util/ParallelMultiwayMerge.h
@@ -1,8 +1,6 @@
 //  Copyright 2023, University of Freiburg,
 //                  Chair of Algorithms and Data Structures.
 //  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_PARALLELMULTIWAYMERGE_H
 #define QLEVER_PARALLELMULTIWAYMERGE_H

--- a/src/util/ParallelMultiwayMerge.h
+++ b/src/util/ParallelMultiwayMerge.h
@@ -1,9 +1,13 @@
 //  Copyright 2023, University of Freiburg,
 //                  Chair of Algorithms and Data Structures.
 //  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_PARALLELMULTIWAYMERGE_H
 #define QLEVER_PARALLELMULTIWAYMERGE_H
+
+#include <absl/functional/bind_front.h>
 
 #include "util/AsyncStream.h"
 #include "util/Generator.h"
@@ -86,7 +90,7 @@ CPP_template(typename T, bool moveElements, typename SizeGetter,
   };
 
   auto pushToBuffer =
-      std::bind_front(detail::pushSingleElement<moveElements, T, SizeGetter>,
+      absl::bind_front(detail::pushSingleElement<moveElements, T, SizeGetter>,
                       std::ref(buffer), std::ref(sizeOfCurrentBlock));
 
   auto isBufferLargeEnough = [&] {

--- a/src/util/ParallelMultiwayMerge.h
+++ b/src/util/ParallelMultiwayMerge.h
@@ -91,7 +91,7 @@ CPP_template(typename T, bool moveElements, typename SizeGetter,
 
   auto pushToBuffer =
       absl::bind_front(detail::pushSingleElement<moveElements, T, SizeGetter>,
-                      std::ref(buffer), std::ref(sizeOfCurrentBlock));
+                       std::ref(buffer), std::ref(sizeOfCurrentBlock));
 
   auto isBufferLargeEnough = [&] {
     return buffer.size() >= maxBlockSize || sizeOfCurrentBlock >= maxMem;

--- a/src/util/Views.h
+++ b/src/util/Views.h
@@ -8,7 +8,6 @@
 #define QLEVER_SRC_UTIL_VIEWS_H
 
 #include <future>
-#include <span>
 
 #include "backports/algorithm.h"
 #include "backports/concepts.h"
@@ -159,7 +158,7 @@ CPP_template(typename UnderlyingRange, bool supportConst = true)(
   }
 
   CPP_auto_member constexpr auto CPP_fun(data)()(
-    requires ql::ranges::contiguous_range<UnderlyingRange>) {
+      requires ql::ranges::contiguous_range<UnderlyingRange>) {
     return ql::ranges::data(underlyingRange_);
   }
 
@@ -362,14 +361,7 @@ CPP_template(typename Range, typename ElementType)(
        generator) {
     for (ElementType c : chunk) {
       if (c == separator) {
-#ifdef QLEVER_CPP_17
-        co_yield ql::span{
-            buffer.data(),
-            static_cast<typename ql::span<ElementType>::index_type>(
-                buffer.size())};
-#else
         co_yield ql::span{buffer.data(), buffer.size()};
-#endif
         buffer.clear();
       } else {
         buffer.push_back(c);
@@ -377,13 +369,7 @@ CPP_template(typename Range, typename ElementType)(
     }
   }
   if (!buffer.empty()) {
-#ifdef QLEVER_CPP_17
-    co_yield ql::span{
-        buffer.data(),
-        static_cast<typename ql::span<ElementType>::index_type>(buffer.size())};
-#else
     co_yield ql::span{buffer.data(), buffer.size()};
-#endif
   }
 }
 }  // namespace ad_utility

--- a/src/util/Views.h
+++ b/src/util/Views.h
@@ -128,13 +128,13 @@ CPP_template(typename UnderlyingRange, bool supportConst = true)(
 
   constexpr auto end() { return ql::ranges::end(underlyingRange_); }
 
-  CPP_auto_member constexpr auto CPP_fun(begin)()(
+  CPP_auto_member constexpr auto CPP_fun(begin) ()(
       const  //
       requires(supportConst&& ql::ranges::range<const UnderlyingRange>)) {
     return ql::ranges::begin(underlyingRange_);
   }
 
-  CPP_auto_member constexpr auto CPP_fun(end)()(
+  CPP_auto_member constexpr auto CPP_fun(end) ()(
       const  //
       requires(supportConst&& ql::ranges::range<const UnderlyingRange>)) {
     return ql::ranges::end(underlyingRange_);
@@ -155,12 +155,12 @@ CPP_template(typename UnderlyingRange, bool supportConst = true)(
     return ql::ranges::size(underlyingRange_);
   }
 
-  CPP_auto_member constexpr auto CPP_fun(data)()(
-      requires ql::ranges::contiguous_range<UnderlyingRange>) {
+  CPP_auto_member constexpr auto
+      CPP_fun(data) ()(requires ql::ranges::contiguous_range<UnderlyingRange>) {
     return ql::ranges::data(underlyingRange_);
   }
 
-  CPP_auto_member constexpr auto CPP_fun(data)()(
+  CPP_auto_member constexpr auto CPP_fun(data) ()(
       const  //
       requires ql::ranges::contiguous_range<const UnderlyingRange>) {
     return ql::ranges::data(underlyingRange_);
@@ -352,14 +352,14 @@ CPP_template(typename Range, typename Transformation)(
 /// separator and the yields spans of the chunks of data received inbetween.
 CPP_template(typename Range, typename ElementType)(
     requires ql::ranges::input_range<Range>) inline cppcoro::
-    generator<std::span<ElementType>> reChunkAtSeparator(
+    generator<absl::Span<ElementType>> reChunkAtSeparator(
         Range generator, ElementType separator) {
   std::vector<ElementType> buffer;
   for (QL_CONCEPT_OR_NOTHING(ql::ranges::input_range) auto const& chunk :
        generator) {
     for (ElementType c : chunk) {
       if (c == separator) {
-        co_yield std::span{buffer.data(), buffer.size()};
+        co_yield absl::Span{buffer.data(), buffer.size()};
         buffer.clear();
       } else {
         buffer.push_back(c);
@@ -367,7 +367,7 @@ CPP_template(typename Range, typename ElementType)(
     }
   }
   if (!buffer.empty()) {
-    co_yield std::span{buffer.data(), buffer.size()};
+    co_yield absl::Span{buffer.data(), buffer.size()};
   }
 }
 }  // namespace ad_utility

--- a/src/util/Views.h
+++ b/src/util/Views.h
@@ -128,13 +128,13 @@ CPP_template(typename UnderlyingRange, bool supportConst = true)(
 
   constexpr auto end() { return ql::ranges::end(underlyingRange_); }
 
-  CPP_auto_member constexpr auto CPP_fun(begin) ()(
+  CPP_auto_member constexpr auto CPP_fun(begin)()(
       const  //
       requires(supportConst&& ql::ranges::range<const UnderlyingRange>)) {
     return ql::ranges::begin(underlyingRange_);
   }
 
-  CPP_auto_member constexpr auto CPP_fun(end) ()(
+  CPP_auto_member constexpr auto CPP_fun(end)()(
       const  //
       requires(supportConst&& ql::ranges::range<const UnderlyingRange>)) {
     return ql::ranges::end(underlyingRange_);
@@ -155,12 +155,12 @@ CPP_template(typename UnderlyingRange, bool supportConst = true)(
     return ql::ranges::size(underlyingRange_);
   }
 
-  CPP_auto_member constexpr auto
-      CPP_fun(data) ()(requires ql::ranges::contiguous_range<UnderlyingRange>) {
+  CPP_auto_member constexpr auto CPP_fun(data)()(
+      requires ql::ranges::contiguous_range<UnderlyingRange>) {
     return ql::ranges::data(underlyingRange_);
   }
 
-  CPP_auto_member constexpr auto CPP_fun(data) ()(
+  CPP_auto_member constexpr auto CPP_fun(data)()(
       const  //
       requires ql::ranges::contiguous_range<const UnderlyingRange>) {
     return ql::ranges::data(underlyingRange_);

--- a/src/util/Views.h
+++ b/src/util/Views.h
@@ -10,6 +10,7 @@
 
 #include "backports/algorithm.h"
 #include "backports/concepts.h"
+#include "backports/span.h"
 #include "util/Generator.h"
 #include "util/Iterators.h"
 #include "util/Log.h"
@@ -156,7 +157,7 @@ CPP_template(typename UnderlyingRange, bool supportConst = true)(
   }
 
   CPP_auto_member constexpr auto CPP_fun(data)()(
-      requires ql::ranges::contiguous_range<UnderlyingRange>) {
+    requires ql::ranges::contiguous_range<UnderlyingRange>) {
     return ql::ranges::data(underlyingRange_);
   }
 
@@ -352,14 +353,21 @@ CPP_template(typename Range, typename Transformation)(
 /// separator and the yields spans of the chunks of data received inbetween.
 CPP_template(typename Range, typename ElementType)(
     requires ql::ranges::input_range<Range>) inline cppcoro::
-    generator<std::span<ElementType>> reChunkAtSeparator(
-        Range generator, ElementType separator) {
+    generator<ql::span<ElementType>> reChunkAtSeparator(Range generator,
+                                                        ElementType separator) {
   std::vector<ElementType> buffer;
   for (QL_CONCEPT_OR_NOTHING(ql::ranges::input_range) auto const& chunk :
        generator) {
     for (ElementType c : chunk) {
       if (c == separator) {
-        co_yield std::span{buffer.data(), buffer.size()};
+#ifdef QLEVER_CPP_17
+        co_yield ql::span{
+            buffer.data(),
+            static_cast<typename ql::span<ElementType>::index_type>(
+                buffer.size())};
+#else
+        co_yield ql::span{buffer.data(), buffer.size()};
+#endif
         buffer.clear();
       } else {
         buffer.push_back(c);
@@ -367,7 +375,13 @@ CPP_template(typename Range, typename ElementType)(
     }
   }
   if (!buffer.empty()) {
-    co_yield std::span{buffer.data(), buffer.size()};
+#ifdef QLEVER_CPP_17
+    co_yield ql::span{
+        buffer.data(),
+        static_cast<typename ql::span<ElementType>::index_type>(buffer.size())};
+#else
+    co_yield ql::span{buffer.data(), buffer.size()};
+#endif
   }
 }
 }  // namespace ad_utility

--- a/src/util/Views.h
+++ b/src/util/Views.h
@@ -352,14 +352,14 @@ CPP_template(typename Range, typename Transformation)(
 /// separator and the yields spans of the chunks of data received inbetween.
 CPP_template(typename Range, typename ElementType)(
     requires ql::ranges::input_range<Range>) inline cppcoro::
-    generator<absl::Span<ElementType>> reChunkAtSeparator(
+    generator<std::span<ElementType>> reChunkAtSeparator(
         Range generator, ElementType separator) {
   std::vector<ElementType> buffer;
   for (QL_CONCEPT_OR_NOTHING(ql::ranges::input_range) auto const& chunk :
        generator) {
     for (ElementType c : chunk) {
       if (c == separator) {
-        co_yield absl::Span{buffer.data(), buffer.size()};
+        co_yield std::span{buffer.data(), buffer.size()};
         buffer.clear();
       } else {
         buffer.push_back(c);
@@ -367,7 +367,7 @@ CPP_template(typename Range, typename ElementType)(
     }
   }
   if (!buffer.empty()) {
-    co_yield absl::Span{buffer.data(), buffer.size()};
+    co_yield std::span{buffer.data(), buffer.size()};
   }
 }
 }  // namespace ad_utility

--- a/src/util/http/HttpClient.cpp
+++ b/src/util/http/HttpClient.cpp
@@ -138,7 +138,7 @@ HttpOrHttpsResponse HttpClientImpl<StreamType>::sendRequest(
                         responseParser,
                     beast::flat_buffer buffer,
                     ad_utility::SharedCancellationHandle handle)
-      -> cppcoro::generator<std::span<std::byte>> {
+      -> cppcoro::generator<ql::span<std::byte>> {
     while (!responseParser->is_done()) {
       std::array<std::byte, 4096> staticBuffer;
       responseParser->get().body().data = staticBuffer.data();
@@ -150,8 +150,8 @@ HttpOrHttpsResponse HttpClientImpl<StreamType>::sendRequest(
               handle, ad_utility::source_location::current()),
           client->ioContext_);
       size_t remainingBytes = responseParser->get().body().size;
-      co_yield std::span{staticBuffer}.first(staticBuffer.size() -
-                                             remainingBytes);
+      co_yield ql::span{staticBuffer}.first(staticBuffer.size() -
+                                            remainingBytes);
     }
   };
 

--- a/src/util/http/HttpClient.cpp
+++ b/src/util/http/HttpClient.cpp
@@ -138,7 +138,7 @@ HttpOrHttpsResponse HttpClientImpl<StreamType>::sendRequest(
                         responseParser,
                     beast::flat_buffer buffer,
                     ad_utility::SharedCancellationHandle handle)
-      -> cppcoro::generator<std::span<std::byte>> {
+      -> cppcoro::generator<absl::Span<std::byte>> {
     while (!responseParser->is_done()) {
       std::array<std::byte, 4096> staticBuffer;
       responseParser->get().body().data = staticBuffer.data();
@@ -150,8 +150,8 @@ HttpOrHttpsResponse HttpClientImpl<StreamType>::sendRequest(
               handle, ad_utility::source_location::current()),
           client->ioContext_);
       size_t remainingBytes = responseParser->get().body().size;
-      co_yield std::span{staticBuffer}.first(staticBuffer.size() -
-                                             remainingBytes);
+      co_yield absl::Span<std::byte>(staticBuffer.data(),
+                                     staticBuffer.size() - remainingBytes);
     }
   };
 

--- a/src/util/http/HttpClient.cpp
+++ b/src/util/http/HttpClient.cpp
@@ -138,7 +138,7 @@ HttpOrHttpsResponse HttpClientImpl<StreamType>::sendRequest(
                         responseParser,
                     beast::flat_buffer buffer,
                     ad_utility::SharedCancellationHandle handle)
-      -> cppcoro::generator<absl::Span<std::byte>> {
+      -> cppcoro::generator<std::span<std::byte>> {
     while (!responseParser->is_done()) {
       std::array<std::byte, 4096> staticBuffer;
       responseParser->get().body().data = staticBuffer.data();
@@ -150,8 +150,8 @@ HttpOrHttpsResponse HttpClientImpl<StreamType>::sendRequest(
               handle, ad_utility::source_location::current()),
           client->ioContext_);
       size_t remainingBytes = responseParser->get().body().size;
-      co_yield absl::Span<std::byte>(staticBuffer.data(),
-                                     staticBuffer.size() - remainingBytes);
+      co_yield std::span{staticBuffer}.first(staticBuffer.size() -
+                                             remainingBytes);
     }
   };
 

--- a/src/util/http/HttpClient.h
+++ b/src/util/http/HttpClient.h
@@ -16,9 +16,9 @@
 // order of the includes should not matter, and it should certainly not cause
 // segmentation faults.
 
-#include <span>
 #include <string>
 
+#include "backports/span.h"
 #include "util/CancellationHandle.h"
 #include "util/Generator.h"
 #include "util/http/HttpUtils.h"

--- a/src/util/http/HttpClient.h
+++ b/src/util/http/HttpClient.h
@@ -28,7 +28,7 @@
 struct HttpOrHttpsResponse {
   boost::beast::http::status status_;
   std::string contentType_;
-  cppcoro::generator<std::span<std::byte>> body_;
+  cppcoro::generator<absl::Span<std::byte>> body_;
 };
 
 // A class for basic communication with a remote server via HTTP or HTTPS. For
@@ -50,7 +50,7 @@ class HttpClientImpl {
   // Send a request (the first argument must be either `http::verb::get` or
   // `http::verb::post`) and return the status and content-type as
   // well as the body of the response (possibly very large) as an
-  // `cppcoro::generator<std::span<std::byte>>`. The connection can be used
+  // `cppcoro::generator<absl::Span<std::byte>>`. The connection can be used
   // for only one request, as the client is moved to the content yielding
   // coroutine.
   static HttpOrHttpsResponse sendRequest(
@@ -86,9 +86,10 @@ using HttpsClient =
     HttpClientImpl<boost::asio::ssl::stream<boost::asio::ip::tcp::socket>>;
 
 // Global convenience function for sending a request (default: GET) to the given
-// URL and obtaining the result as a `cppcoro::generator<std::span<std::byte>>`.
-// The protocol (HTTP or HTTPS) is chosen automatically based on the URL. The
-// `requestBody` is the payload sent for POST requests (default: empty).
+// URL and obtaining the result as a
+// `cppcoro::generator<absl::Span<std::byte>>`. The protocol (HTTP or HTTPS) is
+// chosen automatically based on the URL. The `requestBody` is the payload sent
+// for POST requests (default: empty).
 HttpOrHttpsResponse sendHttpOrHttpsRequest(
     const ad_utility::httpUtils::Url& url,
     ad_utility::SharedCancellationHandle handle,

--- a/src/util/http/HttpClient.h
+++ b/src/util/http/HttpClient.h
@@ -28,7 +28,7 @@
 struct HttpOrHttpsResponse {
   boost::beast::http::status status_;
   std::string contentType_;
-  cppcoro::generator<absl::Span<std::byte>> body_;
+  cppcoro::generator<std::span<std::byte>> body_;
 };
 
 // A class for basic communication with a remote server via HTTP or HTTPS. For
@@ -50,7 +50,7 @@ class HttpClientImpl {
   // Send a request (the first argument must be either `http::verb::get` or
   // `http::verb::post`) and return the status and content-type as
   // well as the body of the response (possibly very large) as an
-  // `cppcoro::generator<absl::Span<std::byte>>`. The connection can be used
+  // `cppcoro::generator<std::span<std::byte>>`. The connection can be used
   // for only one request, as the client is moved to the content yielding
   // coroutine.
   static HttpOrHttpsResponse sendRequest(
@@ -86,10 +86,9 @@ using HttpsClient =
     HttpClientImpl<boost::asio::ssl::stream<boost::asio::ip::tcp::socket>>;
 
 // Global convenience function for sending a request (default: GET) to the given
-// URL and obtaining the result as a
-// `cppcoro::generator<absl::Span<std::byte>>`. The protocol (HTTP or HTTPS) is
-// chosen automatically based on the URL. The `requestBody` is the payload sent
-// for POST requests (default: empty).
+// URL and obtaining the result as a `cppcoro::generator<std::span<std::byte>>`.
+// The protocol (HTTP or HTTPS) is chosen automatically based on the URL. The
+// `requestBody` is the payload sent for POST requests (default: empty).
 HttpOrHttpsResponse sendHttpOrHttpsRequest(
     const ad_utility::httpUtils::Url& url,
     ad_utility::SharedCancellationHandle handle,

--- a/src/util/http/HttpClient.h
+++ b/src/util/http/HttpClient.h
@@ -28,7 +28,7 @@
 struct HttpOrHttpsResponse {
   boost::beast::http::status status_;
   std::string contentType_;
-  cppcoro::generator<std::span<std::byte>> body_;
+  cppcoro::generator<ql::span<std::byte>> body_;
 };
 
 // A class for basic communication with a remote server via HTTP or HTTPS. For
@@ -50,7 +50,7 @@ class HttpClientImpl {
   // Send a request (the first argument must be either `http::verb::get` or
   // `http::verb::post`) and return the status and content-type as
   // well as the body of the response (possibly very large) as an
-  // `cppcoro::generator<std::span<std::byte>>`. The connection can be used
+  // `cppcoro::generator<ql::span<std::byte>>`. The connection can be used
   // for only one request, as the client is moved to the content yielding
   // coroutine.
   static HttpOrHttpsResponse sendRequest(
@@ -86,7 +86,7 @@ using HttpsClient =
     HttpClientImpl<boost::asio::ssl::stream<boost::asio::ip::tcp::socket>>;
 
 // Global convenience function for sending a request (default: GET) to the given
-// URL and obtaining the result as a `cppcoro::generator<std::span<std::byte>>`.
+// URL and obtaining the result as a `cppcoro::generator<ql::span<std::byte>>`.
 // The protocol (HTTP or HTTPS) is chosen automatically based on the URL. The
 // `requestBody` is the payload sent for POST requests (default: empty).
 HttpOrHttpsResponse sendHttpOrHttpsRequest(

--- a/test/CompactStringVectorTest.cpp
+++ b/test/CompactStringVectorTest.cpp
@@ -29,7 +29,14 @@ auto vectorsEqual = [](const auto& compactVector, const auto& compareVector) {
   for (size_t i = 0; i < compactVector.size(); ++i) {
     using value_type =
         typename std::decay_t<decltype(compareVector)>::value_type;
-    value_type a(compactVector[i].begin(), compactVector[i].end());
+    value_type a = [&]() {
+      if constexpr (std::is_same_v<value_type, std::vector<int>> ||
+                    std::is_same_v<value_type, std::vector<char>>) {
+        return value_type(compactVector[i].begin(), compactVector[i].end());
+      } else {
+        return value_type(compactVector[i].data(), compactVector[i].size());
+      }
+    }();
     iterablesEqual(a, compareVector[i]);
   }
 };

--- a/test/CompactStringVectorTest.cpp
+++ b/test/CompactStringVectorTest.cpp
@@ -1,8 +1,6 @@
 //  Copyright 2022, University of Freiburg,
 //  Chair of Algorithms and Data Structures.
 //  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #include <gtest/gtest.h>
 
@@ -31,14 +29,7 @@ auto vectorsEqual = [](const auto& compactVector, const auto& compareVector) {
   for (size_t i = 0; i < compactVector.size(); ++i) {
     using value_type =
         typename std::decay_t<decltype(compareVector)>::value_type;
-    value_type a = [&]() {
-      if constexpr (std::is_same_v<value_type, std::vector<int>> ||
-                    std::is_same_v<value_type, std::vector<char>>) {
-        return value_type(compactVector[i].begin(), compactVector[i].end());
-      } else {
-        return value_type(compactVector[i].data(), compactVector[i].size());
-      }
-    }();
+    value_type a(compactVector[i].begin(), compactVector[i].end());
     iterablesEqual(a, compareVector[i]);
   }
 };

--- a/test/CompactStringVectorTest.cpp
+++ b/test/CompactStringVectorTest.cpp
@@ -21,7 +21,7 @@ std::vector<std::vector<int>> ints1{{1}, {42, 19}, {6, 5, -4, 96}, {-38, 4, 7}};
 
 auto iterablesEqual(const auto& a, const auto& b) {
   ASSERT_EQ(a.size(), b.size());
-  for (decltype(a.size()) i = 0; i < a.size(); ++i) {
+  for (size_t i = 0; i < a.size(); ++i) {
     ASSERT_EQ(a[i], b[i]);
   }
 }
@@ -32,12 +32,7 @@ auto vectorsEqual = [](const auto& compactVector, const auto& compareVector) {
     using value_type =
         typename std::decay_t<decltype(compareVector)>::value_type;
     value_type a = [&]() {
-      if constexpr (std::is_same_v<value_type, std::vector<int>> ||
-                    std::is_same_v<value_type, std::vector<char>>) {
-        return value_type(compactVector[i].begin(), compactVector[i].end());
-      } else {
-        return value_type(compactVector[i].data(), compactVector[i].size());
-      }
+      return value_type(compactVector[i].begin(), compactVector[i].end());
     }();
     iterablesEqual(a, compareVector[i]);
   }

--- a/test/CompactStringVectorTest.cpp
+++ b/test/CompactStringVectorTest.cpp
@@ -1,6 +1,8 @@
 //  Copyright 2022, University of Freiburg,
 //  Chair of Algorithms and Data Structures.
 //  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #include <gtest/gtest.h>
 

--- a/test/CompactStringVectorTest.cpp
+++ b/test/CompactStringVectorTest.cpp
@@ -1,6 +1,8 @@
 //  Copyright 2022, University of Freiburg,
 //  Chair of Algorithms and Data Structures.
 //  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #include <gtest/gtest.h>
 
@@ -19,7 +21,7 @@ std::vector<std::vector<int>> ints1{{1}, {42, 19}, {6, 5, -4, 96}, {-38, 4, 7}};
 
 auto iterablesEqual(const auto& a, const auto& b) {
   ASSERT_EQ(a.size(), b.size());
-  for (size_t i = 0; i < a.size(); ++i) {
+  for (decltype(a.size()) i = 0; i < a.size(); ++i) {
     ASSERT_EQ(a[i], b[i]);
   }
 }
@@ -29,7 +31,14 @@ auto vectorsEqual = [](const auto& compactVector, const auto& compareVector) {
   for (size_t i = 0; i < compactVector.size(); ++i) {
     using value_type =
         typename std::decay_t<decltype(compareVector)>::value_type;
-    value_type a(compactVector[i].begin(), compactVector[i].end());
+    value_type a = [&]() {
+      if constexpr (std::is_same_v<value_type, std::vector<int>> ||
+                    std::is_same_v<value_type, std::vector<char>>) {
+        return value_type(compactVector[i].begin(), compactVector[i].end());
+      } else {
+        return value_type(compactVector[i].data(), compactVector[i].size());
+      }
+    }();
     iterablesEqual(a, compareVector[i]);
   }
 };

--- a/test/HttpTest.cpp
+++ b/test/HttpTest.cpp
@@ -23,7 +23,7 @@ using ::testing::HasSubstr;
 namespace {
 
 /// Join all of the bytes into a big string.
-std::string toString(cppcoro::generator<std::span<std::byte>> generator) {
+std::string toString(cppcoro::generator<ql::span<std::byte>> generator) {
   std::string result;
   for (std::byte byte : generator | ql::ranges::views::join) {
     result.push_back(static_cast<char>(byte));

--- a/test/HttpTest.cpp
+++ b/test/HttpTest.cpp
@@ -23,7 +23,7 @@ using ::testing::HasSubstr;
 namespace {
 
 /// Join all of the bytes into a big string.
-std::string toString(cppcoro::generator<std::span<std::byte>> generator) {
+std::string toString(cppcoro::generator<absl::Span<std::byte>> generator) {
   std::string result;
   for (std::byte byte : generator | ql::ranges::views::join) {
     result.push_back(static_cast<char>(byte));

--- a/test/HttpTest.cpp
+++ b/test/HttpTest.cpp
@@ -23,7 +23,7 @@ using ::testing::HasSubstr;
 namespace {
 
 /// Join all of the bytes into a big string.
-std::string toString(cppcoro::generator<absl::Span<std::byte>> generator) {
+std::string toString(cppcoro::generator<std::span<std::byte>> generator) {
   std::string result;
   for (std::byte byte : generator | ql::ranges::views::join) {
     result.push_back(static_cast<char>(byte));

--- a/test/JoinTest.cpp
+++ b/test/JoinTest.cpp
@@ -235,7 +235,7 @@ namespace {
 // corresponding result column and the `UndefStatus`.
 using ExpectedColumns = ad_utility::HashMap<
     Variable,
-    std::pair<std::span<const Id>, ColumnIndexAndTypeInfo::UndefStatus>>;
+    std::pair<ql::span<const Id>, ColumnIndexAndTypeInfo::UndefStatus>>;
 
 // Test that the result of the `join` matches the `expected` outcome.
 // If `requestLaziness` is true, the join is requested to be lazy. If

--- a/test/JoinTest.cpp
+++ b/test/JoinTest.cpp
@@ -235,7 +235,7 @@ namespace {
 // corresponding result column and the `UndefStatus`.
 using ExpectedColumns = ad_utility::HashMap<
     Variable,
-    std::pair<absl::Span<const Id>, ColumnIndexAndTypeInfo::UndefStatus>>;
+    std::pair<std::span<const Id>, ColumnIndexAndTypeInfo::UndefStatus>>;
 
 // Test that the result of the `join` matches the `expected` outcome.
 // If `requestLaziness` is true, the join is requested to be lazy. If

--- a/test/JoinTest.cpp
+++ b/test/JoinTest.cpp
@@ -235,7 +235,7 @@ namespace {
 // corresponding result column and the `UndefStatus`.
 using ExpectedColumns = ad_utility::HashMap<
     Variable,
-    std::pair<std::span<const Id>, ColumnIndexAndTypeInfo::UndefStatus>>;
+    std::pair<absl::Span<const Id>, ColumnIndexAndTypeInfo::UndefStatus>>;
 
 // Test that the result of the `join` matches the `expected` outcome.
 // If `requestLaziness` is true, the join is requested to be lazy. If

--- a/test/LocalVocabTest.cpp
+++ b/test/LocalVocabTest.cpp
@@ -159,8 +159,7 @@ TEST(LocalVocab, merge) {
 
   // Clone it and test that the clone contains the same words.
   auto vocabs = std::vector{&std::as_const(vocA), &std::as_const(vocB)};
-  absl::Span<const LocalVocab*> vocabsSpan(vocabs.data(), vocabs.size());
-  LocalVocab localVocabMerged = LocalVocab::merge(vocabsSpan);
+  LocalVocab localVocabMerged = LocalVocab::merge(vocabs);
   ASSERT_EQ(localVocabMerged.size(), 4u);
   ASSERT_THAT(localVocabMerged.getAllWordsForTesting(),
               ::testing::UnorderedElementsAre(lit("oneA"), lit("twoA"),
@@ -180,8 +179,7 @@ TEST(LocalVocab, merge) {
     LocalVocab vocC, vocD;
     id = vocC.getBlankNodeIndex(&bnm);
     auto vocabs2 = std::vector{&std::as_const(vocC), &std::as_const(vocD)};
-    absl::Span<const LocalVocab*> vocabs2Span(vocabs2.data(), vocabs2.size());
-    localVocabMerged2 = LocalVocab::merge(vocabs2Span);
+    localVocabMerged2 = LocalVocab::merge(vocabs2);
   }
   EXPECT_TRUE(localVocabMerged2.isBlankNodeIndexContained(id));
 

--- a/test/LocalVocabTest.cpp
+++ b/test/LocalVocabTest.cpp
@@ -159,7 +159,8 @@ TEST(LocalVocab, merge) {
 
   // Clone it and test that the clone contains the same words.
   auto vocabs = std::vector{&std::as_const(vocA), &std::as_const(vocB)};
-  LocalVocab localVocabMerged = LocalVocab::merge(vocabs);
+  absl::Span<const LocalVocab*> vocabsSpan(vocabs.data(), vocabs.size());
+  LocalVocab localVocabMerged = LocalVocab::merge(vocabsSpan);
   ASSERT_EQ(localVocabMerged.size(), 4u);
   ASSERT_THAT(localVocabMerged.getAllWordsForTesting(),
               ::testing::UnorderedElementsAre(lit("oneA"), lit("twoA"),
@@ -179,7 +180,8 @@ TEST(LocalVocab, merge) {
     LocalVocab vocC, vocD;
     id = vocC.getBlankNodeIndex(&bnm);
     auto vocabs2 = std::vector{&std::as_const(vocC), &std::as_const(vocD)};
-    localVocabMerged2 = LocalVocab::merge(vocabs2);
+    absl::Span<const LocalVocab*> vocabs2Span(vocabs2.data(), vocabs2.size());
+    localVocabMerged2 = LocalVocab::merge(vocabs2Span);
   }
   EXPECT_TRUE(localVocabMerged2.isBlankNodeIndexContained(id));
 

--- a/test/LocatedTriplesTest.cpp
+++ b/test/LocatedTriplesTest.cpp
@@ -912,15 +912,15 @@ TEST_F(LocatedTriplesTest, augmentedMetadataGraphInfo) {
     // Add the exact amount of graphs such that we are at the maximum number of
     // stored graphs.
     locatedTriplesPerBlock.add(LocatedTriple::locateTriplesInPermutation(
-        std::span{triples}.subspan(0, numGraphsToMax), metadata, keyOrder, true,
+        ql::span{triples}.subspan(0, numGraphsToMax), metadata, keyOrder, true,
         handle));
     actualMetadata = locatedTriplesPerBlock.getAugmentedMetadata();
     ASSERT_TRUE(actualMetadata[1].graphInfo_.has_value());
 
     // Adding one more graph will exceed the maximum.
     locatedTriplesPerBlock.add(LocatedTriple::locateTriplesInPermutation(
-        std::span{triples}.subspan(numGraphsToMax, numGraphsToMax + 1),
-        metadata, keyOrder, true, handle));
+        ql::span{triples}.subspan(numGraphsToMax, numGraphsToMax + 1), metadata,
+        keyOrder, true, handle));
     actualMetadata = locatedTriplesPerBlock.getAugmentedMetadata();
     ASSERT_FALSE(actualMetadata[1].graphInfo_.has_value());
   }

--- a/test/LocatedTriplesTest.cpp
+++ b/test/LocatedTriplesTest.cpp
@@ -912,14 +912,15 @@ TEST_F(LocatedTriplesTest, augmentedMetadataGraphInfo) {
     // Add the exact amount of graphs such that we are at the maximum number of
     // stored graphs.
     locatedTriplesPerBlock.add(LocatedTriple::locateTriplesInPermutation(
-        std::span{triples}.subspan(0, numGraphsToMax), metadata, keyOrder, true,
-        handle));
+        absl::Span<const IdTriple<0>>(triples).subspan(0, numGraphsToMax),
+        metadata, keyOrder, true, handle));
     actualMetadata = locatedTriplesPerBlock.getAugmentedMetadata();
     ASSERT_TRUE(actualMetadata[1].graphInfo_.has_value());
 
     // Adding one more graph will exceed the maximum.
     locatedTriplesPerBlock.add(LocatedTriple::locateTriplesInPermutation(
-        std::span{triples}.subspan(numGraphsToMax, numGraphsToMax + 1),
+        absl::Span<const IdTriple<0>>(triples).subspan(numGraphsToMax,
+                                                       numGraphsToMax + 1),
         metadata, keyOrder, true, handle));
     actualMetadata = locatedTriplesPerBlock.getAugmentedMetadata();
     ASSERT_FALSE(actualMetadata[1].graphInfo_.has_value());

--- a/test/LocatedTriplesTest.cpp
+++ b/test/LocatedTriplesTest.cpp
@@ -912,15 +912,14 @@ TEST_F(LocatedTriplesTest, augmentedMetadataGraphInfo) {
     // Add the exact amount of graphs such that we are at the maximum number of
     // stored graphs.
     locatedTriplesPerBlock.add(LocatedTriple::locateTriplesInPermutation(
-        absl::Span<const IdTriple<0>>(triples).subspan(0, numGraphsToMax),
-        metadata, keyOrder, true, handle));
+        std::span{triples}.subspan(0, numGraphsToMax), metadata, keyOrder, true,
+        handle));
     actualMetadata = locatedTriplesPerBlock.getAugmentedMetadata();
     ASSERT_TRUE(actualMetadata[1].graphInfo_.has_value());
 
     // Adding one more graph will exceed the maximum.
     locatedTriplesPerBlock.add(LocatedTriple::locateTriplesInPermutation(
-        absl::Span<const IdTriple<0>>(triples).subspan(numGraphsToMax,
-                                                       numGraphsToMax + 1),
+        std::span{triples}.subspan(numGraphsToMax, numGraphsToMax + 1),
         metadata, keyOrder, true, handle));
     actualMetadata = locatedTriplesPerBlock.getAugmentedMetadata();
     ASSERT_FALSE(actualMetadata[1].graphInfo_.has_value());

--- a/test/PrefilterExpressionIndexTest.cpp
+++ b/test/PrefilterExpressionIndexTest.cpp
@@ -45,7 +45,7 @@ const auto makeIdForLYearDate = [](int year, DateT type = DateT::Date) {
 using IdxPair = std::pair<size_t, size_t>;
 using IdxPairRanges = std::vector<IdxPair>;
 // Convert `IdxPairRanges` to `BlockMetadataRanges` with respect to
-// `BlockMetadataIt beginBlockSpan` (first possible `std::span<const
+// `BlockMetadataIt beginBlockSpan` (first possible `ql::span<const
 // CompressedBlockMetadata>::iterator`).
 static BlockMetadataRanges convertFromSpanIdxToSpanBlockItRanges(
     const BlockMetadataIt& beginBlockSpan, const IdxPairRanges idxRanges) {
@@ -380,21 +380,21 @@ class PrefilterExpressionOnMetadataTest : public ::testing::Test {
   // Test the `mapValueIdItRangesToBlockItRangesComplemented` (if
   // `testComplement = true`) or `mapValueIdItRangesToBlockItRanges` helper
   // function of `PrefilterExpression`s. We assert that the retrieved
-  // relevant iterators with respect to the containerized `std::span<const
+  // relevant iterators with respect to the containerized `ql::span<const
   // CompressedBlockMetadata> evalBlocks` are correctly mapped back to
   // `RelevantBlockRange`s (index values regarding `evalBlocks`).
   auto makeTestDetailIndexMapping(CompOp compOp, ValueId referenceId,
                                   IdxPairRanges&& relevantIdxRanges,
                                   bool testComplement) {
-    std::span<const CompressedBlockMetadata> evalBlocks(
-        allTestBlocksIsDatatype);
+    ql::span<const CompressedBlockMetadata> evalBlocks(allTestBlocksIsDatatype);
     // Make `ValueId`s of `evalBlocks` accessible by iterators.
     // For the defined `CompressedBlockMetadata` values above, evaluation column
     // at index 2 is relevant.
     AccessValueIdFromBlockMetadata accessValueIdOp(2);
     ValueIdSubrange inputRange{
         ValueIdIt{&evalBlocks, 0, accessValueIdOp},
-        ValueIdIt{&evalBlocks, evalBlocks.size() * 2, accessValueIdOp}};
+        ValueIdIt{&evalBlocks, static_cast<size_t>(evalBlocks.size() * 2),
+                  accessValueIdOp}};
     std::vector<ValueIdItPair> iteratorRanges = getRangesForId(
         inputRange.begin(), inputRange.end(), referenceId, compOp);
     using namespace prefilterExpressions::detail::mapping;
@@ -423,7 +423,7 @@ class PrefilterExpressionOnMetadataTest : public ::testing::Test {
   template <bool TestUnion>
   auto makeTestAndOrOrMergeBlocks(IdxPairRanges&& r1, IdxPairRanges&& r2,
                                   IdxPairRanges&& rExpected) {
-    std::span<const CompressedBlockMetadata> blockSpan(allTestBlocksIsDatatype);
+    ql::span<const CompressedBlockMetadata> blockSpan(allTestBlocksIsDatatype);
     auto spanBegin = blockSpan.begin();
     auto mergedBlockItRanges =
         prefilterExpressions::detail::logicalOps::mergeRelevantBlockItRanges<

--- a/test/PrefilterExpressionIndexTest.cpp
+++ b/test/PrefilterExpressionIndexTest.cpp
@@ -45,7 +45,7 @@ const auto makeIdForLYearDate = [](int year, DateT type = DateT::Date) {
 using IdxPair = std::pair<size_t, size_t>;
 using IdxPairRanges = std::vector<IdxPair>;
 // Convert `IdxPairRanges` to `BlockMetadataRanges` with respect to
-// `BlockMetadataIt beginBlockSpan` (first possible `std::span<const
+// `BlockMetadataIt beginBlockSpan` (first possible `absl::Span<const
 // CompressedBlockMetadata>::iterator`).
 static BlockMetadataRanges convertFromSpanIdxToSpanBlockItRanges(
     const BlockMetadataIt& beginBlockSpan, const IdxPairRanges idxRanges) {
@@ -380,13 +380,13 @@ class PrefilterExpressionOnMetadataTest : public ::testing::Test {
   // Test the `mapValueIdItRangesToBlockItRangesComplemented` (if
   // `testComplement = true`) or `mapValueIdItRangesToBlockItRanges` helper
   // function of `PrefilterExpression`s. We assert that the retrieved
-  // relevant iterators with respect to the containerized `std::span<const
+  // relevant iterators with respect to the containerized `absl::Span<const
   // CompressedBlockMetadata> evalBlocks` are correctly mapped back to
   // `RelevantBlockRange`s (index values regarding `evalBlocks`).
   auto makeTestDetailIndexMapping(CompOp compOp, ValueId referenceId,
                                   IdxPairRanges&& relevantIdxRanges,
                                   bool testComplement) {
-    std::span<const CompressedBlockMetadata> evalBlocks(
+    absl::Span<const CompressedBlockMetadata> evalBlocks(
         allTestBlocksIsDatatype);
     // Make `ValueId`s of `evalBlocks` accessible by iterators.
     // For the defined `CompressedBlockMetadata` values above, evaluation column
@@ -423,7 +423,8 @@ class PrefilterExpressionOnMetadataTest : public ::testing::Test {
   template <bool TestUnion>
   auto makeTestAndOrOrMergeBlocks(IdxPairRanges&& r1, IdxPairRanges&& r2,
                                   IdxPairRanges&& rExpected) {
-    std::span<const CompressedBlockMetadata> blockSpan(allTestBlocksIsDatatype);
+    absl::Span<const CompressedBlockMetadata> blockSpan(
+        allTestBlocksIsDatatype);
     auto spanBegin = blockSpan.begin();
     auto mergedBlockItRanges =
         prefilterExpressions::detail::logicalOps::mergeRelevantBlockItRanges<

--- a/test/PrefilterExpressionIndexTest.cpp
+++ b/test/PrefilterExpressionIndexTest.cpp
@@ -45,7 +45,7 @@ const auto makeIdForLYearDate = [](int year, DateT type = DateT::Date) {
 using IdxPair = std::pair<size_t, size_t>;
 using IdxPairRanges = std::vector<IdxPair>;
 // Convert `IdxPairRanges` to `BlockMetadataRanges` with respect to
-// `BlockMetadataIt beginBlockSpan` (first possible `absl::Span<const
+// `BlockMetadataIt beginBlockSpan` (first possible `std::span<const
 // CompressedBlockMetadata>::iterator`).
 static BlockMetadataRanges convertFromSpanIdxToSpanBlockItRanges(
     const BlockMetadataIt& beginBlockSpan, const IdxPairRanges idxRanges) {
@@ -380,13 +380,13 @@ class PrefilterExpressionOnMetadataTest : public ::testing::Test {
   // Test the `mapValueIdItRangesToBlockItRangesComplemented` (if
   // `testComplement = true`) or `mapValueIdItRangesToBlockItRanges` helper
   // function of `PrefilterExpression`s. We assert that the retrieved
-  // relevant iterators with respect to the containerized `absl::Span<const
+  // relevant iterators with respect to the containerized `std::span<const
   // CompressedBlockMetadata> evalBlocks` are correctly mapped back to
   // `RelevantBlockRange`s (index values regarding `evalBlocks`).
   auto makeTestDetailIndexMapping(CompOp compOp, ValueId referenceId,
                                   IdxPairRanges&& relevantIdxRanges,
                                   bool testComplement) {
-    absl::Span<const CompressedBlockMetadata> evalBlocks(
+    std::span<const CompressedBlockMetadata> evalBlocks(
         allTestBlocksIsDatatype);
     // Make `ValueId`s of `evalBlocks` accessible by iterators.
     // For the defined `CompressedBlockMetadata` values above, evaluation column
@@ -423,8 +423,7 @@ class PrefilterExpressionOnMetadataTest : public ::testing::Test {
   template <bool TestUnion>
   auto makeTestAndOrOrMergeBlocks(IdxPairRanges&& r1, IdxPairRanges&& r2,
                                   IdxPairRanges&& rExpected) {
-    absl::Span<const CompressedBlockMetadata> blockSpan(
-        allTestBlocksIsDatatype);
+    std::span<const CompressedBlockMetadata> blockSpan(allTestBlocksIsDatatype);
     auto spanBegin = blockSpan.begin();
     auto mergedBlockItRanges =
         prefilterExpressions::detail::logicalOps::mergeRelevantBlockItRanges<

--- a/test/PrefilterExpressionIndexTest.cpp
+++ b/test/PrefilterExpressionIndexTest.cpp
@@ -393,8 +393,7 @@ class PrefilterExpressionOnMetadataTest : public ::testing::Test {
     AccessValueIdFromBlockMetadata accessValueIdOp(2);
     ValueIdSubrange inputRange{
         ValueIdIt{&evalBlocks, 0, accessValueIdOp},
-        ValueIdIt{&evalBlocks, static_cast<size_t>(evalBlocks.size() * 2),
-                  accessValueIdOp}};
+        ValueIdIt{&evalBlocks, evalBlocks.size() * 2, accessValueIdOp}};
     std::vector<ValueIdItPair> iteratorRanges = getRangesForId(
         inputRange.begin(), inputRange.end(), referenceId, compOp);
     using namespace prefilterExpressions::detail::mapping;

--- a/test/ServiceTest.cpp
+++ b/test/ServiceTest.cpp
@@ -103,9 +103,7 @@ class ServiceTest : public ::testing::Test {
         for (size_t start = 0; start < resultStr.length();) {
           size_t size = distribution(rng);
           std::string resultCopy{resultStr.substr(start, size)};
-          co_yield ql::span<std::byte>(
-              reinterpret_cast<std::byte*>(resultCopy.data()),
-              resultCopy.size());
+          co_yield ql::as_writeable_bytes(ql::span{resultCopy});
           start += size;
         }
       };

--- a/test/ServiceTest.cpp
+++ b/test/ServiceTest.cpp
@@ -92,7 +92,7 @@ class ServiceTest : public ::testing::Test {
       }
 
       auto body =
-          [](std::string result) -> cppcoro::generator<std::span<std::byte>> {
+          [](std::string result) -> cppcoro::generator<ql::span<std::byte>> {
         // Randomly slice the string to make tests more robust.
         std::mt19937 rng{std::random_device{}()};
 
@@ -103,7 +103,9 @@ class ServiceTest : public ::testing::Test {
         for (size_t start = 0; start < resultStr.length();) {
           size_t size = distribution(rng);
           std::string resultCopy{resultStr.substr(start, size)};
-          co_yield std::as_writable_bytes(std::span{resultCopy});
+          co_yield ql::span<std::byte>(
+              reinterpret_cast<std::byte*>(resultCopy.data()),
+              resultCopy.size());
           start += size;
         }
       };

--- a/test/ServiceTest.cpp
+++ b/test/ServiceTest.cpp
@@ -103,7 +103,7 @@ class ServiceTest : public ::testing::Test {
         for (size_t start = 0; start < resultStr.length();) {
           size_t size = distribution(rng);
           std::string resultCopy{resultStr.substr(start, size)};
-          co_yield ql::as_writeable_bytes(ql::span{resultCopy});
+          co_yield ql::as_writable_bytes(ql::span{resultCopy});
           start += size;
         }
       };

--- a/test/ServiceTest.cpp
+++ b/test/ServiceTest.cpp
@@ -92,7 +92,7 @@ class ServiceTest : public ::testing::Test {
       }
 
       auto body =
-          [](std::string result) -> cppcoro::generator<std::span<std::byte>> {
+          [](std::string result) -> cppcoro::generator<absl::Span<std::byte>> {
         // Randomly slice the string to make tests more robust.
         std::mt19937 rng{std::random_device{}()};
 
@@ -103,7 +103,9 @@ class ServiceTest : public ::testing::Test {
         for (size_t start = 0; start < resultStr.length();) {
           size_t size = distribution(rng);
           std::string resultCopy{resultStr.substr(start, size)};
-          co_yield std::as_writable_bytes(std::span{resultCopy});
+          co_yield absl::Span<std::byte>(
+              reinterpret_cast<std::byte*>(resultCopy.data()),
+              resultCopy.size());
           start += size;
         }
       };

--- a/test/ServiceTest.cpp
+++ b/test/ServiceTest.cpp
@@ -92,7 +92,7 @@ class ServiceTest : public ::testing::Test {
       }
 
       auto body =
-          [](std::string result) -> cppcoro::generator<absl::Span<std::byte>> {
+          [](std::string result) -> cppcoro::generator<std::span<std::byte>> {
         // Randomly slice the string to make tests more robust.
         std::mt19937 rng{std::random_device{}()};
 
@@ -103,9 +103,7 @@ class ServiceTest : public ::testing::Test {
         for (size_t start = 0; start < resultStr.length();) {
           size_t size = distribution(rng);
           std::string resultCopy{resultStr.substr(start, size)};
-          co_yield absl::Span<std::byte>(
-              reinterpret_cast<std::byte*>(resultCopy.data()),
-              resultCopy.size());
+          co_yield std::as_writable_bytes(std::span{resultCopy});
           start += size;
         }
       };

--- a/test/ValueIdTest.cpp
+++ b/test/ValueIdTest.cpp
@@ -61,7 +61,7 @@ TEST_F(ValueIdTest, makeFromDouble) {
   testRepresentableDouble(-std::numeric_limits<double>::infinity());
 
   // Test positive and negative 0.
-  ASSERT_NE(std::bit_cast<uint64_t>(0.0), std::bit_cast<uint64_t>(-0.0));
+  ASSERT_NE(absl::bit_cast<uint64_t>(0.0), absl::bit_cast<uint64_t>(-0.0));
   ASSERT_EQ(0.0, -0.0);
   testRepresentableDouble(0.0);
   testRepresentableDouble(-0.0);
@@ -222,7 +222,7 @@ TEST_F(ValueIdTest, DoubleOrdering) {
   // In `ids` the negative number stand AFTER the positive numbers because of
   // the bitOrdering. First rotate the negative numbers to the beginning.
   auto doubleIdIsNegative = [](ValueId id) {
-    auto bits = std::bit_cast<uint64_t>(id.getDouble());
+    auto bits = absl::bit_cast<uint64_t>(id.getDouble());
     return bits & ad_utility::bitMaskForHigherBits(1);
   };
   auto beginOfNegatives =

--- a/test/ViewsTest.cpp
+++ b/test/ViewsTest.cpp
@@ -198,7 +198,7 @@ TEST(Views, inPlaceTransform) {
 
 // __________________________________________________________________________
 
-std::string_view toView(std::span<char> span) {
+std::string_view toView(absl::Span<char> span) {
   return {span.data(), span.size()};
 }
 

--- a/test/ViewsTest.cpp
+++ b/test/ViewsTest.cpp
@@ -198,7 +198,7 @@ TEST(Views, inPlaceTransform) {
 
 // __________________________________________________________________________
 
-std::string_view toView(absl::Span<char> span) {
+std::string_view toView(std::span<char> span) {
   return {span.data(), span.size()};
 }
 

--- a/test/ViewsTest.cpp
+++ b/test/ViewsTest.cpp
@@ -199,7 +199,7 @@ TEST(Views, inPlaceTransform) {
 // __________________________________________________________________________
 
 std::string_view toView(ql::span<char> span) {
-  return {span.data(), static_cast<std::string_view::size_type>(span.size())};
+  return {span.data(), span.size()};
 }
 
 // __________________________________________________________________________

--- a/test/ViewsTest.cpp
+++ b/test/ViewsTest.cpp
@@ -198,8 +198,8 @@ TEST(Views, inPlaceTransform) {
 
 // __________________________________________________________________________
 
-std::string_view toView(std::span<char> span) {
-  return {span.data(), span.size()};
+std::string_view toView(ql::span<char> span) {
+  return {span.data(), static_cast<std::string_view::size_type>(span.size())};
 }
 
 // __________________________________________________________________________

--- a/test/engine/CartesianProductJoinTest.cpp
+++ b/test/engine/CartesianProductJoinTest.cpp
@@ -274,7 +274,7 @@ class CartesianProductJoinLazyTest
     auto* qec = ad_utility::testing::getQec();
     size_t counter = 0;
     CartesianProductJoin::Children children{};
-    for (IdTable& table : std::span{tables}.subspan(0, tables.size() - 1)) {
+    for (IdTable& table : ql::span{tables}.subspan(0, tables.size() - 1)) {
       children.push_back(ad_utility::makeExecutionTree<ValuesForTesting>(
           qec, table.clone(), makeUniqueVariables(table)));
       // Make sure size estimates are increasing to ensure the order stays the

--- a/test/engine/CartesianProductJoinTest.cpp
+++ b/test/engine/CartesianProductJoinTest.cpp
@@ -274,8 +274,7 @@ class CartesianProductJoinLazyTest
     auto* qec = ad_utility::testing::getQec();
     size_t counter = 0;
     CartesianProductJoin::Children children{};
-    for (IdTable& table :
-         absl::Span<IdTable>(tables).subspan(0, tables.size() - 1)) {
+    for (IdTable& table : std::span{tables}.subspan(0, tables.size() - 1)) {
       children.push_back(ad_utility::makeExecutionTree<ValuesForTesting>(
           qec, table.clone(), makeUniqueVariables(table)));
       // Make sure size estimates are increasing to ensure the order stays the

--- a/test/engine/CartesianProductJoinTest.cpp
+++ b/test/engine/CartesianProductJoinTest.cpp
@@ -274,7 +274,8 @@ class CartesianProductJoinLazyTest
     auto* qec = ad_utility::testing::getQec();
     size_t counter = 0;
     CartesianProductJoin::Children children{};
-    for (IdTable& table : std::span{tables}.subspan(0, tables.size() - 1)) {
+    for (IdTable& table :
+         absl::Span<IdTable>(tables).subspan(0, tables.size() - 1)) {
       children.push_back(ad_utility::makeExecutionTree<ValuesForTesting>(
           qec, table.clone(), makeUniqueVariables(table)));
       // Make sure size estimates are increasing to ensure the order stays the


### PR DESCRIPTION
The following cpp20 functions are in context of the change:
std::bit_front -> absl::bit_front 
std::span -> ql::span, which is ::ranges::span when the `QLEVER_CPP_17` macro is enabled.
std::bit_cast -> absl::bit_cast
std::construct_at -> placement new
std::bit_width -> absl::bit_width
std::popcount -> absl::popcount

Notes:
* To make `::ranges::span` an (almost) drop-in replacement for `std::span`, several changes had to be applied to our fork of `range-v3` (in particular some constructors were added, and the size is now an unsigned type).
* `absl::bit_cast` cannot be used in constexpr land (at least not with GCC 8, but it seems that we don't use it in constexpr functions currently.
