### PR TITLE
Revert "Get rid of `cmake` warning when using version `4.0.0` or later"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 3.27)
-cmake_policy(SET CMP0167 NEW)
 project(QLever C CXX)
 
 # C/C++ Versions


### PR DESCRIPTION
This reverts commit 76f09840bb85e47988ed98fe76b0a79a9dd9aa77.

Reason: Ubuntu 24.04 required here https://github.com/ad-freiburg/qlever/blob/76f09840bb85e47988ed98fe76b0a79a9dd9aa77/Dockerfile#L1 still ships with cmake 3.28.3 (https://launchpad.net/ubuntu/noble/+package/cmake).

Locally I also have 3.28.3 (working on Ubuntu 24.04)