### PR TITLE
Join with graph for transitive path join optimization with empty path

### DIFF
--- a/src/engine/ExistsJoin.cpp
+++ b/src/engine/ExistsJoin.cpp
@@ -236,3 +236,13 @@ std::unique_ptr<Operation> ExistsJoin::cloneImpl() const {
   newJoin->right_ = right_->clone();
   return newJoin;
 }
+
+// _____________________________________________________________________________
+bool ExistsJoin::columnOriginatesFromGraph(Variable variable) const {
+  AD_CONTRACT_CHECK(getExternallyVisibleVariableColumns().contains(variable));
+  if (left_->getVariableColumnOrNullopt(variable).has_value() &&
+      right_->getVariableColumnOrNullopt(variable).has_value()) {
+    return left_->getRootOperation()->columnOriginatesFromGraph(variable);
+  }
+  return Operation::columnOriginatesFromGraph(variable);
+}

--- a/src/engine/ExistsJoin.h
+++ b/src/engine/ExistsJoin.h
@@ -76,6 +76,8 @@ class ExistsJoin : public Operation {
     return {left_.get(), right_.get()};
   }
 
+  bool columnOriginatesFromGraph(Variable variable) const override;
+
  private:
   std::unique_ptr<Operation> cloneImpl() const override;
 

--- a/src/engine/IndexScan.cpp
+++ b/src/engine/IndexScan.cpp
@@ -673,3 +673,9 @@ std::unique_ptr<Operation> IndexScan::cloneImpl() const {
                                      additionalVariables_, graphsToFilter_,
                                      std::move(prefilter));
 }
+
+// _____________________________________________________________________________
+bool IndexScan::columnOriginatesFromGraph(Variable variable) const {
+  AD_CONTRACT_CHECK(getExternallyVisibleVariableColumns().contains(variable));
+  return variable == subject_ || variable == predicate_ || variable == object_;
+}

--- a/src/engine/IndexScan.h
+++ b/src/engine/IndexScan.h
@@ -177,6 +177,8 @@ class IndexScan final : public Operation {
   void updateRuntimeInfoForLazyScan(
       const CompressedRelationReader::LazyScanMetadata& metadata);
 
+  bool columnOriginatesFromGraph(Variable variable) const override;
+
  private:
   std::unique_ptr<Operation> cloneImpl() const override;
 

--- a/src/engine/Join.cpp
+++ b/src/engine/Join.cpp
@@ -845,3 +845,15 @@ std::unique_ptr<Operation> Join::cloneImpl() const {
   copy->_right = _right->clone();
   return copy;
 }
+
+// _____________________________________________________________________________
+bool Join::columnOriginatesFromGraph(Variable variable) const {
+  AD_CONTRACT_CHECK(getExternallyVisibleVariableColumns().contains(variable));
+  // For the join column we don't union the elements, we intersect them so we
+  // can have a more efficient implementation.
+  if (variable == _joinVar) {
+    return _left->getRootOperation()->columnOriginatesFromGraph(_joinVar) ||
+           _right->getRootOperation()->columnOriginatesFromGraph(_joinVar);
+  }
+  return Operation::columnOriginatesFromGraph(variable);
+}

--- a/src/engine/Join.h
+++ b/src/engine/Join.h
@@ -69,6 +69,8 @@ class Join : public Operation {
     return {_left.get(), _right.get()};
   }
 
+  bool columnOriginatesFromGraph(Variable variable) const override;
+
   /**
    * @brief Joins IdTables a and b on join column jc2, returning
    * the result in dynRes. Creates a cross product for matching rows.

--- a/src/engine/Minus.cpp
+++ b/src/engine/Minus.cpp
@@ -228,3 +228,13 @@ std::unique_ptr<Operation> Minus::cloneImpl() const {
   copy->_right = _right->clone();
   return copy;
 }
+
+// _____________________________________________________________________________
+bool Minus::columnOriginatesFromGraph(Variable variable) const {
+  AD_CONTRACT_CHECK(getExternallyVisibleVariableColumns().contains(variable));
+  if (_left->getVariableColumnOrNullopt(variable).has_value() &&
+      _right->getVariableColumnOrNullopt(variable).has_value()) {
+    return _left->getRootOperation()->columnOriginatesFromGraph(variable);
+  }
+  return Operation::columnOriginatesFromGraph(variable);
+}

--- a/src/engine/Minus.h
+++ b/src/engine/Minus.h
@@ -53,6 +53,8 @@ class Minus : public Operation {
     return {_left.get(), _right.get()};
   }
 
+  bool columnOriginatesFromGraph(Variable variable) const override;
+
   /**
    * @brief Joins a and b using the column defined int joinColumns, storing the
    *        result in result. R should have width resultWidth (or be a vector

--- a/src/engine/Operation.cpp
+++ b/src/engine/Operation.cpp
@@ -677,6 +677,12 @@ std::unique_ptr<Operation> Operation::clone() const {
 // _____________________________________________________________________________
 bool Operation::columnOriginatesFromGraph(Variable variable) const {
   AD_CONTRACT_CHECK(getExternallyVisibleVariableColumns().contains(variable));
+  // If the column contains UNDEF, it cannot possibly be guaranteed to originate
+  // from the graph.
+  if (getExternallyVisibleVariableColumns().at(variable).mightContainUndef_ !=
+      ColumnIndexAndTypeInfo::UndefStatus::AlwaysDefined) {
+    return false;
+  }
   // Returning false does never lead to a wrong result, but it might be
   // inefficient.
   if (ql::ranges::none_of(getChildren(), [&variable](const auto* child) {

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -434,6 +434,10 @@ class Operation {
       RuntimeInformation::Status status =
           RuntimeInformation::Status::optimizedOut);
 
+  // Return true if the given column originates from the loaded knowledge graph.
+  // This is used to skip potentially expensive checks.
+  virtual bool columnOriginatesFromGraph(Variable variable) const;
+
  private:
   // Create the runtime information in case the evaluation of this operation has
   // failed.

--- a/src/engine/OptionalJoin.cpp
+++ b/src/engine/OptionalJoin.cpp
@@ -276,6 +276,16 @@ auto OptionalJoin::computeImplementationFromIdTables(
   return implementation;
 }
 
+// _____________________________________________________________________________
+bool OptionalJoin::columnOriginatesFromGraph(Variable variable) const {
+  AD_CONTRACT_CHECK(getExternallyVisibleVariableColumns().contains(variable));
+  if (_left->getVariableColumnOrNullopt(variable).has_value() &&
+      _right->getVariableColumnOrNullopt(variable).has_value()) {
+    return _left->getRootOperation()->columnOriginatesFromGraph(variable);
+  }
+  return Operation::columnOriginatesFromGraph(variable);
+}
+
 // ______________________________________________________________
 void OptionalJoin::optionalJoin(
     const IdTable& left, const IdTable& right,

--- a/src/engine/OptionalJoin.h
+++ b/src/engine/OptionalJoin.h
@@ -60,6 +60,8 @@ class OptionalJoin : public Operation {
     return {_left.get(), _right.get()};
   }
 
+  bool columnOriginatesFromGraph(Variable variable) const override;
+
   // Joins two result tables on any number of columns, inserting the special
   // value `Id::makeUndefined()` for any entries marked as optional.
   void optionalJoin(

--- a/src/engine/TransitivePathBase.cpp
+++ b/src/engine/TransitivePathBase.cpp
@@ -520,3 +520,9 @@ void TransitivePathBase::insertIntoMap(Map& map, Id key, Id value) const {
   auto [it, success] = map.try_emplace(key, allocator());
   it->second.insert(value);
 }
+
+// _____________________________________________________________________________
+bool TransitivePathBase::columnOriginatesFromGraph(Variable variable) const {
+  AD_CONTRACT_CHECK(getExternallyVisibleVariableColumns().contains(variable));
+  return getExternallyVisibleVariableColumns().at(variable).columnIndex_ < 2;
+}

--- a/src/engine/TransitivePathBase.cpp
+++ b/src/engine/TransitivePathBase.cpp
@@ -524,5 +524,5 @@ void TransitivePathBase::insertIntoMap(Map& map, Id key, Id value) const {
 // _____________________________________________________________________________
 bool TransitivePathBase::columnOriginatesFromGraph(Variable variable) const {
   AD_CONTRACT_CHECK(getExternallyVisibleVariableColumns().contains(variable));
-  return getExternallyVisibleVariableColumns().at(variable).columnIndex_ < 2;
+  return variable == lhs_.value_ || variable == rhs_.value_;
 }

--- a/src/engine/TransitivePathBase.h
+++ b/src/engine/TransitivePathBase.h
@@ -318,6 +318,8 @@ class TransitivePathBase : public Operation {
 
   VariableToColumnMap computeVariableToColumnMap() const override;
 
+  bool columnOriginatesFromGraph(Variable variable) const override;
+
   // The internal implementation of `bindLeftSide` and `bindRightSide` which
   // share a lot of code.
   std::shared_ptr<TransitivePathBase> bindLeftOrRightSide(

--- a/src/engine/TransitivePathBase.h
+++ b/src/engine/TransitivePathBase.h
@@ -127,6 +127,10 @@ class TransitivePathBase : public Operation {
   // re-bound to something cheaper later if the query permits it.
   bool boundVariableIsForEmptyPath_ = false;
 
+  // Store the active graphs for the transitive path operation. This is used to
+  // correctly match against the proper graph when the minimum distance is 0.
+  Graphs activeGraphs_;
+
  public:
   TransitivePathBase(QueryExecutionContext* qec,
                      std::shared_ptr<QueryExecutionTree> child,
@@ -260,7 +264,8 @@ class TransitivePathBase : public Operation {
   // Return an execution tree that represents one side of an empty path. This is
   // used as a starting point for evaluating the empty path.
   static std::shared_ptr<QueryExecutionTree> makeEmptyPathSide(
-      QueryExecutionContext* qec, Graphs activeGraphs);
+      QueryExecutionContext* qec, Graphs activeGraphs,
+      std::optional<Variable> variable = std::nullopt);
 
  public:
   size_t getCostEstimate() override;

--- a/test/MinusTest.cpp
+++ b/test/MinusTest.cpp
@@ -9,6 +9,7 @@
 
 #include "./util/IdTestHelpers.h"
 #include "engine/CallFixedSize.h"
+#include "engine/IndexScan.h"
 #include "engine/Minus.h"
 #include "engine/ValuesForTesting.h"
 #include "util/AllocatorTestHelpers.h"
@@ -122,4 +123,47 @@ TEST(Minus, clone) {
   ASSERT_TRUE(clone);
   EXPECT_THAT(minus, IsDeepCopy(*clone));
   EXPECT_EQ(clone->getDescriptor(), minus.getDescriptor());
+}
+
+// _____________________________________________________________________________
+TEST(Minus, columnOriginatesFromGraph) {
+  using ad_utility::triple_component::Iri;
+  auto* qec = ad_utility::testing::getQec();
+  auto values1 = ad_utility::makeExecutionTree<ValuesForTesting>(
+      qec, makeIdTableFromVector({{0, 1}}),
+      std::vector<std::optional<Variable>>{Variable{"?a"}, Variable{"?b"}});
+  auto values2 = ad_utility::makeExecutionTree<ValuesForTesting>(
+      qec, makeIdTableFromVector({{0, 1}}),
+      std::vector<std::optional<Variable>>{Variable{"?a"}, Variable{"?c"}});
+  auto index = ad_utility::makeExecutionTree<IndexScan>(
+      qec, Permutation::POS,
+      SparqlTripleSimple{Variable{"?a"}, Iri::fromIriref("<b>"),
+                         Iri::fromIriref("<c>")});
+
+  Minus minus1{qec, values1, values1};
+  EXPECT_FALSE(minus1.columnOriginatesFromGraph(Variable{"?a"}));
+  EXPECT_FALSE(minus1.columnOriginatesFromGraph(Variable{"?b"}));
+  EXPECT_THROW(minus1.columnOriginatesFromGraph(Variable{"?notExisting"}),
+               ad_utility::Exception);
+
+  Minus minus2{qec, values1, values2};
+  EXPECT_FALSE(minus2.columnOriginatesFromGraph(Variable{"?a"}));
+  EXPECT_FALSE(minus2.columnOriginatesFromGraph(Variable{"?b"}));
+  EXPECT_THROW(minus2.columnOriginatesFromGraph(Variable{"?c"}),
+               ad_utility::Exception);
+  EXPECT_THROW(minus2.columnOriginatesFromGraph(Variable{"?notExisting"}),
+               ad_utility::Exception);
+
+  Minus minus3{qec, index, values1};
+  EXPECT_TRUE(minus3.columnOriginatesFromGraph(Variable{"?a"}));
+  EXPECT_THROW(minus3.columnOriginatesFromGraph(Variable{"?b"}),
+               ad_utility::Exception);
+  EXPECT_THROW(minus3.columnOriginatesFromGraph(Variable{"?notExisting"}),
+               ad_utility::Exception);
+
+  Minus minus4{qec, values1, index};
+  EXPECT_FALSE(minus4.columnOriginatesFromGraph(Variable{"?a"}));
+  EXPECT_FALSE(minus4.columnOriginatesFromGraph(Variable{"?b"}));
+  EXPECT_THROW(minus4.columnOriginatesFromGraph(Variable{"?notExisting"}),
+               ad_utility::Exception);
 }

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -4190,3 +4190,72 @@ TEST(QueryPlanner, emptyPathWithLiteralsBound) {
               h::IndexScanFromStrings("?_QLever_internal_variable_qp_0", "<a>",
                                       "?_QLever_internal_variable_qp_1")))));
 }
+
+// _____________________________________________________________________________
+TEST(QueryPlanner, emptyPathWithJoinOptimization) {
+  TransitivePathSide left{std::nullopt, 1, Variable{"?other"}, 0};
+  TransitivePathSide right{std::nullopt, 0, Variable{"?var"}, 1};
+  h::expect(
+      "SELECT * { ?other <a>* ?var . VALUES ?var { 2 } }",
+      h::TransitivePath(
+          left, right, 0, std::numeric_limits<size_t>::max(),
+          h::Join(
+              h::Distinct(
+                  {0},
+                  h::Union(h::IndexScanFromStrings(
+                               "?var", "?internal_property_path_variable_y",
+                               "?internal_property_path_variable_z"),
+                           h::IndexScanFromStrings(
+                               "?internal_property_path_variable_z",
+                               "?internal_property_path_variable_y", "?var"))),
+              h::Sort(h::ValuesClause("VALUES (?var) { (2) }"))),
+          h::IndexScanFromStrings("?_QLever_internal_variable_qp_0", "<a>",
+                                  "?_QLever_internal_variable_qp_1")));
+
+  TransitivePathSide left2{std::nullopt, 0, Variable{"?var"}, 0};
+  TransitivePathSide right2{std::nullopt, 1, Variable{"?other"}, 1};
+  h::expect(
+      "SELECT * { ?var <a>* ?other . VALUES ?var { 2 } }",
+      h::TransitivePath(
+          left2, right2, 0, std::numeric_limits<size_t>::max(),
+          h::Join(
+              h::Distinct(
+                  {0},
+                  h::Union(h::IndexScanFromStrings(
+                               "?var", "?internal_property_path_variable_y",
+                               "?internal_property_path_variable_z"),
+                           h::IndexScanFromStrings(
+                               "?internal_property_path_variable_z",
+                               "?internal_property_path_variable_y", "?var"))),
+              h::Sort(h::ValuesClause("VALUES (?var) { (2) }"))),
+          h::IndexScanFromStrings("?_QLever_internal_variable_qp_0", "<a>",
+                                  "?_QLever_internal_variable_qp_1")));
+
+  h::expect(
+      "SELECT * { ?other <a>* ?var . ?var <a> <b> }",
+      h::TransitivePath(
+          left, right, 0, std::numeric_limits<size_t>::max(),
+          h::IndexScanFromStrings("?var", "<a>", "<b>"),
+          h::IndexScanFromStrings("?_QLever_internal_variable_qp_0", "<a>",
+                                  "?_QLever_internal_variable_qp_1")));
+
+  h::expectWithGivenBudgets(
+      "SELECT * { ?var <a> <b> . ?var <c> <d> . ?other <a>* ?var }",
+      h::TransitivePath(
+          left, right, 0, std::numeric_limits<size_t>::max(),
+          h::Join(h::IndexScanFromStrings("?var", "<a>", "<b>"),
+                  h::IndexScanFromStrings("?var", "<c>", "<d>")),
+          h::IndexScanFromStrings("?_QLever_internal_variable_qp_0", "<a>",
+                                  "?_QLever_internal_variable_qp_1")),
+      std::nullopt, {16, 64'000'000});
+
+  h::expectWithGivenBudgets(
+      "SELECT * { VALUES ?var { 1 } . ?var <c> <d> . ?other <a>* ?var }",
+      h::TransitivePath(
+          left, right, 0, std::numeric_limits<size_t>::max(),
+          h::Join(h::Sort(h::ValuesClause("VALUES (?var) { (1) }")),
+                  h::IndexScanFromStrings("?var", "<c>", "<d>")),
+          h::IndexScanFromStrings("?_QLever_internal_variable_qp_0", "<a>",
+                                  "?_QLever_internal_variable_qp_1")),
+      std::nullopt, {0, 4});
+}

--- a/test/TransitivePathTest.cpp
+++ b/test/TransitivePathTest.cpp
@@ -912,19 +912,46 @@ TEST_P(TransitivePathTest, clone) {
 TEST_P(TransitivePathTest, columnOriginatesFromGraph) {
   auto sub = makeIdTableFromVector({{0, 2}});
 
-  TransitivePathSide left(std::nullopt, 0, Variable{"?start"}, 0);
-  TransitivePathSide right(std::nullopt, 1, Variable{"?target"}, 1);
-  auto transitivePath = makePathBound(
-      false, std::move(sub), {Variable{"?internal1"}, Variable{"?internal2"}},
-      sub.clone(), 0, {Variable{"?start"}, Variable{"?other"}}, left, right, 0,
-      std::numeric_limits<size_t>::max());
+  {
+    TransitivePathSide left(std::nullopt, 0, Variable{"?start"}, 0);
+    TransitivePathSide right(std::nullopt, 1, Variable{"?target"}, 1);
+    auto transitivePath = makePathBound(
+        false, sub.clone(), {Variable{"?internal1"}, Variable{"?internal2"}},
+        sub.clone(), 0, {Variable{"?start"}, Variable{"?other"}}, left, right,
+        0, std::numeric_limits<size_t>::max());
 
-  EXPECT_TRUE(transitivePath->columnOriginatesFromGraph(Variable{"?start"}));
-  EXPECT_TRUE(transitivePath->columnOriginatesFromGraph(Variable{"?target"}));
-  EXPECT_FALSE(transitivePath->columnOriginatesFromGraph(Variable{"?other"}));
-  EXPECT_THROW(
-      transitivePath->columnOriginatesFromGraph(Variable{"?notExisting"}),
-      ad_utility::Exception);
+    EXPECT_TRUE(transitivePath->columnOriginatesFromGraph(Variable{"?start"}));
+    EXPECT_TRUE(transitivePath->columnOriginatesFromGraph(Variable{"?target"}));
+    EXPECT_FALSE(transitivePath->columnOriginatesFromGraph(Variable{"?other"}));
+    EXPECT_THROW(
+        transitivePath->columnOriginatesFromGraph(Variable{"?internal1"}),
+        ad_utility::Exception);
+    EXPECT_THROW(
+        transitivePath->columnOriginatesFromGraph(Variable{"?internal2"}),
+        ad_utility::Exception);
+    EXPECT_THROW(
+        transitivePath->columnOriginatesFromGraph(Variable{"?notExisting"}),
+        ad_utility::Exception);
+  }
+
+  {
+    TransitivePathSide left(std::nullopt, 0, 1, 0);
+    TransitivePathSide right(std::nullopt, 1, Variable{"?target"}, 1);
+    auto transitivePath = makePathUnbound(
+        std::move(sub), {Variable{"?internal1"}, Variable{"?internal2"}}, left,
+        right, 0, std::numeric_limits<size_t>::max());
+
+    EXPECT_TRUE(transitivePath->columnOriginatesFromGraph(Variable{"?target"}));
+    EXPECT_THROW(
+        transitivePath->columnOriginatesFromGraph(Variable{"?internal1"}),
+        ad_utility::Exception);
+    EXPECT_THROW(
+        transitivePath->columnOriginatesFromGraph(Variable{"?internal2"}),
+        ad_utility::Exception);
+    EXPECT_THROW(
+        transitivePath->columnOriginatesFromGraph(Variable{"?notExisting"}),
+        ad_utility::Exception);
+  }
 }
 
 // _____________________________________________________________________________

--- a/test/TransitivePathTest.cpp
+++ b/test/TransitivePathTest.cpp
@@ -909,6 +909,25 @@ TEST_P(TransitivePathTest, clone) {
 }
 
 // _____________________________________________________________________________
+TEST_P(TransitivePathTest, columnOriginatesFromGraph) {
+  auto sub = makeIdTableFromVector({{0, 2}});
+
+  TransitivePathSide left(std::nullopt, 0, Variable{"?start"}, 0);
+  TransitivePathSide right(std::nullopt, 1, Variable{"?target"}, 1);
+  auto transitivePath = makePathBound(
+      false, std::move(sub), {Variable{"?internal1"}, Variable{"?internal2"}},
+      sub.clone(), 0, {Variable{"?start"}, Variable{"?other"}}, left, right, 0,
+      std::numeric_limits<size_t>::max());
+
+  EXPECT_TRUE(transitivePath->columnOriginatesFromGraph(Variable{"?start"}));
+  EXPECT_TRUE(transitivePath->columnOriginatesFromGraph(Variable{"?target"}));
+  EXPECT_FALSE(transitivePath->columnOriginatesFromGraph(Variable{"?other"}));
+  EXPECT_THROW(
+      transitivePath->columnOriginatesFromGraph(Variable{"?notExisting"}),
+      ad_utility::Exception);
+}
+
+// _____________________________________________________________________________
 INSTANTIATE_TEST_SUITE_P(
     TransitivePathTestSuite, TransitivePathTest,
     ::testing::Combine(::testing::Bool(), ::testing::Bool()),

--- a/test/engine/ExistsJoinTest.cpp
+++ b/test/engine/ExistsJoinTest.cpp
@@ -218,3 +218,50 @@ TEST(Exists, testGeneratorIsForwardedForDistinctColumnsFalseCase) {
 
   EXPECT_EQ(++it, idTables.end());
 }
+
+// _____________________________________________________________________________
+TEST(Exists, columnOriginatesFromGraph) {
+  using ad_utility::triple_component::Iri;
+  auto* qec = getQec();
+  auto values1 = ad_utility::makeExecutionTree<ValuesForTesting>(
+      qec, makeIdTableFromVector({{0, 1}}),
+      std::vector<std::optional<Variable>>{Variable{"?a"}, Variable{"?b"}});
+  auto values2 = ad_utility::makeExecutionTree<ValuesForTesting>(
+      qec, makeIdTableFromVector({{0, 1}}),
+      std::vector<std::optional<Variable>>{Variable{"?a"}, Variable{"?c"}});
+  auto index = ad_utility::makeExecutionTree<IndexScan>(
+      qec, Permutation::POS,
+      SparqlTripleSimple{Variable{"?a"}, Iri::fromIriref("<b>"),
+                         Iri::fromIriref("<c>")});
+
+  ExistsJoin existJoin1{qec, values1, values1, Variable{"?z"}};
+  EXPECT_FALSE(existJoin1.columnOriginatesFromGraph(Variable{"?a"}));
+  EXPECT_FALSE(existJoin1.columnOriginatesFromGraph(Variable{"?b"}));
+  EXPECT_FALSE(existJoin1.columnOriginatesFromGraph(Variable{"?z"}));
+  EXPECT_THROW(existJoin1.columnOriginatesFromGraph(Variable{"?notExisting"}),
+               ad_utility::Exception);
+
+  ExistsJoin existJoin2{qec, values1, values2, Variable{"?z"}};
+  EXPECT_FALSE(existJoin2.columnOriginatesFromGraph(Variable{"?a"}));
+  EXPECT_FALSE(existJoin2.columnOriginatesFromGraph(Variable{"?b"}));
+  EXPECT_FALSE(existJoin2.columnOriginatesFromGraph(Variable{"?z"}));
+  EXPECT_THROW(existJoin2.columnOriginatesFromGraph(Variable{"?c"}),
+               ad_utility::Exception);
+  EXPECT_THROW(existJoin2.columnOriginatesFromGraph(Variable{"?notExisting"}),
+               ad_utility::Exception);
+
+  ExistsJoin existJoin3{qec, index, values1, Variable{"?z"}};
+  EXPECT_TRUE(existJoin3.columnOriginatesFromGraph(Variable{"?a"}));
+  EXPECT_THROW(existJoin3.columnOriginatesFromGraph(Variable{"?b"}),
+               ad_utility::Exception);
+  EXPECT_FALSE(existJoin3.columnOriginatesFromGraph(Variable{"?z"}));
+  EXPECT_THROW(existJoin3.columnOriginatesFromGraph(Variable{"?notExisting"}),
+               ad_utility::Exception);
+
+  ExistsJoin existJoin4{qec, values1, index, Variable{"?z"}};
+  EXPECT_FALSE(existJoin4.columnOriginatesFromGraph(Variable{"?a"}));
+  EXPECT_FALSE(existJoin4.columnOriginatesFromGraph(Variable{"?b"}));
+  EXPECT_FALSE(existJoin4.columnOriginatesFromGraph(Variable{"?z"}));
+  EXPECT_THROW(existJoin4.columnOriginatesFromGraph(Variable{"?notExisting"}),
+               ad_utility::Exception);
+}

--- a/test/engine/IndexScanTest.cpp
+++ b/test/engine/IndexScanTest.cpp
@@ -1122,3 +1122,34 @@ TEST(IndexScan, clone) {
     EXPECT_EQ(cloneReference.getDescriptor(), scan.getDescriptor());
   }
 }
+
+// _____________________________________________________________________________
+TEST(IndexScan, columnOriginatesFromGraph) {
+  auto* qec = getQec();
+  IndexScan scan1{qec, Permutation::PSO,
+                  SparqlTripleSimple{Var{"?x"}, Var{"?y"}, Var{"?z"}}};
+  EXPECT_TRUE(scan1.columnOriginatesFromGraph(Var{"?x"}));
+  EXPECT_TRUE(scan1.columnOriginatesFromGraph(Var{"?y"}));
+  EXPECT_TRUE(scan1.columnOriginatesFromGraph(Var{"?z"}));
+  EXPECT_THROW(scan1.columnOriginatesFromGraph(Var{"?notExisting"}),
+               ad_utility::Exception);
+
+  IndexScan scan2{
+      qec, Permutation::PSO,
+      SparqlTripleSimple{
+          Var{"?x"}, Var{"?y"}, Var{"?z"}, {std::pair{3, Var{"?g"}}}}};
+  EXPECT_TRUE(scan2.columnOriginatesFromGraph(Var{"?x"}));
+  EXPECT_TRUE(scan2.columnOriginatesFromGraph(Var{"?y"}));
+  EXPECT_TRUE(scan2.columnOriginatesFromGraph(Var{"?z"}));
+  EXPECT_FALSE(scan2.columnOriginatesFromGraph(Var{"?g"}));
+  EXPECT_THROW(scan2.columnOriginatesFromGraph(Var{"?notExisting"}),
+               ad_utility::Exception);
+
+  IndexScan scan3{qec, Permutation::OSP,
+                  SparqlTripleSimple{iri("<a>"), Var{"?y"}, iri("<c>")}};
+  EXPECT_THROW(scan3.columnOriginatesFromGraph(Var{"?x"}),
+               ad_utility::Exception);
+  EXPECT_TRUE(scan3.columnOriginatesFromGraph(Var{"?y"}));
+  EXPECT_THROW(scan3.columnOriginatesFromGraph(Var{"?z"}),
+               ad_utility::Exception);
+}


### PR DESCRIPTION
This PR fixes the behaviour of property paths with the `*` modifier to properly match against the knowledge graph, even when another operation is bound to it.
Example:

```sparql
SELEC *  {
  VALUES ?x { 1 }
  ?x a* ?x
}
```

should only produce a value if the literal "1" is present in the graph. Currently it always produces at least a single result. We achieve this by adding an extra join. This join will be more efficient once a subset of the changes proposed by #1666 land.