### PR TITLE
Add dummy implementation of GeoSPARQL simple features relation functions

### DIFF
--- a/src/engine/sparqlExpressions/NaryExpression.cpp
+++ b/src/engine/sparqlExpressions/NaryExpression.cpp
@@ -6,7 +6,9 @@
 
 #include "engine/sparqlExpressions/NaryExpression.h"
 
+#include "engine/SpatialJoin.h"
 #include "engine/sparqlExpressions/NaryExpressionImpl.h"
+#include "engine/sparqlExpressions/SparqlExpression.h"
 #include "engine/sparqlExpressions/SparqlExpressionValueGetters.h"
 #include "util/GeoSparqlHelpers.h"
 
@@ -28,6 +30,11 @@ NARY_EXPRESSION(
     DistWithUnitExpression, 3,
     FV<NumericIdWrapper<ad_utility::WktDistGeoPoints, true>,
        GeoPointValueGetter, GeoPointValueGetter, UnitOfMeasurementValueGetter>);
+
+template <SpatialJoinType Relation>
+NARY_EXPRESSION(
+    GeoRelationExpression, 2,
+    FV<ad_utility::WktGeometricRelation<Relation>, GeoPointValueGetter>);
 
 }  // namespace detail
 
@@ -54,6 +61,13 @@ SparqlExpression::Ptr makeDistWithUnitExpression(
   }
 }
 
+template <SpatialJoinType Relation>
+SparqlExpression::Ptr makeGeoRelationExpression(SparqlExpression::Ptr child1,
+                                                SparqlExpression::Ptr child2) {
+  return std::make_unique<GeoRelationExpression<Relation>>(std::move(child1),
+                                                           std::move(child2));
+}
+
 SparqlExpression::Ptr makeLatitudeExpression(SparqlExpression::Ptr child) {
   return std::make_unique<LatitudeExpression>(std::move(child));
 }
@@ -62,3 +76,35 @@ SparqlExpression::Ptr makeLongitudeExpression(SparqlExpression::Ptr child) {
 }
 
 }  // namespace sparqlExpression
+
+// Explicit instantiations for the different geometric relations to avoid linker
+// problems
+template sparqlExpression::SparqlExpression::Ptr
+    sparqlExpression::makeGeoRelationExpression<SpatialJoinType::INTERSECTS>(
+        sparqlExpression::SparqlExpression::Ptr,
+        sparqlExpression::SparqlExpression::Ptr);
+
+template sparqlExpression::SparqlExpression::Ptr
+    sparqlExpression::makeGeoRelationExpression<SpatialJoinType::CONTAINS>(
+        sparqlExpression::SparqlExpression::Ptr,
+        sparqlExpression::SparqlExpression::Ptr);
+
+template sparqlExpression::SparqlExpression::Ptr
+    sparqlExpression::makeGeoRelationExpression<SpatialJoinType::CROSSES>(
+        sparqlExpression::SparqlExpression::Ptr,
+        sparqlExpression::SparqlExpression::Ptr);
+
+template sparqlExpression::SparqlExpression::Ptr
+    sparqlExpression::makeGeoRelationExpression<SpatialJoinType::TOUCHES>(
+        sparqlExpression::SparqlExpression::Ptr,
+        sparqlExpression::SparqlExpression::Ptr);
+
+template sparqlExpression::SparqlExpression::Ptr
+    sparqlExpression::makeGeoRelationExpression<SpatialJoinType::EQUALS>(
+        sparqlExpression::SparqlExpression::Ptr,
+        sparqlExpression::SparqlExpression::Ptr);
+
+template sparqlExpression::SparqlExpression::Ptr
+    sparqlExpression::makeGeoRelationExpression<SpatialJoinType::OVERLAPS>(
+        sparqlExpression::SparqlExpression::Ptr,
+        sparqlExpression::SparqlExpression::Ptr);

--- a/src/engine/sparqlExpressions/NaryExpression.h
+++ b/src/engine/sparqlExpressions/NaryExpression.h
@@ -12,6 +12,7 @@
 #include <cstdlib>
 
 #include "backports/concepts.h"
+#include "engine/SpatialJoin.h"
 #include "engine/sparqlExpressions/SparqlExpression.h"
 
 // Factory functions for all kinds of expressions that only have other
@@ -55,6 +56,11 @@ SparqlExpression::Ptr makeMetricDistExpression(SparqlExpression::Ptr child1,
 SparqlExpression::Ptr makeDistWithUnitExpression(
     SparqlExpression::Ptr child1, SparqlExpression::Ptr child2,
     std::optional<SparqlExpression::Ptr> child3 = std::nullopt);
+
+template <SpatialJoinType Relation>
+SparqlExpression::Ptr makeGeoRelationExpression(SparqlExpression::Ptr child1,
+                                                SparqlExpression::Ptr child2);
+
 SparqlExpression::Ptr makeLatitudeExpression(SparqlExpression::Ptr child);
 SparqlExpression::Ptr makeLongitudeExpression(SparqlExpression::Ptr child);
 

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -14,6 +14,7 @@
 #include <string>
 #include <vector>
 
+#include "engine/SpatialJoin.h"
 #include "engine/sparqlExpressions/BlankNodeExpression.h"
 #include "engine/sparqlExpressions/CountStarExpression.h"
 #include "engine/sparqlExpressions/ExistsExpression.h"
@@ -182,6 +183,21 @@ ExpressionPtr Visitor::processIriFunctionCall(
       return createUnary(&makeLongitudeExpression);
     } else if (functionName == "latitude") {
       return createUnary(&makeLatitudeExpression);
+    } else if (functionName == "sfIntersects") {
+      return createBinary(
+          &makeGeoRelationExpression<SpatialJoinType::INTERSECTS>);
+    } else if (functionName == "sfContains") {
+      return createBinary(
+          &makeGeoRelationExpression<SpatialJoinType::CONTAINS>);
+    } else if (functionName == "sfCrosses") {
+      return createBinary(&makeGeoRelationExpression<SpatialJoinType::CROSSES>);
+    } else if (functionName == "sfTouches") {
+      return createBinary(&makeGeoRelationExpression<SpatialJoinType::TOUCHES>);
+    } else if (functionName == "sfEquals") {
+      return createBinary(&makeGeoRelationExpression<SpatialJoinType::EQUALS>);
+    } else if (functionName == "sfOverlaps") {
+      return createBinary(
+          &makeGeoRelationExpression<SpatialJoinType::OVERLAPS>);
     }
   }
 

--- a/src/util/GeoSparqlHelpers.h
+++ b/src/util/GeoSparqlHelpers.h
@@ -12,8 +12,10 @@
 #include <optional>
 #include <string_view>
 
+#include "engine/SpatialJoin.h"
 #include "global/Constants.h"
 #include "parser/GeoPoint.h"
+#include "parser/LiteralOrIri.h"
 #include "parser/NormalizedString.h"
 
 namespace ad_utility {
@@ -86,6 +88,24 @@ class WktMetricDistGeoPoints {
   double operator()(const std::optional<GeoPoint>& point1,
                     const std::optional<GeoPoint>& point2) const {
     return WktDistGeoPoints{}(point1, point2, UnitOfMeasurement::METERS);
+  }
+};
+
+// A generic operation for all geometric relation functions, like
+// geof:sfIntersects.
+template <SpatialJoinType Relation>
+class WktGeometricRelation {
+ public:
+  ValueId operator()(
+      // TODO<ullingerc> For implementation, use a new appropriate value getter
+      // for geometry literals and points.
+      [[maybe_unused]] const std::optional<GeoPoint>& geoLeft,
+      [[maybe_unused]] const std::optional<GeoPoint>& geoRight) const {
+    AD_THROW(
+        "Geometric relations via the `geof:sf...` functions are not yet "
+        "implemented in QLever. Please refer to the custom `SERVICE qlss:` "
+        "with algorithm `qlss:libspatialjoin` for now. More details can be "
+        "found on the QLever Wiki.");
   }
 };
 

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -1913,6 +1913,32 @@ TEST(SparqlParser, FunctionCall) {
                          variableExpressionMatcher(Variable{"?b"}),
                          variableExpressionMatcher(Variable{"?unit"})));
 
+  // Geometric relation functions
+  expectFunctionCall(
+      absl::StrCat(geof, "sfIntersects>(?a, ?b)"),
+      matchNary(&makeGeoRelationExpression<SpatialJoinType::INTERSECTS>,
+                Variable{"?a"}, Variable{"?b"}));
+  expectFunctionCall(
+      absl::StrCat(geof, "sfContains>(?a, ?b)"),
+      matchNary(&makeGeoRelationExpression<SpatialJoinType::CONTAINS>,
+                Variable{"?a"}, Variable{"?b"}));
+  expectFunctionCall(
+      absl::StrCat(geof, "sfCrosses>(?a, ?b)"),
+      matchNary(&makeGeoRelationExpression<SpatialJoinType::CROSSES>,
+                Variable{"?a"}, Variable{"?b"}));
+  expectFunctionCall(
+      absl::StrCat(geof, "sfTouches>(?a, ?b)"),
+      matchNary(&makeGeoRelationExpression<SpatialJoinType::TOUCHES>,
+                Variable{"?a"}, Variable{"?b"}));
+  expectFunctionCall(
+      absl::StrCat(geof, "sfEquals>(?a, ?b)"),
+      matchNary(&makeGeoRelationExpression<SpatialJoinType::EQUALS>,
+                Variable{"?a"}, Variable{"?b"}));
+  expectFunctionCall(
+      absl::StrCat(geof, "sfOverlaps>(?a, ?b)"),
+      matchNary(&makeGeoRelationExpression<SpatialJoinType::OVERLAPS>,
+                Variable{"?a"}, Variable{"?b"}));
+
   // Math functions
   expectFunctionCall(absl::StrCat(math, "log>(?x)"),
                      matchUnary(&makeLogExpression));
@@ -1955,6 +1981,31 @@ TEST(SparqlParser, FunctionCall) {
   expectFunctionCallFails(absl::StrCat(geof, "distance>(?a, ?b, ?c, ?d)"));
   expectFunctionCallFails(absl::StrCat(geof, "metricDistance>(?a)"));
   expectFunctionCallFails(absl::StrCat(geof, "metricDistance>(?a, ?b, ?c)"));
+
+  expectFunctionCallFails(absl::StrCat(geof, "sfIntersects>(?a)"));
+  expectFunctionCallFails(absl::StrCat(geof, "sfIntersects>()"));
+  expectFunctionCallFails(absl::StrCat(geof, "sfIntersects>(?a, ?b, ?c)"));
+
+  expectFunctionCallFails(absl::StrCat(geof, "sfContains>(?a)"));
+  expectFunctionCallFails(absl::StrCat(geof, "sfContains>()"));
+  expectFunctionCallFails(absl::StrCat(geof, "sfContains>(?a, ?b, ?c)"));
+
+  expectFunctionCallFails(absl::StrCat(geof, "sfCrosses>(?a)"));
+  expectFunctionCallFails(absl::StrCat(geof, "sfCrosses>()"));
+  expectFunctionCallFails(absl::StrCat(geof, "sfCrosses>(?a, ?b, ?c)"));
+
+  expectFunctionCallFails(absl::StrCat(geof, "sfTouches>(?a)"));
+  expectFunctionCallFails(absl::StrCat(geof, "sfTouches>()"));
+  expectFunctionCallFails(absl::StrCat(geof, "sfTouches>(?a, ?b, ?c)"));
+
+  expectFunctionCallFails(absl::StrCat(geof, "sfEquals>(?a)"));
+  expectFunctionCallFails(absl::StrCat(geof, "sfEquals>()"));
+  expectFunctionCallFails(absl::StrCat(geof, "sfEquals>(?a, ?b, ?c)"));
+
+  expectFunctionCallFails(absl::StrCat(geof, "sfOverlaps>(?a)"));
+  expectFunctionCallFails(absl::StrCat(geof, "sfOverlaps>()"));
+  expectFunctionCallFails(absl::StrCat(geof, "sfOverlaps>(?a, ?b, ?c)"));
+
   expectFunctionCallFails(absl::StrCat(xsd, "date>(?varYear, ?varMonth)"));
   expectFunctionCallFails(absl::StrCat(xsd, "dateTime>(?varYear, ?varMonth)"));
 


### PR DESCRIPTION
This PR adds the GeoSPARQL functions `geof:sfIntersects`, `geof:sfContains`, `geof:sfCrosses`, `geof:sfTouches`,  `geof:sfEquals`, `geof:sfOverlaps` as a dummy implementation (they throw an explanatory exception). This is a preparation for a future rewrite of the functions to a `libspatialjoin` operation.

Related to #1935 and #1961
