### PR TITLE
Add git hash to result for `?cmd=stats` request

### DIFF
--- a/src/ServerMain.cpp
+++ b/src/ServerMain.cpp
@@ -159,8 +159,7 @@ int main(int argc, char** argv) {
 
   try {
     Server server(port, numSimultaneousQueries, memoryMaxSize,
-                  std::move(accessToken), qlever::version::GitShortHash,
-                  !noPatternTrick);
+                  std::move(accessToken), !noPatternTrick);
     server.run(indexBasename, text, !noPatterns, !onlyPsoAndPosPermutations,
                persistUpdates);
   } catch (const std::exception& e) {

--- a/src/ServerMain.cpp
+++ b/src/ServerMain.cpp
@@ -159,7 +159,8 @@ int main(int argc, char** argv) {
 
   try {
     Server server(port, numSimultaneousQueries, memoryMaxSize,
-                  std::move(accessToken), !noPatternTrick);
+                  std::move(accessToken), qlever::version::GitShortHash,
+                  !noPatternTrick);
     server.run(indexBasename, text, !noPatterns, !onlyPsoAndPosPermutations,
                persistUpdates);
   } catch (const std::exception& e) {

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -1,8 +1,10 @@
-// Copyright 2011 - 2024, University of Freiburg
-// Chair of Algorithms and Data Structures
-// Authors: Björn Buchhold <b.buchhold@gmail.com>
-//          Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
-//          Hannah Bast <bast@cs.uni-freiburg.de>
+// Copyright 2015 - 2025 The QLever Authors, in particular:
+//
+// 2015 - 2017 Björn Buchhold, UFR
+// 2020 - 2025 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+// 2022 - 2025 Hannah Bast <bast@cs.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
 
 #include "engine/Server.h"
 
@@ -38,10 +40,11 @@ using ad_utility::MediaType;
 // __________________________________________________________________________
 Server::Server(unsigned short port, size_t numThreads,
                ad_utility::MemorySize maxMem, std::string accessToken,
-               bool usePatternTrick)
+               std::string_view gitHash, bool usePatternTrick)
     : numThreads_(numThreads),
       port_(port),
       accessToken_(std::move(accessToken)),
+      gitHash_(gitHash),
       allocator_{ad_utility::makeAllocationMemoryLeftThreadsafeObject(maxMem),
                  [this](ad_utility::MemorySize numMemoryToAllocate) {
                    cache_.makeRoomAsMuchAsPossible(MAKE_ROOM_SLACK_FACTOR *
@@ -610,6 +613,8 @@ json Server::composeErrorResponseJson(
 json Server::composeStatsJson() const {
   json result;
   result["name-index"] = index_.getKbName();
+  result["git-hash-index"] = index_.getGitHash();
+  result["git-hash-server"] = gitHash_;
   result["num-permutations"] = (index_.hasAllPermutations() ? 6 : 2);
   result["num-predicates-normal"] = index_.numDistinctPredicates().normal;
   result["num-predicates-internal"] = index_.numDistinctPredicates().internal;

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -13,6 +13,7 @@
 #include <string>
 #include <vector>
 
+#include "CompilationInfo.h"
 #include "GraphStoreProtocol.h"
 #include "engine/ExecuteUpdate.h"
 #include "engine/ExportQueryExecutionTrees.h"
@@ -40,11 +41,10 @@ using ad_utility::MediaType;
 // __________________________________________________________________________
 Server::Server(unsigned short port, size_t numThreads,
                ad_utility::MemorySize maxMem, std::string accessToken,
-               std::string_view gitHash, bool usePatternTrick)
+               bool usePatternTrick)
     : numThreads_(numThreads),
       port_(port),
       accessToken_(std::move(accessToken)),
-      gitHash_(gitHash),
       allocator_{ad_utility::makeAllocationMemoryLeftThreadsafeObject(maxMem),
                  [this](ad_utility::MemorySize numMemoryToAllocate) {
                    cache_.makeRoomAsMuchAsPossible(MAKE_ROOM_SLACK_FACTOR *
@@ -613,8 +613,9 @@ json Server::composeErrorResponseJson(
 json Server::composeStatsJson() const {
   json result;
   result["name-index"] = index_.getKbName();
-  result["git-hash-index"] = index_.getGitHash();
-  result["git-hash-server"] = gitHash_;
+  result["git-hash-index"] = index_.getGitShortHash();
+  result["git-hash-server"] =
+      *qlever::version::gitShortHashWithoutLinking.wlock();
   result["num-permutations"] = (index_.hasAllPermutations() ? 6 : 2);
   result["num-predicates-normal"] = index_.numDistinctPredicates().normal;
   result["num-predicates-internal"] = index_.numDistinctPredicates().internal;

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -1,7 +1,10 @@
-// Copyright 2021 - 2024, University of Freiburg
-// Chair of Algorithms and Data Structures
-// Authors: Johannes Kalmbach<kalmbach@cs.uni-freiburg.de>
-//          Hannah Bast <bast@cs.uni-freiburg.de>
+// Copyright 2015 - 2025 The QLever Authors, in particular:
+//
+// 2015 - 2017 Björn Buchhold, UFR
+// 2020 - 2025 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+// 2022 - 2025 Hannah Bast <bast@cs.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
 
 #ifndef QLEVER_SRC_ENGINE_SERVER_H
 #define QLEVER_SRC_ENGINE_SERVER_H
@@ -45,7 +48,7 @@ class Server {
  public:
   explicit Server(unsigned short port, size_t numThreads,
                   ad_utility::MemorySize maxMem, std::string accessToken,
-                  bool usePatternTrick = true);
+                  std::string_view gitHash, bool usePatternTrick = true);
 
   virtual ~Server() = default;
 
@@ -74,6 +77,7 @@ class Server {
   const size_t numThreads_;
   unsigned short port_;
   std::string accessToken_;
+  std::string gitHash_;
   QueryResultCache cache_;
   ad_utility::AllocatorWithLimit<Id> allocator_;
   SortPerformanceEstimator sortPerformanceEstimator_;

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -59,15 +59,19 @@ class Server {
                   bool persistUpdates = false);
 
  public:
-  //! First initialize the server. Then loop, wait for requests and trigger
-  //! processing. This method never returns except when throwing an exception.
+  // First initialize the server. Then loop, wait for requests and trigger
+  // processing. This method never returns except when throwing an exception.
   void run(const string& indexBaseName, bool useText, bool usePatterns = true,
            bool loadAllPermutations = true, bool persistUpdates = false);
 
   Index& index() { return index_; }
   const Index& index() const { return index_; }
 
-  /// Helper struct bundling a parsed query with a query execution tree.
+  // Get server statistics.
+  json composeStatsJson() const;
+  json composeCacheStatsJson() const;
+
+  // Helper struct bundling a parsed query with a query execution tree.
   struct PlannedQuery {
     ParsedQuery parsedQuery_;
     QueryExecutionTree queryExecutionTree_;
@@ -210,10 +214,6 @@ class Server {
       const string& query, const std::string& errorMsg,
       const ad_utility::Timer& requestTimer,
       const std::optional<ExceptionMetadata>& metadata = std::nullopt);
-
-  json composeStatsJson() const;
-
-  json composeCacheStatsJson() const;
 
   /// Invoke `function` on `threadPool_`, and return an awaitable to wait for
   /// its completion, wrapping the result.

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -48,7 +48,7 @@ class Server {
  public:
   explicit Server(unsigned short port, size_t numThreads,
                   ad_utility::MemorySize maxMem, std::string accessToken,
-                  std::string_view gitHash, bool usePatternTrick = true);
+                  bool usePatternTrick = true);
 
   virtual ~Server() = default;
 
@@ -81,7 +81,6 @@ class Server {
   const size_t numThreads_;
   unsigned short port_;
   std::string accessToken_;
-  std::string gitHash_;
   QueryResultCache cache_;
   ad_utility::AllocatorWithLimit<Id> allocator_;
   SortPerformanceEstimator sortPerformanceEstimator_;

--- a/src/index/Index.cpp
+++ b/src/index/Index.cpp
@@ -234,6 +234,9 @@ const std::string& Index::getOnDiskBase() const {
 const std::string& Index::getIndexId() const { return pimpl_->getIndexId(); }
 
 // ____________________________________________________________________________
+const std::string& Index::getGitHash() const { return pimpl_->getGitHash(); }
+
+// ____________________________________________________________________________
 Index::NumNormalAndInternal Index::numTriples() const {
   return pimpl_->numTriples();
 }

--- a/src/index/Index.cpp
+++ b/src/index/Index.cpp
@@ -234,7 +234,9 @@ const std::string& Index::getOnDiskBase() const {
 const std::string& Index::getIndexId() const { return pimpl_->getIndexId(); }
 
 // ____________________________________________________________________________
-const std::string& Index::getGitHash() const { return pimpl_->getGitHash(); }
+const std::string& Index::getGitShortHash() const {
+  return pimpl_->getGitShortHash();
+}
 
 // ____________________________________________________________________________
 Index::NumNormalAndInternal Index::numTriples() const {

--- a/src/index/Index.h
+++ b/src/index/Index.h
@@ -217,7 +217,7 @@ class Index {
   const std::string& getKbName() const;
   const std::string& getOnDiskBase() const;
   const std::string& getIndexId() const;
-  const std::string& getGitHash() const;
+  const std::string& getGitShortHash() const;
 
   NumNormalAndInternal numTriples() const;
 

--- a/src/index/Index.h
+++ b/src/index/Index.h
@@ -217,6 +217,7 @@ class Index {
   const std::string& getKbName() const;
   const std::string& getOnDiskBase() const;
   const std::string& getIndexId() const;
+  const std::string& getGitHash() const;
 
   NumNormalAndInternal numTriples() const;
 

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -1138,7 +1138,7 @@ void IndexImpl::readConfiguration() {
     }
   };
 
-  loadDataMember("git-hash", gitHash_);
+  loadDataMember("git-hash", gitShortHash_);
   loadDataMember("has-all-permutations", loadAllPermutations_, true);
   loadDataMember("num-predicates", numPredicates_);
   // These might be missing if there are only two permutations.

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -1138,6 +1138,7 @@ void IndexImpl::readConfiguration() {
     }
   };
 
+  loadDataMember("git-hash", gitHash_);
   loadDataMember("has-all-permutations", loadAllPermutations_, true);
   loadDataMember("num-predicates", numPredicates_);
   // These might be missing if there are only two permutations.

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -160,6 +160,7 @@ class IndexImpl {
   NumNormalAndInternal numObjects_;
   NumNormalAndInternal numTriples_;
   string indexId_;
+  string gitHash_;
 
   // Keeps track of the number of nonLiteral contexts in the index this is used
   // in the test retrieval of the texts. This only works reliably if the
@@ -445,6 +446,7 @@ class IndexImpl {
   const string& getKbName() const { return pso_.getKbName(); }
   const string& getOnDiskBase() const { return onDiskBase_; }
   const string& getIndexId() const { return indexId_; }
+  const string& getGitHash() const { return gitHash_; }
 
   size_t getNofTextRecords() const { return textMeta_.getNofTextRecords(); }
   size_t getNofWordPostings() const { return textMeta_.getNofWordPostings(); }

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -160,7 +160,7 @@ class IndexImpl {
   NumNormalAndInternal numObjects_;
   NumNormalAndInternal numTriples_;
   string indexId_;
-  string gitHash_;
+  string gitShortHash_ = "git short hash not set";
 
   // Keeps track of the number of nonLiteral contexts in the index this is used
   // in the test retrieval of the texts. This only works reliably if the
@@ -446,7 +446,7 @@ class IndexImpl {
   const string& getKbName() const { return pso_.getKbName(); }
   const string& getOnDiskBase() const { return onDiskBase_; }
   const string& getIndexId() const { return indexId_; }
-  const string& getGitHash() const { return gitHash_; }
+  const string& getGitShortHash() const { return gitShortHash_; }
 
   size_t getNofTextRecords() const { return textMeta_.getNofTextRecords(); }
   size_t getNofWordPostings() const { return textMeta_.getNofWordPostings(); }

--- a/test/IndexTest.cpp
+++ b/test/IndexTest.cpp
@@ -281,7 +281,7 @@ TEST(IndexTest, createFromOnDiskIndexTest) {
   ASSERT_TRUE(index.POS().getMetadata(b2, deltaTriples).value().isFunctional());
 };
 
-TEST(IndexTest, indexId) {
+TEST(IndexTest, indexIdAndGitHash) {
   std::string kb =
       "<a1> <b> <c1> .\n"
       "<a2> <b> <c2> .\n"
@@ -292,6 +292,9 @@ TEST(IndexTest, indexId) {
   // and two distinct objects.
   const Index& index = makeQec(kb, true, false)->getIndex();
   ASSERT_EQ(index.getIndexId(), "#.4.3.1.2");
+
+  // For the test index, the git hash is not set, see `src/CompilationInfo.h`.
+  ASSERT_EQ(index.getGitHash(), "git short hash not set");
 }
 
 TEST(IndexTest, scanTest) {

--- a/test/IndexTest.cpp
+++ b/test/IndexTest.cpp
@@ -294,7 +294,7 @@ TEST(IndexTest, indexIdAndGitHash) {
   ASSERT_EQ(index.getIndexId(), "#.4.3.1.2");
 
   // For the test index, the git hash is not set, see `src/CompilationInfo.h`.
-  ASSERT_EQ(index.getGitHash(), "git short hash not set");
+  ASSERT_EQ(index.getGitShortHash(), "git short hash not set");
 }
 
 TEST(IndexTest, scanTest) {

--- a/test/ServerTest.cpp
+++ b/test/ServerTest.cpp
@@ -80,8 +80,7 @@ TEST(ServerTest, determineMediaType) {
 
 TEST(ServerTest, getQueryId) {
   using namespace ad_utility::websocket;
-  Server server{9999, 1, ad_utility::MemorySize::megabytes(1), "accessToken",
-                "git hash"};
+  Server server{9999, 1, ad_utility::MemorySize::megabytes(1), "accessToken"};
   auto reqWithExplicitQueryId = makeGetRequest("/");
   reqWithExplicitQueryId.set("Query-Id", "100");
   const auto req = makeGetRequest("/");
@@ -105,10 +104,9 @@ TEST(ServerTest, getQueryId) {
 }
 
 TEST(ServerTest, composeStatsJson) {
-  Server server{9999, 1, ad_utility::MemorySize::megabytes(1), "accessToken",
-                "git hash"};
-  json expectedJson{{"git-hash-index", ""},
-                    {"git-hash-server", "git hash"},
+  Server server{9999, 1, ad_utility::MemorySize::megabytes(1), "accessToken"};
+  json expectedJson{{"git-hash-index", "git short hash not set"},
+                    {"git-hash-server", "git short hash not set"},
                     {"name-index", ""},
                     {"name-text-index", ""},
                     {"num-entity-occurrences", 0},
@@ -123,8 +121,7 @@ TEST(ServerTest, composeStatsJson) {
 }
 
 TEST(ServerTest, createMessageSender) {
-  Server server{9999, 1, ad_utility::MemorySize::megabytes(1), "accessToken",
-                "git hash"};
+  Server server{9999, 1, ad_utility::MemorySize::megabytes(1), "accessToken"};
   auto reqWithExplicitQueryId = makeGetRequest("/");
   std::string customQueryId = "100";
   reqWithExplicitQueryId.set("Query-Id", customQueryId);

--- a/test/ServerTest.cpp
+++ b/test/ServerTest.cpp
@@ -14,6 +14,7 @@
 #include "util/IndexTestHelpers.h"
 #include "util/http/HttpUtils.h"
 #include "util/http/UrlParser.h"
+#include "util/json.h"
 
 using namespace ad_utility::url_parser;
 using namespace ad_utility::url_parser::sparqlOperation;
@@ -101,6 +102,24 @@ TEST(ServerTest, getQueryId) {
   // Without custom query ids, unique ids are generated.
   auto queryId2 = server.getQueryId(req, "SELECT * WHERE { ?a ?b ?c }");
   auto queryId3 = server.getQueryId(req, "SELECT * WHERE { ?a ?b ?c }");
+}
+
+TEST(ServerTest, composeStatsJson) {
+  Server server{9999, 1, ad_utility::MemorySize::megabytes(1), "accessToken",
+                "git hash"};
+  json expectedJson{{"git-hash-index", ""},
+                    {"git-hash-server", "git hash"},
+                    {"name-index", ""},
+                    {"name-text-index", ""},
+                    {"num-entity-occurrences", 0},
+                    {"num-permutations", 2},
+                    {"num-predicates-internal", 0},
+                    {"num-predicates-normal", 0},
+                    {"num-text-records", 0},
+                    {"num-triples-internal", 0},
+                    {"num-triples-normal", 0},
+                    {"num-word-occurrences", 0}};
+  EXPECT_THAT(server.composeStatsJson(), testing::Eq(expectedJson));
 }
 
 TEST(ServerTest, createMessageSender) {

--- a/test/ServerTest.cpp
+++ b/test/ServerTest.cpp
@@ -79,7 +79,8 @@ TEST(ServerTest, determineMediaType) {
 
 TEST(ServerTest, getQueryId) {
   using namespace ad_utility::websocket;
-  Server server{9999, 1, ad_utility::MemorySize::megabytes(1), "accessToken"};
+  Server server{9999, 1, ad_utility::MemorySize::megabytes(1), "accessToken",
+                "git hash"};
   auto reqWithExplicitQueryId = makeGetRequest("/");
   reqWithExplicitQueryId.set("Query-Id", "100");
   const auto req = makeGetRequest("/");
@@ -103,7 +104,8 @@ TEST(ServerTest, getQueryId) {
 }
 
 TEST(ServerTest, createMessageSender) {
-  Server server{9999, 1, ad_utility::MemorySize::megabytes(1), "accessToken"};
+  Server server{9999, 1, ad_utility::MemorySize::megabytes(1), "accessToken",
+                "git hash"};
   auto reqWithExplicitQueryId = makeGetRequest("/");
   std::string customQueryId = "100";
   reqWithExplicitQueryId.set("Query-Id", customQueryId);


### PR DESCRIPTION
Add two fields `git-hash-index` and `git-hash-server` to the result for a `?cmd=stats` request. This makes it easy to find out the version of the server and of the index builder (at the time of the index build) for a particular QLever endpoint. In particular, this information can then be displayed in the QLever UI. For now, we make this information available without access token, but this could easily be changed in the future if desired or needed.