### PR TITLE
Give `ProgressBar` users control over timer if needed

### DIFF
--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -455,10 +455,16 @@ IndexBuilderDataAsExternalVector IndexImpl::passFileForVocabulary(
   // batch of triples and partial vocabulary.
   std::array<std::future<void>, 3> writePartialVocabularyFuture;
 
-  // Have a nice progress bar that shows the number of triples parsed. Depending
-  // on how the input is generated, it may take a long time before the first
-  // triple is parsed. We do not want to count that time, hence we stop the
-  // timer at this point and start it again when the first triple is parsed.
+  // Show progress and statistics for the number of triples parsed, in
+  // particular, the average processing time for a batch of 10M triples (see
+  // `DEFAULT_PROGRESS_BAR_BATCH_SIZE`).
+  //
+  // NOTE: Some input generation processes (for example, `osm2rdf` for the OSM
+  // data) have a long startup time before they produce the first triple, but
+  // then produce triples fast. If we would count that startup time towards the
+  // first batch, the reported average batch processing time would be
+  // distorted. We therefore stop the timer here, and then start it when the
+  // first triple is parsed (see `numTriplesParsedTimer.cont()` below).
   size_t numTriplesParsed = 0;
   ad_utility::ProgressBar progressBar{numTriplesParsed, "Triples parsed: "};
   ad_utility::Timer& numTriplesParsedTimer = progressBar.getTimer();

--- a/src/util/ProgressBar.h
+++ b/src/util/ProgressBar.h
@@ -138,13 +138,19 @@ class ProgressBar {
   // Final progress string (should only be called once after the computation has
   // finished).
   std::string getFinalProgressString() {
-    AD_CONTRACT_CHECK(timer_.isRunning(),
+    AD_CONTRACT_CHECK(!finished_,
                       "`ProgressBar::getFinalProgressString()` should only be "
                       "called once after the computation has finished");
     timer_.stop();
     totalDuration_ = timer_.value();
+    finished_ = true;
     return getProgressString();
   }
+
+  // Get timer. This is useful for more advanced use cases, where parts of the
+  // processing should not be timed (for example, when it takes a long time
+  // before the first step is processed and we do not want to include that).
+  Timer& getTimer() { return timer_; }
 
  private:
   // The total number of units that have been processed so far.
@@ -161,6 +167,8 @@ class ProgressBar {
 
   // Timer that is started as soon as this progress bar is created.
   Timer timer_{Timer::Started};
+  // Finished yet or not.
+  bool finished_ = false;
   // Update the statistics when at least this many steps have been processed.
   size_t updateWhenThisManyStepsProcessed_ = statisticsBatchSize_;
 

--- a/test/ProgressBarTest.cpp
+++ b/test/ProgressBarTest.cpp
@@ -64,32 +64,33 @@ TEST(ProgressBar, typicalUsage) {
 
 // Test special case where the number of steps is less than the batch size.
 TEST(ProgressBar, numberOfStepsLessThanBatchSize) {
-  size_t numSteps = 3'000;
-  ProgressBar progressBar(numSteps, "Steps: ", 5'000);
-  std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  size_t numSteps = 30'000;
+  ProgressBar progressBar(numSteps, "Steps: ", 50'000);
+  std::this_thread::sleep_for(std::chrono::milliseconds(10));
   std::string expectedUpdateRegex =
 #ifndef _QLEVER_NO_TIMING_TESTS
-      "Steps: 3,000 \\[average speed [234]\\.[0-9] M/s\\] \n";
+      "Steps: 30,000 \\[average speed [234]\\.[0-9] M/s\\] \n";
 #else
-      "Steps: 3,000 \\[average speed [0-9]\\.[0-9] M/s\\] \n";
+      "Steps: 30,000 \\[average speed [0-9]\\.[0-9] M/s\\] \n";
 #endif
   ASSERT_THAT(progressBar.getFinalProgressString(),
               ::testing::MatchesRegex(expectedUpdateRegex));
 }
 
-// Test `getTimer` by stopping the timer after 1ms and checking that this is
-// reflected in the reported speed.
+// Test `getTimer` by stopping the timer after 10ms, then sleeping for 10ms
+// more, and checking that these additional 10ms are not considered in the
+// reported average speed.
 TEST(ProgressBar, getTimer) {
-  size_t numSteps = 3'000;
-  ProgressBar progressBar(numSteps, "Steps: ", 5'000);
-  std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  size_t numSteps = 30'000;
+  ProgressBar progressBar(numSteps, "Steps: ", 50'000);
+  std::this_thread::sleep_for(std::chrono::milliseconds(10));
   progressBar.getTimer().stop();
-  std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  std::this_thread::sleep_for(std::chrono::milliseconds(10));
   std::string expectedUpdateRegex =
 #ifndef _QLEVER_NO_TIMING_TESTS
-      "Steps: 3,000 \\[average speed [234]\\.[0-9] M/s\\] \n";
+      "Steps: 30,000 \\[average speed [234]\\.[0-9] M/s\\] \n";
 #else
-      "Steps: 3,000 \\[average speed [0-9]\\.[0-9] M/s\\] \n";
+      "Steps: 30,000 \\[average speed [0-9]\\.[0-9] M/s\\] \n";
 #endif
   ASSERT_THAT(progressBar.getFinalProgressString(),
               ::testing::MatchesRegex(expectedUpdateRegex));

--- a/test/ProgressBarTest.cpp
+++ b/test/ProgressBarTest.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024, University of Freiburg
+// Copyright 2024 - 2025, University of Freiburg
 // Chair of Algorithms and Data Structures
 // Author: Hannah Bast <bast@cs.uni-freiburg.de>
 
@@ -11,6 +11,7 @@
 #include "../test/util/GTestHelpers.h"
 #include "util/ProgressBar.h"
 #include "util/StringUtils.h"
+#include "util/Timer.h"
 
 using ad_utility::ProgressBar;
 
@@ -65,6 +66,24 @@ TEST(ProgressBar, typicalUsage) {
 TEST(ProgressBar, numberOfStepsLessThanBatchSize) {
   size_t numSteps = 3'000;
   ProgressBar progressBar(numSteps, "Steps: ", 5'000);
+  std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  std::string expectedUpdateRegex =
+#ifndef _QLEVER_NO_TIMING_TESTS
+      "Steps: 3,000 \\[average speed [234]\\.[0-9] M/s\\] \n";
+#else
+      "Steps: 3,000 \\[average speed [0-9]\\.[0-9] M/s\\] \n";
+#endif
+  ASSERT_THAT(progressBar.getFinalProgressString(),
+              ::testing::MatchesRegex(expectedUpdateRegex));
+}
+
+// Test `getTimer` by stopping the timer after 1ms and checking that this is
+// reflected in the reported speed.
+TEST(ProgressBar, getTimer) {
+  size_t numSteps = 3'000;
+  ProgressBar progressBar(numSteps, "Steps: ", 5'000);
+  std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  progressBar.getTimer().stop();
   std::this_thread::sleep_for(std::chrono::milliseconds(1));
   std::string expectedUpdateRegex =
 #ifndef _QLEVER_NO_TIMING_TESTS


### PR DESCRIPTION
So far, the timer for a `ProgressBar` was always started as soon as the `ProgressBar` was created. However, some input generation processes (for example, `osm2rdf` feeding OSM triples to QLever's index builder) have a long startup time before they produce the first item but then produce items fast. In such a scenario. if we count that startup time towards the first batch of items, the average batch processing time reported by the `ProgressBar` is heavily distorted.

The `ProgressBar` class now has a `getTimer()` method that gives the user more control. This is used in `IndexImpl::passFileForVocabulary()` to start timing only once the first triple has been parsed.