### PR TITLE
Add missing `flush` in `BlockZipperJoinImpl::consumeRemainingBlocks`

### DIFF
--- a/src/util/JoinAlgorithms/JoinAlgorithms.h
+++ b/src/util/JoinAlgorithms/JoinAlgorithms.h
@@ -1257,6 +1257,7 @@ CPP_template(typename LeftSide, typename RightSide, typename LessThan,
           }
         }
       }
+      compatibleRowAction_.flush();
       ++side.it_;
     }
   }

--- a/test/JoinTest.cpp
+++ b/test/JoinTest.cpp
@@ -677,6 +677,13 @@ TEST(JoinTest, joinTwoLazyOperationsWithAndWithoutUndefValues) {
   rightTables.push_back(createIdTableOfSizeWithValue(Join::CHUNK_SIZE, I(1)));
   auto expected7 = createIdTableOfSizeWithValue(Join::CHUNK_SIZE, I(1));
   performJoin(std::move(leftTables), std::move(rightTables), expected7, false);
+
+  leftTables.push_back(makeIdTableFromVector({{U}}));
+  leftTables.push_back(makeIdTableFromVector({{I(1)}}));
+  rightTables.push_back(makeIdTableFromVector({{I(2)}}));
+  rightTables.push_back(makeIdTableFromVector({{I(2)}}));
+  auto expected8 = createIdTableOfSizeWithValue(2, I(2));
+  performJoin(std::move(leftTables), std::move(rightTables), expected8, false);
 }
 
 // _____________________________________________________________________________


### PR DESCRIPTION
This led to undefined behavior in certain situations. Fix it and add a corresponding regression test.