### PR TITLE
Fix missing runtime information in `application/qlever-results+json` result for failed queries

### DIFF
--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -1073,7 +1073,7 @@ bool Server::checkAccessToken(
 
 // _____________________________________________________________________________
 void Server::adjustParsedQueryLimitOffset(
-    PlannedQuery& plannedQuery, const ad_utility::MediaType mediaType,
+    PlannedQuery& plannedQuery, const ad_utility::MediaType& mediaType,
     const ad_utility::url_parser::ParamValueMap& parameters) {
   // Read the export limit from the send` parameter (historical name). This
   // limits the number of bindings exported in `ExportQueryExecutionTrees`.

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -144,16 +144,16 @@ class Server {
       Awaitable<void> processOperation(
           ad_utility::url_parser::sparqlOperation::Operation operation,
           VisitorT visitor, const ad_utility::Timer& requestTimer,
-          const RequestT& request, ResponseT& send);
+          const RequestT& request, ResponseT& send,
+          std::optional<PlannedQuery>& plannedQuery);
   // Do the actual execution of a query.
   CPP_template_2(typename RequestT, typename ResponseT)(
       requires ad_utility::httpUtils::HttpRequest<RequestT>)
       Awaitable<void> processQuery(
           const ad_utility::url_parser::ParamValueMap& params,
-          ParsedQuery&& query, const ad_utility::Timer& requestTimer,
+          PlannedQuery&& plannedQuery, const ad_utility::Timer& requestTimer,
           ad_utility::SharedCancellationHandle cancellationHandle,
-          QueryExecutionContext& qec, const RequestT& request, ResponseT&& send,
-          TimeLimit timeLimit);
+          const RequestT& request, ResponseT&& send);
   // For an executed update create a json with some stats on the update (timing,
   // number of changed triples, etc.).
   static json createResponseMetadataForUpdate(
@@ -167,10 +167,9 @@ class Server {
   CPP_template_2(typename RequestT, typename ResponseT)(
       requires ad_utility::httpUtils::HttpRequest<RequestT>)
       Awaitable<void> processUpdate(
-          ParsedQuery&& update, const ad_utility::Timer& requestTimer,
+          PlannedQuery&& update, const ad_utility::Timer& requestTimer,
           ad_utility::SharedCancellationHandle cancellationHandle,
-          QueryExecutionContext& qec, const RequestT& request, ResponseT&& send,
-          TimeLimit timeLimit);
+          const RequestT& request, ResponseT&& send);
 
   // Determine the media type to be used for the result. The media type is
   // determined (in this order) by the current action (e.g.,

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -145,13 +145,13 @@ class Server {
           ad_utility::url_parser::sparqlOperation::Operation operation,
           VisitorT visitor, const ad_utility::Timer& requestTimer,
           const RequestT& request, ResponseT& send,
-          std::optional<PlannedQuery>& plannedQuery);
+          const std::optional<PlannedQuery>& plannedQuery);
   // Do the actual execution of a query.
   CPP_template_2(typename RequestT, typename ResponseT)(
       requires ad_utility::httpUtils::HttpRequest<RequestT>)
       Awaitable<void> processQuery(
           const ad_utility::url_parser::ParamValueMap& params,
-          PlannedQuery&& plannedQuery, const ad_utility::Timer& requestTimer,
+          PlannedQuery& plannedQuery, const ad_utility::Timer& requestTimer,
           ad_utility::SharedCancellationHandle cancellationHandle,
           const RequestT& request, ResponseT&& send);
   // For an executed update create a json with some stats on the update (timing,
@@ -167,7 +167,7 @@ class Server {
   CPP_template_2(typename RequestT, typename ResponseT)(
       requires ad_utility::httpUtils::HttpRequest<RequestT>)
       Awaitable<void> processUpdate(
-          PlannedQuery&& update, const ad_utility::Timer& requestTimer,
+          const PlannedQuery& update, const ad_utility::Timer& requestTimer,
           ad_utility::SharedCancellationHandle cancellationHandle,
           const RequestT& request, ResponseT&& send);
 

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -150,8 +150,8 @@ class Server {
   CPP_template_2(typename RequestT, typename ResponseT)(
       requires ad_utility::httpUtils::HttpRequest<RequestT>)
       Awaitable<void> processQuery(
-          const ad_utility::url_parser::ParamValueMap& params,
-          PlannedQuery& plannedQuery, const ad_utility::Timer& requestTimer,
+          ad_utility::MediaType mediaType, const PlannedQuery& plannedQuery,
+          const ad_utility::Timer& requestTimer,
           ad_utility::SharedCancellationHandle cancellationHandle,
           const RequestT& request, ResponseT&& send);
   // For an executed update create a json with some stats on the update (timing,
@@ -189,6 +189,10 @@ class Server {
                         ad_utility::websocket::MessageSender& messageSender,
                         const ad_utility::url_parser::ParamValueMap& params,
                         TimeLimit timeLimit);
+  // Sets the export limit (`send` parameter) and offset on the ParsedQuery;
+  void adjustParsedQueryLimitOffset(
+      PlannedQuery& plannedQuery, const ad_utility::MediaType mediaType,
+      const ad_utility::url_parser::ParamValueMap& parameters);
 
   // Plan a parsed query.
   Awaitable<PlannedQuery> planQuery(

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -44,6 +44,7 @@ CPP_concept QueryOrUpdate =
 class Server {
   FRIEND_TEST(ServerTest, getQueryId);
   FRIEND_TEST(ServerTest, createMessageSender);
+  FRIEND_TEST(ServerTest, adjustParsedQueryLimitOffset);
 
  public:
   explicit Server(unsigned short port, size_t numThreads,
@@ -190,8 +191,8 @@ class Server {
                         const ad_utility::url_parser::ParamValueMap& params,
                         TimeLimit timeLimit);
   // Sets the export limit (`send` parameter) and offset on the ParsedQuery;
-  void adjustParsedQueryLimitOffset(
-      PlannedQuery& plannedQuery, const ad_utility::MediaType mediaType,
+  static void adjustParsedQueryLimitOffset(
+      PlannedQuery& plannedQuery, const ad_utility::MediaType& mediaType,
       const ad_utility::url_parser::ParamValueMap& parameters);
 
   // Plan a parsed query.


### PR DESCRIPTION
For quite some time now (this got broken during our refactoring of SPARQL Update), when a query failed, the final `application/qlever-results+json` result did not contain the runtime information anymore. This is now fixed again. In particular, fixes #2007