### PR TITLE
Fix runtime information for lazy operations with non-lazy children

### DIFF
--- a/src/engine/Operation.cpp
+++ b/src/engine/Operation.cpp
@@ -169,7 +169,11 @@ Result Operation::runComputation(const ad_utility::Timer& timer,
                                       ad_utility::CacheStatus::computed,
                                       timer.msecs(), std::nullopt);
   } else {
-    runtimeInfo().status_ = RuntimeInformation::lazilyMaterialized;
+    auto& rti = runtimeInfo();
+    rti.status_ = RuntimeInformation::lazilyMaterialized;
+    rti.totalTime_ = timer.msecs();
+    rti.originalTotalTime_ = rti.totalTime_;
+    rti.originalOperationTime_ = rti.getOperationTime();
     result.runOnNewChunkComputed(
         [this, timeSizeUpdate = 0us, vocabStats = LocalVocabTracking{}](
             const Result::IdTableVocabPair& pair,

--- a/test/OperationTest.cpp
+++ b/test/OperationTest.cpp
@@ -381,6 +381,8 @@ TEST(Operation, verifyRuntimeInformationIsUpdatedForLazyOperations) {
   EXPECT_THROW(
       valuesForTesting.runComputation(timer, ComputationMode::ONLY_IF_CACHED),
       ad_utility::Exception);
+  auto timeout = 3ms;
+  std::this_thread::sleep_for(timeout);
 
   auto result = valuesForTesting.runComputation(
       timer, ComputationMode::LAZY_IF_SUPPORTED);
@@ -388,9 +390,9 @@ TEST(Operation, verifyRuntimeInformationIsUpdatedForLazyOperations) {
   auto& rti = valuesForTesting.runtimeInfo();
 
   EXPECT_EQ(rti.status_, Status::lazilyMaterialized);
-  EXPECT_EQ(rti.totalTime_, 0ms);
-  EXPECT_EQ(rti.originalTotalTime_, 0ms);
-  EXPECT_EQ(rti.originalOperationTime_, 0ms);
+  EXPECT_GE(rti.totalTime_, timeout);
+  EXPECT_GE(rti.originalTotalTime_, timeout);
+  EXPECT_GE(rti.originalOperationTime_, timeout);
 
   expectAtEachStageOfGenerator(
       std::move(result.idTables()),


### PR DESCRIPTION
There was a bug in the calculation of the runtime information for operations that produce lazy results, have more than one input, only one of which is provided lazily. This is now fixed.