### PR TITLE
Restore compatibility with cmake 3.28.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.27)
-cmake_policy(SET CMP0167 NEW)
+if(POLICY CMP0167)
+    cmake_policy(SET CMP0167 NEW)
+endif()
 project(QLever C CXX)
 
 # C/C++ Versions
@@ -171,7 +173,7 @@ endif ()
 ######################################
 # BOOST
 ######################################
-find_package(Boost 1.81 COMPONENTS iostreams program_options url REQUIRED)
+find_package(Boost 1.81 COMPONENTS iostreams program_options url REQUIRED CONFIG)
 include_directories(${Boost_INCLUDE_DIR})
 
 


### PR DESCRIPTION
The recent fix to make QLever compile with CMake 4.0 broke older CMake versions (in particular versions `>=3.27` but `<= 4.0`. This PR fixes this bug and also mitigates one of the many CMake warnings when finding `Boost`.