### PR TITLE
Make `<=>` for `LiteralOrIri` respect language tag

### DIFF
--- a/src/parser/LiteralOrIri.cpp
+++ b/src/parser/LiteralOrIri.cpp
@@ -128,7 +128,8 @@ LiteralOrIri LiteralOrIri::literalWithoutQuotes(
 // ___________________________________________
 std::strong_ordering LiteralOrIri::operator<=>(const LiteralOrIri& rhs) const {
   int i = IndexImpl::staticGlobalSingletonComparator().compare(
-      toStringRepresentation(), rhs.toStringRepresentation());
+      toStringRepresentation(), rhs.toStringRepresentation(),
+      LocaleManager::Level::TOTAL);
   if (i < 0) {
     return std::strong_ordering::less;
   } else if (i > 0) {

--- a/test/parser/LiteralOrIriTest.cpp
+++ b/test/parser/LiteralOrIriTest.cpp
@@ -410,7 +410,7 @@ TEST(LiteralTest, concat) {
   EXPECT_FALSE(literal.hasDatatype());
 }
 
-TEST(LiteralTest, spaceshipOperator) {
+TEST(LiteralTest, spaceshipOperatorLangtagLiteral) {
   LiteralOrIri l1 = LiteralOrIri::fromStringRepresentation(
       "\"Comparative evaluation of the protective effect of sodium "
       "valproate, phenazepam and ionol in stress-induced liver damage in "
@@ -420,9 +420,10 @@ TEST(LiteralTest, spaceshipOperator) {
       "valproate, phenazepam and ionol in stress-induced liver damage in "
       "rats\"@en");
   using namespace ad_utility::testing;
-  Index index =
-      makeTestIndex("LiteralTest_spaceshipOperator", TestIndexConfig{});
-  index.getImpl().setGlobalIndexAndComparatorOnlyForTesting();
+  // Ensure that the global singleton comparator (which is used for the <=>
+  // comparison) is available. Creating a QEC sets this comparator.
+  getQec(TestIndexConfig{});
+  ASSERT_NO_THROW(IndexImpl::staticGlobalSingletonComparator());
   EXPECT_THAT(l1, testing::Not(testing::Eq(l2)));
   EXPECT_THAT(l1 <=> l2,
               testing::Not(testing::Eq(std::strong_ordering::equal)));

--- a/test/parser/LiteralOrIriTest.cpp
+++ b/test/parser/LiteralOrIriTest.cpp
@@ -7,6 +7,8 @@
 #include <gtest/gtest.h>
 
 #include "../util/GTestHelpers.h"
+#include "../util/IndexTestHelpers.h"
+#include "index/IndexImpl.h"
 #include "parser/Iri.h"
 #include "parser/Literal.h"
 #include "parser/LiteralOrIri.h"
@@ -406,4 +408,22 @@ TEST(LiteralTest, concat) {
   EXPECT_THAT("Hello World!Thüss!", asStringViewUnsafe(literal.getContent()));
   EXPECT_FALSE(literal.hasLanguageTag());
   EXPECT_FALSE(literal.hasDatatype());
+}
+
+TEST(LiteralTest, spaceshipOperator) {
+  LiteralOrIri l1 = LiteralOrIri::fromStringRepresentation(
+      "\"Comparative evaluation of the protective effect of sodium "
+      "valproate, phenazepam and ionol in stress-induced liver damage in "
+      "rats\"@nl");
+  LiteralOrIri l2 = LiteralOrIri::fromStringRepresentation(
+      "\"Comparative evaluation of the protective effect of sodium "
+      "valproate, phenazepam and ionol in stress-induced liver damage in "
+      "rats\"@en");
+  using namespace ad_utility::testing;
+  Index index =
+      makeTestIndex("LiteralTest_spaceshipOperator", TestIndexConfig{});
+  index.getImpl().setGlobalIndexAndComparatorOnlyForTesting();
+  EXPECT_THAT(l1, testing::Not(testing::Eq(l2)));
+  EXPECT_THAT(l1 <=> l2,
+              testing::Not(testing::Eq(std::strong_ordering::equal)));
 }


### PR DESCRIPTION
So far, there was a subtle inconsistency between the `==` and `<=>` operators for `LiteralOrIri`. For example, `"foo"@en` and `"foo"@de` were not equal according to `==` (which has the default implementation), but equal according to `<=>` (which has a custom implementation using `staticSingletonComparator`). The reason is that the latter ignored the language tag, because the level defaults to `QUARTERNARY`. The level is now explicitly set to `TOTAL` for the comparison, which fixes the inconsistency. Fixes #1990