### PR TITLE
Backport coroutines usages to cpp17

### DIFF
--- a/src/util/Iterators.h
+++ b/src/util/Iterators.h
@@ -404,6 +404,8 @@ class InputRangeTypeErased {
   std::unique_ptr<InputRangeFromGet<ValueType>> impl_;
 
  public:
+  // Add value_type definition to make compatible with range-based functions
+  using value_type = ValueType;
   // Constructor for ranges that directly inherit from
   // `InputRangeOptionalMixin`.
   CPP_template(typename Range)(


### PR DESCRIPTION
This changes are part of the Backport effort to cpp17.
Target code: 
AggregateExpression.h
RelationalExpressions.cpp
SparqlExpressionGenerators.h