### PR TITLE
Fix `GroupBy::knownEmptyResult` for implicit group by

### DIFF
--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -66,6 +66,7 @@ class GroupBy : public Operation {
   virtual vector<ColumnIndex> resultSortedOn() const override;
 
   virtual bool knownEmptyResult() override {
+    // Implicit group by always returns a single row.
     return _subtree->knownEmptyResult() && !_groupByVariables.empty();
   }
 

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -66,7 +66,7 @@ class GroupBy : public Operation {
   virtual vector<ColumnIndex> resultSortedOn() const override;
 
   virtual bool knownEmptyResult() override {
-    return _subtree->knownEmptyResult();
+    return _subtree->knownEmptyResult() && !_groupByVariables.empty();
   }
 
   virtual float getMultiplicity(size_t col) override;

--- a/src/engine/Operation.cpp
+++ b/src/engine/Operation.cpp
@@ -168,7 +168,9 @@ Result Operation::runComputation(const ad_utility::Timer& timer,
     updateRuntimeInformationOnSuccess(result.idTable().size(),
                                       ad_utility::CacheStatus::computed,
                                       timer.msecs(), std::nullopt);
-    AD_CORRECTNESS_CHECK(result.idTable().empty() || !knownEmptyResult());
+    AD_CORRECTNESS_CHECK(result.idTable().empty() || !knownEmptyResult(),
+                         "Operation returned non-empty result, but "
+                         "knownEmptyResult() returned true");
   } else {
     auto& rti = runtimeInfo();
     rti.status_ = RuntimeInformation::lazilyMaterialized;
@@ -180,7 +182,9 @@ Result Operation::runComputation(const ad_utility::Timer& timer,
          ker = knownEmptyResult()](const Result::IdTableVocabPair& pair,
                                    std::chrono::microseconds duration) mutable {
           const IdTable& idTable = pair.idTable_;
-          AD_CORRECTNESS_CHECK(idTable.empty() || !ker);
+          AD_CORRECTNESS_CHECK(idTable.empty() || !ker,
+                               "Operation returned non-empty result, but "
+                               "knownEmptyResult() returned true");
           updateRuntimeStats(false, idTable.numRows(), idTable.numColumns(),
                              duration);
           AD_CORRECTNESS_CHECK(idTable.numColumns() == getResultWidth());

--- a/test/GroupByTest.cpp
+++ b/test/GroupByTest.cpp
@@ -2061,6 +2061,23 @@ TEST(GroupBy, Descriptor) {
   EXPECT_EQ(groupBy2.getDescriptor(), "GroupBy (implicit)");
 }
 
+// _____________________________________________________________________________
+TEST(GroupBy, knownEmptyResult) {
+  auto* qec = ad_utility::testing::getQec();
+  auto subtree = ad_utility::makeExecutionTree<ValuesForTesting>(
+      qec, IdTable{1, qec->getAllocator()},
+      std::vector<std::optional<Variable>>{Variable{"?a"}});
+
+  {
+    GroupBy groupBy{qec, {Variable{"?a"}}, {}, subtree};
+    EXPECT_TRUE(groupBy.knownEmptyResult());
+  }
+  {
+    GroupBy groupBy{qec, {}, {}, subtree};
+    EXPECT_FALSE(groupBy.knownEmptyResult());
+  }
+}
+
 namespace {
 class GroupByLazyFixture : public ::testing::TestWithParam<bool> {
  protected:

--- a/test/GroupByTest.cpp
+++ b/test/GroupByTest.cpp
@@ -2068,10 +2068,12 @@ TEST(GroupBy, knownEmptyResult) {
       qec, IdTable{1, qec->getAllocator()},
       std::vector<std::optional<Variable>>{Variable{"?a"}});
 
+  // Explicit group by should propagate knownEmptyResult() from child operation.
   {
     GroupBy groupBy{qec, {Variable{"?a"}}, {}, subtree};
     EXPECT_TRUE(groupBy.knownEmptyResult());
   }
+  // Implicit group by always returns a result
   {
     GroupBy groupBy{qec, {}, {}, subtree};
     EXPECT_FALSE(groupBy.knownEmptyResult());


### PR DESCRIPTION
So far, `GroupBy::knownEmptyResult()` simply returned `_subtree->knownEmptyResult()`. However, for an aggregation without `GROUP BY`, the result is non-empty also when there is nothing to group. For example, `SELECT (COUNT(*) AS ?count) WHERE { <x> <x> <x> }` is `0` and not nothing. This now fixed. In particular, fixes #2044