### PR TITLE
Implement `LoadURL` operation

### DIFF
--- a/src/engine/CMakeLists.txt
+++ b/src/engine/CMakeLists.txt
@@ -16,5 +16,5 @@ add_library(engine
         CountConnectedSubgraphs.cpp SpatialJoinAlgorithms.cpp PathSearch.cpp ExecuteUpdate.cpp
         Describe.cpp GraphStoreProtocol.cpp
         QueryExecutionContext.cpp ExistsJoin.cpp SPARQLProtocol.cpp ParsedRequestBuilder.cpp
-        NeutralOptional.cpp)
+        NeutralOptional.cpp LoadURL.cpp)
 qlever_target_link_libraries(engine util index parser sparqlExpressions http SortPerformanceEstimator Boost::iostreams s2 spatialjoin-dev pb_util)

--- a/src/engine/LoadURL.cpp
+++ b/src/engine/LoadURL.cpp
@@ -22,7 +22,7 @@ string LoadURL::getDescriptor() const {
 }
 
 // _____________________________________________________________________________
-size_t LoadURL::getResultWidth() const { return 3; }
+size_t LoadURL::getResultWidth() const { return 4; }
 
 // _____________________________________________________________________________
 size_t LoadURL::getCostEstimate() {
@@ -117,6 +117,7 @@ Result LoadURL::computeResult(bool) {
                              .toValueId(getIndex().getVocab(), lv);
     result(row_idx, 2) =
         std::move(triple.object_).toValueId(getIndex().getVocab(), lv);
+    result(row_idx, 3) = defaultGraph_;
     row_idx++;
     checkCancellation();
   }
@@ -129,6 +130,7 @@ VariableToColumnMap LoadURL::computeVariableToColumnMap() const {
   map[Variable("?s")] = makeAlwaysDefinedColumn(0);
   map[Variable("?p")] = makeAlwaysDefinedColumn(1);
   map[Variable("?o")] = makeAlwaysDefinedColumn(2);
+  map[Variable("?g")] = makeAlwaysDefinedColumn(3);
   return map;
 }
 

--- a/src/engine/LoadURL.cpp
+++ b/src/engine/LoadURL.cpp
@@ -1,0 +1,141 @@
+// Copyright 2025 The QLever Authors, in particular:
+//
+// 2025 Julian Mundhahs <mundhahj@tf.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+
+#include "engine/LoadURL.h"
+
+#include "util/http/HttpUtils.h"
+
+// _____________________________________________________________________________
+string LoadURL::getCacheKeyImpl() const {
+  return absl::StrCat("LOAD URL ", url_, " ", cacheBreaker_);
+}
+
+// _____________________________________________________________________________
+string LoadURL::getDescriptor() const {
+  return absl::StrCat("LOAD URL ", url_);
+}
+
+// _____________________________________________________________________________
+size_t LoadURL::getResultWidth() const { return 3; }
+
+// _____________________________________________________________________________
+size_t LoadURL::getCostEstimate() {
+  // TODO: For now, we don't have any information about the cost at query
+  // planning time, so we just return ten times the estimated size.
+  return 10 * getSizeEstimateBeforeLimit();
+}
+
+// _____________________________________________________________________________
+uint64_t LoadURL::getSizeEstimateBeforeLimit() {
+  // TODO: For now, we don't have any information about the result size at
+  // query planning time, so we just return `100'000`.
+  return 100'000;
+}
+
+// _____________________________________________________________________________
+float LoadURL::getMultiplicity(size_t) {
+  // TODO: For now, we don't have any information about the multiplicities at
+  // query planning time, so we just return `1` for each column.
+  return 1;
+}
+
+// _____________________________________________________________________________
+bool LoadURL::knownEmptyResult() { return false; }
+
+// _____________________________________________________________________________
+std::unique_ptr<Operation> LoadURL::cloneImpl() const {
+  auto load = std::make_unique<LoadURL>(_executionContext, url_);
+  load->cacheBreaker_ = cacheBreaker_;
+  return load;
+}
+
+// _____________________________________________________________________________
+vector<ColumnIndex> LoadURL::resultSortedOn() const { return {}; }
+
+// _____________________________________________________________________________
+Result LoadURL::computeResult(bool requestLaziness) {
+  // TODO: do lazy loading
+  ad_utility::httpUtils::Url url{url_};
+  LOG(INFO) << "Loading RDF dataset from " << url.asString() << std::endl;
+  HttpOrHttpsResponse response = getResultFunction_(
+      url, cancellationHandle_, boost::beast::http::verb::get, "", "", "");
+
+  auto throwErrorWithContext = [this, &response](std::string_view sv) {
+    std::string ctx;
+    ctx.reserve(100);
+    for (const auto& bytes : std::move(response.body_)) {
+      ctx += std::string(reinterpret_cast<const char*>(bytes.data()),
+                         bytes.size());
+      if (ctx.size() >= 100) {
+        break;
+      }
+    }
+    this->throwErrorWithContext(sv, std::string_view(ctx).substr(0, 100));
+  };
+
+  if (response.status_ != boost::beast::http::status::ok) {
+    throwErrorWithContext(absl::StrCat(
+        "RDF dataset responded with HTTP status code: ",
+        static_cast<int>(response.status_), ", ",
+        toStd(boost::beast::http::obsolete_reason(response.status_))));
+  }
+  std::optional<ad_utility::MediaType> mediaType =
+      ad_utility::toMediaType(response.contentType_);
+  if (!mediaType) {
+    throwErrorWithContext(
+        "QLever requires the endpoint of a LoadURL to return the mediatype.");
+  }
+  if (!ad_utility::contains(SUPPORTED_MEDIATYPES, mediaType.value())) {
+    throwErrorWithContext(
+        absl::StrCat("Unsupported media type \"", toString(mediaType.value()),
+                     "\". Supported media types are \"text/turtle\" and "
+                     "\"application/n-triples\"."));
+  }
+  using Re2Parser = RdfStringParser<TurtleParser<Tokenizer>>;
+  auto parser = Re2Parser();
+  std::string body;
+  for (const auto& bytes : response.body_) {
+    body.append(reinterpret_cast<const char*>(bytes.data()), bytes.size());
+  }
+  parser.setInputStream(body);
+  LocalVocab lv;
+  IdTable result{getResultWidth(), getExecutionContext()->getAllocator()};
+  size_t row_idx = 0;
+  for (auto& triple : parser.parseAndReturnAllTriples()) {
+    result.emplace_back();
+    result(row_idx, 0) =
+        std::move(triple.subject_).toValueId(getIndex().getVocab(), lv);
+    result(row_idx, 1) = std::move(TripleComponent(triple.predicate_))
+                             .toValueId(getIndex().getVocab(), lv);
+    result(row_idx, 2) =
+        std::move(triple.object_).toValueId(getIndex().getVocab(), lv);
+    row_idx++;
+    checkCancellation();
+  }
+  return Result{std::move(result), resultSortedOn(), std::move(lv)};
+}
+
+// _____________________________________________________________________________
+VariableToColumnMap LoadURL::computeVariableToColumnMap() const {
+  VariableToColumnMap map;
+  map[Variable("?s")] = makeAlwaysDefinedColumn(0);
+  map[Variable("?p")] = makeAlwaysDefinedColumn(1);
+  map[Variable("?o")] = makeAlwaysDefinedColumn(2);
+  return map;
+}
+
+// _____________________________________________________________________________
+void LoadURL::throwErrorWithContext(std::string_view msg,
+                                    std::string_view first100,
+                                    std::string_view last100) const {
+  const ad_utility::httpUtils::Url url{url_};
+
+  throw std::runtime_error(absl::StrCat(
+      "Error while executing a LoadURL request to <", url.asString(),
+      ">: ", msg, ". First 100 bytes of the response: '", first100,
+      (last100.empty() ? "'"
+                       : absl::StrCat(", last 100 bytes: '", last100, "'"))));
+}

--- a/src/engine/LoadURL.h
+++ b/src/engine/LoadURL.h
@@ -26,7 +26,7 @@ class LoadURL final : public Operation {
       ad_utility::MediaType::turtle, ad_utility::MediaType::ntriples};
 
  private:
-  // The generate LOAD URL clause.
+  // The generated LOAD URL clause.
   parsedQuery::LoadURL loadURLClause_;
 
   // The function used to obtain the result from the remote endpoint.
@@ -39,21 +39,12 @@ class LoadURL final : public Operation {
   // instance of the class.
   uint32_t cacheBreaker_ = counter_++;
 
-  Id defaultGraph_;
-
  public:
   LoadURL(QueryExecutionContext* qec, parsedQuery::LoadURL loadURLClause,
           GetResultFunction getResultFunction = sendHttpOrHttpsRequest)
       : Operation(qec),
         loadURLClause_(loadURLClause),
-        getResultFunction_(std::move(getResultFunction)) {
-    auto defaultGraph =
-        TripleComponent(
-            ad_utility::triple_component::Iri::fromIriref(DEFAULT_GRAPH_IRI))
-            .toValueId(qec->getIndex().getVocab());
-    AD_CORRECTNESS_CHECK(defaultGraph);
-    defaultGraph_ = defaultGraph.value();
-  };
+        getResultFunction_(std::move(getResultFunction)){};
 
   ~LoadURL() override = default;
 

--- a/src/engine/LoadURL.h
+++ b/src/engine/LoadURL.h
@@ -39,12 +39,21 @@ class LoadURL final : public Operation {
   // instance of the class.
   uint32_t cacheBreaker_ = counter_++;
 
+  Id defaultGraph_;
+
  public:
   LoadURL(QueryExecutionContext* qec, parsedQuery::LoadURL loadURLClause,
           GetResultFunction getResultFunction = sendHttpOrHttpsRequest)
       : Operation(qec),
         loadURLClause_(loadURLClause),
-        getResultFunction_(std::move(getResultFunction)){};
+        getResultFunction_(std::move(getResultFunction)) {
+    auto defaultGraph =
+        TripleComponent(
+            ad_utility::triple_component::Iri::fromIriref(DEFAULT_GRAPH_IRI))
+            .toValueId(qec->getIndex().getVocab());
+    AD_CORRECTNESS_CHECK(defaultGraph);
+    defaultGraph_ = defaultGraph.value();
+  };
 
   ~LoadURL() override = default;
 

--- a/src/engine/LoadURL.h
+++ b/src/engine/LoadURL.h
@@ -10,6 +10,7 @@
 #include <string>
 
 #include "engine/Operation.h"
+#include "parser/ParsedQuery.h"
 #include "util/http/HttpClient.h"
 
 class LoadURL final : public Operation {
@@ -25,9 +26,8 @@ class LoadURL final : public Operation {
       ad_utility::MediaType::turtle, ad_utility::MediaType::ntriples};
 
  private:
-  // TODO: use a proper type
-  // The URL from where to load the data.
-  std::string url_;
+  // The generate LOAD URL clause.
+  parsedQuery::LoadURL loadURLClause_;
 
   // The function used to obtain the result from the remote endpoint.
   GetResultFunction getResultFunction_;
@@ -40,10 +40,10 @@ class LoadURL final : public Operation {
   uint32_t cacheBreaker_ = counter_++;
 
  public:
-  LoadURL(QueryExecutionContext* qec, const std::string& url,
+  LoadURL(QueryExecutionContext* qec, parsedQuery::LoadURL loadURLClause,
           GetResultFunction getResultFunction = sendHttpOrHttpsRequest)
       : Operation(qec),
-        url_(url),
+        loadURLClause_(loadURLClause),
         getResultFunction_(std::move(getResultFunction)){};
 
   ~LoadURL() override = default;

--- a/src/engine/LoadURL.h
+++ b/src/engine/LoadURL.h
@@ -48,7 +48,6 @@ class LoadURL final : public Operation {
 
   ~LoadURL() override = default;
 
-  // TODO: huh
   vector<QueryExecutionTree*> getChildren() override { return {}; }
 
   std::string getCacheKeyImpl() const override;

--- a/src/engine/LoadURL.h
+++ b/src/engine/LoadURL.h
@@ -1,0 +1,90 @@
+// Copyright 2025 The QLever Authors, in particular:
+//
+// 2025 Julian Mundhahs <mundhahj@tf.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+
+#ifndef QLEVER_LOADURL_H
+#define QLEVER_LOADURL_H
+
+#include <string>
+
+#include "engine/Operation.h"
+#include "util/http/HttpClient.h"
+
+class LoadURL final : public Operation {
+ public:
+  // The type of the function used to obtain the results, see below.
+  using GetResultFunction = std::function<HttpOrHttpsResponse(
+      const ad_utility::httpUtils::Url&,
+      ad_utility::SharedCancellationHandle handle,
+      const boost::beast::http::verb&, std::string_view, std::string_view,
+      std::string_view)>;
+
+  const std::vector<ad_utility::MediaType> SUPPORTED_MEDIATYPES{
+      ad_utility::MediaType::turtle, ad_utility::MediaType::ntriples};
+
+ private:
+  // TODO: use a proper type
+  // The URL from where to load the data.
+  std::string url_;
+
+  // The function used to obtain the result from the remote endpoint.
+  GetResultFunction getResultFunction_;
+
+  // Counter to generate fresh ids for each instance of the class.
+  static inline std::atomic_uint32_t counter_ = 0;
+
+  // Id that is used to avoid caching of the result. It is unique for every
+  // instance of the class.
+  uint32_t cacheBreaker_ = counter_++;
+
+ public:
+  LoadURL(QueryExecutionContext* qec, const std::string& url,
+          GetResultFunction getResultFunction = sendHttpOrHttpsRequest)
+      : Operation(qec),
+        url_(url),
+        getResultFunction_(std::move(getResultFunction)){};
+
+  ~LoadURL() override = default;
+
+  // TODO: huh
+  vector<QueryExecutionTree*> getChildren() override { return {}; }
+
+  std::string getCacheKeyImpl() const override;
+
+  std::string getDescriptor() const override;
+
+  size_t getResultWidth() const override;
+
+  size_t getCostEstimate() override;
+
+ private:
+  uint64_t getSizeEstimateBeforeLimit() override;
+
+ public:
+  float getMultiplicity(size_t col) override;
+
+  bool knownEmptyResult() override;
+
+ private:
+  std::unique_ptr<Operation> cloneImpl() const override;
+
+ protected:
+  vector<ColumnIndex> resultSortedOn() const override;
+
+ private:
+  Result computeResult(bool requestLaziness) override;
+
+  VariableToColumnMap computeVariableToColumnMap() const override;
+
+  // Throws an error message, providing the first 100 bytes of the result as
+  // context.
+  [[noreturn]] void throwErrorWithContext(
+      std::string_view msg, std::string_view first100,
+      std::string_view last100 = ""sv) const;
+
+  FRIEND_TEST(LoadURLTest, basicMethods);
+};
+
+#endif  // QLEVER_LOADURL_H

--- a/src/global/RuntimeParameters.h
+++ b/src/global/RuntimeParameters.h
@@ -69,6 +69,9 @@ inline auto& RuntimeParameters() {
         // which has the downside that the sibling optimization where VALUES are
         // dynamically pushed into `SERVICE` is no longer used.
         Bool<"cache-service-results">{false},
+        // Whether the results of a `LOAD URL` operation should be cached. The
+        // caching currently assumes the content of all URLs to be fixed.
+        Bool<"cache-load-results">{false},
     };
   }();
   return params;

--- a/src/parser/GraphPatternOperation.h
+++ b/src/parser/GraphPatternOperation.h
@@ -25,6 +25,7 @@
 #include "parser/data/Variable.h"
 #include "util/Algorithm.h"
 #include "util/VisitMixin.h"
+#include "util/http/HttpUtils.h"
 
 // First some forward declarations.
 // TODO<joka921> More stuff should consistently be in the `parsedQuery`
@@ -65,6 +66,13 @@ struct Service {
   // The body of the SPARQL query for the remote endpoint.
   std::string graphPatternAsString_;
   // The existence of the `SILENT`-keyword.
+  bool silent_;
+};
+
+/// An internal pattern used in the `LOAD` update operation.
+struct LoadURL {
+ public:
+  ad_utility::httpUtils::Url url_;
   bool silent_;
 };
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -304,6 +304,8 @@ addLinkAndDiscoverTestSerial(ValuesTest engine)
 
 addLinkAndDiscoverTestSerial(ServiceTest engine)
 
+addLinkAndDiscoverTestSerial(LoadURLTest engine)
+
 addLinkAndDiscoverTestSerial(HttpTest Boost::iostreams http)
 
 addLinkAndDiscoverTest(CallFixedSizeTest)

--- a/test/LoadURLTest.cpp
+++ b/test/LoadURLTest.cpp
@@ -12,6 +12,7 @@
 #include "util/IdTableHelpers.h"
 #include "util/IndexTestHelpers.h"
 #include "util/OperationTestHelpers.h"
+#include "util/RuntimeParametersTestHelpers.h"
 
 auto pqLoadURL = [](std::string url, bool silent = false) {
   return parsedQuery::LoadURL{ad_utility::httpUtils::Url{url}, silent};
@@ -98,19 +99,17 @@ TEST_F(LoadURLTest, basicMethods) {
   EXPECT_THAT(loadURL.getDescriptor(),
               testing::Eq("LOAD URL https://mundhahs.dev:443/"));
   EXPECT_THAT(loadURL.getCacheKey(), testing::StartsWith("LOAD URL"));
-  EXPECT_THAT(loadURL.getResultWidth(), testing::Eq(4));
+  EXPECT_THAT(loadURL.getResultWidth(), testing::Eq(3));
   EXPECT_THAT(loadURL.getMultiplicity(0), testing::Eq(1));
   EXPECT_THAT(loadURL.getMultiplicity(1), testing::Eq(1));
   EXPECT_THAT(loadURL.getMultiplicity(2), testing::Eq(1));
-  EXPECT_THAT(loadURL.getMultiplicity(3), testing::Eq(1));
   EXPECT_THAT(loadURL.getSizeEstimate(), testing::Eq(100'000));
   EXPECT_THAT(loadURL.getCostEstimate(), testing::Eq(1'000'000));
   EXPECT_THAT(loadURL.computeVariableToColumnMap(),
               testing::UnorderedElementsAreArray(VariableToColumnMap{
                   {Variable("?s"), makeAlwaysDefinedColumn(0)},
                   {Variable("?p"), makeAlwaysDefinedColumn(1)},
-                  {Variable("?o"), makeAlwaysDefinedColumn(2)},
-                  {Variable("?g"), makeAlwaysDefinedColumn(3)}}));
+                  {Variable("?o"), makeAlwaysDefinedColumn(2)}}));
   EXPECT_THAT(loadURL.knownEmptyResult(), testing::IsFalse());
   EXPECT_THAT(loadURL.getChildren(), testing::IsEmpty());
 }
@@ -153,7 +152,7 @@ TEST_F(LoadURLTest, computeResult) {
   }
   auto expectLoad =
       [this](std::string responseBody, std::string contentType,
-             std::vector<std::array<TripleComponent, 4>> expectedIdTable,
+             std::vector<std::array<TripleComponent, 3>> expectedIdTable,
              ad_utility::source_location loc =
                  ad_utility::source_location::current()) {
         auto g = generateLocationTrace(loc);
@@ -193,29 +192,49 @@ TEST_F(LoadURLTest, computeResult) {
   auto Iri = ad_utility::triple_component::Iri::fromIriref;
   auto Literal =
       ad_utility::triple_component::Literal::fromStringRepresentation;
-  auto DEFAULT_GRAPH = Iri(DEFAULT_GRAPH_IRI);
   expectLoad("<x> <b> <c>", "text/turtle",
-             {{Iri("<x>"), Iri("<b>"), Iri("<c>"), DEFAULT_GRAPH}});
+             {{Iri("<x>"), Iri("<b>"), Iri("<c>")}});
   expectLoad("<x> <b> <c> ; <d> <y>", "text/turtle",
-             {{Iri("<x>"), Iri("<b>"), Iri("<c>"), DEFAULT_GRAPH},
-              {Iri("<x>"), Iri("<d>"), Iri("<y>"), DEFAULT_GRAPH}});
+             {{Iri("<x>"), Iri("<b>"), Iri("<c>")},
+              {Iri("<x>"), Iri("<d>"), Iri("<y>")}});
   expectLoad("<x> <b> <c> , <y>", "text/turtle",
-             {{Iri("<x>"), Iri("<b>"), Iri("<c>"), DEFAULT_GRAPH},
-              {Iri("<x>"), Iri("<b>"), Iri("<y>"), DEFAULT_GRAPH}});
+             {{Iri("<x>"), Iri("<b>"), Iri("<c>")},
+              {Iri("<x>"), Iri("<b>"), Iri("<y>")}});
   expectLoad("<x> <b> <c> , \"foo\"@en", "text/turtle",
-             {{Iri("<x>"), Iri("<b>"), Iri("<c>"), DEFAULT_GRAPH},
-              {Iri("<x>"), Iri("<b>"), Literal("\"foo\"@en"), DEFAULT_GRAPH}});
-  expectLoad("@prefix foo: <http://mundhahs.dev/rdf/> . foo:bar <is-a> <x>",
-             "text/turtle",
-             {{Iri("<http://mundhahs.dev/rdf/bar>"), Iri("<is-a>"), Iri("<x>"),
-               DEFAULT_GRAPH}});
+             {{Iri("<x>"), Iri("<b>"), Iri("<c>")},
+              {Iri("<x>"), Iri("<b>"), Literal("\"foo\"@en")}});
+  expectLoad(
+      "@prefix foo: <http://mundhahs.dev/rdf/> . foo:bar <is-a> <x>",
+      "text/turtle",
+      {{Iri("<http://mundhahs.dev/rdf/bar>"), Iri("<is-a>"), Iri("<x>")}});
 }
 
 TEST_F(LoadURLTest, getCacheKey) {
-  LoadURL load1{testQec, pqLoadURL("https://mundhahs.dev")};
-  LoadURL load2{testQec, pqLoadURL("https://mundhahs.dev")};
-  EXPECT_THAT(load1.getCacheKey(),
-              testing::Not(testing::Eq(load2.getCacheKey())));
+  {
+    auto cleanup = setRuntimeParameterForTest<"cache-load-results">(true);
+
+    LoadURL load1{testQec, pqLoadURL("https://mundhahs.dev")};
+    LoadURL load2{testQec, pqLoadURL("https://mundhahs.dev")};
+    LoadURL load3{testQec, pqLoadURL("https://mundhahs.dev", true)};
+    EXPECT_THAT(load1.getCacheKey(), testing::Eq(load2.getCacheKey()));
+    EXPECT_THAT(load1.getCacheKey(),
+                testing::Not(testing::Eq(load3.getCacheKey())));
+    EXPECT_THAT(load1.getCacheKey(),
+                testing::Eq("LOAD URL https://mundhahs.dev:443/"));
+    EXPECT_THAT(load3.getCacheKey(),
+                testing::Eq("LOAD URL https://mundhahs.dev:443/ SILENT"));
+  }
+  {
+    auto cleanup = setRuntimeParameterForTest<"cache-load-results">(false);
+
+    LoadURL load1{testQec, pqLoadURL("https://mundhahs.dev")};
+    LoadURL load2{testQec, pqLoadURL("https://mundhahs.dev")};
+    LoadURL load3{testQec, pqLoadURL("https://mundhahs.dev", true)};
+    EXPECT_THAT(load1.getCacheKey(),
+                testing::Not(testing::Eq(load2.getCacheKey())));
+    EXPECT_THAT(load1.getCacheKey(),
+                testing::Not(testing::Eq(load3.getCacheKey())));
+  }
 }
 
 TEST_F(LoadURLTest, clone) {

--- a/test/LoadURLTest.cpp
+++ b/test/LoadURLTest.cpp
@@ -1,0 +1,220 @@
+// Copyright 2025 The QLever Authors, in particular:
+//
+// 2025 Julian Mundhahs <mundhahj@tf.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "engine/LoadURL.h"
+#include "util/GTestHelpers.h"
+#include "util/IdTableHelpers.h"
+#include "util/IndexTestHelpers.h"
+#include "util/OperationTestHelpers.h"
+
+// Fixture that sets up a test index and a factory for producing mocks for the
+// `getResultFunction` needed by the `Service` operation.
+class LoadURLTest : public ::testing::Test {
+ protected:
+  // Query execution context (with small test index) and allocator for testing,
+  // see `IndexTestHelpers.h`. Note that `getQec` returns a pointer to a static
+  // `QueryExecutionContext`, so no need to ever delete `testQec`.
+  QueryExecutionContext* testQec = ad_utility::testing::getQec();
+  ad_utility::AllocatorWithLimit<Id> testAllocator =
+      ad_utility::testing::makeAllocator();
+
+  // Factory for generating mocks of the `sendHttpOrHttpsRequest` function that
+  // is used by default by a `Service` operation (see the constructor in
+  // `Service.h`). Each mock does the following:
+  //
+  // 1. It tests that the request method is POST, the content-type header is
+  //    `application/sparql-query`, and the accept header is
+  //    `text/tab-separated-values` (our `Service` always does this).
+  //
+  // 2. It tests that the host and port are as expected.
+  //
+  // 3. It tests that the post data is as expected.
+  //
+  // 4. It returns the specified JSON.
+  //
+  // NOTE: In a previous version of this test, we set up an actual test server.
+  // The code can be found in the history of this PR.
+  static auto constexpr getResultFunctionFactory =
+      [](std::string predefinedResult,
+         boost::beast::http::status status = boost::beast::http::status::ok,
+         std::string contentType = "text/turtle",
+         std::exception_ptr mockException = nullptr,
+         ad_utility::source_location loc =
+             ad_utility::source_location::current())
+      -> LoadURL::GetResultFunction {
+    return [=](const ad_utility::httpUtils::Url&,
+               ad_utility::SharedCancellationHandle,
+               const boost::beast::http::verb& method,
+               std::string_view postData, std::string_view contentTypeHeader,
+               std::string_view acceptHeader) {
+      auto g = generateLocationTrace(loc);
+      EXPECT_THAT(method, testing::Eq(boost::beast::http::verb::get));
+      EXPECT_THAT(contentTypeHeader, testing::Eq(""));
+      EXPECT_THAT(acceptHeader, testing::Eq(""));
+      EXPECT_THAT(postData, testing::Eq(""));
+
+      if (mockException) {
+        std::rethrow_exception(mockException);
+      }
+
+      auto randomlySlice =
+          [](std::string result) -> cppcoro::generator<ql::span<std::byte>> {
+        // Randomly slice the string to make tests more robust.
+        std::mt19937 rng{std::random_device{}()};
+
+        const std::string resultStr = result;
+        std::uniform_int_distribution<size_t> distribution{
+            0, resultStr.length() / 2};
+
+        for (size_t start = 0; start < resultStr.length();) {
+          size_t size = distribution(rng);
+          std::string resultCopy{resultStr.substr(start, size)};
+          co_yield ql::as_writable_bytes(ql::span{resultCopy});
+          start += size;
+        }
+      };
+      return HttpOrHttpsResponse{.status_ = status,
+                                 .contentType_ = contentType,
+                                 .body_ = randomlySlice(predefinedResult)};
+    };
+  };
+};
+
+TEST_F(LoadURLTest, basicMethods) {
+  // Create an instance of the operation.
+  LoadURL loadURL{testQec, "https://mundhahs.dev"};
+
+  // Test the basic methods.
+  EXPECT_THAT(loadURL.getDescriptor(),
+              testing::Eq("LOAD URL https://mundhahs.dev"));
+  EXPECT_THAT(loadURL.getCacheKey(), testing::StartsWith("LOAD URL"));
+  EXPECT_THAT(loadURL.getResultWidth(), testing::Eq(3));
+  EXPECT_THAT(loadURL.getMultiplicity(0), testing::Eq(1));
+  EXPECT_THAT(loadURL.getMultiplicity(1), testing::Eq(1));
+  EXPECT_THAT(loadURL.getMultiplicity(2), testing::Eq(1));
+  EXPECT_THAT(loadURL.getSizeEstimate(), testing::Eq(100'000));
+  EXPECT_THAT(loadURL.getCostEstimate(), testing::Eq(1'000'000));
+  EXPECT_THAT(loadURL.computeVariableToColumnMap(),
+              testing::UnorderedElementsAreArray(VariableToColumnMap{
+                  {Variable("?s"), makeAlwaysDefinedColumn(0)},
+                  {Variable("?p"), makeAlwaysDefinedColumn(1)},
+                  {Variable("?o"), makeAlwaysDefinedColumn(2)}}));
+  EXPECT_THAT(loadURL.knownEmptyResult(), testing::IsFalse());
+  EXPECT_THAT(loadURL.getChildren(), testing::IsEmpty());
+}
+
+TEST_F(LoadURLTest, computeResult) {
+  {
+    LoadURL loadURL{testQec, "https://mundhahs.dev",
+                    getResultFunctionFactory(
+                        "<x> <b> <c>", boost::beast::http::status::not_found)};
+    AD_EXPECT_THROW_WITH_MESSAGE(
+        loadURL.computeResultOnlyForTesting(),
+        testing::HasSubstr("RDF dataset responded with HTTP status code: 404"));
+  }
+  {
+    LoadURL loadURL{
+        testQec, "https://mundhahs.dev",
+        getResultFunctionFactory("<x> <b> <c>", boost::beast::http::status::ok,
+                                 "text/plain")};
+    AD_EXPECT_THROW_WITH_MESSAGE(
+        loadURL.computeResultOnlyForTesting(),
+        testing::HasSubstr("Unsupported media type \"text/plain\"."));
+  }
+  {
+    LoadURL loadURL{testQec, "https://mundhahs.dev",
+                    getResultFunctionFactory(
+                        "<x> <b> <c>", boost::beast::http::status::ok, "")};
+    AD_EXPECT_THROW_WITH_MESSAGE(
+        loadURL.computeResultOnlyForTesting(),
+        testing::HasSubstr("QLever requires the endpoint of a LoadURL to "
+                           "return the mediatype."));
+  }
+  {
+    LoadURL loadURL{testQec, "https://mundhahs.dev",
+                    getResultFunctionFactory("this is not turtle",
+                                             boost::beast::http::status::ok,
+                                             "text/turtle")};
+    AD_EXPECT_THROW_WITH_MESSAGE(
+        loadURL.computeResultOnlyForTesting(),
+        testing::HasSubstr("Parse error at byte position 0"));
+  }
+  auto expectLoad =
+      [this](std::string responseBody, std::string contentType,
+             std::vector<std::array<TripleComponent, 3>> expectedIdTable,
+             ad_utility::source_location loc =
+                 ad_utility::source_location::current()) {
+        auto g = generateLocationTrace(loc);
+
+        LoadURL loadURL{
+            testQec, "https://mundhahs.dev",
+            getResultFunctionFactory(
+                responseBody, boost::beast::http::status::ok, contentType)};
+        auto res = loadURL.computeResultOnlyForTesting();
+
+        auto& idTable = res.idTable();
+        auto& lv = res.localVocab();
+
+        std::vector<std::vector<IntOrId>> idVector;
+        for (const auto& row : expectedIdTable) {
+          auto& idVecRow = idVector.emplace_back();
+          for (auto& field : row) {
+            auto idOpt = field.toValueId(testQec->getIndex().getVocab());
+            if (!idOpt) {
+              ASSERT_THAT(field.isLiteral() || field.isIri(),
+                          testing::IsTrue());
+              using LiteralOrIri = ad_utility::triple_component::LiteralOrIri;
+              auto lveOpt = lv.getIndexOrNullopt(
+                  field.isLiteral() ? LiteralOrIri{field.getLiteral()}
+                                    : LiteralOrIri{field.getIri()});
+              ASSERT_THAT(lveOpt, testing::Not(testing::Eq(std::nullopt)));
+              idOpt = Id::makeFromLocalVocabIndex(lveOpt.value());
+            }
+            idVecRow.emplace_back(idOpt.value());
+          }
+        }
+
+        IdTable expectedId = makeIdTableFromVector(idVector);
+        EXPECT_EQ(idTable, makeIdTableFromVector(idVector));
+        EXPECT_THAT(idTable, testing::Eq(std::ref(expectedId)));
+      };
+  auto Iri = ad_utility::triple_component::Iri::fromIriref;
+  auto Literal =
+      ad_utility::triple_component::Literal::fromStringRepresentation;
+  expectLoad("<x> <b> <c>", "text/turtle",
+             {{Iri("<x>"), Iri("<b>"), Iri("<c>")}});
+  expectLoad("<x> <b> <c> ; <d> <y>", "text/turtle",
+             {{Iri("<x>"), Iri("<b>"), Iri("<c>")},
+              {Iri("<x>"), Iri("<d>"), Iri("<y>")}});
+  expectLoad("<x> <b> <c> , <y>", "text/turtle",
+             {{Iri("<x>"), Iri("<b>"), Iri("<c>")},
+              {Iri("<x>"), Iri("<b>"), Iri("<y>")}});
+  expectLoad("<x> <b> <c> , \"foo\"@en", "text/turtle",
+             {{Iri("<x>"), Iri("<b>"), Iri("<c>")},
+              {Iri("<x>"), Iri("<b>"), Literal("\"foo\"@en")}});
+  expectLoad(
+      "@prefix foo: <http://mundhahs.dev/rdf/> . foo:bar <is-a> <x>",
+      "text/turtle",
+      {{Iri("<http://mundhahs.dev/rdf/bar>"), Iri("<is-a>"), Iri("<x>")}});
+}
+
+TEST_F(LoadURLTest, getCacheKey) {
+  LoadURL load1{testQec, "https://mundhahs.dev"};
+  LoadURL load2{testQec, "https://mundhahs.dev"};
+  EXPECT_THAT(load1.getCacheKey(),
+              testing::Not(testing::Eq(load2.getCacheKey())));
+}
+
+TEST_F(LoadURLTest, clone) {
+  LoadURL loadUrl{testQec, "https://mundhahs.dev"};
+  auto clone = loadUrl.clone();
+  ASSERT_THAT(clone, testing::Not(testing::Eq(nullptr)));
+  EXPECT_THAT(*clone, IsDeepCopy(loadUrl));
+  EXPECT_THAT(clone->getDescriptor(), testing::Eq(loadUrl.getDescriptor()));
+}


### PR DESCRIPTION
Implement a `LoadURL` (preliminary name) operation that reads a RDF document from a IRI and returns all the triples in columns `?s`, `?p` and `?o`.

Context: This is a PR the prepares the implementation of the [`LOAD` Update operation](https://www.w3.org/TR/sparql11-update/#load). This operations reads an RDF document from a IRI and iserts all triples into a specified graph. There currently is no primitive to read an RDF document from a IRI. This PR add this missing operation. `LOAD` can then be modeled as a normal update with this internal operation.