### PR TITLE
Variables that only occur inside a `MINUS` should not be visible outside

### DIFF
--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -1437,8 +1437,13 @@ TripleComponent Visitor::visit(Parser::DataBlockValueContext* ctx) {
 
 // ____________________________________________________________________________________
 GraphPatternOperation Visitor::visit(Parser::MinusGraphPatternContext* ctx) {
-  return GraphPatternOperation{
+  auto visibleVariables = std::move(visibleVariables_);
+  GraphPatternOperation operation{
       parsedQuery::Minus{visit(ctx->groupGraphPattern())}};
+  // Make sure that the variables from the minus graph pattern are NOT added to
+  // visible variables.
+  visibleVariables_ = std::move(visibleVariables);
+  return operation;
 }
 
 // ____________________________________________________________________________________

--- a/test/SparqlParserTest.cpp
+++ b/test/SparqlParserTest.cpp
@@ -1488,3 +1488,17 @@ TEST(ParserTest, multipleUpdatesAreForbidden) {
           "INSERT DATA { <a> <b> <c> }; DELETE DATA { <d> <e> <f> }"),
       testing::HasSubstr("Multiple Updates in one request are not supported."));
 }
+
+// _____________________________________________________________________________
+TEST(ParserTest, variablesInMinusAreHidden) {
+  EXPECT_THAT(
+      SparqlParser::parseQuery(
+          "SELECT * { VALUES ?a { 1 } MINUS { VALUES (?a ?b) { ( 2 2 ) } } }"),
+      m::SelectQuery(
+          m::VariablesSelect({"?a"}, false, false),
+          m::GraphPattern(
+              m::InlineData({Variable{"?a"}}, {{TripleComponent{1}}}),
+              m::Minus(m::GraphPattern(m::InlineData(
+                  {Variable{"?a"}, Variable{"?b"}},
+                  {{TripleComponent{2}, TripleComponent{2}}}))))));
+}


### PR DESCRIPTION
In the following example query, the variable `?b` should not be visible outside of the `MINUS`, and, in particular, should not be part of the result. Fixes #2016
```sparql
SELECT * WHERE {
  VALUES ?a { 1 }
  MINUS {
    VALUES (?a ?b) { (2 2) }
  }
}
```