### PR TITLE
Use the C++-17 backports when compiling with Clang-16

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,8 @@ add_definitions("-DBOOST_ASIO_DISABLE_AWAITABLE_FRAME_RECYCLING")
 # Coroutines require an additional compiler flag that is called differently
 # on clang and g++
 option(COMPILER_VERSION_CHECK_DEACTIVATED "Disable compiler version check" OFF)
+set(FORCE_CPP_17_BACKPORTS OFF)
+
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS "11.0.0" AND NOT COMPILER_VERSION_CHECK_DEACTIVATED)
         MESSAGE(FATAL_ERROR "G++ versions older than 11.0 are not supported by QLever")
@@ -36,6 +38,10 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS "16.0.0" AND NOT COMPILER_VERSION_CHECK_DEACTIVATED)
         MESSAGE(FATAL_ERROR "Clang++ versions older than 16.0 are not supported by QLever")
+    endif ()
+    if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS "17.0.0")
+        set(FORCE_CPP_17_BACKPORTS ON)
+        MESSAGE(STATUS "Using range-v3 for Clang16 to avoid errors for newer versions of `libstdc++`")
     endif ()
 else ()
     MESSAGE(FATAL_ERROR "QLever currently only supports the G++ or LLVM-Clang++ compilers. Found ${CMAKE_CXX_COMPILER_ID}")
@@ -211,7 +217,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${ADDITIONAL_COMPILER_FLAGS}")
 # of `std::ranges` and the `std::enable_if_t` based expansion of the concept
 # macros from `range-v3`.
 set(USE_CPP_17_BACKPORTS OFF CACHE BOOL "Use the C++17 backports (range-v3 and enable_if_t instead of std::ranges and concepts)")
-if (${USE_CPP_17_BACKPORTS})
+if (${USE_CPP_17_BACKPORTS} OR ${FORCE_CPP_17_BACKPORTS})
     add_definitions("-DQLEVER_CPP_17 -DCPP_CXX_CONCEPTS=0")
 endif()
 

--- a/src/engine/Join.cpp
+++ b/src/engine/Join.cpp
@@ -380,7 +380,7 @@ void Join::join(const IdTable& a, const IdTable& b, IdTable* result) const {
 }
 
 // _____________________________________________________________________________
-CPP_template_2(typename ActionT)(
+CPP_template_def(typename ActionT)(
     requires ad_utility::InvocableWithExactReturnType<
         ActionT, Result::IdTableVocabPair,
         std::function<void(IdTable&, LocalVocab&)>>)

--- a/src/engine/Join.h
+++ b/src/engine/Join.h
@@ -96,7 +96,7 @@ class Join : public Operation {
   // `action` is a lambda that can be used to send partial chunks to a consumer
   // in addition to returning the remaining result. If laziness is not required
   // it is a no-op.
-  CPP_template_2(typename ActionT)(
+  CPP_template(typename ActionT)(
       requires ad_utility::InvocableWithExactReturnType<
           ActionT, Result::IdTableVocabPair,
           std::function<void(IdTable&, LocalVocab&)>>) Result

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -180,7 +180,7 @@ void Server::run(const string& indexBaseName, bool useText, bool usePatterns,
 }
 
 // _____________________________________________________________________________
-CPP_template_2(typename RequestT, typename ResponseT)(
+CPP_template_def(typename RequestT, typename ResponseT)(
     requires ad_utility::httpUtils::HttpRequest<RequestT>)
     net::awaitable<std::optional<Server::TimeLimit>> Server::
         verifyUserSubmittedQueryTimeout(
@@ -278,7 +278,7 @@ auto Server::prepareOperation(
 }
 
 // _____________________________________________________________________________
-CPP_template_2(typename RequestT, typename ResponseT)(
+CPP_template_def(typename RequestT, typename ResponseT)(
     requires ad_utility::httpUtils::HttpRequest<RequestT>)
     Awaitable<void> Server::process(const RequestT& request, ResponseT&& send) {
   using namespace ad_utility::httpUtils;
@@ -652,7 +652,7 @@ nlohmann::json Server::composeCacheStatsJson() const {
 }
 
 // _____________________________________________
-CPP_template_2(typename RequestT)(
+CPP_template_def(typename RequestT)(
     requires ad_utility::httpUtils::HttpRequest<RequestT>)
     ad_utility::websocket::OwningQueryId Server::getQueryId(
         const RequestT& request, std::string_view query) {
@@ -670,7 +670,7 @@ CPP_template_2(typename RequestT)(
 }
 
 // _____________________________________________________________________________
-CPP_template_2(typename RequestT, typename ResponseT)(
+CPP_template_def(typename RequestT, typename ResponseT)(
     requires ad_utility::httpUtils::HttpRequest<RequestT>)
     Awaitable<void> Server::sendStreamableResponse(
         const RequestT& request, ResponseT& send, MediaType mediaType,
@@ -714,7 +714,7 @@ CPP_template_2(typename RequestT, typename ResponseT)(
 }
 
 // ____________________________________________________________________________
-CPP_template_2(typename RequestT)(
+CPP_template_def(typename RequestT)(
     requires ad_utility::httpUtils::HttpRequest<RequestT>)
     MediaType Server::determineMediaType(
         const ad_utility::url_parser::ParamValueMap& params,
@@ -753,7 +753,7 @@ CPP_template_2(typename RequestT)(
 }
 
 // ____________________________________________________________________________
-CPP_template_2(typename RequestT)(
+CPP_template_def(typename RequestT)(
     requires ad_utility::httpUtils::HttpRequest<RequestT>)
     ad_utility::websocket::MessageSender Server::createMessageSender(
         const std::weak_ptr<ad_utility::websocket::QueryHub>& queryHub,
@@ -766,7 +766,7 @@ CPP_template_2(typename RequestT)(
 }
 
 // ____________________________________________________________________________
-CPP_template_2(typename RequestT, typename ResponseT)(
+CPP_template_def(typename RequestT, typename ResponseT)(
     requires ad_utility::httpUtils::HttpRequest<RequestT>)
     Awaitable<void> Server::processQuery(
         const ad_utility::url_parser::ParamValueMap& params,
@@ -919,7 +919,7 @@ json Server::processUpdateImpl(
 }
 
 // ____________________________________________________________________________
-CPP_template_2(typename RequestT, typename ResponseT)(
+CPP_template_def(typename RequestT, typename ResponseT)(
     requires ad_utility::httpUtils::HttpRequest<RequestT>)
     Awaitable<void> Server::processUpdate(
         ParsedQuery&& update, const ad_utility::Timer& requestTimer,
@@ -954,7 +954,7 @@ CPP_template_2(typename RequestT, typename ResponseT)(
 }
 
 // ____________________________________________________________________________
-CPP_template_2(typename VisitorT, typename RequestT, typename ResponseT)(
+CPP_template_def(typename VisitorT, typename RequestT, typename ResponseT)(
     requires ad_utility::httpUtils::HttpRequest<RequestT>)
     Awaitable<void> Server::processOperation(
         ad_utility::url_parser::sparqlOperation::Operation operation,

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -120,7 +120,7 @@ class Server {
   // Clang doesn't seem to be able to automatically deduce the type correctly.
   // and GCC 11 thinks deduction guides are not allowed within classes.
 #ifdef __clang__
-  CPP_template_2(typename CancelTimeout)(
+  CPP_template(typename CancelTimeout)(
       requires ad_utility::isInstantiation<CancelTimeout, absl::Cleanup>)
       CancellationHandleAndTimeoutTimerCancel(SharedCancellationHandle,
                                               CancelTimeout)
@@ -133,20 +133,20 @@ class Server {
   /// \param req The HTTP request.
   /// \param send The action that sends a http:response. (see the
   ///             `HttpServer.h` for documentation).
-  CPP_template_2(typename RequestT, typename ResponseT)(
+  CPP_template(typename RequestT, typename ResponseT)(
       requires ad_utility::httpUtils::HttpRequest<RequestT>)
       Awaitable<void> process(const RequestT& request, ResponseT&& send);
 
   // Wraps the error handling around the processing of operations. Calls the
   // visitor on the given operation.
-  CPP_template_2(typename VisitorT, typename RequestT, typename ResponseT)(
+  CPP_template(typename VisitorT, typename RequestT, typename ResponseT)(
       requires ad_utility::httpUtils::HttpRequest<RequestT>)
       Awaitable<void> processOperation(
           ad_utility::url_parser::sparqlOperation::Operation operation,
           VisitorT visitor, const ad_utility::Timer& requestTimer,
           const RequestT& request, ResponseT& send);
   // Do the actual execution of a query.
-  CPP_template_2(typename RequestT, typename ResponseT)(
+  CPP_template(typename RequestT, typename ResponseT)(
       requires ad_utility::httpUtils::HttpRequest<RequestT>)
       Awaitable<void> processQuery(
           const ad_utility::url_parser::ParamValueMap& params,
@@ -164,7 +164,7 @@ class Server {
       const DeltaTriplesCount& countAfter);
   FRIEND_TEST(ServerTest, createResponseMetadata);
   // Do the actual execution of an update.
-  CPP_template_2(typename RequestT, typename ResponseT)(
+  CPP_template(typename RequestT, typename ResponseT)(
       requires ad_utility::httpUtils::HttpRequest<RequestT>)
       Awaitable<void> processUpdate(
           ParsedQuery&& update, const ad_utility::Timer& requestTimer,
@@ -175,8 +175,8 @@ class Server {
   // Determine the media type to be used for the result. The media type is
   // determined (in this order) by the current action (e.g.,
   // "action=csv_export") and by the "Accept" header of the request.
-  CPP_template_2(typename RequestT)(requires ad_utility::httpUtils::HttpRequest<
-                                    RequestT>) static ad_utility::MediaType
+  CPP_template(typename RequestT)(requires ad_utility::httpUtils::HttpRequest<
+                                  RequestT>) static ad_utility::MediaType
       determineMediaType(const ad_utility::url_parser::ParamValueMap& params,
                          const RequestT& request);
   FRIEND_TEST(ServerTest, determineMediaType);
@@ -197,7 +197,7 @@ class Server {
       const ad_utility::Timer& requestTimer, TimeLimit timeLimit,
       QueryExecutionContext& qec, SharedCancellationHandle handle);
   // Creates a `MessageSender` for the given operation.
-  CPP_template_2(typename RequestT)(
+  CPP_template(typename RequestT)(
       requires ad_utility::httpUtils::HttpRequest<RequestT>)
       ad_utility::websocket::MessageSender createMessageSender(
           const std::weak_ptr<ad_utility::websocket::QueryHub>& queryHub,
@@ -235,7 +235,7 @@ class Server {
   ///
   /// \return An OwningQueryId object. It removes itself from the registry
   ///         on destruction.
-  CPP_template_2(typename RequestT)(
+  CPP_template(typename RequestT)(
       requires ad_utility::httpUtils::HttpRequest<RequestT>)
       ad_utility::websocket::OwningQueryId
       getQueryId(const RequestT& request, std::string_view query);
@@ -272,7 +272,7 @@ class Server {
   /// lower than the server default. Return an empty optional and send a 403
   /// Forbidden HTTP response if the change is not allowed. Return the new
   /// timeout otherwise.
-  CPP_template_2(typename RequestT, typename ResponseT)(
+  CPP_template(typename RequestT, typename ResponseT)(
       requires ad_utility::httpUtils::HttpRequest<RequestT>) boost::asio::
       awaitable<std::optional<Server::TimeLimit>> verifyUserSubmittedQueryTimeout(
           std::optional<std::string_view> userTimeout, bool accessTokenOk,
@@ -280,7 +280,7 @@ class Server {
 
   /// Send response for the streamable media types (tsv, csv, octet-stream,
   /// turtle, sparqlJson, qleverJson).
-  CPP_template_2(typename RequestT, typename ResponseT)(
+  CPP_template(typename RequestT, typename ResponseT)(
       requires ad_utility::httpUtils::HttpRequest<RequestT>)
       Awaitable<void> sendStreamableResponse(
           const RequestT& request, ResponseT& send,

--- a/src/index/VocabularyMergerImpl.h
+++ b/src/index/VocabularyMergerImpl.h
@@ -146,7 +146,7 @@ auto VocabularyMerger::mergeVocabulary(const std::string& basename,
 
 // ________________________________________________________________________________
 CPP_template_def(typename C, typename L)(
-    requires WordCallback<C> CPP_and
+    requires WordCallback<C> CPP_and_def
         ranges::predicate<L, TripleComponentWithIndex,
                           TripleComponentWithIndex>) void VocabularyMerger::
     writeQueueWordsToIdVec(const std::vector<QueueWord>& buffer,

--- a/test/index/vocabulary/CompressedVocabularyTest.cpp
+++ b/test/index/vocabulary/CompressedVocabularyTest.cpp
@@ -89,9 +89,9 @@ using Compressors =
                      PrefixCompressionWrapper, DummyCompressionWrapper>;
 
 // _________________________________________________________________________
-CPP_template(typename Compressor)(
-    requires ad_utility::vocabulary::CompressionWrapper<
-        Compressor>) struct CompressedVocabularyF : public testing::Test {
+template <typename Compressor>
+struct CompressedVocabularyF : public testing::Test {
+  static_assert(ad_utility::vocabulary::CompressionWrapper<Compressor>);
   // Tests for the FSST-compressed vocabulary. These use the generic testing
   // framework that was set up for all the other vocabularies.
   static constexpr auto createCompressedVocabulary(


### PR DESCRIPTION
Clang-16 is not compatible with `std::ranges::join_view` from `libstdc++-14`, which is used by Ubuntu 24.04 by default. 