### PR TITLE
Fix edge case in lazy join implementation

### DIFF
--- a/src/util/JoinAlgorithms/JoinAlgorithms.h
+++ b/src/util/JoinAlgorithms/JoinAlgorithms.h
@@ -989,7 +989,11 @@ CPP_template(typename LeftSide, typename RightSide, typename LessThan,
     // reason.
     auto [begin, end] = std::equal_range(
         last.subrange().begin(), last.subrange().end(), currentEl, lessThan_);
-    last.setSubrange(begin, end);
+    if (begin == end) {
+      result.pop_back();
+    } else {
+      last.setSubrange(begin, end);
+    }
     return result;
   }
 
@@ -1188,15 +1192,23 @@ CPP_template(typename LeftSide, typename RightSide, typename LessThan,
     auto equalToCurrentElRight =
         getEqualToCurrentEl(currentBlocksRight, currentEl);
 
-    auto getNextBlocks = [this, &currentEl, &blockStatus](Blocks& target,
-                                                          Side& side) {
-      // Explicit this to avoid false positive warning in clang.
-      this->removeEqualToCurrentEl(side.currentBlocks_, currentEl);
-      bool allBlocksWereFilled = fillEqualToCurrentEl(side, currentEl);
+    // Remove all elements at the beginning of `blocks` that are equal to
+    // `currentEl`. This always has to be called for blocks that have been
+    // completely processed.
+    auto removeEqual = [this, &currentEl](auto& blocks) {
+      if (!blocks.empty()) {
+        // Explicit this to avoid false positive warning in clang.
+        this->removeEqualToCurrentEl(blocks, currentEl);
+      }
+    };
+    auto getNextBlocks = [this, &currentEl, &blockStatus, &removeEqual](
+                             Blocks& target, Side& side) {
+      removeEqual(side.currentBlocks_);
+      bool allBlocksWereFilled = this->fillEqualToCurrentEl(side, currentEl);
       if (side.currentBlocks_.empty()) {
         AD_CORRECTNESS_CHECK(allBlocksWereFilled);
       }
-      target = getEqualToCurrentEl(side.currentBlocks_, currentEl);
+      target = this->getEqualToCurrentEl(side.currentBlocks_, currentEl);
       if (allBlocksWereFilled) {
         blockStatus = BlockStatus::allFilled;
       }
@@ -1204,15 +1216,27 @@ CPP_template(typename LeftSide, typename RightSide, typename LessThan,
 
     // We are only guaranteed to have all relevant blocks from one side, so we
     // also need to pass through the remaining blocks from the other side.
-    while (!equalToCurrentElLeft.empty() && !equalToCurrentElRight.empty()) {
+    while (true) {
       joinWithUndefBlocks(blockStatus, equalToCurrentElLeft,
                           equalToCurrentElRight);
-      addAll<DoOptionalJoin>(equalToCurrentElLeft, equalToCurrentElRight);
+      bool allFilled = blockStatus == BlockStatus::allFilled;
+      bool emptyInput =
+          equalToCurrentElLeft.empty() || equalToCurrentElRight.empty();
+      if (!emptyInput) {
+        // TODO<RobinTF> The optional join handling seems to be strange in the
+        // `addAll` function. If it is required in the case of no matching right
+        // blocks, then it might be broken for many consecutive empty blocks. If
+        // it is not required, then it doesn't have to be part of this logic.
+        addAll<DoOptionalJoin>(equalToCurrentElLeft, equalToCurrentElRight);
+      }
+      if (allFilled || emptyInput) {
+        AD_CORRECTNESS_CHECK(allFilled);
+        // Before returning we have to remove the equal elements in all cases.
+        removeEqual(currentBlocksLeft);
+        removeEqual(currentBlocksRight);
+        return;
+      }
       switch (blockStatus) {
-        case BlockStatus::allFilled:
-          removeEqualToCurrentEl(currentBlocksLeft, currentEl);
-          removeEqualToCurrentEl(currentBlocksRight, currentEl);
-          return;
         case BlockStatus::rightMissing:
           getNextBlocks(equalToCurrentElRight, rightSide_);
           continue;
@@ -1222,19 +1246,6 @@ CPP_template(typename LeftSide, typename RightSide, typename LessThan,
         default:
           AD_FAIL();
       }
-    }
-    // Handle the case where status `leftMissing`/`rightMissing` turned into
-    // `allFilled` because the current element does not exist in the next block
-    // and therefore the loop ends without clearing equivalent elements on the
-    // respective other side.
-    AD_CORRECTNESS_CHECK(blockStatus == BlockStatus::allFilled);
-    joinWithUndefBlocks(blockStatus, equalToCurrentElLeft,
-                        equalToCurrentElRight);
-    if (!currentBlocksLeft.empty()) {
-      removeEqualToCurrentEl(currentBlocksLeft, currentEl);
-    }
-    if (!currentBlocksRight.empty()) {
-      removeEqualToCurrentEl(currentBlocksRight, currentEl);
     }
   }
 

--- a/test/JoinAlgorithmsTest.cpp
+++ b/test/JoinAlgorithmsTest.cpp
@@ -208,6 +208,67 @@ TEST(JoinAlgorithms, JoinWithBlocksMultipleBlocksPerElementBothSides) {
   testOptionalJoin(a, b, expectedResult);
 }
 
+// Regression tests for https://github.com/ad-freiburg/qlever/issues/2051
+TEST(JoinAlgorithms, JoinWithEquivalentValuesOverMultipleEnclosedBlocks) {
+  // The number of equivalent blocks is based on this constant in the code.
+  static_assert(ad_utility::detail::FETCH_BLOCKS == 3);
+  {
+    NestedBlock a{{{1, 10}}, {{1, 11}}, {{1, 12}}, {{1, 13}}, {{2, 20}}};
+    NestedBlock b{{{1, 100}}, {{1, 101}}, {{1, 102}}};
+    std::vector<std::array<size_t, 3>> expectedResult{
+        {1, 10, 100}, {1, 10, 101}, {1, 10, 102}, {1, 11, 100},
+        {1, 11, 101}, {1, 11, 102}, {1, 12, 100}, {1, 12, 101},
+        {1, 12, 102}, {1, 13, 100}, {1, 13, 101}, {1, 13, 102},
+    };
+    testJoin(a, b, expectedResult);
+  }
+  {
+    NestedBlock a{{{1, 10}}, {{1, 11}}, {{1, 12}}, {{1, 13}}, {{2, 20}}};
+    NestedBlock b{{{1, 100}}, {{1, 101}}};
+    std::vector<std::array<size_t, 3>> expectedResult{
+        {1, 10, 100}, {1, 10, 101}, {1, 11, 100}, {1, 11, 101},
+        {1, 12, 100}, {1, 12, 101}, {1, 13, 100}, {1, 13, 101}};
+    testJoin(a, b, expectedResult);
+  }
+  {
+    NestedBlock a{{{1, 10}}, {{1, 11}}, {{1, 12}}, {{1, 13}}, {{2, 20}}};
+    NestedBlock b{{{1, 100}}, {{1, 101}}, {{1, 102}, {3, 300}}};
+    std::vector<std::array<size_t, 3>> expectedResult{
+        {1, 10, 100}, {1, 10, 101}, {1, 10, 102}, {1, 11, 100},
+        {1, 11, 101}, {1, 11, 102}, {1, 12, 100}, {1, 12, 101},
+        {1, 12, 102}, {1, 13, 100}, {1, 13, 101}, {1, 13, 102}};
+    testJoin(a, b, expectedResult);
+  }
+  {
+    NestedBlock a{{{1, 10}}, {{1, 11}}, {{1, 12}}, {{1, 13}}, {{2, 20}}};
+    NestedBlock b{{{1, 100}}, {{1, 101}}, {{3, 300}}};
+    std::vector<std::array<size_t, 3>> expectedResult{
+        {1, 10, 100}, {1, 10, 101}, {1, 11, 100}, {1, 11, 101},
+        {1, 12, 100}, {1, 12, 101}, {1, 13, 100}, {1, 13, 101}};
+    testJoin(a, b, expectedResult);
+  }
+  {
+    NestedBlock a{{{1, 10}}, {{1, 11}}, {{1, 12}}, {{1, 13}}, {{2, 20}}};
+    NestedBlock b{{{1, 100}}, {{1, 101}}, {{1, 102}}, {{1, 103}}};
+    std::vector<std::array<size_t, 3>> expectedResult{
+        {1, 10, 100}, {1, 10, 101}, {1, 10, 102}, {1, 10, 103},
+        {1, 11, 100}, {1, 11, 101}, {1, 11, 102}, {1, 11, 103},
+        {1, 12, 100}, {1, 12, 101}, {1, 12, 102}, {1, 12, 103},
+        {1, 13, 100}, {1, 13, 101}, {1, 13, 102}, {1, 13, 103}};
+    testJoin(a, b, expectedResult);
+  }
+  {
+    NestedBlock a{{{1, 10}}, {{1, 11}}, {{1, 12}}, {{1, 13}}, {{2, 20}}};
+    NestedBlock b{{{1, 100}}, {{1, 101}}, {{1, 102}}, {{1, 103}}, {{1, 104}}};
+    std::vector<std::array<size_t, 3>> expectedResult{
+        {1, 10, 100}, {1, 10, 101}, {1, 10, 102}, {1, 10, 103}, {1, 10, 104},
+        {1, 11, 100}, {1, 11, 101}, {1, 11, 102}, {1, 11, 103}, {1, 11, 104},
+        {1, 12, 100}, {1, 12, 101}, {1, 12, 102}, {1, 12, 103}, {1, 12, 104},
+        {1, 13, 100}, {1, 13, 101}, {1, 13, 102}, {1, 13, 103}, {1, 13, 104}};
+    testJoin(a, b, expectedResult);
+  }
+}
+
 namespace {
 
 // Replacement for `Id`, but with an additional tag to distinguish between ids


### PR DESCRIPTION
The edge case could happen for index scans involving large relations that span over multiple blocks and end directly on a block boundary in the lazy join. When it happened, it triggered an assertion failure. This is now fixed and regression tests were added. Fixes #2051