### PR TITLE
Update augmented metadata once per operation, not once per triple

### DIFF
--- a/src/index/DeltaTriples.cpp
+++ b/src/index/DeltaTriples.cpp
@@ -158,6 +158,7 @@ void DeltaTriples::modifyTriplesImpl(CancellationHandle cancellationHandle,
   std::erase_if(triples, [&targetMap](const IdTriple<0>& triple) {
     return targetMap.contains(triple);
   });
+  // `eraseTripleInAllPermutations` does not update the block metadata.
   ql::ranges::for_each(triples, [this, &inverseMap](const IdTriple<0>& triple) {
     auto handle = inverseMap.find(triple);
     if (handle != inverseMap.end()) {
@@ -165,6 +166,10 @@ void DeltaTriples::modifyTriplesImpl(CancellationHandle cancellationHandle,
       inverseMap.erase(triple);
     }
   });
+  // After erasing the triples update the block metadate for all permutations.
+  for (auto permutation : Permutation::ALL) {
+    locatedTriples()[static_cast<int>(permutation)].updateAugmentedMetadata();
+  }
 
   std::vector<LocatedTripleHandles> handles =
       locateAndAddTriples(std::move(cancellationHandle), triples, shouldExist);

--- a/src/index/DeltaTriples.cpp
+++ b/src/index/DeltaTriples.cpp
@@ -158,7 +158,6 @@ void DeltaTriples::modifyTriplesImpl(CancellationHandle cancellationHandle,
   std::erase_if(triples, [&targetMap](const IdTriple<0>& triple) {
     return targetMap.contains(triple);
   });
-  // `eraseTripleInAllPermutations` does not update the block metadata.
   ql::ranges::for_each(triples, [this, &inverseMap](const IdTriple<0>& triple) {
     auto handle = inverseMap.find(triple);
     if (handle != inverseMap.end()) {
@@ -166,10 +165,10 @@ void DeltaTriples::modifyTriplesImpl(CancellationHandle cancellationHandle,
       inverseMap.erase(triple);
     }
   });
-  // After erasing the triples update the block metadate for all permutations.
-  for (auto permutation : Permutation::ALL) {
-    locatedTriples()[static_cast<int>(permutation)].updateAugmentedMetadata();
-  }
+  // Manually update the block metadata, because `eraseTripleInAllPermutations`
+  // does not update them for performance reason.
+  ql::ranges::for_each(locatedTriples(),
+                       &LocatedTriplesPerBlock::updateAugmentedMetadata);
 
   std::vector<LocatedTripleHandles> handles =
       locateAndAddTriples(std::move(cancellationHandle), triples, shouldExist);

--- a/src/index/LocatedTriples.cpp
+++ b/src/index/LocatedTriples.cpp
@@ -242,7 +242,6 @@ void LocatedTriplesPerBlock::erase(size_t blockIndex,
   if (block.empty()) {
     map_.erase(blockIndex);
   }
-  updateAugmentedMetadata();
 }
 
 // ____________________________________________________________________________

--- a/src/index/LocatedTriples.h
+++ b/src/index/LocatedTriples.h
@@ -150,6 +150,10 @@ class LocatedTriplesPerBlock {
   std::vector<LocatedTriples::iterator> add(
       ql::span<const LocatedTriple> locatedTriples);
 
+  // Removes the given `LocatedTriple` from the `LocatedTriplesPerBlock`.
+  //
+  // NOTE: `updateAugmentedMetadata()` must be called to update the block
+  // metadata.
   void erase(size_t blockIndex, LocatedTriples::iterator iter);
 
   // Get the total number of `LocatedTriple`s (for all blocks).

--- a/test/LocatedTriplesTest.cpp
+++ b/test/LocatedTriplesTest.cpp
@@ -163,6 +163,7 @@ TEST_F(LocatedTriplesTest, numTriplesInBlock) {
                                  {4, {LT6, LT7, LT9}}}));
 
   locatedTriplesPerBlock.erase(3, handles[0]);
+  locatedTriplesPerBlock.updateAugmentedMetadata();
 
   EXPECT_THAT(locatedTriplesPerBlock, numBlocks(3));
   EXPECT_THAT(locatedTriplesPerBlock, numTriplesTotal(8));
@@ -177,6 +178,7 @@ TEST_F(LocatedTriplesTest, numTriplesInBlock) {
   // Erasing in a block that does not exist, raises an exception.
   EXPECT_THROW(locatedTriplesPerBlock.erase(100, handles[1]),
                ad_utility::Exception);
+  locatedTriplesPerBlock.updateAugmentedMetadata();
 
   // Nothing changed.
   EXPECT_THAT(locatedTriplesPerBlock, numBlocks(3));
@@ -190,6 +192,7 @@ TEST_F(LocatedTriplesTest, numTriplesInBlock) {
           {{1, {LT1, LT2, LT3}}, {2, {LT4, LT5}}, {4, {LT6, LT7, LT9}}}));
 
   locatedTriplesPerBlock.erase(4, handles[1]);
+  locatedTriplesPerBlock.updateAugmentedMetadata();
 
   EXPECT_THAT(locatedTriplesPerBlock, numBlocks(3));
   EXPECT_THAT(locatedTriplesPerBlock, numTriplesTotal(7));
@@ -787,6 +790,7 @@ TEST_F(LocatedTriplesTest, augmentedMetadata) {
 
     // Erasing the update of T4 restores the beginning of block 4.
     locatedTriplesPerBlock.erase(4, handles[0]);
+    locatedTriplesPerBlock.updateAugmentedMetadata();
 
     expectedAugmentedMetadata[4] = CBM(PT8, PT8);
     // The block 4 has no more updates, so we restore the info about the block


### PR DESCRIPTION
So far, the (rather expensive) `updateAugmentedMetadata` was called after each single triple that was erased as part of an update operation. Now there is only one such call after erasing all triples of the operation.