### PR TITLE
Add `PolymorphicVocabulary` class with unit tests

### DIFF
--- a/src/index/vocabulary/CMakeLists.txt
+++ b/src/index/vocabulary/CMakeLists.txt
@@ -1,4 +1,4 @@
 add_library(vocabulary VocabularyInMemory.h VocabularyInMemory.cpp
                        VocabularyInMemoryBinSearch.cpp VocabularyInternalExternal.cpp
-                       VocabularyOnDisk.cpp)
+                       VocabularyOnDisk.cpp PolymorphicVocabulary.cpp )
 qlever_target_link_libraries(vocabulary)

--- a/src/index/vocabulary/CompressedVocabulary.h
+++ b/src/index/vocabulary/CompressedVocabulary.h
@@ -120,15 +120,13 @@ CPP_template(typename UnderlyingVocabulary,
 
   /// Allows the incremental writing of the words to disk. Uses `WordWriter` of
   /// the underlying vocabulary.
-  class DiskWriterFromUncompressedWords {
+  class DiskWriterFromUncompressedWords : public WordWriterBase {
    private:
     std::vector<std::string> wordBuffer_;
     std::vector<bool> isExternalBuffer_;
     std::vector<typename CompressionWrapper::Decoder> decoders_;
     typename UnderlyingVocabulary::WordWriter underlyingWriter_;
     std::string filenameDecoders_;
-    std::string readableName_ = "";
-    bool isFinished_ = false;
     ad_utility::MemorySize uncompressedSize_ = bytes(0);
     ad_utility::MemorySize compressedSize_ = bytes(0);
     size_t numBlocks_ = 0u;
@@ -153,8 +151,7 @@ CPP_template(typename UnderlyingVocabulary,
 
     /// Compress the `uncompressedWord` and write it to disk.
     uint64_t operator()(std::string_view uncompressedWord,
-                        bool isExternal = false) {
-      AD_CORRECTNESS_CHECK(!isFinished_);
+                        bool isExternal) override {
       wordBuffer_.emplace_back(uncompressedWord);
       isExternalBuffer_.push_back(isExternal);
       if (wordBuffer_.size() == NumWordsPerBlock) {
@@ -163,14 +160,12 @@ CPP_template(typename UnderlyingVocabulary,
       return counter_++;
     }
 
+   private:
     /// Dump all the words that still might be contained in intermediate buffers
     /// to the underlying file and close the file. After calls to `finish()` no
     /// more words can be pushed. `finish()` is implicitly also called by the
     /// destructor.
-    void finish() {
-      if (std::exchange(isFinished_, true)) {
-        return;
-      }
+    void finishImpl() override {
       finishBlock();
       compressQueue_.finish();
       writeQueue_.finish();
@@ -184,7 +179,7 @@ CPP_template(typename UnderlyingVocabulary,
           (100ULL * std::max(compressedSize_.getBytes(), size_t(1))) /
           std::max(uncompressedSize_.getBytes(), size_t(1));
       std::string nameString =
-          readableName_.empty() ? std::string{"vocabulary"} : readableName_;
+          readableName().empty() ? std::string{"vocabulary"} : readableName();
       LOG(INFO) << "Finished writing compressed " << nameString
                 << ", size = " << compressedSize_
                 << " [uncompressed = " << uncompressedSize_
@@ -197,16 +192,7 @@ CPP_template(typename UnderlyingVocabulary,
       }
     }
 
-    // Access the human-readable description for the vocabulary to be written
-    // that will be used in log message.
-    std::string& readableName() { return readableName_; }
-
-    // Call `finish`, does nothing if `finish` has been manually called.
-    ~DiskWriterFromUncompressedWords() noexcept {
-      ad_utility::terminateIfThrows(
-          [this]() { this->finish(); },
-          "The destructor of a DiskWriter of a `CompressedVocabulary`");
-    }
+   public:
     DiskWriterFromUncompressedWords(const DiskWriterFromUncompressedWords&) =
         delete;
     DiskWriterFromUncompressedWords& operator=(

--- a/src/index/vocabulary/CompressedVocabulary.h
+++ b/src/index/vocabulary/CompressedVocabulary.h
@@ -160,6 +160,14 @@ CPP_template(typename UnderlyingVocabulary,
       return counter_++;
     }
 
+    ~DiskWriterFromUncompressedWords() override {
+      if (!finishWasCalled()) {
+        ad_utility::terminateIfThrows([this]() { this->finish(); },
+                                      "Calling `finish` from the destructor of "
+                                      "`DiskWriterFromUncompressedWords`");
+      }
+    }
+
    private:
     /// Dump all the words that still might be contained in intermediate buffers
     /// to the underlying file and close the file. After calls to `finish()` no

--- a/src/index/vocabulary/PolymorphicVocabulary.cpp
+++ b/src/index/vocabulary/PolymorphicVocabulary.cpp
@@ -34,36 +34,18 @@ std::string PolymorphicVocabulary::operator[](uint64_t i) const {
 }
 
 // _____________________________________________________________________________
-PolymorphicVocabulary::WordWriter::WordWriter(WordWriters writer)
-    : writer_(std::move(writer)) {}
-
-// _____________________________________________________________________________
-void PolymorphicVocabulary::WordWriter::finish() {
-  std::visit([](auto& writer) { return writer->finish(); }, writer_);
-}
-
-// _____________________________________________________________________________
-uint64_t PolymorphicVocabulary::WordWriter::operator()(std::string_view word,
-                                                       bool isExternal) {
-  return std::visit(
-      [&word, isExternal](auto& writer) { return (*writer)(word, isExternal); },
-      writer_);
-}
-
-// _____________________________________________________________________________
 auto PolymorphicVocabulary::makeDiskWriterPtr(const std::string& filename) const
-    -> std::unique_ptr<WordWriter> {
-  return std::make_unique<WordWriter>(std::visit(
-      [&filename](auto& vocab) -> WordWriters {
+    -> std::unique_ptr<WordWriterBase> {
+  return std::visit(
+      [&filename](auto& vocab) -> std::unique_ptr<WordWriterBase> {
         return vocab.makeDiskWriterPtr(filename);
       },
-      vocab_));
+      vocab_);
 }
 
 // _____________________________________________________________________________
-std::unique_ptr<PolymorphicVocabulary::WordWriter>
-PolymorphicVocabulary::makeDiskWriterPtr(const std::string& filename,
-                                         VocabularyType type) {
+std::unique_ptr<WordWriterBase> PolymorphicVocabulary::makeDiskWriterPtr(
+    const std::string& filename, VocabularyType type) {
   PolymorphicVocabulary dummyVocab;
   dummyVocab.resetToType(type);
   return dummyVocab.makeDiskWriterPtr(filename);

--- a/src/index/vocabulary/PolymorphicVocabulary.cpp
+++ b/src/index/vocabulary/PolymorphicVocabulary.cpp
@@ -4,7 +4,7 @@
 
 #include "index/vocabulary/PolymorphicVocabulary.h"
 
-#include <engine/CallFixedSize.h>
+#include "engine/CallFixedSize.h"
 
 // _____________________________________________________________________________
 void PolymorphicVocabulary::open(const std::string& filename) {

--- a/src/index/vocabulary/PolymorphicVocabulary.cpp
+++ b/src/index/vocabulary/PolymorphicVocabulary.cpp
@@ -1,0 +1,91 @@
+//  Copyright 2025, University of Freiburg,
+//  Chair of Algorithms and Data Structures.
+//  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+
+#include "index/vocabulary/PolymorphicVocabulary.h"
+
+#include <engine/CallFixedSize.h>
+
+// _____________________________________________________________________________
+void PolymorphicVocabulary::open(const std::string& filename) {
+  std::visit([&filename](auto& vocab) { vocab.open(filename); }, vocab_);
+}
+
+// _____________________________________________________________________________
+void PolymorphicVocabulary::open(const std::string& filename,
+                                 VocabularyType type) {
+  resetToType(type);
+  open(filename);
+}
+
+// _____________________________________________________________________________
+void PolymorphicVocabulary::close() {
+  std::visit([](auto& vocab) { return vocab.close(); }, vocab_);
+}
+
+// _____________________________________________________________________________
+size_t PolymorphicVocabulary::size() const {
+  return std::visit([](auto& vocab) -> size_t { return vocab.size(); }, vocab_);
+}
+
+// _____________________________________________________________________________
+std::string PolymorphicVocabulary::operator[](uint64_t i) const {
+  return std::visit([i](auto& vocab) { return std::string{vocab[i]}; }, vocab_);
+}
+
+// _____________________________________________________________________________
+PolymorphicVocabulary::WordWriter::WordWriter(WordWriters writer)
+    : writer_(std::move(writer)) {}
+
+// _____________________________________________________________________________
+void PolymorphicVocabulary::WordWriter::finish() {
+  std::visit([](auto& writer) { return writer->finish(); }, writer_);
+}
+
+// _____________________________________________________________________________
+uint64_t PolymorphicVocabulary::WordWriter::operator()(std::string_view word,
+                                                       bool isExternal) {
+  return std::visit(
+      [&word, isExternal](auto& writer) { return (*writer)(word, isExternal); },
+      writer_);
+}
+
+// _____________________________________________________________________________
+auto PolymorphicVocabulary::makeDiskWriterPtr(const std::string& filename) const
+    -> std::unique_ptr<WordWriter> {
+  return std::make_unique<WordWriter>(std::visit(
+      [&filename](auto& vocab) -> WordWriters {
+        return vocab.makeDiskWriterPtr(filename);
+      },
+      vocab_));
+}
+
+// _____________________________________________________________________________
+std::unique_ptr<PolymorphicVocabulary::WordWriter>
+PolymorphicVocabulary::makeDiskWriterPtr(const std::string& filename,
+                                         VocabularyType type) {
+  PolymorphicVocabulary dummyVocab;
+  dummyVocab.resetToType(type);
+  return dummyVocab.makeDiskWriterPtr(filename);
+}
+
+// _____________________________________________________________________________
+void PolymorphicVocabulary::resetToType(VocabularyType type) {
+  close();
+  switch (type.value()) {
+    case VocabularyType::Enum::InMemoryUncompressed:
+      vocab_.emplace<InMemory>();
+      break;
+    case VocabularyType::Enum::OnDiskUncompressed:
+      vocab_.emplace<External>();
+      break;
+    case VocabularyType::Enum::InMemoryCompressed:
+      vocab_.emplace<CompressedInMemory>();
+      break;
+    case VocabularyType::Enum::OnDiskCompressed:
+      vocab_.emplace<CompressedExternal>();
+      break;
+    default:
+      AD_FAIL();
+  }
+}

--- a/src/index/vocabulary/PolymorphicVocabulary.cpp
+++ b/src/index/vocabulary/PolymorphicVocabulary.cpp
@@ -54,19 +54,19 @@ std::unique_ptr<WordWriterBase> PolymorphicVocabulary::makeDiskWriterPtr(
 // _____________________________________________________________________________
 void PolymorphicVocabulary::resetToType(VocabularyType type) {
   close();
+  // The names of the enum values are the same as the type aliases for the
+  // implementations, so we can shorten the following code using a macro.
+#undef AD_CASE
+#define AD_CASE(vocabType)              \
+  case VocabularyType::Enum::vocabType: \
+    vocab_.emplace<vocabType>();        \
+    break
+
   switch (type.value()) {
-    case VocabularyType::Enum::InMemoryUncompressed:
-      vocab_.emplace<InMemory>();
-      break;
-    case VocabularyType::Enum::OnDiskUncompressed:
-      vocab_.emplace<External>();
-      break;
-    case VocabularyType::Enum::InMemoryCompressed:
-      vocab_.emplace<CompressedInMemory>();
-      break;
-    case VocabularyType::Enum::OnDiskCompressed:
-      vocab_.emplace<CompressedExternal>();
-      break;
+    AD_CASE(InMemoryUncompressed);
+    AD_CASE(OnDiskUncompressed);
+    AD_CASE(InMemoryCompressed);
+    AD_CASE(OnDiskCompressed);
     default:
       AD_FAIL();
   }

--- a/src/index/vocabulary/PolymorphicVocabulary.h
+++ b/src/index/vocabulary/PolymorphicVocabulary.h
@@ -16,21 +16,6 @@
 #include "index/vocabulary/VocabularyType.h"
 #include "util/json.h"
 
-namespace polymorphic_vocabulary::detail {
-
-// For `T = std::variant<VocabType1, VocabType2, ...` `WriterPointers<T> =
-// std::variant<unique_ptr<VocabType1::WordWriter>,
-// unique_ptr<VocabType2::WordWriter>, ...>`. This is used in the implementation
-// of the `PolymorphicVocabulary` below.
-template <typename T>
-struct WriterPointers {};
-
-template <typename... Vocabs>
-struct WriterPointers<std::variant<Vocabs...>> {
-  using type = std::variant<std::unique_ptr<typename Vocabs::WordWriter>...>;
-};
-}  // namespace polymorphic_vocabulary::detail
-
 // A vocabulary that can at runtime choose between different vocabulary
 // implementations. The only restriction is, that a vocabulary can only be read
 // from disk with the same implementation that it was written to.
@@ -94,10 +79,6 @@ class PolymorphicVocabulary {
         },
         vocab_);
   }
-
-  using WordWriters =
-      polymorphic_vocabulary::detail::WriterPointers<Variant>::type;
-
   // Create a `WordWriter` that will create a vocabulary with the given `type`
   // at the given `filename`.
   static std::unique_ptr<WordWriterBase> makeDiskWriterPtr(

--- a/src/index/vocabulary/PolymorphicVocabulary.h
+++ b/src/index/vocabulary/PolymorphicVocabulary.h
@@ -98,33 +98,14 @@ class PolymorphicVocabulary {
   using WordWriters =
       polymorphic_vocabulary::detail::WriterPointers<Variant>::type;
 
-  // The `WordWriter` is used to write a vocabulary to disk word by word (in
-  // sorted order).
-  class WordWriter {
-    WordWriters writer_;
-    std::string readableName_;
-
-   public:
-    // Constructor, used by the `makeDiskWriter` functions below.
-    explicit WordWriter(WordWriters);
-
-    // This function has to be called after the last word has been written.
-    void finish();
-
-    // Write the next word to the vocabulary.
-    uint64_t operator()(std::string_view word, bool isExternal);
-
-    std::string& readableName() { return readableName_; }
-  };
-
   // Create a `WordWriter` that will create a vocabulary with the given `type`
   // at the given `filename`.
-  static std::unique_ptr<WordWriter> makeDiskWriterPtr(
+  static std::unique_ptr<WordWriterBase> makeDiskWriterPtr(
       const std::string& filename, VocabularyType type);
 
   // Same as above, but the `VocabularyType` is the currently active type of
   // `this`.
-  std::unique_ptr<WordWriter> makeDiskWriterPtr(
+  std::unique_ptr<WordWriterBase> makeDiskWriterPtr(
       const std::string& filename) const;
 };
 

--- a/src/index/vocabulary/PolymorphicVocabulary.h
+++ b/src/index/vocabulary/PolymorphicVocabulary.h
@@ -1,0 +1,131 @@
+//  Copyright 2025, University of Freiburg,
+//  Chair of Algorithms and Data Structures.
+//  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+
+#ifndef QLEVER_SRC_INDEX_VOCABULARY_POLYMORPHICVOCABULARY_H
+#define QLEVER_SRC_INDEX_VOCABULARY_POLYMORPHICVOCABULARY_H
+
+#include <absl/strings/str_cat.h>
+#include <absl/strings/str_join.h>
+
+#include <variant>
+
+#include "index/vocabulary/CompressedVocabulary.h"
+#include "index/vocabulary/VocabularyInMemory.h"
+#include "index/vocabulary/VocabularyInternalExternal.h"
+#include "index/vocabulary/VocabularyType.h"
+#include "util/json.h"
+
+namespace polymorphic_vocabulary::detail {
+
+// For `T = std::variant<VocabType1, VocabType2, ...` `WriterPointers<T> =
+// std::variant<unique_ptr<VocabType1::WordWriter>,
+// unique_ptr<VocabType2::WordWriter>, ...>`. This is used in the implementation
+// of the `PolymorphicVocabulary` below.
+template <typename T>
+struct WriterPointers {};
+
+template <typename... Vocabs>
+struct WriterPointers<std::variant<Vocabs...>> {
+  using type = std::variant<std::unique_ptr<typename Vocabs::WordWriter>...>;
+};
+}  // namespace polymorphic_vocabulary::detail
+
+// A vocabulary that can at runtime choose between different vocabulary
+// implementations. The only restriction is, that a vocabulary can only be read
+// from disk with the same implementation that it was written to.
+class PolymorphicVocabulary {
+ public:
+  using VocabularyType = ad_utility::VocabularyType;
+
+ private:
+  // Type aliases for all the currently supported vocabularies. If another
+  // vocabulary is added, don't forget to also register it in the
+  // `VocabularyType` enum.
+  using InMemory = VocabularyInMemory;
+  using External = VocabularyInternalExternal;
+  using CompressedInMemory = CompressedVocabulary<InMemory>;
+  using CompressedExternal = CompressedVocabulary<External>;
+  using Variant =
+      std::variant<InMemory, External, CompressedExternal, CompressedInMemory>;
+
+  // In this variant we store the actual vocabulary.
+  Variant vocab_;
+
+ public:
+  // Read a vocabulary with the given `type` from the file with the `filename`.
+  // A vocabulary with the corresponding `type` must have been previously
+  // written to that file.
+  void open(const std::string& filename, VocabularyType type);
+
+  // Close the vocabulary if it is open, and set the underlying vocabulary
+  // implementation according to the `type` without opening the vocabulary.
+  void resetToType(VocabularyType type);
+
+  // Same as the overload of `open` above, but expects that the correct
+  // `VocabularyType` has already been set via `resetToType` above.
+  void open(const std::string& filename);
+
+  // Close the vocabulary s.t. it consumes no more RAM.
+  void close();
+
+  // Return the total number of words in the vocabulary.
+  size_t size() const;
+
+  // Return the `i`-the word, throw of `i` is out of bounds.
+  std::string operator[](uint64_t i) const;
+
+  // Same as `std::lower_bound`, return the smallest entry >= `word`.
+  template <typename String, typename Comp>
+  WordAndIndex lower_bound(const String& word, Comp comp) const {
+    return std::visit(
+        [&word, &comp](auto& vocab) {
+          return vocab.lower_bound(word, std::move(comp));
+        },
+        vocab_);
+  }
+
+  // Analogous to `lower_bound` (see above).
+  template <typename String, typename Comp>
+  WordAndIndex upper_bound(const String& word, Comp comp) const {
+    return std::visit(
+        [&word, &comp](auto& vocab) {
+          return vocab.upper_bound(word, std::move(comp));
+        },
+        vocab_);
+  }
+
+  using WordWriters =
+      polymorphic_vocabulary::detail::WriterPointers<Variant>::type;
+
+  // The `WordWriter` is used to write a vocabulary to disk word by word (in
+  // sorted order).
+  class WordWriter {
+    WordWriters writer_;
+    std::string readableName_;
+
+   public:
+    // Constructor, used by the `makeDiskWriter` functions below.
+    explicit WordWriter(WordWriters);
+
+    // This function has to be called after the last word has been written.
+    void finish();
+
+    // Write the next word to the vocabulary.
+    uint64_t operator()(std::string_view word, bool isExternal);
+
+    std::string& readableName() { return readableName_; }
+  };
+
+  // Create a `WordWriter` that will create a vocabulary with the given `type`
+  // at the given `filename`.
+  static std::unique_ptr<WordWriter> makeDiskWriterPtr(
+      const std::string& filename, VocabularyType type);
+
+  // Same as above, but the `VocabularyType` is the currently active type of
+  // `this`.
+  std::unique_ptr<WordWriter> makeDiskWriterPtr(
+      const std::string& filename) const;
+};
+
+#endif  // QLEVER_SRC_INDEX_VOCABULARY_POLYMORPHICVOCABULARY_H

--- a/src/index/vocabulary/PolymorphicVocabulary.h
+++ b/src/index/vocabulary/PolymorphicVocabulary.h
@@ -24,15 +24,20 @@ class PolymorphicVocabulary {
   using VocabularyType = ad_utility::VocabularyType;
 
  private:
-  // Type aliases for all the currently supported vocabularies. If another
-  // vocabulary is added, don't forget to also register it in the
-  // `VocabularyType` enum.
-  using InMemory = VocabularyInMemory;
-  using External = VocabularyInternalExternal;
-  using CompressedInMemory = CompressedVocabulary<InMemory>;
-  using CompressedExternal = CompressedVocabulary<External>;
-  using Variant =
-      std::variant<InMemory, External, CompressedExternal, CompressedInMemory>;
+  // Type aliases for all the currently supported vocabularies. To add another
+  // vocabulary,
+  // 1. Add an enum value to the `VocabularyTypeEnum`.
+  // 2. Add an alias below for the vocabulary that has the same name as the enum
+  // value.
+  // 3. Add the alias type to the `Variant` below.
+  // 4. Add the corresponding line to the `resetToType` function in
+  // `PolymorphicVocabulary.cpp`.
+  using InMemoryUncompressed = VocabularyInMemory;
+  using OnDiskUncompressed = VocabularyInternalExternal;
+  using InMemoryCompressed = CompressedVocabulary<InMemoryUncompressed>;
+  using OnDiskCompressed = CompressedVocabulary<OnDiskUncompressed>;
+  using Variant = std::variant<InMemoryUncompressed, OnDiskUncompressed,
+                               OnDiskCompressed, InMemoryCompressed>;
 
   // In this variant we store the actual vocabulary.
   Variant vocab_;

--- a/src/index/vocabulary/PolymorphicVocabulary.h
+++ b/src/index/vocabulary/PolymorphicVocabulary.h
@@ -72,7 +72,7 @@ class PolymorphicVocabulary {
   // Return the total number of words in the vocabulary.
   size_t size() const;
 
-  // Return the `i`-the word, throw of `i` is out of bounds.
+  // Return the `i`-th word, throw if `i` is out of bounds.
   std::string operator[](uint64_t i) const;
 
   // Same as `std::lower_bound`, return the smallest entry >= `word`.

--- a/src/index/vocabulary/VocabularyInMemory.h
+++ b/src/index/vocabulary/VocabularyInMemory.h
@@ -78,6 +78,14 @@ class VocabularyInMemory
       return index_++;
     }
 
+    ~WordWriter() override {
+      if (!finishWasCalled()) {
+        ad_utility::terminateIfThrows([this]() { this->finish(); },
+                                      "Calling `finish` from the destructor of "
+                                      "`VocabularyInMemory::WordWriter`");
+      }
+    }
+
    private:
     void finishImpl() override { writer_.finish(); }
   };

--- a/src/index/vocabulary/VocabularyInMemory.h
+++ b/src/index/vocabulary/VocabularyInMemory.h
@@ -67,20 +67,19 @@ class VocabularyInMemory
   /// A helper type that can be used to directly write a vocabulary to disk
   /// word-by-word, without having to materialize it in RAM first. See the
   /// documentation of `CompactVectorOfStrings` for details.
-  struct WordWriter {
+  struct WordWriter : public WordWriterBase {
     typename Words::Writer writer_;
     uint64_t index_ = 0;
-    std::string readableName_ = "";
 
     explicit WordWriter(const std::string& filename) : writer_{filename} {}
     uint64_t operator()(std::string_view str,
-                        [[maybe_unused]] bool isExternalDummy = false) {
+                        [[maybe_unused]] bool isExternalDummy) override {
       writer_.push(str.data(), str.size());
       return index_++;
     }
 
-    void finish() { writer_.finish(); }
-    std::string& readableName() { return readableName_; }
+   private:
+    void finishImpl() override { writer_.finish(); }
   };
 
   // Return a `unique_ptr<WordWriter>` that directly writes the words to the

--- a/src/index/vocabulary/VocabularyInternalExternal.cpp
+++ b/src/index/vocabulary/VocabularyInternalExternal.cpp
@@ -39,6 +39,15 @@ void VocabularyInternalExternal::WordWriter::finishImpl() {
 }
 
 // _____________________________________________________________________________
+VocabularyInternalExternal::WordWriter::~WordWriter() {
+  if (!finishWasCalled()) {
+    ad_utility::terminateIfThrows([this]() { this->finish(); },
+                                  "Calling `finish` from the destructor of "
+                                  "`VocabularyInternalExternal::WordWriter`");
+  }
+}
+
+// _____________________________________________________________________________
 void VocabularyInternalExternal::open(const string& filename) {
   internalVocab_.open(filename + ".internal");
   externalVocab_.open(filename + ".external");

--- a/src/index/vocabulary/VocabularyInternalExternal.cpp
+++ b/src/index/vocabulary/VocabularyInternalExternal.cpp
@@ -23,7 +23,7 @@ VocabularyInternalExternal::WordWriter::WordWriter(const std::string& filename,
 // _____________________________________________________________________________
 uint64_t VocabularyInternalExternal::WordWriter::operator()(
     std::string_view str, bool isExternal) {
-  externalWriter_(str);
+  externalWriter_(str, true);
   if (!isExternal || sinceMilestone_ >= milestoneDistance_ || idx_ == 0) {
     internalWriter_(str, idx_);
     sinceMilestone_ = 0;
@@ -33,7 +33,7 @@ uint64_t VocabularyInternalExternal::WordWriter::operator()(
 }
 
 // _____________________________________________________________________________
-void VocabularyInternalExternal::WordWriter::finish() {
+void VocabularyInternalExternal::WordWriter::finishImpl() {
   internalWriter_.finish();
   externalWriter_.finish();
 }

--- a/src/index/vocabulary/VocabularyInternalExternal.h
+++ b/src/index/vocabulary/VocabularyInternalExternal.h
@@ -95,13 +95,12 @@ class VocabularyInternalExternal {
 
   /// A helper type that can be used to directly write a vocabulary to disk
   /// word-by-word, without having to materialize it in RAM first.
-  struct WordWriter {
+  struct WordWriter : public WordWriterBase {
     VocabularyInMemoryBinSearch::WordWriter internalWriter_;
     VocabularyOnDisk::WordWriter externalWriter_;
     uint64_t idx_ = 0;
     size_t milestoneDistance_;
     size_t sinceMilestone_ = 0;
-    std::string readableName_ = "";
 
     // Construct from the `filename` to which the vocabulary will be serialized.
     // At least every `milestoneDistance`-th word will be cached in RAM.
@@ -110,12 +109,10 @@ class VocabularyInternalExternal {
 
     // Add the next word. If `isExternal` is true, then the word will only be
     // stored on disk, and not be cached in RAM.
-    uint64_t operator()(std::string_view word, bool isExternal = true);
+    uint64_t operator()(std::string_view word, bool isExternal) override;
 
     // Finish writing.
-    void finish();
-
-    std::string& readableName() { return readableName_; }
+    void finishImpl() override;
   };
 
   // Return a `unique_ptr<WordWriter>` that writes to the given `filename`.

--- a/src/index/vocabulary/VocabularyInternalExternal.h
+++ b/src/index/vocabulary/VocabularyInternalExternal.h
@@ -111,6 +111,8 @@ class VocabularyInternalExternal {
     // stored on disk, and not be cached in RAM.
     uint64_t operator()(std::string_view word, bool isExternal) override;
 
+    ~WordWriter() override;
+
     // Finish writing.
     void finishImpl() override;
   };

--- a/src/index/vocabulary/VocabularyOnDisk.cpp
+++ b/src/index/vocabulary/VocabularyOnDisk.cpp
@@ -78,6 +78,15 @@ void VocabularyOnDisk::WordWriter::finishImpl() {
 }
 
 // _____________________________________________________________________________
+VocabularyOnDisk::WordWriter::~WordWriter() {
+  if (!finishWasCalled()) {
+    ad_utility::terminateIfThrows([this]() { this->finish(); },
+                                  "Calling `finish` from the destructor of "
+                                  "`VocabularyOnDisk::WordWriter`");
+  }
+}
+
+// _____________________________________________________________________________
 void VocabularyOnDisk::buildFromStringsAndIds(
     const std::vector<std::pair<std::string, uint64_t>>& wordsAndIds,
     const std::string& fileName) {

--- a/src/index/vocabulary/VocabularyOnDisk.cpp
+++ b/src/index/vocabulary/VocabularyOnDisk.cpp
@@ -69,21 +69,12 @@ uint64_t VocabularyOnDisk::WordWriter::operator()(
 }
 
 // _____________________________________________________________________________
-void VocabularyOnDisk::WordWriter::finish() {
-  if (std::exchange(isFinished_, true)) {
-    return;
-  }
+void VocabularyOnDisk::WordWriter::finishImpl() {
   // End offset of last vocabulary entry, also consistent with the empty
   // vocabulary.
   offsets_.push_back(currentOffset_);
   file_.close();
   offsets_.close();
-}
-
-// _____________________________________________________________________________
-VocabularyOnDisk::WordWriter::~WordWriter() {
-  throwInDestructorIfSafe_([this]() { finish(); },
-                           "`~VocabularyOnDisk::WordWriter`");
 }
 
 // _____________________________________________________________________________

--- a/src/index/vocabulary/VocabularyOnDisk.h
+++ b/src/index/vocabulary/VocabularyOnDisk.h
@@ -41,26 +41,21 @@ class VocabularyOnDisk : public VocabularyBinarySearchMixin<VocabularyOnDisk> {
   // At the end, the `finish()` method can be called. Note that `finish`
   // is also implicitly called by the destructor, but doing so implicitly
   // releases resources earlier and is cleaner in case of exceptions.
-  class WordWriter {
+  class WordWriter : public WordWriterBase {
    private:
     ad_utility::File file_;
     ad_utility::MmapVector<Offset> offsets_;
     uint64_t currentOffset_ = 0;
-    bool isFinished_ = false;
-    ad_utility::ThrowInDestructorIfSafe throwInDestructorIfSafe_;
-    std::string readableName_ = "";
 
    public:
     // Constructor, used by `VocabularyOnDisk::wordWriter`.
     explicit WordWriter(const std::string& filename);
     // Add the next word to the vocabulary and return its index.
-    uint64_t operator()(std::string_view word, bool isExternalDummy = true);
-    // Finish the writing. After this no more calls to `operator()` are allowed.
-    void finish();
-    // Destructor. Implicitly calls `finish` if it hasn't been called before.
-    ~WordWriter();
+    uint64_t operator()(std::string_view word, bool isExternalDummy) override;
 
-    std::string& readableName() { return readableName_; }
+   private:
+    // Finish the writing. After this no more calls to `operator()` are allowed.
+    void finishImpl() override;
   };
 
   /// Build from a vector of pairs of `(string, id)`. This requires the IDs to

--- a/src/index/vocabulary/VocabularyOnDisk.h
+++ b/src/index/vocabulary/VocabularyOnDisk.h
@@ -53,6 +53,8 @@ class VocabularyOnDisk : public VocabularyBinarySearchMixin<VocabularyOnDisk> {
     // Add the next word to the vocabulary and return its index.
     uint64_t operator()(std::string_view word, bool isExternalDummy) override;
 
+    ~WordWriter() override;
+
    private:
     // Finish the writing. After this no more calls to `operator()` are allowed.
     void finishImpl() override;

--- a/src/index/vocabulary/VocabularyType.h
+++ b/src/index/vocabulary/VocabularyType.h
@@ -1,0 +1,100 @@
+//  Copyright 2025, University of Freiburg,
+//  Chair of Algorithms and Data Structures.
+//  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+
+#ifndef QLEVER_SRC_INDEX_VOCABULARY_VOCABULARYTYPE_H
+#define QLEVER_SRC_INDEX_VOCABULARY_VOCABULARYTYPE_H
+
+#include <array>
+#include <string_view>
+
+#include "util/Random.h"
+#include "util/json.h"
+
+namespace ad_utility {
+
+// A lightweight enum for the different implementation strategies of the
+// `PolymorphicVocabulary`. Also includes operations for conversion to and from
+// string.
+// TODO<joka921> Implement a generic mixin that can also be used for other
+// enums, especially such used in command-line interfaces.
+class VocabularyType {
+ public:
+  // The different vocabulary implementations;
+  enum struct Enum {
+    InMemoryUncompressed,
+    OnDiskUncompressed,
+    InMemoryCompressed,
+    OnDiskCompressed
+  };
+
+ private:
+  Enum value_ = Enum::InMemoryUncompressed;
+
+  static constexpr size_t numValues_ = 4;
+  // All possible values.
+  static constexpr std::array<Enum, numValues_> all_{
+      Enum::InMemoryUncompressed, Enum::OnDiskUncompressed,
+      Enum::InMemoryCompressed, Enum::OnDiskCompressed};
+
+  // The string representations of the enum values.
+  static constexpr std::array<std::string_view, numValues_> descriptions_{
+      "in-memory-uncompressed", "on-disk-uncompressed", "in-memory-compressed",
+      "on-disk-compressed"};
+
+  static_assert(all_.size() == descriptions_.size());
+
+ public:
+  // Constructors
+  VocabularyType() = default;
+  explicit VocabularyType(Enum value) : value_{value} {}
+
+  // Create from a string. The string must be one of the `descriptions_`,
+  // otherwise a `runtime_error_` is thrown.
+  static VocabularyType fromString(std::string_view description) {
+    auto it = ql::ranges::find(descriptions_, description);
+    if (it == descriptions_.end()) {
+      throw std::runtime_error{
+          absl::StrCat("\"", description,
+                       "\" is not a valid vocabulary type. The currently "
+                       "supported vocabulary types are ",
+                       getListOfSupportedValues())};
+    }
+    return VocabularyType{all().at(it - descriptions_.begin())};
+  }
+
+  // Return all the possible enum values as a comma-separated single string.
+  static std::string getListOfSupportedValues() {
+    return absl::StrJoin(descriptions_, ", ");
+  }
+
+  // Convert the enum to the corresponding string.
+  std::string_view toString() const {
+    return descriptions_.at(static_cast<size_t>(value_));
+  }
+
+  // Return the actual enum value.
+  Enum value() const { return value_; }
+
+  // Return a list of all the enum values.
+  static constexpr const std::array<Enum, 4>& all() { return all_; }
+
+  // Conversion To JSON.
+  friend void to_json(nlohmann::json& j, const VocabularyType& vocabEnum) {
+    j = vocabEnum.toString();
+  }
+
+  // Conversion from JSON.
+  friend void from_json(const nlohmann::json& j, VocabularyType& vocabEnum) {
+    vocabEnum = VocabularyType::fromString(static_cast<std::string>(j));
+  }
+
+  // Get a random value, useful for fuzz testing.
+  static VocabularyType random() {
+    ad_utility::FastRandomIntGenerator<size_t> r;
+    return VocabularyType{static_cast<Enum>(r() % numValues_)};
+  }
+};
+}  // namespace ad_utility
+
+#endif  // QLEVER_SRC_INDEX_VOCABULARY_VOCABULARYTYPE_H

--- a/src/index/vocabulary/VocabularyType.h
+++ b/src/index/vocabulary/VocabularyType.h
@@ -94,7 +94,7 @@ class VocabularyType {
   // vocabulary type (repeating all these tests for all types exhaustively would
   // be infeasible).
   static VocabularyType random() {
-    ad_utility::FastRandomIntGenerator<size_t> r;
+    static thread_local ad_utility::FastRandomIntGenerator<size_t> r;
     return VocabularyType{static_cast<Enum>(r() % numValues_)};
   }
 };

--- a/src/index/vocabulary/VocabularyType.h
+++ b/src/index/vocabulary/VocabularyType.h
@@ -77,7 +77,7 @@ class VocabularyType {
   Enum value() const { return value_; }
 
   // Return a list of all the enum values.
-  static constexpr const std::array<Enum, 4>& all() { return all_; }
+  static constexpr const std::array<Enum, numValues_>& all() { return all_; }
 
   // Conversion To JSON.
   friend void to_json(nlohmann::json& j, const VocabularyType& vocabEnum) {
@@ -89,7 +89,10 @@ class VocabularyType {
     vocabEnum = VocabularyType::fromString(static_cast<std::string>(j));
   }
 
-  // Get a random value, useful for fuzz testing.
+  // Get a random value, useful for fuzz testing. In particular, each time an
+  // index is built for testing in `IndexTestHelpers.cpp` we assign it a random
+  // vocabulary type (repeating all these tests for all types exhaustively would
+  // be infeasible).
   static VocabularyType random() {
     ad_utility::FastRandomIntGenerator<size_t> r;
     return VocabularyType{static_cast<Enum>(r() % numValues_)};

--- a/test/index/vocabulary/CMakeLists.txt
+++ b/test/index/vocabulary/CMakeLists.txt
@@ -9,3 +9,7 @@ addLinkAndDiscoverTestNoLibs(UnicodeVocabularyTest vocabulary)
 addLinkAndDiscoverTestNoLibs(VocabularyInternalExternalTest vocabulary)
 
 addLinkAndDiscoverTestNoLibs(VocabularyInMemoryBinSearchTest vocabulary)
+
+addLinkAndDiscoverTestNoLibs(PolymorphicVocabularyTest vocabulary)
+
+addLinkAndDiscoverTestNoLibs(VocabularyTypeTest)

--- a/test/index/vocabulary/CompressedVocabularyTest.cpp
+++ b/test/index/vocabulary/CompressedVocabularyTest.cpp
@@ -59,14 +59,17 @@ TEST(CompressedVocabulary, CompressionIsActuallyApplied) {
                                        "31",    "0",     "al"};
 
   CompressedVocabulary<VocabularyInMemory, DummyCompressionWrapper> v;
-  auto writerPtr = v.makeDiskWriterPtr("vocabtmp.txt");
-  auto& writer = *writerPtr;
-  for (const auto& [i, word] : ::ranges::views::enumerate(words)) {
-    ASSERT_EQ(writer(word, false), static_cast<uint64_t>(i));
+  {
+    auto writerPtr = v.makeDiskWriterPtr("vocabtmp.txt");
+    auto& writer = *writerPtr;
+    for (const auto& [i, word] : ::ranges::views::enumerate(words)) {
+      ASSERT_EQ(writer(word, false), static_cast<uint64_t>(i));
+    }
+    writer.readableName() = "blabb";
+    EXPECT_EQ(writer.readableName(), "blabb");
+    // Test the case that the destructor implicitly calls `finish`.
+    // The other unit tests have
   }
-  writer.finish();
-  writer.readableName() = "blabb";
-  EXPECT_EQ(writer.readableName(), "blabb");
 
   VocabularyInMemory simple;
   simple.open("vocabtmp.txt.words");

--- a/test/index/vocabulary/CompressedVocabularyTest.cpp
+++ b/test/index/vocabulary/CompressedVocabularyTest.cpp
@@ -62,7 +62,7 @@ TEST(CompressedVocabulary, CompressionIsActuallyApplied) {
   auto writerPtr = v.makeDiskWriterPtr("vocabtmp.txt");
   auto& writer = *writerPtr;
   for (const auto& [i, word] : ::ranges::views::enumerate(words)) {
-    ASSERT_EQ(writer(word), static_cast<uint64_t>(i));
+    ASSERT_EQ(writer(word, false), static_cast<uint64_t>(i));
   }
   writer.finish();
   writer.readableName() = "blabb";
@@ -102,7 +102,7 @@ struct CompressedVocabularyF : public testing::Test {
       auto writerPtr = vocab.makeDiskWriterPtr(filename);
       auto& writer = *writerPtr;
       for (const auto& word : words) {
-        writer(word);
+        writer(word, false);
       }
       writer.finish();
       vocab.open(filename);

--- a/test/index/vocabulary/PolymorphicVocabularyTest.cpp
+++ b/test/index/vocabulary/PolymorphicVocabularyTest.cpp
@@ -1,0 +1,54 @@
+//  Copyright 2025, University of Freiburg,
+//  Chair of Algorithms and Data Structures.
+//  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+
+#include <gmock/gmock.h>
+
+#include "index/vocabulary/PolymorphicVocabulary.h"
+
+using ad_utility::VocabularyType;
+
+namespace {
+
+// Test a `PolymorphicVocabulary` with a given `vocabType`.
+void testForVocabType(VocabularyType::Enum vocabType) {
+  VocabularyType type{vocabType};
+  std::string filename =
+      absl::StrCat("polymorphicVocabularyTest.", type.toString(), ".vocab");
+
+  auto writerPtr = PolymorphicVocabulary::makeDiskWriterPtr(filename, type);
+  auto& writer = *writerPtr;
+  writer("alpha", false);
+  writer("beta", true);
+  writer("gamma", false);
+  writer.finish();
+
+  PolymorphicVocabulary vocab;
+  vocab.open(filename, type);
+  EXPECT_EQ(vocab.size(), 3);
+
+  EXPECT_EQ(vocab[0], "alpha");
+  EXPECT_EQ(vocab[1], "beta");
+  EXPECT_EQ(vocab[2], "gamma");
+
+  auto wI = vocab.lower_bound("alx", ql::ranges::less{});
+  EXPECT_EQ(wI.index(), 1);
+  EXPECT_EQ(wI.word(), "beta");
+
+  wI = vocab.upper_bound("gamma", ql::ranges::less{});
+  EXPECT_TRUE(wI.isEnd());
+}
+}  // namespace
+
+// Test the general functionality of the `PolymorphicVocabulary` for all the
+// possible `VocabularyType`s.
+TEST(PolymorphicVocabulary, basicTests) {
+  ql::ranges::for_each(VocabularyType::all(), &testForVocabType);
+}
+
+// Test a corner case in a `switch` statement.
+TEST(PolymorphicVocabulary, invalidVocabularyType) {
+  PolymorphicVocabulary vocab;
+  auto invalidType = VocabularyType{static_cast<VocabularyType::Enum>(23401)};
+  EXPECT_ANY_THROW(vocab.resetToType(invalidType));
+}

--- a/test/index/vocabulary/VocabularyInMemoryTest.cpp
+++ b/test/index/vocabulary/VocabularyInMemoryTest.cpp
@@ -20,7 +20,7 @@ auto createVocabulary(const std::vector<std::string>& words) {
     auto writerPtr = v.makeDiskWriterPtr(filename);
     auto& writer = *writerPtr;
     for (const auto& [i, word] : ::ranges::views::enumerate(words)) {
-      auto idx = writer(word);
+      auto idx = writer(word, false);
       EXPECT_EQ(idx, static_cast<uint64_t>(i));
     }
     writer.readableName() = "blubb";

--- a/test/index/vocabulary/VocabularyInMemoryTest.cpp
+++ b/test/index/vocabulary/VocabularyInMemoryTest.cpp
@@ -59,4 +59,51 @@ TEST(VocabularyInMemory, ReadAndWriteFromFile) {
 TEST(VocabularyInMemory, EmptyVocabulary) {
   testEmptyVocabulary(createVocabulary);
 }
+
+// _____________________________________________________________________________
+TEST(VocabularyInMemory, WordWriterDestructorBehavior) {
+  const std::string filename = "VocabInMemoryWordWriterDestructorBehavior.tmp";
+  Vocab v;
+  {
+    auto writerPtr = v.makeDiskWriterPtr(filename);
+    auto& writer = *writerPtr;
+    writer("alpha", false);
+  }
+  v.open(filename);
+  { auto writerPtr = v.makeDiskWriterPtr(filename); };
+  {
+    VocabularyInMemory vocab;
+    {
+      auto wwPtr = vocab.makeDiskWriterPtr(filename);
+      auto& ww = *wwPtr;
+      ww("alpha", false);
+    }
+    vocab.open(filename);
+    EXPECT_EQ(vocab[0], "alpha");
+  }
+  ad_utility::deleteFile(filename);
+  {
+    VocabularyInMemory vocab;
+    auto wwPtr = vocab.makeDiskWriterPtr(filename);
+    auto& ww = *wwPtr;
+    ww("beta", false);
+    ww.finish();
+    ww.finish();
+    vocab.open(filename);
+    EXPECT_EQ(vocab[0], "beta");
+  }
+  ad_utility::deleteFile(filename);
+
+  // This class doesn't automatically call `finish` in the destructor, so the
+  // base class terminates in this case.
+  struct WordWriter : WordWriterBase {
+    WordWriter() = default;
+    uint64_t operator()(std::string_view, bool) override { return 0; }
+    void finishImpl() override {}
+  };
+
+  auto f = []() { WordWriter w{}; };
+  EXPECT_DEATH(f(), "");
+}
+
 }  // namespace

--- a/test/index/vocabulary/VocabularyOnDiskTest.cpp
+++ b/test/index/vocabulary/VocabularyOnDiskTest.cpp
@@ -40,7 +40,7 @@ class VocabularyCreator {
       {
         auto writer = VocabularyOnDisk::WordWriter(vocabFilename_);
         for (const auto& [i, word] : ::ranges::views::enumerate(words)) {
-          EXPECT_EQ(writer(word), static_cast<uint64_t>(i));
+          EXPECT_EQ(writer(word, false), static_cast<uint64_t>(i));
         }
         writer.readableName() = "blubb";
         EXPECT_EQ(writer.readableName(), "blubb");

--- a/test/index/vocabulary/VocabularyTypeTest.cpp
+++ b/test/index/vocabulary/VocabularyTypeTest.cpp
@@ -5,6 +5,7 @@
 #include <gmock/gmock.h>
 
 #include "index/vocabulary/VocabularyType.h"
+#include "util/HashMap.h"
 
 using namespace ad_utility;
 // Simple tests for the glorified enum `VocabularyType`.
@@ -33,5 +34,17 @@ TEST(VocabularyType, allTests) {
     nlohmann::json j = T{e};
     t = j.get<T>();
     EXPECT_EQ(t.value(), e);
+  }
+}
+
+// Test the random sampling.
+TEST(VocabularyType, random) {
+  ad_utility::HashMap<size_t, size_t> counts;
+  size_t numSamples = 100'000;
+  for (size_t i = 0; i < numSamples; ++i) {
+    counts[static_cast<size_t>(VocabularyType::random().value())]++;
+  }
+  for (const auto& [_, count] : counts) {
+    EXPECT_GE(count, numSamples / VocabularyType::all().size() / 3);
   }
 }

--- a/test/index/vocabulary/VocabularyTypeTest.cpp
+++ b/test/index/vocabulary/VocabularyTypeTest.cpp
@@ -1,0 +1,37 @@
+//  Copyright 2025, University of Freiburg,
+//  Chair of Algorithms and Data Structures.
+//  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+
+#include <gmock/gmock.h>
+
+#include "index/vocabulary/VocabularyType.h"
+
+using namespace ad_utility;
+// Simple tests for the glorified enum `VocabularyType`.
+TEST(VocabularyType, allTests) {
+  using E = VocabularyType::Enum;
+  using T = VocabularyType;
+  T t{};
+  EXPECT_EQ(t.value(), E::InMemoryUncompressed);
+  for (auto e : T::all()) {
+    EXPECT_EQ(T{e}.value(), e);
+  }
+
+  t = T::fromString("on-disk-compressed");
+  EXPECT_EQ(t.value(), E::OnDiskCompressed);
+
+  EXPECT_ANY_THROW(T::fromString("kartoffelsalat"));
+
+  EXPECT_EQ(T{E::OnDiskUncompressed}.toString(), "on-disk-uncompressed");
+
+  using namespace ::testing;
+  EXPECT_THAT(T::getListOfSupportedValues(),
+              AllOf(HasSubstr("in-memory-uncompressed"),
+                    HasSubstr(", on-disk-uncompressed")));
+
+  for (auto e : T::all()) {
+    nlohmann::json j = T{e};
+    t = j.get<T>();
+    EXPECT_EQ(t.value(), e);
+  }
+}


### PR DESCRIPTION
Enable a choice (at runtime) between four kinds of vocabularies: `InMemoryUncompressed`, `OnDiskUncompressed`, `InMemoryCompressed`, and `OnDiskCompressed`. The only restriction is that the vocabulary must be read from disk with the same choice that was used for writing it.

This change adds the new class `PolymorphicVocabulary` together with some unit tests. This prepares #1740, which will integrate this class into QLever.