### PR TITLE
Make `LocatedTriplesPerBlock::numTriples` more efficient

### DIFF
--- a/src/index/DeltaTriples.h
+++ b/src/index/DeltaTriples.h
@@ -1,8 +1,13 @@
-// Copyright 2023 - 2024, University of Freiburg
-// Chair of Algorithms and Data Structures
-// Authors: Hannah Bast <bast@cs.uni-freiburg.de>
-//          Julian Mundhahs <mundhahj@tf.uni-freiburg.de>
-//          Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+// Copyright 2023 - 2025 The QLever Authors, in particular:
+//
+// 2023 - 2025 Hannah Bast <bast@cs.uni-freiburg.de>, UFR
+// 2024 - 2025 Julian Mundhahs <mundhahj@tf.uni-freiburg.de>, UFR
+// 2024 - 2025 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
 
 #ifndef QLEVER_SRC_INDEX_DELTATRIPLES_H
 #define QLEVER_SRC_INDEX_DELTATRIPLES_H
@@ -193,20 +198,21 @@ class DeltaTriples {
  private:
   // Find the position of the given triple in the given permutation and add it
   // to each of the six `LocatedTriplesPerBlock` maps (one per permutation).
-  // `shouldExist` specifies the action: insert or delete. Return the iterators
-  // of where it was added (so that we can easily delete it again from these
-  // maps later).
+  // When `insertOrDelete` is `true`, the triples are inserted, otherwise
+  // deleted. Return the iterators of where it was added (so that we can easily
+  // delete it again from these maps later).
   std::vector<LocatedTripleHandles> locateAndAddTriples(
       CancellationHandle cancellationHandle,
-      ql::span<const IdTriple<0>> idTriples, bool shouldExist);
+      ql::span<const IdTriple<0>> triples, bool insertOrDelete);
 
-  // Common implementation for `insertTriples` and `deleteTriples`.
-  // `shouldExist` specifies the action: insert or delete. `targetMap` contains
-  // triples for the current action. `inverseMap` contains triples for the
-  // inverse action. These are then used to resolve idempotent actions and
-  // update the corresponding maps.
+  // Common implementation for `insertTriples` and `deleteTriples`. When
+  // `insertOrDelete` is `true`, the triples are inserted, `targetMap` contains
+  // the already inserted triples, and `inverseMap` contains the already deleted
+  // triples. When `insertOrDelete` is `false`, the triples are deleted, and it
+  // is the other way around:. This is used to resolve insertions or deletions
+  // that are idempotent or cancel each other out.
   void modifyTriplesImpl(CancellationHandle cancellationHandle, Triples triples,
-                         bool shouldExist, TriplesToHandlesMap& targetMap,
+                         bool insertOrDelete, TriplesToHandlesMap& targetMap,
                          TriplesToHandlesMap& inverseMap);
 
   // Rewrite each triple in `triples` such that all local vocab entries and all

--- a/src/index/LocatedTriples.cpp
+++ b/src/index/LocatedTriples.cpp
@@ -1,10 +1,12 @@
-// Copyright 2023 - 2024, University of Freiburg
-// Chair of Algorithms and Data Structures
-// Authors:
-//    2023 Hannah Bast <bast@cs.uni-freiburg.de>
-//    2024 Julian Mundhahs <mundhahj@tf.uni-freiburg.de>
+// Copyright 2023 - 2025 The QLever Authors, in particular:
 //
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+// 2023 - 2025 Hannah Bast <bast@cs.uni-freiburg.de>, UFR
+// 2024 - 2025 Julian Mundhahs <mundhahj@tf.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
 
 #include "index/LocatedTriples.h"
 
@@ -19,13 +21,13 @@
 std::vector<LocatedTriple> LocatedTriple::locateTriplesInPermutation(
     ql::span<const IdTriple<0>> triples,
     ql::span<const CompressedBlockMetadata> blockMetadata,
-    const qlever::KeyOrder& keyOrder, bool shouldExist,
+    const qlever::KeyOrder& keyOrder, bool insertOrDelete,
     ad_utility::SharedCancellationHandle cancellationHandle) {
   std::vector<LocatedTriple> out;
   out.reserve(triples.size());
   ad_utility::chunkedForLoop<10'000>(
       0, triples.size(),
-      [&triples, &out, &blockMetadata, &keyOrder, &shouldExist](size_t i) {
+      [&triples, &out, &blockMetadata, &keyOrder, &insertOrDelete](size_t i) {
         auto triple = triples[i].permute(keyOrder);
         // A triple belongs to the first block that contains at least one triple
         // that larger than or equal to the triple. See `LocatedTriples.h` for a
@@ -35,7 +37,7 @@ std::vector<LocatedTriple> LocatedTriple::locateTriplesInPermutation(
                                     std::less<>{},
                                     &CompressedBlockMetadata::lastTriple_) -
             blockMetadata.begin();
-        out.emplace_back(blockIndex, triple, shouldExist);
+        out.emplace_back(blockIndex, triple, insertOrDelete);
       },
       [&cancellationHandle]() { cancellationHandle->throwIfCancelled(); });
 
@@ -52,19 +54,9 @@ NumAddedAndDeleted LocatedTriplesPerBlock::numTriples(size_t blockIndex) const {
   if (!hasUpdates(blockIndex)) {
     return {0, 0};
   } else {
-    // TODO: A previous version of this code iterated over `blockUpdateTriples`
-    // and counted the number of triples with `shouldTripleExist_ == true` and
-    // `shouldTripleExist_ == false` separately. This makes the estimate
-    // slightly more precise, but turned out to be very slow because iterating
-    // over a `std::set` is surprisingly slow. However, it would be easy to
-    // simply keep track of the number of insertions and deletions per block,
-    // which would then enable the previous more precise estimate in constant
-    // time.
-    //
-    // Note that in the typical use case, the number of update triples per block
-    // is small relative to the total number of triples in the block. Therefore,
-    // the different in precision probably does not matter much.
     const auto& blockUpdateTriples = map_.at(blockIndex);
+    // Simply return the number of located triples twice. See the comment in the
+    // header file for the reasons and potential improvements.
     return {blockUpdateTriples.size(), blockUpdateTriples.size()};
   }
 }
@@ -170,13 +162,13 @@ IdTable LocatedTriplesPerBlock::mergeTriplesImpl(size_t blockIndex,
 
   while (rowIt != block.end() && locatedTripleIt != locatedTriples.end()) {
     if (lessThan(locatedTripleIt, *rowIt)) {
-      if (locatedTripleIt->shouldTripleExist_) {
+      if (locatedTripleIt->insertOrDelete_) {
         // Insertion of a non-existent triple.
         writeLocatedTripleToResult(*locatedTripleIt);
       }
       locatedTripleIt++;
     } else if (equal(locatedTripleIt, *rowIt)) {
-      if (!locatedTripleIt->shouldTripleExist_) {
+      if (!locatedTripleIt->insertOrDelete_) {
         // Deletion of an existing triple.
         rowIt++;
       }
@@ -191,7 +183,7 @@ IdTable LocatedTriplesPerBlock::mergeTriplesImpl(size_t blockIndex,
     AD_CORRECTNESS_CHECK(rowIt == block.end());
     ql::ranges::for_each(
         ql::ranges::subrange(locatedTripleIt, locatedTriples.end()) |
-            ql::views::filter(&LocatedTriple::shouldTripleExist_),
+            ql::views::filter(&LocatedTriple::insertOrDelete_),
         writeLocatedTripleToResult);
   }
   if (rowIt != block.end()) {
@@ -293,7 +285,7 @@ static auto updateGraphMetadata(CompressedBlockMetadata& blockMetadata,
   ad_utility::HashSet<Id> newGraphs(graphs.value().begin(),
                                     graphs.value().end());
   for (auto& lt : locatedTriples) {
-    if (!lt.shouldTripleExist_) {
+    if (!lt.insertOrDelete_) {
       // Don't update the graph info for triples that are deleted.
       continue;
     }
@@ -379,10 +371,10 @@ std::ostream& operator<<(std::ostream& os, const std::vector<IdTriple<0>>& v) {
 
 // ____________________________________________________________________________
 bool LocatedTriplesPerBlock::isLocatedTriple(const IdTriple<0>& triple,
-                                             bool isInsertion) const {
-  auto blockContains = [&triple, isInsertion](const LocatedTriples& lt,
-                                              size_t blockIndex) {
-    LocatedTriple locatedTriple{blockIndex, triple, isInsertion};
+                                             bool insertOrDelete) const {
+  auto blockContains = [&triple, insertOrDelete](const LocatedTriples& lt,
+                                                 size_t blockIndex) {
+    LocatedTriple locatedTriple{blockIndex, triple, insertOrDelete};
     locatedTriple.blockIndex_ = blockIndex;
     return ad_utility::contains(lt, locatedTriple);
   };

--- a/test/DeltaTriplesCountTest.cpp
+++ b/test/DeltaTriplesCountTest.cpp
@@ -1,7 +1,11 @@
-// Copyright 2025, University of Freiburg
-//  Chair of Algorithms and Data Structures.
-//  Authors:
-//    2025 Julian Mundhahs <mundhahj@tf.uni-freiburg.de>
+// Copyright 2025 The QLever Authors, in particular:
+//
+// 2025        Julian Mundhahs <mundhahj@tf.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
 
 #include <gmock/gmock.h>
 

--- a/test/DeltaTriplesTest.cpp
+++ b/test/DeltaTriplesTest.cpp
@@ -1,8 +1,13 @@
-// Copyright 2023 - 2024, University of Freiburg
-//  Chair of Algorithms and Data Structures.
-//  Authors:
-//    2023 Hannah Bast <bast@cs.uni-freiburg.de>
-//    2024 Julian Mundhahs <mundhahj@tf.uni-freiburg.de>
+// Copyright 2023 - 2025 The QLever Authors, in particular:
+//
+// 2023 - 2025 Hannah Bast <bast@cs.uni-freiburg.de>, UFR
+// 2024 - 2025 Julian Mundhahs <mundhahj@tf.uni-freiburg.de>, UFR
+// 2024 - 2025 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
 
 #include <absl/strings/str_split.h>
 #include <gtest/gtest.h>

--- a/test/DeltaTriplesTestHelpers.h
+++ b/test/DeltaTriplesTestHelpers.h
@@ -1,7 +1,11 @@
-// Copyright 2024, University of Freiburg
-//  Chair of Algorithms and Data Structures.
-//  Authors:
-//    2024 Julian Mundhahs <mundhahj@tf.uni-freiburg.de>
+// Copyright 2024 The QLever Authors, in particular:
+//
+// 2024        Julian Mundhahs <mundhahj@tf.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>

--- a/test/LocatedTriplesTest.cpp
+++ b/test/LocatedTriplesTest.cpp
@@ -1,7 +1,12 @@
-// Copyright 2023 - 2025, University of Freiburg
-// Chair of Algorithms and Data Structures.
-// Authors: Hannah Bast <bast@cs.uni-freiburg.de>
-//          Julian Mundhahs <mundhahj@tf.uni-freiburg.de>
+// Copyright 2023 - 2025 The QLever Authors, in particular:
+//
+// 2023 - 2025 Hannah Bast <bast@cs.uni-freiburg.de>, UFR
+// 2024 - 2025 Julian Mundhahs <mundhahj@tf.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
 
 #include <gtest/gtest.h>
 


### PR DESCRIPTION
So far, `LocatedTriplesPerBlock::numTriples` iterated over the `LocatedTriplesPerBlock` for each block, counted the number of triples with `insertOrDelete_ == true` and `insertOrDelete_ == false`, and returned that pair. This turned to be very inefficient because the located triples per block are stored in a `std::set` and iterating over an `std::set` is terrifyingly slow. As a consequence, many queries involving update triples were also slow because the size estimator for index scans uses `LocatedTriplesPerBlock::numTriples`.  This is now fixed by simply returning the number of triples in the block as an upper bound for both the number of inserted and the number of deleted triples in the block. Fixes #2072, which explains all the details behind this.

On the side, improve a variable name (`insertOrDelete` was called `shouldExist` before) and several comments. Also update some of the copyright headers to the latest format. The actual code change is very small, but its consequences are huge.

With this change, the first ten example queries for Wikidata are now only a few percent slower when running with the full set of update triples (a bit over 100 M triples) needed to bring the SPARQL endpoint (that was built from the weekly dump) in sync with the current version.