### PR TITLE
Fix Docker build on macOS (`signed char` vs. `unsigned char` issue)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -75,8 +75,7 @@ jobs:
         # future, then we can set this to `true`. Then the ARM64 image will also
         # be built on pull requests which allows for debugging without changing
         # the master branch.
-        if: true
-        #TODO<joka921> revert back once this works
+        if: false
         uses: docker/build-push-action@v6
         with:
           context: .

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -75,7 +75,8 @@ jobs:
         # future, then we can set this to `true`. Then the ARM64 image will also
         # be built on pull requests which allows for debugging without changing
         # the master branch.
-        if: false
+        if: true
+        #TODO<joka921> revert back once this works
         uses: docker/build-push-action@v6
         with:
           context: .

--- a/src/index/TextIndexBuilder.cpp
+++ b/src/index/TextIndexBuilder.cpp
@@ -339,18 +339,26 @@ static auto fourLetterPrefixes() {
   static_assert(
       MIN_WORD_PREFIX_SIZE == 4,
       "If you need this to be changed, please contact the developers");
+  auto aToZ = ::ranges::views::iota(char{'a'}, char{'z' + 1});
+  return ::ranges::views::cartesian_product(aToZ, aToZ, aToZ, aToZ) |
+         ::ranges::views::transform([](const auto& x) {
+           auto [a, b, c, d] = x;
+           return std::string{a, b, c, d};
+         });
+  /*
   return ql::views::join(ql::views::join(ql::views::join(
-      ql::views::transform(ql::views::iota('a', 'z' + 1), [](char a) {
-        return ql::views::transform(ql::views::iota('a', 'z' + 1), [=](char b) {
+      ql::views::transform(aToZ, [aToZ](char a) {
+        return ql::views::transform(aToZ, [=](char b) {
           return ql::views::transform(
-              ql::views::iota('a', 'z' + 1), [=](char c) {
-                return ql::views::transform(ql::views::iota('a', 'z' + 1),
+              aToZ, [=](char c) {
+                return ql::views::transform(aToZ,
                                             [=](char d) {
                                               return std::string{a, b, c, d};
                                             });
               });
         });
       }))));
+      */
 }
 
 /// Check if the `fourLetterPrefixes` are sorted wrt to the `comparator`

--- a/src/index/TextIndexBuilder.cpp
+++ b/src/index/TextIndexBuilder.cpp
@@ -345,20 +345,6 @@ static auto fourLetterPrefixes() {
            auto [a, b, c, d] = x;
            return std::string{a, b, c, d};
          });
-  /*
-  return ql::views::join(ql::views::join(ql::views::join(
-      ql::views::transform(aToZ, [aToZ](char a) {
-        return ql::views::transform(aToZ, [=](char b) {
-          return ql::views::transform(
-              aToZ, [=](char c) {
-                return ql::views::transform(aToZ,
-                                            [=](char d) {
-                                              return std::string{a, b, c, d};
-                                            });
-              });
-        });
-      }))));
-      */
 }
 
 /// Check if the `fourLetterPrefixes` are sorted wrt to the `comparator`


### PR DESCRIPTION
In `TextIndexBuilder::fourLetterPrefixes()`, there was a call to `views::iota('a', 'z' + 1)`, which works fine when `char` is `signed char`  (which is true for most systems), but produces a warning when `char` is `unsigned char` (as is the case for our macOS build). This is now fixed by explicitly writing `views::iota(char{'a'}, char{'z' + 1})`. On the side, simplify the code by using `views::cartesian_product`.

