### PR TITLE
Spatial join service now accepts floating point values for `<maxDistance>`

### DIFF
--- a/src/engine/SpatialJoin.cpp
+++ b/src/engine/SpatialJoin.cpp
@@ -75,8 +75,8 @@ std::shared_ptr<SpatialJoin> SpatialJoin::addChild(
 bool SpatialJoin::isConstructed() const { return childLeft_ && childRight_; }
 
 // ____________________________________________________________________________
-std::optional<size_t> SpatialJoin::getMaxDist() const {
-  auto visitor = [](const auto& config) -> std::optional<size_t> {
+std::optional<double> SpatialJoin::getMaxDist() const {
+  auto visitor = [](const auto& config) -> std::optional<double> {
     return config.maxDist_;
   };
   return std::visit(visitor, config_.task_);

--- a/src/engine/SpatialJoin.h
+++ b/src/engine/SpatialJoin.h
@@ -31,19 +31,19 @@ enum class SpatialJoinType {
 // A nearest neighbor search with optionally a maximum distance.
 struct NearestNeighborsConfig {
   size_t maxResults_;
-  std::optional<size_t> maxDist_ = std::nullopt;
+  std::optional<double> maxDist_ = std::nullopt;
 };
 
 // A spatial search limited only by a maximum distance.
 struct MaxDistanceConfig {
-  size_t maxDist_;
+  double maxDist_;
 };
 
 // Spatial join using one of the join types above. The maximal distance is
 // relevant only for the `WITHIN_DIST` join type.
 struct SpatialJoinConfig {
   SpatialJoinType joinType_;
-  std::optional<size_t> maxDist_ = std::nullopt;
+  std::optional<double> maxDist_ = std::nullopt;
 };
 
 // Configuration to restrict the results provided by the SpatialJoin
@@ -94,7 +94,7 @@ struct PreparedSpatialJoinParams {
   ColumnIndex rightJoinCol_;
   std::vector<ColumnIndex> rightSelectedCols_;
   size_t numColumns_;
-  std::optional<size_t> maxDist_;
+  std::optional<double> maxDist_;
   std::optional<size_t> maxResults_;
   std::optional<SpatialJoinType> joinType_;
 };
@@ -163,7 +163,7 @@ class SpatialJoin : public Operation {
   bool isConstructed() const;
 
   // this function is used to give the maximum distance for internal purposes
-  std::optional<size_t> getMaxDist() const;
+  std::optional<double> getMaxDist() const;
 
   // this function is used to give the maximum number of results
   std::optional<size_t> getMaxResults() const;
@@ -180,8 +180,8 @@ class SpatialJoin : public Operation {
   }
 
   // Helper functions for unit tests
-  std::pair<size_t, size_t> onlyForTestingGetTask() const {
-    return std::pair{getMaxDist().value_or(-1), getMaxResults().value_or(-1)};
+  std::pair<double, size_t> onlyForTestingGetTask() const {
+    return std::pair{getMaxDist().value_or(-1.0), getMaxResults().value_or(-1)};
   }
 
   const SpatialJoinConfiguration& onlyForTestingGetConfig() const {

--- a/src/parser/SpatialQuery.cpp
+++ b/src/parser/SpatialQuery.cpp
@@ -36,12 +36,15 @@ void SpatialQuery::addParameter(const SparqlTriple& triple) {
     }
     maxResults_ = object.getInt();
   } else if (predString == "maxDistance") {
-    if (!object.isInt()) {
+    if (object.isInt()) {
+      maxDist_ = static_cast<double>(object.getInt());
+    } else if (object.isDouble()) {
+      maxDist_ = object.getDouble();
+    } else {
       throw SpatialSearchException(
-          "The parameter `<maxDistance>` expects an integer (the maximum "
-          "distance in meters)");
+          "The parameter `<maxDistance>` expects an integer or decimal (the "
+          "maximum distance in meters)");
     }
-    maxDist_ = object.getInt();
   } else if (predString == "bindDistance") {
     setVariable("bindDistance", object, distanceVariable_);
   } else if (predString == "joinType") {

--- a/src/parser/SpatialQuery.h
+++ b/src/parser/SpatialQuery.h
@@ -27,7 +27,7 @@ struct SpatialQuery : MagicServiceQuery {
 
   // The spatial join task definition: maximum distance and number of results.
   // One of both - or both - must be provided.
-  std::optional<size_t> maxDist_;
+  std::optional<double> maxDist_;
   std::optional<size_t> maxResults_;
 
   // Optional further argument: a variable to which the distance between spatial

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -1849,6 +1849,21 @@ TEST(QueryPlanner, SpatialJoinService) {
       h::spatialJoin(-1, 5, V{"?y"}, V{"?b"}, std::nullopt, emptyPayload, S2,
                      std::nullopt, scan("?x", "<p>", "?y"),
                      scan("?a", "<p>", "?b")));
+
+  // Floating point as maximum distance
+  h::expect(
+      "PREFIX spatialSearch: <https://qlever.cs.uni-freiburg.de/spatialSearch/>"
+      "SELECT * WHERE {"
+      "?x <p> ?y."
+      "SERVICE spatialSearch: {"
+      "_:config spatialSearch:algorithm spatialSearch:s2 ;"
+      "spatialSearch:left ?y ;"
+      "spatialSearch:right ?b ;"
+      "spatialSearch:maxDistance 0.5 . "
+      "{ ?a <p> ?b } }}",
+      h::spatialJoin(0.5, -1, V{"?y"}, V{"?b"}, std::nullopt, emptyPayload, S2,
+                     std::nullopt, scan("?x", "<p>", "?y"),
+                     scan("?a", "<p>", "?b")));
 }
 
 TEST(QueryPlanner, SpatialJoinServicePayloadVars) {

--- a/test/QueryPlannerTestHelpers.h
+++ b/test/QueryPlannerTestHelpers.h
@@ -381,7 +381,7 @@ inline auto ValuesClause = [](string cacheKey) {
 // Match a SpatialJoin operation, set arguments to ignore to -1
 struct SpatialJoin {
   template <QL_CONCEPT_OR_TYPENAME(std::same_as<QetMatcher>)... ChildArgs>
-  auto operator()(size_t maxDist, size_t maxResults, Variable left,
+  auto operator()(double maxDist, size_t maxResults, Variable left,
                   Variable right, std::optional<Variable> distanceVariable,
                   PayloadVariables payloadVariables,
                   SpatialJoinAlgorithm algorithm,

--- a/test/engine/SpatialJoinAlgorithmsTest.cpp
+++ b/test/engine/SpatialJoinAlgorithmsTest.cpp
@@ -905,7 +905,7 @@ TEST_P(SpatialJoinParamTest, computeResultSmallDatasetDifferentSizeChildren) {
 }
 
 TEST_P(SpatialJoinParamTest, maxSizeMaxDistanceTest) {
-  auto maxDist = std::numeric_limits<size_t>::max();
+  auto maxDist = std::numeric_limits<double>::max();
   MaxDistanceConfig maxDistConf{maxDist};
   bool addLeftChildFirst = std::get<1>(GetParam());
 

--- a/test/engine/SpatialJoinTest.cpp
+++ b/test/engine/SpatialJoinTest.cpp
@@ -798,7 +798,7 @@ TEST(SpatialJoin, getDescriptor) {
   SpatialJoin* spatialJoin = static_cast<SpatialJoin*>(op.get());
 
   auto description = spatialJoin->getDescriptor();
-  ASSERT_THAT(description, ::testing::HasSubstr(std::to_string(
+  ASSERT_THAT(description, ::testing::HasSubstr(absl::StrCat(
                                spatialJoin->getMaxDist().value_or(-1))));
   ASSERT_TRUE(description.find("?subject") != std::string::npos);
   ASSERT_TRUE(description.find("?object") != std::string::npos);
@@ -840,7 +840,7 @@ TEST(SpatialJoin, getCacheKeyImpl) {
       spatialJoin->onlyForTestingGetRightChild()->getCacheKey();
 
   ASSERT_TRUE(cacheKeyString.find(
-                  std::to_string(spatialJoin->getMaxDist().value_or(-1))) !=
+                  absl::StrCat(spatialJoin->getMaxDist().value_or(-1))) !=
               std::string::npos);
   ASSERT_TRUE(cacheKeyString.find(leftCacheKeyString) != std::string::npos);
   ASSERT_TRUE(cacheKeyString.find(rightCacheKeyString) != std::string::npos);

--- a/test/engine/SpatialJoinTestHelpers.h
+++ b/test/engine/SpatialJoinTestHelpers.h
@@ -423,7 +423,7 @@ inline SpatialJoinAlgorithms getDummySpatialJoinAlgsForWrapperTesting(
   if (!qec) {
     qec = buildTestQEC();
   }
-  MaxDistanceConfig task{maxDist};
+  MaxDistanceConfig task{static_cast<double>(maxDist)};
   std::shared_ptr<QueryExecutionTree> spatialJoinOperation =
       ad_utility::makeExecutionTree<SpatialJoin>(
           qec.value(),


### PR DESCRIPTION
The `<maxDistance>` parameter of the spatial join service now accepts a floating point value and is also stored as a floating point value. In particular, the distance, which is measured in meters, can now be smaller than one meter. This follows the suggestion from <https://github.com/ad-freiburg/qlever/pull/1935#discussion_r2120272456>.