### PR TITLE
Lowercase all language tags

### DIFF
--- a/src/rdfTypes/Literal.cpp
+++ b/src/rdfTypes/Literal.cpp
@@ -28,6 +28,11 @@ Literal::Literal(std::string content, size_t beginOfSuffix)
   AD_CORRECTNESS_CHECK(beginOfSuffix_ == content_.size() ||
                        content_[beginOfSuffix] == at ||
                        content_[beginOfSuffix] == hat);
+  if (beginOfSuffix_ < content_.size() && content_[beginOfSuffix_] == '@') {
+    size_t tagStart = beginOfSuffix_ + 1;
+    std::string lowercaseTag = utf8ToLower(content_.substr(tagStart));
+    content_.replace(tagStart, content_.size() - tagStart, lowercaseTag);
+  }
 }
 
 // __________________________________________
@@ -111,10 +116,11 @@ Literal Literal::literalWithNormalizedContent(
 // __________________________________________
 void Literal::addLanguageTag(std::string_view languageTag) {
   AD_CORRECTNESS_CHECK(!hasDatatype() && !hasLanguageTag());
+  std::string lowercaseTag = utf8ToLower(languageTag);
   if (languageTag.starts_with('@')) {
-    absl::StrAppend(&content_, languageTag);
+    absl::StrAppend(&content_, lowercaseTag);
   } else {
-    absl::StrAppend(&content_, "@"sv, languageTag);
+    absl::StrAppend(&content_, "@"sv, lowercaseTag);
   }
 }
 

--- a/test/LanguageExpressionsTest.cpp
+++ b/test/LanguageExpressionsTest.cpp
@@ -207,8 +207,8 @@ TEST(LanguageTagGetter, testLanguageTagValueGetterWithVocab) {
                         testContext.litId3, testContext.litId4,
                         testContext.litId5, testContext.litId6,
                         testContext.iriId1, testContext.iriId2};
-  std::vector<strOpt> expected = {"",   "es",    "de-LATN-CH", "de-DE",
-                                  "de", "de-AT", std::nullopt, std::nullopt};
+  std::vector<strOpt> expected = {"",   "es",    "de-latn-ch", "de-de",
+                                  "de", "de-at", std::nullopt, std::nullopt};
   assertLangTagValueGetter(in, expected, langTagGetter, testContext);
 }
 
@@ -222,15 +222,15 @@ TEST(LanguageTagGetter, testLanguageTagValueGetterWithLocalVocab) {
                         testContext.locVocLit1, testContext.locVocLit2,
                         testContext.locVocLit3, testContext.locVocLit4};
   std::vector<strOpt> expected = {std::nullopt, std::nullopt, "",
-                                  "de-DE",      "de",         "de-AT"};
+                                  "de-de",      "de",         "de-at"};
   assertLangTagValueGetter(in, expected, langTagGetter, testContext);
 }
 
 // ____________________________________________________________________________
 TEST(LangExpression, testLangExpressionOnLiteralColumn) {
   testLanguageExpressions<getLangExpression, IdOrLiteralOrIri>(
-      {litOrIri(""), litOrIri("es"), litOrIri("de-LATN-CH"), litOrIri("de-DE"),
-       litOrIri("de-DE"), litOrIri("de-AT"), litOrIri("de"), litOrIri("de-AT")},
+      {litOrIri(""), litOrIri("es"), litOrIri("de-latn-ch"), litOrIri("de-de"),
+       litOrIri("de-de"), litOrIri("de-at"), litOrIri("de"), litOrIri("de-at")},
       "?literals");
 }
 


### PR DESCRIPTION
To be SPARQL compliant we need to treat all language tags as case-insensitive.
This PR changes the implementation of the `Literal` class to lowercase all language tags, which achieves just that.