### PR TITLE
Handle `xsd:boolean` values in full compliance with the standard

### DIFF
--- a/src/engine/ExportQueryExecutionTrees.cpp
+++ b/src/engine/ExportQueryExecutionTrees.cpp
@@ -337,8 +337,11 @@ ExportQueryExecutionTrees::idToStringAndTypeForEncodedValue(Id id) {
         return std::pair{std::move(ss).str(), XSD_DECIMAL_TYPE};
       }();
     case Bool:
-      return id.getBool() ? std::pair{"true", XSD_BOOLEAN_TYPE}
-                          : std::pair{"false", XSD_BOOLEAN_TYPE};
+      if (id.getBits() & 0b10) {
+        return std::pair{id.getBool() ? "1" : "0", XSD_BOOLEAN_TYPE};
+      } else {
+        return std::pair{id.getBool() ? "true" : "false", XSD_BOOLEAN_TYPE};
+      }
     case Int:
       return std::pair{std::to_string(id.getInt()), XSD_INT_TYPE};
     case Date:

--- a/src/engine/ExportQueryExecutionTrees.cpp
+++ b/src/engine/ExportQueryExecutionTrees.cpp
@@ -337,11 +337,7 @@ ExportQueryExecutionTrees::idToStringAndTypeForEncodedValue(Id id) {
         return std::pair{std::move(ss).str(), XSD_DECIMAL_TYPE};
       }();
     case Bool:
-      if (id.getBits() & 0b10) {
-        return std::pair{id.getBool() ? "1" : "0", XSD_BOOLEAN_TYPE};
-      } else {
-        return std::pair{id.getBool() ? "true" : "false", XSD_BOOLEAN_TYPE};
-      }
+      return std::pair{std::string{id.getBoolLiteral()}, XSD_BOOLEAN_TYPE};
     case Int:
       return std::pair{std::to_string(id.getInt()), XSD_INT_TYPE};
     case Date:
@@ -768,9 +764,9 @@ ExportQueryExecutionTrees::selectQueryResultToStream(
           const auto& val = selectedColumnIndices[j].value();
           Id id = pair.idTable_(i, val.columnIndex_);
           auto optionalStringAndType =
-              idToStringAndType<format == MediaType::csv>(
-                  qet.getQec()->getIndex(), id, pair.localVocab_,
-                  escapeFunction);
+              idToStringAndType < format ==
+              MediaType::csv > (qet.getQec()->getIndex(), id, pair.localVocab_,
+                                escapeFunction);
           if (optionalStringAndType.has_value()) [[likely]] {
             co_yield optionalStringAndType.value().first;
           }

--- a/src/engine/ExportQueryExecutionTrees.cpp
+++ b/src/engine/ExportQueryExecutionTrees.cpp
@@ -764,9 +764,9 @@ ExportQueryExecutionTrees::selectQueryResultToStream(
           const auto& val = selectedColumnIndices[j].value();
           Id id = pair.idTable_(i, val.columnIndex_);
           auto optionalStringAndType =
-              idToStringAndType < format ==
-              MediaType::csv > (qet.getQec()->getIndex(), id, pair.localVocab_,
-                                escapeFunction);
+              idToStringAndType<format == MediaType::csv>(
+                  qet.getQec()->getIndex(), id, pair.localVocab_,
+                  escapeFunction);
           if (optionalStringAndType.has_value()) [[likely]] {
             co_yield optionalStringAndType.value().first;
           }

--- a/src/engine/sparqlExpressions/SparqlExpressionValueGetters.cpp
+++ b/src/engine/sparqlExpressions/SparqlExpressionValueGetters.cpp
@@ -82,6 +82,10 @@ auto EffectiveBooleanValueGetter::operator()(
 // ____________________________________________________________________________
 std::optional<std::string> StringValueGetter::operator()(
     Id id, const EvaluationContext* context) const {
+  if (id.getDatatype() == Datatype::Bool) {
+    // Always use canonical representation when converting to string.
+    return id.getBool() ? "true" : "false";
+  }
   // `true` means that we remove the quotes and angle brackets.
   auto optionalStringAndType =
       ExportQueryExecutionTrees::idToStringAndType<true>(

--- a/src/global/ValueId.h
+++ b/src/global/ValueId.h
@@ -275,6 +275,15 @@ class ValueId {
     return static_cast<bool>(removeDatatypeBits(_bits) & 1);
   }
 
+  // Obtain the boolean value as a string view.
+  std::string_view getBoolLiteral() const noexcept {
+    bool value = getBool();
+    if (removeDatatypeBits(_bits) & 0b10) {
+      return value ? "1" : "0";
+    }
+    return value ? "true" : "false";
+  }
+
   /// Create a `ValueId` for an unsigned index of type
   /// `VocabIndex|TextRecordIndex|LocalVocabIndex`. These types can
   /// represent values in the range [0, 2^60]. When `index` is outside of this
@@ -421,7 +430,7 @@ class ValueId {
       return ostr << id.getBits();
     }
 
-    auto visitor = [&ostr, id](auto&& value) {
+    auto visitor = [&ostr](auto&& value) {
       using T = decltype(value);
       if constexpr (ad_utility::isSimilar<T, UndefinedType>) {
         // already handled above
@@ -430,12 +439,7 @@ class ValueId {
                            ad_utility::isSimilar<T, int64_t>) {
         ostr << std::to_string(value);
       } else if constexpr (ad_utility::isSimilar<T, bool>) {
-        if (removeDatatypeBits(id._bits) & 0b10) {
-          ostr << '"' << (value ? '1' : '0') << "\"^^<" << XSD_BOOLEAN_TYPE
-               << '>';
-        } else {
-          ostr << (value ? "true" : "false");
-        }
+        ostr << (value ? "true" : "false");
       } else if constexpr (ad_utility::isSimilar<T, DateYearOrDuration>) {
         ostr << value.toStringAndType().first;
       } else if constexpr (ad_utility::isSimilar<T, GeoPoint>) {

--- a/src/global/ValueId.h
+++ b/src/global/ValueId.h
@@ -262,9 +262,9 @@ class ValueId {
     return addDatatypeBits(bits, Datatype::Bool);
   }
 
-  /// Create a `ValueId` for a boolean value, represented as 0/1 instead of
-  /// false/true.
-  static constexpr ValueId makeFromBinaryBool(bool b) noexcept {
+  /// Create a `ValueId` for a boolean value, represented as "0" or "1" instead
+  /// of "false" or "true".
+  static constexpr ValueId makeBoolFromZeroOrOne(bool b) noexcept {
     auto bits = static_cast<T>(b);
     bits |= static_cast<T>(true) << 1;
     return addDatatypeBits(bits, Datatype::Bool);
@@ -275,10 +275,12 @@ class ValueId {
     return static_cast<bool>(removeDatatypeBits(_bits) & 1);
   }
 
-  // Obtain the boolean value as a string view.
+  // Obtain the boolean value as a string view. In particular, return either
+  // `true`, `false`, `0` , or `1`, depending on whether the value was created
+  // via `makeFromBool` or `makeBoolFromZeroOrOne` (see above).
   std::string_view getBoolLiteral() const noexcept {
     bool value = getBool();
-    if (removeDatatypeBits(_bits) & 0b10) {
+    if (_bits & 0b10) {
       return value ? "1" : "0";
     }
     return value ? "true" : "false";

--- a/src/global/ValueId.h
+++ b/src/global/ValueId.h
@@ -256,15 +256,18 @@ class ValueId {
     return IntegerType::fromNBit(_bits);
   }
 
-  /// Create a `ValueId` for a boolean value.
-  static constexpr ValueId makeFromBool(bool b) noexcept {
+  /// Create a `ValueId` for a boolean value. If `binaryLiteral` is true, this
+  /// will store it as 0/1 instead of false/true.
+  static constexpr ValueId makeFromBool(bool b,
+                                        bool binaryLiteral = false) noexcept {
     auto bits = static_cast<T>(b);
+    bits |= static_cast<T>(binaryLiteral) << 1;
     return addDatatypeBits(bits, Datatype::Bool);
   }
 
   // Obtain the boolean value.
   [[nodiscard]] bool getBool() const noexcept {
-    return static_cast<bool>(removeDatatypeBits(_bits));
+    return static_cast<bool>(removeDatatypeBits(_bits) & 1);
   }
 
   /// Create a `ValueId` for an unsigned index of type

--- a/src/parser/RdfParser.cpp
+++ b/src/parser/RdfParser.cpp
@@ -541,11 +541,12 @@ TripleComponent TurtleParser<T>::literalAndDatatypeToTripleComponentImpl(
       } else if (normalizedLiteralContent == "false") {
         parser->lastParseResult_ = false;
       } else if (normalizedLiteralContent == "1") {
-        parser->lastParseResult_ = Id::makeFromBool(true, true);
+        parser->lastParseResult_ = Id::makeFromBinaryBool(true);
       } else if (normalizedLiteralContent == "0") {
-        parser->lastParseResult_ = Id::makeFromBool(false, true);
+        parser->lastParseResult_ = Id::makeFromBinaryBool(false);
       } else {
-        makeNormalLiteral();
+        raiseOrIgnoreTriple(absl::StrCat("Invalid boolean literal: '",
+                                         normalizedLiteralContent, "'"));
       }
     } else if (ad_utility::contains(floatDatatypes_, type)) {
       parser->parseDoubleConstant(normalizedLiteralContent);

--- a/src/parser/RdfParser.cpp
+++ b/src/parser/RdfParser.cpp
@@ -540,6 +540,10 @@ TripleComponent TurtleParser<T>::literalAndDatatypeToTripleComponentImpl(
         parser->lastParseResult_ = true;
       } else if (normalizedLiteralContent == "false") {
         parser->lastParseResult_ = false;
+      } else if (normalizedLiteralContent == "1") {
+        parser->lastParseResult_ = Id::makeFromBool(true, true);
+      } else if (normalizedLiteralContent == "0") {
+        parser->lastParseResult_ = Id::makeFromBool(false, true);
       } else {
         makeNormalLiteral();
       }

--- a/src/parser/RdfParser.cpp
+++ b/src/parser/RdfParser.cpp
@@ -545,8 +545,8 @@ TripleComponent TurtleParser<T>::literalAndDatatypeToTripleComponentImpl(
       } else if (normalizedLiteralContent == "0") {
         parser->lastParseResult_ = Id::makeFromBinaryBool(false);
       } else {
-        raiseOrIgnoreTriple(absl::StrCat("Invalid boolean literal: '",
-                                         normalizedLiteralContent, "'"));
+        parser->raiseOrIgnoreTriple(absl::StrCat(
+            "Invalid boolean literal: '", normalizedLiteralContent, "'"));
       }
     } else if (ad_utility::contains(floatDatatypes_, type)) {
       parser->parseDoubleConstant(normalizedLiteralContent);

--- a/src/parser/RdfParser.cpp
+++ b/src/parser/RdfParser.cpp
@@ -500,8 +500,7 @@ bool TurtleParser<T>::rdfLiteralImpl(bool allowMultilineLiterals) {
     lastParseResult_ = std::move(previous);
   } else if (skip<TurtleTokenId::DoubleCircumflex>() && check(iri())) {
     literalAndDatatypeToTripleComponentImpl(
-        asStringViewUnsafe(previous.getContent()), lastParseResult_.getIri(),
-        this);
+        asStringViewUnsafe(previous.getContent()), lastParseResult_.getIri());
   }
 
   // It is okay to neither have a langtag nor an XSD datatype.
@@ -512,13 +511,13 @@ bool TurtleParser<T>::rdfLiteralImpl(bool allowMultilineLiterals) {
 template <class T>
 TripleComponent TurtleParser<T>::literalAndDatatypeToTripleComponentImpl(
     std::string_view normalizedLiteralContent,
-    const TripleComponent::Iri& typeIri, TurtleParser<T>* parser) {
+    const TripleComponent::Iri& typeIri) {
   auto literal = TripleComponent::Literal::literalWithNormalizedContent(
       asNormalizedStringViewUnsafe(normalizedLiteralContent));
   std::string_view type = asStringViewUnsafe(typeIri.getContent());
 
   // Helper to handle literals that are invalid for the respective datatype
-  auto makeNormalLiteral = [&parser, &literal, normalizedLiteralContent,
+  auto makeNormalLiteral = [this, &literal, normalizedLiteralContent,
                             type](std::optional<std::exception> error =
                                       std::nullopt) {
     std::string_view errorMsg = error.has_value() ? error.value().what() : "";
@@ -529,54 +528,54 @@ TripleComponent TurtleParser<T>::literalAndDatatypeToTripleComponentImpl(
                << ". It is treated as a plain string literal without datatype "
                   "instead."
                << std::endl;
-    parser->lastParseResult_ = std::move(literal);
+    lastParseResult_ = std::move(literal);
   };
 
   try {
     if (ad_utility::contains(integerDatatypes_, type)) {
-      parser->parseIntegerConstant(normalizedLiteralContent);
+      parseIntegerConstant(normalizedLiteralContent);
     } else if (type == XSD_BOOLEAN_TYPE) {
       if (normalizedLiteralContent == "true") {
-        parser->lastParseResult_ = true;
+        lastParseResult_ = true;
       } else if (normalizedLiteralContent == "false") {
-        parser->lastParseResult_ = false;
+        lastParseResult_ = false;
       } else if (normalizedLiteralContent == "1") {
-        parser->lastParseResult_ = Id::makeFromBinaryBool(true);
+        lastParseResult_ = Id::makeFromBinaryBool(true);
       } else if (normalizedLiteralContent == "0") {
-        parser->lastParseResult_ = Id::makeFromBinaryBool(false);
+        lastParseResult_ = Id::makeFromBinaryBool(false);
       } else {
-        parser->raiseOrIgnoreTriple(absl::StrCat(
-            "Invalid boolean literal: '", normalizedLiteralContent, "'"));
+        raiseOrIgnoreTriple(absl::StrCat("Invalid boolean literal: '",
+                                         normalizedLiteralContent, "'"));
       }
     } else if (ad_utility::contains(floatDatatypes_, type)) {
-      parser->parseDoubleConstant(normalizedLiteralContent);
+      parseDoubleConstant(normalizedLiteralContent);
     } else if (type == XSD_DATETIME_TYPE) {
-      parser->lastParseResult_ =
+      lastParseResult_ =
           DateYearOrDuration::parseXsdDatetime(normalizedLiteralContent);
     } else if (type == XSD_DATE_TYPE) {
-      parser->lastParseResult_ =
+      lastParseResult_ =
           DateYearOrDuration::parseXsdDate(normalizedLiteralContent);
     } else if (type == XSD_GYEARMONTH_TYPE) {
-      parser->lastParseResult_ =
+      lastParseResult_ =
           DateYearOrDuration::parseGYearMonth(normalizedLiteralContent);
     } else if (type == XSD_GYEAR_TYPE) {
-      parser->lastParseResult_ =
+      lastParseResult_ =
           DateYearOrDuration::parseGYear(normalizedLiteralContent);
     } else if (type == XSD_DAYTIME_DURATION_TYPE) {
-      parser->lastParseResult_ =
+      lastParseResult_ =
           DateYearOrDuration::parseXsdDayTimeDuration(normalizedLiteralContent);
     } else if (type == GEO_WKT_LITERAL) {
       // Not all WKT literals represent points (we can only fold points)
       auto geopoint = GeoPoint::parseFromLiteral(literal, false);
       if (geopoint.has_value()) {
-        parser->lastParseResult_ = geopoint.value();
+        lastParseResult_ = geopoint.value();
       } else {
         literal.addDatatype(typeIri);
-        parser->lastParseResult_ = std::move(literal);
+        lastParseResult_ = std::move(literal);
       }
     } else {
       literal.addDatatype(typeIri);
-      parser->lastParseResult_ = std::move(literal);
+      lastParseResult_ = std::move(literal);
     }
   } catch (const DateParseException& ex) {
     makeNormalLiteral(ex);
@@ -589,9 +588,9 @@ TripleComponent TurtleParser<T>::literalAndDatatypeToTripleComponentImpl(
   } catch (const CoordinateOutOfRangeException& ex) {
     makeNormalLiteral(ex);
   } catch (const std::exception& e) {
-    parser->raise(e.what());
+    raise(e.what());
   }
-  return parser->lastParseResult_;
+  return lastParseResult_;
 }
 
 // _____________________________________________________________________________
@@ -625,8 +624,8 @@ TripleComponent TurtleParser<T>::literalAndDatatypeToTripleComponent(
     const TripleComponent::Iri& typeIri) {
   RdfStringParser<TurtleParser<T>> parser;
 
-  return literalAndDatatypeToTripleComponentImpl(normalizedLiteralContent,
-                                                 typeIri, &parser);
+  return parser.literalAndDatatypeToTripleComponentImpl(
+      normalizedLiteralContent, typeIri);
 }
 
 // ______________________________________________________________________

--- a/src/parser/RdfParser.cpp
+++ b/src/parser/RdfParser.cpp
@@ -540,9 +540,9 @@ TripleComponent TurtleParser<T>::literalAndDatatypeToTripleComponentImpl(
       } else if (normalizedLiteralContent == "false") {
         lastParseResult_ = false;
       } else if (normalizedLiteralContent == "1") {
-        lastParseResult_ = Id::makeFromBinaryBool(true);
+        lastParseResult_ = Id::makeBoolFromZeroOrOne(true);
       } else if (normalizedLiteralContent == "0") {
-        lastParseResult_ = Id::makeFromBinaryBool(false);
+        lastParseResult_ = Id::makeBoolFromZeroOrOne(false);
       } else {
         raiseOrIgnoreTriple(absl::StrCat("Invalid boolean literal: '",
                                          normalizedLiteralContent, "'"));

--- a/src/parser/RdfParser.h
+++ b/src/parser/RdfParser.h
@@ -124,9 +124,9 @@ class TurtleParser : public RdfParserBase {
 
  private:
   // Impl of the method above, also used in rdfLiteral parsing.
-  static TripleComponent literalAndDatatypeToTripleComponentImpl(
+  TripleComponent literalAndDatatypeToTripleComponentImpl(
       std::string_view normalizedLiteralContent,
-      const TripleComponent::Iri& typeIri, TurtleParser<Tokenizer_T>* parser);
+      const TripleComponent::Iri& typeIri);
 
   static constexpr std::array<const char*, 12> integerDatatypes_ = {
       XSD_INT_TYPE,

--- a/src/parser/data/Variable.cpp
+++ b/src/parser/data/Variable.cpp
@@ -46,7 +46,8 @@ Variable::Variable(std::string name, bool checkName) : _name{std::move(name)} {
     const char* i = XSD_INT_TYPE;
     const char* d = XSD_DECIMAL_TYPE;
     const char* b = XSD_BOOLEAN_TYPE;
-    if (type == nullptr || type == i || type == d || type == b) {
+    if (type == nullptr || type == i || type == d ||
+        (type == b && literal.length() > 1)) {
       return std::move(literal);
     } else {
       return absl::StrCat("\"", literal, "\"^^<", type, ">");

--- a/test/ExportQueryExecutionTreesTest.cpp
+++ b/test/ExportQueryExecutionTreesTest.cpp
@@ -458,25 +458,29 @@ TEST(ExportQueryExecutionTrees, Bool) {
       kg, "CONSTRUCT {?s ?p ?o} WHERE {?s ?p ?o} ORDER BY ?o", 4, 4,
       // TSV
       "<s>\t<p>\tfalse\n"
-      "<s2>\t<p2>\t0\n"
+      "<s2>\t<p2>\t\"0\"^^<http://www.w3.org/2001/XMLSchema#boolean>\n"
       "<s>\t<p>\ttrue\n"
-      "<s2>\t<p2>\t1\n",
+      "<s2>\t<p2>\t\"1\"^^<http://www.w3.org/2001/XMLSchema#boolean>\n",
       // CSV
       "<s>,<p>,false\n"
-      "<s2>,<p2>,0\n"
+      "<s2>,<p2>,\"\"\"0\"\"^^<http://www.w3.org/2001/XMLSchema#boolean>\"\n"
       "<s>,<p>,true\n"
-      "<s2>,<p2>,1\n",
+      "<s2>,<p2>,\"\"\"1\"\"^^<http://www.w3.org/2001/XMLSchema#boolean>\"\n",
       // Turtle
       "<s> <p> false .\n"
-      "<s2> <p2> 0 .\n"
+      "<s2> <p2> \"0\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n"
       "<s> <p> true .\n"
-      "<s2> <p2> 1 .\n",
+      "<s2> <p2> \"1\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n",
       []() {
         nlohmann::json j;
         j.push_back(std::vector{"<s>"s, "<p>"s, "false"s});
-        j.push_back(std::vector{"<s2>"s, "<p2>"s, "0"s});
+        j.push_back(
+            std::vector{"<s2>"s, "<p2>"s,
+                        "\"0\"^^<http://www.w3.org/2001/XMLSchema#boolean>"s});
         j.push_back(std::vector{"<s>"s, "<p>"s, "true"s});
-        j.push_back(std::vector{"<s2>"s, "<p2>"s, "1"s});
+        j.push_back(
+            std::vector{"<s2>"s, "<p2>"s,
+                        "\"1\"^^<http://www.w3.org/2001/XMLSchema#boolean>"s});
         return j;
       }()};
   runConstructQueryTestCase(testCaseConstruct);

--- a/test/ExportQueryExecutionTreesTest.cpp
+++ b/test/ExportQueryExecutionTreesTest.cpp
@@ -403,7 +403,10 @@ TEST(ExportQueryExecutionTrees, Integers) {
 
 // ____________________________________________________________________________
 TEST(ExportQueryExecutionTrees, Bool) {
-  std::string kg = "<s> <p> true . <s> <p> false.";
+  std::string kg =
+      "<s> <p> true . <s> <p> false ."
+      " <s2> <p2> \"1\"^^<http://www.w3.org/2001/XMLSchema#boolean> ."
+      " <s2> <p2> \"0\"^^<http://www.w3.org/2001/XMLSchema#boolean> .";
   std::string query = "SELECT ?o WHERE {?s ?p ?o} ORDER BY ?o";
 
   std::string expectedXml = makeXMLHeader({"o"}) +
@@ -412,44 +415,68 @@ TEST(ExportQueryExecutionTrees, Bool) {
     <binding name="o"><literal datatype="http://www.w3.org/2001/XMLSchema#boolean">false</literal></binding>
   </result>
   <result>
+    <binding name="o"><literal datatype="http://www.w3.org/2001/XMLSchema#boolean">0</literal></binding>
+  </result>
+  <result>
     <binding name="o"><literal datatype="http://www.w3.org/2001/XMLSchema#boolean">true</literal></binding>
+  </result>
+  <result>
+    <binding name="o"><literal datatype="http://www.w3.org/2001/XMLSchema#boolean">1</literal></binding>
   </result>)" + xmlTrailer;
   TestCaseSelectQuery testCase{
-      kg, query, 2,
+      kg, query, 4,
       // TSV
       "?o\n"
       "false\n"
-      "true\n",
+      "0\n"
+      "true\n"
+      "1\n",
       // CSV
       "o\n"
       "false\n"
-      "true\n",
+      "0\n"
+      "true\n"
+      "1\n",
       makeExpectedQLeverJSON(
           {"\"false\"^^<http://www.w3.org/2001/XMLSchema#boolean>"s,
-           "\"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>"s}),
+           "\"0\"^^<http://www.w3.org/2001/XMLSchema#boolean>"s,
+           "\"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>"s,
+           "\"1\"^^<http://www.w3.org/2001/XMLSchema#boolean>"s}),
       makeExpectedSparqlJSON(
           {makeJSONBinding("http://www.w3.org/2001/XMLSchema#boolean",
                            "literal", "false"),
            makeJSONBinding("http://www.w3.org/2001/XMLSchema#boolean",
-                           "literal", "true")}),
+                           "literal", "0"),
+           makeJSONBinding("http://www.w3.org/2001/XMLSchema#boolean",
+                           "literal", "true"),
+           makeJSONBinding("http://www.w3.org/2001/XMLSchema#boolean",
+                           "literal", "1")}),
       expectedXml};
   runSelectQueryTestCase(testCase);
 
   TestCaseConstructQuery testCaseConstruct{
-      kg, "CONSTRUCT {?s ?p ?o} WHERE {?s ?p ?o} ORDER BY ?o", 2, 2,
+      kg, "CONSTRUCT {?s ?p ?o} WHERE {?s ?p ?o} ORDER BY ?o", 4, 4,
       // TSV
       "<s>\t<p>\tfalse\n"
-      "<s>\t<p>\ttrue\n",
+      "<s2>\t<p2>\t0\n"
+      "<s>\t<p>\ttrue\n"
+      "<s2>\t<p2>\t1\n",
       // CSV
       "<s>,<p>,false\n"
-      "<s>,<p>,true\n",
+      "<s2>,<p2>,0\n"
+      "<s>,<p>,true\n"
+      "<s2>,<p2>,1\n",
       // Turtle
       "<s> <p> false .\n"
-      "<s> <p> true .\n",
+      "<s2> <p2> 0 .\n"
+      "<s> <p> true .\n"
+      "<s2> <p2> 1 .\n",
       []() {
         nlohmann::json j;
         j.push_back(std::vector{"<s>"s, "<p>"s, "false"s});
+        j.push_back(std::vector{"<s2>"s, "<p2>"s, "0"s});
         j.push_back(std::vector{"<s>"s, "<p>"s, "true"s});
+        j.push_back(std::vector{"<s2>"s, "<p2>"s, "1"s});
         return j;
       }()};
   runConstructQueryTestCase(testCaseConstruct);

--- a/test/RdfParserTest.cpp
+++ b/test/RdfParserTest.cpp
@@ -723,9 +723,9 @@ TEST(RdfParserTest, booleanLiteralLongForm) {
     ruleChecker("\"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>", true);
     ruleChecker("\"false\"^^<http://www.w3.org/2001/XMLSchema#boolean>", false);
     ruleChecker("\"1\"^^<http://www.w3.org/2001/XMLSchema#boolean>",
-                Id::makeFromBinaryBool(true));
+                Id::makeBoolFromZeroOrOne(true));
     ruleChecker("\"0\"^^<http://www.w3.org/2001/XMLSchema#boolean>",
-                Id::makeFromBinaryBool(false));
+                Id::makeBoolFromZeroOrOne(false));
     EXPECT_THROW(
         ruleChecker("\"maybe\"^^<http://www.w3.org/2001/XMLSchema#boolean>",
                     Id::makeUndefined()),

--- a/test/RdfParserTest.cpp
+++ b/test/RdfParserTest.cpp
@@ -722,8 +722,14 @@ TEST(RdfParserTest, booleanLiteralLongForm) {
   auto runCommonTests = [](const auto& ruleChecker) {
     ruleChecker("\"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>", true);
     ruleChecker("\"false\"^^<http://www.w3.org/2001/XMLSchema#boolean>", false);
-    ruleChecker("\"maybe\"^^<http://www.w3.org/2001/XMLSchema#boolean>",
-                lit("\"maybe\""));
+    ruleChecker("\"1\"^^<http://www.w3.org/2001/XMLSchema#boolean>",
+                Id::makeFromBinaryBool(true));
+    ruleChecker("\"0\"^^<http://www.w3.org/2001/XMLSchema#boolean>",
+                Id::makeFromBinaryBool(false));
+    EXPECT_THROW(
+        ruleChecker("\"maybe\"^^<http://www.w3.org/2001/XMLSchema#boolean>",
+                    Id::makeUndefined()),
+        ParseException);
   };
   runCommonTests(checkParseResult<Re2Parser, &Re2Parser::rdfLiteral>);
   runCommonTests(checkParseResult<CtreParser, &CtreParser::rdfLiteral>);

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -610,8 +610,10 @@ TEST(SparqlExpression, stringOperators) {
            IdOrLiteralOrIriVec{lit("1"), lit("2"), lit("3")});
   checkStr(Ids{D(-1.0), D(1.0), D(2.34)},
            IdOrLiteralOrIriVec{lit("-1"), lit("1"), lit("2.34")});
-  checkStr(Ids{B(true), B(false), B(true)},
-           IdOrLiteralOrIriVec{lit("true"), lit("false"), lit("true")});
+  checkStr(Ids{B(true), B(false), Id::makeFromBinaryBool(true),
+               Id::makeFromBinaryBool(false)},
+           IdOrLiteralOrIriVec{lit("true"), lit("false"), lit("true"),
+                               lit("false")});
   checkStr(IdOrLiteralOrIriVec{lit("one"), lit("two"), lit("three")},
            IdOrLiteralOrIriVec{lit("one"), lit("two"), lit("three")});
   checkStr(IdOrLiteralOrIriVec{iriref("<http://example.org/str>"),

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -610,8 +610,8 @@ TEST(SparqlExpression, stringOperators) {
            IdOrLiteralOrIriVec{lit("1"), lit("2"), lit("3")});
   checkStr(Ids{D(-1.0), D(1.0), D(2.34)},
            IdOrLiteralOrIriVec{lit("-1"), lit("1"), lit("2.34")});
-  checkStr(Ids{B(true), B(false), Id::makeFromBinaryBool(true),
-               Id::makeFromBinaryBool(false)},
+  checkStr(Ids{B(true), B(false), Id::makeBoolFromZeroOrOne(true),
+               Id::makeBoolFromZeroOrOne(false)},
            IdOrLiteralOrIriVec{lit("true"), lit("false"), lit("true"),
                                lit("false")});
   checkStr(IdOrLiteralOrIriVec{lit("one"), lit("two"), lit("three")},

--- a/test/ValueIdTest.cpp
+++ b/test/ValueIdTest.cpp
@@ -108,14 +108,14 @@ TEST_F(ValueIdTest, makeFromInt) {
 
 // _____________________________________________________________________________
 TEST_F(ValueIdTest, makeFromBool) {
-  EXPECT_TRUE(ValueId::makeFromBinaryBool(true).getBool());
+  EXPECT_TRUE(ValueId::makeBoolFromZeroOrOne(true).getBool());
   EXPECT_TRUE(ValueId::makeFromBool(true).getBool());
-  EXPECT_FALSE(ValueId::makeFromBinaryBool(false).getBool());
+  EXPECT_FALSE(ValueId::makeBoolFromZeroOrOne(false).getBool());
   EXPECT_FALSE(ValueId::makeFromBool(false).getBool());
 
-  EXPECT_EQ(ValueId::makeFromBinaryBool(true).getBoolLiteral(), "1");
+  EXPECT_EQ(ValueId::makeBoolFromZeroOrOne(true).getBoolLiteral(), "1");
   EXPECT_EQ(ValueId::makeFromBool(true).getBoolLiteral(), "true");
-  EXPECT_EQ(ValueId::makeFromBinaryBool(false).getBoolLiteral(), "0");
+  EXPECT_EQ(ValueId::makeBoolFromZeroOrOne(false).getBoolLiteral(), "0");
   EXPECT_EQ(ValueId::makeFromBool(false).getBoolLiteral(), "false");
 }
 
@@ -359,8 +359,8 @@ TEST_F(ValueIdTest, toDebugString) {
   test(ValueId::makeFromDouble(42.0), "D:42.000000");
   test(ValueId::makeFromBool(false), "B:false");
   test(ValueId::makeFromBool(true), "B:true");
-  test(ValueId::makeFromBinaryBool(false), "B:false");
-  test(ValueId::makeFromBinaryBool(true), "B:true");
+  test(ValueId::makeBoolFromZeroOrOne(false), "B:false");
+  test(ValueId::makeBoolFromZeroOrOne(true), "B:true");
   test(makeVocabId(15), "V:15");
   auto str = LocalVocabEntry{
       ad_utility::triple_component::LiteralOrIri::literalWithoutQuotes(

--- a/test/ValueIdTest.cpp
+++ b/test/ValueIdTest.cpp
@@ -106,6 +106,19 @@ TEST_F(ValueIdTest, makeFromInt) {
   testOverflow(underflowingNBitGenerator);
 }
 
+// _____________________________________________________________________________
+TEST_F(ValueIdTest, makeFromBool) {
+  EXPECT_TRUE(ValueId::makeFromBinaryBool(true).getBool());
+  EXPECT_TRUE(ValueId::makeFromBool(true).getBool());
+  EXPECT_FALSE(ValueId::makeFromBinaryBool(false).getBool());
+  EXPECT_FALSE(ValueId::makeFromBool(false).getBool());
+
+  EXPECT_EQ(ValueId::makeFromBinaryBool(true).getBoolLiteral(), "1");
+  EXPECT_EQ(ValueId::makeFromBool(true).getBoolLiteral(), "true");
+  EXPECT_EQ(ValueId::makeFromBinaryBool(false).getBoolLiteral(), "0");
+  EXPECT_EQ(ValueId::makeFromBool(false).getBoolLiteral(), "false");
+}
+
 TEST_F(ValueIdTest, Indices) {
   auto testRandomIds = [&](auto makeId, auto getFromId, Datatype type) {
     auto testSingle = [&](auto value) {
@@ -346,6 +359,8 @@ TEST_F(ValueIdTest, toDebugString) {
   test(ValueId::makeFromDouble(42.0), "D:42.000000");
   test(ValueId::makeFromBool(false), "B:false");
   test(ValueId::makeFromBool(true), "B:true");
+  test(ValueId::makeFromBinaryBool(false), "B:false");
+  test(ValueId::makeFromBinaryBool(true), "B:true");
   test(makeVocabId(15), "V:15");
   auto str = LocalVocabEntry{
       ad_utility::triple_component::LiteralOrIri::literalWithoutQuotes(


### PR DESCRIPTION
In RDF and SPARQL, there can be four values with the Boolean datatype, namely: `"true"^^xsd:boolean`, `"false"^^xsd:boolean`, `"1"^^xsd:boolean`, and `"0"^^xsd:boolean`. They behave as follows:

1. When exporting them, the value should be exported as is (e.g., `"true"` should not become `"1"` or vice versa)
1. In an expression, `"1"` and `"true"` evaluate to true, `"0"` and `"false"` evaluate to false
3. When using the `STR` function, `"1"` and `"true"` both result in `"true"`, the other two both result in `"false"` (without datatype)
4. Any other than these four should result in a parse error with datatype `xsd:boolean`

QLever now handles this in full compliance with the standard. So far, alle values other then `"true"^^xsd:boolean` or `"false"^^xsd:boolean` were treated like ordinary string literals. Here is a SPARQQL query to check the correct behavior:
```
PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
SELECT ?bool (STR(?bool) AS ?str_bool) (IF(?bool, "YES", "NO") AS ?yes_or_no) WHERE {
  VALUES ?bool { "0"^^xsd:boolean  "false"^^xsd:boolean "1"^^xsd:boolean "true"^^xsd:boolean } 
}
```