### PR TITLE
Fix handling of `UNDEF` in first argument of `IF` function

### DIFF
--- a/src/engine/sparqlExpressions/ConditionalExpressions.cpp
+++ b/src/engine/sparqlExpressions/ConditionalExpressions.cpp
@@ -21,9 +21,11 @@ using namespace sparqlExpression::detail;
             std::is_rvalue_reference_v<decltype(e)&&>) {
   if (condition == EffectiveBooleanValueGetter::Result::True) {
     return AD_FWD(i);
-  } else {
+  } else if (condition == EffectiveBooleanValueGetter::Result::False) {
     return AD_FWD(e);
   }
+  AD_CORRECTNESS_CHECK(condition == EffectiveBooleanValueGetter::Result::Undef);
+  return IdOrLiteralOrIri{Id::makeUndefined()};
 };
 NARY_EXPRESSION(IfExpression, 3,
                 FV<decltype(ifImpl), EffectiveBooleanValueGetter,

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -1339,8 +1339,8 @@ TEST(SparqlExpression, ifAndCoalesce) {
   const auto T = Id::makeFromBool(true);
   const auto F = Id::makeFromBool(false);
 
-  checkIf(idOrLitOrStringVec({I(0), "eins", I(2), I(3), "vier", "fünf"}),
-          // UNDEF and the empty string are considered to be `false`.
+  checkIf(idOrLitOrStringVec({I(0), "eins", I(2), I(3), U, "fünf"}),
+          // The empty string is considered to be `false`.
           std::tuple{idOrLitOrStringVec({T, F, T, "true", U, ""}),
                      Ids{I(0), I(1), I(2), I(3), I(4), I(5)},
                      idOrLitOrStringVec(


### PR DESCRIPTION
For example, `IF(UNDEF, 1, 2)` should return `UNDEF`, and now indeed does. So far, it returned `2`.