### PR TITLE
Make the behavior for division by zero configurable

### DIFF
--- a/src/engine/sparqlExpressions/NaryExpressionImpl.h
+++ b/src/engine/sparqlExpressions/NaryExpressionImpl.h
@@ -110,7 +110,7 @@ struct NumericIdWrapper {
 // floating point) and converts it to a function, that takes the same arguments
 // and returns the same result, but the arguments and the return type are the
 // `NumericValue` variant.
-template <typename Function>
+template <typename Function, bool NanToUndef = false>
 inline auto makeNumericExpression() {
   return [](const auto&... args) {
     CPP_assert(
@@ -120,7 +120,7 @@ inline auto makeNumericExpression() {
                      std::is_same_v<NotNumeric, std::decay_t<decltype(t)>>)) {
         return Id::makeUndefined();
       } else {
-        return makeNumericId(Function{}(t...));
+        return makeNumericId<NanToUndef>(Function{}(t...));
       }
     };
     return std::visit(visitor, args...);

--- a/src/engine/sparqlExpressions/NaryExpressionImpl.h
+++ b/src/engine/sparqlExpressions/NaryExpressionImpl.h
@@ -110,7 +110,7 @@ struct NumericIdWrapper {
 // floating point) and converts it to a function, that takes the same arguments
 // and returns the same result, but the arguments and the return type are the
 // `NumericValue` variant.
-template <typename Function, bool NanToUndef = false>
+template <typename Function, bool NanOrInfToUndef = false>
 inline auto makeNumericExpression() {
   return [](const auto&... args) {
     CPP_assert(
@@ -120,7 +120,7 @@ inline auto makeNumericExpression() {
                      std::is_same_v<NotNumeric, std::decay_t<decltype(t)>>)) {
         return Id::makeUndefined();
       } else {
-        return makeNumericId<NanToUndef>(Function{}(t...));
+        return makeNumericId<NanOrInfToUndef>(Function{}(t...));
       }
     };
     return std::visit(visitor, args...);

--- a/src/engine/sparqlExpressions/NumericBinaryExpressions.cpp
+++ b/src/engine/sparqlExpressions/NumericBinaryExpressions.cpp
@@ -20,8 +20,8 @@ NARY_EXPRESSION(MultiplyExpression, 2,
 // between those two types, we have to choose one of the behaviors. We make the
 // result `UNDEF` in this case to pass the sparql conformance tests that rely on
 // this behavior. The old behavior can be reinstated by a RuntimeParameter.
-// Note: The result of a division in
-// SPARQL is always a decimal number, so there is no integer division.
+// Note: The result of a division in SPARQL is always a decimal number, so there
+// is no integer division.
 [[maybe_unused]] inline auto divideImpl = [](auto x, auto y) {
   return static_cast<double>(x) / static_cast<double>(y);
 };

--- a/src/engine/sparqlExpressions/NumericBinaryExpressions.cpp
+++ b/src/engine/sparqlExpressions/NumericBinaryExpressions.cpp
@@ -19,25 +19,18 @@ NARY_EXPRESSION(MultiplyExpression, 2,
 // like `NaN` or `infinity`, decimals don't). As we currently make no difference
 // between those two types, we have to choose one of the behaviors. We make the
 // result `UNDEF` in this case to pass the sparql conformance tests that rely on
-// this behavior.
+// this behavior. The old behavior can be reinstated by a RuntimeParameter.
 // Note: The result of a division in
 // SPARQL is always a decimal number, so there is no integer division.
-template <bool DivisionByZeroIsUndef>
 [[maybe_unused]] inline auto divideImpl = [](auto x, auto y) {
-  if constexpr (DivisionByZeroIsUndef) {
-    if (y == 0) {
-      return std::numeric_limits<double>::quiet_NaN();
-    }
-  }
   return static_cast<double>(x) / static_cast<double>(y);
 };
 
-inline auto divide1 = makeNumericExpression<decltype(divideImpl<true>), true>();
+inline auto divide1 = makeNumericExpression<decltype(divideImpl), true>();
 NARY_EXPRESSION(DivideExpressionByZeroIsUndef, 2,
                 FV<decltype(divide1), NumericValueGetter>);
 
-inline auto divide2 =
-    makeNumericExpression<decltype(divideImpl<false>), false>();
+inline auto divide2 = makeNumericExpression<decltype(divideImpl), false>();
 NARY_EXPRESSION(DivideExpressionByZeroIsNan, 2,
                 FV<decltype(divide2), NumericValueGetter>);
 

--- a/src/engine/sparqlExpressions/SparqlExpressionValueGetters.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionValueGetters.h
@@ -53,15 +53,15 @@ CPP_concept ValueAsNumericId =
     ad_utility::SimilarToAny<T, Id, NotNumeric, NumericValue>;
 
 // Convert a numeric value (either a plain number, or the `NumericValue` variant
-// from above) into an `ID`. When `NanToUndef` is `true` then floating point NaN
-// values will become `Id::makeUndefined()`.
-CPP_template(bool NanToUndef = false,
+// from above) into an `ID`. When `NanOrInfToUndef` is `true` then floating
+// point `NaN` or `+-infinity` values will become `Id::makeUndefined()`.
+CPP_template(bool NanOrInfToUndef = false,
              typename T)(requires ValueAsNumericId<T>) Id makeNumericId(T t) {
   if constexpr (concepts::integral<T>) {
     return Id::makeFromInt(t);
-  } else if constexpr (ad_utility::FloatingPoint<T> && NanToUndef) {
-    return std::isnan(t) ? Id::makeUndefined() : Id::makeFromDouble(t);
-  } else if constexpr (ad_utility::FloatingPoint<T> && !NanToUndef) {
+  } else if constexpr (ad_utility::FloatingPoint<T> && NanOrInfToUndef) {
+    return std::isfinite(t) ? Id::makeFromDouble(t) : Id::makeUndefined();
+  } else if constexpr (ad_utility::FloatingPoint<T> && !NanOrInfToUndef) {
     return Id::makeFromDouble(t);
   } else if constexpr (concepts::same_as<NotNumeric, T>) {
     return Id::makeUndefined();

--- a/src/global/RuntimeParameters.h
+++ b/src/global/RuntimeParameters.h
@@ -72,6 +72,12 @@ inline auto& RuntimeParameters() {
         // If set to `true`, we expect the contents of URLs loaded via a LOAD to
         // not change over time. This enables caching of LOAD operations.
         Bool<"cache-load-results">{false},
+        // If set to `true`, then a division by zero in an expression will lead
+        // to an
+        // expression error, meaning that the result is undefined. If set to
+        // false,
+        // the result will be `NaN` or `infinity` respectively.
+        Bool<"division-by-zero-is-undef">{true},
     };
   }();
   return params;


### PR DESCRIPTION
So far, divisions by zero were treated according to the IEEE standard for floating point numbers: 1/0 = infinity, -1/0 = -infinity, 0/0 = NaN. Now, all these divisions result in UNDEF, in compliance with the SPARQL standard.

The old behavior can be reinstated by setting the new runtime parameter `division-by-zero-is-undef` to `false`.

NOTE: These peculiarities arise from QLever not making a difference between `xsd:double` and `xsd:decimal`.