### PR TITLE
Don't drop `FILTER` operations with unbound variables

### DIFF
--- a/src/engine/CartesianProductJoin.cpp
+++ b/src/engine/CartesianProductJoin.cpp
@@ -400,7 +400,7 @@ Result::LazyResult CartesianProductJoin::createLazyConsumer(
             })});
   };
   return Result::LazyResult(ad_utility::CachingContinuableTransformInputRange(
-      std::move(lazyResult->idTables()), std::move(get)));
+      lazyResult->idTables(), std::move(get)));
 }
 
 // _____________________________________________________________________________

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -270,8 +270,8 @@ std::vector<SubtreePlan> QueryPlanner::optimize(
   // it might be, that we have not yet applied all the filters
   // (it might be, that the last join was optional and introduced new variables)
   if (!candidatePlans.empty()) {
-    applyFiltersIfPossible<true, true>(candidatePlans[0],
-                                       rootPattern->_filters);
+    applyFiltersIfPossible<FilterMode::ApplyAllFiltersAndReplaceUnfiltered>(
+        candidatePlans[0], rootPattern->_filters);
     applyTextLimitsIfPossible(candidatePlans[0],
                               TextLimitVec{rootPattern->textLimits_.begin(),
                                            rootPattern->textLimits_.end()},
@@ -290,7 +290,8 @@ std::vector<SubtreePlan> QueryPlanner::optimize(
       // or it only consists of a MINUS clause (which then has no effect).
       std::vector neutralPlans{makeSubtreePlan<NeutralElementOperation>(_qec)};
       // Neutral element can potentially still get filtered out
-      applyFiltersIfPossible<true, true>(neutralPlans, rootPattern->_filters);
+      applyFiltersIfPossible<FilterMode::ApplyAllFiltersAndReplaceUnfiltered>(
+          neutralPlans, rootPattern->_filters);
       return neutralPlans;
     }
     return candidatePlans[0];
@@ -1299,10 +1300,9 @@ string QueryPlanner::getPruningKey(
 }
 
 // _____________________________________________________________________________
-template <bool replace, bool alsoApplyIfMissingVariables>
+template <QueryPlanner::FilterMode mode>
 void QueryPlanner::applyFiltersIfPossible(
     vector<SubtreePlan>& row, const vector<SparqlFilter>& filters) const {
-  static_assert(!alsoApplyIfMissingVariables || replace);
   // Apply every filter possible.
   // It is possible when,
   // 1) the filter has not already been applied
@@ -1332,7 +1332,9 @@ void QueryPlanner::applyFiltersIfPossible(
         continue;
       }
 
-      if (alsoApplyIfMissingVariables ||
+      const bool applyAll =
+          mode == FilterMode::ApplyAllFiltersAndReplaceUnfiltered;
+      if (applyAll ||
           ql::ranges::all_of(filters[i].expression_.containedVariables(),
                              [&plan](const auto& variable) {
                                return plan._qet->isVariableCovered(*variable);
@@ -1344,7 +1346,7 @@ void QueryPlanner::applyFiltersIfPossible(
         newPlan._idsOfIncludedFilters |= (size_t(1) << i);
         newPlan._idsOfIncludedNodes = plan._idsOfIncludedNodes;
         newPlan.type = plan.type;
-        if constexpr (replace) {
+        if constexpr (mode != FilterMode::KeepUnfiltered) {
           plan = std::move(newPlan);
         } else {
           addedPlans.push_back(std::move(newPlan));
@@ -1439,7 +1441,7 @@ QueryPlanner::runDynamicProgrammingOnConnectedComponent(
   // (there might be duplicates because we already have multiple candidates
   // for each index scan with different permutations.
   dpTab.push_back(std::move(connectedComponent));
-  applyFiltersIfPossible<false>(dpTab.back(), filters);
+  applyFiltersIfPossible<FilterMode::KeepUnfiltered>(dpTab.back(), filters);
   applyTextLimitsIfPossible(dpTab.back(), textLimits, false);
   size_t numSeeds = findUniqueNodeIds(dpTab.back());
 
@@ -1451,7 +1453,7 @@ QueryPlanner::runDynamicProgrammingOnConnectedComponent(
       checkCancellation();
       auto newPlans = merge(dpTab[i - 1], dpTab[k - i - 1], tg);
       dpTab[k - 1].insert(dpTab[k - 1].end(), newPlans.begin(), newPlans.end());
-      applyFiltersIfPossible<false>(dpTab.back(), filters);
+      applyFiltersIfPossible<FilterMode::KeepUnfiltered>(dpTab.back(), filters);
       applyTextLimitsIfPossible(dpTab.back(), textLimits, false);
     }
     // As we only passed in connected components, we expect the result to always
@@ -1459,7 +1461,7 @@ QueryPlanner::runDynamicProgrammingOnConnectedComponent(
     AD_CORRECTNESS_CHECK(!dpTab[k - 1].empty());
   }
   auto& result = dpTab.back();
-  applyFiltersIfPossible<true>(result, filters);
+  applyFiltersIfPossible<FilterMode::ReplaceUnfiltered>(result, filters);
   applyTextLimitsIfPossible(result, textLimits, true);
   return std::move(result);
 }
@@ -1541,7 +1543,8 @@ std::vector<SubtreePlan> QueryPlanner::runGreedyPlanningOnConnectedComponent(
     std::vector<SubtreePlan> connectedComponent,
     const vector<SparqlFilter>& filters, const TextLimitVec& textLimits,
     const TripleGraph& tg) const {
-  applyFiltersIfPossible<true>(connectedComponent, filters);
+  applyFiltersIfPossible<FilterMode::ReplaceUnfiltered>(connectedComponent,
+                                                        filters);
   applyTextLimitsIfPossible(connectedComponent, textLimits, true);
   const size_t numSeeds = findUniqueNodeIds(connectedComponent);
   if (numSeeds <= 1) {
@@ -1574,7 +1577,7 @@ std::vector<SubtreePlan> QueryPlanner::runGreedyPlanningOnConnectedComponent(
     // compute all possible combinations.
     auto newPlans = isFirstStep ? merge(currentPlans, currentPlans, tg)
                                 : merge(currentPlans, nextBestPlan, tg);
-    applyFiltersIfPossible<true>(newPlans, filters);
+    applyFiltersIfPossible<FilterMode::ReplaceUnfiltered>(newPlans, filters);
     applyTextLimitsIfPossible(newPlans, textLimits, true);
     AD_CORRECTNESS_CHECK(!newPlans.empty());
     ql::ranges::move(newPlans, std::back_inserter(cache));
@@ -1655,7 +1658,8 @@ vector<vector<SubtreePlan>> QueryPlanner::fillDpTab(
   }
   if (numConnectedComponents == 1) {
     // A Cartesian product is not needed if there is only one component.
-    applyFiltersIfPossible<true>(lastDpRowFromComponents.back(), filters);
+    applyFiltersIfPossible<FilterMode::ReplaceUnfiltered>(
+        lastDpRowFromComponents.back(), filters);
     applyTextLimitsIfPossible(lastDpRowFromComponents.back(), textLimitVec,
                               true);
     return lastDpRowFromComponents;
@@ -1687,7 +1691,7 @@ vector<vector<SubtreePlan>> QueryPlanner::fillDpTab(
   plan._idsOfIncludedNodes = nodes;
   plan._idsOfIncludedFilters = filterIds;
   plan.idsOfIncludedTextLimits_ = textLimitIds;
-  applyFiltersIfPossible<true>(result.at(0), filters);
+  applyFiltersIfPossible<FilterMode::ReplaceUnfiltered>(result.at(0), filters);
   applyTextLimitsIfPossible(result.at(0), textLimitVec, true);
   return result;
 }

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -428,8 +428,24 @@ class QueryPlanner {
   string getPruningKey(const SubtreePlan& plan,
                        const vector<ColumnIndex>& orderedOnColumns) const;
 
-  template <bool replaceInsteadOfAddPlans,
-            bool alsoAddFiltersWithMissingVariables = false>
+  // Configure the behavior of the `applyFiltersIfPossible` function below.
+  enum class FilterMode {
+    // Only apply matching filters, that is filters are only added to plans that
+    // already bind all the variables that are used in the filter. The plans
+    // with the added filters are added to the candidate set. This mode is used
+    // in the dynamic programming approach, where we don't apply the filters
+    // greedily.
+    KeepUnfiltered,
+    // Only apply matching filters (see above), but the plans with added filters
+    // replace the plans without filters. This is used in the greedy approach,
+    // where filters are always applied as early as possible.
+    ReplaceUnfiltered,
+    // Apply all filters (also the nonmatching ones) and replace the unfiltered
+    // plans. This has to be called at the end of parsing a group graph pattern
+    // where we have to make sure that all filters are applied.
+    ApplyAllFiltersAndReplaceUnfiltered,
+  };
+  template <FilterMode mode = FilterMode::KeepUnfiltered>
   void applyFiltersIfPossible(std::vector<SubtreePlan>& row,
                               const std::vector<SparqlFilter>& filters) const;
 

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -428,7 +428,8 @@ class QueryPlanner {
   string getPruningKey(const SubtreePlan& plan,
                        const vector<ColumnIndex>& orderedOnColumns) const;
 
-  template <bool replaceInsteadOfAddPlans>
+  template <bool replaceInsteadOfAddPlans,
+            bool alsoAddFiltersWithMissingVariables = false>
   void applyFiltersIfPossible(std::vector<SubtreePlan>& row,
                               const std::vector<SparqlFilter>& filters) const;
 

--- a/src/engine/Union.cpp
+++ b/src/engine/Union.cpp
@@ -313,7 +313,8 @@ IdTable Union::transformToCorrectColumnFormat(
     IdTable idTable, const std::vector<ColumnIndex>& permutation) const {
   // NOTE: previously the check was for `getResultWidth()`, but that is wrong if
   // some variables in the subtree are invisible because of a subquery.
-  auto maxNumRequiredColumns = ql::ranges::max(permutation) + 1;
+  auto maxNumRequiredColumns =
+      permutation.empty() ? ColumnIndex{0} : ql::ranges::max(permutation) + 1;
   while (idTable.numColumns() < maxNumRequiredColumns) {
     idTable.addEmptyColumn();
     ad_utility::chunkedFill(idTable.getColumn(idTable.numColumns() - 1),

--- a/src/engine/idTable/IdTable.h
+++ b/src/engine/idTable/IdTable.h
@@ -623,7 +623,7 @@ class IdTable {
     std::vector<ColumnIndex> check{subset.begin(), subset.end()};
     ql::ranges::sort(check);
     AD_CONTRACT_CHECK(std::unique(check.begin(), check.end()) == check.end());
-    AD_CONTRACT_CHECK(!subset.empty() && subset.back() < numColumns());
+    AD_CONTRACT_CHECK(subset.empty() || subset.back() < numColumns());
 
     AD_CONTRACT_CHECK(
         isDynamic || subset.size() == NumColumns,

--- a/test/IdTableTest.cpp
+++ b/test/IdTableTest.cpp
@@ -1016,7 +1016,6 @@ TEST(IdTable, setColumnSubset) {
 
   // Empty column subset
   t.setColumnSubset(std::array<ColumnIndex, 0>{});
-  ;
   ASSERT_EQ(0, t.numColumns());
 
   // Duplicate columns are not allowed.

--- a/test/IdTableTest.cpp
+++ b/test/IdTableTest.cpp
@@ -1014,8 +1014,11 @@ TEST(IdTable, setColumnSubset) {
   ASSERT_THAT(t.getColumn(0), ::testing::ElementsAre(20, 21, 22));
   ASSERT_THAT(t.getColumn(1), ::testing::ElementsAre(0, 1, 2));
 
-  // Empty column subset is not allowed.
-  ASSERT_ANY_THROW(t.setColumnSubset(std::vector<ColumnIndex>{}));
+  // Empty column subset
+  t.setColumnSubset(std::array<ColumnIndex, 0>{});
+  ;
+  ASSERT_EQ(0, t.numColumns());
+
   // Duplicate columns are not allowed.
   ASSERT_ANY_THROW(t.setColumnSubset(std::vector<ColumnIndex>{0, 0, 1}));
   // A column index is out of range.

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -4250,3 +4250,12 @@ TEST(QueryPlanner, propertyPathWithSameVariableTwiceBound) {
                                   "?_QLever_internal_variable_qp_0", "<a>",
                                   "?_QLever_internal_variable_qp_1")));
 }
+
+// _____________________________________________________________________________
+TEST(QueryPlanner, filtersWithUnboundVariables) {
+  auto scan = h::IndexScanFromStrings;
+  h::expect("SELECT * { ?a ?b ?c FILTER(?c = ?d) }",
+            h::Filter("?c = ?d", scan("?a", "?b", "?c")));
+  h::expect("SELECT * { FILTER(?c = 1) }",
+            h::Filter("?c = 1", h::NeutralElement()));
+}

--- a/test/UnionTest.cpp
+++ b/test/UnionTest.cpp
@@ -198,7 +198,7 @@ TEST(Union, inputWithZeroColumns) {
     qec->getQueryTreeCache().clearAll();
     auto resultTable = u.computeResultOnlyForTesting(true);
     ASSERT_FALSE(resultTable.isFullyMaterialized());
-    auto& result = resultTable.idTables();
+    auto result = resultTable.idTables();
 
     auto expected1 = makeIdTableFromVector({{}});
 

--- a/test/UnionTest.cpp
+++ b/test/UnionTest.cpp
@@ -186,6 +186,43 @@ TEST(Union, ensurePermutationIsAppliedCorrectly) {
 }
 
 // _____________________________________________________________________________
+TEST(Union, inputWithZeroColumns) {
+  auto* qec = ad_utility::testing::getQec();
+  auto leftT = ad_utility::makeExecutionTree<NeutralElementOperation>(qec);
+  auto rightT = ad_utility::makeExecutionTree<NeutralElementOperation>(qec);
+
+  Union u{qec, std::move(leftT), std::move(rightT)};
+
+  {
+    qec->getQueryTreeCache().clearAll();
+    auto resultTable = u.computeResultOnlyForTesting(true);
+    ASSERT_FALSE(resultTable.isFullyMaterialized());
+    auto& result = resultTable.idTables();
+
+    auto expected1 = makeIdTableFromVector({{}});
+
+    auto iterator = result.begin();
+    ASSERT_NE(iterator, result.end());
+    ASSERT_EQ(iterator->idTable_, expected1);
+
+    ++iterator;
+    ASSERT_NE(iterator, result.end());
+    ASSERT_EQ(iterator->idTable_, expected1);
+
+    ASSERT_EQ(++iterator, result.end());
+  }
+
+  {
+    qec->getQueryTreeCache().clearAll();
+    auto resultTable = u.computeResultOnlyForTesting();
+    ASSERT_TRUE(resultTable.isFullyMaterialized());
+
+    auto expected = makeIdTableFromVector({{}, {}});
+    EXPECT_EQ(resultTable.idTable(), expected);
+  }
+}
+
+// _____________________________________________________________________________
 TEST(Union, clone) {
   auto* qec = ad_utility::testing::getQec();
 


### PR DESCRIPTION
So far, QLever silently dropped `FILTER` operations that referred to variables that were unbound in the respective group graph pattern. This is now fixed. For example, the following query now has an empty result as it should:
```sparql
SELECT * {
  BIND (3 as ?a)
  FILTER (?a < ?b)
}
```