### PR TITLE
Make `LANG` function return the empty string for numeric literals

### DIFF
--- a/src/engine/sparqlExpressions/SparqlExpressionValueGetters.cpp
+++ b/src/engine/sparqlExpressions/SparqlExpressionValueGetters.cpp
@@ -409,9 +409,8 @@ std::optional<std::string> LanguageTagValueGetter::operator()(
     case WordVocabIndex:
     case BlankNodeIndex:
       return getValue<std::optional<std::string>>(id, context, *this);
-    default:
-      AD_FAIL();
   }
+  AD_FAIL();
 }
 
 //______________________________________________________________________________

--- a/src/engine/sparqlExpressions/SparqlExpressionValueGetters.cpp
+++ b/src/engine/sparqlExpressions/SparqlExpressionValueGetters.cpp
@@ -392,7 +392,19 @@ sparqlExpression::IdOrLiteralOrIri IriOrUriValueGetter::operator()(
 //______________________________________________________________________________
 std::optional<std::string> LanguageTagValueGetter::operator()(
     ValueId id, const EvaluationContext* context) const {
-  return getValue<std::optional<std::string>>(id, context, *this);
+  using enum Datatype;
+  switch (id.getDatatype()) {
+    case Bool:
+    case Int:
+    case Double:
+    case Date:
+    case GeoPoint:
+      // For literals without language tag, we return an empty string per
+      // standard.
+      return {""};
+    default:
+      return getValue<std::optional<std::string>>(id, context, *this);
+  }
 }
 
 //______________________________________________________________________________

--- a/src/engine/sparqlExpressions/SparqlExpressionValueGetters.cpp
+++ b/src/engine/sparqlExpressions/SparqlExpressionValueGetters.cpp
@@ -402,8 +402,15 @@ std::optional<std::string> LanguageTagValueGetter::operator()(
       // For literals without language tag, we return an empty string per
       // standard.
       return {""};
-    default:
+    case Undefined:
+    case VocabIndex:
+    case LocalVocabIndex:
+    case TextRecordIndex:
+    case WordVocabIndex:
+    case BlankNodeIndex:
       return getValue<std::optional<std::string>>(id, context, *this);
+    default:
+      AD_FAIL();
   }
 }
 

--- a/test/LanguageExpressionsTest.cpp
+++ b/test/LanguageExpressionsTest.cpp
@@ -135,7 +135,10 @@ auto litOrIri = [](const std::string& literal) {
 // ____________________________________________________________________________
 auto assertLangTagValueGetter =
     [](const std::vector<Id>& input, const std::vector<strOpt>& expected,
-       LanguageTagGetter& langTagValueGetter, TestContext& testContext) {
+       LanguageTagGetter& langTagValueGetter, TestContext& testContext,
+       ad_utility::source_location loc =
+           ad_utility::source_location::current()) {
+      auto trace = generateLocationTrace(loc);
       EXPECT_EQ(input.size(), expected.size());
       auto ctx = &testContext.context;
       for (size_t i = 0; i < input.size(); i++) {
@@ -185,7 +188,7 @@ TEST(LanguageTagGetter, testLanguageTagValueGetterWithoutVocabId) {
   // return values w.r.t. LanguageTagValueGetter
   std::vector<Id> in = {dateId1,    dateId2,          F, T,
                         IntId(323), DoubleId(234.23), U};
-  std::vector<strOpt> expected(7, std::nullopt);
+  std::vector<strOpt> expected{"", "", "", "", "", "", std::nullopt};
 
   assertLangTagValueGetter(in, expected, langTagGetter, testContext);
 
@@ -234,7 +237,8 @@ TEST(LangExpression, testLangExpressionOnLiteralColumn) {
 // ____________________________________________________________________________
 TEST(LangExpression, testLangExpressionOnMixedColumn) {
   testLanguageExpressions<getLangExpression, IdOrLiteralOrIri>(
-      {U, U, litOrIri("de"), U, U, U, U, litOrIri("")}, "?mixed");
+      {litOrIri(""), litOrIri(""), litOrIri("de"), U, U, U, U, litOrIri("")},
+      "?mixed");
 }
 
 // ____________________________________________________________________________
@@ -274,13 +278,13 @@ TEST(SparqlExpression, testLangMatchesOnLiteralColumn) {
 // ____________________________________________________________________________
 TEST(SparqlExpression, testLangMatchesOnMixedColumn) {
   testLanguageExpressions<getLangMatchesExpression, Id>(
-      {U, U, T, U, U, U, U, F}, "?mixed", "de");
+      {F, F, T, U, U, U, U, F}, "?mixed", "de");
   testLanguageExpressions<getLangMatchesExpression, Id>(
-      {U, U, T, U, U, U, U, F}, "?mixed", "dE");
+      {F, F, T, U, U, U, U, F}, "?mixed", "dE");
   testLanguageExpressions<getLangMatchesExpression, Id>(
-      {U, U, T, U, U, U, U, F}, "?mixed", "*");
+      {F, F, T, U, U, U, U, F}, "?mixed", "*");
   testLanguageExpressions<getLangMatchesExpression, Id>(
-      {U, U, F, U, U, U, U, F}, "?mixed", "en-US");
+      {F, F, F, U, U, U, U, F}, "?mixed", "en-US");
   testLanguageExpressions<getLangMatchesExpression, Id>(
-      {U, U, F, U, U, U, U, F}, "?mixed", "");
+      {F, F, F, U, U, U, U, F}, "?mixed", "");
 }


### PR DESCRIPTION
The `LANG` function applied to numeric literals should return the empty string. Due to a regression inadvertently introduced in #2099, QLever returned UNDEF. This is now fixed.