### PR TITLE
Fix bug in `TransitivePathBase::knownEmptyResult` for empty path

### DIFF
--- a/src/engine/TransitivePathBase.cpp
+++ b/src/engine/TransitivePathBase.cpp
@@ -301,13 +301,12 @@ VariableToColumnMap TransitivePathBase::computeVariableToColumnMap() const {
 
 // _____________________________________________________________________________
 bool TransitivePathBase::knownEmptyResult() {
-  // When minDist_ == 0, then there always needs to be a starting tree bound for
-  // correct results, so it is safe to call `std::optional<>::value()` without a
-  // prior check.
-  return subtree_->knownEmptyResult() &&
-         (minDist_ > 0 || decideDirection()
-                              .first.treeAndCol_.value()
-                              .first->knownEmptyResult());
+  auto sideHasKnownEmptyResult = [this]() {
+    auto tree = decideDirection().first.treeAndCol_;
+    return tree.has_value() && tree.value().first->knownEmptyResult();
+  };
+  return (subtree_->knownEmptyResult() && minDist_ > 0) ||
+         sideHasKnownEmptyResult();
 }
 
 // _____________________________________________________________________________

--- a/test/TransitivePathTest.cpp
+++ b/test/TransitivePathTest.cpp
@@ -212,7 +212,7 @@ TEST_P(TransitivePathTest, knownEmptyResult) {
                              emptySub.clone(), 0, vars, left, right, 0,
                              std::numeric_limits<size_t>::max());
       EXPECT_TRUE(T->isBoundOrId());
-      EXPECT_FALSE(T->knownEmptyResult());
+      EXPECT_TRUE(T->knownEmptyResult());
     }
   }
 }


### PR DESCRIPTION
The implementation for `TransitivePathBase::knownEmptyResult()` returned `true` for empty paths with a non-empty result, which led to an assertion error. This is now fixed and a query like the following now returns the correct result:
```sparql
SELECT * {
 ?s <nexistepas>* ?o
}
```