### PR TITLE
Fix `STRAFTER` and `STRBEFORE` for incompatible language tags

### DIFF
--- a/src/engine/sparqlExpressions/StringExpressions.cpp
+++ b/src/engine/sparqlExpressions/StringExpressions.cpp
@@ -314,42 +314,43 @@ using ContainsExpression =
 // STRAFTER / STRBEFORE
 template <bool isStrAfter>
 [[maybe_unused]] auto strAfterOrBeforeImpl =
-    [](std::optional<ad_utility::triple_component::Literal> literal,
+    [](std::optional<ad_utility::triple_component::Literal> optLiteral,
        std::optional<ad_utility::triple_component::Literal> optPattern)
     -> IdOrLiteralOrIri {
-  if (!optPattern.has_value() || !literal.has_value()) {
+  if (!optPattern.has_value() || !optLiteral.has_value()) {
     return Id::makeUndefined();
   }
+  auto& literal = optLiteral.value();
   const auto& patternLit = optPattern.value();
   // Check if arguments are compatible with their language tags.
   if (patternLit.hasLanguageTag() &&
-      (!literal.value().hasLanguageTag() ||
-       literal.value().getLanguageTag() != patternLit.getLanguageTag())) {
+      (!literal.hasLanguageTag() ||
+       literal.getLanguageTag() != patternLit.getLanguageTag())) {
     return Id::makeUndefined();
   }
   const auto& pattern = asStringViewUnsafe(optPattern.value().getContent());
   //  Required by the SPARQL standard.
   if (pattern.empty()) {
     if (isStrAfter) {
-      return LiteralOrIri(std::move(literal.value()));
+      return LiteralOrIri(std::move(literal));
     } else {
-      literal.value().setSubstr(0, 0);
-      return LiteralOrIri(std::move(literal.value()));
+      literal.setSubstr(0, 0);
+      return LiteralOrIri(std::move(literal));
     }
   }
-  auto literalContent = literal.value().getContent();
+  auto literalContent = literal.getContent();
   auto pos = asStringViewUnsafe(literalContent).find(pattern);
   if (pos >= literalContent.size()) {
     return toLiteral("");
   }
   if constexpr (isStrAfter) {
-    literal.value().setSubstr(pos + pattern.size(),
-                              literalContent.size() - pos - pattern.size());
+    literal.setSubstr(pos + pattern.size(),
+                      literalContent.size() - pos - pattern.size());
   } else {
     // STRBEFORE
-    literal.value().setSubstr(0, pos);
+    literal.setSubstr(0, pos);
   }
-  return LiteralOrIri(std::move(literal.value()));
+  return LiteralOrIri(std::move(literal));
 };
 
 auto strAfter = strAfterOrBeforeImpl<true>;

--- a/src/engine/sparqlExpressions/StringExpressions.cpp
+++ b/src/engine/sparqlExpressions/StringExpressions.cpp
@@ -320,6 +320,13 @@ template <bool isStrAfter>
   if (!optPattern.has_value() || !literal.has_value()) {
     return Id::makeUndefined();
   }
+  const auto& patternLit = optPattern.value();
+  // Check if arguments are compatible with their language tags.
+  if (patternLit.hasLanguageTag() &&
+      (!literal.value().hasLanguageTag() ||
+       literal.value().getLanguageTag() != patternLit.getLanguageTag())) {
+    return Id::makeUndefined();
+  }
   const auto& pattern = asStringViewUnsafe(optPattern.value().getContent());
   //  Required by the SPARQL standard.
   if (pattern.empty()) {

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -766,16 +766,18 @@ TEST(SparqlExpression, binaryStringOperations) {
   checkStrAfter(
       IdOrLiteralOrIriVec{lit("bc"), lit("abc"), lit("c", "@en"), lit(""),
                           lit("abc", "@en"), lit("abc", "@en"), lit(""),
-                          lit("abc", "@en")},
+                          lit("abc", "@en"), U, U},
       IdOrLiteralOrIriVec{
           lit("abc", "^^<http://www.w3.org/2001/XMLSchema#string>"),
           lit("abc", "^^<http://www.w3.org/2001/XMLSchema#string>"),
           lit("abc", "@en"), lit("abc", "@en"), lit("abc", "@en"),
-          lit("abc", "@en"), lit("abc", "@en"), lit("abc", "@en")},
+          lit("abc", "@en"), lit("abc", "@en"), lit("abc", "@en"), lit("abc"),
+          lit("abc", "@en")},
       IdOrLiteralOrIriVec{
           lit("a"), lit(""), lit("ab"), lit("z"), lit(""), lit("", "@en"),
           lit("z", "@en"),
-          lit("", "^^<http://www.w3.org/2001/XMLSchema#string>")});
+          lit("", "^^<http://www.w3.org/2001/XMLSchema#string>"),
+          lit("a", "@en"), lit("a", "@de")});
 
   checkStrBefore(
       S({U, U, "", "", "", "", "Hä", "", "", "Hä"}),
@@ -783,16 +785,18 @@ TEST(SparqlExpression, binaryStringOperations) {
       S({"", U, "", "x", "", "ullo", "ll", "Hällo", "Hällox", "l"}));
   checkStrBefore(IdOrLiteralOrIriVec{lit("a"), lit(""), lit("a", "@en"),
                                      lit(""), lit("", "@en"), lit("", "@en"),
-                                     lit(""), lit("", "@en")},
+                                     lit(""), lit("", "@en"), U, U},
                  IdOrLiteralOrIriVec{
                      lit("abc", "^^<http://www.w3.org/2001/XMLSchema#string>"),
                      lit("abc", "^^<http://www.w3.org/2001/XMLSchema#string>"),
                      lit("abc", "@en"), lit("abc", "@en"), lit("abc", "@en"),
-                     lit("abc", "@en"), lit("abc", "@en"), lit("abc", "@en")},
+                     lit("abc", "@en"), lit("abc", "@en"), lit("abc", "@en"),
+                     lit("abc"), lit("abc", "@en")},
                  IdOrLiteralOrIriVec{
                      lit("bc"), lit(""), lit("bc"), lit("z"), lit(""),
                      lit("", "@en"), lit("z", "@en"),
-                     lit("", "^^<http://www.w3.org/2001/XMLSchema#string>")});
+                     lit("", "^^<http://www.w3.org/2001/XMLSchema#string>"),
+                     lit("bc", "@en"), lit("bc", "@de")});
 }
 
 // ______________________________________________________________________________


### PR DESCRIPTION
When the language tags of the two arguments to `STRAFTER` or `STRBEFORE` are incompatible, as in `STRAFTER("abc", "b"@en)` or `STRAFTER("abc"@de, "b"@en)`, the result should be UNDEF. This is now fixed.