### PR TITLE
Return `Result::idTables()` by value

### DIFF
--- a/src/engine/Distinct.cpp
+++ b/src/engine/Distinct.cpp
@@ -80,9 +80,8 @@ Result Distinct::computeResult(bool requestLaziness) {
             subRes->getSharedLocalVocab()};
   }
 
-  auto generator =
-      CALL_FIXED_SIZE(width, &Distinct::lazyDistinct, this,
-                      std::move(subRes->idTables()), !requestLaziness);
+  auto generator = CALL_FIXED_SIZE(width, &Distinct::lazyDistinct, this,
+                                   subRes->idTables(), !requestLaziness);
   return requestLaziness
              ? Result{std::move(generator), resultSortedOn()}
              : Result{cppcoro::getSingleElement(std::move(generator)),

--- a/src/engine/ExistsJoin.cpp
+++ b/src/engine/ExistsJoin.cpp
@@ -100,7 +100,7 @@ Result ExistsJoin::computeResult(bool requestLaziness) {
     // Forward lazy result, otherwise let the existing code handle the join with
     // no column.
     return {Result::LazyResult{
-                ad_utility::OwningView{std::move(leftRes->idTables())} |
+                ad_utility::OwningView{leftRes->idTables()} |
                 ql::views::transform([exists = !right.empty(),
                                       leftRes](Result::IdTableVocabPair& pair) {
                   // Make sure we keep this shared ptr alive until the result is

--- a/src/engine/GroupByImpl.cpp
+++ b/src/engine/GroupByImpl.cpp
@@ -397,7 +397,7 @@ Result GroupByImpl::computeResult(bool requestLaziness) {
           std::array{std::pair{std::cref(subresult->idTable()),
                                std::cref(subresult->localVocab())}});
     } else {
-      return computeWithHashMap(std::move(subresult->idTables()));
+      return computeWithHashMap(subresult->idTables());
     }
   }
 

--- a/src/engine/Join.cpp
+++ b/src/engine/Join.cpp
@@ -634,8 +634,7 @@ Result Join::computeResultForIndexScanAndIdTable(
                 scan->getResult(false, ComputationMode::LAZY_IF_SUPPORTED);
             AD_CORRECTNESS_CHECK(
                 !indexScanResult.value()->isFullyMaterialized());
-            return convertGenerator(
-                std::move(indexScanResult.value()->idTables()));
+            return convertGenerator(indexScanResult.value()->idTables());
           } else {
             auto rightBlocksInternal =
                 scan->lazyScanForJoinOfColumnWithScan(permutationIdTable.col());
@@ -690,8 +689,8 @@ Result Join::computeResultForIndexScanAndLazyOperation(
           std::function<void(IdTable&, LocalVocab&)> yieldTable) {
         auto rowAdder = makeRowAdder(std::move(yieldTable));
 
-        auto [joinSide, indexScanSide] = scan->prefilterTables(
-            std::move(resultWithIdTable->idTables()), _leftJoinCol);
+        auto [joinSide, indexScanSide] =
+            scan->prefilterTables(resultWithIdTable->idTables(), _leftJoinCol);
 
         // Note: The `zipperJoinForBlocksWithPotentialUndef` automatically
         // switches to a more efficient implementation if there are no UNDEF

--- a/src/engine/JoinHelpers.h
+++ b/src/engine/JoinHelpers.h
@@ -69,7 +69,7 @@ inline std::variant<LazyInputView, MaterializedInputView> resultToView(
   if (result.isFullyMaterialized()) {
     return asSingleTableView(result, permutation);
   }
-  return convertGenerator(std::move(result.idTables()), permutation);
+  return convertGenerator(result.idTables(), permutation);
 }
 
 using GeneratorWithDetails =

--- a/src/engine/NeutralOptional.cpp
+++ b/src/engine/NeutralOptional.cpp
@@ -127,10 +127,10 @@ Result NeutralOptional::computeResult(bool requestLaziness) {
             childResult->getSharedLocalVocab()};
   }
   if (singleRowCroppedByLimit()) {
-    return {std::move(childResult->idTables()), childResult->sortedBy()};
+    return {childResult->idTables(), childResult->sortedBy()};
   }
-  return {Result::LazyResult{WrapperWithEnsuredRow{
-              std::move(childResult->idTables()), std::move(singleRowTable)}},
+  return {Result::LazyResult{WrapperWithEnsuredRow{childResult->idTables(),
+                                                   std::move(singleRowTable)}},
           childResult->sortedBy()};
 }
 

--- a/src/engine/Result.h
+++ b/src/engine/Result.h
@@ -71,6 +71,7 @@ class Result {
     LocalVocabPtr localVocab_;
   };
   using Data = std::variant<IdTableSharedLocalVocabPair, GenContainer>;
+
   // The actual entries.
   Data data_;
 
@@ -80,8 +81,11 @@ class Result {
 
   // Note: If additional members and invariants are added to the class (for
   // example information about the datatypes in each column) make sure that
-  // those remain valid after calling non-const function like
-  // `applyLimitOffset`.
+  // 1. The members and invariants remain valid after calling non-const function
+  // like `applyLimitOffset`.
+  // 2. The generator returned by the `idTables()`method for lazy operations is
+  // valid even after the `Result` object from which it was obtained is
+  // destroyed.
 
   // This class is used to enforce the invariant, that the `localVocab_` (which
   // is stored in a shared_ptr) is only shared between instances of the
@@ -170,8 +174,12 @@ class Result {
   const IdTable& idTable() const;
 
   // Access to the underlying `IdTable`s. Throw an `ad_utility::Exception`
-  // if the underlying `data_` member holds the wrong variant.
-  LazyResult& idTables() const;
+  // if the underlying `data_` member holds the wrong variant or if the result
+  // has previously already been retrieved.
+  // Note: The returned `LazyResult` is not coupled to the `Result` object, and
+  // thus can be used even after the `Result` object from which it was obtained
+  // was destroyed.
+  LazyResult idTables() const;
 
   // Const access to the columns by which the `idTable()` is sorted.
   const std::vector<ColumnIndex>& sortedBy() const { return sortedBy_; }

--- a/src/engine/Service.cpp
+++ b/src/engine/Service.cpp
@@ -596,8 +596,7 @@ void Service::precomputeSiblingResult(std::shared_ptr<Operation> left,
   // result with subsequent calls to get(). Therefore, we do not need to
   // keep and pass an iterator to the sibling result if the max row threshold
   // is exceeded
-  auto generator =
-      moveToCachingInputRange(std::move(siblingResult->idTables()));
+  auto generator = moveToCachingInputRange(siblingResult->idTables());
   const size_t maxValueRows =
       RuntimeParameters().get<"service-max-value-rows">();
   while (auto pairOpt = generator.get()) {

--- a/test/FilterTest.cpp
+++ b/test/FilterTest.cpp
@@ -89,7 +89,7 @@ TEST(Filter, verifyPredicateIsAppliedCorrectlyOnLazyEvaluation) {
 
   auto result = filter.getResult(false, ComputationMode::LAZY_IF_SUPPORTED);
   ASSERT_FALSE(result->isFullyMaterialized());
-  auto& generator = result->idTables();
+  auto generator = result->idTables();
 
   auto referenceTable1 =
       makeIdTableFromVector({{true}, {true}, {true}}, asBool);

--- a/test/GroupByTest.cpp
+++ b/test/GroupByTest.cpp
@@ -2294,7 +2294,7 @@ TEST_P(GroupByLazyFixture, nestedAggregateFunctionsWork) {
   auto i = IntId;
 
   if (GetParam()) {
-    auto& generator = result.idTables();
+    auto generator = result.idTables();
 
     auto iterator = generator.begin();
     ASSERT_NE(iterator, generator.end());

--- a/test/JoinTest.cpp
+++ b/test/JoinTest.cpp
@@ -255,8 +255,7 @@ void testJoinOperation(Join& join, const ExpectedColumns& expected,
   IdTable table =
       res->isFullyMaterialized()
           ? res->idTable().clone()
-          : aggregateTables(std::move(res->idTables()), join.getResultWidth())
-                .first;
+          : aggregateTables(res->idTables(), join.getResultWidth()).first;
   ASSERT_EQ(table.numColumns(), expected.size());
   for (const auto& [var, columnAndStatus] : expected) {
     const auto& [colIndex, undefStatus] = varToCols.at(var);
@@ -779,7 +778,7 @@ TEST(JoinTest, errorInSeparateThreadIsPropagatedCorrectly) {
   auto result = join.getResult(false, ComputationMode::LAZY_IF_SUPPORTED);
   ASSERT_FALSE(result->isFullyMaterialized());
 
-  auto& idTables = result->idTables();
+  auto idTables = result->idTables();
   AD_EXPECT_THROW_WITH_MESSAGE_AND_TYPE(idTables.begin(),
                                         testing::StrEq("AlwaysFailOperation"),
                                         std::runtime_error);

--- a/test/OperationTest.cpp
+++ b/test/OperationTest.cpp
@@ -417,7 +417,7 @@ TEST(Operation, verifyRuntimeInformationIsUpdatedForLazyOperations) {
   EXPECT_GE(rti.originalOperationTime_, timeout);
 
   expectAtEachStageOfGenerator(
-      std::move(result.idTables()),
+      result.idTables(),
       {[&]() {
          EXPECT_EQ(rti.status_, Status::lazilyMaterialized);
          expectRtiHasDimensions(rti, 2, 1);
@@ -493,7 +493,7 @@ TEST(Operation, ensureSignalUpdateIsOnlyCalledEvery50msAndAtTheEnd) {
 
   EXPECT_EQ(updateCallCounter, 1);
 
-  expectAtEachStageOfGenerator(std::move(result.idTables()),
+  expectAtEachStageOfGenerator(result.idTables(),
                                {
                                    [&]() { EXPECT_EQ(updateCallCounter, 2); },
                                    [&]() { EXPECT_EQ(updateCallCounter, 2); },
@@ -525,7 +525,7 @@ TEST(Operation, ensureSignalUpdateIsCalledAtTheEndOfPartialConsumption) {
         operation.runComputation(timer, ComputationMode::LAZY_IF_SUPPORTED);
 
     EXPECT_EQ(updateCallCounter, 1);
-    auto& idTables = result.idTables();
+    auto idTables = result.idTables();
     // Only consume partially
     auto iterator = idTables.begin();
     ASSERT_NE(iterator, idTables.end());
@@ -558,7 +558,7 @@ TEST(Operation, verifyLimitIsProperlyAppliedAndUpdatesRuntimeInfoCorrectly) {
   expectRtiHasDimensions(rti, 0, 0);
   expectRtiHasDimensions(childRti, 0, 0);
 
-  expectAtEachStageOfGenerator(std::move(result.idTables()),
+  expectAtEachStageOfGenerator(result.idTables(),
                                {[&]() {
                                   expectRtiHasDimensions(rti, 2, 0);
                                   expectRtiHasDimensions(childRti, 2, 1);

--- a/test/ResultTest.cpp
+++ b/test/ResultTest.cpp
@@ -55,7 +55,7 @@ std::vector<Result::Generator> getAllSubSplits(const IdTable& idTable) {
 }
 
 // _____________________________________________________________________________
-void consumeGenerator(Result::LazyResult& generator) {
+void consumeGenerator(Result::LazyResult generator) {
   for ([[maybe_unused]] IdTableVocabPair& _ : generator) {
   }
 }

--- a/test/TransitivePathTest.cpp
+++ b/test/TransitivePathTest.cpp
@@ -105,7 +105,7 @@ class TransitivePathTest
     ASSERT_NE(result.isFullyMaterialized(), requestLaziness());
     if (requestLaziness()) {
       const auto& [idTable, localVocab] =
-          aggregateTables(std::move(result.idTables()), expected.numColumns());
+          aggregateTables(result.idTables(), expected.numColumns());
       EXPECT_THAT(idTable, UnorderedElementsAreArray(expected));
     } else {
       EXPECT_THAT(result.idTable(), UnorderedElementsAreArray(expected));

--- a/test/UnionTest.cpp
+++ b/test/UnionTest.cpp
@@ -115,7 +115,7 @@ TEST(Union, computeUnionLazy) {
     Union u{qec, std::move(leftT), std::move(rightT)};
     auto resultTable = u.computeResultOnlyForTesting(true);
     ASSERT_FALSE(resultTable.isFullyMaterialized());
-    auto& result = resultTable.idTables();
+    auto result = resultTable.idTables();
 
     auto U = Id::makeUndefined();
     auto expected1 = makeIdTableFromVector({{V(1), U}, {V(2), U}, {V(3), U}});
@@ -156,7 +156,7 @@ TEST(Union, ensurePermutationIsAppliedCorrectly) {
     qec->getQueryTreeCache().clearAll();
     auto resultTable = u.computeResultOnlyForTesting(true);
     ASSERT_FALSE(resultTable.isFullyMaterialized());
-    auto& result = resultTable.idTables();
+    auto result = resultTable.idTables();
 
     auto U = Id::makeUndefined();
     auto expected1 = makeIdTableFromVector({{1, 2, 3, 4, 5}});
@@ -218,7 +218,7 @@ TEST(Union, cheapMergeIfOrderNotImportant) {
     auto result =
         unionOperation.getResult(true, ComputationMode::LAZY_IF_SUPPORTED);
     EXPECT_FALSE(result->isFullyMaterialized());
-    auto& idTables = result->idTables();
+    auto idTables = result->idTables();
     auto expected1 = makeIdTableFromVector({{1, 2}});
     auto expected2 = makeIdTableFromVector({{0, 0}, {2, 4}});
 
@@ -263,7 +263,7 @@ TEST(Union, sortedMerge) {
     auto result =
         unionOperation.getResult(true, ComputationMode::LAZY_IF_SUPPORTED);
     auto expected = makeIdTableFromVector({{1, U, 4}, {1, 2, 4}, {2, U, 8}});
-    auto& idTables = result->idTables();
+    auto idTables = result->idTables();
     auto it = idTables.begin();
     ASSERT_NE(it, idTables.end());
     EXPECT_EQ(it->idTable_, expected);
@@ -296,7 +296,7 @@ TEST(Union, sortedMergeWithOneSideNonLazy) {
     qec->getQueryTreeCache().clearAll();
     auto result =
         unionOperation.getResult(true, ComputationMode::LAZY_IF_SUPPORTED);
-    auto& idTables = result->idTables();
+    auto idTables = result->idTables();
     auto it = idTables.begin();
     ASSERT_NE(it, idTables.end());
     EXPECT_EQ(it->idTable_, makeIdTableFromVector({{0}, {1}}));
@@ -350,7 +350,7 @@ TEST(Union, sortedMergeWithLocalVocab) {
     Union unionOperation{qec, std::move(leftT), std::move(rightT), {0}};
     auto result =
         unionOperation.getResult(true, ComputationMode::LAZY_IF_SUPPORTED);
-    auto& idTables = result->idTables();
+    auto idTables = result->idTables();
 
     auto it = idTables.begin();
     ASSERT_NE(it, idTables.end());
@@ -603,7 +603,7 @@ TEST(Union, checkChunkSizeSplitsProperly) {
   qec->getQueryTreeCache().clearAll();
   auto result =
       unionOperation.getResult(true, ComputationMode::LAZY_IF_SUPPORTED);
-  auto& idTables = result->idTables();
+  auto idTables = result->idTables();
 
   auto it = idTables.begin();
   ASSERT_NE(it, idTables.end());

--- a/test/engine/BindTest.cpp
+++ b/test/engine/BindTest.cpp
@@ -42,7 +42,7 @@ void expectBindYieldsIdTable(
     qec->getQueryTreeCache().clearAll();
     auto result = bind.getResult(false, ComputationMode::LAZY_IF_SUPPORTED);
     ASSERT_FALSE(result->isFullyMaterialized());
-    auto& idTables = result->idTables();
+    auto idTables = result->idTables();
     auto iterator = idTables.begin();
     ASSERT_NE(iterator, idTables.end());
     EXPECT_EQ(iterator->idTable_, expected);
@@ -123,7 +123,7 @@ TEST(
     qec->getQueryTreeCache().clearAll();
     auto result = bind.getResult(false, ComputationMode::LAZY_IF_SUPPORTED);
     ASSERT_FALSE(result->isFullyMaterialized());
-    auto& idTables = result->idTables();
+    auto idTables = result->idTables();
     auto iterator = idTables.begin();
     ASSERT_NE(iterator, idTables.end());
     EXPECT_EQ(iterator->idTable_, table);

--- a/test/engine/CartesianProductJoinTest.cpp
+++ b/test/engine/CartesianProductJoinTest.cpp
@@ -466,7 +466,7 @@ TEST_P(CartesianProductJoinLazyTest, allTablesSmallerThanChunk) {
       {1, 11, 102, 1000, 10001, 100001},
   });
 
-  auto materializedResult = aggregateTables(std::move(result.idTables()), 6);
+  auto materializedResult = aggregateTables(result.idTables(), 6);
   EXPECT_EQ(
       materializedResult.first,
       trimToLimitAndOffset(std::move(reference), getOffset(), getLimit()));
@@ -514,7 +514,7 @@ TEST_P(CartesianProductJoinLazyTest, leftTableBiggerThanChunk) {
   fillWithVocabValue(2, 12);
   reference.insertAtEnd(bigTable);
 
-  auto materializedResult = aggregateTables(std::move(result.idTables()), 4);
+  auto materializedResult = aggregateTables(result.idTables(), 4);
   EXPECT_EQ(
       materializedResult.first,
       trimToLimitAndOffset(std::move(reference), getOffset(), getLimit()));
@@ -591,7 +591,7 @@ TEST(CartesianProductJoinLazy, lazyTableTurnsOutEmpty) {
 
   auto result = join.computeResultOnlyForTesting(true);
   ASSERT_FALSE(result.isFullyMaterialized());
-  auto& generator = result.idTables();
+  auto generator = result.idTables();
   ASSERT_EQ(generator.begin(), generator.end());
 }
 
@@ -614,7 +614,7 @@ TEST(CartesianProductJoinLazy, lazyTableTurnsOutEmptyWithEmptyGenerator) {
 
   auto result = join.computeResultOnlyForTesting(true);
   ASSERT_FALSE(result.isFullyMaterialized());
-  auto& generator = result.idTables();
+  auto generator = result.idTables();
   ASSERT_EQ(generator.begin(), generator.end());
 }
 

--- a/test/engine/DistinctTest.cpp
+++ b/test/engine/DistinctTest.cpp
@@ -216,7 +216,7 @@ TEST(Distinct, lazyWithLazyInputs) {
   auto m = matchesIdTable;
   using ::testing::ElementsAre;
   EXPECT_THAT(
-      toVector(std::move(result->idTables())),
+      toVector(result->idTables()),
       ElementsAre(
           m(makeIdTableFromVector({{1, 1, 3, 7}})),
           m(makeIdTableFromVector({{2, 2, 3, 5}, {3, 6, 5, 4}})),

--- a/test/engine/ExistsJoinTest.cpp
+++ b/test/engine/ExistsJoinTest.cpp
@@ -184,7 +184,7 @@ TEST(Exists, testGeneratorIsForwardedForDistinctColumnsTrueCase) {
   auto result = existsJoin.computeResultOnlyForTesting(true);
   ASSERT_FALSE(result.isFullyMaterialized());
 
-  auto& idTables = result.idTables();
+  auto idTables = result.idTables();
   auto it = idTables.begin();
   ASSERT_NE(it, idTables.end());
   EXPECT_EQ(it->idTable_,
@@ -210,7 +210,7 @@ TEST(Exists, testGeneratorIsForwardedForDistinctColumnsFalseCase) {
   auto result = existsJoin.computeResultOnlyForTesting(true);
   ASSERT_FALSE(result.isFullyMaterialized());
 
-  auto& idTables = result.idTables();
+  auto idTables = result.idTables();
   auto it = idTables.begin();
   ASSERT_NE(it, idTables.end());
   EXPECT_EQ(it->idTable_,

--- a/test/engine/NeutralOptionalTest.cpp
+++ b/test/engine/NeutralOptionalTest.cpp
@@ -209,7 +209,7 @@ TEST(NeutralOptional, ensureEmptyResultWhenLimitCutsOffEverything) {
 
     qec->getQueryTreeCache().clearAll();
     auto result = no.computeResultOnlyForTesting(true);
-    auto& idTables = result.idTables();
+    auto idTables = result.idTables();
     EXPECT_EQ(idTables.begin(), idTables.end());
   }
   {
@@ -234,7 +234,7 @@ TEST(NeutralOptional, ensureEmptyResultWhenLimitCutsOffEverything) {
 
     qec->getQueryTreeCache().clearAll();
     auto result = no.computeResultOnlyForTesting(true);
-    auto& idTables = result.idTables();
+    auto idTables = result.idTables();
     EXPECT_EQ(idTables.begin(), idTables.end());
   }
 }
@@ -257,7 +257,7 @@ TEST(NeutralOptional, ensureSingleRowWhenChildIsEmpty) {
   {
     qec->getQueryTreeCache().clearAll();
     auto result = no.computeResultOnlyForTesting(true);
-    auto& idTables = result.idTables();
+    auto idTables = result.idTables();
 
     auto it = idTables.begin();
     ASSERT_NE(it, idTables.end());
@@ -300,7 +300,7 @@ TEST(NeutralOptional, ensureResultIsProperlyPropagated) {
     {
       qec->getQueryTreeCache().clearAll();
       auto result = no.computeResultOnlyForTesting(true);
-      auto& idTables = result.idTables();
+      auto idTables = result.idTables();
 
       auto it = idTables.begin();
       ASSERT_NE(it, idTables.end());
@@ -335,7 +335,7 @@ TEST(NeutralOptional, ensureResultIsProperlyPropagated) {
     no.applyLimitOffset({std::nullopt, 1});
     qec->getQueryTreeCache().clearAll();
     auto result = no.computeResultOnlyForTesting(true);
-    auto& idTables = result.idTables();
+    auto idTables = result.idTables();
 
     auto it = idTables.begin();
     ASSERT_NE(it, idTables.end());
@@ -369,7 +369,7 @@ TEST(NeutralOptional, ensureResultIsProperlyPropagated) {
     no.applyLimitOffset({2});
     qec->getQueryTreeCache().clearAll();
     auto result = no.computeResultOnlyForTesting(true);
-    auto& idTables = result.idTables();
+    auto idTables = result.idTables();
 
     auto it = idTables.begin();
     ASSERT_NE(it, idTables.end());

--- a/test/engine/OptionalJoinTest.cpp
+++ b/test/engine/OptionalJoinTest.cpp
@@ -521,7 +521,7 @@ TEST(OptionalJoin, lazyOptionalJoinWithOneMaterializedTable) {
 
     ASSERT_FALSE(result.isFullyMaterialized());
 
-    auto& lazyResult = result.idTables();
+    auto lazyResult = result.idTables();
     auto it = lazyResult.begin();
     ASSERT_NE(it, lazyResult.end());
 
@@ -551,7 +551,7 @@ TEST(OptionalJoin, lazyOptionalJoinWithOneMaterializedTable) {
 
     ASSERT_FALSE(result.isFullyMaterialized());
 
-    auto& lazyResult = result.idTables();
+    auto lazyResult = result.idTables();
     auto it = lazyResult.begin();
     ASSERT_NE(it, lazyResult.end());
 


### PR DESCRIPTION
Previously, `Result::idTables()` returned a `LazyResult` by reference, which could be used only once. The function was often used as a temporary, as in `other_function(std::move(res->idTables(), ...)`. This did not make sense and was misleading. Now the `LazyResult` is returned by value and the function is used without `std::move` when used as a temporary.