### PR TITLE
More correct behavior of `FROM [NAMED]` , `USING [NAMED]` and `WITH`

### DIFF
--- a/src/engine/CartesianProductJoin.cpp
+++ b/src/engine/CartesianProductJoin.cpp
@@ -400,7 +400,7 @@ Result::LazyResult CartesianProductJoin::createLazyConsumer(
             })});
   };
   return Result::LazyResult(ad_utility::CachingContinuableTransformInputRange(
-      std::move(lazyResult->idTables()), std::move(get)));
+      lazyResult->idTables(), std::move(get)));
 }
 
 // _____________________________________________________________________________

--- a/src/engine/Describe.cpp
+++ b/src/engine/Describe.cpp
@@ -52,7 +52,7 @@ string Describe::getCacheKeyImpl() const {
   // `subtree_`. However, the named graphs only determine the result for
   // `subtree_` (the resources to be described), whereas the default graphs
   // also determine which triples for these resources become part of the result.
-  const auto& defaultGraphs = describe_.datasetClauses_.defaultGraphs_;
+  const auto& defaultGraphs = describe_.datasetClauses_.defaultGraphs();
   if (defaultGraphs.has_value()) {
     std::vector<std::string> graphIdVec;
     ql::ranges::transform(defaultGraphs.value(), std::back_inserter(graphIdVec),
@@ -164,7 +164,7 @@ IdTable Describe::makeAndExecuteJoinWithFullIndex(
   SparqlTripleSimple triple{subjectVar, V{"?predicate"}, V{"?object"}};
   auto indexScan = ad_utility::makeExecutionTree<IndexScan>(
       getExecutionContext(), Permutation::SPO, triple,
-      describe_.datasetClauses_.defaultGraphs_);
+      describe_.datasetClauses_.defaultGraphs());
   auto joinColValues = valuesOp->getVariableColumn(subjectVar);
   auto joinColScan = indexScan->getVariableColumn(subjectVar);
   auto join = ad_utility::makeExecutionTree<Join>(

--- a/src/engine/Describe.cpp
+++ b/src/engine/Describe.cpp
@@ -52,7 +52,7 @@ string Describe::getCacheKeyImpl() const {
   // `subtree_`. However, the named graphs only determine the result for
   // `subtree_` (the resources to be described), whereas the default graphs
   // also determine which triples for these resources become part of the result.
-  const auto& defaultGraphs = describe_.datasetClauses_.defaultGraphs();
+  const auto& defaultGraphs = describe_.datasetClauses_.activeDefaultGraphs();
   if (defaultGraphs.has_value()) {
     std::vector<std::string> graphIdVec;
     ql::ranges::transform(defaultGraphs.value(), std::back_inserter(graphIdVec),
@@ -164,7 +164,7 @@ IdTable Describe::makeAndExecuteJoinWithFullIndex(
   SparqlTripleSimple triple{subjectVar, V{"?predicate"}, V{"?object"}};
   auto indexScan = ad_utility::makeExecutionTree<IndexScan>(
       getExecutionContext(), Permutation::SPO, triple,
-      describe_.datasetClauses_.defaultGraphs());
+      describe_.datasetClauses_.activeDefaultGraphs());
   auto joinColValues = valuesOp->getVariableColumn(subjectVar);
   auto joinColScan = indexScan->getVariableColumn(subjectVar);
   auto join = ad_utility::makeExecutionTree<Join>(

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -509,7 +509,7 @@ QueryPlanner::TripleGraph QueryPlanner::createTripleGraph(
         std::string s{ad_utility::utf8ToLower(term)};
         potentialTermsForCvar[t.s_.getVariable()].push_back(s);
         if (activeGraphVariable_.has_value() ||
-            activeDatasetClauses_.defaultGraphs().has_value()) {
+            activeDatasetClauses_.activeDefaultGraphs().has_value()) {
           AD_THROW(
               "contains-word is not allowed inside GRAPH clauses or in queries "
               "with FROM/FROM NAMED clauses.");
@@ -832,7 +832,7 @@ auto QueryPlanner::seedWithScansAndText(
 
     auto addIndexScan =
         [this, pushPlan, node,
-         &relevantGraphs = activeDatasetClauses_.defaultGraphs()](
+         &relevantGraphs = activeDatasetClauses_.activeDefaultGraphs()](
             Permutation::Enum permutation,
             std::optional<SparqlTripleSimple> triple = std::nullopt) {
           if (!triple.has_value()) {
@@ -2831,7 +2831,7 @@ void QueryPlanner::GraphPatternPlanner::visitTransitivePath(
     }
     auto transitivePath = TransitivePathBase::makeTransitivePath(
         qec_, std::move(sub._qet), std::move(left), std::move(right), min, max,
-        planner_.activeDatasetClauses_.defaultGraphs());
+        planner_.activeDatasetClauses_.activeDefaultGraphs());
     auto plan = makeSubtreePlan<TransitivePathBase>(std::move(transitivePath));
     candidatesOut.push_back(std::move(plan));
   }

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -2685,6 +2685,10 @@ void QueryPlanner::GraphPatternPlanner::graphPatternOperationVisitor(Arg& arg) {
               "{...}` clause may not appear in the body of that clause");
         }
         datasetBackup = planner_.activeDatasetClauses_;
+
+        // TODO<joka921> Move this whole block above and below into the
+        // `DatasetClauses` class. By the way the following is not quite
+        // correct, as it also should set the `specifiedUsingWith` to false etc.
         planner_.activeDatasetClauses_.defaultGraphsMutable() =
             planner_.activeDatasetClauses_.namedGraphs();
         // We already have backed up the `activeGraphVariable_`.

--- a/src/parser/DatasetClauses.cpp
+++ b/src/parser/DatasetClauses.cpp
@@ -64,4 +64,24 @@ bool DatasetClauses::isCompatibleNamedGraph(
     const TripleComponent::Iri& graph) const {
   return isUnconstrainedOrWithClause() || namedGraphs().value().contains(graph);
 }
+
+// _____________________________________________________________________________
+DatasetClauses DatasetClauses::getDatasetClauseForGraphClause(
+    const TripleComponent::Iri& graphIri) const {
+  DatasetClauses result;
+  result.defaultGraphs_.emplace();
+  if (isCompatibleNamedGraph(graphIri)) {
+    result.defaultGraphs_.value().insert({graphIri});
+  }
+  return result;
+}
+
+// _____________________________________________________________________________
+DatasetClauses DatasetClauses::getDatasetClauseForVariableGraphClause() const {
+  DatasetClauses result;
+  result.defaultGraphs_ = namedGraphs_;
+  result.namedGraphs_ = namedGraphs_;
+  return result;
+}
+
 }  // namespace parsedQuery

--- a/src/parser/DatasetClauses.cpp
+++ b/src/parser/DatasetClauses.cpp
@@ -55,11 +55,6 @@ auto DatasetClauses::namedGraphs() const -> const Graphs& {
 }
 
 // _____________________________________________________________________________
-auto DatasetClauses::defaultGraphsMutable() -> Graphs& {
-  return defaultGraphs_;
-}
-
-// _____________________________________________________________________________
 bool DatasetClauses::isCompatibleNamedGraph(
     const TripleComponent::Iri& graph) const {
   return isUnconstrainedOrWithClause() || namedGraphs().value().contains(graph);

--- a/src/parser/DatasetClauses.cpp
+++ b/src/parser/DatasetClauses.cpp
@@ -56,7 +56,6 @@ auto DatasetClauses::namedGraphs() const -> const Graphs& {
 
 // _____________________________________________________________________________
 auto DatasetClauses::defaultGraphsMutable() -> Graphs& {
-  AD_CORRECTNESS_CHECK(!defaultGraphSpecifiedUsingWith_);
   return defaultGraphs_;
 }
 

--- a/src/parser/DatasetClauses.cpp
+++ b/src/parser/DatasetClauses.cpp
@@ -41,7 +41,7 @@ bool DatasetClauses::isUnconstrainedOrWithClause() const {
 }
 
 // _____________________________________________________________________________
-auto DatasetClauses::defaultGraphs() const -> const Graphs& {
+auto DatasetClauses::activeDefaultGraphs() const -> const Graphs& {
   return isUnconstrainedOrWithClause() || defaultGraphs_.has_value()
              ? defaultGraphs_
              : emptyDummy_;

--- a/src/parser/DatasetClauses.cpp
+++ b/src/parser/DatasetClauses.cpp
@@ -74,7 +74,10 @@ DatasetClauses DatasetClauses::getDatasetClauseForGraphClause(
 // _____________________________________________________________________________
 DatasetClauses DatasetClauses::getDatasetClauseForVariableGraphClause() const {
   DatasetClauses result;
-  result.defaultGraphs_ = namedGraphs_;
+  // Note: It is important that we use the member function `namedGraphs()` here,
+  // because if default graphs were specified but no named graphs, then `GRAPH
+  // ?var` clauses have to be empty according to the SPARQL 1.1 standard.
+  result.defaultGraphs_ = namedGraphs();
   result.namedGraphs_ = namedGraphs_;
   return result;
 }

--- a/src/parser/DatasetClauses.h
+++ b/src/parser/DatasetClauses.h
@@ -62,6 +62,8 @@ struct DatasetClauses {
 
   // Get mutable access to the defaultGraphs_ member, required in the query
   // planner. Should be used with care.
+  // TODO<joka921> Make this interface unnecessary, by implementing everything
+  // as a member function.
   Graphs& defaultGraphsMutable();
 
   // Return true iff the `graph` is a supported named graph, either because it

--- a/src/parser/DatasetClauses.h
+++ b/src/parser/DatasetClauses.h
@@ -14,12 +14,44 @@ namespace parsedQuery {
 // A struct for the FROM clause (default graphs) and FROM NAMED clauses (named
 // graphs).
 struct DatasetClauses {
-  ScanSpecificationAsTripleComponent::Graphs defaultGraphs_{};
-  ScanSpecificationAsTripleComponent::Graphs namedGraphs_{};
+  using Graphs = ScanSpecificationAsTripleComponent::Graphs;
 
-  // Divide the dataset clause from `clauses` into default and named graphs, as
-  // needed for a `DatasetClauses` object.
+ private:
+  Graphs defaultGraphs_{};
+  Graphs namedGraphs_{};
+  Graphs emptyDummy_{Graphs::value_type{}};
+  bool defaultGraphSpecifiedUsingWith_ = false;
+
+ public:
+  // Divide the dataset clause from `clauses` into default and named graphs,
+  // as needed for a `DatasetClauses` object.
   static DatasetClauses fromClauses(const std::vector<DatasetClause>& clauses);
+
+  bool unspecified() const {
+    return (defaultGraphSpecifiedUsingWith_ || !defaultGraphs_.has_value()) &&
+           !namedGraphs_.has_value();
+  }
+
+  const auto& defaultGraphs() const {
+    return unspecified() || defaultGraphs_.has_value() ? defaultGraphs_
+                                                       : emptyDummy_;
+  }
+
+  const auto& namedGraphs() const {
+    return unspecified() || namedGraphs_.has_value() ? namedGraphs_
+                                                     : emptyDummy_;
+  }
+
+  // TODO<joka921> Can we get a safer interface here?
+  auto& defaultGraphsMutable() { return defaultGraphs_; }
+
+  bool isCompatibleNamedGraph(const TripleComponent::Iri& graph) const {
+    return unspecified() || namedGraphs().value().contains(graph);
+  }
+
+  void setDefaultGraphIsSpecifiedUsingWith() {
+    defaultGraphSpecifiedUsingWith_ = true;
+  }
 
   bool operator==(const DatasetClauses& other) const = default;
 };

--- a/src/parser/DatasetClauses.h
+++ b/src/parser/DatasetClauses.h
@@ -27,6 +27,11 @@ struct DatasetClauses {
   // as needed for a `DatasetClauses` object.
   static DatasetClauses fromClauses(const std::vector<DatasetClause>& clauses);
 
+  DatasetClauses(Graphs defaultGraphs = std::nullopt,
+                 Graphs namedGraphs = std::nullopt)
+      : defaultGraphs_{std::move(defaultGraphs)},
+        namedGraphs_{std::move(namedGraphs)} {}
+
   bool unspecified() const {
     return (defaultGraphSpecifiedUsingWith_ || !defaultGraphs_.has_value()) &&
            !namedGraphs_.has_value();

--- a/src/parser/DatasetClauses.h
+++ b/src/parser/DatasetClauses.h
@@ -60,11 +60,18 @@ struct DatasetClauses {
   // section 13.2).
   const Graphs& namedGraphs() const;
 
-  // Get mutable access to the defaultGraphs_ member, required in the query
-  // planner. Should be used with care.
-  // TODO<joka921> Make this interface unnecessary, by implementing everything
-  // as a member function.
-  Graphs& defaultGraphsMutable();
+  // Get the DatasetClause that corresponds to a given `Graph <iri> {}` clause
+  // when `this` is the dataset clause of the outer query. In particular,
+  // `<iri>` becomes the default graph, unless it is not specified in the
+  // `namedGraphs` of this dataset clause. In that case, the default graph will
+  // be empty.
+  [[nodiscard]] DatasetClauses getDatasetClauseForGraphClause(
+      const TripleComponent::Iri&) const;
+
+  // Get the DatasetClause that corresponds to a given `Graph ?var {}` clause
+  // when `this` is the dataset clause of the outer query. In particular, the
+  // named graphs now become the default graph.
+  [[nodiscard]] DatasetClauses getDatasetClauseForVariableGraphClause() const;
 
   // Return true iff the `graph` is a supported named graph, either because it
   // is explicitly part of the `namedGraphs()`, or because all named graphs are

--- a/src/parser/Quads.cpp
+++ b/src/parser/Quads.cpp
@@ -33,35 +33,9 @@ std::vector<SparqlTripleSimpleWithGraph> Quads::toTriplesWithGraph(
       [](size_t acc, const GraphBlock& block) {
         return acc + get<ad_utility::sparql_types::Triples>(block).size();
       });
-  // TODO<joka921> Could adapt the free triples things.
   quads.reserve(numTriplesInGraphs + freeTriples_.size());
   ad_utility::appendVector(
       quads, transformTriplesTemplate(freeTriples_, defaultGraph));
-
-  /*
-  bool noDefaultGraphs = !activeDatasets.defaultGraphs().has_value() ||
-                         activeDatasets.defaultGraphs().value().empty();
-  bool withGraphContradictsDatasets = [&]() {
-    return isDelete &&
-  std::holds_alternative<TripleComponent::Iri>(defaultGraph) &&
-        !activeDatasets.isCompatibleNamedGraph(std::get<TripleComponent::Iri>(defaultGraph));
-  }();
-
-  if (!withGraphContradictsDatasets) {
-    if (!std::holds_alternative<std::monostate>(defaultGraph) ||
-        noDefaultGraphs) {
-      ad_utility::appendVector(
-          quads, transformTriplesTemplate(freeTriples_, defaultGraph));
-    } else {
-      for (const auto& dataset : activeDatasets.defaultGraphs().value()) {
-        ad_utility::appendVector(
-            quads, transformTriplesTemplate(
-                       freeTriples_,
-                       SparqlTripleSimpleWithGraph::Graph{dataset.getIri()}));
-      }
-    }
-  }
-   */
   for (const auto& [graph, triples] : graphTriples_) {
     ad_utility::appendVector(
         quads,

--- a/src/parser/Quads.cpp
+++ b/src/parser/Quads.cpp
@@ -26,8 +26,7 @@ static T expandVariant(const ad_utility::sparql_types::VarOrIri& graph) {
 
 // ____________________________________________________________________________________
 std::vector<SparqlTripleSimpleWithGraph> Quads::toTriplesWithGraph(
-    bool isDelete, const SparqlTripleSimpleWithGraph::Graph& defaultGraph,
-    const parsedQuery::DatasetClauses& activeDatasets) const {
+    const SparqlTripleSimpleWithGraph::Graph& defaultGraph) const {
   std::vector<SparqlTripleSimpleWithGraph> quads;
   size_t numTriplesInGraphs = std::accumulate(
       graphTriples_.begin(), graphTriples_.end(), 0,

--- a/src/parser/Quads.h
+++ b/src/parser/Quads.h
@@ -37,8 +37,7 @@ struct Quads {
 
   // Return the quads in a format for use as an update template.
   std::vector<SparqlTripleSimpleWithGraph> toTriplesWithGraph(
-      bool isDelete, const SparqlTripleSimpleWithGraph::Graph& withGraph,
-      const parsedQuery::DatasetClauses& activeDatasetClauses) const;
+      const SparqlTripleSimpleWithGraph::Graph& withGraph) const;
   // Return the quads in a format for use in a GraphPattern.
   std::vector<parsedQuery::GraphPatternOperation> toGraphPatternOperations()
       const;

--- a/src/parser/Quads.h
+++ b/src/parser/Quads.h
@@ -8,6 +8,7 @@
 
 #include <vector>
 
+#include "parser/DatasetClauses.h"
 #include "parser/GraphPatternOperation.h"
 #include "parser/SparqlTriple.h"
 #include "parser/data/Types.h"
@@ -35,7 +36,9 @@ struct Quads {
   void forAllVariables(absl::FunctionRef<void(const Variable&)> f);
 
   // Return the quads in a format for use as an update template.
-  std::vector<SparqlTripleSimpleWithGraph> toTriplesWithGraph() const;
+  std::vector<SparqlTripleSimpleWithGraph> toTriplesWithGraph(
+      bool isDelete, const SparqlTripleSimpleWithGraph::Graph& withGraph,
+      const parsedQuery::DatasetClauses& activeDatasetClauses) const;
   // Return the quads in a format for use in a GraphPattern.
   std::vector<parsedQuery::GraphPatternOperation> toGraphPatternOperations()
       const;

--- a/src/parser/Quads.h
+++ b/src/parser/Quads.h
@@ -8,7 +8,6 @@
 
 #include <vector>
 
-#include "parser/DatasetClauses.h"
 #include "parser/GraphPatternOperation.h"
 #include "parser/SparqlTriple.h"
 #include "parser/data/Types.h"
@@ -36,8 +35,11 @@ struct Quads {
   void forAllVariables(absl::FunctionRef<void(const Variable&)> f);
 
   // Return the quads in a format for use as an update template.
+  // The `defaultGraph` is used for the `freeTriples_`. It for example is set
+  // when using a `WITH` clause. It can also be `std::monostate{}`, in which
+  // case the global default graph will be used later on.
   std::vector<SparqlTripleSimpleWithGraph> toTriplesWithGraph(
-      const SparqlTripleSimpleWithGraph::Graph& withGraph) const;
+      const SparqlTripleSimpleWithGraph::Graph& defaultGraph) const;
   // Return the quads in a format for use in a GraphPattern.
   std::vector<parsedQuery::GraphPatternOperation> toGraphPatternOperations()
       const;

--- a/src/parser/UpdateClause.h
+++ b/src/parser/UpdateClause.h
@@ -58,7 +58,6 @@ struct Copy {
 struct GraphUpdate {
   std::vector<SparqlTripleSimpleWithGraph> toInsert_;
   std::vector<SparqlTripleSimpleWithGraph> toDelete_;
-  std::optional<ad_utility::triple_component::Iri> with_;
 
   GraphUpdate() = default;
   GraphUpdate(std::vector<SparqlTripleSimpleWithGraph> toInsert,

--- a/test/GraphStoreProtocolTest.cpp
+++ b/test/GraphStoreProtocolTest.cpp
@@ -31,27 +31,21 @@ TEST(GraphStoreProtocolTest, transformPost) {
 
   expectTransformPost(
       makePostRequest("/?default", "text/turtle", "<a> <b> <c> ."), DEFAULT{},
-      m::UpdateClause(
-          m::GraphUpdate(
-              {}, {{iri("<a>"), iri("<b>"), iri("<c>"), std::monostate{}}},
-              std::nullopt),
-          m::GraphPattern()));
+      m::UpdateClause(m::GraphUpdate({}, {{iri("<a>"), iri("<b>"), iri("<c>"),
+                                           std::monostate{}}}),
+                      m::GraphPattern()));
   expectTransformPost(
       makePostRequest("/?default", "application/n-triples", "<a> <b> <c> ."),
       DEFAULT{},
-      m::UpdateClause(
-          m::GraphUpdate(
-              {}, {{iri("<a>"), iri("<b>"), iri("<c>"), std::monostate{}}},
-              std::nullopt),
-          m::GraphPattern()));
+      m::UpdateClause(m::GraphUpdate({}, {{iri("<a>"), iri("<b>"), iri("<c>"),
+                                           std::monostate{}}}),
+                      m::GraphPattern()));
   expectTransformPost(
       makePostRequest("/?graph=bar", "application/n-triples", "<a> <b> <c> ."),
       iri("<bar>"),
-      m::UpdateClause(
-          m::GraphUpdate({},
-                         {{iri("<a>"), iri("<b>"), iri("<c>"), iri("<bar>")}},
-                         std::nullopt),
-          m::GraphPattern()));
+      m::UpdateClause(m::GraphUpdate({}, {{iri("<a>"), iri("<b>"), iri("<c>"),
+                                           iri("<bar>")}}),
+                      m::GraphPattern()));
   AD_EXPECT_THROW_WITH_MESSAGE(
       GraphStoreProtocol::transformPost(
           ad_utility::testing::makePostRequest(
@@ -114,10 +108,8 @@ TEST(GraphStoreProtocolTest, transformGraphStoreProtocol) {
           GraphStoreOperation{DEFAULT{}},
           ad_utility::testing::makePostRequest(
               "/?default", "application/n-triples", "<foo> <bar> <baz> .")),
-      m::UpdateClause(m::GraphUpdate({},
-                                     {{iri("<foo>"), iri("<bar>"), iri("<baz>"),
-                                       std::monostate{}}},
-                                     std::nullopt),
+      m::UpdateClause(m::GraphUpdate({}, {{iri("<foo>"), iri("<bar>"),
+                                           iri("<baz>"), std::monostate{}}}),
                       m::GraphPattern()));
   auto expectUnsupportedMethod =
       [](const http::verb method, ad_utility::source_location l =

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -3453,13 +3453,16 @@ TEST(QueryPlanner, DatasetClause) {
   h::expect("SELECT * FROM <x> FROM <y> { SELECT * {?x ?y ?z}}",
             scan("?x", "?y", "?z", {}, Graphs{"<x>", "<y>"}));
 
-  h::expect("SELECT * FROM <x> WHERE { GRAPH <z> {?x ?y ?z}}",
+  h::expect("SELECT * FROM <x> FROM NAMED <z> WHERE { GRAPH <z> {?x ?y ?z}}",
             scan("?x", "?y", "?z", {}, Graphs{"<z>"}));
+  h::expect("SELECT * FROM <x> WHERE { GRAPH <z> {?x ?y ?z}}",
+            scan("?x", "?y", "?z", {}, Graphs{}));
 
   auto g1 = Graphs{"<g1>"};
   auto g2 = Graphs{"<g2>"};
   h::expect(
-      "SELECT * FROM <g1> { <a> ?p <x>. {<b> ?p <y>} GRAPH <g2> { <c> ?p <z> "
+      "SELECT * FROM <g1> FROM NAMED <g2> { <a> ?p <x>. {<b> ?p <y>} GRAPH "
+      "<g2> { <c> ?p <z> "
       "{SELECT * {<d> ?p <z2>}}} <e> ?p <z3> }",
       h::UnorderedJoins(
           scan("<a>", "?p", "<x>", {}, g1), scan("<b>", "?p", "<y>", {}, g1),
@@ -3467,6 +3470,7 @@ TEST(QueryPlanner, DatasetClause) {
           scan("<e>", "?p", "<z3>", {}, g1)));
 
   auto g12 = Graphs{"<g1>", "<g2>"};
+  auto noGraphs = Graphs{};
   auto varG = std::vector{Variable{"?g"}};
   std::vector<ColumnIndex> graphCol{ADDITIONAL_COLUMN_GRAPH_ID};
   h::expect(
@@ -3475,7 +3479,7 @@ TEST(QueryPlanner, DatasetClause) {
       scan("<a>", "<b>", "<c>", {}, g12, varG, graphCol));
 
   h::expect("SELECT * FROM <x> WHERE { GRAPH ?g {<a> <b> <c>}}",
-            scan("<a>", "<b>", "<c>", {}, std::nullopt, varG, graphCol));
+            scan("<a>", "<b>", "<c>", {}, noGraphs, varG, graphCol));
 
   // `GROUP BY` inside a `GRAPH ?g` clause.
   // We use the `UnorderedJoins` matcher, because the index scan has to be

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -2045,7 +2045,6 @@ TEST(SparqlParser, Exists) {
   // Now run the same tests, but with non-empty dataset clauses, that have to be
   // propagated to the `ParsedQuery` stored inside the `ExistsExpression`.
   ParsedQuery::DatasetClauses datasetClauses{defaultGraphs, namedGraphs};
-  datasetClauses.defaultGraphsMutable().value().insert(iri("<blubb>"));
   expectBuiltInCall("EXISTS {?a <bar> ?foo}",
                     m::Exists(selectABarFooMatcher()));
   expectBuiltInCall("NOT EXISTS {?a <bar> ?foo}",

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -2516,19 +2516,15 @@ TEST(SparqlParser, Load) {
   expectLoad(
       "LOAD <https://example.com>",
       m::UpdateClause(
-          m::GraphUpdate({},
-                         {SparqlTripleSimpleWithGraph{Var("?s"), Var("?p"),
-                                                      Var("?o"), noGraph}},
-                         std::nullopt),
+          m::GraphUpdate({}, {SparqlTripleSimpleWithGraph{Var("?s"), Var("?p"),
+                                                          Var("?o"), noGraph}}),
           m::GraphPattern(m::Load(Iri("<https://example.com>"), false))));
-  expectLoad(
-      "LOAD SILENT <http://example.com> into GRAPH <bar>",
-      m::UpdateClause(
-          m::GraphUpdate({},
-                         {SparqlTripleSimpleWithGraph{Var("?s"), Var("?p"),
-                                                      Var("?o"), Iri("<bar>")}},
-                         std::nullopt),
-          m::GraphPattern(m::Load(Iri("<http://example.com>"), true))));
+  expectLoad("LOAD SILENT <http://example.com> into GRAPH <bar>",
+             m::UpdateClause(
+                 m::GraphUpdate(
+                     {}, {SparqlTripleSimpleWithGraph{
+                             Var("?s"), Var("?p"), Var("?o"), Iri("<bar>")}}),
+                 m::GraphPattern(m::Load(Iri("<http://example.com>"), true))));
 }
 
 TEST(SparqlParser, GraphOrDefault) {

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -2290,27 +2290,22 @@ TEST(SparqlParser, Update) {
   expectUpdate(
       "INSERT DATA { <a> <b> <c> }",
       m::UpdateClause(
-          m::GraphUpdate({}, {{Iri("<a>"), Iri("<b>"), Iri("<c>"), noGraph}},
-                         std::nullopt),
+          m::GraphUpdate({}, {{Iri("<a>"), Iri("<b>"), Iri("<c>"), noGraph}}),
           m::GraphPattern()));
   expectUpdate(
       "INSERT DATA { <a> <b> \"foo:bar\" }",
-      m::UpdateClause(
-          m::GraphUpdate(
-              {}, {{Iri("<a>"), Iri("<b>"), Literal("\"foo:bar\""), noGraph}},
-              std::nullopt),
-          m::GraphPattern()));
+      m::UpdateClause(m::GraphUpdate({}, {{Iri("<a>"), Iri("<b>"),
+                                           Literal("\"foo:bar\""), noGraph}}),
+                      m::GraphPattern()));
   expectUpdate(
       "DELETE DATA { <a> <b> <c> }",
       m::UpdateClause(
-          m::GraphUpdate({{Iri("<a>"), Iri("<b>"), Iri("<c>"), noGraph}}, {},
-                         std::nullopt),
+          m::GraphUpdate({{Iri("<a>"), Iri("<b>"), Iri("<c>"), noGraph}}, {}),
           m::GraphPattern()));
   expectUpdate(
       "DELETE { ?a <b> <c> } WHERE { <d> <e> ?a }",
       m::UpdateClause(
-          m::GraphUpdate({{Var("?a"), Iri("<b>"), Iri("<c>"), noGraph}}, {},
-                         std::nullopt),
+          m::GraphUpdate({{Var("?a"), Iri("<b>"), Iri("<c>"), noGraph}}, {}),
           m::GraphPattern(m::Triples({{Iri("<d>"), "<e>", Var{"?a"}}}))));
   // Use variables that are not visible in the query body. Do this for all parts
   // of the quad for coverage reasons.
@@ -2324,14 +2319,12 @@ TEST(SparqlParser, Update) {
       "DELETE { ?a <b> <c> } INSERT { <a> ?a <c> } WHERE { <d> <e> ?a }",
       m::UpdateClause(
           m::GraphUpdate({{Var("?a"), Iri("<b>"), Iri("<c>"), noGraph}},
-                         {{Iri("<a>"), Var("?a"), Iri("<c>"), noGraph}},
-                         std::nullopt),
+                         {{Iri("<a>"), Var("?a"), Iri("<c>"), noGraph}}),
           m::GraphPattern(m::Triples({{Iri("<d>"), "<e>", Var{"?a"}}}))));
   expectUpdate(
       "DELETE WHERE { ?a <foo> ?c }",
       m::UpdateClause(
-          m::GraphUpdate({{Var("?a"), Iri("<foo>"), Var("?c"), noGraph}}, {},
-                         std::nullopt),
+          m::GraphUpdate({{Var("?a"), Iri("<foo>"), Var("?c"), noGraph}}, {}),
           m::GraphPattern(m::Triples({{Var{"?a"}, "<foo>", Var{"?c"}}}))));
   expectUpdate("CLEAR DEFAULT",
                m::UpdateClause(m::Clear(false, DEFAULT{}), m::GraphPattern()));
@@ -2340,26 +2333,23 @@ TEST(SparqlParser, Update) {
   expectUpdate(
       "WITH <foo> DELETE { ?a ?b ?c } WHERE { ?a ?b ?c }",
       m::UpdateClause(
-          m::GraphUpdate({{Var("?a"), Var("?b"), Var("?c"), noGraph}}, {},
-                         Iri("<foo>")),
-          m::GraphPattern(m::Triples({{Var{"?a"}, Var{"?b"}, Var{"?c"}}}))));
-  expectUpdate(
-      "DELETE { ?a ?b ?c } USING <foo> WHERE { ?a ?b ?c }",
-      m::UpdateClause(
-          m::GraphUpdate({{Var("?a"), Var("?b"), Var("?c"), noGraph}}, {},
-                         std::nullopt),
+          m::GraphUpdate({{Var("?a"), Var("?b"), Var("?c"), Iri("<foo>")}}, {}),
           m::GraphPattern(m::Triples({{Var{"?a"}, Var{"?b"}, Var{"?c"}}})),
           m::datasetClausesMatcher(m::Graphs{TripleComponent(Iri("<foo>"))},
                                    std::nullopt)));
   expectUpdate(
-      "INSERT DATA { GRAPH <foo> { } }",
-      m::UpdateClause(m::GraphUpdate({}, {}, std::nullopt), m::GraphPattern()));
+      "DELETE { ?a ?b ?c } USING <foo> WHERE { ?a ?b ?c }",
+      m::UpdateClause(
+          m::GraphUpdate({{Var("?a"), Var("?b"), Var("?c"), noGraph}}, {}),
+          m::GraphPattern(m::Triples({{Var{"?a"}, Var{"?b"}, Var{"?c"}}})),
+          m::datasetClausesMatcher(m::Graphs{TripleComponent(Iri("<foo>"))},
+                                   m::Graphs{})));
+  expectUpdate("INSERT DATA { GRAPH <foo> { } }",
+               m::UpdateClause(m::GraphUpdate({}, {}), m::GraphPattern()));
   expectUpdate("INSERT DATA { GRAPH <foo> { <a> <b> <c> } }",
-               m::UpdateClause(
-                   m::GraphUpdate(
-                       {}, {{Iri("<a>"), Iri("<b>"), Iri("<c>"), Iri("<foo>")}},
-                       std::nullopt),
-                   m::GraphPattern()));
+               m::UpdateClause(m::GraphUpdate({}, {{Iri("<a>"), Iri("<b>"),
+                                                    Iri("<c>"), Iri("<foo>")}}),
+                               m::GraphPattern()));
   expectUpdateFails(
       "INSERT DATA { GRAPH ?f { } }",
       testing::HasSubstr(
@@ -2367,17 +2357,18 @@ TEST(SparqlParser, Update) {
   expectUpdate(
       "DELETE { ?a <b> <c> } USING NAMED <foo> WHERE { <d> <e> ?a }",
       m::UpdateClause(
-          m::GraphUpdate({{Var("?a"), Iri("<b>"), Iri("<c>"), noGraph}}, {},
-                         std::nullopt),
+          m::GraphUpdate({{Var("?a"), Iri("<b>"), Iri("<c>"), noGraph}}, {}),
           m::GraphPattern(m::Triples({{Iri("<d>"), "<e>", Var{"?a"}}})),
-          m::datasetClausesMatcher(std::nullopt,
+          m::datasetClausesMatcher(m::Graphs{},
                                    m::Graphs{TripleComponent(Iri("<foo>"))})));
   expectUpdate(
       "WITH <foo> DELETE { ?a <b> <c> } WHERE { <d> <e> ?a }",
       m::UpdateClause(
-          m::GraphUpdate({{Var("?a"), Iri("<b>"), Iri("<c>"), noGraph}}, {},
-                         Iri("<foo>")),
-          m::GraphPattern(m::Triples({{Iri("<d>"), "<e>", Var{"?a"}}}))));
+          m::GraphUpdate({{Var("?a"), Iri("<b>"), Iri("<c>"), Iri("<foo>")}},
+                         {}),
+          m::GraphPattern(m::Triples({{Iri("<d>"), "<e>", Var{"?a"}}})),
+          m::datasetClausesMatcher(m::Graphs{TripleComponent(Iri("<foo>"))},
+                                   std::nullopt)));
   expectUpdate("LOAD <foo>",
                m::UpdateClause(m::Load(false, Iri("<foo>"), std::nullopt),
                                m::GraphPattern()));
@@ -2404,17 +2395,14 @@ TEST(SparqlParser, Update) {
                m::UpdateClause(m::Copy(false, DEFAULT{}, Iri("<foo>")),
                                m::GraphPattern()));
   const auto insertMatcher = m::UpdateClause(
-      m::GraphUpdate({}, {{Iri("<a>"), Iri("<b>"), Iri("<c>"), noGraph}},
-                     std::nullopt),
+      m::GraphUpdate({}, {{Iri("<a>"), Iri("<b>"), Iri("<c>"), noGraph}}),
       m::GraphPattern());
   const auto fooInsertMatcher = m::UpdateClause(
       m::GraphUpdate(
-          {}, {{Iri("<foo/a>"), Iri("<foo/b>"), Iri("<foo/c>"), noGraph}},
-          std::nullopt),
+          {}, {{Iri("<foo/a>"), Iri("<foo/b>"), Iri("<foo/c>"), noGraph}}),
       m::GraphPattern());
   const auto deleteWhereAllMatcher = m::UpdateClause(
-      m::GraphUpdate({{Var("?s"), Var("?p"), Var("?o"), noGraph}}, {},
-                     std::nullopt),
+      m::GraphUpdate({{Var("?s"), Var("?p"), Var("?o"), noGraph}}, {}),
       m::GraphPattern(m::Triples({{Var("?s"), Var{"?p"}, Var("?o")}})));
   expectUpdate("INSERT DATA { <a> <b> <c> }", insertMatcher);
   // Multiple Updates
@@ -2566,31 +2554,31 @@ TEST(SparqlParser, Datasets) {
     return TripleComponent::Iri::fromIriref(stringWithBrackets);
   };
   auto noGraph = std::monostate{};
+  auto noGraphs = m::Graphs{};
   ScanSpecificationAsTripleComponent::Graphs datasets{{Iri("<g>")}};
   // Only checks `_filters` on the GraphPattern. We are not concerned with the
   // `_graphPatterns` here.
   auto filterGraphPattern = m::Filters(m::ExistsFilter(
       m::GraphPattern(m::Triples({{Var("?a"), Var{"?b"}, Var("?c")}})),
-      datasets));
+      datasets, noGraphs));
   // Check that datasets are propagated correctly into the different types of
   // operations.
   expectUpdate(
       "DELETE { ?x <b> <c> } USING <g> WHERE { ?x ?y ?z FILTER EXISTS {?a ?b "
       "?c} }",
       testing::ElementsAre(m::UpdateClause(
-          m::GraphUpdate({{Var("?x"), Iri("<b>"), Iri("<c>"), noGraph}}, {},
-                         std::nullopt),
-          filterGraphPattern, m::datasetClausesMatcher(datasets))));
-  expectQuery(
-      "SELECT * FROM <g> WHERE { ?x ?y ?z FILTER EXISTS {?a ?b ?c} }",
-      m::SelectQuery(m::AsteriskSelect(), filterGraphPattern, datasets));
+          m::GraphUpdate({{Var("?x"), Iri("<b>"), Iri("<c>"), noGraph}}, {}),
+          filterGraphPattern, m::datasetClausesMatcher(datasets, noGraphs))));
+  expectQuery("SELECT * FROM <g> WHERE { ?x ?y ?z FILTER EXISTS {?a ?b ?c} }",
+              m::SelectQuery(m::AsteriskSelect(), filterGraphPattern, datasets,
+                             noGraphs));
   expectAsk("ASK FROM <g> { ?x ?y ?z FILTER EXISTS {?a ?b ?c}}",
-            m::AskQuery(filterGraphPattern, datasets));
+            m::AskQuery(filterGraphPattern, datasets, noGraphs));
   expectConstruct(
       "CONSTRUCT {<a> <b> <c>} FROM <g> { ?x ?y ?z FILTER EXISTS {?a ?b?c}}",
       m::ConstructQuery(
           {std::array<GraphTerm, 3>{::Iri("<a>"), ::Iri("<b>"), ::Iri("<c>")}},
-          filterGraphPattern, datasets));
+          filterGraphPattern, datasets, noGraphs));
   // See comment in visit function for `DescribeQueryContext`.
   expectDescribe(
       "Describe ?x FROM <g> { ?x ?y ?z FILTER EXISTS {?a ?b ?c}}",
@@ -2598,5 +2586,5 @@ TEST(SparqlParser, Datasets) {
           m::Describe({Var("?x")}, {datasets, {}},
                       m::SelectQuery(m::VariablesSelect({"?x"}, false, false),
                                      filterGraphPattern)),
-          datasets));
+          datasets, noGraphs));
 }

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -2044,10 +2044,8 @@ TEST(SparqlParser, Exists) {
 
   // Now run the same tests, but with non-empty dataset clauses, that have to be
   // propagated to the `ParsedQuery` stored inside the `ExistsExpression`.
-  ParsedQuery::DatasetClauses datasetClauses;
-  datasetClauses.defaultGraphs_ = defaultGraphs;
-  datasetClauses.namedGraphs_ = namedGraphs;
-  datasetClauses.defaultGraphs_.value().insert(iri("<blubb>"));
+  ParsedQuery::DatasetClauses datasetClauses{defaultGraphs, namedGraphs};
+  datasetClauses.defaultGraphsMutable().value().insert(iri("<blubb>"));
   expectBuiltInCall("EXISTS {?a <bar> ?foo}",
                     m::Exists(selectABarFooMatcher()));
   expectBuiltInCall("NOT EXISTS {?a <bar> ?foo}",

--- a/test/SparqlAntlrParserTestHelpers.h
+++ b/test/SparqlAntlrParserTestHelpers.h
@@ -828,12 +828,13 @@ inline auto SubSelect =
 
 // Return a matcher that matches a `DatasetClause` with given
 inline auto datasetClausesMatcher(
-    ScanSpecificationAsTripleComponent::Graphs defaultGraphs = std::nullopt,
+    ScanSpecificationAsTripleComponent::Graphs activeDefaultGraphs =
+        std::nullopt,
     ScanSpecificationAsTripleComponent::Graphs namedGraphs = std::nullopt)
     -> Matcher<const ::ParsedQuery::DatasetClauses&> {
   using DS = ParsedQuery::DatasetClauses;
   using namespace ::testing;
-  return AllOf(AD_PROPERTY(DS, defaultGraphs, Eq(defaultGraphs)),
+  return AllOf(AD_PROPERTY(DS, activeDefaultGraphs, Eq(activeDefaultGraphs)),
                AD_PROPERTY(DS, namedGraphs, Eq(namedGraphs)));
 }
 
@@ -953,7 +954,7 @@ inline auto GraphUpdate =
 };
 
 inline auto EmptyDatasets = [] {
-  return AllOf(AD_PROPERTY(ParsedQuery::DatasetClauses, defaultGraphs,
+  return AllOf(AD_PROPERTY(ParsedQuery::DatasetClauses, activeDefaultGraphs,
                            testing::Eq(std::nullopt)),
                AD_PROPERTY(ParsedQuery::DatasetClauses, namedGraphs,
                            testing::Eq(std::nullopt)));

--- a/test/SparqlAntlrParserTestHelpers.h
+++ b/test/SparqlAntlrParserTestHelpers.h
@@ -826,8 +826,8 @@ inline auto datasetClausesMatcher(
     -> Matcher<const ::ParsedQuery::DatasetClauses&> {
   using DS = ParsedQuery::DatasetClauses;
   using namespace ::testing;
-  return AllOf(Property(&DS::defaultGraphs, Eq(defaultGraphs)),
-               Property(&DS::namedGraphs, Eq(namedGraphs)));
+  return AllOf(AD_PROPERTY(DS, defaultGraphs, Eq(defaultGraphs)),
+               AD_PROPERTY(DS, namedGraphs, Eq(namedGraphs)));
 }
 
 inline auto SelectQuery =

--- a/test/SparqlAntlrParserTestHelpers.h
+++ b/test/SparqlAntlrParserTestHelpers.h
@@ -945,13 +945,11 @@ using namespace updateClause;
 
 inline auto GraphUpdate =
     [](const std::vector<SparqlTripleSimpleWithGraph>& toDelete,
-       const std::vector<SparqlTripleSimpleWithGraph>& toInsert,
-       const std::optional<ad_utility::triple_component::Iri>& with)
+       const std::vector<SparqlTripleSimpleWithGraph>& toInsert)
     -> Matcher<const updateClause::GraphUpdate&> {
   return testing::AllOf(
       AD_FIELD(GraphUpdate, toInsert_, testing::ElementsAreArray(toInsert)),
-      AD_FIELD(GraphUpdate, toDelete_, testing::ElementsAreArray(toDelete))
-      ));
+      AD_FIELD(GraphUpdate, toDelete_, testing::ElementsAreArray(toDelete)));
 };
 
 inline auto EmptyDatasets = [] {
@@ -1154,18 +1152,16 @@ inline auto Clear = [](const parsedQuery::GroupGraphPattern::GraphSpec& graph,
   return UpdateClause(
       GraphUpdate(
           {{{::Variable("?s")}, {::Variable("?p")}, {::Variable("?o")}, graph}},
-          {}, std::nullopt),
+          {}),
       SelectAllPattern(graph, AD_FWD(filter)));
 };
 
 // Matcher for a `ParsedQuery` with an add of all triples in `from` to `to`.
 inline auto AddAll = [](const SparqlTripleSimpleWithGraph::Graph& from,
                         const SparqlTripleSimpleWithGraph::Graph& to) {
-  return UpdateClause(GraphUpdate({},
-                                  {SparqlTripleSimpleWithGraph(
-                                      ::Variable("?s"), ::Variable("?p"),
-                                      ::Variable("?o"), to)},
-                                  std::nullopt),
+  return UpdateClause(GraphUpdate({}, {SparqlTripleSimpleWithGraph(
+                                          ::Variable("?s"), ::Variable("?p"),
+                                          ::Variable("?o"), to)}),
                       SelectAllPattern(from));
 };
 

--- a/test/SparqlAntlrParserTestHelpers.h
+++ b/test/SparqlAntlrParserTestHelpers.h
@@ -826,8 +826,8 @@ inline auto datasetClausesMatcher(
     -> Matcher<const ::ParsedQuery::DatasetClauses&> {
   using DS = ParsedQuery::DatasetClauses;
   using namespace ::testing;
-  return AllOf(Field(&DS::defaultGraphs_, Eq(defaultGraphs)),
-               Field(&DS::namedGraphs_, Eq(namedGraphs)));
+  return AllOf(Property(&DS::defaultGraphs, Eq(defaultGraphs)),
+               Property(&DS::namedGraphs, Eq(namedGraphs)));
 }
 
 inline auto SelectQuery =
@@ -999,20 +999,18 @@ inline auto Copy = [](bool silent, const GraphOrDefault& source,
 
 inline auto GraphUpdate =
     [](const std::vector<SparqlTripleSimpleWithGraph>& toDelete,
-       const std::vector<SparqlTripleSimpleWithGraph>& toInsert,
-       const std::optional<ad_utility::triple_component::Iri>& with)
+       const std::vector<SparqlTripleSimpleWithGraph>& toInsert)
     -> Matcher<const updateClause::Operation&> {
   return testing::VariantWith<updateClause::GraphUpdate>(testing::AllOf(
       AD_FIELD(GraphUpdate, toInsert_, testing::ElementsAreArray(toInsert)),
-      AD_FIELD(GraphUpdate, toDelete_, testing::ElementsAreArray(toDelete)),
-      AD_FIELD(GraphUpdate, with_, testing::Eq(with))));
+      AD_FIELD(GraphUpdate, toDelete_, testing::ElementsAreArray(toDelete))));
 };
 
 inline auto EmptyDatasets = [] {
-  return AllOf(AD_FIELD(ParsedQuery::DatasetClauses, defaultGraphs_,
-                        testing::Eq(std::nullopt)),
-               AD_FIELD(ParsedQuery::DatasetClauses, namedGraphs_,
-                        testing::Eq(std::nullopt)));
+  return AllOf(AD_PROPERTY(ParsedQuery::DatasetClauses, defaultGraphs,
+                           testing::Eq(std::nullopt)),
+               AD_PROPERTY(ParsedQuery::DatasetClauses, namedGraphs,
+                           testing::Eq(std::nullopt)));
 };
 
 using Graphs = ad_utility::HashSet<TripleComponent>;

--- a/test/engine/DescribeTest.cpp
+++ b/test/engine/DescribeTest.cpp
@@ -159,7 +159,7 @@ TEST(Describe, simpleMembers) {
 
   // Test the cache key of the same query, but with a FROM clause.
   auto parsedDescribe2 = parsedDescribe;
-  parsedDescribe2.datasetClauses_.defaultGraphs_.emplace(
+  parsedDescribe2.datasetClauses_.defaultGraphsMutable().emplace(
       {TripleComponent::Iri::fromIriref("<default-graph-1>")});
   Describe describe2{
       qec, ad_utility::makeExecutionTree<NeutralElementOperation>(qec),

--- a/test/engine/DescribeTest.cpp
+++ b/test/engine/DescribeTest.cpp
@@ -159,8 +159,9 @@ TEST(Describe, simpleMembers) {
 
   // Test the cache key of the same query, but with a FROM clause.
   auto parsedDescribe2 = parsedDescribe;
-  parsedDescribe2.datasetClauses_.defaultGraphsMutable().emplace(
-      {TripleComponent::Iri::fromIriref("<default-graph-1>")});
+  parsedDescribe2.datasetClauses_ =
+      parsedQuery::DatasetClauses::fromClauses(std::vector{DatasetClause{
+          TripleComponent::Iri::fromIriref("<default-graph-1>"), false}});
   Describe describe2{
       qec, ad_utility::makeExecutionTree<NeutralElementOperation>(qec),
       parsedDescribe2};

--- a/test/parser/QuadTest.cpp
+++ b/test/parser/QuadTest.cpp
@@ -21,7 +21,7 @@ TEST(QuadTest, getQuads) {
              ad_utility::source_location::current()) {
         auto t = generateLocationTrace(l);
         const Quads quads{std::move(triples), std::move(graphs)};
-        EXPECT_THAT(quads.toTriplesWithGraph(std::monostate),
+        EXPECT_THAT(quads.toTriplesWithGraph(std::monostate{}),
                     testing::UnorderedElementsAreArray(expected));
       };
   auto TripleOf = [](const GraphTerm& t) -> std::array<GraphTerm, 3> {

--- a/test/parser/QuadTest.cpp
+++ b/test/parser/QuadTest.cpp
@@ -21,7 +21,7 @@ TEST(QuadTest, getQuads) {
              ad_utility::source_location::current()) {
         auto t = generateLocationTrace(l);
         const Quads quads{std::move(triples), std::move(graphs)};
-        EXPECT_THAT(quads.toTriplesWithGraph(<#initializer #>),
+        EXPECT_THAT(quads.toTriplesWithGraph(std::monostate),
                     testing::UnorderedElementsAreArray(expected));
       };
   auto TripleOf = [](const GraphTerm& t) -> std::array<GraphTerm, 3> {

--- a/test/parser/QuadTest.cpp
+++ b/test/parser/QuadTest.cpp
@@ -21,7 +21,7 @@ TEST(QuadTest, getQuads) {
              ad_utility::source_location::current()) {
         auto t = generateLocationTrace(l);
         const Quads quads{std::move(triples), std::move(graphs)};
-        EXPECT_THAT(quads.toTriplesWithGraph(),
+        EXPECT_THAT(quads.toTriplesWithGraph(<#initializer #>),
                     testing::UnorderedElementsAreArray(expected));
       };
   auto TripleOf = [](const GraphTerm& t) -> std::array<GraphTerm, 3> {


### PR DESCRIPTION
The following is fixed now, where everything said about `FROM [NAMED]` for queries also holds for `USING [NAMED]` for updates:

1. If a `FROM NAMED` clause is used, but no `FROM` clause, then the default graph for the `WHERE` clause is empty.
2. If a `FROM` clause is used, but no `FROM NAMED` clause, then all `GRAPH` clauses inside the `WHERE` clause will have an empty result because no named graphs were specified.
3. In the `WHERE` clause, an explicit `GRAPH` (as in `GRAPH <fixedIri> {...}`) has to be part of the `FROM NAMED` clauses, unless there is no `FROM` or `FROM NAMED` clause at all, in which case all named graphs can be used.
4. The graph specified in a `WITH` clause of an update is used as the graph for all `INSERT` and `DELETE` triples for which no graph is stated explicitly. In addition, the graph specified in the `WITH` clause is used as the default graph for the `WHERE` clause, but only if there is no additional `USING [NAMED]` clause