### PR TITLE
Fix `isLiteral` for values folded into the `Id`

### DIFF
--- a/src/engine/sparqlExpressions/SparqlExpressionValueGetters.cpp
+++ b/src/engine/sparqlExpressions/SparqlExpressionValueGetters.cpp
@@ -176,19 +176,33 @@ std::string ReplacementStringGetter::convertToReplacementString(
 template <auto isSomethingFunction, auto prefix>
 Id IsSomethingValueGetter<isSomethingFunction, prefix>::operator()(
     ValueId id, const EvaluationContext* context) const {
-  if (id.getDatatype() == Datatype::VocabIndex) {
-    // See instantiations below for what `isSomethingFunction` is.
-    return Id::makeFromBool(std::invoke(isSomethingFunction,
-                                        context->_qec.getIndex().getVocab(),
-                                        id.getVocabIndex()));
-  } else if (id.getDatatype() == Datatype::LocalVocabIndex) {
-    auto word = ExportQueryExecutionTrees::idToStringAndType<false>(
-        context->_qec.getIndex(), id, context->_localVocab);
-    return Id::makeFromBool(word.has_value() &&
-                            word.value().first.starts_with(prefix));
-  } else {
-    return Id::makeFromBool(false);
+  switch (id.getDatatype()) {
+    case Datatype::VocabIndex:
+      // See instantiations below for what `isSomethingFunction` is.
+      return Id::makeFromBool(std::invoke(isSomethingFunction,
+                                          context->_qec.getIndex().getVocab(),
+                                          id.getVocabIndex()));
+    case Datatype::LocalVocabIndex: {
+      auto word = ExportQueryExecutionTrees::idToStringAndType<false>(
+          context->_qec.getIndex(), id, context->_localVocab);
+      return Id::makeFromBool(word.has_value() &&
+                              word.value().first.starts_with(prefix));
+    }
+    case Datatype::Bool:
+    case Datatype::Int:
+    case Datatype::Double:
+    case Datatype::Date:
+    case Datatype::GeoPoint:
+      if constexpr (prefix == isLiteralPrefix) {
+        return Id::makeFromBool(true);
+      }
+    case Datatype::Undefined:
+    case Datatype::TextRecordIndex:
+    case Datatype::WordVocabIndex:
+    case Datatype::BlankNodeIndex:
+      return Id::makeFromBool(false);
   }
+  AD_FAIL();
 }
 template struct sparqlExpression::detail::IsSomethingValueGetter<
     &Index::Vocab::isIri, isIriPrefix>;

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -1019,6 +1019,7 @@ TEST(SparqlExpression, isSomethingFunctions) {
   Id T = Id::makeFromBool(true);
   Id F = Id::makeFromBool(false);
   Id geo = Id::makeFromGeoPoint(GeoPoint{0, 0});
+  Id date = Id::makeFromDate(DateYearOrDuration::parseXsdDate("2025-06-13"));
   Id iri = testContext().x;
   Id literal = testContext().zz;
   Id blank = testContext().blank;
@@ -1026,18 +1027,18 @@ TEST(SparqlExpression, isSomethingFunctions) {
   Id localLiteral = testContext().notInVocabA;
 
   IdOrLiteralOrIriVec testIdOrStrings = IdOrLiteralOrIriVec{
-      iriref("<i>"), lit("\"l\""), blank2, iri, literal, blank,
-      localLiteral,  I(42),        D(1),   F,   geo,     U};
+      iriref("<i>"), lit("\"l\""), blank2, iri, literal, blank, localLiteral,
+      I(42),         D(1),         F,      geo, date,    U};
   testUnaryExpression<makeIsIriExpression>(
-      testIdOrStrings, Ids{T, F, F, T, F, F, F, F, F, F, F, F});
+      testIdOrStrings, Ids{T, F, F, T, F, F, F, F, F, F, F, F, F});
   testUnaryExpression<makeIsBlankExpression>(
-      testIdOrStrings, Ids{F, F, T, F, F, T, F, F, F, F, F, F});
+      testIdOrStrings, Ids{F, F, T, F, F, T, F, F, F, F, F, F, F});
   testUnaryExpression<makeIsLiteralExpression>(
-      testIdOrStrings, Ids{F, T, F, F, T, F, T, T, T, T, T, F});
+      testIdOrStrings, Ids{F, T, F, F, T, F, T, T, T, T, T, T, F});
   testUnaryExpression<makeIsNumericExpression>(
-      testIdOrStrings, Ids{F, F, F, F, F, F, F, T, T, F, F, F});
+      testIdOrStrings, Ids{F, F, F, F, F, F, F, T, T, F, F, F, F});
   testUnaryExpression<makeBoundExpression>(
-      testIdOrStrings, Ids{T, T, T, T, T, T, T, T, T, T, T, F});
+      testIdOrStrings, Ids{T, T, T, T, T, T, T, T, T, T, T, T, F});
 }
 
 // ____________________________________________________________________________

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -1018,25 +1018,26 @@ TEST(SparqlExpression, customNumericFunctions) {
 TEST(SparqlExpression, isSomethingFunctions) {
   Id T = Id::makeFromBool(true);
   Id F = Id::makeFromBool(false);
+  Id geo = Id::makeFromGeoPoint(GeoPoint{0, 0});
   Id iri = testContext().x;
   Id literal = testContext().zz;
   Id blank = testContext().blank;
   Id blank2 = Id::makeFromBlankNodeIndex(BlankNodeIndex::make(12));
   Id localLiteral = testContext().notInVocabA;
 
-  IdOrLiteralOrIriVec testIdOrStrings =
-      IdOrLiteralOrIriVec{iriref("<i>"), lit("\"l\""), blank2, iri,  literal,
-                          blank,         localLiteral, I(42),  D(1), U};
-  testUnaryExpression<makeIsIriExpression>(testIdOrStrings,
-                                           Ids{T, F, F, T, F, F, F, F, F, F});
-  testUnaryExpression<makeIsBlankExpression>(testIdOrStrings,
-                                             Ids{F, F, T, F, F, T, F, F, F, F});
+  IdOrLiteralOrIriVec testIdOrStrings = IdOrLiteralOrIriVec{
+      iriref("<i>"), lit("\"l\""), blank2, iri, literal, blank,
+      localLiteral,  I(42),        D(1),   F,   geo,     U};
+  testUnaryExpression<makeIsIriExpression>(
+      testIdOrStrings, Ids{T, F, F, T, F, F, F, F, F, F, F, F});
+  testUnaryExpression<makeIsBlankExpression>(
+      testIdOrStrings, Ids{F, F, T, F, F, T, F, F, F, F, F, F});
   testUnaryExpression<makeIsLiteralExpression>(
-      testIdOrStrings, Ids{F, T, F, F, T, F, T, F, F, F});
+      testIdOrStrings, Ids{F, T, F, F, T, F, T, T, T, T, T, F});
   testUnaryExpression<makeIsNumericExpression>(
-      testIdOrStrings, Ids{F, F, F, F, F, F, F, T, T, F});
-  testUnaryExpression<makeBoundExpression>(testIdOrStrings,
-                                           Ids{T, T, T, T, T, T, T, T, T, F});
+      testIdOrStrings, Ids{F, F, F, F, F, F, F, T, T, F, F, F});
+  testUnaryExpression<makeBoundExpression>(
+      testIdOrStrings, Ids{T, T, T, T, T, T, T, T, T, T, T, F});
 }
 
 // ____________________________________________________________________________


### PR DESCRIPTION
For all values that are represented directly in the `Id` (like numerical values, Booleans, dates, and geo points), the function `isLiteral` so far returned false. Now it returns true as it should. Fixes #1930