### PR TITLE
Disallow `USING` and `WITH` when one of the corresponding URL parameters is used

### DIFF
--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -871,8 +871,14 @@ ParsedQuery Visitor::visit(Parser::ModifyContext* ctx) {
   using Iri = TripleComponent::Iri;
   // The graph specified in the `WITH` clause or `std::monostate{}` if there was
   // no with clause.
-  auto withGraph = [&]() -> SparqlTripleSimpleWithGraph::Graph {
+  auto withGraph = [&ctx, this]() -> SparqlTripleSimpleWithGraph::Graph {
     std::optional<Iri> with;
+    if (ctx->iri() && datasetsAreFixed_) {
+      reportError(ctx->iri(),
+                  "`WITH` is disallowed in section 2.2.3 of the SPARQL "
+                  "1.1 protocol standard if the `using-graph-uri` or "
+                  "`using-named-graph-uri` http parameters are used");
+    }
     visitIf(&with, ctx->iri());
     if (with.has_value()) {
       return std::move(with.value());
@@ -905,13 +911,6 @@ ParsedQuery Visitor::visit(Parser::ModifyContext* ctx) {
   // {}` clauses.
   visitTemplateClause(ctx->insertClause(), &op.toInsert_, withGraph);
   visitTemplateClause(ctx->deleteClause(), &op.toDelete_, withGraph);
-
-  if (ctx->iri() && datasetsAreFixed_) {
-    reportError(ctx->iri(),
-                "`WITH` is disallowed in section 2.2.3 of the SPARQL "
-                "1.1 protocol standard if the `using-graph-uri` or "
-                "`using-named-graph-uri` http parameters are used");
-  }
   parsedQuery_._clause = parsedQuery::UpdateClause{op};
 
   return parsedQuery_;

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -877,6 +877,12 @@ ParsedQuery Visitor::visit(Parser::ModifyContext* ctx) {
   auto op = GraphUpdate{};
   visitTemplateClause(ctx->insertClause(), &op.toInsert_);
   visitTemplateClause(ctx->deleteClause(), &op.toDelete_);
+  if (ctx->iri() && datasetsAreFixed_) {
+    reportError(ctx->iri(),
+                "`WITH` is disallowed in section 2.2.3 of the SPARQL "
+                "1.1 protocol standard if the `using-graph-uri` or "
+                "`using-named-graph-uri` http parameters are used");
+  }
   visitIf(&op.with_, ctx->iri());
   parsedQuery_._clause = parsedQuery::UpdateClause{op};
 
@@ -1402,6 +1408,12 @@ string Visitor::visit(Parser::PnameNsContext* ctx) {
 
 // ____________________________________________________________________________________
 DatasetClause SparqlQleverVisitor::visit(Parser::UsingClauseContext* ctx) {
+  if (datasetsAreFixed_) {
+    reportError(ctx,
+                "`USING [NAMED]` is disallowed in section 2.2.3 of the SPARQL "
+                "1.1 protocol standard if the `using-graph-uri` or "
+                "`using-named-graph-uri` http parameters are used");
+  }
   if (ctx->NAMED()) {
     return {.dataset_ = visit(ctx->iri()), .isNamed_ = true};
   } else {

--- a/test/SparqlParserTest.cpp
+++ b/test/SparqlParserTest.cpp
@@ -9,6 +9,7 @@
 #include <utility>
 #include <variant>
 
+#include "./util/GTestHelpers.h"
 #include "SparqlAntlrParserTestHelpers.h"
 #include "global/Constants.h"
 #include "parser/SparqlParser.h"
@@ -1456,15 +1457,20 @@ TEST(ParserTest, parseWithDatasets) {
   auto filterGraphPattern = m::Filters(m::ExistsFilter(
       m::GraphPattern(m::Triples({{Var("?a"), Var{"?b"}, Var("?c")}})),
       datasets));
-  EXPECT_THAT(
+
+  // If the datasets are specified externally, then `USING [NAMED]` is forbidden
+  // by the SPARQL standard.
+  AD_EXPECT_THROW_WITH_MESSAGE(
       SparqlParser::parseUpdate("DELETE { ?x <b> <c> } USING <g> WHERE { ?x ?y "
                                 "?z FILTER EXISTS {?a ?b ?c} }",
                                 {{{Iri("<h>"), false}}}),
-      testing::ElementsAre(m::UpdateClause(
-          m::GraphUpdate(
-              {{Var("?x"), Iri("<b>"), Iri("<c>"), std::monostate{}}}, {},
-              std::nullopt),
-          filterGraphPattern, m::datasetClausesMatcher(datasets))));
+      ::testing::HasSubstr("`USING [NAMED]` is disallowed"));
+  // Same goes for `WITH`
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      SparqlParser::parseUpdate("WITH <g> DELETE { ?x <b> <c> } WHERE { ?x ?y "
+                                "?z FILTER EXISTS {?a ?b ?c} }",
+                                {{{Iri("<h>"), false}}}),
+      ::testing::HasSubstr("`WITH` is disallowed"));
   EXPECT_THAT(
       SparqlParser::parseQuery(
           "SELECT * FROM <g> WHERE { ?x ?y ?z FILTER EXISTS {?a ?b ?c} }",


### PR DESCRIPTION
According to the SPARQL 1.1 Update standard, when the graphs are specified via the URL parameter `using-graph-uri` or `using-named-graph-uri`, then neither `USING` nor `WITH` may be used in the update operation. QLever now returns HTTP status code 400 and an error message when that happens.