### PR TITLE
Add runtime parameter `syntax-test-mode` for silently ignoring certain exceptions

### DIFF
--- a/src/ServerMain.cpp
+++ b/src/ServerMain.cpp
@@ -138,6 +138,11 @@ int main(int argc, char** argv) {
   add("persist-updates", po::bool_switch(&persistUpdates),
       "If set, then SPARQL UPDATES will be persisted on disk. Otherwise they "
       "will be lost when the engine is stopped");
+  add("syntax-test-mode", optionFactory.getProgramOption<"syntax-test-mode">(),
+      "Make several query patterns that are syntactially valid, but otherwise "
+      "erroneous silently into empty results (e.g. LOAD or SERVICE requests to "
+      "nonexisting endpoints). This mode should only be used for running the "
+      "syntax tests from the W3C SPARQL 1.1 test suite.");
   po::variables_map optionsMap;
 
   try {

--- a/src/engine/Load.cpp
+++ b/src/engine/Load.cpp
@@ -80,7 +80,7 @@ Result Load::computeResult(bool requestLaziness) {
     // element for this operation (an empty `IdTable`). The `IdTable` is used to
     // fill in the variables in the template triple `?s ?p ?o`. The empty
     // `IdTable` results in no triples being updated.
-    if (loadClause_.silent_) {
+    if (loadClause_.silent_ || RuntimeParameters().get<"syntax-test-mode">()) {
       return {IdTable{getResultWidth(), getExecutionContext()->getAllocator()},
               resultSortedOn(), LocalVocab{}};
     }

--- a/src/global/RuntimeParameters.h
+++ b/src/global/RuntimeParameters.h
@@ -72,6 +72,11 @@ inline auto& RuntimeParameters() {
         // If set to `true`, we expect the contents of URLs loaded via a LOAD to
         // not change over time. This enables caching of LOAD operations.
         Bool<"cache-load-results">{false},
+        // If set to `true`, several exceptions will silently be ignored and a
+        // dummy result will be returned instead.
+        // This mode should only be activated when running the syntax tests of
+        // the SPARQL conformance test suite.
+        Bool<"syntax-test-mode">{false},
     };
   }();
   return params;


### PR DESCRIPTION
Add a runtime parameter `syntax-test-mode` that, if set to `true`, suppresses certain exception. The default value is `false`. This mode should only activated when running syntax tests from the SPARQL conformance test suite. Some of these tests use queries that are syntactically valid, but impossible to compute.

Currently, setting this runtime parameter suppresses exceptions in the `LOAD` operation. Specifically, all `LOAD` operations then behave as if they were silent. The next step is to set this flag in https://github.com/ad-freiburg/sparql-conformance. After that, make more operations consider `syntax-test-mode`, so that all syntax texts from the conformance test suite run through.