### PR TITLE
Unify `MINUS` implementation to fix bugs with `UNDEF` handling

### DIFF
--- a/src/engine/Minus.cpp
+++ b/src/engine/Minus.cpp
@@ -7,6 +7,7 @@
 #include "engine/CallFixedSize.h"
 #include "engine/Service.h"
 #include "util/Exception.h"
+#include "util/JoinAlgorithms/JoinAlgorithms.h"
 
 using std::endl;
 using std::string;
@@ -42,9 +43,6 @@ Result Minus::computeResult([[maybe_unused]] bool requestLaziness) {
                                    _right->getRootOperation(), true,
                                    requestLaziness);
 
-  IdTable idTable{getExecutionContext()->getAllocator()};
-  idTable.setNumColumns(getResultWidth());
-
   const auto leftResult = _left->getResult();
   const auto rightResult = _right->getResult();
 
@@ -54,11 +52,8 @@ Result Minus::computeResult([[maybe_unused]] bool requestLaziness) {
              << leftResult->idTable().size() << " and "
              << rightResult->idTable().size() << endl;
 
-  int leftWidth = leftResult->idTable().numColumns();
-  int rightWidth = rightResult->idTable().numColumns();
-  CALL_FIXED_SIZE((std::array{leftWidth, rightWidth}), &Minus::computeMinus,
-                  this, leftResult->idTable(), rightResult->idTable(),
-                  _matchedColumns, &idTable);
+  IdTable idTable = computeMinus(leftResult->idTable(), rightResult->idTable(),
+                                 _matchedColumns);
 
   LOG(DEBUG) << "Minus result computation done" << endl;
   // If only one of the two operands has a non-empty local vocabulary, share
@@ -101,124 +96,54 @@ size_t Minus::getCostEstimate() {
 }
 
 // _____________________________________________________________________________
-template <int A_WIDTH, int B_WIDTH>
-void Minus::computeMinus(
-    const IdTable& dynA, const IdTable& dynB,
-    const std::vector<std::array<ColumnIndex, 2>>& joinColumns,
-    IdTable* dynResult) const {
-  // Subtract dynB from dynA. The result should be all result mappings mu
-  // for which all result mappings mu' in dynB are not compatible (one value
-  // for a variable defined in both differs) or the domain of mu and mu' are
-  // disjoint (mu' defines no solution for any variables for which mu defines a
-  // solution).
-
-  // The output is always the same size as the left input
-  constexpr int OUT_WIDTH = A_WIDTH;
-
-  // check for trivial cases
-  if (dynA.size() == 0) {
-    return;
+IdTable Minus::computeMinus(
+    const IdTable& left, const IdTable& right,
+    const std::vector<std::array<ColumnIndex, 2>>& joinColumns) const {
+  if (left.empty()) {
+    return IdTable{getResultWidth(), getExecutionContext()->getAllocator()};
   }
 
-  if (dynB.size() == 0 || joinColumns.empty()) {
-    // B is the empty set of solution mappings, so the result is A
-    // Copy a into the result, allowing for optimizations for small width by
-    // using the templated width types.
-    *dynResult = dynA.clone();
-    return;
+  if (right.empty() || joinColumns.empty()) {
+    return left.clone();
   }
 
-  IdTableView<A_WIDTH> a = dynA.asStaticView<A_WIDTH>();
-  IdTableView<B_WIDTH> b = dynB.asStaticView<B_WIDTH>();
-  IdTableStatic<OUT_WIDTH> result = std::move(*dynResult).toStatic<OUT_WIDTH>();
+  ad_utility::JoinColumnMapping joinColumnData{joinColumns, left.numColumns(),
+                                               right.numColumns()};
 
-  std::vector<size_t> rightToLeftCols(b.numColumns(),
-                                      std::numeric_limits<size_t>::max());
-  for (const auto& jc : joinColumns) {
-    rightToLeftCols[jc[1]] = jc[0];
+  IdTableView<0> joinColumnsLeft =
+      left.asColumnSubsetView(joinColumnData.jcsLeft());
+  IdTableView<0> joinColumnsRight =
+      right.asColumnSubsetView(joinColumnData.jcsRight());
+
+  checkCancellation();
+
+  auto leftPermuted = left.asColumnSubsetView(joinColumnData.permutationLeft());
+  auto rightPermuted =
+      right.asColumnSubsetView(joinColumnData.permutationRight());
+
+  std::vector<size_t> nonMatchingIndices;
+
+  auto outOfOrder = ad_utility::zipperJoinWithUndef(
+      joinColumnsLeft, joinColumnsRight, ql::ranges::lexicographical_compare,
+      [](const auto&, const auto&) {}, ad_utility::findSmallerUndefRanges,
+      ad_utility::findSmallerUndefRanges,
+      [&nonMatchingIndices, &joinColumnsLeft](const auto& matching) {
+        nonMatchingIndices.push_back(
+            ql::ranges::distance(joinColumnsLeft.begin(), matching));
+      });
+  AD_CORRECTNESS_CHECK(outOfOrder == 0);
+
+  IdTable result{getResultWidth(), getExecutionContext()->getAllocator()};
+  AD_CORRECTNESS_CHECK(result.numColumns() == left.numColumns());
+  result.resize(nonMatchingIndices.size());
+
+  for (ColumnIndex col = 0; col < result.numColumns(); col++) {
+    ql::ranges::transform(
+        nonMatchingIndices, result.getColumn(col).begin(),
+        [inputCol = left.getColumn(col)](size_t row) { return inputCol[row]; });
   }
 
-  /**
-   * @brief A function to copy a row from a to the end of result.
-   * @param ia The index of the row in a.
-   */
-  auto writeResult = [&result, &a](size_t ia) { result.push_back(a[ia]); };
-
-  size_t ia = 0, ib = 0;
-  while (ia < a.size() && ib < b.size()) {
-    // Join columns 0 are the primary sort columns
-    while (a(ia, joinColumns[0][0]) < b(ib, joinColumns[0][1])) {
-      // Write a result
-      writeResult(ia);
-      ia++;
-      checkCancellation();
-      if (ia >= a.size()) {
-        goto finish;
-      }
-    }
-    while (b(ib, joinColumns[0][1]) < a(ia, joinColumns[0][0])) {
-      ib++;
-      checkCancellation();
-      if (ib >= b.size()) {
-        goto finish;
-      }
-    }
-
-    while (b(ib, joinColumns[0][1]) == a(ia, joinColumns[0][0])) {
-      // check if the rest of the join columns also match
-      RowComparison rowEq = isRowEqSkipFirst(a, b, ia, ib, joinColumns);
-      switch (rowEq) {
-        case RowComparison::EQUAL: {
-          ia++;
-          if (ia >= a.size()) {
-            goto finish;
-          }
-        } break;
-        case RowComparison::LEFT_SMALLER: {
-          // ib does not discard ia, and there can not be another ib that
-          // would discard ia.
-          writeResult(ia);
-          ia++;
-          if (ia >= a.size()) {
-            goto finish;
-          }
-        } break;
-        case RowComparison::RIGHT_SMALLER: {
-          ib++;
-          if (ib >= b.size()) {
-            goto finish;
-          }
-        } break;
-        default:
-          AD_FAIL();
-      }
-      checkCancellation();
-    }
-  }
-finish:
-  result.reserve(result.size() + (a.size() - ia));
-  while (ia < a.size()) {
-    writeResult(ia);
-    ia++;
-  }
-  *dynResult = std::move(result).toDynamic();
-}
-
-template <int A_WIDTH, int B_WIDTH>
-Minus::RowComparison Minus::isRowEqSkipFirst(
-    const IdTableView<A_WIDTH>& a, const IdTableView<B_WIDTH>& b, size_t ia,
-    size_t ib, const std::vector<std::array<ColumnIndex, 2>>& joinColumns) {
-  for (size_t i = 1; i < joinColumns.size(); ++i) {
-    Id va{a(ia, joinColumns[i][0])};
-    Id vb{b(ib, joinColumns[i][1])};
-    if (va < vb) {
-      return RowComparison::LEFT_SMALLER;
-    }
-    if (va > vb) {
-      return RowComparison::RIGHT_SMALLER;
-    }
-  }
-  return RowComparison::EQUAL;
+  return result;
 }
 
 // _____________________________________________________________________________

--- a/src/engine/Minus.h
+++ b/src/engine/Minus.h
@@ -25,10 +25,6 @@ class Minus : public Operation {
   Minus(QueryExecutionContext* qec, std::shared_ptr<QueryExecutionTree> left,
         std::shared_ptr<QueryExecutionTree> right);
 
-  // Uninitialized Object for testing the computeMinus method
-  struct OnlyForTestingTag {};
-  explicit Minus(OnlyForTestingTag) {}
-
  protected:
   string getCacheKeyImpl() const override;
 
@@ -62,22 +58,12 @@ class Minus : public Operation {
    *        that should have resultWidth entries).
    *        This method is made public here for unit testing purposes.
    **/
-  template <int A_WIDTH, int B_WIDTH>
-  void computeMinus(const IdTable& a, const IdTable& b,
-                    const vector<std::array<ColumnIndex, 2>>& matchedColumns,
-                    IdTable* result) const;
+  IdTable computeMinus(
+      const IdTable& a, const IdTable& b,
+      const vector<std::array<ColumnIndex, 2>>& matchedColumns) const;
 
  private:
   std::unique_ptr<Operation> cloneImpl() const override;
-
-  /**
-   * @brief Compares the two rows under the assumption that the first
-   * entries of the rows are equal.
-   */
-  template <int A_WIDTH, int B_WIDTH>
-  static RowComparison isRowEqSkipFirst(
-      const IdTableView<A_WIDTH>& a, const IdTableView<B_WIDTH>& b, size_t ia,
-      size_t ib, const vector<std::array<ColumnIndex, 2>>& matchedColumns);
 
   Result computeResult([[maybe_unused]] bool requestLaziness) override;
 

--- a/test/MinusTest.cpp
+++ b/test/MinusTest.cpp
@@ -17,7 +17,7 @@
 #include "util/IndexTestHelpers.h"
 #include "util/OperationTestHelpers.h"
 
-TEST(EngineTest, minusTest) {
+TEST(Minus, computeMinus) {
   IdTable a = makeIdTableFromVector(
       {{1, 2, 1}, {2, 1, 4}, {5, 4, 1}, {8, 1, 2}, {8, 2, 3}});
 
@@ -73,6 +73,32 @@ TEST(EngineTest, minusTest) {
   IdTable vres = vm.computeMinus(va, vb, jcls);
 
   EXPECT_EQ(vres, makeIdTableFromVector({{7, 6, 5, 4, 3, 2}}));
+}
+
+// _____________________________________________________________________________
+TEST(Minus, computeMinusWithUndefined) {
+  auto U = Id::makeUndefined();
+  IdTable a =
+      makeIdTableFromVector({{U, U, 10}, {U, 1, 11}, {1, U, 12}, {5, 4, 13}});
+  IdTable b = makeIdTableFromVector({{U, U, 20}, {3, U, 21}, {1, 2, 22}});
+
+  std::vector<std::array<ColumnIndex, 2>> jcls;
+  jcls.push_back(std::array<ColumnIndex, 2>{{0, 1}});
+  jcls.push_back(std::array<ColumnIndex, 2>{{1, 0}});
+
+  auto* qec = ad_utility::testing::getQec();
+  Minus m{qec,
+          ad_utility::makeExecutionTree<ValuesForTesting>(
+              qec, a.clone(),
+              std::vector<std::optional<Variable>>{
+                  Variable{"?a"}, Variable{"?b"}, std::nullopt}),
+          ad_utility::makeExecutionTree<ValuesForTesting>(
+              qec, b.clone(),
+              std::vector<std::optional<Variable>>{
+                  Variable{"?b"}, Variable{"?a"}, std::nullopt})};
+
+  IdTable res = m.computeMinus(a, b, jcls);
+  EXPECT_EQ(res, makeIdTableFromVector({{U, U, 10}, {1, U, 12}, {5, 4, 13}}));
 }
 
 // _____________________________________________________________________________


### PR DESCRIPTION
This changes the implementation of the `Minus` operation to use the interface provided by `JoinAlgorithms.h` and uses it in a way that ensures `UNDEF` values are handled correctly.

Specifically, a query like

```sparql
SELECT * WHERE {
  VALUES (?a ?b) { (UNDEF UNDEF) (UNDEF 1) }
  MINUS {
    VALUES (?a ?b) { (1 UNDEF) (UNDEF UNDEF) (1 1) }
  }
}
```

returns a single row with two `UNDEF` values.

and

```sparql
SELECT * WHERE {
  VALUES (?a ?b) { (UNDEF UNDEF) (UNDEF 1) }
  MINUS {
    VALUES (?a ?b) { (1 UNDEF) (UNDEF UNDEF) }
  }
}
```

now correctly returns two rows, one with `UNDEF` and `UNDEF`, the other one with `UNDEF` and `1`.