### PR TITLE
Let syntax tests with non-existing endpoints or IRI functions pass

### DIFF
--- a/src/engine/Service.cpp
+++ b/src/engine/Service.cpp
@@ -133,6 +133,9 @@ Result Service::computeResult(bool requestLaziness) {
 // ____________________________________________________________________________
 Result Service::computeResultImpl(bool requestLaziness) {
   // Get the URL of the SPARQL endpoint.
+  if (RuntimeParameters().get<"syntax-test-mode">()) {
+    return makeNeutralElementResultForSilentFail();
+  }
   ad_utility::httpUtils::Url serviceUrl{
       asStringViewUnsafe(parsedServiceClause_.serviceIri_.getContent())};
 

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -239,9 +239,17 @@ ExpressionPtr Visitor::processIriFunctionCall(
     }
   }
 
-  // If none of the above matched, report unknown function.
-  reportNotSupported(ctx,
-                     "Function \""s + iri.toStringRepresentation() + "\" is");
+  if (RuntimeParameters().get<"syntax-test-mode">()) {
+    AD_CORRECTNESS_CHECK(
+        argList.size() == 1,
+        "Please change if the W3C test suite ever adds syntax tests for "
+        "arbitrary function IRIs which don't have exactly one argument");
+    return createUnary(&makeLatitudeExpression);
+  } else {
+    // If none of the above matched, report unknown function.
+    reportNotSupported(ctx,
+                       "Function \""s + iri.toStringRepresentation() + "\" is");
+  }
 }
 
 void Visitor::addVisibleVariable(Variable var) {

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -240,11 +240,10 @@ ExpressionPtr Visitor::processIriFunctionCall(
   }
 
   if (RuntimeParameters().get<"syntax-test-mode">()) {
-    AD_CORRECTNESS_CHECK(
-        argList.size() == 1,
-        "Please change if the W3C test suite ever adds syntax tests for "
-        "arbitrary function IRIs which don't have exactly one argument");
-    return createUnary(&makeLatitudeExpression);
+    // In the syntax test mode we silently create an expression that always
+    // returns `UNDEF`.
+    return std::make_unique<sparqlExpression::IdExpression>(
+        Id::makeUndefined());
   } else {
     // If none of the above matched, report unknown function.
     reportNotSupported(ctx,

--- a/test/ServiceTest.cpp
+++ b/test/ServiceTest.cpp
@@ -254,6 +254,11 @@ TEST_F(ServiceTest, computeResult) {
               runComputeResult(result, status, contentType, false),
               ::testing::HasSubstr(errorMsg));
           EXPECT_NO_THROW(runComputeResult(result, status, contentType, true));
+
+          // In the syntax test mode, all services (so also the failing ones)
+          // return the neutral result.
+          auto cleanup = setRuntimeParameterForTest<"syntax-test-mode">(true);
+          EXPECT_NO_THROW(runComputeResult(result, status, contentType, false));
         };
 
     // CHECK 1: An exception shall be thrown (and maybe silenced), when

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -13,6 +13,7 @@
 
 #include "./SparqlExpressionTestHelpers.h"
 #include "./util/GTestHelpers.h"
+#include "./util/RuntimeParametersTestHelpers.h"
 #include "./util/TripleComponentTestHelpers.h"
 #include "QueryPlannerTestHelpers.h"
 #include "SparqlAntlrParserTestHelpers.h"
@@ -1965,8 +1966,14 @@ TEST(SparqlParser, FunctionCall) {
   expectFunctionCallFails(absl::StrCat(ql, "nada>(?x)"));
 
   // Prefix for which no function is known.
-  std::string prefixNexistepas = "<http://nexiste.pas/>";
+  std::string prefixNexistepas = "<http://nexiste.pas/";
   expectFunctionCallFails(absl::StrCat(prefixNexistepas, "nada>(?x)"));
+
+  // Check that arbitrary nonexisting functions with a single argument silently
+  // return a `LatitudeExpression` in the syntax test mode.
+  auto cleanup = setRuntimeParameterForTest<"syntax-test-mode">(true);
+  expectFunctionCall(absl::StrCat(prefixNexistepas, "nada>(?x)"),
+                     matchUnary(&makeLatitudeExpression));
 }
 
 // ______________________________________________________________________________

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -1970,10 +1970,12 @@ TEST(SparqlParser, FunctionCall) {
   expectFunctionCallFails(absl::StrCat(prefixNexistepas, "nada>(?x)"));
 
   // Check that arbitrary nonexisting functions with a single argument silently
-  // return a `LatitudeExpression` in the syntax test mode.
+  // return an `IdExpression(UNDEF)` in the syntax test mode.
   auto cleanup = setRuntimeParameterForTest<"syntax-test-mode">(true);
-  expectFunctionCall(absl::StrCat(prefixNexistepas, "nada>(?x)"),
-                     matchUnary(&makeLatitudeExpression));
+  expectFunctionCall(
+      absl::StrCat(prefixNexistepas, "nada>(?x)"),
+      matchPtr<IdExpression>(AD_PROPERTY(IdExpression, value,
+                                         ::testing::Eq(Id::makeUndefined()))));
 }
 
 // ______________________________________________________________________________


### PR DESCRIPTION
Some of the syntax tests of the W3C test suite use `SERVICE` with a non-existing endpoint (like `SERVICE <g>`) or non-existing function IRIs (line `BIND <http://nexistepas.org/nothingHere>(?x) as ?y)`). With `syntax-test-mode = true`, such `SERVICE` operations now fail silently and non-existing IRI functions return UNDEF.

NOTE: Now only two more syntax tests fail, but those are due to actual bugs in QLever, which need to be fixed.