### PR TITLE
Choose media type depending on the query type

### DIFF
--- a/src/engine/GraphStoreProtocol.h
+++ b/src/engine/GraphStoreProtocol.h
@@ -46,14 +46,16 @@ class GraphStoreProtocol {
       // content.
       throw UnknownMediatypeError("Mediatype empty or not set.");
     }
-    const auto mediatype =
-        ad_utility::getMediaTypeFromAcceptHeader(contentTypeString);
+    auto mediaTypes =
+        ad_utility::getMediaTypesFromAcceptHeader(contentTypeString);
+
     // A media type is set but not one of the supported ones as per the QLever
-    // MediaType code.
-    if (!mediatype.has_value()) {
+    // MediaType code. Content-Type is only allowed to return a single value, so
+    // wildcards are also correctly discarded here.
+    if (mediaTypes.size() != 1) {
       throwUnsupportedMediatype(rawRequest.at(field::content_type));
     }
-    return mediatype.value();
+    return mediaTypes.front();
   }
   FRIEND_TEST(GraphStoreProtocolTest, extractMediatype);
 

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -765,16 +765,16 @@ CPP_template_def(typename RequestT)(
 // _____________________________________________________________________________
 ad_utility::MediaType Server::chooseBestFittingMediaType(
     const std::vector<ad_utility::MediaType>& candidates,
-    const ParsedQuery& plannedQuery) {
+    const ParsedQuery& parsedQuery) {
   if (!candidates.empty()) {
-    auto it = ql::ranges::find_if(candidates, [&plannedQuery](
+    auto it = ql::ranges::find_if(candidates, [&parsedQuery](
                                                   MediaType mediaType) {
-      if (plannedQuery.hasAskClause()) {
+      if (parsedQuery.hasAskClause()) {
         std::array supportedMediaTypes{
             MediaType::sparqlXml, MediaType::sparqlJson, MediaType::qleverJson};
         return ad_utility::contains(supportedMediaTypes, mediaType);
       }
-      if (plannedQuery.hasSelectClause()) {
+      if (parsedQuery.hasSelectClause()) {
         std::array supportedMediaTypes{
             MediaType::octetStream, MediaType::csv,
             MediaType::tsv,         MediaType::qleverJson,
@@ -790,8 +790,8 @@ ad_utility::MediaType Server::chooseBestFittingMediaType(
     }
   }
 
-  return plannedQuery.hasConstructClause() ? MediaType::turtle
-                                           : MediaType::sparqlJson;
+  return parsedQuery.hasConstructClause() ? MediaType::turtle
+                                          : MediaType::sparqlJson;
 }
 
 // ____________________________________________________________________________

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -154,7 +154,8 @@ class Server {
   // list is empty, just choose one that works for the given query type.
   static ad_utility::MediaType chooseBestFittingMediaType(
       const std::vector<ad_utility::MediaType>& candidates,
-      const PlannedQuery& plannedQuery);
+      const ParsedQuery& plannedQuery);
+  FRIEND_TEST(ServerTest, chooseBestFittingMediaType);
 
   // Do the actual execution of a query.
   CPP_template(typename RequestT, typename ResponseT)(

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -154,7 +154,7 @@ class Server {
   // list is empty, just choose one that works for the given query type.
   static ad_utility::MediaType chooseBestFittingMediaType(
       const std::vector<ad_utility::MediaType>& candidates,
-      const ParsedQuery& plannedQuery);
+      const ParsedQuery& parsedQuery);
   FRIEND_TEST(ServerTest, chooseBestFittingMediaType);
 
   // Do the actual execution of a query.

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -148,6 +148,14 @@ class Server {
           VisitorT visitor, const ad_utility::Timer& requestTimer,
           const RequestT& request, ResponseT& send,
           const std::optional<PlannedQuery>& plannedQuery);
+
+  // Out of a list of allowed media types, choose the one that best fits the
+  // given query type. Currently it just chooses the first from the list. If the
+  // list is empty, just choose one that works for the given query type.
+  static ad_utility::MediaType chooseBestFittingMediaType(
+      const std::vector<ad_utility::MediaType>& candidates,
+      const PlannedQuery& plannedQuery);
+
   // Do the actual execution of a query.
   CPP_template(typename RequestT, typename ResponseT)(
       requires ad_utility::httpUtils::HttpRequest<RequestT>)
@@ -176,13 +184,15 @@ class Server {
           QueryExecutionContext& qec, const RequestT& request, ResponseT&& send,
           TimeLimit timeLimit, std::optional<PlannedQuery>& plannedUpdate);
 
-  // Determine the media type to be used for the result. The media type is
+  // Determine media type candidates to be used for the result. Media types are
   // determined (in this order) by the current action (e.g.,
-  // "action=csv_export") and by the "Accept" header of the request.
-  CPP_template(typename RequestT)(requires ad_utility::httpUtils::HttpRequest<
-                                  RequestT>) static ad_utility::MediaType
-      determineMediaType(const ad_utility::url_parser::ParamValueMap& params,
-                         const RequestT& request);
+  // "action=csv_export") and by the "Accept" header of the request. The latter
+  // option can produce multiple candidates.
+  CPP_template(typename RequestT)(
+      requires ad_utility::httpUtils::HttpRequest<RequestT>) static std::
+      vector<ad_utility::MediaType> determineMediaTypes(
+          const ad_utility::url_parser::ParamValueMap& params,
+          const RequestT& request);
   FRIEND_TEST(ServerTest, determineMediaType);
   // Determine whether the subtrees and the result should be pinned.
   static std::pair<bool, bool> determineResultPinning(

--- a/src/util/http/MediaTypes.h
+++ b/src/util/http/MediaTypes.h
@@ -107,16 +107,11 @@ const std::string& getType(MediaType t);
 std::vector<MediaTypeWithQuality> parseAcceptHeader(
     std::string_view acceptHeader);
 
-/// Parse `acceptHeader`, and determine which of the `SUPPORTED_MEDIA_TYPES`
-/// has the highest priority, and return this type. If several mediaTypes have
-/// the same priority (e.g. because of a wildcard in `acceptHeader`) then
-/// media types that appear earlier in the `SUPPORTED_MEDIA_TYPES`. If none of
-/// the `SUPPORTED_MEDIA_TYPES` is accepted by `acceptHeader`, then
-/// `std::nullopt` is returned.
-// TODO: This function never returns `nullopt`, because an exception is thrown
-// if no supported media type is found. Update the docstring and make the return
-// type just `MediaType`.
-std::optional<MediaType> getMediaTypeFromAcceptHeader(
+// Parse `acceptHeader` and create a vector of compatible `MediaType`s from it.
+// Unconstrained wildcards will be ignored, and leave the decision to a
+// different mechanism down the line. The media types will be sorted according
+// to the order created by `parseAcceptHeader`.
+std::vector<MediaType> getMediaTypesFromAcceptHeader(
     std::string_view acceptHeader);
 
 /// Return an error message, which reports that only the `SUPPORTED_MEDIA_TYPES`

--- a/test/AcceptHeaderTest.cpp
+++ b/test/AcceptHeaderTest.cpp
@@ -2,7 +2,7 @@
 //  Chair of Algorithms and Data Structures.
 //  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
 
-#include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
 #include <string>
 
@@ -138,35 +138,32 @@ TEST(AcceptHeaderParser, IllegalInput) {
 
 TEST(AcceptHeaderParser, FindMediaTypeFromAcceptHeader) {
   std::string p = "text/html,application/sparql-results+json";
-  auto result = getMediaTypeFromAcceptHeader(p);
-  ASSERT_TRUE(result.has_value());
-  ASSERT_EQ(result.value(), MediaType::sparqlJson);
+  auto result = getMediaTypesFromAcceptHeader(p);
+  EXPECT_THAT(result, ::testing::ElementsAre(MediaType::sparqlJson));
 
   p = "application/json, image/jpeg";
-  ASSERT_FALSE(getMediaTypeFromAcceptHeader(p).has_value());
+  result = getMediaTypesFromAcceptHeader(p);
+  EXPECT_THAT(result, ::testing::ElementsAre());
 
-  // The wildcard matches all the supported media types, sparql-json has
-  // higher priority;
+  // The wildcard matches all the supported media types, ignoring it leaves the
+  // decision to another mechanism.
   p = "*/*, text/html";
-  result = getMediaTypeFromAcceptHeader(p);
-  ASSERT_TRUE(result.has_value());
-  ASSERT_EQ(result.value(), MediaType::sparqlJson);
+  result = getMediaTypesFromAcceptHeader(p);
+  EXPECT_THAT(result, ::testing::ElementsAre());
 
   // The wildcard matches csv and tsv, but not the json variants
   p = "text/*, text/html";
-  result = getMediaTypeFromAcceptHeader(p);
-  ASSERT_TRUE(result.has_value());
-  ASSERT_EQ(result.value(), MediaType::tsv);
+  result = getMediaTypesFromAcceptHeader(p);
+  EXPECT_THAT(result, ::testing::ElementsAre(MediaType::tsv));
 
   // The wildcard matches csv/tsv, qlever-json has higher precedence;
   p = "text/*, application/qlever-results+json";
-  result = getMediaTypeFromAcceptHeader(p);
-  ASSERT_TRUE(result.has_value());
-  ASSERT_EQ(result.value(), MediaType::qleverJson);
+  result = getMediaTypesFromAcceptHeader(p);
+  EXPECT_THAT(result,
+              ::testing::ElementsAre(MediaType::qleverJson, MediaType::tsv));
 
-  // The wildcard matches tsv/csv, which has the higher quality value;
+  // The wildcard matches tsv/csv, since the json is not supported.
   p = "text/*, application/json; q=0.3";
-  result = getMediaTypeFromAcceptHeader(p);
-  ASSERT_TRUE(result.has_value());
-  ASSERT_EQ(result.value(), MediaType::tsv);
+  result = getMediaTypesFromAcceptHeader(p);
+  EXPECT_THAT(result, ::testing::ElementsAre(MediaType::tsv));
 }

--- a/test/AcceptHeaderTest.cpp
+++ b/test/AcceptHeaderTest.cpp
@@ -159,7 +159,8 @@ TEST(AcceptHeaderParser, FindMediaTypeFromAcceptHeader) {
   EXPECT_THAT(result,
               ElementsAre(MediaType::tsv, MediaType::csv, MediaType::turtle));
 
-  // The wildcard matches csv/tsv/turtle, qlever-json has higher precedence;
+  // The wildcard matches csv/tsv/turtle, qlever-json has higher precedence
+  // because it is explicit.
   p = "text/*, application/qlever-results+json";
   result = getMediaTypesFromAcceptHeader(p);
   EXPECT_THAT(result, ElementsAre(MediaType::qleverJson, MediaType::tsv,

--- a/test/ServerTest.cpp
+++ b/test/ServerTest.cpp
@@ -45,37 +45,37 @@ TEST(ServerTest, determineMediaType) {
   };
   auto checkActionMediatype = [&](const std::string& actionName,
                                   ad_utility::MediaType expectedMediaType) {
-    EXPECT_THAT(Server::determineMediaType({{"action", {actionName}}},
-                                           MakeRequest(std::nullopt)),
-                testing::Eq(expectedMediaType));
+    EXPECT_THAT(Server::determineMediaTypes({{"action", {actionName}}},
+                                            MakeRequest(std::nullopt)),
+                testing::ElementsAre(expectedMediaType));
   };
   // The media type associated with the action overrides the `Accept` header.
-  EXPECT_THAT(Server::determineMediaType(
+  EXPECT_THAT(Server::determineMediaTypes(
                   {{"action", {"csv_export"}}},
                   MakeRequest("application/sparql-results+json")),
-              testing::Eq(ad_utility::MediaType::csv));
+              testing::ElementsAre(ad_utility::MediaType::csv));
   checkActionMediatype("csv_export", ad_utility::MediaType::csv);
   checkActionMediatype("tsv_export", ad_utility::MediaType::tsv);
   checkActionMediatype("qlever_json_export", ad_utility::MediaType::qleverJson);
   checkActionMediatype("sparql_json_export", ad_utility::MediaType::sparqlJson);
   checkActionMediatype("turtle_export", ad_utility::MediaType::turtle);
   checkActionMediatype("binary_export", ad_utility::MediaType::octetStream);
-  EXPECT_THAT(Server::determineMediaType(
+  EXPECT_THAT(Server::determineMediaTypes(
                   {}, MakeRequest("application/sparql-results+json")),
-              testing::Eq(ad_utility::MediaType::sparqlJson));
+              testing::ElementsAre(ad_utility::MediaType::sparqlJson));
   // No supported media type in the `Accept` header. (Contrary to it's docstring
   // and interface) `ad_utility::getMediaTypeFromAcceptHeader` throws an
   // exception if no supported media type is found.
   AD_EXPECT_THROW_WITH_MESSAGE(
-      Server::determineMediaType({}, MakeRequest("text/css")),
+      Server::determineMediaTypes({}, MakeRequest("text/css")),
       testing::HasSubstr("Not a single media type known to this parser was "
                          "detected in \"text/css\"."));
   // No `Accept` header means that any content type is allowed.
-  EXPECT_THAT(Server::determineMediaType({}, MakeRequest(std::nullopt)),
-              testing::Eq(ad_utility::MediaType::sparqlJson));
+  EXPECT_THAT(Server::determineMediaTypes({}, MakeRequest(std::nullopt)),
+              testing::ElementsAre());
   // No `Accept` header and an empty `Accept` header are not distinguished.
-  EXPECT_THAT(Server::determineMediaType({}, MakeRequest("")),
-              testing::Eq(ad_utility::MediaType::sparqlJson));
+  EXPECT_THAT(Server::determineMediaTypes({}, MakeRequest("")),
+              testing::ElementsAre());
 }
 
 TEST(ServerTest, getQueryId) {


### PR DESCRIPTION
So far, the choice of media type did not respect the query type. In particular, the default media type (when no accept header was specified) was always `application/sparql-results+json`, which led to an error message for `CONSTRUCT` and `DESCRIBE` queries.

This is now fixed and made compliant with the standard. The media type is now the best fit for both the accept header (if any) and the query type. Note that an accept header can also specify multiple media types (separated by comma), wildcards (e.g., `text/*`), and priorities (e.g., `text/turtle;q=0.9, text/csv;q=0.1`).