### PR TITLE
Consider `GRAPH` variable inside of `GRAPH` clause

### DIFF
--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -2987,9 +2987,9 @@ void QueryPlanner::GraphPatternPlanner::visitUnion(parsedQuery::Union& arg) {
 void QueryPlanner::GraphPatternPlanner::visitSubquery(
     parsedQuery::Subquery& arg) {
   absl::Cleanup resetActiveGraphs{
-      [this, originalVar = planner_.activeGraphVariable_]() {
+      [this, originalVar = planner_.activeGraphVariable_]() mutable {
         // Reset back to original
-        planner_.activeGraphVariable_ = originalVar;
+        planner_.activeGraphVariable_ = std::move(originalVar);
       }};
 
   ParsedQuery& subquery = arg.get();

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -3567,6 +3567,13 @@ TEST(QueryPlanner, graphVariablesWithinPattern) {
             h::Filter("?x = ?_QLever_internal_variable_qp_0",
                       scan("?x", "?y", "?z", {}, std::nullopt,
                            {Variable{internalVar(0)}}, {3})));
+
+  // Wrapped in subquery (one of the compliance tests)
+  h::expect(
+      "SELECT ?x ?p WHERE { GRAPH ?g { { SELECT * WHERE { ?x ?p ?g } } } }",
+      h::Filter("?g = ?_QLever_internal_variable_qp_0",
+                scan("?x", "?p", "?g", {}, std::nullopt,
+                     {Variable{internalVar(0)}}, {3})));
 }
 
 // _____________________________________________________________________________

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -3563,7 +3563,7 @@ TEST(QueryPlanner, graphVariablesWithinPattern) {
                            {Variable{internalVar(0)}}, {3})));
 
   // Wrapped in subquery (one of the compliance tests), this behaviour is
-  // currently not correct, the subquery needs to be joined with all exising
+  // currently not correct, the subquery needs to be joined with all existing
   // graphs.
   h::expect(
       "SELECT ?x ?p WHERE { GRAPH ?g { { SELECT * WHERE { ?x ?p ?g } } } }",

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -3517,12 +3517,56 @@ TEST(QueryPlanner, DatasetClause) {
                      h::UnorderedJoins(
                          scan("<d>", "?p", "<z2>", {}, g2, varG, graphCol))),
           scan("<e>", "?p", "<z3>", {}, g1)));
-  // We currently don't support repeating the graph variable inside the
-  // graph clause
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      h::expect("SELECT * { GRAPH ?x {?x <b> <c>}}", ::testing::_),
-      AllOf(HasSubstr("used as the graph specifier"),
-            HasSubstr("may not appear in the body")));
+}
+// _____________________________________________________________________________
+TEST(QueryPlanner, graphVariablesWithinPattern) {
+  auto scan = h::IndexScanFromStrings;
+  // Single variable
+  h::expect("SELECT * { GRAPH ?x { ?x <b> <c> } }",
+            h::Filter("?x = ?_QLever_internal_variable_qp_0",
+                      scan("?x", "<b>", "<c>", {}, std::nullopt,
+                           {Variable{internalVar(0)}}, {3})));
+  h::expect("SELECT * { GRAPH ?x { <a> ?x <c> } }",
+            h::Filter("?x = ?_QLever_internal_variable_qp_0",
+                      scan("<a>", "?x", "<c>", {}, std::nullopt,
+                           {Variable{internalVar(0)}}, {3})));
+  h::expect("SELECT * { GRAPH ?x { <a> <b> ?x } }",
+            h::Filter("?x = ?_QLever_internal_variable_qp_0",
+                      scan("<a>", "<b>", "?x", {}, std::nullopt,
+                           {Variable{internalVar(0)}}, {3})));
+  // Two variables
+  h::expect(
+      "SELECT * { GRAPH ?x { ?x ?x <c> } }",
+      h::Filter("?x = ?_QLever_internal_variable_qp_1",
+                h::Filter("?_QLever_internal_variable_qp_0=?x",
+                          scan(internalVar(0), "?x", "<c>", {}, std::nullopt,
+                               {Variable{internalVar(1)}}, {3}))));
+  h::expect(
+      "SELECT * { GRAPH ?x { ?x <b> ?x } }",
+      h::Filter("?x = ?_QLever_internal_variable_qp_1",
+                h::Filter("?_QLever_internal_variable_qp_0=?x",
+                          scan("?x", "<b>", internalVar(0), {}, std::nullopt,
+                               {Variable{internalVar(1)}}, {3}))));
+  h::expect(
+      "SELECT * { GRAPH ?x { <a> ?x ?x } }",
+      h::Filter("?x = ?_QLever_internal_variable_qp_1",
+                h::Filter("?_QLever_internal_variable_qp_0=?x",
+                          scan("<a>", "?x", internalVar(0), {}, std::nullopt,
+                               {Variable{internalVar(1)}}, {3}))));
+  // Three variables
+  h::expect(
+      "SELECT * { GRAPH ?x { ?x ?x ?x } }",
+      h::Filter("?x = ?_QLever_internal_variable_qp_2",
+                h::Filter("?_QLever_internal_variable_qp_1=?x",
+                          h::Filter("?_QLever_internal_variable_qp_0=?x",
+                                    scan(internalVar(1), "?x", internalVar(0),
+                                         {}, std::nullopt,
+                                         {Variable{internalVar(2)}}, {3})))));
+  // Three distinct variables
+  h::expect("SELECT * { GRAPH ?x { ?x ?y ?z } }",
+            h::Filter("?x = ?_QLever_internal_variable_qp_0",
+                      scan("?x", "?y", "?z", {}, std::nullopt,
+                           {Variable{internalVar(0)}}, {3})));
 }
 
 // _____________________________________________________________________________

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -3568,12 +3568,12 @@ TEST(QueryPlanner, graphVariablesWithinPattern) {
                       scan("?x", "?y", "?z", {}, std::nullopt,
                            {Variable{internalVar(0)}}, {3})));
 
-  // Wrapped in subquery (one of the compliance tests)
+  // Wrapped in subquery (one of the compliance tests), this behaviour is
+  // currently not correct, the subquery needs to be joined with all exising
+  // graphs.
   h::expect(
       "SELECT ?x ?p WHERE { GRAPH ?g { { SELECT * WHERE { ?x ?p ?g } } } }",
-      h::Filter("?g = ?_QLever_internal_variable_qp_0",
-                scan("?x", "?p", "?g", {}, std::nullopt,
-                     {Variable{internalVar(0)}}, {3})));
+      scan("?x", "?p", "?g"));
 }
 
 // _____________________________________________________________________________

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -3491,16 +3491,12 @@ TEST(QueryPlanner, DatasetClause) {
             scan("<a>", "<b>", "<c>", {}, noGraphs, varG, graphCol));
 
   // `GROUP BY` inside a `GRAPH ?g` clause.
-  // We use the `UnorderedJoins` matcher, because the index scan has to be
-  // resorted by the graph column.
   h::expect(
       "SELECT * FROM <g1> FROM NAMED <g2> { GRAPH ?g "
       "{ "
       "{SELECT ?p {<d> ?p <z2>} GROUP BY ?p}"
       "} }",
-      h::GroupBy({Variable{"?p"}, Variable{"?g"}}, {},
-                 h::UnorderedJoins(
-                     scan("<d>", "?p", "<z2>", {}, g2, varG, graphCol))));
+      h::GroupBy({Variable{"?p"}}, {}, scan("<d>", "?p", "<z2>", {}, g2)));
 
   // A complex example with graph variables.
   h::expect(
@@ -3512,10 +3508,8 @@ TEST(QueryPlanner, DatasetClause) {
       h::UnorderedJoins(
           scan("<a>", "?p", "<x>", {}, g1), scan("<b>", "?p", "<y>", {}, g1),
           scan("<c>", "?p", "<z>", {}, g2, varG, graphCol),
-          scan("<d>", "?p", "<z2>", {}, g2, varG, graphCol),
-          h::GroupBy({Variable{"?p"}, Variable{"?g"}}, {},
-                     h::UnorderedJoins(
-                         scan("<d>", "?p", "<z2>", {}, g2, varG, graphCol))),
+          scan("<d>", "?p", "<z2>", {}, g2),
+          h::GroupBy({Variable{"?p"}}, {}, scan("<d>", "?p", "<z2>", {}, g2)),
           scan("<e>", "?p", "<z3>", {}, g1)));
 }
 // _____________________________________________________________________________


### PR DESCRIPTION
Queries like the following did not work correctly so far because the `GRAPH` variable was treated like any other variable inside of the `GRAPH` clause. This is now tentatively fixed by adding a suitable `FILTER` operation.
```sparql
SELECT * {
  GRAPH ?g {
    ?g ?p ?o
  }
}
```
NOTE: There are still problems when the `?g` in the example above is also used in other patterns inside the `GRAPH` clause, like `BIND` or `VALUES`.  To properly fix this, we need an operation that efficiently returns a list of all distinct graphs, which we do not have yet (but plan to have soon).