### PR TITLE
Quick fix for handling `LIMIT` and `OFFSET` in Cartesian product join

### DIFF
--- a/src/engine/CartesianProductJoin.cpp
+++ b/src/engine/CartesianProductJoin.cpp
@@ -9,8 +9,10 @@
 
 namespace {
 constexpr std::string_view recomputeMessage =
-    "After limits have been applied to the children, we can't compute the "
-    "results again in case the index changed.";
+    "Cannot re-evaluate child results after applying limits, as the result set "
+    "may have changed (which could result in different limits being applied). "
+    "Cloning is also forbidden, as it would preserve potentially incorrect "
+    "limits.";
 }
 
 // ____________________________________________________________________________

--- a/src/engine/CartesianProductJoin.cpp
+++ b/src/engine/CartesianProductJoin.cpp
@@ -7,6 +7,12 @@
 #include "engine/CallFixedSize.h"
 #include "util/Views.h"
 
+namespace {
+constexpr std::string_view recomputeMessage =
+    "After limits have been applied to the children, we can't compute the "
+    "results again in case the index changed.";
+}
+
 // ____________________________________________________________________________
 CartesianProductJoin::CartesianProductJoin(
     QueryExecutionContext* executionContext, Children children,
@@ -136,9 +142,6 @@ Result CartesianProductJoin::computeResult(bool requestLaziness) {
     return {IdTable{getResultWidth(), getExecutionContext()->getAllocator()},
             resultSortedOn(), LocalVocab{}};
   }
-  // Make sure the children are reset back to their initial state after
-  // computing the results.
-  auto cleanup = resetChildLimitsAndOffsetOnDestruction();
   auto [subResults, lazyResult] = calculateSubResults(requestLaziness);
 
   LocalVocab staticMergedVocab{};
@@ -248,6 +251,7 @@ CPP_template_def(typename R)(requires ql::ranges::random_access_range<R>)
 std::pair<std::vector<std::shared_ptr<const Result>>,
           std::shared_ptr<const Result>>
 CartesianProductJoin::calculateSubResults(bool requestLaziness) {
+  AD_CONTRACT_CHECK(!forbiddenToRecompute_, recomputeMessage);
   std::vector<std::shared_ptr<const Result>> subResults;
   // We don't need to fully materialize the child results if we have a LIMIT
   // specified and an OFFSET of 0.
@@ -266,6 +270,7 @@ CartesianProductJoin::calculateSubResults(bool requestLaziness) {
   for (std::shared_ptr<QueryExecutionTree>& childTree : children_) {
     if (limitIfPresent.has_value() && childTree->supportsLimit()) {
       childTree->applyLimit(limitIfPresent.value());
+      forbiddenToRecompute_ = true;
     }
     auto& child = *childTree->getRootOperation();
     // To preserve order of the columns we can only consume the first child
@@ -405,6 +410,7 @@ Result::LazyResult CartesianProductJoin::createLazyConsumer(
 
 // _____________________________________________________________________________
 std::unique_ptr<Operation> CartesianProductJoin::cloneImpl() const {
+  AD_CONTRACT_CHECK(!forbiddenToRecompute_, recomputeMessage);
   Children copy;
   copy.reserve(children_.size());
   for (const auto& operation : children_) {

--- a/src/engine/CartesianProductJoin.h
+++ b/src/engine/CartesianProductJoin.h
@@ -18,6 +18,11 @@ class CartesianProductJoin : public Operation {
  private:
   Children children_;
   size_t chunkSize_;
+  // If `true` calls to `computeResult` and `cloneImpl` will result in an
+  // exception. This is because this flag indicates that a limit has been
+  // dynamically applied to the children of this operation and we currently have
+  // to mechanism to reverse this.
+  bool forbiddenToRecompute_ = false;
 
   // Access to the actual operations of the children.
   // TODO<joka921> We can move this whole children management into a base class

--- a/test/OperationTest.cpp
+++ b/test/OperationTest.cpp
@@ -770,22 +770,3 @@ TEST(OperationTest, disableCaching) {
   valuesForTesting.getResult(false);
   EXPECT_FALSE(qec->getQueryTreeCache().cacheContains(cacheKey));
 }
-
-// _____________________________________________________________________________
-TEST(OperationTest, resetChildLimitsAndOffsetOnDestruction) {
-  auto qec = getQec();
-
-  auto parent = ShallowParentOperation::of<NeutralElementOperation>(qec);
-
-  auto child = parent.getChildren().at(0)->getRootOperation();
-  child->applyLimitOffset({10, 1});
-
-  {
-    auto cleanup = parent.resetChildLimitsAndOffsetOnDestruction();
-    EXPECT_EQ(child->getLimitOffset(), LimitOffsetClause(10, 1));
-
-    child->applyLimitOffset({9, 1});
-    EXPECT_EQ(child->getLimitOffset(), LimitOffsetClause(9, 2));
-  }
-  EXPECT_EQ(child->getLimitOffset(), LimitOffsetClause(10, 1));
-}

--- a/test/util/OperationTestHelpers.h
+++ b/test/util/OperationTestHelpers.h
@@ -187,6 +187,7 @@ inline auto IsDeepCopy(const Operation& other) {
       Address(SameTypeId(&other)),
       AD_PROPERTY(Operation, getChildren, Pointwise(Ne(), other.getChildren())),
       AD_PROPERTY(Operation, getCacheKey, Eq(other.getCacheKey())),
+      AD_PROPERTY(Operation, getLimitOffset, Eq(other.getLimitOffset())),
       AD_PROPERTY(Operation, getExternallyVisibleVariableColumns,
                   Eq(other.getExternallyVisibleVariableColumns())));
 }


### PR DESCRIPTION
In the current code, the `CartesianProductJoin` operation dynamically sets the limit and offset for its children and then resets them to their original values. However, this mechanism is flawed because the resetting happens too early for lazily evaluated children, which then falsely operate with the reset values. This is now tentatively fixed in two ways. First, the limit and offset of the children is no longer reset. Second, an error is thrown when the children are evaluated again (which is meant as a safeguard and cannot happen when processing real SPARQL queries). In particular, this fixes #2146 

NOTE: A proper fix requires a refactoring of the handling of limits and offsets. This is work for a separate PR.