### PR TITLE
Correct Union behaviour with dependent patterns

### DIFF
--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -2986,11 +2986,20 @@ void QueryPlanner::GraphPatternPlanner::visitUnion(parsedQuery::Union& arg) {
   auto allVariables = std::exchange(boundVariables_, originalVariables);
 
   handleChild(arg._child2);
-  const auto& rightPlans = candidatePlans_;
+  auto& rightPlans = candidatePlans_;
   // Merge variables
   allVariables.insert(boundVariables_.begin(), boundVariables_.end());
   // Set back to original to prevent conflicts with `visitGroupOptionalOrMinus`.
   boundVariables_ = std::move(originalVariables);
+
+  if (leftPlans.at(0).empty()) {
+    leftPlans.at(0).push_back(
+        makeSubtreePlan<NeutralElementOperation>(planner_._qec));
+  }
+  if (rightPlans.at(0).empty()) {
+    rightPlans.at(0).push_back(
+        makeSubtreePlan<NeutralElementOperation>(planner_._qec));
+  }
 
   std::vector<SubtreePlan> newCandidates;
 

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -3818,8 +3818,9 @@ TEST(QueryPlanner, ensurePlanningIsSkippedWhenNoTransitivePathIsPresent) {
   auto qp = makeQueryPlanner();
   {
     auto query = SparqlParser::parseQuery(
-        "SELECT * WHERE { ?x <P31> ?o ."
-        "{ VALUES ?x { 1 } } UNION { VALUES ?x { 1 } }}");
+        "SELECT * { "
+        "{ VALUES ?x { 1 } } UNION { VALUES ?x { 1 } } "
+        "?x <P31> ?o }");
     auto plans = qp.createExecutionTrees(query);
     ASSERT_EQ(plans.size(), 1);
     EXPECT_TRUE(
@@ -3827,10 +3828,11 @@ TEST(QueryPlanner, ensurePlanningIsSkippedWhenNoTransitivePathIsPresent) {
   }
   {
     auto query = SparqlParser::parseQuery(
-        "SELECT * WHERE { ?x <P31> ?o . "
+        "SELECT * WHERE { "
         "{ { VALUES ?x { 1 } } UNION { VALUES ?x { 1 } } } "
         "UNION "
-        "{ { VALUES ?x { 1 } } UNION { VALUES ?x { 1 } } } }");
+        "{ { VALUES ?x { 1 } } UNION { VALUES ?x { 1 } } } "
+        "?x <P31> ?o }");
     auto plans = qp.createExecutionTrees(query);
     ASSERT_EQ(plans.size(), 1);
     EXPECT_TRUE(


### PR DESCRIPTION
This changes query planning such that queries of the form

```sparql
SELECT * {
  # something
  {
    # A
  } UNION {
    # B
  }
}
```

are always transformed into the form

```sparql
SELECT * {
  {
    # something
    # A
  } UNION {
    # something
    # B
  }
}
```

which is the correct behaviour when one of the branches in `UNION` contains a position-dependent operation like `BIND`, but might be a pessimization otherwise. Related to #2139. Fixes #2096.

Also of the form:
```sparql
PREFIX wdt: <http://www.wikidata.org/prop/direct/>
SELECT * WHERE {
  ?a a ?b
  {
    BIND(?a AS ?c)
  } UNION {
    ?a a ?c
  }
}
```

produce false positive warnings during parsing.