### PR TITLE
Pad negative years in dates to 4 digits

### DIFF
--- a/src/util/Date.cpp
+++ b/src/util/Date.cpp
@@ -33,33 +33,34 @@ std::pair<std::string, const char*> Date::toStringAndType() const {
   const char* type = nullptr;
 
   if (getMonth() == 0) {
-    constexpr static std::string_view formatString = "%04d";
-    dateString = absl::StrFormat(formatString, getYear());
+    dateString = getFormattedYear();
     type = XSD_GYEAR_TYPE;
   } else if (getDay() == 0) {
-    constexpr static std::string_view formatString = "%04d-%02d";
-    dateString = absl::StrFormat(formatString, getYear(), getMonth());
+    dateString = absl::StrFormat("%s-%02d", getFormattedYear(), getMonth());
     type = XSD_GYEARMONTH_TYPE;
   } else if (!hasTime()) {
-    constexpr static std::string_view formatString = "%04d-%02d-%02d";
-    dateString = absl::StrFormat(formatString, getYear(), getMonth(), getDay());
+    dateString = absl::StrFormat("%s-%02d-%02d", getFormattedYear(), getMonth(),
+                                 getDay());
     type = XSD_DATE_TYPE;
   } else {
     type = XSD_DATETIME_TYPE;
     double seconds = getSecond();
     double dIntPart;
     if (std::modf(seconds, &dIntPart) == 0.0) {
-      constexpr std::string_view formatString = "%04d-%02d-%02dT%02d:%02d:%02d";
-      dateString =
-          absl::StrFormat(formatString, getYear(), getMonth(), getDay(),
-                          getHour(), getMinute(), static_cast<int>(seconds));
+      dateString = absl::StrFormat(
+          "%s-%02d-%02dT%02d:%02d:%02d", getFormattedYear(), getMonth(),
+          getDay(), getHour(), getMinute(), static_cast<int>(seconds));
     } else {
-      constexpr std::string_view formatString =
-          "%04d-%02d-%02dT%02d:%02d:%06.3f";
-      dateString =
-          absl::StrFormat(formatString, getYear(), getMonth(), getDay(),
-                          getHour(), getMinute(), getSecond());
+      dateString = absl::StrFormat("%s-%02d-%02dT%02d:%02d:%06.3f",
+                                   getFormattedYear(), getMonth(), getDay(),
+                                   getHour(), getMinute(), getSecond());
     }
   }
   return {absl::StrCat(dateString, formatTimeZone()), type};
+}
+
+// _____________________________________________________________________________
+std::string Date::getFormattedYear() const {
+  return getYear() >= 0 ? absl::StrFormat("%04d", getYear())
+                        : absl::StrFormat("%05d", getYear());
 }

--- a/src/util/Date.h
+++ b/src/util/Date.h
@@ -323,6 +323,9 @@ class Date {
   // `xsd:dateTime` pointing to the January 1st, 00:00 hours. (This is the
   // format used by Wikidata).
   std::pair<std::string, const char*> toStringAndType() const;
+
+  // Acquire the year, but padded up to 4 digits with a leading `-` if negative.
+  std::string getFormattedYear() const;
 };
 
 #endif  // QLEVER_DATE_H

--- a/test/DateYearDurationTest.cpp
+++ b/test/DateYearDurationTest.cpp
@@ -357,6 +357,8 @@ TEST(Date, parseDateTime) {
                Date::NoTimeZone{});
   testDatetime("-2034-12-24T02:12:42Z", -2034, 12, 24, 2, 12, 42.0,
                Date::TimeZoneZ{});
+  testDatetime("-0100-12-31T02:12:42Z", -100, 12, 31, 2, 12, 42.0,
+               Date::TimeZoneZ{});
 }
 
 TEST(Date, parseDate) {
@@ -365,6 +367,7 @@ TEST(Date, parseDate) {
   testDate("2034-12-24Z", 2034, 12, 24, Date::TimeZoneZ{});
   testDate("2034-12-24", 2034, 12, 24, Date::NoTimeZone{});
   testDate("-2034-12-24", -2034, 12, 24, Date::NoTimeZone{});
+  testDate("-0100-12-31", -100, 12, 31, Date::NoTimeZone{});
 }
 
 TEST(Date, parseYearMonth) {
@@ -373,6 +376,7 @@ TEST(Date, parseYearMonth) {
   testYearMonth("2034-12Z", 2034, 12, Date::TimeZoneZ{});
   testYearMonth("2034-12", 2034, 12, Date::NoTimeZone{});
   testYearMonth("-2034-12", -2034, 12, Date::NoTimeZone{});
+  testYearMonth("-0100-12", -100, 12, Date::NoTimeZone{});
 }
 
 TEST(Date, parseYear) {
@@ -381,6 +385,7 @@ TEST(Date, parseYear) {
   testYear("2034Z", 2034, Date::TimeZoneZ{});
   testYear("2034", 2034, Date::NoTimeZone{});
   testYear("-2034", -2034, Date::NoTimeZone{});
+  testYear("-0100", -100, Date::NoTimeZone{});
 }
 
 TEST(Date, timeZoneWithMinutes) {


### PR DESCRIPTION
Fixes #2106
Currently date literals that are being exported by QLever are only padded to three digits when exported, because the printf syntax treats the leading `-` as a digit for some reason. This PR changes this, so that you'll always have 4 real digits regardless if the year is positive or negative.