### PR TITLE
Add runtime parameter `enable-prefilter-on-index-scans`

### DIFF
--- a/src/ServerMain.cpp
+++ b/src/ServerMain.cpp
@@ -143,6 +143,10 @@ int main(int argc, char** argv) {
       "erroneous silently into empty results (e.g. LOAD or SERVICE requests to "
       "nonexisting endpoints). This mode should only be used for running the "
       "syntax tests from the W3C SPARQL 1.1 test suite.");
+  add("disable-prefilter-for-filter-clauses",
+      optionFactory.getProgramOption<"disable-prefilter-for-filter-clauses">(),
+      "If set to true, the prefilter procedures for FILTER expressions are "
+      "disabled.");
   po::variables_map optionsMap;
 
   try {

--- a/src/ServerMain.cpp
+++ b/src/ServerMain.cpp
@@ -143,9 +143,9 @@ int main(int argc, char** argv) {
       "erroneous silently into empty results (e.g. LOAD or SERVICE requests to "
       "nonexisting endpoints). This mode should only be used for running the "
       "syntax tests from the W3C SPARQL 1.1 test suite.");
-  add("disable-prefilter-for-filter-clauses",
-      optionFactory.getProgramOption<"disable-prefilter-for-filter-clauses">(),
-      "If set to true, the prefilter procedures for FILTER expressions are "
+  add("enable-prefilter-on-index-scans",
+      optionFactory.getProgramOption<"enable-prefilter-on-index-scans">(),
+      "If set to false, the prefilter procedures for FILTER expressions are "
       "disabled.");
   po::variables_map optionsMap;
 

--- a/src/engine/Filter.cpp
+++ b/src/engine/Filter.cpp
@@ -33,7 +33,7 @@ Filter::Filter(QueryExecutionContext* qec,
   _subtree = ExistsJoin::addExistsJoinsToSubtree(
       _expression, std::move(_subtree), getExecutionContext(),
       cancellationHandle_);
-  if (RuntimeParameters().get<"enable-prefilter-for-filter-clauses">()) {
+  if (!RuntimeParameters().get<"disable-prefilter-for-filter-clauses">()) {
     setPrefilterExpressionForChildren();
   }
 }

--- a/src/engine/Filter.cpp
+++ b/src/engine/Filter.cpp
@@ -15,6 +15,7 @@
 #include "engine/sparqlExpressions/SparqlExpression.h"
 #include "engine/sparqlExpressions/SparqlExpressionGenerators.h"
 #include "engine/sparqlExpressions/SparqlExpressionValueGetters.h"
+#include "global/RuntimeParameters.h"
 
 using std::endl;
 using std::string;
@@ -32,7 +33,9 @@ Filter::Filter(QueryExecutionContext* qec,
   _subtree = ExistsJoin::addExistsJoinsToSubtree(
       _expression, std::move(_subtree), getExecutionContext(),
       cancellationHandle_);
-  setPrefilterExpressionForChildren();
+  if (RuntimeParameters().get<"enable-prefilter-for-filter-clauses">()) {
+    setPrefilterExpressionForChildren();
+  }
 }
 
 // _____________________________________________________________________________

--- a/src/engine/Filter.cpp
+++ b/src/engine/Filter.cpp
@@ -33,7 +33,7 @@ Filter::Filter(QueryExecutionContext* qec,
   _subtree = ExistsJoin::addExistsJoinsToSubtree(
       _expression, std::move(_subtree), getExecutionContext(),
       cancellationHandle_);
-  if (!RuntimeParameters().get<"disable-prefilter-for-filter-clauses">()) {
+  if (RuntimeParameters().get<"enable-prefilter-on-index-scans">()) {
     setPrefilterExpressionForChildren();
   }
 }

--- a/src/global/RuntimeParameters.h
+++ b/src/global/RuntimeParameters.h
@@ -83,6 +83,16 @@ inline auto& RuntimeParameters() {
         // false,
         // the result will be `NaN` or `infinity` respectively.
         Bool<"division-by-zero-is-undef">{true},
+        // If set to `true`, the contained `FILTER` expressions in the query try
+        // to set and apply a corresponding `PrefilterExpression` (see
+        // `PrefilterExpressionIndex.h`) on its variable related `IndexScan`
+        // operation.
+        //
+        // If set to `false`, the queries `FILTER` expressions omit setting and
+        // applying `PrefilterExpression`s. This is useful to set a
+        // prefilter-free baseline, or for debugging, as wrong results may be
+        // related to the `PrefilterExpression`s.
+        Bool<"enable-prefilter-for-filter-clauses">{true},
     };
   }();
   return params;

--- a/src/global/RuntimeParameters.h
+++ b/src/global/RuntimeParameters.h
@@ -83,16 +83,16 @@ inline auto& RuntimeParameters() {
         // false,
         // the result will be `NaN` or `infinity` respectively.
         Bool<"division-by-zero-is-undef">{true},
-        // If set to `true`, the contained `FILTER` expressions in the query try
-        // to set and apply a corresponding `PrefilterExpression` (see
-        // `PrefilterExpressionIndex.h`) on its variable related `IndexScan`
+        // If set to `false`, the contained `FILTER` expressions in the query
+        // try to set and apply a corresponding `PrefilterExpression` (see
+        // `PrefilterExpressionIndex.h`) on its variable-related `IndexScan`
         // operation.
         //
-        // If set to `false`, the queries `FILTER` expressions omit setting and
+        // If set to `true`, the queries `FILTER` expressions omit setting and
         // applying `PrefilterExpression`s. This is useful to set a
         // prefilter-free baseline, or for debugging, as wrong results may be
         // related to the `PrefilterExpression`s.
-        Bool<"enable-prefilter-for-filter-clauses">{true},
+        Bool<"disable-prefilter-for-filter-clauses">{false},
     };
   }();
   return params;

--- a/src/global/RuntimeParameters.h
+++ b/src/global/RuntimeParameters.h
@@ -83,16 +83,16 @@ inline auto& RuntimeParameters() {
         // false,
         // the result will be `NaN` or `infinity` respectively.
         Bool<"division-by-zero-is-undef">{true},
-        // If set to `false`, the contained `FILTER` expressions in the query
+        // If set to `true`, the contained `FILTER` expressions in the query
         // try to set and apply a corresponding `PrefilterExpression` (see
         // `PrefilterExpressionIndex.h`) on its variable-related `IndexScan`
         // operation.
         //
-        // If set to `true`, the queries `FILTER` expressions omit setting and
+        // If set to `false`, the queries `FILTER` expressions omit setting and
         // applying `PrefilterExpression`s. This is useful to set a
         // prefilter-free baseline, or for debugging, as wrong results may be
         // related to the `PrefilterExpression`s.
-        Bool<"disable-prefilter-for-filter-clauses">{false},
+        Bool<"enable-prefilter-on-index-scans">{true},
     };
   }();
   return params;

--- a/test/FilterTest.cpp
+++ b/test/FilterTest.cpp
@@ -11,10 +11,10 @@
 #include "engine/sparqlExpressions/LiteralExpression.h"
 #include "engine/sparqlExpressions/NaryExpression.h"
 #include "engine/sparqlExpressions/SparqlExpression.h"
-#include "global/RuntimeParameters.h"
 #include "util/IdTableHelpers.h"
 #include "util/IndexTestHelpers.h"
 #include "util/OperationTestHelpers.h"
+#include "util/RuntimeParametersTestHelpers.h"
 
 using ::testing::ElementsAre;
 using ::testing::Eq;
@@ -49,8 +49,9 @@ void checkSetPrefilterExpressionVariablePair(
     std::unique_ptr<prefilterExpressions::PrefilterExpression> prefilterExpr,
     ColumnIndex columnIdx, bool prefilterIsApplicable,
     bool enablePrefilterForFilter = true) {
-  RuntimeParameters().set<"enable-prefilter-on-index-scans">(
-      enablePrefilterForFilter);
+  const auto& rtp =
+      setRuntimeParameterForTest<"enable-prefilter-on-index-scans">(
+          enablePrefilterForFilter);
   Filter filter{
       qec,
       ad_utility::makeExecutionTree<IndexScan>(qec, permutation, triple),

--- a/test/FilterTest.cpp
+++ b/test/FilterTest.cpp
@@ -49,7 +49,7 @@ void checkSetPrefilterExpressionVariablePair(
     std::unique_ptr<prefilterExpressions::PrefilterExpression> prefilterExpr,
     ColumnIndex columnIdx, bool prefilterIsApplicable,
     bool enablePrefilterForFilter = true) {
-  RuntimeParameters().set<"disable-prefilter-for-filter-clauses">(
+  RuntimeParameters().set<"enable-prefilter-on-index-scans">(
       enablePrefilterForFilter);
   Filter filter{
       qec,
@@ -59,7 +59,7 @@ void checkSetPrefilterExpressionVariablePair(
   os << "Added PrefiterExpression: \n";
   os << *prefilterExpr;
   os << "\nApplied on column: " << columnIdx << ".";
-  if (prefilterIsApplicable && !enablePrefilterForFilter) {
+  if (prefilterIsApplicable && enablePrefilterForFilter) {
     EXPECT_THAT(filter.getCacheKey(), ::testing::HasSubstr(os.str()));
   } else {
     EXPECT_THAT(filter.getCacheKey(),

--- a/test/FilterTest.cpp
+++ b/test/FilterTest.cpp
@@ -48,9 +48,9 @@ void checkSetPrefilterExpressionVariablePair(
     std::unique_ptr<sparqlExpression::SparqlExpression> sparqlExpr,
     std::unique_ptr<prefilterExpressions::PrefilterExpression> prefilterExpr,
     ColumnIndex columnIdx, bool prefilterIsApplicable,
-    bool enablePrefilterForFilter = true) {
-  RuntimeParameters().set<"enable-prefilter-for-filter-clauses">(
-      enablePrefilterForFilter);
+    bool disablePrefilterForFilter = false) {
+  RuntimeParameters().set<"disable-prefilter-for-filter-clauses">(
+      disablePrefilterForFilter);
   Filter filter{
       qec,
       ad_utility::makeExecutionTree<IndexScan>(qec, permutation, triple),
@@ -59,7 +59,7 @@ void checkSetPrefilterExpressionVariablePair(
   os << "Added PrefiterExpression: \n";
   os << *prefilterExpr;
   os << "\nApplied on column: " << columnIdx << ".";
-  if (prefilterIsApplicable && enablePrefilterForFilter) {
+  if (prefilterIsApplicable && !disablePrefilterForFilter) {
     EXPECT_THAT(filter.getCacheKey(), ::testing::HasSubstr(os.str()));
   } else {
     EXPECT_THAT(filter.getCacheKey(),
@@ -184,12 +184,12 @@ TEST(Filter, verifySetPrefilterExpressionVariablePairForIndexScanChild) {
   checkSetPrefilterExpressionVariablePair(
       qec, Permutation::POS, {Variable{"?x"}, iri("<p>"), Variable{"?z"}},
       ltSprql(Variable{"?z"}, IntId(10)), lt(IntId(10)), 1, true);
-  // If the runtime parameter `enable-prefilter-for-filter-clauses` is set to
-  // false, we expect that no prefilter is set although it would be possible
+  // If the runtime parameter `disable-prefilter-for-filter-clauses` is set to
+  // true, we expect that no prefilter is set although it would be possible
   // (last argument is set to false).
   checkSetPrefilterExpressionVariablePair(
       qec, Permutation::POS, {Variable{"?x"}, iri("<p>"), Variable{"?z"}},
-      ltSprql(Variable{"?z"}, IntId(10)), lt(IntId(10)), 1, true, false);
+      ltSprql(Variable{"?z"}, IntId(10)), lt(IntId(10)), 1, true, true);
   checkSetPrefilterExpressionVariablePair(
       qec, Permutation::POS, {Variable{"?x"}, iri("<p>"), Variable{"?z"}},
       andSprqlExpr(neqSprql(Variable{"?z"}, IntId(10)),
@@ -200,15 +200,15 @@ TEST(Filter, verifySetPrefilterExpressionVariablePairForIndexScanChild) {
       {makeSparqlExpression::Iri::fromIriref("<a>"), iri("<p>"),
        Variable{"?z"}},
       eqSprql(Variable{"?z"}, DoubleId(22.5)), eq(DoubleId(22.5)), 2, true);
-  // If the runtime parameter `enable-prefilter-for-filter-clauses` is set to
-  // false, we expect that no prefilter is set although it would be possible
+  // If the runtime parameter `disable-prefilter-for-filter-clauses` is set to
+  // true, we expect that no prefilter is set although it would be possible
   // (last argument is set to false).
   checkSetPrefilterExpressionVariablePair(
       qec, Permutation::PSO,
       {makeSparqlExpression::Iri::fromIriref("<a>"), iri("<p>"),
        Variable{"?z"}},
       eqSprql(Variable{"?z"}, DoubleId(22.5)), eq(DoubleId(22.5)), 2, true,
-      false);
+      true);
 
   // We expect that no <PrefilterExpression, Variable> pair is assigned
   // (no prefilter procedure applicable) with Filter construction.

--- a/test/FilterTest.cpp
+++ b/test/FilterTest.cpp
@@ -11,6 +11,7 @@
 #include "engine/sparqlExpressions/LiteralExpression.h"
 #include "engine/sparqlExpressions/NaryExpression.h"
 #include "engine/sparqlExpressions/SparqlExpression.h"
+#include "global/RuntimeParameters.h"
 #include "util/IdTableHelpers.h"
 #include "util/IndexTestHelpers.h"
 #include "util/OperationTestHelpers.h"
@@ -46,7 +47,10 @@ void checkSetPrefilterExpressionVariablePair(
     SparqlTripleSimple triple,
     std::unique_ptr<sparqlExpression::SparqlExpression> sparqlExpr,
     std::unique_ptr<prefilterExpressions::PrefilterExpression> prefilterExpr,
-    ColumnIndex columnIdx, bool prefilterIsApplicable) {
+    ColumnIndex columnIdx, bool prefilterIsApplicable,
+    bool enablePrefilterForFilter = true) {
+  RuntimeParameters().set<"enable-prefilter-for-filter-clauses">(
+      enablePrefilterForFilter);
   Filter filter{
       qec,
       ad_utility::makeExecutionTree<IndexScan>(qec, permutation, triple),
@@ -55,7 +59,7 @@ void checkSetPrefilterExpressionVariablePair(
   os << "Added PrefiterExpression: \n";
   os << *prefilterExpr;
   os << "\nApplied on column: " << columnIdx << ".";
-  if (prefilterIsApplicable) {
+  if (prefilterIsApplicable && enablePrefilterForFilter) {
     EXPECT_THAT(filter.getCacheKey(), ::testing::HasSubstr(os.str()));
   } else {
     EXPECT_THAT(filter.getCacheKey(),
@@ -180,6 +184,12 @@ TEST(Filter, verifySetPrefilterExpressionVariablePairForIndexScanChild) {
   checkSetPrefilterExpressionVariablePair(
       qec, Permutation::POS, {Variable{"?x"}, iri("<p>"), Variable{"?z"}},
       ltSprql(Variable{"?z"}, IntId(10)), lt(IntId(10)), 1, true);
+  // If the runtime parameter `enable-prefilter-for-filter-clauses` is set to
+  // false, we expect that no prefilter is set although it would be possible
+  // (last argument is set to false).
+  checkSetPrefilterExpressionVariablePair(
+      qec, Permutation::POS, {Variable{"?x"}, iri("<p>"), Variable{"?z"}},
+      ltSprql(Variable{"?z"}, IntId(10)), lt(IntId(10)), 1, true, false);
   checkSetPrefilterExpressionVariablePair(
       qec, Permutation::POS, {Variable{"?x"}, iri("<p>"), Variable{"?z"}},
       andSprqlExpr(neqSprql(Variable{"?z"}, IntId(10)),
@@ -190,6 +200,15 @@ TEST(Filter, verifySetPrefilterExpressionVariablePairForIndexScanChild) {
       {makeSparqlExpression::Iri::fromIriref("<a>"), iri("<p>"),
        Variable{"?z"}},
       eqSprql(Variable{"?z"}, DoubleId(22.5)), eq(DoubleId(22.5)), 2, true);
+  // If the runtime parameter `enable-prefilter-for-filter-clauses` is set to
+  // false, we expect that no prefilter is set although it would be possible
+  // (last argument is set to false).
+  checkSetPrefilterExpressionVariablePair(
+      qec, Permutation::PSO,
+      {makeSparqlExpression::Iri::fromIriref("<a>"), iri("<p>"),
+       Variable{"?z"}},
+      eqSprql(Variable{"?z"}, DoubleId(22.5)), eq(DoubleId(22.5)), 2, true,
+      false);
 
   // We expect that no <PrefilterExpression, Variable> pair is assigned
   // (no prefilter procedure applicable) with Filter construction.


### PR DESCRIPTION
This runtime parameter controls whether block prefiltering is done for index scans combined with binary-search like `FILTER` operations. This is enabled by default because it can dramatically speed up the respective index scans. Disabling it can be useful for benchmarking and debugging. For example, the following query is extremely fast with prefiltering enabled (because only the few relevant blocks are read) but requires a full index scan with prefiltering disabled https://qlever.cs.uni-freiburg.de/wikidata/0I1WXj
```sparql
SELECT * WHERE {
  ?s ?p ?o .
  FILTER ISBLANK(?o)
}
```
NOTE: https://github.com/ad-freiburg/qlever-control/pull/172 adds the corresponding option to the `qlever` CLI.