### PR TITLE
Reduce the disk space usage of the GitHub Actions workflows

### DIFF
--- a/.github/workflows/install-compiler-ubuntu/action.yml
+++ b/.github/workflows/install-compiler-ubuntu/action.yml
@@ -48,5 +48,9 @@ runs:
         wget http://mirrors.kernel.org/ubuntu/pool/universe/g/gcc-8/g++-8_8.4.0-3ubuntu2_amd64.deb
         sudo apt install ./libstdc++-8-dev_8.4.0-3ubuntu2_amd64.deb ./g++-8_8.4.0-3ubuntu2_amd64.deb
       shell: bash
+    - name: Install mold linker
+      run: |
+        sudo apt update
+        sudo apt install -y mold
 
 # TODO<joka921> Add assertion for unsupported compilers and versions.

--- a/.github/workflows/install-compiler-ubuntu/action.yml
+++ b/.github/workflows/install-compiler-ubuntu/action.yml
@@ -49,6 +49,7 @@ runs:
         sudo apt install ./libstdc++-8-dev_8.4.0-3ubuntu2_amd64.deb ./g++-8_8.4.0-3ubuntu2_amd64.deb
       shell: bash
     - name: Install mold linker
+      shell: bash
       run: |
         sudo apt update
         sudo apt install -y mold

--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -130,7 +130,7 @@ jobs:
       - name: Configure CMake
         # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
         # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build-type}} -DCMAKE_TOOLCHAIN_FILE="$(pwd)/toolchains/${{matrix.compiler}}${{matrix.compiler-version}}.cmake" -DADDITIONAL_COMPILER_FLAGS="${{matrix.warnings}} ${{matrix.asan-flags}} ${{matrix.ubsan-flags}}" -DUSE_PARALLEL=true -DRUN_EXPENSIVE_TESTS=${{matrix.expensive-tests}} -DENABLE_EXPENSIVE_CHECKS=true ${{matrix.additional-cmake-options}}
+        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build-type}} -DCMAKE_TOOLCHAIN_FILE="$(pwd)/toolchains/${{matrix.compiler}}${{matrix.compiler-version}}.cmake" -DADDITIONAL_COMPILER_FLAGS="${{matrix.warnings}} ${{matrix.asan-flags}} ${{matrix.ubsan-flags}}" -DUSE_PARALLEL=true -DRUN_EXPENSIVE_TESTS=${{matrix.expensive-tests}} -DENABLE_EXPENSIVE_CHECKS=true ${{matrix.additional-cmake-options}} -DADDITIONAL_LINKER_FLAGS="-B /usr/bin/mold" -DSINGLE_TEST_BINARY=ON
 
       - name: Build
         # Build your program with the given configuration

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.27)
-if(POLICY CMP0167)
+if (POLICY CMP0167)
     cmake_policy(SET CMP0167 NEW)
-endif()
+endif ()
 project(QLever C CXX)
 
 # C/C++ Versions
@@ -46,7 +46,7 @@ elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
         # libstdc++13 ranges in some cases.
         MESSAGE(STATUS "range-v3 is used for clang-16 because of its incompatibility with libstdc++13")
         set(RANGE_V3_REQUIRED_BY_COMPILER ON)
-    endif()
+    endif ()
 else ()
     MESSAGE(FATAL_ERROR "QLever currently only supports the G++ or LLVM-Clang++ compilers. Found ${CMAKE_CXX_COMPILER_ID}")
 endif ()
@@ -114,7 +114,7 @@ FetchContent_Declare(
 FetchContent_Declare(
         range-v3
         GIT_REPOSITORY https://github.com/joka921/range-v3
-        GIT_TAG  b661537be421fee77df40bdffa8f221ead53bb8e  # branch fork-for-qlever
+        GIT_TAG b661537be421fee77df40bdffa8f221ead53bb8e  # branch fork-for-qlever
 )
 
 #################################
@@ -220,10 +220,10 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${ADDITIONAL_COMPILER_FLAGS}")
 # of `std::ranges` and the `std::enable_if_t` based expansion of the concept
 # macros from `range-v3`.
 set(USE_CPP_17_BACKPORTS OFF CACHE BOOL "Use the C++17 backports (range-v3 and enable_if_t instead of std::ranges and concepts)")
-if (${USE_CPP_17_BACKPORTS} OR ${RANGE_V3_REQUIRED_BY_COMPILER} )
+if (${USE_CPP_17_BACKPORTS} OR ${RANGE_V3_REQUIRED_BY_COMPILER})
     MESSAGE(STATUS "Using the C++17 backports (e.g. range-v3)")
     add_compile_definitions(QLEVER_CPP_17 CPP_CXX_CONCEPTS=0)
-endif()
+endif ()
 
 set(VOCAB_UNCOMPRESSED_IN_MEMORY OFF CACHE BOOL "Store QLever's vocabulary uncompressed and completely in RAM")
 if (${VOCAB_UNCOMPRESSED_IN_MEMORY})
@@ -435,7 +435,7 @@ add_subdirectory(src/global)
 add_subdirectory(benchmark)
 
 enable_testing()
-option(SINGLE_TEST_BINARY "Link all unit tests into a single binary. This is useful e.g. for code coverage tools and greatly reduces the total disk space required when building" OFF)
+option(SINGLE_TEST_BINARY "Link all unit tests into a single binary. This is useful e.g. for code coverage tools and greatly reduces the total disk space required when building all unit tests with debug symbols" OFF)
 add_subdirectory(test)
 
 # Add the library with the constants declared in `CompilationInfo.h` and defined

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -435,7 +435,7 @@ add_subdirectory(src/global)
 add_subdirectory(benchmark)
 
 enable_testing()
-option(SINGLE_TEST_BINARY "Link all unit tests into a single binary. This is useful e.g. for code coverage tools" OFF)
+option(SINGLE_TEST_BINARY "Link all unit tests into a single binary. This is useful e.g. for code coverage tools and greatly reduces the total disk space required when building" OFF)
 add_subdirectory(test)
 
 # Add the library with the constants declared in `CompilationInfo.h` and defined

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -41,9 +41,10 @@ if (SINGLE_TEST_BINARY)
     message(STATUS "All tests are linked into a single executable `QLeverAllUnitTestsMain`")
     add_executable(QLeverAllUnitTestsMain)
     qlever_target_link_libraries(QLeverAllUnitTestsMain gtest gmock_main testUtil ${CMAKE_THREAD_LIBS_INIT})
+    # The following line (as opposed to using `gtest_discover_tests`) has the effect that `ctest` will treat all the
+    # unit tests as a single test case and will simply run the executable (using the main function from `gtest_main`.
+    # This decreases the runtime overhead per unit tests in particular for sanitizer builds.
     add_test(NAME QLeverAllUnitTests COMMAND $<TARGET_FILE:QLeverAllUnitTestsMain>)
-    #gtest_discover_tests(QLeverAllUnitTestsMain QLeverAllUnitTestsMain DISCOVERY_TIMEOUT 600 PROPERTIES RUN_SERIAL
-    #        TRUE)
 else ()
     message(STATUS "The tests are split over multiple binaries")
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -41,8 +41,9 @@ if (SINGLE_TEST_BINARY)
     message(STATUS "All tests are linked into a single executable `QLeverAllUnitTestsMain`")
     add_executable(QLeverAllUnitTestsMain)
     qlever_target_link_libraries(QLeverAllUnitTestsMain gtest gmock_main testUtil ${CMAKE_THREAD_LIBS_INIT})
-    gtest_discover_tests(QLeverAllUnitTestsMain QLeverAllUnitTestsMain DISCOVERY_TIMEOUT 600 PROPERTIES RUN_SERIAL
-            TRUE)
+    add_test(NAME QLeverAllUnitTests COMMAND $<TARGET_FILE:QLeverAllUnitTestsMain>)
+    #gtest_discover_tests(QLeverAllUnitTestsMain QLeverAllUnitTestsMain DISCOVERY_TIMEOUT 600 PROPERTIES RUN_SERIAL
+    #        TRUE)
 else ()
     message(STATUS "The tests are split over multiple binaries")
 

--- a/test/PrefilterExpressionTestHelpers.h
+++ b/test/PrefilterExpressionTestHelpers.h
@@ -23,20 +23,19 @@ constexpr auto DateParser = &DateYearOrDuration::parseXsdDate;
 namespace makeFilterExpression {
 using namespace prefilterExpressions;
 
-namespace {
-//______________________________________________________________________________
 // Make RelationalExpression
 template <typename RelExpr>
-auto relExpr = [](const IdOrLocalVocabEntry& referenceId)
+inline auto relExpr = [](const IdOrLocalVocabEntry& referenceId)
     -> std::unique_ptr<PrefilterExpression> {
   return std::make_unique<RelExpr>(referenceId);
 };
 
 // Make IsInExpression
-auto isInExpression = [](std::vector<IdOrLocalVocabEntry>&& referenceValues,
-                         bool isNegated = false) {
-  return std::make_unique<IsInExpression>(referenceValues, isNegated);
-};
+inline auto isInExpression =
+    [](std::vector<IdOrLocalVocabEntry>&& referenceValues,
+       bool isNegated = false) {
+      return std::make_unique<IsInExpression>(referenceValues, isNegated);
+    };
 
 // Make IsDatatypeExpression
 template <typename IsDtypeExpr>
@@ -54,66 +53,65 @@ auto logExpr = [](std::unique_ptr<PrefilterExpression> child1,
 };
 
 // Make NotExpression
-auto notPrefilterExpression = [](std::unique_ptr<PrefilterExpression> child)
+inline auto notPrefilterExpression =
+    [](std::unique_ptr<PrefilterExpression> child)
     -> std::unique_ptr<PrefilterExpression> {
   return std::make_unique<NotExpression>(std::move(child));
 };
 
 // Make PrefixRegexExpression
-auto makePrefixRegexExpression = [](const TripleComponent::Literal& prefix,
-                                    bool isNegated = false) {
-  return std::make_unique<PrefixRegexExpression>(prefix, isNegated);
-};
-
-}  // namespace
+inline auto makePrefixRegexExpression =
+    [](const TripleComponent::Literal& prefix, bool isNegated = false) {
+      return std::make_unique<PrefixRegexExpression>(prefix, isNegated);
+    };
 
 // Make PrefilterExpression
 //______________________________________________________________________________
 // instantiation relational
 // LESS THAN (`<`)
-constexpr auto lt = relExpr<LessThanExpression>;
+constexpr inline auto lt = relExpr<LessThanExpression>;
 // LESS EQUAL (`<=`)
-constexpr auto le = relExpr<LessEqualExpression>;
+constexpr inline auto le = relExpr<LessEqualExpression>;
 // GREATER EQUAL (`>=`)
-constexpr auto ge = relExpr<GreaterEqualExpression>;
+constexpr inline auto ge = relExpr<GreaterEqualExpression>;
 // GREATER THAN (`>`)
-constexpr auto gt = relExpr<GreaterThanExpression>;
+constexpr inline auto gt = relExpr<GreaterThanExpression>;
 // EQUAL (`==`)
-constexpr auto eq = relExpr<EqualExpression>;
+constexpr inline auto eq = relExpr<EqualExpression>;
 // NOT EQUAL (`!=`)
-constexpr auto neq = relExpr<NotEqualExpression>;
+constexpr inline auto neq = relExpr<NotEqualExpression>;
 // IS IRI
-constexpr auto isIri = isDtypeExpr<IsIriExpression>;
+constexpr inline auto isIri = isDtypeExpr<IsIriExpression>;
 // IS LITERAL
-constexpr auto isLit = isDtypeExpr<IsLiteralExpression>;
+constexpr inline auto isLit = isDtypeExpr<IsLiteralExpression>;
 // IS NUMERIC
-constexpr auto isNum = isDtypeExpr<IsNumericExpression>;
+constexpr inline auto isNum = isDtypeExpr<IsNumericExpression>;
 // IS BLANK
-constexpr auto isBlank = isDtypeExpr<IsBlankExpression>;
+constexpr inline auto isBlank = isDtypeExpr<IsBlankExpression>;
 // AND (`&&`)
-constexpr auto andExpr = logExpr<AndExpression>;
+constexpr inline auto andExpr = logExpr<AndExpression>;
 // OR (`||`)
-constexpr auto orExpr = logExpr<OrExpression>;
+constexpr inline auto orExpr = logExpr<OrExpression>;
 // NOT (`!`)
-constexpr auto notExpr = notPrefilterExpression;
+constexpr inline auto notExpr = notPrefilterExpression;
 // `IN`, or `NOT IN` if the `isNegated` flag is set to true.
-constexpr auto inExpr = isInExpression;
+constexpr inline auto inExpr = isInExpression;
 // PREFIX REGEX
-constexpr auto prefixRegex = makePrefixRegexExpression;
+constexpr inline auto prefixRegex = makePrefixRegexExpression;
 
 namespace filterHelper {
 //______________________________________________________________________________
 // Create `LocalVocabEntry` / `LiteralOrIri`.
 // Note: `Iri` string value must start and end with `<`/`>` and the `Literal`
 // value with `'`/`'`.
-const auto LVE = [](const std::string& litOrIri) -> LocalVocabEntry {
+constexpr inline auto LVE = [](const std::string& litOrIri) -> LocalVocabEntry {
   return LocalVocabEntry::fromStringRepresentation(litOrIri);
 };
 
 //______________________________________________________________________________
 // Construct a `PAIR` with the given `PrefilterExpression` and `Variable`
 // value.
-auto pr =
+constexpr inline auto pr =
     [](std::unique_ptr<prefilterExpressions::PrefilterExpression> expr,
        const Variable& var) -> sparqlExpression::PrefilterExprVariablePair {
   return {std::move(expr), var};
@@ -156,7 +154,7 @@ using VariantArgs = std::variant<Variable, ValueId, Iri, Literal, SparqlPtr>;
 // If value `child` is not already a `SparqlExpression` pointer, try to create
 // the respective leaf `SparqlExpression` (`LiteralExpression`) for the given
 // value.
-const auto makeOptLiteralSparqlExpr =
+constexpr inline auto makeOptLiteralSparqlExpr =
     [](auto child) -> std::unique_ptr<SparqlExpression> {
   using T = std::decay_t<decltype(child)>;
   if constexpr (std::is_same_v<T, ValueId>) {
@@ -178,7 +176,8 @@ const auto makeOptLiteralSparqlExpr =
 };
 
 //______________________________________________________________________________
-auto getExpr = [](auto variantVal) -> std::unique_ptr<SparqlExpression> {
+constexpr inline auto getExpr =
+    [](auto variantVal) -> std::unique_ptr<SparqlExpression> {
   return makeOptLiteralSparqlExpr(std::move(variantVal));
 };
 
@@ -252,53 +251,53 @@ CPP_template(typename... Args)(
 
 //______________________________________________________________________________
 // LESS THAN (`<`, `SparqlExpression`)
-constexpr auto ltSprql =
+constexpr inline auto ltSprql =
     &makeRelationalSparqlExprImpl<sparqlExpression::LessThanExpression>;
 // LESS EQUAL (`<=`, `SparqlExpression`)
-constexpr auto leSprql =
+constexpr inline auto leSprql =
     &makeRelationalSparqlExprImpl<sparqlExpression::LessEqualExpression>;
 // EQUAL (`==`, `SparqlExpression`)
-constexpr auto eqSprql =
+constexpr inline auto eqSprql =
     &makeRelationalSparqlExprImpl<sparqlExpression::EqualExpression>;
 // NOT EQUAL (`!=`, `SparqlExpression`)
-constexpr auto neqSprql =
+constexpr inline auto neqSprql =
     &makeRelationalSparqlExprImpl<sparqlExpression::NotEqualExpression>;
 // GREATER EQUAL (`>=`, `SparqlExpression`)
-constexpr auto geSprql =
+constexpr inline auto geSprql =
     &makeRelationalSparqlExprImpl<sparqlExpression::GreaterEqualExpression>;
 // GREATER THAN (`>`, `SparqlExpression`)
-constexpr auto gtSprql =
+constexpr inline auto gtSprql =
     &makeRelationalSparqlExprImpl<sparqlExpression::GreaterThanExpression>;
 // AND (`&&`, `SparqlExpression`)
-constexpr auto andSprqlExpr = &makeAndExpression;
+constexpr inline auto andSprqlExpr = &makeAndExpression;
 // OR (`||`, `SparqlExpression`)
-constexpr auto orSprqlExpr = &makeOrExpression;
+constexpr inline auto orSprqlExpr = &makeOrExpression;
 // NOT (`!`, `SparqlExpression`)
-constexpr auto notSprqlExpr = &makeUnaryNegateExpression;
+constexpr inline auto notSprqlExpr = &makeUnaryNegateExpression;
 
 //______________________________________________________________________________
 // Create SparqlExpression `STRSTARTS`.
-constexpr auto strStartsSprql = &makeStringStartsWithSparqlExpression;
+constexpr inline auto strStartsSprql = &makeStringStartsWithSparqlExpression;
 // Create SparqlExpression `REGEX`.
-constexpr auto regexSparql = &makePrefixRegexExpression;
+constexpr inline auto regexSparql = &makePrefixRegexExpression;
 // Create SparqlExpression `STR`
-constexpr auto strSprql = &makeStrSparqlExpression;
+constexpr inline auto strSprql = &makeStrSparqlExpression;
 
 //______________________________________________________________________________
 // Create SparqlExpression `isIri`
-constexpr auto isIriSprql =
+constexpr inline auto isIriSprql =
     &makeIsDatatypeStartsWithExpression<prefilterExpressions::IsDatatype::IRI>;
 // Create SparqlExpression `isLiteral`
-constexpr auto isLiteralSprql = &makeIsDatatypeStartsWithExpression<
+constexpr inline auto isLiteralSprql = &makeIsDatatypeStartsWithExpression<
     prefilterExpressions::IsDatatype::LITERAL>;
 // Create SparqlExpression `isNumeric`
-constexpr auto isNumericSprql = &makeIsDatatypeStartsWithExpression<
+constexpr inline auto isNumericSprql = &makeIsDatatypeStartsWithExpression<
     prefilterExpressions::IsDatatype::NUMERIC>;
 // Create SparqlExpression `isBlank`
-constexpr auto isBlankSprql = &makeIsDatatypeStartsWithExpression<
+constexpr inline auto isBlankSprql = &makeIsDatatypeStartsWithExpression<
     prefilterExpressions::IsDatatype::BLANK>;
 // Create SparqlExpression `YEAR`.
-constexpr auto yearSprqlExpr = &makeYearSparqlExpression;
+constexpr inline auto yearSprqlExpr = &makeYearSparqlExpression;
 
 }  // namespace makeSparqlExpression
 

--- a/test/TransitivePathTest.cpp
+++ b/test/TransitivePathTest.cpp
@@ -38,7 +38,7 @@ class TransitivePathTest
            std::optional<std::string> turtleInput = std::nullopt) {
     bool useBinSearch = std::get<0>(GetParam());
     auto qec = getQec(std::move(turtleInput));
-    // TODO<joka921> properly address this issue.
+    // Clear the cache to avoid crosstalk between tests.
     qec->clearCacheUnpinnedOnly();
     auto subtree = ad_utility::makeExecutionTree<ValuesForTesting>(
         qec, std::move(input), vars);
@@ -889,10 +889,14 @@ TEST_P(TransitivePathTest, literalsNotInIndexButInDeltaTriples) {
 
   // Simulate entries in the delta triples by using entries that are not in the
   // index
+  // Note: the entries in this local vocab are destroyed when this test is done.
+  // It is therefore crucial that the `makePath...` functions clear the cache,
+  // s.t. subsequent tests do not read results with a dangling local vocab from
+  // the cache (Currently the indexes used for testing are `static` which should
+  // be changed in the future).
   LocalVocab localVocab;
   auto id = Id::makeFromLocalVocabIndex(localVocab.getIndexAndAddIfNotContained(
       LocalVocabEntry{Literal::literalWithoutQuotes(literal)}));
-  std::cerr << "id: " << id.getLocalVocabIndex() << std::endl;
   auto sub = makeIdTableFromVector({
       {id, id},
   });

--- a/test/TransitivePathTest.cpp
+++ b/test/TransitivePathTest.cpp
@@ -38,6 +38,8 @@ class TransitivePathTest
            std::optional<std::string> turtleInput = std::nullopt) {
     bool useBinSearch = std::get<0>(GetParam());
     auto qec = getQec(std::move(turtleInput));
+    // TODO<joka921> properly address this issue.
+    qec->clearCacheUnpinnedOnly();
     auto subtree = ad_utility::makeExecutionTree<ValuesForTesting>(
         qec, std::move(input), vars);
     return {TransitivePathBase::makeTransitivePath(
@@ -97,9 +99,10 @@ class TransitivePathTest
   static bool requestLaziness() { return std::get<1>(GetParam()); }
 
   // ___________________________________________________________________________
-  void assertResultMatchesIdTable(const Result& result, const IdTable& expected,
-                                  ad_utility::source_location loc =
-                                      ad_utility::source_location::current()) {
+  static void assertResultMatchesIdTable(
+      const Result& result, const IdTable& expected,
+      ad_utility::source_location loc =
+          ad_utility::source_location::current()) {
     auto t = generateLocationTrace(loc);
     using ::testing::UnorderedElementsAreArray;
     ASSERT_NE(result.isFullyMaterialized(), requestLaziness());
@@ -889,6 +892,7 @@ TEST_P(TransitivePathTest, literalsNotInIndexButInDeltaTriples) {
   LocalVocab localVocab;
   auto id = Id::makeFromLocalVocabIndex(localVocab.getIndexAndAddIfNotContained(
       LocalVocabEntry{Literal::literalWithoutQuotes(literal)}));
+  std::cerr << "id: " << id.getLocalVocabIndex() << std::endl;
   auto sub = makeIdTableFromVector({
       {id, id},
   });

--- a/test/engine/SpatialJoinTestHelpers.h
+++ b/test/engine/SpatialJoinTestHelpers.h
@@ -15,11 +15,12 @@
 
 namespace SpatialJoinTestHelpers {
 
-auto makePointLiteral = [](std::string_view c1, std::string_view c2) {
+constexpr inline auto makePointLiteral = [](std::string_view c1,
+                                            std::string_view c2) {
   return absl::StrCat(" \"POINT(", c1, " ", c2, ")\"^^<", GEO_WKT_LITERAL, ">");
 };
 
-auto makeAreaLiteral = [](std::string_view coordinateList) {
+constexpr inline auto makeAreaLiteral = [](std::string_view coordinateList) {
   return absl::StrCat("\"POLYGON((", coordinateList, "))\"^^<", GEO_WKT_LITERAL,
                       ">");
 };


### PR DESCRIPTION
Our ASAN builds have been failing for quite some time now because the workflows were running out of disk space. We tentatively fix this by doing the following **for all native builds** (which includes the address-sanitizer and thread-sanitizer builds):

1. Link all unit tests into a single executable; this greatly reduces the required disk space, especially when debug symbols are enabled (this also includes the `RelWithDebugInfo` mode)
2. Use the `mold` linker, which saves RAM and hopefully also some time
3. Don't use `ctest` per test case, which has a significant time overhead per test case, especially with the sanitizer runs; instead, run the `gtest` executable directly by registering the complete file as a single test case in `test/CMakeLists.txt`

NOTE: There are several improvements possible for the future. In particular, using shared linking instead of static linking to enable one test case per `...Test.cpp` file again (and the corresponding more fine-grained output), but without the previous slow-down.