### PR TITLE
Refactor `TransitivePathBase` and `TransitivePathImpl`

### DIFF
--- a/src/engine/TransitivePathBase.cpp
+++ b/src/engine/TransitivePathBase.cpp
@@ -163,12 +163,12 @@ TransitivePathBase::decideDirection() {
 // _____________________________________________________________________________
 Result::Generator TransitivePathBase::fillTableWithHull(
     NodeGenerator hull, size_t startSideCol, size_t targetSideCol,
-    size_t skipCol, bool yieldOnce, size_t inputWidth) const {
+    bool yieldOnce, size_t inputWidth) const {
   return ad_utility::callFixedSizeVi(
       std::array{inputWidth, getResultWidth()},
       [&](auto INPUT_WIDTH, auto OUTPUT_WIDTH) {
         return fillTableWithHullImpl<INPUT_WIDTH, OUTPUT_WIDTH>(
-            std::move(hull), startSideCol, targetSideCol, yieldOnce, skipCol);
+            std::move(hull), startSideCol, targetSideCol, yieldOnce);
       });
 }
 
@@ -179,7 +179,7 @@ Result::Generator TransitivePathBase::fillTableWithHull(NodeGenerator hull,
                                                         bool yieldOnce) const {
   return ad_utility::callFixedSizeVi(getResultWidth(), [&](auto WIDTH) {
     return fillTableWithHullImpl<0, WIDTH>(std::move(hull), startSideCol,
-                                           targetSideCol, yieldOnce, 0);
+                                           targetSideCol, yieldOnce);
   });
 }
 
@@ -187,7 +187,7 @@ Result::Generator TransitivePathBase::fillTableWithHull(NodeGenerator hull,
 template <size_t INPUT_WIDTH, size_t OUTPUT_WIDTH>
 Result::Generator TransitivePathBase::fillTableWithHullImpl(
     NodeGenerator hull, size_t startSideCol, size_t targetSideCol,
-    bool yieldOnce, size_t skipCol) const {
+    bool yieldOnce) const {
   ad_utility::Timer timer{ad_utility::Timer::Stopped};
   size_t outputRow = 0;
   IdTableStatic<OUTPUT_WIDTH> table{getResultWidth(), allocator()};
@@ -211,7 +211,7 @@ Result::Generator TransitivePathBase::fillTableWithHullImpl(
 
       if (inputView.has_value()) {
         copyColumns<INPUT_WIDTH, OUTPUT_WIDTH>(inputView.value(), table,
-                                               inputRow, outputRow, skipCol);
+                                               inputRow, outputRow);
       }
 
       outputRow++;
@@ -537,18 +537,11 @@ bool TransitivePathBase::isBoundOrId() const {
 template <size_t INPUT_WIDTH, size_t OUTPUT_WIDTH>
 void TransitivePathBase::copyColumns(const IdTableView<INPUT_WIDTH>& inputTable,
                                      IdTableStatic<OUTPUT_WIDTH>& outputTable,
-                                     size_t inputRow, size_t outputRow,
-                                     size_t skipCol) {
+                                     size_t inputRow, size_t outputRow) {
   size_t inCol = 0;
   size_t outCol = 2;
-  AD_CORRECTNESS_CHECK(skipCol < inputTable.numColumns());
-  AD_CORRECTNESS_CHECK(inputTable.numColumns() + 1 == outputTable.numColumns());
+  AD_CORRECTNESS_CHECK(inputTable.numColumns() + 2 == outputTable.numColumns());
   while (inCol < inputTable.numColumns() && outCol < outputTable.numColumns()) {
-    if (skipCol == inCol) {
-      inCol++;
-      continue;
-    }
-
     outputTable.at(outputRow, outCol) = inputTable.at(inputRow, inCol);
     inCol++;
     outCol++;

--- a/src/engine/TransitivePathBase.cpp
+++ b/src/engine/TransitivePathBase.cpp
@@ -179,7 +179,7 @@ Result::Generator TransitivePathBase::fillTableWithHull(NodeGenerator hull,
                                                         bool yieldOnce) const {
   return ad_utility::callFixedSizeVi(getResultWidth(), [&](auto WIDTH) {
     return fillTableWithHullImpl<0, WIDTH>(std::move(hull), startSideCol,
-                                           targetSideCol, yieldOnce);
+                                           targetSideCol, yieldOnce, 0);
   });
 }
 
@@ -201,7 +201,7 @@ Result::Generator TransitivePathBase::fillTableWithHullImpl(
       table.reserve(linkedNodes.size());
     }
     std::optional<IdTableView<INPUT_WIDTH>> inputView = std::nullopt;
-    if (idTable != nullptr) {
+    if (idTable.has_value()) {
       inputView = idTable->template asStaticView<INPUT_WIDTH>();
     }
     for (Id linkedNode : linkedNodes) {

--- a/src/engine/TransitivePathBase.cpp
+++ b/src/engine/TransitivePathBase.cpp
@@ -556,12 +556,6 @@ void TransitivePathBase::copyColumns(const IdTableView<INPUT_WIDTH>& inputTable,
 }
 
 // _____________________________________________________________________________
-void TransitivePathBase::insertIntoMap(Map& map, Id key, Id value) const {
-  auto [it, success] = map.try_emplace(key, allocator());
-  it->second.insert(value);
-}
-
-// _____________________________________________________________________________
 bool TransitivePathBase::columnOriginatesFromGraphOrUndef(
     const Variable& variable) const {
   AD_CONTRACT_CHECK(getExternallyVisibleVariableColumns().contains(variable));

--- a/src/engine/TransitivePathBase.h
+++ b/src/engine/TransitivePathBase.h
@@ -70,13 +70,10 @@ struct TransitivePathSide {
   }
 };
 
-// We deliberately use the `std::` variants of a hash set and hash map because
-// `absl`s types are not exception safe.
+// We deliberately use the `std::` variants of a hash set because `absl`s types
+// are not exception safe.
 using Set = std::unordered_set<Id, absl::Hash<Id>, std::equal_to<Id>,
                                ad_utility::AllocatorWithLimit<Id>>;
-using Map = std::unordered_map<
-    Id, Set, absl::Hash<Id>, std::equal_to<Id>,
-    ad_utility::AllocatorWithLimit<std::pair<const Id, Set>>>;
 
 // Helper struct, that allows a generator to yield a a node and all its
 // connected nodes (the `targets`), along with a local vocabulary and the row
@@ -228,11 +225,6 @@ class TransitivePathBase : public Operation {
   static void copyColumns(const IdTableView<INPUT_WIDTH>& inputTable,
                           IdTableStatic<OUTPUT_WIDTH>& outputTable,
                           size_t inputRow, size_t outputRow, size_t skipCol);
-
-  // A small helper function: Insert the `value` to the set at `map[key]`.
-  // As the sets all have an allocator with memory limit, this construction is a
-  // little bit more involved, so this can be a separate helper function.
-  void insertIntoMap(Map& map, Id key, Id value) const;
 
  public:
   std::string getDescriptor() const override;

--- a/src/engine/TransitivePathBase.h
+++ b/src/engine/TransitivePathBase.h
@@ -75,6 +75,9 @@ struct TransitivePathSide {
 using Set = std::unordered_set<Id, absl::Hash<Id>, std::equal_to<Id>,
                                ad_utility::AllocatorWithLimit<Id>>;
 
+// Alias for common type
+using PayloadTable = std::optional<IdTableView<0>>;
+
 // Helper struct, that allows a generator to yield a a node and all its
 // connected nodes (the `targets`), along with a local vocabulary and the row
 // index of the node in the input table. The `IdTable` pointer might be null if
@@ -84,13 +87,13 @@ struct NodeWithTargets {
   Id node_;
   Set targets_;
   LocalVocab localVocab_;
-  std::optional<IdTableView<0>> idTable_;
+  PayloadTable idTable_;
   size_t row_;
 
   // Explicit to prevent issues with co_yield and lifetime.
   // See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=103909 for more info.
   NodeWithTargets(Id node, Set targets, LocalVocab localVocab,
-                  std::optional<IdTableView<0>> idTable, size_t row)
+                  PayloadTable idTable, size_t row)
       : node_{node},
         targets_{std::move(targets)},
         localVocab_{std::move(localVocab)},

--- a/src/engine/TransitivePathBase.h
+++ b/src/engine/TransitivePathBase.h
@@ -84,17 +84,17 @@ struct NodeWithTargets {
   Id node_;
   Set targets_;
   LocalVocab localVocab_;
-  const IdTable* idTable_;
+  std::optional<IdTableView<0>> idTable_;
   size_t row_;
 
   // Explicit to prevent issues with co_yield and lifetime.
   // See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=103909 for more info.
   NodeWithTargets(Id node, Set targets, LocalVocab localVocab,
-                  const IdTable* idTable, size_t row)
+                  std::optional<IdTableView<0>> idTable, size_t row)
       : node_{node},
         targets_{std::move(targets)},
         localVocab_{std::move(localVocab)},
-        idTable_{idTable},
+        idTable_{std::move(idTable)},
         row_{row} {}
 };
 
@@ -244,7 +244,7 @@ class TransitivePathBase : public Operation {
   Result::Generator fillTableWithHullImpl(NodeGenerator hull,
                                           size_t startSideCol,
                                           size_t targetSideCol, bool yieldOnce,
-                                          size_t skipCol = 0) const;
+                                          size_t skipCol) const;
 
   // Return an execution tree, that "joins" the given `tripleComponent` with all
   // of the subjects or objects in the knowledge graph, so if the graph does not

--- a/src/engine/TransitivePathBase.h
+++ b/src/engine/TransitivePathBase.h
@@ -195,15 +195,13 @@ class TransitivePathBase : public Operation {
    * hull
    * @param targetSideCol The column of the result table for the targetSide of
    * the hull
-   * @param skipCol This column contains the Ids of the start side in the
-   * startSideTable and will be skipped.
    * @param yieldOnce If true, the generator will yield only a single time.
    * @param inputWidth The width of the input table that is referenced by the
    * elements of `hull`.
    */
   Result::Generator fillTableWithHull(NodeGenerator hull, size_t startSideCol,
-                                      size_t targetSideCol, size_t skipCol,
-                                      bool yieldOnce, size_t inputWidth) const;
+                                      size_t targetSideCol, bool yieldOnce,
+                                      size_t inputWidth) const;
 
   /**
    * @brief Fill the given table with the transitive hull.
@@ -224,7 +222,7 @@ class TransitivePathBase : public Operation {
   template <size_t INPUT_WIDTH, size_t OUTPUT_WIDTH>
   static void copyColumns(const IdTableView<INPUT_WIDTH>& inputTable,
                           IdTableStatic<OUTPUT_WIDTH>& outputTable,
-                          size_t inputRow, size_t outputRow, size_t skipCol);
+                          size_t inputRow, size_t outputRow);
 
  public:
   std::string getDescriptor() const override;
@@ -243,8 +241,8 @@ class TransitivePathBase : public Operation {
   template <size_t INPUT_WIDTH, size_t OUTPUT_WIDTH>
   Result::Generator fillTableWithHullImpl(NodeGenerator hull,
                                           size_t startSideCol,
-                                          size_t targetSideCol, bool yieldOnce,
-                                          size_t skipCol) const;
+                                          size_t targetSideCol,
+                                          bool yieldOnce) const;
 
   // Return an execution tree, that "joins" the given `tripleComponent` with all
   // of the subjects or objects in the knowledge graph, so if the graph does not

--- a/src/engine/TransitivePathHashMap.cpp
+++ b/src/engine/TransitivePathHashMap.cpp
@@ -25,13 +25,14 @@ HashMapWrapper TransitivePathHashMap::setupEdgesMap(
     const IdTable& dynSub, const TransitivePathSide& startSide,
     const TransitivePathSide& targetSide) const {
   const IdTableView<SUB_WIDTH> sub = dynSub.asStaticView<SUB_WIDTH>();
-  Map edges{allocator()};
+  HashMapWrapper::Map edges{allocator()};
   decltype(auto) startCol = sub.getColumn(startSide.subCol_);
   decltype(auto) targetCol = sub.getColumn(targetSide.subCol_);
 
   for (size_t i = 0; i < sub.size(); i++) {
     checkCancellation();
-    insertIntoMap(edges, startCol[i], targetCol[i]);
+    auto [it, success] = edges.try_emplace(startCol[i], allocator());
+    it->second.insert(targetCol[i]);
   }
   return HashMapWrapper{std::move(edges), allocator()};
 }

--- a/src/engine/TransitivePathHashMap.cpp
+++ b/src/engine/TransitivePathHashMap.cpp
@@ -31,7 +31,7 @@ HashMapWrapper TransitivePathHashMap::setupEdgesMap(
 
   for (size_t i = 0; i < sub.size(); i++) {
     checkCancellation();
-    auto [it, success] = edges.try_emplace(startCol[i], allocator());
+    auto [it, _] = edges.try_emplace(startCol[i], allocator());
     it->second.insert(targetCol[i]);
   }
   return HashMapWrapper{std::move(edges), allocator()};

--- a/src/engine/TransitivePathHashMap.h
+++ b/src/engine/TransitivePathHashMap.h
@@ -19,6 +19,12 @@
  *
  */
 struct HashMapWrapper {
+  // We deliberately use the `std::` variants of a hash map because `absl`s
+  // types are not exception safe.
+  using Map = std::unordered_map<
+      Id, Set, absl::Hash<Id>, std::equal_to<Id>,
+      ad_utility::AllocatorWithLimit<std::pair<const Id, Set>>>;
+
   Map map_;
   Set emptySet_;
 

--- a/src/engine/TransitivePathImpl.h
+++ b/src/engine/TransitivePathImpl.h
@@ -25,10 +25,10 @@ struct TableColumnWithVocab {
 
   // Explicit to prevent issues with co_yield and lifetime.
   // See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=103909 for more info.
-  TableColumnWithVocab(std::optional<IdTableView<0>> table, ColumnType column,
-                       LocalVocab vocab)
-      : payload_{std::move(table)},
-        startNodes_{std::move(column)},
+  TableColumnWithVocab(std::optional<IdTableView<0>> payload,
+                       ColumnType startNodes, LocalVocab vocab)
+      : payload_{std::move(payload)},
+        startNodes_{std::move(startNodes)},
         vocab_{std::move(vocab)} {}
 };
 };  // namespace detail


### PR DESCRIPTION
Improve and unify the interfaces, such that the code becomes easier to maintain and extend. In particular, prepares #2128 (property paths in graphs)