### PR TITLE
GroupBy HashMap: Switching to sorting if too many groups 1.0

### DIFF
--- a/benchmark/GroupByHashMapBenchmark.cpp
+++ b/benchmark/GroupByHashMapBenchmark.cpp
@@ -139,36 +139,36 @@ class GroupByHashMapBenchmark : public BenchmarkInterface {
     for (auto multiplicity : multiplicities) {
       for (auto valueIdType : numericValueIdTypes) {
         //-----------------------------------------------------------------------------------------------------
-        runTests<AvgExpression>(results, multiplicity, valueIdType, false,
-                                false);
+        // runTests<AvgExpression>(results, multiplicity, valueIdType, false,
+        //                         false);
 
         runTests<AvgExpression>(results, multiplicity, valueIdType, true,
                                 false);
 
         //-----------------------------------------------------------------------------------------------------
-        runTests<SumExpression>(results, multiplicity, valueIdType, false,
-                                false);
+        // runTests<SumExpression>(results, multiplicity, valueIdType, false,
+        //                         false);
 
         runTests<SumExpression>(results, multiplicity, valueIdType, true,
                                 false);
 
         //-----------------------------------------------------------------------------------------------------
-        runTests<CountExpression>(results, multiplicity, valueIdType, false,
-                                  false);
+        // runTests<CountExpression>(results, multiplicity, valueIdType, false,
+        //                           false);
 
         runTests<CountExpression>(results, multiplicity, valueIdType, true,
                                   false);
 
         //-----------------------------------------------------------------------------------------------------
-        runTests<MinExpression>(results, multiplicity, valueIdType, false,
-                                false);
+        // runTests<MinExpression>(results, multiplicity, valueIdType, false,
+        //                         false);
 
         runTests<MinExpression>(results, multiplicity, valueIdType, true,
                                 false);
 
         //-----------------------------------------------------------------------------------------------------
-        runTests<MaxExpression>(results, multiplicity, valueIdType, false,
-                                false);
+        // runTests<MaxExpression>(results, multiplicity, valueIdType, false,
+        //                         false);
 
         runTests<MaxExpression>(results, multiplicity, valueIdType, true,
                                 false);
@@ -180,29 +180,29 @@ class GroupByHashMapBenchmark : public BenchmarkInterface {
     for (auto multiplicity : multiplicities) {
       for (auto valueIdType : numericValueIdTypes) {
         //-----------------------------------------------------------------------------------------------------
-        runTests<AvgExpression, SumExpression>(results, multiplicity,
-                                               valueIdType, false, false);
+        // runTests<AvgExpression, SumExpression>(results, multiplicity,
+        //                                        valueIdType, false, false);
 
         runTests<AvgExpression, SumExpression>(results, multiplicity,
                                                valueIdType, true, false);
 
         //-----------------------------------------------------------------------------------------------------
-        runTests<AvgExpression, MaxExpression>(results, multiplicity,
-                                               valueIdType, false, false);
+        // runTests<AvgExpression, MaxExpression>(results, multiplicity,
+        //                                        valueIdType, false, false);
 
         runTests<AvgExpression, MaxExpression>(results, multiplicity,
                                                valueIdType, true, false);
 
         //-----------------------------------------------------------------------------------------------------
-        runTests<AvgExpression, MinExpression>(results, multiplicity,
-                                               valueIdType, false, false);
+        // runTests<AvgExpression, MinExpression>(results, multiplicity,
+        //                                        valueIdType, false, false);
 
         runTests<AvgExpression, MinExpression>(results, multiplicity,
                                                valueIdType, true, false);
 
         //-----------------------------------------------------------------------------------------------------
-        runTests<AvgExpression, CountExpression>(results, multiplicity,
-                                                 valueIdType, false, false);
+        // runTests<AvgExpression, CountExpression>(results, multiplicity,
+        //                                          valueIdType, false, false);
 
         runTests<AvgExpression, CountExpression>(results, multiplicity,
                                                  valueIdType, true, false);
@@ -212,8 +212,8 @@ class GroupByHashMapBenchmark : public BenchmarkInterface {
 
   void runStringBenchmarks(BenchmarkResults& results) {
     for (auto multiplicity : multiplicities) {
-      runTests<GroupConcatExpression>(results, multiplicity,
-                                      ValueIdType::Strings, false, false);
+      // runTests<GroupConcatExpression>(results, multiplicity,
+      //                                 ValueIdType::Strings, false, false);
       runTests<GroupConcatExpression>(results, multiplicity,
                                       ValueIdType::Strings, true, false);
     }

--- a/benchmark/infrastructure/BenchmarkMain.cpp
+++ b/benchmark/infrastructure/BenchmarkMain.cpp
@@ -20,6 +20,7 @@
 #include "../benchmark/infrastructure/BenchmarkToJson.h"
 #include "../benchmark/infrastructure/BenchmarkToString.h"
 #include "BenchmarkMetadata.h"
+#include "global/RuntimeParameters.h"
 #include "util/Algorithm.h"
 #include "util/ConfigManager/ConfigManager.h"
 #include "util/Exception.h"
@@ -118,27 +119,52 @@ int main(int argc, char** argv) {
   // For easier usage.
   namespace po = boost::program_options;
 
+  // sampling guard parameters
+  double samplePercent = RuntimeParameters().get<"group-by-sample-percent">();
+  size_t maxSampleRows = RuntimeParameters().get<"group-by-sample-max-rows">();
+  double sampleDistinctRatio = RuntimeParameters().get<"group-by-sample-distinct-ratio">();
+  size_t groupThreshold = RuntimeParameters().get<"group-by-sample-group-threshold">();
+  size_t hashMapGroupThreshold = RuntimeParameters().get<"group-by-hash-map-group-threshold">();
+
   // Declaring the supported options.
   po::options_description options("Options for the benchmark");
-  options.add_options()("help,h", "Print the help message.")(
-      "print,p", "Roughly prints all benchmarks.")(
-      "write,w", po::value<std::string>(&writeFileName),
+  options.add_options()
+      ("help,h", "Print the help message.")
+      ("print,p", "Roughly prints all benchmarks.")
+      ("write,w", po::value<std::string>(&writeFileName),
       "Writes the benchmarks as json to a json file, overriding the previous"
-      " content of the file.")(
-      "append,a",
+      " content of the file.")
+      ("append,a",
       "Causes the json option to append to the end of the json array in the "
       "json file, if there is one, instead of overriding the previous content "
       "of "
-      "the file.")(
-      "configuration-json,j",
+      "the file.")
+      ("configuration-json,j",
       po::value<std::string>(&jsonConfigurationFileName),
-      "Set the configuration of benchmarks as described in a json file.")(
-      "configuration-shorthand,s",
+      "Set the configuration of benchmarks as described in a json file.")
+      ("configuration-shorthand,s",
       po::value<std::string>(&shortHandConfigurationString),
       "Allows you to add options to configuration of the benchmarks using the"
-      " short hand described in `BenchmarkConfiguration.h:parseShortHand`.")(
-      "configuration-options,o",
-      "Prints all available benchmark configuration options.");
+      " short hand described in `BenchmarkConfiguration.h:parseShortHand`.")
+      ("configuration-options,o",
+      "Prints all available benchmark configuration options.")
+      // GROUP BY sampling options
+      ("group-by-sample-percent,e",
+      po::value<double>(&samplePercent)
+          ->default_value(RuntimeParameters().get<"group-by-sample-percent">()),
+      "Fraction of rows sampled for GROUP BY sampling guard.")
+      ("group-by-sample-max-rows,m",
+      po::value<size_t>(&maxSampleRows),
+      "Max sample rows for GROUP BY sampling guard.")
+      ("group-by-sample-distinct-ratio,r",
+      po::value<double>(&sampleDistinctRatio),
+      "Switch to sort if sampled distinct groups/sample size exceed this ratio.")
+      ("group-by-sample-group-threshold,t",
+      po::value<size_t>(&groupThreshold),
+      "Switch to sort if estimated number of distinct groups exceeds this number.")
+      ("group-by-hash-map-group-threshold,g",
+      po::value<size_t>(&hashMapGroupThreshold),
+      "Max number of groups for hash-map GROUP BY optimization.");
 
   // Prints how to use the file correctly and exits.
   auto printUsageAndExit = [&options]() {
@@ -157,6 +183,13 @@ int main(int argc, char** argv) {
   po::variables_map vm;
   po::store(po::parse_command_line(argc, argv, options), vm);
   po::notify(vm);
+
+  // Apply GROUP BY sampling params to runtime parameters
+  RuntimeParameters().set<"group-by-sample-percent">(samplePercent);
+  RuntimeParameters().set<"group-by-sample-max-rows">(maxSampleRows);
+  RuntimeParameters().set<"group-by-sample-distinct-ratio">(sampleDistinctRatio);
+  RuntimeParameters().set<"group-by-sample-group-threshold">(groupThreshold);
+  RuntimeParameters().set<"group-by-hash-map-group-threshold">(hashMapGroupThreshold);
 
   // If write was chosen, then the given file must be a json file.
   if (vm.count("write") && !writeFileName.ends_with(".json")) {

--- a/src/ServerMain.cpp
+++ b/src/ServerMain.cpp
@@ -147,6 +147,25 @@ int main(int argc, char** argv) {
       optionFactory.getProgramOption<"enable-prefilter-on-index-scans">(),
       "If set to false, the prefilter procedures for FILTER expressions are "
       "disabled.");
+  add("group-by-hash-map-enabled",
+      optionFactory.getProgramOption<"group-by-hash-map-enabled">(),
+      "If set, then the GROUP BY operation will use a hash map to store "
+      "intermediate results. This is faster for small groups, but uses more "
+      "memory. If not set, the GROUP BY operation will use a sort-based "
+      "algorithm.");
+  add("group-by-sample-max-rows",
+      optionFactory.getProgramOption<"group-by-sample-max-rows">(),
+      "Maximum number of rows to sample for the GROUP BY sampling guard. "
+      "If the number of distinct groups exceeds the ratio of "
+      "`group-by-sample-distinct-ratio`, then the GROUP BY will be executed "
+      "using a sort-based algorithm.");
+  add("group-by-sample-distinct-ratio",
+      optionFactory.getProgramOption<"group-by-sample-distinct-ratio">(),
+      "Switch to sort if the fraction (sampled distinct groups / sample size) "
+      "exceeds this ratio.");
+  add("group-by-hash-map-group-threshold",
+      optionFactory.getProgramOption<"group-by-hash-map-group-threshold">(),
+      "Maximum number of groups for hash-map GROUP BY optimization.");
   po::variables_map optionsMap;
 
   try {

--- a/src/engine/GroupByImpl.cpp
+++ b/src/engine/GroupByImpl.cpp
@@ -331,6 +331,29 @@ sparqlExpression::EvaluationContext GroupByImpl::createEvaluationContext(
 Result GroupByImpl::computeResult(bool requestLaziness) {
   LOG(DEBUG) << "GroupBy result computation..." << std::endl;
 
+  // no aliases = no aggregates → skip everything else
+  if (_aliases.empty()) {
+    // force the child to deliver a full, in‐memory table
+    auto childRes = _subtree->getResult(false);
+    // collect the group‐by‐column indices
+    vector<size_t> groupByCols;
+    groupByCols.reserve(_groupByVariables.size());
+    for (auto& var : _groupByVariables) {
+      groupByCols.push_back(
+        _subtree->getVariableColumns().at(var).columnIndex_
+      );
+    }
+    auto localVocab = childRes->getCopyOfLocalVocab();
+    // doGroupBy will simply collapse duplicates (no aggregates → empty list)
+    IdTable t = CALL_FIXED_SIZE(
+      (std::array{_subtree->getResultWidth(), getResultWidth()}),
+      &GroupByImpl::doGroupBy, this, childRes->idTable(),
+      groupByCols, /*aggregates=*/std::vector<Aggregate>{},
+      &localVocab
+    );
+    return {std::move(t), resultSortedOn(), std::move(localVocab)};
+  }
+
   if (auto idTable = computeOptimizedGroupByIfPossible()) {
     // Note: The optimized group bys currently all include index scans and thus
     // can never produce local vocab entries. If this should ever change, then
@@ -401,24 +424,17 @@ Result GroupByImpl::computeResult(bool requestLaziness) {
     groupByColumns.push_back(it->second.columnIndex_);
   }
 
-  // Why remove this?
-  std::vector<size_t> groupByCols;
-  groupByCols.reserve(_groupByVariables.size());
-  for (const auto& var : _groupByVariables) {
-    groupByCols.push_back(subtreeVarCols.at(var).columnIndex_);
-  }
-
   if (useHashMapOptimization) {
     // Helper lambda that calls `computeGroupByForHashMapOptimization` for the
     // given `subresults`.
     auto computeWithHashMap = [this, &metadataForUnsequentialData,
-                               &groupByCols](auto&& subresults) {
+                               &groupByColumns](auto&& subresults) {
       auto doCompute = [&](auto numCols) {
         return computeGroupByForHashMapOptimization<numCols>(
             metadataForUnsequentialData->aggregateAliases_, AD_FWD(subresults),
-            groupByCols);
+            groupByColumns);
       };
-      return ad_utility::callFixedSizeVi(groupByCols.size(), doCompute);
+      return ad_utility::callFixedSizeVi(groupByColumns.size(), doCompute);
     };
 
     // Now call `computeWithHashMap` and return the result. It expects a range
@@ -443,7 +459,7 @@ Result GroupByImpl::computeResult(bool requestLaziness) {
         (std::array{inWidth, outWidth}), &GroupByImpl::computeResultLazily,
         this, std::move(subresult), std::move(aggregates),
         std::move(metadataForUnsequentialData).value().aggregateAliases_,
-        std::move(groupByCols), !requestLaziness);
+        std::move(groupByColumns), !requestLaziness);
 
     return requestLaziness
                ? Result{std::move(generator), resultSortedOn()}
@@ -718,8 +734,8 @@ std::optional<IdTable> GroupByImpl::computeGroupByObjectWithCount() const {
       "GROUP BY variable, this is a bug in the query planner",
       permutedTriple[1]->toString(), groupByVariable.name());
 
-  // There must be exactly one alias, which is a non-distinct count of one of
-  // the two variables of the index scan.
+  // There must be exactly one alias, which is a non-distinct count of one of the
+  // two variables of the index scan.
   auto countedVariable = getVariableForNonDistinctCountOfSingleAlias();
   bool countedVariableIsOneOfIndexScanVariables =
       countedVariable == *(permutedTriple[1]) ||
@@ -956,10 +972,6 @@ std::optional<IdTable> GroupByImpl::computeOptimizedGroupByIfPossible() const {
   if (_groupByVariables.empty()) {
     return std::nullopt;
   }
-  // Early out: no aliases means no aggregates, so we can skip the optimization
-  if (_aliases.empty()) {
-    return std::nullopt;
-  }
 
   // Fall back to existing optimized paths
   if (!RuntimeParameters().get<"group-by-disable-index-scan-optimizations">()) {
@@ -1030,10 +1042,6 @@ GroupByImpl::computeUnsequentialProcessingMetadata(
 std::optional<GroupByImpl::HashMapOptimizationData>
 GroupByImpl::checkIfHashMapOptimizationPossible(
     std::vector<Aggregate>& aliases) const {
-  if (aliases.empty()) {
-    return std::nullopt;
-  }
-
   if (!RuntimeParameters().get<"group-by-hash-map-enabled">()) {
     return std::nullopt;
   }
@@ -1915,8 +1923,9 @@ bool GroupByImpl::shouldSkipHashMapGrouping(const IdTable& table) const {
   std::mt19937_64 gen{std::random_device{}()};
   for (size_t i = sampleSize; i < totalSize; ++i) {
     std::uniform_int_distribution<size_t> dist(0, i);
-    if (dist(gen) < sampleSize) {
-      indices[dist(gen)] = i;
+    size_t randIdx = dist(gen);
+    if (randIdx < sampleSize) {
+      indices[randIdx] = i;
     }
   }
   // Use absl::flat_hash_set to estimate distinct groups

--- a/src/engine/GroupByImpl.cpp
+++ b/src/engine/GroupByImpl.cpp
@@ -13,6 +13,7 @@
 #include <sstream>     // for std::ostringstream
 #include <unordered_set>
 #include <absl/container/flat_hash_set.h>
+#include <absl/strings/str_join.h>
 #include <type_traits>
 
 #include "engine/CallFixedSize.h"
@@ -184,7 +185,7 @@ float GroupByImpl::getMultiplicity([[maybe_unused]] size_t col) {
   return 1;
 }
 
-uint64_t GroupByImpl::getSizeEstimateBeforeLimit() {
+uint64_t GroupByImpl::getSizeEstimateBeforeLimit() const {
   if (_groupByVariables.empty()) {
     return 1;
   }
@@ -193,10 +194,14 @@ uint64_t GroupByImpl::getSizeEstimateBeforeLimit() {
   auto varToMultiplicity = [this](const Variable& var) -> float {
     return _subtree->getMultiplicity(_subtree->getVariableColumn(var));
   };
-
   float minMultiplicity = ql::ranges::min(
       _groupByVariables | ql::views::transform(varToMultiplicity));
   return _subtree->getSizeEstimate() / minMultiplicity;
+}
+
+uint64_t GroupByImpl::getSizeEstimateBeforeLimit() {
+  // Delegate to the const overload
+  return static_cast<const GroupByImpl&>(*this).getSizeEstimateBeforeLimit();
 }
 
 size_t GroupByImpl::getCostEstimate() {
@@ -251,6 +256,11 @@ IdTable GroupByImpl::doGroupBy(const IdTable& inTable,
                                LocalVocab* outLocalVocab) const {
   LOG(DEBUG) << "Group by input size " << inTable.size() << std::endl;
   IdTable dynResult{getResultWidth(), getExecutionContext()->getAllocator()};
+  // Reserve estimated number of result groups to reduce reallocations
+  if (!groupByCols.empty()) {
+    auto estimatedGroups = getSizeEstimateBeforeLimit();
+    dynResult.reserve(estimatedGroups);
+  }
 
   // If the input is empty, the result is also empty, except for an implicit
   // GROUP BY (`groupByCols.empty()`), which always has to produce one result
@@ -378,7 +388,7 @@ Result GroupByImpl::computeResult(bool requestLaziness) {
                         "Subresult must be sorted on GROUP BY columns after fallback");
   }
 
-  std::vector<size_t> groupByCols;
+  std::vector<size_t> groupByColumns;
 
   // parse the group by columns
   const auto& subtreeVarCols = _subtree->getVariableColumns();
@@ -388,7 +398,14 @@ Result GroupByImpl::computeResult(bool requestLaziness) {
       AD_THROW("Groupby variable " + var.name() + " is not groupable");
     }
 
-    groupByCols.push_back(it->second.columnIndex_);
+    groupByColumns.push_back(it->second.columnIndex_);
+  }
+
+  // Why remove this?
+  std::vector<size_t> groupByCols;
+  groupByCols.reserve(_groupByVariables.size());
+  for (const auto& var : _groupByVariables) {
+    groupByCols.push_back(subtreeVarCols.at(var).columnIndex_);
   }
 
   if (useHashMapOptimization) {
@@ -443,12 +460,9 @@ Result GroupByImpl::computeResult(bool requestLaziness) {
 
   IdTable idTable = CALL_FIXED_SIZE(
       (std::array{inWidth, outWidth}), &GroupByImpl::doGroupBy, this,
-      subresult->idTable(), groupByCols, aggregates, &localVocab);
+      subresult->idTable(), groupByColumns, aggregates, &localVocab);
 
   LOG(DEBUG) << "GroupBy result computation done." << std::endl;
-  // Assert that the final result preserves the expected sort order
-  AD_CORRECTNESS_CHECK(isSortedOn(idTable, resultSortedOn()),
-                      "Final GROUP BY result is not sorted on expected columns");
   return {std::move(idTable), resultSortedOn(), std::move(localVocab)};
 }
 
@@ -532,6 +546,11 @@ Result::Generator GroupByImpl::computeResultLazily(
                           groupByCols.size()};
 
   IdTable resultTable{getResultWidth(), getExecutionContext()->getAllocator()};
+  // Reserve estimated number of result groups to reduce reallocations
+  if (!groupByCols.empty()) {
+    auto estimatedGroups = getSizeEstimateBeforeLimit();
+    resultTable.reserve(estimatedGroups);
+  }
 
   bool groupSplitAcrossTables = false;
 
@@ -663,7 +682,7 @@ std::optional<IdTable> GroupByImpl::computeGroupByForSingleIndexScan() const {
       table(0, 0) = Id::makeFromInt(
           getIndex().getImpl().numDistinctCol0(permutation.value()).normal);
     } else {
-      table(0, 0) = Id::makeFromInt(indexScan->getExactSize());
+      table(0, 0) = Id::makeFromInt(getIndex().numTriples().normal);
     }
   } else {
     table(0, 0) = Id::makeFromInt(indexScan->getExactSize());
@@ -699,8 +718,8 @@ std::optional<IdTable> GroupByImpl::computeGroupByObjectWithCount() const {
       "GROUP BY variable, this is a bug in the query planner",
       permutedTriple[1]->toString(), groupByVariable.name());
 
-  // There must be exactly one alias, which is a non-distinct count of one of the
-  // two variables of the index scan.
+  // There must be exactly one alias, which is a non-distinct count of one of
+  // the two variables of the index scan.
   auto countedVariable = getVariableForNonDistinctCountOfSingleAlias();
   bool countedVariableIsOneOfIndexScanVariables =
       countedVariable == *(permutedTriple[1]) ||

--- a/src/engine/GroupByImpl.cpp
+++ b/src/engine/GroupByImpl.cpp
@@ -254,7 +254,7 @@ IdTable GroupByImpl::doGroupBy(const IdTable& inTable,
                                const vector<size_t>& groupByCols,
                                const vector<Aggregate>& aggregates,
                                LocalVocab* outLocalVocab) const {
-  LOG(DEBUG) << "Group by input size " << inTable.size() << std::endl;
+  LOG(DEBUG) << "GroupBy input size " << inTable.size() << std::endl;
   IdTable dynResult{getResultWidth(), getExecutionContext()->getAllocator()};
   // Reserve estimated number of result groups to reduce reallocations
   if (!groupByCols.empty()) {
@@ -355,10 +355,19 @@ Result GroupByImpl::computeResult(bool requestLaziness) {
   LOG(DEBUG) << "GroupBy HashMap optimization: "
             << (useHashMapOptimization ? "enabled" : "disabled") << std::endl;
 
-  std::shared_ptr<const Result> subresult;
-  if (useHashMapOptimization) {
-    const auto* child = _subtree->getRootOperation()->getChildren().at(0);
-    // Skip sorting
+  const auto* child = _subtree->getRootOperation()->getChildren().at(0);
+  std::shared_ptr<const Result> subresult = child->getResult(true);
+
+  // Use the correct sampling-based hash-map grouping guard depending on materialization
+  auto shouldSkipHashMapGroupingDynamic = [this](const std::shared_ptr<const Result>& subresult) {
+    if (subresult->isFullyMaterialized()) {
+      return shouldSkipHashMapGrouping(subresult->idTable());
+    } else {
+      return shouldSkipHashMapGroupingLazy(subresult);
+    }
+  };
+  // Sampling-based guard: decide whether to skip hash-map grouping based on estimated number of groups
+  if (useHashMapOptimization && !shouldSkipHashMapGroupingDynamic(subresult)) {
     subresult = child->getResult(true);
     // Update runtime information
     auto runTimeInfoChildren =
@@ -366,26 +375,17 @@ Result GroupByImpl::computeResult(bool requestLaziness) {
     _subtree->getRootOperation()->updateRuntimeInformationWhenOptimizedOut(
         {runTimeInfoChildren}, RuntimeInformation::Status::optimizedOut);
   } else {
+    if (useHashMapOptimization) {
+      // Fall back to sort-based grouping
+      LOG(DEBUG) << "GroupBy: skipping hash-map grouping, using sort-based fallback due to high estimated group count"
+                 << std::endl;
+      useHashMapOptimization = false;
+    }
     // Always request child operation to provide a lazy result if the aggregate
     // expressions allow to compute the full result in chunks
     metadataForUnsequentialData =
         computeUnsequentialProcessingMetadata(aggregates, _groupByVariables);
     subresult = _subtree->getResult(metadataForUnsequentialData.has_value());
-  }
-
-  LOG(DEBUG) << "GroupBy subresult computation done" << std::endl;
-  // Sampling-based guard: decide whether to skip hash-map grouping based on estimated number of groups
-  if (useHashMapOptimization && subresult->isFullyMaterialized()) {
-    // If sampling indicates too many distinct groups, fall back to sort-based aggregation
-    if (shouldSkipHashMapGrouping(subresult->idTable())) {
-      LOG(DEBUG) << "GroupBy: skipping hash-map grouping, using sort-based fallback due to high estimated group count" << std::endl;
-      useHashMapOptimization = false;
-      // Recompute fully materialized, sorted subresult for fallback
-      subresult = _subtree->getResult(false);
-    }
-    // Ensure subresult is sorted on the GROUP BY columns for correct fallback grouping
-    AD_CORRECTNESS_CHECK(isSortedOn(subresult->idTable(), resultSortedOn()),
-                        "Subresult must be sorted on GROUP BY columns after fallback");
   }
 
   std::vector<size_t> groupByColumns;
@@ -395,7 +395,7 @@ Result GroupByImpl::computeResult(bool requestLaziness) {
   for (const auto& var : _groupByVariables) {
     auto it = subtreeVarCols.find(var);
     if (it == subtreeVarCols.end()) {
-      AD_THROW("Groupby variable " + var.name() + " is not groupable");
+      AD_THROW("GroupBy variable " + var.name() + " is not groupable");
     }
 
     groupByColumns.push_back(it->second.columnIndex_);
@@ -956,6 +956,10 @@ std::optional<IdTable> GroupByImpl::computeOptimizedGroupByIfPossible() const {
   if (_groupByVariables.empty()) {
     return std::nullopt;
   }
+  // Early out: no aliases means no aggregates, so we can skip the optimization
+  if (_aliases.empty()) {
+    return std::nullopt;
+  }
 
   // Fall back to existing optimized paths
   if (!RuntimeParameters().get<"group-by-disable-index-scan-optimizations">()) {
@@ -1026,6 +1030,10 @@ GroupByImpl::computeUnsequentialProcessingMetadata(
 std::optional<GroupByImpl::HashMapOptimizationData>
 GroupByImpl::checkIfHashMapOptimizationPossible(
     std::vector<Aggregate>& aliases) const {
+  if (aliases.empty()) {
+    return std::nullopt;
+  }
+
   if (!RuntimeParameters().get<"group-by-hash-map-enabled">()) {
     return std::nullopt;
   }
@@ -1586,35 +1594,33 @@ Result GroupByImpl::computeGroupByForHashMapOptimization(
   size_t groupThreshold = RuntimeParameters()
       .get<"group-by-hash-map-group-threshold">();
 
+  std::string groupByVariablesString =
+      absl::StrJoin(_groupByVariables, ", ",
+                    [](std::string* out, const Variable& var) {
+                      out->append(var.name());
+                    });
+  LOG(DEBUG) << "Entering HashMapOptimization with " 
+            << columnIndices.size()
+            << " grouping columns, namely ["
+            << groupByVariablesString
+            << "] and "
+            << aggregateAliases.size()
+            << " aggregates. Group threshold: "
+            << groupThreshold << std::endl;
+
   ad_utility::Timer lookupTimer{ad_utility::Timer::Stopped};
   ad_utility::Timer aggregationTimer{ad_utility::Timer::Stopped};
+
+  auto beginIt = std::ranges::begin(subresults);
+  auto endIt   = std::ranges::end(subresults);
+  bool singleBlock = std::ranges::next(beginIt) == endIt;
+
   // Iterate through input blocks; break out and buffer the rest if threshold exceeded
-  auto it = subresults.begin();
-  for (; it != subresults.end(); ++it) {
+  for (auto it = beginIt; it != endIt; ++it) {
     const auto& [inputTableRef, inputLocalVocabRef] = *it;
-      const IdTable& inputTable = inputTableRef;
-      const LocalVocab& inputLocalVocab = inputLocalVocabRef;
-      // After each block, check if the number of groups is too large
-      size_t currentGroups = aggregationData.getNumberOfGroups();
-      if (currentGroups > groupThreshold) {
-        LOG(DEBUG) << "Hash-map group count: " << currentGroups
-                  << ", threshold: " << groupThreshold << std::endl;
-        switchToSort = true;
-        // buffer this and all remaining blocks into tailBlocks
-        for (; it != subresults.end(); ++it) {
-          auto& block = *it;
-          if constexpr (requires { block.idTable_; }) {
-            // `block` is a real IdTableVocabPair: move its members
-            tailBlocks.emplace_back(std::move(block.idTable_), std::move(block.localVocab_));
-          } else {
-            // `block` is a pair of reference_wrappers: copy and clone
-            IdTable copiedTable = block.first.get().clone();
-            LocalVocab copiedVocab = block.second.get().clone();
-            tailBlocks.emplace_back(std::move(copiedTable), std::move(copiedVocab));
-          }
-        }
-        break;
-      }
+    const IdTable& inputTable = inputTableRef;
+    const LocalVocab& inputLocalVocab = inputLocalVocabRef;
+    
     // Merge the local vocab of each input block.
     //
     // NOTE: If the input blocks have very similar or even identical non-empty
@@ -1656,6 +1662,7 @@ Result GroupByImpl::computeGroupByForHashMapOptimization(
       }
       lookupTimer.cont();
       auto hashEntries = aggregationData.getHashEntries(groupValues);
+      size_t blockSize = hashEntries.size(); 
       lookupTimer.stop();
 
       aggregationTimer.cont();
@@ -1669,12 +1676,36 @@ Result GroupByImpl::computeGroupByForHashMapOptimization(
               aggregationData.getAggregationDataVariant(
                   aggregate.aggregateDataIndex_);
 
-          std::visit(makeProcessGroupsVisitor(currentBlockSize,
+          std::visit(makeProcessGroupsVisitor(blockSize,
                                               &evaluationContext, hashEntries),
-                     std::move(expressionResult), aggregationDataVariant);
+          std::move(expressionResult), aggregationDataVariant);
         }
       }
       aggregationTimer.stop();
+    }
+
+    size_t currentGroups = aggregationData.getNumberOfGroups();
+    // After each block, check if the number of groups is too large, but only if
+    // we are not processing a single block (which is the case for lazy
+    // evaluation).
+    if (!singleBlock && currentGroups > groupThreshold) {
+      LOG(DEBUG) << "GroupBy Hash-map group count (" << currentGroups
+                << ") is bigger than threshold (" << groupThreshold
+                << "), switching to sort-based aggregation." << std::endl;
+      switchToSort = true;
+      // buffer this and all remaining blocks into tailBlocks
+      for (auto tailIt = std::next(it); tailIt != subresults.end(); ++tailIt) {
+        if constexpr (requires { tailIt->idTable_; }) {
+          tailBlocks.emplace_back(
+            std::move(tailIt->idTable_),
+            std::move(tailIt->localVocab_));
+        } else {
+          tailBlocks.emplace_back(
+            tailIt->first.get().clone(),
+            tailIt->second.get().clone());
+        }
+      }
+      break;
     }
   }
 
@@ -1683,11 +1714,14 @@ Result GroupByImpl::computeGroupByForHashMapOptimization(
   IdTable resultTable =
       createResultFromHashMap(aggregationData, aggregateAliases, &localVocab);
   if (switchToSort) {
+    LOG(DEBUG) << "GroupBy HashMap: Switching to sort-based merge of " << tailBlocks.size()
+               << " leftover blocks" << std::endl;
     // Materialize partial result
     IdTable partial = std::move(resultTable);
     // Merge sorted tail blocks into partial
     IdTable merged = mergeSortedTailIntoPartial(
         std::move(partial), tailBlocks, columnIndices, &localVocab);
+    LOG(DEBUG) << "GroupBy HashMap: Merged result has " << merged.numRows() << " rows" << std::endl;
     return {std::move(merged), resultSortedOn(), std::move(localVocab)};
   } else {
     return {std::move(resultTable), resultSortedOn(), std::move(localVocab)};
@@ -1704,6 +1738,18 @@ IdTable GroupByImpl::mergeSortedTailIntoPartial(
 
   // Phase 1: Aggregate tailBlocks
   IdTable aggregatedTailData = aggregateTailBlocks(tailBlocks, columnIndices, *localVocab);
+
+  // ensure the tail is sorted on the GROUP-BY columns
+  std::sort(
+    aggregatedTailData.begin(), aggregatedTailData.end(),
+    [&](auto const& L, auto const& R) {
+      for (auto col : columnIndices) {
+        if (L[col] < R[col]) return true;
+        if (R[col] < L[col]) return false;
+      }
+      return false;
+    });
+
   // Delay merging LocalVocabs until after grouping: now merge all tail block vocabs
   for (auto& [block, vocab] : tailBlocks) {
     localVocab->mergeWith(vocab);
@@ -1718,66 +1764,72 @@ IdTable GroupByImpl::mergeSortedTailIntoPartial(
     return aggregatedTailData;
   }
 
+  // Phase 2: merge partial and tail
   // Schema must match
   AD_CORRECTNESS_CHECK(partial.numColumns() == aggregatedTailData.numColumns());
-  // If no grouping columns (DISTINCT), perform sorted unique merge
+  // Common definitions for merging
+  const auto numCols = partial.numColumns();
+  const auto numGroupCols = columnIndices.size();
+  IdTable merged{numCols, getExecutionContext()->getAllocator()};
+  merged.reserve(partial.size() + aggregatedTailData.size());
+  auto appendRow = [&](const IdTable& tbl, size_t idx) {
+    merged.emplace_back();
+    size_t destRow = merged.numRows() - 1;
+    for (size_t c = 0; c < numCols; ++c) {
+      merged(destRow, c) = tbl(idx, c);
+    }
+  };
+  size_t i = 0, j = 0;
   if (columnIndices.empty()) {
-    // Merge both sorted tables and drop exact duplicate rows
-    IdTable merged{partial.numColumns(), getExecutionContext()->getAllocator()};
-    merged.reserve(partial.size() + aggregatedTailData.size());
-    size_t i = 0, j = 0;
-    const auto numCols = partial.numColumns();
-    // Helper to append row idx from table
-    auto appendRow = [&](const IdTable& tbl, size_t idx) {
-      merged.emplace_back();
-      size_t newRow = merged.size() - 1;
-      for (size_t c = 0; c < numCols; ++c) {
-        merged(newRow, c) = tbl(idx, c);
-      }
-    };
+    // Distinct merge: simply interleave sorted rows
     while (i < partial.size() && j < aggregatedTailData.size()) {
-      // Compare rows lexicographically
-      bool lessPartial = false;
-      bool lessTail = false;
+      bool lessPartial = false, lessTail = false;
       for (size_t c = 0; c < numCols; ++c) {
-        auto v1 = partial(i, c);
-        auto v2 = aggregatedTailData(j, c);
+        auto v1 = partial(i, c), v2 = aggregatedTailData(j, c);
         if (v1 < v2) { lessPartial = true; break; }
         if (v2 < v1) { lessTail = true; break; }
       }
-      if (lessPartial) {
+      if (lessPartial) appendRow(partial, i++);
+      else if (lessTail) appendRow(aggregatedTailData, j++);
+      else { appendRow(partial, i++); ++j; }
+    }
+    while (i < partial.size()) appendRow(partial, i++);
+    while (j < aggregatedTailData.size()) appendRow(aggregatedTailData, j++);
+  } else {
+    // Fallback: sum aggregates for matching keys
+    while (i < partial.size() && j < aggregatedTailData.size()) {
+      bool equal = true, less = false;
+      for (size_t c = 0; c < numGroupCols; ++c) {
+        auto v1 = partial(i, c), v2 = aggregatedTailData(j, c);
+        if (v1 < v2) { less = true; equal = false; break; }
+        if (v2 < v1) { equal = false; break; }
+      }
+      if (equal) {
+        merged.emplace_back();
+        size_t destRow = merged.numRows() - 1;
+        // copy group columns
+        for (size_t c = 0; c < numGroupCols; ++c) {
+          merged(destRow, c) = partial(i, c);
+        }
+        // sum aggregate columns
+        for (size_t c = numGroupCols; c < numCols; ++c) {
+          merged(destRow, c) = Id::makeFromInt(
+              partial(i, c).getInt() + aggregatedTailData(j, c).getInt());
+        }
+        ++i; ++j;
+      } else if (less) {
         appendRow(partial, i++);
-      } else if (lessTail) {
-        appendRow(aggregatedTailData, j++);
       } else {
-        appendRow(partial, i++);
-        ++j;
+        appendRow(aggregatedTailData, j++);
       }
     }
     while (i < partial.size()) appendRow(partial, i++);
     while (j < aggregatedTailData.size()) appendRow(aggregatedTailData, j++);
-    return merged;
   }
-
-  // Fallback: re-aggregate combined data using existing doGroupBy
-  // Build aggregates from aliases
-  std::vector<Aggregate> aggregates;
-  aggregates.reserve(_aliases.size());
-  const auto& varColMap = getInternallyVisibleVariableColumns();
-  for (const auto& alias : _aliases) {
-    aggregates.emplace_back(alias._expression,
-                           varColMap.at(alias._target).columnIndex_);
-  }
-  // Group-by columns in the partial result are the first _groupByVariables.size() columns
-  std::vector<size_t> groupByCols(_groupByVariables.size());
-  std::iota(groupByCols.begin(), groupByCols.end(), 0);
-  // Call doGroupBy with dynamic in/out widths
-  size_t inWidth = partial.numColumns();
-  size_t outWidth = getResultWidth();
-  return CALL_FIXED_SIZE((std::array{inWidth, outWidth}), &GroupByImpl::doGroupBy,
-                         this, partial, groupByCols, aggregates, localVocab);
+  return merged;
 }
 
+// _____________________________________________________________________________
 IdTable GroupByImpl::aggregateTailBlocks(
     const std::vector<std::pair<IdTable, LocalVocab>>& tailBlocks,
     const std::vector<size_t>& columnIndices,
@@ -1884,4 +1936,45 @@ bool GroupByImpl::shouldSkipHashMapGrouping(const IdTable& table) const {
   LOG(DEBUG) << "Estimated groups: " << estGroupsScaled
               << " (threshold: " << groupThreshold << ")" << std::endl;
   return estGroupsScaled > groupThreshold;
+}
+
+// _____________________________________________________________________________
+// Lazy sampling guard: skip hash-map grouping if estimated distinct groups exceed threshold ratio
+bool GroupByImpl::shouldSkipHashMapGroupingLazy(
+    const std::shared_ptr<const Result>& subresult) const {
+  // Fetch runtime parameters
+  size_t sampleSize = RuntimeParameters().get<"group-by-sample-max-rows">();
+  // This is the threshold for the estimated number of distinct groups
+  double ratioThreshold = RuntimeParameters().get<"group-by-sample-distinct-ratio">();
+  // Note: total number of rows is not fetched to avoid full materialization
+
+  LOG(DEBUG) << "GroupBy: Sampling " << sampleSize << " rows for group estimation" << std::endl;
+
+  absl::flat_hash_set<std::vector<Id>> uniqueGroups;
+  uniqueGroups.reserve(sampleSize);
+  size_t rowsProcessed = 0;
+  const auto& varCols = _subtree->getVariableColumns();
+  for (auto& pair : subresult->idTables()) {
+    const auto& table = pair.idTable_;
+    for (size_t i = 0; i < table.size() && rowsProcessed < sampleSize; ++i) {
+      std::vector<Id> key;
+      key.reserve(_groupByVariables.size());
+      for (auto& var : _groupByVariables) {
+        key.push_back(table(i, varCols.at(var).columnIndex_));
+      }
+      uniqueGroups.insert(std::move(key));
+      ++rowsProcessed;
+    }
+    if (rowsProcessed >= sampleSize) break;
+  }
+
+  size_t sampleGroupSize = uniqueGroups.size();
+  double estimatedGroupRatio = double(sampleGroupSize) / rowsProcessed;
+  LOG(DEBUG) << "GroupBy: Sampled " << rowsProcessed << " rows, "
+              << "estimated distinct groups: " << sampleGroupSize
+              << ", ratio: " << estimatedGroupRatio
+              << " (threshold: " << ratioThreshold << ")" << std::endl;
+
+  // If the estimated number of distinct groups exceeds the threshold, skip the hash-map optimization
+  return estimatedGroupRatio > ratioThreshold;
 }

--- a/src/engine/GroupByImpl.cpp
+++ b/src/engine/GroupByImpl.cpp
@@ -7,7 +7,13 @@
 
 #include "engine/GroupByImpl.h"
 
-#include <absl/strings/str_join.h>
+#include <random>      // for std::mt19937_64, std::uniform_int_distribution
+#include <numeric>     // for std::iota
+#include <algorithm>  // for std::min
+#include <sstream>     // for std::ostringstream
+#include <unordered_set>
+#include <absl/container/flat_hash_set.h>
+#include <type_traits>
 
 #include "engine/CallFixedSize.h"
 #include "engine/ExistsJoin.h"
@@ -336,6 +342,8 @@ Result GroupByImpl::computeResult(bool requestLaziness) {
   auto metadataForUnsequentialData =
       checkIfHashMapOptimizationPossible(aggregates);
   bool useHashMapOptimization = metadataForUnsequentialData.has_value();
+  LOG(DEBUG) << "GroupBy HashMap optimization: "
+            << (useHashMapOptimization ? "enabled" : "disabled") << std::endl;
 
   std::shared_ptr<const Result> subresult;
   if (useHashMapOptimization) {
@@ -356,8 +364,21 @@ Result GroupByImpl::computeResult(bool requestLaziness) {
   }
 
   LOG(DEBUG) << "GroupBy subresult computation done" << std::endl;
+  // Sampling-based guard: decide whether to skip hash-map grouping based on estimated number of groups
+  if (useHashMapOptimization && subresult->isFullyMaterialized()) {
+    // If sampling indicates too many distinct groups, fall back to sort-based aggregation
+    if (shouldSkipHashMapGrouping(subresult->idTable())) {
+      LOG(DEBUG) << "GroupBy: skipping hash-map grouping, using sort-based fallback due to high estimated group count" << std::endl;
+      useHashMapOptimization = false;
+      // Recompute fully materialized, sorted subresult for fallback
+      subresult = _subtree->getResult(false);
+    }
+    // Ensure subresult is sorted on the GROUP BY columns for correct fallback grouping
+    AD_CORRECTNESS_CHECK(isSortedOn(subresult->idTable(), resultSortedOn()),
+                        "Subresult must be sorted on GROUP BY columns after fallback");
+  }
 
-  std::vector<size_t> groupByColumns;
+  std::vector<size_t> groupByCols;
 
   // parse the group by columns
   const auto& subtreeVarCols = _subtree->getVariableColumns();
@@ -367,13 +388,7 @@ Result GroupByImpl::computeResult(bool requestLaziness) {
       AD_THROW("Groupby variable " + var.name() + " is not groupable");
     }
 
-    groupByColumns.push_back(it->second.columnIndex_);
-  }
-
-  std::vector<size_t> groupByCols;
-  groupByCols.reserve(_groupByVariables.size());
-  for (const auto& var : _groupByVariables) {
-    groupByCols.push_back(subtreeVarCols.at(var).columnIndex_);
+    groupByCols.push_back(it->second.columnIndex_);
   }
 
   if (useHashMapOptimization) {
@@ -431,6 +446,9 @@ Result GroupByImpl::computeResult(bool requestLaziness) {
       subresult->idTable(), groupByCols, aggregates, &localVocab);
 
   LOG(DEBUG) << "GroupBy result computation done." << std::endl;
+  // Assert that the final result preserves the expected sort order
+  AD_CORRECTNESS_CHECK(isSortedOn(idTable, resultSortedOn()),
+                      "Final GROUP BY result is not sorted on expected columns");
   return {std::move(idTable), resultSortedOn(), std::move(localVocab)};
 }
 
@@ -562,7 +580,7 @@ Result::Generator GroupByImpl::computeResultLazily(
     if (!singleIdTable && !resultTable.empty()) {
       currentLocalVocab.mergeWith(storedLocalVocabs);
       Result::IdTableVocabPair outputPair{std::move(resultTable),
-                                          std::move(currentLocalVocab)};
+                                           std::move(currentLocalVocab)};
       co_yield outputPair;
       // Reuse buffer if not moved out
       resultTable = std::move(outputPair.idTable_);
@@ -645,7 +663,7 @@ std::optional<IdTable> GroupByImpl::computeGroupByForSingleIndexScan() const {
       table(0, 0) = Id::makeFromInt(
           getIndex().getImpl().numDistinctCol0(permutation.value()).normal);
     } else {
-      table(0, 0) = Id::makeFromInt(getIndex().numTriples().normal);
+      table(0, 0) = Id::makeFromInt(indexScan->getExactSize());
     }
   } else {
     table(0, 0) = Id::makeFromInt(indexScan->getExactSize());
@@ -681,8 +699,8 @@ std::optional<IdTable> GroupByImpl::computeGroupByObjectWithCount() const {
       "GROUP BY variable, this is a bug in the query planner",
       permutedTriple[1]->toString(), groupByVariable.name());
 
-  // There must be exactly one alias, which is a non-distinct count of one of
-  // the two variables of the index scan.
+  // There must be exactly one alias, which is a non-distinct count of one of the
+  // two variables of the index scan.
   auto countedVariable = getVariableForNonDistinctCountOfSingleAlias();
   bool countedVariableIsOneOfIndexScanVariables =
       countedVariable == *(permutedTriple[1]) ||
@@ -915,6 +933,12 @@ std::optional<IdTable> GroupByImpl::computeGroupByForJoinWithFullScan() const {
 // _____________________________________________________________________________
 std::optional<IdTable> GroupByImpl::computeOptimizedGroupByIfPossible() const {
   // TODO<C++23> Use `std::optional::or_else`.
+  // Early out: implicit group (no grouping columns) is trivial and handled by doGroupBy
+  if (_groupByVariables.empty()) {
+    return std::nullopt;
+  }
+
+  // Fall back to existing optimized paths
   if (!RuntimeParameters().get<"group-by-disable-index-scan-optimizations">()) {
     if (auto result = computeGroupByForSingleIndexScan()) {
       return result;
@@ -932,7 +956,16 @@ std::optional<IdTable> GroupByImpl::computeOptimizedGroupByIfPossible() const {
   return std::nullopt;
 }
 
-// _____________________________________________________________________________
+// Hybrid GROUP BY fallback strategy:
+// 1) If no grouping columns, handled by doGroupBy directly.
+// 2) Sample a fraction of rows and estimate distinct group count via hash sketch;
+//    if estimated groups exceed threshold, skip hash-map path entirely.
+// 3) Attempt index-scan-based shortcuts (single index count, full index scan,
+//    join full scan, object count).
+// 4) Otherwise, compute subresult (lazy if possible) and apply hash-map grouping.
+// 5) If the hash-map grows too large mid-aggregation, buffer remaining data and
+//    switch to sort-based aggregation via mergeSortedTailIntoPartial.
+// 6) If all optimizations fail or threshold crossed, fallback to standard doGroupBy (sort+group-by).
 std::optional<GroupByImpl::HashMapOptimizationData>
 GroupByImpl::computeUnsequentialProcessingMetadata(
     std::vector<Aggregate>& aliases,
@@ -1518,6 +1551,7 @@ template <size_t NUM_GROUP_COLUMNS, typename SubResults>
 Result GroupByImpl::computeGroupByForHashMapOptimization(
     std::vector<HashMapAliasInformation>& aggregateAliases,
     SubResults subresults, const std::vector<size_t>& columnIndices) const {
+  // Contract check(?)
   AD_CORRECTNESS_CHECK(columnIndices.size() == NUM_GROUP_COLUMNS ||
                        NUM_GROUP_COLUMNS == 0);
   LocalVocab localVocab;
@@ -1527,14 +1561,41 @@ Result GroupByImpl::computeGroupByForHashMapOptimization(
       getExecutionContext()->getAllocator(), aggregateAliases,
       columnIndices.size());
 
-  // Process the input blocks (pairs of `IdTable` and `LocalVocab`) one after
-  // the other.
+  // Buffer for tail blocks if we switch to sort
+  std::vector<std::pair<IdTable, LocalVocab>> tailBlocks;
+  bool switchToSort = false;
+  size_t groupThreshold = RuntimeParameters()
+      .get<"group-by-hash-map-group-threshold">();
+
   ad_utility::Timer lookupTimer{ad_utility::Timer::Stopped};
   ad_utility::Timer aggregationTimer{ad_utility::Timer::Stopped};
-  for (const auto& [inputTableRef, inputLocalVocabRef] : subresults) {
-    const IdTable& inputTable = inputTableRef;
-    const LocalVocab& inputLocalVocab = inputLocalVocabRef;
-
+  // Iterate through input blocks; break out and buffer the rest if threshold exceeded
+  auto it = subresults.begin();
+  for (; it != subresults.end(); ++it) {
+    const auto& [inputTableRef, inputLocalVocabRef] = *it;
+      const IdTable& inputTable = inputTableRef;
+      const LocalVocab& inputLocalVocab = inputLocalVocabRef;
+      // After each block, check if the number of groups is too large
+      size_t currentGroups = aggregationData.getNumberOfGroups();
+      if (currentGroups > groupThreshold) {
+        LOG(DEBUG) << "Hash-map group count: " << currentGroups
+                  << ", threshold: " << groupThreshold << std::endl;
+        switchToSort = true;
+        // buffer this and all remaining blocks into tailBlocks
+        for (; it != subresults.end(); ++it) {
+          auto& block = *it;
+          if constexpr (requires { block.idTable_; }) {
+            // `block` is a real IdTableVocabPair: move its members
+            tailBlocks.emplace_back(std::move(block.idTable_), std::move(block.localVocab_));
+          } else {
+            // `block` is a pair of reference_wrappers: copy and clone
+            IdTable copiedTable = block.first.get().clone();
+            LocalVocab copiedVocab = block.second.get().clone();
+            tailBlocks.emplace_back(std::move(copiedTable), std::move(copiedVocab));
+          }
+        }
+        break;
+      }
     // Merge the local vocab of each input block.
     //
     // NOTE: If the input blocks have very similar or even identical non-empty
@@ -1602,7 +1663,133 @@ Result GroupByImpl::computeGroupByForHashMapOptimization(
   runtimeInfo().addDetail("timeAggregation", aggregationTimer.msecs());
   IdTable resultTable =
       createResultFromHashMap(aggregationData, aggregateAliases, &localVocab);
-  return {std::move(resultTable), resultSortedOn(), std::move(localVocab)};
+  if (switchToSort) {
+    // Materialize partial result
+    IdTable partial = std::move(resultTable);
+    // Merge sorted tail blocks into partial
+    IdTable merged = mergeSortedTailIntoPartial(
+        std::move(partial), tailBlocks, columnIndices, &localVocab);
+    return {std::move(merged), resultSortedOn(), std::move(localVocab)};
+  } else {
+    return {std::move(resultTable), resultSortedOn(), std::move(localVocab)};
+  }
+}
+
+// _____________________________________________________________________________
+IdTable GroupByImpl::mergeSortedTailIntoPartial(
+    IdTable&& partial,
+    const std::vector<std::pair<IdTable, LocalVocab>>& tailBlocks,
+    const std::vector<size_t>& columnIndices,
+    LocalVocab* localVocab) const {
+  AD_CORRECTNESS_CHECK(localVocab);
+
+  // Phase 1: Aggregate tailBlocks
+  IdTable aggregatedTailData = aggregateTailBlocks(tailBlocks, columnIndices, *localVocab);
+  // Delay merging LocalVocabs until after grouping: now merge all tail block vocabs
+  for (auto& [block, vocab] : tailBlocks) {
+    localVocab->mergeWith(vocab);
+  }
+  // If no new data, return existing partial
+  if (aggregatedTailData.empty()) {
+    return std::move(partial);
+  }
+  // If partial is empty, return aggregated tail
+  if (partial.empty()) {
+    // No existing partial: return aggregated tail directly (RVO applies)
+    return aggregatedTailData;
+  }
+
+  // Schema must match
+  AD_CORRECTNESS_CHECK(partial.numColumns() == aggregatedTailData.numColumns());
+  // If no grouping columns (DISTINCT), perform sorted unique merge
+  if (columnIndices.empty()) {
+    // Merge both sorted tables and drop exact duplicate rows
+    IdTable merged{partial.numColumns(), getExecutionContext()->getAllocator()};
+    merged.reserve(partial.size() + aggregatedTailData.size());
+    size_t i = 0, j = 0;
+    const auto numCols = partial.numColumns();
+    // Helper to append row idx from table
+    auto appendRow = [&](const IdTable& tbl, size_t idx) {
+      merged.emplace_back();
+      size_t newRow = merged.size() - 1;
+      for (size_t c = 0; c < numCols; ++c) {
+        merged(newRow, c) = tbl(idx, c);
+      }
+    };
+    while (i < partial.size() && j < aggregatedTailData.size()) {
+      // Compare rows lexicographically
+      bool lessPartial = false;
+      bool lessTail = false;
+      for (size_t c = 0; c < numCols; ++c) {
+        auto v1 = partial(i, c);
+        auto v2 = aggregatedTailData(j, c);
+        if (v1 < v2) { lessPartial = true; break; }
+        if (v2 < v1) { lessTail = true; break; }
+      }
+      if (lessPartial) {
+        appendRow(partial, i++);
+      } else if (lessTail) {
+        appendRow(aggregatedTailData, j++);
+      } else {
+        appendRow(partial, i++);
+        ++j;
+      }
+    }
+    while (i < partial.size()) appendRow(partial, i++);
+    while (j < aggregatedTailData.size()) appendRow(aggregatedTailData, j++);
+    return merged;
+  }
+
+  // Fallback: re-aggregate combined data using existing doGroupBy
+  // Build aggregates from aliases
+  std::vector<Aggregate> aggregates;
+  aggregates.reserve(_aliases.size());
+  const auto& varColMap = getInternallyVisibleVariableColumns();
+  for (const auto& alias : _aliases) {
+    aggregates.emplace_back(alias._expression,
+                           varColMap.at(alias._target).columnIndex_);
+  }
+  // Group-by columns in the partial result are the first _groupByVariables.size() columns
+  std::vector<size_t> groupByCols(_groupByVariables.size());
+  std::iota(groupByCols.begin(), groupByCols.end(), 0);
+  // Call doGroupBy with dynamic in/out widths
+  size_t inWidth = partial.numColumns();
+  size_t outWidth = getResultWidth();
+  return CALL_FIXED_SIZE((std::array{inWidth, outWidth}), &GroupByImpl::doGroupBy,
+                         this, partial, groupByCols, aggregates, localVocab);
+}
+
+IdTable GroupByImpl::aggregateTailBlocks(
+    const std::vector<std::pair<IdTable, LocalVocab>>& tailBlocks,
+    const std::vector<size_t>& columnIndices,
+    LocalVocab& localVocab) const {
+  // Concatenate raw tail blocks
+  if (tailBlocks.empty()) {
+    // No tail blocks to aggregate: return empty result with correct schema
+    return IdTable{getResultWidth(), getExecutionContext()->getAllocator()};
+  }
+  // Determine input width from first block
+  size_t inWidth = tailBlocks.front().first.numColumns();
+  IdTable concatenated{inWidth, getExecutionContext()->getAllocator()};
+  for (const auto& [block, vocab] : tailBlocks) {
+    // Batch-append all rows of the block at once
+    concatenated.insertAtEnd(block);
+    // Delay merging LocalVocabs until after grouping
+    // localVocab.mergeWith(vocab);
+  }
+  // Build aggregates from aliases
+  std::vector<Aggregate> aggregates;
+  aggregates.reserve(_aliases.size());
+  const auto& varColMap = getInternallyVisibleVariableColumns();
+  for (const auto& alias : _aliases) {
+    aggregates.emplace_back(alias._expression,
+                           varColMap.at(alias._target).columnIndex_);
+  }
+  // Perform grouping on concatenated data
+  size_t outWidth = getResultWidth();
+  return CALL_FIXED_SIZE((std::array{inWidth, outWidth}), &GroupByImpl::doGroupBy,
+                         this, concatenated, columnIndices, aggregates,
+                         &localVocab);
 }
 
 // _____________________________________________________________________________
@@ -1633,4 +1820,49 @@ bool GroupByImpl::isVariableBoundInSubtree(const Variable& variable) const {
 std::unique_ptr<Operation> GroupByImpl::cloneImpl() const {
   return std::make_unique<GroupByImpl>(_executionContext, _groupByVariables,
                                        _aliases, _subtree->clone());
+}
+
+// _____________________________________________________________________________
+// Sampling guard: skip hash-map grouping if estimated distinct groups exceed threshold
+bool GroupByImpl::shouldSkipHashMapGrouping(const IdTable& table) const {
+  // Fetch runtime parameters
+  double samplePercent = RuntimeParameters().get<"group-by-sample-percent">();
+  size_t maxSampleRows = RuntimeParameters().get<"group-by-sample-max-rows">();
+  size_t groupThreshold = RuntimeParameters().get<"group-by-sample-group-threshold">();
+  size_t totalSize = table.size();
+
+  size_t sampleSize = std::min(static_cast<size_t>(totalSize * samplePercent), maxSampleRows);
+  if (sampleSize == 0) {
+    return false;
+  }
+
+  LOG(DEBUG) << "Sampling " << sampleSize << " rows out of " << totalSize
+              << " for group estimation" << std::endl;
+  // Reservoir-sample indices only
+  std::vector<size_t> indices(sampleSize);
+  for (size_t i = 0; i < sampleSize; ++i) indices[i] = i;
+  std::mt19937_64 gen{std::random_device{}()};
+  for (size_t i = sampleSize; i < totalSize; ++i) {
+    std::uniform_int_distribution<size_t> dist(0, i);
+    if (dist(gen) < sampleSize) {
+      indices[dist(gen)] = i;
+    }
+  }
+  // Use absl::flat_hash_set to estimate distinct groups
+  absl::flat_hash_set<std::vector<Id>> uniqueGroups;
+  uniqueGroups.reserve(sampleSize);
+  for (size_t idx : indices) {
+    std::vector<Id> key;
+    key.reserve(_groupByVariables.size());
+    const auto& varCols = _subtree->getVariableColumns();
+    for (auto& var : _groupByVariables) {
+      key.push_back(table(idx, varCols.at(var).columnIndex_));
+    }
+    uniqueGroups.insert(std::move(key));
+  }
+  size_t estGroups = uniqueGroups.size();
+  size_t estGroupsScaled = static_cast<size_t>(double(estGroups) / sampleSize * totalSize);
+  LOG(DEBUG) << "Estimated groups: " << estGroupsScaled
+              << " (threshold: " << groupThreshold << ")" << std::endl;
+  return estGroupsScaled > groupThreshold;
 }

--- a/src/engine/GroupByImpl.cpp
+++ b/src/engine/GroupByImpl.cpp
@@ -328,6 +328,17 @@ sparqlExpression::EvaluationContext GroupByImpl::createEvaluationContext(
 }
 
 // _____________________________________________________________________________
+// Hybrid GROUP BY fallback strategy:
+// 1) If no aliases, the result is simply a collapsed version of the input
+// 2) If no grouping columns, handled by doGroupBy directly.
+// 3) Sample a fraction of rows and estimate distinct group count via hash sketch;
+//    if estimated groups exceed threshold, skip hash-map path entirely.
+// 4) Attempt index-scan-based shortcuts (single index count, full index scan,
+//    join full scan, object count).
+// 5) Otherwise, compute subresult (lazy if possible) and apply hash-map grouping.
+// 6) If the hash-map grows too large mid-aggregation, buffer remaining data and
+//    switch to sort-based aggregation via mergeSortedTailIntoPartial.
+// 7) If all optimizations fail or threshold crossed, fallback to standard doGroupBy (sort+group-by).
 Result GroupByImpl::computeResult(bool requestLaziness) {
   LOG(DEBUG) << "GroupBy result computation..." << std::endl;
 
@@ -615,7 +626,7 @@ Result::Generator GroupByImpl::computeResultLazily(
     if (!singleIdTable && !resultTable.empty()) {
       currentLocalVocab.mergeWith(storedLocalVocabs);
       Result::IdTableVocabPair outputPair{std::move(resultTable),
-                                           std::move(currentLocalVocab)};
+                                          std::move(currentLocalVocab)};
       co_yield outputPair;
       // Reuse buffer if not moved out
       resultTable = std::move(outputPair.idTable_);
@@ -734,8 +745,8 @@ std::optional<IdTable> GroupByImpl::computeGroupByObjectWithCount() const {
       "GROUP BY variable, this is a bug in the query planner",
       permutedTriple[1]->toString(), groupByVariable.name());
 
-  // There must be exactly one alias, which is a non-distinct count of one of the
-  // two variables of the index scan.
+  // There must be exactly one alias, which is a non-distinct count of one of
+  // the two variables of the index scan.
   auto countedVariable = getVariableForNonDistinctCountOfSingleAlias();
   bool countedVariableIsOneOfIndexScanVariables =
       countedVariable == *(permutedTriple[1]) ||
@@ -973,7 +984,6 @@ std::optional<IdTable> GroupByImpl::computeOptimizedGroupByIfPossible() const {
     return std::nullopt;
   }
 
-  // Fall back to existing optimized paths
   if (!RuntimeParameters().get<"group-by-disable-index-scan-optimizations">()) {
     if (auto result = computeGroupByForSingleIndexScan()) {
       return result;
@@ -991,16 +1001,7 @@ std::optional<IdTable> GroupByImpl::computeOptimizedGroupByIfPossible() const {
   return std::nullopt;
 }
 
-// Hybrid GROUP BY fallback strategy:
-// 1) If no grouping columns, handled by doGroupBy directly.
-// 2) Sample a fraction of rows and estimate distinct group count via hash sketch;
-//    if estimated groups exceed threshold, skip hash-map path entirely.
-// 3) Attempt index-scan-based shortcuts (single index count, full index scan,
-//    join full scan, object count).
-// 4) Otherwise, compute subresult (lazy if possible) and apply hash-map grouping.
-// 5) If the hash-map grows too large mid-aggregation, buffer remaining data and
-//    switch to sort-based aggregation via mergeSortedTailIntoPartial.
-// 6) If all optimizations fail or threshold crossed, fallback to standard doGroupBy (sort+group-by).
+// _____________________________________________________________________________
 std::optional<GroupByImpl::HashMapOptimizationData>
 GroupByImpl::computeUnsequentialProcessingMetadata(
     std::vector<Aggregate>& aliases,
@@ -1586,7 +1587,7 @@ template <size_t NUM_GROUP_COLUMNS, typename SubResults>
 Result GroupByImpl::computeGroupByForHashMapOptimization(
     std::vector<HashMapAliasInformation>& aggregateAliases,
     SubResults subresults, const std::vector<size_t>& columnIndices) const {
-  // Contract check(?)
+  // [Benke] Contract check instead? (AI suggested)
   AD_CORRECTNESS_CHECK(columnIndices.size() == NUM_GROUP_COLUMNS ||
                        NUM_GROUP_COLUMNS == 0);
   LocalVocab localVocab;

--- a/src/engine/GroupByImpl.h
+++ b/src/engine/GroupByImpl.h
@@ -73,7 +73,10 @@ class GroupByImpl : public Operation {
   virtual float getMultiplicity(size_t col) override;
 
  public:
+  // Overrides Operation::getSizeEstimateBeforeLimit()
   uint64_t getSizeEstimateBeforeLimit() override;
+  // Const overload for internal use
+  uint64_t getSizeEstimateBeforeLimit() const;
   size_t getCostEstimate() override;
 
   /**

--- a/src/engine/GroupByImpl.h
+++ b/src/engine/GroupByImpl.h
@@ -612,6 +612,8 @@ class GroupByImpl : public Operation {
 
   // Check via sampling if the hash-map path should be skipped due to too many groups
   bool shouldSkipHashMapGrouping(const IdTable& table) const;
+  bool shouldSkipHashMapGroupingLazy(
+      const std::shared_ptr<const Result>& subresult) const;
 
   // Check if the table is sorted on the given columns (non-decreasing order)
   bool isSortedOn(const IdTable& table, const std::vector<ColumnIndex>& cols) const {

--- a/src/global/RuntimeParameters.h
+++ b/src/global/RuntimeParameters.h
@@ -49,6 +49,11 @@ inline auto& RuntimeParameters() {
         Bool<"use-binsearch-transitive-path">{true},
         Bool<"group-by-hash-map-enabled">{false},
         Bool<"group-by-disable-index-scan-optimizations">{false},
+        // Sampling-based hybrid GROUP BY thresholds
+        Double<"group-by-sample-percent">{0.01},      // percent of rows to sample (1%)
+        SizeT<"group-by-sample-max-rows">{50000},     // cap on sample size
+        SizeT<"group-by-sample-group-threshold">{1000000},    // switch to sort if estimated groups exceed this
+        SizeT<"group-by-hash-map-group-threshold">{1000000}, // max groups for hash-map optimization
         SizeT<"service-max-value-rows">{10'000},
         SizeT<"query-planning-budget">{1500},
         Bool<"throw-on-unbound-variables">{false},

--- a/src/global/RuntimeParameters.h
+++ b/src/global/RuntimeParameters.h
@@ -13,6 +13,7 @@ inline auto& RuntimeParameters() {
   using ad_utility::detail::parameterShortNames::DurationParameter;
   using ad_utility::detail::parameterShortNames::MemorySizeParameter;
   using ad_utility::detail::parameterShortNames::SizeT;
+  using ad_utility::detail::parameterShortNames::Int;
   // NOTE: It is important that the value of the static variable is created by
   // an immediately invoked lambda, otherwise we get really strange segfaults on
   // Clang 16 and 17.
@@ -52,8 +53,9 @@ inline auto& RuntimeParameters() {
         // Sampling-based hybrid GROUP BY thresholds
         Double<"group-by-sample-percent">{0.01},      // percent of rows to sample (1%)
         SizeT<"group-by-sample-max-rows">{50000},     // cap on sample size
-        SizeT<"group-by-sample-group-threshold">{1000000},    // switch to sort if estimated groups exceed this
-        SizeT<"group-by-hash-map-group-threshold">{1000000}, // max groups for hash-map optimization
+        Double<"group-by-sample-distinct-ratio">{0.95},    // LAZY CASE: switch to sort if the fraction (sampled distinct groups / sample size) exceeds this ratio
+        SizeT<"group-by-sample-group-threshold">{1'000'000},    // MATERIALIZED CASE: switch to sort if the estimated number of distinct groups exceeds this number
+        SizeT<"group-by-hash-map-group-threshold">{1'000'000}, // max groups for hash-map optimization
         SizeT<"service-max-value-rows">{10'000},
         SizeT<"query-planning-budget">{1500},
         Bool<"throw-on-unbound-variables">{false},

--- a/src/util/Parameters.h
+++ b/src/util/Parameters.h
@@ -170,6 +170,12 @@ struct szt {
     return std::stoull(s);
   }
 };
+struct sztnu {
+  template <typename T>
+  int operator()(const T& s) const {
+    return std::stoi(s);
+  }
+};
 struct bl {
   template <typename T>
   bool operator()(const T& s) const {
@@ -232,6 +238,9 @@ using String = Parameter<std::string, std::identity, std::identity, Name>;
 
 template <ParameterName Name>
 using Bool = Parameter<bool, bl, boolToString, Name>;
+
+template <ParameterName Name>
+using Int = Parameter<int, sztnu, toString, Name>;
 
 template <ParameterName Name>
 using MemorySizeParameter =

--- a/test/util/IndexTestHelpers.cpp
+++ b/test/util/IndexTestHelpers.cpp
@@ -306,7 +306,7 @@ QueryExecutionContext* getQec(TestIndexConfig c) {
     std::unique_ptr<QueryResultCache> cache_;
     std::unique_ptr<QueryExecutionContext> qec_ =
         std::make_unique<QueryExecutionContext>(
-            *index_, cache_.get(), makeAllocator(MemorySize::megabytes(100)),
+            *index_, cache_.get(), makeAllocator(),
             SortPerformanceEstimator{});
   };
 


### PR DESCRIPTION
- Made `getSizeEstimateBeforeLimit` internally usable
    - …in order to be able to reserve an estimated number of result groups to reduce reallocations
- When there are no aliases (because no aggregate functions were used), we use a very simple approach in `computeResult`
- Implemented a “reservoir sample”-based early check, whether there will be too many groups, in that case, we disable the HashMap optimization
    - `shouldSkipHashMapGroupingDynamic` → defined as `shouldSkipHashMapGrouping` or `shouldSkipHashMapGroupingLazy`, depending on which method we want to use
- We use `groupByColumns` instead of redundant `groupByCols` in `computeResult`
- We “early out” `computeOptimizedGroupByIfPossible`, if there are no GroupBy variables
- We check repeatedly in `computeGroupByForHashMapOptimization`
- We use `hashEntries.size()` instead of `currentBlockSize` (to prevent an error)