### PR TITLE
Add `geof:minX`, `geof:minY`, `geof:maxX` and `geof:maxY` using `GeometryInfo`

### DIFF
--- a/src/engine/sparqlExpressions/GeoExpression.cpp
+++ b/src/engine/sparqlExpressions/GeoExpression.cpp
@@ -56,6 +56,11 @@ NARY_EXPRESSION(
     GeoRelationExpression, 2,
     FV<ad_utility::WktGeometricRelation<Relation>, GeoPointValueGetter>);
 
+template <ad_utility::BoundingCoordinate RequestedCoordinate>
+NARY_EXPRESSION(BoundingCoordinateExpression, 1,
+                FV<ad_utility::WktBoundingCoordinate<RequestedCoordinate>,
+                   GeometryInfoValueGetter<ad_utility::BoundingBox>>);
+
 }  // namespace detail
 
 using namespace detail;
@@ -119,6 +124,14 @@ SparqlExpression::Ptr makeGeoRelationExpression(SparqlExpression::Ptr child1,
   return std::make_unique<GeoRelationExpression<Relation>>(std::move(child1),
                                                            std::move(child2));
 }
+
+// _____________________________________________________________________________
+template <ad_utility::BoundingCoordinate RequestedCoordinate>
+SparqlExpression::Ptr makeBoundingCoordinateExpression(
+    SparqlExpression::Ptr child) {
+  return std::make_unique<BoundingCoordinateExpression<RequestedCoordinate>>(
+      std::move(child));
+};
 
 namespace {
 
@@ -277,3 +290,16 @@ QL_INSTANTIATE_GEO_RELATION_EXPR(TOUCHES);
 QL_INSTANTIATE_GEO_RELATION_EXPR(EQUALS);
 QL_INSTANTIATE_GEO_RELATION_EXPR(OVERLAPS);
 QL_INSTANTIATE_GEO_RELATION_EXPR(WITHIN);
+
+// Explicit instantiations for the bounding cordinate expressions
+#ifdef QL_INSTANTIATE_BOUNDING_COORDINATE_EXPR
+#error "Macro QL_INSTANTIATE_BOUNDING_COORDINATE_EXPR already defined"
+#endif
+#define QL_INSTANTIATE_BOUNDING_COORDINATE_EXPR(RequestedCoordinate) \
+  template Ptr sparqlExpression::makeBoundingCoordinateExpression<   \
+      ad_utility::BoundingCoordinate::RequestedCoordinate>(Ptr);
+
+QL_INSTANTIATE_BOUNDING_COORDINATE_EXPR(MIN_X);
+QL_INSTANTIATE_BOUNDING_COORDINATE_EXPR(MIN_Y);
+QL_INSTANTIATE_BOUNDING_COORDINATE_EXPR(MAX_X);
+QL_INSTANTIATE_BOUNDING_COORDINATE_EXPR(MAX_Y);

--- a/src/engine/sparqlExpressions/GeoExpression.cpp
+++ b/src/engine/sparqlExpressions/GeoExpression.cpp
@@ -291,7 +291,7 @@ QL_INSTANTIATE_GEO_RELATION_EXPR(EQUALS);
 QL_INSTANTIATE_GEO_RELATION_EXPR(OVERLAPS);
 QL_INSTANTIATE_GEO_RELATION_EXPR(WITHIN);
 
-// Explicit instantiations for the bounding cordinate expressions
+// Explicit instantiations for the bounding coordinate expressions
 #ifdef QL_INSTANTIATE_BOUNDING_COORDINATE_EXPR
 #error "Macro QL_INSTANTIATE_BOUNDING_COORDINATE_EXPR already defined"
 #endif

--- a/src/engine/sparqlExpressions/NaryExpression.h
+++ b/src/engine/sparqlExpressions/NaryExpression.h
@@ -16,6 +16,7 @@
 #include "engine/SpatialJoinConfig.h"
 #include "engine/sparqlExpressions/SparqlExpression.h"
 #include "global/Constants.h"
+#include "rdfTypes/GeometryInfo.h"
 #include "rdfTypes/Variable.h"
 
 // Factory functions for all kinds of expressions that only have other
@@ -69,6 +70,10 @@ SparqlExpression::Ptr makeLongitudeExpression(SparqlExpression::Ptr child);
 SparqlExpression::Ptr makeCentroidExpression(SparqlExpression::Ptr child);
 SparqlExpression::Ptr makeEnvelopeExpression(SparqlExpression::Ptr child);
 SparqlExpression::Ptr makeGeometryTypeExpression(SparqlExpression::Ptr child);
+
+template <ad_utility::BoundingCoordinate RequestedCoordinate>
+SparqlExpression::Ptr makeBoundingCoordinateExpression(
+    SparqlExpression::Ptr child);
 
 SparqlExpression::Ptr makeSecondsExpression(SparqlExpression::Ptr child);
 SparqlExpression::Ptr makeMinutesExpression(SparqlExpression::Ptr child);

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -41,6 +41,7 @@
 #include "parser/SparqlParser.h"
 #include "parser/SpatialQuery.h"
 #include "parser/TokenizerCtre.h"
+#include "rdfTypes/GeometryInfo.h"
 #include "rdfTypes/Variable.h"
 #include "util/StringUtils.h"
 #include "util/TransparentFunctors.h"
@@ -184,12 +185,17 @@ ExpressionPtr Visitor::processIriFunctionCall(
       std::unordered_map<std::string_view, absl::FunctionRef<Ptr(Ptr, Ptr)>>;
 
   // Geo functions.
+  using enum ad_utility::BoundingCoordinate;
   static const UnaryFuncTable geoUnaryFuncs{
       {"longitude", &makeLongitudeExpression},
       {"latitude", &makeLatitudeExpression},
       {"centroid", &makeCentroidExpression},
       {"envelope", &makeEnvelopeExpression},
-      {"geometryType", &makeGeometryTypeExpression}};
+      {"geometryType", &makeGeometryTypeExpression},
+      {"minX", &makeBoundingCoordinateExpression<MIN_X>},
+      {"minY", &makeBoundingCoordinateExpression<MIN_Y>},
+      {"maxX", &makeBoundingCoordinateExpression<MAX_X>},
+      {"maxY", &makeBoundingCoordinateExpression<MAX_Y>}};
   using enum SpatialJoinType;
   static const BinaryFuncTable geoBinaryFuncs{
       {"metricDistance", &makeMetricDistExpression},

--- a/src/rdfTypes/GeometryInfo.cpp
+++ b/src/rdfTypes/GeometryInfo.cpp
@@ -114,7 +114,9 @@ double BoundingBox::getBoundingCoordinate() const {
   } else if constexpr (RequestedCoordinate == MAX_Y) {
     return upperRight_.getLat();
   } else {
-    static_assert(ad_utility::alwaysFalse<BoundingCoordinate>);
+    // Unfortunately, we cannot use a `static_assert` here because some compiler
+    // versions don't like it.
+    AD_FAIL();
   }
 };
 

--- a/src/rdfTypes/GeometryInfo.cpp
+++ b/src/rdfTypes/GeometryInfo.cpp
@@ -102,6 +102,33 @@ std::string BoundingBox::asWkt() const {
 }
 
 // ____________________________________________________________________________
+template <BoundingCoordinate RequestedCoordinate>
+double BoundingBox::getBoundingCoordinate() const {
+  using enum BoundingCoordinate;
+  if constexpr (RequestedCoordinate == MIN_X) {
+    return lowerLeft_.getLng();
+  } else if constexpr (RequestedCoordinate == MIN_Y) {
+    return lowerLeft_.getLat();
+  } else if constexpr (RequestedCoordinate == MAX_X) {
+    return upperRight_.getLng();
+  } else if constexpr (RequestedCoordinate == MAX_Y) {
+    return upperRight_.getLat();
+  } else {
+    static_assert(ad_utility::alwaysFalse<BoundingCoordinate>);
+  }
+};
+
+// Explicit instantiations
+template double BoundingBox::getBoundingCoordinate<BoundingCoordinate::MIN_X>()
+    const;
+template double BoundingBox::getBoundingCoordinate<BoundingCoordinate::MIN_Y>()
+    const;
+template double BoundingBox::getBoundingCoordinate<BoundingCoordinate::MAX_X>()
+    const;
+template double BoundingBox::getBoundingCoordinate<BoundingCoordinate::MAX_Y>()
+    const;
+
+// ____________________________________________________________________________
 template <typename RequestedInfo>
 requires RequestedInfoT<RequestedInfo>
 RequestedInfo GeometryInfo::getRequestedInfo() const {

--- a/src/rdfTypes/GeometryInfo.h
+++ b/src/rdfTypes/GeometryInfo.h
@@ -27,6 +27,9 @@ struct Centroid {
   Centroid(double lat, double lng) : centroid_{lat, lng} {};
 };
 
+// The indivdual coordinates describing the bounding box.
+enum class BoundingCoordinate { MIN_X, MIN_Y, MAX_X, MAX_Y };
+
 // Represents the bounding box of a geometry by two `GeoPoint`s for lower left
 // corner and upper right corner.
 struct BoundingBox {
@@ -34,6 +37,10 @@ struct BoundingBox {
   GeoPoint upperRight_;
 
   std::string asWkt() const;
+
+  // Extract the minimum or maximum coordinates
+  template <BoundingCoordinate RequestedCoordinate>
+  double getBoundingCoordinate() const;
 };
 
 // The encoded bounding box is a pair of the bit encodings of the

--- a/src/rdfTypes/GeometryInfo.h
+++ b/src/rdfTypes/GeometryInfo.h
@@ -27,7 +27,7 @@ struct Centroid {
   Centroid(double lat, double lng) : centroid_{lat, lng} {};
 };
 
-// The indivdual coordinates describing the bounding box.
+// The individual coordinates describing the bounding box.
 enum class BoundingCoordinate { MIN_X, MIN_Y, MAX_X, MAX_Y };
 
 // Represents the bounding box of a geometry by two `GeoPoint`s for lower left

--- a/src/util/GeoSparqlHelpers.h
+++ b/src/util/GeoSparqlHelpers.h
@@ -132,6 +132,19 @@ class WktEnvelope {
   }
 };
 
+// Get a single coordinate of the bounding box.
+template <BoundingCoordinate RequestedCoordinate>
+class WktBoundingCoordinate {
+ public:
+  ValueId operator()(const std::optional<BoundingBox>& boundingBox) const {
+    if (!boundingBox.has_value()) {
+      return ValueId::makeUndefined();
+    }
+    return ValueId::makeFromDouble(
+        boundingBox.value().getBoundingCoordinate<RequestedCoordinate>());
+  }
+};
+
 // Compute the distance between two WKT points in meters.
 class WktGeometryType {
  public:

--- a/test/GeometryInfoTest.cpp
+++ b/test/GeometryInfoTest.cpp
@@ -142,6 +142,23 @@ TEST(GeometryInfoTest, BoundingBoxAsWKT) {
 }
 
 // ____________________________________________________________________________
+TEST(GeometryInfoTest, BoundingBoxGetBoundingCoordinate) {
+  using enum ad_utility::BoundingCoordinate;
+
+  BoundingBox bb1{{2, 1}, {4, 3}};
+  EXPECT_NEAR(bb1.getBoundingCoordinate<MIN_X>(), 1, 0.0001);
+  EXPECT_NEAR(bb1.getBoundingCoordinate<MIN_Y>(), 2, 0.0001);
+  EXPECT_NEAR(bb1.getBoundingCoordinate<MAX_X>(), 3, 0.0001);
+  EXPECT_NEAR(bb1.getBoundingCoordinate<MAX_Y>(), 4, 0.0001);
+
+  BoundingBox bb2{{-20, -5}, {-4, -3}};
+  EXPECT_NEAR(bb2.getBoundingCoordinate<MIN_X>(), -5, 0.0001);
+  EXPECT_NEAR(bb2.getBoundingCoordinate<MIN_Y>(), -20, 0.0001);
+  EXPECT_NEAR(bb2.getBoundingCoordinate<MAX_X>(), -3, 0.0001);
+  EXPECT_NEAR(bb2.getBoundingCoordinate<MAX_Y>(), -4, 0.0001);
+}
+
+// ____________________________________________________________________________
 TEST(GeometryInfoTest, GeometryTypeAsIri) {
   ASSERT_EQ(GeometryType{1}.asIri().value(),
             "http://www.opengis.net/ont/sf#Point");

--- a/test/SparqlAntlrParserExpressionTest.cpp
+++ b/test/SparqlAntlrParserExpressionTest.cpp
@@ -343,16 +343,13 @@ TEST(SparqlParser, FunctionCall) {
   expectFunctionCall(
       absl::StrCat(geof, "metricDistance>(?a, ?b)"),
       matchNary(&makeMetricDistExpression, Variable{"?a"}, Variable{"?b"}));
-  // Compatibility version of geof:distance with two
-  // arguments
+  // Compatibility version of geof:distance with two arguments
   expectFunctionCall(
       absl::StrCat(geof, "distance>(?a, ?b)"),
       matchNary(&makeDistExpression, Variable{"?a"}, Variable{"?b"}));
   // geof:distance with IRI as unit in third argument
   expectFunctionCall(
-      absl::StrCat(geof,
-                   "distance>(?a, ?b, "
-                   "<http://qudt.org/vocab/unit/M>)"),
+      absl::StrCat(geof, "distance>(?a, ?b, <http://qudt.org/vocab/unit/M>)"),
       matchNaryWithChildrenMatchers(
           &makeDistWithUnitExpression,
           variableExpressionMatcher(Variable{"?a"}),
@@ -361,13 +358,11 @@ TEST(SparqlParser, FunctionCall) {
               ad_utility::triple_component::Iri::fromIriref(
                   "<http://qudt.org/vocab/unit/M>"))));
 
-  // geof:distance with xsd:anyURI literal as unit in third
-  // argument
+  // geof:distance with xsd:anyURI literal as unit in third argument
   expectFunctionCall(
       absl::StrCat(geof,
                    "distance>(?a, ?b, "
-                   "\"http://qudt.org/vocab/unit/"
-                   "M\"^^<http://www.w3.org/2001/"
+                   "\"http://qudt.org/vocab/unit/M\"^^<http://www.w3.org/2001/"
                    "XMLSchema#anyURI>)"),
       matchNaryWithChildrenMatchers(
           &makeDistWithUnitExpression,
@@ -375,8 +370,7 @@ TEST(SparqlParser, FunctionCall) {
           variableExpressionMatcher(Variable{"?b"}),
           matchLiteralExpression<ad_utility::triple_component::Literal>(
               ad_utility::triple_component::Literal::fromStringRepresentation(
-                  "\"http://qudt.org/vocab/unit/"
-                  "M\"^^<http://www.w3.org/2001/"
+                  "\"http://qudt.org/vocab/unit/M\"^^<http://www.w3.org/2001/"
                   "XMLSchema#anyURI>"))));
 
   // geof:distance with variable as unit in third argument
@@ -480,8 +474,7 @@ TEST(SparqlParser, FunctionCall) {
   expectFunctionCallFails(absl::StrCat(xsd, "date>(?varYear, ?varMonth)"));
   expectFunctionCallFails(absl::StrCat(xsd, "dateTime>(?varYear, ?varMonth)"));
 
-  // Unknown function with `geof:`, `math:`, `xsd:`, or
-  // `ql` prefix.
+  // Unknown function with `geof:`, `math:`, `xsd:`, or `ql` prefix.
   expectFunctionCallFails(absl::StrCat(geof, "nada>(?x)"));
   expectFunctionCallFails(absl::StrCat(math, "nada>(?x)"));
   expectFunctionCallFails(absl::StrCat(xsd, "nada>(?x)"));
@@ -491,9 +484,8 @@ TEST(SparqlParser, FunctionCall) {
   std::string prefixNexistepas = "<http://nexiste.pas/";
   expectFunctionCallFails(absl::StrCat(prefixNexistepas, "nada>(?x)"));
 
-  // Check that arbitrary nonexisting functions with a
-  // single argument silently return an
-  // `IdExpression(UNDEF)` in the syntax test mode.
+  // Check that arbitrary nonexisting functions with a single argument silently
+  // return an `IdExpression(UNDEF)` in the syntax test mode.
   auto cleanup = setRuntimeParameterForTest<"syntax-test-mode">(true);
   expectFunctionCall(
       absl::StrCat(prefixNexistepas, "nada>(?x)"),

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -1340,6 +1340,7 @@ TEST(SparqlExpression, geoSparqlExpressions) {
   auto checkDist = std::bind_front(testNaryExpression, &makeDistExpression);
   auto checkEnvelope = testUnaryExpression<&makeEnvelopeExpression>;
   auto checkGeometryType = testUnaryExpression<&makeGeometryTypeExpression>;
+  // TODO test minX,minY,maxX,maxY
 
   auto p = GeoPoint(26.8, 24.3);
   auto v = ValueId::makeFromGeoPoint(p);

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -1340,7 +1340,6 @@ TEST(SparqlExpression, geoSparqlExpressions) {
   auto checkDist = std::bind_front(testNaryExpression, &makeDistExpression);
   auto checkEnvelope = testUnaryExpression<&makeEnvelopeExpression>;
   auto checkGeometryType = testUnaryExpression<&makeGeometryTypeExpression>;
-  // TODO test minX,minY,maxX,maxY
 
   auto p = GeoPoint(26.8, 24.3);
   auto v = ValueId::makeFromGeoPoint(p);
@@ -1393,6 +1392,33 @@ TEST(SparqlExpression, geoSparqlExpressions) {
                           geoLit("BLABLIBLU(1 1, 2 2)")},
       IdOrLiteralOrIriVec{U, U, sfGeoType("Point"), sfGeoType("LineString"),
                           sfGeoType("Polygon"), U});
+
+  // Bounding coordinate expressions
+  using enum ad_utility::BoundingCoordinate;
+  auto checkMinX =
+      testUnaryExpression<&makeBoundingCoordinateExpression<MIN_X>>;
+  auto checkMinY =
+      testUnaryExpression<&makeBoundingCoordinateExpression<MIN_Y>>;
+  auto checkMaxX =
+      testUnaryExpression<&makeBoundingCoordinateExpression<MAX_X>>;
+  auto checkMaxY =
+      testUnaryExpression<&makeBoundingCoordinateExpression<MAX_Y>>;
+
+  const IdOrLiteralOrIriVec boundingCoordInputs{
+      U,
+      D(0.0),
+      v,  // POINT(24.3, 26.8)
+      geoLit("LINESTRING(2 8, 4 6)"),
+      geoLit("POLYGON((2 4, 4 4, 4 2, 2 2, 2 4))"),
+      lit("BLABLIBLU(1 1, 2 2)")
+      // TODO<ullingerc> Handle invalid geo literals gracefully. Then add
+      // geoLit("BLABLIBLU(1 1, 2 2)")
+  };
+  using IdVec = std::vector<ValueId>;
+  checkMinX(boundingCoordInputs, IdVec{U, U, D(24.3), D(2), D(2), U});
+  checkMinY(boundingCoordInputs, IdVec{U, U, D(26.8), D(6), D(2), U});
+  checkMaxX(boundingCoordInputs, IdVec{U, U, D(24.3), D(4), D(4), U});
+  checkMaxY(boundingCoordInputs, IdVec{U, U, D(26.8), D(8), D(4), U});
 }
 
 // ________________________________________________________________________________________


### PR DESCRIPTION
Add support for the `geof:minX`, `geof:minY`, `geof:maxX` and `geof:maxY` GeoSPARQL functions using the `GeometryInfo` class. If a precomputed bounding box is available, these coordinates will be extracted from it. Example query:
```sparql
PREFIX geo: <http://www.opengis.net/ont/geosparql#>
PREFIX geof: <http://www.opengis.net/def/function/geosparql/>
SELECT * {
  BIND("LINESTRING(2 4, 6 8)"^^geo:wktLiteral AS ?geometry)
  BIND (geof:minX(?geometry) AS ?minX) # Result: 2
  BIND (geof:minY(?geometry) AS ?minY) # Result: 4
  BIND (geof:maxX(?geometry) AS ?maxX) # Result: 6
  BIND (geof:maxY(?geometry) AS ?maxY) # Result: 8
}
```