### PR TITLE
Refactor `Union::computeResultLazily` to return range instead of gene…

### DIFF
--- a/src/engine/Union.h
+++ b/src/engine/Union.h
@@ -110,10 +110,10 @@ class Union : public Operation {
   IdTable transformToCorrectColumnFormat(
       IdTable idTable, const std::vector<ColumnIndex>& permutation) const;
 
-  // Create a generator that yields the `IdTable` for the left or right child
+  // Create a lazy result that yields the `IdTable` for the left or right child
   // one after another and apply a potential differing permutation to it. Write
   // the merged LocalVocab to the given `LocalVocab` object at the end.
-  Result::Generator computeResultLazily(
+  Result::LazyResult computeResultLazily(
       std::shared_ptr<const Result> result1,
       std::shared_ptr<const Result> result2) const;
 


### PR DESCRIPTION
Use lazy result instead of generators in Union lazy operation

Part of c++17 migration effort

Waiting for https://github.com/ad-freiburg/qlever/pull/2196 to be merged
