### PR TITLE
Remove `using std::vector` and explicitly write `std::vector` everywhere

### DIFF
--- a/src/engine/Bind.cpp
+++ b/src/engine/Bind.cpp
@@ -61,7 +61,7 @@ float Bind::getMultiplicity(size_t col) {
 std::string Bind::getDescriptor() const { return _bind.getDescriptor(); }
 
 // _____________________________________________________________________________
-[[nodiscard]] vector<ColumnIndex> Bind::resultSortedOn() const {
+[[nodiscard]] std::vector<ColumnIndex> Bind::resultSortedOn() const {
   // We always append the result column of the BIND at the end and this column
   // is not sorted, so the sequence of indices of the sorted columns do not
   // change.

--- a/src/engine/Bind.h
+++ b/src/engine/Bind.h
@@ -44,7 +44,7 @@ class Bind : public Operation {
   bool knownEmptyResult() override;
 
  protected:
-  [[nodiscard]] vector<ColumnIndex> resultSortedOn() const override;
+  [[nodiscard]] std::vector<ColumnIndex> resultSortedOn() const override;
 
  private:
   Result computeResult(bool requestLaziness) override;

--- a/src/engine/CartesianProductJoin.h
+++ b/src/engine/CartesianProductJoin.h
@@ -86,7 +86,7 @@ class CartesianProductJoin : public Operation {
   // columns from either the first or the last input, but it is questionable if
   // there would be any real benefit from this and it would only increase the
   // complexity of the query planning and required testing.
-  vector<ColumnIndex> resultSortedOn() const override { return {}; }
+  std::vector<ColumnIndex> resultSortedOn() const override { return {}; }
 
  private:
   //! Compute the result of the query-subtree rooted at this element..

--- a/src/engine/CountAvailablePredicates.cpp
+++ b/src/engine/CountAvailablePredicates.cpp
@@ -44,7 +44,7 @@ std::string CountAvailablePredicates::getDescriptor() const {
 size_t CountAvailablePredicates::getResultWidth() const { return 2; }
 
 // _____________________________________________________________________________
-vector<ColumnIndex> CountAvailablePredicates::resultSortedOn() const {
+std::vector<ColumnIndex> CountAvailablePredicates::resultSortedOn() const {
   // The result is not sorted on any column.
   return {};
 }

--- a/src/engine/CountAvailablePredicates.h
+++ b/src/engine/CountAvailablePredicates.h
@@ -50,7 +50,7 @@ class CountAvailablePredicates : public Operation {
   [[nodiscard]] std::vector<ColumnIndex> resultSortedOn() const override;
 
   std::vector<QueryExecutionTree*> getChildren() override {
-    using R = vector<QueryExecutionTree*>;
+    using R = std::vector<QueryExecutionTree*>;
     return subtree_ != nullptr ? R{subtree_.get()} : R{};
   }
 

--- a/src/engine/Describe.cpp
+++ b/src/engine/Describe.cpp
@@ -81,7 +81,7 @@ bool Describe::knownEmptyResult() { return false; }
 
 // The result cannot easily be sorted, as it involves recursive expanding of
 // graphs.
-vector<ColumnIndex> Describe::resultSortedOn() const { return {}; }
+std::vector<ColumnIndex> Describe::resultSortedOn() const { return {}; }
 
 // The result always has three variables `?subject`, `?predicate`, `?object`.
 //

--- a/src/engine/Describe.h
+++ b/src/engine/Describe.h
@@ -49,7 +49,7 @@ class Describe : public Operation {
 
  private:
   std::unique_ptr<Operation> cloneImpl() const override;
-  [[nodiscard]] vector<ColumnIndex> resultSortedOn() const override;
+  [[nodiscard]] std::vector<ColumnIndex> resultSortedOn() const override;
   Result computeResult(bool requestLaziness) override;
   VariableToColumnMap computeVariableToColumnMap() const override;
 

--- a/src/engine/ExistsJoin.cpp
+++ b/src/engine/ExistsJoin.cpp
@@ -64,7 +64,7 @@ size_t ExistsJoin::getResultWidth() const {
 }
 
 // ____________________________________________________________________________
-vector<ColumnIndex> ExistsJoin::resultSortedOn() const {
+std::vector<ColumnIndex> ExistsJoin::resultSortedOn() const {
   // We add one column to `left_`, but do not change the order of the rows.
   return left_->resultSortedOn();
 }

--- a/src/engine/ExistsJoin.h
+++ b/src/engine/ExistsJoin.h
@@ -60,7 +60,7 @@ class ExistsJoin : public Operation {
 
   size_t getResultWidth() const override;
 
-  vector<ColumnIndex> resultSortedOn() const override;
+  std::vector<ColumnIndex> resultSortedOn() const override;
 
   bool knownEmptyResult() override { return left_->knownEmptyResult(); }
 
@@ -72,7 +72,7 @@ class ExistsJoin : public Operation {
  public:
   size_t getCostEstimate() override;
 
-  vector<QueryExecutionTree*> getChildren() override {
+  std::vector<QueryExecutionTree*> getChildren() override {
     return {left_.get(), right_.get()};
   }
 

--- a/src/engine/GroupByImpl.cpp
+++ b/src/engine/GroupByImpl.cpp
@@ -111,7 +111,7 @@ size_t GroupByImpl::getResultWidth() const {
   return getInternallyVisibleVariableColumns().size();
 }
 
-vector<ColumnIndex> GroupByImpl::resultSortedOn() const {
+std::vector<ColumnIndex> GroupByImpl::resultSortedOn() const {
   auto varCols = getInternallyVisibleVariableColumns();
   vector<ColumnIndex> sortedOn;
   sortedOn.reserve(_groupByVariables.size());
@@ -121,7 +121,7 @@ vector<ColumnIndex> GroupByImpl::resultSortedOn() const {
   return sortedOn;
 }
 
-vector<ColumnIndex> GroupByImpl::computeSortColumns(
+std::vector<ColumnIndex> GroupByImpl::computeSortColumns(
     const QueryExecutionTree* subtree) {
   vector<ColumnIndex> cols;
   // If we have an implicit GROUP BY, where the entire input is a single group,

--- a/src/engine/HasPredicateScan.cpp
+++ b/src/engine/HasPredicateScan.cpp
@@ -141,7 +141,7 @@ size_t HasPredicateScan::getResultWidth() const {
 }
 
 // ___________________________________________________________________________
-vector<ColumnIndex> HasPredicateScan::resultSortedOn() const {
+std::vector<ColumnIndex> HasPredicateScan::resultSortedOn() const {
   checkType(type_);
   switch (type_) {
     case ScanType::FREE_S:

--- a/src/engine/HasPredicateScan.h
+++ b/src/engine/HasPredicateScan.h
@@ -70,7 +70,7 @@ class HasPredicateScan : public Operation {
 
   [[nodiscard]] size_t getResultWidth() const override;
 
-  [[nodiscard]] vector<ColumnIndex> resultSortedOn() const override;
+  [[nodiscard]] std::vector<ColumnIndex> resultSortedOn() const override;
 
   bool knownEmptyResult() override;
 
@@ -87,7 +87,7 @@ class HasPredicateScan : public Operation {
 
   [[nodiscard]] const TripleComponent& getObject() const;
 
-  vector<QueryExecutionTree*> getChildren() override {
+  std::vector<QueryExecutionTree*> getChildren() override {
     if (subtree_) {
       return {std::addressof(subtree())};
     } else {

--- a/src/engine/IndexScan.cpp
+++ b/src/engine/IndexScan.cpp
@@ -141,7 +141,7 @@ size_t IndexScan::getResultWidth() const {
 }
 
 // _____________________________________________________________________________
-vector<ColumnIndex> IndexScan::resultSortedOn() const {
+std::vector<ColumnIndex> IndexScan::resultSortedOn() const {
   std::vector<ColumnIndex> result;
   for (auto i : ad_utility::integerRange(ColumnIndex{numVariables_})) {
     result.push_back(i);

--- a/src/engine/Join.cpp
+++ b/src/engine/Join.cpp
@@ -188,7 +188,7 @@ size_t Join::getResultWidth() const {
 }
 
 // _____________________________________________________________________________
-vector<ColumnIndex> Join::resultSortedOn() const { return {_leftJoinCol}; }
+std::vector<ColumnIndex> Join::resultSortedOn() const { return {_leftJoinCol}; }
 
 // _____________________________________________________________________________
 float Join::getMultiplicity(size_t col) {

--- a/src/engine/Join.h
+++ b/src/engine/Join.h
@@ -28,7 +28,7 @@ class Join : public Operation {
   bool _sizeEstimateComputed;
   size_t _sizeEstimate;
 
-  vector<float> _multiplicities;
+  std::vector<float> _multiplicities;
 
  public:
   // `allowSwappingChildrenOnlyForTesting` should only ever be changed by tests.
@@ -42,7 +42,7 @@ class Join : public Operation {
 
   virtual size_t getResultWidth() const override;
 
-  virtual vector<ColumnIndex> resultSortedOn() const override;
+  virtual std::vector<ColumnIndex> resultSortedOn() const override;
 
  private:
   uint64_t getSizeEstimateBeforeLimit() override {
@@ -64,7 +64,7 @@ class Join : public Operation {
 
   float getMultiplicity(size_t col) override;
 
-  vector<QueryExecutionTree*> getChildren() override {
+  std::vector<QueryExecutionTree*> getChildren() override {
     return {_left.get(), _right.get()};
   }
 

--- a/src/engine/Load.cpp
+++ b/src/engine/Load.cpp
@@ -65,7 +65,7 @@ std::unique_ptr<Operation> Load::cloneImpl() const {
 }
 
 // _____________________________________________________________________________
-vector<ColumnIndex> Load::resultSortedOn() const { return {}; }
+std::vector<ColumnIndex> Load::resultSortedOn() const { return {}; }
 
 // _____________________________________________________________________________
 Result Load::computeResult(bool requestLaziness) {

--- a/src/engine/Load.h
+++ b/src/engine/Load.h
@@ -68,7 +68,7 @@ class Load final : public Operation {
   std::unique_ptr<Operation> cloneImpl() const override;
 
  protected:
-  vector<ColumnIndex> resultSortedOn() const override;
+  std::vector<ColumnIndex> resultSortedOn() const override;
 
  private:
   // Error handling around `computeResultImpl`.

--- a/src/engine/Minus.cpp
+++ b/src/engine/Minus.cpp
@@ -71,7 +71,7 @@ VariableToColumnMap Minus::computeVariableToColumnMap() const {
 size_t Minus::getResultWidth() const { return _left->getResultWidth(); }
 
 // _____________________________________________________________________________
-vector<ColumnIndex> Minus::resultSortedOn() const {
+std::vector<ColumnIndex> Minus::resultSortedOn() const {
   return _left->resultSortedOn();
 }
 

--- a/src/engine/Minus.h
+++ b/src/engine/Minus.h
@@ -16,7 +16,7 @@ class Minus : public Operation {
   std::shared_ptr<QueryExecutionTree> _left;
   std::shared_ptr<QueryExecutionTree> _right;
 
-  vector<float> _multiplicities;
+  std::vector<float> _multiplicities;
   std::vector<std::array<ColumnIndex, 2>> _matchedColumns;
 
   enum class RowComparison { EQUAL, LEFT_SMALLER, RIGHT_SMALLER };
@@ -33,7 +33,7 @@ class Minus : public Operation {
 
   size_t getResultWidth() const override;
 
-  vector<ColumnIndex> resultSortedOn() const override;
+  std::vector<ColumnIndex> resultSortedOn() const override;
 
   bool knownEmptyResult() override { return _left->knownEmptyResult(); }
 
@@ -57,7 +57,7 @@ class Minus : public Operation {
  public:
   size_t getCostEstimate() override;
 
-  vector<QueryExecutionTree*> getChildren() override {
+  std::vector<QueryExecutionTree*> getChildren() override {
     return {_left.get(), _right.get()};
   }
 
@@ -72,7 +72,7 @@ class Minus : public Operation {
    **/
   IdTable computeMinus(
       const IdTable& a, const IdTable& b,
-      const vector<std::array<ColumnIndex, 2>>& matchedColumns) const;
+      const std::vector<std::array<ColumnIndex, 2>>& matchedColumns) const;
 
  private:
   std::unique_ptr<Operation> cloneImpl() const override;

--- a/src/engine/MultiColumnJoin.cpp
+++ b/src/engine/MultiColumnJoin.cpp
@@ -111,7 +111,7 @@ size_t MultiColumnJoin::getResultWidth() const {
 }
 
 // _____________________________________________________________________________
-vector<ColumnIndex> MultiColumnJoin::resultSortedOn() const {
+std::vector<ColumnIndex> MultiColumnJoin::resultSortedOn() const {
   std::vector<ColumnIndex> sortedOn;
   // The result is sorted on all join columns from the left subtree.
   for (const auto& a : _joinColumns) {

--- a/src/engine/MultiColumnJoin.h
+++ b/src/engine/MultiColumnJoin.h
@@ -18,7 +18,7 @@ class MultiColumnJoin : public Operation {
 
   std::vector<std::array<ColumnIndex, 2>> _joinColumns;
 
-  vector<float> _multiplicities;
+  std::vector<float> _multiplicities;
   size_t _sizeEstimate;
   bool _multiplicitiesComputed = false;
 
@@ -37,7 +37,7 @@ class MultiColumnJoin : public Operation {
 
   size_t getResultWidth() const override;
 
-  vector<ColumnIndex> resultSortedOn() const override;
+  std::vector<ColumnIndex> resultSortedOn() const override;
 
   bool knownEmptyResult() override {
     return _left->knownEmptyResult() || _right->knownEmptyResult();
@@ -51,7 +51,7 @@ class MultiColumnJoin : public Operation {
  public:
   size_t getCostEstimate() override;
 
-  vector<QueryExecutionTree*> getChildren() override {
+  std::vector<QueryExecutionTree*> getChildren() override {
     return {_left.get(), _right.get()};
   }
 

--- a/src/engine/Operation.cpp
+++ b/src/engine/Operation.cpp
@@ -67,8 +67,8 @@ void Operation::forAllDescendants(F f) const {
 }
 
 // _____________________________________________________________________________
-vector<std::string> Operation::collectWarnings() const {
-  vector<std::string> res{*getWarnings().rlock()};
+std::vector<std::string> Operation::collectWarnings() const {
+  std::vector<std::string> res{*getWarnings().rlock()};
   for (auto child : getChildren()) {
     if (!child) {
       continue;
@@ -626,7 +626,7 @@ std::optional<Variable> Operation::getPrimarySortKeyVariable() const {
 }
 
 // ___________________________________________________________________________
-const vector<ColumnIndex>& Operation::getResultSortedOn() const {
+const std::vector<ColumnIndex>& Operation::getResultSortedOn() const {
   // TODO<joka921> refactor this without a mutex (for details see the
   // `getVariableColumns` method for details.
   std::lock_guard l{_resultSortedColumnsMutex};
@@ -707,7 +707,7 @@ std::unique_ptr<Operation> Operation::clone() const {
 }
 
 // _____________________________________________________________________________
-bool Operation::isSortedBy(const vector<ColumnIndex>& sortColumns) const {
+bool Operation::isSortedBy(const std::vector<ColumnIndex>& sortColumns) const {
   auto inputSortedOn = resultSortedOn();
   if (sortColumns.size() > inputSortedOn.size()) {
     return false;
@@ -722,7 +722,7 @@ bool Operation::isSortedBy(const vector<ColumnIndex>& sortColumns) const {
 
 // _____________________________________________________________________________
 std::optional<std::shared_ptr<QueryExecutionTree>> Operation::makeSortedTree(
-    const vector<ColumnIndex>& sortColumns) const {
+    const std::vector<ColumnIndex>& sortColumns) const {
   AD_CONTRACT_CHECK(!isSortedBy(sortColumns));
   return std::nullopt;
 }

--- a/src/engine/OptionalJoin.cpp
+++ b/src/engine/OptionalJoin.cpp
@@ -154,7 +154,7 @@ size_t OptionalJoin::getResultWidth() const {
 }
 
 // _____________________________________________________________________________
-vector<ColumnIndex> OptionalJoin::resultSortedOn() const {
+std::vector<ColumnIndex> OptionalJoin::resultSortedOn() const {
   std::vector<ColumnIndex> sortedOn;
   // The result is sorted on all join columns from the left subtree.
   for (const auto& [joinColumnLeft, joinColumnRight] : _joinColumns) {

--- a/src/engine/OptionalJoin.h
+++ b/src/engine/OptionalJoin.h
@@ -44,7 +44,7 @@ class OptionalJoin : public Operation {
 
   size_t getResultWidth() const override;
 
-  vector<ColumnIndex> resultSortedOn() const override;
+  std::vector<ColumnIndex> resultSortedOn() const override;
 
   bool knownEmptyResult() override { return _left->knownEmptyResult(); }
 
@@ -56,7 +56,7 @@ class OptionalJoin : public Operation {
  public:
   size_t getCostEstimate() override;
 
-  vector<QueryExecutionTree*> getChildren() override {
+  std::vector<QueryExecutionTree*> getChildren() override {
     return {_left.get(), _right.get()};
   }
 

--- a/src/engine/OrderBy.cpp
+++ b/src/engine/OrderBy.cpp
@@ -20,7 +20,7 @@ size_t OrderBy::getResultWidth() const { return subtree_->getResultWidth(); }
 // _____________________________________________________________________________
 OrderBy::OrderBy(QueryExecutionContext* qec,
                  std::shared_ptr<QueryExecutionTree> subtree,
-                 vector<std::pair<ColumnIndex, bool>> sortIndices)
+                 std::vector<std::pair<ColumnIndex, bool>> sortIndices)
     : Operation{qec},
       subtree_{std::move(subtree)},
       sortIndices_{std::move(sortIndices)} {

--- a/src/engine/OrderBy.h
+++ b/src/engine/OrderBy.h
@@ -75,7 +75,7 @@ class OrderBy : public Operation {
 
   size_t getResultWidth() const override;
 
-  vector<QueryExecutionTree*> getChildren() override {
+  std::vector<QueryExecutionTree*> getChildren() override {
     return {subtree_.get()};
   }
 

--- a/src/engine/PathSearch.cpp
+++ b/src/engine/PathSearch.cpp
@@ -203,7 +203,7 @@ bool PathSearch::knownEmptyResult() {
 };
 
 // _____________________________________________________________________________
-vector<ColumnIndex> PathSearch::resultSortedOn() const { return {}; };
+std::vector<ColumnIndex> PathSearch::resultSortedOn() const { return {}; };
 
 // _____________________________________________________________________________
 void PathSearch::bindSourceSide(std::shared_ptr<QueryExecutionTree> sourcesOp,

--- a/src/engine/QueryExecutionTree.cpp
+++ b/src/engine/QueryExecutionTree.cpp
@@ -155,7 +155,7 @@ void QueryExecutionTree::readFromCache() {
 std::shared_ptr<QueryExecutionTree>
 QueryExecutionTree::createSortedTreeAnyPermutation(
     std::shared_ptr<QueryExecutionTree> qet,
-    const vector<ColumnIndex>& sortColumns) {
+    const std::vector<ColumnIndex>& sortColumns) {
   const auto& sortedOn = qet->resultSortedOn();
   ql::span relevantSortedCols{sortedOn.begin(),
                               std::min(sortedOn.size(), sortColumns.size())};
@@ -169,7 +169,7 @@ QueryExecutionTree::createSortedTreeAnyPermutation(
 // ________________________________________________________________________________________________________________
 std::shared_ptr<QueryExecutionTree> QueryExecutionTree::createSortedTree(
     std::shared_ptr<QueryExecutionTree> qet,
-    const vector<ColumnIndex>& sortColumns) {
+    const std::vector<ColumnIndex>& sortColumns) {
   const auto& rootOperation = qet->getRootOperation();
   if (rootOperation->isSortedBy(sortColumns)) {
     return qet;
@@ -209,7 +209,7 @@ std::pair<std::shared_ptr<QueryExecutionTree>,
 QueryExecutionTree::createSortedTrees(
     std::shared_ptr<QueryExecutionTree> qetA,
     std::shared_ptr<QueryExecutionTree> qetB,
-    const vector<std::array<ColumnIndex, 2>>& sortColumns) {
+    const std::vector<std::array<ColumnIndex, 2>>& sortColumns) {
   std::vector<ColumnIndex> sortColumnsA, sortColumnsB;
   for (auto [sortColumnA, sortColumnB] : sortColumns) {
     sortColumnsA.push_back(sortColumnA);

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -306,7 +306,7 @@ std::vector<SubtreePlan> QueryPlanner::optimize(
 }
 
 // _____________________________________________________________________________
-vector<SubtreePlan> QueryPlanner::getDistinctRow(
+std::vector<SubtreePlan> QueryPlanner::getDistinctRow(
     const p::SelectClause& selectClause,
     const vector<vector<SubtreePlan>>& dpTab) const {
   const vector<SubtreePlan>& previous = dpTab[dpTab.size() - 1];
@@ -336,7 +336,7 @@ vector<SubtreePlan> QueryPlanner::getDistinctRow(
 }
 
 // _____________________________________________________________________________
-vector<SubtreePlan> QueryPlanner::getPatternTrickRow(
+std::vector<SubtreePlan> QueryPlanner::getPatternTrickRow(
     const p::SelectClause& selectClause,
     const vector<vector<SubtreePlan>>& dpTab,
     const checkUsePatternTrick::PatternTrickTuple& patternTrickTuple) {
@@ -367,7 +367,7 @@ vector<SubtreePlan> QueryPlanner::getPatternTrickRow(
 }
 
 // _____________________________________________________________________________
-vector<SubtreePlan> QueryPlanner::getHavingRow(
+std::vector<SubtreePlan> QueryPlanner::getHavingRow(
     const ParsedQuery& pq, const vector<vector<SubtreePlan>>& dpTab) const {
   const vector<SubtreePlan>& previous = dpTab[dpTab.size() - 1];
   vector<SubtreePlan> added;
@@ -399,7 +399,7 @@ std::vector<SubtreePlan> QueryPlanner::applyPostQueryValues(
 }
 
 // _____________________________________________________________________________
-vector<SubtreePlan> QueryPlanner::getGroupByRow(
+std::vector<SubtreePlan> QueryPlanner::getGroupByRow(
     const ParsedQuery& pq, const vector<vector<SubtreePlan>>& dpTab) const {
   const vector<SubtreePlan>& previous = dpTab[dpTab.size() - 1];
   vector<SubtreePlan> added;
@@ -432,7 +432,7 @@ vector<SubtreePlan> QueryPlanner::getGroupByRow(
 }
 
 // _____________________________________________________________________________
-vector<SubtreePlan> QueryPlanner::getOrderByRow(
+std::vector<SubtreePlan> QueryPlanner::getOrderByRow(
     const ParsedQuery& pq, const vector<vector<SubtreePlan>>& dpTab) const {
   const vector<SubtreePlan>& previous = dpTab[dpTab.size() - 1];
   vector<SubtreePlan> added;
@@ -1183,7 +1183,7 @@ SubtreePlan QueryPlanner::getTextLeafPlan(
 }
 
 // _____________________________________________________________________________
-vector<SubtreePlan> QueryPlanner::merge(
+std::vector<SubtreePlan> QueryPlanner::merge(
     const vector<SubtreePlan>& a, const vector<SubtreePlan>& b,
     const QueryPlanner::TripleGraph& tg) const {
   // TODO: Add the following features:
@@ -1709,7 +1709,7 @@ QueryPlanner::FiltersAndOptionalSubstitutes QueryPlanner::seedFilterSubstitutes(
 };
 
 // _____________________________________________________________________________
-vector<vector<SubtreePlan>> QueryPlanner::fillDpTab(
+std::vector<std::vector<SubtreePlan>> QueryPlanner::fillDpTab(
     const QueryPlanner::TripleGraph& tg, vector<SparqlFilter> filters,
     TextLimitMap& textLimits, const vector<vector<SubtreePlan>>& children) {
   auto [initialPlans, additionalFilters] =
@@ -1817,7 +1817,7 @@ bool QueryPlanner::TripleGraph::isTextNode(size_t i) const {
 }
 
 // _____________________________________________________________________________
-vector<std::pair<QueryPlanner::TripleGraph, vector<SparqlFilter>>>
+std::vector<std::pair<QueryPlanner::TripleGraph, std::vector<SparqlFilter>>>
 QueryPlanner::TripleGraph::splitAtContextVars(
     const vector<SparqlFilter>& origFilters,
     ad_utility::HashMap<std::string, vector<size_t>>& contextVarToTextNodes)
@@ -1896,7 +1896,7 @@ QueryPlanner::TripleGraph::splitAtContextVars(
 }
 
 // _____________________________________________________________________________
-vector<size_t> QueryPlanner::TripleGraph::bfsLeaveOut(
+std::vector<size_t> QueryPlanner::TripleGraph::bfsLeaveOut(
     size_t startNode, ad_utility::HashSet<size_t> leaveOut) const {
   vector<size_t> res;
   ad_utility::HashSet<size_t> visited;
@@ -1919,7 +1919,7 @@ vector<size_t> QueryPlanner::TripleGraph::bfsLeaveOut(
 }
 
 // _____________________________________________________________________________
-vector<SparqlFilter> QueryPlanner::TripleGraph::pickFilters(
+std::vector<SparqlFilter> QueryPlanner::TripleGraph::pickFilters(
     const vector<SparqlFilter>& origFilters,
     const vector<size_t>& nodes) const {
   vector<SparqlFilter> ret;

--- a/src/engine/Service.h
+++ b/src/engine/Service.h
@@ -83,7 +83,7 @@ class Service : public Operation {
   bool knownEmptyResult() override { return false; }
 
   // A SERVICE clause has no children.
-  vector<QueryExecutionTree*> getChildren() override { return {}; }
+  std::vector<QueryExecutionTree*> getChildren() override { return {}; }
 
   // Convert the given binding to TripleComponent.
   TripleComponent bindingToTripleComponent(

--- a/src/engine/Sort.cpp
+++ b/src/engine/Sort.cpp
@@ -77,7 +77,7 @@ Result Sort::computeResult([[maybe_unused]] bool requestLaziness) {
 
 // _____________________________________________________________________________
 std::optional<std::shared_ptr<QueryExecutionTree>> Sort::makeSortedTree(
-    const vector<ColumnIndex>& sortColumns) const {
+    const std::vector<ColumnIndex>& sortColumns) const {
   AD_CONTRACT_CHECK(!isSortedBy(sortColumns));
   AD_LOG_DEBUG
       << "Tried to re-sort a subtree that is already sorted by `Sort` with a "

--- a/src/engine/Sort.h
+++ b/src/engine/Sort.h
@@ -29,7 +29,7 @@ class Sort : public Operation {
  public:
   virtual std::string getDescriptor() const override;
 
-  virtual vector<ColumnIndex> resultSortedOn() const override {
+  virtual std::vector<ColumnIndex> resultSortedOn() const override {
     return sortColumnIndices_;
   }
 
@@ -61,12 +61,12 @@ class Sort : public Operation {
 
   [[nodiscard]] size_t getResultWidth() const override;
 
-  vector<QueryExecutionTree*> getChildren() override {
+  std::vector<QueryExecutionTree*> getChildren() override {
     return {subtree_.get()};
   }
 
   std::optional<std::shared_ptr<QueryExecutionTree>> makeSortedTree(
-      const vector<ColumnIndex>& sortColumns) const override;
+      const std::vector<ColumnIndex>& sortColumns) const override;
 
  private:
   std::unique_ptr<Operation> cloneImpl() const override;

--- a/src/engine/SpatialJoin.cpp
+++ b/src/engine/SpatialJoin.cpp
@@ -355,7 +355,7 @@ bool SpatialJoin::knownEmptyResult() {
 }
 
 // ____________________________________________________________________________
-vector<ColumnIndex> SpatialJoin::resultSortedOn() const {
+std::vector<ColumnIndex> SpatialJoin::resultSortedOn() const {
   // the baseline (with O(n^2) runtime) can have some sorted columns, but as
   // the "true" computeResult method will use bounding boxes, which can't
   // guarantee that a sorted column stays sorted, this will return no sorted

--- a/src/engine/TextIndexScanForEntity.cpp
+++ b/src/engine/TextIndexScanForEntity.cpp
@@ -123,7 +123,7 @@ bool TextIndexScanForEntity::knownEmptyResult() {
 }
 
 // _____________________________________________________________________________
-vector<ColumnIndex> TextIndexScanForEntity::resultSortedOn() const {
+std::vector<ColumnIndex> TextIndexScanForEntity::resultSortedOn() const {
   return {ColumnIndex(0)};
 }
 

--- a/src/engine/TextIndexScanForEntity.h
+++ b/src/engine/TextIndexScanForEntity.h
@@ -58,7 +58,7 @@ class TextIndexScanForEntity : public Operation {
 
   bool knownEmptyResult() override;
 
-  vector<ColumnIndex> resultSortedOn() const override;
+  std::vector<ColumnIndex> resultSortedOn() const override;
 
   VariableToColumnMap computeVariableToColumnMap() const override;
 
@@ -76,7 +76,7 @@ class TextIndexScanForEntity : public Operation {
 
   Result computeResult([[maybe_unused]] bool requestLaziness) override;
 
-  vector<QueryExecutionTree*> getChildren() override { return {}; }
+  std::vector<QueryExecutionTree*> getChildren() override { return {}; }
 
   void setVariableToColumnMap();
 };

--- a/src/engine/TextIndexScanForWord.cpp
+++ b/src/engine/TextIndexScanForWord.cpp
@@ -100,7 +100,7 @@ uint64_t TextIndexScanForWord::getSizeEstimateBeforeLimit() {
 }
 
 // _____________________________________________________________________________
-vector<ColumnIndex> TextIndexScanForWord::resultSortedOn() const {
+std::vector<ColumnIndex> TextIndexScanForWord::resultSortedOn() const {
   return {ColumnIndex(0)};
 }
 

--- a/src/engine/TextIndexScanForWord.h
+++ b/src/engine/TextIndexScanForWord.h
@@ -43,7 +43,7 @@ class TextIndexScanForWord : public Operation {
 
   bool knownEmptyResult() override { return getSizeEstimateBeforeLimit() == 0; }
 
-  vector<ColumnIndex> resultSortedOn() const override;
+  std::vector<ColumnIndex> resultSortedOn() const override;
 
   VariableToColumnMap computeVariableToColumnMap() const override;
 
@@ -56,7 +56,7 @@ class TextIndexScanForWord : public Operation {
   // the text variable and the completed word (if it was prefixed)
   Result computeResult([[maybe_unused]] bool requestLaziness) override;
 
-  vector<QueryExecutionTree*> getChildren() override { return {}; }
+  std::vector<QueryExecutionTree*> getChildren() override { return {}; }
 
   void setVariableToColumnMap();
 };

--- a/src/engine/TextLimit.cpp
+++ b/src/engine/TextLimit.cpp
@@ -8,8 +8,8 @@
 TextLimit::TextLimit(QueryExecutionContext* qec, const size_t limit,
                      std::shared_ptr<QueryExecutionTree> child,
                      const ColumnIndex& textRecordColumn,
-                     const vector<ColumnIndex>& entityColumns,
-                     const vector<ColumnIndex>& scoreColumns)
+                     const std::vector<ColumnIndex>& entityColumns,
+                     const std::vector<ColumnIndex>& scoreColumns)
     : Operation(qec),
       limit_(limit),
       child_(std::move(child)),
@@ -141,8 +141,8 @@ Variable TextLimit::getTextRecordVariable() const {
 }
 
 // _____________________________________________________________________________
-vector<Variable> TextLimit::getEntityVariables() const {
-  vector<Variable> entityVars;
+std::vector<Variable> TextLimit::getEntityVariables() const {
+  std::vector<Variable> entityVars;
   for (auto col : entityColumns_) {
     entityVars.push_back(child_->getVariableAndInfoByColumnIndex(col).first);
   }
@@ -150,8 +150,8 @@ vector<Variable> TextLimit::getEntityVariables() const {
 }
 
 // _____________________________________________________________________________
-vector<Variable> TextLimit::getScoreVariables() const {
-  vector<Variable> scoreVars;
+std::vector<Variable> TextLimit::getScoreVariables() const {
+  std::vector<Variable> scoreVars;
   for (auto col : scoreColumns_) {
     scoreVars.push_back(child_->getVariableAndInfoByColumnIndex(col).first);
   }
@@ -164,7 +164,9 @@ uint64_t TextLimit::getSizeEstimateBeforeLimit() {
 }
 
 // _____________________________________________________________________________
-vector<ColumnIndex> TextLimit::resultSortedOn() const { return entityColumns_; }
+std::vector<ColumnIndex> TextLimit::resultSortedOn() const {
+  return entityColumns_;
+}
 
 // _____________________________________________________________________________
 std::string TextLimit::getDescriptor() const {

--- a/src/engine/TextLimit.h
+++ b/src/engine/TextLimit.h
@@ -20,15 +20,15 @@ class TextLimit : public Operation {
   const size_t limit_;
   std::shared_ptr<QueryExecutionTree> child_;
   const ColumnIndex textRecordColumn_;
-  const vector<ColumnIndex> entityColumns_;
-  const vector<ColumnIndex> scoreColumns_;
+  const std::vector<ColumnIndex> entityColumns_;
+  const std::vector<ColumnIndex> scoreColumns_;
 
  public:
   TextLimit(QueryExecutionContext* qec, const size_t limit,
             std::shared_ptr<QueryExecutionTree> child,
             const ColumnIndex& textRecordColumn,
-            const vector<ColumnIndex>& entityColumns,
-            const vector<ColumnIndex>& scoreColumns);
+            const std::vector<ColumnIndex>& entityColumns,
+            const std::vector<ColumnIndex>& scoreColumns);
 
   ~TextLimit() override = default;
 
@@ -44,9 +44,9 @@ class TextLimit : public Operation {
 
   Variable getTextRecordVariable() const;
 
-  vector<Variable> getEntityVariables() const;
+  std::vector<Variable> getEntityVariables() const;
 
-  vector<Variable> getScoreVariables() const;
+  std::vector<Variable> getScoreVariables() const;
 
   uint64_t getSizeEstimateBeforeLimit() override;
 
@@ -58,7 +58,7 @@ class TextLimit : public Operation {
     return limit_ == 0 || child_->knownEmptyResult();
   }
 
-  vector<ColumnIndex> resultSortedOn() const override;
+  std::vector<ColumnIndex> resultSortedOn() const override;
 
   VariableToColumnMap computeVariableToColumnMap() const override;
 
@@ -67,7 +67,7 @@ class TextLimit : public Operation {
 
   Result computeResult([[maybe_unused]] bool requestLaziness) override;
 
-  vector<QueryExecutionTree*> getChildren() override { return {child_.get()}; }
+  std::vector<QueryExecutionTree*> getChildren() override { return {child_.get()}; }
 };
 
 #endif  // QLEVER_SRC_ENGINE_TEXTLIMIT_H

--- a/src/engine/TextLimit.h
+++ b/src/engine/TextLimit.h
@@ -67,7 +67,9 @@ class TextLimit : public Operation {
 
   Result computeResult([[maybe_unused]] bool requestLaziness) override;
 
-  std::vector<QueryExecutionTree*> getChildren() override { return {child_.get()}; }
+  std::vector<QueryExecutionTree*> getChildren() override {
+    return {child_.get()};
+  }
 };
 
 #endif  // QLEVER_SRC_ENGINE_TEXTLIMIT_H

--- a/src/engine/TransitivePathBase.cpp
+++ b/src/engine/TransitivePathBase.cpp
@@ -286,7 +286,7 @@ std::string TransitivePathBase::getDescriptor() const {
 size_t TransitivePathBase::getResultWidth() const { return resultWidth_; }
 
 // _____________________________________________________________________________
-vector<ColumnIndex> TransitivePathBase::resultSortedOn() const {
+std::vector<ColumnIndex> TransitivePathBase::resultSortedOn() const {
   if (lhs_.isSortedOnInputCol()) {
     return {0};
   }
@@ -393,7 +393,7 @@ std::shared_ptr<TransitivePathBase> TransitivePathBase::makeTransitivePath(
 }
 
 // _____________________________________________________________________________
-vector<QueryExecutionTree*> TransitivePathBase::getChildren() {
+std::vector<QueryExecutionTree*> TransitivePathBase::getChildren() {
   std::vector<QueryExecutionTree*> res;
   auto addChildren = [](std::vector<QueryExecutionTree*>& res,
                         TransitivePathSide side) {

--- a/src/engine/TransitivePathBase.h
+++ b/src/engine/TransitivePathBase.h
@@ -232,7 +232,7 @@ class TransitivePathBase : public Operation {
 
   size_t getResultWidth() const override;
 
-  vector<ColumnIndex> resultSortedOn() const override;
+  std::vector<ColumnIndex> resultSortedOn() const override;
 
   bool knownEmptyResult() override;
 
@@ -319,7 +319,7 @@ class TransitivePathBase : public Operation {
       TransitivePathSide leftSide, TransitivePathSide rightSide, size_t minDist,
       size_t maxDist, Graphs activeGraphs = {});
 
-  vector<QueryExecutionTree*> getChildren() override;
+  std::vector<QueryExecutionTree*> getChildren() override;
 
   VariableToColumnMap computeVariableToColumnMap() const override;
 

--- a/src/engine/Union.cpp
+++ b/src/engine/Union.cpp
@@ -61,7 +61,7 @@ Union::Union(QueryExecutionContext* qec,
 
   if (!targetOrder_.empty()) {
     auto computeSortOrder = [this](bool left) {
-      vector<ColumnIndex> specificSortOrder;
+      std::vector<ColumnIndex> specificSortOrder;
       for (ColumnIndex index : targetOrder_) {
         ColumnIndex realIndex = _columnOrigins.at(index).at(!left);
         if (realIndex != NO_COLUMN) {
@@ -115,7 +115,7 @@ size_t Union::getResultWidth() const {
   return _columnOrigins.size();
 }
 
-vector<ColumnIndex> Union::resultSortedOn() const { return targetOrder_; }
+std::vector<ColumnIndex> Union::resultSortedOn() const { return targetOrder_; }
 
 // _____________________________________________________________________________
 VariableToColumnMap Union::computeVariableToColumnMap() const {
@@ -365,7 +365,7 @@ std::unique_ptr<Operation> Union::cloneImpl() const {
 
 // _____________________________________________________________________________
 std::optional<std::shared_ptr<QueryExecutionTree>> Union::makeSortedTree(
-    const vector<ColumnIndex>& sortColumns) const {
+    const std::vector<ColumnIndex>& sortColumns) const {
   AD_CONTRACT_CHECK(!isSortedBy(sortColumns));
   return ad_utility::makeExecutionTree<Union>(
       _executionContext, _subtrees.at(0), _subtrees.at(1), sortColumns);

--- a/src/engine/Union.h
+++ b/src/engine/Union.h
@@ -43,7 +43,7 @@ class Union : public Operation {
 
   virtual size_t getResultWidth() const override;
 
-  virtual vector<ColumnIndex> resultSortedOn() const override;
+  virtual std::vector<ColumnIndex> resultSortedOn() const override;
 
   virtual bool knownEmptyResult() override;
 
@@ -64,7 +64,7 @@ class Union : public Operation {
       const IdTable& left, const IdTable& right,
       const std::vector<std::array<size_t, 2>>& columnOrigins) const;
 
-  vector<QueryExecutionTree*> getChildren() override {
+  std::vector<QueryExecutionTree*> getChildren() override {
     return {_subtrees[0].get(), _subtrees[1].get()};
   }
 
@@ -74,7 +74,7 @@ class Union : public Operation {
   // sorted properly then it is way cheaper to sort the other child and then
   // merge the two sorted results.
   std::optional<std::shared_ptr<QueryExecutionTree>> makeSortedTree(
-      const vector<ColumnIndex>& sortColumns) const override;
+      const std::vector<ColumnIndex>& sortColumns) const override;
 
   // Provide access the the left child of this union.
   const std::shared_ptr<QueryExecutionTree>& leftChild() const {

--- a/src/engine/Values.cpp
+++ b/src/engine/Values.cpp
@@ -40,7 +40,7 @@ size_t Values::getResultWidth() const {
 }
 
 // ____________________________________________________________________________
-vector<ColumnIndex> Values::resultSortedOn() const { return {}; }
+std::vector<ColumnIndex> Values::resultSortedOn() const { return {}; }
 
 // ____________________________________________________________________________
 VariableToColumnMap Values::computeVariableToColumnMap() const {

--- a/src/engine/Values.h
+++ b/src/engine/Values.h
@@ -31,7 +31,7 @@ class Values : public Operation {
 
   virtual size_t getResultWidth() const override;
 
-  virtual vector<ColumnIndex> resultSortedOn() const override;
+  virtual std::vector<ColumnIndex> resultSortedOn() const override;
 
   virtual bool knownEmptyResult() override {
     return parsedValues_._variables.empty() || parsedValues_._values.empty();
@@ -45,7 +45,7 @@ class Values : public Operation {
  public:
   virtual size_t getCostEstimate() override;
 
-  vector<QueryExecutionTree*> getChildren() override { return {}; }
+  std::vector<QueryExecutionTree*> getChildren() override { return {}; }
 
  public:
   // These two are also used by class `Service`, hence public.

--- a/src/index/Index.cpp
+++ b/src/index/Index.cpp
@@ -131,7 +131,7 @@ IdTable Index::getEntityMentionsForWord(
 
 // ____________________________________________________________________________
 size_t Index::getIndexOfBestSuitedElTerm(
-    const vector<std::string>& terms) const {
+    const std::vector<std::string>& terms) const {
   return pimpl_->getIndexOfBestSuitedElTerm(terms);
 }
 
@@ -267,12 +267,12 @@ Index::NumNormalAndInternal Index::numDistinctPredicates() const {
 bool Index::hasAllPermutations() const { return pimpl_->hasAllPermutations(); }
 
 // ____________________________________________________________________________
-vector<float> Index::getMultiplicities(Permutation::Enum p) const {
+std::vector<float> Index::getMultiplicities(Permutation::Enum p) const {
   return pimpl_->getMultiplicities(p);
 }
 
 // ____________________________________________________________________________
-vector<float> Index::getMultiplicities(
+std::vector<float> Index::getMultiplicities(
     const TripleComponent& key, Permutation::Enum p,
     const LocatedTriplesSnapshot& locatedTriplesSnapshot) const {
   return pimpl_->getMultiplicities(key, p, locatedTriplesSnapshot);

--- a/src/index/IndexImpl.Text.cpp
+++ b/src/index/IndexImpl.Text.cpp
@@ -112,7 +112,7 @@ IdTable IndexImpl::getEntityMentionsForWord(
 
 // _____________________________________________________________________________
 size_t IndexImpl::getIndexOfBestSuitedElTerm(
-    const vector<std::string>& terms) const {
+    const std::vector<std::string>& terms) const {
   // It is beneficial to choose a term where no filtering by regular word id
   // is needed. Then the entity lists can be read directly from disk.
   // For others it is always necessary to reach wordlist and filter them

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -606,7 +606,7 @@ IndexBuilderDataAsExternalVector IndexImpl::passFileForVocabulary(
 // _____________________________________________________________________________
 template <typename Func>
 auto IndexImpl::convertPartialToGlobalIds(
-    TripleVec& data, const vector<size_t>& actualLinesPerPartial,
+    TripleVec& data, const std::vector<size_t>& actualLinesPerPartial,
     size_t linesPerPartial, Func isQLeverInternalTriple)
     -> FirstPermutationSorterAndInternalTriplesAsPso {
   AD_LOG_INFO << "Converting triples from local IDs to global IDs ..."
@@ -1580,7 +1580,7 @@ Index::Vocab::PrefixRanges IndexImpl::prefixRanges(
 }
 
 // _____________________________________________________________________________
-vector<float> IndexImpl::getMultiplicities(
+std::vector<float> IndexImpl::getMultiplicities(
     const TripleComponent& key, Permutation::Enum permutation,
     const LocatedTriplesSnapshot& locatedTriplesSnapshot) const {
   if (auto keyId = key.toValueId(getVocab()); keyId.has_value()) {
@@ -1595,7 +1595,7 @@ vector<float> IndexImpl::getMultiplicities(
 }
 
 // _____________________________________________________________________________
-vector<float> IndexImpl::getMultiplicities(
+std::vector<float> IndexImpl::getMultiplicities(
     Permutation::Enum permutation) const {
   const auto& p = getPermutation(permutation);
   auto numTriples = static_cast<float>(this->numTriples().normal);

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -28,7 +28,6 @@
 #include "index/IndexMetaData.h"
 #include "index/PatternCreator.h"
 #include "index/Permutation.h"
-#include "index/Postings.h"
 #include "index/TextMetaData.h"
 #include "index/TextScoring.h"
 #include "index/Vocabulary.h"
@@ -51,7 +50,6 @@ using ad_utility::MmapVectorView;
 using std::array;
 using std::shared_ptr;
 using std::tuple;
-using std::vector;
 
 using json = nlohmann::json;
 
@@ -138,7 +136,7 @@ class IndexImpl {
 
   TextMetaData textMeta_;
   DocsDB docsDB_;
-  vector<WordIndex> blockBoundaries_;
+  std::vector<WordIndex> blockBoundaries_;
   off_t currenttOffset_;
   mutable ad_utility::File textIndexFile_;
 
@@ -381,7 +379,7 @@ class IndexImpl {
       const std::string& term,
       const ad_utility::AllocatorWithLimit<Id>& allocator) const;
 
-  size_t getIndexOfBestSuitedElTerm(const vector<std::string>& terms) const;
+  size_t getIndexOfBestSuitedElTerm(const std::vector<std::string>& terms) const;
 
   std::string getTextExcerpt(TextRecordIndex cid) const {
     if (cid.get() >= docsDB_._size) {
@@ -446,12 +444,12 @@ class IndexImpl {
   bool hasAllPermutations() const { return SPO().isLoaded(); }
 
   // _____________________________________________________________________________
-  vector<float> getMultiplicities(
+  std::vector<float> getMultiplicities(
       const TripleComponent& key, Permutation::Enum permutation,
       const LocatedTriplesSnapshot& locatedTriplesSnapshot) const;
 
   // ___________________________________________________________________
-  vector<float> getMultiplicities(Permutation::Enum permutation) const;
+  std::vector<float> getMultiplicities(Permutation::Enum permutation) const;
 
   // _____________________________________________________________________________
   IdTable scan(const ScanSpecificationAsTripleComponent& scanSpecification,
@@ -517,7 +515,7 @@ class IndexImpl {
 
   template <typename Func>
   FirstPermutationSorterAndInternalTriplesAsPso convertPartialToGlobalIds(
-      TripleVec& data, const vector<size_t>& actualLinesPerPartial,
+      TripleVec& data, const std::vector<size_t>& actualLinesPerPartial,
       size_t linesPerPartial, Func isQLeverInternalTriple);
 
   // TODO<joka921> Get rid of the `numColumns` by including them into the

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -379,7 +379,8 @@ class IndexImpl {
       const std::string& term,
       const ad_utility::AllocatorWithLimit<Id>& allocator) const;
 
-  size_t getIndexOfBestSuitedElTerm(const std::vector<std::string>& terms) const;
+  size_t getIndexOfBestSuitedElTerm(
+      const std::vector<std::string>& terms) const;
 
   std::string getTextExcerpt(TextRecordIndex cid) const {
     if (cid.get() >= docsDB_._size) {

--- a/src/index/TextIndexBuilder.cpp
+++ b/src/index/TextIndexBuilder.cpp
@@ -4,6 +4,7 @@
 
 #include "index/TextIndexBuilder.h"
 
+#include "index/Postings.h"
 #include "index/TextIndexReadWrite.h"
 
 // _____________________________________________________________________________
@@ -277,8 +278,8 @@ void TextIndexBuilder::createTextIndex(const std::string& filename,
   TextBlockIndex currentBlockIndex = 0;
   WordIndex currentMinWordIndex = std::numeric_limits<WordIndex>::max();
   WordIndex currentMaxWordIndex = std::numeric_limits<WordIndex>::min();
-  vector<Posting> classicPostings;
-  vector<Posting> entityPostings;
+  std::vector<Posting> classicPostings;
+  std::vector<Posting> entityPostings;
   for (const auto& value : vec.sortedView()) {
     TextBlockIndex textBlockIndex = value[0].getInt();
     bool flag = value[1].getBool();

--- a/src/index/TextIndexReadWrite.cpp
+++ b/src/index/TextIndexReadWrite.cpp
@@ -78,7 +78,7 @@ void compressAndWrite(ql::span<const T> src, ad_utility::File& out,
 
 // ____________________________________________________________________________
 ContextListMetaData writePostings(ad_utility::File& out,
-                                  const vector<Posting>& postings,
+                                  const std::vector<Posting>& postings,
                                   bool skipWordlistIfAllTheSame,
                                   off_t& currentOffset, bool scoreIsInt) {
   ContextListMetaData meta;
@@ -131,7 +131,7 @@ ContextListMetaData writePostings(ad_utility::File& out,
 
 // ____________________________________________________________________________
 template <typename T>
-size_t writeCodebook(const vector<T>& codebook, ad_utility::File& file) {
+size_t writeCodebook(const std::vector<T>& codebook, ad_utility::File& file) {
   size_t byteSizeOfCodebook = sizeof(T) * codebook.size();
   file.write(&byteSizeOfCodebook, sizeof(byteSizeOfCodebook));
   file.write(codebook.data(), byteSizeOfCodebook);

--- a/src/index/TextIndexReadWrite.h
+++ b/src/index/TextIndexReadWrite.h
@@ -30,7 +30,7 @@ namespace textIndexReadWrite::detail {
 template <typename From>
 void readFreqComprListHelper(size_t nofElements, off_t from, size_t nofBytes,
                              const ad_utility::File& textIndexFile,
-                             vector<uint64_t>& frequencyEncodedVector,
+                             std::vector<uint64_t>& frequencyEncodedVector,
                              std::vector<From>& codebook) {
   AD_CONTRACT_CHECK(nofBytes > 0);
   LOG(DEBUG) << "Reading frequency-encoded list from disk...\n";
@@ -80,7 +80,7 @@ void readFreqComprListHelper(size_t nofElements, off_t from, size_t nofBytes,
 template <typename From>
 void readGapComprListHelper(size_t nofElements, off_t from, size_t nofBytes,
                             const ad_utility::File& textIndexFile,
-                            vector<From>& gapEncodedVector) {
+                            std::vector<From>& gapEncodedVector) {
   LOG(DEBUG) << "Reading gap-encoded list from disk...\n";
   LOG(TRACE) << "NofElements: " << nofElements << ", from: " << from
              << ", nofBytes: " << nofBytes << '\n';
@@ -150,12 +150,12 @@ void compressAndWrite(ql::span<const T> src, ad_utility::File& out,
  *
  */
 ContextListMetaData writePostings(ad_utility::File& out,
-                                  const vector<Posting>& postings,
+                                  const std::vector<Posting>& postings,
                                   bool skipWordlistIfAllTheSame,
                                   off_t& currentOffset, bool scoreIsInt);
 
 template <typename T>
-size_t writeCodebook(const vector<T>& codebook, ad_utility::File& file);
+size_t writeCodebook(const std::vector<T>& codebook, ad_utility::File& file);
 
 /**
  * @brief Encodes a span of elements and writes the encoded list to file.
@@ -173,9 +173,9 @@ void encodeAndWriteSpanAndMoveOffset(ql::span<const T> spanToWrite,
 /// READING PART
 
 template <typename T>
-vector<T> readZstdComprList(size_t nofElements, off_t from,
-                            size_t nofBytesCompressed,
-                            const ad_utility::File& textIndexFile) {
+std::vector<T> readZstdComprList(size_t nofElements, off_t from,
+                                 size_t nofBytesCompressed,
+                                 const ad_utility::File& textIndexFile) {
   std::vector<char> compressed(nofBytesCompressed);
   size_t ret = textIndexFile.read(compressed.data(), nofBytesCompressed, from);
   AD_CONTRACT_CHECK(ret == nofBytesCompressed);
@@ -213,14 +213,15 @@ IdTable readWordEntityCl(const TextBlockMetaData& tbmd,
  */
 template <typename To, typename From,
           typename Transformer = decltype(ad_utility::staticCast<To>)>
-vector<To> readFreqComprList(size_t nofElements, off_t from, size_t nofBytes,
-                             const ad_utility::File& textIndexFile,
-                             Transformer transformer = {}) {
-  vector<uint64_t> frequencyEncodedVector;
-  vector<From> codebook;
+std::vector<To> readFreqComprList(size_t nofElements, off_t from,
+                                  size_t nofBytes,
+                                  const ad_utility::File& textIndexFile,
+                                  Transformer transformer = {}) {
+  std::vector<uint64_t> frequencyEncodedVector;
+  std::vector<From> codebook;
   detail::readFreqComprListHelper(nofElements, from, nofBytes, textIndexFile,
                                   frequencyEncodedVector, codebook);
-  vector<To> result;
+  std::vector<To> result;
   result.reserve(frequencyEncodedVector.size());
   ql::ranges::for_each(frequencyEncodedVector, [&](const auto& encoded) {
     result.push_back(transformer(codebook.at(encoded)));
@@ -241,8 +242,8 @@ template <typename To, typename From, typename OutputIterator,
 void readFreqComprList(OutputIterator iterator, size_t nofElements, off_t from,
                        size_t nofBytes, const ad_utility::File& textIndexFile,
                        Transformer transformer = {}) {
-  vector<uint64_t> frequencyEncodedVector;
-  vector<From> codebook;
+  std::vector<uint64_t> frequencyEncodedVector;
+  std::vector<From> codebook;
   detail::readFreqComprListHelper(nofElements, from, nofBytes, textIndexFile,
                                   frequencyEncodedVector, codebook);
   ql::ranges::for_each(frequencyEncodedVector, [&](const auto& encoded) {
@@ -267,15 +268,16 @@ void readFreqComprList(OutputIterator iterator, size_t nofElements, off_t from,
  */
 template <typename To, typename From,
           typename Transformer = decltype(ad_utility::staticCast<To>)>
-vector<To> readGapComprList(size_t nofElements, off_t from, size_t nofBytes,
-                            const ad_utility::File& textIndexFile,
-                            Transformer transformer = {}) {
-  vector<From> gapEncodedVector;
+std::vector<To> readGapComprList(size_t nofElements, off_t from,
+                                 size_t nofBytes,
+                                 const ad_utility::File& textIndexFile,
+                                 Transformer transformer = {}) {
+  std::vector<From> gapEncodedVector;
   detail::readGapComprListHelper(nofElements, from, nofBytes, textIndexFile,
                                  gapEncodedVector);
 
   // Undo gapEncoding
-  vector<To> result;
+  std::vector<To> result;
   result.reserve(nofElements);
   From previous = 0;
   for (auto gap : gapEncodedVector) {
@@ -298,7 +300,7 @@ template <typename To, typename From, typename OutputIterator,
 void readGapComprList(OutputIterator iterator, size_t nofElements, off_t from,
                       size_t nofBytes, const ad_utility::File& textIndexFile,
                       Transformer transformer = {}) {
-  vector<From> gapEncodedVector;
+  std::vector<From> gapEncodedVector;
   detail::readGapComprListHelper(nofElements, from, nofBytes, textIndexFile,
                                  gapEncodedVector);
 

--- a/src/index/TextMetaData.h
+++ b/src/index/TextMetaData.h
@@ -8,13 +8,10 @@
 #include <cstdio>
 #include <vector>
 
-#include "../global/Id.h"
-#include "../util/Exception.h"
-#include "../util/File.h"
-#include "../util/Serializer/Serializer.h"
-#include "../util/TypeTraits.h"
-
-using std::vector;
+#include "global/Id.h"
+#include "util/File.h"
+#include "util/Serializer/Serializer.h"
+#include "util/TypeTraits.h"
 
 class ContextListMetaData {
  public:
@@ -121,12 +118,12 @@ class TextMetaData {
   float getAverageNofEntityContexts() const { return 1.0f; };
 
  private:
-  vector<uint64_t> _blockUpperBoundWordIds;
+  std::vector<uint64_t> _blockUpperBoundWordIds;
   size_t _nofTextRecords = 0;
   size_t _nofWordPostings = 0;
   size_t _nofEntityPostings = 0;
   std::string _name;
-  vector<TextBlockMetaData> _blocks;
+  std::vector<TextBlockMetaData> _blocks;
 
   // ___________________________________________________________________________
   AD_SERIALIZE_FRIEND_FUNCTION(TextMetaData) {

--- a/src/parser/ParsedQuery.h
+++ b/src/parser/ParsedQuery.h
@@ -27,8 +27,6 @@
 #include "parser/data/SolutionModifiers.h"
 #include "parser/data/SparqlFilter.h"
 
-using std::vector;
-
 // Data container for prefixes
 class SparqlPrefix {
  public:
@@ -70,10 +68,10 @@ class ParsedQuery {
   ParsedQuery() = default;
 
   GraphPattern _rootGraphPattern;
-  vector<SparqlFilter> _havingClauses;
-  vector<VariableOrderKey> _orderBy;
+  std::vector<SparqlFilter> _havingClauses;
+  std::vector<VariableOrderKey> _orderBy;
   IsInternalSort _isInternalSort = IsInternalSort::False;
-  vector<Variable> _groupByVariables;
+  std::vector<Variable> _groupByVariables;
   LimitOffsetClause _limitOffset{};
   std::string _originalString;
   std::optional<parsedQuery::Values> postQueryValuesClause_ = std::nullopt;
@@ -135,7 +133,8 @@ class ParsedQuery {
   void registerVariableVisibleInQueryBody(const Variable& variable);
 
   // Add variables, that were found in the query body.
-  void registerVariablesVisibleInQueryBody(const vector<Variable>& variables);
+  void registerVariablesVisibleInQueryBody(
+      const std::vector<Variable>& variables);
 
   // Return all the warnings that have been added via `addWarning()` or
   // `addWarningOrThrow`.

--- a/src/parser/Quads.cpp
+++ b/src/parser/Quads.cpp
@@ -6,7 +6,7 @@
 
 // ____________________________________________________________________________________
 // Transform the triples and sets the graph on all triples.
-vector<SparqlTripleSimpleWithGraph> transformTriplesTemplate(
+std::vector<SparqlTripleSimpleWithGraph> transformTriplesTemplate(
     ad_utility::sparql_types::Triples triples,
     const SparqlTripleSimpleWithGraph::Graph& graph) {
   auto convertTriple = [&graph](const std::array<GraphTerm, 3>& triple)

--- a/src/parser/SelectClause.cpp
+++ b/src/parser/SelectClause.cpp
@@ -19,7 +19,7 @@ void ClauseBase::addVisibleVariable(const Variable& variable) {
   }
 }
 
-const vector<Variable>& ClauseBase::getVisibleVariables() const {
+const std::vector<Variable>& ClauseBase::getVisibleVariables() const {
   return visibleVariables_;
 }
 

--- a/src/parser/TextSearchQuery.cpp
+++ b/src/parser/TextSearchQuery.cpp
@@ -224,7 +224,8 @@ TextSearchQuery::toConfigs(const QueryExecutionContext* qec) const {
                            TextIndexScanForEntityConfiguration>>
       output;
   // First pass to get all word searches
-  ad_utility::HashMap<Variable, std::vector<std::string>> potentialTermsForTextVar;
+  ad_utility::HashMap<Variable, std::vector<std::string>>
+      potentialTermsForTextVar;
   ad_utility::HashMap<Variable, std::string> optTermForTextVar;
   for (const auto& [var, conf] : configVarToConfigs_) {
     if (!conf.isWordSearch_.has_value()) {

--- a/src/parser/TextSearchQuery.cpp
+++ b/src/parser/TextSearchQuery.cpp
@@ -224,7 +224,7 @@ TextSearchQuery::toConfigs(const QueryExecutionContext* qec) const {
                            TextIndexScanForEntityConfiguration>>
       output;
   // First pass to get all word searches
-  ad_utility::HashMap<Variable, vector<std::string>> potentialTermsForTextVar;
+  ad_utility::HashMap<Variable, std::vector<std::string>> potentialTermsForTextVar;
   ad_utility::HashMap<Variable, std::string> optTermForTextVar;
   for (const auto& [var, conf] : configVarToConfigs_) {
     if (!conf.isWordSearch_.has_value()) {

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -1097,8 +1097,8 @@ GraphPattern Visitor::visit(Parser::GroupGraphPatternContext* ctx) {
 
 Visitor::OperationsAndFilters Visitor::visit(
     Parser::GroupGraphPatternSubContext* ctx) {
-  vector<GraphPatternOperation> ops;
-  vector<SparqlFilter> filters;
+  std::vector<GraphPatternOperation> ops;
+  std::vector<SparqlFilter> filters;
 
   auto filter = [&filters](SparqlFilter filter) {
     filters.emplace_back(std::move(filter));
@@ -1374,7 +1374,7 @@ LimitOffsetClause Visitor::visit(Parser::LimitOffsetClausesContext* ctx) {
 }
 
 // ____________________________________________________________________________________
-vector<SparqlFilter> Visitor::visit(Parser::HavingClauseContext* ctx) {
+std::vector<SparqlFilter> Visitor::visit(Parser::HavingClauseContext* ctx) {
   return visitVector(ctx->havingCondition());
 }
 
@@ -1404,7 +1404,7 @@ OrderClause Visitor::visit(Parser::OrderClauseContext* ctx) {
 }
 
 // ____________________________________________________________________________________
-vector<GroupKey> Visitor::visit(Parser::GroupClauseContext* ctx) {
+std::vector<GroupKey> Visitor::visit(Parser::GroupClauseContext* ctx) {
   return visitVector(ctx->groupCondition());
 }
 
@@ -1649,7 +1649,8 @@ SparqlValues Visitor::visit(Parser::InlineDataFullContext* ctx) {
 }
 
 // ____________________________________________________________________________________
-vector<TripleComponent> Visitor::visit(Parser::DataBlockSingleContext* ctx) {
+std::vector<TripleComponent> Visitor::visit(
+    Parser::DataBlockSingleContext* ctx) {
   if (ctx->NIL()) {
     return {};
   }
@@ -1758,7 +1759,8 @@ ExpressionPtr Visitor::visit(Parser::FunctionCallContext* ctx) {
 }
 
 // ____________________________________________________________________________________
-vector<Visitor::ExpressionPtr> Visitor::visit(Parser::ArgListContext* ctx) {
+std::vector<Visitor::ExpressionPtr> Visitor::visit(
+    Parser::ArgListContext* ctx) {
   // If no arguments, return empty expression vector.
   if (ctx->NIL()) {
     return std::vector<ExpressionPtr>{};
@@ -1929,7 +1931,7 @@ void Visitor::setMatchingWordAndScoreVisibleIfPresent(
 }
 
 // ___________________________________________________________________________
-vector<TripleWithPropertyPath> Visitor::visit(
+std::vector<TripleWithPropertyPath> Visitor::visit(
     Parser::TriplesSameSubjectPathContext* ctx) {
   /*
   // If a triple `?var ql:contains-word "words"` or `?var ql:contains-entity
@@ -2019,7 +2021,7 @@ PathObjectPairsAndTriples Visitor::visit(
     Parser::PropertyListPathNotEmptyContext* ctx) {
   PathObjectPairsAndTriples result = visit(ctx->tupleWithPath());
   auto& [pairs, triples] = result;
-  vector<PathObjectPairsAndTriples> pairsAndTriples =
+  std::vector<PathObjectPairsAndTriples> pairsAndTriples =
       visitVector(ctx->tupleWithoutPath());
   for (auto& [newPairs, newTriples] : pairsAndTriples) {
     ql::ranges::move(newPairs, std::back_inserter(pairs));
@@ -3011,7 +3013,7 @@ GraphTerm Visitor::visit(Parser::BlankNodeContext* ctx) {
 // ____________________________________________________________________________________
 CPP_template_def(typename Ctx)(
     requires Visitor::voidWhenVisited<Visitor, Ctx>) void Visitor::
-    visitVector(const vector<Ctx*>& childContexts) {
+    visitVector(const std::vector<Ctx*>& childContexts) {
   for (const auto& child : childContexts) {
     visit(child);
   }

--- a/src/parser/sparqlParser/SparqlQleverVisitor.h
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.h
@@ -45,7 +45,7 @@ class SparqlQleverVisitor {
   using PredicateObjectPairsAndTriples =
       ad_utility::sparql_types::PredicateObjectPairsAndTriples;
   using OperationsAndFilters =
-      std::pair<vector<GraphPatternOperation>, vector<SparqlFilter>>;
+      std::pair<std::vector<GraphPatternOperation>, std::vector<SparqlFilter>>;
   using OperationOrFilterAndMaybeTriples =
       std::pair<std::variant<GraphPatternOperation, SparqlFilter>,
                 std::optional<parsedQuery::BasicGraphPattern>>;
@@ -53,7 +53,7 @@ class SparqlQleverVisitor {
   using SubQueryAndMaybeValues =
       std::pair<parsedQuery::Subquery, std::optional<parsedQuery::Values>>;
   using PatternAndVisibleVariables =
-      std::pair<ParsedQuery::GraphPattern, vector<Variable>>;
+      std::pair<ParsedQuery::GraphPattern, std::vector<Variable>>;
   using SparqlExpressionPimpl = sparqlExpression::SparqlExpressionPimpl;
   using PrefixMap = ad_utility::HashMap<std::string, std::string>;
   using Parser = SparqlAutomaticParser;
@@ -193,11 +193,11 @@ class SparqlQleverVisitor {
 
   SolutionModifiers visit(Parser::SolutionModifierContext* ctx);
 
-  vector<GroupKey> visit(Parser::GroupClauseContext* ctx);
+  std::vector<GroupKey> visit(Parser::GroupClauseContext* ctx);
 
   GroupKey visit(Parser::GroupConditionContext* ctx);
 
-  vector<SparqlFilter> visit(Parser::HavingClauseContext* ctx);
+  std::vector<SparqlFilter> visit(Parser::HavingClauseContext* ctx);
 
   SparqlFilter visit(Parser::HavingConditionContext* ctx);
 
@@ -309,7 +309,7 @@ class SparqlQleverVisitor {
 
   parsedQuery::SparqlValues visit(Parser::InlineDataFullContext* ctx);
 
-  vector<TripleComponent> visit(Parser::DataBlockSingleContext* ctx);
+  std::vector<TripleComponent> visit(Parser::DataBlockSingleContext* ctx);
 
   TripleComponent visit(Parser::DataBlockValueContext* ctx);
 
@@ -323,7 +323,7 @@ class SparqlQleverVisitor {
 
   ExpressionPtr visit(Parser::FunctionCallContext* ctx);
 
-  vector<ExpressionPtr> visit(Parser::ArgListContext* ctx);
+  std::vector<ExpressionPtr> visit(Parser::ArgListContext* ctx);
 
   std::vector<ExpressionPtr> visit(Parser::ExpressionListContext* ctx);
 
@@ -345,7 +345,7 @@ class SparqlQleverVisitor {
 
   SubjectOrObjectAndTriples visit(Parser::ObjectRContext* ctx);
 
-  vector<TripleWithPropertyPath> visit(
+  std::vector<TripleWithPropertyPath> visit(
       Parser::TriplesSameSubjectPathContext* ctx);
 
   std::optional<PathObjectPairsAndTriples> visit(

--- a/test/CompressedRelationsTest.cpp
+++ b/test/CompressedRelationsTest.cpp
@@ -150,7 +150,7 @@ compressedRelationTestWriteCompressedRelations(
   AD_CORRECTNESS_CHECK(numColumns >= 4);
   CompressedRelationWriter writer{numColumns, ad_utility::File{filename, "w"},
                                   blocksize};
-  vector<CompressedRelationMetadata> metaData;
+  std::vector<CompressedRelationMetadata> metaData;
   {
     size_t i = 0;
     for (const auto& input : inputs) {

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -133,12 +133,12 @@ TEST(QueryPlanner, testCpyCtorWithKeepNodes) {
         "2 {s: <X>, p: ?p, o: <Y>} : (0)",
         tg.asString());
     {
-      vector<size_t> keep;
+      std::vector<size_t> keep;
       QueryPlanner::TripleGraph tgnew(tg, keep);
       ASSERT_EQ("", tgnew.asString());
     }
     {
-      vector<size_t> keep;
+      std::vector<size_t> keep;
       keep.push_back(0);
       keep.push_back(1);
       keep.push_back(2);
@@ -153,14 +153,14 @@ TEST(QueryPlanner, testCpyCtorWithKeepNodes) {
       ASSERT_EQ(1u, tgnew._nodeMap.find(2)->second->_variables.size());
     }
     {
-      vector<size_t> keep;
+      std::vector<size_t> keep;
       keep.push_back(0);
       QueryPlanner::TripleGraph tgnew(tg, keep);
       ASSERT_EQ("0 {s: ?x, p: ?p, o: <X>} : ()", tgnew.asString());
       ASSERT_EQ(2u, tgnew._nodeMap.find(0)->second->_variables.size());
     }
     {
-      vector<size_t> keep;
+      std::vector<size_t> keep;
       keep.push_back(0);
       keep.push_back(1);
       QueryPlanner::TripleGraph tgnew(tg, keep);
@@ -3717,8 +3717,8 @@ TEST(QueryPlanner, TextLimit) {
       h::TextLimit(10,
                    h::Join(wordScan(Var{"?text"}, "test*"),
                            entityScan(Var{"?text"}, "<testEntity>", "test*")),
-                   Var{"?text"}, vector<Variable>{},
-                   vector<Variable>{
+                   Var{"?text"}, std::vector<Variable>{},
+                   std::vector<Variable>{
                        Var{"?text"}.getEntityScoreVariable("<testEntity>")}),
       qec);
 
@@ -3730,8 +3730,8 @@ TEST(QueryPlanner, TextLimit) {
           10,
           h::Join(wordScan(Var{"?text"}, "test*"),
                   entityScan(Var{"?text"}, Var{"?scientist"}, "test*")),
-          Var{"?text"}, vector<Variable>{Var{"?scientist"}},
-          vector<Variable>{
+          Var{"?text"}, std::vector<Variable>{Var{"?scientist"}},
+          std::vector<Variable>{
               Var{"?text"}.getEntityScoreVariable(Var{"?scientist"})}),
       qec);
 
@@ -3745,8 +3745,8 @@ TEST(QueryPlanner, TextLimit) {
                        wordScan(Var{"?text"}, "test*"),
                        entityScan(Var{"?text"}, Var{"?scientist"}, "test*"),
                        entityScan(Var{"?text"}, "<testEntity>", "test*")),
-                   Var{"?text"}, vector<Variable>{Var{"?scientist"}},
-                   vector<Variable>{
+                   Var{"?text"}, std::vector<Variable>{Var{"?scientist"}},
+                   std::vector<Variable>{
                        Var{"?text"}.getEntityScoreVariable(Var{"?scientist"}),
                        Var{"?text"}.getEntityScoreVariable("<testEntity>")}),
       qec);
@@ -3762,8 +3762,8 @@ TEST(QueryPlanner, TextLimit) {
               wordScan(Var{"?text"}, "test*"),
               entityScan(Var{"?text"}, Var{"?scientist"}, "test*"),
               entityScan(Var{"?text"}, Var{"?scientist2"}, "test*")),
-          Var{"?text"}, vector<Variable>{Var{"?scientist"}, Var{"?scientist2"}},
-          vector<Variable>{
+          Var{"?text"}, std::vector<Variable>{Var{"?scientist"}, Var{"?scientist2"}},
+          std::vector<Variable>{
               Var{"?text"}.getEntityScoreVariable(Var{"?scientist"}),
               Var{"?text"}.getEntityScoreVariable(Var{"?scientist2"})}),
       qec);
@@ -3780,8 +3780,8 @@ TEST(QueryPlanner, TextLimit) {
               5,
               h::Join(wordScan(Var{"?text1"}, "test*"),
                       entityScan(Var{"?text1"}, Var{"?scientist1"}, "test*")),
-              Var{"?text1"}, vector<Variable>{Var{"?scientist1"}},
-              vector<Variable>{
+              Var{"?text1"}, std::vector<Variable>{Var{"?scientist1"}},
+              std::vector<Variable>{
                   Var{"?text1"}.getEntityScoreVariable(Var{"?scientist1"})}),
           h::TextLimit(
               5,
@@ -3789,8 +3789,8 @@ TEST(QueryPlanner, TextLimit) {
                   wordScan(Var{"?text2"}, "test*"),
                   entityScan(Var{"?text2"}, Var{"?author1"}, "test*"),
                   entityScan(Var{"?text2"}, Var{"?author2"}, "test*")),
-              Var{"?text2"}, vector<Variable>{Var{"?author1"}, Var{"?author2"}},
-              vector<Variable>{
+              Var{"?text2"}, std::vector<Variable>{Var{"?author1"}, Var{"?author2"}},
+              std::vector<Variable>{
                   Var{"?text2"}.getEntityScoreVariable(Var{"?author1"}),
                   Var{"?text2"}.getEntityScoreVariable(Var{"?author2"})})),
       qec);

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -3762,7 +3762,8 @@ TEST(QueryPlanner, TextLimit) {
               wordScan(Var{"?text"}, "test*"),
               entityScan(Var{"?text"}, Var{"?scientist"}, "test*"),
               entityScan(Var{"?text"}, Var{"?scientist2"}, "test*")),
-          Var{"?text"}, std::vector<Variable>{Var{"?scientist"}, Var{"?scientist2"}},
+          Var{"?text"},
+          std::vector<Variable>{Var{"?scientist"}, Var{"?scientist2"}},
           std::vector<Variable>{
               Var{"?text"}.getEntityScoreVariable(Var{"?scientist"}),
               Var{"?text"}.getEntityScoreVariable(Var{"?scientist2"})}),
@@ -3789,7 +3790,8 @@ TEST(QueryPlanner, TextLimit) {
                   wordScan(Var{"?text2"}, "test*"),
                   entityScan(Var{"?text2"}, Var{"?author1"}, "test*"),
                   entityScan(Var{"?text2"}, Var{"?author2"}, "test*")),
-              Var{"?text2"}, std::vector<Variable>{Var{"?author1"}, Var{"?author2"}},
+              Var{"?text2"},
+              std::vector<Variable>{Var{"?author1"}, Var{"?author2"}},
               std::vector<Variable>{
                   Var{"?text2"}.getEntityScoreVariable(Var{"?author1"}),
                   Var{"?text2"}.getEntityScoreVariable(Var{"?author2"})})),

--- a/test/QueryPlannerTestHelpers.h
+++ b/test/QueryPlannerTestHelpers.h
@@ -168,10 +168,10 @@ constexpr auto TextIndexScanForWordConf =
 };
 
 // Matcher for the `TextLimit` Operation.
-constexpr auto TextLimit = [](const size_t n, const QetMatcher& childMatcher,
-                              const Variable& textRecVar,
-                              const vector<Variable>& entityVars,
-                              const vector<Variable>& scoreVars) -> QetMatcher {
+constexpr auto TextLimit =
+    [](const size_t n, const QetMatcher& childMatcher,
+       const Variable& textRecVar, const std::vector<Variable>& entityVars,
+       const std::vector<Variable>& scoreVars) -> QetMatcher {
   return RootOperation<::TextLimit>(AllOf(
       AD_PROPERTY(::TextLimit, getTextLimit, Eq(n)), children(childMatcher),
       AD_PROPERTY(::TextLimit, getTextRecordVariable, Eq(textRecVar)),

--- a/test/SparqlAntlrParserTestHelpers.h
+++ b/test/SparqlAntlrParserTestHelpers.h
@@ -398,7 +398,7 @@ inline auto VariableOrderKeyVariant =
 inline auto VariableOrderKeys =
     [](const std::vector<std::pair<::Variable, bool>>& orderKeys)
     -> Matcher<const std::vector<::VariableOrderKey>&> {
-  vector<Matcher<const ::VariableOrderKey&>> matchers;
+  std::vector<Matcher<const ::VariableOrderKey&>> matchers;
   for (auto [key, desc] : orderKeys) {
     matchers.push_back(VariableOrderKey(key, desc));
   }
@@ -418,7 +418,7 @@ inline auto OrderKeys =
            std::variant<::VariableOrderKey, ExpressionOrderKeyTest>>& orderKeys,
        IsInternalSort isInternalSort =
            IsInternalSort::False) -> Matcher<const OrderClause&> {
-  vector<Matcher<const OrderKey&>> keyMatchers;
+  std::vector<Matcher<const OrderKey&>> keyMatchers;
   auto variableOrderKey =
       [](const ::VariableOrderKey& key) -> Matcher<const OrderKey&> {
     return VariableOrderKeyVariant(key.variable_, key.isDescending_);
@@ -460,8 +460,8 @@ inline auto AliasGroupKey =
 inline auto GroupKeys =
     [](const std::vector<std::variant<
            std::string, std::pair<std::string, ::Variable>, ::Variable>>&
-           groupKeys) -> Matcher<const vector<GroupKey>&> {
-  vector<Matcher<const GroupKey&>> keyMatchers;
+           groupKeys) -> Matcher<const std::vector<GroupKey>&> {
+  std::vector<Matcher<const GroupKey&>> keyMatchers;
   auto variableGroupKey =
       [](const ::Variable& key) -> Matcher<const GroupKey&> {
     return VariableGroupKey(key.name());
@@ -484,15 +484,15 @@ inline auto GroupKeys =
 };
 
 inline auto GroupByVariables =
-    [](const vector<::Variable>& vars) -> Matcher<const ParsedQuery&> {
+    [](const std::vector<::Variable>& vars) -> Matcher<const ParsedQuery&> {
   return AD_FIELD(ParsedQuery, _groupByVariables,
                   testing::UnorderedElementsAreArray(vars));
 };
 
 // Test that a `ParsedQuery` contains the `warnings` in any order. The
 // `warnings` can be substrings of the full warning messages.
-inline auto WarningsOfParsedQuery =
-    [](const vector<std::string>& warnings) -> Matcher<const ParsedQuery&> {
+inline auto WarningsOfParsedQuery = [](const std::vector<std::string>& warnings)
+    -> Matcher<const ParsedQuery&> {
   auto matchers = ad_utility::transform(
       warnings, [](const std::string& s) { return ::testing::HasSubstr(s); });
   return AD_PROPERTY(ParsedQuery, warnings,
@@ -500,7 +500,7 @@ inline auto WarningsOfParsedQuery =
 };
 
 inline auto Values = [](const std::vector<::Variable>& vars,
-                        const std::vector<vector<TripleComponent>>& values)
+                        const std::vector<std::vector<TripleComponent>>& values)
     -> Matcher<const p::Values&> {
   // TODO Refactor GraphPatternOperation::Values / SparqlValues s.t. this
   //  becomes a trivial Eq matcher.
@@ -511,8 +511,9 @@ inline auto Values = [](const std::vector<::Variable>& vars,
                      AD_FIELD(SparqlValues, _values, testing::Eq(values)))));
 };
 
-inline auto InlineData = [](const std::vector<::Variable>& vars,
-                            const vector<vector<TripleComponent>>& values)
+inline auto InlineData =
+    [](const std::vector<::Variable>& vars,
+       const std::vector<std::vector<TripleComponent>>& values)
     -> Matcher<const p::GraphPatternOperation&> {
   // TODO Refactor GraphPatternOperation::Values / SparqlValues s.t. this
   //  becomes a trivial Eq matcher.
@@ -554,7 +555,7 @@ inline auto AsteriskSelect = [](bool distinct = false,
 };
 
 inline auto VariablesSelect =
-    [](const vector<std::string>& variables, bool distinct = false,
+    [](const std::vector<std::string>& variables, bool distinct = false,
        bool reduced = false) -> Matcher<const p::SelectClause&> {
   return testing::AllOf(
       detail::SelectBase(distinct, reduced),
@@ -666,7 +667,7 @@ inline auto SolutionModifier =
     [](const std::vector<std::variant<
            std::string, std::pair<std::string, ::Variable>, ::Variable>>&
            groupKeys = {},
-       const vector<std::string>& havingClauses = {},
+       const std::vector<std::string>& havingClauses = {},
        const std::vector<std::variant<::VariableOrderKey,
                                       ExpressionOrderKeyTest>>& orderKeys = {},
        const LimitOffsetClause& limitOffset = {})
@@ -679,7 +680,7 @@ inline auto SolutionModifier =
       AD_FIELD(SolutionModifiers, limitOffset_, testing::Eq(limitOffset)));
 };
 
-inline auto Triples = [](const vector<SparqlTriple>& triples)
+inline auto Triples = [](const std::vector<SparqlTriple>& triples)
     -> Matcher<const p::GraphPatternOperation&> {
   return detail::GraphPatternOperation<p::BasicGraphPattern>(
       AD_FIELD(p::BasicGraphPattern, _triples,
@@ -732,7 +733,7 @@ inline auto RootGraphPattern = [](const Matcher<const p::GraphPattern&>& m)
 template <auto SubMatcherLambda>
 struct MatcherWithDefaultFilters {
   Matcher<const p::GraphPatternOperation&> operator()(
-      vector<std::string>&& filters, const auto&... childMatchers) {
+      std::vector<std::string>&& filters, const auto&... childMatchers) {
     return SubMatcherLambda(std::move(filters), childMatchers...);
   }
 
@@ -745,7 +746,7 @@ struct MatcherWithDefaultFilters {
 template <auto SubMatcherLambda>
 struct MatcherWithDefaultFiltersAndOptional {
   Matcher<const ParsedQuery::GraphPattern&> operator()(
-      bool optional, vector<std::string>&& filters,
+      bool optional, std::vector<std::string>&& filters,
       const auto&... childMatchers) {
     return SubMatcherLambda(optional, std::move(filters), childMatchers...);
   }
@@ -758,7 +759,7 @@ struct MatcherWithDefaultFiltersAndOptional {
 
 namespace detail {
 inline auto GraphPattern =
-    [](bool optional, const vector<std::string>& filters,
+    [](bool optional, const std::vector<std::string>& filters,
        auto&&... childMatchers) -> Matcher<const ParsedQuery::GraphPattern&> {
   return testing::AllOf(
       AD_FIELD(ParsedQuery::GraphPattern, _optional, testing::Eq(optional)),
@@ -773,7 +774,7 @@ inline auto GraphPattern =
     MatcherWithDefaultFiltersAndOptional<detail::GraphPattern>{};
 
 namespace detail {
-inline auto OptionalGraphPattern = [](vector<std::string>&& filters,
+inline auto OptionalGraphPattern = [](std::vector<std::string>&& filters,
                                       const auto&... childMatchers)
     -> Matcher<const p::GraphPatternOperation&> {
   return detail::Optional(
@@ -785,15 +786,15 @@ inline auto OptionalGraphPattern =
     MatcherWithDefaultFilters<detail::OptionalGraphPattern>{};
 
 namespace detail {
-inline auto GroupGraphPattern = [](vector<std::string>&& filters,
+inline auto GroupGraphPattern = [](std::vector<std::string>&& filters,
                                    const auto&... childMatchers)
     -> Matcher<const p::GraphPatternOperation&> {
   return Group(detail::GraphPattern(false, filters, childMatchers...));
 };
 
 inline auto GroupGraphPatternWithGraph =
-    [](vector<std::string>&& filters, p::GroupGraphPattern::GraphSpec graph,
-       const auto&... childMatchers)
+    [](std::vector<std::string>&& filters,
+       p::GroupGraphPattern::GraphSpec graph, const auto&... childMatchers)
     -> Matcher<const p::GraphPatternOperation&> {
   return Group(detail::GraphPattern(false, filters, childMatchers...), graph);
 };
@@ -806,7 +807,7 @@ inline auto GroupGraphPatternWithGraph =
     MatcherWithDefaultFilters<detail::GroupGraphPatternWithGraph>{};
 
 namespace detail {
-inline auto MinusGraphPattern = [](vector<std::string>&& filters,
+inline auto MinusGraphPattern = [](std::vector<std::string>&& filters,
                                    const auto&... childMatchers)
     -> Matcher<const p::GraphPatternOperation&> {
   return Minus(detail::GraphPattern(false, filters, childMatchers...));
@@ -866,7 +867,7 @@ inline auto LimitOffset = [](const LimitOffsetClause& limitOffset = {})
     -> Matcher<const ::ParsedQuery&> {
   return AD_FIELD(ParsedQuery, _limitOffset, testing::Eq(limitOffset));
 };
-inline auto Having = [](const vector<std::string>& havingClauses = {})
+inline auto Having = [](const std::vector<std::string>& havingClauses = {})
     -> Matcher<const ::ParsedQuery&> {
   return AD_FIELD(ParsedQuery, _havingClauses,
                   stringsMatchFilters(havingClauses));

--- a/test/SparqlParserTest.cpp
+++ b/test/SparqlParserTest.cpp
@@ -262,9 +262,9 @@ TEST(ParserTest, testParse) {
     const auto& values1 = std::get<p::Values>(pq.children()[0])._inlineValues;
     const auto& values2 = std::get<p::Values>(pq.children()[1])._inlineValues;
 
-    vector<Variable> vvars = {Var{"?a"}};
+    std::vector<Variable> vvars = {Var{"?a"}};
     ASSERT_EQ(vvars, values1._variables);
-    vector<vector<TripleComponent>> vvals = {{iri("<1>")}, {2}};
+    std::vector<std::vector<TripleComponent>> vvals = {{iri("<1>")}, {2}};
     ASSERT_EQ(vvals, values1._values);
 
     vvars = {Var{"?b"}, Var{"?c"}};
@@ -287,9 +287,10 @@ TEST(ParserTest, testParse) {
     const auto& values1 = std::get<p::Values>(pq.children()[0])._inlineValues;
     const auto& values2 = std::get<p::Values>(pq.children()[1])._inlineValues;
 
-    vector<Variable> vvars = {Var{"?a"}};
+    std::vector<Variable> vvars = {Var{"?a"}};
     ASSERT_EQ(vvars, values1._variables);
-    vector<vector<TripleComponent>> vvals = {{iri("<Albert_Einstein>")}};
+    std::vector<std::vector<TripleComponent>> vvals = {
+        {iri("<Albert_Einstein>")}};
     ASSERT_EQ(vvals, values1._values);
 
     vvars = {Var{"?b"}, Var{"?c"}};
@@ -320,9 +321,9 @@ TEST(ParserTest, testParse) {
     ASSERT_EQ(c._triples[0].o_, Var{"?citytype"});
 
     const auto& values1 = std::get<p::Values>(pq.children()[0])._inlineValues;
-    vector<Variable> vvars = {Var{"?citytype"}};
+    std::vector<Variable> vvars = {Var{"?citytype"}};
     ASSERT_EQ(vvars, values1._variables);
-    vector<vector<TripleComponent>> vvals = {
+    std::vector<std::vector<TripleComponent>> vvals = {
         {iri("<http://www.wikidata.org/entity/Q515>")},
         {iri("<http://www.wikidata.org/entity/Q262166>")}};
     ASSERT_EQ(vvals, values1._values);
@@ -436,7 +437,7 @@ TEST(ParserTest, testParse) {
     ASSERT_EQ(true, sc.reduced_);
     ASSERT_EQ(true, sc.isAsterisk());
 
-    vector<std::string> vvars = {"?movie", "?director"};
+    std::vector<std::string> vvars = {"?movie", "?director"};
     ASSERT_EQ(vvars, sc.getSelectedVariablesAsStrings());
   }
 
@@ -466,7 +467,7 @@ TEST(ParserTest, testParse) {
     ASSERT_EQ(true, sc.distinct_);
     ASSERT_EQ(true, sc.isAsterisk());
 
-    vector<std::string> vvars = {"?movie", "?director"};
+    std::vector<std::string> vvars = {"?movie", "?director"};
     ASSERT_EQ(vvars, sc.getSelectedVariablesAsStrings());
   }
 
@@ -506,7 +507,7 @@ TEST(ParserTest, testParse) {
     ASSERT_EQ(true, sc.distinct_);
     ASSERT_EQ(true, sc.isAsterisk());
 
-    vector<std::string> vvars = {"?movie", "?director", "?year"};
+    std::vector<std::string> vvars = {"?movie", "?director", "?year"};
     ASSERT_EQ(vvars, sc.getSelectedVariablesAsStrings());
 
     // -- SubQuery
@@ -538,7 +539,7 @@ TEST(ParserTest, testParse) {
     ASSERT_EQ(false, sc_subquery.distinct_);
     ASSERT_EQ(false, sc_subquery.reduced_);
     ASSERT_EQ(true, sc_subquery.isAsterisk());
-    vector<std::string> vvars_subquery = {"?movie", "?director", "?year"};
+    std::vector<std::string> vvars_subquery = {"?movie", "?director", "?year"};
     ASSERT_EQ(vvars_subquery, sc_subquery.getSelectedVariablesAsStrings());
   }
 
@@ -583,7 +584,7 @@ TEST(ParserTest, testParse) {
     ASSERT_EQ(true, sc.distinct_);
     ASSERT_EQ(true, sc.isAsterisk());
 
-    vector<std::string> vvars = {"?movie", "?director", "?year"};
+    std::vector<std::string> vvars = {"?movie", "?director", "?year"};
     ASSERT_EQ(vvars, sc.getSelectedVariablesAsStrings());
 
     // -- SubQuery (level 1)
@@ -611,7 +612,7 @@ TEST(ParserTest, testParse) {
     ASSERT_EQ(false, sc_subquery.distinct_);
     ASSERT_EQ(false, sc_subquery.reduced_);
     ASSERT_EQ(true, sc_subquery.isAsterisk());
-    vector<std::string> vvars_subquery = {"?movie", "?director", "?year"};
+    std::vector<std::string> vvars_subquery = {"?movie", "?director", "?year"};
     ASSERT_EQ(vvars_subquery, sc_subquery.getSelectedVariablesAsStrings());
 
     // -- SubQuery (level 2)
@@ -636,7 +637,7 @@ TEST(ParserTest, testParse) {
     ASSERT_EQ(false, sc_sub_subquery.distinct_);
     ASSERT_EQ(false, sc_sub_subquery.reduced_);
     ASSERT_EQ(false, sc_sub_subquery.isAsterisk());
-    vector<std::string> vvars_sub_subquery = {"?year"};
+    std::vector<std::string> vvars_sub_subquery = {"?year"};
     ASSERT_EQ(vvars_sub_subquery,
               sc_sub_subquery.getSelectedVariablesAsStrings());
   }

--- a/test/TextLimitOperationTest.cpp
+++ b/test/TextLimitOperationTest.cpp
@@ -16,8 +16,8 @@
 namespace {
 TextLimit makeTextLimit(IdTable input, const size_t& n,
                         const ColumnIndex& textRecordColumn,
-                        const vector<ColumnIndex>& entityColumns,
-                        const vector<ColumnIndex>& scoreColumns) {
+                        const std::vector<ColumnIndex>& entityColumns,
+                        const std::vector<ColumnIndex>& scoreColumns) {
   auto qec = ad_utility::testing::getQec();
   std::vector<std::optional<Variable>> vars;
   for (size_t i = 0; i < input.numColumns(); ++i) {

--- a/test/parser/QuadTest.cpp
+++ b/test/parser/QuadTest.cpp
@@ -68,7 +68,7 @@ TEST(QuadTest, getOperations) {
     return {t, t.getIri(), t};
   };
   auto GraphTriples =
-      [](const vector<::SparqlTriple>& triples,
+      [](const std::vector<::SparqlTriple>& triples,
          const parsedQuery::GroupGraphPattern::GraphSpec& graph) {
         return matchers::GroupGraphPatternWithGraph({}, graph,
                                                     matchers::Triples(triples));

--- a/test/util/OperationTestHelpers.h
+++ b/test/util/OperationTestHelpers.h
@@ -27,7 +27,7 @@ class StallForeverOperation : public Operation {
   uint64_t getSizeEstimateBeforeLimit() override { return 0; }
   float getMultiplicity([[maybe_unused]] size_t) override { return 0; }
   bool knownEmptyResult() override { return false; }
-  vector<ColumnIndex> resultSortedOn() const override { return {}; }
+  std::vector<ColumnIndex> resultSortedOn() const override { return {}; }
   VariableToColumnMap computeVariableToColumnMap() const override { return {}; }
 
  public:
@@ -69,7 +69,7 @@ class ShallowParentOperation : public Operation {
   uint64_t getSizeEstimateBeforeLimit() override { return 0; }
   float getMultiplicity([[maybe_unused]] size_t) override { return 0; }
   bool knownEmptyResult() override { return false; }
-  vector<ColumnIndex> resultSortedOn() const override { return {}; }
+  std::vector<ColumnIndex> resultSortedOn() const override { return {}; }
   VariableToColumnMap computeVariableToColumnMap() const override { return {}; }
 
  public:
@@ -117,7 +117,7 @@ class AlwaysFailOperation : public Operation {
   uint64_t getSizeEstimateBeforeLimit() override { return 0; }
   float getMultiplicity([[maybe_unused]] size_t) override { return 0; }
   bool knownEmptyResult() override { return false; }
-  vector<ColumnIndex> resultSortedOn() const override { return {0}; }
+  std::vector<ColumnIndex> resultSortedOn() const override { return {0}; }
   VariableToColumnMap computeVariableToColumnMap() const override {
     if (!variable_.has_value()) {
       return {};
@@ -163,7 +163,7 @@ class CustomGeneratorOperation : public Operation {
   uint64_t getSizeEstimateBeforeLimit() override { return 0; }
   float getMultiplicity([[maybe_unused]] size_t) override { return 0; }
   bool knownEmptyResult() override { return false; }
-  vector<ColumnIndex> resultSortedOn() const override { return {}; }
+  std::vector<ColumnIndex> resultSortedOn() const override { return {}; }
   VariableToColumnMap computeVariableToColumnMap() const override { return {}; }
 
  public:


### PR DESCRIPTION
This is a trivial clean-up change, which touches many files and code lines though (follow-up to #2190, which did the analogous change for `std::string`) 