### PR TITLE
Fix `GROUP BY` for group from vector with single entry 

### DIFF
--- a/src/engine/GroupByImpl.cpp
+++ b/src/engine/GroupByImpl.cpp
@@ -232,7 +232,7 @@ void GroupByImpl::processGroup(
                            "An expression returned a vector expression result "
                            "that contained an unexpected amount of entries.");
       return sparqlExpression::detail::constantExpressionResultToId(
-          std::move(AD_FWD(singleResult).at(0)), *localVocab);
+          std::move(singleResult.at(0)), *localVocab);
     } else {
       // This should never happen since aggregates always return constants or
       // vectors.


### PR DESCRIPTION
Fix a bug in `GroupByImpl::processGroup`, so that in addition to `sparqlExpression::isConstantResult`, it also accepts `sparqlExpression::isVectorResult` with a single entry. For example, the latter is produced by the following query. Fixes #2123
```
SELECT (COALESCE(SAMPLE(?x)) AS ?y) WHERE {}
GROUP BY ?x
```