### PR TITLE
Refactor Error Handling in Graph Store Protocol

### DIFF
--- a/src/engine/GraphStoreProtocol.cpp
+++ b/src/engine/GraphStoreProtocol.cpp
@@ -11,12 +11,14 @@
 // ____________________________________________________________________________
 void GraphStoreProtocol::throwUnsupportedMediatype(
     const std::string_view& mediatype) {
-  throw UnsupportedMediatypeError(absl::StrCat(
-      "Mediatype \"", mediatype,
-      "\" is not supported for SPARQL Graph Store HTTP Protocol in QLever. "
-      "Supported: ",
-      toString(ad_utility::MediaType::turtle), ", ",
-      toString(ad_utility::MediaType::ntriples), "."));
+  throw HttpError(
+      boost::beast::http::status::unsupported_media_type,
+      absl::StrCat(
+          "Mediatype \"", mediatype,
+          "\" is not supported for SPARQL Graph Store HTTP Protocol in QLever. "
+          "Supported: ",
+          toString(ad_utility::MediaType::turtle), ", ",
+          toString(ad_utility::MediaType::ntriples), "."));
 }
 
 // ____________________________________________________________________________

--- a/src/engine/GraphStoreProtocol.h
+++ b/src/engine/GraphStoreProtocol.h
@@ -7,24 +7,11 @@
 
 #include <gtest/gtest_prod.h>
 
+#include "engine/HttpError.h"
 #include "parser/ParsedQuery.h"
 #include "parser/RdfParser.h"
 #include "util/http/HttpUtils.h"
 #include "util/http/UrlParser.h"
-
-// The mediatype of a request could not be determined.
-class UnknownMediatypeError : public std::runtime_error {
- public:
-  explicit UnknownMediatypeError(std::string_view msg)
-      : std::runtime_error{std::string{msg}} {}
-};
-
-// The mediatype of a request is not supported.
-class UnsupportedMediatypeError : public std::runtime_error {
- public:
-  explicit UnsupportedMediatypeError(std::string_view msg)
-      : std::runtime_error{std::string{msg}} {}
-};
 
 // Transform SPARQL Graph Store Protocol requests to their equivalent
 // ParsedQuery (SPARQL Query or Update).
@@ -44,18 +31,24 @@ class GraphStoreProtocol {
       // If the mediatype is not given, return an error.
       // Note: The specs also allow to try to determine the media type from the
       // content.
-      throw UnknownMediatypeError("Mediatype empty or not set.");
+      throw HttpError(boost::beast::http::status::unsupported_media_type,
+                      "Mediatype empty or not set.");
     }
-    auto mediaTypes =
-        ad_utility::getMediaTypesFromAcceptHeader(contentTypeString);
+    std::optional<std::vector<ad_utility::MediaType>> mediaTypes;
+    try {
+      mediaTypes = ad_utility::getMediaTypesFromAcceptHeader(contentTypeString);
+    } catch (const std::exception& e) {
+      throw HttpError(boost::beast::http::status::unsupported_media_type,
+                      e.what());
+    }
 
     // A media type is set but not one of the supported ones as per the QLever
     // MediaType code. Content-Type is only allowed to return a single value, so
     // wildcards are also correctly discarded here.
-    if (mediaTypes.size() != 1) {
+    if (mediaTypes->size() != 1) {
       throwUnsupportedMediatype(rawRequest.at(field::content_type));
     }
-    return mediaTypes.front();
+    return mediaTypes->front();
   }
   FRIEND_TEST(GraphStoreProtocolTest, extractMediatype);
 
@@ -66,6 +59,15 @@ class GraphStoreProtocol {
   // Throws the error if an HTTP method is not supported.
   [[noreturn]] static void throwUnsupportedHTTPMethod(
       const std::string_view& method);
+
+  // Aborts the request with an HTTP 204 No Content if the request body is
+  // empty.
+  static void throwIfRequestBodyEmpty(const auto& request) {
+    if (request.body().empty()) {
+      throw HttpError(boost::beast::http::status::no_content,
+                      "Request body is empty.");
+    }
+  }
 
   // Parse the triples from the request body according to the content type.
   static std::vector<TurtleTriple> parseTriples(
@@ -83,6 +85,7 @@ class GraphStoreProtocol {
   CPP_template_2(typename RequestT)(
       requires ad_utility::httpUtils::HttpRequest<RequestT>) static ParsedQuery
       transformPost(const RequestT& rawRequest, const GraphOrDefault& graph) {
+    throwIfRequestBodyEmpty(rawRequest);
     auto triples =
         parseTriples(rawRequest.body(), extractMediatype(rawRequest));
     auto convertedTriples = convertTriples(graph, std::move(triples));

--- a/src/engine/HttpError.h
+++ b/src/engine/HttpError.h
@@ -1,0 +1,35 @@
+// Copyright 2025 The QLever Authors, in particular:
+//
+// 2025 Julian Mundhahs <mundhahj@tf.uni-freiburg>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+
+#include <exception>
+
+#include "util/http/beast.h"
+
+#ifndef QLEVER_SRC_ENGINE_HTTPERROR_H
+#define QLEVER_SRC_ENGINE_HTTPERROR_H
+
+// An Error occurred that immediately results in a specific HTTP status code.
+// This can be used to prematurely end the execution of a request in the Server
+// and return a specific status code and response.
+class HttpError : public std::exception {
+ public:
+  explicit HttpError(boost::beast::http::status status)
+      : status_{status}, reason_{boost::beast::http::obsolete_reason(status)} {}
+  explicit HttpError(boost::beast::http::status status, std::string_view extra)
+      : status_{status}, reason_{extra} {}
+
+  const char* what() const noexcept override { return reason_.c_str(); }
+
+  [[nodiscard]] const boost::beast::http::status& status() const {
+    return status_;
+  }
+
+ private:
+  boost::beast::http::status status_;
+  std::string reason_{};
+};
+
+#endif  // QLEVER_SRC_ENGINE_HTTPERROR_H

--- a/src/engine/SPARQLProtocol.cpp
+++ b/src/engine/SPARQLProtocol.cpp
@@ -4,6 +4,8 @@
 
 #include "engine/SPARQLProtocol.h"
 
+#include "engine/HttpError.h"
+
 using namespace ad_utility::url_parser::sparqlOperation;
 namespace http = boost::beast::http;
 
@@ -163,8 +165,10 @@ ad_utility::url_parser::ParsedRequest SPARQLProtocol::parseHttpRequest(
   }
   std::ostringstream requestMethodName;
   requestMethodName << request.method();
-  throw std::runtime_error(absl::StrCat(
-      "Request method \"", requestMethodName.str(),
-      "\" not supported (only GET and POST are supported; PUT, DELETE, HEAD "
-      "and PATCH for graph store protocol are not yet supported)"));
+  throw HttpError(
+      boost::beast::http::status::method_not_allowed,
+      absl::StrCat(
+          "Request method \"", requestMethodName.str(),
+          "\" not supported (only GET and POST are supported; PUT, DELETE, "
+          "HEAD and PATCH for graph store protocol are not yet supported)"));
 }

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -20,6 +20,7 @@
 #include "GraphStoreProtocol.h"
 #include "engine/ExecuteUpdate.h"
 #include "engine/ExportQueryExecutionTrees.h"
+#include "engine/HttpError.h"
 #include "engine/QueryPlanner.h"
 #include "engine/SPARQLProtocol.h"
 #include "global/RuntimeParameters.h"
@@ -132,10 +133,20 @@ void Server::run(const std::string& indexBaseName, bool useText,
     // response with that message. Note that the C++ standard forbids co_await
     // in the catch block, hence the workaround with the `exceptionErrorMsg`.
     std::optional<std::string> exceptionErrorMsg;
+    std::optional<boost::beast::http::status> httpResponseStatus;
     try {
       co_await process(request, sendWithAccessControlHeaders);
+    } catch (const HttpError& e) {
+      httpResponseStatus = e.status();
+      exceptionErrorMsg = e.what();
     } catch (const std::exception& e) {
       exceptionErrorMsg = e.what();
+    }
+    if (httpResponseStatus && exceptionErrorMsg) {
+      auto response = createHttpResponseFromString(
+          exceptionErrorMsg.value(), httpResponseStatus.value(), request,
+          MediaType::textPlain);
+      co_return co_await sendWithAccessControlHeaders(std::move(response));
     }
     if (exceptionErrorMsg) {
       LOG(ERROR) << exceptionErrorMsg.value() << std::endl;
@@ -745,8 +756,12 @@ CPP_template_def(typename RequestT)(
 
   if (mediaType.has_value()) {
     return {mediaType.value()};
-  } else {
+  }
+
+  try {
     return ad_utility::getMediaTypesFromAcceptHeader(acceptHeader);
+  } catch (const std::exception& e) {
+    throw HttpError(http::status::not_acceptable, e.what());
   }
 }
 
@@ -1051,15 +1066,15 @@ CPP_template_def(typename VisitorT, typename RequestT, typename ResponseT)(
   std::optional<ExceptionMetadata> metadata;
   try {
     co_return co_await std::visit(visitor, std::move(operation));
+  } catch (const HttpError& e) {
+    responseStatus = e.status();
+    exceptionErrorMsg = e.what();
   } catch (const ParseException& e) {
     responseStatus = http::status::bad_request;
     exceptionErrorMsg = e.errorMessageWithoutPositionalInfo();
     metadata = e.metadata();
   } catch (const QueryAlreadyInUseError& e) {
     responseStatus = http::status::conflict;
-    exceptionErrorMsg = e.what();
-  } catch (const UnknownMediatypeError& e) {
-    responseStatus = http::status::bad_request;
     exceptionErrorMsg = e.what();
   } catch (const ad_utility::CancellationException& e) {
     // Send 429 status code to indicate that the time limit was reached


### PR DESCRIPTION
Extracted changes from #2117 that refactored the error handling in the graph store protocol.