### PR TITLE
Bugfix for `FILTER` in `OPTIONAL` with variable-disjoint LHS and RHS

### DIFF
--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -2758,7 +2758,11 @@ bool QueryPlanner::GraphPatternPlanner::handleUnconnectedMinusOrOptional(
     ql::ranges::for_each(
         candidates, [this, &newPlans](const SubtreePlan& plan) {
           auto joinedPlan = makeSubtreePlan<NeutralOptional>(qec_, plan._qet);
-          assignNodesFilterAndTextLimitIds(joinedPlan, plan);
+          // Note: It is important that we do NOT copy the filter and
+          // textLimit IDs, as they originate from the inner scope of the
+          // OPTIONAL clause and have been already completely dealt with.
+          // This was the cause of
+          // https://github.com/ad-freiburg/qlever/issues/2194.
           newPlans.push_back(std::move(joinedPlan));
         });
     return true;


### PR DESCRIPTION
Fix a bug introduced by #2121, which occurred when an `OPTIONAL` clause contains a `FILTER` and the left-hand side and right-hand side of the optional join share no variables. Here is a minimal example query. In particular, fixes #2194.
```
SELECT * WHERE {
  OPTIONAL {
    <x> <y> ?class .
    FILTER (?class != <z>)
  }
}
```