### PR TITLE
Catch `Could not parse WKT` from `pb_util`

### DIFF
--- a/src/rdfTypes/GeometryInfoHelpersImpl.h
+++ b/src/rdfTypes/GeometryInfoHelpersImpl.h
@@ -38,41 +38,43 @@ inline ParseResult parseWkt(const std::string_view& wkt) {
   auto wktLiteral = removeDatatype(wkt);
   std::optional<ParsedWkt> parsed = std::nullopt;
   auto type = getWKTType(wktLiteral);
+  using enum WKTType;
   try {
     switch (type) {
-      case WKTType::POINT: {
+      case POINT: {
         parsed = pointFromWKT<CoordType>(wktLiteral);
         break;
       }
-      case WKTType::LINESTRING: {
+      case LINESTRING: {
         parsed = lineFromWKT<CoordType>(wktLiteral);
         break;
       }
-      case WKTType::POLYGON: {
+      case POLYGON: {
         parsed = polygonFromWKT<CoordType>(wktLiteral);
         break;
       }
-      case WKTType::MULTIPOINT: {
+      case MULTIPOINT: {
         parsed = multiPointFromWKT<CoordType>(wktLiteral);
         break;
       }
-      case WKTType::MULTILINESTRING: {
+      case MULTILINESTRING: {
         parsed = multiLineFromWKT<CoordType>(wktLiteral);
         break;
       }
-      case WKTType::MULTIPOLYGON: {
+      case MULTIPOLYGON: {
         parsed = multiPolygonFromWKT<CoordType>(wktLiteral);
         break;
       }
-      case WKTType::COLLECTION: {
+      case COLLECTION: {
         parsed = collectionFromWKT<CoordType>(wktLiteral);
         break;
       }
-      case WKTType::NONE:
+      case NONE:
+      default:
         break;
     }
   } catch (const std::runtime_error& error) {
-    AD_LOG_DEBUG << "Cannot parse WKT `" << wkt << "`: " << error.what()
+    AD_LOG_DEBUG << "Error parsing WKT `" << wkt << "`: " << error.what()
                  << std::endl;
   }
 

--- a/src/rdfTypes/GeometryInfoHelpersImpl.h
+++ b/src/rdfTypes/GeometryInfoHelpersImpl.h
@@ -41,34 +41,27 @@ inline ParseResult parseWkt(const std::string_view& wkt) {
   using enum WKTType;
   try {
     switch (type) {
-      case POINT: {
+      case POINT:
         parsed = pointFromWKT<CoordType>(wktLiteral);
         break;
-      }
-      case LINESTRING: {
+      case LINESTRING:
         parsed = lineFromWKT<CoordType>(wktLiteral);
         break;
-      }
-      case POLYGON: {
+      case POLYGON:
         parsed = polygonFromWKT<CoordType>(wktLiteral);
         break;
-      }
-      case MULTIPOINT: {
+      case MULTIPOINT:
         parsed = multiPointFromWKT<CoordType>(wktLiteral);
         break;
-      }
-      case MULTILINESTRING: {
+      case MULTILINESTRING:
         parsed = multiLineFromWKT<CoordType>(wktLiteral);
         break;
-      }
-      case MULTIPOLYGON: {
+      case MULTIPOLYGON:
         parsed = multiPolygonFromWKT<CoordType>(wktLiteral);
         break;
-      }
-      case COLLECTION: {
+      case COLLECTION:
         parsed = collectionFromWKT<CoordType>(wktLiteral);
         break;
-      }
       case NONE:
       default:
         break;
@@ -78,7 +71,7 @@ inline ParseResult parseWkt(const std::string_view& wkt) {
                  << std::endl;
   }
 
-  return {type, parsed};
+  return {type, std::move(parsed)};
 }
 
 // ____________________________________________________________________________

--- a/src/rdfTypes/GeometryInfoHelpersImpl.h
+++ b/src/rdfTypes/GeometryInfoHelpersImpl.h
@@ -38,37 +38,42 @@ inline ParseResult parseWkt(const std::string_view& wkt) {
   auto wktLiteral = removeDatatype(wkt);
   std::optional<ParsedWkt> parsed = std::nullopt;
   auto type = getWKTType(wktLiteral);
-  switch (type) {
-    case WKTType::POINT: {
-      parsed = pointFromWKT<CoordType>(wktLiteral);
-      break;
+  try {
+    switch (type) {
+      case WKTType::POINT: {
+        parsed = pointFromWKT<CoordType>(wktLiteral);
+        break;
+      }
+      case WKTType::LINESTRING: {
+        parsed = lineFromWKT<CoordType>(wktLiteral);
+        break;
+      }
+      case WKTType::POLYGON: {
+        parsed = polygonFromWKT<CoordType>(wktLiteral);
+        break;
+      }
+      case WKTType::MULTIPOINT: {
+        parsed = multiPointFromWKT<CoordType>(wktLiteral);
+        break;
+      }
+      case WKTType::MULTILINESTRING: {
+        parsed = multiLineFromWKT<CoordType>(wktLiteral);
+        break;
+      }
+      case WKTType::MULTIPOLYGON: {
+        parsed = multiPolygonFromWKT<CoordType>(wktLiteral);
+        break;
+      }
+      case WKTType::COLLECTION: {
+        parsed = collectionFromWKT<CoordType>(wktLiteral);
+        break;
+      }
+      case WKTType::NONE:
+        break;
     }
-    case WKTType::LINESTRING: {
-      parsed = lineFromWKT<CoordType>(wktLiteral);
-      break;
-    }
-    case WKTType::POLYGON: {
-      parsed = polygonFromWKT<CoordType>(wktLiteral);
-      break;
-    }
-    case WKTType::MULTIPOINT: {
-      parsed = multiPointFromWKT<CoordType>(wktLiteral);
-      break;
-    }
-    case WKTType::MULTILINESTRING: {
-      parsed = multiLineFromWKT<CoordType>(wktLiteral);
-      break;
-    }
-    case WKTType::MULTIPOLYGON: {
-      parsed = multiPolygonFromWKT<CoordType>(wktLiteral);
-      break;
-    }
-    case WKTType::COLLECTION: {
-      parsed = collectionFromWKT<CoordType>(wktLiteral);
-      break;
-    }
-    case WKTType::NONE:
-      break;
+  } catch (const std::runtime_error& error) {
+    AD_LOG_DEBUG << "Cannot parse WKT `" << wkt << "`: " << error.what()
+                 << std::endl;
   }
 
   return {type, parsed};

--- a/test/GeometryInfoTest.cpp
+++ b/test/GeometryInfoTest.cpp
@@ -36,8 +36,14 @@ constexpr std::string_view litCollection =
     "\"GEOMETRYCOLLECTION(POLYGON((2 4,8 4,8 6,2 6,2 4)), LINESTRING(2 2, 4 4),"
     "POINT(3 4))\"^^<http://www.opengis.net/ont/geosparql#wktLiteral>";
 
-constexpr std::string_view litInvalid =
+constexpr std::string_view litInvalidType =
     "\"BLABLIBLU(xyz)\"^^<http://www.opengis.net/ont/geosparql#wktLiteral>";
+constexpr std::string_view litInvalidBrackets =
+    "\"POLYGON)2 4, 4 4, 4 2, 2 2(\""
+    "^^<http://www.opengis.net/ont/geosparql#wktLiteral>";
+constexpr std::string_view litInvalidNumCoords =
+    "\"POINT(1)\""
+    "^^<http://www.opengis.net/ont/geosparql#wktLiteral>";
 constexpr std::string_view litCoordOutOfRange =
     "\"LINESTRING(2 -500, 4 4)\""
     "^^<http://www.opengis.net/ont/geosparql#wktLiteral>";
@@ -101,7 +107,7 @@ TEST(GeometryInfoTest, FromWktLiteral) {
   GeometryInfo exp7{7, {{2, 2}, {6, 8}}, {5, 5}};
   checkGeoInfo(g7, exp7);
 
-  auto g8 = GeometryInfo::fromWktLiteral(litInvalid);
+  auto g8 = GeometryInfo::fromWktLiteral(litInvalidType);
   checkGeoInfo(g8, std::nullopt);
 }
 
@@ -220,7 +226,9 @@ TEST(GeometryInfoTest, GeometryInfoHelpers) {
 
 // ____________________________________________________________________________
 TEST(GeometryInfoTest, InvalidLiteralAdHocCompuation) {
-  checkInvalidLiteral(litInvalid);
+  checkInvalidLiteral(litInvalidType);
+  checkInvalidLiteral(litInvalidBrackets, true);
+  checkInvalidLiteral(litInvalidNumCoords, true);
 }
 
 // ____________________________________________________________________________


### PR DESCRIPTION
Catch the exception `Could not parse WKT` from `pb_util`, which occurs for a specific subset of invalid literals only. This error is now treated like the other WKT parsing errors (debug log message, no precomputed geometry info). Fixes a part of #2229.