### PR TITLE
Add `GeoPointOrWktValueGetter`

### DIFF
--- a/src/engine/sparqlExpressions/SparqlExpressionValueGetters.cpp
+++ b/src/engine/sparqlExpressions/SparqlExpressionValueGetters.cpp
@@ -378,6 +378,43 @@ UnitOfMeasurement UnitOfMeasurementValueGetter::litOrIriToUnit(
 }
 
 //______________________________________________________________________________
+std::optional<ad_utility::GeoPointOrWkt> GeoPointOrWktValueGetter::operator()(
+    ValueId id, const EvaluationContext* context) const {
+  using enum Datatype;
+  switch (id.getDatatype()) {
+    case GeoPoint:
+      return id.getGeoPoint();
+    case VocabIndex:
+    case LocalVocabIndex: {
+      auto lit = ExportQueryExecutionTrees::getLiteralOrIriFromVocabIndex(
+          context->_qec.getIndex(), id, context->_localVocab);
+      return GeoPointOrWktValueGetter{}(lit, context);
+    }
+    case Bool:
+    case Int:
+    case Double:
+    case Date:
+    case Undefined:
+    case TextRecordIndex:
+    case WordVocabIndex:
+    case BlankNodeIndex:
+      return std::nullopt;
+  }
+
+  AD_FAIL();
+}
+
+//______________________________________________________________________________
+std::optional<ad_utility::GeoPointOrWkt> GeoPointOrWktValueGetter::operator()(
+    const LiteralOrIri& litOrIri, const EvaluationContext*) const {
+  if (litOrIri.isLiteral() && litOrIri.hasDatatype() &&
+      asStringViewUnsafe(litOrIri.getDatatype()) == GEO_WKT_LITERAL) {
+    return litOrIri.toStringRepresentation();
+  }
+  return std::nullopt;
+};
+
+//______________________________________________________________________________
 CPP_template(typename T, typename ValueGetter)(
     requires(concepts::same_as<sparqlExpression::IdOrLiteralOrIri, T> ||
              concepts::same_as<std::optional<std::string>, T>)) T

--- a/src/engine/sparqlExpressions/SparqlExpressionValueGetters.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionValueGetters.h
@@ -368,6 +368,16 @@ struct UnitOfMeasurementValueGetter : Mixin<UnitOfMeasurementValueGetter> {
   static UnitOfMeasurement litOrIriToUnit(const LiteralOrIri& s);
 };
 
+// This value getter retrieves geometries: `GeoPoints` or literals with
+// `geo:wktLiteral` datatype.
+struct GeoPointOrWktValueGetter : Mixin<GeoPointOrWktValueGetter> {
+  using Mixin<GeoPointOrWktValueGetter>::operator();
+  std::optional<ad_utility::GeoPointOrWkt> operator()(
+      ValueId id, const EvaluationContext*) const;
+  std::optional<ad_utility::GeoPointOrWkt> operator()(
+      const LiteralOrIri&, const EvaluationContext*) const;
+};
+
 // `LanguageTagValueGetter` returns an `std::optional<std::string>` object
 // which contains the language tag if previously set w.r.t. given
 // `Id`/`Literal`. This ValueGetter is currently used within

--- a/src/rdfTypes/GeometryInfo.h
+++ b/src/rdfTypes/GeometryInfo.h
@@ -70,6 +70,9 @@ template <typename T>
 CPP_concept RequestedInfoT =
     SameAsAny<T, GeometryInfo, Centroid, BoundingBox, GeometryType>;
 
+// Where the actual geometries are required, this type can be used.
+using GeoPointOrWkt = std::variant<GeoPoint, std::string>;
+
 // The version of the `GeometryInfo`: to ensure correctness when reading disk
 // serialized objects of this class.
 constexpr uint64_t GEOMETRY_INFO_VERSION = 1;

--- a/test/ValueGetterTest.cpp
+++ b/test/ValueGetterTest.cpp
@@ -200,4 +200,13 @@ TEST(GeometryInfoValueGetterTest, OperatorWithUnrelatedId) {
   checkGeoInfoFromValueId(ValueId::makeFromDouble(42.01), std::nullopt);
 }
 
+// _____________________________________________________________________________
+TEST(GeoPointOrWktValueGetterTest, OperatorWithIdGeoPoint) {}
+
+// _____________________________________________________________________________
+TEST(GeoPointOrWktValueGetterTest, OperatorWithIdVocab) {}
+
+// _____________________________________________________________________________
+TEST(GeoPointOrWktValueGetterTest, OperatorWithLit) {}
+
 };  // namespace


### PR DESCRIPTION
Add a new `GeoPointOrWktValueGetter`, which implements the expensive case to return the actual geometry for all geometry types. Preparation for #2180 and more future work.