### PR TITLE
Fix two bugs in `CompressedExternalIdTable`

### DIFF
--- a/src/engine/idTable/CompressedExternalIdTable.h
+++ b/src/engine/idTable/CompressedExternalIdTable.h
@@ -218,10 +218,11 @@ class CompressedExternalIdTableWriter {
   template <size_t NumCols = 0>
   InputRangeTypeErased<IdTableStatic<NumCols>> makeGeneratorForIdTable(
       size_t index) {
+    size_t firstBlock = startOfSingleIdTables_.at(index);
     size_t lastBlock{index + 1 < startOfSingleIdTables_.size()
                          ? startOfSingleIdTables_.at(index + 1)
                          : blocksPerColumn_.at(0).size()};
-    auto readBlocks = ql::views::iota(index, lastBlock) |
+    auto readBlocks = ql::views::iota(firstBlock, lastBlock) |
                       ql::views::transform([this](auto blockIdx) {
                         return this->template readBlock<NumCols>(blockIdx);
                       });

--- a/test/util/IdTableHelpers.cpp
+++ b/test/util/IdTableHelpers.cpp
@@ -69,8 +69,6 @@ void sortIdTableByJoinColumnInPlace(IdTableAndJoinColumn& table) {
 IdTable generateIdTable(
     const size_t numberRows, const size_t numberColumns,
     const std::function<std::vector<ValueId>()>& rowGenerator) {
-  AD_CONTRACT_CHECK(numberRows > 0 && numberColumns > 0);
-
   // Creating the table and setting it to the wanted size.
   IdTable table{numberColumns, ad_utility::testing::makeAllocator()};
   table.resize(numberRows);
@@ -102,8 +100,6 @@ IdTable createRandomlyFilledIdTable(
     const std::vector<std::pair<size_t, std::function<ValueId()>>>&
         joinColumnWithGenerator,
     const ad_utility::RandomSeed randomSeed) {
-  AD_CONTRACT_CHECK(numberRows > 0 && numberColumns > 0);
-
   // Views for clearer access.
   auto joinColumnNumberView = ql::views::keys(joinColumnWithGenerator);
   auto joinColumnGeneratorView = ql::views::values(joinColumnWithGenerator);


### PR DESCRIPTION
Fix a bug introduced in #2036 due to which most index builds failed. Add a unit test that would have caught that bug. Fixes #2229 