### PR TITLE
Fix compilation on gcc

### DIFF
--- a/test/MinusTest.cpp
+++ b/test/MinusTest.cpp
@@ -566,7 +566,8 @@ TEST(Minus, MinusRowHandlerKeepsLeftLocalVocabAfterFlush) {
 
   handler.flush();
 
-  EXPECT_THAT(resultTables, ::testing::ElementsAre(std::cref(input)));
+  EXPECT_THAT(resultTables,
+              ::testing::ElementsAre(::testing::Eq(std::cref(input))));
   EXPECT_EQ(handler.localVocab().size(), 1);
   EXPECT_THAT(handler.localVocab().getAllWordsForTesting(),
               ::testing::ElementsAre(testLiteral));


### PR DESCRIPTION
This PR fixes a regression introduced in #2026, which introduced a compiler error when using gcc. This issue is not present when compiling with clang.