### PR TITLE
Add `geof:numGeometries` using `GeometryInfo`

### DIFF
--- a/src/rdfTypes/GeometryInfo.cpp
+++ b/src/rdfTypes/GeometryInfo.cpp
@@ -152,6 +152,21 @@ template double BoundingBox::getBoundingCoordinate<BoundingCoordinate::MAX_Y>()
     const;
 
 // ____________________________________________________________________________
+NumGeometries GeometryInfo::getNumGeometries() const {
+  return {numGeometries_};
+}
+
+// ____________________________________________________________________________
+std::optional<NumGeometries> GeometryInfo::getNumGeometries(
+    std::string_view wkt) {
+  auto [type, parsed] = detail::parseWkt(wkt);
+  if (!parsed.has_value()) {
+    return std::nullopt;
+  }
+  return NumGeometries{detail::countChildGeometries(parsed.value())};
+}
+
+// ____________________________________________________________________________
 template <typename RequestedInfo>
 requires RequestedInfoT<RequestedInfo>
 RequestedInfo GeometryInfo::getRequestedInfo() const {
@@ -163,6 +178,8 @@ RequestedInfo GeometryInfo::getRequestedInfo() const {
     return getBoundingBox();
   } else if constexpr (std::is_same_v<RequestedInfo, GeometryType>) {
     return getWktType();
+  } else if constexpr (std::is_same_v<RequestedInfo, NumGeometries>) {
+    return getNumGeometries();
   } else {
     static_assert(ad_utility::alwaysFalse<RequestedInfo>);
   }
@@ -173,6 +190,7 @@ template GeometryInfo GeometryInfo::getRequestedInfo<GeometryInfo>() const;
 template Centroid GeometryInfo::getRequestedInfo<Centroid>() const;
 template BoundingBox GeometryInfo::getRequestedInfo<BoundingBox>() const;
 template GeometryType GeometryInfo::getRequestedInfo<GeometryType>() const;
+template NumGeometries GeometryInfo::getRequestedInfo<NumGeometries>() const;
 
 // ____________________________________________________________________________
 template <typename RequestedInfo>
@@ -187,6 +205,8 @@ std::optional<RequestedInfo> GeometryInfo::getRequestedInfo(
     return GeometryInfo::getBoundingBox(wkt);
   } else if constexpr (std::is_same_v<RequestedInfo, GeometryType>) {
     return GeometryInfo::getWktType(wkt);
+  } else if constexpr (std::is_same_v<RequestedInfo, NumGeometries>) {
+    return GeometryInfo::getNumGeometries(wkt);
   } else {
     static_assert(ad_utility::alwaysFalse<RequestedInfo>);
   }
@@ -201,5 +221,7 @@ template std::optional<BoundingBox> GeometryInfo::getRequestedInfo<BoundingBox>(
     std::string_view wkt);
 template std::optional<GeometryType>
 GeometryInfo::getRequestedInfo<GeometryType>(std::string_view wkt);
+template std::optional<NumGeometries>
+GeometryInfo::getRequestedInfo<NumGeometries>(std::string_view wkt);
 
 }  // namespace ad_utility

--- a/src/rdfTypes/GeometryInfo.h
+++ b/src/rdfTypes/GeometryInfo.h
@@ -61,18 +61,23 @@ struct GeometryType {
   std::optional<std::string_view> asIri() const;
 };
 
+// Represents the number of child geometries inside a collection geometry type.
+struct NumGeometries {
+  uint32_t numGeometries_;
+};
+
 // Forward declaration for concept
 class GeometryInfo;
 
 // Concept for the `RequestedInfo` template parameter: any of these types is
 // allowed to be requested.
 template <typename T>
-CPP_concept RequestedInfoT =
-    SameAsAny<T, GeometryInfo, Centroid, BoundingBox, GeometryType>;
+CPP_concept RequestedInfoT = SameAsAny<T, GeometryInfo, Centroid, BoundingBox,
+                                       GeometryType, NumGeometries>;
 
 // The version of the `GeometryInfo`: to ensure correctness when reading disk
 // serialized objects of this class.
-constexpr uint64_t GEOMETRY_INFO_VERSION = 1;
+constexpr uint64_t GEOMETRY_INFO_VERSION = 2;
 
 // A geometry info object holds precomputed details on WKT literals.
 // IMPORTANT: Every modification of the attributes of this class will be an
@@ -86,6 +91,7 @@ class GeometryInfo {
   // `GeoVocabulary` to represent invalid literals.
   EncodedBoundingBox boundingBox_;
   uint64_t geometryTypeAndCentroid_;
+  uint32_t numGeometries_;
 
   // TODO<ullingerc>: Implement the behavior for the following two
   // attributes
@@ -127,6 +133,13 @@ class GeometryInfo {
 
   // Parse an arbitrary WKT literal and compute only the bounding box.
   static std::optional<BoundingBox> getBoundingBox(std::string_view wkt);
+
+  // Get the number of child geometries contained in this geometry.
+  NumGeometries getNumGeometries() const;
+
+  // Parse an arbitrary WKT literal and compute only the number of child
+  // geometries.
+  static std::optional<NumGeometries> getNumGeometries(std::string_view wkt);
 
   // Extract the requested information from this object.
   template <typename RequestedInfo = GeometryInfo>


### PR DESCRIPTION
Add the `geof:numGeometries` GeoSPARQL function which counts the member geometries of a given literal. 

Draft/WIP ; TODO: ambiguities, tests, function/expression
