### PR TITLE
Make `SpatialJoin` bounding box prefilter configurable

### DIFF
--- a/src/ServerMain.cpp
+++ b/src/ServerMain.cpp
@@ -147,6 +147,11 @@ int main(int argc, char** argv) {
       optionFactory.getProgramOption<"enable-prefilter-on-index-scans">(),
       "If set to false, the prefilter procedures for FILTER expressions are "
       "disabled.");
+  add("spatial-join-prefilter-max-size",
+      optionFactory.getProgramOption<"spatial-join-prefilter-max-size">(),
+      "The maximum size of the aggregated bounding box of the smaller join "
+      "partner in a spatial join, such that prefiltering will be employed. To "
+      "disable prefiltering for non-point geometries, set this option to 0.");
   po::variables_map optionsMap;
 
   try {

--- a/src/engine/SpatialJoinAlgorithms.cpp
+++ b/src/engine/SpatialJoinAlgorithms.cpp
@@ -80,12 +80,11 @@ std::pair<util::geo::I32Box, size_t> SpatialJoinAlgorithms::libspatialjoinParse(
   bool usePrefiltering = prefilterLatLngBox.has_value() &&
                          qec_->getIndex().getVocab().isGeoInfoAvailable();
 
-  // If the prefilter box is larger than 50 x 50 coordinates, the
-  // prefiltering overhead (cost of retrieving bounding boxes from disk) is
-  // likely larger than its performance gain. Therefore prefiltering is
-  // disabled in this case.
+  // If the prefilter box is too large, the prefiltering overhead (cost of
+  // retrieving bounding boxes from disk) is likely larger than its performance
+  // gain. Therefore prefiltering is disabled in this case.
   if (usePrefiltering &&
-      util::geo::area(prefilterLatLngBox.value()) > maxAreaPrefilterBox_) {
+      util::geo::area(prefilterLatLngBox.value()) > maxAreaPrefilterBox()) {
     usePrefiltering = false;
     spatialJoin_.value()->runtimeInfo().addDetail(
         "prefilter-disabled-by-bounding-box-area", true);

--- a/src/engine/SpatialJoinAlgorithms.h
+++ b/src/engine/SpatialJoinAlgorithms.h
@@ -19,6 +19,7 @@
 
 #include "engine/Result.h"
 #include "engine/SpatialJoin.h"
+#include "global/RuntimeParameters.h"
 #include "util/GeoSparqlHelpers.h"
 
 namespace BoostGeometryNamespace {
@@ -238,7 +239,10 @@ class SpatialJoinAlgorithms {
   // Maximum area of bounding box in square coordinates for prefiltering
   // libspatialjoin input by bounding box. If exceeded, prefiltering is
   // disabled. See `libspatialjoinParse`.
-  static constexpr double maxAreaPrefilterBox_ = 2500.0;
+  static double maxAreaPrefilterBox() {
+    return static_cast<double>(
+        RuntimeParameters().get<"spatial-join-prefilter-max-size">());
+  };
 
   // if the distance calculation should be approximated, by the midpoint of
   // the area

--- a/src/global/RuntimeParameters.h
+++ b/src/global/RuntimeParameters.h
@@ -93,6 +93,9 @@ inline auto& RuntimeParameters() {
         // prefilter-free baseline, or for debugging, as wrong results may be
         // related to the `PrefilterExpression`s.
         Bool<"enable-prefilter-on-index-scans">{true},
+        // The maximum size of the `prefilterBox` for
+        // `SpatialJoinAlgorithms::libspatialjoinParse()`.
+        SizeT<"spatial-join-prefilter-max-size">{2'500},
     };
   }();
   return params;


### PR DESCRIPTION
With #2205 , `SpatialJoin` can prefilter the geometries of the larger join side using the aggregated bounding box of the geometries on the smaller side. If this bounding box happens to be very large, this optimization does not provide a performance benefit. Thus, if the bounding box was larger than 2,500 square coordinates, prefiltering was disabled automatically.

This PR adds a runtime parameter `spatial-join-prefilter-max-size`, which can be used to customize when prefiltering is enabled and disabled. It may be set to `0` to disable prefiltering altogether.
