### PR TITLE
Implement index nested loop join for `MINUS` and `EXISTS`

### DIFF
--- a/src/engine/ExistsJoin.cpp
+++ b/src/engine/ExistsJoin.cpp
@@ -292,8 +292,8 @@ std::optional<Result> ExistsJoin::tryNestedLoopJoinIfSuitable() {
   result.addEmptyColumn();
   ad_utility::chunkedCopy(
       ql::ranges::transform_view(
-          ad_utility::OwningView{nestedLoopJoin.computeCounter()},
-          [](size_t counter) { return Id::makeFromBool(counter != 0); }),
+          ad_utility::OwningView{nestedLoopJoin.computeTracker()},
+          [](char tracker) { return Id::makeFromBool(tracker != 0); }),
       result.getColumn(result.numColumns() - 1).begin(),
       qlever::joinHelpers::CHUNK_SIZE, [this]() { checkCancellation(); });
   return std::optional{

--- a/src/engine/ExistsJoin.cpp
+++ b/src/engine/ExistsJoin.cpp
@@ -294,9 +294,9 @@ std::optional<Result> ExistsJoin::tryNestedLoopJoinIfSuitable() {
   }
   auto leftRes = left_->getResult(false);
   auto child = right_->getRootOperation()->getChildren().at(0);
-  auto runTimeInfoChildren = child->getRootOperation()->getRuntimeInfoPointer();
+  auto runtimeInfoChildren = child->getRootOperation()->getRuntimeInfoPointer();
   right_->getRootOperation()->updateRuntimeInformationWhenOptimizedOut(
-      {runTimeInfoChildren});
+      {runtimeInfoChildren});
   auto rightRes = child->getResult(true);
 
   IdTable result = leftRes->idTable().clone();

--- a/src/engine/ExistsJoin.h
+++ b/src/engine/ExistsJoin.h
@@ -82,6 +82,8 @@ class ExistsJoin : public Operation {
  private:
   std::unique_ptr<Operation> cloneImpl() const override;
 
+  // Nested loop join optimization than can apply when a memory intensive sort
+  // can be avoided this way.
   std::optional<Result> tryNestedLoopJoinIfSuitable();
 
   Result computeResult(bool requestLaziness) override;

--- a/src/engine/ExistsJoin.h
+++ b/src/engine/ExistsJoin.h
@@ -82,6 +82,8 @@ class ExistsJoin : public Operation {
  private:
   std::unique_ptr<Operation> cloneImpl() const override;
 
+  std::optional<Result> tryNestedLoopJoinIfSuitable();
+
   Result computeResult(bool requestLaziness) override;
 
   VariableToColumnMap computeVariableToColumnMap() const override;

--- a/src/engine/Minus.cpp
+++ b/src/engine/Minus.cpp
@@ -256,9 +256,9 @@ std::optional<Result> Minus::tryNestedLoopJoinIfSuitable() {
   auto leftRes = _left->getResult(false);
   const IdTable& leftTable = leftRes->idTable();
   auto child = _right->getRootOperation()->getChildren().at(0);
-  auto runTimeInfoChildren = child->getRootOperation()->getRuntimeInfoPointer();
+  auto runtimeInfoChildren = child->getRootOperation()->getRuntimeInfoPointer();
   _right->getRootOperation()->updateRuntimeInformationWhenOptimizedOut(
-      {runTimeInfoChildren});
+      {runtimeInfoChildren});
   auto rightRes = child->getResult(true);
 
   LocalVocab localVocab = leftRes->getCopyOfLocalVocab();

--- a/src/engine/Minus.cpp
+++ b/src/engine/Minus.cpp
@@ -150,9 +150,9 @@ IdTable Minus::copyMatchingRows(const IdTable& left, T reference,
   }
   result.resize(nonMatchingIndices.size());
 
-  using O = ad_utility::OwningView;
   for (const auto& [outputCol, inputCol] :
-       ::ranges::views::zip(O{result.getColumns()}, O{left.getColumns()})) {
+       ::ranges::views::zip(ad_utility::OwningView{result.getColumns()},
+                            ad_utility::OwningView{left.getColumns()})) {
     ad_utility::chunkedCopy(
         ql::views::transform(nonMatchingIndices,
                              [&inputCol](size_t row) { return inputCol[row]; }),

--- a/src/engine/Minus.h
+++ b/src/engine/Minus.h
@@ -54,6 +54,12 @@ class Minus : public Operation {
   // implementation of this function.
   auto makeUndefRangesChecker(bool left, const IdTable& idTable) const;
 
+  // Helper function to copy all rows from `left` that have a corresponding
+  // value of `reference` in `keepEntry`.
+  template <typename T>
+  IdTable copyMatchingRows(const IdTable& left, T reference,
+                           const std::vector<T>& keepEntry) const;
+
  public:
   size_t getCostEstimate() override;
 
@@ -76,6 +82,10 @@ class Minus : public Operation {
 
  private:
   std::unique_ptr<Operation> cloneImpl() const override;
+
+  // Nested loop join optimization than can apply when a memory intensive sort
+  // can be avoided this way.
+  std::optional<Result> tryNestedLoopJoinIfSuitable();
 
   // Lazily compute the minus join of two results when at least one of the
   // results is computed lazily. This currently only works if we have just a

--- a/src/util/JoinAlgorithms/NestedLoopJoin.h
+++ b/src/util/JoinAlgorithms/NestedLoopJoin.h
@@ -1,0 +1,96 @@
+//   Copyright 2025, University of Freiburg,
+//   Chair of Algorithms and Data Structures.
+//   Author: Robin Textor-Falconi <textorr@informatik.uni-freiburg.de>
+
+#ifndef QLEVER_SRC_UTIL_JOINALGORITHMS_NESTEDLOOPJOIN_H
+#define QLEVER_SRC_UTIL_JOINALGORITHMS_NESTEDLOOPJOIN_H
+
+#include <vector>
+
+#include "engine/CallFixedSize.h"
+#include "engine/Result.h"
+#include "engine/idTable/IdTable.h"
+#include "util/Exception.h"
+
+class NestedLoopJoin {
+  std::vector<std::array<ColumnIndex, 2>> joinColumns_;
+  std::shared_ptr<const Result> leftResult_;
+  std::shared_ptr<const Result> rightResult_;
+
+  const IdTable& leftTable_;
+
+  std::optional<Result::IdTableVocabPair> currentRightTable_ = std::nullopt;
+
+ public:
+  NestedLoopJoin(std::vector<std::array<ColumnIndex, 2>> joinColumns,
+                 std::shared_ptr<const Result> leftResult,
+                 std::shared_ptr<const Result> rightResult)
+      : joinColumns_{std::move(joinColumns)},
+        leftResult_{std::move(leftResult)},
+        rightResult_{std::move(rightResult)},
+        leftTable_{leftResult_->idTable()} {}
+
+ private:
+  template <int JOIN_COLUMNS>
+  void matchLeft(std::vector<size_t>& matchCounter,
+                 IdTableView<JOIN_COLUMNS> leftTable,
+                 IdTableView<JOIN_COLUMNS> rightTable) {
+    AD_CORRECTNESS_CHECK(matchCounter.size() == leftTable.size());
+    for (const auto& rightRow : rightTable) {
+      size_t leftOffset = 0;
+      size_t leftSize = leftTable.size();
+      for (const auto& [rightId, leftCol] :
+           ::ranges::zip_view(rightRow, leftTable.getColumns())) {
+        AD_CORRECTNESS_CHECK(!rightId.isUndefined());
+        ql::ranges::subrange rangeToCheck{
+            leftCol.begin() + leftOffset,
+            leftCol.begin() + leftOffset + leftSize};
+        auto subrange =
+            ql::ranges::equal_range(rangeToCheck, rightId, std::less{});
+        leftSize = ql::ranges::size(subrange);
+        if (subrange.empty()) {
+          break;
+        }
+        leftOffset = ql::ranges::distance(leftCol.begin(), subrange.begin());
+      }
+      for (size_t i = 0; i < leftSize; ++i) {
+        ++matchCounter[leftOffset + i];
+      }
+    }
+  }
+
+ public:
+  std::vector<size_t> computeCounter() {
+    return ad_utility::callFixedSize(
+        static_cast<int>(joinColumns_.size()), [this]<int JOIN_COLUMNS>() {
+          std::vector<size_t> matchCounter(leftTable_.size(), 0);
+          std::array<ColumnIndex, JOIN_COLUMNS> leftColumns;
+          std::array<ColumnIndex, JOIN_COLUMNS> rightColumns;
+          size_t idx = 0;
+          for (const auto& [leftCol, rightCol] : joinColumns_) {
+            leftColumns[idx] = leftCol;
+            rightColumns[idx] = rightCol;
+            ++idx;
+          }
+          IdTableView<JOIN_COLUMNS> leftTable =
+              leftTable_.asColumnSubsetView(leftColumns)
+                  .template asStaticView<JOIN_COLUMNS>();
+          auto matchHelper = [this, &matchCounter, &leftTable,
+                              &rightColumns](const IdTable& idTable) {
+            this->matchLeft(matchCounter, leftTable,
+                            idTable.asColumnSubsetView(rightColumns)
+                                .template asStaticView<JOIN_COLUMNS>());
+          };
+          if (rightResult_->isFullyMaterialized()) {
+            matchHelper(rightResult_->idTable());
+          } else {
+            for (const auto& [idTable, _] : rightResult_->idTables()) {
+              matchHelper(idTable);
+            }
+          }
+          return matchCounter;
+        });
+  }
+};
+
+#endif  // QLEVER_SRC_UTIL_JOINALGORITHMS_NESTEDLOOPJOIN_H

--- a/src/util/JoinAlgorithms/NestedLoopJoin.h
+++ b/src/util/JoinAlgorithms/NestedLoopJoin.h
@@ -42,12 +42,10 @@ class NestedLoopJoin {
       size_t leftSize = leftTable.size();
       for (const auto& [rightId, leftCol] :
            ::ranges::zip_view(rightRow, leftColumns)) {
-        AD_CORRECTNESS_CHECK(!rightId.isUndefined());
-        ql::ranges::subrange rangeToCheck{
-            leftCol.begin() + leftOffset,
-            leftCol.begin() + leftOffset + leftSize};
-        auto subrange =
-            ql::ranges::equal_range(rangeToCheck, rightId, std::less{});
+        AD_EXPENSIVE_CHECK(!rightId.isUndefined());
+        auto currentStart = leftCol.begin() + leftOffset;
+        auto subrange = ql::ranges::equal_range(
+            currentStart, currentStart + leftSize, rightId, std::less{});
         leftSize = ql::ranges::size(subrange);
         if (subrange.empty()) {
           break;

--- a/src/util/JoinAlgorithms/NestedLoopJoin.h
+++ b/src/util/JoinAlgorithms/NestedLoopJoin.h
@@ -10,6 +10,7 @@
 #include "engine/CallFixedSize.h"
 #include "engine/Result.h"
 #include "engine/idTable/IdTable.h"
+#include "util/CompilerExtensions.h"
 #include "util/Exception.h"
 
 class NestedLoopJoin {
@@ -32,9 +33,9 @@ class NestedLoopJoin {
 
  private:
   template <int JOIN_COLUMNS>
-  static void matchLeft(std::vector<char>& matchTracker,
-                        IdTableView<JOIN_COLUMNS> leftTable,
-                        IdTableView<JOIN_COLUMNS> rightTable) {
+  AD_ALWAYS_INLINE static void matchLeft(std::vector<char>& matchTracker,
+                                         IdTableView<JOIN_COLUMNS> leftTable,
+                                         IdTableView<JOIN_COLUMNS> rightTable) {
     AD_CORRECTNESS_CHECK(matchTracker.size() == leftTable.size());
     auto leftColumns = leftTable.getColumns();
     for (const auto& rightRow : rightTable) {

--- a/test/LocalVocabTest.cpp
+++ b/test/LocalVocabTest.cpp
@@ -368,7 +368,7 @@ TEST(LocalVocab, propagation) {
   Minus minus1(testQec, qet(values1), qet(values2));
   checkLocalVocab(minus1, localVocab1);
   Minus minus2(testQec, qet(values1), qet(values3));
-  checkLocalVocab(minus2, localVocab13);
+  checkLocalVocab(minus2, localVocab1);
 
   // FILTER operation (the third argument is an expression; which one doesn't
   // matter for this test).

--- a/test/MinusTest.cpp
+++ b/test/MinusTest.cpp
@@ -145,9 +145,11 @@ TEST(Minus, computeMinus) {
 
 // _____________________________________________________________________________
 TEST(Minus, computeMinusNestedLoopJoinOptimization) {
+  // From this table columns 1 and 2 will be used for the join.
   IdTable a = makeIdTableFromVector(
       {{1, 1, 2}, {4, 2, 1}, {2, 8, 1}, {3, 8, 2}, {4, 8, 2}});
 
+  // From this table columns 2 and 1 will be used for the join.
   // This is deliberately not sorted to check the optimization that avoids
   // sorting on the right if bigger
   IdTable b = makeIdTableFromVector({{7, 2, 1, 5},

--- a/test/MinusTest.cpp
+++ b/test/MinusTest.cpp
@@ -144,6 +144,45 @@ TEST(Minus, computeMinus) {
 }
 
 // _____________________________________________________________________________
+TEST(Minus, computeMinusNestedLoopJoinOptimization) {
+  IdTable a = makeIdTableFromVector(
+      {{1, 1, 2}, {4, 2, 1}, {2, 8, 1}, {3, 8, 2}, {4, 8, 2}});
+
+  // This is deliberately not sorted to check the optimization that avoids
+  // sorting on the right if bigger
+  IdTable b = makeIdTableFromVector({{7, 2, 1, 5},
+                                     {1, 3, 3, 5},
+                                     {1, 8, 1, 5},
+                                     {7, 2, 8, 14},
+                                     {10, 11, 12, 13},
+                                     {14, 15, 16, 17}});
+  IdTable expected = makeIdTableFromVector({{4, 2, 1}, {2, 8, 1}});
+
+  auto* qec = ad_utility::testing::getQec();
+  for (bool forceFullyMaterialized : {false, true}) {
+    Minus m{qec,
+            ad_utility::makeExecutionTree<ValuesForTesting>(
+                qec, a.clone(),
+                std::vector<std::optional<Variable>>{
+                    std::nullopt, Variable{"?a"}, Variable{"?b"}},
+                false, std::vector<ColumnIndex>{1, 2}),
+            ad_utility::makeExecutionTree<ValuesForTesting>(
+                qec, b.clone(),
+                std::vector<std::optional<Variable>>{
+                    std::nullopt, Variable{"?b"}, Variable{"?a"}, std::nullopt},
+                false, std::vector<ColumnIndex>{}, LocalVocab{}, std::nullopt,
+                forceFullyMaterialized)};
+    auto result = m.computeResultOnlyForTesting(true);
+    ASSERT_TRUE(result.isFullyMaterialized());
+    EXPECT_EQ(result.idTable(), expected);
+    const auto& runtimeInfo =
+        m.getChildren().at(1)->getRootOperation()->runtimeInfo();
+    EXPECT_EQ(runtimeInfo.status_, RuntimeInformation::Status::optimizedOut);
+    EXPECT_EQ(runtimeInfo.numRows_, 0);
+  }
+}
+
+// _____________________________________________________________________________
 TEST(Minus, computeMinusWithEmptyTables) {
   IdTable nonEmpty = makeIdTableFromVector({{1, 2}, {3, 3}, {1, 8}});
   IdTable empty = IdTable{2, nonEmpty.getAllocator()};

--- a/test/engine/ExistsJoinTest.cpp
+++ b/test/engine/ExistsJoinTest.cpp
@@ -198,9 +198,11 @@ TEST(Exists, computeResult) {
 
 // _____________________________________________________________________________
 TEST(ExistsJoin, computeExistsJoinNestedLoopJoinOptimization) {
+  // From this table columns 1 and 2 will be used for the join.
   IdTable a = makeIdTableFromVector(
       {{1, 1, 2}, {4, 2, 1}, {2, 8, 1}, {3, 8, 2}, {4, 8, 2}});
 
+  // From this table columns 2 and 1 will be used for the join.
   // This is deliberately not sorted to check the optimization that avoids
   // sorting on the right if bigger
   IdTable b = makeIdTableFromVector({{7, 2, 1, 5},


### PR DESCRIPTION
Queries like the following two run out of memory with the current code because the RHS (the argument of the `MINUS` or `EXISTS`) is too large to be materialized and sorted in memory (and QLever currently does *not* have a query operation that sorts lazily with limited memory). This is now remedied by an index nested loop join, provided that the size estimate of the LHS is smaller than (or equal to) the size estimate of the RHS. Specifically, the LHS is then fully materialized (hence the precondition on its size) and binary-searched for each element from the lazily produced RHS.

NOTE: This has running time ~ RHS * log(LHS), which is large but at least it works now. A better algorithm could be to sort chunks of the RHS and join them with the LHS. However, that is not trivial for multi-column joins and when a single element matches mutliple blocks.
```sparql
SELECT * WHERE {
  ?s wdt:P31 ?o .
  MINUS {
    ?s wdt:P31 ?m .
    ?m wdt:P279* ?o .
  }
}
```
```sparql
SELECT * WHERE {
  ?s wdt:P31 ?o .
  FILTER EXISTS {
    ?s wdt:P31 ?m .
    ?m wdt:P279* ?o .
  }
}
```