### PR TITLE
Improve the performance of `getBlocksForJoin`

### DIFF
--- a/src/index/CompressedRelation.cpp
+++ b/src/index/CompressedRelation.cpp
@@ -458,51 +458,64 @@ auto getRelevantIdFromTriple(
                                maxId)
       .value_or(triple.col2Id_);
 }
-
-// `blockLessThanBlock` (a dummy) and `std::less<Id>` are only needed to
-// fulfill a concept for the `ql::ranges` algorithms.
-struct BlockLessThanBlock {
-  template <typename T = void>
-  bool operator()(const CompressedBlockMetadata&,
-                  const CompressedBlockMetadata&) const;
-};
 }  // namespace
 
 // _____________________________________________________________________________
-std::vector<CompressedBlockMetadata> CompressedRelationReader::getBlocksForJoin(
+auto CompressedRelationReader::getBlocksForJoin(
     ql::span<const Id> joinColumn,
-    const ScanSpecAndBlocksAndBounds& metadataAndBlocks) {
-  // We need symmetric comparisons between Ids and blocks.
+    const ScanSpecAndBlocksAndBounds& metadataAndBlocks)
+    -> GetBlocksForJoinResult {
+  if (joinColumn.empty() || metadataAndBlocks.getBlockMetadataView().empty()) {
+    return {};
+  }
+
+  // `id < block` iff `id < block.firstTriple`
   auto idLessThanBlock = [&metadataAndBlocks](
                              Id id, const CompressedBlockMetadata& block) {
     return id < getRelevantIdFromTriple(block.firstTriple_, metadataAndBlocks);
   };
 
+  // `block < id` iff `block.lastTriple < id`
   auto blockLessThanId = [&metadataAndBlocks](
                              const CompressedBlockMetadata& block, Id id) {
     return getRelevantIdFromTriple(block.lastTriple_, metadataAndBlocks) < id;
   };
 
-  auto lessThan = ad_utility::OverloadCallOperator{
-      idLessThanBlock, blockLessThanId, BlockLessThanBlock{}, std::less<Id>{}};
-
-  // Find the matching blocks by performing binary search on the `joinColumn`.
-  // Note that it is tempting to reuse the `zipperJoinWithUndef` routine, but
-  // this doesn't work because the implicit equality defined by
-  // `!lessThan(a,b) && !lessThan(b, a)` is not transitive.
-  auto blockIsNeeded = [&joinColumn, &lessThan](const auto& block) {
-    return !ql::ranges::equal_range(joinColumn, block, lessThan).empty();
-  };
-
   std::vector<CompressedBlockMetadata> result;
-  ql::ranges::copy(metadataAndBlocks.getBlockMetadataView() |
-                       ql::views::filter(blockIsNeeded),
-                   std::back_inserter(result));
+  const auto& mdView = metadataAndBlocks.getBlockMetadataView();
 
-  // The following check is cheap as there are only few blocks.
-  AD_CORRECTNESS_CHECK(std::unique(result.begin(), result.end()) ==
-                       result.end());
-  return result;
+  auto [colIt, colEnd] = getBeginAndEnd(joinColumn);
+  auto [blockIt, blockEnd] = getBeginAndEnd(mdView);
+  GetBlocksForJoinResult res;
+
+  // Manually count the blocks that we pass in the `mdView`.
+  auto& blockIdx = res.numHandledBlocks;
+  while (true) {
+    while (colIt != colEnd && idLessThanBlock(*colIt, *blockIt)) {
+      ++colIt;
+    }
+    if (colIt == colEnd) {
+      return res;
+    }
+    while (blockIt != blockEnd && blockLessThanId(*blockIt, *colIt)) {
+      ++blockIt;
+      ++blockIdx;
+    }
+    if (blockIt == blockEnd) {
+      return res;
+    }
+    // It holds that `*blockIt >= *colIt`. As the entries in the `joinColumn`
+    // are sorted, it suffices to additionally find the values where
+    // `*blockIt <= *colIt` to find possibly matching blocks.
+    while (blockIt != blockEnd && !idLessThanBlock(*colIt, *blockIt)) {
+      res.matchingBlocks_.push_back(*blockIt);
+      ++blockIt;
+      ++blockIdx;
+    }
+    if (blockIt == blockEnd) {
+      return res;
+    }
+  }
 }
 
 // _____________________________________________________________________________

--- a/src/index/CompressedRelation.h
+++ b/src/index/CompressedRelation.h
@@ -531,6 +531,29 @@ class CompressedRelationReader {
     static void checkBlockMetadataInvariant(
         std::span<const CompressedBlockMetadata> blocks,
         size_t firstFreeColIndex);
+
+    // Remove the first `numBlocksToRemove` from the `blockMetadata_`. This can
+    // be used if it is known that those are not needed anymnore, e.g. because
+    // they have already been dealt with by a lazy `IndexScan` or `Join`.
+    void removePrefix(size_t numBlocksToRemove) {
+      auto it = blockMetadata_.begin();
+      auto end = blockMetadata_.end();
+      while (it != end) {
+        auto& subspan = *it;
+        auto sz = ql::ranges::size(subspan);
+        if (numBlocksToRemove < sz) {
+          // Partially remove a subspan if it contains less blocks than we have
+          // to remove.
+          subspan.advance(numBlocksToRemove);
+          break;
+        } else {
+          // Completely remove the subspan (via the `erase` at the end).
+          numBlocksToRemove -= sz;
+        }
+      }
+      // Remove all the blocks that are to be erased completely.
+      blockMetadata_.erase(blockMetadata_.begin(), it);
+    }
   };
 
   // This struct additionally contains the first and last triple of the scan
@@ -604,7 +627,15 @@ class CompressedRelationReader {
   // is not fixed by the `metadataAndBlocks`, so the middle column (col1) in
   // case the `metadataAndBlocks` doesn't contain a `col1Id`, or the last column
   // (col2) else.
-  static std::vector<CompressedBlockMetadata> getBlocksForJoin(
+  // Additionally, return the number of blocks in the input that (according to
+  // their metadata) might contain IDs `<=` any value in the `joinColumn`. Note
+  // that this is an offset into `metadataAndBlocks` and not to be
+  // confused with the globally assigned `blockIndex_`.
+  struct GetBlocksForJoinResult {
+    std::vector<CompressedBlockMetadata> matchingBlocks_;
+    size_t numHandledBlocks{0};
+  };
+  static GetBlocksForJoinResult getBlocksForJoin(
       ql::span<const Id> joinColumn,
       const ScanSpecAndBlocksAndBounds& metadataAndBlocks);
 

--- a/src/index/CompressedRelation.h
+++ b/src/index/CompressedRelation.h
@@ -533,7 +533,7 @@ class CompressedRelationReader {
         size_t firstFreeColIndex);
 
     // Remove the first `numBlocksToRemove` from the `blockMetadata_`. This can
-    // be used if it is known that those are not needed anymnore, e.g. because
+    // be used if it is known that those are not needed anymore, e.g. because
     // they have already been dealt with by a lazy `IndexScan` or `Join`.
     void removePrefix(size_t numBlocksToRemove) {
       auto it = blockMetadata_.begin();

--- a/test/CompressedRelationsTest.cpp
+++ b/test/CompressedRelationsTest.cpp
@@ -736,13 +736,13 @@ TEST(CompressedRelationReader, getBlocksForJoinWithColumn) {
   // All values smaller than the smallest block.
   test({V(1), V(2)}, {}, 0);
   // None of the values matches a block, but the largest value is larger than
-  // the larges block.
+  // the largest block.
   test({V(1), V(2), V(7)}, {}, 2);
 
   // Largest value contained in the first block.
   test({V(3)}, {block2}, 1);
 
-  // Although only `block2` matches, we have completely handled `block3`also,
+  // Although only `block2` matches, we have completely handled `block3` also,
   // because the `29` is larger than the largest value in `block3`, we thus have
   // two blocks handled.
   test({V(1), V(3), V(17), V(29)}, {block2}, 2);

--- a/test/CompressedRelationsTest.cpp
+++ b/test/CompressedRelationsTest.cpp
@@ -97,7 +97,6 @@ void checkThatTablesAreEqual(const auto& expected, const IdTable& actual,
 
   VectorTable exp;
   for (const auto& row : expected) {
-    // exp.emplace_back(row.begin(), row.end());
     exp.emplace_back();
     for (auto& el : row) {
       exp.back().push_back(el);
@@ -760,6 +759,10 @@ TEST(CompressedRelationReader, getBlocksForJoinWithColumn) {
   test({V(11), V(27), V(30)}, {block2, block3}, 2);
   test({V(12)}, {block2}, 1);
   test({V(13)}, {block3}, 2);
+
+  // Test empty blocks edge case
+  metadataAndBlocks.emplace(SpecBlocksBounds{{scanSpec, {}}, {}});
+  test({V(1)}, {}, 0);
 }
 
 TEST(CompressedRelationReader, getBlocksForJoin) {

--- a/test/CompressedRelationsTest.cpp
+++ b/test/CompressedRelationsTest.cpp
@@ -742,8 +742,8 @@ TEST(CompressedRelationReader, getBlocksForJoinWithColumn) {
   // Largest value contained in the first block.
   test({V(3)}, {block2}, 1);
 
-  // Although only `block2` matches, we have completely handled `block3` also,
-  // because the `29` is larger than the largest value in `block3`, we thus have
+  // Although only `block2` matches, we have also completely handled `block3`
+  // since `V(29)` is larger than the largest value in `block3`, we thus have
   // two blocks handled.
   test({V(1), V(3), V(17), V(29)}, {block2}, 2);
   test({V(2), V(3), V(4), V(5)}, {block2, block3}, 2);

--- a/test/CompressedRelationsTest.cpp
+++ b/test/CompressedRelationsTest.cpp
@@ -719,21 +719,37 @@ TEST(CompressedRelationReader, getBlocksForJoinWithColumn) {
   auto test = [&metadataAndBlocks](
                   const std::vector<Id>& joinColumn,
                   const std::vector<CompressedBlockMetadata>& expectedBlocks,
+                  size_t numHandledBlocksExpected,
                   source_location l = source_location::current()) {
     auto t = generateLocationTrace(l);
-    auto result = CompressedRelationReader::getBlocksForJoin(
-        joinColumn, *metadataAndBlocks);
+    auto [result, numHandledBlocks] =
+        CompressedRelationReader::getBlocksForJoin(joinColumn,
+                                                   *metadataAndBlocks);
     EXPECT_THAT(result, ::testing::ElementsAreArray(expectedBlocks));
+    EXPECT_EQ(numHandledBlocks, numHandledBlocksExpected);
   };
   // We have fixed the `col0Id` to be 42. The col1/2Ids of the matching blocks
   // are as follows (starting at `block2`)
   // [(3, 0)-(4, 12)], [(4, 13)-(6, 9)]
 
   // Tests for a fixed col0Id, so the join is on the middle column.
-  test({V(1), V(3), V(17), V(29)}, {block2});
-  test({V(2), V(3), V(4), V(5)}, {block2, block3});
-  test({V(4)}, {block2, block3});
-  test({V(6)}, {block3});
+  test({}, {}, 0);
+  // All values smaller than the smallest block.
+  test({V(1), V(2)}, {}, 0);
+  // None of the values matches a block, but the largest value is larger than
+  // the larges block.
+  test({V(1), V(2), V(7)}, {}, 2);
+
+  // Largest value contained in the first block.
+  test({V(3)}, {block2}, 1);
+
+  // Although only `block2` matches, we have completely handled `block3`also,
+  // because the `29` is larger than the largest value in `block3`, we thus have
+  // two blocks handled.
+  test({V(1), V(3), V(17), V(29)}, {block2}, 2);
+  test({V(2), V(3), V(4), V(5)}, {block2, block3}, 2);
+  test({V(4)}, {block2, block3}, 2);
+  test({V(6)}, {block3}, 2);
 
   // Test with a fixed col1Id. We now join on the last column, the first column
   // is fixed (42), and the second column is also fixed (4).
@@ -741,9 +757,9 @@ TEST(CompressedRelationReader, getBlocksForJoinWithColumn) {
   metadataAndBlocks.emplace(
       SpecBlocksBounds{{scanSpec, getBlockMetadataRangesfromVec(blocks)},
                        {{V(42), V(4), V(11), g}, {V(42), V(4), V(738), g}}});
-  test({V(11), V(27), V(30)}, {block2, block3});
-  test({V(12)}, {block2});
-  test({V(13)}, {block3});
+  test({V(11), V(27), V(30)}, {block2, block3}, 2);
+  test({V(12)}, {block2}, 1);
+  test({V(13)}, {block3}, 2);
 }
 
 TEST(CompressedRelationReader, getBlocksForJoin) {


### PR DESCRIPTION
So far, `CompressedRelationReader::getBlocksForJoin` did a binary search on the join column for each block, that is, it had a complexity of `O(B x log J)`, where `B` is the number of blocks and `J` is the number of rows in the join column. This has now been improved to a zipper-like merge, which has a complexity of `O(B + J)`, at least when there is no significant Cartesian blow-up. This is significantly faster when both `B` and `J` are large. For example, it makes the last join in the following query on Wikidata three times faster:
```sparql
SELECT * WHERE {
  ?s rdf:type ?o1 .
  ?s wdt:P31 ?o2 .
  ?s wdt:P31 ?o3 .
}
```