### PR TITLE
More efficient `COUNT(*)`

### DIFF
--- a/src/engine/GroupByImpl.cpp
+++ b/src/engine/GroupByImpl.cpp
@@ -937,6 +937,9 @@ std::optional<IdTable> GroupByImpl::computeOptimizedGroupByIfPossible() const {
   if (auto result = computeGroupByObjectWithCount()) {
     return result;
   }
+  if (auto result = computeCountStar()) {
+    return result;
+  }
   return std::nullopt;
 }
 
@@ -1641,4 +1644,33 @@ bool GroupByImpl::isVariableBoundInSubtree(const Variable& variable) const {
 std::unique_ptr<Operation> GroupByImpl::cloneImpl() const {
   return std::make_unique<GroupByImpl>(_executionContext, _groupByVariables,
                                        _aliases, _subtree->clone());
+}
+
+// _____________________________________________________________________________
+std::optional<IdTable> GroupByImpl::computeCountStar() const {
+  bool isCountStar = _groupByVariables.empty() && _aliases.size() == 1 &&
+                     dynamic_cast<const sparqlExpression::CountStarExpression*>(
+                         _aliases[0]._expression.getPimpl());
+  if (!isCountStar) {
+    return std::nullopt;
+  }
+  auto childRes = _subtree->getResult(true);
+  // Compute the result as a single `size_t`.
+  auto res = [&input = *childRes]() -> size_t {
+    if (input.isFullyMaterialized()) {
+      return input.idTable().size();
+    } else {
+      auto gen = input.idTables();
+      auto sz = gen | ql::views::transform([](const auto& pair) {
+                  return pair.idTable_.numRows();
+                }) |
+                ql::views::common;
+      return std::accumulate(sz.begin(), sz.end(), size_t{0});
+    }
+  }();
+
+  // Wrap the result in an IdTable with a single row and column.
+  IdTable result{1, getExecutionContext()->getAllocator()};
+  result.push_back(std::array{Id::makeFromInt(res)});
+  return result;
 }

--- a/src/engine/GroupByImpl.h
+++ b/src/engine/GroupByImpl.h
@@ -227,6 +227,10 @@ class GroupByImpl : public Operation {
   // `?z`.
   std::optional<IdTable> computeGroupByForJoinWithFullScan() const;
 
+  // Compute the result for a single `COUNT(*)` aggregate with a single
+  // (implicit) group.
+  std::optional<IdTable> computeCountStar() const;
+
   // Stores information required for substitution of an expression in an
   // expression tree.
   struct ParentAndChildIndex {

--- a/src/engine/sparqlExpressions/CountStarExpression.h
+++ b/src/engine/sparqlExpressions/CountStarExpression.h
@@ -7,8 +7,8 @@
 
 #include "engine/sparqlExpressions/SparqlExpression.h"
 
-// Return a `SparqlExpression::Ptr` that implements the `COUNT [DISTINCT} *`
-// function.
+// Return a `SparqlExpression::Ptr` that implements the `COUNT(*)` and
+// `COUNT(DISTINCT *)` function.
 namespace sparqlExpression {
 class CountStarExpression : public SparqlExpression {
  private:
@@ -31,6 +31,8 @@ class CountStarExpression : public SparqlExpression {
 
   // ___________________________________________________________________________
   ql::span<SparqlExpression::Ptr> childrenImpl() override { return {}; }
+
+  bool isDistinct() const { return distinct_; }
 };
 
 SparqlExpression::Ptr makeCountStarExpression(bool distinct);

--- a/test/GroupByTest.cpp
+++ b/test/GroupByTest.cpp
@@ -676,6 +676,95 @@ TEST_F(GroupByOptimizations, findGroupedVariable) {
 }
 
 // _____________________________________________________________________________
+TEST_F(GroupByOptimizations, countStarOptimizationWorksAsExpected) {
+  using namespace sparqlExpression;
+  auto* qec = getQec();
+
+  std::shared_ptr expr1{makeCountStarExpression(false)};
+  std::shared_ptr expr2{makeCountStarExpression(true)};
+
+  auto makeIdTables = []() {
+    std::vector<IdTable> idTables;
+    idTables.push_back(makeIdTableFromVector({{Id::makeUndefined()}, {1}}));
+    idTables.push_back(makeIdTableFromVector({{2}, {2}, {4}, {8}}));
+    return idTables;
+  };
+
+  // Regular case that should get optimized, with and without lazy input
+  {
+    auto subtree = makeExecutionTree<ValuesForTesting>(
+        qec, makeIdTables(),
+        std::vector<std::optional<Variable>>{Variable{"?a"}}, true,
+        std::vector<ColumnIndex>{});
+    GroupByImpl groupBy{
+        qec,
+        {},
+        {Alias{SparqlExpressionPimpl{std::shared_ptr{expr1}, "COUNT(*) AS ?x"},
+               Variable{"?x"}}},
+        std::move(subtree)};
+    auto result = groupBy.computeResultOnlyForTesting(false);
+    EXPECT_EQ(result.idTable(), makeIdTableFromVector({{Id::makeFromInt(6)}}));
+  }
+  {
+    auto subtree = makeExecutionTree<ValuesForTesting>(
+        qec,
+        makeIdTableFromVector({{Id::makeUndefined()}, {1}, {2}, {2}, {4}, {8}}),
+        std::vector<std::optional<Variable>>{Variable{"?a"}}, false,
+        std::vector<ColumnIndex>{}, LocalVocab{}, std::nullopt, true);
+    GroupByImpl groupBy{
+        qec,
+        {},
+        {Alias{SparqlExpressionPimpl{std::shared_ptr{expr1}, "COUNT(*) AS ?x"},
+               Variable{"?x"}}},
+        std::move(subtree)};
+    auto result = groupBy.computeResultOnlyForTesting(false);
+    EXPECT_EQ(result.idTable(), makeIdTableFromVector({{Id::makeFromInt(6)}}));
+  }
+  // Distinct should not be optimized
+  {
+    auto subtree = makeExecutionTree<ValuesForTesting>(
+        qec, makeIdTables(),
+        std::vector<std::optional<Variable>>{Variable{"?a"}}, true,
+        std::vector<ColumnIndex>{0});
+    GroupByImpl groupBy{qec,
+                        {},
+                        {Alias{SparqlExpressionPimpl{std::shared_ptr{expr2},
+                                                     "COUNT(DISTINCT *) AS ?x"},
+                               Variable{"?x"}}},
+                        std::move(subtree)};
+    auto result = groupBy.computeResultOnlyForTesting(false);
+    EXPECT_EQ(result.idTable(), makeIdTableFromVector({{Id::makeFromInt(5)}}));
+  }
+  // With variable name should also not be optimized
+  {
+    auto subtree = makeExecutionTree<ValuesForTesting>(
+        qec, makeIdTables(),
+        std::vector<std::optional<Variable>>{Variable{"?a"}}, true,
+        std::vector<ColumnIndex>{0});
+    GroupByImpl groupBy{
+        qec,
+        {},
+        {Alias{makeCountPimpl(Variable{"?a"}, false), Variable{"?x"}}},
+        std::move(subtree)};
+    auto result = groupBy.computeResultOnlyForTesting(false);
+    EXPECT_EQ(result.idTable(), makeIdTableFromVector({{Id::makeFromInt(5)}}));
+  }
+  {
+    auto subtree = makeExecutionTree<ValuesForTesting>(
+        qec, makeIdTables(),
+        std::vector<std::optional<Variable>>{Variable{"?a"}}, true,
+        std::vector<ColumnIndex>{0});
+    GroupByImpl groupBy{
+        qec,
+        {},
+        {Alias{makeCountPimpl(Variable{"?a"}, true), Variable{"?x"}}},
+        std::move(subtree)};
+    auto result = groupBy.computeResultOnlyForTesting(false);
+    EXPECT_EQ(result.idTable(), makeIdTableFromVector({{Id::makeFromInt(4)}}));
+  }
+}
+
+// _____________________________________________________________________________
 TEST_F(GroupByOptimizations, checkIfHashMapOptimizationPossible) {
   auto testFailure = [this](const auto& groupByVariables, const auto& aliases,
                             const auto& join, auto& aggregates) {
@@ -2189,6 +2278,8 @@ class GroupByLazyFixture : public ::testing::TestWithParam<bool> {
   using V = Variable;
   QueryExecutionContext* qec_ = getQec();
 
+  void SetUp() override { qec_->getQueryTreeCache().clearAll(); }
+
   // ___________________________________________________________________________
   static std::vector<std::optional<Variable>> vars(
       std::convertible_to<std::string> auto&&... strings) {
@@ -2208,16 +2299,13 @@ class GroupByLazyFixture : public ::testing::TestWithParam<bool> {
   template <size_t N>
   static void expectReturningIdTables(
       GroupBy& groupBy, const std::array<IdTable, N>& idTables,
-      bool mightViolateLaziness = false,
       ad_utility::source_location sourceLocation =
           ad_utility::source_location::current()) {
     auto l = generateLocationTrace(sourceLocation);
     bool lazyResult = GetParam();
     auto result = groupBy.computeResultOnlyForTesting(lazyResult);
-    if (!mightViolateLaziness) {
-      ASSERT_NE(result.isFullyMaterialized(), lazyResult);
-    }
-    if (!result.isFullyMaterialized()) {
+    ASSERT_NE(result.isFullyMaterialized(), lazyResult);
+    if (lazyResult) {
       size_t counter = 0;
       for (const Result::IdTableVocabPair& pair : result.idTables()) {
         ASSERT_LT(counter, idTables.size())
@@ -2473,7 +2561,12 @@ TEST_P(GroupByLazyFixture, countStarWorks) {
   Alias alias{
       SparqlExpressionPimpl{makeCountStarExpression(false), "COUNT(*) as ?y"},
       V{"?y"}};
-  GroupBy groupBy{qec_, {}, {std::move(alias)}, std::move(subtree)};
+  // Second entry to avoid the COUNT(*) optimization
+  Alias aliasDummy{
+      SparqlExpressionPimpl{makeCountStarExpression(false), "COUNT(*) as ?z"},
+      V{"?z"}};
+  GroupBy groupBy{
+      qec_, {}, {std::move(alias), std::move(aliasDummy)}, std::move(subtree)};
 
-  expectReturningIdTables<1>(groupBy, {makeIntTable({{4}})}, true);
+  expectReturningIdTables<1>(groupBy, {makeIntTable({{4, 4}})});
 }


### PR DESCRIPTION
For queries of the form `SELECT (COUNT(*) AS ?count) { ... }`, QLever generates one or more `IdTable`s and adds up their sizes (number of rows). So far, each `IdTable` was produced row by row (just like for any other query) and there was one column for each variable visible in the query body (just like for any other query involving `*`). This is now improved in two ways. First, each such `IdTable` now has zero columns. Second, each such `IdTable` is resized to its target size in one go, instead of adding the rows one by one.