### PR TITLE
Improve the `AddCombinedRowToTable` class

### DIFF
--- a/src/engine/AddCombinedRowToTable.h
+++ b/src/engine/AddCombinedRowToTable.h
@@ -145,7 +145,7 @@ class AddCombinedRowToIdTable {
   // Concept for the `addRows` function below for a `sized_range` that has
   // unsigned integral values as its `value_type`.
   template <typename R>
-  static constexpr bool sizeTRange =
+  static constexpr bool sizedRangeOfUnsigned =
       ql::ranges::sized_range<R> &&
       ql::concepts::unsigned_integral<ql::ranges::range_value_t<R>>;
 
@@ -153,9 +153,9 @@ class AddCombinedRowToIdTable {
   // `rowIndicesA` and `rowIndicesB` with an optimization for the special case
   // that the `resultTable` has zero columns.
   CPP_template(typename R1, typename R2)(
-      requires sizeTRange<R1> CPP_and
-          sizeTRange<R2>) void addRows(const R1& rowIndicesA,
-                                       const R2& rowIndicesB) {
+      requires sizedRangeOfUnsigned<R1> CPP_and
+          sizedRangeOfUnsigned<R2>) void addRows(const R1& rowIndicesA,
+                                                 const R2& rowIndicesB) {
     size_t total =
         ql::ranges::size(rowIndicesA) * ql::ranges::size(rowIndicesB);
     if (resultTable_.numColumns() == 0) {
@@ -224,13 +224,14 @@ class AddCombinedRowToIdTable {
     flushBeforeInputChange();
     mergeVocab(inputLeft, currentVocabs_.at(0));
     // The right input will be empty, but with the correct number of columns.
+    using namespace ad_utility::memory_literals;
     inputLeftAndRight_ = std::array{
         detail::toView(inputLeft),
         IdTableView<0>{
             resultTable_.numColumns() +
-                static_cast<size_t>(!keepJoinColumns_) * numJoinColumns_ -
+                (static_cast<size_t>(!keepJoinColumns_) * numJoinColumns_) -
                 detail::toView(inputLeft).numColumns() + numJoinColumns_,
-            ad_utility::makeUnlimitedAllocator<Id>()}};
+            ad_utility::makeAllocatorWithLimit<Id>(0_B)}};
   }
 
   // The next free row in the output will be created from

--- a/src/engine/AddCombinedRowToTable.h
+++ b/src/engine/AddCombinedRowToTable.h
@@ -1,6 +1,9 @@
-//  Copyright 2023, University of Freiburg,
-//                  Chair of Algorithms and Data Structures.
-//  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+// Copyright 2023-2025 The QLever Authors, in particular:
+//
+// 2025 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR/QL
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+// QL =  QLeverize AG
 
 #ifndef QLEVER_SRC_ENGINE_ADDCOMBINEDROWTOTABLE_H
 #define QLEVER_SRC_ENGINE_ADDCOMBINEDROWTOTABLE_H
@@ -28,11 +31,16 @@ namespace ad_utility {
 class AddCombinedRowToIdTable {
   std::vector<size_t> numUndefinedPerColumn_;
   size_t numJoinColumns_;
+  // If set to false, then the join columns will not be written to the output.
+  // The result table will also have no columns corresponding to the join
+  // columns, but will only consist of the remaining payload columns.
+  bool keepJoinColumns_ = true;
   std::optional<std::array<IdTableView<0>, 2>> inputLeftAndRight_;
   IdTable resultTable_;
   LocalVocab mergedVocab_{};
   std::array<const LocalVocab*, 2> currentVocabs_{nullptr, nullptr};
 
+ public:
   // This struct stores the information, which row indices from the input are
   // combined into a given row index in the output, i.e. "To obtain the
   // `targetIndex_`-th row in the output, you have to combine
@@ -80,10 +88,11 @@ class AddCombinedRowToIdTable {
   explicit AddCombinedRowToIdTable(
       size_t numJoinColumns, IdTableView<0> input1, IdTableView<0> input2,
       IdTable output, CancellationHandle cancellationHandle,
-      size_t bufferSize = 100'000,
+      bool keepJoinColumns = true, size_t bufferSize = 100'000,
       BlockwiseCallback blockwiseCallback = ad_utility::noop)
       : numUndefinedPerColumn_(output.numColumns()),
         numJoinColumns_{numJoinColumns},
+        keepJoinColumns_{keepJoinColumns},
         inputLeftAndRight_{std::array{input1, input2}},
         resultTable_{std::move(output)},
         bufferSize_{bufferSize},
@@ -93,16 +102,19 @@ class AddCombinedRowToIdTable {
     checkNumColumns();
     indexBuffer_.reserve(bufferSize);
   }
+
   // Similar to the previous constructor, but the inputs are not given.
   // This means that the inputs have to be set to an explicit
   // call to `setInput` before adding rows. This is used for the lazy join
   // operations (see Join.cpp) where the input changes over time.
   explicit AddCombinedRowToIdTable(
       size_t numJoinColumns, IdTable output,
-      CancellationHandle cancellationHandle, size_t bufferSize = 100'000,
+      CancellationHandle cancellationHandle, bool keepJoinColumns = true,
+      size_t bufferSize = 100'000,
       BlockwiseCallback blockwiseCallback = ad_utility::noop)
       : numUndefinedPerColumn_(output.numColumns()),
         numJoinColumns_{numJoinColumns},
+        keepJoinColumns_{keepJoinColumns},
         inputLeftAndRight_{std::nullopt},
         resultTable_{std::move(output)},
         bufferSize_{bufferSize},
@@ -125,8 +137,42 @@ class AddCombinedRowToIdTable {
     indexBuffer_.push_back(
         TargetIndexAndRowIndices{nextIndex_, {rowIndexA, rowIndexB}});
     ++nextIndex_;
-    if (nextIndex_ > bufferSize_) {
+    if (nextIndex_ >= bufferSize_) {
       flush();
+    }
+  }
+
+  // Concept for the `addRows` function below for a `sized_range` that has
+  // unsigned integral values as its `value_type`.
+  template <typename R>
+  static constexpr bool sizeTRange =
+      ql::ranges::sized_range<R> &&
+      ql::concepts::unsigned_integral<ql::ranges::range_value_t<R>>;
+
+  // Same as calling `addRow` for each element in the Cartesian product of
+  // `rowIndicesA` and `rowIndicesB` with an optimization for the special case
+  // that the `resultTable` has zero columns.
+  CPP_template(typename R1, typename R2)(
+      requires sizeTRange<R1> CPP_and
+          sizeTRange<R2>) void addRows(const R1& rowIndicesA,
+                                       const R2& rowIndicesB) {
+    size_t total =
+        ql::ranges::size(rowIndicesA) * ql::ranges::size(rowIndicesB);
+    if (resultTable_.numColumns() == 0) {
+      while (total > 0) {
+        auto chunkSz = std::min(bufferSize_ - nextIndex_, total);
+        nextIndex_ += chunkSz;
+        total -= chunkSz;
+        if (nextIndex_ >= bufferSize_) {
+          flush();
+        }
+      }
+    } else {
+      for (auto a : rowIndicesA) {
+        for (auto b : rowIndicesB) {
+          addRow(a, b);
+        }
+      }
     }
   }
 
@@ -178,12 +224,13 @@ class AddCombinedRowToIdTable {
     flushBeforeInputChange();
     mergeVocab(inputLeft, currentVocabs_.at(0));
     // The right input will be empty, but with the correct number of columns.
-    inputLeftAndRight_ =
-        std::array{detail::toView(inputLeft),
-                   IdTableView<0>{resultTable_.numColumns() -
-                                      detail::toView(inputLeft).numColumns() +
-                                      numJoinColumns_,
-                                  ad_utility::makeUnlimitedAllocator<Id>()}};
+    inputLeftAndRight_ = std::array{
+        detail::toView(inputLeft),
+        IdTableView<0>{
+            resultTable_.numColumns() +
+                static_cast<size_t>(!keepJoinColumns_) * numJoinColumns_ -
+                detail::toView(inputLeft).numColumns() + numJoinColumns_,
+            ad_utility::makeUnlimitedAllocator<Id>()}};
   }
 
   // The next free row in the output will be created from
@@ -194,7 +241,7 @@ class AddCombinedRowToIdTable {
     optionalIndexBuffer_.push_back(
         TargetIndexAndRowIndex{nextIndex_, rowIndexA});
     ++nextIndex_;
-    if (nextIndex_ > bufferSize_) {
+    if (nextIndex_ >= bufferSize_) {
       flush();
     }
   }
@@ -224,8 +271,9 @@ class AddCombinedRowToIdTable {
     cancellationHandle_->throwIfCancelled();
     auto& result = resultTable_;
     size_t oldSize = result.size();
-    AD_CORRECTNESS_CHECK(nextIndex_ ==
-                         indexBuffer_.size() + optionalIndexBuffer_.size());
+    AD_CORRECTNESS_CHECK(nextIndex_ == indexBuffer_.size() +
+                                           optionalIndexBuffer_.size() ||
+                         result.numColumns() == 0);
     // Sometimes the left input and right input are not valid anymore, because
     // the `IdTable`s they point to have already been destroyed. This case is
     // okay, as long as there was a manual call to `flush` (after which
@@ -322,8 +370,10 @@ class AddCombinedRowToIdTable {
     size_t nextResultColIdx = 0;
     // First write all the join columns.
     for (size_t col = 0; col < numJoinColumns_; col++) {
-      writeJoinColumn(col, nextResultColIdx);
-      ++nextResultColIdx;
+      if (keepJoinColumns_) {
+        writeJoinColumn(col, nextResultColIdx);
+        ++nextResultColIdx;
+      }
     }
 
     // Then the remaining columns from the left input.
@@ -362,11 +412,13 @@ class AddCombinedRowToIdTable {
   }
 
   void checkNumColumns() const {
+    AD_CONTRACT_CHECK(bufferSize_ > 0);
     AD_CONTRACT_CHECK(inputLeft().numColumns() >= numJoinColumns_);
     AD_CONTRACT_CHECK(inputRight().numColumns() >= numJoinColumns_);
-    AD_CONTRACT_CHECK(resultTable_.numColumns() ==
-                      inputLeft().numColumns() + inputRight().numColumns() -
-                          numJoinColumns_);
+    AD_CONTRACT_CHECK(
+        resultTable_.numColumns() ==
+        inputLeft().numColumns() + inputRight().numColumns() - numJoinColumns_ -
+            numJoinColumns_ * static_cast<size_t>(!keepJoinColumns_));
   }
 };
 }  // namespace ad_utility

--- a/src/engine/Join.cpp
+++ b/src/engine/Join.cpp
@@ -736,8 +736,12 @@ ad_utility::JoinColumnMapping Join::getJoinColumnMapping() const {
 ad_utility::AddCombinedRowToIdTable Join::makeRowAdder(
     std::function<void(IdTable&, LocalVocab&)> callback) const {
   return ad_utility::AddCombinedRowToIdTable{
-      1, IdTable{getResultWidth(), allocator()}, cancellationHandle_,
-      CHUNK_SIZE, std::move(callback)};
+      1,
+      IdTable{getResultWidth(), allocator()},
+      cancellationHandle_,
+      keepJoinColumn_,
+      CHUNK_SIZE,
+      std::move(callback)};
 }
 
 // _____________________________________________________________________________

--- a/src/engine/Join.h
+++ b/src/engine/Join.h
@@ -30,6 +30,9 @@ class Join : public Operation {
 
   std::vector<float> _multiplicities;
 
+  // Specify whether the join column will be contained in the result.
+  static constexpr bool keepJoinColumn_ = true;
+
  public:
   // `allowSwappingChildrenOnlyForTesting` should only ever be changed by tests.
   Join(QueryExecutionContext* qec, std::shared_ptr<QueryExecutionTree> t1,

--- a/src/engine/MinusRowHandler.h
+++ b/src/engine/MinusRowHandler.h
@@ -68,6 +68,12 @@ class MinusRowHandler {
     // `BlockZipperJoinImpl` expects this interface.
   }
 
+  // No-op for `MINUS`.
+  template <typename R1, typename R2>
+  static void addRows(const R1&, const R2&) {
+    // `BlockZipperJoinImpl` expects this interface.
+  }
+
   // Flush remaining pending entries before changing the input.
   void flushBeforeInputChange() {
     // Clear to avoid unnecessary merge.

--- a/src/engine/OptionalJoin.cpp
+++ b/src/engine/OptionalJoin.cpp
@@ -342,7 +342,7 @@ void OptionalJoin::optionalJoin(
 
   auto rowAdder = ad_utility::AddCombinedRowToIdTable(
       joinColumns.size(), leftPermuted, rightPermuted, std::move(*result),
-      cancellationHandle_);
+      cancellationHandle_, keepJoinColumns_);
   auto addRow = [&rowAdder, beginLeft = joinColumnsLeft.begin(),
                  beginRight = joinColumnsRight.begin()](const auto& itLeft,
                                                         const auto& itRight) {
@@ -430,7 +430,8 @@ Result OptionalJoin::lazyOptionalJoin(std::shared_ptr<const Result> left,
                     std::function<void(IdTable&, LocalVocab&)> yieldTable) {
     ad_utility::AddCombinedRowToIdTable rowAdder{
         _joinColumns.size(), IdTable{getResultWidth(), allocator()},
-        cancellationHandle_, CHUNK_SIZE, std::move(yieldTable)};
+        cancellationHandle_, keepJoinColumns_,
+        CHUNK_SIZE,          std::move(yieldTable)};
     auto leftRange = resultToView(*left, joinColMap.permutationLeft());
     auto rightRange = resultToView(*right, joinColMap.permutationRight());
     std::visit(

--- a/src/engine/OptionalJoin.h
+++ b/src/engine/OptionalJoin.h
@@ -31,6 +31,11 @@ class OptionalJoin : public Operation {
   std::optional<size_t> _costEstimate;
   bool _multiplicitiesComputed = false;
 
+  // Specify whether the join columns should be part of the result.
+  // TODO<joka921> In the future this will be configurable, defined as a
+  // constant to make the splitting up into smaller PRs feasible.
+  static constexpr bool keepJoinColumns_ = true;
+
  public:
   OptionalJoin(QueryExecutionContext* qec,
                std::shared_ptr<QueryExecutionTree> t1,

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -112,9 +112,12 @@ static auto lazyOptionalJoinOnFirstColumn(T1& leftInput, T2& rightInput,
                       ad_utility::makeUnlimitedAllocator<Id>()};
   // The first argument is the number of join columns.
   auto rowAdder = ad_utility::AddCombinedRowToIdTable{
-      1, std::move(outputTable),
+      1,
+      std::move(outputTable),
       std::make_shared<ad_utility::CancellationHandle<>>(),
-      BUFFER_SIZE_JOIN_PATTERNS_WITH_OSP, resultCallback};
+      true,
+      BUFFER_SIZE_JOIN_PATTERNS_WITH_OSP,
+      resultCallback};
 
   ad_utility::zipperJoinForBlocksWithoutUndef(leftInput, rightInput, comparator,
                                               rowAdder, projection, projection,

--- a/src/util/JoinAlgorithms/JoinAlgorithms.h
+++ b/src/util/JoinAlgorithms/JoinAlgorithms.h
@@ -1115,9 +1115,8 @@ CPP_template(typename LeftSide, typename RightSide, typename LessThan,
     };
     auto addRowIndices = [&begL, &begR, this](auto itFromL, auto endFromL,
                                               auto itFromR, auto endFromR) {
-      AD_EXPENSIVE_CHECK(itFromL >= begL);
-      AD_EXPENSIVE_CHECK(itFromR >= begR);
-      // TODO<joka921> more expensive checks.
+      AD_EXPENSIVE_CHECK(itFromL >= begL && endFromL >= itFromL);
+      AD_EXPENSIVE_CHECK(itFromR >= begR && endFromR >= itFromR);
       auto io = [&](const auto& beg, const auto& it, const auto& end) {
         return ql::views::iota(static_cast<size_t>(it - beg),
                                static_cast<size_t>(end - beg));

--- a/src/util/JoinAlgorithms/JoinAlgorithms.h
+++ b/src/util/JoinAlgorithms/JoinAlgorithms.h
@@ -44,6 +44,16 @@ CPP_concept BinaryIteratorFunction =
 // for each position they are equal, or at least one of them is UNDEF. This is
 // exactly the semantics of the SPARQL standard for rows that match in a JOIN
 // operation.
+namespace joinAlgorithms::detail {
+
+template <typename F, typename It1, typename It2>
+CPP_requires(HasAddRowsRequires,
+             requires(F& p, It1 it1, It2 it2)(p.addRows(it1, it1, it2, it2)));
+
+template <typename F, typename It1, typename It2>
+CPP_concept HasAddRows = CPP_requires_ref(HasAddRowsRequires, F, It1, It2);
+
+}  // namespace joinAlgorithms::detail
 
 /**
  * @brief This function performs a merge/zipper join that also handles UNDEF
@@ -264,11 +274,24 @@ CPP_template(typename Range1, typename Range2, typename LessThan,
         mergeWithUndefLeft(it, std::begin(left), it1);
       }
 
-      for (; it1 != endSame1; ++it1) {
-        checkCancellation();
-        cover(it1);
-        for (auto innerIt2 = it2; innerIt2 != endSame2; ++innerIt2) {
-          compatibleRowAction(it1, innerIt2);
+      // Add all the matching rows to the result.
+      // TODO<joka921> We should at some point enforce that all the
+      // `CompatibleRowAction`s support adding multiple rows at once.
+      if constexpr (joinAlgorithms::detail::HasAddRows<
+                        CompatibleRowAction, decltype(it1), decltype(it2)>) {
+        compatibleRowAction.addRows(it1, endSame1, it2, endSame2);
+        if constexpr (hasNotFoundAction) {
+          for (; it1 != endSame1; ++it1) {
+            cover(it1);
+          }
+        }
+      } else {
+        for (; it1 != endSame1; ++it1) {
+          checkCancellation();
+          cover(it1);
+          for (auto innerIt2 = it2; innerIt2 != endSame2; ++innerIt2) {
+            compatibleRowAction(it1, innerIt2);
+          }
         }
       }
       it1 = endSame1;
@@ -849,7 +872,7 @@ CPP_template(typename LeftSide, typename RightSide, typename LessThan,
         AD_CORRECTNESS_CHECK(lessThan_(currentEl, (*it)[0]));
         return true;
       }
-      AD_CORRECTNESS_CHECK(ql::ranges::is_sorted(*it, lessThan_));
+      AD_EXPENSIVE_CHECK(ql::ranges::is_sorted(*it, lessThan_));
       side.currentBlocks_.emplace_back(std::move(*it));
     }
     return it == end;
@@ -932,11 +955,8 @@ CPP_template(typename LeftSide, typename RightSide, typename LessThan,
     for (const auto& lBlock : blocksLeft) {
       for (const auto& rBlock : blocksRight) {
         compatibleRowAction_.setInput(lBlock.fullBlock(), rBlock.fullBlock());
-        for (size_t i : lBlock.getIndexRange()) {
-          for (size_t j : rBlock.getIndexRange()) {
-            compatibleRowAction_.addRow(i, j);
-          }
-        }
+        compatibleRowAction_.addRows(lBlock.getIndexRange(),
+                                     rBlock.getIndexRange());
       }
     }
   }
@@ -1054,6 +1074,22 @@ CPP_template(typename LeftSide, typename RightSide, typename LessThan,
     };
   }
 
+  // A helper struct that is used to move the `addRow` and `addRows` function of
+  // the `AddCombinedRowToTable` (which requires integers as arguments) to a
+  // class with a similar interface that takes `iterators` as expected by the
+  // `zipperJoinWithUndef` function that is called for each block.
+  // It simply takes two callables, the first one will be the `operator()` and
+  // the second one the `addRow` function.
+  template <typename F1, typename F2>
+  struct RowIndexAdder {
+    F1 f1;
+    F2 f2;
+    void operator()(auto&&... args) const { return f1(AD_FWD(args)...); }
+    void addRows(auto&&... args) const { return f2(AD_FWD(args)...); }
+  };
+  template <typename F1, typename F2>
+  RowIndexAdder(F1, F2) -> RowIndexAdder<std::decay_t<F1>, std::decay_t<F2>>;
+
   // Join the first block in `currentBlocksLeft` with the first block in
   // `currentBlocksRight`, but ignore all elements that are `>= currentEl`
   // The fully joined parts of the block are then removed from
@@ -1071,10 +1107,23 @@ CPP_template(typename LeftSide, typename RightSide, typename LessThan,
     compatibleRowAction_.setInput(fullBlockLeft.get(), fullBlockRight.get());
     auto begL = fullBlockLeft.get().begin();
     auto begR = fullBlockRight.get().begin();
+
     auto addRowIndex = [&begL, &begR, this](auto itFromL, auto itFromR) {
       AD_EXPENSIVE_CHECK(itFromL >= begL);
       AD_EXPENSIVE_CHECK(itFromR >= begR);
       compatibleRowAction_.addRow(itFromL - begL, itFromR - begR);
+    };
+    auto addRowIndices = [&begL, &begR, this](auto itFromL, auto endFromL,
+                                              auto itFromR, auto endFromR) {
+      AD_EXPENSIVE_CHECK(itFromL >= begL);
+      AD_EXPENSIVE_CHECK(itFromR >= begR);
+      // TODO<joka921> more expensive checks.
+      auto io = [&](const auto& beg, const auto& it, const auto& end) {
+        return ql::views::iota(static_cast<size_t>(it - beg),
+                               static_cast<size_t>(end - beg));
+      };
+      compatibleRowAction_.addRows(io(begL, itFromL, endFromL),
+                                   io(begR, itFromR, endFromR));
     };
 
     auto addNotFoundRowIndex = [&]() {
@@ -1101,7 +1150,7 @@ CPP_template(typename LeftSide, typename RightSide, typename LessThan,
       [[maybe_unused]] auto res = zipperJoinWithUndef(
           ql::ranges::subrange{subrangeLeft.begin(), currentElItL},
           ql::ranges::subrange{subrangeRight.begin(), currentElItR}, lessThan_,
-          addRowIndex,
+          RowIndexAdder{addRowIndex, addRowIndices},
           findUndefValues<true>(fullBlockLeft, fullBlockRight, begL, begR),
           findUndefValues<false>(fullBlockLeft, fullBlockRight, begL, begR),
           addNotFoundRowIndex, noop, std::false_type{});
@@ -1109,7 +1158,8 @@ CPP_template(typename LeftSide, typename RightSide, typename LessThan,
       [[maybe_unused]] auto res = zipperJoinWithUndef(
           ql::ranges::subrange{subrangeLeft.begin(), currentElItL},
           ql::ranges::subrange{subrangeRight.begin(), currentElItR}, lessThan_,
-          addRowIndex, noop, noop, addNotFoundRowIndex);
+          RowIndexAdder{addRowIndex, addRowIndices}, noop, noop,
+          addNotFoundRowIndex);
     }
     compatibleRowAction_.flush();
 
@@ -1127,7 +1177,7 @@ CPP_template(typename LeftSide, typename RightSide, typename LessThan,
     while (targetBuffer.empty() && it != end) {
       auto& el = *it;
       if (!el.empty()) {
-        AD_CORRECTNESS_CHECK(ql::ranges::is_sorted(el, lessThan_));
+        AD_EXPENSIVE_CHECK(ql::ranges::is_sorted(el, lessThan_));
         targetBuffer.emplace_back(std::move(el));
       }
       ++it;

--- a/test/AddCombinedRowToTableTest.cpp
+++ b/test/AddCombinedRowToTableTest.cpp
@@ -162,7 +162,6 @@ TEST_P(RowAdderTest, setInput) {
   {
     auto result = makeIdTableFromVector({});
     result.setNumColumns(keepJoinCol ? 2 : 1);
-    ;
     auto adder = ad_utility::AddCombinedRowToIdTable(
         1, std::move(result),
         std::make_shared<ad_utility::CancellationHandle<>>(), keepJoinCol,
@@ -170,7 +169,8 @@ TEST_P(RowAdderTest, setInput) {
     // It is okay to flush even if no inputs were specified, as long as we
     // haven't pushed any rows yet.
     EXPECT_NO_THROW(adder.flush());
-    if (ad_utility::areExpensiveChecksEnabled || bufferSize == 0) {
+
+    if (ad_utility::areExpensiveChecksEnabled || bufferSize <= 1) {
       EXPECT_ANY_THROW(adder.addRow(0, 0));
     } else {
       adder.addRow(0, 0);

--- a/test/AddCombinedRowToTableTest.cpp
+++ b/test/AddCombinedRowToTableTest.cpp
@@ -4,288 +4,255 @@
 
 #include <gtest/gtest.h>
 
+#include <type_traits>
+
 #include "./util/IdTableHelpers.h"
+#include "backports/concepts.h"
 #include "engine/AddCombinedRowToTable.h"
 
 namespace {
 static constexpr auto U = Id::makeUndefined();
 
-template <typename F>
-void testWithAllBuffersizes(const F& testFunction) {
-  auto eval = [&](int bufferSize) {
-    if constexpr (std::is_invocable_v<F, int, bool>) {
-      testFunction(bufferSize, true);
-      testFunction(bufferSize, false);
-    } else {
-      testFunction(bufferSize);
+class RowAdderTest : public ::testing::TestWithParam<std::tuple<size_t, bool>> {
+};
+
+// Check that the result of the `adder` matches the `expectedResult` and that
+// the number of undefined values per columns (as reported by the `adder`) match
+// the `expectedNumUndefined`. If `keepJoinColumns` is `false`, then the first
+// `numJoinColumns` columns will be removed from `expectedResult` and
+// `expectedNumUndefined`respectively before comparing them to the actual
+// result.
+void testAdder(ad_utility::AddCombinedRowToIdTable& adder,
+               IdTable& expectedResult,
+               std::vector<size_t> expectedNumUndefined, size_t numJoinColumns,
+               bool keepJoinColumns) {
+  auto numUndefined = adder.numUndefinedPerColumn();
+  auto result = std::move(adder).resultTable();
+  if (!keepJoinColumns) {
+    for ([[maybe_unused]] auto i : ad_utility::integerRange(numJoinColumns)) {
+      expectedResult.deleteColumn(0);
+      expectedNumUndefined.erase(expectedNumUndefined.begin());
     }
-  };
-  EXPECT_ANY_THROW(eval(0));
-  ql::ranges::for_each(ql::views::iota(1, 10), eval);
-  eval(100'000);
-}
-}  // namespace
+  }
+  EXPECT_EQ(result, expectedResult);
 
-// _______________________________________________________________________________
-TEST(AddCombinedRowToTable, OneJoinColumn) {
-  auto testWithBufferSize = [](size_t bufferSize, bool keepJoinColumns) {
-    auto left = makeIdTableFromVector({{3, 4}, {7, 8}, {11, 10}, {14, 11}});
-    auto right =
-        makeIdTableFromVector({{7, 14, 0}, {9, 10, 1}, {14, 8, 2}, {33, 5, 3}});
-    auto result = makeIdTableFromVector({});
-    size_t numColsResult = keepJoinColumns ? 4 : 3;
-    result.setNumColumns(numColsResult);
-    auto adder = ad_utility::AddCombinedRowToIdTable(
-        1, left.asStaticView<0>(), right.asStaticView<0>(), std::move(result),
-        std::make_shared<ad_utility::CancellationHandle<>>(), keepJoinColumns,
-        bufferSize);
-    adder.addRow(1, 0);
-    adder.setOnlyLeftInputForOptionalJoin(left);
-    adder.addOptionalRow(2);
-    adder.setInput(left, right);
-    adder.addRow(3, 2);
-    auto numUndefined = adder.numUndefinedPerColumn();
-    result = std::move(adder).resultTable();
-
-    auto expected =
-        makeIdTableFromVector({{7, 8, 14, 0}, {11, 10, U, U}, {14, 11, 8, 2}});
-    auto expectedUndefined = std::vector<size_t>{0, 0, 1, 1};
-    if (!keepJoinColumns) {
-      expected.deleteColumn(0);
-      expectedUndefined.erase(expectedUndefined.begin());
-    }
-    EXPECT_EQ(result, expected);
-
-    EXPECT_EQ(numUndefined, expectedUndefined);
-  };
-  testWithAllBuffersizes(testWithBufferSize);
+  EXPECT_EQ(numUndefined, expectedNumUndefined);
 }
 
 // _______________________________________________________________________________
-TEST(AddCombinedRowToTable, AddRows) {
-  auto testWithBufferSize = [](size_t bufferSize, bool keepJoinColumns) {
-    auto left = makeIdTableFromVector({{3, 4}, {7, 8}, {7, 10}, {14, 11}});
-    auto right =
-        makeIdTableFromVector({{7, 14, 0}, {7, 12, 1}, {14, 8, 2}, {33, 5, 3}});
-    auto result = makeIdTableFromVector({});
-    size_t numColsResult = keepJoinColumns ? 4 : 3;
-    result.setNumColumns(numColsResult);
-    auto adder = ad_utility::AddCombinedRowToIdTable(
-        1, left.asStaticView<0>(), right.asStaticView<0>(), std::move(result),
-        std::make_shared<ad_utility::CancellationHandle<>>(), keepJoinColumns,
-        bufferSize);
-    adder.addOptionalRow(0);
-    adder.addRows(ql::views::iota(1u, 3u), ql::views::iota(0u, 2u));
-    auto numUndefined = adder.numUndefinedPerColumn();
-    result = std::move(adder).resultTable();
+TEST_P(RowAdderTest, OneJoinColumn) {
+  auto [bufferSize, keepJoinColumns] = GetParam();
+  auto left = makeIdTableFromVector({{3, 4}, {7, 8}, {11, 10}, {14, 11}});
+  auto right =
+      makeIdTableFromVector({{7, 14, 0}, {9, 10, 1}, {14, 8, 2}, {33, 5, 3}});
+  auto result = makeIdTableFromVector({});
+  size_t numColsResult = keepJoinColumns ? 4 : 3;
+  result.setNumColumns(numColsResult);
+  auto adder = ad_utility::AddCombinedRowToIdTable(
+      1, left.asStaticView<0>(), right.asStaticView<0>(), std::move(result),
+      std::make_shared<ad_utility::CancellationHandle<>>(), keepJoinColumns,
+      bufferSize);
+  adder.addRow(1, 0);
+  adder.setOnlyLeftInputForOptionalJoin(left);
+  adder.addOptionalRow(2);
+  adder.setInput(left, right);
+  adder.addRow(3, 2);
 
-    auto expected = makeIdTableFromVector({{3, 4, U, U},
-                                           {7, 8, 14, 0},
-                                           {7, 8, 12, 1},
-                                           {7, 10, 14, 0},
-                                           {7, 10, 12, 1}});
-    auto expectedUndefined = std::vector<size_t>{0, 0, 1, 1};
-    if (!keepJoinColumns) {
-      expected.deleteColumn(0);
-      expectedUndefined.erase(expectedUndefined.begin());
-    }
-    EXPECT_EQ(result, expected);
+  auto expected =
+      makeIdTableFromVector({{7, 8, 14, 0}, {11, 10, U, U}, {14, 11, 8, 2}});
+  auto expectedUndefined = std::vector<size_t>{0, 0, 1, 1};
+  testAdder(adder, expected, expectedUndefined, 1, keepJoinColumns);
+};
 
-    EXPECT_EQ(numUndefined, expectedUndefined);
-  };
-  testWithAllBuffersizes(testWithBufferSize);
+// _______________________________________________________________________________
+TEST_P(RowAdderTest, AddRows) {
+  auto [bufferSize, keepJoinColumns] = GetParam();
+  auto left = makeIdTableFromVector({{3, 4}, {7, 8}, {7, 10}, {14, 11}});
+  auto right =
+      makeIdTableFromVector({{7, 14, 0}, {7, 12, 1}, {14, 8, 2}, {33, 5, 3}});
+  auto result = makeIdTableFromVector({});
+  size_t numColsResult = keepJoinColumns ? 4 : 3;
+  result.setNumColumns(numColsResult);
+  auto adder = ad_utility::AddCombinedRowToIdTable(
+      1, left.asStaticView<0>(), right.asStaticView<0>(), std::move(result),
+      std::make_shared<ad_utility::CancellationHandle<>>(), keepJoinColumns,
+      bufferSize);
+  adder.addOptionalRow(0);
+  adder.addRows(ql::views::iota(1u, 3u), ql::views::iota(0u, 2u));
+
+  auto expected = makeIdTableFromVector({{3, 4, U, U},
+                                         {7, 8, 14, 0},
+                                         {7, 8, 12, 1},
+                                         {7, 10, 14, 0},
+                                         {7, 10, 12, 1}});
+  auto expectedUndefined = std::vector<size_t>{0, 0, 1, 1};
+  testAdder(adder, expected, expectedUndefined, 1, keepJoinColumns);
 }
 
 // _______________________________________________________________________________
-TEST(AddCombinedRowToTable, AddRowsZeroColumns) {
-  auto testWithBufferSize = [](size_t bufferSize, bool keepJoinColumns) {
-    auto left = makeIdTableFromVector({{3}, {3}, {3}, {7}});
-    auto right = makeIdTableFromVector({{2}, {3}, {3}, {5}});
-    auto result = makeIdTableFromVector({});
-    size_t numColsResult = keepJoinColumns ? 1 : 0;
-    result.setNumColumns(numColsResult);
-    auto adder = ad_utility::AddCombinedRowToIdTable(
-        1, left.asStaticView<0>(), right.asStaticView<0>(), std::move(result),
-        std::make_shared<ad_utility::CancellationHandle<>>(), keepJoinColumns,
-        bufferSize);
-    adder.addRows(ql::views::iota(0u, 3u), ql::views::iota(1u, 3u));
-    adder.addOptionalRow(3);
-    auto numUndefined = adder.numUndefinedPerColumn();
-    result = std::move(adder).resultTable();
+TEST_P(RowAdderTest, AddRowsZeroColumns) {
+  auto [bufferSize, keepJoinColumns] = GetParam();
+  auto left = makeIdTableFromVector({{3}, {3}, {3}, {7}});
+  auto right = makeIdTableFromVector({{2}, {3}, {3}, {5}});
+  auto result = makeIdTableFromVector({});
+  size_t numColsResult = keepJoinColumns ? 1 : 0;
+  result.setNumColumns(numColsResult);
+  auto adder = ad_utility::AddCombinedRowToIdTable(
+      1, left.asStaticView<0>(), right.asStaticView<0>(), std::move(result),
+      std::make_shared<ad_utility::CancellationHandle<>>(), keepJoinColumns,
+      bufferSize);
+  adder.addRows(ql::views::iota(0u, 3u), ql::views::iota(1u, 3u));
+  adder.addOptionalRow(3);
 
-    auto expected = makeIdTableFromVector({{3}, {3}, {3}, {3}, {3}, {3}, {7}});
-    auto expectedUndefined = std::vector<size_t>{0};
-    if (!keepJoinColumns) {
-      expected.deleteColumn(0);
-      expectedUndefined.erase(expectedUndefined.begin());
-    }
-    EXPECT_EQ(result, expected);
-
-    EXPECT_EQ(numUndefined, expectedUndefined);
-  };
-  testWithAllBuffersizes(testWithBufferSize);
+  auto expected = makeIdTableFromVector({{3}, {3}, {3}, {3}, {3}, {3}, {7}});
+  auto expectedUndefined = std::vector<size_t>{0};
+  testAdder(adder, expected, expectedUndefined, 1, keepJoinColumns);
 }
 
 // _______________________________________________________________________________
-TEST(AddCombinedRowToTable, TwoJoinColumns) {
-  auto testWithBufferSize = [](size_t bufferSize, bool keepJoinColumns) {
-    auto left = makeIdTableFromVector({{3, 4}, {7, 8}, {11, 10}, {14, U}});
-    auto right =
-        makeIdTableFromVector({{U, 8, 0}, {9, 10, 1}, {14, 11, 2}, {33, 5, 3}});
-    auto result = makeIdTableFromVector({});
-    static constexpr size_t numJoinCols = 2;
-    size_t numColsResult = keepJoinColumns ? 3 : 1;
-    result.setNumColumns(numColsResult);
-    auto adder = ad_utility::AddCombinedRowToIdTable(
-        numJoinCols, left.asStaticView<0>(), right.asStaticView<0>(),
-        std::move(result), std::make_shared<ad_utility::CancellationHandle<>>(),
-        keepJoinColumns, bufferSize);
-    adder.addRow(1, 0);
-    adder.addOptionalRow(2);
-    adder.addRow(3, 2);
-    auto numUndefined = adder.numUndefinedPerColumn();
-    result = std::move(adder).resultTable();
+TEST_P(RowAdderTest, TwoJoinColumns) {
+  auto [bufferSize, keepJoinColumns] = GetParam();
+  auto left = makeIdTableFromVector({{3, 4}, {7, 8}, {11, 10}, {14, U}});
+  auto right =
+      makeIdTableFromVector({{U, 8, 0}, {9, 10, 1}, {14, 11, 2}, {33, 5, 3}});
+  auto result = makeIdTableFromVector({});
+  static constexpr size_t numJoinCols = 2;
+  size_t numColsResult = keepJoinColumns ? 3 : 1;
+  result.setNumColumns(numColsResult);
+  auto adder = ad_utility::AddCombinedRowToIdTable(
+      numJoinCols, left.asStaticView<0>(), right.asStaticView<0>(),
+      std::move(result), std::make_shared<ad_utility::CancellationHandle<>>(),
+      keepJoinColumns, bufferSize);
+  adder.addRow(1, 0);
+  adder.addOptionalRow(2);
+  adder.addRow(3, 2);
 
-    auto expected =
-        makeIdTableFromVector({{7, 8, 0}, {11, 10, U}, {14, 11, 2}});
-    auto expectedUndefined = std::vector<size_t>{0, 0, 1};
-    if (!keepJoinColumns) {
-      for ([[maybe_unused]] auto _ : ad_utility::integerRange(numJoinCols)) {
-        expected.deleteColumn(0);
-      }
-      expectedUndefined.erase(expectedUndefined.begin(),
-                              expectedUndefined.begin() + numJoinCols);
-    }
-    EXPECT_EQ(result, expected);
-    EXPECT_EQ(numUndefined, expectedUndefined);
-  };
-  testWithAllBuffersizes(testWithBufferSize);
+  auto expected = makeIdTableFromVector({{7, 8, 0}, {11, 10, U}, {14, 11, 2}});
+  auto expectedUndefined = std::vector<size_t>{0, 0, 1};
+  testAdder(adder, expected, expectedUndefined, numJoinCols, keepJoinColumns);
 }
 
 // _______________________________________________________________________________
-TEST(AddCombinedRowToTable, UndefInInput) {
-  auto testWithBufferSize = [](size_t bufferSize, bool keepJoinCol) {
-    auto left = makeIdTableFromVector({{U, 5}, {2, U}, {3, U}, {4, U}});
-    auto right = makeIdTableFromVector({{1}, {3}, {4}, {U}});
+TEST_P(RowAdderTest, UndefInInput) {
+  auto [bufferSize, keepJoinCol] = GetParam();
+  auto left = makeIdTableFromVector({{U, 5}, {2, U}, {3, U}, {4, U}});
+  auto right = makeIdTableFromVector({{1}, {3}, {4}, {U}});
+  auto result = makeIdTableFromVector({});
+  result.setNumColumns(keepJoinCol ? 2 : 1);
+  auto adder = ad_utility::AddCombinedRowToIdTable(
+      1, left.asStaticView<0>(), right.asStaticView<0>(), std::move(result),
+      std::make_shared<ad_utility::CancellationHandle<>>(), keepJoinCol,
+      bufferSize);
+  adder.addRow(0, 0);
+  adder.addRow(0, 1);
+  adder.addRow(2, 1);
+  adder.addRow(0, 2);
+  adder.addRow(3, 2);
+  adder.addRow(0, 3);
+
+  auto expected =
+      makeIdTableFromVector({{1, 5}, {3, 5}, {3, U}, {4, 5}, {4, U}, {U, 5}});
+  auto expectedUndefined = std::vector<size_t>{1, 2};
+  testAdder(adder, expected, expectedUndefined, 1, keepJoinCol);
+}
+
+// _______________________________________________________________________________
+TEST_P(RowAdderTest, setInput) {
+  auto [bufferSize, keepJoinCol] = GetParam();
+  {
     auto result = makeIdTableFromVector({});
     result.setNumColumns(keepJoinCol ? 2 : 1);
-    auto adder = ad_utility::AddCombinedRowToIdTable(
-        1, left.asStaticView<0>(), right.asStaticView<0>(), std::move(result),
-        std::make_shared<ad_utility::CancellationHandle<>>(), keepJoinCol,
-        bufferSize);
-    adder.addRow(0, 0);
-    adder.addRow(0, 1);
-    adder.addRow(2, 1);
-    adder.addRow(0, 2);
-    adder.addRow(3, 2);
-    adder.addRow(0, 3);
-    auto numUndefined = adder.numUndefinedPerColumn();
-    result = std::move(adder).resultTable();
-
-    auto expected =
-        makeIdTableFromVector({{1, 5}, {3, 5}, {3, U}, {4, 5}, {4, U}, {U, 5}});
-    auto expectedUndefined = std::vector<size_t>{1, 2};
-    if (!keepJoinCol) {
-      expected.deleteColumn(0);
-      expectedUndefined.erase(expectedUndefined.begin());
-    }
-
-    EXPECT_EQ(result, expected);
-    EXPECT_EQ(numUndefined, expectedUndefined);
-  };
-  testWithAllBuffersizes(testWithBufferSize);
-}
-
-// _______________________________________________________________________________
-TEST(AddCombinedRowToTable, setInput) {
-  auto testWithBufferSize = [](size_t bufferSize, bool keepJoinCol) {
-    {
-      auto result = makeIdTableFromVector({});
-      result.setNumColumns(keepJoinCol ? 2 : 1);
-      ;
-      auto adder = ad_utility::AddCombinedRowToIdTable(
-          1, std::move(result),
-          std::make_shared<ad_utility::CancellationHandle<>>(), keepJoinCol,
-          bufferSize);
-      // It is okay to flush even if no inputs were specified, as long as we
-      // haven't pushed any rows yet.
-      EXPECT_NO_THROW(adder.flush());
-      if (ad_utility::areExpensiveChecksEnabled || bufferSize == 0) {
-        EXPECT_ANY_THROW(adder.addRow(0, 0));
-      } else {
-        adder.addRow(0, 0);
-        EXPECT_ANY_THROW(adder.flush());
-      }
-    }
-
-    auto result = makeIdTableFromVector({});
-    result.setNumColumns(keepJoinCol ? 3 : 2);
+    ;
     auto adder = ad_utility::AddCombinedRowToIdTable(
         1, std::move(result),
         std::make_shared<ad_utility::CancellationHandle<>>(), keepJoinCol,
         bufferSize);
-    auto left = makeIdTableFromVector({{U, 5}, {2, U}, {3, U}, {4, U}});
-    auto right = makeIdTableFromVector({{1, 2}, {3, 4}, {4, 7}, {U, 8}});
-    adder.setInput(left, right);
-    adder.addRow(0, 0);
-    adder.addRow(0, 1);
-    adder.addRow(2, 1);
-    adder.addRow(0, 2);
-    adder.addRow(3, 2);
-    adder.addRow(0, 3);
-    adder.setInput(right, left);
-    adder.addRow(0, 0);
-    adder.addRow(1, 0);
-    adder.addRow(1, 2);
-    adder.addRow(2, 0);
-    adder.addRow(2, 3);
-    adder.addRow(3, 0);
-    result = std::move(adder).resultTable();
-
-    auto expected = makeIdTableFromVector({{1, 5, 2},
-                                           {3, 5, 4},
-                                           {3, U, 4},
-                                           {4, 5, 7},
-                                           {4, U, 7},
-                                           {U, 5, 8},
-                                           {1, 2, 5},
-                                           {3, 4, 5},
-                                           {3, 4, U},
-                                           {4, 7, 5},
-                                           {4, 7, U},
-                                           {U, 8, 5}});
-    if (!keepJoinCol) {
-      expected.deleteColumn(0);
+    // It is okay to flush even if no inputs were specified, as long as we
+    // haven't pushed any rows yet.
+    EXPECT_NO_THROW(adder.flush());
+    if (ad_utility::areExpensiveChecksEnabled || bufferSize == 0) {
+      EXPECT_ANY_THROW(adder.addRow(0, 0));
+    } else {
+      adder.addRow(0, 0);
+      EXPECT_ANY_THROW(adder.flush());
     }
-    EXPECT_EQ(result, expected);
-  };
-  testWithAllBuffersizes(testWithBufferSize);
+  }
+
+  auto result = makeIdTableFromVector({});
+  result.setNumColumns(keepJoinCol ? 3 : 2);
+  auto adder = ad_utility::AddCombinedRowToIdTable(
+      1, std::move(result),
+      std::make_shared<ad_utility::CancellationHandle<>>(), keepJoinCol,
+      bufferSize);
+  auto left = makeIdTableFromVector({{U, 5}, {2, U}, {3, U}, {4, U}});
+  auto right = makeIdTableFromVector({{1, 2}, {3, 4}, {4, 7}, {U, 8}});
+  adder.setInput(left, right);
+  adder.addRow(0, 0);
+  adder.addRow(0, 1);
+  adder.addRow(2, 1);
+  adder.addRow(0, 2);
+  adder.addRow(3, 2);
+  adder.addRow(0, 3);
+  adder.setInput(right, left);
+  adder.addRow(0, 0);
+  adder.addRow(1, 0);
+  adder.addRow(1, 2);
+  adder.addRow(2, 0);
+  adder.addRow(2, 3);
+  adder.addRow(3, 0);
+
+  auto expected = makeIdTableFromVector({{1, 5, 2},
+                                         {3, 5, 4},
+                                         {3, U, 4},
+                                         {4, 5, 7},
+                                         {4, U, 7},
+                                         {U, 5, 8},
+                                         {1, 2, 5},
+                                         {3, 4, 5},
+                                         {3, 4, U},
+                                         {4, 7, 5},
+                                         {4, 7, U},
+                                         {U, 8, 5}});
+  std::vector<size_t> expectedUndefined{2, 2, 2};
+  testAdder(adder, expected, expectedUndefined, 1, keepJoinCol);
 }
 
 // _______________________________________________________________________________
-TEST(AddCombinedRowToTable, cornerCases) {
-  auto testWithBufferSize = [](size_t bufferSize, bool keepJoinCol) {
-    auto result = makeIdTableFromVector({});
-    result.setNumColumns(keepJoinCol ? 3 : 1);
-    auto adder = ad_utility::AddCombinedRowToIdTable(
-        2, std::move(result),
-        std::make_shared<ad_utility::CancellationHandle<>>(), keepJoinCol,
-        bufferSize);
-    auto left = makeIdTableFromVector({{U, 5}, {2, U}, {3, U}, {4, U}});
-    auto right = makeIdTableFromVector({{1, 2}, {3, 4}, {4, 7}, {U, 8}});
-    // We have specified two join columns and our inputs have two columns each,
-    // so the result should also have two columns, but it has three.
-    EXPECT_ANY_THROW(adder.setInput(left, right));
+TEST_P(RowAdderTest, cornerCases) {
+  auto [bufferSize, keepJoinCol] = GetParam();
+  auto result = makeIdTableFromVector({});
+  result.setNumColumns(keepJoinCol ? 3 : 1);
+  auto adder = ad_utility::AddCombinedRowToIdTable(
+      2, std::move(result),
+      std::make_shared<ad_utility::CancellationHandle<>>(), keepJoinCol,
+      bufferSize);
+  auto left = makeIdTableFromVector({{U, 5}, {2, U}, {3, U}, {4, U}});
+  auto right = makeIdTableFromVector({{1, 2}, {3, 4}, {4, 7}, {U, 8}});
+  // We have specified two join columns and our inputs have two columns each,
+  // so the result should also have two columns, but it has three.
+  EXPECT_ANY_THROW(adder.setInput(left, right));
 
-    left = makeIdTableFromVector({{1}, {2}, {3}});
+  left = makeIdTableFromVector({{1}, {2}, {3}});
 
-    // Left has only one column, but we have specified two join columns.
-    EXPECT_ANY_THROW(adder.setInput(left, right));
-    // The same test with the arguments switched.
-    EXPECT_ANY_THROW(adder.setInput(right, left));
-  };
-  testWithAllBuffersizes(testWithBufferSize);
+  // Left has only one column, but we have specified two join columns.
+  EXPECT_ANY_THROW(adder.setInput(left, right));
+  // The same test with the arguments switched.
+  EXPECT_ANY_THROW(adder.setInput(right, left));
 }
+// _______________________________________________________________________________
+TEST(AddCombinedRowToTable, BufferSizeZeroThrows) {
+  auto left = makeIdTableFromVector({{3, 4}, {7, 8}, {11, 10}, {14, 11}});
+  auto right =
+      makeIdTableFromVector({{7, 14, 0}, {9, 10, 1}, {14, 8, 2}, {33, 5, 3}});
+  auto result = makeIdTableFromVector({});
+  result.setNumColumns(4);
+  EXPECT_ANY_THROW(ad_utility::AddCombinedRowToIdTable(
+      1, left.asStaticView<0>(), right.asStaticView<0>(), std::move(result),
+      std::make_shared<ad_utility::CancellationHandle<>>(), true, 0));
+  EXPECT_ANY_THROW(ad_utility::AddCombinedRowToIdTable(
+      1, left.asStaticView<0>(), right.asStaticView<0>(), std::move(result),
+      std::make_shared<ad_utility::CancellationHandle<>>(), false, 0));
+};
 
 // _______________________________________________________________________________
 TEST(AddCombinedRowToTable, flushDoesCheckCancellation) {
@@ -462,3 +429,10 @@ TEST(AddCombinedRowToTable, localVocabIsOnlyClearedWhenLegal) {
   EXPECT_TRUE(vocabContainsString(localVocab, "d"));
   EXPECT_THAT(localVocab.getAllWordsForTesting(), ::testing::SizeIs(4));
 }
+
+INSTANTIATE_TEST_SUITE_P(AddCombinedRowToTable, RowAdderTest,
+                         ::testing::Combine(::testing::Values(1u, 2u, 3u, 4u,
+                                                              5u, 6u, 7u, 8u,
+                                                              9u, 10u, 100000u),
+                                            ::testing::Values(true, false)));
+}  // namespace

--- a/test/JoinAlgorithmsTest.cpp
+++ b/test/JoinAlgorithmsTest.cpp
@@ -38,6 +38,14 @@ struct RowAdder {
     AD_CONTRACT_CHECK(x1 == y1);
     target_->push_back(std::array{x1, x2, y2});
   }
+  template <typename R1, typename R2>
+  void addRows(const R1& left, const R2& right) {
+    for (auto a : left) {
+      for (auto b : right) {
+        addRow(a, b);
+      }
+    }
+  }
 
   void addOptionalRow(size_t leftIndex) {
     auto [x1, x2] = (*left_)[leftIndex];
@@ -308,6 +316,15 @@ struct RowAdderWithUndef {
     auto id1 = (*left_)[leftIndex];
     auto id2 = (*right_)[rightIndex];
     output_.push_back({id1, id2});
+  }
+
+  template <typename R1, typename R2>
+  void addRows(const R1& left, const R2& right) {
+    for (auto a : left) {
+      for (auto b : right) {
+        addRow(a, b);
+      }
+    }
   }
 
   void addOptionalRow(size_t leftIndex) {

--- a/test/engine/OptionalJoinTest.cpp
+++ b/test/engine/OptionalJoinTest.cpp
@@ -567,18 +567,18 @@ TEST(OptionalJoin, lazyOptionalJoinWithOneMaterializedTable) {
 TEST(OptionalJoin, lazyOptionalJoinExceedingChunkSize) {
   std::vector<IdTable> expected;
   expected.push_back(createIdTableOfSizeWithValue(
-      qlever::joinHelpers::CHUNK_SIZE + 1, Id::makeFromInt(1)));
+      qlever::joinHelpers::CHUNK_SIZE, Id::makeFromInt(1)));
   expected.push_back(createIdTableOfSizeWithValue(
-      qlever::joinHelpers::CHUNK_SIZE + 1, Id::makeFromInt(2)));
+      qlever::joinHelpers::CHUNK_SIZE, Id::makeFromInt(2)));
 
   std::vector<IdTable> leftTables;
   leftTables.push_back(
       makeIdTableFromVector({{Id::makeFromInt(1)}, {Id::makeFromInt(2)}}));
   std::vector<IdTable> rightTables;
   rightTables.push_back(createIdTableOfSizeWithValue(
-      qlever::joinHelpers::CHUNK_SIZE + 1, Id::makeFromInt(1)));
+      qlever::joinHelpers::CHUNK_SIZE, Id::makeFromInt(1)));
   rightTables.push_back(createIdTableOfSizeWithValue(
-      qlever::joinHelpers::CHUNK_SIZE + 1, Id::makeFromInt(2)));
+      qlever::joinHelpers::CHUNK_SIZE, Id::makeFromInt(2)));
 
   testLazyOptionalJoin(std::move(leftTables), std::move(rightTables),
                        std::move(expected), true);


### PR DESCRIPTION
Prepare the following optimizations:
1. Allow adding multiple rows at once (so far, each `IdTable` was grown row by row)
2. Allow for not including the join columns in the result (so far, this has always been included)
3. Optimize the case where the result has zero columns (which happens when neither the "payload" columns nor the join columns are needed)