### PR TITLE
In `GroupBy` operation, use `IndexScan::numVariables` instead of `IndexScan::getResultWidth`

### DIFF
--- a/src/engine/GroupByImpl.cpp
+++ b/src/engine/GroupByImpl.cpp
@@ -622,7 +622,7 @@ std::optional<IdTable> GroupByImpl::computeGroupByForSingleIndexScan() const {
     return std::nullopt;
   }
 
-  if (indexScan->getResultWidth() <= 1 ||
+  if (indexScan->numVariables() <= 1 ||
       indexScan->graphsToFilter().has_value() || !_groupByVariables.empty()) {
     return std::nullopt;
   }
@@ -635,7 +635,7 @@ std::optional<IdTable> GroupByImpl::computeGroupByForSingleIndexScan() const {
 
   // Distinct counts are only supported for triples with three variables.
   bool countIsDistinct = varAndDistinctness.value().isDistinct_;
-  if (countIsDistinct && indexScan->getResultWidth() != 3) {
+  if (countIsDistinct && indexScan->numVariables() != 3) {
     return std::nullopt;
   }
 
@@ -645,7 +645,7 @@ std::optional<IdTable> GroupByImpl::computeGroupByForSingleIndexScan() const {
   if (!isVariableBoundInSubtree(var)) {
     // The variable is never bound, so its count is zero.
     table(0, 0) = Id::makeFromInt(0);
-  } else if (indexScan->getResultWidth() == 3) {
+  } else if (indexScan->numVariables() == 3) {
     if (countIsDistinct) {
       auto permutation =
           getPermutationForThreeVariableTriple(*_subtree, var, var);
@@ -786,7 +786,7 @@ GroupByImpl::getPermutationForThreeVariableTriple(
       std::dynamic_pointer_cast<const IndexScan>(tree.getRootOperation());
 
   if (!indexScan || indexScan->graphsToFilter().has_value() ||
-      indexScan->getResultWidth() != 3) {
+      indexScan->numVariables() != 3) {
     return std::nullopt;
   }
   {


### PR DESCRIPTION
This does not change any functionality for now, but will make the `GroupBy` operation checks for optimizations more robust when columns are stripped away from an `IndexScan`