### PR TITLE
Implement index nested loop join for `OPTIONAL`

### DIFF
--- a/src/engine/ExistsJoin.cpp
+++ b/src/engine/ExistsJoin.cpp
@@ -293,8 +293,8 @@ std::optional<Result> ExistsJoin::tryIndexNestedLoopJoinIfSuitable() {
 
   IdTable result = leftRes->idTable().clone();
   LocalVocab localVocab = leftRes->getCopyOfLocalVocab();
-  IndexNestedLoopJoin nestedLoopJoin{joinColumns_, std::move(leftRes),
-                                     std::move(rightRes)};
+  joinAlgorithms::indexNestedLoop::IndexNestedLoopJoin nestedLoopJoin{
+      joinColumns_, std::move(leftRes), std::move(rightRes)};
   result.addEmptyColumn();
   ad_utility::chunkedCopy(
       ql::views::transform(

--- a/src/engine/ExistsJoin.cpp
+++ b/src/engine/ExistsJoin.cpp
@@ -104,7 +104,7 @@ Result ExistsJoin::computeResult(bool requestLaziness) {
   bool noJoinNecessary = joinColumns_.empty();
 
   if (!noJoinNecessary) {
-    if (auto res = tryNestedLoopJoinIfSuitable()) {
+    if (auto res = tryIndexNestedLoopJoinIfSuitable()) {
       return std::move(res).value();
     }
   }
@@ -271,7 +271,7 @@ std::unique_ptr<Operation> ExistsJoin::cloneImpl() const {
 }
 
 // _____________________________________________________________________________
-std::optional<Result> ExistsJoin::tryNestedLoopJoinIfSuitable() {
+std::optional<Result> ExistsJoin::tryIndexNestedLoopJoinIfSuitable() {
   auto alwaysDefined = [this]() {
     return qlever::joinHelpers::joinColumnsAreAlwaysDefined(joinColumns_, left_,
                                                             right_);

--- a/src/engine/ExistsJoin.cpp
+++ b/src/engine/ExistsJoin.cpp
@@ -284,12 +284,8 @@ std::optional<Result> ExistsJoin::tryIndexNestedLoopJoinIfSuitable() {
     return std::nullopt;
   }
 
-  auto child = sort->getChildren().at(0);
-  auto runtimeInfoChildren = child->getRootOperation()->getRuntimeInfoPointer();
-  sort->updateRuntimeInformationWhenOptimizedOut({runtimeInfoChildren});
-
   auto leftRes = left_->getResult(false);
-  auto rightRes = child->getResult(true);
+  auto rightRes = qlever::joinHelpers::computeResultSkipChild(sort);
 
   IdTable result = leftRes->idTable().clone();
   LocalVocab localVocab = leftRes->getCopyOfLocalVocab();

--- a/src/engine/ExistsJoin.cpp
+++ b/src/engine/ExistsJoin.cpp
@@ -298,7 +298,7 @@ std::optional<Result> ExistsJoin::tryNestedLoopJoinIfSuitable() {
   result.addEmptyColumn();
   ad_utility::chunkedCopy(
       ql::views::transform(
-          ad_utility::OwningView{nestedLoopJoin.computeTracker()},
+          ad_utility::OwningView{nestedLoopJoin.computeExistance()},
           [](char tracker) { return Id::makeFromBool(tracker != 0); }),
       result.getColumn(result.numColumns() - 1).begin(),
       qlever::joinHelpers::CHUNK_SIZE, [this]() { checkCancellation(); });

--- a/src/engine/ExistsJoin.h
+++ b/src/engine/ExistsJoin.h
@@ -84,7 +84,7 @@ class ExistsJoin : public Operation {
 
   // Nested loop join optimization than can apply when a memory intensive sort
   // can be avoided this way.
-  std::optional<Result> tryNestedLoopJoinIfSuitable();
+  std::optional<Result> tryIndexNestedLoopJoinIfSuitable();
 
   Result computeResult(bool requestLaziness) override;
 

--- a/src/engine/Minus.cpp
+++ b/src/engine/Minus.cpp
@@ -258,7 +258,7 @@ std::optional<Result> Minus::tryNestedLoopJoinIfSuitable() {
   IndexNestedLoopJoin nestedLoopJoin{_matchedColumns, std::move(leftRes),
                                      std::move(rightRes)};
 
-  std::vector<char> nonMatchingEntries = nestedLoopJoin.computeTracker();
+  std::vector<char> nonMatchingEntries = nestedLoopJoin.computeExistance();
   return std::optional{Result{
       copyMatchingRows(leftTable, static_cast<char>(false), nonMatchingEntries),
       resultSortedOn(), std::move(localVocab)}};

--- a/src/engine/Minus.cpp
+++ b/src/engine/Minus.cpp
@@ -247,13 +247,9 @@ std::optional<Result> Minus::tryIndexNestedLoopJoinIfSuitable() {
     return std::nullopt;
   }
 
-  auto child = sort->getChildren().at(0);
-  auto runtimeInfoChildren = child->getRootOperation()->getRuntimeInfoPointer();
-  sort->updateRuntimeInformationWhenOptimizedOut({runtimeInfoChildren});
-
   auto leftRes = _left->getResult(false);
   const IdTable& leftTable = leftRes->idTable();
-  auto rightRes = child->getResult(true);
+  auto rightRes = qlever::joinHelpers::computeResultSkipChild(sort);
 
   LocalVocab localVocab = leftRes->getCopyOfLocalVocab();
   joinAlgorithms::indexNestedLoop::IndexNestedLoopJoin nestedLoopJoin{

--- a/src/engine/Minus.cpp
+++ b/src/engine/Minus.cpp
@@ -256,8 +256,8 @@ std::optional<Result> Minus::tryIndexNestedLoopJoinIfSuitable() {
   auto rightRes = child->getResult(true);
 
   LocalVocab localVocab = leftRes->getCopyOfLocalVocab();
-  IndexNestedLoopJoin nestedLoopJoin{_matchedColumns, std::move(leftRes),
-                                     std::move(rightRes)};
+  joinAlgorithms::indexNestedLoop::IndexNestedLoopJoin nestedLoopJoin{
+      _matchedColumns, std::move(leftRes), std::move(rightRes)};
 
   auto nonMatchingEntries = nestedLoopJoin.computeExistance();
   return std::optional{Result{

--- a/src/engine/Minus.cpp
+++ b/src/engine/Minus.cpp
@@ -47,7 +47,7 @@ Result Minus::computeResult(bool requestLaziness) {
                                    _right->getRootOperation(), true,
                                    requestLaziness);
 
-  if (auto res = tryNestedLoopJoinIfSuitable()) {
+  if (auto res = tryIndexNestedLoopJoinIfSuitable()) {
     return std::move(res).value();
   }
 
@@ -234,7 +234,7 @@ std::unique_ptr<Operation> Minus::cloneImpl() const {
 }
 
 // _____________________________________________________________________________
-std::optional<Result> Minus::tryNestedLoopJoinIfSuitable() {
+std::optional<Result> Minus::tryIndexNestedLoopJoinIfSuitable() {
   auto alwaysDefined = [this]() {
     return qlever::joinHelpers::joinColumnsAreAlwaysDefined(_matchedColumns,
                                                             _left, _right);

--- a/src/engine/Minus.h
+++ b/src/engine/Minus.h
@@ -57,8 +57,9 @@ class Minus : public Operation {
   // Helper function to copy all rows from `left` that have a corresponding
   // value of `reference` in `keepEntry`.
   template <typename T>
-  IdTable copyMatchingRows(const IdTable& left, T reference,
-                           const std::vector<T>& keepEntry) const;
+  IdTable copyMatchingRows(
+      const IdTable& left, T reference,
+      const std::vector<T, ad_utility::AllocatorWithLimit<T>>& keepEntry) const;
 
  public:
   size_t getCostEstimate() override;

--- a/src/engine/Minus.h
+++ b/src/engine/Minus.h
@@ -86,7 +86,7 @@ class Minus : public Operation {
 
   // Nested loop join optimization than can apply when a memory intensive sort
   // can be avoided this way.
-  std::optional<Result> tryNestedLoopJoinIfSuitable();
+  std::optional<Result> tryIndexNestedLoopJoinIfSuitable();
 
   // Lazily compute the minus join of two results when at least one of the
   // results is computed lazily. This currently only works if we have just a

--- a/src/engine/OptionalJoin.cpp
+++ b/src/engine/OptionalJoin.cpp
@@ -104,7 +104,7 @@ Result OptionalJoin::computeResult(bool requestLaziness) {
                                    _right->getRootOperation(), true,
                                    requestLaziness);
 
-  if (auto res = tryNestedLoopJoinIfSuitable(requestLaziness)) {
+  if (auto res = tryIndexNestedLoopJoinIfSuitable(requestLaziness)) {
     return std::move(res).value();
   }
 
@@ -163,7 +163,7 @@ size_t OptionalJoin::getResultWidth() const {
 std::vector<ColumnIndex> OptionalJoin::resultSortedOn() const {
   std::vector<ColumnIndex> sortedOn;
   // This optimization doesn't allow preserving sort order.
-  if (isNestedLoopJoinSuitable()) {
+  if (isIndexNestedLoopJoinSuitable()) {
     return sortedOn;
   }
   // The result is sorted on all join columns from the left subtree.
@@ -476,7 +476,7 @@ std::unique_ptr<Operation> OptionalJoin::cloneImpl() const {
 }
 
 // _____________________________________________________________________________
-bool OptionalJoin::isNestedLoopJoinSuitable() const {
+bool OptionalJoin::isIndexNestedLoopJoinSuitable() const {
   auto alwaysDefined = [this]() {
     return qlever::joinHelpers::joinColumnsAreAlwaysDefined(_joinColumns, _left,
                                                             _right);
@@ -489,9 +489,9 @@ bool OptionalJoin::isNestedLoopJoinSuitable() const {
 }
 
 // _____________________________________________________________________________
-std::optional<Result> OptionalJoin::tryNestedLoopJoinIfSuitable(
+std::optional<Result> OptionalJoin::tryIndexNestedLoopJoinIfSuitable(
     bool requestLaziness) {
-  if (!isNestedLoopJoinSuitable()) {
+  if (!isIndexNestedLoopJoinSuitable()) {
     return std::nullopt;
   }
   auto leftRes = _left->getResult(false);

--- a/src/engine/OptionalJoin.cpp
+++ b/src/engine/OptionalJoin.cpp
@@ -531,9 +531,11 @@ std::optional<Result> OptionalJoin::tryIndexNestedLoopJoinIfSuitable(
   // This algorithm doesn't produce sorted output
   AD_CORRECTNESS_CHECK(resultSortedOn().empty());
 
-  auto lazyResult = std::move(nestedLoopJoin)
-                        .computeOptionalJoin(!requestLaziness, getResultWidth(),
-                                             cancellationHandle_);
+  auto lazyResult =
+      std::move(nestedLoopJoin)
+          .computeOptionalJoin(!requestLaziness, getResultWidth(),
+                               cancellationHandle_, _right->getResultWidth(),
+                               keepJoinColumns_);
   return requestLaziness
              ? Result{std::move(lazyResult), resultSortedOn()}
              : Result{ad_utility::getSingleElement(std::move(lazyResult)),

--- a/src/engine/OptionalJoin.cpp
+++ b/src/engine/OptionalJoin.cpp
@@ -495,11 +495,7 @@ std::optional<Result> OptionalJoin::tryIndexNestedLoopJoinIfSuitable(
     return std::nullopt;
   }
   auto leftRes = _left->getResult(false);
-  auto rightOp = _right->getRootOperation();
-  auto child = rightOp->getChildren().at(0);
-  auto runtimeInfoChildren = child->getRootOperation()->getRuntimeInfoPointer();
-  rightOp->updateRuntimeInformationWhenOptimizedOut({runtimeInfoChildren});
-  auto rightRes = child->getResult(true);
+  auto rightRes = computeResultSkipChild(_right->getRootOperation());
 
   LocalVocab localVocab = leftRes->getCopyOfLocalVocab();
   joinAlgorithms::indexNestedLoop::IndexNestedLoopJoin nestedLoopJoin{

--- a/src/engine/OptionalJoin.cpp
+++ b/src/engine/OptionalJoin.cpp
@@ -11,8 +11,8 @@
 #include "engine/JoinHelpers.h"
 #include "engine/Service.h"
 #include "engine/Sort.h"
+#include "util/JoinAlgorithms/IndexNestedLoopJoin.h"
 #include "util/JoinAlgorithms/JoinAlgorithms.h"
-#include "util/JoinAlgorithms/NestedLoopJoin.h"
 
 using namespace qlever::joinHelpers;
 
@@ -511,8 +511,8 @@ std::optional<Result> OptionalJoin::tryNestedLoopJoinIfSuitable(
   auto rightRes = child->getResult(true);
 
   LocalVocab localVocab = leftRes->getCopyOfLocalVocab();
-  NestedLoopJoin nestedLoopJoin{_joinColumns, std::move(leftRes),
-                                std::move(rightRes)};
+  IndexNestedLoopJoin nestedLoopJoin{_joinColumns, std::move(leftRes),
+                                     std::move(rightRes)};
 
   // This algorithm doesn't produce sorted output
   AD_CORRECTNESS_CHECK(resultSortedOn().empty());

--- a/src/engine/OptionalJoin.cpp
+++ b/src/engine/OptionalJoin.cpp
@@ -517,9 +517,9 @@ std::optional<Result> OptionalJoin::tryNestedLoopJoinIfSuitable(
   // This algorithm doesn't produce sorted output
   AD_CORRECTNESS_CHECK(resultSortedOn().empty());
 
-  auto lazyResult =
-      std::move(nestedLoopJoin)
-          .computeOptionalJoin(!requestLaziness, getResultWidth());
+  auto lazyResult = std::move(nestedLoopJoin)
+                        .computeOptionalJoin(!requestLaziness, getResultWidth(),
+                                             cancellationHandle_);
   return requestLaziness
              ? Result{std::move(lazyResult), resultSortedOn()}
              : Result{ad_utility::getSingleElement(std::move(lazyResult)),

--- a/src/engine/OptionalJoin.cpp
+++ b/src/engine/OptionalJoin.cpp
@@ -502,8 +502,8 @@ std::optional<Result> OptionalJoin::tryIndexNestedLoopJoinIfSuitable(
   auto rightRes = child->getResult(true);
 
   LocalVocab localVocab = leftRes->getCopyOfLocalVocab();
-  IndexNestedLoopJoin nestedLoopJoin{_joinColumns, std::move(leftRes),
-                                     std::move(rightRes)};
+  joinAlgorithms::indexNestedLoop::IndexNestedLoopJoin nestedLoopJoin{
+      _joinColumns, std::move(leftRes), std::move(rightRes)};
 
   // This algorithm doesn't produce sorted output
   AD_CORRECTNESS_CHECK(resultSortedOn().empty());

--- a/src/engine/OptionalJoin.h
+++ b/src/engine/OptionalJoin.h
@@ -85,13 +85,13 @@ class OptionalJoin : public Operation {
  private:
   std::unique_ptr<Operation> cloneImpl() const override;
 
-  // Helper function for `tryNestedLoopJoinIfSuitable` which makes the logic
-  // reusable.
-  bool isNestedLoopJoinSuitable() const;
+  // Helper function for `tryIndexNestedLoopJoinIfSuitable` which makes the
+  // logic reusable.
+  bool isIndexNestedLoopJoinSuitable() const;
 
   // Nested loop join optimization than can apply when a memory intensive sort
   // can be avoided this way.
-  std::optional<Result> tryNestedLoopJoinIfSuitable(bool requestLaziness);
+  std::optional<Result> tryIndexNestedLoopJoinIfSuitable(bool requestLaziness);
 
   void computeSizeEstimateAndMultiplicities();
 

--- a/src/engine/OptionalJoin.h
+++ b/src/engine/OptionalJoin.h
@@ -85,6 +85,14 @@ class OptionalJoin : public Operation {
  private:
   std::unique_ptr<Operation> cloneImpl() const override;
 
+  // Helper function for `tryNestedLoopJoinIfSuitable` which makes the logic
+  // reusable.
+  bool isNestedLoopJoinSuitable() const;
+
+  // Nested loop join optimization than can apply when a memory intensive sort
+  // can be avoided this way.
+  std::optional<Result> tryNestedLoopJoinIfSuitable(bool requestLaziness);
+
   void computeSizeEstimateAndMultiplicities();
 
   Result computeResult(bool requestLaziness) override;

--- a/src/util/AllocatorWithLimit.h
+++ b/src/util/AllocatorWithLimit.h
@@ -168,7 +168,7 @@ class AllocatorWithLimit {
   /// Obtain an AllocatorWithLimit<OtherType> that refers to the
   /// same limit.
   template <typename U>
-  AllocatorWithLimit<U> as() {
+  AllocatorWithLimit<U> as() const {
     return AllocatorWithLimit<U>(memoryLeft_);
   }
   AllocatorWithLimit() = delete;

--- a/src/util/JoinAlgorithms/IndexNestedLoopJoin.h
+++ b/src/util/JoinAlgorithms/IndexNestedLoopJoin.h
@@ -193,7 +193,7 @@ class OptionalJoinRange
 // that it doesn't require the right side to be sorted, potentially allowing you
 // to skip an expensive sort operation entirely. The downside is that the left
 // side has to be fully materialized. Currently handling undef values is
-// unsupported. `matchLeft` can be used with different types to accomodate
+// unsupported. `matchLeft` can be used with different types to accommodate
 // different types of joins.
 class IndexNestedLoopJoin {
   std::vector<std::array<ColumnIndex, 2>> joinColumns_;

--- a/src/util/JoinAlgorithms/IndexNestedLoopJoin.h
+++ b/src/util/JoinAlgorithms/IndexNestedLoopJoin.h
@@ -125,13 +125,12 @@ struct Adder {
       cancellationHandle_->throwIfCancelled();
       ++resultColIdx;
     }
-    while (resultColIdx < result.numColumns()) {
-      auto col = result.getColumn(resultColIdx);
+    for (auto col : ad_utility::OwningView{result.getColumns()} |
+                        ql::views::drop(resultColIdx)) {
       ad_utility::chunkedFill(
           ql::ranges::subrange{col.begin() + originalSize, col.end()},
           Id::makeUndefined(), qlever::joinHelpers::CHUNK_SIZE,
           [this]() { cancellationHandle_->throwIfCancelled(); });
-      ++resultColIdx;
     }
   }
 };

--- a/src/util/JoinAlgorithms/JoinAlgorithms.h
+++ b/src/util/JoinAlgorithms/JoinAlgorithms.h
@@ -1372,7 +1372,10 @@ CPP_template(typename LeftSide, typename RightSide, typename LessThan,
     // The reference of `it` is there on purpose.
     for (auto& it = side.it_; it != side.end_; ++it) {
       auto& el = *it;
-      if (ql::ranges::empty(el) || !isUndefined_(el.front())) {
+      if (ql::ranges::empty(el)) {
+        continue;
+      }
+      if (!isUndefined_(el.front())) {
         return;
       }
       bool endIsUndefined = isUndefined_(el.back());
@@ -1417,7 +1420,8 @@ CPP_template(typename LeftSide, typename RightSide, typename LessThan,
       // Handle case where the left has undef values in optional join, but the
       // right doesn't contain any values.
       if (doOptionalJoin && rightSide_.undefBlocks_.empty() &&
-          rightSide_.currentBlocks_.empty()) {
+          rightSide_.currentBlocks_.empty() &&
+          rightSide_.it_ == rightSide_.end_) {
         matchLeftUndefValuesWithNothing();
       }
     }

--- a/test/MinusTest.cpp
+++ b/test/MinusTest.cpp
@@ -175,13 +175,13 @@ TEST(Minus, computeMinusIndexNestedLoopJoinOptimization) {
                 qec, a.clone(),
                 std::vector<std::optional<Variable>>{
                     std::nullopt, Variable{"?a"}, Variable{"?b"}},
-                false, std::vector<ColumnIndex>{1, 2}),
+                false, std::vector<ColumnIndex>{1, 2}, leftVocab.clone()),
             ad_utility::makeExecutionTree<ValuesForTesting>(
                 qec, b.clone(),
                 std::vector<std::optional<Variable>>{
                     std::nullopt, Variable{"?b"}, Variable{"?a"}, std::nullopt},
-                false, std::vector<ColumnIndex>{}, LocalVocab{}, std::nullopt,
-                forceFullyMaterialized)};
+                false, std::vector<ColumnIndex>{}, rightVocab.clone(),
+                std::nullopt, forceFullyMaterialized)};
     auto result = m.computeResultOnlyForTesting(true);
     ASSERT_TRUE(result.isFullyMaterialized());
     EXPECT_EQ(result.idTable(), expected);

--- a/test/MinusTest.cpp
+++ b/test/MinusTest.cpp
@@ -144,7 +144,7 @@ TEST(Minus, computeMinus) {
 }
 
 // _____________________________________________________________________________
-TEST(Minus, computeMinusNestedLoopJoinOptimization) {
+TEST(Minus, computeMinusIndexNestedLoopJoinOptimization) {
   // From this table columns 1 and 2 will be used for the join.
   IdTable a = makeIdTableFromVector(
       {{1, 1, 2}, {4, 2, 1}, {2, 8, 1}, {3, 8, 2}, {4, 8, 2}});

--- a/test/MinusTest.cpp
+++ b/test/MinusTest.cpp
@@ -145,6 +145,14 @@ TEST(Minus, computeMinus) {
 
 // _____________________________________________________________________________
 TEST(Minus, computeMinusIndexNestedLoopJoinOptimization) {
+  LocalVocabEntry entryA = LocalVocabEntry::fromStringRepresentation("\"a\"");
+  LocalVocabEntry entryB = LocalVocabEntry::fromStringRepresentation("\"b\"");
+
+  LocalVocab leftVocab;
+  leftVocab.getIndexAndAddIfNotContained(entryA);
+  LocalVocab rightVocab;
+  rightVocab.getIndexAndAddIfNotContained(entryB);
+
   // From this table columns 1 and 2 will be used for the join.
   IdTable a = makeIdTableFromVector(
       {{1, 1, 2}, {4, 2, 1}, {2, 8, 1}, {3, 8, 2}, {4, 8, 2}});
@@ -177,6 +185,8 @@ TEST(Minus, computeMinusIndexNestedLoopJoinOptimization) {
     auto result = m.computeResultOnlyForTesting(true);
     ASSERT_TRUE(result.isFullyMaterialized());
     EXPECT_EQ(result.idTable(), expected);
+    EXPECT_THAT(result.localVocab().getAllWordsForTesting(),
+                ::testing::UnorderedElementsAre(entryA));
     const auto& runtimeInfo =
         m.getChildren().at(1)->getRootOperation()->runtimeInfo();
     EXPECT_EQ(runtimeInfo.status_, RuntimeInformation::Status::optimizedOut);

--- a/test/engine/ExistsJoinTest.cpp
+++ b/test/engine/ExistsJoinTest.cpp
@@ -197,7 +197,7 @@ TEST(Exists, computeResult) {
 }
 
 // _____________________________________________________________________________
-TEST(ExistsJoin, computeExistsJoinNestedLoopJoinOptimization) {
+TEST(ExistsJoin, computeExistsJoinIndexNestedLoopJoinOptimization) {
   // From this table columns 1 and 2 will be used for the join.
   IdTable a = makeIdTableFromVector(
       {{1, 1, 2}, {4, 2, 1}, {2, 8, 1}, {3, 8, 2}, {4, 8, 2}});

--- a/test/engine/ExistsJoinTest.cpp
+++ b/test/engine/ExistsJoinTest.cpp
@@ -198,6 +198,13 @@ TEST(Exists, computeResult) {
 
 // _____________________________________________________________________________
 TEST(ExistsJoin, computeExistsJoinIndexNestedLoopJoinOptimization) {
+  LocalVocabEntry entryA = LocalVocabEntry::fromStringRepresentation("\"a\"");
+  LocalVocabEntry entryB = LocalVocabEntry::fromStringRepresentation("\"b\"");
+
+  LocalVocab leftVocab;
+  leftVocab.getIndexAndAddIfNotContained(entryA);
+  LocalVocab rightVocab;
+  rightVocab.getIndexAndAddIfNotContained(entryB);
   // From this table columns 1 and 2 will be used for the join.
   IdTable a = makeIdTableFromVector(
       {{1, 1, 2}, {4, 2, 1}, {2, 8, 1}, {3, 8, 2}, {4, 8, 2}});
@@ -233,6 +240,8 @@ TEST(ExistsJoin, computeExistsJoinIndexNestedLoopJoinOptimization) {
     auto result = existsJoin.computeResultOnlyForTesting(true);
     ASSERT_TRUE(result.isFullyMaterialized());
     EXPECT_EQ(result.idTable(), expected);
+    EXPECT_THAT(result.localVocab().getAllWordsForTesting(),
+                ::testing::UnorderedElementsAre(entryA));
     const auto& runtimeInfo =
         existsJoin.getChildren().at(1)->getRootOperation()->runtimeInfo();
     EXPECT_EQ(runtimeInfo.status_, RuntimeInformation::Status::optimizedOut);

--- a/test/engine/ExistsJoinTest.cpp
+++ b/test/engine/ExistsJoinTest.cpp
@@ -229,12 +229,12 @@ TEST(ExistsJoin, computeExistsJoinIndexNestedLoopJoinOptimization) {
             qec, a.clone(),
             std::vector<std::optional<Variable>>{std::nullopt, Variable{"?a"},
                                                  Variable{"?b"}},
-            false, std::vector<ColumnIndex>{1, 2}),
+            false, std::vector<ColumnIndex>{1, 2}, leftVocab.clone()),
         ad_utility::makeExecutionTree<ValuesForTesting>(
             qec, b.clone(),
             std::vector<std::optional<Variable>>{std::nullopt, Variable{"?b"},
                                                  Variable{"?a"}, std::nullopt},
-            false, std::vector<ColumnIndex>{}, LocalVocab{}, std::nullopt,
+            false, std::vector<ColumnIndex>{}, rightVocab.clone(), std::nullopt,
             forceFullyMaterialized),
         Variable{"?result"}};
     auto result = existsJoin.computeResultOnlyForTesting(true);

--- a/test/engine/OptionalJoinTest.cpp
+++ b/test/engine/OptionalJoinTest.cpp
@@ -49,17 +49,21 @@ void testOptionalJoin(const IdTable& inputA, const IdTable& inputB,
     for (size_t i = 0; i < inputB.numColumns(); ++i) {
       varsRight.emplace_back(absl::StrCat("?right_", i));
     }
+    std::vector<ColumnIndex> leftSorted;
+    std::vector<ColumnIndex> rightSorted;
     size_t idx = 0;
     for (auto [left, right] : jcls) {
       varsLeft.at(left) = Variable(absl::StrCat("?joinColumn_", idx));
       varsRight.at(right) = Variable(absl::StrCat("?joinColumn_", idx));
+      leftSorted.push_back(left);
+      rightSorted.push_back(right);
       ++idx;
     }
     auto qec = ad_utility::testing::getQec();
     auto left = ad_utility::makeExecutionTree<ValuesForTesting>(
-        qec, inputA.clone(), varsLeft);
+        qec, inputA.clone(), varsLeft, false, std::move(leftSorted));
     auto right = ad_utility::makeExecutionTree<ValuesForTesting>(
-        qec, inputB.clone(), varsRight);
+        qec, inputB.clone(), varsRight, false, std::move(rightSorted));
     OptionalJoin opt{qec, left, right};
 
     auto result = opt.computeResultOnlyForTesting();

--- a/test/engine/OptionalJoinTest.cpp
+++ b/test/engine/OptionalJoinTest.cpp
@@ -402,6 +402,107 @@ TEST(OptionalJoin, gallopingJoin) {
 }
 
 // _____________________________________________________________________________
+TEST(OptionalJoin, computeOptionalJoinIndexNestedLoopJoinOptimization) {
+  // From this table columns 1 and 2 will be used for the join.
+  IdTable a = makeIdTableFromVector(
+      {{1, 1, 2}, {4, 2, 1}, {2, 8, 1}, {3, 8, 2}, {4, 8, 2}});
+
+  // From this table columns 2 and 1 will be used for the join.
+  // This is deliberately not sorted to check the optimization that avoids
+  // sorting on the right if bigger
+  IdTable b = makeIdTableFromVector({{7, 2, 1, 5},
+                                     {1, 3, 3, 5},
+                                     {1, 8, 1, 5},
+                                     {7, 2, 8, 14},
+                                     {6, 2, 8, 12},
+                                     {14, 15, 16, 17}});
+  IdTable expected = makeIdTableFromVector({{1, 1, 2, 7, 5},
+                                            {3, 8, 2, 7, 14},
+                                            {4, 8, 2, 7, 14},
+                                            {3, 8, 2, 6, 12},
+                                            {4, 8, 2, 6, 12},
+                                            {4, 2, 1, U, U},
+                                            {2, 8, 1, U, U}});
+
+  auto* qec = ad_utility::testing::getQec();
+  for (bool forceFullyMaterialized : {false, true}) {
+    OptionalJoin optionalJoin{
+        qec,
+        ad_utility::makeExecutionTree<ValuesForTesting>(
+            qec, a.clone(),
+            std::vector<std::optional<Variable>>{std::nullopt, Variable{"?a"},
+                                                 Variable{"?b"}},
+            false, std::vector<ColumnIndex>{1, 2}),
+        ad_utility::makeExecutionTree<ValuesForTesting>(
+            qec, b.clone(),
+            std::vector<std::optional<Variable>>{std::nullopt, Variable{"?b"},
+                                                 Variable{"?a"}, std::nullopt},
+            false, std::vector<ColumnIndex>{}, LocalVocab{}, std::nullopt,
+            forceFullyMaterialized)};
+    auto result = optionalJoin.computeResultOnlyForTesting(false);
+    ASSERT_TRUE(result.isFullyMaterialized());
+
+    EXPECT_EQ(result.idTable(), expected);
+
+    const auto& runtimeInfo =
+        optionalJoin.getChildren().at(1)->getRootOperation()->runtimeInfo();
+    EXPECT_EQ(runtimeInfo.status_, RuntimeInformation::Status::optimizedOut);
+    EXPECT_EQ(runtimeInfo.numRows_, 0);
+  }
+}
+
+// _____________________________________________________________________________
+TEST(OptionalJoin, computeLazyOptionalJoinIndexNestedLoopJoinOptimization) {
+  // From this table columns 1 and 2 will be used for the join.
+  IdTable a = makeIdTableFromVector(
+      {{1, 1, 2}, {4, 2, 1}, {2, 8, 1}, {3, 8, 2}, {4, 8, 2}});
+
+  // From these tables columns 2 and 1 will be used for the join.
+  // This is deliberately not sorted to check the optimization that avoids
+  // sorting on the right if bigger
+  std::vector<IdTable> rightTables;
+  rightTables.push_back(makeIdTableFromVector(
+      {{7, 2, 1, 5}, {1, 3, 3, 5}, {1, 8, 1, 5}, {7, 2, 8, 14}}));
+  rightTables.push_back(
+      makeIdTableFromVector({{6, 2, 8, 12}, {14, 15, 16, 17}}));
+
+  std::vector<IdTable> expected;
+  expected.push_back(makeIdTableFromVector(
+      {{1, 1, 2, 7, 5}, {3, 8, 2, 7, 14}, {4, 8, 2, 7, 14}}));
+  expected.push_back(
+      makeIdTableFromVector({{3, 8, 2, 6, 12}, {4, 8, 2, 6, 12}}));
+  expected.push_back(makeIdTableFromVector({{4, 2, 1, U, U}, {2, 8, 1, U, U}}));
+
+  auto* qec = ad_utility::testing::getQec();
+  OptionalJoin optionalJoin{
+      qec,
+      ad_utility::makeExecutionTree<ValuesForTesting>(
+          qec, std::move(a),
+          std::vector<std::optional<Variable>>{std::nullopt, Variable{"?a"},
+                                               Variable{"?b"}},
+          false, std::vector<ColumnIndex>{1, 2}),
+      ad_utility::makeExecutionTree<ValuesForTesting>(
+          qec, std::move(rightTables),
+          std::vector<std::optional<Variable>>{std::nullopt, Variable{"?b"},
+                                               Variable{"?a"}, std::nullopt},
+          false, std::vector<ColumnIndex>{}, LocalVocab{})};
+  auto result = optionalJoin.computeResultOnlyForTesting(true);
+  ASSERT_FALSE(result.isFullyMaterialized());
+
+  std::vector<IdTable> actualTables;
+  for (auto& [idTable, localVocab] : result.idTables()) {
+    actualTables.emplace_back(std::move(idTable));
+  }
+
+  EXPECT_THAT(actualTables, ::testing::ElementsAreArray(expected));
+
+  const auto& runtimeInfo =
+      optionalJoin.getChildren().at(1)->getRootOperation()->runtimeInfo();
+  EXPECT_EQ(runtimeInfo.status_, RuntimeInformation::Status::optimizedOut);
+  EXPECT_EQ(runtimeInfo.numRows_, 0);
+}
+
+// _____________________________________________________________________________
 TEST(OptionalJoin, clone) {
   auto qec = ad_utility::testing::getQec();
   auto a = makeIdTableFromVector({{0}});

--- a/test/engine/OptionalJoinTest.cpp
+++ b/test/engine/OptionalJoinTest.cpp
@@ -484,12 +484,10 @@ TEST(OptionalJoin, computeLazyOptionalJoinIndexNestedLoopJoinOptimization) {
   rightTables.push_back(
       makeIdTableFromVector({{6, 2, 8, 12}, {14, 15, 16, 17}}));
 
-  std::vector<IdTable> expected;
-  expected.push_back(makeIdTableFromVector(
-      {{1, 1, 2, 7, 5}, {3, 8, 2, 7, 14}, {4, 8, 2, 7, 14}}));
-  expected.push_back(
-      makeIdTableFromVector({{3, 8, 2, 6, 12}, {4, 8, 2, 6, 12}}));
-  expected.push_back(makeIdTableFromVector({{4, 2, 1, U, U}, {2, 8, 1, U, U}}));
+  auto expected0 = makeIdTableFromVector(
+      {{1, 1, 2, 7, 5}, {3, 8, 2, 7, 14}, {4, 8, 2, 7, 14}});
+  auto expected1 = makeIdTableFromVector({{3, 8, 2, 6, 12}, {4, 8, 2, 6, 12}});
+  auto expected2 = makeIdTableFromVector({{4, 2, 1, U, U}, {2, 8, 1, U, U}});
 
   auto* qec = ad_utility::testing::getQec();
   OptionalJoin optionalJoin{
@@ -514,14 +512,18 @@ TEST(OptionalJoin, computeLazyOptionalJoinIndexNestedLoopJoinOptimization) {
     actualVocabs.emplace_back(std::move(localVocab));
   }
 
-  EXPECT_THAT(actualTables, ::testing::ElementsAreArray(expected));
+  using namespace ::testing;
+
+  EXPECT_THAT(actualTables,
+              ElementsAre(Eq(std::cref(expected0)), Eq(std::cref(expected1)),
+                          Eq(std::cref(expected2))));
   ASSERT_EQ(actualVocabs.size(), 3);
   EXPECT_THAT(actualVocabs.at(0).getAllWordsForTesting(),
-              ::testing::UnorderedElementsAre(entryA, entryB));
+              UnorderedElementsAre(entryA, entryB));
   EXPECT_THAT(actualVocabs.at(1).getAllWordsForTesting(),
-              ::testing::UnorderedElementsAre(entryA, entryB));
+              UnorderedElementsAre(entryA, entryB));
   EXPECT_THAT(actualVocabs.at(2).getAllWordsForTesting(),
-              ::testing::UnorderedElementsAre(entryA));
+              UnorderedElementsAre(entryA));
 
   const auto& runtimeInfo =
       optionalJoin.getChildren().at(1)->getRootOperation()->runtimeInfo();


### PR DESCRIPTION
Follow-up to #2251, which implements index nested loop joins for `OPTIONAL`, under the same conditions as in #2251.  Here is an analogous example query, which fails with an out-of-memory error with the current code but now completes, albeit slowly. On the side, fix a minor bug in the algorithm for computing a lazy optional join, which occurs when an undefined value on the left is joined with an empty table on the right.
```sparql
SELECT (COUNT(*) AS ?count) {
  ?a wdt:P2860 ?b .
  OPTIONAL {
    ?b wdt:P31 ?c .
    ?c schema:description ?d .
  }
}
```