### PR TITLE
Suppress false positive warning for `gcc 12` build

### DIFF
--- a/src/parser/Tokenizer.h
+++ b/src/parser/Tokenizer.h
@@ -10,6 +10,7 @@
 #include <re2/re2.h>
 
 #include "parser/TurtleTokenId.h"
+#include "util/CompilerWarnings.h"
 #include "util/Log.h"
 
 using re2::RE2;
@@ -21,6 +22,7 @@ using namespace std::string_literals;
  */
 struct TurtleToken {
   using string = std::string;
+  DISABLE_STRINGOP_OVERFLOW_WARNINGS
   TurtleToken()
       // those constants are always skipped, so they don't need a group around
       // them
@@ -64,6 +66,8 @@ struct TurtleToken {
         WsMultiple(grp(WsMultipleString)),
         Anon(grp(AnonString)),
         Comment(grp(CommentString)) {}
+
+  GCC_REENABLE_WARNINGS
 
   TurtleToken(const TurtleToken& other) : TurtleToken() { (void)other; }
   TurtleToken& operator=([[maybe_unused]] const TurtleToken& other) {

--- a/src/util/CompilerWarnings.h
+++ b/src/util/CompilerWarnings.h
@@ -20,6 +20,11 @@
   _Pragma("GCC diagnostic push")  \
       _Pragma("GCC diagnostic ignored \"-Wstringop-overread\"")
 
+// Disable the `stringop-overflow` warning, which has many false positives.
+#define DISABLE_STRINGOP_OVERFLOW_WARNINGS \
+  _Pragma("GCC diagnostic push")           \
+      _Pragma("GCC diagnostic ignored \"-Wstringop-overflow\"")
+
 // Disable the `non-template-friend` warning which sometimes can't be avoided
 // in generic code.
 #define DISABLE_WARNINGS_GCC_TEMPLATE_FRIEND \
@@ -32,6 +37,7 @@
 #else
 #define DISABLE_UNINITIALIZED_WARNINGS
 #define DISABLE_OVERREAD_WARNINGS
+#define DISABLE_STRINGOP_OVERFLOW_WARNINGS
 #define DISABLE_WARNINGS_GCC_TEMPLATE_FRIEND
 #define GCC_REENABLE_WARNINGS
 #endif


### PR DESCRIPTION
The native build with `gcc 12` is failing since #2219. This is an attempt to fix this, by suppressing the `stringop-overflow` warning