### PR TITLE
Fix assertion error when `�` is present in text

### DIFF
--- a/src/parser/WordsAndDocsFileParser.h
+++ b/src/parser/WordsAndDocsFileParser.h
@@ -110,9 +110,9 @@ struct LiteralsTokenizationDelimiter {
     while (pos < size) {
       size_t oldPos = pos;
       UChar32 codePoint;
-      U8_NEXT_OR_FFFD(reinterpret_cast<const uint8_t*>(text.data()), pos, size,
-                      codePoint);
-      AD_CONTRACT_CHECK(codePoint != 0xFFFD, "Invalid UTF-8 in input");
+      U8_NEXT(reinterpret_cast<const uint8_t*>(text.data()), pos, size,
+              codePoint);
+      AD_CONTRACT_CHECK(codePoint != U_SENTINEL, "Invalid UTF-8 in input");
       if (!u_isalnum(codePoint)) {
         return text.substr(oldPos, pos - oldPos);
       }

--- a/src/rdfTypes/Variable.cpp
+++ b/src/rdfTypes/Variable.cpp
@@ -97,9 +97,9 @@ void Variable::appendEscapedWord(std::string_view word, std::string& target) {
     // Convert all other characters based on their unicode codepoint.
     UChar32 codePoint;
     int64_t i = 0;
-    U8_NEXT_OR_FFFD(reinterpret_cast<const uint8_t*>(ptr), i,
-                    static_cast<int64_t>(word.size()), codePoint);
-    AD_CONTRACT_CHECK(codePoint != 0xFFFD, "Invalid UTF-8");
+    U8_NEXT(reinterpret_cast<const uint8_t*>(ptr), i,
+            static_cast<int64_t>(word.size()), codePoint);
+    AD_CONTRACT_CHECK(codePoint != U_SENTINEL, "Invalid UTF-8");
     if (codePointSuitableForVariableName(codePoint)) {
       target.append(ptr, i);
     } else {

--- a/test/WordsAndDocsFileParserTest.cpp
+++ b/test/WordsAndDocsFileParserTest.cpp
@@ -86,19 +86,22 @@ auto testDocsFileParser = [](const std::string& docsFilePath,
 
 // Passing the testText as copy to make sure it stays alive during the usage of
 // tokenizer
-auto testTokenizeAndNormalizeText = [](std::string testText,
-                                       const StringVec& normalizedTextAsVec) {
-  size_t i = 0;
-  LocaleManager localeManager = getLocaleManager();
-  for (auto normalizedWord :
-       tokenizeAndNormalizeText(testText, localeManager)) {
-    ASSERT_TRUE(i < normalizedTextAsVec.size());
-    ASSERT_EQ(normalizedWord, normalizedTextAsVec.at(i));
+auto testTokenizeAndNormalizeText =
+    [](std::string testText, const StringVec& normalizedTextAsVec,
+       ad_utility::source_location loc =
+           ad_utility::source_location::current()) {
+      auto t = generateLocationTrace(loc);
+      size_t i = 0;
+      LocaleManager localeManager = getLocaleManager();
+      for (auto normalizedWord :
+           tokenizeAndNormalizeText(testText, localeManager)) {
+        ASSERT_TRUE(i < normalizedTextAsVec.size());
+        ASSERT_EQ(normalizedWord, normalizedTextAsVec.at(i));
 
-    ++i;
-  }
-  ASSERT_EQ(i, normalizedTextAsVec.size());
-};
+        ++i;
+      }
+      ASSERT_EQ(i, normalizedTextAsVec.size());
+    };
 
 }  // namespace
 
@@ -163,6 +166,9 @@ TEST(TokenizeAndNormalizeText, tokenizeAndNormalizeTextTest) {
   testTokenizeAndNormalizeText(
       "test\twith\ndifferent,separators.here ,.\t",
       {"test", "with", "different", "separators", "here"});
+
+  // Regression test for https://github.com/ad-freiburg/qlever/issues/2244
+  testTokenizeAndNormalizeText("�", {});
 }
 
 // _____________________________________________________________________________

--- a/test/rdfTypes/VariableTest.cpp
+++ b/test/rdfTypes/VariableTest.cpp
@@ -71,6 +71,9 @@ TEST(Variable, ScoreAndMatchVariablesUnicode) {
   // Invalid UTF-8 will throw an exception.
   AD_EXPECT_THROW_WITH_MESSAGE(Variable("?x").getMatchingWordVariable("\255"),
                                ::testing::HasSubstr("Invalid UTF-8"));
+
+  // Regression test for https://github.com/ad-freiburg/qlever/issues/2244
+  EXPECT_NO_THROW(Variable("?x").getMatchingWordVariable("�"));
 }
 
 // _____________________________________________________________________________


### PR DESCRIPTION
#2215 added Unicode support for text search, but introduced the regression that `�` in the text (which is used to indicate invalid UTF-8, but is itself a perfectly valid Unicode character) triggered an assertion error. This is now fixed. In particular, fixes #2244