### PR TITLE
Change transitive path datastructures to conceptually support graphs

### DIFF
--- a/src/engine/TransitivePathBase.cpp
+++ b/src/engine/TransitivePathBase.cpp
@@ -30,7 +30,8 @@
 TransitivePathBase::TransitivePathBase(
     QueryExecutionContext* qec, std::shared_ptr<QueryExecutionTree> child,
     TransitivePathSide leftSide, TransitivePathSide rightSide, size_t minDist,
-    size_t maxDist, Graphs activeGraphs)
+    size_t maxDist, Graphs activeGraphs,
+    const std::optional<Variable>& graphVariable)
     : Operation(qec),
       subtree_(std::move(child)),
       lhs_(std::move(leftSide)),
@@ -40,6 +41,8 @@ TransitivePathBase::TransitivePathBase(
       activeGraphs_{std::move(activeGraphs)} {
   AD_CORRECTNESS_CHECK(qec != nullptr);
   AD_CORRECTNESS_CHECK(subtree_);
+  // Temporary
+  AD_CORRECTNESS_CHECK(!graphVariable.has_value());
   if (lhs_.isVariable()) {
     variableColumns_[lhs_.value_.getVariable()] = makeAlwaysDefinedColumn(0);
   }
@@ -368,27 +371,29 @@ size_t TransitivePathBase::getCostEstimate() {
 std::shared_ptr<TransitivePathBase> TransitivePathBase::makeTransitivePath(
     QueryExecutionContext* qec, std::shared_ptr<QueryExecutionTree> child,
     TransitivePathSide leftSide, TransitivePathSide rightSide, size_t minDist,
-    size_t maxDist, Graphs activeGraphs) {
+    size_t maxDist, Graphs activeGraphs,
+    const std::optional<Variable>& graphVariable) {
   bool useBinSearch =
       RuntimeParameters().get<"use-binsearch-transitive-path">();
-  return makeTransitivePath(qec, std::move(child), std::move(leftSide),
-                            std::move(rightSide), minDist, maxDist,
-                            useBinSearch, std::move(activeGraphs));
+  return makeTransitivePath(
+      qec, std::move(child), std::move(leftSide), std::move(rightSide), minDist,
+      maxDist, useBinSearch, std::move(activeGraphs), graphVariable);
 }
 
 // _____________________________________________________________________________
 std::shared_ptr<TransitivePathBase> TransitivePathBase::makeTransitivePath(
     QueryExecutionContext* qec, std::shared_ptr<QueryExecutionTree> child,
     TransitivePathSide leftSide, TransitivePathSide rightSide, size_t minDist,
-    size_t maxDist, bool useBinSearch, Graphs activeGraphs) {
+    size_t maxDist, bool useBinSearch, Graphs activeGraphs,
+    const std::optional<Variable>& graphVariable) {
   if (useBinSearch) {
     return std::make_shared<TransitivePathBinSearch>(
         qec, std::move(child), std::move(leftSide), std::move(rightSide),
-        minDist, maxDist, std::move(activeGraphs));
+        minDist, maxDist, std::move(activeGraphs), graphVariable);
   } else {
     return std::make_shared<TransitivePathHashMap>(
         qec, std::move(child), std::move(leftSide), std::move(rightSide),
-        minDist, maxDist, std::move(activeGraphs));
+        minDist, maxDist, std::move(activeGraphs), graphVariable);
   }
 }
 

--- a/src/engine/TransitivePathBase.h
+++ b/src/engine/TransitivePathBase.h
@@ -130,12 +130,14 @@ class TransitivePathBase : public Operation {
   // Store the active graphs for the transitive path operation. This is used to
   // correctly match against the proper graph when the minimum distance is 0.
   Graphs activeGraphs_;
+  std::optional<Variable> graphVariable_;
 
  public:
   TransitivePathBase(QueryExecutionContext* qec,
                      std::shared_ptr<QueryExecutionTree> child,
                      TransitivePathSide leftSide, TransitivePathSide rightSide,
-                     size_t minDist, size_t maxDist, Graphs activeGraphs);
+                     size_t minDist, size_t maxDist, Graphs activeGraphs,
+                     const std::optional<Variable>& graphVariable);
 
   ~TransitivePathBase() override = 0;
 
@@ -296,7 +298,8 @@ class TransitivePathBase : public Operation {
   static std::shared_ptr<TransitivePathBase> makeTransitivePath(
       QueryExecutionContext* qec, std::shared_ptr<QueryExecutionTree> child,
       TransitivePathSide leftSide, TransitivePathSide rightSide, size_t minDist,
-      size_t maxDist, bool useBinSearch, Graphs activeGraphs = {});
+      size_t maxDist, bool useBinSearch, Graphs activeGraphs = {},
+      const std::optional<Variable>& graphVariable = std::nullopt);
 
   /**
    * @brief Make a concrete TransitivePath object using the given parameters.
@@ -313,11 +316,13 @@ class TransitivePathBase : public Operation {
    * number of nodes)
    * @param activeGraphs Contains the graphs that are active in the current
    * context.
+   * @param graphVariable Set a graph variable when inside a `GRAPH ?g { ... }`.
    */
   static std::shared_ptr<TransitivePathBase> makeTransitivePath(
       QueryExecutionContext* qec, std::shared_ptr<QueryExecutionTree> child,
       TransitivePathSide leftSide, TransitivePathSide rightSide, size_t minDist,
-      size_t maxDist, Graphs activeGraphs = {});
+      size_t maxDist, Graphs activeGraphs = {},
+      const std::optional<Variable>& graphVariable = std::nullopt);
 
   std::vector<QueryExecutionTree*> getChildren() override;
 

--- a/src/engine/TransitivePathBinSearch.cpp
+++ b/src/engine/TransitivePathBinSearch.cpp
@@ -10,26 +10,107 @@
 #include "engine/TransitivePathBase.h"
 
 // _____________________________________________________________________________
+BinSearchMap::BinSearchMap(ql::span<const Id> startIds,
+                           ql::span<const Id> targetIds,
+                           std::optional<ql::span<const Id>> graphIds)
+    : startIds_{startIds},
+      targetIds_{targetIds},
+      graphIds_{graphIds.has_value() ? graphIds.value() : ql::span<const Id>{}},
+      size_{startIds_.size()} {
+  AD_CORRECTNESS_CHECK(startIds.size() == targetIds.size());
+  AD_CORRECTNESS_CHECK(startIds.size() == graphIds_.size() ||
+                       !graphIds.has_value());
+}
+
+// _____________________________________________________________________________
+ql::span<const Id> BinSearchMap::successors(Id node) const {
+  auto range = ql::ranges::equal_range(startIds_.subspan(offset_, size_), node);
+
+  auto startIndex = std::distance(startIds_.begin(), range.begin());
+
+  return targetIds_.subspan(startIndex, range.size());
+}
+
+// _____________________________________________________________________________
+absl::InlinedVector<std::pair<Id, Id>, 1> BinSearchMap::getEquivalentIds(
+    Id node) const {
+  absl::InlinedVector<std::pair<Id, Id>, 1> result;
+  if (graphIds_.empty()) {
+    if (node.isUndefined()) {
+      for (Id id : startIds_) {
+        if (result.empty() || result.back().first != id) {
+          result.emplace_back(id, Id::makeUndefined());
+        }
+      }
+    } else {
+      auto range = ql::ranges::equal_range(startIds_, node);
+      if (!range.empty()) {
+        result.emplace_back(range.front(), Id::makeUndefined());
+      }
+    }
+  } else {
+    for (auto [id, graphId] : ::ranges::views::zip(startIds_, graphIds_)) {
+      bool isNewEntry = result.empty() || result.back().first != id ||
+                        result.back().second != graphId;
+      if ((id == node || node.isUndefined()) && isNewEntry) {
+        result.emplace_back(id, graphId);
+      }
+    }
+  }
+  return result;
+}
+
+// _____________________________________________________________________________
+void BinSearchMap::setGraphId(Id graphId) {
+  if (graphId.isUndefined()) {
+    // If the graph id is undefined, this means that all graphs should match,
+    // which only works if we sorted by the actual values, not by graphs.
+    AD_CORRECTNESS_CHECK(graphIds_.empty());
+  } else {
+    auto range = ql::ranges::equal_range(graphIds_, graphId);
+    auto startIndex = std::distance(graphIds_.begin(), range.begin());
+
+    offset_ = startIndex;
+    size_ = range.size();
+  }
+}
+
+// _____________________________________________________________________________
 TransitivePathBinSearch::TransitivePathBinSearch(
     QueryExecutionContext* qec, std::shared_ptr<QueryExecutionTree> child,
     TransitivePathSide leftSide, TransitivePathSide rightSide, size_t minDist,
-    size_t maxDist, Graphs activeGraphs)
+    size_t maxDist, Graphs activeGraphs,
+    const std::optional<Variable>& graphVariable)
     : TransitivePathImpl<BinSearchMap>(
           qec, std::move(child), std::move(leftSide), std::move(rightSide),
-          minDist, maxDist, std::move(activeGraphs)) {
+          minDist, maxDist, std::move(activeGraphs), graphVariable) {
   auto [startSide, targetSide] = decideDirection();
+  auto makeSortColumns = [this, &graphVariable](ColumnIndex first,
+                                                ColumnIndex second) {
+    std::vector<ColumnIndex> sortColumns;
+    if (graphVariable.has_value()) {
+      sortColumns.push_back(subtree_->getVariableColumn(graphVariable.value()));
+    }
+    sortColumns.push_back(first);
+    sortColumns.push_back(second);
+    return sortColumns;
+  };
   alternativelySortedSubtree_ = QueryExecutionTree::createSortedTree(
-      subtree_, {targetSide.subCol_, startSide.subCol_});
+      subtree_, makeSortColumns(targetSide.subCol_, startSide.subCol_));
   subtree_ = QueryExecutionTree::createSortedTree(
-      subtree_, {startSide.subCol_, targetSide.subCol_});
+      subtree_, makeSortColumns(startSide.subCol_, targetSide.subCol_));
 }
 
 // _____________________________________________________________________________
 BinSearchMap TransitivePathBinSearch::setupEdgesMap(
     const IdTable& dynSub, const TransitivePathSide& startSide,
     const TransitivePathSide& targetSide) const {
-  return BinSearchMap{dynSub.getColumn(startSide.subCol_),
-                      dynSub.getColumn(targetSide.subCol_)};
+  return BinSearchMap{
+      dynSub.getColumn(startSide.subCol_), dynSub.getColumn(targetSide.subCol_),
+      graphVariable_.has_value()
+          ? std::optional{dynSub.getColumn(
+                subtree_->getVariableColumn(graphVariable_.value()))}
+          : std::nullopt};
 }
 
 // _____________________________________________________________________________

--- a/src/engine/TransitivePathBinSearch.cpp
+++ b/src/engine/TransitivePathBinSearch.cpp
@@ -16,7 +16,7 @@ BinSearchMap::BinSearchMap(ql::span<const Id> startIds,
     : startIds_{startIds},
       targetIds_{targetIds},
       graphIds_{graphIds.has_value() ? graphIds.value() : ql::span<const Id>{}},
-      size_{startIds_.size()} {
+      sizeOfActiveGraph_{startIds_.size()} {
   AD_CORRECTNESS_CHECK(startIds.size() == targetIds.size());
   AD_CORRECTNESS_CHECK(startIds.size() == graphIds_.size() ||
                        !graphIds.has_value());
@@ -24,7 +24,8 @@ BinSearchMap::BinSearchMap(ql::span<const Id> startIds,
 
 // _____________________________________________________________________________
 ql::span<const Id> BinSearchMap::successors(Id node) const {
-  auto range = ql::ranges::equal_range(startIds_.subspan(offset_, size_), node);
+  auto range = ql::ranges::equal_range(
+      startIds_.subspan(offsetOfActiveGraph_, sizeOfActiveGraph_), node);
 
   auto startIndex = std::distance(startIds_.begin(), range.begin());
 
@@ -32,8 +33,8 @@ ql::span<const Id> BinSearchMap::successors(Id node) const {
 }
 
 // _____________________________________________________________________________
-absl::InlinedVector<std::pair<Id, Id>, 1> BinSearchMap::getEquivalentIds(
-    Id node) const {
+absl::InlinedVector<std::pair<Id, Id>, 1>
+BinSearchMap::getEquivalentIdAndMatchingGraphs(Id node) const {
   absl::InlinedVector<std::pair<Id, Id>, 1> result;
   if (graphIds_.empty()) {
     if (node.isUndefined()) {
@@ -70,8 +71,8 @@ void BinSearchMap::setGraphId(Id graphId) {
     auto range = ql::ranges::equal_range(graphIds_, graphId);
     auto startIndex = std::distance(graphIds_.begin(), range.begin());
 
-    offset_ = startIndex;
-    size_ = range.size();
+    offsetOfActiveGraph_ = startIndex;
+    sizeOfActiveGraph_ = range.size();
   }
 }
 

--- a/src/engine/TransitivePathBinSearch.cpp
+++ b/src/engine/TransitivePathBinSearch.cpp
@@ -2,7 +2,7 @@
 // Chair of Algorithms and Data Structures.
 // Author: Johannes Herrmann (johannes.r.herrmann(at)gmail.com)
 
-#include "TransitivePathBinSearch.h"
+#include "engine/TransitivePathBinSearch.h"
 
 #include <memory>
 #include <utility>

--- a/src/engine/TransitivePathBinSearch.h
+++ b/src/engine/TransitivePathBinSearch.h
@@ -62,10 +62,10 @@ class BinSearchMap {
   // function need it in this format for convenience. The most common case is
   // that there's a single matching entry, (especially when using this without
   // an active graph,) which is why `absl::InlinedVector` is used with size 1.
-  // If no entry matches an empty vector is returned. If an active graph is set,
-  // entries will be limited to just that graph. If `node` is undefined, it will
-  // return all elements in the currently active graph, or all elements if no
-  // graph is set.
+  // If no entry matches an empty vector is returned. If `node` is undefined, it
+  // will return all elements in the currently active graph, or all elements if
+  // no graph is set. Active graphs set via `setGraphId` are ignored. Entries
+  // are deduplicated.
   absl::InlinedVector<std::pair<Id, Id>, 1> getEquivalentIdAndMatchingGraphs(
       Id node) const;
 

--- a/src/engine/TransitivePathBinSearch.h
+++ b/src/engine/TransitivePathBinSearch.h
@@ -39,8 +39,8 @@ class BinSearchMap {
   ql::span<const Id> startIds_;
   ql::span<const Id> targetIds_;
   ql::span<const Id> graphIds_;
-  size_t offset_ = 0;
-  size_t size_;
+  size_t offsetOfActiveGraph_ = 0;
+  size_t sizeOfActiveGraph_;
 
  public:
   BinSearchMap(ql::span<const Id> startIds, ql::span<const Id> targetIds,
@@ -57,10 +57,19 @@ class BinSearchMap {
    */
   ql::span<const Id> successors(Id node) const;
 
-  // Return equivalent ids from the index, along with an associated graph id in
-  // case these are available.
-  absl::InlinedVector<std::pair<Id, Id>, 1> getEquivalentIds(Id node) const;
+  // Return a pair of matching ids + graph ids. The first id of the pair is
+  // always the same element. It is flattened out because all callers of this
+  // function need it in this format for convenience. The most common case is
+  // that there's a single matching entry, (especially when using this without
+  // an active graph,) which is why `absl::InlinedVector` is used with size 1.
+  // If no entry matches an empty vector is returned. If an active graph is set,
+  // entries will be limited to just that graph. If `node` is undefined, it will
+  // return all elements in the currently active graph, or all elements if no
+  // graph is set.
+  absl::InlinedVector<std::pair<Id, Id>, 1> getEquivalentIdAndMatchingGraphs(
+      Id node) const;
 
+  // Prefilter the map for values of a certain graph.
   void setGraphId(Id graphId);
 };
 

--- a/src/engine/TransitivePathHashMap.cpp
+++ b/src/engine/TransitivePathHashMap.cpp
@@ -39,8 +39,8 @@ const Set& HashMapWrapper::successors(const Id node) const {
 }
 
 // _____________________________________________________________________________
-absl::InlinedVector<std::pair<Id, Id>, 1> HashMapWrapper::getEquivalentIds(
-    Id node) const {
+absl::InlinedVector<std::pair<Id, Id>, 1>
+HashMapWrapper::getEquivalentIdAndMatchingGraphs(Id node) const {
   absl::InlinedVector<std::pair<Id, Id>, 1> result;
   for (const auto& [graph, map] : graphMap_) {
     if (node.isUndefined()) {

--- a/src/engine/TransitivePathHashMap.cpp
+++ b/src/engine/TransitivePathHashMap.cpp
@@ -11,23 +11,81 @@
 #include "engine/TransitivePathBase.h"
 
 // _____________________________________________________________________________
-HashMapWrapper TransitivePathHashMap::setupEdgesMap(
-    const IdTable& dynSub, const TransitivePathSide& startSide,
-    const TransitivePathSide& targetSide) const {
-  return CALL_FIXED_SIZE((std::array{dynSub.numColumns()}),
-                         &TransitivePathHashMap::setupEdgesMap, this, dynSub,
-                         startSide, targetSide);
+HashMapWrapper::HashMapWrapper(
+    Map map, const ad_utility::AllocatorWithLimit<Id>& allocator)
+    : graphMap_{allocator},
+      map_{nullptr},
+      emptySet_{allocator},
+      emptyMap_{allocator} {
+  graphMap_.try_emplace(Id::makeUndefined(), std::move(map));
+  map_ = &graphMap_.at(Id::makeUndefined());
 }
 
 // _____________________________________________________________________________
-template <size_t SUB_WIDTH>
+HashMapWrapper::HashMapWrapper(
+    MapOfMaps graphMap, const ad_utility::AllocatorWithLimit<Id>& allocator)
+    : graphMap_{std::move(graphMap)},
+      map_{&emptyMap_},
+      emptySet_{allocator},
+      emptyMap_{allocator} {}
+
+// _____________________________________________________________________________
+const Set& HashMapWrapper::successors(const Id node) const {
+  auto iterator = map_->find(node);
+  if (iterator == map_->end()) {
+    return emptySet_;
+  }
+  return iterator->second;
+}
+
+// _____________________________________________________________________________
+absl::InlinedVector<std::pair<Id, Id>, 1> HashMapWrapper::getEquivalentIds(
+    Id node) const {
+  absl::InlinedVector<std::pair<Id, Id>, 1> result;
+  for (const auto& [graph, map] : graphMap_) {
+    if (node.isUndefined()) {
+      for (Id newId : map | ql::views::keys) {
+        result.emplace_back(newId, graph);
+      }
+    } else {
+      auto iterator = map.find(node);
+      if (iterator != map.end()) {
+        result.emplace_back(iterator->first, graph);
+      }
+    }
+  }
+  return result;
+}
+
+// _____________________________________________________________________________
+void HashMapWrapper::setGraphId(Id graphId) {
+  AD_CORRECTNESS_CHECK(!graphId.isUndefined() || graphMap_.size() == 1);
+  if (graphMap_.contains(graphId)) {
+    map_ = &graphMap_.at(graphId);
+  } else {
+    map_ = &emptyMap_;
+  }
+}
+
+// _____________________________________________________________________________
 HashMapWrapper TransitivePathHashMap::setupEdgesMap(
-    const IdTable& dynSub, const TransitivePathSide& startSide,
+    const IdTable& sub, const TransitivePathSide& startSide,
     const TransitivePathSide& targetSide) const {
-  const IdTableView<SUB_WIDTH> sub = dynSub.asStaticView<SUB_WIDTH>();
-  HashMapWrapper::Map edges{allocator()};
   decltype(auto) startCol = sub.getColumn(startSide.subCol_);
   decltype(auto) targetCol = sub.getColumn(targetSide.subCol_);
+  if (graphVariable_.has_value()) {
+    decltype(auto) graphCol =
+        sub.getColumn(subtree_->getVariableColumn(graphVariable_.value()));
+    HashMapWrapper::MapOfMaps edgesWithGraph{allocator()};
+    for (size_t i = 0; i < sub.size(); i++) {
+      checkCancellation();
+      auto it1 = edgesWithGraph.try_emplace(graphCol[i], allocator()).first;
+      auto it2 = it1->second.try_emplace(startCol[i], allocator()).first;
+      it2->second.insert(targetCol[i]);
+    }
+    return HashMapWrapper{std::move(edgesWithGraph), allocator()};
+  }
+  HashMapWrapper::Map edges{allocator()};
 
   for (size_t i = 0; i < sub.size(); i++) {
     checkCancellation();

--- a/src/engine/TransitivePathHashMap.cpp
+++ b/src/engine/TransitivePathHashMap.cpp
@@ -3,7 +3,7 @@
 // Author: Florian Kramer (florian.kramer@neptun.uni-freiburg.de)
 //         Johannes Herrmann (johannes.r.herrmann(at)gmail.com)
 
-#include "TransitivePathHashMap.h"
+#include "engine/TransitivePathHashMap.h"
 
 #include <memory>
 

--- a/src/engine/TransitivePathHashMap.h
+++ b/src/engine/TransitivePathHashMap.h
@@ -55,9 +55,17 @@ class HashMapWrapper {
    */
   const Set& successors(Id node) const;
 
-  // Return equivalent ids from the index, along with an associated graph id in
-  // case these are available.
-  absl::InlinedVector<std::pair<Id, Id>, 1> getEquivalentIds(Id node) const;
+  // Return a pair of matching ids + graph ids. The first id of the pair is
+  // always the same element. It is flattened out because all callers of this
+  // function need it in this format for convenience. The most common case is
+  // that there's a single matching entry, (especially when using this without
+  // an active graph,) which is why `absl::InlinedVector` is used with size 1.
+  // If no entry matches an empty vector is returned. If an active graph is set,
+  // entries will be limited to just that graph. If `node` is undefined, it will
+  // return all elements in the currently active graph, or all elements if no
+  // graph is set.
+  absl::InlinedVector<std::pair<Id, Id>, 1> getEquivalentIdAndMatchingGraphs(
+      Id node) const;
 
   // Prefilter the map for values of a certain graph.
   void setGraphId(Id graphId);

--- a/src/engine/TransitivePathHashMap.h
+++ b/src/engine/TransitivePathHashMap.h
@@ -60,10 +60,10 @@ class HashMapWrapper {
   // function need it in this format for convenience. The most common case is
   // that there's a single matching entry, (especially when using this without
   // an active graph,) which is why `absl::InlinedVector` is used with size 1.
-  // If no entry matches an empty vector is returned. If an active graph is set,
-  // entries will be limited to just that graph. If `node` is undefined, it will
-  // return all elements in the currently active graph, or all elements if no
-  // graph is set.
+  // If no entry matches an empty vector is returned. If `node` is undefined, it
+  // will return all elements in the currently active graph, or all elements if
+  // no graph is set. Active graphs set via `setGraphId` are ignored. Entries
+  // are deduplicated.
   absl::InlinedVector<std::pair<Id, Id>, 1> getEquivalentIdAndMatchingGraphs(
       Id node) const;
 

--- a/src/engine/TransitivePathImpl.h
+++ b/src/engine/TransitivePathImpl.h
@@ -290,8 +290,9 @@ class TransitivePathImpl : public TransitivePathBase {
     // Make sure we retrieve the Id from an IndexScan, so we don't have to pass
     // this LocalVocab around. If it's not present then no result needs to be
     // returned anyways.
-    if (const Id* id = edges.getEquivalentId(startId)) {
-      result.insert(*id);
+    const auto& idsWithGraph = edges.getEquivalentIds(startId);
+    for (const auto& [id, graphId] : idsWithGraph) {
+      result.insert(id);
     }
     return result;
   }

--- a/src/engine/TransitivePathImpl.h
+++ b/src/engine/TransitivePathImpl.h
@@ -290,7 +290,7 @@ class TransitivePathImpl : public TransitivePathBase {
     // Make sure we retrieve the Id from an IndexScan, so we don't have to pass
     // this LocalVocab around. If it's not present then no result needs to be
     // returned anyways.
-    const auto& idsWithGraph = edges.getEquivalentIds(startId);
+    const auto& idsWithGraph = edges.getEquivalentIdAndMatchingGraphs(startId);
     for (const auto& [id, graphId] : idsWithGraph) {
       result.insert(id);
     }

--- a/test/TransitivePathTest.cpp
+++ b/test/TransitivePathTest.cpp
@@ -12,6 +12,8 @@
 #include "./util/IndexTestHelpers.h"
 #include "engine/QueryExecutionTree.h"
 #include "engine/TransitivePathBase.h"
+#include "engine/TransitivePathBinSearch.h"
+#include "engine/TransitivePathHashMap.h"
 #include "engine/ValuesForTesting.h"
 #include "util/GTestHelpers.h"
 #include "util/IdTableHelpers.h"
@@ -22,7 +24,8 @@ using ad_utility::testing::getQec;
 namespace {
 auto V = ad_utility::testing::VocabId;
 using Vars = std::vector<std::optional<Variable>>;
-
+auto U = Id::makeUndefined();
+using namespace ::testing;
 }  // namespace
 
 // The first bool indicates if binary search should be used (true) or hash map
@@ -1125,3 +1128,211 @@ INSTANTIATE_TEST_SUITE_P(
       result += std::get<1>(info.param) ? "Lazy" : "FullyMaterialized";
       return result;
     });
+
+// _____________________________________________________________________________
+TEST(TransitivePathBinSearch, successors) {
+  auto input =
+      makeIdTableFromVector({{0, 10}, {1, 10}, {2, 11}, {2, 12}, {3, 13}});
+  BinSearchMap binSearchMap{input.getColumn(0), input.getColumn(1)};
+  EXPECT_THAT(binSearchMap.successors(V(0)), ElementsAre(V(10)));
+  EXPECT_THAT(binSearchMap.successors(V(1)), ElementsAre(V(10)));
+  EXPECT_THAT(binSearchMap.successors(V(2)), ElementsAre(V(11), V(12)));
+  EXPECT_THAT(binSearchMap.successors(V(3)), ElementsAre(V(13)));
+}
+
+// _____________________________________________________________________________
+TEST(TransitivePathBinSearch, successorsWithGraph) {
+  auto input = makeIdTableFromVector(
+      {{0, 10, 100}, {1, 10, 100}, {2, 11, 100}, {2, 12, 101}, {3, 13, 101}});
+  BinSearchMap binSearchMap{input.getColumn(0), input.getColumn(1),
+                            input.getColumn(2)};
+  binSearchMap.setGraphId(V(100));
+  EXPECT_THAT(binSearchMap.successors(V(0)), ElementsAre(V(10)));
+  EXPECT_THAT(binSearchMap.successors(V(1)), ElementsAre(V(10)));
+  EXPECT_THAT(binSearchMap.successors(V(2)), ElementsAre(V(11)));
+  EXPECT_THAT(binSearchMap.successors(V(3)), ElementsAre());
+
+  binSearchMap.setGraphId(V(101));
+  EXPECT_THAT(binSearchMap.successors(V(0)), ElementsAre());
+  EXPECT_THAT(binSearchMap.successors(V(1)), ElementsAre());
+  EXPECT_THAT(binSearchMap.successors(V(2)), ElementsAre(V(12)));
+  EXPECT_THAT(binSearchMap.successors(V(3)), ElementsAre(V(13)));
+}
+
+namespace {
+// _____________________________________________________________________________
+HashMapWrapper::MapOfMaps columnsToMap(
+    const ad_utility::AllocatorWithLimit<Id>& allocator,
+    ql::span<const Id> startCol, ql::span<const Id> targetCol,
+    ql::span<const Id> graphCol) {
+  HashMapWrapper::MapOfMaps edgesWithGraph{allocator};
+  for (size_t i = 0; i < startCol.size(); i++) {
+    auto it1 = edgesWithGraph.try_emplace(graphCol[i], allocator).first;
+    auto it2 = it1->second.try_emplace(startCol[i], allocator).first;
+    it2->second.insert(targetCol[i]);
+  }
+  return edgesWithGraph;
+}
+
+// _____________________________________________________________________________
+HashMapWrapper::Map columnsToMap(
+    const ad_utility::AllocatorWithLimit<Id>& allocator,
+    ql::span<const Id> startCol, ql::span<const Id> targetCol) {
+  HashMapWrapper::Map edges{allocator};
+
+  for (size_t i = 0; i < startCol.size(); i++) {
+    auto [it, _] = edges.try_emplace(startCol[i], allocator);
+    it->second.insert(targetCol[i]);
+  }
+  return edges;
+}
+}  // namespace
+
+// _____________________________________________________________________________
+TEST(TransitivePathHashMap, successors) {
+  auto input =
+      makeIdTableFromVector({{0, 10}, {1, 10}, {2, 11}, {2, 12}, {3, 13}});
+  HashMapWrapper hashMapWrapper{
+      columnsToMap(input.getAllocator(), input.getColumn(0),
+                   input.getColumn(1)),
+      input.getAllocator()};
+  EXPECT_THAT(hashMapWrapper.successors(V(0)), UnorderedElementsAre(V(10)));
+  EXPECT_THAT(hashMapWrapper.successors(V(1)), UnorderedElementsAre(V(10)));
+  EXPECT_THAT(hashMapWrapper.successors(V(2)),
+              UnorderedElementsAre(V(11), V(12)));
+  EXPECT_THAT(hashMapWrapper.successors(V(3)), UnorderedElementsAre(V(13)));
+}
+TEST(TransitivePathHashMap, successorsWithGraph) {
+  auto input = makeIdTableFromVector(
+      {{0, 10, 100}, {1, 10, 100}, {2, 11, 100}, {2, 12, 101}, {3, 13, 101}});
+  HashMapWrapper hashMapWrapper{
+      columnsToMap(input.getAllocator(), input.getColumn(0), input.getColumn(1),
+                   input.getColumn(2)),
+      input.getAllocator()};
+  hashMapWrapper.setGraphId(V(100));
+  EXPECT_THAT(hashMapWrapper.successors(V(0)), UnorderedElementsAre(V(10)));
+  EXPECT_THAT(hashMapWrapper.successors(V(1)), UnorderedElementsAre(V(10)));
+  EXPECT_THAT(hashMapWrapper.successors(V(2)), UnorderedElementsAre(V(11)));
+  EXPECT_THAT(hashMapWrapper.successors(V(3)), UnorderedElementsAre());
+
+  hashMapWrapper.setGraphId(V(101));
+  EXPECT_THAT(hashMapWrapper.successors(V(0)), UnorderedElementsAre());
+  EXPECT_THAT(hashMapWrapper.successors(V(1)), UnorderedElementsAre());
+  EXPECT_THAT(hashMapWrapper.successors(V(2)), UnorderedElementsAre(V(12)));
+  EXPECT_THAT(hashMapWrapper.successors(V(3)), UnorderedElementsAre(V(13)));
+}
+
+// _____________________________________________________________________________
+TEST(TransitivePathBinSearch, getEquivalentIdAndMatchingGraphs) {
+  auto input =
+      makeIdTableFromVector({{0, 10}, {1, 10}, {2, 11}, {2, 12}, {3, 13}});
+  BinSearchMap binSearchMap{input.getColumn(0), input.getColumn(1)};
+  EXPECT_THAT(
+      binSearchMap.getEquivalentIdAndMatchingGraphs(U),
+      ElementsAre(Pair(V(0), U), Pair(V(1), U), Pair(V(2), U), Pair(V(3), U)));
+  EXPECT_THAT(binSearchMap.getEquivalentIdAndMatchingGraphs(V(0)),
+              ElementsAre(Pair(V(0), U)));
+  EXPECT_THAT(binSearchMap.getEquivalentIdAndMatchingGraphs(V(1)),
+              ElementsAre(Pair(V(1), U)));
+  EXPECT_THAT(binSearchMap.getEquivalentIdAndMatchingGraphs(V(2)),
+              ElementsAre(Pair(V(2), U)));
+  EXPECT_THAT(binSearchMap.getEquivalentIdAndMatchingGraphs(V(3)),
+              ElementsAre(Pair(V(3), U)));
+  EXPECT_THAT(binSearchMap.getEquivalentIdAndMatchingGraphs(V(4)),
+              ElementsAre());
+}
+
+// _____________________________________________________________________________
+TEST(TransitivePathBinSearch, getEquivalentIdAndMatchingGraphsWithGraphs) {
+  auto input = makeIdTableFromVector({{0, 10, 100},
+                                      {1, 10, 100},
+                                      {2, 11, 100},
+                                      {0, 10, 101},
+                                      {2, 12, 101},
+                                      {3, 13, 101},
+                                      {3, 14, 101}});
+  BinSearchMap binSearchMap{input.getColumn(0), input.getColumn(1),
+                            input.getColumn(2)};
+  // The active graph should be ignored
+  for (Id graphId : {U, V(100), V(101)}) {
+    // Don't explicitly set undefined, this works fine because by default no
+    // active graph is set.
+    if (!graphId.isUndefined()) {
+      binSearchMap.setGraphId(graphId);
+    }
+    EXPECT_THAT(binSearchMap.getEquivalentIdAndMatchingGraphs(U),
+                ElementsAre(Pair(V(0), V(100)), Pair(V(1), V(100)),
+                            Pair(V(2), V(100)), Pair(V(0), V(101)),
+                            Pair(V(2), V(101)), Pair(V(3), V(101))));
+    EXPECT_THAT(binSearchMap.getEquivalentIdAndMatchingGraphs(V(0)),
+                ElementsAre(Pair(V(0), V(100)), Pair(V(0), V(101))));
+    EXPECT_THAT(binSearchMap.getEquivalentIdAndMatchingGraphs(V(1)),
+                ElementsAre(Pair(V(1), V(100))));
+    EXPECT_THAT(binSearchMap.getEquivalentIdAndMatchingGraphs(V(2)),
+                ElementsAre(Pair(V(2), V(100)), Pair(V(2), V(101))));
+    EXPECT_THAT(binSearchMap.getEquivalentIdAndMatchingGraphs(V(3)),
+                ElementsAre(Pair(V(3), V(101))));
+    EXPECT_THAT(binSearchMap.getEquivalentIdAndMatchingGraphs(V(4)),
+                ElementsAre());
+  }
+}
+
+// _____________________________________________________________________________
+TEST(TransitivePathHashMap, getEquivalentIdAndMatchingGraphs) {
+  auto input =
+      makeIdTableFromVector({{0, 10}, {1, 10}, {2, 11}, {2, 12}, {3, 13}});
+  HashMapWrapper hashMapWrapper{
+      columnsToMap(input.getAllocator(), input.getColumn(0),
+                   input.getColumn(1)),
+      input.getAllocator()};
+  EXPECT_THAT(hashMapWrapper.getEquivalentIdAndMatchingGraphs(U),
+              UnorderedElementsAre(Pair(V(0), U), Pair(V(1), U), Pair(V(2), U),
+                                   Pair(V(3), U)));
+  EXPECT_THAT(hashMapWrapper.getEquivalentIdAndMatchingGraphs(V(0)),
+              UnorderedElementsAre(Pair(V(0), U)));
+  EXPECT_THAT(hashMapWrapper.getEquivalentIdAndMatchingGraphs(V(1)),
+              UnorderedElementsAre(Pair(V(1), U)));
+  EXPECT_THAT(hashMapWrapper.getEquivalentIdAndMatchingGraphs(V(2)),
+              UnorderedElementsAre(Pair(V(2), U)));
+  EXPECT_THAT(hashMapWrapper.getEquivalentIdAndMatchingGraphs(V(3)),
+              UnorderedElementsAre(Pair(V(3), U)));
+  EXPECT_THAT(hashMapWrapper.getEquivalentIdAndMatchingGraphs(V(4)),
+              UnorderedElementsAre());
+}
+
+// _____________________________________________________________________________
+TEST(TransitivePathHashMap, getEquivalentIdAndMatchingGraphsWithGraphs) {
+  auto input = makeIdTableFromVector({{0, 10, 100},
+                                      {1, 10, 100},
+                                      {2, 11, 100},
+                                      {0, 10, 101},
+                                      {2, 12, 101},
+                                      {3, 13, 101},
+                                      {3, 14, 101}});
+  HashMapWrapper hashMapWrapper{
+      columnsToMap(input.getAllocator(), input.getColumn(0), input.getColumn(1),
+                   input.getColumn(2)),
+      input.getAllocator()};
+  // The active graph should be ignored
+  for (Id graphId : {U, V(100), V(101)}) {
+    // Don't explicitly set undefined, this works fine because by default no
+    // active graph is set.
+    if (!graphId.isUndefined()) {
+      hashMapWrapper.setGraphId(graphId);
+    }
+    EXPECT_THAT(hashMapWrapper.getEquivalentIdAndMatchingGraphs(U),
+                UnorderedElementsAre(Pair(V(0), V(100)), Pair(V(1), V(100)),
+                                     Pair(V(2), V(100)), Pair(V(0), V(101)),
+                                     Pair(V(2), V(101)), Pair(V(3), V(101))));
+    EXPECT_THAT(hashMapWrapper.getEquivalentIdAndMatchingGraphs(V(0)),
+                UnorderedElementsAre(Pair(V(0), V(100)), Pair(V(0), V(101))));
+    EXPECT_THAT(hashMapWrapper.getEquivalentIdAndMatchingGraphs(V(1)),
+                UnorderedElementsAre(Pair(V(1), V(100))));
+    EXPECT_THAT(hashMapWrapper.getEquivalentIdAndMatchingGraphs(V(2)),
+                UnorderedElementsAre(Pair(V(2), V(100)), Pair(V(2), V(101))));
+    EXPECT_THAT(hashMapWrapper.getEquivalentIdAndMatchingGraphs(V(3)),
+                UnorderedElementsAre(Pair(V(3), V(101))));
+    EXPECT_THAT(hashMapWrapper.getEquivalentIdAndMatchingGraphs(V(4)),
+                UnorderedElementsAre());
+  }
+}


### PR DESCRIPTION
This is a subset of #2128 to be easier to review. It changes the `HashMapWrapper` and `BinSearchMap` helper classes to conceptually support graph columns. This does not yet change any actual behaviour.