### PR TITLE
Fix `COUNT(DISTINCT ?g)`

### DIFF
--- a/src/engine/GroupByImpl.cpp
+++ b/src/engine/GroupByImpl.cpp
@@ -650,9 +650,11 @@ std::optional<IdTable> GroupByImpl::computeGroupByForSingleIndexScan() const {
     return std::nullopt;
   }
 
-  // Distinct counts are only supported for triples with three variables.
+  // Distinct counts are only supported for triples with three variables without
+  // a GRAPH variable.
   bool countIsDistinct = varAndDistinctness.value().isDistinct_;
-  if (countIsDistinct && indexScan->numVariables() != 3) {
+  if (countIsDistinct && (indexScan->numVariables() != 3 ||
+                          !indexScan->additionalVariables().empty())) {
     return std::nullopt;
   }
 


### PR DESCRIPTION
The following query leads to an assertion error. This is a regression introduced by #2264. It is now fixed again. In particular, fixes #2284.
```sparql
SELECT (COUNT(DISTINCT ?g) AS ?count) WHERE {
  GRAPH ?g {
    ?s ?p ?o .
  }
}
```
NOTE: The query materializes all quads (triples + graph info) from the data, and thus only works when enough memory for that is available. Fixing this is a separate issue