### PR TITLE
Use `enum class JoinType` to indicate the type of join

### DIFF
--- a/src/engine/Minus.cpp
+++ b/src/engine/Minus.cpp
@@ -298,7 +298,7 @@ Result Minus::lazyMinusJoin(std::shared_ptr<const Result> left,
             [&rowAdder](auto& leftBlocks, auto& rightBlocks) {
               ad_utility::zipperJoinForBlocksWithPotentialUndef(
                   leftBlocks, rightBlocks, std::less{}, rowAdder, {}, {},
-                  ad_utility::ConstantJoinType<ad_utility::JoinType::MINUS>{});
+                  ad_utility::MinusJoinTag{});
             },
             leftRange, rightRange);
         auto localVocab = std::move(rowAdder.localVocab());

--- a/src/engine/Minus.cpp
+++ b/src/engine/Minus.cpp
@@ -300,7 +300,7 @@ Result Minus::lazyMinusJoin(std::shared_ptr<const Result> left,
             [&rowAdder](auto& leftBlocks, auto& rightBlocks) {
               ad_utility::zipperJoinForBlocksWithPotentialUndef(
                   leftBlocks, rightBlocks, std::less{}, rowAdder, {}, {},
-                  std::true_type{}, std::true_type{});
+                  ad_utility::ConstantJoinType<ad_utility::JoinType::MINUS>{});
             },
             leftRange, rightRange);
         auto localVocab = std::move(rowAdder.localVocab());

--- a/src/engine/OptionalJoin.cpp
+++ b/src/engine/OptionalJoin.cpp
@@ -475,7 +475,7 @@ Result OptionalJoin::lazyOptionalJoin(std::shared_ptr<const Result> left,
         [&rowAdder](auto& leftBlocks, auto& rightBlocks) {
           ad_utility::zipperJoinForBlocksWithPotentialUndef(
               leftBlocks, rightBlocks, std::less{}, rowAdder, {}, {},
-              ad_utility::ConstantJoinType<ad_utility::JoinType::OPTIONAL>{});
+              ad_utility::OptionalJoinTag{});
         },
         leftRange, rightRange);
     auto localVocab = std::move(rowAdder.localVocab());

--- a/src/engine/OptionalJoin.cpp
+++ b/src/engine/OptionalJoin.cpp
@@ -475,7 +475,7 @@ Result OptionalJoin::lazyOptionalJoin(std::shared_ptr<const Result> left,
         [&rowAdder](auto& leftBlocks, auto& rightBlocks) {
           ad_utility::zipperJoinForBlocksWithPotentialUndef(
               leftBlocks, rightBlocks, std::less{}, rowAdder, {}, {},
-              std::true_type{});
+              ad_utility::ConstantJoinType<ad_utility::JoinType::OPTIONAL>{});
         },
         leftRange, rightRange);
     auto localVocab = std::move(rowAdder.localVocab());

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -121,7 +121,7 @@ static auto lazyOptionalJoinOnFirstColumn(T1& leftInput, T2& rightInput,
 
   ad_utility::zipperJoinForBlocksWithoutUndef(leftInput, rightInput, comparator,
                                               rowAdder, projection, projection,
-                                              std::true_type{});
+                                              ad_utility::ConstantJoinType<ad_utility::JoinType::OPTIONAL>{});
   rowAdder.flush();
 }
 

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -119,9 +119,9 @@ static auto lazyOptionalJoinOnFirstColumn(T1& leftInput, T2& rightInput,
       BUFFER_SIZE_JOIN_PATTERNS_WITH_OSP,
       resultCallback};
 
-  ad_utility::zipperJoinForBlocksWithoutUndef(leftInput, rightInput, comparator,
-                                              rowAdder, projection, projection,
-                                              ad_utility::ConstantJoinType<ad_utility::JoinType::OPTIONAL>{});
+  ad_utility::zipperJoinForBlocksWithoutUndef(
+      leftInput, rightInput, comparator, rowAdder, projection, projection,
+      ad_utility::ConstantJoinType<ad_utility::JoinType::OPTIONAL>{});
   rowAdder.flush();
 }
 

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -119,9 +119,9 @@ static auto lazyOptionalJoinOnFirstColumn(T1& leftInput, T2& rightInput,
       BUFFER_SIZE_JOIN_PATTERNS_WITH_OSP,
       resultCallback};
 
-  ad_utility::zipperJoinForBlocksWithoutUndef(
-      leftInput, rightInput, comparator, rowAdder, projection, projection,
-      ad_utility::ConstantJoinType<ad_utility::JoinType::OPTIONAL>{});
+  ad_utility::zipperJoinForBlocksWithoutUndef(leftInput, rightInput, comparator,
+                                              rowAdder, projection, projection,
+                                              ad_utility::OptionalJoinTag{});
   rowAdder.flush();
 }
 

--- a/test/JoinAlgorithmsTest.cpp
+++ b/test/JoinAlgorithmsTest.cpp
@@ -74,9 +74,9 @@ void testJoin(const NestedBlock& a, const NestedBlock& b, JoinResult expected,
   auto compare = [](auto l, auto r) { return l[0] < r[0]; };
   auto adder = makeRowAdder(result);
   if constexpr (DoOptionalJoin) {
-    zipperJoinForBlocksWithoutUndef(
-        a, b, compare, adder, std::identity{}, std::identity{},
-        ad_utility::ConstantJoinType<ad_utility::JoinType::OPTIONAL>{});
+    zipperJoinForBlocksWithoutUndef(a, b, compare, adder, std::identity{},
+                                    std::identity{},
+                                    ad_utility::OptionalJoinTag{});
   } else {
     zipperJoinForBlocksWithoutUndef(a, b, compare, adder);
   }

--- a/test/JoinAlgorithmsTest.cpp
+++ b/test/JoinAlgorithmsTest.cpp
@@ -74,8 +74,9 @@ void testJoin(const NestedBlock& a, const NestedBlock& b, JoinResult expected,
   auto compare = [](auto l, auto r) { return l[0] < r[0]; };
   auto adder = makeRowAdder(result);
   if constexpr (DoOptionalJoin) {
-    zipperJoinForBlocksWithoutUndef(a, b, compare, adder, std::identity{},
-                                    std::identity{}, std::true_type{});
+    zipperJoinForBlocksWithoutUndef(
+        a, b, compare, adder, std::identity{}, std::identity{},
+        ad_utility::ConstantJoinType<ad_utility::JoinType::OPTIONAL>{});
   } else {
     zipperJoinForBlocksWithoutUndef(a, b, compare, adder);
   }


### PR DESCRIPTION
Simplify the code (in particular, function signatures) for the various joins by introducing

`enum class JoinType { JOIN, OPTIONAL, MINUS };`

This is a follow-up to #2026. No change of functionality