### PR TITLE
Avoid cloning `LocalVocab` in `Filter` operation

### DIFF
--- a/src/engine/Filter.cpp
+++ b/src/engine/Filter.cpp
@@ -4,7 +4,7 @@
 //   2015-2017 Björn Buchhold (buchhold@informatik.uni-freiburg.de)
 //   2020-     Johannes Kalmbach (kalmbach@informatik.uni-freiburg.de)
 
-#include "./Filter.h"
+#include "engine/Filter.h"
 
 #include <sstream>
 
@@ -18,7 +18,6 @@
 #include "global/RuntimeParameters.h"
 
 using std::endl;
-using std::string;
 
 // _____________________________________________________________________________
 size_t Filter::getResultWidth() const { return _subtree->getResultWidth(); }
@@ -39,7 +38,7 @@ Filter::Filter(QueryExecutionContext* qec,
 }
 
 // _____________________________________________________________________________
-string Filter::getCacheKeyImpl() const {
+std::string Filter::getCacheKeyImpl() const {
   std::ostringstream os;
   os << "FILTER " << _subtree->getCacheKey();
   os << " with " << _expression.getCacheKey(_subtree->getVariableColumns());
@@ -47,7 +46,7 @@ string Filter::getCacheKeyImpl() const {
 }
 
 //______________________________________________________________________________
-string Filter::getDescriptor() const {
+std::string Filter::getDescriptor() const {
   return absl::StrCat("Filter ", _expression.getDescriptor());
 }
 
@@ -64,33 +63,30 @@ void Filter::setPrefilterExpressionForChildren() {
 
 // _____________________________________________________________________________
 Result Filter::computeResult(bool requestLaziness) {
-  LOG(DEBUG) << "Getting sub-result for Filter result computation..." << endl;
+  AD_LOG_DEBUG << "Getting sub-result for Filter result computation..." << endl;
   std::shared_ptr<const Result> subRes = _subtree->getResult(true);
-  LOG(DEBUG) << "Filter result computation..." << endl;
+  AD_LOG_DEBUG << "Filter result computation..." << endl;
   checkCancellation();
 
   if (subRes->isFullyMaterialized()) {
-    IdTable result = filterIdTable(subRes->sortedBy(), subRes->idTable(),
-                                   subRes->localVocab());
-    LOG(DEBUG) << "Filter result computation done." << endl;
+    IdTable result = filterIdTable(subRes->sortedBy(), subRes->idTable());
+    AD_LOG_DEBUG << "Filter result computation done." << endl;
 
     return {std::move(result), resultSortedOn(), subRes->getSharedLocalVocab()};
   }
 
   if (requestLaziness) {
     return {Result::LazyResult{
-                ad_utility::OwningView{subRes->idTables()} |
-                ql::views::transform([this, subRes](auto& idTableVocabPair) {
-                  IdTable filteredTable = this->filterIdTable(
-                      subRes->sortedBy(), idTableVocabPair.idTable_,
-                      idTableVocabPair.localVocab_);
-                  // Note: the `clone` is shallow and therefore cheap, but
-                  // necessary to establish invariants in the `LocalVocab`
-                  // class.
-                  return Result::IdTableVocabPair{
-                      std::move(filteredTable),
-                      idTableVocabPair.localVocab_.clone()};
-                }) |
+                ad_utility::OwningView{
+                    Result::LazyResult{ad_utility::CachingTransformInputRange{
+                        subRes->idTables(),
+                        [this, subRes](auto& idTableVocabPair) {
+                          IdTable filteredTable = this->filterIdTable(
+                              subRes->sortedBy(), idTableVocabPair.idTable_);
+                          return Result::IdTableVocabPair{
+                              std::move(filteredTable),
+                              std::move(idTableVocabPair.localVocab_)};
+                        }}}} |
                 ql::views::filter(
                     [](const auto& pair) { return !pair.idTable_.empty(); })},
             subRes->sortedBy()};
@@ -106,12 +102,12 @@ Result Filter::computeResult(bool requestLaziness) {
       width, [this, &subRes, &result, &resultLocalVocab](auto WIDTH) {
         for (Result::IdTableVocabPair& pair : subRes->idTables()) {
           computeFilterImpl<WIDTH>(result, std::move(pair.idTable_),
-                                   pair.localVocab_, subRes->sortedBy());
+                                   subRes->sortedBy());
           resultLocalVocab.mergeWith(pair.localVocab_);
         }
       });
 
-  LOG(DEBUG) << "Filter result computation done." << endl;
+  AD_LOG_DEBUG << "Filter result computation done." << endl;
 
   return {std::move(result), resultSortedOn(), std::move(resultLocalVocab)};
 }
@@ -119,13 +115,12 @@ Result Filter::computeResult(bool requestLaziness) {
 // _____________________________________________________________________________
 CPP_template_def(typename Table)(requires ad_utility::SimilarTo<Table, IdTable>)
     IdTable Filter::filterIdTable(std::vector<ColumnIndex> sortedBy,
-                                  Table&& idTable,
-                                  const LocalVocab& localVocab) const {
+                                  Table&& idTable) const {
   size_t width = idTable.numColumns();
   IdTable result{width, getExecutionContext()->getAllocator()};
 
-  auto impl = [this, &result, &idTable, &localVocab, &sortedBy](auto WIDTH) {
-    return this->computeFilterImpl<WIDTH>(result, AD_FWD(idTable), localVocab,
+  auto impl = [this, &result, &idTable, &sortedBy](auto WIDTH) {
+    return this->computeFilterImpl<WIDTH>(result, AD_FWD(idTable),
                                           std::move(sortedBy));
   };
   ad_utility::callFixedSizeVi(width, impl);
@@ -136,7 +131,6 @@ CPP_template_def(typename Table)(requires ad_utility::SimilarTo<Table, IdTable>)
 CPP_template_def(int WIDTH, typename Table)(
     requires ad_utility::SimilarTo<Table, IdTable>) void Filter::
     computeFilterImpl(IdTable& dynamicResultTable, Table&& inputTable,
-                      [[maybe_unused]] const LocalVocab& localVocab,
                       std::vector<ColumnIndex> sortedBy) const {
   LocalVocab dummyLocalVocab{};
   AD_CONTRACT_CHECK(inputTable.numColumns() == WIDTH || WIDTH == 0);

--- a/src/engine/Filter.h
+++ b/src/engine/Filter.h
@@ -77,14 +77,13 @@ class Filter : public Operation {
       requires ad_utility::SimilarTo<
           Table, IdTable>) void computeFilterImpl(IdTable& dynamicResultTable,
                                                   Table&& input,
-                                                  const LocalVocab& localVocab,
                                                   std::vector<ColumnIndex>
                                                       sortedBy) const;
 
   // Run `computeFilterImpl` on the provided IdTable
-  CPP_template(typename Table)(requires ad_utility::SimilarTo<Table, IdTable>)
-      IdTable filterIdTable(std::vector<ColumnIndex> sortedBy, Table&& idTable,
-                            const LocalVocab& localVocab) const;
+  CPP_template(typename Table)(
+      requires ad_utility::SimilarTo<Table, IdTable>) IdTable
+      filterIdTable(std::vector<ColumnIndex> sortedBy, Table&& idTable) const;
 };
 
 #endif  // QLEVER_SRC_ENGINE_FILTER_H


### PR DESCRIPTION
Follow-up PR to #2058, which removes the copy of local vocab by wrapping the whole thing inside a `ad_utility::CachingTransformInputRange` to avoid double-moves that could happen when using `ql::ranges::transform` (and also double filter operations).