### PR TITLE
For `MINUS`, ignore `LocalVocab` from right child

### DIFF
--- a/src/engine/ExistsJoin.cpp
+++ b/src/engine/ExistsJoin.cpp
@@ -224,8 +224,8 @@ Result ExistsJoin::computeResult(bool requestLaziness) {
   }
 
   // The added column only contains Boolean values, and adds no new words to the
-  // local vocabulary, so we can simply copy the local vocab from `leftRes`.
-  return {std::move(result), resultSortedOn(), leftRes->getCopyOfLocalVocab()};
+  // local vocabulary, so we can use the local vocab from `leftRes`.
+  return {std::move(result), resultSortedOn(), leftRes->getSharedLocalVocab()};
 }
 
 // _____________________________________________________________________________

--- a/src/engine/Minus.cpp
+++ b/src/engine/Minus.cpp
@@ -39,7 +39,7 @@ string Minus::getDescriptor() const { return "Minus"; }
 
 // _____________________________________________________________________________
 Result Minus::computeResult(bool requestLaziness) {
-  LOG(DEBUG) << "Minus result computation..." << endl;
+  AD_LOG_DEBUG << "Minus result computation..." << endl;
 
   // If the right of the RootOperations is a Service, precompute the result of
   // its sibling.
@@ -64,20 +64,18 @@ Result Minus::computeResult(bool requestLaziness) {
                          requestLaziness);
   }
 
-  LOG(DEBUG) << "Minus subresult computation done" << std::endl;
+  AD_LOG_DEBUG << "Minus subresult computation done" << std::endl;
 
-  LOG(DEBUG) << "Computing minus of results of size "
-             << leftResult->idTable().size() << " and "
-             << rightResult->idTable().size() << endl;
+  AD_LOG_DEBUG << "Computing minus of results of size "
+               << leftResult->idTable().size() << " and "
+               << rightResult->idTable().size() << endl;
 
   IdTable idTable = computeMinus(leftResult->idTable(), rightResult->idTable(),
                                  _matchedColumns);
 
-  LOG(DEBUG) << "Minus result computation done" << endl;
-  // If only one of the two operands has a non-empty local vocabulary, share
-  // with that one (otherwise, throws an exception).
+  AD_LOG_DEBUG << "Minus result computation done" << endl;
   return {std::move(idTable), resultSortedOn(),
-          Result::getMergedLocalVocab(*leftResult, *rightResult)};
+          leftResult->getSharedLocalVocab()};
 }
 
 // _____________________________________________________________________________

--- a/test/MinusTest.cpp
+++ b/test/MinusTest.cpp
@@ -144,6 +144,33 @@ TEST(Minus, computeMinus) {
 }
 
 // _____________________________________________________________________________
+TEST(Minus, ensureLocalVocabFromLeftIsPassed) {
+  IdTable a = makeIdTableFromVector({{0}, {1}, {2}, {3}, {4}});
+  IdTable b = makeIdTableFromVector({{0}});
+  LocalVocabEntry aEntry = LocalVocabEntry::fromStringRepresentation("\"a\"");
+  LocalVocab vocabA;
+  vocabA.getIndexAndAddIfNotContained(aEntry);
+  LocalVocab vocabB;
+  vocabB.getIndexAndAddIfNotContained(
+      LocalVocabEntry::fromStringRepresentation("\"b\""));
+
+  auto* qec = ad_utility::testing::getQec();
+  Minus m{qec,
+          ad_utility::makeExecutionTree<ValuesForTesting>(
+              qec, std::move(a),
+              std::vector<std::optional<Variable>>{Variable{"?a"}}, false,
+              std::vector<ColumnIndex>{0}, std::move(vocabA)),
+          ad_utility::makeExecutionTree<ValuesForTesting>(
+              qec, std::move(b),
+              std::vector<std::optional<Variable>>{Variable{"?a"}}, false,
+              std::vector<ColumnIndex>{0}, std::move(vocabB))};
+
+  auto result = m.computeResultOnlyForTesting(false);
+  EXPECT_THAT(result.localVocab().getAllWordsForTesting(),
+              ::testing::ElementsAre(::testing::Eq(aEntry)));
+}
+
+// _____________________________________________________________________________
 TEST(Minus, computeMinusIndexNestedLoopJoinOptimization) {
   LocalVocabEntry entryA = LocalVocabEntry::fromStringRepresentation("\"a\"");
   LocalVocabEntry entryB = LocalVocabEntry::fromStringRepresentation("\"b\"");


### PR DESCRIPTION
So far, the result of a non-lazy `MINUS` operation inherited the `LocalVocab` from both the left and right child. But `Id`s from the right child never make it into the result. We therefore now simply inherit the `LocalVocab` from the left child.