### PR TITLE
Prevent wrong `SERVICE` optimization when `LIMIT` is present

### DIFF
--- a/src/engine/Service.cpp
+++ b/src/engine/Service.cpp
@@ -567,6 +567,12 @@ void Service::precomputeSiblingResult(std::shared_ptr<Operation> left,
   }();
   AD_CORRECTNESS_CHECK(service != nullptr);
 
+  // If this operation is constrained by a `LIMIT` or `OFFSET` we can't apply
+  // the optimization.
+  if (!service->getLimitOffset().isUnconstrained()) {
+    return;
+  }
+
   auto addRuntimeInfo = [&](bool siblingUsed) {
     std::string_view v = siblingUsed ? "yes"sv : "no"sv;
     service->runtimeInfo().addDetail("optimized-with-sibling-result", v);

--- a/src/engine/Service.h
+++ b/src/engine/Service.h
@@ -161,6 +161,7 @@ class Service : public Operation {
   FRIEND_TEST(ServiceTest, computeResult);
   FRIEND_TEST(ServiceTest, computeResultWrapSubqueriesWithSibling);
   FRIEND_TEST(ServiceTest, precomputeSiblingResultDoesNotWorkWithCaching);
+  FRIEND_TEST(ServiceTest, precomputeSiblingResultDoesNotWorkWithLimit);
   FRIEND_TEST(ServiceTest, precomputeSiblingResult);
 };
 


### PR DESCRIPTION
Since #1341, the `SERVICE` query can be constrained by the values matching the preceding graph pattern. However, in in a query like the following on Wikidata, where the `SERVICE` is followed by a `LIMIT`, this optimization must not be applied. Indeed, the current master returns a non-empty result for this query (with `strip-columns=false`, otherwise the optimization is never applied) because `wd:64` ("Berlin") is one of the objects of `wdt:P36` ("capital"). With this fix, the result is empty as it should be because the first triple of `wdt:P36` does not contain `wdt:P64` as object.
```sparql
SELECT * WHERE {
  VALUES ?o { wd:Q64 }
  { SELECT * {
      SERVICE <https://qlever.cs.uni-freiburg.de/api/wikidata> { ?s wdt:P36 ?o }
  } LIMIT 1 }
}
```
NOTE: This does not add the optimization that the `LIMIT` (or `OFFSET`) is pulled into the `SERVICE` request. This would, of course, be much more efficient, than first computing and transmitting the full result of the `SERVICE` request and then applying the `LIMIT` afterwards