### PR TITLE
Distributive union cleanup

### DIFF
--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -2359,6 +2359,10 @@ auto QueryPlanner::applyJoinDistributivelyToUnion(const SubtreePlan& a,
   AD_CORRECTNESS_CHECK(a.type == SubtreePlan::BASIC &&
                        b.type == SubtreePlan::BASIC);
   std::vector<SubtreePlan> candidates{};
+  // Disable this optimization.
+  if (!RuntimeParameters().get<"distributive-union">()) {
+    return candidates;
+  }
   auto findCandidates = [this, &candidates, &jcs](const SubtreePlan& thisPlan,
                                                   const SubtreePlan& other,
                                                   bool flipped) {

--- a/src/global/RuntimeParameters.h
+++ b/src/global/RuntimeParameters.h
@@ -104,6 +104,9 @@ inline auto& RuntimeParameters() {
         // The maximum size of the `prefilterBox` for
         // `SpatialJoinAlgorithms::libspatialjoinParse()`.
         SizeT<"spatial-join-prefilter-max-size">{2'500},
+        // Push joins into both childs of unions if this leads to a cheaper
+        // cost-estimate.
+        Bool<"distributive-union">{true},
     };
   }();
   return params;

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -7,10 +7,10 @@
 #include <gmock/gmock.h>
 
 #include "./printers/PayloadVariablePrinters.h"
-#include "./util/RuntimeParametersTestHelpers.h"
 #include "QueryPlannerTestHelpers.h"
 #include "engine/QueryPlanner.h"
 #include "engine/SpatialJoin.h"
+#include "gmock/gmock.h"
 #include "parser/GraphPatternOperation.h"
 #include "parser/MagicServiceQuery.h"
 #include "parser/PayloadVariables.h"
@@ -4321,50 +4321,56 @@ TEST(QueryPlanner, testDistributiveJoinInUnion) {
                                 "?_QLever_internal_variable_qp_0", "<P279>",
                                 "?_QLever_internal_variable_qp_1"))),
       qec, {4, 16, 64'000'000});
+
+  h::expectWithGivenBudgets(
+      "SELECT * WHERE { ?x <P31> ?o ."
+      "{ VALUES ?x { 1 } } UNION { VALUES ?x { 2 } }}",
+      h::Union(h::Join(h::Sort(h::ValuesClause("VALUES (?x) { (1) }")),
+                       h::IndexScanFromStrings("?x", "<P31>", "?o")),
+               h::Join(h::Sort(h::ValuesClause("VALUES (?x) { (2) }")),
+                       h::IndexScanFromStrings("?x", "<P31>", "?o"))),
+      qec, {4, 16, 64'000'000});
+
+  h::expectWithGivenBudgets(
+      "SELECT * WHERE { ?x <P31> ?o . "
+      "{ { VALUES ?x { 1 } } UNION { VALUES ?x { 2 } } } "
+      "UNION "
+      "{ { VALUES ?x { 3 } } UNION { VALUES ?x { 4 } } } }",
+      h::Union(h::Union(h::Join(h::Sort(h::ValuesClause("VALUES (?x) { (1) }")),
+                                h::IndexScanFromStrings("?x", "<P31>", "?o")),
+                        h::Join(h::Sort(h::ValuesClause("VALUES (?x) { (2) }")),
+                                h::IndexScanFromStrings("?x", "<P31>", "?o"))),
+               h::Union(h::Join(h::Sort(h::ValuesClause("VALUES (?x) { (3) }")),
+                                h::IndexScanFromStrings("?x", "<P31>", "?o")),
+                        h::Join(h::Sort(h::ValuesClause("VALUES (?x) { (4) }")),
+                                h::IndexScanFromStrings("?x", "<P31>", "?o")))),
+      qec, {4, 16, 64'000'000});
 }
 
-// TODO<joka921> Properly adapt those tests to the distributed union
-/*
 // _____________________________________________________________________________
-TEST(QueryPlanner, ensurePlanningIsSkippedWhenNoTransitivePathIsPresent) {
-  auto qp = makeQueryPlanner();
-  {
-    auto query = SparqlParser::parseQuery(
-        "SELECT * WHERE { ?x <P31> ?o ."
-        "{ VALUES ?x { 1 } } UNION { VALUES ?x { 1 } }}");
-    auto plans = qp.createExecutionTrees(query);
-    ASSERT_EQ(plans.size(), 2);
-    EXPECT_TRUE(
-        std::dynamic_pointer_cast<Join>(plans.at(0)._qet->getRootOperation()));
-  }
-  {
-    auto query = SparqlParser::parseQuery(
-        "SELECT * WHERE { ?x <P31> ?o . "
-        "{ { VALUES ?x { 1 } } UNION { VALUES ?x { 1 } } } "
-        "UNION "
-        "{ { VALUES ?x { 1 } } UNION { VALUES ?x { 1 } } } }");
-    auto plans = qp.createExecutionTrees(query);
-    ASSERT_EQ(plans.size(), 1);
-    EXPECT_TRUE(
-        std::dynamic_pointer_cast<Join>(plans.at(0)._qet->getRootOperation()));
-  }
-}
- */
-
-// TODO<joka921> This test is no longer relevant with the distributed union,
-// find out what to properly replace it by.
-/*
-// _____________________________________________________________________________
-TEST(QueryPlanner, ensurePlanningIsSkippedWhenTransitivePathIsAlreadyBound) {
+TEST(QueryPlanner, ensureRegularJoinIsUsedIfTransitivePathIsAlreadyBound) {
+  using namespace ::testing;
   auto qp = makeQueryPlanner();
   auto query = SparqlParser::parseQuery(
       "SELECT * { { VALUES ?x { 1 } } UNION { ?s <P279>+ 1 } . ?s <P31> ?o }");
   auto plans = qp.createExecutionTrees(query);
-  ASSERT_EQ(plans.size(), 1);
-  EXPECT_TRUE(
-      std::dynamic_pointer_cast<Join>(plans.at(0)._qet->getRootOperation()));
+
+  EXPECT_THAT(
+      plans,
+      UnorderedElementsAre(
+          Truly([](const auto& plan) {
+            // Case where join is at the top level.
+            return std::dynamic_pointer_cast<Join>(
+                plan._qet->getRootOperation());
+          }),
+          Truly([](const auto& plan) {
+            // Case where join is pushed into the union.
+            auto operation = plan._qet->getRootOperation();
+            return std::dynamic_pointer_cast<Union>(operation) &&
+                   std::dynamic_pointer_cast<Join>(
+                       operation->getChildren().at(1)->getRootOperation());
+          })));
 }
- */
 
 // _____________________________________________________________________________
 TEST(QueryPlanner, testDistributiveJoinInUnionRecursive) {
@@ -5056,39 +5062,4 @@ LIMIT 1
 )";
   h::expect(q1, ::testing::_);
   h::expect(q2, ::testing::_);
-}
-
-// Test that subqueries strip columns correctly and that stripped variables
-// are not even stored as `stripped`.
-TEST(QueryPlanner, SubqueryColumnStripping) {
-  // Save current strip-columns setting and ensure it's enabled for this test
-  auto cleanup = setRuntimeParameterForTest<"strip-columns">(true);
-
-  // Test a subquery that selects only some variables, causing others to be
-  // stripped
-  std::string query = R"(
-    SELECT ?x ?y WHERE {
-      { SELECT ?x ?y WHERE { ?x <p1> ?y . ?x <p2> ?z . ?y <p3> ?w } }
-    }
-  )";
-
-  auto qec = ad_utility::testing::getQec();
-  for (bool doStrip : {true, false}) {
-    qec->clearCacheUnpinnedOnly();
-
-    // The outer cleanup will reset the original status, so we can safely
-    // modify the global parameter here.
-    RuntimeParameters().set<"strip-columns">(doStrip);
-
-    // The inner subquery should have ?z and ?w stripped (as they're not
-    // selected) but since it's a subquery, the stripped variables should not be
-    // stored in the `QueryExecutionTree`. (hideStrippedColumns=true)
-    auto qet = h::parseAndPlan(query, qec);
-
-    // The root should have no stripped variables (it's not created via
-    // makeTreeWithStrippedColumns)
-    EXPECT_THAT(qet, h::HasNoStrippedVariables());
-    EXPECT_THAT(qet, h::hasVariables({"?x", "?y"}));
-    EXPECT_EQ(qet.getResultWidth(), doStrip ? 2 : 4);
-  }
 }


### PR DESCRIPTION
Originally part of #2286, this PR factors out the cleanup part that is unrelated to the actual cost estimate and cleans up the code left untidy by #2267.