### PR TITLE
Distributive union cleanup

### DIFF
--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -2359,6 +2359,10 @@ auto QueryPlanner::applyJoinDistributivelyToUnion(const SubtreePlan& a,
   AD_CORRECTNESS_CHECK(a.type == SubtreePlan::BASIC &&
                        b.type == SubtreePlan::BASIC);
   std::vector<SubtreePlan> candidates{};
+  // Disable this optimization.
+  if (!RuntimeParameters().get<"distributive-union">()) {
+    return candidates;
+  }
   auto findCandidates = [this, &candidates, &jcs](const SubtreePlan& thisPlan,
                                                   const SubtreePlan& other,
                                                   bool flipped) {

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -2348,24 +2348,6 @@ SubtreePlan cloneWithNewTree(const SubtreePlan& plan,
   newPlan._qet = std::move(newTree);
   return newPlan;
 }
-
-// Check if an unbound transitive path is somewhere in the tree. This is because
-// the optimization with `Union` currently only makes sense if there is a
-// transitive path in the tree that benefits from directly applying the join.
-bool hasUnboundTransitivePathInTree(const Operation& operation) {
-  if (auto* transitivePath =
-          dynamic_cast<const TransitivePathBase*>(&operation)) {
-    return !transitivePath->isBoundOrId();
-  }
-  // Only check `UNION`s for children.
-  if (!dynamic_cast<const Union*>(&operation)) {
-    return false;
-  }
-  return ql::ranges::any_of(
-      operation.getChildren(), [](const QueryExecutionTree* child) {
-        return hasUnboundTransitivePathInTree(*child->getRootOperation());
-      });
-}
 }  // namespace
 
 // _____________________________________________________________________________________________________________________
@@ -2383,9 +2365,6 @@ auto QueryPlanner::applyJoinDistributivelyToUnion(const SubtreePlan& a,
     auto unionOperation =
         std::dynamic_pointer_cast<Union>(thisPlan._qet->getRootOperation());
 
-    // TODO<joka921> This changes the behavior to consider applying the
-    // distribution to ALL unions. Evaluate the impact and make sure that the
-    // documentation is correct.
     if (!unionOperation) {
       return;
     }

--- a/src/global/RuntimeParameters.h
+++ b/src/global/RuntimeParameters.h
@@ -104,6 +104,9 @@ inline auto& RuntimeParameters() {
         // The maximum size of the `prefilterBox` for
         // `SpatialJoinAlgorithms::libspatialjoinParse()`.
         SizeT<"spatial-join-prefilter-max-size">{2'500},
+        // Push joins into both childs of unions if this leads to a cheaper
+        // cost-estimate.
+        Bool<"distributive-union">{true},
     };
   }();
   return params;

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -4321,50 +4321,56 @@ TEST(QueryPlanner, testDistributiveJoinInUnion) {
                                 "?_QLever_internal_variable_qp_0", "<P279>",
                                 "?_QLever_internal_variable_qp_1"))),
       qec, {4, 16, 64'000'000});
+
+  h::expectWithGivenBudgets(
+      "SELECT * WHERE { ?x <P31> ?o ."
+      "{ VALUES ?x { 1 } } UNION { VALUES ?x { 2 } }}",
+      h::Union(h::Join(h::Sort(h::ValuesClause("VALUES (?x) { (1) }")),
+                       h::IndexScanFromStrings("?x", "<P31>", "?o")),
+               h::Join(h::Sort(h::ValuesClause("VALUES (?x) { (2) }")),
+                       h::IndexScanFromStrings("?x", "<P31>", "?o"))),
+      qec, {4, 16, 64'000'000});
+
+  h::expectWithGivenBudgets(
+      "SELECT * WHERE { ?x <P31> ?o . "
+      "{ { VALUES ?x { 1 } } UNION { VALUES ?x { 2 } } } "
+      "UNION "
+      "{ { VALUES ?x { 3 } } UNION { VALUES ?x { 4 } } } }",
+      h::Union(h::Union(h::Join(h::Sort(h::ValuesClause("VALUES (?x) { (1) }")),
+                                h::IndexScanFromStrings("?x", "<P31>", "?o")),
+                        h::Join(h::Sort(h::ValuesClause("VALUES (?x) { (2) }")),
+                                h::IndexScanFromStrings("?x", "<P31>", "?o"))),
+               h::Union(h::Join(h::Sort(h::ValuesClause("VALUES (?x) { (3) }")),
+                                h::IndexScanFromStrings("?x", "<P31>", "?o")),
+                        h::Join(h::Sort(h::ValuesClause("VALUES (?x) { (4) }")),
+                                h::IndexScanFromStrings("?x", "<P31>", "?o")))),
+      qec, {4, 16, 64'000'000});
 }
 
-// TODO<joka921> Properly adapt those tests to the distributed union
-/*
 // _____________________________________________________________________________
-TEST(QueryPlanner, ensurePlanningIsSkippedWhenNoTransitivePathIsPresent) {
-  auto qp = makeQueryPlanner();
-  {
-    auto query = SparqlParser::parseQuery(
-        "SELECT * WHERE { ?x <P31> ?o ."
-        "{ VALUES ?x { 1 } } UNION { VALUES ?x { 1 } }}");
-    auto plans = qp.createExecutionTrees(query);
-    ASSERT_EQ(plans.size(), 2);
-    EXPECT_TRUE(
-        std::dynamic_pointer_cast<Join>(plans.at(0)._qet->getRootOperation()));
-  }
-  {
-    auto query = SparqlParser::parseQuery(
-        "SELECT * WHERE { ?x <P31> ?o . "
-        "{ { VALUES ?x { 1 } } UNION { VALUES ?x { 1 } } } "
-        "UNION "
-        "{ { VALUES ?x { 1 } } UNION { VALUES ?x { 1 } } } }");
-    auto plans = qp.createExecutionTrees(query);
-    ASSERT_EQ(plans.size(), 1);
-    EXPECT_TRUE(
-        std::dynamic_pointer_cast<Join>(plans.at(0)._qet->getRootOperation()));
-  }
-}
- */
-
-// TODO<joka921> This test is no longer relevant with the distributed union,
-// find out what to properly replace it by.
-/*
-// _____________________________________________________________________________
-TEST(QueryPlanner, ensurePlanningIsSkippedWhenTransitivePathIsAlreadyBound) {
+TEST(QueryPlanner, ensureRegularJoinIsUsedIfTransitivePathIsAlreadyBound) {
+  using namespace ::testing;
   auto qp = makeQueryPlanner();
   auto query = SparqlParser::parseQuery(
       "SELECT * { { VALUES ?x { 1 } } UNION { ?s <P279>+ 1 } . ?s <P31> ?o }");
   auto plans = qp.createExecutionTrees(query);
-  ASSERT_EQ(plans.size(), 1);
-  EXPECT_TRUE(
-      std::dynamic_pointer_cast<Join>(plans.at(0)._qet->getRootOperation()));
+
+  EXPECT_THAT(
+      plans,
+      UnorderedElementsAre(
+          Truly([](const auto& plan) {
+            // Case where join is at the top level.
+            return std::dynamic_pointer_cast<Join>(
+                plan._qet->getRootOperation());
+          }),
+          Truly([](const auto& plan) {
+            // Case where join is pushed into the union.
+            auto operation = plan._qet->getRootOperation();
+            return std::dynamic_pointer_cast<Union>(operation) &&
+                   std::dynamic_pointer_cast<Join>(
+                       operation->getChildren().at(1)->getRootOperation());
+          })));
 }
- */
 
 // _____________________________________________________________________________
 TEST(QueryPlanner, testDistributiveJoinInUnionRecursive) {


### PR DESCRIPTION
Originally part of https://github.com/ad-freiburg/qlever/pull/2286, this PR factors out the cleanup part that is unrelated to the actual cost estimate and cleans up the code left untidy by https://github.com/ad-freiburg/qlever/pull/2267.