### PR TITLE
Fix prefilter for `isLiteral()`

### DIFF
--- a/src/engine/sparqlExpressions/PrefilterExpressionIndex.cpp
+++ b/src/engine/sparqlExpressions/PrefilterExpressionIndex.cpp
@@ -636,7 +636,7 @@ std::string IsDatatypeExpression<Datatype>::asString(
 //______________________________________________________________________________
 static BlockMetadataRanges getRangesForDatatypes(
     const ValueIdSubrange& idRange, BlockMetadataSpan blockRange,
-    const bool isNegated, const ql::span<Datatype>& datatypes) {
+    const bool isNegated, ql::span<Datatype> datatypes) {
   std::vector<ValueIdItPair> relevantRanges;
   for (Datatype datatype : datatypes) {
     relevantRanges.emplace_back(valueIdComparators::getRangeForDatatype(

--- a/src/engine/sparqlExpressions/PrefilterExpressionIndex.cpp
+++ b/src/engine/sparqlExpressions/PrefilterExpressionIndex.cpp
@@ -634,10 +634,9 @@ std::string IsDatatypeExpression<Datatype>::asString(
 }
 
 //______________________________________________________________________________
-template <size_t N>
 static BlockMetadataRanges getRangesForDatatypes(
     const ValueIdSubrange& idRange, BlockMetadataSpan blockRange,
-    const bool isNegated, std::array<Datatype, N> datatypes) {
+    const bool isNegated, const ql::span<Datatype>& datatypes) {
   std::vector<ValueIdItPair> relevantRanges;
   for (Datatype datatype : datatypes) {
     relevantRanges.emplace_back(valueIdComparators::getRangeForDatatype(
@@ -659,8 +658,8 @@ BlockMetadataRanges IsDatatypeExpression<IsDatatype::BLANK>::evaluateImpl(
     [[maybe_unused]] const Vocab& vocab, const ValueIdSubrange& idRange,
     BlockMetadataSpan blockRange,
     [[maybe_unused]] bool getTotalComplement) const {
-  return getRangesForDatatypes(idRange, blockRange, isNegated_,
-                               std::array{Datatype::BlankNodeIndex});
+  std::array datatypes{Datatype::BlankNodeIndex};
+  return getRangesForDatatypes(idRange, blockRange, isNegated_, datatypes);
 }
 
 //______________________________________________________________________________
@@ -669,8 +668,8 @@ BlockMetadataRanges IsDatatypeExpression<IsDatatype::NUMERIC>::evaluateImpl(
     [[maybe_unused]] const Vocab& vocab, const ValueIdSubrange& idRange,
     BlockMetadataSpan blockRange,
     [[maybe_unused]] bool getTotalComplement) const {
-  return getRangesForDatatypes(idRange, blockRange, isNegated_,
-                               std::array{Datatype::Int, Datatype::Double});
+  std::array datatypes{Datatype::Int, Datatype::Double};
+  return getRangesForDatatypes(idRange, blockRange, isNegated_, datatypes);
 }
 
 //______________________________________________________________________________
@@ -698,12 +697,12 @@ BlockMetadataRanges IsDatatypeExpression<IsDatatype::LITERAL>::evaluateImpl(
   // For pre-filtering LITERAL related ValueIds we use the ValueId representing
   // the beginning of IRI values as an upper bound and add all the value types
   // that are literals inlined into a compact representation.
-  auto inlinedRanges = getRangesForDatatypes(
-      idRange, blockRange, isNegated_,
-      std::array{Datatype::Int, Datatype::Double, Datatype::Date,
-                 Datatype::Bool, Datatype::GeoPoint});
+  std::array datatypes{Datatype::Int, Datatype::Double, Datatype::Date,
+                       Datatype::Bool, Datatype::GeoPoint};
+  auto inlinedRanges =
+      getRangesForDatatypes(idRange, blockRange, isNegated_, datatypes);
   auto nonInlinedRanges =
-      make<LessThanExpression>(LVE::fromStringRepresentation("<"))
+      make<LessThanExpression>(LVE::fromStringRepresentation("<>"))
           ->evaluateImpl(vocab, idRange, blockRange, isNegated_);
 
   if (isNegated_) {

--- a/src/engine/sparqlExpressions/PrefilterExpressionIndex.cpp
+++ b/src/engine/sparqlExpressions/PrefilterExpressionIndex.cpp
@@ -634,9 +634,10 @@ std::string IsDatatypeExpression<Datatype>::asString(
 }
 
 //______________________________________________________________________________
-static BlockMetadataRanges getRangesForDatatypes(
-    const ValueIdSubrange& idRange, BlockMetadataSpan blockRange,
-    const bool isNegated, ql::span<Datatype> datatypes) {
+static BlockMetadataRanges getRangesForDatatypes(const ValueIdSubrange& idRange,
+                                                 BlockMetadataSpan blockRange,
+                                                 const bool isNegated,
+                                                 ql::span<Datatype> datatypes) {
   std::vector<ValueIdItPair> relevantRanges;
   for (Datatype datatype : datatypes) {
     relevantRanges.emplace_back(valueIdComparators::getRangeForDatatype(

--- a/src/engine/sparqlExpressions/PrefilterExpressionIndex.cpp
+++ b/src/engine/sparqlExpressions/PrefilterExpressionIndex.cpp
@@ -37,7 +37,7 @@ static Id getIdFromColumnIndex(
       // columnIndex out of bounds
       AD_FAIL();
   }
-};
+}
 
 //______________________________________________________________________________
 // Check for the following conditions.
@@ -50,7 +50,7 @@ static void checkRequirementsBlockMetadata(
     ql::span<const CompressedBlockMetadata> input, size_t evaluationColumn) {
   CompressedRelationReader::ScanSpecAndBlocks::checkBlockMetadataInvariant(
       input, evaluationColumn);
-};
+}
 
 namespace detail {
 //______________________________________________________________________________
@@ -77,7 +77,7 @@ static void mergeBlockRangeWithRanges(BlockMetadataRanges& blockRanges,
     // The new blockRange doesn't intersect with previous blockRange(s).
     blockRanges.push_back(blockRange);
   }
-};
+}
 
 namespace mapping {
 //______________________________________________________________________________
@@ -361,7 +361,7 @@ ValueId AccessValueIdFromBlockMetadata::operator()(
   return i % 2 == 0
              ? getIdFromColumnIndex(block.firstTriple_, evaluationColumn_)
              : getIdFromColumnIndex(block.lastTriple_, evaluationColumn_);
-};
+}
 
 // SECTION PREFILTER EXPRESSION (BASE CLASS)
 //______________________________________________________________________________
@@ -403,7 +403,7 @@ BlockMetadataRanges PrefilterExpression::evaluate(
     result.push_back(lastBlockRange.value());
   }
   return result;
-};
+}
 
 //______________________________________________________________________________
 ValueId PrefilterExpression::getValueIdFromIdOrLocalVocabEntry(
@@ -422,7 +422,7 @@ ValueId PrefilterExpression::getValueIdFromIdOrLocalVocabEntry(
 std::unique_ptr<PrefilterExpression> PrefixRegexExpression::logicalComplement()
     const {
   return make<PrefixRegexExpression>(prefixLiteral_, !isNegated_);
-};
+}
 
 //______________________________________________________________________________
 bool PrefixRegexExpression::operator==(const PrefilterExpression& other) const {
@@ -433,12 +433,12 @@ bool PrefixRegexExpression::operator==(const PrefilterExpression& other) const {
   }
   return isNegated_ == otherPrefixRegex->isNegated_ &&
          prefixLiteral_ == otherPrefixRegex->prefixLiteral_;
-};
+}
 
 //______________________________________________________________________________
 std::unique_ptr<PrefilterExpression> PrefixRegexExpression::clone() const {
   return make<PrefixRegexExpression>(*this);
-};
+}
 
 //______________________________________________________________________________
 std::string PrefixRegexExpression::asString(
@@ -447,7 +447,7 @@ std::string PrefixRegexExpression::asString(
       "Prefilter PrefixRegexExpression with prefix ",
       prefixLiteral_.toStringRepresentation(),
       ".\nExpression is negated: ", isNegated_ ? "true.\n" : "false.\n");
-};
+}
 
 //______________________________________________________________________________
 BlockMetadataRanges PrefixRegexExpression::evaluateImpl(
@@ -498,7 +498,7 @@ BlockMetadataRanges PrefixRegexExpression::evaluateImpl(
   // Prefilter ?var > Id(prev("prefix)) && ?var < Id(next("prefix)).
   return AndExpression(std::move(lowerRefExpr), std::move(upperRefExpr))
       .evaluateImpl(vocab, idRange, blockRange, getTotalComplement);
-};
+}
 
 // SECTION RELATIONAL OPERATIONS
 //______________________________________________________________________________
@@ -520,7 +520,7 @@ RelationalExpression<Comparison>::logicalComplement() const {
       {P{LT, GE}, P{LE, GT}, P{GE, LT}, P{GT, LE}, P{EQ, NE}, P{NE, EQ}});
   return make<RelationalExpression<complementMap.at(Comparison)>>(
       rightSideReferenceValue_);
-};
+}
 
 //______________________________________________________________________________
 template <CompOp Comparison>
@@ -550,7 +550,7 @@ BlockMetadataRanges RelationalExpression<Comparison>::evaluateImpl(
                    relevantIdRanges, idRange, blockRange)
              : detail::mapping::mapValueIdItRangesToBlockItRanges(
                    relevantIdRanges, idRange, blockRange);
-};
+}
 
 //______________________________________________________________________________
 template <CompOp Comparison>
@@ -562,14 +562,14 @@ bool RelationalExpression<Comparison>::operator==(
     return false;
   }
   return rightSideReferenceValue_ == otherRelational->rightSideReferenceValue_;
-};
+}
 
 //______________________________________________________________________________
 template <CompOp Comparison>
 std::unique_ptr<PrefilterExpression> RelationalExpression<Comparison>::clone()
     const {
   return make<RelationalExpression<Comparison>>(rightSideReferenceValue_);
-};
+}
 
 //______________________________________________________________________________
 template <CompOp Comparison>
@@ -592,7 +592,7 @@ std::string RelationalExpression<Comparison>::asString(
   referenceValueToString(stream, rightSideReferenceValue_);
   stream << " ." << std::endl;
   return stream.str();
-};
+}
 
 // SECTION ISDATATYPE
 //______________________________________________________________________________
@@ -603,14 +603,14 @@ template <IsDatatype Datatype>
 std::unique_ptr<PrefilterExpression>
 IsDatatypeExpression<Datatype>::logicalComplement() const {
   return make<IsDatatypeExpression<Datatype>>(!isNegated_);
-};
+}
 
 //______________________________________________________________________________
 template <IsDatatype Datatype>
 std::unique_ptr<PrefilterExpression> IsDatatypeExpression<Datatype>::clone()
     const {
   return make<IsDatatypeExpression<Datatype>>(*this);
-};
+}
 
 //______________________________________________________________________________
 template <IsDatatype Datatype>
@@ -622,7 +622,7 @@ bool IsDatatypeExpression<Datatype>::operator==(
     return false;
   }
   return isNegated_ == otherIsDatatype->isNegated_;
-};
+}
 
 //______________________________________________________________________________
 template <IsDatatype Datatype>
@@ -632,7 +632,7 @@ std::string IsDatatypeExpression<Datatype>::asString(
       "Prefilter IsDatatypeExpression:", "\nPrefilter for datatype: ",
       getDatatypeIsTypeStr(Datatype),
       "\nis negated: ", isNegated_ ? "true" : "false", ".\n");
-};
+}
 
 //______________________________________________________________________________
 template <IsDatatype Datatype>
@@ -720,13 +720,13 @@ BlockMetadataRanges IsDatatypeExpression<Datatype>::evaluateImpl(
     return evaluateIsIriOrIsLiteralImpl<Datatype>(vocab, idRange, blockRange,
                                                   isNegated_);
   }
-};
+}
 
 // SECTION IS-IN-EXPRESSION (and NOT-IS-IN-EXPRESSION)
 //______________________________________________________________________________
 std::unique_ptr<PrefilterExpression> IsInExpression::logicalComplement() const {
   return make<IsInExpression>(referenceValues_, true);
-};
+}
 
 //______________________________________________________________________________
 bool IsInExpression::operator==(const PrefilterExpression& other) const {
@@ -737,12 +737,12 @@ bool IsInExpression::operator==(const PrefilterExpression& other) const {
 
   return isNegated_ == otherIsIn->isNegated_ &&
          ql::ranges::equal(referenceValues_, otherIsIn->referenceValues_);
-};
+}
 
 //______________________________________________________________________________
 std::unique_ptr<PrefilterExpression> IsInExpression::clone() const {
   return make<IsInExpression>(*this);
-};
+}
 
 //______________________________________________________________________________
 std::string IsInExpression::asString([[maybe_unused]] size_t depth) const {
@@ -750,7 +750,7 @@ std::string IsInExpression::asString([[maybe_unused]] size_t depth) const {
       "Prefilter IsInExpression\nisNegated: ", isNegated_ ? "true" : "false",
       "\nWith the following number of reference values: ",
       referenceValues_.size());
-};
+}
 
 //______________________________________________________________________________
 BlockMetadataRanges IsInExpression::evaluateImpl(
@@ -776,7 +776,7 @@ BlockMetadataRanges IsInExpression::evaluateImpl(
 
   return prefilterExpr.value()->evaluateImpl(vocab, idRange, blockRange,
                                              isNegated_);
-};
+}
 
 // SECTION LOGICAL OPERATIONS
 //______________________________________________________________________________
@@ -796,7 +796,7 @@ LogicalExpression<Operation>::logicalComplement() const {
     return make<OrExpression>(child1_->logicalComplement(),
                               child2_->logicalComplement());
   }
-};
+}
 
 //______________________________________________________________________________
 template <LogicalOperator Operation>
@@ -814,7 +814,7 @@ BlockMetadataRanges LogicalExpression<Operation>::evaluateImpl(
         child1_->evaluateImpl(vocab, idRange, blockRange, getTotalComplement),
         child2_->evaluateImpl(vocab, idRange, blockRange, getTotalComplement));
   }
-};
+}
 
 //______________________________________________________________________________
 template <LogicalOperator Operation>
@@ -827,14 +827,14 @@ bool LogicalExpression<Operation>::operator==(
   }
   return *child1_ == *otherlogical->child1_ &&
          *child2_ == *otherlogical->child2_;
-};
+}
 
 //______________________________________________________________________________
 template <LogicalOperator Operation>
 std::unique_ptr<PrefilterExpression> LogicalExpression<Operation>::clone()
     const {
   return make<LogicalExpression<Operation>>(child1_->clone(), child2_->clone());
-};
+}
 
 //______________________________________________________________________________
 template <LogicalOperator Operation>
@@ -849,7 +849,7 @@ std::string LogicalExpression<Operation>::asString(size_t depth) const {
          << "child1 {" << child1Info << "}"
          << "child2 {" << child2Info << "}" << std::endl;
   return stream.str();
-};
+}
 
 // SECTION NOT-EXPRESSION
 //______________________________________________________________________________
@@ -858,7 +858,7 @@ std::unique_ptr<PrefilterExpression> NotExpression::logicalComplement() const {
   // Therefore, we can simply return the child of the respective NOT
   // expression after undoing its previous complementation.
   return child_->logicalComplement();
-};
+}
 
 //______________________________________________________________________________
 BlockMetadataRanges NotExpression::evaluateImpl(const Vocab& vocab,
@@ -866,7 +866,7 @@ BlockMetadataRanges NotExpression::evaluateImpl(const Vocab& vocab,
                                                 BlockMetadataSpan blockRange,
                                                 bool getTotalComplement) const {
   return child_->evaluateImpl(vocab, idRange, blockRange, getTotalComplement);
-};
+}
 
 //______________________________________________________________________________
 bool NotExpression::operator==(const PrefilterExpression& other) const {
@@ -880,7 +880,7 @@ bool NotExpression::operator==(const PrefilterExpression& other) const {
 //______________________________________________________________________________
 std::unique_ptr<PrefilterExpression> NotExpression::clone() const {
   return make<NotExpression>((child_->clone()), true);
-};
+}
 
 //______________________________________________________________________________
 std::string NotExpression::asString(size_t depth) const {
@@ -964,7 +964,7 @@ std::unique_ptr<PrefilterExpression> makePrefilterExpressionYearImpl(
                        "the creation of PrefilterExpression on date-values: ",
                        getRelationalOpStr(comparison)));
   }
-};
+}
 
 //______________________________________________________________________________
 template <CompOp comparison>
@@ -1016,7 +1016,7 @@ static std::unique_ptr<PrefilterExpression> makePrefilterExpressionVecImpl(
       };
   return makePrefilterExpressionYearImpl(
       comparison, retrieveYearIntOrThrowErr(referenceValue));
-};
+}
 
 //______________________________________________________________________________
 template <CompOp comparison>

--- a/src/engine/sparqlExpressions/PrefilterExpressionIndex.h
+++ b/src/engine/sparqlExpressions/PrefilterExpressionIndex.h
@@ -236,7 +236,7 @@ class IsDatatypeExpression : public PrefilterExpression {
 
  public:
   explicit IsDatatypeExpression(bool isNegated = false)
-      : isNegated_(isNegated){};
+      : isNegated_(isNegated) {}
   std::unique_ptr<PrefilterExpression> logicalComplement() const override;
   bool operator==(const PrefilterExpression& other) const override;
   std::unique_ptr<PrefilterExpression> clone() const override;

--- a/src/engine/sparqlExpressions/PrefilterExpressionIndex.h
+++ b/src/engine/sparqlExpressions/PrefilterExpressionIndex.h
@@ -379,6 +379,36 @@ using OrExpression = prefilterExpressions::LogicalExpression<
     prefilterExpressions::LogicalOperator::OR>;
 
 namespace detail {
+
+class IsBoolExpression : public PrefilterExpression {
+  bool isNegated_;
+
+ public:
+  explicit IsBoolExpression(bool isNegated) : isNegated_{isNegated} {}
+  bool operator==(const PrefilterExpression& other) const override;
+  std::unique_ptr<PrefilterExpression> clone() const override;
+  std::string asString(size_t depth) const override;
+  std::unique_ptr<PrefilterExpression> logicalComplement() const override;
+  BlockMetadataRanges evaluateImpl(const Vocab& vocab,
+                                   const ValueIdSubrange& idRange,
+                                   BlockMetadataSpan blockRange,
+                                   bool getTotalComplement) const override;
+};
+
+class IsDateExpression : public PrefilterExpression {
+  bool isNegated_;
+
+ public:
+  explicit IsDateExpression(bool isNegated) : isNegated_{isNegated} {}
+  bool operator==(const PrefilterExpression& other) const override;
+  std::unique_ptr<PrefilterExpression> clone() const override;
+  std::string asString(size_t depth) const override;
+  std::unique_ptr<PrefilterExpression> logicalComplement() const override;
+  BlockMetadataRanges evaluateImpl(const Vocab& vocab,
+                                   const ValueIdSubrange& idRange,
+                                   BlockMetadataSpan blockRange,
+                                   bool getTotalComplement) const override;
+};
 //______________________________________________________________________________
 namespace logicalOps {
 

--- a/src/engine/sparqlExpressions/PrefilterExpressionIndex.h
+++ b/src/engine/sparqlExpressions/PrefilterExpressionIndex.h
@@ -379,36 +379,6 @@ using OrExpression = prefilterExpressions::LogicalExpression<
     prefilterExpressions::LogicalOperator::OR>;
 
 namespace detail {
-
-class IsBoolExpression : public PrefilterExpression {
-  bool isNegated_;
-
- public:
-  explicit IsBoolExpression(bool isNegated) : isNegated_{isNegated} {}
-  bool operator==(const PrefilterExpression& other) const override;
-  std::unique_ptr<PrefilterExpression> clone() const override;
-  std::string asString(size_t depth) const override;
-  std::unique_ptr<PrefilterExpression> logicalComplement() const override;
-  BlockMetadataRanges evaluateImpl(const Vocab& vocab,
-                                   const ValueIdSubrange& idRange,
-                                   BlockMetadataSpan blockRange,
-                                   bool getTotalComplement) const override;
-};
-
-class IsDateExpression : public PrefilterExpression {
-  bool isNegated_;
-
- public:
-  explicit IsDateExpression(bool isNegated) : isNegated_{isNegated} {}
-  bool operator==(const PrefilterExpression& other) const override;
-  std::unique_ptr<PrefilterExpression> clone() const override;
-  std::string asString(size_t depth) const override;
-  std::unique_ptr<PrefilterExpression> logicalComplement() const override;
-  BlockMetadataRanges evaluateImpl(const Vocab& vocab,
-                                   const ValueIdSubrange& idRange,
-                                   BlockMetadataSpan blockRange,
-                                   bool getTotalComplement) const override;
-};
 //______________________________________________________________________________
 namespace logicalOps {
 

--- a/src/global/ValueIdComparators.h
+++ b/src/global/ValueIdComparators.h
@@ -394,12 +394,6 @@ template <typename RandomIt>
 inline std::vector<std::pair<RandomIt, RandomIt>> getRangesForId(
     RandomIt begin, RandomIt end, ValueId valueId, Comparison comparison,
     bool removeEmptyRanges = true) {
-  // For the evaluation of FILTERs, comparisons that involve undefined values
-  // are always false.
-  if (valueId.getDatatype() == Datatype::Undefined) {
-    return {};
-  }
-  // This lambda enforces the invariants `non-empty` and `sorted`.
   switch (valueId.getDatatype()) {
     case Datatype::Double:
       return detail::simplifyRanges(
@@ -412,6 +406,9 @@ inline std::vector<std::pair<RandomIt, RandomIt>> getRangesForId(
                                              comparison),
           removeEmptyRanges);
     case Datatype::Undefined:
+      // For the evaluation of FILTERs, comparisons that involve undefined
+      // values are always false.
+      return {};
     case Datatype::VocabIndex:
     case Datatype::LocalVocabIndex:
     case Datatype::WordVocabIndex:

--- a/src/global/ValueIdComparators.h
+++ b/src/global/ValueIdComparators.h
@@ -377,7 +377,7 @@ auto simplifyRanges(std::vector<std::pair<RandomIt, RandomIt>> input,
     }
   }
   return result;
-};
+}
 
 }  // namespace detail
 

--- a/test/PrefilterExpressionIndexTest.cpp
+++ b/test/PrefilterExpressionIndexTest.cpp
@@ -873,6 +873,10 @@ TEST_F(PrefilterExpressionOnMetadataTest, testIsDatatypeExpression) {
                      {b18GapIriAndLiteral, b28});
   makeTestIsDatatype(isLit(), {b18GapIriAndLiteral}, false,
                      {b14, b15, b16, b18GapIriAndLiteral});
+  // Test inlined literals
+  makeTestIsDatatype(isLit(), {b6, b7}, false, {b1, b6, b7});
+  makeTestIsDatatype(isLit(), {b16, b13}, false, {b16, b13});
+  makeTestIsDatatype(isLit(), {b27}, false, {b27});
 
   // Test isIri
   // Blocks b22 - b25 contain IRI values.

--- a/test/PrefilterExpressionIndexTest.cpp
+++ b/test/PrefilterExpressionIndexTest.cpp
@@ -862,19 +862,23 @@ TEST_F(PrefilterExpressionOnMetadataTest, testPrefixRegexExpression) {
 //______________________________________________________________________________
 TEST_F(PrefilterExpressionOnMetadataTest, testIsDatatypeExpression) {
   // Test isLiteral
-  // Blocks b18 - b22 contain LITERAL values.
-  makeTestIsDatatype(isLit(), {b18, b19, b21, b22}, true);
+  // Blocks b18 - b22 contain arbitrary LITERAL values. The other blocks contain
+  // inlined literals like int, float, bool, date and point.
+  makeTestIsDatatype(isLit(),
+                     {b2,  b4,  b6,  b7,  b8,  b9,  b10, b11, b13, b14,
+                      b15, b16, b17, b18, b19, b21, b22, b25, b27, b28},
+                     true);
   // Block b18GapiriAndLiteral contains possibly hidden literal values.
   // Remark: b28 is a block holding mixed datatypes, this block should also be
   // returned with the current implementation of getSetDifference (see
   // PrefilterExpressionIndex.cpp).
-  makeTestIsDatatype(isLit(), {b18GapIriAndLiteral, b28}, false,
+  makeTestIsDatatype(isLit(), {b16, b17, b18GapIriAndLiteral, b27, b28}, false,
                      {b16, b17, b18GapIriAndLiteral, b27, b28});
   makeTestIsDatatype(isLit(), {b18GapIriAndLiteral}, false,
                      {b18GapIriAndLiteral});
   makeTestIsDatatype(isLit(), {b18GapIriAndLiteral, b28}, false,
                      {b18GapIriAndLiteral, b28});
-  makeTestIsDatatype(isLit(), {b18GapIriAndLiteral}, false,
+  makeTestIsDatatype(isLit(), {b14, b15, b16, b18GapIriAndLiteral}, false,
                      {b14, b15, b16, b18GapIriAndLiteral});
   // Test inlined literals
   makeTestIsDatatype(isLit(), {b6, b7}, false, {b1, b6, b7});
@@ -928,19 +932,15 @@ TEST_F(PrefilterExpressionOnMetadataTest, testIsDatatypeExpression) {
 
   // Test !isLiteral
   // Blocks b19 - b21 contain only IRI related Ids (not contained in expected)
-  makeTestIsDatatype(notExpr(isLit()),
-                     {b1,  b2,  b4,  b6,  b7,  b8,  b9,  b10, b11, b13, b14,
-                      b15, b16, b17, b18, b22, b23, b24, b25, b27, b28},
-                     true);
+  makeTestIsDatatype(notExpr(isLit()), {b1, b2, b22, b23, b24, b25, b28}, true);
   // b18GapIriAndLiteral should be considered relevant when evaluating
   // expression !isLit.
   makeTestIsDatatype(notExpr(isLit()), {b18GapIriAndLiteral}, false,
                      {b18GapIriAndLiteral});
-  makeTestIsDatatype(notExpr(isLit()), {b1, b2, b17, b18GapIriAndLiteral},
-                     false, {b1, b2, b17, b18GapIriAndLiteral});
-  makeTestIsDatatype(notExpr(isLit()),
-                     {b1, b2, b17, b18GapIriAndLiteral, b27, b28}, false,
-                     {b1, b2, b17, b18GapIriAndLiteral, b27, b28});
+  makeTestIsDatatype(notExpr(isLit()), {b1, b2, b18GapIriAndLiteral}, false,
+                     {b1, b2, b17, b18GapIriAndLiteral});
+  makeTestIsDatatype(notExpr(isLit()), {b1, b2, b18GapIriAndLiteral, b28},
+                     false, {b1, b2, b17, b18GapIriAndLiteral, b27, b28});
 
   // Test !isIri
   // Blocks b23 - b24 contain only IRI related Ids (not contained in expected)

--- a/test/PrefilterExpressionIndexTest.cpp
+++ b/test/PrefilterExpressionIndexTest.cpp
@@ -447,7 +447,10 @@ class PrefilterExpressionOnMetadataTest : public ::testing::Test {
   auto makeTestIsDatatype(std::unique_ptr<PrefilterExpression> expr,
                           std::vector<CompressedBlockMetadata>&& expected,
                           bool testIsIriOrIsLit = false,
-                          std::vector<CompressedBlockMetadata>&& input = {}) {
+                          std::vector<CompressedBlockMetadata>&& input = {},
+                          ad_utility::source_location loc =
+                              ad_utility::source_location::current()) {
+    auto t = generateLocationTrace(loc);
     // The evaluation implementation of `isLiteral()` and `isIri()` uses two
     // conjuncted relational `PrefilterExpression`s. Thus we have to add all
     // CompressedBlockMetadata values containing mixed datatypes.


### PR DESCRIPTION
Since #1876, index scans in conjunction with `isLiteral` can be pre-filtered. However, this optimization falsely filtered out blocks with only bools, ints, and doubles, which are literals too. In particular, the result for `?count_yes` in the following query was wrong so far. This is now fixed, and the results for `?count_yes` and `?count_no` correctly sum to the result for `?cout_all` https://qlever.cs.uni-freiburg.de/wikidata/QQfbH7
```sparql
SELECT * WHERE {
  { SELECT (COUNT(*) AS ?count_yes) { ?s ?p ?o . FILTER isLiteral(?o) } }
  { SELECT (COUNT(*) AS ?count_no) { ?s ?p ?o . FILTER (!isLiteral(?o)) } }
  { SELECT (COUNT(*) AS ?tcount_all) { ?s ?p ?o . } }
}
```