### PR TITLE
Implement mirrored index nested loop join for `MINUS` and `EXISTS`

### DIFF
--- a/src/engine/ExistsJoin.cpp
+++ b/src/engine/ExistsJoin.cpp
@@ -70,6 +70,9 @@ size_t ExistsJoin::getResultWidth() const {
 
 // ____________________________________________________________________________
 std::vector<ColumnIndex> ExistsJoin::resultSortedOn() const {
+  if (rightIndexNestedLoopJoinIsPossible()) {
+    return left_->getRootOperation()->getChildren().at(0)->resultSortedOn();
+  }
   // We add one column to `left_`, but do not change the order of the rows.
   return left_->resultSortedOn();
 }
@@ -271,16 +274,19 @@ std::unique_ptr<Operation> ExistsJoin::cloneImpl() const {
 }
 
 // _____________________________________________________________________________
-std::optional<Result> ExistsJoin::tryIndexNestedLoopJoinIfSuitable() {
-  auto alwaysDefined = [this]() {
-    return qlever::joinHelpers::joinColumnsAreAlwaysDefined(joinColumns_, left_,
-                                                            right_);
-  };
+bool ExistsJoin::rightIndexNestedLoopJoinIsPossible() const {
+  auto sort = std::dynamic_pointer_cast<Sort>(left_->getRootOperation());
+  return sort && left_->getSizeEstimate() >= right_->getSizeEstimate() &&
+         qlever::joinHelpers::joinColumnsAreAlwaysDefined(joinColumns_, left_,
+                                                          right_);
+}
+
+// _____________________________________________________________________________
+std::optional<Result> ExistsJoin::tryLeftIndexNestedLoopJoinIfSuitable() {
   // This algorithm only works well if the left side is smaller and we can avoid
   // sorting the right side. It currently doesn't support undef.
   auto sort = std::dynamic_pointer_cast<Sort>(right_->getRootOperation());
-  if (!sort || left_->getSizeEstimate() > right_->getSizeEstimate() ||
-      !alwaysDefined()) {
+  if (!sort || left_->getSizeEstimate() > right_->getSizeEstimate()) {
     return std::nullopt;
   }
 
@@ -294,12 +300,56 @@ std::optional<Result> ExistsJoin::tryIndexNestedLoopJoinIfSuitable() {
   result.addEmptyColumn();
   ad_utility::chunkedCopy(
       ql::views::transform(
-          ad_utility::OwningView{nestedLoopJoin.computeExistance()},
+          ad_utility::OwningView{nestedLoopJoin.computeLeftExistance()},
           [](char tracker) { return Id::makeFromBool(tracker != 0); }),
       result.getColumn(result.numColumns() - 1).begin(),
       qlever::joinHelpers::CHUNK_SIZE, [this]() { checkCancellation(); });
   return std::optional{
       Result{std::move(result), resultSortedOn(), std::move(localVocab)}};
+}
+
+// _____________________________________________________________________________
+std::optional<Result> ExistsJoin::tryRightIndexNestedLoopJoinIfSuitable() {
+  // This algorithm only works well if the right side is smaller and we can
+  // avoid sorting the left side. It currently doesn't support undef.
+  if (!rightIndexNestedLoopJoinIsPossible()) {
+    return std::nullopt;
+  }
+
+  auto leftRes = qlever::joinHelpers::computeResultSkipChild(
+      std::dynamic_pointer_cast<Sort>(left_->getRootOperation()));
+  auto rightRes = right_->getResult(false);
+
+  joinAlgorithms::indexNestedLoop::IndexNestedLoopJoin nestedLoopJoin{
+      joinColumns_, std::move(leftRes), std::move(rightRes)};
+  auto result = nestedLoopJoin.computeRightExistance(
+      [this](auto&& idTable, LocalVocab localVocab,
+             const std::vector<bool, ad_utility::AllocatorWithLimit<bool>>&
+                 matchingTracker) {
+        IdTable resultTable = idTable.moveOrClone();
+        resultTable.addEmptyColumn();
+        ad_utility::chunkedCopy(
+            ql::views::transform(
+                matchingTracker,
+                [](bool tracker) { return Id::makeFromBool(tracker); }),
+            resultTable.getColumn(resultTable.numColumns() - 1).begin(),
+            qlever::joinHelpers::CHUNK_SIZE, [this]() { checkCancellation(); });
+        return Result::IdTableVocabPair{std::move(resultTable),
+                                        std::move(localVocab)};
+      });
+  return std::optional{Result{std::move(result), resultSortedOn()}};
+}
+
+// _____________________________________________________________________________
+std::optional<Result> ExistsJoin::tryIndexNestedLoopJoinIfSuitable() {
+  if (!qlever::joinHelpers::joinColumnsAreAlwaysDefined(joinColumns_, left_,
+                                                        right_)) {
+    return std::nullopt;
+  }
+  if (auto leftResult = tryRightIndexNestedLoopJoinIfSuitable()) {
+    return leftResult;
+  }
+  return tryLeftIndexNestedLoopJoinIfSuitable();
 }
 
 // _____________________________________________________________________________

--- a/src/engine/ExistsJoin.h
+++ b/src/engine/ExistsJoin.h
@@ -82,6 +82,12 @@ class ExistsJoin : public Operation {
  private:
   std::unique_ptr<Operation> cloneImpl() const override;
 
+  bool rightIndexNestedLoopJoinIsPossible() const;
+
+  std::optional<Result> tryLeftIndexNestedLoopJoinIfSuitable();
+
+  std::optional<Result> tryRightIndexNestedLoopJoinIfSuitable();
+
   // Nested loop join optimization than can apply when a memory intensive sort
   // can be avoided this way.
   std::optional<Result> tryIndexNestedLoopJoinIfSuitable();

--- a/src/engine/ExistsJoin.h
+++ b/src/engine/ExistsJoin.h
@@ -97,14 +97,15 @@ class ExistsJoin : public Operation {
   // materialized and sorted, and the left side is unsorted. Only returns a
   // result when `rightIndexNestedLoopJoinIsPossible()` returns true, in this
   // case the result is also unsorted.
-  std::optional<Result> tryRightIndexNestedLoopJoinIfSuitable();
+  std::optional<Result> tryRightIndexNestedLoopJoinIfSuitable(
+      bool requestLaziness);
 
   // Nested loop join optimization than can apply when a memory intensive sort
   // can be avoided this way. This currently only works when we can statically
   // guarantee that no undef values are found in the join columns. The
   // implementation first tries `tryRightIndexNestedLoopJoinIfSuitable` and then
   // `tryLeftIndexNestedLoopJoinIfSuitable`.
-  std::optional<Result> tryIndexNestedLoopJoinIfSuitable();
+  std::optional<Result> tryIndexNestedLoopJoinIfSuitable(bool requestLaziness);
 
   Result computeResult(bool requestLaziness) override;
 
@@ -115,7 +116,8 @@ class ExistsJoin : public Operation {
                         std::shared_ptr<const Result> right,
                         bool requestLaziness);
 
-  FRIEND_TEST(Exists, addExistsJoinsToSubtreeDoesntCollideForHiddenVariables);
+  FRIEND_TEST(ExistsJoin,
+              addExistsJoinsToSubtreeDoesntCollideForHiddenVariables);
 };
 
 #endif  // QLEVER_SRC_ENGINE_EXISTSJOIN_H

--- a/src/engine/JoinHelpers.h
+++ b/src/engine/JoinHelpers.h
@@ -177,14 +177,14 @@ inline bool joinColumnsAreAlwaysDefined(
 // Helper function that is commonly used to skip sort operations and use an
 // alternative algorithm that doesn't require sorting instead.
 inline std::shared_ptr<const Result> computeResultSkipChild(
-    const std::shared_ptr<Operation>& operation) {
+    const std::shared_ptr<Operation>& operation, bool requestLaziness) {
   auto children = operation->getChildren();
   AD_CONTRACT_CHECK(children.size() == 1);
   auto child = children.at(0);
   auto runtimeInfoChildren = child->getRootOperation()->getRuntimeInfoPointer();
   operation->updateRuntimeInformationWhenOptimizedOut({runtimeInfoChildren});
 
-  return child->getResult(true);
+  return child->getResult(requestLaziness);
 }
 }  // namespace qlever::joinHelpers
 

--- a/src/engine/Minus.h
+++ b/src/engine/Minus.h
@@ -99,14 +99,15 @@ class Minus : public Operation {
   // materialized and sorted, and the left side is unsorted. Only returns a
   // result when `rightIndexNestedLoopJoinIsPossible()` returns true, in this
   // case the result is also unsorted.
-  std::optional<Result> tryRightIndexNestedLoopJoinIfSuitable();
+  std::optional<Result> tryRightIndexNestedLoopJoinIfSuitable(
+      bool requestLaziness);
 
   // Nested loop join optimization than can apply when a memory intensive sort
   // can be avoided this way. This currently only works when we can statically
   // guarantee that no undef values are found in the join columns. The
   // implementation first tries `tryRightIndexNestedLoopJoinIfSuitable` and then
   // `tryLeftIndexNestedLoopJoinIfSuitable`.
-  std::optional<Result> tryIndexNestedLoopJoinIfSuitable();
+  std::optional<Result> tryIndexNestedLoopJoinIfSuitable(bool requestLaziness);
 
   // Lazily compute the minus join of two results when at least one of the
   // results is computed lazily. This currently only works if we have just a

--- a/src/engine/Minus.h
+++ b/src/engine/Minus.h
@@ -84,8 +84,28 @@ class Minus : public Operation {
  private:
   std::unique_ptr<Operation> cloneImpl() const override;
 
+  // Return true if the size estimate for the right side is smaller or equal
+  // than the estimate of the right side, a sort on the left can be skipped and
+  // all join columns are statically guaranteed to not contain undef values.
+  bool rightIndexNestedLoopJoinIsPossible() const;
+
+  // Specialized algorithm that performs a join when the left side is fully
+  // materialized and sorted, and the right side is unsorted. Only returns a
+  // result when the size estimate for the left side is smaller or equal than
+  // the estimate of the right side and a sort on the left can be skipped.
+  std::optional<Result> tryLeftIndexNestedLoopJoinIfSuitable();
+
+  // Specialized algorithm that performs a join when the right side is fully
+  // materialized and sorted, and the left side is unsorted. Only returns a
+  // result when `rightIndexNestedLoopJoinIsPossible()` returns true, in this
+  // case the result is also unsorted.
+  std::optional<Result> tryRightIndexNestedLoopJoinIfSuitable();
+
   // Nested loop join optimization than can apply when a memory intensive sort
-  // can be avoided this way.
+  // can be avoided this way. This currently only works when we can statically
+  // guarantee that no undef values are found in the join columns. The
+  // implementation first tries `tryRightIndexNestedLoopJoinIfSuitable` and then
+  // `tryLeftIndexNestedLoopJoinIfSuitable`.
   std::optional<Result> tryIndexNestedLoopJoinIfSuitable();
 
   // Lazily compute the minus join of two results when at least one of the

--- a/src/engine/OptionalJoin.cpp
+++ b/src/engine/OptionalJoin.cpp
@@ -522,7 +522,7 @@ std::optional<Result> OptionalJoin::tryIndexNestedLoopJoinIfSuitable(
     return std::nullopt;
   }
   auto leftRes = _left->getResult(false);
-  auto rightRes = computeResultSkipChild(_right->getRootOperation());
+  auto rightRes = computeResultSkipChild(_right->getRootOperation(), true);
 
   LocalVocab localVocab = leftRes->getCopyOfLocalVocab();
   joinAlgorithms::indexNestedLoop::IndexNestedLoopJoin nestedLoopJoin{


### PR DESCRIPTION
This PR extends the index nested loop join algorithm first introduced in #2251 to also work on a small right join side. In particular this fixes #2174 by making the query reported fast and memory efficient.