### PR TITLE
Make `GeometryInfo` helper classes immutable

### DIFF
--- a/src/rdfTypes/GeometryInfo.h
+++ b/src/rdfTypes/GeometryInfo.h
@@ -80,9 +80,7 @@ struct GeometryType {
   // Returns an IRI without brackets of the OGC Simple Features geometry type.
   std::optional<std::string_view> asIri() const;
 
-  bool operator==(const GeometryType& other) const {
-    return type_ == other.type_;
-  }
+  constexpr bool operator==(const GeometryType& other) const = default;
 };
 
 // Forward declaration for concept

--- a/src/rdfTypes/GeometryInfo.h
+++ b/src/rdfTypes/GeometryInfo.h
@@ -80,7 +80,9 @@ struct GeometryType {
   // Returns an IRI without brackets of the OGC Simple Features geometry type.
   std::optional<std::string_view> asIri() const;
 
-  bool operator==(GeometryType& other) { return type_ == other.type_; }
+  bool operator==(const GeometryType& other) const {
+    return type_ == other.type_;
+  }
 };
 
 // Forward declaration for concept

--- a/src/rdfTypes/GeometryInfo.h
+++ b/src/rdfTypes/GeometryInfo.h
@@ -21,10 +21,14 @@ namespace ad_utility {
 
 // Represents the centroid of a geometry as a `GeoPoint`.
 struct Centroid {
+ private:
   GeoPoint centroid_;
 
-  Centroid(GeoPoint centroid) : centroid_{centroid} {};
+ public:
+  explicit Centroid(GeoPoint centroid) : centroid_{centroid} {};
   Centroid(double lat, double lng) : centroid_{lat, lng} {};
+
+  GeoPoint centroid() const { return centroid_; };
 };
 
 // The individual coordinates describing the bounding box.
@@ -33,8 +37,19 @@ enum class BoundingCoordinate { MIN_X, MIN_Y, MAX_X, MAX_Y };
 // Represents the bounding box of a geometry by two `GeoPoint`s for lower left
 // corner and upper right corner.
 struct BoundingBox {
+ private:
   GeoPoint lowerLeft_;
   GeoPoint upperRight_;
+
+ public:
+  BoundingBox(GeoPoint lowerLeft, GeoPoint upperRight)
+      : lowerLeft_{lowerLeft}, upperRight_{upperRight} {};
+
+  GeoPoint lowerLeft() const { return lowerLeft_; }
+  GeoPoint upperRight() const { return upperRight_; }
+  std::pair<GeoPoint, GeoPoint> pair() const {
+    return {lowerLeft_, upperRight_};
+  }
 
   std::string asWkt() const;
 
@@ -54,11 +69,18 @@ struct EncodedBoundingBox {
 // Represents the WKT geometry type, for the meaning see `libspatialjoin`'s
 // `WKTType`.
 struct GeometryType {
+ private:
   uint8_t type_;
-  GeometryType(uint8_t type) : type_{type} {};
+
+ public:
+  explicit GeometryType(uint8_t type) : type_{type} {};
+
+  uint8_t type() const { return type_; };
 
   // Returns an IRI without brackets of the OGC Simple Features geometry type.
   std::optional<std::string_view> asIri() const;
+
+  bool operator==(GeometryType& other) { return type_ == other.type_; }
 };
 
 // Forward declaration for concept

--- a/src/rdfTypes/GeometryInfoHelpersImpl.h
+++ b/src/rdfTypes/GeometryInfoHelpersImpl.h
@@ -90,7 +90,7 @@ inline GeoPoint utilPointToGeoPoint(const Point<CoordType>& point) {
 inline std::optional<Centroid> centroidAsGeoPoint(const ParsedWkt& geometry) {
   auto uPoint = std::visit([](auto& val) { return centroid(val); }, geometry);
   try {
-    return utilPointToGeoPoint(uPoint);
+    return Centroid{utilPointToGeoPoint(uPoint)};
   } catch (const CoordinateOutOfRangeException& ex) {
     AD_LOG_DEBUG << "Cannot compute centroid due to invalid "
                     "coordinates. Error: "
@@ -133,8 +133,8 @@ inline std::string boundingBoxAsWkt(const GeoPoint& lowerLeft,
 // Convert a `BoundingBox` struct holding two `GeoPoint`s to a `Box` struct as
 // required by `pb_util`.
 inline Box<CoordType> boundingBoxToUtilBox(const BoundingBox& boundingBox) {
-  return {geoPointToUtilPoint(boundingBox.lowerLeft_),
-          geoPointToUtilPoint(boundingBox.upperRight_)};
+  return {geoPointToUtilPoint(boundingBox.lowerLeft()),
+          geoPointToUtilPoint(boundingBox.upperRight())};
 }
 
 // Constexpr helper to add the required suffixes to the OGC simple features IRI

--- a/src/util/GeoSparqlHelpers.h
+++ b/src/util/GeoSparqlHelpers.h
@@ -113,7 +113,7 @@ class WktCentroid {
     if (!geom.has_value()) {
       return ValueId::makeUndefined();
     }
-    return ValueId::makeFromGeoPoint(geom.value().centroid_);
+    return ValueId::makeFromGeoPoint(geom.value().centroid());
   }
 };
 

--- a/test/GeometryInfoTest.cpp
+++ b/test/GeometryInfoTest.cpp
@@ -57,10 +57,10 @@ const auto getAllTestLiterals = []() {
 TEST(GeometryInfoTest, BasicTests) {
   // Constructor and getters
   GeometryInfo g{5, {{1, 1}, {2, 2}}, {1.5, 1.5}};
-  ASSERT_EQ(g.getWktType().type_, 5);
-  ASSERT_NEAR(g.getCentroid().centroid_.getLat(), 1.5, 0.0001);
-  ASSERT_NEAR(g.getCentroid().centroid_.getLng(), 1.5, 0.0001);
-  auto [lowerLeft, upperRight] = g.getBoundingBox();
+  ASSERT_EQ(g.getWktType().type(), 5);
+  ASSERT_NEAR(g.getCentroid().centroid().getLat(), 1.5, 0.0001);
+  ASSERT_NEAR(g.getCentroid().centroid().getLng(), 1.5, 0.0001);
+  auto [lowerLeft, upperRight] = g.getBoundingBox().pair();
   ASSERT_NEAR(lowerLeft.getLat(), 1, 0.0001);
   ASSERT_NEAR(lowerLeft.getLng(), 1, 0.0001);
   ASSERT_NEAR(upperRight.getLat(), 2, 0.0001);
@@ -114,12 +114,12 @@ TEST(GeometryInfoTest, FromWktLiteral) {
 TEST(GeometryInfoTest, FromGeoPoint) {
   GeoPoint p{1.234, 5.678};
   auto g = GeometryInfo::fromGeoPoint(p);
-  GeometryInfo exp{1, {p, p}, p};
+  GeometryInfo exp{1, {p, p}, Centroid{p}};
   checkGeoInfo(g, exp);
 
   GeoPoint p2{0, 0};
   auto g2 = GeometryInfo::fromGeoPoint(p2);
-  GeometryInfo exp2{1, {p2, p2}, p2};
+  GeometryInfo exp2{1, {p2, p2}, Centroid{p2}};
   checkGeoInfo(g2, exp2);
 }
 
@@ -213,7 +213,7 @@ TEST(GeometryInfoTest, GeometryInfoHelpers) {
   checkBoundingBox(bb1, bbExp1);
 
   auto bb1Wkt =
-      boundingBoxAsWkt(bb1.value().lowerLeft_, bb1.value().upperRight_);
+      boundingBoxAsWkt(bb1.value().lowerLeft(), bb1.value().upperRight());
   EXPECT_EQ(bb1Wkt, "POLYGON((3 4,3 4,3 4,3 4,3 4))");
 
   EXPECT_EQ(addSfPrefix<"Example">(), "http://www.opengis.net/ont/sf#Example");
@@ -233,10 +233,10 @@ TEST(GeometryInfoTest, InvalidLiteralAdHocCompuation) {
 // ____________________________________________________________________________
 TEST(GeometryInfoTest, CoordinateOutOfRangeDoesNotThrow) {
   checkInvalidLiteral(litCoordOutOfRange, true);
-  checkGeometryType(GeometryInfo::getWktType(litCoordOutOfRange).value().type_,
-                    {2});
-  checkGeometryType(
-      GeometryInfo::getRequestedInfo<GeometryType>(litCoordOutOfRange), {2});
+  EXPECT_EQ(GeometryInfo::getWktType(litCoordOutOfRange).value(),
+            std::optional<GeometryType>{GeometryType{2}});
+  EXPECT_EQ(GeometryInfo::getRequestedInfo<GeometryType>(litCoordOutOfRange),
+            std::optional<GeometryType>{GeometryType{2}});
 }
 
 // _____________________________________________________________________________

--- a/test/GeometryInfoTestHelpers.h
+++ b/test/GeometryInfoTestHelpers.h
@@ -20,18 +20,6 @@ using Loc = source_location;
 // instances of the associated helper classes.
 
 // ____________________________________________________________________________
-inline void checkGeometryType(std::optional<GeometryType> a,
-                              std::optional<GeometryType> b,
-                              Loc sourceLocation = Loc::current()) {
-  auto l = generateLocationTrace(sourceLocation);
-  ASSERT_EQ(a.has_value(), b.has_value());
-  if (!a.has_value()) {
-    return;
-  }
-  ASSERT_EQ(a.value().type_, b.value().type_);
-}
-
-// ____________________________________________________________________________
 inline void checkCentroid(std::optional<Centroid> a, std::optional<Centroid> b,
                           Loc sourceLocation = Loc::current()) {
   auto l = generateLocationTrace(sourceLocation);
@@ -39,9 +27,9 @@ inline void checkCentroid(std::optional<Centroid> a, std::optional<Centroid> b,
   if (!a.has_value()) {
     return;
   }
-  ASSERT_NEAR(a.value().centroid_.getLat(), b.value().centroid_.getLat(),
+  ASSERT_NEAR(a.value().centroid().getLat(), b.value().centroid().getLat(),
               0.001);
-  ASSERT_NEAR(a.value().centroid_.getLng(), b.value().centroid_.getLng(),
+  ASSERT_NEAR(a.value().centroid().getLng(), b.value().centroid().getLng(),
               0.001);
 }
 
@@ -54,8 +42,8 @@ inline void checkBoundingBox(std::optional<BoundingBox> a,
   if (!a.has_value()) {
     return;
   }
-  auto [all, aur] = a.value();
-  auto [bll, bur] = b.value();
+  auto [all, aur] = a.value().pair();
+  auto [bll, bur] = b.value().pair();
   ASSERT_NEAR(all.getLat(), bll.getLat(), 0.001);
   ASSERT_NEAR(all.getLng(), bll.getLng(), 0.001);
   ASSERT_NEAR(aur.getLng(), bur.getLng(), 0.001);
@@ -75,7 +63,7 @@ inline void checkGeoInfo(std::optional<GeometryInfo> actual,
   auto a = actual.value();
   auto b = expected.value();
 
-  checkGeometryType(a.getWktType(), b.getWktType());
+  EXPECT_EQ(a.getWktType(), b.getWktType());
 
   checkCentroid(a.getCentroid(), b.getCentroid());
 
@@ -94,8 +82,8 @@ inline void checkRequestedInfoForInstance(
                    sourceLocation);
   checkCentroid(gi.getCentroid(), gi.getRequestedInfo<Centroid>(),
                 sourceLocation);
-  checkGeometryType(gi.getWktType(), gi.getRequestedInfo<GeometryType>(),
-                    sourceLocation);
+  EXPECT_EQ(std::optional<GeometryType>{gi.getWktType()},
+            gi.getRequestedInfo<GeometryType>());
 }
 
 // ____________________________________________________________________________
@@ -110,8 +98,8 @@ inline void checkRequestedInfoForWktLiteral(
                    GeometryInfo::getRequestedInfo<BoundingBox>(wkt));
   checkCentroid(gi.getCentroid(),
                 GeometryInfo::getRequestedInfo<Centroid>(wkt));
-  checkGeometryType(gi.getWktType(),
-                    GeometryInfo::getRequestedInfo<GeometryType>(wkt));
+  EXPECT_EQ(std::optional<GeometryType>{gi.getWktType()},
+            GeometryInfo::getRequestedInfo<GeometryType>(wkt));
 }
 
 // ____________________________________________________________________________

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -1410,13 +1410,15 @@ TEST(SparqlExpression, geoSparqlExpressions) {
       v,  // POINT(24.3, 26.8)
       geoLit("LINESTRING(2 8, 4 6)"),
       geoLit("POLYGON((2 4, 4 4, 4 2, 2 2, 2 4))"),
-      lit("BLABLIBLU(1 1, 2 2)"),
-      geoLit("BLABLIBLU(1 1, 2 2)"),
+      lit("BLABLIBLU(1 1, 2 2)")
+      // TODO<ullingerc> Handle invalid geo literals gracefully. Then add
+      // geoLit("BLABLIBLU(1 1, 2 2)")
   };
-  checkMinX(boundingCoordInputs, Ids{U, U, D(24.3), D(2), D(2), U});
-  checkMinY(boundingCoordInputs, Ids{U, U, D(26.8), D(6), D(2), U});
-  checkMaxX(boundingCoordInputs, Ids{U, U, D(24.3), D(4), D(4), U});
-  checkMaxY(boundingCoordInputs, Ids{U, U, D(26.8), D(8), D(4), U});
+  using IdVec = std::vector<ValueId>;
+  checkMinX(boundingCoordInputs, IdVec{U, U, D(24.3), D(2), D(2), U});
+  checkMinY(boundingCoordInputs, IdVec{U, U, D(26.8), D(6), D(2), U});
+  checkMaxX(boundingCoordInputs, IdVec{U, U, D(24.3), D(4), D(4), U});
+  checkMaxY(boundingCoordInputs, IdVec{U, U, D(26.8), D(8), D(4), U});
 }
 
 // ________________________________________________________________________________________

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -1410,15 +1410,13 @@ TEST(SparqlExpression, geoSparqlExpressions) {
       v,  // POINT(24.3, 26.8)
       geoLit("LINESTRING(2 8, 4 6)"),
       geoLit("POLYGON((2 4, 4 4, 4 2, 2 2, 2 4))"),
-      lit("BLABLIBLU(1 1, 2 2)")
-      // TODO<ullingerc> Handle invalid geo literals gracefully. Then add
-      // geoLit("BLABLIBLU(1 1, 2 2)")
+      lit("BLABLIBLU(1 1, 2 2)"),
+      geoLit("BLABLIBLU(1 1, 2 2)"),
   };
-  using IdVec = std::vector<ValueId>;
-  checkMinX(boundingCoordInputs, IdVec{U, U, D(24.3), D(2), D(2), U});
-  checkMinY(boundingCoordInputs, IdVec{U, U, D(26.8), D(6), D(2), U});
-  checkMaxX(boundingCoordInputs, IdVec{U, U, D(24.3), D(4), D(4), U});
-  checkMaxY(boundingCoordInputs, IdVec{U, U, D(26.8), D(8), D(4), U});
+  checkMinX(boundingCoordInputs, Ids{U, U, D(24.3), D(2), D(2), U});
+  checkMinY(boundingCoordInputs, Ids{U, U, D(26.8), D(6), D(2), U});
+  checkMaxX(boundingCoordInputs, Ids{U, U, D(24.3), D(4), D(4), U});
+  checkMaxY(boundingCoordInputs, Ids{U, U, D(26.8), D(8), D(4), U});
 }
 
 // ________________________________________________________________________________________


### PR DESCRIPTION
So far, the helper classes `Centroid`, `BoundingBox`, and `GeometryType` defined in `GeometryInfo.h` were simple `struct`s with public member variables. Now each of them is an immutable class, with private member variables, an explicit constructor and const accessors. Preparation for #2238