### PR TITLE
Make code compatible with LLVM 19

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -258,7 +258,7 @@ set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
 FetchContent_Declare(
         ctre
         GIT_REPOSITORY https://github.com/hanickadot/compile-time-regular-expressions.git
-        GIT_TAG eb9577aae3515d14e6c5564f9aeb046d2e7c1124 # v3.9.0
+        GIT_TAG e34c26ba149b9fd9c34aa0f678e39739641a0d1e # v3.10.0
 )
 
 ################################

--- a/src/engine/sparqlExpressions/SparqlExpressionTypes.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionTypes.h
@@ -298,7 +298,7 @@ template <typename SpecializedFunctionsTuple, typename... Operands>
 constexpr bool isAnySpecializedFunctionPossible(SpecializedFunctionsTuple&& tup,
                                                 const Operands&... operands) {
   auto onPack = [&](auto&&... fs) constexpr {
-    return (... || fs.template areAllOperandsValid(operands...));
+    return (... || fs.areAllOperandsValid(operands...));
   };
 
   return std::apply(onPack, tup);

--- a/src/parser/GraphPatternOperation.h
+++ b/src/parser/GraphPatternOperation.h
@@ -22,7 +22,6 @@
 #include "rdfTypes/Variable.h"
 #include "util/TransparentFunctors.h"
 #include "util/VisitMixin.h"
-#include "util/http/HttpUtils.h"
 
 // First some forward declarations.
 // TODO<joka921> More stuff should consistently be in the `parsedQuery`

--- a/src/util/MemorySize/MemorySize.cpp
+++ b/src/util/MemorySize/MemorySize.cpp
@@ -69,12 +69,16 @@ MemorySize MemorySize::parse(std::string_view str) {
   constexpr ctll::fixed_string regex =
       "(?<amount>\\d+(?:\\.\\d+)?)\\s*(?<unit>[kKmMgGtT][bB]?|[bB])";
   if (auto matcher = ctre::match<regex>(str)) {
-    auto amountGroup = matcher.get<"amount">();
-    double amount = amountGroup.to_number<double>();
+    auto amountString = matcher.get<"amount">().to_view();
+    // Even though CTRE supports to_number() with double values, this relies on
+    // `std::from_chars` which is currently not supported by the standard
+    // library used by our macOS build.
+    double amount;
+    absl::from_chars(amountString.begin(), amountString.end(), amount);
     auto unitString = matcher.get<"unit">().to_view();
     switch (std::tolower(unitString.at(0))) {
       case 'b':
-        if (ad_utility::contains(amountGroup.to_view(), '.')) {
+        if (ad_utility::contains(amountString, '.')) {
           throw std::runtime_error(absl::StrCat(
               "'", str,
               "' could not be parsed as a memory size. When using bytes as "

--- a/src/util/MemorySize/MemorySize.cpp
+++ b/src/util/MemorySize/MemorySize.cpp
@@ -80,7 +80,7 @@ MemorySize MemorySize::parse(std::string_view str) {
               "' could not be parsed as a memory size. When using bytes as "
               "units only unsigned integers are allowed."));
         }
-        return MemorySize::bytes(amount);
+        return MemorySize::bytes(static_cast<size_t>(amount));
       case 'k':
         return MemorySize::kilobytes(amount);
       case 'm':


### PR DESCRIPTION
1. Update to the lastest version of `CTRE` (Compile Time Regular Expressions)
2. Remove redundant use of the keyword `template`
3. Correct a comment in `MemorySize.cpp`