### PR TITLE
Start migrating the `RuntimeParameter`s to C++17

### DIFF
--- a/src/ServerMain.cpp
+++ b/src/ServerMain.cpp
@@ -29,7 +29,7 @@ namespace po = boost::program_options;
 int main(int argc, char** argv) {
   // TODO<joka921> This is a hack, because the unit tests currently don't work
   // with the strip-columns feature.
-  RuntimeParameters().set<"strip-columns">(true);
+  runtimeParametersNew().wlock()->stripColumns_.set(true);
   // Copy the git hash and datetime of compilation (which require relinking)
   // to make them accessible to other parts of the code
   qlever::version::copyVersionInfo();

--- a/src/engine/GroupByImpl.cpp
+++ b/src/engine/GroupByImpl.cpp
@@ -51,7 +51,7 @@ GroupByImpl::GroupByImpl(QueryExecutionContext* qec,
 
   // The subtrees of a GROUP BY only need to compute columns that are grouped or
   // used in any of the aggregate aliases.
-  if (RuntimeParameters().get<"strip-columns">()) {
+  if (runtimeParametersNew().rlock()->stripColumns_.get()) {
     std::set<Variable> usedVariables{_groupByVariables.begin(),
                                      _groupByVariables.end()};
     for (const auto& alias : _aliases) {

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -3187,7 +3187,7 @@ void QueryPlanner::GraphPatternPlanner::visitSubquery(
   auto setSelectedVariables = [&select](SubtreePlan& plan) {
     const auto& selected = select.getSelectedVariables();
     std::set<Variable> selectedVariables{selected.begin(), selected.end()};
-    if (RuntimeParameters().get<"strip-columns">()) {
+    if (runtimeParametersNew().rlock()->stripColumns_.get()) {
       plan._qet = QueryExecutionTree::makeTreeWithStrippedColumns(
           std::move(plan._qet), selectedVariables, HideStrippedColumns::True);
     } else {

--- a/src/index/LocalVocabEntry.h
+++ b/src/index/LocalVocabEntry.h
@@ -26,7 +26,8 @@ class alignas(16) LocalVocabEntry
 
   // Note: The values here actually are `Id`s, but we cannot store the `Id` type
   // directly because of cyclic dependencies.
-  using IdProxy = ad_utility::TypedIndex<uint64_t, "LveIdProxy">;
+  static constexpr std::string_view proxyTag = "LveIdProxy";
+  using IdProxy = ad_utility::TypedIndex<uint64_t, proxyTag>;
 
  private:
   // The cache for the position in the vocabulary. As usual, the `lowerBound` is

--- a/src/util/MemorySize/MemorySize.h
+++ b/src/util/MemorySize/MemorySize.h
@@ -11,7 +11,6 @@
 #include <absl/strings/str_cat.h>
 
 #include <cassert>
-#include <concepts>
 #include <cstddef>
 #include <functional>
 #include <limits>

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -5316,7 +5316,8 @@ LIMIT 1
 // are not even stored as `stripped`.
 TEST(QueryPlanner, SubqueryColumnStripping) {
   // Save current strip-columns setting and ensure it's enabled for this test
-  auto cleanup = setRuntimeParameterForTest<"strip-columns">(true);
+  auto cleanup =
+      setNewRuntimeParameterForTest<&RuntimeParametersNew::stripColumns_>(true);
 
   // Test a subquery that selects only some variables, causing others to be
   // stripped
@@ -5332,7 +5333,7 @@ TEST(QueryPlanner, SubqueryColumnStripping) {
 
     // The outer cleanup will reset the original status, so we can safely
     // modify the global parameter here.
-    RuntimeParameters().set<"strip-columns">(doStrip);
+    runtimeParametersNew().wlock()->stripColumns_.set(doStrip);
 
     // The inner subquery should have ?z and ?w stripped (as they're not
     // selected) but since it's a subquery, the stripped variables should not be

--- a/test/util/RuntimeParametersTestHelpers.h
+++ b/test/util/RuntimeParametersTestHelpers.h
@@ -20,4 +20,15 @@ template <ad_utility::ParameterName Name, typename Value>
   }};
 }
 
+template <auto ParameterPtr, typename Value>
+[[nodiscard]] auto setNewRuntimeParameterForTest(Value&& value) {
+  auto originalValue =
+      std::invoke(ParameterPtr, *runtimeParametersNew().rlock()).get();
+  std::invoke(ParameterPtr, *runtimeParametersNew().wlock()).set(AD_FWD(value));
+  return absl::Cleanup{[originalValue = std::move(originalValue)]() {
+    std::invoke(ParameterPtr, *runtimeParametersNew().wlock())
+        .set(std::move(originalValue));
+  }};
+}
+
 #endif  // QLEVER_TEST_UTIL_RUNTIMEPARAMETERSTESTHELPERS_H


### PR DESCRIPTION
TODO(BMW):

0. Fork this PR to continue the work on it.
1. Currently the new format is only used for a single parameter, migrate the other parameters to this format.
2. Add unit tests/migrate the unit tests for the old format to the new (much simpler format).
3. Delete the old Parameter code that is not needed anymore.
4. Verify that the newly cleaned up Parameters.h and RuntimeParameters.h compile in C++-17 mode.