### PR TITLE
Replace more concepts usages by C++17

### DIFF
--- a/src/backports/concepts.h
+++ b/src/backports/concepts.h
@@ -111,12 +111,27 @@ namespace ql::concepts {
 #ifdef QLEVER_CPP_17
 using namespace ::concepts;
 using ::ranges::bidirectional_iterator;
+using ::ranges::constructible_from;
 using ::ranges::contiguous_iterator;
+using ::ranges::convertible_to;
+using ::ranges::equality_comparable_with;
 using ::ranges::forward_iterator;
 using ::ranges::input_iterator;
+using ::ranges::invocable;
 using ::ranges::random_access_iterator;
+using ::ranges::regular_invocable;
 using ::ranges::sentinel_for;
 using ::ranges::sized_sentinel_for;
+
+template <typename T>
+CPP_concept floating_point = std::is_floating_point_v<T>;
+template <typename T>
+CPP_concept integral = std::is_integral_v<T>;
+
+// TODO<joka921> There is another par that requires T{} to be valid, rewrite
+// this using the more complex range-v3 macros.
+template <typename T>
+CPP_concept default_initializable = ql::concepts::constructible_from<T>;
 #else
 using namespace std;
 #endif

--- a/src/engine/CallFixedSize.h
+++ b/src/engine/CallFixedSize.h
@@ -10,6 +10,7 @@
 #include <functional>
 #include <optional>
 
+#include "backports/concepts.h"
 #include "global/Constants.h"
 #include "util/ConstexprUtils.h"
 #include "util/Exception.h"
@@ -56,19 +57,21 @@ namespace detail {
 
 // Call the `lambda` when the correct compile-time `Int`s are given as a
 // `std::integer_sequence`.
-template <std::integral Int, Int... Is, typename F, typename... Args>
-auto applyOnIntegerSequence(ad_utility::ValueSequence<Int, Is...>, F&& lambda,
-                            Args&&... args) {
+CPP_variadic_template(typename Int, Int... Is, typename F, typename... Args)(
+    requires ql::concepts::integral<
+        Int>) auto applyOnIntegerSequence(ad_utility::ValueSequence<Int, Is...>,
+                                          F&& lambda, Args&&... args) {
   return lambda.template operator()<Is...>(AD_FWD(args)...);
 };
 
 // Internal helper functions that calls `lambda.template operator()<I,
 // J,...)(args)` where `I, J, ...` are the elements in the `array`. Requires
 // that each element in the `array` is `<= maxValue`.
-template <int maxValue, size_t NumValues, std::integral Int, typename F,
-          typename... Args>
-auto callLambdaForIntArray(std::array<Int, NumValues> array, F&& lambda,
-                           Args&&... args) {
+CPP_variadic_template(int maxValue, size_t NumValues, typename Int, typename F,
+                      typename... Args)(
+    requires ql::concepts::integral<
+        Int>) auto callLambdaForIntArray(std::array<Int, NumValues> array,
+                                         F&& lambda, Args&&... args) {
   AD_CONTRACT_CHECK(
       ql::ranges::all_of(array, [](auto el) { return el <= maxValue; }));
   using ArrayType = std::array<Int, NumValues>;
@@ -119,8 +122,9 @@ auto callLambdaForIntArray(std::array<Int, NumValues> array, F&& lambda,
 }
 
 // Overload for a single int.
-template <int maxValue, std::integral Int, typename F, typename... Args>
-auto callLambdaForIntArray(Int i, F&& lambda, Args&&... args) {
+CPP_variadic_template(int maxValue, typename Int, typename F, typename... Args)(
+    requires ql::concepts::integral<
+        Int>) auto callLambdaForIntArray(Int i, F&& lambda, Args&&... args) {
   return callLambdaForIntArray<maxValue>(std::array{i}, AD_FWD(lambda),
                                          AD_FWD(args)...);
 }

--- a/src/engine/Result.h
+++ b/src/engine/Result.h
@@ -215,9 +215,9 @@ class Result {
 
   // Overload for more than two `Results`
   CPP_template(typename R)(
-      requires ql::ranges::forward_range<R> CPP_and
-          std::convertible_to<ql::ranges::range_value_t<R>,
-                              const Result&>) static SharedLocalVocabWrapper
+      requires ql::ranges::forward_range<R> CPP_and ql::concepts::
+          convertible_to<ql::ranges::range_value_t<R>,
+                         const Result&>) static SharedLocalVocabWrapper
       getMergedLocalVocab(R&& subResults) {
     std::vector<const LocalVocab*> vocabs;
     for (const Result& table : subResults) {

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -1118,10 +1118,11 @@ CPP_template_def(typename VisitorT, typename RequestT, typename ResponseT)(
 }
 
 // _____________________________________________________________________________
-template <std::invocable Function, typename T>
-Awaitable<T> Server::computeInNewThread(net::static_thread_pool& threadPool,
-                                        Function function,
-                                        SharedCancellationHandle handle) {
+CPP_template_def(typename Function,
+                 typename T)(requires ql::concepts::invocable<Function>)
+    Awaitable<T> Server::computeInNewThread(net::static_thread_pool& threadPool,
+                                            Function function,
+                                            SharedCancellationHandle handle) {
   // `interruptible` will set the shared state of this promise
   // with a function that can be used to cancel the timer.
   std::promise<std::function<void()>> cancelTimerPromise{};

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -233,11 +233,11 @@ class Server {
 
   /// Invoke `function` on `threadPool_`, and return an awaitable to wait for
   /// its completion, wrapping the result.
-  template <std::invocable Function,
-            typename T = std::invoke_result_t<Function>>
-  Awaitable<T> computeInNewThread(boost::asio::static_thread_pool& threadPool,
-                                  Function function,
-                                  SharedCancellationHandle handle);
+  CPP_template(typename Function, typename T = std::invoke_result_t<Function>)(
+      requires ql::concepts::invocable<Function>)
+      Awaitable<T> computeInNewThread(
+          boost::asio::static_thread_pool& threadPool, Function function,
+          SharedCancellationHandle handle);
 
   /// This method extracts a client-defined query id from the passed HTTP
   /// request if it is present. If it is not present or empty, a new

--- a/src/engine/idTable/CompressedExternalIdTable.h
+++ b/src/engine/idTable/CompressedExternalIdTable.h
@@ -273,9 +273,11 @@ class CompressedExternalIdTableWriter {
 // The common base implementation of `CompressedExternalIdTable` and
 // `CompressedExternalIdTableSorter` (see below). It is implemented as a mixin
 // class.
-template <size_t NumStaticCols, std::invocable<IdTableStatic<NumStaticCols>&>
-                                    BlockTransformation = ad_utility::Noop>
-class CompressedExternalIdTableBase {
+CPP_template_2(size_t NumStaticCols,
+               typename BlockTransformation = ad_utility::Noop)(
+    requires ql::concepts::invocable<
+        BlockTransformation,
+        IdTableStatic<NumStaticCols>&>) class CompressedExternalIdTableBase {
  public:
   using value_type = IdTableStatic<NumStaticCols>::row_type;
   using reference = IdTableStatic<NumStaticCols>::row_reference;

--- a/src/engine/sparqlExpressions/SparqlExpressionTypes.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionTypes.h
@@ -34,12 +34,12 @@ class VectorWithMemoryLimit
   // The `AllocatorWithMemoryLimit` is not default-constructible (on purpose).
   // Unfortunately, the support for such allocators is not really great in the
   // standard library. In particular, the type trait
-  // `std::default_initializable<std::vector<T, Alloc>>` will be true, even if
-  // the `Alloc` is not default-initializable, which leads to hard compile
-  // errors with the ranges library. For this reason we cannot simply inherit
-  // all the constructors from `Base`, but explicitly have to forward all but
-  // the default constructor. In particular, we only forward constructors that
-  // have
+  // `ql::concepts::default_initializable<std::vector<T, Alloc>>` will be true,
+  // even if the `Alloc` is not default-initializable, which leads to hard
+  // compile errors with the ranges library. For this reason we cannot simply
+  // inherit all the constructors from `Base`, but explicitly have to forward
+  // all but the default constructor. In particular, we only forward
+  // constructors that have
   // * at least one argument
   // * the first argument must not be similar to `std::vector` or
   // `VectorWithMemoryLimit` to not hide copy or move constructors
@@ -81,7 +81,7 @@ class VectorWithMemoryLimit
     return VectorWithMemoryLimit(*this);
   }
 };
-static_assert(!std::default_initializable<VectorWithMemoryLimit<int>>);
+static_assert(!ql::concepts::default_initializable<VectorWithMemoryLimit<int>>);
 
 // A class to store the results of expressions that can yield strings or IDs as
 // their result (for example IF and COALESCE). It is also used for expressions

--- a/src/util/Algorithm.h
+++ b/src/util/Algorithm.h
@@ -151,10 +151,12 @@ CPP_template(typename Range)(requires ql::ranges::forward_range<
 // Return a new `std::input` that is obtained by applying the `function` to each
 // of the elements of the `input`.
 CPP_template(typename Array, typename Function)(
-    requires ad_utility::isArray<std::decay_t<Array>> CPP_and std::invocable<
-        Function,
-        typename Array::value_type>) auto transformArray(Array&& input,
-                                                         Function function) {
+    requires ad_utility::isArray<std::decay_t<Array>> CPP_and
+        ql::concepts::invocable<
+            Function,
+            typename Array::value_type>) auto transformArray(Array&& input,
+                                                             Function
+                                                                 function) {
   return std::apply(
       [&function](auto&&... vals) {
         return std::array{std::invoke(function, AD_FWD(vals))...};

--- a/src/util/AsioHelpers.h
+++ b/src/util/AsioHelpers.h
@@ -26,8 +26,9 @@ namespace detail {
 // function is called directly, but the invocation of the handler is posted to
 // the associated executor of the `handler`, or to the `executor` if no such
 // associated executor exists.
-CPP_template(typename Executor, typename Function, typename Handler)(
-    requires std::invocable<Function>) struct CallFunctionAndPassToHandler {
+CPP_template(typename Executor, typename Function,
+             typename Handler)(requires ql::concepts::invocable<
+                               Function>) struct CallFunctionAndPassToHandler {
   Executor executor_;
   Function function_;
   Handler handler_;
@@ -71,8 +72,8 @@ CPP_template(typename Executor, typename Function, typename Handler)(
 };
 // Explicit deduction guides, we need objects and not references as the template
 // parameters.
-CPP_template(typename Executor, typename Function,
-             typename Handler)(requires std::invocable<std::decay_t<Function>>)
+CPP_template(typename Executor, typename Function, typename Handler)(
+    requires ql::concepts::invocable<std::decay_t<Function>>)
     CallFunctionAndPassToHandler(Executor&&, Function&&, Handler&&)
         -> CallFunctionAndPassToHandler<std::decay_t<Executor>,
                                         std::decay_t<Function>,
@@ -86,14 +87,14 @@ CPP_template(typename Executor, typename Function,
 // Note: If no executor is associated with the `completionToken`, then the
 // handler will also be run on the `executor` that is passed to this function as
 // there is no other way of running it.
-CPP_template(typename Executor, typename CompletionToken,
-             typename Function)(requires std::invocable<Function> CPP_and(
-    std::is_default_constructible_v<std::invoke_result_t<Function>> ||
-    std::is_void_v<std::invoke_result_t<
-        Function>>)) auto runFunctionOnExecutor(Executor executor,
-                                                Function function,
-                                                CompletionToken&
-                                                    completionToken) {
+CPP_template(typename Executor, typename CompletionToken, typename Function)(
+    requires ql::concepts::invocable<Function> CPP_and(
+        std::is_default_constructible_v<std::invoke_result_t<Function>> ||
+        std::is_void_v<std::invoke_result_t<
+            Function>>)) auto runFunctionOnExecutor(Executor executor,
+                                                    Function function,
+                                                    CompletionToken&
+                                                        completionToken) {
   using Value = std::invoke_result_t<Function>;
   static constexpr bool isVoid = std::is_void_v<Value>;
 

--- a/src/util/ChunkedForLoop.h
+++ b/src/util/ChunkedForLoop.h
@@ -31,7 +31,7 @@ using SetIndexToEndAction =
 /// where `*` can be any type. False otherwise.
 template <typename Func>
 CPP_concept IteratorWithBreak =
-    std::invocable<Func, size_t, SetIndexToEndAction>;
+    ql::concepts::invocable<Func, size_t, SetIndexToEndAction>;
 
 /// Helper concept that allows `chunkedForLoop` to offer an action with an
 /// optional second argument in `action`.
@@ -47,7 +47,7 @@ CPP_concept IteratorAction =
 /// every `CHUNK_SIZE` iteration steps, and at least a single time at the end if
 /// the range is not empty.
 CPP_template(std::size_t CHUNK_SIZE, typename Action, typename ChunkOpT)(
-    requires detail::IteratorAction<Action> CPP_and std::invocable<
+    requires detail::IteratorAction<Action> CPP_and ql::concepts::invocable<
         ChunkOpT>) inline void chunkedForLoop(std::size_t start,
                                               std::size_t end,
                                               const Action& action,
@@ -78,7 +78,7 @@ CPP_concept SizedInputRange =
 // not a multiple of `chunkSize`.)
 CPP_template(typename R, typename O, typename ChunkOperationFunc)(
     requires SizedInputRange<R> CPP_and std::weakly_incrementable<O> CPP_and
-        std::invocable<ChunkOperationFunc>
+        ql::concepts::invocable<ChunkOperationFunc>
             CPP_and std::indirectly_copyable<
                 ql::ranges::iterator_t<R>,
                 O>) inline void chunkedCopy(R&& inputRange, O result,
@@ -108,7 +108,7 @@ CPP_concept SizedOutputRange =
 // `chunkSize` elements. (Round up to the next chunk size if the range size is
 // not a multiple of `chunkSize`.)
 CPP_template(typename T, typename R, typename ChunkOperationFunc)(
-    requires SizedOutputRange<R, T> CPP_and std::invocable<
+    requires SizedOutputRange<R, T> CPP_and ql::concepts::invocable<
         ChunkOperationFunc>) inline void chunkedFill(R&& outputRange,
                                                      const T& value,
                                                      ql::ranges::

--- a/src/util/ConfigManager/ConfigManager.cpp
+++ b/src/util/ConfigManager/ConfigManager.cpp
@@ -113,14 +113,14 @@ std::optional<const ConfigManager*> ConfigManager::HashMapEntry::getSubManager()
 
 // ____________________________________________________________________________
 CPP_template_def(typename Visitor)(
-    requires std::invocable<Visitor, ConfigOption&> CPP_and_def
-        std::invocable<Visitor, ConfigManager&>) decltype(auto)
+    requires ql::concepts::invocable<Visitor, ConfigOption&> CPP_and_def
+        ql::concepts::invocable<Visitor, ConfigManager&>) decltype(auto)
     ConfigManager::HashMapEntry::visit(Visitor&& vis) {
   return visitImpl(AD_FWD(vis), data_);
 }
 CPP_template_def(typename Visitor)(
-    requires std::invocable<Visitor, ConfigOption&> CPP_and_def
-        std::invocable<Visitor, ConfigManager&>) decltype(auto)
+    requires ql::concepts::invocable<Visitor, ConfigOption&> CPP_and_def
+        ql::concepts::invocable<Visitor, ConfigManager&>) decltype(auto)
     ConfigManager::HashMapEntry::visit(Visitor&& vis) const {
   return visitImpl(AD_FWD(vis), data_);
 }
@@ -129,10 +129,10 @@ CPP_template_def(typename Visitor)(
 CPP_template_def(typename Visitor, typename PointerType)(
     requires ad_utility::SimilarTo<
         std::unique_ptr<ConfigManager::HashMapEntry::Data>, PointerType>
-        CPP_and_def std::invocable<
+        CPP_and_def ql::concepts::invocable<
             Visitor, std::conditional_t<std::is_const_v<PointerType>,
                                         const ConfigOption&, ConfigOption&>>
-            CPP_and_def std::invocable<
+            CPP_and_def ql::concepts::invocable<
                 Visitor, std::conditional_t<std::is_const_v<PointerType>,
                                             const ConfigManager&,
                                             ConfigManager&>>) decltype(auto)

--- a/src/util/ConfigManager/ConfigManager.h
+++ b/src/util/ConfigManager/ConfigManager.h
@@ -93,12 +93,12 @@ class ConfigManager {
 
     // Wrapper for calling `std::visit` on the saved `Data`.
     CPP_template(typename Visitor)(
-        requires std::invocable<Visitor, ConfigOption&> CPP_and
-            std::invocable<Visitor, ConfigManager&>) decltype(auto)
+        requires ql::concepts::invocable<Visitor, ConfigOption&> CPP_and
+            ql::concepts::invocable<Visitor, ConfigManager&>) decltype(auto)
         visit(Visitor&& vis);
     CPP_template(typename Visitor)(
-        requires std::invocable<Visitor, ConfigOption&> CPP_and
-            std::invocable<Visitor, ConfigManager&>) decltype(auto)
+        requires ql::concepts::invocable<Visitor, ConfigOption&> CPP_and
+            ql::concepts::invocable<Visitor, ConfigManager&>) decltype(auto)
         visit(Visitor&& vis) const;
 
    private:
@@ -131,10 +131,10 @@ class ConfigManager {
     CPP_template(typename Visitor, typename PointerType)(
         requires ad_utility::SimilarTo<
             std::unique_ptr<ConfigManager::HashMapEntry::Data>, PointerType>
-            CPP_and std::invocable<
+            CPP_and ql::concepts::invocable<
                 Visitor, std::conditional_t<std::is_const_v<PointerType>,
                                             const ConfigOption&, ConfigOption&>>
-                CPP_and std::invocable<
+                CPP_and ql::concepts::invocable<
                     Visitor,
                     std::conditional_t<std::is_const_v<PointerType>,
                                        const ConfigManager&,

--- a/src/util/ConfigManager/Validator.h
+++ b/src/util/ConfigManager/Validator.h
@@ -135,8 +135,8 @@ class ConfigOptionValidatorManager {
                typename... ExceptionValidatorParameterTypes)(
       requires(...&& isInstantiation<ExceptionValidatorParameterTypes,
                                      ConstConfigOptionProxy>)
-          CPP_and(...&& std::invocable<TranslationFunction,
-                                       const ExceptionValidatorParameterTypes>)
+          CPP_and(...&& ql::concepts::invocable<
+                  TranslationFunction, const ExceptionValidatorParameterTypes>)
               CPP_and ExceptionValidatorFunction<
                   ExceptionValidatorFunc,
                   std::invoke_result_t<
@@ -201,8 +201,9 @@ class ConfigOptionValidatorManager {
                typename... ValidatorParameterTypes)(
       requires(...&& isInstantiation<ValidatorParameterTypes,
                                      ConstConfigOptionProxy>)
-          CPP_and(... && (std::invocable<TranslationFunction,
-                                         const ValidatorParameterTypes>))
+          CPP_and(... &&
+                  (ql::concepts::invocable<TranslationFunction,
+                                           const ValidatorParameterTypes>))
               CPP_and(ValidatorFunction<
                       ValidatorFunc,
                       std::invoke_result_t<TranslationFunction,

--- a/src/util/ConstexprUtils.h
+++ b/src/util/ConstexprUtils.h
@@ -86,8 +86,8 @@ struct ConstexprSwitch {
   CPP_template(typename FuncType, typename ValueType, typename... Args)(
       requires((sizeof...(Cases) == 0) ||
                ad_utility::SameAsAny<decltype(FirstCase), decltype(Cases)...>)
-          CPP_and std::equality_comparable_with<decltype(FirstCase),
-                                                decltype(FirstCase)>
+          CPP_and ql::concepts::equality_comparable_with<decltype(FirstCase),
+                                                         decltype(FirstCase)>
               CPP_and InvocableWithCase<FuncType, FirstCase, Args...>
                   CPP_and(InvocableWithCase<FuncType, Cases,
                                             Args...>&&...)) constexpr auto
@@ -175,9 +175,9 @@ constexpr size_t getIndexOfFirstTypeToPassCheck() {
 
 // An `ad_utility::ValueSequence<T, values...>` has the same functionality as
 // `std::integer_sequence`. This replacement is needed to compile QLever with
-// libc++, because libc++ strictly enforces the `std::integral` constraint for
-// `std::integer_sequence`, and we also need non-integral types as values, for
-// example `std::array<...>`.
+// libc++, because libc++ strictly enforces the `ql::concepts::integral`
+// constraint for `std::integer_sequence`, and we also need non-integral types
+// as values, for example `std::array<...>`.
 namespace detail {
 template <typename T, T... values>
 struct ValueSequenceImpl {};
@@ -212,8 +212,8 @@ auto toIntegerSequence() {
 // NumIntegers - 1 to an array of `NumIntegers` many integers that are each in
 // the range
 // `[0, ..., (maxValue)]`
-CPP_template(typename Int,
-             size_t NumIntegers)(requires std::integral<Int>) constexpr std::
+CPP_template(typename Int, size_t NumIntegers)(
+    requires ql::concepts::integral<Int>) constexpr std::
     array<Int, NumIntegers> integerToArray(Int value, Int numValues) {
   std::array<Int, NumIntegers> res;
   for (auto& el : res | ql::views::reverse) {
@@ -228,7 +228,7 @@ CPP_template(typename Int,
 // value from `[0, ..., Upper - 1] ^ Num` exactly once. `^` denotes the
 // cartesian power.
 CPP_template(auto Upper, size_t Num)(
-    requires std::integral<
+    requires ql::concepts::integral<
         decltype(Upper)>) constexpr auto cartesianPowerAsArray() {
   using Int = decltype(Upper);
   constexpr auto numValues = pow(Upper, Num);
@@ -244,7 +244,7 @@ CPP_template(auto Upper, size_t Num)(
 // cartesian product of sets. The elements of the `integer_sequence` are
 // of type `std::array<Int, Num>` where `Int` is the type of `Upper`.
 CPP_template(auto Upper,
-             size_t Num)(requires std::integral<
+             size_t Num)(requires ql::concepts::integral<
                          decltype(Upper)>) auto cartesianPowerAsIntegerArray() {
   return toIntegerSequence<cartesianPowerAsArray<Upper, Num>()>();
 }

--- a/src/util/ExceptionHandling.h
+++ b/src/util/ExceptionHandling.h
@@ -27,7 +27,7 @@ namespace detail {
 // has to perform actions that might throw, but when handling these exceptions
 // is not important.
 CPP_template(typename F)(
-    requires std::invocable<std::remove_cvref_t<
+    requires ql::concepts::invocable<std::remove_cvref_t<
         F>>) void ignoreExceptionIfThrows(F&& f,
                                           std::string_view additionalNote =
                                               "") noexcept {
@@ -56,7 +56,7 @@ CPP_template(typename F)(
 // this function must never throw an exception.
 CPP_template(typename F,
              typename TerminateAction = decltype(detail::callStdTerminate))(
-    requires std::invocable<std::remove_cvref_t<F>> CPP_and
+    requires ql::concepts::invocable<std::remove_cvref_t<F>> CPP_and
         std::is_nothrow_invocable_v<
             TerminateAction>) void terminateIfThrows(F&& f,
                                                      std::string_view message,
@@ -118,9 +118,9 @@ class ThrowInDestructorIfSafe {
   int numExceptionsDuringConstruction_ = std::uncaught_exceptions();
 
  public:
-  CPP_template(typename FuncType,
-               typename... Args)(requires std::invocable<FuncType> CPP_and(
-      ...&& std::convertible_to<Args, std::string_view>)) void
+  CPP_template(typename FuncType, typename... Args)(
+      requires ql::concepts::invocable<FuncType> CPP_and(
+          ...&& ql::concepts::convertible_to<Args, std::string_view>)) void
   operator()(FuncType f, const Args&... additionalMessages) const {
     auto logIgnoredException = [&additionalMessages...](std::string_view what) {
       std::string_view sep = sizeof...(additionalMessages) == 0 ? "" : " ";

--- a/src/util/Generators.h
+++ b/src/util/Generators.h
@@ -55,7 +55,7 @@ CPP_template(typename InputRange, typename AggregatorT,
 // the elements that are yielded by the created `generator`.
 template <typename T, typename F>
 cppcoro::generator<T> generatorFromActionWithCallback(F functionWithCallback)
-    requires std::invocable<F, std::function<void(T)>> {
+    requires ql::concepts::invocable<F, std::function<void(T)>> {
   std::mutex mutex;
   std::condition_variable cv;
 

--- a/src/util/JoinAlgorithms/JoinAlgorithms.h
+++ b/src/util/JoinAlgorithms/JoinAlgorithms.h
@@ -31,14 +31,14 @@ namespace ad_utility {
 // single argument of the `Range`'s iterator type (NOT value type).
 template <typename F, typename Range>
 CPP_concept UnaryIteratorFunction =
-    std::invocable<F, ql::ranges::iterator_t<Range>>;
+    ql::concepts::invocable<F, ql::ranges::iterator_t<Range>>;
 
 // A  function `F` fulfills `BinaryIteratorFunction` if it can be called with
 // two arguments of the `Range`'s iterator type (NOT value type).
 template <typename F, typename Range>
 CPP_concept BinaryIteratorFunction =
-    std::invocable<F, ql::ranges::iterator_t<Range>,
-                   ql::ranges::iterator_t<Range>>;
+    ql::concepts::invocable<F, ql::ranges::iterator_t<Range>,
+                            ql::ranges::iterator_t<Range>>;
 
 // Helper type to indicate the different join modes.
 enum class JoinType { JOIN, OPTIONAL, MINUS };
@@ -486,7 +486,7 @@ CPP_template(typename CompatibleActionT, typename NotFoundActionT,
              typename CancellationFuncT)(
     requires BinaryIteratorFunction<CompatibleActionT, IdTableView<0>> CPP_and UnaryIteratorFunction<
         NotFoundActionT, IdTableView<0>>
-        CPP_and std::invocable<
+        CPP_and ql::concepts::invocable<
             CancellationFuncT>) void specialOptionalJoin(const IdTableView<0>&
                                                              left,
                                                          const IdTableView<0>&

--- a/src/util/MemorySize/MemorySize.cpp
+++ b/src/util/MemorySize/MemorySize.cpp
@@ -26,10 +26,10 @@ std::string MemorySize::asString() const {
   // Convert number and memory unit name to the string, we want to return.
   auto toString = [](const auto number, std::string_view unitName) {
     using T = std::decay_t<decltype(number)>;
-    if constexpr (std::integral<T>) {
+    if constexpr (ql::concepts::integral<T>) {
       return absl::StrCat(number, " ", unitName);
     } else {
-      static_assert(std::floating_point<T>);
+      static_assert(ql::concepts::floating_point<T>);
       return number * 10 == std::floor(number * 10)
                  ? absl::StrCat(number, " ", unitName)
                  : absl::StrCat(std::round(number * 10) / 10, " ", unitName);

--- a/src/util/MemorySize/MemorySize.h
+++ b/src/util/MemorySize/MemorySize.h
@@ -33,7 +33,8 @@ namespace ad_utility {
 
 // A concept, for when a type should be an integral, or a floating point.
 template <typename T>
-CPP_concept Arithmetic = (std::integral<T> || std::floating_point<T>);
+CPP_concept Arithmetic =
+    (ql::concepts::integral<T> || ql::concepts::floating_point<T>);
 
 /*
 An abstract class, that represents an amount of memory.
@@ -72,7 +73,7 @@ class MemorySize {
   memory size saved internally. Always requires the exact memory size unit and
   size wanted.
   */
-  CPP_template(typename T)(requires std::integral<T>)  //
+  CPP_template(typename T)(requires ql::concepts::integral<T>)  //
       constexpr static MemorySize bytes(T numBytes);
   CPP_template(typename T)(requires Arithmetic<T>)  //
       constexpr static MemorySize kilobytes(T numKilobytes);
@@ -280,8 +281,8 @@ multiplied/divied with.
 return types will be automatically done, and can be ignored by `func`.
  */
 CPP_template(typename T, typename Func)(requires Arithmetic<T> CPP_and(
-    std::invocable<Func, const double, const double> ||
-    std::invocable<Func, const size_t, const size_t>))               //
+    ql::concepts::invocable<Func, const double, const double> ||
+    ql::concepts::invocable<Func, const size_t, const size_t>))      //
     constexpr MemorySize magicImplForDivAndMul(const MemorySize& m,  //
                                                const T c, Func func) {
   // In order for the results to be as precise as possible, we cast to highest
@@ -296,7 +297,8 @@ CPP_template(typename T, typename Func)(requires Arithmetic<T> CPP_and(
 }  // namespace detail
 
 // _____________________________________________________________________________
-CPP_template_def(typename T)(requires std::integral<T>) constexpr MemorySize
+CPP_template_def(typename T)(
+    requires ql::concepts::integral<T>) constexpr MemorySize
     MemorySize::bytes(T numBytes) {
   if constexpr (std::is_signed_v<T>) {
     // Doesn't make much sense to a negative amount of memory.
@@ -449,7 +451,7 @@ CPP_template_def(typename T)(requires Arithmetic<T>) constexpr MemorySize
   point number.
   For example: 1/(1/2) = 2
   */
-  if (std::floating_point<T> &&
+  if (ql::concepts::floating_point<T> &&
       static_cast<double>(memoryInBytes_) >
           static_cast<double>(detail::size_t_max) * static_cast<double>(c)) {
     throw std::overflow_error(

--- a/src/util/OnDestructionDontThrowDuringStackUnwinding.h
+++ b/src/util/OnDestructionDontThrowDuringStackUnwinding.h
@@ -72,7 +72,7 @@ class OnDestructionCreator {
 // return object in a container because all of its constructors are either
 // private or deleted. This is disabled deliberately as it might lead to program
 // termination (for `std::vector`) or to uncalled destructors.
-CPP_template(typename F)(requires std::invocable<F>)
+CPP_template(typename F)(requires ql::concepts::invocable<F>)
     [[nodiscard("")]] detail::OnDestructionDontThrowDuringStackUnwinding<
         F> makeOnDestructionDontThrowDuringStackUnwinding(F f) {
   static_assert(

--- a/src/util/Parameters.h
+++ b/src/util/Parameters.h
@@ -40,12 +40,12 @@ struct ParameterBase {
 // Concepts for the template types of `Parameter`.
 template <typename FunctionType, typename ToType>
 CPP_concept ParameterFromStringType =
-    std::default_initializable<FunctionType> &&
+    ql::concepts::default_initializable<FunctionType> &&
     InvocableWithSimilarReturnType<FunctionType, ToType, const std::string&>;
 
 template <typename FunctionType, typename FromType>
 CPP_concept ParameterToStringType =
-    std::default_initializable<FunctionType> &&
+    ql::concepts::default_initializable<FunctionType> &&
     InvocableWithSimilarReturnType<FunctionType, std::string, FromType>;
 
 /// Abstraction for a parameter that connects a (compile time) `Name` to a

--- a/src/util/Synchronized.h
+++ b/src/util/Synchronized.h
@@ -92,7 +92,7 @@ class Synchronized {
   Synchronized(Synchronized&&) noexcept = default;
   Synchronized& operator=(Synchronized&&) noexcept = default;
 
-  Synchronized() requires std::default_initializable<T> = default;
+  Synchronized() requires ql::concepts::default_initializable<T> = default;
   ~Synchronized() = default;
 
   /// Constructor that is not copy or move, tries to instantiate the underlying

--- a/src/util/ThreadSafeQueue.h
+++ b/src/util/ThreadSafeQueue.h
@@ -236,7 +236,7 @@ namespace detail {
 // and the queue is finished if `numThreads <= 0`. All exceptions that
 // happen during the execution of `producer` are propagated to the queue.
 CPP_template(typename Queue, typename Producer)(
-    requires IsThreadsafeQueue<Queue> CPP_and std::invocable<
+    requires IsThreadsafeQueue<Queue> CPP_and ql::concepts::invocable<
         Producer>) auto makeQueueTask(Queue& queue, Producer producer,
                                       std::atomic<int64_t>& numThreads) {
   return [&queue, producer = std::move(producer), &numThreads] {

--- a/src/util/TypeTraits.h
+++ b/src/util/TypeTraits.h
@@ -346,7 +346,7 @@ are the same when ignoring `const`, `volatile`, and reference qualifiers.
 */
 template <typename Fn, typename Ret, typename... Args>
 CPP_concept InvocableWithSimilarReturnType =
-    std::invocable<Fn, Args...> &&
+    ql::concepts::invocable<Fn, Args...> &&
     isSimilar<InvokeResultSfinaeFriendly<Fn, Args...>, Ret>;
 
 /*
@@ -355,7 +355,7 @@ CPP_concept InvocableWithSimilarReturnType =
 */
 template <typename Fn, typename Ret, typename... Args>
 CPP_concept InvocableWithExactReturnType =
-    std::invocable<Fn, Args...> &&
+    ql::concepts::invocable<Fn, Args...> &&
     std::same_as<InvokeResultSfinaeFriendly<Fn, Args...>, Ret>;
 
 /*
@@ -369,7 +369,7 @@ For more information see: https://en.cppreference.com/w/cpp/concepts/invocable
 */
 template <typename Fn, typename Ret, typename... Args>
 CPP_concept RegularInvocableWithSimilarReturnType =
-    std::regular_invocable<Fn, Args...> &&
+    ql::concepts::regular_invocable<Fn, Args...> &&
     isSimilar<InvokeResultSfinaeFriendly<Fn, Args...>, Ret>;
 
 /*
@@ -383,7 +383,7 @@ For more information see: https://en.cppreference.com/w/cpp/concepts/invocable
 */
 template <typename Fn, typename Ret, typename... Args>
 CPP_concept RegularInvocableWithExactReturnType =
-    std::regular_invocable<Fn, Args...> &&
+    ql::concepts::regular_invocable<Fn, Args...> &&
     std::same_as<InvokeResultSfinaeFriendly<Fn, Args...>, Ret>;
 
 // True iff `T` is a value type or an rvalue reference. Can be used to force

--- a/src/util/ValueSizeGetters.h
+++ b/src/util/ValueSizeGetters.h
@@ -19,7 +19,7 @@ with the given value type as const l-value reference and return a `MemorySize`.
 */
 template <typename T, typename ValueType>
 CPP_concept ValueSizeGetter =
-    std::default_initializable<T> &&
+    ql::concepts::default_initializable<T> &&
     RegularInvocableWithSimilarReturnType<T, MemorySize, const ValueType&>;
 
 // A templated default value size getter. Can be specialized for additional

--- a/src/util/Views.h
+++ b/src/util/Views.h
@@ -186,8 +186,8 @@ using all_t = decltype(allView(std::declval<Range>()));
 // view is destroyed, or the iteration reaches `end`, whichever happens first,
 // the given `callback` is invoked.
 CPP_template(typename V, typename F)(
-    requires ql::ranges::input_range<V> CPP_and
-        ql::ranges::view<V>&& std::invocable<F&>) class CallbackOnEndView
+    requires ql::ranges::input_range<V> CPP_and ql::ranges::view<V>&&
+        ql::concepts::invocable<F&>) class CallbackOnEndView
     : public ql::ranges::view_interface<CallbackOnEndView<V, F>> {
  private:
   V base_;

--- a/src/util/antlr/ANTLRErrorHandling.h
+++ b/src/util/antlr/ANTLRErrorHandling.h
@@ -35,7 +35,7 @@ For an example of a valid `GrammarParseException` see
 */
 CPP_template(typename GrammarParseException)(
     requires std::derived_from<GrammarParseException, ParseException> CPP_and
-        std::constructible_from<
+        ql::concepts::constructible_from<
             GrammarParseException, std::string_view,
             std::optional<ExceptionMetadata>>) struct ThrowingErrorListener
     : public antlr4::BaseErrorListener {

--- a/test/ConstexprUtilsTest.cpp
+++ b/test/ConstexprUtilsTest.cpp
@@ -173,8 +173,10 @@ TEST(ConstexprUtils, ConstexprSwitch) {
   }
 
   // F1 can only be called with 0 and 1 as template arguments.
-  static_assert(std::invocable<decltype(ConstexprSwitch<0, 1>{}), F1, int>);
-  static_assert(!std::invocable<decltype(ConstexprSwitch<0, 1, 2>{}), F1, int>);
+  static_assert(
+      ql::concepts::invocable<decltype(ConstexprSwitch<0, 1>{}), F1, int>);
+  static_assert(
+      !ql::concepts::invocable<decltype(ConstexprSwitch<0, 1, 2>{}), F1, int>);
 }
 
 struct PushToVector {

--- a/test/GetPrefilterExpressionFromSparqlExpressionTest.cpp
+++ b/test/GetPrefilterExpressionFromSparqlExpressionTest.cpp
@@ -69,8 +69,11 @@ const auto equalityCheckPrefilterVectors =
 // `<PrefilterExpression, Variable>` pair is provided, the expected value for
 // the `SparqlExpression` is an empty vector.
 const auto evalAndEqualityCheck =
-    [](std::unique_ptr<SparqlExpression> sparqlExpr,
-       std::convertible_to<PrefilterExprVariablePair> auto&&... prefilterArgs) {
+    [](std::unique_ptr<SparqlExpression> sparqlExpr, auto&&... prefilterArgs) {
+      static_assert(
+          (... &&
+           ql::concepts::convertible_to<std::decay_t<decltype(prefilterArgs)>,
+                                        PrefilterExprVariablePair>));
       std::vector<PrefilterExprVariablePair> prefilterVarPair = {};
       if constexpr (sizeof...(prefilterArgs) > 0) {
         (prefilterVarPair.emplace_back(

--- a/test/GroupByTest.cpp
+++ b/test/GroupByTest.cpp
@@ -2304,8 +2304,9 @@ class GroupByLazyFixture : public ::testing::TestWithParam<bool> {
   void SetUp() override { qec_->getQueryTreeCache().clearAll(); }
 
   // ___________________________________________________________________________
-  static std::vector<std::optional<Variable>> vars(
-      std::convertible_to<std::string> auto&&... strings) {
+  CPP_variadic_template(typename... Strings)(requires(
+      ...&& ql::concepts::convertible_to<Strings, std::string>)) static std::
+      vector<std::optional<Variable>> vars(Strings&&... strings) {
     std::vector<std::optional<Variable>> result;
     result.reserve(sizeof...(strings));
     (result.emplace_back(V{AD_FWD(strings)}), ...);

--- a/test/PrefilterExpressionTestHelpers.h
+++ b/test/PrefilterExpressionTestHelpers.h
@@ -122,7 +122,8 @@ constexpr inline auto pr =
 // pairs.
 struct MakePrefilterVec {
   template <QL_CONCEPT_OR_TYPENAME(
-      std::convertible_to<sparqlExpression::PrefilterExprVariablePair>)... Args>
+      ql::concepts::convertible_to<
+          sparqlExpression::PrefilterExprVariablePair>)... Args>
   constexpr auto operator()(Args&&... prefilterArgs) const {
     std::vector<sparqlExpression::PrefilterExprVariablePair> prefilterVarPairs =
         {};
@@ -237,7 +238,7 @@ std::unique_ptr<SparqlExpression> makeIsDatatypeStartsWithExpression(
 
 //______________________________________________________________________________
 CPP_template(typename... Args)(
-    requires(std::convertible_to<Args, VariantArgs>&&...))
+    requires(ql::concepts::convertible_to<Args, VariantArgs>&&...))
     std::unique_ptr<SparqlExpression> inSprqlExpr(VariantArgs first,
                                                   Args&&... argList) {
   std::vector<std::unique_ptr<SparqlExpression>> childrenSparql;

--- a/test/RandomTest.cpp
+++ b/test/RandomTest.cpp
@@ -29,9 +29,12 @@ numbers for the same seed.
 @param randomNumberGeneratorFactory An invocable object, that should return a
 random number generator, using the given seed.
 */
-CPP_template(typename T)(requires std::invocable<T, RandomSeed>) void testSeed(
-    T randomNumberGeneratorFactory,
-    ad_utility::source_location l = ad_utility::source_location::current()) {
+CPP_template(typename T)(
+    requires ql::concepts::invocable<
+        T,
+        RandomSeed>) void testSeed(T randomNumberGeneratorFactory,
+                                   ad_utility::source_location l =
+                                       ad_utility::source_location::current()) {
   // For generating better messages, when failing a test.
   auto trace{generateLocationTrace(l, "testSeed")};
 
@@ -105,7 +108,7 @@ should be `RangeNumberType rangeMin, RangeNumberType rangeMax, Seed seed`.
 @param ranges The ranges, that should be used.
 */
 CPP_template(typename RangeNumberType, typename GeneratorFactory)(
-    requires std::invocable<
+    requires ql::concepts::invocable<
         GeneratorFactory, RangeNumberType, RangeNumberType,
         RandomSeed>) void testSeedWithRange(GeneratorFactory
                                                 randomNumberGeneratorFactory,
@@ -136,8 +139,9 @@ of the range.
 @param ranges The ranges, for which should be tested for.
 */
 template <typename Generator, typename RangeNumberType>
-requires std::constructible_from<Generator, RangeNumberType, RangeNumberType> &&
-         std::invocable<Generator> &&
+requires ql::concepts::constructible_from<Generator, RangeNumberType,
+                                          RangeNumberType> &&
+         ql::concepts::invocable<Generator> &&
          ad_utility::isSimilar<std::invoke_result_t<Generator>, RangeNumberType>
 void testRange(
     const std::vector<NumericalRange<RangeNumberType>>& ranges,

--- a/test/ResultTableColumnOperationsTest.cpp
+++ b/test/ResultTableColumnOperationsTest.cpp
@@ -68,7 +68,7 @@ static void compareToColumn(
   // Compare every entry with the fitting comparison function.
   AD_CONTRACT_CHECK(expectedContent.size() == tableToCompareAgainst.numRows());
   for (size_t i = 0; i < expectedContent.size(); i++) {
-    if constexpr (std::floating_point<T>) {
+    if constexpr (ql::concepts::floating_point<T>) {
       ASSERT_FLOAT_EQ(expectedContent.at(i),
                       tableToCompareAgainst.getEntry<T>(
                           i, columnsToCompareAgainst.columnNum_));

--- a/test/SerializerTest.cpp
+++ b/test/SerializerTest.cpp
@@ -455,7 +455,7 @@ TEST(Serializer, CopyAndMove) {
     static_assert(!requires(Writer w1, Writer w2) {
       { w1 = w2 };
     });
-    static_assert(!std::constructible_from<Writer, const Writer&>);
+    static_assert(!ql::concepts::constructible_from<Writer, const Writer&>);
 
     // Assert that moving writers consistently writes to the same resource.
     writer | 1;
@@ -470,7 +470,7 @@ TEST(Serializer, CopyAndMove) {
     static_assert(!requires(Reader r1, Reader r2) {
       { r1 = r2 };
     });
-    static_assert(!std::constructible_from<Reader, const Reader&>);
+    static_assert(!ql::concepts::constructible_from<Reader, const Reader&>);
     // Assert that moving writers consistently reads from the same resource.
     int i;
     reader | i;

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -106,7 +106,7 @@ template <typename T>
 concept VectorOrExpressionResult =
     SingleExpressionResult<T> ||
     (ad_utility::isVector<T> && isConstantResult<typename T::value_type>) ||
-    std::convertible_to<T, std::string_view>;
+    ql::concepts::convertible_to<T, std::string_view>;
 
 // Convert a `VectorOrExpressionResult` (see above) to a type that is supported
 // by the expression module.
@@ -1715,16 +1715,19 @@ TEST(SparqlExpression, encodeForUri) {
   auto l = [](std::string_view s, std::string_view langOrDatatype = "") {
     return IoS{lit(s, langOrDatatype)};
   };
-  checkEncodeForUri("Los Angeles", "Los%20Angeles");
-  checkEncodeForUri(l("Los Angeles", "@en"), "Los%20Angeles");
-  checkEncodeForUri(l("Los Angeles", "^^<someDatatype>"), "Los%20Angeles");
-  checkEncodeForUri(l("Los Ängeles", "^^<someDatatype>"), "Los%20%C3%84ngeles");
-  checkEncodeForUri(l("\"Los Angeles"), "%22Los%20Angeles");
-  checkEncodeForUri(l("L\"os \"Angeles"), "L%22os%20%22Angeles");
+
+  using namespace std::string_view_literals;
+  checkEncodeForUri("Los Angeles"sv, "Los%20Angeles"sv);
+  checkEncodeForUri(l("Los Angeles", "@en"), "Los%20Angeles"sv);
+  checkEncodeForUri(l("Los Angeles", "^^<someDatatype>"), "Los%20Angeles"sv);
+  checkEncodeForUri(l("Los Ängeles", "^^<someDatatype>"),
+                    "Los%20%C3%84ngeles"sv);
+  checkEncodeForUri(l("\"Los Angeles"), "%22Los%20Angeles"sv);
+  checkEncodeForUri(l("L\"os \"Angeles"), "L%22os%20%22Angeles"sv);
   // Literals from the global and local vocab.
-  checkEncodeForUri(testContext().aelpha, "%C3%A4lpha");
-  checkEncodeForUri(testContext().notInVocabA, "notInVocabA");
-  checkEncodeForUri(testContext().notInVocabAelpha, "notInVocab%C3%84lpha");
+  checkEncodeForUri(testContext().aelpha, "%C3%A4lpha"sv);
+  checkEncodeForUri(testContext().notInVocabA, "notInVocabA"sv);
+  checkEncodeForUri(testContext().notInVocabAelpha, "notInVocab%C3%84lpha"sv);
   // Entities from the local and global vocab (become undefined without STR()
   // around the expression).
   checkEncodeForUri(testContext().label, IoS{U});

--- a/test/TransitivePathTest.cpp
+++ b/test/TransitivePathTest.cpp
@@ -130,12 +130,17 @@ class TransitivePathTest
   // Call testCase three times with differing arguments. This is used to test
   // scenarios where the same input table is delivered in different splits
   // either wrapped within a generator or as a single table.
-  static void runTestWithForcedSideTableScenarios(
-      const std::invocable<std::variant<IdTable, std::vector<IdTable>>,
-                           bool> auto& testCase,
-      IdTable idTable,
-      ad_utility::source_location loc =
-          ad_utility::source_location::current()) {
+  CPP_template(typename TestCase)(
+      requires ql::concepts::invocable<
+          TestCase, std::variant<IdTable, std::vector<IdTable>>,
+          bool>) static void runTestWithForcedSideTableScenarios(const TestCase&
+                                                                     testCase,
+                                                                 IdTable
+                                                                     idTable,
+                                                                 ad_utility::source_location
+                                                                     loc = ad_utility::
+                                                                         source_location::
+                                                                             current()) {
     auto trace = generateLocationTrace(loc);
     testCase(idTable.clone(), false);
     testCase(split(idTable), false);

--- a/test/TypeTraitsTest.cpp
+++ b/test/TypeTraitsTest.cpp
@@ -205,8 +205,9 @@ struct BothInvocableWithSimilarReturnType {
 // There is a lot of overlap between the concepts.
 TEST(TypeTraits, InvocableWithConvertibleReturnType) {
   /*
-  Currently, `std::invocable` and `std::regular_invocable` are the same.
-  Therefore, having separate tests would be an unnecessary code increase.
+  Currently, `ql::concepts::invocable` and `ql::concepts::regular_invocable` are
+  the same. Therefore, having separate tests would be an unnecessary code
+  increase.
   */
   constexpr auto bothInvocableWithExactReturnType =
       BothInvocableWithExactReturnType{};

--- a/test/util/GTestHelpers.h
+++ b/test/util/GTestHelpers.h
@@ -141,11 +141,13 @@ class CopyShield {
 
  public:
   template <typename... Ts>
-  requires std::constructible_from<T, Ts&&...> explicit CopyShield(Ts&&... args)
+  requires ql::concepts::constructible_from<T, Ts&&...>
+  explicit CopyShield(Ts&&... args)
       : pointer_{std::make_shared<T>(AD_FWD(args)...)} {}
 
   template <typename Ts>
-  requires std::constructible_from<T, Ts&&> CopyShield& operator=(Ts&& ts) {
+  requires ql::concepts::constructible_from<T, Ts&&>
+  CopyShield& operator=(Ts&& ts) {
     pointer_ = std::make_shared<T>(AD_FWD(ts));
     return *this;
   }

--- a/test/util/IdTableHelpers.h
+++ b/test/util/IdTableHelpers.h
@@ -101,7 +101,7 @@ static constexpr MatchesIdTableFromVector matchesIdTableFromVector;
 // workaround for GMock/GTest.
 struct MatchesIdTable {
   template <typename... Ts>
-  requires(std::constructible_from<IdTable, Ts && ...>)
+  requires(ql::concepts::constructible_from<IdTable, Ts && ...>)
   auto operator()(Ts&&... ts) const {
     return ::testing::Eq(CopyShield<IdTable>(IdTable{AD_FWD(ts)...}));
   }

--- a/test/util/IdTestHelpers.h
+++ b/test/util/IdTestHelpers.h
@@ -30,7 +30,8 @@ inline auto BlankNodeId = [](const auto& v) {
   return Id::makeFromBlankNodeIndex(BlankNodeIndex::make(v));
 };
 
-inline auto LocalVocabId = [](std::integral auto v) {
+inline auto LocalVocabId = [](auto v) {
+  static_assert(ql::concepts::integral<decltype(v)>);
   static ad_utility::Synchronized<LocalVocab> localVocab;
   using namespace ad_utility::triple_component;
   return Id::makeFromLocalVocabIndex(


### PR DESCRIPTION
Rewrite more concepts to C++17.

Further TODOs:

1. systematically figure out remaining concepts usages in the codebase (in particular,replace `std::same_as` and remove all includes of the `<concepts>` header.