### PR TITLE
Add `QL_CONSTEVAL` and `QL_EXPLICIT` macros for compatibility with C++ 17

### DIFF
--- a/benchmark/JoinAlgorithmBenchmark.cpp
+++ b/benchmark/JoinAlgorithmBenchmark.cpp
@@ -37,6 +37,7 @@
 #include "../test/util/IdTableHelpers.h"
 #include "../test/util/JoinHelpers.h"
 #include "../test/util/RandomTestHelpers.h"
+#include "backports/keywords.h"
 #include "engine/Engine.h"
 #include "engine/Join.h"
 #include "engine/QueryExecutionTree.h"
@@ -74,8 +75,8 @@ static constexpr bool isValuePreservingCast(const Source& source) {
 /*
 @brief Return biggest possible value for the given arithmetic type.
 */
-CPP_template(typename Type)(
-    requires ad_utility::Arithmetic<Type>) consteval Type getMaxValue() {
+CPP_template(typename Type)(requires ad_utility::Arithmetic<Type>)
+    QL_CONSTEVAL Type getMaxValue() {
   return std::numeric_limits<Type>::max();
 }
 

--- a/src/backports/keywords.h
+++ b/src/backports/keywords.h
@@ -1,0 +1,19 @@
+//
+// Created by kalmbacj on 9/2/25.
+//
+
+// TODO<joka921> header guard.
+#ifndef KEYWORDS_H
+#define KEYWORDS_H
+
+// TODO<joka921> Comments.
+#ifdef QLEVER_CPP_17
+#define QL_CONSTEVAL constexpr
+#define QL_EXPLICIT(...)
+
+#else
+#define QL_CONSTEVAL consteval
+#define QL_EXPLICIT(...) explicit(__VA_ARGS__)
+#endif
+
+#endif  // KEYWORDS_H

--- a/src/backports/keywords.h
+++ b/src/backports/keywords.h
@@ -1,12 +1,19 @@
+// Copyright 2025 The QLever Authors, in particular:
 //
-// Created by kalmbacj on 9/2/25.
+// 2025 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR/QL
 //
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+// QL =  QLeverize AG
 
-// TODO<joka921> header guard.
-#ifndef KEYWORDS_H
-#define KEYWORDS_H
+#ifndef QLEVER_SRC_BACKPORTS_KEYWORDS_H
+#define QLEVER_SRC_BACKPORTS_KEYWORDS_H
 
-// TODO<joka921> Comments.
+// Add C++17 replacements for C++20 keywords like `consteval` and
+// `explicit(condition)`
+// 1. `QL_CONSTEVAL` is `consteval` in C++20 mode, and `constexpr` in C++17
+// mode.
+// 2. `QL_EXPLICIT(trueOrFalse)` is `explicit(trueOrFalse)`in C++20 mode and the
+// empty string (not explicit) in C++17 mode.
 #ifdef QLEVER_CPP_17
 #define QL_CONSTEVAL constexpr
 #define QL_EXPLICIT(...)
@@ -16,4 +23,4 @@
 #define QL_EXPLICIT(...) explicit(__VA_ARGS__)
 #endif
 
-#endif  // KEYWORDS_H
+#endif  // QLEVER_SRC_BACKPORTS_KEYWORDS_H

--- a/src/engine/sparqlExpressions/SparqlExpressionTypes.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionTypes.h
@@ -10,6 +10,7 @@
 
 #include <vector>
 
+#include "backports/keywords.h"
 #include "engine/QueryExecutionContext.h"
 #include "engine/sparqlExpressions/SetOfIntervals.h"
 #include "global/Id.h"
@@ -51,9 +52,8 @@ class VectorWithMemoryLimit
           concepts::derived_from<
               std::remove_cvref_t<ad_utility::First<Args...>>, Base>)
           CPP_and concepts::convertible_to<ad_utility::Last<Args...>, Allocator>
-              CPP_and concepts::constructible_from<
-                  Base, Args&&...>) explicit(sizeof...(Args) == 1)
-      VectorWithMemoryLimit(Args&&... args)
+              CPP_and concepts::constructible_from<Base, Args&&...>)
+      QL_EXPLICIT(sizeof...(Args) == 1) VectorWithMemoryLimit(Args&&... args)
       : Base{AD_FWD(args)...} {}
 
   // We have to explicitly forward the `initializer_list` constructor because it

--- a/src/index/LocalVocabEntry.h
+++ b/src/index/LocalVocabEntry.h
@@ -8,6 +8,7 @@
 #include <atomic>
 
 #include "backports/algorithm.h"
+#include "backports/keywords.h"
 #include "global/TypedIndex.h"
 #include "global/VocabIndex.h"
 #include "parser/LiteralOrIri.h"
@@ -45,9 +46,9 @@ class alignas(16) LocalVocabEntry
   using Base::Base;
 
   // Deliberately allow implicit conversion from `LiteralOrIri`.
-  explicit(false) LocalVocabEntry(const Base& base) : Base{base} {}
-  explicit(false) LocalVocabEntry(Base&& base) noexcept
-      : Base{std::move(base)} {}
+  QL_EXPLICIT(false) LocalVocabEntry(const Base& base) : Base{base} {}
+  QL_EXPLICIT(false)
+  LocalVocabEntry(Base&& base) noexcept : Base{std::move(base)} {}
 
   // Slice to base class `LiteralOrIri`.
   const ad_utility::triple_component::LiteralOrIri& asLiteralOrIri() const {

--- a/src/util/ConcurrentCache.h
+++ b/src/util/ConcurrentCache.h
@@ -10,6 +10,7 @@
 #include <mutex>
 #include <utility>
 
+#include "backports/keywords.h"
 #include "util/Forward.h"
 #include "util/HashMap.h"
 #include "util/Log.h"
@@ -338,10 +339,10 @@ class ConcurrentCache {
 
     CacheAndInProgressMap() = default;
     CPP_template_2(typename Arg, typename... Args)(
-        requires(!ql::concepts::same_as<
-                 std::remove_cvref_t<Arg>,
-                 CacheAndInProgressMap>)) explicit(sizeof...(Args) > 0)
-        CacheAndInProgressMap(Arg&& arg, Args&&... args)
+        requires(!ql::concepts::same_as<std::remove_cvref_t<Arg>,
+                                        CacheAndInProgressMap>))
+        QL_EXPLICIT(sizeof...(Args) > 0)
+            CacheAndInProgressMap(Arg&& arg, Args&&... args)
         : _cache{AD_FWD(arg), AD_FWD(args)...} {}
   };
 

--- a/src/util/ConfigManager/ConfigOptionProxy.h
+++ b/src/util/ConfigManager/ConfigOptionProxy.h
@@ -11,6 +11,7 @@
 #include <stdexcept>
 #include <type_traits>
 
+#include "backports/keywords.h"
 #include "util/ConfigManager/ConfigOption.h"
 #include "util/Exception.h"
 #include "util/TypeTraits.h"
@@ -57,12 +58,14 @@ CPP_template(typename T, typename ConfigOptionType)(
   }
 
   // (Implicit) conversion to `ConfigOptionType&`.
-  explicit(false) operator ConfigOptionType&() const
+  QL_EXPLICIT(false)
+  operator ConfigOptionType&() const
       QL_CONCEPT_OR_NOTHING(requires(std::is_const_v<ConfigOptionType>)) {
     return getConfigOption();
   }
 
-  explicit(false) operator ConfigOptionType&()
+  QL_EXPLICIT(false)
+  operator ConfigOptionType&()
       QL_CONCEPT_OR_NOTHING(requires(!std::is_const_v<ConfigOptionType>)) {
     return getConfigOption();
   }
@@ -102,7 +105,7 @@ class ConfigOptionProxy
   explicit ConfigOptionProxy(ConfigOption& opt) : Base(opt) {}
 
   // Implicit conversion from not const to const is allowed.
-  explicit(false) operator ConstConfigOptionProxy<T>() {
+  QL_EXPLICIT(false) operator ConstConfigOptionProxy<T>() {
     return ConstConfigOptionProxy<T>(Base::getConfigOption());
   }
 };

--- a/src/util/Log.h
+++ b/src/util/Log.h
@@ -16,6 +16,7 @@
 #include <sstream>
 #include <string>
 
+#include "backports/keywords.h"
 #include "util/ConstexprMap.h"
 #include "util/TypeTraits.h"
 
@@ -125,7 +126,7 @@ class Log {
   }
 
   template <LogLevel LEVEL>
-  static consteval std::string_view getLevel() {
+  static QL_CONSTEVAL std::string_view getLevel() {
     using std::pair;
     constexpr ad_utility::ConstexprMap map{std::array{
         pair(TRACE, "TRACE: "),

--- a/src/util/MemorySize/MemorySize.h
+++ b/src/util/MemorySize/MemorySize.h
@@ -20,6 +20,7 @@
 #include <type_traits>
 
 #include "backports/algorithm.h"
+#include "backports/keywords.h"
 #include "util/ConstexprMap.h"
 #include "util/ConstexprUtils.h"
 #include "util/Exception.h"
@@ -156,15 +157,15 @@ Note that user defined literals only allow very specific types for function
 arguments, so I couldn't use more fitting types.
 */
 namespace memory_literals {
-consteval MemorySize operator""_B(unsigned long long int bytes);
-consteval MemorySize operator""_kB(long double kilobytes);
-consteval MemorySize operator""_kB(unsigned long long int kilobytes);
-consteval MemorySize operator""_MB(long double megabytes);
-consteval MemorySize operator""_MB(unsigned long long int megabytes);
-consteval MemorySize operator""_GB(long double gigabytes);
-consteval MemorySize operator""_GB(unsigned long long int gigabytes);
-consteval MemorySize operator""_TB(long double terabytes);
-consteval MemorySize operator""_TB(unsigned long long int terabytes);
+QL_CONSTEVAL MemorySize operator""_B(unsigned long long int bytes);
+QL_CONSTEVAL MemorySize operator""_kB(long double kilobytes);
+QL_CONSTEVAL MemorySize operator""_kB(unsigned long long int kilobytes);
+QL_CONSTEVAL MemorySize operator""_MB(long double megabytes);
+QL_CONSTEVAL MemorySize operator""_MB(unsigned long long int megabytes);
+QL_CONSTEVAL MemorySize operator""_GB(long double gigabytes);
+QL_CONSTEVAL MemorySize operator""_GB(unsigned long long int gigabytes);
+QL_CONSTEVAL MemorySize operator""_TB(long double terabytes);
+QL_CONSTEVAL MemorySize operator""_TB(unsigned long long int terabytes);
 }  // namespace memory_literals
 
 /*
@@ -487,47 +488,47 @@ CPP_template_def(typename T)(
 
 namespace memory_literals {
 // _____________________________________________________________________________
-consteval MemorySize operator""_B(unsigned long long int bytes) {
+QL_CONSTEVAL MemorySize operator""_B(unsigned long long int bytes) {
   return MemorySize::bytes(bytes);
 }
 
 // _____________________________________________________________________________
-consteval MemorySize operator""_kB(long double kilobytes) {
+QL_CONSTEVAL MemorySize operator""_kB(long double kilobytes) {
   return MemorySize::kilobytes(static_cast<double>(kilobytes));
 }
 
 // _____________________________________________________________________________
-consteval MemorySize operator""_kB(unsigned long long int kilobytes) {
+QL_CONSTEVAL MemorySize operator""_kB(unsigned long long int kilobytes) {
   return MemorySize::kilobytes(static_cast<size_t>(kilobytes));
 }
 
 // _____________________________________________________________________________
-consteval MemorySize operator""_MB(long double megabytes) {
+QL_CONSTEVAL MemorySize operator""_MB(long double megabytes) {
   return MemorySize::megabytes(static_cast<double>(megabytes));
 }
 
 // _____________________________________________________________________________
-consteval MemorySize operator""_MB(unsigned long long int megabytes) {
+QL_CONSTEVAL MemorySize operator""_MB(unsigned long long int megabytes) {
   return MemorySize::megabytes(static_cast<size_t>(megabytes));
 }
 
 // _____________________________________________________________________________
-consteval MemorySize operator""_GB(long double gigabytes) {
+QL_CONSTEVAL MemorySize operator""_GB(long double gigabytes) {
   return MemorySize::gigabytes(static_cast<double>(gigabytes));
 }
 
 // _____________________________________________________________________________
-consteval MemorySize operator""_GB(unsigned long long int gigabytes) {
+QL_CONSTEVAL MemorySize operator""_GB(unsigned long long int gigabytes) {
   return MemorySize::gigabytes(static_cast<size_t>(gigabytes));
 }
 
 // _____________________________________________________________________________
-consteval MemorySize operator""_TB(long double terabytes) {
+QL_CONSTEVAL MemorySize operator""_TB(long double terabytes) {
   return MemorySize::terabytes(static_cast<double>(terabytes));
 }
 
 // _____________________________________________________________________________
-consteval MemorySize operator""_TB(unsigned long long int terabytes) {
+QL_CONSTEVAL MemorySize operator""_TB(unsigned long long int terabytes) {
   return MemorySize::terabytes(static_cast<size_t>(terabytes));
 }
 }  // namespace memory_literals

--- a/src/util/Parameters.h
+++ b/src/util/Parameters.h
@@ -13,6 +13,7 @@
 #include <tuple>
 #include <type_traits>
 
+#include "backports/keywords.h"
 #include "util/ConstexprMap.h"
 #include "util/ConstexprSmallString.h"
 #include "util/HashMap.h"
@@ -292,8 +293,8 @@ class Parameters {
 
  public:
   Parameters() = delete;
-  explicit(sizeof...(ParameterTypes) == 1) Parameters(ParameterTypes... ts)
-      : _parameters{std::move(ts)...} {}
+  QL_EXPLICIT(sizeof...(ParameterTypes) == 1)
+  Parameters(ParameterTypes... ts) : _parameters{std::move(ts)...} {}
 
   // Get value for parameter `Name` known at compile time.
   // The parameter is returned  by value, since

--- a/src/util/ParseableDuration.h
+++ b/src/util/ParseableDuration.h
@@ -14,6 +14,7 @@
 #include <ctre-unicode.hpp>
 #include <iostream>
 
+#include "backports/keywords.h"
 #include "util/Exception.h"
 #include "util/TypeTraits.h"
 
@@ -35,9 +36,9 @@ class ParseableDuration {
  public:
   ParseableDuration() = default;
   // Implicit conversion is on purpose!
-  explicit(false) ParseableDuration(DurationType duration)
-      : duration_{duration} {}
-  explicit(false) operator DurationType() const { return duration_; }
+  QL_EXPLICIT(false)
+  ParseableDuration(DurationType duration) : duration_{duration} {}
+  QL_EXPLICIT(false) operator DurationType() const { return duration_; }
 
   // TODO default this implementation (and remove explicit equality) once libc++
   // supports it.

--- a/src/util/Serializer/SerializeArrayOrTuple.h
+++ b/src/util/Serializer/SerializeArrayOrTuple.h
@@ -10,6 +10,7 @@
 #include <array>
 #include <tuple>
 
+#include "backports/keywords.h"
 #include "util/ConstexprUtils.h"
 #include "util/Serializer/Serializer.h"
 #include "util/TypeTraits.h"
@@ -35,7 +36,7 @@ struct IsTriviallySerializable {
 };
 
 template <typename T>
-consteval bool tupleTriviallySerializableImpl() {
+QL_CONSTEVAL bool tupleTriviallySerializableImpl() {
   bool result = true;
   ad_utility::forEachTypeInTemplateType<T>(IsTriviallySerializable{result});
   return result;

--- a/src/util/Synchronized.h
+++ b/src/util/Synchronized.h
@@ -12,6 +12,7 @@
 #include <condition_variable>
 #include <shared_mutex>
 
+#include "backports/keywords.h"
 #include "util/Forward.h"
 #include "util/OnDestructionDontThrowDuringStackUnwinding.h"
 
@@ -97,10 +98,9 @@ class Synchronized {
 
   /// Constructor that is not copy or move, tries to instantiate the underlying
   /// type via perfect forwarding (this includes the default constructor)
-  CPP_template(typename Arg, typename... Args)(requires CPP_NOT(
-      std::same_as<std::remove_cvref_t<Arg>,
-                   Synchronized>)) explicit(sizeof...(Args) == 0)
-      Synchronized(Arg&& arg, Args&&... args)
+  CPP_template(typename Arg, typename... Args)(
+      requires CPP_NOT(std::same_as<std::remove_cvref_t<Arg>, Synchronized>))
+      QL_EXPLICIT(sizeof...(Args) == 0) Synchronized(Arg&& arg, Args&&... args)
       : data_{AD_FWD(arg), AD_FWD(args)...}, m_{} {}
 
   template <typename... Args>

--- a/src/util/ValueIdentity.h
+++ b/src/util/ValueIdentity.h
@@ -5,7 +5,7 @@
 
 #include <tuple>
 
-#include "backports/algorithm.h"
+#include "backports/keywords.h"
 #include "util/Forward.h"
 
 // The use case of the following aliases and constants is as follows:

--- a/src/util/ValueIdentity.h
+++ b/src/util/ValueIdentity.h
@@ -5,6 +5,7 @@
 
 #include <tuple>
 
+#include "backports/algorithm.h"
 #include "util/Forward.h"
 
 // The use case of the following aliases and constants is as follows:
@@ -26,7 +27,7 @@ namespace use_value_identity {
 template <auto V>
 struct ValueIdentity {
   static constexpr auto value = V;
-  explicit(false) constexpr operator decltype(V)() const { return value; }
+  QL_EXPLICIT(false) constexpr operator decltype(V)() const { return value; }
 };
 
 template <auto V>

--- a/test/CancellationHandleTest.cpp
+++ b/test/CancellationHandleTest.cpp
@@ -8,6 +8,7 @@
 #include <absl/strings/str_cat.h>
 #include <gmock/gmock.h>
 
+#include "backports/keywords.h"
 #include "util/CancellationHandle.h"
 #include "util/GTestHelpers.h"
 #include "util/jthread.h"
@@ -465,7 +466,7 @@ TEST(CancellationHandle, expectDisabledHandleIsAlwaysFalse) {
 }
 
 template <typename T>
-consteval bool isMemberFunction([[maybe_unused]] T funcPtr) {
+QL_CONSTEVAL bool isMemberFunction([[maybe_unused]] T funcPtr) {
   return std::is_member_function_pointer_v<T>;
 }
 


### PR DESCRIPTION
Introduce `backports/keywords.h`, which defines the following two macros:

1. `QL_CONSTEVAL`, which is `consteval` by default, and `constexpr` for C++ 17
2. `QL_EXPLICIT`, which is `explicit` with a Boolean argument by default, and the empty string for C++17 