### PR TITLE
Make `ConstexprMap` compatible with C++17

### DIFF
--- a/src/engine/sparqlExpressions/PrefilterExpressionIndex.cpp
+++ b/src/engine/sparqlExpressions/PrefilterExpressionIndex.cpp
@@ -507,7 +507,7 @@ std::unique_ptr<PrefilterExpression>
 RelationalExpression<Comparison>::logicalComplement() const {
   using enum CompOp;
   using namespace ad_utility;
-  using P = std::pair<CompOp, CompOp>;
+  using P = ConstexprMapPair<CompOp, CompOp>;
   // The complementation logic implemented with the following mapping
   // procedure:
   // (1) ?var < referenceValue -> ?var >= referenceValue
@@ -1019,7 +1019,7 @@ std::vector<PrefilterExprVariablePair> makePrefilterExpressionVec(
   using enum CompOp;
   std::vector<PrefilterExprVariablePair> resVec{};
   if (mirrored) {
-    using P = std::pair<CompOp, CompOp>;
+    using P = ad_utility::ConstexprMapPair<CompOp, CompOp>;
     // Retrieve by map the corresponding mirrored `CompOp` value for
     // the given `CompOp comparison` template argument. E.g., this
     // procedure will transform the relational expression

--- a/src/util/ConstexprMap.h
+++ b/src/util/ConstexprMap.h
@@ -32,9 +32,8 @@ class ConstexprMap {
   // Create from an Array of key-value pairs. The keys have to be unique.
   explicit constexpr ConstexprMap(Arr values) : _values{std::move(values)} {
     ql::ranges::sort(_values, compare);
-    if (::ranges::unique(_values, [](const Pair& a, const Pair& b) {
-          return boost::hana::first(a) == boost::hana::first(b);
-        }) != _values.end()) {
+    if (::ranges::adjacent_find(_values, std::equal_to<>{},
+                                boost::hana::first) != _values.end()) {
       throw std::runtime_error{
           "ConstexprMap requires that all the keys are unique"};
     }
@@ -43,9 +42,8 @@ class ConstexprMap {
   // If `key` is in the map, return an iterator to the corresponding `(Key,
   // Value)` pair. Else return `end()`.
   constexpr typename Arr::const_iterator find(const Key& key) const {
-    auto lb = ql::ranges::lower_bound(
-        _values, key, [](const Key& a, const Key& b) { return a < b; },
-        [](const Pair& p) -> decltype(auto) { return boost::hana::first(p); });
+    auto lb = ql::ranges::lower_bound(_values, key, std::less<>{},
+                                      boost::hana::first);
     if (lb == _values.end() || boost::hana::first(*lb) != key) {
       return _values.end();
     }

--- a/src/util/Log.h
+++ b/src/util/Log.h
@@ -126,15 +126,15 @@ class Log {
 
   template <LogLevel LEVEL>
   static consteval std::string_view getLevel() {
-    using std::pair;
-    constexpr ad_utility::ConstexprMap map{std::array{
-        pair(TRACE, "TRACE: "),
-        pair(TIMING, "TIMING: "),
-        pair(DEBUG, "DEBUG: "),
-        pair(INFO, "INFO: "),
-        pair(WARN, "WARN: "),
-        pair(ERROR, "ERROR: "),
-        pair(FATAL, "FATAL: "),
+    using P = ConstexprMapPair<LogLevel, std::string_view>;
+    constexpr ConstexprMap map{std::array{
+        P(TRACE, "TRACE: "),
+        P(TIMING, "TIMING: "),
+        P(DEBUG, "DEBUG: "),
+        P(INFO, "INFO: "),
+        P(WARN, "WARN: "),
+        P(ERROR, "ERROR: "),
+        P(FATAL, "FATAL: "),
     }};
     return map.at(LEVEL);
   }

--- a/src/util/MemorySize/MemorySize.cpp
+++ b/src/util/MemorySize/MemorySize.cpp
@@ -42,11 +42,12 @@ std::string MemorySize::asString() const {
   // NOTE: the lower bound for `kB` is `100'000` instead of `1'000` because we
   // want exact values below `100'000` bytes (for example, block or page sizes
   // are often larger than 1'000 bytes but below 100'000 bytes).
-  constexpr ad_utility::ConstexprMap<char, size_t, 4> memoryUnitLowerBound(
-      {std::pair<char, size_t>{'k', ad_utility::pow(10, 5)},
-       std::pair<char, size_t>{'M', detail::numBytesPerUnit.at("MB")},
-       std::pair<char, size_t>{'G', detail::numBytesPerUnit.at("GB")},
-       std::pair<char, size_t>{'T', detail::numBytesPerUnit.at("TB")}});
+  using P = ad_utility::ConstexprMapPair<char, size_t>;
+  constexpr static ad_utility::ConstexprMap<char, size_t, 4>
+      memoryUnitLowerBound({P{'k', ad_utility::pow(10, 5)},
+                            P{'M', detail::numBytesPerUnit.at("MB")},
+                            P{'G', detail::numBytesPerUnit.at("GB")},
+                            P{'T', detail::numBytesPerUnit.at("TB")}});
 
   // Go through the units from top to bottom, in terms of size, and choose the
   // first one, that is smaller/equal to `memoryInBytes_`.

--- a/src/util/MemorySize/MemorySize.h
+++ b/src/util/MemorySize/MemorySize.h
@@ -176,11 +176,12 @@ consteval MemorySize operator""_TB(unsigned long long int terabytes);
 // Helper functions.
 namespace detail {
 // Just the number of bytes per memory unit.
+using MapPair = ConstexprMapPair<std::string_view, size_t>;
 constexpr ConstexprMap<std::string_view, size_t, 5> numBytesPerUnit(
-    {std::pair{"B", 1uL}, std::pair{"kB", ad_utility::pow<size_t>(10, 3)},
-     std::pair{"MB", ad_utility::pow<size_t>(10, 6)},
-     std::pair{"GB", ad_utility::pow<size_t>(10, 9)},
-     std::pair{"TB", ad_utility::pow<size_t>(10, 12)}});
+    {MapPair{"B", 1uL}, MapPair{"kB", ad_utility::pow<size_t>(10, 3)},
+     MapPair{"MB", ad_utility::pow<size_t>(10, 6)},
+     MapPair{"GB", ad_utility::pow<size_t>(10, 9)},
+     MapPair{"TB", ad_utility::pow<size_t>(10, 12)}});
 
 /*
 Helper function for dividing two instances of `size_t`.
@@ -201,11 +202,13 @@ static constexpr size_t size_t_max = std::numeric_limits<size_t>::max();
 
 // The maximal amount of a memory unit, that a `MemorySize` can remember.
 constexpr ConstexprMap<std::string_view, double, 5> maxAmountOfUnit(
-    {std::pair{"B", sizeTDivision(size_t_max, numBytesPerUnit.at("B"))},
-     std::pair{"kB", sizeTDivision(size_t_max, numBytesPerUnit.at("kB"))},
-     std::pair{"MB", sizeTDivision(size_t_max, numBytesPerUnit.at("MB"))},
-     std::pair{"GB", sizeTDivision(size_t_max, numBytesPerUnit.at("GB"))},
-     std::pair{"TB", sizeTDivision(size_t_max, numBytesPerUnit.at("TB"))}});
+    // TODO<joka921> There currently is an overflow in the division (which is
+    // performed using doubles). Mitigate this properly.
+    {MapPair{"B", size_t_max},
+     MapPair{"kB", sizeTDivision(size_t_max, numBytesPerUnit.at("kB"))},
+     MapPair{"MB", sizeTDivision(size_t_max, numBytesPerUnit.at("MB"))},
+     MapPair{"GB", sizeTDivision(size_t_max, numBytesPerUnit.at("GB"))},
+     MapPair{"TB", sizeTDivision(size_t_max, numBytesPerUnit.at("TB"))}});
 
 // Converts a given number to `size_t`. Rounds up, if needed.
 CPP_template(typename T)(requires Arithmetic<T>) constexpr size_t

--- a/src/util/MemorySize/MemorySize.h
+++ b/src/util/MemorySize/MemorySize.h
@@ -201,14 +201,13 @@ constexpr static double sizeTDivision(const size_t dividend,
 static constexpr size_t size_t_max = std::numeric_limits<size_t>::max();
 
 // The maximal amount of a memory unit, that a `MemorySize` can remember.
-constexpr ConstexprMap<std::string_view, double, 5> maxAmountOfUnit(
-    // TODO<joka921> There currently is an overflow in the division (which is
-    // performed using doubles). Mitigate this properly.
-    {MapPair{"B", size_t_max},
-     MapPair{"kB", sizeTDivision(size_t_max, numBytesPerUnit.at("kB"))},
-     MapPair{"MB", sizeTDivision(size_t_max, numBytesPerUnit.at("MB"))},
-     MapPair{"GB", sizeTDivision(size_t_max, numBytesPerUnit.at("GB"))},
-     MapPair{"TB", sizeTDivision(size_t_max, numBytesPerUnit.at("TB"))}});
+static constexpr auto maxAmountOfUnit = []() {
+  auto p = [](std::string_view unitName) {
+    return ConstexprMapPair<std::string_view, double>{
+        unitName, sizeTDivision(size_t_max, numBytesPerUnit.at(unitName))};
+  };
+  return ConstexprMap{std::array{p("B"), p("kB"), p("MB"), p("GB"), p("TB")}};
+}();
 
 // Converts a given number to `size_t`. Rounds up, if needed.
 CPP_template(typename T)(requires Arithmetic<T>) constexpr size_t

--- a/src/util/Parameters.h
+++ b/src/util/Parameters.h
@@ -266,11 +266,11 @@ class Parameters {
   static constexpr auto _nameToIndex = []() {
     size_t i = 0;
     // {firstName, 0}, {secondName, 1}, {thirdName, 2}...
-    auto arr = std::array{std::pair{ParameterTypes::name, i++}...};
+    auto arr = std::array{boost::hana::pair{ParameterTypes::name, i++}...};
 
     // Assert that the indices are in fact correct.
     for (size_t k = 0; k < arr.size(); ++k) {
-      if (arr[k].second != k) {
+      if (boost::hana::second(arr[k]) != k) {
         throw std::runtime_error{
             "Wrong order in parameter array, this should never happen."};
       }

--- a/test/MemorySizeTest.cpp
+++ b/test/MemorySizeTest.cpp
@@ -65,15 +65,15 @@ struct AllMemoryUnitSizes {
 
 // A hash map pairing up a single memory size unit with the corresponding
 // `AllMemoryUnitSizes` representations.
+using Pair = ad_utility::ConstexprMapPair<std::string_view, AllMemoryUnitSizes>;
 constexpr ad_utility::ConstexprMap<std::string_view, AllMemoryUnitSizes, 5>
     singleMemoryUnitSizes(
-        {std::pair{"B", AllMemoryUnitSizes{1uL, 1e-3, 1e-6, 1e-9, 1e-12}},
-         std::pair{"kB", AllMemoryUnitSizes{1'000uL, 1, 1e-3, 1e-6, 1e-9}},
-         std::pair{"MB", AllMemoryUnitSizes{1'000'000uL, 1e3, 1, 1e-3, 1e-6}},
-         std::pair{"GB",
-                   AllMemoryUnitSizes{1'000'000'000uL, 1e6, 1e3, 1, 1e-3}},
-         std::pair{"TB",
-                   AllMemoryUnitSizes{1'000'000'000'000uL, 1e9, 1e6, 1e3, 1}}});
+        {Pair{"B", AllMemoryUnitSizes{1uL, 1e-3, 1e-6, 1e-9, 1e-12}},
+         Pair{"kB", AllMemoryUnitSizes{1'000uL, 1, 1e-3, 1e-6, 1e-9}},
+         Pair{"MB", AllMemoryUnitSizes{1'000'000uL, 1e3, 1, 1e-3, 1e-6}},
+         Pair{"GB", AllMemoryUnitSizes{1'000'000'000uL, 1e6, 1e3, 1, 1e-3}},
+         Pair{"TB",
+              AllMemoryUnitSizes{1'000'000'000'000uL, 1e9, 1e6, 1e3, 1}}});
 
 /*
 Checks all the getters of the class with the wanted memory sizes.


### PR DESCRIPTION
This is done by using `boost::hana::pair` instead of `std::pair`, because the latter only becomes `constexpr` as of C++20. This changes neither functionality nor performance, just compatibility with C++17