### PR TITLE
Refactor `constexprStrCat` to be compatible with C++17

### DIFF
--- a/src/global/Constants.h
+++ b/src/global/Constants.h
@@ -44,19 +44,6 @@ constexpr inline std::string_view QLEVER_INTERNAL_PREFIX_URL =
 namespace string_constants::detail {
 constexpr inline std::string_view openAngle = "<";
 constexpr inline std::string_view closeAngle = ">";
-constexpr inline std::string_view empty = "";
-constexpr inline std::string_view contains_entity = "contains-entity";
-constexpr inline std::string_view contains_word = "contains-word";
-constexpr inline std::string_view text = "text";
-constexpr inline std::string_view has_predicate = "has-predicate";
-constexpr inline std::string_view has_pattern = "has-pattern";
-constexpr inline std::string_view default_graph = "default-graph";
-constexpr inline std::string_view internal_graph = "internal-graph";
-constexpr inline std::string_view blank_node_prefix = "blank-node/";
-constexpr inline std::string_view geo_literal_prefix = "\"^^<";
-constexpr inline std::string_view unit_meter = "M";
-constexpr inline std::string_view unit_kilometer = "KiloM";
-constexpr inline std::string_view unit_mile = "MI";
 }  // namespace string_constants::detail
 template <const std::string_view&... suffixes>
 constexpr std::string_view makeQleverInternalIriConst() {
@@ -69,27 +56,54 @@ inline std::string makeQleverInternalIri(const T&... suffixes) {
   return absl::StrCat("<", QLEVER_INTERNAL_PREFIX_URL, suffixes..., ">");
 }
 
+namespace string_constants::detail {
+constexpr inline std::string_view empty = "";
+}  // namespace string_constants::detail
 constexpr inline std::string_view QLEVER_INTERNAL_PREFIX_IRI =
     makeQleverInternalIriConst<string_constants::detail::empty>();
 constexpr inline std::string_view
     QLEVER_INTERNAL_PREFIX_IRI_WITHOUT_CLOSING_BRACKET =
         ad_utility::constexprStrCat<string_constants::detail::openAngle,
                                     QLEVER_INTERNAL_PREFIX_URL>();
+namespace string_constants::detail {
+constexpr inline std::string_view contains_entity = "contains-entity";
+}  // namespace string_constants::detail
 constexpr inline std::string_view CONTAINS_ENTITY_PREDICATE =
     makeQleverInternalIriConst<string_constants::detail::contains_entity>();
+namespace string_constants::detail {
+constexpr inline std::string_view contains_word = "contains-word";
+}  // namespace string_constants::detail
 constexpr inline std::string_view CONTAINS_WORD_PREDICATE =
     makeQleverInternalIriConst<string_constants::detail::contains_word>();
 
+namespace string_constants::detail {
+constexpr inline std::string_view text = "text";
+}  // namespace string_constants::detail
 constexpr inline std::string_view QLEVER_INTERNAL_TEXT_MATCH_PREDICATE =
     makeQleverInternalIriConst<string_constants::detail::text>();
+namespace string_constants::detail {
+constexpr inline std::string_view has_predicate = "has-predicate";
+}  // namespace string_constants::detail
 constexpr inline std::string_view HAS_PREDICATE_PREDICATE =
     makeQleverInternalIriConst<string_constants::detail::has_predicate>();
+namespace string_constants::detail {
+constexpr inline std::string_view has_pattern = "has-pattern";
+}  // namespace string_constants::detail
 constexpr inline std::string_view HAS_PATTERN_PREDICATE =
     makeQleverInternalIriConst<string_constants::detail::has_pattern>();
+namespace string_constants::detail {
+constexpr inline std::string_view default_graph = "default-graph";
+}  // namespace string_constants::detail
 constexpr inline std::string_view DEFAULT_GRAPH_IRI =
     makeQleverInternalIriConst<string_constants::detail::default_graph>();
+namespace string_constants::detail {
+constexpr inline std::string_view internal_graph = "internal-graph";
+}  // namespace string_constants::detail
 constexpr inline std::string_view QLEVER_INTERNAL_GRAPH_IRI =
     makeQleverInternalIriConst<string_constants::detail::internal_graph>();
+namespace string_constants::detail {
+constexpr inline std::string_view blank_node_prefix = "blank-node/";
+}  // namespace string_constants::detail
 constexpr inline std::string_view QLEVER_INTERNAL_BLANK_NODE_IRI_PREFIX =
     ad_utility::constexprStrCat<string_constants::detail::openAngle,
                                 QLEVER_INTERNAL_PREFIX_URL,
@@ -175,6 +189,9 @@ constexpr inline char RDF_LANGTAG_STRING[] =
 
 constexpr inline std::string_view GEO_WKT_LITERAL =
     "http://www.opengis.net/ont/geosparql#wktLiteral";
+namespace string_constants::detail {
+constexpr inline std::string_view geo_literal_prefix = "\"^^<";
+}  // namespace string_constants::detail
 static constexpr std::string_view GEO_LITERAL_SUFFIX =
     ad_utility::constexprStrCat<string_constants::detail::geo_literal_prefix,
                                 GEO_WKT_LITERAL,
@@ -182,12 +199,21 @@ static constexpr std::string_view GEO_LITERAL_SUFFIX =
 
 enum class UnitOfMeasurement { METERS, KILOMETERS, MILES, UNKNOWN };
 constexpr inline std::string_view UNIT_PREFIX = "http://qudt.org/vocab/unit/";
+namespace string_constants::detail {
+constexpr inline std::string_view unit_meter = "M";
+}  // namespace string_constants::detail
 constexpr inline std::string_view UNIT_METER_IRI =
     ad_utility::constexprStrCat<UNIT_PREFIX,
                                 string_constants::detail::unit_meter>();
+namespace string_constants::detail {
+constexpr inline std::string_view unit_kilometer = "KiloM";
+}  // namespace string_constants::detail
 constexpr inline std::string_view UNIT_KILOMETER_IRI =
     ad_utility::constexprStrCat<UNIT_PREFIX,
                                 string_constants::detail::unit_kilometer>();
+namespace string_constants::detail {
+constexpr inline std::string_view unit_mile = "MI";
+}  // namespace string_constants::detail
 constexpr inline std::string_view UNIT_MILE_IRI =
     ad_utility::constexprStrCat<UNIT_PREFIX,
                                 string_constants::detail::unit_mile>();

--- a/src/global/Constants.h
+++ b/src/global/Constants.h
@@ -35,48 +35,65 @@ constexpr inline size_t TEXT_PREDICATE_CARDINALITY_ESTIMATE = 1'000'000'000;
 constexpr inline size_t GALLOP_THRESHOLD = 1000;
 
 constexpr inline char QLEVER_INTERNAL_PREFIX_NAME[] = "ql";
-constexpr inline char QLEVER_INTERNAL_PREFIX_URL[] =
+constexpr inline std::string_view QLEVER_INTERNAL_PREFIX_URL =
     "http://qlever.cs.uni-freiburg.de/builtin-functions/";
 
 // Make a QLever-internal IRI from `QL_INTERNAL_PREFIX_URL` by appending the
 // concatenation of the given `suffixes` and enclosing the result in angle
 // brackets (const and non-const version).
-template <
-    ad_utility::detail::constexpr_str_cat_impl::ConstexprString... suffixes>
+namespace string_constants::detail {
+constexpr inline std::string_view openAngle = "<";
+constexpr inline std::string_view closeAngle = ">";
+constexpr inline std::string_view empty = "";
+constexpr inline std::string_view contains_entity = "contains-entity";
+constexpr inline std::string_view contains_word = "contains-word";
+constexpr inline std::string_view text = "text";
+constexpr inline std::string_view has_predicate = "has-predicate";
+constexpr inline std::string_view has_pattern = "has-pattern";
+constexpr inline std::string_view default_graph = "default-graph";
+constexpr inline std::string_view internal_graph = "internal-graph";
+constexpr inline std::string_view blank_node_prefix = "blank-node/";
+constexpr inline std::string_view geo_literal_prefix = "\"^^<";
+constexpr inline std::string_view unit_meter = "M";
+constexpr inline std::string_view unit_kilometer = "KiloM";
+constexpr inline std::string_view unit_mile = "MI";
+}  // namespace string_constants::detail
+template <const std::string_view&... suffixes>
 constexpr std::string_view makeQleverInternalIriConst() {
-  return ad_utility::constexprStrCat<"<", QLEVER_INTERNAL_PREFIX_URL,
-                                     suffixes..., ">">();
+  using namespace string_constants::detail;
+  return ad_utility::constexprStrCat<openAngle, QLEVER_INTERNAL_PREFIX_URL,
+                                     suffixes..., closeAngle>();
 }
 template <typename... T>
 inline std::string makeQleverInternalIri(const T&... suffixes) {
-  return absl::StrCat("<", std::string_view{QLEVER_INTERNAL_PREFIX_URL},
-                      suffixes..., ">");
+  return absl::StrCat("<", QLEVER_INTERNAL_PREFIX_URL, suffixes..., ">");
 }
 
 constexpr inline std::string_view QLEVER_INTERNAL_PREFIX_IRI =
-    makeQleverInternalIriConst<"">();
+    makeQleverInternalIriConst<string_constants::detail::empty>();
 constexpr inline std::string_view
     QLEVER_INTERNAL_PREFIX_IRI_WITHOUT_CLOSING_BRACKET =
-        ad_utility::constexprStrCat<"<", QLEVER_INTERNAL_PREFIX_URL>();
+        ad_utility::constexprStrCat<string_constants::detail::openAngle,
+                                    QLEVER_INTERNAL_PREFIX_URL>();
 constexpr inline std::string_view CONTAINS_ENTITY_PREDICATE =
-    makeQleverInternalIriConst<"contains-entity">();
+    makeQleverInternalIriConst<string_constants::detail::contains_entity>();
 constexpr inline std::string_view CONTAINS_WORD_PREDICATE =
-    makeQleverInternalIriConst<"contains-word">();
+    makeQleverInternalIriConst<string_constants::detail::contains_word>();
 
 constexpr inline std::string_view QLEVER_INTERNAL_TEXT_MATCH_PREDICATE =
-    makeQleverInternalIriConst<"text">();
+    makeQleverInternalIriConst<string_constants::detail::text>();
 constexpr inline std::string_view HAS_PREDICATE_PREDICATE =
-    makeQleverInternalIriConst<"has-predicate">();
+    makeQleverInternalIriConst<string_constants::detail::has_predicate>();
 constexpr inline std::string_view HAS_PATTERN_PREDICATE =
-    makeQleverInternalIriConst<"has-pattern">();
+    makeQleverInternalIriConst<string_constants::detail::has_pattern>();
 constexpr inline std::string_view DEFAULT_GRAPH_IRI =
-    makeQleverInternalIriConst<"default-graph">();
+    makeQleverInternalIriConst<string_constants::detail::default_graph>();
 constexpr inline std::string_view QLEVER_INTERNAL_GRAPH_IRI =
-    makeQleverInternalIriConst<"internal-graph">();
+    makeQleverInternalIriConst<string_constants::detail::internal_graph>();
 constexpr inline std::string_view QLEVER_INTERNAL_BLANK_NODE_IRI_PREFIX =
-    ad_utility::constexprStrCat<"<", QLEVER_INTERNAL_PREFIX_URL,
-                                "blank-node/">();
-
+    ad_utility::constexprStrCat<string_constants::detail::openAngle,
+                                QLEVER_INTERNAL_PREFIX_URL,
+                                string_constants::detail::blank_node_prefix>();
 constexpr inline std::pair<std::string_view, std::string_view> GEOF_PREFIX = {
     "geof:", "http://www.opengis.net/def/function/geosparql/"};
 constexpr inline std::pair<std::string_view, std::string_view> MATH_PREFIX = {
@@ -100,8 +117,11 @@ constexpr inline std::string_view SCORE_VARIABLE_PREFIX = "?ql_score_";
 constexpr inline std::string_view MATCHINGWORD_VARIABLE_PREFIX =
     "?ql_matchingword_";
 
+namespace constants::details::strings {
+constexpr inline std::string_view langtag{"langtag"};
+}
 constexpr inline std::string_view LANGUAGE_PREDICATE =
-    makeQleverInternalIriConst<"langtag">();
+    makeQleverInternalIriConst<constants::details::strings::langtag>();
 
 // TODO<joka921> Move them to their own file, make them strings, remove
 // duplications, etc.
@@ -153,19 +173,24 @@ constexpr inline char RDF_PREFIX[] =
 constexpr inline char RDF_LANGTAG_STRING[] =
     "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString";
 
-constexpr inline char GEO_WKT_LITERAL[] =
+constexpr inline std::string_view GEO_WKT_LITERAL =
     "http://www.opengis.net/ont/geosparql#wktLiteral";
 static constexpr std::string_view GEO_LITERAL_SUFFIX =
-    ad_utility::constexprStrCat<"\"^^<", GEO_WKT_LITERAL, ">">();
+    ad_utility::constexprStrCat<string_constants::detail::geo_literal_prefix,
+                                GEO_WKT_LITERAL,
+                                string_constants::detail::closeAngle>();
 
 enum class UnitOfMeasurement { METERS, KILOMETERS, MILES, UNKNOWN };
 constexpr inline std::string_view UNIT_PREFIX = "http://qudt.org/vocab/unit/";
 constexpr inline std::string_view UNIT_METER_IRI =
-    ad_utility::constexprStrCat<UNIT_PREFIX, "M">();
+    ad_utility::constexprStrCat<UNIT_PREFIX,
+                                string_constants::detail::unit_meter>();
 constexpr inline std::string_view UNIT_KILOMETER_IRI =
-    ad_utility::constexprStrCat<UNIT_PREFIX, "KiloM">();
+    ad_utility::constexprStrCat<UNIT_PREFIX,
+                                string_constants::detail::unit_kilometer>();
 constexpr inline std::string_view UNIT_MILE_IRI =
-    ad_utility::constexprStrCat<UNIT_PREFIX, "MI">();
+    ad_utility::constexprStrCat<UNIT_PREFIX,
+                                string_constants::detail::unit_mile>();
 
 constexpr std::string_view SF_PREFIX = "http://www.opengis.net/ont/sf#";
 

--- a/src/rdfTypes/GeoPoint.cpp
+++ b/src/rdfTypes/GeoPoint.cpp
@@ -105,5 +105,5 @@ std::string GeoPoint::toStringRepresentation() const {
 
 // _____________________________________________________________________________
 std::pair<std::string, const char*> GeoPoint::toStringAndType() const {
-  return std::pair(toStringRepresentation(), GEO_WKT_LITERAL);
+  return std::pair(toStringRepresentation(), GEO_WKT_LITERAL.data());
 };

--- a/src/rdfTypes/GeometryInfoHelpersImpl.h
+++ b/src/rdfTypes/GeometryInfoHelpersImpl.h
@@ -139,21 +139,32 @@ inline Box<CoordType> boundingBoxToUtilBox(const BoundingBox& boundingBox) {
 
 // Constexpr helper to add the required suffixes to the OGC simple features IRI
 // prefix.
-template <detail::constexpr_str_cat_impl::ConstexprString suffix>
-inline constexpr std::string_view addSfPrefix() {
+template <const std::string_view& suffix>
+constexpr std::string_view addSfPrefix() {
   return constexprStrCat<SF_PREFIX, suffix>();
 }
 
-// Concrete IRIs, built at compile time, for the supported geometry types.
-static constexpr std::array<std::optional<std::string_view>, 8> SF_WKT_TYPE_IRI{
-    std::nullopt,  // Invalid geometry
-    addSfPrefix<"Point">(),
-    addSfPrefix<"LineString">(),
-    addSfPrefix<"Polygon">(),
-    addSfPrefix<"MultiPoint">(),
-    addSfPrefix<"MultiLineString">(),
-    addSfPrefix<"MultiPolygon">(),
-    addSfPrefix<"GeometryCollection">()};
+namespace detail::geoStrings {
+constexpr inline std::string_view point = "Point";
+constexpr inline std::string_view linestring = "LineString";
+constexpr inline std::string_view polygon = "Polygon";
+constexpr inline std::string_view multipoint = "MultiPoint";
+constexpr inline std::string_view multiLineString = "MultiLineString";
+constexpr inline std::string_view multiPolygon = "MultiPolygon";
+constexpr inline std::string_view geometryCollection = "geometryCollection";
+}  // namespace detail::geoStrings
+static constexpr auto SF_WKT_TYPE_IRI = []() {
+  using namespace detail::geoStrings;
+  return std::array<std::optional<std::string_view>, 8>{
+      std::nullopt,  // Invalid geometry
+      addSfPrefix<point>(),
+      addSfPrefix<linestring>(),
+      addSfPrefix<polygon>(),
+      addSfPrefix<multipoint>(),
+      addSfPrefix<multiLineString>(),
+      addSfPrefix<multiPolygon>(),
+      addSfPrefix<geometryCollection>()};
+}();
 
 // Lookup the IRI for a given WKT type in the array of prepared IRIs.
 inline std::optional<std::string_view> wktTypeToIri(uint8_t type) {

--- a/src/rdfTypes/GeometryInfoHelpersImpl.h
+++ b/src/rdfTypes/GeometryInfoHelpersImpl.h
@@ -151,9 +151,9 @@ constexpr inline std::string_view polygon = "Polygon";
 constexpr inline std::string_view multipoint = "MultiPoint";
 constexpr inline std::string_view multiLineString = "MultiLineString";
 constexpr inline std::string_view multiPolygon = "MultiPolygon";
-constexpr inline std::string_view geometryCollection = "geometryCollection";
+constexpr inline std::string_view geometryCollection = "GeometryCollection";
 }  // namespace detail::geoStrings
-static constexpr auto SF_WKT_TYPE_IRI = []() {
+inline constexpr auto SF_WKT_TYPE_IRI = []() {
   using namespace detail::geoStrings;
   return std::array<std::optional<std::string_view>, 8>{
       std::nullopt,  // Invalid geometry

--- a/test/ConstantsTest.cpp
+++ b/test/ConstantsTest.cpp
@@ -26,9 +26,13 @@ TEST(Constants, testDefaultQueryTimeoutIsStriclyPositive) {
   EXPECT_NO_THROW(RuntimeParameters().set<"default-query-timeout">(1s));
 }
 
+namespace {
+constexpr std::string_view hi = "hi";
+constexpr std::string_view bye = "-bye";
+}  // namespace
 TEST(Constants, makeQleverInternalIri) {
   EXPECT_EQ(makeQleverInternalIri("hi", "-bye"),
-            (makeQleverInternalIriConst<"hi", "-bye">()));
-  EXPECT_EQ(makeQleverInternalIri("hi", "-bye"),
+            (makeQleverInternalIriConst<hi, bye>()));
+  EXPECT_EQ(makeQleverInternalIri(hi, bye),
             "<http://qlever.cs.uni-freiburg.de/builtin-functions/hi-bye>");
 }

--- a/test/GeometryInfoTest.cpp
+++ b/test/GeometryInfoTest.cpp
@@ -186,6 +186,10 @@ TEST(GeometryInfoTest, GeometryTypeAsIri) {
   ASSERT_FALSE(GeometryType{8}.asIri().has_value());
 }
 
+namespace {
+constexpr std::string_view example = "Example";
+}
+
 // ____________________________________________________________________________
 TEST(GeometryInfoTest, GeometryInfoHelpers) {
   using namespace ad_utility::detail;
@@ -216,7 +220,7 @@ TEST(GeometryInfoTest, GeometryInfoHelpers) {
       boundingBoxAsWkt(bb1.value().lowerLeft_, bb1.value().upperRight_);
   EXPECT_EQ(bb1Wkt, "POLYGON((3 4,3 4,3 4,3 4,3 4))");
 
-  EXPECT_EQ(addSfPrefix<"Example">(), "http://www.opengis.net/ont/sf#Example");
+  EXPECT_EQ(addSfPrefix<example>(), "http://www.opengis.net/ont/sf#Example");
   EXPECT_FALSE(wktTypeToIri(0).has_value());
   EXPECT_FALSE(wktTypeToIri(8).has_value());
   EXPECT_TRUE(wktTypeToIri(1).has_value());

--- a/test/StringUtilsTest.cpp
+++ b/test/StringUtilsTest.cpp
@@ -363,15 +363,27 @@ TEST(StringUtils, strLangTag) {
   ASSERT_TRUE(strIsLangTag("en"));
 }
 
+// Constants for the tests of `constexprStrCat` below. They have to be at
+// namespace scope, because of the compilation on G++-8.
+namespace {
+constexpr std::string_view empty = "";
+constexpr std::string_view single = "single";
+constexpr std::string_view hello = "hello";
+constexpr std::string_view space = " ";
+constexpr std::string_view world = "World!";
+constexpr std::string_view h = "h";
+constexpr std::string_view i = "i";
+}  // namespace
 // _____________________________________________________________________________
 TEST(StringUtils, constexprStrCat) {
   using namespace std::string_view_literals;
   ASSERT_EQ((constexprStrCat<>()), ""sv);
-  ASSERT_EQ((constexprStrCat<"">()), ""sv);
-  ASSERT_EQ((constexprStrCat<"single">()), "single"sv);
-  ASSERT_EQ((constexprStrCat<"", "single", "">()), "single"sv);
-  ASSERT_EQ((constexprStrCat<"hello", " ", "World!">()), "hello World!"sv);
-  static_assert(constexprStrCat<"hello", " ", "World!">() == "hello World!"sv);
+  ASSERT_EQ((constexprStrCat<empty>()), ""sv);
+  ASSERT_EQ((constexprStrCat<single>()), "single"sv);
+  ASSERT_EQ((constexprStrCat<empty, single, empty>()), "single"sv);
+
+  ASSERT_EQ((constexprStrCat<hello, space, world>()), "hello World!"sv);
+  static_assert(constexprStrCat<hello, space, world>() == "hello World!"sv);
 }
 
 // _____________________________________________________________________________
@@ -379,12 +391,9 @@ TEST(StringUtils, constexprStrCatImpl) {
   // The coverage tools don't track the compile time usages of these internal
   // helper functions, so we test them manually.
   using namespace ad_utility::detail::constexpr_str_cat_impl;
-  ASSERT_EQ((constexprStrCatBufferImpl<"h", "i">()),
-            (std::array{'h', 'i', '\0'}));
+  ASSERT_EQ((constexprStrCatBufferImpl<h, i>()), (std::array{'h', 'i', '\0'}));
 
-  using C = ConstexprString;
-  ASSERT_EQ((catImpl<2>(std::array{C{"h"}, C{"i"}})),
-            (std::array{'h', 'i', '\0'}));
+  ASSERT_EQ((catImpl<2>(std::array{&h, &i})), (std::array{'h', 'i', '\0'}));
 }
 
 // _____________________________________________________________________________


### PR DESCRIPTION
Refactor the `ad_utility::constexprStrCat` function, which is used to define compile-time constants, as well as all of its usages to be compatible with C++ 17 on GCC 8.3. This is non-trivial and slightly ugly for the following reasons:

1. In C++ 17, there is very limited support for template parameters that are not types; in particular, simply using a string as in `template <const std::string s> constexpr fct() { ... }` and then using it as in `fct<"doof">()` does not work
2. What works is to define the template parameter as a reference, as in `template <const std::string_view&> fct()`); then the template parameter has to be defined as in `static constexpr std::string_view sv = "doof";` to be used as in `fct<sv>()` 
3. Unfortunately, defining these constants at function scope does not compile on GCC 8.3; we thus have define them at global or namespace scope
4. Moreover, each such template parameter has to be its own dedicated variable; defining a `constexpr array` or even `constexpr ConstexprSet` does not work