### PR TITLE
Use `boost::asio::steady_timer` instead of the deprecated  `boost::asio::deadline_timer`

### DIFF
--- a/src/util/http/websocket/QueryToSocketDistributor.cpp
+++ b/src/util/http/websocket/QueryToSocketDistributor.cpp
@@ -12,8 +12,7 @@ namespace ad_utility::websocket {
 QueryToSocketDistributor::QueryToSocketDistributor(
     net::io_context& ioContext, const std::function<void(bool)>& cleanupCall)
     : strand_{net::make_strand(ioContext)},
-      infiniteTimer_{strand_, static_cast<net::deadline_timer::time_type>(
-                                  boost::posix_time::pos_infin)},
+      infiniteTimer_{strand_, net::steady_timer::time_point::max()},
       cleanupCall_{
           cleanupCall,
           [](const auto& cleanupCall) { std::invoke(cleanupCall, false); }},
@@ -36,7 +35,7 @@ net::awaitable<void> QueryToSocketDistributor::waitForUpdate() const {
 
 void QueryToSocketDistributor::wakeUpWaitingListeners() {
   // Setting the time anew automatically cancels waiting operations
-  infiniteTimer_.expires_at(boost::posix_time::pos_infin);
+  infiniteTimer_.expires_at(net::steady_timer::time_point::max());
 }
 
 // _____________________________________________________________________________

--- a/src/util/http/websocket/QueryToSocketDistributor.h
+++ b/src/util/http/websocket/QueryToSocketDistributor.h
@@ -26,7 +26,7 @@ class QueryToSocketDistributor
     : public std::enable_shared_from_this<QueryToSocketDistributor> {
   /// Strand to synchronize all operations on this class
   net::strand<net::any_io_executor> strand_;
-  mutable net::deadline_timer infiniteTimer_;
+  mutable net::steady_timer infiniteTimer_;
   /// Vector that stores the actual data, so all websockets can read it at
   /// their own pace.
   std::vector<std::shared_ptr<const std::string>> data_{};

--- a/test/MessageSenderTest.cpp
+++ b/test/MessageSenderTest.cpp
@@ -6,6 +6,7 @@
 #include <gtest/gtest.h>
 
 #include <boost/asio/experimental/awaitable_operators.hpp>
+#include <chrono>
 
 #include "util/AsyncTestHelpers.h"
 #include "util/http/websocket/MessageSender.h"
@@ -19,6 +20,7 @@ using ad_utility::websocket::QueryRegistry;
 
 using namespace boost::asio::experimental::awaitable_operators;
 using namespace std::string_literals;
+using namespace std::chrono_literals;
 
 using ::testing::Pointee;
 using ::testing::VariantWith;
@@ -36,7 +38,7 @@ ASYNC_TEST(MessageSender, destructorCallsSignalEnd) {
   { MessageSender dummy{std::move(queryId), queryHub}; }
 
   auto impl = [&]() -> net::awaitable<void> {
-    net::deadline_timer timer{ioContext, boost::posix_time::seconds(2)};
+    net::steady_timer timer{ioContext, 2s};
 
     auto result = co_await (distributor->waitForNextDataPiece(0) ||
                             timer.async_wait(net::use_awaitable));
@@ -65,7 +67,7 @@ ASYNC_TEST(MessageSender, callingOperatorBroadcastsPayload) {
     updateWrapper("Still");
     updateWrapper("Dre");
 
-    net::deadline_timer timer{ioContext, boost::posix_time::seconds(2)};
+    net::steady_timer timer{ioContext, 2s};
 
     auto impl = [&]() -> net::awaitable<void> {
       auto result = co_await (distributor->waitForNextDataPiece(0) ||


### PR DESCRIPTION
Fixes #2334