### PR TITLE
fix: allow authentication when access token is provided in headers

### DIFF
--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -1154,9 +1154,8 @@ bool Server::checkAccessToken(
   }
   const auto accessTokenProvidedMsg = "Access token was provided";
   if (accessToken_.empty()) {
-    throw std::runtime_error(
-        absl::StrCat(accessTokenProvidedMsg,
-                     " but server was started without --access-token"));
+    LOG(DEBUG) << accessTokenProvidedMsg << " but server was started without --access-token" << std::endl;
+    return true;
   } else if (!ad_utility::constantTimeEquals(accessToken.value(),
                                              accessToken_)) {
     throw std::runtime_error(


### PR DESCRIPTION
Today, if I don't set up authorization via the `--access-token` argument, I can't specify an `Authorization` header with a value against Qlever. It will fail with an exception.

This is an issue, because I am trying to host Qlever in AWS ECS, and putting an AWS ALB in front of it which then handles the authorization. This creates a problem now, because the ALB will forward all headers to Qlever, including the `Authorization` header which contains a token for authenticating via the ALB.

In my opinion, it is wrong for Qlever to throw an exception here. Instead, it should just be logged. If your server is not configured for authorization, then everything should be authorized.