### PR TITLE
Fix export and `STR` result for doubles and decimals with integer values

### DIFF
--- a/src/engine/ExportQueryExecutionTrees.cpp
+++ b/src/engine/ExportQueryExecutionTrees.cpp
@@ -355,9 +355,9 @@ ExportQueryExecutionTrees::idToStringAndTypeForEncodedValue(Id id) {
           return std::pair{std::move(literal), XSD_DOUBLE_TYPE};
         }
         double dIntPart;
-        // If the fractional part is zero, write number without decimal point.
-        // Otherwise, use `%g`, which uses fixed-size or exponential notation,
-        // whichever is more compact.
+        // If the fractional part is zero, write number with one decimal place
+        // to make it distinct from integers. Otherwise, use `%g`, which uses
+        // fixed-size or exponential notation, whichever is more compact.
         std::string out = std::modf(d, &dIntPart) == 0.0
                               ? absl::StrFormat("%.1f", d)
                               : absl::StrFormat("%g", d);

--- a/src/engine/ExportQueryExecutionTrees.cpp
+++ b/src/engine/ExportQueryExecutionTrees.cpp
@@ -359,7 +359,7 @@ ExportQueryExecutionTrees::idToStringAndTypeForEncodedValue(Id id) {
         // Otherwise, use `%g`, which uses fixed-size or exponential notation,
         // whichever is more compact.
         std::string out = std::modf(d, &dIntPart) == 0.0
-                              ? absl::StrFormat("%.0f", d)
+                              ? absl::StrFormat("%.1f", d)
                               : absl::StrFormat("%g", d);
         return std::pair{std::move(out), XSD_DECIMAL_TYPE};
       }();

--- a/test/ExportQueryExecutionTreesTest.cpp
+++ b/test/ExportQueryExecutionTreesTest.cpp
@@ -554,7 +554,7 @@ TEST(ExportQueryExecutionTrees, Floats) {
     <binding name="o"><literal datatype="http://www.w3.org/2001/XMLSchema#double">-INF</literal></binding>
   </result>
   <result>
-    <binding name="o"><literal datatype="http://www.w3.org/2001/XMLSchema#decimal">-42019234865780982022144</literal></binding>
+    <binding name="o"><literal datatype="http://www.w3.org/2001/XMLSchema#decimal">-42019234865780982022144.0</literal></binding>
   </result>
   <result>
     <binding name="o"><literal datatype="http://www.w3.org/2001/XMLSchema#decimal">4.01293e-12</literal></binding>
@@ -573,7 +573,7 @@ TEST(ExportQueryExecutionTrees, Floats) {
       // TSV
       "?o\n"
       "-INF\n"
-      "-42019234865780982022144\n"
+      "-42019234865780982022144.0\n"
       "4.01293e-12\n"
       "42.2\n"
       "INF\n"
@@ -581,14 +581,14 @@ TEST(ExportQueryExecutionTrees, Floats) {
       // CSV
       "o\n"
       "-INF\n"
-      "-42019234865780982022144\n"
+      "-42019234865780982022144.0\n"
       "4.01293e-12\n"
       "42.2\n"
       "INF\n"
       "NaN\n",
       makeExpectedQLeverJSON(
           {"\"-INF\"^^<http://www.w3.org/2001/XMLSchema#double>"s,
-           "\"-42019234865780982022144\"^^<http://www.w3.org/2001/XMLSchema#decimal>"s,
+           "\"-42019234865780982022144.0\"^^<http://www.w3.org/2001/XMLSchema#decimal>"s,
            "\"4.01293e-12\"^^<http://www.w3.org/2001/XMLSchema#decimal>"s,
            "\"42.2\"^^<http://www.w3.org/2001/XMLSchema#decimal>"s,
            "\"INF\"^^<http://www.w3.org/2001/XMLSchema#double>"s,
@@ -597,7 +597,7 @@ TEST(ExportQueryExecutionTrees, Floats) {
           {makeJSONBinding("http://www.w3.org/2001/XMLSchema#double", "literal",
                            "-INF"),
            makeJSONBinding("http://www.w3.org/2001/XMLSchema#decimal",
-                           "literal", "-42019234865780982022144"),
+                           "literal", "-42019234865780982022144.0"),
            makeJSONBinding("http://www.w3.org/2001/XMLSchema#decimal",
                            "literal", "4.01293e-12"),
            makeJSONBinding("http://www.w3.org/2001/XMLSchema#decimal",
@@ -613,21 +613,21 @@ TEST(ExportQueryExecutionTrees, Floats) {
       kg, "CONSTRUCT {?s ?p ?o} WHERE {?s ?p ?o} ORDER BY ?o", 6, 6,
       // TSV
       "<s>\t<p>\t\"-INF\"^^<http://www.w3.org/2001/XMLSchema#double>\n"
-      "<s>\t<p>\t-42019234865780982022144\n"
+      "<s>\t<p>\t-42019234865780982022144.0\n"
       "<s>\t<p>\t4.01293e-12\n"
       "<s>\t<p>\t42.2\n"
       "<s>\t<p>\t\"INF\"^^<http://www.w3.org/2001/XMLSchema#double>\n"
       "<s>\t<p>\t\"NaN\"^^<http://www.w3.org/2001/XMLSchema#double>\n",
       // CSV
       "<s>,<p>,\"\"\"-INF\"\"^^<http://www.w3.org/2001/XMLSchema#double>\"\n"
-      "<s>,<p>,-42019234865780982022144\n"
+      "<s>,<p>,-42019234865780982022144.0\n"
       "<s>,<p>,4.01293e-12\n"
       "<s>,<p>,42.2\n"
       "<s>,<p>,\"\"\"INF\"\"^^<http://www.w3.org/2001/XMLSchema#double>\"\n"
       "<s>,<p>,\"\"\"NaN\"\"^^<http://www.w3.org/2001/XMLSchema#double>\"\n",
       // Turtle
       "<s> <p> \"-INF\"^^<http://www.w3.org/2001/XMLSchema#double> .\n"
-      "<s> <p> -42019234865780982022144 .\n"
+      "<s> <p> -42019234865780982022144.0 .\n"
       "<s> <p> 4.01293e-12 .\n"
       "<s> <p> 42.2 .\n"
       "<s> <p> \"INF\"^^<http://www.w3.org/2001/XMLSchema#double> .\n"
@@ -637,7 +637,7 @@ TEST(ExportQueryExecutionTrees, Floats) {
         j.push_back(std::vector{
             "<s>"s, "<p>"s,
             "\"-INF\"^^<http://www.w3.org/2001/XMLSchema#double>"s});
-        j.push_back(std::vector{"<s>"s, "<p>"s, "-42019234865780982022144"s});
+        j.push_back(std::vector{"<s>"s, "<p>"s, "-42019234865780982022144.0"s});
         j.push_back(std::vector{"<s>"s, "<p>"s, "4.01293e-12"s});
         j.push_back(std::vector{"<s>"s, "<p>"s, "42.2"s});
         j.push_back(

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -636,7 +636,7 @@ TEST(SparqlExpression, stringOperators) {
   checkStr(Ids{I(1), I(2), I(3)},
            IdOrLiteralOrIriVec{lit("1"), lit("2"), lit("3")});
   checkStr(Ids{D(-1.0), D(1.0), D(2.34), D(NAN), D(INFINITY), D(-INFINITY)},
-           IdOrLiteralOrIriVec{lit("-1.0"), lit("1.0"), lit("2.34"), lit("NaN"),
+           IdOrLiteralOrIriVec{lit("-1"), lit("1"), lit("2.34"), lit("NaN"),
                                lit("INF"), lit("-INF")});
   checkStr(Ids{B(true), B(false), Id::makeBoolFromZeroOrOne(true),
                Id::makeBoolFromZeroOrOne(false)},

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -636,7 +636,7 @@ TEST(SparqlExpression, stringOperators) {
   checkStr(Ids{I(1), I(2), I(3)},
            IdOrLiteralOrIriVec{lit("1"), lit("2"), lit("3")});
   checkStr(Ids{D(-1.0), D(1.0), D(2.34), D(NAN), D(INFINITY), D(-INFINITY)},
-           IdOrLiteralOrIriVec{lit("-1"), lit("1"), lit("2.34"), lit("NaN"),
+           IdOrLiteralOrIriVec{lit("-1.0"), lit("1.0"), lit("2.34"), lit("NaN"),
                                lit("INF"), lit("-INF")});
   checkStr(Ids{B(true), B(false), Id::makeBoolFromZeroOrOne(true),
                Id::makeBoolFromZeroOrOne(false)},


### PR DESCRIPTION
So far, a double or decimal with an integer value of, say, 12345, was exported as, `12345`. This is not standard-compliant and for a good reason: When reading such a result back in (e.g., from `text/turtle` generated by a `CONSTRUCT` query), the value would become an integer.

The value is now exported as `12345.0`. However, when converted to a string, either implicitly or using `STR`, the standard demands that the string is `12345` without the decimal point. This is now ensured as well.

NOTE: The standard has further requirements on the conversion of a double to a string, see https://www.w3.org/TR/xpath-functions/#casting-to-string . In particular, the standard demands that values between `0.000001` (one millionth) and `1000000` (one million) are converted to a string like a decimal, while for other values (except for `0`, `-0`, `INF`, and `-INF`), the `E` notation must be used. This is not yet implemented and work for a separate PR.