### PR TITLE
Fix expression evaluation for grouped variables in lazy `GROUP BY`

### DIFF
--- a/src/engine/GroupByImpl.cpp
+++ b/src/engine/GroupByImpl.cpp
@@ -1319,16 +1319,12 @@ GroupByImpl::substituteGroupVariable(
       originalChildren;
   originalChildren.reserve(occurrences.size());
   for (const auto& occurrence : occurrences) {
-    auto newExpression =
-        [&groupValues,
-         &allocator]() -> std::unique_ptr<sparqlExpression::SparqlExpression> {
-      sparqlExpression::VectorWithMemoryLimit<ValueId> values(allocator);
-      values.resize(groupValues.size());
-      ql::ranges::copy(groupValues, values.begin());
+    sparqlExpression::VectorWithMemoryLimit<ValueId> values(allocator);
+    values.resize(groupValues.size());
+    ql::ranges::copy(groupValues, values.begin());
 
-      return std::make_unique<sparqlExpression::VectorIdExpression>(
-          std::move(values));
-    }();
+    auto newExpression = std::make_unique<sparqlExpression::VectorIdExpression>(
+        std::move(values));
 
     originalChildren.push_back(occurrence.parent_->replaceChild(
         occurrence.nThChild_, std::move(newExpression)));
@@ -1454,6 +1450,76 @@ GroupByImpl::HashMapAggregationData<NUM_GROUP_COLUMNS>::getSortedGroupColumns()
 
 // _____________________________________________________________________________
 template <size_t NUM_GROUP_COLUMNS>
+void GroupByImpl::substituteAndEvaluate(
+    HashMapAliasInformation& alias, IdTable* result,
+    sparqlExpression::EvaluationContext& evaluationContext,
+    const HashMapAggregationData<NUM_GROUP_COLUMNS>& aggregationData,
+    LocalVocab* localVocab, const Allocator& allocator,
+    std::vector<HashMapAggregateInformation>& info,
+    const std::vector<HashMapGroupedVariableInformation>& substitutions) {
+  // Store which SPARQL expressions of grouped variables have been substituted.
+  std::vector<std::pair<
+      const std::vector<ParentAndChildIndex>&,
+      std::vector<std::unique_ptr<sparqlExpression::SparqlExpression>>>>
+      originalChildrenForGroupVariable;
+  originalChildrenForGroupVariable.reserve(substitutions.size());
+  for (const auto& substitution : substitutions) {
+    const auto& occurrences =
+        get<std::vector<ParentAndChildIndex>>(substitution.occurrences_);
+    // Substitute in the values of the grouped variable and store the original
+    // expressions.
+    originalChildrenForGroupVariable.emplace_back(
+        occurrences, substituteGroupVariable(
+                         occurrences, result, evaluationContext._beginIndex,
+                         evaluationContext.size(),
+                         substitution.resultColumnIndex_, allocator));
+  }
+
+  // Substitute in the results of all aggregates contained in the
+  // expression of the current alias, if `info` is non-empty and keep the
+  // original expressions.
+  std::vector<std::unique_ptr<sparqlExpression::SparqlExpression>>
+      originalChildren = substituteAllAggregates(
+          info, evaluationContext._beginIndex, evaluationContext._endIndex,
+          aggregationData, result, localVocab, allocator);
+
+  // Evaluate top-level alias expression.
+  sparqlExpression::ExpressionResult expressionResult =
+      alias.expr_.getPimpl()->evaluate(&evaluationContext);
+
+  // Restore original children. Only necessary when the expression will be
+  // used in the future (not the case for the hash map optimization).
+  auto restoreOriginalExpressions = [](auto&& range, auto& originalChildren) {
+    for (auto&& [parentAndIndex, originalExpression] :
+         ::ranges::views::zip(AD_FWD(range), originalChildren)) {
+      parentAndIndex.parent_->replaceChild(parentAndIndex.nThChild_,
+                                           std::move(originalExpression));
+    }
+  };
+
+  // Restore grouped variable expressions.
+  for (auto& [occurrences, children] : originalChildrenForGroupVariable) {
+    restoreOriginalExpressions(occurrences, children);
+  }
+
+  // Restore aggregated variable expressions.
+  restoreOriginalExpressions(
+      info | ql::views::transform(
+                 [](auto& aggregate) -> const ParentAndChildIndex& {
+                   return aggregate.parentAndIndex_.value();
+                 }),
+      originalChildren);
+
+  // Copy the result so that future aliases may reuse it.
+  evaluationContext._previousResultsFromSameGroup.at(alias.outCol_) =
+      sparqlExpression::copyExpressionResult(expressionResult);
+
+  // Extract values.
+  extractValues(std::move(expressionResult), evaluationContext, result,
+                localVocab, alias.outCol_);
+}
+// _____________________________________________________________________________
+template <size_t NUM_GROUP_COLUMNS>
 void GroupByImpl::evaluateAlias(
     HashMapAliasInformation& alias, IdTable* result,
     sparqlExpression::EvaluationContext& evaluationContext,
@@ -1468,10 +1534,10 @@ void GroupByImpl::evaluateAlias(
   // - Possibly multiple aggregates and occurrences of grouped variables. All
   // have to be substituted away before evaluation
 
-  auto substitutions = alias.groupedVariables_;
+  const auto& substitutions = alias.groupedVariables_;
   auto topLevelGroupedVariable = ql::ranges::find_if(
-      substitutions, [](HashMapGroupedVariableInformation& val) {
-        return std::get_if<OccurAsRoot>(&val.occurrences_);
+      substitutions, [](const HashMapGroupedVariableInformation& val) {
+        return std::holds_alternative<OccurAsRoot>(val.occurrences_);
       });
 
   if (topLevelGroupedVariable != substitutions.end()) {
@@ -1515,61 +1581,9 @@ void GroupByImpl::evaluateAlias(
         sparqlExpression::copyExpressionResult(
             sparqlExpression::ExpressionResult{std::move(aggregateResults)});
   } else {
-    std::vector<std::pair<
-        const std::vector<ParentAndChildIndex>&,
-        std::vector<std::unique_ptr<sparqlExpression::SparqlExpression>>>>
-        originalChildrenForGroupVariable;
-    originalChildrenForGroupVariable.reserve(substitutions.size());
-    for (const auto& substitution : substitutions) {
-      const auto& occurrences =
-          get<std::vector<ParentAndChildIndex>>(substitution.occurrences_);
-      // Substitute in the values of the grouped variable
-      originalChildrenForGroupVariable.emplace_back(
-          occurrences, substituteGroupVariable(
-                           occurrences, result, evaluationContext._beginIndex,
-                           evaluationContext.size(),
-                           substitution.resultColumnIndex_, allocator));
-    }
-
-    // Substitute in the results of all aggregates contained in the
-    // expression of the current alias, if `info` is non-empty.
-    std::vector<std::unique_ptr<sparqlExpression::SparqlExpression>>
-        originalChildren = substituteAllAggregates(
-            info, evaluationContext._beginIndex, evaluationContext._endIndex,
-            aggregationData, result, localVocab, allocator);
-
-    // Evaluate top-level alias expression
-    sparqlExpression::ExpressionResult expressionResult =
-        alias.expr_.getPimpl()->evaluate(&evaluationContext);
-
-    // Restore original children. Only necessary when the expression will be
-    // used in the future (not the case for the hash map optimization).
-    auto restoreOriginalExpressions = [](auto&& range, auto& originalChildren) {
-      for (auto&& [parentAndIndex, originalExpression] :
-           ::ranges::views::zip(AD_FWD(range), originalChildren)) {
-        parentAndIndex.parent_->replaceChild(parentAndIndex.nThChild_,
-                                             std::move(originalExpression));
-      }
-    };
-
-    for (auto& [occurrences, children] : originalChildrenForGroupVariable) {
-      restoreOriginalExpressions(occurrences, children);
-    }
-
-    restoreOriginalExpressions(
-        info | ql::views::transform(
-                   [](auto& aggregate) -> const ParentAndChildIndex& {
-                     return aggregate.parentAndIndex_.value();
-                   }),
-        originalChildren);
-
-    // Copy the result so that future aliases may reuse it
-    evaluationContext._previousResultsFromSameGroup.at(alias.outCol_) =
-        sparqlExpression::copyExpressionResult(expressionResult);
-
-    // Extract values
-    extractValues(std::move(expressionResult), evaluationContext, result,
-                  localVocab, alias.outCol_);
+    substituteAndEvaluate<NUM_GROUP_COLUMNS>(alias, result, evaluationContext,
+                                             aggregationData, localVocab,
+                                             allocator, info, substitutions);
   }
 }
 

--- a/src/engine/GroupByImpl.cpp
+++ b/src/engine/GroupByImpl.cpp
@@ -1519,6 +1519,7 @@ void GroupByImpl::evaluateAlias(
         const std::vector<ParentAndChildIndex>&,
         std::vector<std::unique_ptr<sparqlExpression::SparqlExpression>>>>
         originalChildrenForGroupVariable;
+    originalChildrenForGroupVariable.reserve(substitutions.size());
     for (const auto& substitution : substitutions) {
       const auto& occurrences =
           get<std::vector<ParentAndChildIndex>>(substitution.occurrences_);

--- a/src/engine/GroupByImpl.h
+++ b/src/engine/GroupByImpl.h
@@ -493,11 +493,13 @@ class GroupByImpl : public Operation {
       sparqlExpression::EvaluationContext& evaluationContext,
       IdTable* resultTable, LocalVocab* localVocab, size_t outCol);
 
-  // Substitute the group values for all occurrences of a group variable.
-  static void substituteGroupVariable(
-      const std::vector<ParentAndChildIndex>& occurrences, IdTable* resultTable,
-      size_t beginIndex, size_t count, size_t columnIndex,
-      const Allocator& allocator);
+  // Substitute the group values for all occurrences of a group variable. Return
+  // a vector of the replaced `SparqlExpression`s to potentially put them pack
+  // afterwards.
+  static std::vector<std::unique_ptr<sparqlExpression::SparqlExpression>>
+  substituteGroupVariable(const std::vector<ParentAndChildIndex>& occurrences,
+                          IdTable* resultTable, size_t beginIndex, size_t count,
+                          size_t columnIndex, const Allocator& allocator);
 
   // Substitute the results for all aggregates in `info`. The values of the
   // grouped variable should be at column 0 in `groupValues`. Return a vector of

--- a/src/engine/GroupByImpl.h
+++ b/src/engine/GroupByImpl.h
@@ -447,6 +447,22 @@ class GroupByImpl : public Operation {
       size_t dataIndex, size_t beginIndex, size_t endIndex,
       LocalVocab* localVocab, const Allocator& allocator);
 
+  // Helper function of `evaluateAlias`.
+  // 1. Substitute SPARQL expressions with precomputed values.
+  // 2. Performs evaluation of the unevaluated expression.
+  // 3. Reverts back the substitution changes.
+  //
+  // Basically, perform the fallback case if no faster approach can be chosen
+  // instead.
+  template <size_t NUM_GROUP_COLUMNS>
+  static void substituteAndEvaluate(
+      HashMapAliasInformation& alias, IdTable* result,
+      sparqlExpression::EvaluationContext& evaluationContext,
+      const HashMapAggregationData<NUM_GROUP_COLUMNS>& aggregationData,
+      LocalVocab* localVocab, const Allocator& allocator,
+      std::vector<HashMapAggregateInformation>& info,
+      const std::vector<HashMapGroupedVariableInformation>& substitutions);
+
   // Substitute away any occurrences of the grouped variable and of aggregate
   // results, if necessary, and subsequently evaluate the expression of an
   // alias

--- a/src/engine/GroupByImpl.h
+++ b/src/engine/GroupByImpl.h
@@ -448,9 +448,14 @@ class GroupByImpl : public Operation {
       LocalVocab* localVocab, const Allocator& allocator);
 
   // Helper function of `evaluateAlias`.
-  // 1. Substitute SPARQL expressions with precomputed values.
-  // 2. Performs evaluation of the unevaluated expression.
-  // 3. Reverts back the substitution changes.
+  // 1. In the Expressions for the aliases of this GROUP BY, replace all
+  //    aggregates and all occurences of the grouped variables values that have
+  //    been precomputed.
+  // 2. Evaluate the (partially substituted) expressions using the
+  //    `evaluationContext`, to get the final values of the aliases and store
+  //    them in the `result`.
+  // 3. Undo the substitution, s.t. we can reuse the expressions for additional
+  //    blocks of values etc.
   //
   // Basically, perform the fallback case if no faster approach can be chosen
   // instead.

--- a/src/engine/GroupByImpl.h
+++ b/src/engine/GroupByImpl.h
@@ -449,7 +449,7 @@ class GroupByImpl : public Operation {
 
   // Helper function of `evaluateAlias`.
   // 1. In the Expressions for the aliases of this GROUP BY, replace all
-  //    aggregates and all occurences of the grouped variables values that have
+  //    aggregates and all occurrences of the grouped variables values that have
   //    been precomputed.
   // 2. Evaluate the (partially substituted) expressions using the
   //    `evaluationContext`, to get the final values of the aliases and store


### PR DESCRIPTION
When evaluating expressions on grouped variables, QLever substitutes, for each group, the `VariableExpression` with the grouped variable by a `VectorIdExpression` with the variable value (repeated x times if the group has x elements) . This breaks when the `GROUP BY` is lazy and more than one block is produced. This results in an "Assertion `numItems == vector.size()` failed" error. This change fixes the bug for most, but still not all expression. In particular, fixes #2349

NOTE: See #2374 for more details, including queries, where it still does not work as it should.