### PR TITLE
Fix bug regarding SPARQL update and "small relations"

### DIFF
--- a/src/index/CompressedRelation.cpp
+++ b/src/index/CompressedRelation.cpp
@@ -1748,33 +1748,50 @@ CompressedRelationReader::getMetadataForSmallRelation(
   metadata.offsetInBlock_ = 0;
   const auto& scanSpec = scanSpecAndBlocks.scanSpec_;
   auto config = getScanConfig(scanSpec, {}, locatedTriplesPerBlock);
-  if (scanSpecAndBlocks.sizeBlockMetadata_ == 0) {
-    return std::nullopt;
-  }
   const auto& blocks = scanSpecAndBlocks.getBlockMetadataView();
-  AD_CONTRACT_CHECK(scanSpecAndBlocks.sizeBlockMetadata_ <= 1,
-                    "Should only be called for small relations");
-  auto block = readPossiblyIncompleteBlock(
-      scanSpec, config, blocks.front(), std::nullopt, locatedTriplesPerBlock);
-  if (block.empty()) {
+  // For relations that already span more than one block when the index is first
+  // built, this function should never be called. With SPARQL UPDATE it might
+  // happen that a relation starts in a single block, but added triples land in
+  // an adjacent block (because the relation was right at the end of a block).
+  // In this case we might also see two blocks here.
+  AD_CONTRACT_CHECK(scanSpecAndBlocks.sizeBlockMetadata_ <= 2,
+                    "Should only be called for small relations (contained in "
+                    "at most one block), or relations that started in a single "
+                    "block, but were extended into the adjacent block by "
+                    "SPARQL UPDATE, but found a relation which spans ",
+                    scanSpecAndBlocks.sizeBlockMetadata_, "block.");
+
+  ad_utility::HashSet<Id> distinctCol2;
+  size_t numRowsTotal = 0;
+  size_t numDistinct = 0;
+  for (const auto& blockMetadata : blocks) {
+    auto block = readPossiblyIncompleteBlock(
+        scanSpec, config, blockMetadata, std::nullopt, locatedTriplesPerBlock);
+
+    numRowsTotal += block.numRows();
+    // The `col1` is sorted, so we compute the multiplicity using
+    // `std::unique`. Note: The distinct count might be off by one in the case
+    // of two blocks, because we perform the `unique` separately for both
+    // blocks. But as the multiplicity is only an approximate measure used for
+    // query planning statistics, this is not an issue.
+    const auto& blockCol = block.getColumn(0);
+    auto endOfUnique = std::unique(blockCol.begin(), blockCol.end());
+    numDistinct += endOfUnique - blockCol.begin();
+
+    // The `col2` is unsorted, so we use a hash map.
+    for (auto id : block.getColumn(1)) {
+      distinctCol2.insert(id);
+    }
+  };
+
+  if (numRowsTotal == 0) {
     return std::nullopt;
   }
-
-  // The `col1` is sorted, so we compute the multiplicity using
-  // `std::unique`.
-  const auto& blockCol = block.getColumn(0);
-  auto endOfUnique = std::unique(blockCol.begin(), blockCol.end());
-  size_t numDistinct = endOfUnique - blockCol.begin();
-  metadata.numRows_ = block.size();
+  metadata.numRows_ = numRowsTotal;
   metadata.multiplicityCol1_ =
-      CompressedRelationWriter::computeMultiplicity(block.size(), numDistinct);
-
-  // The `col2` is not sorted, so we compute the multiplicity using a hash
-  // set.
-  ad_utility::HashSet<Id> distinctCol2{block.getColumn(1).begin(),
-                                       block.getColumn(1).end()};
+      CompressedRelationWriter::computeMultiplicity(numRowsTotal, numDistinct);
   metadata.multiplicityCol2_ = CompressedRelationWriter::computeMultiplicity(
-      block.size(), distinctCol2.size());
+      numRowsTotal, distinctCol2.size());
   return metadata;
 }
 

--- a/test/CompressedRelationsTest.cpp
+++ b/test/CompressedRelationsTest.cpp
@@ -313,26 +313,41 @@ void testCompressedRelations(const auto& inputsOriginalBeforeCopy,
   std::vector<ColumnIndex> additionalColumns;
   ql::ranges::copy(ql::views::iota(3ul, getNumColumns(inputs) + 1),
                    std::back_inserter(additionalColumns));
-  auto getMetadata = [&](size_t i) {
-    Id col0 = V(inputs[i].col0_);
+  // Get a pair<optional<RelationMetadata>, bool>` for the given `col0`, where
+  // the `bool` is true if the `col0` is a "large" relation, meaning that the
+  // metadata is explicitly stored and not extracted from the compressed data on
+  // the fly.
+  auto getMetadataFromId = [&](Id col0) {
     auto it = ql::ranges::lower_bound(metaData, col0, {},
                                       &CompressedRelationMetadata::col0Id_);
     if (it != metaData.end() && it->col0Id_ == col0) {
-      return *it;
+      return std::pair{std::optional{*it}, true};
     }
-    return reader
-        .getMetadataForSmallRelation(
+    return std::pair{
+        reader.getMetadataForSmallRelation(
             ScanSpecAndBlocks{
                 ScanSpecification{col0, std::nullopt, std::nullopt}, blocks},
-            col0, locatedTriples)
-        .value();
+            col0, locatedTriples),
+        false};
   };
+
+  AD_EXPECT_NULLOPT(getMetadataFromId(V(Id::maxIndex - 1)).first);
+
+  // return a `pair<RelationMetadata, bool>` (see above), but for the `i`-th
+  // relation specified by the `inputs`.
+  auto getMetadata = [&](size_t i) {
+    Id col0 = V(inputs[i].col0_);
+    auto [optMetadata, isLarge] = getMetadataFromId(col0);
+    return std::pair{std::move(optMetadata).value(), isLarge};
+  };
+
   for (size_t i = 0; i < inputs.size(); ++i) {
-    // The metadata does not include the located triples, so we can only test it
-    // if there are no located triples.
-    if (locatedTriplesProbability == 0) {
-      const auto& m = getMetadata(i);
-      ASSERT_EQ(V(inputs[i].col0_), m.col0Id_);
+    const auto& [m, isLarge] = getMetadata(i);
+    ASSERT_EQ(V(inputs[i].col0_), m.col0Id_);
+    // For large relations the metadata is currently not updated when
+    // `LocatedTriples` are added or deleted. We thus have to exclude this case
+    // here.
+    if (locatedTriplesProbability == 0 || !isLarge) {
       ASSERT_EQ(inputs[i].col1And2_.size(), m.numRows_);
     }
 


### PR DESCRIPTION
So far, the following sequence with an update operation led to the error "Assertion `scanSpecAndBlocks.sizeBlockMetadata_ <= 1` failed. Should only be called for small relations [...] in file `src/index/CompressedRelation.cpp`"
```bash
echo "<a> <b> <c1>" | IndexBuilderMain -i issue-1767 -F ttl -f -
pkill -f "p 8019"; ServerMain.MASTER -i issue-1767 -p 8019 -a issue-1767 & sleep 1
curl -s "localhost:8019?access-token=issue-1767" -H "Content-type: application/sparql-update" --data "INSERT DATA { <a> <b> <c2> }" > /dev/null
curl -s "localhost:8019" -H "Content-type: application/sparql-query" -H "Accept: text/tab-separated-values" --data "SELECT * { ?s <b> ?o }"
```
The reason is that QLever stores so-called "small relations" for a permutation in a single block, but an update operation may lead to delta triples for that relation being stored in an addition block (namely, the subsequent block).

This is now fixed by taking into account that that may happen. In particular, fixes #2348 and #1767 