### PR TITLE
Introduce runtime parameter `propagate-changes-from-updates`

### DIFF
--- a/src/global/RuntimeParameters.cpp
+++ b/src/global/RuntimeParameters.cpp
@@ -51,6 +51,7 @@ RuntimeParameters::RuntimeParameters() {
   add(materializedViewWriterMemory_);
   add(defaultQueryTimeout_);
   add(sortInMemoryThreshold_);
+  add(propagateChangesFromUpdates_);
 
   defaultQueryTimeout_.setParameterConstraint(
       [](std::chrono::seconds value, std::string_view parameterName) {

--- a/src/global/RuntimeParameters.h
+++ b/src/global/RuntimeParameters.h
@@ -135,6 +135,10 @@ struct RuntimeParameters {
   MemorySizeParameter sortInMemoryThreshold_{
       ad_utility::MemorySize::gigabytes(5), "sort-in-memory-threshold"};
 
+  // The changes from updates operations run after this parameter has been set
+  // to `false` will not be visible to queries until it is set back to `true`.
+  Bool propagateChangesFromUpdates_{true, "propagate-changes-from-updates"};
+
   // ___________________________________________________________________________
   // IMPORTANT NOTE: IF YOU ADD PARAMETERS ABOVE, ALSO REGISTER THEM IN THE
   // CONSTRUCTOR, S.T. THEY CAN ALSO BE ACCESSED VIA THE RUNTIME INTERFACE.

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -936,7 +936,7 @@ void IndexImpl::createFromOnDiskIndex(const std::string& onDiskBase,
         [&permutation](DeltaTriples& deltaTriples) {
           permutation.setOriginalMetadataForDeltaTriples(deltaTriples);
         },
-        false, false);
+        DeltaTriplesManager::UpdateSnapshotAfterRequest);
   };
 
   auto load = [this, &setMetadata](PermutationPtr permutation,

--- a/src/index/LocatedTriples.h
+++ b/src/index/LocatedTriples.h
@@ -96,6 +96,7 @@ class LocatedTriplesPerBlock {
   ad_utility::HashMap<size_t, LocatedTriples> map_;
 
   FRIEND_TEST(LocatedTriplesTest, numTriplesInBlock);
+  FRIEND_TEST(DeltaTriplesTest, propagateChangesFromUpdatesMetadataBehavior);
 
   // Implementation of the `mergeTriples` function (which has `numIndexColumns`
   // as a normal argument, and translates it into a template argument).

--- a/src/rdfTypes/CMakeLists.txt
+++ b/src/rdfTypes/CMakeLists.txt
@@ -2,4 +2,4 @@ add_library(rdfEscaping RdfEscaping.cpp)
 qlever_target_link_libraries(rdfEscaping)
 
 add_library(rdfTypes Iri.cpp Literal.cpp Variable.cpp GeoPoint.cpp GeometryInfo.cpp)
-qlever_target_link_libraries(rdfTypes pb_util pb_util_geo rdfEscaping sparqlParser)
+qlever_target_link_libraries(rdfTypes pb_util pb_util_geo rdfEscaping sparqlParser global)

--- a/src/util/Parameters.h
+++ b/src/util/Parameters.h
@@ -202,7 +202,7 @@ struct MemorySizeFromString {
 }  // namespace detail::parameterSerializers
 
 namespace detail::parameterShortNames {
-namespace n = detail::parameterSerializers;
+namespace n = parameterSerializers;
 /// Partial template specialization for Parameters with common types (numeric
 /// types and strings)
 using Float = Parameter<float, n::fl, n::toString>;

--- a/test/LocatedTriplesTest.cpp
+++ b/test/LocatedTriplesTest.cpp
@@ -823,6 +823,9 @@ TEST_F(LocatedTriplesTest, augmentedMetadata) {
 
 // _____________________________________________________________________________
 TEST_F(LocatedTriplesTest, augmentedMetadataGraphInfo) {
+  // Explicitly set the default value - updates are visible
+  setRuntimeParameter<&RuntimeParameters::propagateChangesFromUpdates_>(true);
+
   // Create a vector that is automatically converted to a span.
   using Span = std::vector<IdTriple<0>>;
 


### PR DESCRIPTION
Currently waiting for #2500 to be merged.

The runtime parameter `propagate-changes-from-updates` controls whether changes from new updates are visible. This is done by controlling whether snapshots and the augmented metadata are created/updated after updates. It is `true` by default which results in normal operations (snapshot and metadata update after each update). This saves time, but means that the update has no effect on queries (yet). When changed from `false` to `true`, the changes from updates while it was `false` become visible immediately. Updates that are executed while it is `false` are still executed correctly.