### PR TITLE
Support outdated type `typed-literal` in `sparql-results+json`

### DIFF
--- a/src/engine/Service.cpp
+++ b/src/engine/Service.cpp
@@ -404,9 +404,10 @@ TripleComponent Service::bindingToTripleComponent(
       getExecutionContext()->getIndex().getBlankNodeManager();
 
   TripleComponent tc;
-  // typed-literal is a pre SPARQL 1.1 WG note construct
-  // found widely in the wild because it was left in Virtuoso OS until summer 
-  // 2025
+  // NOTE: The type `typed-literal` is not part of the official SPARQL 1.1
+  // standard, but was mentioned in a pre SPARQL 1.1 WG note and used by
+  // Virtuoso until the summer of 2025. It is therefore still produced by
+  // some SPARQL endpoints, and we therefore support parsing it.
   if (type == "literal" || type == "typed-literal") {
     if (binding.contains("datatype")) {
       tc = TurtleParser<TokenizerCtre>::literalAndDatatypeToTripleComponent(

--- a/test/ServiceTest.cpp
+++ b/test/ServiceTest.cpp
@@ -642,10 +642,13 @@ TEST_F(ServiceTest, bindingToTripleComponent) {
   EXPECT_EQ(
       bTTC({{"type", "literal"}, {"value", "Hallo Welt"}, {"xml:lang", "de"}}),
       TripleComponent::Literal::literalWithoutQuotes("Hallo Welt", "@de"));
- 
-  //Test that we can read pre SPARQL 1.1 sparql-results 
+
+  // See the comment in `src/engine/Service.cpp` regarding the support of the
+  // deprecated `typed-literal` type.
   EXPECT_EQ(
-      bTTC({{"type", "typed-literal"}, {"value", "Hallo Welt"}, {"xml:lang", "de"}}),
+      bTTC({{"type", "typed-literal"},
+            {"value", "Hallo Welt"},
+            {"xml:lang", "de"}}),
       TripleComponent::Literal::literalWithoutQuotes("Hallo Welt", "@de"));
 
   EXPECT_EQ(bTTC({{"type", "literal"}, {"value", "Hello World"}}),


### PR DESCRIPTION
Until https://github.com/openlink/virtuoso-opensource/commit/e0e4ec02721ac26474c74d19b5fd94abae0530c5 from 03.07.2025, Virtuoso VOS produced `sparql-results+json` with type `typed-literal` instead of `literal`, following a very early [W3C Working Group Note from 18.06.2007](https://www.w3.org/TR/rdf-sparql-json-res/).

Such `sparql-results+json` are therefore still produced by various endpoints and it doesn't harm to support that type, albeit very outdated, so we support it. Fixes #2394