### PR TITLE
Replace deprecated `::set-output` in GitHub Action

### DIFF
--- a/.github/workflows/install-dependencies-ubuntu/action.yml
+++ b/.github/workflows/install-dependencies-ubuntu/action.yml
@@ -42,7 +42,7 @@ runs:
     - name: Get cmake version
       id: cmake
       run: |
-        echo "::set-output name=cmake-version::$(cmake --version | head -n1 | cut -d' ' -f3)"
+        echo "cmake-version=$(cmake --version | head -n1 | cut -d' ' -f3)" >> $GITHUB_OUTPUT
         echo "Minimum desired version: ${{ inputs.cmake-version }}"
       shell: bash
 


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands