### PR TITLE
Consistently use `AD_LOG_...` instead of the deprecated `LOG(...)`

### DIFF
--- a/benchmark/ParallelMergeBenchmark.cpp
+++ b/benchmark/ParallelMergeBenchmark.cpp
@@ -44,7 +44,7 @@ class IdTableCompressedWriterBenchmark : public BenchmarkInterface {
           result += el;
         }
       }
-      LOG(INFO) << "result was " << result << std::endl;
+      AD_LOG_INFO << "result was " << result << std::endl;
     };
 
     results.addMeasurement("simple merge", run);

--- a/benchmark/infrastructure/BenchmarkMeasurementContainer.h
+++ b/benchmark/infrastructure/BenchmarkMeasurementContainer.h
@@ -26,7 +26,7 @@ namespace ad_benchmark {
 // Helper function for adding time entries to the classes.
 /*
 @brief Return execution time of function in seconds and inserts the progress in
-`LOG(INFO)`.
+`AD_LOG_INFO`.
 
 @tparam Function Best left to type inference.
 
@@ -37,8 +37,8 @@ template <std::invocable Function>
 static float measureTimeOfFunction(
     const Function& functionToMeasure,
     std::string_view measurementSubjectIdentifier) {
-  LOG(INFO) << "Running measurement \"" << measurementSubjectIdentifier
-            << "\" ..." << std::endl;
+  AD_LOG_INFO << "Running measurement \"" << measurementSubjectIdentifier
+              << "\" ..." << std::endl;
 
   // Measuring the time.
   ad_utility::timer::Timer benchmarkTimer(ad_utility::timer::Timer::Started);
@@ -49,7 +49,7 @@ static float measureTimeOfFunction(
   // precision.
   const auto measuredTime = static_cast<float>(
       ad_utility::timer::Timer::toSeconds(benchmarkTimer.value()));
-  LOG(INFO) << "Done in " << measuredTime << " seconds." << std::endl;
+  AD_LOG_INFO << "Done in " << measuredTime << " seconds." << std::endl;
 
   return measuredTime;
 }
@@ -142,7 +142,7 @@ class ResultTable : public BenchmarkMetadataGetter {
   // For identification.
   std::string descriptor_;
   /*
-  For identification within `Log(Info)`. This class knows nothing about the
+  For identification within `AD_LOG_INFO`. This class knows nothing about the
   groups, where it is a member, but we want to include this information in
   the log. This is our workaround.
   */

--- a/src/ServerMain.cpp
+++ b/src/ServerMain.cpp
@@ -169,9 +169,9 @@ int main(int argc, char** argv) {
     return EXIT_FAILURE;
   }
 
-  LOG(INFO) << EMPH_ON << "QLever Server, compiled on "
-            << qlever::version::DatetimeOfCompilation << " using git hash "
-            << qlever::version::GitShortHash << EMPH_OFF << std::endl;
+  AD_LOG_INFO << EMPH_ON << "QLever Server, compiled on "
+              << qlever::version::DatetimeOfCompilation << " using git hash "
+              << qlever::version::GitShortHash << EMPH_OFF << std::endl;
 
   try {
     Server server(port, numSimultaneousQueries, memoryMaxSize,
@@ -181,7 +181,7 @@ int main(int argc, char** argv) {
   } catch (const std::exception& e) {
     // This code should never be reached as all exceptions should be handled
     // within server.run()
-    LOG(ERROR) << e.what() << std::endl;
+    AD_LOG_ERROR << e.what() << std::endl;
     return 1;
   }
   // This should also never be reached as the server threads are not supposed

--- a/src/engine/Bind.cpp
+++ b/src/engine/Bind.cpp
@@ -113,9 +113,9 @@ IdTable Bind::cloneSubView(const IdTable& idTable,
 
 // _____________________________________________________________________________
 Result Bind::computeResult(bool requestLaziness) {
-  LOG(DEBUG) << "Get input to BIND operation..." << std::endl;
+  AD_LOG_DEBUG << "Get input to BIND operation..." << std::endl;
   std::shared_ptr<const Result> subRes = _subtree->getResult(requestLaziness);
-  LOG(DEBUG) << "Got input to Bind operation." << std::endl;
+  AD_LOG_DEBUG << "Got input to Bind operation." << std::endl;
 
   auto applyBind = [this](IdTable idTable, LocalVocab* localVocab) {
     return computeExpressionBind(localVocab, std::move(idTable),
@@ -150,7 +150,7 @@ Result Bind::computeResult(bool requestLaziness) {
     // new words.
     LocalVocab localVocab = subRes->getCopyOfLocalVocab();
     IdTable result = applyBind(subRes->idTable().clone(), &localVocab);
-    LOG(DEBUG) << "BIND result computation done." << std::endl;
+    AD_LOG_DEBUG << "BIND result computation done." << std::endl;
     return {std::move(result), resultSortedOn(), std::move(localVocab)};
   }
 

--- a/src/engine/Distinct.cpp
+++ b/src/engine/Distinct.cpp
@@ -89,15 +89,16 @@ Result::LazyResult Distinct::lazyDistinct(Result::LazyResult input,
 
 // _____________________________________________________________________________
 Result Distinct::computeResult(bool requestLaziness) {
-  LOG(DEBUG) << "Getting sub-result for distinct result computation..." << endl;
+  AD_LOG_DEBUG << "Getting sub-result for distinct result computation..."
+               << endl;
   std::shared_ptr<const Result> subRes = subtree_->getResult(true);
 
-  LOG(DEBUG) << "Distinct result computation..." << endl;
+  AD_LOG_DEBUG << "Distinct result computation..." << endl;
   size_t width = subtree_->getResultWidth();
   if (subRes->isFullyMaterialized()) {
     IdTable idTable = CALL_FIXED_SIZE(width, &Distinct::outOfPlaceDistinct,
                                       this, subRes->idTable());
-    LOG(DEBUG) << "Distinct result computation done." << endl;
+    AD_LOG_DEBUG << "Distinct result computation done." << endl;
     return {std::move(idTable), resultSortedOn(),
             subRes->getSharedLocalVocab()};
   }
@@ -123,7 +124,7 @@ IdTable Distinct::distinct(
     IdTable dynInput,
     std::optional<typename IdTableStatic<WIDTH>::row_type> previousRow) const {
   AD_CONTRACT_CHECK(keepIndices_.size() <= dynInput.numColumns());
-  LOG(DEBUG) << "Distinct on " << dynInput.size() << " elements.\n";
+  AD_LOG_DEBUG << "Distinct on " << dynInput.size() << " elements.\n";
   IdTableStatic<WIDTH> result = std::move(dynInput).toStatic<WIDTH>();
 
   // Variant of `ql::ranges::unique` that allows to skip the begin rows of
@@ -167,7 +168,7 @@ IdTable Distinct::distinct(
   result.erase(dest, end);
   checkCancellation();
 
-  LOG(DEBUG) << "Distinct done.\n";
+  AD_LOG_DEBUG << "Distinct done.\n";
   return std::move(result).toDynamic();
 }
 
@@ -175,7 +176,7 @@ IdTable Distinct::distinct(
 template <size_t WIDTH>
 IdTable Distinct::outOfPlaceDistinct(const IdTable& dynInput) const {
   AD_CONTRACT_CHECK(keepIndices_.size() <= dynInput.numColumns());
-  LOG(DEBUG) << "Distinct on " << dynInput.size() << " elements.\n";
+  AD_LOG_DEBUG << "Distinct on " << dynInput.size() << " elements.\n";
   auto inputView = dynInput.asStaticView<WIDTH>();
   IdTableStatic<WIDTH> output{dynInput.numColumns(), allocator()};
 
@@ -208,7 +209,7 @@ IdTable Distinct::outOfPlaceDistinct(const IdTable& dynInput) const {
     } while (begin != end && matchesRow(*begin, begin[-1]));
   }
 
-  LOG(DEBUG) << "Distinct done.\n";
+  AD_LOG_DEBUG << "Distinct done.\n";
   return std::move(output).toDynamic();
 }
 

--- a/src/engine/Engine.h
+++ b/src/engine/Engine.h
@@ -16,7 +16,7 @@ class Engine {
  public:
   template <size_t WIDTH>
   static void sort(IdTable* tab, const size_t keyColumn) {
-    LOG(DEBUG) << "Sorting " << tab->size() << " elements ..." << std::endl;
+    AD_LOG_DEBUG << "Sorting " << tab->size() << " elements ..." << std::endl;
     IdTableStatic<WIDTH> stab = std::move(*tab).toStatic<WIDTH>();
     if constexpr (USE_PARALLEL_SORT) {
       ad_utility::parallel_sort(
@@ -32,7 +32,7 @@ class Engine {
                 });
     }
     *tab = std::move(stab).toDynamic();
-    LOG(TRACE) << "Sort done.\n";
+    AD_LOG_TRACE << "Sort done.\n";
   }
   // The effect of the third template argument is that if C does not have
   // operator() with the specified arguments that returns bool, then this
@@ -44,7 +44,7 @@ class Engine {
           bool, std::invoke_result_t<C, typename IdTableStatic<WIDTH>::row_type,
                                      typename IdTableStatic<WIDTH>::row_type>>>>
   static void sort(IdTable* tab, C comp) {
-    LOG(DEBUG) << "Sorting " << tab->size() << " elements.\n";
+    AD_LOG_DEBUG << "Sorting " << tab->size() << " elements.\n";
     IdTableStatic<WIDTH> stab = std::move(*tab).toStatic<WIDTH>();
     if constexpr (USE_PARALLEL_SORT) {
       ad_utility::parallel_sort(stab.begin(), stab.end(), comp,
@@ -53,7 +53,7 @@ class Engine {
       std::sort(stab.begin(), stab.end(), comp);
     }
     *tab = std::move(stab).toDynamic();
-    LOG(DEBUG) << "Sort done.\n";
+    AD_LOG_DEBUG << "Sort done.\n";
   }
 
   static void sort(IdTable& idTable, const std::vector<ColumnIndex>& sortCols);

--- a/src/engine/ExportQueryExecutionTrees.cpp
+++ b/src/engine/ExportQueryExecutionTrees.cpp
@@ -726,7 +726,7 @@ ExportQueryExecutionTrees::selectQueryResultBindingsToQLeverJSON(
     std::shared_ptr<const Result> result, uint64_t& resultSize,
     CancellationHandle cancellationHandle) {
   AD_CORRECTNESS_CHECK(result != nullptr);
-  LOG(DEBUG) << "Resolving strings for finished binary result...\n";
+  AD_LOG_DEBUG << "Resolving strings for finished binary result...\n";
   QueryExecutionTree::ColumnIndicesAndTypes selectedColumnIndices =
       qet.selectedVariablesToColumnIndices(selectClause, true);
 
@@ -755,8 +755,8 @@ ExportQueryExecutionTrees::selectQueryResultToStream(
   // unless the result is already cached.
   std::shared_ptr<const Result> result = qet.getResult(true);
   result->logResultSize();
-  LOG(DEBUG) << "Converting result IDs to their corresponding strings ..."
-             << std::endl;
+  AD_LOG_DEBUG << "Converting result IDs to their corresponding strings ..."
+               << std::endl;
   auto selectedColumnIndices =
       qet.selectedVariablesToColumnIndices(selectClause, true);
 
@@ -819,7 +819,7 @@ ExportQueryExecutionTrees::selectQueryResultToStream(
       cancellationHandle->throwIfCancelled();
     }
   }
-  LOG(DEBUG) << "Done creating readable result.\n";
+  AD_LOG_DEBUG << "Done creating readable result.\n";
 }
 
 // Convert a single ID to an XML binding of the given `variable`.
@@ -960,8 +960,8 @@ ad_utility::streams::stream_generator ExportQueryExecutionTrees::
   // unless the result is already cached.
   std::shared_ptr<const Result> result = qet.getResult(true);
   result->logResultSize();
-  LOG(DEBUG) << "Converting result IDs to their corresponding strings ..."
-             << std::endl;
+  AD_LOG_DEBUG << "Converting result IDs to their corresponding strings ..."
+               << std::endl;
   auto selectedColumnIndices =
       qet.selectedVariablesToColumnIndices(selectClause, false);
 
@@ -1194,8 +1194,8 @@ ExportQueryExecutionTrees::computeResultAsQLeverJSON(
     ++numBindingsExported;
   }
   if (numBindingsExported < resultSize) {
-    LOG(INFO) << "Number of bindings exported: " << numBindingsExported
-              << " of " << resultSize << std::endl;
+    AD_LOG_INFO << "Number of bindings exported: " << numBindingsExported
+                << " of " << resultSize << std::endl;
   }
 
   RuntimeInformation runtimeInformation = qet.getRootOperation()->runtimeInfo();

--- a/src/engine/GroupByImpl.cpp
+++ b/src/engine/GroupByImpl.cpp
@@ -456,7 +456,7 @@ IdTable GroupByImpl::doGroupBy(const IdTable& inTable,
                                const vector<size_t>& groupByCols,
                                const vector<Aggregate>& aggregates,
                                LocalVocab* outLocalVocab) const {
-  LOG(DEBUG) << "Group by input size " << inTable.size() << std::endl;
+  AD_LOG_DEBUG << "Group by input size " << inTable.size() << std::endl;
   IdTable dynResult{getResultWidth(), getExecutionContext()->getAllocator()};
 
   // If the input is empty, the result is also empty, except for an implicit
@@ -526,7 +526,7 @@ sparqlExpression::EvaluationContext GroupByImpl::createEvaluationContext(
 
 // _____________________________________________________________________________
 Result GroupByImpl::computeResult(bool requestLaziness) {
-  LOG(DEBUG) << "GroupBy result computation..." << std::endl;
+  AD_LOG_DEBUG << "GroupBy result computation..." << std::endl;
 
   if (auto idTable = computeOptimizedGroupByIfPossible()) {
     // Note: The optimized group bys currently all include index scans and thus
@@ -568,7 +568,7 @@ Result GroupByImpl::computeResult(bool requestLaziness) {
     subresult = _subtree->getResult(metadataForUnsequentialData.has_value());
   }
 
-  LOG(DEBUG) << "GroupBy subresult computation done" << std::endl;
+  AD_LOG_DEBUG << "GroupBy subresult computation done" << std::endl;
 
   std::vector<size_t> groupByColumns;
 
@@ -643,7 +643,7 @@ Result GroupByImpl::computeResult(bool requestLaziness) {
       (std::array{inWidth, outWidth}), &GroupByImpl::doGroupBy, this,
       subresult->idTable(), groupByCols, aggregates, &localVocab);
 
-  LOG(DEBUG) << "GroupBy result computation done." << std::endl;
+  AD_LOG_DEBUG << "GroupBy result computation done." << std::endl;
   return {std::move(idTable), resultSortedOn(), std::move(localVocab)};
 }
 

--- a/src/engine/IndexScan.cpp
+++ b/src/engine/IndexScan.cpp
@@ -255,7 +255,7 @@ IdTable IndexScan::materializedIndexScan() const {
   IdTable idTable = getScanPermutation().scan(
       scanSpecAndBlocks_, additionalColumns(), cancellationHandle_,
       locatedTriplesSnapshot(), getLimitOffset());
-  LOG(DEBUG) << "IndexScan result computation done.\n";
+  AD_LOG_DEBUG << "IndexScan result computation done.\n";
   checkCancellation();
   idTable = makeApplyColumnSubset()(std::move(idTable));
   AD_CORRECTNESS_CHECK(idTable.numColumns() == getResultWidth());
@@ -264,7 +264,7 @@ IdTable IndexScan::materializedIndexScan() const {
 
 // _____________________________________________________________________________
 Result IndexScan::computeResult(bool requestLaziness) {
-  LOG(DEBUG) << "IndexScan result computation...\n";
+  AD_LOG_DEBUG << "IndexScan result computation...\n";
   if (requestLaziness) {
     return {chunkedIndexScan(), resultSortedOn()};
   }

--- a/src/engine/Join.cpp
+++ b/src/engine/Join.cpp
@@ -95,7 +95,7 @@ string Join::getDescriptor() const { return "Join on " + _joinVar.name(); }
 
 // _____________________________________________________________________________
 Result Join::computeResult(bool requestLaziness) {
-  LOG(DEBUG) << "Getting sub-results for join result computation..." << endl;
+  AD_LOG_DEBUG << "Getting sub-results for join result computation..." << endl;
   if (_left->knownEmptyResult() || _right->knownEmptyResult()) {
     _left->getRootOperation()->updateRuntimeInformationWhenOptimizedOut();
     _right->getRootOperation()->updateRuntimeInformationWhenOptimizedOut();
@@ -257,9 +257,9 @@ void Join::computeSizeEstimateAndMultiplicities() {
       size_t(1), static_cast<size_t>(corrFactor * jcMultiplicityInResult *
                                      nofDistinctInResult));
 
-  LOG(TRACE) << "Estimated size as: " << _sizeEstimate << " := " << corrFactor
-             << " * " << jcMultiplicityInResult << " * " << nofDistinctInResult
-             << std::endl;
+  AD_LOG_TRACE << "Estimated size as: " << _sizeEstimate << " := " << corrFactor
+               << " * " << jcMultiplicityInResult << " * "
+               << nofDistinctInResult << std::endl;
 
   for (auto i = ColumnIndex{0}; i < _left->getResultWidth(); ++i) {
     double oldMult = _left->getMultiplicity(i);
@@ -294,11 +294,11 @@ void Join::computeSizeEstimateAndMultiplicities() {
 // ______________________________________________________________________________
 
 void Join::join(const IdTable& a, const IdTable& b, IdTable* result) const {
-  LOG(DEBUG) << "Performing join between two tables.\n";
-  LOG(DEBUG) << "A: width = " << a.numColumns() << ", size = " << a.size()
-             << "\n";
-  LOG(DEBUG) << "B: width = " << b.numColumns() << ", size = " << b.size()
-             << "\n";
+  AD_LOG_DEBUG << "Performing join between two tables.\n";
+  AD_LOG_DEBUG << "A: width = " << a.numColumns() << ", size = " << a.size()
+               << "\n";
+  AD_LOG_DEBUG << "B: width = " << b.numColumns() << ", size = " << b.size()
+               << "\n";
 
   // Check trivial case.
   if (a.empty() || b.empty()) {
@@ -378,9 +378,9 @@ void Join::join(const IdTable& a, const IdTable& b, IdTable* result) const {
   // the order.
   result->setColumnSubset(joinColumnData.permutationResult());
 
-  LOG(DEBUG) << "Join done.\n";
-  LOG(DEBUG) << "Result: width = " << result->numColumns()
-             << ", size = " << result->size() << "\n";
+  AD_LOG_DEBUG << "Join done.\n";
+  AD_LOG_DEBUG << "Result: width = " << result->numColumns()
+               << ", size = " << result->size() << "\n";
 }
 
 // _____________________________________________________________________________
@@ -439,11 +439,11 @@ void Join::hashJoinImpl(const IdTable& dynA, ColumnIndex jc1,
   const IdTableView<L_WIDTH> a = dynA.asStaticView<L_WIDTH>();
   const IdTableView<R_WIDTH> b = dynB.asStaticView<R_WIDTH>();
 
-  LOG(DEBUG) << "Performing hashJoin between two tables.\n";
-  LOG(DEBUG) << "A: width = " << a.numColumns() << ", size = " << a.size()
-             << "\n";
-  LOG(DEBUG) << "B: width = " << b.numColumns() << ", size = " << b.size()
-             << "\n";
+  AD_LOG_DEBUG << "Performing hashJoin between two tables.\n";
+  AD_LOG_DEBUG << "A: width = " << a.numColumns() << ", size = " << a.size()
+               << "\n";
+  AD_LOG_DEBUG << "B: width = " << b.numColumns() << ", size = " << b.size()
+               << "\n";
 
   // Check trivial case.
   if (a.empty() || b.empty()) {
@@ -523,9 +523,9 @@ void Join::hashJoinImpl(const IdTable& dynA, ColumnIndex jc1,
   }
   *dynRes = std::move(result).toDynamic();
 
-  LOG(DEBUG) << "HashJoin done.\n";
-  LOG(DEBUG) << "Result: width = " << dynRes->numColumns()
-             << ", size = " << dynRes->size() << "\n";
+  AD_LOG_DEBUG << "HashJoin done.\n";
+  AD_LOG_DEBUG << "Result: width = " << dynRes->numColumns()
+               << ", size = " << dynRes->size() << "\n";
 }
 
 // ______________________________________________________________________________

--- a/src/engine/Load.cpp
+++ b/src/engine/Load.cpp
@@ -105,7 +105,7 @@ Result Load::computeResultImpl([[maybe_unused]] bool requestLaziness) {
   // TODO<qup42> implement lazy loading; requires modifications to the parser
   ad_utility::httpUtils::Url url{
       asStringViewUnsafe(loadClause_.iri_.getContent())};
-  LOG(INFO) << "Loading RDF dataset from " << url.asString() << std::endl;
+  AD_LOG_INFO << "Loading RDF dataset from " << url.asString() << std::endl;
   HttpOrHttpsResponse response = getResultFunction_(
       url, cancellationHandle_, boost::beast::http::verb::get, "", "", "");
 

--- a/src/engine/MultiColumnJoin.cpp
+++ b/src/engine/MultiColumnJoin.cpp
@@ -60,7 +60,7 @@ string MultiColumnJoin::getDescriptor() const {
 
 // _____________________________________________________________________________
 Result MultiColumnJoin::computeResult([[maybe_unused]] bool requestLaziness) {
-  LOG(DEBUG) << "MultiColumnJoin result computation..." << endl;
+  AD_LOG_DEBUG << "MultiColumnJoin result computation..." << endl;
 
   IdTable idTable{getExecutionContext()->getAllocator()};
   idTable.setNumColumns(getResultWidth());
@@ -72,18 +72,18 @@ Result MultiColumnJoin::computeResult([[maybe_unused]] bool requestLaziness) {
 
   checkCancellation();
 
-  LOG(DEBUG) << "MultiColumnJoin subresult computation done." << std::endl;
+  AD_LOG_DEBUG << "MultiColumnJoin subresult computation done." << std::endl;
 
-  LOG(DEBUG) << "Computing a multi column join between results of size "
-             << leftResult->idTable().size() << " and "
-             << rightResult->idTable().size() << endl;
+  AD_LOG_DEBUG << "Computing a multi column join between results of size "
+               << leftResult->idTable().size() << " and "
+               << rightResult->idTable().size() << endl;
 
   computeMultiColumnJoin(leftResult->idTable(), rightResult->idTable(),
                          _joinColumns, &idTable);
 
   checkCancellation();
 
-  LOG(DEBUG) << "MultiColumnJoin result computation done" << endl;
+  AD_LOG_DEBUG << "MultiColumnJoin result computation done" << endl;
   // If only one of the two operands has a non-empty local vocabulary, share
   // with that one (otherwise, throws an exception).
   return {std::move(idTable), resultSortedOn(),

--- a/src/engine/Operation.cpp
+++ b/src/engine/Operation.cpp
@@ -193,8 +193,8 @@ Result Operation::runComputation(const ad_utility::Timer& timer,
           updateRuntimeStats(false, idTable.numRows(), idTable.numColumns(),
                              duration);
           AD_CORRECTNESS_CHECK(idTable.numColumns() == getResultWidth());
-          LOG(DEBUG) << "Computed partial chunk of size " << idTable.numRows()
-                     << " x " << idTable.numColumns() << std::endl;
+          AD_LOG_DEBUG << "Computed partial chunk of size " << idTable.numRows()
+                       << " x " << idTable.numColumns() << std::endl;
           mergeStats(vocabStats, pair.localVocab_);
           if (vocabStats.sizeSum_ > 0) {
             runtimeInfo().addDetail(
@@ -278,8 +278,8 @@ CacheValue Operation::runComputationAndPrepareForCache(
   if (result.isFullyMaterialized()) {
     auto resultNumRows = result.idTable().size();
     auto resultNumCols = result.idTable().numColumns();
-    LOG(DEBUG) << "Computed result of size " << resultNumRows << " x "
-               << resultNumCols << std::endl;
+    AD_LOG_DEBUG << "Computed result of size " << resultNumRows << " x "
+                 << resultNumCols << std::endl;
   }
 
   return CacheValue{std::move(result), runtimeInfo()};
@@ -410,21 +410,21 @@ std::shared_ptr<const Result> Operation::getResult(
     // runtime info) only in the DEBUG log. Note that the exception will be
     // caught by the `processQuery` method, where the error message will be
     // printed *and* included in an error response sent to the client.
-    LOG(ERROR) << "Waited for a result from another thread which then failed"
-               << std::endl;
-    LOG(DEBUG) << getCacheKey();
+    AD_LOG_ERROR << "Waited for a result from another thread which then failed"
+                 << std::endl;
+    AD_LOG_DEBUG << getCacheKey();
     throw ad_utility::AbortException(e);
   } catch (const std::exception& e) {
     // We are in the innermost level of the exception, so print
-    LOG(ERROR) << "Aborted Operation" << std::endl;
-    LOG(DEBUG) << getCacheKey() << std::endl;
+    AD_LOG_ERROR << "Aborted Operation" << std::endl;
+    AD_LOG_DEBUG << getCacheKey() << std::endl;
     // Rethrow as QUERY_ABORTED allowing us to print the Operation
     // only at innermost failure of a recursive call
     throw ad_utility::AbortException(e);
   } catch (...) {
     // We are in the innermost level of the exception, so print
-    LOG(ERROR) << "Aborted Operation" << std::endl;
-    LOG(DEBUG) << getCacheKey() << std::endl;
+    AD_LOG_ERROR << "Aborted Operation" << std::endl;
+    AD_LOG_DEBUG << getCacheKey() << std::endl;
     // Rethrow as QUERY_ABORTED allowing us to print the Operation
     // only at innermost failure of a recursive call
     throw ad_utility::AbortException(

--- a/src/engine/OptionalJoin.cpp
+++ b/src/engine/OptionalJoin.cpp
@@ -102,7 +102,7 @@ string OptionalJoin::getDescriptor() const {
 
 // _____________________________________________________________________________
 Result OptionalJoin::computeResult(bool requestLaziness) {
-  LOG(DEBUG) << "OptionalJoin result computation..." << endl;
+  AD_LOG_DEBUG << "OptionalJoin result computation..." << endl;
 
   // If the right of the RootOperations is a Service, precompute the result of
   // its sibling.
@@ -127,7 +127,7 @@ Result OptionalJoin::computeResult(bool requestLaziness) {
 
   checkCancellation();
 
-  LOG(DEBUG) << "OptionalJoin subresult computation done." << std::endl;
+  AD_LOG_DEBUG << "OptionalJoin subresult computation done." << std::endl;
 
   if (!leftResult->isFullyMaterialized() ||
       !rightResult->isFullyMaterialized()) {
@@ -135,16 +135,16 @@ Result OptionalJoin::computeResult(bool requestLaziness) {
                             requestLaziness);
   }
 
-  LOG(DEBUG) << "Computing optional join between results of size "
-             << leftResult->idTable().size() << " and "
-             << rightResult->idTable().size() << endl;
+  AD_LOG_DEBUG << "Computing optional join between results of size "
+               << leftResult->idTable().size() << " and "
+               << rightResult->idTable().size() << endl;
 
   optionalJoin(leftResult->idTable(), rightResult->idTable(), _joinColumns,
                &idTable, implementation_);
 
   checkCancellation();
 
-  LOG(DEBUG) << "OptionalJoin result computation done." << endl;
+  AD_LOG_DEBUG << "OptionalJoin result computation done." << endl;
   // If only one of the two operands has a non-empty local vocabulary, share
   // with that one (otherwise, throws an exception).
   return {std::move(idTable), resultSortedOn(),

--- a/src/engine/OrderBy.cpp
+++ b/src/engine/OrderBy.cpp
@@ -65,7 +65,8 @@ std::string OrderBy::getDescriptor() const {
 // _____________________________________________________________________________
 Result OrderBy::computeResult([[maybe_unused]] bool requestLaziness) {
   using std::endl;
-  LOG(DEBUG) << "Getting sub-result for OrderBy result computation..." << endl;
+  AD_LOG_DEBUG << "Getting sub-result for OrderBy result computation..."
+               << endl;
   std::shared_ptr<const Result> subRes = subtree_->getResult();
 
   // TODO<joka921> proper timeout for sorting operations
@@ -74,7 +75,7 @@ Result OrderBy::computeResult([[maybe_unused]] bool requestLaziness) {
       subTable.numRows(), subTable.numColumns(), deadline_,
       "Sort for COUNT(DISTINCT *)");
 
-  LOG(DEBUG) << "OrderBy result computation..." << endl;
+  AD_LOG_DEBUG << "OrderBy result computation..." << endl;
   IdTable idTable = subRes->idTable().clone();
 
   size_t width = idTable.numColumns();
@@ -125,7 +126,7 @@ Result OrderBy::computeResult([[maybe_unused]] bool requestLaziness) {
   // We can't check during sort, so reset status here
   cancellationHandle_->resetWatchDogState();
   checkCancellation();
-  LOG(DEBUG) << "OrderBy result computation done." << endl;
+  AD_LOG_DEBUG << "OrderBy result computation done." << endl;
   return {std::move(idTable), resultSortedOn(), subRes->getSharedLocalVocab()};
 }
 

--- a/src/engine/QueryExecutionTree.cpp
+++ b/src/engine/QueryExecutionTree.cpp
@@ -67,10 +67,10 @@ QueryExecutionTree::selectedVariablesToColumnIndices(
           VariableAndColumnIndex{std::move(varString), columnIndex});
     } else {
       exportColumns.emplace_back(std::nullopt);
-      LOG(WARN) << "The variable \"" << varString
-                << "\" was found in the original query, but not in the "
-                   "execution tree. This is likely a bug"
-                << std::endl;
+      AD_LOG_WARN << "The variable \"" << varString
+                  << "\" was found in the original query, but not in the "
+                     "execution tree. This is likely a bug"
+                  << std::endl;
     }
   }
   return exportColumns;

--- a/src/engine/QueryPlanningCostFactors.cpp
+++ b/src/engine/QueryPlanningCostFactors.cpp
@@ -48,8 +48,8 @@ void QueryPlanningCostFactors::readFromFile(const std::string& fileName) {
     std::vector<std::string_view> v = absl::StrSplit(line, '\t');
     AD_CONTRACT_CHECK(v.size() == 2);
     float factor = toFloat(v[1]);
-    LOG(INFO) << "Setting cost factor: " << v[0] << " from " << _factors[v[0]]
-              << " to " << factor << std::endl;
+    AD_LOG_INFO << "Setting cost factor: " << v[0] << " from " << _factors[v[0]]
+                << " to " << factor << std::endl;
     _factors[v[0]] = factor;
   }
 }

--- a/src/engine/Result.cpp
+++ b/src/engine/Result.cpp
@@ -376,9 +376,9 @@ void Result::cacheDuringConsumption(
 // _____________________________________________________________________________
 void Result::logResultSize() const {
   if (isFullyMaterialized()) {
-    LOG(INFO) << "Result has size " << idTable().size() << " x "
-              << idTable().numColumns() << std::endl;
+    AD_LOG_INFO << "Result has size " << idTable().size() << " x "
+                << idTable().numColumns() << std::endl;
   } else {
-    LOG(INFO) << "Result has unknown size (not computed yet)" << std::endl;
+    AD_LOG_INFO << "Result has unknown size (not computed yet)" << std::endl;
   }
 }

--- a/src/engine/Service.cpp
+++ b/src/engine/Service.cpp
@@ -149,12 +149,12 @@ Result Service::computeResultImpl(bool requestLaziness) {
   std::string serviceQuery =
       absl::StrCat(parsedServiceClause_.prologue_, "\nSELECT ",
                    variablesForSelectClause, " ", getGraphPattern());
-  LOG(INFO) << "Sending SERVICE query to remote endpoint "
-            << "(protocol: " << serviceUrl.protocolAsString()
-            << ", host: " << serviceUrl.host()
-            << ", port: " << serviceUrl.port()
-            << ", target: " << serviceUrl.target() << ")" << std::endl
-            << serviceQuery << std::endl;
+  AD_LOG_INFO << "Sending SERVICE query to remote endpoint "
+              << "(protocol: " << serviceUrl.protocolAsString()
+              << ", host: " << serviceUrl.host()
+              << ", port: " << serviceUrl.port()
+              << ", target: " << serviceUrl.target() << ")" << std::endl
+              << serviceQuery << std::endl;
 
   HttpOrHttpsResponse response = getResultFunction_(
       serviceUrl, cancellationHandle_, boost::beast::http::verb::post,

--- a/src/engine/Sort.cpp
+++ b/src/engine/Sort.cpp
@@ -53,7 +53,7 @@ std::string Sort::getDescriptor() const {
 // _____________________________________________________________________________
 Result Sort::computeResult([[maybe_unused]] bool requestLaziness) {
   using std::endl;
-  LOG(DEBUG) << "Getting sub-result for Sort result computation..." << endl;
+  AD_LOG_DEBUG << "Getting sub-result for Sort result computation..." << endl;
   std::shared_ptr<const Result> subRes = subtree_->getResult();
 
   // TODO<joka921> proper timeout for sorting operations
@@ -61,7 +61,7 @@ Result Sort::computeResult([[maybe_unused]] bool requestLaziness) {
   getExecutionContext()->getSortPerformanceEstimator().throwIfEstimateTooLong(
       subTable.numRows(), subTable.numColumns(), deadline_, "Sort operation");
 
-  LOG(DEBUG) << "Sort result computation..." << endl;
+  AD_LOG_DEBUG << "Sort result computation..." << endl;
   ad_utility::Timer t{ad_utility::timer::Timer::InitialStatus::Started};
   IdTable idTable = subRes->idTable().clone();
   runtimeInfo().addDetail("time-cloning", t.msecs());
@@ -71,7 +71,7 @@ Result Sort::computeResult([[maybe_unused]] bool requestLaziness) {
   cancellationHandle_->resetWatchDogState();
   checkCancellation();
 
-  LOG(DEBUG) << "Sort result computation done." << endl;
+  AD_LOG_DEBUG << "Sort result computation done." << endl;
   return {std::move(idTable), resultSortedOn(), subRes->getSharedLocalVocab()};
 }
 

--- a/src/engine/SortPerformanceEstimator.cpp
+++ b/src/engine/SortPerformanceEstimator.cpp
@@ -63,9 +63,10 @@ auto SortPerformanceEstimator::estimatedSortTime(size_t numRows,
                                                  size_t numCols) const noexcept
     -> Timer::Duration {
   if (!_estimatesWereCalculated) {
-    LOG(WARN) << "The estimates of the SortPerformanceEstimator were never set "
-                 "up, Sorts will thus never time out"
-              << std::endl;
+    AD_LOG_WARN
+        << "The estimates of the SortPerformanceEstimator were never set "
+           "up, Sorts will thus never time out"
+        << std::endl;
     return Timer::Duration::zero();
   }
   // Return the index of the element in the !sorted! `sampleVector`, which is
@@ -94,10 +95,10 @@ auto SortPerformanceEstimator::estimatedSortTime(size_t numRows,
   // start with the closest sample
   Timer::Duration result = _samples[rowIndex][columnIndex];
 
-  LOG(TRACE) << "Closest sample result was " << sampleValuesRows[rowIndex]
-             << " rows with " << sampleValuesCols[columnIndex]
-             << " columns and an estimate of " << Timer::toSeconds(result)
-             << " seconds." << std::endl;
+  AD_LOG_TRACE << "Closest sample result was " << sampleValuesRows[rowIndex]
+               << " rows with " << sampleValuesCols[columnIndex]
+               << " columns and an estimate of " << Timer::toSeconds(result)
+               << " seconds." << std::endl;
 
   auto numRowsInSample = static_cast<double>(sampleValuesRows[rowIndex]);
   double rowRatio = static_cast<double>(numRows) / numRowsInSample;
@@ -121,9 +122,9 @@ void SortPerformanceEstimator::computeEstimatesExpensively(
   static_assert(isSorted(sampleValuesCols));
   static_assert(isSorted(sampleValuesRows));
 
-  LOG(INFO) << "Sorting random result tables to estimate the sorting "
-               "performance of this machine ..."
-            << std::endl;
+  AD_LOG_INFO << "Sorting random result tables to estimate the sorting "
+                 "performance of this machine ..."
+              << std::endl;
 
   _samples.fill({});
   for (size_t i = 0; i < NUM_SAMPLES_ROWS; ++i) {
@@ -156,9 +157,10 @@ void SortPerformanceEstimator::computeEstimatesExpensively(
       if (estimateSortingTime) {
         // These estimates are not too important, since results of this size
         // cannot be sorted anyway because of the memory limit.
-        LOG(TRACE) << "Creating the table failed because of a lack of memory"
-                   << std::endl;
-        LOG(TRACE) << "Creating an estimate from a smaller result" << std::endl;
+        AD_LOG_TRACE << "Creating the table failed because of a lack of memory"
+                     << std::endl;
+        AD_LOG_TRACE << "Creating an estimate from a smaller result"
+                     << std::endl;
         if (i > 0) {
           // Assume that sorting time grows linearly in the number of rows. For
           // details on the usage of `toDuration()` see its first usage above.
@@ -177,18 +179,18 @@ void SortPerformanceEstimator::computeEstimatesExpensively(
         } else {
           // not even the smallest IdTable could be created, this should never
           // happen.
-          LOG(WARN)
+          AD_LOG_WARN
               << "Could not create any estimate for the sorting performance. "
               << "Setting all estimates to 0. This means that no sort "
               << "operations will be canceled." << std::endl;
         }
-        LOG(TRACE) << "Estimated the sort time to be " << std::fixed
-                   << std::setprecision(3) << Timer::toSeconds(_samples[i][j])
-                   << " seconds." << std::endl;
+        AD_LOG_TRACE << "Estimated the sort time to be " << std::fixed
+                     << std::setprecision(3) << Timer::toSeconds(_samples[i][j])
+                     << " seconds." << std::endl;
       }
     }
   }
-  LOG(DEBUG) << "Done computing sort estimates" << std::endl;
+  AD_LOG_DEBUG << "Done computing sort estimates" << std::endl;
   _estimatesWereCalculated = true;
 }
 // ___________________________________________________________________________

--- a/src/engine/SparqlProtocol.cpp
+++ b/src/engine/SparqlProtocol.cpp
@@ -120,7 +120,7 @@ ad_utility::url_parser::ParsedRequest SparqlProtocol::parsePOST(
   // Reference: https://www.w3.org/TR/2013/REC-sparql11-protocol-20130321
   std::string_view contentType =
       request.base()[boost::beast::http::field::content_type];
-  LOG(DEBUG) << "Content-type: \"" << contentType << "\"" << std::endl;
+  AD_LOG_DEBUG << "Content-type: \"" << contentType << "\"" << std::endl;
 
   // Note: For simplicity we only check via `starts_with`. This ignores
   // additional parameters like `application/sparql-query;charset=utf8`. We

--- a/src/engine/TransitivePathBase.cpp
+++ b/src/engine/TransitivePathBase.cpp
@@ -184,13 +184,13 @@ TransitivePathBase::~TransitivePathBase() = default;
 std::pair<TransitivePathSide&, TransitivePathSide&>
 TransitivePathBase::decideDirection() {
   if (lhs_.isBoundVariable()) {
-    LOG(DEBUG) << "Computing TransitivePath left to right" << std::endl;
+    AD_LOG_DEBUG << "Computing TransitivePath left to right" << std::endl;
     return {lhs_, rhs_};
   } else if (rhs_.isBoundVariable() || !rhs_.isVariable()) {
-    LOG(DEBUG) << "Computing TransitivePath right to left" << std::endl;
+    AD_LOG_DEBUG << "Computing TransitivePath right to left" << std::endl;
     return {rhs_, lhs_};
   }
-  LOG(DEBUG) << "Computing TransitivePath left to right" << std::endl;
+  AD_LOG_DEBUG << "Computing TransitivePath left to right" << std::endl;
   return {lhs_, rhs_};
 }
 

--- a/src/engine/Union.cpp
+++ b/src/engine/Union.cpp
@@ -227,7 +227,7 @@ size_t Union::getCostEstimate() {
 }
 
 Result Union::computeResult(bool requestLaziness) {
-  LOG(DEBUG) << "Union result computation..." << std::endl;
+  AD_LOG_DEBUG << "Union result computation..." << std::endl;
   std::shared_ptr<const Result> subRes1 =
       _subtrees[0]->getResult(requestLaziness);
   std::shared_ptr<const Result> subRes2 =
@@ -249,12 +249,12 @@ Result Union::computeResult(bool requestLaziness) {
             resultSortedOn()};
   }
 
-  LOG(DEBUG) << "Union subresult computation done." << std::endl;
+  AD_LOG_DEBUG << "Union subresult computation done." << std::endl;
 
   IdTable idTable =
       computeUnion(subRes1->idTable(), subRes2->idTable(), _columnOrigins);
 
-  LOG(DEBUG) << "Union result computation done" << std::endl;
+  AD_LOG_DEBUG << "Union result computation done" << std::endl;
   // If only one of the two operands has a non-empty local vocabulary, share
   // with that one (otherwise, throws an exception).
   return {std::move(idTable), resultSortedOn(),

--- a/src/engine/Values.cpp
+++ b/src/engine/Values.cpp
@@ -142,9 +142,9 @@ void Values::writeValues(IdTable* idTablePtr, LocalVocab* localVocab) {
     rowIdx++;
   }
   AD_CORRECTNESS_CHECK(rowIdx == parsedValues_._values.size());
-  LOG(INFO) << "Number of tuples in VALUES clause: " << rowIdx << std::endl;
-  LOG(INFO) << "Number of entries in local vocabulary per column: "
-            << absl::StrJoin(numLocalVocabPerColumn, ", ") << std::endl;
+  AD_LOG_INFO << "Number of tuples in VALUES clause: " << rowIdx << std::endl;
+  AD_LOG_INFO << "Number of entries in local vocabulary per column: "
+              << absl::StrJoin(numLocalVocabPerColumn, ", ") << std::endl;
   *idTablePtr = std::move(idTable).toDynamic();
 }
 

--- a/src/index/CompressedRelation.cpp
+++ b/src/index/CompressedRelation.cpp
@@ -1832,7 +1832,7 @@ auto CompressedRelationWriter::createPermutationPair(
 
       ++numTriplesProcessed;
       if (progressBar.update()) {
-        LOG(INFO) << progressBar.getProgressString() << std::flush;
+        AD_LOG_INFO << progressBar.getProgressString() << std::flush;
       }
     }
     // Call each of the `perBlockCallbacks` for the current block.
@@ -1848,7 +1848,7 @@ auto CompressedRelationWriter::createPermutationPair(
     blockCallbackTimer.stop();
     inputWaitTimer.cont();
   }
-  LOG(INFO) << progressBar.getFinalProgressString() << std::flush;
+  AD_LOG_INFO << progressBar.getFinalProgressString() << std::flush;
   inputWaitTimer.stop();
   if (!relation.empty() || numBlocksCurrentRel > 0) {
     finishRelation();
@@ -1859,21 +1859,21 @@ auto CompressedRelationWriter::createPermutationPair(
   blockCallbackTimer.cont();
   blockCallbackQueue.finish();
   blockCallbackTimer.stop();
-  LOG(TIMING) << "Time spent waiting for the input "
-              << ad_utility::Timer::toSeconds(inputWaitTimer.msecs()) << "s"
-              << std::endl;
-  LOG(TIMING) << "Time spent waiting for writer1's queue "
-              << ad_utility::Timer::toSeconds(
-                     writer1.blockWriteQueueTimer_.msecs())
-              << "s" << std::endl;
-  LOG(TIMING) << "Time spent waiting for writer2's queue "
-              << ad_utility::Timer::toSeconds(
-                     writer2.blockWriteQueueTimer_.msecs())
-              << "s" << std::endl;
-  LOG(TIMING) << "Time spent waiting for large twin relations "
-              << ad_utility::Timer::toSeconds(largeTwinRelationTimer.msecs())
-              << "s" << std::endl;
-  LOG(TIMING)
+  AD_LOG_TIMING << "Time spent waiting for the input "
+                << ad_utility::Timer::toSeconds(inputWaitTimer.msecs()) << "s"
+                << std::endl;
+  AD_LOG_TIMING << "Time spent waiting for writer1's queue "
+                << ad_utility::Timer::toSeconds(
+                       writer1.blockWriteQueueTimer_.msecs())
+                << "s" << std::endl;
+  AD_LOG_TIMING << "Time spent waiting for writer2's queue "
+                << ad_utility::Timer::toSeconds(
+                       writer2.blockWriteQueueTimer_.msecs())
+                << "s" << std::endl;
+  AD_LOG_TIMING << "Time spent waiting for large twin relations "
+                << ad_utility::Timer::toSeconds(largeTwinRelationTimer.msecs())
+                << "s" << std::endl;
+  AD_LOG_TIMING
       << "Time spent waiting for triple callbacks (e.g. the next sorter) "
       << ad_utility::Timer::toSeconds(blockCallbackTimer.msecs()) << "s"
       << std::endl;

--- a/src/index/DeltaTriples.cpp
+++ b/src/index/DeltaTriples.cpp
@@ -90,9 +90,9 @@ DeltaTriplesCount DeltaTriples::getCounts() const {
 void DeltaTriples::insertTriples(CancellationHandle cancellationHandle,
                                  Triples triples,
                                  ad_utility::timer::TimeTracer& tracer) {
-  LOG(DEBUG) << "Inserting"
-             << " " << triples.size()
-             << " triples (including idempotent triples)." << std::endl;
+  AD_LOG_DEBUG << "Inserting"
+               << " " << triples.size()
+               << " triples (including idempotent triples)." << std::endl;
   modifyTriplesImpl(std::move(cancellationHandle), std::move(triples), true,
                     triplesInserted_, triplesDeleted_, tracer);
 }
@@ -101,9 +101,9 @@ void DeltaTriples::insertTriples(CancellationHandle cancellationHandle,
 void DeltaTriples::deleteTriples(CancellationHandle cancellationHandle,
                                  Triples triples,
                                  ad_utility::timer::TimeTracer& tracer) {
-  LOG(DEBUG) << "Deleting"
-             << " " << triples.size()
-             << " triples (including idempotent triples)." << std::endl;
+  AD_LOG_DEBUG << "Deleting"
+               << " " << triples.size()
+               << " triples (including idempotent triples)." << std::endl;
   modifyTriplesImpl(std::move(cancellationHandle), std::move(triples), false,
                     triplesDeleted_, triplesInserted_, tracer);
 }

--- a/src/index/FTSAlgorithms.cpp
+++ b/src/index/FTSAlgorithms.cpp
@@ -11,8 +11,8 @@
 IdTable FTSAlgorithms::filterByRange(const IdRange<WordVocabIndex>& idRange,
                                      const IdTable& idTablePreFilter) {
   AD_CONTRACT_CHECK(idTablePreFilter.numColumns() == 3);
-  LOG(DEBUG) << "Filtering " << idTablePreFilter.getColumn(0).size()
-             << " elements by ID range...\n";
+  AD_LOG_DEBUG << "Filtering " << idTablePreFilter.getColumn(0).size()
+               << " elements by ID range...\n";
 
   IdTable idTableResult{idTablePreFilter.getAllocator()};
   idTableResult.setNumColumns(3);
@@ -45,7 +45,7 @@ IdTable FTSAlgorithms::filterByRange(const IdRange<WordVocabIndex>& idRange,
 
   idTableResult.resize(nofResultElements);
 
-  LOG(DEBUG) << "Filtering by ID range done. Result has "
-             << idTableResult.numRows() << " elements.\n";
+  AD_LOG_DEBUG << "Filtering by ID range done. Result has "
+               << idTableResult.numRows() << " elements.\n";
   return idTableResult;
 }

--- a/src/index/IndexBuilderMain.cpp
+++ b/src/index/IndexBuilderMain.cpp
@@ -267,9 +267,9 @@ int main(int argc, char** argv) {
     return EXIT_FAILURE;
   }
 
-  LOG(INFO) << EMPH_ON << "QLever IndexBuilder, compiled on "
-            << qlever::version::DatetimeOfCompilation << " using git hash "
-            << qlever::version::GitShortHash << EMPH_OFF << std::endl;
+  AD_LOG_INFO << EMPH_ON << "QLever IndexBuilder, compiled on "
+              << qlever::version::DatetimeOfCompilation << " using git hash "
+              << qlever::version::GitShortHash << EMPH_OFF << std::endl;
 
   try {
     config.inputFiles_ = getFileSpecifications(filetype, inputFile,
@@ -278,9 +278,9 @@ int main(int argc, char** argv) {
     qlever::Qlever::buildIndex(config);
 
   } catch (std::exception& e) {
-    LOG(ERROR) << "Creating the index for QLever failed with the following "
-                  "exception: "
-               << e.what() << std::endl;
+    AD_LOG_ERROR << "Creating the index for QLever failed with the following "
+                    "exception: "
+                 << e.what() << std::endl;
     return 2;
   }
   return 0;

--- a/src/index/PatternCreator.cpp
+++ b/src/index/PatternCreator.cpp
@@ -131,7 +131,8 @@ void PatternCreator::readPatternsFromFile(
     uint64_t& numDistinctSubjectPredicatePairs,
     CompactVectorOfStrings<Id>& patterns) {
   // Read the pattern info from the patterns file.
-  LOG(INFO) << "Reading patterns from file " << filename << " ..." << std::endl;
+  AD_LOG_INFO << "Reading patterns from file " << filename << " ..."
+              << std::endl;
 
   // Read the subjectToPatternMap.
   ad_utility::serialization::FileReadSerializer patternReader(filename);
@@ -150,18 +151,18 @@ void PatternCreator::readPatternsFromFile(
 // ____________________________________________________________________________
 void PatternCreator::printStatistics(
     PatternStatistics patternStatistics) const {
-  LOG(INFO) << "Number of distinct patterns: " << patternToIdAndCount_.size()
-            << std::endl;
-  LOG(INFO) << "Number of subjects with pattern: " << numDistinctSubjects_
-            << " [all]" << std::endl;
-  LOG(INFO) << "Total number of distinct subject-predicate pairs: "
-            << numDistinctSubjectPredicatePairs_ << std::endl;
-  LOG(INFO) << "Average number of predicates per subject: " << std::fixed
-            << std::setprecision(1)
-            << patternStatistics.avgNumDistinctPredicatesPerSubject_
-            << std::endl;
-  LOG(INFO) << "Average number of subjects per predicate: " << std::fixed
-            << std::setprecision(0)
-            << patternStatistics.avgNumDistinctSubjectsPerPredicate_
-            << std::endl;
+  AD_LOG_INFO << "Number of distinct patterns: " << patternToIdAndCount_.size()
+              << std::endl;
+  AD_LOG_INFO << "Number of subjects with pattern: " << numDistinctSubjects_
+              << " [all]" << std::endl;
+  AD_LOG_INFO << "Total number of distinct subject-predicate pairs: "
+              << numDistinctSubjectPredicatePairs_ << std::endl;
+  AD_LOG_INFO << "Average number of predicates per subject: " << std::fixed
+              << std::setprecision(1)
+              << patternStatistics.avgNumDistinctPredicatesPerSubject_
+              << std::endl;
+  AD_LOG_INFO << "Average number of subjects per predicate: " << std::fixed
+              << std::setprecision(0)
+              << patternStatistics.avgNumDistinctSubjectsPerPredicate_
+              << std::endl;
 }

--- a/src/index/PatternCreator.h
+++ b/src/index/PatternCreator.h
@@ -143,7 +143,7 @@ class PatternCreator {
                 basename + ".second-sorter.dat", memoryLimit / 2,
                 ad_utility::makeUnlimitedAllocator<Id>())},
         idOfHasPattern_{idOfHasPattern} {
-    LOG(DEBUG) << "Computing predicate patterns ..." << std::endl;
+    AD_LOG_DEBUG << "Computing predicate patterns ..." << std::endl;
   }
 
   // This function has to be called for all the triples in the SPO permutation

--- a/src/index/Permutation.cpp
+++ b/src/index/Permutation.cpp
@@ -59,8 +59,8 @@ void Permutation::loadFromDisk(const std::string& onDiskBase,
   }
   meta_.readFromFile(&file);
   reader_.emplace(allocator_, std::move(file));
-  LOG(INFO) << "Registered " << readableName_
-            << " permutation: " << meta_.statistics() << std::endl;
+  AD_LOG_INFO << "Registered " << readableName_
+              << " permutation: " << meta_.statistics() << std::endl;
   isLoaded_ = true;
 }
 

--- a/src/index/TextIndexReadWrite.h
+++ b/src/index/TextIndexReadWrite.h
@@ -38,15 +38,15 @@ void readFreqComprListHelper(size_t nofElements, off_t from, size_t nofBytes,
     return;
   }
   AD_CONTRACT_CHECK(nofBytes > 0);
-  LOG(DEBUG) << "Reading frequency-encoded list from disk...\n";
-  LOG(TRACE) << "NofElements: " << nofElements << ", from: " << from
-             << ", nofBytes: " << nofBytes << '\n';
+  AD_LOG_DEBUG << "Reading frequency-encoded list from disk...\n";
+  AD_LOG_TRACE << "NofElements: " << nofElements << ", from: " << from
+               << ", nofBytes: " << nofBytes << '\n';
 
   // Read codebook size and advance pointer (current)
   size_t nofCodebookBytes;
   off_t current = from;
   size_t ret = textIndexFile.read(&nofCodebookBytes, sizeof(size_t), current);
-  LOG(TRACE) << "Nof Codebook Bytes: " << nofCodebookBytes << '\n';
+  AD_LOG_TRACE << "Nof Codebook Bytes: " << nofCodebookBytes << '\n';
   AD_CONTRACT_CHECK(sizeof(size_t) == ret);
   current += ret;
 
@@ -69,11 +69,11 @@ void readFreqComprListHelper(size_t nofElements, off_t from, size_t nofBytes,
   // simple8b decode the list which is then directly passed to
   // frequencyEncodedVector. The resizing with overhead is necessary for
   // simple8b
-  LOG(DEBUG) << "Decoding Simple8b code...\n";
+  AD_LOG_DEBUG << "Decoding Simple8b code...\n";
   frequencyEncodedVector.resize(nofElements + 250);
   ad_utility::Simple8bCode::decode(simple8bEncoded.data(), nofElements,
                                    frequencyEncodedVector.data());
-  LOG(DEBUG) << "Reverting frequency encoded items to actual IDs...\n";
+  AD_LOG_DEBUG << "Reverting frequency encoded items to actual IDs...\n";
   frequencyEncodedVector.resize(nofElements);
 }
 
@@ -86,9 +86,9 @@ template <typename From>
 void readGapComprListHelper(size_t nofElements, off_t from, size_t nofBytes,
                             const ad_utility::File& textIndexFile,
                             std::vector<From>& gapEncodedVector) {
-  LOG(DEBUG) << "Reading gap-encoded list from disk...\n";
-  LOG(TRACE) << "NofElements: " << nofElements << ", from: " << from
-             << ", nofBytes: " << nofBytes << '\n';
+  AD_LOG_DEBUG << "Reading gap-encoded list from disk...\n";
+  AD_LOG_TRACE << "NofElements: " << nofElements << ", from: " << from
+               << ", nofBytes: " << nofBytes << '\n';
   if (nofBytes == 0) {
     // This might happen for empty blocks.
     gapEncodedVector.clear();
@@ -103,11 +103,11 @@ void readGapComprListHelper(size_t nofElements, off_t from, size_t nofBytes,
 
   // simple8b decode the list which is then directly passed to
   // gapEncodedVector. The resizing with overhead is necessary for simple8b
-  LOG(DEBUG) << "Decoding Simple8b code...\n";
+  AD_LOG_DEBUG << "Decoding Simple8b code...\n";
   gapEncodedVector.resize(nofElements + 250);
   ad_utility::Simple8bCode::decode(simple8bEncoded.data(), nofElements,
                                    gapEncodedVector.data());
-  LOG(DEBUG) << "Reverting gaps to actual IDs...\n";
+  AD_LOG_DEBUG << "Reverting gaps to actual IDs...\n";
   gapEncodedVector.resize(nofElements);
 }
 
@@ -231,8 +231,8 @@ std::vector<To> readFreqComprList(size_t nofElements, off_t from,
   ql::ranges::for_each(frequencyEncodedVector, [&](const auto& encoded) {
     result.push_back(transformer(codebook.at(encoded)));
   });
-  LOG(DEBUG) << "Done reading frequency-encoded list. Size: " << result.size()
-             << "\n";
+  AD_LOG_DEBUG << "Done reading frequency-encoded list. Size: " << result.size()
+               << "\n";
   return result;
 }
 
@@ -255,7 +255,7 @@ void readFreqComprList(OutputIterator iterator, size_t nofElements, off_t from,
     *iterator = transformer(codebook.at(encoded));
     ++iterator;
   });
-  LOG(DEBUG) << "Done reading frequency-encoded list.";
+  AD_LOG_DEBUG << "Done reading frequency-encoded list.";
 }
 
 /**
@@ -289,8 +289,8 @@ std::vector<To> readGapComprList(size_t nofElements, off_t from,
     previous += gap;
     result.push_back(transformer(previous));
   }
-  LOG(DEBUG) << "Done reading gap-encoded list. Size: " << result.size()
-             << "\n";
+  AD_LOG_DEBUG << "Done reading gap-encoded list. Size: " << result.size()
+               << "\n";
   return result;
 }
 
@@ -316,7 +316,7 @@ void readGapComprList(OutputIterator iterator, size_t nofElements, off_t from,
     *iterator = transformer(previous);
     ++iterator;
   }
-  LOG(DEBUG) << "Done reading gap-encoded list.";
+  AD_LOG_DEBUG << "Done reading gap-encoded list.";
 }
 
 }  // namespace textIndexReadWrite

--- a/src/index/TextScoring.cpp
+++ b/src/index/TextScoring.cpp
@@ -10,18 +10,19 @@
 static void logWordNotFound(const std::string& word,
                             size_t& wordNotFoundErrorMsgCount) {
   if (wordNotFoundErrorMsgCount < 20) {
-    LOG(WARN) << "The following word was found in the docsfile but not in "
-                 "the wordsfile: "
-              << word << '\n';
+    AD_LOG_WARN << "The following word was found in the docsfile but not in "
+                   "the wordsfile: "
+                << word << '\n';
     ++wordNotFoundErrorMsgCount;
     if (wordNotFoundErrorMsgCount == 1) {
-      LOG(WARN) << "Note that this might be intentional if for example stop "
-                   "words from the documents where omitted in the wordsfile to "
-                   "make the text index more efficient and effective. \n";
+      AD_LOG_WARN
+          << "Note that this might be intentional if for example stop "
+             "words from the documents where omitted in the wordsfile to "
+             "make the text index more efficient and effective. \n";
     } else if (wordNotFoundErrorMsgCount == 20) {
-      LOG(WARN) << "There are more words not in the KB during score "
-                   "calculation..."
-                << " suppressing further warnings...\n";
+      AD_LOG_WARN << "There are more words not in the KB during score "
+                     "calculation..."
+                  << " suppressing further warnings...\n";
     }
   } else {
     wordNotFoundErrorMsgCount++;
@@ -58,7 +59,7 @@ void ScoreData::calculateScoreData(const std::string& docsFileName,
     return;
   }
   if (wordsNotFoundFromDocuments > 0) {
-    LOG(WARN)
+    AD_LOG_WARN
         << "Number of words not found in vocabulary during score calculation: "
         << wordsNotFoundFromDocuments << std::endl;
   }
@@ -114,8 +115,8 @@ float ScoreData::getScore(WordIndex wordIndex, TextRecordIndex contextId) {
   // Retrieve inner map
   auto it = invertedIndex_.find(wordIndex);
   if (it == invertedIndex_.end()) {
-    LOG(DEBUG) << "Didn't find word in Inverted Scoring Index. WordId: "
-               << wordIndex << std::endl;
+    AD_LOG_DEBUG << "Didn't find word in Inverted Scoring Index. WordId: "
+                 << wordIndex << std::endl;
     return 0;
   }
   calculateAVDL();
@@ -147,8 +148,9 @@ float ScoreData::getScore(WordIndex wordIndex, TextRecordIndex contextId) {
   }
   auto ret1 = innerMap.find(docId);
   if (ret1 == innerMap.end()) {
-    LOG(DEBUG) << "The calculated docId doesn't exist in the inner Map. docId: "
-               << docId << std::endl;
+    AD_LOG_DEBUG
+        << "The calculated docId doesn't exist in the inner Map. docId: "
+        << docId << std::endl;
     return 0;
   }
   TermFrequency tf = ret1->second;

--- a/src/index/Vocabulary.cpp
+++ b/src/index/Vocabulary.cpp
@@ -58,7 +58,7 @@ void Vocabulary<S, C, I>::readFromFile(const string& fileName) {
 template <class S, class C, class I>
 void Vocabulary<S, C, I>::createFromSet(
     const ad_utility::HashSet<std::string>& set, const std::string& filename) {
-  LOG(DEBUG) << "BEGIN Vocabulary::createFromSet" << std::endl;
+  AD_LOG_DEBUG << "BEGIN Vocabulary::createFromSet" << std::endl;
   vocabulary_.close();
   std::vector<std::string> words(set.begin(), set.end());
   auto totalComparison = [this](const auto& a, const auto& b) {
@@ -76,7 +76,7 @@ void Vocabulary<S, C, I>::createFromSet(
   ql::ranges::for_each(words, writeWords);
   writerPtr->finish();
   vocabulary_.open(filename);
-  LOG(DEBUG) << "END Vocabulary::createFromSet" << std::endl;
+  AD_LOG_DEBUG << "END Vocabulary::createFromSet" << std::endl;
 }
 
 // _____________________________________________________________________________

--- a/src/index/VocabularyMergerImpl.h
+++ b/src/index/VocabularyMergerImpl.h
@@ -120,7 +120,7 @@ auto VocabularyMerger::mergeVocabulary(const std::string& basename,
       sortedBuffer.reserve(bufferSize_);
       // wait for the last batch
 
-      LOG(TIMING) << "A new batch of words is ready" << std::endl;
+      AD_LOG_TIMING << "A new batch of words is ready" << std::endl;
       // First wait for the last batch to finish, that way there will be no
       // race conditions.
       if (writeFuture.valid()) {
@@ -140,7 +140,7 @@ auto VocabularyMerger::mergeVocabulary(const std::string& basename,
   if (!sortedBuffer.empty()) {
     writeQueueWordsToIdMap(sortedBuffer, wordCallback, lessThan, progressBar);
   }
-  LOG(INFO) << progressBar.getFinalProgressString() << std::flush;
+  AD_LOG_INFO << progressBar.getFinalProgressString() << std::flush;
 
   auto metaData = std::move(metaData_);
   // completely reset all the inner state
@@ -156,7 +156,7 @@ CPP_template_def(typename C, typename L)(
     writeQueueWordsToIdMap(const std::vector<QueueWord>& buffer,
                            C& wordCallback, const L& lessThan,
                            ad_utility::ProgressBar& progressBar) {
-  LOG(TIMING) << "Start writing a batch of merged words\n";
+  AD_LOG_TIMING << "Start writing a batch of merged words\n";
 
   // Smaller grained buffer for the actual inner write.
   auto bufSize = bufferSize_ / 5;
@@ -170,9 +170,9 @@ CPP_template_def(typename C, typename L)(
         top.iriOrLiteral() != lastTripleComponent_.value().iriOrLiteral()) {
       if (lastTripleComponent_.has_value() &&
           !lessThan(lastTripleComponent_.value(), top.entry_)) {
-        LOG(WARN) << "Total vocabulary order violated for "
-                  << lastTripleComponent_->iriOrLiteral() << " and "
-                  << top.iriOrLiteral() << std::endl;
+        AD_LOG_WARN << "Total vocabulary order violated for "
+                    << lastTripleComponent_->iriOrLiteral() << " and "
+                    << top.iriOrLiteral() << std::endl;
       }
       lastTripleComponent_ = TripleComponentWithIndex{
           top.iriOrLiteral(), top.isExternal(), metaData_.numWordsTotal()};
@@ -191,7 +191,7 @@ CPP_template_def(typename C, typename L)(
         metaData_.addWord(top.iriOrLiteral(), nextWord.index_);
       }
       if (progressBar.update()) {
-        LOG(INFO) << progressBar.getProgressString() << std::flush;
+        AD_LOG_INFO << progressBar.getProgressString() << std::flush;
       }
     } else {
       // If a word appears with different values for `isExternal`, then we
@@ -277,8 +277,8 @@ inline void writeMappedIdsToExtVec(
       }
       auto iterator = map.find(curTriple[k].getVocabIndex().get());
       if (iterator == map.end()) {
-        LOG(ERROR) << "not found in partial local vocabulary: " << curTriple[k]
-                   << std::endl;
+        AD_LOG_ERROR << "not found in partial local vocabulary: "
+                     << curTriple[k] << std::endl;
         AD_FAIL();
       }
       mappedTriple[k] =
@@ -291,7 +291,7 @@ inline void writeMappedIdsToExtVec(
 // _________________________________________________________________________________________________________
 inline void writePartialVocabularyToFile(const ItemVec& els,
                                          const std::string& fileName) {
-  LOG(DEBUG) << "Writing partial vocabulary to: " << fileName << "\n";
+  AD_LOG_DEBUG << "Writing partial vocabulary to: " << fileName << "\n";
   ad_utility::serialization::ByteBufferWriteSerializer byteBuffer;
   byteBuffer.reserve(1'000'000'000);
   ad_utility::serialization::FileWriteSerializer serializer{fileName};
@@ -312,7 +312,7 @@ inline void writePartialVocabularyToFile(const ItemVec& els,
                               byteBuffer.data().size());
     serializer.close();
   }
-  LOG(DEBUG) << "Done writing partial vocabulary\n";
+  AD_LOG_DEBUG << "Done writing partial vocabulary\n";
 }
 
 // __________________________________________________________________________________________________

--- a/src/index/vocabulary/CompressedVocabulary.h
+++ b/src/index/vocabulary/CompressedVocabulary.h
@@ -188,15 +188,16 @@ CPP_template(typename UnderlyingVocabulary,
           std::max(uncompressedSize_.getBytes(), size_t(1));
       std::string nameString =
           readableName().empty() ? std::string{"vocabulary"} : readableName();
-      LOG(INFO) << "Finished writing compressed " << nameString
-                << ", size = " << compressedSize_
-                << " [uncompressed = " << uncompressedSize_
-                << ", ratio = " << compressionRatio << "%]" << std::endl;
+      AD_LOG_INFO << "Finished writing compressed " << nameString
+                  << ", size = " << compressedSize_
+                  << " [uncompressed = " << uncompressedSize_
+                  << ", ratio = " << compressionRatio << "%]" << std::endl;
       if (numBlocksLargerWhenCompressed_ > 0) {
-        LOG(WARN) << "Number of blocks made larger by the compression instead "
-                     "of smaller: "
-                  << numBlocksLargerWhenCompressed_ << " of " << numBlocks_
-                  << std::endl;
+        AD_LOG_WARN
+            << "Number of blocks made larger by the compression instead "
+               "of smaller: "
+            << numBlocksLargerWhenCompressed_ << " of " << numBlocks_
+            << std::endl;
       }
     }
 

--- a/src/index/vocabulary/GeoVocabulary.cpp
+++ b/src/index/vocabulary/GeoVocabulary.cpp
@@ -86,9 +86,9 @@ void GeoVocabulary<V>::WordWriter::finishImpl() {
   geoInfoFile_.close();
 
   if (numInvalidGeometries_ > 0) {
-    LOG(WARN) << "Geometry preprocessing skipped " << numInvalidGeometries_
-              << " invalid WKT literal"
-              << (numInvalidGeometries_ == 1 ? "" : "s") << std::endl;
+    AD_LOG_WARN << "Geometry preprocessing skipped " << numInvalidGeometries_
+                << " invalid WKT literal"
+                << (numInvalidGeometries_ == 1 ? "" : "s") << std::endl;
   }
 }
 

--- a/src/index/vocabulary/SplitVocabularyImpl.h
+++ b/src/index/vocabulary/SplitVocabularyImpl.h
@@ -17,8 +17,8 @@ template <typename SF, typename SFN, typename... S>
 requires SplitFunctionT<SF> && SplitFilenameFunctionT<SFN, sizeof...(S)>
 void SplitVocabulary<SF, SFN, S...>::readFromFile(const std::string& filename) {
   auto readSingle = [](auto& vocab, const std::string& filename) {
-    LOG(INFO) << "Reading vocabulary from file " << filename << " ..."
-              << std::endl;
+    AD_LOG_INFO << "Reading vocabulary from file " << filename << " ..."
+                << std::endl;
     vocab.close();
     vocab.open(filename);
 
@@ -26,12 +26,12 @@ void SplitVocabulary<SF, SFN, S...>::readFromFile(const std::string& filename) {
                                  detail::UnderlyingVocabRdfsVocabulary>) {
       const auto& internalExternalVocab =
           vocab.getUnderlyingVocabulary().getUnderlyingVocabulary();
-      LOG(INFO) << "Done, number of words: "
-                << internalExternalVocab.internalVocab().size() << std::endl;
-      LOG(INFO) << "Number of words in external vocabulary: "
-                << internalExternalVocab.externalVocab().size() << std::endl;
+      AD_LOG_INFO << "Done, number of words: "
+                  << internalExternalVocab.internalVocab().size() << std::endl;
+      AD_LOG_INFO << "Number of words in external vocabulary: "
+                  << internalExternalVocab.externalVocab().size() << std::endl;
     } else {
-      LOG(INFO) << "Done, number of words: " << vocab.size() << std::endl;
+      AD_LOG_INFO << "Done, number of words: " << vocab.size() << std::endl;
     }
   };
 

--- a/src/parser/ParallelParseBuffer.h
+++ b/src/parser/ParallelParseBuffer.h
@@ -155,7 +155,7 @@ class ParallelParseBuffer {
   // that were parsed before the parser was done, so we still have to consider
   // these.
   std::pair<bool, std::vector<std::array<std::string, 3>>> parseBatch() {
-    LOG(TRACE) << "Parsing next batch in parallel" << std::endl;
+    AD_LOG_TRACE << "Parsing next batch in parallel" << std::endl;
     std::vector<std::array<std::string, 3>> buf;
     // for small knowledge bases on small systems that fit in one
     // batch (e.g. during tests) the reserve may fail which is not bad in this
@@ -172,7 +172,7 @@ class ParallelParseBuffer {
         return {false, std::move(buf)};
       }
       if (buf.size() % 10000000 == 0) {
-        LOG(INFO) << "Parsed " << buf.size() << " triples." << std::endl;
+        AD_LOG_INFO << "Parsed " << buf.size() << " triples." << std::endl;
       }
     }
     return {true, std::move(buf)};

--- a/src/parser/ParsedQuery.cpp
+++ b/src/parser/ParsedQuery.cpp
@@ -319,10 +319,10 @@ bool ParsedQuery::GraphPattern::addLanguageFilter(const Variable& variable,
     if (!variableFoundInTriple) {
       return false;
     }
-    LOG(DEBUG) << "language filter variable " + variable.name() +
-                      " did not appear as object in any suitable "
-                      "triple. "
-                      "Using literal-to-language predicate instead.\n";
+    AD_LOG_DEBUG << "language filter variable " + variable.name() +
+                        " did not appear as object in any suitable "
+                        "triple. "
+                        "Using literal-to-language predicate instead.\n";
 
     // If necessary create an empty `BasicGraphPattern` at the end to which we
     // can append a triple.

--- a/src/parser/RdfParser.cpp
+++ b/src/parser/RdfParser.cpp
@@ -524,12 +524,13 @@ TripleComponent TurtleParser<T>::literalAndDatatypeToTripleComponentImpl(
                                       std::nullopt) {
     std::string_view errorMsg = error.has_value() ? error.value().what() : "";
     std::string_view sep = error.has_value() ? ": " : "";
-    LOG(DEBUG) << normalizedLiteralContent
-               << " could not be parsed as an object of type " << type << sep
-               << errorMsg
-               << ". It is treated as a plain string literal without datatype "
-                  "instead."
-               << std::endl;
+    AD_LOG_DEBUG
+        << normalizedLiteralContent
+        << " could not be parsed as an object of type " << type << sep
+        << errorMsg
+        << ". It is treated as a plain string literal without datatype "
+           "instead."
+        << std::endl;
     lastParseResult_ = std::move(literal);
   };
 
@@ -897,8 +898,8 @@ bool TurtleParser<T>::iriref() {
     return true;
   } else {
     if (!parseTerminal<TurtleTokenId::Iriref>()) {
-      LOG(WARN) << "IRI ref not standard-compliant: "
-                << view.substr(0, endPos + 1) << std::endl;
+      AD_LOG_WARN << "IRI ref not standard-compliant: "
+                  << view.substr(0, endPos + 1) << std::endl;
       if (!parseTerminal<TurtleTokenId::IrirefRelaxed>()) {
         return false;
       }
@@ -954,8 +955,8 @@ bool RdfStreamParser<T>::resetStateAndRead(
   byteVec_ = std::move(buf);
   tok_.reset(byteVec_.data(), byteVec_.size());
 
-  LOG(TRACE) << "Successfully decompressed next batch of " << nextBytes.size()
-             << " << bytes to parser\n";
+  AD_LOG_TRACE << "Successfully decompressed next batch of " << nextBytes.size()
+               << " << bytes to parser\n";
 
   // repair the backup state, its pointers might have changed due to
   // reallocation
@@ -987,7 +988,7 @@ void RdfStreamParser<T>::initialize(const std::string& filename,
     byteVec_ = std::move(res.value());
     tok_.reset(byteVec_.data(), byteVec_.size());
   } else {
-    LOG(WARN)
+    AD_LOG_WARN
         << "The input stream for the turtle parser seems to contain no data!\n";
   }
 }
@@ -1023,17 +1024,17 @@ bool RdfStreamParser<T>::getLineImpl(TurtleTriple* triple) {
           // we have successfully extended our buffer
           if (byteVec_.size() > BZIP2_MAX_TOTAL_BUFFER_SIZE) {
             auto d = tok_.view();
-            LOG(ERROR) << "Could not parse " << PARSER_MIN_TRIPLES_AT_ONCE
-                       << " Within " << (BZIP2_MAX_TOTAL_BUFFER_SIZE >> 10)
-                       << "MB of Turtle input\n";
-            LOG(ERROR) << "If you really have Turtle input with such a "
-                          "long structure please recompile with adjusted "
-                          "constants in ConstantsIndexCreation.h or "
-                          "decompress your file and "
-                          "use --file-format mmap\n";
+            AD_LOG_ERROR << "Could not parse " << PARSER_MIN_TRIPLES_AT_ONCE
+                         << " Within " << (BZIP2_MAX_TOTAL_BUFFER_SIZE >> 10)
+                         << "MB of Turtle input\n";
+            AD_LOG_ERROR << "If you really have Turtle input with such a "
+                            "long structure please recompile with adjusted "
+                            "constants in ConstantsIndexCreation.h or "
+                            "decompress your file and "
+                            "use --file-format mmap\n";
             auto s = std::min(size_t(1000), size_t(d.size()));
-            LOG(INFO) << "Logging first 1000 unparsed characters\n";
-            LOG(INFO) << std::string_view(d.data(), s) << std::endl;
+            AD_LOG_INFO << "Logging first 1000 unparsed characters\n";
+            AD_LOG_INFO << std::string_view(d.data(), s) << std::endl;
             if (ex.has_value()) {
               throw ex.value();
 
@@ -1058,12 +1059,13 @@ bool RdfStreamParser<T>::getLineImpl(TurtleTriple* triple) {
             tok_.skipWhitespaceAndComments();
             auto d = tok_.view();
             if (!d.empty()) {
-              LOG(INFO) << "Parsing of line has Failed, but parseInput is not "
-                           "yet exhausted. Remaining bytes: "
-                        << d.size() << '\n';
+              AD_LOG_INFO
+                  << "Parsing of line has Failed, but parseInput is not "
+                     "yet exhausted. Remaining bytes: "
+                  << d.size() << '\n';
               auto s = std::min(size_t(1000), size_t(d.size()));
-              LOG(INFO) << "Logging first 1000 unparsed characters\n";
-              LOG(INFO) << std::string_view(d.data(), s) << std::endl;
+              AD_LOG_INFO << "Logging first 1000 unparsed characters\n";
+              AD_LOG_INFO << std::string_view(d.data(), s) << std::endl;
             }
             isParserExhausted_ = true;
             break;

--- a/src/parser/Tokenizer.h
+++ b/src/parser/Tokenizer.h
@@ -242,8 +242,8 @@ struct SkipWhitespaceAndCommentsMixin {
       auto pos = v.find('\n');
       if (pos == std::string::npos) {
         // TODO<joka921>: This should rather yield an error.
-        LOG(INFO) << "Warning, unfinished comment found while parsing"
-                  << std::endl;
+        AD_LOG_INFO << "Warning, unfinished comment found while parsing"
+                    << std::endl;
       } else {
         self()._data.remove_prefix(pos + 1);
       }

--- a/src/rdfTypes/GeometryInfo.cpp
+++ b/src/rdfTypes/GeometryInfo.cpp
@@ -50,10 +50,10 @@ std::optional<GeometryInfo> GeometryInfo::fromWktLiteral(std::string_view wkt) {
   auto boundingBox = boundingBoxAsGeoPoints(parsed.value());
   auto centroid = centroidAsGeoPoint(parsed.value());
   if (!boundingBox.has_value() || !centroid.has_value()) {
-    LOG(DEBUG) << "The WKT string `" << wkt
-               << "` would lead to an invalid centroid or bounding box. It "
-                  "will thus be treated as an invalid WKT literal."
-               << std::endl;
+    AD_LOG_DEBUG << "The WKT string `" << wkt
+                 << "` would lead to an invalid centroid or bounding box. It "
+                    "will thus be treated as an invalid WKT literal."
+                 << std::endl;
     return std::nullopt;
   }
 

--- a/src/rdfTypes/RdfEscaping.cpp
+++ b/src/rdfTypes/RdfEscaping.cpp
@@ -262,9 +262,10 @@ std::string unescapePrefixedIri(std::string_view literal) {
   while (pos != literal.npos) {
     res.append(literal.begin(), literal.begin() + pos);
     if (pos + 1 >= literal.size() || !m.contains(literal[pos + 1])) {
-      LOG(ERROR) << "Error in function unescapePrefixedIri, could not unescape "
-                    "prefixed iri "
-                 << origLiteral << '\n';
+      AD_LOG_ERROR
+          << "Error in function unescapePrefixedIri, could not unescape "
+             "prefixed iri "
+          << origLiteral << '\n';
     }
     AD_CONTRACT_CHECK(pos + 1 < literal.size());
     AD_CONTRACT_CHECK(m.contains(literal[pos + 1]));

--- a/src/util/AsyncStream.h
+++ b/src/util/AsyncStream.h
@@ -60,8 +60,8 @@ struct AsyncStreamGenerator
     if (!value) {
       ifTiming([this] {
         t_->stop();
-        LOG(TRACE) << "Waiting time for async stream was "
-                   << t_->msecs().count() << "ms" << std::endl;
+        AD_LOG_TRACE << "Waiting time for async stream was "
+                     << t_->msecs().count() << "ms" << std::endl;
       });
     }
     return value;

--- a/src/util/CancellationHandle.h
+++ b/src/util/CancellationHandle.h
@@ -178,18 +178,18 @@ class CancellationHandle {
               state, CancellationState::NOT_CANCELLED,
               std::memory_order_relaxed)) {
         if (windowMissed) {
-          LOG(WARN) << "No timeout check has been performed for at least "
-                    << ParseableDuration{duration_cast<DurationType>(
-                                             steady_clock::now() -
-                                             startTimeoutWindow_.load()) +
-                                         DESIRED_CANCELLATION_CHECK_INTERVAL}
-                    << ", should be at most "
-                    << ParseableDuration{DESIRED_CANCELLATION_CHECK_INTERVAL}
-                    << ". Checked at " << trimFileName(location.file_name())
-                    << ":" << location.line()
-                    << detail::printAdditionalDetails(
-                           std::invoke(stageInvocable))
-                    << std::endl;
+          AD_LOG_WARN << "No timeout check has been performed for at least "
+                      << ParseableDuration{duration_cast<DurationType>(
+                                               steady_clock::now() -
+                                               startTimeoutWindow_.load()) +
+                                           DESIRED_CANCELLATION_CHECK_INTERVAL}
+                      << ", should be at most "
+                      << ParseableDuration{DESIRED_CANCELLATION_CHECK_INTERVAL}
+                      << ". Checked at " << trimFileName(location.file_name())
+                      << ":" << location.line()
+                      << detail::printAdditionalDetails(
+                             std::invoke(stageInvocable))
+                      << std::endl;
         }
         break;
       }

--- a/src/util/ConcurrentCache.h
+++ b/src/util/ConcurrentCache.h
@@ -415,7 +415,7 @@ class ConcurrentCache {
       }
     }  // release the lock, it is not required while we are computing
     if (mustCompute) {
-      LOG(TRACE) << "Not in the cache, need to compute result" << std::endl;
+      AD_LOG_TRACE << "Not in the cache, need to compute result" << std::endl;
       try {
         // The actual computation
         shared_ptr<Value> result = make_shared<Value>(computeFunction());

--- a/src/util/DateYearDuration.cpp
+++ b/src/util/DateYearDuration.cpp
@@ -64,9 +64,9 @@ static Date::TimeZone parseTimeZone(const T& match) {
     tz *= -1;
   }
   if (match.template get<"tzMinutes">() != "00") {
-    LOG(DEBUG) << "Qlever supports only full hours as timezones, timezone"
-               << match.template get<0>() << "will be rounded down to " << tz
-               << ":00" << std::endl;
+    AD_LOG_DEBUG << "Qlever supports only full hours as timezones, timezone"
+                 << match.template get<0>() << "will be rounded down to " << tz
+                 << ":00" << std::endl;
   }
   return tz;
 }
@@ -84,10 +84,10 @@ static DateYearOrDuration makeDateOrLargeYear(std::string_view fullInput,
   if (year < Date::minYear || year > Date::maxYear) {
     if (year < DateYearOrDuration::minYear ||
         year > DateYearOrDuration::maxYear) {
-      LOG(DEBUG) << "QLever cannot encode dates that are less than "
-                 << DateYearOrDuration::minYear << " or larger than "
-                 << DateYearOrDuration::maxYear << ". Input " << fullInput
-                 << " will be clamped to this range";
+      AD_LOG_DEBUG << "QLever cannot encode dates that are less than "
+                   << DateYearOrDuration::minYear << " or larger than "
+                   << DateYearOrDuration::maxYear << ". Input " << fullInput
+                   << " will be clamped to this range";
       year = std::clamp(year, DateYearOrDuration::minYear,
                         DateYearOrDuration::maxYear);
     }
@@ -102,11 +102,12 @@ static DateYearOrDuration makeDateOrLargeYear(std::string_view fullInput,
       }
       // Warn only for one component per input.
       alreadyWarned = true;
-      LOG(DEBUG) << "When the year of a datetime object is smaller than -9999 "
-                    "or larger than 9999 then the "
-                 << component << " will always be set to " << defaultValue
-                 << " in QLever's implementation of dates. Full input was "
-                 << fullInput << std::endl;
+      AD_LOG_DEBUG
+          << "When the year of a datetime object is smaller than -9999 "
+             "or larger than 9999 then the "
+          << component << " will always be set to " << defaultValue
+          << " in QLever's implementation of dates. Full input was "
+          << fullInput << std::endl;
     };
 
     if (month == 0) {

--- a/src/util/ExceptionHandling.h
+++ b/src/util/ExceptionHandling.h
@@ -38,11 +38,11 @@ CPP_template(typename F)(
   try {
     std::invoke(AD_FWD(f));
   } catch (const std::exception& e) {
-    LOG(INFO) << "Ignored an exception. The exception message was:\""
-              << e.what() << "\". " << additionalNote << std::endl;
+    AD_LOG_INFO << "Ignored an exception. The exception message was:\""
+                << e.what() << "\". " << additionalNote << std::endl;
   } catch (...) {
-    LOG(INFO) << "Ignored an exception of an unknown type. " << additionalNote
-              << std::endl;
+    AD_LOG_INFO << "Ignored an exception of an unknown type. " << additionalNote
+                << std::endl;
   }
 }
 
@@ -78,7 +78,7 @@ CPP_template(typename F,
 
   auto logAndTerminate = [&terminateAction](std::string_view msg) {
     try {
-      LOG(ERROR) << msg << std::endl;
+      AD_LOG_ERROR << msg << std::endl;
       std::cerr << msg << std::endl;
     } catch (...) {
       std::cerr << msg << std::endl;
@@ -124,12 +124,12 @@ class ThrowInDestructorIfSafe {
   operator()(FuncType f, const Args&... additionalMessages) const {
     auto logIgnoredException = [&additionalMessages...](std::string_view what) {
       std::string_view sep = sizeof...(additionalMessages) == 0 ? "" : " ";
-      LOG(WARN) << absl::StrCat(
-                       "An exception was ignored because it would have led to "
-                       "program termination",
-                       sep, additionalMessages...,
-                       ". Exception message: ", what)
-                << std::endl;
+      AD_LOG_WARN
+          << absl::StrCat(
+                 "An exception was ignored because it would have led to "
+                 "program termination",
+                 sep, additionalMessages..., ". Exception message: ", what)
+          << std::endl;
     };
     // If the number of uncaught exceptions is the same as when then constructor
     // was called, then it is safe to throw a possible exception. For details

--- a/src/util/File.h
+++ b/src/util/File.h
@@ -202,8 +202,8 @@ inline void deleteFile(const std::filesystem::path& path,
                        bool warnOnFailure = true) {
   if (!std::filesystem::remove(path)) {
     if (warnOnFailure) {
-      LOG(WARN) << "Deletion of file '" << path << "' was not successful"
-                << std::endl;
+      AD_LOG_WARN << "Deletion of file '" << path << "' was not successful"
+                  << std::endl;
     }
   }
 }

--- a/src/util/FsstCompressor.h
+++ b/src/util/FsstCompressor.h
@@ -204,9 +204,9 @@ class FsstEncoder {
         if (numCompressed == strings.size()) {
           break;
         }
-        LOG(DEBUG) << "FSST compression of a block of strings made the input "
-                      "larger instead of smaller"
-                   << std::endl;
+        AD_LOG_DEBUG << "FSST compression of a block of strings made the input "
+                        "larger instead of smaller"
+                     << std::endl;
         output.resize(2 * output.size());
       }
       // Convert the result pointers to `string_views` for easier handling.

--- a/src/util/Log.h
+++ b/src/util/Log.h
@@ -24,24 +24,6 @@
 #define LOGLEVEL INFO
 #endif
 
-// Abseil also defines its own LOG macro, so we need to undefine it here.
-//
-// NOTE: In case you run into trouble with this conflict, in particular, if you
-// use the `LOG(INFO)` macro and you get compilation errors that mention
-// `abseil`, use the (otherwise identical) `AD_LOG_INFO` macro below.
-//
-// TODO<joka921>: Eventually replace the `LOG` macro by `AD_LOG` everywhere.
-
-#ifdef LOG
-#undef LOG
-#endif
-
-#define LOG(x)      \
-  if (x > LOGLEVEL) \
-    ;               \
-  else              \
-    ad_utility::Log::getLog<x>()  // NOLINT
-
 #define AD_LOG(x)   \
   if (x > LOGLEVEL) \
     ;               \
@@ -58,8 +40,7 @@ enum class LogLevel {
   TRACE = 6
 };
 
-// Macros for the different log levels. Always use these instead of the old
-// `LOG(...)` macro to avoid conflicts with `abseil`.
+// Macros for the different log levels.
 #define AD_LOG_FATAL AD_LOG(LogLevel::FATAL)
 #define AD_LOG_ERROR AD_LOG(LogLevel::ERROR)
 #define AD_LOG_WARN AD_LOG(LogLevel::WARN)

--- a/src/util/ProgressBar.h
+++ b/src/util/ProgressBar.h
@@ -36,7 +36,7 @@ namespace ad_utility {
 // the batch size is purely a parameter of this class, the actual computation
 // need not proceed in batches in any way.
 //
-// Typical usage (note the `std::flush` at the end of the `LOG(INFO)` calls in
+// Typical usage (note the `std::flush` at the end of the `AD_LOG_INFO` calls in
 // order to ensure a flush for lines ending in `\r` instead of `\n`):
 //
 // numTriplesProcessed = 0;
@@ -46,10 +46,10 @@ namespace ad_utility {
 //   // Code that does the processing.
 //   ++numTriplesProcessed;
 //   if (progressBar.update()) {
-//     LOG(INFO) << progressBar.getProgressString() << std::flush;
+//     AD_LOG_INFO << progressBar.getProgressString() << std::flush;
 //   }
 // }
-// LOG(INFO) << progressBar.getFinalProgressString() << std::flush;
+// AD_LOG_INFO << progressBar.getFinalProgressString() << std::flush;
 //
 class ProgressBar {
  public:

--- a/src/util/Timer.h
+++ b/src/util/Timer.h
@@ -189,7 +189,7 @@ namespace detail {
 // callable with a `size_t` (the number of milliseconds) and `message`.
 [[maybe_unused]] inline auto defaultLogger = [](chr::milliseconds msecs,
                                                 std::string_view message) {
-  LOG(TIMING) << message << " took " << msecs.count() << "ms" << std::endl;
+  AD_LOG_TIMING << message << " took " << msecs.count() << "ms" << std::endl;
 };
 template <typename Callback = decltype(defaultLogger)>
 struct [[nodiscard(

--- a/src/util/Views.h
+++ b/src/util/Views.h
@@ -137,8 +137,9 @@ InputRangeTypeErased<BlockType> uniqueBlockView(SortedBlockView view) {
 
     std::optional<BlockType> get() override {
       if (iter_ == ql::ranges::end(nonEmptyView_)) {
-        LOG(INFO) << "Number of inputs to `uniqueView`: " << numInputs_ << '\n';
-        LOG(INFO) << "Number of unique elements: " << numUnique_ << std::endl;
+        AD_LOG_INFO << "Number of inputs to `uniqueView`: " << numInputs_
+                    << '\n';
+        AD_LOG_INFO << "Number of unique elements: " << numUnique_ << std::endl;
         return std::nullopt;
       }
 

--- a/src/util/http/HttpParser/AcceptHeaderQleverVisitor.h
+++ b/src/util/http/HttpParser/AcceptHeaderQleverVisitor.h
@@ -90,9 +90,9 @@ class AcceptHeaderQleverVisitor : public AcceptHeaderVisitor {
     // of agents (especially web browsers) automatically add some default
     // parameters.
     if (!ctx->parameter().empty()) {
-      LOG(WARN) << "Ignoring unsupported media type parameters, the first of "
-                   "which is \""
-                << ctx->parameter()[0]->getText() << std::endl;
+      AD_LOG_WARN << "Ignoring unsupported media type parameters, the first of "
+                     "which is \""
+                  << ctx->parameter()[0]->getText() << std::endl;
     }
     using V = std::optional<ad_utility::MediaTypeWithQuality::Variant>;
     if (!ctx->subtype()) {

--- a/src/util/http/HttpServer.h
+++ b/src/util/http/HttpServer.h
@@ -168,7 +168,7 @@ CPP_template(typename HttpHandler, typename WebSocketHandler)(
  private:
   // Format a boost/beast error and log it to console
   void logBeastError(beast::error_code ec, std::string_view message) {
-    LOG(ERROR) << message << ": " << ec.message() << std::endl;
+    AD_LOG_ERROR << message << ": " << ec.message() << std::endl;
   }
 
   // The loop which accepts TCP connections and delegates their handling
@@ -311,8 +311,8 @@ CPP_template(typename HttpHandler, typename WebSocketHandler)(
           // the client stream ended unexpectedly.
           if (error.code() == beast::error::timeout ||
               error.code() == boost::asio::error::eof) {
-            LOG(TRACE) << error.what() << " (code " << error.code() << ")"
-                       << std::endl;
+            AD_LOG_TRACE << error.what() << " (code " << error.code() << ")"
+                         << std::endl;
           } else {
             logBeastError(error.code(), error.what());
           }
@@ -324,12 +324,12 @@ CPP_template(typename HttpHandler, typename WebSocketHandler)(
           co_return;
         }
       } catch (const std::exception& error) {
-        LOG(ERROR) << error.what() << std::endl;
+        AD_LOG_ERROR << error.what() << std::endl;
         co_return;
       } catch (...) {
-        LOG(ERROR) << "Weird exception not inheriting from std::exception, "
-                      "this shouldn't happen"
-                   << std::endl;
+        AD_LOG_ERROR << "Weird exception not inheriting from std::exception, "
+                        "this shouldn't happen"
+                     << std::endl;
         co_return;
       }
 

--- a/src/util/http/streamable_body.h
+++ b/src/util/http/streamable_body.h
@@ -124,7 +124,7 @@ class streamable_body::writer {
       }};
     } catch (const std::exception& e) {
       ec = {EPIPE, boost::system::generic_category()};
-      LOG(ERROR) << "Failed to generate response:\n" << e.what() << std::endl;
+      AD_LOG_ERROR << "Failed to generate response:\n" << e.what() << std::endl;
       return boost::none;
     }
   }

--- a/test/SortPerformanceEstimatorTest.cpp
+++ b/test/SortPerformanceEstimatorTest.cpp
@@ -39,18 +39,20 @@ TEST(SortPerformanceEstimator, TestManyEstimates) {
             SortPerformanceEstimator::measureSortingTime(i, numColumns,
                                                          allocator);
         Timer::Duration estimate = t.estimatedSortTime(i, numColumns);
-        LOG(INFO) << std::fixed << std::setprecision(3) << "input of size " << i
-                  << "with " << numColumns << " columns took "
-                  << Timer::toSeconds(measurement) << " seconds, estimate was "
-                  << Timer::toSeconds(estimate) << " seconds" << std::endl;
+        AD_LOG_INFO << std::fixed << std::setprecision(3) << "input of size "
+                    << i << "with " << numColumns << " columns took "
+                    << Timer::toSeconds(measurement)
+                    << " seconds, estimate was " << Timer::toSeconds(estimate)
+                    << " seconds" << std::endl;
         ASSERT_GE(2 * measurement, estimate);
         if (!isFirst) {
           EXPECT_LE(0.5 * measurement, estimate);
         } else if (0.5 * measurement > estimate) {
-          LOG(WARN) << "The first measurement with a new column size took "
-                       "twice as long as estimated. This is not unusual (even "
-                       "typical) and hence does not count as a failed test."
-                    << std::endl;
+          AD_LOG_WARN
+              << "The first measurement with a new column size took "
+                 "twice as long as estimated. This is not unusual (even "
+                 "typical) and hence does not count as a failed test."
+              << std::endl;
         }
         isFirst = false;
       } catch (ad_utility::detail::AllocationExceedsLimitException&) {

--- a/test/parser/SparqlAntlrParserTest.cpp
+++ b/test/parser/SparqlAntlrParserTest.cpp
@@ -97,13 +97,13 @@ TEST(SparqlExpressionParser, First) {
   string s = "(5 * 5 ) bimbam";
   // This is an example on how to access a certain parsed substring.
   /*
-  LOG(INFO) << context->getText() << std::endl;
-  LOG(INFO) << p.parser_.getTokenStream()
+  AD_LOG_INFO << context->getText() << std::endl;
+  AD_LOG_INFO << p.parser_.getTokenStream()
                    ->getTokenSource()
                    ->getInputStream()
                    ->toString()
             << std::endl;
-  LOG(INFO) << p.parser_.getCurrentToken()->getStartIndex() << std::endl;
+  AD_LOG_INFO << p.parser_.getCurrentToken()->getStartIndex() << std::endl;
    */
   auto resultofParse = parse<&Parser::expression>(s);
   EXPECT_EQ(resultofParse.remainingText_.length(), 6);


### PR DESCRIPTION
QLever originally used the macro `LOG(...)` for logging, e.g. `LOG(INFO)` or `LOG(DEBUG)`. However, this macro collides with other libraries who define a macro with the same name, most prominently `abseil`, which is used at many places in the QLever codebase. For some time now, there are equivalent macros  `AD_LOG_...`, e.g., `AD_LOG_INFO` or `AD_LOG_DEBUG`, which are much less likely to collide with other libraries. These new macros are now used consistently throughout the codebase.