### PR TITLE
Migrate `std::erase` and `std::erase_if` to C++17

### DIFF
--- a/src/backports/algorithm.h
+++ b/src/backports/algorithm.h
@@ -1,6 +1,7 @@
 //  Copyright 2024, University of Freiburg,
 //                  Chair of Algorithms and Data Structures.
 //  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_SRC_BACKPORTS_ALGORITHM_H
 #define QLEVER_SRC_BACKPORTS_ALGORITHM_H
@@ -9,6 +10,7 @@
 #include <functional>
 #include <range/v3/all.hpp>
 #include <utility>
+#include <vector>
 
 #include "backports/concepts.h"
 
@@ -47,6 +49,19 @@ using namespace ::ranges::views;
 using namespace std::views;
 #endif
 }  // namespace views
+
+#ifdef QLEVER_CPP_17
+template <class T, class Alloc, class U>
+constexpr typename std::vector<T, Alloc>::size_type erase(
+    std::vector<T, Alloc>& c, const U& value);
+
+template <class T, class Alloc, class Pred>
+constexpr typename std::vector<T, Alloc>::size_type erase_if(
+    std::vector<T, Alloc>& c, Pred pred);
+#else
+using std::erase;
+using std::erase_if;
+#endif
 
 }  // namespace ql
 

--- a/src/backports/algorithm.h
+++ b/src/backports/algorithm.h
@@ -28,7 +28,6 @@
 #endif
 
 namespace ql {
-
 namespace ranges {
 #ifdef QLEVER_CPP_17
 using namespace ::ranges;
@@ -50,14 +49,31 @@ using namespace std::views;
 #endif
 }  // namespace views
 
-#ifdef QLEVER_CPP_17
+// Backported versions of `std::erase(_if)`
+namespace backports {
 template <class T, class Alloc, class U>
-constexpr typename std::vector<T, Alloc>::size_type erase(
-    std::vector<T, Alloc>& c, const U& value);
+constexpr std::vector<T, Alloc>::size_type erase(std::vector<T, Alloc>& c,
+                                                 const U& value) {
+  auto it = std::remove(c.begin(), c.end(), value);
+  auto r = c.end() - it;
+  c.erase(it, c.end());
+  return r;
+}
 
 template <class T, class Alloc, class Pred>
-constexpr typename std::vector<T, Alloc>::size_type erase_if(
-    std::vector<T, Alloc>& c, Pred pred);
+constexpr std::vector<T, Alloc>::size_type erase_if(std::vector<T, Alloc>& c,
+                                                    Pred pred) {
+  auto it = std::remove_if(c.begin(), c.end(), pred);
+  auto r = c.end() - it;
+  c.erase(it, c.end());
+  return r;
+}
+}  // namespace backports
+
+#ifdef QLEVER_CPP_17
+using backports::erase;
+using backports::erase_if;
+
 #else
 using std::erase;
 using std::erase_if;

--- a/src/engine/ExportQueryExecutionTrees.cpp
+++ b/src/engine/ExportQueryExecutionTrees.cpp
@@ -974,7 +974,11 @@ ad_utility::streams::stream_generator ExportQueryExecutionTrees::
   // Get all columns with defined variables.
   QueryExecutionTree::ColumnIndicesAndTypes columns =
       qet.selectedVariablesToColumnIndices(selectClause, false);
-  std::erase(columns, std::nullopt);
+  // std::erase(columns, std::nullopt);
+  columns.erase(std::remove(columns.begin(), columns.end(),
+                             std::nullopt),
+                columns.end());
+
 
   auto getBinding = [&](const IdTable& idTable, const uint64_t& i,
                         const LocalVocab& localVocab) {

--- a/src/engine/ExportQueryExecutionTrees.cpp
+++ b/src/engine/ExportQueryExecutionTrees.cpp
@@ -3,6 +3,7 @@
 // Authors: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
 //          Robin Textor-Falconi <textorr@cs.uni-freiburg.de>
 //          Hannah Bast <bast@cs.uni-freiburg.de>
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #include "ExportQueryExecutionTrees.h"
 
@@ -974,7 +975,6 @@ ad_utility::streams::stream_generator ExportQueryExecutionTrees::
   // Get all columns with defined variables.
   QueryExecutionTree::ColumnIndicesAndTypes columns =
       qet.selectedVariablesToColumnIndices(selectClause, false);
-  // std::erase(columns, std::nullopt);
   columns.erase(std::remove(columns.begin(), columns.end(),
                              std::nullopt),
                 columns.end());

--- a/src/engine/ExportQueryExecutionTrees.cpp
+++ b/src/engine/ExportQueryExecutionTrees.cpp
@@ -14,6 +14,7 @@
 
 #include <ranges>
 
+#include "backports/algorithm.h"
 #include "index/EncodedIriManager.h"
 #include "index/IndexImpl.h"
 #include "rdfTypes/RdfEscaping.h"
@@ -975,10 +976,7 @@ ad_utility::streams::stream_generator ExportQueryExecutionTrees::
   // Get all columns with defined variables.
   QueryExecutionTree::ColumnIndicesAndTypes columns =
       qet.selectedVariablesToColumnIndices(selectClause, false);
-  columns.erase(std::remove(columns.begin(), columns.end(),
-                             std::nullopt),
-                columns.end());
-
+  ql::erase(columns, std::nullopt);
 
   auto getBinding = [&](const IdTable& idTable, const uint64_t& i,
                         const LocalVocab& localVocab) {

--- a/src/engine/GroupByImpl.cpp
+++ b/src/engine/GroupByImpl.cpp
@@ -232,10 +232,12 @@ GroupByImpl::GroupByImpl(QueryExecutionContext* qec,
   AD_CORRECTNESS_CHECK(subtree != nullptr);
   // Remove all undefined GROUP BY variables (according to the SPARQL standard
   // they are allowed, but have no effect on the result).
-  std::erase_if(_groupByVariables,
-                [&map = subtree->getVariableColumns()](const auto& var) {
-                  return !map.contains(var);
-                });
+  _groupByVariables.erase(std::remove_if(_groupByVariables.begin(),
+                                          _groupByVariables.end(),
+                                          [&map = subtree->getVariableColumns()](const auto& var) {
+                                            return !map.contains(var);
+                                          }),
+                            _groupByVariables.end());
 
   // The subtrees of a GROUP BY only need to compute columns that are grouped or
   // used in any of the aggregate aliases.

--- a/src/engine/GroupByImpl.cpp
+++ b/src/engine/GroupByImpl.cpp
@@ -9,6 +9,7 @@
 
 #include <absl/strings/str_join.h>
 
+#include "backports/algorithm.h"
 #include "engine/CallFixedSize.h"
 #include "engine/ExistsJoin.h"
 #include "engine/IndexScan.h"
@@ -232,12 +233,10 @@ GroupByImpl::GroupByImpl(QueryExecutionContext* qec,
   AD_CORRECTNESS_CHECK(subtree != nullptr);
   // Remove all undefined GROUP BY variables (according to the SPARQL standard
   // they are allowed, but have no effect on the result).
-  _groupByVariables.erase(std::remove_if(_groupByVariables.begin(),
-                                          _groupByVariables.end(),
-                                          [&map = subtree->getVariableColumns()](const auto& var) {
-                                            return !map.contains(var);
-                                          }),
-                            _groupByVariables.end());
+  ql::erase_if(_groupByVariables,
+               [&map = subtree->getVariableColumns()](const auto& var) {
+                 return !map.contains(var);
+               });
 
   // The subtrees of a GROUP BY only need to compute columns that are grouped or
   // used in any of the aggregate aliases.

--- a/src/engine/QueryExecutionTree.cpp
+++ b/src/engine/QueryExecutionTree.cpp
@@ -2,6 +2,7 @@
 // Chair of Algorithms and Data Structures
 // Authors: Björn Buchhold <buchhold@cs.uni-freiburg.de> [2015 - 2017]
 //          Johannes Kalmbach <kalmbach@cs.uni-freiburg.de> [2017 - 2024]
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #include "engine/QueryExecutionTree.h"
 
@@ -115,10 +116,13 @@ QueryExecutionTree::setPrefilterGetUpdatedQueryExecutionTree(
 
   // Note: Variables that have been stripped are still semantically part of the
   // query, and thus can be prefiltered.
-  std::erase_if(prefilterPairs, [&varToColMap, this](const auto& pair) {
-    return !varToColMap.contains(pair.second) &&
-           !strippedVariables_.contains(pair.second);
-  });
+  prefilterPairs.erase(std::remove_if(prefilterPairs.begin(),
+                                      prefilterPairs.end(),
+                                      [&varToColMap, this](const auto& pair) {
+                                        return !varToColMap.contains(pair.second) &&
+                                               !strippedVariables_.contains(pair.second);
+                                      }),
+                       prefilterPairs.end());
 
   if (prefilterPairs.empty()) {
     return std::nullopt;

--- a/src/engine/QueryExecutionTree.cpp
+++ b/src/engine/QueryExecutionTree.cpp
@@ -12,6 +12,7 @@
 #include <string>
 #include <vector>
 
+#include "backports/algorithm.h"
 #include "engine/Sort.h"
 #include "engine/StripColumns.h"
 #include "global/RuntimeParameters.h"
@@ -116,13 +117,10 @@ QueryExecutionTree::setPrefilterGetUpdatedQueryExecutionTree(
 
   // Note: Variables that have been stripped are still semantically part of the
   // query, and thus can be prefiltered.
-  prefilterPairs.erase(std::remove_if(prefilterPairs.begin(),
-                                      prefilterPairs.end(),
-                                      [&varToColMap, this](const auto& pair) {
-                                        return !varToColMap.contains(pair.second) &&
-                                               !strippedVariables_.contains(pair.second);
-                                      }),
-                       prefilterPairs.end());
+  ql::erase_if(prefilterPairs, [&varToColMap, this](const auto& pair) {
+    return !varToColMap.contains(pair.second) &&
+           !strippedVariables_.contains(pair.second);
+  });
 
   if (prefilterPairs.empty()) {
     return std::nullopt;

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -1678,8 +1678,12 @@ std::vector<SubtreePlan> QueryPlanner::runGreedyPlanningOnConnectedComponent(
     auto shouldBeErased = [&nextTree = nextBestPlan.front()](const auto& plan) {
       return (nextTree._idsOfIncludedNodes & plan._idsOfIncludedNodes) != 0;
     };
-    std::erase_if(currentPlans, shouldBeErased);
-    std::erase_if(cache, shouldBeErased);
+    currentPlans.erase(
+        std::remove_if(currentPlans.begin(), currentPlans.end(), shouldBeErased),
+        currentPlans.end());
+    cache.erase(
+        std::remove_if(cache.begin(), cache.end(), shouldBeErased),
+        cache.end());
   };
 
   Plans result;

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -1678,12 +1678,8 @@ std::vector<SubtreePlan> QueryPlanner::runGreedyPlanningOnConnectedComponent(
     auto shouldBeErased = [&nextTree = nextBestPlan.front()](const auto& plan) {
       return (nextTree._idsOfIncludedNodes & plan._idsOfIncludedNodes) != 0;
     };
-    currentPlans.erase(
-        std::remove_if(currentPlans.begin(), currentPlans.end(), shouldBeErased),
-        currentPlans.end());
-    cache.erase(
-        std::remove_if(cache.begin(), cache.end(), shouldBeErased),
-        cache.end());
+    ql::erase_if(currentPlans, shouldBeErased);
+    ql::erase_if(cache, shouldBeErased);
   };
 
   Plans result;

--- a/src/engine/sparqlExpressions/SparqlExpressionPimpl.cpp
+++ b/src/engine/sparqlExpressions/SparqlExpressionPimpl.cpp
@@ -4,8 +4,10 @@
 // Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #include "./SparqlExpressionPimpl.h"
+
 #include <algorithm>
 
+#include "backports/algorithm.h"
 #include "engine/sparqlExpressions/LiteralExpression.h"
 #include "engine/sparqlExpressions/SparqlExpression.h"
 
@@ -40,9 +42,8 @@ SparqlExpressionPimpl& SparqlExpressionPimpl::operator=(
 std::vector<Variable> SparqlExpressionPimpl::getUnaggregatedVariables(
     const ad_utility::HashSet<Variable>& groupedVariables) const {
   auto vars = _pimpl->getUnaggregatedVariables();
-  vars.erase(std::remove_if(vars.begin(), vars.end(),
-                            [&](const auto& var) { return groupedVariables.contains(var); }),
-             vars.end());
+  ql::erase_if(vars,
+               [&](const auto& var) { return groupedVariables.contains(var); });
   return vars;
 }
 

--- a/src/engine/sparqlExpressions/SparqlExpressionPimpl.cpp
+++ b/src/engine/sparqlExpressions/SparqlExpressionPimpl.cpp
@@ -5,8 +5,6 @@
 
 #include "./SparqlExpressionPimpl.h"
 
-#include <algorithm>
-
 #include "backports/algorithm.h"
 #include "engine/sparqlExpressions/LiteralExpression.h"
 #include "engine/sparqlExpressions/SparqlExpression.h"

--- a/src/engine/sparqlExpressions/SparqlExpressionPimpl.cpp
+++ b/src/engine/sparqlExpressions/SparqlExpressionPimpl.cpp
@@ -1,8 +1,10 @@
 //  Copyright 2021, University of Freiburg,
 //                  Chair of Algorithms and Data Structures.
 //  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #include "./SparqlExpressionPimpl.h"
+#include <algorithm>
 
 #include "engine/sparqlExpressions/LiteralExpression.h"
 #include "engine/sparqlExpressions/SparqlExpression.h"
@@ -38,8 +40,9 @@ SparqlExpressionPimpl& SparqlExpressionPimpl::operator=(
 std::vector<Variable> SparqlExpressionPimpl::getUnaggregatedVariables(
     const ad_utility::HashSet<Variable>& groupedVariables) const {
   auto vars = _pimpl->getUnaggregatedVariables();
-  std::erase_if(
-      vars, [&](const auto& var) { return groupedVariables.contains(var); });
+  vars.erase(std::remove_if(vars.begin(), vars.end(),
+                            [&](const auto& var) { return groupedVariables.contains(var); }),
+             vars.end());
   return vars;
 }
 

--- a/src/global/ValueIdComparators.h
+++ b/src/global/ValueIdComparators.h
@@ -359,7 +359,9 @@ auto simplifyRanges(std::vector<std::pair<RandomIt, RandomIt>> input,
                     bool removeEmptyRanges = true) {
   if (removeEmptyRanges) {
     // Eliminate empty ranges
-    std::erase_if(input, [](const auto& p) { return p.first == p.second; });
+    input.erase(std::remove_if(input.begin(), input.end(),
+                           [](const auto& p) { return p.first == p.second; }),
+                input.end());
   }
   std::sort(input.begin(), input.end());
   if (input.empty()) {

--- a/src/global/ValueIdComparators.h
+++ b/src/global/ValueIdComparators.h
@@ -9,6 +9,7 @@
 
 #include <utility>
 
+#include "backports/algorithm.h"
 #include "global/Id.h"
 #include "util/Algorithm.h"
 #include "util/ComparisonWithNan.h"
@@ -359,9 +360,7 @@ auto simplifyRanges(std::vector<std::pair<RandomIt, RandomIt>> input,
                     bool removeEmptyRanges = true) {
   if (removeEmptyRanges) {
     // Eliminate empty ranges
-    input.erase(std::remove_if(input.begin(), input.end(),
-                           [](const auto& p) { return p.first == p.second; }),
-                input.end());
+    ql::erase_if(input, [](const auto& p) { return p.first == p.second; });
   }
   std::sort(input.begin(), input.end());
   if (input.empty()) {

--- a/src/index/DeltaTriples.cpp
+++ b/src/index/DeltaTriples.cpp
@@ -8,11 +8,13 @@
 
 // You may not use this file except in compliance with the Apache 2.0 License,
 // which can be found in the `LICENSE` file at the root of the QLever project.
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #include "index/DeltaTriples.h"
 
 #include <absl/strings/str_cat.h>
 
+#include "backports/algorithm.h"
 #include "engine/ExecuteUpdate.h"
 #include "index/Index.h"
 #include "index/IndexImpl.h"
@@ -176,7 +178,7 @@ void DeltaTriples::modifyTriplesImpl(CancellationHandle cancellationHandle,
   AD_EXPENSIVE_CHECK(std::unique(triples.begin(), triples.end()) ==
                      triples.end());
   tracer.beginTrace("removeExistingTriples");
-  std::erase_if(triples, [&targetMap](const IdTriple<0>& triple) {
+  ql::erase_if(triples, [&targetMap](const IdTriple<0>& triple) {
     return targetMap.contains(triple);
   });
   tracer.endTrace("removeExistingTriples");

--- a/test/ValueIdTest.cpp
+++ b/test/ValueIdTest.cpp
@@ -1,6 +1,7 @@
 //  Copyright 2022, University of Freiburg,
 //  Chair of Algorithms and Data Structures.
 //  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #include <absl/hash/hash_testing.h>
 #include <gtest/gtest.h>
@@ -213,7 +214,9 @@ TEST_F(ValueIdTest, DoubleOrdering) {
 
   // The sorting of `double`s is broken as soon as NaNs are present. We remove
   // the NaNs from the `double`s.
-  std::erase_if(doubles, [](double d) { return std::isnan(d); });
+  doubles.erase(std::remove_if(doubles.begin(), doubles.end(),
+                               [](double d) { return std::isnan(d); }),
+                doubles.end());
   std::sort(doubles.begin(), doubles.end());
 
   // When sorting ValueIds that hold doubles, the NaN values form a contiguous

--- a/test/ValueIdTest.cpp
+++ b/test/ValueIdTest.cpp
@@ -11,6 +11,7 @@
 #include "./ValueIdTestHelpers.h"
 #include "./util/GTestHelpers.h"
 #include "./util/IndexTestHelpers.h"
+#include "backports/algorithm.h"
 #include "global/ValueId.h"
 #include "index/EncodedIriManager.h"
 #include "index/LocalVocabEntry.h"
@@ -214,9 +215,7 @@ TEST_F(ValueIdTest, DoubleOrdering) {
 
   // The sorting of `double`s is broken as soon as NaNs are present. We remove
   // the NaNs from the `double`s.
-  doubles.erase(std::remove_if(doubles.begin(), doubles.end(),
-                               [](double d) { return std::isnan(d); }),
-                doubles.end());
+  ql::erase_if(doubles, [](double d) { return std::isnan(d); });
   std::sort(doubles.begin(), doubles.end());
 
   // When sorting ValueIds that hold doubles, the NaN values form a contiguous

--- a/test/backports/algorithmTest.cpp
+++ b/test/backports/algorithmTest.cpp
@@ -17,15 +17,17 @@ class AlgorithmBackportTest : public ::testing::Test {
   std::vector<int> testVector;
 };
 
+// _____________________________________________________________________________
 TEST_F(AlgorithmBackportTest, EraseSingleValue) {
-  ql::erase(testVector, 4);
+  EXPECT_EQ(ql::backports::erase(testVector, 4), 1);
   std::vector<int> expected{5, 3, 8, 1, 2, 7, 6};
   EXPECT_EQ(testVector, expected);
 }
 
+// _____________________________________________________________________________
 TEST_F(AlgorithmBackportTest, EraseIfRemovesCorrectElements) {
   auto isEven = [](int x) { return x % 2 == 0; };
-  ql::erase_if(testVector, isEven);
+  EXPECT_EQ(ql::backports::erase_if(testVector, isEven), 4);
   std::vector<int> expected{5, 3, 1, 7};
   EXPECT_EQ(testVector, expected);
 }

--- a/test/backports/algorithmTest.cpp
+++ b/test/backports/algorithmTest.cpp
@@ -1,9 +1,31 @@
 //
 // Created by kalmbacj on 12/6/24.
 //
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #include <gtest/gtest.h>
+
+#include <vector>
 
 #include "backports/algorithm.h"
 
 TEST(Range, Sort) {}
+
+class AlgorithmBackportTest : public ::testing::Test {
+ protected:
+  void SetUp() override { testVector = {5, 3, 8, 1, 2, 7, 4, 6}; }
+  std::vector<int> testVector;
+};
+
+TEST_F(AlgorithmBackportTest, EraseSingleValue) {
+  ql::erase(testVector, 4);
+  std::vector<int> expected{5, 3, 8, 1, 2, 7, 6};
+  EXPECT_EQ(testVector, expected);
+}
+
+TEST_F(AlgorithmBackportTest, EraseIfRemovesCorrectElements) {
+  auto isEven = [](int x) { return x % 2 == 0; };
+  ql::erase_if(testVector, isEven);
+  std::vector<int> expected{5, 3, 1, 7};
+  EXPECT_EQ(testVector, expected);
+}


### PR DESCRIPTION
Implement `ql::erase` and `ql::erase_if` in the `backports/algorithm.h` header as drop-in replacements for `std::erase` and `std::erase_if`.