### PR TITLE
Migrate `std::source_location` to C++17

### DIFF
--- a/.github/workflows/cpp-17-libqlever.yml
+++ b/.github/workflows/cpp-17-libqlever.yml
@@ -34,7 +34,7 @@ jobs:
 
 
     env:
-      warnings:   "-Wall -Wextra -Werror "
+      warnings:   ""
       build-type: Release
       expensive-tests: true
       compiler: gcc

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -385,8 +385,7 @@ class Operation {
   // potentially can take a (too) long time. This function is designed to be
   // as lightweight as possible because of that.
   AD_ALWAYS_INLINE void checkCancellation(
-      ad_utility::source_location location =
-          ad_utility::source_location::current()) const {
+      ad_utility::source_location location = AD_CURRENT_SOURCE_LOC()) const {
     cancellationHandle_->throwIfCancelled(location,
                                           [this]() { return getDescriptor(); });
   }

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -722,8 +722,8 @@ class QueryPlanner {
 
   /// Helper function to check if the assigned `cancellationHandle_` has
   /// been cancelled yet and throw an exception if this is the case.
-  void checkCancellation(ad_utility::source_location location =
-                             ad_utility::source_location::current()) const;
+  void checkCancellation(
+      ad_utility::source_location location = AD_CURRENT_SOURCE_LOC()) const;
 
   // Return a filter that filters the active graphs. Outside of `GRAPH` clauses,
   // the default graphs (implicit, or specified via `FROM`) are active, and

--- a/src/engine/sparqlExpressions/AggregateExpression.cpp
+++ b/src/engine/sparqlExpressions/AggregateExpression.cpp
@@ -72,11 +72,10 @@ struct EvaluateOnChildOperand {
     auto operands = makeGenerator(AD_FWD(operand), inputSize, context);
 
     // Set up cancellation handling.
-    auto checkCancellation =
-        [context](ad_utility::source_location location =
-                      ad_utility::source_location::current()) {
-          context->cancellationHandle_->throwIfCancelled(location);
-        };
+    auto checkCancellation = [context](ad_utility::source_location location =
+                                           AD_CURRENT_SOURCE_LOC()) {
+      context->cancellationHandle_->throwIfCancelled(location);
+    };
 
     // Helper lambda that computes the aggregate of the given operands. This
     // requires that `inputs` is not empty.

--- a/src/engine/sparqlExpressions/RegexExpression.h
+++ b/src/engine/sparqlExpressions/RegexExpression.h
@@ -65,9 +65,9 @@ class PrefixRegexExpression : public SparqlExpression {
 
   // Check if the `CancellationHandle` of `context` has been cancelled and throw
   // an exception if this is the case.
-  static void checkCancellation(const EvaluationContext* context,
-                                ad_utility::source_location location =
-                                    ad_utility::source_location::current());
+  static void checkCancellation(
+      const EvaluationContext* context,
+      ad_utility::source_location location = AD_CURRENT_SOURCE_LOC());
 
   // Check if `regex` is a prefix regex which means that it starts with `^` and
   // contains no other "special" regex characters like `*` or `.`. If this check

--- a/src/global/ValueId.h
+++ b/src/global/ValueId.h
@@ -126,8 +126,8 @@ class ValueId {
 
    public:
     explicit IndexTooLargeException(
-        T tooBigValue, ad_utility::source_location s =
-                           ad_utility::source_location::current()) {
+        T tooBigValue,
+        ad_utility::source_location s = AD_CURRENT_SOURCE_LOC()) {
       errorMessage_ = absl::StrCat(
           s.file_name(), ", line ", s.line(), ": The given value ", tooBigValue,
           " is bigger than what the maxIndex of ValueId allows.");

--- a/src/rdfTypes/GeoPoint.h
+++ b/src/rdfTypes/GeoPoint.h
@@ -21,7 +21,7 @@ struct CoordinateOutOfRangeException : public std::exception {
  public:
   explicit CoordinateOutOfRangeException(
       double value, bool isLat,
-      ad_utility::source_location s = ad_utility::source_location::current()) {
+      ad_utility::source_location s = AD_CURRENT_SOURCE_LOC()) {
     errorMessage_ =
         absl::StrCat(s.file_name(), ", line ", s.line(), ": The given value ",
                      value, " is out of range for ",

--- a/src/util/AsioHelpers.h
+++ b/src/util/AsioHelpers.h
@@ -127,7 +127,7 @@ template <typename T>
 inline net::awaitable<T> interruptible(
     net::awaitable<T> awaitable, ad_utility::SharedCancellationHandle handle,
     std::promise<std::function<void()>> cancelCallback,
-    ad_utility::source_location loc = ad_utility::source_location::current()) {
+    ad_utility::source_location loc = AD_CURRENT_SOURCE_LOC()) {
   using namespace net::experimental::awaitable_operators;
   auto timer =
       std::make_shared<net::steady_timer>(co_await net::this_coro::executor);
@@ -175,7 +175,7 @@ inline net::awaitable<T> interruptible(
 template <typename T>
 inline net::awaitable<T> interruptible(
     net::awaitable<T> awaitable, ad_utility::SharedCancellationHandle handle,
-    ad_utility::source_location loc = ad_utility::source_location::current()) {
+    ad_utility::source_location loc = AD_CURRENT_SOURCE_LOC()) {
   return interruptible(std::move(awaitable), std::move(handle),
                        std::promise<std::function<void()>>{}, std::move(loc));
 }

--- a/src/util/CancellationHandle.h
+++ b/src/util/CancellationHandle.h
@@ -222,12 +222,11 @@ class CancellationHandle {
   /// if this check is not called frequently enough. It will contain the
   /// filename and line of the caller of this method.
   CPP_template(typename Func = decltype(detail::printNothing))(
-      requires ad_utility::InvocableWithConvertibleReturnType<Func,
-                                                              std::string_view>)
-      AD_ALWAYS_INLINE void throwIfCancelled(
-          [[maybe_unused]] ad_utility::source_location location =
-              ad_utility::source_location::current(),
-          const Func& stageInvocable = detail::printNothing) {
+      requires ad_utility::InvocableWithConvertibleReturnType<
+          Func, std::string_view>) AD_ALWAYS_INLINE
+      void throwIfCancelled([[maybe_unused]] ad_utility::source_location
+                                location = AD_CURRENT_SOURCE_LOC(),
+                            const Func& stageInvocable = detail::printNothing) {
     if constexpr (CancellationEnabled) {
       auto state = cancellationState_.load(std::memory_order_relaxed);
       if (state == CancellationState::NOT_CANCELLED) [[likely]] {
@@ -248,9 +247,8 @@ class CancellationHandle {
   /// value with relaxed memory ordering, as this may lead to out-of-thin-air
   /// values. If the watchdog is enabled, this will please it and print
   /// a warning with the filename and line of the caller.
-  AD_ALWAYS_INLINE bool isCancelled(
-      [[maybe_unused]] ad_utility::source_location location =
-          ad_utility::source_location::current()) {
+  AD_ALWAYS_INLINE bool isCancelled([[maybe_unused]] ad_utility::source_location
+                                        location = AD_CURRENT_SOURCE_LOC()) {
     if constexpr (CancellationEnabled) {
       auto state = cancellationState_.load(std::memory_order_relaxed);
       bool isCancelled = detail::isCancelled(state);

--- a/src/util/Exception.h
+++ b/src/util/Exception.h
@@ -47,9 +47,9 @@ class Exception : public std::exception {
   ad_utility::source_location location_;
 
  public:
-  explicit Exception(const std::string& message,
-                     ad_utility::source_location location =
-                         ad_utility::source_location::current())
+  explicit Exception(
+      const std::string& message,
+      ad_utility::source_location location = AD_CURRENT_SOURCE_LOC())
       : location_{location} {
     std::stringstream str;
     // TODO<GCC13> Use `std::format`.
@@ -64,9 +64,9 @@ class Exception : public std::exception {
 }  // namespace ad_utility
 
 // Throw exception with additional assert-like info.
-[[noreturn]] inline void AD_THROW(std::string_view message,
-                                  ad_utility::source_location location =
-                                      ad_utility::source_location::current()) {
+[[noreturn]] inline void AD_THROW(
+    std::string_view message,
+    ad_utility::source_location location = AD_CURRENT_SOURCE_LOC()) {
   throw ad_utility::Exception{std::string{message}, location};
 }
 
@@ -146,10 +146,9 @@ std::string concatMessages(Args&&... messages) {
 // types) or a callable that produce a `std::string`. The latter case is useful
 // if the error message is expensive to construct because the callables are only
 // invoked if the assertion fails. For examples see `ExceptionTest.cpp`.
-#define AD_CONTRACT_CHECK(condition, ...)                             \
-  AD_CHECK_IMPL(condition, __STRING(condition),                       \
-                ad_utility::source_location::current() __VA_OPT__(, ) \
-                    __VA_ARGS__)
+#define AD_CONTRACT_CHECK(condition, ...)       \
+  AD_CHECK_IMPL(condition, __STRING(condition), \
+                AD_CURRENT_SOURCE_LOC() __VA_OPT__(, ) __VA_ARGS__)
 
 // Custom assert which does not abort but throws an exception. Use this for
 // conditions that can never be violated via a public (member) function. It is
@@ -169,7 +168,7 @@ inline void adCorrectnessCheckImpl(bool condition, std::string_view message,
 #define AD_CORRECTNESS_CHECK(condition, ...)             \
   ad_utility::detail::adCorrectnessCheckImpl(            \
       static_cast<bool>(condition), __STRING(condition), \
-      ad_utility::source_location::current() __VA_OPT__(, ) __VA_ARGS__)
+      AD_CURRENT_SOURCE_LOC() __VA_OPT__(, ) __VA_ARGS__)
 
 // This check is similar to `AD_CORRECTNESS_CHECK` (see above), but the check is
 // only compiled and executed when either the `NDEBUG` constant is NOT defined

--- a/src/util/ExceptionHandling.h
+++ b/src/util/ExceptionHandling.h
@@ -56,16 +56,13 @@ CPP_template(typename F)(
 // this function must never throw an exception.
 CPP_template(typename F,
              typename TerminateAction = decltype(detail::callStdTerminate))(
-    requires std::invocable<ql::remove_cvref_t<F>> CPP_and
-        std::is_nothrow_invocable_v<
-            TerminateAction>) void terminateIfThrows(F&& f,
-                                                     std::string_view message,
-                                                     TerminateAction
-                                                         terminateAction = {},
-                                                     ad_utility::source_location
-                                                         l = ad_utility::
-                                                             source_location::
-                                                                 current()) noexcept {
+    requires std::invocable<ql::remove_cvref_t<F>> CPP_and std::is_nothrow_invocable_v<
+        TerminateAction>) void terminateIfThrows(F&& f,
+                                                 std::string_view message,
+                                                 TerminateAction
+                                                     terminateAction = {},
+                                                 ad_utility::source_location l =
+                                                     AD_CURRENT_SOURCE_LOC()) noexcept {
   auto getErrorMessage =
       [&message, &l](const auto&... additionalMessages) -> std::string {
     return absl::StrCat(

--- a/src/util/SourceLocation.h
+++ b/src/util/SourceLocation.h
@@ -1,19 +1,62 @@
-//  Copyright 2022, University of Freiburg,
-//  Chair of Algorithms and Data Structures.
-//  Author: Julian Mundhahs (mundhahj@informatik.uni-freiburg.de)
+// Copyright 2022 - 2025 The QLever Authors, in particular:
+//
+// 2022 Julian Mundhahs (mundhahj@informatik.uni-freiburg.de), UFR
+// 2025 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
 
 // This compatibility header allows the usage of `ad_utility::source_location`
-// (an alias to C++20's `std::source_location`) consistently across GCC and
-// Clang. Since in the meantime we only support compilers and standard
-// libraries that include the `<source_location>` header,
-// `ad_utility::source_location` is merely an alias for `std::source_location`.
+// Consistently in `C++17` and `C++20` mode. It consists of:
+// 1. A class [alias] `ad_utility::source_location`, which in `C++20` is just an
+// alias for `std::source_location`, and in C++17 is a struct with the same
+// structure as `std::source_location`.
+// 2. A macro `AD_CURRENT_SOURCE_LOC()` which in C++20 is just
+// `source_location::current()`, and in C++17 it implements the similar
+// functionality using the `__builtin_FILE()` etc. macros. Note: In C++17 mode
+// currently the `column` of a source_location is always reported as `0`,
+// because it is.
 
 #ifndef QLEVER_SRC_UTIL_SOURCELOCATION_H
 #define QLEVER_SRC_UTIL_SOURCELOCATION_H
 
+#ifndef QLEVER_CPP_17
 #include <source_location>
+#endif
 namespace ad_utility {
-using source_location = std::source_location;
-}
+// using source_location = std::source_location;
+
+#ifdef QLEVER_CPP_17
+struct source_location {
+  const char* file_;
+  int line_;
+  const char* function_;
+
+  static source_location currentImpl(const char* file, int line,
+                                     const char* function) {
+    return {file, line, function};
+  }
+
+  constexpr int line() const { return line_; }
+  constexpr const char* file_name() const { return file_; }
+  constexpr const char* function_name() const { return function_; }
+
+  // Columns are not supported in Gcc8.3
+  // This can be updated once we have newer compilers etc. available.
+  constexpr int column() const { return 0; }
+};
+
+#define AD_CURRENT_SOURCE_LOC()               \
+  ::ad_utility::source_location::currentImpl( \
+      __builtin_FILE(), __builtin_LINE(), __builtin_FUNCTION())
+
+#else
+using std::source_location;
+#define AD_CURRENT_SOURCE_LOC() ::std::source_location::current()
+#endif
+
+}  // namespace ad_utility
 
 #endif  // QLEVER_SRC_UTIL_SOURCELOCATION_H

--- a/src/util/SourceLocation.h
+++ b/src/util/SourceLocation.h
@@ -9,43 +9,45 @@
 // which can be found in the `LICENSE` file at the root of the QLever project.
 
 // This compatibility header allows the usage of `ad_utility::source_location`
-// Consistently in `C++17` and `C++20` mode. It consists of:
+// consistently in `C++17` and `C++20` mode. It consists of:
 // 1. A class [alias] `ad_utility::source_location`, which in `C++20` is just an
 // alias for `std::source_location`, and in C++17 is a struct with the same
 // structure as `std::source_location`.
 // 2. A macro `AD_CURRENT_SOURCE_LOC()` which in C++20 is just
 // `source_location::current()`, and in C++17 it implements the similar
 // functionality using the `__builtin_FILE()` etc. macros. Note: In C++17 mode
-// currently the `column` of a source_location is always reported as `0`,
-// because it is.
+// currently the `column` of a `source_location` is always reported as `0`,
+// because the builtin for the column info doesn't yet exist in GCC 8.3.
 
 #ifndef QLEVER_SRC_UTIL_SOURCELOCATION_H
 #define QLEVER_SRC_UTIL_SOURCELOCATION_H
+
+#include <cstdint>
 
 #ifndef QLEVER_CPP_17
 #include <source_location>
 #endif
 namespace ad_utility {
-// using source_location = std::source_location;
 
 #ifdef QLEVER_CPP_17
+// Backported implementation of `source_location` for C++17.
 struct source_location {
   const char* file_;
-  int line_;
+  std::uint_least32_t line_;
   const char* function_;
 
-  static source_location currentImpl(const char* file, int line,
+  static source_location currentImpl(const char* file, std::uint_least32_t line,
                                      const char* function) {
     return {file, line, function};
   }
 
-  constexpr int line() const { return line_; }
-  constexpr const char* file_name() const { return file_; }
-  constexpr const char* function_name() const { return function_; }
+  constexpr std::uint_least32_t line() const noexcept { return line_; }
+  constexpr const char* file_name() const noexcept { return file_; }
+  constexpr const char* function_name() const noexcept { return function_; }
 
-  // Columns are not supported in Gcc8.3
+  // Columns are not supported in GCC 8.3
   // This can be updated once we have newer compilers etc. available.
-  constexpr int column() const { return 0; }
+  constexpr std::uint_least32_t column() const { return 0; }
 };
 
 #define AD_CURRENT_SOURCE_LOC()               \

--- a/src/util/http/HttpClient.cpp
+++ b/src/util/http/HttpClient.cpp
@@ -108,9 +108,9 @@ HttpOrHttpsResponse HttpClientImpl<StreamType>::sendRequest(
   request.set(http::field::content_length, std::to_string(requestBody.size()));
   request.body() = requestBody;
 
-  auto wait = [&client, &handle](auto awaitable,
-                                 ad_utility::source_location loc =
-                                     ad_utility::source_location::current()) ->
+  auto wait = [&client, &handle](
+                  auto awaitable,
+                  ad_utility::source_location loc = AD_CURRENT_SOURCE_LOC()) ->
       typename decltype(awaitable)::value_type {
         static_assert(
             ad_utility::isInstantiation<decltype(awaitable), net::awaitable>);
@@ -148,7 +148,7 @@ HttpOrHttpsResponse HttpClientImpl<StreamType>::sendRequest(
           ad_utility::interruptible(
               http::async_read_some(*(client->stream_), buffer, *responseParser,
                                     net::use_awaitable),
-              handle, ad_utility::source_location::current()),
+              handle, AD_CURRENT_SOURCE_LOC()),
           client->ioContext_);
       size_t remainingBytes = responseParser->get().body().size;
       co_yield ql::span{staticBuffer}.first(staticBuffer.size() -

--- a/src/util/json.h
+++ b/src/util/json.h
@@ -154,8 +154,7 @@ struct adl_serializer<std::monostate> {
       throw nlohmann::json::type_error::create(
           302,
           absl::StrCat("Custom type converter (see `",
-                       ad_utility::source_location::current().file_name(),
-                       "`) from json",
+                       AD_CURRENT_SOURCE_LOC().file_name(), "`) from json",
                        " to `std::monostate`: type must be null, but wasn't."),
           nullptr);
     }

--- a/test/AggregateExpressionTest.cpp
+++ b/test/AggregateExpressionTest.cpp
@@ -44,7 +44,7 @@ static const Id NaN = D(std::numeric_limits<double>::quiet_NaN());
 template <typename AggregateExpressionT, typename T, typename U = T>
 auto testAggregate = [](std::vector<T> inputAsVector, U expectedResult,
                         bool distinct = false,
-                        source_location l = source_location::current()) {
+                        source_location l = AD_CURRENT_SOURCE_LOC()) {
   auto trace = generateLocationTrace(l);
   VectorWithMemoryLimit<T> input(inputAsVector.begin(), inputAsVector.end(),
                                  makeAllocator());
@@ -61,7 +61,7 @@ auto testAggregate = [](std::vector<T> inputAsVector, U expectedResult,
 template <typename AggregateExpressionT, typename T, typename U = T>
 auto testAggregateWithVariable =
     [](Variable input, U expectedResult, bool distinct = false,
-       source_location l = source_location::current()) {
+       source_location l = AD_CURRENT_SOURCE_LOC()) {
       auto trace = generateLocationTrace(l);
       auto d = std::make_unique<VariableExpression>(std::move(input));
       auto t = TestContext{};

--- a/test/BenchmarkMeasurementContainerTest.cpp
+++ b/test/BenchmarkMeasurementContainerTest.cpp
@@ -278,8 +278,7 @@ TEST(BenchmarkMeasurementContainerTest, ResultTableEraseRow) {
   auto singleEraseOperationTest =
       [&createTestTable, &checkForm, &testTableColumnNames](
           const size_t numRows, const size_t rowToDelete,
-          ad_utility::source_location l =
-              ad_utility::source_location::current()) {
+          ad_utility::source_location l = AD_CURRENT_SOURCE_LOC()) {
         // For generating better messages, when failing a test.
         auto trace{generateLocationTrace(l, "singleEraseOperationTest")};
         ResultTable table{createTestTable(numRows)};
@@ -336,11 +335,10 @@ TEST(BenchmarkMeasurementContainerTest, ResultGroupDeleteMember) {
   @param memberDeletionPoint The number of dummy members, that are added, before
   we add the member, that will be later deleted.
   */
-  auto singleDeleteTest = [&addDummyMembers](
-                              const size_t numMembers,
-                              const size_t memberDeletionPoint,
-                              ad_utility::source_location l =
-                                  ad_utility::source_location::current()) {
+  auto singleDeleteTest = [&addDummyMembers](const size_t numMembers,
+                                             const size_t memberDeletionPoint,
+                                             ad_utility::source_location l =
+                                                 AD_CURRENT_SOURCE_LOC()) {
     AD_CONTRACT_CHECK(memberDeletionPoint < numMembers);
     // For generating better messages, when failing a test.
     auto trace{generateLocationTrace(l, "singleDeleteTest")};

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -474,3 +474,5 @@ addLinkAndDiscoverTestSerial(QueryRewriteUtilTest engine)
 addLinkAndDiscoverTestSerial(HttpErrorTest engine)
 
 addLinkAndDiscoverTest(TimeTracerTest)
+
+addLinkAndDiscoverTestNoLibs(SourceLocationTest)

--- a/test/CancellationHandleTest.cpp
+++ b/test/CancellationHandleTest.cpp
@@ -23,7 +23,7 @@ using ::testing::HasSubstr;
 
 using namespace std::chrono_literals;
 
-ad_utility::source_location location = ad_utility::source_location::current();
+ad_utility::source_location location = AD_CURRENT_SOURCE_LOC();
 const int expectedLocationLine = __LINE__ - 1;
 const auto expectedLocation =
     absl::StrCat("CancellationHandleTest.cpp:", expectedLocationLine);

--- a/test/CheckUsePatternTrickTest.cpp
+++ b/test/CheckUsePatternTrickTest.cpp
@@ -30,7 +30,7 @@ ParsedQuery parseWhereClause(const std::string& whereClause) {
 auto expectContained = [](const std::string& whereClause,
                           const std::string& variable,
                           bool shouldBeContained = true,
-                          source_location l = source_location::current()) {
+                          source_location l = AD_CURRENT_SOURCE_LOC()) {
   auto trace = generateLocationTrace(l, "expectContained");
   auto pq = parseWhereClause(whereClause);
   bool b = isVariableContainedInGraphPattern(Variable{variable},
@@ -46,7 +46,7 @@ auto expectContained = [](const std::string& whereClause,
 // does not contain the `variable`.
 auto expectNotContained = [](const std::string& whereClause,
                              const std::string& variable,
-                             source_location l = source_location::current()) {
+                             source_location l = AD_CURRENT_SOURCE_LOC()) {
   auto trace = generateLocationTrace(l, "expectNotContained");
   expectContained(whereClause, variable, false);
 };
@@ -65,7 +65,7 @@ const SparqlTriple& getFirstTriple(const ParsedQuery& parsedQuery) {
 // Test that `whereClause`, when parsed as the WHERE clause of a SPARQL query,
 // contains the variables `?x`, `?y`, and `?z`, but not the variable `?not`.
 auto expectXYZContained(const std::string& whereClause,
-                        source_location l = source_location::current()) {
+                        source_location l = AD_CURRENT_SOURCE_LOC()) {
   auto trace = generateLocationTrace(l, "expectContained");
   expectContained(whereClause, "?x");
   expectContained(whereClause, "?y");
@@ -111,7 +111,7 @@ auto expectFirstTripleSuitableForPatternTrick =
            sparqlExpression::SparqlExpressionPimpl::VariableAndDistinctness>&
            countedVariable = std::nullopt,
        bool shouldBeSuitable = true,
-       source_location l = source_location::current()) {
+       source_location l = AD_CURRENT_SOURCE_LOC()) {
       auto trace =
           generateLocationTrace(l, "expectFirstTripleSuitableForPatternTrick");
       auto pq = SparqlParser::parseQuery(encodedIriManager(), query);
@@ -135,7 +135,7 @@ auto expectFirstTripleNotSuitableForPatternTrick =
        const std::optional<
            sparqlExpression::SparqlExpressionPimpl::VariableAndDistinctness>&
            countedVariable = std::nullopt,
-       source_location l = source_location::current()) {
+       source_location l = AD_CURRENT_SOURCE_LOC()) {
       auto trace = generateLocationTrace(l, "firstTripleNotSuitable");
       expectFirstTripleSuitableForPatternTrick(query, "", "", countedVariable,
                                                false);
@@ -196,7 +196,7 @@ TEST(CheckUsePatternTrick, isTripleSuitable) {
 auto expectQuerySuitableForPatternTrick =
     [](const std::string& query, const std::string& subjectVariable,
        const std::string& predicateVariable, bool shouldBeSuitable = true,
-       source_location l = source_location::current()) {
+       source_location l = AD_CURRENT_SOURCE_LOC()) {
       auto trace = generateLocationTrace(l, "expectQuerySuitable");
       auto pq = SparqlParser::parseQuery(encodedIriManager(), query);
       auto querySuitable = checkUsePatternTrick::checkUsePatternTrick(&pq);
@@ -212,8 +212,7 @@ auto expectQuerySuitableForPatternTrick =
 
 // Expect that the pattern trick cannot be applied to the given `query`.
 auto expectQueryNotSuitableForPatternTrick =
-    [](const std::string& query,
-       source_location l = source_location::current()) {
+    [](const std::string& query, source_location l = AD_CURRENT_SOURCE_LOC()) {
       auto trace = generateLocationTrace(l, "expectQueryNotSuitable");
       expectQuerySuitableForPatternTrick(query, "", "", false);
     };

--- a/test/CompressedRelationsTest.cpp
+++ b/test/CompressedRelationsTest.cpp
@@ -92,7 +92,7 @@ size_t getNumColumns(const std::vector<RelationInput>& vec) {
 // expected are converted to `Id`s of type `VocabIndex` using the `V`-function
 // before the comparison.
 void checkThatTablesAreEqual(const auto& expected, const IdTable& actual,
-                             source_location l = source_location::current()) {
+                             source_location l = AD_CURRENT_SOURCE_LOC()) {
   auto trace = generateLocationTrace(l);
 
   VectorTable exp;
@@ -495,7 +495,7 @@ TEST(CompressedRelationWriter, getFirstAndLastTriple) {
   auto testFirstAndLastBlock = [&](ScanSpecification spec, auto matcher,
                                    const LocatedTriplesPerBlock& =
                                        emptyLocatedTriples,
-                                   Loc loc = Loc::current()) {
+                                   Loc loc = AD_CURRENT_SOURCE_LOC()) {
     auto trace = generateLocationTrace(loc);
     auto firstAndLastTriple = readerPtr->getFirstAndLastTriple(
         {spec, blockMetadata}, emptyLocatedTriples);
@@ -549,7 +549,7 @@ TEST(CompressedRelationWriter, getFirstAndLastTripleWithUpdates) {
   // Test infrastructure.
   using Loc = ad_utility::source_location;
   auto testFirstAndLastBlock = [&](ScanSpecification spec, auto matcher,
-                                   Loc loc = Loc::current()) {
+                                   Loc loc = AD_CURRENT_SOURCE_LOC()) {
     auto trace = generateLocationTrace(loc);
     auto blockMetadata =
         getBlockMetadataRangesfromVec(locatedTriples.getAugmentedMetadata());
@@ -727,7 +727,7 @@ TEST(CompressedRelationReader, getBlocksForJoinWithColumn) {
                   const std::vector<Id>& joinColumn,
                   const std::vector<CompressedBlockMetadata>& expectedBlocks,
                   size_t numHandledBlocksExpected,
-                  source_location l = source_location::current()) {
+                  source_location l = AD_CURRENT_SOURCE_LOC()) {
     auto t = generateLocationTrace(l);
     auto [result, numHandledBlocks] =
         CompressedRelationReader::getBlocksForJoin(joinColumn,
@@ -830,7 +830,7 @@ TEST(CompressedRelationReader, getBlocksForJoin) {
   auto test = [&metadataAndBlocks, &metadataAndBlocksB](
                   const std::array<std::vector<CompressedBlockMetadata>, 2>&
                       expectedBlocks,
-                  source_location l = source_location::current()) {
+                  source_location l = AD_CURRENT_SOURCE_LOC()) {
     auto t = generateLocationTrace(l);
     auto result = CompressedRelationReader::getBlocksForJoin(
         *metadataAndBlocks, *metadataAndBlocksB);
@@ -988,7 +988,7 @@ TEST(CompressedRelationReader, getResultSizeImpl) {
                                const ScanSpecification& scanSpec, size_t lower,
                                size_t upper, size_t exact,
                                ad_utility::source_location sourceLocation =
-                                   ad_utility::source_location::current()) {
+                                   AD_CURRENT_SOURCE_LOC()) {
     auto loc = generateLocationTrace(sourceLocation);
     auto& perm = impl.getPermutation(p);
     auto& reader = perm.reader();

--- a/test/ConcurrentCacheTest.cpp
+++ b/test/ConcurrentCacheTest.cpp
@@ -497,8 +497,7 @@ TEST(ConcurrentCache, testTryInsertIfNotPresentDoesWorkCorrectly) {
 
   auto expectContainsSingleElementAtKey0 =
       [&](bool pinned, std::string expected,
-          ad_utility::source_location l =
-              ad_utility::source_location::current()) {
+          ad_utility::source_location l = AD_CURRENT_SOURCE_LOC()) {
         using namespace ::testing;
         auto trace = generateLocationTrace(l);
         auto value = cache.getIfContained(0);

--- a/test/ConfigManagerTest.cpp
+++ b/test/ConfigManagerTest.cpp
@@ -1632,9 +1632,8 @@ well as adding, of a new validator function.
 @param l For better error messages, when the tests fail.
 */
 template <typename F>
-void doValidatorTest(
-    F addValidatorFunction,
-    ad_utility::source_location l = ad_utility::source_location::current()) {
+void doValidatorTest(F addValidatorFunction,
+                     ad_utility::source_location l = AD_CURRENT_SOURCE_LOC()) {
   // For generating better messages, when failing a test.
   auto trace{generateLocationTrace(l, "doValidatorTest")};
 
@@ -1883,7 +1882,7 @@ ConstConfigOptionProxy... validatorArguments)`.
 template <typename F>
 void doValidatorExceptionTest(
     F addAlwaysValidValidatorFunction,
-    ad_utility::source_location l = ad_utility::source_location::current()) {
+    ad_utility::source_location l = AD_CURRENT_SOURCE_LOC()) {
   // For generating better messages, when failing a test.
   auto trace{generateLocationTrace(l, "doValidatorExceptionTest")};
 
@@ -1923,7 +1922,7 @@ validatorExceptionMessage, ConfigManager& m, ConstConfigOptionProxy...)`.
 template <typename F>
 void doAddOptionValidatorTest(
     F addNonExceptionValidatorFunction,
-    ad_utility::source_location l = ad_utility::source_location::current()) {
+    ad_utility::source_location l = AD_CURRENT_SOURCE_LOC()) {
   // For generating better messages, when failing a test.
   auto trace{generateLocationTrace(l, "doAddOptionValidatorTest")};
 
@@ -2097,7 +2096,7 @@ ConstConfigOptionProxy... validatorArguments)`.
 template <typename F>
 void doAddOptionValidatorExceptionTest(
     F addAlwaysValidValidatorFunction,
-    ad_utility::source_location l = ad_utility::source_location::current()) {
+    ad_utility::source_location l = AD_CURRENT_SOURCE_LOC()) {
   // For generating better messages, when failing a test.
   auto trace{generateLocationTrace(l, "doValidatorExceptionTest")};
 
@@ -2371,7 +2370,7 @@ TEST(ConfigManagerTest, ValidatorsSorting) {
   auto checkOrder = [](const ConfigManager& manager,
                        const ConfigOptionsAndValidatorsOrder& order,
                        ad_utility::source_location l =
-                           ad_utility::source_location::current()) {
+                           AD_CURRENT_SOURCE_LOC()) {
     // For generating better messages, when failing a test.
     auto trace{generateLocationTrace(l, "checkOrder")};
 
@@ -2518,8 +2517,7 @@ TEST(ConfigManagerTest, ConfigurationDocValidatorAssignment) {
   auto testPairVector =
       [](const ConfigManager::ConfigurationDocValidatorAssignment& assignment,
          const auto& pairVector,
-         ad_utility::source_location l =
-             ad_utility::source_location::current()) {
+         ad_utility::source_location l = AD_CURRENT_SOURCE_LOC()) {
         // For generating better messages, when failing a test.
         auto trace{generateLocationTrace(l, "testPairVector")};
         ql::ranges::for_each(pairVector, [&assignment](const auto& pair) {
@@ -2685,15 +2683,14 @@ struct AddOptionsAndValidatorToConfigManager {
 // A simple hard coded comparison test.
 TEST(ConfigManagerTest, PrintConfigurationDocComparison) {
   // For comparing strings.
-  auto assertStringEqual = [](const std::string_view a,
-                              const std::string_view b,
-                              ad_utility::source_location l =
-                                  ad_utility::source_location::current()) {
-    // For generating better messages, when failing a test.
-    auto trace{generateLocationTrace(l, "assertStringEqual")};
+  auto assertStringEqual =
+      [](const std::string_view a, const std::string_view b,
+         ad_utility::source_location l = AD_CURRENT_SOURCE_LOC()) {
+        // For generating better messages, when failing a test.
+        auto trace{generateLocationTrace(l, "assertStringEqual")};
 
-    ASSERT_STREQ(a.data(), b.data());
-  };
+        ASSERT_STREQ(a.data(), b.data());
+      };
 
   // Empty config manager.
   assertStringEqual(emptyConfigManagerExpectedString,

--- a/test/ConstexprUtilsTest.cpp
+++ b/test/ConstexprUtilsTest.cpp
@@ -236,7 +236,7 @@ parameter pack and a lambda function argument, which it passes to a
 template <typename F>
 void testConstExprForEachNormalCall(
     const F& callToForEachWrapper, auto callToTypeToStringFactory,
-    ad_utility::source_location l = ad_utility::source_location::current()) {
+    ad_utility::source_location l = AD_CURRENT_SOURCE_LOC()) {
   // For generating better messages, when failing a test.
   auto trace{generateLocationTrace(l, "testConstExprForEachNormalCall")};
 

--- a/test/DateYearDurationTest.cpp
+++ b/test/DateYearDurationTest.cpp
@@ -324,7 +324,7 @@ auto testDatetime(std::string_view input, int year, int month, int day,
 // Specialization of `testDatetimeImpl` for parsing `xsd:date`.
 auto testDate(std::string_view input, int year, int month, int day,
               Date::TimeZone timeZone = 0,
-              source_location l = source_location::current()) {
+              source_location l = AD_CURRENT_SOURCE_LOC()) {
   auto t = generateLocationTrace(l);
   return testDatetimeImpl(DateYearOrDuration::parseXsdDate, input,
                           XSD_DATE_TYPE, year, month, day, -1, 0, 0, timeZone);
@@ -332,7 +332,7 @@ auto testDate(std::string_view input, int year, int month, int day,
 
 // Specialization of `testDatetimeImpl` for parsing `xsd:gYear`.
 auto testYear(std::string_view input, int year, Date::TimeZone timeZone = 0,
-              source_location l = source_location::current()) {
+              source_location l = AD_CURRENT_SOURCE_LOC()) {
   auto t = generateLocationTrace(l);
   return testDatetimeImpl(DateYearOrDuration::parseGYear, input, XSD_GYEAR_TYPE,
                           year, 0, 0, -1, 0, 0, timeZone);
@@ -341,7 +341,7 @@ auto testYear(std::string_view input, int year, Date::TimeZone timeZone = 0,
 // Specialization of `testDatetimeImpl` for parsing `xsd:gYearMonth`.
 auto testYearMonth(std::string_view input, int year, int month,
                    Date::TimeZone timeZone = 0,
-                   source_location l = source_location::current()) {
+                   source_location l = AD_CURRENT_SOURCE_LOC()) {
   auto t = generateLocationTrace(l);
   return testDatetimeImpl(DateYearOrDuration::parseGYearMonth, input,
                           XSD_GYEARMONTH_TYPE, year, month, 0, -1, 0, 0,

--- a/test/ExceptionTest.cpp
+++ b/test/ExceptionTest.cpp
@@ -13,8 +13,7 @@ using namespace ad_utility;
 
 namespace {
 auto makeMatcher = [](const std::string& condition,
-                      ad_utility::source_location l =
-                          ad_utility::source_location::current()) {
+                      ad_utility::source_location l = AD_CURRENT_SOURCE_LOC()) {
   using namespace ::testing;
   auto line = l.line();
   auto e = [](size_t l) { return EndsWith(std::to_string(l)); };
@@ -38,7 +37,7 @@ TEST(Exception, AbortException) {
 }
 
 TEST(Exception, Exception) {
-  ad_utility::source_location l = ad_utility::source_location::current();
+  ad_utility::source_location l = AD_CURRENT_SOURCE_LOC();
   Exception e{"exceptionE"};
   ASSERT_THAT(e.what(), ::testing::StartsWith("exceptionE"));
   ASSERT_THAT(e.what(), ::testing::EndsWith(std::to_string(l.line() + 1)));
@@ -48,7 +47,7 @@ TEST(Exception, Exception) {
 TEST(Exception, AD_THROW) {
   ad_utility::source_location l;
   try {
-    l = ad_utility::source_location::current();
+    l = AD_CURRENT_SOURCE_LOC();
     AD_THROW("anError");
     FAIL() << "No exception was thrown, but one was expected";
   } catch (const Exception& e) {

--- a/test/ExecuteUpdateTest.cpp
+++ b/test/ExecuteUpdateTest.cpp
@@ -68,7 +68,7 @@ TEST(ExecuteUpdate, executeUpdate) {
       [&expectExecuteUpdateHelper, &indexConfig](
           const std::string& update,
           const testing::Matcher<const DeltaTriples&>& deltaTriplesMatcher,
-          source_location sourceLocation = source_location::current()) {
+          source_location sourceLocation = AD_CURRENT_SOURCE_LOC()) {
         auto l = generateLocationTrace(sourceLocation);
         Index index = ad_utility::testing::makeTestIndex(
             "ExecuteUpdate_executeUpdate", indexConfig);
@@ -90,7 +90,7 @@ TEST(ExecuteUpdate, executeUpdate) {
       [&expectExecuteUpdateHelper](
           Index& index, const std::string& update,
           const testing::Matcher<const std::string&>& messageMatcher,
-          source_location sourceLocation = source_location::current()) {
+          source_location sourceLocation = AD_CURRENT_SOURCE_LOC()) {
         auto l = generateLocationTrace(sourceLocation);
         QueryResultCache cache = QueryResultCache();
         NamedResultCache namedResultCache;
@@ -107,7 +107,7 @@ TEST(ExecuteUpdate, executeUpdate) {
         [&expectExecuteUpdateFails_](
             const std::string& update,
             const testing::Matcher<const std::string&>& messageMatcher,
-            source_location sourceLocation = source_location::current()) {
+            source_location sourceLocation = AD_CURRENT_SOURCE_LOC()) {
           Index index = ad_utility::testing::makeTestIndex(
               "ExecuteUpdate_executeUpdate",
               ad_utility::testing::TestIndexConfig());
@@ -252,7 +252,7 @@ TEST(ExecuteUpdate, computeGraphUpdateQuads) {
               toInsertMatchers,
           std::vector<Matcher<const std::vector<::IdTriple<>>&>>
               toDeleteMatchers,
-          source_location sourceLocation = source_location::current()) {
+          source_location sourceLocation = AD_CURRENT_SOURCE_LOC()) {
         auto l = generateLocationTrace(sourceLocation);
         ASSERT_THAT(toInsertMatchers, testing::SizeIs(toDeleteMatchers.size()));
         auto graphUpdateQuads = executeComputeGraphUpdateQuads(update);
@@ -278,7 +278,7 @@ TEST(ExecuteUpdate, computeGraphUpdateQuads) {
       [&executeComputeGraphUpdateQuads](
           const std::string& update,
           const Matcher<const std::string&>& messageMatcher,
-          source_location sourceLocation = source_location::current()) {
+          source_location sourceLocation = AD_CURRENT_SOURCE_LOC()) {
         auto l = generateLocationTrace(sourceLocation);
         AD_EXPECT_THROW_WITH_MESSAGE(executeComputeGraphUpdateQuads(update),
                                      messageMatcher);
@@ -588,7 +588,7 @@ TEST(ExecuteUpdate, computeAndAddQuadsForResultRow) {
 TEST(ExecuteUpdate, sortAndRemoveDuplicates) {
   auto expect = [](std::vector<IdTriple<>> input,
                    const std::vector<IdTriple<>>& expected,
-                   source_location l = source_location::current()) {
+                   source_location l = AD_CURRENT_SOURCE_LOC()) {
     auto trace = generateLocationTrace(l);
     ExecuteUpdate::sortAndRemoveDuplicates(input);
     EXPECT_THAT(input, testing::ElementsAreArray(expected));
@@ -610,7 +610,7 @@ TEST(ExecuteUpdate, sortAndRemoveDuplicates) {
 TEST(ExecuteUpdate, setMinus) {
   auto expect = [](std::vector<IdTriple<>> a, std::vector<IdTriple<>> b,
                    const std::vector<IdTriple<>>& expected,
-                   source_location l = source_location::current()) {
+                   source_location l = AD_CURRENT_SOURCE_LOC()) {
     auto trace = generateLocationTrace(l);
     EXPECT_THAT(ExecuteUpdate::setMinus(a, b),
                 testing::ElementsAreArray(expected));

--- a/test/ExportQueryExecutionTreesTest.cpp
+++ b/test/ExportQueryExecutionTreesTest.cpp
@@ -138,7 +138,7 @@ struct TestCaseConstructQuery {
 // Run a single test case for a SELECT query.
 void runSelectQueryTestCase(
     const TestCaseSelectQuery& testCase, bool useTextIndex = false,
-    ad_utility::source_location l = ad_utility::source_location::current()) {
+    ad_utility::source_location l = AD_CURRENT_SOURCE_LOC()) {
   auto trace = generateLocationTrace(l, "runSelectQueryTestCase");
   using enum ad_utility::MediaType;
   EXPECT_EQ(
@@ -180,7 +180,7 @@ void runSelectQueryTestCase(
 // Run a single test case for a CONSTRUCT query.
 void runConstructQueryTestCase(
     const TestCaseConstructQuery& testCase,
-    ad_utility::source_location l = ad_utility::source_location::current()) {
+    ad_utility::source_location l = AD_CURRENT_SOURCE_LOC()) {
   auto trace = generateLocationTrace(l, "runConstructQueryTestCase");
   using enum ad_utility::MediaType;
   EXPECT_EQ(runQueryStreamableResult(testCase.kg, testCase.query, tsv),
@@ -211,7 +211,7 @@ void runConstructQueryTestCase(
 // Run a single test case for an ASK query.
 void runAskQueryTestCase(
     const TestCaseAskQuery& testCase,
-    ad_utility::source_location l = ad_utility::source_location::current()) {
+    ad_utility::source_location l = AD_CURRENT_SOURCE_LOC()) {
   auto trace = generateLocationTrace(l, "runAskQueryTestCase");
   using enum ad_utility::MediaType;
   // TODO<joka921> match the exception

--- a/test/FindUndefRangesTest.cpp
+++ b/test/FindUndefRangesTest.cpp
@@ -44,7 +44,7 @@ template <size_t I>
 void testSmallerUndefRangesForArbitraryRows(
     Arr<I> row, const std::vector<Arr<I>>& range,
     const std::vector<size_t>& expectedPositions,
-    source_location l = source_location::current()) {
+    source_location l = AD_CURRENT_SOURCE_LOC()) {
   auto t = generateLocationTrace(l);
   // TODO<joka921> also actually test the bool;
   [[maybe_unused]] bool outOfOrder;
@@ -64,7 +64,7 @@ template <size_t I>
 void testSmallerUndefRangesForRowsWithoutUndef(
     Arr<I> row, const std::vector<Arr<I>>& range,
     const std::vector<size_t>& positions,
-    source_location l = source_location::current()) {
+    source_location l = AD_CURRENT_SOURCE_LOC()) {
   auto t = generateLocationTrace(l);
   ASSERT_TRUE(ql::ranges::is_sorted(range));
   std::vector<int64_t> foundPositions;
@@ -112,7 +112,7 @@ template <size_t I>
 void testSmallerUndefRangesForRowsWithUndefInLastColumns(
     Arr<I> row, const std::vector<Arr<I>>& range, size_t numLastUndef,
     const std::vector<size_t>& positions,
-    source_location l = source_location::current()) {
+    source_location l = AD_CURRENT_SOURCE_LOC()) {
   auto t = generateLocationTrace(l);
   ASSERT_TRUE(ql::ranges::is_sorted(range));
   std::vector<int64_t> foundPositions;

--- a/test/GeoSparqlHelpersTest.cpp
+++ b/test/GeoSparqlHelpersTest.cpp
@@ -160,7 +160,7 @@ TEST(GeoSparqlHelpers, IriToUnit) {
 // _____________________________________________________________________________
 template <SpatialJoinType SJType>
 void checkGeoRelationDummyImpl(
-    source_location sourceLocation = source_location::current()) {
+    source_location sourceLocation = AD_CURRENT_SOURCE_LOC()) {
   auto l = generateLocationTrace(sourceLocation);
   const auto geoRelationFunction = WktGeometricRelation<SJType>();
   AD_EXPECT_THROW_WITH_MESSAGE(

--- a/test/GeometryInfoTestHelpers.h
+++ b/test/GeometryInfoTestHelpers.h
@@ -21,7 +21,7 @@ using Loc = source_location;
 
 // ____________________________________________________________________________
 inline void checkCentroid(std::optional<Centroid> a, std::optional<Centroid> b,
-                          Loc sourceLocation = Loc::current()) {
+                          Loc sourceLocation = AD_CURRENT_SOURCE_LOC()) {
   auto l = generateLocationTrace(sourceLocation);
   ASSERT_EQ(a.has_value(), b.has_value());
   if (!a.has_value()) {
@@ -36,7 +36,7 @@ inline void checkCentroid(std::optional<Centroid> a, std::optional<Centroid> b,
 // ____________________________________________________________________________
 inline void checkBoundingBox(std::optional<BoundingBox> a,
                              std::optional<BoundingBox> b,
-                             Loc sourceLocation = Loc::current()) {
+                             Loc sourceLocation = AD_CURRENT_SOURCE_LOC()) {
   auto l = generateLocationTrace(sourceLocation);
   ASSERT_EQ(a.has_value(), b.has_value());
   if (!a.has_value()) {
@@ -53,7 +53,7 @@ inline void checkBoundingBox(std::optional<BoundingBox> a,
 // ____________________________________________________________________________
 inline void checkGeoInfo(std::optional<GeometryInfo> actual,
                          std::optional<GeometryInfo> expected,
-                         Loc sourceLocation = Loc::current()) {
+                         Loc sourceLocation = AD_CURRENT_SOURCE_LOC()) {
   auto l = generateLocationTrace(sourceLocation);
   ASSERT_EQ(actual.has_value(), expected.has_value());
   if (!actual.has_value() || !expected.has_value()) {
@@ -73,7 +73,7 @@ inline void checkGeoInfo(std::optional<GeometryInfo> actual,
 // ____________________________________________________________________________
 inline void checkRequestedInfoForInstance(
     std::optional<GeometryInfo> optGeoInfo,
-    Loc sourceLocation = Loc::current()) {
+    Loc sourceLocation = AD_CURRENT_SOURCE_LOC()) {
   ASSERT_TRUE(optGeoInfo.has_value());
   auto gi = optGeoInfo.value();
   auto l = generateLocationTrace(sourceLocation);
@@ -88,7 +88,7 @@ inline void checkRequestedInfoForInstance(
 
 // ____________________________________________________________________________
 inline void checkRequestedInfoForWktLiteral(
-    const std::string_view& wkt, Loc sourceLocation = Loc::current()) {
+    const std::string_view& wkt, Loc sourceLocation = AD_CURRENT_SOURCE_LOC()) {
   auto l = generateLocationTrace(sourceLocation);
   auto optGeoInfo = GeometryInfo::fromWktLiteral(wkt);
   ASSERT_TRUE(optGeoInfo.has_value());
@@ -105,7 +105,7 @@ inline void checkRequestedInfoForWktLiteral(
 // ____________________________________________________________________________
 inline void checkInvalidLiteral(std::string_view wkt,
                                 bool expectValidGeometryType = false,
-                                Loc sourceLocation = Loc::current()) {
+                                Loc sourceLocation = AD_CURRENT_SOURCE_LOC()) {
   auto l = generateLocationTrace(sourceLocation);
 
   EXPECT_FALSE(GeometryInfo::fromWktLiteral(wkt).has_value());
@@ -122,7 +122,7 @@ inline void checkInvalidLiteral(std::string_view wkt,
 
 // ____________________________________________________________________________
 inline void checkUtilBoundingBox(util::geo::DBox a, util::geo::DBox b,
-                                 Loc sourceLocation = Loc::current()) {
+                                 Loc sourceLocation = AD_CURRENT_SOURCE_LOC()) {
   auto l = generateLocationTrace(sourceLocation);
   ASSERT_NEAR(a.getLowerLeft().getX(), b.getLowerLeft().getX(), 0.001);
   ASSERT_NEAR(a.getLowerLeft().getY(), b.getLowerLeft().getY(), 0.001);

--- a/test/GraphStoreProtocolTest.cpp
+++ b/test/GraphStoreProtocolTest.cpp
@@ -116,8 +116,7 @@ TEST(GraphStoreProtocolTest, transformGet) {
   auto expectTransformGet =
       [](const GraphOrDefault& graph,
          const testing::Matcher<const ParsedQuery&>& matcher,
-         ad_utility::source_location l =
-             ad_utility::source_location::current()) {
+         ad_utility::source_location l = AD_CURRENT_SOURCE_LOC()) {
         auto trace = generateLocationTrace(l);
         EXPECT_THAT(
             GraphStoreProtocol::transformGet(graph, encodedIriManager()),
@@ -144,7 +143,7 @@ TEST(GraphStoreProtocolTest, transformPut) {
   auto expectTransformPut = CPP_template_lambda(&index)(typename RequestT)(
       const RequestT& request, const GraphOrDefault& graph,
       const testing::Matcher<std::vector<ParsedQuery>>& matcher,
-      ad_utility::source_location l = ad_utility::source_location::current())(
+      ad_utility::source_location l = AD_CURRENT_SOURCE_LOC())(
       requires ad_utility::httpUtils::HttpRequest<RequestT>) {
     auto trace = generateLocationTrace(l);
     EXPECT_THAT(GraphStoreProtocol::transformPut(request, graph, index),
@@ -210,8 +209,7 @@ TEST(GraphStoreProtocolTest, transformDelete) {
   auto expectTransformDelete =
       [&index](const GraphOrDefault& graph,
                const testing::Matcher<const ParsedQuery&>& matcher,
-               ad_utility::source_location l =
-                   ad_utility::source_location::current()) {
+               ad_utility::source_location l = AD_CURRENT_SOURCE_LOC()) {
         auto trace = generateLocationTrace(l);
         EXPECT_THAT(GraphStoreProtocol::transformDelete(graph, index), matcher);
       };
@@ -270,19 +268,18 @@ TEST(GraphStoreProtocolTest, transformGraphStoreProtocol) {
           m::UpdateClause(m::GraphUpdate({}, {{iri("<a>"), iri("<b>"),
                                                iri("<c>"), iri("<foo>")}}),
                           m::GraphPattern())));
-  auto expectUnsupportedMethod =
-      [&index](const http::verb method,
-               ad_utility::source_location l =
-                   ad_utility::source_location::current()) {
-        auto trace = generateLocationTrace(l);
-        AD_EXPECT_THROW_WITH_MESSAGE(
-            GraphStoreProtocol::transformGraphStoreProtocol(
-                GraphStoreOperation{DEFAULT{}},
-                ad_utility::testing::makeRequest(method, "/?default"), index),
-            testing::HasSubstr(
-                absl::StrCat(std::string{boost::beast::http::to_string(method)},
-                             " in the SPARQL Graph Store HTTP Protocol")));
-      };
+  auto expectUnsupportedMethod = [&index](const http::verb method,
+                                          ad_utility::source_location l =
+                                              AD_CURRENT_SOURCE_LOC()) {
+    auto trace = generateLocationTrace(l);
+    AD_EXPECT_THROW_WITH_MESSAGE(
+        GraphStoreProtocol::transformGraphStoreProtocol(
+            GraphStoreOperation{DEFAULT{}},
+            ad_utility::testing::makeRequest(method, "/?default"), index),
+        testing::HasSubstr(
+            absl::StrCat(std::string{boost::beast::http::to_string(method)},
+                         " in the SPARQL Graph Store HTTP Protocol")));
+  };
   expectUnsupportedMethod(http::verb::head);
   expectUnsupportedMethod(http::verb::patch);
   AD_EXPECT_THROW_WITH_MESSAGE(
@@ -372,8 +369,7 @@ TEST(GraphStoreProtocolTest, convertTriples) {
   auto expectConvert =
       [&bn](const GraphOrDefault& graph, std::vector<TurtleTriple>&& triples,
             const std::vector<SparqlTripleSimpleWithGraph>& expectedTriples,
-            ad_utility::source_location l =
-                ad_utility::source_location::current()) {
+            ad_utility::source_location l = AD_CURRENT_SOURCE_LOC()) {
         auto trace = generateLocationTrace(l);
         auto convertedTriples =
             GraphStoreProtocol::convertTriples(graph, std::move(triples), bn);
@@ -436,7 +432,7 @@ TEST(GraphStoreProtocolTest, EncodedIriManagerUsage) {
   auto expectTransformPost = CPP_template_lambda(&index)(typename RequestT)(
       const RequestT& request, const GraphOrDefault& graph,
       const testing::Matcher<const ParsedQuery&>& matcher,
-      ad_utility::source_location l = ad_utility::source_location::current())(
+      ad_utility::source_location l = AD_CURRENT_SOURCE_LOC())(
       requires ad_utility::httpUtils::HttpRequest<RequestT>) {
     auto trace = generateLocationTrace(l);
     EXPECT_THAT(GraphStoreProtocol::transformPost(request, graph, index),

--- a/test/GroupByTest.cpp
+++ b/test/GroupByTest.cpp
@@ -1737,7 +1737,7 @@ TEST_F(GroupByOptimizations, computeGroupByForJoinWithFullScan) {
   using ad_utility::source_location;
   auto testWithBothInterfaces = [&](bool chooseInterface,
                                     source_location l =
-                                        source_location::current()) {
+                                        AD_CURRENT_SOURCE_LOC()) {
     auto trace = generateLocationTrace(l);
     auto getId = makeGetId(qec->getIndex());
     Id idOfX = getId("<x>");
@@ -2429,8 +2429,7 @@ class GroupByLazyFixture : public ::testing::TestWithParam<bool> {
   template <size_t N>
   static void expectReturningIdTables(
       GroupBy& groupBy, const std::array<IdTable, N>& idTables,
-      ad_utility::source_location sourceLocation =
-          ad_utility::source_location::current()) {
+      ad_utility::source_location sourceLocation = AD_CURRENT_SOURCE_LOC()) {
     auto l = generateLocationTrace(sourceLocation);
     bool lazyResult = GetParam();
     auto result = groupBy.computeResultOnlyForTesting(lazyResult);

--- a/test/IndexTest.cpp
+++ b/test/IndexTest.cpp
@@ -54,8 +54,7 @@ auto makeTestScanWidthOne = [](const IndexImpl& index,
       [&index, &qec](const TripleComponent& c0, const TripleComponent& c1,
                      Permutation::Enum permutation, const VectorTable& expected,
                      Permutation::ColumnIndices additionalColumns = {},
-                     ad_utility::source_location l =
-                         ad_utility::source_location::current()) {
+                     ad_utility::source_location l = AD_CURRENT_SOURCE_LOC()) {
         auto t = generateLocationTrace(l);
         IdTable result =
             index.scan({c0, c1, std::nullopt}, permutation, additionalColumns,
@@ -74,8 +73,7 @@ auto makeTestScanWidthTwo = [](const IndexImpl& index,
   return
       [&index, &qec](const TripleComponent& c0, Permutation::Enum permutation,
                      const VectorTable& expected,
-                     ad_utility::source_location l =
-                         ad_utility::source_location::current()) {
+                     ad_utility::source_location l = AD_CURRENT_SOURCE_LOC()) {
         auto t = generateLocationTrace(l);
         IdTable wol =
             index.scan({c0, std::nullopt, std::nullopt}, permutation,

--- a/test/JoinAlgorithmsTest.cpp
+++ b/test/JoinAlgorithmsTest.cpp
@@ -68,7 +68,7 @@ using ad_utility::source_location;
 // more test cases automatically.
 template <bool DoOptionalJoin = false>
 void testJoin(const NestedBlock& a, const NestedBlock& b, JoinResult expected,
-              source_location l = source_location::current()) {
+              source_location l = AD_CURRENT_SOURCE_LOC()) {
   auto trace = generateLocationTrace(l);
   JoinResult result;
   auto compare = [](auto l, auto r) { return l[0] < r[0]; };
@@ -104,7 +104,7 @@ void testJoin(const NestedBlock& a, const NestedBlock& b, JoinResult expected,
 }
 void testOptionalJoin(const NestedBlock& a, const NestedBlock& b,
                       JoinResult expected,
-                      source_location l = source_location::current()) {
+                      source_location l = AD_CURRENT_SOURCE_LOC()) {
   testJoin<true>(a, b, std::move(expected), l);
 }
 }  // namespace
@@ -346,7 +346,7 @@ struct RowAdderWithUndef {
 void testDynamicJoinWithUndef(const std::vector<std::vector<FakeId>>& a,
                               const std::vector<std::vector<FakeId>>& b,
                               std::vector<std::array<FakeId, 2>> expected,
-                              source_location l = source_location::current()) {
+                              source_location l = AD_CURRENT_SOURCE_LOC()) {
   using namespace std::placeholders;
   using namespace std::ranges;
   auto trace = generateLocationTrace(l);

--- a/test/JsonUtilTest.cpp
+++ b/test/JsonUtilTest.cpp
@@ -16,10 +16,9 @@
 */
 CPP_template(typename WantedJsonClassType)(
     requires OrderedOrUnorderedJson<
-        WantedJsonClassType>) static void doFileToJsonTest(ad_utility::source_location
-                                                               l = ad_utility::
-                                                                   source_location::
-                                                                       current()) {
+        WantedJsonClassType>) static void doFileToJsonTest(ad_utility::
+                                                               source_location l =
+                                                                   AD_CURRENT_SOURCE_LOC()) {
   // For generating better messages, when failing a test.
   auto trace{generateLocationTrace(l, "doFileToJsonTest")};
 

--- a/test/LanguageExpressionsTest.cpp
+++ b/test/LanguageExpressionsTest.cpp
@@ -136,8 +136,7 @@ auto litOrIri = [](const std::string& literal) {
 auto assertLangTagValueGetter =
     [](const std::vector<Id>& input, const std::vector<strOpt>& expected,
        LanguageTagGetter& langTagValueGetter, TestContext& testContext,
-       ad_utility::source_location loc =
-           ad_utility::source_location::current()) {
+       ad_utility::source_location loc = AD_CURRENT_SOURCE_LOC()) {
       auto trace = generateLocationTrace(loc);
       EXPECT_EQ(input.size(), expected.size());
       auto ctx = &testContext.context;

--- a/test/LoadTest.cpp
+++ b/test/LoadTest.cpp
@@ -47,7 +47,7 @@ class LoadTest : public ::testing::Test {
          std::string contentType = "text/turtle",
          std::exception_ptr mockException = nullptr,
          ad_utility::source_location loc =
-             ad_utility::source_location::current()) -> SendRequestType {
+             AD_CURRENT_SOURCE_LOC()) -> SendRequestType {
     httpClientTestHelpers::RequestMatchers matchers{
         .method_ = testing::Eq(boost::beast::http::verb::get),
         .postData_ = testing::Eq(""),
@@ -85,10 +85,9 @@ TEST_F(LoadTest, computeResult) {
   auto testSilentBehavior = [this](parsedQuery::Load pq,
                                    SendRequestType sendFunc,
                                    ad_utility::source_location loc =
-                                       ad_utility::source_location::current()) {
-    auto impl = [this, &pq,
-                 &sendFunc](ad_utility::source_location loc =
-                                ad_utility::source_location::current()) {
+                                       AD_CURRENT_SOURCE_LOC()) {
+    auto impl = [this, &pq, &sendFunc](ad_utility::source_location loc =
+                                           AD_CURRENT_SOURCE_LOC()) {
       auto tr = generateLocationTrace(loc);
       Load load{testQec, pq, sendFunc};
       auto res = load.computeResultOnlyForTesting();
@@ -113,8 +112,7 @@ TEST_F(LoadTest, computeResult) {
       [this, testSilentBehavior](
           parsedQuery::Load pq, SendRequestType sendFunc,
           const testing::Matcher<std::string>& expectedError,
-          ad_utility::source_location loc =
-              ad_utility::source_location::current()) {
+          ad_utility::source_location loc = AD_CURRENT_SOURCE_LOC()) {
         auto g = generateLocationTrace(loc);
         Load load{testQec, pq, sendFunc};
 
@@ -125,8 +123,7 @@ TEST_F(LoadTest, computeResult) {
   auto expectThrowAlways =
       [this](parsedQuery::Load pq, SendRequestType sendFunc,
              const testing::Matcher<std::string>& expectedError,
-             ad_utility::source_location loc =
-                 ad_utility::source_location::current()) {
+             ad_utility::source_location loc = AD_CURRENT_SOURCE_LOC()) {
         auto g = generateLocationTrace(loc);
         Load load{testQec, pq, sendFunc};
 
@@ -140,8 +137,7 @@ TEST_F(LoadTest, computeResult) {
   auto expectLoad =
       [this](std::string responseBody, std::string contentType,
              std::vector<std::array<TripleComponent, 3>> expectedIdTable,
-             ad_utility::source_location loc =
-                 ad_utility::source_location::current()) {
+             ad_utility::source_location loc = AD_CURRENT_SOURCE_LOC()) {
         auto g = generateLocationTrace(loc);
 
         Load load{

--- a/test/LocalVocabTest.cpp
+++ b/test/LocalVocabTest.cpp
@@ -215,8 +215,7 @@ TEST(LocalVocab, propagation) {
   auto checkLocalVocab =
       [&](Operation& operation,
           const std::vector<std::string>& expectedWordsAsStrings,
-          ad_utility::source_location loc =
-              ad_utility::source_location::current()) -> void {
+          ad_utility::source_location loc = AD_CURRENT_SOURCE_LOC()) -> void {
     auto t = generateLocationTrace(loc);
     TestWords expectedWords;
     auto toLitOrIri = [](const auto& word) {

--- a/test/MemorySizeTest.cpp
+++ b/test/MemorySizeTest.cpp
@@ -80,7 +80,7 @@ Checks all the getters of the class with the wanted memory sizes.
 */
 void checkAllMemorySizeGetter(
     const ad_utility::MemorySize& m, const AllMemoryUnitSizes& ms,
-    ad_utility::source_location l = ad_utility::source_location::current()) {
+    ad_utility::source_location l = AD_CURRENT_SOURCE_LOC()) {
   auto trace{generateLocationTrace(l)};
 
   ASSERT_EQ(m.getBytes(), ms.bytes);

--- a/test/MinusTest.cpp
+++ b/test/MinusTest.cpp
@@ -28,8 +28,7 @@ void testMinus(std::vector<IdTable> leftTables,
                std::vector<IdTable> rightTables,
                const std::vector<IdTable>& expectedResult,
                bool singleVar = false,
-               ad_utility::source_location location =
-                   ad_utility::source_location::current()) {
+               ad_utility::source_location location = AD_CURRENT_SOURCE_LOC()) {
   auto g = generateLocationTrace(location);
   auto qec = ad_utility::testing::getQec();
 

--- a/test/MultiColumnJoinTest.cpp
+++ b/test/MultiColumnJoinTest.cpp
@@ -147,21 +147,20 @@ TEST(MultiColumnJoin, columnOriginatesFromGraphOrUndef) {
                SparqlTripleSimple{Variable{"?a"}, Iri::fromIriref("<b>"),
                                   Variable{"?b"}}));
 
-  auto testWithTrees = [qec](std::shared_ptr<QueryExecutionTree> left,
-                             std::shared_ptr<QueryExecutionTree> right, bool a,
-                             bool b, bool c,
-                             ad_utility::source_location location =
-                                 ad_utility::source_location::current()) {
-    auto trace = generateLocationTrace(location);
+  auto testWithTrees =
+      [qec](std::shared_ptr<QueryExecutionTree> left,
+            std::shared_ptr<QueryExecutionTree> right, bool a, bool b, bool c,
+            ad_utility::source_location location = AD_CURRENT_SOURCE_LOC()) {
+        auto trace = generateLocationTrace(location);
 
-    MultiColumnJoin join{qec, std::move(left), std::move(right), false};
-    EXPECT_EQ(join.columnOriginatesFromGraphOrUndef(Variable{"?a"}), a);
-    EXPECT_EQ(join.columnOriginatesFromGraphOrUndef(Variable{"?b"}), b);
-    EXPECT_EQ(join.columnOriginatesFromGraphOrUndef(Variable{"?c"}), c);
-    EXPECT_THROW(
-        join.columnOriginatesFromGraphOrUndef(Variable{"?notExisting"}),
-        ad_utility::Exception);
-  };
+        MultiColumnJoin join{qec, std::move(left), std::move(right), false};
+        EXPECT_EQ(join.columnOriginatesFromGraphOrUndef(Variable{"?a"}), a);
+        EXPECT_EQ(join.columnOriginatesFromGraphOrUndef(Variable{"?b"}), b);
+        EXPECT_EQ(join.columnOriginatesFromGraphOrUndef(Variable{"?c"}), c);
+        EXPECT_THROW(
+            join.columnOriginatesFromGraphOrUndef(Variable{"?notExisting"}),
+            ad_utility::Exception);
+      };
 
   testWithTrees(index3, index4, true, true, true);
   testWithTrees(index3, index2, true, true, true);

--- a/test/OperationTest.cpp
+++ b/test/OperationTest.cpp
@@ -31,7 +31,7 @@ namespace {
 template <typename Range, typename T = ql::ranges::range_value_t<Range>>
 auto expectAtEachStageOfGenerator(
     Range generator, std::vector<std::function<void()>> functions,
-    ad_utility::source_location l = ad_utility::source_location::current()) {
+    ad_utility::source_location l = AD_CURRENT_SOURCE_LOC()) {
   auto locationTrace = generateLocationTrace(l);
   size_t index = 0;
   for ([[maybe_unused]] T& _ : generator) {
@@ -43,7 +43,7 @@ auto expectAtEachStageOfGenerator(
 
 void expectRtiHasDimensions(
     RuntimeInformation& rti, uint64_t cols, uint64_t rows,
-    ad_utility::source_location l = ad_utility::source_location::current()) {
+    ad_utility::source_location l = AD_CURRENT_SOURCE_LOC()) {
   auto locationTrace = generateLocationTrace(l);
   EXPECT_EQ(rti.numCols_, cols);
   EXPECT_EQ(rti.numRows_, rows);
@@ -746,7 +746,7 @@ TEST(Operation, checkMaxCacheSizeIsComputedCorrectly) {
                     ad_utility::MemorySize runtimeParameterLimit, bool isRoot,
                     ad_utility::MemorySize expectedSize,
                     ad_utility::source_location sourceLocation =
-                        ad_utility::source_location::current()) {
+                        AD_CURRENT_SOURCE_LOC()) {
     auto loc = generateLocationTrace(sourceLocation);
     auto qec = getQec();
     qec->getQueryTreeCache().clearAll();

--- a/test/OrderByTest.cpp
+++ b/test/OrderByTest.cpp
@@ -38,7 +38,7 @@ OrderBy makeOrderBy(IdTable input, const OrderBy::SortIndices& sortColumns) {
 // `input` and `expected` accordingly.
 void testOrderBy(IdTable input, const IdTable& expected,
                  std::vector<bool> isDescending,
-                 source_location l = source_location::current()) {
+                 source_location l = AD_CURRENT_SOURCE_LOC()) {
   auto trace = generateLocationTrace(l);
   auto qec = ad_utility::testing::getQec();
 

--- a/test/ParseExceptionTest.cpp
+++ b/test/ParseExceptionTest.cpp
@@ -32,7 +32,7 @@ TEST(ParseException, illegalConstructorArguments) {
 // _____________________________________________________________________________
 void expectParseExceptionWithMetadata(
     const std::string& input, const std::optional<ExceptionMetadata>& metadata,
-    ad_utility::source_location l = ad_utility::source_location::current()) {
+    ad_utility::source_location l = AD_CURRENT_SOURCE_LOC()) {
   auto trace = generateLocationTrace(l);
   try {
     static EncodedIriManager ev;

--- a/test/ParsedRequestBuilderTest.cpp
+++ b/test/ParsedRequestBuilderTest.cpp
@@ -23,7 +23,7 @@ TEST(ParsedRequestBuilderTest, Constructor) {
   auto expect = [](const auto& request, const std::string& path,
                    const ParamValueMap& params,
                    const ad_utility::source_location l =
-                       ad_utility::source_location::current()) {
+                       AD_CURRENT_SOURCE_LOC()) {
     auto t = generateLocationTrace(l);
     const auto builder = ParsedRequestBuilder(request);
     EXPECT_THAT(
@@ -46,7 +46,7 @@ TEST(ParsedRequestBuilderTest, extractAccessToken) {
   auto expect = [](const auto& request,
                    const std::optional<std::string>& expected,
                    const ad_utility::source_location l =
-                       ad_utility::source_location::current()) {
+                       AD_CURRENT_SOURCE_LOC()) {
     auto t = generateLocationTrace(l);
     auto builder = ParsedRequestBuilder(request);
     EXPECT_THAT(builder.parsedRequest_.accessToken_, testing::Eq(std::nullopt));
@@ -75,7 +75,7 @@ TEST(ParsedRequestBuilderTest, extractDatasetClause) {
   auto expect = [](const auto& request, auto ti,
                    const std::vector<DatasetClause>& expected,
                    const ad_utility::source_location l =
-                       ad_utility::source_location::current()) {
+                       AD_CURRENT_SOURCE_LOC()) {
     using T = typename decltype(ti)::type;
     auto t = generateLocationTrace(l);
     auto builder = ParsedRequestBuilder(request);
@@ -106,7 +106,7 @@ TEST(ParsedRequestBuilderTest, extractOperationIfSpecified) {
   auto expect = [](const auto& request, auto ti, std::string_view paramName,
                    const Operation& expected,
                    const ad_utility::source_location l =
-                       ad_utility::source_location::current()) {
+                       AD_CURRENT_SOURCE_LOC()) {
     using T = typename decltype(ti)::type;
     auto t = generateLocationTrace(l);
     auto builder = ParsedRequestBuilder(request);
@@ -173,7 +173,7 @@ TEST(ParsedRequestBuilderTest, extractGraphStoreOperationIndirect) {
   auto Iri = ad_utility::triple_component::Iri::fromIriref;
   auto expect = [](const auto& request, const GraphOrDefault& graph,
                    const ad_utility::source_location l =
-                       ad_utility::source_location::current()) {
+                       AD_CURRENT_SOURCE_LOC()) {
     auto t = generateLocationTrace(l);
     auto builder = ParsedRequestBuilder(request);
     EXPECT_THAT(builder.parsedRequest_.operation_,
@@ -211,7 +211,7 @@ TEST(ParsedRequestBuilderTest, extractGraphStoreOperationDirect) {
   };
   auto expect = [](const auto& request, const GraphOrDefault& graph,
                    const ad_utility::source_location l =
-                       ad_utility::source_location::current()) {
+                       AD_CURRENT_SOURCE_LOC()) {
     auto t = generateLocationTrace(l);
     auto builder = ParsedRequestBuilder(request);
     EXPECT_THAT(builder.parsedRequest_.operation_,

--- a/test/PrefilterExpressionIndexTest.cpp
+++ b/test/PrefilterExpressionIndexTest.cpp
@@ -444,12 +444,12 @@ class PrefilterExpressionOnMetadataTest : public ::testing::Test {
   // this necessary wider range of `CompressedBlockMetadata` values (compared to
   // `blocks`) which are relevant for testing the expressions `isIri` and
   // `isLiteral`.
-  auto makeTestIsDatatype(std::unique_ptr<PrefilterExpression> expr,
-                          std::vector<CompressedBlockMetadata>&& expected,
-                          bool testIsIriOrIsLit = false,
-                          std::vector<CompressedBlockMetadata>&& input = {},
-                          ad_utility::source_location loc =
-                              ad_utility::source_location::current()) {
+  auto makeTestIsDatatype(
+      std::unique_ptr<PrefilterExpression> expr,
+      std::vector<CompressedBlockMetadata>&& expected,
+      bool testIsIriOrIsLit = false,
+      std::vector<CompressedBlockMetadata>&& input = {},
+      ad_utility::source_location loc = AD_CURRENT_SOURCE_LOC()) {
     auto t = generateLocationTrace(loc);
     // The evaluation implementation of `isLiteral()` and `isIri()` uses two
     // conjuncted relational `PrefilterExpression`s. Thus we have to add all

--- a/test/QueryPlannerTestHelpers.h
+++ b/test/QueryPlannerTestHelpers.h
@@ -619,7 +619,7 @@ template <typename QueryPlannerClass = QueryPlanner>
 void expectWithGivenBudget(std::string query, auto matcher,
                            std::optional<QueryExecutionContext*> optQec,
                            size_t queryPlanningBudget,
-                           source_location l = source_location::current()) {
+                           source_location l = AD_CURRENT_SOURCE_LOC()) {
   auto budgetBackup =
       getRuntimeParameter<&RuntimeParameters::queryPlanningBudget_>();
   setRuntimeParameter<&RuntimeParameters::queryPlanningBudget_>(
@@ -641,7 +641,7 @@ template <typename QueryPlannerClass = QueryPlanner>
 void expectWithGivenBudgets(std::string query, auto matcher,
                             std::optional<QueryExecutionContext*> optQec,
                             std::vector<size_t> queryPlanningBudgets,
-                            source_location l = source_location::current()) {
+                            source_location l = AD_CURRENT_SOURCE_LOC()) {
   for (size_t budget : queryPlanningBudgets) {
     expectWithGivenBudget<QueryPlannerClass>(query, matcher, optQec, budget, l);
   }
@@ -652,7 +652,7 @@ void expectWithGivenBudgets(std::string query, auto matcher,
 template <typename QueryPlannerClass = QueryPlanner>
 void expectGreedy(std::string query, auto matcher,
                   std::optional<QueryExecutionContext*> optQec = std::nullopt,
-                  source_location l = source_location::current()) {
+                  source_location l = AD_CURRENT_SOURCE_LOC()) {
   expectWithGivenBudget<QueryPlannerClass>(std::move(query), std::move(matcher),
                                            optQec, 0, l);
 }
@@ -662,7 +662,7 @@ template <typename QueryPlannerClass = QueryPlanner>
 void expectDynamicProgramming(
     std::string query, auto matcher,
     std::optional<QueryExecutionContext*> optQec = std::nullopt,
-    source_location l = source_location::current()) {
+    source_location l = AD_CURRENT_SOURCE_LOC()) {
   expectWithGivenBudget<QueryPlannerClass>(
       std::move(query), std::move(matcher), optQec,
       std::numeric_limits<size_t>::max(), l);
@@ -674,7 +674,7 @@ void expectDynamicProgramming(
 template <typename QueryPlannerClass = QueryPlanner>
 void expect(std::string query, auto matcher,
             std::optional<QueryExecutionContext*> optQec = std::nullopt,
-            source_location l = source_location::current()) {
+            source_location l = AD_CURRENT_SOURCE_LOC()) {
   expectWithGivenBudgets<QueryPlannerClass>(
       std::move(query), std::move(matcher), std::move(optQec),
       {0, 1, 4, 16, 64'000'000}, l);

--- a/test/QueryRewriteUtilTestHelpers.h
+++ b/test/QueryRewriteUtilTestHelpers.h
@@ -32,7 +32,7 @@ using DistancePtrAndExpected = std::pair<Ptr, std::optional<GeoDistanceCall>>;
 // Test helper for `GeoFunctionCall`
 inline void checkGeoFunctionCall(const std::optional<GeoFunctionCall>& a,
                                  const std::optional<GeoFunctionCall>& b,
-                                 Loc loc = Loc::current()) {
+                                 Loc loc = AD_CURRENT_SOURCE_LOC()) {
   auto l = generateLocationTrace(loc);
   ASSERT_EQ(a.has_value(), b.has_value());
   if (!a.has_value()) {
@@ -46,7 +46,7 @@ inline void checkGeoFunctionCall(const std::optional<GeoFunctionCall>& a,
 // Test helper for `GeoDistanceCall`
 inline void checkGeoDistanceCall(const std::optional<GeoDistanceCall>& a,
                                  const std::optional<GeoDistanceCall>& b,
-                                 Loc loc = Loc::current()) {
+                                 Loc loc = AD_CURRENT_SOURCE_LOC()) {
   auto l = generateLocationTrace(loc);
   checkGeoFunctionCall(a, b);
   if (!a.has_value()) {
@@ -59,7 +59,7 @@ inline void checkGeoDistanceCall(const std::optional<GeoDistanceCall>& a,
 inline void checkGeoDistanceFilter(
     const GeoDistanceFilter& result,
     const std::optional<GeoFunctionCall>& expected, double expectedMeters,
-    Loc loc = Loc::current()) {
+    Loc loc = AD_CURRENT_SOURCE_LOC()) {
   auto l = generateLocationTrace(loc);
   ASSERT_EQ(result.has_value(), expected.has_value());
   if (!result.has_value()) {

--- a/test/RandomTest.cpp
+++ b/test/RandomTest.cpp
@@ -31,7 +31,7 @@ random number generator, using the given seed.
 */
 CPP_template(typename T)(requires std::invocable<T, RandomSeed>) void testSeed(
     T randomNumberGeneratorFactory,
-    ad_utility::source_location l = ad_utility::source_location::current()) {
+    ad_utility::source_location l = AD_CURRENT_SOURCE_LOC()) {
   // For generating better messages, when failing a test.
   auto trace{generateLocationTrace(l, "testSeed")};
 
@@ -112,8 +112,7 @@ CPP_template(typename RangeNumberType, typename GeneratorFactory)(
                                             const std::vector<NumericalRange<
                                                 RangeNumberType>>& ranges,
                                             ad_utility::source_location l =
-                                                ad_utility::source_location::
-                                                    current()) {
+                                                AD_CURRENT_SOURCE_LOC()) {
   // For generating better messages, when failing a test.
   auto trace{generateLocationTrace(l, "testSeedWithRange")};
 
@@ -139,9 +138,8 @@ template <typename Generator, typename RangeNumberType>
 requires std::constructible_from<Generator, RangeNumberType, RangeNumberType> &&
          std::invocable<Generator> &&
          ad_utility::isSimilar<std::invoke_result_t<Generator>, RangeNumberType>
-void testRange(
-    const std::vector<NumericalRange<RangeNumberType>>& ranges,
-    ad_utility::source_location l = ad_utility::source_location::current()) {
+void testRange(const std::vector<NumericalRange<RangeNumberType>>& ranges,
+               ad_utility::source_location l = AD_CURRENT_SOURCE_LOC()) {
   // For generating better messages, when failing a test.
   auto trace{generateLocationTrace(l, "testRange")};
 

--- a/test/RdfParserTest.cpp
+++ b/test/RdfParserTest.cpp
@@ -261,7 +261,7 @@ TEST(RdfParserTest, rdfLiteral) {
 
   auto testLiteral = [](const std::string& literal, const auto& predicate,
                         ad_utility::source_location loc =
-                            ad_utility::source_location::current()) {
+                            AD_CURRENT_SOURCE_LOC()) {
     auto trace = generateLocationTrace(loc);
 
     EXPECT_THAT((checkParseResult<Re2Parser, &Re2Parser::rdfLiteral>(literal))

--- a/test/RegexExpressionTest.cpp
+++ b/test/RegexExpressionTest.cpp
@@ -85,7 +85,7 @@ SparqlExpression::Ptr makeRegexExpression(
 void testWithExplicitResult(
     const SparqlExpression& expression, const std::vector<Id>& expected,
     const std::optional<size_t>& numInputs = std::nullopt,
-    source_location l = source_location::current()) {
+    source_location l = AD_CURRENT_SOURCE_LOC()) {
   TestContext ctx;
   auto trace = generateLocationTrace(std::move(l), "testWithExplicitResult");
   if (numInputs.has_value()) {
@@ -104,7 +104,7 @@ void testWithExplicitResult(
 void testValuesInVariables(
     const std::vector<std::array<std::string, 3>>& inputValues,
     const std::vector<Id>& expected, bool flagsUsed,
-    source_location l = source_location::current()) {
+    source_location l = AD_CURRENT_SOURCE_LOC()) {
   TestContext ctx;
   auto trace = generateLocationTrace(std::move(l), "testWithExplicitResult");
   ctx.varToColMap.clear();
@@ -137,7 +137,7 @@ void testValuesInVariables(
 auto testNonPrefixRegex = [](std::string variable, std::string regex,
                              const std::vector<Id>& expectedResult,
                              bool childAsStr = false,
-                             source_location l = source_location::current()) {
+                             source_location l = AD_CURRENT_SOURCE_LOC()) {
   auto trace = generateLocationTrace(std::move(l), "testNonPrefixRegex");
   auto expr = makeRegexExpression(std::move(variable), std::move(regex),
                                   std::nullopt, childAsStr);
@@ -233,7 +233,7 @@ TEST(RegexExpression, inputNotVariable) {
 auto testNonPrefixRegexWithFlags =
     [](std::string variable, std::string regex, std::string flags,
        const std::vector<Id>& expectedResult,
-       source_location l = source_location::current()) {
+       source_location l = AD_CURRENT_SOURCE_LOC()) {
       auto trace = generateLocationTrace(l, "testNonPrefixRegexWithFlags");
       auto expr = makeRegexExpression(std::move(variable), std::move(regex),
                                       std::move(flags));
@@ -324,7 +324,7 @@ TEST(RegexExpression, getPrefixRegex) {
 auto testPrefixRegexUnorderedColumn =
     [](std::string variable, std::string regex,
        const std::vector<Id>& expectedResult, bool childAsStr = false,
-       source_location l = source_location::current()) {
+       source_location l = AD_CURRENT_SOURCE_LOC()) {
       auto trace = generateLocationTrace(l, "testUnorderedPrefix");
       auto expr = makeRegexExpression(std::move(variable), std::move(regex),
                                       std::nullopt, childAsStr);
@@ -359,7 +359,7 @@ TEST(RegexExpression, unorderedPrefixRegexUnorderedColumn) {
 auto testPrefixRegexOrderedColumn =
     [](std::string variableAsString, std::string regex,
        ad_utility::SetOfIntervals expected, bool childAsStr = false,
-       source_location l = source_location::current()) {
+       source_location l = AD_CURRENT_SOURCE_LOC()) {
       auto trace = generateLocationTrace(l, "testPrefixRegexOrderedColumn");
       auto variable = Variable{variableAsString};
       TestContext ctx = TestContext::sortedBy(variable);

--- a/test/RelationalExpressionTest.cpp
+++ b/test/RelationalExpressionTest.cpp
@@ -128,7 +128,7 @@ VectorWithMemoryLimit<ValueId> makeValueIdVector(
 }
 
 auto expectTrue = [](const ExpressionResult& result,
-                     source_location l = source_location::current()) {
+                     source_location l = AD_CURRENT_SOURCE_LOC()) {
   auto t = generateLocationTrace(l);
   auto id = std::get<Id>(result);
   EXPECT_EQ(id.getDatatype(), Datatype::Bool);
@@ -136,7 +136,7 @@ auto expectTrue = [](const ExpressionResult& result,
 };
 
 auto expectFalse = [](const ExpressionResult& result,
-                      source_location l = source_location::current()) {
+                      source_location l = AD_CURRENT_SOURCE_LOC()) {
   auto t = generateLocationTrace(l);
   auto id = std::get<Id>(result);
   EXPECT_EQ(id.getDatatype(), Datatype::Bool);
@@ -146,7 +146,7 @@ auto expectFalse = [](const ExpressionResult& result,
 // Assert that the given `expression`, when evaluated on the `TestContext` (see
 // above), has a single boolean result that is true.
 auto expectTrueBoolean = [](const SparqlExpression& expression,
-                            source_location l = source_location::current()) {
+                            source_location l = AD_CURRENT_SOURCE_LOC()) {
   auto trace = generateLocationTrace(l, "expectTrueBoolean was called here");
   auto result = evaluateOnTestContext(expression);
   auto id = std::get<Id>(result);
@@ -156,7 +156,7 @@ auto expectTrueBoolean = [](const SparqlExpression& expression,
 
 // Similar to `expectTrueBoolean`, but assert that the boolean is `false`.
 auto expectFalseBoolean = [](const SparqlExpression& expression,
-                             source_location l = source_location::current()) {
+                             source_location l = AD_CURRENT_SOURCE_LOC()) {
   auto trace = generateLocationTrace(l, "expectFalseBoolean was called here");
   auto result = evaluateOnTestContext(expression);
   auto id = std::get<Id>(result);
@@ -165,7 +165,7 @@ auto expectFalseBoolean = [](const SparqlExpression& expression,
 };
 
 auto expectUndefined = [](const SparqlExpression& expression,
-                          source_location l = source_location::current()) {
+                          source_location l = AD_CURRENT_SOURCE_LOC()) {
   auto trace = generateLocationTrace(l, "expectUndefined was called here");
   auto result = evaluateOnTestContext(expression);
   if (std::holds_alternative<Id>(result)) {
@@ -188,7 +188,7 @@ auto expectUndefined = [](const SparqlExpression& expression,
 template <typename T, typename U>
 auto testLessThanGreaterThanEqualHelper(
     std::pair<T, U> lessThanPair, std::pair<T, U> greaterThanPair,
-    std::pair<T, U> equalPair, source_location l = source_location::current()) {
+    std::pair<T, U> equalPair, source_location l = AD_CURRENT_SOURCE_LOC()) {
   auto trace = generateLocationTrace(
       l, "testLessThanGreaterThanEqualHelper was called here");
   auto True = expectTrueBoolean;
@@ -221,9 +221,10 @@ auto testLessThanGreaterThanEqualHelper(
 // `ValueId` before the call; the second element  is ...; both elements are ...
 // Requires that both `leftValue` and `rightValue` are numeric constants.
 template <typename L, typename R>
-void testLessThanGreaterThanEqual(
-    std::pair<L, R> lessThanPair, std::pair<L, R> greaterThanPair,
-    std::pair<L, R> equalPair, source_location l = source_location::current()) {
+void testLessThanGreaterThanEqual(std::pair<L, R> lessThanPair,
+                                  std::pair<L, R> greaterThanPair,
+                                  std::pair<L, R> equalPair,
+                                  source_location l = AD_CURRENT_SOURCE_LOC()) {
   auto trace =
       generateLocationTrace(l, "testLessThanGreaterThanEqual was called here");
 
@@ -241,7 +242,7 @@ void testLessThanGreaterThanEqual(
 // single boolean that is false. The only exception is the `not equal`
 // comparison, for which true is expected.
 void testNotEqualHelper(auto leftValueIn, auto rightValueIn,
-                        source_location l = source_location::current()) {
+                        source_location l = AD_CURRENT_SOURCE_LOC()) {
   auto leftValue = liftToValueId(leftValueIn);
   auto rightValue = liftToValueId(rightValueIn);
   auto trace = generateLocationTrace(l, "testNotEqualHelper was called here");
@@ -264,7 +265,7 @@ void testNotEqualHelper(auto leftValueIn, auto rightValueIn,
 }
 
 void testUndefHelper(auto leftValueIn, auto rightValueIn,
-                     source_location l = source_location::current()) {
+                     source_location l = AD_CURRENT_SOURCE_LOC()) {
   auto leftValue = liftToValueId(leftValueIn);
   auto rightValue = liftToValueId(rightValueIn);
   auto trace = generateLocationTrace(l, "testUndefHelper was called here");
@@ -290,7 +291,7 @@ void testUndefHelper(auto leftValueIn, auto rightValueIn,
 // call. `rightValue` "" both values "" Requires that both `leftValue` and
 // `rightValue` are numeric constants.
 void testNotEqual(auto leftValue, auto rightValue,
-                  source_location l = source_location::current()) {
+                  source_location l = AD_CURRENT_SOURCE_LOC()) {
   auto trace = generateLocationTrace(l, "testNotEqual was called here");
   testNotEqualHelper(liftToValueId(leftValue), liftToValueId(rightValue));
 }
@@ -382,7 +383,7 @@ struct ExpressionEvaluator {
 // rightValue[i] > leftValue[i]; For i in [6, 8] : rightValue[i] = leftValue[i];
 template <typename T, typename U>
 void testLessThanGreaterThanEqualMultipleValuesHelper(
-    T leftValue, U rightValue, source_location l = source_location::current()) {
+    T leftValue, U rightValue, source_location l = AD_CURRENT_SOURCE_LOC()) {
   auto trace = generateLocationTrace(
       l, "testLessThanGreaterThanEqualMultipleValuesHelper was called here");
 
@@ -460,8 +461,7 @@ void testLessThanGreaterThanEqualMultipleValuesHelper(
 // or numeric vectors, and that at least one of them is a vector.
 template <typename T1, typename T2>
 void testLessThanGreaterThanEqualMultipleValues(
-    T1 leftValue, T2 rightValue,
-    source_location l = source_location::current()) {
+    T1 leftValue, T2 rightValue, source_location l = AD_CURRENT_SOURCE_LOC()) {
   auto trace = generateLocationTrace(
       l, "testLessThanGreaterThanEqualMultipleValues was called here");
 
@@ -483,7 +483,7 @@ void testLessThanGreaterThanEqualMultipleValues(
 // equal, greater) must be true.
 template <typename T, typename U>
 auto testNotComparableHelper(T leftValue, U rightValue,
-                             source_location l = source_location::current()) {
+                             source_location l = AD_CURRENT_SOURCE_LOC()) {
   auto trace = generateLocationTrace(
       l, "testLessThanGreaterThanEqualMultipleValuesHelper was called here");
   ad_utility::AllocatorWithLimit<Id> alloc{makeAllocator()};
@@ -536,7 +536,7 @@ auto testNotComparableHelper(T leftValue, U rightValue,
 // for the `testNotComparableHelper` function.
 template <typename T, typename U>
 auto testNotComparable(T leftValue, U rightValue,
-                       source_location l = source_location::current()) {
+                       source_location l = AD_CURRENT_SOURCE_LOC()) {
   auto trace = generateLocationTrace(l, "testNotComparable was called here");
   /*
   testNotComparableHelper(makeCopy(leftValue), makeCopy(rightValue));
@@ -668,7 +668,7 @@ void testInExpressionVector(T1 leftValue, T2 rightValue, Ctx& ctx,
 template <Comparison Comp, typename T1, typename T2>
 void testWithExplicitIdResult(T1 leftValue, T2 rightValue,
                               std::vector<Id> expected,
-                              source_location l = source_location::current()) {
+                              source_location l = AD_CURRENT_SOURCE_LOC()) {
   static TestContext ctx;
   auto expression =
       makeExpression<Comp>(liftToValueId(leftValue), liftToValueId(rightValue));
@@ -685,7 +685,7 @@ void testWithExplicitIdResult(T1 leftValue, T2 rightValue,
 template <Comparison Comp, typename T1, typename T2>
 void testWithExplicitResult(T1 leftValue, T2 rightValue,
                             std::vector<bool> expectedAsBool,
-                            source_location l = source_location::current()) {
+                            source_location l = AD_CURRENT_SOURCE_LOC()) {
   auto t = generateLocationTrace(l);
   std::vector<Id> expected;
   ql::ranges::transform(expectedAsBool, std::back_inserter(expected),
@@ -789,7 +789,7 @@ TEST(RelationalExpression, VariableAndVariable) {
 template <Comparison Comp, typename T>
 void testSortedVariableAndConstant(
     Variable leftValue, T rightValue, ad_utility::SetOfIntervals expected,
-    source_location l = source_location::current()) {
+    source_location l = AD_CURRENT_SOURCE_LOC()) {
   auto trace = generateLocationTrace(
       l, "test between sorted variable and constant was called here");
   TestContext ctx = TestContext::sortedBy(leftValue);
@@ -919,8 +919,7 @@ TEST(RelationalExpression, FilterEstimates) {
   // Implementation for testing the size estimates of different relational
   // expressions.
   auto testImpl = [&](auto ti, size_t expectedSize,
-                      ad_utility::source_location l =
-                          source_location::current()) {
+                      ad_utility::source_location l = AD_CURRENT_SOURCE_LOC()) {
     using T = typename decltype(ti)::type;
 
     auto tr = generateLocationTrace(l);

--- a/test/ResultTableColumnOperationsTest.cpp
+++ b/test/ResultTableColumnOperationsTest.cpp
@@ -61,7 +61,7 @@ static void compareToColumn(
     const std::vector<T>& expectedContent,
     const ResultTable& tableToCompareAgainst,
     const ColumnNumWithType<T>& columnsToCompareAgainst,
-    ad_utility::source_location l = ad_utility::source_location::current()) {
+    ad_utility::source_location l = AD_CURRENT_SOURCE_LOC()) {
   // For generating better messages, when failing a test.
   auto trace{generateLocationTrace(l, "compareToColumn")};
 
@@ -98,7 +98,7 @@ ColumnNumWithType<ColumnInputTypeTwo> inputColumnTwo`.
 template <typename F>
 static void generalExceptionTestTwoInputColumns(
     const F& callTransform,
-    ad_utility::source_location l = ad_utility::source_location::current()) {
+    ad_utility::source_location l = AD_CURRENT_SOURCE_LOC()) {
   // For generating better messages, when failing a test.
   auto trace{generateLocationTrace(l, "generalExceptionTestTwoInputColumns")};
 
@@ -176,7 +176,7 @@ ColumnNumWithType<ColumnInputTypes>&... inputColumns`.
 template <typename F>
 static void generalExceptionTestUnlimitedInputColumns(
     const F& callTransform,
-    ad_utility::source_location l = ad_utility::source_location::current()) {
+    ad_utility::source_location l = AD_CURRENT_SOURCE_LOC()) {
   // For generating better messages, when failing a test.
   auto trace{
       generateLocationTrace(l, "generalExceptionTestUnlimitedInputColumns")};
@@ -330,9 +330,9 @@ TEST(ResultTableColumnOperations, calculateSpeedupOfColumn) {
   // Test things for a range of speedups.
   ql::ranges::for_each(
       std::array{2.f, 16.f, 73.696f, 4.2f},
-      [&fillColumnsForSpeedup](const float wantedSpeedup,
-                               ad_utility::source_location l =
-                                   ad_utility::source_location::current()) {
+      [&fillColumnsForSpeedup](
+          const float wantedSpeedup,
+          ad_utility::source_location l = AD_CURRENT_SOURCE_LOC()) {
         // For generating better messages, when failing a test.
         auto trace{generateLocationTrace(l, "testRangeOfSpeedups")};
         ResultTable table{createTestTable(NUM_ROWS, 10)};

--- a/test/ServerTest.cpp
+++ b/test/ServerTest.cpp
@@ -288,8 +288,7 @@ TEST(ServerTest, adjustParsedQueryLimitOffset) {
               "SELECT * WHERE { <a> <b> ?c } LIMIT 10 OFFSET 15",
           const ad_utility::url_parser::ParamValueMap& parameters = {{"send",
                                                                       {"12"}}},
-          ad_utility::source_location l =
-              ad_utility::source_location::current()) {
+          ad_utility::source_location l = AD_CURRENT_SOURCE_LOC()) {
         auto trace = generateLocationTrace(l);
         auto pq = makePlannedQuery(std::move(operation));
         Server::adjustParsedQueryLimitOffset(pq, mediaType, parameters);

--- a/test/ServiceTest.cpp
+++ b/test/ServiceTest.cpp
@@ -61,7 +61,7 @@ class ServiceTest : public ::testing::Test {
          std::string contentType = "application/sparql-results+json",
          std::exception_ptr mockException = nullptr,
          ad_utility::source_location loc =
-             ad_utility::source_location::current()) -> SendRequestType {
+             AD_CURRENT_SOURCE_LOC()) -> SendRequestType {
     // Check that the request parameters are as expected.
     //
     // NOTE: Method, Content-Type and Accept are hard-coded in
@@ -184,7 +184,7 @@ TEST_F(ServiceTest, computeResult) {
             std::string contentType = "application/sparql-results+json",
             bool silent = false,
             ad_utility::source_location loc =
-                ad_utility::source_location::current()) -> Result {
+                AD_CURRENT_SOURCE_LOC()) -> Result {
       Service s{
           testQec, silent ? parsedServiceClauseSilent : parsedServiceClause,
           getResultFunctionFactory(expectedUrl, expectedSparqlQuery, result,
@@ -247,8 +247,7 @@ TEST_F(ServiceTest, computeResult) {
         [&](const std::string& result, std::string_view errorMsg,
             boost::beast::http::status status = boost::beast::http::status::ok,
             std::string contentType = "application/sparql-results+json",
-            ad_utility::source_location loc =
-                ad_utility::source_location::current()) {
+            ad_utility::source_location loc = AD_CURRENT_SOURCE_LOC()) {
           auto g = generateLocationTrace(loc);
           AD_EXPECT_THROW_WITH_MESSAGE(
               runComputeResult(result, status, contentType, false),

--- a/test/SortTest.cpp
+++ b/test/SortTest.cpp
@@ -36,7 +36,7 @@ Sort makeSort(IdTable input, const std::vector<ColumnIndex>& sortColumns) {
 // permutations of the sort columns by also permuting `input` and `expected`
 // accordingly.
 void testSort(IdTable input, const IdTable& expected,
-              source_location l = source_location::current()) {
+              source_location l = AD_CURRENT_SOURCE_LOC()) {
   auto trace = generateLocationTrace(l);
   auto qec = ad_utility::testing::getQec();
 

--- a/test/SourceLocationTest.cpp
+++ b/test/SourceLocationTest.cpp
@@ -1,0 +1,39 @@
+// Copyright 2025 The QLever Authors, in particular:
+//
+// 2025 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#include <gmock/gmock.h>
+
+#include "util/SourceLocation.h"
+
+auto getSourceLoc(ad_utility::source_location loc = AD_CURRENT_SOURCE_LOC()) {
+  return loc;
+}
+
+// Test that the `AD_CURRENT_SOURCE_LOC()` behaves as expected (it captures the
+// location of the call-site).
+TEST(SourceLocation, Current) {
+  auto file = __builtin_FILE();
+  auto function = __builtin_FUNCTION();
+  auto line = __builtin_LINE();
+  auto loc = getSourceLoc();
+
+  EXPECT_EQ(loc.file_name(), file);
+  EXPECT_EQ(loc.line(), line + 1);
+  // The details of the function name are different
+  //(`TestBody` vs `SourceLocation_Current_Test::TestBody`)
+  EXPECT_THAT(loc.function_name(), testing::HasSubstr("TestBody"));
+  EXPECT_THAT(function, testing::HasSubstr("TestBody"));
+
+#ifdef QLEVER_CPP_17
+  // In C++17 mode the `column()` is currently a dummy.
+  EXPECT_EQ(loc.column(), 0);
+#else
+  EXPECT_NE(loc.column(), 0);
+#endif
+}

--- a/test/SourceLocationTest.cpp
+++ b/test/SourceLocationTest.cpp
@@ -11,9 +11,11 @@
 
 #include "util/SourceLocation.h"
 
+namespace {
 auto getSourceLoc(ad_utility::source_location loc = AD_CURRENT_SOURCE_LOC()) {
   return loc;
 }
+}  // namespace
 
 // Test that the `AD_CURRENT_SOURCE_LOC()` behaves as expected (it captures the
 // location of the call-site).
@@ -26,7 +28,8 @@ TEST(SourceLocation, Current) {
   EXPECT_EQ(loc.file_name(), file);
   EXPECT_EQ(loc.line(), line + 1);
   // The details of the function name are different
-  //(`TestBody` vs `SourceLocation_Current_Test::TestBody`)
+  // (`TestBody` vs `SourceLocation_Current_Test::TestBody`), so we cannot
+  // use `EXPECT_STREQ` etc.
   EXPECT_THAT(loc.function_name(), testing::HasSubstr("TestBody"));
   EXPECT_THAT(function, testing::HasSubstr("TestBody"));
 

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -255,7 +255,7 @@ auto testNaryExpression = [](auto&& makeExpression,
 template <auto makeFunction>
 auto testBinaryExpressionCommutative =
     [](const auto& expected, const auto& op1, const auto& op2,
-       source_location l = source_location::current()) {
+       source_location l = AD_CURRENT_SOURCE_LOC()) {
       CPP_assert(SingleExpressionResult<decltype(expected)> &&
                  SingleExpressionResult<decltype(op1)> &&
                  SingleExpressionResult<decltype(op2)>);
@@ -272,7 +272,7 @@ template <auto makeFunction>
 struct TestNaryExpressionVec {
   template <VectorOrExpressionResult Exp, VectorOrExpressionResult... Ops>
   void operator()(Exp expected, std::tuple<Ops...> ops,
-                  source_location l = source_location::current()) {
+                  source_location l = AD_CURRENT_SOURCE_LOC()) {
     auto t = generateLocationTrace(l, "testBinaryExpressionVec");
 
     std::apply(
@@ -479,7 +479,7 @@ TEST(SparqlExpression, arithmeticOperators) {
 template <auto makeFunction>
 auto testUnaryExpression = [](VectorOrExpressionResult auto const& operand,
                               VectorOrExpressionResult auto const& expected,
-                              source_location l = source_location::current()) {
+                              source_location l = AD_CURRENT_SOURCE_LOC()) {
   auto trace = generateLocationTrace(l);
   testNaryExpression(makeFunction, expected, operand);
 };
@@ -504,7 +504,7 @@ TEST(SparqlExpression, dateOperators) {
                    std::optional<int> expectedHours = std::nullopt,
                    std::optional<int> expectedMinutes = std::nullopt,
                    std::optional<double> expectedSeconds = std::nullopt,
-                   std::source_location l = std::source_location::current()) {
+                   ad_utility::source_location l = AD_CURRENT_SOURCE_LOC()) {
     auto trace = generateLocationTrace(l);
     auto optToIdInt = [](const auto& opt) {
       if (opt.has_value()) {

--- a/test/SparqlProtocolTest.cpp
+++ b/test/SparqlProtocolTest.cpp
@@ -47,8 +47,7 @@ auto testAccessTokenCombinations = [](auto parse, const http::verb& method,
                                       const std::optional<std::string>& body =
                                           std::nullopt,
                                       ad_utility::source_location l =
-                                          ad_utility::source_location::
-                                              current()) {
+                                          AD_CURRENT_SOURCE_LOC()) {
   auto t = generateLocationTrace(l);
   // Test the cases:
   // 1. No access token
@@ -85,50 +84,50 @@ auto testAccessTokenCombinations = [](auto parse, const http::verb& method,
                          "`Authorization` header and by the `access-token` "
                          "parameter, but they are not the same"));
 };
-auto testAccessTokenCombinationsUrlEncoded =
-    [](auto parse, const std::string& bodyBase,
-       const Operation& expectedOperation,
-       ad_utility::source_location l = ad_utility::source_location::current()) {
-      auto t = generateLocationTrace(l);
-      // Test the cases:
-      // 1. No access token
-      // 2. Access token in query
-      // 3. Access token in `Authorization` header
-      // 4. Different access tokens
-      // 5. Same access token
-      boost::urls::url paramsWithAccessToken{absl::StrCat("/?", bodyBase)};
-      paramsWithAccessToken.params().append({"access-token", "foo"});
-      std::string bodyWithAccessToken{
-          paramsWithAccessToken.encoded_params().buffer()};
-      ad_utility::HashMap<http::field, std::string> headers{
-          {http::field::content_type, {URLENCODED}}};
-      ad_utility::HashMap<http::field, std::string>
-          headersWithDifferentAccessToken{
-              {http::field::content_type, {URLENCODED}},
-              {http::field::authorization, "Bearer bar"}};
-      ad_utility::HashMap<http::field, std::string> headersWithSameAccessToken{
-          {http::field::content_type, {URLENCODED}},
-          {http::field::authorization, "Bearer foo"}};
-      EXPECT_THAT(parse(makeRequest(http::verb::post, "/", headers, bodyBase)),
-                  ParsedRequestIs("/", std::nullopt, {}, expectedOperation));
-      EXPECT_THAT(parse(makeRequest(http::verb::post, "/", headers,
-                                    bodyWithAccessToken)),
-                  ParsedRequestIs("/", "foo", {{"access-token", {"foo"}}},
-                                  expectedOperation));
-      EXPECT_THAT(parse(makeRequest(http::verb::post, "/",
-                                    headersWithDifferentAccessToken, bodyBase)),
-                  ParsedRequestIs("/", "bar", {}, expectedOperation));
-      EXPECT_THAT(parse(makeRequest(http::verb::post, "/",
-                                    headersWithSameAccessToken, bodyBase)),
-                  ParsedRequestIs("/", "foo", {}, expectedOperation));
-      AD_EXPECT_THROW_WITH_MESSAGE(
-          parse(makeRequest(http::verb::post, "/",
-                            headersWithDifferentAccessToken,
-                            bodyWithAccessToken)),
-          testing::HasSubstr("Access token is specified both in the "
-                             "`Authorization` header and by the `access-token` "
-                             "parameter, but they are not the same"));
-    };
+auto testAccessTokenCombinationsUrlEncoded = [](auto parse,
+                                                const std::string& bodyBase,
+                                                const Operation&
+                                                    expectedOperation,
+                                                ad_utility::source_location l =
+                                                    AD_CURRENT_SOURCE_LOC()) {
+  auto t = generateLocationTrace(l);
+  // Test the cases:
+  // 1. No access token
+  // 2. Access token in query
+  // 3. Access token in `Authorization` header
+  // 4. Different access tokens
+  // 5. Same access token
+  boost::urls::url paramsWithAccessToken{absl::StrCat("/?", bodyBase)};
+  paramsWithAccessToken.params().append({"access-token", "foo"});
+  std::string bodyWithAccessToken{
+      paramsWithAccessToken.encoded_params().buffer()};
+  ad_utility::HashMap<http::field, std::string> headers{
+      {http::field::content_type, {URLENCODED}}};
+  ad_utility::HashMap<http::field, std::string> headersWithDifferentAccessToken{
+      {http::field::content_type, {URLENCODED}},
+      {http::field::authorization, "Bearer bar"}};
+  ad_utility::HashMap<http::field, std::string> headersWithSameAccessToken{
+      {http::field::content_type, {URLENCODED}},
+      {http::field::authorization, "Bearer foo"}};
+  EXPECT_THAT(parse(makeRequest(http::verb::post, "/", headers, bodyBase)),
+              ParsedRequestIs("/", std::nullopt, {}, expectedOperation));
+  EXPECT_THAT(
+      parse(makeRequest(http::verb::post, "/", headers, bodyWithAccessToken)),
+      ParsedRequestIs("/", "foo", {{"access-token", {"foo"}}},
+                      expectedOperation));
+  EXPECT_THAT(parse(makeRequest(http::verb::post, "/",
+                                headersWithDifferentAccessToken, bodyBase)),
+              ParsedRequestIs("/", "bar", {}, expectedOperation));
+  EXPECT_THAT(parse(makeRequest(http::verb::post, "/",
+                                headersWithSameAccessToken, bodyBase)),
+              ParsedRequestIs("/", "foo", {}, expectedOperation));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      parse(makeRequest(http::verb::post, "/", headersWithDifferentAccessToken,
+                        bodyWithAccessToken)),
+      testing::HasSubstr("Access token is specified both in the "
+                         "`Authorization` header and by the `access-token` "
+                         "parameter, but they are not the same"));
+};
 
 }  // namespace
 

--- a/test/StringSortComparatorTest.cpp
+++ b/test/StringSortComparatorTest.cpp
@@ -116,7 +116,7 @@ TEST(StringSortComparatorTest, TripleComponentComparatorTotal) {
   // result, no matter if it is done on the level of strings or on `SortKey`s.
   auto assertConsistent = [&comparator, &comp](
                               const auto& a, const auto& b,
-                              source_location l = source_location::current()) {
+                              source_location l = AD_CURRENT_SOURCE_LOC()) {
     auto tr = generateLocationTrace(l);
     bool ab = comp(a, b);
     bool ba = comp(b, a);
@@ -135,14 +135,14 @@ TEST(StringSortComparatorTest, TripleComponentComparatorTotal) {
 
   auto assertTrue = [&comp, &assertConsistent](
                         const auto& a, const auto& b,
-                        source_location l = source_location::current()) {
+                        source_location l = AD_CURRENT_SOURCE_LOC()) {
     auto tr = generateLocationTrace(l);
     ASSERT_TRUE(comp(a, b));
     assertConsistent(a, b);
   };
   auto assertFalse = [&comp, &assertConsistent](
                          const auto& a, const auto& b,
-                         source_location l = source_location::current()) {
+                         source_location l = AD_CURRENT_SOURCE_LOC()) {
     auto tr = generateLocationTrace(l);
     ASSERT_FALSE(comp(a, b));
     assertConsistent(a, b);

--- a/test/StringUtilsTest.cpp
+++ b/test/StringUtilsTest.cpp
@@ -186,7 +186,7 @@ TEST(StringUtils, insertThousandSeparator) {
   */
   auto doNotExceptionTest = [](auto valueIdentity, const char separatorSymbol,
                                ad_utility::source_location l =
-                                   ad_utility::source_location::current()) {
+                                   AD_CURRENT_SOURCE_LOC()) {
     static constexpr char floatingPointSignifier = valueIdentity.value;
     // For generating better messages, when failing a test.
     auto trace{generateLocationTrace(l, "doNotExceptionTest")};
@@ -205,9 +205,9 @@ TEST(StringUtils, insertThousandSeparator) {
     number 4", "198."}`.
     */
     auto simpleComparisonTest =
-        [&separatorSymbol](const std::vector<std::string>& stringPieces,
-                           ad_utility::source_location l =
-                               ad_utility::source_location::current()) {
+        [&separatorSymbol](
+            const std::vector<std::string>& stringPieces,
+            ad_utility::source_location l = AD_CURRENT_SOURCE_LOC()) {
           // For generating better messages, when failing a test.
           auto trace{generateLocationTrace(l, "simpleComparisonTest")};
           ASSERT_STREQ(
@@ -400,7 +400,7 @@ TEST(StringUtils, constexprStrCatImpl) {
 TEST(StringUtils, truncateOperationString) {
   auto expectTruncate = [](std::string_view test, bool willTruncate,
                            ad_utility::source_location l =
-                               ad_utility::source_location::current()) {
+                               AD_CURRENT_SOURCE_LOC()) {
     auto tr = generateLocationTrace(l);
     const std::string truncated = ad_utility::truncateOperationString(test);
     if (willTruncate) {

--- a/test/TransitivePathTest.cpp
+++ b/test/TransitivePathTest.cpp
@@ -115,8 +115,7 @@ class TransitivePathTest
   // ___________________________________________________________________________
   static void assertResultMatchesIdTable(
       const Result& result, const IdTable& expected,
-      ad_utility::source_location loc =
-          ad_utility::source_location::current()) {
+      ad_utility::source_location loc = AD_CURRENT_SOURCE_LOC()) {
     auto t = generateLocationTrace(loc);
     using ::testing::UnorderedElementsAreArray;
     ASSERT_NE(result.isFullyMaterialized(), requestLaziness());
@@ -136,8 +135,7 @@ class TransitivePathTest
       const std::invocable<std::variant<IdTable, std::vector<IdTable>>,
                            bool> auto& testCase,
       IdTable idTable,
-      ad_utility::source_location loc =
-          ad_utility::source_location::current()) {
+      ad_utility::source_location loc = AD_CURRENT_SOURCE_LOC()) {
     auto trace = generateLocationTrace(loc);
     testCase(idTable.clone(), false);
     testCase(split(idTable), false);

--- a/test/UnionTest.cpp
+++ b/test/UnionTest.cpp
@@ -79,8 +79,7 @@ TEST(Union, computeUnionLarge) {
 // _____________________________________________________________________________
 TEST(Union, computeUnionLazy) {
   auto runTest = [](bool nonLazyChildren, bool invisibleSubtreeColumns,
-                    ad_utility::source_location loc =
-                        ad_utility::source_location::current()) {
+                    ad_utility::source_location loc = AD_CURRENT_SOURCE_LOC()) {
     auto l = generateLocationTrace(loc);
     auto* qec = ad_utility::testing::getQec();
     qec->getQueryTreeCache().clearAll();

--- a/test/ValidatorTest.cpp
+++ b/test/ValidatorTest.cpp
@@ -261,7 +261,7 @@ args)`.
 template <typename F>
 void doConstructorTest(
     F generateValidatorManager,
-    ad_utility::source_location l = ad_utility::source_location::current()) {
+    ad_utility::source_location l = AD_CURRENT_SOURCE_LOC()) {
   // For generating better messages, when failing a test.
   auto trace{generateLocationTrace(l, "doConstructorTest")};
 
@@ -442,7 +442,7 @@ auto checkValidator(
     // ValidatorFunction<ParameterTypes...> auto func,
     ValidatorFunc func, const std::tuple<ParameterTypes...>& validValues,
     const std::tuple<ParameterTypes...>& nonValidValues,
-    ad_utility::source_location l = ad_utility::source_location::current()) {
+    ad_utility::source_location l = AD_CURRENT_SOURCE_LOC()) {
   // For generating better messages, when failing a test.
   auto trace{generateLocationTrace(l, "checkValidator")};
 

--- a/test/ValueGetterTestHelpers.h
+++ b/test/ValueGetterTestHelpers.h
@@ -209,7 +209,7 @@ using namespace geoInfoTestHelpers;
 // LocalVocabIndex as a ValueId to the GeometryInfoValueGetter
 inline void checkGeoInfoFromLocalVocab(
     std::string wktInput, std::optional<ad_utility::GeometryInfo> expected,
-    Loc sourceLocation = Loc::current()) {
+    Loc sourceLocation = AD_CURRENT_SOURCE_LOC()) {
   auto l = generateLocationTrace(sourceLocation);
   sparqlExpression::detail::GeometryInfoValueGetter getter;
   // Not the geoInfoTtl here because the literals should not be contained
@@ -239,7 +239,7 @@ const std::string geoInfoTtl =
 // VocabIndex for a string in the example knowledge graph.
 inline void checkGeoInfoFromVocab(
     std::string wktInput, std::optional<ad_utility::GeometryInfo> expected,
-    Loc sourceLocation = Loc::current()) {
+    Loc sourceLocation = AD_CURRENT_SOURCE_LOC()) {
   auto l = generateLocationTrace(sourceLocation);
   sparqlExpression::detail::GeometryInfoValueGetter getter;
   TestContextWithGivenTTl testContext{
@@ -257,7 +257,7 @@ inline void checkGeoInfoFromVocab(
 // Helper that tests the GeometryInfoValueGetter using an arbitrary ValueId
 inline void checkGeoInfoFromValueId(
     ValueId input, std::optional<ad_utility::GeometryInfo> expected,
-    Loc sourceLocation = Loc::current()) {
+    Loc sourceLocation = AD_CURRENT_SOURCE_LOC()) {
   auto l = generateLocationTrace(sourceLocation);
   sparqlExpression::detail::GeometryInfoValueGetter getter;
   TestContextWithGivenTTl testContext{geoInfoTtl};
@@ -269,7 +269,7 @@ inline void checkGeoInfoFromValueId(
 // as LiteralOrIri, not ValueId
 inline void checkGeoInfoFromLiteral(
     std::string wktInput, std::optional<ad_utility::GeometryInfo> expected,
-    Loc sourceLocation = Loc::current()) {
+    Loc sourceLocation = AD_CURRENT_SOURCE_LOC()) {
   auto l = generateLocationTrace(sourceLocation);
   sparqlExpression::detail::GeometryInfoValueGetter getter;
   TestContextWithGivenTTl testContext{geoInfoTtl};
@@ -284,7 +284,7 @@ inline void checkGeoInfoFromLiteral(
 // input
 inline void checkGeoInfoFromLocalAndNormalVocabAndLiteral(
     std::string wktInput, std::optional<ad_utility::GeometryInfo> expected,
-    Loc sourceLocation = Loc::current()) {
+    Loc sourceLocation = AD_CURRENT_SOURCE_LOC()) {
   auto l = generateLocationTrace(sourceLocation);
   checkGeoInfoFromVocab(wktInput, expected);
   checkGeoInfoFromLocalVocab(wktInput, expected);

--- a/test/ValueIdComparatorsTest.cpp
+++ b/test/ValueIdComparatorsTest.cpp
@@ -108,7 +108,7 @@ template <typename It, typename IsMatchingDatatype, typename ApplyComparator>
 auto testGetRangesForId(It begin, It end, ValueId id,
                         IsMatchingDatatype isMatchingDatatype,
                         ApplyComparator applyComparator,
-                        source_location l = source_location::current()) {
+                        source_location l = AD_CURRENT_SOURCE_LOC()) {
   auto trage = generateLocationTrace(l);
   // Perform the testing for a single `Comparison`
   auto testImpl = [&](auto comparison) {

--- a/test/ViewsTest.cpp
+++ b/test/ViewsTest.cpp
@@ -204,7 +204,7 @@ TEST(Views, RvalueView) {
   // place where it's used (second argument).
   auto testImpl = [&t, &f](auto isConst, bool doMove,
                            ad_utility::source_location loc =
-                               ad_utility::source_location::current()) {
+                               AD_CURRENT_SOURCE_LOC()) {
     auto tr = generateLocationTrace(loc);
     std::vector<MoveTracker> vec(10, t);
 

--- a/test/WordsAndDocsFileParserTest.cpp
+++ b/test/WordsAndDocsFileParserTest.cpp
@@ -88,8 +88,7 @@ auto testDocsFileParser = [](const std::string& docsFilePath,
 // tokenizer
 auto testTokenizeAndNormalizeText =
     [](std::string testText, const StringVec& normalizedTextAsVec,
-       ad_utility::source_location loc =
-           ad_utility::source_location::current()) {
+       ad_utility::source_location loc = AD_CURRENT_SOURCE_LOC()) {
       auto t = generateLocationTrace(loc);
       size_t i = 0;
       LocaleManager localeManager = getLocaleManager();

--- a/test/engine/BindTest.cpp
+++ b/test/engine/BindTest.cpp
@@ -28,7 +28,7 @@ Bind makeBindForIdTable(QueryExecutionContext* qec, IdTable idTable) {
 
 void expectBindYieldsIdTable(
     QueryExecutionContext* qec, Bind& bind, const IdTable& expected,
-    ad_utility::source_location loc = ad_utility::source_location::current()) {
+    ad_utility::source_location loc = AD_CURRENT_SOURCE_LOC()) {
   auto trace = generateLocationTrace(loc);
 
   {

--- a/test/engine/CartesianProductJoinTest.cpp
+++ b/test/engine/CartesianProductJoinTest.cpp
@@ -60,7 +60,7 @@ CartesianProductJoin makeJoin(const std::vector<VectorTable>& inputs,
 void testCartesianProductImpl(VectorTable expected,
                               std::vector<VectorTable> inputs,
                               bool useLimitInSuboperations = false,
-                              source_location l = source_location::current()) {
+                              source_location l = AD_CURRENT_SOURCE_LOC()) {
   auto t = generateLocationTrace(l);
   {
     auto join = makeJoin(inputs, useLimitInSuboperations);
@@ -87,7 +87,7 @@ void testCartesianProductImpl(VectorTable expected,
 // result. Perform the test for children that directly support the LIMIT
 // operation as well for children that don't (see `makeJoin` above for details).
 void testCartesianProduct(VectorTable expected, std::vector<VectorTable> inputs,
-                          source_location l = source_location::current()) {
+                          source_location l = AD_CURRENT_SOURCE_LOC()) {
   auto t = generateLocationTrace(l);
   testCartesianProductImpl(expected, inputs, true);
   testCartesianProductImpl(expected, inputs, false);
@@ -375,7 +375,7 @@ class CartesianProductJoinLazyTest
       CartesianProductJoin& join, size_t expectedSize,
       const std::vector<size_t>& occurenceCounts,
       const std::vector<size_t>& valueCount,
-      source_location loc = source_location::current()) {
+      source_location loc = AD_CURRENT_SOURCE_LOC()) {
     auto trace = generateLocationTrace(loc);
     join.getExecutionContext()->getQueryTreeCache().clearAll();
     Result result = join.computeResultOnlyForTesting(true);

--- a/test/engine/ExistsJoinTest.cpp
+++ b/test/engine/ExistsJoinTest.cpp
@@ -32,7 +32,7 @@ constexpr auto I = Id::makeFromInt;
 void testExistsFromIdTable(
     IdTable left, IdTable right, std::vector<bool> expectedAsBool,
     size_t numJoinColumns,
-    ad_utility::source_location loc = ad_utility::source_location::current()) {
+    ad_utility::source_location loc = AD_CURRENT_SOURCE_LOC()) {
   auto g = generateLocationTrace(loc);
   AD_CORRECTNESS_CHECK(left.numRows() == expectedAsBool.size());
   AD_CORRECTNESS_CHECK(left.numColumns() >= numJoinColumns);
@@ -85,10 +85,9 @@ void testExistsFromIdTable(
 
 // Same as the function above, but conveniently takes `VectorTable`s instead of
 // `IdTable`s.
-void testExists(
-    const VectorTable& leftInput, const VectorTable& rightInput,
-    std::vector<bool> expectedAsBool, size_t numJoinColumns,
-    ad_utility::source_location loc = ad_utility::source_location::current()) {
+void testExists(const VectorTable& leftInput, const VectorTable& rightInput,
+                std::vector<bool> expectedAsBool, size_t numJoinColumns,
+                ad_utility::source_location loc = AD_CURRENT_SOURCE_LOC()) {
   auto left = makeIdTableFromVector(leftInput);
   auto right = makeIdTableFromVector(rightInput);
   testExistsFromIdTable(std::move(left), std::move(right),
@@ -96,12 +95,10 @@ void testExists(
                         std::move(loc));
 }
 // Helper function to test exists join implementations.
-void testExistsJoin(std::vector<IdTable> leftTables,
-                    std::vector<IdTable> rightTables,
-                    const std::vector<IdTable>& expectedResult,
-                    bool singleVar = false,
-                    ad_utility::source_location location =
-                        ad_utility::source_location::current()) {
+void testExistsJoin(
+    std::vector<IdTable> leftTables, std::vector<IdTable> rightTables,
+    const std::vector<IdTable>& expectedResult, bool singleVar = false,
+    ad_utility::source_location location = AD_CURRENT_SOURCE_LOC()) {
   auto g = generateLocationTrace(location);
   auto qec = ad_utility::testing::getQec();
 

--- a/test/engine/GroupConcatExpressionTest.cpp
+++ b/test/engine/GroupConcatExpressionTest.cpp
@@ -15,10 +15,9 @@ using namespace sparqlExpression;
 namespace tc = ad_utility::triple_component;
 
 // _____________________________________________________________________________
-void expectIdsAreConcatenatedTo(bool distinct, const IdTable& idTable,
-                                const ExpressionResult& expected,
-                                ad_utility::source_location location =
-                                    ad_utility::source_location::current()) {
+void expectIdsAreConcatenatedTo(
+    bool distinct, const IdTable& idTable, const ExpressionResult& expected,
+    ad_utility::source_location location = AD_CURRENT_SOURCE_LOC()) {
   AD_CONTRACT_CHECK(idTable.numColumns() == 1);
   auto* qec = ad_utility::testing::getQec();
   auto g = generateLocationTrace(location);
@@ -50,8 +49,7 @@ void expectIdsAreConcatenatedTo(bool distinct, const IdTable& idTable,
 void expectLiteralsAreConcatenatedTo(
     bool distinct, const std::vector<tc::Literal>& literals,
     const ad_utility::triple_component::Literal& literal,
-    ad_utility::source_location location =
-        ad_utility::source_location::current()) {
+    ad_utility::source_location location = AD_CURRENT_SOURCE_LOC()) {
   LocalVocab localVocab;
   IdTable input{1, ad_utility::makeUnlimitedAllocator<Id>()};
 

--- a/test/engine/IndexScanTest.cpp
+++ b/test/engine/IndexScanTest.cpp
@@ -42,7 +42,7 @@ void testLazyScan(Permutation::IdTableGenerator partialLazyScanResult,
                   IndexScan& fullScan,
                   const std::vector<IndexPair>& expectedRows,
                   const LimitOffsetClause& limitOffset = {},
-                  source_location l = source_location::current()) {
+                  source_location l = AD_CURRENT_SOURCE_LOC()) {
   auto t = generateLocationTrace(l);
   auto alloc = ad_utility::makeUnlimitedAllocator<Id>();
   IdTable lazyScanRes{0, alloc};
@@ -103,7 +103,7 @@ void testLazyScanForJoinOfTwoScans(
     const std::vector<IndexPair>& leftRows,
     const std::vector<IndexPair>& rightRows,
     ad_utility::MemorySize blocksizePermutations = 16_B,
-    source_location l = source_location::current()) {
+    source_location l = AD_CURRENT_SOURCE_LOC()) {
   auto t = generateLocationTrace(l);
   // As soon as there is a LIMIT clause present, we cannot use the prefiltered
   // blocks.
@@ -134,7 +134,7 @@ void testLazyScanForJoinOfTwoScans(
 void testLazyScanThrows(const std::string& kg,
                         const SparqlTripleSimple& tripleLeft,
                         const SparqlTripleSimple& tripleRight,
-                        source_location l = source_location::current()) {
+                        source_location l = AD_CURRENT_SOURCE_LOC()) {
   auto t = generateLocationTrace(l);
   auto qec = getQec(kg);
   IndexScan s1{qec, Permutation::PSO, tripleLeft};
@@ -149,7 +149,7 @@ void testLazyScanForJoinWithColumn(
     const std::string& kg, const SparqlTripleSimple& scanTriple,
     std::vector<TripleComponent> columnEntries,
     const std::vector<IndexPair>& expectedRows,
-    source_location l = source_location::current()) {
+    source_location l = AD_CURRENT_SOURCE_LOC()) {
   auto t = generateLocationTrace(l);
   auto qec = getQec(kg);
   IndexScan scan{qec, Permutation::PSO, scanTriple};
@@ -169,7 +169,7 @@ void testLazyScanForJoinWithColumn(
 void testLazyScanWithColumnThrows(
     const std::string& kg, const SparqlTripleSimple& scanTriple,
     const std::vector<TripleComponent>& columnEntries,
-    source_location l = source_location::current()) {
+    source_location l = AD_CURRENT_SOURCE_LOC()) {
   auto t = generateLocationTrace(l);
   auto qec = getQec(kg);
   IndexScan s1{qec, Permutation::PSO, scanTriple};
@@ -204,7 +204,7 @@ const auto testSetAndMakeScanWithPrefilterExpr =
        const std::vector<ValueId>& expectedIdsOnFilterColumn,
        bool prefilterCanBeSet,
        std::optional<IndexScan::PrefilterVariablePair> pr2 = std::nullopt,
-       source_location l = source_location::current()) {
+       source_location l = AD_CURRENT_SOURCE_LOC()) {
       auto t = generateLocationTrace(l);
       IndexScan scan{getQec(kg), permutation, triple};
       auto variable = pr1.second;
@@ -625,7 +625,7 @@ TEST(IndexScan, unlikelyToFitInCacheCalculatesSizeCorrectly) {
   auto expectMaximumCacheableSize = [&](const IndexScan& scan, size_t numRows,
                                         size_t numCols,
                                         source_location l =
-                                            source_location::current()) {
+                                            AD_CURRENT_SOURCE_LOC()) {
     auto locationTrace = generateLocationTrace(l);
 
     EXPECT_TRUE(scan.unlikelyToFitInCache(MemorySize::bytes(0)));
@@ -1356,7 +1356,7 @@ TEST(IndexScanTest, StripColumns) {
                                  const std::vector<Variable>& varsToKeep,
                                  const std::vector<ColumnIndex>& sortedOn,
                                  ad_utility::source_location l =
-                                     ad_utility::source_location::current()) {
+                                     AD_CURRENT_SOURCE_LOC()) {
     auto trace = generateLocationTrace(l);
     IdTable baseResult =
         baseScan.computeResultOnlyForTesting(false).idTable().clone();
@@ -1511,8 +1511,7 @@ TEST(IndexScanTest, StripColumns) {
                                    IndexScan& baseScanDifferentVars) {
     return [&](const std::vector<Variable>& varsToKeep,
                const std::vector<ColumnIndex>& sortedOn,
-               ad_utility::source_location l =
-                   ad_utility::source_location::current()) {
+               ad_utility::source_location l = AD_CURRENT_SOURCE_LOC()) {
       return testStrippedColumns(baseScan, baseScanDifferentVars, varsToKeep,
                                  sortedOn, l);
     };

--- a/test/engine/OptionalJoinTest.cpp
+++ b/test/engine/OptionalJoinTest.cpp
@@ -72,12 +72,10 @@ void testOptionalJoin(const IdTable& inputA, const IdTable& inputB,
 }
 
 // Helper function to test lazy join implementations.
-void testLazyOptionalJoin(std::vector<IdTable> leftTables,
-                          std::vector<IdTable> rightTables,
-                          const std::vector<IdTable>& expectedResult,
-                          bool singleVar = false,
-                          ad_utility::source_location location =
-                              ad_utility::source_location::current()) {
+void testLazyOptionalJoin(
+    std::vector<IdTable> leftTables, std::vector<IdTable> rightTables,
+    const std::vector<IdTable>& expectedResult, bool singleVar = false,
+    ad_utility::source_location location = AD_CURRENT_SOURCE_LOC()) {
   auto g = generateLocationTrace(location);
   auto qec = ad_utility::testing::getQec();
 
@@ -742,21 +740,20 @@ TEST(OptionalJoin, columnOriginatesFromGraphOrUndef) {
                SparqlTripleSimple{Variable{"?a"}, Iri::fromIriref("<b>"),
                                   Variable{"?c"}}));
 
-  auto testWithTrees = [qec](std::shared_ptr<QueryExecutionTree> left,
-                             std::shared_ptr<QueryExecutionTree> right, bool a,
-                             bool b, bool c,
-                             ad_utility::source_location location =
-                                 ad_utility::source_location::current()) {
-    auto trace = generateLocationTrace(location);
+  auto testWithTrees =
+      [qec](std::shared_ptr<QueryExecutionTree> left,
+            std::shared_ptr<QueryExecutionTree> right, bool a, bool b, bool c,
+            ad_utility::source_location location = AD_CURRENT_SOURCE_LOC()) {
+        auto trace = generateLocationTrace(location);
 
-    OptionalJoin optional{qec, std::move(left), std::move(right)};
-    EXPECT_EQ(optional.columnOriginatesFromGraphOrUndef(Variable{"?a"}), a);
-    EXPECT_EQ(optional.columnOriginatesFromGraphOrUndef(Variable{"?b"}), b);
-    EXPECT_EQ(optional.columnOriginatesFromGraphOrUndef(Variable{"?c"}), c);
-    EXPECT_THROW(
-        optional.columnOriginatesFromGraphOrUndef(Variable{"?notExisting"}),
-        ad_utility::Exception);
-  };
+        OptionalJoin optional{qec, std::move(left), std::move(right)};
+        EXPECT_EQ(optional.columnOriginatesFromGraphOrUndef(Variable{"?a"}), a);
+        EXPECT_EQ(optional.columnOriginatesFromGraphOrUndef(Variable{"?b"}), b);
+        EXPECT_EQ(optional.columnOriginatesFromGraphOrUndef(Variable{"?c"}), c);
+        EXPECT_THROW(
+            optional.columnOriginatesFromGraphOrUndef(Variable{"?notExisting"}),
+            ad_utility::Exception);
+      };
 
   OptionalJoin optional{qec, values1, values1};
   EXPECT_FALSE(optional.columnOriginatesFromGraphOrUndef(Variable{"?a"}));

--- a/test/engine/SpatialJoinAlgorithmsTest.cpp
+++ b/test/engine/SpatialJoinAlgorithmsTest.cpp
@@ -1691,7 +1691,7 @@ using Loc = ad_utility::source_location;
 // used number of threads is the expected.
 void testNumberOfThreads(size_t runtimeParamNumThreads,
                          size_t expectedNumberOfThreads,
-                         Loc sourceLocation = Loc::current()) {
+                         Loc sourceLocation = AD_CURRENT_SOURCE_LOC()) {
   auto cleanUp =
       setRuntimeParameterForTest<&RuntimeParameters::spatialJoinMaxNumThreads_>(
           runtimeParamNumThreads);

--- a/test/engine/SpatialJoinPrefilterTestHelpers.h
+++ b/test/engine/SpatialJoinPrefilterTestHelpers.h
@@ -157,7 +157,7 @@ inline ValueId getValId(const GeomNameToValId& nMap, std::string_view name) {
 // names to `ValueId`s for the geometries in `testGeometries`.
 inline ValIdTable resolveValIdTable(QueryExecutionContext* qec,
                                     size_t expectedSize,
-                                    Loc loc = Loc::current()) {
+                                    Loc loc = AD_CURRENT_SOURCE_LOC()) {
   auto l = generateLocationTrace(loc);
   ValIdToGeomName vMap;
   GeomNameToValId nMap;
@@ -243,7 +243,7 @@ inline void runParsingAndSweeper(
     QEC qec, std::string_view leftPred, std::string_view rightPred,
     const LibSpatialJoinConfig& sjTask, SweeperTestResult& testResult,
     bool usePrefilter = true, bool checkPrefilterDeactivate = false,
-    bool useRegularImplementation = false, Loc loc = Loc::current()) {
+    bool useRegularImplementation = false, Loc loc = AD_CURRENT_SOURCE_LOC()) {
   using V = Variable;
   auto l = generateLocationTrace(loc);
 
@@ -379,7 +379,7 @@ inline void runParsingAndSweeper(
 // `runParsingAndSweeper`
 inline void checkPrefilterBox(const util::geo::DBox& actualLatLng,
                               const util::geo::DBox& expectedLatLng,
-                              Loc loc = Loc::current()) {
+                              Loc loc = AD_CURRENT_SOURCE_LOC()) {
   auto l = generateLocationTrace(loc);
 
   auto lowerLeftActual = actualLatLng.getLowerLeft();
@@ -399,12 +399,12 @@ inline void checkSweeperTestResult(
     const ValIdToGeomName& vMap, const SweeperTestResult& actual,
     const SweeperTestResult& expected,
     std::optional<SpatialJoinType> checkOnlySjType = std::nullopt,
-    bool checkPrefilterBoxes = false, Loc loc = Loc::current()) {
+    bool checkPrefilterBoxes = false, Loc loc = AD_CURRENT_SOURCE_LOC()) {
   auto l = generateLocationTrace(loc);
 
   ad_utility::HashMap<GeoRelationWithIds, double> expectedResultsAndDist;
 
-  auto checkValId = [&](ValueId valId, Loc loc = Loc::current()) {
+  auto checkValId = [&](ValueId valId, Loc loc = AD_CURRENT_SOURCE_LOC()) {
     auto l = generateLocationTrace(loc);
     ASSERT_EQ(valId.getDatatype(), Datatype::VocabIndex);
     ASSERT_TRUE(vMap.contains(valId));

--- a/test/engine/idTable/CompressedExternalIdTableTest.cpp
+++ b/test/engine/idTable/CompressedExternalIdTableTest.cpp
@@ -62,7 +62,7 @@ TEST(CompressedExternalIdTable, compressedExternalIdTableWriter) {
 
   auto runTestForBlockSize = [](ad_utility::MemorySize memoryToUse,
                                 ad_utility::source_location l =
-                                    source_location::current()) {
+                                    AD_CURRENT_SOURCE_LOC()) {
     auto trace = generateLocationTrace(l);
     std::string filename = "idTableCompressedWriter.compressedWriterTest.dat";
     ad_utility::CompressedExternalIdTableWriter writer{
@@ -97,7 +97,7 @@ template <size_t NumStaticColumns>
 void testExternalSorterImpl(size_t numDynamicColumns, size_t numRows,
                             ad_utility::MemorySize memoryToUse,
                             bool mergeMultipleTimes,
-                            source_location l = source_location::current()) {
+                            source_location l = AD_CURRENT_SOURCE_LOC()) {
   auto tr = generateLocationTrace(l);
   std::string filename = "idTableCompressedSorter.testExternalSorter.dat";
   using namespace ad_utility::memory_literals;
@@ -163,7 +163,7 @@ void testExternalSorterImpl(size_t numDynamicColumns, size_t numRows,
 template <size_t NumStaticColumns>
 void testExternalSorter(size_t numDynamicColumns, size_t numRows,
                         ad_utility::MemorySize memoryToUse,
-                        source_location l = source_location::current()) {
+                        source_location l = AD_CURRENT_SOURCE_LOC()) {
   testExternalSorterImpl<NumStaticColumns>(numDynamicColumns, numRows,
                                            memoryToUse, true, l);
   testExternalSorterImpl<NumStaticColumns>(numDynamicColumns, numRows,

--- a/test/index/PatternCreatorTest.cpp
+++ b/test/index/PatternCreatorTest.cpp
@@ -124,7 +124,7 @@ auto createExamplePatterns(PatternCreator& creator) {
 // from the `createExamplePatterns` function.
 void assertPatternContents(const std::string& filename,
                            const TripleVec& addedTriples,
-                           source_location l = source_location ::current()) {
+                           source_location l = AD_CURRENT_SOURCE_LOC()) {
   auto tr = generateLocationTrace(l);
   double averageNumSubjectsPerPredicate;
   double averageNumPredicatesPerSubject;

--- a/test/parser/BlankNodeExpressionTest.cpp
+++ b/test/parser/BlankNodeExpressionTest.cpp
@@ -61,7 +61,7 @@ TEST(BlankNodeExpression, labelsAreCorrectlyEscaped) {
   auto expectIrisAre = [&context](std::string_view input,
                                   const std::vector<std::string_view>& expected,
                                   ad_utility::source_location loc =
-                                      ad_utility::source_location::current()) {
+                                      AD_CURRENT_SOURCE_LOC()) {
     auto t = generateLocationTrace(loc);
     auto expression =
         makeBlankNodeExpression(std::make_unique<StringLiteralExpression>(

--- a/test/parser/QuadTest.cpp
+++ b/test/parser/QuadTest.cpp
@@ -18,8 +18,7 @@ TEST(QuadTest, getQuads) {
       [](ad_utility::sparql_types::Triples triples,
          std::vector<Quads::GraphBlock> graphs,
          const std::vector<SparqlTripleSimpleWithGraph>& expected,
-         ad_utility::source_location l =
-             ad_utility::source_location::current()) {
+         ad_utility::source_location l = AD_CURRENT_SOURCE_LOC()) {
         auto t = generateLocationTrace(l);
         // For this test, there are no blank nodes. Below you find a dedicated
         // test with blank nodes.
@@ -89,8 +88,7 @@ TEST(QuadTest, getOperations) {
          std::vector<Quads::GraphBlock> graphs,
          const testing::Matcher<
              std::vector<parsedQuery::GraphPatternOperation>>& m,
-         ad_utility::source_location l =
-             ad_utility::source_location::current()) {
+         ad_utility::source_location l = AD_CURRENT_SOURCE_LOC()) {
         auto t = generateLocationTrace(l);
         const Quads quads{std::move(triples), std::move(graphs)};
         EXPECT_THAT(quads.toGraphPatternOperations(), m);
@@ -131,8 +129,7 @@ TEST(QuadTest, getOperations) {
 TEST(QuadTest, forAllVariables) {
   auto expectForAllVariables =
       [](Quads quads, const ad_utility::HashSet<Variable>& expectVariables,
-         ad_utility::source_location l =
-             ad_utility::source_location::current()) {
+         ad_utility::source_location l = AD_CURRENT_SOURCE_LOC()) {
         auto t = generateLocationTrace(l);
         ad_utility::HashSet<Variable> calledVariables;
         quads.forAllVariables([&calledVariables](const Variable& var) {

--- a/test/parser/SparqlAntlrParserTestHelpers.h
+++ b/test/parser/SparqlAntlrParserTestHelpers.h
@@ -140,7 +140,7 @@ inline std::ostream& operator<<(std::ostream& out,
 template <typename Result, typename Matcher>
 void expectCompleteParse(
     const Result& resultOfParseAndText, Matcher&& matcher,
-    ad_utility::source_location l = ad_utility::source_location::current()) {
+    ad_utility::source_location l = AD_CURRENT_SOURCE_LOC()) {
   auto trace = generateLocationTrace(l);
   EXPECT_THAT(resultOfParseAndText.resultOfParse_, matcher);
   EXPECT_TRUE(resultOfParseAndText.remainingText_.empty());
@@ -160,7 +160,7 @@ template <typename Result, typename Matcher>
 void expectIncompleteParse(
     const Result& resultOfParseAndText, const std::string& rest,
     Matcher&& matcher,
-    ad_utility::source_location l = ad_utility::source_location::current()) {
+    ad_utility::source_location l = AD_CURRENT_SOURCE_LOC()) {
   auto trace = generateLocationTrace(l);
   EXPECT_THAT(resultOfParseAndText.resultOfParse_, matcher);
   EXPECT_EQ(resultOfParseAndText.remainingText_, rest);
@@ -1254,31 +1254,29 @@ struct ExpectCompleteParse {
   SparqlQleverVisitor::DisableSomeChecksOnlyForTesting disableSomeChecks =
       SparqlQleverVisitor::DisableSomeChecksOnlyForTesting::False;
 
-  auto operator()(const std::string& input, const Value& value,
-                  ad_utility::source_location l =
-                      ad_utility::source_location::current()) const {
+  auto operator()(
+      const std::string& input, const Value& value,
+      ad_utility::source_location l = AD_CURRENT_SOURCE_LOC()) const {
     return operator()(input, value, prefixMap_, l);
   }
 
-  auto operator()(const std::string& input,
-                  const testing::Matcher<const Value&>& matcher,
-                  ad_utility::source_location l =
-                      ad_utility::source_location::current()) const {
+  auto operator()(
+      const std::string& input, const testing::Matcher<const Value&>& matcher,
+      ad_utility::source_location l = AD_CURRENT_SOURCE_LOC()) const {
     return operator()(input, matcher, prefixMap_, l);
   }
 
-  auto operator()(const std::string& input, const Value& value,
-                  SparqlQleverVisitor::PrefixMap prefixMap,
-                  ad_utility::source_location l =
-                      ad_utility::source_location::current()) const {
+  auto operator()(
+      const std::string& input, const Value& value,
+      SparqlQleverVisitor::PrefixMap prefixMap,
+      ad_utility::source_location l = AD_CURRENT_SOURCE_LOC()) const {
     return operator()(input, testing::Eq(value), std::move(prefixMap), l);
   }
 
-  auto operator()(const std::string& input,
-                  const testing::Matcher<const Value&>& matcher,
-                  SparqlQleverVisitor::PrefixMap prefixMap,
-                  ad_utility::source_location l =
-                      ad_utility::source_location::current()) const {
+  auto operator()(
+      const std::string& input, const testing::Matcher<const Value&>& matcher,
+      SparqlQleverVisitor::PrefixMap prefixMap,
+      ad_utility::source_location l = AD_CURRENT_SOURCE_LOC()) const {
     auto tr = generateLocationTrace(l, "successful parsing was expected here");
     EXPECT_NO_THROW({
       return expectCompleteParse(
@@ -1288,11 +1286,10 @@ struct ExpectCompleteParse {
     });
   }
 
-  auto operator()(const std::string& input,
-                  const testing::Matcher<const Value&>& matcher,
-                  ParsedQuery::DatasetClauses activeDatasetClauses,
-                  ad_utility::source_location l =
-                      ad_utility::source_location::current()) const {
+  auto operator()(
+      const std::string& input, const testing::Matcher<const Value&>& matcher,
+      ParsedQuery::DatasetClauses activeDatasetClauses,
+      ad_utility::source_location l = AD_CURRENT_SOURCE_LOC()) const {
     auto tr = generateLocationTrace(l, "successful parsing was expected here");
     EXPECT_NO_THROW({
       return expectCompleteParse(
@@ -1312,14 +1309,14 @@ struct ExpectParseFails {
   auto operator()(
       const std::string& input,
       const testing::Matcher<const std::string&>& messageMatcher = ::testing::_,
-      ad_utility::source_location l = ad_utility::source_location::current()) {
+      ad_utility::source_location l = AD_CURRENT_SOURCE_LOC()) {
     return operator()(input, prefixMap_, messageMatcher, l);
   }
 
   auto operator()(
       const std::string& input, SparqlQleverVisitor::PrefixMap prefixMap,
       const testing::Matcher<const std::string&>& messageMatcher = ::testing::_,
-      ad_utility::source_location l = ad_utility::source_location::current()) {
+      ad_utility::source_location l = AD_CURRENT_SOURCE_LOC()) {
     auto trace = generateLocationTrace(l);
     AD_EXPECT_THROW_WITH_MESSAGE(
         parse<Clause>(input, std::move(prefixMap), {}, disableSomeChecks),

--- a/test/parser/SparqlAntlrParserUpdateTest.cpp
+++ b/test/parser/SparqlAntlrParserUpdateTest.cpp
@@ -15,10 +15,10 @@ auto iri = ad_utility::testing::iri;
 TEST(SparqlParser, Update) {
   auto expectUpdate_ = ExpectCompleteParse<&Parser::update>{defaultPrefixMap};
   // Automatically test all updates for their `_originalString`.
-  auto expectUpdate = [&expectUpdate_](
-                          const std::string& query, auto&& expected,
-                          ad_utility::source_location l =
-                              ad_utility::source_location::current()) {
+  auto expectUpdate = [&expectUpdate_](const std::string& query,
+                                       auto&& expected,
+                                       ad_utility::source_location l =
+                                           AD_CURRENT_SOURCE_LOC()) {
     expectUpdate_(query,
                   testing::ElementsAre(
                       testing::AllOf(expected, m::pq::OriginalString(query))),

--- a/test/parser/UpdateTriplesTest.cpp
+++ b/test/parser/UpdateTriplesTest.cpp
@@ -31,9 +31,8 @@ TEST(UpdateTriples, ConstructorsAndAssignments) {
 
   // Check that the `UpdateTriples tr` consist of exactly the single `triple` as
   // specified above and that the local vocab was also correctly porpagated.
-  auto testTriples = [&](auto&& tr,
-                         ad_utility::source_location loc =
-                             ad_utility::source_location::current()) {
+  auto testTriples = [&](auto&& tr, ad_utility::source_location loc =
+                                        AD_CURRENT_SOURCE_LOC()) {
     auto trace = generateLocationTrace(loc);
     EXPECT_EQ(tr.triples_, triples);
     EXPECT_THAT(tr.localVocab_.getAllWordsForTesting(),

--- a/test/util/HttpClientTestHelpers.h
+++ b/test/util/HttpClientTestHelpers.h
@@ -36,7 +36,7 @@ static auto constexpr getResultFunctionFactory =
        RequestMatchers matchers_ = {},
        std::exception_ptr mockException = nullptr,
        ad_utility::source_location loc =
-           ad_utility::source_location::current()) -> SendRequestType {
+           AD_CURRENT_SOURCE_LOC()) -> SendRequestType {
   return
       [=](const ad_utility::httpUtils::Url& url,
           ad_utility::SharedCancellationHandle,

--- a/test/util/IdTableHelpers.h
+++ b/test/util/IdTableHelpers.h
@@ -135,7 +135,7 @@ void compareIdTableWithExpectedContent(
     const IdTable& table, const IdTable& expectedContent,
     const bool resultMustBeSortedByJoinColumn = false,
     const size_t joinColumn = 0,
-    ad_utility::source_location l = ad_utility::source_location::current());
+    ad_utility::source_location l = AD_CURRENT_SOURCE_LOC());
 
 /*
  * @brief Sorts an IdTable in place, in the same way, that we sort them during


### PR DESCRIPTION
Implement `ad_utility::source_location` , a drop-in replacement for `std::source_location`.  The function `source_location::current()` is replaced by a macro `AD_CURRENT_SOURCE_LOC()` which has the exact same behavior. In particular, when used as a defaulted argument to a function, it provides the source location from which the function was called.