### PR TITLE
Migrate default-constructed lambdas to C++17

### DIFF
--- a/src/engine/sparqlExpressions/NaryExpressionImpl.h
+++ b/src/engine/sparqlExpressions/NaryExpressionImpl.h
@@ -135,12 +135,15 @@ template <size_t N, typename X, typename... T>
 using NARY = NaryExpression<Operation<N, X, T...>>;
 
 // True iff all types `Ts` are `SetOfIntervals`.
-inline auto areAllSetOfIntervals = [](const auto&... t) constexpr {
-  return (... && ad_utility::isSimilar<std::decay_t<decltype(t)>,
-                                       ad_utility::SetOfIntervals>);
+struct AreAllSetOfIntervals {
+  template <typename... Ts>
+  constexpr bool operator()(const Ts&... t) const {
+    return (... && ad_utility::isSimilar<std::decay_t<decltype(t)>,
+                                         ad_utility::SetOfIntervals>);
+  }
 };
 template <typename F>
-using SET = SpecializedFunction<F, decltype(areAllSetOfIntervals)>;
+using SET = SpecializedFunction<F, AreAllSetOfIntervals>;
 
 using ad_utility::SetOfIntervals;
 

--- a/src/engine/sparqlExpressions/NaryExpressionImpl.h
+++ b/src/engine/sparqlExpressions/NaryExpressionImpl.h
@@ -111,10 +111,10 @@ struct NumericIdWrapper {
 // and returns the same result, but the arguments and the return type are the
 // `NumericValue` variant.
 template <typename Function, bool NanOrInfToUndef = false>
-inline auto makeNumericExpression() {
-  return [](const auto&... args) {
-    CPP_assert(
-        (concepts::same_as<std::decay_t<decltype(args)>, NumericValue> && ...));
+struct MakeNumericExpression {
+  template <typename... Args>
+  Id operator()(const Args&... args) const {
+    CPP_assert((concepts::same_as<std::decay_t<Args>, NumericValue> && ...));
     auto visitor = [](const auto&... t) {
       if constexpr ((... ||
                      std::is_same_v<NotNumeric, std::decay_t<decltype(t)>>)) {
@@ -124,8 +124,8 @@ inline auto makeNumericExpression() {
       }
     };
     return std::visit(visitor, args...);
-  };
-}
+  }
+};
 
 // Two short aliases to make the instantiations more readable.
 template <typename... T>

--- a/src/engine/sparqlExpressions/NumericBinaryExpressions.cpp
+++ b/src/engine/sparqlExpressions/NumericBinaryExpressions.cpp
@@ -8,9 +8,8 @@
 namespace sparqlExpression {
 namespace detail {
 // Multiplication.
-inline auto multiply = makeNumericExpression<std::multiplies<>>();
-NARY_EXPRESSION(MultiplyExpression, 2,
-                FV<decltype(multiply), NumericValueGetter>);
+using Multiply = MakeNumericExpression<std::multiplies<>>;
+NARY_EXPRESSION(MultiplyExpression, 2, FV<Multiply, NumericValueGetter>);
 
 // Division.
 //
@@ -29,21 +28,20 @@ struct DivideImpl {
   }
 };
 
-inline auto divide1 = makeNumericExpression<DivideImpl, true>();
+using Divide1 = MakeNumericExpression<DivideImpl, true>;
 NARY_EXPRESSION(DivideExpressionByZeroIsUndef, 2,
-                FV<decltype(divide1), NumericValueGetter>);
+                FV<Divide1, NumericValueGetter>);
 
-inline auto divide2 = makeNumericExpression<DivideImpl, false>();
+using Divide2 = MakeNumericExpression<DivideImpl, false>;
 NARY_EXPRESSION(DivideExpressionByZeroIsNan, 2,
-                FV<decltype(divide2), NumericValueGetter>);
+                FV<Divide2, NumericValueGetter>);
 
 // Addition and subtraction, currently all results are converted to double.
-inline auto add = makeNumericExpression<std::plus<>>();
-NARY_EXPRESSION(AddExpression, 2, FV<decltype(add), NumericValueGetter>);
+using Add = MakeNumericExpression<std::plus<>>;
+NARY_EXPRESSION(AddExpression, 2, FV<Add, NumericValueGetter>);
 
-inline auto subtract = makeNumericExpression<std::minus<>>();
-NARY_EXPRESSION(SubtractExpression, 2,
-                FV<decltype(subtract), NumericValueGetter>);
+using Subtract = MakeNumericExpression<std::minus<>>;
+NARY_EXPRESSION(SubtractExpression, 2, FV<Subtract, NumericValueGetter>);
 
 // _____________________________________________________________________________
 // Power.
@@ -52,8 +50,8 @@ struct PowImpl {
     return std::pow(base, exp);
   }
 };
-inline auto pow = makeNumericExpression<PowImpl>();
-NARY_EXPRESSION(PowExpression, 2, FV<decltype(pow), NumericValueGetter>);
+using Pow = MakeNumericExpression<PowImpl>;
+NARY_EXPRESSION(PowExpression, 2, FV<Pow, NumericValueGetter>);
 
 // OR and AND
 // _____________________________________________________________________________

--- a/src/engine/sparqlExpressions/NumericUnaryExpressions.cpp
+++ b/src/engine/sparqlExpressions/NumericUnaryExpressions.cpp
@@ -13,17 +13,19 @@ namespace detail {
 
 // _____________________________________________________________________________
 // Unary negation.
-inline auto unaryNegate = [](TernaryBool a) {
-  using enum TernaryBool;
-  switch (a) {
-    case True:
-      return Id::makeFromBool(false);
-    case False:
-      return Id::makeFromBool(true);
-    case Undef:
-      return Id::makeUndefined();
+struct UnaryNegate {
+  Id operator()(TernaryBool a) const {
+    using enum TernaryBool;
+    switch (a) {
+      case True:
+        return Id::makeFromBool(false);
+      case False:
+        return Id::makeFromBool(true);
+      case Undef:
+        return Id::makeUndefined();
+    }
+    AD_FAIL();
   }
-  AD_FAIL();
 };
 
 CPP_template(typename NaryOperation)(
@@ -81,7 +83,7 @@ CPP_template(typename NaryOperation)(
 };
 
 using UnaryNegateExpression = UnaryNegateExpressionImpl<
-    Operation<1, FV<decltype(unaryNegate), EffectiveBooleanValueGetter>,
+    Operation<1, FV<UnaryNegate, EffectiveBooleanValueGetter>,
               SET<SetOfIntervals::Complement>>>;
 
 // _____________________________________________________________________________
@@ -90,78 +92,119 @@ inline auto unaryMinus = makeNumericExpression<std::negate<>>();
 NARY_EXPRESSION(UnaryMinusExpression, 1,
                 FV<decltype(unaryMinus), NumericValueGetter>);
 // Abs
-inline const auto absImpl = [](auto num) { return std::abs(num); };
-inline const auto abs = makeNumericExpression<decltype(absImpl)>();
+struct AbsImpl {
+  template <typename T>
+  auto operator()(T num) const {
+    return std::abs(num);
+  }
+};
+inline const auto abs = makeNumericExpression<AbsImpl>();
 NARY_EXPRESSION(AbsExpression, 1, FV<decltype(abs), NumericValueGetter>);
 
 // Rounding.
-inline const auto roundImpl = [](auto num) {
-  using T = decltype(num);
-  if constexpr (ql::concepts::floating_point<T>) {
-    auto res = std::round(num);
-    // In SPARQL, negative numbers are rounded towards zero if they lie exactly
-    // between two integers.
-    return (num < 0 && std::abs(res - num) == 0.5) ? res + 1 : res;
-  } else {
-    return num;
+struct RoundImpl {
+  template <typename T>
+  auto operator()(T num) const {
+    if constexpr (ql::concepts::floating_point<T>) {
+      auto res = std::round(num);
+      // In SPARQL, negative numbers are rounded towards zero if they lie
+      // exactly between two integers.
+      return (num < 0 && std::abs(res - num) == 0.5) ? res + 1 : res;
+    } else {
+      return num;
+    }
   }
 };
 
-inline const auto round = makeNumericExpression<decltype(roundImpl)>();
+inline const auto round = makeNumericExpression<RoundImpl>();
 NARY_EXPRESSION(RoundExpression, 1, FV<decltype(round), NumericValueGetter>);
 
 // Ceiling.
-inline const auto ceilImpl = [](auto num) {
-  using T = decltype(num);
-  if constexpr (ql::concepts::floating_point<T>) {
-    return std::ceil(num);
-  } else {
-    return num;
+struct CeilImpl {
+  template <typename T>
+  auto operator()(T num) const {
+    if constexpr (ql::concepts::floating_point<T>) {
+      return std::ceil(num);
+    } else {
+      return num;
+    }
   }
 };
-inline const auto ceil = makeNumericExpression<decltype(ceilImpl)>();
+inline const auto ceil = makeNumericExpression<CeilImpl>();
 NARY_EXPRESSION(CeilExpression, 1, FV<decltype(ceil), NumericValueGetter>);
 
 // Flooring.
-inline const auto floorImpl = [](auto num) {
-  using T = decltype(num);
-  if constexpr (ql::concepts::floating_point<T>) {
-    return std::floor(num);
-  } else {
-    return num;
+struct FloorImpl {
+  template <typename T>
+  auto operator()(T num) const {
+    if constexpr (ql::concepts::floating_point<T>) {
+      return std::floor(num);
+    } else {
+      return num;
+    }
   }
 };
-inline const auto floor = makeNumericExpression<decltype(floorImpl)>();
+inline const auto floor = makeNumericExpression<FloorImpl>();
 using FloorExpression = NARY<1, FV<decltype(floor), NumericValueGetter>>;
 
 // Natural Logarithm.
-inline const auto logImpl = [](auto num) { return std::log(num); };
-inline const auto log = makeNumericExpression<decltype(logImpl)>();
+struct LogImpl {
+  template <typename T>
+  auto operator()(T num) const {
+    return std::log(num);
+  }
+};
+inline const auto log = makeNumericExpression<LogImpl>();
 using LogExpression = NARY<1, FV<decltype(log), NumericValueGetter>>;
 
 // Exponentiation.
-inline const auto expImpl = [](auto num) { return std::exp(num); };
-inline const auto exp = makeNumericExpression<decltype(expImpl)>();
+struct ExpImpl {
+  template <typename T>
+  auto operator()(T num) const {
+    return std::exp(num);
+  }
+};
+inline const auto exp = makeNumericExpression<ExpImpl>();
 using ExpExpression = NARY<1, FV<decltype(exp), NumericValueGetter>>;
 
 // Square root.
-inline const auto sqrtImpl = [](auto num) { return std::sqrt(num); };
-inline const auto sqrt = makeNumericExpression<decltype(sqrtImpl)>();
+struct SqrtImpl {
+  template <typename T>
+  auto operator()(T num) const {
+    return std::sqrt(num);
+  }
+};
+inline const auto sqrt = makeNumericExpression<SqrtImpl>();
 using SqrtExpression = NARY<1, FV<decltype(sqrt), NumericValueGetter>>;
 
 // Sine.
-inline const auto sinImpl = [](auto num) { return std::sin(num); };
-inline const auto sin = makeNumericExpression<decltype(sinImpl)>();
+struct SinImpl {
+  template <typename T>
+  auto operator()(T num) const {
+    return std::sin(num);
+  }
+};
+inline const auto sin = makeNumericExpression<SinImpl>();
 using SinExpression = NARY<1, FV<decltype(sin), NumericValueGetter>>;
 
 // Cosine.
-inline const auto cosImpl = [](auto num) { return std::cos(num); };
-inline const auto cos = makeNumericExpression<decltype(cosImpl)>();
+struct CosImpl {
+  template <typename T>
+  auto operator()(T num) const {
+    return std::cos(num);
+  }
+};
+inline const auto cos = makeNumericExpression<CosImpl>();
 using CosExpression = NARY<1, FV<decltype(cos), NumericValueGetter>>;
 
 // Tangent.
-inline const auto tanImpl = [](auto num) { return std::tan(num); };
-inline const auto tan = makeNumericExpression<decltype(tanImpl)>();
+struct TanImpl {
+  template <typename T>
+  auto operator()(T num) const {
+    return std::tan(num);
+  }
+};
+inline const auto tan = makeNumericExpression<TanImpl>();
 using TanExpression = NARY<1, FV<decltype(tan), NumericValueGetter>>;
 
 }  // namespace detail

--- a/src/engine/sparqlExpressions/NumericUnaryExpressions.cpp
+++ b/src/engine/sparqlExpressions/NumericUnaryExpressions.cpp
@@ -88,9 +88,8 @@ using UnaryNegateExpression = UnaryNegateExpressionImpl<
 
 // _____________________________________________________________________________
 // Unary Minus.
-inline auto unaryMinus = makeNumericExpression<std::negate<>>();
-NARY_EXPRESSION(UnaryMinusExpression, 1,
-                FV<decltype(unaryMinus), NumericValueGetter>);
+using UnaryMinus = MakeNumericExpression<std::negate<>>;
+NARY_EXPRESSION(UnaryMinusExpression, 1, FV<UnaryMinus, NumericValueGetter>);
 // Abs
 struct AbsImpl {
   template <typename T>
@@ -98,8 +97,8 @@ struct AbsImpl {
     return std::abs(num);
   }
 };
-inline const auto abs = makeNumericExpression<AbsImpl>();
-NARY_EXPRESSION(AbsExpression, 1, FV<decltype(abs), NumericValueGetter>);
+using Abs = MakeNumericExpression<AbsImpl>;
+NARY_EXPRESSION(AbsExpression, 1, FV<Abs, NumericValueGetter>);
 
 // Rounding.
 struct RoundImpl {
@@ -116,8 +115,8 @@ struct RoundImpl {
   }
 };
 
-inline const auto round = makeNumericExpression<RoundImpl>();
-NARY_EXPRESSION(RoundExpression, 1, FV<decltype(round), NumericValueGetter>);
+using Round = MakeNumericExpression<RoundImpl>;
+NARY_EXPRESSION(RoundExpression, 1, FV<Round, NumericValueGetter>);
 
 // Ceiling.
 struct CeilImpl {
@@ -130,8 +129,8 @@ struct CeilImpl {
     }
   }
 };
-inline const auto ceil = makeNumericExpression<CeilImpl>();
-NARY_EXPRESSION(CeilExpression, 1, FV<decltype(ceil), NumericValueGetter>);
+using Ceil = MakeNumericExpression<CeilImpl>;
+NARY_EXPRESSION(CeilExpression, 1, FV<Ceil, NumericValueGetter>);
 
 // Flooring.
 struct FloorImpl {
@@ -144,8 +143,8 @@ struct FloorImpl {
     }
   }
 };
-inline const auto floor = makeNumericExpression<FloorImpl>();
-using FloorExpression = NARY<1, FV<decltype(floor), NumericValueGetter>>;
+using Floor = MakeNumericExpression<FloorImpl>;
+using FloorExpression = NARY<1, FV<Floor, NumericValueGetter>>;
 
 // Natural Logarithm.
 struct LogImpl {
@@ -154,8 +153,8 @@ struct LogImpl {
     return std::log(num);
   }
 };
-inline const auto log = makeNumericExpression<LogImpl>();
-using LogExpression = NARY<1, FV<decltype(log), NumericValueGetter>>;
+using Log = MakeNumericExpression<LogImpl>;
+using LogExpression = NARY<1, FV<Log, NumericValueGetter>>;
 
 // Exponentiation.
 struct ExpImpl {
@@ -164,8 +163,8 @@ struct ExpImpl {
     return std::exp(num);
   }
 };
-inline const auto exp = makeNumericExpression<ExpImpl>();
-using ExpExpression = NARY<1, FV<decltype(exp), NumericValueGetter>>;
+using Exp = MakeNumericExpression<ExpImpl>;
+using ExpExpression = NARY<1, FV<Exp, NumericValueGetter>>;
 
 // Square root.
 struct SqrtImpl {
@@ -174,8 +173,8 @@ struct SqrtImpl {
     return std::sqrt(num);
   }
 };
-inline const auto sqrt = makeNumericExpression<SqrtImpl>();
-using SqrtExpression = NARY<1, FV<decltype(sqrt), NumericValueGetter>>;
+using Sqrt = MakeNumericExpression<SqrtImpl>;
+using SqrtExpression = NARY<1, FV<Sqrt, NumericValueGetter>>;
 
 // Sine.
 struct SinImpl {
@@ -184,8 +183,8 @@ struct SinImpl {
     return std::sin(num);
   }
 };
-inline const auto sin = makeNumericExpression<SinImpl>();
-using SinExpression = NARY<1, FV<decltype(sin), NumericValueGetter>>;
+using Sin = MakeNumericExpression<SinImpl>;
+using SinExpression = NARY<1, FV<Sin, NumericValueGetter>>;
 
 // Cosine.
 struct CosImpl {
@@ -194,8 +193,8 @@ struct CosImpl {
     return std::cos(num);
   }
 };
-inline const auto cos = makeNumericExpression<CosImpl>();
-using CosExpression = NARY<1, FV<decltype(cos), NumericValueGetter>>;
+using Cos = MakeNumericExpression<CosImpl>;
+using CosExpression = NARY<1, FV<Cos, NumericValueGetter>>;
 
 // Tangent.
 struct TanImpl {
@@ -204,8 +203,8 @@ struct TanImpl {
     return std::tan(num);
   }
 };
-inline const auto tan = makeNumericExpression<TanImpl>();
-using TanExpression = NARY<1, FV<decltype(tan), NumericValueGetter>>;
+using Tan = MakeNumericExpression<TanImpl>;
+using TanExpression = NARY<1, FV<Tan, NumericValueGetter>>;
 
 }  // namespace detail
 

--- a/src/engine/sparqlExpressions/StringExpressions.cpp
+++ b/src/engine/sparqlExpressions/StringExpressions.cpp
@@ -29,7 +29,7 @@ struct ToLiteral {
             asNormalizedStringViewUnsafe(normalizedContent), descriptor)};
   }
 };
-constexpr ToLiteral toLiteral{};
+static constexpr ToLiteral toLiteral{};
 
 // Return `true` if the byte representation of `c` does not start with `10`,
 // meaning that it is not a UTF-8 continuation byte, and therefore the start of

--- a/src/engine/sparqlExpressions/StringExpressions.cpp
+++ b/src/engine/sparqlExpressions/StringExpressions.cpp
@@ -20,14 +20,16 @@ using LiteralOrIri = ad_utility::triple_component::LiteralOrIri;
 // Convert a `string_view` to a `LiteralOrIri` that stores a `Literal`.
 // Note: This currently requires a copy of a string since the `Literal` class
 // has to add the quotation marks.
-constexpr auto toLiteral =
-    [](std::string_view normalizedContent,
-       const std::optional<std::variant<Iri, std::string>>& descriptor =
-           std::nullopt) {
-      return LiteralOrIri{
-          ad_utility::triple_component::Literal::literalWithNormalizedContent(
-              asNormalizedStringViewUnsafe(normalizedContent), descriptor)};
-    };
+struct ToLiteral {
+  LiteralOrIri operator()(std::string_view normalizedContent,
+                          const std::optional<std::variant<Iri, std::string>>&
+                              descriptor = std::nullopt) const {
+    return LiteralOrIri{
+        ad_utility::triple_component::Literal::literalWithNormalizedContent(
+            asNormalizedStringViewUnsafe(normalizedContent), descriptor)};
+  }
+};
+constexpr ToLiteral toLiteral{};
 
 // Return `true` if the byte representation of `c` does not start with `10`,
 // meaning that it is not a UTF-8 continuation byte, and therefore the start of
@@ -75,15 +77,16 @@ static std::size_t utf8ToByteOffset(std::string_view str, int64_t utf8Pos) {
 }
 
 // String functions.
-[[maybe_unused]] auto strImpl =
-    [](std::optional<std::string> s) -> IdOrLiteralOrIri {
-  if (s.has_value()) {
-    return IdOrLiteralOrIri{toLiteral(s.value())};
-  } else {
-    return Id::makeUndefined();
+struct StrImpl {
+  IdOrLiteralOrIri operator()(std::optional<std::string> s) const {
+    if (s.has_value()) {
+      return IdOrLiteralOrIri{toLiteral(s.value())};
+    } else {
+      return Id::makeUndefined();
+    }
   }
 };
-NARY_EXPRESSION(StrExpressionImpl, 1, FV<decltype(strImpl), StringValueGetter>);
+NARY_EXPRESSION(StrExpressionImpl, 1, FV<StrImpl, StringValueGetter>);
 
 class StrExpression : public StrExpressionImpl {
   using StrExpressionImpl::StrExpressionImpl;
@@ -133,30 +136,32 @@ const Iri& extractIri(const IdOrLiteralOrIri& litOrIri) {
   return baseIriOrUri.getIri();
 }
 
-[[maybe_unused]] auto applyBaseIfPresent =
-    [](IdOrLiteralOrIri iri, const IdOrLiteralOrIri& base) -> IdOrLiteralOrIri {
-  if (std::holds_alternative<Id>(iri)) {
-    AD_CORRECTNESS_CHECK(std::get<Id>(iri).isUndefined());
-    return iri;
+struct ApplyBaseIfPresent {
+  IdOrLiteralOrIri operator()(IdOrLiteralOrIri iri,
+                              const IdOrLiteralOrIri& base) const {
+    if (std::holds_alternative<Id>(iri)) {
+      AD_CORRECTNESS_CHECK(std::get<Id>(iri).isUndefined());
+      return iri;
+    }
+    const auto& baseIri = extractIri(base);
+    if (baseIri.empty()) {
+      return iri;
+    }
+    // TODO<RobinTF> Avoid unnecessary string copies because of conversion.
+    return LiteralOrIri{Iri::fromIrirefConsiderBase(
+        extractIri(iri).toStringRepresentation(), baseIri.getBaseIri(false),
+        baseIri.getBaseIri(true))};
   }
-  const auto& baseIri = extractIri(base);
-  if (baseIri.empty()) {
-    return iri;
-  }
-  // TODO<RobinTF> Avoid unnecessary string copies because of conversion.
-  return LiteralOrIri{Iri::fromIrirefConsiderBase(
-      extractIri(iri).toStringRepresentation(), baseIri.getBaseIri(false),
-      baseIri.getBaseIri(true))};
 };
-using IriOrUriExpression =
-    NARY<2, FV<decltype(applyBaseIfPresent), IriOrUriValueGetter>>;
+using IriOrUriExpression = NARY<2, FV<ApplyBaseIfPresent, IriOrUriValueGetter>>;
 
 // STRLEN
-[[maybe_unused]] auto strlen = [](std::string_view s) {
-  return Id::makeFromInt(utf8Length(s));
+struct Strlen {
+  Id operator()(std::string_view s) const {
+    return Id::makeFromInt(utf8Length(s));
+  }
 };
-using StrlenExpression =
-    StringExpressionImpl<1, LiftStringFunction<decltype(strlen)>>;
+using StrlenExpression = StringExpressionImpl<1, LiftStringFunction<Strlen>>;
 
 // UCase and LCase
 template <auto toLowerOrToUpper>
@@ -252,9 +257,10 @@ using SubstrExpression =
                           NumericValueGetter>;
 
 // STRSTARTS
-[[maybe_unused]] auto strStartsImpl = [](std::string_view text,
-                                         std::string_view pattern) -> Id {
-  return Id::makeFromBool(ql::starts_with(text, pattern));
+struct StrStartsImpl {
+  Id operator()(std::string_view text, std::string_view pattern) const {
+    return Id::makeFromBool(ql::starts_with(text, pattern));
+  }
 };
 
 namespace {
@@ -289,124 +295,127 @@ CPP_template(typename NaryOperation)(
 
 }  // namespace
 
-using StrStartsExpression = StrStartsExpressionImpl<Operation<
-    2, FV<LiftStringFunction<decltype(strStartsImpl)>, StringValueGetter>>>;
+using StrStartsExpression = StrStartsExpressionImpl<
+    Operation<2, FV<LiftStringFunction<StrStartsImpl>, StringValueGetter>>>;
 
 // STRENDS
-[[maybe_unused]] auto strEndsImpl = [](std::string_view text,
-                                       std::string_view pattern) {
-  return Id::makeFromBool(ql::ends_with(text, pattern));
+struct StrEndsImpl {
+  Id operator()(std::string_view text, std::string_view pattern) const {
+    return Id::makeFromBool(ql::ends_with(text, pattern));
+  }
 };
 
 using StrEndsExpression =
-    StringExpressionImpl<2, LiftStringFunction<decltype(strEndsImpl)>,
-                         StringValueGetter>;
+    StringExpressionImpl<2, LiftStringFunction<StrEndsImpl>, StringValueGetter>;
 
 // STRCONTAINS
-[[maybe_unused]] auto containsImpl = [](std::string_view text,
-                                        std::string_view pattern) {
-  return Id::makeFromBool(text.find(pattern) != std::string::npos);
+struct ContainsImpl {
+  Id operator()(std::string_view text, std::string_view pattern) const {
+    return Id::makeFromBool(text.find(pattern) != std::string::npos);
+  }
 };
 
 using ContainsExpression =
-    StringExpressionImpl<2, LiftStringFunction<decltype(containsImpl)>,
+    StringExpressionImpl<2, LiftStringFunction<ContainsImpl>,
                          StringValueGetter>;
 
 // STRAFTER / STRBEFORE
 template <bool isStrAfter>
-[[maybe_unused]] auto strAfterOrBeforeImpl =
-    [](std::optional<ad_utility::triple_component::Literal> optLiteral,
-       std::optional<ad_utility::triple_component::Literal> optPattern)
-    -> IdOrLiteralOrIri {
-  if (!optPattern.has_value() || !optLiteral.has_value()) {
-    return Id::makeUndefined();
-  }
-  auto& literal = optLiteral.value();
-  const auto& patternLit = optPattern.value();
-  // Check if arguments are compatible with their language tags.
-  if (patternLit.hasLanguageTag() &&
-      (!literal.hasLanguageTag() ||
-       literal.getLanguageTag() != patternLit.getLanguageTag())) {
-    return Id::makeUndefined();
-  }
-  const auto& pattern = asStringViewUnsafe(optPattern.value().getContent());
-  //  Required by the SPARQL standard.
-  if (pattern.empty()) {
-    if (isStrAfter) {
-      return LiteralOrIri(std::move(literal));
-    } else {
-      literal.setSubstr(0, 0);
-      return LiteralOrIri(std::move(literal));
+struct StrAfterOrBeforeImpl {
+  IdOrLiteralOrIri operator()(
+      std::optional<ad_utility::triple_component::Literal> optLiteral,
+      std::optional<ad_utility::triple_component::Literal> optPattern) const {
+    if (!optPattern.has_value() || !optLiteral.has_value()) {
+      return Id::makeUndefined();
     }
+    auto& literal = optLiteral.value();
+    const auto& patternLit = optPattern.value();
+    // Check if arguments are compatible with their language tags.
+    if (patternLit.hasLanguageTag() &&
+        (!literal.hasLanguageTag() ||
+         literal.getLanguageTag() != patternLit.getLanguageTag())) {
+      return Id::makeUndefined();
+    }
+    const auto& pattern = asStringViewUnsafe(optPattern.value().getContent());
+    //  Required by the SPARQL standard.
+    if (pattern.empty()) {
+      if (isStrAfter) {
+        return LiteralOrIri(std::move(literal));
+      } else {
+        literal.setSubstr(0, 0);
+        return LiteralOrIri(std::move(literal));
+      }
+    }
+    auto literalContent = literal.getContent();
+    auto pos = asStringViewUnsafe(literalContent).find(pattern);
+    if (pos >= literalContent.size()) {
+      return toLiteral("");
+    }
+    if constexpr (isStrAfter) {
+      literal.setSubstr(pos + pattern.size(),
+                        literalContent.size() - pos - pattern.size());
+    } else {
+      // STRBEFORE
+      literal.setSubstr(0, pos);
+    }
+    return LiteralOrIri(std::move(literal));
   }
-  auto literalContent = literal.getContent();
-  auto pos = asStringViewUnsafe(literalContent).find(pattern);
-  if (pos >= literalContent.size()) {
-    return toLiteral("");
-  }
-  if constexpr (isStrAfter) {
-    literal.setSubstr(pos + pattern.size(),
-                      literalContent.size() - pos - pattern.size());
-  } else {
-    // STRBEFORE
-    literal.setSubstr(0, pos);
-  }
-  return LiteralOrIri(std::move(literal));
 };
 
-auto strAfter = strAfterOrBeforeImpl<true>;
 using StrAfterExpression =
-    LiteralExpressionImpl<2, decltype(strAfter),
+    LiteralExpressionImpl<2, StrAfterOrBeforeImpl<true>,
                           LiteralValueGetterWithoutStrFunction>;
 
-auto strBefore = strAfterOrBeforeImpl<false>;
 using StrBeforeExpression =
-    LiteralExpressionImpl<2, decltype(strBefore),
+    LiteralExpressionImpl<2, StrAfterOrBeforeImpl<false>,
                           LiteralValueGetterWithoutStrFunction>;
 
-[[maybe_unused]] auto mergeFlagsIntoRegex =
-    [](std::optional<std::string> regex,
-       const std::optional<std::string>& flags) -> IdOrLiteralOrIri {
-  if (!flags.has_value() || !regex.has_value()) {
-    return Id::makeUndefined();
-  }
-  auto firstInvalidFlag = flags.value().find_first_not_of("imsU");
-  if (firstInvalidFlag != std::string::npos) {
-    return Id::makeUndefined();
-  }
+struct MergeFlagsIntoRegex {
+  IdOrLiteralOrIri operator()(std::optional<std::string> regex,
+                              const std::optional<std::string>& flags) const {
+    if (!flags.has_value() || !regex.has_value()) {
+      return Id::makeUndefined();
+    }
+    auto firstInvalidFlag = flags.value().find_first_not_of("imsU");
+    if (firstInvalidFlag != std::string::npos) {
+      return Id::makeUndefined();
+    }
 
-  // In Google RE2 the flags are directly part of the regex.
-  std::string result =
-      flags.value().empty()
-          ? std::move(regex.value())
-          : absl::StrCat("(?", flags.value(), ":", regex.value() + ")");
-  return toLiteral(std::move(result));
+    // In Google RE2 the flags are directly part of the regex.
+    std::string result =
+        flags.value().empty()
+            ? std::move(regex.value())
+            : absl::StrCat("(?", flags.value(), ":", regex.value() + ")");
+    return toLiteral(std::move(result));
+  }
 };
 
 using MergeRegexPatternAndFlagsExpression =
-    StringExpressionImpl<2, decltype(mergeFlagsIntoRegex), LiteralFromIdGetter>;
+    StringExpressionImpl<2, MergeFlagsIntoRegex, LiteralFromIdGetter>;
 
-[[maybe_unused]] auto replaceImpl =
-    [](std::optional<ad_utility::triple_component::Literal> s,
-       const std::shared_ptr<RE2>& pattern,
-       const std::optional<std::string>& replacement) -> IdOrLiteralOrIri {
-  if (!s.has_value() || !pattern || !replacement.has_value()) {
-    return Id::makeUndefined();
+struct ReplaceImpl {
+  IdOrLiteralOrIri operator()(
+      std::optional<ad_utility::triple_component::Literal> s,
+      const std::shared_ptr<RE2>& pattern,
+      const std::optional<std::string>& replacement) const {
+    if (!s.has_value() || !pattern || !replacement.has_value()) {
+      return Id::makeUndefined();
+    }
+    std::string in(asStringViewUnsafe(s.value().getContent()));
+    const auto& pat = *pattern;
+    // Check for invalid regexes.
+    if (!pat.ok()) {
+      return Id::makeUndefined();
+    }
+    const auto& repl = replacement.value();
+    RE2::GlobalReplace(&in, pat, repl);
+    s.value().replaceContent(in);
+    return LiteralOrIri(std::move(s.value()));
   }
-  std::string in(asStringViewUnsafe(s.value().getContent()));
-  const auto& pat = *pattern;
-  // Check for invalid regexes.
-  if (!pat.ok()) {
-    return Id::makeUndefined();
-  }
-  const auto& repl = replacement.value();
-  RE2::GlobalReplace(&in, pat, repl);
-  s.value().replaceContent(in);
-  return LiteralOrIri(std::move(s.value()));
 };
 
 using ReplaceExpression =
-    LiteralExpressionImpl<3, decltype(replaceImpl), RegexValueGetter,
+    LiteralExpressionImpl<3, ReplaceImpl, RegexValueGetter,
                           ReplacementStringGetter>;
 
 // CONCAT
@@ -544,67 +553,70 @@ class ConcatExpression : public detail::VariadicExpression {
 };
 
 // ENCODE_FOR_URI
-[[maybe_unused]] auto encodeForUriImpl =
-    [](std::optional<std::string> input) -> IdOrLiteralOrIri {
-  if (!input.has_value()) {
-    return Id::makeUndefined();
-  } else {
-    std::string_view value{input.value()};
+struct EncodeForUriImpl {
+  IdOrLiteralOrIri operator()(std::optional<std::string> input) const {
+    if (!input.has_value()) {
+      return Id::makeUndefined();
+    } else {
+      std::string_view value{input.value()};
 
-    return toLiteral(boost::urls::encode(value, boost::urls::unreserved_chars));
+      return toLiteral(
+          boost::urls::encode(value, boost::urls::unreserved_chars));
+    }
   }
 };
-using EncodeForUriExpression =
-    StringExpressionImpl<1, decltype(encodeForUriImpl)>;
+using EncodeForUriExpression = StringExpressionImpl<1, EncodeForUriImpl>;
 
 // LANGMATCHES
-[[maybe_unused]] inline auto langMatching =
-    [](std::optional<std::string> languageTag,
-       std::optional<std::string> languageRange) {
-      if (!languageTag.has_value() || !languageRange.has_value()) {
-        return Id::makeUndefined();
-      } else {
-        return Id::makeFromBool(ad_utility::isLanguageMatch(
-            languageTag.value(), languageRange.value()));
-      }
-    };
+struct LangMatching {
+  Id operator()(std::optional<std::string> languageTag,
+                std::optional<std::string> languageRange) const {
+    if (!languageTag.has_value() || !languageRange.has_value()) {
+      return Id::makeUndefined();
+    } else {
+      return Id::makeFromBool(ad_utility::isLanguageMatch(
+          languageTag.value(), languageRange.value()));
+    }
+  }
+};
 
-using LangMatches =
-    StringExpressionImpl<2, decltype(langMatching), StringValueGetter>;
+using LangMatches = StringExpressionImpl<2, LangMatching, StringValueGetter>;
 
 // STRING WITH LANGUAGE TAG
-[[maybe_unused]] inline auto strLangTag =
-    [](std::optional<ad_utility::triple_component::Literal> literal,
-       std::optional<std::string> langTag) -> IdOrLiteralOrIri {
-  if (!literal.has_value() || !langTag.has_value() ||
-      !literal.value().isPlain()) {
-    return Id::makeUndefined();
-  } else if (!ad_utility::strIsLangTag(langTag.value())) {
-    return Id::makeUndefined();
-  } else {
-    literal.value().addLanguageTag(std::move(langTag.value()));
-    return LiteralOrIri{std::move(literal.value())};
+struct StrLangTag {
+  IdOrLiteralOrIri operator()(
+      std::optional<ad_utility::triple_component::Literal> literal,
+      std::optional<std::string> langTag) const {
+    if (!literal.has_value() || !langTag.has_value() ||
+        !literal.value().isPlain()) {
+      return Id::makeUndefined();
+    } else if (!ad_utility::strIsLangTag(langTag.value())) {
+      return Id::makeUndefined();
+    } else {
+      literal.value().addLanguageTag(std::move(langTag.value()));
+      return LiteralOrIri{std::move(literal.value())};
+    }
   }
 };
 
-using StrLangTagged =
-    LiteralExpressionImpl<2, decltype(strLangTag), StringValueGetter>;
+using StrLangTagged = LiteralExpressionImpl<2, StrLangTag, StringValueGetter>;
 
 // STRING WITH DATATYPE IRI
-[[maybe_unused]] inline auto strIriDtTag =
-    [](std::optional<ad_utility::triple_component::Literal> literal,
-       OptIri inputIri) -> IdOrLiteralOrIri {
-  if (!literal.has_value() || !inputIri.has_value() ||
-      !literal.value().isPlain()) {
-    return Id::makeUndefined();
-  } else {
-    literal.value().addDatatype(inputIri.value());
-    return LiteralOrIri{std::move(literal.value())};
+struct StrIriDtTag {
+  IdOrLiteralOrIri operator()(
+      std::optional<ad_utility::triple_component::Literal> literal,
+      OptIri inputIri) const {
+    if (!literal.has_value() || !inputIri.has_value() ||
+        !literal.value().isPlain()) {
+      return Id::makeUndefined();
+    } else {
+      literal.value().addDatatype(inputIri.value());
+      return LiteralOrIri{std::move(literal.value())};
+    }
   }
 };
 
-using StrIriTagged =
-    LiteralExpressionImpl<2, decltype(strIriDtTag), IriValueGetter>;
+using StrIriTagged = LiteralExpressionImpl<2, StrIriDtTag, IriValueGetter>;
 
 // HASH
 template <auto HashFunc>

--- a/src/index/vocabulary/SplitVocabulary.cpp
+++ b/src/index/vocabulary/SplitVocabulary.cpp
@@ -8,9 +8,9 @@
 // Explicit template instantiations
 using namespace detail::splitVocabulary;
 template class SplitVocabulary<
-    decltype(geoSplitFunc), decltype(geoFilenameFunc),
+    GeoSplitFunc, GeoFilenameFunc,
     CompressedVocabulary<VocabularyInternalExternal>,
     GeoVocabulary<CompressedVocabulary<VocabularyInternalExternal>>>;
-template class SplitVocabulary<decltype(geoSplitFunc),
-                               decltype(geoFilenameFunc), VocabularyInMemory,
+template class SplitVocabulary<GeoSplitFunc, GeoFilenameFunc,
+                               VocabularyInMemory,
                                GeoVocabulary<VocabularyInMemory>>;

--- a/src/index/vocabulary/SplitVocabulary.h
+++ b/src/index/vocabulary/SplitVocabulary.h
@@ -294,17 +294,20 @@ namespace detail::splitVocabulary {
 
 // Split function for Well-Known Text Literals: All words are written to
 // vocabulary 0 except WKT literals, which go to vocabulary 1.
-[[maybe_unused]] inline auto geoSplitFunc =
-    [](std::string_view word) -> uint8_t {
-  return ql::starts_with(word, "\"") && ql::ends_with(word, GEO_LITERAL_SUFFIX);
+struct GeoSplitFunc {
+  uint8_t operator()(std::string_view word) const {
+    return ql::starts_with(word, "\"") &&
+           ql::ends_with(word, GEO_LITERAL_SUFFIX);
+  }
 };
 
 // Split filename function for Well-Known Text Literals: The vocabulary 0 is
 // saved under the base filename and WKT literals are saved with a suffix
 // ".geometry"
-[[maybe_unused]] inline auto geoFilenameFunc =
-    [](std::string_view base) -> std::array<std::string, 2> {
-  return {std::string(base), absl::StrCat(base, ".geometry")};
+struct GeoFilenameFunc {
+  std::array<std::string, 2> operator()(std::string_view base) const {
+    return {std::string(base), absl::StrCat(base, ".geometry")};
+  }
 };
 
 }  // namespace detail::splitVocabulary
@@ -313,8 +316,8 @@ namespace detail::splitVocabulary {
 // vocabulary. This can be used for precomputations for spatial features.
 template <class UnderlyingVocabulary>
 using SplitGeoVocabulary =
-    SplitVocabulary<decltype(detail::splitVocabulary::geoSplitFunc),
-                    decltype(detail::splitVocabulary::geoFilenameFunc),
+    SplitVocabulary<detail::splitVocabulary::GeoSplitFunc,
+                    detail::splitVocabulary::GeoFilenameFunc,
                     UnderlyingVocabulary, GeoVocabulary<UnderlyingVocabulary>>;
 
 #endif  // QLEVER_SRC_INDEX_VOCABULARY_SPLITVOCABULARY_H

--- a/src/util/ExceptionHandling.h
+++ b/src/util/ExceptionHandling.h
@@ -18,7 +18,7 @@
 namespace ad_utility {
 namespace detail {
 struct CallStdTerminate {
-  void operator()() const noexcept { std::terminate(); }
+  [[noreturn]] void operator()() const noexcept { std::terminate(); }
 };
 }  // namespace detail
 // Call `f()`. If this call throws, catch the exception and log it, but do not

--- a/src/util/ExceptionHandling.h
+++ b/src/util/ExceptionHandling.h
@@ -17,8 +17,8 @@
 
 namespace ad_utility {
 namespace detail {
-[[maybe_unused]] static constexpr auto callStdTerminate = []() noexcept {
-  std::terminate();
+struct CallStdTerminate {
+  void operator()() const noexcept { std::terminate(); }
 };
 }  // namespace detail
 // Call `f()`. If this call throws, catch the exception and log it, but do not
@@ -53,8 +53,7 @@ CPP_template(typename F)(
 // also is not easily recoverable. For an example usage see `PatternCreator.h`.
 // The actual termination call can be configured for testing purposes. Note that
 // this function must never throw an exception.
-CPP_template(typename F,
-             typename TerminateAction = decltype(detail::callStdTerminate))(
+CPP_template(typename F, typename TerminateAction = detail::CallStdTerminate)(
     requires ql::concepts::invocable<ql::remove_cvref_t<F>> CPP_and
         std::is_nothrow_invocable_v<
             TerminateAction>) void terminateIfThrows(F&& f,


### PR DESCRIPTION
In C++20, capture-less lambdas of the form `[](someArgs){ doSomething; }` can be default-constructed, in C++17 they can't. This is relevant when a class template takes the type of a callable (using `decltype`), and then default-constructs it.  Several of these lambdas are now rewritten, each to an equivalent named `struct` with an `operator()`.