### PR TITLE
Migrate the usage of `CTRE` (compile-time regexes) to C++17

### DIFF
--- a/src/engine/Service.cpp
+++ b/src/engine/Service.cpp
@@ -23,6 +23,11 @@
 #include "util/StringUtils.h"
 #include "util/http/HttpUtils.h"
 
+namespace {
+// CTRE regex patterns for C++17 compatibility
+constexpr ctll::fixed_string selectPatternRegex = "[ \t\r\n]*SELECT";
+}  // namespace
+
 // ____________________________________________________________________________
 Service::Service(QueryExecutionContext* qec,
                  parsedQuery::Service parsedServiceClause,
@@ -98,7 +103,7 @@ std::string Service::pushDownValues(std::string_view pattern,
   pattern.remove_prefix(index + 1);
   // If we have a single subquery in the service clause, wrap it inside curly
   // braces so it remains valid syntax alongside a VALUES clause.
-  if (ctre::starts_with<"[ \t\r\n]*SELECT">(pattern)) {
+  if (ctre::starts_with<selectPatternRegex>(pattern)) {
     return absl::StrCat("{\n", values, "\n{", pattern, "\n}");
   }
   return absl::StrCat("{\n", values, "\n", pattern);

--- a/src/index/EncodedIriManager.h
+++ b/src/index/EncodedIriManager.h
@@ -14,6 +14,11 @@
 #include "util/Log.h"
 #include "util/json.h"
 
+namespace detail {
+// CTRE named capture group identifiers for C++17 compatibility
+constexpr ctll::fixed_string digitsCaptureGroup = "digits";
+}  // namespace detail
+
 // This class allows the encoding of IRIs that start with a fixed prefix
 // followed by a sequence of decimal digits directly into an `Id`. For
 // example, <http://example.org/12345> with digit sequence `12345` and
@@ -146,7 +151,8 @@ class EncodedIriManagerImpl {
     }
 
     // Extract the substring with the digits, and check that it is not too long.
-    const auto& numString = match.template get<"digits">().to_view();
+    const auto& numString =
+        match.template get<detail::digitsCaptureGroup>().to_view();
     if (numString.size() > NumDigits) {
       return std::nullopt;
     }

--- a/src/parser/SparqlParserHelpers.cpp
+++ b/src/parser/SparqlParserHelpers.cpp
@@ -14,6 +14,12 @@
 namespace sparqlParserHelpers {
 using std::string;
 
+namespace detail {
+// CTRE regex pattern for C++17 compatibility
+constexpr ctll::fixed_string unicodeEscapeRegex =
+    R"(\\U[0-9A-Fa-f]{8}|\\u[0-9A-Fa-f]{4})";
+}  // namespace detail
+
 // _____________________________________________________________________________
 ParserAndVisitor::ParserAndVisitor(
     ad_utility::BlankNodeManager* blankNodeManager,
@@ -54,8 +60,7 @@ std::string ParserAndVisitor::unescapeUnicodeSequences(std::string input) {
     }
   };
 
-  for (const auto& match :
-       ctre::search_all<R"(\\U[0-9A-Fa-f]{8}|\\u[0-9A-Fa-f]{4})">(view)) {
+  for (const auto& match : ctre::search_all<detail::unicodeEscapeRegex>(view)) {
     if (noEscapeSequenceFound) {
       output.reserve(input.size());
       noEscapeSequenceFound = false;

--- a/src/parser/SpatialQuery.cpp
+++ b/src/parser/SpatialQuery.cpp
@@ -12,6 +12,12 @@
 
 namespace parsedQuery {
 
+namespace detail {
+// CTRE named capture group identifiers for C++17 compatibility
+constexpr ctll::fixed_string distCaptureGroup = "dist";
+constexpr ctll::fixed_string resultsCaptureGroup = "results";
+}  // namespace detail
+
 // ____________________________________________________________________________
 void SpatialQuery::addParameter(const SparqlTriple& triple) {
   auto simpleTriple = triple.getSimple();
@@ -256,11 +262,11 @@ SpatialQuery::SpatialQuery(const SparqlTriple& triple) {
 
   // Check if one of the regexes matches
   if (auto match = ctre::match<MAX_DIST_IN_METERS_REGEX>(input)) {
-    maxDist_ = matchToInt(match.get<"dist">());
+    maxDist_ = matchToInt(match.get<detail::distCaptureGroup>());
     AD_CORRECTNESS_CHECK(maxDist_.has_value());
   } else if (auto match = ctre::search<NEAREST_NEIGHBORS_REGEX>(input)) {
-    maxResults_ = matchToInt(match.get<"results">());
-    maxDist_ = matchToInt(match.get<"dist">());
+    maxResults_ = matchToInt(match.get<detail::resultsCaptureGroup>());
+    maxDist_ = matchToInt(match.get<detail::distCaptureGroup>());
     ignoreMissingRightChild_ = true;
     AD_CORRECTNESS_CHECK(maxResults_.has_value());
   } else {

--- a/src/parser/data/BlankNode.cpp
+++ b/src/parser/data/BlankNode.cpp
@@ -7,13 +7,18 @@
 #include <ctre-unicode.hpp>
 #include <sstream>
 
+namespace {
+// CTRE regex pattern for C++17 compatibility
+constexpr ctll::fixed_string blankNodeLabelRegex = "\\w(?:(?:\\w|-|\\.)*\\w)?";
+}  // namespace
+
 // _____________________________________________________________________________
 BlankNode::BlankNode(bool generated, std::string label)
     : _generated{generated}, _label{std::move(label)} {
   // roughly check allowed characters as blank node labels.
   // Weaker than the SPARQL grammar, but good
   // enough so that it will likely never be an issue
-  AD_CONTRACT_CHECK(ctre::match<"\\w(?:(?:\\w|-|\\.)*\\w)?">(_label));
+  AD_CONTRACT_CHECK(ctre::match<blankNodeLabelRegex>(_label));
 }
 
 // ___________________________________________________________________________

--- a/src/parser/data/Iri.cpp
+++ b/src/parser/data/Iri.cpp
@@ -5,8 +5,15 @@
 #include "parser/data/Iri.h"
 
 #include <ctre-unicode.hpp>
+
+namespace {
+// CTRE regex pattern for C++17 compatibility
+constexpr ctll::fixed_string iriValidationRegex =
+    "(?:@[a-zA-Z]+(?:-(?:[a-zA-Z]|\\d)+)*@)?"
+    "<[^<>\"{}|^\\\\`\\0- ]*>";
+}  // namespace
+
 // ____________________________________________________________________________
 Iri::Iri(std::string str) : _string{std::move(str)} {
-  AD_CONTRACT_CHECK(ctre::match<"(?:@[a-zA-Z]+(?:-(?:[a-zA-Z]|\\d)+)*@)?"
-                                "<[^<>\"{}|^\\\\`\\0- ]*>">(_string));
+  AD_CONTRACT_CHECK(ctre::match<iriValidationRegex>(_string));
 }

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -12,6 +12,7 @@
 #include <absl/strings/str_split.h>
 #include <absl/time/time.h>
 
+#include <ctre-unicode.hpp>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -50,6 +51,11 @@
 #include "util/TransparentFunctors.h"
 #include "util/TypeIdentity.h"
 #include "util/antlr/GenerateAntlrExceptionMetadata.h"
+
+namespace {
+// CTRE regex pattern for C++17 compatibility
+constexpr ctll::fixed_string iriSchemeRegex = "<[A-Za-z]*[A-Za-z0-9+-.]:";
+}  // namespace
 
 using namespace ad_utility::sparql_types;
 using namespace ad_utility::use_type_identity;
@@ -1530,7 +1536,7 @@ void Visitor::visit(Parser::PrologueContext* ctx) {
 // ____________________________________________________________________________________
 void Visitor::visit(Parser::BaseDeclContext* ctx) {
   auto rawIri = ctx->iriref()->getText();
-  bool hasScheme = ctre::starts_with<"<[A-Za-z]*[A-Za-z0-9+-.]:">(rawIri);
+  bool hasScheme = ctre::starts_with<iriSchemeRegex>(rawIri);
   if (!hasScheme) {
     reportError(
         ctx,

--- a/src/util/DateYearDuration.cpp
+++ b/src/util/DateYearDuration.cpp
@@ -31,6 +31,18 @@ constexpr static ctll::fixed_string gYearMonthRegex =
     "(?<year>-?\\d{4,})-(?<month>\\d{2})";
 constexpr static ctll::fixed_string gYearMonthRegexWithTz =
     gYearMonthRegex + grp(timeZoneRegex) + "?";
+
+// CTRE named capture group identifiers for C++17 compatibility
+constexpr ctll::fixed_string yearGroup = "year";
+constexpr ctll::fixed_string monthGroup = "month";
+constexpr ctll::fixed_string dayGroup = "day";
+constexpr ctll::fixed_string hourGroup = "hour";
+constexpr ctll::fixed_string minuteGroup = "minute";
+constexpr ctll::fixed_string secondGroup = "second";
+constexpr ctll::fixed_string tzZGroup = "tzZ";
+constexpr ctll::fixed_string tzSignGroup = "tzSign";
+constexpr ctll::fixed_string tzHoursGroup = "tzHours";
+constexpr ctll::fixed_string tzMinutesGroup = "tzMinutes";
 }  // namespace detail
 
 // _____________________________________________________________________________
@@ -70,16 +82,16 @@ std::pair<std::string, const char*> DateYearOrDuration::toStringAndType()
 // _____________________________________________________________________________
 template <typename T>
 static Date::TimeZone parseTimeZone(const T& match) {
-  if (match.template get<"tzZ">() == "Z") {
+  if (match.template get<detail::tzZGroup>() == "Z") {
     return Date::TimeZoneZ{};
-  } else if (!match.template get<"tzHours">()) {
+  } else if (!match.template get<detail::tzHoursGroup>()) {
     return Date::NoTimeZone{};
   }
-  int tz = match.template get<"tzHours">().to_number();
-  if (match.template get<"tzSign">() == "-") {
+  int tz = match.template get<detail::tzHoursGroup>().to_number();
+  if (match.template get<detail::tzSignGroup>() == "-") {
     tz *= -1;
   }
-  if (match.template get<"tzMinutes">() != "00") {
+  if (match.template get<detail::tzMinutesGroup>() != "00") {
     AD_LOG_DEBUG << "Qlever supports only full hours as timezones, timezone"
                  << match.template get<0>() << "will be rounded down to " << tz
                  << ":00" << std::endl;
@@ -154,12 +166,12 @@ DateYearOrDuration::parseXsdDatetimeGetOptDate(std::string_view dateString) {
   if (!match) {
     return std::nullopt;
   }
-  int64_t year = match.template get<"year">().to_number<int64_t>();
-  int month = match.template get<"month">().to_number();
-  int day = match.template get<"day">().to_number();
-  int hour = match.template get<"hour">().to_number();
-  int minute = match.template get<"minute">().to_number();
-  double second = std::strtod(match.get<"second">().data(), nullptr);
+  int64_t year = match.template get<detail::yearGroup>().to_number<int64_t>();
+  int month = match.template get<detail::monthGroup>().to_number();
+  int day = match.template get<detail::dayGroup>().to_number();
+  int hour = match.template get<detail::hourGroup>().to_number();
+  int minute = match.template get<detail::minuteGroup>().to_number();
+  double second = std::strtod(match.get<detail::secondGroup>().data(), nullptr);
   return makeDateOrLargeYear(dateString, year, month, day, hour, minute, second,
                              parseTimeZone(match));
 }
@@ -181,9 +193,9 @@ std::optional<DateYearOrDuration> DateYearOrDuration::parseXsdDateGetOptDate(
   if (!match) {
     return std::nullopt;
   }
-  int64_t year = match.template get<"year">().to_number<int64_t>();
-  int month = match.template get<"month">().to_number();
-  int day = match.template get<"day">().to_number();
+  int64_t year = match.template get<detail::yearGroup>().to_number<int64_t>();
+  int month = match.template get<detail::monthGroup>().to_number();
+  int day = match.template get<detail::dayGroup>().to_number();
   return makeDateOrLargeYear(dateString, year, month, day, -1, 0, 0.0,
                              parseTimeZone(match));
 }
@@ -205,7 +217,7 @@ DateYearOrDuration DateYearOrDuration::parseGYear(std::string_view dateString) {
     throw DateParseException{absl::StrCat(
         "The value ", dateString, " cannot be parsed as an `xsd:gYear`.")};
   }
-  int64_t year = match.template get<"year">().to_number<int64_t>();
+  int64_t year = match.template get<detail::yearGroup>().to_number<int64_t>();
   return makeDateOrLargeYear(dateString, year, 0, 0, -1, 0, 0.0,
                              parseTimeZone(match));
 }
@@ -218,8 +230,8 @@ DateYearOrDuration DateYearOrDuration::parseGYearMonth(
     throw DateParseException{absl::StrCat(
         "The value ", dateString, " cannot be parsed as an `xsd:gYearMonth`.")};
   }
-  int64_t year = match.template get<"year">().to_number<int64_t>();
-  int month = match.template get<"month">().to_number();
+  int64_t year = match.template get<detail::yearGroup>().to_number<int64_t>();
+  int month = match.template get<detail::monthGroup>().to_number();
   return makeDateOrLargeYear(dateString, year, month, 0, -1, 0, 0.0,
                              parseTimeZone(match));
 }

--- a/src/util/Duration.cpp
+++ b/src/util/Duration.cpp
@@ -15,6 +15,13 @@ namespace {
 constexpr ctll::fixed_string dayTimePattern =
     "(?<negation>-?)P((?<days>\\d+)D)?(T((?<hours>\\d+)H)?((?<"
     "minutes>\\d+)M)?((?<seconds>\\d+(\\.\\d+)?)S)?)?";
+
+// CTRE named capture group identifiers for C++17 compatibility
+constexpr ctll::fixed_string negationGroup = "negation";
+constexpr ctll::fixed_string daysGroup = "days";
+constexpr ctll::fixed_string hoursGroup = "hours";
+constexpr ctll::fixed_string minutesGroup = "minutes";
+constexpr ctll::fixed_string secondsGroup = "seconds";
 }  // namespace
 
 //______________________________________________________________________________
@@ -76,8 +83,9 @@ DayTimeDuration DayTimeDuration::parseXsdDayTimeDuration(
         absl::StrCat("The value ", dayTimeDurationStr,
                      " cannot be parsed as an `xsd:dayTimeDuration`.")};
   } else {
-    Type negation = match.get<"negation">().to_string() == "-" ? Type::Negative
-                                                               : Type::Positive;
+    Type negation = match.get<negationGroup>().to_string() == "-"
+                        ? Type::Negative
+                        : Type::Positive;
     int days = 0;
     int hours = 0;
     int minutes = 0;
@@ -85,16 +93,17 @@ DayTimeDuration DayTimeDuration::parseXsdDayTimeDuration(
 
     // Certain duration strings could trigger segmentations faults, thus a
     // check for value is necessary here.
-    if (auto matchedDays = match.template get<"days">(); matchedDays) {
+    if (auto matchedDays = match.template get<daysGroup>(); matchedDays) {
       days = matchedDays.to_number();
     }
-    if (auto matchedHours = match.template get<"hours">(); matchedHours) {
+    if (auto matchedHours = match.template get<hoursGroup>(); matchedHours) {
       hours = matchedHours.to_number();
     }
-    if (auto matchedMinutes = match.template get<"minutes">(); matchedMinutes) {
+    if (auto matchedMinutes = match.template get<minutesGroup>();
+        matchedMinutes) {
       minutes = matchedMinutes.to_number();
     }
-    if (auto matchedSeconds = match.get<"seconds">(); matchedSeconds) {
+    if (auto matchedSeconds = match.get<secondsGroup>(); matchedSeconds) {
       seconds = std::strtod(matchedSeconds.data(), nullptr);
     }
     return DayTimeDuration(negation, days, hours, minutes, seconds);

--- a/src/util/Duration.cpp
+++ b/src/util/Duration.cpp
@@ -10,6 +10,13 @@
 
 #include "global/Constants.h"
 
+namespace {
+// CTRE regex pattern for C++17 compatibility (namespace scope)
+constexpr ctll::fixed_string dayTimePattern =
+    "(?<negation>-?)P((?<days>\\d+)D)?(T((?<hours>\\d+)H)?((?<"
+    "minutes>\\d+)M)?((?<seconds>\\d+(\\.\\d+)?)S)?)?";
+}  // namespace
+
 //______________________________________________________________________________
 std::pair<std::string, const char*> DayTimeDuration::toStringAndType() const {
   std::string str = isPositive() ? "P" : "-P";
@@ -61,10 +68,6 @@ std::pair<std::string, const char*> DayTimeDuration::toStringAndType() const {
 //______________________________________________________________________________
 DayTimeDuration DayTimeDuration::parseXsdDayTimeDuration(
     std::string_view dayTimeDurationStr) {
-  static constexpr ctll::fixed_string dayTimePattern =
-      "(?<negation>-?)P((?<days>\\d+)D)?(T((?<hours>\\d+)H)?((?<"
-      "minutes>\\d+)M)?((?<seconds>\\d+(\\.\\d+)?)S)?)?";
-
   // Try to match the given pattern with the provided string. If the matching
   // procedure fails, raise DurationParseException (for Turtle Parser).
   auto match = ctre::match<dayTimePattern>(dayTimeDurationStr);

--- a/src/util/Duration.cpp
+++ b/src/util/Duration.cpp
@@ -83,7 +83,7 @@ DayTimeDuration DayTimeDuration::parseXsdDayTimeDuration(
         absl::StrCat("The value ", dayTimeDurationStr,
                      " cannot be parsed as an `xsd:dayTimeDuration`.")};
   } else {
-    Type negation = match.get<negationGroup>().to_string() == "-"
+    Type negation = match.get<negationGroup>().to_view() == "-"
                         ? Type::Negative
                         : Type::Positive;
     int days = 0;

--- a/src/util/MemorySize/MemorySize.cpp
+++ b/src/util/MemorySize/MemorySize.cpp
@@ -23,6 +23,10 @@ namespace {
 // CTRE regex pattern for C++17 compatibility (namespace scope)
 constexpr ctll::fixed_string memorySizeRegex =
     "(?<amount>\\d+(?:\\.\\d+)?)\\s*(?<unit>[kKmMgGtT][bB]?|[bB])";
+
+// CTRE named capture group identifiers for C++17 compatibility
+constexpr ctll::fixed_string amountGroup = "amount";
+constexpr ctll::fixed_string unitGroup = "unit";
 }  // namespace
 #include "util/ConstexprUtils.h"
 
@@ -74,13 +78,13 @@ std::string MemorySize::asString() const {
 // _____________________________________________________________________________
 MemorySize MemorySize::parse(std::string_view str) {
   if (auto matcher = ctre::match<memorySizeRegex>(str)) {
-    auto amountString = matcher.get<"amount">().to_view();
+    auto amountString = matcher.get<amountGroup>().to_view();
     // Even though CTRE supports to_number() with double values, this relies on
     // `std::from_chars` which is currently not supported by the standard
     // library used by our macOS build.
     double amount;
     absl::from_chars(amountString.begin(), amountString.end(), amount);
-    auto unitString = matcher.get<"unit">().to_view();
+    auto unitString = matcher.get<unitGroup>().to_view();
     switch (std::tolower(unitString.at(0))) {
       case 'b':
         if (ad_utility::contains(amountString, '.')) {

--- a/src/util/MemorySize/MemorySize.cpp
+++ b/src/util/MemorySize/MemorySize.cpp
@@ -18,6 +18,12 @@
 
 #include "util/Algorithm.h"
 #include "util/ConstexprMap.h"
+
+namespace {
+// CTRE regex pattern for C++17 compatibility (namespace scope)
+constexpr ctll::fixed_string memorySizeRegex =
+    "(?<amount>\\d+(?:\\.\\d+)?)\\s*(?<unit>[kKmMgGtT][bB]?|[bB])";
+}  // namespace
 #include "util/ConstexprUtils.h"
 
 namespace ad_utility {
@@ -67,9 +73,7 @@ std::string MemorySize::asString() const {
 
 // _____________________________________________________________________________
 MemorySize MemorySize::parse(std::string_view str) {
-  constexpr ctll::fixed_string regex =
-      "(?<amount>\\d+(?:\\.\\d+)?)\\s*(?<unit>[kKmMgGtT][bB]?|[bB])";
-  if (auto matcher = ctre::match<regex>(str)) {
+  if (auto matcher = ctre::match<memorySizeRegex>(str)) {
     auto amountString = matcher.get<"amount">().to_view();
     // Even though CTRE supports to_number() with double values, this relies on
     // `std::from_chars` which is currently not supported by the standard

--- a/src/util/ParseableDuration.h
+++ b/src/util/ParseableDuration.h
@@ -22,6 +22,12 @@
 
 namespace ad_utility {
 
+namespace detail {
+// CTRE regex pattern for C++17 compatibility
+constexpr ctll::fixed_string durationPatternRegex =
+    R"(\s*(-?\d+)\s*(ns|us|ms|s|min|h)\s*)";
+}  // namespace detail
+
 // Wrapper type for std::chrono::duration<> to avoid having to declare
 // this in the std::chrono namespace.
 template <typename DT>
@@ -84,7 +90,7 @@ class ParseableDuration {
     using namespace std::chrono;
     using ad_utility::use_type_identity::ti;
 
-    if (auto m = ctre::match<R"(\s*(-?\d+)\s*(ns|us|ms|s|min|h)\s*)">(arg)) {
+    if (auto m = ctre::match<detail::durationPatternRegex>(arg)) {
       auto unit = m.template get<2>().to_view();
 
       auto toDuration = [&m](auto t) {

--- a/src/util/StringUtils.cpp
+++ b/src/util/StringUtils.cpp
@@ -18,6 +18,11 @@
 #include "util/StringUtilsImpl.h"
 
 namespace ad_utility {
+
+namespace detail {
+// CTRE regex pattern for C++17 compatibility
+constexpr ctll::fixed_string langTagRegex = "[a-zA-Z]+(-[a-zA-Z0-9]+)*";
+}  // namespace detail
 // ____________________________________________________________________________
 std::string_view commonPrefix(std::string_view a, const std::string_view b) {
   size_t maxIdx = std::min(a.size(), b.size());
@@ -53,7 +58,7 @@ std::string getUppercase(const std::string& orig) {
 
 // ____________________________________________________________________________
 bool strIsLangTag(const std::string& input) {
-  return ctre::match<"[a-zA-Z]+(-[a-zA-Z0-9]+)*">(input);
+  return ctre::match<detail::langTagRegex>(input);
 }
 
 // ____________________________________________________________________________

--- a/src/util/StringUtilsImpl.h
+++ b/src/util/StringUtilsImpl.h
@@ -14,6 +14,12 @@
 #include "util/StringUtils.h"
 
 namespace ad_utility {
+
+namespace detail {
+// CTRE named capture group identifiers for C++17 compatibility
+constexpr ctll::fixed_string digitCaptureGroup = "digit";
+}  // namespace detail
+
 // _____________________________________________________________________________
 template <const char floatingPointSignifier>
 std::string insertThousandSeparator(const std::string_view str,
@@ -84,7 +90,8 @@ std::string insertThousandSeparator(const std::string_view str,
         The digit sequence, that must be transformed. Note: The string view
         iterators point to entries in the `str` string.
         */
-        const std::string_view& digitSequence{match.template get<"digit">()};
+        const std::string_view& digitSequence{
+            match.template get<detail::digitCaptureGroup>()};
 
         // Insert the transformed digit sequence, and the string between it
         // and the `parseIterator`, into the stream.

--- a/src/util/http/websocket/WebSocketSession.cpp
+++ b/src/util/http/websocket/WebSocketSession.cpp
@@ -17,9 +17,14 @@
 namespace ad_utility::websocket {
 using namespace boost::asio::experimental::awaitable_operators;
 
+namespace detail {
+// CTRE regex pattern for C++17 compatibility
+constexpr ctll::fixed_string watchPathRegex = "/watch/([^/?]+)";
+}  // namespace detail
+
 // Extracts the query id from a URL path. Returns the empty string when invalid.
 std::string extractQueryId(std::string_view path) {
-  auto match = ctre::match<"/watch/([^/?]+)">(path);
+  auto match = ctre::match<detail::watchPathRegex>(path);
   if (match) {
     return match.get<1>().to_string();
   }


### PR DESCRIPTION
In C++17, string-like types can't be taken by value as template parameters, and GCC 8.3 requires that regexes are defined outside of a function. Therefore, we rewrite the pattern `ctre::match<"some regex">(string)` as follows:
```
// Regex defined as global variable in namespace `detail`.
constexpr ctll::fixed_string someRegex = "some regex"; 

// Some function using the regex.
void someFunction(...) {
  ... ctre::match<detail::someRegex>(string) ...
}
```