### PR TITLE
Implement two-stage vocabulary merging to avoid file descriptor limits

### DIFF
--- a/src/index/ConstantsIndexBuilding.h
+++ b/src/index/ConstantsIndexBuilding.h
@@ -56,6 +56,11 @@ constexpr inline std::string_view PARTIAL_VOCAB_WORDS_INFIX =
     ".partial-vocab.words.tmp.";
 constexpr inline std::string_view PARTIAL_VOCAB_IDMAP_INFIX =
     ".partial-vocab.idmap.tmp.";
+// Intermediate files created during two-stage vocabulary merging
+constexpr inline std::string_view BATCH_VOCAB_WORDS_INFIX =
+    ".batch-vocab.words.tmp.";
+constexpr inline std::string_view BATCH_VOCAB_INTERNAL_IDMAP_INFIX =
+    ".batch-vocab.internal-idmap.tmp.";
 
 // ________________________________________________________________
 constexpr inline std::string_view TMP_BASENAME_COMPRESSION =
@@ -63,6 +68,12 @@ constexpr inline std::string_view TMP_BASENAME_COMPRESSION =
 
 // _________________________________________________________________
 constexpr inline std::string_view QLEVER_INTERNAL_INDEX_INFIX = ".internal";
+
+// The maximum number of input files that can be merged simultaneously without
+// hitting OS file descriptor limits. When the number of partial vocabulary
+// files exceeds this limit, the merging is done in two stages: first merging
+// batches of files, then merging the batch results.
+constexpr inline size_t MAX_NUM_FILES_FOR_DIRECT_MERGE = 2000;
 
 // _________________________________________________________________
 // The degree of parallelism that is used for the index building step, where the

--- a/src/index/ConstantsIndexBuilding.h
+++ b/src/index/ConstantsIndexBuilding.h
@@ -61,6 +61,8 @@ constexpr inline std::string_view BATCH_VOCAB_WORDS_INFIX =
     ".batch-vocab.words.tmp.";
 constexpr inline std::string_view BATCH_VOCAB_INTERNAL_IDMAP_INFIX =
     ".batch-vocab.internal-idmap.tmp.";
+constexpr inline std::string_view BATCH_TO_GLOBAL_IDMAP_INFIX =
+    ".batch-to-global-idmap.tmp.";
 
 // ________________________________________________________________
 constexpr inline std::string_view TMP_BASENAME_COMPRESSION =

--- a/src/index/IndexBuilderMain.cpp
+++ b/src/index/IndexBuilderMain.cpp
@@ -250,6 +250,10 @@ int main(int argc, char** argv) {
       "large enough to hold a single input triple. Default: 10 MB.");
   add("keep-temporary-files,k", po::bool_switch(&config.keepTemporaryFiles_),
       "Do not delete temporary files from index creation for debugging.");
+  add("max-files-per-batch", po::value(&config.maxFilesPerBatch_),
+      "Maximum number of partial vocabulary files to merge simultaneously. "
+      "If the number of partial files exceeds this limit, two-stage merging "
+      "is used to avoid hitting OS file descriptor limits. Default: 2000.");
 
   // Process command line arguments.
   po::variables_map optionsMap;

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -601,7 +601,7 @@ IndexBuilderDataAsExternalVector IndexImpl::passFileForVocabulary(
     wordCallback.readableName() = "internal vocabulary";
     auto mergedVocabMeta = ad_utility::vocabulary_merger::mergeVocabulary(
         onDiskBase_, numFiles, sortPred, wordCallback,
-        memoryLimitIndexBuilding());
+        memoryLimitIndexBuilding(), maxFilesPerBatch_);
     wordCallback.finish();
     return mergedVocabMeta;
   }();

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -142,6 +142,7 @@ class IndexImpl {
 
   size_t parserBatchSize_ = PARSER_BATCH_SIZE;
   size_t numTriplesPerBatch_ = NUM_TRIPLES_PER_PARTIAL_VOCAB;
+  size_t maxFilesPerBatch_ = MAX_NUM_FILES_FOR_DIRECT_MERGE;
 
   NumNormalAndInternal numSubjects_;
   NumNormalAndInternal numPredicates_;
@@ -274,6 +275,11 @@ class IndexImpl {
   // the `Id`; see `EncodedIriManager` for details.
   void setPrefixesForEncodedValues(
       std::vector<std::string> prefixesWithoutAngleBrackets);
+
+  // Set the maximum number of files to merge per batch during vocabulary
+  // merging. If the number of partial vocabulary files exceeds this limit,
+  // two-stage merging is used to avoid hitting OS file descriptor limits.
+  void setMaxFilesPerBatch(size_t maxFiles) { maxFilesPerBatch_ = maxFiles; }
 
   // Set the vocabulary type; see `ad_utility::VocabularyType` for details.
   void setVocabularyTypeForIndexBuilding(ad_utility::VocabularyType type) {

--- a/src/index/VocabularyMerger.h
+++ b/src/index/VocabularyMerger.h
@@ -286,6 +286,27 @@ class VocabularyMerger {
   void doActualWrite(
       const std::vector<std::pair<size_t, std::pair<size_t, Id>>>& buffer);
 
+  // Helper: Create comparator functions from a word comparator.
+  template <typename W>
+  static auto makeComparators(W comparator);
+
+  // Helper: Create a generator that reads words from a partial vocabulary file.
+  static auto makePartialVocabGenerator(const std::string& basename,
+                                        size_t fileIndex);
+
+  // Helper: Create a generator that reads words from a batch vocabulary file.
+  static auto makeBatchVocabGenerator(const std::string& basename,
+                                      size_t batchIndex);
+
+  // Helper: Process a queue word and update metadata/mappings.
+  // Returns true if this is a new unique word.
+  template <typename C, typename L>
+  bool processQueueWord(const QueueWord& word, C& wordCallback,
+                        const L& lessThan, ad_utility::ProgressBar& progressBar)
+      requires WordCallback<C> &&
+               ranges::predicate<L, TripleComponentWithIndex,
+                                 TripleComponentWithIndex>;
+
   // Merge a batch of partial vocabulary files into a single batch file.
   // Returns the number of words in the merged batch.
   template <typename W>

--- a/src/index/VocabularyMerger.h
+++ b/src/index/VocabularyMerger.h
@@ -185,8 +185,8 @@ auto mergeVocabulary(const std::string& basename, size_t numFiles, W comparator,
 
 // Helper structure that holds information about batch merging.
 struct BatchInfo {
-  size_t batchIndex_;           // Which meta-batch (0, 1, 2, ...)
-  size_t originalFileIndex_;    // Original file index in the full set
+  size_t batchIndex_;         // Which meta-batch (0, 1, 2, ...)
+  size_t originalFileIndex_;  // Original file index in the full set
 
   BatchInfo(size_t batchIndex, size_t originalFileIndex)
       : batchIndex_(batchIndex), originalFileIndex_(originalFileIndex) {}
@@ -211,7 +211,8 @@ class VocabularyMerger {
   template <typename W, typename C>
   friend auto mergeVocabulary(const std::string& basename, size_t numFiles,
                               W comparator, C& wordCallback,
-                              ad_utility::MemorySize memoryToUse)
+                              ad_utility::MemorySize memoryToUse,
+                              size_t maxFilesPerBatch)
       -> CPP_ret(VocabularyMetaData)(
           requires WordComparator<W>&& WordCallback<C>);
   VocabularyMerger() = default;
@@ -306,9 +307,8 @@ class VocabularyMerger {
   template <typename C, typename L>
   bool processQueueWord(const QueueWord& word, C& wordCallback,
                         const L& lessThan, ad_utility::ProgressBar& progressBar)
-      requires WordCallback<C> &&
-               ranges::predicate<L, TripleComponentWithIndex,
-                                 TripleComponentWithIndex>;
+      requires WordCallback<C> && ranges::predicate<L, TripleComponentWithIndex,
+                                                    TripleComponentWithIndex>;
 
   // Helper: Compute the target ID for the last processed triple component.
   Id getTargetIdForLastComponent() const;

--- a/src/index/VocabularyMerger.h
+++ b/src/index/VocabularyMerger.h
@@ -201,7 +201,44 @@ class VocabularyMerger {
 
   // The result (mostly metadata) which we'll return.
   VocabularyMetaData metaData_;
-  std::optional<TripleComponentWithIndex> lastTripleComponent_ = std::nullopt;
+  /**
+   * @brief Struct to manage duplicate occurrences of words during merging of
+   *        partial vocabularies.
+   * @detail This struct is needed for the correct semantics of isExternal.
+   *         If multiple occurrences of the same iriOrLiteral appear, they are
+   *         flattened to one vocab entry. If those occurrences have different
+   *         values for isExternal the logic is as follows:
+   *         For isExternal: If one of the occurrences has this set to true,
+   *         this should be set to true later on after merging.
+   *
+   *         This struct is used to collect all multiple occurrences of
+   *         iriOrLiterals and once all are collected, the writing happens. The
+   *         reason the collection works is the QueueWords being sorted.
+   */
+  struct EqualWords {
+    std::string iriOrLiteral_;
+    bool isExternal_;
+    // The targetId_ the Id the words are mapped to by vocabulary. This is the
+    // same for equal words since they are later written as one.
+    Id targetId_;
+    // partialVocabAndPartialFileIds
+    struct PartialIds {
+      size_t fileId_;
+      size_t localIndex_;
+    };
+    std::vector<PartialIds> partialIds_;
+
+    EqualWords(std::string iriOrLiteral, bool isExternal,
+               size_t fileId, size_t localIndex)
+        : iriOrLiteral_(std::move(iriOrLiteral)),
+          isExternal_(isExternal),
+          partialIds_({{fileId, localIndex}}) {
+      targetId_ = Id::makeUndefined();
+    }
+
+    bool isBlankNode() const { return iriOrLiteral_.starts_with("_:"); }
+  };
+  std::optional<EqualWords> currentWord_ = std::nullopt;
   // we will store pairs of <partialId, globalId>
   std::vector<IdMapWriter> idMaps_;
 
@@ -275,11 +312,21 @@ class VocabularyMerger {
           const L& lessThan, ad_utility::ProgressBar& progressBar,
           std::vector<IdMapWriter>& batchToGlobalIdMaps);
 
+  // This function has to be called for a word once all of its occurrences in
+  // the different partial vocabularies have been processed by the queue. It
+  // gets the index and target index for EqualWords. This target index has to be
+  // set only once for EqualWords. The function isn't const since `metaData_` is
+  // modified.
+  CPP_template(typename C)(
+      requires WordCallback<C>) void writeAndGetEqualWordIds(EqualWords&
+                                                                 equalWords,
+                                                             C& wordCallback);
+
   // Close all associated files and file-based vectors and reset all internal
   // variables.
   void clear() {
     metaData_ = VocabularyMetaData{};
-    lastTripleComponent_ = std::nullopt;
+    currentWord_ = std::nullopt;
     idMaps_.clear();
   }
 

--- a/src/index/VocabularyMergerImpl.h
+++ b/src/index/VocabularyMergerImpl.h
@@ -539,7 +539,7 @@ size_t VocabularyMerger::mergeSingleBatch(const std::string& basename,
                                           size_t endFile, W comparator,
                                           ad_utility::MemorySize memoryToUse) {
   AD_LOG_INFO << "Merging batch " << batchIndex << " (files " << startFile
-              << " to " << endFile << ")" << std::endl;
+              << " to " << (endFile - 1) << ")" << std::endl;
 
   // Create comparators
   auto [lessThan, lessThanForQueue] = makeComparators(comparator);

--- a/src/index/VocabularyMergerImpl.h
+++ b/src/index/VocabularyMergerImpl.h
@@ -718,6 +718,9 @@ auto VocabularyMerger::mergeTwoStage(const std::string& basename,
 
   AD_LOG_INFO << progressBar.getFinalProgressString() << std::flush;
 
+  // Ensure all ID map writers are closed before reading them back
+  batchToGlobalIdMaps.clear();
+
   // Stage 3: Compose the ID mappings
   composeIdMappings(basename, numFiles, batchSize, numBatches);
 

--- a/src/libqlever/Qlever.cpp
+++ b/src/libqlever/Qlever.cpp
@@ -74,6 +74,7 @@ void Qlever::buildIndex(IndexBuilderConfig config) {
   index.loadAllPermutations() = !config.onlyPsoAndPos_;
   index.getImpl().setVocabularyTypeForIndexBuilding(config.vocabType_);
   index.getImpl().setPrefixesForEncodedValues(config.prefixesForIdEncodedIris_);
+  index.getImpl().setMaxFilesPerBatch(config.maxFilesPerBatch_);
 
   // Build text index if requested (various options).
   if (!config.onlyAddTextIndex_) {

--- a/src/libqlever/Qlever.h
+++ b/src/libqlever/Qlever.h
@@ -18,6 +18,7 @@
 #include "engine/QueryExecutionContext.h"
 #include "engine/QueryPlanner.h"
 #include "global/RuntimeParameters.h"
+#include "index/ConstantsIndexBuilding.h"
 #include "index/Index.h"
 #include "index/InputFileSpecification.h"
 #include "util/AllocatorWithLimit.h"
@@ -97,6 +98,12 @@ struct IndexBuilderConfig : CommonConfig {
   // If set to true, then certain temporary files which are created while
   // building the index are not deleted. This can be useful for debugging.
   bool keepTemporaryFiles_ = false;
+
+  // Maximum number of partial vocabulary files to merge simultaneously during
+  // vocabulary merging. If the number of partial files exceeds this limit,
+  // two-stage merging is used to avoid hitting OS file descriptor limits.
+  // The default value (2000) works well for most systems.
+  size_t maxFilesPerBatch_ = MAX_NUM_FILES_FOR_DIRECT_MERGE;
 
   // A list of IRI prefixes (without angle brackets). IRIs that start with one
   // of these prefixes, followed by a sequence of a bounded number of digits


### PR DESCRIPTION
This commit adds batched vocabulary merging to handle cases where the number of partial vocabulary files exceeds the operating system's file descriptor limit (typically 1024-4096).

**Problem:**
The vocabulary merger previously opened all input files and all output mapping files simultaneously. With thousands of input files (e.g., 5000+), this exceeded OS file descriptor limits.

**Solution:**
Implement two-stage merging when numFiles > MAX_NUM_FILES_FOR_DIRECT_MERGE (default: 2000):

Stage 1: Merge input files in batches
- Process batches of up to 2000 files at a time
- Each batch is merged into intermediate files (same format as originals)
- Create internal ID mappings (original file ID → batch-local ID)

Stage 2: Merge batch results into final vocabulary
- Merge the batch files (much fewer than original file count)
- Generate batch-to-global ID mappings

Stage 3: Compose final ID mappings
- For each original file: compose (original → batch) and (batch → global) to create (original → global) mappings
- Clean up all intermediate files

**Optimization:**
When numFiles ≤ MAX_NUM_FILES_FOR_DIRECT_MERGE, the original single-pass algorithm is used (no overhead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)