### PR TITLE
Correct handling of `LIMIT` and `OFFSET` when stripping columns of `IndexScan`

### DIFF
--- a/src/engine/QueryExecutionTree.cpp
+++ b/src/engine/QueryExecutionTree.cpp
@@ -213,7 +213,7 @@ QueryExecutionTree::makeTreeWithStrippedColumns(
       "`LIMIT` and `OFFSET` are applied by "
       "`QueryExecutionTree::makeTreeWithStrippedColumns` not by the individual "
       "implementations.");
-  resultTree->applyLimit(resultTree->getRootOperation()->getLimitOffset());
+  resultTree->applyLimit(rootOperation->getLimitOffset());
   // Only store stripped variables if `hideStrippedColumns` is `False`
   if (hideStrippedColumns == HideStrippedColumns::False) {
     // Calculate the variables that will be stripped (present in the input, but

--- a/test/engine/QueryExecutionTreeTest.cpp
+++ b/test/engine/QueryExecutionTreeTest.cpp
@@ -116,10 +116,9 @@ TEST(QueryExecutionTree, limitAndOffsetIsPropagatedWhenStrippingColumns) {
 
   auto strippedIndex = QueryExecutionTree::makeTreeWithStrippedColumns(
       indexScan, {Variable{"?s"}});
-  EXPECT_EQ(strippedIndex->getRootOperation()->getLimitOffset(),
-            LimitOffsetClause(2, 3));
-  EXPECT_FALSE(std::dynamic_pointer_cast<StripColumns>(
-      strippedIndex->getRootOperation()));
+  EXPECT_EQ(strippedIndex->getRootOperation()->getLimitOffset(), limitOffset);
+  EXPECT_TRUE(
+      std::dynamic_pointer_cast<IndexScan>(strippedIndex->getRootOperation()));
 
   auto strippedValues = QueryExecutionTree::makeTreeWithStrippedColumns(
       valuesForTesting, {Variable{"?s"}});
@@ -127,10 +126,10 @@ TEST(QueryExecutionTree, limitAndOffsetIsPropagatedWhenStrippingColumns) {
       strippedValues->getRootOperation()->getLimitOffset().isUnconstrained());
   ASSERT_TRUE(std::dynamic_pointer_cast<StripColumns>(
       strippedValues->getRootOperation()));
-  EXPECT_EQ(strippedIndex->getRootOperation()
+  EXPECT_EQ(strippedValues->getRootOperation()
                 ->getChildren()
                 .at(0)
                 ->getRootOperation()
                 ->getLimitOffset(),
-            LimitOffsetClause(2, 3));
+            limitOffset);
 }


### PR DESCRIPTION
When stripping columns from an index scan operation, the limit and offset were not correctly transferred. For example, in the following query, the `LIMIT 10` had no effect.
```sparql
SELECT ?type WHERE {
  SELECT ?subject ?type WHERE { ?subject a ?type } LIMIT 10
} GROUP BY ?type
```
This is now fixed. In particular, fixes #2404