### PR TITLE
Fix `LocalVocab` cloning issue in `GROUP BY`

### DIFF
--- a/src/engine/GroupByImpl.cpp
+++ b/src/engine/GroupByImpl.cpp
@@ -168,8 +168,9 @@ class LazyGroupByRange
       currentLocalVocab_.mergeWith(storedLocalVocabs_);
       auto result = Result::IdTableVocabPair{std::move(resultTable_),
                                              std::move(currentLocalVocab_)};
-      // Keep last local vocab for next commit.
-      currentLocalVocab_ = std::move(storedLocalVocabs_.back());
+      // Keep last local vocab for next commit, since we might write to
+      // `currentLocalVocab_`, we need to clone it.
+      currentLocalVocab_ = storedLocalVocabs_.back().clone();
       storedLocalVocabs_.clear();
 
       return LoopControl::yieldValue(std::move(result));


### PR DESCRIPTION
There was a subtle issue with GROUP BY, when the input was lazy with more than one block, had local vocab entries, and local vocab entries were added to the output as part of the grouping. Then the the local vocab from the first block was moved to the second result block (because the last elements from the first block might be in the same group as the first elements from the second block so that we still need the vocabulary from the first block) and then new local vocab entries were added to it. However, new local vocab entries can only be added to a local vocab with empty primary word set. Here is an example query where that happened (the second name from the `VALUES` clause is not part of the original vocabulary, so becomes a local vocab entry):
```sparql
PREFIX wdt: <http://www.wikidata.org/prop/direct/>
SELECT (ENCODE_FOR_URI(?author_name) AS ?author_name_encoded) WHERE {
  VALUES ?author_name { "A D Yalcinkaya" "Arda Deniz Yalçınkaya" "Jørgen Bach Andersen" }
  ?work wdt:P2093 ?author_name .
}
GROUP BY ?author_name
```
The fix ist simple: just clone that local vocab (thereby moving the entries from the primary word set to the other word sets and deduplicating) instead of moving it. In particular, fixes #2445.