### PR TITLE
Fix SPARQL expression comparison of encoded values and IRIs

### DIFF
--- a/src/global/ValueId.h
+++ b/src/global/ValueId.h
@@ -103,17 +103,8 @@ class ValueId {
   // types form a consecutive range of IDs when sorted. Within this range, the
   // IDs are ordered by their string values, not by their IDs (and hence also
   // not by their types).
-  static constexpr std::array<Datatype, 2> stringTypes_{
-      Datatype::VocabIndex, Datatype::LocalVocabIndex};
-
-  // Assert that the types in `stringTypes_` are directly adjacent. This is
-  // required to make the comparison of IDs in `ValueIdComparators.h` work.
-  static constexpr Datatype maxStringType_ = ql::ranges::max(stringTypes_);
-  static constexpr Datatype minStringType_ = ql::ranges::min(stringTypes_);
-  static_assert(static_cast<size_t>(maxStringType_) -
-                    static_cast<size_t>(minStringType_) + 1 ==
-                stringTypes_.size());
-
+  static constexpr std::array<Datatype, 3> stringTypes_{
+      Datatype::VocabIndex, Datatype::LocalVocabIndex, Datatype::EncodedVal};
   // Assert that the size of an encoded GeoPoint equals the available bits in a
   // ValueId.
   static_assert(numDataBits == GeoPoint::numDataBits);

--- a/src/global/ValueIdComparators.h
+++ b/src/global/ValueIdComparators.h
@@ -512,7 +512,9 @@ ComparisonResult compareIdsImpl(ValueId a, ValueId b, Comparator comparator) {
   // If any of the entries is a `LocalVocabIndex`, then the ordinary comparison
   // on ValueIds already does the right thing.
   if (a.getDatatype() == Datatype::LocalVocabIndex ||
-      b.getDatatype() == Datatype::LocalVocabIndex) {
+      b.getDatatype() == Datatype::LocalVocabIndex ||
+      a.getDatatype() == Datatype::EncodedVal ||
+      b.getDatatype() == Datatype::EncodedVal) {
     return fromBool(std::invoke(comparator, a, b));
   }
 


### PR DESCRIPTION
SPARQL expressions that check for equality of two IRIs now no longer return UNDEF. The order of actual IRIs remains arbitrary but still deterministic after this change.