### PR TITLE
Set proper cache key for `ExplicitIdTableOperation`

### DIFF
--- a/src/engine/ExplicitIdTableOperation.h
+++ b/src/engine/ExplicitIdTableOperation.h
@@ -20,13 +20,14 @@ class ExplicitIdTableOperation : public Operation {
   VariableToColumnMap variables_;
   std::vector<ColumnIndex> sortedColumns_;
   LocalVocab localVocab_;
+  std::string cacheKey_;
 
  public:
   ExplicitIdTableOperation(QueryExecutionContext* ctx,
                            std::shared_ptr<const IdTable> table,
                            VariableToColumnMap variables,
                            std::vector<ColumnIndex> sortedColumns,
-                           LocalVocab localVocab);
+                           LocalVocab localVocab, std::string cacheKey);
 
   // Const and public getter for testing.
   size_t sizeEstimate() const { return idTable_->numRows(); }

--- a/src/engine/NamedResultCache.cpp
+++ b/src/engine/NamedResultCache.cpp
@@ -12,7 +12,7 @@ std::shared_ptr<ExplicitIdTableOperation> NamedResultCache::getOperation(
   const auto& result = get(name);
   const auto& [table, map, sortedOn, localVocab, cacheKey, geoIndex] = *result;
   auto resultAsOperation = std::make_shared<ExplicitIdTableOperation>(
-      qec, table, map, sortedOn, localVocab.clone());
+      qec, table, map, sortedOn, localVocab.clone(), cacheKey);
   return resultAsOperation;
 }
 

--- a/src/engine/SpatialJoin.cpp
+++ b/src/engine/SpatialJoin.cpp
@@ -196,21 +196,9 @@ std::string SpatialJoin::getCacheKeyImpl() const {
     os << "\n";
 
     // If we use the s2-point-polyline algorithm, we also need to add the cache
-    // entry name to our own cache key because the `ExplicitIdTableOperation`
-    // which then becomes our right child doesn't have a cache key on its own.
+    // entry name to our own cache key.
     if (config_.rightCacheName_.has_value()) {
       os << "right cache name:" << config_.rightCacheName_.value() << "\n";
-
-      // Additionally we add the pointer address of the cache entry to the
-      // cache key. This is to ensure invalidation of the cache for this
-      // operation when the user rebuilds the underlying cached s2 index.
-      if (algo == SpatialJoinAlgorithm::S2_POINT_POLYLINE) {
-        os << "cache entry: ("
-           << _executionContext->namedResultCache()
-                  .get(config_.rightCacheName_.value())
-                  ->cacheKey_
-           << ")\n";
-      }
     }
 
     // Algorithm is not included here because it should not have any impact on

--- a/test/engine/SpatialJoinCachedIndexTest.cpp
+++ b/test/engine/SpatialJoinCachedIndexTest.cpp
@@ -152,8 +152,7 @@ TEST(SpatialJoinCachedIndex, UseOfIndexByS2PointPolylineAlgorithm) {
 
   const auto cacheKey = spatialJoin->getCacheKey();
   EXPECT_THAT(cacheKey, ::testing::HasSubstr("right cache name:dummy"));
-  EXPECT_THAT(cacheKey, ::testing::HasSubstr(absl::StrCat(
-                            "cache entry: (", pinResultCacheKey, ")")));
+  EXPECT_THAT(cacheKey, ::testing::HasSubstr(pinResultCacheKey));
 }
 
 }  // namespace


### PR DESCRIPTION
The `NamedResultCache` from #1739 did not work as expected when using a named result from that cache in another query and then changing the named result in the cache. Then the query using the named result should be recomputed. This is now fixed, using the mechanism introduced in #2381, namely by setting the cache key of an `ExplicitIdTableOperation` to the cache key of the query used for obtaining the cached result.