### PR TITLE
Backport the code in `src/engine/sparqlExpressions` to C++17

### DIFF
--- a/src/engine/GroupByHashMapOptimization.h
+++ b/src/engine/GroupByHashMapOptimization.h
@@ -84,7 +84,7 @@ struct ExtremumAggregationData {
       return;
     }
 
-    currentValue_ = sparqlExpression::detail::minMaxLambdaForAllTypes<Comp>(
+    currentValue_ = sparqlExpression::detail::MinMaxLambdaForAllTypes<Comp>{}(
         value, currentValue_, ctx);
   }
 

--- a/src/engine/sparqlExpressions/AggregateExpression.cpp
+++ b/src/engine/sparqlExpressions/AggregateExpression.cpp
@@ -191,7 +191,7 @@ template class DeviationAggExpression<AvgOperation, StdevFinalOperation>;
 #define INSTANTIATE_AGG_EXP(Function, ValueGetter) \
   template class AggregateExpression<              \
       Operation<2, FunctionAndValueGetters<Function, ValueGetter>>>;
-INSTANTIATE_AGG_EXP(decltype(addForSum), NumericValueGetter);
+INSTANTIATE_AGG_EXP(AddForSum, NumericValueGetter);
 INSTANTIATE_AGG_EXP(Count, IsValidValueGetter);
 INSTANTIATE_AGG_EXP(MinLambdaForAllTypes, ActualValueGetter);
 INSTANTIATE_AGG_EXP(MaxLambdaForAllTypes, ActualValueGetter);

--- a/src/engine/sparqlExpressions/AggregateExpression.cpp
+++ b/src/engine/sparqlExpressions/AggregateExpression.cpp
@@ -181,19 +181,18 @@ AggregateExpression<AggregateOperation, FinalOperation>::getVariableForCount()
 }
 
 // Explicit instantiation for the AVG expression.
-template class AggregateExpression<AvgOperation, decltype(avgFinalOperation)>;
+template class AggregateExpression<AvgOperation, AvgFinalOperation>;
 
 // Explicit instantiation for the STDEV expression.
-template class AggregateExpression<AvgOperation, decltype(stdevFinalOperation)>;
-template class DeviationAggExpression<AvgOperation,
-                                      decltype(stdevFinalOperation)>;
+template class AggregateExpression<AvgOperation, StdevFinalOperation>;
+template class DeviationAggExpression<AvgOperation, StdevFinalOperation>;
 
 // Explicit instantiations for the other aggregate expressions.
 #define INSTANTIATE_AGG_EXP(Function, ValueGetter) \
   template class AggregateExpression<              \
       Operation<2, FunctionAndValueGetters<Function, ValueGetter>>>;
 INSTANTIATE_AGG_EXP(decltype(addForSum), NumericValueGetter);
-INSTANTIATE_AGG_EXP(decltype(count), IsValidValueGetter);
-INSTANTIATE_AGG_EXP(decltype(minLambdaForAllTypes), ActualValueGetter);
-INSTANTIATE_AGG_EXP(decltype(maxLambdaForAllTypes), ActualValueGetter);
+INSTANTIATE_AGG_EXP(Count, IsValidValueGetter);
+INSTANTIATE_AGG_EXP(MinLambdaForAllTypes, ActualValueGetter);
+INSTANTIATE_AGG_EXP(MaxLambdaForAllTypes, ActualValueGetter);
 }  // namespace sparqlExpression::detail

--- a/src/engine/sparqlExpressions/AggregateExpression.h
+++ b/src/engine/sparqlExpressions/AggregateExpression.h
@@ -19,7 +19,13 @@ namespace sparqlExpression {
 
 // This can be used as the `FinalOperation` parameter to an
 // `AggregateExpression` if there is nothing to be done on the final result.
-inline auto identity = [](auto&& result, size_t) { return AD_FWD(result); };
+struct Identity {
+  template <typename T>
+  decltype(auto) operator()(T&& result, size_t) const {
+    return AD_FWD(result);
+  }
+};
+inline constexpr Identity identity{};
 
 namespace detail {
 
@@ -102,15 +108,14 @@ template <typename Function, typename ValueGetter>
 using AGG_EXP = AggregateExpression<
     Operation<2, FunctionAndValueGetters<Function, ValueGetter>>>;
 
-// Helper function that for a given `NumericOperation` with numeric arguments
+// Helper struct that for a given `NumericOperation` with numeric arguments
 // and result (integer or floating points), returns the corresponding function
 // with arguments and result of type `NumericValue` (which is a `std::variant`).
 template <typename NumericOperation>
-inline auto makeNumericExpressionForAggregate() {
-  return [](const auto&... args)
-             -> CPP_ret(NumericValue)(
-                 requires(concepts::same_as<std::decay_t<decltype(args)>,
-                                            NumericValue>&&...)) {
+struct NumericExpressionForAggregate {
+  template <typename... Args>
+  auto operator()(const Args&... args) const -> CPP_ret(NumericValue)(
+      requires(concepts::same_as<std::decay_t<Args>, NumericValue>&&...)) {
     auto visitor = [](const auto&... t) -> NumericValue {
       if constexpr ((... ||
                      std::is_same_v<NotNumeric, std::decay_t<decltype(t)>>)) {
@@ -120,17 +125,25 @@ inline auto makeNumericExpressionForAggregate() {
       }
     };
     return std::visit(visitor, args...);
-  };
+  }
+};
+
+template <typename NumericOperation>
+inline auto makeNumericExpressionForAggregate() {
+  return NumericExpressionForAggregate<NumericOperation>{};
 }
 
 // Aggregate expression for COUNT.
 //
 // NOTE: For this expression, we have to override `getVariableForCount` for the
 // pattern trick.
-inline auto count = [](const auto& a, const auto& b) -> int64_t {
-  return a + b;
+struct Count {
+  template <typename T1, typename T2>
+  int64_t operator()(const T1& a, const T2& b) const {
+    return a + b;
+  }
 };
-using CountExpressionBase = AGG_EXP<decltype(count), IsValidValueGetter>;
+using CountExpressionBase = AGG_EXP<Count, IsValidValueGetter>;
 class CountExpression : public CountExpressionBase {
   using CountExpressionBase::CountExpressionBase;
   [[nodiscard]] std::optional<SparqlExpressionPimpl::VariableAndDistinctness>
@@ -155,16 +168,17 @@ class SumExpression : public AGG_EXP<decltype(addForSum), NumericValueGetter> {
 };
 
 // Aggregate expression for AVG.
-inline auto avgFinalOperation = [](const NumericValue& aggregation,
-                                   size_t numElements) {
-  return makeNumericExpressionForAggregate<std::divides<>>()(
-      aggregation, NumericValue{static_cast<double>(numElements)});
+struct AvgFinalOperation {
+  NumericValue operator()(const NumericValue& aggregation,
+                          size_t numElements) const {
+    return makeNumericExpressionForAggregate<std::divides<>>()(
+        aggregation, NumericValue{static_cast<double>(numElements)});
+  }
 };
 using AvgOperation =
     Operation<2,
               FunctionAndValueGetters<decltype(addForSum), NumericValueGetter>>;
-using AvgExpressionBase =
-    AggregateExpression<AvgOperation, decltype(avgFinalOperation)>;
+using AvgExpressionBase = AggregateExpression<AvgOperation, AvgFinalOperation>;
 class AvgExpression : public AvgExpressionBase {
   using AvgExpressionBase::AvgExpressionBase;
   ValueId resultForEmptyGroup() const override { return Id::makeFromInt(0); }
@@ -187,27 +201,27 @@ inline const auto compareIdsOrStrings =
 
 // Aggregate expression for MIN and MAX.
 template <valueIdComparators::Comparison comparison>
-inline const auto minMaxLambdaForAllTypes = CPP_template_lambda()(typename T)(
-    const T& a, const T& b,
-    const EvaluationContext* ctx)(requires SingleExpressionResult<T>) {
-  auto actualImpl = [ctx](const auto& x, const auto& y) {
-    return compareIdsOrStrings<comparison>(x, y, ctx);
-  };
-  if constexpr (ad_utility::isSimilar<T, Id>) {
-    return std::get<Id>(actualImpl(a, b));
-  } else {
-    // TODO<joka921> We should definitely move strings here.
-    return std::visit(actualImpl, a, b);
+struct MinMaxLambdaForAllTypes {
+  template <typename T>
+  auto operator()(const T& a, const T& b, const EvaluationContext* ctx) const
+      -> CPP_ret(T)(requires SingleExpressionResult<T>) {
+    auto actualImpl = [ctx](const auto& x, const auto& y) {
+      return compareIdsOrStrings<comparison>(x, y, ctx);
+    };
+    if constexpr (ad_utility::isSimilar<T, Id>) {
+      return std::get<Id>(actualImpl(a, b));
+    } else {
+      // TODO<joka921> We should definitely move strings here.
+      return std::visit(actualImpl, a, b);
+    }
   }
 };
-constexpr inline auto minLambdaForAllTypes =
-    minMaxLambdaForAllTypes<valueIdComparators::Comparison::LT>;
-constexpr inline auto maxLambdaForAllTypes =
-    minMaxLambdaForAllTypes<valueIdComparators::Comparison::GT>;
-using MinExpressionBase =
-    AGG_EXP<decltype(minLambdaForAllTypes), ActualValueGetter>;
-using MaxExpressionBase =
-    AGG_EXP<decltype(maxLambdaForAllTypes), ActualValueGetter>;
+using MinLambdaForAllTypes =
+    MinMaxLambdaForAllTypes<valueIdComparators::Comparison::LT>;
+using MaxLambdaForAllTypes =
+    MinMaxLambdaForAllTypes<valueIdComparators::Comparison::GT>;
+using MinExpressionBase = AGG_EXP<MinLambdaForAllTypes, ActualValueGetter>;
+using MaxExpressionBase = AGG_EXP<MaxLambdaForAllTypes, ActualValueGetter>;
 class MinExpression : public MinExpressionBase {
   using MinExpressionBase::MinExpressionBase;
   ValueId resultForEmptyGroup() const override { return Id::makeUndefined(); }

--- a/src/engine/sparqlExpressions/AggregateExpression.h
+++ b/src/engine/sparqlExpressions/AggregateExpression.h
@@ -115,7 +115,7 @@ template <typename NumericOperation>
 struct NumericExpressionForAggregate {
   template <typename... Args>
   auto operator()(const Args&... args) const -> CPP_ret(NumericValue)(
-      requires(concepts::same_as<std::decay_t<Args>, NumericValue>&&...)) {
+      requires(ad_utility::SimilarTo<Args, NumericValue>&&...)) {
     auto visitor = [](const auto&... t) -> NumericValue {
       if constexpr ((... ||
                      std::is_same_v<NotNumeric, std::decay_t<decltype(t)>>)) {

--- a/src/engine/sparqlExpressions/AggregateExpression.h
+++ b/src/engine/sparqlExpressions/AggregateExpression.h
@@ -21,11 +21,10 @@ namespace sparqlExpression {
 // `AggregateExpression` if there is nothing to be done on the final result.
 struct Identity {
   template <typename T>
-  decltype(auto) operator()(T&& result, size_t) const {
+  auto operator()(T&& result, size_t) const {
     return AD_FWD(result);
   }
 };
-inline constexpr Identity identity{};
 
 namespace detail {
 
@@ -52,11 +51,10 @@ inline auto getUniqueElements = [](const EvaluationContext* context,
 // Class for a SPARQL expression that aggregates a given set of values to a
 // single value using `AggregateOperation`, and then applies `FinalOperation`.
 //
-// NOTE: The `FinalOperation` is typically the `identity` from above. One
+// NOTE: The `FinalOperation` is typically the `Identity` from above. One
 // exception is the `AvgExpression`, where the `FinalOperation` divides the
 // aggregated value (sum) by the number of elements.
-template <typename AggregateOperation,
-          typename FinalOperation = decltype(identity)>
+template <typename AggregateOperation, typename FinalOperation = Identity>
 class AggregateExpression : public SparqlExpression {
  public:
   // Create an aggregate expression from the given arguments. For example, for
@@ -160,9 +158,9 @@ class CountExpression : public CountExpressionBase {
 };
 
 // Aggregate expression for SUM.
-inline auto addForSum = makeNumericExpressionForAggregate<std::plus<>>();
-using SumExpressionBase = AGG_EXP<decltype(addForSum), NumericValueGetter>;
-class SumExpression : public AGG_EXP<decltype(addForSum), NumericValueGetter> {
+using AddForSum = NumericExpressionForAggregate<std::plus<>>;
+using SumExpressionBase = AGG_EXP<AddForSum, NumericValueGetter>;
+class SumExpression : public AGG_EXP<AddForSum, NumericValueGetter> {
   using SumExpressionBase::SumExpressionBase;
   ValueId resultForEmptyGroup() const override { return Id::makeFromInt(0); }
 };
@@ -176,8 +174,7 @@ struct AvgFinalOperation {
   }
 };
 using AvgOperation =
-    Operation<2,
-              FunctionAndValueGetters<decltype(addForSum), NumericValueGetter>>;
+    Operation<2, FunctionAndValueGetters<AddForSum, NumericValueGetter>>;
 using AvgExpressionBase = AggregateExpression<AvgOperation, AvgFinalOperation>;
 class AvgExpression : public AvgExpressionBase {
   using AvgExpressionBase::AvgExpressionBase;

--- a/src/engine/sparqlExpressions/ConvertToDtypeConstructor.cpp
+++ b/src/engine/sparqlExpressions/ConvertToDtypeConstructor.cpp
@@ -133,33 +133,33 @@ namespace detail::to_datetime {
 
 // Cast to xsd:dateTime or xsd:date (ValueId)
 template <bool ToJustXsdDate>
-inline const auto castStringToDateTimeValueId = [](OptStringOrDate input) {
-  if (!input.has_value()) return Id::makeUndefined();
+struct CastStringToDateTimeValueId {
+  Id operator()(OptStringOrDate input) const {
+    if (!input.has_value()) return Id::makeUndefined();
 
-  using DYD = DateYearOrDuration;
-  std::optional<DYD> optValueId = std::visit(
-      [&](const auto& value) {
-        using T = std::decay_t<decltype(value)>;
-        if constexpr (ad_utility::isSimilar<T, DYD>) {
-          return ToJustXsdDate ? DYD::convertToXsdDate(value)
-                               : DYD::convertToXsdDatetime(value);
-        } else {
-          static_assert(ad_utility::isSimilar<T, std::string>);
-          return ToJustXsdDate ? DYD::parseXsdDateGetOptDate(value)
-                               : DYD::parseXsdDatetimeGetOptDate(value);
-        }
-      },
-      input.value());
-  return optValueId.has_value() ? Id::makeFromDate(optValueId.value())
-                                : Id::makeUndefined();
+    using DYD = DateYearOrDuration;
+    std::optional<DYD> optValueId = std::visit(
+        [&](const auto& value) {
+          using T = std::decay_t<decltype(value)>;
+          if constexpr (ad_utility::isSimilar<T, DYD>) {
+            return ToJustXsdDate ? DYD::convertToXsdDate(value)
+                                 : DYD::convertToXsdDatetime(value);
+          } else {
+            static_assert(ad_utility::isSimilar<T, std::string>);
+            return ToJustXsdDate ? DYD::parseXsdDateGetOptDate(value)
+                                 : DYD::parseXsdDatetimeGetOptDate(value);
+          }
+        },
+        input.value());
+    return optValueId.has_value() ? Id::makeFromDate(optValueId.value())
+                                  : Id::makeUndefined();
+  }
 };
 
-NARY_EXPRESSION(
-    ToXsdDateTime, 1,
-    FV<decltype(castStringToDateTimeValueId<false>), StringOrDateGetter>);
-NARY_EXPRESSION(
-    ToXsdDate, 1,
-    FV<decltype(castStringToDateTimeValueId<true>), StringOrDateGetter>);
+NARY_EXPRESSION(ToXsdDateTime, 1,
+                FV<CastStringToDateTimeValueId<false>, StringOrDateGetter>);
+NARY_EXPRESSION(ToXsdDate, 1,
+                FV<CastStringToDateTimeValueId<true>, StringOrDateGetter>);
 }  // namespace detail::to_datetime
 
 using namespace detail::to_numeric;

--- a/src/engine/sparqlExpressions/DateExpressions.cpp
+++ b/src/engine/sparqlExpressions/DateExpressions.cpp
@@ -23,7 +23,6 @@ struct ExtractYear {
     }
   }
 };
-inline constexpr ExtractYear extractYear{};
 
 //______________________________________________________________________________
 struct ExtractMonth {
@@ -39,7 +38,6 @@ struct ExtractMonth {
     return Id::makeFromInt(optionalMonth.value());
   }
 };
-inline constexpr ExtractMonth extractMonth{};
 
 //______________________________________________________________________________
 struct ExtractDay {
@@ -55,7 +53,6 @@ struct ExtractDay {
     return Id::makeFromInt(optionalDay.value());
   }
 };
-inline constexpr ExtractDay extractDay{};
 
 //______________________________________________________________________________
 struct ExtractStrTimezone {
@@ -69,7 +66,6 @@ struct ExtractStrTimezone {
         asNormalizedStringViewUnsafe(timezoneStr))};
   }
 };
-inline constexpr ExtractStrTimezone extractStrTimezone{};
 
 //______________________________________________________________________________
 struct ExtractTimezoneDurationFormat {
@@ -85,7 +81,6 @@ struct ExtractTimezoneDurationFormat {
                : Id::makeUndefined();
   }
 };
-inline constexpr ExtractTimezoneDurationFormat extractTimezoneDurationFormat{};
 
 //______________________________________________________________________________
 template <auto dateMember, auto makeId>
@@ -103,27 +98,22 @@ struct ExtractTimeComponentImpl {
 };
 
 //______________________________________________________________________________
-inline constexpr ExtractTimeComponentImpl<&Date::getHour, &Id::makeFromInt>
-    extractHours{};
-inline constexpr ExtractTimeComponentImpl<&Date::getMinute, &Id::makeFromInt>
-    extractMinutes{};
-inline constexpr ExtractTimeComponentImpl<&Date::getSecond, &Id::makeFromDouble>
-    extractSeconds{};
+using ExtractHours = ExtractTimeComponentImpl<&Date::getHour, &Id::makeFromInt>;
+using ExtractMinutes =
+    ExtractTimeComponentImpl<&Date::getMinute, &Id::makeFromInt>;
+using ExtractSeconds =
+    ExtractTimeComponentImpl<&Date::getSecond, &Id::makeFromDouble>;
 
 //______________________________________________________________________________
-NARY_EXPRESSION(MonthExpression, 1,
-                FV<decltype(extractMonth), DateValueGetter>);
-NARY_EXPRESSION(DayExpression, 1, FV<decltype(extractDay), DateValueGetter>);
+NARY_EXPRESSION(MonthExpression, 1, FV<ExtractMonth, DateValueGetter>);
+NARY_EXPRESSION(DayExpression, 1, FV<ExtractDay, DateValueGetter>);
 NARY_EXPRESSION(TimezoneStrExpression, 1,
-                FV<decltype(extractStrTimezone), DateValueGetter>);
+                FV<ExtractStrTimezone, DateValueGetter>);
 NARY_EXPRESSION(TimezoneDurationExpression, 1,
-                FV<decltype(extractTimezoneDurationFormat), DateValueGetter>);
-NARY_EXPRESSION(HoursExpression, 1,
-                FV<decltype(extractHours), DateValueGetter>);
-NARY_EXPRESSION(MinutesExpression, 1,
-                FV<decltype(extractMinutes), DateValueGetter>);
-NARY_EXPRESSION(SecondsExpression, 1,
-                FV<decltype(extractSeconds), DateValueGetter>);
+                FV<ExtractTimezoneDurationFormat, DateValueGetter>);
+NARY_EXPRESSION(HoursExpression, 1, FV<ExtractHours, DateValueGetter>);
+NARY_EXPRESSION(MinutesExpression, 1, FV<ExtractMinutes, DateValueGetter>);
+NARY_EXPRESSION(SecondsExpression, 1, FV<ExtractSeconds, DateValueGetter>);
 
 //______________________________________________________________________________
 // `YearExpression` requires `YearExpressionImpl` to be easily identifiable if
@@ -136,8 +126,8 @@ CPP_class_template(typename NaryOperation)(
   bool isYearExpression() const override { return true; }
 };
 
-using YearExpression = YearExpressionImpl<
-    Operation<1, FV<decltype(extractYear), DateValueGetter>>>;
+using YearExpression =
+    YearExpressionImpl<Operation<1, FV<ExtractYear, DateValueGetter>>>;
 
 }  // namespace detail
 using namespace detail;

--- a/src/engine/sparqlExpressions/GroupConcatHelper.h
+++ b/src/engine/sparqlExpressions/GroupConcatHelper.h
@@ -45,8 +45,9 @@ inline void pushLanguageTag(
 }
 
 // Combine a string and an optional language tag into a `LiteralOrIri` object.
-inline LiteralOrIri stringWithOptionalLangTagToLiteral(
-    const std::string& result, std::optional<std::string> langTag) {
+inline ad_utility::triple_component::LiteralOrIri
+stringWithOptionalLangTagToLiteral(const std::string& result,
+                                   std::optional<std::string> langTag) {
   return ad_utility::triple_component::LiteralOrIri{
       ad_utility::triple_component::Literal::literalWithNormalizedContent(
           asNormalizedStringViewUnsafe(result),

--- a/src/engine/sparqlExpressions/IsSomethingExpressions.cpp
+++ b/src/engine/sparqlExpressions/IsSomethingExpressions.cpp
@@ -74,8 +74,10 @@ using isGeoPointExpression =
 //______________________________________________________________________________
 // The expression for `bound` is slightly different as `IsValidValueGetter`
 // returns a `bool` and not an `Id`.
-inline auto boolToId = [](bool b) { return Id::makeFromBool(b); };
-using boundExpression = NARY<1, FV<decltype(boolToId), IsValidValueGetter>>;
+struct BoolToId {
+  Id operator()(bool b) const { return Id::makeFromBool(b); }
+};
+using boundExpression = NARY<1, FV<BoolToId, IsValidValueGetter>>;
 
 }  // namespace detail
 

--- a/src/engine/sparqlExpressions/LangExpression.cpp
+++ b/src/engine/sparqlExpressions/LangExpression.cpp
@@ -38,14 +38,17 @@ CPP_template(typename NaryOperation)(
 };
 
 //______________________________________________________________________________
-inline auto getLanguageTag = [](OptValue optLangTag) -> IdOrLiteralOrIri {
-  if (!optLangTag.has_value()) {
-    return Id::makeUndefined();
-  } else {
-    return LiteralOrIri{Lit::literalWithNormalizedContent(
-        asNormalizedStringViewUnsafe(std::move(optLangTag.value())))};
+struct GetLanguageTag {
+  IdOrLiteralOrIri operator()(OptValue optLangTag) const {
+    if (!optLangTag.has_value()) {
+      return Id::makeUndefined();
+    } else {
+      return LiteralOrIri{Lit::literalWithNormalizedContent(
+          asNormalizedStringViewUnsafe(std::move(optLangTag.value())))};
+    }
   }
 };
+inline constexpr GetLanguageTag getLanguageTag{};
 
 //______________________________________________________________________________
 using LangExpression = detail::langImpl::LangExpressionImpl<

--- a/src/engine/sparqlExpressions/LangExpression.cpp
+++ b/src/engine/sparqlExpressions/LangExpression.cpp
@@ -48,12 +48,10 @@ struct GetLanguageTag {
     }
   }
 };
-inline constexpr GetLanguageTag getLanguageTag{};
 
 //______________________________________________________________________________
-using LangExpression = detail::langImpl::LangExpressionImpl<
-    detail::Operation<1, detail::FV<decltype(detail::langImpl::getLanguageTag),
-                                    detail::LanguageTagValueGetter>>>;
+using LangExpression = detail::langImpl::LangExpressionImpl<detail::Operation<
+    1, detail::FV<GetLanguageTag, detail::LanguageTagValueGetter>>>;
 
 }  //  namespace detail::langImpl
 

--- a/src/engine/sparqlExpressions/NaryExpressionImpl.h
+++ b/src/engine/sparqlExpressions/NaryExpressionImpl.h
@@ -141,7 +141,6 @@ struct AreAllSetOfIntervals {
   }
 };
 
-inline constexpr AreAllSetOfIntervals areAllSetOfIntervals{};
 template <typename F>
 using SET = SpecializedFunction<F, AreAllSetOfIntervals>;
 

--- a/src/engine/sparqlExpressions/NaryExpressionImpl.h
+++ b/src/engine/sparqlExpressions/NaryExpressionImpl.h
@@ -140,6 +140,8 @@ struct AreAllSetOfIntervals {
                                          ad_utility::SetOfIntervals>);
   }
 };
+
+inline constexpr AreAllSetOfIntervals areAllSetOfIntervals{};
 template <typename F>
 using SET = SpecializedFunction<F, AreAllSetOfIntervals>;
 

--- a/src/engine/sparqlExpressions/RdfTermExpressions.cpp
+++ b/src/engine/sparqlExpressions/RdfTermExpressions.cpp
@@ -7,15 +7,17 @@
 namespace sparqlExpression {
 namespace detail::rdfExpressions {
 
-inline auto getDatatype = [](OptIri input) -> IdOrLiteralOrIri {
-  if (!input.has_value()) {
-    return Id::makeUndefined();
-  } else {
-    return LiteralOrIri{std::move(input.value())};
+struct GetDatatypeImpl {
+  IdOrLiteralOrIri operator()(OptIri input) const {
+    if (!input.has_value()) {
+      return Id::makeUndefined();
+    } else {
+      return LiteralOrIri{std::move(input.value())};
+    }
   }
 };
 
-using GetDatatype = NARY<1, FV<decltype(getDatatype), DatatypeValueGetter>>;
+using GetDatatype = NARY<1, FV<GetDatatypeImpl, DatatypeValueGetter>>;
 
 }  //  namespace detail::rdfExpressions
 

--- a/src/engine/sparqlExpressions/RegexExpression.cpp
+++ b/src/engine/sparqlExpressions/RegexExpression.cpp
@@ -80,7 +80,6 @@ struct RegexImpl {
     return Id::makeFromBool(RE2::PartialMatch(input.value(), *pattern));
   }
 };
-[[maybe_unused]] inline constexpr RegexImpl regexImpl{};
 
 using RegexExpression =
     string_expressions::StringExpressionImpl<2, RegexImpl, RegexValueGetter>;
@@ -237,9 +236,9 @@ ExpressionResult PrefixRegexExpression::evaluate(
       }
       checkCancellation(context);
     }
-    return std::accumulate(
-        resultSetOfIntervals.begin(), resultSetOfIntervals.end(),
-        ad_utility::SetOfIntervals{}, ad_utility::SetOfIntervals::Union{});
+    return ::ranges::accumulate(resultSetOfIntervals,
+                                ad_utility::SetOfIntervals{},
+                                ad_utility::SetOfIntervals::Union{});
   }
 
   // If the input is not sorted by the variable, we have to check each row

--- a/src/engine/sparqlExpressions/RegexExpression.cpp
+++ b/src/engine/sparqlExpressions/RegexExpression.cpp
@@ -67,21 +67,23 @@ void ensureIsValidFlagIfConstant(const SparqlExpression& expression) {
 }
 
 // _____________________________________________________________________________
-[[maybe_unused]] auto regexImpl = [](const std::optional<std::string>& input,
-                                     const std::shared_ptr<RE2>& pattern) {
-  if (!input.has_value() || !pattern) {
-    return Id::makeUndefined();
+struct RegexImpl {
+  Id operator()(const std::optional<std::string>& input,
+                const std::shared_ptr<RE2>& pattern) const {
+    if (!input.has_value() || !pattern) {
+      return Id::makeUndefined();
+    }
+    // Check for invalid regexes.
+    if (!pattern->ok()) {
+      return Id::makeUndefined();
+    }
+    return Id::makeFromBool(RE2::PartialMatch(input.value(), *pattern));
   }
-  // Check for invalid regexes.
-  if (!pattern->ok()) {
-    return Id::makeUndefined();
-  }
-  return Id::makeFromBool(RE2::PartialMatch(input.value(), *pattern));
 };
+[[maybe_unused]] inline constexpr RegexImpl regexImpl{};
 
 using RegexExpression =
-    string_expressions::StringExpressionImpl<2, decltype(regexImpl),
-                                             RegexValueGetter>;
+    string_expressions::StringExpressionImpl<2, RegexImpl, RegexValueGetter>;
 
 }  // namespace sparqlExpression::detail
 
@@ -235,9 +237,9 @@ ExpressionResult PrefixRegexExpression::evaluate(
       }
       checkCancellation(context);
     }
-    return std::reduce(resultSetOfIntervals.begin(), resultSetOfIntervals.end(),
-                       ad_utility::SetOfIntervals{},
-                       ad_utility::SetOfIntervals::Union{});
+    return std::accumulate(
+        resultSetOfIntervals.begin(), resultSetOfIntervals.end(),
+        ad_utility::SetOfIntervals{}, ad_utility::SetOfIntervals::Union{});
   }
 
   // If the input is not sorted by the variable, we have to check each row

--- a/src/engine/sparqlExpressions/RegexExpression.h
+++ b/src/engine/sparqlExpressions/RegexExpression.h
@@ -32,11 +32,10 @@ class PrefixRegexExpression : public SparqlExpression {
   PrefixRegexExpression(Ptr child, std::string prefixRegex, Variable variable);
 
  public:
-  PrefixRegexExpression(PrefixRegexExpression&&) noexcept = default;
-  PrefixRegexExpression& operator=(PrefixRegexExpression&&) noexcept = default;
-  PrefixRegexExpression(const PrefixRegexExpression&) noexcept = delete;
-  PrefixRegexExpression& operator=(const PrefixRegexExpression&) noexcept =
-      delete;
+  PrefixRegexExpression(PrefixRegexExpression&&) = default;
+  PrefixRegexExpression& operator=(PrefixRegexExpression&&) = default;
+  PrefixRegexExpression(const PrefixRegexExpression&) = delete;
+  PrefixRegexExpression& operator=(const PrefixRegexExpression&) = delete;
 
   std::vector<PrefilterExprVariablePair> getPrefilterExpressionForMetadata(
       bool isNegated) const override;

--- a/src/engine/sparqlExpressions/RelationalExpressionHelpers.h
+++ b/src/engine/sparqlExpressions/RelationalExpressionHelpers.h
@@ -108,7 +108,9 @@ constexpr Comparison getComparisonForSwappedArguments(Comparison comp) {
     case Comparison::GT:
       return Comparison::LT;
   }
+#ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
   AD_FAIL();
+#endif
 }
 
 // Return the ID range `[begin, end)` in which the entries of the vocabulary

--- a/src/engine/sparqlExpressions/SampleExpression.h
+++ b/src/engine/sparqlExpressions/SampleExpression.h
@@ -6,13 +6,14 @@
 
 #include <absl/strings/str_cat.h>
 
+#include "backports/keywords.h"
 #include "engine/sparqlExpressions/SparqlExpression.h"
 
 namespace sparqlExpression {
 /// The (SAMPLE(?x) as ?sample) expression
 class SampleExpression : public SparqlExpression {
  public:
-  SampleExpression([[maybe_unused]] bool distinct, Ptr&& child)
+  SampleExpression(QL_MAYBE_UNUSED bool distinct, Ptr&& child)
       : _child{std::move(child)} {
     setIsInsideAggregate();
   }

--- a/src/engine/sparqlExpressions/SparqlExpressionTypes.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionTypes.h
@@ -32,6 +32,10 @@ class VectorWithMemoryLimit
   using Allocator = ad_utility::AllocatorWithLimit<T>;
   using Base = std::vector<T, ad_utility::AllocatorWithLimit<T>>;
 
+ private:
+  struct CloneTag {};
+
+ public:
   // The `AllocatorWithMemoryLimit` is not default-constructible (on purpose).
   // Unfortunately, the support for such allocators is not really great in the
   // standard library. In particular, the type trait
@@ -64,13 +68,9 @@ class VectorWithMemoryLimit
   // Disable copy constructor and copy assignment operator (copying is too
   // expensive in the setting where we want to use this class and not
   // necessary).
-  // The copy constructor is not deleted, but private, because it is used
-  // for the explicit clone() function.
- private:
-  VectorWithMemoryLimit(const VectorWithMemoryLimit&) = default;
-
  public:
   VectorWithMemoryLimit& operator=(const VectorWithMemoryLimit&) = delete;
+  VectorWithMemoryLimit(const VectorWithMemoryLimit&) = delete;
   // Moving is fine.
   VectorWithMemoryLimit(VectorWithMemoryLimit&&) noexcept = default;
   VectorWithMemoryLimit& operator=(VectorWithMemoryLimit&&) noexcept = default;
@@ -78,10 +78,16 @@ class VectorWithMemoryLimit
   // Allow copying via an explicit clone() function.
   [[nodiscard]] VectorWithMemoryLimit clone() const {
     // Call the private copy constructor.
-    return VectorWithMemoryLimit(*this);
+    return VectorWithMemoryLimit(CloneTag{}, *this);
   }
+
+ private:
+  // Constructor for copying, used to implement the `clone` function.
+  VectorWithMemoryLimit(CloneTag, const VectorWithMemoryLimit& other)
+      : Base{static_cast<const Base&>(other)} {}
 };
 static_assert(!ql::concepts::default_initializable<VectorWithMemoryLimit<int>>);
+static_assert(!ql::concepts::copyable<VectorWithMemoryLimit<int>>);
 
 // A class to store the results of expressions that can yield strings or IDs as
 // their result (for example IF and COALESCE). It is also used for expressions
@@ -120,18 +126,17 @@ CPP_concept SingleExpressionResult =
 
 // Copy an expression result.
 CPP_template(typename ResultT)(
-    requires ad_utility::SimilarTo<ResultT,
-                                   ExpressionResult>) inline ExpressionResult
+    requires ad_utility::SimilarTo<ResultT, ExpressionResult>) ExpressionResult
     copyExpressionResult(ResultT&& result) {
   auto copyIfCopyable = [](const auto& x)
       -> CPP_ret(ExpressionResult)(
           requires SingleExpressionResult<std::decay_t<decltype(x)>>) {
     using R = std::decay_t<decltype(x)>;
-    if constexpr (std::is_constructible_v<R, decltype(AD_FWD(x))> &&
-                  !ad_utility::similarToInstantiation<R,
-                                                      VectorWithMemoryLimit>) {
-      return AD_FWD(x);
+    if constexpr (ql::concepts::copyable<R>) {
+      return x;
     } else {
+      static_assert(
+          ad_utility::similarToInstantiation<R, VectorWithMemoryLimit>);
       return x.clone();
     }
   };

--- a/src/engine/sparqlExpressions/SparqlExpressionTypes.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionTypes.h
@@ -127,7 +127,9 @@ CPP_template(typename ResultT)(
       -> CPP_ret(ExpressionResult)(
           requires SingleExpressionResult<std::decay_t<decltype(x)>>) {
     using R = std::decay_t<decltype(x)>;
-    if constexpr (std::is_constructible_v<R, decltype(AD_FWD(x))>) {
+    if constexpr (std::is_constructible_v<R, decltype(AD_FWD(x))> &&
+                  !ad_utility::similarToInstantiation<R,
+                                                      VectorWithMemoryLimit>) {
       return AD_FWD(x);
     } else {
       return x.clone();

--- a/src/engine/sparqlExpressions/SparqlExpressionTypes.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionTypes.h
@@ -83,6 +83,10 @@ class VectorWithMemoryLimit
 
  private:
   // Constructor for copying, used to implement the `clone` function.
+  // We use the explicit tag, s.t. this constructor doesn't match the signature
+  // of a copy constructor, because otherwise type traits like `copyable` or
+  // `constructible_form` would be misled (they might return true for certain
+  // compilers in C++17 if the copy constructor is present but private.
   VectorWithMemoryLimit(CloneTag, const VectorWithMemoryLimit& other)
       : Base{static_cast<const Base&>(other)} {}
 };

--- a/src/engine/sparqlExpressions/SparqlExpressionValueGetters.cpp
+++ b/src/engine/sparqlExpressions/SparqlExpressionValueGetters.cpp
@@ -195,7 +195,7 @@ std::string ReplacementStringGetter::convertToReplacementString(
 }
 
 // ____________________________________________________________________________
-template <auto isSomethingFunction, auto prefix>
+template <auto isSomethingFunction, const auto& prefix>
 Id IsSomethingValueGetter<isSomethingFunction, prefix>::operator()(
     ValueId id, const EvaluationContext* context) const {
   switch (id.getDatatype()) {
@@ -267,7 +267,7 @@ IntDoubleStr ToNumericValueGetter::operator()(
     case Datatype::Double:
       return id.getDouble();
     case Datatype::Bool:
-      return static_cast<int>(id.getBool());
+      return static_cast<int64_t>(id.getBool());
     case Datatype::GeoPoint:
       return id.getGeoPoint().toStringRepresentation();
     case Datatype::VocabIndex:

--- a/src/engine/sparqlExpressions/SparqlExpressionValueGetters.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionValueGetters.h
@@ -207,7 +207,7 @@ struct IsNumericValueGetter : Mixin<IsNumericValueGetter> {
 };
 
 // Boolean value getters for `isIRI`, `isBlank`, and `isLiteral`.
-template <auto isSomethingFunction, auto isLiteralOrIriSomethingFunction>
+template <auto isSomethingFunction, const auto& isLiteralOrIriSomethingFunction>
 struct IsSomethingValueGetter
     : Mixin<IsSomethingValueGetter<isSomethingFunction,
                                    isLiteralOrIriSomethingFunction>> {
@@ -221,8 +221,8 @@ struct IsSomethingValueGetter
                                             isLiteralOrIriSomethingFunction));
   }
 };
-static constexpr auto isIriPrefix = ad_utility::ConstexprSmallString<2>{"<"};
-static constexpr auto isLiteralPrefix =
+inline constexpr auto isIriPrefix = ad_utility::ConstexprSmallString<2>{"<"};
+inline constexpr auto isLiteralPrefix =
     ad_utility::ConstexprSmallString<2>{"\""};
 using IsIriValueGetter =
     IsSomethingValueGetter<&Index::Vocab::isIri, isIriPrefix>;

--- a/src/engine/sparqlExpressions/StdevExpression.h
+++ b/src/engine/sparqlExpressions/StdevExpression.h
@@ -56,8 +56,7 @@ class DeviationExpression : public SparqlExpression {
 
 // Separate subclass of AggregateOperation, that replaces its child with a
 // DeviationExpression of this child. Everything else is left untouched.
-template <typename AggregateOperation,
-          typename FinalOperation = decltype(identity)>
+template <typename AggregateOperation, typename FinalOperation = Identity>
 class DeviationAggExpression
     : public AggregateExpression<AggregateOperation, FinalOperation> {
  public:

--- a/src/engine/sparqlExpressions/StringExpressions.cpp
+++ b/src/engine/sparqlExpressions/StringExpressions.cpp
@@ -165,23 +165,24 @@ using StrlenExpression = StringExpressionImpl<1, LiftStringFunction<Strlen>>;
 
 // UCase and LCase
 template <auto toLowerOrToUpper>
-auto upperOrLowerCaseImpl =
-    [](std::optional<ad_utility::triple_component::Literal> input)
-    -> IdOrLiteralOrIri {
-  if (!input.has_value()) {
-    return Id::makeUndefined();
+struct UpperOrLowerCaseImpl {
+  IdOrLiteralOrIri operator()(
+      std::optional<ad_utility::triple_component::Literal> input) const {
+    if (!input.has_value()) {
+      return Id::makeUndefined();
+    }
+    auto& literal = input.value();
+    auto newContent =
+        std::invoke(toLowerOrToUpper, asStringViewUnsafe(literal.getContent()));
+    literal.replaceContent(newContent);
+    return LiteralOrIri(std::move(literal));
   }
-  auto& literal = input.value();
-  auto newContent =
-      std::invoke(toLowerOrToUpper, asStringViewUnsafe(literal.getContent()));
-  literal.replaceContent(newContent);
-  return LiteralOrIri(std::move(literal));
 };
-auto uppercaseImpl = upperOrLowerCaseImpl<&ad_utility::utf8ToUpper>;
-auto lowercaseImpl = upperOrLowerCaseImpl<&ad_utility::utf8ToLower>;
 
-using UppercaseExpression = LiteralExpressionImpl<1, decltype(uppercaseImpl)>;
-using LowercaseExpression = LiteralExpressionImpl<1, decltype(lowercaseImpl)>;
+using UppercaseExpression =
+    LiteralExpressionImpl<1, UpperOrLowerCaseImpl<&ad_utility::utf8ToUpper>>;
+using LowercaseExpression =
+    LiteralExpressionImpl<1, UpperOrLowerCaseImpl<&ad_utility::utf8ToLower>>;
 
 // SUBSTR
 class SubstrImpl {
@@ -619,28 +620,29 @@ struct StrIriDtTag {
 using StrIriTagged = LiteralExpressionImpl<2, StrIriDtTag, IriValueGetter>;
 
 // HASH
-template <auto HashFunc>
-[[maybe_unused]] inline constexpr auto hash =
-    [](std::optional<std::string> input) -> IdOrLiteralOrIri {
-  if (!input.has_value()) {
-    return Id::makeUndefined();
-  } else {
-    std::vector<unsigned char> hashed = HashFunc(input.value());
-    auto hexStr = absl::StrJoin(hashed, "", ad_utility::hexFormatter);
-    return toLiteral(std::move(hexStr));
+template <typename HashFunc>
+struct Hash {
+  IdOrLiteralOrIri operator()(std::optional<std::string> input) const {
+    if (!input.has_value()) {
+      return Id::makeUndefined();
+    } else {
+      std::vector<unsigned char> hashed = HashFunc{}(input.value());
+      auto hexStr = absl::StrJoin(hashed, "", ad_utility::hexFormatter);
+      return toLiteral(std::move(hexStr));
+    }
   }
 };
 
 using MD5Expression =
-    StringExpressionImpl<1, decltype(hash<ad_utility::hashMd5>)>;
+    StringExpressionImpl<1, Hash<decltype(ad_utility::hashMd5)>>;
 using SHA1Expression =
-    StringExpressionImpl<1, decltype(hash<ad_utility::hashSha1>)>;
+    StringExpressionImpl<1, Hash<decltype(ad_utility::hashSha1)>>;
 using SHA256Expression =
-    StringExpressionImpl<1, decltype(hash<ad_utility::hashSha256>)>;
+    StringExpressionImpl<1, Hash<decltype(ad_utility::hashSha256)>>;
 using SHA384Expression =
-    StringExpressionImpl<1, decltype(hash<ad_utility::hashSha384>)>;
+    StringExpressionImpl<1, Hash<decltype(ad_utility::hashSha384)>>;
 using SHA512Expression =
-    StringExpressionImpl<1, decltype(hash<ad_utility::hashSha512>)>;
+    StringExpressionImpl<1, Hash<decltype(ad_utility::hashSha512)>>;
 
 }  // namespace detail::string_expressions
 using namespace detail::string_expressions;

--- a/src/engine/sparqlExpressions/StringExpressions.cpp
+++ b/src/engine/sparqlExpressions/StringExpressions.cpp
@@ -633,16 +633,11 @@ struct Hash {
   }
 };
 
-using MD5Expression =
-    StringExpressionImpl<1, Hash<decltype(ad_utility::hashMd5)>>;
-using SHA1Expression =
-    StringExpressionImpl<1, Hash<decltype(ad_utility::hashSha1)>>;
-using SHA256Expression =
-    StringExpressionImpl<1, Hash<decltype(ad_utility::hashSha256)>>;
-using SHA384Expression =
-    StringExpressionImpl<1, Hash<decltype(ad_utility::hashSha384)>>;
-using SHA512Expression =
-    StringExpressionImpl<1, Hash<decltype(ad_utility::hashSha512)>>;
+using MD5Expression = StringExpressionImpl<1, Hash<ad_utility::HashMd5>>;
+using SHA1Expression = StringExpressionImpl<1, Hash<ad_utility::HashSha1>>;
+using SHA256Expression = StringExpressionImpl<1, Hash<ad_utility::HashSha256>>;
+using SHA384Expression = StringExpressionImpl<1, Hash<ad_utility::HashSha384>>;
+using SHA512Expression = StringExpressionImpl<1, Hash<ad_utility::HashSha512>>;
 
 }  // namespace detail::string_expressions
 using namespace detail::string_expressions;

--- a/src/engine/sparqlExpressions/UuidExpressions.h
+++ b/src/engine/sparqlExpressions/UuidExpressions.h
@@ -40,7 +40,7 @@ inline constexpr auto iriUuidKey = [](int64_t randId) {
 // Iri object: <urn:uuid:b9302fb5-642e-4d3b-af19-29a8f6d894c9> (example). With
 // UuidExpressionImpl<fromLiteral,, litUuidKey>, the UUIDs are returned as an
 // Literal object: "73cd4307-8a99-4691-a608-b5bda64fb6c1" (example).
-template <auto FuncConv, auto FuncKey>
+template <const auto& FuncConv, const auto& FuncKey>
 class UuidExpressionImpl : public SparqlExpression {
  private:
   int64_t randId_ = ad_utility::FastRandomIntGenerator<int64_t>{}();

--- a/src/engine/sparqlExpressions/UuidExpressions.h
+++ b/src/engine/sparqlExpressions/UuidExpressions.h
@@ -72,12 +72,12 @@ class UuidExpressionImpl : public SparqlExpression {
   ql::span<SparqlExpression::Ptr> childrenImpl() override { return {}; }
 };
 
+using UuidExpression = UuidExpressionImpl<fromIri, iriUuidKey>;
+using StrUuidExpression = UuidExpressionImpl<fromLiteral, litUuidKey>;
 }  //  namespace detail::uuidExpression
 
-using UuidExpression = detail::uuidExpression::UuidExpressionImpl<
-    detail::uuidExpression::fromIri, detail::uuidExpression::iriUuidKey>;
-using StrUuidExpression = detail::uuidExpression::UuidExpressionImpl<
-    detail::uuidExpression::fromLiteral, detail::uuidExpression::litUuidKey>;
+using UuidExpression = detail::uuidExpression::UuidExpression;
+using StrUuidExpression = detail::uuidExpression::StrUuidExpression;
 
 }  // namespace sparqlExpression
 

--- a/src/util/CryptographicHashUtils.h
+++ b/src/util/CryptographicHashUtils.h
@@ -40,25 +40,25 @@ struct HexFormatter {
 };
 inline constexpr HexFormatter hexFormatter{};
 
-// `hashMd5` takes an argument of type `std::string_view` and provides
+// `HashMd5` takes an argument of type `std::string_view` and provides
 // a Hex value by applying `EVP_md5()` from the openssl library as a result.
-inline constexpr HashImpl<&EVP_md5, MD5_DIGEST_LENGTH> hashMd5{};
+using HashMd5 = HashImpl<&EVP_md5, MD5_DIGEST_LENGTH>;
 
-// `hashSha1` takes an argument of type `std::string_view` and provides
+// `HashSha1` takes an argument of type `std::string_view` and provides
 // a Hex by applying `EVP_sha1()` from the openssl library as a result.
-inline constexpr HashImpl<&EVP_sha1, SHA_DIGEST_LENGTH> hashSha1{};
+using HashSha1 = HashImpl<&EVP_sha1, SHA_DIGEST_LENGTH>;
 
-// `hashSha256` takes an argument of type `std::string_view` and provides
+// `HashSha256` takes an argument of type `std::string_view` and provides
 // a Hex by applying `EVP_sha256()` from the openssl library as a result.
-inline constexpr HashImpl<&EVP_sha256, SHA256_DIGEST_LENGTH> hashSha256{};
+using HashSha256 = HashImpl<&EVP_sha256, SHA256_DIGEST_LENGTH>;
 
-// `hashSha384` takes an argument of type `std::string_view` and provides
+// `HashSha384` takes an argument of type `std::string_view` and provides
 // a Hex by applying `EVP_sha384()` from the openssl library as a result.
-inline constexpr HashImpl<&EVP_sha384, SHA384_DIGEST_LENGTH> hashSha384{};
+using HashSha384 = HashImpl<&EVP_sha384, SHA384_DIGEST_LENGTH>;
 
-// `hashSha512` takes an argument of type `std::string_view` and provides
+// `HashSha512` takes an argument of type `std::string_view` and provides
 // a Hex by applying `EVP_sha512()` from the openssl library as a result.
-inline constexpr HashImpl<&EVP_sha512, SHA512_DIGEST_LENGTH> hashSha512{};
+using HashSha512 = HashImpl<&EVP_sha512, SHA512_DIGEST_LENGTH>;
 
 }  //  namespace ad_utility
 

--- a/test/CryptographicHashUtilsTest.cpp
+++ b/test/CryptographicHashUtilsTest.cpp
@@ -21,9 +21,9 @@ std::string testStr3 = "abc";
 
 // TEST MD5
 TEST(CryptographicHashUtilsTest, testMd5) {
-  auto res1 = toHexString(hashMd5(testStr1));
-  auto res2 = toHexString(hashMd5(testStr2));
-  auto res3 = toHexString(hashMd5(testStr3));
+  auto res1 = toHexString(HashMd5{}(testStr1));
+  auto res2 = toHexString(HashMd5{}(testStr2));
+  auto res3 = toHexString(HashMd5{}(testStr3));
   EXPECT_EQ(res1, "d41d8cd98f00b204e9800998ecf8427e");
   EXPECT_EQ(res2, "9d9a73f67e20835e516029541595c381");
   EXPECT_EQ(res3, "900150983cd24fb0d6963f7d28e17f72");
@@ -31,9 +31,9 @@ TEST(CryptographicHashUtilsTest, testMd5) {
 
 // TEST SHA1
 TEST(CryptographicHashUtilsTest, testSha1) {
-  auto res1 = toHexString(hashSha1(testStr1));
-  auto res2 = toHexString(hashSha1(testStr2));
-  auto res3 = toHexString(hashSha1(testStr3));
+  auto res1 = toHexString(HashSha1{}(testStr1));
+  auto res2 = toHexString(HashSha1{}(testStr2));
+  auto res3 = toHexString(HashSha1{}(testStr3));
   EXPECT_EQ(res1, "da39a3ee5e6b4b0d3255bfef95601890afd80709");
   EXPECT_EQ(res2, "c3a77a6104fa091f590f594b3e2dba2668196d3c");
   EXPECT_EQ(res3, "a9993e364706816aba3e25717850c26c9cd0d89d");
@@ -41,9 +41,9 @@ TEST(CryptographicHashUtilsTest, testSha1) {
 
 // TEST SHA256
 TEST(CryptographicHashUtilsTest, testSha256) {
-  auto res1 = toHexString(hashSha256(testStr1));
-  auto res2 = toHexString(hashSha256(testStr2));
-  auto res3 = toHexString(hashSha256(testStr3));
+  auto res1 = toHexString(HashSha256{}(testStr1));
+  auto res2 = toHexString(HashSha256{}(testStr2));
+  auto res3 = toHexString(HashSha256{}(testStr3));
   EXPECT_EQ(res1,
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
   EXPECT_EQ(res2,
@@ -54,9 +54,9 @@ TEST(CryptographicHashUtilsTest, testSha256) {
 
 // TEST SHA384
 TEST(CryptographicHashUtilsTest, testSha384) {
-  auto res1 = toHexString(hashSha384(testStr1));
-  auto res2 = toHexString(hashSha384(testStr2));
-  auto res3 = toHexString(hashSha384(testStr3));
+  auto res1 = toHexString(HashSha384{}(testStr1));
+  auto res2 = toHexString(HashSha384{}(testStr2));
+  auto res3 = toHexString(HashSha384{}(testStr3));
   EXPECT_EQ(res1,
             "38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da27"
             "4edebfe76f65fbd51ad2f14898b95b");
@@ -70,9 +70,9 @@ TEST(CryptographicHashUtilsTest, testSha384) {
 
 // TEST SHA512
 TEST(CryptographicHashUtilsTest, testSha512) {
-  auto res1 = toHexString(hashSha512(testStr1));
-  auto res2 = toHexString(hashSha512(testStr2));
-  auto res3 = toHexString(hashSha512(testStr3));
+  auto res1 = toHexString(HashSha512{}(testStr1));
+  auto res2 = toHexString(HashSha512{}(testStr2));
+  auto res3 = toHexString(HashSha512{}(testStr3));
   EXPECT_EQ(res1,
             "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47"
             "d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e");


### PR DESCRIPTION
1. Use `inline constexpr` variables instead of C++20 `consteval`
2. Replace `template auto` parameters with explicit `template` parameters where needed
3. Add `[[maybe_unused]]` attribute using `QL_MAYBE_UNUSED` macro
4. Use `std::invoke` for member function pointers and function objects
5. Replace direct lambda capture of `constexpr` variables with references
6. Add missing `#ifndef` guards for unreachable code paths in `switch` statements
7. Update `template` syntax for better C++17 compatibility
8. Use explicit instantiation for complex template types