### PR TITLE
Fix the `atomic_flag` backport

### DIFF
--- a/src/util/Generators.h
+++ b/src/util/Generators.h
@@ -89,7 +89,6 @@ InputRangeTypeErased<T> generatorFromActionWithCallback(F functionWithCallback)
     requires ql::concepts::invocable<F, std::function<void(T)>> {
   class CallbackToRangeAdapter : public InputRangeFromGet<T> {
     F functionWithCallback_;
-    ad_utility::JThread thread_;
     std::mutex mutex_;
     std::condition_variable cv_;
     // Only one of the threads can run at the same time. The semantics are
@@ -105,6 +104,11 @@ InputRangeTypeErased<T> generatorFromActionWithCallback(F functionWithCallback)
     // further values. `exception_ptr` means that the inner thread has
     // encountered an exception, which is then rethrown by the outer generator.
     std::variant<std::monostate, T, std::exception_ptr> storage_;
+
+    // IMPORTANT NOTE: It is crucial that this `thread_` is the last data member
+    // of this class, as it references several of the above members, and thus
+    // has to be joined/destroyed before these other members are destroyed!!!
+    ad_utility::JThread thread_;
 
    public:
     explicit CallbackToRangeAdapter(F functionWithCallback)


### PR DESCRIPTION
The backport of `std::atomic_flag` from #2431 was prone to a deadlock in the `wait` method. This was discovered by our Clang 17 debug-with-thread-sanitizer build, which failed or all recent commits because it was cancelled after six hours. The reason for the deadlock was an overly optimistic use of an `std::atomic<bool>` flag. This is now fixed by synchronizing access to that flag via a mutex.

NOTE: In principle, this makes the implementation of the `atomic_flag` class slightly less efficient in C++17 mode. However, we only use that class for synchronizing relatively large batches of computation, so that we don't expect any significant performance degradation anywhere.