### PR TITLE
Native multi-arch `Docker` build

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,6 +15,7 @@ concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.sha}}'
   cancel-in-progress: true
 
+# This workflow is heavily based on https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners .
 jobs:
   build:
     strategy:
@@ -28,6 +29,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        # Generate metadata for the docker image based on the GH Actions environment.
       - name: Generate image metadata
         id: meta
         uses: docker/metadata-action@v5
@@ -48,10 +50,14 @@ jobs:
           context: .
           platforms: ${{ matrix.platform }}
           tags: ${{ env.IMAGE }}
+          # push-by-digest means that the built image is not associated with a tag. Instead, the only way to refer to it
+          # is by using its digest (which is basically a unique hash).
           outputs: type=image,push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}
+        # Export the digest outside of this job, so that the merge job can pick it up.
       - name: Export digest
+        if: github.event_name != 'pull_request'
         run: |
           # Strip forward slash from matrix.platform
           platform=${{ matrix.platform }}
@@ -60,16 +66,19 @@ jobs:
           digest="${{ steps.build.outputs.digest }}"
           touch "${{ runner.temp }}/digests/${digest#sha256:}"
       - name: Upload digest
+        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: digests-${{ env.ARTIFACT_NAME }}
           path: ${{ runner.temp }}/digests/*
           if-no-files-found: error
           retention-days: 1
-        # Setup image for local use.
+        # Build image for local use. Since we pushed by digest it has not been loaded into the local docker instance.
+        # It might be possible to directly push by using a unique tag and make this step redundant, but pushing by digest
+        # seems to be the recommended way to do it.
       - name: Setup E2E test image
-        uses: docker/build-push-action@v6
         if: matrix.platform == 'linux/amd64'
+        uses: docker/build-push-action@v6
         with:
           # The cache should already provide this. So no rebuild should occur.
           context: .
@@ -118,7 +127,15 @@ jobs:
           pattern: digests-*
           merge-multiple: true
       - name: Merge amd64 + arm64 images into multi-arch manifest
+        # Changing the working directory to this folder is important, so that
+        # the '*' in printf down below is expanded to the simple filenames without
+        # a leading path in the way.
         working-directory: ${{ runner.temp }}/digests
+        # steps.meta.outputs.annotations contains a line for every annotation.
+        # To properly handle the expansion of this multi-line value in bash,
+        # we need to properly transform it into the `EXPANDED_ANNOTATIONS`
+        # variable, which then no longer contains newlines and properly
+        # handles other spaces in the annotations.
         run: |
           ANNOTATIONS=$(cat <<'EOF'
           ${{ steps.meta.outputs.annotations }}


### PR DESCRIPTION
Instead of using slow `qemu` to cross-compile the binaries, run one build natively on each of `linux/amd64` and `linux/arm64`, respectively, and merge the two images at the end. This drastically decreases overall build time.

NOTE: The change is largely based on https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners . Only minor adjustments were done to allow for conditional end-to-end testing