### PR TITLE
Run expensive checks only if they are enabled [two instances]

### DIFF
--- a/src/index/CompressedRelation.cpp
+++ b/src/index/CompressedRelation.cpp
@@ -2057,11 +2057,15 @@ CPP_template(typename Range)(requires ql::ranges::input_range<Range>) static voi
 CompressedRelationReader::ScanSpecAndBlocks::ScanSpecAndBlocks(
     ScanSpecification scanSpec, const BlockMetadataRanges& blockMetadataRanges)
     : scanSpec_(std::move(scanSpec)) {
-  const auto& blockRangeView = blockMetadataRanges | ql::views::join;
-  checkBlockMetadataInvariantOrderAndUniquenessImpl(blockRangeView);
+  if constexpr (ad_utility::areExpensiveChecksEnabled) {
+    const auto& blockRangeView = blockMetadataRanges | ql::views::join;
+    checkBlockMetadataInvariantOrderAndUniquenessImpl(blockRangeView);
+  }
   blockMetadata_ = getRelevantBlocks(scanSpec_, blockMetadataRanges);
-  checkBlockMetadataInvariantBlockConsistencyImpl(
-      getBlockMetadataView(), scanSpec_.firstFreeColIndex());
+  if constexpr (ad_utility::areExpensiveChecksEnabled) {
+    checkBlockMetadataInvariantBlockConsistencyImpl(
+        getBlockMetadataView(), scanSpec_.firstFreeColIndex());
+  }
   sizeBlockMetadata_ = getNumberOfBlockMetadataValues(blockMetadata_);
 }
 

--- a/test/PrefilterExpressionIndexTest.cpp
+++ b/test/PrefilterExpressionIndexTest.cpp
@@ -1207,8 +1207,10 @@ TEST_F(PrefilterExpressionOnMetadataTest,
       blockRanges));
   ASSERT_TRUE(blockRanges.size() > 1);
   blockRanges.push_back(blockRanges.at(0));
-  EXPECT_ANY_THROW(CompressedRelationReader::ScanSpecAndBlocks(
-      ScanSpecification{VocabId10, DoubleId33, DoubleId33}, blockRanges));
+  if constexpr (ad_utility::areExpensiveChecksEnabled) {
+    EXPECT_ANY_THROW(CompressedRelationReader::ScanSpecAndBlocks(
+        ScanSpecification{VocabId10, DoubleId33, DoubleId33}, blockRanges));
+  }
 }
 
 //______________________________________________________________________________


### PR DESCRIPTION
There were two expensive checks in `CompressedRelation.cpp` that were run for every index scan during query planning. One of them iterated over the complete block meta data, regardless of the query. This was particularly noticeable for large datasets, like `osm-planet`. The two tests are now both executed if and only if `areExpensiveChecksEnabled` is true, as it should have been in the first place.

NOTE: What still takes relatively long for large datasets, and now dominates the query planning time for simple queries, is `CompressedRelationReader::getResultSizeImpl`. We should look into this in a separate PR.