### PR TITLE
Show permutation of index scan in description and runtime information

### DIFF
--- a/src/engine/IndexScan.cpp
+++ b/src/engine/IndexScan.cpp
@@ -129,8 +129,9 @@ bool IndexScan::canResultBeCachedImpl() const {
 
 // _____________________________________________________________________________
 string IndexScan::getDescriptor() const {
-  return "IndexScan " + subject_.toString() + " " + predicate_.toString() +
-         " " + object_.toString();
+  return absl::StrCat("IndexScan ", Permutation::toString(permutation_), " ",
+                      subject_.toString(), " ", predicate_.toString(), " ",
+                      object_.toString());
 }
 
 // _____________________________________________________________________________


### PR DESCRIPTION
So far, the description of an index scan in the runtime information was like in `IndexScan ?x <p> ?z`. The information about the permutation was missing. Now the description has the form `IndexScan POS ?x <p> ?z`, where `POS` is the permutation of the index scan. In particular, this additional information now shows in the "Analysis" tree in the QLever UI. This is a very simple but useful change