### PR TITLE
Fix build error on clang 16 on master

### DIFF
--- a/src/engine/sparqlExpressions/SampleExpression.h
+++ b/src/engine/sparqlExpressions/SampleExpression.h
@@ -6,15 +6,16 @@
 
 #include <absl/strings/str_cat.h>
 
-#include "backports/keywords.h"
 #include "engine/sparqlExpressions/SparqlExpression.h"
 
 namespace sparqlExpression {
-/// The (SAMPLE(?x) as ?sample) expression
+// The (SAMPLE(?x) AS ?sample) expression
 class SampleExpression : public SparqlExpression {
  public:
-  SampleExpression(QL_MAYBE_UNUSED bool distinct, Ptr&& child)
-      : _child{std::move(child)} {
+  // The first parameter is the `DISTINCT` bool that is always there on the
+  // constructor for all aggregate expressions. For this particular expression
+  // it doesn't make a difference, so it is ignored.
+  SampleExpression(bool, Ptr&& child) : _child{std::move(child)} {
     setIsInsideAggregate();
   }
 


### PR DESCRIPTION
Make sure we don't get a warning turned error on master because in C++17 mode the `QL_MAYBE_UNUSED` is replaced with nothing.