### PR TITLE
Properly handle exceptions in `findUndefValuesHelper`

### DIFF
--- a/src/util/JoinAlgorithms/JoinAlgorithms.h
+++ b/src/util/JoinAlgorithms/JoinAlgorithms.h
@@ -1066,13 +1066,15 @@ CPP_template(typename LeftSide, typename RightSide, typename LessThan,
           return ad_utility::IteratorRange(subr.begin(), subr.end());
         });
 
-    auto endCallback = [&, this, throwIfSafe = ad_utility::ThrowInDestructorIfSafe{}]() {
+    auto endCallback = [&, this,
+                        throwIfSafe = ad_utility::ThrowInDestructorIfSafe{}]() {
       // Reset back to original input.
       begL = fullBlockLeft.get().begin();
       begR = fullBlockRight.get().begin();
       // Use ThrowInDestructorIfSafe to prevent throwing during stack unwinding.
       throwIfSafe([&]() {
-        compatibleRowAction_.setInput(fullBlockLeft.get(), fullBlockRight.get());
+        compatibleRowAction_.setInput(fullBlockLeft.get(),
+                                      fullBlockRight.get());
       });
     };
 


### PR DESCRIPTION
Since https://github.com/ad-freiburg/qlever/pull/2266, it can happen that an exception is thrown in the destructor of `CallbackOnEndView` (triggered by the end of the iteration over the range returned by `findUndefValuesHelper`), which terminates the program. This is now fixed by wrapping the call to `setInput` (which can throw) in the respective `CallbackOnEndView` in a `ThrowInDestructorIfSafe` object. Fixes #2495 

Co-authored-by: RobinTF <83676088+RobinTF@users.noreply.github.com>
