### PR TITLE
Remove code duplication for `ad_utility::getUTF8Prefix`

### DIFF
--- a/src/engine/sparqlExpressions/StringExpressions.cpp
+++ b/src/engine/sparqlExpressions/StringExpressions.cpp
@@ -205,6 +205,10 @@ class SubstrImpl {
     // If the starting position is negative, we have to correct the length.
     if (startInt < 0) {
       lengthInt += startInt;
+      startInt = 0;
+    }
+    if (lengthInt < 0) {
+      lengthInt = 0;
     }
     const auto& str = asStringViewUnsafe(s.value().getContent());
     auto substr = ad_utility::getUTF8Substring(str, startInt, lengthInt);

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -23,7 +23,6 @@
 #include "engine/sparqlExpressions/SparqlExpression.h"
 #include "engine/sparqlExpressions/SparqlExpressionTypes.h"
 #include "engine/sparqlExpressions/StdevExpression.h"
-#include "engine/sparqlExpressions/StringExpressions.cpp"
 #include "rdfTypes/GeoPoint.h"
 #include "rdfTypes/GeometryInfo.h"
 #include "util/AllocatorTestHelpers.h"


### PR DESCRIPTION
The changes in #1636 required clamping of UTF-8 strings and introduced own functions for this. Now, the already existing `ad_utility::getUTF8Prefix` is used instead, removing the code duplication