### PR TITLE
Backport code in `CallFixedSize.h` and `GroupBy*` to C++17

### DIFF
--- a/src/engine/CallFixedSize.h
+++ b/src/engine/CallFixedSize.h
@@ -63,16 +63,11 @@ CPP_variadic_template(typename Int, Int... Is, typename F, typename... Args)(
   return lambda.template operator()<Is...>(AD_FWD(args)...);
 };
 
-CPP_variadic_template(typename Int, Int... Is, typename F, typename... Args)(
-    requires ql::concepts::integral<
-        Int>) auto applyOnIntegerSequence(ad_utility::ValueSequenceRef<Int,
-                                                                       Is...>,
-                                          F&& lambda, Args&&... args) {
-  return lambda.template operator()<Is...>(AD_FWD(args)...);
-};
-
+// An array with `NumValues` entries of type `Int` that has linkage in C++17
+// mopde. It is needed below to deduce a return type.
 template <typename Int, size_t NumValues>
 static constexpr std::array<Int, NumValues> DummyArray{};
+
 // Internal helper functions that calls `lambda.template operator()<I,
 // J,...)(args)` where `I, J, ...` are the elements in the `array`. Requires
 // that each element in the `array` is `<= maxValue`.
@@ -97,13 +92,14 @@ CPP_variadic_template(int maxValue, size_t NumValues, typename Int, typename F,
   using Storage = std::conditional_t<resultIsVoid, int, std::optional<Result>>;
   Storage result;
 
-  // Lambda: If the compile time parameter `I` and the runtime parameter `array`
-  // are equal, then call the `lambda` with `I` as a template parameter and
-  // store the result in `result` (unless it is `void`).
-  // TODO<joka921> Do we need a VI here?
-  auto applyIf2 = [&](auto index) {
+  // Lambda: If the compile time parameter `i` and the runtime parameter `array`
+  // are equal (when the elements of `array` are interpreted as the digits of a
+  // single number), then call the `lambda` with `array` as a template parameter
+  // and store the result in `result` (unless it is `void`).
+  auto applyIf = [&](auto i) {
+    // Get the digits of `i` as a compile-time array.
     constexpr const auto& arrayConst =
-        integerToArrayStaticVar<Int, NumValues, index.value, maxValue + 1>;
+        integerToArrayStaticVar<Int, NumValues, i.value, maxValue + 1>;
     if (array == arrayConst) {
       const auto& seq = toIntegerSequenceRef<arrayConst>();
       if constexpr (resultIsVoid) {
@@ -118,13 +114,13 @@ CPP_variadic_template(int maxValue, size_t NumValues, typename Int, typename F,
   // runtime parameter always is `array`.
   auto f = [&](auto&& valueSequence) {
     forEachValueInValueSequence(AD_FWD(valueSequence),
-                                ApplyAsValueIdentity{AD_FWD(applyIf2)});
+                                ApplyAsValueIdentity{AD_FWD(applyIf)});
   };
 
-  // Call f for all combinations of compileTimeIntegers in `M x NumValues` where
-  // `M` is `[0, ..., maxValue]` and `x` denotes the cartesian product of sets.
-  // Exactly one of these combinations is equal to `array`, and so the lambda
-  // will be executed exactly once.
+  // Call `f` for all integers in `[0, (maxValue + 1) ^ NumValues]`, which makes
+  // `applyIf` see all the different arrays consisting of `NumValues` numbers in
+  // the range
+  // `[0, ... maxValue]`, where exactly one of them is equal to the `array`.
   f(std::make_index_sequence<pow(maxValue + 1, NumValues)>{});
 
   if constexpr (!resultIsVoid) {
@@ -202,26 +198,4 @@ CPP_variadic_template(int MaxValue = DEFAULT_MAX_NUM_COLUMNS_STATIC_ID_TABLE,
 }
 
 }  // namespace ad_utility
-
-// The definitions of the macro for an easier syntax.
-// The first argument (an array of integers) has to be put in parentheses if
-// it is directly instantiated in the call, for example
-// `CALL_FIXED_SIZE((std::array{1, 2}), &funcThatTakesTwoIntegers, argument);`
-// This is necessary because macros do not correctly parse the curly braces.
-// TODO<joka921, C++23> In C++23 `std::array` and other aggregates can be
-// initialized with parentheses such that we can write
-// `CALL_FIXED_SIZE(std::array(1, 2), ...`. For a single integer you can also
-// simply write `CALL_FIXED_SIZE(1, function, params)`, this is handled by
-// the corresponding overload of `ad_utility::callFixedSize`.
-#define CALL_FIXED_SIZE(integers, func, ...)                                \
-  ad_utility::callFixedSize(                                                \
-      integers,                                                             \
-      ad_utility::ApplyAsValueIdentityTuple{                                \
-          [](auto argsTuple, auto... Is) -> decltype(auto) {                \
-            auto innerLambda = [&](auto&&... innerArgs) -> decltype(auto) { \
-              return func<static_cast<int>(Is)...>(AD_FWD(innerArgs)...);   \
-            };                                                              \
-            return std::apply(innerLambda, std::move(argsTuple));           \
-          }},                                                               \
-      ##__VA_ARGS__)
 #endif  // QLEVER_SRC_ENGINE_CALLFIXEDSIZE_H

--- a/src/engine/CallFixedSize.h
+++ b/src/engine/CallFixedSize.h
@@ -64,7 +64,7 @@ CPP_variadic_template(typename Int, Int... Is, typename F, typename... Args)(
 };
 
 // An array with `NumValues` entries of type `Int` that has linkage in C++17
-// mopde. It is needed below to deduce a return type.
+// mode. It is needed below to deduce a return type.
 template <typename Int, size_t NumValues>
 static constexpr std::array<Int, NumValues> DummyArray{};
 

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -23,8 +23,8 @@ GroupBy::GroupBy(QueryExecutionContext* qec,
 
 // _____________________________________________________________________________
 GroupBy::~GroupBy() = default;
-GroupBy::GroupBy(GroupBy&&) noexcept = default;
-GroupBy& GroupBy::operator=(GroupBy&&) noexcept = default;
+GroupBy::GroupBy(GroupBy&&) = default;
+GroupBy& GroupBy::operator=(GroupBy&&) = default;
 
 // _____________________________________________________________________________
 std::string GroupBy::getDescriptor() const { return _impl->getDescriptor(); }

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -25,8 +25,8 @@ class GroupBy : public Operation {
           std::shared_ptr<QueryExecutionTree> subtree);
 
   ~GroupBy() override;
-  GroupBy(GroupBy&&) noexcept;
-  GroupBy& operator=(GroupBy&&) noexcept;
+  GroupBy(GroupBy&&);
+  GroupBy& operator=(GroupBy&&);
 
   // Internal constructor used for the implementation of `clone`.
   GroupBy(QueryExecutionContext* qec, std::unique_ptr<GroupByImpl>&& impl);

--- a/src/engine/GroupByImpl.cpp
+++ b/src/engine/GroupByImpl.cpp
@@ -547,8 +547,8 @@ Result GroupByImpl::computeResult(bool requestLaziness) {
   // parse the aggregate aliases
   const auto& varColMap = getInternallyVisibleVariableColumns();
   for (const Alias& alias : _aliases) {
-    aggregates.emplace_back(alias._expression,
-                            varColMap.at(alias._target).columnIndex_);
+    aggregates.push_back(
+        {alias._expression, varColMap.at(alias._target).columnIndex_});
   }
 
   // Check if optimization for explicitly sorted child can be applied
@@ -626,11 +626,14 @@ Result GroupByImpl::computeResult(bool requestLaziness) {
   if (!subresult->isFullyMaterialized()) {
     AD_CORRECTNESS_CHECK(metadataForUnsequentialData.has_value());
 
-    Result::LazyResult generator = CALL_FIXED_SIZE(
-        (std::array{inWidth, outWidth}), &GroupByImpl::computeResultLazily,
-        this, std::move(subresult), std::move(aggregates),
-        std::move(metadataForUnsequentialData).value().aggregateAliases_,
-        std::move(groupByCols), !requestLaziness);
+    Result::LazyResult generator = ad_utility::callFixedSizeVi(
+        (std::array{inWidth, outWidth}),
+        [&, self = this](auto inWidth, auto outWidth) {
+          return self->computeResultLazily<inWidth, outWidth>(
+              std::move(subresult), std::move(aggregates),
+              std::move(metadataForUnsequentialData).value().aggregateAliases_,
+              std::move(groupByCols), !requestLaziness);
+        });
 
     return requestLaziness
                ? Result{std::move(generator), resultSortedOn()}
@@ -645,28 +648,35 @@ Result GroupByImpl::computeResult(bool requestLaziness) {
 
   auto localVocab = subresult->getCopyOfLocalVocab();
 
-  IdTable idTable = CALL_FIXED_SIZE(
-      (std::array{inWidth, outWidth}), &GroupByImpl::doGroupBy, this,
-      subresult->idTable(), groupByCols, aggregates, &localVocab);
+  IdTable idTable = ad_utility::callFixedSizeVi(
+      (std::array{inWidth, outWidth}),
+      [&, self = this](auto inWidth, auto outWidth) {
+        return self->doGroupBy<inWidth, outWidth>(
+            subresult->idTable(), groupByCols, aggregates, &localVocab);
+      });
 
   AD_LOG_DEBUG << "GroupBy result computation done." << std::endl;
   return {std::move(idTable), resultSortedOn(), std::move(localVocab)};
 }
 
 // _____________________________________________________________________________
-CPP_template_def(int COLS, typename T)(
-    requires ranges::invocable<T, size_t, size_t>) size_t
-    GroupByImpl::searchBlockBoundaries(const T& onBlockChange,
-                                       const IdTableView<COLS>& idTable,
-                                       GroupBlock& currentGroupBlock) const {
+template <int COLS, typename T>
+QL_CONCEPT_OR_NOTHING(requires ranges::invocable<T, size_t, size_t>)
+size_t GroupByImpl::searchBlockBoundaries(const T& onBlockChange,
+                                          const IdTableView<COLS>& idTable,
+                                          GroupBlock& currentGroupBlock) const {
   size_t blockStart = 0;
 
   for (size_t pos = 0; pos < idTable.size(); pos++) {
     checkCancellation();
     bool rowMatchesCurrentBlock =
-        ql::ranges::all_of(currentGroupBlock, [&](const auto& colIdxAndValue) {
-          return idTable(pos, colIdxAndValue.first) == colIdxAndValue.second;
-        });
+        // TODO<joka921> ql::ranges has problems with the local lambda, find out
+        // what's wrong.
+        std::all_of(currentGroupBlock.begin(), currentGroupBlock.end(),
+                    [&](const auto& colIdxAndValue) {
+                      return idTable(pos, colIdxAndValue.first) ==
+                             colIdxAndValue.second;
+                    });
     if (!rowMatchesCurrentBlock) {
       onBlockChange(blockStart, pos);
       // setup for processing the next block
@@ -894,7 +904,7 @@ std::optional<IdTable> GroupByImpl::computeGroupByForFullIndexScan() const {
       cancellationHandle_, locatedTriplesSnapshot(),
       indexScan->getLimitOffset());
   if (numCounts == 0) {
-    table.setColumnSubset({{0}});
+    table.setColumnSubset(std::array{ColumnIndex{0}});
   } else if (!variableIsBoundInSubtree) {
     // The variable inside the COUNT() is not part of the input, so it is always
     // unbound and has a count of 0 in each group.
@@ -1099,14 +1109,14 @@ GroupByImpl::computeUnsequentialProcessingMetadata(
     // TODO<C++23> use views::enumerate
     size_t i = 0;
     for (const auto& groupedVariable : groupByVariables) {
-      groupedVariables.emplace_back(groupedVariable, i,
-                                    findGroupedVariable(expr, groupedVariable));
+      groupedVariables.push_back(
+          {groupedVariable, i, findGroupedVariable(expr, groupedVariable)});
       ++i;
     }
 
-    aliasesWithAggregateInfo.emplace_back(alias._expression, alias._outCol,
-                                          foundAggregates.value(),
-                                          groupedVariables);
+    aliasesWithAggregateInfo.push_back({alias._expression, alias._outCol,
+                                        foundAggregates.value(),
+                                        groupedVariables});
   }
 
   return HashMapOptimizationData{aliasesWithAggregateInfo};
@@ -1292,8 +1302,8 @@ GroupByImpl::getHashMapAggregationResults(
   auto& aggregateDataVariant =
       aggregationData.getAggregationDataVariant(dataIndex);
 
-  using B =
-      HashMapAggregationData<NUM_GROUP_COLUMNS>::template ArrayOrVector<Id>;
+  using B = typename HashMapAggregationData<
+      NUM_GROUP_COLUMNS>::template ArrayOrVector<Id>;
   for (size_t rowIdx = beginIndex; rowIdx < endIndex; ++rowIdx) {
     size_t vectorIdx;
     // Special case for lazy consumer where the hashmap is not used
@@ -1480,7 +1490,7 @@ void GroupByImpl::substituteAndEvaluate(
   originalChildrenForGroupVariable.reserve(substitutions.size());
   for (const auto& substitution : substitutions) {
     const auto& occurrences =
-        get<std::vector<ParentAndChildIndex>>(substitution.occurrences_);
+        std::get<std::vector<ParentAndChildIndex>>(substitution.occurrences_);
     // Substitute in the values of the grouped variable and store the original
     // expressions.
     originalChildrenForGroupVariable.emplace_back(
@@ -1745,7 +1755,7 @@ Result GroupByImpl::computeGroupByForHashMapOptimization(
       auto currentBlockSize = evaluationContext.size();
 
       // Perform HashMap lookup once for all groups in current block
-      using U = HashMapAggregationData<
+      using U = typename HashMapAggregationData<
           NUM_GROUP_COLUMNS>::template ArrayOrVector<ql::span<const Id>>;
       U groupValues;
       resizeIfVector(groupValues, columnIndices.size());

--- a/src/engine/GroupByImpl.h
+++ b/src/engine/GroupByImpl.h
@@ -121,11 +121,11 @@ class GroupByImpl : public Operation {
   // function returns the starting index of the last block of this `idTable`.
   // The argument `currentGroupBlock` is used to store the values of the group
   // by columns for the current group.
-  CPP_template(int COLS,
-               typename T)(requires ranges::invocable<T, size_t, size_t>) size_t
-      searchBlockBoundaries(const T& onBlockChange,
-                            const IdTableView<COLS>& idTable,
-                            GroupBlock& currentGroupBlock) const;
+  template <int COLS, typename T>
+  QL_CONCEPT_OR_NOTHING(requires ranges::invocable<T, size_t, size_t>)
+  size_t searchBlockBoundaries(const T& onBlockChange,
+                               const IdTableView<COLS>& idTable,
+                               GroupBlock& currentGroupBlock) const;
 
   // Helper function to process a sorted group within a single id table.
   template <size_t OUT_WIDTH>
@@ -631,7 +631,7 @@ class GroupByImpl : public Operation {
 // _____________________________________________________________________________
 namespace groupBy::detail {
 template <typename A>
-concept VectorOfAggregationData =
+CPP_concept VectorOfAggregationData =
     ad_utility::SameAsAnyTypeIn<A, GroupByImpl::AggregationDataVectors>;
 }
 

--- a/test/CallFixedSizeTest.cpp
+++ b/test/CallFixedSizeTest.cpp
@@ -100,16 +100,10 @@ struct S {
 TEST(CallFixedSize, CallFixedSize1) {
   using namespace oneVar;
   // static constexpr int m = DEFAULT_MAX_NUM_COLUMNS_STATIC_ID_TABLE;
-  auto testWithGivenUpperBound = [](auto m, bool useMacro) {
+  auto testWithGivenUpperBound = [](auto m) {
     for (int i = 0; i <= m; ++i) {
       ASSERT_EQ(callFixedSizeVi<m>(i, lambda), i);
       ASSERT_EQ(callFixedSizeVi<m>(i, lambda, 2, 3), i + 5);
-      if (useMacro) {
-        ASSERT_EQ(CALL_FIXED_SIZE(i, freeFunction, 2, 3), i + 5);
-        S s;
-        // ASSERT_EQ(CALL_FIXED_SIZE(i, &S::memberFunction, &s, 2, 3), i + 5);
-        // ASSERT_EQ(CALL_FIXED_SIZE(i, &S::staticFunction, 2, 3), i + 5);
-      }
     }
 
     // Values that are greater than `m` will be mapped to zero before being
@@ -117,25 +111,15 @@ TEST(CallFixedSize, CallFixedSize1) {
     for (int i = m + 1; i <= m + m + 1; ++i) {
       ASSERT_EQ(callFixedSizeVi<m>(i, lambda), 0);
       ASSERT_EQ(callFixedSizeVi<m>(i, lambda, 2, 3), 5);
-      /*
-      if (useMacro) {
-        ASSERT_EQ(CALL_FIXED_SIZE(i, freeFunction, 2, 3), 5);
-        S s;
-        ASSERT_EQ(CALL_FIXED_SIZE(i, &S::memberFunction, &s, 2, 3), 5);
-        ASSERT_EQ(CALL_FIXED_SIZE(i, &S::staticFunction, 2, 3), 5);
-      }
-      */
     }
   };
   testWithGivenUpperBound(
-      std::integral_constant<int, DEFAULT_MAX_NUM_COLUMNS_STATIC_ID_TABLE>{},
-      true);
+      std::integral_constant<int, DEFAULT_MAX_NUM_COLUMNS_STATIC_ID_TABLE>{});
   // Custom upper bounds cannot be tested with the macros, as the macros don't
   // allow redefining the upper bound.
-  // testWithGivenUpperBound(std::integral_constant<int, 12>{}, false);
+  testWithGivenUpperBound(std::integral_constant<int, 12>{});
 }
 
-#if false
 // Tests for two variables. The test cases are similar to the one variable
 // case, see above for detailed documentation.
 namespace twoVars {
@@ -175,20 +159,12 @@ TEST(CallFixedSize, CallFixedSize2) {
   using namespace twoVars;
   using namespace ad_utility::detail;
 
-  auto testWithGivenUpperBound = [](auto m, bool useMacro) {
+  auto testWithGivenUpperBound = [](auto m) {
     // For given values for the template parameters I and J, and the result
     // I - J perform a set of tests.
     auto testForIAndJ = [&](auto array, auto resultOfIJ) {
       ASSERT_EQ(callFixedSizeVi<m>(array, lambda), resultOfIJ);
       ASSERT_EQ(callFixedSizeVi<m>(array, lambda, 2, 3), resultOfIJ + 5);
-      if (useMacro) {
-        ASSERT_EQ(CALL_FIXED_SIZE(array, freeFunction, 2, 3), resultOfIJ + 5);
-        S s;
-        ASSERT_EQ(CALL_FIXED_SIZE(array, &S::memberFunction, &s, 2, 3),
-                  resultOfIJ + 5);
-        ASSERT_EQ(CALL_FIXED_SIZE(array, &S::staticFunction, 2, 3),
-                  resultOfIJ + 5);
-      }
     };
     // TODO<joka921, Clang16> the ranges of the loop can be greatly simplified
     // using `ql::views::iota`, but views don't work yet on clang.
@@ -224,11 +200,6 @@ TEST(CallFixedSize, CallFixedSize2) {
   };
 
   testWithGivenUpperBound(
-      std::integral_constant<int, DEFAULT_MAX_NUM_COLUMNS_STATIC_ID_TABLE>{},
-      true);
-  // Custom upper bounds cannot be tested with the macros, as the macros don't
-  // allow redefining the upper bound.
-  testWithGivenUpperBound(std::integral_constant<int, 12>{}, false);
+      std::integral_constant<int, DEFAULT_MAX_NUM_COLUMNS_STATIC_ID_TABLE>{});
+  testWithGivenUpperBound(std::integral_constant<int, 12>{});
 }
-
-#endif

--- a/test/CallFixedSizeTest.cpp
+++ b/test/CallFixedSizeTest.cpp
@@ -77,7 +77,7 @@ auto lambda = [](auto valueIdentityI, int arg1 = 0, int arg2 = 0) {
 // of the `CALL_FIXED_SIZE` macro. Note that here we have to state all the
 // types of the arguments explicitly and default values do not work.
 template <int I>
-auto freeFunction(int arg1 = 0, int arg2 = 0) {
+auto freeFunction(int arg1, int arg2) {
   return I + arg1 + arg2;
 }
 
@@ -85,12 +85,12 @@ auto freeFunction(int arg1 = 0, int arg2 = 0) {
 // `CALL_FIXED_SIZE` macro
 struct S {
   template <int I>
-  auto memberFunction(int arg1 = 0, int arg2 = 0) {
+  auto memberFunction(int arg1, int arg2) {
     return I + arg1 + arg2;
   }
 
   template <int I>
-  static auto staticFunction(int arg1 = 0, int arg2 = 0) {
+  static auto staticFunction(int arg1, int arg2) {
     return I + arg1 + arg2;
   }
 };
@@ -107,8 +107,8 @@ TEST(CallFixedSize, CallFixedSize1) {
       if (useMacro) {
         ASSERT_EQ(CALL_FIXED_SIZE(i, freeFunction, 2, 3), i + 5);
         S s;
-        ASSERT_EQ(CALL_FIXED_SIZE(i, &S::memberFunction, &s, 2, 3), i + 5);
-        ASSERT_EQ(CALL_FIXED_SIZE(i, &S::staticFunction, 2, 3), i + 5);
+        // ASSERT_EQ(CALL_FIXED_SIZE(i, &S::memberFunction, &s, 2, 3), i + 5);
+        // ASSERT_EQ(CALL_FIXED_SIZE(i, &S::staticFunction, 2, 3), i + 5);
       }
     }
 
@@ -117,12 +117,14 @@ TEST(CallFixedSize, CallFixedSize1) {
     for (int i = m + 1; i <= m + m + 1; ++i) {
       ASSERT_EQ(callFixedSizeVi<m>(i, lambda), 0);
       ASSERT_EQ(callFixedSizeVi<m>(i, lambda, 2, 3), 5);
+      /*
       if (useMacro) {
         ASSERT_EQ(CALL_FIXED_SIZE(i, freeFunction, 2, 3), 5);
         S s;
         ASSERT_EQ(CALL_FIXED_SIZE(i, &S::memberFunction, &s, 2, 3), 5);
         ASSERT_EQ(CALL_FIXED_SIZE(i, &S::staticFunction, 2, 3), 5);
       }
+      */
     }
   };
   testWithGivenUpperBound(
@@ -130,9 +132,10 @@ TEST(CallFixedSize, CallFixedSize1) {
       true);
   // Custom upper bounds cannot be tested with the macros, as the macros don't
   // allow redefining the upper bound.
-  testWithGivenUpperBound(std::integral_constant<int, 12>{}, false);
+  // testWithGivenUpperBound(std::integral_constant<int, 12>{}, false);
 }
 
+#if false
 // Tests for two variables. The test cases are similar to the one variable
 // case, see above for detailed documentation.
 namespace twoVars {
@@ -227,3 +230,5 @@ TEST(CallFixedSize, CallFixedSize2) {
   // allow redefining the upper bound.
   testWithGivenUpperBound(std::integral_constant<int, 12>{}, false);
 }
+
+#endif

--- a/test/util/IdTableHelpers.cpp
+++ b/test/util/IdTableHelpers.cpp
@@ -61,8 +61,10 @@ void compareIdTableWithExpectedContent(
 
 // ____________________________________________________________________________
 void sortIdTableByJoinColumnInPlace(IdTableAndJoinColumn& table) {
-  CALL_FIXED_SIZE((std::array{table.idTable.numColumns()}), &Engine::sort,
-                  &table.idTable, table.joinColumn);
+  ad_utility::callFixedSizeVi(
+      table.idTable.numColumns(), [&table](auto numCols) {
+        Engine::sort<numCols>(&table.idTable, table.joinColumn);
+      });
 }
 
 // ____________________________________________________________________________


### PR DESCRIPTION
In particular:
1.  the `CALL_FIXED_SIZE` macro is now completely removed, and consistently replaced with `ad_utility::callFixedSize(int, lambda)`, which is cleaner and works in C++17
2. The move constructor and move assignment operator of the `GroupBy` operation are no longer `noexcept` because the move constructor of the base class `Operation` might throw