### PR TITLE
Backport some more code to C++17 (straightforward changes here and there)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,7 +138,7 @@ FetchContent_Declare(
         GIT_REPOSITORY https://github.com/joka921/range-v3
         # This branch removes some differences in the interface between `range-v3` and `std::ranges` s.t.
         # the former can be used as an (almost) drop-in replacement for the latter.
-        GIT_TAG 5ae161451ec1baaac352d7567298d3ac143bccae # branch fork-for-qlever
+        GIT_TAG e84be9d671fbf91e2d977aaaf17a9dd34aaa127d # branch fork-for-qlever
 )
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,7 +138,7 @@ FetchContent_Declare(
         GIT_REPOSITORY https://github.com/joka921/range-v3
         # This branch removes some differences in the interface between `range-v3` and `std::ranges` s.t.
         # the former can be used as an (almost) drop-in replacement for the latter.
-        GIT_TAG e84be9d671fbf91e2d977aaaf17a9dd34aaa127d # branch fork-for-qlever
+        GIT_TAG 42340ef354f7b4e4660268b788e37008d9cc85aa # branch fork-for-qlever
 )
 
 

--- a/src/backports/iterator.h
+++ b/src/backports/iterator.h
@@ -15,7 +15,10 @@
 
 // Backport types and traits from the `<iterator>` header s.t. they
 // can be used in C++17 using the `ql` namespace, in particular
-// `default_sentinel`, `move_sentinel` and `iter_reference_t`.
+// `default_sentinel`, `move_iterator`, `move_sentinel` and `iter_reference_t`.
+// NOTE: technically `std::move_iterator` is already present in C++11, but
+// combining `std::move_iterator` with `ql::move_sentinel` led to trouble inside
+// `range-v3` in C++17 mode inside QCC8.
 namespace ql {
 
 using ::ranges::move_iterator;
@@ -104,7 +107,6 @@ CPP_template(typename Sent)(
 
 using ::ranges::iter_reference_t;
 using ::ranges::iter_value_t;
-
 }  // namespace ql
 
 #endif  // QLEVER_SRC_BACKPORTS_ITERATOR_H

--- a/src/backports/iterator.h
+++ b/src/backports/iterator.h
@@ -9,6 +9,7 @@
 
 #include <iterator>
 #include <range/v3/iterator/access.hpp>
+#include <range/v3/iterator/move_iterators.hpp>
 
 #include "backports/concepts.h"
 #include "backports/type_traits.h"

--- a/src/backports/iterator.h
+++ b/src/backports/iterator.h
@@ -18,12 +18,18 @@
 // `default_sentinel`, `move_sentinel` and `iter_reference_t`.
 namespace ql {
 
+using ::ranges::move_iterator;
+template <class Iter>
+move_iterator<Iter> make_move_iterator(Iter i) {
+  return move_iterator<Iter>{std::move(i)};
+}
+
 // Backport of `std::default_sentinel[_t]`
 struct default_sentinel_t {};
 inline constexpr default_sentinel_t default_sentinel{};
 
 // A backport of `std::move_sentinel` for C++17. It wraps an iterator or
-// sentinel type and can be compared with a compatible `std::move_iterator`.
+// sentinel type and can be compared with a compatible `ql::move_iterator`.
 CPP_template(typename Sent)(
     requires ql::concepts::semiregular<Sent>) class move_sentinel {
  public:
@@ -64,17 +70,17 @@ CPP_template(typename Sent)(
   }
 
   // Compare with a compatible iterator (typically obtained via
-  // `std::make_move_iterator`.
+  // `ql::make_move_iterator`.
   CPP_template_2(typename It)(
       requires ql::concepts::sentinel_for<Sent, It>) friend bool
-  operator==(const std::move_iterator<It> it, move_sentinel sent) {
+  operator==(const move_iterator<It> it, move_sentinel sent) {
     return it.base() == sent.base();
   }
 
   // Operator != (details same as for `operator==` above).
   CPP_template_2(typename It)(
       requires ql::concepts::sentinel_for<Sent, It>) friend bool
-  operator!=(const std::move_iterator<It> it, move_sentinel sent) {
+  operator!=(const move_iterator<It> it, move_sentinel sent) {
     return it.base() != sent.base();
   }
 
@@ -82,13 +88,13 @@ CPP_template(typename Sent)(
   // first). They are required by the C++17 mode of `range-v3`.
   CPP_template_2(typename It)(
       requires ql::concepts::sentinel_for<Sent, It>) friend bool
-  operator==(move_sentinel sent, const std::move_iterator<It> it) {
+  operator==(move_sentinel sent, const move_iterator<It> it) {
     return it == sent;
   }
 
   CPP_template_2(typename It)(
       requires ql::concepts::sentinel_for<Sent, It>) friend bool
-  operator!=(move_sentinel sent, const std::move_iterator<It> it) {
+  operator!=(move_sentinel sent, const move_iterator<It> it) {
     return it != sent;
   }
 
@@ -98,6 +104,7 @@ CPP_template(typename Sent)(
 
 using ::ranges::iter_reference_t;
 using ::ranges::iter_value_t;
+
 }  // namespace ql
 
 #endif  // QLEVER_SRC_BACKPORTS_ITERATOR_H

--- a/src/engine/ExecuteUpdate.cpp
+++ b/src/engine/ExecuteUpdate.cpp
@@ -207,7 +207,6 @@ ExecuteUpdate::computeGraphUpdateQuads(
 // _____________________________________________________________________________
 void ExecuteUpdate::sortAndRemoveDuplicates(
     std::vector<IdTriple<>>& container) {
-  // TODO<joka921> why doesn't this work with ql::ranges?
   ql::ranges::sort(container);
   container.erase(std::unique(container.begin(), container.end()),
                   container.end());

--- a/src/engine/ExecuteUpdate.cpp
+++ b/src/engine/ExecuteUpdate.cpp
@@ -169,8 +169,8 @@ ExecuteUpdate::computeGraphUpdateQuads(
         updateTriples.reserve(result.idTable().size() *
                               transformedTripleTemplates.size());
 
-        return std::tuple{std::move(transformedTripleTemplates),
-                          std::move(updateTriples), std::move(localVocab)};
+        return std::make_tuple(std::move(transformedTripleTemplates),
+                               std::move(updateTriples), std::move(localVocab));
       };
 
   auto [toInsertTemplates, toInsert, localVocabInsert] =
@@ -207,6 +207,7 @@ ExecuteUpdate::computeGraphUpdateQuads(
 // _____________________________________________________________________________
 void ExecuteUpdate::sortAndRemoveDuplicates(
     std::vector<IdTriple<>>& container) {
+  // TODO<joka921> why doesn't this work with ql::ranges?
   ql::ranges::sort(container);
   container.erase(std::unique(container.begin(), container.end()),
                   container.end());

--- a/src/engine/LocalVocab.h
+++ b/src/engine/LocalVocab.h
@@ -131,7 +131,8 @@ class LocalVocab {
     // duplicates, we still manually filter out empty sets, because these
     // typically don't compare equal to each other because of the`shared_ptr`
     // semantics.
-    for (const auto& vocab : vocabs | filter(std::not_fn(&LocalVocab::empty))) {
+    for (const LocalVocab& vocab :
+         vocabs | filter(std::not_fn(&LocalVocab::empty))) {
       // Mark vocab as copied
       vocab.copied_->store(true);
       ql::ranges::for_each(vocab.otherWordSets_, addWordSet);

--- a/src/engine/Operation.cpp
+++ b/src/engine/Operation.cpp
@@ -76,8 +76,8 @@ std::vector<std::string> Operation::collectWarnings() const {
       continue;
     }
     auto recursive = child->collectWarnings();
-    res.insert(res.end(), std::make_move_iterator(recursive.begin()),
-               std::make_move_iterator(recursive.end()));
+    res.insert(res.end(), ql::make_move_iterator(recursive.begin()),
+               ql::make_move_iterator(recursive.end()));
   }
 
   return res;

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -1232,8 +1232,8 @@ std::vector<SubtreePlan> QueryPlanner::merge(
 
   if (isInTestMode()) {
     std::vector<std::pair<std::string, vector<SubtreePlan>>> sortedCandidates{
-        std::make_move_iterator(candidates.begin()),
-        std::make_move_iterator(candidates.end())};
+        ql::make_move_iterator(candidates.begin()),
+        ql::make_move_iterator(candidates.end())};
     std::sort(sortedCandidates.begin(), sortedCandidates.end(),
               [](const auto& a, const auto& b) { return a.first < b.first; });
     pruneCandidates(sortedCandidates);
@@ -2118,7 +2118,7 @@ size_t QueryPlanner::findSmallestExecutionTree(
   AD_CONTRACT_CHECK(!lastRow.empty());
   auto compare = [](const auto& a, const auto& b) {
     auto tie = [](const auto& x) {
-      return std::tuple{x.getSizeEstimate(), x.getSizeEstimate()};
+      return std::make_tuple(x.getSizeEstimate(), x.getSizeEstimate());
     };
     return tie(a) < tie(b);
   };
@@ -2436,7 +2436,7 @@ QueryPlanner::getJoinColumnsForTransitivePath(const JoinColumns& jcs,
     if (transitiveCol >= graphColIndex) {
       return std::nullopt;
     }
-    return std::tuple{transitiveCol, otherCol};
+    return std::make_tuple(transitiveCol, otherCol);
   }
 
   // At this point, we know that we have exactly two pairs of join columns,
@@ -2449,14 +2449,14 @@ QueryPlanner::getJoinColumnsForTransitivePath(const JoinColumns& jcs,
   size_t otherColB = jcs[1][otherIndex];
   if (transitiveColA < graphColIndex) {
     if (transitiveColB == graphColIndex) {
-      return std::tuple{transitiveColA, otherColA};
+      return std::make_tuple(transitiveColA, otherColA);
     }
     // We currently don't support binding two regular columns at once
     return std::nullopt;
   }
   AD_CORRECTNESS_CHECK(transitiveColB < graphColIndex);
   AD_CORRECTNESS_CHECK(transitiveColA == graphColIndex);
-  return std::tuple{transitiveColB, otherColB};
+  return std::make_tuple(transitiveColB, otherColB);
 #endif
 }
 
@@ -2805,7 +2805,7 @@ qlever::index::GraphFilter<TripleComponent> QueryPlanner::getActiveGraphs()
 template <typename Variables>
 bool QueryPlanner::GraphPatternPlanner::handleUnconnectedMinusOrOptional(
     std::vector<SubtreePlan>& candidates, const Variables& variables) {
-  using enum SubtreePlan::Type;
+  using enum QueryPlanner::SubtreePlan::Type;
   bool areVariablesUnconnected = ql::ranges::all_of(
       variables,
       [this](const Variable& var) { return !boundVariables_.contains(var); });
@@ -2898,8 +2898,8 @@ void QueryPlanner::GraphPatternPlanner::visitGroupOptionalOrMinus(
         plan.containsFilterSubstitute_ = a.containsFilterSubstitute_;
       }
       nextCandidates.insert(nextCandidates.end(),
-                            std::make_move_iterator(vec.begin()),
-                            std::make_move_iterator(vec.end()));
+                            ql::make_move_iterator(vec.begin()),
+                            ql::make_move_iterator(vec.end()));
     }
   }
 

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -2805,7 +2805,7 @@ qlever::index::GraphFilter<TripleComponent> QueryPlanner::getActiveGraphs()
 template <typename Variables>
 bool QueryPlanner::GraphPatternPlanner::handleUnconnectedMinusOrOptional(
     std::vector<SubtreePlan>& candidates, const Variables& variables) {
-  using enum QueryPlanner::SubtreePlan::Type;
+  using enum SubtreePlan::Type;
   bool areVariablesUnconnected = ql::ranges::all_of(
       variables,
       [this](const Variable& var) { return !boundVariables_.contains(var); });

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -309,8 +309,8 @@ auto Server::prepareOperation(
 
   configurePinnedResultWithName(pinResultWithName, pinNamedGeoIndex,
                                 accessTokenOk, qec);
-  return std::tuple{std::move(qec), std::move(cancellationHandle),
-                    std::move(cancelTimeoutOnDestruction)};
+  return std::make_tuple(std::move(qec), std::move(cancellationHandle),
+                         std::move(cancelTimeoutOnDestruction));
 }
 
 // _____________________________________________________________________________

--- a/src/engine/VariableToColumnMap.cpp
+++ b/src/engine/VariableToColumnMap.cpp
@@ -11,7 +11,7 @@
 std::vector<std::pair<Variable, ColumnIndexAndTypeInfo>>
 copySortedByColumnIndex(VariableToColumnMap map) {
   std::vector<std::pair<Variable, ColumnIndexAndTypeInfo>> result{
-      std::make_move_iterator(map.begin()), std::make_move_iterator(map.end())};
+      ql::make_move_iterator(map.begin()), ql::make_move_iterator(map.end())};
   ql::ranges::sort(result, std::less<>{},
                    [](const auto& pair) { return pair.second.columnIndex_; });
   return result;

--- a/src/engine/idTable/CompressedExternalIdTable.h
+++ b/src/engine/idTable/CompressedExternalIdTable.h
@@ -146,8 +146,8 @@ class CompressedExternalIdTableWriter {
                     offset = file.tell();
                     file.write(compressed.data(), compressed.size());
                   });
-              blockMetadata.emplace_back(compressed.size(),
-                                         thisBlockSizeUncompressed, offset);
+              blockMetadata.push_back(
+                  {compressed.size(), thisBlockSizeUncompressed, offset});
             }
           }));
     }
@@ -280,9 +280,10 @@ CPP_class_template(size_t NumStaticCols,
         BlockTransformation,
         IdTableStatic<NumStaticCols>&>)) class CompressedExternalIdTableBase {
  public:
-  using value_type = IdTableStatic<NumStaticCols>::row_type;
-  using reference = IdTableStatic<NumStaticCols>::row_reference;
-  using const_reference = IdTableStatic<NumStaticCols>::const_row_reference;
+  using value_type = typename IdTableStatic<NumStaticCols>::row_type;
+  using reference = typename IdTableStatic<NumStaticCols>::row_reference;
+  using const_reference =
+      typename IdTableStatic<NumStaticCols>::const_row_reference;
   using MemorySize = ad_utility::MemorySize;
 
  protected:

--- a/src/engine/idTable/IdTable.h
+++ b/src/engine/idTable/IdTable.h
@@ -210,8 +210,8 @@ class IdTable {
   CPP_template(typename ColT)(
       requires ql::ranges::forward_range<ColT> CPP_and CPP_NOT(isView))
       IdTable(size_t numColumns, ColT columns)
-      : data_{std::make_move_iterator(columns.begin()),
-              std::make_move_iterator(columns.end())},
+      : data_{ql::make_move_iterator(columns.begin()),
+              ql::make_move_iterator(columns.end())},
         numColumns_{numColumns} {
     if constexpr (!isDynamic) {
       AD_CONTRACT_CHECK(NumColumns == numColumns);
@@ -524,8 +524,8 @@ class IdTable {
           std::vector<ColumnStorage> newColumns,
           Allocator allocator = {}) const {
     AD_CONTRACT_CHECK(newColumns.size() >= numColumns());
-    Data newStorage(std::make_move_iterator(newColumns.begin()),
-                    std::make_move_iterator(newColumns.begin() + numColumns()));
+    Data newStorage(ql::make_move_iterator(newColumns.begin()),
+                    ql::make_move_iterator(newColumns.begin() + numColumns()));
     ql::ranges::for_each(
         ad_utility::integerRange(numColumns()), [this, &newStorage](auto i) {
           newStorage[i].insert(newStorage[i].end(), data()[i].begin(),

--- a/src/engine/idTable/IdTableRow.h
+++ b/src/engine/idTable/IdTableRow.h
@@ -367,10 +367,12 @@ template <typename Table, ad_utility::IsConst isConstTag>
 class RowReference
     : public RowReferenceImpl::RowReferenceWithRestrictedAccess<Table,
                                                                 isConstTag> {
- private:
+ public:
   using Base =
       RowReferenceImpl::RowReferenceWithRestrictedAccess<Table, isConstTag>;
   using Base::numStaticColumns;
+
+ private:
   using TablePtr = typename Base::TablePtr;
   using T = typename Base::T;
   static constexpr bool isConst = isConstTag == ad_utility::IsConst::True;

--- a/src/engine/idTable/IdTableRow.h
+++ b/src/engine/idTable/IdTableRow.h
@@ -10,6 +10,7 @@
 #include <variant>
 #include <vector>
 
+#include "backports/keywords.h"
 #include "backports/three_way_comparison.h"
 #include "backports/type_traits.h"
 #include "global/Id.h"
@@ -67,8 +68,10 @@ class Row {
   CPP_template_2(typename = void)(requires(!isDynamic())) Row(){};
 
   CPP_template_2(typename = void)(requires(!isDynamic())) explicit Row(
-      [[maybe_unused]] size_t numCols)
-      : Row() {}
+      QL_MAYBE_UNUSED size_t numCols)
+      : Row() {
+    (void)numCols;
+  }
 
   // Access the i-th element.
   T& operator[](size_t i) { return data_[i]; }
@@ -94,7 +97,7 @@ class Row {
   QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(Row, data_)
 
   // Convert from a static `RowReference` to a `std::array` (makes a copy).
-  CPP_template_2(typename = void)(requires(numStaticColumns != 0)) explicit
+  CPP_template_2(typename = void)(requires(NumColumns != 0)) explicit
   operator std::array<T, numStaticColumns>() const {
     std::array<T, numStaticColumns> result;
     ql::ranges::copy(*this, result.begin());
@@ -266,20 +269,38 @@ class RowReferenceImpl {
 
     // Equality comparison. Works between two `RowReference`s, but also between
     // a `RowReference` and a `Row` if the number of columns match.
+    template <typename U>
+    // QCC says "U::numStaticColumns is inaccessible in this context".
+    /*
     CPP_template(typename U)(requires(numStaticColumns ==
                                       U::numStaticColumns)) bool
-    operator==(const U& other) const {
+                                      */
+    bool operator==(const U& other) const {
+      // TODO<joka921> Reinstate
+      /*
       if constexpr (numStaticColumns == 0) {
-        if (numColumns() != other.numColumns()) {
-          return false;
-        }
+      */
+      if (numColumns() != other.numColumns()) {
+        return false;
       }
+      /*
+      }
+      */
       for (size_t i = 0; i < numColumns(); ++i) {
         if ((*this)[i] != other[i]) {
           return false;
         }
       }
       return true;
+    }
+    /*
+    CPP_template(typename U)(requires(numStaticColumns ==
+                                      U::numStaticColumns)) bool
+                                      */
+    // SAME QCC stuff as above.
+    template <typename U>
+    bool operator!=(const U& other) const {
+      return !(*this == other);
     }
 
     // Convert from a `RowReference` to a `Row`.
@@ -410,6 +431,12 @@ class RowReference
     return base() == other;
   }
 
+  CPP_template_2(typename T)(requires(numStaticColumns ==
+                                      T::numStaticColumns)) bool
+  operator!=(const T& other) const {
+    return !(base() == other);
+  }
+
  public:
   // Assignment from a `Row` with the same number of columns.
   RowReference& operator=(const Row<T, numStaticColumns>& other) & {
@@ -434,11 +461,13 @@ class RowReference
     this->assignmentImpl(base(), other);
     return *this;
   }
-
   // No need to copy `RowReference`s, because that is also most likely a bug.
   // Currently none of our functions or of the STL-algorithms require it.
   // If necessary, we can still enable it in the future.
-  RowReference(const RowReference&) = delete;
+
+  // TODO<joka921> Analyze this further, QCC from BMW requires this for concept
+  // checks, can we leave it unimplemented for now for increased safety?
+  RowReference(const RowReference&);
 };
 
 }  // namespace columnBasedIdTable

--- a/src/engine/idTable/IdTableRow.h
+++ b/src/engine/idTable/IdTableRow.h
@@ -268,23 +268,16 @@ class RowReferenceImpl {
 
     // Equality comparison. Works between two `RowReference`s, but also between
     // a `RowReference` and a `Row` if the number of columns match.
+    // Note: QCC 8.3 doesn't have access to `U::numStaticColumns`.
     template <typename U>
-    // QCC says "U::numStaticColumns is inaccessible in this context".
-    /*
-    CPP_template(typename U)(requires(numStaticColumns ==
-                                      U::numStaticColumns)) bool
-                                      */
+    QL_CONCEPT_OR_NOTHING(requires(numStaticColumns == U::numStaticColumns))
     bool operator==(const U& other) const {
-      // TODO<joka921> Reinstate
-      /*
+      static_assert(numStaticColumns == U::numStaticColumns);
       if constexpr (numStaticColumns == 0) {
-      */
-      if (numColumns() != other.numColumns()) {
-        return false;
+        if (numColumns() != other.numColumns()) {
+          return false;
+        }
       }
-      /*
-      }
-      */
       for (size_t i = 0; i < numColumns(); ++i) {
         if ((*this)[i] != other[i]) {
           return false;
@@ -292,12 +285,8 @@ class RowReferenceImpl {
       }
       return true;
     }
-    /*
-    CPP_template(typename U)(requires(numStaticColumns ==
-                                      U::numStaticColumns)) bool
-                                      */
-    // SAME QCC stuff as above.
     template <typename U>
+    QL_CONCEPT_OR_NOTHING(requires(numStaticColumns == U::numStaticColumns))
     bool operator!=(const U& other) const {
       return !(*this == other);
     }

--- a/src/engine/idTable/IdTableRow.h
+++ b/src/engine/idTable/IdTableRow.h
@@ -10,7 +10,6 @@
 #include <variant>
 #include <vector>
 
-#include "backports/keywords.h"
 #include "backports/three_way_comparison.h"
 #include "backports/type_traits.h"
 #include "global/Id.h"
@@ -68,7 +67,7 @@ class Row {
   CPP_template_2(typename = void)(requires(!isDynamic())) Row(){};
 
   CPP_template_2(typename = void)(requires(!isDynamic())) explicit Row(
-      QL_MAYBE_UNUSED size_t numCols)
+      size_t numCols)
       : Row() {
     (void)numCols;
   }
@@ -461,13 +460,16 @@ class RowReference
     this->assignmentImpl(base(), other);
     return *this;
   }
-  // No need to copy `RowReference`s, because that is also most likely a bug.
-  // Currently none of our functions or of the STL-algorithms require it.
-  // If necessary, we can still enable it in the future.
 
-  // TODO<joka921> Analyze this further, QCC from BMW requires this for concept
-  // checks, can we leave it unimplemented for now for increased safety?
-  RowReference(const RowReference&);
+  // It is technically a bug to copy a row reference, hence we delete the copy
+  // constructor, at least in C++20 mode. However, on older compilers like QCC8,
+  // range-v3 requires not only a declaration, but a definition of the copy
+  // constructor.
+#ifdef QLEVER_CPP_17
+  RowReference(const RowReference&) = default;
+#else
+  RowReference(const RowReference&) = delete;
+#endif
 };
 
 }  // namespace columnBasedIdTable

--- a/src/engine/idTable/VectorWithElementwiseMove.h
+++ b/src/engine/idTable/VectorWithElementwiseMove.h
@@ -50,8 +50,8 @@ struct VectorWithElementwiseMove : public std::vector<T> {
     ad_utility::terminateIfThrows(
         [&other, self = this] {
           AD_CORRECTNESS_CHECK(self->empty());
-          self->insert(self->end(), std::make_move_iterator(other.begin()),
-                       std::make_move_iterator(other.end()));
+          self->insert(self->end(), ql::make_move_iterator(other.begin()),
+                       ql::make_move_iterator(other.end()));
         },
         "Error happened during the move construction or move assignment of an "
         "IdTable");

--- a/src/engine/sparqlExpressions/SparqlExpression.cpp
+++ b/src/engine/sparqlExpressions/SparqlExpression.cpp
@@ -4,6 +4,8 @@
 
 #include "engine/sparqlExpressions/SparqlExpression.h"
 
+#include "backports/iterator.h"
+
 namespace sparqlExpression {
 
 // _____________________________________________________________________________
@@ -36,8 +38,8 @@ std::vector<Variable> SparqlExpression::getUnaggregatedVariables() const {
   std::vector<Variable> result;
   for (const auto& child : children()) {
     auto childResult = child->getUnaggregatedVariables();
-    result.insert(result.end(), std::make_move_iterator(childResult.begin()),
-                  std::make_move_iterator(childResult.end()));
+    result.insert(result.end(), ql::make_move_iterator(childResult.begin()),
+                  ql::make_move_iterator(childResult.end()));
   }
   return result;
 }
@@ -139,8 +141,8 @@ ql::span<const SparqlExpression::Ptr> SparqlExpression::childrenForTesting()
 // _____________________________________________________________________________
 std::vector<SparqlExpression::Ptr> SparqlExpression::moveChildrenOut() && {
   auto span = children();
-  return {std::make_move_iterator(span.begin()),
-          std::make_move_iterator(span.end())};
+  return {ql::make_move_iterator(span.begin()),
+          ql::make_move_iterator(span.end())};
 }
 
 // _____________________________________________________________________________

--- a/src/global/Pattern.h
+++ b/src/global/Pattern.h
@@ -126,10 +126,6 @@ class CompactVectorOfStrings {
     return {ptr, size};
   }
 
-  // Forward iterator for a `CompactVectorOfStrings` that reads directly from
-  // disk without buffering the whole `Vector`.
-  static cppcoro::generator<vector_type> diskIterator(std::string filename);
-
   using Iterator = ad_utility::IteratorForAccessOperator<
       CompactVectorOfStrings, ad_utility::AccessViaBracketOperator,
       ad_utility::IsConst::True>;

--- a/src/global/SpecialIds.h
+++ b/src/global/SpecialIds.h
@@ -34,11 +34,13 @@ inline const ad_utility::HashMap<std::string, Id>& specialIds() {
     // have the `Undefined` datatype, but none of them is equal to the "actual"
     // UNDEF value.
     auto values = ql::views::values(result);
+#ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
     auto undefTypeButNotUndefValue = [](Id id) {
       return id != Id::makeUndefined() &&
              id.getDatatype() == Datatype::Undefined;
     };
     AD_CORRECTNESS_CHECK(ql::ranges::all_of(values, undefTypeButNotUndefValue));
+#endif
     ad_utility::HashSet<Id> uniqueIds(values.begin(), values.end());
     AD_CORRECTNESS_CHECK(uniqueIds.size() == result.size());
     return result;

--- a/src/parser/SelectClause.cpp
+++ b/src/parser/SelectClause.cpp
@@ -61,8 +61,8 @@ void SelectClause::addAlias(parsedQuery::SelectClause::VarOrAlias varOrAlias,
 
 // ____________________________________________________________________
 void SelectClause::setSelected(std::vector<Variable> variables) {
-  std::vector<VarOrAlias> v(std::make_move_iterator(variables.begin()),
-                            std::make_move_iterator(variables.end()));
+  std::vector<VarOrAlias> v(ql::make_move_iterator(variables.begin()),
+                            ql::make_move_iterator(variables.end()));
   setSelected(v);
 }
 

--- a/src/util/BatchedPipeline.h
+++ b/src/util/BatchedPipeline.h
@@ -8,6 +8,7 @@
 #include <future>
 #include <utility>
 
+#include "backports/iterator.h"
 #include "util/Exception.h"
 #include "util/Log.h"
 #include "util/Timer.h"
@@ -308,7 +309,7 @@ class BatchedPipeline {
   template <typename It, typename ResIt, typename TransformerPtr>
   static void moveAndTransform(It beg, It end, ResIt res,
                                TransformerPtr transformer) {
-    std::transform(std::make_move_iterator(beg), std::make_move_iterator(end),
+    std::transform(ql::make_move_iterator(beg), ql::make_move_iterator(end),
                    res,
                    [transformer](typename std::decay_t<decltype(*beg)>&& x) {
                      return (*transformer)(std::move(x));

--- a/src/util/Iterators.h
+++ b/src/util/Iterators.h
@@ -190,7 +190,7 @@ class IteratorForAccessOperator {
 };
 
 /// If `T` is a type that can safely be moved from (e.g. std::vector<int> or
-/// std::vector<int>&&), then return `std::make_move_iterator(iterator)`. Else
+/// std::vector<int>&&), then return `ql::make_move_iterator(iterator)`. Else
 /// (for example if `T` is `std::vector<int>&` or `const std::vector<int>&` the
 /// iterator is returned unchanged. Typically used in generic code where we need
 /// the semantics of "if `std::forward` would move the container, we can also
@@ -198,7 +198,7 @@ class IteratorForAccessOperator {
 template <typename T, typename It>
 auto makeForwardingIterator(It iterator) {
   if constexpr (std::is_rvalue_reference_v<T&&>) {
-    return std::make_move_iterator(iterator);
+    return ql::make_move_iterator(iterator);
   } else {
     return iterator;
   }

--- a/src/util/Views.h
+++ b/src/util/Views.h
@@ -283,7 +283,7 @@ CallbackOnEndView(R&&, F) -> CallbackOnEndView<all_t<R>, F>;
 // A drop-in replacement for `std::views::as_rvalue` from C++23.
 // It yields the same elements as the underlying range, but casts them to
 // rvalue references via `std::move`. It is implemented via
-// `std::make_move_iterator`.
+// `ql::make_move_iterator`.
 CPP_template(typename UnderlyingRange)(
     requires ql::ranges::view<UnderlyingRange> CPP_and
         ql::ranges::input_range<UnderlyingRange>) class RvalueView
@@ -323,11 +323,11 @@ CPP_template(typename UnderlyingRange)(
   // Note: We currently don't implement the const `begin` and `end` functions,
   // but they can be added should they ever become necessary.
   constexpr auto begin() {
-    return std::make_move_iterator(ql::ranges::begin(underlyingRange_));
+    return ql::make_move_iterator(ql::ranges::begin(underlyingRange_));
   }
   constexpr auto end() {
     if constexpr (ql::ranges::common_range<UnderlyingRange>) {
-      return std::move_iterator{ql::ranges::end(underlyingRange_)};
+      return ql::move_iterator{ql::ranges::end(underlyingRange_)};
     } else {
       return ql::move_sentinel(ql::ranges::end(underlyingRange_));
     }

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -121,8 +121,8 @@ CPP_template(typename T)(
     return IdOrLiteralOrIri{lit(vec)};
   } else {
     return VectorWithMemoryLimit<typename T::value_type>{
-        std::make_move_iterator(vec.begin()),
-        std::make_move_iterator(vec.end()), alloc};
+        ql::make_move_iterator(vec.begin()), ql::make_move_iterator(vec.end()),
+        alloc};
   }
 }
 

--- a/test/backports/BackportIteratorTest.cpp
+++ b/test/backports/BackportIteratorTest.cpp
@@ -46,7 +46,7 @@ TYPED_TEST_SUITE(MoveSentinelTest, ContainerTypes);
 // _____________________________________________________________________________
 TYPED_TEST(MoveSentinelTest, doesInFactMove) {
   auto& cont = this->container_;
-  auto beg = std::make_move_iterator(cont.begin());
+  auto beg = ql::make_move_iterator(cont.begin());
   auto end = ql::move_sentinel{cont.end()};
 
   [[maybe_unused]] R target{false};
@@ -64,8 +64,8 @@ TYPED_TEST(MoveSentinelTest, basicFunctions) {
     auto& empty = this->emptyContainer_;
     EXPECT_EQ(empty.begin(), empty.end());
     auto emptySent = ql::move_sentinel{empty.end()};
-    EXPECT_EQ(std::make_move_iterator(empty.begin()), emptySent);
-    EXPECT_EQ(emptySent, std::make_move_iterator(empty.begin()));
+    EXPECT_EQ(ql::make_move_iterator(empty.begin()), emptySent);
+    EXPECT_EQ(emptySent, ql::make_move_iterator(empty.begin()));
     EXPECT_EQ(emptySent.base(), empty.end());
     EXPECT_EQ(emptySent.base(), empty.begin());
   }
@@ -75,8 +75,8 @@ TYPED_TEST(MoveSentinelTest, basicFunctions) {
     auto& cont = this->container_;
     auto sent = ql::move_sentinel{cont.end()};
     EXPECT_NE(cont.begin(), cont.end());
-    EXPECT_NE(std::make_move_iterator(cont.begin()), sent);
-    EXPECT_NE(sent, std::make_move_iterator(cont.begin()));
+    EXPECT_NE(ql::make_move_iterator(cont.begin()), sent);
+    EXPECT_NE(sent, ql::make_move_iterator(cont.begin()));
     EXPECT_EQ(sent.base(), cont.end());
     EXPECT_NE(sent.base(), cont.begin());
   }


### PR DESCRIPTION
1. Replace `std::make_move_iterator` with `ql::make_move_iterator` backported from `range-v3`
2. Replace `std::move_iterator` with `ql::move_iterator` backported from `range-v3`
3. Replace brace-initialization for tuples with `std::make_tuple` to avoid CTAD requirements
4. Replace `emplace_back` with `push_back({...})` for aggregate types
5. Add `typename` keyword for dependent type names in templates
6. Add template parameter constraint workarounds for GCC 8.3 using `static_assert`
7. Add explicit `operator!=` implementations where C++17 doesn't auto-generate from `operator==`
8. Fix unused parameter warnings with explicit `(void)param` statements
9. Make copy constructors conditionally defined: `= default` in C++17, `= delete` in C++20+
10. Add missing `#include "backports/iterator.h"` headers
11. Enhance backport of move iterators and sentinels in `backports/iterator.h`
12. Use explicit types instead of `auto` in range-based `for` loops
13. Add `#ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17` guards for C++20-only code
14. Remove unused forward declarations
15. Update `range-v3` dependency