### PR TITLE
`AddToVariant` type trait

### DIFF
--- a/src/util/TypeTraits.h
+++ b/src/util/TypeTraits.h
@@ -435,8 +435,7 @@ struct AddToVariantImpl<std::variant<Ts...>, T> {
 };
 }  // namespace detail
 
-// Adds an additional type `T` to a variant `V`. Use together with
-// `UniqueVariant` if `T` might already be contained in `V`.
+// Adds an additional type `T` to a variant `V`.
 template <class V, class T>
 using AddToVariant = typename detail::AddToVariantImpl<V, T>::type;
 // Examples:


### PR DESCRIPTION
Adds a new type trait which can be used to extend an existing `std::variant` with further types. For example `AddToVariant<std::variant<int, bool>, double>` produces `std::variant<int, bool, double>`.

Preparation for #2204 
