### PR TITLE
Backport more code (all over the codebase) to C++17

### DIFF
--- a/src/engine/AddCombinedRowToTable.h
+++ b/src/engine/AddCombinedRowToTable.h
@@ -418,7 +418,8 @@ class AddCombinedRowToIdTable {
           if (el != nullptr) {
             tmpVocabs.push_back(std::cref(*el));
           }
-          return tmpVocabs;
+        }
+        return tmpVocabs;
 #endif
       }();
       mergedVocab_.mergeWith(ql::ranges::ref_view{rangeOfNonNullVocabs});

--- a/src/engine/AddCombinedRowToTable.h
+++ b/src/engine/AddCombinedRowToTable.h
@@ -8,6 +8,8 @@
 #ifndef QLEVER_SRC_ENGINE_ADDCOMBINEDROWTOTABLE_H
 #define QLEVER_SRC_ENGINE_ADDCOMBINEDROWTOTABLE_H
 
+#include <absl/container/inlined_vector.h>
+
 #include <array>
 #include <cstdint>
 #include <vector>
@@ -356,7 +358,9 @@ class AddCombinedRowToIdTable {
           // undefined.
           for (const auto& [targetIndex, sourceIndex] : optionalIndexBuffer_) {
             Id id = [&col, isColFromLeft, sourceIndex = sourceIndex]() {
-              if constexpr (isColFromLeft) {
+              // TODO<joka921> The `constexpr` doesn't work on QCC, figure out
+              // what is wrong.
+              if /*constexpr*/ (isColFromLeft) {
                 return col[sourceIndex];
               } else {
                 (void)col;
@@ -400,9 +404,22 @@ class AddCombinedRowToIdTable {
       // Make sure to reset `mergedVocab_` so it is in a valid state again.
       mergedVocab_ = LocalVocab{};
       // Only merge non-null vocabs.
-      auto range = currentVocabs_ | ql::views::filter(toBool) |
+
+      absl::InlinedVector<std::reference_wrapper<const LocalVocab>, 2>
+          tmpVocabs;
+      for (const auto& el : currentVocabs_) {
+        if (el != nullptr) {
+          tmpVocabs.push_back(std::cref(*el));
+        }
+      }
+
+      /*
+      auto filter = ql::views::filter(toBool);
+      auto range = currentVocabs_ | filter |
                    ql::views::transform(dereference);
-      mergedVocab_.mergeWith(ql::ranges::ref_view{range});
+                   */
+      // auto range = tmpVocabs | ql::views::transform(dereference);
+      mergedVocab_.mergeWith(ql::ranges::ref_view{tmpVocabs});
     }
   }
   const IdTableView<0>& inputLeft() const {

--- a/src/engine/AddCombinedRowToTable.h
+++ b/src/engine/AddCombinedRowToTable.h
@@ -358,9 +358,9 @@ class AddCombinedRowToIdTable {
           // undefined.
           for (const auto& [targetIndex, sourceIndex] : optionalIndexBuffer_) {
             Id id = [&col, isColFromLeft, sourceIndex = sourceIndex]() {
-              // TODO<joka921> The `constexpr` doesn't work on QCC, figure out
-              // what is wrong.
-              if /*constexpr*/ (isColFromLeft) {
+              // Note: `if constexpr` doesn't work here for QCC 8.3 for some
+              // reason which has yet to be analyzed.
+              if QL_CONSTEXPR (isColFromLeft) {
                 return col[sourceIndex];
               } else {
                 (void)col;
@@ -404,22 +404,24 @@ class AddCombinedRowToIdTable {
       // Make sure to reset `mergedVocab_` so it is in a valid state again.
       mergedVocab_ = LocalVocab{};
       // Only merge non-null vocabs.
-
-      absl::InlinedVector<std::reference_wrapper<const LocalVocab>, 2>
-          tmpVocabs;
-      for (const auto& el : currentVocabs_) {
-        if (el != nullptr) {
-          tmpVocabs.push_back(std::cref(*el));
-        }
-      }
-
-      /*
-      auto filter = ql::views::filter(toBool);
-      auto range = currentVocabs_ | filter |
-                   ql::views::transform(dereference);
-                   */
-      // auto range = tmpVocabs | ql::views::transform(dereference);
-      mergedVocab_.mergeWith(ql::ranges::ref_view{tmpVocabs});
+      // Note: On QCC 8.3, the elegant lazy range pipeline gives us trouble, so
+      // we use an `absl::InlinedVector<reference_wrapper>` instead, which can
+      // be done here as we know that we have at most two local vocabs.
+      auto rangeOfNonNullVocabs = [&]() {
+#ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
+        return currentVocabs_ | ql::views::filter(toBool) |
+               ql::views::transform(dereference);
+#else
+        absl::InlinedVector<std::reference_wrapper<const LocalVocab>, 2>
+            tmpVocabs;
+        for (const auto& el : currentVocabs_) {
+          if (el != nullptr) {
+            tmpVocabs.push_back(std::cref(*el));
+          }
+          return tmpVocabs;
+#endif
+      }();
+      mergedVocab_.mergeWith(ql::ranges::ref_view{rangeOfNonNullVocabs});
     }
   }
   const IdTableView<0>& inputLeft() const {

--- a/src/index/IndexBuilderTypes.h
+++ b/src/index/IndexBuilderTypes.h
@@ -76,6 +76,8 @@ struct LocalVocabIndexAndSplitVal {
 using ItemAlloc = ql::pmr::polymorphic_allocator<
     std::pair<const std::string_view, LocalVocabIndexAndSplitVal>>;
 
+// static_assert(std::is_nothrow_move_constructible_v<ItemAlloc>);
+
 // The actual hash map type.
 using ItemMap = ad_utility::HashMap<
     std::string_view, LocalVocabIndexAndSplitVal,
@@ -114,8 +116,15 @@ struct ItemMapAndBuffer {
   ItemMap map_;
   MonotonicBuffer buffer_;
 
+  // static_assert(std::is_nothrow_move_constructible_v<ItemMap>);
+  // static_assert(std::is_nothrow_move_constructible_v<MonotonicBuffer>);
+
   explicit ItemMapAndBuffer(ItemAlloc alloc) : map_{alloc} {}
-  ItemMapAndBuffer(ItemMapAndBuffer&&) noexcept = default;
+  // TODO<joka921> make this `=default` as soon as we have a
+  // nothrow-copy-constructible polymorphic_allocator also in older BOOSt
+  // versions used by BMW.
+  ItemMapAndBuffer(ItemMapAndBuffer&& rhs) noexcept
+      : map_{std::move(rhs.map_)}, buffer_{std::move(rhs.buffer_)} {}
   // We have to delete the move-assignment as it would have the wrong semantics
   // (the monotonic buffer wouldn't be moved, this is one of the oddities of the
   // `ql::pmr` types.

--- a/src/index/TextIndexBuilder.cpp
+++ b/src/index/TextIndexBuilder.cpp
@@ -443,7 +443,7 @@ void TextIndexBuilder::calculateBlockBoundariesImpl(
     // If we are in a block where one of the fourLetterPrefixes are contained,
     // use those as the block start.
     adjustPrefixSortKey(prefixSortKey, len);
-    return std::tuple{std::move(len), std::move(prefixSortKey)};
+    return std::make_tuple(std::move(len), std::move(prefixSortKey));
   };
   auto [currentLen, prefixSortKey] =
       getLengthAndPrefixSortKey(WordVocabIndex::make(0));

--- a/src/libqlever/LibQLeverExample.cpp
+++ b/src/libqlever/LibQLeverExample.cpp
@@ -30,7 +30,7 @@ int main(int argc, char** argv) {
   std::cout << "\x1b[1mBuilding index for input file \"" << inputFile << "\""
             << " with basename \"" << indexBasename << "\x1b[0m" << std::endl;
   qlever::IndexBuilderConfig config;
-  config.inputFiles_.emplace_back(inputFile, qlever::Filetype::Turtle);
+  config.inputFiles_.push_back({inputFile, qlever::Filetype::Turtle});
   config.baseName_ = indexBasename;
   try {
     qlever::Qlever::buildIndex(config);

--- a/src/parser/Tokenizer.h
+++ b/src/parser/Tokenizer.h
@@ -312,7 +312,7 @@ class Tokenizer : public SkipWhitespaceAndCommentsMixin<Tokenizer> {
 
   template <size_t idx>
   std::tuple<bool, size_t, std::string_view> getNextTokenRecurse() {
-    return std::tuple(false, idx, "");
+    return std::make_tuple(false, idx, "");
   }
 
   template <size_t idx, TurtleTokenId fst, TurtleTokenId... ids>
@@ -326,8 +326,9 @@ class Tokenizer : public SkipWhitespaceAndCommentsMixin<Tokenizer> {
     reset(beg, dataSize);
     bool curBetter = currentSuccess && res.size() > content.size();
 
-    return std::tuple(success || currentSuccess, curBetter ? idx : unusedIdx,
-                      curBetter ? res : content);
+    return std::make_tuple(success || currentSuccess,
+                           curBetter ? idx : unusedIdx,
+                           curBetter ? res : content);
   }
 
   // If there is a prefix match with the argument, move forward the input stream

--- a/src/parser/Tokenizer.h
+++ b/src/parser/Tokenizer.h
@@ -312,7 +312,7 @@ class Tokenizer : public SkipWhitespaceAndCommentsMixin<Tokenizer> {
 
   template <size_t idx>
   std::tuple<bool, size_t, std::string_view> getNextTokenRecurse() {
-    return std::make_tuple(false, idx, "");
+    return std::make_tuple(false, idx, std::string_view{""});
   }
 
   template <size_t idx, TurtleTokenId fst, TurtleTokenId... ids>

--- a/src/parser/TokenizerCtre.h
+++ b/src/parser/TokenizerCtre.h
@@ -304,7 +304,7 @@ class TokenizerCtre : public SkipWhitespaceAndCommentsMixin<TokenizerCtre> {
   // left, so there's no match.
   template <size_t idx>
   std::tuple<bool, size_t, std::string_view> getNextTokenRecurse() {
-    return std::tuple(false, idx, "");
+    return std::make_tuple(false, idx, "");
   }
 
   /*
@@ -328,8 +328,9 @@ class TokenizerCtre : public SkipWhitespaceAndCommentsMixin<TokenizerCtre> {
     reset(beg, dataSize);
     bool curBetter = currentSuccess && res.size() > content.size();
 
-    return std::tuple(success || currentSuccess, curBetter ? idx : unusedIdx,
-                      curBetter ? res : content);
+    return std::make_tuple(success || currentSuccess,
+                           curBetter ? idx : unusedIdx,
+                           curBetter ? res : content);
   }
 
   /*

--- a/src/parser/TokenizerCtre.h
+++ b/src/parser/TokenizerCtre.h
@@ -304,7 +304,7 @@ class TokenizerCtre : public SkipWhitespaceAndCommentsMixin<TokenizerCtre> {
   // left, so there's no match.
   template <size_t idx>
   std::tuple<bool, size_t, std::string_view> getNextTokenRecurse() {
-    return std::make_tuple(false, idx, "");
+    return std::make_tuple(false, idx, std::string_view{""});
   }
 
   /*

--- a/src/rdfTypes/GeometryInfo.h
+++ b/src/rdfTypes/GeometryInfo.h
@@ -95,7 +95,9 @@ struct NumGeometries {
 
   uint32_t numGeometries() const { return numGeometries_; }
 
-  constexpr bool operator==(const NumGeometries& other) const = default;
+  constexpr bool operator==(const NumGeometries& other) const {
+    return numGeometries_ == other.numGeometries_;
+  };
 };
 
 // Represents the length of the geometry in meters.
@@ -105,6 +107,10 @@ struct MetricLength {
 
  public:
   explicit MetricLength(double length);
+#ifdef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
+  // Required for `bit_cast`.
+  MetricLength() = default;
+#endif
 
   double length() const { return length_; }
 };
@@ -120,6 +126,10 @@ struct MetricArea {
 
  public:
   explicit MetricArea(double area);
+#ifdef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
+  // Required for `bit_cast`.
+  MetricArea() = default;
+#endif
 
   double area() const { return area_; };
 
@@ -177,6 +187,10 @@ class GeometryInfo {
   GeometryInfo(uint8_t wktType, const BoundingBox& boundingBox,
                Centroid centroid, NumGeometries numGeometries,
                MetricLength metricLength, MetricArea metricArea);
+#ifdef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
+  // Required for `bit_cast`.
+  GeometryInfo() = default;
+#endif
 
   GeometryInfo(const GeometryInfo& other) = default;
 

--- a/src/rdfTypes/RdfEscaping.cpp
+++ b/src/rdfTypes/RdfEscaping.cpp
@@ -179,7 +179,7 @@ static void literalUnescape(std::string_view input, std::string& res) {
 // ____________________________________________________________________________
 static void literalUnescapeWithQuotesRemoved(std::string_view input,
                                              std::string& res) {
-  if (ql::starts_with(input, R"(""")") || input.starts_with(R"(''')")) {
+  if (ql::starts_with(input, R"(""")") || ql::starts_with(input, R"(''')")) {
     AD_CONTRACT_CHECK(ql::ends_with(input, input.substr(0, 3)));
     input.remove_prefix(3);
     input.remove_suffix(3);

--- a/src/util/ConstexprSmallString.h
+++ b/src/util/ConstexprSmallString.h
@@ -5,6 +5,8 @@
 #ifndef QLEVER_SRC_UTIL_CONSTEXPRSMALLSTRING_H
 #define QLEVER_SRC_UTIL_CONSTEXPRSMALLSTRING_H
 
+#include <backports/algorithm.h>
+
 #include <array>
 #include <stdexcept>
 #include <string>

--- a/src/util/FsstCompressor.h
+++ b/src/util/FsstCompressor.h
@@ -214,7 +214,7 @@ class FsstEncoder {
       for (size_t i = 0; i < strings.size(); ++i) {
         stringViews.emplace_back(outputPtrs.at(i), outputLengths.at(i));
       }
-      return std::tuple{std::move(outputPtr), std::move(stringViews),
+      return BulkResult{std::move(outputPtr), std::move(stringViews),
                         FsstDecoder(fsst_decoder(encoder))};
     }
   }

--- a/src/util/Generators.h
+++ b/src/util/Generators.h
@@ -84,9 +84,10 @@ CPP_template(typename InputRange, typename AggregatorT,
 // callable that takes a `callback` with signature `void(T)`. The arguments with
 // which this callback is called when running the `functionWithCallback` become
 // the elements that are yielded by the created `generator`.
-template <typename T, typename F>
-InputRangeTypeErased<T> generatorFromActionWithCallback(F functionWithCallback)
-    requires ql::concepts::invocable<F, std::function<void(T)>> {
+CPP_template(typename T, typename F)(
+    requires ql::concepts::invocable<F, std::function<void(T)>>)
+    InputRangeTypeErased<T> generatorFromActionWithCallback(
+        F functionWithCallback) {
   class CallbackToRangeAdapter : public InputRangeFromGet<T> {
     F functionWithCallback_;
     std::mutex mutex_;
@@ -216,4 +217,4 @@ InputRangeTypeErased<T> generatorFromActionWithCallback(F functionWithCallback)
 }
 };  // namespace ad_utility
 
-#endif  // QLEVER_SRC_UTIL_GENERATORS_H
+#endif

--- a/src/util/Generators.h
+++ b/src/util/Generators.h
@@ -217,4 +217,4 @@ CPP_template(typename T, typename F)(
 }
 };  // namespace ad_utility
 
-#endif
+#endif  // QLEVER_SRC_UTIL_GENERATORS_H

--- a/src/util/GeoSparqlHelpers.cpp
+++ b/src/util/GeoSparqlHelpers.cpp
@@ -13,7 +13,6 @@
 #include <cmath>
 #include <ctre-unicode.hpp>
 #include <limits>
-#include <numbers>
 #include <string_view>
 
 #include "global/Constants.h"

--- a/src/util/JoinAlgorithms/IndexNestedLoopJoin.h
+++ b/src/util/JoinAlgorithms/IndexNestedLoopJoin.h
@@ -7,6 +7,7 @@
 
 #include <vector>
 
+#include "JoinAlgorithms.h"
 #include "engine/CallFixedSize.h"
 #include "engine/JoinHelpers.h"
 #include "engine/Result.h"
@@ -268,13 +269,16 @@ class IndexNestedLoopJoin {
     }
     ad_utility::callFixedSizeVi(
         static_cast<int>(joinColumns_.size()),
-        [this, &matchTracker, &leftColumns, &rightColumns](auto JOIN_COLUMNS) {
+        [this, &matchTracker, &leftColumns,
+         &rightColumns](auto JOIN_COLUMNS_PAR) {
+          static constexpr size_t JOIN_COLUMNS =
+              static_cast<size_t>(JOIN_COLUMNS_PAR);
           IdTableView<JOIN_COLUMNS> leftTable =
               leftResult_->idTable()
                   .asColumnSubsetView(leftColumns)
                   .template asStaticView<JOIN_COLUMNS>();
-          auto matchHelper = [&matchTracker, &leftTable, &rightColumns,
-                              &JOIN_COLUMNS](const IdTable& idTable) {
+          auto matchHelper = [&matchTracker, &leftTable,
+                              &rightColumns](const IdTable& idTable) {
             matchLeft(matchTracker, leftTable,
                       idTable.asColumnSubsetView(rightColumns)
                           .template asStaticView<JOIN_COLUMNS>());
@@ -303,7 +307,9 @@ class IndexNestedLoopJoin {
     return ad_utility::callFixedSizeVi(
         static_cast<int>(joinColumns_.size()),
         [this, &matchTracker, yieldOnce, resultWidth, numColsRight,
-         keepJoinColumns](auto JOIN_COLUMNS) -> Result::LazyResult {
+         keepJoinColumns](auto JOIN_COLUMNS_PAR) -> Result::LazyResult {
+          static constexpr auto JOIN_COLUMNS =
+              static_cast<size_t>(JOIN_COLUMNS_PAR);
           const IdTable& leftTable = leftResult_->idTable();
           size_t numColsLeft = leftTable.numColumns();
           ad_utility::JoinColumnMapping joinColumnData{
@@ -311,7 +317,7 @@ class IndexNestedLoopJoin {
           IdTableView<JOIN_COLUMNS> leftTableView =
               leftTable.asColumnSubsetView(joinColumnData.jcsLeft())
                   .template asStaticView<JOIN_COLUMNS>();
-          auto matchHelper = [&matchTracker, &leftTableView, &JOIN_COLUMNS,
+          auto matchHelper = [&matchTracker, &leftTableView,
                               rightColumns = joinColumnData.jcsRight()](
                                  const IdTable& idTable) {
             matchLeft(matchTracker, leftTableView,
@@ -354,7 +360,7 @@ class IndexNestedLoopJoin {
                 leftTable, std::move(rightTables), std::move(matchTracker),
                 resultWidth, std::move(joinColumnData),
                 [leftTableView = std::move(leftTableView),
-                 rightColumns = std::move(rightColumns), JOIN_COLUMNS](
+                 rightColumns = std::move(rightColumns)](
                     detail::Adder& adder, const IdTable& rightTable) {
                   matchLeft(adder, leftTableView,
                             rightTable.asColumnSubsetView(rightColumns)

--- a/src/util/JoinAlgorithms/IndexNestedLoopJoin.h
+++ b/src/util/JoinAlgorithms/IndexNestedLoopJoin.h
@@ -7,7 +7,6 @@
 
 #include <vector>
 
-#include "JoinAlgorithms.h"
 #include "engine/CallFixedSize.h"
 #include "engine/JoinHelpers.h"
 #include "engine/Result.h"
@@ -16,6 +15,7 @@
 #include "util/ChunkedForLoop.h"
 #include "util/CompilerExtensions.h"
 #include "util/Exception.h"
+#include "util/JoinAlgorithms/JoinAlgorithms.h"
 #include "util/JoinAlgorithms/JoinColumnMapping.h"
 
 namespace joinAlgorithms::indexNestedLoop {

--- a/src/util/JoinAlgorithms/JoinAlgorithms.h
+++ b/src/util/JoinAlgorithms/JoinAlgorithms.h
@@ -968,7 +968,15 @@ CPP_template(typename LeftSide, typename RightSide, typename LessThan,
     // TODO<joka921> ql::ranges::lower_bound doesn't work here.
     auto it = std::lower_bound(first.subrange().begin(), first.subrange().end(),
                                currentEl, lessThan_);
-    return std::tuple{std::ref(first.fullBlock()), first.subrange(), it};
+    // 1. Automatic type deduction for `std::tuple{...}` doesn't work on QCC
+    // 2. std::make_tuple has special (undesired in our case) behavior for
+    // `reference_wrapper`....
+    // TODO<joka921> Address this.
+    using RefWrap = decltype(std::ref(first.fullBlock()));
+    using Subr = std::decay_t<decltype(first.subrange())>;
+    using It = decltype(it);
+    return std::tuple<RefWrap, Subr, It>{std::ref(first.fullBlock()),
+                                         first.subrange(), it};
   }
 
   // Check if a side contains undefined values.

--- a/src/util/JoinAlgorithms/JoinAlgorithms.h
+++ b/src/util/JoinAlgorithms/JoinAlgorithms.h
@@ -968,15 +968,9 @@ CPP_template(typename LeftSide, typename RightSide, typename LessThan,
     // TODO<joka921> ql::ranges::lower_bound doesn't work here.
     auto it = std::lower_bound(first.subrange().begin(), first.subrange().end(),
                                currentEl, lessThan_);
-    // 1. Automatic type deduction for `std::tuple{...}` doesn't work on QCC
-    // 2. std::make_tuple has special (undesired in our case) behavior for
-    // `reference_wrapper`....
-    // TODO<joka921> Address this.
-    using RefWrap = decltype(std::ref(first.fullBlock()));
-    using Subr = std::decay_t<decltype(first.subrange())>;
-    using It = decltype(it);
-    return std::tuple<RefWrap, Subr, It>{std::ref(first.fullBlock()),
-                                         first.subrange(), it};
+    // Note: `std::make_tuple` will convert the `reference_wrapper` returned by
+    // `std::ref` into a plain reference as the tuple element.
+    return std::make_tuple(std::ref(first.fullBlock()), first.subrange(), it);
   }
 
   // Check if a side contains undefined values.
@@ -1062,10 +1056,10 @@ CPP_template(typename LeftSide, typename RightSide, typename LessThan,
           if constexpr (left) {
             begL = undefBlock.fullBlock().begin();
             compatibleRowAction_.setInput(undefBlock.fullBlock(),
-                                          fullBlockRight.get());
+                                          fullBlockRight);
           } else {
             begR = undefBlock.fullBlock().begin();
-            compatibleRowAction_.setInput(fullBlockLeft.get(),
+            compatibleRowAction_.setInput(fullBlockLeft,
                                           undefBlock.fullBlock());
           }
           const auto& subr = undefBlock.subrange();
@@ -1075,9 +1069,9 @@ CPP_template(typename LeftSide, typename RightSide, typename LessThan,
 
     auto endCallback = [&, this]() {
       // Reset back to original input.
-      begL = fullBlockLeft.get().begin();
-      begR = fullBlockRight.get().begin();
-      compatibleRowAction_.setInput(fullBlockLeft.get(), fullBlockRight.get());
+      begL = fullBlockLeft.begin();
+      begR = fullBlockRight.begin();
+      compatibleRowAction_.setInput(fullBlockLeft, fullBlockRight);
     };
 
     // TODO<joka921> improve the `CachingTransformInputRange` to make it movable
@@ -1123,14 +1117,14 @@ CPP_template(typename LeftSide, typename RightSide, typename LessThan,
                                       RightBlocks& currentBlocksRight,
                                       const ProjectedEl& currentEl) {
     // Get the first blocks.
-    auto [fullBlockLeft, subrangeLeft, currentElItL] =
+    auto&& [fullBlockLeft, subrangeLeft, currentElItL] =
         getFirstBlock(currentBlocksLeft, currentEl);
-    auto [fullBlockRight, subrangeRight, currentElItR] =
+    auto&& [fullBlockRight, subrangeRight, currentElItR] =
         getFirstBlock(currentBlocksRight, currentEl);
 
-    compatibleRowAction_.setInput(fullBlockLeft.get(), fullBlockRight.get());
-    auto begL = fullBlockLeft.get().begin();
-    auto begR = fullBlockRight.get().begin();
+    compatibleRowAction_.setInput(fullBlockLeft, fullBlockRight);
+    auto begL = fullBlockLeft.begin();
+    auto begR = fullBlockRight.begin();
 
     auto addRowIndex = [&begL, &begR, this](auto itFromL, auto itFromR) {
       AD_EXPENSIVE_CHECK(itFromL >= begL);
@@ -1151,7 +1145,7 @@ CPP_template(typename LeftSide, typename RightSide, typename LessThan,
 
     auto addNotFoundRowIndex = [&]() {
       if constexpr (DoOptionalJoinOrMinus) {
-        return [this, begL = fullBlockLeft.get().begin()](auto itFromL) {
+        return [this, begL = fullBlockLeft.begin()](auto itFromL) {
           AD_CORRECTNESS_CHECK(!hasUndef(rightSide_));
           compatibleRowAction_.addOptionalRow(itFromL - begL);
         };

--- a/src/util/Serializer/TripleSerializer.h
+++ b/src/util/Serializer/TripleSerializer.h
@@ -53,7 +53,7 @@ CPP_template(typename Serializer)(
 CPP_template(typename Serializer)(
     requires serialization::ReadSerializer<
         Serializer>) void readHeader(Serializer& serializer) {
-  std::decay_t<typeof(magicBytes)> magicByteBuffer{};
+  std::decay_t<decltype(magicBytes)> magicByteBuffer{};
   serializer >> magicByteBuffer;
   AD_CORRECTNESS_CHECK(magicByteBuffer == magicBytes);
   uint16_t version;

--- a/src/util/TupleHelpers.h
+++ b/src/util/TupleHelpers.h
@@ -20,7 +20,7 @@ namespace detail {
  */
 template <class F, size_t... I>
 auto setupTupleFromCallableImpl(F&& f, std::index_sequence<I...>) {
-  return std::tuple(f(I)...);
+  return std::make_tuple(f(I)...);
 }
 }  // namespace detail
 
@@ -32,7 +32,7 @@ auto setupTupleFromCallableImpl(F&& f, std::index_sequence<I...>) {
  * @tparam numEntries the size of the tuple to be created
  * @tparam F A function object that takes a single size_t as an argument
  * @param f
- * @return std::tuple(f(0), f(1), f(2), ... f(numEntries - 1));
+ * @return std::make_tuple(f(0), f(1), f(2), ... f(numEntries - 1));
  * @todo<joka921> Can we simplify this implementation via fold expressions etc?
  */
 template <size_t numEntries, class F>
@@ -46,16 +46,17 @@ auto setupTupleFromCallable(F&& f) {
  * @brief convert a parameter pack to a tuple of unique_ptrs that are
  * constructed from the elements of the parameter pack. E.g.
  * toUniquePtrTuple(int(3), std::string("foo")) ==
- * std::tuple(std::make_unique<int>(3), std::make_unique<std::string>("foo")) It
- * can take an arbitrary positive number of arguments. Currently this template
- * is linearly expanded, if this becomes a bottleneck at compile time (e.g. for
- * very long parameter packs) we could do something more intelligent.
- * @return std::tuple(std::make_unique<First>(std::forward<First>(l),
+ * std::make_tuple(std::make_unique<int>(3),
+ * std::make_unique<std::string>("foo")) It can take an arbitrary positive
+ * number of arguments. Currently this template is linearly expanded, if this
+ * becomes a bottleneck at compile time (e.g. for very long parameter packs) we
+ * could do something more intelligent.
+ * @return std::make_tuple(std::make_unique<First>(std::forward<First>(l),
  * std::make_unique<FirstOfRem.....
  */
 template <typename... Rest>
 auto toUniquePtrTuple(Rest&&... rem) {
-  return std::tuple(
+  return std::make_tuple(
       std::make_unique<std::decay_t<Rest>>(std::forward<Rest>(rem))...);
 }
 
@@ -73,8 +74,8 @@ using toUniquePtrTuple_t = decltype(toUniquePtrTuple(std::declval<ts>()...));
  * .get() method e.g. std::tuple<std::unique_ptr<int>,
  * std::shared_ptr<std::string>> or std::array<std::shared_ptr<int>, 42>;
  * @param tuple A tuple/array of type Tuple
- * @return std::tuple(std::get<0>(tuple).get(), std::get<1>(tuple).get(), ...
- * std::get<std::tuple_size_v<Tuple>>(tuple).get());
+ * @return std::make_tuple(std::get<0>(tuple).get(), std::get<1>(tuple).get(),
+ * ... std::get<std::tuple_size_v<Tuple>>(tuple).get());
  */
 template <typename Tuple, bool safe = true>
 auto toRawPtrTuple(Tuple&& tuple) {
@@ -84,7 +85,7 @@ auto toRawPtrTuple(Tuple&& tuple) {
         "You can't pass an rvalue reference to toRawPtrTuple, because "
         "the argument preserves the ownership to the pointers");
   }
-  auto f = [](auto&&... args) { return std::tuple(args.get()...); };
+  auto f = [](auto&&... args) { return std::make_tuple(args.get()...); };
   return std::apply(f, tuple);  // std::forward<Tuple>(tuple));
 }
 

--- a/src/util/TypeTraits.h
+++ b/src/util/TypeTraits.h
@@ -283,7 +283,7 @@ inline auto visitWithVariantsAndParameters =
 template <typename Function, typename Tuple>
 auto applyFunctionToEachElementOfTuple(Function&& f, Tuple&& tuple) {
   auto transformer = [f = std::forward<Function>(f)](auto&&... args) {
-    return std::tuple{f(AD_FWD(args))...};
+    return std::make_tuple(f(AD_FWD(args))...);
   };
   return std::apply(transformer, std::forward<Tuple>(tuple));
 }

--- a/src/util/http/CMakeLists.txt
+++ b/src/util/http/CMakeLists.txt
@@ -2,8 +2,11 @@ add_subdirectory(HttpParser)
 add_library(mediaTypes MediaTypes.h MediaTypes.cpp)
 target_compile_options(mediaTypes PUBLIC -Wno-attributes)
 qlever_target_link_libraries(mediaTypes util)
+
+if (NOT REDUCED_FEATURE_SET_FOR_CPP17)
 add_library(http HttpServer.h HttpServer.cpp HttpClient.h HttpClient.cpp HttpUtils.h HttpUtils.cpp UrlParser.h UrlParser.cpp "HttpParser/AcceptHeaderQleverVisitor.h"
         websocket/WebSocketSession.cpp websocket/MessageSender.cpp websocket/QueryToSocketDistributor.cpp
         websocket/QueryHub.cpp websocket/UpdateFetcher.cpp)
 
 qlever_target_link_libraries(http parser util mediaTypes httpParser OpenSSL::SSL OpenSSL::Crypto)
+endif()

--- a/test/libqlever/QleverTest.cpp
+++ b/test/libqlever/QleverTest.cpp
@@ -21,7 +21,7 @@ TEST(LibQlever, buildIndexAndRunQuery) {
   }
 
   IndexBuilderConfig c;
-  c.inputFiles_.emplace_back(filename, Filetype::Turtle);
+  c.inputFiles_.push_back({filename, Filetype::Turtle});
   c.baseName_ = "testIndexForLibQlever";
 
   // Test the activation of the memory limit


### PR DESCRIPTION
1. Replace `if constexpr` with `QL_CONSTEXPR` macro where GCC 8.3 miscompiles
2. Replace lazy range pipelines with eager evaluation using `absl::InlinedVector` for GCC 8.3
3. Explicitly implement move constructors instead of defaulting due to older Boost `noexcept` issues
4. Replace brace-initialized tuple returns with `std::make_tuple`
5. Replace `emplace_back` with `push_back({...})` for aggregate initialization
6. Replace defaulted comparison operators with explicit implementations
7. Add default constructors for types used with `bit_cast` in C++17 mode
8. Replace `std::string_view::starts_with` with `ql::starts_with`
9. Remove C++20 header `<numbers>`
10. Add missing `#include <backports/algorithm.h>` headers
11. Replace returns with brace-initialized struct by explicit struct construction
12. Change abbreviated function templates to `CPP_template` macro
13. Extract `constexpr` values from lambda captures to `static constexpr` variables
14. Replace structured binding references with universal references for GCC 8
15. Replace `typeof` with `decltype` for C++11 compliance
16. Add conditional compilation to exclude HTTP server components in C++17 builds
17. Explicitly convert string literals to `std::string_view` in tuple construction