### PR TITLE
Fix cache key for text index scans

### DIFF
--- a/src/engine/TextIndexScanForEntity.cpp
+++ b/src/engine/TextIndexScanForEntity.cpp
@@ -138,7 +138,8 @@ std::string TextIndexScanForEntity::getCacheKeyImpl() const {
   std::ostringstream os;
   os << "ENTITY INDEX SCAN FOR WORD: "
      << " with word: \"" << config_.word_ << "\" and fixed-entity: \""
-     << (hasFixedEntity() ? fixedEntity() : "no fixed-entity") << " \"";
+     << (hasFixedEntity() ? fixedEntity() : "no fixed-entity")
+     << "\", has variable: " << config_.scoreVar_.has_value();
   return std::move(os).str();
 }
 

--- a/src/engine/TextIndexScanForWord.cpp
+++ b/src/engine/TextIndexScanForWord.cpp
@@ -116,7 +116,8 @@ std::string TextIndexScanForWord::getDescriptor() const {
 std::string TextIndexScanForWord::getCacheKeyImpl() const {
   std::ostringstream os;
   os << "WORD INDEX SCAN: "
-     << " with word: \"" << config_.word_ << "\"";
+     << " with word: \"" << config_.word_
+     << "\", has variable: " << config_.scoreVar_.has_value();
   return std::move(os).str();
 }
 

--- a/test/engine/TextIndexScanForEntityTest.cpp
+++ b/test/engine/TextIndexScanForEntityTest.cpp
@@ -151,6 +151,12 @@ TEST(TextIndexScanForEntity, CacheKeys) {
                             "sentences"};
   // Same text var, same fixed entity, different words
   ASSERT_NE(s7.getCacheKeyImpl(), s8.getCacheKeyImpl());
+
+  auto copy = s1.getConfig();
+  copy.scoreVar_ = std::nullopt;
+  TextIndexScanForEntity s9{qec, copy};
+  EXPECT_NE(s1.getResultWidth(), s9.getResultWidth());
+  EXPECT_NE(s1.getCacheKeyImpl(), s9.getCacheKeyImpl());
 }
 
 TEST(TextIndexScanForEntity, KnownEmpty) {

--- a/test/engine/TextIndexScanForWordTest.cpp
+++ b/test/engine/TextIndexScanForWordTest.cpp
@@ -444,6 +444,19 @@ TEST(TextIndexScanForWord, CacheKey) {
   ASSERT_NE(s3.getCacheKeyImpl(), s5.getCacheKeyImpl());
   // Different text variables, same words (both without prefix)
   ASSERT_EQ(s4.getCacheKeyImpl(), s5.getCacheKeyImpl());
+
+  auto copy = s1.getConfig();
+  // Prefix config should be overwritten so this returns the same operation.
+  copy.isPrefix_ = !copy.isPrefix_;
+  TextIndexScanForWord s6{qec, copy};
+  EXPECT_EQ(s1.getResultWidth(), s6.getResultWidth());
+  EXPECT_EQ(s1.getCacheKeyImpl(), s6.getCacheKeyImpl());
+
+  copy = s1.getConfig();
+  copy.scoreVar_ = std::nullopt;
+  TextIndexScanForWord s7{qec, copy};
+  EXPECT_NE(s1.getResultWidth(), s7.getResultWidth());
+  EXPECT_NE(s1.getCacheKeyImpl(), s7.getCacheKeyImpl());
 }
 
 TEST(TextIndexScanForWord, KnownEmpty) {


### PR DESCRIPTION
So far, the cache key for a text index scan was the same with and without score variable. The bit whether there is a score variable or not is now part of the cache key. Fixes #2528