### PR TITLE
Only buffer single payload for WebSocket communication

### DIFF
--- a/src/util/http/websocket/QueryToSocketDistributor.cpp
+++ b/src/util/http/websocket/QueryToSocketDistributor.cpp
@@ -48,7 +48,8 @@ void QueryToSocketDistributor::addQueryStatusUpdate(std::string payload) {
   // reasoning much simpler.
   auto impl = [self = shared_from_this(),
                sharedPayload = std::move(sharedPayload)]() mutable {
-    self->data_.push_back(std::move(sharedPayload));
+    self->data_ = std::move(sharedPayload);
+    self->currentIndex_++;
     self->wakeUpWaitingListeners();
   };
   AD_CONTRACT_CHECK(!finished_.test());
@@ -68,21 +69,23 @@ void QueryToSocketDistributor::signalEnd() {
 }
 
 // _____________________________________________________________________________
-net::awaitable<std::shared_ptr<const std::string>>
-QueryToSocketDistributor::waitForNextDataPiece(size_t index) const {
+net::awaitable<std::pair<std::shared_ptr<const std::string>, size_t>>
+QueryToSocketDistributor::waitForNextDataPiece(size_t oldIndex) const {
   AD_CORRECTNESS_CHECK(strand_.running_in_this_thread());
-  if (index < data_.size()) {
-    co_return data_.at(index);
+  if (oldIndex < currentIndex_) {
+    co_return std::make_pair(data_, currentIndex_);
   } else if (finished_.test()) {
-    co_return nullptr;
+    co_return std::make_pair(nullptr, currentIndex_);
   }
 
   co_await waitForUpdate();
 
-  if (index < data_.size()) {
-    co_return data_.at(index);
+  // When `waitForUpdate()` returns, `currentIteration_` might have a different
+  // value.
+  if (oldIndex < currentIndex_) {
+    co_return std::make_pair(data_, currentIndex_);
   } else {
-    co_return nullptr;
+    co_return std::make_pair(nullptr, currentIndex_);
   }
 }
 }  // namespace ad_utility::websocket

--- a/src/util/http/websocket/UpdateFetcher.cpp
+++ b/src/util/http/websocket/UpdateFetcher.cpp
@@ -12,10 +12,9 @@ net::awaitable<UpdateFetcher::PayloadType> UpdateFetcher::waitForEvent() {
   AD_CORRECTNESS_CHECK(distributor_);
   AD_EXPENSIVE_CHECK(strand().running_in_this_thread());
 
-  auto data = co_await distributor_->waitForNextDataPiece(nextIndex_);
-  if (data) {
-    nextIndex_++;
-  }
+  auto [data, latest] =
+      co_await distributor_->waitForNextDataPiece(currentIndex_);
+  currentIndex_ = latest;
   co_return data;
 }
 }  // namespace ad_utility::websocket

--- a/src/util/http/websocket/UpdateFetcher.h
+++ b/src/util/http/websocket/UpdateFetcher.h
@@ -22,7 +22,7 @@ class UpdateFetcher {
   std::shared_ptr<const QueryToSocketDistributor> distributor_ =
       queryHub_.createOrAcquireDistributorForReceiving(queryId_);
   // Counter to ensure sequential processing
-  size_t nextIndex_ = 0;
+  size_t currentIndex_ = 0;
 
  public:
   UpdateFetcher(QueryHub& queryHub, QueryId queryId)

--- a/test/UpdateFetcherTest.cpp
+++ b/test/UpdateFetcherTest.cpp
@@ -28,8 +28,6 @@ ASYNC_TEST(UpdateFetcher, checkIndexIncrements) {
 
   auto impl = [&]() -> net::awaitable<void> {
     auto payload = co_await updateFetcher.waitForEvent();
-    EXPECT_THAT(payload, Pointee("1"s));
-    payload = co_await updateFetcher.waitForEvent();
     EXPECT_THAT(payload, Pointee("2"s));
   };
   co_await net::co_spawn(updateFetcher.strand(), impl, net::use_awaitable);


### PR DESCRIPTION
So far, each payload generated by a single query (the JSON strings with the current runtime information) was stored in the `QueryToSocketDistributor` class and sent one after the other to the consumer. Now only the latest payload is stored and when the other side is slow to consume, intermediate payloads are not sent. This saves network traffic and RAM (though the latter is only significant for complex and long-running queries, which generate many large JSON strings in the course of their processing)