### PR TITLE
Re-add `default-query-timeout` runtime parameter

### DIFF
--- a/src/global/RuntimeParameters.cpp
+++ b/src/global/RuntimeParameters.cpp
@@ -47,6 +47,7 @@ RuntimeParameters::RuntimeParameters() {
   add(spatialJoinPrefilterMaxSize_);
   add(enableDistributiveUnion_);
   add(treatDefaultGraphAsNamedGraph_);
+  add(defaultQueryTimeout_);
 
   defaultQueryTimeout_.setParameterConstraint(
       [](std::chrono::seconds value, std::string_view parameterName) {


### PR DESCRIPTION
When the runtime parameters were refactored in #2376, the `default-query-timeout` parameter was accidentally removed. Now it is there again.