### PR TITLE
Make labeled blank nodes from different files distinct

### DIFF
--- a/src/parser/RdfParser.cpp
+++ b/src/parser/RdfParser.cpp
@@ -813,9 +813,12 @@ bool TurtleParser<T>::blankNodeLabel() {
     // Add a special prefix to ensure that the manually specified blank nodes
     // never interfere with the automatically generated ones. The `substr`
     // removes the leading `_:` which will be added again by the `BlankNode`
-    // constructor.
+    // constructor. We also add the `blankNodePrefix_` to ensure that blank
+    // nodes with the same label from different files are treated as different.
     lastParseResult_ =
-        BlankNode{false, lastParseResult_.getString().substr(2)}.toSparql();
+        BlankNode{false, absl::StrCat(blankNodePrefix_, "_",
+                                      lastParseResult_.getString().substr(2))}
+            .toSparql();
   }
   return res;
 }

--- a/src/parser/RdfParser.h
+++ b/src/parser/RdfParser.h
@@ -370,6 +370,7 @@ class TurtleParser : public RdfParserBase {
   FRIEND_TEST(RdfParserTest, base);
   FRIEND_TEST(RdfParserTest, sparqlBase);
   FRIEND_TEST(RdfParserTest, blankNode);
+  FRIEND_TEST(RdfParserTest, blankNodesUniqueAcrossFiles);
   FRIEND_TEST(RdfParserTest, blankNodePropertyList);
   FRIEND_TEST(RdfParserTest, numericLiteral);
   FRIEND_TEST(RdfParserTest, booleanLiteral);


### PR DESCRIPTION
When the same blank node label (e.g., `_:b1`) appears in different RDF files, they must be treated as distinct blank nodes, which so far, QLever did not do. There was already a distinct blank node prefix for each file, but it was used only for anonymous blank nodes. Now it is also used for labeled blank nodes. Fixes #642