### PR TITLE
Backport remaining generators to C++17

### DIFF
--- a/src/engine/Result.cpp
+++ b/src/engine/Result.cpp
@@ -104,9 +104,11 @@ Result::Result(IdTableVocabPair pair, std::vector<ColumnIndex> sortedBy)
     : Result{std::move(pair.idTable_), std::move(sortedBy),
              std::move(pair.localVocab_)} {}
 
+#ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
 // _____________________________________________________________________________
 Result::Result(Generator idTables, std::vector<ColumnIndex> sortedBy)
     : Result{LazyResult{std::move(idTables)}, std::move(sortedBy)} {}
+#endif
 
 // _____________________________________________________________________________
 Result::Result(LazyResult idTables, std::vector<ColumnIndex> sortedBy)

--- a/src/engine/Result.h
+++ b/src/engine/Result.h
@@ -38,12 +38,18 @@ class Result {
         : idTable_{std::move(idTable)}, localVocab_{std::move(localVocab)} {}
   };
 
-  // The current implementation of (most of the) lazy results. Will be replaced
-  // in the future to make QLever compatible with C++17 again.
-  using Generator = cppcoro::generator<IdTableVocabPair>;
   // The lazy result type that is actually stored. It is type-erased and allows
   // explicit conversion from the `Generator` above.
   using LazyResult = ad_utility::InputRangeTypeErased<IdTableVocabPair>;
+
+  // The current implementation of some lazy results that have not (yet) been
+  // ported to C++17 .
+#ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
+  using Generator = cppcoro::generator<IdTableVocabPair>;
+#else
+  // This typedef avoids some ugly `#ifdef`s in the remaining codebase.
+  using Generator = LazyResult;
+#endif
 
   // A commonly used LoopControl type for CachingContinuableTransformInputRange
   // generators
@@ -136,7 +142,9 @@ class Result {
   Result(std::shared_ptr<const IdTable> idTablePtr,
          std::vector<ColumnIndex> sortedBy, LocalVocab&& localVocab);
   Result(IdTableVocabPair pair, std::vector<ColumnIndex> sortedBy);
+#ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
   Result(Generator idTables, std::vector<ColumnIndex> sortedBy);
+#endif
   Result(LazyResult idTables, std::vector<ColumnIndex> sortedBy);
 
   // Prevent accidental copying of a result table.

--- a/src/engine/sparqlExpressions/PrefilterExpressionIndex.cpp
+++ b/src/engine/sparqlExpressions/PrefilterExpressionIndex.cpp
@@ -516,8 +516,8 @@ RelationalExpression<Comparison>::logicalComplement() const {
   // (4) ?var > referenceValue -> ?var <= referenceValue
   // (5) ?var = referenceValue -> ?var != referenceValue
   // (6) ?var != referenceValue -> ?var = referenceValue
-  constexpr ConstexprMap<CompOp, CompOp, 6> complementMap(
-      {P{LT, GE}, P{LE, GT}, P{GE, LT}, P{GT, LE}, P{EQ, NE}, P{NE, EQ}});
+  constexpr ConstexprMap<CompOp, CompOp, 6> complementMap(std::array<P, 6>{
+      P{LT, GE}, P{LE, GT}, P{GE, LT}, P{GT, LE}, P{EQ, NE}, P{NE, EQ}});
   return make<RelationalExpression<complementMap.at(Comparison)>>(
       rightSideReferenceValue_);
 }
@@ -1025,7 +1025,8 @@ std::vector<PrefilterExprVariablePair> makePrefilterExpressionVec(
     // procedure will transform the relational expression
     // `referenceValue > ?var` into `?var < referenceValue`.
     constexpr ad_utility::ConstexprMap<CompOp, CompOp, 6> mirrorMap(
-        {P{LT, GT}, P{LE, GE}, P{GE, LE}, P{GT, LT}, P{EQ, EQ}, P{NE, NE}});
+        std::array<P, 6>{P{LT, GT}, P{LE, GE}, P{GE, LE}, P{GT, LT}, P{EQ, EQ},
+                         P{NE, NE}});
     resVec.emplace_back(
         makePrefilterExpressionVecImpl<mirrorMap.at(comparison)>(
             referenceValue, prefilterDateByYear),

--- a/src/index/CompressedRelation.h
+++ b/src/index/CompressedRelation.h
@@ -17,7 +17,6 @@
 #include "parser/data/LimitOffsetClause.h"
 #include "util/CancellationHandle.h"
 #include "util/File.h"
-#include "util/Generator.h"
 #include "util/MemorySize/MemorySize.h"
 #include "util/Serializer/SerializeArrayOrTuple.h"
 #include "util/Serializer/SerializeOptional.h"
@@ -623,12 +622,6 @@ class CompressedRelationReader {
     void aggregate(const LazyScanMetadata& newValue);
   };
 
-  // TODO: other modules are using this so, it was left untouched, should be
-  // removed when they migrate to ranges
-  using IdTableGenerator = cppcoro::generator<IdTable, LazyScanMetadata>;
-
-  // TODO: rename to IdTableGenerator when other modules will migrate to non
-  // coro
   using IdTableGeneratorInputRange =
       ad_utility::InputRangeTypeErased<IdTable, LazyScanMetadata>;
 

--- a/src/util/Generator.h
+++ b/src/util/Generator.h
@@ -17,7 +17,17 @@
 #include "backports/type_traits.h"
 #include "util/Exception.h"
 
+#endif  // QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
+
 namespace cppcoro {
+
+// This struct is used as the default of the details object for the case that
+// there are no details (see below).
+// It is also used by some generator-free input range abstractions, hence we
+// define it oudside the #ifdef.
+struct NoDetails {};
+
+#ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
 // This struct can be `co_await`ed inside a `generator` to obtain a reference to
 // the details object (the value of which is a template parameter to the
 // generator). For an example see `GeneratorTest.cpp`.
@@ -32,10 +42,6 @@ template <typename Details>
 struct SetDetails {
   Details details_;
 };
-
-// This struct is used as the default of the details object for the case that
-// there are no details
-struct NoDetails {};
 
 template <typename T, typename Details = NoDetails>
 class generator;
@@ -343,11 +349,7 @@ T getSingleElement(generator<T, Details> g) {
   AD_CORRECTNESS_CHECK(++it == g.end());
   return t;
 }
+#endif  // QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
 }  // namespace cppcoro
-#else
-namespace cppcoro {
-struct NoDetails {};
-}  // namespace cppcoro
-#endif
 
-#endif
+#endif  // CPPCORO_GENERATOR_HPP_INCLUDED

--- a/src/util/Generator.h
+++ b/src/util/Generator.h
@@ -5,6 +5,8 @@
 #ifndef CPPCORO_GENERATOR_HPP_INCLUDED
 #define CPPCORO_GENERATOR_HPP_INCLUDED
 
+#ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
+
 #include <coroutine>
 #include <exception>
 #include <utility>
@@ -342,5 +344,10 @@ T getSingleElement(generator<T, Details> g) {
   return t;
 }
 }  // namespace cppcoro
+#else
+namespace cppcoro {
+struct NoDetails {};
+}  // namespace cppcoro
+#endif
 
 #endif


### PR DESCRIPTION
1. Guard `cppcoro::generator` with `#ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17` in `util/Generator.h`
2. Move `cppcoro::NoDetails` outside the guard (needed by generator-free input range abstractions)
3. Define `Result::Generator` as `LazyResult` in C++17 mode to avoid `#ifdef`s in consuming code
4. Guard `Result(Generator, ...)` constructor with `#ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17`
5. Remove unused `IdTableGenerator` typedef from `CompressedRelation.h`
6. Remove `#include "util/Generator.h"` from `CompressedRelation.h`
7. Add explicit `std::array` for `ConstexprMap` initialization in `PrefilterExpressionIndex.cpp`