### PR TITLE
Generic read and write serializer from given serialization function

### DIFF
--- a/src/util/Serializer/FromCallableSerializer.h
+++ b/src/util/Serializer/FromCallableSerializer.h
@@ -1,0 +1,47 @@
+// Copyright 2025 The QLever Authors, in particular:
+//
+// 2025 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#ifndef QLEVER_SRC_UTIL_SERIALIZERFROMCALLABLESERIALIZER_H
+#define QLEVER_SRC_UTIL_SERIALIZERFROMCALLABLESERIALIZER_H
+
+#include "backports/concepts.h"
+#include "util/Serializer/Serializer.h"
+
+namespace ad_utility::serialization {
+// A serializer, that lifts a callable (that will become the `serializeBytes`
+// function, to a fully blown `ReadSerializer`, that can be used within the
+// serialization framework.
+CPP_template(typename F)(requires ql::concepts::invocable<
+                         F, char*, size_t>) class ReadViaCallableSerializer {
+ public:
+  using SerializerType = ReadSerializerTag;
+
+ private:
+  ::ranges::semiregular_box<F> readFunction_;
+
+ public:
+  // Construct from the `readFunction`.
+  explicit ReadViaCallableSerializer(F readFunction)
+      : readFunction_{std::move(readFunction)} {};
+
+  // The main serialization function, simply delegates to the `readFunction_`.
+  void serializeBytes(char* bytePointer, size_t numBytes) {
+    readFunction_(bytePointer, numBytes);
+  }
+
+  // Serializers are move-only types.
+  ReadViaCallableSerializer(const ReadViaCallableSerializer&) = delete;
+  ReadViaCallableSerializer& operator=(const ReadViaCallableSerializer&) =
+      delete;
+  ReadViaCallableSerializer(ReadViaCallableSerializer&&) = default;
+  ReadViaCallableSerializer& operator=(ReadViaCallableSerializer&&) = default;
+};
+}  // namespace ad_utility::serialization
+
+#endif  // QLEVER_SRC_UTIL_SERIALIZERFROMCALLABLESERIALIZER_H

--- a/src/util/Serializer/FromCallableSerializer.h
+++ b/src/util/Serializer/FromCallableSerializer.h
@@ -49,6 +49,43 @@ CPP_template(typename ReadFunction)(
   ReadViaCallableSerializer(ReadViaCallableSerializer&&) = default;
   ReadViaCallableSerializer& operator=(ReadViaCallableSerializer&&) = default;
 };
+
+// A serializer that lifts a simple callable (called the `WriteFunction`) to a
+// fully blown `WriteSerializer`. The `WriteFunction` has two arguments, a
+// `const char*` (the source to read from), and a `size_t` (the number of bytes
+// to serialize from the source). The semantics of the `WriteFunction` are
+// "write `numBytes` bytes from the source to the sink that is represented by
+// the `WriteFunction`. An example for a
+// `WriteFunction` is a lambda that captures a network stream, and writes to
+// that stream in its `operator()`.
+CPP_template(typename WriteFunction)(
+    requires ql::concepts::invocable<WriteFunction, const char*,
+                                     size_t>) class WriteViaCallableSerializer {
+ public:
+  using SerializerType = WriteSerializerTag;
+
+ private:
+  // The `semiregular_box` adds the move-assignment operator in case the
+  // `WriteFunction` is a lambda.
+  ::ranges::semiregular_box<WriteFunction> writeFunction_;
+
+ public:
+  // Construct from the `writeFunction` (see above for details).
+  explicit WriteViaCallableSerializer(WriteFunction writeFunction)
+      : writeFunction_{std::move(writeFunction)} {};
+
+  // The main serialization function, simply delegates to the `writeFunction_`.
+  void serializeBytes(const char* bytePointer, size_t numBytes) {
+    writeFunction_(bytePointer, numBytes);
+  }
+
+  // Serializers are move-only types.
+  WriteViaCallableSerializer(const WriteViaCallableSerializer&) = delete;
+  WriteViaCallableSerializer& operator=(const WriteViaCallableSerializer&) =
+      delete;
+  WriteViaCallableSerializer(WriteViaCallableSerializer&&) = default;
+  WriteViaCallableSerializer& operator=(WriteViaCallableSerializer&&) = default;
+};
 }  // namespace ad_utility::serialization
 
 #endif  // QLEVER_SRC_UTIL_SERIALIZERFROMCALLABLESERIALIZER_H

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -230,7 +230,7 @@ addAndLinkTest(SortPerformanceEstimatorTest SortPerformanceEstimator)
 # cases are run in parallel. This should be fixed by using distinct filenames
 # for each test case.
 # TODO<qup42, joka921> fix this
-addLinkAndDiscoverTestSerial(SerializerTest)
+addLinkAndDiscoverTestNoLibs(SerializerTest)
 
 addLinkAndDiscoverTestNoLibs(ParametersTest)
 

--- a/test/SerializerTest.cpp
+++ b/test/SerializerTest.cpp
@@ -31,6 +31,7 @@ using ad_utility::serialization::ReadSerializer;
 using ad_utility::serialization::ReadViaCallableSerializer;
 using ad_utility::serialization::Serializer;
 using ad_utility::serialization::WriteSerializer;
+using ad_utility::serialization::WriteViaCallableSerializer;
 
 // The following tests are also examples for the serialization module and for
 // several pitfalls.
@@ -243,10 +244,13 @@ auto testWithByteBuffer = [](auto testFunction) {
 };
 
 auto testWithCallableSerializer = [](auto testFunction) {
-  ByteBufferWriteSerializer writer;
   std::vector<char> buffer;
-  auto makeReaderFromWriter = [&writer, &buffer]() {
-    buffer = std::move(writer).data();
+  auto write = [&buffer](const char* source, size_t numBytes) {
+    buffer.insert(buffer.end(), source, source + numBytes);
+  };
+
+  WriteViaCallableSerializer writer{write};
+  auto makeReaderFromWriter = [&buffer]() {
     auto read = [pos = 0ul, &buffer](char* target, size_t numBytes) mutable {
       std::copy(buffer.begin() + pos, buffer.begin() + pos + numBytes, target);
       pos += numBytes;


### PR DESCRIPTION
Two classes for lifting a `ReadFunction` (which reads a given number of `char`s) to a `ReadSerializer` and a `WriteFunction` (which writes a given number of `char`s) to a `WriteSerializer`. This is preparation for an efficient binary export and import of `SERVICE` results