### PR TITLE
Backport code in `ConstexprMap` and related files to C++17

### DIFF
--- a/src/parser/ParsedQuery.cpp
+++ b/src/parser/ParsedQuery.cpp
@@ -342,11 +342,11 @@ bool ParsedQuery::GraphPattern::addLanguageFilter(
 
     std::vector<BasicGraphPattern> operations;
     for (const auto& langTag : langTags) {
-      operations.emplace_back(std::vector{SparqlTriple{
+      operations.push_back({std::vector{SparqlTriple{
           variable,
           PropertyPath::fromIri(ad_utility::triple_component::Iri::fromIriref(
               LANGUAGE_PREDICATE)),
-          ad_utility::convertLangtagToEntityUri(langTag)}});
+          ad_utility::convertLangtagToEntityUri(langTag)}}});
     }
 
     // Optimization if there already is a `BasicGraphPattern` we can use.

--- a/src/util/ConstexprMap.h
+++ b/src/util/ConstexprMap.h
@@ -5,17 +5,25 @@
 #ifndef QLEVER_CONSTEXPRMAP_H
 #define QLEVER_CONSTEXPRMAP_H
 
-#include <boost/hana/tuple.hpp>
 #include <stdexcept>
+#include <utility>
 
 #include "backports/algorithm.h"
 
 namespace ad_utility {
 
 // The type used to store `key, value` pairs inside the `ConstexprMap` below.
-// We use `boost::hana::pair` because it is `constexpr` in C++17.
+// We cannot use `std::pair` or `std::tuple`, because they are not constexpr in
+// C++17. We also cannot use `boost::hana::pair` as it has a strange bug in
+// C++17 on GCC 8.3 (Wrong behavior in constexpr mode, correct behavior if the
+// `constexpr` keyword is removed.
 template <typename Key, typename Value>
-using ConstexprMapPair = boost::hana::pair<Key, Value>;
+struct ConstexprMapPair {
+  Key key_;
+  Value value_;
+  constexpr ConstexprMapPair(Key key, Value value)
+      : key_{std::move(key)}, value_{std::move(value)} {}
+};
 
 /// A const and constexpr map from `Key`s to `Value`s.
 template <typename Key, typename Value, size_t numEntries>
@@ -32,8 +40,8 @@ class ConstexprMap {
   // Create from an Array of key-value pairs. The keys have to be unique.
   explicit constexpr ConstexprMap(Arr values) : _values{std::move(values)} {
     ql::ranges::sort(_values, compare);
-    if (::ranges::adjacent_find(_values, std::equal_to<>{},
-                                boost::hana::first) != _values.end()) {
+    if (::ranges::adjacent_find(_values, std::equal_to<>{}, &Pair::key_) !=
+        _values.end()) {
       throw std::runtime_error{
           "ConstexprMap requires that all the keys are unique"};
     }
@@ -42,9 +50,8 @@ class ConstexprMap {
   // If `key` is in the map, return an iterator to the corresponding `(Key,
   // Value)` pair. Else return `end()`.
   constexpr typename Arr::const_iterator find(const Key& key) const {
-    auto lb = ql::ranges::lower_bound(_values, key, std::less<>{},
-                                      boost::hana::first);
-    if (lb == _values.end() || boost::hana::first(*lb) != key) {
+    auto lb = ql::ranges::lower_bound(_values, key, std::less<>{}, &Pair::key_);
+    if (lb == _values.end() || lb->key_ != key) {
       return _values.end();
     }
     return lb;
@@ -62,12 +69,12 @@ class ConstexprMap {
     if (it == _values.end()) {
       throw std::out_of_range{"Key was not found in map"};
     }
-    return boost::hana::second(*it);
+    return it->value_;
   }
 
  private:
   static constexpr auto compare = [](const Pair& a, const Pair& b) {
-    return boost::hana::first(a) < boost::hana::first(b);
+    return a.key_ < b.key_;
   };
 };
 

--- a/src/util/ConstexprMap.h
+++ b/src/util/ConstexprMap.h
@@ -32,6 +32,14 @@ class ConstexprMap {
   using Pair = ConstexprMapPair<Key, Value>;
   using Arr = std::array<Pair, numEntries>;
 
+  // A lambda to obtain the `key_` from a `pair`.
+  // Note: We cannot simply use the pointer-to-member `&Pair::key_`, because
+  // then the `ConstexprMap` for some reason is not `constexpr` anymore on
+  // `GCC 8.3`.
+  static constexpr auto getKey = [](const auto& pair) -> const auto& {
+    return pair.key_;
+  };
+
  private:
   // TODO make const
   Arr _values;

--- a/src/util/Log.h
+++ b/src/util/Log.h
@@ -109,7 +109,7 @@ class Log {
   template <LogLevel LEVEL>
   static QL_CONSTEVAL std::string_view getLevel() {
     using P = ConstexprMapPair<LogLevel, std::string_view>;
-    constexpr ConstexprMap map{std::array{
+    constexpr ConstexprMap map{std::array<P, 7>{
         P(TRACE, "TRACE: "),
         P(TIMING, "TIMING: "),
         P(DEBUG, "DEBUG: "),

--- a/src/util/MmapVectorImpl.h
+++ b/src/util/MmapVectorImpl.h
@@ -323,7 +323,7 @@ void MmapVector<T>::advise(AccessPattern pattern) {
   // systems, in particular they are not present on the `QNX` platform which
   // we target with the `REDUCED_FEATURE_SET` mode. Therefore, we simply disable
   // the following `madvise` calls, as they only are hints to the runtime and
-  // have no directly observable behavior.
+  // do not change the program semantics.
 #ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
   switch (pattern) {
     case AccessPattern::Sequential:

--- a/src/util/MmapVectorImpl.h
+++ b/src/util/MmapVectorImpl.h
@@ -319,6 +319,12 @@ MmapVector<T>& MmapVector<T>::operator=(MmapVector<T>&& other) noexcept {
 // ________________________________________________________________
 template <class T>
 void MmapVector<T>::advise(AccessPattern pattern) {
+  // The constants `MADV_SEQUENTIAL` etc. don't seem to be present on all POSIX
+  // systems, in particular they are not present on the `QNX` platform which
+  // we target with the `REDUCED_FEATURE_SET` mode. Therefore, we simply disable
+  // the following `madvise` calls, as they only are hints to the runtime and
+  // have no directly observable behavior.
+#ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
   switch (pattern) {
     case AccessPattern::Sequential:
       madvise(static_cast<void*>(_ptr), _bytesize, MADV_SEQUENTIAL);
@@ -330,6 +336,9 @@ void MmapVector<T>::advise(AccessPattern pattern) {
       madvise(static_cast<void*>(_ptr), _bytesize, MADV_NORMAL);
       break;
   }
+#else
+  (void)pattern;
+#endif
 }
 
 // ________________________________________________________________

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -484,3 +484,5 @@ addLinkAndDiscoverTest(TimeTracerTest)
 addLinkAndDiscoverTestNoLibs(SourceLocationTest)
 
 addLinkAndDiscoverTest(UnitOfMeasurementTest util)
+
+addLinkAndDiscoverTestNoLibs(ConstexprMapTest)

--- a/test/ConstexprMapTest.cpp
+++ b/test/ConstexprMapTest.cpp
@@ -1,0 +1,44 @@
+// Copyright 2021 - 2025 The QLever Authors, in particular:
+//
+// 2025 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#include <gmock/gmock.h>
+
+#include "./util/GTestHelpers.h"
+#include "util/ConstexprMap.h"
+
+using namespace ad_utility;
+
+// _____________________________________________________________________________
+TEST(ConstexprMap, AllTests) {
+  using P = ConstexprMapPair<int, int>;
+  ad_utility::ConstexprMap map{std::array{P{3, 36}, P{1, 3}}};
+  ASSERT_EQ(map.at(1), 3);
+  ASSERT_EQ(map.at(3), 36);
+  ASSERT_TRUE(map.contains(1));
+  ASSERT_TRUE(map.contains(3));
+  ASSERT_FALSE(map.contains(2));
+  ASSERT_FALSE(map.contains(4));
+  AD_EXPECT_THROW_WITH_MESSAGE(map.at(4),
+                               ::testing::HasSubstr("was not found"));
+
+  // Now the same tests at compile time.
+  static constexpr ad_utility::ConstexprMap mapC{std::array{P{3, 36}, P{1, 3}}};
+  static_assert(mapC.at(1) == 3);
+  static_assert(mapC.at(3) == 36);
+  static_assert(!mapC.contains(2));
+  static_assert(!mapC.contains(4));
+
+  // The following map throws during construction because it has duplicate keys.
+  auto illegalMap = []() {
+    return ConstexprMap{std::array{P{1, 3}, P{3, 36}, P{1, 5}}};
+  };
+
+  AD_EXPECT_THROW_WITH_MESSAGE(illegalMap(),
+                               ::testing::HasSubstr("all the keys are unique"));
+}

--- a/test/libqlever/QleverTest.cpp
+++ b/test/libqlever/QleverTest.cpp
@@ -113,7 +113,7 @@ TEST(LibQlever, fulltextIndex) {
   }
 
   IndexBuilderConfig c;
-  c.inputFiles_.emplace_back(filename, Filetype::Turtle);
+  c.inputFiles_.push_back({filename, Filetype::Turtle, std::nullopt});
   c.wordsfile_ = wordsfileName;
   c.docsfile_ = docsFileName;
   c.baseName_ = "testIndexForLibQlever";


### PR DESCRIPTION
1. Replace `boost::hana::pair` with custom `ConstexprMapPair` struct (avoids GCC 8.3 `constexpr` bug)
2. Add explicit `std::array<P, 7>` type for `ConstexprMap` initialization in `Log.h`
3. Replace `emplace_back` with `push_back({...})` for aggregate initialization in `ParsedQuery.cpp`
4. Replace `emplace_back` with `push_back` with explicit aggregate in `QleverTest.cpp`
5. Guard `madvise` calls with `#ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17` in `MmapVectorImpl.h` (constants not available on all POSIX systems)