### PR TITLE
Minor fixes and additions to the `Serializer` code

### DIFF
--- a/src/engine/VariableToColumnMap.h
+++ b/src/engine/VariableToColumnMap.h
@@ -40,7 +40,7 @@ struct ColumnIndexAndTypeInfo {
   // Equality comparison, mostly used for testing.
   QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(ColumnIndexAndTypeInfo,
                                               columnIndex_, mightContainUndef_)
-  // Serialization for ColumnIndexAndTypeInfo
+  // Serialization for ColumnIndexAndTypeInfo.
   AD_SERIALIZE_FRIEND_FUNCTION(ColumnIndexAndTypeInfo) {
     serializer | arg.columnIndex_;
     serializer | arg.mightContainUndef_;

--- a/src/engine/VariableToColumnMap.h
+++ b/src/engine/VariableToColumnMap.h
@@ -40,6 +40,11 @@ struct ColumnIndexAndTypeInfo {
   // Equality comparison, mostly used for testing.
   QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(ColumnIndexAndTypeInfo,
                                               columnIndex_, mightContainUndef_)
+  // Serialization for ColumnIndexAndTypeInfo
+  AD_SERIALIZE_FRIEND_FUNCTION(ColumnIndexAndTypeInfo) {
+    serializer | arg.columnIndex_;
+    serializer | arg.mightContainUndef_;
+  }
 };
 
 // Return a `ColumnIndexAndType` info with the given `columnIndex` that is

--- a/src/rdfTypes/Variable.h
+++ b/src/rdfTypes/Variable.h
@@ -106,7 +106,7 @@ class Variable {
   // it at the end of target.
   static void appendEscapedWord(std::string_view word, std::string& target);
 
-  // Serialization for Variable - just serialize the name
+  // Serialization for `Variable`s - just serialize the name.
   AD_SERIALIZE_FRIEND_FUNCTION(Variable) { serializer | arg._name; }
 };
 

--- a/src/rdfTypes/Variable.h
+++ b/src/rdfTypes/Variable.h
@@ -11,6 +11,8 @@
 #include <variant>
 
 #include "backports/three_way_comparison.h"
+#include "util/Serializer/Serializer.h"
+#include "util/Serializer/SerializeString.h"
 
 // Forward declaration because of cyclic dependencies
 // TODO<joka921> The coupling of the `Variable` with its `evaluate` methods
@@ -103,6 +105,9 @@ class Variable {
   // The method escapes all special chars in word to "_ASCIICODE_" and appends
   // it at the end of target.
   static void appendEscapedWord(std::string_view word, std::string& target);
+
+  // Serialization for Variable - just serialize the name
+  AD_SERIALIZE_FRIEND_FUNCTION(Variable) { serializer | arg._name; }
 };
 
 #endif  // QLEVER_SRC_PARSER_DATA_VARIABLE_H

--- a/src/rdfTypes/Variable.h
+++ b/src/rdfTypes/Variable.h
@@ -11,8 +11,8 @@
 #include <variant>
 
 #include "backports/three_way_comparison.h"
-#include "util/Serializer/Serializer.h"
 #include "util/Serializer/SerializeString.h"
+#include "util/Serializer/Serializer.h"
 
 // Forward declaration because of cyclic dependencies
 // TODO<joka921> The coupling of the `Variable` with its `evaluate` methods

--- a/src/util/Serializer/SerializeVector.h
+++ b/src/util/Serializer/SerializeVector.h
@@ -9,9 +9,9 @@
 #include <string>
 #include <vector>
 
-#include "util/TypeTraits.h"
 #include "backports/span.h"
 #include "util/Serializer/Serializer.h"
+#include "util/TypeTraits.h"
 #include "util/Views.h"
 
 namespace ad_utility::serialization {
@@ -51,14 +51,18 @@ AD_SERIALIZE_FUNCTION_WITH_CONSTRAINT((ad_utility::SimilarToSpan<T>)) {
 
   if constexpr (ReadSerializer<S>) {
     if (arg.size() != size) {
-      V v;
+      // The size does not match, we consume the complete `span` into the void
+      // and then throw an exeption.
+      [[maybe_unused]] V dummyForSerializationOnSizeError;
       for ([[maybe_unused]] auto i : ad_utility::integerRange(size)) {
-        serializer | v;
+        serializer | dummyForSerializationOnSizeError;
       }
-    throw std::runtime_error{
-        "To serialize into a span, the span must be properly sized in advance. Note: "
-        "the span with the non-matching size has been consumed from the serializer, "
-        "and can no longer be retrieved."};
+      throw std::runtime_error{
+          "To serialize into a span, the span must be properly sized in "
+          "advance. Note: "
+          "the span with the non-matching size has been consumed from the "
+          "serializer, "
+          "and can no longer be retrieved."};
     }
   }
   if constexpr (TriviallySerializable<V>) {

--- a/src/util/Serializer/SerializeVector.h
+++ b/src/util/Serializer/SerializeVector.h
@@ -9,12 +9,10 @@
 #include <string>
 #include <vector>
 
-#include "../TypeTraits.h"
-#include "./Serializer.h"
-#include "backports/span.h"
-#include "backports/type_traits.h"
-#include "util/Serializer/Serializer.h"
 #include "util/TypeTraits.h"
+#include "backports/span.h"
+#include "util/Serializer/Serializer.h"
+#include "util/Views.h"
 
 namespace ad_utility::serialization {
 AD_SERIALIZE_FUNCTION_WITH_CONSTRAINT(
@@ -39,25 +37,37 @@ AD_SERIALIZE_FUNCTION_WITH_CONSTRAINT(
 }
 
 // Serialization for `ql::span`. When writing to a `span` from a serializer, the
-// span has to have the correct size, else an `AD_CONTRACT_CHECK` will fail.
+// span has to have the correct size, else an exception will be thrown.
+// Note 1: In that case, the serializer behaves as if the span was read, so the
+// contents of the span are lost, but elements following the `span` can still be
+// deserialized.
+// Note 2: To mitigate this issue, it is much safer to deserialize to
+// a `std::vector`, as serializing from a `span` but deserializing to
+// a `vector` works because those types share the same serialization format.
 AD_SERIALIZE_FUNCTION_WITH_CONSTRAINT((ad_utility::SimilarToSpan<T>)) {
   using V = typename std::decay_t<T>::value_type;
   auto size = arg.size();  // The value is ignored for `ReadSerializer`s.
   serializer | size;
 
   if constexpr (ReadSerializer<S>) {
-    AD_CONTRACT_CHECK(
-        arg.size() == size,
+    if (arg.size() != size) {
+      V v;
+      for ([[maybe_unused]] auto i : ad_utility::integerRange(size)) {
+        serializer | v;
+      }
+    throw std::runtime_error{
         "To serialize into a span, the span must be properly sized in advance. Note: "
-        "this invalidates all further serialization from this stream");
+        "the span with the non-matching size has been consumed from the serializer, "
+        "and can no longer be retrieved."};
+    }
   }
   if constexpr (TriviallySerializable<V>) {
     using CharPtr = std::conditional_t<ReadSerializer<S>, char*, const char*>;
     serializer.serializeBytes(reinterpret_cast<CharPtr>(arg.data()),
                               arg.size() * sizeof(V));
   } else {
-    for (size_t i = 0; i < size; ++i) {
-      serializer | arg[i];
+    for (auto& el : arg) {
+      serializer | el;
     }
   }
 }

--- a/src/util/Serializer/SerializeVector.h
+++ b/src/util/Serializer/SerializeVector.h
@@ -52,7 +52,7 @@ AD_SERIALIZE_FUNCTION_WITH_CONSTRAINT((ad_utility::SimilarToSpan<T>)) {
   if constexpr (ReadSerializer<S>) {
     if (arg.size() != size) {
       // The size does not match, we consume the complete `span` into the void
-      // and then throw an exeption.
+      // and then throw an exception.
       [[maybe_unused]] V dummyForSerializationOnSizeError;
       for ([[maybe_unused]] auto i : ad_utility::integerRange(size)) {
         serializer | dummyForSerializationOnSizeError;

--- a/src/util/Serializer/Serializer.h
+++ b/src/util/Serializer/Serializer.h
@@ -209,6 +209,8 @@ struct TrivialSerializationHelperTag {};
  * `ad_utility::serialization` because of the argument-dependent lookup rules.
  * If you want to break the dependencies between your types and this header, you
  * can also define the second parameter to be templated.
+ * Note: In addition to the cases described above, all `enum` types are
+ * implicitly trivially serializable.
  *
  * For example, one can equivalently write one of the following two:
  *
@@ -242,8 +244,9 @@ CPP_requires(
 
 template <typename T>
 CPP_concept TriviallySerializable =
-    CPP_requires_ref(triviallySerializableRequires, T) &&
-    std::is_trivially_copyable_v<std::decay_t<T>>;
+    (CPP_requires_ref(triviallySerializableRequires, T) &&
+     std::is_trivially_copyable_v<std::decay_t<T>>) ||
+    std::is_enum_v<std::decay_t<T>>;
 
 /// Serialize function for `TriviallySerializable` types that works by simply
 /// serializing the binary object representation.

--- a/src/util/Serializer/Serializer.h
+++ b/src/util/Serializer/Serializer.h
@@ -244,9 +244,8 @@ CPP_requires(
 
 template <typename T>
 CPP_concept TriviallySerializable =
-    (CPP_requires_ref(triviallySerializableRequires, T) &&
-     std::is_trivially_copyable_v<std::decay_t<T>>) ||
-    std::is_enum_v<std::decay_t<T>>;
+    CPP_requires_ref(triviallySerializableRequires, T) &&
+    std::is_trivially_copyable_v<std::decay_t<T>>;
 
 /// Serialize function for `TriviallySerializable` types that works by simply
 /// serializing the binary object representation.
@@ -261,10 +260,11 @@ CPP_template(typename S, typename T)(
   }
 }
 
-/// Arithmetic types (the builtins like int, char, double) can be trivially
-/// serialized.
+/// Arithmetic types (the builtins like int, char, double), as well as enums can
+/// be trivially serialized.
 CPP_template(typename T,
-             typename U)(requires std::is_arithmetic_v<std::decay_t<T>>)
+             typename U)(requires(std::is_arithmetic_v<std::decay_t<T>> ||
+                                  std::is_enum_v<std::decay_t<T>>))
     [[maybe_unused]] std::true_type allowTrivialSerialization(T, U) {
   return {};
 }

--- a/src/util/TypeTraits.h
+++ b/src/util/TypeTraits.h
@@ -17,6 +17,7 @@
 #include <vector>
 
 #include "backports/concepts.h"
+#include "backports/span.h"
 #include "backports/type_traits.h"
 #include "util/Forward.h"
 
@@ -145,6 +146,17 @@ constexpr static bool isArray<std::array<T, N>> = true;
 // `SimilarToArray` is also true for `std::array<...>&`, etc.
 template <typename T>
 CPP_concept SimilarToArray = isArray<std::decay_t<T>>;
+
+// Same as `isArray` above, but for `ql::span`.
+template <typename T>
+constexpr static bool isSpan = false;
+
+template <typename T, size_t N>
+constexpr static bool isSpan<ql::span<T, N>> = true;
+
+// `SimilarToSpan` is also true for `ql::span<...>&`, etc.
+template <typename T>
+CPP_concept SimilarToSpan = isSpan<std::decay_t<T>>;
 
 /// Two types are similar, if they are the same when we remove all cv (const or
 /// volatile) qualifiers and all references

--- a/src/util/TypeTraits.h
+++ b/src/util/TypeTraits.h
@@ -158,6 +158,13 @@ constexpr static bool isSpan<ql::span<T, N>> = true;
 template <typename T>
 CPP_concept SimilarToSpan = isSpan<std::decay_t<T>>;
 
+// `static_assert` tests for `isSpan` and `SimilarToSpan`.
+static_assert(isSpan<ql::span<int>>);
+static_assert(isSpan<ql::span<std::string, 37>>);
+static_assert(!isSpan<std::array<int, 3>>);
+static_assert(!isSpan<ql::span<int>&>);
+static_assert(SimilarToSpan<ql::span<int>&>);
+
 /// Two types are similar, if they are the same when we remove all cv (const or
 /// volatile) qualifiers and all references
 template <typename T, typename U>

--- a/test/SerializerTest.cpp
+++ b/test/SerializerTest.cpp
@@ -9,6 +9,7 @@
 #include <gtest/gtest.h>
 
 #include "backports/span.h"
+#include "util/GTestHelpers.h"
 #include "util/MemorySize/MemorySize.h"
 #include "util/Random.h"
 #include "util/Serializer/ByteBufferSerializer.h"
@@ -613,6 +614,56 @@ TEST(VectorIncrementalSerializer, SerializeInTheMiddle) {
 }
 
 // _____________________________________________________________________________
+TEST(Serializer, serializeSpan) {
+  std::vector ints{3, 4, 5, 6};
+  std::vector<std::string> strings{"eins", "zwei", "drei", "vier"};
+  auto intSpan = ql::span{ints}.subspan(1, 2);
+  auto stringSpan = ql::span{strings}.subspan(2, 2);
+  ByteBufferWriteSerializer writer;
+  writer | intSpan;
+  writer | stringSpan;
+  writer | stringSpan;
+  writer | stringSpan;
+  writer | stringSpan;
+
+  auto buffer = std::move(writer).data();
+  ByteBufferReadSerializer reader(buffer);
+  {
+    std::vector<int> intResult;
+    intResult.resize(2);
+    // Read into a span of the correct size, trivially serializable
+    // `value_type`.
+    reader | ql::span{intResult};
+    EXPECT_THAT(intResult, ::testing::ElementsAre(4, 5));
+  }
+
+  {
+    std::vector<std::string> stringResult;
+    stringResult.resize(2);
+    // Read into a span of the correct size, nontrivially serializable
+    // `value_type`.
+    reader | ql::span{stringResult};
+    EXPECT_THAT(stringResult, ::testing::ElementsAre("drei", "vier"));
+  }
+
+  std::vector<std::string> stringsWithWrongSize;
+  {
+    // The writing was done via a `span`, but we now read into a `vector`.
+    // This works even if the vector is not resized in advance, because the
+    // vector deserialization will do the resize.
+    EXPECT_NO_THROW(reader | stringsWithWrongSize);
+    EXPECT_THAT(stringsWithWrongSize, ::testing::ElementsAre("drei", "vier"));
+  }
+
+    stringsWithWrongSize.clear();
+  // Deserialize into a `span` that doesn't have the correct size. This throws
+  // an exception and renders the serialization stream unusable (that's why we
+  // have this test last).
+  AD_EXPECT_THROW_WITH_MESSAGE(reader | ql::span{stringsWithWrongSize},
+                               ::testing::HasSubstr("must be properly sized"));
+}
+
+// _____________________________________________________________________________
 TEST(Serializer, serializeOptional) {
   std::optional<std::string> s = "hallo";
   std::optional<std::string> nil = std::nullopt;
@@ -626,6 +677,25 @@ TEST(Serializer, serializeOptional) {
   reader >> nilExpected;
   EXPECT_THAT(sExpected, ::testing::Optional(std::string("hallo")));
   EXPECT_EQ(nilExpected, std::nullopt);
+}
+
+// _____________________________________________________________________________
+TEST(Serializer, serializeEnum) {
+  // Enums are implicitly serializable without any additional code.
+  enum E {a, b, c};
+  enum struct F {d, e, f};
+
+  ByteBufferWriteSerializer writer;
+  writer << b;
+  writer << F::f;
+
+  ByteBufferReadSerializer reader(std::move(writer).data());
+  E e;
+  F f;
+  reader | e;
+  reader | f;
+  EXPECT_EQ(e, E::b);
+  EXPECT_EQ(f, F::f);
 }
 
 // _____________________________________________________________________________

--- a/test/SerializerTest.cpp
+++ b/test/SerializerTest.cpp
@@ -647,6 +647,10 @@ TEST(Serializer, serializeSpan) {
   }
 
   std::vector<std::string> stringsWithWrongSize;
+  // Deserialize into a `span` that doesn't have the correct size. This throws
+  // an exception and skips the span.
+  AD_EXPECT_THROW_WITH_MESSAGE(reader | ql::span{stringsWithWrongSize},
+                               ::testing::HasSubstr("must be properly sized"));
   {
     // The writing was done via a `span`, but we now read into a `vector`.
     // This works even if the vector is not resized in advance, because the
@@ -655,12 +659,6 @@ TEST(Serializer, serializeSpan) {
     EXPECT_THAT(stringsWithWrongSize, ::testing::ElementsAre("drei", "vier"));
   }
 
-    stringsWithWrongSize.clear();
-  // Deserialize into a `span` that doesn't have the correct size. This throws
-  // an exception and renders the serialization stream unusable (that's why we
-  // have this test last).
-  AD_EXPECT_THROW_WITH_MESSAGE(reader | ql::span{stringsWithWrongSize},
-                               ::testing::HasSubstr("must be properly sized"));
 }
 
 // _____________________________________________________________________________

--- a/test/SerializerTest.cpp
+++ b/test/SerializerTest.cpp
@@ -658,7 +658,6 @@ TEST(Serializer, serializeSpan) {
     EXPECT_NO_THROW(reader | stringsWithWrongSize);
     EXPECT_THAT(stringsWithWrongSize, ::testing::ElementsAre("drei", "vier"));
   }
-
 }
 
 // _____________________________________________________________________________
@@ -680,8 +679,8 @@ TEST(Serializer, serializeOptional) {
 // _____________________________________________________________________________
 TEST(Serializer, serializeEnum) {
   // Enums are implicitly serializable without any additional code.
-  enum E {a, b, c};
-  enum struct F {d, e, f};
+  enum E { a, b, c };
+  enum struct F { d, e, f };
 
   ByteBufferWriteSerializer writer;
   writer << b;

--- a/test/TypeTraitsTest.cpp
+++ b/test/TypeTraitsTest.cpp
@@ -431,10 +431,3 @@ TEST(TypeTraits, getInvokeResultImpl) {
       (std::is_same_v<typename decltype(tp2)::type,
                       InvalidInvokeResult<decltype(lambda), const char*>>));
 }
-
-// `static_assert` tests for `isSpan`
-static_assert (isSpan<ql::span<int>>);
-static_assert (isSpan<ql::span<std::string, 37>>);
-static_assert(!isSpan<std::array<int, 3>>);
-static_assert(!isSpan<ql::span<int>&>);
-static_assert(SimilarToSpan<ql::span<int>&>);

--- a/test/TypeTraitsTest.cpp
+++ b/test/TypeTraitsTest.cpp
@@ -431,3 +431,10 @@ TEST(TypeTraits, getInvokeResultImpl) {
       (std::is_same_v<typename decltype(tp2)::type,
                       InvalidInvokeResult<decltype(lambda), const char*>>));
 }
+
+// `static_assert` tests for `isSpan`
+static_assert (isSpan<ql::span<int>>);
+static_assert (isSpan<ql::span<std::string, 37>>);
+static_assert(!isSpan<std::array<int, 3>>);
+static_assert(!isSpan<ql::span<int>&>);
+static_assert(SimilarToSpan<ql::span<int>&>);

--- a/test/VariableToColumnMapTest.cpp
+++ b/test/VariableToColumnMapTest.cpp
@@ -5,9 +5,9 @@
 #include "./printers/VariablePrinters.h"
 #include "./printers/VariableToColumnMapPrinters.h"
 #include "engine/VariableToColumnMap.h"
-#include "util/Serializer/ByteBufferSerializer.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include "util/Serializer/ByteBufferSerializer.h"
 
 class VariableToColumnMapTest : public ::testing::TestWithParam<bool> {};
 

--- a/test/VariableToColumnMapTest.cpp
+++ b/test/VariableToColumnMapTest.cpp
@@ -5,6 +5,7 @@
 #include "./printers/VariablePrinters.h"
 #include "./printers/VariableToColumnMapPrinters.h"
 #include "engine/VariableToColumnMap.h"
+#include "util/Serializer/ByteBufferSerializer.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -155,3 +156,21 @@ INSTANTIATE_TEST_SUITE_P(VariableToColumnMap,            // Instance name
                          VariableToColumnMapTest,        // Test suite name
                          ::testing::Values(true, false)  // Parameters
 );
+
+// _____________________________________________________________________________
+TEST(ColumnIndexAndTypeInfo, serialization) {
+  ColumnIndexAndTypeInfo c1 = makeAlwaysDefinedColumn(42);
+  ColumnIndexAndTypeInfo c2 = makePossiblyUndefinedColumn(46);
+  using namespace ad_utility::serialization;
+  ByteBufferWriteSerializer writer;
+  writer | c1;
+  writer | c2;
+
+  ColumnIndexAndTypeInfo c3;
+  ColumnIndexAndTypeInfo c4;
+  ByteBufferReadSerializer reader{std::move(writer).data()};
+  reader | c3;
+  reader | c4;
+  EXPECT_EQ(c1, c3);
+  EXPECT_EQ(c2, c4);
+}

--- a/test/rdfTypes/VariableTest.cpp
+++ b/test/rdfTypes/VariableTest.cpp
@@ -119,7 +119,8 @@ TEST(Variable, Serialization) {
   Variable v{"?x"};
   ad_utility::serialization::ByteBufferWriteSerializer writer;
   writer << v;
-  ad_utility::serialization::ByteBufferReadSerializer reader(std::move(writer).data());
+  ad_utility::serialization::ByteBufferReadSerializer reader(
+      std::move(writer).data());
   Variable v2{"?somethingElse"};
   reader | v2;
   EXPECT_EQ(v2.name(), "?x");

--- a/test/rdfTypes/VariableTest.cpp
+++ b/test/rdfTypes/VariableTest.cpp
@@ -8,6 +8,7 @@
 #include "../util/GTestHelpers.h"
 #include "rdfTypes/Variable.h"
 #include "util/HashSet.h"
+#include "util/Serializer/ByteBufferSerializer.h"
 
 // _____________________________________________________________________________
 TEST(Variable, legalAndIllegalNames) {
@@ -111,4 +112,15 @@ TEST(Variable, ScoreAndMatchUnicodeExhaustive) {
     }
   }
   EXPECT_EQ(numErrors, 0) << numErrors << ' ' << numSuccesful;
+}
+
+// _____________________________________________________________________________
+TEST(Variable, Serialization) {
+  Variable v{"?x"};
+  ad_utility::serialization::ByteBufferWriteSerializer writer;
+  writer << v;
+  ad_utility::serialization::ByteBufferReadSerializer reader(std::move(writer).data());
+  Variable v2{"?somethingElse"};
+  reader | v2;
+  EXPECT_EQ(v2.name(), "?x");
 }


### PR DESCRIPTION
This complements #2526 by some additional changes necessary for the serialization of a `NamedCachedResult` to disk. In particular:

1. Make `Variable` and `ColumnIndexAndTypeInfo` serializable
2. Make `ql::span` serializable
3. Make all enum types (scoped and unscoped) implicitly serializable (by just copying their bytes)
4. Add a type trait `isSpan<T>` (used in the implementation of `2.`)
5. Add unit tests for all of the above