### PR TITLE
Enable allocation of an explicit set of ranges of blank node identifiers

### DIFF
--- a/src/engine/LocalVocab.cpp
+++ b/src/engine/LocalVocab.cpp
@@ -118,3 +118,26 @@ LocalVocab::LifetimeExtender LocalVocab::getLifetimeExtender() const {
   ql::ranges::copy(otherWordSets_, std::back_inserter(wordSets));
   return LifetimeExtender{std::move(wordSets)};
 }
+
+// _____________________________________________________________________________
+auto LocalVocab::getOwnedLocalBlankNodeBlocks() const
+    -> std::vector<LocalBlankNodeManager::OwnedBlocksEntry> {
+  if (!localBlankNodeManager_) {
+    return {};
+  }
+  return localBlankNodeManager_->getOwnedBlockIndices();
+}
+
+// _____________________________________________________________________________
+void LocalVocab::reserveBlankNodeBlocksFromExplicitIndices(
+    const std::vector<LocalBlankNodeManager::OwnedBlocksEntry>& indices,
+    ad_utility::BlankNodeManager* blankNodeManager) {
+  AD_CONTRACT_CHECK(!localBlankNodeManager_);
+  if (indices.empty()) {
+    return;
+  }
+  localBlankNodeManager_ =
+      std::make_shared<ad_utility::BlankNodeManager::LocalBlankNodeManager>(
+          blankNodeManager);
+  localBlankNodeManager_->allocateBlocksFromExplicitIndices(indices);
+}

--- a/src/engine/LocalVocab.h
+++ b/src/engine/LocalVocab.h
@@ -179,7 +179,7 @@ class LocalVocab {
     if (!localBlankNodeManager_) {
       return {};
     }
-    return localBlankNodeManager_->getReservedBlockIndices();
+    return localBlankNodeManager_->getOwnedBlockIndices();
   }
 
   void reserveBlankNodeBlocksFromExplicitIndices(
@@ -189,7 +189,7 @@ class LocalVocab {
     localBlankNodeManager_ =
         std::make_shared<ad_utility::BlankNodeManager::LocalBlankNodeManager>(
             blankNodeManager);
-    localBlankNodeManager_->reserveBlocksFromExplicitIndices(indices);
+    localBlankNodeManager_->allocateBlocksFromExplicitIndices(indices);
   }
 
   // Get a new BlankNodeIndex using the LocalBlankNodeManager.

--- a/src/engine/LocalVocab.h
+++ b/src/engine/LocalVocab.h
@@ -44,6 +44,9 @@ class LocalVocab {
   using Set = absl::node_hash_set<LocalVocabEntry>;
   std::shared_ptr<Set> primaryWordSet_ = std::make_shared<Set>();
 
+  using LocalBlankNodeManager =
+      ad_utility::BlankNodeManager::LocalBlankNodeManager;
+
   // The other sets of `LocalVocabEntry`s, which are static.
   absl::flat_hash_set<std::shared_ptr<const Set>> otherWordSets_;
 
@@ -52,8 +55,7 @@ class LocalVocab {
 
   // Each `LocalVocab` has its own `LocalBlankNodeManager` to generate blank
   // nodes when needed (e.g., when parsing the result of a SERVICE query).
-  std::shared_ptr<ad_utility::BlankNodeManager::LocalBlankNodeManager>
-      localBlankNodeManager_;
+  std::shared_ptr<LocalBlankNodeManager> localBlankNodeManager_;
 
   // Flag to prevent modification after copy.
   std::unique_ptr<std::atomic_bool> copied_ =
@@ -175,7 +177,8 @@ class LocalVocab {
   const Set& primaryWordSet() const { return *primaryWordSet_; }
   const auto& otherSets() const { return otherWordSets_; }
 
-  std::vector<uint64_t> getIndicesOfBlankNodeBlocks() const {
+  std::vector<LocalBlankNodeManager::OwnedBlocksEntry>
+  getOwnedLocalBlankNodeBlocks() const {
     if (!localBlankNodeManager_) {
       return {};
     }
@@ -183,9 +186,12 @@ class LocalVocab {
   }
 
   void reserveBlankNodeBlocksFromExplicitIndices(
-      const std::vector<uint64_t>& indices,
+      const std::vector<LocalBlankNodeManager::OwnedBlocksEntry>& indices,
       ad_utility::BlankNodeManager* blankNodeManager) {
     AD_CONTRACT_CHECK(!localBlankNodeManager_);
+    if (indices.empty()) {
+      return;
+    }
     localBlankNodeManager_ =
         std::make_shared<ad_utility::BlankNodeManager::LocalBlankNodeManager>(
             blankNodeManager);

--- a/src/engine/LocalVocab.h
+++ b/src/engine/LocalVocab.h
@@ -9,6 +9,7 @@
 #include <absl/container/flat_hash_set.h>
 #include <absl/container/node_hash_set.h>
 
+#include <boost/asio/local/detail/endpoint.hpp>
 #include <cstdlib>
 #include <memory>
 #include <string>
@@ -172,6 +173,24 @@ class LocalVocab {
   std::vector<LocalVocabEntry> getAllWordsForTesting() const;
 
   const Set& primaryWordSet() const { return *primaryWordSet_; }
+  const auto& otherSets() const { return otherWordSets_; }
+
+  std::vector<uint64_t> getIndicesOfBlankNodeBlocks() const {
+    if (!localBlankNodeManager_) {
+      return {};
+    }
+    return localBlankNodeManager_->getReservedBlockIndices();
+  }
+
+  void reserveBlankNodeBlocksFromExplicitIndices(
+      const std::vector<uint64_t>& indices,
+      ad_utility::BlankNodeManager* blankNodeManager) {
+    AD_CONTRACT_CHECK(!localBlankNodeManager_);
+    localBlankNodeManager_ =
+        std::make_shared<ad_utility::BlankNodeManager::LocalBlankNodeManager>(
+            blankNodeManager);
+    localBlankNodeManager_->reserveBlocksFromExplicitIndices(indices);
+  }
 
   // Get a new BlankNodeIndex using the LocalBlankNodeManager.
   [[nodiscard]] BlankNodeIndex getBlankNodeIndex(

--- a/src/engine/LocalVocab.h
+++ b/src/engine/LocalVocab.h
@@ -176,26 +176,19 @@ class LocalVocab {
   const Set& primaryWordSet() const { return *primaryWordSet_; }
   const auto& otherSets() const { return otherWordSets_; }
 
+  // This function returns the required data structure to restore the
+  // `LocalBlankNodeManager`, e.g. when UPDATEs or cached queries are serialized
+  // to disk and the engine is restarted.
   std::vector<LocalBlankNodeManager::OwnedBlocksEntry>
-  getOwnedLocalBlankNodeBlocks() const {
-    if (!localBlankNodeManager_) {
-      return {};
-    }
-    return localBlankNodeManager_->getOwnedBlockIndices();
-  }
+  getOwnedLocalBlankNodeBlocks() const;
 
+  // Restore the state of the `LocalBlankNodeManager` from the serialized data
+  // structure obtained from `getOwnedLocalBlankNodeBlocks` above. This must be
+  // called at the engine start before any queries that might create new local
+  // blank nodes are run (see `BlankNodeManager.h` for details).
   void reserveBlankNodeBlocksFromExplicitIndices(
       const std::vector<LocalBlankNodeManager::OwnedBlocksEntry>& indices,
-      ad_utility::BlankNodeManager* blankNodeManager) {
-    AD_CONTRACT_CHECK(!localBlankNodeManager_);
-    if (indices.empty()) {
-      return;
-    }
-    localBlankNodeManager_ =
-        std::make_shared<ad_utility::BlankNodeManager::LocalBlankNodeManager>(
-            blankNodeManager);
-    localBlankNodeManager_->allocateBlocksFromExplicitIndices(indices);
-  }
+      ad_utility::BlankNodeManager* blankNodeManager);
 
   // Get a new BlankNodeIndex using the LocalBlankNodeManager.
   [[nodiscard]] BlankNodeIndex getBlankNodeIndex(

--- a/src/engine/LocalVocab.h
+++ b/src/engine/LocalVocab.h
@@ -9,7 +9,6 @@
 #include <absl/container/flat_hash_set.h>
 #include <absl/container/node_hash_set.h>
 
-#include <boost/asio/local/detail/endpoint.hpp>
 #include <cstdlib>
 #include <memory>
 #include <string>

--- a/src/util/BlankNodeManager.cpp
+++ b/src/util/BlankNodeManager.cpp
@@ -114,22 +114,14 @@ void BlankNodeManager::LocalBlankNodeManager::allocateBlocksFromExplicitIndices(
                     "Explicit reserving of blank node blocks is only allowed "
                     "for empty `LocalBlankNodeManager`s");
 
-  // The semantics of the argument is (as enforced by the `getOwnedBlockIndices`
-  // function): The first element is the `blocks_` primarily owned by this
-  // `LocalBlankNodeManager`, The remaining elements are the `otherBlocks_`.
-  AD_CONTRACT_CHECK(!indices.empty());
-  blocks_ = blankNodeManager_->registerAndAllocateBlockSet(indices.at(0));
-  otherBlocks_.reserve(indices.size() - 1);
-  for (const auto& entry : indices | ql::views::drop(1)) {
+  // We read all the previously allocated blocks into the `otherBlocks_`, s.t.
+  // the primary `blocks_` vector statys empty. That way, we are completely
+  // decoupled from other `LocalBlankNodeManager`s which might reuse the same
+  // blocks as `*this`.
+  otherBlocks_.reserve(indices.size());
+  for (const auto& entry : indices) {
     otherBlocks_.push_back(
         blankNodeManager_->registerAndAllocateBlockSet(entry));
-  }
-
-  // The following code ensures that the next call to `getId` allocates a new
-  // block. This is necessary, because we don't have access to the information
-  // which IDs in the allocated blocks actually are in use.
-  if (!blocks_->blocks_.empty()) {
-    idxAfterCurrentBlock_ = blocks_->blocks_.back().nextIdx_;
   }
 }
 

--- a/src/util/BlankNodeManager.cpp
+++ b/src/util/BlankNodeManager.cpp
@@ -79,7 +79,8 @@ bool BlankNodeManager::LocalBlankNodeManager::containsBlankNodeIndex(
 
   return ql::ranges::any_of(blocks_->blocks_, containsIndex) ||
          ql::ranges::any_of(
-             otherBlocks_, [&](const std::shared_ptr<const Blocks>& blocks) {
+             otherBlocks_,
+             [containsIndex](const std::shared_ptr<const Blocks>& blocks) {
                return ql::ranges::any_of(blocks->blocks_, containsIndex);
              });
 }
@@ -92,10 +93,8 @@ auto BlankNodeManager::LocalBlankNodeManager::getOwnedBlockIndices() const
   auto resultFromSingleSet = [](const auto& set) {
     OwnedBlocksEntry res;
     res.uuid_ = set->uuid_;
-    // TODO<joka921> use ::ranges::transform/to_vector.
-    for (const auto& block : set->blocks_) {
-      res.blockIndices_.push_back(block.blockIdx_);
-    }
+    res.blockIndices_ = ::ranges::to<std::vector>(
+        set->blocks_ | ql::views::transform(&Block::blockIdx_));
     return res;
   };
 
@@ -115,34 +114,15 @@ void BlankNodeManager::LocalBlankNodeManager::allocateBlocksFromExplicitIndices(
                     "Explicit reserving of blank node blocks is only allowed "
                     "for empty `LocalBlankNodeManager`s");
 
-  // Lambda that does the registering for a single `Blocks` object.
-  auto allocateSingleSet = [this](const OwnedBlocksEntry& entry) {
-    auto [blocks, isNew] =
-        blankNodeManager_->registerBlocksWithExplicitUuid(entry.uuid_);
-    // If the block is not new, then the `Blocks` with the given UUID have
-    // already been reserved by another `LocalBlankNodeManager` that owns the
-    // same set. If it is new, we are the first, and have to also allocate the
-    // blocks.
-    // TODO<joka921> It is ugly to not have this under a single lock and sublte,
-    // maybe this complete lambda should be a member function of the
-    // `BlankNodeManager` under a single lock.
-    if (isNew) {
-      for (const auto& idx : entry.blockIndices_) {
-        blocks->blocks_.emplace_back(
-            blankNodeManager_->allocateExplicitBlock(idx));
-      }
-    }
-    return blocks;
-  };
-
   // The semantics of the argument is (as enforced by the `getOwnedBlockIndices`
   // function): The first element is the `blocks_` primarily owned by this
   // `LocalBlankNodeManager`, The remaining elements are the `otherBlocks_`.
   AD_CONTRACT_CHECK(!indices.empty());
-  blocks_ = allocateSingleSet(indices.at(0));
+  blocks_ = blankNodeManager_->registerAndAllocateBlockSet(indices.at(0));
   otherBlocks_.reserve(indices.size() - 1);
   for (const auto& entry : indices | ql::views::drop(1)) {
-    otherBlocks_.push_back(allocateSingleSet(entry));
+    otherBlocks_.push_back(
+        blankNodeManager_->registerAndAllocateBlockSet(entry));
   }
 
   // The following code ensures that the next call to `getId` allocates a new
@@ -155,63 +135,84 @@ void BlankNodeManager::LocalBlankNodeManager::allocateBlocksFromExplicitIndices(
 
 // _____________________________________________________________________________
 auto BlankNodeManager::createBlockSet() -> std::shared_ptr<Blocks> {
-  auto res = std::make_shared<Blocks>(this);
   // Guard against the (very very unlikely) case of UUID collision
   auto lock = state_.wlock();
-  while (true) {
-    auto [it, isNew] = lock->managedBlockSets_.try_emplace(res->uuid_, res);
-    if (isNew) {
-      return res;
+  auto uuid = lock->uuidGenerator_();
+  auto res = std::make_shared<Blocks>(this, std::move(uuid));
+  auto [it, isNew] = lock->managedBlockSets_.try_emplace(uuid, res);
+  AD_CORRECTNESS_CHECK(isNew,
+                       "You encountered a UUID collision inside "
+                       "`BlankNodeManager::createBlockSet()`. Consider "
+                       "yourself to be very (un)lucky!");
+  it->second = res;
+  return res;
+}
+
+// _____________________________________________________________________________
+void BlankNodeManager::freeBlockSet(const Blocks& blocks) {
+  // We keep the lock the whole time because we have to perform a consistent,
+  // transactional operation on the `state_`, which itself is not threadsafe.
+  state_.withWriteLock([&blocks](auto& state) {
+    // First unregister the UUID.
+    auto it = state.managedBlockSets_.find(blocks.uuid_);
+    if (it == state.managedBlockSets_.end()) {
+      // Note: it is very hard to manually trigger this condition in unit tests.
+      return;
     }
-    // Note: the only realistic way to cover this is by tampering with the UUID
-    // generator.
-    res->uuid_ = lock->uuidGenerator_();
-  }
+    // This `if` check guards against a very rare condition where timings AND
+    // UUIDs have to collide. In particular, we expect the value to be expired,
+    // because this function is only called in the destructor of the object that
+    // the `weak_ptr` points to, so after there are no more `shared_ptr`s to
+    // this object.
+    if (it->second.expired()) {
+      state.managedBlockSets_.erase(it);
+    }
+    auto& usedBlockSet = state.usedBlocksSet_;
+    for (const auto& block : blocks.blocks_) {
+      AD_CONTRACT_CHECK(usedBlockSet.contains(block.blockIdx_));
+      usedBlockSet.erase(block.blockIdx_);
+    }
+  });
 }
 
 // _____________________________________________________________________________
-void BlankNodeManager::freeBlockSet(Blocks& blocks) {
-  // We keep the lock the whole time to not make any inconsistent state visible
-  // to the outside world.
+std::shared_ptr<BlankNodeManager::Blocks>
+BlankNodeManager::registerAndAllocateBlockSet(
+    const LocalBlankNodeManager::OwnedBlocksEntry& entry) {
+  // We keep the lock the whole time to avoid race conditions between
+  // registering the UUID and allocating the blocks.
   auto lock = state_.wlock();
-  // First unregister the UUID.
-  auto it = lock->managedBlockSets_.find(blocks.uuid_);
-  AD_CORRECTNESS_CHECK(it != lock->managedBlockSets_.end());
-  // This `if` check guards against a very rare condition where timings AND
-  // UUIDs have to collide. In particular, we expect the value to be expired,
-  // because this function is only called in the destructor of the object that
-  // the `weak_ptr` points to, so after there are no more `shared_ptr`s to this
-  // object.
-  if (it->second.expired()) {
-    lock->managedBlockSets_.erase(it);
-  }
-  auto& usedBlockSet = lock->usedBlocksSet_;
-  for (const auto& block : blocks.blocks_) {
-    AD_CONTRACT_CHECK(usedBlockSet.contains(block.blockIdx_));
-    usedBlockSet.erase(block.blockIdx_);
-  }
-}
 
-// _____________________________________________________________________________
-std::pair<std::shared_ptr<BlankNodeManager::Blocks>, bool>
-BlankNodeManager::registerBlocksWithExplicitUuid(boost::uuids::uuid uuid) {
-  auto lock = state_.wlock();
-  // Try to insert a new `nullptr` at the given UUID. If  the insertion
+  // Try to insert a new `nullptr` at the given UUID. If the insertion
   // succeeds, we will later emplace a useful value.
   auto [it, isNew] = lock->managedBlockSets_.try_emplace(
-      uuid, std::shared_ptr<Blocks>(nullptr));
+      entry.uuid_, std::shared_ptr<Blocks>(nullptr));
 
   // The `expired()` might happen in a very rare condition, where deleting of a
-  // `UUID` and its reinsertion race against each other. (I doubt that it can be
-  // observed in correct code outside of unit tests).
-  if (isNew || it->second.expired()) {
-    auto blocks = std::make_shared<Blocks>(this);
+  // `UUID` and its reinsertion race against each other.
+  auto ptr = isNew ? it->second.lock() : std::shared_ptr<Blocks>();
+  if (isNew || ptr == nullptr) {
+    auto blocks = std::make_shared<Blocks>(this, entry.uuid_);
     it->second = blocks;
-    return std::make_pair(std::move(blocks), true);
+    // If the block is new, we need to allocate all the specified block indices.
+    for (const auto& idx : entry.blockIndices_) {
+      auto& usedBlocksSet = lock->usedBlocksSet_;
+      AD_CONTRACT_CHECK(
+          !usedBlocksSet.contains(idx),
+          "Trying to explicitly allocate a block of blank nodes that "
+          "has previously already been allocated.");
+      usedBlocksSet.insert(idx);
+      blocks->blocks_.emplace_back(Block(idx, minIndex_ + idx * blockSize_));
+    }
+    return blocks;
   } else {
     // We have found a preexisting, nonexpired `Blocks` object with the
     // requested UUID, just return a shared_ptr to the stored `Blocks` object.
-    return std::make_pair(it->second.lock(), true);
+    AD_CORRECTNESS_CHECK(ptr != nullptr);
+    AD_CORRECTNESS_CHECK(ql::ranges::equal(
+        entry.blockIndices_,
+        ptr->blocks_ | ql::views::transform(&Block::blockIdx_)));
+    return ptr;
   }
 }
 

--- a/src/util/BlankNodeManager.cpp
+++ b/src/util/BlankNodeManager.cpp
@@ -190,7 +190,7 @@ BlankNodeManager::registerAndAllocateBlockSet(
 
   // The `expired()` might happen in a very rare condition, where deleting of a
   // `UUID` and its reinsertion race against each other.
-  auto ptr = isNew ? it->second.lock() : std::shared_ptr<Blocks>();
+  auto ptr = isNew ? std::shared_ptr<Blocks>() : it->second.lock();
   if (isNew || ptr == nullptr) {
     auto blocks = std::make_shared<Blocks>(this, entry.uuid_);
     it->second = blocks;

--- a/src/util/BlankNodeManager.cpp
+++ b/src/util/BlankNodeManager.cpp
@@ -129,7 +129,7 @@ void BlankNodeManager::LocalBlankNodeManager::allocateBlocksFromExplicitIndices(
 
 // _____________________________________________________________________________
 auto BlankNodeManager::createBlockSet() -> std::shared_ptr<Blocks> {
-  // Guard against the (very very unlikely) case of UUID collision
+  // Guard against the (very very unlikely) case of UUID collision.
   auto lockOpt = std::optional{state_.wlock()};
   auto& lock = lockOpt.value();
   auto uuid = lock->uuidGenerator_();

--- a/src/util/BlankNodeManager.h
+++ b/src/util/BlankNodeManager.h
@@ -237,11 +237,12 @@ class BlankNodeManager {
 
   // If the `uuid` of the `entry` is not yet registered with this
   // `BlankNodeManager`, register and return a new `Blocks` struct with the
-  // explicit `uuid`, and explicitly allocate all blocks represented by the
-  // `entry` and store them in the result. If the `uuid` is already registered,
-  // then return a `shared_ptr` to the `Blocks` associated with this `uuid`.
-  // This functionality is used to reinstate sets of registered blocks when
-  // loading SPARQL UPDATEs or serialized cache results when QLever is started.
+  // explicit UUID of the `entry`, and explicitly allocate all blocks
+  // represented by the `entry` and store them in the result. If the `uuid` is
+  // already registered, then return a `shared_ptr` to the `Blocks` associated
+  // with this `uuid`. This functionality is used to reinstate sets of
+  // registered blocks when loading SPARQL UPDATEs or serialized cache results
+  // when QLever is started.
   std::shared_ptr<Blocks> registerAndAllocateBlockSet(
       const LocalBlankNodeManager::OwnedBlocksEntry& entry);
 

--- a/src/util/BlankNodeManager.h
+++ b/src/util/BlankNodeManager.h
@@ -120,9 +120,10 @@ class BlankNodeManager {
       AD_CORRECTNESS_CHECK(manager_ != nullptr);
     }
     ~Blocks() noexcept(false) {
-      throwIfSafe_([this]() { manager_->freeBlockSet(*this); },
-                   "In `freeBlockSet` called from the destructor of a "
-                   "`BlankNodeManager::Blocks` object");
+      throwIfSafe_(
+          [this]() { manager_->freeBlockSet(*this); },
+          std::string_view{"In `freeBlockSet` called from the destructor of a "
+                           "`BlankNodeManager::Blocks` object"});
     }
     // We never want to copy or move `Blocks`, they are only ever to be managed
     // by `shared_ptr`s.

--- a/src/util/BlankNodeManager.h
+++ b/src/util/BlankNodeManager.h
@@ -103,6 +103,9 @@ class BlankNodeManager {
       }
     }
 
+    std::vector<uint64_t> getReservedBlockIndices() const;
+    void reserveBlocksFromExplicitIndices(const std::vector<uint64_t>& indices);
+
     // Getter for the `blankNodeManager_` pointer required in
     // `LocalVocab::mergeWith`.
     BlankNodeManager* blankNodeManager() const { return blankNodeManager_; }
@@ -134,6 +137,13 @@ class BlankNodeManager {
 
   // Allocate and retrieve a block of new blank node indexes.
   [[nodiscard]] Block allocateBlock();
+
+  // Reserve and return the block with the given `blockIdx`. This function can
+  // only be safely called when no calls to `allocatedBlock()` have been
+  // performed. It can for example be used to restore blocks from previously
+  // serialized cache results or updates when the engine is started, but before
+  // any queries are performed.
+  [[nodiscard]] Block reserveExplicitBlock(uint64_t blockIdx);
 
   // Get the number of currently used blocks
   size_t numBlocksUsed() const { return usedBlocksSet_.rlock()->size(); }

--- a/src/util/Synchronized.h
+++ b/src/util/Synchronized.h
@@ -261,9 +261,9 @@ class LockPtr {
                   !isSharedLock);  // if we only have a shared lock, we may only
                                    // perform const operations
     if constexpr (isSharedLock) {
-      s()->mutex().lock_shared();
+      s().mutex().lock_shared();
     } else {
-      s()->mutex().lock();
+      s().mutex().lock();
     }
   }
 
@@ -272,9 +272,9 @@ class LockPtr {
   ~LockPtr() {
     if (!s_) return;
     if constexpr (isSharedLock) {
-      s()->mutex().unlock_shared();
+      s().mutex().unlock_shared();
     } else {
-      s()->mutex().unlock();
+      s().mutex().unlock();
     }
   }
 
@@ -282,21 +282,21 @@ class LockPtr {
   /// locks that are not const.
   template <bool isConstLocal = isConst>
   std::enable_if_t<!isConstLocal, value_type&> operator*() {
-    return s()->data_;
+    return s().data_;
   }
 
   /// Access to underlying data.
-  const value_type& operator*() const { return s()->data_; }
+  const value_type& operator*() const { return s().data_; }
 
   /// Access to underlying data. Non const access is only allowed for exclusive
   /// locks that are not const.
   template <bool isConstLocal = isConst>
   std::enable_if_t<!isConstLocal, value_type*> operator->() {
-    return &s()->data_;
+    return &s().data_;
   }
 
   /// Access to underlying data.
-  const value_type* operator->() const { return &s()->data_; }
+  const value_type* operator->() const { return &s().data_; }
 
   LockPtr(const LockPtr&) = delete;
   LockPtr& operator=(const LockPtr&) = delete;
@@ -307,9 +307,14 @@ class LockPtr {
   LockPtr& operator=(LockPtr&&) = default;
 
  private:
-  ptr_type s() const {
+  // Accessor functions for the `Synchronized` object that is managed.
+  const auto& s() const {
     AD_CORRECTNESS_CHECK(s_ != nullptr);
-    return s_;
+    return *s_;
+  }
+  auto& s() {
+    AD_CORRECTNESS_CHECK(s_ != nullptr);
+    return *s_;
   }
   ad_utility::ResetWhenMoved<ptr_type, nullptr> s_;
 };

--- a/src/util/Synchronized.h
+++ b/src/util/Synchronized.h
@@ -13,8 +13,10 @@
 
 #include "backports/atomic_flag.h"
 #include "backports/keywords.h"
+#include "util/Exception.h"
 #include "util/Forward.h"
 #include "util/OnDestructionDontThrowDuringStackUnwinding.h"
+#include "util/ResetWhenMoved.h"
 
 namespace ad_utility {
 
@@ -245,7 +247,7 @@ template <class S, bool isSharedLock, bool isConst>
 class LockPtr {
   using value_type = typename S::value_type;
   // either store a Pointer or a Pointer to const
-  using ptr_type = std::conditional_t<isConst, const S* const, S* const>;
+  using ptr_type = std::conditional_t<isConst, const S*, S*>;
 
  private:
   // construction is private and only allowed by the Synchronized class
@@ -253,49 +255,63 @@ class LockPtr {
   friend class Synchronized;
 
   // store a pointer to the parent object and immediately lock it.
-  explicit LockPtr(ptr_type s) : s_(s) {
+  explicit LockPtr(ptr_type synchronizedPtr) : s_(synchronizedPtr) {
+    AD_CORRECTNESS_CHECK(s_ != nullptr);
     static_assert(isConst ||
                   !isSharedLock);  // if we only have a shared lock, we may only
                                    // perform const operations
     if constexpr (isSharedLock) {
-      s_->mutex().lock_shared();
+      s()->mutex().lock_shared();
     } else {
-      s_->mutex().lock();
+      s()->mutex().lock();
     }
   }
 
  public:
   // destructor releases the lock
   ~LockPtr() {
+    if (!s_) return;
     if constexpr (isSharedLock) {
-      s_->mutex().unlock_shared();
+      s()->mutex().unlock_shared();
     } else {
-      s_->mutex().unlock();
+      s()->mutex().unlock();
     }
   }
 
   /// Access to underlying data. Non const access is only allowed for exclusive
   /// locks that are not const.
-  template <bool s = isConst>
-  std::enable_if_t<!s, value_type&> operator*() {
-    return s_->data_;
+  template <bool isConstLocal = isConst>
+  std::enable_if_t<!isConstLocal, value_type&> operator*() {
+    return s()->data_;
   }
 
   /// Access to underlying data.
-  const value_type& operator*() const { return s_->data_; }
+  const value_type& operator*() const { return s()->data_; }
 
   /// Access to underlying data. Non const access is only allowed for exclusive
   /// locks that are not const.
-  template <bool s = isConst>
-  std::enable_if_t<!s, value_type*> operator->() {
-    return &s_->data_;
+  template <bool isConstLocal = isConst>
+  std::enable_if_t<!isConstLocal, value_type*> operator->() {
+    return &s()->data_;
   }
 
   /// Access to underlying data.
-  const value_type* operator->() const { return &s_->data_; }
+  const value_type* operator->() const { return &s()->data_; }
+
+  LockPtr(const LockPtr&) = delete;
+  LockPtr& operator=(const LockPtr&) = delete;
+  // The combination of `ResetWhenMoved` (the `s_` of a moved-from `LockPtr`
+  // will be `nullptr`), and the logic in the destructor (`only unlock, if the
+  // pointer is not null`), lead to valid move semantics.
+  LockPtr(LockPtr&&) = default;
+  LockPtr& operator=(LockPtr&&) = default;
 
  private:
-  ptr_type s_;
+  ptr_type s() const {
+    AD_CORRECTNESS_CHECK(s_ != nullptr);
+    return s_;
+  }
+  ad_utility::ResetWhenMoved<ptr_type, nullptr> s_;
 };
 
 }  // namespace ad_utility

--- a/test/BlankNodeManagerTest.cpp
+++ b/test/BlankNodeManagerTest.cpp
@@ -280,8 +280,11 @@ TEST_F(BlankNodeManagerTestFixture, explicitBlockAllocation) {
   EXPECT_TRUE(isBlockUsed(*bnm, 10));
 
   // Verify we can't allocate the same block twice
+  auto allocateExplicitly = [&]() {
+    [[maybe_unused]] auto blocks = bnm->allocateExplicitBlock(5);
+  };
   AD_EXPECT_THROW_WITH_MESSAGE(
-      bnm->allocateExplicitBlock(5),
+      allocateExplicitly(),
       ::testing::HasSubstr("has previously already been allocated"));
 }
 

--- a/test/BlankNodeManagerTest.cpp
+++ b/test/BlankNodeManagerTest.cpp
@@ -13,33 +13,43 @@
 #include "gmock/gmock.h"
 #include "util/BlankNodeManager.h"
 #include "util/GTestHelpers.h"
+#include "util/SourceLocation.h"
 
 namespace ad_utility {
 
 // ____________________________________________________________________________
-// Test fixture providing common infrastructure for BlankNodeManager tests
+// Test fixture providing common infrastructure for BlankNodeManager tests.
 class BlankNodeManagerTestFixture : public ::testing::Test {
  protected:
-  // Helper to create a BlankNodeManager with default minIndex
+  // Helper to create a BlankNodeManager with default minIndex.
   static std::unique_ptr<BlankNodeManager> createManager(
-      uint64_t minIndex = 0) {
+      uint64_t minIndex = 0,
+      ad_utility::source_location loc = AD_CURRENT_SOURCE_LOC()) {
+    auto t = generateLocationTrace(loc);
     return std::make_unique<BlankNodeManager>(minIndex);
   }
 
-  // Helper to create a LocalBlankNodeManager
+  // Helper to create a LocalBlankNodeManager.
   static std::shared_ptr<BlankNodeManager::LocalBlankNodeManager>
-  createLocalManager(BlankNodeManager* bnm) {
+  createLocalManager(BlankNodeManager* bnm, ad_utility::source_location loc =
+                                                AD_CURRENT_SOURCE_LOC()) {
+    auto t = generateLocationTrace(loc);
     return std::make_shared<BlankNodeManager::LocalBlankNodeManager>(bnm);
   }
 
-  // Helper to get the primary blocks from a LocalBlankNodeManager
-  static auto& getPrimaryBlocks(BlankNodeManager::LocalBlankNodeManager& lbnm) {
+  // Helper to get the primary blocks from a LocalBlankNodeManager.
+  static auto& getPrimaryBlocks(
+      BlankNodeManager::LocalBlankNodeManager& lbnm,
+      ad_utility::source_location loc = AD_CURRENT_SOURCE_LOC()) {
+    auto t = generateLocationTrace(loc);
     return lbnm.blocks_->blocks_;
   }
 
-  // Helper to get the total number of blocks (primary + other)
+  // Helper to get the total number of blocks (primary + other).
   static size_t getTotalBlockCount(
-      const BlankNodeManager::LocalBlankNodeManager& lbnm) {
+      const BlankNodeManager::LocalBlankNodeManager& lbnm,
+      ad_utility::source_location loc = AD_CURRENT_SOURCE_LOC()) {
+    auto t = generateLocationTrace(loc);
     size_t count = lbnm.blocks_->blocks_.size();
     for (const auto& otherBlocks : lbnm.otherBlocks_) {
       count += otherBlocks->blocks_.size();
@@ -47,9 +57,11 @@ class BlankNodeManagerTestFixture : public ::testing::Test {
     return count;
   }
 
-  // Helper to get all block indices (from both primary and other blocks)
+  // Helper to get all block indices (from both primary and other blocks).
   static std::vector<uint64_t> getAllBlockIndices(
-      const BlankNodeManager::LocalBlankNodeManager& lbnm) {
+      const BlankNodeManager::LocalBlankNodeManager& lbnm,
+      ad_utility::source_location loc = AD_CURRENT_SOURCE_LOC()) {
+    auto t = generateLocationTrace(loc);
     std::vector<uint64_t> indices;
     for (const auto& block : lbnm.blocks_->blocks_) {
       indices.push_back(block.blockIdx_);
@@ -62,9 +74,11 @@ class BlankNodeManagerTestFixture : public ::testing::Test {
     return indices;
   }
 
-  // Helper to allocate N IDs from a LocalBlankNodeManager
+  // Helper to allocate N IDs from a LocalBlankNodeManager.
   static std::vector<uint64_t> allocateIds(
-      BlankNodeManager::LocalBlankNodeManager& lbnm, size_t count) {
+      BlankNodeManager::LocalBlankNodeManager& lbnm, size_t count,
+      ad_utility::source_location loc = AD_CURRENT_SOURCE_LOC()) {
+    auto t = generateLocationTrace(loc);
     std::vector<uint64_t> ids;
     ids.reserve(count);
     for (size_t i = 0; i < count; ++i) {
@@ -73,14 +87,16 @@ class BlankNodeManagerTestFixture : public ::testing::Test {
     return ids;
   }
 
-  // Helper to allocate IDs that span multiple blocks
+  // Helper to allocate IDs that span multiple blocks.
   static std::vector<uint64_t> allocateIdsAcrossBlocks(
-      BlankNodeManager::LocalBlankNodeManager& lbnm, size_t numBlocks) {
+      BlankNodeManager::LocalBlankNodeManager& lbnm, size_t numBlocks,
+      ad_utility::source_location loc = AD_CURRENT_SOURCE_LOC()) {
+    auto t = generateLocationTrace(loc);
     std::vector<uint64_t> ids;
     for (size_t i = 0; i < numBlocks; ++i) {
-      // Allocate at least one ID per block
+      // Allocate at least one ID per block.
       ids.push_back(lbnm.getId());
-      // Fill the rest of the block to force allocation of next block
+      // Fill the rest of the block to force allocation of next block.
       if (i < numBlocks - 1) {
         auto& blocks = getPrimaryBlocks(lbnm);
         if (!blocks.empty()) {
@@ -92,61 +108,81 @@ class BlankNodeManagerTestFixture : public ::testing::Test {
     return ids;
   }
 
-  // Helper to verify all IDs are contained in the LocalBlankNodeManager
+  // Helper to verify all IDs are contained in the LocalBlankNodeManager.
   static void verifyIdsContained(
       const BlankNodeManager::LocalBlankNodeManager& lbnm,
-      const std::vector<uint64_t>& ids) {
+      const std::vector<uint64_t>& ids,
+      ad_utility::source_location loc = AD_CURRENT_SOURCE_LOC()) {
+    auto t = generateLocationTrace(loc);
     for (uint64_t id : ids) {
       EXPECT_TRUE(lbnm.containsBlankNodeIndex(id))
           << "ID " << id << " should be contained";
     }
   }
 
-  // Helper to verify IDs are NOT contained in the LocalBlankNodeManager
+  // Helper to verify IDs are NOT contained in the LocalBlankNodeManager.
   static void verifyIdsNotContained(
       const BlankNodeManager::LocalBlankNodeManager& lbnm,
-      const std::vector<uint64_t>& ids) {
+      const std::vector<uint64_t>& ids,
+      ad_utility::source_location loc = AD_CURRENT_SOURCE_LOC()) {
+    auto t = generateLocationTrace(loc);
     for (uint64_t id : ids) {
       EXPECT_FALSE(lbnm.containsBlankNodeIndex(id))
           << "ID " << id << " should not be contained";
     }
   }
 
-  // Helper to get the number of used blocks
-  static size_t getUsedBlockCount(const BlankNodeManager& bnm) {
+  // Helper to get the number of used blocks.
+  static size_t getUsedBlockCount(
+      const BlankNodeManager& bnm,
+      ad_utility::source_location loc = AD_CURRENT_SOURCE_LOC()) {
+    auto t = generateLocationTrace(loc);
     return bnm.state_.rlock()->usedBlocksSet_.size();
   }
 
-  // Helper to check if a specific block index is used
-  static bool isBlockUsed(const BlankNodeManager& bnm, uint64_t blockIdx) {
+  // Helper to check if a specific block index is used.
+  static bool isBlockUsed(
+      const BlankNodeManager& bnm, uint64_t blockIdx,
+      ad_utility::source_location loc = AD_CURRENT_SOURCE_LOC()) {
+    auto t = generateLocationTrace(loc);
     return bnm.state_.rlock()->usedBlocksSet_.contains(blockIdx);
   }
 
-  // Helper to get the number of managed UUIDs
-  static size_t getManagedUuidCount(const BlankNodeManager& bnm) {
+  // Helper to get the number of managed UUIDs.
+  static size_t getManagedUuidCount(
+      const BlankNodeManager& bnm,
+      ad_utility::source_location loc = AD_CURRENT_SOURCE_LOC()) {
+    auto t = generateLocationTrace(loc);
     return bnm.state_.rlock()->managedBlockSets_.size();
   }
 
-  // Helper to serialize a LocalBlankNodeManager
+  // Helper to serialize a LocalBlankNodeManager.
   static std::vector<BlankNodeManager::LocalBlankNodeManager::OwnedBlocksEntry>
-  serialize(const BlankNodeManager::LocalBlankNodeManager& lbnm) {
+  serialize(const BlankNodeManager::LocalBlankNodeManager& lbnm,
+            ad_utility::source_location loc = AD_CURRENT_SOURCE_LOC()) {
+    auto t = generateLocationTrace(loc);
     return lbnm.getOwnedBlockIndices();
   }
 
-  // Helper to deserialize into a new LocalBlankNodeManager
+  // Helper to deserialize into a new LocalBlankNodeManager.
   static std::shared_ptr<BlankNodeManager::LocalBlankNodeManager> deserialize(
       BlankNodeManager* bnm,
       const std::vector<
-          BlankNodeManager::LocalBlankNodeManager::OwnedBlocksEntry>& entries) {
+          BlankNodeManager::LocalBlankNodeManager::OwnedBlocksEntry>& entries,
+      ad_utility::source_location loc = AD_CURRENT_SOURCE_LOC()) {
+    auto t = generateLocationTrace(loc);
     auto lbnm = createLocalManager(bnm);
     lbnm->allocateBlocksFromExplicitIndices(entries);
     return lbnm;
   }
 
-  // Helper to perform a round-trip serialization/deserialization
+  // Helper to perform a round-trip serialization/deserialization.
   static std::shared_ptr<BlankNodeManager::LocalBlankNodeManager>
-  roundTripSerialize(BlankNodeManager* bnm,
-                     const BlankNodeManager::LocalBlankNodeManager& source) {
+  roundTripSerialize(
+      BlankNodeManager* bnm,
+      const BlankNodeManager::LocalBlankNodeManager& source,
+      ad_utility::source_location loc = AD_CURRENT_SOURCE_LOC()) {
+    auto t = generateLocationTrace(loc);
     auto entries = serialize(source);
     return deserialize(bnm, entries);
   }
@@ -157,13 +193,13 @@ TEST(BlankNodeManager, blockAllocationAndFree) {
   EXPECT_TRUE(bnm.state_.rlock()->usedBlocksSet_.empty());
 
   {
-    // LocalBlankNodeManager allocates a new block
+    // LocalBlankNodeManager allocates a new block.
     BlankNodeManager::LocalBlankNodeManager lbnm(&bnm);
     [[maybe_unused]] uint64_t id = lbnm.getId();
     EXPECT_EQ(bnm.state_.rlock()->usedBlocksSet_.size(), 1);
   }
 
-  // Once the LocalBlankNodeManager is destroyed, all Blocks allocated through
+  // Once the LocalBlankNodeManager is destroyed, all Blocks allocated through.
   // it are freed/removed from the BlankNodeManager's set.
   EXPECT_TRUE(bnm.state_.rlock()->usedBlocksSet_.empty());
 
@@ -183,18 +219,18 @@ TEST(BlankNodeManager, LocalBlankNodeManagerGetID) {
 
   // Getter for the contained blocks.
   auto blocks = [&l]() -> auto& { return l->blocks_->blocks_; };
-  // initially the LocalBlankNodeManager doesn't have any blocks
+  // initially the LocalBlankNodeManager doesn't have any blocks.
   EXPECT_EQ(blocks().size(), 0);
 
   // A new Block is allocated, if
-  // no blocks are allocated yet
+  // no blocks are allocated yet.
   uint64_t id = l->getId();
   EXPECT_EQ(blocks().size(), 1);
   EXPECT_TRUE(l->containsBlankNodeIndex(id));
   EXPECT_FALSE(l->containsBlankNodeIndex(id + 1));
   EXPECT_FALSE(l->containsBlankNodeIndex(id - 1));
 
-  // or the ids of the last block are all used
+  // or the ids of the last block are all used.
   blocks().back().nextIdx_ = id + BlankNodeManager::blockSize_;
   id = l->getId();
   EXPECT_TRUE(l->containsBlankNodeIndex(id));
@@ -211,7 +247,7 @@ TEST(BlankNodeManager, LocalBlankNodeManagerGetID) {
 
 // _____________________________________________________________________________
 TEST(BlankNodeManager, maxNumOfBlocks) {
-  // Mock a high `minIndex_` to simulate reduced space in the `usedBlocksSet_`
+  // Mock a high `minIndex_` to simulate reduced space in the `usedBlocksSet_`.
   BlankNodeManager bnm(ValueId::maxIndex - 256 * BlankNodeManager::blockSize_ +
                        2);
   AD_EXPECT_THROW_WITH_MESSAGE(
@@ -223,7 +259,7 @@ TEST(BlankNodeManager, maxNumOfBlocks) {
 // _____________________________________________________________________________
 TEST(BlankNodeManager, moveLocalBlankNodeManager) {
   // This ensures that the `blocks_` of the `LocalBlankNodeManager` are moved
-  // correctly, such that they're freed/removed from the `BlankNodeManager`
+  // correctly, such that they're freed/removed from the `BlankNodeManager`.
   // set only once.
   BlankNodeManager bnm(0);
   EXPECT_NO_THROW({
@@ -240,31 +276,31 @@ TEST_F(BlankNodeManagerTestFixture, serializationRoundTrip) {
   auto bnm = createManager();
   auto lbnm = createLocalManager(bnm.get());
 
-  // Allocate IDs across multiple blocks
+  // Allocate IDs across multiple blocks.
   auto originalIds = allocateIdsAcrossBlocks(*lbnm, 3);
   ASSERT_EQ(getPrimaryBlocks(*lbnm).size(), 3);
 
-  // Serialize
+  // Serialize.
   auto entries = serialize(*lbnm);
-  EXPECT_EQ(entries.size(), 1);  // Only primary blocks, no merged blocks
+  EXPECT_EQ(entries.size(), 1);  // Only primary blocks, no merged blocks.
   EXPECT_EQ(entries[0].blockIndices_.size(), 3);
 
-  // Deserialize into a new LocalBlankNodeManager
+  // Deserialize into a new LocalBlankNodeManager.
   auto lbnm2 = deserialize(bnm.get(), entries);
 
-  // Verify all original IDs are contained
+  // Verify all original IDs are contained.
   verifyIdsContained(*lbnm2, originalIds);
 
-  // Verify block indices are preserved (now in otherBlocks_)
+  // Verify block indices are preserved (now in otherBlocks_).
   EXPECT_EQ(getTotalBlockCount(*lbnm2), 3);
   auto originalIndices = getAllBlockIndices(*lbnm);
   auto restoredIndices = getAllBlockIndices(*lbnm2);
   EXPECT_EQ(originalIndices, restoredIndices);
 
-  // Verify new IDs can still be allocated and don't conflict
+  // Verify new IDs can still be allocated and don't conflict.
   auto newId = lbnm2->getId();
   EXPECT_TRUE(lbnm2->containsBlankNodeIndex(newId));
-  // The new ID should be in a new block (primary blocks now has 1 block)
+  // The new ID should be in a new block (primary blocks now has 1 block).
   EXPECT_EQ(getPrimaryBlocks(*lbnm2).size(), 1);
   EXPECT_EQ(getTotalBlockCount(*lbnm2), 4);
 }
@@ -273,7 +309,7 @@ TEST_F(BlankNodeManagerTestFixture, serializationRoundTrip) {
 TEST_F(BlankNodeManagerTestFixture, explicitBlockAllocation) {
   auto bnm = createManager();
 
-  // Allocate specific block indices
+  // Allocate specific block indices.
   auto block1 = bnm->allocateExplicitBlock(5);
   EXPECT_EQ(block1.blockIdx_, 5);
   EXPECT_EQ(block1.startIdx_, 5 * BlankNodeManager::blockSize_);
@@ -284,7 +320,7 @@ TEST_F(BlankNodeManagerTestFixture, explicitBlockAllocation) {
   EXPECT_EQ(block2.blockIdx_, 10);
   EXPECT_TRUE(isBlockUsed(*bnm, 10));
 
-  // Verify we can't allocate the same block twice
+  // Verify we can't allocate the same block twice.
   auto allocateExplicitly = [&]() {
     [[maybe_unused]] auto blocks = bnm->allocateExplicitBlock(5);
   };
@@ -297,33 +333,33 @@ TEST_F(BlankNodeManagerTestFixture, explicitBlockAllocation) {
 TEST_F(BlankNodeManagerTestFixture, uuidManagement) {
   auto bnm = createManager();
 
-  // Create multiple LocalBlankNodeManagers
+  // Create multiple LocalBlankNodeManagers.
   auto lbnm1 = createLocalManager(bnm.get());
   auto lbnm2 = createLocalManager(bnm.get());
   auto lbnm3 = createLocalManager(bnm.get());
 
-  // Allocate some IDs to create blocks
+  // Allocate some IDs to create blocks.
   allocateIds(*lbnm1, 5);
   allocateIds(*lbnm2, 3);
   allocateIds(*lbnm3, 7);
 
-  // Get UUIDs
+  // Get UUIDs.
   auto entries1 = serialize(*lbnm1);
   auto entries2 = serialize(*lbnm2);
   auto entries3 = serialize(*lbnm3);
 
-  // Verify each has a unique UUID
+  // Verify each has a unique UUID.
   EXPECT_NE(entries1[0].uuid_, entries2[0].uuid_);
   EXPECT_NE(entries1[0].uuid_, entries3[0].uuid_);
   EXPECT_NE(entries2[0].uuid_, entries3[0].uuid_);
 
-  // All three UUIDs should be registered
+  // All three UUIDs should be registered.
   EXPECT_EQ(getManagedUuidCount(*bnm), 3);
 
-  // Destroy one LocalBlankNodeManager
+  // Destroy one LocalBlankNodeManager.
   lbnm1.reset();
 
-  // UUID count should decrease (the destructor of the `Blocks` struct blocks
+  // UUID count should decrease (the destructor of the `Blocks` struct blocks.
   // until it has been deleted).
   EXPECT_EQ(getManagedUuidCount(*bnm), 2);
 }
@@ -333,32 +369,33 @@ TEST_F(BlankNodeManagerTestFixture, sharedBlockSetViaUuid) {
   auto bnm = createManager();
   auto lbnm1 = createLocalManager(bnm.get());
 
-  // Allocate IDs across multiple blocks
+  // Allocate IDs across multiple blocks.
   allocateIdsAcrossBlocks(*lbnm1, 2);
   auto entries = serialize(*lbnm1);
 
-  // Deserialize the same data into two different LocalBlankNodeManagers
+  // Deserialize the same data into two different LocalBlankNodeManagers.
   auto lbnm2 = deserialize(bnm.get(), entries);
   auto lbnm3 = deserialize(bnm.get(), entries);
 
-  // Both should reference the same underlying Blocks (same shared_ptr)
-  // The deserialized blocks are in otherBlocks_, and they share the same UUID
+  // Both should reference the same underlying Blocks (same shared_ptr).
+  // The deserialized blocks are in otherBlocks_, and they share the same UUID.
   auto entries2 = serialize(*lbnm2);
   auto entries3 = serialize(*lbnm3);
-  // Serialize returns primary first (empty), then otherBlocks
-  // So the deserialized blocks are at index 1
-  ASSERT_EQ(entries2.size(), 2);  // Empty primary + 1 from otherBlocks
+  // Serialize returns primary first (empty), then otherBlocks.
+  // So the deserialized blocks are at index 1.
+  ASSERT_EQ(entries2.size(), 2);  // Empty primary + 1 from otherBlocks.
   ASSERT_EQ(entries3.size(), 2);
-  EXPECT_TRUE(entries2[0].blockIndices_.empty());  // Primary is empty
+  EXPECT_TRUE(entries2[0].blockIndices_.empty());  // Primary is empty.
   EXPECT_TRUE(entries3[0].blockIndices_.empty());
-  // The UUIDs of the deserialized blocks (at index 1) should match the original
+  // The UUIDs of the deserialized blocks (at index 1) should match the
+  // original.
   EXPECT_EQ(entries2[1].uuid_, entries[0].uuid_);
   EXPECT_EQ(entries3[1].uuid_, entries[0].uuid_);
 
-  // Block indices should only be allocated once in usedBlocksSet_
+  // Block indices should only be allocated once in usedBlocksSet_.
   EXPECT_EQ(getUsedBlockCount(*bnm), 2);
 
-  // Verify both can see the blocks (now in otherBlocks_)
+  // Verify both can see the blocks (now in otherBlocks_).
   EXPECT_EQ(getTotalBlockCount(*lbnm2), 2);
   EXPECT_EQ(getTotalBlockCount(*lbnm3), 2);
 }
@@ -367,39 +404,39 @@ TEST_F(BlankNodeManagerTestFixture, sharedBlockSetViaUuid) {
 TEST_F(BlankNodeManagerTestFixture, deserializationWithMergedBlocks) {
   auto bnm = createManager();
 
-  // Create LocalBlankNodeManager A with some blocks
+  // Create LocalBlankNodeManager A with some blocks.
   auto lbnmA = createLocalManager(bnm.get());
   auto idsA = allocateIdsAcrossBlocks(*lbnmA, 2);
 
-  // Create LocalBlankNodeManager B with other blocks
+  // Create LocalBlankNodeManager B with other blocks.
   auto lbnmB = createLocalManager(bnm.get());
   auto idsB = allocateIdsAcrossBlocks(*lbnmB, 2);
 
-  // Merge B into A
+  // Merge B into A.
   std::vector managers{lbnmB};
   lbnmA->mergeWith(managers);
 
-  // Serialize A (should have multiple OwnedBlocksEntry elements)
+  // Serialize A (should have multiple OwnedBlocksEntry elements).
   auto entries = serialize(*lbnmA);
-  EXPECT_EQ(entries.size(), 2);  // Primary blocks + one merged set
-  EXPECT_EQ(entries[0].blockIndices_.size(), 2);  // A's blocks
-  EXPECT_EQ(entries[1].blockIndices_.size(), 2);  // B's blocks
+  EXPECT_EQ(entries.size(), 2);  // Primary blocks + one merged set.
+  EXPECT_EQ(entries[0].blockIndices_.size(), 2);  // A's blocks.
+  EXPECT_EQ(entries[1].blockIndices_.size(), 2);  // B's blocks.
 
-  // Deserialize into a new LocalBlankNodeManager C
+  // Deserialize into a new LocalBlankNodeManager C.
   auto lbnmC = deserialize(bnm.get(), entries);
 
-  // Verify C has all blocks in otherBlocks (after deserialization)
-  // We verify indirectly by serializing and checking the number of sets
+  // Verify C has all blocks in otherBlocks (after deserialization).
+  // We verify indirectly by serializing and checking the number of sets.
   auto entriesC = serialize(*lbnmC);
-  // entriesC will have 3 entries: 1 empty primary + 2 from otherBlocks
+  // entriesC will have 3 entries: 1 empty primary + 2 from otherBlocks.
   EXPECT_EQ(entriesC.size(), 3);
-  EXPECT_TRUE(entriesC[0].blockIndices_.empty());  // Primary is empty
-  EXPECT_EQ(entriesC[1].blockIndices_.size(), 2);  // First set
-  EXPECT_EQ(entriesC[2].blockIndices_.size(), 2);  // Second set
-  EXPECT_EQ(getPrimaryBlocks(*lbnmC).size(), 0);   // Primary blocks is empty
-  EXPECT_EQ(getTotalBlockCount(*lbnmC), 4);        // Total of 4 blocks
+  EXPECT_TRUE(entriesC[0].blockIndices_.empty());  // Primary is empty.
+  EXPECT_EQ(entriesC[1].blockIndices_.size(), 2);  // First set.
+  EXPECT_EQ(entriesC[2].blockIndices_.size(), 2);  // Second set.
+  EXPECT_EQ(getPrimaryBlocks(*lbnmC).size(), 0);   // Primary blocks is empty.
+  EXPECT_EQ(getTotalBlockCount(*lbnmC), 4);        // Total of 4 blocks.
 
-  // Verify all IDs from both A and B are contained in C
+  // Verify all IDs from both A and B are contained in C.
   verifyIdsContained(*lbnmC, idsA);
   verifyIdsContained(*lbnmC, idsB);
 }
@@ -409,23 +446,23 @@ TEST_F(BlankNodeManagerTestFixture, idAllocationAfterDeserialization) {
   auto bnm = createManager();
   auto lbnm1 = createLocalManager(bnm.get());
 
-  // Allocate some IDs (but not filling the whole block)
+  // Allocate some IDs (but not filling the whole block).
   auto ids = allocateIds(*lbnm1, 5);
   auto entries = serialize(*lbnm1);
 
-  // Deserialize
+  // Deserialize.
   auto lbnm2 = deserialize(bnm.get(), entries);
 
   // The next ID should come from a NEW block in primary blocks
-  // (deserialized blocks are in otherBlocks_)
+  // (deserialized blocks are in otherBlocks_).
   EXPECT_EQ(getPrimaryBlocks(*lbnm2).size(),
-            0);  // Primary blocks empty before getId
+            0);  // Primary blocks empty before getId.
   [[maybe_unused]] auto newId = lbnm2->getId();
-  EXPECT_EQ(getPrimaryBlocks(*lbnm2).size(), 1);  // New block in primary
-  EXPECT_EQ(getTotalBlockCount(*lbnm2), 2);       // 1 deserialized + 1 new
+  EXPECT_EQ(getPrimaryBlocks(*lbnm2).size(), 1);  // New block in primary.
+  EXPECT_EQ(getTotalBlockCount(*lbnm2), 2);       // 1 deserialized + 1 new.
 
   // The containsBlankNodeIndex test doesn't apply anymore since we don't
-  // have direct access to the partially filled blocks in otherBlocks_
+  // have direct access to the partially filled blocks in otherBlocks_.
 }
 
 // _____________________________________________________________________________
@@ -433,17 +470,17 @@ TEST_F(BlankNodeManagerTestFixture, emptyLocalBlankNodeManagerPrecondition) {
   auto bnm = createManager();
   auto lbnm = createLocalManager(bnm.get());
 
-  // Allocate some IDs to make it non-empty
+  // Allocate some IDs to make it non-empty.
   allocateIds(*lbnm, 5);
 
-  // Create some dummy entries to try to deserialize
+  // Create some dummy entries to try to deserialize.
   BlankNodeManager::LocalBlankNodeManager::OwnedBlocksEntry entry;
   entry.uuid_ = boost::uuids::random_generator()();
   entry.blockIndices_ = {1, 2, 3};
   std::vector<BlankNodeManager::LocalBlankNodeManager::OwnedBlocksEntry>
       entries{entry};
 
-  // Attempt to call allocateBlocksFromExplicitIndices on non-empty manager
+  // Attempt to call allocateBlocksFromExplicitIndices on non-empty manager.
   AD_EXPECT_THROW_WITH_MESSAGE(
       lbnm->allocateBlocksFromExplicitIndices(entries),
       ::testing::HasSubstr(
@@ -466,15 +503,15 @@ TEST_F(BlankNodeManagerTestFixture, blockSetCleanup) {
     savedUuid = entries[0].uuid_;
     blockIndices = entries[0].blockIndices_;
 
-    // Verify UUID is registered and blocks are used
+    // Verify UUID is registered and blocks are used.
     EXPECT_EQ(getManagedUuidCount(*bnm), 1);
     EXPECT_EQ(getUsedBlockCount(*bnm), 3);
     for (auto idx : blockIndices) {
       EXPECT_TRUE(isBlockUsed(*bnm, idx));
     }
-  }  // lbnm is destroyed here
+  }  // lbnm is destroyed here.
 
-  // After destruction, UUID should be cleaned up and blocks freed
+  // After destruction, UUID should be cleaned up and blocks freed.
   EXPECT_EQ(getManagedUuidCount(*bnm), 0);
   EXPECT_EQ(getUsedBlockCount(*bnm), 0);
   for (auto idx : blockIndices) {
@@ -486,22 +523,22 @@ TEST_F(BlankNodeManagerTestFixture, blockSetCleanup) {
 TEST_F(BlankNodeManagerTestFixture, explicitAndRandomAllocationCoexistence) {
   auto bnm = createManager();
 
-  // Allocate some blocks explicitly
+  // Allocate some blocks explicitly.
   auto block1 = bnm->allocateExplicitBlock(100);
   auto block2 = bnm->allocateExplicitBlock(200);
   EXPECT_EQ(getUsedBlockCount(*bnm), 2);
 
-  // Allocate some blocks randomly
+  // Allocate some blocks randomly.
   auto randomBlock1 = bnm->allocateBlock();
   auto randomBlock2 = bnm->allocateBlock();
   EXPECT_EQ(getUsedBlockCount(*bnm), 4);
 
-  // Verify no conflicts (all block indices should be different)
+  // Verify no conflicts (all block indices should be different).
   std::set<uint64_t> allBlocks{block1.blockIdx_, block2.blockIdx_,
                                randomBlock1.blockIdx_, randomBlock2.blockIdx_};
   EXPECT_EQ(allBlocks.size(), 4);
 
-  // All should be marked as used
+  // All should be marked as used.
   EXPECT_TRUE(isBlockUsed(*bnm, block1.blockIdx_));
   EXPECT_TRUE(isBlockUsed(*bnm, block2.blockIdx_));
   EXPECT_TRUE(isBlockUsed(*bnm, randomBlock1.blockIdx_));
@@ -514,20 +551,20 @@ TEST_F(BlankNodeManagerTestFixture, uuidCollisionHandling) {
 
   // We can't easily mock the UUID generator without modifying the production
   // code, but we can at least verify that creating many LocalBlankNodeManagers
-  // doesn't cause issues and all get unique UUIDs
+  // doesn't cause issues and all get unique UUIDs.
   std::vector<std::shared_ptr<BlankNodeManager::LocalBlankNodeManager>>
       managers;
   std::set<boost::uuids::uuid> uuids;
 
   for (int i = 0; i < 100; ++i) {
     auto lbnm = createLocalManager(bnm.get());
-    allocateIds(*lbnm, 1);  // Allocate at least one ID
+    allocateIds(*lbnm, 1);  // Allocate at least one ID.
     auto entries = serialize(*lbnm);
     uuids.insert(entries[0].uuid_);
     managers.push_back(std::move(lbnm));
   }
 
-  // All UUIDs should be unique
+  // All UUIDs should be unique.
   EXPECT_EQ(uuids.size(), 100);
   EXPECT_EQ(getManagedUuidCount(*bnm), 100);
 }
@@ -536,8 +573,8 @@ TEST_F(BlankNodeManagerTestFixture, uuidCollisionHandling) {
 TEST_F(BlankNodeManagerTestFixture, serializationPreservesBlockIndices) {
   auto bnm = createManager();
 
-  // Manually manipulate to allocate specific blocks via explicit allocation
-  // Then use them in a LocalBlankNodeManager
+  // Manually manipulate to allocate specific blocks via explicit allocation.
+  // Then use them in a LocalBlankNodeManager.
   BlankNodeManager::LocalBlankNodeManager::OwnedBlocksEntry entry;
   entry.uuid_ = boost::uuids::random_generator()();
   entry.blockIndices_ = {5, 42, 100};
@@ -545,16 +582,16 @@ TEST_F(BlankNodeManagerTestFixture, serializationPreservesBlockIndices) {
   std::vector entries{entry};
   auto lbnm2 = deserialize(bnm.get(), entries);
 
-  // Verify the block indices match (now in otherBlocks, so second entry)
+  // Verify the block indices match (now in otherBlocks, so second entry).
   auto serialized = serialize(*lbnm2);
-  ASSERT_EQ(serialized.size(), 2);  // Empty primary + 1 in otherBlocks
-  EXPECT_TRUE(serialized[0].blockIndices_.empty());  // Primary is empty
+  ASSERT_EQ(serialized.size(), 2);  // Empty primary + 1 in otherBlocks.
+  EXPECT_TRUE(serialized[0].blockIndices_.empty());  // Primary is empty.
   EXPECT_EQ(serialized[1].blockIndices_, entry.blockIndices_);
 
-  // Verify the blocks are actually registered
+  // Verify the blocks are actually registered.
   EXPECT_TRUE(isBlockUsed(*bnm, 5));
   EXPECT_TRUE(isBlockUsed(*bnm, 42));
   EXPECT_TRUE(isBlockUsed(*bnm, 100));
 }
 
-}  // namespace ad_utility
+}  // namespace ad_utility.

--- a/test/BlankNodeManagerTest.cpp
+++ b/test/BlankNodeManagerTest.cpp
@@ -23,33 +23,24 @@ class BlankNodeManagerTestFixture : public ::testing::Test {
  protected:
   // Helper to create a BlankNodeManager with default minIndex.
   static std::unique_ptr<BlankNodeManager> createManager(
-      uint64_t minIndex = 0,
-      ad_utility::source_location loc = AD_CURRENT_SOURCE_LOC()) {
-    auto t = generateLocationTrace(loc);
+      uint64_t minIndex = 0) {
     return std::make_unique<BlankNodeManager>(minIndex);
   }
 
   // Helper to create a LocalBlankNodeManager.
   static std::shared_ptr<BlankNodeManager::LocalBlankNodeManager>
-  createLocalManager(BlankNodeManager* bnm, ad_utility::source_location loc =
-                                                AD_CURRENT_SOURCE_LOC()) {
-    auto t = generateLocationTrace(loc);
+  createLocalManager(BlankNodeManager* bnm) {
     return std::make_shared<BlankNodeManager::LocalBlankNodeManager>(bnm);
   }
 
   // Helper to get the primary blocks from a LocalBlankNodeManager.
-  static auto& getPrimaryBlocks(
-      BlankNodeManager::LocalBlankNodeManager& lbnm,
-      ad_utility::source_location loc = AD_CURRENT_SOURCE_LOC()) {
-    auto t = generateLocationTrace(loc);
+  static auto& getPrimaryBlocks(BlankNodeManager::LocalBlankNodeManager& lbnm) {
     return lbnm.blocks_->blocks_;
   }
 
   // Helper to get the total number of blocks (primary + other).
   static size_t getTotalBlockCount(
-      const BlankNodeManager::LocalBlankNodeManager& lbnm,
-      ad_utility::source_location loc = AD_CURRENT_SOURCE_LOC()) {
-    auto t = generateLocationTrace(loc);
+      const BlankNodeManager::LocalBlankNodeManager& lbnm) {
     size_t count = lbnm.blocks_->blocks_.size();
     for (const auto& otherBlocks : lbnm.otherBlocks_) {
       count += otherBlocks->blocks_.size();
@@ -59,9 +50,7 @@ class BlankNodeManagerTestFixture : public ::testing::Test {
 
   // Helper to get all block indices (from both primary and other blocks).
   static std::vector<uint64_t> getAllBlockIndices(
-      const BlankNodeManager::LocalBlankNodeManager& lbnm,
-      ad_utility::source_location loc = AD_CURRENT_SOURCE_LOC()) {
-    auto t = generateLocationTrace(loc);
+      const BlankNodeManager::LocalBlankNodeManager& lbnm) {
     std::vector<uint64_t> indices;
     for (const auto& block : lbnm.blocks_->blocks_) {
       indices.push_back(block.blockIdx_);
@@ -76,9 +65,7 @@ class BlankNodeManagerTestFixture : public ::testing::Test {
 
   // Helper to allocate N IDs from a LocalBlankNodeManager.
   static std::vector<uint64_t> allocateIds(
-      BlankNodeManager::LocalBlankNodeManager& lbnm, size_t count,
-      ad_utility::source_location loc = AD_CURRENT_SOURCE_LOC()) {
-    auto t = generateLocationTrace(loc);
+      BlankNodeManager::LocalBlankNodeManager& lbnm, size_t count) {
     std::vector<uint64_t> ids;
     ids.reserve(count);
     for (size_t i = 0; i < count; ++i) {
@@ -89,9 +76,7 @@ class BlankNodeManagerTestFixture : public ::testing::Test {
 
   // Helper to allocate IDs that span multiple blocks.
   static std::vector<uint64_t> allocateIdsAcrossBlocks(
-      BlankNodeManager::LocalBlankNodeManager& lbnm, size_t numBlocks,
-      ad_utility::source_location loc = AD_CURRENT_SOURCE_LOC()) {
-    auto t = generateLocationTrace(loc);
+      BlankNodeManager::LocalBlankNodeManager& lbnm, size_t numBlocks) {
     std::vector<uint64_t> ids;
     for (size_t i = 0; i < numBlocks; ++i) {
       // Allocate at least one ID per block.
@@ -133,34 +118,23 @@ class BlankNodeManagerTestFixture : public ::testing::Test {
   }
 
   // Helper to get the number of used blocks.
-  static size_t getUsedBlockCount(
-      const BlankNodeManager& bnm,
-      ad_utility::source_location loc = AD_CURRENT_SOURCE_LOC()) {
-    auto t = generateLocationTrace(loc);
+  static size_t getUsedBlockCount(const BlankNodeManager& bnm) {
     return bnm.state_.rlock()->usedBlocksSet_.size();
   }
 
   // Helper to check if a specific block index is used.
-  static bool isBlockUsed(
-      const BlankNodeManager& bnm, uint64_t blockIdx,
-      ad_utility::source_location loc = AD_CURRENT_SOURCE_LOC()) {
-    auto t = generateLocationTrace(loc);
+  static bool isBlockUsed(const BlankNodeManager& bnm, uint64_t blockIdx) {
     return bnm.state_.rlock()->usedBlocksSet_.contains(blockIdx);
   }
 
   // Helper to get the number of managed UUIDs.
-  static size_t getManagedUuidCount(
-      const BlankNodeManager& bnm,
-      ad_utility::source_location loc = AD_CURRENT_SOURCE_LOC()) {
-    auto t = generateLocationTrace(loc);
+  static size_t getManagedUuidCount(const BlankNodeManager& bnm) {
     return bnm.state_.rlock()->managedBlockSets_.size();
   }
 
   // Helper to serialize a LocalBlankNodeManager.
   static std::vector<BlankNodeManager::LocalBlankNodeManager::OwnedBlocksEntry>
-  serialize(const BlankNodeManager::LocalBlankNodeManager& lbnm,
-            ad_utility::source_location loc = AD_CURRENT_SOURCE_LOC()) {
-    auto t = generateLocationTrace(loc);
+  serialize(const BlankNodeManager::LocalBlankNodeManager& lbnm) {
     return lbnm.getOwnedBlockIndices();
   }
 
@@ -168,9 +142,7 @@ class BlankNodeManagerTestFixture : public ::testing::Test {
   static std::shared_ptr<BlankNodeManager::LocalBlankNodeManager> deserialize(
       BlankNodeManager* bnm,
       const std::vector<
-          BlankNodeManager::LocalBlankNodeManager::OwnedBlocksEntry>& entries,
-      ad_utility::source_location loc = AD_CURRENT_SOURCE_LOC()) {
-    auto t = generateLocationTrace(loc);
+          BlankNodeManager::LocalBlankNodeManager::OwnedBlocksEntry>& entries) {
     auto lbnm = createLocalManager(bnm);
     lbnm->allocateBlocksFromExplicitIndices(entries);
     return lbnm;
@@ -178,11 +150,8 @@ class BlankNodeManagerTestFixture : public ::testing::Test {
 
   // Helper to perform a round-trip serialization/deserialization.
   static std::shared_ptr<BlankNodeManager::LocalBlankNodeManager>
-  roundTripSerialize(
-      BlankNodeManager* bnm,
-      const BlankNodeManager::LocalBlankNodeManager& source,
-      ad_utility::source_location loc = AD_CURRENT_SOURCE_LOC()) {
-    auto t = generateLocationTrace(loc);
+  roundTripSerialize(BlankNodeManager* bnm,
+                     const BlankNodeManager::LocalBlankNodeManager& source) {
     auto entries = serialize(source);
     return deserialize(bnm, entries);
   }
@@ -195,8 +164,9 @@ TEST(BlankNodeManager, blockAllocationAndFree) {
   {
     // LocalBlankNodeManager allocates a new block.
     BlankNodeManager::LocalBlankNodeManager lbnm(&bnm);
-    [[maybe_unused]] uint64_t id = lbnm.getId();
-    EXPECT_EQ(bnm.state_.rlock()->usedBlocksSet_.size(), 1);
+    //[[maybe_unused]] uint64_t id = lbnm.getId();
+    // EXPECT_EQ(bnm.state_.rlock()->usedBlocksSet_.size(), 1);
+    EXPECT_EQ(bnm.state_.rlock()->usedBlocksSet_.size(), 0);
   }
 
   // Once the LocalBlankNodeManager is destroyed, all Blocks allocated through.
@@ -280,7 +250,6 @@ TEST_F(BlankNodeManagerTestFixture, serializationRoundTrip) {
   auto originalIds = allocateIdsAcrossBlocks(*lbnm, 3);
   ASSERT_EQ(getPrimaryBlocks(*lbnm).size(), 3);
 
-  // Serialize.
   auto entries = serialize(*lbnm);
   EXPECT_EQ(entries.size(), 1);  // Only primary blocks, no merged blocks.
   EXPECT_EQ(entries[0].blockIndices_.size(), 3);
@@ -450,7 +419,6 @@ TEST_F(BlankNodeManagerTestFixture, idAllocationAfterDeserialization) {
   auto ids = allocateIds(*lbnm1, 5);
   auto entries = serialize(*lbnm1);
 
-  // Deserialize.
   auto lbnm2 = deserialize(bnm.get(), entries);
 
   // The next ID should come from a NEW block in primary blocks
@@ -594,4 +562,4 @@ TEST_F(BlankNodeManagerTestFixture, serializationPreservesBlockIndices) {
   EXPECT_TRUE(isBlockUsed(*bnm, 100));
 }
 
-}  // namespace ad_utility.
+}  // namespace ad_utility

--- a/test/BlankNodeManagerTest.cpp
+++ b/test/BlankNodeManagerTest.cpp
@@ -164,9 +164,8 @@ TEST(BlankNodeManager, blockAllocationAndFree) {
   {
     // LocalBlankNodeManager allocates a new block.
     BlankNodeManager::LocalBlankNodeManager lbnm(&bnm);
-    //[[maybe_unused]] uint64_t id = lbnm.getId();
-    // EXPECT_EQ(bnm.state_.rlock()->usedBlocksSet_.size(), 1);
-    EXPECT_EQ(bnm.state_.rlock()->usedBlocksSet_.size(), 0);
+    [[maybe_unused]] uint64_t id = lbnm.getId();
+    EXPECT_EQ(bnm.state_.rlock()->usedBlocksSet_.size(), 1);
   }
 
   // Once the LocalBlankNodeManager is destroyed, all Blocks allocated through.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -214,7 +214,7 @@ addLinkAndDiscoverTestNoLibs(StringSortComparatorTest)
 
 addLinkAndDiscoverTest(PriorityQueueTest)
 
-addLinkAndDiscoverTest(SynchronizedTest)
+addLinkAndDiscoverTestNoLibs(SynchronizedTest)
 
 addLinkAndDiscoverTest(AllocatorWithLimitTest)
 

--- a/test/LocalVocabTest.cpp
+++ b/test/LocalVocabTest.cpp
@@ -548,22 +548,22 @@ TEST(LocalVocab, getOwnedLocalBlankNodeBlocks_WithBlankNodes) {
   ad_utility::BlankNodeManager bnm;
   LocalVocab vocab;
 
-  // Allocate some blank node IDs
+  // Allocate some blank node IDs.
   auto id1 = vocab.getBlankNodeIndex(&bnm);
   auto id2 = vocab.getBlankNodeIndex(&bnm);
   auto id3 = vocab.getBlankNodeIndex(&bnm);
 
-  // Get the owned blocks
+  // Get the owned blocks.
   auto blocks = vocab.getOwnedLocalBlankNodeBlocks();
 
-  // Should have exactly one entry (primary blocks)
+  // Should have exactly one entry (primary blocks).
   EXPECT_FALSE(blocks.empty());
   EXPECT_EQ(blocks.size(), 1);
 
-  // Verify the structure contains block indices
+  // Verify the structure contains block indices.
   EXPECT_FALSE(blocks[0].blockIndices_.empty());
 
-  // Verify the blank node IDs are still valid
+  // Verify the blank node IDs are still valid.
   EXPECT_TRUE(vocab.isBlankNodeIndexContained(id1));
   EXPECT_TRUE(vocab.isBlankNodeIndexContained(id2));
   EXPECT_TRUE(vocab.isBlankNodeIndexContained(id3));
@@ -574,14 +574,14 @@ TEST(LocalVocab, reserveBlankNodeBlocksFromExplicitIndices_EmptyIndices) {
   ad_utility::BlankNodeManager bnm;
   LocalVocab vocab;
 
-  // Call with empty vector - should not crash and should do nothing
+  // Call with empty vector - should not crash and should do nothing.
   std::vector<
       ad_utility::BlankNodeManager::LocalBlankNodeManager::OwnedBlocksEntry>
       emptyIndices;
   EXPECT_NO_THROW(
       vocab.reserveBlankNodeBlocksFromExplicitIndices(emptyIndices, &bnm));
 
-  // Verify still no blank node manager
+  // Verify still no blank node manager.
   auto blocks = vocab.getOwnedLocalBlankNodeBlocks();
   EXPECT_TRUE(blocks.empty());
 }
@@ -590,31 +590,31 @@ TEST(LocalVocab, reserveBlankNodeBlocksFromExplicitIndices_EmptyIndices) {
 TEST(LocalVocab, reserveBlankNodeBlocksFromExplicitIndices_RestoresBlocks) {
   ad_utility::BlankNodeManager bnm;
 
-  // Step 1: Create original vocab with blank nodes
+  // Step 1: Create original vocab with blank nodes.
   LocalVocab originalVocab;
   auto id1 = originalVocab.getBlankNodeIndex(&bnm);
   auto id2 = originalVocab.getBlankNodeIndex(&bnm);
   auto id3 = originalVocab.getBlankNodeIndex(&bnm);
 
-  // Step 2: Serialize the blank node blocks
+  // Step 2: Serialize the blank node blocks.
   auto serializedBlocks = originalVocab.getOwnedLocalBlankNodeBlocks();
   ASSERT_FALSE(serializedBlocks.empty());
 
-  // Step 3: Create new vocab and restore from serialized data
+  // Step 3: Create new vocab and restore from serialized data.
   LocalVocab restoredVocab;
   restoredVocab.reserveBlankNodeBlocksFromExplicitIndices(serializedBlocks,
                                                           &bnm);
 
-  // Step 4: Verify the restored vocab contains the same blank node indices
+  // Step 4: Verify the restored vocab contains the same blank node indices.
   EXPECT_TRUE(restoredVocab.isBlankNodeIndexContained(id1));
   EXPECT_TRUE(restoredVocab.isBlankNodeIndexContained(id2));
   EXPECT_TRUE(restoredVocab.isBlankNodeIndexContained(id3));
 
-  // Step 5: Verify we can still allocate new blank nodes in the restored vocab
+  // Step 5: Verify we can still allocate new blank nodes in the restored vocab.
   auto newId = restoredVocab.getBlankNodeIndex(&bnm);
   EXPECT_TRUE(restoredVocab.isBlankNodeIndexContained(newId));
 
-  // The new ID should be different from the old ones
+  // The new ID should be different from the old ones.
   EXPECT_NE(newId, id1);
   EXPECT_NE(newId, id2);
   EXPECT_NE(newId, id3);
@@ -625,11 +625,11 @@ TEST(LocalVocab, reserveBlankNodeBlocksFromExplicitIndices_PreconditionCheck) {
   ad_utility::BlankNodeManager bnm;
   LocalVocab vocab;
 
-  // Allocate a blank node, which creates the localBlankNodeManager_
+  // Allocate a blank node, which creates the localBlankNodeManager_.
   [[maybe_unused]] auto id = vocab.getBlankNodeIndex(&bnm);
 
-  // Try to reserve blocks when localBlankNodeManager_ already exists
-  // This should violate the AD_CONTRACT_CHECK
+  // Try to reserve blocks when localBlankNodeManager_ already exists.
+  // This should violate the AD_CONTRACT_CHECK.
   ad_utility::BlankNodeManager::LocalBlankNodeManager::OwnedBlocksEntry entry;
   entry.uuid_ = boost::uuids::random_generator()();
   entry.blockIndices_ = {1, 2, 3};

--- a/test/LocalVocabTest.cpp
+++ b/test/LocalVocabTest.cpp
@@ -535,3 +535,109 @@ TEST(LocalVocab, modificationIsNotBlockedAfterAcquiringHolder) {
   EXPECT_EQ(*encodedTest, literal);
   EXPECT_EQ(*encodedOther, otherLiteral);
 }
+
+// _____________________________________________________________________________
+TEST(LocalVocab, getOwnedLocalBlankNodeBlocks_EmptyCase) {
+  LocalVocab vocab;
+  auto blocks = vocab.getOwnedLocalBlankNodeBlocks();
+  EXPECT_TRUE(blocks.empty());
+}
+
+// _____________________________________________________________________________
+TEST(LocalVocab, getOwnedLocalBlankNodeBlocks_WithBlankNodes) {
+  ad_utility::BlankNodeManager bnm;
+  LocalVocab vocab;
+
+  // Allocate some blank node IDs
+  auto id1 = vocab.getBlankNodeIndex(&bnm);
+  auto id2 = vocab.getBlankNodeIndex(&bnm);
+  auto id3 = vocab.getBlankNodeIndex(&bnm);
+
+  // Get the owned blocks
+  auto blocks = vocab.getOwnedLocalBlankNodeBlocks();
+
+  // Should have exactly one entry (primary blocks)
+  EXPECT_FALSE(blocks.empty());
+  EXPECT_EQ(blocks.size(), 1);
+
+  // Verify the structure contains block indices
+  EXPECT_FALSE(blocks[0].blockIndices_.empty());
+
+  // Verify the blank node IDs are still valid
+  EXPECT_TRUE(vocab.isBlankNodeIndexContained(id1));
+  EXPECT_TRUE(vocab.isBlankNodeIndexContained(id2));
+  EXPECT_TRUE(vocab.isBlankNodeIndexContained(id3));
+}
+
+// _____________________________________________________________________________
+TEST(LocalVocab, reserveBlankNodeBlocksFromExplicitIndices_EmptyIndices) {
+  ad_utility::BlankNodeManager bnm;
+  LocalVocab vocab;
+
+  // Call with empty vector - should not crash and should do nothing
+  std::vector<
+      ad_utility::BlankNodeManager::LocalBlankNodeManager::OwnedBlocksEntry>
+      emptyIndices;
+  EXPECT_NO_THROW(
+      vocab.reserveBlankNodeBlocksFromExplicitIndices(emptyIndices, &bnm));
+
+  // Verify still no blank node manager
+  auto blocks = vocab.getOwnedLocalBlankNodeBlocks();
+  EXPECT_TRUE(blocks.empty());
+}
+
+// _____________________________________________________________________________
+TEST(LocalVocab, reserveBlankNodeBlocksFromExplicitIndices_RestoresBlocks) {
+  ad_utility::BlankNodeManager bnm;
+
+  // Step 1: Create original vocab with blank nodes
+  LocalVocab originalVocab;
+  auto id1 = originalVocab.getBlankNodeIndex(&bnm);
+  auto id2 = originalVocab.getBlankNodeIndex(&bnm);
+  auto id3 = originalVocab.getBlankNodeIndex(&bnm);
+
+  // Step 2: Serialize the blank node blocks
+  auto serializedBlocks = originalVocab.getOwnedLocalBlankNodeBlocks();
+  ASSERT_FALSE(serializedBlocks.empty());
+
+  // Step 3: Create new vocab and restore from serialized data
+  LocalVocab restoredVocab;
+  restoredVocab.reserveBlankNodeBlocksFromExplicitIndices(serializedBlocks,
+                                                          &bnm);
+
+  // Step 4: Verify the restored vocab contains the same blank node indices
+  EXPECT_TRUE(restoredVocab.isBlankNodeIndexContained(id1));
+  EXPECT_TRUE(restoredVocab.isBlankNodeIndexContained(id2));
+  EXPECT_TRUE(restoredVocab.isBlankNodeIndexContained(id3));
+
+  // Step 5: Verify we can still allocate new blank nodes in the restored vocab
+  auto newId = restoredVocab.getBlankNodeIndex(&bnm);
+  EXPECT_TRUE(restoredVocab.isBlankNodeIndexContained(newId));
+
+  // The new ID should be different from the old ones
+  EXPECT_NE(newId, id1);
+  EXPECT_NE(newId, id2);
+  EXPECT_NE(newId, id3);
+}
+
+// _____________________________________________________________________________
+TEST(LocalVocab, reserveBlankNodeBlocksFromExplicitIndices_PreconditionCheck) {
+  ad_utility::BlankNodeManager bnm;
+  LocalVocab vocab;
+
+  // Allocate a blank node, which creates the localBlankNodeManager_
+  [[maybe_unused]] auto id = vocab.getBlankNodeIndex(&bnm);
+
+  // Try to reserve blocks when localBlankNodeManager_ already exists
+  // This should violate the AD_CONTRACT_CHECK
+  ad_utility::BlankNodeManager::LocalBlankNodeManager::OwnedBlocksEntry entry;
+  entry.uuid_ = boost::uuids::random_generator()();
+  entry.blockIndices_ = {1, 2, 3};
+  std::vector<
+      ad_utility::BlankNodeManager::LocalBlankNodeManager::OwnedBlocksEntry>
+      indices{entry};
+
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      vocab.reserveBlankNodeBlocksFromExplicitIndices(indices, &bnm),
+      ::testing::HasSubstr("Assertion"));
+}


### PR DESCRIPTION
`CONSTRUCT` queries, `SERVICE` requests, update operations, and the `BNODE` function can create new blank nodes, which must be separate from the already existing blank nodes. To this end, #1504 introduced a `BlankNodeManager`, later extended and improved in #1617 and #2126. So far, there was no control over exactly which blank node identifiers where returned by that manager. However, this is important for persisting results containing such blank node identifiers across server restarts because multiple such results may refer to the same blank node identifiers.

There is now a mechanism for allocating an explicit set of ranges of blank node identifiers. Each such set is identified by a unique UUID, so that the same set of ranges can be unambiguously referenced by multiple results (we could have also used the ranges themselves as unique identifier, but a UUID is simpler). There is also infrastructure for integrating this information with the `LocalVocab` (queries and updates can generate both new blank nodes and new local vocab entries) and serializing this information. There is not yet code for actually writing it to disk or reading it back from disk, that is work for a separate PR