### PR TITLE
Clean up code in `index` related to index building

### DIFF
--- a/src/index/ConstantsIndexBuilding.h
+++ b/src/index/ConstantsIndexBuilding.h
@@ -62,10 +62,6 @@ constexpr inline std::string_view PARTIAL_VOCAB_WORDS_INFIX =
 constexpr inline std::string_view PARTIAL_VOCAB_IDMAP_INFIX =
     ".partial-vocab.idmap.tmp.";
 
-// ________________________________________________________________
-constexpr inline std::string_view TMP_BASENAME_COMPRESSION =
-    ".tmp.for-prefix-compression";
-
 // _________________________________________________________________
 constexpr inline std::string_view QLEVER_INTERNAL_INDEX_INFIX = ".internal";
 

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -1440,13 +1440,10 @@ std::future<void> IndexImpl::writeNextPartialVocabulary(
   std::future<void> resultFuture;
   std::string partialFilename =
       absl::StrCat(onDiskBase_, PARTIAL_VOCAB_WORDS_INFIX, numFiles);
-  std::string partialCompressionFilename =
-      absl::StrCat(onDiskBase_, TMP_BASENAME_COMPRESSION,
-                   PARTIAL_VOCAB_WORDS_INFIX, numFiles);
 
   auto lambda = [localIds = std::move(localIds), globalWritePtr,
                  items = std::move(items), vocab = &vocab_, partialFilename,
-                 partialCompressionFilename, numFiles]() mutable {
+                 numFiles]() mutable {
     auto vec = [&]() {
       ad_utility::TimeBlockAndLog l{"vocab maps to vector"};
       return vocabMapsToVector(*items);
@@ -1462,7 +1459,7 @@ std::future<void> IndexImpl::writeNextPartialVocabulary(
     }
     auto mapping = [&]() {
       ad_utility::TimeBlockAndLog l{"creating internal mapping"};
-      return createInternalMapping(&vec);
+      return createInternalMapping(vec);
     }();
     AD_LOG_TRACE << "Finished creating of Mapping vocabulary" << std::endl;
     // since now adjacent duplicates also have the same Ids, it suffices to

--- a/src/index/VocabularyMerger.h
+++ b/src/index/VocabularyMerger.h
@@ -284,7 +284,7 @@ ad_utility::HashMap<Id, Id> IdMapFromPartialIdMapFile(
  * @param els  Must be sorted(at least duplicates must be adjacent) according to
  * the strings and the Ids must be unique to work correctly.
  */
-ad_utility::HashMap<uint64_t, uint64_t> createInternalMapping(ItemVec* els);
+ad_utility::HashMap<uint64_t, uint64_t> createInternalMapping(ItemVec& els);
 
 /**
  * @brief for each of the IdTriples in <input>: map the three Ids using the

--- a/src/index/VocabularyMergerImpl.h
+++ b/src/index/VocabularyMergerImpl.h
@@ -5,26 +5,17 @@
 #ifndef QLEVER_SRC_INDEX_VOCABULARYMERGERIMPL_H
 #define QLEVER_SRC_INDEX_VOCABULARYMERGERIMPL_H
 
-#include <fstream>
 #include <future>
-#include <iostream>
-#include <queue>
 #include <string>
-#include <unordered_set>
 #include <utility>
 #include <vector>
 
 #include "backports/algorithm.h"
 #include "index/ConstantsIndexBuilding.h"
-#include "index/Vocabulary.h"
 #include "index/VocabularyMerger.h"
-#include "parser/TripleComponent.h"
-#include "rdfTypes/RdfEscaping.h"
-#include "util/Conversions.h"
 #include "util/Exception.h"
 #include "util/HashMap.h"
 #include "util/InputRangeUtils.h"
-#include "util/Iterators.h"
 #include "util/Log.h"
 #include "util/ParallelMultiwayMerge.h"
 #include "util/ProgressBar.h"
@@ -239,10 +230,8 @@ inline void VocabularyMerger::doActualWrite(
 }
 
 // ____________________________________________________________________________________________________________
-inline ad_utility::HashMap<uint64_t, uint64_t> createInternalMapping(
-    ItemVec* elsPtr) {
-  auto& els = *elsPtr;
-  ad_utility::HashMap<uint64_t, uint64_t> res;
+inline HashMap<uint64_t, uint64_t> createInternalMapping(ItemVec& els) {
+  HashMap<uint64_t, uint64_t> res;
   res.reserve(2 * els.size());
   bool first = true;
   std::string_view lastWord;

--- a/test/VocabularyGeneratorTest.cpp
+++ b/test/VocabularyGeneratorTest.cpp
@@ -240,7 +240,7 @@ TEST(VocabularyGeneratorTest, createInternalMapping) {
   input.emplace_back("e", S{38, d});
   input.emplace_back("xenon", S{0, d});
 
-  auto res = createInternalMapping(&input);
+  auto res = createInternalMapping(input);
   ASSERT_EQ(0u, input[0].second.id_);
   ASSERT_EQ(1u, input[1].second.id_);
   ASSERT_EQ(1u, input[2].second.id_);


### PR DESCRIPTION
Remove unused code in `src/index/ConstantsIndexBuilding.h`, `src/index/IndexImpl.cpp`, and `src/index/VocabularyMergerImpl.h` with some minor improvements on the side