### PR TITLE
Backport three more pieces of code to C++17

### DIFF
--- a/src/engine/SpatialJoinAlgorithms.h
+++ b/src/engine/SpatialJoinAlgorithms.h
@@ -56,11 +56,19 @@ struct BoundingBoxVisitor : public boost::static_visitor<Box> {
 struct ClosestPointVisitor : public boost::static_visitor<double> {
   template <typename Geometry1, typename Geometry2>
   double operator()(const Geometry1& geo1, const Geometry2& geo2) const {
+#ifdef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
+    throw std::runtime_error(
+        "ClosestPointVisitor not implemented for C++17, please use a different "
+        "spatial join implementation");
+    (void)geo1;
+    (void)geo2;
+#else
     Segment seg;
     bg::closest_points(geo1, geo2, seg);
     GeoPoint closestPoint1(bg::get<0, 1>(seg), bg::get<0, 0>(seg));
     GeoPoint closestPoint2(bg::get<1, 1>(seg), bg::get<1, 0>(seg));
     return ad_utility::detail::wktDistImpl(closestPoint1, closestPoint2);
+#endif
   }
 };
 

--- a/src/libqlever/LibQLeverExample.cpp
+++ b/src/libqlever/LibQLeverExample.cpp
@@ -59,7 +59,6 @@ int main(int argc, char** argv) {
     std::cerr << "Executing the query failed: " << e.what() << std::endl;
     return 1;
   }
-  std::cout.imbue(std::locale(""));
   std::cout << "Query executed in " << timer.msecs().count() << "ms"
             << std::endl;
   std::cout << std::endl;

--- a/src/util/stream_generator.h
+++ b/src/util/stream_generator.h
@@ -313,7 +313,7 @@ using stream_generator = basic_stream_generator<1u << 20>;
 // NOTE: A `string_view` that is pushed via `operator()` might and often will be
 // split up between two callback invocations. The callback for the final batch
 // is invoked either in the destructor or via an explicit call to `finish()`.
-template <size_t BATCH_SIZE = 1u << 20>
+template <size_t BATCH_SIZE = 1'000>
 class StringBatcher {
   using CallbackForBatches = std::function<void(std::string_view)>;
   CallbackForBatches callbackForBatches_;


### PR DESCRIPTION
1. `boost::geometry::closest_points` does not work with C++17, but we don't use the respective spatial join anyway (we only used this for experiments to test the performance of `Boost.Geometry`)
2. `std::cout.imbue(std::locale(""));` makes problems with C++17 in `LibQleverExample.cpp`, but it's only needed for formatting so we just remove it
3. Reduce the batch size in the `StringBatcher` from `2^20` to `1000`, for systems that do not have such a large stack size