### PR TITLE
Implement `IdTable::insertSubsetAtEnd` and two test helpers

### DIFF
--- a/src/engine/idTable/IdTable.h
+++ b/src/engine/idTable/IdTable.h
@@ -9,7 +9,6 @@
 #include <cassert>
 #include <cstdlib>
 #include <initializer_list>
-#include <ranges>
 #include <variant>
 #include <vector>
 
@@ -776,7 +775,7 @@ class IdTable {
 
   // Add the rows with the specified `indices` from the `table` at the end of
   // this IdTable. The order of the inserted rows is the same as in `indices`.
-  // The input must be some kind of `IdTable`.
+  // The `table` must be some kind of `IdTable`.
   template <typename Table>
   void insertSubsetAtEnd(const Table& table,
                          const std::vector<size_t>& indices) {
@@ -791,11 +790,10 @@ class IdTable {
     resize(numRows() + numInserted);
     // For each column, copy the requested rows into the reserved tail.
     for (auto&& [destination, source] :
-         ranges::views::zip(ad_utility::allView(getColumns()),
-                            ad_utility::allView(table.getColumns()))) {
-      ql::ranges::transform(
-          indices, destination.begin() + oldSize,
-          [&source = source](size_t idx) { return source[idx]; });
+         ::ranges::views::zip(ad_utility::allView(getColumns()),
+                              ad_utility::allView(table.getColumns()))) {
+      ql::ranges::transform(indices, destination.begin() + oldSize,
+                            [&source](size_t idx) { return source[idx]; });
     }
   }
 

--- a/test/IdTableTest.cpp
+++ b/test/IdTableTest.cpp
@@ -395,6 +395,7 @@ TEST(IdTable, insertSubsetAtEnd) {
     // expected rows: original dst row, then src row 2, then src row 0
     ASSERT_EQ(dst.size(), 3u);
     EXPECT_EQ(dst[0][0], make(1));
+    EXPECT_EQ(dst[0][1], make(2));
     EXPECT_EQ(dst[1][0], make(30));
     EXPECT_EQ(dst[2][0], make(10));
     EXPECT_EQ(dst[1][1], make(31));


### PR DESCRIPTION
For an `IdTable`, it is now possible to append a subset of another `IdTable`. The subset is given as a vector of row indices. This is preparation for #2301.

Also implement two test helpers for for setting up `IdTable`s with specific contents for test cases and benchmarks