### PR TITLE
Explicitly instantiate `Server::createMessageSender` for `http::request<http::string_body>`

### DIFF
--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -1288,3 +1288,9 @@ void Server::adjustParsedQueryLimitOffset(
     exportLimit = std::stoul(sendParameter.value());
   }
 }
+
+// _____________________________________________________________________________
+template ad_utility::websocket::MessageSender
+Server::createMessageSender<http::request<http::string_body>>(
+    const std::weak_ptr<ad_utility::websocket::QueryHub>&,
+    const http::request<http::string_body>&, std::string_view);


### PR DESCRIPTION
Fixes a [compilation failure](https://gist.github.com/goelzma/51c0094598fb84c55de97bad4c1927e8) under gcc 15.2.1. `Server::createMessageSender` is being used with the same template parameters inside `Server.cpp` as well as in `ServerTest.cpp`, but this doesn't guarantee that the instantiated function will also be linkable in the final binary. With explicit instantiation we now get this guarantee.