### PR TITLE
Introduce new `RuntimeInformation::Status::fullyMaterializedCompleted`

### DIFF
--- a/src/engine/CountAvailablePredicates.cpp
+++ b/src/engine/CountAvailablePredicates.cpp
@@ -132,7 +132,7 @@ Result CountAvailablePredicates::computeResult(
 
   if (isPatternTrickForAllEntities) {
     subtree_->getRootOperation()->runtimeInfo().status_ =
-        RuntimeInformation::Status::lazilyMaterialized;
+        RuntimeInformation::Status::lazilyMaterializedInProgress;
     signalQueryUpdate(RuntimeInformation::SendPriority::Always);
     // Compute the predicates for all entities
     CountAvailablePredicates::computePatternTrickAllEntities(&idTable,

--- a/src/engine/IndexScan.cpp
+++ b/src/engine/IndexScan.cpp
@@ -500,7 +500,7 @@ void IndexScan::updateRuntimeInfoForLazyScan(
     const LazyScanMetadata& metadata,
     RuntimeInformation::SendPriority sendPriority) {
   auto& rti = runtimeInfo();
-  rti.status_ = RuntimeInformation::Status::lazilyMaterialized;
+  rti.status_ = RuntimeInformation::Status::lazilyMaterializedInProgress;
   rti.numRows_ = metadata.numElementsYielded_;
   rti.totalTime_ = metadata.blockingTime_;
   rti.addDetail("num-blocks-read", metadata.numBlocksRead_);

--- a/src/engine/Join.cpp
+++ b/src/engine/Join.cpp
@@ -633,9 +633,9 @@ Result Join::computeResultForTwoIndexScans(bool requestLaziness) const {
         ad_utility::zipperJoinForBlocksWithoutUndef(leftBlocks, rightBlocks,
                                                     std::less{}, rowAdder);
         leftScan->runtimeInfo().status_ =
-            RuntimeInformation::Status::fullyLazilyMaterialized;
+            RuntimeInformation::Status::lazilyMaterializedCompleted;
         rightScan->runtimeInfo().status_ =
-            RuntimeInformation::Status::fullyLazilyMaterialized;
+            RuntimeInformation::Status::lazilyMaterializedCompleted;
 
         auto localVocab = std::move(rowAdder.localVocab());
         return Result::IdTableVocabPair{std::move(rowAdder).resultTable(),
@@ -705,7 +705,7 @@ Result Join::computeResultForIndexScanAndIdTable(
           doJoin(blockForIdTable, rightBlocks);
         }
         scan->runtimeInfo().status_ =
-            RuntimeInformation::Status::fullyLazilyMaterialized;
+            RuntimeInformation::Status::lazilyMaterializedCompleted;
 
         auto localVocab = std::move(rowAdder.localVocab());
         return Result::IdTableVocabPair{std::move(rowAdder).resultTable(),
@@ -742,7 +742,7 @@ Result Join::computeResultForIndexScanAndLazyOperation(
                              joinColMap.permutationRight()),
             std::less{}, rowAdder);
         scan->runtimeInfo().status_ =
-            RuntimeInformation::Status::fullyLazilyMaterialized;
+            RuntimeInformation::Status::lazilyMaterializedCompleted;
 
         auto localVocab = std::move(rowAdder.localVocab());
         return Result::IdTableVocabPair{std::move(rowAdder).resultTable(),

--- a/src/engine/Operation.cpp
+++ b/src/engine/Operation.cpp
@@ -140,7 +140,8 @@ Result Operation::runComputation(const ad_utility::Timer& timer,
                                  ComputationMode computationMode) {
   AD_CONTRACT_CHECK(computationMode != ComputationMode::ONLY_IF_CACHED);
   checkCancellation();
-  runtimeInfo().status_ = RuntimeInformation::Status::inProgress;
+  runtimeInfo().status_ =
+      RuntimeInformation::Status::fullyMaterializedInProgress;
   signalQueryUpdate(RuntimeInformation::SendPriority::Always);
   Result result =
       computeResult(computationMode == ComputationMode::LAZY_IF_SUPPORTED);
@@ -179,7 +180,7 @@ Result Operation::runComputation(const ad_utility::Timer& timer,
         });
   } else {
     auto& rti = runtimeInfo();
-    rti.status_ = RuntimeInformation::lazilyMaterialized;
+    rti.status_ = RuntimeInformation::lazilyMaterializedInProgress;
     rti.totalTime_ = timer.msecs();
     rti.originalTotalTime_ = rti.totalTime_;
     rti.originalOperationTime_ = rti.getOperationTime();
@@ -208,9 +209,10 @@ Result Operation::runComputation(const ad_utility::Timer& timer,
           signalQueryUpdate(RuntimeInformation::SendPriority::IfDue);
         },
         [this](bool failed) {
+          // TODO<RobinTF> Distinguish between failed and cancelled.
           runtimeInfo().status_ =
               failed ? RuntimeInformation::failed
-                     : RuntimeInformation::fullyLazilyMaterialized;
+                     : RuntimeInformation::lazilyMaterializedCompleted;
           signalQueryUpdate(RuntimeInformation::SendPriority::Always);
         });
   }
@@ -266,7 +268,7 @@ CacheValue Operation::runComputationAndPrepareForCache(
         [runtimeInfo = getRuntimeInfoPointer(), &cache,
          cacheKey](Result aggregatedResult) {
           auto copy = *runtimeInfo;
-          copy.status_ = RuntimeInformation::Status::fullyMaterialized;
+          copy.status_ = RuntimeInformation::Status::fullyMaterializedCompleted;
           cache.tryInsertIfNotPresent(
               false, cacheKey,
               std::make_shared<CacheValue>(std::move(aggregatedResult),
@@ -473,7 +475,8 @@ void Operation::updateRuntimeInformationOnSuccess(
   _runtimeInfo->numRows_ = numRows;
   _runtimeInfo->cacheStatus_ = cacheStatus;
 
-  _runtimeInfo->status_ = RuntimeInformation::Status::fullyMaterialized;
+  _runtimeInfo->status_ =
+      RuntimeInformation::Status::fullyMaterializedCompleted;
 
   bool wasCached = cacheStatus != ad_utility::CacheStatus::computed;
   // If the result was read from the cache, then we need the additional

--- a/src/engine/RuntimeInformation.cpp
+++ b/src/engine/RuntimeInformation.cpp
@@ -168,14 +168,14 @@ size_t RuntimeInformation::getOperationCostEstimate() const {
 // __________________________________________________________________________
 std::string_view RuntimeInformation::toString(Status status) {
   switch (status) {
-    case fullyMaterialized:
-      return "fully materialized";
-    case lazilyMaterialized:
-      return "lazily materialized";
-    case fullyLazilyMaterialized:
-      return "fully lazily materialized";
-    case inProgress:
-      return "in progress";
+    case fullyMaterializedCompleted:
+      return "fully materialized completed";
+    case lazilyMaterializedInProgress:
+      return "lazily materialized in progress";
+    case lazilyMaterializedCompleted:
+      return "lazily materialized completed";
+    case fullyMaterializedInProgress:
+      return "fully materialized in progress";
     case notStarted:
       return "not started";
     case optimizedOut:

--- a/src/engine/RuntimeInformation.h
+++ b/src/engine/RuntimeInformation.h
@@ -31,10 +31,10 @@ class RuntimeInformation {
   /// The computation status of an operation.
   enum struct Status {
     notStarted,
-    inProgress,
-    fullyMaterialized,
-    lazilyMaterialized,
-    fullyLazilyMaterialized,
+    fullyMaterializedInProgress,
+    fullyMaterializedCompleted,
+    lazilyMaterializedInProgress,
+    lazilyMaterializedCompleted,
     optimizedOut,
     failed,
     failedBecauseChildFailed,

--- a/test/OperationTest.cpp
+++ b/test/OperationTest.cpp
@@ -104,7 +104,7 @@ TEST(OperationTest, getResultOnlyCached) {
   NeutralElementOperation n2{qec};
   auto result = n2.getResult();
   EXPECT_NE(result, nullptr);
-  EXPECT_EQ(n2.runtimeInfo().status_, Status::fullyMaterialized);
+  EXPECT_EQ(n2.runtimeInfo().status_, Status::fullyMaterializedCompleted);
   EXPECT_EQ(n2.runtimeInfo().cacheStatus_, CacheStatus::computed);
   EXPECT_EQ(qec->getQueryTreeCache().numNonPinnedEntries(), 1);
   EXPECT_EQ(qec->getQueryTreeCache().numPinnedEntries(), 0);
@@ -203,14 +203,16 @@ TEST_F(OperationTestFixture,
 
   EXPECT_THAT(
       jsonHistory,
-      ElementsAre(
-          ParsedAsJson(HasKeyMatching("status", Eq("not started"))),
-          ParsedAsJson(HasKeyMatching("status", Eq("in progress"))),
-          // Note: Currently the implementation triggers twice if a value
-          // is not cached. This is not a requirement, just an implementation
-          // detail that we account for here.
-          ParsedAsJson(HasKeyMatching("status", Eq("fully materialized"))),
-          ParsedAsJson(HasKeyMatching("status", Eq("fully materialized")))));
+      ElementsAre(ParsedAsJson(HasKeyMatching("status", Eq("not started"))),
+                  ParsedAsJson(HasKeyMatching(
+                      "status", Eq("fully materialized in progress"))),
+                  // Note: Currently the implementation triggers twice if a
+                  // value is not cached. This is not a requirement, just an
+                  // implementation detail that we account for here.
+                  ParsedAsJson(HasKeyMatching(
+                      "status", Eq("fully materialized completed"))),
+                  ParsedAsJson(HasKeyMatching(
+                      "status", Eq("fully materialized completed")))));
 }
 
 // _____________________________________________________________________________
@@ -223,9 +225,9 @@ TEST_F(OperationTestFixture, verifyCachePreventsInProgressState) {
 
   EXPECT_THAT(
       jsonHistory,
-      ElementsAre(
-          ParsedAsJson(HasKeyMatching("status", Eq("not started"))),
-          ParsedAsJson(HasKeyMatching("status", Eq("fully materialized")))));
+      ElementsAre(ParsedAsJson(HasKeyMatching("status", Eq("not started"))),
+                  ParsedAsJson(HasKeyMatching(
+                      "status", Eq("fully materialized completed")))));
 }
 
 // _____________________________________________________________________________
@@ -446,7 +448,7 @@ TEST(Operation, verifyRuntimeInformationIsUpdatedForLazyOperations) {
 
   auto& rti = valuesForTesting.runtimeInfo();
 
-  EXPECT_EQ(rti.status_, Status::lazilyMaterialized);
+  EXPECT_EQ(rti.status_, Status::lazilyMaterializedInProgress);
   EXPECT_GE(rti.totalTime_, timeout);
   EXPECT_GE(rti.originalTotalTime_, timeout);
   EXPECT_GE(rti.originalOperationTime_, timeout);
@@ -454,21 +456,21 @@ TEST(Operation, verifyRuntimeInformationIsUpdatedForLazyOperations) {
   expectAtEachStageOfGenerator(
       result.idTables(),
       {[&]() {
-         EXPECT_EQ(rti.status_, Status::lazilyMaterialized);
+         EXPECT_EQ(rti.status_, Status::lazilyMaterializedInProgress);
          expectRtiHasDimensions(rti, 2, 1);
          ASSERT_TRUE(rti.details_.contains("non-empty-local-vocabs"));
          EXPECT_EQ(rti.details_["non-empty-local-vocabs"],
                    "1 / 1, Ø = 1, max = 1");
        },
        [&]() {
-         EXPECT_EQ(rti.status_, Status::lazilyMaterialized);
+         EXPECT_EQ(rti.status_, Status::lazilyMaterializedInProgress);
          expectRtiHasDimensions(rti, 2, 2);
          ASSERT_TRUE(rti.details_.contains("non-empty-local-vocabs"));
          EXPECT_EQ(rti.details_["non-empty-local-vocabs"],
                    "2 / 2, Ø = 1, max = 1");
        }});
 
-  EXPECT_EQ(rti.status_, Status::fullyLazilyMaterialized);
+  EXPECT_EQ(rti.status_, Status::lazilyMaterializedCompleted);
   expectRtiHasDimensions(rti, 2, 2);
   ASSERT_TRUE(rti.details_.contains("non-empty-local-vocabs"));
   EXPECT_EQ(rti.details_["non-empty-local-vocabs"], "2 / 2, Ø = 1, max = 1");
@@ -492,7 +494,8 @@ TEST(Operation, ensureFailedStatusIsSetWhenGeneratorThrowsException) {
   auto result =
       operation.runComputation(timer, ComputationMode::LAZY_IF_SUPPORTED);
 
-  EXPECT_EQ(operation.runtimeInfo().status_, Status::lazilyMaterialized);
+  EXPECT_EQ(operation.runtimeInfo().status_,
+            Status::lazilyMaterializedInProgress);
 
   EXPECT_THROW(result.idTables().begin(), std::runtime_error);
 
@@ -665,7 +668,7 @@ TEST(Operation, ensureLazyOperationIsCachedIfSmallEnough) {
   EXPECT_EQ(newRti.totalTime_, oldRti.totalTime_);
   EXPECT_EQ(newRti.originalTotalTime_, oldRti.originalTotalTime_);
   EXPECT_EQ(newRti.originalOperationTime_, oldRti.originalOperationTime_);
-  EXPECT_EQ(newRti.status_, Status::fullyMaterialized);
+  EXPECT_EQ(newRti.status_, Status::fullyMaterializedCompleted);
 
   const auto& aggregatedResult =
       aggregatedValue.value()._resultPointer->resultTable();

--- a/test/RuntimeInformationTest.cpp
+++ b/test/RuntimeInformationTest.cpp
@@ -92,13 +92,20 @@ TEST(RuntimeInformation, setColumnNames) {
 TEST(RuntimeInformation, statusToString) {
   using enum RuntimeInformation::Status;
   using R = RuntimeInformation;
-  EXPECT_EQ(R::toString(fullyMaterialized), "fully materialized");
-  EXPECT_EQ(R::toString(lazilyMaterialized), "lazily materialized");
+  EXPECT_EQ(R::toString(fullyMaterializedCompleted),
+            "fully materialized completed");
+  EXPECT_EQ(R::toString(lazilyMaterializedInProgress),
+            "lazily materialized in progress");
+  EXPECT_EQ(R::toString(lazilyMaterializedCompleted),
+            "lazily materialized completed");
+  EXPECT_EQ(R::toString(fullyMaterializedInProgress),
+            "fully materialized in progress");
   EXPECT_EQ(R::toString(notStarted), "not started");
   EXPECT_EQ(R::toString(optimizedOut), "optimized out");
   EXPECT_EQ(R::toString(failed), "failed");
   EXPECT_EQ(R::toString(failedBecauseChildFailed),
             "failed because child failed");
+  EXPECT_EQ(R::toString(cancelled), "cancelled");
   EXPECT_ANY_THROW(R::toString(static_cast<RuntimeInformation::Status>(72)));
 }
 
@@ -152,7 +159,7 @@ TEST(RuntimeInformation, toStringAndJson) {
   parent.columnNames_.push_back("?alpha");
   parent.totalTime_ = 6ms;
   parent.cacheStatus_ = ad_utility::CacheStatus::computed;
-  parent.status_ = RuntimeInformation::Status::fullyMaterialized;
+  parent.status_ = RuntimeInformation::Status::fullyMaterializedCompleted;
 
   parent.children_.push_back(std::make_shared<RuntimeInformation>(child));
 
@@ -164,7 +171,7 @@ TEST(RuntimeInformation, toStringAndJson) {
 │  columns: ?alpha
 │  total_time: 6 ms
 │  operation_time: 3 ms
-│  status: fully materialized
+│  status: fully materialized completed
 │  cache_status: computed
 │  ┬
 │  │
@@ -198,7 +205,7 @@ TEST(RuntimeInformation, toStringAndJson) {
 "estimated_operation_cost": 0,
 "estimated_column_multiplicities": [],
 "estimated_size": 0,
-"status": "fully materialized",
+"status": "fully materialized completed",
 "children": [
     {
         "description": "child",

--- a/test/engine/IndexScanTest.cpp
+++ b/test/engine/IndexScanTest.cpp
@@ -970,7 +970,7 @@ TEST_P(IndexScanWithLazyJoin, prefilterTablesDoesFilterCorrectly) {
         const auto& rti = scan.runtimeInfo();
         if (counter >= sideOffset) {
           EXPECT_EQ(rti.status_,
-                    RuntimeInformation::Status::lazilyMaterialized);
+                    RuntimeInformation::Status::lazilyMaterializedInProgress);
         }
         if (counter >= 2 + sideOffset) {
           EXPECT_GT(rti.numRows_, 0);
@@ -1004,7 +1004,8 @@ TEST_P(IndexScanWithLazyJoin, prefilterTablesDoesFilterCorrectly) {
             makeIdTable({iri("<c>"), iri("<q>"), iri("<xb>")}));
 
   const auto& rti = scan.runtimeInfo();
-  EXPECT_EQ(rti.status_, RuntimeInformation::Status::lazilyMaterialized);
+  EXPECT_EQ(rti.status_,
+            RuntimeInformation::Status::lazilyMaterializedInProgress);
   EXPECT_EQ(rti.numRows_, 4);
   // Note: In the code the `totalTime_` is also set, but the actual code runs
   // faster than a single millisecond, so it won't show up in the data.
@@ -1068,7 +1069,8 @@ TEST_P(IndexScanWithLazyJoin,
   ASSERT_EQ(joinSideResults.size(), 0);
 
   const auto& rti = scan.runtimeInfo();
-  EXPECT_EQ(rti.status_, RuntimeInformation::Status::lazilyMaterialized);
+  EXPECT_EQ(rti.status_,
+            RuntimeInformation::Status::lazilyMaterializedInProgress);
   EXPECT_EQ(rti.numRows_, 0);
   EXPECT_EQ(rti.details_["num-blocks-read"], 0);
   EXPECT_EQ(rti.details_["num-blocks-all"], 1);
@@ -1188,7 +1190,8 @@ TEST_P(IndexScanWithLazyJoin, prefilterTablesDoesNotFilterOnUndefined) {
       tableFromTriples({{iri("<c>"), iri("<C>")}, {iri("<c>"), iri("<C2>")}}));
 
   const auto& rti = scan.runtimeInfo();
-  EXPECT_EQ(rti.status_, RuntimeInformation::Status::lazilyMaterialized);
+  EXPECT_EQ(rti.status_,
+            RuntimeInformation::Status::lazilyMaterializedInProgress);
   EXPECT_EQ(rti.numRows_, 6);
   EXPECT_EQ(rti.details_["num-blocks-read"], 3);
   EXPECT_EQ(rti.details_["num-blocks-all"], 3);
@@ -1242,7 +1245,8 @@ TEST_P(IndexScanWithLazyJoin, prefilterTablesWorksWithSingleEmptyTable) {
   ASSERT_EQ(scanResults.size(), 0);
 
   const auto& rti = scan.runtimeInfo();
-  EXPECT_EQ(rti.status_, RuntimeInformation::Status::lazilyMaterialized);
+  EXPECT_EQ(rti.status_,
+            RuntimeInformation::Status::lazilyMaterializedInProgress);
   EXPECT_EQ(rti.numRows_, 0);
   EXPECT_EQ(rti.details_["num-blocks-read"], 0);
   EXPECT_EQ(rti.details_["num-blocks-all"], 3);


### PR DESCRIPTION
Rename three of the existing states and add one new. Here are the new names, the last one being for the new state. The new state helps the new Qlue UI to figure out when a lazily materialized operation is completed (which was hard so far when it was the root operation of a query).
```
RuntimeInformation::Status::fullyMaterializedInProgress
RuntimeInformation::Status::fullyMaterializedCompleted
RuntimeInformation::Status::lazilyMaterializedInProgress
RuntimeInformation::Status::lazilyMaterializedCompleted
```