### PR TITLE
Handle blank nodes and local vocab entries correctly in the triple serializer

### DIFF
--- a/src/util/BlankNodeManager.h
+++ b/src/util/BlankNodeManager.h
@@ -23,6 +23,8 @@
 #include "util/HashMap.h"
 #include "util/HashSet.h"
 #include "util/Random.h"
+#include "util/Serializer/SerializeVector.h"
+#include "util/Serializer/Serializer.h"
 #include "util/Synchronized.h"
 
 namespace ad_utility {
@@ -190,6 +192,10 @@ class BlankNodeManager {
     struct OwnedBlocksEntry {
       boost::uuids::uuid uuid_;
       std::vector<uint64_t> blockIndices_;
+      AD_SERIALIZE_FRIEND_FUNCTION(OwnedBlocksEntry) {
+        triviallySerialize(serializer, arg.uuid_);
+        serializer | arg.blockIndices_;
+      }
     };
 
     // Return the indices of all the blank node blocks that are currently being

--- a/src/util/Serializer/TripleSerializer.h
+++ b/src/util/Serializer/TripleSerializer.h
@@ -19,6 +19,7 @@
 #include "util/Serializer/FileSerializer.h"
 #include "util/Serializer/SerializeArrayOrTuple.h"
 #include "util/Serializer/SerializeString.h"
+#include "util/TransparentFunctors.h"
 #include "util/TypeTraits.h"
 #include "util/Views.h"
 
@@ -67,21 +68,36 @@ CPP_template(typename Serializer)(
     requires serialization::WriteSerializer<
         Serializer>) void serializeLocalVocab(Serializer& serializer,
                                               const LocalVocab& vocab) {
-  AD_CONTRACT_CHECK(vocab.numSets() == 1);
-  const auto& words = vocab.primaryWordSet();
-  serializer << words.size();
-  ql::ranges::for_each(words, [&serializer](const auto& localVocabEntry) {
-    serializer << Id::makeFromLocalVocabIndex(&localVocabEntry);
-    serializer << localVocabEntry.toStringRepresentation();
-  });
+  serializer << vocab.getOwnedLocalBlankNodeBlocks();
+  uint64_t numWords = vocab.primaryWordSet().size() +
+                      ::ranges::accumulate(vocab.otherSets(), 0ULL,
+                                           [](auto acc, const auto& set) {
+                                             return acc + set->size();
+                                           });
+  serializer << numWords;
+
+  auto writeWordSet = [&serializer](const auto& words) {
+    ql::ranges::for_each(words, [&serializer](const auto& localVocabEntry) {
+      serializer << Id::makeFromLocalVocabIndex(&localVocabEntry);
+      serializer << localVocabEntry.toStringRepresentation();
+    });
+  };
+  writeWordSet(vocab.primaryWordSet());
+  ql::ranges::for_each(vocab.otherSets(), writeWordSet,
+                       ad_utility::dereference);
 }
 
 // Deserialize the local vocabulary from the input stream.
 CPP_template(typename Serializer)(
     requires serialization::ReadSerializer<Serializer>) std::
     tuple<LocalVocab, absl::flat_hash_map<Id::T, Id>> deserializeLocalVocab(
-        Serializer& serializer) {
+        Serializer& serializer, BlankNodeManager* blankNodeManager) {
   LocalVocab vocab;
+  vocab.reserveBlankNodeBlocksFromExplicitIndices(
+      readValue<std::vector<
+          BlankNodeManager::LocalBlankNodeManager::OwnedBlocksEntry>>(
+          serializer),
+      blankNodeManager);
   auto size = readValue<uint64_t>(serializer);
   // Note:: It might happen that the `size` is zero because the local vocab was
   // empty.
@@ -102,35 +118,45 @@ CPP_template(typename Serializer)(
 CPP_template(typename Range, typename Serializer)(
     requires ql::ranges::range<Range>) void serializeIds(Serializer& serializer,
                                                          Range&& range) {
-  ad_utility::serialization::VectorIncrementalSerializer<Id, Serializer>
-      vectorSerializer{std::move(serializer)};
-  for (const Id& value : range) {
-    vectorSerializer.push(value);
+  if constexpr (std::ranges::contiguous_range<std::decay_t<Range>>) {
+    serializer << ql::span{range};
+  } else {
+    ad_utility::serialization::VectorIncrementalSerializer<Id, Serializer>
+        vectorSerializer{std::move(serializer)};
+    for (const Id& value : range) {
+      vectorSerializer.push(value);
+    }
+    vectorSerializer.finish();
+    serializer = std::move(vectorSerializer).serializer();
   }
-  vectorSerializer.finish();
-  serializer = std::move(vectorSerializer).serializer();
+}
+
+// TODO<joka921> Comments.
+inline void remapLocalVocab(ql::span<Id> ids,
+                            const absl::flat_hash_map<Id::T, Id>& mapping) {
+  for (Id& id : ids) {
+    if (id.getDatatype() == Datatype::LocalVocabIndex) {
+      id = mapping.at(id.getBits());
+    }
+  }
 }
 
 // Deserialize a range of Ids from the input stream. If an Id is of type
 // LocalVocabIndex, apply the mapping to the Id after reading it.
-CPP_template(typename Serializer, typename BlankNodeFunc)(
-    requires ad_utility::InvocableWithConvertibleReturnType<BlankNodeFunc,
-                                                            BlankNodeIndex>)
-    std::vector<Id> deserializeIds(
-        Serializer& serializer, const absl::flat_hash_map<Id::T, Id>& mapping,
-        BlankNodeFunc newBlankNodeIndex) {
+template <typename Serializer>
+void deserializeIds(Serializer& serializer,
+                    const absl::flat_hash_map<Id::T, Id>& mapping,
+                    ql::span<Id> ids) {
+  serializer >> ids;
+  remapLocalVocab(ids, mapping);
+}
+// Deserialize a range of Ids from the input stream. If an Id is of type
+// LocalVocabIndex, apply the mapping to the Id after reading it.
+template <typename Serializer>
+std::vector<Id> deserializeIds(Serializer& serializer,
+                               const absl::flat_hash_map<Id::T, Id>& mapping) {
   std::vector<Id> ids = readValue<std::vector<Id>>(serializer);
-  absl::flat_hash_map<Id, BlankNodeIndex> blankNodeMapping;
-  for (Id& id : ids) {
-    if (id.getDatatype() == Datatype::LocalVocabIndex) {
-      id = mapping.at(id.getBits());
-    } else if (id.getDatatype() == Datatype::BlankNodeIndex) {
-      BlankNodeIndex index = blankNodeMapping.contains(id)
-                                 ? blankNodeMapping[id]
-                                 : (blankNodeMapping[id] = newBlankNodeIndex());
-      id = Id::makeFromBlankNodeIndex(index);
-    }
-  }
+  remapLocalVocab(ids, mapping);
   return ids;
 }
 }  // namespace detail
@@ -172,14 +198,12 @@ inline std::tuple<LocalVocab, std::vector<std::vector<Id>>> deserializeIds(
   AD_LOG_INFO << "Reading and processing persisted updates from " << path
               << " ..." << std::endl;
   detail::readHeader(serializer);
-  auto [vocab, mapping] = detail::deserializeLocalVocab(serializer);
+  auto [vocab, mapping] =
+      detail::deserializeLocalVocab(serializer, blankNodeManager);
   std::vector<std::vector<Id>> idVectors;
   auto numRanges = detail::readValue<uint64_t>(serializer);
   for ([[maybe_unused]] auto i : ad_utility::integerRange(numRanges)) {
-    idVectors.push_back(detail::deserializeIds(
-        serializer, mapping, [blankNodeManager, &vocab]() {
-          return vocab.getBlankNodeIndex(blankNodeManager);
-        }));
+    idVectors.push_back(detail::deserializeIds(serializer, mapping));
   }
   return {std::move(vocab), std::move(idVectors)};
 }

--- a/test/DeltaTriplesTest.cpp
+++ b/test/DeltaTriplesTest.cpp
@@ -587,7 +587,7 @@ TEST_F(DeltaTriplesTest, storeAndRestoreFromEmptySet) {
   EXPECT_NO_THROW(deltaTriples.writeToDisk());
 
   // Check if file contents match
-  std::array<char, 47> expectedContent{
+  std::array<char, 55> expectedContent{
       // Magic bytes
       'Q',
       'L',
@@ -603,6 +603,15 @@ TEST_F(DeltaTriplesTest, storeAndRestoreFromEmptySet) {
       'T',
       'E',
       // Version
+      1,
+      0,
+      // Size of `BlankNodeBlocks`.
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
       0,
       0,
       // LocalVocab size
@@ -643,7 +652,7 @@ TEST_F(DeltaTriplesTest, storeAndRestoreFromEmptySet) {
       0,
   };
 
-  std::array<char, 47> actualContent{};
+  std::array<char, expectedContent.size()> actualContent{};
 
   std::ifstream tmpFileStream{tmpFile, std::ios::binary};
   tmpFileStream.read(actualContent.data(), actualContent.size());

--- a/test/TripleSerializerTest.cpp
+++ b/test/TripleSerializerTest.cpp
@@ -12,7 +12,6 @@
 namespace {
 auto I = ad_utility::testing::IntId;
 auto V = ad_utility::testing::VocabId;
-auto BN = ad_utility::testing::BlankNodeId;
 TEST(TripleSerializer, simpleExample) {
   LocalVocab localVocab;
   std::vector<std::vector<Id>> ids;
@@ -58,8 +57,8 @@ TEST(TripleSerializer, localVocabIsRemapped) {
 
 TEST(TripleSerializer, blankNodesRemapper) {
   ad_utility::testing::getQec();
-  LocalVocab localVocab;
   ad_utility::BlankNodeManager bm;
+  LocalVocab localVocab;
   std::vector<std::vector<Id>> ids;
 
   auto bn = [&]() {


### PR DESCRIPTION
So far, the serialization functions in `TripleSerializer.h` (which are used for persisting update triples in the `DeltaTriples` class) were not quite correct regarding blank nodes and local vocab entries. This is now improved in two ways:

1. The blank node blocks used by a `LocalVocab` are now correctly serialized and deserialized; see #2574
2. So far, only the `primaryWordSet` of a `LocalVocab` was serialized, now also the `otherWortSet`s are serialized

CAVEAT: This is much better than before but still not 100% correct in all cases. For example, consider the case where an update operation creates a new local vocab entry and an `Id` with a pointer to that local vocab entry becomes part of a query result. Such local vocab entries are not part of the local vocab of the query result. For example, when serializing this query result to disk, restarting the server, and reading the result back in again, the pointer encoded in that local vocab entry will be dangling.