### PR TITLE
Fix Docker image for macOS (FSST triggered an illegal instruction)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,19 +30,12 @@ COPY CMakeLists.txt /qlever/
 COPY CompilationInfo.cmake /qlever/
 
 # Build and compile. By default, also compile and run all tests. In order not
-# to, build the image with `--build-arg RUN_TESTS=false`. Explicitly set
-# `ARCH_FLAGS` depending on the architecture we are building for, for reasons
-# explained in https://github.com/ad-freiburg/qlever/issues/2595 .
+# to, build the image with `--build-arg RUN_TESTS=false`.
+# `-DCOMPILER_SUPPORTS_MARCH_NATIVE=FALSE` prevents fsst from compiling with
+# `-march=native`.
 ARG RUN_TESTS=true
 WORKDIR /qlever/build/
-ARG TARGETARCH
-RUN case "${TARGETARCH}" in \
-        "arm64") ARCH_FLAGS="-march=armv8-a" ;; \
-        "amd64") ARCH_FLAGS="-march=x86-64" ;; \
-        *)       ARCH_FLAGS="" ;; \
-      esac && \
-    cmake -DCMAKE_CXX_FLAGS="${ARCH_FLAGS}" -DCMAKE_C_FLAGS="${ARCH_FLAGS}" \
-          -DCMAKE_BUILD_TYPE=Release -DLOGLEVEL=INFO -DUSE_PARALLEL=true -D_NO_TIMING_TESTS=ON -GNinja ..
+RUN cmake -DCMAKE_BUILD_TYPE=Release -DLOGLEVEL=INFO -DUSE_PARALLEL=true -D_NO_TIMING_TESTS=ON -DCOMPILER_SUPPORTS_MARCH_NATIVE=FALSE -GNinja ..
 RUN if [ "$RUN_TESTS" = "true" ]; then \
       cmake --build . && ctest --rerun-failed --output-on-failure; \
     else \


### PR DESCRIPTION
For some time now, running the Docker images on macOS ran into an `Illegal instruction` error. This is now fixed by preventing FSST (used for compressing vocabulary entries) from setting `-march=native` when building the Docker image. See https://github.com/cwida/fsst/blob/75b2e7535392d5ca5eaec937259388d89e38ba4d/CMakeLists.txt#L13-L17 for context. In particular, fixes #2595