### PR TITLE
Fix build failure

### DIFF
--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -225,6 +225,9 @@ class IndexImpl {
   const auto& OPS() const { return getPermutationImpl(ops_, "OPS"); }
   const auto& OSP() const { return getPermutationImpl(osp_, "OSP"); }
 
+  // Function only exposed for testing.
+  auto& SPOForTesting() { return const_cast<Permutation&>(SPO()); }
+
   static const IndexImpl& staticGlobalSingletonIndex() {
     AD_CORRECTNESS_CHECK(globalSingletonIndex_ != nullptr);
     return *globalSingletonIndex_;

--- a/test/IndexTest.cpp
+++ b/test/IndexTest.cpp
@@ -703,8 +703,8 @@ TEST(IndexImpl, recomputeStatistics) {
     // Simulate scenario where not all permutations are loaded.
     if (!loadAllPermutations) {
       // Overwrite with unloaded permutation.
-      indexImpl.SPO() = Permutation{Permutation::SPO,
-                                    ad_utility::makeUnlimitedAllocator<Id>()};
+      indexImpl.SPOForTesting() = Permutation{
+          Permutation::SPO, ad_utility::makeUnlimitedAllocator<Id>()};
       // Zero out original values.
       indexImpl.configurationJson_["num-subjects"] = NNAI(0, 0);
       indexImpl.configurationJson_["num-objects"] = NNAI(0, 0);


### PR DESCRIPTION
The latest master has a build failure due to indirect merge conflicts. This PR fixes this by providing a non-const access to the `SPO` permutation within the `IndexImpl` class.