### PR TITLE
When writing a materialized view, remember the query string

### DIFF
--- a/src/engine/MaterializedViews.cpp
+++ b/src/engine/MaterializedViews.cpp
@@ -275,7 +275,8 @@ void MaterializedViewWriter::writeViewMetadata() const {
 void MaterializedViewWriter::computeResultAndWritePermutation() const {
   // Run query and sort the result externally (only if necessary).
   AD_LOG_INFO << "Computing query result for materialized view '" << name_
-              << "': " << parsedQuery_._originalString << std::endl;
+              << "': " << parsedQuery_._originalString.substr(0, 80) << "..."
+              << std::endl;
   auto result = qet_->getResult(true);
 
   Sorter spoSorter{getFilenameBase() + ".spo-sorter.dat", numCols(),
@@ -339,7 +340,9 @@ MaterializedView::MaterializedView(std::string onDiskBase, std::string name)
   }
 
   // Restore original query string.
-  originalQuery_ = viewInfoJson.at("query").get<std::string>();
+  if (viewInfoJson.contains("query")) {
+    originalQuery_ = viewInfoJson.at("query").get<std::string>();
+  }
 
   // Read permutation
   permutation_->loadFromDisk(filename, false);

--- a/src/engine/MaterializedViews.h
+++ b/src/engine/MaterializedViews.h
@@ -26,7 +26,7 @@ class IndexScan;
 // For the future, materialized views save their version. If we change something
 // about the way materialized views are stored, we can break the existing ones
 // cleanly without breaking the entire index format.
-static constexpr size_t MATERIALIZED_VIEWS_VERSION = 2;
+static constexpr size_t MATERIALIZED_VIEWS_VERSION = 1;
 
 // The `MaterializedViewWriter` can be used to write a new materialized view to
 // disk, given an already planned query. The query will be executed lazily and
@@ -149,7 +149,7 @@ class MaterializedView {
       Permutation::Enum::SPO, ad_utility::makeUnlimitedAllocator<Id>())};
   VariableToColumnMap varToColMap_;
   std::shared_ptr<LocatedTriplesState> locatedTriplesState_;
-  std::string originalQuery_;
+  std::optional<std::string> originalQuery_;
 
   using AdditionalScanColumns = SparqlTripleSimple::AdditionalScanColumns;
 
@@ -172,7 +172,9 @@ class MaterializedView {
   }
 
   // Get the original query string used for writing the view.
-  const std::string& originalQuery() const { return originalQuery_; }
+  const std::optional<std::string>& originalQuery() const {
+    return originalQuery_;
+  }
 
   // Return the combined filename from the index' `onDiskBase` and the name of
   // the view. Note that this function does not check for validity or existence.

--- a/test/MaterializedViewsTest.cpp
+++ b/test/MaterializedViewsTest.cpp
@@ -376,7 +376,8 @@ TEST_F(MaterializedViewsTest, ManualConfigurations) {
   EXPECT_EQ(view->name(), "testView1");
   EXPECT_EQ(view->permutation()->permutation(), Permutation::Enum::SPO);
   EXPECT_NE(view->locatedTriplesState(), nullptr);
-  EXPECT_EQ(view->originalQuery(), simpleWriteQuery_);
+  EXPECT_THAT(view->originalQuery(),
+              ::testing::Optional(::testing::Eq(simpleWriteQuery_)));
 
   MaterializedViewsManager managerNoBaseName;
   AD_EXPECT_THROW_WITH_MESSAGE(


### PR DESCRIPTION
The query string is now stored as part of the metadata JSON stored for each materialized view.  This is useful for reproducing the view, as well as for rewriting parts of a query with a suitable view query. In particular, this is a preparation for #2649