### PR TITLE
Fix blank node label consistency in parallel parsing

### DIFF
--- a/src/parser/RdfParser.h
+++ b/src/parser/RdfParser.h
@@ -226,6 +226,11 @@ class TurtleParser : public RdfParserBase {
   static inline std::atomic<size_t> numParsers_ = 0;
   size_t blankNodePrefix_ = numParsers_.fetch_add(1);
 
+  // Prefix for user-specified blank node labels. For parallel parsing of the
+  // same file, this should be the same across all sub-parsers, while
+  // blankNodePrefix_ should be unique per parser.
+  size_t fileBlankNodePrefix_ = blankNodePrefix_;
+
   // Used to restrict a worker for the parallel turtle parser to a simpler
   // grammar that can be parsed in parallel. This disallows re-definitions of
   // @base and @prefix as well as usage of multiline literals.
@@ -357,7 +362,15 @@ class TurtleParser : public RdfParserBase {
   // To get consistent blank node labels when testing, we need to manually set
   // the prefix. This function is named `...ForTesting` so you really shouldn't
   // use it in the actual QLever code.
-  void setBlankNodePrefixOnlyForTesting(size_t id) { blankNodePrefix_ = id; }
+  void setBlankNodePrefixOnlyForTesting(size_t id) {
+    blankNodePrefix_ = id;
+    fileBlankNodePrefix_ = id;
+  }
+
+  // Set the file-level blank node prefix. This is used by parallel parsers
+  // to ensure that user-specified blank node labels have the same ID across
+  // all sub-parsers of the same file.
+  void setFileBlankNodePrefix(size_t id) { fileBlankNodePrefix_ = id; }
 
  protected:
   FRIEND_TEST(RdfParserTest, prefixedName);

--- a/test/RdfParserTest.cpp
+++ b/test/RdfParserTest.cpp
@@ -367,6 +367,66 @@ TEST(RdfParserTest, blankNodesUniqueAcrossFiles) {
   checkRe2Prefix7(" []", "_:g_7_0", 3);
 }
 
+// Test that blank node labels are consistent across batches when parsing in
+// parallel (issue #2656). The same user-specified blank node label should get
+// the same internal ID even when it appears in different batches.
+TEST(RdfParserTest, blankNodeLabelsConsistentInParallelParsing) {
+  std::string filename{"blankNodeLabelsConsistentInParallelParsing.dat"};
+  auto testWithParser = [&](auto t, bool useBatchInterface,
+                            ad_utility::MemorySize bufferSize) {
+    using Parser = typename decltype(t)::type;
+    // Create input where the same blank node label appears multiple times,
+    // with enough content to ensure batching happens with small buffer size.
+    std::string input = R"(PREFIX ex: <http://example.org/>
+ex:a ex:b _:blank .
+ex:filler1 ex:filler2 ex:filler3 .
+ex:filler4 ex:filler5 ex:filler6 .
+_:blank ex:b ex:c .
+)";
+    {
+      auto of = ad_utility::makeOfstream(filename);
+      of << input;
+    }
+    auto result =
+        parseFromFile<Parser>(filename, useBatchInterface, bufferSize);
+
+    // Find the blank node ID used for _:blank by looking at the first triple
+    // where it appears as the object.
+    std::optional<TripleComponent> blankNodeId;
+    for (const auto& triple : result) {
+      if (triple.subject_ == iri("<http://example.org/a>") &&
+          triple.predicate_ == iri("<http://example.org/b>")) {
+        blankNodeId = triple.object_;
+        break;
+      }
+    }
+    ASSERT_TRUE(blankNodeId.has_value());
+
+    // Verify that the same blank node ID is used as the subject in the second
+    // occurrence of _:blank.
+    bool foundAsSubject = false;
+    for (const auto& triple : result) {
+      if (triple.predicate_ == iri("<http://example.org/b>") &&
+          triple.object_ == iri("<http://example.org/c>")) {
+        EXPECT_EQ(triple.subject_, blankNodeId.value())
+            << "Blank node label _:blank should have consistent ID across "
+               "batches, but got different IDs: "
+            << blankNodeId.value().toRdfLiteral() << " vs "
+            << triple.subject_.toRdfLiteral();
+        foundAsSubject = true;
+        break;
+      }
+    }
+    EXPECT_TRUE(foundAsSubject)
+        << "Second occurrence of _:blank should be found as subject";
+
+    ad_utility::deleteFile(filename);
+  };
+
+  // Test with small buffer size to force batching
+  forAllParallelParsers(testWithParser, 70_B);
+}
+
 TEST(RdfParserTest, blankNodePropertyList) {
   auto testPropertyListAsObject = [](auto p) {
     p.activeSubject_ = iri("<s>");

--- a/test/RdfParserTest.cpp
+++ b/test/RdfParserTest.cpp
@@ -367,66 +367,6 @@ TEST(RdfParserTest, blankNodesUniqueAcrossFiles) {
   checkRe2Prefix7(" []", "_:g_7_0", 3);
 }
 
-// Test that blank node labels are consistent across batches when parsing in
-// parallel (issue #2656). The same user-specified blank node label should get
-// the same internal ID even when it appears in different batches.
-TEST(RdfParserTest, blankNodeLabelsConsistentInParallelParsing) {
-  std::string filename{"blankNodeLabelsConsistentInParallelParsing.dat"};
-  auto testWithParser = [&](auto t, bool useBatchInterface,
-                            ad_utility::MemorySize bufferSize) {
-    using Parser = typename decltype(t)::type;
-    // Create input where the same blank node label appears multiple times,
-    // with enough content to ensure batching happens with small buffer size.
-    std::string input = R"(PREFIX ex: <http://example.org/>
-ex:a ex:b _:blank .
-ex:filler1 ex:filler2 ex:filler3 .
-ex:filler4 ex:filler5 ex:filler6 .
-_:blank ex:b ex:c .
-)";
-    {
-      auto of = ad_utility::makeOfstream(filename);
-      of << input;
-    }
-    auto result =
-        parseFromFile<Parser>(filename, useBatchInterface, bufferSize);
-
-    // Find the blank node ID used for _:blank by looking at the first triple
-    // where it appears as the object.
-    std::optional<TripleComponent> blankNodeId;
-    for (const auto& triple : result) {
-      if (triple.subject_ == iri("<http://example.org/a>") &&
-          triple.predicate_ == iri("<http://example.org/b>")) {
-        blankNodeId = triple.object_;
-        break;
-      }
-    }
-    ASSERT_TRUE(blankNodeId.has_value());
-
-    // Verify that the same blank node ID is used as the subject in the second
-    // occurrence of _:blank.
-    bool foundAsSubject = false;
-    for (const auto& triple : result) {
-      if (triple.predicate_ == iri("<http://example.org/b>") &&
-          triple.object_ == iri("<http://example.org/c>")) {
-        EXPECT_EQ(triple.subject_, blankNodeId.value())
-            << "Blank node label _:blank should have consistent ID across "
-               "batches, but got different IDs: "
-            << blankNodeId.value().toRdfLiteral() << " vs "
-            << triple.subject_.toRdfLiteral();
-        foundAsSubject = true;
-        break;
-      }
-    }
-    EXPECT_TRUE(foundAsSubject)
-        << "Second occurrence of _:blank should be found as subject";
-
-    ad_utility::deleteFile(filename);
-  };
-
-  // Test with small buffer size to force batching
-  forAllParallelParsers(testWithParser, 70_B);
-}
-
 TEST(RdfParserTest, blankNodePropertyList) {
   auto testPropertyListAsObject = [](auto p) {
     p.activeSubject_ = iri("<s>");
@@ -1480,6 +1420,65 @@ TEST(RdfParserTest, payloadSmallerThanInitialChunkSize) {
       "@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.\n"
       "\n"
       "<http://vocab.getty.edu/aat/300312355> rdfs:label \"test\".");
+}
+// Test that blank node labels are consistent across batches when parsing in
+// parallel (issue #2656). The same user-specified blank node label should get
+// the same internal ID even when it appears in different batches.
+TEST(RdfParserTest, blankNodeLabelsConsistentInParallelParsing) {
+  std::string filename{"blankNodeLabelsConsistentInParallelParsing.dat"};
+  auto testWithParser = [&](auto t, bool useBatchInterface,
+                            ad_utility::MemorySize bufferSize) {
+    using Parser = typename decltype(t)::type;
+    // Create input where the same blank node label appears multiple times,
+    // with enough content to ensure batching happens with small buffer size.
+    std::string input = R"(PREFIX ex: <http://example.org/>
+ex:a ex:b _:blank .
+ex:filler1 ex:filler2 ex:filler3 .
+ex:filler4 ex:filler5 ex:filler6 .
+_:blank ex:b ex:c .
+)";
+    {
+      auto of = ad_utility::makeOfstream(filename);
+      of << input;
+    }
+    auto result =
+        parseFromFile<Parser>(filename, useBatchInterface, bufferSize);
+
+    // Find the blank node ID used for _:blank by looking at the first triple
+    // where it appears as the object.
+    std::optional<TripleComponent> blankNodeId;
+    for (const auto& triple : result) {
+      if (triple.subject_ == iri("<http://example.org/a>") &&
+          triple.predicate_ == iri("<http://example.org/b>")) {
+        blankNodeId = triple.object_;
+        break;
+      }
+    }
+    ASSERT_TRUE(blankNodeId.has_value());
+
+    // Verify that the same blank node ID is used as the subject in the second
+    // occurrence of _:blank.
+    bool foundAsSubject = false;
+    for (const auto& triple : result) {
+      if (triple.predicate_ == iri("<http://example.org/b>") &&
+          triple.object_ == iri("<http://example.org/c>")) {
+        EXPECT_EQ(triple.subject_, blankNodeId.value())
+            << "Blank node label _:blank should have consistent ID across "
+               "batches, but got different IDs: "
+            << blankNodeId.value().toRdfLiteral() << " vs "
+            << triple.subject_.toRdfLiteral();
+        foundAsSubject = true;
+        break;
+      }
+    }
+    EXPECT_TRUE(foundAsSubject)
+        << "Second occurrence of _:blank should be found as subject";
+
+    ad_utility::deleteFile(filename);
+  };
+
+  // Test with small buffer size to force batching
+  forAllParallelParsers(testWithParser, 70_B);
 }
 
 // _____________________________________________________________________________


### PR DESCRIPTION
According to the RDF standard, the same blank node identifier (e.g., `_:b5`) denotes the same blank node when re-used in the same file, but denotes a different blank node when re-used in a different file. QLever does consider this by adding a unique (per file) prefix to each blank node name. However, when using the parallel parser, so far, the same blank node identifier encountered in two different batches of the same file ended up denoting different blank nodes. This is now fixed by making different sub-parsers of the same file aware that they parse the same file. Fixes #2656 