### PR TITLE
Use the new binary names `qlever-index` and `qlever-server` in all Dockerfiles

### DIFF
--- a/Dockerfiles/Dockerfile.Ubuntu20.04
+++ b/Dockerfiles/Dockerfile.Ubuntu20.04
@@ -37,7 +37,7 @@ RUN groupadd -r qlever && useradd --no-log-init -r -u $UID -g qlever qlever && c
 USER qlever
 ENV PATH=/app/:$PATH
 
-COPY --from=builder /qlever/build/qlever-* /qlever/
+COPY --from=builder /app/build/qlever-* /app/
 COPY --from=builder /app/build/*Main /app/
 COPY --from=builder /app/e2e/* /app/e2e/
 

--- a/Dockerfiles/Dockerfile.Ubuntu22.04
+++ b/Dockerfiles/Dockerfile.Ubuntu22.04
@@ -33,7 +33,7 @@ RUN groupadd -r qlever && useradd --no-log-init -r -u $UID -g qlever qlever && c
 USER qlever
 ENV PATH=/app/:$PATH
 
-COPY --from=builder /qlever/build/qlever-* /qlever/
+COPY --from=builder /app/build/qlever-* /app/
 COPY --from=builder /app/build/*Main /app/
 COPY --from=builder /app/e2e/* /app/e2e/
 

--- a/Dockerfiles/Dockerfile.debian
+++ b/Dockerfiles/Dockerfile.debian
@@ -28,7 +28,7 @@ RUN groupadd -r qlever && useradd --no-log-init -r -u $UID -g qlever qlever && c
 USER qlever
 ENV PATH=/app/:$PATH
 
-COPY --from=builder /qlever/build/qlever-* /qlever/
+COPY --from=builder /app/build/qlever-* /app/
 COPY --from=builder /app/build/*Main /app/
 COPY --from=builder /app/e2e/* /app/e2e/
 


### PR DESCRIPTION
In #2617, the main binaries were renamed to `qlever-index` and `qlever-server`. The main `Dockerfile` (based on Ubuntu 24.04) was adapted accordingly, but the older Dockerfiles (for earlier versions of Ubuntu and Debian Trixie) were missed. These are now fixed, too