### PR TITLE
Fix destruction order of `transformation_` and `view_` in `CachingTransformInputRange`

### DIFF
--- a/src/util/InputRangeUtils.h
+++ b/src/util/InputRangeUtils.h
@@ -55,19 +55,21 @@ CPP_class_template(typename View, typename F,
   // The input view, the function, and the current iterator into the `view_`.
   // The iterator is `nullopt` before the first call to `get`.
   //
-  // NOTE: The order of these members matters for destruction. C++ destroys
-  // members in reverse declaration order. The `transfomation_` (which may own
-  // resources like file handles that `view_` depends on) must be declared
-  // AFTER `view_` so that it is destroyed LAST. Otherwise, `view_` may have
-  // dangling references when it is destroyed.
-  ::ranges::semiregular_box_t<F> transfomation_;
+  // NOTE: We deliberately declare `view_` before `transformation_` so that
+  // `transformation_` is destroyed after `view_`. That way, a `transformation_`
+  // may own resources that `view_` depends on. For example, the transformation
+  // in `Sort::computeResultExternal` owns a `sorter`, to which the view also
+  // has a reference. Destroying the transformation (and hence the `sorter`)
+  // first might then lead to a segmentation fault when the view is still busy
+  // and tries to access the `sorter`.
+  ::ranges::semiregular_box_t<F> transformation_;
   View view_;
   std::optional<ql::ranges::iterator_t<View>> it_;
 
  public:
   // Constructor.
   explicit CachingTransformInputRange(View view, F transformation = {})
-      : transfomation_(std::move(transformation)), view_{std::move(view)} {
+      : transformation_(std::move(transformation)), view_{std::move(view)} {
     if constexpr (!std::is_same_v<Details, NoDetails>) {
       static_cast<Base*>(this)->setDetailsPointer(&view_.base().details());
     }
@@ -88,7 +90,7 @@ CPP_class_template(typename View, typename F,
     if (*it_ == view_.end()) {
       return std::nullopt;
     }
-    return std::invoke(transfomation_, *it_.value());
+    return std::invoke(transformation_, *it_.value());
   }
 
   // Get access to the underlying view.


### PR DESCRIPTION
So far, `CachingTransformInputRange` declared `transformation_` after `view_`, which means that the transformer was destroyed before the view. This could lead to segmentation faults when an application of this function used a transformer that owns an object to which the view also has a reference. This is now fixed by changing the declaration order. Fixes #2666

For example, in the recently added `Sort::computeResultExternal` from #2622, the transformation owns a `CompressedExternalIdTableSorter` object, to which the view also has a reference. When the transformer (and hence the sorter) is destroyed before the view, then it could happen that a temporary file was closed while it was still being written to, which crashed the server. The debug log showed an assertion failure `File CLOSE: wikidata.sort.<uuid>.dat (was open: 1)` from `File.h:148`, and after the crash there was a temporary file `<base name>.sort.<uuid>`, which under normal circumstances would have been unlinked when done