### PR TITLE
Ensure that tests can be compiled and run on all `LOGLEVEL`s

### DIFF
--- a/src/util/Log.h
+++ b/src/util/Log.h
@@ -96,7 +96,7 @@ class Log {
   static std::ostream& getLog() {
     // use the singleton logging stream as target.
     return LogstreamChoice::get().getStream()
-           << getTimeStamp() << " - " << getLevel<LEVEL>();
+           << getTimeStamp() << " - " << getLevel<LEVEL>() << ": ";
   }
 
   static void imbue(const std::locale& locale) { std::cout.imbue(locale); }
@@ -110,13 +110,13 @@ class Log {
   static QL_CONSTEVAL std::string_view getLevel() {
     using P = ConstexprMapPair<LogLevel, std::string_view>;
     constexpr ConstexprMap map{std::array<P, 7>{
-        P(TRACE, "TRACE: "),
-        P(TIMING, "TIMING: "),
-        P(DEBUG, "DEBUG: "),
-        P(INFO, "INFO: "),
-        P(WARN, "WARN: "),
-        P(ERROR, "ERROR: "),
-        P(FATAL, "FATAL: "),
+        P(TRACE, "TRACE"),
+        P(TIMING, "TIMING"),
+        P(DEBUG, "DEBUG"),
+        P(INFO, "INFO"),
+        P(WARN, "WARN"),
+        P(ERROR, "ERROR"),
+        P(FATAL, "FATAL"),
     }};
     return map.at(LEVEL);
   }

--- a/test/CancellationHandleTest.cpp
+++ b/test/CancellationHandleTest.cpp
@@ -294,10 +294,7 @@ TEST(CancellationHandle, verifyCheckDoesNotOverrideCancelledState) {
 // _____________________________________________________________________________
 
 TEST(CancellationHandle, verifyCheckAfterDeadlineMissDoesReportProperly) {
-  if constexpr (LOGLEVEL < WARN) {
-    GTEST_SKIP() << "This test requires log level of at least INFO.";
-  }
-  EXPECT_GE(LOGLEVEL, WARN);
+  SKIP_IF_LOGLEVEL_IS_LOWER(WARN);
   auto& choice = ad_utility::LogstreamChoice::get();
   CancellationHandle<ENABLED> handle;
 

--- a/test/HttpTest.cpp
+++ b/test/HttpTest.cpp
@@ -277,8 +277,8 @@ TEST(HttpServer, ErrorHandlingInSession) {
   // Thrown object that is not a `std::exception`.
   if constexpr (LOGLEVEL >= ERROR) {
     s = throwAndCaptureLog(47);
-    EXPECT_THAT(s,
-                HasSubstr("Weird exception not inheriting from std::exception"));
+    EXPECT_THAT(
+        s, HasSubstr("Weird exception not inheriting from std::exception"));
   }
 }
 

--- a/test/HttpTest.cpp
+++ b/test/HttpTest.cpp
@@ -269,13 +269,17 @@ TEST(HttpServer, ErrorHandlingInSession) {
   }
 
   // Handling of `std::exception`.
-  s = throwAndCaptureLog(std::runtime_error{"The runtime error for testing"});
-  EXPECT_THAT(s, HasSubstr("The runtime error for testing"));
+  if constexpr (LOGLEVEL >= ERROR) {
+    s = throwAndCaptureLog(std::runtime_error{"The runtime error for testing"});
+    EXPECT_THAT(s, HasSubstr("The runtime error for testing"));
+  }
 
   // Thrown object that is not a `std::exception`.
-  s = throwAndCaptureLog(47);
-  EXPECT_THAT(s,
-              HasSubstr("Weird exception not inheriting from std::exception"));
+  if constexpr (LOGLEVEL >= ERROR) {
+    s = throwAndCaptureLog(47);
+    EXPECT_THAT(s,
+                HasSubstr("Weird exception not inheriting from std::exception"));
+  }
 }
 
 // Test the request body size limit

--- a/test/IndexTest.cpp
+++ b/test/IndexTest.cpp
@@ -587,6 +587,7 @@ TEST(IndexTest, trivialGettersAndSetters) {
 }
 
 TEST(IndexTest, updateInputFileSpecificationsAndLog) {
+  SKIP_IF_LOGLEVEL_IS_LOWER(WARN);
   using enum qlever::Filetype;
   std::vector<qlever::InputFileSpecification> singleFileSpec = {
       {"singleFile.ttl", Turtle, std::nullopt}};

--- a/test/MaterializedViewsTest.cpp
+++ b/test/MaterializedViewsTest.cpp
@@ -36,6 +36,7 @@ using V = Variable;
 
 // _____________________________________________________________________________
 TEST_F(MaterializedViewsTest, Basic) {
+  SKIP_IF_LOGLEVEL_IS_LOWER(INFO);
   // Write a simple view.
   clearLog();
   qlv().writeMaterializedView("testView1", simpleWriteQuery_);
@@ -299,6 +300,7 @@ TEST_F(MaterializedViewsTest, MetadataDependentConfigChecks) {
 
 // _____________________________________________________________________________
 TEST_F(MaterializedViewsTest, ColumnPermutation) {
+  SKIP_IF_LOGLEVEL_IS_LOWER(INFO);
   MaterializedViewsManager manager{testIndexBase_};
 
   // Helper to get all column names from a view via its `VariableToColumnMap`.
@@ -577,6 +579,7 @@ TEST_F(MaterializedViewsTest, ManualConfigurations) {
 
 // _____________________________________________________________________________
 TEST_F(MaterializedViewsTest, serverIntegration) {
+  SKIP_IF_LOGLEVEL_IS_LOWER(INFO);
   using namespace serverTestHelpers;
   SimulateHttpRequest simulateHttpRequest{testIndexBase_};
 

--- a/test/RdfParserTest.cpp
+++ b/test/RdfParserTest.cpp
@@ -829,6 +829,7 @@ TEST(RdfParserTest, collection) {
 
 // Test the parsing of an IRI reference.
 TEST(RdfParserTest, iriref) {
+  SKIP_IF_LOGLEVEL_IS_LOWER(WARN);
   // Run test for given parser.
   auto runTestsForParser = [](auto parser) {
     std::string iriref_1 = "<fine>";

--- a/test/util/GTestHelpers.h
+++ b/test/util/GTestHelpers.h
@@ -96,7 +96,7 @@ https://github.com/google/googletest/blob/main/docs/reference/matchers.md#matche
 // skip such tests if the log level is too low.
 #define SKIP_IF_LOGLEVEL_IS_LOWER(level)                        \
   if (LOGLEVEL < level) {                                       \
-    GTEST_SKIP() << "This test requires log level higher than " \
+    GTEST_SKIP() << "This test requires log level of at least " \
                  << ad_utility::Log::getLevel<level>()          \
                  << ", but the current log level is "           \
                  << ad_utility::Log::getLevel<LOGLEVEL>();      \

--- a/test/util/GTestHelpers.h
+++ b/test/util/GTestHelpers.h
@@ -91,6 +91,19 @@ https://github.com/google/googletest/blob/main/docs/reference/matchers.md#matche
 }
 
 // _____________________________________________________________________________
+// Some tests require a certain log level, e.g. but not only because they
+// capture log output and make assertions about it. This macro can be used to
+// skip such tests if the log level is too low.
+#define SKIP_IF_LOGLEVEL_IS_LOWER(level)                        \
+  if (LOGLEVEL < level) {                                       \
+    GTEST_SKIP() << "This test requires log level of at least " \
+                 << ad_utility::Log::getLevel<level>()          \
+                 << ", but the current log level is "           \
+                 << ad_utility::Log::getLevel<LOGLEVEL>();      \
+  }                                                             \
+  EXPECT_GE(LOGLEVEL, level);
+
+// _____________________________________________________________________________
 
 // Helper matcher that allows to use matchers for strings that represent json
 // objects.

--- a/test/util/GTestHelpers.h
+++ b/test/util/GTestHelpers.h
@@ -101,7 +101,7 @@ https://github.com/google/googletest/blob/main/docs/reference/matchers.md#matche
                  << ", but the current log level is "           \
                  << ad_utility::Log::getLevel<LOGLEVEL>();      \
   }                                                             \
-  EXPECT_GE(LOGLEVEL, level);
+  ASSERT_GE(LOGLEVEL, level);
 
 // _____________________________________________________________________________
 

--- a/test/util/GTestHelpers.h
+++ b/test/util/GTestHelpers.h
@@ -96,7 +96,7 @@ https://github.com/google/googletest/blob/main/docs/reference/matchers.md#matche
 // skip such tests if the log level is too low.
 #define SKIP_IF_LOGLEVEL_IS_LOWER(level)                        \
   if (LOGLEVEL < level) {                                       \
-    GTEST_SKIP() << "This test requires log level of at least " \
+    GTEST_SKIP() << "This test requires log level higher than " \
                  << ad_utility::Log::getLevel<level>()          \
                  << ", but the current log level is "           \
                  << ad_utility::Log::getLevel<LOGLEVEL>();      \


### PR DESCRIPTION
Follow up to #2671 that makes sure that tests can be run with any `-DLOGLEVEL=` now. If a test requires a higher log level than specified, it is simply skipped