### PR TITLE
Include located triples from graph-skipped blocks

### DIFF
--- a/src/index/CompressedRelation.h
+++ b/src/index/CompressedRelation.h
@@ -881,6 +881,15 @@ class CompressedRelationReader {
       const CompressedBlockMetadata& blockMetaData,
       const ScanImplConfig& scanConfig) const;
 
+  // If `canBlockBeSkipped` would skip a block, but there are located triples
+  // for it, create an empty block, merge the located triples into it, apply
+  // graph filtering, and return the result.  Returns std::nullopt if there
+  // are no located triples for this block.
+  std::optional<DecompressedBlockAndMetadata>
+  processSkippedBlockWithLocatedTriples(
+      const CompressedBlockMetadata& blockMetaData,
+      const ScanImplConfig& scanConfig) const;
+
   // Like `readAndDecompressBlock`, and postprocess by merging the located
   // triples (if any) and applying the graph filters (if any), both specified
   // as part of the `scanConfig`.


### PR DESCRIPTION
## Summary

- When `canBlockBeSkipped` returns `true` for a compressed block due to graph filtering, any located triples (delta-updates) for that block were silently dropped.
- Fix: check whether located triples exist for the skipped block; if so, merge them against an empty block and apply the graph filter, so that insertions targeting the requested graph are returned correctly.
- The main-block read from disk is still skipped — only the located-triples path is exercised for such blocks.

## Test plan

- [ ] Build: `cmake --build build/`
- [ ] Run `ctest -R CompressedRelations`
- [ ] Run `ctest -R LocatedTriples`
- [ ] Verify with a manual/integration test: build an index whose blocks contain only graph H, insert a located triple into graph G, issue a scan filtered to graph G, and confirm the inserted triple appears in the result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)