### PR TITLE
Re-enable the clang 21 build

### DIFF
--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -60,8 +60,6 @@ jobs:
           - compiler: clang
             compiler-version: 18
             isPr: true
-          - compiler: clang
-            compiler-version: 21
         include:
           - compiler: gcc
             compiler-version: 11


### PR DESCRIPTION
This reverts commit 745bb54103cc8bc80849a63a00ebbfb25f1e9d7b.
The Clang 21 build stopped working for a while and now it works again, so it can be enabled again.