### PR TITLE
Run free-disk-space before compiler installation to avoid apt conflicts

### DIFF
--- a/.github/workflows/check_index_version.yml
+++ b/.github/workflows/check_index_version.yml
@@ -37,13 +37,15 @@ jobs:
         path: 'master'
         ref: 'master'
 
-    - name: Install dependencies
-      uses: ./pr/.github/workflows/install-dependencies-ubuntu
+    - name: Free disk space
+      uses: ./pr/.github/workflows/free-disk-space
     - name: Install compiler
       uses: ./pr/.github/workflows/install-compiler-ubuntu
       with:
         compiler: ${{matrix.compiler}}
         compiler-version: ${{matrix.compiler-version}}
+    - name: Install dependencies
+      uses: ./pr/.github/workflows/install-dependencies-ubuntu
     - name: Configure CMake Master
       working-directory: ${{github.workspace}}/master
       run:  cmake -B build -DCMAKE_BUILD_TYPE=${{matrix.build-type}} -DCMAKE_TOOLCHAIN_FILE="$(pwd)/toolchains/${{matrix.compiler}}${{matrix.compiler-version}}.cmake" -DADDITIONAL_COMPILER_FLAGS="${{matrix.warnings}} ${{matrix.asan-flags}} ${{matrix.ubsan-flags}}" -DUSE_PARALLEL=true -DRUN_EXPENSIVE_TESTS=true -DENABLE_EXPENSIVE_CHECKS=true

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -41,13 +41,15 @@ jobs:
       with:
         submodules: "recursive"
 
-    - name: Install dependencies
-      uses: ./.github/workflows/install-dependencies-ubuntu
+    - name: Free disk space
+      uses: ./.github/workflows/free-disk-space
     - name: Install compiler
       uses: ./.github/workflows/install-compiler-ubuntu
       with:
         compiler: "clang"
         compiler-version: "16"
+    - name: Install dependencies
+      uses: ./.github/workflows/install-dependencies-ubuntu
     - name: Install coverage tools
       run: |
         sudo apt install -y llvm-16

--- a/.github/workflows/cpp-17-libqlever.yml
+++ b/.github/workflows/cpp-17-libqlever.yml
@@ -43,13 +43,15 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: 'recursive'
-      - name: Install dependencies
-        uses: ./.github/workflows/install-dependencies-ubuntu
+      - name: Free disk space
+        uses: ./.github/workflows/free-disk-space
       - name: Install compiler
         uses: ./.github/workflows/install-compiler-ubuntu
         with:
           compiler: ${{env.compiler}}
           compiler-version: ${{matrix.compiler-version}}
+      - name: Install dependencies
+        uses: ./.github/workflows/install-dependencies-ubuntu
       - name: Configure CMake
         # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
         # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type

--- a/.github/workflows/free-disk-space/action.yml
+++ b/.github/workflows/free-disk-space/action.yml
@@ -1,0 +1,16 @@
+name: "Free disk space"
+description: "Free disk space on Ubuntu runners"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Free Disk Space (Ubuntu)
+      uses: jlumbroso/free-disk-space@main
+      with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true

--- a/.github/workflows/install-dependencies-ubuntu/action.yml
+++ b/.github/workflows/install-dependencies-ubuntu/action.yml
@@ -18,21 +18,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Free Disk Space (Ubuntu)
-      uses: jlumbroso/free-disk-space@main
-      with:
-          # this might remove tools that are actually needed,
-          # if set to "true" but frees about 6 GB
-          tool-cache: false
-
-          # all of these default to true, but feel free to set to
-          # "false" if necessary for your workflow
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          docker-images: true
-          swap-storage: true
     - name: Install basic compiler
       run:  |
         sudo apt-get update

--- a/.github/workflows/native-build-conan.yml
+++ b/.github/workflows/native-build-conan.yml
@@ -30,6 +30,8 @@ jobs:
       with:
         submodules: 'recursive'
 
+    - name: Free disk space
+      uses: ./.github/workflows/free-disk-space
     - name: Install dependencies
       uses: ./.github/workflows/install-dependencies-ubuntu
       with:

--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -106,13 +106,15 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: 'recursive'
-      - name: Install dependencies
-        uses: ./.github/workflows/install-dependencies-ubuntu
+      - name: Free disk space
+        uses: ./.github/workflows/free-disk-space
       - name: Install compiler
         uses: ./.github/workflows/install-compiler-ubuntu
         with:
           compiler: ${{matrix.compiler}}
           compiler-version: ${{matrix.compiler-version}}
+      - name: Install dependencies
+        uses: ./.github/workflows/install-dependencies-ubuntu
       - name: Reduce address randomization to make sanitizers work
         # For details see for example `https://stackoverflow.com/questions/77850769/fatal-threadsanitizer-unexpected-memory-mapping-when-running-on-linux-kernels`
         run: |

--- a/.github/workflows/sparql-conformance.yml
+++ b/.github/workflows/sparql-conformance.yml
@@ -39,13 +39,15 @@ jobs:
           python -m pip install --upgrade pip
           pip install requests
           pip install rdflib
-      - name: Install dependencies
-        uses: ./qlever-code/.github/workflows/install-dependencies-ubuntu
+      - name: Free disk space
+        uses: ./qlever-code/.github/workflows/free-disk-space
       - name: Install compiler
         uses: ./qlever-code/.github/workflows/install-compiler-ubuntu
         with:
           compiler: "clang"
           compiler-version: "16"
+      - name: Install dependencies
+        uses: ./qlever-code/.github/workflows/install-dependencies-ubuntu
       - name: Create build directory
         run: mkdir ${{github.workspace}}/qlever-code/build
       - name: Configure CMake

--- a/.github/workflows/upload-sonarcloud.yml
+++ b/.github/workflows/upload-sonarcloud.yml
@@ -111,13 +111,15 @@ jobs:
         run: shopt -s dotglob && mv qlever-source/* .
       - name: Install Build Wrapper
         uses: SonarSource/sonarqube-scan-action/install-build-wrapper@v6
-      - name: Install dependencies
-        uses: ./.github/workflows/install-dependencies-ubuntu
+      - name: Free disk space
+        uses: ./.github/workflows/free-disk-space
       - name: Install compiler
         uses: ./.github/workflows/install-compiler-ubuntu
         with:
           compiler: ${{env.compiler}}
           compiler-version: ${{env.compiler-version}}
+      - name: Install dependencies
+        uses: ./.github/workflows/install-dependencies-ubuntu
 
       - name: Configure CMake
         # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.


### PR DESCRIPTION
## Summary

- Extract the `jlumbroso/free-disk-space` step from `install-dependencies-ubuntu` into its own `free-disk-space` composite action.
- Reorder CI workflow steps from `install-dependencies → install-compiler` to `free-disk-space → install-compiler → install-dependencies` in all 7 workflows.
- This ensures compiler PPA/apt operations run on a clean system before other apt installs, avoiding held-package conflicts that have been causing CI failures.

## Test plan

- [ ] Verify all CI workflows pass with the new step ordering.
- [ ] Confirm compiler installations no longer fail due to held packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)