### PR TITLE
Make `IdTable` cheaper to move, and `IdTableView` cheaper to create

### DIFF
--- a/src/engine/idTable/IdTable.h
+++ b/src/engine/idTable/IdTable.h
@@ -126,7 +126,7 @@ class IdTable {
   static constexpr size_t numInlinedColumns = 10;
   using Storage = detail::VectorWithElementwiseMove<
       ColumnStorage, absl::InlinedVector<ColumnStorage, numInlinedColumns>>;
-  using ViewSpans = std::vector<ql::span<const T>>;
+  using ViewSpans = absl::InlinedVector<ql::span<const T>, numInlinedColumns>;
   using Data = std::conditional_t<isView, ViewSpans, Storage>;
   using Allocator = decltype(std::declval<ColumnStorage&>().get_allocator());
 

--- a/src/engine/idTable/IdTable.h
+++ b/src/engine/idTable/IdTable.h
@@ -119,8 +119,13 @@ class IdTable {
   // Make the number of (statically known) columns accessible to the outside.
   static constexpr int numStaticColumns = NumColumns;
   // The actual storage is a plain 1D vector with the logical columns
-  // concatenated.
-  using Storage = detail::VectorWithElementwiseMove<ColumnStorage>;
+  // concatenated. We use `InlinedVector` to make the creation of non-owning
+  // `IdTableView`s cheaper (they still need to allocate storage for each
+  // column). Also the moving of `IdTable`s becomes cheaper, as the moved-from
+  // object still needs the storage for the (moved-from) columns.
+  static constexpr size_t numInlinedColumns = 10;
+  using Storage = detail::VectorWithElementwiseMove<
+      ColumnStorage, absl::InlinedVector<ColumnStorage, numInlinedColumns>>;
   using ViewSpans = std::vector<ql::span<const T>>;
   using Data = std::conditional_t<isView, ViewSpans, Storage>;
   using Allocator = decltype(std::declval<ColumnStorage&>().get_allocator());

--- a/src/engine/idTable/VectorWithElementwiseMove.h
+++ b/src/engine/idTable/VectorWithElementwiseMove.h
@@ -10,20 +10,21 @@
 #include "util/ExceptionHandling.h"
 
 namespace columnBasedIdTable::detail {
-// A class that inherits from a `vector<T>`. This class changes the move
-// operators of the underlying `vector` as follows: Instead of moving the vector
+// A class that inherits from a `Vector`. This class changes the move
+// operators of the underlying `Vector` as follows: Instead of moving the vector
 // as a whole, only the individual elements are moved. This is used for the
 // column-based `IdTables` where we move the individual columns, but still want
 // a table that was moved from to have the same number of columns as before, but
 // with the columns now being empty.
+// `Vector` must have an interface similar to `std::vector`, in particular it
+// needs member functions `clear()` and `insert()`.
 
 // Note: This class is an implementation detail of the column-based ID
 // tables. Its semantics are very particular, so we don't expect it to have a
 // use case outside the `IdTable` module.
-template <typename T>
-struct VectorWithElementwiseMove : public std::vector<T> {
-  using Base = std::vector<T>;
-  using Base::Base;
+template <typename T, typename Vector = std::vector<T>>
+struct VectorWithElementwiseMove : public Vector {
+  using Vector::Vector;
   // Defaulted copy operations, inherited from the base class.
   VectorWithElementwiseMove(const VectorWithElementwiseMove&) = default;
   VectorWithElementwiseMove& operator=(const VectorWithElementwiseMove&) =


### PR DESCRIPTION
Use `absl::InlinedVector` instead of `std::vector` for the column storage in `IdTable` and for the span storage in `IdTableView`. Tables with up to 10 columns (which covers the vast majority of cases) avoid heap allocation for the column vector itself. This makes `IdTable` cheaper to move, and a non-owning `IdTableView` cheaper to create. To realize this, the `VectorWithElementwiseMove` template is generalized from `std::vector<T>` to an arbitrary vector type, requiring only `clear()` and `insert()`