### PR TITLE
Implement sister permutation sharing to reduce redundant triple storage

### DIFF
--- a/src/index/CompressedRelation.cpp
+++ b/src/index/CompressedRelation.cpp
@@ -1721,61 +1721,76 @@ CompressedRelationMetadata CompressedRelationWriter::addCompleteLargeRelation(
   using namespace compressedRelationHelpers;
   DistinctIdCounter distinctCol1Counter;
 
-  // Buffer used to ensure the invariant that equal triples (when disregarding
-  // the graph) stay in the same block.
-  // TODO<cross-pair> Add col1-boundary splitting here for twin permutation
-  // alignment (needed for OPS→POS cross-pair sharing on large datasets).
-  std::optional<IdTable> bufferedBlock;
+  // Row buffer for the current (col0, col1) group. We process the twin sorter
+  // output row by row and build aligned blocks from scratch, mirroring the
+  // alignment logic in writePermutation(). This ensures that large (col0, col1)
+  // pairs get exclusive blocks, enabling cross-pair sharing with the sister
+  // permutation.
+  IdTable rowBuffer(0, ad_utility::makeUnlimitedAllocator<Id>());
+  bool rowBufferInitialized = false;
+  std::optional<Id> currentCol1;
+  const size_t bs = blocksize();
+  // Whether we have written at least one aligned block for the current col1
+  // group. Only large groups allow cross-pair sharing.
+  bool currentGroupIsLarge = false;
+
+  // Flush the entire rowBuffer as blocks at the end of a col1 group.
+  auto finishCurrentCol1Group = [&](size_t numCols,
+                                    ad_utility::AllocatorWithLimit<Id> alloc) {
+    if (rowBuffer.empty()) {
+      currentGroupIsLarge = false;
+      return;
+    }
+    // Write the remainder (which may be the only block for small groups).
+    addBlockForLargeRelation(col0Id, std::move(rowBuffer), currentGroupIsLarge);
+    rowBuffer = IdTable(numCols, alloc);
+    currentCol1.reset();
+    currentGroupIsLarge = false;
+  };
 
   for (auto& block :
        sortedBlocks | ql::views::filter(std::not_fn(&IdTable::empty))) {
     ql::ranges::for_each(block.getColumn(1), std::ref(distinctCol1Counter));
 
-    if (!bufferedBlock.has_value()) {
-      // First non-empty block - initialize buffer.
-      bufferedBlock = std::move(block);
-      continue;
+    if (!rowBufferInitialized) {
+      rowBuffer = IdTable(block.numColumns(), block.getAllocator());
+      rowBufferInitialized = true;
     }
 
-    const auto& lastRowFromPrevious = bufferedBlock.value().back();
+    // Process each row, detecting col1 boundaries and blocksize thresholds.
+    for (size_t i = 0; i < block.numRows(); ++i) {
+      Id col1 = block(i, 1);
 
-    // Find how many rows from current block have the same first three columns
-    // as the last row in the buffered block.
-    const size_t upperBoundEqualTriples =
-        ql::ranges::find_if(
-            block,
-            [&lastRowFromPrevious](const auto& row) {
-              return tieFirstThreeColumns(lastRowFromPrevious) !=
-                     tieFirstThreeColumns(row);
-            }) -
-        block.begin();
+      // Col1 changed: finish the previous group.
+      if (currentCol1.has_value() && col1 != currentCol1.value()) {
+        finishCurrentCol1Group(block.numColumns(), block.getAllocator());
+      }
+      if (!currentCol1.has_value()) {
+        currentCol1 = col1;
+      }
 
-    // If we found rows to merge, add them to the buffered block.
-    if (upperBoundEqualTriples > 0) {
-      bufferedBlock->insertAtEnd(block, 0, upperBoundEqualTriples);
+      // Before adding the row, check if we should flush a full aligned block.
+      // This mirrors the `isEndOfBlockForLargeRelation` check: flush when the
+      // buffer has reached blocksize and the incoming row differs in the first
+      // three columns from the last buffered row.
+      if (rowBuffer.numRows() >= bs &&
+          tieFirstThreeColumns(block[i]) !=
+              tieFirstThreeColumns(rowBuffer.back())) {
+        currentGroupIsLarge = true;
+        addBlockForLargeRelation(col0Id, std::move(rowBuffer),
+                                 true /* allowCrossPairSharing */);
+        rowBuffer = IdTable(block.numColumns(), block.getAllocator());
+      }
 
-      // Remove the merged rows from the current block.
-      block.erase(block.begin(), block.begin() + upperBoundEqualTriples);
+      rowBuffer.push_back(block[i]);
     }
-
-    // If the `block` is empty after moving the duplicate triples into the
-    // buffer, continue without writing a block, because the next block might
-    // again contain the `lastRowFromPrevious`.
-    if (block.empty()) {
-      continue;
-    }
-
-    // At this point we know that the `block` contains at least a single triple
-    // larger than `lastRowFromPrevious`, so we can safely write the
-    // `bufferedBlock`.
-    addBlockForLargeRelation(col0Id, std::move(*bufferedBlock));
-    bufferedBlock = std::move(block);
   }
 
-  // Write the remaining triples from the buffer.
-  if (bufferedBlock.has_value()) {
-    AD_CORRECTNESS_CHECK(!bufferedBlock.value().empty());
-    addBlockForLargeRelation(col0Id, std::move(bufferedBlock.value()));
+  // Flush the final col1 group.
+  if (!rowBuffer.empty()) {
+    // We need valid numColumns/allocator for the replacement table, but since
+    // this is the last flush we can just move and not replace.
+    addBlockForLargeRelation(col0Id, std::move(rowBuffer), currentGroupIsLarge);
   }
 
   return finishLargeRelation(distinctCol1Counter.getAndReset());

--- a/src/index/CompressedRelation.cpp
+++ b/src/index/CompressedRelation.cpp
@@ -1374,13 +1374,13 @@ static std::pair<bool, std::optional<std::vector<Id>>> getGraphInfo(
 }
 
 // _____________________________________________________________________________
-void CompressedRelationWriter::compressAndWriteBlock(Id firstCol0Id,
-                                                     Id lastCol0Id,
-                                                     IdTable block,
-                                                     bool invokeCallback) {
+void CompressedRelationWriter::compressAndWriteBlock(
+    Id firstCol0Id, Id lastCol0Id, IdTable block, bool invokeCallback,
+    bool allowCrossPairSharing) {
   auto timer = blockWriteQueueTimer_.startMeasurement();
   blockWriteQueue_.push([this, block = std::move(block), firstCol0Id,
-                         lastCol0Id, invokeCallback]() mutable {
+                         lastCol0Id, invokeCallback,
+                         allowCrossPairSharing]() mutable {
     auto numRows = block.numRows();
     const auto& first = block[0];
     const auto& last = block[numRows - 1];
@@ -1389,11 +1389,12 @@ void CompressedRelationWriter::compressAndWriteBlock(Id firstCol0Id,
 
     // Check if this block has a constant prefix of length >= 2 and should be
     // stored as a cross-pair sharing dummy.  We only do this for large-relation
-    // blocks (invokeCallback=false), because small-relation blocks are shared
-    // with the sister permutation via the sister callback, and creating a
-    // cross-pair dummy would break that reference chain.
-    if (skipConstantPrefixBlocks_ && !invokeCallback && first[0] == last[0] &&
-        first[1] == last[1]) {
+    // blocks (invokeCallback=false) that are part of an aligned (col0, col1)
+    // group (allowCrossPairSharing=true), because small-relation blocks are
+    // shared with the sister permutation via the sister callback, and creating
+    // a cross-pair dummy would break that reference chain.
+    if (skipConstantPrefixBlocks_ && !invokeCallback && allowCrossPairSharing &&
+        first[0] == last[0] && first[1] == last[1]) {
       auto [hasDuplicates, graphInfo] = getGraphInfo(block);
       blockBuffer_.wlock()->emplace_back(CompressedBlockMetadataNoBlockIndex{
           std::nullopt,
@@ -1699,8 +1700,8 @@ CompressedRelationMetadata CompressedRelationWriter::finishLargeRelation(
 }
 
 // _____________________________________________________________________________
-void CompressedRelationWriter::addBlockForLargeRelation(Id col0Id,
-                                                        IdTable relation) {
+void CompressedRelationWriter::addBlockForLargeRelation(
+    Id col0Id, IdTable relation, bool allowCrossPairSharing) {
   AD_CORRECTNESS_CHECK(!relation.empty());
   AD_CORRECTNESS_CHECK(currentCol0Id_ == col0Id ||
                        currentCol0Id_.isUndefined());
@@ -1708,9 +1709,9 @@ void CompressedRelationWriter::addBlockForLargeRelation(Id col0Id,
   currentRelationPreviousSize_ += relation.numRows();
   writeBufferedRelationsToSingleBlock();
   // This is a block of a large relation, so we don't invoke the
-  // `smallBlocksCallback_`. Hence the last argument is `false`.
+  // `smallBlocksCallback_`. Hence the second-to-last argument is `false`.
   compressAndWriteBlock(currentCol0Id_, currentCol0Id_, std::move(relation),
-                        false);
+                        false, allowCrossPairSharing);
 }
 
 // __________________________________________________________________________
@@ -1729,15 +1730,12 @@ CompressedRelationMetadata CompressedRelationWriter::addCompleteLargeRelation(
     ql::ranges::for_each(block.getColumn(1), std::ref(distinctCol1Counter));
 
     if (!bufferedBlock.has_value()) {
-      // First non-empty block - initialize buffer.
       bufferedBlock = std::move(block);
       continue;
     }
 
     const auto& lastRowFromPrevious = bufferedBlock.value().back();
 
-    // Find how many rows from current block have the same first three columns
-    // as the last row in the buffered block
     const size_t upperBoundEqualTriples =
         ql::ranges::find_if(
             block,
@@ -1747,29 +1745,19 @@ CompressedRelationMetadata CompressedRelationWriter::addCompleteLargeRelation(
             }) -
         block.begin();
 
-    // If we found rows to merge, add them to the buffered block
     if (upperBoundEqualTriples > 0) {
       bufferedBlock->insertAtEnd(block, 0, upperBoundEqualTriples);
-
-      // Remove the merged rows from the current block
       block.erase(block.begin(), block.begin() + upperBoundEqualTriples);
     }
 
-    // If the `block` is empty after moving the duplicate triples into the
-    // buffer, continue without writing a block, because the next block might
-    // again contain the `lastRowFromPrevious`
     if (block.empty()) {
       continue;
     }
 
-    // At this point we know that the `block` contains at least a single triple
-    // larger than `lastRowFromPrevious`, so we can safely write the
-    // `bufferedBlock`.
     addBlockForLargeRelation(col0Id, std::move(*bufferedBlock));
     bufferedBlock = std::move(block);
   }
 
-  // Write the remaining triples from the buffer.
   if (bufferedBlock.has_value()) {
     AD_CORRECTNESS_CHECK(!bufferedBlock.value().empty());
     addBlockForLargeRelation(col0Id, std::move(bufferedBlock.value()));

--- a/src/index/CompressedRelation.cpp
+++ b/src/index/CompressedRelation.cpp
@@ -1723,6 +1723,8 @@ CompressedRelationMetadata CompressedRelationWriter::addCompleteLargeRelation(
 
   // Buffer used to ensure the invariant that equal triples (when disregarding
   // the graph) stay in the same block.
+  // TODO<cross-pair> Add col1-boundary splitting here for twin permutation
+  // alignment (needed for OPS→POS cross-pair sharing on large datasets).
   std::optional<IdTable> bufferedBlock;
 
   for (auto& block :
@@ -1730,12 +1732,15 @@ CompressedRelationMetadata CompressedRelationWriter::addCompleteLargeRelation(
     ql::ranges::for_each(block.getColumn(1), std::ref(distinctCol1Counter));
 
     if (!bufferedBlock.has_value()) {
+      // First non-empty block - initialize buffer.
       bufferedBlock = std::move(block);
       continue;
     }
 
     const auto& lastRowFromPrevious = bufferedBlock.value().back();
 
+    // Find how many rows from current block have the same first three columns
+    // as the last row in the buffered block.
     const size_t upperBoundEqualTriples =
         ql::ranges::find_if(
             block,
@@ -1745,19 +1750,29 @@ CompressedRelationMetadata CompressedRelationWriter::addCompleteLargeRelation(
             }) -
         block.begin();
 
+    // If we found rows to merge, add them to the buffered block.
     if (upperBoundEqualTriples > 0) {
       bufferedBlock->insertAtEnd(block, 0, upperBoundEqualTriples);
+
+      // Remove the merged rows from the current block.
       block.erase(block.begin(), block.begin() + upperBoundEqualTriples);
     }
 
+    // If the `block` is empty after moving the duplicate triples into the
+    // buffer, continue without writing a block, because the next block might
+    // again contain the `lastRowFromPrevious`.
     if (block.empty()) {
       continue;
     }
 
+    // At this point we know that the `block` contains at least a single triple
+    // larger than `lastRowFromPrevious`, so we can safely write the
+    // `bufferedBlock`.
     addBlockForLargeRelation(col0Id, std::move(*bufferedBlock));
     bufferedBlock = std::move(block);
   }
 
+  // Write the remaining triples from the buffer.
   if (bufferedBlock.has_value()) {
     AD_CORRECTNESS_CHECK(!bufferedBlock.value().empty());
     addBlockForLargeRelation(col0Id, std::move(bufferedBlock.value()));

--- a/src/index/CompressedRelation.cpp
+++ b/src/index/CompressedRelation.cpp
@@ -1208,11 +1208,113 @@ CompressedRelationReader::readAndDecompressBlock(
   if (scanConfig.graphFilter_.canBlockBeSkipped(blockMetaData)) {
     return std::nullopt;
   }
+  // If this block's data is shared from another permutation, delegate.
+  if (blockMetaData.sharingInfo_.has_value()) {
+    return readSharedBlock(blockMetaData, scanConfig);
+  }
   CompressedBlock compressedColumns =
       readCompressedBlockFromFile(blockMetaData, scanConfig.scanColumns_);
   const auto numRowsToRead = blockMetaData.numRows_;
   return decompressAndPostprocessBlock(compressedColumns, numRowsToRead,
                                        scanConfig, blockMetaData);
+}
+
+// ____________________________________________________________________________
+std::optional<DecompressedBlockAndMetadata>
+CompressedRelationReader::readSharedBlock(
+    const CompressedBlockMetadata& blockMetaData,
+    const ScanImplConfig& scanConfig) const {
+  AD_CONTRACT_CHECK(blockMetaData.sharingInfo_.has_value());
+  const auto& sharing = blockMetaData.sharingInfo_.value();
+  AD_CONTRACT_CHECK(sharing.sourceBlockIndex_ !=
+                    std::numeric_limits<size_t>::max());
+
+  const SharedPermutationAccess* access = nullptr;
+  if (sharing.type_ == BlockSharingInfo::Type::SisterPermutation) {
+    AD_CONTRACT_CHECK(sisterAccess_.has_value());
+    access = &sisterAccess_.value();
+  } else {
+    AD_CONTRACT_CHECK(sharing.type_ ==
+                      BlockSharingInfo::Type::CrossPairPermutation);
+    AD_CONTRACT_CHECK(crossPairAccess_.has_value());
+    access = &crossPairAccess_.value();
+  }
+
+  AD_CONTRACT_CHECK(sharing.sourceBlockIndex_ < access->blocks->size());
+  const auto& sourceBlock = access->blocks->at(sharing.sourceBlockIndex_);
+  AD_CONTRACT_CHECK(!sourceBlock.sharingInfo_.has_value(),
+                    "Source block must not itself be shared.");
+
+  // Read all columns from the source block (we need to rearrange them).
+  std::vector<ColumnIndex> allColumns(scanConfig.scanColumns_.begin(),
+                                      scanConfig.scanColumns_.end());
+  CompressedBlock compressedColumns =
+      access->reader->readCompressedBlockFromFile(sourceBlock, allColumns);
+  DecompressedBlock decompressed =
+      access->reader->decompressBlock(compressedColumns, sourceBlock.numRows_);
+
+  // Find the positions of col1 (block column 1) and col2 (block column 2)
+  // in the decompressed IdTable.  Their positions depend on whether col0
+  // (block column 0) was included in the scan columns.
+  auto it1 = ql::ranges::find(allColumns, ColumnIndex{1});
+  auto it2 = ql::ranges::find(allColumns, ColumnIndex{2});
+
+  if (sharing.type_ == BlockSharingInfo::Type::SisterPermutation) {
+    // Sister permutation: swap col1 and col2, then resort.
+    if (it1 != allColumns.end() && it2 != allColumns.end()) {
+      size_t pos1 = it1 - allColumns.begin();
+      size_t pos2 = it2 - allColumns.begin();
+      decompressed.swapColumns(pos1, pos2);
+    }
+    // Find the position of the graph column in the decompressed table.
+    auto itGraph =
+        ql::ranges::find(allColumns, ColumnIndex{ADDITIONAL_COLUMN_GRAPH_ID});
+    AD_CORRECTNESS_CHECK(itGraph != allColumns.end());
+    size_t graphPos = itGraph - allColumns.begin();
+    // Resort by all triple columns plus graph (columns 0 through graphPos).
+    auto compare = [graphPos](const auto& a, const auto& b) {
+      for (size_t i = 0; i <= graphPos; ++i) {
+        if (a[i] != b[i]) {
+          return a[i] < b[i];
+        }
+      }
+      return false;
+    };
+    ql::ranges::sort(decompressed, compare);
+  } else {
+    // Cross-pair permutation: swap col0 and col1 (block columns 0 and 1).
+    // No resort needed because the remaining columns are already sorted.
+    auto it0 = ql::ranges::find(allColumns, ColumnIndex{0});
+    if (it0 != allColumns.end() && it1 != allColumns.end()) {
+      size_t pos0 = it0 - allColumns.begin();
+      size_t pos1 = it1 - allColumns.begin();
+      decompressed.swapColumns(pos0, pos1);
+    }
+  }
+
+  // Now postprocess (graph filtering, located triples merging).
+  bool hasUpdates = false;
+  auto numIndexColumns =
+      std::min(decompressed.numColumns(), static_cast<size_t>(3));
+  bool includeGraphColumn =
+      ql::ranges::find(scanConfig.scanColumns_, ADDITIONAL_COLUMN_GRAPH_ID) !=
+      scanConfig.scanColumns_.end();
+
+  auto& locatedTriples = scanConfig.locatedTriples_;
+  if (locatedTriples.containsTriples(blockMetaData.blockIndex_)) {
+    locatedTriples.mergeTriples(blockMetaData.blockIndex_, decompressed,
+                                numIndexColumns, includeGraphColumn);
+    hasUpdates = true;
+  }
+  bool wasPostprocessed = false;
+  if (useGraphPostProcessing_) {
+    wasPostprocessed =
+        scanConfig.graphFilter_.postprocessBlock(decompressed, blockMetaData);
+  } else {
+    scanConfig.graphFilter_.deleteGraphColumnIfNecessary(decompressed);
+  }
+  return DecompressedBlockAndMetadata{std::move(decompressed), wasPostprocessed,
+                                      hasUpdates};
 }
 
 // ____________________________________________________________________________
@@ -1274,30 +1376,81 @@ void CompressedRelationWriter::compressAndWriteBlock(Id firstCol0Id,
   auto timer = blockWriteQueueTimer_.startMeasurement();
   blockWriteQueue_.push([this, block = std::move(block), firstCol0Id,
                          lastCol0Id, invokeCallback]() mutable {
-    std::vector<CompressedBlockMetadata::OffsetAndCompressedSize> offsets;
-    for (const auto& column : block.getColumns()) {
-      offsets.push_back(compressAndWriteColumn(column));
-    }
-    AD_CORRECTNESS_CHECK(!offsets.empty());
     auto numRows = block.numRows();
     const auto& first = block[0];
     const auto& last = block[numRows - 1];
     AD_CORRECTNESS_CHECK(firstCol0Id == first[0]);
     AD_CORRECTNESS_CHECK(lastCol0Id == last[0]);
 
+    // Check if this block has a constant prefix of length >= 2 and should be
+    // stored as a cross-pair sharing dummy.  We only do this for large-relation
+    // blocks (invokeCallback=false), because small-relation blocks are shared
+    // with the sister permutation via the sister callback, and creating a
+    // cross-pair dummy would break that reference chain.
+    if (skipConstantPrefixBlocks_ && !invokeCallback && first[0] == last[0] &&
+        first[1] == last[1]) {
+      auto [hasDuplicates, graphInfo] = getGraphInfo(block);
+      blockBuffer_.wlock()->emplace_back(CompressedBlockMetadataNoBlockIndex{
+          std::nullopt,
+          numRows,
+          {first[0], first[1], first[2], first[3]},
+          {last[0], last[1], last[2], last[3]},
+          std::move(graphInfo),
+          hasDuplicates,
+          BlockSharingInfo{BlockSharingInfo::Type::CrossPairPermutation,
+                           std::numeric_limits<size_t>::max()}});
+      return;
+    }
+
+    std::vector<CompressedBlockMetadata::OffsetAndCompressedSize> offsets;
+    for (const auto& column : block.getColumns()) {
+      offsets.push_back(compressAndWriteColumn(column));
+    }
+    AD_CORRECTNESS_CHECK(!offsets.empty());
+
     auto [hasDuplicates, graphInfo] = getGraphInfo(block);
-    blockBuffer_.wlock()->emplace_back(CompressedBlockMetadataNoBlockIndex{
-        std::move(offsets),
-        numRows,
-        {first[0], first[1], first[2], first[3]},
-        {last[0], last[1], last[2], last[3]},
-        std::move(graphInfo),
-        hasDuplicates});
+    size_t bufIdx;
+    {
+      auto locked = blockBuffer_.wlock();
+      locked->emplace_back(CompressedBlockMetadataNoBlockIndex{
+          std::move(offsets),
+          numRows,
+          {first[0], first[1], first[2], first[3]},
+          {last[0], last[1], last[2], last[3]},
+          std::move(graphInfo),
+          hasDuplicates,
+          std::nullopt});
+      bufIdx = locked->size() - 1;
+    }
     if (invokeCallback && smallBlocksCallback_) {
-      std::invoke(smallBlocksCallback_, std::move(block));
+      std::invoke(smallBlocksCallback_, std::move(block), bufIdx);
     }
   });
   timer.stop();
+}
+
+// _____________________________________________________________________________
+size_t CompressedRelationWriter::addSharedBlockMetadata(
+    Id firstCol0Id, Id lastCol0Id, const IdTable& block,
+    BlockSharingInfo sharingInfo) {
+  auto numRows = block.numRows();
+  AD_CORRECTNESS_CHECK(numRows > 0);
+  const auto& first = block[0];
+  const auto& last = block[numRows - 1];
+  AD_CORRECTNESS_CHECK(firstCol0Id == first[0]);
+  AD_CORRECTNESS_CHECK(lastCol0Id == last[0]);
+
+  auto [hasDuplicates, graphInfo] = getGraphInfo(block);
+  auto locked = blockBuffer_.wlock();
+  locked->emplace_back(CompressedBlockMetadataNoBlockIndex{
+      std::nullopt,
+      numRows,
+      {first[0], first[1], first[2], first[3]},
+      {last[0], last[1], last[2], last[3]},
+      std::move(graphInfo),
+      hasDuplicates,
+      std::move(sharingInfo)});
+  return locked->size() - 1;
 }
 
 // _____________________________________________________________________________

--- a/src/index/CompressedRelation.cpp
+++ b/src/index/CompressedRelation.cpp
@@ -223,10 +223,16 @@ CompressedRelationReader::asyncParallelBlockGenerator(
           blockMetadata, scanConfig_.scanColumns_);
 
       lock.unlock();
-      auto decompressedBlockAndMetadata =
-          reader_->decompressAndPostprocessBlock(compressedBlock,
-                                                 blockMetadata.numRows_,
-                                                 scanConfig_, blockMetadata);
+
+      // If this block's data is shared from another permutation, delegate.
+      auto decompressedBlockAndMetadata = [&]() {
+        if (blockMetadata.sharingInfo_.has_value()) {
+          return reader_->readSharedBlock(blockMetadata, scanConfig_);
+        }
+        return reader_->decompressAndPostprocessBlock(
+            compressedBlock, blockMetadata.numRows_, scanConfig_,
+            blockMetadata);
+      }();
       return std::pair{myIndex,
                        std::optional{std::move(decompressedBlockAndMetadata)}};
     };
@@ -1220,8 +1226,7 @@ CompressedRelationReader::readAndDecompressBlock(
 }
 
 // ____________________________________________________________________________
-std::optional<DecompressedBlockAndMetadata>
-CompressedRelationReader::readSharedBlock(
+DecompressedBlockAndMetadata CompressedRelationReader::readSharedBlock(
     const CompressedBlockMetadata& blockMetaData,
     const ScanImplConfig& scanConfig) const {
   AD_CONTRACT_CHECK(blockMetaData.sharingInfo_.has_value());

--- a/src/index/CompressedRelation.h
+++ b/src/index/CompressedRelation.h
@@ -390,6 +390,8 @@ class CompressedRelationWriter {
   void setSkipConstantPrefixBlocks(bool value) {
     skipConstantPrefixBlocks_ = value;
   }
+  // Return whether cross-pair sharing is enabled for this writer.
+  bool skipConstantPrefixBlocks() const { return skipConstantPrefixBlocks_; }
   /// Create using a filename, to which the relation data will be written.
   explicit CompressedRelationWriter(
       size_t numColumns, ad_utility::File f,
@@ -580,7 +582,8 @@ class CompressedRelationWriter {
   // `smallBlocksCallback_(std::move(block), bufferIndex)` is called AFTER the
   // block has completely been dealt with.
   void compressAndWriteBlock(Id firstCol0Id, Id lastCol0Id, IdTable block,
-                             bool invokeCallback);
+                             bool invokeCallback,
+                             bool allowCrossPairSharing = true);
 
   // Add a block's metadata to `blockBuffer_` without compressing or writing
   // any data.  The block's data is shared from a source permutation.  The
@@ -604,7 +607,8 @@ class CompressedRelationWriter {
   // `finishLargeRelation`.
   // * The previously called function was `addBlockForLargeRelation` with the
   // same `col0Id`.
-  void addBlockForLargeRelation(Id col0Id, IdTable relation);
+  void addBlockForLargeRelation(Id col0Id, IdTable relation,
+                                bool allowCrossPairSharing = true);
 
   // This function must be called after all blocks of a large relation have been
   // added via `addBlockForLargeRelation` before any other function may be

--- a/src/index/CompressedRelation.h
+++ b/src/index/CompressedRelation.h
@@ -1021,7 +1021,7 @@ class CompressedRelationReader {
   // Read a block whose data is shared from another permutation.  Depending on
   // `sharingInfo.type_`, this reads from the sister or cross-pair permutation,
   // decompresses, and applies the necessary column swap / resort.
-  std::optional<DecompressedBlockAndMetadata> readSharedBlock(
+  DecompressedBlockAndMetadata readSharedBlock(
       const CompressedBlockMetadata& blockMetaData,
       const ScanImplConfig& scanConfig) const;
 

--- a/src/index/CompressedRelation.h
+++ b/src/index/CompressedRelation.h
@@ -52,6 +52,28 @@ struct DecompressedBlockAndMetadata {
 // `IdTable`.
 using CompressedBlock = std::vector<std::vector<char>>;
 
+// Information about how a block's data is shared with another permutation.
+// When set, the block does not store its own compressed data; instead it
+// references a block in a source permutation.
+struct BlockSharingInfo {
+  enum class Type : uint8_t {
+    // Data is in the sister permutation (same col0, col1/col2 swapped).
+    // Must resort by (col1, col2, graph) after decompression.
+    SisterPermutation,
+    // Data is in a cross-pair permutation (col0/col1 swapped).
+    // Swap the constant col0/col1 columns after decompression (cheap).
+    CrossPairPermutation
+  };
+  Type type_;
+  // Block index in the source permutation that holds the actual compressed
+  // data.  Initially SIZE_MAX for unresolved cross-pair dummies; resolved
+  // after all permutations are built.
+  size_t sourceBlockIndex_ = std::numeric_limits<size_t>::max();
+
+  QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(BlockSharingInfo, type_,
+                                              sourceBlockIndex_)
+};
+
 // The metadata of a compressed block of ID triples in an index permutation.
 struct CompressedBlockMetadataNoBlockIndex {
   // Since we have column-based indices, the two columns of each block are
@@ -123,6 +145,12 @@ struct CompressedBlockMetadataNoBlockIndex {
   // blocks.
   bool containsDuplicatesWithDifferentGraphs_;
 
+  // If set, this block's data is shared with another permutation and no
+  // compressed data is stored for this block in this permutation's file.
+  // When `sharingInfo_` has a value, `offsetsAndCompressedSize_` is
+  // `std::nullopt`.
+  std::optional<BlockSharingInfo> sharingInfo_;
+
   // Check for constant values in `firstTriple_` and `lastTriple` over all
   // columns `< columnIndex`.
   // Returns `true` if the respective column values of `firstTriple_` and
@@ -142,7 +170,7 @@ struct CompressedBlockMetadataNoBlockIndex {
   QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(
       CompressedBlockMetadataNoBlockIndex, offsetsAndCompressedSize_, numRows_,
       firstTriple_, lastTriple_, graphInfo_,
-      containsDuplicatesWithDifferentGraphs_)
+      containsDuplicatesWithDifferentGraphs_, sharingInfo_)
 
   // Format CompressedBlockMetadata contents for debugging.
   friend std::ostream& operator<<(
@@ -205,16 +233,50 @@ AD_SERIALIZE_FUNCTION(CompressedBlockMetadata::OffsetAndCompressedSize) {
 
 // Serialization of the block metadata.
 AD_SERIALIZE_FUNCTION(CompressedBlockMetadata) {
+  // Serialize the sharing info manually (std::optional<BlockSharingInfo> is
+  // trivially copyable and thus not handled by SerializeOptional).
   if constexpr (ad_utility::serialization::WriteSerializer<S>) {
-    AD_CORRECTNESS_CHECK(arg.offsetsAndCompressedSize_.has_value(),
-                         "When serializing blocks offsets and compressed sizes "
-                         "need to be present.");
+    bool hasSharing = arg.sharingInfo_.has_value();
+    serializer | hasSharing;
+    if (hasSharing) {
+      auto typeAsUint = static_cast<uint8_t>(arg.sharingInfo_->type_);
+      serializer | typeAsUint;
+      serializer | arg.sharingInfo_->sourceBlockIndex_;
+    }
   } else {
-    static_assert(ad_utility::serialization::ReadSerializer<S>);
-    // Insert a dummy to overwrite.
-    arg.offsetsAndCompressedSize_.emplace();
+    bool hasSharing;
+    serializer | hasSharing;
+    if (hasSharing) {
+      uint8_t typeAsUint;
+      serializer | typeAsUint;
+      size_t sourceBlockIndex;
+      serializer | sourceBlockIndex;
+      arg.sharingInfo_ = BlockSharingInfo{
+          static_cast<BlockSharingInfo::Type>(typeAsUint), sourceBlockIndex};
+    } else {
+      arg.sharingInfo_ = std::nullopt;
+    }
   }
-  serializer | arg.offsetsAndCompressedSize_.value();
+
+  if (!arg.sharingInfo_.has_value()) {
+    // Normal block: offsets and compressed sizes are present.
+    if constexpr (ad_utility::serialization::WriteSerializer<S>) {
+      AD_CORRECTNESS_CHECK(
+          arg.offsetsAndCompressedSize_.has_value(),
+          "When serializing blocks offsets and compressed sizes "
+          "need to be present.");
+    } else {
+      static_assert(ad_utility::serialization::ReadSerializer<S>);
+      // Insert a dummy to overwrite.
+      arg.offsetsAndCompressedSize_.emplace();
+    }
+    serializer | arg.offsetsAndCompressedSize_.value();
+  } else {
+    // Shared block: no compressed data stored.
+    if constexpr (ad_utility::serialization::ReadSerializer<S>) {
+      arg.offsetsAndCompressedSize_ = std::nullopt;
+    }
+  }
   serializer | arg.numRows_;
   serializer | arg.firstTriple_;
   serializer | arg.lastTriple_;
@@ -310,13 +372,24 @@ class CompressedRelationWriter {
   // same block), after this block has been completely handled by this writer.
   // The callback is used to efficiently pass the block from a permutation to
   // its twin permutation, which only has to re-sort and write the block.
-  using SmallBlocksCallback = std::function<void(IdTable)>;
+  // The second argument is the buffer index of the block in this writer's
+  // `blockBuffer_` (used for sister permutation sharing fix-up).
+  using SmallBlocksCallback = std::function<void(IdTable, size_t)>;
   SmallBlocksCallback smallBlocksCallback_;
 
   // A dummy value for multiplicities that can only later be determined.
   static constexpr float multiplicityDummy = 42.4242f;
 
+  // If true, blocks with a constant prefix of length >= 2 (i.e., col0 AND
+  // col1 are constant) are not compressed/written but stored as unresolved
+  // cross-pair sharing dummies.  Set to true for non-canonical writers.
+  bool skipConstantPrefixBlocks_ = false;
+
  public:
+  // Enable cross-pair sharing for this writer.
+  void setSkipConstantPrefixBlocks(bool value) {
+    skipConstantPrefixBlocks_ = value;
+  }
   /// Create using a filename, to which the relation data will be written.
   explicit CompressedRelationWriter(
       size_t numColumns, ad_utility::File f,
@@ -378,6 +451,14 @@ class CompressedRelationWriter {
   struct AddBlockOfSmallRelationsToSwitched;
 
  public:
+  // The result of `getFinishedBlocks`: the block metadata and a mapping
+  // from buffer insertion index to final sorted block index.
+  struct FinishedBlocksResult {
+    std::vector<CompressedBlockMetadata> blockMetadata_;
+    // Maps buffer insertion index → final block index (after sorting).
+    std::vector<size_t> bufferIndexToBlockIndex_;
+  };
+
   // Helper struct for the result of `createPermutation`.
   struct PermutationPairResult {
     size_t numDistinctCol0_;
@@ -412,23 +493,41 @@ class CompressedRelationWriter {
 
   /// Get all the CompressedBlockMetaData that were created by the calls to
   /// addRelation. This also closes the writer. The typical workflow is:
-  /// add all relations and then call this method.
-  std::vector<CompressedBlockMetadata> getFinishedBlocks() && {
+  /// add all relations and then call this method.  Returns both the sorted
+  /// block metadata and a mapping from buffer insertion index to final sorted
+  /// block index.
+  FinishedBlocksResult getFinishedBlocksWithMapping() && {
     finish();
     auto blocks = std::move(*(blockBuffer_.wlock()));
-    ql::ranges::sort(blocks, {},
-                     &CompressedBlockMetadataNoBlockIndex::firstTriple_);
+
+    // Build a permutation that sorts the blocks by `firstTriple_`.
+    std::vector<size_t> sortPermutation(blocks.size());
+    std::iota(sortPermutation.begin(), sortPermutation.end(), 0);
+    ql::ranges::sort(sortPermutation, {},
+                     [&blocks](size_t i) { return blocks[i].firstTriple_; });
+
+    // Build the inverse mapping: bufferIndex → blockIndex.
+    std::vector<size_t> bufferIndexToBlockIndex(blocks.size());
+    for (size_t blockIdx : ad_utility::integerRange(blocks.size())) {
+      bufferIndexToBlockIndex[sortPermutation[blockIdx]] = blockIdx;
+    }
 
     std::vector<CompressedBlockMetadata> result;
     result.reserve(blocks.size());
-    // Write the correct block indices
-    for (size_t i : ad_utility::integerRange(blocks.size())) {
-      result.push_back({std::move(blocks.at(i)), i});
+    for (size_t blockIdx : ad_utility::integerRange(blocks.size())) {
+      result.push_back(
+          {std::move(blocks[sortPermutation[blockIdx]]), blockIdx});
     }
 
     AD_CORRECTNESS_CHECK(
         CompressedBlockMetadata::checkInvariantsForSortedBlocks(result));
-    return result;
+    return {std::move(result), std::move(bufferIndexToBlockIndex)};
+  }
+
+  /// Convenience wrapper that returns only the block metadata (discards the
+  /// buffer-to-block mapping).
+  std::vector<CompressedBlockMetadata> getFinishedBlocks() && {
+    return std::move(*this).getFinishedBlocksWithMapping().blockMetadata_;
   }
 
   // Compute the multiplicity of given the number of elements and the number of
@@ -478,10 +577,19 @@ class CompressedRelationWriter {
   // `firstCol0Id` and `lastCol0Id` are needed to set up the block's metadata
   // which is appended to the internal buffer. If `invokeCallback` is true and
   // the `smallBlocksCallback_` is not empty, then
-  // `smallBlocksCallback_(std::move(block))` is called AFTER the block has
-  // completely been dealt with.
+  // `smallBlocksCallback_(std::move(block), bufferIndex)` is called AFTER the
+  // block has completely been dealt with.
   void compressAndWriteBlock(Id firstCol0Id, Id lastCol0Id, IdTable block,
                              bool invokeCallback);
+
+  // Add a block's metadata to `blockBuffer_` without compressing or writing
+  // any data.  The block's data is shared from a source permutation.  The
+  // `block` is used only to extract `firstTriple_`, `lastTriple_`,
+  // `graphInfo_`, and `containsDuplicatesWithDifferentGraphs_`.
+  // Returns the buffer index of the newly appended entry.
+  size_t addSharedBlockMetadata(Id firstCol0Id, Id lastCol0Id,
+                                const IdTable& block,
+                                BlockSharingInfo sharingInfo);
 
   // Add a small relation that will be stored in a single block, possibly
   // together with other small relations.
@@ -693,6 +801,32 @@ class CompressedRelationReader {
   using IdTableGeneratorInputRange =
       ad_utility::InputRangeTypeErased<IdTable, LazyScanMetadata>;
 
+ public:
+  // Access to a related permutation's reader and block metadata, used to
+  // read shared blocks from sister or cross-pair permutations.
+  struct SharedPermutationAccess {
+    const CompressedRelationReader* reader;
+    const std::vector<CompressedBlockMetadata>* blocks;
+  };
+
+  explicit CompressedRelationReader(Allocator allocator, ad_utility::File file,
+                                    bool useGraphPostProcessing = true)
+      : allocator_{std::move(allocator)},
+        file_{std::move(file)},
+        useGraphPostProcessing_{useGraphPostProcessing} {}
+
+  // Set the access to the sister permutation's reader and blocks.
+  void setSisterAccess(const CompressedRelationReader* reader,
+                       const std::vector<CompressedBlockMetadata>* blocks) {
+    sisterAccess_ = SharedPermutationAccess{reader, blocks};
+  }
+
+  // Set the access to the cross-pair permutation's reader and blocks.
+  void setCrossPairAccess(const CompressedRelationReader* reader,
+                          const std::vector<CompressedBlockMetadata>* blocks) {
+    crossPairAccess_ = SharedPermutationAccess{reader, blocks};
+  }
+
  private:
   // The allocator used to allocate intermediate buffers.
   mutable Allocator allocator_;
@@ -705,13 +839,12 @@ class CompressedRelationReader {
   // used for materialized views where repeated rows are meaningful.
   bool useGraphPostProcessing_;
 
- public:
-  explicit CompressedRelationReader(Allocator allocator, ad_utility::File file,
-                                    bool useGraphPostProcessing = true)
-      : allocator_{std::move(allocator)},
-        file_{std::move(file)},
-        useGraphPostProcessing_{useGraphPostProcessing} {}
+  // Access to the sister and cross-pair permutation's reader and blocks for
+  // reading shared blocks.
+  std::optional<SharedPermutationAccess> sisterAccess_;
+  std::optional<SharedPermutationAccess> crossPairAccess_;
 
+ public:
   // Helper function that enables a comparison of a triple with an `Id` in the
   // function `getBlocksForJoin` below.  If the given triple matches `col0Id` of
   // the given `ScanSpecification`, then `col1Id` is returned. If the given
@@ -884,6 +1017,13 @@ class CompressedRelationReader {
   template <typename Iterator>
   static void decompressColumn(const std::vector<char>& compressedColumn,
                                size_t numRowsToRead, Iterator iterator);
+
+  // Read a block whose data is shared from another permutation.  Depending on
+  // `sharingInfo.type_`, this reads from the sister or cross-pair permutation,
+  // decompresses, and applies the necessary column swap / resort.
+  std::optional<DecompressedBlockAndMetadata> readSharedBlock(
+      const CompressedBlockMetadata& blockMetaData,
+      const ScanImplConfig& scanConfig) const;
 
   // Read and decompress the parts of the block given by `blockMetaData` (which
   // identifies the block) and `scanConfig` (which specifies the part of that

--- a/src/index/CompressedRelationPermutationWriterImpl.h
+++ b/src/index/CompressedRelationPermutationWriterImpl.h
@@ -123,6 +123,20 @@ struct CompressedRelationWriter::PermutationWriter {
   IdTableStatic<0> relation_{numColumns_, alloc_};
   size_t numBlocksCurrentRel_ = 0;
 
+  // Whether block alignment for cross-pair sharing is active. Only true when
+  // at least one writer in a permutation pair has cross-pair sharing enabled.
+  bool alignBlocks_ = false;
+
+  // Lookahead state for block alignment of large (col0, col1) pairs.
+  // When col1 changes, new triples are buffered in lookaheadBuffer_ until
+  // we can determine if the group is large (>= blocksize_ triples).
+  IdTableStatic<0> lookaheadBuffer_{numColumns_, alloc_};
+  std::optional<Id> lookaheadCol1_;
+  // When a (col0, col1) group is confirmed large, we enter aligned mode
+  // to produce deterministic, exclusive blocks.
+  std::optional<Id> alignedCol1_;
+  bool inAlignedMode_ = false;
+
   using TwinRelationSorter = ad_utility::CompressedExternalIdTableSorter<
       compressedRelationHelpers::ComparatorForConstCol0, 0>;
   IfPair<TwinRelationSorter> twinRelationSorter_;
@@ -159,6 +173,11 @@ struct CompressedRelationWriter::PermutationWriter {
     AD_CORRECTNESS_CHECK(blocksize_ == writer2_->blocksize());
     AD_CORRECTNESS_CHECK(numColumns_ == writer2_->numColumns());
 
+    // Enable block alignment for all permutation pairs. Both canonical and
+    // non-canonical permutations need aligned blocks at col1 boundaries so
+    // that cross-pair sharing can find matching blocks.
+    alignBlocks_ = true;
+
     writer1_->smallBlocksCallback_ =
         AddBlockOfSmallRelationsToSwitched{*writer2_};
   };
@@ -180,7 +199,9 @@ struct CompressedRelationWriter::PermutationWriter {
   };
 
   // Write a block of a large relation with `writer1` and also push the block
-  // into the twin sorter for `writer2`.
+  // into the twin sorter for `writer2`. Cross-pair sharing dummies are only
+  // created when `inAlignedMode_` is true, ensuring that only blocks from
+  // aligned (col0, col1) groups are eligible for cross-pair sharing.
   void addBlockForLargeRelation() {
     using namespace compressedRelationHelpers;
     if (relation_.empty()) {
@@ -194,16 +215,67 @@ struct CompressedRelationWriter::PermutationWriter {
       }
     }
     writer1_->addBlockForLargeRelation(col0IdCurrentRelation_.value(),
-                                       std::move(relation_).toDynamic());
+                                       std::move(relation_).toDynamic(),
+                                       inAlignedMode_);
     relation_.clear();
     relation_.reserve(blocksize_);
     ++numBlocksCurrentRel_;
   };
 
+  // Merge the lookahead buffer back into relation_ when the col1 group
+  // turns out to be small (< blocksize_ triples).
+  void flushLookaheadToRelation() {
+    if (!lookaheadCol1_.has_value()) {
+      return;
+    }
+    for (size_t i = 0; i < lookaheadBuffer_.numRows(); ++i) {
+      relation_.push_back(lookaheadBuffer_[i]);
+    }
+    lookaheadBuffer_.clear();
+    lookaheadCol1_.reset();
+  }
+
+  // Called when lookahead confirms a large (col0, col1) group (>=
+  // blocksize_ triples). Flushes prior mixed content from relation_ and
+  // begins writing aligned blocks for this col1 group.
+  void enterAlignedMode() {
+    // Flush relation_ (prior mixed content) as a partial block.
+    if (!relation_.empty()) {
+      addBlockForLargeRelation();
+    }
+    // Move lookahead buffer into relation_.
+    std::swap(relation_, lookaheadBuffer_);
+    lookaheadBuffer_.clear();
+    alignedCol1_ = lookaheadCol1_;
+    lookaheadCol1_.reset();
+    inAlignedMode_ = true;
+    // Write the first aligned block (relation_ now has blocksize_ rows).
+    addBlockForLargeRelation();
+  }
+
+  // Exit aligned mode by flushing remaining triples as the final
+  // partial block of the aligned (col0, col1) group.
+  void exitAlignedMode() {
+    if (!relation_.empty()) {
+      addBlockForLargeRelation();
+    }
+    inAlignedMode_ = false;
+    alignedCol1_.reset();
+  }
+
   // We have encountered the last occurrence of the current relation (value for
   // column 0). Thus we need to write the remaining buffered rows and metadata.
   // This also resets counters and buffers for writing the next relation.
   void finishRelation() {
+    // Clean up alignment state before finishing the relation.
+    if (alignBlocks_) {
+      if (inAlignedMode_) {
+        exitAlignedMode();
+      }
+      if (lookaheadCol1_.has_value()) {
+        flushLookaheadToRelation();
+      }
+    }
     ++numDistinctCol0_;
     if (numBlocksCurrentRel_ > 0 || static_cast<double>(relation_.numRows()) >
                                         0.8 * static_cast<double>(blocksize_)) {
@@ -333,11 +405,58 @@ struct CompressedRelationWriter::PermutationWriter {
           col0IdCurrentRelation_ = col0Id;
         }
 
+        Id curCol1 = curRemainingCols[c1Idx];
+        distinctCol1Counter_(curCol1);
+
+        // Block alignment for cross-pair sharing is only used when at least
+        // one writer in the pair has cross-pair sharing enabled.
+        if (alignBlocks_) {
+          // Aligned mode: writing exclusive blocks for a large (col0, col1)
+          // pair to enable cross-pair sharing.
+          if (inAlignedMode_) {
+            if (curCol1 == alignedCol1_.value()) {
+              if (isEndOfBlockForLargeRelation(curRemainingCols)) {
+                addBlockForLargeRelation();
+              }
+              relation_.push_back(curRemainingCols);
+              increaseTripleCounter();
+              continue;
+            }
+            // Col1 changed; exit aligned mode and fall through.
+            exitAlignedMode();
+          }
+
+          // Lookahead mode: buffering to detect large (col0, col1) groups.
+          if (lookaheadCol1_.has_value()) {
+            if (curCol1 == lookaheadCol1_.value()) {
+              lookaheadBuffer_.push_back(curRemainingCols);
+              if (lookaheadBuffer_.size() >= blocksize_) {
+                enterAlignedMode();
+              }
+              increaseTripleCounter();
+              continue;
+            }
+            // Col1 changed again; previous group was small.
+            flushLookaheadToRelation();
+          }
+
+          // Start lookahead when col1 differs from what's in relation_ or
+          // when relation_ is empty (start of a new col0 relation or after
+          // exiting aligned mode). This ensures every col1 group gets a
+          // chance to enter aligned mode if it's large enough.
+          if (relation_.empty() || curCol1 != relation_.back()[c1Idx]) {
+            lookaheadCol1_ = curCol1;
+            lookaheadBuffer_.push_back(curRemainingCols);
+            increaseTripleCounter();
+            continue;
+          }
+        }
+
+        // Normal processing path (always used for single permutations,
+        // used for same-col1 triples in pair mode).
         if (isEndOfBlockForLargeRelation(curRemainingCols)) {
           addBlockForLargeRelation();
         }
-
-        distinctCol1Counter_(curRemainingCols[c1Idx]);
         relation_.push_back(curRemainingCols);
 
         increaseTripleCounter();
@@ -347,7 +466,8 @@ struct CompressedRelationWriter::PermutationWriter {
     }
     AD_LOG_INFO << progressBar_.getFinalProgressString() << std::flush;
     inputWaitTimer_.stop();
-    if (!relation_.empty() || numBlocksCurrentRel_ > 0) {
+    if (!relation_.empty() || numBlocksCurrentRel_ > 0 ||
+        lookaheadCol1_.has_value()) {
       finishRelation();
     }
 

--- a/src/index/CompressedRelationPermutationWriterImpl.h
+++ b/src/index/CompressedRelationPermutationWriterImpl.h
@@ -20,7 +20,8 @@
 struct CompressedRelationWriter::AddBlockOfSmallRelationsToSwitched {
   CompressedRelationWriter& writer_;
 
-  void operator()(IdTable blockOfSmallRelations) const {
+  void operator()(IdTable blockOfSmallRelations,
+                  size_t sourceBufferIndex) const {
     using namespace compressedRelationHelpers;
 
     // We don't use the parallel twinRelationSorter to create the twin
@@ -43,8 +44,12 @@ struct CompressedRelationWriter::AddBlockOfSmallRelationsToSwitched {
     auto firstCol0 = blockOfSmallRelations.at(0, 0);
     auto lastCol0 =
         blockOfSmallRelations.at(blockOfSmallRelations.numRows() - 1, 0);
-    writer_.compressAndWriteBlock(firstCol0, lastCol0,
-                                  std::move(blockOfSmallRelations), false);
+    // Instead of compressing and writing the data for the sister permutation,
+    // we add only the metadata and reference the source block in writer1.
+    writer_.addSharedBlockMetadata(
+        firstCol0, lastCol0, blockOfSmallRelations,
+        BlockSharingInfo{BlockSharingInfo::Type::SisterPermutation,
+                         sourceBufferIndex});
   };
 };
 
@@ -353,9 +358,28 @@ struct CompressedRelationWriter::PermutationWriter {
     blockCallbackManager_.finishBlockCallbackQueue();
     logTimers();
     if constexpr (WritePair) {
-      return PermutationPairResult{numDistinctCol0_,
-                                   std::move(*writer1_).getFinishedBlocks(),
-                                   std::move(*writer2_).getFinishedBlocks()};
+      // Get writer1's blocks with the buffer-to-block mapping so we can
+      // fix up sister sharing references in writer2.
+      auto [blocks1, bufferToBlockMapping] =
+          std::move(*writer1_).getFinishedBlocksWithMapping();
+      auto blocks2 = std::move(*writer2_).getFinishedBlocks();
+
+      // Fix up writer2's sister sharing `sourceBlockIndex_` values:
+      // they currently hold buffer indices from writer1, which need to be
+      // translated to final block indices.
+      for (auto& block : blocks2) {
+        if (block.sharingInfo_.has_value() &&
+            block.sharingInfo_->type_ ==
+                BlockSharingInfo::Type::SisterPermutation) {
+          AD_CORRECTNESS_CHECK(block.sharingInfo_->sourceBlockIndex_ <
+                               bufferToBlockMapping.size());
+          block.sharingInfo_->sourceBlockIndex_ =
+              bufferToBlockMapping[block.sharingInfo_->sourceBlockIndex_];
+        }
+      }
+
+      return PermutationPairResult{numDistinctCol0_, std::move(blocks1),
+                                   std::move(blocks2)};
     } else {
       return PermutationSingleResult{numDistinctCol0_,
                                      std::move(*writer1_).getFinishedBlocks()};

--- a/src/index/IndexFormatVersion.h
+++ b/src/index/IndexFormatVersion.h
@@ -40,7 +40,7 @@ struct IndexFormatVersion {
 // The actual index version. Change it once the binary format of the index
 // changes.
 inline const IndexFormatVersion& indexFormatVersion{
-    1572, DateYearOrDuration{Date{2024, 10, 22}}};
+    2750, DateYearOrDuration{Date{2026, 3, 5}}};
 }  // namespace qlever
 
 #endif  // QLEVER_SRC_INDEX_INDEXFORMATVERSION_H

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -1955,10 +1955,8 @@ CPP_template_def(typename... NextSorter)(requires(sizeof...(NextSorter) <= 1))
       auto tripleArr = std::array{triple[0], triple[1], triple[2], triple[3]};
       patternCreator.processTriple(tripleArr, ignoreForPatterns);
     };
-    // TODO<cross-pair> Enable cross-pair sharing once block alignment is
-    // resolved: SPO→PSO (true, false), SOP→OSP (false, true).
     size_t numSubjects = createPermutationPair(
-        numColumns, AD_FWD(sortedTriples), *spo_, *sop_, false, false,
+        numColumns, AD_FWD(sortedTriples), *spo_, *sop_, true, false,
         nextSorter.makePushCallback()..., pushTripleToPatterns);
     patternCreator.finish();
     configurationJson_["num-subjects"] =
@@ -1969,7 +1967,7 @@ CPP_template_def(typename... NextSorter)(requires(sizeof...(NextSorter) <= 1))
     AD_CORRECTNESS_CHECK(sizeof...(nextSorter) == 1);
     size_t numSubjects =
         createPermutationPair(numColumns, AD_FWD(sortedTriples), *spo_, *sop_,
-                              false, false, nextSorter.makePushCallback()...);
+                              true, false, nextSorter.makePushCallback()...);
     configurationJson_["num-subjects"] =
         NumNormalAndInternal::fromNormal(numSubjects);
     writeConfiguration();
@@ -1987,7 +1985,7 @@ CPP_template_def(typename... NextSorter)(
   // have no fourth argument.
   size_t numObjects =
       createPermutationPair(numColumns, AD_FWD(sortedTriples), *osp_, *ops_,
-                            false, false, nextSorter.makePushCallback()...);
+                            false, true, nextSorter.makePushCallback()...);
   configurationJson_["num-objects"] =
       NumNormalAndInternal::fromNormal(numObjects);
   configurationJson_["has-all-permutations"] = true;

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -435,6 +435,7 @@ void IndexImpl::createFromFiles(
     secondSorter.clear();
     createThirdPermutationPair(NumColumnsIndexBuilding,
                                thirdSorter.getSortedBlocks<0>());
+    resolveCrossPairSharing();
     configurationJson_["has-all-permutations"] = true;
   } else {
     // Load all permutations and also load the patterns. In this case the
@@ -449,6 +450,7 @@ void IndexImpl::createFromFiles(
     createInternalPsoAndPosAndSetMetadata();
     createThirdPermutationPair(NumColumnsIndexBuilding + 2,
                                thirdSorterPtr->template getSortedBlocks<0>());
+    resolveCrossPairSharing();
     configurationJson_["has-all-permutations"] = true;
   }
 
@@ -458,6 +460,104 @@ void IndexImpl::createFromFiles(
   addInternalStatisticsToConfiguration(numTriplesInternal,
                                        numPredicatesInternal);
   AD_LOG_INFO << "Index build completed" << std::endl;
+}
+
+// _____________________________________________________________________________
+void IndexImpl::resolveCrossPairSharing() {
+  // Resolve cross-pair sharing: for each (nonCanonical, canonical) pair, find
+  // the matching block in the canonical permutation for each cross-pair dummy
+  // block in the non-canonical permutation.
+  //
+  // Cross-pair partners (non-canonical → canonical):
+  //   SPO → PSO, SOP → OSP, OPS → POS
+  struct PairToResolve {
+    const Permutation& nonCanonical;
+    const Permutation& canonical;
+  };
+  std::array<PairToResolve, 3> pairs{{
+      {*spo_, *pso_},
+      {*sop_, *osp_},
+      {*ops_, *pos_},
+  }};
+
+  // Helper to read block metadata from disk for a permutation.
+  auto readBlockData =
+      [this](const Permutation& perm) -> std::vector<CompressedBlockMetadata> {
+    auto filename = getFilenameForPermutation(perm, false);
+    IndexMetaDataMmapView meta;
+    meta.setup(filename + MMAP_FILE_SUFFIX, ad_utility::ReuseTag(),
+               ad_utility::AccessPattern::Random);
+    ad_utility::File file(filename, "r");
+    meta.readFromFile(&file);
+    file.close();
+    return meta.blockData();
+  };
+
+  for (auto& [nonCanon, canon] : pairs) {
+    auto filename = getFilenameForPermutation(nonCanon, false);
+    // Read the metadata for both permutations.
+    IndexMetaDataMmapView meta;
+    meta.setup(filename + MMAP_FILE_SUFFIX, ad_utility::ReuseTag(),
+               ad_utility::AccessPattern::Random);
+    ad_utility::File file(filename, "r");
+    meta.readFromFile(&file);
+    file.close();
+
+    auto& blocks = meta.blockData();
+    auto canonicalBlocks = readBlockData(canon);
+
+    size_t numResolved = 0;
+    for (auto& block : blocks) {
+      if (!block.sharingInfo_.has_value() ||
+          block.sharingInfo_->type_ !=
+              BlockSharingInfo::Type::CrossPairPermutation) {
+        continue;
+      }
+      AD_CORRECTNESS_CHECK(block.sharingInfo_->sourceBlockIndex_ ==
+                           std::numeric_limits<size_t>::max());
+
+      // The non-canonical block has constant col0 and col1.  In the canonical
+      // permutation, these are swapped: col0_canon = col1_noncanon and
+      // col1_canon = col0_noncanon.
+      auto targetCol0 = block.firstTriple_.col1Id_;
+      auto targetCol1 = block.firstTriple_.col0Id_;
+      auto targetCol2First = block.firstTriple_.col2Id_;
+      auto targetCol2Last = block.lastTriple_.col2Id_;
+      auto targetNumRows = block.numRows_;
+
+      // Find the matching block in the canonical permutation.
+      bool found = false;
+      for (size_t i = 0; i < canonicalBlocks.size(); ++i) {
+        const auto& cb = canonicalBlocks[i];
+        if (cb.firstTriple_.col0Id_ == targetCol0 &&
+            cb.firstTriple_.col1Id_ == targetCol1 &&
+            cb.lastTriple_.col0Id_ == targetCol0 &&
+            cb.lastTriple_.col1Id_ == targetCol1 &&
+            cb.firstTriple_.col2Id_ == targetCol2First &&
+            cb.lastTriple_.col2Id_ == targetCol2Last &&
+            cb.numRows_ == targetNumRows) {
+          block.sharingInfo_->sourceBlockIndex_ = cb.blockIndex_;
+          found = true;
+          ++numResolved;
+          break;
+        }
+      }
+      AD_CONTRACT_CHECK(found,
+                        "Could not find matching canonical block for "
+                        "cross-pair dummy in ",
+                        nonCanon.readableName());
+    }
+
+    if (numResolved > 0) {
+      // Re-write the metadata to disk.
+      ad_utility::File outFile(filename, "r+");
+      meta.appendToFile(&outFile);
+      outFile.close();
+      AD_LOG_INFO << "Resolved " << numResolved
+                  << " cross-pair sharing blocks for "
+                  << nonCanon.readableName() << std::endl;
+    }
+  }
 }
 
 // _____________________________________________________________________________
@@ -866,18 +966,21 @@ CompressedRelationWriter::WriterAndCallback IndexImpl::getWriterAndCallback(
 template <typename T, typename... Callbacks>
 std::tuple<size_t, IndexImpl::IndexMetaDataMmapDispatcher::WriteType,
            IndexImpl::IndexMetaDataMmapDispatcher::WriteType>
-IndexImpl::createPermutationPairImpl(size_t numColumns,
-                                     const std::string& fileName1,
-                                     const std::string& fileName2,
-                                     T&& sortedTriples,
-                                     Permutation::KeyOrder permutation,
-                                     Callbacks&&... perTripleCallbacks) {
+IndexImpl::createPermutationPairImpl(
+    size_t numColumns, const std::string& fileName1,
+    const std::string& fileName2, T&& sortedTriples,
+    Permutation::KeyOrder permutation, bool skipConstantPrefixWriter1,
+    bool skipConstantPrefixWriter2, Callbacks&&... perTripleCallbacks) {
   IndexMetaDataMmapDispatcher::WriteType metaData1;
   auto writerAndCallback1 =
       getWriterAndCallback(metaData1, numColumns, fileName1);
+  writerAndCallback1.writer_->setSkipConstantPrefixBlocks(
+      skipConstantPrefixWriter1);
   IndexMetaDataMmapDispatcher::WriteType metaData2;
   auto writerAndCallback2 =
       getWriterAndCallback(metaData2, numColumns, fileName2);
+  writerAndCallback2.writer_->setSkipConstantPrefixBlocks(
+      skipConstantPrefixWriter2);
 
   std::vector<std::function<void(const IdTableStatic<0>&)>> perBlockCallbacks{
       liftCallback(perTripleCallbacks)...};
@@ -918,13 +1021,16 @@ std::tuple<size_t, IndexImpl::IndexMetaDataMmapDispatcher::WriteType,
            IndexImpl::IndexMetaDataMmapDispatcher::WriteType>
 IndexImpl::createPermutations(size_t numColumns, T&& sortedTriples,
                               const Permutation& p1, const Permutation& p2,
+                              bool skipConstantPrefixWriter1,
+                              bool skipConstantPrefixWriter2,
                               Callbacks&&... perTripleCallbacks) {
   AD_LOG_INFO << "Creating permutations " << p1.readableName() << " and "
               << p2.readableName() << " ..." << std::endl;
   auto metaData = createPermutationPairImpl(
       numColumns, getFilenameForPermutation(p1, false),
       getFilenameForPermutation(p2, false), AD_FWD(sortedTriples),
-      p1.keyOrder(), AD_FWD(perTripleCallbacks)...);
+      p1.keyOrder(), skipConstantPrefixWriter1, skipConstantPrefixWriter2,
+      AD_FWD(perTripleCallbacks)...);
 
   auto& [numDistinctCol0, meta1, meta2] = metaData;
   meta1.calculateStatistics(numDistinctCol0);
@@ -976,13 +1082,13 @@ void IndexImpl::finalizePermutation(
 
 // ________________________________________________________________________
 template <typename SortedTriplesType, typename... CallbackTypes>
-size_t IndexImpl::createPermutationPair(size_t numColumns,
-                                        SortedTriplesType&& sortedTriples,
-                                        const Permutation& p1,
-                                        const Permutation& p2,
-                                        CallbackTypes&&... perTripleCallbacks) {
+size_t IndexImpl::createPermutationPair(
+    size_t numColumns, SortedTriplesType&& sortedTriples, const Permutation& p1,
+    const Permutation& p2, bool skipConstantPrefixWriter1,
+    bool skipConstantPrefixWriter2, CallbackTypes&&... perTripleCallbacks) {
   auto [numDistinctC0, metaData1, metaData2] = createPermutations(
-      numColumns, AD_FWD(sortedTriples), p1, p2, AD_FWD(perTripleCallbacks)...);
+      numColumns, AD_FWD(sortedTriples), p1, p2, skipConstantPrefixWriter1,
+      skipConstantPrefixWriter2, AD_FWD(perTripleCallbacks)...);
   AD_LOG_DEBUG << "Writing meta data for " << p1.readableName() << " and "
                << p2.readableName() << " ..." << std::endl;
   writeMetaData(metaData1, getFilenameForPermutation(p1, false));
@@ -1046,6 +1152,31 @@ void IndexImpl::createFromOnDiskIndex(const std::string& onDiskBase,
           << "Only the PSO and POS permutation were loaded, SPARQL queries "
              "with predicate variables will therefore not work"
           << std::endl;
+    }
+  }
+
+  // Set up sister and cross-pair permutation links for shared block reading.
+  // PSO↔POS are always loaded, so always set up their sister links.
+  if (!doNotLoadPermutations_) {
+    pso_->setSisterPermutation(pos_.get());
+    pos_->setSisterPermutation(pso_.get());
+    pso_->wireSharedBlockAccess();
+    pos_->wireSharedBlockAccess();
+  }
+  if (loadAllPermutations_ && !doNotLoadPermutations_) {
+    // Sister pairs: SPO↔SOP, OSP↔OPS.
+    spo_->setSisterPermutation(sop_.get());
+    sop_->setSisterPermutation(spo_.get());
+    osp_->setSisterPermutation(ops_.get());
+    ops_->setSisterPermutation(osp_.get());
+    // Cross-pair links (non-canonical → canonical):
+    // SPO→PSO, SOP→OSP, OPS→POS.
+    spo_->setCrossPairPermutation(pso_.get());
+    sop_->setCrossPairPermutation(osp_.get());
+    ops_->setCrossPairPermutation(pos_.get());
+    // Wire the readers.
+    for (auto perm : {spo_, sop_, osp_, ops_}) {
+      perm->wireSharedBlockAccess();
     }
   }
 
@@ -1780,9 +1911,9 @@ CPP_template_def(typename... NextSorter)(requires(
                                             NextSorter&&... nextSorter) {
   size_t numTriples = 0;
   auto countTriples = [&numTriples](const auto&) mutable { ++numTriples; };
-  size_t numPredicates =
-      createPermutationPair(numColumns, AD_FWD(sortedTriples), *pso_, *pos_,
-                            nextSorter.makePushCallback()..., countTriples);
+  size_t numPredicates = createPermutationPair(
+      numColumns, AD_FWD(sortedTriples), *pso_, *pos_, false, false,
+      nextSorter.makePushCallback()..., countTriples);
   configurationJson_["num-predicates"] =
       NumNormalAndInternal::fromNormal(numPredicates);
   configurationJson_["num-triples"] =
@@ -1824,8 +1955,10 @@ CPP_template_def(typename... NextSorter)(requires(sizeof...(NextSorter) <= 1))
       auto tripleArr = std::array{triple[0], triple[1], triple[2], triple[3]};
       patternCreator.processTriple(tripleArr, ignoreForPatterns);
     };
+    // TODO<cross-pair> Enable cross-pair sharing once block alignment is
+    // resolved: SPO→PSO (true, false), SOP→OSP (false, true).
     size_t numSubjects = createPermutationPair(
-        numColumns, AD_FWD(sortedTriples), *spo_, *sop_,
+        numColumns, AD_FWD(sortedTriples), *spo_, *sop_, false, false,
         nextSorter.makePushCallback()..., pushTripleToPatterns);
     patternCreator.finish();
     configurationJson_["num-subjects"] =
@@ -1836,7 +1969,7 @@ CPP_template_def(typename... NextSorter)(requires(sizeof...(NextSorter) <= 1))
     AD_CORRECTNESS_CHECK(sizeof...(nextSorter) == 1);
     size_t numSubjects =
         createPermutationPair(numColumns, AD_FWD(sortedTriples), *spo_, *sop_,
-                              nextSorter.makePushCallback()...);
+                              false, false, nextSorter.makePushCallback()...);
     configurationJson_["num-subjects"] =
         NumNormalAndInternal::fromNormal(numSubjects);
     writeConfiguration();
@@ -1854,7 +1987,7 @@ CPP_template_def(typename... NextSorter)(
   // have no fourth argument.
   size_t numObjects =
       createPermutationPair(numColumns, AD_FWD(sortedTriples), *osp_, *ops_,
-                            nextSorter.makePushCallback()...);
+                            false, false, nextSorter.makePushCallback()...);
   configurationJson_["num-objects"] =
       NumNormalAndInternal::fromNormal(numObjects);
   configurationJson_["has-all-permutations"] = true;

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -566,6 +566,11 @@ class IndexImpl {
       IndexMetaDataMmapDispatcher::WriteType& metaData, size_t numColumns,
       const std::string& fileName) const;
 
+  // After all permutations are built, resolve cross-pair sharing dummy blocks.
+  // Each non-canonical permutation has dummy blocks (with sourceBlockIndex_ =
+  // SIZE_MAX) that need to be resolved against the canonical permutation.
+  void resolveCrossPairSharing();
+
   // TODO<joka921> Get rid of the `numColumns` by including them into the
   // `sortedTriples` argument.
   template <typename T, typename... Callbacks>
@@ -574,6 +579,8 @@ class IndexImpl {
   createPermutationPairImpl(size_t numColumns, const std::string& fileName1,
                             const std::string& fileName2, T&& sortedTriples,
                             Permutation::KeyOrder permutation,
+                            bool skipConstantPrefixWriter1,
+                            bool skipConstantPrefixWriter2,
                             Callbacks&&... perTripleCallbacks);
 
   // Write a single permutation to disk. `numColumns` specifies the number of
@@ -611,6 +618,7 @@ class IndexImpl {
   [[nodiscard]] size_t createPermutationPair(
       size_t numColumns, SortedTriplesType&& sortedTriples,
       const Permutation& p1, const Permutation& p2,
+      bool skipConstantPrefixWriter1, bool skipConstantPrefixWriter2,
       CallbackTypes&&... perTripleCallbacks);
 
   // wrapper for createPermutation that saves a lot of code duplications
@@ -627,6 +635,8 @@ class IndexImpl {
              IndexMetaDataMmapDispatcher::WriteType>
   createPermutations(size_t numColumns, T&& sortedTriples,
                      const Permutation& p1, const Permutation& p2,
+                     bool skipConstantPrefixWriter1,
+                     bool skipConstantPrefixWriter2,
                      Callbacks&&... perTripleCallbacks);
 
  public:

--- a/src/index/LocatedTriples.cpp
+++ b/src/index/LocatedTriples.cpp
@@ -347,7 +347,8 @@ void LocatedTriplesPerBlock::updateAugmentedMetadata() {
     // The first `std::nullopt` means that this block contains only
     // `LocatedTriple`s.
     CompressedBlockMetadataNoBlockIndex lastBlockN{
-        std::nullopt, 0, firstTriple, lastTriple, std::nullopt, true};
+        std::nullopt, 0,    firstTriple, lastTriple,
+        std::nullopt, true, std::nullopt};
     lastBlockN.graphInfo_.emplace();
     CompressedBlockMetadata lastBlock{lastBlockN, blockIndex};
     updateGraphMetadata(lastBlock, *blockUpdates);

--- a/src/index/Permutation.cpp
+++ b/src/index/Permutation.cpp
@@ -232,6 +232,21 @@ BlockMetadataRanges Permutation::getAugmentedMetadataForPermutation(
 }
 
 // ______________________________________________________________________
+void Permutation::wireSharedBlockAccess() {
+  if (!reader_.has_value()) {
+    return;
+  }
+  if (sisterPermutation_ != nullptr && sisterPermutation_->isLoaded()) {
+    reader_->setSisterAccess(&sisterPermutation_->reader(),
+                             &sisterPermutation_->metaData().blockData());
+  }
+  if (crossPairPermutation_ != nullptr && crossPairPermutation_->isLoaded()) {
+    reader_->setCrossPairAccess(&crossPairPermutation_->reader(),
+                                &crossPairPermutation_->metaData().blockData());
+  }
+}
+
+// ______________________________________________________________________
 const Permutation& Permutation::internalPermutation() const {
   AD_CONTRACT_CHECK(internalPermutation_ != nullptr);
   return *internalPermutation_;

--- a/src/index/Permutation.h
+++ b/src/index/Permutation.h
@@ -203,6 +203,19 @@ class Permutation {
 
   const CompressedRelationReader& reader() const { return reader_.value(); }
 
+  // Set up shared block access links to sister/cross-pair permutations.
+  // Must be called after all permutations are loaded.
+  void setSisterPermutation(Permutation* sister) {
+    sisterPermutation_ = sister;
+  }
+  void setCrossPairPermutation(Permutation* crossPair) {
+    crossPairPermutation_ = crossPair;
+  }
+
+  // Wire the reader's shared accesses based on the sister/cross-pair links.
+  // Must be called after setSisterPermutation/setCrossPairPermutation.
+  void wireSharedBlockAccess();
+
   Enum permutation() const { return permutation_; }
 
   // Provide const access to a linked internal permutation. If no internal
@@ -233,6 +246,11 @@ class Permutation {
   std::unique_ptr<Permutation> internalPermutation_ = nullptr;
 
   bool isInternalPermutation_ = false;
+
+  // Pointers to sister and cross-pair permutations for shared block reading.
+  // These are set up after all permutations are loaded.
+  Permutation* sisterPermutation_ = nullptr;
+  Permutation* crossPairPermutation_ = nullptr;
 };
 
 #endif  // QLEVER_SRC_INDEX_PERMUTATION_H

--- a/test/index/IndexRebuilderTest.cpp
+++ b/test/index/IndexRebuilderTest.cpp
@@ -442,6 +442,12 @@ TEST(IndexRebuilder, createPermutationWriterTask) {
   threadPool.join();
   for (std::string_view suffix : suffixes) {
     EXPECT_TRUE(std::filesystem::exists(prefix + suffix));
+  }
+  // PSO is writer1 (canonical) in pair mode, so its files are byte-identical
+  // to the single-permutation rebuild.  POS is writer2 and may have sister
+  // sharing blocks in the original, which the single-permutation rebuild does
+  // not produce, so we only compare PSO files byte-for-byte.
+  for (std::string_view suffix : {".index.pso", ".index.pso.meta"}) {
     EXPECT_EQ(fileToBuffer(index.getOnDiskBase() + suffix),
               fileToBuffer(prefix + suffix));
   }


### PR DESCRIPTION
## Summary

- When building permutation pairs (SPO↔SOP, PSO↔POS, OSP↔OPS), blocks of small relations in the second writer (writer2) now reference the corresponding block in the first writer (writer1) instead of storing their own compressed data
- At read time, the shared block is read from the sister permutation, col1/col2 are swapped, and the result is resorted
- This reduces index size by avoiding duplicate compressed storage for blocks that contain the same triples in a different column order
- Cross-pair sharing infrastructure (for blocks with constant col0+col1 prefix) is in place but disabled pending block alignment work

### Key changes
- `BlockSharingInfo` struct and `sharingInfo_` field added to block metadata
- `addSharedBlockMetadata` in writer creates shared block references without compressing data
- `readSharedBlock` in reader handles decompression from sister permutation with column swap and resort
- `Permutation` objects track sister/cross-pair links for reader access
- Buffer-to-block index mapping enables fix-up of sharing references after block sorting
- PSO↔POS sister links are always set up (even when only 2 permutations loaded)
- Index format version bumped to reflect metadata format change

## Test plan
- [x] All `CompressedRelationsTest` tests pass (22/22)
- [x] All `IndexTest` tests pass (17/17)
- [x] All `IndexScanTest` tests pass (49/49)
- [x] All `IndexRebuilderTest` tests pass (12/12)
- [x] Byte-level comparison of PSO files between pair-built and single-rebuilt indices

🤖 Generated with [Claude Code](https://claude.com/claude-code)