### PR TITLE
Fix the compilation with `CHEAPER_COMPILATION=ON`

### DIFF
--- a/src/engine/sparqlExpressions/SparqlExpressionValueGetters.cpp
+++ b/src/engine/sparqlExpressions/SparqlExpressionValueGetters.cpp
@@ -695,5 +695,6 @@ template struct TypeErasedValueGetter<StringOrDateGetter>;
 template struct TypeErasedValueGetter<IntValueGetter>;
 template struct TypeErasedValueGetter<RegexValueGetter>;
 template struct TypeErasedValueGetter<AlwaysTrueValueGetter>;
+template struct TypeErasedValueGetter<NumericOrDateValueGetter>;
 
 }  // namespace sparqlExpression::detail

--- a/src/engine/sparqlExpressions/SparqlExpressionValueGetters.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionValueGetters.h
@@ -113,6 +113,7 @@ struct NumericValueGetter : Mixin<NumericValueGetter> {
 // expressions.
 struct NumericOrDateValueGetter : Mixin<NumericOrDateValueGetter> {
   using Mixin<NumericOrDateValueGetter>::operator();
+  using Value = NumericOrDateValue;
   // Same as in `NumericValueGetter`.
   // Here a `LiteralOrIri` can never be of type `bool`, `int`, `double` or
   // `DateYearOrDuration`. These types were already folded into `ValueId`s.


### PR DESCRIPTION
Yesterday, two PRs were merged that slightly conflicted, this is now fixed and ensures the builds are green again.