### PR TITLE
Add bit-pattern encoding support to EncodedIriManager

### DIFF
--- a/src/index/EncodedIriManager.h
+++ b/src/index/EncodedIriManager.h
@@ -6,7 +6,8 @@
 #define QLEVER_SRC_INDEX_ENCODEDVALUES_H
 
 #include <absl/numeric/bits.h>
-
+#include <absl/strings/str_cat.h>
+#include <limits>
 #include "backports/StartsWithAndEndsWith.h"
 #include "backports/algorithm.h"
 #include "backports/three_way_comparison.h"
@@ -16,15 +17,209 @@
 #include "util/Log.h"
 #include "util/json.h"
 
+namespace encodedIris {
+// Represents a constraint on a range of bits in the encoded value.
+// The bits in the range [bitStart, bitEnd) must all have the specified value
+// (0 or 1).
+struct BitRangeConstraint {
+  size_t bitStart;  // Start of the bit range (inclusive).
+  size_t bitEnd;    // End of the bit range (exclusive).
+  uint64_t value;   // The required value for these bits (stored as uint64_t,
+  // but should fit within the bit range).
+
+  // Constructor.
+  BitRangeConstraint(size_t start, size_t end, uint64_t val)
+      : bitStart(start), bitEnd(end), value(val) {
+    AD_CONTRACT_CHECK(bitStart < bitEnd);
+    AD_CONTRACT_CHECK(bitEnd <= 64);
+    size_t rangeSize = bitEnd - bitStart;
+    AD_CONTRACT_CHECK(value < (1ULL << rangeSize));
+  }
+
+  // Get the number of bits in this range.
+  size_t size() const { return bitEnd - bitStart; }
+
+  // Equality for testing.
+  bool operator==(const BitRangeConstraint& other) const {
+    return bitStart == other.bitStart && bitEnd == other.bitEnd &&
+           value == other.value;
+  }
+
+  // Hash support.
+  template <typename H>
+  friend H AbslHashValue(H h, const BitRangeConstraint& c) {
+    return H::combine(std::move(h), c.bitStart, c.bitEnd, c.value);
+  }
+};
+
+// Configuration for encoding an IRI prefix with bit range constraints.
+struct PrefixWithBitConstraints {
+  std::string prefix;  // The IRI prefix (without angle brackets).
+  std::vector<BitRangeConstraint> constraints;  // Bit constraints (optional).
+
+  // Constructor for plain prefix mode (no constraints).
+  explicit PrefixWithBitConstraints(std::string p) : prefix(std::move(p)) {}
+
+  // Constructor for multi-constraint mode.
+  PrefixWithBitConstraints(std::string p, std::vector<BitRangeConstraint> c)
+      : prefix(std::move(p)), constraints(std::move(c)) {}
+};
+}  // namespace encodedIris
+
 namespace detail {
 // CTRE named capture group identifiers for C++17 compatibility
 constexpr ctll::fixed_string digitsCaptureGroup = "digits";
+
+// Enum to identify special hard-coded encoding schemes
+enum class SpecialEncodingType {
+  None,          // Not a special encoding
+  RangePattern,  // BMW range_ pattern: range_<special-32-bit>_<8-bit>_<8-bit>P
+  ValRangePattern,  // BMW valRange_ pattern:
+                    // valRange_<special-32-bit>_<11-bit>_<11-bit>M
+  LaneRef,          // BMW laneRef pattern: laneRef_<special-64-bit>_<4-bit>
+  RoadRef,          // BMW roadRef pattern: roadRef_<special-64-bit>_<4-bit>
+  SpeedProfile,     // BMW speedprofile pattern:
+                    // speedprofile_<special-64-bit>_<4-bit>
+  StopLoc,          // BMW stopLoc pattern: stopLoc_<special-64-bit>_<4-bit>
+  StopLoc32         // BMW stopLoc pattern (32-bit variant):
+                    // stopLoc_<32-bit>_<18-bit>
+};
+
+// Configuration for a prefix encoding. Either plain (just a prefix and digits)
+// or with bit pattern constraints (prefix + numeric value where certain bits
+// must be zero), or with special hard-coded encoding schemes.
+struct PrefixConfig {
+  // The IRI prefix (with leading angle bracket, e.g., "<http://example.org/")
+  std::string prefix;
+
+  // For bit pattern mode: the range of bits that must be zero in the numeric
+  // value [bitStart, bitEnd) (half-open interval, bitEnd is exclusive).
+  // If not set, plain digit encoding is used.
+  // DEPRECATED: Use bitRangeConstraints instead for new code.
+  std::optional<std::pair<size_t, size_t>> zeroBitRange;
+
+  // For multi-bit pattern mode: a vector of bit range constraints.
+  // Each constraint specifies a range of bits and the required value.
+  // The constraints must not overlap and should be sorted by bitStart.
+  using BitRangeConstraint = encodedIris::BitRangeConstraint;
+  std::vector<BitRangeConstraint> bitRangeConstraints;
+
+  // Special encoding type for hard-coded patterns
+  SpecialEncodingType specialEncoding = SpecialEncodingType::None;
+
+  // Default constructor for plain prefix mode
+  explicit PrefixConfig(std::string p) : prefix(std::move(p)) {}
+
+  // Constructor for bit pattern mode. The bit range is [bitStart, bitEnd)
+  // where bitEnd is exclusive.
+  // DEPRECATED: Use the multi-constraint constructor instead.
+  PrefixConfig(std::string p, size_t bitStart, size_t bitEnd)
+      : prefix(std::move(p)), zeroBitRange(std::make_pair(bitStart, bitEnd)) {
+    AD_CONTRACT_CHECK(bitStart < bitEnd);
+    AD_CONTRACT_CHECK(bitEnd <= 64);
+  }
+
+  // Constructor for multi-bit pattern mode with constraints.
+  PrefixConfig(std::string p, std::vector<BitRangeConstraint> constraints)
+      : prefix(std::move(p)), bitRangeConstraints(std::move(constraints)) {
+    validateConstraints();
+  }
+
+  // Constructor for special hard-coded encodings
+  PrefixConfig(std::string p, SpecialEncodingType type)
+      : prefix(std::move(p)), specialEncoding(type) {}
+
+  // Check if this is a bit pattern encoding (either old or new style)
+  bool isBitPatternMode() const {
+    return zeroBitRange.has_value() || !bitRangeConstraints.empty();
+  }
+
+  // Check if this is a special hard-coded encoding
+  bool isSpecialEncoding() const {
+    return specialEncoding != SpecialEncodingType::None;
+  }
+
+  // Get the bit range (throws if not in bit pattern mode)
+  // DEPRECATED: Only works with old-style single zero bit range.
+  std::pair<size_t, size_t> getBitRange() const {
+    AD_CONTRACT_CHECK(zeroBitRange.has_value());
+    return zeroBitRange.value();
+  }
+
+  // Get the bit range constraints for multi-bit pattern mode.
+  const std::vector<BitRangeConstraint>& getBitRangeConstraints() const {
+    return bitRangeConstraints;
+  }
+
+  // Check if this uses the new multi-constraint mode.
+  bool isMultiConstraintMode() const { return !bitRangeConstraints.empty(); }
+
+  // Equality for testing
+  bool operator==(const PrefixConfig& other) const {
+    return prefix == other.prefix && zeroBitRange == other.zeroBitRange &&
+           specialEncoding == other.specialEncoding &&
+           bitRangeConstraints == other.bitRangeConstraints;
+  }
+
+  // Hash support.
+  template <typename H>
+  friend H AbslHashValue(H h, const PrefixConfig& c) {
+    return H::combine(std::move(h), c.prefix, c.zeroBitRange,
+                      static_cast<int>(c.specialEncoding),
+                      c.bitRangeConstraints);
+  }
+
+ private:
+  // Validate that constraints don't overlap and are sorted.
+  // Note: This does NOT check that the remaining bits fit in the encoding
+  // space - that check must be done by the EncodedIriManager with knowledge
+  // of NumBitsEncoding.
+  void validateConstraints() {
+    // Sort by bitStart.
+    ql::ranges::sort(bitRangeConstraints, [](const BitRangeConstraint& a,
+                                             const BitRangeConstraint& b) {
+      return a.bitStart < b.bitStart;
+    });
+
+    // Check for overlaps.
+    for (size_t i = 1; i < bitRangeConstraints.size(); ++i) {
+      AD_CONTRACT_CHECK(bitRangeConstraints[i - 1].bitEnd <=
+                        bitRangeConstraints[i].bitStart);
+    }
+  }
+
+ public:
+  // Calculate the total number of bits consumed by the constraints.
+  size_t getTotalConstrainedBits() const {
+    size_t total = 0;
+    for (const auto& constraint : bitRangeConstraints) {
+      total += constraint.size();
+    }
+    return total;
+  }
+};
 }  // namespace detail
 
 // This class allows the encoding of IRIs that start with a fixed prefix
 // followed by a sequence of decimal digits directly into an `Id`. For
 // example, <http://example.org/12345> with digit sequence `12345` and
-// prefix `http://example.org/`. This is implemented as follows:
+// prefix `http://example.org/`.
+//
+// Two encoding modes are supported:
+//
+// 1. PLAIN DIGIT MODE (original behavior):
+// The digits are encoded in a non-standard way which ensures the order of
+// encoded values corresponds to the lexical order of the original IRIs.
+// Each decimal digit is encoded as a 4-bit nibble, where digit `i` is
+// encoded as `i+1` and converted to a hexadecimal number. The nibbles are
+// stored left-aligned (not right-aligned) and filled on the right with zeroes.
+//
+// 2. BIT PATTERN MODE (new):
+// For IRIs with numeric values where certain bits are always zero, this mode
+// compresses the value by removing those zero bits. The prefix configuration
+// specifies a bit range [bitStart, bitEnd) (half-open interval) that must be
+// all zeros. The value is then stored with those bits removed, allowing more
+// efficient encoding.
 //
 // An `Id` has 64 bits, of which the `NumBitsTotal` rightmost bits are
 // used for the encoding. The `64 - NumBitsTotal` leftmost bits are ignored when
@@ -32,13 +227,6 @@ constexpr ctll::fixed_string digitsCaptureGroup = "digits";
 // encode the IRI prefix; that is, at most `2 ** NumBitsTags` different prefixes
 // can be used. The remaining `NumBitsTotal - NumBitsTags` bits are used to
 // encode the digits that follow the prefix.
-//
-// The digits are encoded in the following non-standard way, which makes sure
-// that the order of the encoded values corresponds to the lexical order of the
-// original IRIs. Each decimal digit is encoded as a 4-bit nibble, where digit
-// `i` is encoded as `i+1` and converted to a hexadecimal number. The nibbles
-// are stored left-aligned (not right-aliged) and filled on the right with
-// zeroes.
 //
 // For example, here are a few example encodings, with `NumBitsTotal = 40` and
 // `NumBitsTags = 8`. The prefix is `http://example.org/` and encoded in 8
@@ -60,6 +248,7 @@ template <size_t NumBitsTotal, size_t NumBitsTags>
 class EncodedIriManagerImpl {
  public:
   static constexpr size_t NumBitsEncoding = NumBitsTotal - NumBitsTags;
+  using BitRangeConstraint = encodedIris::BitRangeConstraint;
 
   // We use 4-bit nibbles per digit in the encoding.
   static constexpr size_t NibbleSize = 4;
@@ -71,19 +260,27 @@ class EncodedIriManagerImpl {
   static_assert(NumDigits > 0);
 
   // The prefixes of the IRIs that will be encoded.
-  std::vector<std::string> prefixes_;
+  std::vector<detail::PrefixConfig> prefixes_;
 
   static constexpr auto maxNumPrefixes_ = 1ULL << NumBitsTags;
 
-  // By default, `prefixes_` is empty, so no IRI will be encoded.
-  EncodedIriManagerImpl() = default;
+  // By default, `prefixes_` contains only the hard-coded BMW patterns.
+  EncodedIriManagerImpl() { initializeHardCodedPrefixes(); }
 
   // Construct from the list of prefixes. The prefixes have to be specified
   // without any brackes, so e.g. "http://example.org/" if IRIs of the form
   // `<http://example.org/1234>` should be encoded.
   explicit EncodedIriManagerImpl(
       std::vector<std::string> prefixesWithoutAngleBrackets) {
+    // Reserve space for hard-coded prefixes (6 special patterns)
+    static constexpr size_t numHardCodedPrefixes = 6;
+    static constexpr auto maxNumPrefixes = 1ULL << NumBitsTags;
+    static constexpr auto maxNumConfigurablePrefixes =
+        maxNumPrefixes - numHardCodedPrefixes;
+
     if (prefixesWithoutAngleBrackets.empty()) {
+      // Initialize only hard-coded prefixes
+      initializeHardCodedPrefixes();
       return;
     }
     // Sort the prefixes lexicographically to make the ordering deterministic
@@ -98,11 +295,12 @@ class EncodedIriManagerImpl {
         ::ranges::unique(prefixesWithoutAngleBrackets),
         prefixesWithoutAngleBrackets.end());
 
-    if (prefixesWithoutAngleBrackets.size() > maxNumPrefixes_) {
+    if (prefixesWithoutAngleBrackets.size() > maxNumConfigurablePrefixes) {
       throw std::runtime_error(absl::StrCat(
           "Number of prefixes specified with `--encode-as-id` is ",
           prefixesWithoutAngleBrackets.size(), ", which is too many; ",
-          "the maximum is ", maxNumPrefixes_));
+          "the maximum is ", maxNumConfigurablePrefixes, " (reduced from ",
+          maxNumPrefixes, " to reserve space for hard-coded BMW patterns)"));
     }
 
     // TODO<C++23> use `std::views::adjacent`.
@@ -116,7 +314,8 @@ class EncodedIriManagerImpl {
             a, "\" and \"", b, "\"."));
       }
     }
-    prefixes_.reserve(prefixesWithoutAngleBrackets.size());
+    prefixes_.reserve(prefixesWithoutAngleBrackets.size() +
+                      numHardCodedPrefixes);
     for (const auto& prefix : prefixesWithoutAngleBrackets) {
       if (ql::starts_with(prefix, '<')) {
         throw std::runtime_error(absl::StrCat(
@@ -124,8 +323,11 @@ class EncodedIriManagerImpl {
             "be enclosed in angle brackets; here is a violating prefix: \"",
             prefix, "\""));
       }
-      prefixes_.push_back(absl::StrCat("<", prefix));
+      prefixes_.emplace_back(absl::StrCat("<", prefix));
     }
+
+    // Add hard-coded prefixes at the end (using the highest prefix IDs)
+    initializeHardCodedPrefixes();
   }
 
   // Try to encode the given string as an `Id`. If the encoding fails, return
@@ -135,33 +337,61 @@ class EncodedIriManagerImpl {
   // 2. The string does not start with any of the `prefixes_`
   // 3. After the matching prefix, there are characters other than `[0-9]`
   // 4. There are more digits than fit into `NumBitsEncoding` (4 bits / digit)
+  static constexpr auto regex = ctll::fixed_string{"(?<digits>[0-9]+)>"};
   std::optional<Id> encode(std::string_view repr) const {
+    auto origRepr = repr;
     // Find the matching prefix.
-    auto it = ql::ranges::find_if(prefixes_, [&repr](std::string_view prefix) {
-      return ql::starts_with(repr, prefix);
-    });
+    auto it = ql::ranges::find_if(prefixes_,
+                                  [&repr](const detail::PrefixConfig& cfg) {
+                                    return ql::starts_with(repr, cfg.prefix);
+                                  });
     if (it == prefixes_.end()) {
       return std::nullopt;
     }
 
+    // Get the index of the used prefix.
+    auto prefixIndex = static_cast<size_t>(it - prefixes_.begin());
+
+    // Handle special hard-coded encodings
+    if (it->isSpecialEncoding()) {
+      repr.remove_prefix(it->prefix.size());
+      return encodeSpecialPattern(repr, prefixIndex, it->specialEncoding);
+    }
+
     // Check that after the prefix, the string contains only digits and the
     // trailing '>'.
-    repr.remove_prefix(it->size());
-    static constexpr auto regex = ctll::fixed_string{"(?<digits>[0-9]+)>"};
+    repr.remove_prefix(it->prefix.size());
     auto match = ctre::match<regex>(repr);
     if (!match) {
       return std::nullopt;
     }
 
-    // Extract the substring with the digits, and check that it is not too long.
+    // Extract the substring with the digits.
     const auto& numString =
         match.template get<detail::digitsCaptureGroup>().to_view();
+
+    // Handle multi-constraint bit pattern mode
+    if (it->isMultiConstraintMode()) {
+      auto opt = encodeMultiConstraintBitPattern(numString, prefixIndex,
+                                                 it->getBitRangeConstraints());
+      if (opt) {
+        // AD_LOG_INFO << "successfully encoded " << repr << std::endl;
+      } else {
+        std::cerr << "failed to encode " << origRepr << std::endl;
+      }
+      return opt;
+    }
+
+    // Handle old-style bit pattern mode
+    if (it->zeroBitRange.has_value()) {
+      return encodeBitPattern(numString, prefixIndex, it->getBitRange());
+    }
+
+    // Handle plain digit mode
     if (numString.size() > NumDigits) {
       return std::nullopt;
     }
 
-    // Get the index of the used prefix, and run the actual encoding.
-    auto prefixIndex = static_cast<size_t>(it - prefixes_.begin());
     return makeIdFromPrefixIdxAndPayload(prefixIndex,
                                          encodeDecimalToNBit(numString));
   }
@@ -179,12 +409,37 @@ class EncodedIriManagerImpl {
     AD_CORRECTNESS_CHECK(id.getDatatype() == Datatype::EncodedVal);
     // Get only the rightmost bits that represent the digits.
     auto [prefixIdx, digitEncoding] = splitIntoPrefixIdxAndPayload(id);
-    return toStringWithGivenPrefix(digitEncoding, prefixes_.at(prefixIdx));
+    std::string result;
+    const auto& prefixConfig = prefixes_.at(prefixIdx);
+    result.reserve(prefixConfig.prefix.size() + NumDigits + 1);
+    result = prefixConfig.prefix;
+
+    // Handle special hard-coded encodings
+    if (prefixConfig.isSpecialEncoding()) {
+      decodeSpecialPattern(result, digitEncoding, prefixConfig.specialEncoding);
+      result.push_back('>');
+      return result;
+    }
+
+    // Handle multi-constraint bit pattern mode
+    if (prefixConfig.isMultiConstraintMode()) {
+      decodeMultiConstraintBitPattern(result, digitEncoding,
+                                      prefixConfig.getBitRangeConstraints());
+    } else if (prefixConfig.zeroBitRange.has_value()) {
+      // Handle old-style bit pattern mode
+      decodeBitPattern(result, digitEncoding, prefixConfig.getBitRange());
+    } else {
+      // Handle plain digit mode
+      decodeDecimalFrom64Bit(result, digitEncoding);
+    }
+    result.push_back('>');
+    return result;
   }
 
   // The second half of `toString` above: combine the integer encoding of the
   // payload and the prefix string into a result string that represents an IRI.
   // Note: This function expects, that the prefix starts with `<`.
+  // Note: This only works for plain digit mode prefixes.
   static std::string toStringWithGivenPrefix(uint64_t digitEncoding,
                                              std::string_view prefix) {
     AD_EXPENSIVE_CHECK(ql::starts_with(prefix, '<'));
@@ -211,17 +466,123 @@ class EncodedIriManagerImpl {
     return std::make_pair(prefixIdx, digitEncoding);
   }
 
+  // Extract the numeric value from an encoded IRI as a uint64_t.
+  // Returns the original number that was encoded (after decompression).
+  // Throws if the Id is not an EncodedVal or if it's a special encoding.
+  uint64_t getNumberFromEncodedIri(Id id) const {
+    AD_CORRECTNESS_CHECK(id.getDatatype() == Datatype::EncodedVal);
+    auto [prefixIdx, digitEncoding] = splitIntoPrefixIdxAndPayload(id);
+    const auto& prefixConfig = prefixes_.at(prefixIdx);
+
+    // Special encodings are not supported for simple number extraction.
+    AD_CORRECTNESS_CHECK(!prefixConfig.isSpecialEncoding(),
+                         "Cannot extract simple number from special encoding");
+
+    // Handle multi-constraint bit pattern mode.
+    if (prefixConfig.isMultiConstraintMode()) {
+      auto res = decompressMultiConstraintValue(
+          digitEncoding, prefixConfig.getBitRangeConstraints());
+      AD_CORRECTNESS_CHECK(digitEncoding ==
+                           compressMultiConstraintValue(
+                               res, prefixConfig.getBitRangeConstraints()));
+      return res;
+    }
+
+    // Handle old-style bit pattern mode.
+    if (prefixConfig.zeroBitRange.has_value()) {
+      auto [bitStart, bitEnd] = prefixConfig.getBitRange();
+      // Reconstruct the original value by reinserting the zero bits.
+      uint64_t lowerBits =
+          digitEncoding & ad_utility::bitMaskForLowerBits(bitStart);
+      uint64_t upperBits = digitEncoding >> bitStart;
+      return (upperBits << bitEnd) | lowerBits;
+    }
+
+    // Handle plain digit mode - need to decode the nibble encoding.
+    return decodeDecimalToUint64(digitEncoding);
+  }
+
   // Conversion to and from JSON.
   static constexpr const char* jsonKey_ =
       "prefixes-with-leading-angle-brackets";
+  static constexpr const char* jsonKeyExtended_ = "prefix-configs";
+
   friend void to_json(nlohmann::json& j,
                       const EncodedIriManagerImpl& encodedIriManager) {
-    j[jsonKey_] = encodedIriManager.prefixes_;
+    // Use new format that supports plain, bit pattern, multi-constraint, and
+    // special modes
+    nlohmann::json configs = nlohmann::json::array();
+    for (const auto& cfg : encodedIriManager.prefixes_) {
+      nlohmann::json item;
+      item["prefix"] = cfg.prefix;
+      if (cfg.isMultiConstraintMode()) {
+        // Multi-constraint mode (new format).
+        nlohmann::json constraints = nlohmann::json::array();
+        for (const auto& constraint : cfg.getBitRangeConstraints()) {
+          nlohmann::json c;
+          c["bitStart"] = constraint.bitStart;
+          c["bitEnd"] = constraint.bitEnd;
+          c["value"] = constraint.value;
+          constraints.push_back(c);
+        }
+        item["bitRangeConstraints"] = constraints;
+      } else if (cfg.zeroBitRange.has_value()) {
+        // Old-style single zero bit range (for backward compatibility).
+        auto [bitStart, bitEnd] = cfg.getBitRange();
+        item["zeroBitStart"] = bitStart;
+        item["zeroBitEnd"] = bitEnd;
+      } else if (cfg.isSpecialEncoding()) {
+        item["specialEncoding"] = static_cast<int>(cfg.specialEncoding);
+      }
+      configs.push_back(item);
+    }
+    j[jsonKeyExtended_] = configs;
   }
+
   friend void from_json(const nlohmann::json& j,
                         EncodedIriManagerImpl& encodedIriManager) {
-    encodedIriManager.prefixes_ =
-        static_cast<std::vector<std::string>>(j[jsonKey_]);
+    encodedIriManager.prefixes_.clear();
+
+    // Try new format first
+    if (j.contains(jsonKeyExtended_)) {
+      const auto& configs = j[jsonKeyExtended_];
+      for (const auto& item : configs) {
+        std::string prefix = static_cast<std::string>(item["prefix"]);
+        if (item.contains("bitRangeConstraints")) {
+          // Multi-constraint mode (new format).
+          std::vector<encodedIris::BitRangeConstraint> constraints;
+          for (const auto& c : item["bitRangeConstraints"]) {
+            size_t bitStart = static_cast<size_t>(c["bitStart"]);
+            size_t bitEnd = static_cast<size_t>(c["bitEnd"]);
+            uint64_t value = static_cast<uint64_t>(c["value"]);
+            constraints.emplace_back(bitStart, bitEnd, value);
+          }
+          encodedIriManager.prefixes_.emplace_back(std::move(prefix),
+                                                   std::move(constraints));
+        } else if (item.contains("zeroBitStart") &&
+                   item.contains("zeroBitEnd")) {
+          // Old-style single zero bit range.
+          size_t bitStart = static_cast<size_t>(item["zeroBitStart"]);
+          size_t bitEnd = static_cast<size_t>(item["zeroBitEnd"]);
+          encodedIriManager.prefixes_.emplace_back(std::move(prefix), bitStart,
+                                                   bitEnd);
+        } else if (item.contains("specialEncoding")) {
+          int encodingType = static_cast<int>(item["specialEncoding"]);
+          encodedIriManager.prefixes_.emplace_back(
+              std::move(prefix),
+              static_cast<detail::SpecialEncodingType>(encodingType));
+        } else {
+          encodedIriManager.prefixes_.emplace_back(std::move(prefix));
+        }
+      }
+    } else if (j.contains(jsonKey_)) {
+      // Fall back to old format for backward compatibility
+      std::vector<std::string> oldPrefixes =
+          j[jsonKey_].get<std::vector<std::string>>();
+      for (auto& prefix : oldPrefixes) {
+        encodedIriManager.prefixes_.emplace_back(std::move(prefix));
+      }
+    }
   }
 
   // Hash support for use in `TestIndexConfig`.
@@ -232,6 +593,188 @@ class EncodedIriManagerImpl {
 
   // Equality operator for use in `TestIndexConfig`.
   QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(EncodedIriManagerImpl, prefixes_)
+
+  // Encode a number with bit pattern constraints. The numString must parse to
+  // a valid uint64_t, and the bits in the range [bitStart, bitEnd) must all be
+  // zero. Returns nullopt if constraints are not met or if the number is too
+  // large to fit after removing the zero bits.
+  std::optional<Id> encodeBitPattern(std::string_view numString,
+                                     size_t prefixIndex,
+                                     std::pair<size_t, size_t> bitRange) const {
+    auto [bitStart, bitEnd] = bitRange;
+
+    // Parse the numeric string to uint64_t
+    uint64_t value = 0;
+    for (char c : numString) {
+      // Check for overflow
+      if (value > (std::numeric_limits<uint64_t>::max() - (c - '0')) / 10) {
+        return std::nullopt;
+      }
+      value = value * 10 + (c - '0');
+    }
+
+    // Check that all bits in the range [bitStart, bitEnd) are zero
+    for (size_t bit = bitStart; bit < bitEnd; ++bit) {
+      if ((value >> bit) & 1) {
+        return std::nullopt;
+      }
+    }
+
+    // Remove the zero bits from the value
+    uint64_t lowerBits = value & ad_utility::bitMaskForLowerBits(bitStart);
+    uint64_t upperBits = value >> bitEnd;
+    uint64_t compressedValue = (upperBits << bitStart) | lowerBits;
+
+    // Check if the compressed value fits in the available encoding bits
+    // We need to store the compressed value, so it must fit in NumBitsEncoding
+    if (compressedValue >= (1ULL << NumBitsEncoding)) {
+      return std::nullopt;
+    }
+
+    return Id::makeFromEncodedVal(compressedValue |
+                                  (prefixIndex << NumBitsEncoding));
+  }
+
+  // Decode a bit pattern encoded value back to the original uint64_t and
+  // append it to the result string. The bit range [bitStart, bitEnd) specifies
+  // which bits were removed during encoding.
+  static void decodeBitPattern(std::string& result, uint64_t encoded,
+                               std::pair<size_t, size_t> bitRange) {
+    auto [bitStart, bitEnd] = bitRange;
+
+    // Reconstruct the original value by reinserting the zero bits
+    uint64_t lowerBits = encoded & ad_utility::bitMaskForLowerBits(bitStart);
+    uint64_t upperBits = encoded >> bitStart;
+    uint64_t originalValue = (upperBits << bitEnd) | lowerBits;
+
+    // Convert to decimal string
+    result.append(std::to_string(originalValue));
+  }
+
+  // Encode a number with multiple bit range constraints. The numString must
+  // parse to a valid uint64_t, and the bits in each constrained range must
+  // match the specified values. Returns nullopt if constraints are not met or
+  // if the number is too large to fit after removing the constrained bits.
+  std::optional<Id> encodeMultiConstraintBitPattern(
+      std::string_view numString, size_t prefixIndex,
+      const std::vector<BitRangeConstraint>& constraints) const {
+    // Validate that the constraints can fit in the encoding space.
+    // After removing the constrained bits, we need 64 - total_constrained_bits
+    // to fit in NumBitsEncoding.
+    size_t totalConstrainedBits = 0;
+    for (const auto& constraint : constraints) {
+      totalConstrainedBits += constraint.size();
+    }
+
+    // The remaining bits after compression must fit in NumBitsEncoding.
+    size_t remainingBits = 64 - totalConstrainedBits;
+    AD_CONTRACT_CHECK(
+        remainingBits <= NumBitsEncoding,
+        absl::StrCat("Bit range constraints require ", remainingBits,
+                     " bits to encode, but only ", NumBitsEncoding,
+                     " bits are available. Total constrained bits: ",
+                     totalConstrainedBits));
+
+    // Parse the numeric string to uint64_t.
+    auto valueOpt = parseDecimal(numString);
+    if (!valueOpt) {
+      return std::nullopt;
+    }
+    uint64_t value = *valueOpt;
+
+    // Check that all constraints are satisfied.
+    for (const auto& constraint : constraints) {
+      // Extract the bits in this range.
+      uint64_t mask = ad_utility::bitMaskForLowerBits(constraint.size());
+      uint64_t extractedBits = (value >> constraint.bitStart) & mask;
+      if (extractedBits != constraint.value) {
+        return std::nullopt;
+      }
+    }
+
+    // Compress the value by removing the constrained bits.
+    uint64_t compressedValue = compressMultiConstraintValue(value, constraints);
+
+    // Check if the compressed value fits in the available encoding bits.
+    if (compressedValue >= (1ULL << NumBitsEncoding)) {
+      return std::nullopt;
+    }
+
+    return Id::makeFromEncodedVal(compressedValue |
+                                  (prefixIndex << NumBitsEncoding));
+  }
+
+  // Compress a value by removing bits specified in the constraints.
+  // The constraints must be sorted by bitStart and non-overlapping.
+  static uint64_t compressMultiConstraintValue(
+      uint64_t value, const std::vector<BitRangeConstraint>& constraints) {
+    uint64_t result = 0;
+    size_t outputBitPos = 0;
+    size_t inputBitPos = 0;
+
+    for (const auto& constraint : constraints) {
+      // Copy bits from inputBitPos to constraint.bitStart.
+      size_t numBitsToCopy = constraint.bitStart - inputBitPos;
+      if (numBitsToCopy > 0) {
+        uint64_t mask = ad_utility::bitMaskForLowerBits(numBitsToCopy);
+        uint64_t bits = (value >> inputBitPos) & mask;
+        result |= bits << outputBitPos;
+        outputBitPos += numBitsToCopy;
+      }
+      // Skip the constrained bits.
+      inputBitPos = constraint.bitEnd;
+    }
+
+    // Copy any remaining bits after the last constraint.
+    if (inputBitPos < 64) {
+      uint64_t remainingBits = value >> inputBitPos;
+      result |= remainingBits << outputBitPos;
+    }
+
+    AD_CORRECTNESS_CHECK(decompressMultiConstraintValue(result, constraints) ==
+                         value);
+    return result;
+  }
+
+  // Decompress a value by reinserting bits specified in the constraints.
+  // The constraints must be sorted by bitStart and non-overlapping.
+  static uint64_t decompressMultiConstraintValue(
+      uint64_t compressed, const std::vector<BitRangeConstraint>& constraints) {
+    uint64_t result = 0;
+    size_t inputBitPos = 0;
+    size_t outputBitPos = 0;
+
+    for (const auto& constraint : constraints) {
+      // Copy bits to outputBitPos from inputBitPos.
+      size_t numBitsToCopy = constraint.bitStart - outputBitPos;
+      if (numBitsToCopy > 0) {
+        uint64_t mask = ad_utility::bitMaskForLowerBits(numBitsToCopy);
+        uint64_t bits = (compressed >> inputBitPos) & mask;
+        result |= bits << outputBitPos;
+        inputBitPos += numBitsToCopy;
+      }
+      // Insert the constrained value.
+      result |= constraint.value << constraint.bitStart;
+      outputBitPos = constraint.bitEnd;
+    }
+
+    // Copy any remaining bits after the last constraint.
+    if (inputBitPos < 64) {
+      uint64_t remainingBits = compressed >> inputBitPos;
+      result |= remainingBits << outputBitPos;
+    }
+
+    return result;
+  }
+
+  // Decode a multi-constraint bit pattern encoded value and append to result.
+  static void decodeMultiConstraintBitPattern(
+      std::string& result, uint64_t encoded,
+      const std::vector<BitRangeConstraint>& constraints) {
+    uint64_t originalValue =
+        decompressMultiConstraintValue(encoded, constraints);
+    result.append(std::to_string(originalValue));
+  }
 
   // Encode the `numberStr` (which may only consist of digits) into a 64-bit
   // number.
@@ -265,6 +808,472 @@ class EncodedIriManagerImpl {
       result.push_back(static_cast<char>(((encoded >> shift) & 0xF) + '0' - 1));
       shift -= NibbleSize;
     }
+  }
+
+  // Decode a nibble-encoded value to uint64_t.
+  // This is the inverse of `encodeDecimalToNBit` but returns a number.
+  static uint64_t decodeDecimalToUint64(uint64_t encoded) {
+    std::string temp;
+    decodeDecimalFrom64Bit(temp, encoded);
+    // Parse the string back to uint64_t.
+    uint64_t result = 0;
+    for (char c : temp) {
+      result = result * 10 + (c - '0');
+    }
+    return result;
+  }
+
+  // Initialize the hard-coded BMW-specific encoding patterns
+  void initializeHardCodedPrefixes() {
+    // Range pattern: range_<special-32-bit>_<8-bit>_<8-bit>P
+    // First number has upper 3 bits as "001"
+    prefixes_.emplace_back(
+        "<http://www.bmw-carit.de/Foresight/Map/Ontologies/Low/"
+        "behaviorMap#range_",
+        detail::SpecialEncodingType::RangePattern);
+
+    // ValRange pattern: valRange_<special-32-bit>_<11-bit>_<11-bit>M
+    // First number has upper 3 bits as "001"
+    prefixes_.emplace_back(
+        "<http://www.bmw-carit.de/Foresight/Map/Ontologies/Low/"
+        "behaviorMap#valRange_",
+        detail::SpecialEncodingType::ValRangePattern);
+
+    // LaneRef pattern: laneRef_<special-64-bit>_<4-bit>
+    prefixes_.emplace_back(
+        "<http://www.bmw-carit.de/Foresight/Map/Ontologies/Low/"
+        "behaviorMap#laneRef_",
+        detail::SpecialEncodingType::LaneRef);
+
+    // RoadRef pattern: roadRef_<special-64-bit>_<4-bit>
+    prefixes_.emplace_back(
+        "<http://www.bmw-carit.de/Foresight/Map/Ontologies/Low/"
+        "behaviorMap#roadRef_",
+        detail::SpecialEncodingType::RoadRef);
+
+    // SpeedProfile pattern: speedprofile_<special-64-bit>_<4-bit>
+    prefixes_.emplace_back(
+        "<http://www.bmw-carit.de/Foresight/Map/Ontologies/Low/"
+        "behaviorMap#speedprofile_",
+        detail::SpecialEncodingType::SpeedProfile);
+
+    // StopLoc pattern (32-bit variant): stopLoc_<32-bit>_<18-bit>
+    prefixes_.emplace_back(
+        "<http://www.bmw-carit.de/Foresight/Map/Ontologies/Low/"
+        "behaviorMap#stopLoc_",
+        detail::SpecialEncodingType::StopLoc32);
+  }
+
+  // Parse a decimal number string to uint64_t. Returns nullopt on overflow.
+  static std::optional<uint64_t> parseDecimal(std::string_view numString) {
+    uint64_t value = 0;
+    for (char c : numString) {
+      // Check for overflow
+      if (value > (std::numeric_limits<uint64_t>::max() - (c - '0')) / 10) {
+        return std::nullopt;
+      }
+      value = value * 10 + (c - '0');
+    }
+    return value;
+  }
+
+  // Encode special BMW patterns
+  std::optional<Id> encodeSpecialPattern(
+      std::string_view suffix, size_t prefixIndex,
+      detail::SpecialEncodingType encodingType) const {
+    switch (encodingType) {
+      case detail::SpecialEncodingType::RangePattern:
+        return encodeRangePattern(suffix, prefixIndex);
+      case detail::SpecialEncodingType::ValRangePattern:
+        return encodeValRangePattern(suffix, prefixIndex);
+      case detail::SpecialEncodingType::LaneRef:
+      case detail::SpecialEncodingType::RoadRef:
+      case detail::SpecialEncodingType::SpeedProfile:
+        return encodeRefPattern(suffix, prefixIndex);
+      case detail::SpecialEncodingType::StopLoc:
+      case detail::SpecialEncodingType::StopLoc32:
+        return encodeStopLocPattern(suffix, prefixIndex);
+      default:
+        return std::nullopt;
+    }
+  }
+
+  // Decode special BMW patterns
+  static void decodeSpecialPattern(std::string& result, uint64_t encoded,
+                                   detail::SpecialEncodingType encodingType) {
+    switch (encodingType) {
+      case detail::SpecialEncodingType::RangePattern:
+        decodeRangePattern(result, encoded);
+        break;
+      case detail::SpecialEncodingType::ValRangePattern:
+        decodeValRangePattern(result, encoded);
+        break;
+      case detail::SpecialEncodingType::LaneRef:
+      case detail::SpecialEncodingType::RoadRef:
+      case detail::SpecialEncodingType::SpeedProfile:
+        decodeRefPattern(result, encoded);
+        break;
+      case detail::SpecialEncodingType::StopLoc:
+      case detail::SpecialEncodingType::StopLoc32:
+        decodeStopLocPattern(result, encoded);
+        break;
+      default:
+        break;
+    }
+  }
+
+  // Encode range_ pattern: range_<special-32-bit>_<8-bit>_<8-bit>P>
+  // First number has upper 3 bits as "001" (bit 31=0, bit 30=0, bit 29=1)
+  // After removing bit 29, we get 29 bits + 8 + 8 = 45 bits, but we store as
+  // 29 + 10 + 11 = 50 bits to align with encoding
+  std::optional<Id> encodeRangePattern(std::string_view suffix,
+                                       size_t prefixIndex) const {
+    // Pattern: <num1>_<num2>_<num3>P>
+    static constexpr auto regex =
+        ctll::fixed_string{"([0-9]+)_([0-9]+)_([0-9]+)P>"};
+    auto match = ctre::match<regex>(suffix);
+    if (!match) {
+      return std::nullopt;
+    }
+
+    auto num1Str = match.template get<1>().to_view();
+    auto num2Str = match.template get<2>().to_view();
+    auto num3Str = match.template get<3>().to_view();
+
+    auto num1 = parseDecimal(num1Str);
+    auto num2 = parseDecimal(num2Str);
+    auto num3 = parseDecimal(num3Str);
+
+    if (!num1 || !num2 || !num3) {
+      return std::nullopt;
+    }
+
+    // Check constraints on num1:
+    // - Must fit in 32 bits
+    if (*num1 >= (1ULL << 32)) {
+      return std::nullopt;
+    }
+    // - Bits 31 and 30 must be 0 (upper 3 bits are "001")
+    if ((*num1 >> 30) != 0) {
+      return std::nullopt;
+    }
+    // - Bit 29 must be 1
+    if (((*num1 >> 29) & 1) != 1) {
+      return std::nullopt;
+    }
+
+    // Check constraints: num2 and num3 fit in 8 bits
+    if (*num2 >= (1ULL << 8) || *num3 >= (1ULL << 8)) {
+      return std::nullopt;
+    }
+
+    // Remove bit 29 from num1 (we know it's 1)
+    // Extract lower 29 bits
+    uint32_t num1Compressed = *num1 & ad_utility::bitMaskForLowerBits(29);
+
+    // Pack into 50 bits: [num1Compressed:29][num2:10][num3:11]
+    // We extend num2 and num3 to 10 and 11 bits respectively for alignment
+    uint64_t encoded = (static_cast<uint64_t>(num1Compressed) << 21) |
+                       (static_cast<uint64_t>(*num2) << 11) | *num3;
+
+    // Check that encoded value fits in NumBitsEncoding
+    if (encoded >= (1ULL << NumBitsEncoding)) {
+      return std::nullopt;
+    }
+
+    return Id::makeFromEncodedVal(encoded | (prefixIndex << NumBitsEncoding));
+  }
+
+  // Decode range_ pattern
+  static void decodeRangePattern(std::string& result, uint64_t encoded) {
+    // Extract num3 (lowest 11 bits)
+    uint16_t num3 = encoded & ad_utility::bitMaskForLowerBits(11);
+    // Extract num2 (next 10 bits)
+    uint16_t num2 = (encoded >> 11) & ad_utility::bitMaskForLowerBits(10);
+    // Extract num1Compressed (next 29 bits)
+    uint32_t num1Compressed =
+        (encoded >> 21) & ad_utility::bitMaskForLowerBits(29);
+
+    // Reconstruct num1 by setting bit 29
+    uint32_t num1 = (1U << 29) | num1Compressed;
+
+    result.append(std::to_string(num1));
+    result.push_back('_');
+    result.append(std::to_string(num2));
+    result.push_back('_');
+    result.append(std::to_string(num3));
+    result.push_back('P');
+  }
+
+  // Encode valRange_ pattern: valRange_<special-32-bit>_<11-bit>_<11-bit>M>
+  // First number has upper 3 bits as "001" (bit 31=0, bit 30=0, bit 29=1)
+  // After removing bit 29, we get 29 bits + 11 + 11 = 51 bits
+  std::optional<Id> encodeValRangePattern(std::string_view suffix,
+                                          size_t prefixIndex) const {
+    // Pattern: <num1>_<num2>_<num3>M>
+    static constexpr auto regex =
+        ctll::fixed_string{"([0-9]+)_([0-9]+)_([0-9]+)M>"};
+    auto match = ctre::match<regex>(suffix);
+    if (!match) {
+      return std::nullopt;
+    }
+
+    auto num1Str = match.template get<1>().to_view();
+    auto num2Str = match.template get<2>().to_view();
+    auto num3Str = match.template get<3>().to_view();
+
+    auto num1 = parseDecimal(num1Str);
+    auto num2 = parseDecimal(num2Str);
+    auto num3 = parseDecimal(num3Str);
+
+    if (!num1 || !num2 || !num3) {
+      return std::nullopt;
+    }
+
+    // Check constraints on num1:
+    // - Must fit in 32 bits
+    if (*num1 >= (1ULL << 32)) {
+      return std::nullopt;
+    }
+    // - Bits 31 and 30 must be 0 (upper 3 bits are "001")
+    if ((*num1 >> 30) != 0) {
+      return std::nullopt;
+    }
+    // - Bit 29 must be 1
+    if (((*num1 >> 29) & 1) != 1) {
+      return std::nullopt;
+    }
+
+    // Check constraints: num2 and num3 fit in 11 bits
+    if (*num2 >= (1ULL << 11) || *num3 >= (1ULL << 11)) {
+      return std::nullopt;
+    }
+
+    // Remove bit 29 from num1 (we know it's 1)
+    // Extract lower 29 bits
+    uint32_t num1Compressed = *num1 & ad_utility::bitMaskForLowerBits(29);
+
+    // Pack into 51 bits: [num1Compressed:29][num2:11][num3:11]
+    uint64_t encoded = (static_cast<uint64_t>(num1Compressed) << 22) |
+                       (static_cast<uint64_t>(*num2) << 11) | *num3;
+
+    // Check that encoded value fits in NumBitsEncoding
+    if (encoded >= (1ULL << NumBitsEncoding)) {
+      return std::nullopt;
+    }
+
+    return Id::makeFromEncodedVal(encoded | (prefixIndex << NumBitsEncoding));
+  }
+
+  // Decode valRange_ pattern
+  static void decodeValRangePattern(std::string& result, uint64_t encoded) {
+    // Extract num3 (lowest 11 bits)
+    uint16_t num3 = encoded & ad_utility::bitMaskForLowerBits(11);
+    // Extract num2 (next 11 bits)
+    uint16_t num2 = (encoded >> 11) & ad_utility::bitMaskForLowerBits(11);
+    // Extract num1Compressed (next 29 bits)
+    uint32_t num1Compressed =
+        (encoded >> 22) & ad_utility::bitMaskForLowerBits(29);
+
+    // Reconstruct num1 by setting bit 29
+    uint32_t num1 = (1U << 29) | num1Compressed;
+
+    result.append(std::to_string(num1));
+    result.push_back('_');
+    result.append(std::to_string(num2));
+    result.push_back('_');
+    result.append(std::to_string(num3));
+    result.push_back('M');
+  }
+
+  // Encode stopLoc pattern - handles both 64-bit and 32-bit variants
+  // Variant 1 (64-bit): stopLoc_<special-64-bit>_<4-bit>
+  //   - First number: highest 3 bits "001", bits [17,32) all zero
+  //   - Second number: < 16
+  //   - Encoded with flag bit 51 = 0
+  // Variant 2 (32-bit): stopLoc_<32-bit>_<18-bit>
+  //   - First number: any 32-bit value
+  //   - Second number: < 2^18
+  //   - Encoded with flag bit 51 = 1
+  std::optional<Id> encodeStopLocPattern(std::string_view suffix,
+                                         size_t prefixIndex) const {
+    // Pattern: <num1>_<num2>
+    static constexpr auto regex = ctll::fixed_string{"([0-9]+)_([0-9]+)>"};
+    auto match = ctre::match<regex>(suffix);
+    if (!match) {
+      return std::nullopt;
+    }
+
+    auto num1Str = match.template get<1>().to_view();
+    auto num2Str = match.template get<2>().to_view();
+
+    auto num1 = parseDecimal(num1Str);
+    auto num2 = parseDecimal(num2Str);
+
+    if (!num1 || !num2) {
+      return std::nullopt;
+    }
+
+    // Try 64-bit variant first (more restrictive)
+    if (*num2 < 16) {
+      // Check 64-bit constraints
+      if ((*num1 >> 62) == 0 && ((*num1 >> 61) & 1) == 1) {
+        // Check bits [17, 32) are all zero
+        bool bitsZero = true;
+        for (size_t bit = 17; bit < 32; ++bit) {
+          if ((*num1 >> bit) & 1) {
+            bitsZero = false;
+            break;
+          }
+        }
+
+        if (bitsZero) {
+          // Encode as 64-bit variant
+          // Extract bits [0, 17) and [32, 61)
+          uint64_t lowerBits = *num1 & ad_utility::bitMaskForLowerBits(17);
+          uint64_t middleBits =
+              (*num1 >> 32) & ad_utility::bitMaskForLowerBits(29);
+          // Pack: [0:flag][middleBits:29][lowerBits:17][num2:4] = 51 bits
+          uint64_t encoded = (middleBits << 21) | (lowerBits << 4) | *num2;
+
+          if (encoded < (1ULL << NumBitsEncoding)) {
+            return Id::makeFromEncodedVal(encoded |
+                                          (prefixIndex << NumBitsEncoding));
+          }
+        }
+      }
+    }
+
+    // Try 32-bit variant
+    if (*num1 < (1ULL << 32) && *num2 < (1ULL << 18)) {
+      // Pack: [1:flag][num1:32][num2:18] = 51 bits
+      uint64_t encoded = (1ULL << 50) | (*num1 << 18) | *num2;
+
+      if (encoded < (1ULL << NumBitsEncoding)) {
+        return Id::makeFromEncodedVal(encoded |
+                                      (prefixIndex << NumBitsEncoding));
+      }
+    }
+
+    return std::nullopt;
+  }
+
+  // Decode stopLoc pattern - handles both variants
+  static void decodeStopLocPattern(std::string& result, uint64_t encoded) {
+    // Check flag bit (bit 50)
+    bool is32BitVariant = (encoded >> 50) & 1;
+
+    if (is32BitVariant) {
+      // 32-bit variant: [1:flag][num1:32][num2:18]
+      uint32_t num2 = encoded & ad_utility::bitMaskForLowerBits(18);
+      uint32_t num1 = (encoded >> 18) & ad_utility::bitMaskForLowerBits(32);
+
+      result.append(std::to_string(num1));
+      result.push_back('_');
+      result.append(std::to_string(num2));
+    } else {
+      // 64-bit variant: [0:flag][middleBits:29][lowerBits:17][num2:4]
+      uint8_t num2 = encoded & 0xF;
+      uint64_t lowerBits = (encoded >> 4) & ad_utility::bitMaskForLowerBits(17);
+      uint64_t middleBits =
+          (encoded >> 21) & ad_utility::bitMaskForLowerBits(29);
+
+      // Reconstruct num1: [0][0][1][middleBits:29][zeros:15][lowerBits:17]
+      uint64_t num1 = (1ULL << 61) | (middleBits << 32) | lowerBits;
+
+      result.append(std::to_string(num1));
+      result.push_back('_');
+      result.append(std::to_string(num2));
+    }
+  }
+
+  // Encode laneRef/roadRef/speedprofile pattern:
+  // <type>_<special-64-bit>_<4-bit>
+  // The 64-bit number must have:
+  // - Highest 3 bits are "001" (so bit 63=0, bit 62=0, bit 61=1)
+  // - Bits [17, 32) are all 0
+  // - The second number (4-bit) is < 16
+  //
+  // After removing the constraints:
+  // - Remove bit 61 (we know it's 1)
+  // - Remove bits [17, 32) (15 bits, we know they're 0)
+  // Total removed: 16 bits
+  // Remaining: 64 - 16 = 48 bits from first number + 4 bits from second = 52
+  // bits
+  std::optional<Id> encodeRefPattern(std::string_view suffix,
+                                     size_t prefixIndex) const {
+    // Pattern: <num1>_<num2>
+    static constexpr auto regex = ctll::fixed_string{"([0-9]+)_([0-9]+)>"};
+    auto match = ctre::match<regex>(suffix);
+    if (!match) {
+      return std::nullopt;
+    }
+
+    auto num1Str = match.template get<1>().to_view();
+    auto num2Str = match.template get<2>().to_view();
+
+    auto num1 = parseDecimal(num1Str);
+    auto num2 = parseDecimal(num2Str);
+
+    if (!num1 || !num2) {
+      return std::nullopt;
+    }
+
+    // Check that num2 fits in 4 bits (< 16)
+    if (*num2 >= 16) {
+      return std::nullopt;
+    }
+
+    // Check constraints on num1:
+    // - Bits 63 and 62 must be 0 (highest 3 bits are "001")
+    if ((*num1 >> 62) != 0) {
+      return std::nullopt;
+    }
+    // - Bit 61 must be 1
+    if (((*num1 >> 61) & 1) != 1) {
+      return std::nullopt;
+    }
+    // - Bits [17, 32) must all be 0
+    for (size_t bit = 17; bit < 32; ++bit) {
+      if ((*num1 >> bit) & 1) {
+        return std::nullopt;
+      }
+    }
+
+    // Remove the constrained bits:
+    // Extract bits [0, 17) (lower 17 bits)
+    uint64_t lowerBits = *num1 & ad_utility::bitMaskForLowerBits(17);
+    // Extract bits [32, 61) (29 bits)
+    uint64_t middleBits = (*num1 >> 32) & ad_utility::bitMaskForLowerBits(29);
+    // Combine: [middleBits:29][lowerBits:17][num2:4] = 50 bits total
+    uint64_t compressed = (middleBits << 21) | (lowerBits << 4) | *num2;
+
+    // Check that compressed value fits in NumBitsEncoding
+    if (compressed >= (1ULL << NumBitsEncoding)) {
+      return std::nullopt;
+    }
+
+    return Id::makeFromEncodedVal(compressed |
+                                  (prefixIndex << NumBitsEncoding));
+  }
+
+  // Decode laneRef/roadRef/speedprofile/stopLoc pattern
+  static void decodeRefPattern(std::string& result, uint64_t encoded) {
+    // Extract num2 (lowest 4 bits)
+    uint8_t num2 = encoded & 0xF;
+    // Extract lowerBits (next 17 bits)
+    uint64_t lowerBits = (encoded >> 4) & ad_utility::bitMaskForLowerBits(17);
+    // Extract middleBits (next 29 bits)
+    uint64_t middleBits = (encoded >> 21) & ad_utility::bitMaskForLowerBits(29);
+
+    // Reconstruct num1:
+    // [0][0][1][middleBits:29][zeros:15][lowerBits:17]
+    uint64_t num1 = (1ULL << 61) |  // Set bit 61
+                    (middleBits << 32) | lowerBits;
+
+    result.append(std::to_string(num1));
+    result.push_back('_');
+    result.append(std::to_string(num2));
   }
 };
 

--- a/src/index/IndexBuilderMain.cpp
+++ b/src/index/IndexBuilderMain.cpp
@@ -191,6 +191,7 @@ int main(int argc, char** argv) {
   std::vector<string> defaultGraphs;
   std::vector<bool> parseParallel;
   std::string materializedViewsJson;
+  std::vector<std::string> encodeAsIdPrefixes;
 
   boost::program_options::options_description boostOptions(
       "Options for qlever-index");
@@ -266,7 +267,7 @@ int main(int argc, char** argv) {
   add("vocabulary-type", po::value(&config.vocabType_), msg.c_str());
 
   add("encode-as-id",
-      po::value(&config.prefixesForIdEncodedIris_)->composing()->multitoken(),
+      po::value(&encodeAsIdPrefixes)->composing()->multitoken(),
       "Space-separated list of IRI prefixes (without angle brackets). "
       "IRIs that start with one of these prefixes, followed by a sequence of "
       "digits, do not require a vocabulary entry, but are directly encoded "
@@ -319,6 +320,22 @@ int main(int argc, char** argv) {
                                                defaultGraphs, parseParallel);
     config.writeMaterializedViews_ =
         parseMaterializedViewsJson(materializedViewsJson);
+
+    // Convert plain string prefixes from --encode-as-id to the new
+    // PrefixWithBitConstraints format.
+    for (const auto& prefix : encodeAsIdPrefixes) {
+      config.prefixesForIdEncodedIris_.emplace_back(prefix);
+    }
+
+    // Add hard-coded BMW bit-pattern prefixes.
+    config.prefixesForIdEncodedIrisWithBitPattern_.push_back(
+        {"http://www.bmw-carit.de/Foresight/Map/Ontologies/Low/behaviorMap#dp_",
+         16, 32});
+    config.prefixesForIdEncodedIrisWithBitPattern_.push_back(
+        {"http://www.bmw.de/FS/Map#roadPart_", 16, 32});
+    config.prefixesForIdEncodedIrisWithBitPattern_.push_back(
+        {"http://www.bmw.de/FS/Map#lane_", 16, 32});
+
     config.validate();
     qlever::Qlever::buildIndex(config);
   } catch (std::exception& e) {

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -5,6 +5,7 @@
 
 #include "index/IndexImpl.h"
 
+#include <absl/strings/str_cat.h>
 #include <absl/strings/str_join.h>
 
 #include <cstdio>
@@ -1898,9 +1899,47 @@ ad_utility::BlankNodeManager* IndexImpl::getBlankNodeManager() const {
 
 // _____________________________________________________________________________
 void IndexImpl::setPrefixesForEncodedValues(
-    std::vector<std::string> prefixesWithoutAngleBrackets) {
-  encodedIriManager_ =
-      EncodedIriManager{std::move(prefixesWithoutAngleBrackets)};
+    const std::vector<encodedIris::PrefixWithBitConstraints>& prefixConfigs) {
+  // Convert encodedIris::PrefixWithBitConstraints to detail::PrefixConfig.
+  std::vector<std::string> plainPrefixes;
+
+  for (const auto& config : prefixConfigs) {
+    if (config.constraints.empty()) {
+      // Plain prefix mode.
+      plainPrefixes.push_back(config.prefix);
+    } else {
+      // Multi-constraint mode - we'll add these after creating the manager.
+    }
+  }
+
+  // Create the manager with plain prefixes.
+  encodedIriManager_ = EncodedIriManager{std::move(plainPrefixes)};
+
+  // Add prefixes with constraints.
+  for (const auto& config : prefixConfigs) {
+    if (!config.constraints.empty()) {
+      // Convert qlever::BitRangeConstraint to detail::BitRangeConstraint.
+      std::vector<encodedIris::BitRangeConstraint> detailConstraints;
+      for (const auto& constraint : config.constraints) {
+        detailConstraints.emplace_back(constraint.bitStart, constraint.bitEnd,
+                                       constraint.value);
+      }
+      encodedIriManager_.prefixes_.emplace_back(
+          absl::StrCat("<", config.prefix), std::move(detailConstraints));
+    }
+  }
+}
+
+// _____________________________________________________________________________
+void IndexImpl::setPrefixesForEncodedValuesWithBitPattern(
+    std::vector<std::tuple<std::string, size_t, size_t>>
+        prefixesWithBitPatterns) {
+  // Add bit pattern prefixes to the existing encodedIriManager.
+  // This is kept for backward compatibility.
+  for (auto& [prefix, bitStart, bitEnd] : prefixesWithBitPatterns) {
+    encodedIriManager_.prefixes_.emplace_back(absl::StrCat("<", prefix),
+                                              bitStart, bitEnd);
+  }
 }
 // _____________________________________________________________________________
 void IndexImpl::writePatternsToFile() const {

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -285,8 +285,17 @@ class IndexImpl {
 
   // Set the prefixes of the IRIs that will be encoded directly into
   // the `Id`; see `EncodedIriManager` for details.
+  // This now accepts PrefixWithBitConstraints which can specify plain prefixes
+  // or prefixes with arbitrary bit range constraints.
   void setPrefixesForEncodedValues(
-      std::vector<std::string> prefixesWithoutAngleBrackets);
+      const std::vector<encodedIris::PrefixWithBitConstraints>& prefixConfigs);
+
+  // DEPRECATED: Use setPrefixesForEncodedValues with PrefixWithBitConstraints
+  // instead. Set the prefixes with bit patterns for IRIs that will be encoded
+  // directly into the `Id`; see `EncodedIriManager` for details.
+  void setPrefixesForEncodedValuesWithBitPattern(
+      std::vector<std::tuple<std::string, size_t, size_t>>
+          prefixesWithBitPatterns);
 
   // Set the vocabulary type; see `ad_utility::VocabularyType` for details.
   void setVocabularyTypeForIndexBuilding(ad_utility::VocabularyType type) {

--- a/src/libqlever/Qlever.cpp
+++ b/src/libqlever/Qlever.cpp
@@ -78,7 +78,17 @@ void Qlever::buildIndex(IndexBuilderConfig config) {
   index.setSettingsFile(config.settingsFile_);
   index.loadAllPermutations() = !config.onlyPsoAndPos_;
   index.getImpl().setVocabularyTypeForIndexBuilding(config.vocabType_);
-  index.getImpl().setPrefixesForEncodedValues(config.prefixesForIdEncodedIris_);
+  // Set encoded IRI prefixes with the new unified interface.
+  if (!config.prefixesForIdEncodedIris_.empty()) {
+    index.getImpl().setPrefixesForEncodedValues(
+        config.prefixesForIdEncodedIris_);
+  }
+
+  // Handle deprecated bit pattern interface for backward compatibility.
+  if (!config.prefixesForIdEncodedIrisWithBitPattern_.empty()) {
+    index.getImpl().setPrefixesForEncodedValuesWithBitPattern(
+        config.prefixesForIdEncodedIrisWithBitPattern_);
+  }
 
   // Build text index if requested (various options).
   if (!config.onlyAddTextIndex_) {

--- a/src/libqlever/Qlever.h
+++ b/src/libqlever/Qlever.h
@@ -18,6 +18,7 @@
 #include "engine/QueryExecutionContext.h"
 #include "engine/QueryPlanner.h"
 #include "global/RuntimeParameters.h"
+#include "index/EncodedIriManager.h"
 #include "index/Index.h"
 #include "index/InputFileSpecification.h"
 #include "libqlever/QleverTypes.h"
@@ -26,6 +27,9 @@
 #include "util/http/MediaTypes.h"
 
 namespace qlever {
+
+using encodedIris::BitRangeConstraint;
+using encodedIris::PrefixWithBitConstraints;
 
 // The common configuration shared by the index building and query execution.
 struct CommonConfig {
@@ -62,6 +66,47 @@ struct CommonConfig {
   // TODO: We have not tested this mode in a while. In particular, it is
   // unlikely to work when updates are involved.
   bool onlyPsoAndPos_ = false;
+
+  // Configuration for encoding IRIs directly into IDs.
+  //
+  // Each entry is either:
+  // - A simple string prefix (without angle brackets) for plain digit encoding
+  // - A prefix with bit range constraints for bit pattern encoding
+  //
+  // Plain mode: IRIs starting with the prefix followed by digits are encoded.
+  // Bit pattern mode: IRIs with numeric values where specified bit ranges
+  // have specified values get compressed by removing those bits.
+  //
+  // This reduces vocabulary size and improves export performance.
+  //
+  // NOTE: Read the description of
+  // https://github.com/ad-freiburg/qlever/pull/2299 for the details and
+  // limitations regarding the correctness of FILTER and ORDER BY.
+  //
+  // Example:
+  //   // Plain mode (no constraints):
+  //   prefixesForIdEncodedIris_.push_back(
+  //       PrefixWithBitConstraints{"http://example.org/"});
+  //
+  //   // Multi-constraint mode:
+  //   prefixesForIdEncodedIris_.push_back(
+  //       PrefixWithBitConstraints{"http://constrained.org/", {
+  //           {0, 3, 0b001},    // bits 0-2 must be "001"
+  //           {13, 19, 0},      // bits 13-18 must be all zeros
+  //           {24, 28, 0b1010}  // bits 24-27 must be "1010"
+  //       }});
+  //
+  //   // Legacy single zero-bit-range mode (for backward compatibility):
+  //   prefixesForIdEncodedIris_.push_back(
+  //       PrefixWithBitConstraints{"http://legacy.org/", {
+  //           {10, 16, 0}  // bits 10-15 must be zero
+  //       }});
+  std::vector<PrefixWithBitConstraints> prefixesForIdEncodedIris_;
+
+  // DEPRECATED: Use prefixesForIdEncodedIris_ with PrefixWithBitConstraints
+  // instead. This field is kept for backward compatibility only.
+  std::vector<std::tuple<std::string, size_t, size_t>>
+      prefixesForIdEncodedIrisWithBitPattern_;
 };
 
 // Additional configuration used for building an index for a given dataset.
@@ -99,17 +144,6 @@ struct IndexBuilderConfig : CommonConfig {
   // If set to true, then certain temporary files which are created while
   // building the index are not deleted. This can be useful for debugging.
   bool keepTemporaryFiles_ = false;
-
-  // A list of IRI prefixes (without angle brackets). IRIs that start with one
-  // of these prefixes, followed by a sequence of a bounded number of digits
-  // are encoded directly in the internal ID. This reduces the size of the
-  // vocabulary (see above) and the time for exporting results involving
-  // such IRIs.
-  //
-  // NOTE: Read the description of
-  // https://github.com/ad-freiburg/qlever/pull/2299 for the details and
-  // limitations regarding the correctness of FILTER and ORDER BY.
-  std::vector<std::string> prefixesForIdEncodedIris_;
 
   // The remaining members of this class, are only relevant if a full-text
   // index is built in addition to the RDF index. By default, no fulltext index

--- a/test/index/EncodedIriManagerTest.cpp
+++ b/test/index/EncodedIriManagerTest.cpp
@@ -114,16 +114,472 @@ TEST(EncodedIriManger, illegalPrefixes) {
 
 // _____________________________________________________________________________
 TEST(EncodedIriManager, emptyPrefixes) {
-  // Calls the default constructor.
+  // Calls the default constructor (now includes hard-coded BMW prefixes).
   EncodedIriManager em;
   // Note: It is tempting to use `AD_EXPECT_NULLOPT` etc. here, but that
   // requires to pull in the equality comparison for IDs, which requires linking
   // against basically the whole codebase.
+
+  // This IRI doesn't match any hard-coded pattern, so it should fail
   EXPECT_FALSE(em.encode("<http://www.wikidata.org/entity/Q42>").has_value());
 
-  // Calls the constructor with an explicitly empty list of prefixes.
+  // But hard-coded BMW patterns should work (with proper bit 29 set)
+  EXPECT_TRUE(em.encode("<http://www.bmw-carit.de/Foresight/Map/Ontologies/Low/"
+                        "behaviorMap#range_536870912_50_25P>")
+                  .has_value());
+
+  // Calls the constructor with an explicitly empty list of prefixes
+  // (still includes hard-coded prefixes).
   EncodedIriManager em2(std::vector<std::string>{});
-  EXPECT_FALSE(em.encode("<http://www.wikidata.org/entity/Q42>").has_value());
+  EXPECT_FALSE(em2.encode("<http://www.wikidata.org/entity/Q42>").has_value());
+  EXPECT_TRUE(
+      em2.encode("<http://www.bmw-carit.de/Foresight/Map/Ontologies/Low/"
+                 "behaviorMap#range_536870912_50_25P>")
+          .has_value());
+}
+
+// _____________________________________________________________________________
+TEST(EncodedIriManager, BitPatternMode) {
+  // Create an EncodedIriManager with bit pattern mode
+  // For testing, let's use a simple prefix and specify that bits [10, 16) must
+  // be zero
+  EncodedIriManager em;
+  detail::PrefixConfig cfg("<http://example.org/", 10, 16);
+  em.prefixes_.push_back(cfg);
+
+  // Test values that should encode successfully (bits [10, 16) are zero)
+  // Value with bits [10, 16) all zero: e.g., 1023 (binary: 1111111111, bits
+  // 0-9 set)
+  auto id1 = em.encode("<http://example.org/1023>");
+  ASSERT_TRUE(id1.has_value());
+  EXPECT_EQ(em.toString(id1.value()), "<http://example.org/1023>");
+
+  // Test value 0 (all bits zero)
+  auto id2 = em.encode("<http://example.org/0>");
+  ASSERT_TRUE(id2.has_value());
+  EXPECT_EQ(em.toString(id2.value()), "<http://example.org/0>");
+
+  // Test value with upper bits set but bits [10, 16) zero
+  // 65536 = 2^16, binary: 10000000000000000 (bit 16 set, bits [10, 16) zero)
+  auto id3 = em.encode("<http://example.org/65536>");
+  ASSERT_TRUE(id3.has_value());
+  EXPECT_EQ(em.toString(id3.value()), "<http://example.org/65536>");
+
+  // Test values that should NOT encode (bits [10, 16) are not all zero)
+  // 1024 = 2^10, binary: 10000000000 (bit 10 is set)
+  auto id4 = em.encode("<http://example.org/1024>");
+  EXPECT_FALSE(id4.has_value());
+
+  // 2048 = 2^11, binary: 100000000000 (bit 11 is set)
+  auto id5 = em.encode("<http://example.org/2048>");
+  EXPECT_FALSE(id5.has_value());
+
+  // 32768 = 2^15, binary: 1000000000000000 (bit 15 is set, within [10, 16))
+  auto id6 = em.encode("<http://example.org/32768>");
+  EXPECT_FALSE(id6.has_value());
+
+  // Test combined value: 66559 = 65536 + 1023 (bits [10, 16) zero, others set)
+  auto id7 = em.encode("<http://example.org/66559>");
+  ASSERT_TRUE(id7.has_value());
+  EXPECT_EQ(em.toString(id7.value()), "<http://example.org/66559>");
+}
+
+// _____________________________________________________________________________
+TEST(EncodedIriManager, BitPatternAndPlainMixed) {
+  // Create an EncodedIriManager with both plain and bit pattern prefixes
+  EncodedIriManager em;
+  detail::PrefixConfig plainCfg("<http://plain.org/");
+  detail::PrefixConfig bitPatternCfg("<http://bitpattern.org/", 8, 12);
+  em.prefixes_.push_back(plainCfg);
+  em.prefixes_.push_back(bitPatternCfg);
+
+  // Test plain mode
+  auto id1 = em.encode("<http://plain.org/12345>");
+  ASSERT_TRUE(id1.has_value());
+  EXPECT_EQ(em.toString(id1.value()), "<http://plain.org/12345>");
+
+  // Test bit pattern mode with valid value (bits [8, 12) zero)
+  // 255 = 2^8 - 1, binary: 11111111 (bits 0-7 set, bits [8, 12) zero)
+  auto id2 = em.encode("<http://bitpattern.org/255>");
+  ASSERT_TRUE(id2.has_value());
+  EXPECT_EQ(em.toString(id2.value()), "<http://bitpattern.org/255>");
+
+  // Test bit pattern mode with invalid value (bit 8 is set, within [8, 12))
+  // 256 = 2^8
+  auto id3 = em.encode("<http://bitpattern.org/256>");
+  EXPECT_FALSE(id3.has_value());
+}
+
+// _____________________________________________________________________________
+TEST(EncodedIriManager, JsonSerializationBackwardCompatibility) {
+  using namespace ::testing;
+
+  // Create an EncodedIriManager with old-style plain prefixes
+  // (manually to bypass the automatic hard-coded prefix initialization)
+  EncodedIriManager em1;
+  em1.prefixes_.clear();  // Remove hard-coded prefixes
+  em1.prefixes_.emplace_back("<http://example.org/");
+  em1.prefixes_.emplace_back("<http://test.org/");
+
+  // Serialize to JSON
+  nlohmann::json j1;
+  to_json(j1, em1);
+
+  // Deserialize and check (will include hard-coded prefixes)
+  EncodedIriManager em2;
+  em2.prefixes_.clear();  // Clear to test deserialization only
+  from_json(j1, em2);
+  EXPECT_EQ(em2.prefixes_.size(), 2);
+  EXPECT_EQ(em2.prefixes_[0].prefix, "<http://example.org/");
+  EXPECT_FALSE(em2.prefixes_[0].isBitPatternMode());
+  EXPECT_EQ(em2.prefixes_[1].prefix, "<http://test.org/");
+  EXPECT_FALSE(em2.prefixes_[1].isBitPatternMode());
+
+  // Create an EncodedIriManager with bit pattern prefixes
+  EncodedIriManager em3;
+  em3.prefixes_.clear();  // Remove hard-coded prefixes
+  em3.prefixes_.emplace_back("<http://bitpattern.org/", 5, 11);
+  em3.prefixes_.emplace_back("<http://plain.org/");
+
+  // Serialize to JSON
+  nlohmann::json j3;
+  to_json(j3, em3);
+
+  // Deserialize and check
+  EncodedIriManager em4;
+  em4.prefixes_.clear();  // Clear to test deserialization only
+  from_json(j3, em4);
+  EXPECT_EQ(em4.prefixes_.size(), 2);
+  EXPECT_EQ(em4.prefixes_[0].prefix, "<http://bitpattern.org/");
+  EXPECT_TRUE(em4.prefixes_[0].isBitPatternMode());
+  auto [bitStart, bitEnd] = em4.prefixes_[0].getBitRange();
+  EXPECT_EQ(bitStart, 5);
+  EXPECT_EQ(bitEnd, 11);
+  EXPECT_EQ(em4.prefixes_[1].prefix, "<http://plain.org/");
+  EXPECT_FALSE(em4.prefixes_[1].isBitPatternMode());
+
+  // Test backward compatibility: old format JSON
+  nlohmann::json oldFormatJson;
+  oldFormatJson["prefixes-with-leading-angle-brackets"] =
+      std::vector<std::string>{"<http://old.org/", "<http://legacy.org/"};
+
+  EncodedIriManager em5;
+  em5.prefixes_.clear();  // Clear to test deserialization only
+  from_json(oldFormatJson, em5);
+  EXPECT_EQ(em5.prefixes_.size(), 2);
+  EXPECT_EQ(em5.prefixes_[0].prefix, "<http://old.org/");
+  EXPECT_FALSE(em5.prefixes_[0].isBitPatternMode());
+  EXPECT_EQ(em5.prefixes_[1].prefix, "<http://legacy.org/");
+  EXPECT_FALSE(em5.prefixes_[1].isBitPatternMode());
+}
+
+// _____________________________________________________________________________
+TEST(EncodedIriManager, BMWRangePattern) {
+  // Create an EncodedIriManager - hard-coded patterns are initialized
+  // automatically
+  EncodedIriManager em;
+
+  // Test valid range_ pattern: range_545554944_0_0P
+  // 545554944 in binary has upper 3 bits as "001" (bit 29=1, bits 30-31=0)
+  std::string rangeIri =
+      "<http://www.bmw-carit.de/Foresight/Map/Ontologies/Low/"
+      "behaviorMap#range_545554944_0_0P>";
+  auto id1 = em.encode(rangeIri);
+  ASSERT_TRUE(id1.has_value());
+  EXPECT_EQ(em.toString(id1.value()), rangeIri);
+
+  // Test with minimum valid value: bit 29 set = 536870912
+  std::string rangeIri2 =
+      "<http://www.bmw-carit.de/Foresight/Map/Ontologies/Low/"
+      "behaviorMap#range_536870912_0_0P>";
+  auto id2 = em.encode(rangeIri2);
+  ASSERT_TRUE(id2.has_value());
+  EXPECT_EQ(em.toString(id2.value()), rangeIri2);
+
+  // Test with maximum valid value for first number (bit 29 set, bits 30-31
+  // clear) Max: (1<<30) - 1 = 1073741823
+  std::string rangeIri3 =
+      "<http://www.bmw-carit.de/Foresight/Map/Ontologies/Low/"
+      "behaviorMap#range_1073741823_255_255P>";
+  auto id3 = em.encode(rangeIri3);
+  ASSERT_TRUE(id3.has_value());
+  EXPECT_EQ(em.toString(id3.value()), rangeIri3);
+
+  // Test values that exceed constraints
+  // First number has bit 30 set (violates upper 3 bits = "001")
+  std::string rangeIri4 =
+      "<http://www.bmw-carit.de/Foresight/Map/Ontologies/Low/"
+      "behaviorMap#range_1073741824_0_0P>";  // 2^30
+  auto id4 = em.encode(rangeIri4);
+  EXPECT_FALSE(id4.has_value());
+
+  // First number doesn't have bit 29 set (violates upper 3 bits = "001")
+  std::string rangeIri5 =
+      "<http://www.bmw-carit.de/Foresight/Map/Ontologies/Low/"
+      "behaviorMap#range_100_0_0P>";
+  auto id5 = em.encode(rangeIri5);
+  EXPECT_FALSE(id5.has_value());
+
+  // Second number exceeds 8 bits
+  std::string rangeIri6 =
+      "<http://www.bmw-carit.de/Foresight/Map/Ontologies/Low/"
+      "behaviorMap#range_545554944_256_0P>";
+  auto id6 = em.encode(rangeIri6);
+  EXPECT_FALSE(id6.has_value());
+
+  // Third number exceeds 8 bits
+  std::string rangeIri7 =
+      "<http://www.bmw-carit.de/Foresight/Map/Ontologies/Low/"
+      "behaviorMap#range_545554944_0_256P>";
+  auto id7 = em.encode(rangeIri7);
+  EXPECT_FALSE(id7.has_value());
+
+  // Missing 'P' at the end
+  std::string rangeIri8 =
+      "<http://www.bmw-carit.de/Foresight/Map/Ontologies/Low/"
+      "behaviorMap#range_545554944_0_0>";
+  auto id8 = em.encode(rangeIri8);
+  EXPECT_FALSE(id8.has_value());
+}
+
+// _____________________________________________________________________________
+TEST(EncodedIriManager, BMWValRangePattern) {
+  EncodedIriManager em;
+
+  // Test valid valRange_ pattern: valRange_545555094_809_830M
+  // 545555094 in binary has upper 3 bits as "001" (bit 29=1, bits 30-31=0)
+  std::string valRangeIri =
+      "<http://www.bmw-carit.de/Foresight/Map/Ontologies/Low/"
+      "behaviorMap#valRange_545555094_809_830M>";
+  auto id1 = em.encode(valRangeIri);
+  ASSERT_TRUE(id1.has_value());
+  EXPECT_EQ(em.toString(id1.value()), valRangeIri);
+
+  // Test with minimum valid value: bit 29 set = 536870912
+  std::string valRangeIri2 =
+      "<http://www.bmw-carit.de/Foresight/Map/Ontologies/Low/"
+      "behaviorMap#valRange_536870912_0_0M>";
+  auto id2 = em.encode(valRangeIri2);
+  ASSERT_TRUE(id2.has_value());
+  EXPECT_EQ(em.toString(id2.value()), valRangeIri2);
+
+  // Test with maximum valid values
+  // First number max: (1<<30) - 1 = 1073741823
+  // Second and third numbers max: (1<<11) - 1 = 2047
+  std::string valRangeIri3 =
+      "<http://www.bmw-carit.de/Foresight/Map/Ontologies/Low/"
+      "behaviorMap#valRange_1073741823_2047_2047M>";
+  auto id3 = em.encode(valRangeIri3);
+  ASSERT_TRUE(id3.has_value());
+  EXPECT_EQ(em.toString(id3.value()), valRangeIri3);
+
+  // Test values that exceed constraints
+  // First number has bit 30 set (violates upper 3 bits = "001")
+  std::string valRangeIri4 =
+      "<http://www.bmw-carit.de/Foresight/Map/Ontologies/Low/"
+      "behaviorMap#valRange_1073741824_100_100M>";  // 2^30
+  auto id4 = em.encode(valRangeIri4);
+  EXPECT_FALSE(id4.has_value());
+
+  // First number doesn't have bit 29 set
+  std::string valRangeIri5 =
+      "<http://www.bmw-carit.de/Foresight/Map/Ontologies/Low/"
+      "behaviorMap#valRange_100_100_100M>";
+  auto id5 = em.encode(valRangeIri5);
+  EXPECT_FALSE(id5.has_value());
+
+  // Second number exceeds 11 bits
+  std::string valRangeIri6 =
+      "<http://www.bmw-carit.de/Foresight/Map/Ontologies/Low/"
+      "behaviorMap#valRange_545555094_2048_100M>";
+  auto id6 = em.encode(valRangeIri6);
+  EXPECT_FALSE(id6.has_value());
+
+  // Third number exceeds 11 bits
+  std::string valRangeIri7 =
+      "<http://www.bmw-carit.de/Foresight/Map/Ontologies/Low/"
+      "behaviorMap#valRange_545555094_100_2048M>";
+  auto id7 = em.encode(valRangeIri7);
+  EXPECT_FALSE(id7.has_value());
+
+  // Missing 'M' at the end (has 'P' instead)
+  std::string valRangeIri8 =
+      "<http://www.bmw-carit.de/Foresight/Map/Ontologies/Low/"
+      "behaviorMap#valRange_545555094_100_100P>";
+  auto id8 = em.encode(valRangeIri8);
+  EXPECT_FALSE(id8.has_value());
+}
+
+// _____________________________________________________________________________
+TEST(EncodedIriManager, BMWLaneRefPattern) {
+  EncodedIriManager em;
+
+  // Test valid laneRef pattern with the example value from the spec
+  // 2343140642651111426 in binary has:
+  // - Highest 3 bits: 001 (bit 61 = 1, bits 62-63 = 0)
+  // - Bits [17, 32): all 0
+  std::string laneRefIri =
+      "<http://www.bmw-carit.de/Foresight/Map/Ontologies/Low/"
+      "behaviorMap#laneRef_2343140642651111426_0>";
+  auto id1 = em.encode(laneRefIri);
+  ASSERT_TRUE(id1.has_value());
+  EXPECT_EQ(em.toString(id1.value()), laneRefIri);
+
+  // Test with different valid second number (< 16)
+  std::string laneRefIri2 =
+      "<http://www.bmw-carit.de/Foresight/Map/Ontologies/Low/"
+      "behaviorMap#laneRef_2343140642651111426_15>";
+  auto id2 = em.encode(laneRefIri2);
+  ASSERT_TRUE(id2.has_value());
+  EXPECT_EQ(em.toString(id2.value()), laneRefIri2);
+
+  // Test with minimum valid value: bit 61 set, bits [17,32) zero
+  // Minimum: 2^61 = 2305843009213693952
+  std::string laneRefIri3 =
+      "<http://www.bmw-carit.de/Foresight/Map/Ontologies/Low/"
+      "behaviorMap#laneRef_2305843009213693952_0>";
+  auto id3 = em.encode(laneRefIri3);
+  ASSERT_TRUE(id3.has_value());
+  EXPECT_EQ(em.toString(id3.value()), laneRefIri3);
+
+  // Test invalid: second number >= 16
+  std::string laneRefIri4 =
+      "<http://www.bmw-carit.de/Foresight/Map/Ontologies/Low/"
+      "behaviorMap#laneRef_2343140642651111426_16>";
+  auto id4 = em.encode(laneRefIri4);
+  EXPECT_FALSE(id4.has_value());
+
+  // Test invalid: bit 61 not set (number < 2^61)
+  std::string laneRefIri5 =
+      "<http://www.bmw-carit.de/Foresight/Map/Ontologies/Low/"
+      "behaviorMap#laneRef_1000000000000000000_0>";
+  auto id5 = em.encode(laneRefIri5);
+  EXPECT_FALSE(id5.has_value());
+
+  // Test invalid: bit 62 or 63 set (number >= 2^62)
+  std::string laneRefIri6 =
+      "<http://www.bmw-carit.de/Foresight/Map/Ontologies/Low/"
+      "behaviorMap#laneRef_4611686018427387904_0>";  // 2^62
+  auto id6 = em.encode(laneRefIri6);
+  EXPECT_FALSE(id6.has_value());
+}
+
+// _____________________________________________________________________________
+TEST(EncodedIriManager, BMWRoadRefPattern) {
+  EncodedIriManager em;
+
+  // Test valid roadRef pattern (same constraints as laneRef)
+  std::string roadRefIri =
+      "<http://www.bmw-carit.de/Foresight/Map/Ontologies/Low/"
+      "behaviorMap#roadRef_2343140642651111426_5>";
+  auto id1 = em.encode(roadRefIri);
+  ASSERT_TRUE(id1.has_value());
+  EXPECT_EQ(em.toString(id1.value()), roadRefIri);
+}
+
+// _____________________________________________________________________________
+TEST(EncodedIriManager, BMWSpeedProfilePattern) {
+  EncodedIriManager em;
+
+  // Test valid speedprofile pattern (same constraints as laneRef)
+  std::string speedProfileIri =
+      "<http://www.bmw-carit.de/Foresight/Map/Ontologies/Low/"
+      "behaviorMap#speedprofile_2343140642651111426_10>";
+  auto id1 = em.encode(speedProfileIri);
+  ASSERT_TRUE(id1.has_value());
+  EXPECT_EQ(em.toString(id1.value()), speedProfileIri);
+}
+
+// _____________________________________________________________________________
+TEST(EncodedIriManager, BMWStopLocPattern) {
+  EncodedIriManager em;
+
+  // Test 32-bit variant: stopLoc_<32-bit>_<18-bit>
+  std::string stopLocIri32 =
+      "<http://www.bmw-carit.de/Foresight/Map/Ontologies/Low/"
+      "behaviorMap#stopLoc_545554944_0>";
+  auto id1 = em.encode(stopLocIri32);
+  ASSERT_TRUE(id1.has_value());
+  EXPECT_EQ(em.toString(id1.value()), stopLocIri32);
+
+  // Test 64-bit variant: stopLoc_<special-64-bit>_<4-bit>
+  // 2343140642651111426 has upper 3 bits "001" and bits [17,32) zero
+  std::string stopLocIri64 =
+      "<http://www.bmw-carit.de/Foresight/Map/Ontologies/Low/"
+      "behaviorMap#stopLoc_2343140642651111426_7>";
+  auto id2 = em.encode(stopLocIri64);
+  ASSERT_TRUE(id2.has_value());
+  EXPECT_EQ(em.toString(id2.value()), stopLocIri64);
+
+  // Test minimum valid 64-bit value
+  std::string stopLocIri64Min =
+      "<http://www.bmw-carit.de/Foresight/Map/Ontologies/Low/"
+      "behaviorMap#stopLoc_2305843009213693952_0>";  // 2^61
+  auto id3 = em.encode(stopLocIri64Min);
+  ASSERT_TRUE(id3.has_value());
+  EXPECT_EQ(em.toString(id3.value()), stopLocIri64Min);
+
+  // Test 32-bit variant with maximum values
+  // First number max: (1<<32) - 1 = 4294967295
+  // Second number max: (1<<18) - 1 = 262143
+  std::string stopLocIri32Max =
+      "<http://www.bmw-carit.de/Foresight/Map/Ontologies/Low/"
+      "behaviorMap#stopLoc_4294967295_262143>";
+  auto id4 = em.encode(stopLocIri32Max);
+  ASSERT_TRUE(id4.has_value());
+  EXPECT_EQ(em.toString(id4.value()), stopLocIri32Max);
+
+  // Test values that exceed constraints
+  // First number exceeds 64 bits (shouldn't be possible with parseDecimal, but
+  // test large invalid value)
+  std::string stopLocIriBad1 =
+      "<http://www.bmw-carit.de/Foresight/Map/Ontologies/Low/"
+      "behaviorMap#stopLoc_4294967296_0>";  // > 32 bits, but < 64 bits, no
+                                            // special bits
+  auto id5 = em.encode(stopLocIriBad1);
+  // This should fail because it doesn't match 64-bit constraints (no bit 61
+  // set) and exceeds 32 bits for 32-bit variant
+  EXPECT_FALSE(id5.has_value());
+
+  // Second number exceeds both variants (> 18 bits)
+  std::string stopLocIriBad2 =
+      "<http://www.bmw-carit.de/Foresight/Map/Ontologies/Low/"
+      "behaviorMap#stopLoc_545554944_262144>";
+  auto id6 = em.encode(stopLocIriBad2);
+  EXPECT_FALSE(id6.has_value());
+
+  // 64-bit variant with second number >= 16 should fall back to 32-bit, but
+  // here the first number is valid for 64-bit pattern but second exceeds 18
+  // bits
+  std::string stopLocIriBad3 =
+      "<http://www.bmw-carit.de/Foresight/Map/Ontologies/Low/"
+      "behaviorMap#stopLoc_2343140642651111426_262144>";
+  auto id7 = em.encode(stopLocIriBad3);
+  EXPECT_FALSE(id7.has_value());
+}
+
+// _____________________________________________________________________________
+TEST(EncodedIriManager, BMWPatternsWithConfigurablePrefixes) {
+  // Test that hard-coded patterns work alongside configurable prefixes
+  std::vector<std::string> prefixes = {"http://www.wikidata.org/entity/Q"};
+  EncodedIriManager em{prefixes};
+
+  // Test configurable prefix
+  std::string wikidataIri = "<http://www.wikidata.org/entity/Q42>";
+  auto id1 = em.encode(wikidataIri);
+  ASSERT_TRUE(id1.has_value());
+  EXPECT_EQ(em.toString(id1.value()), wikidataIri);
+
+  // Test hard-coded BMW pattern (with proper bit 29 set)
+  std::string rangeIri =
+      "<http://www.bmw-carit.de/Foresight/Map/Ontologies/Low/"
+      "behaviorMap#range_536883257_100_200P>";  // 536870912 + 12345
+  auto id2 = em.encode(rangeIri);
+  ASSERT_TRUE(id2.has_value());
+  EXPECT_EQ(em.toString(id2.value()), rangeIri);
+
+  // Ensure they have different prefix indices
+  EXPECT_NE(id1.value().getBits(), id2.value().getBits());
 }
 
 // _____________________________________________________________________________

--- a/test/util/IndexTestHelpers.cpp
+++ b/test/util/IndexTestHelpers.cpp
@@ -224,13 +224,25 @@ Index makeTestIndex(const std::string& indexBasename, TestIndexConfig c) {
                                      : VocabularyType::random());
     if (c.encodedIriManager.has_value()) {
       // Extract prefixes without angle brackets from the EncodedIriManager
-      std::vector<std::string> prefixes;
-      for (const auto& prefix : c.encodedIriManager.value().prefixes_) {
-        AD_CORRECTNESS_CHECK(ql::starts_with(prefix, '<') &&
-                             !ql::ends_with(prefix, '>'));
-        prefixes.push_back(prefix.substr(1));
+      // and convert to PrefixWithBitConstraints for the new interface.
+      std::vector<encodedIris::PrefixWithBitConstraints> prefixConfigs;
+      for (const auto& cfg : c.encodedIriManager.value().prefixes_) {
+        AD_CORRECTNESS_CHECK(ql::starts_with(cfg.prefix, '<') &&
+                             !ql::ends_with(cfg.prefix, '>'));
+        if (cfg.isMultiConstraintMode()) {
+          prefixConfigs.emplace_back(cfg.prefix.substr(1),
+                                     cfg.getBitRangeConstraints());
+        } else if (cfg.zeroBitRange.has_value()) {
+          auto [bitStart, bitEnd] = cfg.getBitRange();
+          prefixConfigs.emplace_back(
+              cfg.prefix.substr(1),
+              std::vector<encodedIris::BitRangeConstraint>{
+                  {bitStart, bitEnd, 0}});
+        } else {
+          prefixConfigs.emplace_back(cfg.prefix.substr(1));
+        }
       }
-      index.getImpl().setPrefixesForEncodedValues(std::move(prefixes));
+      index.getImpl().setPrefixesForEncodedValues(prefixConfigs);
     }
     index.createFromFiles({spec});
     if (c.createTextIndex) {


### PR DESCRIPTION
Extend EncodedIriManager with BitRangeConstraint and PrefixWithBitConstraints to support multi-bit-pattern encoding of IRIs. This allows more efficient compression of numeric IRIs where certain bit ranges are predictably constrained.

Integrates the new encoding mode into IndexImpl, Qlever config, and IndexBuilderMain.