### PR TITLE
Remove redundant `globalSingletonComparator_`

### DIFF
--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -996,7 +996,6 @@ void IndexImpl::createFromOnDiskIndex(const std::string& onDiskBase,
   setOnDiskBase(onDiskBase);
   readConfiguration();
   vocab_.readFromFile(onDiskBase_ + VOCAB_SUFFIX);
-  globalSingletonComparator_ = &vocab_.getCaseComparator();
 
   AD_LOG_DEBUG << "Number of words in internal and external vocabulary: "
                << vocab_.size() << std::endl;

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -162,8 +162,6 @@ class IndexImpl {
   // Those are used to compare LocalVocab entries with each other as well as
   // with Vocab entries.
   static inline const IndexImpl* globalSingletonIndex_ = nullptr;
-  static inline const TripleComponentComparator* globalSingletonComparator_ =
-      nullptr;
   /**
    * @brief Maps pattern ids to sets of predicate ids.
    */
@@ -234,15 +232,7 @@ class IndexImpl {
     return *globalSingletonIndex_;
   }
 
-  static const TripleComponentComparator& staticGlobalSingletonComparator() {
-    AD_CORRECTNESS_CHECK(globalSingletonComparator_ != nullptr);
-    return *globalSingletonComparator_;
-  }
-
-  void setGlobalIndexAndComparatorOnlyForTesting() const {
-    globalSingletonIndex_ = this;
-    globalSingletonComparator_ = &vocab_.getCaseComparator();
-  }
+  void setGlobalIndexOnlyForTesting() const { globalSingletonIndex_ = this; }
 
   // For a given `Permutation::Enum` (e.g. `PSO`) return the corresponding
   // `Permutation` object by reference or shared pointer (`pso_`).

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -158,9 +158,8 @@ class IndexImpl {
   TextScoringMetric textScoringMetric_;
   std::pair<float, float> bAndKParamForTextScoring_;
 
-  // Global static pointers to the currently active index and comparator.
-  // Those are used to compare LocalVocab entries with each other as well as
-  // with Vocab entries.
+  // Global static pointer to the currently active index. It is used to compare
+  // LocalVocab entries with each other as well as with Vocab entries.
   static inline const IndexImpl* globalSingletonIndex_ = nullptr;
   /**
    * @brief Maps pattern ids to sets of predicate ids.

--- a/src/index/LocalVocabEntry.cpp
+++ b/src/index/LocalVocabEntry.cpp
@@ -8,6 +8,23 @@
 #include "index/IndexImpl.h"
 
 // ___________________________________________________________________________
+ql::strong_ordering LocalVocabEntry::compareThreeWay(
+    const LocalVocabEntry& rhs) const {
+  int i = IndexImpl::staticGlobalSingletonIndex()
+              .getVocab()
+              .getCaseComparator()
+              .compare(toStringRepresentation(), rhs.toStringRepresentation(),
+                       LocaleManager::Level::TOTAL);
+  if (i < 0) {
+    return ql::strong_ordering::less;
+  } else if (i > 0) {
+    return ql::strong_ordering::greater;
+  } else {
+    return ql::strong_ordering::equal;
+  }
+}
+
+// ___________________________________________________________________________
 auto LocalVocabEntry::positionInVocabExpensiveCase() const -> PositionInVocab {
   // Lookup the lower and upper bound from the vocabulary of the index,
   // cache and return them. This represents the place in the vocabulary where

--- a/src/index/LocalVocabEntry.h
+++ b/src/index/LocalVocabEntry.h
@@ -111,10 +111,7 @@ class alignas(16) LocalVocabEntry
   // cached `position` if it has previously been computed for both of the
   // entries, but it is currently questionable whether this gains much
   // performance.
-  auto compareThreeWay(const LocalVocabEntry& rhs) const {
-    return ql::compareThreeWay(static_cast<const Base&>(*this),
-                               static_cast<const Base&>(rhs));
-  }
+  ql::strong_ordering compareThreeWay(const LocalVocabEntry& rhs) const;
   QL_DEFINE_CUSTOM_THREEWAY_OPERATOR_LOCAL(LocalVocabEntry)
 
  private:

--- a/src/parser/LiteralOrIri.cpp
+++ b/src/parser/LiteralOrIri.cpp
@@ -101,9 +101,11 @@ NormalizedStringView BasicLiteralOrIri<isOwning>::getContent() const {
 template <bool isOwning>
 ql::strong_ordering BasicLiteralOrIri<isOwning>::compareThreeWay(
     const BasicLiteralOrIri& rhs) const {
-  int i = IndexImpl::staticGlobalSingletonComparator().compare(
-      toStringRepresentation(), rhs.toStringRepresentation(),
-      LocaleManager::Level::TOTAL);
+  int i = IndexImpl::staticGlobalSingletonIndex()
+              .getVocab()
+              .getCaseComparator()
+              .compare(toStringRepresentation(), rhs.toStringRepresentation(),
+                       LocaleManager::Level::TOTAL);
   if (i < 0) {
     return ql::strong_ordering::less;
   } else if (i > 0) {

--- a/src/parser/LiteralOrIri.cpp
+++ b/src/parser/LiteralOrIri.cpp
@@ -14,7 +14,6 @@
 
 #include "backports/algorithm.h"
 #include "backports/three_way_comparison.h"
-#include "index/IndexImpl.h"
 
 namespace ad_utility::triple_component {
 
@@ -95,24 +94,6 @@ NormalizedStringView BasicLiteralOrIri<isOwning>::getContent() const {
     return getIriContent();
   else
     AD_THROW("LiteralOrIri object contains neither Iri not Literal");
-}
-
-// ___________________________________________
-template <bool isOwning>
-ql::strong_ordering BasicLiteralOrIri<isOwning>::compareThreeWay(
-    const BasicLiteralOrIri& rhs) const {
-  int i = IndexImpl::staticGlobalSingletonIndex()
-              .getVocab()
-              .getCaseComparator()
-              .compare(toStringRepresentation(), rhs.toStringRepresentation(),
-                       LocaleManager::Level::TOTAL);
-  if (i < 0) {
-    return ql::strong_ordering::less;
-  } else if (i > 0) {
-    return ql::strong_ordering::greater;
-  } else {
-    return ql::strong_ordering::equal;
-  }
 }
 
 template class BasicLiteralOrIri<true>;

--- a/src/parser/LiteralOrIri.h
+++ b/src/parser/LiteralOrIri.h
@@ -104,9 +104,6 @@ class alignas(16) BasicLiteralOrIri {
 
   QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(BasicLiteralOrIri, data_)
 
-  ql::strong_ordering compareThreeWay(const BasicLiteralOrIri& rhs) const;
-  QL_DEFINE_CUSTOM_THREEWAY_OPERATOR_LOCAL(BasicLiteralOrIri)
-
   // Return true if object contains an Iri object.
   bool isIri() const;
 

--- a/test/parser/LiteralOrIriTest.cpp
+++ b/test/parser/LiteralOrIriTest.cpp
@@ -487,14 +487,7 @@ TEST(LiteralTest, spaceshipOperatorLangtagLiteral) {
       "\"Comparative evaluation of the protective effect of sodium "
       "valproate, phenazepam and ionol in stress-induced liver damage in "
       "rats\"@en");
-  using namespace ad_utility::testing;
-  // Ensure that the global singleton comparator (which is used for the <=>
-  // comparison) is available. Creating a QEC sets this comparator.
-  getQec(TestIndexConfig{});
-  ASSERT_NO_THROW(IndexImpl::staticGlobalSingletonIndex());
   EXPECT_THAT(l1, testing::Not(testing::Eq(l2)));
-  EXPECT_THAT(ql::compareThreeWay(l1, l2),
-              testing::Not(testing::Eq(ql::strong_ordering::equal)));
 }
 
 // _____________________________________________________________________________

--- a/test/parser/LiteralOrIriTest.cpp
+++ b/test/parser/LiteralOrIriTest.cpp
@@ -491,7 +491,7 @@ TEST(LiteralTest, spaceshipOperatorLangtagLiteral) {
   // Ensure that the global singleton comparator (which is used for the <=>
   // comparison) is available. Creating a QEC sets this comparator.
   getQec(TestIndexConfig{});
-  ASSERT_NO_THROW(IndexImpl::staticGlobalSingletonComparator());
+  ASSERT_NO_THROW(IndexImpl::staticGlobalSingletonIndex());
   EXPECT_THAT(l1, testing::Not(testing::Eq(l2)));
   EXPECT_THAT(ql::compareThreeWay(l1, l2),
               testing::Not(testing::Eq(ql::strong_ordering::equal)));

--- a/test/util/IndexTestHelpers.cpp
+++ b/test/util/IndexTestHelpers.cpp
@@ -377,7 +377,7 @@ QueryExecutionContext* getQec(TestIndexConfig c) {
                    std::make_unique<MaterializedViewsManager>()});
   }
   auto* qec = contextMap.at(c).qec_.get();
-  qec->getIndex().getImpl().setGlobalIndexAndComparatorOnlyForTesting();
+  qec->getIndex().getImpl().setGlobalIndexOnlyForTesting();
   return qec;
 }
 


### PR DESCRIPTION
Remove the redundant `globalSingletonComparator_` static pointer from `IndexImpl`; it always pointed to `globalSingletonIndex_->getVocab().getCaseComparator()`. Move the `compareThreeWay` method from `BasicLiteralOrIri` (where it required the now-removed singleton) to `LocalVocabEntry` (where it's actually needed). `BasicLiteralOrIri` no longer has a three-way comparison operator — only equality. This is preparation for supporting multiple indexes