### PR TITLE
Change interface of `toValueId` to take `const IndexImpl&`

### DIFF
--- a/src/engine/Describe.cpp
+++ b/src/engine/Describe.cpp
@@ -205,13 +205,12 @@ IdTable Describe::getIdsToDescribe(const Result& result,
                                    LocalVocab& localVocab) const {
   // First collect the `Id`s in a hash set, in order to remove duplicates.
   ad_utility::HashSetWithMemoryLimit<Id> idsToDescribe{allocator()};
-  const auto& vocab = getIndex().getVocab();
   for (const auto& resource : describe_.resources_) {
     if (std::holds_alternative<TripleComponent::Iri>(resource)) {
       // For an IRI, add the corresponding ID to `idsToDescribe`.
       idsToDescribe.insert(
           TripleComponent{std::get<TripleComponent::Iri>(resource)}.toValueId(
-              vocab, localVocab, getIndex().encodedIriManager()));
+              getIndex().getImpl(), localVocab));
     } else {
       // For a variable, add all IDs that match the variable in the `result` of
       // the WHERE clause to `idsToDescribe`.

--- a/src/engine/Describe.cpp
+++ b/src/engine/Describe.cpp
@@ -210,7 +210,7 @@ IdTable Describe::getIdsToDescribe(const Result& result,
       // For an IRI, add the corresponding ID to `idsToDescribe`.
       idsToDescribe.insert(
           TripleComponent{std::get<TripleComponent::Iri>(resource)}.toValueId(
-              getIndex().getImpl(), localVocab));
+              getIndex(), localVocab));
     } else {
       // For a variable, add all IDs that match the variable in the `result` of
       // the WHERE clause to `idsToDescribe`.

--- a/src/engine/ExecuteUpdate.cpp
+++ b/src/engine/ExecuteUpdate.cpp
@@ -233,8 +233,7 @@ ExecuteUpdate::computeGraphUpdateQuads(
       [&index, &variableColumns, &result](
           const std::vector<SparqlTripleSimpleWithGraph>& tripleTemplates) {
         auto [transformedTripleTemplates, localVocab] =
-            transformTriplesTemplate(index.getImpl(), variableColumns,
-                                     tripleTemplates);
+            transformTriplesTemplate(index, variableColumns, tripleTemplates);
         std::vector<IdTriple<>> updateTriples;
         // The maximum result size is size(query result) x num template rows.
         // The actual result can be smaller if there are template rows with

--- a/src/engine/ExecuteUpdate.cpp
+++ b/src/engine/ExecuteUpdate.cpp
@@ -6,6 +6,7 @@
 
 #include "engine/ExportQueryExecutionTrees.h"
 #include "engine/UpdateMetadata.h"
+#include "index/IndexImpl.h"
 
 // _____________________________________________________________________________
 UpdateMetadata ExecuteUpdate::executeUpdate(
@@ -48,9 +49,9 @@ UpdateMetadata ExecuteUpdate::executeUpdate(
 // operation). Still, it would be cleaner to avoid these copies.
 std::pair<std::vector<ExecuteUpdate::TransformedTriple>, LocalVocab>
 ExecuteUpdate::transformTriplesTemplate(
-    const EncodedIriManager& encodedIriManager, const Index::Vocab& vocab,
-    const VariableToColumnMap& variableColumns,
+    const IndexImpl& index, const VariableToColumnMap& variableColumns,
     const std::vector<SparqlTripleSimpleWithGraph>& triples) {
+  const auto& encodedIriManager = index.encodedIriManager();
   // We collect all `TripleComponent`s from `triples` in a hash set.
   ad_utility::HashSet<TripleComponent> lookupItems;
 
@@ -95,12 +96,13 @@ ExecuteUpdate::transformTriplesTemplate(
   // Sort the `TripleComponent`s.
   std::vector lookupVec(std::move_iterator(lookupItems.begin()),
                         std::move_iterator(lookupItems.end()));
-  ql::ranges::sort(
-      lookupVec, vocab.getCaseComparator(), [](const TripleComponent& tc) {
-        AD_CORRECTNESS_CHECK(tc.isLiteral() || tc.isIri());
-        return tc.isLiteral() ? tc.getLiteral().toStringRepresentation()
-                              : tc.getIri().toStringRepresentation();
-      });
+  ql::ranges::sort(lookupVec, index.getVocab().getCaseComparator(),
+                   [](const TripleComponent& tc) {
+                     AD_CORRECTNESS_CHECK(tc.isLiteral() || tc.isIri());
+                     return tc.isLiteral()
+                                ? tc.getLiteral().toStringRepresentation()
+                                : tc.getIri().toStringRepresentation();
+                   });
 
   // Local vocab for all `TripleComponent`s that are not in the existing vocab.
   //
@@ -117,8 +119,8 @@ ExecuteUpdate::transformTriplesTemplate(
   ad_utility::HashMap<TripleComponent, Id> lookupMap;
   for (auto& tc : lookupVec) {
     TripleComponent copy{tc};
-    lookupMap.emplace(std::move(tc), std::move(copy).toValueId(
-                                         vocab, localVocab, encodedIriManager));
+    lookupMap.emplace(std::move(tc),
+                      std::move(copy).toValueId(index, localVocab));
   }
 
   // Lookup the given `TripleComponent` in `lookupMap`. For a variable, return
@@ -226,14 +228,12 @@ ExecuteUpdate::computeGraphUpdateQuads(
 
   // Start the timer once the where clause has been evaluated.
   tracer.beginTrace("computeIds");
-  const auto& vocab = index.getVocab();
-  const auto& encodedIriManager = index.encodedIriManager();
 
   auto prepareTemplateAndResultContainer =
-      [&vocab, &variableColumns, &encodedIriManager, &result](
+      [&index, &variableColumns, &result](
           const std::vector<SparqlTripleSimpleWithGraph>& tripleTemplates) {
         auto [transformedTripleTemplates, localVocab] =
-            transformTriplesTemplate(encodedIriManager, vocab, variableColumns,
+            transformTriplesTemplate(index.getImpl(), variableColumns,
                                      tripleTemplates);
         std::vector<IdTriple<>> updateTriples;
         // The maximum result size is size(query result) x num template rows.

--- a/src/engine/ExecuteUpdate.h
+++ b/src/engine/ExecuteUpdate.h
@@ -33,8 +33,7 @@ class ExecuteUpdate {
   // `SparqlTripleSimpleWithGraph` into `Variable`s or `Id`s.
   static std::pair<std::vector<ExecuteUpdate::TransformedTriple>, LocalVocab>
   transformTriplesTemplate(
-      const EncodedIriManager& encodedIriManager, const Index::Vocab& vocab,
-      const VariableToColumnMap& variableColumns,
+      const IndexImpl& index, const VariableToColumnMap& variableColumns,
       const std::vector<SparqlTripleSimpleWithGraph>& triples);
   FRIEND_TEST(ExecuteUpdate, transformTriplesTemplate);
 

--- a/src/engine/GroupByImpl.cpp
+++ b/src/engine/GroupByImpl.cpp
@@ -813,7 +813,7 @@ std::optional<IdTable> GroupByImpl::computeGroupByObjectWithCount() const {
     return std::nullopt;
   }
   const auto& permutedTriple = indexScan->getPermutedTriple();
-  std::optional<Id> col0Id = permutedTriple[0]->toValueId(getIndex().getImpl());
+  std::optional<Id> col0Id = permutedTriple[0]->toValueId(getIndex());
   if (!col0Id.has_value()) {
     return std::nullopt;
   }

--- a/src/engine/GroupByImpl.cpp
+++ b/src/engine/GroupByImpl.cpp
@@ -813,9 +813,7 @@ std::optional<IdTable> GroupByImpl::computeGroupByObjectWithCount() const {
     return std::nullopt;
   }
   const auto& permutedTriple = indexScan->getPermutedTriple();
-  const auto& vocabulary = getIndex().getVocab();
-  std::optional<Id> col0Id =
-      permutedTriple[0]->toValueId(vocabulary, getIndex().encodedIriManager());
+  std::optional<Id> col0Id = permutedTriple[0]->toValueId(getIndex().getImpl());
   if (!col0Id.has_value()) {
     return std::nullopt;
   }

--- a/src/engine/HasPredicateScan.cpp
+++ b/src/engine/HasPredicateScan.cpp
@@ -282,7 +282,7 @@ Result HasPredicateScan::computeResult([[maybe_unused]] bool requestLaziness) {
   };
 
   auto getId = [this](const TripleComponent tc) {
-    std::optional<Id> id = tc.toValueId(getIndex().getImpl());
+    std::optional<Id> id = tc.toValueId(getIndex());
     if (!id.has_value()) {
       AD_THROW("The entity '" + tc.toRdfLiteral() +
                "' required by `ql:has-predicate` is not in the vocabulary.");

--- a/src/engine/HasPredicateScan.cpp
+++ b/src/engine/HasPredicateScan.cpp
@@ -282,8 +282,7 @@ Result HasPredicateScan::computeResult([[maybe_unused]] bool requestLaziness) {
   };
 
   auto getId = [this](const TripleComponent tc) {
-    std::optional<Id> id =
-        tc.toValueId(getIndex().getVocab(), getIndex().encodedIriManager());
+    std::optional<Id> id = tc.toValueId(getIndex().getImpl());
     if (!id.has_value()) {
       AD_THROW("The entity '" + tc.toRdfLiteral() +
                "' required by `ql:has-predicate` is not in the vocabulary.");

--- a/src/engine/Load.cpp
+++ b/src/engine/Load.cpp
@@ -150,7 +150,7 @@ Result Load::computeResultImpl([[maybe_unused]] bool requestLaziness) {
   LocalVocab lv;
   IdTable result{getResultWidth(), getExecutionContext()->getAllocator()};
   auto toId = [this, &lv](TripleComponent&& tc) {
-    return std::move(tc).toValueId(getIndex().getImpl(), lv);
+    return std::move(tc).toValueId(getIndex(), lv);
   };
   for (auto& triple : parser.parseAndReturnAllTriples()) {
     result.push_back(

--- a/src/engine/Load.cpp
+++ b/src/engine/Load.cpp
@@ -149,9 +149,8 @@ Result Load::computeResultImpl([[maybe_unused]] bool requestLaziness) {
   parser.setInputStream(body);
   LocalVocab lv;
   IdTable result{getResultWidth(), getExecutionContext()->getAllocator()};
-  auto toId = [this, &lv, &encodedIriManager](TripleComponent&& tc) {
-    return std::move(tc).toValueId(getIndex().getVocab(), lv,
-                                   encodedIriManager);
+  auto toId = [this, &lv](TripleComponent&& tc) {
+    return std::move(tc).toValueId(getIndex().getImpl(), lv);
   };
   for (auto& triple : parser.parseAndReturnAllTriples()) {
     result.push_back(

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -3258,9 +3258,7 @@ void QueryPlanner::GraphPatternPlanner::visitTransitivePath(
 void QueryPlanner::GraphPatternPlanner::visitPathSearch(
     parsedQuery::PathQuery& pathQuery) {
   const auto& index = planner_._qec->getIndex();
-  const auto& vocab = index.getVocab();
-  auto config =
-      pathQuery.toPathSearchConfiguration(vocab, index.encodedIriManager());
+  auto config = pathQuery.toPathSearchConfiguration(index.getImpl());
 
   // The path search requires a child graph pattern
   AD_CORRECTNESS_CHECK(pathQuery.childGraphPattern_.has_value());

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -3257,8 +3257,7 @@ void QueryPlanner::GraphPatternPlanner::visitTransitivePath(
 // _______________________________________________________________
 void QueryPlanner::GraphPatternPlanner::visitPathSearch(
     parsedQuery::PathQuery& pathQuery) {
-  const auto& index = planner_._qec->getIndex();
-  auto config = pathQuery.toPathSearchConfiguration(index.getImpl());
+  auto config = pathQuery.toPathSearchConfiguration(planner_._qec->getIndex());
 
   // The path search requires a child graph pattern
   AD_CORRECTNESS_CHECK(pathQuery.childGraphPattern_.has_value());

--- a/src/engine/Service.cpp
+++ b/src/engine/Service.cpp
@@ -263,8 +263,7 @@ void Service::writeJsonResult(const std::vector<std::string>& vars,
                                            localVocab)
                 : TripleComponent::UNDEF();
 
-        Id id = std::move(tc).toValueId(getIndex().getVocab(), *localVocab,
-                                        getIndex().encodedIriManager());
+        Id id = std::move(tc).toValueId(getIndex().getImpl(), *localVocab);
         idTable(rowIdx, colIdx) = id;
         if (id.getDatatype() == Datatype::LocalVocabIndex) {
           ++numLocalVocabPerColumn[colIdx];

--- a/src/engine/Service.cpp
+++ b/src/engine/Service.cpp
@@ -263,7 +263,7 @@ void Service::writeJsonResult(const std::vector<std::string>& vars,
                                            localVocab)
                 : TripleComponent::UNDEF();
 
-        Id id = std::move(tc).toValueId(getIndex().getImpl(), *localVocab);
+        Id id = std::move(tc).toValueId(getIndex(), *localVocab);
         idTable(rowIdx, colIdx) = id;
         if (id.getDatatype() == Datatype::LocalVocabIndex) {
           ++numLocalVocabPerColumn[colIdx];

--- a/src/engine/TransitivePathImpl.h
+++ b/src/engine/TransitivePathImpl.h
@@ -231,10 +231,9 @@ class TransitivePathImpl : public TransitivePathBase {
     LocalVocab targetHelper;
     const auto& index = getIndex();
     std::optional<Id> targetId =
-        target.isVariable()
-            ? std::nullopt
-            : std::optional{std::move(target).toValueId(
-                  index.getVocab(), targetHelper, index.encodedIriManager())};
+        target.isVariable() ? std::nullopt
+                            : std::optional{std::move(target).toValueId(
+                                  index.getImpl(), targetHelper)};
     bool sameVariableOnBothSides =
         !targetId.has_value() && lhs_.value_ == rhs_.value_;
     bool endsWithGraphVariable =
@@ -324,7 +323,7 @@ class TransitivePathImpl : public TransitivePathBase {
     // id -> var|id
     LocalVocab helperVocab;
     Id startId = TripleComponent{startSide.value_}.toValueId(
-        getIndex().getVocab(), helperVocab, getIndex().encodedIriManager());
+        getIndex().getImpl(), helperVocab);
     // Make sure we retrieve the Id from an IndexScan, so we don't have to pass
     // this LocalVocab around. If it's not present then no result needs to be
     // returned anyways. This also augments the id with matching graph ids.

--- a/src/engine/TransitivePathImpl.h
+++ b/src/engine/TransitivePathImpl.h
@@ -231,9 +231,9 @@ class TransitivePathImpl : public TransitivePathBase {
     LocalVocab targetHelper;
     const auto& index = getIndex();
     std::optional<Id> targetId =
-        target.isVariable() ? std::nullopt
-                            : std::optional{std::move(target).toValueId(
-                                  index.getImpl(), targetHelper)};
+        target.isVariable()
+            ? std::nullopt
+            : std::optional{std::move(target).toValueId(index, targetHelper)};
     bool sameVariableOnBothSides =
         !targetId.has_value() && lhs_.value_ == rhs_.value_;
     bool endsWithGraphVariable =
@@ -322,8 +322,8 @@ class TransitivePathImpl : public TransitivePathBase {
     }
     // id -> var|id
     LocalVocab helperVocab;
-    Id startId = TripleComponent{startSide.value_}.toValueId(
-        getIndex().getImpl(), helperVocab);
+    Id startId =
+        TripleComponent{startSide.value_}.toValueId(getIndex(), helperVocab);
     // Make sure we retrieve the Id from an IndexScan, so we don't have to pass
     // this LocalVocab around. If it's not present then no result needs to be
     // returned anyways. This also augments the id with matching graph ids.

--- a/src/engine/Values.cpp
+++ b/src/engine/Values.cpp
@@ -134,7 +134,7 @@ void Values::writeValues(IdTable* idTablePtr, LocalVocab* localVocab) {
       const TripleComponent& tc = row[colIdx];
       // TODO<joka921> We don't want to move, but also don't want to
       // unconditionally copy.
-      Id id = TripleComponent{tc}.toValueId(getIndex().getImpl(), *localVocab);
+      Id id = TripleComponent{tc}.toValueId(getIndex(), *localVocab);
       idTable(rowIdx, colIdx) = id;
       if (id.getDatatype() == Datatype::LocalVocabIndex) {
         ++numLocalVocabPerColumn[colIdx];

--- a/src/engine/Values.cpp
+++ b/src/engine/Values.cpp
@@ -134,8 +134,7 @@ void Values::writeValues(IdTable* idTablePtr, LocalVocab* localVocab) {
       const TripleComponent& tc = row[colIdx];
       // TODO<joka921> We don't want to move, but also don't want to
       // unconditionally copy.
-      Id id = TripleComponent{tc}.toValueId(getIndex().getVocab(), *localVocab,
-                                            getIndex().encodedIriManager());
+      Id id = TripleComponent{tc}.toValueId(getIndex().getImpl(), *localVocab);
       idTable(rowIdx, colIdx) = id;
       if (id.getDatatype() == Datatype::LocalVocabIndex) {
         ++numLocalVocabPerColumn[colIdx];

--- a/src/engine/sparqlExpressions/LiteralExpression.h
+++ b/src/engine/sparqlExpressions/LiteralExpression.h
@@ -53,8 +53,7 @@ class LiteralExpression : public SparqlExpression {
       }
       TripleComponent tc{s};
       const auto& index = context->_qec.getIndex();
-      std::optional<Id> id =
-          tc.toValueId(index.getVocab(), index.encodedIriManager());
+      std::optional<Id> id = tc.toValueId(index.getImpl());
       IdOrLiteralOrIri result =
           id.has_value()
               ? IdOrLiteralOrIri{id.value()}

--- a/src/engine/sparqlExpressions/LiteralExpression.h
+++ b/src/engine/sparqlExpressions/LiteralExpression.h
@@ -52,8 +52,7 @@ class LiteralExpression : public SparqlExpression {
         return *ptr;
       }
       TripleComponent tc{s};
-      const auto& index = context->_qec.getIndex();
-      std::optional<Id> id = tc.toValueId(index.getImpl());
+      std::optional<Id> id = tc.toValueId(context->_qec.getIndex());
       IdOrLiteralOrIri result =
           id.has_value()
               ? IdOrLiteralOrIri{id.value()}

--- a/src/index/DeltaTriples.cpp
+++ b/src/index/DeltaTriples.cpp
@@ -234,8 +234,7 @@ DeltaTriples::Triples DeltaTriples::makeInternalTriples(const Triples& triples,
     languagePredicate_ =
         TripleComponent{
             ad_utility::triple_component::Iri::fromIriref(LANGUAGE_PREDICATE)}
-            .toValueId(index_.getVocab(), localVocab_,
-                       index_.encodedIriManager());
+            .toValueId(index_, localVocab_);
   }
   ad_utility::HashSet<Id> addedObjects;
   for (const auto& triple : triples) {
@@ -261,7 +260,7 @@ DeltaTriples::Triples DeltaTriples::makeInternalTriples(const Triples& triples,
     auto specialPredicate =
         ad_utility::convertToLanguageTaggedPredicate(predicate, langtag);
     Id specialId = TripleComponent{std::move(specialPredicate)}.toValueId(
-        index_.getVocab(), localVocab_, index_.encodedIriManager());
+        index_, localVocab_);
     // Extra triple `<subject> @language@<predicate> "object"@language`.
     internalTriples.push_back(
         IdTriple<0>{std::array{ids.at(0), specialId, objectId, ids.at(3)}});
@@ -273,8 +272,7 @@ DeltaTriples::Triples DeltaTriples::makeInternalTriples(const Triples& triples,
     Id langtagId =
         languageTagCache_.getOrCompute(langtag, [this](const std::string& tag) {
           return TripleComponent{ad_utility::convertLangtagToEntityUri(tag)}
-              .toValueId(index_.getVocab(), localVocab_,
-                         index_.encodedIriManager());
+              .toValueId(index_, localVocab_);
         });
 
     // Because we don't track the exact counts of existing objects, we just

--- a/src/index/Index.cpp
+++ b/src/index/Index.cpp
@@ -48,13 +48,6 @@ ad_utility::BlankNodeManager* Index::getBlankNodeManager() const {
 
 // ____________________________________________________________________________
 size_t Index::getCardinality(
-    const TripleComponent& comp, Permutation::Enum p,
-    const LocatedTriplesState& locatedTriplesState) const {
-  return pimpl_->getCardinality(comp, p, locatedTriplesState);
-}
-
-// ____________________________________________________________________________
-size_t Index::getCardinality(
     Id id, Permutation::Enum p,
     const LocatedTriplesState& locatedTriplesState) const {
   return pimpl_->getCardinality(id, p, locatedTriplesState);

--- a/src/index/Index.h
+++ b/src/index/Index.h
@@ -122,9 +122,6 @@ class Index {
   // RDF RETRIEVAL
   // --------------------------------------------------------------------------
   [[nodiscard]] size_t getCardinality(
-      const TripleComponent& comp, Permutation::Enum permutation,
-      const LocatedTriplesState& locatedTriplesState) const;
-  [[nodiscard]] size_t getCardinality(
       Id id, Permutation::Enum permutation,
       const LocatedTriplesState& locatedTriplesState) const;
 

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -1698,8 +1698,7 @@ size_t IndexImpl::getCardinality(
   if (comp == QLEVER_INTERNAL_TEXT_MATCH_PREDICATE) {
     return TEXT_PREDICATE_CARDINALITY_ESTIMATE;
   }
-  if (std::optional<Id> relId =
-          comp.toValueId(getVocab(), encodedIriManager())) {
+  if (std::optional<Id> relId = comp.toValueId(*this)) {
     return getCardinality(relId.value(), permutation, locatedTriplesState);
   }
   return 0;
@@ -1727,7 +1726,7 @@ Index::Vocab::PrefixRanges IndexImpl::prefixRanges(
 std::vector<float> IndexImpl::getMultiplicities(
     const TripleComponent& key, const Permutation& permutation,
     const LocatedTriplesState& locatedTriplesState) const {
-  if (auto keyId = key.toValueId(getVocab(), encodedIriManager())) {
+  if (auto keyId = key.toValueId(*this)) {
     auto meta = permutation.getMetadata(keyId.value(), locatedTriplesState);
     if (meta.has_value()) {
       return {meta.value().getCol1Multiplicity(),

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -1687,24 +1687,6 @@ size_t IndexImpl::getCardinality(
 }
 
 // ___________________________________________________________________________
-size_t IndexImpl::getCardinality(
-    const TripleComponent& comp, Permutation::Enum permutation,
-    const LocatedTriplesState& locatedTriplesState) const {
-  // TODO<joka921> This special case is only relevant for the `PSO` and `POS`
-  // permutations, but this internal predicate should never appear in subjects
-  // or objects anyway.
-  // TODO<joka921> Find out what the effect of this special case is for the
-  // query planning.
-  if (comp == QLEVER_INTERNAL_TEXT_MATCH_PREDICATE) {
-    return TEXT_PREDICATE_CARDINALITY_ESTIMATE;
-  }
-  if (std::optional<Id> relId = comp.toValueId(*this)) {
-    return getCardinality(relId.value(), permutation, locatedTriplesState);
-  }
-  return 0;
-}
-
-// ___________________________________________________________________________
 RdfsVocabulary::AccessReturnType IndexImpl::indexToString(VocabIndex id) const {
   return vocab_[id];
 }

--- a/src/index/ScanSpecification.cpp
+++ b/src/index/ScanSpecification.cpp
@@ -12,8 +12,7 @@ namespace {
 // Helper function to turn a triple component into a `ValueId`.
 Id getNonOptionalId(TripleComponent tripleComponent, const IndexImpl& index,
                     LocalVocab& localVocab) {
-  return std::move(tripleComponent)
-      .toValueId(index.getVocab(), localVocab, index.encodedIriManager());
+  return std::move(tripleComponent).toValueId(index, localVocab);
 }
 
 }  // namespace

--- a/src/parser/PathQuery.cpp
+++ b/src/parser/PathQuery.cpp
@@ -68,8 +68,7 @@ void PathQuery::addParameter(const SparqlTriple& triple) {
 
 // ____________________________________________________________________________
 std::variant<Variable, std::vector<Id>> PathQuery::toSearchSide(
-    std::vector<TripleComponent> side, const Index::Vocab& vocab,
-    const EncodedIriManager& encodedIriManager) const {
+    std::vector<TripleComponent> side, const IndexImpl& index) const {
   if (side.size() == 1 && side[0].isVariable()) {
     return side[0].getVariable();
   } else {
@@ -80,7 +79,7 @@ std::variant<Variable, std::vector<Id>> PathQuery::toSearchSide(
             "Only one variable is allowed per search side");
       }
       LocalVocab lv;
-      auto id = TripleComponent{comp}.toValueId(vocab, lv, encodedIriManager);
+      auto id = TripleComponent{comp}.toValueId(index, lv);
       if (id.getDatatype() == Datatype::LocalVocabIndex) {
         throw PathSearchException("No vocabulary entry for " + comp.toString());
       } else {
@@ -93,10 +92,9 @@ std::variant<Variable, std::vector<Id>> PathQuery::toSearchSide(
 
 // ____________________________________________________________________________
 PathSearchConfiguration PathQuery::toPathSearchConfiguration(
-    const Index::Vocab& vocab,
-    const EncodedIriManager& encodedIriManager) const {
-  auto sources = toSearchSide(sources_, vocab, encodedIriManager);
-  auto targets = toSearchSide(targets_, vocab, encodedIriManager);
+    const IndexImpl& index) const {
+  auto sources = toSearchSide(sources_, index);
+  auto targets = toSearchSide(targets_, index);
 
   if (!start_.has_value()) {
     throw PathSearchException("Missing parameter <start> in path search.");

--- a/src/parser/PathQuery.h
+++ b/src/parser/PathQuery.h
@@ -60,12 +60,12 @@ struct PathQuery : MagicServiceQuery {
    *
    * @param side A vector of TripleComponents, containing either exactly one
    *             Variable or zero or more ValueIds
-   * @param vocab A Vocabulary containing the Ids of the TripleComponents.
-   *              The Vocab is only used if the given vector contains IRIs.
+   * @param index The IndexImpl instance containing the vocabulary containing
+   * the Ids of the TripleComponents. The Vocab is only used if the given vector
+   * contains IRIs.
    */
   std::variant<Variable, std::vector<Id>> toSearchSide(
-      std::vector<TripleComponent> side, const Index::Vocab& vocab,
-      const EncodedIriManager& encodedIriManager) const;
+      std::vector<TripleComponent> side, const IndexImpl& index) const;
 
   /**
    * @brief Convert this PathQuery into a PathSearchConfiguration object.
@@ -74,13 +74,12 @@ struct PathQuery : MagicServiceQuery {
    * A PathSearchException is thrown if required parameters are missing.
    * The required parameters are start, end, pathColumn and edgeColumn.
    *
-   * @param vocab A vocab containing the Ids of the IRIs in
-   *              sources_ and targets_
+   * @param index The IndexImpl instance containing the vocabulary containing
+   * the Ids of the IRIs in sources_ and targets_
    * @return A valid PathSearchConfiguration
    */
   PathSearchConfiguration toPathSearchConfiguration(
-      const Index::Vocab& vocab,
-      const EncodedIriManager& encodedIriManager) const;
+      const IndexImpl& index) const;
 
   constexpr std::string_view name() const override { return "path search"; };
 };

--- a/src/parser/TripleComponent.cpp
+++ b/src/parser/TripleComponent.cpp
@@ -136,7 +136,7 @@ std::optional<Id> TripleComponent::toValueId(const IndexImpl& index) const {
 Id TripleComponent::toValueId(const IndexImpl& index,
                               LocalVocab& localVocab) && {
   auto idOrBounds = toValueIdOrBounds(index);
-  if (auto* id = std::get_if<Id>(&idOrBounds)) {
+  if (const auto* id = std::get_if<Id>(&idOrBounds)) {
     return *id;
   }
   using Bounds = std::pair<VocabIndex, VocabIndex>;
@@ -146,7 +146,7 @@ Id TripleComponent::toValueId(const IndexImpl& index,
   // which we look up in (and potentially add to) our local vocabulary.
   AD_CORRECTNESS_CHECK(isLiteral() || isIri());
   using LiteralOrIri = ad_utility::triple_component::LiteralOrIri;
-  auto moveWord = [&]() -> LiteralOrIri {
+  auto moveWord = [&]() {
     if (isLiteral()) {
       return LiteralOrIri{std::move(getLiteral())};
     } else {

--- a/src/parser/TripleComponent.cpp
+++ b/src/parser/TripleComponent.cpp
@@ -10,8 +10,8 @@
 #include <absl/strings/str_cat.h>
 
 #include "engine/ExportQueryExecutionTrees.h"
-#include "global/Constants.h"
 #include "index/ExportIds.h"
+#include "index/IndexImpl.h"
 #include "rdfTypes/GeoPoint.h"
 #include "util/GeoSparqlHelpers.h"
 
@@ -102,4 +102,58 @@ std::string TripleComponent::toRdfLiteral() const {
                              .value();
     return absl::StrCat("\"", value, "\"^^<", type, ">");
   }
+}
+
+// _____________________________________________________________________________
+std::variant<Id, std::pair<VocabIndex, VocabIndex>>
+TripleComponent::toValueIdOrBounds(const IndexImpl& index) const {
+  AD_CONTRACT_CHECK(!isString());
+  std::optional<Id> vid = toValueIdIfNotString(&index.encodedIriManager());
+  if (vid != std::nullopt) {
+    return vid.value();
+  }
+  AD_CORRECTNESS_CHECK(isLiteral() || isIri());
+  const std::string& content = isLiteral()
+                                   ? getLiteral().toStringRepresentation()
+                                   : getIri().toStringRepresentation();
+  auto [lower, upper] = index.getVocab().getPositionOfWord(content);
+  if (lower != upper) {
+    return Id::makeFromVocabIndex(lower);
+  }
+  return std::pair(lower, upper);
+}
+
+// _____________________________________________________________________________
+std::optional<Id> TripleComponent::toValueId(const IndexImpl& index) const {
+  auto idOrBounds = toValueIdOrBounds(index);
+  if (auto* id = std::get_if<Id>(&idOrBounds)) {
+    return *id;
+  }
+  return std::nullopt;
+}
+
+// _____________________________________________________________________________
+Id TripleComponent::toValueId(const IndexImpl& index,
+                              LocalVocab& localVocab) && {
+  auto idOrBounds = toValueIdOrBounds(index);
+  if (auto* id = std::get_if<Id>(&idOrBounds)) {
+    return *id;
+  }
+  using Bounds = std::pair<VocabIndex, VocabIndex>;
+  AD_CORRECTNESS_CHECK(std::holds_alternative<Bounds>(idOrBounds));
+  auto [lower, upper] = std::get<Bounds>(idOrBounds);
+  // If `toValueId` could not convert to `Id`, we have a Literal or Iri,
+  // which we look up in (and potentially add to) our local vocabulary.
+  AD_CORRECTNESS_CHECK(isLiteral() || isIri());
+  using LiteralOrIri = ad_utility::triple_component::LiteralOrIri;
+  auto moveWord = [&]() -> LiteralOrIri {
+    if (isLiteral()) {
+      return LiteralOrIri{std::move(getLiteral())};
+    } else {
+      return LiteralOrIri{std::move(getIri())};
+    }
+  };
+  return Id::makeFromLocalVocabIndex(localVocab.getIndexAndAddIfNotContained(
+      LocalVocabEntry(moveWord(), Id::makeFromVocabIndex(lower),
+                      Id::makeFromVocabIndex(upper))));
 }

--- a/src/parser/TripleComponent.h
+++ b/src/parser/TripleComponent.h
@@ -25,6 +25,8 @@
 #include "util/Exception.h"
 #include "util/Forward.h"
 
+class IndexImpl;
+
 namespace ad_utility::detail {
 
 template <typename T, typename U>
@@ -217,34 +219,11 @@ class TripleComponent {
   // Convert the `TripleComponent` to an `Id`. If the `TripleComponent` is a
   // literal or IRI, resolve using the `vocabulary`. If they are not found in
   // the vocabulary, return the positions of the two neighboring entries.
-  template <typename Vocabulary>
   [[nodiscard]] std::variant<Id, std::pair<VocabIndex, VocabIndex>>
-  toValueIdOrBounds(const Vocabulary& vocabulary,
-                    const EncodedIriManager& evManager) const {
-    AD_CONTRACT_CHECK(!isString());
-    std::optional<Id> vid = toValueIdIfNotString(&evManager);
-    if (vid != std::nullopt) return vid.value();
-    AD_CORRECTNESS_CHECK(isLiteral() || isIri());
-    const std::string& content = isLiteral()
-                                     ? getLiteral().toStringRepresentation()
-                                     : getIri().toStringRepresentation();
-    auto [lower, upper] = vocabulary.getPositionOfWord(content);
-    if (lower != upper) {
-      return Id::makeFromVocabIndex(lower);
-    }
-    return std::pair(lower, upper);
-  }
+  toValueIdOrBounds(const IndexImpl& index) const;
 
   // Like `toValueIdOrBounds`, but returns `std::nullopt` if not found.
-  template <typename Vocabulary>
-  [[nodiscard]] std::optional<Id> toValueId(
-      const Vocabulary& vocabulary, const EncodedIriManager& evManager) const {
-    auto idOrBounds = toValueIdOrBounds(vocabulary, evManager);
-    if (auto* id = std::get_if<Id>(&idOrBounds)) {
-      return *id;
-    }
-    return std::nullopt;
-  }
+  [[nodiscard]] std::optional<Id> toValueId(const IndexImpl& index) const;
 
   // Like `toValueIdOrBounds`, but also take the given `LocalVocab` into
   // account. If this `TripleComponent` is neither found in `vocabulary` nor in
@@ -255,32 +234,7 @@ class TripleComponent {
   // `TripleComponent` object is created solely to call this method and we want
   // to avoid copying the literal or IRI when passing it to the local
   // vocabulary.
-  template <typename Vocabulary>
-  [[nodiscard]] Id toValueId(const Vocabulary& vocabulary,
-                             LocalVocab& localVocab,
-                             const EncodedIriManager& encodedIriManager) && {
-    auto idOrBounds = toValueIdOrBounds(vocabulary, encodedIriManager);
-    if (auto* id = std::get_if<Id>(&idOrBounds)) {
-      return *id;
-    }
-    using Bounds = std::pair<VocabIndex, VocabIndex>;
-    AD_CORRECTNESS_CHECK(std::holds_alternative<Bounds>(idOrBounds));
-    auto [lower, upper] = std::get<Bounds>(idOrBounds);
-    // If `toValueId` could not convert to `Id`, we have a Literal or Iri,
-    // which we look up in (and potentially add to) our local vocabulary.
-    AD_CORRECTNESS_CHECK(isLiteral() || isIri());
-    using LiteralOrIri = ad_utility::triple_component::LiteralOrIri;
-    auto moveWord = [&]() -> LiteralOrIri {
-      if (isLiteral()) {
-        return LiteralOrIri{std::move(getLiteral())};
-      } else {
-        return LiteralOrIri{std::move(getIri())};
-      }
-    };
-    return Id::makeFromLocalVocabIndex(localVocab.getIndexAndAddIfNotContained(
-        LocalVocabEntry(moveWord(), Id::makeFromVocabIndex(lower),
-                        Id::makeFromVocabIndex(upper))));
-  }
+  [[nodiscard]] Id toValueId(const IndexImpl& index, LocalVocab& localVocab) &&;
 
   // Human-readable output. Is used for debugging, testing, and for the creation
   // of descriptors and cache keys.

--- a/test/CompressedRelationsTest.cpp
+++ b/test/CompressedRelationsTest.cpp
@@ -1048,7 +1048,7 @@ TEST(CompressedRelationReader, getFirstAndLastTripleIgnoringGraph) {
 
   auto getId = [&index](std::string_view iri) {
     return TripleComponent{ad_utility::triple_component::Iri::fromIriref(iri)}
-        .toValueId(index.getImpl())
+        .toValueId(index)
         .value();
   };
   auto a = getId("<a>");

--- a/test/CompressedRelationsTest.cpp
+++ b/test/CompressedRelationsTest.cpp
@@ -1048,7 +1048,7 @@ TEST(CompressedRelationReader, getFirstAndLastTripleIgnoringGraph) {
 
   auto getId = [&index](std::string_view iri) {
     return TripleComponent{ad_utility::triple_component::Iri::fromIriref(iri)}
-        .toValueId(index.getVocab(), index.encodedIriManager())
+        .toValueId(index.getImpl())
         .value();
   };
   auto a = getId("<a>");

--- a/test/DeltaTriplesTest.cpp
+++ b/test/DeltaTriplesTest.cpp
@@ -79,9 +79,9 @@ class DeltaTriplesTest : public ::testing::Test {
   // Make `IdTriple` from given Turtle input (the LocalVocab is not `const`
   // because we might change it).
   std::vector<IdTriple<0>> makeIdTriples(
-      const Index::Vocab& vocab, LocalVocab& localVocab,
+      const IndexImpl& index, LocalVocab& localVocab,
       const std::vector<std::string>& turtles) {
-    auto toID = [&localVocab, &vocab](TurtleTriple triple) {
+    auto toID = [&localVocab, &index](TurtleTriple triple) {
       // The RdfStringParser returns temporary internal IDs for the default
       // graph. Detect this and overwrite with the Iri which gets looked up for
       // the correct ID.
@@ -90,14 +90,11 @@ class DeltaTriplesTest : public ::testing::Test {
             TripleComponent::Iri::fromIriref(DEFAULT_GRAPH_IRI));
       }
       std::array<Id, 4> ids{
-          std::move(triple.subject_)
-              .toValueId(vocab, localVocab, *encodedIriManager()),
+          std::move(triple.subject_).toValueId(index, localVocab),
           std::move(TripleComponent(triple.predicate_))
-              .toValueId(vocab, localVocab, *encodedIriManager()),
-          std::move(triple.object_)
-              .toValueId(vocab, localVocab, *encodedIriManager()),
-          std::move(triple.graphIri_)
-              .toValueId(vocab, localVocab, *encodedIriManager())};
+              .toValueId(index, localVocab),
+          std::move(triple.object_).toValueId(index, localVocab),
+          std::move(triple.graphIri_).toValueId(index, localVocab)};
       return IdTriple<0>(ids);
     };
     return ad_utility::transform(
@@ -112,17 +109,17 @@ TEST_F(DeltaTriplesTest, clear) {
       std::make_shared<ad_utility::CancellationHandle<>>();
 
   DeltaTriples deltaTriples(testQec->getIndex());
-  auto& vocab = testQec->getIndex().getVocab();
+  auto& index = testQec->getIndex().getImpl();
   auto& localVocab = deltaTriples.localVocab();
 
   EXPECT_THAT(deltaTriples, NumTriples(0, 0, 0));
 
   // Insert then clear.
   deltaTriples.insertTriples(
-      cancellationHandle, makeIdTriples(vocab, localVocab, {"<a> <UPP> <A>"}));
+      cancellationHandle, makeIdTriples(index, localVocab, {"<a> <UPP> <A>"}));
   deltaTriples.insertInternalTriplesForTesting(
       cancellationHandle,
-      makeIdTriples(vocab, localVocab,
+      makeIdTriples(index, localVocab,
                     {"<internal-a> <internal-UPP> <internal-A>"}));
 
   EXPECT_THAT(deltaTriples, NumTriples(1, 0, 1, 1, 0));
@@ -133,18 +130,18 @@ TEST_F(DeltaTriplesTest, clear) {
 
   // Delete, insert and then clear.
   deltaTriples.deleteTriples(
-      cancellationHandle, makeIdTriples(vocab, localVocab, {"<A> <low> <a>"}));
+      cancellationHandle, makeIdTriples(index, localVocab, {"<A> <low> <a>"}));
   deltaTriples.deleteInternalTriplesForTesting(
       cancellationHandle,
-      makeIdTriples(vocab, localVocab,
+      makeIdTriples(index, localVocab,
                     {"<internal-A> <internal-low> <internal-a>"}));
   EXPECT_THAT(deltaTriples, NumTriples(0, 1, 1, 0, 1));
 
   deltaTriples.insertTriples(
-      cancellationHandle, makeIdTriples(vocab, localVocab, {"<a> <UPP> <A>"}));
+      cancellationHandle, makeIdTriples(index, localVocab, {"<a> <UPP> <A>"}));
   deltaTriples.insertInternalTriplesForTesting(
       cancellationHandle,
-      makeIdTriples(vocab, localVocab,
+      makeIdTriples(index, localVocab,
                     {"<internal-a> <internal-UPP> <internal-A>"}));
 
   EXPECT_THAT(deltaTriples, NumTriples(1, 1, 2, 1, 1));
@@ -156,7 +153,7 @@ TEST_F(DeltaTriplesTest, clear) {
 
 TEST_F(DeltaTriplesTest, insertTriplesAndDeleteTriples) {
   DeltaTriples deltaTriples(testQec->getIndex());
-  auto& vocab = testQec->getIndex().getVocab();
+  auto& index = testQec->getIndex().getImpl();
   auto& localVocab = deltaTriples.localVocab();
 
   auto cancellationHandle =
@@ -166,7 +163,7 @@ TEST_F(DeltaTriplesTest, insertTriplesAndDeleteTriples) {
     return ad_utility::transform(map,
                                  [](const auto& item) { return item.first; });
   };
-  auto UnorderedTriplesAre = [&mapKeys, this, &vocab, &localVocab](
+  auto UnorderedTriplesAre = [&mapKeys, this, &index, &localVocab](
                                  [[maybe_unused]] auto isInternal,
                                  const std::vector<std::string>& triples)
       -> testing::Matcher<const ad_utility::HashMap<
@@ -176,7 +173,7 @@ TEST_F(DeltaTriplesTest, insertTriplesAndDeleteTriples) {
     return testing::ResultOf(
         "mapKeys(...)", [&mapKeys](const auto map) { return mapKeys(map); },
         testing::UnorderedElementsAreArray(
-            makeIdTriples(vocab, localVocab, triples)));
+            makeIdTriples(index, localVocab, triples)));
   };
   // A matcher that checks the state of a `DeltaTriples`:
   // - `numInserted()` and `numDeleted()` and the derived `getCounts()`
@@ -217,7 +214,7 @@ TEST_F(DeltaTriplesTest, insertTriplesAndDeleteTriples) {
   // Inserting triples. The triples being inserted must be sorted.
   deltaTriples.insertTriples(
       cancellationHandle,
-      makeIdTriples(vocab, localVocab, {"<A> <B> <C>", "<A> <B> <D>"}));
+      makeIdTriples(index, localVocab, {"<A> <B> <C>", "<A> <B> <D>"}));
   EXPECT_THAT(
       deltaTriples,
       StateIs(2, 0, 2, 0, 0, {"<A> <B> <C>", "<A> <B> <D>"}, {}, {}, {}));
@@ -225,7 +222,7 @@ TEST_F(DeltaTriplesTest, insertTriplesAndDeleteTriples) {
   // We only locate triples in a Block but don't resolve whether they exist.
   // Inserting triples that exist in the index works normally.
   deltaTriples.insertTriples(
-      cancellationHandle, makeIdTriples(vocab, localVocab, {"<A> <low> <a>"}));
+      cancellationHandle, makeIdTriples(index, localVocab, {"<A> <low> <a>"}));
   EXPECT_THAT(
       deltaTriples,
       StateIs(3, 0, 3, 0, 0, {"<A> <B> <C>", "<A> <B> <D>", "<A> <low> <a>"},
@@ -234,7 +231,7 @@ TEST_F(DeltaTriplesTest, insertTriplesAndDeleteTriples) {
   // Insert more triples.
   deltaTriples.insertTriples(
       cancellationHandle,
-      makeIdTriples(vocab, localVocab, {"<B> <C> <D>", "<B> <D> <C>"}));
+      makeIdTriples(index, localVocab, {"<B> <C> <D>", "<B> <D> <C>"}));
   EXPECT_THAT(deltaTriples,
               StateIs(5, 0, 5, 0, 0,
                       {"<A> <B> <C>", "<A> <B> <D>", "<B> <C> <D>",
@@ -243,7 +240,7 @@ TEST_F(DeltaTriplesTest, insertTriplesAndDeleteTriples) {
 
   // Inserting already inserted triples has no effect.
   deltaTriples.insertTriples(cancellationHandle,
-                             makeIdTriples(vocab, localVocab, {"<A> <B> <C>"}));
+                             makeIdTriples(index, localVocab, {"<A> <B> <C>"}));
   EXPECT_THAT(deltaTriples,
               StateIs(5, 0, 5, 0, 0,
                       {"<A> <B> <C>", "<A> <B> <D>", "<B> <C> <D>",
@@ -253,7 +250,7 @@ TEST_F(DeltaTriplesTest, insertTriplesAndDeleteTriples) {
   // Deleting a previously inserted triple removes it from the inserted
   // triples and adds it to the deleted ones.
   deltaTriples.deleteTriples(cancellationHandle,
-                             makeIdTriples(vocab, localVocab, {"<A> <B> <D>"}));
+                             makeIdTriples(index, localVocab, {"<A> <B> <D>"}));
   EXPECT_THAT(deltaTriples, StateIs(4, 1, 5, 0, 0,
                                     {"<A> <B> <C>", "<B> <C> <D>",
                                      "<A> <low> <a>", "<B> <D> <C>"},
@@ -262,7 +259,7 @@ TEST_F(DeltaTriplesTest, insertTriplesAndDeleteTriples) {
   // Deleting triples.
   deltaTriples.deleteTriples(
       cancellationHandle,
-      makeIdTriples(vocab, localVocab, {"<A> <next> <B>", "<B> <next> <C>"}));
+      makeIdTriples(index, localVocab, {"<A> <next> <B>", "<B> <next> <C>"}));
   EXPECT_THAT(
       deltaTriples,
       StateIs(4, 3, 7, 0, 0,
@@ -271,7 +268,7 @@ TEST_F(DeltaTriplesTest, insertTriplesAndDeleteTriples) {
 
   // Deleting non-existent triples.
   deltaTriples.deleteTriples(cancellationHandle,
-                             makeIdTriples(vocab, localVocab, {"<A> <B> <F>"}));
+                             makeIdTriples(index, localVocab, {"<A> <B> <F>"}));
   EXPECT_THAT(
       deltaTriples,
       StateIs(
@@ -288,7 +285,7 @@ TEST_F(DeltaTriplesTest, insertTriplesAndDeleteTriples) {
     AD_EXPECT_THROW_WITH_MESSAGE(
         deltaTriples.deleteTriples(
             cancellationHandle,
-            makeIdTriples(vocab, localVocab,
+            makeIdTriples(index, localVocab,
                           {"<C> <prev> <B>", "<B> <prev> <A>"})),
         testing::_);
   }
@@ -297,7 +294,7 @@ TEST_F(DeltaTriplesTest, insertTriplesAndDeleteTriples) {
   // Deleting triples.
   deltaTriples.deleteTriples(
       cancellationHandle,
-      makeIdTriples(vocab, localVocab, {"<B> <prev> <A>", "<C> <prev> <B>"}));
+      makeIdTriples(index, localVocab, {"<B> <prev> <A>", "<C> <prev> <B>"}));
   EXPECT_THAT(
       deltaTriples,
       StateIs(4, 6, 10, 0, 0,
@@ -308,7 +305,7 @@ TEST_F(DeltaTriplesTest, insertTriplesAndDeleteTriples) {
 
   // Deleting previously deleted triples.
   deltaTriples.deleteTriples(
-      cancellationHandle, makeIdTriples(vocab, localVocab, {"<A> <next> <B>"}));
+      cancellationHandle, makeIdTriples(index, localVocab, {"<A> <next> <B>"}));
   EXPECT_THAT(
       deltaTriples,
       StateIs(4, 6, 10, 0, 0,
@@ -319,7 +316,7 @@ TEST_F(DeltaTriplesTest, insertTriplesAndDeleteTriples) {
 
   // Inserting previously deleted triple.
   deltaTriples.insertTriples(cancellationHandle,
-                             makeIdTriples(vocab, localVocab, {"<A> <B> <F>"}));
+                             makeIdTriples(index, localVocab, {"<A> <B> <F>"}));
   EXPECT_THAT(deltaTriples,
               StateIs(5, 5, 10, 0, 0,
                       {"<A> <B> <C>", "<A> <B> <F>", "<B> <C> <D>",
@@ -331,7 +328,7 @@ TEST_F(DeltaTriplesTest, insertTriplesAndDeleteTriples) {
   // Insert new internal triple.
   deltaTriples.insertInternalTriplesForTesting(
       cancellationHandle,
-      makeIdTriples(vocab, localVocab,
+      makeIdTriples(index, localVocab,
                     {"<internal-A> <internal-B> <internal-F>"}));
   EXPECT_THAT(deltaTriples,
               StateIs(5, 5, 10, 1, 0,
@@ -344,7 +341,7 @@ TEST_F(DeltaTriplesTest, insertTriplesAndDeleteTriples) {
   // Remove "existing" internal triple.
   deltaTriples.deleteInternalTriplesForTesting(
       cancellationHandle,
-      makeIdTriples(vocab, localVocab,
+      makeIdTriples(index, localVocab,
                     {"<internal-C> <internal-D> <internal-E>"}));
   EXPECT_THAT(deltaTriples,
               StateIs(5, 5, 10, 1, 1,
@@ -358,7 +355,7 @@ TEST_F(DeltaTriplesTest, insertTriplesAndDeleteTriples) {
   // Remove previously inserted internal triple.
   deltaTriples.deleteInternalTriplesForTesting(
       cancellationHandle,
-      makeIdTriples(vocab, localVocab,
+      makeIdTriples(index, localVocab,
                     {"<internal-A> <internal-B> <internal-F>"}));
   EXPECT_THAT(deltaTriples,
               StateIs(5, 5, 10, 0, 2,
@@ -373,7 +370,7 @@ TEST_F(DeltaTriplesTest, insertTriplesAndDeleteTriples) {
   // Remove previously removes internal triple again.
   deltaTriples.deleteInternalTriplesForTesting(
       cancellationHandle,
-      makeIdTriples(vocab, localVocab,
+      makeIdTriples(index, localVocab,
                     {"<internal-C> <internal-D> <internal-E>"}));
   EXPECT_THAT(deltaTriples,
               StateIs(5, 5, 10, 0, 2,
@@ -388,7 +385,7 @@ TEST_F(DeltaTriplesTest, insertTriplesAndDeleteTriples) {
   // Inserting previously deleted internal triple.
   deltaTriples.insertInternalTriplesForTesting(
       cancellationHandle,
-      makeIdTriples(vocab, localVocab,
+      makeIdTriples(index, localVocab,
                     {"<internal-C> <internal-D> <internal-E>"}));
   EXPECT_THAT(deltaTriples,
               StateIs(5, 5, 10, 1, 1,
@@ -401,15 +398,14 @@ TEST_F(DeltaTriplesTest, insertTriplesAndDeleteTriples) {
 
   deltaTriples.clear();
   // Test internal language filter triples are inserted correctly.
-  auto toId = [this, &vocab, &localVocab](TripleComponent& component) {
-    return std::move(component).toValueId(
-        vocab, localVocab, testQec->getIndex().encodedIriManager());
+  auto toId = [this, &index, &localVocab](TripleComponent& component) {
+    return std::move(component).toValueId(index, localVocab);
   };
 
-  Id graphId = [&vocab]() {
+  Id graphId = [&index]() {
     auto graphOpt =
         TripleComponent(TripleComponent::Iri::fromIriref(DEFAULT_GRAPH_IRI))
-            .toValueId(vocab, *encodedIriManager());
+            .toValueId(index);
     AD_CORRECTNESS_CHECK(graphOpt.has_value());
     return graphOpt.value();
   }();
@@ -449,7 +445,7 @@ TEST_F(DeltaTriplesTest, insertTriplesAndDeleteTriples) {
 
   deltaTriples.insertTriples(
       cancellationHandle,
-      makeIdTriples(vocab, localVocab,
+      makeIdTriples(index, localVocab,
                     {"<a> <b> 1", "<a> <b> \"abc\"", "<a> <b> \"abc\"@de",
                      "<a> <b> \"abc\"@en",
                      "<a> <b> \"abc\"^^<http://example.com/datatype>",
@@ -485,7 +481,7 @@ TEST_F(DeltaTriplesTest, insertTriplesAndDeleteTriples) {
 
   deltaTriples.deleteTriples(
       cancellationHandle,
-      makeIdTriples(vocab, localVocab,
+      makeIdTriples(index, localVocab,
                     {"<a> <b> 1", "<a> <b> \"abc\"", "<a> <b> \"abc\"@de",
                      "<a> <b> \"abc\"@en",
                      "<a> <b> \"abc\"^^<http://example.com/datatype>",
@@ -521,10 +517,10 @@ TEST_F(DeltaTriplesTest, rewriteLocalVocabEntriesAndBlankNodes) {
   // that we can test that both occurrences are rewritten to the same new blank
   // node.
   DeltaTriples deltaTriples(testQec->getIndex());
-  auto& vocab = testQec->getIndex().getVocab();
+  auto& index = testQec->getIndex().getImpl();
   LocalVocab localVocabOutside;
   auto triples =
-      makeIdTriples(vocab, localVocabOutside, {"<A> <notInVocab> <B>"});
+      makeIdTriples(index, localVocabOutside, {"<A> <notInVocab> <B>"});
   AD_CORRECTNESS_CHECK(triples.size() == 1);
   triples[0].ids()[2] =
       Id::makeFromBlankNodeIndex(BlankNodeIndex::make(999'888'777));
@@ -593,8 +589,8 @@ TEST_F(DeltaTriplesTest, rewriteLocalVocabEntriesAndBlankNodes) {
 // _____________________________________________________________________________
 TEST_F(DeltaTriplesTest, DeltaTriplesManager) {
   // Preparation.
-  DeltaTriplesManager deltaTriplesManager(testQec->getIndex().getImpl());
-  auto& vocab = testQec->getIndex().getVocab();
+  auto& index = testQec->getIndex().getImpl();
+  DeltaTriplesManager deltaTriplesManager(index);
   auto cancellationHandle =
       std::make_shared<ad_utility::CancellationHandle<>>();
   std::vector<ad_utility::JThread> threads;
@@ -612,11 +608,11 @@ TEST_F(DeltaTriplesTest, DeltaTriplesManager) {
       // The first triple in both vectors is the same for all threads, the
       // others are exclusive to this thread via the `threadIdx`.
       auto triplesToInsert = makeIdTriples(
-          vocab, localVocab,
+          index, localVocab,
           {"<A> <B> <C>", absl::StrCat("<A> <B> <D", threadIdx, ">"),
            absl::StrCat("<A> <B> <E", threadIdx, ">")});
       auto triplesToDelete = makeIdTriples(
-          vocab, localVocab,
+          index, localVocab,
           {"<A> <A> <E>", absl::StrCat("<A> <B> <E", threadIdx, ">"),
            absl::StrCat("<A> <B> <F", threadIdx, ">")});
       // Insert the `triplesToInsert`.
@@ -706,7 +702,7 @@ TEST_F(DeltaTriplesTest, LocatedTriplesSharedState) {
                  testing::ElementsAre(m, m, m, m, m, m))));
   };
   DeltaTriples deltaTriples(testQec->getIndex());
-  auto& vocab = testQec->getIndex().getVocab();
+  auto& index = testQec->getIndex().getImpl();
   auto cancellationHandle =
       std::make_shared<ad_utility::CancellationHandle<>>();
 
@@ -725,7 +721,7 @@ TEST_F(DeltaTriplesTest, LocatedTriplesSharedState) {
 
   // Modifying the delta triples increases the index_.
   LocalVocab localVocab;
-  auto triplesToInsert = makeIdTriples(vocab, localVocab, {"<A> <B> <C>"});
+  auto triplesToInsert = makeIdTriples(index, localVocab, {"<A> <B> <C>"});
   deltaTriples.insertTriples(cancellationHandle, std::move(triplesToInsert));
 
   // Another transparent and copied snapshot.
@@ -1017,23 +1013,23 @@ TEST_F(DeltaTriplesTest, vacuum) {
   auto cancellationHandle =
       std::make_shared<ad_utility::CancellationHandle<>>();
   DeltaTriples deltaTriples(testQec->getIndex());
-  auto& vocab = testQec->getIndex().getVocab();
+  auto& index = testQec->getIndex().getImpl();
   LocalVocab localVocab;
 
   // Insertions of triples in the index.
   deltaTriples.insertTriples(
       cancellationHandle,
-      makeIdTriples(vocab, localVocab, {"<a> <upp> <A>", "<b> <upp> <B>"}));
+      makeIdTriples(index, localVocab, {"<a> <upp> <A>", "<b> <upp> <B>"}));
   // Deletions of triples not in the index.
   deltaTriples.deleteTriples(cancellationHandle,
-                             makeIdTriples(vocab, localVocab, {"<X> <Y> <Z>"}));
+                             makeIdTriples(index, localVocab, {"<X> <Y> <Z>"}));
   // Insertions of triples not in the index.
   deltaTriples.insertTriples(
       cancellationHandle,
-      makeIdTriples(vocab, localVocab, {"<a> <upp> <newval>"}));
+      makeIdTriples(index, localVocab, {"<a> <upp> <newval>"}));
   // Deletions of triples in the index.
   deltaTriples.deleteTriples(
-      cancellationHandle, makeIdTriples(vocab, localVocab, {"<a> <next> <b>"}));
+      cancellationHandle, makeIdTriples(index, localVocab, {"<a> <next> <b>"}));
 
   EXPECT_THAT(deltaTriples, NumTriples(3, 2, 5));
 

--- a/test/DeltaTriplesTest.cpp
+++ b/test/DeltaTriplesTest.cpp
@@ -398,7 +398,7 @@ TEST_F(DeltaTriplesTest, insertTriplesAndDeleteTriples) {
 
   deltaTriples.clear();
   // Test internal language filter triples are inserted correctly.
-  auto toId = [this, &index, &localVocab](TripleComponent& component) {
+  auto toId = [&index, &localVocab](TripleComponent& component) {
     return std::move(component).toValueId(index, localVocab);
   };
 

--- a/test/DeltaTriplesTest.cpp
+++ b/test/DeltaTriplesTest.cpp
@@ -109,7 +109,7 @@ TEST_F(DeltaTriplesTest, clear) {
       std::make_shared<ad_utility::CancellationHandle<>>();
 
   DeltaTriples deltaTriples(testQec->getIndex());
-  auto& index = testQec->getIndex().getImpl();
+  auto& index = testQec->getIndex();
   auto& localVocab = deltaTriples.localVocab();
 
   EXPECT_THAT(deltaTriples, NumTriples(0, 0, 0));
@@ -153,7 +153,7 @@ TEST_F(DeltaTriplesTest, clear) {
 
 TEST_F(DeltaTriplesTest, insertTriplesAndDeleteTriples) {
   DeltaTriples deltaTriples(testQec->getIndex());
-  auto& index = testQec->getIndex().getImpl();
+  auto& index = testQec->getIndex();
   auto& localVocab = deltaTriples.localVocab();
 
   auto cancellationHandle =
@@ -517,7 +517,7 @@ TEST_F(DeltaTriplesTest, rewriteLocalVocabEntriesAndBlankNodes) {
   // that we can test that both occurrences are rewritten to the same new blank
   // node.
   DeltaTriples deltaTriples(testQec->getIndex());
-  auto& index = testQec->getIndex().getImpl();
+  auto& index = testQec->getIndex();
   LocalVocab localVocabOutside;
   auto triples =
       makeIdTriples(index, localVocabOutside, {"<A> <notInVocab> <B>"});
@@ -589,7 +589,7 @@ TEST_F(DeltaTriplesTest, rewriteLocalVocabEntriesAndBlankNodes) {
 // _____________________________________________________________________________
 TEST_F(DeltaTriplesTest, DeltaTriplesManager) {
   // Preparation.
-  auto& index = testQec->getIndex().getImpl();
+  auto& index = testQec->getIndex();
   DeltaTriplesManager deltaTriplesManager(index);
   auto cancellationHandle =
       std::make_shared<ad_utility::CancellationHandle<>>();
@@ -702,7 +702,7 @@ TEST_F(DeltaTriplesTest, LocatedTriplesSharedState) {
                  testing::ElementsAre(m, m, m, m, m, m))));
   };
   DeltaTriples deltaTriples(testQec->getIndex());
-  auto& index = testQec->getIndex().getImpl();
+  auto& index = testQec->getIndex();
   auto cancellationHandle =
       std::make_shared<ad_utility::CancellationHandle<>>();
 

--- a/test/ExecuteUpdateTest.cpp
+++ b/test/ExecuteUpdateTest.cpp
@@ -470,8 +470,8 @@ TEST(ExecuteUpdate, transformTriplesTemplate) {
               AD_CURRENT_SOURCE_LOC()) {
         auto loc = generateLocationTrace(sourceLocation);
         auto [transformedTriples, localVocab] =
-            ExecuteUpdate::transformTriplesTemplate(index.getImpl(),
-                                                    variableColumns, triples);
+            ExecuteUpdate::transformTriplesTemplate(index, variableColumns,
+                                                    triples);
         const auto transformedTriplesMatchers = ad_utility::transform(
             expectedTransformedTriples,
             [&localVocab, &TripleComponentMatcher](const auto& expectedTriple) {
@@ -492,8 +492,8 @@ TEST(ExecuteUpdate, transformTriplesTemplate) {
                    AD_CURRENT_SOURCE_LOC()) {
         auto loc = generateLocationTrace(sourceLocation);
         AD_EXPECT_THROW_WITH_MESSAGE(
-            ExecuteUpdate::transformTriplesTemplate(
-                index.getImpl(), variableColumns, std::move(triples)),
+            ExecuteUpdate::transformTriplesTemplate(index, variableColumns,
+                                                    std::move(triples)),
             messageMatcher);
       };
   // Transforming an empty vector of template results in no `TransformedTriple`s

--- a/test/ExecuteUpdateTest.cpp
+++ b/test/ExecuteUpdateTest.cpp
@@ -419,8 +419,6 @@ TEST(ExecuteUpdate, transformTriplesTemplate) {
   indexConfig.encodedIriManager = encodedIriManager;
   Index index = ad_utility::testing::makeTestIndex(
       "_ExecuteUppdateTest_transformTriplesTemplate", indexConfig);
-  // We need a non-const vocab for the test.
-  auto& vocab = const_cast<Index::Vocab&>(index.getVocab());
 
   // Helpers
   using namespace ::testing;
@@ -463,7 +461,7 @@ TEST(ExecuteUpdate, transformTriplesTemplate) {
         component);
   };
   auto expectTransformTriplesTemplate =
-      [&vocab, &TripleComponentMatcher, &encodedIriManager](
+      [&index, &TripleComponentMatcher](
           const VariableToColumnMap& variableColumns,
           std::vector<SparqlTripleSimpleWithGraph>&& triples,
           const std::vector<std::array<TripleComponentT, 4>>&
@@ -472,7 +470,7 @@ TEST(ExecuteUpdate, transformTriplesTemplate) {
               AD_CURRENT_SOURCE_LOC()) {
         auto loc = generateLocationTrace(sourceLocation);
         auto [transformedTriples, localVocab] =
-            ExecuteUpdate::transformTriplesTemplate(encodedIriManager, vocab,
+            ExecuteUpdate::transformTriplesTemplate(index.getImpl(),
                                                     variableColumns, triples);
         const auto transformedTriplesMatchers = ad_utility::transform(
             expectedTransformedTriples,
@@ -487,16 +485,15 @@ TEST(ExecuteUpdate, transformTriplesTemplate) {
                     ElementsAreArray(transformedTriplesMatchers));
       };
   auto expectTransformTriplesTemplateFails =
-      [&vocab, &encodedIriManager](
-          const VariableToColumnMap& variableColumns,
-          std::vector<SparqlTripleSimpleWithGraph>&& triples,
-          const Matcher<const std::string&>& messageMatcher,
-          ad_utility::source_location sourceLocation =
-              AD_CURRENT_SOURCE_LOC()) {
+      [&index](const VariableToColumnMap& variableColumns,
+               std::vector<SparqlTripleSimpleWithGraph>&& triples,
+               const Matcher<const std::string&>& messageMatcher,
+               ad_utility::source_location sourceLocation =
+                   AD_CURRENT_SOURCE_LOC()) {
         auto loc = generateLocationTrace(sourceLocation);
         AD_EXPECT_THROW_WITH_MESSAGE(
             ExecuteUpdate::transformTriplesTemplate(
-                encodedIriManager, vocab, variableColumns, std::move(triples)),
+                index.getImpl(), variableColumns, std::move(triples)),
             messageMatcher);
       };
   // Transforming an empty vector of template results in no `TransformedTriple`s

--- a/test/LoadTest.cpp
+++ b/test/LoadTest.cpp
@@ -153,8 +153,7 @@ TEST_F(LoadTest, computeResult) {
         for (const auto& row : expectedIdTable) {
           auto& idVecRow = idVector.emplace_back();
           for (auto& field : row) {
-            const auto& idx = testQec->getIndex().getImpl();
-            auto idOpt = field.toValueId(idx);
+            auto idOpt = field.toValueId(testQec->getIndex());
             if (!idOpt) {
               ASSERT_THAT(field.isLiteral() || field.isIri(),
                           testing::IsTrue());

--- a/test/LoadTest.cpp
+++ b/test/LoadTest.cpp
@@ -153,9 +153,8 @@ TEST_F(LoadTest, computeResult) {
         for (const auto& row : expectedIdTable) {
           auto& idVecRow = idVector.emplace_back();
           for (auto& field : row) {
-            const auto& idx = testQec->getIndex();
-            auto idOpt =
-                field.toValueId(idx.getVocab(), idx.encodedIriManager());
+            const auto& idx = testQec->getIndex().getImpl();
+            auto idOpt = field.toValueId(idx);
             if (!idOpt) {
               ASSERT_THAT(field.isLiteral() || field.isIri(),
                           testing::IsTrue());

--- a/test/LocatedTriplesTest.cpp
+++ b/test/LocatedTriplesTest.cpp
@@ -995,9 +995,8 @@ TEST_F(LocatedTriplesTest, identifyTriplesToVacuum) {
       std::make_shared<ad_utility::CancellationHandle<>>();
   using TC = TripleComponent;
   auto Iri = ad_utility::triple_component::Iri::fromIriref;
-  auto getId = [&lv, &qec](TC&& tc) {
-    EncodedIriManager mgr;
-    return std::move(tc).toValueId(qec->getIndex().getVocab(), lv, mgr);
+  auto getId = [&lv, &index](TC&& tc) {
+    return std::move(tc).toValueId(index, lv);
   };
   auto defaultGraph = getId(Iri(DEFAULT_GRAPH_IRI));
   auto makeTriple = [&getId, &defaultGraph](TC&& s, TC&& p,

--- a/test/TripleComponentTest.cpp
+++ b/test/TripleComponentTest.cpp
@@ -204,25 +204,25 @@ TEST(TripleComponent, toValueId) {
   TripleComponent tc = iri("<x>");
   auto getId = makeGetId(qec->getIndex());
   Id id = getId("<x>");
-  ASSERT_EQ(tc.toValueId(index.getImpl()).value(), id);
+  ASSERT_EQ(tc.toValueId(index).value(), id);
 
   tc = lit("\"alpha\"");
   id = getId("\"alpha\"");
-  EXPECT_EQ(tc.toValueId(index.getImpl()).value(), id);
+  EXPECT_EQ(tc.toValueId(index).value(), id);
 
   tc = iri("<notexisting>");
-  ASSERT_FALSE(tc.toValueId(index.getImpl()).has_value());
+  ASSERT_FALSE(tc.toValueId(index).has_value());
   tc = 42;
 
   ASSERT_EQ(tc.toValueIdIfNotString(encodedIriManager()).value(), I(42));
 
   tc = iri(HAS_PATTERN_PREDICATE);
-  ASSERT_EQ(tc.toValueId(index.getImpl()).value(),
+  ASSERT_EQ(tc.toValueId(index).value(),
             getId(std::string{HAS_PATTERN_PREDICATE}));
 
   auto lv = LocalVocab();
   auto expectLocalVocab = [&lv, &index](TripleComponent tc, size_t pos) {
-    auto id = std::move(tc).toValueId(index.getImpl(), lv);
+    auto id = std::move(tc).toValueId(index, lv);
     ASSERT_TRUE(id.getDatatype() == Datatype::LocalVocabIndex);
     auto lve = lv.getWord(id.getLocalVocabIndex());
     // Check that the constructed LVEs have the correct position in vocab set
@@ -247,7 +247,7 @@ TEST(TripleComponent, toValueIdOrBounds) {
 
   auto expectIsInVocab = [&index, &getId](TripleComponent tc) {
     AD_CORRECTNESS_CHECK(tc.isLiteral() || tc.isIri());
-    auto idOrBounds = tc.toValueIdOrBounds(index.getImpl());
+    auto idOrBounds = tc.toValueIdOrBounds(index);
     auto expectedId =
         getId(tc.isLiteral() ? tc.getLiteral().toStringRepresentation()
                              : tc.getIri().toStringRepresentation());
@@ -263,7 +263,7 @@ TEST(TripleComponent, toValueIdOrBounds) {
   auto expectBounds = [&index, &makePos](TripleComponent tc, BoundsT bounds) {
     AD_CORRECTNESS_CHECK(tc.isLiteral() || tc.isIri());
     // Check that toValueIdOrBounds returns the expected bounds
-    auto idOrBounds = tc.toValueIdOrBounds(index.getImpl());
+    auto idOrBounds = tc.toValueIdOrBounds(index);
     EXPECT_THAT(idOrBounds, testing::VariantWith<BoundsT>(testing::Eq(bounds)));
     // Check that the bounds are the same as from LocalVocabEntry
     auto lve = tc.isLiteral() ? LocalVocabEntry(tc.getLiteral())

--- a/test/TripleComponentTest.cpp
+++ b/test/TripleComponentTest.cpp
@@ -199,30 +199,30 @@ TEST(TripleComponent, toValueIdIfNotString) {
 
 TEST(TripleComponent, toValueId) {
   auto qec = getQec("<x> <y> <z>. <x> <y> \"alpha\".");
-  const auto& vocab = qec->getIndex().getVocab();
+  const auto& index = qec->getIndex();
 
   TripleComponent tc = iri("<x>");
   auto getId = makeGetId(qec->getIndex());
   Id id = getId("<x>");
-  ASSERT_EQ(tc.toValueId(vocab, *encodedIriManager()).value(), id);
+  ASSERT_EQ(tc.toValueId(index.getImpl()).value(), id);
 
   tc = lit("\"alpha\"");
   id = getId("\"alpha\"");
-  EXPECT_EQ(tc.toValueId(vocab, *encodedIriManager()).value(), id);
+  EXPECT_EQ(tc.toValueId(index.getImpl()).value(), id);
 
   tc = iri("<notexisting>");
-  ASSERT_FALSE(tc.toValueId(vocab, *encodedIriManager()).has_value());
+  ASSERT_FALSE(tc.toValueId(index.getImpl()).has_value());
   tc = 42;
 
   ASSERT_EQ(tc.toValueIdIfNotString(encodedIriManager()).value(), I(42));
 
   tc = iri(HAS_PATTERN_PREDICATE);
-  ASSERT_EQ(tc.toValueId(vocab, *encodedIriManager()).value(),
+  ASSERT_EQ(tc.toValueId(index.getImpl()).value(),
             getId(std::string{HAS_PATTERN_PREDICATE}));
 
   auto lv = LocalVocab();
-  auto expectLocalVocab = [&lv, &vocab](TripleComponent tc, size_t pos) {
-    auto id = std::move(tc).toValueId(vocab, lv, *encodedIriManager());
+  auto expectLocalVocab = [&lv, &index](TripleComponent tc, size_t pos) {
+    auto id = std::move(tc).toValueId(index.getImpl(), lv);
     ASSERT_TRUE(id.getDatatype() == Datatype::LocalVocabIndex);
     auto lve = lv.getWord(id.getLocalVocabIndex());
     // Check that the constructed LVEs have the correct position in vocab set
@@ -243,12 +243,11 @@ TEST(TripleComponent, toValueIdOrBounds) {
   // ql:internal-graph ql:langtag <x> <y> <z>
   auto qec = getQec("<x> <y> <z>. <x> <y> \"alpha\".");
   const auto& index = qec->getIndex();
-  const auto& vocab = index.getVocab();
   auto getId = makeGetId(index);
 
-  auto expectIsInVocab = [&vocab, &getId](TripleComponent tc) {
+  auto expectIsInVocab = [&index, &getId](TripleComponent tc) {
     AD_CORRECTNESS_CHECK(tc.isLiteral() || tc.isIri());
-    auto idOrBounds = tc.toValueIdOrBounds(vocab, *encodedIriManager());
+    auto idOrBounds = tc.toValueIdOrBounds(index.getImpl());
     auto expectedId =
         getId(tc.isLiteral() ? tc.getLiteral().toStringRepresentation()
                              : tc.getIri().toStringRepresentation());
@@ -261,10 +260,10 @@ TEST(TripleComponent, toValueIdOrBounds) {
   auto makePos = [](VocabIndex vi) {
     return LocalVocabEntry::IdProxy::make(Id::makeFromVocabIndex(vi).getBits());
   };
-  auto expectBounds = [&vocab, &makePos](TripleComponent tc, BoundsT bounds) {
+  auto expectBounds = [&index, &makePos](TripleComponent tc, BoundsT bounds) {
     AD_CORRECTNESS_CHECK(tc.isLiteral() || tc.isIri());
     // Check that toValueIdOrBounds returns the expected bounds
-    auto idOrBounds = tc.toValueIdOrBounds(vocab, *encodedIriManager());
+    auto idOrBounds = tc.toValueIdOrBounds(index.getImpl());
     EXPECT_THAT(idOrBounds, testing::VariantWith<BoundsT>(testing::Eq(bounds)));
     // Check that the bounds are the same as from LocalVocabEntry
     auto lve = tc.isLiteral() ? LocalVocabEntry(tc.getLiteral())

--- a/test/engine/IndexScanTest.cpp
+++ b/test/engine/IndexScanTest.cpp
@@ -154,7 +154,7 @@ void testLazyScanForJoinWithColumn(
   IndexScan scan{qec, Permutation::PSO, scanTriple};
   std::vector<Id> column;
   for (const auto& entry : columnEntries) {
-    column.push_back(entry.toValueId(qec->getIndex().getImpl()).value());
+    column.push_back(entry.toValueId(qec->getIndex()).value());
   }
 
   auto lazyScan = scan.lazyScanForJoinOfColumnWithScan(column);
@@ -172,7 +172,7 @@ void testLazyScanWithColumnThrows(
   IndexScan s1{qec, Permutation::PSO, scanTriple};
   std::vector<Id> column;
   for (const auto& entry : columnEntries) {
-    column.push_back(entry.toValueId(qec->getIndex().getImpl()).value());
+    column.push_back(entry.toValueId(qec->getIndex()).value());
   }
 
   // We need this to suppress the warning about a [[nodiscard]] return value

--- a/test/engine/IndexScanTest.cpp
+++ b/test/engine/IndexScanTest.cpp
@@ -29,11 +29,6 @@ using LazyResult = Result::LazyResult;
 
 using IndexPair = std::pair<size_t, size_t>;
 
-constexpr auto encodedIriManager = []() -> const EncodedIriManager* {
-  static EncodedIriManager encodedIriManager_;
-  return &encodedIriManager_;
-};
-
 // NOTE: All the following helper functions always use the `PSO` permutation to
 // set up index scans unless explicitly stated otherwise.
 

--- a/test/engine/IndexScanTest.cpp
+++ b/test/engine/IndexScanTest.cpp
@@ -159,9 +159,7 @@ void testLazyScanForJoinWithColumn(
   IndexScan scan{qec, Permutation::PSO, scanTriple};
   std::vector<Id> column;
   for (const auto& entry : columnEntries) {
-    column.push_back(
-        entry.toValueId(qec->getIndex().getVocab(), *encodedIriManager())
-            .value());
+    column.push_back(entry.toValueId(qec->getIndex().getImpl()).value());
   }
 
   auto lazyScan = scan.lazyScanForJoinOfColumnWithScan(column);
@@ -179,9 +177,7 @@ void testLazyScanWithColumnThrows(
   IndexScan s1{qec, Permutation::PSO, scanTriple};
   std::vector<Id> column;
   for (const auto& entry : columnEntries) {
-    column.push_back(
-        entry.toValueId(qec->getIndex().getVocab(), *encodedIriManager())
-            .value());
+    column.push_back(entry.toValueId(qec->getIndex().getImpl()).value());
   }
 
   // We need this to suppress the warning about a [[nodiscard]] return value

--- a/test/engine/LazyJoinTestHelpers.h
+++ b/test/engine/LazyJoinTestHelpers.h
@@ -31,8 +31,7 @@ class LazyJoinTestHelper {
 
   // Convert a TripleComponent to a ValueId.
   Id toValueId(const TripleComponent& tc) const {
-    return tc.toValueId(qec_->getIndex().getVocab(), encodedIriManager())
-        .value();
+    return tc.toValueId(qec_->getIndex().getImpl()).value();
   }
 
   // Create an id table with a single column from a vector of TripleComponents.

--- a/test/engine/LazyJoinTestHelpers.h
+++ b/test/engine/LazyJoinTestHelpers.h
@@ -23,12 +23,6 @@ class LazyJoinTestHelper {
  protected:
   QueryExecutionContext* qec_ = nullptr;
 
-  // Get the EncodedIriManager singleton.
-  static const EncodedIriManager& encodedIriManager() {
-    static EncodedIriManager manager;
-    return manager;
-  }
-
   // Convert a TripleComponent to a ValueId.
   Id toValueId(const TripleComponent& tc) const {
     return tc.toValueId(qec_->getIndex()).value();

--- a/test/engine/LazyJoinTestHelpers.h
+++ b/test/engine/LazyJoinTestHelpers.h
@@ -31,7 +31,7 @@ class LazyJoinTestHelper {
 
   // Convert a TripleComponent to a ValueId.
   Id toValueId(const TripleComponent& tc) const {
-    return tc.toValueId(qec_->getIndex().getImpl()).value();
+    return tc.toValueId(qec_->getIndex()).value();
   }
 
   // Create an id table with a single column from a vector of TripleComponents.

--- a/test/engine/OptionalJoinTest.cpp
+++ b/test/engine/OptionalJoinTest.cpp
@@ -967,13 +967,13 @@ TEST_P(OptionalJoinWithIndexScan, twoColumnsBasicFiltering) {
   // Left side: two columns with UNDEF in second column.
   IdTable leftTable{2, makeAllocator()};
   auto s1 = TripleComponent{TripleComponent::Iri::fromIriref("<s1>")}
-                .toValueId(qec2->getIndex().getVocab(), encodedIriManager())
+                .toValueId(qec2->getIndex().getImpl())
                 .value();
   auto s3 = TripleComponent{TripleComponent::Iri::fromIriref("<s3>")}
-                .toValueId(qec2->getIndex().getVocab(), encodedIriManager())
+                .toValueId(qec2->getIndex().getImpl())
                 .value();
   auto o1 = TripleComponent{TripleComponent::Iri::fromIriref("<o1>")}
-                .toValueId(qec2->getIndex().getVocab(), encodedIriManager())
+                .toValueId(qec2->getIndex().getImpl())
                 .value();
 
   leftTable.push_back({s1, o1});  // matches 1 row
@@ -1016,10 +1016,10 @@ TEST_P(OptionalJoinWithIndexScan, twoColumnsMultipleMatches) {
   auto qec2 = getQec(std::move(config));
 
   auto s1 = TripleComponent{TripleComponent::Iri::fromIriref("<s1>")}
-                .toValueId(qec2->getIndex().getVocab(), encodedIriManager())
+                .toValueId(qec2->getIndex().getImpl())
                 .value();
   auto s2 = TripleComponent{TripleComponent::Iri::fromIriref("<s2>")}
-                .toValueId(qec2->getIndex().getVocab(), encodedIriManager())
+                .toValueId(qec2->getIndex().getImpl())
                 .value();
   auto o1 = Id::makeFromInt(2);
   auto o3 = Id::makeFromInt(4);

--- a/test/engine/OptionalJoinTest.cpp
+++ b/test/engine/OptionalJoinTest.cpp
@@ -967,13 +967,13 @@ TEST_P(OptionalJoinWithIndexScan, twoColumnsBasicFiltering) {
   // Left side: two columns with UNDEF in second column.
   IdTable leftTable{2, makeAllocator()};
   auto s1 = TripleComponent{TripleComponent::Iri::fromIriref("<s1>")}
-                .toValueId(qec2->getIndex().getImpl())
+                .toValueId(qec2->getIndex())
                 .value();
   auto s3 = TripleComponent{TripleComponent::Iri::fromIriref("<s3>")}
-                .toValueId(qec2->getIndex().getImpl())
+                .toValueId(qec2->getIndex())
                 .value();
   auto o1 = TripleComponent{TripleComponent::Iri::fromIriref("<o1>")}
-                .toValueId(qec2->getIndex().getImpl())
+                .toValueId(qec2->getIndex())
                 .value();
 
   leftTable.push_back({s1, o1});  // matches 1 row
@@ -1016,10 +1016,10 @@ TEST_P(OptionalJoinWithIndexScan, twoColumnsMultipleMatches) {
   auto qec2 = getQec(std::move(config));
 
   auto s1 = TripleComponent{TripleComponent::Iri::fromIriref("<s1>")}
-                .toValueId(qec2->getIndex().getImpl())
+                .toValueId(qec2->getIndex())
                 .value();
   auto s2 = TripleComponent{TripleComponent::Iri::fromIriref("<s2>")}
-                .toValueId(qec2->getIndex().getImpl())
+                .toValueId(qec2->getIndex())
                 .value();
   auto o1 = Id::makeFromInt(2);
   auto o3 = Id::makeFromInt(4);

--- a/test/index/IndexRebuilderTest.cpp
+++ b/test/index/IndexRebuilderTest.cpp
@@ -271,7 +271,7 @@ TEST(IndexRebuilder, readIndexAndRemap) {
 
   auto g = TripleComponent{ad_utility::triple_component::Iri::fromIriref(
                                DEFAULT_GRAPH_IRI)}
-               .toValueId(index.getVocab(), index.encodedIriManager())
+               .toValueId(index.getImpl())
                .value();
 
   index.deltaTriplesManager().modify<void>([&cancellationHandle,
@@ -468,7 +468,7 @@ TEST(IndexRebuilder, materializeToIndex) {
                                                  DeltaTriples& deltaTriples) {
       auto g = TripleComponent{ad_utility::triple_component::Iri::fromIriref(
                                    DEFAULT_GRAPH_IRI)}
-                   .toValueId(index.getVocab(), index.encodedIriManager())
+                   .toValueId(index.getImpl())
                    .value();
       deltaTriples.insertTriples(
           cancellationHandle, {IdTriple<0>{std::array{V(2), V(1), V(0), g}},

--- a/test/index/IndexRebuilderTest.cpp
+++ b/test/index/IndexRebuilderTest.cpp
@@ -271,7 +271,7 @@ TEST(IndexRebuilder, readIndexAndRemap) {
 
   auto g = TripleComponent{ad_utility::triple_component::Iri::fromIriref(
                                DEFAULT_GRAPH_IRI)}
-               .toValueId(index.getImpl())
+               .toValueId(index)
                .value();
 
   index.deltaTriplesManager().modify<void>([&cancellationHandle,
@@ -468,7 +468,7 @@ TEST(IndexRebuilder, materializeToIndex) {
                                                  DeltaTriples& deltaTriples) {
       auto g = TripleComponent{ad_utility::triple_component::Iri::fromIriref(
                                    DEFAULT_GRAPH_IRI)}
-                   .toValueId(index.getImpl())
+                   .toValueId(index)
                    .value();
       deltaTriples.insertTriples(
           cancellationHandle, {IdTriple<0>{std::array{V(2), V(1), V(0), g}},

--- a/test/util/IndexTestHelpers.cpp
+++ b/test/util/IndexTestHelpers.cpp
@@ -401,8 +401,7 @@ std::function<Id(const std::string&)> makeGetId(const Index& index) {
         return TripleComponent::Literal::fromStringRepresentation(el);
       }
     }();
-    static const EncodedIriManager encodedIriManager;
-    auto id = literalOrIri.toValueId(index.getVocab(), encodedIriManager);
+    auto id = literalOrIri.toValueId(index.getImpl());
     AD_CONTRACT_CHECK(id.has_value());
     return id.value();
   };

--- a/test/util/IndexTestHelpers.cpp
+++ b/test/util/IndexTestHelpers.cpp
@@ -401,7 +401,7 @@ std::function<Id(const std::string&)> makeGetId(const Index& index) {
         return TripleComponent::Literal::fromStringRepresentation(el);
       }
     }();
-    auto id = literalOrIri.toValueId(index.getImpl());
+    auto id = literalOrIri.toValueId(index);
     AD_CONTRACT_CHECK(id.has_value());
     return id.value();
   };


### PR DESCRIPTION
Change the interface of `TripleComponent::toValueId` and `toValueIdOrBounds` to take a `const IndexImpl&` instead of separate `Vocabulary` and `EncodedIriManager` references. The latter are always obtained from the same index, so passing them separately was redundant and cluttered every call site. The implementations are moved from the header (where they were templates parameterized on the vocabulary type) to `TripleComponent.cpp`. As a consequence, the `Index::getCardinality(const TripleComponent&, ...)` overload is removed — callers now resolve the `TripleComponent` to an `Id` themselves and call the `Id` overload directly. Make the analogous change for `PathQuery::toSearchSide` and `toPathSearchConfiguration`. This continues #2801 in preparing for supporting multiple indexes