### PR TITLE
Make `disable-caching` runtime parameter accessible via `HTTP`

### DIFF
--- a/src/engine/Operation.cpp
+++ b/src/engine/Operation.cpp
@@ -350,6 +350,9 @@ std::shared_ptr<const Result> Operation::getResult(
             });
 
     if (_executionContext->disableCaching()) {
+      if (computationMode == ComputationMode::ONLY_IF_CACHED) {
+        return nullptr;
+      }
       return std::make_shared<Result>(runComputation(timer, computationMode));
     }
 

--- a/src/global/RuntimeParameters.cpp
+++ b/src/global/RuntimeParameters.cpp
@@ -57,6 +57,7 @@ RuntimeParameters::RuntimeParameters() {
   add(serviceAllowedIriPrefixes_);
   add(permutationWriterNumThreads_);
   add(vacuumMinimumBlockSize_);
+  add(disableCaching_);
 
   defaultQueryTimeout_.setParameterConstraint(
       [](std::chrono::seconds value, std::string_view parameterName) {

--- a/test/OperationTest.cpp
+++ b/test/OperationTest.cpp
@@ -891,4 +891,8 @@ TEST(OperationTest, disableCachingGlobally) {
   valuesForTesting.getResult(true);
   // Still not stored in the cache, because caching was disabled.
   EXPECT_FALSE(qec->getQueryTreeCache().cacheContains(cacheKey));
+
+  // ONLY_IF_CACHED returns nullptr when caching is disabled.
+  EXPECT_EQ(valuesForTesting.getResult(false, ComputationMode::ONLY_IF_CACHED),
+            nullptr);
 }


### PR DESCRIPTION
This was an omission from #2758, which only cared about making this work for `libqlever`