### PR TITLE
Update GitHub Actions to avoid Node.js 20 deprecation issues

### DIFF
--- a/.github/workflows/check_index_version.yml
+++ b/.github/workflows/check_index_version.yml
@@ -27,11 +27,11 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: 'recursive'
         path: 'pr'
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: 'recursive'
         path: 'master'

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -37,7 +37,7 @@ jobs:
 
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: "recursive"
 

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Annotate locations with typos
         uses: codespell-project/codespell-problem-matcher@v1
       - name: Codespell

--- a/.github/workflows/cpp-17-libqlever.yml
+++ b/.github/workflows/cpp-17-libqlever.yml
@@ -40,7 +40,7 @@ jobs:
       compiler: gcc
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
       - name: Install dependencies

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         # Generate metadata for the docker image based on the GH Actions environment.
       - name: Generate image metadata
         id: meta
@@ -97,7 +97,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Generate image metadata
         id: meta
         uses: docker/metadata-action@v5

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install dependencies
         run:  |
             # The following line currently seems to be necessary to work around a bug in the installation.

--- a/.github/workflows/macos-appleclang-native.yml
+++ b/.github/workflows/macos-appleclang-native.yml
@@ -23,7 +23,7 @@ jobs:
         build-type: [Release]
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install dependencies via Homebrew
         run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -50,7 +50,7 @@ jobs:
         run: clang++ --version
 
       - name: Cache for conan
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         env:
           cache-name: cache-conan-modules-macos-15
         with:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -25,7 +25,7 @@ jobs:
     env:
       LLVM_VERSION: 17
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install ICU dependency for python (only needed for E2E test)
         run: |

--- a/.github/workflows/native-build-conan.yml
+++ b/.github/workflows/native-build-conan.yml
@@ -26,7 +26,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: 'recursive'
 

--- a/.github/workflows/native-build-with-conan-and-emscripten.yml
+++ b/.github/workflows/native-build-with-conan-and-emscripten.yml
@@ -35,7 +35,7 @@ jobs:
         conan profile detect
 
     - name: Cache for conan
-      uses: actions/cache@v3
+      uses: actions/cache@v5
       env:
         cache-name: cache-conan-with-emscripten-modules-ubuntu-24.04
       with:

--- a/.github/workflows/native-build-with-conan-and-emscripten.yml
+++ b/.github/workflows/native-build-with-conan-and-emscripten.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: 'recursive'
     - name: Install conan package manager

--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Skip early if conditions are not met
         if: (github.event_name == 'pull_request' && matrix.skipIfPr)
         run: exit 0;
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
       - name: Install dependencies

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: 'recursive'
 

--- a/.github/workflows/sparql-conformance.yml
+++ b/.github/workflows/sparql-conformance.yml
@@ -16,17 +16,17 @@ jobs:
       cmake-flags: "-DCMAKE_C_COMPILER=clang-16 -DCMAKE_CXX_COMPILER=clang++-16"
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           submodules: "recursive"
           path: qlever-code
       - name: Checkout sparql-test-suite-files
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           repository: "w3c/rdf-tests"
           path: sparql-test-suite
       - name: Checkout qlever-test-suite
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           repository: "ad-freiburg/sparql-conformance"
           path: qlever-test-suite

--- a/.github/workflows/upload-coverage.yml
+++ b/.github/workflows/upload-coverage.yml
@@ -64,7 +64,7 @@ jobs:
         # be overwritten. We then move all the files back into the working
         # directory such that Codecov will pick them up properly.
       - name: "Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{env.original_github_repository}}
           submodules: "recursive"

--- a/.github/workflows/upload-sonarcloud.yml
+++ b/.github/workflows/upload-sonarcloud.yml
@@ -91,7 +91,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: "Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ github.event.workflow_run.head_repository.full_name }}
           ref: ${{ github.event.workflow_run.head_branch }}


### PR DESCRIPTION
Currently on some runners we get the following warning:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/cache@v3, actions/checkout@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

This PR updates the workflow files to fix this problem.