### PR TITLE
Fix three build failures in the `CPP17/GCC 8` and `AppleClang` workflows

### DIFF
--- a/test/ConcurrentCacheTest.cpp
+++ b/test/ConcurrentCacheTest.cpp
@@ -107,7 +107,9 @@ TEST(ConcurrentCache, sequentialComputation) {
   ASSERT_EQ("3"s, *result2._resultPointer);
   ASSERT_EQ(result2._cacheStatus, ad_utility::CacheStatus::cachedNotPinned);
   ASSERT_EQ(result._resultPointer, result2._resultPointer);
+#ifndef _QLEVER_NO_TIMING_TESTS
   ASSERT_LE(t.msecs(), 5ms);
+#endif
   ASSERT_EQ(1ul, a.numNonPinnedEntries());
   ASSERT_EQ(0ul, a.numPinnedEntries());
   ASSERT_TRUE(a.getStorage().wlock()->_inProgress.empty());
@@ -138,7 +140,9 @@ TEST(ConcurrentCache, sequentialPinnedComputation) {
   ASSERT_EQ("3"s, *result2._resultPointer);
   ASSERT_EQ(result2._cacheStatus, ad_utility::CacheStatus::cachedPinned);
   ASSERT_EQ(result._resultPointer, result2._resultPointer);
+#ifndef _QLEVER_NO_TIMING_TESTS
   ASSERT_LE(t.msecs(), 5ms);
+#endif
   ASSERT_EQ(1ul, a.numPinnedEntries());
   ASSERT_EQ(0ul, a.numNonPinnedEntries());
   ASSERT_TRUE(a.getStorage().wlock()->_inProgress.empty());
@@ -170,7 +174,9 @@ TEST(ConcurrentCache, sequentialPinnedUpgradeComputation) {
   ASSERT_EQ("3"s, *result2._resultPointer);
   ASSERT_EQ(result2._cacheStatus, ad_utility::CacheStatus::cachedNotPinned);
   ASSERT_EQ(result._resultPointer, result2._resultPointer);
+#ifndef _QLEVER_NO_TIMING_TESTS
   ASSERT_LE(t.msecs(), 5ms);
+#endif
   ASSERT_EQ(1ul, a.numPinnedEntries());
   ASSERT_EQ(0ul, a.numNonPinnedEntries());
   ASSERT_TRUE(a.getStorage().wlock()->_inProgress.empty());

--- a/test/util/IndexTestHelpers.cpp
+++ b/test/util/IndexTestHelpers.cpp
@@ -125,18 +125,18 @@ void checkConsistencyBetweenPatternPredicateAndAdditionalColumn(
       };
 
   auto checkConsistencyForPredicate = [&](Id predicateId) {
-    using enum Permutation::Enum;
     checkConsistencyForCol0IdAndPermutation(
-        predicateId, indexImpl.getPermutation(PSO), 0, 1);
+        predicateId, indexImpl.getPermutation(Permutation::Enum::PSO), 0, 1);
     checkConsistencyForCol0IdAndPermutation(
-        predicateId, indexImpl.getPermutation(POS), 1, 0);
+        predicateId, indexImpl.getPermutation(Permutation::Enum::POS), 1, 0);
   };
   auto checkConsistencyForObject = [&](Id objectId) {
-    using enum Permutation::Enum;
     checkConsistencyForCol0IdAndPermutation(
-        objectId, indexImpl.getPermutation(OPS), 1, col0IdTag);
+        objectId, indexImpl.getPermutation(Permutation::Enum::OPS), 1,
+        col0IdTag);
     checkConsistencyForCol0IdAndPermutation(
-        objectId, indexImpl.getPermutation(OSP), 0, col0IdTag);
+        objectId, indexImpl.getPermutation(Permutation::Enum::OSP), 0,
+        col0IdTag);
   };
 
   auto predicates = index.getImpl().PSO().getDistinctCol0IdsAndCounts(

--- a/test/util/ValidatorHelpers.h
+++ b/test/util/ValidatorHelpers.h
@@ -47,11 +47,11 @@ function.
 creation of multiple different validator functions. For more information,
 what the exact difference is, see the code in `createDummyValueForValidator`.
 */
-template <typename... ParameterTypes>
-requires((ad_utility::SameAsAnyTypeIn<
-             ParameterTypes, ad_utility::ConfigOption::AvailableTypes>) &&
-         ...)
-auto generateDummyNonExceptionValidatorFunction(size_t variant) {
+CPP_variadic_template(typename... ParameterTypes)(
+    requires(ad_utility::SameAsAnyTypeIn<
+                 ParameterTypes, ad_utility::ConfigOption::AvailableTypes> &&
+             ...)) auto generateDummyNonExceptionValidatorFunction(size_t
+                                                                       variant) {
   return [... dummyValuesToCompareTo =
               createDummyValueForValidator<ParameterTypes>(variant)](
              const ParameterTypes&... args) {

--- a/test/util/ValidatorHelpers.h
+++ b/test/util/ValidatorHelpers.h
@@ -47,11 +47,12 @@ function.
 creation of multiple different validator functions. For more information,
 what the exact difference is, see the code in `createDummyValueForValidator`.
 */
-CPP_variadic_template(typename... ParameterTypes)(
-    requires(ad_utility::SameAsAnyTypeIn<
-                 ParameterTypes, ad_utility::ConfigOption::AvailableTypes> &&
-             ...)) auto generateDummyNonExceptionValidatorFunction(size_t
-                                                                       variant) {
+CPP_variadic_template(typename... ParameterTypes)(requires(
+    ad_utility::SameAsAnyTypeIn<
+        ParameterTypes,
+        ad_utility::ConfigOption::
+            AvailableTypes>&&...)) auto generateDummyNonExceptionValidatorFunction(size_t
+                                                                                       variant) {
   return [... dummyValuesToCompareTo =
               createDummyValueForValidator<ParameterTypes>(variant)](
              const ParameterTypes&... args) {

--- a/test/util/ValidatorHelpers.h
+++ b/test/util/ValidatorHelpers.h
@@ -10,6 +10,7 @@
 
 #include <cstddef>
 #include <sstream>
+#include <tuple>
 
 #include "backports/type_traits.h"
 #include "util/ConfigManager/ConfigOption.h"
@@ -53,9 +54,9 @@ CPP_variadic_template(typename... ParameterTypes)(requires(
         ad_utility::ConfigOption::
             AvailableTypes>&&...)) auto generateDummyNonExceptionValidatorFunction(size_t
                                                                                        variant) {
-  return [... dummyValuesToCompareTo =
-              createDummyValueForValidator<ParameterTypes>(variant)](
-             const ParameterTypes&... args) {
+  return [dummyValuesToCompareTo = std::tuple<ParameterTypes...>{
+              createDummyValueForValidator<ParameterTypes>(
+                  variant)...}](const ParameterTypes&... args) {
     // Special handling for `args` of type bool is needed. For the reasoning:
     // See the doc string.
     auto compare = [](const auto& arg, const auto& dummyValueToCompareTo) {
@@ -69,7 +70,11 @@ CPP_variadic_template(typename... ParameterTypes)(requires(
         return arg != dummyValueToCompareTo;
       }
     };
-    return (compare(args, dummyValuesToCompareTo) || ...);
+    return std::apply(
+        [&](const ParameterTypes&... dummies) {
+          return (compare(args, dummies) || ...);
+        },
+        dummyValuesToCompareTo);
   };
 };
 


### PR DESCRIPTION
1. In `ValidatorHelpers.h`, rewrite a pack expansion (C++20) in a lambda init-capture using `std::tuple` and `std::apply` (C++17)
2. In `IndexTestHelpers.cpp`, replace `using enum Permutation::Enum (C++20) with fully qualified `Permutation::Enum::PSO` etc. (C++17)
3. In `ConcurrentCacheTest.cpp`, guard three `ASSERT_LE(t.msecs(), 5ms)` timing assertions with `#ifndef _QLEVER_NO_TIMING_TESTS` (timing is flaky on GitHub's macOS runners)