### PR TITLE
Fix two more lifetime issues (one ASAN and one SEGV)

### DIFF
--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -87,16 +87,22 @@ class Server {
   // server code.
   struct PlannedQuery {
    private:
+    // NOTE: `qec_` must be declared before `queryExecutionTree_` so that it
+    // is destroyed after it. The `QueryExecutionTree` holds operations with
+    // raw `_executionContext` pointers to the QEC, and their lazy result
+    // cleanup accesses the QEC via `signalQueryUpdate`. If `qec_` is the
+    // last `shared_ptr` and is destroyed first, the QEC is freed while the
+    // operations still reference it.
+    std::shared_ptr<const QueryExecutionContext> qec_;
     ParsedQuery parsedQuery_;
     QueryExecutionTree queryExecutionTree_;
-    std::shared_ptr<const QueryExecutionContext> qec_;
 
    public:
     PlannedQuery(ParsedQuery pq, QueryExecutionTree qet,
                  const QueryExecutionContext& qec)
-        : parsedQuery_{std::move(pq)},
-          queryExecutionTree_{std::move(qet)},
-          qec_{qec.shared_from_this()} {
+        : qec_{qec.shared_from_this()},
+          parsedQuery_{std::move(pq)},
+          queryExecutionTree_{std::move(qet)} {
       AD_CORRECTNESS_CHECK(qec_.get() == queryExecutionTree_.getQec());
     }
 

--- a/src/util/JoinAlgorithms/IndexNestedLoopJoin.h
+++ b/src/util/JoinAlgorithms/IndexNestedLoopJoin.h
@@ -297,7 +297,8 @@ class IndexNestedLoopJoin {
               rightResult_->idTable(), rightColumns);
           auto matchHelper =
               [rightTable = std::move(rightTable), leftColumns, JOIN_COLUMNS,
-               transformationFunc = std::move(transformationFunc)](
+               transformationFunc = std::move(transformationFunc),
+               rightResult = rightResult_](
                   auto&& idTable,
                   LocalVocab localVocab) -> Result::IdTableVocabPair {
             detail::RightFiller matchTracker{


### PR DESCRIPTION
1. In `PlannedQuery`, declare the shared pointer to the execution context (which was the fix from #2812, item 3) *before* the query execution tree; this fixes an ASAN crash that occurred under high load
2. In `IndexNestedLoopJoin::computeRightExistance`, now capture `rightResult_` so that the right input's `IdTable` lives at least as long the `IdTableView` with spans into that `IdTable`; this fixes a SEGV that occurred under high load 