### PR TITLE
Remove the `globalSingletonIndex_` static pointer from `IndexImpl`

### DIFF
--- a/benchmark/GroupByHashMapBenchmark.cpp
+++ b/benchmark/GroupByHashMapBenchmark.cpp
@@ -71,7 +71,8 @@ auto generateSortedGroupVec = [](size_t n, size_t g) {
 
 // Create a local vocab of random strings and a vector of the local vocab
 // indices.
-auto generateRandomLocalVocabAndIndicesVec = [](const IndexImpl& index,
+auto generateRandomLocalVocabAndIndicesVec = [](const LocalVocabContext&
+                                                    context,
                                                 size_t n, size_t m) {
   LocalVocab localVocab;
   std::vector<LocalVocabIndex> indices;
@@ -90,7 +91,7 @@ auto generateRandomLocalVocabAndIndicesVec = [](const IndexImpl& index,
     }
     using namespace ad_utility::triple_component;
     indices.push_back(localVocab.getIndexAndAddIfNotContained(
-        LocalVocabEntry{LiteralOrIri::literalWithoutQuotes(str), index}));
+        LocalVocabEntry{LiteralOrIri::literalWithoutQuotes(str), context}));
   }
 
   return std::make_pair(std::move(localVocab), indices);

--- a/benchmark/GroupByHashMapBenchmark.cpp
+++ b/benchmark/GroupByHashMapBenchmark.cpp
@@ -18,6 +18,7 @@
 #include "engine/sparqlExpressions/GroupConcatExpression.h"
 #include "engine/sparqlExpressions/LiteralExpression.h"
 #include "global/RuntimeParameters.h"
+#include "index/LocalVocabEntry.h"
 #include "util/Log.h"
 #include "util/Random.h"
 #include "util/TypeIdentity.h"
@@ -70,7 +71,8 @@ auto generateSortedGroupVec = [](size_t n, size_t g) {
 
 // Create a local vocab of random strings and a vector of the local vocab
 // indices.
-auto generateRandomLocalVocabAndIndicesVec = [](size_t n, size_t m) {
+auto generateRandomLocalVocabAndIndicesVec = [](const IndexImpl& index,
+                                                size_t n, size_t m) {
   LocalVocab localVocab;
   std::vector<LocalVocabIndex> indices;
 
@@ -88,7 +90,7 @@ auto generateRandomLocalVocabAndIndicesVec = [](size_t n, size_t m) {
     }
     using namespace ad_utility::triple_component;
     indices.push_back(localVocab.getIndexAndAddIfNotContained(
-        LiteralOrIri::literalWithoutQuotes(str)));
+        LocalVocabEntry{LiteralOrIri::literalWithoutQuotes(str), index}));
   }
 
   return std::make_pair(std::move(localVocab), indices);
@@ -404,7 +406,7 @@ class GroupByHashMapBenchmark : public BenchmarkInterface {
           });
     } else {
       auto [newLocalVocab, indices] = generateRandomLocalVocabAndIndicesVec(
-          numInputRows, randomStringLength);
+          qec->getIndex(), numInputRows, randomStringLength);
       localVocab = std::move(newLocalVocab);
 
       ql::ranges::transform(indices.begin(), indices.end(), otherValues.begin(),

--- a/benchmark/GroupByHashMapBenchmark.cpp
+++ b/benchmark/GroupByHashMapBenchmark.cpp
@@ -407,7 +407,7 @@ class GroupByHashMapBenchmark : public BenchmarkInterface {
           });
     } else {
       auto [newLocalVocab, indices] = generateRandomLocalVocabAndIndicesVec(
-          qec->getIndex(), numInputRows, randomStringLength);
+          qec->getLocalVocabContext(), numInputRows, randomStringLength);
       localVocab = std::move(newLocalVocab);
 
       ql::ranges::transform(indices.begin(), indices.end(), otherValues.begin(),

--- a/benchmark/GroupByHashMapBenchmark.cpp
+++ b/benchmark/GroupByHashMapBenchmark.cpp
@@ -91,7 +91,7 @@ auto generateRandomLocalVocabAndIndicesVec = [](const LocalVocabContext&
     }
     using namespace ad_utility::triple_component;
     indices.push_back(localVocab.getIndexAndAddIfNotContained(
-        LocalVocabEntry{LiteralOrIri::literalWithoutQuotes(str), context}));
+        LocalVocabEntry::literalWithoutQuotes(str, context)));
   }
 
   return std::make_pair(std::move(localVocab), indices);

--- a/src/engine/Filter.cpp
+++ b/src/engine/Filter.cpp
@@ -53,7 +53,7 @@ std::string Filter::getDescriptor() const {
 //______________________________________________________________________________
 void Filter::setPrefilterExpressionForChildren() {
   std::vector<PrefilterVariablePair> prefilterPairs =
-      _expression.getPrefilterExpressionForMetadata(getIndex());
+      _expression.getPrefilterExpressionForMetadata(getLocalVocabContext());
   auto optNewSubTree =
       _subtree->getUpdatedQueryExecutionTreeWithPrefilterApplied(
           std::move(prefilterPairs));

--- a/src/engine/Filter.cpp
+++ b/src/engine/Filter.cpp
@@ -53,7 +53,7 @@ std::string Filter::getDescriptor() const {
 //______________________________________________________________________________
 void Filter::setPrefilterExpressionForChildren() {
   std::vector<PrefilterVariablePair> prefilterPairs =
-      _expression.getPrefilterExpressionForMetadata();
+      _expression.getPrefilterExpressionForMetadata(getIndex());
   auto optNewSubTree =
       _subtree->getUpdatedQueryExecutionTreeWithPrefilterApplied(
           std::move(prefilterPairs));

--- a/src/engine/GroupByHashMapOptimization.cpp
+++ b/src/engine/GroupByHashMapOptimization.cpp
@@ -73,11 +73,9 @@ void GroupConcatAggregationData::addValueImpl(
     return ValueId::makeUndefined();
   }
   using namespace ad_utility::triple_component;
-  auto localVocabIndex =
-      localVocab->getIndexAndAddIfNotContained(LocalVocabEntry{
-          ad_utility::triple_component::Literal::literalWithNormalizedContent(
-              asNormalizedStringViewUnsafe(currentValue_)),
-          context});
+  auto localVocabIndex = localVocab->getIndexAndAddIfNotContained(
+      LocalVocabEntry::literalWithNormalizedContent(
+          asNormalizedStringViewUnsafe(currentValue_), context));
   return ValueId::makeFromLocalVocabIndex(localVocabIndex);
 }
 

--- a/src/engine/GroupByHashMapOptimization.cpp
+++ b/src/engine/GroupByHashMapOptimization.cpp
@@ -6,7 +6,7 @@
 
 // _____________________________________________________________________________
 [[nodiscard]] ValueId AvgAggregationData::calculateResult(
-    [[maybe_unused]] const IndexImpl& index,
+    [[maybe_unused]] const LocalVocabContext& context,
     [[maybe_unused]] const LocalVocab* localVocab) const {
   if (error_) {
     return ValueId::makeUndefined();
@@ -21,7 +21,7 @@
 
 // _____________________________________________________________________________
 [[nodiscard]] ValueId CountAggregationData::calculateResult(
-    [[maybe_unused]] const IndexImpl& index,
+    [[maybe_unused]] const LocalVocabContext& context,
     [[maybe_unused]] const LocalVocab* localVocab) const {
   return ValueId::makeFromInt(count_);
 }
@@ -29,7 +29,8 @@
 // _____________________________________________________________________________
 template <valueIdComparators::Comparison Comp>
 [[nodiscard]] ValueId ExtremumAggregationData<Comp>::calculateResult(
-    [[maybe_unused]] const IndexImpl& index, LocalVocab* localVocab) const {
+    [[maybe_unused]] const LocalVocabContext& context,
+    LocalVocab* localVocab) const {
   return sparqlExpression::detail::idOrLiteralOrIriToId(currentValue_,
                                                         localVocab);
 }
@@ -39,7 +40,7 @@ template struct ExtremumAggregationData<valueIdComparators::Comparison::GT>;
 
 // _____________________________________________________________________________
 [[nodiscard]] ValueId SumAggregationData::calculateResult(
-    [[maybe_unused]] const IndexImpl& index,
+    [[maybe_unused]] const LocalVocabContext& context,
     [[maybe_unused]] const LocalVocab* localVocab) const {
   if (error_) {
     return ValueId::makeUndefined();
@@ -67,7 +68,7 @@ void GroupConcatAggregationData::addValueImpl(
 
 // _____________________________________________________________________________
 [[nodiscard]] ValueId GroupConcatAggregationData::calculateResult(
-    const IndexImpl& index, LocalVocab* localVocab) const {
+    const LocalVocabContext& context, LocalVocab* localVocab) const {
   if (undefined_) {
     return ValueId::makeUndefined();
   }
@@ -76,7 +77,7 @@ void GroupConcatAggregationData::addValueImpl(
       localVocab->getIndexAndAddIfNotContained(LocalVocabEntry{
           ad_utility::triple_component::Literal::literalWithNormalizedContent(
               asNormalizedStringViewUnsafe(currentValue_)),
-          index});
+          context});
   return ValueId::makeFromLocalVocabIndex(localVocabIndex);
 }
 
@@ -96,7 +97,8 @@ void GroupConcatAggregationData::reset() {
 
 // _____________________________________________________________________________
 [[nodiscard]] ValueId SampleAggregationData::calculateResult(
-    [[maybe_unused]] const IndexImpl& index, LocalVocab* localVocab) const {
+    [[maybe_unused]] const LocalVocabContext& context,
+    LocalVocab* localVocab) const {
   if (!value_.has_value()) {
     return Id::makeUndefined();
   }

--- a/src/engine/GroupByHashMapOptimization.cpp
+++ b/src/engine/GroupByHashMapOptimization.cpp
@@ -6,6 +6,7 @@
 
 // _____________________________________________________________________________
 [[nodiscard]] ValueId AvgAggregationData::calculateResult(
+    [[maybe_unused]] const IndexImpl& index,
     [[maybe_unused]] const LocalVocab* localVocab) const {
   if (error_) {
     return ValueId::makeUndefined();
@@ -20,6 +21,7 @@
 
 // _____________________________________________________________________________
 [[nodiscard]] ValueId CountAggregationData::calculateResult(
+    [[maybe_unused]] const IndexImpl& index,
     [[maybe_unused]] const LocalVocab* localVocab) const {
   return ValueId::makeFromInt(count_);
 }
@@ -27,7 +29,7 @@
 // _____________________________________________________________________________
 template <valueIdComparators::Comparison Comp>
 [[nodiscard]] ValueId ExtremumAggregationData<Comp>::calculateResult(
-    LocalVocab* localVocab) const {
+    [[maybe_unused]] const IndexImpl& index, LocalVocab* localVocab) const {
   return sparqlExpression::detail::idOrLiteralOrIriToId(currentValue_,
                                                         localVocab);
 }
@@ -37,6 +39,7 @@ template struct ExtremumAggregationData<valueIdComparators::Comparison::GT>;
 
 // _____________________________________________________________________________
 [[nodiscard]] ValueId SumAggregationData::calculateResult(
+    [[maybe_unused]] const IndexImpl& index,
     [[maybe_unused]] const LocalVocab* localVocab) const {
   if (error_) {
     return ValueId::makeUndefined();
@@ -64,14 +67,16 @@ void GroupConcatAggregationData::addValueImpl(
 
 // _____________________________________________________________________________
 [[nodiscard]] ValueId GroupConcatAggregationData::calculateResult(
-    LocalVocab* localVocab) const {
+    const IndexImpl& index, LocalVocab* localVocab) const {
   if (undefined_) {
     return ValueId::makeUndefined();
   }
   using namespace ad_utility::triple_component;
-  auto localVocabIndex = localVocab->getIndexAndAddIfNotContained(LiteralOrIri{
-      ad_utility::triple_component::Literal::literalWithNormalizedContent(
-          asNormalizedStringViewUnsafe(currentValue_))});
+  auto localVocabIndex =
+      localVocab->getIndexAndAddIfNotContained(LocalVocabEntry{
+          ad_utility::triple_component::Literal::literalWithNormalizedContent(
+              asNormalizedStringViewUnsafe(currentValue_)),
+          index});
   return ValueId::makeFromLocalVocabIndex(localVocabIndex);
 }
 
@@ -91,7 +96,7 @@ void GroupConcatAggregationData::reset() {
 
 // _____________________________________________________________________________
 [[nodiscard]] ValueId SampleAggregationData::calculateResult(
-    LocalVocab* localVocab) const {
+    [[maybe_unused]] const IndexImpl& index, LocalVocab* localVocab) const {
   if (!value_.has_value()) {
     return Id::makeUndefined();
   }

--- a/src/engine/GroupByHashMapOptimization.h
+++ b/src/engine/GroupByHashMapOptimization.h
@@ -45,7 +45,7 @@ struct AvgAggregationData {
 
   // _____________________________________________________________________________
   [[nodiscard]] ValueId calculateResult(
-      [[maybe_unused]] const IndexImpl& index,
+      [[maybe_unused]] const LocalVocabContext& context,
       [[maybe_unused]] const LocalVocab* localVocab) const;
 
   void reset() { *this = AvgAggregationData{}; }
@@ -64,7 +64,7 @@ struct CountAggregationData {
 
   // _____________________________________________________________________________
   [[nodiscard]] ValueId calculateResult(
-      [[maybe_unused]] const IndexImpl& index,
+      [[maybe_unused]] const LocalVocabContext& context,
       [[maybe_unused]] const LocalVocab* localVocab) const;
 
   void reset() { *this = CountAggregationData{}; }
@@ -90,8 +90,9 @@ struct ExtremumAggregationData {
   }
 
   // _____________________________________________________________________________
-  [[nodiscard]] ValueId calculateResult([[maybe_unused]] const IndexImpl& index,
-                                        LocalVocab* localVocab) const;
+  [[nodiscard]] ValueId calculateResult(
+      [[maybe_unused]] const LocalVocabContext& context,
+      LocalVocab* localVocab) const;
 
   void reset() { *this = ExtremumAggregationData{}; }
 };
@@ -133,7 +134,7 @@ struct SumAggregationData {
 
   // _____________________________________________________________________________
   [[nodiscard]] ValueId calculateResult(
-      [[maybe_unused]] const IndexImpl& index,
+      [[maybe_unused]] const LocalVocabContext& context,
       [[maybe_unused]] const LocalVocab* localVocab) const;
 
   void reset() { *this = SumAggregationData{}; }
@@ -163,7 +164,7 @@ struct GroupConcatAggregationData {
   void addValueImpl(
       const std::optional<ad_utility::triple_component::Literal>& value);
 
-  [[nodiscard]] ValueId calculateResult(const IndexImpl& index,
+  [[nodiscard]] ValueId calculateResult(const LocalVocabContext& context,
                                         LocalVocab* localVocab) const;
 
   explicit GroupConcatAggregationData(std::string_view separator);
@@ -184,8 +185,9 @@ struct SampleAggregationData {
   }
 
   // _____________________________________________________________________________
-  [[nodiscard]] ValueId calculateResult([[maybe_unused]] const IndexImpl& index,
-                                        LocalVocab* localVocab) const;
+  [[nodiscard]] ValueId calculateResult(
+      [[maybe_unused]] const LocalVocabContext& context,
+      LocalVocab* localVocab) const;
 
   void reset() { *this = SampleAggregationData{}; }
 };

--- a/src/engine/GroupByHashMapOptimization.h
+++ b/src/engine/GroupByHashMapOptimization.h
@@ -45,6 +45,7 @@ struct AvgAggregationData {
 
   // _____________________________________________________________________________
   [[nodiscard]] ValueId calculateResult(
+      [[maybe_unused]] const IndexImpl& index,
       [[maybe_unused]] const LocalVocab* localVocab) const;
 
   void reset() { *this = AvgAggregationData{}; }
@@ -63,6 +64,7 @@ struct CountAggregationData {
 
   // _____________________________________________________________________________
   [[nodiscard]] ValueId calculateResult(
+      [[maybe_unused]] const IndexImpl& index,
       [[maybe_unused]] const LocalVocab* localVocab) const;
 
   void reset() { *this = CountAggregationData{}; }
@@ -88,7 +90,8 @@ struct ExtremumAggregationData {
   }
 
   // _____________________________________________________________________________
-  [[nodiscard]] ValueId calculateResult(LocalVocab* localVocab) const;
+  [[nodiscard]] ValueId calculateResult([[maybe_unused]] const IndexImpl& index,
+                                        LocalVocab* localVocab) const;
 
   void reset() { *this = ExtremumAggregationData{}; }
 };
@@ -130,6 +133,7 @@ struct SumAggregationData {
 
   // _____________________________________________________________________________
   [[nodiscard]] ValueId calculateResult(
+      [[maybe_unused]] const IndexImpl& index,
       [[maybe_unused]] const LocalVocab* localVocab) const;
 
   void reset() { *this = SumAggregationData{}; }
@@ -159,7 +163,8 @@ struct GroupConcatAggregationData {
   void addValueImpl(
       const std::optional<ad_utility::triple_component::Literal>& value);
 
-  [[nodiscard]] ValueId calculateResult(LocalVocab* localVocab) const;
+  [[nodiscard]] ValueId calculateResult(const IndexImpl& index,
+                                        LocalVocab* localVocab) const;
 
   explicit GroupConcatAggregationData(std::string_view separator);
 
@@ -179,7 +184,8 @@ struct SampleAggregationData {
   }
 
   // _____________________________________________________________________________
-  [[nodiscard]] ValueId calculateResult(LocalVocab* localVocab) const;
+  [[nodiscard]] ValueId calculateResult([[maybe_unused]] const IndexImpl& index,
+                                        LocalVocab* localVocab) const;
 
   void reset() { *this = SampleAggregationData{}; }
 };

--- a/src/engine/GroupByImpl.cpp
+++ b/src/engine/GroupByImpl.cpp
@@ -1675,7 +1675,7 @@ IdTable GroupByImpl::createResultFromHashMap(
 
     for (auto& alias : aggregateAliases) {
       evaluateAlias(alias, &result, evaluationContext, aggregationData,
-                    getIndex(), localVocab, allocator());
+                    getLocalVocabContext(), localVocab, allocator());
     }
   }
   runtimeInfo().addDetail("timeEvaluationAndResults",

--- a/src/engine/GroupByImpl.cpp
+++ b/src/engine/GroupByImpl.cpp
@@ -1296,7 +1296,7 @@ GroupByImpl::getHashMapAggregationResults(
     IdTable* resultTable,
     const HashMapAggregationData<NUM_GROUP_COLUMNS>& aggregationData,
     size_t dataIndex, size_t beginIndex, size_t endIndex,
-    const IndexImpl& index, LocalVocab* localVocab,
+    const LocalVocabContext& context, LocalVocab* localVocab,
     const Allocator& allocator) {
   sparqlExpression::VectorWithMemoryLimit<ValueId> aggregateResults(allocator);
   aggregateResults.resize(endIndex - beginIndex);
@@ -1321,10 +1321,11 @@ GroupByImpl::getHashMapAggregationResults(
       vectorIdx = aggregationData.getIndex(mapKey);
     }
 
-    auto visitor = [&index, &aggregateResults, vectorIdx, rowIdx, beginIndex,
+    auto visitor = [&context, &aggregateResults, vectorIdx, rowIdx, beginIndex,
                     localVocab](auto& aggregateDataVariant) {
       aggregateResults[rowIdx - beginIndex] =
-          aggregateDataVariant.at(vectorIdx).calculateResult(index, localVocab);
+          aggregateDataVariant.at(vectorIdx).calculateResult(context,
+                                                             localVocab);
     };
 
     std::visit(visitor, aggregateDataVariant);
@@ -1366,8 +1367,8 @@ GroupByImpl::substituteAllAggregates(
     std::vector<HashMapAggregateInformation>& info, size_t beginIndex,
     size_t endIndex,
     const HashMapAggregationData<NUM_GROUP_COLUMNS>& aggregationData,
-    IdTable* resultTable, const IndexImpl& index, LocalVocab* localVocab,
-    const Allocator& allocator) {
+    IdTable* resultTable, const LocalVocabContext& context,
+    LocalVocab* localVocab, const Allocator& allocator) {
   std::vector<std::unique_ptr<sparqlExpression::SparqlExpression>>
       originalChildren;
   originalChildren.reserve(info.size());
@@ -1375,7 +1376,7 @@ GroupByImpl::substituteAllAggregates(
   for (auto& aggregate : info) {
     auto aggregateResults = getHashMapAggregationResults(
         resultTable, aggregationData, aggregate.aggregateDataIndex_, beginIndex,
-        endIndex, index, localVocab, allocator);
+        endIndex, context, localVocab, allocator);
 
     // Substitute the resulting vector as a literal
     auto newExpression = std::make_unique<sparqlExpression::VectorIdExpression>(
@@ -1482,8 +1483,8 @@ void GroupByImpl::substituteAndEvaluate(
     HashMapAliasInformation& alias, IdTable* result,
     sparqlExpression::EvaluationContext& evaluationContext,
     const HashMapAggregationData<NUM_GROUP_COLUMNS>& aggregationData,
-    const IndexImpl& index, LocalVocab* localVocab, const Allocator& allocator,
-    std::vector<HashMapAggregateInformation>& info,
+    const LocalVocabContext& context, LocalVocab* localVocab,
+    const Allocator& allocator, std::vector<HashMapAggregateInformation>& info,
     const std::vector<HashMapGroupedVariableInformation>& substitutions) {
   // Store which SPARQL expressions of grouped variables have been substituted.
   std::vector<std::pair<
@@ -1509,7 +1510,7 @@ void GroupByImpl::substituteAndEvaluate(
   std::vector<std::unique_ptr<sparqlExpression::SparqlExpression>>
       originalChildren = substituteAllAggregates(
           info, evaluationContext._beginIndex, evaluationContext._endIndex,
-          aggregationData, result, index, localVocab, allocator);
+          aggregationData, result, context, localVocab, allocator);
 
   // Evaluate top-level alias expression.
   sparqlExpression::ExpressionResult expressionResult =
@@ -1552,7 +1553,7 @@ void GroupByImpl::evaluateAlias(
     HashMapAliasInformation& alias, IdTable* result,
     sparqlExpression::EvaluationContext& evaluationContext,
     const HashMapAggregationData<NUM_GROUP_COLUMNS>& aggregationData,
-    const IndexImpl& index, LocalVocab* localVocab,
+    const LocalVocabContext& context, LocalVocab* localVocab,
     const Allocator& allocator) {
   auto& info = alias.aggregateInfo_;
 
@@ -1597,7 +1598,7 @@ void GroupByImpl::evaluateAlias(
     // Get aggregate results
     auto aggregateResults = getHashMapAggregationResults(
         result, aggregationData, aggregate.aggregateDataIndex_,
-        evaluationContext._beginIndex, evaluationContext._endIndex, index,
+        evaluationContext._beginIndex, evaluationContext._endIndex, context,
         localVocab, allocator);
 
     // Copy to result table
@@ -1610,9 +1611,9 @@ void GroupByImpl::evaluateAlias(
         sparqlExpression::copyExpressionResult(
             sparqlExpression::ExpressionResult{std::move(aggregateResults)});
   } else {
-    substituteAndEvaluate<NUM_GROUP_COLUMNS>(alias, result, evaluationContext,
-                                             aggregationData, index, localVocab,
-                                             allocator, info, substitutions);
+    substituteAndEvaluate<NUM_GROUP_COLUMNS>(
+        alias, result, evaluationContext, aggregationData, context, localVocab,
+        allocator, info, substitutions);
   }
 }
 

--- a/src/engine/GroupByImpl.cpp
+++ b/src/engine/GroupByImpl.cpp
@@ -1296,7 +1296,8 @@ GroupByImpl::getHashMapAggregationResults(
     IdTable* resultTable,
     const HashMapAggregationData<NUM_GROUP_COLUMNS>& aggregationData,
     size_t dataIndex, size_t beginIndex, size_t endIndex,
-    LocalVocab* localVocab, const Allocator& allocator) {
+    const IndexImpl& index, LocalVocab* localVocab,
+    const Allocator& allocator) {
   sparqlExpression::VectorWithMemoryLimit<ValueId> aggregateResults(allocator);
   aggregateResults.resize(endIndex - beginIndex);
 
@@ -1320,10 +1321,10 @@ GroupByImpl::getHashMapAggregationResults(
       vectorIdx = aggregationData.getIndex(mapKey);
     }
 
-    auto visitor = [&aggregateResults, vectorIdx, rowIdx, beginIndex,
+    auto visitor = [&index, &aggregateResults, vectorIdx, rowIdx, beginIndex,
                     localVocab](auto& aggregateDataVariant) {
       aggregateResults[rowIdx - beginIndex] =
-          aggregateDataVariant.at(vectorIdx).calculateResult(localVocab);
+          aggregateDataVariant.at(vectorIdx).calculateResult(index, localVocab);
     };
 
     std::visit(visitor, aggregateDataVariant);
@@ -1365,7 +1366,8 @@ GroupByImpl::substituteAllAggregates(
     std::vector<HashMapAggregateInformation>& info, size_t beginIndex,
     size_t endIndex,
     const HashMapAggregationData<NUM_GROUP_COLUMNS>& aggregationData,
-    IdTable* resultTable, LocalVocab* localVocab, const Allocator& allocator) {
+    IdTable* resultTable, const IndexImpl& index, LocalVocab* localVocab,
+    const Allocator& allocator) {
   std::vector<std::unique_ptr<sparqlExpression::SparqlExpression>>
       originalChildren;
   originalChildren.reserve(info.size());
@@ -1373,7 +1375,7 @@ GroupByImpl::substituteAllAggregates(
   for (auto& aggregate : info) {
     auto aggregateResults = getHashMapAggregationResults(
         resultTable, aggregationData, aggregate.aggregateDataIndex_, beginIndex,
-        endIndex, localVocab, allocator);
+        endIndex, index, localVocab, allocator);
 
     // Substitute the resulting vector as a literal
     auto newExpression = std::make_unique<sparqlExpression::VectorIdExpression>(
@@ -1480,7 +1482,7 @@ void GroupByImpl::substituteAndEvaluate(
     HashMapAliasInformation& alias, IdTable* result,
     sparqlExpression::EvaluationContext& evaluationContext,
     const HashMapAggregationData<NUM_GROUP_COLUMNS>& aggregationData,
-    LocalVocab* localVocab, const Allocator& allocator,
+    const IndexImpl& index, LocalVocab* localVocab, const Allocator& allocator,
     std::vector<HashMapAggregateInformation>& info,
     const std::vector<HashMapGroupedVariableInformation>& substitutions) {
   // Store which SPARQL expressions of grouped variables have been substituted.
@@ -1507,7 +1509,7 @@ void GroupByImpl::substituteAndEvaluate(
   std::vector<std::unique_ptr<sparqlExpression::SparqlExpression>>
       originalChildren = substituteAllAggregates(
           info, evaluationContext._beginIndex, evaluationContext._endIndex,
-          aggregationData, result, localVocab, allocator);
+          aggregationData, result, index, localVocab, allocator);
 
   // Evaluate top-level alias expression.
   sparqlExpression::ExpressionResult expressionResult =
@@ -1550,7 +1552,8 @@ void GroupByImpl::evaluateAlias(
     HashMapAliasInformation& alias, IdTable* result,
     sparqlExpression::EvaluationContext& evaluationContext,
     const HashMapAggregationData<NUM_GROUP_COLUMNS>& aggregationData,
-    LocalVocab* localVocab, const Allocator& allocator) {
+    const IndexImpl& index, LocalVocab* localVocab,
+    const Allocator& allocator) {
   auto& info = alias.aggregateInfo_;
 
   // Either:
@@ -1594,8 +1597,8 @@ void GroupByImpl::evaluateAlias(
     // Get aggregate results
     auto aggregateResults = getHashMapAggregationResults(
         result, aggregationData, aggregate.aggregateDataIndex_,
-        evaluationContext._beginIndex, evaluationContext._endIndex, localVocab,
-        allocator);
+        evaluationContext._beginIndex, evaluationContext._endIndex, index,
+        localVocab, allocator);
 
     // Copy to result table
     decltype(auto) outValues = result->getColumn(alias.outCol_);
@@ -1608,7 +1611,7 @@ void GroupByImpl::evaluateAlias(
             sparqlExpression::ExpressionResult{std::move(aggregateResults)});
   } else {
     substituteAndEvaluate<NUM_GROUP_COLUMNS>(alias, result, evaluationContext,
-                                             aggregationData, localVocab,
+                                             aggregationData, index, localVocab,
                                              allocator, info, substitutions);
   }
 }
@@ -1671,7 +1674,7 @@ IdTable GroupByImpl::createResultFromHashMap(
 
     for (auto& alias : aggregateAliases) {
       evaluateAlias(alias, &result, evaluationContext, aggregationData,
-                    localVocab, allocator());
+                    getIndex(), localVocab, allocator());
     }
   }
   runtimeInfo().addDetail("timeEvaluationAndResults",

--- a/src/engine/GroupByImpl.h
+++ b/src/engine/GroupByImpl.h
@@ -445,7 +445,8 @@ class GroupByImpl : public Operation {
       IdTable* resultTable,
       const HashMapAggregationData<NUM_GROUP_COLUMNS>& aggregationData,
       size_t dataIndex, size_t beginIndex, size_t endIndex,
-      LocalVocab* localVocab, const Allocator& allocator);
+      const IndexImpl& index, LocalVocab* localVocab,
+      const Allocator& allocator);
 
   // Helper function of `evaluateAlias`.
   // 1. In the Expressions for the aliases of this GROUP BY, replace all
@@ -464,7 +465,8 @@ class GroupByImpl : public Operation {
       HashMapAliasInformation& alias, IdTable* result,
       sparqlExpression::EvaluationContext& evaluationContext,
       const HashMapAggregationData<NUM_GROUP_COLUMNS>& aggregationData,
-      LocalVocab* localVocab, const Allocator& allocator,
+      const IndexImpl& index, LocalVocab* localVocab,
+      const Allocator& allocator,
       std::vector<HashMapAggregateInformation>& info,
       const std::vector<HashMapGroupedVariableInformation>& substitutions);
 
@@ -476,7 +478,8 @@ class GroupByImpl : public Operation {
       HashMapAliasInformation& alias, IdTable* result,
       sparqlExpression::EvaluationContext& evaluationContext,
       const HashMapAggregationData<NUM_GROUP_COLUMNS>& aggregationData,
-      LocalVocab* localVocab, const Allocator& allocator);
+      const IndexImpl& index, LocalVocab* localVocab,
+      const Allocator& allocator);
 
   // Helper function to evaluate the child expression of an aggregate function.
   // Only `COUNT(*)` does not have a single child, so we make a special case for
@@ -531,7 +534,7 @@ class GroupByImpl : public Operation {
           std::vector<HashMapAggregateInformation>& info, size_t beginIndex,
           size_t endIndex,
           const HashMapAggregationData<NUM_GROUP_COLUMNS>& aggregationData,
-          IdTable* resultTable, LocalVocab* localVocab,
+          IdTable* resultTable, const IndexImpl& index, LocalVocab* localVocab,
           const Allocator& allocator);
 
   // Check if an expression is a currently supported aggregate.

--- a/src/engine/GroupByImpl.h
+++ b/src/engine/GroupByImpl.h
@@ -445,7 +445,7 @@ class GroupByImpl : public Operation {
       IdTable* resultTable,
       const HashMapAggregationData<NUM_GROUP_COLUMNS>& aggregationData,
       size_t dataIndex, size_t beginIndex, size_t endIndex,
-      const IndexImpl& index, LocalVocab* localVocab,
+      const LocalVocabContext& context, LocalVocab* localVocab,
       const Allocator& allocator);
 
   // Helper function of `evaluateAlias`.
@@ -465,7 +465,7 @@ class GroupByImpl : public Operation {
       HashMapAliasInformation& alias, IdTable* result,
       sparqlExpression::EvaluationContext& evaluationContext,
       const HashMapAggregationData<NUM_GROUP_COLUMNS>& aggregationData,
-      const IndexImpl& index, LocalVocab* localVocab,
+      const LocalVocabContext& context, LocalVocab* localVocab,
       const Allocator& allocator,
       std::vector<HashMapAggregateInformation>& info,
       const std::vector<HashMapGroupedVariableInformation>& substitutions);
@@ -478,7 +478,7 @@ class GroupByImpl : public Operation {
       HashMapAliasInformation& alias, IdTable* result,
       sparqlExpression::EvaluationContext& evaluationContext,
       const HashMapAggregationData<NUM_GROUP_COLUMNS>& aggregationData,
-      const IndexImpl& index, LocalVocab* localVocab,
+      const LocalVocabContext& context, LocalVocab* localVocab,
       const Allocator& allocator);
 
   // Helper function to evaluate the child expression of an aggregate function.
@@ -534,8 +534,8 @@ class GroupByImpl : public Operation {
           std::vector<HashMapAggregateInformation>& info, size_t beginIndex,
           size_t endIndex,
           const HashMapAggregationData<NUM_GROUP_COLUMNS>& aggregationData,
-          IdTable* resultTable, const IndexImpl& index, LocalVocab* localVocab,
-          const Allocator& allocator);
+          IdTable* resultTable, const LocalVocabContext& context,
+          LocalVocab* localVocab, const Allocator& allocator);
 
   // Check if an expression is a currently supported aggregate.
   static std::optional<HashMapAggregateTypeWithData> isSupportedAggregate(

--- a/src/engine/IndexScan.cpp
+++ b/src/engine/IndexScan.cpp
@@ -235,7 +235,7 @@ IndexScan::getUpdatedQueryExecutionTreeWithPrefilterApplied(
   if (it != prefilterVariablePairs.end()) {
     const auto& blockMetadataRanges =
         prefilterExpressions::detail::logicalOps::getIntersectionOfBlockRanges(
-            it->first->evaluate(getIndex(),
+            it->first->evaluate(getLocalVocabContext(),
                                 getScanSpecAndBlocks().getBlockMetadataSpan(),
                                 colIndex),
             scanSpecAndBlocks_.blockMetadata_);

--- a/src/engine/IndexScan.cpp
+++ b/src/engine/IndexScan.cpp
@@ -233,11 +233,11 @@ IndexScan::getUpdatedQueryExecutionTreeWithPrefilterApplied(
   auto it =
       ql::ranges::find(prefilterVariablePairs, sortedVar, ad_utility::second);
   if (it != prefilterVariablePairs.end()) {
-    const auto& vocab = getIndex().getVocab();
     const auto& blockMetadataRanges =
         prefilterExpressions::detail::logicalOps::getIntersectionOfBlockRanges(
-            it->first->evaluate(
-                vocab, getScanSpecAndBlocks().getBlockMetadataSpan(), colIndex),
+            it->first->evaluate(getIndex(),
+                                getScanSpecAndBlocks().getBlockMetadataSpan(),
+                                colIndex),
             scanSpecAndBlocks_.blockMetadata_);
 
     return makeCopyWithPrefilteredScanSpecAndBlocks(

--- a/src/engine/LazyGroupBy.cpp
+++ b/src/engine/LazyGroupBy.cpp
@@ -60,9 +60,10 @@ void LazyGroupBy::commitRow(
   evaluationContext._endIndex = resultTable.size();
 
   for (auto& alias : aggregateAliases_) {
-    GroupByImpl::evaluateAlias(
-        alias, &resultTable, evaluationContext, aggregationData_,
-        evaluationContext._qec.getIndex(), &localVocab_, allocator_);
+    GroupByImpl::evaluateAlias(alias, &resultTable, evaluationContext,
+                               aggregationData_,
+                               evaluationContext._qec.getLocalVocabContext(),
+                               &localVocab_, allocator_);
   }
   resetAggregationData();
 }

--- a/src/engine/LazyGroupBy.cpp
+++ b/src/engine/LazyGroupBy.cpp
@@ -60,8 +60,9 @@ void LazyGroupBy::commitRow(
   evaluationContext._endIndex = resultTable.size();
 
   for (auto& alias : aggregateAliases_) {
-    GroupByImpl::evaluateAlias(alias, &resultTable, evaluationContext,
-                               aggregationData_, &localVocab_, allocator_);
+    GroupByImpl::evaluateAlias(
+        alias, &resultTable, evaluationContext, aggregationData_,
+        evaluationContext._qec.getIndex(), &localVocab_, allocator_);
   }
   resetAggregationData();
 }

--- a/src/engine/NamedResultCache.h
+++ b/src/engine/NamedResultCache.h
@@ -37,12 +37,11 @@ class NamedResultCache {
     std::string cacheKey_;
     std::optional<SpatialJoinCachedIndex> cachedGeoIndex_;
 
-    // The following two members (`Allocator` and `BlankNodeManager`) are only
+    // The following two members (`Allocator` and `IndexImpl`) are only
     // used when reading a `Value` from a serializer.
     using Allocator = ad_utility::AllocatorWithLimit<Id>;
     std::optional<Allocator> allocatorForSerialization_{std::nullopt};
-    boost::optional<ad_utility::BlankNodeManager&>
-        blankNodeManagerForSerialization_{boost::none};
+    const IndexImpl* indexForSerialization_{nullptr};
   };
 
   // The size of a cached result, which currently is just a dummy value of 1,
@@ -111,8 +110,7 @@ class NamedResultCache {
       requires ad_utility::serialization::ReadSerializer<
           Serializer>) void readFromSerializer(Serializer& serializer,
                                                Value::Allocator allocator,
-                                               ad_utility::BlankNodeManager&
-                                                   blankNodeManager);
+                                               const IndexImpl& index);
 };
 
 #endif  // QLEVER_SRC_ENGINE_NAMEDRESULTCACHE_H

--- a/src/engine/NamedResultCache.h
+++ b/src/engine/NamedResultCache.h
@@ -37,11 +37,11 @@ class NamedResultCache {
     std::string cacheKey_;
     std::optional<SpatialJoinCachedIndex> cachedGeoIndex_;
 
-    // The following two members (`Allocator` and `IndexImpl`) are only
+    // The following two members (`Allocator` and `LocalVocabContext`) are only
     // used when reading a `Value` from a serializer.
     using Allocator = ad_utility::AllocatorWithLimit<Id>;
     std::optional<Allocator> allocatorForSerialization_{std::nullopt};
-    const IndexImpl* indexForSerialization_{nullptr};
+    const LocalVocabContext* contextForSerialization_{nullptr};
   };
 
   // The size of a cached result, which currently is just a dummy value of 1,
@@ -110,7 +110,8 @@ class NamedResultCache {
       requires ad_utility::serialization::ReadSerializer<
           Serializer>) void readFromSerializer(Serializer& serializer,
                                                Value::Allocator allocator,
-                                               const IndexImpl& index);
+                                               const LocalVocabContext&
+                                                   context);
 };
 
 #endif  // QLEVER_SRC_ENGINE_NAMEDRESULTCACHE_H

--- a/src/engine/NamedResultCacheSerializer.h
+++ b/src/engine/NamedResultCacheSerializer.h
@@ -44,7 +44,7 @@ CPP_template_def(typename Serializer)(
     requires ad_utility::serialization::ReadSerializer<
         Serializer>) void NamedResultCache::
     readFromSerializer(Serializer& serializer, Value::Allocator allocator,
-                       const IndexImpl& index) {
+                       const LocalVocabContext& context) {
   // Clear the cache first.
   clear();
 
@@ -61,7 +61,7 @@ CPP_template_def(typename Serializer)(
     // Deserialize the value.
     Value value;
     value.allocatorForSerialization_ = allocator;
-    value.indexForSerialization_ = &index;
+    value.contextForSerialization_ = &context;
     serializer >> value;
 
     // Use the store method to maintain consistency.
@@ -131,9 +131,9 @@ AD_SERIALIZE_FUNCTION_WITH_CONSTRAINT(
     }
   } else {
     // Deserialize the LocalVocab and get the ID mapping.
-    AD_CORRECTNESS_CHECK(arg.indexForSerialization_ != nullptr);
+    AD_CORRECTNESS_CHECK(arg.contextForSerialization_ != nullptr);
     auto [localVocab, mapping] = ad_utility::detail::deserializeLocalVocab(
-        serializer, *arg.indexForSerialization_);
+        serializer, *arg.contextForSerialization_);
 
     // Deserialize the IdTable with ID mapping applied.
     size_t numRows, numColumns;

--- a/src/engine/NamedResultCacheSerializer.h
+++ b/src/engine/NamedResultCacheSerializer.h
@@ -44,7 +44,7 @@ CPP_template_def(typename Serializer)(
     requires ad_utility::serialization::ReadSerializer<
         Serializer>) void NamedResultCache::
     readFromSerializer(Serializer& serializer, Value::Allocator allocator,
-                       ad_utility::BlankNodeManager& blankNodeManager) {
+                       const IndexImpl& index) {
   // Clear the cache first.
   clear();
 
@@ -61,7 +61,7 @@ CPP_template_def(typename Serializer)(
     // Deserialize the value.
     Value value;
     value.allocatorForSerialization_ = allocator;
-    value.blankNodeManagerForSerialization_ = blankNodeManager;
+    value.indexForSerialization_ = &index;
     serializer >> value;
 
     // Use the store method to maintain consistency.
@@ -131,9 +131,9 @@ AD_SERIALIZE_FUNCTION_WITH_CONSTRAINT(
     }
   } else {
     // Deserialize the LocalVocab and get the ID mapping.
-    AD_CORRECTNESS_CHECK(arg.blankNodeManagerForSerialization_.has_value());
+    AD_CORRECTNESS_CHECK(arg.indexForSerialization_ != nullptr);
     auto [localVocab, mapping] = ad_utility::detail::deserializeLocalVocab(
-        serializer, &arg.blankNodeManagerForSerialization_.value());
+        serializer, *arg.indexForSerialization_);
 
     // Deserialize the IdTable with ID mapping applied.
     size_t numRows, numColumns;

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -548,6 +548,10 @@ class Operation {
   // of the result).
   virtual bool columnOriginatesFromGraphOrUndef(const Variable& variable) const;
 
+  // Helper function to abstract away the fact that our context is currently
+  // just the index.
+  const LocalVocabContext& getLocalVocabContext() const { return getIndex(); }
+
  private:
   // Create the runtime information in case the evaluation of this operation has
   // failed.

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -548,8 +548,8 @@ class Operation {
   // of the result).
   virtual bool columnOriginatesFromGraphOrUndef(const Variable& variable) const;
 
-  // Helper function to abstract away the fact that our context is currently
-  // just the index.
+  // Helper function to abstract away the fact that `LocalVocabContext` is
+  // currently just an alias for `IndexImpl`.
   const LocalVocabContext& getLocalVocabContext() const { return getIndex(); }
 
  private:

--- a/src/engine/QueryExecutionContext.h
+++ b/src/engine/QueryExecutionContext.h
@@ -204,6 +204,10 @@ class QueryExecutionContext
   auto& pinResultWithName() { return pinResultWithName_; }
   const auto& pinResultWithName() const { return pinResultWithName_; }
 
+  // Helper function to abstract away the fact that our context is currently
+  // just the index.
+  const LocalVocabContext& getLocalVocabContext() const { return getIndex(); }
+
  private:
   // Helper functions to avoid including `global/RuntimeParameters.h` in this
   // header.

--- a/src/engine/QueryExecutionContext.h
+++ b/src/engine/QueryExecutionContext.h
@@ -204,8 +204,8 @@ class QueryExecutionContext
   auto& pinResultWithName() { return pinResultWithName_; }
   const auto& pinResultWithName() const { return pinResultWithName_; }
 
-  // Helper function to abstract away the fact that our context is currently
-  // just the index.
+  // Helper function to abstract away the fact that `LocalVocabContext` is
+  // currently just an alias for `IndexImpl`.
   const LocalVocabContext& getLocalVocabContext() const { return getIndex(); }
 
  private:

--- a/src/engine/sparqlExpressions/BlankNodeExpression.cpp
+++ b/src/engine/sparqlExpressions/BlankNodeExpression.cpp
@@ -113,7 +113,7 @@ class BlankNodeExpression : public SparqlExpression {
                 LiteralOrIri{
                     ad_utility::triple_component::Iri::fromStringRepresentation(
                         std::move(uniqueIri))},
-                context->_qec.getIndex()});
+                context->getLocalVocabContext()});
           } else {
             result.push_back(Id::makeUndefined());
             ++counter_;

--- a/src/engine/sparqlExpressions/BlankNodeExpression.cpp
+++ b/src/engine/sparqlExpressions/BlankNodeExpression.cpp
@@ -109,11 +109,8 @@ class BlankNodeExpression : public SparqlExpression {
             auto uniqueIri = absl::StrCat(QLEVER_INTERNAL_BLANK_NODE_IRI_PREFIX,
                                           "_:", blankNodePrefix, label.value(),
                                           "_", counter_++, ">");
-            result.push_back(LocalVocabEntry{
-                LiteralOrIri{
-                    ad_utility::triple_component::Iri::fromStringRepresentation(
-                        std::move(uniqueIri))},
-                context->getLocalVocabContext()});
+            result.push_back(LocalVocabEntry::fromStringRepresentation(
+                std::move(uniqueIri), context->getLocalVocabContext()));
           } else {
             result.push_back(Id::makeUndefined());
             ++counter_;

--- a/src/engine/sparqlExpressions/BlankNodeExpression.cpp
+++ b/src/engine/sparqlExpressions/BlankNodeExpression.cpp
@@ -99,7 +99,7 @@ class BlankNodeExpression : public SparqlExpression {
 
     ad_utility::chunkedForLoop<1000>(
         0, numElements,
-        [this, &result, &blankNodePrefix, &getNextLabel](size_t) {
+        [this, &result, context, &blankNodePrefix, &getNextLabel](size_t) {
           const auto& label = getNextLabel();
           // TODO<RobinTF> Encoding blank nodes as IRIs is very
           // memory-inefficient given that we only need to ensure distinctness.
@@ -109,9 +109,11 @@ class BlankNodeExpression : public SparqlExpression {
             auto uniqueIri = absl::StrCat(QLEVER_INTERNAL_BLANK_NODE_IRI_PREFIX,
                                           "_:", blankNodePrefix, label.value(),
                                           "_", counter_++, ">");
-            result.push_back(LiteralOrIri{
-                ad_utility::triple_component::Iri::fromStringRepresentation(
-                    std::move(uniqueIri))});
+            result.push_back(LocalVocabEntry{
+                LiteralOrIri{
+                    ad_utility::triple_component::Iri::fromStringRepresentation(
+                        std::move(uniqueIri))},
+                context->_qec.getIndex()});
           } else {
             result.push_back(Id::makeUndefined());
             ++counter_;

--- a/src/engine/sparqlExpressions/GroupConcatExpression.cpp
+++ b/src/engine/sparqlExpressions/GroupConcatExpression.cpp
@@ -58,11 +58,8 @@ sparqlExpression::GroupConcatExpression::evaluate(
     if (undefined) {
       return Id::makeUndefined();
     }
-    return IdOrLocalVocabEntry{LocalVocabEntry{
-        ad_utility::triple_component::LiteralOrIri{
-            ad_utility::triple_component::Literal::literalWithNormalizedContent(
-                asNormalizedStringViewUnsafe(result))},
-        context->getLocalVocabContext()}};
+    return IdOrLocalVocabEntry{LocalVocabEntry::literalWithNormalizedContent(
+        asNormalizedStringViewUnsafe(result), context->getLocalVocabContext())};
   };
 
   auto childRes = child_->evaluate(context);

--- a/src/engine/sparqlExpressions/GroupConcatExpression.cpp
+++ b/src/engine/sparqlExpressions/GroupConcatExpression.cpp
@@ -62,7 +62,7 @@ sparqlExpression::GroupConcatExpression::evaluate(
         ad_utility::triple_component::LiteralOrIri{
             ad_utility::triple_component::Literal::literalWithNormalizedContent(
                 asNormalizedStringViewUnsafe(result))},
-        context->_qec.getIndex()}};
+        context->getLocalVocabContext()}};
   };
 
   auto childRes = child_->evaluate(context);

--- a/src/engine/sparqlExpressions/GroupConcatExpression.cpp
+++ b/src/engine/sparqlExpressions/GroupConcatExpression.cpp
@@ -58,9 +58,11 @@ sparqlExpression::GroupConcatExpression::evaluate(
     if (undefined) {
       return Id::makeUndefined();
     }
-    return IdOrLocalVocabEntry{ad_utility::triple_component::LiteralOrIri{
-        ad_utility::triple_component::Literal::literalWithNormalizedContent(
-            asNormalizedStringViewUnsafe(result))}};
+    return IdOrLocalVocabEntry{LocalVocabEntry{
+        ad_utility::triple_component::LiteralOrIri{
+            ad_utility::triple_component::Literal::literalWithNormalizedContent(
+                asNormalizedStringViewUnsafe(result))},
+        context->_qec.getIndex()}};
   };
 
   auto childRes = child_->evaluate(context);

--- a/src/engine/sparqlExpressions/IsSomethingExpressions.cpp
+++ b/src/engine/sparqlExpressions/IsSomethingExpressions.cpp
@@ -31,7 +31,7 @@ CPP_class_template(typename NaryOperation,
  public:
   using NaryExpression<NaryOperation>::NaryExpression;
   std::vector<PrefilterExprVariablePair> getPrefilterExpressionForMetadata(
-      [[maybe_unused]] const IndexImpl& index,
+      [[maybe_unused]] const LocalVocabContext& context,
       [[maybe_unused]] bool isNegated) const override {
     using namespace prefilterExpressions;
     std::vector<PrefilterExprVariablePair> prefilterVec;

--- a/src/engine/sparqlExpressions/IsSomethingExpressions.cpp
+++ b/src/engine/sparqlExpressions/IsSomethingExpressions.cpp
@@ -31,6 +31,7 @@ CPP_class_template(typename NaryOperation,
  public:
   using NaryExpression<NaryOperation>::NaryExpression;
   std::vector<PrefilterExprVariablePair> getPrefilterExpressionForMetadata(
+      [[maybe_unused]] const IndexImpl& index,
       [[maybe_unused]] bool isNegated) const override {
     using namespace prefilterExpressions;
     std::vector<PrefilterExprVariablePair> prefilterVec;

--- a/src/engine/sparqlExpressions/LiteralExpression.h
+++ b/src/engine/sparqlExpressions/LiteralExpression.h
@@ -267,15 +267,15 @@ using IdOrLocalVocabEntry = prefilterExpressions::IdOrLocalVocabEntry;
 // contain a suitable type.
 inline std::optional<IdOrLocalVocabEntry>
 getIdOrLocalVocabEntryFromLiteralExpression(const SparqlExpression* child,
-                                            const IndexImpl& index) {
+                                            const LocalVocabContext& context) {
   using enum Datatype;
   if (const auto* idExpr = dynamic_cast<const IdExpression*>(child)) {
     return idExpr->value();
   } else if (const auto* literalExpr =
                  dynamic_cast<const StringLiteralExpression*>(child)) {
-    return LocalVocabEntry{literalExpr->value(), index};
+    return LocalVocabEntry{literalExpr->value(), context};
   } else if (const auto* iriExpr = dynamic_cast<const IriExpression*>(child)) {
-    return LocalVocabEntry{iriExpr->value(), index};
+    return LocalVocabEntry{iriExpr->value(), context};
   } else {
     return std::nullopt;
   }

--- a/src/engine/sparqlExpressions/LiteralExpression.h
+++ b/src/engine/sparqlExpressions/LiteralExpression.h
@@ -57,7 +57,7 @@ class LiteralExpression : public SparqlExpression {
           id.has_value() ? IdOrLocalVocabEntry{id.value()}
                          : IdOrLocalVocabEntry{LocalVocabEntry{
                                ad_utility::triple_component::LiteralOrIri{s},
-                               context->_qec.getIndex()}};
+                               context->getLocalVocabContext()}};
       auto ptrForCache = std::make_unique<IdOrLocalVocabEntry>(result);
       ptrForCache.reset(std::atomic_exchange_explicit(
           &cachedResult_, ptrForCache.release(), std::memory_order_relaxed));

--- a/src/engine/sparqlExpressions/LiteralExpression.h
+++ b/src/engine/sparqlExpressions/LiteralExpression.h
@@ -56,8 +56,7 @@ class LiteralExpression : public SparqlExpression {
       IdOrLocalVocabEntry result =
           id.has_value() ? IdOrLocalVocabEntry{id.value()}
                          : IdOrLocalVocabEntry{LocalVocabEntry{
-                               ad_utility::triple_component::LiteralOrIri{s},
-                               context->getLocalVocabContext()}};
+                               s, context->getLocalVocabContext()}};
       auto ptrForCache = std::make_unique<IdOrLocalVocabEntry>(result);
       ptrForCache.reset(std::atomic_exchange_explicit(
           &cachedResult_, ptrForCache.release(), std::memory_order_relaxed));

--- a/src/engine/sparqlExpressions/LiteralExpression.h
+++ b/src/engine/sparqlExpressions/LiteralExpression.h
@@ -56,7 +56,8 @@ class LiteralExpression : public SparqlExpression {
       IdOrLocalVocabEntry result =
           id.has_value() ? IdOrLocalVocabEntry{id.value()}
                          : IdOrLocalVocabEntry{LocalVocabEntry{
-                               ad_utility::triple_component::LiteralOrIri{s}}};
+                               ad_utility::triple_component::LiteralOrIri{s},
+                               context->_qec.getIndex()}};
       auto ptrForCache = std::make_unique<IdOrLocalVocabEntry>(result);
       ptrForCache.reset(std::atomic_exchange_explicit(
           &cachedResult_, ptrForCache.release(), std::memory_order_relaxed));
@@ -265,15 +266,16 @@ using IdOrLocalVocabEntry = prefilterExpressions::IdOrLocalVocabEntry;
 // (`std::variant<ValueId, LocalVocabEntry>`) for `LiteralExpression`s that
 // contain a suitable type.
 inline std::optional<IdOrLocalVocabEntry>
-getIdOrLocalVocabEntryFromLiteralExpression(const SparqlExpression* child) {
+getIdOrLocalVocabEntryFromLiteralExpression(const SparqlExpression* child,
+                                            const IndexImpl& index) {
   using enum Datatype;
   if (const auto* idExpr = dynamic_cast<const IdExpression*>(child)) {
     return idExpr->value();
   } else if (const auto* literalExpr =
                  dynamic_cast<const StringLiteralExpression*>(child)) {
-    return LocalVocabEntry{literalExpr->value()};
+    return LocalVocabEntry{literalExpr->value(), index};
   } else if (const auto* iriExpr = dynamic_cast<const IriExpression*>(child)) {
-    return LocalVocabEntry{iriExpr->value()};
+    return LocalVocabEntry{iriExpr->value(), index};
   } else {
     return std::nullopt;
   }

--- a/src/engine/sparqlExpressions/NaryExpressionImpl.h
+++ b/src/engine/sparqlExpressions/NaryExpressionImpl.h
@@ -86,7 +86,8 @@ class NaryExpressionStronglyTyped : public SparqlExpression {
       VectorWithMemoryLimit<ResultType> result{context->_allocator};
       result.reserve(targetSize);
       for (auto&& element : resultGenerator) {
-        result.push_back(promoteToLocalVocabEntry(std::move(element)));
+        result.push_back(promoteToLocalVocabEntry(std::move(element),
+                                                  context->_qec.getIndex()));
       }
 
       if constexpr (resultIsConstant) {
@@ -241,9 +242,11 @@ class NaryExpressionTypeErasedImpl : public SparqlExpression {
     // Apply the `function_` on a tuple of arguments (the `zipper` above has
     // tuples as value and reference type).
     auto onTuple = [&](auto&& tuple) {
-      return promoteToLocalVocabEntry(std::apply(
-          [this](auto&&... args) { return function_(AD_FWD(args)...); },
-          AD_FWD(tuple)));
+      return promoteToLocalVocabEntry(
+          std::apply(
+              [this](auto&&... args) { return function_(AD_FWD(args)...); },
+              AD_FWD(tuple)),
+          context->_qec.getIndex());
     };
     auto resultGenerator =
         ql::views::transform(ql::ranges::ref_view(zipper), onTuple);

--- a/src/engine/sparqlExpressions/NaryExpressionImpl.h
+++ b/src/engine/sparqlExpressions/NaryExpressionImpl.h
@@ -86,8 +86,8 @@ class NaryExpressionStronglyTyped : public SparqlExpression {
       VectorWithMemoryLimit<ResultType> result{context->_allocator};
       result.reserve(targetSize);
       for (auto&& element : resultGenerator) {
-        result.push_back(promoteToLocalVocabEntry(std::move(element),
-                                                  context->_qec.getIndex()));
+        result.push_back(promoteToLocalVocabEntry(
+            std::move(element), context->getLocalVocabContext()));
       }
 
       if constexpr (resultIsConstant) {
@@ -246,7 +246,7 @@ class NaryExpressionTypeErasedImpl : public SparqlExpression {
           std::apply(
               [this](auto&&... args) { return function_(AD_FWD(args)...); },
               AD_FWD(tuple)),
-          context->_qec.getIndex());
+          context->getLocalVocabContext());
     };
     auto resultGenerator =
         ql::views::transform(ql::ranges::ref_view(zipper), onTuple);

--- a/src/engine/sparqlExpressions/NumericBinaryExpressions.cpp
+++ b/src/engine/sparqlExpressions/NumericBinaryExpressions.cpp
@@ -374,13 +374,13 @@ CPP_template(typename BinaryPrefilterExpr, typename NaryOperation)(
   using NaryExpression<NaryOperation>::NaryExpression;
 
   std::vector<PrefilterExprVariablePair> getPrefilterExpressionForMetadata(
-      const IndexImpl& index, bool isNegated) const override {
+      const LocalVocabContext& context, bool isNegated) const override {
     const auto& children = this->children();
     AD_CORRECTNESS_CHECK(children.size() == 2);
     auto leftChild =
-        children[0]->getPrefilterExpressionForMetadata(index, isNegated);
+        children[0]->getPrefilterExpressionForMetadata(context, isNegated);
     auto rightChild =
-        children[1]->getPrefilterExpressionForMetadata(index, isNegated);
+        children[1]->getPrefilterExpressionForMetadata(context, isNegated);
     return constructPrefilterExpr::getMergeFunction<BinaryPrefilterExpr>(
         isNegated)(std::move(leftChild), std::move(rightChild));
   }

--- a/src/engine/sparqlExpressions/NumericBinaryExpressions.cpp
+++ b/src/engine/sparqlExpressions/NumericBinaryExpressions.cpp
@@ -374,11 +374,13 @@ CPP_template(typename BinaryPrefilterExpr, typename NaryOperation)(
   using NaryExpression<NaryOperation>::NaryExpression;
 
   std::vector<PrefilterExprVariablePair> getPrefilterExpressionForMetadata(
-      bool isNegated) const override {
+      const IndexImpl& index, bool isNegated) const override {
     const auto& children = this->children();
     AD_CORRECTNESS_CHECK(children.size() == 2);
-    auto leftChild = children[0]->getPrefilterExpressionForMetadata(isNegated);
-    auto rightChild = children[1]->getPrefilterExpressionForMetadata(isNegated);
+    auto leftChild =
+        children[0]->getPrefilterExpressionForMetadata(index, isNegated);
+    auto rightChild =
+        children[1]->getPrefilterExpressionForMetadata(index, isNegated);
     return constructPrefilterExpr::getMergeFunction<BinaryPrefilterExpr>(
         isNegated)(std::move(leftChild), std::move(rightChild));
   }

--- a/src/engine/sparqlExpressions/NumericUnaryExpressions.cpp
+++ b/src/engine/sparqlExpressions/NumericUnaryExpressions.cpp
@@ -33,7 +33,7 @@ CPP_template(typename NaryOperation)(
   using NaryExpression<NaryOperation>::NaryExpression;
 
   std::vector<PrefilterExprVariablePair> getPrefilterExpressionForMetadata(
-      const IndexImpl& index, bool isNegated) const override {
+      const LocalVocabContext& context, bool isNegated) const override {
     AD_CORRECTNESS_CHECK(this->N == 1);
     namespace p = prefilterExpressions;
     // The bool flag isNegated (by default false) acts as decision variable
@@ -68,7 +68,7 @@ CPP_template(typename NaryOperation)(
     // {<(!(>= IntId(10))), ?x>, <(!(>= IntId(10))), ?y>}
     // => Result (2): {<(< IntId(10)), ?x>, <(< IntId(10)), ?y>}
     auto child = this->children()[0].get()->getPrefilterExpressionForMetadata(
-        index, !isNegated);
+        context, !isNegated);
     ql::ranges::for_each(
         child | ql::views::keys,
         [](std::unique_ptr<p::PrefilterExpression>& expression) {

--- a/src/engine/sparqlExpressions/NumericUnaryExpressions.cpp
+++ b/src/engine/sparqlExpressions/NumericUnaryExpressions.cpp
@@ -33,7 +33,7 @@ CPP_template(typename NaryOperation)(
   using NaryExpression<NaryOperation>::NaryExpression;
 
   std::vector<PrefilterExprVariablePair> getPrefilterExpressionForMetadata(
-      bool isNegated) const override {
+      const IndexImpl& index, bool isNegated) const override {
     AD_CORRECTNESS_CHECK(this->N == 1);
     namespace p = prefilterExpressions;
     // The bool flag isNegated (by default false) acts as decision variable
@@ -68,7 +68,7 @@ CPP_template(typename NaryOperation)(
     // {<(!(>= IntId(10))), ?x>, <(!(>= IntId(10))), ?y>}
     // => Result (2): {<(< IntId(10)), ?x>, <(< IntId(10)), ?y>}
     auto child = this->children()[0].get()->getPrefilterExpressionForMetadata(
-        !isNegated);
+        index, !isNegated);
     ql::ranges::for_each(
         child | ql::views::keys,
         [](std::unique_ptr<p::PrefilterExpression>& expression) {

--- a/src/engine/sparqlExpressions/PrefilterExpressionIndex.cpp
+++ b/src/engine/sparqlExpressions/PrefilterExpressionIndex.cpp
@@ -9,6 +9,7 @@
 #include <absl/functional/bind_front.h>
 
 #include "global/ValueIdComparators.h"
+#include "index/IndexImpl.h"
 #include "util/ConstexprMap.h"
 #include "util/OverloadCallOperator.h"
 
@@ -366,7 +367,7 @@ ValueId AccessValueIdFromBlockMetadata::operator()(
 // SECTION PREFILTER EXPRESSION (BASE CLASS)
 //______________________________________________________________________________
 BlockMetadataRanges PrefilterExpression::evaluate(
-    const Vocab& vocab, BlockMetadataSpan blockRange,
+    const IndexImpl& index, BlockMetadataSpan blockRange,
     size_t evaluationColumn) const {
   if (blockRange.size() < 3) {
     return {{blockRange.begin(), blockRange.end()}};
@@ -391,7 +392,7 @@ BlockMetadataRanges PrefilterExpression::evaluate(
         ValueIdIt{&blockRange, 0, accessValueIdOp},
         ValueIdIt{&blockRange, blockRange.size() * 2, accessValueIdOp}};
     result = detail::logicalOps::mergeRelevantBlockItRanges<true>(
-        evaluateImpl(vocab, idRange, blockRange, false),
+        evaluateImpl(index, idRange, blockRange, false),
         // always add mixed datatype blocks
         getRangesMixedDatatypeBlocks(idRange, blockRange));
   }
@@ -451,21 +452,24 @@ std::string PrefixRegexExpression::asString(
 
 //______________________________________________________________________________
 BlockMetadataRanges PrefixRegexExpression::evaluateImpl(
-    const Vocab& vocab, const ValueIdSubrange& idRange,
+    const IndexImpl& index, const ValueIdSubrange& idRange,
     BlockMetadataSpan blockRange, bool getTotalComplement) const {
   static_assert(Datatype::LocalVocabIndex > Datatype::VocabIndex);
   static_assert(Vocab::PrefixRanges::Ranges{}.size() == 1);
-  using LVE = LocalVocabEntry;
   LocalVocab localVocab{};
   auto prefixQuoted =
       absl::StrCat("\"", asStringViewUnsafe(prefixLiteral_.getContent()));
   auto [lowerVocabIndex, upperVocabIndex] =
-      vocab.prefixRanges(prefixQuoted).ranges().front();
+      index.getVocab().prefixRanges(prefixQuoted).ranges().front();
 
   // Set lower reference.
   const auto& lowerIdVocab = Id::makeFromVocabIndex(lowerVocabIndex);
   const auto& beginIdIri = getValueIdFromIdOrLocalVocabEntry(
-      LVE::fromStringRepresentation("<>"), localVocab);
+      LocalVocabEntry{
+          ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
+              "<>"),
+          index},
+      localVocab);
 
   // The `vocab.prefixRanges` returns the correct bounds only for preindexed
   // vocab entries, there might be local vocab entries in `(lowerVocabIndex-1,
@@ -481,7 +485,7 @@ BlockMetadataRanges PrefixRegexExpression::evaluateImpl(
                make<LessThanExpression>(lowerIdVocab),
                make<AndExpression>(make<GreaterThanExpression>(upperIdAdjusted),
                                    make<LessThanExpression>(beginIdIri)))
-        .evaluateImpl(vocab, idRange, blockRange, getTotalComplement);
+        .evaluateImpl(index, idRange, blockRange, getTotalComplement);
   }
 
   // Set expression associated with the lower reference.
@@ -491,13 +495,13 @@ BlockMetadataRanges PrefixRegexExpression::evaluateImpl(
                                 lowerVocabIndex.decremented()));
   // Set expression associated with the upper reference.
   auto upperRefExpr =
-      upperVocabIndex.get() == vocab.size()
+      upperVocabIndex.get() == index.getVocab().size()
           ? make<LessThanExpression>(beginIdIri)
           : make<LessThanExpression>(Id::makeFromVocabIndex(upperVocabIndex));
   // Case `STRSTARTS(?var, "prefix")` or `REGEX(?var, "^prefix")`.
   // Prefilter ?var > Id(prev("prefix)) && ?var < Id(next("prefix)).
   return AndExpression(std::move(lowerRefExpr), std::move(upperRefExpr))
-      .evaluateImpl(vocab, idRange, blockRange, getTotalComplement);
+      .evaluateImpl(index, idRange, blockRange, getTotalComplement);
 }
 
 // SECTION RELATIONAL OPERATIONS
@@ -525,7 +529,7 @@ RelationalExpression<Comparison>::logicalComplement() const {
 //______________________________________________________________________________
 template <CompOp Comparison>
 BlockMetadataRanges RelationalExpression<Comparison>::evaluateImpl(
-    [[maybe_unused]] const Vocab& vocab, const ValueIdSubrange& idRange,
+    [[maybe_unused]] const IndexImpl& index, const ValueIdSubrange& idRange,
     BlockMetadataSpan blockRange, bool getTotalComplement) const {
   using namespace valueIdComparators;
   // If `rightSideReferenceValue_` contains a `LocalVocabEntry` value, we use
@@ -656,7 +660,7 @@ static BlockMetadataRanges getRangesForDatatypes(const ValueIdSubrange& idRange,
 //______________________________________________________________________________
 template <>
 BlockMetadataRanges IsDatatypeExpression<IsDatatype::BLANK>::evaluateImpl(
-    [[maybe_unused]] const Vocab& vocab, const ValueIdSubrange& idRange,
+    [[maybe_unused]] const IndexImpl& index, const ValueIdSubrange& idRange,
     BlockMetadataSpan blockRange,
     [[maybe_unused]] bool getTotalComplement) const {
   std::array datatypes{Datatype::BlankNodeIndex};
@@ -666,7 +670,7 @@ BlockMetadataRanges IsDatatypeExpression<IsDatatype::BLANK>::evaluateImpl(
 //______________________________________________________________________________
 template <>
 BlockMetadataRanges IsDatatypeExpression<IsDatatype::NUMERIC>::evaluateImpl(
-    [[maybe_unused]] const Vocab& vocab, const ValueIdSubrange& idRange,
+    [[maybe_unused]] const IndexImpl& index, const ValueIdSubrange& idRange,
     BlockMetadataSpan blockRange,
     [[maybe_unused]] bool getTotalComplement) const {
   std::array datatypes{Datatype::Int, Datatype::Double};
@@ -676,25 +680,25 @@ BlockMetadataRanges IsDatatypeExpression<IsDatatype::NUMERIC>::evaluateImpl(
 //______________________________________________________________________________
 template <>
 BlockMetadataRanges IsDatatypeExpression<IsDatatype::IRI>::evaluateImpl(
-    const Vocab& vocab, const ValueIdSubrange& idRange,
+    const IndexImpl& index, const ValueIdSubrange& idRange,
     BlockMetadataSpan blockRange,
     [[maybe_unused]] bool getTotalComplement) const {
-  using LVE = LocalVocabEntry;
   // Remark: Ids containing LITERAL values precede IRI related Ids
   // in order. The smallest possible IRI is represented by "<>", we
   // use its corresponding ValueId later on as a lower bound.
-  return make<GreaterThanExpression>(LVE::fromStringRepresentation("<>"))
-      ->evaluateImpl(vocab, idRange, blockRange, isNegated_);
+  return make<GreaterThanExpression>(
+             LocalVocabEntry{ad_utility::triple_component::LiteralOrIri::
+                                 fromStringRepresentation("<>"),
+                             index})
+      ->evaluateImpl(index, idRange, blockRange, isNegated_);
 }
 
 //______________________________________________________________________________
 template <>
 BlockMetadataRanges IsDatatypeExpression<IsDatatype::LITERAL>::evaluateImpl(
-    const Vocab& vocab, const ValueIdSubrange& idRange,
+    const IndexImpl& index, const ValueIdSubrange& idRange,
     BlockMetadataSpan blockRange,
     [[maybe_unused]] bool getTotalComplement) const {
-  using LVE = LocalVocabEntry;
-
   // For pre-filtering LITERAL related ValueIds we use the ValueId representing
   // the beginning of IRI values as an upper bound and add all the value types
   // that are literals inlined into a compact representation.
@@ -703,8 +707,11 @@ BlockMetadataRanges IsDatatypeExpression<IsDatatype::LITERAL>::evaluateImpl(
   auto inlinedRanges =
       getRangesForDatatypes(idRange, blockRange, isNegated_, datatypes);
   auto nonInlinedRanges =
-      make<LessThanExpression>(LVE::fromStringRepresentation("<>"))
-          ->evaluateImpl(vocab, idRange, blockRange, isNegated_);
+      make<LessThanExpression>(
+          LocalVocabEntry{ad_utility::triple_component::LiteralOrIri::
+                              fromStringRepresentation("<>"),
+                          index})
+          ->evaluateImpl(index, idRange, blockRange, isNegated_);
 
   if (isNegated_) {
     return detail::logicalOps::mergeRelevantBlockItRanges<false>(
@@ -747,7 +754,7 @@ std::string IsInExpression::asString([[maybe_unused]] size_t depth) const {
 
 //______________________________________________________________________________
 BlockMetadataRanges IsInExpression::evaluateImpl(
-    const Vocab& vocab, const ValueIdSubrange& idRange,
+    const IndexImpl& index, const ValueIdSubrange& idRange,
     BlockMetadataSpan blockRange,
     [[maybe_unused]] bool getTotalComplement) const {
   if (referenceValues_.empty()) {
@@ -767,7 +774,7 @@ BlockMetadataRanges IsInExpression::evaluateImpl(
                           : make<OrExpression>(AD_FWD(c1), AD_FWD(c2));
       });
 
-  return prefilterExpr.value()->evaluateImpl(vocab, idRange, blockRange,
+  return prefilterExpr.value()->evaluateImpl(index, idRange, blockRange,
                                              isNegated_);
 }
 
@@ -794,18 +801,18 @@ LogicalExpression<Operation>::logicalComplement() const {
 //______________________________________________________________________________
 template <LogicalOperator Operation>
 BlockMetadataRanges LogicalExpression<Operation>::evaluateImpl(
-    const Vocab& vocab, const ValueIdSubrange& idRange,
+    const IndexImpl& index, const ValueIdSubrange& idRange,
     BlockMetadataSpan blockRange, bool getTotalComplement) const {
   using enum LogicalOperator;
   if constexpr (Operation == AND) {
     return detail::logicalOps::mergeRelevantBlockItRanges<false>(
-        child1_->evaluateImpl(vocab, idRange, blockRange, getTotalComplement),
-        child2_->evaluateImpl(vocab, idRange, blockRange, getTotalComplement));
+        child1_->evaluateImpl(index, idRange, blockRange, getTotalComplement),
+        child2_->evaluateImpl(index, idRange, blockRange, getTotalComplement));
   } else {
     static_assert(Operation == OR);
     return detail::logicalOps::mergeRelevantBlockItRanges<true>(
-        child1_->evaluateImpl(vocab, idRange, blockRange, getTotalComplement),
-        child2_->evaluateImpl(vocab, idRange, blockRange, getTotalComplement));
+        child1_->evaluateImpl(index, idRange, blockRange, getTotalComplement),
+        child2_->evaluateImpl(index, idRange, blockRange, getTotalComplement));
   }
 }
 
@@ -854,11 +861,11 @@ std::unique_ptr<PrefilterExpression> NotExpression::logicalComplement() const {
 }
 
 //______________________________________________________________________________
-BlockMetadataRanges NotExpression::evaluateImpl(const Vocab& vocab,
+BlockMetadataRanges NotExpression::evaluateImpl(const IndexImpl& index,
                                                 const ValueIdSubrange& idRange,
                                                 BlockMetadataSpan blockRange,
                                                 bool getTotalComplement) const {
-  return child_->evaluateImpl(vocab, idRange, blockRange, getTotalComplement);
+  return child_->evaluateImpl(index, idRange, blockRange, getTotalComplement);
 }
 
 //______________________________________________________________________________

--- a/src/engine/sparqlExpressions/PrefilterExpressionIndex.cpp
+++ b/src/engine/sparqlExpressions/PrefilterExpressionIndex.cpp
@@ -465,11 +465,7 @@ BlockMetadataRanges PrefixRegexExpression::evaluateImpl(
   // Set lower reference.
   const auto& lowerIdVocab = Id::makeFromVocabIndex(lowerVocabIndex);
   const auto& beginIdIri = getValueIdFromIdOrLocalVocabEntry(
-      LocalVocabEntry{
-          ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
-              "<>"),
-          context},
-      localVocab);
+      LocalVocabEntry::fromStringRepresentation("<>", context), localVocab);
 
   // The `vocab.prefixRanges` returns the correct bounds only for preindexed
   // vocab entries, there might be local vocab entries in `(lowerVocabIndex-1,
@@ -688,9 +684,7 @@ BlockMetadataRanges IsDatatypeExpression<IsDatatype::IRI>::evaluateImpl(
   // in order. The smallest possible IRI is represented by "<>", we
   // use its corresponding ValueId later on as a lower bound.
   return make<GreaterThanExpression>(
-             LocalVocabEntry{ad_utility::triple_component::LiteralOrIri::
-                                 fromStringRepresentation("<>"),
-                             context})
+             LocalVocabEntry::fromStringRepresentation("<>", context))
       ->evaluateImpl(context, idRange, blockRange, isNegated_);
 }
 
@@ -709,9 +703,7 @@ BlockMetadataRanges IsDatatypeExpression<IsDatatype::LITERAL>::evaluateImpl(
       getRangesForDatatypes(idRange, blockRange, isNegated_, datatypes);
   auto nonInlinedRanges =
       make<LessThanExpression>(
-          LocalVocabEntry{ad_utility::triple_component::LiteralOrIri::
-                              fromStringRepresentation("<>"),
-                          context})
+          LocalVocabEntry::fromStringRepresentation("<>", context))
           ->evaluateImpl(context, idRange, blockRange, isNegated_);
 
   if (isNegated_) {

--- a/src/engine/sparqlExpressions/PrefilterExpressionIndex.cpp
+++ b/src/engine/sparqlExpressions/PrefilterExpressionIndex.cpp
@@ -456,6 +456,7 @@ BlockMetadataRanges PrefixRegexExpression::evaluateImpl(
     BlockMetadataSpan blockRange, bool getTotalComplement) const {
   static_assert(Datatype::LocalVocabIndex > Datatype::VocabIndex);
   static_assert(Vocab::PrefixRanges::Ranges{}.size() == 1);
+  using LVE = LocalVocabEntry;
   LocalVocab localVocab{};
   auto prefixQuoted =
       absl::StrCat("\"", asStringViewUnsafe(prefixLiteral_.getContent()));
@@ -465,7 +466,7 @@ BlockMetadataRanges PrefixRegexExpression::evaluateImpl(
   // Set lower reference.
   const auto& lowerIdVocab = Id::makeFromVocabIndex(lowerVocabIndex);
   const auto& beginIdIri = getValueIdFromIdOrLocalVocabEntry(
-      LocalVocabEntry::fromStringRepresentation("<>", context), localVocab);
+      LVE::fromStringRepresentation("<>", context), localVocab);
 
   // The `vocab.prefixRanges` returns the correct bounds only for preindexed
   // vocab entries, there might be local vocab entries in `(lowerVocabIndex-1,
@@ -680,11 +681,12 @@ BlockMetadataRanges IsDatatypeExpression<IsDatatype::IRI>::evaluateImpl(
     const LocalVocabContext& context, const ValueIdSubrange& idRange,
     BlockMetadataSpan blockRange,
     [[maybe_unused]] bool getTotalComplement) const {
+  using LVE = LocalVocabEntry;
   // Remark: Ids containing LITERAL values precede IRI related Ids
   // in order. The smallest possible IRI is represented by "<>", we
   // use its corresponding ValueId later on as a lower bound.
   return make<GreaterThanExpression>(
-             LocalVocabEntry::fromStringRepresentation("<>", context))
+             LVE::fromStringRepresentation("<>", context))
       ->evaluateImpl(context, idRange, blockRange, isNegated_);
 }
 
@@ -694,6 +696,8 @@ BlockMetadataRanges IsDatatypeExpression<IsDatatype::LITERAL>::evaluateImpl(
     const LocalVocabContext& context, const ValueIdSubrange& idRange,
     BlockMetadataSpan blockRange,
     [[maybe_unused]] bool getTotalComplement) const {
+  using LVE = LocalVocabEntry;
+
   // For pre-filtering LITERAL related ValueIds we use the ValueId representing
   // the beginning of IRI values as an upper bound and add all the value types
   // that are literals inlined into a compact representation.
@@ -702,8 +706,7 @@ BlockMetadataRanges IsDatatypeExpression<IsDatatype::LITERAL>::evaluateImpl(
   auto inlinedRanges =
       getRangesForDatatypes(idRange, blockRange, isNegated_, datatypes);
   auto nonInlinedRanges =
-      make<LessThanExpression>(
-          LocalVocabEntry::fromStringRepresentation("<>", context))
+      make<LessThanExpression>(LVE::fromStringRepresentation("<>", context))
           ->evaluateImpl(context, idRange, blockRange, isNegated_);
 
   if (isNegated_) {

--- a/src/engine/sparqlExpressions/PrefilterExpressionIndex.cpp
+++ b/src/engine/sparqlExpressions/PrefilterExpressionIndex.cpp
@@ -367,7 +367,7 @@ ValueId AccessValueIdFromBlockMetadata::operator()(
 // SECTION PREFILTER EXPRESSION (BASE CLASS)
 //______________________________________________________________________________
 BlockMetadataRanges PrefilterExpression::evaluate(
-    const IndexImpl& index, BlockMetadataSpan blockRange,
+    const LocalVocabContext& context, BlockMetadataSpan blockRange,
     size_t evaluationColumn) const {
   if (blockRange.size() < 3) {
     return {{blockRange.begin(), blockRange.end()}};
@@ -392,7 +392,7 @@ BlockMetadataRanges PrefilterExpression::evaluate(
         ValueIdIt{&blockRange, 0, accessValueIdOp},
         ValueIdIt{&blockRange, blockRange.size() * 2, accessValueIdOp}};
     result = detail::logicalOps::mergeRelevantBlockItRanges<true>(
-        evaluateImpl(index, idRange, blockRange, false),
+        evaluateImpl(context, idRange, blockRange, false),
         // always add mixed datatype blocks
         getRangesMixedDatatypeBlocks(idRange, blockRange));
   }
@@ -452,7 +452,7 @@ std::string PrefixRegexExpression::asString(
 
 //______________________________________________________________________________
 BlockMetadataRanges PrefixRegexExpression::evaluateImpl(
-    const IndexImpl& index, const ValueIdSubrange& idRange,
+    const LocalVocabContext& context, const ValueIdSubrange& idRange,
     BlockMetadataSpan blockRange, bool getTotalComplement) const {
   static_assert(Datatype::LocalVocabIndex > Datatype::VocabIndex);
   static_assert(Vocab::PrefixRanges::Ranges{}.size() == 1);
@@ -460,7 +460,7 @@ BlockMetadataRanges PrefixRegexExpression::evaluateImpl(
   auto prefixQuoted =
       absl::StrCat("\"", asStringViewUnsafe(prefixLiteral_.getContent()));
   auto [lowerVocabIndex, upperVocabIndex] =
-      index.getVocab().prefixRanges(prefixQuoted).ranges().front();
+      context.getVocab().prefixRanges(prefixQuoted).ranges().front();
 
   // Set lower reference.
   const auto& lowerIdVocab = Id::makeFromVocabIndex(lowerVocabIndex);
@@ -468,7 +468,7 @@ BlockMetadataRanges PrefixRegexExpression::evaluateImpl(
       LocalVocabEntry{
           ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
               "<>"),
-          index},
+          context},
       localVocab);
 
   // The `vocab.prefixRanges` returns the correct bounds only for preindexed
@@ -485,7 +485,7 @@ BlockMetadataRanges PrefixRegexExpression::evaluateImpl(
                make<LessThanExpression>(lowerIdVocab),
                make<AndExpression>(make<GreaterThanExpression>(upperIdAdjusted),
                                    make<LessThanExpression>(beginIdIri)))
-        .evaluateImpl(index, idRange, blockRange, getTotalComplement);
+        .evaluateImpl(context, idRange, blockRange, getTotalComplement);
   }
 
   // Set expression associated with the lower reference.
@@ -495,13 +495,13 @@ BlockMetadataRanges PrefixRegexExpression::evaluateImpl(
                                 lowerVocabIndex.decremented()));
   // Set expression associated with the upper reference.
   auto upperRefExpr =
-      upperVocabIndex.get() == index.getVocab().size()
+      upperVocabIndex.get() == context.getVocab().size()
           ? make<LessThanExpression>(beginIdIri)
           : make<LessThanExpression>(Id::makeFromVocabIndex(upperVocabIndex));
   // Case `STRSTARTS(?var, "prefix")` or `REGEX(?var, "^prefix")`.
   // Prefilter ?var > Id(prev("prefix)) && ?var < Id(next("prefix)).
   return AndExpression(std::move(lowerRefExpr), std::move(upperRefExpr))
-      .evaluateImpl(index, idRange, blockRange, getTotalComplement);
+      .evaluateImpl(context, idRange, blockRange, getTotalComplement);
 }
 
 // SECTION RELATIONAL OPERATIONS
@@ -529,8 +529,9 @@ RelationalExpression<Comparison>::logicalComplement() const {
 //______________________________________________________________________________
 template <CompOp Comparison>
 BlockMetadataRanges RelationalExpression<Comparison>::evaluateImpl(
-    [[maybe_unused]] const IndexImpl& index, const ValueIdSubrange& idRange,
-    BlockMetadataSpan blockRange, bool getTotalComplement) const {
+    [[maybe_unused]] const LocalVocabContext& context,
+    const ValueIdSubrange& idRange, BlockMetadataSpan blockRange,
+    bool getTotalComplement) const {
   using namespace valueIdComparators;
   // If `rightSideReferenceValue_` contains a `LocalVocabEntry` value, we use
   // the here created `LocalVocab` to retrieve a corresponding `ValueId`.
@@ -660,8 +661,8 @@ static BlockMetadataRanges getRangesForDatatypes(const ValueIdSubrange& idRange,
 //______________________________________________________________________________
 template <>
 BlockMetadataRanges IsDatatypeExpression<IsDatatype::BLANK>::evaluateImpl(
-    [[maybe_unused]] const IndexImpl& index, const ValueIdSubrange& idRange,
-    BlockMetadataSpan blockRange,
+    [[maybe_unused]] const LocalVocabContext& context,
+    const ValueIdSubrange& idRange, BlockMetadataSpan blockRange,
     [[maybe_unused]] bool getTotalComplement) const {
   std::array datatypes{Datatype::BlankNodeIndex};
   return getRangesForDatatypes(idRange, blockRange, isNegated_, datatypes);
@@ -670,8 +671,8 @@ BlockMetadataRanges IsDatatypeExpression<IsDatatype::BLANK>::evaluateImpl(
 //______________________________________________________________________________
 template <>
 BlockMetadataRanges IsDatatypeExpression<IsDatatype::NUMERIC>::evaluateImpl(
-    [[maybe_unused]] const IndexImpl& index, const ValueIdSubrange& idRange,
-    BlockMetadataSpan blockRange,
+    [[maybe_unused]] const LocalVocabContext& context,
+    const ValueIdSubrange& idRange, BlockMetadataSpan blockRange,
     [[maybe_unused]] bool getTotalComplement) const {
   std::array datatypes{Datatype::Int, Datatype::Double};
   return getRangesForDatatypes(idRange, blockRange, isNegated_, datatypes);
@@ -680,7 +681,7 @@ BlockMetadataRanges IsDatatypeExpression<IsDatatype::NUMERIC>::evaluateImpl(
 //______________________________________________________________________________
 template <>
 BlockMetadataRanges IsDatatypeExpression<IsDatatype::IRI>::evaluateImpl(
-    const IndexImpl& index, const ValueIdSubrange& idRange,
+    const LocalVocabContext& context, const ValueIdSubrange& idRange,
     BlockMetadataSpan blockRange,
     [[maybe_unused]] bool getTotalComplement) const {
   // Remark: Ids containing LITERAL values precede IRI related Ids
@@ -689,14 +690,14 @@ BlockMetadataRanges IsDatatypeExpression<IsDatatype::IRI>::evaluateImpl(
   return make<GreaterThanExpression>(
              LocalVocabEntry{ad_utility::triple_component::LiteralOrIri::
                                  fromStringRepresentation("<>"),
-                             index})
-      ->evaluateImpl(index, idRange, blockRange, isNegated_);
+                             context})
+      ->evaluateImpl(context, idRange, blockRange, isNegated_);
 }
 
 //______________________________________________________________________________
 template <>
 BlockMetadataRanges IsDatatypeExpression<IsDatatype::LITERAL>::evaluateImpl(
-    const IndexImpl& index, const ValueIdSubrange& idRange,
+    const LocalVocabContext& context, const ValueIdSubrange& idRange,
     BlockMetadataSpan blockRange,
     [[maybe_unused]] bool getTotalComplement) const {
   // For pre-filtering LITERAL related ValueIds we use the ValueId representing
@@ -710,8 +711,8 @@ BlockMetadataRanges IsDatatypeExpression<IsDatatype::LITERAL>::evaluateImpl(
       make<LessThanExpression>(
           LocalVocabEntry{ad_utility::triple_component::LiteralOrIri::
                               fromStringRepresentation("<>"),
-                          index})
-          ->evaluateImpl(index, idRange, blockRange, isNegated_);
+                          context})
+          ->evaluateImpl(context, idRange, blockRange, isNegated_);
 
   if (isNegated_) {
     return detail::logicalOps::mergeRelevantBlockItRanges<false>(
@@ -754,7 +755,7 @@ std::string IsInExpression::asString([[maybe_unused]] size_t depth) const {
 
 //______________________________________________________________________________
 BlockMetadataRanges IsInExpression::evaluateImpl(
-    const IndexImpl& index, const ValueIdSubrange& idRange,
+    const LocalVocabContext& context, const ValueIdSubrange& idRange,
     BlockMetadataSpan blockRange,
     [[maybe_unused]] bool getTotalComplement) const {
   if (referenceValues_.empty()) {
@@ -774,7 +775,7 @@ BlockMetadataRanges IsInExpression::evaluateImpl(
                           : make<OrExpression>(AD_FWD(c1), AD_FWD(c2));
       });
 
-  return prefilterExpr.value()->evaluateImpl(index, idRange, blockRange,
+  return prefilterExpr.value()->evaluateImpl(context, idRange, blockRange,
                                              isNegated_);
 }
 
@@ -801,18 +802,20 @@ LogicalExpression<Operation>::logicalComplement() const {
 //______________________________________________________________________________
 template <LogicalOperator Operation>
 BlockMetadataRanges LogicalExpression<Operation>::evaluateImpl(
-    const IndexImpl& index, const ValueIdSubrange& idRange,
+    const LocalVocabContext& context, const ValueIdSubrange& idRange,
     BlockMetadataSpan blockRange, bool getTotalComplement) const {
   using enum LogicalOperator;
   if constexpr (Operation == AND) {
     return detail::logicalOps::mergeRelevantBlockItRanges<false>(
-        child1_->evaluateImpl(index, idRange, blockRange, getTotalComplement),
-        child2_->evaluateImpl(index, idRange, blockRange, getTotalComplement));
+        child1_->evaluateImpl(context, idRange, blockRange, getTotalComplement),
+        child2_->evaluateImpl(context, idRange, blockRange,
+                              getTotalComplement));
   } else {
     static_assert(Operation == OR);
     return detail::logicalOps::mergeRelevantBlockItRanges<true>(
-        child1_->evaluateImpl(index, idRange, blockRange, getTotalComplement),
-        child2_->evaluateImpl(index, idRange, blockRange, getTotalComplement));
+        child1_->evaluateImpl(context, idRange, blockRange, getTotalComplement),
+        child2_->evaluateImpl(context, idRange, blockRange,
+                              getTotalComplement));
   }
 }
 
@@ -861,11 +864,10 @@ std::unique_ptr<PrefilterExpression> NotExpression::logicalComplement() const {
 }
 
 //______________________________________________________________________________
-BlockMetadataRanges NotExpression::evaluateImpl(const IndexImpl& index,
-                                                const ValueIdSubrange& idRange,
-                                                BlockMetadataSpan blockRange,
-                                                bool getTotalComplement) const {
-  return child_->evaluateImpl(index, idRange, blockRange, getTotalComplement);
+BlockMetadataRanges NotExpression::evaluateImpl(
+    const LocalVocabContext& context, const ValueIdSubrange& idRange,
+    BlockMetadataSpan blockRange, bool getTotalComplement) const {
+  return child_->evaluateImpl(context, idRange, blockRange, getTotalComplement);
 }
 
 //______________________________________________________________________________

--- a/src/engine/sparqlExpressions/PrefilterExpressionIndex.cpp
+++ b/src/engine/sparqlExpressions/PrefilterExpressionIndex.cpp
@@ -15,6 +15,8 @@
 
 namespace prefilterExpressions {
 
+using LVE = LocalVocabEntry;
+
 // HELPER FUNCTIONS
 //______________________________________________________________________________
 // Create and return `std::unique_ptr<PrefilterExpression>(args...)`.
@@ -456,7 +458,6 @@ BlockMetadataRanges PrefixRegexExpression::evaluateImpl(
     BlockMetadataSpan blockRange, bool getTotalComplement) const {
   static_assert(Datatype::LocalVocabIndex > Datatype::VocabIndex);
   static_assert(Vocab::PrefixRanges::Ranges{}.size() == 1);
-  using LVE = LocalVocabEntry;
   LocalVocab localVocab{};
   auto prefixQuoted =
       absl::StrCat("\"", asStringViewUnsafe(prefixLiteral_.getContent()));
@@ -681,7 +682,6 @@ BlockMetadataRanges IsDatatypeExpression<IsDatatype::IRI>::evaluateImpl(
     const LocalVocabContext& context, const ValueIdSubrange& idRange,
     BlockMetadataSpan blockRange,
     [[maybe_unused]] bool getTotalComplement) const {
-  using LVE = LocalVocabEntry;
   // Remark: Ids containing LITERAL values precede IRI related Ids
   // in order. The smallest possible IRI is represented by "<>", we
   // use its corresponding ValueId later on as a lower bound.
@@ -696,8 +696,6 @@ BlockMetadataRanges IsDatatypeExpression<IsDatatype::LITERAL>::evaluateImpl(
     const LocalVocabContext& context, const ValueIdSubrange& idRange,
     BlockMetadataSpan blockRange,
     [[maybe_unused]] bool getTotalComplement) const {
-  using LVE = LocalVocabEntry;
-
   // For pre-filtering LITERAL related ValueIds we use the ValueId representing
   // the beginning of IRI values as an upper bound and add all the value types
   // that are literals inlined into a compact representation.

--- a/src/engine/sparqlExpressions/PrefilterExpressionIndex.h
+++ b/src/engine/sparqlExpressions/PrefilterExpressionIndex.h
@@ -130,7 +130,8 @@ class PrefilterExpression {
   // potentially incomplete first/last `CompressedBlockMetadata` values in input
   // are handled automatically. They are stripped at the beginning and added
   // again when the evaluation procedure was successfully performed.
-  BlockMetadataRanges evaluate(const Vocab& vocab, BlockMetadataSpan blockRange,
+  BlockMetadataRanges evaluate(const IndexImpl& index,
+                               BlockMetadataSpan blockRange,
                                size_t evaluationColumn) const;
 
   // `evaluateImpl` is internally used for the actual pre-filter procedure.
@@ -141,7 +142,7 @@ class PrefilterExpression {
   // return their corresponding complement over ALL datatypes. This is in
   // particular needed for the complement of `IsDatatype` and `InExpression`.
   virtual BlockMetadataRanges evaluateImpl(
-      const Vocab& vocab, const ValueIdSubrange& idRange,
+      const IndexImpl& index, const ValueIdSubrange& idRange,
       BlockMetadataSpan blockRange, bool getTotalComplement = false) const = 0;
 
   // Format for debugging
@@ -180,7 +181,7 @@ class PrefixRegexExpression : public PrefilterExpression {
   std::string asString(size_t depth) const override;
 
  private:
-  BlockMetadataRanges evaluateImpl(const Vocab& vocab,
+  BlockMetadataRanges evaluateImpl(const IndexImpl& index,
                                    const ValueIdSubrange& idRange,
                                    BlockMetadataSpan blockRange,
                                    bool getTotalComplement) const override;
@@ -214,7 +215,7 @@ class LogicalExpression : public PrefilterExpression {
   // Declare `PrefixRegexExpression` as a friend because its `evaluateImpl`
   // requires access to the `evaluateImpl` declared here.
   friend class PrefixRegexExpression;
-  BlockMetadataRanges evaluateImpl(const Vocab& vocab,
+  BlockMetadataRanges evaluateImpl(const IndexImpl& index,
                                    const ValueIdSubrange& idRange,
                                    BlockMetadataSpan blockRange,
                                    bool getTotalComplement) const override;
@@ -243,7 +244,7 @@ class IsDatatypeExpression : public PrefilterExpression {
   std::string asString(size_t depth) const override;
 
  private:
-  BlockMetadataRanges evaluateImpl(const Vocab& vocab,
+  BlockMetadataRanges evaluateImpl(const IndexImpl& index,
                                    const ValueIdSubrange& idRange,
                                    BlockMetadataSpan blockRange,
                                    bool getTotalComplement) const override;
@@ -273,7 +274,7 @@ class IsInExpression : public PrefilterExpression {
   std::string asString(size_t depth) const override;
 
  private:
-  BlockMetadataRanges evaluateImpl(const Vocab& vocab,
+  BlockMetadataRanges evaluateImpl(const IndexImpl& index,
                                    const ValueIdSubrange& idRange,
                                    BlockMetadataSpan blockRange,
                                    bool getTotalComplement) const override;
@@ -313,7 +314,7 @@ class RelationalExpression : public PrefilterExpression {
   // If `getTotalComplement` is set to `true`, this method returns
   // the total complement over all datatype `ValueId`s from the
   // provided `CompressedBlockMetadata` values.
-  BlockMetadataRanges evaluateImpl(const Vocab& vocab,
+  BlockMetadataRanges evaluateImpl(const IndexImpl& index,
                                    const ValueIdSubrange& idRange,
                                    BlockMetadataSpan blockRange,
                                    bool getTotalComplement) const override;
@@ -339,7 +340,7 @@ class NotExpression : public PrefilterExpression {
   std::string asString(size_t depth) const override;
 
  private:
-  BlockMetadataRanges evaluateImpl(const Vocab& vocab,
+  BlockMetadataRanges evaluateImpl(const IndexImpl& index,
                                    const ValueIdSubrange& idRange,
                                    BlockMetadataSpan blockRange,
                                    bool getTotalComplement) const override;

--- a/src/engine/sparqlExpressions/PrefilterExpressionIndex.h
+++ b/src/engine/sparqlExpressions/PrefilterExpressionIndex.h
@@ -130,7 +130,7 @@ class PrefilterExpression {
   // potentially incomplete first/last `CompressedBlockMetadata` values in input
   // are handled automatically. They are stripped at the beginning and added
   // again when the evaluation procedure was successfully performed.
-  BlockMetadataRanges evaluate(const IndexImpl& index,
+  BlockMetadataRanges evaluate(const LocalVocabContext& context,
                                BlockMetadataSpan blockRange,
                                size_t evaluationColumn) const;
 
@@ -142,7 +142,7 @@ class PrefilterExpression {
   // return their corresponding complement over ALL datatypes. This is in
   // particular needed for the complement of `IsDatatype` and `InExpression`.
   virtual BlockMetadataRanges evaluateImpl(
-      const IndexImpl& index, const ValueIdSubrange& idRange,
+      const LocalVocabContext& context, const ValueIdSubrange& idRange,
       BlockMetadataSpan blockRange, bool getTotalComplement = false) const = 0;
 
   // Format for debugging
@@ -181,7 +181,7 @@ class PrefixRegexExpression : public PrefilterExpression {
   std::string asString(size_t depth) const override;
 
  private:
-  BlockMetadataRanges evaluateImpl(const IndexImpl& index,
+  BlockMetadataRanges evaluateImpl(const LocalVocabContext& context,
                                    const ValueIdSubrange& idRange,
                                    BlockMetadataSpan blockRange,
                                    bool getTotalComplement) const override;
@@ -215,7 +215,7 @@ class LogicalExpression : public PrefilterExpression {
   // Declare `PrefixRegexExpression` as a friend because its `evaluateImpl`
   // requires access to the `evaluateImpl` declared here.
   friend class PrefixRegexExpression;
-  BlockMetadataRanges evaluateImpl(const IndexImpl& index,
+  BlockMetadataRanges evaluateImpl(const LocalVocabContext& context,
                                    const ValueIdSubrange& idRange,
                                    BlockMetadataSpan blockRange,
                                    bool getTotalComplement) const override;
@@ -244,7 +244,7 @@ class IsDatatypeExpression : public PrefilterExpression {
   std::string asString(size_t depth) const override;
 
  private:
-  BlockMetadataRanges evaluateImpl(const IndexImpl& index,
+  BlockMetadataRanges evaluateImpl(const LocalVocabContext& context,
                                    const ValueIdSubrange& idRange,
                                    BlockMetadataSpan blockRange,
                                    bool getTotalComplement) const override;
@@ -274,7 +274,7 @@ class IsInExpression : public PrefilterExpression {
   std::string asString(size_t depth) const override;
 
  private:
-  BlockMetadataRanges evaluateImpl(const IndexImpl& index,
+  BlockMetadataRanges evaluateImpl(const LocalVocabContext& context,
                                    const ValueIdSubrange& idRange,
                                    BlockMetadataSpan blockRange,
                                    bool getTotalComplement) const override;
@@ -314,7 +314,7 @@ class RelationalExpression : public PrefilterExpression {
   // If `getTotalComplement` is set to `true`, this method returns
   // the total complement over all datatype `ValueId`s from the
   // provided `CompressedBlockMetadata` values.
-  BlockMetadataRanges evaluateImpl(const IndexImpl& index,
+  BlockMetadataRanges evaluateImpl(const LocalVocabContext& context,
                                    const ValueIdSubrange& idRange,
                                    BlockMetadataSpan blockRange,
                                    bool getTotalComplement) const override;
@@ -340,7 +340,7 @@ class NotExpression : public PrefilterExpression {
   std::string asString(size_t depth) const override;
 
  private:
-  BlockMetadataRanges evaluateImpl(const IndexImpl& index,
+  BlockMetadataRanges evaluateImpl(const LocalVocabContext& context,
                                    const ValueIdSubrange& idRange,
                                    BlockMetadataSpan blockRange,
                                    bool getTotalComplement) const override;

--- a/src/engine/sparqlExpressions/RegexExpression.cpp
+++ b/src/engine/sparqlExpressions/RegexExpression.cpp
@@ -288,7 +288,7 @@ void PrefixRegexExpression::checkCancellation(
 // _____________________________________________________________________________
 std::vector<PrefilterExprVariablePair>
 PrefixRegexExpression::getPrefilterExpressionForMetadata(
-    [[maybe_unused]] const IndexImpl& index,
+    [[maybe_unused]] const LocalVocabContext& context,
     [[maybe_unused]] bool isNegated) const {
   // It is currently not possible to prefilter PREFIX expressions involving
   // STR(?var), since we not only have to match "Bob", but also "Bob"@en,

--- a/src/engine/sparqlExpressions/RegexExpression.cpp
+++ b/src/engine/sparqlExpressions/RegexExpression.cpp
@@ -288,6 +288,7 @@ void PrefixRegexExpression::checkCancellation(
 // _____________________________________________________________________________
 std::vector<PrefilterExprVariablePair>
 PrefixRegexExpression::getPrefilterExpressionForMetadata(
+    [[maybe_unused]] const IndexImpl& index,
     [[maybe_unused]] bool isNegated) const {
   // It is currently not possible to prefilter PREFIX expressions involving
   // STR(?var), since we not only have to match "Bob", but also "Bob"@en,

--- a/src/engine/sparqlExpressions/RegexExpression.h
+++ b/src/engine/sparqlExpressions/RegexExpression.h
@@ -37,7 +37,7 @@ class PrefixRegexExpression : public SparqlExpression {
   PrefixRegexExpression& operator=(const PrefixRegexExpression&) = delete;
 
   std::vector<PrefilterExprVariablePair> getPrefilterExpressionForMetadata(
-      bool isNegated) const override;
+      const IndexImpl& index, bool isNegated) const override;
 
   // Check if the children of this expression allow for the prefix regex
   // optimization. If this is the case, a `PrefixRegexExpression` is returned,

--- a/src/engine/sparqlExpressions/RegexExpression.h
+++ b/src/engine/sparqlExpressions/RegexExpression.h
@@ -37,7 +37,7 @@ class PrefixRegexExpression : public SparqlExpression {
   PrefixRegexExpression& operator=(const PrefixRegexExpression&) = delete;
 
   std::vector<PrefilterExprVariablePair> getPrefilterExpressionForMetadata(
-      const IndexImpl& index, bool isNegated) const override;
+      const LocalVocabContext& context, bool isNegated) const override;
 
   // Check if the children of this expression allow for the prefix regex
   // optimization. If this is the case, a `PrefixRegexExpression` is returned,

--- a/src/engine/sparqlExpressions/RelationalExpressions.cpp
+++ b/src/engine/sparqlExpressions/RelationalExpressions.cpp
@@ -445,20 +445,20 @@ static std::optional<std::pair<Variable, bool>> getOptVariableAndIsYear(
 template <Comparison comp>
 std::vector<PrefilterExprVariablePair>
 RelationalExpression<comp>::getPrefilterExpressionForMetadata(
-    [[maybe_unused]] const IndexImpl& index,
+    [[maybe_unused]] const LocalVocabContext& context,
     [[maybe_unused]] bool isNegated) const {
   AD_CORRECTNESS_CHECK(children_.size() == 2);
   const SparqlExpression* child0 = children_.at(0).get();
   const SparqlExpression* child1 = children_.at(1).get();
 
   const auto tryGetPrefilterExprVariablePairVec =
-      [&index](const SparqlExpression* child0, const SparqlExpression* child1,
-               bool reversed) -> std::vector<PrefilterExprVariablePair> {
+      [&context](const SparqlExpression* child0, const SparqlExpression* child1,
+                 bool reversed) -> std::vector<PrefilterExprVariablePair> {
     const auto& optVariableIsYearPair = getOptVariableAndIsYear(child0);
     if (!optVariableIsYearPair.has_value()) return {};
     const auto& [variable, prefilterDate] = optVariableIsYearPair.value();
     const auto& optReferenceValue =
-        detail::getIdOrLocalVocabEntryFromLiteralExpression(child1, index);
+        detail::getIdOrLocalVocabEntryFromLiteralExpression(child1, context);
     if (!optReferenceValue.has_value()) return {};
     return prefilterExpressions::detail::makePrefilterExpressionVec<comp>(
         optReferenceValue.value(), variable, reversed, prefilterDate);
@@ -514,7 +514,7 @@ std::string InExpression::getCacheKey(
 // it (see `NotExpression` in PrefilterExpressionIndex.h).
 std::vector<PrefilterExprVariablePair>
 InExpression::getPrefilterExpressionForMetadata(
-    const IndexImpl& index, [[maybe_unused]] bool isNegated) const {
+    const LocalVocabContext& context, [[maybe_unused]] bool isNegated) const {
   AD_CORRECTNESS_CHECK(children_.size() >= 1);
   auto var = children_.front()->getVariableOrNullopt();
   if (!var.has_value()) {
@@ -525,7 +525,8 @@ InExpression::getPrefilterExpressionForMetadata(
   referenceValues.reserve(children_.size());
   for (const auto& expr : children_ | ql::ranges::views::drop(1)) {
     auto optReferenceValue =
-        detail::getIdOrLocalVocabEntryFromLiteralExpression(expr.get(), index);
+        detail::getIdOrLocalVocabEntryFromLiteralExpression(expr.get(),
+                                                            context);
     if (!optReferenceValue.has_value()) {
       return {};
     }

--- a/src/engine/sparqlExpressions/RelationalExpressions.cpp
+++ b/src/engine/sparqlExpressions/RelationalExpressions.cpp
@@ -445,19 +445,20 @@ static std::optional<std::pair<Variable, bool>> getOptVariableAndIsYear(
 template <Comparison comp>
 std::vector<PrefilterExprVariablePair>
 RelationalExpression<comp>::getPrefilterExpressionForMetadata(
+    [[maybe_unused]] const IndexImpl& index,
     [[maybe_unused]] bool isNegated) const {
   AD_CORRECTNESS_CHECK(children_.size() == 2);
   const SparqlExpression* child0 = children_.at(0).get();
   const SparqlExpression* child1 = children_.at(1).get();
 
   const auto tryGetPrefilterExprVariablePairVec =
-      [](const SparqlExpression* child0, const SparqlExpression* child1,
-         bool reversed) -> std::vector<PrefilterExprVariablePair> {
+      [&index](const SparqlExpression* child0, const SparqlExpression* child1,
+               bool reversed) -> std::vector<PrefilterExprVariablePair> {
     const auto& optVariableIsYearPair = getOptVariableAndIsYear(child0);
     if (!optVariableIsYearPair.has_value()) return {};
     const auto& [variable, prefilterDate] = optVariableIsYearPair.value();
     const auto& optReferenceValue =
-        detail::getIdOrLocalVocabEntryFromLiteralExpression(child1);
+        detail::getIdOrLocalVocabEntryFromLiteralExpression(child1, index);
     if (!optReferenceValue.has_value()) return {};
     return prefilterExpressions::detail::makePrefilterExpressionVec<comp>(
         optReferenceValue.value(), variable, reversed, prefilterDate);
@@ -513,7 +514,7 @@ std::string InExpression::getCacheKey(
 // it (see `NotExpression` in PrefilterExpressionIndex.h).
 std::vector<PrefilterExprVariablePair>
 InExpression::getPrefilterExpressionForMetadata(
-    [[maybe_unused]] bool isNegated) const {
+    const IndexImpl& index, [[maybe_unused]] bool isNegated) const {
   AD_CORRECTNESS_CHECK(children_.size() >= 1);
   auto var = children_.front()->getVariableOrNullopt();
   if (!var.has_value()) {
@@ -524,7 +525,7 @@ InExpression::getPrefilterExpressionForMetadata(
   referenceValues.reserve(children_.size());
   for (const auto& expr : children_ | ql::ranges::views::drop(1)) {
     auto optReferenceValue =
-        detail::getIdOrLocalVocabEntryFromLiteralExpression(expr.get());
+        detail::getIdOrLocalVocabEntryFromLiteralExpression(expr.get(), index);
     if (!optReferenceValue.has_value()) {
       return {};
     }

--- a/src/engine/sparqlExpressions/RelationalExpressions.h
+++ b/src/engine/sparqlExpressions/RelationalExpressions.h
@@ -46,7 +46,7 @@ class RelationalExpression : public SparqlExpression {
   // `CompressedBlockMetadata`. In addition we return the `Variable` that
   // corresponds to the sorted column.
   std::vector<PrefilterExprVariablePair> getPrefilterExpressionForMetadata(
-      bool isNegated) const override;
+      const IndexImpl& index, bool isNegated) const override;
 
   // These expressions are typically used inside `FILTER` clauses, so we need
   // proper estimates.
@@ -81,6 +81,7 @@ class InExpression : public SparqlExpression {
       const VariableToColumnMap& varColMap) const override;
 
   std::vector<PrefilterExprVariablePair> getPrefilterExpressionForMetadata(
+      [[maybe_unused]] const IndexImpl& index,
       [[maybe_unused]] bool isNegated) const override;
 
   // These expressions are typically used inside `FILTER` clauses, so we need

--- a/src/engine/sparqlExpressions/RelationalExpressions.h
+++ b/src/engine/sparqlExpressions/RelationalExpressions.h
@@ -46,7 +46,7 @@ class RelationalExpression : public SparqlExpression {
   // `CompressedBlockMetadata`. In addition we return the `Variable` that
   // corresponds to the sorted column.
   std::vector<PrefilterExprVariablePair> getPrefilterExpressionForMetadata(
-      const IndexImpl& index, bool isNegated) const override;
+      const LocalVocabContext& context, bool isNegated) const override;
 
   // These expressions are typically used inside `FILTER` clauses, so we need
   // proper estimates.
@@ -81,7 +81,7 @@ class InExpression : public SparqlExpression {
       const VariableToColumnMap& varColMap) const override;
 
   std::vector<PrefilterExprVariablePair> getPrefilterExpressionForMetadata(
-      [[maybe_unused]] const IndexImpl& index,
+      [[maybe_unused]] const LocalVocabContext& context,
       [[maybe_unused]] bool isNegated) const override;
 
   // These expressions are typically used inside `FILTER` clauses, so we need

--- a/src/engine/sparqlExpressions/SparqlExpression.cpp
+++ b/src/engine/sparqlExpressions/SparqlExpression.cpp
@@ -115,7 +115,7 @@ Estimates SparqlExpression::getEstimatesForFilterExpression(
 // `getPrefilterExpressionForMetadata` method declared there.
 std::vector<PrefilterExprVariablePair>
 SparqlExpression::getPrefilterExpressionForMetadata(
-    [[maybe_unused]] const IndexImpl& index,
+    [[maybe_unused]] const LocalVocabContext& context,
     [[maybe_unused]] bool isNegated) const {
   return {};
 };

--- a/src/engine/sparqlExpressions/SparqlExpression.cpp
+++ b/src/engine/sparqlExpressions/SparqlExpression.cpp
@@ -115,6 +115,7 @@ Estimates SparqlExpression::getEstimatesForFilterExpression(
 // `getPrefilterExpressionForMetadata` method declared there.
 std::vector<PrefilterExprVariablePair>
 SparqlExpression::getPrefilterExpressionForMetadata(
+    [[maybe_unused]] const IndexImpl& index,
     [[maybe_unused]] bool isNegated) const {
   return {};
 };

--- a/src/engine/sparqlExpressions/SparqlExpression.h
+++ b/src/engine/sparqlExpressions/SparqlExpression.h
@@ -119,7 +119,8 @@ class SparqlExpression {
   // <`PrefilterExpression`, `Variable`> pairs (see `getMergeFunction` in
   // NumericBinaryExpression.cpp).
   virtual std::vector<PrefilterExprVariablePair>
-  getPrefilterExpressionForMetadata(bool isNegated = false) const;
+  getPrefilterExpressionForMetadata(const IndexImpl& index,
+                                    bool isNegated = false) const;
 
   // Returns true iff this expression is a simple constant. Default
   // implementation returns `false`.

--- a/src/engine/sparqlExpressions/SparqlExpression.h
+++ b/src/engine/sparqlExpressions/SparqlExpression.h
@@ -119,7 +119,7 @@ class SparqlExpression {
   // <`PrefilterExpression`, `Variable`> pairs (see `getMergeFunction` in
   // NumericBinaryExpression.cpp).
   virtual std::vector<PrefilterExprVariablePair>
-  getPrefilterExpressionForMetadata(const IndexImpl& index,
+  getPrefilterExpressionForMetadata(const LocalVocabContext& context,
                                     bool isNegated = false) const;
 
   // Returns true iff this expression is a simple constant. Default

--- a/src/engine/sparqlExpressions/SparqlExpressionPimpl.cpp
+++ b/src/engine/sparqlExpressions/SparqlExpressionPimpl.cpp
@@ -102,8 +102,9 @@ auto SparqlExpressionPimpl::getEstimatesForFilterExpression(
 
 //_____________________________________________________________________________
 std::vector<PrefilterExprVariablePair>
-SparqlExpressionPimpl::getPrefilterExpressionForMetadata() const {
-  return _pimpl->getPrefilterExpressionForMetadata();
+SparqlExpressionPimpl::getPrefilterExpressionForMetadata(
+    const IndexImpl& index) const {
+  return _pimpl->getPrefilterExpressionForMetadata(index);
 }
 
 // _____________________________________________________________________________

--- a/src/engine/sparqlExpressions/SparqlExpressionPimpl.cpp
+++ b/src/engine/sparqlExpressions/SparqlExpressionPimpl.cpp
@@ -103,8 +103,8 @@ auto SparqlExpressionPimpl::getEstimatesForFilterExpression(
 //_____________________________________________________________________________
 std::vector<PrefilterExprVariablePair>
 SparqlExpressionPimpl::getPrefilterExpressionForMetadata(
-    const IndexImpl& index) const {
-  return _pimpl->getPrefilterExpressionForMetadata(index);
+    const LocalVocabContext& context) const {
+  return _pimpl->getPrefilterExpressionForMetadata(context);
 }
 
 // _____________________________________________________________________________

--- a/src/engine/sparqlExpressions/SparqlExpressionPimpl.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionPimpl.h
@@ -124,8 +124,8 @@ class SparqlExpressionPimpl {
 
   // For a concise description of this method and its functionality, refer to
   // the corresponding declaration in SparqlExpression.h.
-  std::vector<PrefilterExprVariablePair> getPrefilterExpressionForMetadata()
-      const;
+  std::vector<PrefilterExprVariablePair> getPrefilterExpressionForMetadata(
+      const IndexImpl& index) const;
 
   SparqlExpression* getPimpl() { return _pimpl.get(); }
   [[nodiscard]] const SparqlExpression* getPimpl() const {

--- a/src/engine/sparqlExpressions/SparqlExpressionPimpl.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionPimpl.h
@@ -125,7 +125,7 @@ class SparqlExpressionPimpl {
   // For a concise description of this method and its functionality, refer to
   // the corresponding declaration in SparqlExpression.h.
   std::vector<PrefilterExprVariablePair> getPrefilterExpressionForMetadata(
-      const IndexImpl& index) const;
+      const LocalVocabContext& context) const;
 
   SparqlExpression* getPimpl() { return _pimpl.get(); }
   [[nodiscard]] const SparqlExpression* getPimpl() const {

--- a/src/engine/sparqlExpressions/SparqlExpressionTypes.cpp
+++ b/src/engine/sparqlExpressions/SparqlExpressionTypes.cpp
@@ -80,4 +80,9 @@ EvaluationContext::getResultFromPreviousAggregate(const Variable& var) const {
   return copyExpressionResult(_previousResultsFromSameGroup.at(idx));
 }
 
+// _____________________________________________________________________________
+const LocalVocabContext& EvaluationContext::getLocalVocabContext() const {
+  return _qec.getIndex();
+}
+
 }  // namespace sparqlExpression

--- a/src/engine/sparqlExpressions/SparqlExpressionTypes.cpp
+++ b/src/engine/sparqlExpressions/SparqlExpressionTypes.cpp
@@ -82,7 +82,7 @@ EvaluationContext::getResultFromPreviousAggregate(const Variable& var) const {
 
 // _____________________________________________________________________________
 const LocalVocabContext& EvaluationContext::getLocalVocabContext() const {
-  return _qec.getIndex();
+  return _qec.getLocalVocabContext();
 }
 
 }  // namespace sparqlExpression

--- a/src/engine/sparqlExpressions/SparqlExpressionTypes.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionTypes.h
@@ -437,26 +437,23 @@ using PromoteToLocalVocabEntry =
     std::conditional_t<std::is_same_v<T, IdOrLiteralOrIri>, IdOrLocalVocabEntry,
                        T>;
 
-// Helper functor to upgrade the variant type from `IdOrLiteralOrIri` to
+// Helper function to upgrade the variant type from `IdOrLiteralOrIri` to
 // `IdOrLocalVocabEntry` by wrapping the `LiteralOrIri` in a `LocalVocabEntry`.
 // For other types, the functor just returns the input as is.
-struct PromoteToLocalVocabEntryT {
-  template <typename T>
-  decltype(auto) operator()(T&& value) const {
-    if constexpr (std::is_same_v<std::decay_t<T>, IdOrLiteralOrIri>) {
-      return std::visit(ad_utility::OverloadCallOperator{
-                            [](Id id) -> IdOrLocalVocabEntry { return id; },
-                            [](auto&& literalOrIri) -> IdOrLocalVocabEntry {
-                              return {LocalVocabEntry{AD_FWD(literalOrIri)}};
-                            }},
-                        AD_FWD(value));
-    } else {
-      return AD_FWD(value);
-    }
+template <typename T>
+decltype(auto) promoteToLocalVocabEntry(T&& value, const IndexImpl& index) {
+  if constexpr (std::is_same_v<std::decay_t<T>, IdOrLiteralOrIri>) {
+    return std::visit(
+        ad_utility::OverloadCallOperator{
+            [](Id id) -> IdOrLocalVocabEntry { return id; },
+            [&index](auto&& literalOrIri) -> IdOrLocalVocabEntry {
+              return {LocalVocabEntry{AD_FWD(literalOrIri), index}};
+            }},
+        AD_FWD(value));
+  } else {
+    return AD_FWD(value);
   }
-};
-
-constexpr PromoteToLocalVocabEntryT promoteToLocalVocabEntry{};
+}
 
 }  // namespace detail
 }  // namespace sparqlExpression

--- a/src/engine/sparqlExpressions/SparqlExpressionTypes.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionTypes.h
@@ -441,13 +441,14 @@ using PromoteToLocalVocabEntry =
 // `IdOrLocalVocabEntry` by wrapping the `LiteralOrIri` in a `LocalVocabEntry`.
 // For other types, the functor just returns the input as is.
 template <typename T>
-decltype(auto) promoteToLocalVocabEntry(T&& value, const IndexImpl& index) {
+decltype(auto) promoteToLocalVocabEntry(T&& value,
+                                        const LocalVocabContext& context) {
   if constexpr (std::is_same_v<std::decay_t<T>, IdOrLiteralOrIri>) {
     return std::visit(
         ad_utility::OverloadCallOperator{
             [](Id id) -> IdOrLocalVocabEntry { return id; },
-            [&index](auto&& literalOrIri) -> IdOrLocalVocabEntry {
-              return {LocalVocabEntry{AD_FWD(literalOrIri), index}};
+            [&context](auto&& literalOrIri) -> IdOrLocalVocabEntry {
+              return {LocalVocabEntry{AD_FWD(literalOrIri), context}};
             }},
         AD_FWD(value));
   } else {

--- a/src/engine/sparqlExpressions/SparqlExpressionTypes.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionTypes.h
@@ -239,6 +239,11 @@ struct EvaluationContext {
   // _____________________________________________________________________________
   std::optional<ExpressionResult> getResultFromPreviousAggregate(
       const Variable& var) const;
+
+  // Currently a helper function that returns the index from `qec_`. Might
+  // change in the future so we hide the implementation details behind this
+  // function.
+  const LocalVocabContext& getLocalVocabContext() const;
 };
 
 namespace detail {

--- a/src/engine/sparqlExpressions/SparqlExpressionValueGetters.cpp
+++ b/src/engine/sparqlExpressions/SparqlExpressionValueGetters.cpp
@@ -532,7 +532,7 @@ sparqlExpression::IdOrLocalVocabEntry IriOrUriValueGetter::operator()(
                        ? litOrIri.getIri()
                        : Iri::fromIrirefWithoutBrackets(asStringViewUnsafe(
                              litOrIri.getLiteral().getContent()))},
-      context->_qec.getIndex()};
+      context->getLocalVocabContext()};
 }
 
 //______________________________________________________________________________

--- a/src/engine/sparqlExpressions/SparqlExpressionValueGetters.cpp
+++ b/src/engine/sparqlExpressions/SparqlExpressionValueGetters.cpp
@@ -526,12 +526,13 @@ std::optional<std::string> LanguageTagValueGetter::operator()(
 
 //______________________________________________________________________________
 sparqlExpression::IdOrLocalVocabEntry IriOrUriValueGetter::operator()(
-    const LiteralOrIri& litOrIri,
-    [[maybe_unused]] const EvaluationContext* context) const {
-  return LiteralOrIri{litOrIri.isIri()
-                          ? litOrIri.getIri()
-                          : Iri::fromIrirefWithoutBrackets(asStringViewUnsafe(
-                                litOrIri.getLiteral().getContent()))};
+    const LiteralOrIri& litOrIri, const EvaluationContext* context) const {
+  return LocalVocabEntry{
+      LiteralOrIri{litOrIri.isIri()
+                       ? litOrIri.getIri()
+                       : Iri::fromIrirefWithoutBrackets(asStringViewUnsafe(
+                             litOrIri.getLiteral().getContent()))},
+      context->_qec.getIndex()};
 }
 
 //______________________________________________________________________________

--- a/src/engine/sparqlExpressions/StringExpressions.cpp
+++ b/src/engine/sparqlExpressions/StringExpressions.cpp
@@ -241,7 +241,7 @@ CPP_template(typename NaryOperation)(
  public:
   using NaryExpression<NaryOperation>::NaryExpression;
   std::vector<PrefilterExprVariablePair> getPrefilterExpressionForMetadata(
-      [[maybe_unused]] const IndexImpl& index,
+      [[maybe_unused]] const LocalVocabContext& context,
       [[maybe_unused]] bool isNegated) const override {
     std::vector<PrefilterExprVariablePair> prefilterVec;
     const auto& children = this->children();

--- a/src/engine/sparqlExpressions/StringExpressions.cpp
+++ b/src/engine/sparqlExpressions/StringExpressions.cpp
@@ -428,7 +428,7 @@ class ConcatExpression : public detail::VariadicExpression {
       if (!literal.has_value()) {
         return Id::makeUndefined();
       }
-      return LocalVocabEntry{LiteralOrIri(std::move(literal.value())),
+      return LocalVocabEntry{std::move(literal.value()),
                              ctx->getLocalVocabContext()};
     };
 

--- a/src/engine/sparqlExpressions/StringExpressions.cpp
+++ b/src/engine/sparqlExpressions/StringExpressions.cpp
@@ -429,7 +429,7 @@ class ConcatExpression : public detail::VariadicExpression {
         return Id::makeUndefined();
       }
       return LocalVocabEntry{LiteralOrIri(std::move(literal.value())),
-                             ctx->_qec.getIndex()};
+                             ctx->getLocalVocabContext()};
     };
 
     auto visitSingleExpressionResult = CPP_template_lambda(

--- a/src/engine/sparqlExpressions/StringExpressions.cpp
+++ b/src/engine/sparqlExpressions/StringExpressions.cpp
@@ -114,15 +114,15 @@ const Iri& extractIri(const IdOrLocalVocabEntry& litOrIri) {
 }
 
 struct ApplyBaseIfPresent {
-  IdOrLocalVocabEntry operator()(IdOrLocalVocabEntry iri,
-                                 const IdOrLocalVocabEntry& base) const {
+  IdOrLiteralOrIri operator()(IdOrLocalVocabEntry iri,
+                              const IdOrLocalVocabEntry& base) const {
     if (std::holds_alternative<Id>(iri)) {
       AD_CORRECTNESS_CHECK(std::get<Id>(iri).isUndefined());
-      return iri;
+      return std::get<Id>(iri);
     }
     const auto& baseIri = extractIri(base);
     if (baseIri.empty()) {
-      return iri;
+      return std::get<LocalVocabEntry>(iri);
     }
     // TODO<RobinTF> Avoid unnecessary string copies because of conversion.
     return LiteralOrIri{Iri::fromIrirefConsiderBase(
@@ -241,6 +241,7 @@ CPP_template(typename NaryOperation)(
  public:
   using NaryExpression<NaryOperation>::NaryExpression;
   std::vector<PrefilterExprVariablePair> getPrefilterExpressionForMetadata(
+      [[maybe_unused]] const IndexImpl& index,
       [[maybe_unused]] bool isNegated) const override {
     std::vector<PrefilterExprVariablePair> prefilterVec;
     const auto& children = this->children();
@@ -423,11 +424,12 @@ class ConcatExpression : public detail::VariadicExpression {
     bool isFirstLiteral = true;
 
     auto moveLiteralToResult =
-        [](std::optional<Literal>& literal) -> IdOrLocalVocabEntry {
+        [ctx](std::optional<Literal>& literal) -> IdOrLocalVocabEntry {
       if (!literal.has_value()) {
         return Id::makeUndefined();
       }
-      return LiteralOrIri(std::move(literal.value()));
+      return LocalVocabEntry{LiteralOrIri(std::move(literal.value())),
+                             ctx->_qec.getIndex()};
     };
 
     auto visitSingleExpressionResult = CPP_template_lambda(

--- a/src/engine/sparqlExpressions/UuidExpressions.h
+++ b/src/engine/sparqlExpressions/UuidExpressions.h
@@ -53,12 +53,15 @@ class UuidExpressionImpl : public SparqlExpression {
     ad_utility::UuidGenerator uuidGen;
 
     if (context->_isPartOfGroupBy) {
-      return FuncConv(uuidGen());
+      return LocalVocabEntry{FuncConv(uuidGen()), context->_qec.getIndex()};
     }
 
     ad_utility::chunkedForLoop<1000>(
         0, numElements,
-        [&result, &uuidGen](size_t) { result.push_back(FuncConv(uuidGen())); },
+        [&result, &uuidGen, context](size_t) {
+          result.push_back(
+              LocalVocabEntry{FuncConv(uuidGen()), context->_qec.getIndex()});
+        },
         [context]() { context->cancellationHandle_->throwIfCancelled(); });
     return result;
   }

--- a/src/engine/sparqlExpressions/UuidExpressions.h
+++ b/src/engine/sparqlExpressions/UuidExpressions.h
@@ -53,14 +53,15 @@ class UuidExpressionImpl : public SparqlExpression {
     ad_utility::UuidGenerator uuidGen;
 
     if (context->_isPartOfGroupBy) {
-      return LocalVocabEntry{FuncConv(uuidGen()), context->_qec.getIndex()};
+      return LocalVocabEntry{FuncConv(uuidGen()),
+                             context->getLocalVocabContext()};
     }
 
     ad_utility::chunkedForLoop<1000>(
         0, numElements,
         [&result, &uuidGen, context](size_t) {
-          result.push_back(
-              LocalVocabEntry{FuncConv(uuidGen()), context->_qec.getIndex()});
+          result.push_back(LocalVocabEntry{FuncConv(uuidGen()),
+                                           context->getLocalVocabContext()});
         },
         [context]() { context->cancellationHandle_->throwIfCancelled(); });
     return result;

--- a/src/index/DeltaTriples.cpp
+++ b/src/index/DeltaTriples.cpp
@@ -636,8 +636,8 @@ void DeltaTriples::readFromDisk() {
     return;
   }
   AD_CONTRACT_CHECK(localVocab_.empty());
-  auto [vocab, idRanges] = ad_utility::deserializeIds(
-      filenameForPersisting_.value(), index_.getBlankNodeManager());
+  auto [vocab, idRanges] =
+      ad_utility::deserializeIds(filenameForPersisting_.value(), index_);
   if (idRanges.empty()) {
     return;
   }

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -49,12 +49,8 @@ constexpr std::string_view BLANK_NODE_ALLOCATION_START =
     "num-blank-nodes-total";
 
 // _____________________________________________________________________________
-IndexImpl::IndexImpl(ad_utility::AllocatorWithLimit<Id> allocator,
-                     bool registerSingleton)
+IndexImpl::IndexImpl(ad_utility::AllocatorWithLimit<Id> allocator)
     : allocator_{std::move(allocator)} {
-  if (registerSingleton) {
-    globalSingletonIndex_ = this;
-  }
   deltaTriples_.emplace(*this);
 }
 

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -158,9 +158,6 @@ class IndexImpl {
   TextScoringMetric textScoringMetric_;
   std::pair<float, float> bAndKParamForTextScoring_;
 
-  // Global static pointer to the currently active index. It is used to compare
-  // LocalVocab entries with each other as well as with Vocab entries.
-  static inline const IndexImpl* globalSingletonIndex_ = nullptr;
   /**
    * @brief Maps pattern ids to sets of predicate ids.
    */
@@ -205,8 +202,7 @@ class IndexImpl {
   std::optional<DeltaTriplesManager> deltaTriples_;
 
  public:
-  explicit IndexImpl(ad_utility::AllocatorWithLimit<Id> allocator,
-                     bool registerSingleton = true);
+  explicit IndexImpl(ad_utility::AllocatorWithLimit<Id> allocator);
 
   // Forbid copying.
   IndexImpl& operator=(const IndexImpl&) = delete;
@@ -225,13 +221,6 @@ class IndexImpl {
 
   // Function only exposed for testing.
   auto& SPOForTesting() { return const_cast<Permutation&>(SPO()); }
-
-  static const IndexImpl& staticGlobalSingletonIndex() {
-    AD_CORRECTNESS_CHECK(globalSingletonIndex_ != nullptr);
-    return *globalSingletonIndex_;
-  }
-
-  void setGlobalIndexOnlyForTesting() const { globalSingletonIndex_ = this; }
 
   // For a given `Permutation::Enum` (e.g. `PSO`) return the corresponding
   // `Permutation` object by reference or shared pointer (`pso_`).

--- a/src/index/IndexRebuilder.cpp
+++ b/src/index/IndexRebuilder.cpp
@@ -367,7 +367,7 @@ void materializeToIndex(
       minBlankNodeIndex +
       blankNodeBlocks.size() * ad_utility::BlankNodeManager::blockSize_;
 
-  IndexImpl newIndex{index.allocator(), false};
+  IndexImpl newIndex{index.allocator()};
   newIndex.loadConfigFromOldIndex(newIndexName, index, newStats);
 
   REBUILD_LOG_INFO << "Writing new permutations ..." << std::endl;

--- a/src/index/LocalVocabEntry.cpp
+++ b/src/index/LocalVocabEntry.cpp
@@ -68,12 +68,6 @@ LocalVocabEntry LocalVocabEntry::fromIriref(std::string_view view,
 }
 
 // _____________________________________________________________________________
-LocalVocabEntry LocalVocabEntry::fromIrirefWithoutBrackets(
-    std::string_view view, const LocalVocabContext& ctx) {
-  return LocalVocabEntry{IriT::fromIrirefWithoutBrackets(view), ctx};
-}
-
-// _____________________________________________________________________________
 LocalVocabEntry LocalVocabEntry::literalWithoutQuotes(
     std::string_view view, const LocalVocabContext& ctx) {
   return LocalVocabEntry{LiteralT::literalWithoutQuotes(view), ctx};

--- a/src/index/LocalVocabEntry.cpp
+++ b/src/index/LocalVocabEntry.cpp
@@ -10,7 +10,7 @@
 // ___________________________________________________________________________
 ql::strong_ordering LocalVocabEntry::compareThreeWay(
     const LocalVocabEntry& rhs) const {
-  int i = index_.getVocab().getCaseComparator().compare(
+  int i = index_->getVocab().getCaseComparator().compare(
       toStringRepresentation(), rhs.toStringRepresentation(),
       LocaleManager::Level::TOTAL);
   if (i < 0) {
@@ -29,13 +29,13 @@ auto LocalVocabEntry::positionInVocabExpensiveCase() const -> PositionInVocab {
   // this word would be stored if it were present.
   PositionInVocab positionInVocab;
 
-  const auto& vocab = index_.getVocab();
+  const auto& vocab = index_->getVocab();
 
   // NOTE: For encoded IRIs, the only purpose of the returned `std::pair` is to
   // give us a consistent ordering, which is important for determining equality
   // and for operations like `Join`, `Distinct`, `GroupBy`, etc.
   auto [lower, upper] = [&]() {
-    if (auto opt = index_.encodedIriManager().encode(toStringRepresentation());
+    if (auto opt = index_->encodedIriManager().encode(toStringRepresentation());
         opt.has_value()) {
       return std::pair{opt.value(), Id::fromBits(opt.value().getBits() + 1)};
     }

--- a/src/index/LocalVocabEntry.cpp
+++ b/src/index/LocalVocabEntry.cpp
@@ -10,7 +10,7 @@
 // ___________________________________________________________________________
 ql::strong_ordering LocalVocabEntry::compareThreeWay(
     const LocalVocabEntry& rhs) const {
-  int i = index_->getVocab().getCaseComparator().compare(
+  int i = context_->getVocab().getCaseComparator().compare(
       toStringRepresentation(), rhs.toStringRepresentation(),
       LocaleManager::Level::TOTAL);
   if (i < 0) {
@@ -29,13 +29,14 @@ auto LocalVocabEntry::positionInVocabExpensiveCase() const -> PositionInVocab {
   // this word would be stored if it were present.
   PositionInVocab positionInVocab;
 
-  const auto& vocab = index_->getVocab();
+  const auto& vocab = context_->getVocab();
 
   // NOTE: For encoded IRIs, the only purpose of the returned `std::pair` is to
   // give us a consistent ordering, which is important for determining equality
   // and for operations like `Join`, `Distinct`, `GroupBy`, etc.
   auto [lower, upper] = [&]() {
-    if (auto opt = index_->encodedIriManager().encode(toStringRepresentation());
+    if (auto opt =
+            context_->encodedIriManager().encode(toStringRepresentation());
         opt.has_value()) {
       return std::pair{opt.value(), Id::fromBits(opt.value().getBits() + 1)};
     }

--- a/src/index/LocalVocabEntry.cpp
+++ b/src/index/LocalVocabEntry.cpp
@@ -10,11 +10,9 @@
 // ___________________________________________________________________________
 ql::strong_ordering LocalVocabEntry::compareThreeWay(
     const LocalVocabEntry& rhs) const {
-  int i = IndexImpl::staticGlobalSingletonIndex()
-              .getVocab()
-              .getCaseComparator()
-              .compare(toStringRepresentation(), rhs.toStringRepresentation(),
-                       LocaleManager::Level::TOTAL);
+  int i = index_.getVocab().getCaseComparator().compare(
+      toStringRepresentation(), rhs.toStringRepresentation(),
+      LocaleManager::Level::TOTAL);
   if (i < 0) {
     return ql::strong_ordering::less;
   } else if (i > 0) {
@@ -29,16 +27,15 @@ auto LocalVocabEntry::positionInVocabExpensiveCase() const -> PositionInVocab {
   // Lookup the lower and upper bound from the vocabulary of the index,
   // cache and return them. This represents the place in the vocabulary where
   // this word would be stored if it were present.
-  const IndexImpl& index = IndexImpl::staticGlobalSingletonIndex();
   PositionInVocab positionInVocab;
 
-  const auto& vocab = index.getVocab();
+  const auto& vocab = index_.getVocab();
 
   // NOTE: For encoded IRIs, the only purpose of the returned `std::pair` is to
   // give us a consistent ordering, which is important for determining equality
   // and for operations like `Join`, `Distinct`, `GroupBy`, etc.
   auto [lower, upper] = [&]() {
-    if (auto opt = index.encodedIriManager().encode(toStringRepresentation());
+    if (auto opt = index_.encodedIriManager().encode(toStringRepresentation());
         opt.has_value()) {
       return std::pair{opt.value(), Id::fromBits(opt.value().getBits() + 1)};
     }

--- a/src/index/LocalVocabEntry.cpp
+++ b/src/index/LocalVocabEntry.cpp
@@ -54,3 +54,33 @@ auto LocalVocabEntry::positionInVocabExpensiveCase() const -> PositionInVocab {
   positionInVocabKnown_.store(true, std::memory_order_release);
   return positionInVocab;
 }
+
+// _____________________________________________________________________________
+LocalVocabEntry LocalVocabEntry::fromStringRepresentation(
+    std::string s, const LocalVocabContext& ctx) {
+  return LocalVocabEntry{Base::fromStringRepresentation(std::move(s)), ctx};
+}
+
+// _____________________________________________________________________________
+LocalVocabEntry LocalVocabEntry::fromIriref(std::string_view view,
+                                            const LocalVocabContext& ctx) {
+  return LocalVocabEntry{IriT::fromIriref(view), ctx};
+}
+
+// _____________________________________________________________________________
+LocalVocabEntry LocalVocabEntry::fromIrirefWithoutBrackets(
+    std::string_view view, const LocalVocabContext& ctx) {
+  return LocalVocabEntry{IriT::fromIrirefWithoutBrackets(view), ctx};
+}
+
+// _____________________________________________________________________________
+LocalVocabEntry LocalVocabEntry::literalWithoutQuotes(
+    std::string_view view, const LocalVocabContext& ctx) {
+  return LocalVocabEntry{LiteralT::literalWithoutQuotes(view), ctx};
+}
+
+// _____________________________________________________________________________
+LocalVocabEntry LocalVocabEntry::literalWithNormalizedContent(
+    NormalizedStringView view, const LocalVocabContext& ctx) {
+  return LocalVocabEntry{LiteralT::literalWithNormalizedContent(view), ctx};
+}

--- a/src/index/LocalVocabEntry.h
+++ b/src/index/LocalVocabEntry.h
@@ -18,6 +18,8 @@
 #include "util/CopyableSynchronization.h"
 #include "util/Exception.h"
 
+class IndexImpl;
+
 // This is the type we use to store literals and IRIs in the `LocalVocab`.
 // It consists of a `LiteralOrIri` and a cache to store the position, where
 // the entry would be in the global vocabulary of the Index. This position is
@@ -44,22 +46,27 @@ class alignas(16) LocalVocabEntry
   // three separate atomics to avoid mutexes. The downside is, that in parallel
   // code multiple threads might look up the position concurrently, which wastes
   // a bit of resources. However, we don't consider this case to be likely.
+  const IndexImpl& index_;
   mutable ad_utility::CopyableAtomic<IdProxy> lowerBoundInVocab_;
   mutable ad_utility::CopyableAtomic<IdProxy> upperBoundInVocab_;
   mutable ad_utility::CopyableAtomic<bool> positionInVocabKnown_ = false;
 
  public:
-  // Inherit the constructors from `LiteralOrIri`
-  using Base::Base;
+  LocalVocabEntry(LiteralT literal, const IndexImpl& index)
+      : Base{std::move(literal)}, index_{index} {}
+  LocalVocabEntry(IriT iri, const IndexImpl& index) noexcept
+      : Base{std::move(iri)}, index_{index} {}
 
   // Deliberately allow implicit conversion from `LiteralOrIri`.
-  QL_EXPLICIT(false) LocalVocabEntry(const Base& base) : Base{base} {}
-  QL_EXPLICIT(false)
-  LocalVocabEntry(Base&& base) noexcept : Base{std::move(base)} {}
+  LocalVocabEntry(const Base& base, const IndexImpl& index)
+      : Base{base}, index_{index} {}
+  LocalVocabEntry(Base&& base, const IndexImpl& index) noexcept
+      : Base{std::move(base)}, index_{index} {}
+
   // Constructor for when the position in the vocab is already known.
-  QL_EXPLICIT(true)
-  LocalVocabEntry(Base&& base, auto lower, auto upper)
+  LocalVocabEntry(Base&& base, auto lower, auto upper, const IndexImpl& index)
       : Base{std::move(base)},
+        index_{index},
         lowerBoundInVocab_(IdProxy::make(lower.getBits())),
         upperBoundInVocab_(IdProxy::make(upper.getBits())),
         positionInVocabKnown_(true) {

--- a/src/index/LocalVocabEntry.h
+++ b/src/index/LocalVocabEntry.h
@@ -19,6 +19,7 @@
 #include "util/Exception.h"
 
 class IndexImpl;
+using LocalVocabContext = IndexImpl;
 
 // This is the type we use to store literals and IRIs in the `LocalVocab`.
 // It consists of a `LiteralOrIri` and a cache to store the position, where
@@ -40,7 +41,7 @@ class alignas(16) LocalVocabEntry
 
  private:
   // Pointer to keep this object assignable.
-  const IndexImpl* index_;
+  const LocalVocabContext* context_;
   // The cache for the position in the vocabulary. As usual, the `lowerBound` is
   // inclusive, the `upperBound` is not, so if `lowerBound == upperBound`, then
   // the entry is not part of the globalVocabulary, and `lowerBound` points to
@@ -53,21 +54,22 @@ class alignas(16) LocalVocabEntry
   mutable ad_utility::CopyableAtomic<bool> positionInVocabKnown_ = false;
 
  public:
-  LocalVocabEntry(LiteralT literal, const IndexImpl& index)
-      : Base{std::move(literal)}, index_{&index} {}
-  LocalVocabEntry(IriT iri, const IndexImpl& index) noexcept
-      : Base{std::move(iri)}, index_{&index} {}
+  LocalVocabEntry(LiteralT literal, const LocalVocabContext& context)
+      : Base{std::move(literal)}, context_{&context} {}
+  LocalVocabEntry(IriT iri, const LocalVocabContext& context) noexcept
+      : Base{std::move(iri)}, context_{&context} {}
 
   // Deliberately allow implicit conversion from `LiteralOrIri`.
-  LocalVocabEntry(const Base& base, const IndexImpl& index)
-      : Base{base}, index_{&index} {}
-  LocalVocabEntry(Base&& base, const IndexImpl& index) noexcept
-      : Base{std::move(base)}, index_{&index} {}
+  LocalVocabEntry(const Base& base, const LocalVocabContext& context)
+      : Base{base}, context_{&context} {}
+  LocalVocabEntry(Base&& base, const LocalVocabContext& context) noexcept
+      : Base{std::move(base)}, context_{&context} {}
 
   // Constructor for when the position in the vocab is already known.
-  LocalVocabEntry(Base&& base, auto lower, auto upper, const IndexImpl& index)
+  LocalVocabEntry(Base&& base, auto lower, auto upper,
+                  const LocalVocabContext& context)
       : Base{std::move(base)},
-        index_{&index},
+        context_{&context},
         lowerBoundInVocab_(IdProxy::make(lower.getBits())),
         upperBoundInVocab_(IdProxy::make(upper.getBits())),
         positionInVocabKnown_(true) {

--- a/src/index/LocalVocabEntry.h
+++ b/src/index/LocalVocabEntry.h
@@ -39,6 +39,8 @@ class alignas(16) LocalVocabEntry
   FRIEND_TEST(TripleComponent, toValueId);
 
  private:
+  // Pointer to keep this object assignable.
+  const IndexImpl* index_;
   // The cache for the position in the vocabulary. As usual, the `lowerBound` is
   // inclusive, the `upperBound` is not, so if `lowerBound == upperBound`, then
   // the entry is not part of the globalVocabulary, and `lowerBound` points to
@@ -46,27 +48,26 @@ class alignas(16) LocalVocabEntry
   // three separate atomics to avoid mutexes. The downside is, that in parallel
   // code multiple threads might look up the position concurrently, which wastes
   // a bit of resources. However, we don't consider this case to be likely.
-  const IndexImpl& index_;
   mutable ad_utility::CopyableAtomic<IdProxy> lowerBoundInVocab_;
   mutable ad_utility::CopyableAtomic<IdProxy> upperBoundInVocab_;
   mutable ad_utility::CopyableAtomic<bool> positionInVocabKnown_ = false;
 
  public:
   LocalVocabEntry(LiteralT literal, const IndexImpl& index)
-      : Base{std::move(literal)}, index_{index} {}
+      : Base{std::move(literal)}, index_{&index} {}
   LocalVocabEntry(IriT iri, const IndexImpl& index) noexcept
-      : Base{std::move(iri)}, index_{index} {}
+      : Base{std::move(iri)}, index_{&index} {}
 
   // Deliberately allow implicit conversion from `LiteralOrIri`.
   LocalVocabEntry(const Base& base, const IndexImpl& index)
-      : Base{base}, index_{index} {}
+      : Base{base}, index_{&index} {}
   LocalVocabEntry(Base&& base, const IndexImpl& index) noexcept
-      : Base{std::move(base)}, index_{index} {}
+      : Base{std::move(base)}, index_{&index} {}
 
   // Constructor for when the position in the vocab is already known.
   LocalVocabEntry(Base&& base, auto lower, auto upper, const IndexImpl& index)
       : Base{std::move(base)},
-        index_{index},
+        index_{&index},
         lowerBoundInVocab_(IdProxy::make(lower.getBits())),
         upperBoundInVocab_(IdProxy::make(upper.getBits())),
         positionInVocabKnown_(true) {
@@ -77,6 +78,11 @@ class alignas(16) LocalVocabEntry
                         PositionInVocab{IdProxy::make(lower.getBits()),
                                         IdProxy::make(upper.getBits())}));
   }
+
+  LocalVocabEntry(const LocalVocabEntry&) = default;
+  LocalVocabEntry(LocalVocabEntry&&) noexcept = default;
+  LocalVocabEntry& operator=(const LocalVocabEntry&) = default;
+  LocalVocabEntry& operator=(LocalVocabEntry&&) noexcept = default;
 
   // Slice to base class `LiteralOrIri`.
   const ad_utility::triple_component::LiteralOrIri& asLiteralOrIri() const {

--- a/src/index/LocalVocabEntry.h
+++ b/src/index/LocalVocabEntry.h
@@ -94,9 +94,6 @@ class alignas(16) LocalVocabEntry
   static LocalVocabEntry fromIriref(std::string_view view,
                                     const LocalVocabContext& ctx);
 
-  static LocalVocabEntry fromIrirefWithoutBrackets(
-      std::string_view view, const LocalVocabContext& ctx);
-
   static LocalVocabEntry literalWithoutQuotes(std::string_view view,
                                               const LocalVocabContext& ctx);
 

--- a/src/index/LocalVocabEntry.h
+++ b/src/index/LocalVocabEntry.h
@@ -86,12 +86,22 @@ class alignas(16) LocalVocabEntry
   LocalVocabEntry& operator=(const LocalVocabEntry&) = default;
   LocalVocabEntry& operator=(LocalVocabEntry&&) noexcept = default;
 
-  // Factory method that creates a `LocalVocabEntry` from a string
-  // representation (e.g. `"<someIri>"` or `"\"someLiteral\""`).
-  static LocalVocabEntry fromStringRepresentation(
-      std::string s, const LocalVocabContext& ctx) {
-    return LocalVocabEntry{Base::fromStringRepresentation(std::move(s)), ctx};
-  }
+  // Convenience functions that delegate to the corresponding static functions
+  // of `IriT` and `LiteralT`.
+  static LocalVocabEntry fromStringRepresentation(std::string s,
+                                                  const LocalVocabContext& ctx);
+
+  static LocalVocabEntry fromIriref(std::string_view view,
+                                    const LocalVocabContext& ctx);
+
+  static LocalVocabEntry fromIrirefWithoutBrackets(
+      std::string_view view, const LocalVocabContext& ctx);
+
+  static LocalVocabEntry literalWithoutQuotes(std::string_view view,
+                                              const LocalVocabContext& ctx);
+
+  static LocalVocabEntry literalWithNormalizedContent(
+      NormalizedStringView view, const LocalVocabContext& ctx);
 
   // Slice to base class `LiteralOrIri`.
   const ad_utility::triple_component::LiteralOrIri& asLiteralOrIri() const {

--- a/src/index/LocalVocabEntry.h
+++ b/src/index/LocalVocabEntry.h
@@ -86,6 +86,13 @@ class alignas(16) LocalVocabEntry
   LocalVocabEntry& operator=(const LocalVocabEntry&) = default;
   LocalVocabEntry& operator=(LocalVocabEntry&&) noexcept = default;
 
+  // Factory method that creates a `LocalVocabEntry` from a string
+  // representation (e.g. `"<someIri>"` or `"\"someLiteral\""`).
+  static LocalVocabEntry fromStringRepresentation(
+      std::string s, const LocalVocabContext& ctx) {
+    return LocalVocabEntry{Base::fromStringRepresentation(std::move(s)), ctx};
+  }
+
   // Slice to base class `LiteralOrIri`.
   const ad_utility::triple_component::LiteralOrIri& asLiteralOrIri() const {
     return *this;

--- a/src/libqlever/Qlever.h
+++ b/src/libqlever/Qlever.h
@@ -279,8 +279,7 @@ class Qlever {
   // Read the contents of the `NamedResultCache` from disk.
   template <typename Serializer>
   void readNamedResultCacheFromDisk(Serializer& serializer) {
-    namedResultCache_.readFromSerializer(serializer, allocator_,
-                                         index_.getImpl());
+    namedResultCache_.readFromSerializer(serializer, allocator_, index_);
   }
 
   // Low-level access to the QLever API, use with care.

--- a/src/libqlever/Qlever.h
+++ b/src/libqlever/Qlever.h
@@ -280,7 +280,7 @@ class Qlever {
   template <typename Serializer>
   void readNamedResultCacheFromDisk(Serializer& serializer) {
     namedResultCache_.readFromSerializer(serializer, allocator_,
-                                         *index_.getBlankNodeManager());
+                                         index_.getImpl());
   }
 
   // Low-level access to the QLever API, use with care.

--- a/src/parser/TripleComponent.cpp
+++ b/src/parser/TripleComponent.cpp
@@ -155,5 +155,5 @@ Id TripleComponent::toValueId(const IndexImpl& index,
   };
   return Id::makeFromLocalVocabIndex(localVocab.getIndexAndAddIfNotContained(
       LocalVocabEntry(moveWord(), Id::makeFromVocabIndex(lower),
-                      Id::makeFromVocabIndex(upper))));
+                      Id::makeFromVocabIndex(upper), index)));
 }

--- a/src/util/CompilerWarnings.h
+++ b/src/util/CompilerWarnings.h
@@ -37,6 +37,13 @@
   _Pragma("GCC diagnostic push")             \
       _Pragma("GCC diagnostic ignored \"-Wnon-template-friend\"")
 
+// Disable the `aggressive-loop-optimizations` warning, which produces false
+// positives on GCC 13 when `std::advance` is inlined into
+// `std::vector::assign` through a `ranges::elements_view` over a hash map.
+#define DISABLE_AGGRESSIVE_LOOP_OPT_WARNINGS \
+  _Pragma("GCC diagnostic push")             \
+      _Pragma("GCC diagnostic ignored \"-Waggressive-loop-optimizations\"")
+
 // Re-enable the warnings disabled by the last `DISABLE_...` call.
 #define GCC_REENABLE_WARNINGS _Pragma("GCC diagnostic pop")
 
@@ -46,6 +53,7 @@
 #define DISABLE_STRINGOP_OVERFLOW_WARNINGS
 #define DISABLE_WARNINGS_GCC_TEMPLATE_FRIEND
 #define DISABLE_FREE_NONHEAP_WARNINGS
+#define DISABLE_AGGRESSIVE_LOOP_OPT_WARNINGS
 #define GCC_REENABLE_WARNINGS
 #endif
 

--- a/src/util/Serializer/TripleSerializer.h
+++ b/src/util/Serializer/TripleSerializer.h
@@ -112,9 +112,8 @@ CPP_template(typename Serializer)(
   for (uint64_t i = 0; i < size; ++i) {
     auto id = readValue<Id::T>(serializer);
     auto s = readValue<std::string>(serializer);
-    auto localVocabIndex = vocab.getIndexAndAddIfNotContained(LocalVocabEntry{
-        triple_component::LiteralOrIri::fromStringRepresentation(std::move(s)),
-        context});
+    auto localVocabIndex = vocab.getIndexAndAddIfNotContained(
+        LocalVocabEntry::fromStringRepresentation(std::move(s), context));
     mapping.emplace(id, Id::makeFromLocalVocabIndex(localVocabIndex));
   }
   return {std::move(vocab), std::move(mapping)};

--- a/src/util/Serializer/TripleSerializer.h
+++ b/src/util/Serializer/TripleSerializer.h
@@ -97,13 +97,13 @@ CPP_template(typename Serializer)(
 CPP_template(typename Serializer)(
     requires serialization::ReadSerializer<Serializer>) std::
     tuple<LocalVocab, absl::flat_hash_map<Id::T, Id>> deserializeLocalVocab(
-        Serializer& serializer, const IndexImpl& index) {
+        Serializer& serializer, const LocalVocabContext& context) {
   LocalVocab vocab;
   vocab.reserveBlankNodeBlocksFromExplicitIndices(
       readValue<std::vector<
           BlankNodeManager::LocalBlankNodeManager::OwnedBlocksEntry>>(
           serializer),
-      index.getBlankNodeManager());
+      context.getBlankNodeManager());
   auto size = readValue<uint64_t>(serializer);
   // Note:: It might happen that the `size` is zero because the local vocab was
   // empty.
@@ -114,7 +114,7 @@ CPP_template(typename Serializer)(
     auto s = readValue<std::string>(serializer);
     auto localVocabIndex = vocab.getIndexAndAddIfNotContained(LocalVocabEntry{
         triple_component::LiteralOrIri::fromStringRepresentation(std::move(s)),
-        index});
+        context});
     mapping.emplace(id, Id::makeFromLocalVocabIndex(localVocabIndex));
   }
   return {std::move(vocab), std::move(mapping)};
@@ -183,7 +183,7 @@ CPP_template(typename Range)(
 }
 
 inline std::tuple<LocalVocab, std::vector<std::vector<Id>>> deserializeIds(
-    const std::filesystem::path& path, const IndexImpl& index) {
+    const std::filesystem::path& path, const LocalVocabContext& context) {
   // This is a minor TOCTOU issue, the file might be gone after this check and
   // before the call to `fopen`, done by `FileReadSerializer`, so ideally we'd
   // handle this as a special exception type of our own `File` class, which
@@ -205,7 +205,7 @@ inline std::tuple<LocalVocab, std::vector<std::vector<Id>>> deserializeIds(
   AD_LOG_INFO << "Reading and processing persisted updates from " << path
               << " ..." << std::endl;
   detail::readHeader(serializer);
-  auto [vocab, mapping] = detail::deserializeLocalVocab(serializer, index);
+  auto [vocab, mapping] = detail::deserializeLocalVocab(serializer, context);
   std::vector<std::vector<Id>> idVectors;
   auto numRanges = detail::readValue<uint64_t>(serializer);
   for ([[maybe_unused]] auto i : ad_utility::integerRange(numRanges)) {

--- a/src/util/Serializer/TripleSerializer.h
+++ b/src/util/Serializer/TripleSerializer.h
@@ -14,6 +14,7 @@
 #include "backports/concepts.h"
 #include "backports/type_traits.h"
 #include "global/Id.h"
+#include "index/IndexImpl.h"
 #include "index/LocalVocab.h"
 #include "util/Exception.h"
 #include "util/Serializer/FileSerializer.h"
@@ -96,13 +97,13 @@ CPP_template(typename Serializer)(
 CPP_template(typename Serializer)(
     requires serialization::ReadSerializer<Serializer>) std::
     tuple<LocalVocab, absl::flat_hash_map<Id::T, Id>> deserializeLocalVocab(
-        Serializer& serializer, BlankNodeManager* blankNodeManager) {
+        Serializer& serializer, const IndexImpl& index) {
   LocalVocab vocab;
   vocab.reserveBlankNodeBlocksFromExplicitIndices(
       readValue<std::vector<
           BlankNodeManager::LocalBlankNodeManager::OwnedBlocksEntry>>(
           serializer),
-      blankNodeManager);
+      index.getBlankNodeManager());
   auto size = readValue<uint64_t>(serializer);
   // Note:: It might happen that the `size` is zero because the local vocab was
   // empty.
@@ -111,8 +112,9 @@ CPP_template(typename Serializer)(
   for (uint64_t i = 0; i < size; ++i) {
     auto id = readValue<Id::T>(serializer);
     auto s = readValue<std::string>(serializer);
-    auto localVocabIndex = vocab.getIndexAndAddIfNotContained(
-        LocalVocabEntry::fromStringRepresentation(std::move(s)));
+    auto localVocabIndex = vocab.getIndexAndAddIfNotContained(LocalVocabEntry{
+        triple_component::LiteralOrIri::fromStringRepresentation(std::move(s)),
+        index});
     mapping.emplace(id, Id::makeFromLocalVocabIndex(localVocabIndex));
   }
   return {std::move(vocab), std::move(mapping)};
@@ -181,7 +183,7 @@ CPP_template(typename Range)(
 }
 
 inline std::tuple<LocalVocab, std::vector<std::vector<Id>>> deserializeIds(
-    const std::filesystem::path& path, BlankNodeManager* blankNodeManager) {
+    const std::filesystem::path& path, const IndexImpl& index) {
   // This is a minor TOCTOU issue, the file might be gone after this check and
   // before the call to `fopen`, done by `FileReadSerializer`, so ideally we'd
   // handle this as a special exception type of our own `File` class, which
@@ -203,8 +205,7 @@ inline std::tuple<LocalVocab, std::vector<std::vector<Id>>> deserializeIds(
   AD_LOG_INFO << "Reading and processing persisted updates from " << path
               << " ..." << std::endl;
   detail::readHeader(serializer);
-  auto [vocab, mapping] =
-      detail::deserializeLocalVocab(serializer, blankNodeManager);
+  auto [vocab, mapping] = detail::deserializeLocalVocab(serializer, index);
   std::vector<std::vector<Id>> idVectors;
   auto numRanges = detail::readValue<uint64_t>(serializer);
   for ([[maybe_unused]] auto i : ad_utility::integerRange(numRanges)) {

--- a/test/AddCombinedRowToTableTest.cpp
+++ b/test/AddCombinedRowToTableTest.cpp
@@ -305,7 +305,7 @@ bool vocabContainsString(const LocalVocab& vocab, std::string_view string,
 // _____________________________________________________________________________
 TEST(AddCombinedRowToTable, verifyLocalVocabIsUpdatedCorrectly) {
   auto* qec = ad_utility::testing::getQec();
-  const auto& index = qec->getIndex();
+  const auto& localVocabContext = qec->getLocalVocabContext();
   auto outputTable = makeIdTableFromVector({});
   outputTable.setNumColumns(3);
   std::vector<LocalVocab> localVocabs;
@@ -323,11 +323,11 @@ TEST(AddCombinedRowToTable, verifyLocalVocabIsUpdatedCorrectly) {
       }};
 
   IdTableWithVocab input1{makeIdTableFromVector({{0, 1}}),
-                          createVocabWithSingleString("a", index)};
+                          createVocabWithSingleString("a", localVocabContext)};
   IdTableWithVocab input2{makeIdTableFromVector({{0, 2}}),
-                          createVocabWithSingleString("b", index)};
+                          createVocabWithSingleString("b", localVocabContext)};
   IdTableWithVocab input3{makeIdTableFromVector({{0, 3}}),
-                          createVocabWithSingleString("c", index)};
+                          createVocabWithSingleString("c", localVocabContext)};
 
   using ::testing::SizeIs;
 
@@ -353,31 +353,31 @@ TEST(AddCombinedRowToTable, verifyLocalVocabIsUpdatedCorrectly) {
 
   ASSERT_THAT(localVocabs, SizeIs(5));
 
-  EXPECT_TRUE(vocabContainsString(localVocabs[0], "a", index));
-  EXPECT_TRUE(vocabContainsString(localVocabs[0], "b", index));
-  EXPECT_FALSE(vocabContainsString(localVocabs[0], "c", index));
+  EXPECT_TRUE(vocabContainsString(localVocabs[0], "a", localVocabContext));
+  EXPECT_TRUE(vocabContainsString(localVocabs[0], "b", localVocabContext));
+  EXPECT_FALSE(vocabContainsString(localVocabs[0], "c", localVocabContext));
 
-  EXPECT_TRUE(vocabContainsString(localVocabs[1], "a", index));
-  EXPECT_TRUE(vocabContainsString(localVocabs[1], "b", index));
-  EXPECT_FALSE(vocabContainsString(localVocabs[1], "c", index));
+  EXPECT_TRUE(vocabContainsString(localVocabs[1], "a", localVocabContext));
+  EXPECT_TRUE(vocabContainsString(localVocabs[1], "b", localVocabContext));
+  EXPECT_FALSE(vocabContainsString(localVocabs[1], "c", localVocabContext));
 
-  EXPECT_FALSE(vocabContainsString(localVocabs[2], "a", index));
-  EXPECT_TRUE(vocabContainsString(localVocabs[2], "b", index));
-  EXPECT_TRUE(vocabContainsString(localVocabs[2], "c", index));
+  EXPECT_FALSE(vocabContainsString(localVocabs[2], "a", localVocabContext));
+  EXPECT_TRUE(vocabContainsString(localVocabs[2], "b", localVocabContext));
+  EXPECT_TRUE(vocabContainsString(localVocabs[2], "c", localVocabContext));
 
-  EXPECT_TRUE(vocabContainsString(localVocabs[3], "a", index));
-  EXPECT_FALSE(vocabContainsString(localVocabs[3], "b", index));
-  EXPECT_FALSE(vocabContainsString(localVocabs[3], "c", index));
+  EXPECT_TRUE(vocabContainsString(localVocabs[3], "a", localVocabContext));
+  EXPECT_FALSE(vocabContainsString(localVocabs[3], "b", localVocabContext));
+  EXPECT_FALSE(vocabContainsString(localVocabs[3], "c", localVocabContext));
 
-  EXPECT_TRUE(vocabContainsString(localVocabs[4], "a", index));
-  EXPECT_FALSE(vocabContainsString(localVocabs[4], "b", index));
-  EXPECT_FALSE(vocabContainsString(localVocabs[4], "c", index));
+  EXPECT_TRUE(vocabContainsString(localVocabs[4], "a", localVocabContext));
+  EXPECT_FALSE(vocabContainsString(localVocabs[4], "b", localVocabContext));
+  EXPECT_FALSE(vocabContainsString(localVocabs[4], "c", localVocabContext));
 }
 
 // _____________________________________________________________________________
 TEST(AddCombinedRowToTable, verifyLocalVocabIsRetainedWhenNotMoving) {
   auto* qec = ad_utility::testing::getQec();
-  const auto& index = qec->getIndex();
+  const auto& localVocabContext = qec->getLocalVocabContext();
   auto outputTable = makeIdTableFromVector({});
   outputTable.setNumColumns(3);
   ad_utility::AddCombinedRowToIdTable adder{
@@ -385,9 +385,9 @@ TEST(AddCombinedRowToTable, verifyLocalVocabIsRetainedWhenNotMoving) {
       std::make_shared<ad_utility::CancellationHandle<>>(), 1};
 
   IdTableWithVocab input1{makeIdTableFromVector({{0, 1}}),
-                          createVocabWithSingleString("a", index)};
+                          createVocabWithSingleString("a", localVocabContext)};
   IdTableWithVocab input2{makeIdTableFromVector({{0, 2}}),
-                          createVocabWithSingleString("b", index)};
+                          createVocabWithSingleString("b", localVocabContext)};
 
   adder.setInput(input1, input2);
   adder.addRow(0, 0);
@@ -396,15 +396,15 @@ TEST(AddCombinedRowToTable, verifyLocalVocabIsRetainedWhenNotMoving) {
 
   LocalVocab localVocab = std::move(adder.localVocab());
 
-  EXPECT_TRUE(vocabContainsString(localVocab, "a", index));
-  EXPECT_TRUE(vocabContainsString(localVocab, "b", index));
+  EXPECT_TRUE(vocabContainsString(localVocab, "a", localVocabContext));
+  EXPECT_TRUE(vocabContainsString(localVocab, "b", localVocabContext));
   EXPECT_THAT(localVocab.getAllWordsForTesting(), ::testing::SizeIs(2));
 }
 
 // _____________________________________________________________________________
 TEST(AddCombinedRowToTable, localVocabIsOnlyClearedWhenLegal) {
   auto* qec = ad_utility::testing::getQec();
-  const auto& index = qec->getIndex();
+  const auto& localVocabContext = qec->getLocalVocabContext();
   auto outputTable = makeIdTableFromVector({});
   outputTable.setNumColumns(3);
   ad_utility::AddCombinedRowToIdTable adder{
@@ -412,16 +412,16 @@ TEST(AddCombinedRowToTable, localVocabIsOnlyClearedWhenLegal) {
       std::make_shared<ad_utility::CancellationHandle<>>(), 1};
 
   IdTableWithVocab input1{makeIdTableFromVector({{0, 1}}),
-                          createVocabWithSingleString("a", index)};
+                          createVocabWithSingleString("a", localVocabContext)};
   IdTableWithVocab input2{makeIdTableFromVector({{0, 2}}),
-                          createVocabWithSingleString("b", index)};
+                          createVocabWithSingleString("b", localVocabContext)};
 
   adder.setInput(input1, input2);
   adder.addRow(0, 0);
   IdTableWithVocab input3{makeIdTableFromVector({{3, 1}}),
-                          createVocabWithSingleString("c", index)};
+                          createVocabWithSingleString("c", localVocabContext)};
   IdTableWithVocab input4{makeIdTableFromVector({{3, 2}}),
-                          createVocabWithSingleString("d", index)};
+                          createVocabWithSingleString("d", localVocabContext)};
   // NOTE: This seemingly redundant call to `setInput` is important, as it tests
   // a previous bug: Each call to `setInput` implicitly also calls `flush` and
   // also possibly clears the local vocab if it is not used anymore. In this
@@ -432,10 +432,10 @@ TEST(AddCombinedRowToTable, localVocabIsOnlyClearedWhenLegal) {
   adder.addRow(0, 0);
   auto localVocab = adder.localVocab().clone();
 
-  EXPECT_TRUE(vocabContainsString(localVocab, "a", index));
-  EXPECT_TRUE(vocabContainsString(localVocab, "b", index));
-  EXPECT_TRUE(vocabContainsString(localVocab, "c", index));
-  EXPECT_TRUE(vocabContainsString(localVocab, "d", index));
+  EXPECT_TRUE(vocabContainsString(localVocab, "a", localVocabContext));
+  EXPECT_TRUE(vocabContainsString(localVocab, "b", localVocabContext));
+  EXPECT_TRUE(vocabContainsString(localVocab, "c", localVocabContext));
+  EXPECT_TRUE(vocabContainsString(localVocab, "d", localVocabContext));
   EXPECT_THAT(localVocab.getAllWordsForTesting(), ::testing::SizeIs(4));
 }
 

--- a/test/AddCombinedRowToTableTest.cpp
+++ b/test/AddCombinedRowToTableTest.cpp
@@ -287,18 +287,18 @@ Literal fromString(std::string_view string) {
 
 // _____________________________________________________________________________
 LocalVocab createVocabWithSingleString(std::string_view string,
-                                       const IndexImpl& index) {
+                                       const LocalVocabContext& context) {
   LocalVocab localVocab;
   localVocab.getIndexAndAddIfNotContained(
-      LocalVocabEntry{fromString(string), index});
+      LocalVocabEntry{fromString(string), context});
   return localVocab;
 }
 
 // _____________________________________________________________________________
 bool vocabContainsString(const LocalVocab& vocab, std::string_view string,
-                         const IndexImpl& index) {
+                         const LocalVocabContext& context) {
   return ad_utility::contains(vocab.getAllWordsForTesting(),
-                              LocalVocabEntry{fromString(string), index});
+                              LocalVocabEntry{fromString(string), context});
 }
 }  // namespace
 

--- a/test/AddCombinedRowToTableTest.cpp
+++ b/test/AddCombinedRowToTableTest.cpp
@@ -8,6 +8,7 @@
 #include "backports/concepts.h"
 #include "backports/type_traits.h"
 #include "engine/AddCombinedRowToTable.h"
+#include "util/IndexTestHelpers.h"
 
 namespace {
 static constexpr auto U = Id::makeUndefined();
@@ -285,16 +286,22 @@ Literal fromString(std::string_view string) {
 }
 
 // _____________________________________________________________________________
+const auto& getTestIndexImpl() {
+  return ad_utility::testing::getQec()->getIndex().getImpl();
+}
+
 LocalVocab createVocabWithSingleString(std::string_view string) {
   LocalVocab localVocab;
-  localVocab.getIndexAndAddIfNotContained(LocalVocabEntry{fromString(string)});
+  localVocab.getIndexAndAddIfNotContained(
+      LocalVocabEntry{fromString(string), getTestIndexImpl()});
   return localVocab;
 }
 
 // _____________________________________________________________________________
 bool vocabContainsString(const LocalVocab& vocab, std::string_view string) {
-  return ad_utility::contains(vocab.getAllWordsForTesting(),
-                              LocalVocabEntry{fromString(string)});
+  return ad_utility::contains(
+      vocab.getAllWordsForTesting(),
+      LocalVocabEntry{fromString(string), getTestIndexImpl()});
 }
 }  // namespace
 

--- a/test/AddCombinedRowToTableTest.cpp
+++ b/test/AddCombinedRowToTableTest.cpp
@@ -286,27 +286,26 @@ Literal fromString(std::string_view string) {
 }
 
 // _____________________________________________________________________________
-const auto& getTestIndexImpl() {
-  return ad_utility::testing::getQec()->getIndex().getImpl();
-}
-
-LocalVocab createVocabWithSingleString(std::string_view string) {
+LocalVocab createVocabWithSingleString(std::string_view string,
+                                       const IndexImpl& index) {
   LocalVocab localVocab;
   localVocab.getIndexAndAddIfNotContained(
-      LocalVocabEntry{fromString(string), getTestIndexImpl()});
+      LocalVocabEntry{fromString(string), index});
   return localVocab;
 }
 
 // _____________________________________________________________________________
-bool vocabContainsString(const LocalVocab& vocab, std::string_view string) {
-  return ad_utility::contains(
-      vocab.getAllWordsForTesting(),
-      LocalVocabEntry{fromString(string), getTestIndexImpl()});
+bool vocabContainsString(const LocalVocab& vocab, std::string_view string,
+                         const IndexImpl& index) {
+  return ad_utility::contains(vocab.getAllWordsForTesting(),
+                              LocalVocabEntry{fromString(string), index});
 }
 }  // namespace
 
 // _____________________________________________________________________________
 TEST(AddCombinedRowToTable, verifyLocalVocabIsUpdatedCorrectly) {
+  auto* qec = ad_utility::testing::getQec();
+  const auto& index = qec->getIndex();
   auto outputTable = makeIdTableFromVector({});
   outputTable.setNumColumns(3);
   std::vector<LocalVocab> localVocabs;
@@ -324,11 +323,11 @@ TEST(AddCombinedRowToTable, verifyLocalVocabIsUpdatedCorrectly) {
       }};
 
   IdTableWithVocab input1{makeIdTableFromVector({{0, 1}}),
-                          createVocabWithSingleString("a")};
+                          createVocabWithSingleString("a", index)};
   IdTableWithVocab input2{makeIdTableFromVector({{0, 2}}),
-                          createVocabWithSingleString("b")};
+                          createVocabWithSingleString("b", index)};
   IdTableWithVocab input3{makeIdTableFromVector({{0, 3}}),
-                          createVocabWithSingleString("c")};
+                          createVocabWithSingleString("c", index)};
 
   using ::testing::SizeIs;
 
@@ -354,29 +353,31 @@ TEST(AddCombinedRowToTable, verifyLocalVocabIsUpdatedCorrectly) {
 
   ASSERT_THAT(localVocabs, SizeIs(5));
 
-  EXPECT_TRUE(vocabContainsString(localVocabs[0], "a"));
-  EXPECT_TRUE(vocabContainsString(localVocabs[0], "b"));
-  EXPECT_FALSE(vocabContainsString(localVocabs[0], "c"));
+  EXPECT_TRUE(vocabContainsString(localVocabs[0], "a", index));
+  EXPECT_TRUE(vocabContainsString(localVocabs[0], "b", index));
+  EXPECT_FALSE(vocabContainsString(localVocabs[0], "c", index));
 
-  EXPECT_TRUE(vocabContainsString(localVocabs[1], "a"));
-  EXPECT_TRUE(vocabContainsString(localVocabs[1], "b"));
-  EXPECT_FALSE(vocabContainsString(localVocabs[1], "c"));
+  EXPECT_TRUE(vocabContainsString(localVocabs[1], "a", index));
+  EXPECT_TRUE(vocabContainsString(localVocabs[1], "b", index));
+  EXPECT_FALSE(vocabContainsString(localVocabs[1], "c", index));
 
-  EXPECT_FALSE(vocabContainsString(localVocabs[2], "a"));
-  EXPECT_TRUE(vocabContainsString(localVocabs[2], "b"));
-  EXPECT_TRUE(vocabContainsString(localVocabs[2], "c"));
+  EXPECT_FALSE(vocabContainsString(localVocabs[2], "a", index));
+  EXPECT_TRUE(vocabContainsString(localVocabs[2], "b", index));
+  EXPECT_TRUE(vocabContainsString(localVocabs[2], "c", index));
 
-  EXPECT_TRUE(vocabContainsString(localVocabs[3], "a"));
-  EXPECT_FALSE(vocabContainsString(localVocabs[3], "b"));
-  EXPECT_FALSE(vocabContainsString(localVocabs[3], "c"));
+  EXPECT_TRUE(vocabContainsString(localVocabs[3], "a", index));
+  EXPECT_FALSE(vocabContainsString(localVocabs[3], "b", index));
+  EXPECT_FALSE(vocabContainsString(localVocabs[3], "c", index));
 
-  EXPECT_TRUE(vocabContainsString(localVocabs[4], "a"));
-  EXPECT_FALSE(vocabContainsString(localVocabs[4], "b"));
-  EXPECT_FALSE(vocabContainsString(localVocabs[4], "c"));
+  EXPECT_TRUE(vocabContainsString(localVocabs[4], "a", index));
+  EXPECT_FALSE(vocabContainsString(localVocabs[4], "b", index));
+  EXPECT_FALSE(vocabContainsString(localVocabs[4], "c", index));
 }
 
 // _____________________________________________________________________________
 TEST(AddCombinedRowToTable, verifyLocalVocabIsRetainedWhenNotMoving) {
+  auto* qec = ad_utility::testing::getQec();
+  const auto& index = qec->getIndex();
   auto outputTable = makeIdTableFromVector({});
   outputTable.setNumColumns(3);
   ad_utility::AddCombinedRowToIdTable adder{
@@ -384,9 +385,9 @@ TEST(AddCombinedRowToTable, verifyLocalVocabIsRetainedWhenNotMoving) {
       std::make_shared<ad_utility::CancellationHandle<>>(), 1};
 
   IdTableWithVocab input1{makeIdTableFromVector({{0, 1}}),
-                          createVocabWithSingleString("a")};
+                          createVocabWithSingleString("a", index)};
   IdTableWithVocab input2{makeIdTableFromVector({{0, 2}}),
-                          createVocabWithSingleString("b")};
+                          createVocabWithSingleString("b", index)};
 
   adder.setInput(input1, input2);
   adder.addRow(0, 0);
@@ -395,13 +396,15 @@ TEST(AddCombinedRowToTable, verifyLocalVocabIsRetainedWhenNotMoving) {
 
   LocalVocab localVocab = std::move(adder.localVocab());
 
-  EXPECT_TRUE(vocabContainsString(localVocab, "a"));
-  EXPECT_TRUE(vocabContainsString(localVocab, "b"));
+  EXPECT_TRUE(vocabContainsString(localVocab, "a", index));
+  EXPECT_TRUE(vocabContainsString(localVocab, "b", index));
   EXPECT_THAT(localVocab.getAllWordsForTesting(), ::testing::SizeIs(2));
 }
 
 // _____________________________________________________________________________
 TEST(AddCombinedRowToTable, localVocabIsOnlyClearedWhenLegal) {
+  auto* qec = ad_utility::testing::getQec();
+  const auto& index = qec->getIndex();
   auto outputTable = makeIdTableFromVector({});
   outputTable.setNumColumns(3);
   ad_utility::AddCombinedRowToIdTable adder{
@@ -409,16 +412,16 @@ TEST(AddCombinedRowToTable, localVocabIsOnlyClearedWhenLegal) {
       std::make_shared<ad_utility::CancellationHandle<>>(), 1};
 
   IdTableWithVocab input1{makeIdTableFromVector({{0, 1}}),
-                          createVocabWithSingleString("a")};
+                          createVocabWithSingleString("a", index)};
   IdTableWithVocab input2{makeIdTableFromVector({{0, 2}}),
-                          createVocabWithSingleString("b")};
+                          createVocabWithSingleString("b", index)};
 
   adder.setInput(input1, input2);
   adder.addRow(0, 0);
   IdTableWithVocab input3{makeIdTableFromVector({{3, 1}}),
-                          createVocabWithSingleString("c")};
+                          createVocabWithSingleString("c", index)};
   IdTableWithVocab input4{makeIdTableFromVector({{3, 2}}),
-                          createVocabWithSingleString("d")};
+                          createVocabWithSingleString("d", index)};
   // NOTE: This seemingly redundant call to `setInput` is important, as it tests
   // a previous bug: Each call to `setInput` implicitly also calls `flush` and
   // also possibly clears the local vocab if it is not used anymore. In this
@@ -429,10 +432,10 @@ TEST(AddCombinedRowToTable, localVocabIsOnlyClearedWhenLegal) {
   adder.addRow(0, 0);
   auto localVocab = adder.localVocab().clone();
 
-  EXPECT_TRUE(vocabContainsString(localVocab, "a"));
-  EXPECT_TRUE(vocabContainsString(localVocab, "b"));
-  EXPECT_TRUE(vocabContainsString(localVocab, "c"));
-  EXPECT_TRUE(vocabContainsString(localVocab, "d"));
+  EXPECT_TRUE(vocabContainsString(localVocab, "a", index));
+  EXPECT_TRUE(vocabContainsString(localVocab, "b", index));
+  EXPECT_TRUE(vocabContainsString(localVocab, "c", index));
+  EXPECT_TRUE(vocabContainsString(localVocab, "d", index));
   EXPECT_THAT(localVocab.getAllWordsForTesting(), ::testing::SizeIs(4));
 }
 

--- a/test/AggregateExpressionTest.cpp
+++ b/test/AggregateExpressionTest.cpp
@@ -167,13 +167,9 @@ TEST(AggregateExpression, min) {
   // from the local vocabulary ("alx" and "aalx").
   Id alpha = t.alpha;
   const auto& index = t.qec->getIndex();
-  LocalVocabEntry l1{
-      ad_utility::triple_component::LiteralOrIri::literalWithoutQuotes("alx"),
-      index};
+  LocalVocabEntry l1 = LocalVocabEntry::literalWithoutQuotes("alx", index);
   Id alx = Id::makeFromLocalVocabIndex(&l1);
-  LocalVocabEntry l2{
-      ad_utility::triple_component::LiteralOrIri::literalWithoutQuotes("aalx"),
-      index};
+  LocalVocabEntry l2 = LocalVocabEntry::literalWithoutQuotes("aalx", index);
   Id aalx = Id::makeFromLocalVocabIndex(&l2);
 
   // Test cases. Make sure that vocab entries and local vocab entries are
@@ -199,10 +195,8 @@ TEST(AggregateExpression, max) {
   // from the local vocabulary ("alx").
   Id alpha = t.alpha;
   Id beta = t.Beta;
-  const auto& index = t.qec->getIndex();
-  LocalVocabEntry l{
-      ad_utility::triple_component::LiteralOrIri::literalWithoutQuotes("alx"),
-      index};
+  LocalVocabEntry l =
+      LocalVocabEntry::literalWithoutQuotes("alx", t.qec->getIndex());
   Id alx = Id::makeFromLocalVocabIndex(&l);
 
   // Test cases. Make sure that vocab entries and local vocab entries are

--- a/test/AggregateExpressionTest.cpp
+++ b/test/AggregateExpressionTest.cpp
@@ -52,7 +52,7 @@ auto testAggregate = [](std::vector<T> inputAsVector, U expectedResult,
   input.reserve(inputAsVector.size());
   for (auto& value : inputAsVector) {
     input.push_back(sparqlExpression::detail::promoteToLocalVocabEntry(
-        std::move(value), t.context._qec.getIndex()));
+        std::move(value), t.context._qec.getLocalVocabContext()));
   }
   auto d = std::make_unique<SingleUseExpression>(input.clone());
   t.context._endIndex = input.size();
@@ -61,7 +61,7 @@ auto testAggregate = [](std::vector<T> inputAsVector, U expectedResult,
   auto res = std::get<sparqlExpression::detail::PromoteToLocalVocabEntry<U>>(
       resAsVariant);
   EXPECT_EQ(res, sparqlExpression::detail::promoteToLocalVocabEntry(
-                     expectedResult, t.context._qec.getIndex()));
+                     expectedResult, t.context._qec.getLocalVocabContext()));
 };
 
 // Same as `testAggregate` above, but the input is specified as a variable.
@@ -166,10 +166,12 @@ TEST(AggregateExpression, min) {
   // IDs of one word from the vocabulary ("alpha") and two words
   // from the local vocabulary ("alx" and "aalx").
   Id alpha = t.alpha;
-  const auto& index = t.qec->getIndex();
-  LocalVocabEntry l1 = LocalVocabEntry::literalWithoutQuotes("alx", index);
+  const auto& localVocabContext = t.qec->getLocalVocabContext();
+  LocalVocabEntry l1 =
+      LocalVocabEntry::literalWithoutQuotes("alx", localVocabContext);
   Id alx = Id::makeFromLocalVocabIndex(&l1);
-  LocalVocabEntry l2 = LocalVocabEntry::literalWithoutQuotes("aalx", index);
+  LocalVocabEntry l2 =
+      LocalVocabEntry::literalWithoutQuotes("aalx", localVocabContext);
   Id aalx = Id::makeFromLocalVocabIndex(&l2);
 
   // Test cases. Make sure that vocab entries and local vocab entries are
@@ -195,8 +197,8 @@ TEST(AggregateExpression, max) {
   // from the local vocabulary ("alx").
   Id alpha = t.alpha;
   Id beta = t.Beta;
-  LocalVocabEntry l =
-      LocalVocabEntry::literalWithoutQuotes("alx", t.qec->getIndex());
+  LocalVocabEntry l = LocalVocabEntry::literalWithoutQuotes(
+      "alx", t.qec->getLocalVocabContext());
   Id alx = Id::makeFromLocalVocabIndex(&l);
 
   // Test cases. Make sure that vocab entries and local vocab entries are

--- a/test/AggregateExpressionTest.cpp
+++ b/test/AggregateExpressionTest.cpp
@@ -166,7 +166,7 @@ TEST(AggregateExpression, min) {
   // IDs of one word from the vocabulary ("alpha") and two words
   // from the local vocabulary ("alx" and "aalx").
   Id alpha = t.alpha;
-  const auto& index = t.qec->getIndex().getImpl();
+  const auto& index = t.qec->getIndex();
   LocalVocabEntry l1{
       ad_utility::triple_component::LiteralOrIri::literalWithoutQuotes("alx"),
       index};
@@ -199,7 +199,7 @@ TEST(AggregateExpression, max) {
   // from the local vocabulary ("alx").
   Id alpha = t.alpha;
   Id beta = t.Beta;
-  const auto& index = t.qec->getIndex().getImpl();
+  const auto& index = t.qec->getIndex();
   LocalVocabEntry l{
       ad_utility::triple_component::LiteralOrIri::literalWithoutQuotes("alx"),
       index};

--- a/test/AggregateExpressionTest.cpp
+++ b/test/AggregateExpressionTest.cpp
@@ -31,8 +31,11 @@ auto V = VocabId;
 auto U = Id::makeUndefined();
 auto D = DoubleId;
 auto lit = [](auto s) {
-  return IdOrLocalVocabEntry(
-      ad_utility::triple_component::LiteralOrIri(tripleComponentLiteral(s)));
+  return IdOrLocalVocabEntry(LocalVocabEntry{
+      ad_utility::triple_component::LiteralOrIri(tripleComponentLiteral(s)),
+      getQec(sparqlExpression::TestContext::turtleInput)
+          ->getIndex()
+          .getImpl()});
 };
 static const Id NaN = D(std::numeric_limits<double>::quiet_NaN());
 }  // namespace
@@ -161,11 +164,14 @@ TEST(AggregateExpression, min) {
   // IDs of one word from the vocabulary ("alpha") and two words
   // from the local vocabulary ("alx" and "aalx").
   Id alpha = t.alpha;
-  LocalVocabEntry l1 =
-      ad_utility::triple_component::LiteralOrIri::literalWithoutQuotes("alx");
+  const auto& index = t.qec->getIndex().getImpl();
+  LocalVocabEntry l1{
+      ad_utility::triple_component::LiteralOrIri::literalWithoutQuotes("alx"),
+      index};
   Id alx = Id::makeFromLocalVocabIndex(&l1);
-  LocalVocabEntry l2 =
-      ad_utility::triple_component::LiteralOrIri::literalWithoutQuotes("aalx");
+  LocalVocabEntry l2{
+      ad_utility::triple_component::LiteralOrIri::literalWithoutQuotes("aalx"),
+      index};
   Id aalx = Id::makeFromLocalVocabIndex(&l2);
 
   // Test cases. Make sure that vocab entries and local vocab entries are
@@ -191,8 +197,10 @@ TEST(AggregateExpression, max) {
   // from the local vocabulary ("alx").
   Id alpha = t.alpha;
   Id beta = t.Beta;
-  LocalVocabEntry l =
-      ad_utility::triple_component::LiteralOrIri::literalWithoutQuotes("alx");
+  const auto& index = t.qec->getIndex().getImpl();
+  LocalVocabEntry l{
+      ad_utility::triple_component::LiteralOrIri::literalWithoutQuotes("alx"),
+      index};
   Id alx = Id::makeFromLocalVocabIndex(&l);
 
   // Test cases. Make sure that vocab entries and local vocab entries are

--- a/test/AggregateExpressionTest.cpp
+++ b/test/AggregateExpressionTest.cpp
@@ -31,11 +31,8 @@ auto V = VocabId;
 auto U = Id::makeUndefined();
 auto D = DoubleId;
 auto lit = [](auto s) {
-  return IdOrLocalVocabEntry(LocalVocabEntry{
-      ad_utility::triple_component::LiteralOrIri(tripleComponentLiteral(s)),
-      getQec(sparqlExpression::TestContext::turtleInput)
-          ->getIndex()
-          .getImpl()});
+  return IdOrLiteralOrIri{
+      ad_utility::triple_component::LiteralOrIri(tripleComponentLiteral(s))};
 };
 static const Id NaN = D(std::numeric_limits<double>::quiet_NaN());
 }  // namespace
@@ -49,15 +46,22 @@ auto testAggregate = [](std::vector<T> inputAsVector, U expectedResult,
                         bool distinct = false,
                         source_location l = AD_CURRENT_SOURCE_LOC()) {
   auto trace = generateLocationTrace(l);
-  VectorWithMemoryLimit<T> input(inputAsVector.begin(), inputAsVector.end(),
-                                 makeAllocator());
-  auto d = std::make_unique<SingleUseExpression>(input.clone());
   auto t = TestContext{};
+  VectorWithMemoryLimit<sparqlExpression::detail::PromoteToLocalVocabEntry<T>>
+      input(makeAllocator());
+  input.reserve(inputAsVector.size());
+  for (auto& value : inputAsVector) {
+    input.push_back(sparqlExpression::detail::promoteToLocalVocabEntry(
+        std::move(value), t.context._qec.getIndex()));
+  }
+  auto d = std::make_unique<SingleUseExpression>(input.clone());
   t.context._endIndex = input.size();
   AggregateExpressionT m{distinct, std::move(d)};
   auto resAsVariant = m.evaluate(&t.context);
-  auto res = std::get<U>(resAsVariant);
-  EXPECT_EQ(res, expectedResult);
+  auto res = std::get<sparqlExpression::detail::PromoteToLocalVocabEntry<U>>(
+      resAsVariant);
+  EXPECT_EQ(res, sparqlExpression::detail::promoteToLocalVocabEntry(
+                     expectedResult, t.context._qec.getIndex()));
 };
 
 // Same as `testAggregate` above, but the input is specified as a variable.
@@ -86,8 +90,7 @@ TEST(AggregateExpression, count) {
   testCountId({I(3), NaN, NaN}, I(2), true);
   testCountId({}, I(0));
 
-  auto testCountString =
-      testAggregate<CountExpression, IdOrLocalVocabEntry, Id>;
+  auto testCountString = testAggregate<CountExpression, IdOrLiteralOrIri, Id>;
   testCountString({lit("alpha"), lit("äpfel"), lit(""), lit("unfug")}, I(4));
 }
 
@@ -109,10 +112,10 @@ TEST(AggregateExpression, sum) {
   testSumId({I(3), NaN}, NaN);
   testSumId({}, I(0));
 
-  auto testMaxString = testAggregate<MaxExpression, IdOrLocalVocabEntry>;
+  auto testMaxString = testAggregate<MaxExpression, IdOrLiteralOrIri>;
   testMaxString({lit("alpha"), lit("äpfel"), lit("Beta"), lit("unfug")},
                 lit("unfug"));
-  auto testSumString = testAggregate<SumExpression, IdOrLocalVocabEntry, Id>;
+  auto testSumString = testAggregate<SumExpression, IdOrLiteralOrIri, Id>;
   testSumString({lit("alpha"), lit("äpfel"), lit("Beta"), lit("unfug")}, U);
 }
 
@@ -125,7 +128,7 @@ TEST(AggregateExpression, avg) {
   testAvgId({I(3), NaN}, NaN);
   testAvgId({}, I(0));
 
-  auto testAvgString = testAggregate<AvgExpression, IdOrLocalVocabEntry, Id>;
+  auto testAvgString = testAggregate<AvgExpression, IdOrLiteralOrIri, Id>;
   testAvgString({lit("alpha"), lit("äpfel"), lit("Beta"), lit("unfug")}, U);
 }
 
@@ -152,8 +155,7 @@ TEST(StdevExpression, avg) {
   testStdevId({D(500)}, D(0));
   testStdevId({D(500), D(500), D(500)}, D(0));
 
-  auto testStdevString =
-      testAggregate<StdevExpression, IdOrLocalVocabEntry, Id>;
+  auto testStdevString = testAggregate<StdevExpression, IdOrLiteralOrIri, Id>;
   testStdevString({lit("alpha"), lit("äpfel"), lit("Beta"), lit("unfug")}, U);
 }
 
@@ -184,7 +186,7 @@ TEST(AggregateExpression, min) {
   testMinId({I(3), alpha, alx, (I(-1)), U}, U);
   testMinId({alpha, alx, aalx}, aalx);
   testMinId({}, U);
-  auto testMinString = testAggregate<MinExpression, IdOrLocalVocabEntry>;
+  auto testMinString = testAggregate<MinExpression, IdOrLiteralOrIri>;
   testMinString({lit("alpha"), lit("äpfel"), lit("Beta"), lit("unfug")},
                 lit("alpha"));
 }

--- a/test/CompressedRelationsTest.cpp
+++ b/test/CompressedRelationsTest.cpp
@@ -1118,9 +1118,10 @@ TEST(CompressedRelationReader, ensureDummyBlockWith6ColumnsDoesntCauseIssues) {
       "ensureDummyBlockWith6ColumnsDoesntCauseIssues",
       std::move(testIndexConfig));
   index.deltaTriplesManager().modify<void>(
-      [cancellationHandle](DeltaTriples& deltaTriples) {
+      [cancellationHandle, &index](DeltaTriples& deltaTriples) {
         LocalVocabEntry entry{
-            ad_utility::triple_component::Iri::fromIriref("<zzz>")};
+            ad_utility::triple_component::Iri::fromIriref("<zzz>"),
+            index.getImpl()};
         Id id = Id::makeFromLocalVocabIndex(&entry);
         // Insert a single triple at the end.
         deltaTriples.insertTriples(cancellationHandle,

--- a/test/CompressedRelationsTest.cpp
+++ b/test/CompressedRelationsTest.cpp
@@ -1120,7 +1120,7 @@ TEST(CompressedRelationReader, ensureDummyBlockWith6ColumnsDoesntCauseIssues) {
   index.deltaTriplesManager().modify<void>(
       [cancellationHandle, &index](DeltaTriples& deltaTriples) {
         LocalVocabEntry entry =
-            LocalVocabEntry::fromStringRepresentation("<zzz>", index);
+            LocalVocabEntry::fromIriref("<zzz>", index);
         Id id = Id::makeFromLocalVocabIndex(&entry);
         // Insert a single triple at the end.
         deltaTriples.insertTriples(cancellationHandle,

--- a/test/CompressedRelationsTest.cpp
+++ b/test/CompressedRelationsTest.cpp
@@ -1120,8 +1120,7 @@ TEST(CompressedRelationReader, ensureDummyBlockWith6ColumnsDoesntCauseIssues) {
   index.deltaTriplesManager().modify<void>(
       [cancellationHandle, &index](DeltaTriples& deltaTriples) {
         LocalVocabEntry entry{
-            ad_utility::triple_component::Iri::fromIriref("<zzz>"),
-            index.getImpl()};
+            ad_utility::triple_component::Iri::fromIriref("<zzz>"), index};
         Id id = Id::makeFromLocalVocabIndex(&entry);
         // Insert a single triple at the end.
         deltaTriples.insertTriples(cancellationHandle,

--- a/test/CompressedRelationsTest.cpp
+++ b/test/CompressedRelationsTest.cpp
@@ -1119,8 +1119,7 @@ TEST(CompressedRelationReader, ensureDummyBlockWith6ColumnsDoesntCauseIssues) {
       std::move(testIndexConfig));
   index.deltaTriplesManager().modify<void>(
       [cancellationHandle, &index](DeltaTriples& deltaTriples) {
-        LocalVocabEntry entry =
-            LocalVocabEntry::fromIriref("<zzz>", index);
+        LocalVocabEntry entry = LocalVocabEntry::fromIriref("<zzz>", index);
         Id id = Id::makeFromLocalVocabIndex(&entry);
         // Insert a single triple at the end.
         deltaTriples.insertTriples(cancellationHandle,

--- a/test/CompressedRelationsTest.cpp
+++ b/test/CompressedRelationsTest.cpp
@@ -1119,8 +1119,8 @@ TEST(CompressedRelationReader, ensureDummyBlockWith6ColumnsDoesntCauseIssues) {
       std::move(testIndexConfig));
   index.deltaTriplesManager().modify<void>(
       [cancellationHandle, &index](DeltaTriples& deltaTriples) {
-        LocalVocabEntry entry{
-            ad_utility::triple_component::Iri::fromIriref("<zzz>"), index};
+        LocalVocabEntry entry =
+            LocalVocabEntry::fromStringRepresentation("<zzz>", index);
         Id id = Id::makeFromLocalVocabIndex(&entry);
         // Insert a single triple at the end.
         deltaTriples.insertTriples(cancellationHandle,

--- a/test/DeltaTriplesTest.cpp
+++ b/test/DeltaTriplesTest.cpp
@@ -908,7 +908,7 @@ TEST_F(DeltaTriplesTest, storeAndRestoreData) {
                          deltaTriples.localVocab()
                              .getIndexOrNullopt(
                                  LocalVocabEntry::fromStringRepresentation(
-                                     "<test>", index))
+                                     "<test>", localVocabContext))
                              .value()),
                      Id::makeFromBool(true)}})));
     std::vector<IdTriple<>> deletedTriples;
@@ -922,7 +922,7 @@ TEST_F(DeltaTriplesTest, storeAndRestoreData) {
                          deltaTriples.localVocab()
                              .getIndexOrNullopt(
                                  LocalVocabEntry::fromStringRepresentation(
-                                     "<other>", index))
+                                     "<other>", localVocabContext))
                              .value()),
                      Id::makeFromBool(false)}})));
   }

--- a/test/DeltaTriplesTest.cpp
+++ b/test/DeltaTriplesTest.cpp
@@ -854,7 +854,7 @@ TEST_F(DeltaTriplesTest, storeAndRestoreData) {
   // Make sure no file like this exists
   std::filesystem::remove(tmpFile);
   absl::Cleanup cleanup{[&tmpFile]() { std::filesystem::remove(tmpFile); }};
-  const auto& index = testQec->getIndex().getImpl();
+  const auto& index = testQec->getIndex();
   {
     DeltaTriples deltaTriples{testQec->getIndex()};
     deltaTriples.setPersists(tmpFile);
@@ -934,7 +934,7 @@ TEST_F(DeltaTriplesTest, storeAndRestoreData) {
 TEST_F(DeltaTriplesTest, copyLocalVocab) {
   using namespace ::testing;
   using ad_utility::triple_component::LiteralOrIri;
-  const auto& index = testQec->getIndex().getImpl();
+  const auto& index = testQec->getIndex();
   DeltaTriples deltaTriples{testQec->getIndex()};
 
   std::string iri1 = "<test>";
@@ -976,7 +976,7 @@ TEST_F(DeltaTriplesTest, copyLocalVocab) {
 TEST_F(DeltaTriplesTest, getCurrentLocatedTriplesSharedStateWithVocab) {
   using namespace ::testing;
   using ad_utility::triple_component::LiteralOrIri;
-  const auto& index = testQec->getIndex().getImpl();
+  const auto& index = testQec->getIndex();
   DeltaTriplesManager deltaTriplesManager(index);
 
   std::string iri1 = "<test>";

--- a/test/DeltaTriplesTest.cpp
+++ b/test/DeltaTriplesTest.cpp
@@ -854,7 +854,7 @@ TEST_F(DeltaTriplesTest, storeAndRestoreData) {
   // Make sure no file like this exists
   std::filesystem::remove(tmpFile);
   absl::Cleanup cleanup{[&tmpFile]() { std::filesystem::remove(tmpFile); }};
-  const auto& index = testQec->getIndex();
+  const auto& localVocabContext = testQec->getLocalVocabContext();
   {
     DeltaTriples deltaTriples{testQec->getIndex()};
     deltaTriples.setPersists(tmpFile);
@@ -863,13 +863,13 @@ TEST_F(DeltaTriplesTest, storeAndRestoreData) {
     auto cancellationHandle =
         std::make_shared<ad_utility::CancellationHandle<>>();
     LocalVocabEntry entry1 =
-        LocalVocabEntry::fromStringRepresentation("<test>", index);
+        LocalVocabEntry::fromStringRepresentation("<test>", localVocabContext);
     deltaTriples.insertTriples(
         cancellationHandle,
         {IdTriple<>{{Id::makeFromInt(1), Id::makeFromLocalVocabIndex(&entry1),
                      Id::makeFromBool(true)}}});
     LocalVocabEntry entry2 =
-        LocalVocabEntry::fromStringRepresentation("<other>", index);
+        LocalVocabEntry::fromStringRepresentation("<other>", localVocabContext);
     deltaTriples.deleteTriples(
         cancellationHandle,
         {IdTriple<>{{Id::makeFromInt(2), Id::makeFromLocalVocabIndex(&entry2),
@@ -932,7 +932,7 @@ TEST_F(DeltaTriplesTest, storeAndRestoreData) {
 TEST_F(DeltaTriplesTest, copyLocalVocab) {
   using namespace ::testing;
   using ad_utility::triple_component::LiteralOrIri;
-  const auto& index = testQec->getIndex();
+  const auto& localVocabContext = testQec->getLocalVocabContext();
   DeltaTriples deltaTriples{testQec->getIndex()};
 
   std::string iri1 = "<test>";
@@ -941,13 +941,13 @@ TEST_F(DeltaTriplesTest, copyLocalVocab) {
   auto cancellationHandle =
       std::make_shared<ad_utility::CancellationHandle<>>();
   LocalVocabEntry entry1 =
-      LocalVocabEntry::fromStringRepresentation(iri1, index);
+      LocalVocabEntry::fromStringRepresentation(iri1, localVocabContext);
   deltaTriples.insertTriples(
       cancellationHandle,
       {IdTriple<>{{Id::makeFromInt(1), Id::makeFromLocalVocabIndex(&entry1),
                    Id::makeFromBlankNodeIndex(BlankNodeIndex::make(1337))}}});
   LocalVocabEntry entry2 =
-      LocalVocabEntry::fromStringRepresentation(iri2, index);
+      LocalVocabEntry::fromStringRepresentation(iri2, localVocabContext);
   deltaTriples.deleteTriples(
       cancellationHandle,
       {IdTriple<>{{Id::makeFromInt(2), Id::makeFromLocalVocabIndex(&entry2),

--- a/test/DeltaTriplesTest.cpp
+++ b/test/DeltaTriplesTest.cpp
@@ -862,14 +862,14 @@ TEST_F(DeltaTriplesTest, storeAndRestoreData) {
 
     auto cancellationHandle =
         std::make_shared<ad_utility::CancellationHandle<>>();
-    LocalVocabEntry entry1{LiteralOrIri::fromStringRepresentation("<test>"),
-                           index};
+    LocalVocabEntry entry1 =
+        LocalVocabEntry::fromStringRepresentation("<test>", index);
     deltaTriples.insertTriples(
         cancellationHandle,
         {IdTriple<>{{Id::makeFromInt(1), Id::makeFromLocalVocabIndex(&entry1),
                      Id::makeFromBool(true)}}});
-    LocalVocabEntry entry2{LiteralOrIri::fromStringRepresentation("<other>"),
-                           index};
+    LocalVocabEntry entry2 =
+        LocalVocabEntry::fromStringRepresentation("<other>", index);
     deltaTriples.deleteTriples(
         cancellationHandle,
         {IdTriple<>{{Id::makeFromInt(2), Id::makeFromLocalVocabIndex(&entry2),
@@ -901,32 +901,30 @@ TEST_F(DeltaTriplesTest, storeAndRestoreData) {
     ql::ranges::copy(
         deltaTriples.triplesToHandlesNormal_.triplesInserted_ | ql::views::keys,
         std::back_inserter(insertedTriples));
-    EXPECT_THAT(
-        insertedTriples,
-        ::testing::ElementsAre(::testing::Eq(IdTriple<>{
-            {Id::makeFromInt(1),
-             Id::makeFromLocalVocabIndex(
-                 deltaTriples.localVocab()
-                     .getIndexOrNullopt(LocalVocabEntry{
-                         LiteralOrIri::fromStringRepresentation("<test>"),
-                         index})
-                     .value()),
-             Id::makeFromBool(true)}})));
+    EXPECT_THAT(insertedTriples,
+                ::testing::ElementsAre(::testing::Eq(IdTriple<>{
+                    {Id::makeFromInt(1),
+                     Id::makeFromLocalVocabIndex(
+                         deltaTriples.localVocab()
+                             .getIndexOrNullopt(
+                                 LocalVocabEntry::fromStringRepresentation(
+                                     "<test>", index))
+                             .value()),
+                     Id::makeFromBool(true)}})));
     std::vector<IdTriple<>> deletedTriples;
     ql::ranges::copy(
         deltaTriples.triplesToHandlesNormal_.triplesDeleted_ | ql::views::keys,
         std::back_inserter(deletedTriples));
-    EXPECT_THAT(
-        deletedTriples,
-        ::testing::ElementsAre(::testing::Eq(IdTriple<>{
-            {Id::makeFromInt(2),
-             Id::makeFromLocalVocabIndex(
-                 deltaTriples.localVocab()
-                     .getIndexOrNullopt(LocalVocabEntry{
-                         LiteralOrIri::fromStringRepresentation("<other>"),
-                         index})
-                     .value()),
-             Id::makeFromBool(false)}})));
+    EXPECT_THAT(deletedTriples,
+                ::testing::ElementsAre(::testing::Eq(IdTriple<>{
+                    {Id::makeFromInt(2),
+                     Id::makeFromLocalVocabIndex(
+                         deltaTriples.localVocab()
+                             .getIndexOrNullopt(
+                                 LocalVocabEntry::fromStringRepresentation(
+                                     "<other>", index))
+                             .value()),
+                     Id::makeFromBool(false)}})));
   }
 }
 
@@ -942,12 +940,14 @@ TEST_F(DeltaTriplesTest, copyLocalVocab) {
 
   auto cancellationHandle =
       std::make_shared<ad_utility::CancellationHandle<>>();
-  LocalVocabEntry entry1{LiteralOrIri::fromStringRepresentation(iri1), index};
+  LocalVocabEntry entry1 =
+      LocalVocabEntry::fromStringRepresentation(iri1, index);
   deltaTriples.insertTriples(
       cancellationHandle,
       {IdTriple<>{{Id::makeFromInt(1), Id::makeFromLocalVocabIndex(&entry1),
                    Id::makeFromBlankNodeIndex(BlankNodeIndex::make(1337))}}});
-  LocalVocabEntry entry2{LiteralOrIri::fromStringRepresentation(iri2), index};
+  LocalVocabEntry entry2 =
+      LocalVocabEntry::fromStringRepresentation(iri2, index);
   deltaTriples.deleteTriples(
       cancellationHandle,
       {IdTriple<>{{Id::makeFromInt(2), Id::makeFromLocalVocabIndex(&entry2),
@@ -980,11 +980,13 @@ TEST_F(DeltaTriplesTest, getCurrentLocatedTriplesSharedStateWithVocab) {
   DeltaTriplesManager deltaTriplesManager(index);
 
   std::string iri1 = "<test>";
-  LocalVocabEntry entry1{LiteralOrIri::fromStringRepresentation(iri1), index};
+  LocalVocabEntry entry1 =
+      LocalVocabEntry::fromStringRepresentation(iri1, index);
   IdTriple<> triple1{{Id::makeFromInt(1), Id::makeFromLocalVocabIndex(&entry1),
                       Id::makeFromBool(true)}};
   std::string iri2 = "<other>";
-  LocalVocabEntry entry2{LiteralOrIri::fromStringRepresentation(iri2), index};
+  LocalVocabEntry entry2 =
+      LocalVocabEntry::fromStringRepresentation(iri2, index);
   IdTriple<> triple2{{Id::makeFromInt(2), Id::makeFromLocalVocabIndex(&entry2),
                       Id::makeFromBool(false)}};
   deltaTriplesManager.modify<void>(

--- a/test/DeltaTriplesTest.cpp
+++ b/test/DeltaTriplesTest.cpp
@@ -854,6 +854,7 @@ TEST_F(DeltaTriplesTest, storeAndRestoreData) {
   // Make sure no file like this exists
   std::filesystem::remove(tmpFile);
   absl::Cleanup cleanup{[&tmpFile]() { std::filesystem::remove(tmpFile); }};
+  const auto& index = testQec->getIndex().getImpl();
   {
     DeltaTriples deltaTriples{testQec->getIndex()};
     deltaTriples.setPersists(tmpFile);
@@ -861,12 +862,14 @@ TEST_F(DeltaTriplesTest, storeAndRestoreData) {
 
     auto cancellationHandle =
         std::make_shared<ad_utility::CancellationHandle<>>();
-    LocalVocabEntry entry1{LiteralOrIri::fromStringRepresentation("<test>")};
+    LocalVocabEntry entry1{LiteralOrIri::fromStringRepresentation("<test>"),
+                           index};
     deltaTriples.insertTriples(
         cancellationHandle,
         {IdTriple<>{{Id::makeFromInt(1), Id::makeFromLocalVocabIndex(&entry1),
                      Id::makeFromBool(true)}}});
-    LocalVocabEntry entry2{LiteralOrIri::fromStringRepresentation("<other>")};
+    LocalVocabEntry entry2{LiteralOrIri::fromStringRepresentation("<other>"),
+                           index};
     deltaTriples.deleteTriples(
         cancellationHandle,
         {IdTriple<>{{Id::makeFromInt(2), Id::makeFromLocalVocabIndex(&entry2),
@@ -905,7 +908,8 @@ TEST_F(DeltaTriplesTest, storeAndRestoreData) {
              Id::makeFromLocalVocabIndex(
                  deltaTriples.localVocab()
                      .getIndexOrNullopt(LocalVocabEntry{
-                         LiteralOrIri::fromStringRepresentation("<test>")})
+                         LiteralOrIri::fromStringRepresentation("<test>"),
+                         index})
                      .value()),
              Id::makeFromBool(true)}})));
     std::vector<IdTriple<>> deletedTriples;
@@ -919,7 +923,8 @@ TEST_F(DeltaTriplesTest, storeAndRestoreData) {
              Id::makeFromLocalVocabIndex(
                  deltaTriples.localVocab()
                      .getIndexOrNullopt(LocalVocabEntry{
-                         LiteralOrIri::fromStringRepresentation("<other>")})
+                         LiteralOrIri::fromStringRepresentation("<other>"),
+                         index})
                      .value()),
              Id::makeFromBool(false)}})));
   }
@@ -929,6 +934,7 @@ TEST_F(DeltaTriplesTest, storeAndRestoreData) {
 TEST_F(DeltaTriplesTest, copyLocalVocab) {
   using namespace ::testing;
   using ad_utility::triple_component::LiteralOrIri;
+  const auto& index = testQec->getIndex().getImpl();
   DeltaTriples deltaTriples{testQec->getIndex()};
 
   std::string iri1 = "<test>";
@@ -936,12 +942,12 @@ TEST_F(DeltaTriplesTest, copyLocalVocab) {
 
   auto cancellationHandle =
       std::make_shared<ad_utility::CancellationHandle<>>();
-  LocalVocabEntry entry1{LiteralOrIri::fromStringRepresentation(iri1)};
+  LocalVocabEntry entry1{LiteralOrIri::fromStringRepresentation(iri1), index};
   deltaTriples.insertTriples(
       cancellationHandle,
       {IdTriple<>{{Id::makeFromInt(1), Id::makeFromLocalVocabIndex(&entry1),
                    Id::makeFromBlankNodeIndex(BlankNodeIndex::make(1337))}}});
-  LocalVocabEntry entry2{LiteralOrIri::fromStringRepresentation(iri2)};
+  LocalVocabEntry entry2{LiteralOrIri::fromStringRepresentation(iri2), index};
   deltaTriples.deleteTriples(
       cancellationHandle,
       {IdTriple<>{{Id::makeFromInt(2), Id::makeFromLocalVocabIndex(&entry2),
@@ -970,14 +976,15 @@ TEST_F(DeltaTriplesTest, copyLocalVocab) {
 TEST_F(DeltaTriplesTest, getCurrentLocatedTriplesSharedStateWithVocab) {
   using namespace ::testing;
   using ad_utility::triple_component::LiteralOrIri;
-  DeltaTriplesManager deltaTriplesManager(testQec->getIndex().getImpl());
+  const auto& index = testQec->getIndex().getImpl();
+  DeltaTriplesManager deltaTriplesManager(index);
 
   std::string iri1 = "<test>";
-  LocalVocabEntry entry1{LiteralOrIri::fromStringRepresentation(iri1)};
+  LocalVocabEntry entry1{LiteralOrIri::fromStringRepresentation(iri1), index};
   IdTriple<> triple1{{Id::makeFromInt(1), Id::makeFromLocalVocabIndex(&entry1),
                       Id::makeFromBool(true)}};
   std::string iri2 = "<other>";
-  LocalVocabEntry entry2{LiteralOrIri::fromStringRepresentation(iri2)};
+  LocalVocabEntry entry2{LiteralOrIri::fromStringRepresentation(iri2), index};
   IdTriple<> triple2{{Id::makeFromInt(2), Id::makeFromLocalVocabIndex(&entry2),
                       Id::makeFromBool(false)}};
   deltaTriplesManager.modify<void>(

--- a/test/ExecuteUpdateTest.cpp
+++ b/test/ExecuteUpdateTest.cpp
@@ -302,7 +302,7 @@ TEST(ExecuteUpdate, computeGraphUpdateQuads) {
     auto LVI = [&localVocab, qec](std::string_view iri) {
       return Id::makeFromLocalVocabIndex(
           localVocab.getIndexAndAddIfNotContained(
-              LocalVocabEntry::fromIriref(iri, qec->getIndex())));
+              LocalVocabEntry::fromIriref(iri, qec->getLocalVocabContext())));
     };
 
     expectComputeGraphUpdateQuads(

--- a/test/ExecuteUpdateTest.cpp
+++ b/test/ExecuteUpdateTest.cpp
@@ -299,10 +299,10 @@ TEST(ExecuteUpdate, computeGraphUpdateQuads) {
     defaultGraphId = Id(std::string{DEFAULT_GRAPH_IRI});
 
     LocalVocab localVocab;
-    auto LVI = [&localVocab, qec](const std::string& iri) {
+    auto LVI = [&localVocab, qec](std::string_view iri) {
       return Id::makeFromLocalVocabIndex(
           localVocab.getIndexAndAddIfNotContained(
-              LocalVocabEntry::fromStringRepresentation(iri, qec->getIndex())));
+              LocalVocabEntry::fromIriref(iri, qec->getIndex())));
     };
 
     expectComputeGraphUpdateQuads(

--- a/test/ExecuteUpdateTest.cpp
+++ b/test/ExecuteUpdateTest.cpp
@@ -299,10 +299,11 @@ TEST(ExecuteUpdate, computeGraphUpdateQuads) {
     defaultGraphId = Id(std::string{DEFAULT_GRAPH_IRI});
 
     LocalVocab localVocab;
-    auto LVI = [&localVocab](const std::string& iri) {
+    const auto& indexImpl = qec->getIndex().getImpl();
+    auto LVI = [&localVocab, &indexImpl](const std::string& iri) {
       return Id::makeFromLocalVocabIndex(
           localVocab.getIndexAndAddIfNotContained(LocalVocabEntry(
-              ad_utility::triple_component::Iri::fromIriref(iri))));
+              ad_utility::triple_component::Iri::fromIriref(iri), indexImpl)));
     };
 
     expectComputeGraphUpdateQuads(
@@ -435,8 +436,10 @@ TEST(ExecuteUpdate, transformTriplesTemplate) {
   };
   // Matchers
   using MatcherType = Matcher<const ExecuteUpdate::IdOrVariableIndex&>;
-  auto TripleComponentMatcher = [](const ::LocalVocab& localVocab,
-                                   TripleComponentT component) -> MatcherType {
+  const auto& outerIndexImpl = index.getImpl();
+  auto TripleComponentMatcher = [&outerIndexImpl](
+                                    const ::LocalVocab& localVocab,
+                                    TripleComponentT component) -> MatcherType {
     return std::visit(
         ad_utility::OverloadCallOperator{
             [](const ::Id& id) -> MatcherType {
@@ -445,10 +448,11 @@ TEST(ExecuteUpdate, transformTriplesTemplate) {
             [](const ColumnIndex& index) -> MatcherType {
               return VariantWith<ColumnIndex>(Eq(index));
             },
-            [&localVocab](
+            [&localVocab, &outerIndexImpl](
                 const ad_utility::triple_component::LiteralOrIri& literalOrIri)
                 -> MatcherType {
-              const auto lviOpt = localVocab.getIndexOrNullopt(literalOrIri);
+              const auto lviOpt = localVocab.getIndexOrNullopt(
+                  LocalVocabEntry{literalOrIri, outerIndexImpl});
               if (!lviOpt) {
                 return AlwaysFalse(
                     absl::StrCat(literalOrIri.toStringRepresentation(),

--- a/test/ExecuteUpdateTest.cpp
+++ b/test/ExecuteUpdateTest.cpp
@@ -299,11 +299,11 @@ TEST(ExecuteUpdate, computeGraphUpdateQuads) {
     defaultGraphId = Id(std::string{DEFAULT_GRAPH_IRI});
 
     LocalVocab localVocab;
-    const auto& indexImpl = qec->getIndex().getImpl();
-    auto LVI = [&localVocab, &indexImpl](const std::string& iri) {
+    auto LVI = [&localVocab, qec](const std::string& iri) {
       return Id::makeFromLocalVocabIndex(
           localVocab.getIndexAndAddIfNotContained(LocalVocabEntry(
-              ad_utility::triple_component::Iri::fromIriref(iri), indexImpl)));
+              ad_utility::triple_component::Iri::fromIriref(iri),
+              qec->getIndex())));
     };
 
     expectComputeGraphUpdateQuads(
@@ -436,8 +436,7 @@ TEST(ExecuteUpdate, transformTriplesTemplate) {
   };
   // Matchers
   using MatcherType = Matcher<const ExecuteUpdate::IdOrVariableIndex&>;
-  const auto& outerIndexImpl = index.getImpl();
-  auto TripleComponentMatcher = [&outerIndexImpl](
+  auto TripleComponentMatcher = [&index](
                                     const ::LocalVocab& localVocab,
                                     TripleComponentT component) -> MatcherType {
     return std::visit(
@@ -448,11 +447,11 @@ TEST(ExecuteUpdate, transformTriplesTemplate) {
             [](const ColumnIndex& index) -> MatcherType {
               return VariantWith<ColumnIndex>(Eq(index));
             },
-            [&localVocab, &outerIndexImpl](
+            [&localVocab, &index](
                 const ad_utility::triple_component::LiteralOrIri& literalOrIri)
                 -> MatcherType {
               const auto lviOpt = localVocab.getIndexOrNullopt(
-                  LocalVocabEntry{literalOrIri, outerIndexImpl});
+                  LocalVocabEntry{literalOrIri, index});
               if (!lviOpt) {
                 return AlwaysFalse(
                     absl::StrCat(literalOrIri.toStringRepresentation(),

--- a/test/ExecuteUpdateTest.cpp
+++ b/test/ExecuteUpdateTest.cpp
@@ -301,9 +301,8 @@ TEST(ExecuteUpdate, computeGraphUpdateQuads) {
     LocalVocab localVocab;
     auto LVI = [&localVocab, qec](const std::string& iri) {
       return Id::makeFromLocalVocabIndex(
-          localVocab.getIndexAndAddIfNotContained(LocalVocabEntry(
-              ad_utility::triple_component::Iri::fromIriref(iri),
-              qec->getIndex())));
+          localVocab.getIndexAndAddIfNotContained(
+              LocalVocabEntry::fromStringRepresentation(iri, qec->getIndex())));
     };
 
     expectComputeGraphUpdateQuads(

--- a/test/ExternalValuesTest.cpp
+++ b/test/ExternalValuesTest.cpp
@@ -88,7 +88,7 @@ TEST(ExternalValues, computeResult) {
   auto I = ad_utility::testing::IntId;
   auto l = result->localVocab().getIndexOrNullopt(
       LocalVocabEntry{ad_utility::triple_component::LiteralOrIri::iriref("<y>"),
-                      testQec->getIndex().getImpl()});
+                      testQec->getIndex()});
   ASSERT_TRUE(l.has_value());
   auto U = Id::makeUndefined();
   ASSERT_EQ(table,

--- a/test/ExternalValuesTest.cpp
+++ b/test/ExternalValuesTest.cpp
@@ -87,7 +87,8 @@ TEST(ExternalValues, computeResult) {
   Id x = ad_utility::testing::makeGetId(testQec->getIndex())("<x>");
   auto I = ad_utility::testing::IntId;
   auto l = result->localVocab().getIndexOrNullopt(
-      ad_utility::triple_component::LiteralOrIri::iriref("<y>"));
+      LocalVocabEntry{ad_utility::triple_component::LiteralOrIri::iriref("<y>"),
+                      testQec->getIndex().getImpl()});
   ASSERT_TRUE(l.has_value());
   auto U = Id::makeUndefined();
   ASSERT_EQ(table,

--- a/test/ExternalValuesTest.cpp
+++ b/test/ExternalValuesTest.cpp
@@ -87,8 +87,7 @@ TEST(ExternalValues, computeResult) {
   Id x = ad_utility::testing::makeGetId(testQec->getIndex())("<x>");
   auto I = ad_utility::testing::IntId;
   auto l = result->localVocab().getIndexOrNullopt(
-      LocalVocabEntry{ad_utility::triple_component::LiteralOrIri::iriref("<y>"),
-                      testQec->getIndex()});
+      LocalVocabEntry::fromStringRepresentation("<y>", testQec->getIndex()));
   ASSERT_TRUE(l.has_value());
   auto U = Id::makeUndefined();
   ASSERT_EQ(table,

--- a/test/ExternalValuesTest.cpp
+++ b/test/ExternalValuesTest.cpp
@@ -87,7 +87,7 @@ TEST(ExternalValues, computeResult) {
   Id x = ad_utility::testing::makeGetId(testQec->getIndex())("<x>");
   auto I = ad_utility::testing::IntId;
   auto l = result->localVocab().getIndexOrNullopt(
-      LocalVocabEntry::fromStringRepresentation("<y>", testQec->getIndex()));
+      LocalVocabEntry::fromIriref("<y>", testQec->getIndex()));
   ASSERT_TRUE(l.has_value());
   auto U = Id::makeUndefined();
   ASSERT_EQ(table,

--- a/test/ExternalValuesTest.cpp
+++ b/test/ExternalValuesTest.cpp
@@ -87,7 +87,7 @@ TEST(ExternalValues, computeResult) {
   Id x = ad_utility::testing::makeGetId(testQec->getIndex())("<x>");
   auto I = ad_utility::testing::IntId;
   auto l = result->localVocab().getIndexOrNullopt(
-      LocalVocabEntry::fromIriref("<y>", testQec->getIndex()));
+      LocalVocabEntry::fromIriref("<y>", testQec->getLocalVocabContext()));
   ASSERT_TRUE(l.has_value());
   auto U = Id::makeUndefined();
   ASSERT_EQ(table,

--- a/test/GetPrefilterExpressionFromSparqlExpressionTest.cpp
+++ b/test/GetPrefilterExpressionFromSparqlExpressionTest.cpp
@@ -93,7 +93,8 @@ auto makeEvalAndEqualityCheck(const LocalVocabContext& context) {
 TEST(GetPrefilterExpressionFromSparqlExpression,
      testGetPrefilterExpressionDefault) {
   auto* qec = ad_utility::testing::getQec();
-  auto evalAndEqualityCheck = makeEvalAndEqualityCheck(qec->getIndex());
+  auto evalAndEqualityCheck =
+      makeEvalAndEqualityCheck(qec->getLocalVocabContext());
   evalAndEqualityCheck(
       makeUnaryMinusExpression(makeOptLiteralSparqlExpr(IntId(0))));
   evalAndEqualityCheck(
@@ -117,7 +118,8 @@ TEST(GetPrefilterExpressionFromSparqlExpression,
 TEST(GetPrefilterExpressionFromSparqlExpression,
      getPrefilterExpressionFromSparqlRelational) {
   auto* qec = ad_utility::testing::getQec();
-  auto evalAndEqualityCheck = makeEvalAndEqualityCheck(qec->getIndex());
+  auto evalAndEqualityCheck =
+      makeEvalAndEqualityCheck(qec->getLocalVocabContext());
   const TestDates dt{};
   const Variable var = Variable{"?x"};
   // ?x == BooldId(true) (RelationalExpression Sparql)
@@ -177,7 +179,8 @@ TEST(GetPrefilterExpressionFromSparqlExpression,
 TEST(GetPrefilterExpressionFromSparqlExpression,
      getPrefilterExpressionsToComplexSparqlExpressions) {
   auto* qec = ad_utility::testing::getQec();
-  auto evalAndEqualityCheck = makeEvalAndEqualityCheck(qec->getIndex());
+  auto evalAndEqualityCheck =
+      makeEvalAndEqualityCheck(qec->getLocalVocabContext());
   const Variable varX = Variable{"?x"};
   const Variable varY = Variable{"?y"};
   const Variable varZ = Variable{"?z"};
@@ -190,11 +193,12 @@ TEST(GetPrefilterExpressionFromSparqlExpression,
   // ?x >= "berlin" AND ?x != "hamburg"
   // expected prefilter pairs:
   // {<((>= "berlin") AND (!= "hamburg")), ?x>}
-  evalAndEqualityCheck(andSprqlExpr(geSprql(varX, L("\"berlin\"")),
-                                    neqSprql(varX, L("\"hamburg\""))),
-                       pr(andExpr(ge(LVE("\"berlin\"", qec->getIndex())),
-                                  neq(LVE("\"hamburg\"", qec->getIndex()))),
-                          varX));
+  evalAndEqualityCheck(
+      andSprqlExpr(geSprql(varX, L("\"berlin\"")),
+                   neqSprql(varX, L("\"hamburg\""))),
+      pr(andExpr(ge(LVE("\"berlin\"", qec->getLocalVocabContext())),
+                 neq(LVE("\"hamburg\"", qec->getLocalVocabContext()))),
+         varX));
   // ?z > <iri> AND ?y > 0 AND ?x < 30.00
   // expected prefilter pairs
   // {<(< 30.00), ?x>, <(> 0), ?y>, <(> <iri>), ?z>}
@@ -202,7 +206,7 @@ TEST(GetPrefilterExpressionFromSparqlExpression,
                                                  gtSprql(varY, IntId(0))),
                                     ltSprql(varX, DoubleId(30.00))),
                        pr(lt(DoubleId(30.00)), varX), pr(gt(IntId(0)), varY),
-                       pr(gt(LVE("<iri>", qec->getIndex())), varZ));
+                       pr(gt(LVE("<iri>", qec->getLocalVocabContext())), varZ));
 
   // ?x == VocabId(10) AND ?y >= VocabId(10)
   // expected prefilter pairs:
@@ -247,7 +251,7 @@ TEST(GetPrefilterExpressionFromSparqlExpression,
                                            leSprql(varY, L("\"world\""))),
                                leSprql(varX, VocabId(10)))),
       pr(notExpr(le(VocabId(10))), varX),
-      pr(notExpr(le(LVE("\"world\"", qec->getIndex()))), varY),
+      pr(notExpr(le(LVE("\"world\"", qec->getLocalVocabContext()))), varY),
       pr(notExpr(le(VocabId(10))), varZ));
   // ?x >= 10 AND ?y >= 10
   // expected prefilter pairs:
@@ -289,8 +293,8 @@ TEST(GetPrefilterExpressionFromSparqlExpression,
                                             eqSprql(varX, I("<iri/ref10>")))),
                    notSprqlExpr(orSprqlExpr(geSprql(varZ, DoubleId(10)),
                                             eqSprql(varY, BoolId(false))))),
-      pr(notExpr(orExpr(eq(LVE("<iri/ref1>", qec->getIndex())),
-                        eq(LVE("<iri/ref10>", qec->getIndex())))),
+      pr(notExpr(orExpr(eq(LVE("<iri/ref1>", qec->getLocalVocabContext())),
+                        eq(LVE("<iri/ref10>", qec->getLocalVocabContext())))),
          varX),
       pr(notExpr(eq(BoolId(false))), varY),
       pr(notExpr(ge(DoubleId(10))), varZ));
@@ -325,8 +329,9 @@ TEST(GetPrefilterExpressionFromSparqlExpression,
       notSprqlExpr(orSprqlExpr(
           andSprqlExpr(geSprql(varY, VocabId(0)), leSprql(varY, L("\"W\""))),
           notSprqlExpr(geSprql(varX, I("<iri>"))))),
-      pr(notExpr(notExpr(ge(LVE("<iri>", qec->getIndex())))), varX),
-      pr(notExpr(andExpr(ge(VocabId(0)), le(LVE("\"W\"", qec->getIndex())))),
+      pr(notExpr(notExpr(ge(LVE("<iri>", qec->getLocalVocabContext())))), varX),
+      pr(notExpr(andExpr(ge(VocabId(0)),
+                         le(LVE("\"W\"", qec->getLocalVocabContext())))),
          varY));
   // ?z >= 10 AND ?z <= 100 AND ?x >= 10 AND ?x != 50 AND !(?y <= 10) AND
   // !(?city <= VocabId(1000) OR ?city == VocabId(1005))
@@ -384,7 +389,8 @@ TEST(GetPrefilterExpressionFromSparqlExpression,
 TEST(GetPrefilterExpressionFromSparqlExpression,
      getEmptyPrefilterFromSparqlRelational) {
   auto* qec = ad_utility::testing::getQec();
-  auto evalAndEqualityCheck = makeEvalAndEqualityCheck(qec->getIndex());
+  auto evalAndEqualityCheck =
+      makeEvalAndEqualityCheck(qec->getLocalVocabContext());
   const Variable var = Variable{"?x"};
   const Iri iri = I("<Iri>");
   const Literal lit = L("\"lit\"");
@@ -405,7 +411,8 @@ TEST(GetPrefilterExpressionFromSparqlExpression,
 TEST(GetPrefilterExpressionFromSparqlExpression,
      getEmptyPrefilterForMoreComplexSparqlExpressions) {
   auto* qec = ad_utility::testing::getQec();
-  auto evalAndEqualityCheck = makeEvalAndEqualityCheck(qec->getIndex());
+  auto evalAndEqualityCheck =
+      makeEvalAndEqualityCheck(qec->getLocalVocabContext());
   const Variable varX = Variable{"?x"};
   const Variable varY = Variable{"?y"};
   const Variable varZ = Variable{"?z"};
@@ -492,7 +499,8 @@ TEST(GetPrefilterExpressionFromSparqlExpression,
 TEST(GetPrefilterExpressionFromSparqlExpression,
      testGetPrefixRegexExpressionFromSparqlExprssions) {
   auto* qec = ad_utility::testing::getQec();
-  auto evalAndEqualityCheck = makeEvalAndEqualityCheck(qec->getIndex());
+  auto evalAndEqualityCheck =
+      makeEvalAndEqualityCheck(qec->getLocalVocabContext());
   const auto varX = Variable{"?x"};
   const auto varY = Variable{"?y"};
   evalAndEqualityCheck(strStartsSprql(varX, L("\"de\"")),
@@ -524,7 +532,8 @@ TEST(GetPrefilterExpressionFromSparqlExpression,
 TEST(GetPrefilterExpressionFromSparqlExpression,
      getPrefilterExprForIsDatatypeExpr) {
   auto* qec = ad_utility::testing::getQec();
-  auto evalAndEqualityCheck = makeEvalAndEqualityCheck(qec->getIndex());
+  auto evalAndEqualityCheck =
+      makeEvalAndEqualityCheck(qec->getLocalVocabContext());
   const auto varX = Variable{"?x"};
   // The following cases should return a <Prefilter, Variable> pair.
   evalAndEqualityCheck(isIriSprql(varX), pr(isIri(), varX));
@@ -544,7 +553,8 @@ TEST(GetPrefilterExpressionFromSparqlExpression,
 //______________________________________________________________________________
 TEST(GetPrefilterExpressionFromSparqlExpression, getPrefilterExprIsIn) {
   auto* qec = ad_utility::testing::getQec();
-  auto evalAndEqualityCheck = makeEvalAndEqualityCheck(qec->getIndex());
+  auto evalAndEqualityCheck =
+      makeEvalAndEqualityCheck(qec->getLocalVocabContext());
   const auto varX = Variable{"?x"};
   evalAndEqualityCheck(inSprqlExpr(varX, IntId(0), VocabId(10)),
                        pr(inExpr({IntId(0), VocabId(10)}), varX));
@@ -560,7 +570,8 @@ TEST(GetPrefilterExpressionFromSparqlExpression, getPrefilterExprIsIn) {
 // Test PrefilterExpression creation for the expression: `YEAR(?var) op INT`.
 TEST(GetPrefilterExpressionFromSparqlExpression, tryGetPrefilterExprForDate) {
   auto* qec = ad_utility::testing::getQec();
-  auto evalAndEqualityCheck = makeEvalAndEqualityCheck(qec->getIndex());
+  auto evalAndEqualityCheck =
+      makeEvalAndEqualityCheck(qec->getLocalVocabContext());
   const auto var = Variable{"?x"};
   // Retrieve the `ValueId` for the pre-filter reference `Date` created with the
   // provided `expectedYear` value.
@@ -598,7 +609,7 @@ TEST(GetPrefilterExpressionFromSparqlExpression, tryGetPrefilterExprForDate) {
   auto assertThrowsError = [qec](std::unique_ptr<SparqlExpression> expr,
                                  const std::string& runtimeErrorMessage) {
     AD_EXPECT_THROW_WITH_MESSAGE(
-        expr->getPrefilterExpressionForMetadata(qec->getIndex()),
+        expr->getPrefilterExpressionForMetadata(qec->getLocalVocabContext()),
         ::testing::Eq(runtimeErrorMessage));
   };
   // Test SparqlExpressions for which we expect that the reference value-type

--- a/test/GetPrefilterExpressionFromSparqlExpressionTest.cpp
+++ b/test/GetPrefilterExpressionFromSparqlExpressionTest.cpp
@@ -69,10 +69,10 @@ const auto equalityCheckPrefilterVectors =
 // `<PrefilterExpression, Variable>` pairs in the correct order. If no
 // `<PrefilterExpression, Variable>` pair is provided, the expected value for
 // the `SparqlExpression` is an empty vector.
-auto makeEvalAndEqualityCheck(const IndexImpl& index) {
-  return [&index](std::unique_ptr<SparqlExpression> sparqlExpr,
-                  std::convertible_to<
-                      PrefilterExprVariablePair> auto&&... prefilterArgs) {
+auto makeEvalAndEqualityCheck(const LocalVocabContext& context) {
+  return [&context](std::unique_ptr<SparqlExpression> sparqlExpr,
+                    std::convertible_to<
+                        PrefilterExprVariablePair> auto&&... prefilterArgs) {
     std::vector<PrefilterExprVariablePair> prefilterVarPair = {};
     if constexpr (sizeof...(prefilterArgs) > 0) {
       (prefilterVarPair.emplace_back(
@@ -80,7 +80,7 @@ auto makeEvalAndEqualityCheck(const IndexImpl& index) {
        ...);
     }
     equalityCheckPrefilterVectors(
-        sparqlExpr->getPrefilterExpressionForMetadata(index),
+        sparqlExpr->getPrefilterExpressionForMetadata(context),
         std::move(prefilterVarPair));
   };
 }

--- a/test/GetPrefilterExpressionFromSparqlExpressionTest.cpp
+++ b/test/GetPrefilterExpressionFromSparqlExpressionTest.cpp
@@ -68,6 +68,11 @@ const auto equalityCheckPrefilterVectors =
 // `<PrefilterExpression, Variable>` pairs in the correct order. If no
 // `<PrefilterExpression, Variable>` pair is provided, the expected value for
 // the `SparqlExpression` is an empty vector.
+const auto& testIdx() {
+  static const auto& impl = ad_utility::testing::getQec()->getIndex().getImpl();
+  return impl;
+}
+
 const auto evalAndEqualityCheck =
     [](std::unique_ptr<SparqlExpression> sparqlExpr,
        std::convertible_to<PrefilterExprVariablePair> auto&&... prefilterArgs) {
@@ -78,7 +83,7 @@ const auto evalAndEqualityCheck =
          ...);
       }
       equalityCheckPrefilterVectors(
-          sparqlExpr->getPrefilterExpressionForMetadata(),
+          sparqlExpr->getPrefilterExpressionForMetadata(testIdx()),
           std::move(prefilterVarPair));
     };
 
@@ -181,10 +186,11 @@ TEST(GetPrefilterExpressionFromSparqlExpression,
   // ?x >= "berlin" AND ?x != "hamburg"
   // expected prefilter pairs:
   // {<((>= "berlin") AND (!= "hamburg")), ?x>}
-  evalAndEqualityCheck(
-      andSprqlExpr(geSprql(varX, L("\"berlin\"")),
-                   neqSprql(varX, L("\"hamburg\""))),
-      pr(andExpr(ge(LVE("\"berlin\"")), neq(LVE("\"hamburg\""))), varX));
+  evalAndEqualityCheck(andSprqlExpr(geSprql(varX, L("\"berlin\"")),
+                                    neqSprql(varX, L("\"hamburg\""))),
+                       pr(andExpr(ge(LVE("\"berlin\"", testIdx())),
+                                  neq(LVE("\"hamburg\"", testIdx()))),
+                          varX));
   // ?z > <iri> AND ?y > 0 AND ?x < 30.00
   // expected prefilter pairs
   // {<(< 30.00), ?x>, <(> 0), ?y>, <(> <iri>), ?z>}
@@ -192,7 +198,7 @@ TEST(GetPrefilterExpressionFromSparqlExpression,
                                                  gtSprql(varY, IntId(0))),
                                     ltSprql(varX, DoubleId(30.00))),
                        pr(lt(DoubleId(30.00)), varX), pr(gt(IntId(0)), varY),
-                       pr(gt(LVE("<iri>")), varZ));
+                       pr(gt(LVE("<iri>", testIdx())), varZ));
 
   // ?x == VocabId(10) AND ?y >= VocabId(10)
   // expected prefilter pairs:
@@ -237,7 +243,7 @@ TEST(GetPrefilterExpressionFromSparqlExpression,
                                            leSprql(varY, L("\"world\""))),
                                leSprql(varX, VocabId(10)))),
       pr(notExpr(le(VocabId(10))), varX),
-      pr(notExpr(le(LVE("\"world\""))), varY),
+      pr(notExpr(le(LVE("\"world\"", testIdx()))), varY),
       pr(notExpr(le(VocabId(10))), varZ));
   // ?x >= 10 AND ?y >= 10
   // expected prefilter pairs:
@@ -279,7 +285,9 @@ TEST(GetPrefilterExpressionFromSparqlExpression,
                                             eqSprql(varX, I("<iri/ref10>")))),
                    notSprqlExpr(orSprqlExpr(geSprql(varZ, DoubleId(10)),
                                             eqSprql(varY, BoolId(false))))),
-      pr(notExpr(orExpr(eq(LVE("<iri/ref1>")), eq(LVE("<iri/ref10>")))), varX),
+      pr(notExpr(orExpr(eq(LVE("<iri/ref1>", testIdx())),
+                        eq(LVE("<iri/ref10>", testIdx())))),
+         varX),
       pr(notExpr(eq(BoolId(false))), varY),
       pr(notExpr(ge(DoubleId(10))), varZ));
   // !(!(?x >= 10 AND ?y >= 10)) OR !(!(?x <= 0 AND ?y <= 0))
@@ -313,8 +321,8 @@ TEST(GetPrefilterExpressionFromSparqlExpression,
       notSprqlExpr(orSprqlExpr(
           andSprqlExpr(geSprql(varY, VocabId(0)), leSprql(varY, L("\"W\""))),
           notSprqlExpr(geSprql(varX, I("<iri>"))))),
-      pr(notExpr(notExpr(ge(LVE("<iri>")))), varX),
-      pr(notExpr(andExpr(ge(VocabId(0)), le(LVE("\"W\"")))), varY));
+      pr(notExpr(notExpr(ge(LVE("<iri>", testIdx())))), varX),
+      pr(notExpr(andExpr(ge(VocabId(0)), le(LVE("\"W\"", testIdx())))), varY));
   // ?z >= 10 AND ?z <= 100 AND ?x >= 10 AND ?x != 50 AND !(?y <= 10) AND
   // !(?city <= VocabId(1000) OR ?city == VocabId(1005))
   // expected prefilter pairs:
@@ -572,8 +580,9 @@ TEST(GetPrefilterExpressionFromSparqlExpression, tryGetPrefilterExprForDate) {
 
   auto assertThrowsError = [](std::unique_ptr<SparqlExpression> expr,
                               const std::string& runtimeErrorMessage) {
-    AD_EXPECT_THROW_WITH_MESSAGE(expr->getPrefilterExpressionForMetadata(),
-                                 ::testing::Eq(runtimeErrorMessage));
+    AD_EXPECT_THROW_WITH_MESSAGE(
+        expr->getPrefilterExpressionForMetadata(testIdx()),
+        ::testing::Eq(runtimeErrorMessage));
   };
   // Test SparqlExpressions for which we expect that the reference value-type
   // error is thrown.

--- a/test/GetPrefilterExpressionFromSparqlExpressionTest.cpp
+++ b/test/GetPrefilterExpressionFromSparqlExpressionTest.cpp
@@ -63,29 +63,27 @@ const auto equalityCheckPrefilterVectors =
 };
 
 //______________________________________________________________________________
-// `evalAndEqualityCheck` evaluates the provided `SparqlExpression` and checks
-// in the following if the resulting vector contains the same
+// `makeEvalAndEqualityCheck` creates a lambda that evaluates the provided
+// `SparqlExpression` and checks in the following if the resulting vector
+// contains the same
 // `<PrefilterExpression, Variable>` pairs in the correct order. If no
 // `<PrefilterExpression, Variable>` pair is provided, the expected value for
 // the `SparqlExpression` is an empty vector.
-const auto& testIdx() {
-  static const auto& impl = ad_utility::testing::getQec()->getIndex().getImpl();
-  return impl;
+auto makeEvalAndEqualityCheck(const IndexImpl& index) {
+  return [&index](std::unique_ptr<SparqlExpression> sparqlExpr,
+                  std::convertible_to<
+                      PrefilterExprVariablePair> auto&&... prefilterArgs) {
+    std::vector<PrefilterExprVariablePair> prefilterVarPair = {};
+    if constexpr (sizeof...(prefilterArgs) > 0) {
+      (prefilterVarPair.emplace_back(
+           std::forward<PrefilterExprVariablePair>(prefilterArgs)),
+       ...);
+    }
+    equalityCheckPrefilterVectors(
+        sparqlExpr->getPrefilterExpressionForMetadata(index),
+        std::move(prefilterVarPair));
+  };
 }
-
-const auto evalAndEqualityCheck =
-    [](std::unique_ptr<SparqlExpression> sparqlExpr,
-       std::convertible_to<PrefilterExprVariablePair> auto&&... prefilterArgs) {
-      std::vector<PrefilterExprVariablePair> prefilterVarPair = {};
-      if constexpr (sizeof...(prefilterArgs) > 0) {
-        (prefilterVarPair.emplace_back(
-             std::forward<PrefilterExprVariablePair>(prefilterArgs)),
-         ...);
-      }
-      equalityCheckPrefilterVectors(
-          sparqlExpr->getPrefilterExpressionForMetadata(testIdx()),
-          std::move(prefilterVarPair));
-    };
 
 }  // namespace
 
@@ -94,6 +92,8 @@ const auto evalAndEqualityCheck =
 // getPrefilterExpressionForMetadata.
 TEST(GetPrefilterExpressionFromSparqlExpression,
      testGetPrefilterExpressionDefault) {
+  auto* qec = ad_utility::testing::getQec();
+  auto evalAndEqualityCheck = makeEvalAndEqualityCheck(qec->getIndex());
   evalAndEqualityCheck(
       makeUnaryMinusExpression(makeOptLiteralSparqlExpr(IntId(0))));
   evalAndEqualityCheck(
@@ -116,6 +116,8 @@ TEST(GetPrefilterExpressionFromSparqlExpression,
 // PrefilterExpression.
 TEST(GetPrefilterExpressionFromSparqlExpression,
      getPrefilterExpressionFromSparqlRelational) {
+  auto* qec = ad_utility::testing::getQec();
+  auto evalAndEqualityCheck = makeEvalAndEqualityCheck(qec->getIndex());
   const TestDates dt{};
   const Variable var = Variable{"?x"};
   // ?x == BooldId(true) (RelationalExpression Sparql)
@@ -174,6 +176,8 @@ TEST(GetPrefilterExpressionFromSparqlExpression,
 // corresponding PrefilterExpression values.
 TEST(GetPrefilterExpressionFromSparqlExpression,
      getPrefilterExpressionsToComplexSparqlExpressions) {
+  auto* qec = ad_utility::testing::getQec();
+  auto evalAndEqualityCheck = makeEvalAndEqualityCheck(qec->getIndex());
   const Variable varX = Variable{"?x"};
   const Variable varY = Variable{"?y"};
   const Variable varZ = Variable{"?z"};
@@ -188,8 +192,8 @@ TEST(GetPrefilterExpressionFromSparqlExpression,
   // {<((>= "berlin") AND (!= "hamburg")), ?x>}
   evalAndEqualityCheck(andSprqlExpr(geSprql(varX, L("\"berlin\"")),
                                     neqSprql(varX, L("\"hamburg\""))),
-                       pr(andExpr(ge(LVE("\"berlin\"", testIdx())),
-                                  neq(LVE("\"hamburg\"", testIdx()))),
+                       pr(andExpr(ge(LVE("\"berlin\"", qec->getIndex())),
+                                  neq(LVE("\"hamburg\"", qec->getIndex()))),
                           varX));
   // ?z > <iri> AND ?y > 0 AND ?x < 30.00
   // expected prefilter pairs
@@ -198,7 +202,7 @@ TEST(GetPrefilterExpressionFromSparqlExpression,
                                                  gtSprql(varY, IntId(0))),
                                     ltSprql(varX, DoubleId(30.00))),
                        pr(lt(DoubleId(30.00)), varX), pr(gt(IntId(0)), varY),
-                       pr(gt(LVE("<iri>", testIdx())), varZ));
+                       pr(gt(LVE("<iri>", qec->getIndex())), varZ));
 
   // ?x == VocabId(10) AND ?y >= VocabId(10)
   // expected prefilter pairs:
@@ -243,7 +247,7 @@ TEST(GetPrefilterExpressionFromSparqlExpression,
                                            leSprql(varY, L("\"world\""))),
                                leSprql(varX, VocabId(10)))),
       pr(notExpr(le(VocabId(10))), varX),
-      pr(notExpr(le(LVE("\"world\"", testIdx()))), varY),
+      pr(notExpr(le(LVE("\"world\"", qec->getIndex()))), varY),
       pr(notExpr(le(VocabId(10))), varZ));
   // ?x >= 10 AND ?y >= 10
   // expected prefilter pairs:
@@ -285,8 +289,8 @@ TEST(GetPrefilterExpressionFromSparqlExpression,
                                             eqSprql(varX, I("<iri/ref10>")))),
                    notSprqlExpr(orSprqlExpr(geSprql(varZ, DoubleId(10)),
                                             eqSprql(varY, BoolId(false))))),
-      pr(notExpr(orExpr(eq(LVE("<iri/ref1>", testIdx())),
-                        eq(LVE("<iri/ref10>", testIdx())))),
+      pr(notExpr(orExpr(eq(LVE("<iri/ref1>", qec->getIndex())),
+                        eq(LVE("<iri/ref10>", qec->getIndex())))),
          varX),
       pr(notExpr(eq(BoolId(false))), varY),
       pr(notExpr(ge(DoubleId(10))), varZ));
@@ -321,8 +325,9 @@ TEST(GetPrefilterExpressionFromSparqlExpression,
       notSprqlExpr(orSprqlExpr(
           andSprqlExpr(geSprql(varY, VocabId(0)), leSprql(varY, L("\"W\""))),
           notSprqlExpr(geSprql(varX, I("<iri>"))))),
-      pr(notExpr(notExpr(ge(LVE("<iri>", testIdx())))), varX),
-      pr(notExpr(andExpr(ge(VocabId(0)), le(LVE("\"W\"", testIdx())))), varY));
+      pr(notExpr(notExpr(ge(LVE("<iri>", qec->getIndex())))), varX),
+      pr(notExpr(andExpr(ge(VocabId(0)), le(LVE("\"W\"", qec->getIndex())))),
+         varY));
   // ?z >= 10 AND ?z <= 100 AND ?x >= 10 AND ?x != 50 AND !(?y <= 10) AND
   // !(?city <= VocabId(1000) OR ?city == VocabId(1005))
   // expected prefilter pairs:
@@ -378,6 +383,8 @@ TEST(GetPrefilterExpressionFromSparqlExpression,
 // For this test we expect that no PrefilterExpression is available.
 TEST(GetPrefilterExpressionFromSparqlExpression,
      getEmptyPrefilterFromSparqlRelational) {
+  auto* qec = ad_utility::testing::getQec();
+  auto evalAndEqualityCheck = makeEvalAndEqualityCheck(qec->getIndex());
   const Variable var = Variable{"?x"};
   const Iri iri = I("<Iri>");
   const Literal lit = L("\"lit\"");
@@ -397,6 +404,8 @@ TEST(GetPrefilterExpressionFromSparqlExpression,
 // empty PrefilterExpression vector.
 TEST(GetPrefilterExpressionFromSparqlExpression,
      getEmptyPrefilterForMoreComplexSparqlExpressions) {
+  auto* qec = ad_utility::testing::getQec();
+  auto evalAndEqualityCheck = makeEvalAndEqualityCheck(qec->getIndex());
   const Variable varX = Variable{"?x"};
   const Variable varY = Variable{"?y"};
   const Variable varZ = Variable{"?z"};
@@ -482,6 +491,8 @@ TEST(GetPrefilterExpressionFromSparqlExpression,
 //______________________________________________________________________________
 TEST(GetPrefilterExpressionFromSparqlExpression,
      testGetPrefixRegexExpressionFromSparqlExprssions) {
+  auto* qec = ad_utility::testing::getQec();
+  auto evalAndEqualityCheck = makeEvalAndEqualityCheck(qec->getIndex());
   const auto varX = Variable{"?x"};
   const auto varY = Variable{"?y"};
   evalAndEqualityCheck(strStartsSprql(varX, L("\"de\"")),
@@ -512,6 +523,8 @@ TEST(GetPrefilterExpressionFromSparqlExpression,
 //______________________________________________________________________________
 TEST(GetPrefilterExpressionFromSparqlExpression,
      getPrefilterExprForIsDatatypeExpr) {
+  auto* qec = ad_utility::testing::getQec();
+  auto evalAndEqualityCheck = makeEvalAndEqualityCheck(qec->getIndex());
   const auto varX = Variable{"?x"};
   // The following cases should return a <Prefilter, Variable> pair.
   evalAndEqualityCheck(isIriSprql(varX), pr(isIri(), varX));
@@ -530,6 +543,8 @@ TEST(GetPrefilterExpressionFromSparqlExpression,
 // Test PrefilterExpression creation for SparqlExpression InExpression
 //______________________________________________________________________________
 TEST(GetPrefilterExpressionFromSparqlExpression, getPrefilterExprIsIn) {
+  auto* qec = ad_utility::testing::getQec();
+  auto evalAndEqualityCheck = makeEvalAndEqualityCheck(qec->getIndex());
   const auto varX = Variable{"?x"};
   evalAndEqualityCheck(inSprqlExpr(varX, IntId(0), VocabId(10)),
                        pr(inExpr({IntId(0), VocabId(10)}), varX));
@@ -544,6 +559,8 @@ TEST(GetPrefilterExpressionFromSparqlExpression, getPrefilterExprIsIn) {
 //______________________________________________________________________________
 // Test PrefilterExpression creation for the expression: `YEAR(?var) op INT`.
 TEST(GetPrefilterExpressionFromSparqlExpression, tryGetPrefilterExprForDate) {
+  auto* qec = ad_utility::testing::getQec();
+  auto evalAndEqualityCheck = makeEvalAndEqualityCheck(qec->getIndex());
   const auto var = Variable{"?x"};
   // Retrieve the `ValueId` for the pre-filter reference `Date` created with the
   // provided `expectedYear` value.
@@ -578,10 +595,10 @@ TEST(GetPrefilterExpressionFromSparqlExpression, tryGetPrefilterExprForDate) {
   evalAndEqualityCheck(
       eqSprql(yearSprqlExpr(ltSprql(var, IntId(2025))), IntId(2025)));
 
-  auto assertThrowsError = [](std::unique_ptr<SparqlExpression> expr,
-                              const std::string& runtimeErrorMessage) {
+  auto assertThrowsError = [qec](std::unique_ptr<SparqlExpression> expr,
+                                 const std::string& runtimeErrorMessage) {
     AD_EXPECT_THROW_WITH_MESSAGE(
-        expr->getPrefilterExpressionForMetadata(testIdx()),
+        expr->getPrefilterExpressionForMetadata(qec->getIndex()),
         ::testing::Eq(runtimeErrorMessage));
   };
   // Test SparqlExpressions for which we expect that the reference value-type

--- a/test/GroupByTest.cpp
+++ b/test/GroupByTest.cpp
@@ -197,13 +197,12 @@ TEST_F(GroupByTest, doGroupBy) {
   constexpr auto iriref = [](const std::string& s) {
     return ad_utility::triple_component::LiteralOrIri::iriref(s);
   };
-  const auto& indexImpl = _index.getImpl();
   localVocab->getIndexAndAddIfNotContained(
-      LocalVocabEntry{iriref("<local1>"), indexImpl});
+      LocalVocabEntry{iriref("<local1>"), _index});
   localVocab->getIndexAndAddIfNotContained(
-      LocalVocabEntry{iriref("<local2>"), indexImpl});
+      LocalVocabEntry{iriref("<local2>"), _index});
   localVocab->getIndexAndAddIfNotContained(
-      LocalVocabEntry{iriref("<local3>"), indexImpl});
+      LocalVocabEntry{iriref("<local3>"), _index});
 
   IdTable inputData(6, makeAllocator());
   // The input data types are KB, KB, VERBATIM, TEXT, FLOAT, STRING.
@@ -1483,7 +1482,7 @@ TEST_F(GroupByOptimizations, hashMapOptimizationGroupConcatIndex) {
   const auto& table = result->idTable();
 
   auto getId = makeGetId(qec->getIndex());
-  const auto& index = qec->getIndex().getImpl();
+  const auto& index = qec->getIndex();
   auto getLocalVocabId = [&result, &index](const std::string& word) {
     return getLocalVocabIdFromVocab(result->localVocab(), word, index);
   };
@@ -1526,10 +1525,10 @@ TEST_F(GroupByOptimizations, hashMapOptimizationGroupConcatLocalVocab) {
   const auto& table = result->idTable();
 
   auto getId = makeGetId(qec->getIndex());
-  const auto& index = qec->getIndex().getImpl();
   auto d = DoubleId;
-  auto getLocalVocabId = [&result, &index](const std::string& word) {
-    return getLocalVocabIdFromVocab(result->localVocab(), word, index);
+  auto getLocalVocabId = [&result, qec](const std::string& word) {
+    return getLocalVocabIdFromVocab(result->localVocab(), word,
+                                    qec->getIndex());
   };
 
   auto expected = makeIdTableFromVector(
@@ -2535,19 +2534,18 @@ TEST(GroupBy, strOnGroupedVariableWorks) {
     resultPairs.push_back(std::move(pair));
   }
 
-  const auto& indexImpl = qec->getIndex().getImpl();
   ASSERT_EQ(resultPairs.size(), 2);
   const auto& [idTable0, localVocab0] = resultPairs.at(0);
   EXPECT_EQ(localVocab0.size(), 2);
   auto localVocabIndex0 = localVocab0.getIndexOrNullopt(LocalVocabEntry{
       ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
           "\"1\""),
-      indexImpl});
+      qec->getIndex()});
   ASSERT_TRUE(localVocabIndex0.has_value());
   auto localVocabIndex1 = localVocab0.getIndexOrNullopt(LocalVocabEntry{
       ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
           "\"2\""),
-      indexImpl});
+      qec->getIndex()});
   ASSERT_TRUE(localVocabIndex1.has_value());
   EXPECT_EQ(idTable0,
             makeIdTableFromVector(
@@ -2561,7 +2559,7 @@ TEST(GroupBy, strOnGroupedVariableWorks) {
   auto localVocabIndex2 = localVocab1.getIndexOrNullopt(LocalVocabEntry{
       ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
           "\"3\""),
-      indexImpl});
+      qec->getIndex()});
   ASSERT_TRUE(localVocabIndex2.has_value());
   EXPECT_EQ(idTable1,
             makeIdTableFromVector(
@@ -2579,9 +2577,8 @@ TEST(GroupBy, localVocabIsProperlyCloned) {
   idTables.push_back(makeIdTableFromVector({{2}}, &Id::makeFromInt));
   // This issue occurs only when the vocab contains any actual values.
   LocalVocab dummy{};
-  const auto& indexImpl = qec->getIndex().getImpl();
-  dummy.getIndexAndAddIfNotContained(
-      LocalVocabEntry{Lit::fromStringRepresentation("\"dummy\""), indexImpl});
+  dummy.getIndexAndAddIfNotContained(LocalVocabEntry{
+      Lit::fromStringRepresentation("\"dummy\""), qec->getIndex()});
   auto subtree = makeExecutionTree<ValuesForTesting>(
       qec, std::move(idTables),
       std::vector<std::optional<Variable>>{Variable{"?x"}}, true,
@@ -2614,7 +2611,7 @@ TEST(GroupBy, localVocabIsProperlyCloned) {
                     .getIndexOrNullopt(LocalVocabEntry{
                         Lit::fromStringRepresentation(
                             std::string{expected.at(expectedIndex)}),
-                        indexImpl})
+                        qec->getIndex()})
                     .has_value());
     expectedIndex++;
   }
@@ -2833,11 +2830,9 @@ TEST_P(GroupByLazyFixture, nestedAggregateFunctionsWork) {
   auto result = groupBy.computeResultOnlyForTesting(GetParam());
 
   // Acquire the local vocab index for a given string representation if present.
-  const auto& indexImpl2 = qec_->getIndex().getImpl();
-  auto makeEntry = [&indexImpl2](std::string string,
-                                 const LocalVocab& localVocab) {
+  auto makeEntry = [this](std::string string, const LocalVocab& localVocab) {
     return localVocab.getIndexOrNullopt(LocalVocabEntry{
-        L::fromStringRepresentation(std::move(string)), indexImpl2});
+        L::fromStringRepresentation(std::move(string)), qec_->getIndex()});
   };
 
   auto entryToId = [](std::optional<LocalVocabIndex> entry) {

--- a/test/GroupByTest.cpp
+++ b/test/GroupByTest.cpp
@@ -55,10 +55,11 @@ auto lit(std::string_view s) {
 
 // Helper function to get the local vocab ID for a given word.
 Id getLocalVocabIdFromVocab(const LocalVocab& localVocab,
-                            const std::string& word, const IndexImpl& index) {
+                            const std::string& word,
+                            const LocalVocabContext& context) {
   auto lit =
       ad_utility::triple_component::LiteralOrIri::literalWithoutQuotes(word);
-  auto value = localVocab.getIndexOrNullopt(LocalVocabEntry{lit, index});
+  auto value = localVocab.getIndexOrNullopt(LocalVocabEntry{lit, context});
   if (value.has_value()) {
     return ValueId::makeFromLocalVocabIndex(value.value());
   }

--- a/test/GroupByTest.cpp
+++ b/test/GroupByTest.cpp
@@ -1480,9 +1480,11 @@ TEST_F(GroupByOptimizations, hashMapOptimizationGroupConcatIndex) {
   const auto& table = result->idTable();
 
   auto getId = makeGetId(qec->getIndex());
-  const auto& index = qec->getIndex();
-  auto getLocalVocabId = [&result, &index](const std::string& word) {
-    return getLocalVocabIdFromVocab(result->localVocab(), word, index);
+  const auto& localVocabContext = qec->getLocalVocabContext();
+  auto getLocalVocabId = [&result,
+                          &localVocabContext](const std::string& word) {
+    return getLocalVocabIdFromVocab(result->localVocab(), word,
+                                    localVocabContext);
   };
 
   auto expected = makeIdTableFromVector(
@@ -1526,7 +1528,7 @@ TEST_F(GroupByOptimizations, hashMapOptimizationGroupConcatLocalVocab) {
   auto d = DoubleId;
   auto getLocalVocabId = [&result, qec](const std::string& word) {
     return getLocalVocabIdFromVocab(result->localVocab(), word,
-                                    qec->getIndex());
+                                    qec->getLocalVocabContext());
   };
 
   auto expected = makeIdTableFromVector(
@@ -2535,11 +2537,13 @@ TEST(GroupBy, strOnGroupedVariableWorks) {
   ASSERT_EQ(resultPairs.size(), 2);
   const auto& [idTable0, localVocab0] = resultPairs.at(0);
   EXPECT_EQ(localVocab0.size(), 2);
-  auto localVocabIndex0 = localVocab0.getIndexOrNullopt(
-      LocalVocabEntry::fromStringRepresentation("\"1\"", qec->getIndex()));
+  auto localVocabIndex0 =
+      localVocab0.getIndexOrNullopt(LocalVocabEntry::fromStringRepresentation(
+          "\"1\"", qec->getLocalVocabContext()));
   ASSERT_TRUE(localVocabIndex0.has_value());
-  auto localVocabIndex1 = localVocab0.getIndexOrNullopt(
-      LocalVocabEntry::fromStringRepresentation("\"2\"", qec->getIndex()));
+  auto localVocabIndex1 =
+      localVocab0.getIndexOrNullopt(LocalVocabEntry::fromStringRepresentation(
+          "\"2\"", qec->getLocalVocabContext()));
   ASSERT_TRUE(localVocabIndex1.has_value());
   EXPECT_EQ(idTable0,
             makeIdTableFromVector(
@@ -2550,8 +2554,9 @@ TEST(GroupBy, strOnGroupedVariableWorks) {
 
   const auto& [idTable1, localVocab1] = resultPairs.at(1);
   EXPECT_EQ(localVocab1.size(), 1);
-  auto localVocabIndex2 = localVocab1.getIndexOrNullopt(
-      LocalVocabEntry::fromStringRepresentation("\"3\"", qec->getIndex()));
+  auto localVocabIndex2 =
+      localVocab1.getIndexOrNullopt(LocalVocabEntry::fromStringRepresentation(
+          "\"3\"", qec->getLocalVocabContext()));
   ASSERT_TRUE(localVocabIndex2.has_value());
   EXPECT_EQ(idTable1,
             makeIdTableFromVector(
@@ -2568,8 +2573,8 @@ TEST(GroupBy, localVocabIsProperlyCloned) {
   idTables.push_back(makeIdTableFromVector({{2}}, &Id::makeFromInt));
   // This issue occurs only when the vocab contains any actual values.
   LocalVocab dummy{};
-  dummy.getIndexAndAddIfNotContained(
-      LocalVocabEntry::fromStringRepresentation("\"dummy\"", qec->getIndex()));
+  dummy.getIndexAndAddIfNotContained(LocalVocabEntry::fromStringRepresentation(
+      "\"dummy\"", qec->getLocalVocabContext()));
   auto subtree = makeExecutionTree<ValuesForTesting>(
       qec, std::move(idTables),
       std::vector<std::optional<Variable>>{Variable{"?x"}}, true,
@@ -2601,7 +2606,8 @@ TEST(GroupBy, localVocabIsProperlyCloned) {
     EXPECT_TRUE(
         localVocab
             .getIndexOrNullopt(LocalVocabEntry::fromStringRepresentation(
-                std::string{expected.at(expectedIndex)}, qec->getIndex()))
+                std::string{expected.at(expectedIndex)},
+                qec->getLocalVocabContext()))
             .has_value());
     expectedIndex++;
   }
@@ -2822,8 +2828,8 @@ TEST_P(GroupByLazyFixture, nestedAggregateFunctionsWork) {
   // Acquire the local vocab index for a given string representation if present.
   auto makeEntry = [this](std::string string, const LocalVocab& localVocab) {
     return localVocab.getIndexOrNullopt(
-        LocalVocabEntry::fromStringRepresentation(std::move(string),
-                                                  qec_->getIndex()));
+        LocalVocabEntry::fromStringRepresentation(
+            std::move(string), qec_->getLocalVocabContext()));
   };
 
   auto entryToId = [](std::optional<LocalVocabIndex> entry) {

--- a/test/GroupByTest.cpp
+++ b/test/GroupByTest.cpp
@@ -57,9 +57,8 @@ auto lit(std::string_view s) {
 Id getLocalVocabIdFromVocab(const LocalVocab& localVocab,
                             const std::string& word,
                             const LocalVocabContext& context) {
-  auto lit =
-      ad_utility::triple_component::LiteralOrIri::literalWithoutQuotes(word);
-  auto value = localVocab.getIndexOrNullopt(LocalVocabEntry{lit, context});
+  auto value = localVocab.getIndexOrNullopt(
+      LocalVocabEntry::literalWithoutQuotes(lit, context));
   if (value.has_value()) {
     return ValueId::makeFromLocalVocabIndex(value.value());
   }

--- a/test/GroupByTest.cpp
+++ b/test/GroupByTest.cpp
@@ -55,10 +55,10 @@ auto lit(std::string_view s) {
 
 // Helper function to get the local vocab ID for a given word.
 Id getLocalVocabIdFromVocab(const LocalVocab& localVocab,
-                            const std::string& word) {
+                            const std::string& word, const IndexImpl& index) {
   auto lit =
       ad_utility::triple_component::LiteralOrIri::literalWithoutQuotes(word);
-  auto value = localVocab.getIndexOrNullopt(lit);
+  auto value = localVocab.getIndexOrNullopt(LocalVocabEntry{lit, index});
   if (value.has_value()) {
     return ValueId::makeFromLocalVocabIndex(value.value());
   }
@@ -197,9 +197,13 @@ TEST_F(GroupByTest, doGroupBy) {
   constexpr auto iriref = [](const std::string& s) {
     return ad_utility::triple_component::LiteralOrIri::iriref(s);
   };
-  localVocab->getIndexAndAddIfNotContained(iriref("<local1>"));
-  localVocab->getIndexAndAddIfNotContained(iriref("<local2>"));
-  localVocab->getIndexAndAddIfNotContained(iriref("<local3>"));
+  const auto& indexImpl = _index.getImpl();
+  localVocab->getIndexAndAddIfNotContained(
+      LocalVocabEntry{iriref("<local1>"), indexImpl});
+  localVocab->getIndexAndAddIfNotContained(
+      LocalVocabEntry{iriref("<local2>"), indexImpl});
+  localVocab->getIndexAndAddIfNotContained(
+      LocalVocabEntry{iriref("<local3>"), indexImpl});
 
   IdTable inputData(6, makeAllocator());
   // The input data types are KB, KB, VERBATIM, TEXT, FLOAT, STRING.
@@ -1479,8 +1483,9 @@ TEST_F(GroupByOptimizations, hashMapOptimizationGroupConcatIndex) {
   const auto& table = result->idTable();
 
   auto getId = makeGetId(qec->getIndex());
-  auto getLocalVocabId = [&result](const std::string& word) {
-    return getLocalVocabIdFromVocab(result->localVocab(), word);
+  const auto& index = qec->getIndex().getImpl();
+  auto getLocalVocabId = [&result, &index](const std::string& word) {
+    return getLocalVocabIdFromVocab(result->localVocab(), word, index);
   };
 
   auto expected = makeIdTableFromVector(
@@ -1521,9 +1526,10 @@ TEST_F(GroupByOptimizations, hashMapOptimizationGroupConcatLocalVocab) {
   const auto& table = result->idTable();
 
   auto getId = makeGetId(qec->getIndex());
+  const auto& index = qec->getIndex().getImpl();
   auto d = DoubleId;
-  auto getLocalVocabId = [&result](const std::string& word) {
-    return getLocalVocabIdFromVocab(result->localVocab(), word);
+  auto getLocalVocabId = [&result, &index](const std::string& word) {
+    return getLocalVocabIdFromVocab(result->localVocab(), word, index);
   };
 
   auto expected = makeIdTableFromVector(
@@ -2529,14 +2535,19 @@ TEST(GroupBy, strOnGroupedVariableWorks) {
     resultPairs.push_back(std::move(pair));
   }
 
+  const auto& indexImpl = qec->getIndex().getImpl();
   ASSERT_EQ(resultPairs.size(), 2);
   const auto& [idTable0, localVocab0] = resultPairs.at(0);
   EXPECT_EQ(localVocab0.size(), 2);
-  auto localVocabIndex0 = localVocab0.getIndexOrNullopt(
-      LocalVocabEntry::fromStringRepresentation("\"1\""));
+  auto localVocabIndex0 = localVocab0.getIndexOrNullopt(LocalVocabEntry{
+      ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
+          "\"1\""),
+      indexImpl});
   ASSERT_TRUE(localVocabIndex0.has_value());
-  auto localVocabIndex1 = localVocab0.getIndexOrNullopt(
-      LocalVocabEntry::fromStringRepresentation("\"2\""));
+  auto localVocabIndex1 = localVocab0.getIndexOrNullopt(LocalVocabEntry{
+      ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
+          "\"2\""),
+      indexImpl});
   ASSERT_TRUE(localVocabIndex1.has_value());
   EXPECT_EQ(idTable0,
             makeIdTableFromVector(
@@ -2547,8 +2558,10 @@ TEST(GroupBy, strOnGroupedVariableWorks) {
 
   const auto& [idTable1, localVocab1] = resultPairs.at(1);
   EXPECT_EQ(localVocab1.size(), 1);
-  auto localVocabIndex2 = localVocab1.getIndexOrNullopt(
-      LocalVocabEntry::fromStringRepresentation("\"3\""));
+  auto localVocabIndex2 = localVocab1.getIndexOrNullopt(LocalVocabEntry{
+      ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
+          "\"3\""),
+      indexImpl});
   ASSERT_TRUE(localVocabIndex2.has_value());
   EXPECT_EQ(idTable1,
             makeIdTableFromVector(
@@ -2566,8 +2579,9 @@ TEST(GroupBy, localVocabIsProperlyCloned) {
   idTables.push_back(makeIdTableFromVector({{2}}, &Id::makeFromInt));
   // This issue occurs only when the vocab contains any actual values.
   LocalVocab dummy{};
+  const auto& indexImpl = qec->getIndex().getImpl();
   dummy.getIndexAndAddIfNotContained(
-      LocalVocabEntry{Lit::fromStringRepresentation("\"dummy\"")});
+      LocalVocabEntry{Lit::fromStringRepresentation("\"dummy\""), indexImpl});
   auto subtree = makeExecutionTree<ValuesForTesting>(
       qec, std::move(idTables),
       std::vector<std::optional<Variable>>{Variable{"?x"}}, true,
@@ -2596,11 +2610,12 @@ TEST(GroupBy, localVocabIsProperlyCloned) {
               expected.at(expectedIndex));
     // New value + dummy value
     EXPECT_EQ(localVocab.size(), 2);
-    EXPECT_TRUE(
-        localVocab
-            .getIndexOrNullopt(LocalVocabEntry{Lit::fromStringRepresentation(
-                std::string{expected.at(expectedIndex)})})
-            .has_value());
+    EXPECT_TRUE(localVocab
+                    .getIndexOrNullopt(LocalVocabEntry{
+                        Lit::fromStringRepresentation(
+                            std::string{expected.at(expectedIndex)}),
+                        indexImpl})
+                    .has_value());
     expectedIndex++;
   }
   EXPECT_EQ(expectedIndex, expected.size());
@@ -2818,9 +2833,11 @@ TEST_P(GroupByLazyFixture, nestedAggregateFunctionsWork) {
   auto result = groupBy.computeResultOnlyForTesting(GetParam());
 
   // Acquire the local vocab index for a given string representation if present.
-  auto makeEntry = [](std::string string, const LocalVocab& localVocab) {
-    return localVocab.getIndexOrNullopt(sparqlExpression::detail::LiteralOrIri{
-        L::fromStringRepresentation(std::move(string))});
+  const auto& indexImpl2 = qec_->getIndex().getImpl();
+  auto makeEntry = [&indexImpl2](std::string string,
+                                 const LocalVocab& localVocab) {
+    return localVocab.getIndexOrNullopt(LocalVocabEntry{
+        L::fromStringRepresentation(std::move(string)), indexImpl2});
   };
 
   auto entryToId = [](std::optional<LocalVocabIndex> entry) {

--- a/test/GroupByTest.cpp
+++ b/test/GroupByTest.cpp
@@ -58,7 +58,7 @@ Id getLocalVocabIdFromVocab(const LocalVocab& localVocab,
                             const std::string& word,
                             const LocalVocabContext& context) {
   auto value = localVocab.getIndexOrNullopt(
-      LocalVocabEntry::literalWithoutQuotes(lit, context));
+      LocalVocabEntry::literalWithoutQuotes(word, context));
   if (value.has_value()) {
     return ValueId::makeFromLocalVocabIndex(value.value());
   }

--- a/test/GroupByTest.cpp
+++ b/test/GroupByTest.cpp
@@ -195,15 +195,12 @@ TEST_F(GroupByTest, doGroupBy) {
 
   // Create an input result table with a local vocabulary.
   auto localVocab = std::make_shared<LocalVocab>();
-  constexpr auto iriref = [](const std::string& s) {
-    return ad_utility::triple_component::LiteralOrIri::iriref(s);
-  };
   localVocab->getIndexAndAddIfNotContained(
-      LocalVocabEntry{iriref("<local1>"), _index});
+      LocalVocabEntry::fromStringRepresentation("<local1>", _index));
   localVocab->getIndexAndAddIfNotContained(
-      LocalVocabEntry{iriref("<local2>"), _index});
+      LocalVocabEntry::fromStringRepresentation("<local2>", _index));
   localVocab->getIndexAndAddIfNotContained(
-      LocalVocabEntry{iriref("<local3>"), _index});
+      LocalVocabEntry::fromStringRepresentation("<local3>", _index));
 
   IdTable inputData(6, makeAllocator());
   // The input data types are KB, KB, VERBATIM, TEXT, FLOAT, STRING.
@@ -2538,15 +2535,11 @@ TEST(GroupBy, strOnGroupedVariableWorks) {
   ASSERT_EQ(resultPairs.size(), 2);
   const auto& [idTable0, localVocab0] = resultPairs.at(0);
   EXPECT_EQ(localVocab0.size(), 2);
-  auto localVocabIndex0 = localVocab0.getIndexOrNullopt(LocalVocabEntry{
-      ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
-          "\"1\""),
-      qec->getIndex()});
+  auto localVocabIndex0 = localVocab0.getIndexOrNullopt(
+      LocalVocabEntry::fromStringRepresentation("\"1\"", qec->getIndex()));
   ASSERT_TRUE(localVocabIndex0.has_value());
-  auto localVocabIndex1 = localVocab0.getIndexOrNullopt(LocalVocabEntry{
-      ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
-          "\"2\""),
-      qec->getIndex()});
+  auto localVocabIndex1 = localVocab0.getIndexOrNullopt(
+      LocalVocabEntry::fromStringRepresentation("\"2\"", qec->getIndex()));
   ASSERT_TRUE(localVocabIndex1.has_value());
   EXPECT_EQ(idTable0,
             makeIdTableFromVector(
@@ -2557,10 +2550,8 @@ TEST(GroupBy, strOnGroupedVariableWorks) {
 
   const auto& [idTable1, localVocab1] = resultPairs.at(1);
   EXPECT_EQ(localVocab1.size(), 1);
-  auto localVocabIndex2 = localVocab1.getIndexOrNullopt(LocalVocabEntry{
-      ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
-          "\"3\""),
-      qec->getIndex()});
+  auto localVocabIndex2 = localVocab1.getIndexOrNullopt(
+      LocalVocabEntry::fromStringRepresentation("\"3\"", qec->getIndex()));
   ASSERT_TRUE(localVocabIndex2.has_value());
   EXPECT_EQ(idTable1,
             makeIdTableFromVector(
@@ -2571,15 +2562,14 @@ TEST(GroupBy, strOnGroupedVariableWorks) {
 // _____________________________________________________________________________
 TEST(GroupBy, localVocabIsProperlyCloned) {
   // Regression test for https://github.com/ad-freiburg/qlever/issues/2445
-  using Lit = ad_utility::triple_component::Literal;
   auto* qec = getQec();
   std::vector<IdTable> idTables;
   idTables.push_back(makeIdTableFromVector({{1}, {2}}, &Id::makeFromInt));
   idTables.push_back(makeIdTableFromVector({{2}}, &Id::makeFromInt));
   // This issue occurs only when the vocab contains any actual values.
   LocalVocab dummy{};
-  dummy.getIndexAndAddIfNotContained(LocalVocabEntry{
-      Lit::fromStringRepresentation("\"dummy\""), qec->getIndex()});
+  dummy.getIndexAndAddIfNotContained(
+      LocalVocabEntry::fromStringRepresentation("\"dummy\"", qec->getIndex()));
   auto subtree = makeExecutionTree<ValuesForTesting>(
       qec, std::move(idTables),
       std::vector<std::optional<Variable>>{Variable{"?x"}}, true,
@@ -2608,12 +2598,11 @@ TEST(GroupBy, localVocabIsProperlyCloned) {
               expected.at(expectedIndex));
     // New value + dummy value
     EXPECT_EQ(localVocab.size(), 2);
-    EXPECT_TRUE(localVocab
-                    .getIndexOrNullopt(LocalVocabEntry{
-                        Lit::fromStringRepresentation(
-                            std::string{expected.at(expectedIndex)}),
-                        qec->getIndex()})
-                    .has_value());
+    EXPECT_TRUE(
+        localVocab
+            .getIndexOrNullopt(LocalVocabEntry::fromStringRepresentation(
+                std::string{expected.at(expectedIndex)}, qec->getIndex()))
+            .has_value());
     expectedIndex++;
   }
   EXPECT_EQ(expectedIndex, expected.size());
@@ -2832,8 +2821,9 @@ TEST_P(GroupByLazyFixture, nestedAggregateFunctionsWork) {
 
   // Acquire the local vocab index for a given string representation if present.
   auto makeEntry = [this](std::string string, const LocalVocab& localVocab) {
-    return localVocab.getIndexOrNullopt(LocalVocabEntry{
-        L::fromStringRepresentation(std::move(string)), qec_->getIndex()});
+    return localVocab.getIndexOrNullopt(
+        LocalVocabEntry::fromStringRepresentation(std::move(string),
+                                                  qec_->getIndex()));
   };
 
   auto entryToId = [](std::optional<LocalVocabIndex> entry) {

--- a/test/GroupByTest.cpp
+++ b/test/GroupByTest.cpp
@@ -195,12 +195,12 @@ TEST_F(GroupByTest, doGroupBy) {
 
   // Create an input result table with a local vocabulary.
   auto localVocab = std::make_shared<LocalVocab>();
-  localVocab->getIndexAndAddIfNotContained(
-      LocalVocabEntry::fromStringRepresentation("<local1>", _index));
-  localVocab->getIndexAndAddIfNotContained(
-      LocalVocabEntry::fromStringRepresentation("<local2>", _index));
-  localVocab->getIndexAndAddIfNotContained(
-      LocalVocabEntry::fromStringRepresentation("<local3>", _index));
+  auto iriref = [this](std::string_view s) {
+    return LocalVocabEntry::fromIriref(s, _index);
+  };
+  localVocab->getIndexAndAddIfNotContained(iriref("<local1>"));
+  localVocab->getIndexAndAddIfNotContained(iriref("<local2>"));
+  localVocab->getIndexAndAddIfNotContained(iriref("<local3>"));
 
   IdTable inputData(6, makeAllocator());
   // The input data types are KB, KB, VERBATIM, TEXT, FLOAT, STRING.

--- a/test/IndexTest.cpp
+++ b/test/IndexTest.cpp
@@ -710,8 +710,7 @@ TEST(IndexImpl, recomputeStatistics) {
   index.deltaTriplesManager().modify<void>([&cancellationHandle, blankNodeId,
                                             &indexImpl](
                                                DeltaTriples& deltaTriples) {
-    LocalVocabEntry zzz =
-        LocalVocabEntry::fromStringRepresentation("<zzz>", indexImpl);
+    LocalVocabEntry zzz = LocalVocabEntry::fromIriref("<zzz>", indexImpl);
     LocalVocabEntry literal =
         LocalVocabEntry::fromStringRepresentation("\"test\"@en", indexImpl);
     Id zzzId = Id::makeFromLocalVocabIndex(&zzz);

--- a/test/IndexTest.cpp
+++ b/test/IndexTest.cpp
@@ -710,12 +710,10 @@ TEST(IndexImpl, recomputeStatistics) {
   index.deltaTriplesManager().modify<void>([&cancellationHandle, blankNodeId,
                                             &indexImpl](
                                                DeltaTriples& deltaTriples) {
-    LocalVocabEntry zzz{ad_utility::triple_component::Iri::fromIriref("<zzz>"),
-                        indexImpl};
-    LocalVocabEntry literal{
-        ad_utility::triple_component::Literal::fromStringRepresentation(
-            "\"test\"@en"),
-        indexImpl};
+    LocalVocabEntry zzz =
+        LocalVocabEntry::fromStringRepresentation("<zzz>", indexImpl);
+    LocalVocabEntry literal =
+        LocalVocabEntry::fromStringRepresentation("\"test\"@en", indexImpl);
     Id zzzId = Id::makeFromLocalVocabIndex(&zzz);
     Id literalId = Id::makeFromLocalVocabIndex(&literal);
     // Create duplicate in different graph.

--- a/test/IndexTest.cpp
+++ b/test/IndexTest.cpp
@@ -707,12 +707,15 @@ TEST(IndexImpl, recomputeStatistics) {
 
   // Now, modify the index by adding triples.
   Id blankNodeId = Id::makeFromBlankNodeIndex(BlankNodeIndex::make(42));
-  index.deltaTriplesManager().modify<void>([&cancellationHandle, blankNodeId](
+  index.deltaTriplesManager().modify<void>([&cancellationHandle, blankNodeId,
+                                            &indexImpl](
                                                DeltaTriples& deltaTriples) {
-    LocalVocabEntry zzz{ad_utility::triple_component::Iri::fromIriref("<zzz>")};
+    LocalVocabEntry zzz{ad_utility::triple_component::Iri::fromIriref("<zzz>"),
+                        indexImpl};
     LocalVocabEntry literal{
         ad_utility::triple_component::Literal::fromStringRepresentation(
-            "\"test\"@en")};
+            "\"test\"@en"),
+        indexImpl};
     Id zzzId = Id::makeFromLocalVocabIndex(&zzz);
     Id literalId = Id::makeFromLocalVocabIndex(&literal);
     // Create duplicate in different graph.

--- a/test/LanguageExpressionsTest.cpp
+++ b/test/LanguageExpressionsTest.cpp
@@ -132,10 +132,8 @@ struct TestContext {
 };
 
 // ____________________________________________________________________________
-auto litOrIri = [](const std::string& literal) -> IdOrLocalVocabEntry {
-  const auto& index = ad_utility::testing::getQec(TestContext::turtleInput)
-                          ->getIndex()
-                          .getImpl();
+auto localVocabEntry = [](const std::string& literal,
+                          const IndexImpl& index) -> IdOrLocalVocabEntry {
   return LocalVocabEntry{LiteralOrIri::fromStringRepresentation(
                              absl::StrCat("\""sv, literal, "\""sv)),
                          index};
@@ -173,16 +171,15 @@ auto getLangMatchesExpression =
 
 // ____________________________________________________________________________
 template <auto GetExpr, typename T>
-auto testLanguageExpressions = [](const std::vector<T>& expected,
-                                  const std::string& variable,
-                                  const auto&... args) {
-  TestContext context;
-  ASSERT_TRUE(context.isValidVariableStr(variable));
-  SparqlExpression::Ptr expr = GetExpr(variable, args...);
-  auto resultAsVariant = expr->evaluate(&context.context);
-  const auto& result = std::get<VectorWithMemoryLimit<T>>(resultAsVariant);
-  EXPECT_THAT(result, ::testing::ElementsAreArray(expected));
-};
+auto testLanguageExpressions =
+    [](TestContext& context, const std::vector<T>& expected,
+       const std::string& variable, const auto&... args) {
+      ASSERT_TRUE(context.isValidVariableStr(variable));
+      SparqlExpression::Ptr expr = GetExpr(variable, args...);
+      auto resultAsVariant = expr->evaluate(&context.context);
+      const auto& result = std::get<VectorWithMemoryLimit<T>>(resultAsVariant);
+      EXPECT_THAT(result, ::testing::ElementsAreArray(expected));
+    };
 
 // ____________________________________________________________________________
 TEST(LanguageTagGetter, testLanguageTagValueGetterWithoutVocabId) {
@@ -236,17 +233,25 @@ TEST(LanguageTagGetter, testLanguageTagValueGetterWithLocalVocab) {
 
 // ____________________________________________________________________________
 TEST(LangExpression, testLangExpressionOnLiteralColumn) {
+  TestContext context;
+  auto lve = [&context](const std::string& literal) {
+    return localVocabEntry(literal, context.qec->getIndex().getImpl());
+  };
   testLanguageExpressions<getLangExpression, IdOrLocalVocabEntry>(
-      {litOrIri(""), litOrIri("es"), litOrIri("de-LATN-CH"), litOrIri("de-DE"),
-       litOrIri("de-DE"), litOrIri("de-AT"), litOrIri("de"), litOrIri("de-AT")},
+      context,
+      {lve(""), lve("es"), lve("de-LATN-CH"), lve("de-DE"), lve("de-DE"),
+       lve("de-AT"), lve("de"), lve("de-AT")},
       "?literals");
 }
 
 // ____________________________________________________________________________
 TEST(LangExpression, testLangExpressionOnMixedColumn) {
+  TestContext context;
+  auto lve = [&context](const std::string& literal) {
+    return localVocabEntry(literal, context.qec->getIndex().getImpl());
+  };
   testLanguageExpressions<getLangExpression, IdOrLocalVocabEntry>(
-      {litOrIri(""), litOrIri(""), litOrIri("de"), U, U, U, U, litOrIri("")},
-      "?mixed");
+      context, {lve(""), lve(""), lve("de"), U, U, U, U, lve("")}, "?mixed");
 }
 
 // ____________________________________________________________________________
@@ -263,34 +268,36 @@ TEST(LangExpression, testSimpleMethods) {
 
 // ____________________________________________________________________________
 TEST(SparqlExpression, testLangMatchesOnLiteralColumn) {
+  TestContext context;
   testLanguageExpressions<getLangMatchesExpression, Id>(
-      {F, F, T, T, T, T, T, T}, "?literals", "de");
+      context, {F, F, T, T, T, T, T, T}, "?literals", "de");
   testLanguageExpressions<getLangMatchesExpression, Id>(
-      {F, T, T, T, T, T, T, T}, "?literals", "*");
+      context, {F, T, T, T, T, T, T, T}, "?literals", "*");
   testLanguageExpressions<getLangMatchesExpression, Id>(
-      {F, F, T, F, F, F, F, F}, "?literals", "de-LATN-CH");
+      context, {F, F, T, F, F, F, F, F}, "?literals", "de-LATN-CH");
   testLanguageExpressions<getLangMatchesExpression, Id>(
-      {F, F, T, F, F, F, F, F}, "?literals", "DE-LATN-CH");
+      context, {F, F, T, F, F, F, F, F}, "?literals", "DE-LATN-CH");
   testLanguageExpressions<getLangMatchesExpression, Id>(
-      {F, F, F, F, F, F, F, F}, "?literals", "en-US");
+      context, {F, F, F, F, F, F, F, F}, "?literals", "en-US");
   testLanguageExpressions<getLangMatchesExpression, Id>(
-      {F, F, F, F, F, F, F, F}, "?literals", "");
+      context, {F, F, F, F, F, F, F, F}, "?literals", "");
   testLanguageExpressions<getLangMatchesExpression, Id>(
-      {F, F, T, T, T, T, F, T}, "?literals", "de-*");
+      context, {F, F, T, T, T, T, F, T}, "?literals", "de-*");
   testLanguageExpressions<getLangMatchesExpression, Id>(
-      {F, F, T, T, T, T, F, T}, "?literals", "De-*");
+      context, {F, F, T, T, T, T, F, T}, "?literals", "De-*");
 }
 
 // ____________________________________________________________________________
 TEST(SparqlExpression, testLangMatchesOnMixedColumn) {
+  TestContext context;
   testLanguageExpressions<getLangMatchesExpression, Id>(
-      {F, F, T, U, U, U, U, F}, "?mixed", "de");
+      context, {F, F, T, U, U, U, U, F}, "?mixed", "de");
   testLanguageExpressions<getLangMatchesExpression, Id>(
-      {F, F, T, U, U, U, U, F}, "?mixed", "dE");
+      context, {F, F, T, U, U, U, U, F}, "?mixed", "dE");
   testLanguageExpressions<getLangMatchesExpression, Id>(
-      {F, F, T, U, U, U, U, F}, "?mixed", "*");
+      context, {F, F, T, U, U, U, U, F}, "?mixed", "*");
   testLanguageExpressions<getLangMatchesExpression, Id>(
-      {F, F, F, U, U, U, U, F}, "?mixed", "en-US");
+      context, {F, F, F, U, U, U, U, F}, "?mixed", "en-US");
   testLanguageExpressions<getLangMatchesExpression, Id>(
-      {F, F, F, U, U, U, U, F}, "?mixed", "");
+      context, {F, F, F, U, U, U, U, F}, "?mixed", "");
 }

--- a/test/LanguageExpressionsTest.cpp
+++ b/test/LanguageExpressionsTest.cpp
@@ -132,11 +132,12 @@ struct TestContext {
 };
 
 // ____________________________________________________________________________
-auto localVocabEntry = [](const std::string& literal,
-                          const IndexImpl& index) -> IdOrLocalVocabEntry {
+auto localVocabEntry =
+    [](const std::string& literal,
+       const LocalVocabContext& context) -> IdOrLocalVocabEntry {
   return LocalVocabEntry{LiteralOrIri::fromStringRepresentation(
                              absl::StrCat("\""sv, literal, "\""sv)),
-                         index};
+                         context};
 };
 
 // ____________________________________________________________________________

--- a/test/LanguageExpressionsTest.cpp
+++ b/test/LanguageExpressionsTest.cpp
@@ -81,11 +81,11 @@ struct TestContext {
   };
 
   TestContext() {
-    const auto& index = qec->getIndex();
-    auto add = [this, &index](const std::string& s) {
+    const auto& localVocabContext = qec->getLocalVocabContext();
+    auto add = [this, &localVocabContext](const std::string& s) {
       return Id::makeFromLocalVocabIndex(
           localVocab.getIndexAndAddIfNotContained(
-              LocalVocabEntry::fromStringRepresentation(s, index)));
+              LocalVocabEntry::fromStringRepresentation(s, localVocabContext)));
     };
     locVocIri1 = add("<https:://some_example/iri>");
     locVocIri2 = add("<http://www.w3.org/2001/XMLSchema#integer>");
@@ -220,7 +220,7 @@ TEST(LanguageTagGetter, testLanguageTagValueGetterWithLocalVocab) {
 TEST(LangExpression, testLangExpressionOnLiteralColumn) {
   TestContext context;
   auto lve = [&context](const std::string& literal) {
-    return localVocabEntry(literal, context.qec->getIndex());
+    return localVocabEntry(literal, context.qec->getLocalVocabContext());
   };
   testLanguageExpressions<getLangExpression, IdOrLocalVocabEntry>(
       context,
@@ -233,7 +233,7 @@ TEST(LangExpression, testLangExpressionOnLiteralColumn) {
 TEST(LangExpression, testLangExpressionOnMixedColumn) {
   TestContext context;
   auto lve = [&context](const std::string& literal) {
-    return localVocabEntry(literal, context.qec->getIndex());
+    return localVocabEntry(literal, context.qec->getLocalVocabContext());
   };
   testLanguageExpressions<getLangExpression, IdOrLocalVocabEntry>(
       context, {lve(""), lve(""), lve("de"), U, U, U, U, lve("")}, "?mixed");

--- a/test/LanguageExpressionsTest.cpp
+++ b/test/LanguageExpressionsTest.cpp
@@ -135,9 +135,8 @@ struct TestContext {
 auto localVocabEntry =
     [](const std::string& literal,
        const LocalVocabContext& context) -> IdOrLocalVocabEntry {
-  return LocalVocabEntry{LiteralOrIri::fromStringRepresentation(
-                             absl::StrCat("\""sv, literal, "\""sv)),
-                         context};
+  return LocalVocabEntry::fromStringRepresentation(
+      absl::StrCat("\""sv, literal, "\""sv), context);
 };
 
 // ____________________________________________________________________________

--- a/test/LanguageExpressionsTest.cpp
+++ b/test/LanguageExpressionsTest.cpp
@@ -89,20 +89,25 @@ struct TestContext {
       return ad_utility::triple_component::LiteralOrIri::iriref(s);
     };
 
+    const auto& indexImpl = qec->getIndex().getImpl();
     locVocIri1 =
         Id::makeFromLocalVocabIndex(localVocab.getIndexAndAddIfNotContained(
-            iri("<https:://some_example/iri>")));
-    locVocIri2 =
+            LocalVocabEntry{iri("<https:://some_example/iri>"), indexImpl}));
+    locVocIri2 = Id::makeFromLocalVocabIndex(
+        localVocab.getIndexAndAddIfNotContained(LocalVocabEntry{
+            iri("<http://www.w3.org/2001/XMLSchema#integer>"), indexImpl}));
+    locVocLit1 =
         Id::makeFromLocalVocabIndex(localVocab.getIndexAndAddIfNotContained(
-            iri("<http://www.w3.org/2001/XMLSchema#integer>")));
-    locVocLit1 = Id::makeFromLocalVocabIndex(
-        localVocab.getIndexAndAddIfNotContained(lit("\"leipzig\"")));
-    locVocLit2 = Id::makeFromLocalVocabIndex(
-        localVocab.getIndexAndAddIfNotContained(lit("\"munich\"@de-DE")));
-    locVocLit3 = Id::makeFromLocalVocabIndex(
-        localVocab.getIndexAndAddIfNotContained(lit("\"hamburg\"@de")));
-    locVocLit4 = Id::makeFromLocalVocabIndex(
-        localVocab.getIndexAndAddIfNotContained(lit("\"düsseldorf\"@de-AT")));
+            LocalVocabEntry{lit("\"leipzig\""), indexImpl}));
+    locVocLit2 =
+        Id::makeFromLocalVocabIndex(localVocab.getIndexAndAddIfNotContained(
+            LocalVocabEntry{lit("\"munich\"@de-DE"), indexImpl}));
+    locVocLit3 =
+        Id::makeFromLocalVocabIndex(localVocab.getIndexAndAddIfNotContained(
+            LocalVocabEntry{lit("\"hamburg\"@de"), indexImpl}));
+    locVocLit4 =
+        Id::makeFromLocalVocabIndex(localVocab.getIndexAndAddIfNotContained(
+            LocalVocabEntry{lit("\"düsseldorf\"@de-AT"), indexImpl}));
 
     table.setNumColumns(2);
     // Order of the columns:
@@ -127,9 +132,13 @@ struct TestContext {
 };
 
 // ____________________________________________________________________________
-auto litOrIri = [](const std::string& literal) {
-  return LiteralOrIri::fromStringRepresentation(
-      absl::StrCat("\""sv, literal, "\""sv));
+auto litOrIri = [](const std::string& literal) -> IdOrLocalVocabEntry {
+  const auto& index = ad_utility::testing::getQec(TestContext::turtleInput)
+                          ->getIndex()
+                          .getImpl();
+  return LocalVocabEntry{LiteralOrIri::fromStringRepresentation(
+                             absl::StrCat("\""sv, literal, "\""sv)),
+                         index};
 };
 
 // ____________________________________________________________________________

--- a/test/LanguageExpressionsTest.cpp
+++ b/test/LanguageExpressionsTest.cpp
@@ -89,25 +89,25 @@ struct TestContext {
       return ad_utility::triple_component::LiteralOrIri::iriref(s);
     };
 
-    const auto& indexImpl = qec->getIndex().getImpl();
+    const auto& index = qec->getIndex();
     locVocIri1 =
         Id::makeFromLocalVocabIndex(localVocab.getIndexAndAddIfNotContained(
-            LocalVocabEntry{iri("<https:://some_example/iri>"), indexImpl}));
+            LocalVocabEntry{iri("<https:://some_example/iri>"), index}));
     locVocIri2 = Id::makeFromLocalVocabIndex(
         localVocab.getIndexAndAddIfNotContained(LocalVocabEntry{
-            iri("<http://www.w3.org/2001/XMLSchema#integer>"), indexImpl}));
+            iri("<http://www.w3.org/2001/XMLSchema#integer>"), index}));
     locVocLit1 =
         Id::makeFromLocalVocabIndex(localVocab.getIndexAndAddIfNotContained(
-            LocalVocabEntry{lit("\"leipzig\""), indexImpl}));
+            LocalVocabEntry{lit("\"leipzig\""), index}));
     locVocLit2 =
         Id::makeFromLocalVocabIndex(localVocab.getIndexAndAddIfNotContained(
-            LocalVocabEntry{lit("\"munich\"@de-DE"), indexImpl}));
+            LocalVocabEntry{lit("\"munich\"@de-DE"), index}));
     locVocLit3 =
         Id::makeFromLocalVocabIndex(localVocab.getIndexAndAddIfNotContained(
-            LocalVocabEntry{lit("\"hamburg\"@de"), indexImpl}));
+            LocalVocabEntry{lit("\"hamburg\"@de"), index}));
     locVocLit4 =
         Id::makeFromLocalVocabIndex(localVocab.getIndexAndAddIfNotContained(
-            LocalVocabEntry{lit("\"düsseldorf\"@de-AT"), indexImpl}));
+            LocalVocabEntry{lit("\"düsseldorf\"@de-AT"), index}));
 
     table.setNumColumns(2);
     // Order of the columns:
@@ -235,7 +235,7 @@ TEST(LanguageTagGetter, testLanguageTagValueGetterWithLocalVocab) {
 TEST(LangExpression, testLangExpressionOnLiteralColumn) {
   TestContext context;
   auto lve = [&context](const std::string& literal) {
-    return localVocabEntry(literal, context.qec->getIndex().getImpl());
+    return localVocabEntry(literal, context.qec->getIndex());
   };
   testLanguageExpressions<getLangExpression, IdOrLocalVocabEntry>(
       context,
@@ -248,7 +248,7 @@ TEST(LangExpression, testLangExpressionOnLiteralColumn) {
 TEST(LangExpression, testLangExpressionOnMixedColumn) {
   TestContext context;
   auto lve = [&context](const std::string& literal) {
-    return localVocabEntry(literal, context.qec->getIndex().getImpl());
+    return localVocabEntry(literal, context.qec->getIndex());
   };
   testLanguageExpressions<getLangExpression, IdOrLocalVocabEntry>(
       context, {lve(""), lve(""), lve("de"), U, U, U, U, lve("")}, "?mixed");

--- a/test/LanguageExpressionsTest.cpp
+++ b/test/LanguageExpressionsTest.cpp
@@ -81,33 +81,18 @@ struct TestContext {
   };
 
   TestContext() {
-    constexpr auto lit = [](const std::string& s) {
-      return ad_utility::triple_component::LiteralOrIri::
-          fromStringRepresentation(s);
-    };
-    constexpr auto iri = [](const std::string& s) {
-      return ad_utility::triple_component::LiteralOrIri::iriref(s);
-    };
-
     const auto& index = qec->getIndex();
-    locVocIri1 =
-        Id::makeFromLocalVocabIndex(localVocab.getIndexAndAddIfNotContained(
-            LocalVocabEntry{iri("<https:://some_example/iri>"), index}));
-    locVocIri2 = Id::makeFromLocalVocabIndex(
-        localVocab.getIndexAndAddIfNotContained(LocalVocabEntry{
-            iri("<http://www.w3.org/2001/XMLSchema#integer>"), index}));
-    locVocLit1 =
-        Id::makeFromLocalVocabIndex(localVocab.getIndexAndAddIfNotContained(
-            LocalVocabEntry{lit("\"leipzig\""), index}));
-    locVocLit2 =
-        Id::makeFromLocalVocabIndex(localVocab.getIndexAndAddIfNotContained(
-            LocalVocabEntry{lit("\"munich\"@de-DE"), index}));
-    locVocLit3 =
-        Id::makeFromLocalVocabIndex(localVocab.getIndexAndAddIfNotContained(
-            LocalVocabEntry{lit("\"hamburg\"@de"), index}));
-    locVocLit4 =
-        Id::makeFromLocalVocabIndex(localVocab.getIndexAndAddIfNotContained(
-            LocalVocabEntry{lit("\"düsseldorf\"@de-AT"), index}));
+    auto add = [this, &index](const std::string& s) {
+      return Id::makeFromLocalVocabIndex(
+          localVocab.getIndexAndAddIfNotContained(
+              LocalVocabEntry::fromStringRepresentation(s, index)));
+    };
+    locVocIri1 = add("<https:://some_example/iri>");
+    locVocIri2 = add("<http://www.w3.org/2001/XMLSchema#integer>");
+    locVocLit1 = add("\"leipzig\"");
+    locVocLit2 = add("\"munich\"@de-DE");
+    locVocLit3 = add("\"hamburg\"@de");
+    locVocLit4 = add("\"düsseldorf\"@de-AT");
 
     table.setNumColumns(2);
     // Order of the columns:

--- a/test/LoadTest.cpp
+++ b/test/LoadTest.cpp
@@ -158,9 +158,11 @@ TEST_F(LoadTest, computeResult) {
               ASSERT_THAT(field.isLiteral() || field.isIri(),
                           testing::IsTrue());
               using LiteralOrIri = ad_utility::triple_component::LiteralOrIri;
-              auto lveOpt = lv.getIndexOrNullopt(
+              const auto& indexImpl = testQec->getIndex().getImpl();
+              auto lveOpt = lv.getIndexOrNullopt(LocalVocabEntry{
                   field.isLiteral() ? LiteralOrIri{field.getLiteral()}
-                                    : LiteralOrIri{field.getIri()});
+                                    : LiteralOrIri{field.getIri()},
+                  indexImpl});
               ASSERT_THAT(lveOpt, testing::Not(testing::Eq(std::nullopt)));
               idOpt = Id::makeFromLocalVocabIndex(lveOpt.value());
             }

--- a/test/LoadTest.cpp
+++ b/test/LoadTest.cpp
@@ -161,7 +161,7 @@ TEST_F(LoadTest, computeResult) {
               auto lveOpt = lv.getIndexOrNullopt(LocalVocabEntry{
                   field.isLiteral() ? LiteralOrIri{field.getLiteral()}
                                     : LiteralOrIri{field.getIri()},
-                  testQec->getIndex()});
+                  testQec->getLocalVocabContext()});
               ASSERT_THAT(lveOpt, testing::Not(testing::Eq(std::nullopt)));
               idOpt = Id::makeFromLocalVocabIndex(lveOpt.value());
             }

--- a/test/LoadTest.cpp
+++ b/test/LoadTest.cpp
@@ -158,11 +158,10 @@ TEST_F(LoadTest, computeResult) {
               ASSERT_THAT(field.isLiteral() || field.isIri(),
                           testing::IsTrue());
               using LiteralOrIri = ad_utility::triple_component::LiteralOrIri;
-              const auto& indexImpl = testQec->getIndex().getImpl();
               auto lveOpt = lv.getIndexOrNullopt(LocalVocabEntry{
                   field.isLiteral() ? LiteralOrIri{field.getLiteral()}
                                     : LiteralOrIri{field.getIri()},
-                  indexImpl});
+                  testQec->getIndex()});
               ASSERT_THAT(lveOpt, testing::Not(testing::Eq(std::nullopt)));
               idOpt = Id::makeFromLocalVocabIndex(lveOpt.value());
             }

--- a/test/LocalVocabTest.cpp
+++ b/test/LocalVocabTest.cpp
@@ -37,9 +37,8 @@ namespace {
 
 using TestWords = std::vector<LocalVocabEntry>;
 
-TestWords getTestCollectionOfWords(size_t size) {
+TestWords getTestCollectionOfWords(size_t size, const IndexImpl& index) {
   using namespace ad_utility::triple_component;
-  const auto& index = ad_utility::testing::getQec()->getIndex().getImpl();
   TestWords testCollectionOfWords;
   for (size_t i = 0; i < size; ++i) {
     testCollectionOfWords.push_back(LocalVocabEntry{
@@ -57,8 +56,9 @@ auto lit(std::string_view s) {
 
 // _____________________________________________________________________________
 TEST(LocalVocab, constructionAndAccess) {
+  auto* qec = ad_utility::testing::getQec();
   // Test collection of words.
-  TestWords testWords = getTestCollectionOfWords(1000);
+  TestWords testWords = getTestCollectionOfWords(1000, qec->getIndex());
 
   // Create empty local vocabulary.
   LocalVocab localVocab;
@@ -94,11 +94,10 @@ TEST(LocalVocab, constructionAndAccess) {
   // in our test vocabulary only contain digits as letters, see above.
   for (size_t i = 0; i < testWords.size(); ++i) {
     std::string content{asStringViewUnsafe(testWords[i].getContent())};
-    const auto& index = ad_utility::testing::getQec()->getIndex().getImpl();
     auto illegalWord = LocalVocabEntry{
         ad_utility::triple_component::LiteralOrIri::literalWithoutQuotes(
             content + "A"),
-        index};
+        qec->getIndex()};
     ASSERT_FALSE(localVocab.getIndexOrNullopt(illegalWord));
   }
 
@@ -119,11 +118,12 @@ TEST(LocalVocab, constructionAndAccess) {
 
 // _____________________________________________________________________________
 TEST(LocalVocab, clone) {
+  auto* qec = ad_utility::testing::getQec();
   // Create a small local vocabulary.
   size_t localVocabSize = 100;
   LocalVocab localVocabOriginal;
   std::vector<LocalVocabIndex> indices;
-  auto inputWords = getTestCollectionOfWords(localVocabSize);
+  auto inputWords = getTestCollectionOfWords(localVocabSize, qec->getIndex());
   for (const auto& word : inputWords) {
     indices.push_back(localVocabOriginal.getIndexAndAddIfNotContained(word));
   }
@@ -159,7 +159,8 @@ TEST(LocalVocab, merge) {
   std::vector<LocalVocabIndex> indices;
   LocalVocab vocA;
   LocalVocab vocB;
-  const auto& index = ad_utility::testing::getQec()->getIndex().getImpl();
+  auto* qec = ad_utility::testing::getQec();
+  const auto& index = qec->getIndex();
   constexpr auto lit = [](std::string_view s) {
     return ad_utility::triple_component::LiteralOrIri::literalWithoutQuotes(s);
   };
@@ -228,13 +229,13 @@ TEST(LocalVocab, propagation) {
           ad_utility::source_location loc = AD_CURRENT_SOURCE_LOC()) -> void {
     auto t = generateLocationTrace(loc);
     TestWords expectedWords;
-    const auto& idx = testQec->getIndex().getImpl();
-    auto toLitOrIri = [&idx](const auto& word) {
+    const auto& index = testQec->getIndex();
+    auto toLitOrIri = [&index](const auto& word) {
       using namespace ad_utility::triple_component;
       if (ql::starts_with(word, '<')) {
-        return LocalVocabEntry{LiteralOrIri::iriref(word), idx};
+        return LocalVocabEntry{LiteralOrIri::iriref(word), index};
       } else {
-        return LocalVocabEntry{LiteralOrIri::literalWithoutQuotes(word), idx};
+        return LocalVocabEntry{LiteralOrIri::literalWithoutQuotes(word), index};
       }
     };
     ql::ranges::transform(expectedWordsAsStrings,
@@ -436,7 +437,8 @@ TEST(LocalVocab, getBlankNodeIndex) {
 // _____________________________________________________________________________
 TEST(LocalVocab, otherWordSetIsTransitivelyPropagated) {
   using ad_utility::triple_component::LiteralOrIri;
-  const auto& index = ad_utility::testing::getQec()->getIndex().getImpl();
+  auto* qec = ad_utility::testing::getQec();
+  const auto& index = qec->getIndex();
   LocalVocab original;
   original.getIndexAndAddIfNotContained(
       LocalVocabEntry{LiteralOrIri::literalWithoutQuotes("test"), index});
@@ -455,7 +457,8 @@ TEST(LocalVocab, otherWordSetIsTransitivelyPropagated) {
 TEST(LocalVocab, sizeIsProperlyUpdatedOnMerge) {
   using ad_utility::triple_component::LiteralOrIri;
   using ::testing::UnorderedElementsAre;
-  const auto& index = ad_utility::testing::getQec()->getIndex().getImpl();
+  auto* qec = ad_utility::testing::getQec();
+  const auto& index = qec->getIndex();
   LocalVocab original;
   original.getIndexAndAddIfNotContained(
       LocalVocabEntry{LiteralOrIri::literalWithoutQuotes("test"), index});
@@ -483,7 +486,8 @@ TEST(LocalVocab, sizeIsProperlyUpdatedOnMerge) {
 // _____________________________________________________________________________
 TEST(LocalVocab, modificationIsBlockedAfterCloneOrMerge) {
   using ad_utility::triple_component::LiteralOrIri;
-  const auto& index = ad_utility::testing::getQec()->getIndex().getImpl();
+  auto* qec = ad_utility::testing::getQec();
+  const auto& index = qec->getIndex();
   auto literal = LiteralOrIri::literalWithoutQuotes("test");
   auto otherLiteral = LiteralOrIri::literalWithoutQuotes("other");
   {
@@ -520,7 +524,8 @@ TEST(LocalVocab, modificationIsBlockedAfterCloneOrMerge) {
 // _____________________________________________________________________________
 TEST(LocalVocab, modificationIsNotBlockedAfterAcquiringHolder) {
   using ad_utility::triple_component::LiteralOrIri;
-  const auto& index = ad_utility::testing::getQec()->getIndex().getImpl();
+  auto* qec = ad_utility::testing::getQec();
+  const auto& index = qec->getIndex();
   auto literal = LiteralOrIri::literalWithoutQuotes("test");
   auto otherLiteral = LiteralOrIri::literalWithoutQuotes("other");
   std::optional<LocalVocab::LifetimeExtender> extender = std::nullopt;

--- a/test/LocalVocabTest.cpp
+++ b/test/LocalVocabTest.cpp
@@ -234,7 +234,7 @@ TEST(LocalVocab, propagation) {
     auto toLitOrIri = [&index](const auto& word) {
       using namespace ad_utility::triple_component;
       if (ql::starts_with(word, '<')) {
-        return LocalVocabEntry::fromStringRepresentation(word, index);
+        return LocalVocabEntry::fromIriref(word, index);
       } else {
         return LocalVocabEntry{LiteralOrIri::literalWithoutQuotes(word), index};
       }

--- a/test/LocalVocabTest.cpp
+++ b/test/LocalVocabTest.cpp
@@ -39,10 +39,12 @@ using TestWords = std::vector<LocalVocabEntry>;
 
 TestWords getTestCollectionOfWords(size_t size) {
   using namespace ad_utility::triple_component;
+  const auto& index = ad_utility::testing::getQec()->getIndex().getImpl();
   TestWords testCollectionOfWords;
   for (size_t i = 0; i < size; ++i) {
-    testCollectionOfWords.push_back(
-        LiteralOrIri::literalWithoutQuotes(std::to_string(i * 7635475567ULL)));
+    testCollectionOfWords.push_back(LocalVocabEntry{
+        LiteralOrIri::literalWithoutQuotes(std::to_string(i * 7635475567ULL)),
+        index});
   }
   return testCollectionOfWords;
 }
@@ -92,9 +94,11 @@ TEST(LocalVocab, constructionAndAccess) {
   // in our test vocabulary only contain digits as letters, see above.
   for (size_t i = 0; i < testWords.size(); ++i) {
     std::string content{asStringViewUnsafe(testWords[i].getContent())};
-    auto illegalWord =
+    const auto& index = ad_utility::testing::getQec()->getIndex().getImpl();
+    auto illegalWord = LocalVocabEntry{
         ad_utility::triple_component::LiteralOrIri::literalWithoutQuotes(
-            content + "A");
+            content + "A"),
+        index};
     ASSERT_FALSE(localVocab.getIndexOrNullopt(illegalWord));
   }
 
@@ -155,13 +159,18 @@ TEST(LocalVocab, merge) {
   std::vector<LocalVocabIndex> indices;
   LocalVocab vocA;
   LocalVocab vocB;
+  const auto& index = ad_utility::testing::getQec()->getIndex().getImpl();
   constexpr auto lit = [](std::string_view s) {
     return ad_utility::triple_component::LiteralOrIri::literalWithoutQuotes(s);
   };
-  indices.push_back(vocA.getIndexAndAddIfNotContained(lit("oneA")));
-  indices.push_back(vocA.getIndexAndAddIfNotContained(lit("twoA")));
-  indices.push_back(vocA.getIndexAndAddIfNotContained(lit("oneB")));
-  indices.push_back(vocA.getIndexAndAddIfNotContained(lit("twoB")));
+  indices.push_back(
+      vocA.getIndexAndAddIfNotContained(LocalVocabEntry{lit("oneA"), index}));
+  indices.push_back(
+      vocA.getIndexAndAddIfNotContained(LocalVocabEntry{lit("twoA"), index}));
+  indices.push_back(
+      vocA.getIndexAndAddIfNotContained(LocalVocabEntry{lit("oneB"), index}));
+  indices.push_back(
+      vocA.getIndexAndAddIfNotContained(LocalVocabEntry{lit("twoB"), index}));
 
   // Clone it and test that the clone contains the same words.
   auto vocabs = std::vector{&std::as_const(vocA), &std::as_const(vocB)};
@@ -219,12 +228,13 @@ TEST(LocalVocab, propagation) {
           ad_utility::source_location loc = AD_CURRENT_SOURCE_LOC()) -> void {
     auto t = generateLocationTrace(loc);
     TestWords expectedWords;
-    auto toLitOrIri = [](const auto& word) {
+    const auto& idx = testQec->getIndex().getImpl();
+    auto toLitOrIri = [&idx](const auto& word) {
       using namespace ad_utility::triple_component;
       if (ql::starts_with(word, '<')) {
-        return LiteralOrIri::iriref(word);
+        return LocalVocabEntry{LiteralOrIri::iriref(word), idx};
       } else {
-        return LiteralOrIri::literalWithoutQuotes(word);
+        return LocalVocabEntry{LiteralOrIri::literalWithoutQuotes(word), idx};
       }
     };
     ql::ranges::transform(expectedWordsAsStrings,
@@ -426,9 +436,10 @@ TEST(LocalVocab, getBlankNodeIndex) {
 // _____________________________________________________________________________
 TEST(LocalVocab, otherWordSetIsTransitivelyPropagated) {
   using ad_utility::triple_component::LiteralOrIri;
+  const auto& index = ad_utility::testing::getQec()->getIndex().getImpl();
   LocalVocab original;
   original.getIndexAndAddIfNotContained(
-      LocalVocabEntry{LiteralOrIri::literalWithoutQuotes("test")});
+      LocalVocabEntry{LiteralOrIri::literalWithoutQuotes("test"), index});
 
   LocalVocab clone = original.clone();
   LocalVocab mergeCandidate;
@@ -444,9 +455,10 @@ TEST(LocalVocab, otherWordSetIsTransitivelyPropagated) {
 TEST(LocalVocab, sizeIsProperlyUpdatedOnMerge) {
   using ad_utility::triple_component::LiteralOrIri;
   using ::testing::UnorderedElementsAre;
+  const auto& index = ad_utility::testing::getQec()->getIndex().getImpl();
   LocalVocab original;
   original.getIndexAndAddIfNotContained(
-      LocalVocabEntry{LiteralOrIri::literalWithoutQuotes("test")});
+      LocalVocabEntry{LiteralOrIri::literalWithoutQuotes("test"), index});
 
   LocalVocab clone1 = original.clone();
   LocalVocab clone2 = original.clone();
@@ -471,35 +483,36 @@ TEST(LocalVocab, sizeIsProperlyUpdatedOnMerge) {
 // _____________________________________________________________________________
 TEST(LocalVocab, modificationIsBlockedAfterCloneOrMerge) {
   using ad_utility::triple_component::LiteralOrIri;
+  const auto& index = ad_utility::testing::getQec()->getIndex().getImpl();
   auto literal = LiteralOrIri::literalWithoutQuotes("test");
   auto otherLiteral = LiteralOrIri::literalWithoutQuotes("other");
   {
     LocalVocab original;
-    original.getIndexAndAddIfNotContained(LocalVocabEntry{literal});
+    original.getIndexAndAddIfNotContained(LocalVocabEntry{literal, index});
     (void)original.clone();
-    EXPECT_NE(original.getIndexOrNullopt(LocalVocabEntry{literal}),
+    EXPECT_NE(original.getIndexOrNullopt(LocalVocabEntry{literal, index}),
               std::nullopt);
     EXPECT_THROW(
-        original.getIndexAndAddIfNotContained(LocalVocabEntry{literal}),
+        original.getIndexAndAddIfNotContained(LocalVocabEntry{literal, index}),
         ad_utility::Exception);
-    EXPECT_THROW(
-        original.getIndexAndAddIfNotContained(LocalVocabEntry{otherLiteral}),
-        ad_utility::Exception);
+    EXPECT_THROW(original.getIndexAndAddIfNotContained(
+                     LocalVocabEntry{otherLiteral, index}),
+                 ad_utility::Exception);
     EXPECT_EQ(original.size(), 1);
   }
   {
     LocalVocab original;
     LocalVocab other;
-    original.getIndexAndAddIfNotContained(LocalVocabEntry{literal});
+    original.getIndexAndAddIfNotContained(LocalVocabEntry{literal, index});
     other.mergeWith(original);
-    EXPECT_NE(original.getIndexOrNullopt(LocalVocabEntry{literal}),
+    EXPECT_NE(original.getIndexOrNullopt(LocalVocabEntry{literal, index}),
               std::nullopt);
     EXPECT_THROW(
-        original.getIndexAndAddIfNotContained(LocalVocabEntry{literal}),
+        original.getIndexAndAddIfNotContained(LocalVocabEntry{literal, index}),
         ad_utility::Exception);
-    EXPECT_THROW(
-        original.getIndexAndAddIfNotContained(LocalVocabEntry{otherLiteral}),
-        ad_utility::Exception);
+    EXPECT_THROW(original.getIndexAndAddIfNotContained(
+                     LocalVocabEntry{otherLiteral, index}),
+                 ad_utility::Exception);
     EXPECT_EQ(original.size(), 1);
   }
 }
@@ -507,6 +520,7 @@ TEST(LocalVocab, modificationIsBlockedAfterCloneOrMerge) {
 // _____________________________________________________________________________
 TEST(LocalVocab, modificationIsNotBlockedAfterAcquiringHolder) {
   using ad_utility::triple_component::LiteralOrIri;
+  const auto& index = ad_utility::testing::getQec()->getIndex().getImpl();
   auto literal = LiteralOrIri::literalWithoutQuotes("test");
   auto otherLiteral = LiteralOrIri::literalWithoutQuotes("other");
   std::optional<LocalVocab::LifetimeExtender> extender = std::nullopt;
@@ -515,18 +529,19 @@ TEST(LocalVocab, modificationIsNotBlockedAfterAcquiringHolder) {
   {
     LocalVocab original;
     encodedTest =
-        original.getIndexAndAddIfNotContained(LocalVocabEntry{literal});
+        original.getIndexAndAddIfNotContained(LocalVocabEntry{literal, index});
     extender = original.getLifetimeExtender();
 
-    EXPECT_EQ(original.getIndexOrNullopt(LocalVocabEntry{literal}),
+    EXPECT_EQ(original.getIndexOrNullopt(LocalVocabEntry{literal, index}),
               std::optional{encodedTest});
 
-    EXPECT_EQ(original.getIndexAndAddIfNotContained(LocalVocabEntry{literal}),
-              encodedTest);
+    EXPECT_EQ(
+        original.getIndexAndAddIfNotContained(LocalVocabEntry{literal, index}),
+        encodedTest);
     EXPECT_EQ(original.size(), 1);
 
-    encodedOther =
-        original.getIndexAndAddIfNotContained(LocalVocabEntry{otherLiteral});
+    encodedOther = original.getIndexAndAddIfNotContained(
+        LocalVocabEntry{otherLiteral, index});
     EXPECT_EQ(original.size(), 2);
   }
   // The `extender` keeps the `LocalVocabIndex`es valid even though the

--- a/test/LocalVocabTest.cpp
+++ b/test/LocalVocabTest.cpp
@@ -234,7 +234,7 @@ TEST(LocalVocab, propagation) {
     auto toLitOrIri = [&index](const auto& word) {
       using namespace ad_utility::triple_component;
       if (ql::starts_with(word, '<')) {
-        return LocalVocabEntry{LiteralOrIri::iriref(word), index};
+        return LocalVocabEntry::fromStringRepresentation(word, index);
       } else {
         return LocalVocabEntry{LiteralOrIri::literalWithoutQuotes(word), index};
       }

--- a/test/LocalVocabTest.cpp
+++ b/test/LocalVocabTest.cpp
@@ -37,13 +37,14 @@ namespace {
 
 using TestWords = std::vector<LocalVocabEntry>;
 
-TestWords getTestCollectionOfWords(size_t size, const IndexImpl& index) {
+TestWords getTestCollectionOfWords(size_t size,
+                                   const LocalVocabContext& context) {
   using namespace ad_utility::triple_component;
   TestWords testCollectionOfWords;
   for (size_t i = 0; i < size; ++i) {
     testCollectionOfWords.push_back(LocalVocabEntry{
         LiteralOrIri::literalWithoutQuotes(std::to_string(i * 7635475567ULL)),
-        index});
+        context});
   }
   return testCollectionOfWords;
 }

--- a/test/LocalVocabTest.cpp
+++ b/test/LocalVocabTest.cpp
@@ -58,7 +58,8 @@ auto lit(std::string_view s) {
 TEST(LocalVocab, constructionAndAccess) {
   auto* qec = ad_utility::testing::getQec();
   // Test collection of words.
-  TestWords testWords = getTestCollectionOfWords(1000, qec->getIndex());
+  TestWords testWords =
+      getTestCollectionOfWords(1000, qec->getLocalVocabContext());
 
   // Create empty local vocabulary.
   LocalVocab localVocab;
@@ -97,7 +98,7 @@ TEST(LocalVocab, constructionAndAccess) {
     auto illegalWord = LocalVocabEntry{
         ad_utility::triple_component::LiteralOrIri::literalWithoutQuotes(
             content + "A"),
-        qec->getIndex()};
+        qec->getLocalVocabContext()};
     ASSERT_FALSE(localVocab.getIndexOrNullopt(illegalWord));
   }
 
@@ -123,7 +124,8 @@ TEST(LocalVocab, clone) {
   size_t localVocabSize = 100;
   LocalVocab localVocabOriginal;
   std::vector<LocalVocabIndex> indices;
-  auto inputWords = getTestCollectionOfWords(localVocabSize, qec->getIndex());
+  auto inputWords =
+      getTestCollectionOfWords(localVocabSize, qec->getLocalVocabContext());
   for (const auto& word : inputWords) {
     indices.push_back(localVocabOriginal.getIndexAndAddIfNotContained(word));
   }
@@ -160,18 +162,18 @@ TEST(LocalVocab, merge) {
   LocalVocab vocA;
   LocalVocab vocB;
   auto* qec = ad_utility::testing::getQec();
-  const auto& index = qec->getIndex();
+  const auto& localVocabContext = qec->getLocalVocabContext();
   constexpr auto lit = [](std::string_view s) {
     return ad_utility::triple_component::LiteralOrIri::literalWithoutQuotes(s);
   };
-  indices.push_back(
-      vocA.getIndexAndAddIfNotContained(LocalVocabEntry{lit("oneA"), index}));
-  indices.push_back(
-      vocA.getIndexAndAddIfNotContained(LocalVocabEntry{lit("twoA"), index}));
-  indices.push_back(
-      vocA.getIndexAndAddIfNotContained(LocalVocabEntry{lit("oneB"), index}));
-  indices.push_back(
-      vocA.getIndexAndAddIfNotContained(LocalVocabEntry{lit("twoB"), index}));
+  indices.push_back(vocA.getIndexAndAddIfNotContained(
+      LocalVocabEntry{lit("oneA"), localVocabContext}));
+  indices.push_back(vocA.getIndexAndAddIfNotContained(
+      LocalVocabEntry{lit("twoA"), localVocabContext}));
+  indices.push_back(vocA.getIndexAndAddIfNotContained(
+      LocalVocabEntry{lit("oneB"), localVocabContext}));
+  indices.push_back(vocA.getIndexAndAddIfNotContained(
+      LocalVocabEntry{lit("twoB"), localVocabContext}));
 
   // Clone it and test that the clone contains the same words.
   auto vocabs = std::vector{&std::as_const(vocA), &std::as_const(vocB)};
@@ -229,13 +231,13 @@ TEST(LocalVocab, propagation) {
           ad_utility::source_location loc = AD_CURRENT_SOURCE_LOC()) -> void {
     auto t = generateLocationTrace(loc);
     TestWords expectedWords;
-    const auto& index = testQec->getIndex();
-    auto toLitOrIri = [&index](const auto& word) {
+    const auto& localVocabContext = testQec->getLocalVocabContext();
+    auto toLitOrIri = [&localVocabContext](const auto& word) {
       using namespace ad_utility::triple_component;
       if (ql::starts_with(word, '<')) {
-        return LocalVocabEntry::fromIriref(word, index);
+        return LocalVocabEntry::fromIriref(word, localVocabContext);
       } else {
-        return LocalVocabEntry::literalWithoutQuotes(word, index);
+        return LocalVocabEntry::literalWithoutQuotes(word, localVocabContext);
       }
     };
     ql::ranges::transform(expectedWordsAsStrings,
@@ -438,10 +440,10 @@ TEST(LocalVocab, getBlankNodeIndex) {
 TEST(LocalVocab, otherWordSetIsTransitivelyPropagated) {
   using ad_utility::triple_component::LiteralOrIri;
   auto* qec = ad_utility::testing::getQec();
-  const auto& index = qec->getIndex();
+  const auto& localVocabContext = qec->getLocalVocabContext();
   LocalVocab original;
   original.getIndexAndAddIfNotContained(
-      LocalVocabEntry::literalWithoutQuotes("test", index));
+      LocalVocabEntry::literalWithoutQuotes("test", localVocabContext));
 
   LocalVocab clone = original.clone();
   LocalVocab mergeCandidate;
@@ -458,10 +460,10 @@ TEST(LocalVocab, sizeIsProperlyUpdatedOnMerge) {
   using ad_utility::triple_component::LiteralOrIri;
   using ::testing::UnorderedElementsAre;
   auto* qec = ad_utility::testing::getQec();
-  const auto& index = qec->getIndex();
+  const auto& localVocabContext = qec->getLocalVocabContext();
   LocalVocab original;
   original.getIndexAndAddIfNotContained(
-      LocalVocabEntry::literalWithoutQuotes("test", index));
+      LocalVocabEntry::literalWithoutQuotes("test", localVocabContext));
 
   LocalVocab clone1 = original.clone();
   LocalVocab clone2 = original.clone();
@@ -487,35 +489,39 @@ TEST(LocalVocab, sizeIsProperlyUpdatedOnMerge) {
 TEST(LocalVocab, modificationIsBlockedAfterCloneOrMerge) {
   using ad_utility::triple_component::LiteralOrIri;
   auto* qec = ad_utility::testing::getQec();
-  const auto& index = qec->getIndex();
+  const auto& localVocabContext = qec->getLocalVocabContext();
   auto literal = LiteralOrIri::literalWithoutQuotes("test");
   auto otherLiteral = LiteralOrIri::literalWithoutQuotes("other");
   {
     LocalVocab original;
-    original.getIndexAndAddIfNotContained(LocalVocabEntry{literal, index});
+    original.getIndexAndAddIfNotContained(
+        LocalVocabEntry{literal, localVocabContext});
     (void)original.clone();
-    EXPECT_NE(original.getIndexOrNullopt(LocalVocabEntry{literal, index}),
-              std::nullopt);
-    EXPECT_THROW(
-        original.getIndexAndAddIfNotContained(LocalVocabEntry{literal, index}),
-        ad_utility::Exception);
+    EXPECT_NE(
+        original.getIndexOrNullopt(LocalVocabEntry{literal, localVocabContext}),
+        std::nullopt);
     EXPECT_THROW(original.getIndexAndAddIfNotContained(
-                     LocalVocabEntry{otherLiteral, index}),
+                     LocalVocabEntry{literal, localVocabContext}),
+                 ad_utility::Exception);
+    EXPECT_THROW(original.getIndexAndAddIfNotContained(
+                     LocalVocabEntry{otherLiteral, localVocabContext}),
                  ad_utility::Exception);
     EXPECT_EQ(original.size(), 1);
   }
   {
     LocalVocab original;
     LocalVocab other;
-    original.getIndexAndAddIfNotContained(LocalVocabEntry{literal, index});
+    original.getIndexAndAddIfNotContained(
+        LocalVocabEntry{literal, localVocabContext});
     other.mergeWith(original);
-    EXPECT_NE(original.getIndexOrNullopt(LocalVocabEntry{literal, index}),
-              std::nullopt);
-    EXPECT_THROW(
-        original.getIndexAndAddIfNotContained(LocalVocabEntry{literal, index}),
-        ad_utility::Exception);
+    EXPECT_NE(
+        original.getIndexOrNullopt(LocalVocabEntry{literal, localVocabContext}),
+        std::nullopt);
     EXPECT_THROW(original.getIndexAndAddIfNotContained(
-                     LocalVocabEntry{otherLiteral, index}),
+                     LocalVocabEntry{literal, localVocabContext}),
+                 ad_utility::Exception);
+    EXPECT_THROW(original.getIndexAndAddIfNotContained(
+                     LocalVocabEntry{otherLiteral, localVocabContext}),
                  ad_utility::Exception);
     EXPECT_EQ(original.size(), 1);
   }
@@ -525,7 +531,7 @@ TEST(LocalVocab, modificationIsBlockedAfterCloneOrMerge) {
 TEST(LocalVocab, modificationIsNotBlockedAfterAcquiringHolder) {
   using ad_utility::triple_component::LiteralOrIri;
   auto* qec = ad_utility::testing::getQec();
-  const auto& index = qec->getIndex();
+  const auto& localVocabContext = qec->getLocalVocabContext();
   auto literal = LiteralOrIri::literalWithoutQuotes("test");
   auto otherLiteral = LiteralOrIri::literalWithoutQuotes("other");
   std::optional<LocalVocab::LifetimeExtender> extender = std::nullopt;
@@ -533,20 +539,21 @@ TEST(LocalVocab, modificationIsNotBlockedAfterAcquiringHolder) {
   LocalVocabIndex encodedOther;
   {
     LocalVocab original;
-    encodedTest =
-        original.getIndexAndAddIfNotContained(LocalVocabEntry{literal, index});
+    encodedTest = original.getIndexAndAddIfNotContained(
+        LocalVocabEntry{literal, localVocabContext});
     extender = original.getLifetimeExtender();
 
-    EXPECT_EQ(original.getIndexOrNullopt(LocalVocabEntry{literal, index}),
-              std::optional{encodedTest});
-
     EXPECT_EQ(
-        original.getIndexAndAddIfNotContained(LocalVocabEntry{literal, index}),
-        encodedTest);
+        original.getIndexOrNullopt(LocalVocabEntry{literal, localVocabContext}),
+        std::optional{encodedTest});
+
+    EXPECT_EQ(original.getIndexAndAddIfNotContained(
+                  LocalVocabEntry{literal, localVocabContext}),
+              encodedTest);
     EXPECT_EQ(original.size(), 1);
 
     encodedOther = original.getIndexAndAddIfNotContained(
-        LocalVocabEntry{otherLiteral, index});
+        LocalVocabEntry{otherLiteral, localVocabContext});
     EXPECT_EQ(original.size(), 2);
   }
   // The `extender` keeps the `LocalVocabIndex`es valid even though the

--- a/test/LocalVocabTest.cpp
+++ b/test/LocalVocabTest.cpp
@@ -42,9 +42,8 @@ TestWords getTestCollectionOfWords(size_t size,
   using namespace ad_utility::triple_component;
   TestWords testCollectionOfWords;
   for (size_t i = 0; i < size; ++i) {
-    testCollectionOfWords.push_back(LocalVocabEntry{
-        LiteralOrIri::literalWithoutQuotes(std::to_string(i * 7635475567ULL)),
-        context});
+    testCollectionOfWords.push_back(LocalVocabEntry::literalWithoutQuotes(
+        std::to_string(i * 7635475567ULL), context));
   }
   return testCollectionOfWords;
 }
@@ -236,7 +235,7 @@ TEST(LocalVocab, propagation) {
       if (ql::starts_with(word, '<')) {
         return LocalVocabEntry::fromIriref(word, index);
       } else {
-        return LocalVocabEntry{LiteralOrIri::literalWithoutQuotes(word), index};
+        return LocalVocabEntry::literalWithoutQuotes(word, index);
       }
     };
     ql::ranges::transform(expectedWordsAsStrings,
@@ -442,7 +441,7 @@ TEST(LocalVocab, otherWordSetIsTransitivelyPropagated) {
   const auto& index = qec->getIndex();
   LocalVocab original;
   original.getIndexAndAddIfNotContained(
-      LocalVocabEntry{LiteralOrIri::literalWithoutQuotes("test"), index});
+      LocalVocabEntry::literalWithoutQuotes("test", index));
 
   LocalVocab clone = original.clone();
   LocalVocab mergeCandidate;
@@ -462,7 +461,7 @@ TEST(LocalVocab, sizeIsProperlyUpdatedOnMerge) {
   const auto& index = qec->getIndex();
   LocalVocab original;
   original.getIndexAndAddIfNotContained(
-      LocalVocabEntry{LiteralOrIri::literalWithoutQuotes("test"), index});
+      LocalVocabEntry::literalWithoutQuotes("test", index));
 
   LocalVocab clone1 = original.clone();
   LocalVocab clone2 = original.clone();

--- a/test/LocalVocabTest.cpp
+++ b/test/LocalVocabTest.cpp
@@ -95,10 +95,8 @@ TEST(LocalVocab, constructionAndAccess) {
   // in our test vocabulary only contain digits as letters, see above.
   for (size_t i = 0; i < testWords.size(); ++i) {
     std::string content{asStringViewUnsafe(testWords[i].getContent())};
-    auto illegalWord = LocalVocabEntry{
-        ad_utility::triple_component::LiteralOrIri::literalWithoutQuotes(
-            content + "A"),
-        qec->getLocalVocabContext()};
+    auto illegalWord = LocalVocabEntry::literalWithoutQuotes(
+        content + "A", qec->getLocalVocabContext());
     ASSERT_FALSE(localVocab.getIndexOrNullopt(illegalWord));
   }
 

--- a/test/MaterializedViewsTest.cpp
+++ b/test/MaterializedViewsTest.cpp
@@ -38,6 +38,7 @@
 #include "rdfTypes/Literal.h"
 #include "util/AllocatorWithLimit.h"
 #include "util/CancellationHandle.h"
+#include "util/CompilerWarnings.h"
 #include "util/GTestHelpers.h"
 #include "util/IdTableHelpers.h"
 
@@ -348,8 +349,10 @@ TEST_F(MaterializedViewsTest, ColumnPermutation) {
   // Helper to get all column names from a view via its `VariableToColumnMap`.
   auto columnNames = [](const MaterializedView& view) {
     const auto& varToCol = view.variableToColumnMap();
+    DISABLE_AGGRESSIVE_LOOP_OPT_WARNINGS
     std::vector<Variable> vars =
         varToCol | ql::views::keys | ::ranges::to<std::vector>();
+    GCC_REENABLE_WARNINGS
     ql::ranges::sort(
         vars.begin(), vars.end(), [&](const auto& a, const auto& b) {
           return varToCol.at(a).columnIndex_ < varToCol.at(b).columnIndex_;

--- a/test/MinusTest.cpp
+++ b/test/MinusTest.cpp
@@ -148,17 +148,13 @@ TEST(Minus, ensureLocalVocabFromLeftIsPassed) {
   const auto& index = qec->getIndex();
   IdTable a = makeIdTableFromVector({{0}, {1}, {2}, {3}, {4}});
   IdTable b = makeIdTableFromVector({{0}});
-  LocalVocabEntry aEntry = LocalVocabEntry{
-      ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
-          "\"a\""),
-      index};
+  LocalVocabEntry aEntry =
+      LocalVocabEntry::fromStringRepresentation("\"a\"", index);
   LocalVocab vocabA;
   vocabA.getIndexAndAddIfNotContained(aEntry);
   LocalVocab vocabB;
-  vocabB.getIndexAndAddIfNotContained(LocalVocabEntry{
-      ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
-          "\"b\""),
-      index});
+  vocabB.getIndexAndAddIfNotContained(
+      LocalVocabEntry::fromStringRepresentation("\"b\"", index));
 
   Minus m{qec,
           ad_utility::makeExecutionTree<ValuesForTesting>(
@@ -677,18 +673,14 @@ TEST(Minus, lazyMinusWithPermutedColumns) {
 TEST(Minus, lazyMinusKeepsLeftLocalVocab) {
   auto qec = ad_utility::testing::getQec();
 
-  LocalVocabEntry testLiteral{
-      ad_utility::triple_component::Literal::fromStringRepresentation(
-          "\"Abc\""),
-      qec->getIndex()};
+  LocalVocabEntry testLiteral =
+      LocalVocabEntry::fromStringRepresentation("\"Abc\"", qec->getIndex());
 
   LocalVocab leftVocab{};
   leftVocab.getIndexAndAddIfNotContained(testLiteral);
   LocalVocab rightVocab{};
-  rightVocab.getIndexAndAddIfNotContained(LocalVocabEntry{
-      ad_utility::triple_component::Literal::fromStringRepresentation(
-          "\"Def\""),
-      qec->getIndex()});
+  rightVocab.getIndexAndAddIfNotContained(
+      LocalVocabEntry::fromStringRepresentation("\"Def\"", qec->getIndex()));
 
   auto expected = makeIdTableFromVector({{1, 11, 111}, {3, 33, 333}});
 
@@ -771,10 +763,8 @@ struct Wrapper {
 TEST(Minus, MinusRowHandlerKeepsLeftLocalVocabAfterFlush) {
   auto qec = ad_utility::testing::getQec();
 
-  LocalVocabEntry testLiteral{
-      ad_utility::triple_component::Literal::fromStringRepresentation(
-          "\"Abc\""),
-      qec->getIndex()};
+  LocalVocabEntry testLiteral =
+      LocalVocabEntry::fromStringRepresentation("\"Abc\"", qec->getIndex());
 
   LocalVocab leftVocab{};
   leftVocab.getIndexAndAddIfNotContained(testLiteral);

--- a/test/MinusTest.cpp
+++ b/test/MinusTest.cpp
@@ -175,14 +175,10 @@ TEST(Minus, ensureLocalVocabFromLeftIsPassed) {
 TEST(Minus, computeMinusLeftIndexNestedLoopJoinOptimization) {
   auto* qec = ad_utility::testing::getQec();
   const auto& index = qec->getIndex();
-  LocalVocabEntry entryA{
-      ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
-          "\"a\""),
-      index};
-  LocalVocabEntry entryB{
-      ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
-          "\"b\""),
-      index};
+  LocalVocabEntry entryA =
+      LocalVocabEntry::fromStringRepresentation("\"a\"", index);
+  LocalVocabEntry entryB =
+      LocalVocabEntry::fromStringRepresentation("\"b\"", index);
 
   LocalVocab leftVocab;
   leftVocab.getIndexAndAddIfNotContained(entryA);
@@ -234,14 +230,10 @@ TEST(Minus, computeMinusLeftIndexNestedLoopJoinOptimization) {
 TEST(Minus, computeMinusRightIndexNestedLoopJoinOptimization) {
   auto* qec = ad_utility::testing::getQec();
   const auto& index = qec->getIndex();
-  LocalVocabEntry entryA{
-      ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
-          "\"a\""),
-      index};
-  LocalVocabEntry entryB{
-      ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
-          "\"b\""),
-      index};
+  LocalVocabEntry entryA =
+      LocalVocabEntry::fromStringRepresentation("\"a\"", index);
+  LocalVocabEntry entryB =
+      LocalVocabEntry::fromStringRepresentation("\"b\"", index);
 
   LocalVocab leftVocab;
   leftVocab.getIndexAndAddIfNotContained(entryA);

--- a/test/MinusTest.cpp
+++ b/test/MinusTest.cpp
@@ -677,11 +677,10 @@ TEST(Minus, lazyMinusWithPermutedColumns) {
 TEST(Minus, lazyMinusKeepsLeftLocalVocab) {
   auto qec = ad_utility::testing::getQec();
 
-  const auto& indexImpl = qec->getIndex().getImpl();
   LocalVocabEntry testLiteral{
       ad_utility::triple_component::Literal::fromStringRepresentation(
           "\"Abc\""),
-      indexImpl};
+      qec->getIndex()};
 
   LocalVocab leftVocab{};
   leftVocab.getIndexAndAddIfNotContained(testLiteral);
@@ -689,7 +688,7 @@ TEST(Minus, lazyMinusKeepsLeftLocalVocab) {
   rightVocab.getIndexAndAddIfNotContained(LocalVocabEntry{
       ad_utility::triple_component::Literal::fromStringRepresentation(
           "\"Def\""),
-      indexImpl});
+      qec->getIndex()});
 
   auto expected = makeIdTableFromVector({{1, 11, 111}, {3, 33, 333}});
 
@@ -771,12 +770,11 @@ struct Wrapper {
 // _____________________________________________________________________________
 TEST(Minus, MinusRowHandlerKeepsLeftLocalVocabAfterFlush) {
   auto qec = ad_utility::testing::getQec();
-  const auto& indexImpl = qec->getIndex().getImpl();
 
   LocalVocabEntry testLiteral{
       ad_utility::triple_component::Literal::fromStringRepresentation(
           "\"Abc\""),
-      indexImpl};
+      qec->getIndex()};
 
   LocalVocab leftVocab{};
   leftVocab.getIndexAndAddIfNotContained(testLiteral);

--- a/test/MinusTest.cpp
+++ b/test/MinusTest.cpp
@@ -144,22 +144,22 @@ TEST(Minus, computeMinus) {
 
 // _____________________________________________________________________________
 TEST(Minus, ensureLocalVocabFromLeftIsPassed) {
-  const auto& indexImpl = ad_utility::testing::getQec()->getIndex().getImpl();
+  auto* qec = ad_utility::testing::getQec();
+  const auto& index = qec->getIndex();
   IdTable a = makeIdTableFromVector({{0}, {1}, {2}, {3}, {4}});
   IdTable b = makeIdTableFromVector({{0}});
   LocalVocabEntry aEntry = LocalVocabEntry{
       ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
           "\"a\""),
-      indexImpl};
+      index};
   LocalVocab vocabA;
   vocabA.getIndexAndAddIfNotContained(aEntry);
   LocalVocab vocabB;
   vocabB.getIndexAndAddIfNotContained(LocalVocabEntry{
       ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
           "\"b\""),
-      indexImpl});
+      index});
 
-  auto* qec = ad_utility::testing::getQec();
   Minus m{qec,
           ad_utility::makeExecutionTree<ValuesForTesting>(
               qec, std::move(a),
@@ -177,15 +177,16 @@ TEST(Minus, ensureLocalVocabFromLeftIsPassed) {
 
 // _____________________________________________________________________________
 TEST(Minus, computeMinusLeftIndexNestedLoopJoinOptimization) {
-  const auto& indexImpl = ad_utility::testing::getQec()->getIndex().getImpl();
+  auto* qec = ad_utility::testing::getQec();
+  const auto& index = qec->getIndex();
   LocalVocabEntry entryA{
       ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
           "\"a\""),
-      indexImpl};
+      index};
   LocalVocabEntry entryB{
       ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
           "\"b\""),
-      indexImpl};
+      index};
 
   LocalVocab leftVocab;
   leftVocab.getIndexAndAddIfNotContained(entryA);
@@ -207,7 +208,6 @@ TEST(Minus, computeMinusLeftIndexNestedLoopJoinOptimization) {
                                      {14, 15, 16, 17}});
   IdTable expected = makeIdTableFromVector({{4, 2, 1}, {2, 8, 1}});
 
-  auto* qec = ad_utility::testing::getQec();
   for (bool forceFullyMaterialized : {false, true}) {
     qec->getQueryTreeCache().clearAll();
     Minus m{qec,
@@ -236,15 +236,16 @@ TEST(Minus, computeMinusLeftIndexNestedLoopJoinOptimization) {
 
 // _____________________________________________________________________________
 TEST(Minus, computeMinusRightIndexNestedLoopJoinOptimization) {
-  const auto& indexImpl = ad_utility::testing::getQec()->getIndex().getImpl();
+  auto* qec = ad_utility::testing::getQec();
+  const auto& index = qec->getIndex();
   LocalVocabEntry entryA{
       ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
           "\"a\""),
-      indexImpl};
+      index};
   LocalVocabEntry entryB{
       ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
           "\"b\""),
-      indexImpl};
+      index};
 
   LocalVocab leftVocab;
   leftVocab.getIndexAndAddIfNotContained(entryA);
@@ -267,7 +268,6 @@ TEST(Minus, computeMinusRightIndexNestedLoopJoinOptimization) {
   IdTable expected = makeIdTableFromVector(
       {{1, 3, 3, 5}, {1, 8, 1, 5}, {10, 11, 12, 13}, {14, 15, 16, 17}});
 
-  auto* qec = ad_utility::testing::getQec();
   for (bool requestLaziness : {false, true}) {
     qec->getQueryTreeCache().clearAll();
     Minus m{qec,

--- a/test/MinusTest.cpp
+++ b/test/MinusTest.cpp
@@ -144,14 +144,20 @@ TEST(Minus, computeMinus) {
 
 // _____________________________________________________________________________
 TEST(Minus, ensureLocalVocabFromLeftIsPassed) {
+  const auto& indexImpl = ad_utility::testing::getQec()->getIndex().getImpl();
   IdTable a = makeIdTableFromVector({{0}, {1}, {2}, {3}, {4}});
   IdTable b = makeIdTableFromVector({{0}});
-  LocalVocabEntry aEntry = LocalVocabEntry::fromStringRepresentation("\"a\"");
+  LocalVocabEntry aEntry = LocalVocabEntry{
+      ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
+          "\"a\""),
+      indexImpl};
   LocalVocab vocabA;
   vocabA.getIndexAndAddIfNotContained(aEntry);
   LocalVocab vocabB;
-  vocabB.getIndexAndAddIfNotContained(
-      LocalVocabEntry::fromStringRepresentation("\"b\""));
+  vocabB.getIndexAndAddIfNotContained(LocalVocabEntry{
+      ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
+          "\"b\""),
+      indexImpl});
 
   auto* qec = ad_utility::testing::getQec();
   Minus m{qec,
@@ -171,8 +177,15 @@ TEST(Minus, ensureLocalVocabFromLeftIsPassed) {
 
 // _____________________________________________________________________________
 TEST(Minus, computeMinusLeftIndexNestedLoopJoinOptimization) {
-  LocalVocabEntry entryA = LocalVocabEntry::fromStringRepresentation("\"a\"");
-  LocalVocabEntry entryB = LocalVocabEntry::fromStringRepresentation("\"b\"");
+  const auto& indexImpl = ad_utility::testing::getQec()->getIndex().getImpl();
+  LocalVocabEntry entryA{
+      ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
+          "\"a\""),
+      indexImpl};
+  LocalVocabEntry entryB{
+      ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
+          "\"b\""),
+      indexImpl};
 
   LocalVocab leftVocab;
   leftVocab.getIndexAndAddIfNotContained(entryA);
@@ -223,8 +236,15 @@ TEST(Minus, computeMinusLeftIndexNestedLoopJoinOptimization) {
 
 // _____________________________________________________________________________
 TEST(Minus, computeMinusRightIndexNestedLoopJoinOptimization) {
-  LocalVocabEntry entryA = LocalVocabEntry::fromStringRepresentation("\"a\"");
-  LocalVocabEntry entryB = LocalVocabEntry::fromStringRepresentation("\"b\"");
+  const auto& indexImpl = ad_utility::testing::getQec()->getIndex().getImpl();
+  LocalVocabEntry entryA{
+      ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
+          "\"a\""),
+      indexImpl};
+  LocalVocabEntry entryB{
+      ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
+          "\"b\""),
+      indexImpl};
 
   LocalVocab leftVocab;
   leftVocab.getIndexAndAddIfNotContained(entryA);
@@ -657,16 +677,19 @@ TEST(Minus, lazyMinusWithPermutedColumns) {
 TEST(Minus, lazyMinusKeepsLeftLocalVocab) {
   auto qec = ad_utility::testing::getQec();
 
+  const auto& indexImpl = qec->getIndex().getImpl();
   LocalVocabEntry testLiteral{
       ad_utility::triple_component::Literal::fromStringRepresentation(
-          "\"Abc\"")};
+          "\"Abc\""),
+      indexImpl};
 
   LocalVocab leftVocab{};
   leftVocab.getIndexAndAddIfNotContained(testLiteral);
   LocalVocab rightVocab{};
   rightVocab.getIndexAndAddIfNotContained(LocalVocabEntry{
       ad_utility::triple_component::Literal::fromStringRepresentation(
-          "\"Def\"")});
+          "\"Def\""),
+      indexImpl});
 
   auto expected = makeIdTableFromVector({{1, 11, 111}, {3, 33, 333}});
 
@@ -748,10 +771,12 @@ struct Wrapper {
 // _____________________________________________________________________________
 TEST(Minus, MinusRowHandlerKeepsLeftLocalVocabAfterFlush) {
   auto qec = ad_utility::testing::getQec();
+  const auto& indexImpl = qec->getIndex().getImpl();
 
   LocalVocabEntry testLiteral{
       ad_utility::triple_component::Literal::fromStringRepresentation(
-          "\"Abc\"")};
+          "\"Abc\""),
+      indexImpl};
 
   LocalVocab leftVocab{};
   leftVocab.getIndexAndAddIfNotContained(testLiteral);

--- a/test/MinusTest.cpp
+++ b/test/MinusTest.cpp
@@ -145,16 +145,16 @@ TEST(Minus, computeMinus) {
 // _____________________________________________________________________________
 TEST(Minus, ensureLocalVocabFromLeftIsPassed) {
   auto* qec = ad_utility::testing::getQec();
-  const auto& index = qec->getIndex();
+  const auto& localVocabContext = qec->getLocalVocabContext();
   IdTable a = makeIdTableFromVector({{0}, {1}, {2}, {3}, {4}});
   IdTable b = makeIdTableFromVector({{0}});
   LocalVocabEntry aEntry =
-      LocalVocabEntry::fromStringRepresentation("\"a\"", index);
+      LocalVocabEntry::fromStringRepresentation("\"a\"", localVocabContext);
   LocalVocab vocabA;
   vocabA.getIndexAndAddIfNotContained(aEntry);
   LocalVocab vocabB;
   vocabB.getIndexAndAddIfNotContained(
-      LocalVocabEntry::fromStringRepresentation("\"b\"", index));
+      LocalVocabEntry::fromStringRepresentation("\"b\"", localVocabContext));
 
   Minus m{qec,
           ad_utility::makeExecutionTree<ValuesForTesting>(
@@ -174,11 +174,11 @@ TEST(Minus, ensureLocalVocabFromLeftIsPassed) {
 // _____________________________________________________________________________
 TEST(Minus, computeMinusLeftIndexNestedLoopJoinOptimization) {
   auto* qec = ad_utility::testing::getQec();
-  const auto& index = qec->getIndex();
+  const auto& localVocabContext = qec->getLocalVocabContext();
   LocalVocabEntry entryA =
-      LocalVocabEntry::fromStringRepresentation("\"a\"", index);
+      LocalVocabEntry::fromStringRepresentation("\"a\"", localVocabContext);
   LocalVocabEntry entryB =
-      LocalVocabEntry::fromStringRepresentation("\"b\"", index);
+      LocalVocabEntry::fromStringRepresentation("\"b\"", localVocabContext);
 
   LocalVocab leftVocab;
   leftVocab.getIndexAndAddIfNotContained(entryA);
@@ -229,11 +229,11 @@ TEST(Minus, computeMinusLeftIndexNestedLoopJoinOptimization) {
 // _____________________________________________________________________________
 TEST(Minus, computeMinusRightIndexNestedLoopJoinOptimization) {
   auto* qec = ad_utility::testing::getQec();
-  const auto& index = qec->getIndex();
+  const auto& localVocabContext = qec->getLocalVocabContext();
   LocalVocabEntry entryA =
-      LocalVocabEntry::fromStringRepresentation("\"a\"", index);
+      LocalVocabEntry::fromStringRepresentation("\"a\"", localVocabContext);
   LocalVocabEntry entryB =
-      LocalVocabEntry::fromStringRepresentation("\"b\"", index);
+      LocalVocabEntry::fromStringRepresentation("\"b\"", localVocabContext);
 
   LocalVocab leftVocab;
   leftVocab.getIndexAndAddIfNotContained(entryA);
@@ -665,14 +665,15 @@ TEST(Minus, lazyMinusWithPermutedColumns) {
 TEST(Minus, lazyMinusKeepsLeftLocalVocab) {
   auto qec = ad_utility::testing::getQec();
 
-  LocalVocabEntry testLiteral =
-      LocalVocabEntry::fromStringRepresentation("\"Abc\"", qec->getIndex());
+  LocalVocabEntry testLiteral = LocalVocabEntry::fromStringRepresentation(
+      "\"Abc\"", qec->getLocalVocabContext());
 
   LocalVocab leftVocab{};
   leftVocab.getIndexAndAddIfNotContained(testLiteral);
   LocalVocab rightVocab{};
   rightVocab.getIndexAndAddIfNotContained(
-      LocalVocabEntry::fromStringRepresentation("\"Def\"", qec->getIndex()));
+      LocalVocabEntry::fromStringRepresentation("\"Def\"",
+                                                qec->getLocalVocabContext()));
 
   auto expected = makeIdTableFromVector({{1, 11, 111}, {3, 33, 333}});
 
@@ -755,8 +756,8 @@ struct Wrapper {
 TEST(Minus, MinusRowHandlerKeepsLeftLocalVocabAfterFlush) {
   auto qec = ad_utility::testing::getQec();
 
-  LocalVocabEntry testLiteral =
-      LocalVocabEntry::fromStringRepresentation("\"Abc\"", qec->getIndex());
+  LocalVocabEntry testLiteral = LocalVocabEntry::fromStringRepresentation(
+      "\"Abc\"", qec->getLocalVocabContext());
 
   LocalVocab leftVocab{};
   leftVocab.getIndexAndAddIfNotContained(testLiteral);

--- a/test/OperationTest.cpp
+++ b/test/OperationTest.cpp
@@ -434,7 +434,8 @@ TEST(Operation, verifyRuntimeInformationIsUpdatedForLazyOperations) {
   idTablesVector.push_back(makeIdTableFromVector({{7, 8}}));
   LocalVocab localVocab{};
   localVocab.getIndexAndAddIfNotContained(LocalVocabEntry{
-      ad_utility::triple_component::Literal::literalWithoutQuotes("Test")});
+      ad_utility::triple_component::Literal::literalWithoutQuotes("Test"),
+      qec->getIndex().getImpl()});
   ValuesForTesting valuesForTesting{
       qec,   std::move(idTablesVector),  {Variable{"?x"}, Variable{"?y"}},
       false, std::vector<ColumnIndex>{}, std::move(localVocab)};

--- a/test/OperationTest.cpp
+++ b/test/OperationTest.cpp
@@ -435,7 +435,7 @@ TEST(Operation, verifyRuntimeInformationIsUpdatedForLazyOperations) {
   LocalVocab localVocab{};
   localVocab.getIndexAndAddIfNotContained(LocalVocabEntry{
       ad_utility::triple_component::Literal::literalWithoutQuotes("Test"),
-      qec->getIndex()});
+      qec->getLocalVocabContext()});
   ValuesForTesting valuesForTesting{
       qec,   std::move(idTablesVector),  {Variable{"?x"}, Variable{"?y"}},
       false, std::vector<ColumnIndex>{}, std::move(localVocab)};

--- a/test/OperationTest.cpp
+++ b/test/OperationTest.cpp
@@ -435,7 +435,7 @@ TEST(Operation, verifyRuntimeInformationIsUpdatedForLazyOperations) {
   LocalVocab localVocab{};
   localVocab.getIndexAndAddIfNotContained(LocalVocabEntry{
       ad_utility::triple_component::Literal::literalWithoutQuotes("Test"),
-      qec->getIndex().getImpl()});
+      qec->getIndex()});
   ValuesForTesting valuesForTesting{
       qec,   std::move(idTablesVector),  {Variable{"?x"}, Variable{"?y"}},
       false, std::vector<ColumnIndex>{}, std::move(localVocab)};

--- a/test/PrefilterExpressionIndexTest.cpp
+++ b/test/PrefilterExpressionIndexTest.cpp
@@ -117,7 +117,7 @@ class PrefilterExpressionOnMetadataTest : public ::testing::Test {
   // Given that we depend on LocalVocab and Vocab values during evaluation an
   // active Index + global vocabulary is required.
   QueryExecutionContext* qet = ad_utility::testing::getQec(turtleInput);
-  const Index& idx = qet->getIndex();
+  const LocalVocabContext& lvc = qet->getLocalVocabContext();
   std::function<Id(const std::string&)> getVocabId =
       ad_utility::testing::makeGetId(qet->getIndex());
   LocalVocab vocab{};
@@ -127,22 +127,22 @@ class PrefilterExpressionOnMetadataTest : public ::testing::Test {
   const Id falseId = BoolId(false);
   const Id trueId = BoolId(true);
   const Id referenceDateEqual = DateId(DateParser, "2000-01-01");
-  const LocalVocabEntry augsburg = LVE("\"Augsburg\"", idx);
-  const LocalVocabEntry berlin = LVE("\"Berlin\"", idx);
-  const LocalVocabEntry düsseldorf = LVE("\"Düsseldorf\"", idx);
-  const LocalVocabEntry frankfurt = LVE("\"Frankfurt\"", idx);
-  const LocalVocabEntry hamburg = LVE("\"Hamburg\"", idx);
-  const LocalVocabEntry köln = LVE("\"Köln\"", idx);
-  const LocalVocabEntry münchen = LVE("\"München\"", idx);
-  const LocalVocabEntry stuttgart = LVE("\"Stuttgart\"", idx);
-  const LocalVocabEntry wolfsburg = LVE("\"Wolfsburg\"", idx);
-  const LocalVocabEntry iri0 = LVE("<a>", idx);
-  const LocalVocabEntry iri1 = LVE("<iri>", idx);
-  const LocalVocabEntry iri2 = LVE("<iri>", idx);
-  const LocalVocabEntry iri3 = LVE("<randomiriref>", idx);
-  const LocalVocabEntry iri4 = LVE("<someiri>", idx);
-  const LocalVocabEntry iri5 = LVE("<www-iri.de>", idx);
-  const LocalVocabEntry iriBegin = LVE("<", idx);
+  const LocalVocabEntry augsburg = LVE("\"Augsburg\"", lvc);
+  const LocalVocabEntry berlin = LVE("\"Berlin\"", lvc);
+  const LocalVocabEntry düsseldorf = LVE("\"Düsseldorf\"", lvc);
+  const LocalVocabEntry frankfurt = LVE("\"Frankfurt\"", lvc);
+  const LocalVocabEntry hamburg = LVE("\"Hamburg\"", lvc);
+  const LocalVocabEntry köln = LVE("\"Köln\"", lvc);
+  const LocalVocabEntry münchen = LVE("\"München\"", lvc);
+  const LocalVocabEntry stuttgart = LVE("\"Stuttgart\"", lvc);
+  const LocalVocabEntry wolfsburg = LVE("\"Wolfsburg\"", lvc);
+  const LocalVocabEntry iri0 = LVE("<a>", lvc);
+  const LocalVocabEntry iri1 = LVE("<iri>", lvc);
+  const LocalVocabEntry iri2 = LVE("<iri>", lvc);
+  const LocalVocabEntry iri3 = LVE("<randomiriref>", lvc);
+  const LocalVocabEntry iri4 = LVE("<someiri>", lvc);
+  const LocalVocabEntry iri5 = LVE("<www-iri.de>", lvc);
+  const LocalVocabEntry iriBegin = LVE("<", lvc);
   const Id idAugsburg = getId(augsburg, vocab);
   const Id vocabIdBe = getVocabId("\"Be\"");
   const Id vocabIdBern = getVocabId("\"Bern\"");
@@ -156,12 +156,12 @@ class PrefilterExpressionOnMetadataTest : public ::testing::Test {
   const Id vocabIdMünchen = getVocabId("\"München\"");
   const Id vocabIdStuttgart = getVocabId("\"Stuttgart\"");
   const Id idWolfsburg = getId(wolfsburg, vocab);
-  const Id idB = getId(LVE("\"B\"", idx), vocab);
-  const Id idBe = getId(LVE("\"Be\"", idx), vocab);
-  const Id idBerl = getId(LVE("\"Berl\"", idx), vocab);
-  const Id idHamburgAlt = getId(LVE("\"Hamburg Alt\"", idx), vocab);
+  const Id idB = getId(LVE("\"B\"", lvc), vocab);
+  const Id idBe = getId(LVE("\"Be\"", lvc), vocab);
+  const Id idBerl = getId(LVE("\"Berl\"", lvc), vocab);
+  const Id idHamburgAlt = getId(LVE("\"Hamburg Alt\"", lvc), vocab);
   const Id idStuttgartZuffenhausen =
-      getId(LVE("\"Stuttgart-Zuffenhausen\"", idx), vocab);
+      getId(LVE("\"Stuttgart-Zuffenhausen\"", lvc), vocab);
   const Id idBerlin = getId(berlin, vocab);
   const Id idDüsseldorf = getId(düsseldorf, vocab);
   const Id idFrankfurt = getId(frankfurt, vocab);
@@ -409,7 +409,7 @@ class PrefilterExpressionOnMetadataTest : public ::testing::Test {
                           size_t evaluationColumn = 2) {
     std::vector<CompressedBlockMetadata> testBlocks = input;
     AD_EXPECT_THROW_WITH_MESSAGE(
-        expr->evaluate(idx, testBlocks, evaluationColumn),
+        expr->evaluate(lvc, testBlocks, evaluationColumn),
         ::testing::HasSubstr(expected));
   }
 
@@ -433,7 +433,7 @@ class PrefilterExpressionOnMetadataTest : public ::testing::Test {
     }
     std::vector<CompressedBlockMetadata> testBlocks =
         useBlocksIncomplete ? blocksIncomplete : blocks;
-    ASSERT_EQ(toVec(expr->evaluate(idx, testBlocks, 2)),
+    ASSERT_EQ(toVec(expr->evaluate(lvc, testBlocks, 2)),
               addMixedBlocks ? expectedAdjusted : expected);
   }
 
@@ -459,7 +459,7 @@ class PrefilterExpressionOnMetadataTest : public ::testing::Test {
             ? addBlocksMixedDatatype(expected, mixedBlocksTestIsDatatype)
             : expected;
     ASSERT_EQ(toVec(expr->evaluate(
-                  idx, input.empty() ? allTestBlocksIsDatatype : input, 2)),
+                  lvc, input.empty() ? allTestBlocksIsDatatype : input, 2)),
               adjustedExpected);
   }
 
@@ -502,13 +502,13 @@ class PrefilterExpressionOnMetadataTest : public ::testing::Test {
   // Simple `ASSERT_EQ` on date blocks
   auto makeTestDate(std::unique_ptr<PrefilterExpression> expr,
                     std::vector<CompressedBlockMetadata>&& expected) {
-    ASSERT_EQ(toVec(expr->evaluate(idx, dateBlocks, 2)), expected);
+    ASSERT_EQ(toVec(expr->evaluate(lvc, dateBlocks, 2)), expected);
   }
 
   // Simple `ASSERT_EQ` VocabIdBlocks
   auto makeTestPrefixRegex(std::unique_ptr<PrefilterExpression> expr,
                            std::vector<CompressedBlockMetadata>&& expected) {
-    ASSERT_EQ(toVec(expr->evaluate(idx, blocksRegexTest, 2)), expected);
+    ASSERT_EQ(toVec(expr->evaluate(lvc, blocksRegexTest, 2)), expected);
   }
 
   // Test `PrefilterExpression` helper `mergeRelevantBlockItRanges<bool>`.
@@ -666,7 +666,7 @@ TEST_F(PrefilterExpressionOnMetadataTest, testLessEqualExpressions) {
   makeTest(le(DoubleId(3.1415)), {b6, b9, b10, b11, b15, b16, b17, b18});
   makeTest(le(DoubleId(-11.99999999999999)), {b17, b18}, true);
   makeTest(le(DoubleId(-14.03)), {b18});
-  makeTest(le(LVE("\"Aachen\"", idx)), {b18});
+  makeTest(le(LVE("\"Aachen\"", lvc)), {b18});
   makeTest(le(frankfurt), {b18, b19});
   makeTest(le(hamburg), {b18, b19, b21}, true);
   makeTest(le(undef), {});
@@ -1195,7 +1195,7 @@ TEST_F(PrefilterExpressionOnMetadataTest, testInputConditionCheck) {
 // Test the (full) invariant check of `ScanSpecAndBlocks` constructor.
 TEST_F(PrefilterExpressionOnMetadataTest,
        testScanSpecAndBlocksConstructionFromPrefilteredBlocks) {
-  auto blockRanges = gt(IntId(0))->evaluate(idx, blocks, 2);
+  auto blockRanges = gt(IntId(0))->evaluate(lvc, blocks, 2);
   ASSERT_NO_THROW(CompressedRelationReader::ScanSpecAndBlocks(
       ScanSpecification{VocabId10, DoubleId33, std::nullopt}, blockRanges));
   ASSERT_NO_THROW(CompressedRelationReader::ScanSpecAndBlocks(
@@ -1217,16 +1217,16 @@ TEST_F(PrefilterExpressionOnMetadataTest,
 TEST_F(PrefilterExpressionOnMetadataTest, testWithFewBlockMetadataValues) {
   auto expr = orExpr(eq(DoubleId(-6.25)), eq(IntId(0)));
   std::vector<CompressedBlockMetadata> input = {b16};
-  EXPECT_EQ(toVec(expr->evaluate(idx, input, 0)), input);
-  EXPECT_EQ(toVec(expr->evaluate(idx, input, 1)), input);
-  EXPECT_EQ(toVec(expr->evaluate(idx, input, 2)), input);
+  EXPECT_EQ(toVec(expr->evaluate(lvc, input, 0)), input);
+  EXPECT_EQ(toVec(expr->evaluate(lvc, input, 1)), input);
+  EXPECT_EQ(toVec(expr->evaluate(lvc, input, 2)), input);
   expr = eq(DoubleId(-6.25));
   input = {b15, b16, b17};
-  EXPECT_EQ(toVec(expr->evaluate(idx, input, 2)),
+  EXPECT_EQ(toVec(expr->evaluate(lvc, input, 2)),
             (std::vector<CompressedBlockMetadata>{b15, b16}));
-  EXPECT_EQ(toVec(expr->evaluate(idx, input, 1)),
+  EXPECT_EQ(toVec(expr->evaluate(lvc, input, 1)),
             std::vector<CompressedBlockMetadata>{});
-  EXPECT_EQ(toVec(expr->evaluate(idx, input, 0)),
+  EXPECT_EQ(toVec(expr->evaluate(lvc, input, 0)),
             std::vector<CompressedBlockMetadata>{});
 }
 
@@ -1243,7 +1243,7 @@ TEST_F(PrefilterExpressionOnMetadataTest, testMethodClonePrefilterExpression) {
   makeTestClone(isBlank(true));
   makeTestClone(andExpr(lt(VocabId(20)), gt(VocabId(10))));
   makeTestClone(neq(IntId(10)));
-  makeTestClone(le(LVE("\"Hello World\"", idx)));
+  makeTestClone(le(LVE("\"Hello World\"", lvc)));
   makeTestClone(orExpr(eq(IntId(10)), neq(DoubleId(10))));
   makeTestClone(notExpr(ge(referenceDate1)));
   makeTestClone(notExpr(notExpr(neq(VocabId(0)))));
@@ -1255,8 +1255,8 @@ TEST_F(PrefilterExpressionOnMetadataTest, testMethodClonePrefilterExpression) {
   makeTestClone(orExpr(orExpr(eq(VocabId(101)), lt(IntId(100))),
                        notExpr(andExpr(lt(VocabId(0)), neq(IntId(100))))));
   makeTestClone(
-      orExpr(orExpr(le(LVE("<iri/id5>", idx)), gt(LVE("<iri/id22>", idx))),
-             neq(LVE("<iri/id10>", idx))));
+      orExpr(orExpr(le(LVE("<iri/id5>", lvc)), gt(LVE("<iri/id22>", lvc))),
+             neq(LVE("<iri/id10>", lvc))));
   makeTestClone(inExpr({referenceDate2, idDüsseldorf, idHamburg, IntId(0)}));
   makeTestClone(inExpr({falseId, IntId(10), DoubleId(42.5)}, true));
   makeTestClone(prefixRegex(L("prefixPreeefix")));
@@ -1272,8 +1272,8 @@ TEST_F(PrefilterExpressionOnMetadataTest, testEqualityOperator) {
   ASSERT_FALSE(*neq(BoolId(true)) == *eq(BoolId(true)));
   ASSERT_TRUE(*eq(IntId(1)) == *eq(IntId(1)));
   ASSERT_TRUE(*ge(referenceDate1) == *ge(referenceDate1));
-  ASSERT_TRUE(*eq(LVE("<iri>", idx)) == *eq(LVE("<iri>", idx)));
-  ASSERT_FALSE(*gt(LVE("<iri>", idx)) == *gt(LVE("\"iri\"", idx)));
+  ASSERT_TRUE(*eq(LVE("<iri>", lvc)) == *eq(LVE("<iri>", lvc)));
+  ASSERT_FALSE(*gt(LVE("<iri>", lvc)) == *gt(LVE("\"iri\"", lvc)));
   // IsDatatypeExpression
   ASSERT_TRUE(*isBlank() == *isBlank());
   ASSERT_FALSE(*isLit() == *isNum());
@@ -1283,8 +1283,8 @@ TEST_F(PrefilterExpressionOnMetadataTest, testEqualityOperator) {
   ASSERT_TRUE(*notExpr(eq(IntId(0))) == *notExpr(eq(IntId(0))));
   ASSERT_TRUE(*notExpr(notExpr(ge(VocabId(0)))) ==
               *notExpr(notExpr(ge(VocabId(0)))));
-  ASSERT_TRUE(*notExpr(le(LVE("<iri>", idx))) ==
-              *notExpr(le(LVE("<iri>", idx))));
+  ASSERT_TRUE(*notExpr(le(LVE("<iri>", lvc))) ==
+              *notExpr(le(LVE("<iri>", lvc))));
   ASSERT_FALSE(*notExpr(gt(IntId(0))) == *eq(IntId(0)));
   ASSERT_FALSE(*notExpr(andExpr(eq(IntId(1)), eq(IntId(0)))) ==
                *notExpr(ge(VocabId(0))));
@@ -1292,8 +1292,8 @@ TEST_F(PrefilterExpressionOnMetadataTest, testEqualityOperator) {
   ASSERT_TRUE(*orExpr(eq(IntId(0)), le(IntId(0))) ==
               *orExpr(eq(IntId(0)), le(IntId(0))));
   ASSERT_TRUE(*orExpr(isIri(), isLit()) == *orExpr(isIri(), isLit()));
-  ASSERT_TRUE(*orExpr(lt(LVE("\"L\"", idx)), gt(LVE("\"O\"", idx))) ==
-              *orExpr(lt(LVE("\"L\"", idx)), gt(LVE("\"O\"", idx))));
+  ASSERT_TRUE(*orExpr(lt(LVE("\"L\"", lvc)), gt(LVE("\"O\"", lvc))) ==
+              *orExpr(lt(LVE("\"L\"", lvc)), gt(LVE("\"O\"", lvc))));
   ASSERT_TRUE(*andExpr(le(VocabId(1)), le(IntId(0))) ==
               *andExpr(le(VocabId(1)), le(IntId(0))));
   ASSERT_FALSE(*orExpr(eq(IntId(0)), le(IntId(0))) ==
@@ -1394,15 +1394,15 @@ TEST_F(PrefilterExpressionOnMetadataTest,
               "RelationalExpression<LT(<)>\nreferenceValue_ : I:20 .\n}child2 "
               "{Prefilter RelationalExpression<GT(>)>\nreferenceValue_ : I:10 "
               ".\n}\n.\n"));
-  EXPECT_THAT(*eq(LVE("\"Sophia\"", idx)),
+  EXPECT_THAT(*eq(LVE("\"Sophia\"", lvc)),
               matcher("Prefilter RelationalExpression<EQ(=)>\nreferenceValue_ "
                       ": \"Sophia\" .\n.\n"));
-  EXPECT_THAT(*neq(LVE("<Iri/custom/value>", idx)),
+  EXPECT_THAT(*neq(LVE("<Iri/custom/value>", lvc)),
               matcher("Prefilter RelationalExpression<NE(!=)>\nreferenceValue_ "
                       ": <Iri/custom/value> .\n.\n"));
   EXPECT_THAT(
-      *andExpr(orExpr(lt(LVE("\"Bob\"", idx)), ge(LVE("\"Max\"", idx))),
-               neq(LVE("\"Lars\"", idx))),
+      *andExpr(orExpr(lt(LVE("\"Bob\"", lvc)), ge(LVE("\"Max\"", lvc))),
+               neq(LVE("\"Lars\"", lvc))),
       matcher(
           "Prefilter LogicalExpression<AND(&&)>\nchild1 {Prefilter "
           "LogicalExpression<OR(||)>\nchild1 {Prefilter "
@@ -1412,8 +1412,8 @@ TEST_F(PrefilterExpressionOnMetadataTest,
           "RelationalExpression<NE(!=)>\nreferenceValue_ : \"Lars\" "
           ".\n}\n.\n"));
   EXPECT_THAT(
-      *orExpr(neq(LVE("<iri/custom/v10>", idx)),
-              neq(LVE("<iri/custom/v66>", idx))),
+      *orExpr(neq(LVE("<iri/custom/v10>", lvc)),
+              neq(LVE("<iri/custom/v66>", lvc))),
       matcher(
           "Prefilter LogicalExpression<OR(||)>\nchild1 {Prefilter "
           "RelationalExpression<NE(!=)>\nreferenceValue_ : <iri/custom/v10> "

--- a/test/PrefilterExpressionIndexTest.cpp
+++ b/test/PrefilterExpressionIndexTest.cpp
@@ -117,6 +117,7 @@ class PrefilterExpressionOnMetadataTest : public ::testing::Test {
   // Given that we depend on LocalVocab and Vocab values during evaluation an
   // active Index + global vocabulary is required.
   QueryExecutionContext* qet = ad_utility::testing::getQec(turtleInput);
+  const IndexImpl& idx = qet->getIndex().getImpl();
   std::function<Id(const std::string&)> getVocabId =
       ad_utility::testing::makeGetId(qet->getIndex());
   LocalVocab vocab{};
@@ -126,22 +127,22 @@ class PrefilterExpressionOnMetadataTest : public ::testing::Test {
   const Id falseId = BoolId(false);
   const Id trueId = BoolId(true);
   const Id referenceDateEqual = DateId(DateParser, "2000-01-01");
-  const LocalVocabEntry augsburg = LVE("\"Augsburg\"");
-  const LocalVocabEntry berlin = LVE("\"Berlin\"");
-  const LocalVocabEntry düsseldorf = LVE("\"Düsseldorf\"");
-  const LocalVocabEntry frankfurt = LVE("\"Frankfurt\"");
-  const LocalVocabEntry hamburg = LVE("\"Hamburg\"");
-  const LocalVocabEntry köln = LVE("\"Köln\"");
-  const LocalVocabEntry münchen = LVE("\"München\"");
-  const LocalVocabEntry stuttgart = LVE("\"Stuttgart\"");
-  const LocalVocabEntry wolfsburg = LVE("\"Wolfsburg\"");
-  const LocalVocabEntry iri0 = LVE("<a>");
-  const LocalVocabEntry iri1 = LVE("<iri>");
-  const LocalVocabEntry iri2 = LVE("<iri>");
-  const LocalVocabEntry iri3 = LVE("<randomiriref>");
-  const LocalVocabEntry iri4 = LVE("<someiri>");
-  const LocalVocabEntry iri5 = LVE("<www-iri.de>");
-  const LocalVocabEntry iriBegin = LVE("<");
+  const LocalVocabEntry augsburg = LVE("\"Augsburg\"", idx);
+  const LocalVocabEntry berlin = LVE("\"Berlin\"", idx);
+  const LocalVocabEntry düsseldorf = LVE("\"Düsseldorf\"", idx);
+  const LocalVocabEntry frankfurt = LVE("\"Frankfurt\"", idx);
+  const LocalVocabEntry hamburg = LVE("\"Hamburg\"", idx);
+  const LocalVocabEntry köln = LVE("\"Köln\"", idx);
+  const LocalVocabEntry münchen = LVE("\"München\"", idx);
+  const LocalVocabEntry stuttgart = LVE("\"Stuttgart\"", idx);
+  const LocalVocabEntry wolfsburg = LVE("\"Wolfsburg\"", idx);
+  const LocalVocabEntry iri0 = LVE("<a>", idx);
+  const LocalVocabEntry iri1 = LVE("<iri>", idx);
+  const LocalVocabEntry iri2 = LVE("<iri>", idx);
+  const LocalVocabEntry iri3 = LVE("<randomiriref>", idx);
+  const LocalVocabEntry iri4 = LVE("<someiri>", idx);
+  const LocalVocabEntry iri5 = LVE("<www-iri.de>", idx);
+  const LocalVocabEntry iriBegin = LVE("<", idx);
   const Id idAugsburg = getId(augsburg, vocab);
   const Id vocabIdBe = getVocabId("\"Be\"");
   const Id vocabIdBern = getVocabId("\"Bern\"");
@@ -155,12 +156,12 @@ class PrefilterExpressionOnMetadataTest : public ::testing::Test {
   const Id vocabIdMünchen = getVocabId("\"München\"");
   const Id vocabIdStuttgart = getVocabId("\"Stuttgart\"");
   const Id idWolfsburg = getId(wolfsburg, vocab);
-  const Id idB = getId(LVE("\"B\""), vocab);
-  const Id idBe = getId(LVE("\"Be\""), vocab);
-  const Id idBerl = getId(LVE("\"Berl\""), vocab);
-  const Id idHamburgAlt = getId(LVE("\"Hamburg Alt\""), vocab);
+  const Id idB = getId(LVE("\"B\"", idx), vocab);
+  const Id idBe = getId(LVE("\"Be\"", idx), vocab);
+  const Id idBerl = getId(LVE("\"Berl\"", idx), vocab);
+  const Id idHamburgAlt = getId(LVE("\"Hamburg Alt\"", idx), vocab);
   const Id idStuttgartZuffenhausen =
-      getId(LVE("\"Stuttgart-Zuffenhausen\""), vocab);
+      getId(LVE("\"Stuttgart-Zuffenhausen\"", idx), vocab);
   const Id idBerlin = getId(berlin, vocab);
   const Id idDüsseldorf = getId(düsseldorf, vocab);
   const Id idFrankfurt = getId(frankfurt, vocab);
@@ -175,7 +176,7 @@ class PrefilterExpressionOnMetadataTest : public ::testing::Test {
   const Id idIri4 = getId(iri4, vocab);
   const Id idIri5 = getId(iri5, vocab);
   const Id iriStart = getId(iriBegin, vocab);
-  const RdfsVocabulary& indexVocab = qet->getIndex().getVocab();
+  const IndexImpl& indexVocab = qet->getIndex().getImpl();
 
   // Define CompressedBlockMetadata
   const CompressedBlockMetadata b1 = makeBlock(undef, undef);  // 0
@@ -667,7 +668,7 @@ TEST_F(PrefilterExpressionOnMetadataTest, testLessEqualExpressions) {
   makeTest(le(DoubleId(3.1415)), {b6, b9, b10, b11, b15, b16, b17, b18});
   makeTest(le(DoubleId(-11.99999999999999)), {b17, b18}, true);
   makeTest(le(DoubleId(-14.03)), {b18});
-  makeTest(le(LVE("\"Aachen\"")), {b18});
+  makeTest(le(LVE("\"Aachen\"", idx)), {b18});
   makeTest(le(frankfurt), {b18, b19});
   makeTest(le(hamburg), {b18, b19, b21}, true);
   makeTest(le(undef), {});
@@ -1196,8 +1197,7 @@ TEST_F(PrefilterExpressionOnMetadataTest, testInputConditionCheck) {
 // Test the (full) invariant check of `ScanSpecAndBlocks` constructor.
 TEST_F(PrefilterExpressionOnMetadataTest,
        testScanSpecAndBlocksConstructionFromPrefilteredBlocks) {
-  const auto& vocab = ad_utility::testing::getQec()->getIndex().getVocab();
-  auto blockRanges = gt(IntId(0))->evaluate(vocab, blocks, 2);
+  auto blockRanges = gt(IntId(0))->evaluate(idx, blocks, 2);
   ASSERT_NO_THROW(CompressedRelationReader::ScanSpecAndBlocks(
       ScanSpecification{VocabId10, DoubleId33, std::nullopt}, blockRanges));
   ASSERT_NO_THROW(CompressedRelationReader::ScanSpecAndBlocks(
@@ -1245,7 +1245,7 @@ TEST_F(PrefilterExpressionOnMetadataTest, testMethodClonePrefilterExpression) {
   makeTestClone(isBlank(true));
   makeTestClone(andExpr(lt(VocabId(20)), gt(VocabId(10))));
   makeTestClone(neq(IntId(10)));
-  makeTestClone(le(LVE("\"Hello World\"")));
+  makeTestClone(le(LVE("\"Hello World\"", idx)));
   makeTestClone(orExpr(eq(IntId(10)), neq(DoubleId(10))));
   makeTestClone(notExpr(ge(referenceDate1)));
   makeTestClone(notExpr(notExpr(neq(VocabId(0)))));
@@ -1256,8 +1256,9 @@ TEST_F(PrefilterExpressionOnMetadataTest, testMethodClonePrefilterExpression) {
                         orExpr(gt(DoubleId(0.001)), lt(IntId(250)))));
   makeTestClone(orExpr(orExpr(eq(VocabId(101)), lt(IntId(100))),
                        notExpr(andExpr(lt(VocabId(0)), neq(IntId(100))))));
-  makeTestClone(orExpr(orExpr(le(LVE("<iri/id5>")), gt(LVE("<iri/id22>"))),
-                       neq(LVE("<iri/id10>"))));
+  makeTestClone(
+      orExpr(orExpr(le(LVE("<iri/id5>", idx)), gt(LVE("<iri/id22>", idx))),
+             neq(LVE("<iri/id10>", idx))));
   makeTestClone(inExpr({referenceDate2, idDüsseldorf, idHamburg, IntId(0)}));
   makeTestClone(inExpr({falseId, IntId(10), DoubleId(42.5)}, true));
   makeTestClone(prefixRegex(L("prefixPreeefix")));
@@ -1273,8 +1274,8 @@ TEST_F(PrefilterExpressionOnMetadataTest, testEqualityOperator) {
   ASSERT_FALSE(*neq(BoolId(true)) == *eq(BoolId(true)));
   ASSERT_TRUE(*eq(IntId(1)) == *eq(IntId(1)));
   ASSERT_TRUE(*ge(referenceDate1) == *ge(referenceDate1));
-  ASSERT_TRUE(*eq(LVE("<iri>")) == *eq(LVE("<iri>")));
-  ASSERT_FALSE(*gt(LVE("<iri>")) == *gt(LVE("\"iri\"")));
+  ASSERT_TRUE(*eq(LVE("<iri>", idx)) == *eq(LVE("<iri>", idx)));
+  ASSERT_FALSE(*gt(LVE("<iri>", idx)) == *gt(LVE("\"iri\"", idx)));
   // IsDatatypeExpression
   ASSERT_TRUE(*isBlank() == *isBlank());
   ASSERT_FALSE(*isLit() == *isNum());
@@ -1284,7 +1285,8 @@ TEST_F(PrefilterExpressionOnMetadataTest, testEqualityOperator) {
   ASSERT_TRUE(*notExpr(eq(IntId(0))) == *notExpr(eq(IntId(0))));
   ASSERT_TRUE(*notExpr(notExpr(ge(VocabId(0)))) ==
               *notExpr(notExpr(ge(VocabId(0)))));
-  ASSERT_TRUE(*notExpr(le(LVE("<iri>"))) == *notExpr(le(LVE("<iri>"))));
+  ASSERT_TRUE(*notExpr(le(LVE("<iri>", idx))) ==
+              *notExpr(le(LVE("<iri>", idx))));
   ASSERT_FALSE(*notExpr(gt(IntId(0))) == *eq(IntId(0)));
   ASSERT_FALSE(*notExpr(andExpr(eq(IntId(1)), eq(IntId(0)))) ==
                *notExpr(ge(VocabId(0))));
@@ -1292,8 +1294,8 @@ TEST_F(PrefilterExpressionOnMetadataTest, testEqualityOperator) {
   ASSERT_TRUE(*orExpr(eq(IntId(0)), le(IntId(0))) ==
               *orExpr(eq(IntId(0)), le(IntId(0))));
   ASSERT_TRUE(*orExpr(isIri(), isLit()) == *orExpr(isIri(), isLit()));
-  ASSERT_TRUE(*orExpr(lt(LVE("\"L\"")), gt(LVE("\"O\""))) ==
-              *orExpr(lt(LVE("\"L\"")), gt(LVE("\"O\""))));
+  ASSERT_TRUE(*orExpr(lt(LVE("\"L\"", idx)), gt(LVE("\"O\"", idx))) ==
+              *orExpr(lt(LVE("\"L\"", idx)), gt(LVE("\"O\"", idx))));
   ASSERT_TRUE(*andExpr(le(VocabId(1)), le(IntId(0))) ==
               *andExpr(le(VocabId(1)), le(IntId(0))));
   ASSERT_FALSE(*orExpr(eq(IntId(0)), le(IntId(0))) ==
@@ -1394,15 +1396,15 @@ TEST_F(PrefilterExpressionOnMetadataTest,
               "RelationalExpression<LT(<)>\nreferenceValue_ : I:20 .\n}child2 "
               "{Prefilter RelationalExpression<GT(>)>\nreferenceValue_ : I:10 "
               ".\n}\n.\n"));
-  EXPECT_THAT(*eq(LVE("\"Sophia\"")),
+  EXPECT_THAT(*eq(LVE("\"Sophia\"", idx)),
               matcher("Prefilter RelationalExpression<EQ(=)>\nreferenceValue_ "
                       ": \"Sophia\" .\n.\n"));
-  EXPECT_THAT(*neq(LVE("<Iri/custom/value>")),
+  EXPECT_THAT(*neq(LVE("<Iri/custom/value>", idx)),
               matcher("Prefilter RelationalExpression<NE(!=)>\nreferenceValue_ "
                       ": <Iri/custom/value> .\n.\n"));
   EXPECT_THAT(
-      *andExpr(orExpr(lt(LVE("\"Bob\"")), ge(LVE("\"Max\""))),
-               neq(LVE("\"Lars\""))),
+      *andExpr(orExpr(lt(LVE("\"Bob\"", idx)), ge(LVE("\"Max\"", idx))),
+               neq(LVE("\"Lars\"", idx))),
       matcher(
           "Prefilter LogicalExpression<AND(&&)>\nchild1 {Prefilter "
           "LogicalExpression<OR(||)>\nchild1 {Prefilter "
@@ -1412,7 +1414,8 @@ TEST_F(PrefilterExpressionOnMetadataTest,
           "RelationalExpression<NE(!=)>\nreferenceValue_ : \"Lars\" "
           ".\n}\n.\n"));
   EXPECT_THAT(
-      *orExpr(neq(LVE("<iri/custom/v10>")), neq(LVE("<iri/custom/v66>"))),
+      *orExpr(neq(LVE("<iri/custom/v10>", idx)),
+              neq(LVE("<iri/custom/v66>", idx))),
       matcher(
           "Prefilter LogicalExpression<OR(||)>\nchild1 {Prefilter "
           "RelationalExpression<NE(!=)>\nreferenceValue_ : <iri/custom/v10> "

--- a/test/PrefilterExpressionIndexTest.cpp
+++ b/test/PrefilterExpressionIndexTest.cpp
@@ -117,7 +117,7 @@ class PrefilterExpressionOnMetadataTest : public ::testing::Test {
   // Given that we depend on LocalVocab and Vocab values during evaluation an
   // active Index + global vocabulary is required.
   QueryExecutionContext* qet = ad_utility::testing::getQec(turtleInput);
-  const IndexImpl& idx = qet->getIndex().getImpl();
+  const Index& idx = qet->getIndex();
   std::function<Id(const std::string&)> getVocabId =
       ad_utility::testing::makeGetId(qet->getIndex());
   LocalVocab vocab{};
@@ -176,7 +176,6 @@ class PrefilterExpressionOnMetadataTest : public ::testing::Test {
   const Id idIri4 = getId(iri4, vocab);
   const Id idIri5 = getId(iri5, vocab);
   const Id iriStart = getId(iriBegin, vocab);
-  const IndexImpl& indexVocab = qet->getIndex().getImpl();
 
   // Define CompressedBlockMetadata
   const CompressedBlockMetadata b1 = makeBlock(undef, undef);  // 0
@@ -410,7 +409,7 @@ class PrefilterExpressionOnMetadataTest : public ::testing::Test {
                           size_t evaluationColumn = 2) {
     std::vector<CompressedBlockMetadata> testBlocks = input;
     AD_EXPECT_THROW_WITH_MESSAGE(
-        expr->evaluate(indexVocab, testBlocks, evaluationColumn),
+        expr->evaluate(idx, testBlocks, evaluationColumn),
         ::testing::HasSubstr(expected));
   }
 
@@ -434,7 +433,7 @@ class PrefilterExpressionOnMetadataTest : public ::testing::Test {
     }
     std::vector<CompressedBlockMetadata> testBlocks =
         useBlocksIncomplete ? blocksIncomplete : blocks;
-    ASSERT_EQ(toVec(expr->evaluate(indexVocab, testBlocks, 2)),
+    ASSERT_EQ(toVec(expr->evaluate(idx, testBlocks, 2)),
               addMixedBlocks ? expectedAdjusted : expected);
   }
 
@@ -459,10 +458,9 @@ class PrefilterExpressionOnMetadataTest : public ::testing::Test {
         testIsIriOrIsLit
             ? addBlocksMixedDatatype(expected, mixedBlocksTestIsDatatype)
             : expected;
-    ASSERT_EQ(
-        toVec(expr->evaluate(
-            indexVocab, input.empty() ? allTestBlocksIsDatatype : input, 2)),
-        adjustedExpected);
+    ASSERT_EQ(toVec(expr->evaluate(
+                  idx, input.empty() ? allTestBlocksIsDatatype : input, 2)),
+              adjustedExpected);
   }
 
   // Check if `BlockMetadataRanges r1` and `BlockMetadataRanges r2` contain
@@ -504,13 +502,13 @@ class PrefilterExpressionOnMetadataTest : public ::testing::Test {
   // Simple `ASSERT_EQ` on date blocks
   auto makeTestDate(std::unique_ptr<PrefilterExpression> expr,
                     std::vector<CompressedBlockMetadata>&& expected) {
-    ASSERT_EQ(toVec(expr->evaluate(indexVocab, dateBlocks, 2)), expected);
+    ASSERT_EQ(toVec(expr->evaluate(idx, dateBlocks, 2)), expected);
   }
 
   // Simple `ASSERT_EQ` VocabIdBlocks
   auto makeTestPrefixRegex(std::unique_ptr<PrefilterExpression> expr,
                            std::vector<CompressedBlockMetadata>&& expected) {
-    ASSERT_EQ(toVec(expr->evaluate(indexVocab, blocksRegexTest, 2)), expected);
+    ASSERT_EQ(toVec(expr->evaluate(idx, blocksRegexTest, 2)), expected);
   }
 
   // Test `PrefilterExpression` helper `mergeRelevantBlockItRanges<bool>`.
@@ -1219,16 +1217,16 @@ TEST_F(PrefilterExpressionOnMetadataTest,
 TEST_F(PrefilterExpressionOnMetadataTest, testWithFewBlockMetadataValues) {
   auto expr = orExpr(eq(DoubleId(-6.25)), eq(IntId(0)));
   std::vector<CompressedBlockMetadata> input = {b16};
-  EXPECT_EQ(toVec(expr->evaluate(indexVocab, input, 0)), input);
-  EXPECT_EQ(toVec(expr->evaluate(indexVocab, input, 1)), input);
-  EXPECT_EQ(toVec(expr->evaluate(indexVocab, input, 2)), input);
+  EXPECT_EQ(toVec(expr->evaluate(idx, input, 0)), input);
+  EXPECT_EQ(toVec(expr->evaluate(idx, input, 1)), input);
+  EXPECT_EQ(toVec(expr->evaluate(idx, input, 2)), input);
   expr = eq(DoubleId(-6.25));
   input = {b15, b16, b17};
-  EXPECT_EQ(toVec(expr->evaluate(indexVocab, input, 2)),
+  EXPECT_EQ(toVec(expr->evaluate(idx, input, 2)),
             (std::vector<CompressedBlockMetadata>{b15, b16}));
-  EXPECT_EQ(toVec(expr->evaluate(indexVocab, input, 1)),
+  EXPECT_EQ(toVec(expr->evaluate(idx, input, 1)),
             std::vector<CompressedBlockMetadata>{});
-  EXPECT_EQ(toVec(expr->evaluate(indexVocab, input, 0)),
+  EXPECT_EQ(toVec(expr->evaluate(idx, input, 0)),
             std::vector<CompressedBlockMetadata>{});
 }
 

--- a/test/PrefilterExpressionTestHelpers.h
+++ b/test/PrefilterExpressionTestHelpers.h
@@ -105,12 +105,10 @@ namespace filterHelper {
 // Create `LocalVocabEntry` / `LiteralOrIri`.
 // Note: `Iri` string value must start and end with `<`/`>` and the `Literal`
 // value with `'`/`'`.
-inline auto LVE = [](const std::string& litOrIri,
+inline auto LVE = [](std::string litOrIri,
                      const LocalVocabContext& context) -> LocalVocabEntry {
-  return LocalVocabEntry{
-      ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
-          litOrIri),
-      context};
+  return LocalVocabEntry::fromStringRepresentation(std::move(litOrIri),
+                                                   context);
 };
 
 //______________________________________________________________________________

--- a/test/PrefilterExpressionTestHelpers.h
+++ b/test/PrefilterExpressionTestHelpers.h
@@ -106,11 +106,11 @@ namespace filterHelper {
 // Note: `Iri` string value must start and end with `<`/`>` and the `Literal`
 // value with `'`/`'`.
 inline auto LVE = [](const std::string& litOrIri,
-                     const IndexImpl& index) -> LocalVocabEntry {
+                     const LocalVocabContext& context) -> LocalVocabEntry {
   return LocalVocabEntry{
       ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
           litOrIri),
-      index};
+      context};
 };
 
 //______________________________________________________________________________

--- a/test/PrefilterExpressionTestHelpers.h
+++ b/test/PrefilterExpressionTestHelpers.h
@@ -15,6 +15,7 @@
 #include "./engine/sparqlExpressions/SparqlExpression.h"
 #include "util/DateYearDuration.h"
 #include "util/IdTestHelpers.h"
+#include "util/IndexTestHelpers.h"
 
 using ad_utility::testing::DateId;
 
@@ -104,8 +105,12 @@ namespace filterHelper {
 // Create `LocalVocabEntry` / `LiteralOrIri`.
 // Note: `Iri` string value must start and end with `<`/`>` and the `Literal`
 // value with `'`/`'`.
-constexpr inline auto LVE = [](const std::string& litOrIri) -> LocalVocabEntry {
-  return LocalVocabEntry::fromStringRepresentation(litOrIri);
+inline auto LVE = [](const std::string& litOrIri,
+                     const IndexImpl& index) -> LocalVocabEntry {
+  return LocalVocabEntry{
+      ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
+          litOrIri),
+      index};
 };
 
 //______________________________________________________________________________

--- a/test/RegexExpressionTest.cpp
+++ b/test/RegexExpressionTest.cpp
@@ -118,7 +118,7 @@ void testValuesInVariables(
         ctx.localVocab.getIndexAndAddIfNotContained(LocalVocabEntry{
             ad_utility::triple_component::LiteralOrIri::literalWithoutQuotes(
                 value),
-            ctx.qec->getIndex().getImpl()}));
+            ctx.qec->getIndex()}));
   };
   for (const auto& value : inputValues) {
     ctx.table.push_back({toLiteralId(value.at(0)), toLiteralId(value.at(1)),

--- a/test/RegexExpressionTest.cpp
+++ b/test/RegexExpressionTest.cpp
@@ -115,9 +115,10 @@ void testValuesInVariables(
   ctx.table.setNumColumns(3);
   auto toLiteralId = [&ctx](const std::string& value) {
     return Id::makeFromLocalVocabIndex(
-        ctx.localVocab.getIndexAndAddIfNotContained(
+        ctx.localVocab.getIndexAndAddIfNotContained(LocalVocabEntry{
             ad_utility::triple_component::LiteralOrIri::literalWithoutQuotes(
-                value)));
+                value),
+            ctx.qec->getIndex().getImpl()}));
   };
   for (const auto& value : inputValues) {
     ctx.table.push_back({toLiteralId(value.at(0)), toLiteralId(value.at(1)),
@@ -202,7 +203,9 @@ TEST(RegexExpression, inputNotVariable) {
   // Our expression is a fixed string literal: "hallo".
   VectorWithMemoryLimit<IdOrLocalVocabEntry> input{
       ad_utility::testing::getQec()->getAllocator()};
-  input.push_back(ad_utility::triple_component::LiteralOrIri(lit("\"hallo\"")));
+  input.push_back(LocalVocabEntry{
+      ad_utility::triple_component::LiteralOrIri(lit("\"hallo\"")),
+      ad_utility::testing::getQec()->getIndex().getImpl()});
 
   {
     auto child =

--- a/test/RegexExpressionTest.cpp
+++ b/test/RegexExpressionTest.cpp
@@ -200,12 +200,12 @@ TEST(RegexExpression, nonPrefixRegex) {
 
 // Test where the expression is not simply a variable.
 TEST(RegexExpression, inputNotVariable) {
+  auto* qec = ad_utility::testing::getQec();
+  const auto& index = qec->getIndex();
   // Our expression is a fixed string literal: "hallo".
-  VectorWithMemoryLimit<IdOrLocalVocabEntry> input{
-      ad_utility::testing::getQec()->getAllocator()};
+  VectorWithMemoryLimit<IdOrLocalVocabEntry> input{qec->getAllocator()};
   input.push_back(LocalVocabEntry{
-      ad_utility::triple_component::LiteralOrIri(lit("\"hallo\"")),
-      ad_utility::testing::getQec()->getIndex().getImpl()});
+      ad_utility::triple_component::LiteralOrIri(lit("\"hallo\"")), index});
 
   {
     auto child =

--- a/test/RegexExpressionTest.cpp
+++ b/test/RegexExpressionTest.cpp
@@ -115,10 +115,9 @@ void testValuesInVariables(
   ctx.table.setNumColumns(3);
   auto toLiteralId = [&ctx](const std::string& value) {
     return Id::makeFromLocalVocabIndex(
-        ctx.localVocab.getIndexAndAddIfNotContained(LocalVocabEntry{
-            ad_utility::triple_component::LiteralOrIri::literalWithoutQuotes(
-                value),
-            ctx.qec->getIndex()}));
+        ctx.localVocab.getIndexAndAddIfNotContained(
+            LocalVocabEntry::literalWithoutQuotes(
+                value, ctx.qec->getLocalVocabContext())));
   };
   for (const auto& value : inputValues) {
     ctx.table.push_back({toLiteralId(value.at(0)), toLiteralId(value.at(1)),
@@ -201,11 +200,10 @@ TEST(RegexExpression, nonPrefixRegex) {
 // Test where the expression is not simply a variable.
 TEST(RegexExpression, inputNotVariable) {
   auto* qec = ad_utility::testing::getQec();
-  const auto& index = qec->getIndex();
+  const auto& localVocabContext = qec->getLocalVocabContext();
   // Our expression is a fixed string literal: "hallo".
   VectorWithMemoryLimit<IdOrLocalVocabEntry> input{qec->getAllocator()};
-  input.push_back(LocalVocabEntry{
-      ad_utility::triple_component::LiteralOrIri(lit("\"hallo\"")), index});
+  input.push_back(LocalVocabEntry{lit("\"hallo\""), localVocabContext});
 
   {
     auto child =

--- a/test/RelationalExpressionTest.cpp
+++ b/test/RelationalExpressionTest.cpp
@@ -321,7 +321,7 @@ TEST(RelationalExpression, DoubleAndDouble) {
 TEST(RelationalExpression, StringAndString) {
   auto* qec = getQec();
   auto lve = [qec](std::string_view literal) {
-    return LocalVocabEntry{lit(literal), qec->getIndex()};
+    return LocalVocabEntry{lit(literal), qec->getLocalVocabContext()};
   };
   testLessThanGreaterThanEqualHelper<IdOrLocalVocabEntry, IdOrLocalVocabEntry>(
       {lve("alpha"), lve("beta")}, {lve("sigma"), lve("delta")},
@@ -338,7 +338,7 @@ TEST(RelationalExpression, StringAndString) {
 TEST(RelationalExpression, NumericAndStringAreNeverEqual) {
   auto* qec = getQec();
   auto lve = [qec](std::string_view literal) {
-    return LocalVocabEntry{lit(literal), qec->getIndex()};
+    return LocalVocabEntry{lit(literal), qec->getLocalVocabContext()};
   };
   auto stringVec = VectorWithMemoryLimit<IdOrLocalVocabEntry>(
       {lve("hallo"), lve("by"), lve("")}, makeAllocator());
@@ -575,7 +575,7 @@ TEST(RelationalExpression, NumericConstantAndNumericVector) {
 TEST(RelationalExpression, StringConstantsAndStringVector) {
   auto* qec = getQec();
   auto lve = [qec](std::string_view literal) {
-    return LocalVocabEntry{lit(literal), qec->getIndex()};
+    return LocalVocabEntry{lit(literal), qec->getLocalVocabContext()};
   };
   VectorWithMemoryLimit<IdOrLocalVocabEntry> vec(
       {lve("alpha"), lve("alpaka"), lve("bertram"), lve("sigma"), lve("zeta"),
@@ -636,7 +636,7 @@ TEST(RelationalExpression, DoubleVectorAndIntVector) {
 TEST(RelationalExpression, StringVectorAndStringVector) {
   auto* qec = getQec();
   auto lve = [qec](std::string_view literal) {
-    return LocalVocabEntry{lit(literal), qec->getIndex()};
+    return LocalVocabEntry{lit(literal), qec->getLocalVocabContext()};
   };
   VectorWithMemoryLimit<IdOrLocalVocabEntry> vecA{
       {lve("alpha"), lve("beta"), lve("g"), lve("epsilon"), lve("fraud"),
@@ -716,7 +716,7 @@ void testWithExplicitResult(T1 leftValue, T2 rightValue,
 TEST(RelationalExpression, VariableAndConstant) {
   auto* qec = testContext().qec;
   auto lve = [qec](std::string_view literal) {
-    return LocalVocabEntry{lit(literal), qec->getIndex()};
+    return LocalVocabEntry{lit(literal), qec->getLocalVocabContext()};
   };
   // ?ints column is `1, 0, -1`
   testWithExplicitResult<LT>(int64_t{0}, Variable{"?ints"},
@@ -751,12 +751,12 @@ TEST(RelationalExpression, VariableAndConstant) {
   // ?mixed column is `1, -0.1, <x>`
   auto U = Id::makeUndefined();
   auto B = ad_utility::testing::BoolId;
-  testWithExplicitIdResult<GT>(
-      IdOrLocalVocabEntry{LocalVocabEntry::fromIriref("<xa>", qec->getIndex())},
-      Variable{"?mixed"}, {U, U, B(true)});
-  testWithExplicitIdResult<LT>(
-      IdOrLocalVocabEntry{LocalVocabEntry::fromIriref("<u>", qec->getIndex())},
-      Variable{"?mixed"}, {U, U, B(true)});
+  testWithExplicitIdResult<GT>(IdOrLocalVocabEntry{LocalVocabEntry::fromIriref(
+                                   "<xa>", qec->getLocalVocabContext())},
+                               Variable{"?mixed"}, {U, U, B(true)});
+  testWithExplicitIdResult<LT>(IdOrLocalVocabEntry{LocalVocabEntry::fromIriref(
+                                   "<u>", qec->getLocalVocabContext())},
+                               Variable{"?mixed"}, {U, U, B(true)});
 
   // Note: `1` and `<x>` are "not compatible", so even the "not equal"
   // comparison returns false.
@@ -836,7 +836,7 @@ void testSortedVariableAndConstant(
 TEST(RelationalExpression, VariableAndConstantBinarySearch) {
   auto* qec = testContext().qec;
   auto lve = [qec](std::string_view literal) {
-    return LocalVocabEntry{lit(literal), qec->getIndex()};
+    return LocalVocabEntry{lit(literal), qec->getLocalVocabContext()};
   };
   // Sorted order (by bits of the valueIds):
   // ?ints column is `0, 1,  -1`
@@ -884,7 +884,8 @@ TEST(RelationalExpression, VariableAndConstantBinarySearch) {
   testSortedVariableAndConstant<GT>(mixed, -inf, {{{0, 2}}});
   testSortedVariableAndConstant<LE>(
       mixed,
-      IdOrLocalVocabEntry{LocalVocabEntry::fromIriref("<z>", qec->getIndex())},
+      IdOrLocalVocabEntry{
+          LocalVocabEntry::fromIriref("<z>", qec->getLocalVocabContext())},
       {{{2, 3}}});
 }
 

--- a/test/RelationalExpressionTest.cpp
+++ b/test/RelationalExpressionTest.cpp
@@ -27,12 +27,23 @@ using valueIdComparators::Comparison;
 // First some internal helper functions and constants.
 namespace {
 
+const auto& testIndexImpl() {
+  static const auto& impl =
+      ad_utility::testing::getQec(sparqlExpression::TestContext::turtleInput)
+          ->getIndex()
+          .getImpl();
+  return impl;
+}
+
 auto lit = [](std::string_view s) {
-  return ad_utility::triple_component::LiteralOrIri(tripleComponentLiteral(s));
+  return LocalVocabEntry{
+      ad_utility::triple_component::LiteralOrIri(tripleComponentLiteral(s)),
+      testIndexImpl()};
 };
 
 auto iriref = [](std::string_view s) {
-  return ad_utility::triple_component::LiteralOrIri(iri(s));
+  return LocalVocabEntry{ad_utility::triple_component::LiteralOrIri(iri(s)),
+                         testIndexImpl()};
 };
 
 // Convenient access to constants for "infinity" and "not a number". The

--- a/test/RelationalExpressionTest.cpp
+++ b/test/RelationalExpressionTest.cpp
@@ -752,12 +752,10 @@ TEST(RelationalExpression, VariableAndConstant) {
   auto U = Id::makeUndefined();
   auto B = ad_utility::testing::BoolId;
   testWithExplicitIdResult<GT>(
-      IdOrLocalVocabEntry{
-          LocalVocabEntry::fromStringRepresentation("<xa>", qec->getIndex())},
+      IdOrLocalVocabEntry{LocalVocabEntry::fromIriref("<xa>", qec->getIndex())},
       Variable{"?mixed"}, {U, U, B(true)});
   testWithExplicitIdResult<LT>(
-      IdOrLocalVocabEntry{
-          LocalVocabEntry::fromStringRepresentation("<u>", qec->getIndex())},
+      IdOrLocalVocabEntry{LocalVocabEntry::fromIriref("<u>", qec->getIndex())},
       Variable{"?mixed"}, {U, U, B(true)});
 
   // Note: `1` and `<x>` are "not compatible", so even the "not equal"
@@ -886,8 +884,7 @@ TEST(RelationalExpression, VariableAndConstantBinarySearch) {
   testSortedVariableAndConstant<GT>(mixed, -inf, {{{0, 2}}});
   testSortedVariableAndConstant<LE>(
       mixed,
-      IdOrLocalVocabEntry{
-          LocalVocabEntry::fromStringRepresentation("<z>", qec->getIndex())},
+      IdOrLocalVocabEntry{LocalVocabEntry::fromIriref("<z>", qec->getIndex())},
       {{{2, 3}}});
 }
 

--- a/test/RelationalExpressionTest.cpp
+++ b/test/RelationalExpressionTest.cpp
@@ -27,23 +27,12 @@ using valueIdComparators::Comparison;
 // First some internal helper functions and constants.
 namespace {
 
-const auto& testIndexImpl() {
-  static const auto& impl =
-      ad_utility::testing::getQec(sparqlExpression::TestContext::turtleInput)
-          ->getIndex()
-          .getImpl();
-  return impl;
-}
-
 auto lit = [](std::string_view s) {
-  return LocalVocabEntry{
-      ad_utility::triple_component::LiteralOrIri(tripleComponentLiteral(s)),
-      testIndexImpl()};
+  return ad_utility::triple_component::LiteralOrIri(tripleComponentLiteral(s));
 };
 
 auto iriref = [](std::string_view s) {
-  return LocalVocabEntry{ad_utility::triple_component::LiteralOrIri(iri(s)),
-                         testIndexImpl()};
+  return ad_utility::triple_component::LiteralOrIri(iri(s));
 };
 
 // Convenient access to constants for "infinity" and "not a number". The
@@ -334,9 +323,13 @@ TEST(RelationalExpression, DoubleAndDouble) {
 }
 
 TEST(RelationalExpression, StringAndString) {
+  auto* qec = getQec();
+  auto lve = [qec](std::string_view literal) {
+    return LocalVocabEntry{lit(literal), qec->getIndex()};
+  };
   testLessThanGreaterThanEqualHelper<IdOrLocalVocabEntry, IdOrLocalVocabEntry>(
-      {lit("alpha"), lit("beta")}, {lit("sigma"), lit("delta")},
-      {lit("epsilon"), lit("epsilon")});
+      {lve("alpha"), lve("beta")}, {lve("sigma"), lve("delta")},
+      {lve("epsilon"), lve("epsilon")});
   // TODO<joka921> These tests only work, when we actually use unicode
   // comparisons for the string based expressions.
   // TODO<joka921> Add an example for strings that are bytewise different but
@@ -347,18 +340,22 @@ TEST(RelationalExpression, StringAndString) {
 }
 
 TEST(RelationalExpression, NumericAndStringAreNeverEqual) {
+  auto* qec = getQec();
+  auto lve = [qec](std::string_view literal) {
+    return LocalVocabEntry{lit(literal), qec->getIndex()};
+  };
   auto stringVec = VectorWithMemoryLimit<IdOrLocalVocabEntry>(
-      {lit("hallo"), lit("by"), lit("")}, makeAllocator());
+      {lve("hallo"), lve("by"), lve("")}, makeAllocator());
   auto intVec =
       VectorWithMemoryLimit<int64_t>({-12365, 0, 12}, makeAllocator());
   auto doubleVec =
       VectorWithMemoryLimit<double>({-12.365, 0, 12.1e5}, makeAllocator());
-  testUndefHelper(int64_t{3}, IdOrLocalVocabEntry{lit("hallo")});
-  testUndefHelper(int64_t{3}, IdOrLocalVocabEntry{lit("3")});
-  testUndefHelper(-12.0, IdOrLocalVocabEntry{lit("hallo")});
-  testUndefHelper(-12.0, IdOrLocalVocabEntry{lit("-12.0")});
-  testUndefHelper(intVec.clone(), IdOrLocalVocabEntry{lit("someString")});
-  testUndefHelper(doubleVec.clone(), IdOrLocalVocabEntry{lit("someString")});
+  testUndefHelper(int64_t{3}, IdOrLocalVocabEntry{lve("hallo")});
+  testUndefHelper(int64_t{3}, IdOrLocalVocabEntry{lve("3")});
+  testUndefHelper(-12.0, IdOrLocalVocabEntry{lve("hallo")});
+  testUndefHelper(-12.0, IdOrLocalVocabEntry{lve("-12.0")});
+  testUndefHelper(intVec.clone(), IdOrLocalVocabEntry{lve("someString")});
+  testUndefHelper(doubleVec.clone(), IdOrLocalVocabEntry{lve("someString")});
   testUndefHelper(int64_t{3}, stringVec.clone());
   testUndefHelper(intVec.clone(), stringVec.clone());
   testUndefHelper(doubleVec.clone(), stringVec.clone());
@@ -580,12 +577,16 @@ TEST(RelationalExpression, NumericConstantAndNumericVector) {
 }
 
 TEST(RelationalExpression, StringConstantsAndStringVector) {
+  auto* qec = getQec();
+  auto lve = [qec](std::string_view literal) {
+    return LocalVocabEntry{lit(literal), qec->getIndex()};
+  };
   VectorWithMemoryLimit<IdOrLocalVocabEntry> vec(
-      {lit("alpha"), lit("alpaka"), lit("bertram"), lit("sigma"), lit("zeta"),
-       lit("kaulquappe"), lit("caesar"), lit("caesar"), lit("caesar")},
+      {lve("alpha"), lve("alpaka"), lve("bertram"), lve("sigma"), lve("zeta"),
+       lve("kaulquappe"), lve("caesar"), lve("caesar"), lve("caesar")},
       makeAllocator());
   testLessThanGreaterThanEqualMultipleValuesHelper(
-      IdOrLocalVocabEntry{lit("caesar")}, vec.clone());
+      IdOrLocalVocabEntry{lve("caesar")}, vec.clone());
 
   // TODO<joka921> These tests only work, when we actually use unicode
   // comparisons for the string based expressions. TODDO<joka921> Add an example
@@ -637,13 +638,17 @@ TEST(RelationalExpression, DoubleVectorAndIntVector) {
 }
 
 TEST(RelationalExpression, StringVectorAndStringVector) {
+  auto* qec = getQec();
+  auto lve = [qec](std::string_view literal) {
+    return LocalVocabEntry{lit(literal), qec->getIndex()};
+  };
   VectorWithMemoryLimit<IdOrLocalVocabEntry> vecA{
-      {lit("alpha"), lit("beta"), lit("g"), lit("epsilon"), lit("fraud"),
-       lit("capitalism"), lit(""), lit("bo'sä30"), lit("Me")},
+      {lve("alpha"), lve("beta"), lve("g"), lve("epsilon"), lve("fraud"),
+       lve("capitalism"), lve(""), lve("bo'sä30"), lve("Me")},
       makeAllocator()};
   VectorWithMemoryLimit<IdOrLocalVocabEntry> vecB{
-      {lit("alph"), lit("alpha"), lit("f"), lit("epsiloo"), lit("freud"),
-       lit("communism"), lit(""), lit("bo'sä30"), lit("Me")},
+      {lve("alph"), lve("alpha"), lve("f"), lve("epsiloo"), lve("freud"),
+       lve("communism"), lve(""), lve("bo'sä30"), lve("Me")},
       makeAllocator()};
   testLessThanGreaterThanEqualMultipleValuesHelper(vecA.clone(), vecB.clone());
   // TODO<joka921> Add a test case for correct unicode collation as soon as that
@@ -673,6 +678,12 @@ void testInExpressionVector(T1 leftValue, T2 rightValue, Ctx& ctx,
   check();
 }
 
+// Helper function to expose a static `TestContext` instance.
+TestContext& testContext() {
+  static TestContext ctx;
+  return ctx;
+}
+
 // Assert that the expression `leftValue Comparator rightValue`, when evaluated
 // on the `TestContext` (see above), yields the `expected` result.
 
@@ -680,7 +691,7 @@ template <Comparison Comp, typename T1, typename T2>
 void testWithExplicitIdResult(T1 leftValue, T2 rightValue,
                               std::vector<Id> expected,
                               source_location l = AD_CURRENT_SOURCE_LOC()) {
-  static TestContext ctx;
+  auto& ctx = testContext();
   auto expression =
       makeExpression<Comp>(liftToValueId(leftValue), liftToValueId(rightValue));
   auto trace = generateLocationTrace(l, "test lambda was called here");
@@ -707,6 +718,10 @@ void testWithExplicitResult(T1 leftValue, T2 rightValue,
 }
 
 TEST(RelationalExpression, VariableAndConstant) {
+  auto* qec = testContext().qec;
+  auto lve = [qec](std::string_view literal) {
+    return LocalVocabEntry{lit(literal), qec->getIndex()};
+  };
   // ?ints column is `1, 0, -1`
   testWithExplicitResult<LT>(int64_t{0}, Variable{"?ints"},
                              {true, false, false});
@@ -729,21 +744,23 @@ TEST(RelationalExpression, VariableAndConstant) {
 
   // ?vocab column is `"Beta", "alpha", "älpha"
   testWithExplicitResult<LE>(Variable{"?vocab"},
-                             IdOrLocalVocabEntry{lit("\"älpha\"")},
+                             IdOrLocalVocabEntry{lve("\"älpha\"")},
                              {false, true, true});
   testWithExplicitResult<GT>(Variable{"?vocab"},
-                             IdOrLocalVocabEntry{lit("\"alpha\"")},
+                             IdOrLocalVocabEntry{lve("\"alpha\"")},
                              {true, false, true});
-  testWithExplicitResult<LT>(IdOrLocalVocabEntry{lit("\"atm\"")},
+  testWithExplicitResult<LT>(IdOrLocalVocabEntry{lve("\"atm\"")},
                              Variable{"?vocab"}, {true, false, false});
 
   // ?mixed column is `1, -0.1, <x>`
   auto U = Id::makeUndefined();
   auto B = ad_utility::testing::BoolId;
-  testWithExplicitIdResult<GT>(IdOrLocalVocabEntry{iriref("<xa>")},
-                               Variable{"?mixed"}, {U, U, B(true)});
-  testWithExplicitIdResult<LT>(IdOrLocalVocabEntry{iriref("<u>")},
-                               Variable{"?mixed"}, {U, U, B(true)});
+  testWithExplicitIdResult<GT>(
+      IdOrLocalVocabEntry{LocalVocabEntry{iriref("<xa>"), qec->getIndex()}},
+      Variable{"?mixed"}, {U, U, B(true)});
+  testWithExplicitIdResult<LT>(
+      IdOrLocalVocabEntry{LocalVocabEntry{iriref("<u>"), qec->getIndex()}},
+      Variable{"?mixed"}, {U, U, B(true)});
 
   // Note: `1` and `<x>` are "not compatible", so even the "not equal"
   // comparison returns false.
@@ -821,6 +838,10 @@ void testSortedVariableAndConstant(
 }
 
 TEST(RelationalExpression, VariableAndConstantBinarySearch) {
+  auto* qec = testContext().qec;
+  auto lve = [qec](std::string_view literal) {
+    return LocalVocabEntry{lit(literal), qec->getIndex()};
+  };
   // Sorted order (by bits of the valueIds):
   // ?ints column is `0, 1,  -1`
   // ?doubles column is `0.1 , 2.8`,-0.1
@@ -837,7 +858,7 @@ TEST(RelationalExpression, VariableAndConstantBinarySearch) {
   testSortedVariableAndConstant<GE>(ints, int64_t{-1}, {{{0, 3}}});
   testSortedVariableAndConstant<LE>(ints, 0.3, {{{0, 1}, {2, 3}}});
   // ints and strings are always incompatible.
-  testSortedVariableAndConstant<NE>(ints, IdOrLocalVocabEntry{lit("a string")},
+  testSortedVariableAndConstant<NE>(ints, IdOrLocalVocabEntry{lve("a string")},
                                     {});
 
   testSortedVariableAndConstant<GT>(doubles, int64_t{0}, {{{0, 2}}});
@@ -849,13 +870,13 @@ TEST(RelationalExpression, VariableAndConstantBinarySearch) {
   testSortedVariableAndConstant<NE>(numeric, 3.4, {{{0, 1}, {2, 3}}});
 
   testSortedVariableAndConstant<GT>(
-      vocab, IdOrLocalVocabEntry{lit("\"alpha\"")}, {{{1, 3}}});
+      vocab, IdOrLocalVocabEntry{lve("\"alpha\"")}, {{{1, 3}}});
   testSortedVariableAndConstant<GE>(
-      vocab, IdOrLocalVocabEntry{lit("\"alpha\"")}, {{{0, 3}}});
-  testSortedVariableAndConstant<LE>(vocab, IdOrLocalVocabEntry{lit("\"ball\"")},
+      vocab, IdOrLocalVocabEntry{lve("\"alpha\"")}, {{{0, 3}}});
+  testSortedVariableAndConstant<LE>(vocab, IdOrLocalVocabEntry{lve("\"ball\"")},
                                     {{{0, 2}}});
   testSortedVariableAndConstant<NE>(
-      vocab, IdOrLocalVocabEntry{lit("\"älpha\"")}, {{{0, 1}, {2, 3}}});
+      vocab, IdOrLocalVocabEntry{lve("\"älpha\"")}, {{{0, 1}, {2, 3}}});
   testSortedVariableAndConstant<LE>(vocab, inf, {});
 
   // Note: vocab entries and numeric values are not compatible, so every
@@ -865,11 +886,11 @@ TEST(RelationalExpression, VariableAndConstantBinarySearch) {
   // Note: only *numeric* values that are not equal to 1.0 are considered here.
   testSortedVariableAndConstant<NE>(mixed, 1.0, {{{1, 2}}});
   testSortedVariableAndConstant<GT>(mixed, -inf, {{{0, 2}}});
-  testSortedVariableAndConstant<LE>(mixed, IdOrLocalVocabEntry{iriref("<z>")},
-                                    {{{2, 3}}});
+  testSortedVariableAndConstant<LE>(
+      mixed,
+      IdOrLocalVocabEntry{LocalVocabEntry{iriref("<z>"), qec->getIndex()}},
+      {{{2, 3}}});
 }
-
-TEST(RelationalExpression, InExpression) {}
 
 TEST(RelationalExpression, InExpressionSimpleMemberVariables) {
   auto makeInt = [](int i) {

--- a/test/RelationalExpressionTest.cpp
+++ b/test/RelationalExpressionTest.cpp
@@ -31,10 +31,6 @@ auto lit = [](std::string_view s) {
   return ad_utility::triple_component::LiteralOrIri(tripleComponentLiteral(s));
 };
 
-auto iriref = [](std::string_view s) {
-  return ad_utility::triple_component::LiteralOrIri(iri(s));
-};
-
 // Convenient access to constants for "infinity" and "not a number". The
 // spelling `NaN` was chosen because `nan` conflicts with the standard library.
 const auto inf = std::numeric_limits<double>::infinity();
@@ -756,10 +752,12 @@ TEST(RelationalExpression, VariableAndConstant) {
   auto U = Id::makeUndefined();
   auto B = ad_utility::testing::BoolId;
   testWithExplicitIdResult<GT>(
-      IdOrLocalVocabEntry{LocalVocabEntry{iriref("<xa>"), qec->getIndex()}},
+      IdOrLocalVocabEntry{
+          LocalVocabEntry::fromStringRepresentation("<xa>", qec->getIndex())},
       Variable{"?mixed"}, {U, U, B(true)});
   testWithExplicitIdResult<LT>(
-      IdOrLocalVocabEntry{LocalVocabEntry{iriref("<u>"), qec->getIndex()}},
+      IdOrLocalVocabEntry{
+          LocalVocabEntry::fromStringRepresentation("<u>", qec->getIndex())},
       Variable{"?mixed"}, {U, U, B(true)});
 
   // Note: `1` and `<x>` are "not compatible", so even the "not equal"
@@ -888,7 +886,8 @@ TEST(RelationalExpression, VariableAndConstantBinarySearch) {
   testSortedVariableAndConstant<GT>(mixed, -inf, {{{0, 2}}});
   testSortedVariableAndConstant<LE>(
       mixed,
-      IdOrLocalVocabEntry{LocalVocabEntry{iriref("<z>"), qec->getIndex()}},
+      IdOrLocalVocabEntry{
+          LocalVocabEntry::fromStringRepresentation("<z>", qec->getIndex())},
       {{{2, 3}}});
 }
 

--- a/test/ResultTest.cpp
+++ b/test/ResultTest.cpp
@@ -179,9 +179,9 @@ TEST(Result, verifyRunOnNewChunkComputedFiresCorrectly) {
       [](auto* qec, auto& t1, auto& t2, auto& t3) -> Result::Generator {
         std::this_thread::sleep_for(1ms);
         LocalVocab localVocab{};
-        localVocab.getIndexAndAddIfNotContained(LocalVocabEntry{
-            ad_utility::triple_component::Literal::literalWithoutQuotes("Test"),
-            qec->getIndex()});
+        localVocab.getIndexAndAddIfNotContained(
+            LocalVocabEntry::literalWithoutQuotes("Test",
+                                                  qec->getLocalVocabContext()));
         co_yield {t1.clone(), std::move(localVocab)};
         std::this_thread::sleep_for(3ms);
         co_yield {t2.clone(), LocalVocab{}};

--- a/test/ResultTest.cpp
+++ b/test/ResultTest.cpp
@@ -170,23 +170,24 @@ TEST(Result, verifyRunOnNewChunkComputedThrowsWithFullyMaterializedResult) {
 
 // _____________________________________________________________________________
 TEST(Result, verifyRunOnNewChunkComputedFiresCorrectly) {
+  auto* queryExecutionContext = ad_utility::testing::getQec();
   auto idTable1 = makeIdTableFromVector({{1, 6, 0}, {2, 5, 0}});
   auto idTable2 = makeIdTableFromVector({{3, 4, 0}});
   auto idTable3 = makeIdTableFromVector({{1, 6, 0}, {2, 5, 0}, {3, 4, 0}});
 
   Result result{
-      [](auto& t1, auto& t2, auto& t3) -> Result::Generator {
+      [](auto* qec, auto& t1, auto& t2, auto& t3) -> Result::Generator {
         std::this_thread::sleep_for(1ms);
         LocalVocab localVocab{};
         localVocab.getIndexAndAddIfNotContained(LocalVocabEntry{
             ad_utility::triple_component::Literal::literalWithoutQuotes("Test"),
-            ad_utility::testing::getQec()->getIndex().getImpl()});
+            qec->getIndex()});
         co_yield {t1.clone(), std::move(localVocab)};
         std::this_thread::sleep_for(3ms);
         co_yield {t2.clone(), LocalVocab{}};
         std::this_thread::sleep_for(5ms);
         co_yield {t3.clone(), LocalVocab{}};
-      }(idTable1, idTable2, idTable3),
+      }(queryExecutionContext, idTable1, idTable2, idTable3),
       {}};
   uint32_t callCounter = 0;
   bool finishedConsuming = false;

--- a/test/ResultTest.cpp
+++ b/test/ResultTest.cpp
@@ -6,6 +6,7 @@
 
 #include "engine/Result.h"
 #include "util/IdTableHelpers.h"
+#include "util/IndexTestHelpers.h"
 
 using namespace std::chrono_literals;
 using ::testing::AnyOf;
@@ -178,8 +179,8 @@ TEST(Result, verifyRunOnNewChunkComputedFiresCorrectly) {
         std::this_thread::sleep_for(1ms);
         LocalVocab localVocab{};
         localVocab.getIndexAndAddIfNotContained(LocalVocabEntry{
-            ad_utility::triple_component::Literal::literalWithoutQuotes(
-                "Test")});
+            ad_utility::triple_component::Literal::literalWithoutQuotes("Test"),
+            ad_utility::testing::getQec()->getIndex().getImpl()});
         co_yield {t1.clone(), std::move(localVocab)};
         std::this_thread::sleep_for(3ms);
         co_yield {t2.clone(), LocalVocab{}};

--- a/test/ServiceTest.cpp
+++ b/test/ServiceTest.cpp
@@ -209,12 +209,15 @@ TEST_F(ServiceTest, computeResult) {
           }
 
           // create expected idTable
+          const auto& indexImpl =
+              ad_utility::testing::getQec()->getIndex().getImpl();
           auto get =
-              [&localVocabs](
+              [&localVocabs, &indexImpl](
                   const std::string& s) -> std::optional<LocalVocabIndex> {
             for (const LocalVocab& localVocab : localVocabs) {
-              auto index = localVocab.getIndexOrNullopt(
-                  ad_utility::triple_component::LiteralOrIri::iriref(s));
+              auto index = localVocab.getIndexOrNullopt(LocalVocabEntry{
+                  ad_utility::triple_component::LiteralOrIri::iriref(s),
+                  indexImpl});
               if (index.has_value()) {
                 return index;
               }
@@ -382,9 +385,10 @@ TEST_F(ServiceTest, computeResult) {
     Id idY = getId("<y>");
     const auto& localVocab = result.localVocab();
     EXPECT_EQ(localVocab.size(), 3);
-    auto get = [&localVocab](const std::string& s) {
-      return localVocab.getIndexOrNullopt(
-          ad_utility::triple_component::LiteralOrIri::iriref(s));
+    const auto& indexImpl = testQec->getIndex().getImpl();
+    auto get = [&localVocab, &indexImpl](const std::string& s) {
+      return localVocab.getIndexOrNullopt(LocalVocabEntry{
+          ad_utility::triple_component::LiteralOrIri::iriref(s), indexImpl});
     };
     std::optional<LocalVocabIndex> idxBla = get("<bla>");
     std::optional<LocalVocabIndex> idxBli = get("<bli>");
@@ -722,9 +726,10 @@ TEST_F(ServiceTest, idToValueForValuesClause) {
   EXPECT_EQ(idToVc(index, Id::makeFromBool(true), localVocab), "true");
 
   // Escape Quotes within literals.
-  auto str = LocalVocabEntry(
+  auto str = LocalVocabEntry{
       ad_utility::triple_component::LiteralOrIri::literalWithoutQuotes(
-          "a\"b\"c"));
+          "a\"b\"c"),
+      index.getImpl()};
   EXPECT_EQ(idToVc(index, Id::makeFromLocalVocabIndex(&str), localVocab),
             "\"a\\\"b\\\"c\"");
 

--- a/test/ServiceTest.cpp
+++ b/test/ServiceTest.cpp
@@ -383,10 +383,10 @@ TEST_F(ServiceTest, computeResult) {
     Id idY = getId("<y>");
     const auto& localVocab = result.localVocab();
     EXPECT_EQ(localVocab.size(), 3);
-    const auto& indexImpl = testQec->getIndex().getImpl();
-    auto get = [&localVocab, &indexImpl](const std::string& s) {
+    const auto& index = testQec->getIndex();
+    auto get = [&localVocab, &index](const std::string& s) {
       return localVocab.getIndexOrNullopt(LocalVocabEntry{
-          ad_utility::triple_component::LiteralOrIri::iriref(s), indexImpl});
+          ad_utility::triple_component::LiteralOrIri::iriref(s), index});
     };
     std::optional<LocalVocabIndex> idxBla = get("<bla>");
     std::optional<LocalVocabIndex> idxBli = get("<bli>");
@@ -727,7 +727,7 @@ TEST_F(ServiceTest, idToValueForValuesClause) {
   auto str = LocalVocabEntry{
       ad_utility::triple_component::LiteralOrIri::literalWithoutQuotes(
           "a\"b\"c"),
-      index.getImpl()};
+      index};
   EXPECT_EQ(idToVc(index, Id::makeFromLocalVocabIndex(&str), localVocab),
             "\"a\\\"b\\\"c\"");
 

--- a/test/ServiceTest.cpp
+++ b/test/ServiceTest.cpp
@@ -36,8 +36,6 @@ class ServiceTest : public ::testing::Test {
   // see `IndexTestHelpers.h`. Note that `getQec` returns a pointer to a static
   // `QueryExecutionContext`, so no need to ever delete `testQec`.
   QueryExecutionContext* testQec = ad_utility::testing::getQec();
-  ad_utility::AllocatorWithLimit<Id> testAllocator =
-      ad_utility::testing::makeAllocator();
 
   // Factory for generating mocks of the `sendHttpOrHttpsRequest` function that
   // is used by default by a `Service` operation (see the constructor in

--- a/test/ServiceTest.cpp
+++ b/test/ServiceTest.cpp
@@ -207,13 +207,11 @@ TEST_F(ServiceTest, computeResult) {
           }
 
           // create expected idTable
-          auto get =
-              [this, &localVocabs](
-                  const std::string& s) -> std::optional<LocalVocabIndex> {
+          auto get = [this, &localVocabs](
+                         std::string_view s) -> std::optional<LocalVocabIndex> {
             for (const LocalVocab& localVocab : localVocabs) {
               auto index = localVocab.getIndexOrNullopt(
-                  LocalVocabEntry::fromStringRepresentation(
-                      s, testQec->getIndex()));
+                  LocalVocabEntry::fromIriref(s, testQec->getIndex()));
               if (index.has_value()) {
                 return index;
               }
@@ -382,9 +380,9 @@ TEST_F(ServiceTest, computeResult) {
     const auto& localVocab = result.localVocab();
     EXPECT_EQ(localVocab.size(), 3);
     const auto& index = testQec->getIndex();
-    auto get = [&localVocab, &index](const std::string& s) {
+    auto get = [&localVocab, &index](std::string_view s) {
       return localVocab.getIndexOrNullopt(
-          LocalVocabEntry::fromStringRepresentation(s, index));
+          LocalVocabEntry::fromIriref(s, index));
     };
     std::optional<LocalVocabIndex> idxBla = get("<bla>");
     std::optional<LocalVocabIndex> idxBli = get("<bli>");

--- a/test/ServiceTest.cpp
+++ b/test/ServiceTest.cpp
@@ -196,8 +196,8 @@ TEST_F(ServiceTest, computeResult) {
     // Compute the Result lazily for the given Service and check that the
     // resulting IdTable equals the expected IdTable-vector.
     auto checkLazyResult =
-        [](Service& service,
-           const std::vector<std::vector<std::string>>& expIdTableVector) {
+        [this](Service& service,
+               const std::vector<std::vector<std::string>>& expIdTableVector) {
           auto result = service.computeResultOnlyForTesting(true);
 
           // compute resulting idTable
@@ -209,15 +209,13 @@ TEST_F(ServiceTest, computeResult) {
           }
 
           // create expected idTable
-          const auto& indexImpl =
-              ad_utility::testing::getQec()->getIndex().getImpl();
           auto get =
-              [&localVocabs, &indexImpl](
+              [this, &localVocabs](
                   const std::string& s) -> std::optional<LocalVocabIndex> {
             for (const LocalVocab& localVocab : localVocabs) {
               auto index = localVocab.getIndexOrNullopt(LocalVocabEntry{
                   ad_utility::triple_component::LiteralOrIri::iriref(s),
-                  indexImpl});
+                  testQec->getIndex()});
               if (index.has_value()) {
                 return index;
               }

--- a/test/ServiceTest.cpp
+++ b/test/ServiceTest.cpp
@@ -211,9 +211,9 @@ TEST_F(ServiceTest, computeResult) {
               [this, &localVocabs](
                   const std::string& s) -> std::optional<LocalVocabIndex> {
             for (const LocalVocab& localVocab : localVocabs) {
-              auto index = localVocab.getIndexOrNullopt(LocalVocabEntry{
-                  ad_utility::triple_component::LiteralOrIri::iriref(s),
-                  testQec->getIndex()});
+              auto index = localVocab.getIndexOrNullopt(
+                  LocalVocabEntry::fromStringRepresentation(
+                      s, testQec->getIndex()));
               if (index.has_value()) {
                 return index;
               }
@@ -383,8 +383,8 @@ TEST_F(ServiceTest, computeResult) {
     EXPECT_EQ(localVocab.size(), 3);
     const auto& index = testQec->getIndex();
     auto get = [&localVocab, &index](const std::string& s) {
-      return localVocab.getIndexOrNullopt(LocalVocabEntry{
-          ad_utility::triple_component::LiteralOrIri::iriref(s), index});
+      return localVocab.getIndexOrNullopt(
+          LocalVocabEntry::fromStringRepresentation(s, index));
     };
     std::optional<LocalVocabIndex> idxBla = get("<bla>");
     std::optional<LocalVocabIndex> idxBli = get("<bli>");

--- a/test/ServiceTest.cpp
+++ b/test/ServiceTest.cpp
@@ -210,8 +210,9 @@ TEST_F(ServiceTest, computeResult) {
           auto get = [this, &localVocabs](
                          std::string_view s) -> std::optional<LocalVocabIndex> {
             for (const LocalVocab& localVocab : localVocabs) {
-              auto index = localVocab.getIndexOrNullopt(
-                  LocalVocabEntry::fromIriref(s, testQec->getIndex()));
+              auto index =
+                  localVocab.getIndexOrNullopt(LocalVocabEntry::fromIriref(
+                      s, testQec->getLocalVocabContext()));
               if (index.has_value()) {
                 return index;
               }
@@ -379,10 +380,10 @@ TEST_F(ServiceTest, computeResult) {
     Id idY = getId("<y>");
     const auto& localVocab = result.localVocab();
     EXPECT_EQ(localVocab.size(), 3);
-    const auto& index = testQec->getIndex();
-    auto get = [&localVocab, &index](std::string_view s) {
+    const auto& localVocabContext = testQec->getLocalVocabContext();
+    auto get = [&localVocab, &localVocabContext](std::string_view s) {
       return localVocab.getIndexOrNullopt(
-          LocalVocabEntry::fromIriref(s, index));
+          LocalVocabEntry::fromIriref(s, localVocabContext));
     };
     std::optional<LocalVocabIndex> idxBla = get("<bla>");
     std::optional<LocalVocabIndex> idxBli = get("<bli>");

--- a/test/ServiceTest.cpp
+++ b/test/ServiceTest.cpp
@@ -721,10 +721,7 @@ TEST_F(ServiceTest, idToValueForValuesClause) {
   EXPECT_EQ(idToVc(index, Id::makeFromBool(true), localVocab), "true");
 
   // Escape Quotes within literals.
-  auto str = LocalVocabEntry{
-      ad_utility::triple_component::LiteralOrIri::literalWithoutQuotes(
-          "a\"b\"c"),
-      index};
+  auto str = LocalVocabEntry::literalWithoutQuotes("a\"b\"c", index);
   EXPECT_EQ(idToVc(index, Id::makeFromLocalVocabIndex(&str), localVocab),
             "\"a\\\"b\\\"c\"");
 

--- a/test/SparqlExpressionGeneratorsTest.cpp
+++ b/test/SparqlExpressionGeneratorsTest.cpp
@@ -15,8 +15,8 @@ using namespace sparqlExpression::detail;
 TEST(SparqlExpressionGenerators, makeStringResultGetter) {
   using ad_utility::triple_component::LiteralOrIri;
   auto* qec = ad_utility::testing::getQec();
-  auto literal = LocalVocabEntry{
-      LiteralOrIri::literalWithoutQuotes("Test String"), qec->getIndex()};
+  auto literal =
+      LocalVocabEntry::literalWithoutQuotes("Test String", qec->getIndex());
   LocalVocab localVocab{};
 
   auto function = makeStringResultGetter(&localVocab);
@@ -31,8 +31,8 @@ TEST(SparqlExpressionGenerators, makeStringResultGetter) {
 TEST(SparqlExpressionGenerators, idOrLiteralOrIriToId) {
   using ad_utility::triple_component::LiteralOrIri;
   auto* qec = ad_utility::testing::getQec();
-  auto literal = LocalVocabEntry{
-      LiteralOrIri::literalWithoutQuotes("Test String"), qec->getIndex()};
+  auto literal =
+      LocalVocabEntry::literalWithoutQuotes("Test String", qec->getIndex());
   LocalVocab localVocab{};
 
   auto result = idOrLiteralOrIriToId(literal, &localVocab);

--- a/test/SparqlExpressionGeneratorsTest.cpp
+++ b/test/SparqlExpressionGeneratorsTest.cpp
@@ -7,13 +7,16 @@
 
 #include "engine/sparqlExpressions/SparqlExpressionGenerators.h"
 #include "util/GTestHelpers.h"
+#include "util/IndexTestHelpers.h"
 
 using namespace sparqlExpression::detail;
 
 // _____________________________________________________________________________
 TEST(SparqlExpressionGenerators, makeStringResultGetter) {
   using ad_utility::triple_component::LiteralOrIri;
-  auto literal = LiteralOrIri::literalWithoutQuotes("Test String");
+  const auto& index = ad_utility::testing::getQec()->getIndex().getImpl();
+  auto literal =
+      LocalVocabEntry{LiteralOrIri::literalWithoutQuotes("Test String"), index};
   LocalVocab localVocab{};
 
   auto function = makeStringResultGetter(&localVocab);
@@ -27,7 +30,9 @@ TEST(SparqlExpressionGenerators, makeStringResultGetter) {
 // _____________________________________________________________________________
 TEST(SparqlExpressionGenerators, idOrLiteralOrIriToId) {
   using ad_utility::triple_component::LiteralOrIri;
-  auto literal = LiteralOrIri::literalWithoutQuotes("Test String");
+  const auto& index = ad_utility::testing::getQec()->getIndex().getImpl();
+  auto literal =
+      LocalVocabEntry{LiteralOrIri::literalWithoutQuotes("Test String"), index};
   LocalVocab localVocab{};
 
   auto result = idOrLiteralOrIriToId(literal, &localVocab);

--- a/test/SparqlExpressionGeneratorsTest.cpp
+++ b/test/SparqlExpressionGeneratorsTest.cpp
@@ -14,9 +14,9 @@ using namespace sparqlExpression::detail;
 // _____________________________________________________________________________
 TEST(SparqlExpressionGenerators, makeStringResultGetter) {
   using ad_utility::triple_component::LiteralOrIri;
-  const auto& index = ad_utility::testing::getQec()->getIndex().getImpl();
-  auto literal =
-      LocalVocabEntry{LiteralOrIri::literalWithoutQuotes("Test String"), index};
+  auto* qec = ad_utility::testing::getQec();
+  auto literal = LocalVocabEntry{
+      LiteralOrIri::literalWithoutQuotes("Test String"), qec->getIndex()};
   LocalVocab localVocab{};
 
   auto function = makeStringResultGetter(&localVocab);
@@ -30,9 +30,9 @@ TEST(SparqlExpressionGenerators, makeStringResultGetter) {
 // _____________________________________________________________________________
 TEST(SparqlExpressionGenerators, idOrLiteralOrIriToId) {
   using ad_utility::triple_component::LiteralOrIri;
-  const auto& index = ad_utility::testing::getQec()->getIndex().getImpl();
-  auto literal =
-      LocalVocabEntry{LiteralOrIri::literalWithoutQuotes("Test String"), index};
+  auto* qec = ad_utility::testing::getQec();
+  auto literal = LocalVocabEntry{
+      LiteralOrIri::literalWithoutQuotes("Test String"), qec->getIndex()};
   LocalVocab localVocab{};
 
   auto result = idOrLiteralOrIriToId(literal, &localVocab);

--- a/test/SparqlExpressionGeneratorsTest.cpp
+++ b/test/SparqlExpressionGeneratorsTest.cpp
@@ -15,8 +15,8 @@ using namespace sparqlExpression::detail;
 TEST(SparqlExpressionGenerators, makeStringResultGetter) {
   using ad_utility::triple_component::LiteralOrIri;
   auto* qec = ad_utility::testing::getQec();
-  auto literal =
-      LocalVocabEntry::literalWithoutQuotes("Test String", qec->getIndex());
+  auto literal = LocalVocabEntry::literalWithoutQuotes(
+      "Test String", qec->getLocalVocabContext());
   LocalVocab localVocab{};
 
   auto function = makeStringResultGetter(&localVocab);
@@ -31,8 +31,8 @@ TEST(SparqlExpressionGenerators, makeStringResultGetter) {
 TEST(SparqlExpressionGenerators, idOrLiteralOrIriToId) {
   using ad_utility::triple_component::LiteralOrIri;
   auto* qec = ad_utility::testing::getQec();
-  auto literal =
-      LocalVocabEntry::literalWithoutQuotes("Test String", qec->getIndex());
+  auto literal = LocalVocabEntry::literalWithoutQuotes(
+      "Test String", qec->getLocalVocabContext());
   LocalVocab localVocab{};
 
   auto result = idOrLiteralOrIriToId(literal, &localVocab);

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -26,6 +26,7 @@
 #include "engine/sparqlExpressions/SparqlExpression.h"
 #include "engine/sparqlExpressions/SparqlExpressionTypes.h"
 #include "engine/sparqlExpressions/StdevExpression.h"
+#include "index/Index.h"
 #include "rdfTypes/GeoPoint.h"
 #include "rdfTypes/GeometryInfo.h"
 #include "util/AllocatorTestHelpers.h"
@@ -57,13 +58,24 @@ auto U = Id::makeUndefined();
 using Ids = std::vector<Id>;
 using IdOrLocalVocabEntryVec = std::vector<IdOrLocalVocabEntry>;
 
+const auto& testIndexImpl() {
+  static const auto& impl =
+      ad_utility::testing::getQec(sparqlExpression::TestContext::turtleInput)
+          ->getIndex()
+          .getImpl();
+  return impl;
+}
+
 auto lit = [](std::string_view s, std::string_view langtagOrDatatype = "") {
-  return ad_utility::triple_component::LiteralOrIri(
-      ad_utility::testing::tripleComponentLiteral(s, langtagOrDatatype));
+  return LocalVocabEntry{
+      ad_utility::triple_component::LiteralOrIri(
+          ad_utility::testing::tripleComponentLiteral(s, langtagOrDatatype)),
+      testIndexImpl()};
 };
 
 auto iriref = [](std::string_view s) {
-  return ad_utility::triple_component::LiteralOrIri(iri(s));
+  return LocalVocabEntry{ad_utility::triple_component::LiteralOrIri(iri(s)),
+                         testIndexImpl()};
 };
 
 auto idOrLitOrStringVec =
@@ -772,11 +784,12 @@ TEST(SparqlExpression, stringOperators) {
       DateYearOrDuration(11853, DateYearOrDuration::Type::Year));
   // Test `iriOrUriExpression`.
   // test invalid
-  checkIriOrUri(IdOrLocalVocabEntryVec{U, U, U, U, U, U, U},
-                std::tuple{IdOrLocalVocabEntryVec{U, IntId(2), DoubleId(12.99),
-                                                  dateDate, dateLYear, T, F},
-                           IdOrLocalVocabEntry{LocalVocabEntry{
-                               ad_utility::triple_component::Iri{}}}});
+  checkIriOrUri(
+      IdOrLocalVocabEntryVec{U, U, U, U, U, U, U},
+      std::tuple{IdOrLocalVocabEntryVec{U, IntId(2), DoubleId(12.99), dateDate,
+                                        dateLYear, T, F},
+                 IdOrLocalVocabEntry{LocalVocabEntry{
+                     ad_utility::triple_component::Iri{}, testIndexImpl()}}});
   // test valid
   checkIriOrUri(
       IdOrLocalVocabEntryVec{
@@ -799,8 +812,8 @@ TEST(SparqlExpression, stringOperators) {
               testContext().notInVocabIri, testContext().notInVocabIriLit,
               lit("http://example/"), iriref("<http://\t\t\nexample/>"),
               lit("\t\n\r")},
-          IdOrLocalVocabEntry{
-              LocalVocabEntry{ad_utility::triple_component::Iri{}}}});
+          IdOrLocalVocabEntry{LocalVocabEntry{
+              ad_utility::triple_component::Iri{}, testIndexImpl()}}});
 
   // test with base iri
   checkIriOrUri(
@@ -1454,11 +1467,10 @@ TEST(SparqlExpression, testToBooleanExpression) {
 
   checkGetBoolean(
       IdOrLocalVocabEntryVec(
-          {sparqlExpression::detail::LiteralOrIri{
-               iri("<http://example.org/z>")},
-           lit("string"), lit("-10.2E3"), lit("+33.3300"), lit("0.0"), lit("0"),
-           lit("0E1"), lit("1.5"), lit("1"), lit("1E0"), lit("13"),
-           lit("2002-10-10T17:00:00Z"), lit("false"), lit("true"), T, F,
+          {iriref("<http://example.org/z>"), lit("string"), lit("-10.2E3"),
+           lit("+33.3300"), lit("0.0"), lit("0"), lit("0E1"), lit("1.5"),
+           lit("1"), lit("1E0"), lit("13"), lit("2002-10-10T17:00:00Z"),
+           lit("false"), lit("true"), T, F,
            lit("0", absl::StrCat("^^<", XSD_PREFIX.second, "boolean>")), I(0),
            I(1), I(-1), D(0.0), D(1.0), D(-1.0),
            // The SPARQL compliance tests for the boolean conversion functions

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -58,24 +58,29 @@ auto U = Id::makeUndefined();
 using Ids = std::vector<Id>;
 using IdOrLocalVocabEntryVec = std::vector<IdOrLocalVocabEntry>;
 
-const auto& testIndexImpl() {
-  static const auto& impl =
-      ad_utility::testing::getQec(sparqlExpression::TestContext::turtleInput)
-          ->getIndex()
-          .getImpl();
-  return impl;
+// All the helper functions `testUnaryExpression` etc. below internally evaluate
+// the given expressions using the `TestContext` class, so it is possible to use
+// IDs from the global and local vocab of this class to test expressions. For
+// example `testContext().x` is the ID of the entity `<x>` in the vocabulary of
+// the index on which the expressions will be evaluated. For details see the
+// `TestContext` class. Note: The indirection via a function is necessary
+// because otherwise the `gtest_discover_test` step of the CMake build fails for
+// some reason.
+const auto& testContext() {
+  static TestContext ctx{};
+  return ctx;
 }
 
 auto lit = [](std::string_view s, std::string_view langtagOrDatatype = "") {
   return LocalVocabEntry{
       ad_utility::triple_component::LiteralOrIri(
           ad_utility::testing::tripleComponentLiteral(s, langtagOrDatatype)),
-      testIndexImpl()};
+      testContext().qec->getIndex()};
 };
 
 auto iriref = [](std::string_view s) {
   return LocalVocabEntry{ad_utility::triple_component::LiteralOrIri(iri(s)),
-                         testIndexImpl()};
+                         testContext().qec->getIndex()};
 };
 
 auto idOrLitOrStringVec =
@@ -95,19 +100,6 @@ auto geoLit = [](std::string_view content) {
   return IdOrLocalVocabEntry{
       lit(content, "^^<http://www.opengis.net/ont/geosparql#wktLiteral>")};
 };
-
-// All the helper functions `testUnaryExpression` etc. below internally evaluate
-// the given expressions using the `TestContext` class, so it is possible to use
-// IDs from the global and local vocab of this class to test expressions. For
-// example `testContext().x` is the ID of the entity `<x>` in the vocabulary of
-// the index on which the expressions will be evaluated. For details see the
-// `TestContext` class. Note: The indirection via a function is necessary
-// because otherwise the `gtest_discover_test` step of the CMake build fails for
-// some reason.
-const auto& testContext() {
-  static TestContext ctx{};
-  return ctx;
-}
 
 // Test allocator (the inputs to our `SparqlExpression`s are
 // `VectorWithMemoryLimit`s, and these require an `AllocatorWithLimit`).
@@ -784,12 +776,12 @@ TEST(SparqlExpression, stringOperators) {
       DateYearOrDuration(11853, DateYearOrDuration::Type::Year));
   // Test `iriOrUriExpression`.
   // test invalid
-  checkIriOrUri(
-      IdOrLocalVocabEntryVec{U, U, U, U, U, U, U},
-      std::tuple{IdOrLocalVocabEntryVec{U, IntId(2), DoubleId(12.99), dateDate,
-                                        dateLYear, T, F},
-                 IdOrLocalVocabEntry{LocalVocabEntry{
-                     ad_utility::triple_component::Iri{}, testIndexImpl()}}});
+  checkIriOrUri(IdOrLocalVocabEntryVec{U, U, U, U, U, U, U},
+                std::tuple{IdOrLocalVocabEntryVec{U, IntId(2), DoubleId(12.99),
+                                                  dateDate, dateLYear, T, F},
+                           IdOrLocalVocabEntry{LocalVocabEntry{
+                               ad_utility::triple_component::Iri{},
+                               testContext().qec->getIndex()}}});
   // test valid
   checkIriOrUri(
       IdOrLocalVocabEntryVec{
@@ -812,8 +804,9 @@ TEST(SparqlExpression, stringOperators) {
               testContext().notInVocabIri, testContext().notInVocabIriLit,
               lit("http://example/"), iriref("<http://\t\t\nexample/>"),
               lit("\t\n\r")},
-          IdOrLocalVocabEntry{LocalVocabEntry{
-              ad_utility::triple_component::Iri{}, testIndexImpl()}}});
+          IdOrLocalVocabEntry{
+              LocalVocabEntry{ad_utility::triple_component::Iri{},
+                              testContext().qec->getIndex()}}});
 
   // test with base iri
   checkIriOrUri(

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -75,12 +75,12 @@ auto lit = [](std::string_view s, std::string_view langtagOrDatatype = "") {
   return LocalVocabEntry{
       ad_utility::triple_component::LiteralOrIri(
           ad_utility::testing::tripleComponentLiteral(s, langtagOrDatatype)),
-      testContext().qec->getIndex()};
+      testContext().qec->getLocalVocabContext()};
 };
 
 auto iriref = [](std::string_view s) {
   return LocalVocabEntry{ad_utility::triple_component::LiteralOrIri(iri(s)),
-                         testContext().qec->getIndex()};
+                         testContext().qec->getLocalVocabContext()};
 };
 
 auto idOrLitOrStringVec =
@@ -781,7 +781,7 @@ TEST(SparqlExpression, stringOperators) {
                                                   dateDate, dateLYear, T, F},
                            IdOrLocalVocabEntry{LocalVocabEntry{
                                ad_utility::triple_component::Iri{},
-                               testContext().qec->getIndex()}}});
+                               testContext().qec->getLocalVocabContext()}}});
   // test valid
   checkIriOrUri(
       IdOrLocalVocabEntryVec{
@@ -806,7 +806,7 @@ TEST(SparqlExpression, stringOperators) {
               lit("\t\n\r")},
           IdOrLocalVocabEntry{
               LocalVocabEntry{ad_utility::triple_component::Iri{},
-                              testContext().qec->getIndex()}}});
+                              testContext().qec->getLocalVocabContext()}}});
 
   // test with base iri
   checkIriOrUri(

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -73,14 +73,12 @@ const auto& testContext() {
 
 auto lit = [](std::string_view s, std::string_view langtagOrDatatype = "") {
   return LocalVocabEntry{
-      ad_utility::triple_component::LiteralOrIri(
-          ad_utility::testing::tripleComponentLiteral(s, langtagOrDatatype)),
+      ad_utility::testing::tripleComponentLiteral(s, langtagOrDatatype),
       testContext().qec->getLocalVocabContext()};
 };
 
 auto iriref = [](std::string_view s) {
-  return LocalVocabEntry{ad_utility::triple_component::LiteralOrIri(iri(s)),
-                         testContext().qec->getLocalVocabContext()};
+  return LocalVocabEntry{iri(s), testContext().qec->getLocalVocabContext()};
 };
 
 auto idOrLitOrStringVec =

--- a/test/SparqlExpressionTestHelpers.h
+++ b/test/SparqlExpressionTestHelpers.h
@@ -69,17 +69,17 @@ struct TestContext {
     zz = getId("\"zz\"@en");
     blank = Id::makeFromBlankNodeIndex(BlankNodeIndex::make(0));
 
-    const auto& index = qec->getIndex();
-    auto addLocalLiteral = [this, &index](std::string_view s) {
+    const auto& localVocabContext = qec->getLocalVocabContext();
+    auto addLocalLiteral = [this, &localVocabContext](std::string_view s) {
       return Id::makeFromLocalVocabIndex(
           this->localVocab.getIndexAndAddIfNotContained(
-              LocalVocabEntry ::literalWithoutQuotes(s, index)));
+              LocalVocabEntry ::literalWithoutQuotes(s, localVocabContext)));
     };
 
-    auto addLocalIri = [this, &index](std::string_view s) {
+    auto addLocalIri = [this, &localVocabContext](std::string_view s) {
       return Id::makeFromLocalVocabIndex(
           this->localVocab.getIndexAndAddIfNotContained(
-              LocalVocabEntry::fromIriref(s, index)));
+              LocalVocabEntry::fromIriref(s, localVocabContext)));
     };
 
     notInVocabA = addLocalLiteral("notInVocabA");

--- a/test/SparqlExpressionTestHelpers.h
+++ b/test/SparqlExpressionTestHelpers.h
@@ -78,10 +78,10 @@ struct TestContext {
               index}));
     };
 
-    auto addLocalIri = [this, &index](const std::string& s) {
+    auto addLocalIri = [this, &index](std::string_view s) {
       return Id::makeFromLocalVocabIndex(
           this->localVocab.getIndexAndAddIfNotContained(
-              LocalVocabEntry::fromStringRepresentation(s, index)));
+              LocalVocabEntry::fromIriref(s, index)));
     };
 
     notInVocabA = addLocalLiteral("notInVocabA");

--- a/test/SparqlExpressionTestHelpers.h
+++ b/test/SparqlExpressionTestHelpers.h
@@ -80,8 +80,8 @@ struct TestContext {
 
     auto addLocalIri = [this, &index](const std::string& s) {
       return Id::makeFromLocalVocabIndex(
-          this->localVocab.getIndexAndAddIfNotContained(LocalVocabEntry{
-              ad_utility::triple_component::LiteralOrIri::iriref(s), index}));
+          this->localVocab.getIndexAndAddIfNotContained(
+              LocalVocabEntry::fromStringRepresentation(s, index)));
     };
 
     notInVocabA = addLocalLiteral("notInVocabA");

--- a/test/SparqlExpressionTestHelpers.h
+++ b/test/SparqlExpressionTestHelpers.h
@@ -72,10 +72,8 @@ struct TestContext {
     const auto& index = qec->getIndex();
     auto addLocalLiteral = [this, &index](std::string_view s) {
       return Id::makeFromLocalVocabIndex(
-          this->localVocab.getIndexAndAddIfNotContained(LocalVocabEntry{
-              ad_utility::triple_component::LiteralOrIri::literalWithoutQuotes(
-                  s),
-              index}));
+          this->localVocab.getIndexAndAddIfNotContained(
+              LocalVocabEntry ::literalWithoutQuotes(s, index)));
     };
 
     auto addLocalIri = [this, &index](std::string_view s) {

--- a/test/SparqlExpressionTestHelpers.h
+++ b/test/SparqlExpressionTestHelpers.h
@@ -69,7 +69,7 @@ struct TestContext {
     zz = getId("\"zz\"@en");
     blank = Id::makeFromBlankNodeIndex(BlankNodeIndex::make(0));
 
-    const auto& index = qec->getIndex().getImpl();
+    const auto& index = qec->getIndex();
     auto addLocalLiteral = [this, &index](std::string_view s) {
       return Id::makeFromLocalVocabIndex(
           this->localVocab.getIndexAndAddIfNotContained(LocalVocabEntry{

--- a/test/SparqlExpressionTestHelpers.h
+++ b/test/SparqlExpressionTestHelpers.h
@@ -69,17 +69,19 @@ struct TestContext {
     zz = getId("\"zz\"@en");
     blank = Id::makeFromBlankNodeIndex(BlankNodeIndex::make(0));
 
-    auto addLocalLiteral = [this](std::string_view s) {
+    const auto& index = qec->getIndex().getImpl();
+    auto addLocalLiteral = [this, &index](std::string_view s) {
       return Id::makeFromLocalVocabIndex(
-          this->localVocab.getIndexAndAddIfNotContained(
+          this->localVocab.getIndexAndAddIfNotContained(LocalVocabEntry{
               ad_utility::triple_component::LiteralOrIri::literalWithoutQuotes(
-                  s)));
+                  s),
+              index}));
     };
 
-    auto addLocalIri = [this](const std::string& s) {
+    auto addLocalIri = [this, &index](const std::string& s) {
       return Id::makeFromLocalVocabIndex(
-          this->localVocab.getIndexAndAddIfNotContained(
-              ad_utility::triple_component::LiteralOrIri::iriref(s)));
+          this->localVocab.getIndexAndAddIfNotContained(LocalVocabEntry{
+              ad_utility::triple_component::LiteralOrIri::iriref(s), index}));
     };
 
     notInVocabA = addLocalLiteral("notInVocabA");

--- a/test/SparqlExpressionTypesTest.cpp
+++ b/test/SparqlExpressionTypesTest.cpp
@@ -37,8 +37,7 @@ TEST(SparqlExpressionTypes, printIdOrString) {
   PrintTo(idOrString, &str);
   ASSERT_EQ(str.str(), "U:0");
   auto* qec = ad_utility::testing::getQec();
-  idOrString = LocalVocabEntry{LiteralOrIri::literalWithoutQuotes("bimm"),
-                               qec->getIndex()};
+  idOrString = LocalVocabEntry::literalWithoutQuotes("bimm", qec->getIndex());
   // Clear the stringstream.
   str.str({});
   PrintTo(idOrString, &str);

--- a/test/SparqlExpressionTypesTest.cpp
+++ b/test/SparqlExpressionTypesTest.cpp
@@ -37,7 +37,8 @@ TEST(SparqlExpressionTypes, printIdOrString) {
   PrintTo(idOrString, &str);
   ASSERT_EQ(str.str(), "U:0");
   auto* qec = ad_utility::testing::getQec();
-  idOrString = LocalVocabEntry::literalWithoutQuotes("bimm", qec->getIndex());
+  idOrString = LocalVocabEntry::literalWithoutQuotes(
+      "bimm", qec->getLocalVocabContext());
   // Clear the stringstream.
   str.str({});
   PrintTo(idOrString, &str);

--- a/test/SparqlExpressionTypesTest.cpp
+++ b/test/SparqlExpressionTypesTest.cpp
@@ -36,9 +36,9 @@ TEST(SparqlExpressionTypes, printIdOrString) {
   IdOrLocalVocabEntry idOrString{Id::makeUndefined()};
   PrintTo(idOrString, &str);
   ASSERT_EQ(str.str(), "U:0");
-  const auto& index = ad_utility::testing::getQec()->getIndex().getImpl();
-  idOrString =
-      LocalVocabEntry{LiteralOrIri::literalWithoutQuotes("bimm"), index};
+  auto* qec = ad_utility::testing::getQec();
+  idOrString = LocalVocabEntry{LiteralOrIri::literalWithoutQuotes("bimm"),
+                               qec->getIndex()};
   // Clear the stringstream.
   str.str({});
   PrintTo(idOrString, &str);

--- a/test/SparqlExpressionTypesTest.cpp
+++ b/test/SparqlExpressionTypesTest.cpp
@@ -7,6 +7,7 @@
 #include "gtest/gtest.h"
 #include "util/AllocatorTestHelpers.h"
 #include "util/GTestHelpers.h"
+#include "util/IndexTestHelpers.h"
 
 using namespace sparqlExpression;
 
@@ -35,7 +36,9 @@ TEST(SparqlExpressionTypes, printIdOrString) {
   IdOrLocalVocabEntry idOrString{Id::makeUndefined()};
   PrintTo(idOrString, &str);
   ASSERT_EQ(str.str(), "U:0");
-  idOrString = LiteralOrIri::literalWithoutQuotes("bimm");
+  const auto& index = ad_utility::testing::getQec()->getIndex().getImpl();
+  idOrString =
+      LocalVocabEntry{LiteralOrIri::literalWithoutQuotes("bimm"), index};
   // Clear the stringstream.
   str.str({});
   PrintTo(idOrString, &str);

--- a/test/TransitivePathTest.cpp
+++ b/test/TransitivePathTest.cpp
@@ -36,7 +36,7 @@ class TransitivePathTest
  public:
   [[nodiscard]] static std::pair<std::shared_ptr<TransitivePathBase>,
                                  QueryExecutionContext*>
-  makePath(IdTable input, Vars vars, TransitivePathSide left,
+  makePath(IdTable input, const Vars& vars, TransitivePathSide left,
            TransitivePathSide right, size_t minDist, size_t maxDist,
            std::optional<std::string> turtleInput = std::nullopt,
            const std::optional<Variable>& graphVariable = std::nullopt) {
@@ -60,7 +60,7 @@ class TransitivePathTest
 
   // ___________________________________________________________________________
   [[nodiscard]] static std::shared_ptr<TransitivePathBase> makePathUnbound(
-      IdTable input, Vars vars, TransitivePathSide left,
+      IdTable input, const Vars& vars, TransitivePathSide left,
       TransitivePathSide right, size_t minDist, size_t maxDist,
       std::optional<std::string> turtleInput = std::nullopt,
       const std::optional<Variable>& graphVariable = std::nullopt) {
@@ -1003,8 +1003,24 @@ TEST_P(TransitivePathTest, literalsNotInIndex) {
 // _____________________________________________________________________________
 TEST_P(TransitivePathTest, literalsNotInIndexButInDeltaTriples) {
   using ad_utility::triple_component::Literal;
-  std::string index = "<a> a 0 , 1 , 2 , 4 .";
+  ad_utility::testing::TestIndexConfig config;
+  config.turtleInput = "<a> a 0 , 1 , 2 , 4 .";
+  auto* qec = getQec(std::move(config));
   std::string literal = "my-literal";
+
+  auto makeCustomPath = [qec](IdTable input, const Vars& vars,
+                              TransitivePathSide left, TransitivePathSide right,
+                              size_t minDist, size_t maxDist) {
+    bool useBinSearch = std::get<0>(GetParam());
+    // Clear the cache to avoid crosstalk between tests.
+    qec->clearCacheUnpinnedOnly();
+    auto subtree = ad_utility::makeExecutionTree<ValuesForTesting>(
+        qec, std::move(input), vars);
+    return TransitivePathBase::makeTransitivePath(
+        qec, std::move(subtree), std::move(left), std::move(right), minDist,
+        maxDist, useBinSearch,
+        qlever::index::GraphFilter<TripleComponent>::All(), std::nullopt);
+  };
 
   // Simulate entries in the delta triples by using entries that are not in the
   // index
@@ -1014,9 +1030,9 @@ TEST_P(TransitivePathTest, literalsNotInIndexButInDeltaTriples) {
   // the cache (Currently the indexes used for testing are `static` which should
   // be changed in the future).
   LocalVocab localVocab;
-  const auto& indexImpl = getQec()->getIndex().getImpl();
-  auto id = Id::makeFromLocalVocabIndex(localVocab.getIndexAndAddIfNotContained(
-      LocalVocabEntry{Literal::literalWithoutQuotes(literal), indexImpl}));
+  auto id = Id::makeFromLocalVocabIndex(
+      localVocab.getIndexAndAddIfNotContained(LocalVocabEntry{
+          Literal::literalWithoutQuotes(literal), qec->getIndex()}));
   auto sub = makeIdTableFromVector({
       {id, id},
   });
@@ -1028,9 +1044,9 @@ TEST_P(TransitivePathTest, literalsNotInIndexButInDeltaTriples) {
   {
     TransitivePathSide left(std::nullopt, 0, reference, 0);
     TransitivePathSide right(std::nullopt, 1, reference, 1);
-    auto T = makePathUnbound(
-        sub.clone(), {Variable{"?start"}, Variable{"?target"}}, left, right, 1,
-        std::numeric_limits<size_t>::max(), index);
+    auto T =
+        makeCustomPath(sub.clone(), {Variable{"?start"}, Variable{"?target"}},
+                       left, right, 1, std::numeric_limits<size_t>::max());
 
     EXPECT_TRUE(T->isBoundOrId());
 
@@ -1041,9 +1057,9 @@ TEST_P(TransitivePathTest, literalsNotInIndexButInDeltaTriples) {
   {
     TransitivePathSide left(std::nullopt, 0, reference, 0);
     TransitivePathSide right(std::nullopt, 1, Variable{"?target"}, 1);
-    auto T = makePathUnbound(
-        sub.clone(), {Variable{"?start"}, Variable{"?target"}}, left, right, 1,
-        std::numeric_limits<size_t>::max(), index);
+    auto T =
+        makeCustomPath(sub.clone(), {Variable{"?start"}, Variable{"?target"}},
+                       left, right, 1, std::numeric_limits<size_t>::max());
 
     EXPECT_TRUE(T->isBoundOrId());
 
@@ -1054,9 +1070,9 @@ TEST_P(TransitivePathTest, literalsNotInIndexButInDeltaTriples) {
   {
     TransitivePathSide left(std::nullopt, 0, Variable{"?start"}, 0);
     TransitivePathSide right(std::nullopt, 1, reference, 1);
-    auto T = makePathUnbound(
-        std::move(sub), {Variable{"?start"}, Variable{"?target"}}, left, right,
-        1, std::numeric_limits<size_t>::max(), std::move(index));
+    auto T = makeCustomPath(std::move(sub),
+                            {Variable{"?start"}, Variable{"?target"}}, left,
+                            right, 1, std::numeric_limits<size_t>::max());
 
     EXPECT_TRUE(T->isBoundOrId());
 

--- a/test/TransitivePathTest.cpp
+++ b/test/TransitivePathTest.cpp
@@ -1030,9 +1030,9 @@ TEST_P(TransitivePathTest, literalsNotInIndexButInDeltaTriples) {
   // the cache (Currently the indexes used for testing are `static` which should
   // be changed in the future).
   LocalVocab localVocab;
-  auto id = Id::makeFromLocalVocabIndex(
-      localVocab.getIndexAndAddIfNotContained(LocalVocabEntry{
-          Literal::literalWithoutQuotes(literal), qec->getIndex()}));
+  auto id = Id::makeFromLocalVocabIndex(localVocab.getIndexAndAddIfNotContained(
+      LocalVocabEntry::literalWithoutQuotes(literal,
+                                            qec->getLocalVocabContext())));
   auto sub = makeIdTableFromVector({
       {id, id},
   });

--- a/test/TransitivePathTest.cpp
+++ b/test/TransitivePathTest.cpp
@@ -1014,8 +1014,9 @@ TEST_P(TransitivePathTest, literalsNotInIndexButInDeltaTriples) {
   // the cache (Currently the indexes used for testing are `static` which should
   // be changed in the future).
   LocalVocab localVocab;
+  const auto& indexImpl = getQec()->getIndex().getImpl();
   auto id = Id::makeFromLocalVocabIndex(localVocab.getIndexAndAddIfNotContained(
-      LocalVocabEntry{Literal::literalWithoutQuotes(literal)}));
+      LocalVocabEntry{Literal::literalWithoutQuotes(literal), indexImpl}));
   auto sub = makeIdTableFromVector({
       {id, id},
   });

--- a/test/TripleComponentTest.cpp
+++ b/test/TripleComponentTest.cpp
@@ -266,8 +266,9 @@ TEST(TripleComponent, toValueIdOrBounds) {
     auto idOrBounds = tc.toValueIdOrBounds(index);
     EXPECT_THAT(idOrBounds, testing::VariantWith<BoundsT>(testing::Eq(bounds)));
     // Check that the bounds are the same as from LocalVocabEntry
-    auto lve = tc.isLiteral() ? LocalVocabEntry(tc.getLiteral())
-                              : LocalVocabEntry(tc.getIri());
+    auto lve = tc.isLiteral()
+                   ? LocalVocabEntry(tc.getLiteral(), index.getImpl())
+                   : LocalVocabEntry(tc.getIri(), index.getImpl());
     LocalVocabEntry::PositionInVocab positionFromBounds{makePos(bounds.first),
                                                         makePos(bounds.second)};
     EXPECT_EQ(lve.positionInVocab(), positionFromBounds);

--- a/test/TripleComponentTest.cpp
+++ b/test/TripleComponentTest.cpp
@@ -266,9 +266,8 @@ TEST(TripleComponent, toValueIdOrBounds) {
     auto idOrBounds = tc.toValueIdOrBounds(index);
     EXPECT_THAT(idOrBounds, testing::VariantWith<BoundsT>(testing::Eq(bounds)));
     // Check that the bounds are the same as from LocalVocabEntry
-    auto lve = tc.isLiteral()
-                   ? LocalVocabEntry(tc.getLiteral(), index.getImpl())
-                   : LocalVocabEntry(tc.getIri(), index.getImpl());
+    auto lve = tc.isLiteral() ? LocalVocabEntry(tc.getLiteral(), index)
+                              : LocalVocabEntry(tc.getIri(), index);
     LocalVocabEntry::PositionInVocab positionFromBounds{makePos(bounds.first),
                                                         makePos(bounds.second)};
     EXPECT_EQ(lve.positionInVocab(), positionFromBounds);

--- a/test/TripleSerializerTest.cpp
+++ b/test/TripleSerializerTest.cpp
@@ -64,8 +64,8 @@ TEST(TripleSerializer, blankNodesRemapper) {
   std::vector<std::vector<Id>> ids;
 
   auto bn = [&]() {
-    ad_utility::BlankNodeManager& bm = *qec->getIndex().getBlankNodeManager();
-    return Id::makeFromBlankNodeIndex(localVocab.getBlankNodeIndex(&bm));
+    return Id::makeFromBlankNodeIndex(
+        localVocab.getBlankNodeIndex(qec->getIndex().getBlankNodeManager()));
   };
 
   ids.emplace_back(std::vector{bn(), bn(), bn()});

--- a/test/TripleSerializerTest.cpp
+++ b/test/TripleSerializerTest.cpp
@@ -23,7 +23,7 @@ TEST(TripleSerializer, simpleExample) {
   ad_utility::serializeIds(filename, localVocab, ids);
 
   auto [localVocabOut, idsOut] =
-      ad_utility::deserializeIds(filename, qec->getIndex());
+      ad_utility::deserializeIds(filename, qec->getLocalVocabContext());
   EXPECT_EQ(idsOut, ids);
   EXPECT_EQ(localVocabOut.size(), localVocab.size());
 }
@@ -37,7 +37,7 @@ TEST(TripleSerializer, localVocabIsRemapped) {
         localVocab.getIndexAndAddIfNotContained(LocalVocabEntry{
             ad_utility::triple_component::LiteralOrIri::literalWithoutQuotes(
                 value),
-            qec->getIndex()}));
+            qec->getLocalVocabContext()}));
   };
   std::vector<std::vector<Id>> ids;
 
@@ -46,7 +46,7 @@ TEST(TripleSerializer, localVocabIsRemapped) {
   ad_utility::serializeIds(filename, localVocab, ids);
 
   auto [localVocabOut, idsOut] =
-      ad_utility::deserializeIds(filename, qec->getIndex());
+      ad_utility::deserializeIds(filename, qec->getLocalVocabContext());
   EXPECT_EQ(idsOut, ids);
   EXPECT_EQ(localVocabOut.size(), localVocab.size());
   EXPECT_THAT(localVocab.getAllWordsForTesting(),
@@ -73,7 +73,7 @@ TEST(TripleSerializer, blankNodesRemapper) {
   ad_utility::serializeIds(filename, localVocab, ids);
 
   auto [localVocabOut, idsOut] =
-      ad_utility::deserializeIds(filename, qec->getIndex());
+      ad_utility::deserializeIds(filename, qec->getLocalVocabContext());
   // Blank nodes are now preserved (not remapped).
   EXPECT_EQ(ids, idsOut);
 
@@ -158,7 +158,7 @@ TEST(TripleSerializer, multipleWordSetsInASerializedLocalVocab) {
         localVocab.getIndexAndAddIfNotContained(LocalVocabEntry{
             ad_utility::triple_component::LiteralOrIri::literalWithoutQuotes(
                 value),
-            qec->getIndex()}));
+            qec->getLocalVocabContext()}));
   };
   std::vector<std::vector<Id>> ids;
 
@@ -173,8 +173,8 @@ TEST(TripleSerializer, multipleWordSetsInASerializedLocalVocab) {
   ad_utility::serialization::ByteBufferReadSerializer reader{
       std::move(writer).data()};
 
-  auto [localVocabOut, mapping] =
-      ad_utility::detail::deserializeLocalVocab(reader, qec->getIndex());
+  auto [localVocabOut, mapping] = ad_utility::detail::deserializeLocalVocab(
+      reader, qec->getLocalVocabContext());
   auto fromMapping = [&]() {
     return ::ranges::to<std::vector>(
         mapping | ql::views::values |
@@ -220,7 +220,7 @@ TEST(TripleSerializer, rethrowsOnInvalidFileAccess) {
   LocalVocab localVocab;
 
   AD_EXPECT_THROW_WITH_MESSAGE_AND_TYPE(
-      ad_utility::deserializeIds(tmpFile, qec->getIndex()),
+      ad_utility::deserializeIds(tmpFile, qec->getLocalVocabContext()),
       AllOf(HasSubstr(tmpFile.generic_string()),
             HasSubstr("cannot be opened for reading"),
             HasSubstr("(Permission denied)")),

--- a/test/TripleSerializerTest.cpp
+++ b/test/TripleSerializerTest.cpp
@@ -33,11 +33,9 @@ TEST(TripleSerializer, localVocabIsRemapped) {
   auto* qec = ad_utility::testing::getQec();
   LocalVocab localVocab;
   auto LV = [&localVocab, qec](std::string_view value) {
-    return Id::makeFromLocalVocabIndex(
-        localVocab.getIndexAndAddIfNotContained(LocalVocabEntry{
-            ad_utility::triple_component::LiteralOrIri::literalWithoutQuotes(
-                value),
-            qec->getLocalVocabContext()}));
+    return Id::makeFromLocalVocabIndex(localVocab.getIndexAndAddIfNotContained(
+        LocalVocabEntry::literalWithoutQuotes(value,
+                                              qec->getLocalVocabContext())));
   };
   std::vector<std::vector<Id>> ids;
 
@@ -154,11 +152,9 @@ TEST(TripleSerializer, multipleWordSetsInASerializedLocalVocab) {
   auto* qec = ad_utility::testing::getQec();
   LocalVocab localVocab;
   auto LV = [&localVocab, qec](std::string_view value) {
-    return Id::makeFromLocalVocabIndex(
-        localVocab.getIndexAndAddIfNotContained(LocalVocabEntry{
-            ad_utility::triple_component::LiteralOrIri::literalWithoutQuotes(
-                value),
-            qec->getLocalVocabContext()}));
+    return Id::makeFromLocalVocabIndex(localVocab.getIndexAndAddIfNotContained(
+        LocalVocabEntry::literalWithoutQuotes(value,
+                                              qec->getLocalVocabContext())));
   };
   std::vector<std::vector<Id>> ids;
 

--- a/test/TripleSerializerTest.cpp
+++ b/test/TripleSerializerTest.cpp
@@ -60,11 +60,11 @@ TEST(TripleSerializer, localVocabIsRemapped) {
 
 TEST(TripleSerializer, blankNodesRemapper) {
   auto* qec = ad_utility::testing::getQec();
-  ad_utility::BlankNodeManager bm;
   LocalVocab localVocab;
   std::vector<std::vector<Id>> ids;
 
   auto bn = [&]() {
+    ad_utility::BlankNodeManager& bm = *qec->getIndex().getBlankNodeManager();
     return Id::makeFromBlankNodeIndex(localVocab.getBlankNodeIndex(&bm));
   };
 

--- a/test/TripleSerializerTest.cpp
+++ b/test/TripleSerializerTest.cpp
@@ -12,6 +12,9 @@
 namespace {
 auto I = ad_utility::testing::IntId;
 auto V = ad_utility::testing::VocabId;
+const auto& getIndex() {
+  return ad_utility::testing::getQec()->getIndex().getImpl();
+}
 TEST(TripleSerializer, simpleExample) {
   LocalVocab localVocab;
   std::vector<std::vector<Id>> ids;
@@ -21,20 +24,22 @@ TEST(TripleSerializer, simpleExample) {
   std::string filename = "tripleSerializerTestSimpleExample.dat";
   ad_utility::serializeIds(filename, localVocab, ids);
 
-  ad_utility::BlankNodeManager bm;
-  auto [localVocabOut, idsOut] = ad_utility::deserializeIds(filename, &bm);
+  const auto& index = getIndex();
+  auto [localVocabOut, idsOut] = ad_utility::deserializeIds(filename, index);
   EXPECT_EQ(idsOut, ids);
   EXPECT_EQ(localVocabOut.size(), localVocab.size());
 }
 
 // _____________________________________________________________________________
 TEST(TripleSerializer, localVocabIsRemapped) {
-  ad_utility::testing::getQec();
+  const auto& index = getIndex();
   LocalVocab localVocab;
-  auto LV = [&localVocab](std::string value) {
-    return Id::makeFromLocalVocabIndex(localVocab.getIndexAndAddIfNotContained(
-        ad_utility::triple_component::LiteralOrIri::literalWithoutQuotes(
-            std::move(value))));
+  auto LV = [&localVocab, &index](std::string value) {
+    return Id::makeFromLocalVocabIndex(
+        localVocab.getIndexAndAddIfNotContained(LocalVocabEntry{
+            ad_utility::triple_component::LiteralOrIri::literalWithoutQuotes(
+                std::move(value)),
+            index}));
   };
   std::vector<std::vector<Id>> ids;
 
@@ -42,8 +47,7 @@ TEST(TripleSerializer, localVocabIsRemapped) {
   std::string filename = "tripleSerializerTestLocalVocabIsRemapped.dat";
   ad_utility::serializeIds(filename, localVocab, ids);
 
-  ad_utility::BlankNodeManager bm;
-  auto [localVocabOut, idsOut] = ad_utility::deserializeIds(filename, &bm);
+  auto [localVocabOut, idsOut] = ad_utility::deserializeIds(filename, index);
   EXPECT_EQ(idsOut, ids);
   EXPECT_EQ(localVocabOut.size(), localVocab.size());
   EXPECT_THAT(localVocab.getAllWordsForTesting(),
@@ -56,7 +60,7 @@ TEST(TripleSerializer, localVocabIsRemapped) {
 }
 
 TEST(TripleSerializer, blankNodesRemapper) {
-  ad_utility::testing::getQec();
+  const auto& index = getIndex();
   ad_utility::BlankNodeManager bm;
   LocalVocab localVocab;
   std::vector<std::vector<Id>> ids;
@@ -69,8 +73,7 @@ TEST(TripleSerializer, blankNodesRemapper) {
   std::string filename = "tripleSerializerTestBlankNodesAreRemapped.dat";
   ad_utility::serializeIds(filename, localVocab, ids);
 
-  ad_utility::BlankNodeManager bm2;
-  auto [localVocabOut, idsOut] = ad_utility::deserializeIds(filename, &bm2);
+  auto [localVocabOut, idsOut] = ad_utility::deserializeIds(filename, index);
   // Blank nodes are now preserved (not remapped).
   EXPECT_EQ(ids, idsOut);
 
@@ -148,12 +151,14 @@ TEST(TripleSerializer, errorOnWrongHeaderFormat) {
 
 // _____________________________________________________________________________
 TEST(TripleSerializer, multipleWordSetsInASerializedLocalVocab) {
-  ad_utility::testing::getQec();
+  const auto& index = getIndex();
   LocalVocab localVocab;
-  auto LV = [&localVocab](std::string value) {
-    return Id::makeFromLocalVocabIndex(localVocab.getIndexAndAddIfNotContained(
-        ad_utility::triple_component::LiteralOrIri::literalWithoutQuotes(
-            std::move(value))));
+  auto LV = [&localVocab, &index](std::string value) {
+    return Id::makeFromLocalVocabIndex(
+        localVocab.getIndexAndAddIfNotContained(LocalVocabEntry{
+            ad_utility::triple_component::LiteralOrIri::literalWithoutQuotes(
+                std::move(value)),
+            index}));
   };
   std::vector<std::vector<Id>> ids;
 
@@ -168,9 +173,8 @@ TEST(TripleSerializer, multipleWordSetsInASerializedLocalVocab) {
   ad_utility::serialization::ByteBufferReadSerializer reader{
       std::move(writer).data()};
 
-  ad_utility::BlankNodeManager bm;
   auto [localVocabOut, mapping] =
-      ad_utility::detail::deserializeLocalVocab(reader, &bm);
+      ad_utility::detail::deserializeLocalVocab(reader, index);
   auto fromMapping = [&]() {
     return ::ranges::to<std::vector>(
         mapping | ql::views::values |
@@ -212,11 +216,11 @@ TEST(TripleSerializer, rethrowsOnInvalidFileAccess) {
     GTEST_SKIP_("File permissions are not set to none");
   }
 
-  ad_utility::BlankNodeManager bm;
+  const auto& index = getIndex();
   LocalVocab localVocab;
 
   AD_EXPECT_THROW_WITH_MESSAGE_AND_TYPE(
-      ad_utility::deserializeIds(tmpFile, &bm),
+      ad_utility::deserializeIds(tmpFile, index),
       AllOf(HasSubstr(tmpFile.generic_string()),
             HasSubstr("cannot be opened for reading"),
             HasSubstr("(Permission denied)")),

--- a/test/TripleSerializerTest.cpp
+++ b/test/TripleSerializerTest.cpp
@@ -12,10 +12,8 @@
 namespace {
 auto I = ad_utility::testing::IntId;
 auto V = ad_utility::testing::VocabId;
-const auto& getIndex() {
-  return ad_utility::testing::getQec()->getIndex().getImpl();
-}
 TEST(TripleSerializer, simpleExample) {
+  auto* qec = ad_utility::testing::getQec();
   LocalVocab localVocab;
   std::vector<std::vector<Id>> ids;
 
@@ -24,22 +22,22 @@ TEST(TripleSerializer, simpleExample) {
   std::string filename = "tripleSerializerTestSimpleExample.dat";
   ad_utility::serializeIds(filename, localVocab, ids);
 
-  const auto& index = getIndex();
-  auto [localVocabOut, idsOut] = ad_utility::deserializeIds(filename, index);
+  auto [localVocabOut, idsOut] =
+      ad_utility::deserializeIds(filename, qec->getIndex());
   EXPECT_EQ(idsOut, ids);
   EXPECT_EQ(localVocabOut.size(), localVocab.size());
 }
 
 // _____________________________________________________________________________
 TEST(TripleSerializer, localVocabIsRemapped) {
-  const auto& index = getIndex();
+  auto* qec = ad_utility::testing::getQec();
   LocalVocab localVocab;
-  auto LV = [&localVocab, &index](std::string value) {
+  auto LV = [&localVocab, qec](std::string_view value) {
     return Id::makeFromLocalVocabIndex(
         localVocab.getIndexAndAddIfNotContained(LocalVocabEntry{
             ad_utility::triple_component::LiteralOrIri::literalWithoutQuotes(
-                std::move(value)),
-            index}));
+                value),
+            qec->getIndex()}));
   };
   std::vector<std::vector<Id>> ids;
 
@@ -47,7 +45,8 @@ TEST(TripleSerializer, localVocabIsRemapped) {
   std::string filename = "tripleSerializerTestLocalVocabIsRemapped.dat";
   ad_utility::serializeIds(filename, localVocab, ids);
 
-  auto [localVocabOut, idsOut] = ad_utility::deserializeIds(filename, index);
+  auto [localVocabOut, idsOut] =
+      ad_utility::deserializeIds(filename, qec->getIndex());
   EXPECT_EQ(idsOut, ids);
   EXPECT_EQ(localVocabOut.size(), localVocab.size());
   EXPECT_THAT(localVocab.getAllWordsForTesting(),
@@ -60,7 +59,7 @@ TEST(TripleSerializer, localVocabIsRemapped) {
 }
 
 TEST(TripleSerializer, blankNodesRemapper) {
-  const auto& index = getIndex();
+  auto* qec = ad_utility::testing::getQec();
   ad_utility::BlankNodeManager bm;
   LocalVocab localVocab;
   std::vector<std::vector<Id>> ids;
@@ -73,7 +72,8 @@ TEST(TripleSerializer, blankNodesRemapper) {
   std::string filename = "tripleSerializerTestBlankNodesAreRemapped.dat";
   ad_utility::serializeIds(filename, localVocab, ids);
 
-  auto [localVocabOut, idsOut] = ad_utility::deserializeIds(filename, index);
+  auto [localVocabOut, idsOut] =
+      ad_utility::deserializeIds(filename, qec->getIndex());
   // Blank nodes are now preserved (not remapped).
   EXPECT_EQ(ids, idsOut);
 
@@ -151,14 +151,14 @@ TEST(TripleSerializer, errorOnWrongHeaderFormat) {
 
 // _____________________________________________________________________________
 TEST(TripleSerializer, multipleWordSetsInASerializedLocalVocab) {
-  const auto& index = getIndex();
+  auto* qec = ad_utility::testing::getQec();
   LocalVocab localVocab;
-  auto LV = [&localVocab, &index](std::string value) {
+  auto LV = [&localVocab, qec](std::string_view value) {
     return Id::makeFromLocalVocabIndex(
         localVocab.getIndexAndAddIfNotContained(LocalVocabEntry{
             ad_utility::triple_component::LiteralOrIri::literalWithoutQuotes(
-                std::move(value)),
-            index}));
+                value),
+            qec->getIndex()}));
   };
   std::vector<std::vector<Id>> ids;
 
@@ -174,7 +174,7 @@ TEST(TripleSerializer, multipleWordSetsInASerializedLocalVocab) {
       std::move(writer).data()};
 
   auto [localVocabOut, mapping] =
-      ad_utility::detail::deserializeLocalVocab(reader, index);
+      ad_utility::detail::deserializeLocalVocab(reader, qec->getIndex());
   auto fromMapping = [&]() {
     return ::ranges::to<std::vector>(
         mapping | ql::views::values |
@@ -203,6 +203,7 @@ TEST(TripleSerializer, multipleWordSetsInASerializedLocalVocab) {
 // _____________________________________________________________________________
 TEST(TripleSerializer, rethrowsOnInvalidFileAccess) {
   using namespace ::testing;
+  auto* qec = ad_utility::testing::getQec();
   auto tmpFile = std::filesystem::temp_directory_path() / "fileNoPermissions";
   // Create empty file
   std::ofstream{tmpFile}.close();
@@ -216,11 +217,10 @@ TEST(TripleSerializer, rethrowsOnInvalidFileAccess) {
     GTEST_SKIP_("File permissions are not set to none");
   }
 
-  const auto& index = getIndex();
   LocalVocab localVocab;
 
   AD_EXPECT_THROW_WITH_MESSAGE_AND_TYPE(
-      ad_utility::deserializeIds(tmpFile, index),
+      ad_utility::deserializeIds(tmpFile, qec->getIndex()),
       AllOf(HasSubstr(tmpFile.generic_string()),
             HasSubstr("cannot be opened for reading"),
             HasSubstr("(Permission denied)")),

--- a/test/UnionTest.cpp
+++ b/test/UnionTest.cpp
@@ -352,16 +352,16 @@ TEST(Union, sortedMergeWithLocalVocab) {
   auto* qec = ad_utility::testing::getQec();
 
   LocalVocab vocab1;
-  vocab1.getIndexAndAddIfNotContained(
-      LocalVocabEntry::fromStringRepresentation("\"Test1\"", qec->getIndex()));
+  vocab1.getIndexAndAddIfNotContained(LocalVocabEntry::fromStringRepresentation(
+      "\"Test1\"", qec->getLocalVocabContext()));
 
   auto leftT = ad_utility::makeExecutionTree<ValuesForTesting>(
       qec, makeIdTableFromVector({{1}, {2}, {4}}), Vars{Var{"?a"}}, false,
       std::vector<ColumnIndex>{0}, vocab1.clone());
 
   LocalVocab vocab2;
-  vocab2.getIndexAndAddIfNotContained(
-      LocalVocabEntry::fromStringRepresentation("\"Test2\"", qec->getIndex()));
+  vocab2.getIndexAndAddIfNotContained(LocalVocabEntry::fromStringRepresentation(
+      "\"Test2\"", qec->getLocalVocabContext()));
   std::vector<IdTable> tables;
   tables.push_back(makeIdTableFromVector({{0}}));
   tables.push_back(makeIdTableFromVector({{3}}));

--- a/test/UnionTest.cpp
+++ b/test/UnionTest.cpp
@@ -351,17 +351,22 @@ TEST(Union, sortedMergeWithLocalVocab) {
   using Var = Variable;
   auto* qec = ad_utility::testing::getQec();
 
+  const auto& indexImpl = qec->getIndex().getImpl();
   LocalVocab vocab1;
-  vocab1.getIndexAndAddIfNotContained(
-      LocalVocabEntry::fromStringRepresentation("\"Test1\""));
+  vocab1.getIndexAndAddIfNotContained(LocalVocabEntry{
+      ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
+          "\"Test1\""),
+      indexImpl});
 
   auto leftT = ad_utility::makeExecutionTree<ValuesForTesting>(
       qec, makeIdTableFromVector({{1}, {2}, {4}}), Vars{Var{"?a"}}, false,
       std::vector<ColumnIndex>{0}, vocab1.clone());
 
   LocalVocab vocab2;
-  vocab2.getIndexAndAddIfNotContained(
-      LocalVocabEntry::fromStringRepresentation("\"Test2\""));
+  vocab2.getIndexAndAddIfNotContained(LocalVocabEntry{
+      ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
+          "\"Test2\""),
+      indexImpl});
   std::vector<IdTable> tables;
   tables.push_back(makeIdTableFromVector({{0}}));
   tables.push_back(makeIdTableFromVector({{3}}));

--- a/test/UnionTest.cpp
+++ b/test/UnionTest.cpp
@@ -351,12 +351,11 @@ TEST(Union, sortedMergeWithLocalVocab) {
   using Var = Variable;
   auto* qec = ad_utility::testing::getQec();
 
-  const auto& indexImpl = qec->getIndex().getImpl();
   LocalVocab vocab1;
   vocab1.getIndexAndAddIfNotContained(LocalVocabEntry{
       ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
           "\"Test1\""),
-      indexImpl});
+      qec->getIndex()});
 
   auto leftT = ad_utility::makeExecutionTree<ValuesForTesting>(
       qec, makeIdTableFromVector({{1}, {2}, {4}}), Vars{Var{"?a"}}, false,
@@ -366,7 +365,7 @@ TEST(Union, sortedMergeWithLocalVocab) {
   vocab2.getIndexAndAddIfNotContained(LocalVocabEntry{
       ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
           "\"Test2\""),
-      indexImpl});
+      qec->getIndex()});
   std::vector<IdTable> tables;
   tables.push_back(makeIdTableFromVector({{0}}));
   tables.push_back(makeIdTableFromVector({{3}}));

--- a/test/UnionTest.cpp
+++ b/test/UnionTest.cpp
@@ -352,20 +352,16 @@ TEST(Union, sortedMergeWithLocalVocab) {
   auto* qec = ad_utility::testing::getQec();
 
   LocalVocab vocab1;
-  vocab1.getIndexAndAddIfNotContained(LocalVocabEntry{
-      ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
-          "\"Test1\""),
-      qec->getIndex()});
+  vocab1.getIndexAndAddIfNotContained(
+      LocalVocabEntry::fromStringRepresentation("\"Test1\"", qec->getIndex()));
 
   auto leftT = ad_utility::makeExecutionTree<ValuesForTesting>(
       qec, makeIdTableFromVector({{1}, {2}, {4}}), Vars{Var{"?a"}}, false,
       std::vector<ColumnIndex>{0}, vocab1.clone());
 
   LocalVocab vocab2;
-  vocab2.getIndexAndAddIfNotContained(LocalVocabEntry{
-      ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
-          "\"Test2\""),
-      qec->getIndex()});
+  vocab2.getIndexAndAddIfNotContained(
+      LocalVocabEntry::fromStringRepresentation("\"Test2\"", qec->getIndex()));
   std::vector<IdTable> tables;
   tables.push_back(makeIdTableFromVector({{0}}));
   tables.push_back(makeIdTableFromVector({{3}}));

--- a/test/ValueGetterTestHelpers.h
+++ b/test/ValueGetterTestHelpers.h
@@ -237,8 +237,9 @@ class ValueGetterTester {
     auto litOrIri =
         ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
             literal);
-    auto idx =
-        localVocab.getIndexAndAddIfNotContained(LocalVocabEntry{litOrIri});
+    const auto& index = testContext.qec->getIndex().getImpl();
+    auto idx = localVocab.getIndexAndAddIfNotContained(
+        LocalVocabEntry{litOrIri, index});
     auto id = ValueId::makeFromLocalVocabIndex(idx);
     auto res = getter(id, &testContext.context);
     EXPECT_THAT(res, expected);

--- a/test/ValueGetterTestHelpers.h
+++ b/test/ValueGetterTestHelpers.h
@@ -237,9 +237,8 @@ class ValueGetterTester {
     auto litOrIri =
         ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
             literal);
-    const auto& index = testContext.qec->getIndex().getImpl();
     auto idx = localVocab.getIndexAndAddIfNotContained(
-        LocalVocabEntry{litOrIri, index});
+        LocalVocabEntry{litOrIri, testContext.qec->getIndex()});
     auto id = ValueId::makeFromLocalVocabIndex(idx);
     auto res = getter(id, &testContext.context);
     EXPECT_THAT(res, expected);

--- a/test/ValueGetterTestHelpers.h
+++ b/test/ValueGetterTestHelpers.h
@@ -235,8 +235,8 @@ class ValueGetterTester {
     TestContextWithGivenTTl testContext{""};
     LocalVocab localVocab;
     auto idx = localVocab.getIndexAndAddIfNotContained(
-        LocalVocabEntry::fromStringRepresentation(std::move(literal),
-                                                  testContext.qec->getIndex()));
+        LocalVocabEntry::fromStringRepresentation(
+            std::move(literal), testContext.qec->getLocalVocabContext()));
     auto id = ValueId::makeFromLocalVocabIndex(idx);
     auto res = getter(id, &testContext.context);
     EXPECT_THAT(res, expected);

--- a/test/ValueGetterTestHelpers.h
+++ b/test/ValueGetterTestHelpers.h
@@ -234,11 +234,9 @@ class ValueGetterTester {
     // Empty knowledge graph, so everything needs to be in the local vocab.
     TestContextWithGivenTTl testContext{""};
     LocalVocab localVocab;
-    auto litOrIri =
-        ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
-            literal);
     auto idx = localVocab.getIndexAndAddIfNotContained(
-        LocalVocabEntry{litOrIri, testContext.qec->getIndex()});
+        LocalVocabEntry::fromStringRepresentation(std::move(literal),
+                                                  testContext.qec->getIndex()));
     auto id = ValueId::makeFromLocalVocabIndex(idx);
     auto res = getter(id, &testContext.context);
     EXPECT_THAT(res, expected);

--- a/test/ValueIdTest.cpp
+++ b/test/ValueIdTest.cpp
@@ -21,11 +21,7 @@
 #include "util/Serializer/Serializer.h"
 
 struct ValueIdTest : public ::testing::Test {
-  ValueIdTest() {
-    // We need to initialize a (static). index, otherwise we can't compare
-    // VocabIndex to LocalVocabIndex entries
-    ad_utility::testing::getQec();
-  }
+  QueryExecutionContext* qec_ = ad_utility::testing::getQec();
 };
 
 TEST_F(ValueIdTest, makeFromDouble) {
@@ -319,17 +315,15 @@ TEST_F(ValueIdTest, Hashing) {
   {
     using namespace ad_utility::triple_component;
     using namespace ad_utility::testing;
-    const Index& index = getQec()->getIndex();
-    auto mkId = makeGetId(index);
+    const Index& index = qec_->getIndex();
+    auto mkId = makeGetId(qec_->getIndex());
     LocalVocab lv1;
     LocalVocab lv2;
-    const auto& indexImpl = index.getImpl();
     Iri iri = Iri::fromIriref("<foo>");
-    LocalVocabEntry lve1(iri, indexImpl);
-    LocalVocabEntry lve2(iri, indexImpl);
-    LocalVocabEntry lve3(Literal::fromStringRepresentation("\"foo\""),
-                         indexImpl);
-    LocalVocabEntry lve4(Iri::fromIriref("<x>"), indexImpl);
+    LocalVocabEntry lve1(iri, index);
+    LocalVocabEntry lve2(iri, index);
+    LocalVocabEntry lve3(Literal::fromStringRepresentation("\"foo\""), index);
+    LocalVocabEntry lve4(Iri::fromIriref("<x>"), index);
     auto LVID = [](LocalVocabEntry& lve, LocalVocab& lv) {
       return Id::makeFromLocalVocabIndex(lv.getIndexAndAddIfNotContained(lve));
     };
@@ -371,7 +365,7 @@ TEST_F(ValueIdTest, toDebugString) {
   auto str = LocalVocabEntry{
       ad_utility::triple_component::LiteralOrIri::literalWithoutQuotes(
           "SomeValue"),
-      ad_utility::testing::getQec()->getIndex().getImpl()};
+      qec_->getIndex()};
   test(ValueId::makeFromLocalVocabIndex(&str), "L:\"SomeValue\"");
   test(makeTextRecordId(37), "T:37");
   test(makeWordVocabId(42), "W:42");
@@ -408,7 +402,7 @@ TEST_F(ValueIdTest, EncodedIriEqualityWithLocalVocabEntry) {
   using namespace ad_utility::testing;
   TestIndexConfig config;
   config.encodedIriManager = encodedIriManager;
-  getQec(config);
+  qec_ = getQec(config);
 
   // Test case 1: IRI that can be encoded
   std::string encodableIri = "<http://example.org/123>";
@@ -421,7 +415,7 @@ TEST_F(ValueIdTest, EncodedIriEqualityWithLocalVocabEntry) {
 
   // Create a LocalVocabEntry with the same IRI
   auto iri = ad_utility::triple_component::Iri::fromIriref(encodableIri);
-  LocalVocabEntry localVocabEntry{iri, getQec(config)->getIndex().getImpl()};
+  LocalVocabEntry localVocabEntry{iri, qec_->getIndex()};
   auto localVocabId = ValueId::makeFromLocalVocabIndex(&localVocabEntry);
 
   // The encoded ID should compare equal to the LocalVocabEntry ID
@@ -436,7 +430,7 @@ TEST_F(ValueIdTest, EncodedIriEqualityWithLocalVocabEntry) {
 
   auto encodedId2 = *encodedIdOpt2;
   auto iri2 = ad_utility::triple_component::Iri::fromIriref(encodableIri2);
-  LocalVocabEntry localVocabEntry2{iri2, getQec(config)->getIndex().getImpl()};
+  LocalVocabEntry localVocabEntry2{iri2, qec_->getIndex()};
   auto localVocabId2 = ValueId::makeFromLocalVocabIndex(&localVocabEntry2);
 
   EXPECT_EQ(encodedId2, localVocabId2)

--- a/test/ValueIdTest.cpp
+++ b/test/ValueIdTest.cpp
@@ -324,8 +324,7 @@ TEST_F(ValueIdTest, Hashing) {
     LocalVocabEntry lve2(iri, index);
     LocalVocabEntry lve3 =
         LocalVocabEntry::fromStringRepresentation("\"foo\"", index);
-    LocalVocabEntry lve4 =
-        LocalVocabEntry::fromIriref("<x>", index);
+    LocalVocabEntry lve4 = LocalVocabEntry::fromIriref("<x>", index);
     auto LVID = [](LocalVocabEntry& lve, LocalVocab& lv) {
       return Id::makeFromLocalVocabIndex(lv.getIndexAndAddIfNotContained(lve));
     };

--- a/test/ValueIdTest.cpp
+++ b/test/ValueIdTest.cpp
@@ -325,7 +325,7 @@ TEST_F(ValueIdTest, Hashing) {
     LocalVocabEntry lve3 =
         LocalVocabEntry::fromStringRepresentation("\"foo\"", index);
     LocalVocabEntry lve4 =
-        LocalVocabEntry::fromStringRepresentation("<x>", index);
+        LocalVocabEntry::fromIriref("<x>", index);
     auto LVID = [](LocalVocabEntry& lve, LocalVocab& lv) {
       return Id::makeFromLocalVocabIndex(lv.getIndexAndAddIfNotContained(lve));
     };

--- a/test/ValueIdTest.cpp
+++ b/test/ValueIdTest.cpp
@@ -363,10 +363,8 @@ TEST_F(ValueIdTest, toDebugString) {
   test(ValueId::makeBoolFromZeroOrOne(false), "B:false");
   test(ValueId::makeBoolFromZeroOrOne(true), "B:true");
   test(makeVocabId(15), "V:15");
-  auto str = LocalVocabEntry{
-      ad_utility::triple_component::LiteralOrIri::literalWithoutQuotes(
-          "SomeValue"),
-      qec_->getLocalVocabContext()};
+  auto str = LocalVocabEntry::literalWithoutQuotes(
+      "SomeValue", qec_->getLocalVocabContext());
   test(ValueId::makeFromLocalVocabIndex(&str), "L:\"SomeValue\"");
   test(makeTextRecordId(37), "T:37");
   test(makeWordVocabId(42), "W:42");

--- a/test/ValueIdTest.cpp
+++ b/test/ValueIdTest.cpp
@@ -323,11 +323,13 @@ TEST_F(ValueIdTest, Hashing) {
     auto mkId = makeGetId(index);
     LocalVocab lv1;
     LocalVocab lv2;
+    const auto& indexImpl = index.getImpl();
     Iri iri = Iri::fromIriref("<foo>");
-    LocalVocabEntry lve1(iri);
-    LocalVocabEntry lve2(iri);
-    LocalVocabEntry lve3(Literal::fromStringRepresentation("\"foo\""));
-    LocalVocabEntry lve4(Iri::fromIriref("<x>"));
+    LocalVocabEntry lve1(iri, indexImpl);
+    LocalVocabEntry lve2(iri, indexImpl);
+    LocalVocabEntry lve3(Literal::fromStringRepresentation("\"foo\""),
+                         indexImpl);
+    LocalVocabEntry lve4(Iri::fromIriref("<x>"), indexImpl);
     auto LVID = [](LocalVocabEntry& lve, LocalVocab& lv) {
       return Id::makeFromLocalVocabIndex(lv.getIndexAndAddIfNotContained(lve));
     };
@@ -368,7 +370,8 @@ TEST_F(ValueIdTest, toDebugString) {
   test(makeVocabId(15), "V:15");
   auto str = LocalVocabEntry{
       ad_utility::triple_component::LiteralOrIri::literalWithoutQuotes(
-          "SomeValue")};
+          "SomeValue"),
+      ad_utility::testing::getQec()->getIndex().getImpl()};
   test(ValueId::makeFromLocalVocabIndex(&str), "L:\"SomeValue\"");
   test(makeTextRecordId(37), "T:37");
   test(makeWordVocabId(42), "W:42");
@@ -418,7 +421,7 @@ TEST_F(ValueIdTest, EncodedIriEqualityWithLocalVocabEntry) {
 
   // Create a LocalVocabEntry with the same IRI
   auto iri = ad_utility::triple_component::Iri::fromIriref(encodableIri);
-  LocalVocabEntry localVocabEntry{iri};
+  LocalVocabEntry localVocabEntry{iri, getQec(config)->getIndex().getImpl()};
   auto localVocabId = ValueId::makeFromLocalVocabIndex(&localVocabEntry);
 
   // The encoded ID should compare equal to the LocalVocabEntry ID
@@ -433,7 +436,7 @@ TEST_F(ValueIdTest, EncodedIriEqualityWithLocalVocabEntry) {
 
   auto encodedId2 = *encodedIdOpt2;
   auto iri2 = ad_utility::triple_component::Iri::fromIriref(encodableIri2);
-  LocalVocabEntry localVocabEntry2{iri2};
+  LocalVocabEntry localVocabEntry2{iri2, getQec(config)->getIndex().getImpl()};
   auto localVocabId2 = ValueId::makeFromLocalVocabIndex(&localVocabEntry2);
 
   EXPECT_EQ(encodedId2, localVocabId2)

--- a/test/ValueIdTest.cpp
+++ b/test/ValueIdTest.cpp
@@ -366,7 +366,7 @@ TEST_F(ValueIdTest, toDebugString) {
   auto str = LocalVocabEntry{
       ad_utility::triple_component::LiteralOrIri::literalWithoutQuotes(
           "SomeValue"),
-      qec_->getIndex()};
+      qec_->getLocalVocabContext()};
   test(ValueId::makeFromLocalVocabIndex(&str), "L:\"SomeValue\"");
   test(makeTextRecordId(37), "T:37");
   test(makeWordVocabId(42), "W:42");
@@ -416,7 +416,7 @@ TEST_F(ValueIdTest, EncodedIriEqualityWithLocalVocabEntry) {
 
   // Create a LocalVocabEntry with the same IRI
   auto iri = ad_utility::triple_component::Iri::fromIriref(encodableIri);
-  LocalVocabEntry localVocabEntry{iri, qec_->getIndex()};
+  LocalVocabEntry localVocabEntry{iri, qec_->getLocalVocabContext()};
   auto localVocabId = ValueId::makeFromLocalVocabIndex(&localVocabEntry);
 
   // The encoded ID should compare equal to the LocalVocabEntry ID
@@ -431,7 +431,7 @@ TEST_F(ValueIdTest, EncodedIriEqualityWithLocalVocabEntry) {
 
   auto encodedId2 = *encodedIdOpt2;
   auto iri2 = ad_utility::triple_component::Iri::fromIriref(encodableIri2);
-  LocalVocabEntry localVocabEntry2{iri2, qec_->getIndex()};
+  LocalVocabEntry localVocabEntry2{iri2, qec_->getLocalVocabContext()};
   auto localVocabId2 = ValueId::makeFromLocalVocabIndex(&localVocabEntry2);
 
   EXPECT_EQ(encodedId2, localVocabId2)

--- a/test/ValueIdTest.cpp
+++ b/test/ValueIdTest.cpp
@@ -316,7 +316,7 @@ TEST_F(ValueIdTest, Hashing) {
     using namespace ad_utility::triple_component;
     using namespace ad_utility::testing;
     const Index& index = qec_->getIndex();
-    auto mkId = makeGetId(qec_->getIndex());
+    auto mkId = makeGetId(index);
     LocalVocab lv1;
     LocalVocab lv2;
     Iri iri = Iri::fromIriref("<foo>");

--- a/test/ValueIdTest.cpp
+++ b/test/ValueIdTest.cpp
@@ -322,8 +322,10 @@ TEST_F(ValueIdTest, Hashing) {
     Iri iri = Iri::fromIriref("<foo>");
     LocalVocabEntry lve1(iri, index);
     LocalVocabEntry lve2(iri, index);
-    LocalVocabEntry lve3(Literal::fromStringRepresentation("\"foo\""), index);
-    LocalVocabEntry lve4(Iri::fromIriref("<x>"), index);
+    LocalVocabEntry lve3 =
+        LocalVocabEntry::fromStringRepresentation("\"foo\"", index);
+    LocalVocabEntry lve4 =
+        LocalVocabEntry::fromStringRepresentation("<x>", index);
     auto LVID = [](LocalVocabEntry& lve, LocalVocab& lv) {
       return Id::makeFromLocalVocabIndex(lv.getIndexAndAddIfNotContained(lve));
     };

--- a/test/ValuesTest.cpp
+++ b/test/ValuesTest.cpp
@@ -75,9 +75,9 @@ TEST(Values, computeResult) {
   const auto& table = result->idTable();
   Id x = ad_utility::testing::makeGetId(testQec->getIndex())("<x>");
   auto I = ad_utility::testing::IntId;
-  const auto& indexImpl = testQec->getIndex().getImpl();
-  auto l = result->localVocab().getIndexOrNullopt(LocalVocabEntry{
-      ad_utility::triple_component::LiteralOrIri::iriref("<y>"), indexImpl});
+  auto l = result->localVocab().getIndexOrNullopt(
+      LocalVocabEntry{ad_utility::triple_component::LiteralOrIri::iriref("<y>"),
+                      testQec->getIndex()});
   ASSERT_TRUE(l.has_value());
   auto U = Id::makeUndefined();
   ASSERT_EQ(table,

--- a/test/ValuesTest.cpp
+++ b/test/ValuesTest.cpp
@@ -76,8 +76,7 @@ TEST(Values, computeResult) {
   Id x = ad_utility::testing::makeGetId(testQec->getIndex())("<x>");
   auto I = ad_utility::testing::IntId;
   auto l = result->localVocab().getIndexOrNullopt(
-      LocalVocabEntry{ad_utility::triple_component::LiteralOrIri::iriref("<y>"),
-                      testQec->getIndex()});
+      LocalVocabEntry::fromStringRepresentation("<y>", testQec->getIndex()));
   ASSERT_TRUE(l.has_value());
   auto U = Id::makeUndefined();
   ASSERT_EQ(table,

--- a/test/ValuesTest.cpp
+++ b/test/ValuesTest.cpp
@@ -75,8 +75,9 @@ TEST(Values, computeResult) {
   const auto& table = result->idTable();
   Id x = ad_utility::testing::makeGetId(testQec->getIndex())("<x>");
   auto I = ad_utility::testing::IntId;
-  auto l = result->localVocab().getIndexOrNullopt(
-      ad_utility::triple_component::LiteralOrIri::iriref("<y>"));
+  const auto& indexImpl = testQec->getIndex().getImpl();
+  auto l = result->localVocab().getIndexOrNullopt(LocalVocabEntry{
+      ad_utility::triple_component::LiteralOrIri::iriref("<y>"), indexImpl});
   ASSERT_TRUE(l.has_value());
   auto U = Id::makeUndefined();
   ASSERT_EQ(table,

--- a/test/ValuesTest.cpp
+++ b/test/ValuesTest.cpp
@@ -76,7 +76,8 @@ TEST(Values, computeResult) {
   Id x = ad_utility::testing::makeGetId(testQec->getIndex())("<x>");
   auto I = ad_utility::testing::IntId;
   auto l = result->localVocab().getIndexOrNullopt(
-      LocalVocabEntry::fromStringRepresentation("<y>", testQec->getIndex()));
+      LocalVocabEntry::fromStringRepresentation(
+          "<y>", testQec->getLocalVocabContext()));
   ASSERT_TRUE(l.has_value());
   auto U = Id::makeUndefined();
   ASSERT_EQ(table,

--- a/test/engine/ExistsJoinTest.cpp
+++ b/test/engine/ExistsJoinTest.cpp
@@ -195,15 +195,15 @@ TEST(ExistsJoin, computeResult) {
 
 // _____________________________________________________________________________
 TEST(ExistsJoin, computeExistsJoinLeftIndexNestedLoopJoinOptimization) {
-  const auto& index = ad_utility::testing::getQec()->getIndex().getImpl();
+  auto* qec = ad_utility::testing::getQec();
   LocalVocabEntry entryA{
       ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
           "\"a\""),
-      index};
+      qec->getIndex()};
   LocalVocabEntry entryB{
       ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
           "\"b\""),
-      index};
+      qec->getIndex()};
 
   LocalVocab leftVocab;
   leftVocab.getIndexAndAddIfNotContained(entryA);
@@ -226,7 +226,6 @@ TEST(ExistsJoin, computeExistsJoinLeftIndexNestedLoopJoinOptimization) {
   IdTable expected = makeIdTableFromVector(
       {{1, 1, 2, T}, {4, 2, 1, F}, {2, 8, 1, F}, {3, 8, 2, T}, {4, 8, 2, T}});
 
-  auto* qec = ad_utility::testing::getQec();
   for (bool forceFullyMaterialized : {false, true}) {
     qec->getQueryTreeCache().clearAll();
     ExistsJoin existsJoin{
@@ -257,15 +256,15 @@ TEST(ExistsJoin, computeExistsJoinLeftIndexNestedLoopJoinOptimization) {
 
 // _____________________________________________________________________________
 TEST(ExistsJoin, computeExistsJoinRightIndexNestedLoopJoinOptimization) {
-  const auto& index = ad_utility::testing::getQec()->getIndex().getImpl();
+  auto* qec = ad_utility::testing::getQec();
   LocalVocabEntry entryA{
       ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
           "\"a\""),
-      index};
+      qec->getIndex()};
   LocalVocabEntry entryB{
       ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
           "\"b\""),
-      index};
+      qec->getIndex()};
 
   LocalVocab leftVocab;
   leftVocab.getIndexAndAddIfNotContained(entryA);
@@ -292,7 +291,6 @@ TEST(ExistsJoin, computeExistsJoinRightIndexNestedLoopJoinOptimization) {
                                             {10, 11, 12, 13, F},
                                             {14, 15, 16, 17, F}});
 
-  auto* qec = ad_utility::testing::getQec();
   for (bool requestLaziness : {false, true}) {
     qec->getQueryTreeCache().clearAll();
     ExistsJoin existsJoin{

--- a/test/engine/ExistsJoinTest.cpp
+++ b/test/engine/ExistsJoinTest.cpp
@@ -196,10 +196,10 @@ TEST(ExistsJoin, computeResult) {
 // _____________________________________________________________________________
 TEST(ExistsJoin, computeExistsJoinLeftIndexNestedLoopJoinOptimization) {
   auto* qec = ad_utility::testing::getQec();
-  LocalVocabEntry entryA =
-      LocalVocabEntry::fromStringRepresentation("\"a\"", qec->getIndex());
-  LocalVocabEntry entryB =
-      LocalVocabEntry::fromStringRepresentation("\"b\"", qec->getIndex());
+  LocalVocabEntry entryA = LocalVocabEntry::fromStringRepresentation(
+      "\"a\"", qec->getLocalVocabContext());
+  LocalVocabEntry entryB = LocalVocabEntry::fromStringRepresentation(
+      "\"b\"", qec->getLocalVocabContext());
 
   LocalVocab leftVocab;
   leftVocab.getIndexAndAddIfNotContained(entryA);
@@ -253,10 +253,10 @@ TEST(ExistsJoin, computeExistsJoinLeftIndexNestedLoopJoinOptimization) {
 // _____________________________________________________________________________
 TEST(ExistsJoin, computeExistsJoinRightIndexNestedLoopJoinOptimization) {
   auto* qec = ad_utility::testing::getQec();
-  LocalVocabEntry entryA =
-      LocalVocabEntry::fromStringRepresentation("\"a\"", qec->getIndex());
-  LocalVocabEntry entryB =
-      LocalVocabEntry::fromStringRepresentation("\"b\"", qec->getIndex());
+  LocalVocabEntry entryA = LocalVocabEntry::fromStringRepresentation(
+      "\"a\"", qec->getLocalVocabContext());
+  LocalVocabEntry entryB = LocalVocabEntry::fromStringRepresentation(
+      "\"b\"", qec->getLocalVocabContext());
 
   LocalVocab leftVocab;
   leftVocab.getIndexAndAddIfNotContained(entryA);

--- a/test/engine/ExistsJoinTest.cpp
+++ b/test/engine/ExistsJoinTest.cpp
@@ -195,8 +195,15 @@ TEST(ExistsJoin, computeResult) {
 
 // _____________________________________________________________________________
 TEST(ExistsJoin, computeExistsJoinLeftIndexNestedLoopJoinOptimization) {
-  LocalVocabEntry entryA = LocalVocabEntry::fromStringRepresentation("\"a\"");
-  LocalVocabEntry entryB = LocalVocabEntry::fromStringRepresentation("\"b\"");
+  const auto& index = ad_utility::testing::getQec()->getIndex().getImpl();
+  LocalVocabEntry entryA{
+      ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
+          "\"a\""),
+      index};
+  LocalVocabEntry entryB{
+      ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
+          "\"b\""),
+      index};
 
   LocalVocab leftVocab;
   leftVocab.getIndexAndAddIfNotContained(entryA);
@@ -250,8 +257,15 @@ TEST(ExistsJoin, computeExistsJoinLeftIndexNestedLoopJoinOptimization) {
 
 // _____________________________________________________________________________
 TEST(ExistsJoin, computeExistsJoinRightIndexNestedLoopJoinOptimization) {
-  LocalVocabEntry entryA = LocalVocabEntry::fromStringRepresentation("\"a\"");
-  LocalVocabEntry entryB = LocalVocabEntry::fromStringRepresentation("\"b\"");
+  const auto& index = ad_utility::testing::getQec()->getIndex().getImpl();
+  LocalVocabEntry entryA{
+      ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
+          "\"a\""),
+      index};
+  LocalVocabEntry entryB{
+      ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
+          "\"b\""),
+      index};
 
   LocalVocab leftVocab;
   leftVocab.getIndexAndAddIfNotContained(entryA);

--- a/test/engine/ExistsJoinTest.cpp
+++ b/test/engine/ExistsJoinTest.cpp
@@ -196,14 +196,10 @@ TEST(ExistsJoin, computeResult) {
 // _____________________________________________________________________________
 TEST(ExistsJoin, computeExistsJoinLeftIndexNestedLoopJoinOptimization) {
   auto* qec = ad_utility::testing::getQec();
-  LocalVocabEntry entryA{
-      ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
-          "\"a\""),
-      qec->getIndex()};
-  LocalVocabEntry entryB{
-      ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
-          "\"b\""),
-      qec->getIndex()};
+  LocalVocabEntry entryA =
+      LocalVocabEntry::fromStringRepresentation("\"a\"", qec->getIndex());
+  LocalVocabEntry entryB =
+      LocalVocabEntry::fromStringRepresentation("\"b\"", qec->getIndex());
 
   LocalVocab leftVocab;
   leftVocab.getIndexAndAddIfNotContained(entryA);
@@ -257,14 +253,10 @@ TEST(ExistsJoin, computeExistsJoinLeftIndexNestedLoopJoinOptimization) {
 // _____________________________________________________________________________
 TEST(ExistsJoin, computeExistsJoinRightIndexNestedLoopJoinOptimization) {
   auto* qec = ad_utility::testing::getQec();
-  LocalVocabEntry entryA{
-      ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
-          "\"a\""),
-      qec->getIndex()};
-  LocalVocabEntry entryB{
-      ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
-          "\"b\""),
-      qec->getIndex()};
+  LocalVocabEntry entryA =
+      LocalVocabEntry::fromStringRepresentation("\"a\"", qec->getIndex());
+  LocalVocabEntry entryB =
+      LocalVocabEntry::fromStringRepresentation("\"b\"", qec->getIndex());
 
   LocalVocab leftVocab;
   leftVocab.getIndexAndAddIfNotContained(entryA);

--- a/test/engine/ExplicitIdTableOperationTest.cpp
+++ b/test/engine/ExplicitIdTableOperationTest.cpp
@@ -161,7 +161,7 @@ TEST_F(ExplicitIdTableOperationTest, ComputeResultWithLaziness) {
 TEST_F(ExplicitIdTableOperationTest, ComputeResultWithLocalVocab) {
   LocalVocab localVocab;
   LocalVocabEntry testEntry = LocalVocabEntry::fromStringRepresentation(
-      "\"test_word\"", qec_->getIndex());
+      "\"test_word\"", qec_->getLocalVocabContext());
   localVocab.getIndexAndAddIfNotContained(testEntry);
 
   ExplicitIdTableOperation op(qec_, testTable_, testVariables_,
@@ -180,7 +180,7 @@ TEST_F(ExplicitIdTableOperationTest, ComputeResultWithLocalVocab) {
 TEST_F(ExplicitIdTableOperationTest, CloneImpl) {
   LocalVocab localVocab;
   LocalVocabEntry testEntry = LocalVocabEntry::fromStringRepresentation(
-      "\"clone_test\"", qec_->getIndex());
+      "\"clone_test\"", qec_->getLocalVocabContext());
   localVocab.getIndexAndAddIfNotContained(testEntry);
 
   ExplicitIdTableOperation original(qec_, testTable_, testVariables_,

--- a/test/engine/ExplicitIdTableOperationTest.cpp
+++ b/test/engine/ExplicitIdTableOperationTest.cpp
@@ -159,10 +159,12 @@ TEST_F(ExplicitIdTableOperationTest, ComputeResultWithLaziness) {
 
 // _____________________________________________________________________________
 TEST_F(ExplicitIdTableOperationTest, ComputeResultWithLocalVocab) {
+  const auto& index = qec_->getIndex().getImpl();
   LocalVocab localVocab;
   LocalVocabEntry testEntry{
       ad_utility::triple_component::Literal::fromStringRepresentation(
-          "\"test_word\"")};
+          "\"test_word\""),
+      index};
   localVocab.getIndexAndAddIfNotContained(testEntry);
 
   ExplicitIdTableOperation op(qec_, testTable_, testVariables_,
@@ -179,10 +181,12 @@ TEST_F(ExplicitIdTableOperationTest, ComputeResultWithLocalVocab) {
 
 // Test cloneImpl functionality
 TEST_F(ExplicitIdTableOperationTest, CloneImpl) {
+  const auto& index = qec_->getIndex().getImpl();
   LocalVocab localVocab;
   LocalVocabEntry testEntry{
       ad_utility::triple_component::Literal::fromStringRepresentation(
-          "\"clone_test\"")};
+          "\"clone_test\""),
+      index};
   localVocab.getIndexAndAddIfNotContained(testEntry);
 
   ExplicitIdTableOperation original(qec_, testTable_, testVariables_,

--- a/test/engine/ExplicitIdTableOperationTest.cpp
+++ b/test/engine/ExplicitIdTableOperationTest.cpp
@@ -159,12 +159,11 @@ TEST_F(ExplicitIdTableOperationTest, ComputeResultWithLaziness) {
 
 // _____________________________________________________________________________
 TEST_F(ExplicitIdTableOperationTest, ComputeResultWithLocalVocab) {
-  const auto& index = qec_->getIndex().getImpl();
   LocalVocab localVocab;
   LocalVocabEntry testEntry{
       ad_utility::triple_component::Literal::fromStringRepresentation(
           "\"test_word\""),
-      index};
+      qec_->getIndex()};
   localVocab.getIndexAndAddIfNotContained(testEntry);
 
   ExplicitIdTableOperation op(qec_, testTable_, testVariables_,
@@ -181,12 +180,11 @@ TEST_F(ExplicitIdTableOperationTest, ComputeResultWithLocalVocab) {
 
 // Test cloneImpl functionality
 TEST_F(ExplicitIdTableOperationTest, CloneImpl) {
-  const auto& index = qec_->getIndex().getImpl();
   LocalVocab localVocab;
   LocalVocabEntry testEntry{
       ad_utility::triple_component::Literal::fromStringRepresentation(
           "\"clone_test\""),
-      index};
+      qec_->getIndex()};
   localVocab.getIndexAndAddIfNotContained(testEntry);
 
   ExplicitIdTableOperation original(qec_, testTable_, testVariables_,

--- a/test/engine/ExplicitIdTableOperationTest.cpp
+++ b/test/engine/ExplicitIdTableOperationTest.cpp
@@ -160,10 +160,8 @@ TEST_F(ExplicitIdTableOperationTest, ComputeResultWithLaziness) {
 // _____________________________________________________________________________
 TEST_F(ExplicitIdTableOperationTest, ComputeResultWithLocalVocab) {
   LocalVocab localVocab;
-  LocalVocabEntry testEntry{
-      ad_utility::triple_component::Literal::fromStringRepresentation(
-          "\"test_word\""),
-      qec_->getIndex()};
+  LocalVocabEntry testEntry = LocalVocabEntry::fromStringRepresentation(
+      "\"test_word\"", qec_->getIndex());
   localVocab.getIndexAndAddIfNotContained(testEntry);
 
   ExplicitIdTableOperation op(qec_, testTable_, testVariables_,
@@ -181,10 +179,8 @@ TEST_F(ExplicitIdTableOperationTest, ComputeResultWithLocalVocab) {
 // Test cloneImpl functionality
 TEST_F(ExplicitIdTableOperationTest, CloneImpl) {
   LocalVocab localVocab;
-  LocalVocabEntry testEntry{
-      ad_utility::triple_component::Literal::fromStringRepresentation(
-          "\"clone_test\""),
-      qec_->getIndex()};
+  LocalVocabEntry testEntry = LocalVocabEntry::fromStringRepresentation(
+      "\"clone_test\"", qec_->getIndex());
   localVocab.getIndexAndAddIfNotContained(testEntry);
 
   ExplicitIdTableOperation original(qec_, testTable_, testVariables_,

--- a/test/engine/GroupByHashMapOptimizationTest.cpp
+++ b/test/engine/GroupByHashMapOptimizationTest.cpp
@@ -29,7 +29,7 @@ class GroupByHashMapOptimizationTest : public ::testing::Test {
       sparqlExpression::EvaluationContext::TimePoint::max()};
 
   Id calculate(const auto& data) {
-    return data.calculateResult(qec_->getIndex().getImpl(), &localVocab_);
+    return data.calculateResult(qec_->getIndex(), &localVocab_);
   }
 
   template <typename T>
@@ -57,7 +57,7 @@ class GroupByHashMapOptimizationTest : public ::testing::Test {
     using ad_utility::triple_component::LiteralOrIri;
     auto literal = LiteralOrIri::literalWithoutQuotes(string);
     return Id::makeFromLocalVocabIndex(localVocab_.getIndexAndAddIfNotContained(
-        LocalVocabEntry{std::move(literal), qec_->getIndex().getImpl()}));
+        LocalVocabEntry{std::move(literal), qec_->getIndex()}));
   };
 };
 
@@ -88,7 +88,7 @@ TEST_F(GroupByHashMapOptimizationTest, AvgAggregationDataAggregatesCorrectly) {
   auto literal = LiteralOrIri::literalWithoutQuotes("non-numeric value");
   auto id =
       Id::makeFromLocalVocabIndex(localVocab_.getIndexAndAddIfNotContained(
-          LocalVocabEntry{std::move(literal), qec_->getIndex().getImpl()}));
+          LocalVocabEntry{std::move(literal), qec_->getIndex()}));
   addValue(id);
   EXPECT_TRUE(calc().isUndefined());
 }
@@ -236,7 +236,7 @@ TEST_F(GroupByHashMapOptimizationTest,
         LiteralOrIri::literalWithoutQuotes(string, std::move(langTag));
     addValue(
         Id::makeFromLocalVocabIndex(localVocab_.getIndexAndAddIfNotContained(
-            LocalVocabEntry{std::move(literal), qec_->getIndex().getImpl()})));
+            LocalVocabEntry{std::move(literal), qec_->getIndex()})));
   };
 
   data.reset();

--- a/test/engine/GroupByHashMapOptimizationTest.cpp
+++ b/test/engine/GroupByHashMapOptimizationTest.cpp
@@ -57,7 +57,7 @@ class GroupByHashMapOptimizationTest : public ::testing::Test {
     using ad_utility::triple_component::LiteralOrIri;
     auto literal = LiteralOrIri::literalWithoutQuotes(string);
     return Id::makeFromLocalVocabIndex(localVocab_.getIndexAndAddIfNotContained(
-        LocalVocabEntry{std::move(literal), qec_->getIndex()}));
+        LocalVocabEntry{std::move(literal), qec_->getLocalVocabContext()}));
   };
 };
 
@@ -88,7 +88,7 @@ TEST_F(GroupByHashMapOptimizationTest, AvgAggregationDataAggregatesCorrectly) {
   auto literal = LiteralOrIri::literalWithoutQuotes("non-numeric value");
   auto id =
       Id::makeFromLocalVocabIndex(localVocab_.getIndexAndAddIfNotContained(
-          LocalVocabEntry{std::move(literal), qec_->getIndex()}));
+          LocalVocabEntry{std::move(literal), qec_->getLocalVocabContext()}));
   addValue(id);
   EXPECT_TRUE(calc().isUndefined());
 }
@@ -234,9 +234,9 @@ TEST_F(GroupByHashMapOptimizationTest,
     using ad_utility::triple_component::LiteralOrIri;
     auto literal =
         LiteralOrIri::literalWithoutQuotes(string, std::move(langTag));
-    addValue(
-        Id::makeFromLocalVocabIndex(localVocab_.getIndexAndAddIfNotContained(
-            LocalVocabEntry{std::move(literal), qec_->getIndex()})));
+    addValue(Id::makeFromLocalVocabIndex(
+        localVocab_.getIndexAndAddIfNotContained(LocalVocabEntry{
+            std::move(literal), qec_->getLocalVocabContext()})));
   };
 
   data.reset();

--- a/test/engine/GroupByHashMapOptimizationTest.cpp
+++ b/test/engine/GroupByHashMapOptimizationTest.cpp
@@ -28,7 +28,9 @@ class GroupByHashMapOptimizationTest : public ::testing::Test {
       std::make_shared<ad_utility::CancellationHandle<>>(),
       sparqlExpression::EvaluationContext::TimePoint::max()};
 
-  Id calculate(const auto& data) { return data.calculateResult(&localVocab_); }
+  Id calculate(const auto& data) {
+    return data.calculateResult(qec_->getIndex().getImpl(), &localVocab_);
+  }
 
   template <typename T>
   auto makeCalcAndAddValue(T& data) {
@@ -54,8 +56,8 @@ class GroupByHashMapOptimizationTest : public ::testing::Test {
   Id idFromString(std::string_view string) {
     using ad_utility::triple_component::LiteralOrIri;
     auto literal = LiteralOrIri::literalWithoutQuotes(string);
-    return Id::makeFromLocalVocabIndex(
-        localVocab_.getIndexAndAddIfNotContained(std::move(literal)));
+    return Id::makeFromLocalVocabIndex(localVocab_.getIndexAndAddIfNotContained(
+        LocalVocabEntry{std::move(literal), qec_->getIndex().getImpl()}));
   };
 };
 
@@ -84,8 +86,9 @@ TEST_F(GroupByHashMapOptimizationTest, AvgAggregationDataAggregatesCorrectly) {
   EXPECT_EQ(calc(), I(0));
   using ad_utility::triple_component::LiteralOrIri;
   auto literal = LiteralOrIri::literalWithoutQuotes("non-numeric value");
-  auto id = Id::makeFromLocalVocabIndex(
-      localVocab_.getIndexAndAddIfNotContained(std::move(literal)));
+  auto id =
+      Id::makeFromLocalVocabIndex(localVocab_.getIndexAndAddIfNotContained(
+          LocalVocabEntry{std::move(literal), qec_->getIndex().getImpl()}));
   addValue(id);
   EXPECT_TRUE(calc().isUndefined());
 }
@@ -231,8 +234,9 @@ TEST_F(GroupByHashMapOptimizationTest,
     using ad_utility::triple_component::LiteralOrIri;
     auto literal =
         LiteralOrIri::literalWithoutQuotes(string, std::move(langTag));
-    addValue(Id::makeFromLocalVocabIndex(
-        localVocab_.getIndexAndAddIfNotContained(std::move(literal))));
+    addValue(
+        Id::makeFromLocalVocabIndex(localVocab_.getIndexAndAddIfNotContained(
+            LocalVocabEntry{std::move(literal), qec_->getIndex().getImpl()})));
   };
 
   data.reset();

--- a/test/engine/GroupByHashMapOptimizationTest.cpp
+++ b/test/engine/GroupByHashMapOptimizationTest.cpp
@@ -54,10 +54,9 @@ class GroupByHashMapOptimizationTest : public ::testing::Test {
   };
 
   Id idFromString(std::string_view string) {
-    using ad_utility::triple_component::LiteralOrIri;
-    auto literal = LiteralOrIri::literalWithoutQuotes(string);
     return Id::makeFromLocalVocabIndex(localVocab_.getIndexAndAddIfNotContained(
-        LocalVocabEntry{std::move(literal), qec_->getLocalVocabContext()}));
+        LocalVocabEntry::literalWithoutQuotes(string,
+                                              qec_->getLocalVocabContext())));
   };
 };
 
@@ -84,11 +83,10 @@ TEST_F(GroupByHashMapOptimizationTest, AvgAggregationDataAggregatesCorrectly) {
 
   data.reset();
   EXPECT_EQ(calc(), I(0));
-  using ad_utility::triple_component::LiteralOrIri;
-  auto literal = LiteralOrIri::literalWithoutQuotes("non-numeric value");
   auto id =
       Id::makeFromLocalVocabIndex(localVocab_.getIndexAndAddIfNotContained(
-          LocalVocabEntry{std::move(literal), qec_->getLocalVocabContext()}));
+          LocalVocabEntry::literalWithoutQuotes("non-numeric value",
+                                                qec_->getLocalVocabContext())));
   addValue(id);
   EXPECT_TRUE(calc().isUndefined());
 }
@@ -231,9 +229,8 @@ TEST_F(GroupByHashMapOptimizationTest,
 
   auto addStringWithLangTag = [&](std::string_view string,
                                   std::string langTag) {
-    using ad_utility::triple_component::LiteralOrIri;
-    auto literal =
-        LiteralOrIri::literalWithoutQuotes(string, std::move(langTag));
+    using ad_utility::triple_component::Literal;
+    auto literal = Literal::literalWithoutQuotes(string, std::move(langTag));
     addValue(Id::makeFromLocalVocabIndex(
         localVocab_.getIndexAndAddIfNotContained(LocalVocabEntry{
             std::move(literal), qec_->getLocalVocabContext()})));

--- a/test/engine/GroupConcatExpressionTest.cpp
+++ b/test/engine/GroupConcatExpressionTest.cpp
@@ -16,10 +16,10 @@ namespace tc = ad_utility::triple_component;
 
 // _____________________________________________________________________________
 void expectIdsAreConcatenatedTo(
-    bool distinct, const IdTable& idTable, const ExpressionResult& expected,
+    QueryExecutionContext* qec, bool distinct, const IdTable& idTable,
+    const ExpressionResult& expected,
     ad_utility::source_location location = AD_CURRENT_SOURCE_LOC()) {
   AD_CONTRACT_CHECK(idTable.numColumns() == 1);
-  auto* qec = ad_utility::testing::getQec();
   auto g = generateLocationTrace(location);
 
   Variable var{"?x"};
@@ -47,21 +47,21 @@ void expectIdsAreConcatenatedTo(
 
 // _____________________________________________________________________________
 void expectLiteralsAreConcatenatedTo(
-    bool distinct, const std::vector<tc::Literal>& literals,
+    QueryExecutionContext* qec, bool distinct,
+    const std::vector<tc::Literal>& literals,
     const ad_utility::triple_component::Literal& literal,
     ad_utility::source_location location = AD_CURRENT_SOURCE_LOC()) {
   LocalVocab localVocab;
   IdTable input{1, ad_utility::makeUnlimitedAllocator<Id>()};
 
-  const auto& index = ad_utility::testing::getQec()->getIndex().getImpl();
   for (const auto& inputLiteral : literals) {
     auto idx = localVocab.getIndexAndAddIfNotContained(
-        LocalVocabEntry{inputLiteral, index});
+        LocalVocabEntry{inputLiteral, qec->getIndex()});
     input.push_back({Id::makeFromLocalVocabIndex(idx)});
   }
   expectIdsAreConcatenatedTo(
-      distinct, input, IdOrLocalVocabEntry{LocalVocabEntry{literal, index}},
-      location);
+      qec, distinct, input,
+      IdOrLocalVocabEntry{LocalVocabEntry{literal, qec->getIndex()}}, location);
 }
 
 auto lit = [](std::string s) {
@@ -71,67 +71,69 @@ auto lit = [](std::string s) {
 
 // _____________________________________________________________________________
 TEST(GroupConcatExpression, basicConcatenation) {
-  expectLiteralsAreConcatenatedTo(false, {}, lit("\"\""));
-  expectLiteralsAreConcatenatedTo(true, {}, lit("\"\""));
-  expectLiteralsAreConcatenatedTo(false, {lit("\"\"")}, lit("\"\""));
-  expectLiteralsAreConcatenatedTo(false, {lit("\"a\"")}, lit("\"a\""));
-  expectLiteralsAreConcatenatedTo(true, {lit("\"a\"")}, lit("\"a\""));
-  expectLiteralsAreConcatenatedTo(true, {lit("\"a\""), lit("\"a\"")},
+  auto* qec = ad_utility::testing::getQec();
+  expectLiteralsAreConcatenatedTo(qec, false, {}, lit("\"\""));
+  expectLiteralsAreConcatenatedTo(qec, true, {}, lit("\"\""));
+  expectLiteralsAreConcatenatedTo(qec, false, {lit("\"\"")}, lit("\"\""));
+  expectLiteralsAreConcatenatedTo(qec, false, {lit("\"a\"")}, lit("\"a\""));
+  expectLiteralsAreConcatenatedTo(qec, true, {lit("\"a\"")}, lit("\"a\""));
+  expectLiteralsAreConcatenatedTo(qec, true, {lit("\"a\""), lit("\"a\"")},
                                   lit("\"a\""));
-  expectLiteralsAreConcatenatedTo(false, {lit("\"a\""), lit("\"b\"")},
+  expectLiteralsAreConcatenatedTo(qec, false, {lit("\"a\""), lit("\"b\"")},
                                   lit("\"a;b\""));
   expectLiteralsAreConcatenatedTo(
-      true, {lit("\"a\""), lit("\"a\""), lit("\"b\"")}, lit("\"a;b\""));
+      qec, true, {lit("\"a\""), lit("\"a\""), lit("\"b\"")}, lit("\"a;b\""));
 
   expectLiteralsAreConcatenatedTo(
-      false, {lit("\"a\""), lit("\"b\""), lit("\"\"")}, lit("\"a;b;\""));
+      qec, false, {lit("\"a\""), lit("\"b\""), lit("\"\"")}, lit("\"a;b;\""));
   expectLiteralsAreConcatenatedTo(
-      false, {lit("\"a\""), lit("\"b\""), lit("\"\""), lit("\"\"")},
+      qec, false, {lit("\"a\""), lit("\"b\""), lit("\"\""), lit("\"\"")},
       lit("\"a;b;;\""));
   expectLiteralsAreConcatenatedTo(
-      false,
+      qec, false,
       {lit("\"a\""), lit("\"b\""), lit("\"\""), lit("\"\""), lit("\"c\"")},
       lit("\"a;b;;;c\""));
 }
 
 // _____________________________________________________________________________
 TEST(GroupConcatExpression, concatenationWithUndefined) {
+  auto* qec = ad_utility::testing::getQec();
   LocalVocab localVocab;
-  expectIdsAreConcatenatedTo(false,
+  expectIdsAreConcatenatedTo(qec, false,
                              makeIdTableFromVector({{Id::makeUndefined()}}),
                              ExpressionResult{Id::makeUndefined()});
 
-  const auto& index = ad_utility::testing::getQec()->getIndex().getImpl();
   auto idx = localVocab.getIndexAndAddIfNotContained(LocalVocabEntry{
       ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
           "\"a\""),
-      index});
+      qec->getIndex()});
   auto a = Id::makeFromLocalVocabIndex(idx);
   expectIdsAreConcatenatedTo(
-      false, makeIdTableFromVector({{Id::makeUndefined()}, {a}}),
+      qec, false, makeIdTableFromVector({{Id::makeUndefined()}, {a}}),
       ExpressionResult{Id::makeUndefined()});
   expectIdsAreConcatenatedTo(
-      false, makeIdTableFromVector({{a}, {Id::makeUndefined()}}),
+      qec, false, makeIdTableFromVector({{a}, {Id::makeUndefined()}}),
       ExpressionResult{Id::makeUndefined()});
 }
 
 // _____________________________________________________________________________
 TEST(GroupConcatExpression, concatenationWithLanguageTags) {
-  expectLiteralsAreConcatenatedTo(false, {lit("\"a\"@en")}, lit("\"a\""));
-  expectLiteralsAreConcatenatedTo(true, {lit("\"a\"@en")}, lit("\"a\""));
-  expectLiteralsAreConcatenatedTo(true, {lit("\"a\"@en"), lit("\"a\"@en")},
+  auto* qec = ad_utility::testing::getQec();
+  expectLiteralsAreConcatenatedTo(qec, false, {lit("\"a\"@en")}, lit("\"a\""));
+  expectLiteralsAreConcatenatedTo(qec, true, {lit("\"a\"@en")}, lit("\"a\""));
+  expectLiteralsAreConcatenatedTo(qec, true, {lit("\"a\"@en"), lit("\"a\"@en")},
                                   lit("\"a\""));
-  expectLiteralsAreConcatenatedTo(false, {lit("\"a\"@en"), lit("\"b\"@en")},
+  expectLiteralsAreConcatenatedTo(
+      qec, false, {lit("\"a\"@en"), lit("\"b\"@en")}, lit("\"a;b\""));
+  expectLiteralsAreConcatenatedTo(qec, false, {lit("\"a\""), lit("\"b\"@en")},
                                   lit("\"a;b\""));
-  expectLiteralsAreConcatenatedTo(false, {lit("\"a\""), lit("\"b\"@en")},
-                                  lit("\"a;b\""));
-  expectLiteralsAreConcatenatedTo(true, {lit("\"a\""), lit("\"a\"@en")},
+  expectLiteralsAreConcatenatedTo(qec, true, {lit("\"a\""), lit("\"a\"@en")},
                                   lit("\"a;a\""));
-  expectLiteralsAreConcatenatedTo(false, {lit("\"a\"@en"), lit("\"b\"")},
+  expectLiteralsAreConcatenatedTo(qec, false, {lit("\"a\"@en"), lit("\"b\"")},
                                   lit("\"a;b\""));
-  expectLiteralsAreConcatenatedTo(false, {lit("\"a\"@en"), lit("\"b\"@de")},
-                                  lit("\"a;b\""));
-  expectLiteralsAreConcatenatedTo(true, {lit("\"a\"@en"), lit("\"a\"@de")},
+  expectLiteralsAreConcatenatedTo(
+      qec, false, {lit("\"a\"@en"), lit("\"b\"@de")}, lit("\"a;b\""));
+  expectLiteralsAreConcatenatedTo(qec, true, {lit("\"a\"@en"), lit("\"a\"@de")},
                                   lit("\"a;a\""));
 }
 

--- a/test/engine/GroupConcatExpressionTest.cpp
+++ b/test/engine/GroupConcatExpressionTest.cpp
@@ -56,12 +56,13 @@ void expectLiteralsAreConcatenatedTo(
 
   for (const auto& inputLiteral : literals) {
     auto idx = localVocab.getIndexAndAddIfNotContained(
-        LocalVocabEntry{inputLiteral, qec->getIndex()});
+        LocalVocabEntry{inputLiteral, qec->getLocalVocabContext()});
     input.push_back({Id::makeFromLocalVocabIndex(idx)});
   }
-  expectIdsAreConcatenatedTo(
-      qec, distinct, input,
-      IdOrLocalVocabEntry{LocalVocabEntry{literal, qec->getIndex()}}, location);
+  expectIdsAreConcatenatedTo(qec, distinct, input,
+                             IdOrLocalVocabEntry{LocalVocabEntry{
+                                 literal, qec->getLocalVocabContext()}},
+                             location);
 }
 
 auto lit = [](std::string s) {
@@ -104,7 +105,8 @@ TEST(GroupConcatExpression, concatenationWithUndefined) {
                              ExpressionResult{Id::makeUndefined()});
 
   auto idx = localVocab.getIndexAndAddIfNotContained(
-      LocalVocabEntry::fromStringRepresentation("\"a\"", qec->getIndex()));
+      LocalVocabEntry::fromStringRepresentation("\"a\"",
+                                                qec->getLocalVocabContext()));
   auto a = Id::makeFromLocalVocabIndex(idx);
   expectIdsAreConcatenatedTo(
       qec, false, makeIdTableFromVector({{Id::makeUndefined()}, {a}}),

--- a/test/engine/GroupConcatExpressionTest.cpp
+++ b/test/engine/GroupConcatExpressionTest.cpp
@@ -53,13 +53,15 @@ void expectLiteralsAreConcatenatedTo(
   LocalVocab localVocab;
   IdTable input{1, ad_utility::makeUnlimitedAllocator<Id>()};
 
+  const auto& index = ad_utility::testing::getQec()->getIndex().getImpl();
   for (const auto& inputLiteral : literals) {
-    auto idx =
-        localVocab.getIndexAndAddIfNotContained(LocalVocabEntry{inputLiteral});
+    auto idx = localVocab.getIndexAndAddIfNotContained(
+        LocalVocabEntry{inputLiteral, index});
     input.push_back({Id::makeFromLocalVocabIndex(idx)});
   }
   expectIdsAreConcatenatedTo(
-      distinct, input, IdOrLocalVocabEntry{LocalVocabEntry{literal}}, location);
+      distinct, input, IdOrLocalVocabEntry{LocalVocabEntry{literal, index}},
+      location);
 }
 
 auto lit = [](std::string s) {
@@ -99,8 +101,11 @@ TEST(GroupConcatExpression, concatenationWithUndefined) {
                              makeIdTableFromVector({{Id::makeUndefined()}}),
                              ExpressionResult{Id::makeUndefined()});
 
-  auto idx = localVocab.getIndexAndAddIfNotContained(
-      LocalVocabEntry::fromStringRepresentation("\"a\""));
+  const auto& index = ad_utility::testing::getQec()->getIndex().getImpl();
+  auto idx = localVocab.getIndexAndAddIfNotContained(LocalVocabEntry{
+      ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
+          "\"a\""),
+      index});
   auto a = Id::makeFromLocalVocabIndex(idx);
   expectIdsAreConcatenatedTo(
       false, makeIdTableFromVector({{Id::makeUndefined()}, {a}}),

--- a/test/engine/GroupConcatExpressionTest.cpp
+++ b/test/engine/GroupConcatExpressionTest.cpp
@@ -103,10 +103,8 @@ TEST(GroupConcatExpression, concatenationWithUndefined) {
                              makeIdTableFromVector({{Id::makeUndefined()}}),
                              ExpressionResult{Id::makeUndefined()});
 
-  auto idx = localVocab.getIndexAndAddIfNotContained(LocalVocabEntry{
-      ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
-          "\"a\""),
-      qec->getIndex()});
+  auto idx = localVocab.getIndexAndAddIfNotContained(
+      LocalVocabEntry::fromStringRepresentation("\"a\"", qec->getIndex()));
   auto a = Id::makeFromLocalVocabIndex(idx);
   expectIdsAreConcatenatedTo(
       qec, false, makeIdTableFromVector({{Id::makeUndefined()}, {a}}),

--- a/test/engine/IndexScanTest.cpp
+++ b/test/engine/IndexScanTest.cpp
@@ -1789,7 +1789,7 @@ TEST(IndexScanTest, StripColumnsWithPrefiltering) {
   // Create prefilter condition: ?x < <s2>
   auto prefilterPairs = [&qec]() {
     return makePrefilterVec(pr(
-        lt(LocalVocabEntry::fromStringRepresentation("<s2>", qec->getIndex())),
+        lt(LocalVocabEntry::fromIriref("<s2>", qec->getIndex())),
         Var{"?x"}));
   };
 

--- a/test/engine/IndexScanTest.cpp
+++ b/test/engine/IndexScanTest.cpp
@@ -1788,11 +1788,9 @@ TEST(IndexScanTest, StripColumnsWithPrefiltering) {
 
   // Create prefilter condition: ?x < <s2>
   auto prefilterPairs = [&qec]() {
-    return makePrefilterVec(
-        pr(lt(LocalVocabEntry{
-               ad_utility::triple_component::LiteralOrIri::iriref("<s2>"),
-               qec->getIndex()}),
-           Var{"?x"}));
+    return makePrefilterVec(pr(
+        lt(LocalVocabEntry::fromStringRepresentation("<s2>", qec->getIndex())),
+        Var{"?x"}));
   };
 
   // Test with different variable combinations

--- a/test/engine/IndexScanTest.cpp
+++ b/test/engine/IndexScanTest.cpp
@@ -1789,8 +1789,7 @@ TEST(IndexScanTest, StripColumnsWithPrefiltering) {
   // Create prefilter condition: ?x < <s2>
   auto prefilterPairs = [&qec]() {
     return makePrefilterVec(pr(
-        lt(LocalVocabEntry::fromIriref("<s2>", qec->getIndex())),
-        Var{"?x"}));
+        lt(LocalVocabEntry::fromIriref("<s2>", qec->getIndex())), Var{"?x"}));
   };
 
   // Test with different variable combinations

--- a/test/engine/IndexScanTest.cpp
+++ b/test/engine/IndexScanTest.cpp
@@ -980,7 +980,7 @@ TEST_P(IndexScanWithLazyJoin, prefilterTablesDoesFilterCorrectly) {
     LocalVocab vocab;
     vocab.getIndexAndAddIfNotContained(LocalVocabEntry{
         ad_utility::triple_component::Literal::literalWithoutQuotes("Test"),
-        qec_->getIndex().getImpl()});
+        qec_->getIndex()});
     return std::array{P{makeIdTable({iri("<a>"), iri("<c>")}), LocalVocab{}},
                       P{makeIdTable({iri("<c>")}), LocalVocab{}},
                       P{makeIdTable({iri("<c>"), iri("<q>"), iri("<xb>")}),
@@ -1167,11 +1167,11 @@ TEST_P(IndexScanWithLazyJoin,
   qec_ = getQec(std::move(config));
   IndexScan scan = makeScan();
   LocalVocab extraVocab;
-  const auto& impl = qec_->getIndex().getImpl();
+  const auto& index = qec_->getIndex();
   auto indexE = extraVocab.getIndexAndAddIfNotContained(
-      LocalVocabEntry{iri("<e>"), impl});
+      LocalVocabEntry{iri("<e>"), index});
   auto indexG = extraVocab.getIndexAndAddIfNotContained(
-      LocalVocabEntry{iri("<g>"), impl});
+      LocalVocabEntry{iri("<g>"), index});
 
   using P = Result::IdTableVocabPair;
   std::array pairs{
@@ -1791,7 +1791,7 @@ TEST(IndexScanTest, StripColumnsWithPrefiltering) {
     return makePrefilterVec(
         pr(lt(LocalVocabEntry{
                ad_utility::triple_component::LiteralOrIri::iriref("<s2>"),
-               qec->getIndex().getImpl()}),
+               qec->getIndex()}),
            Var{"?x"}));
   };
 
@@ -1894,7 +1894,7 @@ TEST_P(IndexScanWithLazyJoin, prefilterTablesDoesFilterCorrectlyOptionalJoin) {
     LocalVocab vocab;
     vocab.getIndexAndAddIfNotContained(LocalVocabEntry{
         ad_utility::triple_component::Literal::literalWithoutQuotes("Test"),
-        qec_->getIndex().getImpl()});
+        qec_->getIndex()});
     return std::array{P{makeIdTable({iri("<a>"), iri("<c>")}), LocalVocab{}},
                       P{makeIdTable({iri("<c>")}), LocalVocab{}},
                       P{makeIdTable({iri("<c>"), iri("<q>"), iri("<xb>")}),

--- a/test/engine/IndexScanTest.cpp
+++ b/test/engine/IndexScanTest.cpp
@@ -979,7 +979,8 @@ TEST_P(IndexScanWithLazyJoin, prefilterTablesDoesFilterCorrectly) {
     using P = Result::IdTableVocabPair;
     LocalVocab vocab;
     vocab.getIndexAndAddIfNotContained(LocalVocabEntry{
-        ad_utility::triple_component::Literal::literalWithoutQuotes("Test")});
+        ad_utility::triple_component::Literal::literalWithoutQuotes("Test"),
+        qec_->getIndex().getImpl()});
     return std::array{P{makeIdTable({iri("<a>"), iri("<c>")}), LocalVocab{}},
                       P{makeIdTable({iri("<c>")}), LocalVocab{}},
                       P{makeIdTable({iri("<c>"), iri("<q>"), iri("<xb>")}),
@@ -1166,10 +1167,11 @@ TEST_P(IndexScanWithLazyJoin,
   qec_ = getQec(std::move(config));
   IndexScan scan = makeScan();
   LocalVocab extraVocab;
-  auto indexE =
-      extraVocab.getIndexAndAddIfNotContained(LocalVocabEntry{iri("<e>")});
-  auto indexG =
-      extraVocab.getIndexAndAddIfNotContained(LocalVocabEntry{iri("<g>")});
+  const auto& impl = qec_->getIndex().getImpl();
+  auto indexE = extraVocab.getIndexAndAddIfNotContained(
+      LocalVocabEntry{iri("<e>"), impl});
+  auto indexG = extraVocab.getIndexAndAddIfNotContained(
+      LocalVocabEntry{iri("<g>"), impl});
 
   using P = Result::IdTableVocabPair;
   std::array pairs{
@@ -1785,8 +1787,12 @@ TEST(IndexScanTest, StripColumnsWithPrefiltering) {
       dynamic_cast<IndexScan&>(*baseScanTree->getRootOperation());
 
   // Create prefilter condition: ?x < <s2>
-  auto prefilterPairs = []() {
-    return makePrefilterVec(pr(lt(LocalVocabEntry::iriref("<s2>")), Var{"?x"}));
+  auto prefilterPairs = [&qec]() {
+    return makePrefilterVec(
+        pr(lt(LocalVocabEntry{
+               ad_utility::triple_component::LiteralOrIri::iriref("<s2>"),
+               qec->getIndex().getImpl()}),
+           Var{"?x"}));
   };
 
   // Test with different variable combinations
@@ -1887,7 +1893,8 @@ TEST_P(IndexScanWithLazyJoin, prefilterTablesDoesFilterCorrectlyOptionalJoin) {
     using P = Result::IdTableVocabPair;
     LocalVocab vocab;
     vocab.getIndexAndAddIfNotContained(LocalVocabEntry{
-        ad_utility::triple_component::Literal::literalWithoutQuotes("Test")});
+        ad_utility::triple_component::Literal::literalWithoutQuotes("Test"),
+        qec_->getIndex().getImpl()});
     return std::array{P{makeIdTable({iri("<a>"), iri("<c>")}), LocalVocab{}},
                       P{makeIdTable({iri("<c>")}), LocalVocab{}},
                       P{makeIdTable({iri("<c>"), iri("<q>"), iri("<xb>")}),

--- a/test/engine/IndexScanTest.cpp
+++ b/test/engine/IndexScanTest.cpp
@@ -980,7 +980,7 @@ TEST_P(IndexScanWithLazyJoin, prefilterTablesDoesFilterCorrectly) {
     LocalVocab vocab;
     vocab.getIndexAndAddIfNotContained(LocalVocabEntry{
         ad_utility::triple_component::Literal::literalWithoutQuotes("Test"),
-        qec_->getIndex()});
+        qec_->getLocalVocabContext()});
     return std::array{P{makeIdTable({iri("<a>"), iri("<c>")}), LocalVocab{}},
                       P{makeIdTable({iri("<c>")}), LocalVocab{}},
                       P{makeIdTable({iri("<c>"), iri("<q>"), iri("<xb>")}),
@@ -1167,11 +1167,11 @@ TEST_P(IndexScanWithLazyJoin,
   qec_ = getQec(std::move(config));
   IndexScan scan = makeScan();
   LocalVocab extraVocab;
-  const auto& index = qec_->getIndex();
+  const auto& localVocabContext = qec_->getLocalVocabContext();
   auto indexE = extraVocab.getIndexAndAddIfNotContained(
-      LocalVocabEntry{iri("<e>"), index});
+      LocalVocabEntry{iri("<e>"), localVocabContext});
   auto indexG = extraVocab.getIndexAndAddIfNotContained(
-      LocalVocabEntry{iri("<g>"), index});
+      LocalVocabEntry{iri("<g>"), localVocabContext});
 
   using P = Result::IdTableVocabPair;
   std::array pairs{
@@ -1788,8 +1788,9 @@ TEST(IndexScanTest, StripColumnsWithPrefiltering) {
 
   // Create prefilter condition: ?x < <s2>
   auto prefilterPairs = [&qec]() {
-    return makePrefilterVec(pr(
-        lt(LocalVocabEntry::fromIriref("<s2>", qec->getIndex())), Var{"?x"}));
+    return makePrefilterVec(
+        pr(lt(LocalVocabEntry::fromIriref("<s2>", qec->getLocalVocabContext())),
+           Var{"?x"}));
   };
 
   // Test with different variable combinations
@@ -1891,7 +1892,7 @@ TEST_P(IndexScanWithLazyJoin, prefilterTablesDoesFilterCorrectlyOptionalJoin) {
     LocalVocab vocab;
     vocab.getIndexAndAddIfNotContained(LocalVocabEntry{
         ad_utility::triple_component::Literal::literalWithoutQuotes("Test"),
-        qec_->getIndex()});
+        qec_->getLocalVocabContext()});
     return std::array{P{makeIdTable({iri("<a>"), iri("<c>")}), LocalVocab{}},
                       P{makeIdTable({iri("<c>")}), LocalVocab{}},
                       P{makeIdTable({iri("<c>"), iri("<q>"), iri("<xb>")}),

--- a/test/engine/NamedResultCacheSerializerTest.cpp
+++ b/test/engine/NamedResultCacheSerializerTest.cpp
@@ -13,6 +13,7 @@
 #include "../util/IndexTestHelpers.h"
 #include "engine/NamedResultCache.h"
 #include "engine/NamedResultCacheSerializer.h"
+#include "index/LocalVocabEntry.h"
 #include "util/Serializer/ByteBufferSerializer.h"
 
 using namespace ad_utility::serialization;
@@ -33,23 +34,23 @@ class NamedResultCacheSerializerTest : public ::testing::Test {
 
   // Serialize and immediately deserialize and return the `value`.
   NamedResultCache::Value serializeAndDeserializeValue(
-      const NamedResultCache::Value& value, ad_utility::BlankNodeManager& bm,
+      const NamedResultCache::Value& value, const IndexImpl& index,
       ad_utility::AllocatorWithLimit<Id> allocator) const {
     ByteBufferWriteSerializer writeSerializer;
     writeSerializer << value;
     ByteBufferReadSerializer readSerializer{std::move(writeSerializer).data()};
     NamedResultCache::Value result;
     result.allocatorForSerialization_ = std::move(allocator);
-    result.blankNodeManagerForSerialization_.emplace(bm);
+    result.indexForSerialization_ = &index;
     readSerializer >> result;
     return result;
   }
 
-  // Overload that uses the default member variables, cannot be const, because
-  // the calls might modify the `BlankNodeManager` or the `LocalVocab`.
+  // Overload that uses the default member variables.
   NamedResultCache::Value serializeAndDeserializeValue(
       const NamedResultCache::Value& value) {
-    return serializeAndDeserializeValue(value, blankNodeManager_, alloc_);
+    return serializeAndDeserializeValue(
+        value, ad_utility::testing::getQec()->getIndex().getImpl(), alloc_);
   }
 };
 
@@ -61,8 +62,9 @@ TEST_F(NamedResultCacheSerializerTest, ValueSerialization) {
   // Create a test Value
   LocalVocab localVocab;
   [[maybe_unused]] auto local = localVocab.getIndexAndAddIfNotContained(
-      ad_utility::triple_component::LiteralOrIri::iriref(
-          "<http://example.org/test>"));
+      LocalVocabEntry{ad_utility::triple_component::LiteralOrIri::iriref(
+                          "<http://example.org/test>"),
+                      qec->getIndex().getImpl()});
 
   // Note: Currently the serialization throws if we pass a `LocalVocabIndex`
   // inside the `IdTable` As soon as we have improved the serialization of local
@@ -128,15 +130,19 @@ TEST_F(NamedResultCacheSerializerTest, CacheSerialization) {
   varColMap2[Variable{"?y"}] = makeAlwaysDefinedColumn(1);
   varColMap2[Variable{"?z"}] = makeAlwaysDefinedColumn(2);
 
+  auto qec = ad_utility::testing::getQec();
+  const auto& index = qec->getIndex().getImpl();
   LocalVocab vocab1;
   vocab1.getIndexAndAddIfNotContained(
-      ad_utility::triple_component::LiteralOrIri::iriref(
-          "<http://example.org/1>"));
+      LocalVocabEntry{ad_utility::triple_component::LiteralOrIri::iriref(
+                          "<http://example.org/1>"),
+                      index});
 
   LocalVocab vocab2;
   vocab2.getIndexAndAddIfNotContained(
-      ad_utility::triple_component::LiteralOrIri::iriref(
-          "<http://example.org/2>"));
+      LocalVocabEntry{ad_utility::triple_component::LiteralOrIri::iriref(
+                          "<http://example.org/2>"),
+                      index});
 
   cache.store("query-1", NamedResultCache::Value{
                              std::make_shared<const IdTable>(table1.clone()),
@@ -156,7 +162,6 @@ TEST_F(NamedResultCacheSerializerTest, CacheSerialization) {
 
   EXPECT_EQ(cache.numEntries(), 2);
 
-  auto qec = ad_utility::testing::getQec();
   auto cache2 = [&qec, &cache] {
     using namespace ad_utility::serialization;
     ByteBufferWriteSerializer writer;
@@ -164,7 +169,7 @@ TEST_F(NamedResultCacheSerializerTest, CacheSerialization) {
     NamedResultCache cache2;
     ByteBufferReadSerializer reader{std::move(writer).data()};
     cache2.readFromSerializer(reader, ad_utility::makeUnlimitedAllocator<Id>(),
-                              *qec->getIndex().getBlankNodeManager());
+                              qec->getIndex().getImpl());
     return cache2;
   }();
 
@@ -200,7 +205,7 @@ TEST_F(NamedResultCacheSerializerTest, EmptyCacheSerialization) {
     NamedResultCache cache2;
     ByteBufferReadSerializer reader{std::move(writer).data()};
     cache2.readFromSerializer(reader, ad_utility::makeUnlimitedAllocator<Id>(),
-                              *qec->getIndex().getBlankNodeManager());
+                              qec->getIndex().getImpl());
     return cache2;
   }();
   EXPECT_EQ(cache2.numEntries(), 0);

--- a/test/engine/NamedResultCacheSerializerTest.cpp
+++ b/test/engine/NamedResultCacheSerializerTest.cpp
@@ -59,7 +59,7 @@ TEST_F(NamedResultCacheSerializerTest, ValueSerialization) {
   LocalVocab localVocab;
   [[maybe_unused]] auto local =
       localVocab.getIndexAndAddIfNotContained(LocalVocabEntry::fromIriref(
-          "<http://example.org/test>", qec_->getIndex()));
+          "<http://example.org/test>", qec_->getLocalVocabContext()));
 
   // Note: Currently the serialization throws if we pass a `LocalVocabIndex`
   // inside the `IdTable` As soon as we have improved the serialization of local
@@ -125,14 +125,14 @@ TEST_F(NamedResultCacheSerializerTest, CacheSerialization) {
   varColMap2[Variable{"?y"}] = makeAlwaysDefinedColumn(1);
   varColMap2[Variable{"?z"}] = makeAlwaysDefinedColumn(2);
 
-  const auto& index = qec_->getIndex();
+  const auto& localVocabContext = qec_->getLocalVocabContext();
   LocalVocab vocab1;
   vocab1.getIndexAndAddIfNotContained(
-      LocalVocabEntry::fromIriref("<http://example.org/1>", index));
+      LocalVocabEntry::fromIriref("<http://example.org/1>", localVocabContext));
 
   LocalVocab vocab2;
   vocab2.getIndexAndAddIfNotContained(
-      LocalVocabEntry::fromIriref("<http://example.org/2>", index));
+      LocalVocabEntry::fromIriref("<http://example.org/2>", localVocabContext));
 
   cache.store("query-1", NamedResultCache::Value{
                              std::make_shared<const IdTable>(table1.clone()),
@@ -159,7 +159,7 @@ TEST_F(NamedResultCacheSerializerTest, CacheSerialization) {
     NamedResultCache cache2;
     ByteBufferReadSerializer reader{std::move(writer).data()};
     cache2.readFromSerializer(reader, ad_utility::makeUnlimitedAllocator<Id>(),
-                              qec_->getIndex());
+                              qec_->getLocalVocabContext());
     return cache2;
   }();
 
@@ -194,7 +194,7 @@ TEST_F(NamedResultCacheSerializerTest, EmptyCacheSerialization) {
     NamedResultCache cache2;
     ByteBufferReadSerializer reader{std::move(writer).data()};
     cache2.readFromSerializer(reader, ad_utility::makeUnlimitedAllocator<Id>(),
-                              qec_->getIndex());
+                              qec_->getLocalVocabContext());
     return cache2;
   }();
   EXPECT_EQ(cache2.numEntries(), 0);

--- a/test/engine/NamedResultCacheSerializerTest.cpp
+++ b/test/engine/NamedResultCacheSerializerTest.cpp
@@ -57,9 +57,9 @@ class NamedResultCacheSerializerTest : public ::testing::Test {
 TEST_F(NamedResultCacheSerializerTest, ValueSerialization) {
   // Create a test Value
   LocalVocab localVocab;
-  [[maybe_unused]] auto local = localVocab.getIndexAndAddIfNotContained(
-      LocalVocabEntry::fromStringRepresentation("<http://example.org/test>",
-                                                qec_->getIndex()));
+  [[maybe_unused]] auto local =
+      localVocab.getIndexAndAddIfNotContained(LocalVocabEntry::fromIriref(
+          "<http://example.org/test>", qec_->getIndex()));
 
   // Note: Currently the serialization throws if we pass a `LocalVocabIndex`
   // inside the `IdTable` As soon as we have improved the serialization of local
@@ -127,12 +127,12 @@ TEST_F(NamedResultCacheSerializerTest, CacheSerialization) {
 
   const auto& index = qec_->getIndex();
   LocalVocab vocab1;
-  vocab1.getIndexAndAddIfNotContained(LocalVocabEntry::fromStringRepresentation(
-      "<http://example.org/1>", index));
+  vocab1.getIndexAndAddIfNotContained(
+      LocalVocabEntry::fromIriref("<http://example.org/1>", index));
 
   LocalVocab vocab2;
-  vocab2.getIndexAndAddIfNotContained(LocalVocabEntry::fromStringRepresentation(
-      "<http://example.org/2>", index));
+  vocab2.getIndexAndAddIfNotContained(
+      LocalVocabEntry::fromIriref("<http://example.org/2>", index));
 
   cache.store("query-1", NamedResultCache::Value{
                              std::make_shared<const IdTable>(table1.clone()),

--- a/test/engine/NamedResultCacheSerializerTest.cpp
+++ b/test/engine/NamedResultCacheSerializerTest.cpp
@@ -28,20 +28,20 @@ class NamedResultCacheSerializerTest : public ::testing::Test {
  protected:
   // Blank node manager and allocator that can be used when we don't really
   // care about blank nodes and allocation details.
-  ad_utility::BlankNodeManager blankNodeManager_;
+  QueryExecutionContext* qec_ = ad_utility::testing::getQec();
   ad_utility::AllocatorWithLimit<Id> alloc_{
       ad_utility::makeUnlimitedAllocator<Id>()};
 
   // Serialize and immediately deserialize and return the `value`.
   NamedResultCache::Value serializeAndDeserializeValue(
-      const NamedResultCache::Value& value, const IndexImpl& index,
+      const NamedResultCache::Value& value,
       ad_utility::AllocatorWithLimit<Id> allocator) const {
     ByteBufferWriteSerializer writeSerializer;
     writeSerializer << value;
     ByteBufferReadSerializer readSerializer{std::move(writeSerializer).data()};
     NamedResultCache::Value result;
     result.allocatorForSerialization_ = std::move(allocator);
-    result.indexForSerialization_ = &index;
+    result.indexForSerialization_ = &qec_->getIndex().getImpl();
     readSerializer >> result;
     return result;
   }
@@ -49,22 +49,18 @@ class NamedResultCacheSerializerTest : public ::testing::Test {
   // Overload that uses the default member variables.
   NamedResultCache::Value serializeAndDeserializeValue(
       const NamedResultCache::Value& value) {
-    return serializeAndDeserializeValue(
-        value, ad_utility::testing::getQec()->getIndex().getImpl(), alloc_);
+    return serializeAndDeserializeValue(value, alloc_);
   }
 };
 
 // Test serialization of a complete `NamedResultCache::Value`.
 TEST_F(NamedResultCacheSerializerTest, ValueSerialization) {
-  // we need to setup a dummy index somewhere, because otherwise the comparison
-  // of `IdTable`s won't work;
-  [[maybe_unused]] auto qec = ad_utility::testing::getQec();
   // Create a test Value
   LocalVocab localVocab;
   [[maybe_unused]] auto local = localVocab.getIndexAndAddIfNotContained(
       LocalVocabEntry{ad_utility::triple_component::LiteralOrIri::iriref(
                           "<http://example.org/test>"),
-                      qec->getIndex().getImpl()});
+                      qec_->getIndex()});
 
   // Note: Currently the serialization throws if we pass a `LocalVocabIndex`
   // inside the `IdTable` As soon as we have improved the serialization of local
@@ -130,8 +126,7 @@ TEST_F(NamedResultCacheSerializerTest, CacheSerialization) {
   varColMap2[Variable{"?y"}] = makeAlwaysDefinedColumn(1);
   varColMap2[Variable{"?z"}] = makeAlwaysDefinedColumn(2);
 
-  auto qec = ad_utility::testing::getQec();
-  const auto& index = qec->getIndex().getImpl();
+  const auto& index = qec_->getIndex();
   LocalVocab vocab1;
   vocab1.getIndexAndAddIfNotContained(
       LocalVocabEntry{ad_utility::triple_component::LiteralOrIri::iriref(
@@ -162,14 +157,14 @@ TEST_F(NamedResultCacheSerializerTest, CacheSerialization) {
 
   EXPECT_EQ(cache.numEntries(), 2);
 
-  auto cache2 = [&qec, &cache] {
+  auto cache2 = [this, &cache] {
     using namespace ad_utility::serialization;
     ByteBufferWriteSerializer writer;
     cache.writeToSerializer(writer);
     NamedResultCache cache2;
     ByteBufferReadSerializer reader{std::move(writer).data()};
     cache2.readFromSerializer(reader, ad_utility::makeUnlimitedAllocator<Id>(),
-                              qec->getIndex().getImpl());
+                              qec_->getIndex());
     return cache2;
   }();
 
@@ -197,15 +192,14 @@ TEST_F(NamedResultCacheSerializerTest, EmptyCacheSerialization) {
   NamedResultCache cache;
   EXPECT_EQ(cache.numEntries(), 0);
 
-  auto qec = ad_utility::testing::getQec();
-  auto cache2 = [&qec, &cache] {
+  auto cache2 = [this, &cache] {
     using namespace ad_utility::serialization;
     ByteBufferWriteSerializer writer;
     cache.writeToSerializer(writer);
     NamedResultCache cache2;
     ByteBufferReadSerializer reader{std::move(writer).data()};
     cache2.readFromSerializer(reader, ad_utility::makeUnlimitedAllocator<Id>(),
-                              qec->getIndex().getImpl());
+                              qec_->getIndex());
     return cache2;
   }();
   EXPECT_EQ(cache2.numEntries(), 0);

--- a/test/engine/NamedResultCacheSerializerTest.cpp
+++ b/test/engine/NamedResultCacheSerializerTest.cpp
@@ -58,9 +58,8 @@ TEST_F(NamedResultCacheSerializerTest, ValueSerialization) {
   // Create a test Value
   LocalVocab localVocab;
   [[maybe_unused]] auto local = localVocab.getIndexAndAddIfNotContained(
-      LocalVocabEntry{ad_utility::triple_component::LiteralOrIri::iriref(
-                          "<http://example.org/test>"),
-                      qec_->getIndex()});
+      LocalVocabEntry::fromStringRepresentation("<http://example.org/test>",
+                                                qec_->getIndex()));
 
   // Note: Currently the serialization throws if we pass a `LocalVocabIndex`
   // inside the `IdTable` As soon as we have improved the serialization of local
@@ -128,16 +127,12 @@ TEST_F(NamedResultCacheSerializerTest, CacheSerialization) {
 
   const auto& index = qec_->getIndex();
   LocalVocab vocab1;
-  vocab1.getIndexAndAddIfNotContained(
-      LocalVocabEntry{ad_utility::triple_component::LiteralOrIri::iriref(
-                          "<http://example.org/1>"),
-                      index});
+  vocab1.getIndexAndAddIfNotContained(LocalVocabEntry::fromStringRepresentation(
+      "<http://example.org/1>", index));
 
   LocalVocab vocab2;
-  vocab2.getIndexAndAddIfNotContained(
-      LocalVocabEntry{ad_utility::triple_component::LiteralOrIri::iriref(
-                          "<http://example.org/2>"),
-                      index});
+  vocab2.getIndexAndAddIfNotContained(LocalVocabEntry::fromStringRepresentation(
+      "<http://example.org/2>", index));
 
   cache.store("query-1", NamedResultCache::Value{
                              std::make_shared<const IdTable>(table1.clone()),

--- a/test/engine/NamedResultCacheSerializerTest.cpp
+++ b/test/engine/NamedResultCacheSerializerTest.cpp
@@ -41,7 +41,7 @@ class NamedResultCacheSerializerTest : public ::testing::Test {
     ByteBufferReadSerializer readSerializer{std::move(writeSerializer).data()};
     NamedResultCache::Value result;
     result.allocatorForSerialization_ = std::move(allocator);
-    result.indexForSerialization_ = &qec_->getIndex().getImpl();
+    result.contextForSerialization_ = &qec_->getIndex().getImpl();
     readSerializer >> result;
     return result;
   }

--- a/test/engine/NamedResultCacheTest.cpp
+++ b/test/engine/NamedResultCacheTest.cpp
@@ -25,8 +25,8 @@ TEST(NamedResultCache, basicWorkflow) {
 
   LocalVocab localVocab;
   auto* qec = ad_utility::testing::getQec();
-  localVocab.getIndexAndAddIfNotContained(
-      LocalVocabEntry::fromIriref("<bliBlaBlubb>", qec->getIndex()));
+  localVocab.getIndexAndAddIfNotContained(LocalVocabEntry::fromIriref(
+      "<bliBlaBlubb>", qec->getLocalVocabContext()));
 
   // A matcher for the local vocab
   auto matchLocalVocab =
@@ -138,7 +138,7 @@ TEST(NamedResultCache, E2E) {
       ad_utility::triple_component::LiteralOrIri::iriref("<notInVocab>");
   auto notInVocab =
       Id::makeFromLocalVocabIndex(dummyVocab.getIndexAndAddIfNotContained(
-          LocalVocabEntry{litOrIri, qec->getIndex()}));
+          LocalVocabEntry{litOrIri, qec->getLocalVocabContext()}));
   auto expected =
       makeIdTableFromVector({{notInVocab}, {getId("<s>")}, {getId("<s2>")}});
   EXPECT_THAT(result->idTable(), matchesIdTable(expected));

--- a/test/engine/NamedResultCacheTest.cpp
+++ b/test/engine/NamedResultCacheTest.cpp
@@ -26,8 +26,7 @@ TEST(NamedResultCache, basicWorkflow) {
   LocalVocab localVocab;
   auto* qec = ad_utility::testing::getQec();
   localVocab.getIndexAndAddIfNotContained(
-      LocalVocabEntry::fromStringRepresentation("<bliBlaBlubb>",
-                                                qec->getIndex()));
+      LocalVocabEntry::fromIriref("<bliBlaBlubb>", qec->getIndex()));
 
   // A matcher for the local vocab
   auto matchLocalVocab =

--- a/test/engine/NamedResultCacheTest.cpp
+++ b/test/engine/NamedResultCacheTest.cpp
@@ -8,6 +8,7 @@
 #include "../util/IdTableHelpers.h"
 #include "../util/IndexTestHelpers.h"
 #include "engine/NamedResultCache.h"
+#include "index/LocalVocabEntry.h"
 
 namespace {
 TEST(NamedResultCache, basicWorkflow) {
@@ -23,8 +24,10 @@ TEST(NamedResultCache, basicWorkflow) {
                                 {V{"?y"}, makeAlwaysDefinedColumn(1)}};
 
   LocalVocab localVocab;
-  localVocab.getIndexAndAddIfNotContained(
-      ad_utility::triple_component::LiteralOrIri::iriref("<bliBlaBlubb>"));
+  auto* qec = ad_utility::testing::getQec();
+  localVocab.getIndexAndAddIfNotContained(LocalVocabEntry{
+      ad_utility::triple_component::LiteralOrIri::iriref("<bliBlaBlubb>"),
+      qec->getIndex().getImpl()});
 
   // A matcher for the local vocab
   auto matchLocalVocab =
@@ -37,7 +40,6 @@ TEST(NamedResultCache, basicWorkflow) {
         get, UnorderedElementsAreArray(localVocab.getAllWordsForTesting()));
   };
 
-  auto qec = ad_utility::testing::getQec();
   auto getCacheValue = [&varColMap, &localVocab](const auto& table) {
     return NamedResultCache::Value{
         std::make_shared<const IdTable>(table.clone()),
@@ -135,8 +137,9 @@ TEST(NamedResultCache, E2E) {
   LocalVocab dummyVocab;
   auto litOrIri =
       ad_utility::triple_component::LiteralOrIri::iriref("<notInVocab>");
-  auto notInVocab = Id::makeFromLocalVocabIndex(
-      dummyVocab.getIndexAndAddIfNotContained(litOrIri));
+  auto notInVocab =
+      Id::makeFromLocalVocabIndex(dummyVocab.getIndexAndAddIfNotContained(
+          LocalVocabEntry{litOrIri, qec->getIndex().getImpl()}));
   auto expected =
       makeIdTableFromVector({{notInVocab}, {getId("<s>")}, {getId("<s2>")}});
   EXPECT_THAT(result->idTable(), matchesIdTable(expected));

--- a/test/engine/NamedResultCacheTest.cpp
+++ b/test/engine/NamedResultCacheTest.cpp
@@ -25,9 +25,9 @@ TEST(NamedResultCache, basicWorkflow) {
 
   LocalVocab localVocab;
   auto* qec = ad_utility::testing::getQec();
-  localVocab.getIndexAndAddIfNotContained(LocalVocabEntry{
-      ad_utility::triple_component::LiteralOrIri::iriref("<bliBlaBlubb>"),
-      qec->getIndex()});
+  localVocab.getIndexAndAddIfNotContained(
+      LocalVocabEntry::fromStringRepresentation("<bliBlaBlubb>",
+                                                qec->getIndex()));
 
   // A matcher for the local vocab
   auto matchLocalVocab =

--- a/test/engine/NamedResultCacheTest.cpp
+++ b/test/engine/NamedResultCacheTest.cpp
@@ -134,11 +134,9 @@ TEST(NamedResultCache, E2E) {
 
   auto getId = ad_utility::testing::makeGetId(qec->getIndex());
   LocalVocab dummyVocab;
-  auto litOrIri =
-      ad_utility::triple_component::LiteralOrIri::iriref("<notInVocab>");
-  auto notInVocab =
-      Id::makeFromLocalVocabIndex(dummyVocab.getIndexAndAddIfNotContained(
-          LocalVocabEntry{litOrIri, qec->getLocalVocabContext()}));
+  auto notInVocab = Id::makeFromLocalVocabIndex(
+      dummyVocab.getIndexAndAddIfNotContained(LocalVocabEntry::fromIriref(
+          "<notInVocab>", qec->getLocalVocabContext())));
   auto expected =
       makeIdTableFromVector({{notInVocab}, {getId("<s>")}, {getId("<s2>")}});
   EXPECT_THAT(result->idTable(), matchesIdTable(expected));

--- a/test/engine/NamedResultCacheTest.cpp
+++ b/test/engine/NamedResultCacheTest.cpp
@@ -139,7 +139,7 @@ TEST(NamedResultCache, E2E) {
       ad_utility::triple_component::LiteralOrIri::iriref("<notInVocab>");
   auto notInVocab =
       Id::makeFromLocalVocabIndex(dummyVocab.getIndexAndAddIfNotContained(
-          LocalVocabEntry{litOrIri, qec->getIndex().getImpl()}));
+          LocalVocabEntry{litOrIri, qec->getIndex()}));
   auto expected =
       makeIdTableFromVector({{notInVocab}, {getId("<s>")}, {getId("<s2>")}});
   EXPECT_THAT(result->idTable(), matchesIdTable(expected));

--- a/test/engine/NamedResultCacheTest.cpp
+++ b/test/engine/NamedResultCacheTest.cpp
@@ -27,7 +27,7 @@ TEST(NamedResultCache, basicWorkflow) {
   auto* qec = ad_utility::testing::getQec();
   localVocab.getIndexAndAddIfNotContained(LocalVocabEntry{
       ad_utility::triple_component::LiteralOrIri::iriref("<bliBlaBlubb>"),
-      qec->getIndex().getImpl()});
+      qec->getIndex()});
 
   // A matcher for the local vocab
   auto matchLocalVocab =

--- a/test/engine/NeutralOptionalTest.cpp
+++ b/test/engine/NeutralOptionalTest.cpp
@@ -280,7 +280,8 @@ TEST(NeutralOptional, ensureResultIsProperlyPropagated) {
   LocalVocab localVocab{};
   localVocab.getIndexAndAddIfNotContained(LocalVocabEntry{
       ad_utility::triple_component::Literal::fromStringRepresentation(
-          "\"Test\"")});
+          "\"Test\""),
+      qec->getIndex().getImpl()});
 
   {
     auto child = ad_utility::makeExecutionTree<ValuesForTesting>(

--- a/test/engine/NeutralOptionalTest.cpp
+++ b/test/engine/NeutralOptionalTest.cpp
@@ -278,10 +278,8 @@ TEST(NeutralOptional, ensureSingleRowWhenChildIsEmpty) {
 TEST(NeutralOptional, ensureResultIsProperlyPropagated) {
   auto* qec = ad_utility::testing::getQec();
   LocalVocab localVocab{};
-  localVocab.getIndexAndAddIfNotContained(LocalVocabEntry{
-      ad_utility::triple_component::Literal::fromStringRepresentation(
-          "\"Test\""),
-      qec->getIndex()});
+  localVocab.getIndexAndAddIfNotContained(
+      LocalVocabEntry::fromStringRepresentation("\"Test\"", qec->getIndex()));
 
   {
     auto child = ad_utility::makeExecutionTree<ValuesForTesting>(

--- a/test/engine/NeutralOptionalTest.cpp
+++ b/test/engine/NeutralOptionalTest.cpp
@@ -281,7 +281,7 @@ TEST(NeutralOptional, ensureResultIsProperlyPropagated) {
   localVocab.getIndexAndAddIfNotContained(LocalVocabEntry{
       ad_utility::triple_component::Literal::fromStringRepresentation(
           "\"Test\""),
-      qec->getIndex().getImpl()});
+      qec->getIndex()});
 
   {
     auto child = ad_utility::makeExecutionTree<ValuesForTesting>(

--- a/test/engine/NeutralOptionalTest.cpp
+++ b/test/engine/NeutralOptionalTest.cpp
@@ -279,7 +279,8 @@ TEST(NeutralOptional, ensureResultIsProperlyPropagated) {
   auto* qec = ad_utility::testing::getQec();
   LocalVocab localVocab{};
   localVocab.getIndexAndAddIfNotContained(
-      LocalVocabEntry::fromStringRepresentation("\"Test\"", qec->getIndex()));
+      LocalVocabEntry::fromStringRepresentation("\"Test\"",
+                                                qec->getLocalVocabContext()));
 
   {
     auto child = ad_utility::makeExecutionTree<ValuesForTesting>(

--- a/test/engine/OptionalJoinTest.cpp
+++ b/test/engine/OptionalJoinTest.cpp
@@ -409,8 +409,15 @@ TEST(OptionalJoin, gallopingJoin) {
 
 // _____________________________________________________________________________
 TEST(OptionalJoin, computeOptionalJoinIndexNestedLoopJoinOptimization) {
-  LocalVocabEntry entryA = LocalVocabEntry::fromStringRepresentation("\"a\"");
-  LocalVocabEntry entryB = LocalVocabEntry::fromStringRepresentation("\"b\"");
+  const auto& index = ad_utility::testing::getQec()->getIndex().getImpl();
+  LocalVocabEntry entryA{
+      ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
+          "\"a\""),
+      index};
+  LocalVocabEntry entryB{
+      ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
+          "\"b\""),
+      index};
 
   LocalVocab leftVocab;
   leftVocab.getIndexAndAddIfNotContained(entryA);
@@ -469,8 +476,15 @@ TEST(OptionalJoin, computeOptionalJoinIndexNestedLoopJoinOptimization) {
 
 // _____________________________________________________________________________
 TEST(OptionalJoin, computeLazyOptionalJoinIndexNestedLoopJoinOptimization) {
-  LocalVocabEntry entryA = LocalVocabEntry::fromStringRepresentation("\"a\"");
-  LocalVocabEntry entryB = LocalVocabEntry::fromStringRepresentation("\"b\"");
+  const auto& index = ad_utility::testing::getQec()->getIndex().getImpl();
+  LocalVocabEntry entryA{
+      ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
+          "\"a\""),
+      index};
+  LocalVocabEntry entryB{
+      ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
+          "\"b\""),
+      index};
 
   LocalVocab leftVocab;
   leftVocab.getIndexAndAddIfNotContained(entryA);
@@ -1035,8 +1049,9 @@ TEST_P(OptionalJoinWithIndexScan, twoColumnsLocalVocabPropagation) {
   // payload.
   std::vector<Result::IdTableVocabPair> tAndV;
 
-  auto i = [](int i) {
-    return LocalVocabEntry{iri(absl::StrCat("<local-payload-", i, ">"))};
+  auto i = [&qec2](int i) {
+    return LocalVocabEntry{iri(absl::StrCat("<local-payload-", i, ">")),
+                           qec2->getIndex().getImpl()};
   };
   LocalVocab v;
   auto l1 = Id::makeFromLocalVocabIndex(v.getIndexAndAddIfNotContained(i(1)));

--- a/test/engine/OptionalJoinTest.cpp
+++ b/test/engine/OptionalJoinTest.cpp
@@ -36,8 +36,8 @@ using JoinColumns = std::vector<std::array<ColumnIndex, 2>>;
 
 void testOptionalJoin(const IdTable& inputA, const IdTable& inputB,
                       JoinColumns jcls, const IdTable& expectedResult) {
+  auto* qec = ad_utility::testing::getQec();
   {
-    auto* qec = ad_utility::testing::getQec();
     IdTable result{inputA.numColumns() + inputB.numColumns() - jcls.size(),
                    makeAllocator()};
     // Join a and b on the column pairs 1,2 and 2,1 (entries from columns 1 of
@@ -67,7 +67,6 @@ void testOptionalJoin(const IdTable& inputA, const IdTable& inputB,
       rightSorted.push_back(right);
       ++idx;
     }
-    auto qec = ad_utility::testing::getQec();
     auto left = ad_utility::makeExecutionTree<ValuesForTesting>(
         qec, inputA.clone(), varsLeft, false, std::move(leftSorted));
     auto right = ad_utility::makeExecutionTree<ValuesForTesting>(
@@ -409,15 +408,15 @@ TEST(OptionalJoin, gallopingJoin) {
 
 // _____________________________________________________________________________
 TEST(OptionalJoin, computeOptionalJoinIndexNestedLoopJoinOptimization) {
-  const auto& index = ad_utility::testing::getQec()->getIndex().getImpl();
+  auto* qec = ad_utility::testing::getQec();
   LocalVocabEntry entryA{
       ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
           "\"a\""),
-      index};
+      qec->getIndex()};
   LocalVocabEntry entryB{
       ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
           "\"b\""),
-      index};
+      qec->getIndex()};
 
   LocalVocab leftVocab;
   leftVocab.getIndexAndAddIfNotContained(entryA);
@@ -445,7 +444,6 @@ TEST(OptionalJoin, computeOptionalJoinIndexNestedLoopJoinOptimization) {
                                             {4, 2, 1, U, U},
                                             {2, 8, 1, U, U}});
 
-  auto* qec = ad_utility::testing::getQec();
   for (bool forceFullyMaterialized : {false, true}) {
     OptionalJoin optionalJoin{
         qec,
@@ -476,15 +474,15 @@ TEST(OptionalJoin, computeOptionalJoinIndexNestedLoopJoinOptimization) {
 
 // _____________________________________________________________________________
 TEST(OptionalJoin, computeLazyOptionalJoinIndexNestedLoopJoinOptimization) {
-  const auto& index = ad_utility::testing::getQec()->getIndex().getImpl();
+  auto* qec = ad_utility::testing::getQec();
   LocalVocabEntry entryA{
       ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
           "\"a\""),
-      index};
+      qec->getIndex()};
   LocalVocabEntry entryB{
       ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
           "\"b\""),
-      index};
+      qec->getIndex()};
 
   LocalVocab leftVocab;
   leftVocab.getIndexAndAddIfNotContained(entryA);
@@ -509,7 +507,6 @@ TEST(OptionalJoin, computeLazyOptionalJoinIndexNestedLoopJoinOptimization) {
   auto expected1 = makeIdTableFromVector({{3, 8, 2, 6, 12}, {4, 8, 2, 6, 12}});
   auto expected2 = makeIdTableFromVector({{4, 2, 1, U, U}, {2, 8, 1, U, U}});
 
-  auto* qec = ad_utility::testing::getQec();
   OptionalJoin optionalJoin{
       qec,
       ad_utility::makeExecutionTree<ValuesForTesting>(

--- a/test/engine/OptionalJoinTest.cpp
+++ b/test/engine/OptionalJoinTest.cpp
@@ -409,10 +409,10 @@ TEST(OptionalJoin, gallopingJoin) {
 // _____________________________________________________________________________
 TEST(OptionalJoin, computeOptionalJoinIndexNestedLoopJoinOptimization) {
   auto* qec = ad_utility::testing::getQec();
-  LocalVocabEntry entryA =
-      LocalVocabEntry::fromStringRepresentation("\"a\"", qec->getIndex());
-  LocalVocabEntry entryB =
-      LocalVocabEntry::fromStringRepresentation("\"b\"", qec->getIndex());
+  LocalVocabEntry entryA = LocalVocabEntry::fromStringRepresentation(
+      "\"a\"", qec->getLocalVocabContext());
+  LocalVocabEntry entryB = LocalVocabEntry::fromStringRepresentation(
+      "\"b\"", qec->getLocalVocabContext());
 
   LocalVocab leftVocab;
   leftVocab.getIndexAndAddIfNotContained(entryA);
@@ -471,10 +471,10 @@ TEST(OptionalJoin, computeOptionalJoinIndexNestedLoopJoinOptimization) {
 // _____________________________________________________________________________
 TEST(OptionalJoin, computeLazyOptionalJoinIndexNestedLoopJoinOptimization) {
   auto* qec = ad_utility::testing::getQec();
-  LocalVocabEntry entryA =
-      LocalVocabEntry::fromStringRepresentation("\"a\"", qec->getIndex());
-  LocalVocabEntry entryB =
-      LocalVocabEntry::fromStringRepresentation("\"b\"", qec->getIndex());
+  LocalVocabEntry entryA = LocalVocabEntry::fromStringRepresentation(
+      "\"a\"", qec->getLocalVocabContext());
+  LocalVocabEntry entryB = LocalVocabEntry::fromStringRepresentation(
+      "\"b\"", qec->getLocalVocabContext());
 
   LocalVocab leftVocab;
   leftVocab.getIndexAndAddIfNotContained(entryA);
@@ -1040,7 +1040,7 @@ TEST_P(OptionalJoinWithIndexScan, twoColumnsLocalVocabPropagation) {
 
   auto i = [&qec2](int i) {
     return LocalVocabEntry{iri(absl::StrCat("<local-payload-", i, ">")),
-                           qec2->getIndex()};
+                           qec2->getLocalVocabContext()};
   };
   LocalVocab v;
   auto l1 = Id::makeFromLocalVocabIndex(v.getIndexAndAddIfNotContained(i(1)));

--- a/test/engine/OptionalJoinTest.cpp
+++ b/test/engine/OptionalJoinTest.cpp
@@ -409,14 +409,10 @@ TEST(OptionalJoin, gallopingJoin) {
 // _____________________________________________________________________________
 TEST(OptionalJoin, computeOptionalJoinIndexNestedLoopJoinOptimization) {
   auto* qec = ad_utility::testing::getQec();
-  LocalVocabEntry entryA{
-      ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
-          "\"a\""),
-      qec->getIndex()};
-  LocalVocabEntry entryB{
-      ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
-          "\"b\""),
-      qec->getIndex()};
+  LocalVocabEntry entryA =
+      LocalVocabEntry::fromStringRepresentation("\"a\"", qec->getIndex());
+  LocalVocabEntry entryB =
+      LocalVocabEntry::fromStringRepresentation("\"b\"", qec->getIndex());
 
   LocalVocab leftVocab;
   leftVocab.getIndexAndAddIfNotContained(entryA);
@@ -475,14 +471,10 @@ TEST(OptionalJoin, computeOptionalJoinIndexNestedLoopJoinOptimization) {
 // _____________________________________________________________________________
 TEST(OptionalJoin, computeLazyOptionalJoinIndexNestedLoopJoinOptimization) {
   auto* qec = ad_utility::testing::getQec();
-  LocalVocabEntry entryA{
-      ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
-          "\"a\""),
-      qec->getIndex()};
-  LocalVocabEntry entryB{
-      ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
-          "\"b\""),
-      qec->getIndex()};
+  LocalVocabEntry entryA =
+      LocalVocabEntry::fromStringRepresentation("\"a\"", qec->getIndex());
+  LocalVocabEntry entryB =
+      LocalVocabEntry::fromStringRepresentation("\"b\"", qec->getIndex());
 
   LocalVocab leftVocab;
   leftVocab.getIndexAndAddIfNotContained(entryA);

--- a/test/engine/OptionalJoinTest.cpp
+++ b/test/engine/OptionalJoinTest.cpp
@@ -1048,7 +1048,7 @@ TEST_P(OptionalJoinWithIndexScan, twoColumnsLocalVocabPropagation) {
 
   auto i = [&qec2](int i) {
     return LocalVocabEntry{iri(absl::StrCat("<local-payload-", i, ">")),
-                           qec2->getIndex().getImpl()};
+                           qec2->getIndex()};
   };
   LocalVocab v;
   auto l1 = Id::makeFromLocalVocabIndex(v.getIndexAndAddIfNotContained(i(1)));

--- a/test/engine/SpatialJoinCachedIndexTest.cpp
+++ b/test/engine/SpatialJoinCachedIndexTest.cpp
@@ -27,7 +27,7 @@ void serializeAndDeserializeCache(NamedResultCache& cache,
   cache.clear();
   ByteBufferReadSerializer reader{std::move(writer).data()};
   cache.readFromSerializer(reader, ad_utility::makeUnlimitedAllocator<Id>(),
-                           *qec->getIndex().getBlankNodeManager());
+                           qec->getIndex().getImpl());
 }
 
 // _____________________________________________________________________________

--- a/test/engine/SpatialJoinCachedIndexTest.cpp
+++ b/test/engine/SpatialJoinCachedIndexTest.cpp
@@ -27,7 +27,7 @@ void serializeAndDeserializeCache(NamedResultCache& cache,
   cache.clear();
   ByteBufferReadSerializer reader{std::move(writer).data()};
   cache.readFromSerializer(reader, ad_utility::makeUnlimitedAllocator<Id>(),
-                           qec->getIndex().getImpl());
+                           qec->getIndex());
 }
 
 // _____________________________________________________________________________

--- a/test/engine/SpatialJoinCachedIndexTest.cpp
+++ b/test/engine/SpatialJoinCachedIndexTest.cpp
@@ -27,7 +27,7 @@ void serializeAndDeserializeCache(NamedResultCache& cache,
   cache.clear();
   ByteBufferReadSerializer reader{std::move(writer).data()};
   cache.readFromSerializer(reader, ad_utility::makeUnlimitedAllocator<Id>(),
-                           qec->getIndex());
+                           qec->getLocalVocabContext());
 }
 
 // _____________________________________________________________________________

--- a/test/engine/StringMappingTest.cpp
+++ b/test/engine/StringMappingTest.cpp
@@ -17,8 +17,7 @@ using namespace qlever::binary_export;
 
 // _____________________________________________________________________________
 TEST(StringMapping, remapId) {
-  // This is important so we have a working comparator.
-  ad_utility::testing::getQec("<a> <b> <c> .");
+  auto* qec = ad_utility::testing::getQec("<a> <b> <c> .");
   auto toMappedId = [](size_t count) {
     return Id::makeFromLocalVocabIndex(
         reinterpret_cast<LocalVocabIndex>(count << ValueId::numDatatypeBits));
@@ -31,11 +30,14 @@ TEST(StringMapping, remapId) {
     EXPECT_EQ(a.getBits(), b.getBits());
   };
 
+  const auto& index = qec->getIndex();
   LocalVocabEntry testWord{
       ad_utility::triple_component::Literal::fromStringRepresentation(
-          "\"abc\"")};
+          "\"abc\""),
+      index};
   LocalVocabEntry duplicateWord{
-      ad_utility::triple_component::Iri::fromStringRepresentation("<b>")};
+      ad_utility::triple_component::Iri::fromStringRepresentation("<b>"),
+      index};
   StringMapping mapping;
   Id id1 = Id::makeFromVocabIndex(VocabIndex::make(1));
   Id id2 = Id::makeFromLocalVocabIndex(&testWord);
@@ -68,9 +70,11 @@ TEST(StringMapping, flush) {
   auto* qec = ad_utility::testing::getQec(std::move(config));
   StringMapping mapping;
 
+  const auto& index = qec->getIndex().getImpl();
   LocalVocabEntry testWord{
       ad_utility::triple_component::Literal::fromStringRepresentation(
-          "\"abc\"")};
+          "\"abc\""),
+      index};
   Id id0 = Id::makeFromVocabIndex(VocabIndex::make(1));
   Id id1 = Id::makeFromVocabIndex(VocabIndex::make(2));
   Id id2 = Id::makeFromLocalVocabIndex(&testWord);

--- a/test/engine/StringMappingTest.cpp
+++ b/test/engine/StringMappingTest.cpp
@@ -70,7 +70,7 @@ TEST(StringMapping, flush) {
   auto* qec = ad_utility::testing::getQec(std::move(config));
   StringMapping mapping;
 
-  const auto& index = qec->getIndex().getImpl();
+  const auto& index = qec->getIndex();
   LocalVocabEntry testWord{
       ad_utility::triple_component::Literal::fromStringRepresentation(
           "\"abc\""),
@@ -92,6 +92,6 @@ TEST(StringMapping, flush) {
   EXPECT_EQ(mapping.remapId(id0).getDatatype(), Datatype::LocalVocabIndex);
 
   EXPECT_THAT(
-      mapping.flush(qec->getIndex()),
+      mapping.flush(index),
       ::testing::ElementsAre("<a>", "<b>", "\"abc\"", "\"\"", "\"brown\""));
 }

--- a/test/engine/StringMappingTest.cpp
+++ b/test/engine/StringMappingTest.cpp
@@ -31,13 +31,10 @@ TEST(StringMapping, remapId) {
   };
 
   const auto& index = qec->getIndex();
-  LocalVocabEntry testWord{
-      ad_utility::triple_component::Literal::fromStringRepresentation(
-          "\"abc\""),
-      index};
-  LocalVocabEntry duplicateWord{
-      ad_utility::triple_component::Iri::fromStringRepresentation("<b>"),
-      index};
+  LocalVocabEntry testWord =
+      LocalVocabEntry::fromStringRepresentation("\"abc\"", index);
+  LocalVocabEntry duplicateWord =
+      LocalVocabEntry::fromStringRepresentation("<b>", index);
   StringMapping mapping;
   Id id1 = Id::makeFromVocabIndex(VocabIndex::make(1));
   Id id2 = Id::makeFromLocalVocabIndex(&testWord);
@@ -71,10 +68,8 @@ TEST(StringMapping, flush) {
   StringMapping mapping;
 
   const auto& index = qec->getIndex();
-  LocalVocabEntry testWord{
-      ad_utility::triple_component::Literal::fromStringRepresentation(
-          "\"abc\""),
-      index};
+  LocalVocabEntry testWord =
+      LocalVocabEntry::fromStringRepresentation("\"abc\"", index);
   Id id0 = Id::makeFromVocabIndex(VocabIndex::make(1));
   Id id1 = Id::makeFromVocabIndex(VocabIndex::make(2));
   Id id2 = Id::makeFromLocalVocabIndex(&testWord);

--- a/test/engine/StripColumnsTest.cpp
+++ b/test/engine/StripColumnsTest.cpp
@@ -71,8 +71,8 @@ TEST(StripColumns, computeResult) {
   auto qec = ad_utility::testing::getQec();
   auto makeOp = [&qec]() {
     LocalVocab voc;
-    voc.getIndexAndAddIfNotContained(LocalVocabEntry::fromStringRepresentation(
-        "<kartoffel>", qec->getIndex()));
+    voc.getIndexAndAddIfNotContained(
+        LocalVocabEntry::fromIriref("<kartoffel>", qec->getIndex()));
     qec->clearCacheUnpinnedOnly();
     std::vector<IdTable> children;
     children.push_back(makeIdTableFromVector({{1, 2, 3}, {4, 5, 6}}));
@@ -84,10 +84,9 @@ TEST(StripColumns, computeResult) {
     return StripColumns{qec, std::move(valuesTree), {V{"?c"}, V{"?a"}}};
   };
 
-  auto localVocabMatcher =
-      ResultOf(std::mem_fn(&LocalVocab::getAllWordsForTesting),
-               ElementsAre(LocalVocabEntry::fromStringRepresentation(
-                   "<kartoffel>", qec->getIndex())));
+  auto localVocabMatcher = ResultOf(
+      std::mem_fn(&LocalVocab::getAllWordsForTesting),
+      ElementsAre(LocalVocabEntry::fromIriref("<kartoffel>", qec->getIndex())));
   // Test materialized result.
   {
     auto strip = makeOp();

--- a/test/engine/StripColumnsTest.cpp
+++ b/test/engine/StripColumnsTest.cpp
@@ -71,9 +71,8 @@ TEST(StripColumns, computeResult) {
   auto qec = ad_utility::testing::getQec();
   auto makeOp = [&qec]() {
     LocalVocab voc;
-    voc.getIndexAndAddIfNotContained(LocalVocabEntry{
-        ad_utility::triple_component::LiteralOrIri::iriref("<kartoffel>"),
-        qec->getIndex()});
+    voc.getIndexAndAddIfNotContained(LocalVocabEntry::fromStringRepresentation(
+        "<kartoffel>", qec->getIndex()));
     qec->clearCacheUnpinnedOnly();
     std::vector<IdTable> children;
     children.push_back(makeIdTableFromVector({{1, 2, 3}, {4, 5, 6}}));
@@ -85,11 +84,10 @@ TEST(StripColumns, computeResult) {
     return StripColumns{qec, std::move(valuesTree), {V{"?c"}, V{"?a"}}};
   };
 
-  auto localVocabMatcher = ResultOf(
-      std::mem_fn(&LocalVocab::getAllWordsForTesting),
-      ElementsAre(LocalVocabEntry{
-          ad_utility::triple_component::LiteralOrIri::iriref("<kartoffel>"),
-          qec->getIndex()}));
+  auto localVocabMatcher =
+      ResultOf(std::mem_fn(&LocalVocab::getAllWordsForTesting),
+               ElementsAre(LocalVocabEntry::fromStringRepresentation(
+                   "<kartoffel>", qec->getIndex())));
   // Test materialized result.
   {
     auto strip = makeOp();

--- a/test/engine/StripColumnsTest.cpp
+++ b/test/engine/StripColumnsTest.cpp
@@ -71,7 +71,9 @@ TEST(StripColumns, computeResult) {
   auto qec = ad_utility::testing::getQec();
   auto makeOp = [&qec]() {
     LocalVocab voc;
-    voc.getIndexAndAddIfNotContained(LocalVocabEntry::iriref("<kartoffel>"));
+    voc.getIndexAndAddIfNotContained(LocalVocabEntry{
+        ad_utility::triple_component::LiteralOrIri::iriref("<kartoffel>"),
+        qec->getIndex().getImpl()});
     qec->clearCacheUnpinnedOnly();
     std::vector<IdTable> children;
     children.push_back(makeIdTableFromVector({{1, 2, 3}, {4, 5, 6}}));
@@ -83,9 +85,11 @@ TEST(StripColumns, computeResult) {
     return StripColumns{qec, std::move(valuesTree), {V{"?c"}, V{"?a"}}};
   };
 
-  auto localVocabMatcher =
-      ResultOf(std::mem_fn(&LocalVocab::getAllWordsForTesting),
-               ElementsAre(LocalVocabEntry::iriref("<kartoffel>")));
+  auto localVocabMatcher = ResultOf(
+      std::mem_fn(&LocalVocab::getAllWordsForTesting),
+      ElementsAre(LocalVocabEntry{
+          ad_utility::triple_component::LiteralOrIri::iriref("<kartoffel>"),
+          qec->getIndex().getImpl()}));
   // Test materialized result.
   {
     auto strip = makeOp();

--- a/test/engine/StripColumnsTest.cpp
+++ b/test/engine/StripColumnsTest.cpp
@@ -73,7 +73,7 @@ TEST(StripColumns, computeResult) {
     LocalVocab voc;
     voc.getIndexAndAddIfNotContained(LocalVocabEntry{
         ad_utility::triple_component::LiteralOrIri::iriref("<kartoffel>"),
-        qec->getIndex().getImpl()});
+        qec->getIndex()});
     qec->clearCacheUnpinnedOnly();
     std::vector<IdTable> children;
     children.push_back(makeIdTableFromVector({{1, 2, 3}, {4, 5, 6}}));
@@ -89,7 +89,7 @@ TEST(StripColumns, computeResult) {
       std::mem_fn(&LocalVocab::getAllWordsForTesting),
       ElementsAre(LocalVocabEntry{
           ad_utility::triple_component::LiteralOrIri::iriref("<kartoffel>"),
-          qec->getIndex().getImpl()}));
+          qec->getIndex()}));
   // Test materialized result.
   {
     auto strip = makeOp();

--- a/test/engine/StripColumnsTest.cpp
+++ b/test/engine/StripColumnsTest.cpp
@@ -71,8 +71,8 @@ TEST(StripColumns, computeResult) {
   auto qec = ad_utility::testing::getQec();
   auto makeOp = [&qec]() {
     LocalVocab voc;
-    voc.getIndexAndAddIfNotContained(
-        LocalVocabEntry::fromIriref("<kartoffel>", qec->getIndex()));
+    voc.getIndexAndAddIfNotContained(LocalVocabEntry::fromIriref(
+        "<kartoffel>", qec->getLocalVocabContext()));
     qec->clearCacheUnpinnedOnly();
     std::vector<IdTable> children;
     children.push_back(makeIdTableFromVector({{1, 2, 3}, {4, 5, 6}}));
@@ -84,9 +84,10 @@ TEST(StripColumns, computeResult) {
     return StripColumns{qec, std::move(valuesTree), {V{"?c"}, V{"?a"}}};
   };
 
-  auto localVocabMatcher = ResultOf(
-      std::mem_fn(&LocalVocab::getAllWordsForTesting),
-      ElementsAre(LocalVocabEntry::fromIriref("<kartoffel>", qec->getIndex())));
+  auto localVocabMatcher =
+      ResultOf(std::mem_fn(&LocalVocab::getAllWordsForTesting),
+               ElementsAre(LocalVocabEntry::fromIriref(
+                   "<kartoffel>", qec->getLocalVocabContext())));
   // Test materialized result.
   {
     auto strip = makeOp();

--- a/test/index/IndexRebuilderTest.cpp
+++ b/test/index/IndexRebuilderTest.cpp
@@ -276,10 +276,8 @@ TEST(IndexRebuilder, readIndexAndRemap) {
 
   index.deltaTriplesManager().modify<void>(
       [&cancellationHandle, g, &index](DeltaTriples& deltaTriples) {
-        LocalVocabEntry entry1 =
-            LocalVocabEntry::fromIriref("<a2>", index);
-        LocalVocabEntry entry2 =
-            LocalVocabEntry::fromIriref("<d2>", index);
+        LocalVocabEntry entry1 = LocalVocabEntry::fromIriref("<a2>", index);
+        LocalVocabEntry entry2 = LocalVocabEntry::fromIriref("<d2>", index);
         auto a2 = Id::makeFromLocalVocabIndex(&entry1);
         auto d2 = Id::makeFromLocalVocabIndex(&entry2);
         deltaTriples.insertTriples(

--- a/test/index/IndexRebuilderTest.cpp
+++ b/test/index/IndexRebuilderTest.cpp
@@ -115,9 +115,8 @@ TEST(IndexRebuilder, materializeLocalVocab) {
     deleteVocabFiles(vocabPrefix + VOCAB_SUFFIX, type.value());
   }};
 
-  const auto& indexImpl = oldIndex.getImpl();
-  auto makeVocabEntry = [&indexImpl](std::string_view str) {
-    return LocalVocabEntry{ad_utility::testing::iri(str), indexImpl};
+  auto makeVocabEntry = [&oldIndex](std::string_view str) {
+    return LocalVocabEntry{ad_utility::testing::iri(str), oldIndex};
   };
 
   auto getId = ad_utility::testing::makeGetId(oldIndex);
@@ -275,17 +274,16 @@ TEST(IndexRebuilder, readIndexAndRemap) {
                .toValueId(index)
                .value();
 
-  const auto& indexImpl = index.getImpl();
-  index.deltaTriplesManager().modify<void>([&cancellationHandle, g, &indexImpl](
+  index.deltaTriplesManager().modify<void>([&cancellationHandle, g, &index](
                                                DeltaTriples& deltaTriples) {
     LocalVocabEntry entry1{
         ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
             "<a2>"),
-        indexImpl};
+        index};
     LocalVocabEntry entry2{
         ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
             "<d2>"),
-        indexImpl};
+        index};
     auto a2 = Id::makeFromLocalVocabIndex(&entry1);
     auto d2 = Id::makeFromLocalVocabIndex(&entry2);
     deltaTriples.insertTriples(

--- a/test/index/IndexRebuilderTest.cpp
+++ b/test/index/IndexRebuilderTest.cpp
@@ -274,23 +274,19 @@ TEST(IndexRebuilder, readIndexAndRemap) {
                .toValueId(index)
                .value();
 
-  index.deltaTriplesManager().modify<void>([&cancellationHandle, g, &index](
-                                               DeltaTriples& deltaTriples) {
-    LocalVocabEntry entry1{
-        ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
-            "<a2>"),
-        index};
-    LocalVocabEntry entry2{
-        ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
-            "<d2>"),
-        index};
-    auto a2 = Id::makeFromLocalVocabIndex(&entry1);
-    auto d2 = Id::makeFromLocalVocabIndex(&entry2);
-    deltaTriples.insertTriples(
-        cancellationHandle,
-        {IdTriple<0>{std::array{V(0), a2, Id::makeFromInt(1337), g}},
-         IdTriple<0>{std::array{V(0), d2, B(1), g}}});
-  });
+  index.deltaTriplesManager().modify<void>(
+      [&cancellationHandle, g, &index](DeltaTriples& deltaTriples) {
+        LocalVocabEntry entry1 =
+            LocalVocabEntry::fromStringRepresentation("<a2>", index);
+        LocalVocabEntry entry2 =
+            LocalVocabEntry::fromStringRepresentation("<d2>", index);
+        auto a2 = Id::makeFromLocalVocabIndex(&entry1);
+        auto d2 = Id::makeFromLocalVocabIndex(&entry2);
+        deltaTriples.insertTriples(
+            cancellationHandle,
+            {IdTriple<0>{std::array{V(0), a2, Id::makeFromInt(1337), g}},
+             IdTriple<0>{std::array{V(0), d2, B(1), g}}});
+      });
 
   auto [state, vocabEntries, rawBlocks] =
       index.deltaTriplesManager()

--- a/test/index/IndexRebuilderTest.cpp
+++ b/test/index/IndexRebuilderTest.cpp
@@ -115,8 +115,9 @@ TEST(IndexRebuilder, materializeLocalVocab) {
     deleteVocabFiles(vocabPrefix + VOCAB_SUFFIX, type.value());
   }};
 
-  auto makeVocabEntry = [](std::string_view str) {
-    return LocalVocabEntry{ad_utility::testing::iri(str)};
+  const auto& indexImpl = oldIndex.getImpl();
+  auto makeVocabEntry = [&indexImpl](std::string_view str) {
+    return LocalVocabEntry{ad_utility::testing::iri(str), indexImpl};
   };
 
   auto getId = ad_utility::testing::makeGetId(oldIndex);
@@ -274,14 +275,17 @@ TEST(IndexRebuilder, readIndexAndRemap) {
                .toValueId(index)
                .value();
 
-  index.deltaTriplesManager().modify<void>([&cancellationHandle,
-                                            g](DeltaTriples& deltaTriples) {
+  const auto& indexImpl = index.getImpl();
+  index.deltaTriplesManager().modify<void>([&cancellationHandle, g, &indexImpl](
+                                               DeltaTriples& deltaTriples) {
     LocalVocabEntry entry1{
         ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
-            "<a2>")};
+            "<a2>"),
+        indexImpl};
     LocalVocabEntry entry2{
         ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
-            "<d2>")};
+            "<d2>"),
+        indexImpl};
     auto a2 = Id::makeFromLocalVocabIndex(&entry1);
     auto d2 = Id::makeFromLocalVocabIndex(&entry2);
     deltaTriples.insertTriples(
@@ -404,7 +408,7 @@ TEST(IndexRebuilder, getNumberOfColumnsAndAdditionalColumns) {
 TEST(IndexRebuilder, createPermutationWriterTask) {
   auto* qec = ad_utility::testing::getQec("<a> <b> <c> . <d> <e> _:f .");
   const auto& index = qec->getIndex();
-  IndexImpl newIndex{ad_utility::makeUnlimitedAllocator<Id>(), false};
+  IndexImpl newIndex{ad_utility::makeUnlimitedAllocator<Id>()};
   std::string prefix = "/tmp/createPermutationWriterTask";
   std::array<std::string_view, 4> suffixes{".index.pos", ".index.pos.meta",
                                            ".index.pso", ".index.pso.meta"};
@@ -487,7 +491,7 @@ TEST(IndexRebuilder, materializeToIndex) {
                                blankNodes, cancellationHandle, logFile);
     EXPECT_TRUE(std::filesystem::exists(logFile));
 
-    IndexImpl newIndex{ad_utility::makeUnlimitedAllocator<Id>(), false};
+    IndexImpl newIndex{ad_utility::makeUnlimitedAllocator<Id>()};
     newIndex.usePatterns() = usePatterns;
     newIndex.loadAllPermutations() = loadAllPermutations;
     newIndex.createFromOnDiskIndex(newIndexName, false);

--- a/test/index/IndexRebuilderTest.cpp
+++ b/test/index/IndexRebuilderTest.cpp
@@ -277,9 +277,9 @@ TEST(IndexRebuilder, readIndexAndRemap) {
   index.deltaTriplesManager().modify<void>(
       [&cancellationHandle, g, &index](DeltaTriples& deltaTriples) {
         LocalVocabEntry entry1 =
-            LocalVocabEntry::fromStringRepresentation("<a2>", index);
+            LocalVocabEntry::fromIriref("<a2>", index);
         LocalVocabEntry entry2 =
-            LocalVocabEntry::fromStringRepresentation("<d2>", index);
+            LocalVocabEntry::fromIriref("<d2>", index);
         auto a2 = Id::makeFromLocalVocabIndex(&entry1);
         auto d2 = Id::makeFromLocalVocabIndex(&entry2);
         deltaTriples.insertTriples(

--- a/test/index/ScanSpecificationTest.cpp
+++ b/test/index/ScanSpecificationTest.cpp
@@ -105,7 +105,7 @@ TEST(ScanSpecification, ScanSpecificationAsTripleComponent) {
   // `toScanSpecification` is `nullopt`.
   TripleComponent notInVocab =
       TripleComponent::Iri::fromIriref("<thisIriIsNotContained>");
-  LocalVocabEntry localVocabEntry{notInVocab.getIri(), index.getImpl()};
+  LocalVocabEntry localVocabEntry{notInVocab.getIri(), index};
   auto localVocabId = Id::makeFromLocalVocabIndex(&localVocabEntry);
   EXPECT_THAT(STc(notInVocab, xIri, xIri),
               matchScanSpec(S(localVocabId, x, x)));

--- a/test/index/ScanSpecificationTest.cpp
+++ b/test/index/ScanSpecificationTest.cpp
@@ -105,7 +105,7 @@ TEST(ScanSpecification, ScanSpecificationAsTripleComponent) {
   // `toScanSpecification` is `nullopt`.
   TripleComponent notInVocab =
       TripleComponent::Iri::fromIriref("<thisIriIsNotContained>");
-  LocalVocabEntry localVocabEntry{notInVocab.getIri()};
+  LocalVocabEntry localVocabEntry{notInVocab.getIri(), index.getImpl()};
   auto localVocabId = Id::makeFromLocalVocabIndex(&localVocabEntry);
   EXPECT_THAT(STc(notInVocab, xIri, xIri),
               matchScanSpec(S(localVocabId, x, x)));

--- a/test/parser/BlankNodeExpressionTest.cpp
+++ b/test/parser/BlankNodeExpressionTest.cpp
@@ -35,7 +35,7 @@ TEST(BlankNodeExpression, expectBlankNodeResultEquality) {
   EXPECT_NE(result1, result3);
   EXPECT_NE(result2, result3);
 
-  const auto& index = context.qec->getIndex().getImpl();
+  const auto& index = context.qec->getIndex();
   VectorWithMemoryLimit<IdOrLocalVocabEntry> vector{context.context._allocator};
   vector.emplace_back(LocalVocabEntry{
       LiteralOrIri{Literal::literalWithoutQuotes("Other")}, index});
@@ -158,7 +158,7 @@ TEST(BlankNodeExpression, uniqueValuesAcrossInstances) {
 TEST(BlankNodeExpression, consistentCounterWithUndefined) {
   TestContext context;
   VectorWithMemoryLimit<IdOrLocalVocabEntry> vector{context.context._allocator};
-  const auto& index = context.qec->getIndex().getImpl();
+  const auto& index = context.qec->getIndex();
   vector.emplace_back(LocalVocabEntry{
       LiteralOrIri{Literal::literalWithoutQuotes("T1")}, index});
   vector.emplace_back(Id::makeUndefined());

--- a/test/parser/BlankNodeExpressionTest.cpp
+++ b/test/parser/BlankNodeExpressionTest.cpp
@@ -159,11 +159,9 @@ TEST(BlankNodeExpression, consistentCounterWithUndefined) {
   TestContext context;
   VectorWithMemoryLimit<IdOrLocalVocabEntry> vector{context.context._allocator};
   const auto& index = context.qec->getIndex();
-  vector.emplace_back(LocalVocabEntry{
-      LiteralOrIri{Literal::literalWithoutQuotes("T1")}, index});
+  vector.emplace_back(LocalVocabEntry::literalWithoutQuotes("T1", index));
   vector.emplace_back(Id::makeUndefined());
-  vector.emplace_back(LocalVocabEntry{
-      LiteralOrIri{Literal::literalWithoutQuotes("T2")}, index});
+  vector.emplace_back(LocalVocabEntry::literalWithoutQuotes("T2", index));
 
   auto expression0 =
       makeBlankNodeExpression(std::make_unique<SingleUseExpression>(

--- a/test/parser/BlankNodeExpressionTest.cpp
+++ b/test/parser/BlankNodeExpressionTest.cpp
@@ -37,10 +37,10 @@ TEST(BlankNodeExpression, expectBlankNodeResultEquality) {
 
   const auto& localVocabContext = context.qec->getLocalVocabContext();
   VectorWithMemoryLimit<IdOrLocalVocabEntry> vector{context.context._allocator};
-  vector.emplace_back(LocalVocabEntry{
-      LiteralOrIri{Literal::literalWithoutQuotes("Other")}, localVocabContext});
-  vector.emplace_back(LocalVocabEntry{
-      LiteralOrIri{Literal::literalWithoutQuotes("Test")}, localVocabContext});
+  vector.emplace_back(
+      LocalVocabEntry::literalWithoutQuotes("Other", localVocabContext));
+  vector.emplace_back(
+      LocalVocabEntry::literalWithoutQuotes("Test", localVocabContext));
   vector.emplace_back(
       LocalVocabEntry::fromIriref("<http://example.com>", localVocabContext));
 

--- a/test/parser/BlankNodeExpressionTest.cpp
+++ b/test/parser/BlankNodeExpressionTest.cpp
@@ -42,7 +42,7 @@ TEST(BlankNodeExpression, expectBlankNodeResultEquality) {
   vector.emplace_back(LocalVocabEntry{
       LiteralOrIri{Literal::literalWithoutQuotes("Test")}, index});
   vector.emplace_back(
-      LocalVocabEntry::fromStringRepresentation("<http://example.com>", index));
+      LocalVocabEntry::fromIriref("<http://example.com>", index));
 
   auto expression4 =
       makeBlankNodeExpression(std::make_unique<SingleUseExpression>(

--- a/test/parser/BlankNodeExpressionTest.cpp
+++ b/test/parser/BlankNodeExpressionTest.cpp
@@ -41,8 +41,8 @@ TEST(BlankNodeExpression, expectBlankNodeResultEquality) {
       LiteralOrIri{Literal::literalWithoutQuotes("Other")}, index});
   vector.emplace_back(LocalVocabEntry{
       LiteralOrIri{Literal::literalWithoutQuotes("Test")}, index});
-  vector.emplace_back(LocalVocabEntry{
-      LiteralOrIri{Iri::fromIriref("<http://example.com>")}, index});
+  vector.emplace_back(
+      LocalVocabEntry::fromStringRepresentation("<http://example.com>", index));
 
   auto expression4 =
       makeBlankNodeExpression(std::make_unique<SingleUseExpression>(

--- a/test/parser/BlankNodeExpressionTest.cpp
+++ b/test/parser/BlankNodeExpressionTest.cpp
@@ -35,14 +35,14 @@ TEST(BlankNodeExpression, expectBlankNodeResultEquality) {
   EXPECT_NE(result1, result3);
   EXPECT_NE(result2, result3);
 
-  const auto& index = context.qec->getIndex();
+  const auto& localVocabContext = context.qec->getLocalVocabContext();
   VectorWithMemoryLimit<IdOrLocalVocabEntry> vector{context.context._allocator};
   vector.emplace_back(LocalVocabEntry{
-      LiteralOrIri{Literal::literalWithoutQuotes("Other")}, index});
+      LiteralOrIri{Literal::literalWithoutQuotes("Other")}, localVocabContext});
   vector.emplace_back(LocalVocabEntry{
-      LiteralOrIri{Literal::literalWithoutQuotes("Test")}, index});
+      LiteralOrIri{Literal::literalWithoutQuotes("Test")}, localVocabContext});
   vector.emplace_back(
-      LocalVocabEntry::fromIriref("<http://example.com>", index));
+      LocalVocabEntry::fromIriref("<http://example.com>", localVocabContext));
 
   auto expression4 =
       makeBlankNodeExpression(std::make_unique<SingleUseExpression>(
@@ -158,10 +158,12 @@ TEST(BlankNodeExpression, uniqueValuesAcrossInstances) {
 TEST(BlankNodeExpression, consistentCounterWithUndefined) {
   TestContext context;
   VectorWithMemoryLimit<IdOrLocalVocabEntry> vector{context.context._allocator};
-  const auto& index = context.qec->getIndex();
-  vector.emplace_back(LocalVocabEntry::literalWithoutQuotes("T1", index));
+  const auto& localVocabContext = context.qec->getLocalVocabContext();
+  vector.emplace_back(
+      LocalVocabEntry::literalWithoutQuotes("T1", localVocabContext));
   vector.emplace_back(Id::makeUndefined());
-  vector.emplace_back(LocalVocabEntry::literalWithoutQuotes("T2", index));
+  vector.emplace_back(
+      LocalVocabEntry::literalWithoutQuotes("T2", localVocabContext));
 
   auto expression0 =
       makeBlankNodeExpression(std::make_unique<SingleUseExpression>(

--- a/test/parser/BlankNodeExpressionTest.cpp
+++ b/test/parser/BlankNodeExpressionTest.cpp
@@ -35,10 +35,14 @@ TEST(BlankNodeExpression, expectBlankNodeResultEquality) {
   EXPECT_NE(result1, result3);
   EXPECT_NE(result2, result3);
 
+  const auto& index = context.qec->getIndex().getImpl();
   VectorWithMemoryLimit<IdOrLocalVocabEntry> vector{context.context._allocator};
-  vector.emplace_back(LiteralOrIri{Literal::literalWithoutQuotes("Other")});
-  vector.emplace_back(LiteralOrIri{Literal::literalWithoutQuotes("Test")});
-  vector.emplace_back(LiteralOrIri{Iri::fromIriref("<http://example.com>")});
+  vector.emplace_back(LocalVocabEntry{
+      LiteralOrIri{Literal::literalWithoutQuotes("Other")}, index});
+  vector.emplace_back(LocalVocabEntry{
+      LiteralOrIri{Literal::literalWithoutQuotes("Test")}, index});
+  vector.emplace_back(LocalVocabEntry{
+      LiteralOrIri{Iri::fromIriref("<http://example.com>")}, index});
 
   auto expression4 =
       makeBlankNodeExpression(std::make_unique<SingleUseExpression>(
@@ -154,9 +158,12 @@ TEST(BlankNodeExpression, uniqueValuesAcrossInstances) {
 TEST(BlankNodeExpression, consistentCounterWithUndefined) {
   TestContext context;
   VectorWithMemoryLimit<IdOrLocalVocabEntry> vector{context.context._allocator};
-  vector.emplace_back(LiteralOrIri{Literal::literalWithoutQuotes("T1")});
+  const auto& index = context.qec->getIndex().getImpl();
+  vector.emplace_back(LocalVocabEntry{
+      LiteralOrIri{Literal::literalWithoutQuotes("T1")}, index});
   vector.emplace_back(Id::makeUndefined());
-  vector.emplace_back(LiteralOrIri{Literal::literalWithoutQuotes("T2")});
+  vector.emplace_back(LocalVocabEntry{
+      LiteralOrIri{Literal::literalWithoutQuotes("T2")}, index});
 
   auto expression0 =
       makeBlankNodeExpression(std::make_unique<SingleUseExpression>(

--- a/test/parser/UpdateTriplesTest.cpp
+++ b/test/parser/UpdateTriplesTest.cpp
@@ -21,10 +21,10 @@ TEST(UpdateTriples, DefaultConstructor) {
 
 // _____________________________________________________________________________
 TEST(UpdateTriples, ConstructorsAndAssignments) {
-  const auto& index = ad_utility::testing::getQec()->getIndex().getImpl();
+  auto* qec = ad_utility::testing::getQec();
   LocalVocab l;
   auto iri = LocalVocabEntry::iriref("<hallo>");
-  l.getIndexAndAddIfNotContained(LocalVocabEntry{iri, index});
+  l.getIndexAndAddIfNotContained(LocalVocabEntry{iri, qec->getIndex()});
   std::vector<SparqlTripleSimpleWithGraph> triples;
 
   SparqlTripleSimpleWithGraph triple{V{"?x"}, V{"?y"}, V{"?z"},

--- a/test/parser/UpdateTriplesTest.cpp
+++ b/test/parser/UpdateTriplesTest.cpp
@@ -23,9 +23,9 @@ TEST(UpdateTriples, DefaultConstructor) {
 TEST(UpdateTriples, ConstructorsAndAssignments) {
   auto* qec = ad_utility::testing::getQec();
   LocalVocab l;
-  auto iri = LocalVocabEntry::iriref("<hallo>");
-  l.getIndexAndAddIfNotContained(
-      LocalVocabEntry{iri, qec->getLocalVocabContext()});
+  auto iri =
+      LocalVocabEntry::fromIriref("<hallo>", qec->getLocalVocabContext());
+  l.getIndexAndAddIfNotContained(iri);
   std::vector<SparqlTripleSimpleWithGraph> triples;
 
   SparqlTripleSimpleWithGraph triple{V{"?x"}, V{"?y"}, V{"?z"},

--- a/test/parser/UpdateTriplesTest.cpp
+++ b/test/parser/UpdateTriplesTest.cpp
@@ -5,6 +5,7 @@
 #include <gmock/gmock.h>
 
 #include "../util/GTestHelpers.h"
+#include "../util/IndexTestHelpers.h"
 #include "parser/UpdateTriples.h"
 #include "util/CompilerWarnings.h"
 
@@ -20,9 +21,10 @@ TEST(UpdateTriples, DefaultConstructor) {
 
 // _____________________________________________________________________________
 TEST(UpdateTriples, ConstructorsAndAssignments) {
+  const auto& index = ad_utility::testing::getQec()->getIndex().getImpl();
   LocalVocab l;
   auto iri = LocalVocabEntry::iriref("<hallo>");
-  l.getIndexAndAddIfNotContained(LocalVocabEntry{iri});
+  l.getIndexAndAddIfNotContained(LocalVocabEntry{iri, index});
   std::vector<SparqlTripleSimpleWithGraph> triples;
 
   SparqlTripleSimpleWithGraph triple{V{"?x"}, V{"?y"}, V{"?z"},

--- a/test/parser/UpdateTriplesTest.cpp
+++ b/test/parser/UpdateTriplesTest.cpp
@@ -24,7 +24,8 @@ TEST(UpdateTriples, ConstructorsAndAssignments) {
   auto* qec = ad_utility::testing::getQec();
   LocalVocab l;
   auto iri = LocalVocabEntry::iriref("<hallo>");
-  l.getIndexAndAddIfNotContained(LocalVocabEntry{iri, qec->getIndex()});
+  l.getIndexAndAddIfNotContained(
+      LocalVocabEntry{iri, qec->getLocalVocabContext()});
   std::vector<SparqlTripleSimpleWithGraph> triples;
 
   SparqlTripleSimpleWithGraph triple{V{"?x"}, V{"?y"}, V{"?z"},

--- a/test/util/IdTestHelpers.h
+++ b/test/util/IdTestHelpers.h
@@ -41,8 +41,8 @@ inline auto LocalVocabId = [](std::integral auto v) {
   auto* qec = getQec();
   return Id::makeFromLocalVocabIndex(
       localVocab.wlock()->getIndexAndAddIfNotContained(
-          LocalVocabEntry{LiteralOrIri::literalWithoutQuotes(std::to_string(v)),
-                          qec->getIndex()}));
+          LocalVocabEntry::literalWithoutQuotes(std::to_string(v),
+                                                qec->getIndex())));
 };
 
 inline auto TextRecordId = [](const auto& t) {

--- a/test/util/IdTestHelpers.h
+++ b/test/util/IdTestHelpers.h
@@ -42,7 +42,7 @@ inline auto LocalVocabId = [](std::integral auto v) {
   return Id::makeFromLocalVocabIndex(
       localVocab.wlock()->getIndexAndAddIfNotContained(
           LocalVocabEntry::literalWithoutQuotes(std::to_string(v),
-                                                qec->getIndex())));
+                                                qec->getLocalVocabContext())));
 };
 
 inline auto TextRecordId = [](const auto& t) {

--- a/test/util/IdTestHelpers.h
+++ b/test/util/IdTestHelpers.h
@@ -35,7 +35,7 @@ inline auto BlankNodeId = [](const auto& v) {
 inline auto LocalVocabId = [](std::integral auto v) {
   static ad_utility::Synchronized<LocalVocab> localVocab;
   using namespace ad_utility::triple_component;
-  // Use `getQec()` to obtain a valid `IndexImpl` reference for creating
+  // Use `getQec()` to obtain a valid `LocalVocabContext` reference for creating
   // `LocalVocabEntry` objects. This works because we store the indices in a
   // static map.
   auto* qec = getQec();

--- a/test/util/IdTestHelpers.h
+++ b/test/util/IdTestHelpers.h
@@ -5,7 +5,9 @@
 #ifndef QLEVER_TEST_UTIL_IDTESTHELPERS_H
 #define QLEVER_TEST_UTIL_IDTESTHELPERS_H
 
+#include "IndexTestHelpers.h"
 #include "global/Id.h"
+#include "index/Index.h"
 #include "index/LocalVocab.h"
 #include "util/Synchronized.h"
 
@@ -33,9 +35,12 @@ inline auto BlankNodeId = [](const auto& v) {
 inline auto LocalVocabId = [](std::integral auto v) {
   static ad_utility::Synchronized<LocalVocab> localVocab;
   using namespace ad_utility::triple_component;
+  // Use `getQec()` to obtain a valid `IndexImpl` reference for creating
+  // `LocalVocabEntry` objects.
+  const auto& index = ad_utility::testing::getQec()->getIndex().getImpl();
   return Id::makeFromLocalVocabIndex(
-      localVocab.wlock()->getIndexAndAddIfNotContained(
-          LiteralOrIri::literalWithoutQuotes(std::to_string(v))));
+      localVocab.wlock()->getIndexAndAddIfNotContained(LocalVocabEntry{
+          LiteralOrIri::literalWithoutQuotes(std::to_string(v)), index}));
 };
 
 inline auto TextRecordId = [](const auto& t) {

--- a/test/util/IdTestHelpers.h
+++ b/test/util/IdTestHelpers.h
@@ -36,15 +36,17 @@ inline auto LocalVocabId = [](std::integral auto v) {
   static ad_utility::Synchronized<LocalVocab> localVocab;
   using namespace ad_utility::triple_component;
   // Use `getQec()` to obtain a valid `IndexImpl` reference for creating
-  // `LocalVocabEntry` objects.
-  const auto& index = ad_utility::testing::getQec()->getIndex().getImpl();
+  // `LocalVocabEntry` objects. This works because we store the indices in a
+  // static map.
+  auto* qec = getQec();
   return Id::makeFromLocalVocabIndex(
-      localVocab.wlock()->getIndexAndAddIfNotContained(LocalVocabEntry{
-          LiteralOrIri::literalWithoutQuotes(std::to_string(v)), index}));
+      localVocab.wlock()->getIndexAndAddIfNotContained(
+          LocalVocabEntry{LiteralOrIri::literalWithoutQuotes(std::to_string(v)),
+                          qec->getIndex()}));
 };
 
 inline auto TextRecordId = [](const auto& t) {
-  return Id::makeFromTextRecordIndex(TextRecordIndex ::make(t));
+  return Id::makeFromTextRecordIndex(TextRecordIndex::make(t));
 };
 
 inline auto WordVocabId = [](const auto& t) {

--- a/test/util/IndexTestHelpers.cpp
+++ b/test/util/IndexTestHelpers.cpp
@@ -380,8 +380,7 @@ QueryExecutionContext* getQec(TestIndexConfig c) {
                    std::make_unique<NamedResultCache>(),
                    std::make_unique<MaterializedViewsManager>()});
   }
-  auto* qec = contextMap.at(c).qec_.get();
-  return qec;
+  return contextMap.at(c).qec_.get();
 }
 
 // _____________________________________________________________________________

--- a/test/util/IndexTestHelpers.cpp
+++ b/test/util/IndexTestHelpers.cpp
@@ -381,7 +381,6 @@ QueryExecutionContext* getQec(TestIndexConfig c) {
                    std::make_unique<MaterializedViewsManager>()});
   }
   auto* qec = contextMap.at(c).qec_.get();
-  qec->getIndex().getImpl().setGlobalIndexOnlyForTesting();
   return qec;
 }
 


### PR DESCRIPTION
So far, `LocalVocabEntry` accessed the vocabulary and comparator through this global singleton to compare entries and look up their position in the vocabulary. This made it impossible to support multiple indexes. Instead, every `LocalVocabEntry` now stores a const pointer to a `LocalVocabContext` (which is an alias for `IndexImpl`) that is passed at construction time. The `promoteToLocalVocabEntry` functor is changed to a function template that takes a `LocalVocabContext` parameter, so the context can be threaded through from the expression evaluation layer.

This is a large mechanical change (94 files, ~1900 lines touched) because every site that creates a `LocalVocabEntry` must now provide the context (including many test files that use a test index helper). It continues #2801 and #2808 in preparing for multiple indexes