### PR TITLE
Compute diff between two snapshots and remap IDs to the new index

### DIFF
--- a/src/index/DeltaTriples.cpp
+++ b/src/index/DeltaTriples.cpp
@@ -20,6 +20,7 @@
 #include "index/ExportIds.h"
 #include "index/Index.h"
 #include "index/IndexImpl.h"
+#include "index/IndexRebuilder.h"
 #include "index/LocatedTriples.h"
 #include "util/ChunkedForLoop.h"
 #include "util/Serializer/TripleSerializer.h"
@@ -692,4 +693,72 @@ DeltaTriples::copyLocalVocab() const {
           [](const LocalVocabEntry& entry) { return &entry; }));
   return std::make_pair(std::move(entries),
                         localVocab_.getOwnedLocalBlankNodeBlocks());
+}
+
+// _____________________________________________________________________________
+void DeltaTriples::fillFromOldDeltaTriples(
+    const LocatedTriplesState& oldState, const LocatedTriplesState& newState,
+    const std::tuple<qlever::indexRebuilder::InsertionPositions,
+                     qlever::indexRebuilder::LocalVocabMapping,
+                     qlever::indexRebuilder::BlankNodeBlocks>& idMapping,
+    uint64_t minBlankNodeIndex, CancellationHandle cancellationHandle,
+    ad_utility::timer::TimeTracer& tracer) {
+  tracer.beginTrace("computeDeltaTripleDifference");
+  auto difference = computeDeltaTripleDifference(oldState, newState);
+  for (auto& triples : difference) {
+    ql::ranges::for_each(
+        triples, [&idMapping, minBlankNodeIndex](auto& triple) {
+          ql::ranges::for_each(triple.ids(), [&idMapping,
+                                              minBlankNodeIndex](Id& id) {
+            const auto& [insertionPositions, localVocabMapping,
+                         blankNodeBlocks] = idMapping;
+            auto type = id.getDatatype();
+            if (type == Datatype::VocabIndex) {
+              id = qlever::indexRebuilder::remapVocabId(id, insertionPositions);
+            } else if (type == Datatype::LocalVocabIndex) {
+              auto it = localVocabMapping.find(id.getBits());
+              if (it != localVocabMapping.end()) {
+                id = it->second;
+              }
+            } else if (type == Datatype::BlankNodeIndex) {
+              auto value = qlever::indexRebuilder::tryRemapBlankNodeId(
+                  id, blankNodeBlocks, minBlankNodeIndex);
+              if (value.has_value()) {
+                id = value.value();
+              }
+            }
+          });
+        });
+  }
+  tracer.endTrace("computeDeltaTripleDifference");
+  tracer.beginTrace("insertDiffedTriples");
+  modifyTriplesImpl<false, true>(cancellationHandle,
+                                 std::move(difference.at(0)), tracer);
+  modifyTriplesImpl<false, false>(cancellationHandle,
+                                  std::move(difference.at(1)), tracer);
+  modifyTriplesImpl<true, true>(cancellationHandle, std::move(difference.at(2)),
+                                tracer);
+  modifyTriplesImpl<true, false>(std::move(cancellationHandle),
+                                 std::move(difference.at(3)), tracer);
+  tracer.endTrace("insertDiffedTriples");
+  // Update the index of the located triples to mark that they have changed.
+  locatedTriples_->index_++;
+}
+
+// _____________________________________________________________________________
+std::array<std::vector<IdTriple<0>>, 4>
+DeltaTriples::computeDeltaTripleDifference(
+    const LocatedTriplesState& oldState, const LocatedTriplesState& newState) {
+  auto deltaPermutation = Permutation::SPO;
+  auto [insertions, deletions] =
+      newState.getLocatedTriplesForPermutation<false>(deltaPermutation)
+          .computeDeltaTripleDifference(
+              oldState.getLocatedTriplesForPermutation<false>(
+                  deltaPermutation));
+  auto [internaInsertions, internalDeletions] =
+      newState.getLocatedTriplesForPermutation<true>(deltaPermutation)
+          .computeDeltaTripleDifference(
+              oldState.getLocatedTriplesForPermutation<true>(deltaPermutation));
+  return std::array{std::move(insertions), std::move(deletions),
+                    std::move(internaInsertions), std::move(internalDeletions)};
 }

--- a/src/index/DeltaTriples.cpp
+++ b/src/index/DeltaTriples.cpp
@@ -699,71 +699,102 @@ DeltaTriples::copyLocalVocab() const {
 // _____________________________________________________________________________
 void DeltaTriples::fillFromOldDeltaTriples(
     const LocatedTriplesState& oldState, const LocatedTriplesState& newState,
-    const std::tuple<qlever::indexRebuilder::InsertionPositions,
-                     qlever::indexRebuilder::LocalVocabMapping,
-                     qlever::indexRebuilder::BlankNodeBlocks>& idMapping,
+    const qlever::indexRebuilder::MappingInformation& idMapping,
     uint64_t minBlankNodeIndex, CancellationHandle cancellationHandle,
     ad_utility::timer::TimeTracer& tracer) {
   tracer.beginTrace("computeDeltaTripleDifference");
   auto difference = computeDeltaTripleDifference(oldState, newState);
-  for (auto& triples : difference) {
-    ql::ranges::for_each(
-        triples, [&idMapping, minBlankNodeIndex](auto& triple) {
-          ql::ranges::for_each(triple.ids(), [&idMapping,
-                                              minBlankNodeIndex](Id& id) {
-            const auto& [insertionPositions, localVocabMapping,
-                         blankNodeBlocks] = idMapping;
-            auto type = id.getDatatype();
-            if (type == Datatype::VocabIndex) {
-              id = qlever::indexRebuilder::remapVocabId(id, insertionPositions);
-            } else if (type == Datatype::LocalVocabIndex) {
-              auto it = localVocabMapping.find(id.getBits());
-              if (it != localVocabMapping.end()) {
-                id = it->second;
-              }
-            } else if (type == Datatype::BlankNodeIndex) {
-              auto value = qlever::indexRebuilder::tryRemapBlankNodeId(
-                  id, blankNodeBlocks, minBlankNodeIndex);
-              if (value.has_value()) {
-                id = value.value();
-              }
-            }
-          });
-        });
-  }
+  difference.remapIds([&idMapping, minBlankNodeIndex](Id& id) {
+    remapId(idMapping, minBlankNodeIndex, id);
+  });
   tracer.endTrace("computeDeltaTripleDifference");
   tracer.beginTrace("insertDiffedTriples");
-  modifyTriplesImpl<false, true>(cancellationHandle,
-                                 std::move(difference.at(0)), tracer);
-  modifyTriplesImpl<false, false>(cancellationHandle,
-                                  std::move(difference.at(1)), tracer);
-  modifyTriplesImpl<true, true>(cancellationHandle, std::move(difference.at(2)),
-                                tracer);
-  modifyTriplesImpl<true, false>(std::move(cancellationHandle),
-                                 std::move(difference.at(3)), tracer);
+  auto addTriples = [this, &cancellationHandle, &difference, &tracer](
+                        auto isInternal, auto insertOrDelete) {
+    modifyTriplesImpl<isInternal, insertOrDelete>(
+        cancellationHandle,
+        std::move(difference.triples<isInternal, insertOrDelete>()), tracer);
+  };
+  addTriples(std::bool_constant<false>{}, std::bool_constant<true>{});
+  addTriples(std::bool_constant<false>{}, std::bool_constant<false>{});
+  addTriples(std::bool_constant<true>{}, std::bool_constant<true>{});
+  addTriples(std::bool_constant<true>{}, std::bool_constant<false>{});
   tracer.endTrace("insertDiffedTriples");
   // Update the index of the located triples to mark that they have changed.
   locatedTriples_->index_++;
 }
+
+// _____________________________________________________________________________
+AD_ALWAYS_INLINE void DeltaTriples::remapId(
+    const qlever::indexRebuilder::MappingInformation& idMapping,
+    uint64_t minBlankNodeIndex, Id& id) {
+  const auto& [insertionPositions, localVocabMapping, blankNodeBlocks] =
+      idMapping;
+  auto type = id.getDatatype();
+  if (type == Datatype::VocabIndex) {
+    id = qlever::indexRebuilder::remapVocabId(id, insertionPositions);
+  } else if (type == Datatype::LocalVocabIndex) {
+    auto it = localVocabMapping.find(id.getBits());
+    // If we don't have a mapping we don't need to do anything as the
+    // `LocalVocab` ids are being copied into the `LocalVocab` of the
+    // `DeltaTriples` instance.
+    if (it != localVocabMapping.end()) {
+      id = it->second;
+    }
+  } else if (type == Datatype::BlankNodeIndex) {
+    auto value = qlever::indexRebuilder::tryRemapBlankNodeId(
+        id, blankNodeBlocks, minBlankNodeIndex);
+    // This function might remap more blank node ids that originally planned.
+    // This is not a problem, since any blank node ids that get allocated
+    // outside the interval [0, minBlankNodeIndex) will get remapped on
+    // insertion.
+    if (value.has_value()) {
+      id = value.value();
+    }
+  }
+}
 #endif
 
 // _____________________________________________________________________________
-std::array<std::vector<IdTriple<0>>, 4>
-DeltaTriples::computeDeltaTripleDifference(
+DeltaTriples::DeltaTripleDifference::DeltaTripleDifference(
+    std::vector<IdTriple<0>> inserted, std::vector<IdTriple<0>> deleted,
+    std::vector<IdTriple<0>> internalInserted,
+    std::vector<IdTriple<0>> internalDeleted)
+    : data_{std::move(inserted), std::move(deleted),
+            std::move(internalInserted), std::move(internalDeleted)} {}
+
+// ____________________________________________________________________________
+template <typename Func>
+void DeltaTriples::DeltaTripleDifference::remapIds(Func func) {
+  ql::ranges::for_each(data_, [&func](auto& triples) {
+    ql::ranges::for_each(triples, [&func](auto& triple) {
+      ql::ranges::for_each(triple.ids(), func);
+    });
+  });
+}
+
+// ____________________________________________________________________________
+template <bool isInternal, bool insertOrDelete>
+std::vector<IdTriple<0>>& DeltaTriples::DeltaTripleDifference::triples() {
+  size_t index =
+      (isInternal ? 2 : 0) + (1 - static_cast<size_t>(insertOrDelete));
+  return data_.at(index);
+}
+
+// _____________________________________________________________________________
+DeltaTriples::DeltaTripleDifference DeltaTriples::computeDeltaTripleDifference(
     const LocatedTriplesState& oldState, const LocatedTriplesState& newState) {
-  auto deltaPermutation = Permutation::SPO;
+  auto computeDifference = [&oldState, &newState](
+                               auto isInternal, Permutation::Enum permutation) {
+    return newState.getLocatedTriplesForPermutation<isInternal>(permutation)
+        .computeDeltaTripleDifference(
+            oldState.getLocatedTriplesForPermutation<isInternal>(permutation));
+  };
   auto [insertions, deletions] =
-      newState.getLocatedTriplesForPermutation<false>(deltaPermutation)
-          .computeDeltaTripleDifference(
-              oldState.getLocatedTriplesForPermutation<false>(
-                  deltaPermutation));
-  auto internalPermutation = Permutation::PSO;
+      computeDifference(std::bool_constant<false>{}, Permutation::SPO);
   auto [internalInsertions, internalDeletions] =
-      newState.getLocatedTriplesForPermutation<true>(internalPermutation)
-          .computeDeltaTripleDifference(
-              oldState.getLocatedTriplesForPermutation<true>(
-                  internalPermutation));
-  return std::array{std::move(insertions), std::move(deletions),
-                    std::move(internalInsertions),
-                    std::move(internalDeletions)};
+      computeDifference(std::bool_constant<true>{}, Permutation::PSO);
+  return DeltaTripleDifference{std::move(insertions), std::move(deletions),
+                               std::move(internalInsertions),
+                               std::move(internalDeletions)};
 }

--- a/src/index/DeltaTriples.cpp
+++ b/src/index/DeltaTriples.cpp
@@ -697,15 +697,15 @@ DeltaTriples::copyLocalVocab() const {
 
 #ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
 // _____________________________________________________________________________
-void DeltaTriples::fillFromOldDeltaTriples(
+void DeltaTriples::addFromSnapshotDiff(
     const LocatedTriplesState& oldState, const LocatedTriplesState& newState,
-    const qlever::indexRebuilder::MappingInformation& idMapping,
+    const qlever::indexRebuilder::IndexRebuildMapping& idMapping,
     CancellationHandle cancellationHandle,
     ad_utility::timer::TimeTracer& tracer) {
-  tracer.beginTrace("computeDeltaTripleDifference");
-  auto difference = computeDeltaTripleDifference(oldState, newState);
+  tracer.beginTrace("computeLocatedTriplesDiff");
+  auto difference = computeLocatedTriplesDiff(oldState, newState);
   difference.remapIds([&idMapping](Id& id) { remapId(idMapping, id); });
-  tracer.endTrace("computeDeltaTripleDifference");
+  tracer.endTrace("computeLocatedTriplesDiff");
   tracer.beginTrace("insertDiffedTriples");
   auto addTriples = [this, &cancellationHandle, &difference, &tracer](
                         auto isInternal, auto insertOrDelete) {
@@ -725,7 +725,7 @@ void DeltaTriples::fillFromOldDeltaTriples(
 
 // _____________________________________________________________________________
 AD_ALWAYS_INLINE void DeltaTriples::remapId(
-    const qlever::indexRebuilder::MappingInformation& idMapping, Id& id) {
+    const qlever::indexRebuilder::IndexRebuildMapping& idMapping, Id& id) {
   const auto& [insertionPositions, localVocabMapping, blankNodeBlocks,
                minBlankNodeIndex] = idMapping;
   auto type = id.getDatatype();
@@ -759,15 +759,16 @@ AD_ALWAYS_INLINE void DeltaTriples::remapId(
 #endif
 
 // _____________________________________________________________________________
-DeltaTriples::DeltaTripleDifference::DeltaTripleDifference(
-    Triples inserted, Triples deleted, Triples internalInserted,
-    Triples internalDeleted)
+DeltaTriples::LocatedTriplesDiff::LocatedTriplesDiff(Triples inserted,
+                                                     Triples deleted,
+                                                     Triples internalInserted,
+                                                     Triples internalDeleted)
     : data_{std::move(inserted), std::move(deleted),
             std::move(internalInserted), std::move(internalDeleted)} {}
 
 // ____________________________________________________________________________
 template <typename Func>
-void DeltaTriples::DeltaTripleDifference::remapIds(Func func) {
+void DeltaTriples::LocatedTriplesDiff::remapIds(Func func) {
   ql::ranges::for_each(data_, [&func](auto& triples) {
     ql::ranges::for_each(triples, [&func](auto& triple) {
       ql::ranges::for_each(triple.ids(), func);
@@ -777,26 +778,26 @@ void DeltaTriples::DeltaTripleDifference::remapIds(Func func) {
 
 // ____________________________________________________________________________
 template <bool isInternal, bool insertOrDelete>
-DeltaTriples::Triples& DeltaTriples::DeltaTripleDifference::triples() {
+DeltaTriples::Triples& DeltaTriples::LocatedTriplesDiff::triples() {
   size_t index =
       (isInternal ? 2 : 0) + (1 - static_cast<size_t>(insertOrDelete));
   return data_.at(index);
 }
 
 // _____________________________________________________________________________
-DeltaTriples::DeltaTripleDifference DeltaTriples::computeDeltaTripleDifference(
+DeltaTriples::LocatedTriplesDiff DeltaTriples::computeLocatedTriplesDiff(
     const LocatedTriplesState& oldState, const LocatedTriplesState& newState) {
   auto computeDifference = [&oldState, &newState](
                                auto isInternal, Permutation::Enum permutation) {
     return newState.getLocatedTriplesForPermutation<isInternal>(permutation)
-        .computeDeltaTripleDifference(
+        .computeDiff(
             oldState.getLocatedTriplesForPermutation<isInternal>(permutation));
   };
   auto [insertions, deletions] =
       computeDifference(std::bool_constant<false>{}, Permutation::SPO);
   auto [internalInsertions, internalDeletions] =
       computeDifference(std::bool_constant<true>{}, Permutation::PSO);
-  return DeltaTripleDifference{std::move(insertions), std::move(deletions),
-                               std::move(internalInsertions),
-                               std::move(internalDeletions)};
+  return LocatedTriplesDiff{std::move(insertions), std::move(deletions),
+                            std::move(internalInsertions),
+                            std::move(internalDeletions)};
 }

--- a/src/index/DeltaTriples.cpp
+++ b/src/index/DeltaTriples.cpp
@@ -700,13 +700,11 @@ DeltaTriples::copyLocalVocab() const {
 void DeltaTriples::fillFromOldDeltaTriples(
     const LocatedTriplesState& oldState, const LocatedTriplesState& newState,
     const qlever::indexRebuilder::MappingInformation& idMapping,
-    uint64_t minBlankNodeIndex, CancellationHandle cancellationHandle,
+    CancellationHandle cancellationHandle,
     ad_utility::timer::TimeTracer& tracer) {
   tracer.beginTrace("computeDeltaTripleDifference");
   auto difference = computeDeltaTripleDifference(oldState, newState);
-  difference.remapIds([&idMapping, minBlankNodeIndex](Id& id) {
-    remapId(idMapping, minBlankNodeIndex, id);
-  });
+  difference.remapIds([&idMapping](Id& id) { remapId(idMapping, id); });
   tracer.endTrace("computeDeltaTripleDifference");
   tracer.beginTrace("insertDiffedTriples");
   auto addTriples = [this, &cancellationHandle, &difference, &tracer](
@@ -715,10 +713,11 @@ void DeltaTriples::fillFromOldDeltaTriples(
         cancellationHandle,
         std::move(difference.triples<isInternal, insertOrDelete>()), tracer);
   };
-  addTriples(std::bool_constant<false>{}, std::bool_constant<true>{});
-  addTriples(std::bool_constant<false>{}, std::bool_constant<false>{});
-  addTriples(std::bool_constant<true>{}, std::bool_constant<true>{});
-  addTriples(std::bool_constant<true>{}, std::bool_constant<false>{});
+  using namespace ad_utility::use_value_identity;
+  addTriples(vi<false>, vi<true>);
+  addTriples(vi<false>, vi<false>);
+  addTriples(vi<true>, vi<true>);
+  addTriples(vi<true>, vi<false>);
   tracer.endTrace("insertDiffedTriples");
   // Update the index of the located triples to mark that they have changed.
   locatedTriples_->index_++;
@@ -726,28 +725,32 @@ void DeltaTriples::fillFromOldDeltaTriples(
 
 // _____________________________________________________________________________
 AD_ALWAYS_INLINE void DeltaTriples::remapId(
-    const qlever::indexRebuilder::MappingInformation& idMapping,
-    uint64_t minBlankNodeIndex, Id& id) {
-  const auto& [insertionPositions, localVocabMapping, blankNodeBlocks] =
-      idMapping;
+    const qlever::indexRebuilder::MappingInformation& idMapping, Id& id) {
+  const auto& [insertionPositions, localVocabMapping, blankNodeBlocks,
+               minBlankNodeIndex] = idMapping;
   auto type = id.getDatatype();
   if (type == Datatype::VocabIndex) {
     id = qlever::indexRebuilder::remapVocabId(id, insertionPositions);
   } else if (type == Datatype::LocalVocabIndex) {
     auto it = localVocabMapping.find(id.getBits());
-    // If we don't have a mapping we don't need to do anything as the
-    // `LocalVocab` ids are being copied into the `LocalVocab` of the
-    // `DeltaTriples` instance.
+    // If we have a mapping, this means that the new index used this to make a
+    // vocab index out of it and we have to do the same. If we don't have a
+    // mapping it will remain a local vocab index that is then copied into the
+    // delta triples vocabulary and remapped then.
     if (it != localVocabMapping.end()) {
       id = it->second;
     }
   } else if (type == Datatype::BlankNodeIndex) {
     auto value = qlever::indexRebuilder::tryRemapBlankNodeId(
         id, blankNodeBlocks, minBlankNodeIndex);
-    // This function might remap more blank node ids that originally planned.
-    // This is not a problem, since any blank node ids that get allocated
-    // outside the interval [0, minBlankNodeIndex) will get remapped on
-    // insertion.
+    // If we have a mapping for the given blank node index, this means that the
+    // block was remapped by the index rebuild. We might potentially map blank
+    // node indices that were added after the mapping was created, but still
+    // fall into the same allocation blocks. This is not a problem, since any
+    // blank node ids that get allocated outside the interval [0,
+    // minBlankNodeIndex) will get remapped on insertion. If we don't have a
+    // mapping this means we don't have a mapping and keep the value as-is so it
+    // gets remapped when inserted into the delta triples.
     if (value.has_value()) {
       id = value.value();
     }
@@ -757,9 +760,8 @@ AD_ALWAYS_INLINE void DeltaTriples::remapId(
 
 // _____________________________________________________________________________
 DeltaTriples::DeltaTripleDifference::DeltaTripleDifference(
-    std::vector<IdTriple<0>> inserted, std::vector<IdTriple<0>> deleted,
-    std::vector<IdTriple<0>> internalInserted,
-    std::vector<IdTriple<0>> internalDeleted)
+    Triples inserted, Triples deleted, Triples internalInserted,
+    Triples internalDeleted)
     : data_{std::move(inserted), std::move(deleted),
             std::move(internalInserted), std::move(internalDeleted)} {}
 
@@ -775,7 +777,7 @@ void DeltaTriples::DeltaTripleDifference::remapIds(Func func) {
 
 // ____________________________________________________________________________
 template <bool isInternal, bool insertOrDelete>
-std::vector<IdTriple<0>>& DeltaTriples::DeltaTripleDifference::triples() {
+DeltaTriples::Triples& DeltaTriples::DeltaTripleDifference::triples() {
   size_t index =
       (isInternal ? 2 : 0) + (1 - static_cast<size_t>(insertOrDelete));
   return data_.at(index);

--- a/src/index/DeltaTriples.cpp
+++ b/src/index/DeltaTriples.cpp
@@ -695,6 +695,7 @@ DeltaTriples::copyLocalVocab() const {
                         localVocab_.getOwnedLocalBlankNodeBlocks());
 }
 
+#ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
 // _____________________________________________________________________________
 void DeltaTriples::fillFromOldDeltaTriples(
     const LocatedTriplesState& oldState, const LocatedTriplesState& newState,
@@ -744,6 +745,7 @@ void DeltaTriples::fillFromOldDeltaTriples(
   // Update the index of the located triples to mark that they have changed.
   locatedTriples_->index_++;
 }
+#endif
 
 // _____________________________________________________________________________
 std::array<std::vector<IdTriple<0>>, 4>

--- a/src/index/DeltaTriples.cpp
+++ b/src/index/DeltaTriples.cpp
@@ -755,10 +755,13 @@ DeltaTriples::computeDeltaTripleDifference(
           .computeDeltaTripleDifference(
               oldState.getLocatedTriplesForPermutation<false>(
                   deltaPermutation));
-  auto [internaInsertions, internalDeletions] =
-      newState.getLocatedTriplesForPermutation<true>(deltaPermutation)
+  auto internalPermutation = Permutation::PSO;
+  auto [internalInsertions, internalDeletions] =
+      newState.getLocatedTriplesForPermutation<true>(internalPermutation)
           .computeDeltaTripleDifference(
-              oldState.getLocatedTriplesForPermutation<true>(deltaPermutation));
+              oldState.getLocatedTriplesForPermutation<true>(
+                  internalPermutation));
   return std::array{std::move(insertions), std::move(deletions),
-                    std::move(internaInsertions), std::move(internalDeletions)};
+                    std::move(internalInsertions),
+                    std::move(internalDeletions)};
 }

--- a/src/index/DeltaTriples.h
+++ b/src/index/DeltaTriples.h
@@ -17,6 +17,7 @@
 #include "global/IdTriple.h"
 #include "index/Index.h"
 #include "index/IndexBuilderTypes.h"
+#include "index/IndexRebuilderTypes.h"
 #include "index/LocalVocab.h"
 #include "index/LocatedTriples.h"
 #include "index/Permutation.h"
@@ -296,6 +297,14 @@ class DeltaTriples {
                             OwnedBlocksEntry>>
   copyLocalVocab() const;
 
+  void fillFromOldDeltaTriples(
+      const LocatedTriplesState& oldState, const LocatedTriplesState& newState,
+      const std::tuple<qlever::indexRebuilder::InsertionPositions,
+                       qlever::indexRebuilder::LocalVocabMapping,
+                       qlever::indexRebuilder::BlankNodeBlocks>& idMapping,
+      uint64_t minBlankNodeIndex, CancellationHandle cancellationHandle,
+      ad_utility::timer::TimeTracer& tracer);
+
  private:
   // The proper state according to the template parameter. This will either
   // return a reference to `triplesToHandlesInternal_` or
@@ -346,6 +355,10 @@ class DeltaTriples {
   template <bool isInternal>
   void eraseTripleInAllPermutations(
       typename TriplesToHandles<isInternal>::LocatedTripleHandles& handles);
+
+  // Compute which delta triples have been added since `oldState`.
+  static std::array<std::vector<IdTriple<0>>, 4> computeDeltaTripleDifference(
+      const LocatedTriplesState& oldState, const LocatedTriplesState& newState);
 
   friend class DeltaTriplesManager;
 };

--- a/src/index/DeltaTriples.h
+++ b/src/index/DeltaTriples.h
@@ -299,15 +299,20 @@ class DeltaTriples {
 
 #ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
   // Fill this `DeltaTriples` instance with the difference between `oldState`
-  // and `newState` and map the `Id`s to their new versions using the given
-  // `idMapping`.
+  // and `newState` from an "old" index and map the `Id`s to their new versions
+  // using the given `idMapping` to match the "new" index associated with this
+  // instance of `DeltaTriples`.
   void fillFromOldDeltaTriples(
       const LocatedTriplesState& oldState, const LocatedTriplesState& newState,
-      const std::tuple<qlever::indexRebuilder::InsertionPositions,
-                       qlever::indexRebuilder::LocalVocabMapping,
-                       qlever::indexRebuilder::BlankNodeBlocks>& idMapping,
+      const qlever::indexRebuilder::MappingInformation& idMapping,
       uint64_t minBlankNodeIndex, CancellationHandle cancellationHandle,
       ad_utility::timer::TimeTracer& tracer);
+
+ private:
+  // Helper function to perform the actual `Id` remapping where applicable.
+  static void remapId(
+      const qlever::indexRebuilder::MappingInformation& idMapping,
+      uint64_t minBlankNodeIndex, Id& id);
 #endif
 
  private:
@@ -361,11 +366,30 @@ class DeltaTriples {
   void eraseTripleInAllPermutations(
       typename TriplesToHandles<isInternal>::LocatedTripleHandles& handles);
 
+  class DeltaTripleDifference {
+    std::array<std::vector<IdTriple<0>>, 4> data_;
+
+   public:
+    DeltaTripleDifference(std::vector<IdTriple<0>> inserted,
+                          std::vector<IdTriple<0>> deleted,
+                          std::vector<IdTriple<0>> internalInserted,
+                          std::vector<IdTriple<0>> internalDeleted);
+
+    // Run `func` on all `Id` references contained in `data_`.
+    template <typename Func>
+    void remapIds(Func func);
+
+    // Provides access to the corresponding entry in `data_`.
+    template <bool isInternal, bool insertOrDelete>
+    std::vector<IdTriple<0>>& triples();
+  };
+
   // Compute which delta triples have been added since `oldState`.
-  static std::array<std::vector<IdTriple<0>>, 4> computeDeltaTripleDifference(
+  static DeltaTripleDifference computeDeltaTripleDifference(
       const LocatedTriplesState& oldState, const LocatedTriplesState& newState);
 
   friend class DeltaTriplesManager;
+  FRIEND_TEST(DeltaTriplesTest, remapId);
 };
 
 // This class synchronizes the access to a `DeltaTriples` object, thus avoiding

--- a/src/index/DeltaTriples.h
+++ b/src/index/DeltaTriples.h
@@ -297,6 +297,9 @@ class DeltaTriples {
                             OwnedBlocksEntry>>
   copyLocalVocab() const;
 
+  // Fill this `DeltaTriples` instance with the difference between `oldState`
+  // and `newState` and map the `Id`s to their new versions using the given
+  // `idMapping`.
   void fillFromOldDeltaTriples(
       const LocatedTriplesState& oldState, const LocatedTriplesState& newState,
       const std::tuple<qlever::indexRebuilder::InsertionPositions,

--- a/src/index/DeltaTriples.h
+++ b/src/index/DeltaTriples.h
@@ -298,21 +298,26 @@ class DeltaTriples {
   copyLocalVocab() const;
 
 #ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
-  // Fill this `DeltaTriples` instance with the difference between `oldState`
-  // and `newState` from an "old" index and map the `Id`s to their new versions
-  // using the given `idMapping` to match the "new" index associated with this
-  // instance of `DeltaTriples`.
+  // When you have built a new index and loaded it, which created this instance
+  // of `DeltaTriples`, you can call this function with the following arguments:
+  // `oldState`: The snapshot that was used to start the rebuild.
+  // `newState`: The snapshot of the old index of the current point in time.
+  // `idMapping`: The mapping produced by the rebuild process.
+  // Under these conditions this will fill this instance of `DeltaTriples` with
+  // just the triples that were added during the index build and map them to
+  // their proper ids in the new index.
   void fillFromOldDeltaTriples(
       const LocatedTriplesState& oldState, const LocatedTriplesState& newState,
       const qlever::indexRebuilder::MappingInformation& idMapping,
-      uint64_t minBlankNodeIndex, CancellationHandle cancellationHandle,
+      CancellationHandle cancellationHandle,
       ad_utility::timer::TimeTracer& tracer);
 
  private:
-  // Helper function to perform the actual `Id` remapping where applicable.
+  // Remap the id from the "old" index to the "new" index using the given
+  // `idMapping`. If the `Id` can't be remapped, this means that is was added
+  // after the mapping was created and will be left unchanged.
   static void remapId(
-      const qlever::indexRebuilder::MappingInformation& idMapping,
-      uint64_t minBlankNodeIndex, Id& id);
+      const qlever::indexRebuilder::MappingInformation& idMapping, Id& id);
 #endif
 
  private:
@@ -367,13 +372,11 @@ class DeltaTriples {
       typename TriplesToHandles<isInternal>::LocatedTripleHandles& handles);
 
   class DeltaTripleDifference {
-    std::array<std::vector<IdTriple<0>>, 4> data_;
+    std::array<Triples, 4> data_;
 
    public:
-    DeltaTripleDifference(std::vector<IdTriple<0>> inserted,
-                          std::vector<IdTriple<0>> deleted,
-                          std::vector<IdTriple<0>> internalInserted,
-                          std::vector<IdTriple<0>> internalDeleted);
+    DeltaTripleDifference(Triples inserted, Triples deleted,
+                          Triples internalInserted, Triples internalDeleted);
 
     // Run `func` on all `Id` references contained in `data_`.
     template <typename Func>
@@ -381,7 +384,7 @@ class DeltaTriples {
 
     // Provides access to the corresponding entry in `data_`.
     template <bool isInternal, bool insertOrDelete>
-    std::vector<IdTriple<0>>& triples();
+    Triples& triples();
   };
 
   // Compute which delta triples have been added since `oldState`.

--- a/src/index/DeltaTriples.h
+++ b/src/index/DeltaTriples.h
@@ -298,26 +298,21 @@ class DeltaTriples {
   copyLocalVocab() const;
 
 #ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
-  // When you have built a new index and loaded it, which created this instance
-  // of `DeltaTriples`, you can call this function with the following arguments:
-  // `oldState`: The snapshot that was used to start the rebuild.
-  // `newState`: The snapshot of the old index of the current point in time.
-  // `idMapping`: The mapping produced by the rebuild process.
-  // Under these conditions this will fill this instance of `DeltaTriples` with
-  // just the triples that were added during the index build and map them to
-  // their proper ids in the new index.
-  void fillFromOldDeltaTriples(
+  // Compute the diff between `oldState` (the snapshot used to start the index
+  // rebuild) and `newState` (the current snapshot), remap the IDs using
+  // `idMapping`, and add the resulting triples to this `DeltaTriples` instance.
+  void addFromSnapshotDiff(
       const LocatedTriplesState& oldState, const LocatedTriplesState& newState,
-      const qlever::indexRebuilder::MappingInformation& idMapping,
+      const qlever::indexRebuilder::IndexRebuildMapping& idMapping,
       CancellationHandle cancellationHandle,
       ad_utility::timer::TimeTracer& tracer);
 
  private:
-  // Remap the id from the "old" index to the "new" index using the given
-  // `idMapping`. If the `Id` can't be remapped, this means that is was added
+  // Remap the `Id` from the old index to the new index using the given
+  // `idMapping`. If the `Id` can't be remapped, this means that it was added
   // after the mapping was created and will be left unchanged.
   static void remapId(
-      const qlever::indexRebuilder::MappingInformation& idMapping, Id& id);
+      const qlever::indexRebuilder::IndexRebuildMapping& idMapping, Id& id);
 #endif
 
  private:
@@ -371,12 +366,14 @@ class DeltaTriples {
   void eraseTripleInAllPermutations(
       typename TriplesToHandles<isInternal>::LocatedTripleHandles& handles);
 
-  class DeltaTripleDifference {
+  // The difference between two `LocatedTriplesState` snapshots, split into
+  // inserted/deleted and internal/external triples.
+  class LocatedTriplesDiff {
     std::array<Triples, 4> data_;
 
    public:
-    DeltaTripleDifference(Triples inserted, Triples deleted,
-                          Triples internalInserted, Triples internalDeleted);
+    LocatedTriplesDiff(Triples inserted, Triples deleted,
+                       Triples internalInserted, Triples internalDeleted);
 
     // Run `func` on all `Id` references contained in `data_`.
     template <typename Func>
@@ -387,8 +384,9 @@ class DeltaTriples {
     Triples& triples();
   };
 
-  // Compute which delta triples have been added since `oldState`.
-  static DeltaTripleDifference computeDeltaTripleDifference(
+  // Compute which located triples are present in `newState` but not in
+  // `oldState`.
+  static LocatedTriplesDiff computeLocatedTriplesDiff(
       const LocatedTriplesState& oldState, const LocatedTriplesState& newState);
 
   friend class DeltaTriplesManager;

--- a/src/index/DeltaTriples.h
+++ b/src/index/DeltaTriples.h
@@ -297,6 +297,7 @@ class DeltaTriples {
                             OwnedBlocksEntry>>
   copyLocalVocab() const;
 
+#ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
   // Fill this `DeltaTriples` instance with the difference between `oldState`
   // and `newState` and map the `Id`s to their new versions using the given
   // `idMapping`.
@@ -307,6 +308,7 @@ class DeltaTriples {
                        qlever::indexRebuilder::BlankNodeBlocks>& idMapping,
       uint64_t minBlankNodeIndex, CancellationHandle cancellationHandle,
       ad_utility::timer::TimeTracer& tracer);
+#endif
 
  private:
   // The proper state according to the template parameter. This will either

--- a/src/index/IndexRebuilder.cpp
+++ b/src/index/IndexRebuilder.cpp
@@ -434,7 +434,7 @@ indexRebuilder::MappingInformation materializeToIndex(
 
 #undef REBUILD_LOG_INFO
   return {std::move(insertionPositions), std::move(localVocabMapping),
-          std::move(blankNodeBlocks)};
+          std::move(blankNodeBlocks), minBlankNodeIndex};
 }
 
 }  // namespace qlever

--- a/src/index/IndexRebuilder.cpp
+++ b/src/index/IndexRebuilder.cpp
@@ -343,7 +343,7 @@ boost::asio::awaitable<void> createPermutationWriterTask(
 
 // _____________________________________________________________________________
 namespace qlever {
-indexRebuilder::MappingInformation materializeToIndex(
+indexRebuilder::IndexRebuildMapping materializeToIndex(
     const IndexImpl& index, const std::string& newIndexName,
     const LocatedTriplesSharedState& locatedTriplesSharedState,
     const std::vector<LocalVocabIndex>& entries,

--- a/src/index/IndexRebuilder.cpp
+++ b/src/index/IndexRebuilder.cpp
@@ -343,9 +343,7 @@ boost::asio::awaitable<void> createPermutationWriterTask(
 
 // _____________________________________________________________________________
 namespace qlever {
-std::tuple<indexRebuilder::InsertionPositions,
-           indexRebuilder::LocalVocabMapping, indexRebuilder::BlankNodeBlocks>
-materializeToIndex(
+indexRebuilder::MappingInformation materializeToIndex(
     const IndexImpl& index, const std::string& newIndexName,
     const LocatedTriplesSharedState& locatedTriplesSharedState,
     const std::vector<LocalVocabIndex>& entries,
@@ -367,7 +365,7 @@ materializeToIndex(
   REBUILD_LOG_INFO << "Writing new vocabulary ..." << std::endl;
 
   auto blankNodeBlocks = flattenBlankNodeBlocks(ownedBlocks);
-  const auto& [insertionPositions, localVocabMapping] =
+  auto [insertionPositions, localVocabMapping] =
       materializeLocalVocab(entries, index.getVocab(), newIndexName);
 
   REBUILD_LOG_INFO << "Recomputing statistics ..." << std::endl;

--- a/src/index/IndexRebuilder.cpp
+++ b/src/index/IndexRebuilder.cpp
@@ -147,8 +147,9 @@ AD_ALWAYS_INLINE Id remapVocabId(Id original,
 }
 
 // _____________________________________________________________________________
-Id remapBlankNodeId(Id original, const BlankNodeBlocks& blankNodeBlocks,
-                    uint64_t minBlankNodeIndex) {
+std::optional<Id> tryRemapBlankNodeId(Id original,
+                                      const BlankNodeBlocks& blankNodeBlocks,
+                                      uint64_t minBlankNodeIndex) {
   AD_EXPENSIVE_CHECK(
       original.getDatatype() == Datatype::BlankNodeIndex,
       "Only ids resembling a blank node index can be remapped with this "
@@ -160,13 +161,24 @@ Id remapBlankNodeId(Id original, const BlankNodeBlocks& blankNodeBlocks,
   auto normalizedId = rawId - minBlankNodeIndex;
   auto blockIndex = normalizedId / ad_utility::BlankNodeManager::blockSize_;
   auto it = ql::ranges::lower_bound(blankNodeBlocks, blockIndex);
-  AD_EXPENSIVE_CHECK(it != blankNodeBlocks.end() && *it == blockIndex,
-                     "Could not find block index of blank node.");
+  if (it == blankNodeBlocks.end() || *it != blockIndex) {
+    return std::nullopt;
+  }
   auto relativeId = normalizedId % ad_utility::BlankNodeManager::blockSize_;
   auto blockOffset = ql::ranges::distance(blankNodeBlocks.begin(), it) *
                      ad_utility::BlankNodeManager::blockSize_;
   return Id::makeFromBlankNodeIndex(
       BlankNodeIndex::make(relativeId + blockOffset + minBlankNodeIndex));
+}
+
+// _____________________________________________________________________________
+Id remapBlankNodeId(Id original, const BlankNodeBlocks& blankNodeBlocks,
+                    uint64_t minBlankNodeIndex) {
+  auto value =
+      tryRemapBlankNodeId(original, blankNodeBlocks, minBlankNodeIndex);
+  AD_CORRECTNESS_CHECK(value.has_value(),
+                       "Could not find block index of blank node.");
+  return value.value();
 }
 
 // _____________________________________________________________________________
@@ -331,7 +343,9 @@ boost::asio::awaitable<void> createPermutationWriterTask(
 
 // _____________________________________________________________________________
 namespace qlever {
-void materializeToIndex(
+std::tuple<indexRebuilder::InsertionPositions,
+           indexRebuilder::LocalVocabMapping, indexRebuilder::BlankNodeBlocks>
+materializeToIndex(
     const IndexImpl& index, const std::string& newIndexName,
     const LocatedTriplesSharedState& locatedTriplesSharedState,
     const std::vector<LocalVocabIndex>& entries,
@@ -421,6 +435,8 @@ void materializeToIndex(
   REBUILD_LOG_INFO << "Index rebuild completed" << std::endl;
 
 #undef REBUILD_LOG_INFO
+  return {std::move(insertionPositions), std::move(localVocabMapping),
+          std::move(blankNodeBlocks)};
 }
 
 }  // namespace qlever

--- a/src/index/IndexRebuilder.h
+++ b/src/index/IndexRebuilder.h
@@ -55,9 +55,7 @@ Id remapBlankNodeId(Id original, const BlankNodeBlocks& blankNodeBlocks,
 // caller.
 // Return the datastructures used for mapping to be used in further
 // post-processing.
-std::tuple<indexRebuilder::InsertionPositions,
-           indexRebuilder::LocalVocabMapping, indexRebuilder::BlankNodeBlocks>
-materializeToIndex(
+indexRebuilder::MappingInformation materializeToIndex(
     const IndexImpl& index, const std::string& newIndexName,
     const LocatedTriplesSharedState& locatedTriplesSharedState,
     const std::vector<LocalVocabIndex>& entries,

--- a/src/index/IndexRebuilder.h
+++ b/src/index/IndexRebuilder.h
@@ -55,7 +55,7 @@ Id remapBlankNodeId(Id original, const BlankNodeBlocks& blankNodeBlocks,
 // caller.
 // Return the datastructures used for mapping to be used in further
 // post-processing.
-indexRebuilder::MappingInformation materializeToIndex(
+indexRebuilder::IndexRebuildMapping materializeToIndex(
     const IndexImpl& index, const std::string& newIndexName,
     const LocatedTriplesSharedState& locatedTriplesSharedState,
     const std::vector<LocalVocabIndex>& entries,

--- a/src/index/IndexRebuilder.h
+++ b/src/index/IndexRebuilder.h
@@ -10,16 +10,37 @@
 #ifndef QLEVER_SRC_INDEX_INDEXREBUILDER_H
 #define QLEVER_SRC_INDEX_INDEXREBUILDER_H
 
+#include <optional>
 #include <string>
 #include <vector>
 
 #include "global/IndexTypes.h"
 #include "index/DeltaTriples.h"
 #include "index/IndexImpl.h"
-#include "util/BlankNodeManager.h"
+#include "index/IndexRebuilderTypes.h"
 #include "util/CancellationHandle.h"
 
 namespace qlever {
+
+namespace indexRebuilder {
+
+// Map old vocab `Id`s to new vocab `Id`s according to the given
+// `insertionPositions`. This is the  most performance critical code of the
+// rebuild.
+Id remapVocabId(Id original, const InsertionPositions& insertionPositions);
+
+// Remaps a blank node `Id` to another blank node `Id` to reduce the gaps in the
+// id space left by random allocation of blank node ids. Return an empty
+// optional if the blank node cannot be remapped given the provided mapping.
+std::optional<Id> tryRemapBlankNodeId(Id original,
+                                      const BlankNodeBlocks& blankNodeBlocks,
+                                      uint64_t minBlankNodeIndex);
+
+// Remaps a blank node `Id` to another blank node `Id` to reduce the gaps in the
+// id space left by random allocation of blank node ids.
+Id remapBlankNodeId(Id original, const BlankNodeBlocks& blankNodeBlocks,
+                    uint64_t minBlankNodeIndex);
+}  // namespace indexRebuilder
 
 // Build a new index based on the existing state of the engine.
 // The new index will be written at the path specified by `newIndexName`.
@@ -32,13 +53,15 @@ namespace qlever {
 // `cancellationHandle` can be used to cancel the rebuild. In this case, the new
 // index will be left in an incomplete state and should be deleted by the
 // caller.
-void materializeToIndex(
+// Return the datastructures used for mapping to be used in further
+// post-processing.
+std::tuple<indexRebuilder::InsertionPositions,
+           indexRebuilder::LocalVocabMapping, indexRebuilder::BlankNodeBlocks>
+materializeToIndex(
     const IndexImpl& index, const std::string& newIndexName,
     const LocatedTriplesSharedState& locatedTriplesSharedState,
     const std::vector<LocalVocabIndex>& entries,
-    const std::vector<
-        ad_utility::BlankNodeManager::LocalBlankNodeManager::OwnedBlocksEntry>&
-        ownedBlocks,
+    const indexRebuilder::OwnedBlocks& ownedBlocks,
     const ad_utility::SharedCancellationHandle& cancellationHandle,
     const std::string& logFileName);
 

--- a/src/index/IndexRebuilderImpl.h
+++ b/src/index/IndexRebuilderImpl.h
@@ -10,6 +10,7 @@
 #ifndef QLEVER_SRC_INDEX_INDEXREBUILDERIMPL_H
 #define QLEVER_SRC_INDEX_INDEXREBUILDERIMPL_H
 
+#include <boost/asio/awaitable.hpp>
 #include <cstdint>
 #include <tuple>
 #include <utility>
@@ -18,18 +19,11 @@
 #include "engine/idTable/IdTable.h"
 #include "global/Id.h"
 #include "index/IndexRebuilder.h"
+#include "index/IndexRebuilderTypes.h"
 #include "util/CancellationHandle.h"
-#include "util/HashMap.h"
 #include "util/InputRangeUtils.h"
 
 namespace qlever::indexRebuilder {
-
-using OwnedBlocksEntry =
-    ad_utility::BlankNodeManager::LocalBlankNodeManager::OwnedBlocksEntry;
-using OwnedBlocks = std::vector<OwnedBlocksEntry>;
-using InsertionPositions = std::vector<VocabIndex>;
-using LocalVocabMapping = ad_utility::HashMap<Id::T, Id>;
-using BlankNodeBlocks = std::vector<uint64_t>;
 
 // Write a new vocabulary that contains all words from `vocab` plus all
 // entries in `entries`. Returns a pair consisting of a vector insertion
@@ -43,16 +37,6 @@ std::tuple<InsertionPositions, LocalVocabMapping> materializeLocalVocab(
 // Turn a vector of `OwnedBlocksEntry`s into a vector of `uint64_t`s
 // representing the block ids of the generated blocks.
 BlankNodeBlocks flattenBlankNodeBlocks(const OwnedBlocks& ownedBlocks);
-
-// Map old vocab `Id`s to new vocab `Id`s according to the given
-// `insertionPositions`. This is the  most performance critical code of the
-// rebuild.
-Id remapVocabId(Id original, const InsertionPositions& insertionPositions);
-
-// Remaps a blank node `Id` to another blank node `Id` to reduce the gaps in the
-// id space left by random allocation of blank node ids.
-Id remapBlankNodeId(Id original, const BlankNodeBlocks& blankNodeBlocks,
-                    uint64_t minBlankNodeIndex);
 
 // Create a copy of the given `permutation` scanned according to `scanSpec`,
 // where all local vocab `Id`s are remapped according to `localVocabMapping`

--- a/src/index/IndexRebuilderTypes.h
+++ b/src/index/IndexRebuilderTypes.h
@@ -21,6 +21,12 @@ using OwnedBlocks = std::vector<OwnedBlocksEntry>;
 using InsertionPositions = std::vector<VocabIndex>;
 using LocalVocabMapping = ad_utility::HashMap<Id::T, Id>;
 using BlankNodeBlocks = std::vector<uint64_t>;
+
+struct MappingInformation {
+  InsertionPositions insertionPositions_;
+  LocalVocabMapping localVocabMapping_;
+  BlankNodeBlocks blankNodeBlocks_;
+};
 }  // namespace qlever::indexRebuilder
 
 #endif  // QLEVER_SRC_INDEX_INDEXREBUILDERTYPES_H

--- a/src/index/IndexRebuilderTypes.h
+++ b/src/index/IndexRebuilderTypes.h
@@ -22,8 +22,9 @@ using InsertionPositions = std::vector<VocabIndex>;
 using LocalVocabMapping = ad_utility::HashMap<Id::T, Id>;
 using BlankNodeBlocks = std::vector<uint64_t>;
 
-// Helper struct that groups together data required to map ids to a new index.
-struct MappingInformation {
+// Helper struct that groups together the data required to remap IDs from the
+// old index to the new index after a rebuild.
+struct IndexRebuildMapping {
   InsertionPositions insertionPositions_;
   LocalVocabMapping localVocabMapping_;
   BlankNodeBlocks blankNodeBlocks_;

--- a/src/index/IndexRebuilderTypes.h
+++ b/src/index/IndexRebuilderTypes.h
@@ -22,10 +22,12 @@ using InsertionPositions = std::vector<VocabIndex>;
 using LocalVocabMapping = ad_utility::HashMap<Id::T, Id>;
 using BlankNodeBlocks = std::vector<uint64_t>;
 
+// Helper struct that groups together data required to map ids to a new index.
 struct MappingInformation {
   InsertionPositions insertionPositions_;
   LocalVocabMapping localVocabMapping_;
   BlankNodeBlocks blankNodeBlocks_;
+  uint64_t minBlankNodeIndex_;
 };
 }  // namespace qlever::indexRebuilder
 

--- a/src/index/IndexRebuilderTypes.h
+++ b/src/index/IndexRebuilderTypes.h
@@ -1,0 +1,26 @@
+//  Copyright 2026 The QLever Authors, in particular:
+//
+//  2026 Robin Textor-Falconi <textorr@informatik.uni-freiburg.de>, UFR
+//
+//  UFR = University of Freiburg, Chair of Algorithms and Data Structures
+
+#ifndef QLEVER_SRC_INDEX_INDEXREBUILDERTYPES_H
+#define QLEVER_SRC_INDEX_INDEXREBUILDERTYPES_H
+
+#include <vector>
+
+#include "global/Id.h"
+#include "global/IndexTypes.h"
+#include "util/BlankNodeManager.h"
+#include "util/HashMap.h"
+
+namespace qlever::indexRebuilder {
+using OwnedBlocksEntry =
+    ad_utility::BlankNodeManager::LocalBlankNodeManager::OwnedBlocksEntry;
+using OwnedBlocks = std::vector<OwnedBlocksEntry>;
+using InsertionPositions = std::vector<VocabIndex>;
+using LocalVocabMapping = ad_utility::HashMap<Id::T, Id>;
+using BlankNodeBlocks = std::vector<uint64_t>;
+}  // namespace qlever::indexRebuilder
+
+#endif  // QLEVER_SRC_INDEX_INDEXREBUILDERTYPES_H

--- a/src/index/LocatedTriples.cpp
+++ b/src/index/LocatedTriples.cpp
@@ -533,6 +533,9 @@ LocatedTriplesPerBlock::computeDeltaTripleDifference(
           }
         });
   }
+  // Account for non-deterministic order introduced by hash map. (Or in case a
+  // permutation that is not SPO was used).
+  ql::ranges::for_each(result, ql::ranges::sort);
 
   return result;
 }

--- a/src/index/LocatedTriples.cpp
+++ b/src/index/LocatedTriples.cpp
@@ -511,3 +511,28 @@ bool LocatedTriplesPerBlock::isLocatedTriple(const IdTriple<0>& triple,
     return blockContains(block, index);
   });
 }
+
+// _____________________________________________________________________________
+std::array<std::vector<IdTriple<0>>, 2>
+LocatedTriplesPerBlock::computeDeltaTripleDifference(
+    const LocatedTriplesPerBlock& oldBlocks) const {
+  std::array<std::vector<IdTriple<0>>, 2> result;
+  auto addTriple = [&result](const IdTriple<0>& triple, bool insertion) {
+    result.at(insertion ? 0 : 1).push_back(triple);
+  };
+
+  for (const auto& [blockIndex, locatedTriples] : map_) {
+    auto it = oldBlocks.map_.find(blockIndex);
+    LocatedTriples empty;
+    const auto& set = it != oldBlocks.map_.end() ? it->second : empty;
+    ql::ranges::for_each(
+        locatedTriples, [&addTriple, &set](const LocatedTriple& lt) {
+          auto it = set.find(lt);
+          if (it == set.end() || it->insertOrDelete_ != lt.insertOrDelete_) {
+            addTriple(lt.triple_, lt.insertOrDelete_);
+          }
+        });
+  }
+
+  return result;
+}

--- a/src/index/LocatedTriples.cpp
+++ b/src/index/LocatedTriples.cpp
@@ -513,8 +513,7 @@ bool LocatedTriplesPerBlock::isLocatedTriple(const IdTriple<0>& triple,
 }
 
 // _____________________________________________________________________________
-std::array<std::vector<IdTriple<0>>, 2>
-LocatedTriplesPerBlock::computeDeltaTripleDifference(
+std::array<std::vector<IdTriple<0>>, 2> LocatedTriplesPerBlock::computeDiff(
     const LocatedTriplesPerBlock& oldBlocks) const {
   std::array<std::vector<IdTriple<0>>, 2> result;
   auto addTriple = [&result](const IdTriple<0>& triple, bool insertion) {

--- a/src/index/LocatedTriples.h
+++ b/src/index/LocatedTriples.h
@@ -267,6 +267,9 @@ class LocatedTriplesPerBlock {
   // containment in each. It is only used in our tests, for convenience.
   bool isLocatedTriple(const IdTriple<0>& triple, bool insertOrDelete) const;
 
+  std::array<std::vector<IdTriple<0>>, 2> computeDeltaTripleDifference(
+      const LocatedTriplesPerBlock& oldBlocks) const;
+
   // This operator is only for debugging and testing. It returns a
   // human-readable representation.
   friend std::ostream& operator<<(std::ostream& os,

--- a/src/index/LocatedTriples.h
+++ b/src/index/LocatedTriples.h
@@ -267,10 +267,10 @@ class LocatedTriplesPerBlock {
   // containment in each. It is only used in our tests, for convenience.
   bool isLocatedTriple(const IdTriple<0>& triple, bool insertOrDelete) const;
 
-  // Compute the inserted + deleted triples that are present in this
-  // `LocatedTriplesPerBlock` instance, but not in `oldBlocks`. The resulting
-  // vectors are always sorted in SPO order.
-  std::array<std::vector<IdTriple<0>>, 2> computeDeltaTripleDifference(
+  // Compute the located triples that are present in this
+  // `LocatedTriplesPerBlock` instance but not in `oldBlocks`. The result is a
+  // pair of vectors (insertions, deletions), each sorted in SPO order.
+  std::array<std::vector<IdTriple<0>>, 2> computeDiff(
       const LocatedTriplesPerBlock& oldBlocks) const;
 
   // This operator is only for debugging and testing. It returns a

--- a/src/index/LocatedTriples.h
+++ b/src/index/LocatedTriples.h
@@ -267,6 +267,9 @@ class LocatedTriplesPerBlock {
   // containment in each. It is only used in our tests, for convenience.
   bool isLocatedTriple(const IdTriple<0>& triple, bool insertOrDelete) const;
 
+  // Compute the inserted + deleted triples that are present in this
+  // `LocatedTriplesPerBlock` instance, but not in `oldBlocks`. The resulting
+  // vectors are always sorted in SPO order.
   std::array<std::vector<IdTriple<0>>, 2> computeDeltaTripleDifference(
       const LocatedTriplesPerBlock& oldBlocks) const;
 

--- a/test/DeltaTriplesTest.cpp
+++ b/test/DeltaTriplesTest.cpp
@@ -1064,7 +1064,7 @@ TEST_F(DeltaTriplesTest, remapId) {
   auto I = &Id::makeFromInt;
   auto V = &makeVocabId;
   auto B = &makeBlankNodeId;
-  qlever::indexRebuilder::MappingInformation idMapping;
+  qlever::indexRebuilder::IndexRebuildMapping idMapping;
   Id entryId = makeLocalVocabId(10101010);
   auto remap = [&idMapping](Id id) {
     DeltaTriples::remapId(idMapping, id);
@@ -1093,13 +1093,13 @@ TEST_F(DeltaTriplesTest, remapId) {
 #ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
 
 namespace {
-qlever::indexRebuilder::MappingInformation simulateRebuild(
+qlever::indexRebuilder::IndexRebuildMapping simulateRebuild(
     const std::vector<LocalVocabIndex>& originalVocab,
     const std::vector<
         ad_utility::BlankNodeManager::LocalBlankNodeManager::OwnedBlocksEntry>&
         blankNodeBlocks,
     uint64_t minBlankNodeIndex) {
-  qlever::indexRebuilder::MappingInformation idMapping;
+  qlever::indexRebuilder::IndexRebuildMapping idMapping;
   Id firstNewEntry =
       Id::fromBits(originalVocab.at(0)->positionInVocab().upperBound_.get());
   Id secondNewEntry =
@@ -1122,7 +1122,7 @@ qlever::indexRebuilder::MappingInformation simulateRebuild(
 }  // namespace
 
 // _____________________________________________________________________________
-TEST_F(DeltaTriplesTest, fillFromOldDeltaTriples) {
+TEST_F(DeltaTriplesTest, addFromSnapshotDiff) {
   auto cancellationHandle =
       std::make_shared<ad_utility::CancellationHandle<>>();
   DeltaTriples deltaTriples(testQec->getIndex());
@@ -1164,13 +1164,13 @@ TEST_F(DeltaTriplesTest, fillFromOldDeltaTriples) {
   // Technically you'd use a rebuilt index for this, but for testing the
   // existing one suffices.
   DeltaTriples newDeltaTriples(testQec->getIndex());
-  ad_utility::timer::TimeTracer tracer{"testFillFromOldDeltaTriples"};
-  qlever::indexRebuilder::MappingInformation idMapping = simulateRebuild(
+  ad_utility::timer::TimeTracer tracer{"testAddFromSnapshotDiff"};
+  qlever::indexRebuilder::IndexRebuildMapping idMapping = simulateRebuild(
       originalVocab, blankNodeBlocks, index.getBlankNodeManager()->minIndex_);
 
-  newDeltaTriples.fillFromOldDeltaTriples(
-      *originalSnapshot, *newSnapshot, idMapping, std::move(cancellationHandle),
-      tracer);
+  newDeltaTriples.addFromSnapshotDiff(*originalSnapshot, *newSnapshot,
+                                      idMapping, std::move(cancellationHandle),
+                                      tracer);
 
   EXPECT_THAT(newDeltaTriples, NumTriples(2, 1, 3, 2, 0));
   auto locatedTriples =

--- a/test/DeltaTriplesTest.cpp
+++ b/test/DeltaTriplesTest.cpp
@@ -1048,3 +1048,134 @@ TEST_F(DeltaTriplesTest, vacuum) {
   EXPECT_EQ(result["internal"]["totalRemoved"], 0);
   EXPECT_EQ(result["internal"]["totalKept"], 0);
 }
+
+// _____________________________________________________________________________
+TEST_F(DeltaTriplesTest, fillFromOldDeltaTriples) {
+  auto cancellationHandle =
+      std::make_shared<ad_utility::CancellationHandle<>>();
+  DeltaTriples deltaTriples(testQec->getIndex());
+  auto& index = testQec->getIndex();
+  auto getId = ad_utility::testing::makeGetId(index);
+  LocalVocab localVocab;
+
+  Id x = getId("<x>");
+  Id anon = getId("<anon>");
+  Id graph = getId(std::string{DEFAULT_GRAPH_IRI});
+
+  deltaTriples.insertTriples(
+      cancellationHandle,
+      makeIdTriples(index, localVocab,
+                    {"<a> <upp> <newval>", "<anon> <x> 42", "<C> <next> <D>"}));
+  deltaTriples.insertTriples(
+      cancellationHandle,
+      {IdTriple<0>{std::array{
+          x, anon, Id::makeFromBlankNodeIndex(BlankNodeIndex::make(1337)),
+          graph}}});
+  deltaTriples.deleteTriples(
+      cancellationHandle, makeIdTriples(index, localVocab, {"<a> <next> <b>"}));
+
+  auto originalSnapshot = deltaTriples.getLocatedTriplesSharedStateCopy();
+  auto [originalVocab, blankNodeBlocks] = deltaTriples.copyLocalVocab();
+  ASSERT_EQ(originalVocab.size(), 2);
+  ASSERT_EQ(blankNodeBlocks.size(), 1);
+  ASSERT_EQ(blankNodeBlocks.at(0).blockIndices_.size(), 1);
+
+  // Simulate delta triples being inserted after the rebuild.
+  deltaTriples.insertTriples(
+      cancellationHandle,
+      makeIdTriples(index, localVocab, {"<anon> <x> \"neverseenbefore\"@en"}));
+  deltaTriples.insertTriples(
+      cancellationHandle,
+      {IdTriple<0>{std::array{
+          anon, x, Id::makeFromBlankNodeIndex(BlankNodeIndex::make(1338)),
+          graph}}});
+  deltaTriples.deleteTriples(
+      cancellationHandle, makeIdTriples(index, localVocab, {"<C> <next> <D>"}));
+  auto newSnapshot = deltaTriples.getLocatedTriplesSharedStateCopy();
+
+  // Technically you'd use a rebuilt index for this, but for testing the
+  // existing one suffices.
+  DeltaTriples newDeltaTriples(testQec->getIndex());
+  ad_utility::timer::TimeTracer tracer{"testFillFromOldDeltaTriples"};
+  std::tuple<qlever::indexRebuilder::InsertionPositions,
+             qlever::indexRebuilder::LocalVocabMapping,
+             qlever::indexRebuilder::BlankNodeBlocks>
+      idMapping;
+
+  Id firstNewEntry =
+      Id::fromBits(originalVocab.at(0)->positionInVocab().upperBound_.get());
+  Id secondNewEntry =
+      Id::fromBits(originalVocab.at(1)->positionInVocab().upperBound_.get());
+
+  std::get<0>(idMapping).push_back(firstNewEntry.getVocabIndex());
+  std::get<0>(idMapping).push_back(secondNewEntry.getVocabIndex());
+  ql::ranges::sort(std::get<0>(idMapping));
+  std::get<1>(idMapping).emplace(
+      Id::makeFromLocalVocabIndex(originalVocab.at(0)).getBits(),
+      firstNewEntry);
+  std::get<1>(idMapping).emplace(
+      Id::makeFromLocalVocabIndex(originalVocab.at(1)).getBits(),
+      secondNewEntry);
+  std::get<2>(idMapping).emplace_back(
+      blankNodeBlocks.at(0).blockIndices_.at(0));
+
+  newDeltaTriples.fillFromOldDeltaTriples(
+      *originalSnapshot, *newSnapshot, idMapping,
+      index.getBlankNodeManager()->minIndex_, std::move(cancellationHandle),
+      tracer);
+
+  EXPECT_THAT(newDeltaTriples, NumTriples(2, 1, 3, 2, 0));
+  auto locatedTriples =
+      newDeltaTriples.getLocatedTriplesForPermutation(Permutation::SPO);
+  std::vector<IdTriple<0>> insertedTriples;
+  insertedTriples.reserve(locatedTriples.numTriples());
+
+  for (size_t counter = 0; insertedTriples.size() < locatedTriples.numTriples();
+       counter++) {
+    auto updates = locatedTriples.getUpdatesIfPresent(counter);
+    if (updates.has_value()) {
+      for (const auto& locatedTriple : updates.value()) {
+        insertedTriples.push_back(locatedTriple.triple_);
+      }
+    }
+
+    ASSERT_LT(counter, 1000)
+        << "This is to prevent an infinite loop in case of a bug.";
+  }
+
+  // Account for offset introduced by index rebuild.
+  auto add = [](Id id, size_t offset) {
+    AD_CONTRACT_CHECK(id.getDatatype() == Datatype::VocabIndex);
+    return Id::makeFromVocabIndex(
+        VocabIndex::make(id.getVocabIndex().get() + offset));
+  };
+
+  Id newX = add(x, 2);
+  Id newGraph = add(graph, 1);
+  Id newNext = add(getId("<next>"), 2);
+
+  ASSERT_EQ(insertedTriples.size(), 3);
+  EXPECT_THAT(insertedTriples.at(0).ids(),
+              ::testing::ElementsAre(
+                  anon, newX,
+                  AD_PROPERTY(ValueId, getDatatype,
+                              ::testing::Eq(Datatype::LocalVocabIndex)),
+                  newGraph));
+  EXPECT_THAT(insertedTriples.at(1).ids(),
+              ::testing::ElementsAre(
+                  anon, newX,
+                  ::testing::ResultOf(
+                      [](Id id) {
+                        return id.getDatatype() == Datatype::BlankNodeIndex
+                                   ? id.getBlankNodeIndex().get()
+                                   : 0;
+                      },
+                      ::testing::Gt(2)),
+                  newGraph));
+  EXPECT_THAT(
+      insertedTriples.at(2).ids(),
+      ::testing::ElementsAre(getId("<C>"), newNext,
+                             AD_PROPERTY(ValueId, getDatatype,
+                                         ::testing::Eq(Datatype::VocabIndex)),
+                             newGraph));
+}

--- a/test/DeltaTriplesTest.cpp
+++ b/test/DeltaTriplesTest.cpp
@@ -1049,6 +1049,7 @@ TEST_F(DeltaTriplesTest, vacuum) {
   EXPECT_EQ(result["internal"]["totalKept"], 0);
 }
 
+#ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
 // _____________________________________________________________________________
 TEST_F(DeltaTriplesTest, fillFromOldDeltaTriples) {
   auto cancellationHandle =
@@ -1179,3 +1180,4 @@ TEST_F(DeltaTriplesTest, fillFromOldDeltaTriples) {
                                          ::testing::Eq(Datatype::VocabIndex)),
                              newGraph));
 }
+#endif

--- a/test/DeltaTriplesTest.cpp
+++ b/test/DeltaTriplesTest.cpp
@@ -13,6 +13,7 @@
 #include <gtest/gtest.h>
 
 #include "./DeltaTriplesTestHelpers.h"
+#include "./ValueIdTestHelpers.h"
 #include "./util/GTestHelpers.h"
 #include "./util/IndexTestHelpers.h"
 #include "./util/RuntimeParametersTestHelpers.h"
@@ -1051,54 +1052,33 @@ TEST_F(DeltaTriplesTest, vacuum) {
 
 // _____________________________________________________________________________
 TEST_F(DeltaTriplesTest, remapId) {
+  auto I = &Id::makeFromInt;
+  auto V = &makeVocabId;
+  auto B = &makeBlankNodeId;
   qlever::indexRebuilder::MappingInformation idMapping;
-  LocalVocabEntry entry{
-      ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
-          "<test>")};
-  Id id;
+  Id entryId = makeLocalVocabId(10101010);
+  auto remap = [&idMapping](Id id) {
+    DeltaTriples::remapId(idMapping, id);
+    return id;
+  };
 
-  id = Id::makeFromInt(69);
-  DeltaTriples::remapId(idMapping, 0, id);
-  EXPECT_EQ(id, Id::makeFromInt(69));
+  EXPECT_EQ(remap(I(69)), I(69));
+  EXPECT_EQ(remap(entryId), entryId);
+  idMapping.localVocabMapping_.emplace(entryId.getBits(), I(42));
+  EXPECT_EQ(remap(entryId), I(42));
 
-  id = Id::makeFromLocalVocabIndex(&entry);
-  DeltaTriples::remapId(idMapping, 0, id);
-  EXPECT_EQ(id, Id::makeFromLocalVocabIndex(&entry));
-
-  id = Id::makeFromLocalVocabIndex(&entry);
-  idMapping.localVocabMapping_.emplace(id.getBits(), Id::makeFromInt(42));
-  DeltaTriples::remapId(idMapping, 0, id);
-  EXPECT_EQ(id, Id::makeFromInt(42));
-
-  id = Id::makeFromBlankNodeIndex(BlankNodeIndex::make(1337));
-  DeltaTriples::remapId(idMapping, 0, id);
-  EXPECT_EQ(id, Id::makeFromBlankNodeIndex(BlankNodeIndex::make(1337)));
-
-  id = Id::makeFromBlankNodeIndex(BlankNodeIndex::make(1337));
+  idMapping.minBlankNodeIndex_ = 0;
+  EXPECT_EQ(remap(B(1337)), B(1337));
   idMapping.blankNodeBlocks_.push_back(1);
-  DeltaTriples::remapId(idMapping, 330, id);
-  EXPECT_EQ(id, Id::makeFromBlankNodeIndex(BlankNodeIndex::make(337)));
+  idMapping.minBlankNodeIndex_ = 330;
+  EXPECT_EQ(remap(B(1337)), B(337));
+  EXPECT_EQ(remap(B(37)), B(37));
 
-  id = Id::makeFromBlankNodeIndex(BlankNodeIndex::make(37));
-  DeltaTriples::remapId(idMapping, 330, id);
-  EXPECT_EQ(id, Id::makeFromBlankNodeIndex(BlankNodeIndex::make(37)));
-
-  id = Id::makeFromVocabIndex(VocabIndex::make(10));
-  DeltaTriples::remapId(idMapping, 0, id);
-  EXPECT_EQ(id, Id::makeFromVocabIndex(VocabIndex::make(10)));
-
-  id = Id::makeFromVocabIndex(VocabIndex::make(10));
+  EXPECT_EQ(remap(V(10)), V(10));
   idMapping.insertionPositions_.push_back(VocabIndex::make(5));
-  DeltaTriples::remapId(idMapping, 0, id);
-  EXPECT_EQ(id, Id::makeFromVocabIndex(VocabIndex::make(11)));
-
-  id = Id::makeFromVocabIndex(VocabIndex::make(5));
-  DeltaTriples::remapId(idMapping, 0, id);
-  EXPECT_EQ(id, Id::makeFromVocabIndex(VocabIndex::make(6)));
-
-  id = Id::makeFromVocabIndex(VocabIndex::make(4));
-  DeltaTriples::remapId(idMapping, 0, id);
-  EXPECT_EQ(id, Id::makeFromVocabIndex(VocabIndex::make(4)));
+  EXPECT_EQ(remap(V(10)), V(11));
+  EXPECT_EQ(remap(V(5)), V(6));
+  EXPECT_EQ(remap(V(4)), V(4));
 }
 
 #ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
@@ -1108,7 +1088,8 @@ qlever::indexRebuilder::MappingInformation simulateRebuild(
     const std::vector<LocalVocabIndex>& originalVocab,
     const std::vector<
         ad_utility::BlankNodeManager::LocalBlankNodeManager::OwnedBlocksEntry>&
-        blankNodeBlocks) {
+        blankNodeBlocks,
+    uint64_t minBlankNodeIndex) {
   qlever::indexRebuilder::MappingInformation idMapping;
   Id firstNewEntry =
       Id::fromBits(originalVocab.at(0)->positionInVocab().upperBound_.get());
@@ -1126,6 +1107,7 @@ qlever::indexRebuilder::MappingInformation simulateRebuild(
       secondNewEntry);
   idMapping.blankNodeBlocks_.emplace_back(
       blankNodeBlocks.at(0).blockIndices_.at(0));
+  idMapping.minBlankNodeIndex_ = minBlankNodeIndex;
   return idMapping;
 }
 }  // namespace
@@ -1149,9 +1131,7 @@ TEST_F(DeltaTriplesTest, fillFromOldDeltaTriples) {
                     {"<a> <upp> <newval>", "<anon> <x> 42", "<C> <next> <D>"}));
   deltaTriples.insertTriples(
       cancellationHandle,
-      {IdTriple<0>{std::array{
-          x, anon, Id::makeFromBlankNodeIndex(BlankNodeIndex::make(1337)),
-          graph}}});
+      {IdTriple<0>{std::array{x, anon, makeBlankNodeId(1337), graph}}});
   deltaTriples.deleteTriples(
       cancellationHandle, makeIdTriples(index, localVocab, {"<a> <next> <b>"}));
 
@@ -1167,9 +1147,7 @@ TEST_F(DeltaTriplesTest, fillFromOldDeltaTriples) {
       makeIdTriples(index, localVocab, {"<anon> <x> \"neverseenbefore\"@en"}));
   deltaTriples.insertTriples(
       cancellationHandle,
-      {IdTriple<0>{std::array{
-          anon, x, Id::makeFromBlankNodeIndex(BlankNodeIndex::make(1338)),
-          graph}}});
+      {IdTriple<0>{std::array{anon, x, makeBlankNodeId(1338), graph}}});
   deltaTriples.deleteTriples(
       cancellationHandle, makeIdTriples(index, localVocab, {"<C> <next> <D>"}));
   auto newSnapshot = deltaTriples.getLocatedTriplesSharedStateCopy();
@@ -1178,12 +1156,11 @@ TEST_F(DeltaTriplesTest, fillFromOldDeltaTriples) {
   // existing one suffices.
   DeltaTriples newDeltaTriples(testQec->getIndex());
   ad_utility::timer::TimeTracer tracer{"testFillFromOldDeltaTriples"};
-  qlever::indexRebuilder::MappingInformation idMapping =
-      simulateRebuild(originalVocab, blankNodeBlocks);
+  qlever::indexRebuilder::MappingInformation idMapping = simulateRebuild(
+      originalVocab, blankNodeBlocks, index.getBlankNodeManager()->minIndex_);
 
   newDeltaTriples.fillFromOldDeltaTriples(
-      *originalSnapshot, *newSnapshot, idMapping,
-      index.getBlankNodeManager()->minIndex_, std::move(cancellationHandle),
+      *originalSnapshot, *newSnapshot, idMapping, std::move(cancellationHandle),
       tracer);
 
   EXPECT_THAT(newDeltaTriples, NumTriples(2, 1, 3, 2, 0));

--- a/test/DeltaTriplesTest.cpp
+++ b/test/DeltaTriplesTest.cpp
@@ -1049,7 +1049,87 @@ TEST_F(DeltaTriplesTest, vacuum) {
   EXPECT_EQ(result["internal"]["totalKept"], 0);
 }
 
+// _____________________________________________________________________________
+TEST_F(DeltaTriplesTest, remapId) {
+  qlever::indexRebuilder::MappingInformation idMapping;
+  LocalVocabEntry entry{
+      ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
+          "<test>")};
+  Id id;
+
+  id = Id::makeFromInt(69);
+  DeltaTriples::remapId(idMapping, 0, id);
+  EXPECT_EQ(id, Id::makeFromInt(69));
+
+  id = Id::makeFromLocalVocabIndex(&entry);
+  DeltaTriples::remapId(idMapping, 0, id);
+  EXPECT_EQ(id, Id::makeFromLocalVocabIndex(&entry));
+
+  id = Id::makeFromLocalVocabIndex(&entry);
+  idMapping.localVocabMapping_.emplace(id.getBits(), Id::makeFromInt(42));
+  DeltaTriples::remapId(idMapping, 0, id);
+  EXPECT_EQ(id, Id::makeFromInt(42));
+
+  id = Id::makeFromBlankNodeIndex(BlankNodeIndex::make(1337));
+  DeltaTriples::remapId(idMapping, 0, id);
+  EXPECT_EQ(id, Id::makeFromBlankNodeIndex(BlankNodeIndex::make(1337)));
+
+  id = Id::makeFromBlankNodeIndex(BlankNodeIndex::make(1337));
+  idMapping.blankNodeBlocks_.push_back(1);
+  DeltaTriples::remapId(idMapping, 330, id);
+  EXPECT_EQ(id, Id::makeFromBlankNodeIndex(BlankNodeIndex::make(337)));
+
+  id = Id::makeFromBlankNodeIndex(BlankNodeIndex::make(37));
+  DeltaTriples::remapId(idMapping, 330, id);
+  EXPECT_EQ(id, Id::makeFromBlankNodeIndex(BlankNodeIndex::make(37)));
+
+  id = Id::makeFromVocabIndex(VocabIndex::make(10));
+  DeltaTriples::remapId(idMapping, 0, id);
+  EXPECT_EQ(id, Id::makeFromVocabIndex(VocabIndex::make(10)));
+
+  id = Id::makeFromVocabIndex(VocabIndex::make(10));
+  idMapping.insertionPositions_.push_back(VocabIndex::make(5));
+  DeltaTriples::remapId(idMapping, 0, id);
+  EXPECT_EQ(id, Id::makeFromVocabIndex(VocabIndex::make(11)));
+
+  id = Id::makeFromVocabIndex(VocabIndex::make(5));
+  DeltaTriples::remapId(idMapping, 0, id);
+  EXPECT_EQ(id, Id::makeFromVocabIndex(VocabIndex::make(6)));
+
+  id = Id::makeFromVocabIndex(VocabIndex::make(4));
+  DeltaTriples::remapId(idMapping, 0, id);
+  EXPECT_EQ(id, Id::makeFromVocabIndex(VocabIndex::make(4)));
+}
+
 #ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
+
+namespace {
+qlever::indexRebuilder::MappingInformation simulateRebuild(
+    const std::vector<LocalVocabIndex>& originalVocab,
+    const std::vector<
+        ad_utility::BlankNodeManager::LocalBlankNodeManager::OwnedBlocksEntry>&
+        blankNodeBlocks) {
+  qlever::indexRebuilder::MappingInformation idMapping;
+  Id firstNewEntry =
+      Id::fromBits(originalVocab.at(0)->positionInVocab().upperBound_.get());
+  Id secondNewEntry =
+      Id::fromBits(originalVocab.at(1)->positionInVocab().upperBound_.get());
+
+  idMapping.insertionPositions_.push_back(firstNewEntry.getVocabIndex());
+  idMapping.insertionPositions_.push_back(secondNewEntry.getVocabIndex());
+  ql::ranges::sort(idMapping.insertionPositions_);
+  idMapping.localVocabMapping_.emplace(
+      Id::makeFromLocalVocabIndex(originalVocab.at(0)).getBits(),
+      firstNewEntry);
+  idMapping.localVocabMapping_.emplace(
+      Id::makeFromLocalVocabIndex(originalVocab.at(1)).getBits(),
+      secondNewEntry);
+  idMapping.blankNodeBlocks_.emplace_back(
+      blankNodeBlocks.at(0).blockIndices_.at(0));
+  return idMapping;
+}
+}  // namespace
+
 // _____________________________________________________________________________
 TEST_F(DeltaTriplesTest, fillFromOldDeltaTriples) {
   auto cancellationHandle =
@@ -1098,27 +1178,8 @@ TEST_F(DeltaTriplesTest, fillFromOldDeltaTriples) {
   // existing one suffices.
   DeltaTriples newDeltaTriples(testQec->getIndex());
   ad_utility::timer::TimeTracer tracer{"testFillFromOldDeltaTriples"};
-  std::tuple<qlever::indexRebuilder::InsertionPositions,
-             qlever::indexRebuilder::LocalVocabMapping,
-             qlever::indexRebuilder::BlankNodeBlocks>
-      idMapping;
-
-  Id firstNewEntry =
-      Id::fromBits(originalVocab.at(0)->positionInVocab().upperBound_.get());
-  Id secondNewEntry =
-      Id::fromBits(originalVocab.at(1)->positionInVocab().upperBound_.get());
-
-  std::get<0>(idMapping).push_back(firstNewEntry.getVocabIndex());
-  std::get<0>(idMapping).push_back(secondNewEntry.getVocabIndex());
-  ql::ranges::sort(std::get<0>(idMapping));
-  std::get<1>(idMapping).emplace(
-      Id::makeFromLocalVocabIndex(originalVocab.at(0)).getBits(),
-      firstNewEntry);
-  std::get<1>(idMapping).emplace(
-      Id::makeFromLocalVocabIndex(originalVocab.at(1)).getBits(),
-      secondNewEntry);
-  std::get<2>(idMapping).emplace_back(
-      blankNodeBlocks.at(0).blockIndices_.at(0));
+  qlever::indexRebuilder::MappingInformation idMapping =
+      simulateRebuild(originalVocab, blankNodeBlocks);
 
   newDeltaTriples.fillFromOldDeltaTriples(
       *originalSnapshot, *newSnapshot, idMapping,

--- a/test/LocatedTriplesTest.cpp
+++ b/test/LocatedTriplesTest.cpp
@@ -1068,3 +1068,36 @@ TEST_F(LocatedTriplesTest, identifyTriplesToVacuum) {
     EXPECT_EQ(result.stats_.numDeletionsKept_, 1u);
   }
 }
+
+// _____________________________________________________________________________
+TEST_F(LocatedTriplesTest, computeDeltaTripleDifference) {
+  auto I = &Id::makeFromInt;
+  std::vector<LocatedTriple> locatedTriples;
+  locatedTriples.push_back(
+      LocatedTriple{0, IdTriple<0>{std::array{I(0), I(0), I(0), I(0)}}, true});
+  locatedTriples.push_back(
+      LocatedTriple{0, IdTriple<0>{std::array{I(1), I(0), I(0), I(0)}}, true});
+  locatedTriples.push_back(
+      LocatedTriple{1, IdTriple<0>{std::array{I(2), I(0), I(0), I(0)}}, true});
+  locatedTriples.push_back(
+      LocatedTriple{1, IdTriple<0>{std::array{I(3), I(0), I(0), I(0)}}, false});
+
+  auto originalTriples = makeLocatedTriplesPerBlock(locatedTriples);
+  locatedTriples.at(0).insertOrDelete_ = false;
+  locatedTriples.at(3).insertOrDelete_ = true;
+  locatedTriples.push_back(
+      LocatedTriple{1, IdTriple<0>{std::array{I(3), I(1), I(0), I(0)}}, true});
+  locatedTriples.push_back(
+      LocatedTriple{2, IdTriple<0>{std::array{I(4), I(0), I(0), I(0)}}, false});
+
+  auto newTriples = makeLocatedTriplesPerBlock(locatedTriples);
+  auto result = newTriples.computeDeltaTripleDifference(originalTriples);
+  EXPECT_THAT(result,
+              ::testing::ElementsAre(
+                  ::testing::ElementsAre(
+                      IdTriple<0>{std::array{I(3), I(0), I(0), I(0)}},
+                      IdTriple<0>{std::array{I(3), I(1), I(0), I(0)}}),
+                  ::testing::ElementsAre(
+                      IdTriple<0>{std::array{I(0), I(0), I(0), I(0)}},
+                      IdTriple<0>{std::array{I(4), I(0), I(0), I(0)}})));
+}

--- a/test/LocatedTriplesTest.cpp
+++ b/test/LocatedTriplesTest.cpp
@@ -1070,7 +1070,7 @@ TEST_F(LocatedTriplesTest, identifyTriplesToVacuum) {
 }
 
 // _____________________________________________________________________________
-TEST_F(LocatedTriplesTest, computeDeltaTripleDifference) {
+TEST_F(LocatedTriplesTest, computeDiff) {
   auto I = &Id::makeFromInt;
   std::vector<LocatedTriple> locatedTriples;
   locatedTriples.push_back(
@@ -1091,7 +1091,7 @@ TEST_F(LocatedTriplesTest, computeDeltaTripleDifference) {
       LocatedTriple{2, IdTriple<0>{std::array{I(4), I(0), I(0), I(0)}}, false});
 
   auto newTriples = makeLocatedTriplesPerBlock(locatedTriples);
-  auto result = newTriples.computeDeltaTripleDifference(originalTriples);
+  auto result = newTriples.computeDiff(originalTriples);
   EXPECT_THAT(result,
               ::testing::ElementsAre(
                   ::testing::ElementsAre(


### PR DESCRIPTION
When rebuilding the index while the server is running with live updates, new delta triples may arrive between the start of the rebuild and its completion. This change adds the infrastructure to compute and carry over those "missed" delta triples to the new index. The core addition is `DeltaTriples::addFromSnapshotDiff`, which takes the snapshot used to start the rebuild (`oldState`), the current snapshot (`newState`), and the ID mapping produced by the rebuild. It computes the difference (triples added/deleted since the rebuild started), remaps their IDs from the old index to the new index, and inserts them into the new `DeltaTriples` instance