### PR TITLE
Simplify `mergeVocabulary` phase and remove memory spike

### DIFF
--- a/src/index/ConstantsIndexBuilding.h
+++ b/src/index/ConstantsIndexBuilding.h
@@ -36,13 +36,6 @@ inline std::atomic<size_t>& BUFFER_SIZE_JOIN_PATTERNS_WITH_OSP() {
   return value;
 }
 
-// When merging the vocabulary, this many finished words are buffered
-// before they are written to the output.
-inline std::atomic<size_t>& BATCH_SIZE_VOCABULARY_MERGE() {
-  static std::atomic<size_t> value = 10'000'000;
-  return value;
-}
-
 // When the BZIP2 parser encounters a parsing exception it will increase its
 // buffer and try again (we have no other way currently to determine if the
 // exception was "real" or only because we cut a statement in the middle. Once

--- a/src/index/VocabularyMerger.h
+++ b/src/index/VocabularyMerger.h
@@ -231,6 +231,8 @@ class VocabularyMerger {
       return entry_.iriOrLiteral();
     }
 
+    [[nodiscard]] std::string& iriOrLiteral() { return entry_.iriOrLiteral(); }
+
     [[nodiscard]] const auto& id() const { return entry_.index_; }
   };
 
@@ -250,7 +252,7 @@ class VocabularyMerger {
       requires WordCallback<C> CPP_and ranges::predicate<
           L, TripleComponentWithIndex, TripleComponentWithIndex>)
       // clang-format on
-      void writeQueueWordsToIdMap(const std::vector<QueueWord>& buffer,
+      void writeQueueWordsToIdMap(std::vector<QueueWord>& buffer,
                                   C& wordCallback, const L& lessThan,
                                   ad_utility::ProgressBar& progressBar);
 
@@ -261,12 +263,6 @@ class VocabularyMerger {
     lastTripleComponent_ = std::nullopt;
     idMaps_.clear();
   }
-
-  // Inner helper function for the parallel pipeline, which performs the actual
-  // write to the IdMaps. Format of argument is `<mapToWriteTo<internalId,
-  // globalId>>`.
-  void doActualWrite(
-      const std::vector<std::pair<size_t, std::pair<size_t, Id>>>& buffer);
 };
 
 // ____________________________________________________________________________

--- a/src/index/VocabularyMerger.h
+++ b/src/index/VocabularyMerger.h
@@ -194,8 +194,6 @@ class VocabularyMerger {
   // we will store pairs of <partialId, globalId>
   std::vector<IdMapWriter> idMaps_;
 
-  const size_t bufferSize_ = BATCH_SIZE_VOCABULARY_MERGE();
-
   // Friend declaration for the publicly available function.
   template <typename W, typename C>
   friend auto mergeVocabulary(const std::string& basename, size_t numFiles,

--- a/src/index/VocabularyMergerImpl.h
+++ b/src/index/VocabularyMergerImpl.h
@@ -88,11 +88,17 @@ auto VocabularyMerger::mergeVocabulary(const std::string& basename,
       ad_utility::parallelMultiwayMerge<QueueWord, true,
                                         decltype(sizeOfQueueWord)>(
           0.8 * memoryToUse, std::move(generators), lessThanForQueue);
+  // Only one asynchronous task to limit memory consumption.
+  ad_utility::TaskQueue<> wordWriter{1, 1};
   ad_utility::ProgressBar progressBar{metaData_.numWordsTotal(),
                                       "Words merged: "};
   for (std::vector<QueueWord>& currentWords : mergedWords) {
-    writeQueueWordsToIdMap(currentWords, wordCallback, lessThan, progressBar);
+    wordWriter.push([this, currentWords = std::move(currentWords),
+                     &wordCallback, &lessThan, &progressBar]() mutable {
+      writeQueueWordsToIdMap(currentWords, wordCallback, lessThan, progressBar);
+    });
   }
+  wordWriter.finish();
 
   AD_LOG_INFO << progressBar.getFinalProgressString() << std::flush;
 

--- a/src/index/VocabularyMergerImpl.h
+++ b/src/index/VocabularyMergerImpl.h
@@ -88,17 +88,11 @@ auto VocabularyMerger::mergeVocabulary(const std::string& basename,
       ad_utility::parallelMultiwayMerge<QueueWord, true,
                                         decltype(sizeOfQueueWord)>(
           0.8 * memoryToUse, std::move(generators), lessThanForQueue);
-  // Only one asynchronous task to limit memory consumption.
-  ad_utility::TaskQueue<> wordWriter{1, 1};
   ad_utility::ProgressBar progressBar{metaData_.numWordsTotal(),
                                       "Words merged: "};
   for (std::vector<QueueWord>& currentWords : mergedWords) {
-    wordWriter.push([this, currentWords = std::move(currentWords),
-                     &wordCallback, &lessThan, &progressBar]() mutable {
-      writeQueueWordsToIdMap(currentWords, wordCallback, lessThan, progressBar);
-    });
+    writeQueueWordsToIdMap(currentWords, wordCallback, lessThan, progressBar);
   }
-  wordWriter.finish();
 
   AD_LOG_INFO << progressBar.getFinalProgressString() << std::flush;
 

--- a/src/index/VocabularyMergerImpl.h
+++ b/src/index/VocabularyMergerImpl.h
@@ -80,9 +80,6 @@ auto VocabularyMerger::mergeVocabulary(const std::string& basename,
     idMaps_.emplace_back(absl::StrCat(basename, PARTIAL_VOCAB_IDMAP_INFIX, i));
   }
 
-  std::vector<QueueWord> sortedBuffer;
-  sortedBuffer.reserve(bufferSize_);
-
   // Some memory (that is hard to measure exactly) is used for the writing of
   // a batch of merged words, so we only give 80% of the total memory to the
   // merging. This is very approximate and should be investigated in more
@@ -93,21 +90,10 @@ auto VocabularyMerger::mergeVocabulary(const std::string& basename,
           0.8 * memoryToUse, std::move(generators), lessThanForQueue);
   ad_utility::ProgressBar progressBar{metaData_.numWordsTotal(),
                                       "Words merged: "};
-  for (QueueWord& currentWord : ql::views::join(mergedWords)) {
-    // Accumulate the globally ordered queue words in a buffer.
-    sortedBuffer.push_back(std::move(currentWord));
-
-    if (sortedBuffer.size() >= bufferSize_) {
-      writeQueueWordsToIdMap(sortedBuffer, wordCallback, lessThan, progressBar);
-      sortedBuffer.clear();
-      sortedBuffer.reserve(bufferSize_);
-    }
+  for (std::vector<QueueWord>& currentWords : mergedWords) {
+    writeQueueWordsToIdMap(currentWords, wordCallback, lessThan, progressBar);
   }
 
-  // Handle remaining words in the buffer
-  if (!sortedBuffer.empty()) {
-    writeQueueWordsToIdMap(sortedBuffer, wordCallback, lessThan, progressBar);
-  }
   AD_LOG_INFO << progressBar.getFinalProgressString() << std::flush;
 
   auto metaData = std::move(metaData_);

--- a/src/index/VocabularyMergerImpl.h
+++ b/src/index/VocabularyMergerImpl.h
@@ -83,8 +83,6 @@ auto VocabularyMerger::mergeVocabulary(const std::string& basename,
   std::vector<QueueWord> sortedBuffer;
   sortedBuffer.reserve(bufferSize_);
 
-  std::future<void> writeFuture;
-
   // Some memory (that is hard to measure exactly) is used for the writing of
   // a batch of merged words, so we only give 80% of the total memory to the
   // merging. This is very approximate and should be investigated in more
@@ -100,31 +98,10 @@ auto VocabularyMerger::mergeVocabulary(const std::string& basename,
     sortedBuffer.push_back(std::move(currentWord));
 
     if (sortedBuffer.size() >= bufferSize_) {
-      // Wait for the (asynchronous) writing of the last batch of words, and
-      // trigger the (again asynchronous) writing of the next batch.
-      auto writeTask = [this, buffer = std::move(sortedBuffer), &wordCallback,
-                        &lessThan, &progressBar]() {
-        this->writeQueueWordsToIdMap(buffer, wordCallback, lessThan,
-                                     progressBar);
-      };
+      writeQueueWordsToIdMap(sortedBuffer, wordCallback, lessThan, progressBar);
       sortedBuffer.clear();
       sortedBuffer.reserve(bufferSize_);
-      // wait for the last batch
-
-      AD_LOG_TIMING << "A new batch of words is ready" << std::endl;
-      // First wait for the last batch to finish, that way there will be no
-      // race conditions.
-      if (writeFuture.valid()) {
-        writeFuture.get();
-      }
-      writeFuture = std::async(writeTask);
-      // we have moved away our buffer, start over
     }
-  }
-
-  // wait for the active write tasks to finish
-  if (writeFuture.valid()) {
-    writeFuture.get();
   }
 
   // Handle remaining words in the buffer
@@ -144,16 +121,10 @@ CPP_template_def(typename C, typename L)(
     requires WordCallback<C> CPP_and_def
         ranges::predicate<L, TripleComponentWithIndex,
                           TripleComponentWithIndex>) void VocabularyMerger::
-    writeQueueWordsToIdMap(const std::vector<QueueWord>& buffer,
-                           C& wordCallback, const L& lessThan,
+    writeQueueWordsToIdMap(std::vector<QueueWord>& buffer, C& wordCallback,
+                           const L& lessThan,
                            ad_utility::ProgressBar& progressBar) {
   AD_LOG_TIMING << "Start writing a batch of merged words\n";
-
-  // Smaller grained buffer for the actual inner write.
-  auto bufSize = bufferSize_ / 5;
-  std::future<void> writeFut;
-  std::vector<std::pair<size_t, std::pair<size_t, Id>>> writeBuffer;
-  writeBuffer.reserve(bufSize);
 
   // Iterate (avoid duplicates).
   for (auto& top : buffer) {
@@ -165,8 +136,9 @@ CPP_template_def(typename C, typename L)(
                     << lastTripleComponent_->iriOrLiteral() << " and "
                     << top.iriOrLiteral() << std::endl;
       }
-      lastTripleComponent_ = TripleComponentWithIndex{
-          top.iriOrLiteral(), top.isExternal(), metaData_.numWordsTotal()};
+      lastTripleComponent_ =
+          TripleComponentWithIndex{std::move(top.iriOrLiteral()),
+                                   top.isExternal(), metaData_.numWordsTotal()};
 
       // TODO<optimization> If we aim to further speed this up, we could
       // order all the write requests to _outfile _externalOutfile and all the
@@ -179,7 +151,7 @@ CPP_template_def(typename C, typename L)(
       } else {
         nextWord.index_ =
             wordCallback(nextWord.iriOrLiteral(), nextWord.isExternal());
-        metaData_.addWord(top.iriOrLiteral(), nextWord.index_);
+        metaData_.addWord(nextWord.iriOrLiteral(), nextWord.index_);
       }
       if (progressBar.update()) {
         AD_LOG_INFO << progressBar.getProgressString() << std::flush;
@@ -196,36 +168,8 @@ CPP_template_def(typename C, typename L)(
             ? Id::makeFromBlankNodeIndex(BlankNodeIndex::make(word.index_))
             : Id::makeFromVocabIndex(VocabIndex::make(word.index_));
     // Write pair of local and global ID to buffer.
-    writeBuffer.emplace_back(top.partialFileId_, std::pair{top.id(), targetId});
-
-    if (writeBuffer.size() >= bufSize) {
-      auto task = [this, buffer = std::move(writeBuffer)]() {
-        this->doActualWrite(buffer);
-      };
-      if (writeFut.valid()) {
-        writeFut.get();
-      }
-      writeFut = std::async(task);
-      writeBuffer.clear();
-      writeBuffer.reserve(bufSize);
-    }
-  }
-
-  if (writeFut.valid()) {
-    writeFut.get();
-  }
-
-  if (!writeBuffer.empty()) {
-    doActualWrite(writeBuffer);
-  }
-}
-
-// ____________________________________________________________________________
-inline void VocabularyMerger::doActualWrite(
-    const std::vector<std::pair<size_t, std::pair<size_t, Id>>>& buffer) {
-  for (const auto& [id, value] : buffer) {
-    idMaps_[id].push_back(
-        {Id::makeFromVocabIndex(VocabIndex::make(value.first)), value.second});
+    idMaps_[top.partialFileId_].push_back(
+        {Id::makeFromVocabIndex(VocabIndex::make(top.id())), targetId});
   }
 }
 

--- a/test/util/IndexTestHelpers.cpp
+++ b/test/util/IndexTestHelpers.cpp
@@ -26,7 +26,6 @@ Index makeIndexWithTestSettings(ad_utility::MemorySize parserBufferSize) {
   // Decrease various default batch sizes such that there are multiple batches
   // also for the very small test indices (important for test coverage).
   BUFFER_SIZE_PARTIAL_TO_GLOBAL_ID_MAPPINGS() = 10;
-  BATCH_SIZE_VOCABULARY_MERGE() = 2;
   DEFAULT_PROGRESS_BAR_BATCH_SIZE = 2;
   index.memoryLimitIndexBuilding() = 50_MB;
   index.parserBufferSize() =


### PR DESCRIPTION
So far, `mergeVocabulary` accumulated merged words into a buffer of size `BATCH_SIZE_VOCABULARY_MERGE` (default 10M), then asynchronously wrote each batch with another layer of buffering and `std::async` writing. Now, the outer merge loop directly iterates over the blocks produced by the parallel multiway merge (`mergedWords`), and writes these blocks synchronously and without buffering. In particular, the 10M buffer is gone now, which partly fixes #2821; see the note below for the remaining part. While at it, improve and simplify the code in various other ways.

NOTE: Another reason for #2821 is that after the initial parsing phase, the memory for the `ItemMap`s (which map strings to `Id`s) is not released until after the vocabulary merging. This is trivial to fix, but a separate problem, so we fix it in another PR