### PR TITLE
Set `permutationWriterNumThreads` to 5 for index build

### DIFF
--- a/src/index/IndexBuilderMain.cpp
+++ b/src/index/IndexBuilderMain.cpp
@@ -16,6 +16,7 @@
 
 #include "CompilationInfo.h"
 #include "global/Constants.h"
+#include "global/RuntimeParameters.h"
 #include "index/ConstantsIndexBuilding.h"
 #include "libqlever/Qlever.h"
 #include "util/ProgramOptionsHelpers.h"
@@ -320,6 +321,10 @@ int main(int argc, char** argv) {
     config.writeMaterializedViews_ =
         parseMaterializedViewsJson(materializedViewsJson);
     config.validate();
+    // For index building, use more threads for writing permutations than the
+    // default (which is optimized for `rebuild-index`, where six permutations
+    // are written simultaneously).
+    setRuntimeParameter<&RuntimeParameters::permutationWriterNumThreads_>(5);
     qlever::Qlever::buildIndex(config);
   } catch (std::exception& e) {
     AD_LOG_ERROR << "Creating the index for QLever failed with the following "


### PR DESCRIPTION
https://github.com/ad-freiburg/qlever/pull/2696 introduced the runtime parameter `permutation-writer-num-threads` and set the default value from 10 to 2. This slowed down the index build by around 10%. This change sets this number of threads to 5 for the index build, which is only very marginally slower than the original 10