### PR TITLE
Add builtin function `ql:toEpoch`

### DIFF
--- a/src/engine/sparqlExpressions/DateExpressions.cpp
+++ b/src/engine/sparqlExpressions/DateExpressions.cpp
@@ -99,9 +99,25 @@ struct ExtractTimeComponentImpl {
 
 //______________________________________________________________________________
 #ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
-using ExtractEpoch =
-    ExtractTimeComponentImpl<&Date::toEpochInt, &Id::makeFromInt>;
+struct ExtractEpoch {
+  Id operator()(std::optional<DateYearOrDuration> d) const {
+    if (!d.has_value() || !d->isDate()) {
+      return Id::makeUndefined();
+    }
+    Date date = d.value().getDate();
+    if (!date.hasTime()) {
+      return Id::makeUndefined();
+    }
+    std::optional<int64_t> epoch = date.toEpochInt();
+    if (!epoch.has_value()) {
+      return Id::makeUndefined();
+    }
+    return Id::makeFromInt(epoch.value());
+  }
+};
 #endif
+
+//______________________________________________________________________________
 using ExtractHours = ExtractTimeComponentImpl<&Date::getHour, &Id::makeFromInt>;
 using ExtractMinutes =
     ExtractTimeComponentImpl<&Date::getMinute, &Id::makeFromInt>;

--- a/src/engine/sparqlExpressions/DateExpressions.cpp
+++ b/src/engine/sparqlExpressions/DateExpressions.cpp
@@ -114,7 +114,9 @@ struct ExtractEpoch {
     }
     return Id::makeFromInt(epoch.value());
 #else
-    throw std::runtime_error("This function is not supported for CPP17.");
+    throw std::runtime_error(
+        "This QLever server does not support ql:toEpoch because it was "
+        "compiled with the restricted feature set on C++ 17");
 #endif
   }
 };

--- a/src/engine/sparqlExpressions/DateExpressions.cpp
+++ b/src/engine/sparqlExpressions/DateExpressions.cpp
@@ -105,9 +105,7 @@ struct ExtractEpoch {
       return Id::makeUndefined();
     }
     Date date = d.value().getDate();
-    if (!date.hasTime()) {
-      return Id::makeUndefined();
-    }
+
     std::optional<int64_t> epoch = date.toEpochInt();
     if (!epoch.has_value()) {
       return Id::makeUndefined();

--- a/src/engine/sparqlExpressions/DateExpressions.cpp
+++ b/src/engine/sparqlExpressions/DateExpressions.cpp
@@ -98,8 +98,10 @@ struct ExtractTimeComponentImpl {
 };
 
 //______________________________________________________________________________
+#ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
 using ExtractEpoch =
     ExtractTimeComponentImpl<&Date::toEpochInt, &Id::makeFromInt>;
+#endif
 using ExtractHours = ExtractTimeComponentImpl<&Date::getHour, &Id::makeFromInt>;
 using ExtractMinutes =
     ExtractTimeComponentImpl<&Date::getMinute, &Id::makeFromInt>;
@@ -113,7 +115,9 @@ NARY_EXPRESSION(TimezoneStrExpression, 1,
                 FV<ExtractStrTimezone, DateValueGetter>);
 NARY_EXPRESSION(TimezoneDurationExpression, 1,
                 FV<ExtractTimezoneDurationFormat, DateValueGetter>);
+#ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
 NARY_EXPRESSION(ToEpochExpression, 1, FV<ExtractEpoch, DateValueGetter>);
+#endif
 NARY_EXPRESSION(HoursExpression, 1, FV<ExtractHours, DateValueGetter>);
 NARY_EXPRESSION(MinutesExpression, 1, FV<ExtractMinutes, DateValueGetter>);
 NARY_EXPRESSION(SecondsExpression, 1, FV<ExtractSeconds, DateValueGetter>);
@@ -152,9 +156,11 @@ SparqlExpression::Ptr makeTimezoneExpression(SparqlExpression::Ptr child) {
   return std::make_unique<TimezoneDurationExpression>(std::move(child));
 }
 
+#ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
 SparqlExpression::Ptr makeToEpochExpression(SparqlExpression::Ptr child) {
   return std::make_unique<ToEpochExpression>(std::move(child));
 }
+#endif
 
 SparqlExpression::Ptr makeMonthExpression(SparqlExpression::Ptr child) {
   return std::make_unique<MonthExpression>(std::move(child));

--- a/src/engine/sparqlExpressions/DateExpressions.cpp
+++ b/src/engine/sparqlExpressions/DateExpressions.cpp
@@ -114,7 +114,7 @@ struct ExtractEpoch {
     }
     return Id::makeFromInt(epoch.value());
 #else
-    throw std::runtime_error("This function is not supported for CPP17.")
+    throw std::runtime_error("This function is not supported for CPP17.");
 #endif
   }
 };

--- a/src/engine/sparqlExpressions/DateExpressions.cpp
+++ b/src/engine/sparqlExpressions/DateExpressions.cpp
@@ -98,9 +98,9 @@ struct ExtractTimeComponentImpl {
 };
 
 //______________________________________________________________________________
-#ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
 struct ExtractEpoch {
   Id operator()(std::optional<DateYearOrDuration> d) const {
+#ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
     if (!d.has_value() || !d->isDate()) {
       return Id::makeUndefined();
     }
@@ -113,9 +113,11 @@ struct ExtractEpoch {
       return Id::makeUndefined();
     }
     return Id::makeFromInt(epoch.value());
+#else
+    return Id::makeUndefined();
+#endif
   }
 };
-#endif
 
 //______________________________________________________________________________
 using ExtractHours = ExtractTimeComponentImpl<&Date::getHour, &Id::makeFromInt>;

--- a/src/engine/sparqlExpressions/DateExpressions.cpp
+++ b/src/engine/sparqlExpressions/DateExpressions.cpp
@@ -98,6 +98,8 @@ struct ExtractTimeComponentImpl {
 };
 
 //______________________________________________________________________________
+using ExtractEpoch =
+    ExtractTimeComponentImpl<&Date::toEpochInt, &Id::makeFromInt>;
 using ExtractHours = ExtractTimeComponentImpl<&Date::getHour, &Id::makeFromInt>;
 using ExtractMinutes =
     ExtractTimeComponentImpl<&Date::getMinute, &Id::makeFromInt>;
@@ -111,6 +113,7 @@ NARY_EXPRESSION(TimezoneStrExpression, 1,
                 FV<ExtractStrTimezone, DateValueGetter>);
 NARY_EXPRESSION(TimezoneDurationExpression, 1,
                 FV<ExtractTimezoneDurationFormat, DateValueGetter>);
+NARY_EXPRESSION(ToEpochExpression, 1, FV<ExtractEpoch, DateValueGetter>);
 NARY_EXPRESSION(HoursExpression, 1, FV<ExtractHours, DateValueGetter>);
 NARY_EXPRESSION(MinutesExpression, 1, FV<ExtractMinutes, DateValueGetter>);
 NARY_EXPRESSION(SecondsExpression, 1, FV<ExtractSeconds, DateValueGetter>);
@@ -147,6 +150,10 @@ SparqlExpression::Ptr makeTimezoneStrExpression(SparqlExpression::Ptr child) {
 
 SparqlExpression::Ptr makeTimezoneExpression(SparqlExpression::Ptr child) {
   return std::make_unique<TimezoneDurationExpression>(std::move(child));
+}
+
+SparqlExpression::Ptr makeToEpochExpression(SparqlExpression::Ptr child) {
+  return std::make_unique<ToEpochExpression>(std::move(child));
 }
 
 SparqlExpression::Ptr makeMonthExpression(SparqlExpression::Ptr child) {

--- a/src/engine/sparqlExpressions/DateExpressions.cpp
+++ b/src/engine/sparqlExpressions/DateExpressions.cpp
@@ -114,7 +114,7 @@ struct ExtractEpoch {
     }
     return Id::makeFromInt(epoch.value());
 #else
-    return Id::makeUndefined();
+    throw std::runtime_error("This function is not supported for CPP17.")
 #endif
   }
 };

--- a/src/engine/sparqlExpressions/DateExpressions.cpp
+++ b/src/engine/sparqlExpressions/DateExpressions.cpp
@@ -133,9 +133,7 @@ NARY_EXPRESSION(TimezoneStrExpression, 1,
                 FV<ExtractStrTimezone, DateValueGetter>);
 NARY_EXPRESSION(TimezoneDurationExpression, 1,
                 FV<ExtractTimezoneDurationFormat, DateValueGetter>);
-#ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
 NARY_EXPRESSION(ToEpochExpression, 1, FV<ExtractEpoch, DateValueGetter>);
-#endif
 NARY_EXPRESSION(HoursExpression, 1, FV<ExtractHours, DateValueGetter>);
 NARY_EXPRESSION(MinutesExpression, 1, FV<ExtractMinutes, DateValueGetter>);
 NARY_EXPRESSION(SecondsExpression, 1, FV<ExtractSeconds, DateValueGetter>);
@@ -174,11 +172,9 @@ SparqlExpression::Ptr makeTimezoneExpression(SparqlExpression::Ptr child) {
   return std::make_unique<TimezoneDurationExpression>(std::move(child));
 }
 
-#ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
 SparqlExpression::Ptr makeToEpochExpression(SparqlExpression::Ptr child) {
   return std::make_unique<ToEpochExpression>(std::move(child));
 }
-#endif
 
 SparqlExpression::Ptr makeMonthExpression(SparqlExpression::Ptr child) {
   return std::make_unique<MonthExpression>(std::move(child));

--- a/src/engine/sparqlExpressions/NaryExpression.h
+++ b/src/engine/sparqlExpressions/NaryExpression.h
@@ -96,6 +96,7 @@ SparqlExpression::Ptr makeHoursExpression(SparqlExpression::Ptr child);
 SparqlExpression::Ptr makeDayExpression(SparqlExpression::Ptr child);
 SparqlExpression::Ptr makeTimezoneStrExpression(SparqlExpression::Ptr child);
 SparqlExpression::Ptr makeTimezoneExpression(SparqlExpression::Ptr child);
+SparqlExpression::Ptr makeToEpochExpression(SparqlExpression::Ptr child);
 SparqlExpression::Ptr makeMonthExpression(SparqlExpression::Ptr child);
 SparqlExpression::Ptr makeYearExpression(SparqlExpression::Ptr child);
 

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -2698,6 +2698,8 @@ ExpressionPtr Visitor::visit(Parser::BuiltInCallContext* ctx) {
     return createUnary(&makeTimezoneStrExpression);
   } else if (functionName == "timezone") {
     return createUnary(&makeTimezoneExpression);
+  } else if (functionName == "to_epoch") {
+    return createUnary(&makeToEpochExpression);
   } else if (functionName == "now") {
     AD_CONTRACT_CHECK(argList.empty());
     return std::make_unique<NowDatetimeExpression>(startTime_);

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -294,17 +294,15 @@ ExpressionPtr Visitor::processIriFunctionCall(
   // QLever-internal functions.
   //
   // NOTE: Predicates like `ql:has-predicate` etc. are handled elsewhere.
-  static const UnaryFuncTable customGeoUnaryFuncs{
+  static const UnaryFuncTable unaryInternalFuncs{
       {"envelopeLowerLeft", &makeEnvelopeLowerLeftExpression},
       {"envelopeUpperRight", &makeEnvelopeUpperRightExpression},
+      {"isGeoPoint", &makeIsGeoPointExpression},
+      {"toEpoch", &makeToEpochExpression},
   };
   if (checkPrefix(QL_PREFIX)) {
-    if (functionName == "isGeoPoint") {
-      return createUnary(&makeIsGeoPointExpression);
-    } else if (ad_utility::contains(customGeoUnaryFuncs, functionName)) {
-      return createUnary(customGeoUnaryFuncs.at(functionName));
-    } else if (functionName == "toEpoch") {
-      return createUnary(&makeToEpochExpression);
+    if (ad_utility::contains(unaryInternalFuncs, functionName)) {
+      return createUnary(unaryInternalFuncs.at(functionName));
     } else if (functionName == "prefix-match") {
       return createBinary(&makePrefixMatchExpression);
     }

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -303,6 +303,8 @@ ExpressionPtr Visitor::processIriFunctionCall(
       return createUnary(&makeIsGeoPointExpression);
     } else if (ad_utility::contains(customGeoUnaryFuncs, functionName)) {
       return createUnary(customGeoUnaryFuncs.at(functionName));
+    } else if (functionName == "toEpoch") {
+      return createUnary(&makeToEpochExpression);
     } else if (functionName == "prefix-match") {
       return createBinary(&makePrefixMatchExpression);
     }
@@ -2698,8 +2700,6 @@ ExpressionPtr Visitor::visit(Parser::BuiltInCallContext* ctx) {
     return createUnary(&makeTimezoneStrExpression);
   } else if (functionName == "timezone") {
     return createUnary(&makeTimezoneExpression);
-  } else if (functionName == "to_epoch") {
-    return createUnary(&makeToEpochExpression);
   } else if (functionName == "now") {
     AD_CONTRACT_CHECK(argList.empty());
     return std::make_unique<NowDatetimeExpression>(startTime_);

--- a/src/util/Date.cpp
+++ b/src/util/Date.cpp
@@ -127,6 +127,20 @@ std::optional<Date::Nanoseconds> Date::toEpoch() const {
 }
 
 // _____________________________________________________________________________
+std::optional<int64_t> Date::toEpochInt() const {
+  std::optional<Date::Nanoseconds> result = toEpoch();
+  if (!result.has_value()) {
+    return std::nullopt;  // Invalid date.
+  } else {
+    // First convert the timepoint to its duration representation and then cast
+    // to total seconds.
+    return std::chrono::duration_cast<std::chrono::seconds>(
+               result.value().time_since_epoch())
+        .count();
+  }
+}
+
+// _____________________________________________________________________________
 Date Date::makeFromEpoch(Nanoseconds timestamp, TimeZone tz) {
   int8_t offset = Date::getTimeZoneOffsetToUTCInHours(tz);
   // Shift the timestamp according to the given `TimeZone`offset.
@@ -154,25 +168,6 @@ Date Date::makeFromEpoch(Nanoseconds timestamp, TimeZone tz) {
 }
 
 #endif
-
-// _____________________________________________________________________________
-int64_t Date::toEpochInt() const {
-#ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
-  std::optional<Date::Nanoseconds> result = toEpoch();
-  if (!result.has_value()) {
-    return -1;  // Invalid date.
-  } else {
-    // First convert the timepoint to its duration representation and then cast
-    // to total seconds.
-    return std::chrono::duration_cast<std::chrono::seconds>(
-               result.value().time_since_epoch())
-        .count();
-  }
-#else
-  // This method can not be used with CPP17.
-  return -1;
-#endif
-}
 
 // _____________________________________________________________________________
 int8_t Date::getTimeZoneOffsetToUTCInHours(TimeZone tz) {

--- a/src/util/Date.cpp
+++ b/src/util/Date.cpp
@@ -114,8 +114,11 @@ std::optional<Date::Nanoseconds> Date::toEpoch() const {
   if (date.ok()) {
     // Build timestamp from `Date`.
     auto second = duration<double>{getSecond()};
+    // If getHour returns -1 the date does not specify time, therefore just
+    // assume 0 hours.
+    auto hour = std::max(getHour(), 0);
     Date::Nanoseconds result =
-        sys_days(date) + hours{getHour() - getTimeZoneOffsetToUTCInHours()} +
+        sys_days(date) + hours{hour - getTimeZoneOffsetToUTCInHours()} +
         minutes{getMinute()} +
         duration_cast<nanoseconds>(
             second);  // Here all times are converted to a UTC time.

--- a/src/util/Date.cpp
+++ b/src/util/Date.cpp
@@ -127,20 +127,6 @@ std::optional<Date::Nanoseconds> Date::toEpoch() const {
 }
 
 // _____________________________________________________________________________
-int64_t Date::toEpochInt() const {
-  std::optional<Date::Nanoseconds> result = toEpoch();
-  if (!result.has_value()) {
-    return -1;  // Invalid date.
-  } else {
-    // First convert the timepoint to its duration representation and then cast
-    // to total seconds.
-    return std::chrono::duration_cast<std::chrono::seconds>(
-               result.value().time_since_epoch())
-        .count();
-  }
-}
-
-// _____________________________________________________________________________
 Date Date::makeFromEpoch(Nanoseconds timestamp, TimeZone tz) {
   int8_t offset = Date::getTimeZoneOffsetToUTCInHours(tz);
   // Shift the timestamp according to the given `TimeZone`offset.
@@ -168,6 +154,26 @@ Date Date::makeFromEpoch(Nanoseconds timestamp, TimeZone tz) {
 }
 
 #endif
+
+// _____________________________________________________________________________
+int64_t Date::toEpochInt() const {
+#ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
+  std::optional<Date::Nanoseconds> result = toEpoch();
+  if (!result.has_value()) {
+    return -1;  // Invalid date.
+  } else {
+    // First convert the timepoint to its duration representation and then cast
+    // to total seconds.
+    return std::chrono::duration_cast<std::chrono::seconds>(
+               result.value().time_since_epoch())
+        .count();
+  }
+#else
+  // This method can not be used with CPP17.
+  return -1;
+#endif
+}
+
 // _____________________________________________________________________________
 int8_t Date::getTimeZoneOffsetToUTCInHours(TimeZone tz) {
   // Handle different types contained in variant `TimeZone`.

--- a/src/util/Date.cpp
+++ b/src/util/Date.cpp
@@ -127,6 +127,20 @@ std::optional<Date::Nanoseconds> Date::toEpoch() const {
 }
 
 // _____________________________________________________________________________
+int64_t Date::toEpochInt() const {
+  std::optional<Date::Nanoseconds> result = toEpoch();
+  if (!result.has_value()) {
+    return -1;  // Invalid date.
+  } else {
+    // First convert the timepoint to its duration representation and then cast
+    // to total seconds.
+    return std::chrono::duration_cast<std::chrono::seconds>(
+               result.value().time_since_epoch())
+        .count();
+  }
+}
+
+// _____________________________________________________________________________
 Date Date::makeFromEpoch(Nanoseconds timestamp, TimeZone tz) {
   int8_t offset = Date::getTimeZoneOffsetToUTCInHours(tz);
   // Shift the timestamp according to the given `TimeZone`offset.

--- a/src/util/Date.h
+++ b/src/util/Date.h
@@ -352,6 +352,7 @@ class Date {
   // If `Date` is valid, convert it to Unix Epoch timestamp. ToEpoch always
   // returns a UTC timestamp.
   std::optional<Nanoseconds> toEpoch() const;
+  int64_t toEpochInt() const;
 
   // From a Unix Epoch timestamp, construct the corresponding `Date`.
   static Date makeFromEpoch(Nanoseconds timestamp, TimeZone tz);

--- a/src/util/Date.h
+++ b/src/util/Date.h
@@ -352,12 +352,12 @@ class Date {
   // If `Date` is valid, convert it to Unix Epoch timestamp. ToEpoch always
   // returns a UTC timestamp.
   std::optional<Nanoseconds> toEpoch() const;
+  // Uses `toEpoch` to return the Epoch time in seconds.
+  std::optional<int64_t> toEpochInt() const;
 
   // From a Unix Epoch timestamp, construct the corresponding `Date`.
   static Date makeFromEpoch(Nanoseconds timestamp, TimeZone tz);
 #endif
-  // Uses `toEpoch` to return the Epoch time in seconds.
-  int64_t toEpochInt() const;
 
   static int8_t getTimeZoneOffsetToUTCInHours(TimeZone tz);
   int8_t getTimeZoneOffsetToUTCInHours() const;

--- a/src/util/Date.h
+++ b/src/util/Date.h
@@ -352,11 +352,13 @@ class Date {
   // If `Date` is valid, convert it to Unix Epoch timestamp. ToEpoch always
   // returns a UTC timestamp.
   std::optional<Nanoseconds> toEpoch() const;
-  int64_t toEpochInt() const;
 
   // From a Unix Epoch timestamp, construct the corresponding `Date`.
   static Date makeFromEpoch(Nanoseconds timestamp, TimeZone tz);
 #endif
+  // Uses `toEpoch` to return the Epoch time in seconds.
+  int64_t toEpochInt() const;
+
   static int8_t getTimeZoneOffsetToUTCInHours(TimeZone tz);
   int8_t getTimeZoneOffsetToUTCInHours() const;
 };

--- a/test/DateYearDurationTest.cpp
+++ b/test/DateYearDurationTest.cpp
@@ -615,18 +615,16 @@ TEST(Date, Subtraction) {
 
 // _____________________________________________________________________________
 TEST(Date, toEpochInt) {
+  using namespace testing;
   Date date = Date(1970, 1, 1, 0, 0, 0);
   auto result = date.toEpochInt();
-  ASSERT_TRUE(result.has_value());
-  EXPECT_EQ(result.value(), 0);
+  EXPECT_THAT(result, Optional(Eq(0)));
   date = Date(1999, 1, 1, 10, 12, 0);
   result = date.toEpochInt();
-  ASSERT_TRUE(result.has_value());
-  EXPECT_EQ(result.value(), 915'185'520);
+  EXPECT_THAT(result, Optional(Eq(915'185'520)));
   date = Date(1949, 2, 11, 10, 12, 0);
   result = date.toEpochInt();
-  ASSERT_TRUE(result.has_value());
-  EXPECT_EQ(result.value(), -659'108'880);
+  EXPECT_THAT(result, Optional(Eq(-659'108'880)));
   // Invalid date
   date = Date(1998, 2, 30, 10, 12, 0);
   result = date.toEpochInt();

--- a/test/DateYearDurationTest.cpp
+++ b/test/DateYearDurationTest.cpp
@@ -616,11 +616,21 @@ TEST(Date, Subtraction) {
 // _____________________________________________________________________________
 TEST(Date, toEpochInt) {
   Date date = Date(1970, 1, 1, 0, 0, 0);
-  EXPECT_EQ(date.toEpochInt(), 0);
+  auto result = date.toEpochInt();
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), 0);
   date = Date(1999, 1, 1, 10, 12, 0);
-  EXPECT_EQ(date.toEpochInt(), 915'185'520);
+  result = date.toEpochInt();
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), 915'185'520);
   date = Date(1949, 2, 11, 10, 12, 0);
-  EXPECT_EQ(date.toEpochInt(), -659'108'880);
+  result = date.toEpochInt();
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), -659'108'880);
+  // Invalid date
+  date = Date(1998, 2, 30, 10, 12, 0);
+  result = date.toEpochInt();
+  ASSERT_FALSE(result.has_value());
 }
 
 // _____________________________________________________________________________

--- a/test/DateYearDurationTest.cpp
+++ b/test/DateYearDurationTest.cpp
@@ -614,6 +614,23 @@ TEST(Date, Subtraction) {
 #endif
 
 // _____________________________________________________________________________
+TEST(Date, toEpochInt) {
+#ifndef REDUCED_FEATURE_SET_FOR_CPP17
+  Date date = Date(1970, 1, 1, 0, 0, 0);
+  EXPECT_EQ(date.toEpochInt(), 0);
+  date = Date(1999, 1, 1, 10, 12, 0);
+  EXPECT_EQ(date.toEpochInt(), 915'185'520);
+  date = Date(1344, 2, 11, 10, 12, 0);
+  EXPECT_EQ(date.toEpochInt(), -19'751'089'680);
+#else
+  Date date = Date(1970, 1, 1, 0, 0, 0);
+  EXPECT_EQ(date.toEpochInt(), -1);
+  date = Date(1999, 1, 1, 10, 12, 0);
+  EXPECT_EQ(date.toEpochInt(), -1);
+#endif
+}
+
+// _____________________________________________________________________________
 TEST(Date, getTimeZoneOffsetToUTCInHours) {
   Date date = Date(1970, 1, 1, 0, 0, 0);  // No `TimeZone` given.
   ASSERT_EQ(0, date.getTimeZoneOffsetToUTCInHours());

--- a/test/DateYearDurationTest.cpp
+++ b/test/DateYearDurationTest.cpp
@@ -615,19 +615,12 @@ TEST(Date, Subtraction) {
 
 // _____________________________________________________________________________
 TEST(Date, toEpochInt) {
-#ifndef REDUCED_FEATURE_SET_FOR_CPP17
   Date date = Date(1970, 1, 1, 0, 0, 0);
   EXPECT_EQ(date.toEpochInt(), 0);
   date = Date(1999, 1, 1, 10, 12, 0);
   EXPECT_EQ(date.toEpochInt(), 915'185'520);
-  date = Date(1344, 2, 11, 10, 12, 0);
-  EXPECT_EQ(date.toEpochInt(), -19'751'089'680);
-#else
-  Date date = Date(1970, 1, 1, 0, 0, 0);
-  EXPECT_EQ(date.toEpochInt(), -1);
-  date = Date(1999, 1, 1, 10, 12, 0);
-  EXPECT_EQ(date.toEpochInt(), -1);
-#endif
+  date = Date(1949, 2, 11, 10, 12, 0);
+  EXPECT_EQ(date.toEpochInt(), -659'108'880);
 }
 
 // _____________________________________________________________________________

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -598,7 +598,8 @@ auto testUnaryExpression = [](VectorOrExpressionResult auto const& operand,
 
 TEST(SparqlExpression, dateOperators) {
   // Test `YearExpression`, `MonthExpression`, `DayExpression`,
-  //  `HoursExpression`, `MinutesExpression`, and `SecondsExpression`.
+  //  `HoursExpression`, `MinutesExpression`, `SecondsExpression` and
+  //  `ToEpochExpression`.
   // Helper function that asserts that the date operators give the expected
   // result on the given date.
   auto checkYear = testUnaryExpression<&makeYearExpression>;
@@ -607,8 +608,9 @@ TEST(SparqlExpression, dateOperators) {
   auto checkHours = testUnaryExpression<&makeHoursExpression>;
   auto checkMinutes = testUnaryExpression<&makeMinutesExpression>;
   auto checkSeconds = testUnaryExpression<&makeSecondsExpression>;
+  auto checkEpoch = testUnaryExpression<&makeToEpochExpression>;
   auto check = [&checkYear, &checkMonth, &checkDay, &checkHours, &checkMinutes,
-                &checkSeconds](
+                &checkSeconds, &checkEpoch](
                    const DateYearOrDuration& date,
                    std::optional<int> expectedYear,
                    std::optional<int> expectedMonth = std::nullopt,
@@ -616,6 +618,7 @@ TEST(SparqlExpression, dateOperators) {
                    std::optional<int> expectedHours = std::nullopt,
                    std::optional<int> expectedMinutes = std::nullopt,
                    std::optional<double> expectedSeconds = std::nullopt,
+                   std::optional<int> expectedEpoch = std::nullopt,
                    ad_utility::source_location l = AD_CURRENT_SOURCE_LOC()) {
     auto trace = generateLocationTrace(l);
     auto optToIdInt = [](const auto& opt) {
@@ -639,27 +642,59 @@ TEST(SparqlExpression, dateOperators) {
     checkMinutes(Ids{Id::makeFromDate(date)}, Ids{optToIdInt(expectedMinutes)});
     checkSeconds(Ids{Id::makeFromDate(date)},
                  Ids{optToIdDouble(expectedSeconds)});
+    checkEpoch(Ids{Id::makeFromDate(date)}, Ids{optToIdInt(expectedEpoch)});
   };
 
   using D = DateYearOrDuration;
-  // Now the checks for dates with varying level of detail.
+// Now the checks for dates with varying level of detail.
+#ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
+  // `ToEpochExpression` works with `std::chrono`.
   check(D::parseXsdDatetime("1970-04-22T11:53:42.25"), 1970, 4, 22, 11, 53,
-        42.25);
-  check(D::parseXsdDate("1970-04-22"), 1970, 4, 22);
-  check(D::parseXsdDate("1970-04-22"), 1970, 4, 22);
-  check(D::parseXsdDate("0042-12-24"), 42, 12, 24);
-  check(D::parseXsdDate("-0099-07-01"), -99, 7, 1);
-  check(D::parseGYear("-1234"), -1234, std::nullopt, std::nullopt);
-  check(D::parseXsdDate("0321-07-01"), 321, 7, 1);
-  check(D::parseXsdDate("2321-07-01"), 2321, 7, 1);
-
-  // Test behavior of the `largeYear` representation that doesn't store the
-  // actual date.
+        42.25, 9'633'222);
+  check(D::parseXsdDate("1970-04-22"), 1970, 4, 22, std::nullopt, std::nullopt,
+        std::nullopt, 9'590'400);
+  check(D::parseXsdDate("1970-04-22"), 1970, 4, 22, std::nullopt, std::nullopt,
+        std::nullopt, 9'590'400);
+// TODO<yarox-1> Currently not working, but should be working after change of
+// `toEpoch` from Nanoseconds to Milliseconds.
+// check(D::parseXsdDate("0042-12-24"), 42, 12, 24, std::nullopt, std::nullopt,
+// std::nullopt, -852'768'000); check(D::parseXsdDate("-0099-07-01"), -99, 7, 1,
+// std::nullopt, std::nullopt, std::nullopt, -65'275'718'400);
+// check(D::parseGYear("-1234"), -1234, std::nullopt, std::nullopt,
+// std::nullopt, std::nullopt, std::nullopt, -101'108'476'800);
+// check(D::parseXsdDate("0321-07-01"), 321, 7, 1, std::nullopt, std::nullopt,
+// std::nullopt, -52'021'785'600); check(D::parseXsdDate("2321-07-01"), 2321, 7,
+// 1, std::nullopt, std::nullopt, std::nullopt, 11'092'118'400);
+#else
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      check(D::parseXsdDatetime("1970-04-22T11:53:42.25"), 1970, 4, 22, 11, 53,
+            42.25, 9'633'222),
+      ::testing::ContainsRegex("does not support ql:toEpoch"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      check(D::parseXsdDate("1970-04-22"), 1970, 4, 22, std::nullopt,
+            std::nullopt, std::nullopt, 9'590'400),
+      ::testing::ContainsRegex("does not support ql:toEpoch"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      check(D::parseGYear("-1234"), -1234, std::nullopt, std::nullopt,
+            std::nullopt, std::nullopt, std::nullopt, -101'108'476'800),
+      ::testing::ContainsRegex("does not support ql:toEpoch"));
+#endif
+// Test behavior of the `largeYear` representation that doesn't store the
+// actual date.
+#ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
   check(D::parseGYear("123456"), 123456);
   check(D::parseGYearMonth("-12345-01"), -12345, 1);
   check(D::parseGYearMonth("-12345-03"), -12345, 1);
   check(D::parseXsdDate("-12345-01-01"), -12345, 1, 1);
   check(D::parseXsdDate("-12345-03-04"), -12345, 1, 1);
+#else
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      check(D::parseGYear("123456"), 123456),
+      ::testing::ContainsRegex("does not support ql:toEpoch"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      check(D::parseXsdDate("-12345-01-01"), -12345, 1, 1),
+      ::testing::ContainsRegex("does not support ql:toEpoch"));
+#endif
 
   // Invalid inputs for date expressions.
   checkYear(Ids{Id::makeFromInt(42)}, Ids{Id::makeUndefined()});

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -703,10 +703,15 @@ TEST(SparqlExpression, dateOperators) {
   checkHours(Ids{Id::makeFromInt(42)}, Ids{Id::makeUndefined()});
   checkMinutes(Ids{Id::makeFromInt(84)}, Ids{Id::makeUndefined()});
   checkSeconds(Ids{Id::makeFromDouble(120.0123)}, Ids{Id::makeUndefined()});
+  checkEpoch(Ids{Id::makeFromInt(84)}, Ids{Id::makeUndefined()});
   auto testYear = testUnaryExpression<&makeYearExpression>;
   testYear(Ids{Id::makeFromDouble(42.0)}, Ids{U});
   testYear(Ids{Id::makeFromBool(false)}, Ids{U});
   testYear(IdOrLocalVocabEntryVec{lit("noDate")}, Ids{U});
+
+  // Test epoch for invalid dates.
+  checkEpoch(Ids{Id::makeFromDate(D::parseXsdDate("1970-02-30"))},
+             Ids{Id::makeUndefined()});
 
   // test makeTimezoneStrExpression / makeTimezoneExpression
   auto positive = DayTimeDuration::Type::Positive;

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -655,7 +655,7 @@ TEST(SparqlExpression, dateOperators) {
         std::nullopt, 9'590'400);
   check(D::parseXsdDate("1970-04-22"), 1970, 4, 22, std::nullopt, std::nullopt,
         std::nullopt, 9'590'400);
-// TODO<yarox-1> Currently not working, but should be working after change of
+// TODO<yarox-1> Currently not working, but will be working after change of
 // `toEpoch` from Nanoseconds to Milliseconds.
 // check(D::parseXsdDate("0042-12-24"), 42, 12, 24, std::nullopt, std::nullopt,
 // std::nullopt, -852'768'000); check(D::parseXsdDate("-0099-07-01"), -99, 7, 1,
@@ -669,15 +669,15 @@ TEST(SparqlExpression, dateOperators) {
   AD_EXPECT_THROW_WITH_MESSAGE(
       check(D::parseXsdDatetime("1970-04-22T11:53:42.25"), 1970, 4, 22, 11, 53,
             42.25, 9'633'222),
-      ::testing::ContainsRegex("does not support ql:toEpoch"));
+      ::testing::HasSubstr("does not support ql:toEpoch"));
   AD_EXPECT_THROW_WITH_MESSAGE(
       check(D::parseXsdDate("1970-04-22"), 1970, 4, 22, std::nullopt,
             std::nullopt, std::nullopt, 9'590'400),
-      ::testing::ContainsRegex("does not support ql:toEpoch"));
+      ::testing::HasSubstr("does not support ql:toEpoch"));
   AD_EXPECT_THROW_WITH_MESSAGE(
       check(D::parseGYear("-1234"), -1234, std::nullopt, std::nullopt,
             std::nullopt, std::nullopt, std::nullopt, -101'108'476'800),
-      ::testing::ContainsRegex("does not support ql:toEpoch"));
+      ::testing::HasSubstr("does not support ql:toEpoch"));
 #endif
 // Test behavior of the `largeYear` representation that doesn't store the
 // actual date.
@@ -690,10 +690,10 @@ TEST(SparqlExpression, dateOperators) {
 #else
   AD_EXPECT_THROW_WITH_MESSAGE(
       check(D::parseGYear("123456"), 123456),
-      ::testing::ContainsRegex("does not support ql:toEpoch"));
+      ::testing::HasSubstr("does not support ql:toEpoch"));
   AD_EXPECT_THROW_WITH_MESSAGE(
       check(D::parseXsdDate("-12345-01-01"), -12345, 1, 1),
-      ::testing::ContainsRegex("does not support ql:toEpoch"));
+      ::testing::HasSubstr("does not support ql:toEpoch"));
 #endif
 
   // Invalid inputs for date expressions.

--- a/test/parser/SparqlAntlrParserExpressionTest.cpp
+++ b/test/parser/SparqlAntlrParserExpressionTest.cpp
@@ -324,6 +324,8 @@ TEST(SparqlParser, FunctionCall) {
                      matchUnary(&makeCentroidExpression));
   expectFunctionCall(absl::StrCat(ql, "isGeoPoint>(?x)"),
                      matchUnary(&makeIsGeoPointExpression));
+  expectFunctionCall(absl::StrCat(ql, "toEpoch>(?x)"),
+                     matchUnary(&makeToEpochExpression));
   expectFunctionCall(absl::StrCat(ql, "envelopeLowerLeft>(?x)"),
                      matchUnary(&makeEnvelopeLowerLeftExpression));
   expectFunctionCall(absl::StrCat(ql, "envelopeUpperRight>(?x)"),


### PR DESCRIPTION
There is now a built-in function `ql:toEpoch` that takes a date and returns the corresponding Unix epoch in seconds (UTC). This allows comparison between `xsd:datetime` literals like in the following example query. For dates outside roughly ±292 years from 1970 the result is currently UNDEF, because the internal nanosecond representation overflows `int64_t`.
```sparql
PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
PREFIX ql: <http://qlever.cs.uni-freiburg.de/builtin-functions/>
SELECT ?date1 ?date2 ?date3 ?eq1 ?eq2 ?eq3 ?lt1 ?lt2 ?lt3 WHERE {
  BIND("2025-12-24T18:15:00Z"^^xsd:dateTime AS ?date1)
  BIND("2025-12-24T17:15:00-01:00"^^xsd:dateTime AS ?date2)
  BIND("2025-12-24T17:15:00-02:00"^^xsd:dateTime AS ?date3)
  BIND(?date1 = ?date2 AS ?eq1)
  BIND(ql:toEpoch(?date1) = ql:toEpoch(?date2) AS ?eq2)
  BIND(ql:toEpoch(?date1) = ql:toEpoch(?date3) AS ?eq3)
  BIND(ql:toEpoch(?date1) < ql:toEpoch(?date2) AS ?lt1)
  BIND(ql:toEpoch(?date1) < ql:toEpoch(?date3) AS ?lt2)
  BIND(ql:toEpoch(?date2) < ql:toEpoch(?date3) AS ?lt3)
}
```