### PR TITLE
Reduce in-memory buffer for `idTriples` during partial-vocab building

### DIFF
--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -482,8 +482,8 @@ BuildPartialVocabulariesResult IndexImpl::buildPartialVocabularies(
   parser->integerOverflowBehavior() = turtleParserIntegerOverflowBehavior_;
   parser->invalidLiteralsAreSkipped() = turtleParserSkipIllegalLiterals_;
   ad_utility::Synchronized<std::unique_ptr<TripleVec>> idTriples(
-      std::make_unique<TripleVec>(onDiskBase_ + ".unsorted-triples.dat", 1_GB,
-                                  allocator_));
+      std::make_unique<TripleVec>(onDiskBase_ + ".unsorted-triples.dat",
+                                  2_MB * NumColumnsIndexBuilding, allocator_));
   AD_LOG_INFO << "Parsing input triples and creating partial vocabularies, one "
                  "per batch ..."
               << std::endl;


### PR DESCRIPTION
So far, the `CompressedExternalIdTable` used to collect parsed triples in `buildPartialVocabularies` was constructed with a `1_GB` memory budget, which the underlying class translates into a per-block row count of ~16M rows (with double-buffering). Now the memory budget is `2_MB * NumColumnsIndexBuilding` (currently `8_MB`), structured so that the `NumColumnsIndexBuilding` factor cancels the per-row size in the internal `blocksize_ = memory / (numColumns * sizeof(Id) * 2)` formula and yields a fixed `≈128K` rows per block, independent of column count.

NOTE: For an index build on DBLP (500 M triples), this reduces the max RAM consumption of the parsing stage (7 G -> 6 G), with no significant change in total index time. This continues the improvement from #2856 