### PR TITLE
`AD_LOG_DEBUG` the actually-used `num-triples-per-batch`

### DIFF
--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -72,7 +72,7 @@ IndexBuilderDataAsFirstPermutationSorter IndexImpl::createIdTriplesAndVocab(
   auto firstSorter = convertPartialToGlobalIds(
       *indexBuilderData.parsedTriples_.idTriples_,
       indexBuilderData.parsedTriples_.numTriplesPerPartialVocab_,
-      NUM_TRIPLES_PER_PARTIAL_VOCAB, isQleverInternalTriple);
+      isQleverInternalTriple);
 
   return {std::move(indexBuilderData.vocabularyMetaData_),
           std::move(firstSorter)};
@@ -646,6 +646,9 @@ IndexBuilderDataAsExternalVector IndexImpl::passFileForVocabulary(
         absl::StrCat(onDiskBase_, PARTIAL_VOCAB_WORDS_INFIX, n));
   }
 
+  AD_LOG_DEBUG << "Triples per partial vocabulary: " << linesPerPartial
+               << std::endl;
+
   return {std::move(mergeRes), std::move(parsedTriples)};
 }
 
@@ -653,12 +656,10 @@ IndexBuilderDataAsExternalVector IndexImpl::passFileForVocabulary(
 template <typename Func>
 auto IndexImpl::convertPartialToGlobalIds(
     TripleVec& data, const std::vector<size_t>& actualLinesPerPartial,
-    size_t linesPerPartial, Func isQLeverInternalTriple)
+    Func isQLeverInternalTriple)
     -> FirstPermutationSorterAndInternalTriplesAsPso {
   AD_LOG_INFO << "Converting triples from local IDs to global IDs ..."
               << std::endl;
-  AD_LOG_DEBUG << "Triples per partial vocabulary: " << linesPerPartial
-               << std::endl;
 
   // Iterate over all partial vocabularies.
   auto resultPtr =

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -554,7 +554,7 @@ class IndexImpl {
   template <typename Func>
   FirstPermutationSorterAndInternalTriplesAsPso convertPartialToGlobalIds(
       TripleVec& data, const std::vector<size_t>& actualLinesPerPartial,
-      size_t linesPerPartial, Func isQLeverInternalTriple);
+      Func isQLeverInternalTriple);
 
   // Helper function to get the filename for a given permutation.
   std::string getFilenameForPermutation(const Permutation& permutation,


### PR DESCRIPTION
So far, the `AD_LOG_DEBUG << "Triples per partial vocabulary: ..."` line was emitted from `convertPartialToGlobalIds` with the compile-time constant `NUM_TRIPLES_PER_PARTIAL_VOCAB`, so a user setting `num-triples-per-batch` via `settings.json` saw the wrong value in the debug log. Now the line lives in `passFileForVocabulary` where the value in scope is the actually-used `numTriplesPerBatch_`.