### PR TITLE
Avoid redundant `Sort` operation in query plan for `EXISTS`

### DIFF
--- a/src/engine/ExistsJoin.cpp
+++ b/src/engine/ExistsJoin.cpp
@@ -254,8 +254,9 @@ std::shared_ptr<QueryExecutionTree> ExistsJoin::addExistsJoinsToSubtree(
 
     QueryPlanner qp{qec, cancellationHandle};
     auto pq = exists.argument();
-    // Mimic the behavior of `QueryExecutionTree::getJoinColumns` and make nudge
-    // the query planner into returning a query that is sorted the correct way.
+    // Nudge the query planner into producing a tree that is already sorted
+    // the way `QueryExecutionTree::getJoinColumns` expects, so that
+    // `ExistsJoin`'s constructor does not have to add an extra `Sort`.
     pq._isInternalSort = IsInternalSort::True;
     pq._orderBy = subtree->getVariableColumns() | ql::views::keys |
                   ql::views::filter([&visibleVars = pq.getVisibleVariables()](

--- a/src/engine/ExistsJoin.cpp
+++ b/src/engine/ExistsJoin.cpp
@@ -254,8 +254,8 @@ std::shared_ptr<QueryExecutionTree> ExistsJoin::addExistsJoinsToSubtree(
 
     QueryPlanner qp{qec, cancellationHandle};
     auto pq = exists.argument();
-    // Mimic `QueryExecutionTree::getJoinColumns` and make sure to get a query
-    // plan that is sorted the correct way.
+    // Mimic the behavior of `QueryExecutionTree::getJoinColumns` and make nudge
+    // the query planner into returning a query that is sorted the correct way.
     pq._isInternalSort = IsInternalSort::True;
     pq._orderBy = subtree->getVariableColumns() | ql::views::keys |
                   ql::views::filter([&visibleVars = pq.getVisibleVariables()](
@@ -266,6 +266,13 @@ std::shared_ptr<QueryExecutionTree> ExistsJoin::addExistsJoinsToSubtree(
                     return VariableOrderKey{variable};
                   }) |
                   ::ranges::to<std::vector>;
+    // Ensure we have the same ordering `QueryExecutionTree::getJoinColumns`
+    // would produce.
+    ql::ranges::sort(pq._orderBy, {},
+                     [&columns = subtree->getVariableColumns()](
+                         const VariableOrderKey& key) {
+                       return columns.at(key.variable_).columnIndex_;
+                     });
     auto tree =
         std::make_shared<QueryExecutionTree>(qp.createExecutionTree(pq));
     // Hide non-visible variables in the subtree, so that they are not

--- a/src/engine/ExistsJoin.cpp
+++ b/src/engine/ExistsJoin.cpp
@@ -254,6 +254,18 @@ std::shared_ptr<QueryExecutionTree> ExistsJoin::addExistsJoinsToSubtree(
 
     QueryPlanner qp{qec, cancellationHandle};
     auto pq = exists.argument();
+    // Mimic `QueryExecutionTree::getJoinColumns` and make sure to get a query
+    // plan that is sorted the correct way.
+    pq._isInternalSort = IsInternalSort::True;
+    pq._orderBy = subtree->getVariableColumns() | ql::views::keys |
+                  ql::views::filter([&visibleVars = pq.getVisibleVariables()](
+                                        const Variable& variable) {
+                    return ad_utility::contains(visibleVars, variable);
+                  }) |
+                  ql::views::transform([](const Variable& variable) {
+                    return VariableOrderKey{variable};
+                  }) |
+                  ::ranges::to<std::vector>;
     auto tree =
         std::make_shared<QueryExecutionTree>(qp.createExecutionTree(pq));
     // Hide non-visible variables in the subtree, so that they are not

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -2648,6 +2648,14 @@ TEST(QueryPlanner, Exists) {
       "SELECT * FROM <g> FROM NAMED <g2> { ?x ?y ?z FILTER EXISTS {?a ?b ?c. "
       "GRAPH ?g { ?u ?v ?c}}}",
       filter);
+  // Make sure we get the correct permutation.
+  h::expect("SELECT ?s { ?s <p> <o> FILTER EXISTS { ?s ?p ?o } }",
+            h::Filter("EXISTS { ?s ?p ?o }",
+                      h::ExistsJoin(
+                          h::IndexScanFromStrings("?s", "<p>", "<o>"),
+                          h::IndexScanFromStrings("?s", "?p", "?o",
+                                                  {Permutation::Enum::SPO,
+                                                   Permutation::Enum::SOP}))));
 }
 
 // _____________________________________________________________________________

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -2656,6 +2656,13 @@ TEST(QueryPlanner, Exists) {
                           h::IndexScanFromStrings("?s", "?p", "?o",
                                                   {Permutation::Enum::SPO,
                                                    Permutation::Enum::SOP}))));
+  h::expect("SELECT ?s { ?s ?p <o> FILTER EXISTS { ?s ?p ?o } }",
+            h::Filter("EXISTS { ?s ?p ?o }",
+                      h::ExistsJoin(
+                          h::IndexScanFromStrings("?s", "?p", "<o>",
+                                                  {Permutation::Enum::OSP}),
+                          h::IndexScanFromStrings("?s", "?p", "?o",
+                                                  {Permutation::Enum::SPO}))));
 }
 
 // _____________________________________________________________________________


### PR DESCRIPTION
So far, the `EXISTS` subquery was handed to a fresh `QueryPlanner` with no ordering hint, so the planner often picked a permutation not sorted on the join columns, and the constructor of `ExistsJoin` then added a Sort via `createSortedTrees`. Now we set `_isInternalSort` and `_orderBy` on the parsed query so the planner picks a permutation already sorted the way `QueryExecutionTree::getJoinColumns` expects, making the `Sort` operation unnecessary. For example, the following query on `olympics` is now planned without a `Sort` operation:
```sparql
SELECT ?medal WHERE {
  ?medal olympics:medal medal:Gold .
  FILTER EXISTS { ?medal ?p ?o }
}
```