### PR TITLE
Avoid a GCC 12 `-Werror=array-bounds` false positive in `ExplicitIdTableOperationTest`

### DIFF
--- a/test/engine/ExplicitIdTableOperationTest.cpp
+++ b/test/engine/ExplicitIdTableOperationTest.cpp
@@ -58,7 +58,9 @@ class ExplicitIdTableOperationTest : public ::testing::Test {
     qec_ = getTestQec();
     testTable_ = createTestIdTable(3, 2);
     testVariables_ = createTestVariableMap(2);
-    testSortedColumns_ = {ColumnIndex{0}};
+    // Avoid initializer_list assignment to sidestep a GCC 12 false positive
+    // (-Werror=array-bounds).
+    testSortedColumns_ = std::vector<ColumnIndex>(1, ColumnIndex{0});
     testCacheKey_ = "[dummy cache key]";
   }
 


### PR DESCRIPTION
GCC 12's `-Werror=array-bounds` incorrectly flags the `vector::operator=(initializer_list<T>)` call in `ExplicitIdTableOperationTest::SetUp()` when the initializer list contains a single `uint64_t` element. This was silently suppressed by the `-Wno-error=array-bounds` override in `toolchains/gcc12.cmake`, which #2873 removed.

The fix replaces `= {ColumnIndex{0}}` with the `(count, value)` vector constructor, avoiding `std::initializer_list` entirely. A minimal reproducer ([Godbolt](https://godbolt.org/z/T78G61dh6)) confirms the analysis: the warning only fires on GCC 12.4 and 12.5 at `-O2`, when an initializer list of a single element is assigned to a vector whose size/capacity the compiler cannot reason about (constructors work; the deferred `SetUp` method of `GTest` does not).