### PR TITLE
Split MessageSender lifetimes to fix QueryRegistry leak

### DIFF
--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -330,8 +330,7 @@ auto Server::prepareOperation(
   auto qec = std::make_shared<QueryExecutionContext>(
       index_, &cache_, allocator_, sortPerformanceEstimator_,
       &namedResultCache_, &materializedViewsManager_,
-      std::move(messageSender).extractUpdateCallback(), pinSubtrees,
-      pinResult);
+      std::move(messageSender).extractUpdateCallback(), pinSubtrees, pinResult);
 
   configurePinnedResultWithName(pinResultWithName, pinNamedGeoIndex,
                                 accessTokenOk, *qec);

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -295,7 +295,7 @@ auto Server::setupCancellationHandle(
 // ____________________________________________________________________________
 auto Server::prepareOperation(
     std::string_view operationName, std::string_view operationSPARQL,
-    ad_utility::websocket::MessageSender messageSender,
+    ad_utility::websocket::MessageSender& messageSender,
     const ad_utility::url_parser::ParamValueMap& params, TimeLimit timeLimit,
     bool accessTokenOk) {
   auto [cancellationHandle, cancelTimeoutOnDestruction] =
@@ -324,16 +324,14 @@ auto Server::prepareOperation(
               : "")
       << "\n"
       << ad_utility::truncateOperationString(operationSPARQL) << std::endl;
-  auto sharedMessageSender =
-      std::make_shared<ad_utility::websocket::MessageSender>(
-          std::move(messageSender));
+  // Hand Job A (send channel) to the QEC so it can outlive this request and
+  // still receive late updates during plan teardown. messageSender keeps
+  // Job B, which is freed when the request scope ends.
   auto qec = std::make_shared<QueryExecutionContext>(
       index_, &cache_, allocator_, sortPerformanceEstimator_,
       &namedResultCache_, &materializedViewsManager_,
-      [sharedMessageSender = std::move(sharedMessageSender)](std::string json) {
-        (*sharedMessageSender)(std::move(json));
-      },
-      pinSubtrees, pinResult);
+      std::move(messageSender).extractUpdateCallback(), pinSubtrees,
+      pinResult);
 
   configurePinnedResultWithName(pinResultWithName, pinNamedGeoIndex,
                                 accessTokenOk, *qec);
@@ -662,9 +660,8 @@ CPP_template_def(typename RequestT, typename ResponseT)(
         createMessageSender(queryHub_, request, operationString);
 
     auto [qecPtr, cancellationHandle, cancelTimeoutOnDestruction] =
-        prepareOperation(operationName, operationString,
-                         std::move(messageSender), parameters,
-                         timeLimit.value(), accessTokenOk);
+        prepareOperation(operationName, operationString, messageSender,
+                         parameters, timeLimit.value(), accessTokenOk);
     auto& qec = *qecPtr;
     if (!ql::ranges::all_of(operations, expectedOperation)) {
       throw std::runtime_error(absl::StrCat(

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -254,7 +254,7 @@ class Server {
   //  Prepare the execution of an operation
   auto prepareOperation(std::string_view operationName,
                         std::string_view operationSPARQL,
-                        ad_utility::websocket::MessageSender messageSender,
+                        ad_utility::websocket::MessageSender& messageSender,
                         const ad_utility::url_parser::ParamValueMap& params,
                         TimeLimit timeLimit, bool accessTokenOk);
   // Sets the export limit (`send` parameter) and offset on the ParsedQuery;

--- a/src/util/http/websocket/MessageSender.cpp
+++ b/src/util/http/websocket/MessageSender.cpp
@@ -8,17 +8,28 @@ namespace ad_utility::websocket {
 
 // _____________________________________________________________________________
 MessageSender::MessageSender(OwningQueryId owningQueryId, QueryHub& queryHub)
-    : distributorAndOwningQueryId_{
-          {queryHub.createOrAcquireDistributorForSending(
-               owningQueryId.toQueryId()),
-           std::move(owningQueryId)},
-          [](DistributorAndOwningQueryId distributorAndOwningQueryId) {
-            distributorAndOwningQueryId.distributor_->signalEnd();
-          }} {}
+    : owningQueryId_{std::move(owningQueryId)},
+      distributor_{queryHub.createOrAcquireDistributorForSending(
+                       owningQueryId_.toQueryId()),
+                   [](std::shared_ptr<QueryToSocketDistributor> distributor) {
+                     distributor->signalEnd();
+                   }} {}
 
 // _____________________________________________________________________________
 void MessageSender::operator()(std::string json) const {
-  distributorAndOwningQueryId_->distributor_->addQueryStatusUpdate(
-      std::move(json));
+  (*distributor_)->addQueryStatusUpdate(std::move(json));
+}
+
+// _____________________________________________________________________________
+std::function<void(std::string)> MessageSender::extractUpdateCallback() && {
+  // std::function needs a copyable target, but UniqueCleanup is move-only;
+  // wrap it in a shared_ptr so the lambda is copyable. signalEnd() runs when
+  // the last copy of this callback is destroyed.
+  auto distributor = std::make_shared<
+      UniqueCleanup<std::shared_ptr<QueryToSocketDistributor>>>(
+      std::move(distributor_));
+  return [distributor = std::move(distributor)](std::string json) {
+    (**distributor)->addQueryStatusUpdate(std::move(json));
+  };
 }
 }  // namespace ad_utility::websocket

--- a/src/util/http/websocket/MessageSender.h
+++ b/src/util/http/websocket/MessageSender.h
@@ -5,6 +5,8 @@
 #ifndef QLEVER_MESSAGESENDER_H
 #define QLEVER_MESSAGESENDER_H
 
+#include <functional>
+
 #include "util/UniqueCleanup.h"
 #include "util/http/websocket/QueryHub.h"
 #include "util/http/websocket/QueryId.h"
@@ -19,22 +21,11 @@ using unique_cleanup::UniqueCleanup;
 /// from the non-asio world.
 class MessageSender {
  private:
-  /// Keep the OwningQueryId alive until
-  /// distributorAndOwningQueryId_->signalEnd() is called (see the constructor
-  /// of `MessageSender` for details).
-  struct DistributorAndOwningQueryId {
-    std::shared_ptr<QueryToSocketDistributor> distributor_;
-    OwningQueryId owningQueryId_;
-
-    // There seems to be a bug with gcc < 13 where aggregate-initializing
-    // this struct in combination with coroutines leads to segfaults
-    DistributorAndOwningQueryId(
-        std::shared_ptr<QueryToSocketDistributor> distributor,
-        OwningQueryId owningQueryId)
-        : distributor_{std::move(distributor)},
-          owningQueryId_{std::move(owningQueryId)} {}
-  };
-  UniqueCleanup<DistributorAndOwningQueryId> distributorAndOwningQueryId_;
+  // Job B: registry ticket. Its own cleanup unregisters and logs "end".
+  OwningQueryId owningQueryId_;
+  // Job A: send channel; cleanup calls signalEnd() once. Declared after
+  // owningQueryId_ so the constructor can use the query id.
+  UniqueCleanup<std::shared_ptr<QueryToSocketDistributor>> distributor_;
   net::any_io_executor executor_;
 
  public:
@@ -44,13 +35,19 @@ class MessageSender {
   MessageSender(MessageSender&&) noexcept = default;
   MessageSender& operator=(MessageSender&&) noexcept = default;
 
-  /// Broadcast the string to all listeners of this query asynchronously.
+  // Broadcast the string to all listeners. Precondition: the channel was
+  // not moved out via extractUpdateCallback().
   void operator()(std::string) const;
 
-  /// Get read only view of underlying `QueryId`.
+  // Get read only view of underlying `QueryId`.
   const QueryId& getQueryId() const noexcept {
-    return distributorAndOwningQueryId_->owningQueryId_.toQueryId();
+    return owningQueryId_.toQueryId();
   }
+
+  // Move the send channel (Job A) out into a standalone callback; this
+  // MessageSender then keeps only Job B. signalEnd() fires when the returned
+  // callback is destroyed (after the plan's last late update).
+  std::function<void(std::string)> extractUpdateCallback() &&;
 };
 
 }  // namespace ad_utility::websocket


### PR DESCRIPTION
`MessageSender` does two jobs with one lifetime: the websocket send channel, and the registry ticket (`OwningQueryId`) that unregisters the query on destruction.

PR #2869 fixed a use-after-free by giving the whole `MessageSender` the `QueryExecutionContext`'s lifetime so the send channel survives late updates during plan teardown. The send channel needs that long life, but the registry ticket does not, which meant finished queries were never removed from the `QueryRegistry` (they stayed in `cmd=dump-active-queries` indefinitely).

The two jobs need different lifetimes: `signalEnd()` must run after the last update, so the send channel must outlive the request, whereas the registry ticket must be released as soon as the request ends.

Now `MessageSender` holds the two as independent members, and `extractUpdateCallback() &&` moves only the send channel into the `QueryExecutionContext`. The `MessageSender` stays a request-scoped local, so the query is unregistered as soon as the request finishes, while the send channel still rides the `QueryExecutionContext` lifetime and keeps #2869's fix intact.

Fixes issue #2884
