### PR TITLE
Fix bug in unifying local vocab IDs when building a partial vocabulary

### DIFF
--- a/src/index/VocabularyMergerImpl.h
+++ b/src/index/VocabularyMergerImpl.h
@@ -164,12 +164,12 @@ CPP_template_def(typename C, typename L)(
 inline HashMap<uint64_t, uint64_t> createInternalMapping(ItemVec& els) {
   HashMap<uint64_t, uint64_t> res;
   res.reserve(els.size());
-  bool first = true;
-  std::string_view lastWord;
-  size_t nextWordId = 0;
+  std::optional<std::string_view> lastWord;
+  // This value will overflow on the first entry.
+  size_t nextWordId = -1;
   for (auto& [word, idAndExternal] : els) {
     auto id = idAndExternal.id();
-    if (!first && lastWord != word) {
+    if (lastWord != word) {
       nextWordId++;
       lastWord = word;
     }
@@ -177,7 +177,6 @@ inline HashMap<uint64_t, uint64_t> createInternalMapping(ItemVec& els) {
     AD_CORRECTNESS_CHECK(inserted);
     idAndExternal = PartialVocabIndexWithExternalFlag{
         nextWordId, idAndExternal.isExternal()};
-    first = false;
   }
   return res;
 }

--- a/test/VocabularyGeneratorTest.cpp
+++ b/test/VocabularyGeneratorTest.cpp
@@ -262,3 +262,37 @@ TEST(VocabularyGeneratorTest, createInternalMapping) {
   ASSERT_EQ(3u, res[38]);
   ASSERT_EQ(4u, res[0]);
 }
+
+// Regression test: previously, `createInternalMapping` left `lastWord` empty
+// for the first iteration, so duplicates of the very first sorted word
+// (which can occur when the same string is stored in two parallel
+// `ItemMap`s with different `isExternal` flags) were assigned a *different*
+// internal id than the first occurrence. The subsequent `std::unique` by id
+// then failed to drop them, and the partial-vocab file ended up with two
+// byte-identical entries for that word.
+TEST(VocabularyGeneratorTest, createInternalMappingFirstWordDuplicates) {
+  ItemVec input;
+  using S = PartialVocabIndexWithExternalFlag;
+  // The first word appears three times (e.g., from three parallel item
+  // maps), then a second distinct word appears twice.
+  input.emplace_back("alpha", S{7, true});
+  input.emplace_back("alpha", S{12, false});
+  input.emplace_back("alpha", S{99, false});
+  input.emplace_back("beta", S{3, false});
+  input.emplace_back("beta", S{55, true});
+
+  auto res = createInternalMapping(input);
+  // All three "alpha"s must collapse to the same id (0).
+  EXPECT_EQ(0u, input[0].second.id());
+  EXPECT_EQ(0u, input[1].second.id());
+  EXPECT_EQ(0u, input[2].second.id());
+  // Both "beta"s must collapse to the next id (1).
+  EXPECT_EQ(1u, input[3].second.id());
+  EXPECT_EQ(1u, input[4].second.id());
+
+  EXPECT_EQ(0u, res[7]);
+  EXPECT_EQ(0u, res[12]);
+  EXPECT_EQ(0u, res[99]);
+  EXPECT_EQ(1u, res[3]);
+  EXPECT_EQ(1u, res[55]);
+}


### PR DESCRIPTION
During the index build, when parsing a batch using multiple independent workers, the same RDF term can initially be assigned different local IDs when encountered by different workers. The function `createInternalMapping` then unifies these by assigning exactly *one* local ID for each distinct RDF term encountered. However, due to an off-by-one bug, the lexicographically smallest RDF term could receive two different local IDs. This is now fixed and a regression test is added.