### PR TITLE
Store `Index` and `MaterializedViewsManager` via `shared_ptr`

### DIFF
--- a/src/engine/QueryExecutionContext.cpp
+++ b/src/engine/QueryExecutionContext.cpp
@@ -22,22 +22,22 @@ std::chrono::milliseconds QueryExecutionContext::websocketUpdateInterval() {
 
 // _____________________________________________________________________________
 QueryExecutionContext::QueryExecutionContext(
-    const Index& index, QueryResultCache* const cache,
+    std::shared_ptr<const Index> index, QueryResultCache* const cache,
     ad_utility::AllocatorWithLimit<Id> allocator,
     SortPerformanceEstimator sortPerformanceEstimator,
     NamedResultCache* namedResultCache,
-    MaterializedViewsManager* materializedViewsManager,
+    std::shared_ptr<MaterializedViewsManager> materializedViewsManager,
     std::function<void(std::string)> updateCallback, const bool pinSubtrees,
     const bool pinResult, const DisableCaching disableCaching)
     : _pinSubtrees(pinSubtrees),
       _pinResult(pinResult),
-      _index(index),
+      _index(std::move(index)),
       _subtreeCache(cache),
       _allocator(std::move(allocator)),
       _sortPerformanceEstimator(sortPerformanceEstimator),
       updateCallback_(std::move(updateCallback)),
       namedResultCache_(namedResultCache),
-      materializedViewsManager_(materializedViewsManager) {
+      materializedViewsManager_(std::move(materializedViewsManager)) {
   disableCaching_ = [disableCaching]() {
     if (disableCaching == DisableCaching::True) {
       return true;
@@ -51,7 +51,7 @@ QueryExecutionContext::QueryExecutionContext(
   }();
   AD_CORRECTNESS_CHECK(cache != nullptr);
   AD_CORRECTNESS_CHECK(namedResultCache != nullptr);
-  AD_CORRECTNESS_CHECK(materializedViewsManager != nullptr);
+  AD_CORRECTNESS_CHECK(materializedViewsManager_ != nullptr);
 }
 
 // _____________________________________________________________________________

--- a/src/engine/QueryExecutionContext.h
+++ b/src/engine/QueryExecutionContext.h
@@ -103,11 +103,11 @@ class QueryExecutionContext
  public:
   enum struct DisableCaching { True, False, FromRuntimeParameter };
   QueryExecutionContext(
-      const Index& index, QueryResultCache* const cache,
+      std::shared_ptr<const Index> index, QueryResultCache* const cache,
       ad_utility::AllocatorWithLimit<Id> allocator,
       SortPerformanceEstimator sortPerformanceEstimator,
       NamedResultCache* namedResultCache,
-      MaterializedViewsManager* materializedViewsManager,
+      std::shared_ptr<MaterializedViewsManager> materializedViewsManager,
       std::function<void(std::string)> updateCallback =
           [](std::string) { /* No-op by default for testing */ },
       bool pinSubtrees = false, bool pinResult = false,
@@ -115,7 +115,7 @@ class QueryExecutionContext
 
   QueryResultCache& getQueryTreeCache() { return *_subtreeCache; }
 
-  [[nodiscard]] const Index& getIndex() const { return _index; }
+  [[nodiscard]] const Index& getIndex() const { return *_index; }
 
   const LocatedTriplesState& locatedTriplesState() const {
     AD_CORRECTNESS_CHECK(locatedTriplesSharedState_ != nullptr);
@@ -213,14 +213,14 @@ class QueryExecutionContext
   // header.
   static bool areWebSocketUpdatesEnabled();
   static std::chrono::milliseconds websocketUpdateInterval();
-  const Index& _index;
+  std::shared_ptr<const Index> _index;
 
   // When the `QueryExecutionContext` is constructed, get a stable read-only
   // snapshot of the current (located) delta triples. These can then be used
   // by the respective query without interfering with further incoming
   // update operations.
   LocatedTriplesSharedState locatedTriplesSharedState_{
-      _index.deltaTriplesManager().getCurrentLocatedTriplesSharedState()};
+      _index->deltaTriplesManager().getCurrentLocatedTriplesSharedState()};
   QueryResultCache* const _subtreeCache;
   // allocators are copied but hold shared state
   ad_utility::AllocatorWithLimit<Id> _allocator;
@@ -251,7 +251,7 @@ class QueryExecutionContext
   // `std::nullopt`, the result is not cached.
   std::optional<PinResultWithName> pinResultWithName_ = std::nullopt;
 
-  MaterializedViewsManager* materializedViewsManager_;
+  std::shared_ptr<MaterializedViewsManager> materializedViewsManager_;
 
   // See the documentation for the getter with the same name above;
   bool disableCaching_ = false;

--- a/src/engine/QueryExecutionContext.h
+++ b/src/engine/QueryExecutionContext.h
@@ -96,8 +96,9 @@ using QueryResultCache = ad_utility::ConcurrentCache<
 class NamedResultCache;
 class MaterializedViewsManager;
 
-// Execution context for queries.
-// Holds references to index and engine, implements caching.
+// Execution context for queries. Holds a `std::shared_ptr` to the `Index`
+// and `MaterializedViewsManager` to ensure that they stay alive as long as
+// this context is alive.
 class QueryExecutionContext
     : public std::enable_shared_from_this<QueryExecutionContext> {
  public:
@@ -213,6 +214,9 @@ class QueryExecutionContext
   // header.
   static bool areWebSocketUpdatesEnabled();
   static std::chrono::milliseconds websocketUpdateInterval();
+
+  // Shared pointer to the `Index` to ensure that it stays alive as long as
+  // this context is alive.
   std::shared_ptr<const Index> _index;
 
   // When the `QueryExecutionContext` is constructed, get a stable read-only
@@ -251,6 +255,8 @@ class QueryExecutionContext
   // `std::nullopt`, the result is not cached.
   std::optional<PinResultWithName> pinResultWithName_ = std::nullopt;
 
+  // Shared pointer to the `MaterializedViewsManager` to ensure that it stays
+  // alive as long as this context is alive.
   std::shared_ptr<MaterializedViewsManager> materializedViewsManager_;
 
   // See the documentation for the getter with the same name above;

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -62,7 +62,7 @@ Server::Server(unsigned short port, size_t numThreads,
                    cache_.makeRoomAsMuchAsPossible(MAKE_ROOM_SLACK_FACTOR *
                                                    numMemoryToAllocate);
                  }},
-      index_{allocator_},
+      index_{std::make_shared<Index>(allocator_)},
       enablePatternTrick_(usePatternTrick),
       // The number of server threads currently also is the number of queries
       // that can be processed simultaneously.
@@ -86,23 +86,23 @@ void Server::initialize(const std::string& indexBaseName, bool useText,
                         std::vector<std::string> preloadMaterializedViews) {
   AD_LOG_INFO << "Initializing server ..." << std::endl;
 
-  index_.usePatterns() = usePatterns;
-  index_.loadAllPermutations() = loadAllPermutations;
+  index().usePatterns() = usePatterns;
+  index().loadAllPermutations() = loadAllPermutations;
 
   // Init the index.
-  index_.createFromOnDiskIndex(indexBaseName, persistUpdates);
+  index().createFromOnDiskIndex(indexBaseName, persistUpdates);
   if (useText) {
-    index_.addTextFromOnDiskIndex();
+    index().addTextFromOnDiskIndex();
   }
 
-  materializedViewsManager_.setOnDiskBase(indexBaseName);
+  materializedViewsManager_->setOnDiskBase(indexBaseName);
 
   // Preload materialized views as requested by the user. This is done in a
   // try-catch block to prevent an exception during loading of a view from
   // blocking the server start.
   for (const auto& viewName : preloadMaterializedViews) {
     try {
-      materializedViewsManager_.loadView(viewName);
+      materializedViewsManager_->loadView(viewName);
     } catch (const std::exception& ex) {
       AD_LOG_ERROR << "Preloading materialized view '" << viewName
                    << "' failed: " << ex.what() << "." << std::endl;
@@ -110,7 +110,7 @@ void Server::initialize(const std::string& indexBaseName, bool useText,
   }
 
   sortPerformanceEstimator_.computeEstimatesExpensively(
-      allocator_, index_.numTriples().normalAndInternal_() *
+      allocator_, index().numTriples().normalAndInternal_() *
                       PERCENTAGE_OF_TRIPLES_FOR_SORT_ESTIMATE / 100);
 
   if (noAccessCheck_) {
@@ -329,7 +329,7 @@ auto Server::prepareOperation(
           std::move(messageSender));
   auto qec = std::make_shared<QueryExecutionContext>(
       index_, &cache_, allocator_, sortPerformanceEstimator_,
-      &namedResultCache_, &materializedViewsManager_,
+      &namedResultCache_, materializedViewsManager_,
       [sharedMessageSender = std::move(sharedMessageSender)](std::string json) {
         (*sharedMessageSender)(std::move(json));
       },
@@ -456,7 +456,7 @@ CPP_template_def(typename RequestT, typename ResponseT)(
           // Use `this` explicitly to silence false-positive errors on the
           // captured `this` being unused.
           auto counts =
-              this->index_.deltaTriplesManager().modify<DeltaTriplesCount>(
+              this->index().deltaTriplesManager().modify<DeltaTriplesCount>(
                   [](auto& deltaTriples) {
                     deltaTriples.clear();
                     return deltaTriples.getCounts();
@@ -488,7 +488,7 @@ CPP_template_def(typename RequestT, typename ResponseT)(
         [this, handle] {
           // Use `this` explicitly to silence false-positive errors on the
           // captured `this` being unused.
-          return this->index_.deltaTriplesManager().modify<nlohmann::json>(
+          return this->index().deltaTriplesManager().modify<nlohmann::json>(
               [handle](auto& deltaTriples) {
                 return deltaTriples.vacuum(handle);
               });
@@ -503,7 +503,7 @@ CPP_template_def(typename RequestT, typename ResponseT)(
   } else if (auto cmd = checkParameter("cmd", "get-index-id")) {
     logCommand(cmd, "get index ID");
     response =
-        createOkResponse(index_.getIndexId(), request, MediaType::textPlain);
+        createOkResponse(index().getIndexId(), request, MediaType::textPlain);
   } else if (auto cmd = checkParameter("cmd", "dump-active-queries")) {
     requireValidAccessToken("dump-active-queries");
     logCommand(cmd, "dump active queries");
@@ -590,7 +590,7 @@ CPP_template_def(typename RequestT, typename ResponseT)(
         parameters, "view-name");
     AD_CONTRACT_CHECK(name.has_value());
 
-    materializedViewsManager_.loadView(name.value());
+    materializedViewsManager_->loadView(name.value());
 
     // Construct simple response JSON.
     nlohmann::json json{{"materialized-view-loaded", name.value()}};
@@ -614,7 +614,7 @@ CPP_template_def(typename RequestT, typename ResponseT)(
     requireValidAccessToken("index-description");
     AD_LOG_INFO << "Setting index description to: \"" << description.value()
                 << "\"" << std::endl;
-    index_.setKbName(std::string{description.value()});
+    index().setKbName(std::string{description.value()});
     response = createJsonResponse(composeStatsJson(), request);
   }
 
@@ -623,7 +623,7 @@ CPP_template_def(typename RequestT, typename ResponseT)(
     requireValidAccessToken("text-description");
     AD_LOG_INFO << "Setting text description to: \"" << description.value()
                 << "\"" << std::endl;
-    index_.setTextName(std::string{description.value()});
+    index().setTextName(std::string{description.value()});
     response = createJsonResponse(composeStatsJson(), request);
   }
 
@@ -688,7 +688,7 @@ CPP_template_def(typename RequestT, typename ResponseT)(
     // We need to copy the query string because `visitOperation` below also
     // needs it.
     auto parsedQuery = SparqlParser::parseQuery(
-        &index_.encodedIriManager(), query.query_, query.datasetClauses_);
+        &index().encodedIriManager(), query.query_, query.datasetClauses_);
     auto dummy = std::make_shared<ad_utility::timer::TimeTracer>("dummy");
     return visitOperation(
         {std::move(parsedQuery)}, "SPARQL query", std::move(query.query_),
@@ -722,7 +722,7 @@ CPP_template_def(typename RequestT, typename ResponseT)(
     tracer->beginTrace("parsing");
     std::vector<ParsedQuery> parsedOperations =
         GraphStoreProtocol::transformGraphStoreProtocol(std::move(operation),
-                                                        request, index_);
+                                                        request, index());
     tracer->endTrace("parsing");
 
     if (ql::ranges::any_of(parsedOperations, &ParsedQuery::hasUpdateClause)) {
@@ -838,27 +838,27 @@ nlohmann::json Server::composeErrorResponseJson(
 // _____________________________________________________________________________
 nlohmann::json Server::composeStatsJson() const {
   json result;
-  result["name-index"] = index_.getKbName();
-  result["git-hash-index"] = index_.getGitShortHash();
+  result["name-index"] = index().getKbName();
+  result["git-hash-index"] = index().getGitShortHash();
   result["git-hash-server"] =
       *qlever::version::gitShortHashWithoutLinking.wlock();
-  result["num-permutations"] = (index_.hasAllPermutations() ? 6 : 2);
-  result["num-predicates-normal"] = index_.numDistinctPredicates().normal;
-  result["num-predicates-internal"] = index_.numDistinctPredicates().internal;
-  if (index_.hasAllPermutations()) {
-    result["num-subjects-normal"] = index_.numDistinctSubjects().normal;
-    result["num-subjects-internal"] = index_.numDistinctSubjects().internal;
-    result["num-objects-normal"] = index_.numDistinctObjects().normal;
-    result["num-objects-internal"] = index_.numDistinctObjects().internal;
+  result["num-permutations"] = (index().hasAllPermutations() ? 6 : 2);
+  result["num-predicates-normal"] = index().numDistinctPredicates().normal;
+  result["num-predicates-internal"] = index().numDistinctPredicates().internal;
+  if (index().hasAllPermutations()) {
+    result["num-subjects-normal"] = index().numDistinctSubjects().normal;
+    result["num-subjects-internal"] = index().numDistinctSubjects().internal;
+    result["num-objects-normal"] = index().numDistinctObjects().normal;
+    result["num-objects-internal"] = index().numDistinctObjects().internal;
   }
 
-  auto numTriples = index_.numTriples();
+  auto numTriples = index().numTriples();
   result["num-triples-normal"] = numTriples.normal;
   result["num-triples-internal"] = numTriples.internal;
-  result["name-text-index"] = index_.getTextName();
-  result["num-text-records"] = index_.getNofTextRecords();
-  result["num-word-occurrences"] = index_.getNofWordPostings();
-  result["num-entity-occurrences"] = index_.getNofEntityPostings();
+  result["name-text-index"] = index().getTextName();
+  result["num-text-records"] = index().getNofTextRecords();
+  result["num-word-occurrences"] = index().getNofWordPostings();
+  result["num-entity-occurrences"] = index().getNofEntityPostings();
   return result;
 }
 
@@ -1176,7 +1176,7 @@ UpdateMetadata Server::processUpdateImpl(
 
   DeltaTriplesCount countBefore = deltaTriples.getCounts();
   UpdateMetadata updateMetadata =
-      ExecuteUpdate::executeUpdate(index_, plannedUpdate.parsedQuery(), qet,
+      ExecuteUpdate::executeUpdate(index(), plannedUpdate.parsedQuery(), qet,
                                    deltaTriples, cancellationHandle, tracer);
   updateMetadata.countBefore_ = countBefore;
   updateMetadata.countAfter_ = deltaTriples.getCounts();
@@ -1223,7 +1223,7 @@ CPP_template_def(typename RequestT, typename ResponseT)(
       [this, &requestTimer, &cancellationHandle, &updates, &qec, &timeLimit,
        &plannedUpdate, outerTracer, &metadatas]() {
         outerTracer->endTrace("waitingForUpdateThread");
-        return index_.deltaTriplesManager().modify<json>(
+        return index().deltaTriplesManager().modify<json>(
             [this, &cancellationHandle, &plannedUpdate, &updates, &requestTimer,
              &timeLimit, &qec, &metadatas](DeltaTriples& deltaTriples) {
               qec.setLocatedTriplesForEvaluation(
@@ -1256,7 +1256,7 @@ CPP_template_def(typename RequestT, typename ResponseT)(
 
                 tracer.endTrace("update");
                 results.push_back(createResponseMetadataForUpdate(
-                    index_,
+                    index(),
                     *deltaTriples.getLocatedTriplesSharedStateReference(),
                     *plannedUpdate, plannedUpdate->queryExecutionTree(),
                     updateMetadata, tracer));
@@ -1485,17 +1485,17 @@ void Server::writeMaterializedView(
     ad_utility::SharedCancellationHandle cancellationHandle,
     TimeLimit timeLimit) {
   auto parsedQuery = SparqlParser::parseQuery(
-      &index_.encodedIriManager(), query.query_, query.datasetClauses_);
+      &index().encodedIriManager(), query.query_, query.datasetClauses_);
   auto qec = std::make_shared<QueryExecutionContext>(
       index_, &cache_, allocator_, sortPerformanceEstimator_,
-      &namedResultCache_, &materializedViewsManager_);
+      &namedResultCache_, materializedViewsManager_);
   auto plan = planQuery(std::move(parsedQuery), requestTimer, timeLimit, *qec,
                         cancellationHandle);
   auto qet = std::make_shared<QueryExecutionTree>(
       std::move(plan.queryExecutionTree()));
   auto memoryLimit =
       getRuntimeParameter<&RuntimeParameters::materializedViewWriterMemory_>();
-  materializedViewsManager_.writeViewToDisk(
+  materializedViewsManager_->writeViewToDisk(
       name, {qet, qec, std::move(plan.parsedQuery())}, memoryLimit);
 }
 
@@ -1507,7 +1507,7 @@ Awaitable<void> Server::rebuildIndex(const std::string& indexBaseName) {
         "\" because there are already files with the same base name "
         "in the same directory")};
   }
-  if (!qlever::util::isSubdirectoryOf(indexBaseName, index_.getOnDiskBase())) {
+  if (!qlever::util::isSubdirectoryOf(indexBaseName, index().getOnDiskBase())) {
     throw std::runtime_error{absl::StrCat(
         "Can't build index with base name \"", indexBaseName,
         "\" because it is not located in the same directory as the "
@@ -1522,9 +1522,10 @@ Awaitable<void> Server::rebuildIndex(const std::string& indexBaseName) {
       [this, &handle, &indexBaseName] {
         auto logFileName = indexBaseName + ".rebuild-index-log.txt";
         auto [currentSnapshot, localVocabCopy, ownedBlocks] =
-            index_.deltaTriplesManager()
+            index()
+                .deltaTriplesManager()
                 .getCurrentLocatedTriplesSharedStateWithVocab();
-        qlever::materializeToIndex(index_.getImpl(), indexBaseName,
+        qlever::materializeToIndex(index().getImpl(), indexBaseName,
                                    currentSnapshot, localVocabCopy, ownedBlocks,
                                    handle, logFileName);
       },

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -74,8 +74,8 @@ class Server {
            bool persistUpdates = false,
            std::vector<std::string> preloadMaterializedViews = {});
 
-  Index& index() { return index_; }
-  const Index& index() const { return index_; }
+  Index& index() { return *index_; }
+  const Index& index() const { return *index_; }
 
   // Get server statistics.
   json composeStatsJson() const;
@@ -122,10 +122,11 @@ class Server {
   bool noAccessCheck_;
   QueryResultCache cache_;
   NamedResultCache namedResultCache_;
-  MaterializedViewsManager materializedViewsManager_;
+  std::shared_ptr<MaterializedViewsManager> materializedViewsManager_ =
+      std::make_shared<MaterializedViewsManager>();
   ad_utility::AllocatorWithLimit<Id> allocator_;
   SortPerformanceEstimator sortPerformanceEstimator_;
-  Index index_;
+  std::shared_ptr<Index> index_;
   ad_utility::websocket::QueryRegistry queryRegistry_{};
 
   bool enablePatternTrick_;

--- a/src/libqlever/Qlever.cpp
+++ b/src/libqlever/Qlever.cpp
@@ -20,7 +20,7 @@ Qlever::Qlever(const EngineConfig& config)
     : allocator_{ad_utility::AllocatorWithLimit<Id>{
           ad_utility::makeAllocationMemoryLeftThreadsafeObject(
               config.memoryLimit_.value_or(DEFAULT_MEM_FOR_QUERIES))}},
-      index_{allocator_},
+      index_{std::make_shared<Index>(allocator_)},
       enablePatternTrick_{!config.noPatterns_},
       disableCaching_{config.disableCaching_} {
   // Set runtime parameters relevant for caching and propagate them to the
@@ -35,19 +35,19 @@ Qlever::Qlever(const EngineConfig& config)
       });
 
   // Load the index from disk.
-  index_.usePatterns() = enablePatternTrick_;
-  index_.loadAllPermutations() = !config.onlyPsoAndPos_;
-  index_.doNotLoadPermutations() = config.doNotLoadPermutations_;
-  index_.createFromOnDiskIndex(config.baseName_, config.persistUpdates_);
+  index_->usePatterns() = enablePatternTrick_;
+  index_->loadAllPermutations() = !config.onlyPsoAndPos_;
+  index_->doNotLoadPermutations() = config.doNotLoadPermutations_;
+  index_->createFromOnDiskIndex(config.baseName_, config.persistUpdates_);
   if (config.loadTextIndex_) {
-    index_.addTextFromOnDiskIndex();
+    index_->addTextFromOnDiskIndex();
   }
 
-  materializedViewsManager_.setOnDiskBase(config.baseName_);
+  materializedViewsManager_->setOnDiskBase(config.baseName_);
 
   // Estimate the cost of sorting operations (needed for query planning).
   sortPerformanceEstimator_.computeEstimatesExpensively(
-      allocator_, index_.numTriples().normalAndInternal_() *
+      allocator_, index_->numTriples().normalAndInternal_() *
                       PERCENTAGE_OF_TRIPLES_FOR_SORT_ESTIMATE / 100);
 }
 
@@ -183,11 +183,11 @@ void Qlever::eraseResultWithName(std::string name) {
 Qlever::QueryPlan Qlever::parseAndPlanQuery(std::string query) const {
   auto qecPtr = std::make_shared<QueryExecutionContext>(
       index_, &cache_, allocator_, sortPerformanceEstimator_,
-      &namedResultCache_, &materializedViewsManager_, [](std::string) {}, false,
+      &namedResultCache_, materializedViewsManager_, [](std::string) {}, false,
       false, disableCaching_);
   // TODO<joka921> support Dataset clauses.
   auto parsedQuery = SparqlParser::parseQuery(
-      &index_.getImpl().encodedIriManager(), std::move(query), {});
+      &index_->getImpl().encodedIriManager(), std::move(query), {});
   auto handle = std::make_shared<ad_utility::CancellationHandle<>>();
   QueryPlanner qp{qecPtr.get(), handle};
   qp.setEnablePatternTrick(enablePatternTrick_);
@@ -220,18 +220,18 @@ void IndexBuilderConfig::validate() const {
 
 // ___________________________________________________________________________
 void Qlever::writeMaterializedView(std::string name, std::string query) const {
-  materializedViewsManager_.writeViewToDisk(
+  materializedViewsManager_->writeViewToDisk(
       std::move(name), parseAndPlanQuery(std::move(query)));
 }
 
 // ___________________________________________________________________________
 bool Qlever::isMaterializedViewLoaded(const std::string& name) const {
-  return materializedViewsManager_.isViewLoaded(name);
+  return materializedViewsManager_->isViewLoaded(name);
 }
 
 // ___________________________________________________________________________
 void Qlever::loadMaterializedView(std::string name) const {
-  materializedViewsManager_.loadView(name);
+  materializedViewsManager_->loadView(name);
 }
 
 }  // namespace qlever

--- a/src/libqlever/Qlever.h
+++ b/src/libqlever/Qlever.h
@@ -200,9 +200,10 @@ class Qlever {
   mutable QueryResultCache cache_;
   ad_utility::AllocatorWithLimit<Id> allocator_;
   SortPerformanceEstimator sortPerformanceEstimator_;
-  Index index_;
+  std::shared_ptr<Index> index_;
   mutable NamedResultCache namedResultCache_;
-  mutable MaterializedViewsManager materializedViewsManager_;
+  std::shared_ptr<MaterializedViewsManager> materializedViewsManager_ =
+      std::make_shared<MaterializedViewsManager>();
   bool enablePatternTrick_;
   QueryExecutionContext::DisableCaching disableCaching_;
 
@@ -284,11 +285,11 @@ class Qlever {
   // Read the contents of the `NamedResultCache` from disk.
   template <typename Serializer>
   void readNamedResultCacheFromDisk(Serializer& serializer) {
-    namedResultCache_.readFromSerializer(serializer, allocator_, index_);
+    namedResultCache_.readFromSerializer(serializer, allocator_, index());
   }
 
   // Low-level access to the QLever API, use with care.
-  Index& index() { return index_; }
+  Index& index() { return *index_; }
 };
 }  // namespace qlever
 

--- a/test/ExecuteUpdateTest.cpp
+++ b/test/ExecuteUpdateTest.cpp
@@ -75,18 +75,19 @@ TEST(ExecuteUpdate, executeUpdate) {
           const testing::Matcher<const DeltaTriples&>& deltaTriplesMatcher,
           source_location sourceLocation = AD_CURRENT_SOURCE_LOC()) {
         auto l = generateLocationTrace(sourceLocation);
-        Index index = ad_utility::testing::makeTestIndex(
-            "ExecuteUpdate_executeUpdate", indexConfig);
+        auto index = std::make_shared<Index>(ad_utility::testing::makeTestIndex(
+            "ExecuteUpdate_executeUpdate", indexConfig));
         QueryResultCache cache = QueryResultCache();
         NamedResultCache namedResultCache;
-        MaterializedViewsManager materializedViewsManager;
+        auto materializedViewsManager =
+            std::make_shared<MaterializedViewsManager>();
         QueryExecutionContext qec(index, &cache,
                                   ad_utility::testing::makeAllocator(
                                       ad_utility::MemorySize::megabytes(100)),
                                   SortPerformanceEstimator{}, &namedResultCache,
-                                  &materializedViewsManager);
-        expectExecuteUpdateHelper(update, qec, index);
-        index.deltaTriplesManager().modify<void>(
+                                  materializedViewsManager);
+        expectExecuteUpdateHelper(update, qec, *index);
+        index->deltaTriplesManager().modify<void>(
             [&deltaTriplesMatcher](DeltaTriples& deltaTriples) {
               EXPECT_THAT(deltaTriples, deltaTriplesMatcher);
             });
@@ -94,20 +95,21 @@ TEST(ExecuteUpdate, executeUpdate) {
   // Execute the given `update` and check that it fails with the given message.
   auto expectExecuteUpdateFails_ =
       [&expectExecuteUpdateHelper](
-          Index& index, const std::string& update,
+          std::shared_ptr<Index> index, const std::string& update,
           const testing::Matcher<const std::string&>& messageMatcher,
           source_location sourceLocation = AD_CURRENT_SOURCE_LOC()) {
         auto l = generateLocationTrace(sourceLocation);
         QueryResultCache cache = QueryResultCache();
         NamedResultCache namedResultCache;
-        MaterializedViewsManager materializedViewsManager;
+        auto materializedViewsManager =
+            std::make_shared<MaterializedViewsManager>();
         QueryExecutionContext qec(index, &cache,
                                   ad_utility::testing::makeAllocator(
                                       ad_utility::MemorySize::megabytes(100)),
                                   SortPerformanceEstimator{}, &namedResultCache,
-                                  &materializedViewsManager);
+                                  materializedViewsManager);
         AD_EXPECT_THROW_WITH_MESSAGE(
-            expectExecuteUpdateHelper(update, qec, index), messageMatcher);
+            expectExecuteUpdateHelper(update, qec, *index), messageMatcher);
       };
   {
     auto expectExecuteUpdateFails =
@@ -115,9 +117,10 @@ TEST(ExecuteUpdate, executeUpdate) {
             const std::string& update,
             const testing::Matcher<const std::string&>& messageMatcher,
             source_location sourceLocation = AD_CURRENT_SOURCE_LOC()) {
-          Index index = ad_utility::testing::makeTestIndex(
-              "ExecuteUpdate_executeUpdate",
-              ad_utility::testing::TestIndexConfig());
+          auto index =
+              std::make_shared<Index>(ad_utility::testing::makeTestIndex(
+                  "ExecuteUpdate_executeUpdate",
+                  ad_utility::testing::TestIndexConfig()));
           expectExecuteUpdateFails_(index, update, messageMatcher,
                                     sourceLocation);
         };

--- a/test/MaterializedViewsTest.cpp
+++ b/test/MaterializedViewsTest.cpp
@@ -791,7 +791,7 @@ TEST_F(MaterializedViewsTest, serverIntegration) {
     Server server{4321, 1, ad_utility::MemorySize::megabytes(1), "accessToken"};
     server.initialize(testIndexBase_, false, true, true, false,
                       {"testViewForServerPreload"});
-    EXPECT_TRUE(server.materializedViewsManager_.isViewLoaded(
+    EXPECT_TRUE(server.materializedViewsManager_->isViewLoaded(
         "testViewForServerPreload"));
   }
 

--- a/test/OperationTest.cpp
+++ b/test/OperationTest.cpp
@@ -177,21 +177,23 @@ class OperationTestFixture : public testing::Test {
  protected:
   std::vector<std::string> jsonHistory;
 
-  Index index = []() {
+  std::shared_ptr<Index> index = []() {
     TestIndexConfig indexConfig{};
     indexConfig.blocksizePermutations = 32_B;
-    return makeTestIndex("OperationTest", std::move(indexConfig));
+    return std::make_shared<Index>(
+        makeTestIndex("OperationTest", std::move(indexConfig)));
   }();
   QueryResultCache cache;
   NamedResultCache namedCache;
-  MaterializedViewsManager materializedViewsManager;
+  std::shared_ptr<MaterializedViewsManager> materializedViewsManager =
+      std::make_shared<MaterializedViewsManager>();
   QueryExecutionContext qec{
       index,
       &cache,
       makeAllocator(),
       SortPerformanceEstimator{},
       &namedCache,
-      &materializedViewsManager,
+      materializedViewsManager,
       [&](std::string json) { jsonHistory.emplace_back(std::move(json)); }};
   IdTable table = makeIdTableFromVector({{}, {}, {}});
   ValuesForTesting operation{&qec, std::move(table), {}};
@@ -483,17 +485,19 @@ TEST(Operation, verifyRuntimeInformationIsUpdatedForLazyOperations) {
 // _____________________________________________________________________________
 TEST(Operation, ensureFailedStatusIsSetWhenGeneratorThrowsException) {
   bool signaledUpdate = false;
-  const Index& index = ad_utility::testing::getQec()->getIndex();
+  auto index = std::make_shared<Index>(
+      makeTestIndex("ensureFailedStatusIsSetWhenGeneratorThrowsException",
+                    TestIndexConfig{}));
   QueryResultCache cache{};
   NamedResultCache namedCache{};
-  MaterializedViewsManager materializedViewsManager;
+  auto materializedViewsManager = std::make_shared<MaterializedViewsManager>();
   QueryExecutionContext context{
       index,
       &cache,
       makeAllocator(ad_utility::MemorySize::megabytes(100)),
       SortPerformanceEstimator{},
       &namedCache,
-      &materializedViewsManager,
+      materializedViewsManager,
       [&](std::string) { signaledUpdate = true; }};
   AlwaysFailOperation operation{&context};
   ad_utility::Timer timer{ad_utility::Timer::InitialStatus::Started};
@@ -512,17 +516,18 @@ TEST(Operation, ensureFailedStatusIsSetWhenGeneratorThrowsException) {
 // _____________________________________________________________________________
 TEST(Operation, ensureFailedStatusIsSetWhenGeneratorIsCancelled) {
   bool signaledUpdate = false;
-  const Index& index = ad_utility::testing::getQec()->getIndex();
+  auto index = std::make_shared<Index>(makeTestIndex(
+      "ensureFailedStatusIsSetWhenGeneratorIsCancelled", TestIndexConfig{}));
   QueryResultCache cache{};
   NamedResultCache namedCache{};
-  MaterializedViewsManager materializedViewsManager;
+  auto materializedViewsManager = std::make_shared<MaterializedViewsManager>();
   QueryExecutionContext context{
       index,
       &cache,
       makeAllocator(ad_utility::MemorySize::megabytes(100)),
       SortPerformanceEstimator{},
       &namedCache,
-      &materializedViewsManager,
+      materializedViewsManager,
       [&](std::string) { signaledUpdate = true; }};
   CustomGeneratorOperation operation{
       &context, []() -> Result::Generator {
@@ -549,17 +554,18 @@ TEST(Operation, ensureSignalUpdateIsOnlyCalledEvery50msAndAtTheEnd) {
 #endif
   uint32_t updateCallCounter = 0;
   auto idTable = makeIdTableFromVector({{}});
-  const Index& index = getQec()->getIndex();
+  auto index = std::make_shared<Index>(makeTestIndex(
+      "ensureSignalUpdateIsOnlyCalledEvery50msAndAtTheEnd", TestIndexConfig{}));
   QueryResultCache cache{};
   NamedResultCache namedCache{};
-  MaterializedViewsManager materializedViewsManager;
+  auto materializedViewsManager = std::make_shared<MaterializedViewsManager>();
   QueryExecutionContext context{
       index,
       &cache,
       makeAllocator(ad_utility::MemorySize::megabytes(100)),
       SortPerformanceEstimator{},
       &namedCache,
-      &materializedViewsManager,
+      materializedViewsManager,
       [&](std::string) { ++updateCallCounter; }};
   CustomGeneratorOperation operation{
       &context, [](const IdTable& idTable) -> Result::Generator {
@@ -597,17 +603,19 @@ TEST(Operation, ensureSignalUpdateIsOnlyCalledEvery50msAndAtTheEnd) {
 TEST(Operation, ensureSignalUpdateIsCalledAtTheEndOfPartialConsumption) {
   uint32_t updateCallCounter = 0;
   auto idTable = makeIdTableFromVector({{}});
-  const Index& index = getQec()->getIndex();
+  auto index = std::make_shared<Index>(
+      makeTestIndex("ensureSignalUpdateIsCalledAtTheEndOfPartialConsumption",
+                    TestIndexConfig{}));
   QueryResultCache cache{};
   NamedResultCache namedCache{};
-  MaterializedViewsManager materializedViewsManager;
+  auto materializedViewsManager = std::make_shared<MaterializedViewsManager>();
   QueryExecutionContext context{
       index,
       &cache,
       makeAllocator(ad_utility::MemorySize::megabytes(100)),
       SortPerformanceEstimator{},
       &namedCache,
-      &materializedViewsManager,
+      materializedViewsManager,
       [&](std::string) { ++updateCallCounter; }};
   CustomGeneratorOperation operation{
       &context, [](const IdTable& idTable) -> Result::Generator {

--- a/test/engine/IndexScanTest.cpp
+++ b/test/engine/IndexScanTest.cpp
@@ -562,9 +562,10 @@ TEST(IndexScan, getResultSizeOfScan) {
 
 // _____________________________________________________________________________
 TEST(IndexScan, getResultSizeOfScanWithDeltaTriples) {
-  auto index = makeTestIndex("getResultSizeOfScanWithDeltaTriples",
-                             "<a> <a> <a> . <b> <b> <b> . <c> <c> <c> .");
-  auto getId = makeGetId(index);
+  auto index = std::make_shared<Index>(
+      makeTestIndex("getResultSizeOfScanWithDeltaTriples",
+                    "<a> <a> <a> . <b> <b> <b> . <c> <c> <c> ."));
+  auto getId = makeGetId(*index);
   auto g = qlever::specialIds().at(QLEVER_INTERNAL_GRAPH_IRI);
   auto a = getId("<a>");
   auto b = getId("<b>");
@@ -572,13 +573,13 @@ TEST(IndexScan, getResultSizeOfScanWithDeltaTriples) {
 
   QueryResultCache cache;
   NamedResultCache namedCache;
-  MaterializedViewsManager materializedViewsManager;
+  auto materializedViewsManager = std::make_shared<MaterializedViewsManager>();
   std::unique_ptr<QueryExecutionContext> qec = nullptr;
 
   auto makeScan = [&]() {
     qec = std::make_unique<QueryExecutionContext>(
         index, &cache, makeAllocator(ad_utility::MemorySize::megabytes(100)),
-        SortPerformanceEstimator{}, &namedCache, &materializedViewsManager);
+        SortPerformanceEstimator{}, &namedCache, materializedViewsManager);
 
     SparqlTripleSimple scanTriple{V{"?x"}, V("?y"), V{"?z"}};
     return IndexScan{qec.get(), Permutation::Enum::PSO, scanTriple};
@@ -589,7 +590,7 @@ TEST(IndexScan, getResultSizeOfScanWithDeltaTriples) {
   // Since the rough estimate doesn't know if the delta triples are inserts or
   // deletions, the estimate remains the same regardless of the delta triples.
   {
-    index.deltaTriplesManager().modify<void>([&](DeltaTriples& deltaTriples) {
+    index->deltaTriplesManager().modify<void>([&](DeltaTriples& deltaTriples) {
       deltaTriples.insertTriples(cancellationHandle,
                                  {IdTriple<0>{std::array{a, a, a, g}}});
       deltaTriples.deleteTriples(cancellationHandle,
@@ -600,7 +601,7 @@ TEST(IndexScan, getResultSizeOfScanWithDeltaTriples) {
     EXPECT_FALSE(scan.sizeEstimateIsExactForTesting());
   }
   {
-    index.deltaTriplesManager().modify<void>([&](DeltaTriples& deltaTriples) {
+    index->deltaTriplesManager().modify<void>([&](DeltaTriples& deltaTriples) {
       deltaTriples.insertTriples(cancellationHandle,
                                  {IdTriple<0>{std::array{b, b, b, g}}});
     });
@@ -609,7 +610,7 @@ TEST(IndexScan, getResultSizeOfScanWithDeltaTriples) {
     EXPECT_FALSE(scan.sizeEstimateIsExactForTesting());
   }
   {
-    index.deltaTriplesManager().modify<void>([&](DeltaTriples& deltaTriples) {
+    index->deltaTriplesManager().modify<void>([&](DeltaTriples& deltaTriples) {
       deltaTriples.deleteTriples(cancellationHandle,
                                  {IdTriple<0>{std::array{a, a, a, g}}});
       deltaTriples.deleteTriples(cancellationHandle,

--- a/test/util/IndexTestHelpers.cpp
+++ b/test/util/IndexTestHelpers.cpp
@@ -345,15 +345,15 @@ QueryExecutionContext* getQec(TestIndexConfig c) {
   // `Context`.
   struct Context {
     TypeErasedCleanup cleanup_;
-    std::unique_ptr<Index> index_;
+    std::shared_ptr<Index> index_;
     std::unique_ptr<QueryResultCache> cache_;
     std::unique_ptr<NamedResultCache> namedCache_;
-    std::unique_ptr<MaterializedViewsManager> materializedViewsManager_;
+    std::shared_ptr<MaterializedViewsManager> materializedViewsManager_;
     std::shared_ptr<QueryExecutionContext> qec_ =
         std::make_unique<QueryExecutionContext>(
-            *index_, cache_.get(), makeAllocator(MemorySize::megabytes(100)),
+            index_, cache_.get(), makeAllocator(MemorySize::megabytes(100)),
             SortPerformanceEstimator{}, namedCache_.get(),
-            materializedViewsManager_.get());
+            materializedViewsManager_);
   };
 
   static ad_utility::HashMap<TestIndexConfig, Context> contextMap;
@@ -371,10 +371,10 @@ QueryExecutionContext* getQec(TestIndexConfig c) {
                        ad_utility::deleteFile(indexFilename, false);
                      }
                    }},
-                   std::make_unique<Index>(makeTestIndex(testIndexBasename, c)),
+                   std::make_shared<Index>(makeTestIndex(testIndexBasename, c)),
                    std::make_unique<QueryResultCache>(),
                    std::make_unique<NamedResultCache>(),
-                   std::make_unique<MaterializedViewsManager>()});
+                   std::make_shared<MaterializedViewsManager>()});
   }
   return contextMap.at(c).qec_.get();
 }


### PR DESCRIPTION
So far, `Server` and `Qlever` held `Index` and `MaterializedViewsManager` by value, and passed them to `QueryExecutionContext` as reference or pointer. This tied the lifetimes of those objects to the owning `Server` and `Qlever` instance and made it impossible for a `QueryExecutionContext` to outlive its owner.

Now both `Index` and `MaterializedViewsManager` are held via a `std::shared_ptr` in all three classes. The `QueryExecutionContext` constructor takes the corresponding `shared_ptr` by value and thus keeps the two alive as long as it exists.

This is the first step toward #2832 (shared swappable indexes). In this change, no swap mechanism is added yet, only the ownership model changes.