### PR TITLE
Turn vocabulary-order check during index build into an assertion

### DIFF
--- a/src/index/StringSortComparator.h
+++ b/src/index/StringSortComparator.h
@@ -170,27 +170,16 @@ class LocaleManager {
   }
 
   /**
-   * @brief Transform a UTF-8 string into a SortKey that can be compared using
-   * std::strcmp.
+   * @brief Transform a UTF-8 string into a `SortKey`.
    *
    * We need this wrapper because ICU internally only works on utf16 and does
    * not create c++ strings in large parts of the API
    * @param s A UTF-8 encoded string.
    * @param level The Collation Level for which we want to create the SortKey
-   * @param resultFunction Will be called with a c-string (pointer and size) of
-   * the result.
-   * @return A weight string s.t. compare(s, t, level) ==
-   * std::strcmp(getSortKey(s, level), getSortKey(t, level)
+   * @return A `SortKey` s.t. compare(s, t, level) ==
+   * compare(getSortKey(s, level), getSortKey(t, level))
    */
-  // clang-format off
-  CPP_template(typename F)(
-    requires ranges::invocable<F, const uint8_t*, size_t>)
-      // clang-format on
-      void getSortKey(std::string_view s, const Level level,
-                      F resultFunction) const {
-    // TODO<joka921> This function is one of the bottlenecks of the first pass
-    // of the IndexBuilder One possible improvement is to reuse the memory
-    // allocations for the `sortKeyBuffer`.
+  SortKey getSortKey(std::string_view s, const Level level) const {
     auto utf16 = icu::UnicodeString::fromUTF8(toStringPiece(s));
     auto& col = *_collator[static_cast<uint8_t>(level)];
     std::vector<uint8_t> sortKeyBuffer;
@@ -220,18 +209,10 @@ class LocaleManager {
     // necessary for the prefix range to work correct.
     AD_CORRECTNESS_CHECK(sz > 0);
     --sz;
-    resultFunction(sortKeyBuffer.data(), sz);
-  }
-
-  // Overload of `getSortKey` that returns a `SortKey` directly.
-  [[nodiscard]] SortKey getSortKey(std::string_view s,
-                                   const Level level) const {
     SortKey result;
-    auto writeSortKey = [&result](const uint8_t* begin, size_t sz) {
-      U8String& s = result.get();
-      s.insert(s.end(), begin, begin + sz);
-    };
-    getSortKey(s, level, writeSortKey);
+    U8String& resultView = result.get();
+    resultView.insert(resultView.end(), sortKeyBuffer.data(),
+                      sortKeyBuffer.data() + sz);
     return result;
   }
 

--- a/src/index/VocabularyMergerImpl.h
+++ b/src/index/VocabularyMergerImpl.h
@@ -117,11 +117,11 @@ CPP_template_def(typename C, typename L)(
   for (auto& top : buffer) {
     if (!lastTripleComponent_.has_value() ||
         top.iriOrLiteral() != lastTripleComponent_.value().iriOrLiteral()) {
-      if (lastTripleComponent_.has_value() &&
-          !lessThan(lastTripleComponent_.value(), top.entry_)) {
-        AD_LOG_WARN << "Total vocabulary order violated for "
-                    << lastTripleComponent_->iriOrLiteral() << " and "
-                    << top.iriOrLiteral() << std::endl;
+      if (lastTripleComponent_.has_value()) {
+        AD_CORRECTNESS_CHECK(lessThan(lastTripleComponent_.value(), top.entry_),
+                             "Total vocabulary order violated for ",
+                             lastTripleComponent_->iriOrLiteral(), " and ",
+                             top.iriOrLiteral());
       }
       lastTripleComponent_ =
           TripleComponentWithIndex{std::move(top.iriOrLiteral()),

--- a/test/VocabularyGeneratorTest.cpp
+++ b/test/VocabularyGeneratorTest.cpp
@@ -22,6 +22,7 @@
 #include "index/vocabulary/SplitVocabulary.h"
 #include "index/vocabulary/VocabularyInternalExternal.h"
 #include "util/Algorithm.h"
+#include "util/GTestHelpers.h"
 
 using namespace ad_utility::vocabulary_merger;
 namespace {
@@ -232,6 +233,39 @@ TEST_F(MergeVocabularyTest, mergeVocabulary) {
   IdMap mapping1 = getIdMapFromFile(_basePath + PARTIAL_VOCAB_IDMAP_INFIX +
                                     std::to_string(1));
   ASSERT_TRUE(vocabTestCompare(mapping1, _expMapping1));
+}
+
+// _____________________________________________________________________________
+TEST(MergeVocabulary, mergeVocabularyAssertion) {
+  auto callback = [](const auto&, bool) { return uint64_t{0}; };
+
+  std::string basePath = "MergeVocabulary.mergeVocabularyAssertion";
+
+  auto writeUnorderedFile = [](const auto& path) {
+    ad_utility::serialization::FileWriteSerializer partialVocab(path);
+    // Intentionally in wrong order.
+    std::array<std::string_view, 3> strings{"\"c\"", "\"b\"", "\"a\""};
+    partialVocab << strings.size();
+    size_t localIdx = 0;
+    for (auto s : strings) {
+      partialVocab << s;
+      partialVocab << false;
+      partialVocab << localIdx;
+      localIdx++;
+    }
+  };
+
+  writeUnorderedFile(absl::StrCat(basePath, PARTIAL_VOCAB_WORDS_INFIX, 0));
+  writeUnorderedFile(absl::StrCat(basePath, PARTIAL_VOCAB_WORDS_INFIX, 1));
+
+  AD_EXPECT_THROW_WITH_MESSAGE_AND_TYPE(
+      mergeVocabulary(
+          basePath, 2,
+          [](std::string_view a, bool, std::string_view b, bool) {
+            return std::less{}(a, b);
+          },
+          callback, 1_GB),
+      ::testing::HasSubstr("vocabulary order violated"), ad_utility::Exception);
 }
 
 TEST(VocabularyGeneratorTest, createInternalMapping) {


### PR DESCRIPTION
So far, when `VocabularyMerger::writeQueueWordsToIdMap` saw two adjacent RDF terms in the wrong order, it logged a warning and continued. After the fix from #2856, this should no longer happen. We verified that it no longer happens for the Wikidata index build, which used to have warnings for a few pairs of very similar literals involving rather special diacritics. The order check is therefore now an `AD_CORRECTNESS_CHECK`, which throws a `ad_utility::Exception` that aborts the index build cleanly.

On the side, collapse the two `LocaleManager::getSortKey` overloads into one function that directly returns a `SortKey`.