### PR TITLE
Fix assertion error in `IndexScan` when joining materialized views

### DIFF
--- a/src/engine/IndexScan.cpp
+++ b/src/engine/IndexScan.cpp
@@ -491,7 +491,12 @@ IndexScan::lazyScanForJoinOfTwoScans(const IndexScan& s1, const IndexScan& s2) {
     ad_utility::HashSet<Variable> otherVars;
     for (size_t i = indexOfFirstVar + 1; i < 3; ++i) {
       const auto& el = *scan.getPermutedTriple()[i];
-      if (el.isVariable()) {
+      if (el.isVariable() &&
+          // Variables that get stripped immediately by `scan` should not be
+          // taken into account as they are not part of the result (and will not
+          // be joined on).
+          (!scan.varsToKeep_.has_value() ||
+           scan.varsToKeep_.value().contains(el.getVariable()))) {
         otherVars.insert(el.getVariable());
       }
     }

--- a/src/engine/IndexScan.cpp
+++ b/src/engine/IndexScan.cpp
@@ -489,16 +489,23 @@ IndexScan::lazyScanForJoinOfTwoScans(const IndexScan& s1, const IndexScan& s2) {
     AD_CORRECTNESS_CHECK(numVars <= 3);
     size_t indexOfFirstVar = 3 - numVars;
     ad_utility::HashSet<Variable> otherVars;
+    auto addOtherVar = [&otherVars, &scan](const Variable& el) {
+      // Variables that get stripped immediately by `scan` should not be
+      // taken into account as they are not part of the result (and will not
+      // be joined on).
+      if (!scan.varsToKeep_.has_value() ||
+          scan.varsToKeep_.value().contains(el)) {
+        otherVars.insert(el);
+      }
+    };
     for (size_t i = indexOfFirstVar + 1; i < 3; ++i) {
       const auto& el = *scan.getPermutedTriple()[i];
-      if (el.isVariable() &&
-          // Variables that get stripped immediately by `scan` should not be
-          // taken into account as they are not part of the result (and will not
-          // be joined on).
-          (!scan.varsToKeep_.has_value() ||
-           scan.varsToKeep_.value().contains(el.getVariable()))) {
-        otherVars.insert(el.getVariable());
+      if (el.isVariable()) {
+        addOtherVar(el.getVariable());
       }
+    }
+    for (const auto& var : scan.additionalVariables()) {
+      addOtherVar(var);
     }
     return std::pair{*scan.getPermutedTriple()[3 - numVars],
                      std::move(otherVars)};

--- a/src/engine/IndexScan.cpp
+++ b/src/engine/IndexScan.cpp
@@ -519,7 +519,9 @@ IndexScan::lazyScanForJoinOfTwoScans(const IndexScan& s1, const IndexScan& s2) {
   for (auto& var : other1) {
     other2.insert(var);
   }
-  AD_CONTRACT_CHECK(other2.size() == numTotal);
+  AD_CONTRACT_CHECK(other2.size() == numTotal,
+                    "The two IndexScans for a lazy single-column join have "
+                    "more than one column in common.");
 
   auto metaBlocks1 = s1.getMetadataForScan();
   auto metaBlocks2 = s2.getMetadataForScan();

--- a/test/MaterializedViewsTest.cpp
+++ b/test/MaterializedViewsTest.cpp
@@ -28,7 +28,6 @@
 #include "engine/VariableToColumnMap.h"
 #include "engine/sparqlExpressions/LiteralExpression.h"
 #include "engine/sparqlExpressions/SparqlExpressionPimpl.h"
-#include "gmock/gmock.h"
 #include "index/EncodedIriManager.h"
 #include "parser/MaterializedViewQuery.h"
 #include "parser/SparqlParser.h"

--- a/test/MaterializedViewsTest.cpp
+++ b/test/MaterializedViewsTest.cpp
@@ -1652,3 +1652,34 @@ INSTANTIATE_TEST_SUITE_P(
         // An additional `BIND` is ignored and the view can still be used for
         // query rewriting. Also uses a different sorting.
         RewriteTestParams{std::string{simpleChainRenamedPlusBind}, 1500}));
+
+// _____________________________________________________________________________
+TEST_F(MaterializedViewsTest, JoinBetweenLazyScansWithPlaceholderVars) {
+  // Regression test for #2866.
+  auto plan = qlv().parseAndPlanQuery(simpleWriteQuery_);
+  MaterializedViewsManager manager{testIndexBase_};
+  manager.writeViewToDisk("testView1", plan);
+
+  auto [qetLeft, qecLeft, parsedLeft] = qlv().parseAndPlanQuery(R"(
+      PREFIX view: <https://qlever.cs.uni-freiburg.de/materializedView/>
+      SELECT * {
+        SERVICE view:testView1 {
+          _:config view:column-s <s1> ;
+                   view:column-p ?p .
+        }
+      }
+    )");
+  auto [qetRight, qecRight, parsedRight] = qlv().parseAndPlanQuery(R"(
+      PREFIX view: <https://qlever.cs.uni-freiburg.de/materializedView/>
+      SELECT * {
+        SERVICE view:testView1 {
+          _:config view:column-s <s2> ;
+                   view:column-p ?p .
+        }
+      }
+    )");
+  auto indexScanLeft = dynamic_cast<IndexScan&>(*qetLeft->getRootOperation());
+  auto indexScanRight = dynamic_cast<IndexScan&>(*qetRight->getRootOperation());
+  EXPECT_NO_THROW(
+      IndexScan::lazyScanForJoinOfTwoScans(indexScanLeft, indexScanRight));
+}

--- a/test/MaterializedViewsTest.cpp
+++ b/test/MaterializedViewsTest.cpp
@@ -28,6 +28,7 @@
 #include "engine/VariableToColumnMap.h"
 #include "engine/sparqlExpressions/LiteralExpression.h"
 #include "engine/sparqlExpressions/SparqlExpressionPimpl.h"
+#include "gmock/gmock.h"
 #include "index/EncodedIriManager.h"
 #include "parser/MaterializedViewQuery.h"
 #include "parser/SparqlParser.h"
@@ -1660,7 +1661,10 @@ TEST_F(MaterializedViewsTest, JoinBetweenLazyScansWithPlaceholderVars) {
   MaterializedViewsManager manager{testIndexBase_};
   manager.writeViewToDisk("testView1", plan);
 
-  auto [qetLeft, qecLeft, parsedLeft] = qlv().parseAndPlanQuery(R"(
+  // Test that the placeholder variable for the third column of both views,
+  // which is not read, does not trigger an assertion error.
+  {
+    auto [qetLeft, qecLeft, parsedLeft] = qlv().parseAndPlanQuery(R"(
       PREFIX view: <https://qlever.cs.uni-freiburg.de/materializedView/>
       SELECT * {
         SERVICE view:testView1 {
@@ -1669,7 +1673,7 @@ TEST_F(MaterializedViewsTest, JoinBetweenLazyScansWithPlaceholderVars) {
         }
       }
     )");
-  auto [qetRight, qecRight, parsedRight] = qlv().parseAndPlanQuery(R"(
+    auto [qetRight, qecRight, parsedRight] = qlv().parseAndPlanQuery(R"(
       PREFIX view: <https://qlever.cs.uni-freiburg.de/materializedView/>
       SELECT * {
         SERVICE view:testView1 {
@@ -1678,8 +1682,43 @@ TEST_F(MaterializedViewsTest, JoinBetweenLazyScansWithPlaceholderVars) {
         }
       }
     )");
-  auto indexScanLeft = dynamic_cast<IndexScan&>(*qetLeft->getRootOperation());
-  auto indexScanRight = dynamic_cast<IndexScan&>(*qetRight->getRootOperation());
-  EXPECT_NO_THROW(
-      IndexScan::lazyScanForJoinOfTwoScans(indexScanLeft, indexScanRight));
+    auto indexScanLeft = dynamic_cast<IndexScan&>(*qetLeft->getRootOperation());
+    auto indexScanRight =
+        dynamic_cast<IndexScan&>(*qetRight->getRootOperation());
+    EXPECT_NO_THROW(
+        IndexScan::lazyScanForJoinOfTwoScans(indexScanLeft, indexScanRight));
+  }
+
+  // Test that an join column that is not in the first three columns is
+  // correctly checked and thus triggers the assertion.
+  {
+    auto [qetLeft, qecLeft, parsedLeft] = qlv().parseAndPlanQuery(R"(
+      PREFIX view: <https://qlever.cs.uni-freiburg.de/materializedView/>
+      SELECT * {
+        SERVICE view:testView1 {
+          _:config view:column-s <s1> ;
+                   view:column-p ?p ;
+                   view:column-g ?g .
+        }
+      }
+    )");
+    auto [qetRight, qecRight, parsedRight] = qlv().parseAndPlanQuery(R"(
+      PREFIX view: <https://qlever.cs.uni-freiburg.de/materializedView/>
+      SELECT * {
+        SERVICE view:testView1 {
+          _:config view:column-s <s2> ;
+                   view:column-p ?p ;
+                   view:column-g ?g .
+        }
+      }
+    )");
+    auto indexScanLeft = dynamic_cast<IndexScan&>(*qetLeft->getRootOperation());
+    auto indexScanRight =
+        dynamic_cast<IndexScan&>(*qetRight->getRootOperation());
+    AD_EXPECT_THROW_WITH_MESSAGE(
+        IndexScan::lazyScanForJoinOfTwoScans(indexScanLeft, indexScanRight),
+        ::testing::HasSubstr(
+            "The two IndexScans for a lazy single-column join have "
+            "more than one column in common."));
+  }
 }


### PR DESCRIPTION
An assertion error was thrown under these conditions:

- a single-column join between two `IndexScan`s on materialized views
- both views are scanned lazily
- both views do not read their second column or both views do not read their third column

Also the assertion did not take into account additional columns at all. This is now fixed. Fixes #2866