### PR TITLE
Fix bug in optimized `GROUP BY` with `COUNT`

### DIFF
--- a/src/index/CompressedRelation.cpp
+++ b/src/index/CompressedRelation.cpp
@@ -1041,6 +1041,11 @@ IdTable CompressedRelationReader::getDistinctColIdsAndCounts(
   // contain more than one different `colId`. For the others, we can determine
   // the count from the metadata.
   for (const auto& [i, blockMetadata] : ranges::views::enumerate(blocks)) {
+    // The `numRows_` metadata shortcut is safe iff all rows of the block
+    // agree on the grouped column. Because triples within a block are sorted
+    // lexicographically by `(col0Id, col1Id, col2Id)`, that is equivalent to
+    // `firstTriple_` and `lastTriple_` agreeing on the first `columnIndex + 1`
+    // columns.
     if (!blockMetadata.containsInconsistentTriples(columnIndex + 1)) {
       // The whole block has the same `colId` -> we get all the information
       // from the metadata.

--- a/src/index/CompressedRelation.cpp
+++ b/src/index/CompressedRelation.cpp
@@ -39,23 +39,23 @@ static auto getBeginAndEnd(T& range) {
 // helper functions/methods from below (getMaskedTriple,
 // containsConsistentTriples, isConsistentWith) for consistency checking.
 
-// Extract the Ids from the given `PermutedTriple` in a tuple w.r.t. the
+// Extract the Ids from the given `PermutedTriple` in an array w.r.t. the
 // position (column index) defined by `ignoreIndex`. The ignored positions are
 // filled with Ids `Id::min()`. `Id::min()` is guaranteed
 // to be smaller than Ids of all other types.
-static auto getMaskedTriple(
+static std::array<Id, 3> getMaskedTriple(
     const CompressedBlockMetadata::PermutedTriple& triple,
     size_t ignoreIndex = 3) {
   const Id& undefined = Id::min();
   switch (ignoreIndex) {
     case 3:
-      return std::make_tuple(triple.col0Id_, triple.col1Id_, triple.col2Id_);
+      return {triple.col0Id_, triple.col1Id_, triple.col2Id_};
     case 2:
-      return std::make_tuple(triple.col0Id_, triple.col1Id_, undefined);
+      return {triple.col0Id_, triple.col1Id_, undefined};
     case 1:
-      return std::make_tuple(triple.col0Id_, undefined, undefined);
+      return {triple.col0Id_, undefined, undefined};
     case 0:
-      return std::make_tuple(undefined, undefined, undefined);
+      return {undefined, undefined, undefined};
     default:
       // ignoreIndex out of bound.
       AD_FAIL();
@@ -974,14 +974,12 @@ size_t CompressedRelationReader::getResultSizeOfScan(
 }
 
 // ____________________________________________________________________________
-CPP_template_def(typename IdGetter)(
-    requires ad_utility::InvocableWithConvertibleReturnType<
-        IdGetter, Id, const CompressedBlockMetadata::PermutedTriple&>) IdTable
-    CompressedRelationReader::getDistinctColIdsAndCountsImpl(
-        IdGetter idGetter, const ScanSpecAndBlocks& scanSpecAndBlocks,
-        const CancellationHandle& cancellationHandle,
-        const LocatedTriplesPerBlock& locatedTriplesPerBlock,
-        const LimitOffsetClause& limitOffset) const {
+IdTable CompressedRelationReader::getDistinctColIdsAndCountsImpl(
+    size_t columnIndex, const ScanSpecAndBlocks& scanSpecAndBlocks,
+    const CancellationHandle& cancellationHandle,
+    const LocatedTriplesPerBlock& locatedTriplesPerBlock,
+    const LimitOffsetClause& limitOffset) const {
+  AD_CORRECTNESS_CHECK(columnIndex <= 1);
   // The result has two columns: one for the distinct `Id`s and one for their
   // counts.
   IdTableStatic<2> table(allocator_);
@@ -1043,12 +1041,11 @@ CPP_template_def(typename IdGetter)(
   // contain more than one different `colId`. For the others, we can determine
   // the count from the metadata.
   for (const auto& [i, blockMetadata] : ranges::views::enumerate(blocks)) {
-    Id firstColId = std::invoke(idGetter, blockMetadata.firstTriple_);
-    Id lastColId = std::invoke(idGetter, blockMetadata.lastTriple_);
-    if (firstColId == lastColId) {
+    if (!blockMetadata.containsInconsistentTriples(columnIndex + 1)) {
       // The whole block has the same `colId` -> we get all the information
       // from the metadata.
-      bool abort = processColId(firstColId, blockMetadata.numRows_);
+      Id colId = getMaskedTriple(blockMetadata.firstTriple_)[columnIndex];
+      bool abort = processColId(colId, blockMetadata.numRows_);
       if (abort) {
         return std::move(table).toDynamic();
       }
@@ -1095,9 +1092,9 @@ IdTable CompressedRelationReader::getDistinctCol0IdsAndCounts(
     const CancellationHandle& cancellationHandle,
     const LocatedTriplesPerBlock& locatedTriplesPerBlock,
     const LimitOffsetClause& limitOffset) const {
-  return getDistinctColIdsAndCountsImpl(
-      &CompressedBlockMetadata::PermutedTriple::col0Id_, scanSpecAndBlocks,
-      cancellationHandle, locatedTriplesPerBlock, limitOffset);
+  return getDistinctColIdsAndCountsImpl(0, scanSpecAndBlocks,
+                                        cancellationHandle,
+                                        locatedTriplesPerBlock, limitOffset);
 }
 
 // ____________________________________________________________________________
@@ -1106,9 +1103,9 @@ IdTable CompressedRelationReader::getDistinctCol1IdsAndCounts(
     const CancellationHandle& cancellationHandle,
     const LocatedTriplesPerBlock& locatedTriplesPerBlock,
     const LimitOffsetClause& limitOffset) const {
-  return getDistinctColIdsAndCountsImpl(
-      &CompressedBlockMetadata::PermutedTriple::col1Id_, scanSpecAndBlocks,
-      cancellationHandle, locatedTriplesPerBlock, limitOffset);
+  return getDistinctColIdsAndCountsImpl(1, scanSpecAndBlocks,
+                                        cancellationHandle,
+                                        locatedTriplesPerBlock, limitOffset);
 }
 
 // ____________________________________________________________________________

--- a/src/index/CompressedRelation.cpp
+++ b/src/index/CompressedRelation.cpp
@@ -974,12 +974,12 @@ size_t CompressedRelationReader::getResultSizeOfScan(
 }
 
 // ____________________________________________________________________________
-IdTable CompressedRelationReader::getDistinctColIdsAndCountsImpl(
-    size_t columnIndex, const ScanSpecAndBlocks& scanSpecAndBlocks,
+IdTable CompressedRelationReader::getDistinctColIdsAndCounts(
+    ColumnIndex columnIndex, const ScanSpecAndBlocks& scanSpecAndBlocks,
     const CancellationHandle& cancellationHandle,
     const LocatedTriplesPerBlock& locatedTriplesPerBlock,
     const LimitOffsetClause& limitOffset) const {
-  AD_CORRECTNESS_CHECK(columnIndex <= 1);
+  AD_CORRECTNESS_CHECK(columnIndex <= 1, "Only column 0 and 1 are supported");
   // The result has two columns: one for the distinct `Id`s and one for their
   // counts.
   IdTableStatic<2> table(allocator_);
@@ -1084,28 +1084,6 @@ IdTable CompressedRelationReader::getDistinctColIdsAndCountsImpl(
   // Don't forget to add the last `col1Id` and its count.
   processColId(std::nullopt, 0);
   return std::move(table).toDynamic();
-}
-
-// ____________________________________________________________________________
-IdTable CompressedRelationReader::getDistinctCol0IdsAndCounts(
-    const ScanSpecAndBlocks& scanSpecAndBlocks,
-    const CancellationHandle& cancellationHandle,
-    const LocatedTriplesPerBlock& locatedTriplesPerBlock,
-    const LimitOffsetClause& limitOffset) const {
-  return getDistinctColIdsAndCountsImpl(0, scanSpecAndBlocks,
-                                        cancellationHandle,
-                                        locatedTriplesPerBlock, limitOffset);
-}
-
-// ____________________________________________________________________________
-IdTable CompressedRelationReader::getDistinctCol1IdsAndCounts(
-    const ScanSpecAndBlocks& scanSpecAndBlocks,
-    const CancellationHandle& cancellationHandle,
-    const LocatedTriplesPerBlock& locatedTriplesPerBlock,
-    const LimitOffsetClause& limitOffset) const {
-  return getDistinctColIdsAndCountsImpl(1, scanSpecAndBlocks,
-                                        cancellationHandle,
-                                        locatedTriplesPerBlock, limitOffset);
 }
 
 // ____________________________________________________________________________

--- a/src/index/CompressedRelation.h
+++ b/src/index/CompressedRelation.h
@@ -963,15 +963,17 @@ class CompressedRelationReader {
       const LocatedTriplesPerBlock& locatedTriples);
 
   // The common implementation for `getDistinctCol0IdsAndCounts` and
-  // `getCol1IdsAndCounts`.
-  CPP_template(typename IdGetter)(
-      requires ad_utility::InvocableWithConvertibleReturnType<
-          IdGetter, Id, const CompressedBlockMetadata::PermutedTriple&>) IdTable
-      getDistinctColIdsAndCountsImpl(
-          IdGetter idGetter, const ScanSpecAndBlocks& scanSpecAndBlocks,
-          const CancellationHandle& cancellationHandle,
-          const LocatedTriplesPerBlock& locatedTriplesPerBlock,
-          const LimitOffsetClause& limitOffset) const;
+  // `getCol1IdsAndCounts`. `columnIndex` is the index of the column whose
+  // distinct values and counts are computed (0 for `col0Id_`, 1 for `col1Id_`).
+  // It determines both which column is read and the prefix of columns that must
+  // agree between `firstTriple_` and `lastTriple_` of a block for the block to
+  // count as homogeneous (since the triples are sorted lexicographically by
+  // `(col0, col1, col2)`).
+  IdTable getDistinctColIdsAndCountsImpl(
+      size_t columnIndex, const ScanSpecAndBlocks& scanSpecAndBlocks,
+      const CancellationHandle& cancellationHandle,
+      const LocatedTriplesPerBlock& locatedTriplesPerBlock,
+      const LimitOffsetClause& limitOffset) const;
 };
 
 // TODO<joka921>

--- a/src/index/CompressedRelation.h
+++ b/src/index/CompressedRelation.h
@@ -824,18 +824,10 @@ class CompressedRelationReader {
       const LocatedTriplesPerBlock& locatedTriplesPerBlock) const;
 
  public:
-  // For a given relation, determine the `col1Id`s and their counts. This is
-  // used for `computeGroupByObjectWithCount`.
-  IdTable getDistinctCol1IdsAndCounts(
-      const ScanSpecAndBlocks& scanSpecAndBlocks,
-      const CancellationHandle& cancellationHandle,
-      const LocatedTriplesPerBlock& locatedTriplesPerBlock,
-      const LimitOffsetClause& limitOffset) const;
-
-  // For all `col0Ids` determine their counts. This is
-  // used for `computeGroupByForFullScan`.
-  IdTable getDistinctCol0IdsAndCounts(
-      const ScanSpecAndBlocks& scanSpecAndBlocks,
+  // Determine the distinct values and their counts for the column at
+  // `columnIndex` (must be 0 or 1). Used for GROUP BY optimizations.
+  IdTable getDistinctColIdsAndCounts(
+      ColumnIndex columnIndex, const ScanSpecAndBlocks& scanSpecAndBlocks,
       const CancellationHandle& cancellationHandle,
       const LocatedTriplesPerBlock& locatedTriplesPerBlock,
       const LimitOffsetClause& limitOffset) const;
@@ -961,19 +953,6 @@ class CompressedRelationReader {
   static ScanImplConfig getScanConfig(
       const ScanSpecification& scanSpec, ColumnIndicesRef additionalColumns,
       const LocatedTriplesPerBlock& locatedTriples);
-
-  // The common implementation for `getDistinctCol0IdsAndCounts` and
-  // `getCol1IdsAndCounts`. `columnIndex` is the index of the column whose
-  // distinct values and counts are computed (0 for `col0Id_`, 1 for `col1Id_`).
-  // It determines both which column is read and the prefix of columns that must
-  // agree between `firstTriple_` and `lastTriple_` of a block for the block to
-  // count as homogeneous (since the triples are sorted lexicographically by
-  // `(col0, col1, col2)`).
-  IdTable getDistinctColIdsAndCountsImpl(
-      size_t columnIndex, const ScanSpecAndBlocks& scanSpecAndBlocks,
-      const CancellationHandle& cancellationHandle,
-      const LocatedTriplesPerBlock& locatedTriplesPerBlock,
-      const LimitOffsetClause& limitOffset) const;
 };
 
 // TODO<joka921>

--- a/src/index/Permutation.cpp
+++ b/src/index/Permutation.cpp
@@ -123,7 +123,8 @@ IdTable Permutation::getDistinctCol1IdsAndCounts(
     Id col0Id, const CancellationHandle& cancellationHandle,
     const LocatedTriplesState& locatedTriplesState,
     const LimitOffsetClause& limitOffset) const {
-  return reader().getDistinctCol1IdsAndCounts(
+  return reader().getDistinctColIdsAndCounts(
+      1,
       getScanSpecAndBlocks(
           ScanSpecification{col0Id, std::nullopt, std::nullopt},
           locatedTriplesState),
@@ -137,9 +138,10 @@ IdTable Permutation::getDistinctCol0IdsAndCounts(
     const LocatedTriplesState& locatedTriplesState,
     const LimitOffsetClause& limitOffset) const {
   ScanSpecification scanSpec{std::nullopt, std::nullopt, std::nullopt};
-  return reader().getDistinctCol0IdsAndCounts(
-      getScanSpecAndBlocks(scanSpec, locatedTriplesState), cancellationHandle,
-      getLocatedTriplesForPermutation(locatedTriplesState), limitOffset);
+  return reader().getDistinctColIdsAndCounts(
+      0, getScanSpecAndBlocks(scanSpec, locatedTriplesState),
+      cancellationHandle, getLocatedTriplesForPermutation(locatedTriplesState),
+      limitOffset);
 }
 
 // _____________________________________________________________________

--- a/test/GroupByTest.cpp
+++ b/test/GroupByTest.cpp
@@ -2036,6 +2036,45 @@ TEST_F(GroupByOptimizations, computeGroupByObjectWithCountWithLimitAndOffset) {
 }
 
 // _____________________________________________________________________________
+// Regression test for a bug where `getDistinctColIdsAndCountsImpl` would
+// shortcut a block using only the metadata when `firstTriple_.col1Id_ ==
+// lastTriple_.col1Id_`.
+// This would sometimes occur for queries of the form:
+//   `SELECT ?p (COUNT(?p) AS ?count) WHERE { ?s ?p <o2> } GROUP BY ?p`
+TEST(GroupByOptimizationsRegression,
+     computeGroupByObjectWithCountWithNonUniformCol0) {
+  // All triples share the same predicate `<p>` but have different objects.
+  // Use a non-default `blocksizePermutations` so that multiple triples land in
+  // the same block.
+  TestIndexConfig config{
+      "<s1> <p> <o1> . "
+      "<s2> <p> <o2> . "
+      "<s3> <p> <o3> . "
+      "<s4> <p> <o4> . "
+      "<s5> <p> <o5> ."};
+  config.blocksizePermutations = 1_kB;
+  auto* qec = getQec(std::move(config));
+
+  auto scan = makeExecutionTree<IndexScan>(
+      qec, Permutation::Enum::OPS,
+      SparqlTripleSimple{Variable{"?s"}, Variable{"?p"}, iri("<o2>")});
+
+  Variable varP{"?p"};
+  auto countPPimpl = SparqlExpressionPimpl{
+      std::make_unique<CountExpression>(
+          false, std::make_unique<VariableExpression>(varP)),
+      "COUNT(?p)"};
+  std::vector<Alias> aliases{Alias{std::move(countPPimpl), Variable{"?count"}}};
+
+  GroupByImpl groupBy{qec, {varP}, aliases, scan};
+  auto getId = makeGetId(qec->getIndex());
+  // Exactly one triple (`<s2> <p> <o2>`) matches `?s ?p <o2>`, so the count for
+  // predicate `<p>` must be `1`, not the size of the whole block.
+  EXPECT_THAT(groupBy.computeGroupByObjectWithCount(),
+              optionalHasTable({{getId("<p>"), I(1)}}));
+}
+
+// _____________________________________________________________________________
 TEST_F(GroupByOptimizations, computeGroupByForFullIndexScan) {
   // Assert that a GROUP BY which is constructed from the given arguments
   // can not perform the `GroupByForSingleIndexScan2` optimization.

--- a/test/GroupByTest.cpp
+++ b/test/GroupByTest.cpp
@@ -2036,7 +2036,7 @@ TEST_F(GroupByOptimizations, computeGroupByObjectWithCountWithLimitAndOffset) {
 }
 
 // _____________________________________________________________________________
-// Regression test for a bug where `getDistinctColIdsAndCountsImpl` would
+// Regression test for a bug where `getDistinctColIdsAndCounts` would
 // shortcut a block using only the metadata when `firstTriple_.col1Id_ ==
 // lastTriple_.col1Id_`.
 // This would sometimes occur for queries of the form:


### PR DESCRIPTION
When a `GroupBy` operation on the result of an `IndexScan` just needs to compute the `COUNT` of each group, the reading and decompressing of complete index blocks can be skipped when all elements in the block belong to the same group. This is determined by looking at the first and last element of the block. There was a bug in how this was determined, which is now fixed. For example, the following query on olympics gave a wrong count so far (46875, which is the size of a whole block, instead of 1)
```sparql
SELECT ?p (COUNT(?s) as ?count) WHERE {
  ?s ?p "Michael Fred Phelps, II"@en .
} GROUP BY ?p
```