### PR TITLE
Upgrade to Docker image + performance tuning 🚀

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -26,16 +26,16 @@ jobs:
   build:
     env:
           compiler: clang
-          compiler-version: 16
+          compiler-version: 22
           build-type: Debug
           warnings: "-Wall -Wextra "
           # we disable the `assert()` macro as it messes with the coverage reports
           asan-flags: "-DNDEBUG"
           ubsan-flags: ""
           coverage-flags: "-fprofile-instr-generate -fcoverage-mapping"
-          cmake-flags: "-DCMAKE_C_COMPILER=clang-16 -DCMAKE_CXX_COMPILER=clang++-16"
+          cmake-flags: "-DCMAKE_C_COMPILER=clang-22 -DCMAKE_CXX_COMPILER=clang++-22"
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v6
       with:
@@ -47,15 +47,15 @@ jobs:
       uses: ./.github/workflows/install-compiler-ubuntu
       with:
         compiler: "clang"
-        compiler-version: "16"
+        compiler-version: "22"
     - name: Install coverage tools
       run: |
-        sudo apt install -y llvm-16
+        sudo apt install -y llvm-22
         sudo apt install mold
     - name: Show path
       run: |
-        which llvm-profdata-16
-        which llvm-cov-16
+        which llvm-profdata-22
+        which llvm-cov-22
     - name: Create build directory
       run: mkdir ${{github.workspace}}/build
     - name: Configure CMake
@@ -77,8 +77,8 @@ jobs:
     - name: Process coverage info
       working-directory: ${{github.workspace}}/build/test
       run:  >
-        llvm-profdata-16 merge -sparse *.profraw -o default.profdata;
-        llvm-cov-16 export ./QLeverAllUnitTestsMain --dump --format=lcov --instr-profile ./default.profdata --ignore-filename-regex="/third_party/" --ignore-filename-regex="/generated/"  --ignore-filename-regex="/nlohmann/" --ignore-filename-regex="/ctre/"  --ignore-filename-regex="/test/" --ignore-filename-regex="/benchmark/" > ./coverage.lcov
+        llvm-profdata-22 merge -sparse *.profraw -o default.profdata;
+        llvm-cov-22 export ./QLeverAllUnitTestsMain --dump --format=lcov --instr-profile ./default.profdata --ignore-filename-regex="/third_party/" --ignore-filename-regex="/generated/"  --ignore-filename-regex="/nlohmann/" --ignore-filename-regex="/ctre/"  --ignore-filename-regex="/test/" --ignore-filename-regex="/benchmark/" > ./coverage.lcov
 
 # Only upload the coverage directly if this is not a pull request. In this
 # case we are on the master branch and have access to the Codecov token.

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -23,7 +23,7 @@ jobs:
         build-type: [Release]
     runs-on: macos-15
     env:
-      LLVM_VERSION: 17
+      LLVM_VERSION: 22
     steps:
       - uses: actions/checkout@v6
 
@@ -55,19 +55,19 @@ jobs:
           cache-name: cache-conan-modules-macos-15
         with:
           path: ~/.conan2
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('conanfile.txt', 'conanprofiles/clang-17-macos')}}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('conanfile.txt', 'conanprofiles/clang-22-macos')}}
 
       - name: Create build directory
         run: mkdir ${{github.workspace}}/build
 
       - name: Install and run conan
         working-directory: ${{github.workspace}}/build
-        run: conan install .. -pr:b=../conanprofiles/clang-17-macos -pr:h=../conanprofiles/clang-17-macos -of=. --build=missing
+        run: conan install .. -pr:b=../conanprofiles/clang-22-macos -pr:h=../conanprofiles/clang-22-macos -of=. --build=missing
 
       - name: Configure CMake
-        # For std::ranges::join_view we need the -fexperimental-library flag on libc++17.
-        # We currently cannot use the parallel algorithms, as the parallel sort requires a GNU-extension, and we build with `libc++`.
-        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build-type}} -DCMAKE_TOOLCHAIN_FILE="$(pwd)/build/conan_toolchain.cmake" -DUSE_PARALLEL=false -DRUN_EXPENSIVE_TESTS=false -DENABLE_EXPENSIVE_CHECKS=true -DADDITIONAL_COMPILER_FLAGS="-fexperimental-library" -D_NO_TIMING_TESTS=ON
+        # Parallel algorithms are disabled because std::sort with an execution policy requires
+        # a GNU-extension not available with libc++ on macOS.
+        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build-type}} -DCMAKE_TOOLCHAIN_FILE="$(pwd)/build/conan_toolchain.cmake" -DUSE_PARALLEL=false -DRUN_EXPENSIVE_TESTS=false -DENABLE_EXPENSIVE_CHECKS=true -D_NO_TIMING_TESTS=ON
 
       - name: Build
         # Build your program with the given configuration

--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         compiler: [gcc, clang]
-        compiler-version: [8, 11, 12, 13, 18, 21]
+        compiler-version: [8, 11, 12, 13, 18, 22]
         warnings: [  "-Wall -Wextra -Werror " ]
         build-type: [Release]
         expensive-tests: [true]
@@ -39,7 +39,7 @@ jobs:
           - compiler: gcc
             compiler-version: 18
           - compiler: gcc
-            compiler-version: 21
+            compiler-version: 22
           - compiler: clang
             compiler-version: 8
           - compiler: clang
@@ -107,7 +107,7 @@ jobs:
 
       - name: Configure CMake
         env:
-          USE_PCH: ${{ matrix.compiler-version == 21 && 'ON' || 'OFF' }}
+          USE_PCH: ${{ matrix.compiler-version == 22 && 'ON' || 'OFF' }}
           CHEAPER_COMPILATION: ${{ matrix.compiler-version == 11 && 'ON' || 'OFF' }}
         # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
         # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM ubuntu:24.04 AS base
+FROM debian:trixie-slim AS base
 LABEL maintainer="Hannah Bast <bast@cs.uni-freiburg.de>"
 
-# Packages needed for both both building and running the binaries.
+# Packages needed for both building and running the binaries.
 ENV LANG=C.UTF-8
 ENV LC_ALL=C.UTF-8
 ENV LC_CTYPE=C.UTF-8
@@ -11,9 +11,19 @@ ENV DEBIAN_FRONTEND=noninteractive
 # stage to keep the final image small).
 FROM base AS builder
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get install -y wget
-RUN wget https://apt.kitware.com/kitware-archive.sh && chmod +x kitware-archive.sh && ./kitware-archive.sh
-RUN apt-get update && apt-get install -y build-essential cmake libicu-dev tzdata pkg-config uuid-runtime uuid-dev git libjemalloc-dev ninja-build libzstd-dev libssl-dev libboost1.83-dev libboost-program-options1.83-dev libboost-iostreams1.83-dev libboost-url1.83-dev libboost-container1.83-dev
+# Debian Trixie ships CMake 3.28+ natively, so no additional PPA is needed.
+# ca-certificates + gnupg are required to add the LLVM apt repository below.
+# libomp-dev provides OpenMP support for the parallel sort used in index building.
+RUN apt-get update && apt-get install -y wget ca-certificates gnupg build-essential cmake libicu-dev tzdata pkg-config uuid-runtime uuid-dev git libjemalloc-dev ninja-build libzstd-dev libssl-dev libboost-dev libboost-program-options-dev libboost-iostreams-dev libboost-url-dev libboost-container-dev libomp-dev
+
+# Add the LLVM 22 apt repository for Debian Trixie and install Clang 22.
+# We configure the repository directly rather than using llvm.sh, which requires
+# lsb_release and other tools not present in debian:trixie-slim.
+RUN wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | \
+      gpg --dearmor -o /usr/share/keyrings/llvm-archive-keyring.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] https://apt.llvm.org/trixie/ llvm-toolchain-trixie-22 main" \
+      > /etc/apt/sources.list.d/llvm.list && \
+    apt-get update && apt-get install -y clang-22
 
 # Copy everything we need to build the binaries.
 #
@@ -36,7 +46,7 @@ COPY GitVersion.cmake /qlever/
 # `-march=native`.
 ARG RUN_TESTS=true
 WORKDIR /qlever/build/
-RUN cmake -DCMAKE_BUILD_TYPE=Release -DLOGLEVEL=INFO -DUSE_PARALLEL=true -D_NO_TIMING_TESTS=ON -DCOMPILER_SUPPORTS_MARCH_NATIVE=FALSE -GNinja ..
+RUN cmake -DCMAKE_BUILD_TYPE=Release -DLOGLEVEL=INFO -DUSE_PARALLEL=true -D_NO_TIMING_TESTS=ON -DCOMPILER_SUPPORTS_MARCH_NATIVE=FALSE -DCMAKE_C_COMPILER=clang-22 -DCMAKE_CXX_COMPILER=clang++-22 -DADDITIONAL_COMPILER_FLAGS="-Wno-deprecated-declarations" -GNinja ..
 RUN if [ "$RUN_TESTS" = "true" ]; then \
       cmake --build . && ctest --rerun-failed --output-on-failure; \
     else \
@@ -44,10 +54,12 @@ RUN if [ "$RUN_TESTS" = "true" ]; then \
     fi
 
 # Install the packages needed for the final image.
+# libicu76: Debian Trixie ships ICU 76 (Ubuntu 24.04 had libicu74).
+# libboost-*1.83.0: Trixie has Boost 1.83, same versioned runtime lib names as Ubuntu.
 FROM base AS runtime
 WORKDIR /qlever
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get install -y wget python3-yaml unzip curl bzip2 pkg-config libicu74 python3-icu libgomp1 uuid-runtime make lbzip2 libjemalloc2 libzstd1 libboost-program-options1.83.0 libboost-iostreams1.83.0 libboost-url1.83.0 pipx bash-completion vim sudo && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y wget python3-yaml unzip curl bzip2 pkg-config libicu76 python3-icu libgomp1 uuid-runtime make lbzip2 libjemalloc2 libzstd1 libboost-program-options1.83.0 libboost-iostreams1.83.0 libboost-url1.83.0 pipx bash-completion vim sudo && rm -rf /var/lib/apt/lists/*
 
 # Set up user `qlever` with temporary sudo rights (which will be removed again
 # by the `docker-entrypoint.sh` script, see there).

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,16 +65,19 @@ COPY GitVersion.cmake /qlever/
 #
 #   MARCH (default: auto)
 #     Controls the CPU microarchitecture target. Leave empty (the default) for
-#     automatic selection: x86-64-v3 on amd64 builds, no -march on all others.
-#       x86-64-v3  AVX2 + FMA + BMI2  (Intel Haswell 2013+, AMD Zen1 2017+)
-#                  Auto-selected on amd64. 256-bit SIMD for sort, hash maps, strings.
-#       x86-64-v4  AVX-512            (Intel Ice Lake 2019+, AMD Zen4 2022+)
-#                  Maximum SIMD width; great for Wikidata-scale deployments.
-#       x86-64-v2  SSE4.2 / POPCNT    (2008+ Intel, 2011+ AMD)
-#                  For older but still 64-bit capable hardware.
-#       x86-64     SSE2 baseline       Fully portable across all x86-64 CPUs.
-#       native     Build machine CPU   Only use for local (non-distributed) builds.
-#                  NOTE: produces a non-portable binary.
+#     automatic selection per architecture:
+#       amd64  → x86-64-v3  (AVX2 + FMA + BMI2, Intel Haswell 2013+, AMD Zen1 2017+)
+#       arm64  → armv8.2-a+dotprod+crypto  (Graviton2, Neoverse N1, Ampere Altra 2018+)
+#       other  → no -march flag (compiler default - baseline, portable but suboptimal)
+#
+#     Common overrides:
+#       x86-64      (baseline)      SSE2 — fully portable across all x86-64
+#       x86-64-v2                   SSE4.2 / POPCNT — older x86-64 hardware
+#       x86-64-v4                   AVX-512 (Intel Ice Lake 2019+, AMD Zen4 2022+)
+#       armv8-a     (baseline)      NEON 128-bit (pre-2018 hardware, e.g. Graviton1)
+#       armv8.4-a                   SVE 256-bit — Graviton3, Neoverse V1 (2021+)
+#       armv9-a                     SVE2 — Graviton4, Neoverse V2 (2023+)
+#       native                      Build machine CPU (non-portable, local builds only)
 #     Example: docker build --build-arg MARCH=x86-64-v4 .
 #
 # -DCOMPILER_SUPPORTS_MARCH_NATIVE=FALSE prevents fsst from auto-detecting the
@@ -89,13 +92,13 @@ COPY GitVersion.cmake /qlever/
 #
 # MARCH defaults to empty: the RUN step below auto-selects x86-64-v3 on amd64
 # and leaves the flag unset on all other architectures (e.g. arm64).
-# USE_LTO=false  default: standard build, safe for ≤12 GB build environments.
-# USE_LTO=true   enables ThinLTO with memory-conserving options:
-#   -flto=thin              cross-module inlining at link time
-#   -Wl,--thinlto-jobs=3    cap lld's parallel backend workers at 3 threads;
-#                            without this lld spawns N_cores workers, each
-#                            holding a module in RAM simultaneously
-# Recommended minimum: 16 GB memory with USE_LTO=true.
+# USE_LTO=true   default: enables ThinLTO with memory-conserving options:
+#   -flto=thin              cross-module inlining at link time between QLever
+#                           and its dependencies (abseil, re2, s2geometry)
+#   -Wl,--thinlto-jobs=3    cap lld's parallel backend workers at 3 threads
+#                           to limit peak link-time RAM usage
+# Recommended minimum: 16 GB. Use --build-arg USE_LTO=false on machines
+# with ≤12 GB available to the Docker build (e.g. default Docker Desktop).
 #
 # SHOW_BUILD_STATS=false  default: no extra output.
 # SHOW_BUILD_STATS=true   adds -fproc-stat-report, which prints peak RSS to
@@ -114,6 +117,8 @@ RUN set -e && \
         MARCH_FLAG="-march=${MARCH}"; \
     elif [ "${ARCH}" = "x86_64" ]; then \
         MARCH_FLAG="-march=x86-64-v3"; \
+    elif [ "${ARCH}" = "aarch64" ]; then \
+        MARCH_FLAG="-march=armv8.2-a+dotprod+crypto"; \
     else \
         MARCH_FLAG=""; \
     fi && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,36 +1,52 @@
 FROM debian:trixie-slim AS base
 LABEL maintainer="Hannah Bast <bast@cs.uni-freiburg.de>"
 
-# Packages needed for both building and running the binaries.
 ENV LANG=C.UTF-8
 ENV LC_ALL=C.UTF-8
 ENV LC_CTYPE=C.UTF-8
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Install the packages needed for building the binaries (this is a separate
-# stage to keep the final image small).
+# ╔═════════════════════════════════════════════════════════════════════╗
+# ║  STAGE 1 — BUILD                                                    ║
+# ║  Compile QLever with Clang 22 (LLVM 22) and optionally run tests.   ║
+# ║  This stage is discarded; only the compiled binaries are kept.      ║
+# ╚═════════════════════════════════════════════════════════════════════╝
 FROM base AS builder
 ENV DEBIAN_FRONTEND=noninteractive
-# Debian Trixie ships CMake 3.28+ natively, so no additional PPA is needed.
-# ca-certificates + gnupg are required to add the LLVM apt repository below.
-# libomp-dev provides OpenMP support for the parallel sort used in index building.
-RUN apt-get update && apt-get install -y wget ca-certificates gnupg build-essential cmake libicu-dev tzdata pkg-config uuid-runtime uuid-dev git libjemalloc-dev ninja-build libzstd-dev libssl-dev libboost-dev libboost-program-options-dev libboost-iostreams-dev libboost-url-dev libboost-container-dev libomp-dev
+
+# Core build tools and C/C++ library headers.
+# Notes:
+#   build-essential  — even with Clang, GCC's libc6-dev/libstdc++ headers
+#                      and the system linker are needed at compile time.
+#   cmake / ninja    — Debian Trixie ships CMake 3.28+ natively (no PPA needed).
+#   git              — CMake FetchContent clones googletest, abseil, ctre, re2,
+#                      fsst, ANTLR, s2geometry, spatialjoin at configure time.
+#   libomp-dev       — OpenMP support for the parallel sort used in index building.
+#   ca-certificates + gnupg + wget — required to add the LLVM apt repository below.
+RUN apt-get update && apt-get install -y \
+    wget ca-certificates gnupg \
+    build-essential cmake ninja-build git \
+    libicu-dev pkg-config \
+    uuid-runtime uuid-dev \
+    libjemalloc-dev libzstd-dev libssl-dev \
+    libboost-dev \
+    libboost-program-options-dev \
+    libboost-iostreams-dev \
+    libboost-url-dev \
+    libboost-container-dev \
+    libomp-dev
 
 # Add the LLVM 22 apt repository for Debian Trixie and install Clang 22.
-# We configure the repository directly rather than using llvm.sh, which requires
-# lsb_release and other tools not present in debian:trixie-slim.
+# Configured directly (without llvm.sh) because debian:trixie-slim does not
+# include lsb_release or other tools that llvm.sh requires.
 RUN wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | \
       gpg --dearmor -o /usr/share/keyrings/llvm-archive-keyring.gpg && \
     echo "deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] https://apt.llvm.org/trixie/ llvm-toolchain-trixie-22 main" \
       > /etc/apt/sources.list.d/llvm.list && \
-    apt-get update && apt-get install -y clang-22
+    apt-get update && apt-get install -y clang-22 lld-22
 
-# Copy everything we need to build the binaries.
-#
-# NOTE: We are deliberately explicit here, for two reasons. First, so that we
-# don't copy more than necessary without having to rely on `.dockerignore`.
-# Second, so that we can copy `docker-entrypoint.sh` separately below (we don't
-# to rebuild the whole container when making a small change in there).
+# Copy source. Deliberately explicit: avoids .dockerignore surprises and lets
+# docker-entrypoint.sh be updated without invalidating the full build cache.
 COPY src /qlever/src/
 COPY test /qlever/test/
 COPY e2e /qlever/e2e/
@@ -40,26 +56,141 @@ COPY CMakeLists.txt /qlever/
 COPY CompilationInfo.cmake /qlever/
 COPY GitVersion.cmake /qlever/
 
-# Build and compile. By default, also compile and run all tests. In order not
-# to, build the image with `--build-arg RUN_TESTS=false`.
-# `-DCOMPILER_SUPPORTS_MARCH_NATIVE=FALSE` prevents fsst from compiling with
-# `-march=native`.
+# Configure and build.
+#
+# Build arguments:
+#   RUN_TESTS (default: true)
+#     Pass --build-arg RUN_TESTS=false to skip ctest and build only the
+#     qlever-server and qlever-index binaries.
+#
+#   MARCH (default: auto)
+#     Controls the CPU microarchitecture target. Leave empty (the default) for
+#     automatic selection: x86-64-v3 on amd64 builds, no -march on all others.
+#       x86-64-v3  AVX2 + FMA + BMI2  (Intel Haswell 2013+, AMD Zen1 2017+)
+#                  Auto-selected on amd64. 256-bit SIMD for sort, hash maps, strings.
+#       x86-64-v4  AVX-512            (Intel Ice Lake 2019+, AMD Zen4 2022+)
+#                  Maximum SIMD width; great for Wikidata-scale deployments.
+#       x86-64-v2  SSE4.2 / POPCNT    (2008+ Intel, 2011+ AMD)
+#                  For older but still 64-bit capable hardware.
+#       x86-64     SSE2 baseline       Fully portable across all x86-64 CPUs.
+#       native     Build machine CPU   Only use for local (non-distributed) builds.
+#                  NOTE: produces a non-portable binary.
+#     Example: docker build --build-arg MARCH=x86-64-v4 .
+#
+# -DCOMPILER_SUPPORTS_MARCH_NATIVE=FALSE prevents fsst from auto-detecting the
+# build machine's CPU independently of our MARCH setting.
+#
+# Performance flags:
+#   -fuse-ld=lld      LLVM lld linker — 2-3x faster than GNU ld. Always on.
+#   -flto=thin        ThinLTO — cross-module inlining at link time between QLever
+#                     and its FetchContent dependencies (abseil, re2, s2geometry).
+#                     Disabled by default: during the ThinLTO link step, lld loads
+#                     all LLVM bitcode modules simultaneously, which can require
+#                     10-16 GB of RAM for a codebase of this size. Enable with
+#                     --build-arg USE_LTO=true on machines with ample RAM (≥16 GB
+#                     recommended for Docker Desktop).
+#
+# MARCH defaults to empty: the RUN step below auto-selects x86-64-v3 on amd64
+# and leaves the flag unset on all other architectures (e.g. arm64).
 ARG RUN_TESTS=true
+ARG MARCH=
+ARG USE_LTO=true
 WORKDIR /qlever/build/
-RUN cmake -DCMAKE_BUILD_TYPE=Release -DLOGLEVEL=INFO -DUSE_PARALLEL=true -D_NO_TIMING_TESTS=ON -DCOMPILER_SUPPORTS_MARCH_NATIVE=FALSE -DCMAKE_C_COMPILER=clang-22 -DCMAKE_CXX_COMPILER=clang++-22 -DADDITIONAL_COMPILER_FLAGS="-Wno-deprecated-declarations" -GNinja ..
+RUN set -e && \
+    ARCH=$(uname -m) && \
+    if [ -n "${MARCH}" ]; then \
+        MARCH_FLAG="-march=${MARCH}"; \
+    elif [ "${ARCH}" = "x86_64" ]; then \
+        MARCH_FLAG="-march=x86-64-v3"; \
+    else \
+        MARCH_FLAG=""; \
+    fi && \
+    if [ "${USE_LTO}" = "true" ]; then \
+        LTO_CFLAGS="-flto=thin"; \
+        LTO_LFLAGS="-flto=thin"; \
+    else \
+        LTO_CFLAGS=""; \
+        LTO_LFLAGS=""; \
+    fi && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DLOGLEVEL=INFO \
+        -DUSE_PARALLEL=true \
+        -D_NO_TIMING_TESTS=ON \
+        -DCOMPILER_SUPPORTS_MARCH_NATIVE=FALSE \
+        -DCMAKE_C_COMPILER=clang-22 \
+        -DCMAKE_CXX_COMPILER=clang++-22 \
+        "-DADDITIONAL_COMPILER_FLAGS=-Wno-deprecated-declarations ${MARCH_FLAG} ${LTO_CFLAGS}" \
+        "-DADDITIONAL_LINKER_FLAGS=-fuse-ld=lld ${LTO_LFLAGS}" \
+        -GNinja ..
 RUN if [ "$RUN_TESTS" = "true" ]; then \
       cmake --build . && ctest --rerun-failed --output-on-failure; \
     else \
       cmake --build . --target qlever-index qlever-server && echo "Skipping tests"; \
     fi
 
-# Install the packages needed for the final image.
-# libicu76: Debian Trixie ships ICU 76 (Ubuntu 24.04 had libicu74).
-# libboost-*1.83.0: Trixie has Boost 1.83, same versioned runtime lib names as Ubuntu.
+# Strip debug sections from the compiled binaries. CMake Release mode does not
+# emit -g, but FetchContent dependencies can still contain debug info.
+# Smaller binaries → faster cold-start I/O and better instruction-cache density.
+RUN strip --strip-debug \
+    /qlever/build/qlever-server \
+    /qlever/build/qlever-index \
+    /qlever/build/VocabularyMergerMain \
+    /qlever/build/PrintIndexVersionMain
+
+# ╔═════════════════════════════════════════════════════════════════════╗
+# ║  STAGE 2 — RUNTIME                                                  ║
+# ║  Minimal deployment image (~30 MB base, debian:trixie-slim).        ║
+# ║  Contains only the compiled binaries and their runtime deps.        ║
+# ╚═════════════════════════════════════════════════════════════════════╝
 FROM base AS runtime
 WORKDIR /qlever
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get install -y wget python3-yaml unzip curl bzip2 pkg-config libicu76 python3-icu libgomp1 uuid-runtime make lbzip2 libjemalloc2 libzstd1 libboost-program-options1.83.0 libboost-iostreams1.83.0 libboost-url1.83.0 libboost-container1.83.0 pipx bash-completion vim sudo && rm -rf /var/lib/apt/lists/*
+# jemalloc tuning: enable background threads so dirty/muzzy pages are
+# returned to the OS between queries instead of accumulating indefinitely.
+# This keeps RSS low for long-running server instances without adding latency
+# to individual allocations. See https://jemalloc.net/jemalloc.3.html
+ENV MALLOC_CONF=background_thread:true,metadata_thp:auto
+
+# Shared libraries linked by qlever-server and qlever-index:
+#   libicu76                    Unicode/ICU (text processing, collation)
+#   libssl3                     OpenSSL — TLS for the built-in HTTP server
+#   libjemalloc2                jemalloc allocator (reduces heap fragmentation)
+#   libzstd1                    Zstandard compression (index file storage)
+#   libgomp1                    OpenMP runtime (parallel index building)
+#   libboost-program-options    command-line argument parsing
+#   libboost-iostreams          stream compression / decompression
+#   libboost-url                URL parsing in SPARQL endpoint requests
+#   libboost-container          Boost container data structures
+#
+# QLever Python CLI and its dependencies:
+#   python3-yaml, python3-icu   required by the qlever CLI tool
+#   pipx                        installs the qlever CLI into an isolated venv
+#
+# Index build and data management utilities:
+#   uuid-runtime                uuidgen for blank-node ID generation
+#   make                        runs the Qleverfile (dataset Makefile)
+#   lbzip2, bzip2               parallel + standard bzip2 for index archives
+#   wget, curl, unzip           downloading and unpacking dataset files
+#   pkg-config                  used by some qlever CLI build helpers
+#
+# Container UX:
+#   bash-completion, vim, sudo  interactive shell convenience inside the container
+RUN apt-get update && apt-get install -y \
+    libicu76 \
+    libssl3 \
+    libjemalloc2 \
+    libzstd1 \
+    libgomp1 \
+    libboost-program-options1.83.0 \
+    libboost-iostreams1.83.0 \
+    libboost-url1.83.0 \
+    libboost-container1.83.0 \
+    python3-yaml python3-icu pipx \
+    uuid-runtime make lbzip2 bzip2 \
+    wget curl unzip pkg-config \
+    bash-completion vim sudo \
+    && rm -rf /var/lib/apt/lists/*
 
 # Set up user `qlever` with temporary sudo rights (which will be removed again
 # by the `docker-entrypoint.sh` script, see there).
@@ -67,9 +198,8 @@ RUN groupadd -r qlever && useradd --no-log-init -d /qlever -r -g qlever qlever
 RUN chown qlever:qlever /qlever
 RUN echo "qlever ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
-# Set up a profile script that is sourced whenever a new login shell is
-# started (by any user, hence in `/etc/profile.d/`). For some reason, podman
-# wants it in `/qlever/.bashrc`, so we also copy it there.
+# Profile script sourced by every login shell (any user, hence /etc/profile.d/).
+# Copied to /qlever/.bashrc as well, because podman reads it from there.
 ENV QLEVER_PROFILE=/etc/profile.d/qlever.sh
 RUN echo "eval \"\$(register-python-argcomplete qlever)\"" >> $QLEVER_PROFILE
 RUN echo "export QLEVER_ARGCOMPLETE_ENABLED=1 && export QLEVER_IS_RUNNING_IN_CONTAINER=1" >> $QLEVER_PROFILE
@@ -78,22 +208,19 @@ RUN echo 'alias ll="ls -l"' >> $QLEVER_PROFILE
 RUN echo "if [ -d /data ]; then cd /data; fi" >> $QLEVER_PROFILE
 RUN cp $QLEVER_PROFILE /qlever/.bashrc
 
-# Install the `qlever` command line tool. We have to set the two environment
-# variables again here because in batch mode, the profile script above is not
-# sourced. The `PATH` is set again to avoid a warning from `pipx`.
+# Install the `qlever` command line tool.
+# The two ENV vars are set again here because batch-mode RUN steps do not
+# source the profile script above. PATH is repeated to suppress a pipx warning.
 USER qlever
 ENV PATH=/qlever:/qlever/.local/bin:$PATH
 RUN pipx install qlever
 ENV QLEVER_ARGCOMPLETE_ENABLED=1
 ENV QLEVER_IS_RUNNING_IN_CONTAINER=1
 
-# Copy the binaries and the entrypoint script.
-# qlever-server, qlever-index
+# Copy compiled binaries and the entrypoint from the build stage.
 COPY --from=builder /qlever/build/qlever-* /qlever/
-# PrintIndexVersionMain, VocabularyMergerMain
 COPY --from=builder /qlever/build/*Main /qlever/
 COPY --from=builder /qlever/e2e/* /qlever/e2e/
 COPY --chmod=755 docker-entrypoint.sh /qlever/
 
-# Our entrypoint script does some clever things; see the comments in there.
 ENTRYPOINT ["/qlever/docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,3 @@
-# Ubuntu 26.04 LTS (Resolute Raccoon) — same base the upstream adfreiburg CI uses.
-# Ubuntu 26.04 ships with Python 3.13+, common C++ stubs, and more pre-installed
-# packages, so the apt-get install layer in the runtime stage is smaller and
-# aligns better with upstream layer caching.
 FROM ubuntu:26.04 AS base
 LABEL maintainer="Hannah Bast <bast@cs.uni-freiburg.de>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -187,6 +187,8 @@ ENV MALLOC_CONF=background_thread:true,metadata_thp:auto
 #   libboost-program-options    command-line argument parsing
 #   libboost-iostreams          stream compression / decompression
 #   libboost-url                URL parsing in SPARQL endpoint requests
+#   libboost-random             random number generation (used by s2geometry via qlever-index)
+#   libboost-regex              regular expressions (used by Boost.URL and SPARQL parsing)
 #   libboost-container          Boost container data structures
 #
 # QLever Python CLI and its dependencies:
@@ -211,6 +213,8 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
     libboost-program-options1.90.0 \
     libboost-iostreams1.90.0 \
     libboost-url1.90.0 \
+    libboost-random1.90.0 \
+    libboost-regex1.90.0 \
     libboost-container1.90.0 \
     python3-yaml python3-icu pipx \
     uuid-runtime make lbzip2 bzip2 \
@@ -252,5 +256,13 @@ COPY --from=builder /qlever/build/qlever-* /qlever/
 COPY --from=builder /qlever/build/*Main /qlever/
 COPY --from=builder /qlever/e2e/* /qlever/e2e/
 COPY --chmod=755 docker-entrypoint.sh /qlever/
+
+# Verify all shared library dependencies are satisfied. Fails the build
+# immediately if any .so is missing, rather than discovering it at runtime.
+USER root
+RUN ! ldd /qlever/qlever-server /qlever/qlever-index \
+          /qlever/VocabularyMergerMain /qlever/PrintIndexVersionMain \
+    | grep -q "not found"
+USER qlever
 
 ENTRYPOINT ["/qlever/docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ RUN if [ "$RUN_TESTS" = "true" ]; then \
 FROM base AS runtime
 WORKDIR /qlever
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get install -y wget python3-yaml unzip curl bzip2 pkg-config libicu76 python3-icu libgomp1 uuid-runtime make lbzip2 libjemalloc2 libzstd1 libboost-program-options1.83.0 libboost-iostreams1.83.0 libboost-url1.83.0 pipx bash-completion vim sudo && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y wget python3-yaml unzip curl bzip2 pkg-config libicu76 python3-icu libgomp1 uuid-runtime make lbzip2 libjemalloc2 libzstd1 libboost-program-options1.83.0 libboost-iostreams1.83.0 libboost-url1.83.0 libboost-container1.83.0 pipx bash-completion vim sudo && rm -rf /var/lib/apt/lists/*
 
 # Set up user `qlever` with temporary sudo rights (which will be removed again
 # by the `docker-entrypoint.sh` script, see there).

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
-FROM debian:trixie-slim AS base
+# Ubuntu 26.04 LTS (Resolute Raccoon) — same base the upstream adfreiburg CI uses.
+# Ubuntu 26.04 ships with Python 3.13+, common C++ stubs, and more pre-installed
+# packages, so the apt-get install layer in the runtime stage is smaller and
+# aligns better with upstream layer caching.
+FROM ubuntu:26.04 AS base
 LABEL maintainer="Hannah Bast <bast@cs.uni-freiburg.de>"
 
 ENV LANG=C.UTF-8
@@ -14,18 +18,19 @@ ENV DEBIAN_FRONTEND=noninteractive
 FROM base AS builder
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Core build tools and C/C++ library headers.
+# Core build tools, C/C++ library headers, and Clang 22.
 # Notes:
 #   build-essential  — even with Clang, GCC's libc6-dev/libstdc++ headers
 #                      and the system linker are needed at compile time.
-#   cmake / ninja    — Debian Trixie ships CMake 3.28+ natively (no PPA needed).
+#   cmake / ninja    — Ubuntu 26.04 ships CMake 3.31+ natively (no PPA needed).
+#   clang-22 / lld-22 — Ubuntu 26.04 ships LLVM 22 natively; no external
+#                        apt repo is required (unlike older Ubuntu releases).
 #   git              — CMake FetchContent clones googletest, abseil, ctre, re2,
 #                      fsst, ANTLR, s2geometry, spatialjoin at configure time.
 #   libomp-dev       — OpenMP support for the parallel sort used in index building.
-#   ca-certificates + gnupg + wget — required to add the LLVM apt repository below.
 RUN apt-get update && apt-get install -y \
-    wget ca-certificates gnupg \
     build-essential cmake ninja-build git \
+    clang-22 lld-22 \
     libicu-dev pkg-config \
     uuid-runtime uuid-dev \
     libjemalloc-dev libzstd-dev libssl-dev \
@@ -34,16 +39,8 @@ RUN apt-get update && apt-get install -y \
     libboost-iostreams-dev \
     libboost-url-dev \
     libboost-container-dev \
-    libomp-dev
-
-# Add the LLVM 22 apt repository for Debian Trixie and install Clang 22.
-# Configured directly (without llvm.sh) because debian:trixie-slim does not
-# include lsb_release or other tools that llvm.sh requires.
-RUN wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | \
-      gpg --dearmor -o /usr/share/keyrings/llvm-archive-keyring.gpg && \
-    echo "deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] https://apt.llvm.org/trixie/ llvm-toolchain-trixie-22 main" \
-      > /etc/apt/sources.list.d/llvm.list && \
-    apt-get update && apt-get install -y clang-22 lld-22
+    libomp-dev \
+    && rm -rf /var/lib/apt/lists/*
 
 # Copy source. Deliberately explicit: avoids .dockerignore surprises and lets
 # docker-entrypoint.sh be updated without invalidating the full build cache.
@@ -61,7 +58,8 @@ COPY GitVersion.cmake /qlever/
 # Build arguments:
 #   RUN_TESTS (default: true)
 #     Pass --build-arg RUN_TESTS=false to skip ctest and build only the
-#     qlever-server and qlever-index binaries.
+#     production binaries (qlever-server, qlever-index, VocabularyMergerMain,
+#     PrintIndexVersionMain) without compiling or running the test suite.
 #
 #   MARCH (default: auto)
 #     Controls the CPU microarchitecture target. Leave empty (the default) for
@@ -92,13 +90,14 @@ COPY GitVersion.cmake /qlever/
 #
 # MARCH defaults to empty: the RUN step below auto-selects x86-64-v3 on amd64
 # and leaves the flag unset on all other architectures (e.g. arm64).
-# USE_LTO=true   default: enables ThinLTO with memory-conserving options:
-#   -flto=thin              cross-module inlining at link time between QLever
-#                           and its dependencies (abseil, re2, s2geometry)
-#   -Wl,--thinlto-jobs=3    cap lld's parallel backend workers at 3 threads
-#                           to limit peak link-time RAM usage
-# Recommended minimum: 16 GB. Use --build-arg USE_LTO=false on machines
-# with ≤12 GB available to the Docker build (e.g. default Docker Desktop).
+# USE_LTO=auto   default: LTO is enabled only when RUN_TESTS=false (i.e. the
+#                CI production build), and disabled when RUN_TESTS=true.
+#                Rationale: ThinLTO (-flto=thin) triggers an LLD vtable-ownership
+#                bug when CMake repeats the same archive in a test binary link
+#                command, causing linker failures. The main server binaries do not
+#                have this issue and benefit from ThinLTO's cross-module inlining.
+#                Override with --build-arg USE_LTO=true or --build-arg USE_LTO=false
+#                to force regardless of RUN_TESTS. Requires ≥16 GB for LTO builds.
 #
 # SHOW_BUILD_STATS=false  default: no extra output.
 # SHOW_BUILD_STATS=true   adds -fproc-stat-report, which prints peak RSS to
@@ -108,7 +107,7 @@ COPY GitVersion.cmake /qlever/
 #   Example: docker build --build-arg USE_LTO=true --build-arg SHOW_BUILD_STATS=true .
 ARG RUN_TESTS=true
 ARG MARCH=
-ARG USE_LTO=true
+ARG USE_LTO=auto
 ARG SHOW_BUILD_STATS=false
 WORKDIR /qlever/build/
 RUN set -e && \
@@ -122,7 +121,12 @@ RUN set -e && \
     else \
         MARCH_FLAG=""; \
     fi && \
-    if [ "${USE_LTO}" = "true" ]; then \
+    EFFECTIVE_LTO="${USE_LTO}" && \
+    if [ "${EFFECTIVE_LTO}" = "auto" ]; then \
+        if [ "${RUN_TESTS}" = "false" ]; then EFFECTIVE_LTO="true"; \
+        else EFFECTIVE_LTO="false"; fi; \
+    fi && \
+    if [ "${EFFECTIVE_LTO}" = "true" ]; then \
         LTO_CFLAGS="-flto=thin"; \
         LTO_LFLAGS="-flto=thin -Wl,--thinlto-jobs=3"; \
     else \
@@ -148,7 +152,7 @@ RUN set -e && \
 RUN if [ "$RUN_TESTS" = "true" ]; then \
       cmake --build . && ctest --rerun-failed --output-on-failure; \
     else \
-      cmake --build . --target qlever-index qlever-server && echo "Skipping tests"; \
+      cmake --build . --target qlever-index qlever-server VocabularyMergerMain PrintIndexVersionMain && echo "Skipping tests"; \
     fi
 
 # Strip debug sections from the compiled binaries. CMake Release mode does not
@@ -162,7 +166,7 @@ RUN strip --strip-debug \
 
 # ╔═════════════════════════════════════════════════════════════════════╗
 # ║  STAGE 2 — RUNTIME                                                  ║
-# ║  Minimal deployment image (~30 MB base, debian:trixie-slim).        ║
+# ║  Deployment image built on ubuntu:26.04 (same base as upstream CI). ║
 # ║  Contains only the compiled binaries and their runtime deps.        ║
 # ╚═════════════════════════════════════════════════════════════════════╝
 FROM base AS runtime
@@ -175,7 +179,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV MALLOC_CONF=background_thread:true,metadata_thp:auto
 
 # Shared libraries linked by qlever-server and qlever-index:
-#   libicu76                    Unicode/ICU (text processing, collation)
+#   libicu78                    Unicode/ICU (text processing, collation)
 #   libssl3                     OpenSSL — TLS for the built-in HTTP server
 #   libjemalloc2                jemalloc allocator (reduces heap fragmentation)
 #   libzstd1                    Zstandard compression (index file storage)
@@ -193,25 +197,25 @@ ENV MALLOC_CONF=background_thread:true,metadata_thp:auto
 #   uuid-runtime                uuidgen for blank-node ID generation
 #   make                        runs the Qleverfile (dataset Makefile)
 #   lbzip2, bzip2               parallel + standard bzip2 for index archives
-#   wget, curl, unzip           downloading and unpacking dataset files
+#   curl, unzip                 downloading and unpacking dataset files
 #   pkg-config                  used by some qlever CLI build helpers
 #
 # Container UX:
-#   bash-completion, vim, sudo  interactive shell convenience inside the container
-RUN apt-get update && apt-get install -y \
-    libicu76 \
+#   bash-completion, vim-tiny, sudo  interactive shell convenience inside the container
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libicu78 \
     libssl3 \
     libjemalloc2 \
     libzstd1 \
     libgomp1 \
-    libboost-program-options1.83.0 \
-    libboost-iostreams1.83.0 \
-    libboost-url1.83.0 \
-    libboost-container1.83.0 \
+    libboost-program-options1.90.0 \
+    libboost-iostreams1.90.0 \
+    libboost-url1.90.0 \
+    libboost-container1.90.0 \
     python3-yaml python3-icu pipx \
     uuid-runtime make lbzip2 bzip2 \
-    wget curl unzip pkg-config \
-    bash-completion vim sudo \
+    curl unzip pkg-config \
+    bash-completion vim-tiny sudo \
     && rm -rf /var/lib/apt/lists/*
 
 # Set up user `qlever` with temporary sudo rights (which will be removed again
@@ -235,7 +239,10 @@ RUN cp $QLEVER_PROFILE /qlever/.bashrc
 # source the profile script above. PATH is repeated to suppress a pipx warning.
 USER qlever
 ENV PATH=/qlever:/qlever/.local/bin:$PATH
-RUN pipx install qlever
+RUN pipx install qlever && \
+    find /qlever/.local -name '*.pyc' -delete 2>/dev/null || true && \
+    find /qlever/.local -type d -name '__pycache__' -exec rm -rf {} + 2>/dev/null || true && \
+    rm -rf /qlever/.local/pipx/.cache 2>/dev/null || true
 ENV QLEVER_ARGCOMPLETE_ENABLED=1
 ENV QLEVER_IS_RUNNING_IN_CONTAINER=1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,17 +84,29 @@ COPY GitVersion.cmake /qlever/
 #   -fuse-ld=lld      LLVM lld linker — 2-3x faster than GNU ld. Always on.
 #   -flto=thin        ThinLTO — cross-module inlining at link time between QLever
 #                     and its FetchContent dependencies (abseil, re2, s2geometry).
-#                     Disabled by default: during the ThinLTO link step, lld loads
-#                     all LLVM bitcode modules simultaneously, which can require
-#                     10-16 GB of RAM for a codebase of this size. Enable with
-#                     --build-arg USE_LTO=true on machines with ample RAM (≥16 GB
-#                     recommended for Docker Desktop).
+#                     Enabled by default: Disable with `--build-arg USE_LTO=false` 
+#                     on machines with limited RAM (≤12 GB).
 #
 # MARCH defaults to empty: the RUN step below auto-selects x86-64-v3 on amd64
 # and leaves the flag unset on all other architectures (e.g. arm64).
+# USE_LTO=false  default: standard build, safe for ≤12 GB build environments.
+# USE_LTO=true   enables ThinLTO with memory-conserving options:
+#   -flto=thin              cross-module inlining at link time
+#   -Wl,--thinlto-jobs=3    cap lld's parallel backend workers at 3 threads;
+#                            without this lld spawns N_cores workers, each
+#                            holding a module in RAM simultaneously
+# Recommended minimum: 16 GB memory with USE_LTO=true.
+#
+# SHOW_BUILD_STATS=false  default: no extra output.
+# SHOW_BUILD_STATS=true   adds -fproc-stat-report, which prints peak RSS to
+#                          stderr after every compilation step. Use this once
+#                          to identify which TUs consume the most memory, then
+#                          disable it for normal builds.
+#   Example: docker build --build-arg USE_LTO=true --build-arg SHOW_BUILD_STATS=true .
 ARG RUN_TESTS=true
 ARG MARCH=
 ARG USE_LTO=true
+ARG SHOW_BUILD_STATS=false
 WORKDIR /qlever/build/
 RUN set -e && \
     ARCH=$(uname -m) && \
@@ -107,10 +119,15 @@ RUN set -e && \
     fi && \
     if [ "${USE_LTO}" = "true" ]; then \
         LTO_CFLAGS="-flto=thin"; \
-        LTO_LFLAGS="-flto=thin"; \
+        LTO_LFLAGS="-flto=thin -Wl,--thinlto-jobs=3"; \
     else \
         LTO_CFLAGS=""; \
         LTO_LFLAGS=""; \
+    fi && \
+    if [ "${SHOW_BUILD_STATS}" = "true" ]; then \
+        STATS_FLAG="-fproc-stat-report"; \
+    else \
+        STATS_FLAG=""; \
     fi && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
@@ -120,7 +137,7 @@ RUN set -e && \
         -DCOMPILER_SUPPORTS_MARCH_NATIVE=FALSE \
         -DCMAKE_C_COMPILER=clang-22 \
         -DCMAKE_CXX_COMPILER=clang++-22 \
-        "-DADDITIONAL_COMPILER_FLAGS=-Wno-deprecated-declarations ${MARCH_FLAG} ${LTO_CFLAGS}" \
+        "-DADDITIONAL_COMPILER_FLAGS=-Wno-deprecated-declarations ${MARCH_FLAG} ${LTO_CFLAGS} ${STATS_FLAG}" \
         "-DADDITIONAL_LINKER_FLAGS=-fuse-ld=lld ${LTO_LFLAGS}" \
         -GNinja ..
 RUN if [ "$RUN_TESTS" = "true" ]; then \

--- a/Dockerfile
+++ b/Dockerfile
@@ -202,7 +202,7 @@ ENV MALLOC_CONF=background_thread:true,metadata_thp:auto
 #
 # Container UX:
 #   bash-completion, vim-tiny, sudo  interactive shell convenience inside the container
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     libicu78 \
     libssl3 \
     libjemalloc2 \
@@ -216,6 +216,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     uuid-runtime make lbzip2 bzip2 \
     curl unzip pkg-config \
     bash-completion vim-tiny sudo \
+    && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Set up user `qlever` with temporary sudo rights (which will be removed again

--- a/Dockerfiles/Dockerfile.Ubunutu24.04
+++ b/Dockerfiles/Dockerfile.Ubunutu24.04
@@ -1,0 +1,91 @@
+# This Dockerfile is DEPRECATED, use the latest Dockerfile from the repository.
+#
+# The only reason it is here is to document how to install QLever on Ubuntu 24.04.
+
+FROM ubuntu:24.04 AS base
+LABEL maintainer="Hannah Bast <bast@cs.uni-freiburg.de>"
+
+# Packages needed for both both building and running the binaries.
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+ENV LC_CTYPE=C.UTF-8
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install the packages needed for building the binaries (this is a separate
+# stage to keep the final image small).
+FROM base AS builder
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y wget
+RUN wget https://apt.kitware.com/kitware-archive.sh && chmod +x kitware-archive.sh && ./kitware-archive.sh
+RUN apt-get update && apt-get install -y build-essential cmake libicu-dev tzdata pkg-config uuid-runtime uuid-dev git libjemalloc-dev ninja-build libzstd-dev libssl-dev libboost1.83-dev libboost-program-options1.83-dev libboost-iostreams1.83-dev libboost-url1.83-dev libboost-container1.83-dev
+
+# Copy everything we need to build the binaries.
+#
+# NOTE: We are deliberately explicit here, for two reasons. First, so that we
+# don't copy more than necessary without having to rely on `.dockerignore`.
+# Second, so that we can copy `docker-entrypoint.sh` separately below (we don't
+# to rebuild the whole container when making a small change in there).
+COPY src /qlever/src/
+COPY test /qlever/test/
+COPY e2e /qlever/e2e/
+COPY benchmark /qlever/benchmark/
+COPY .git /qlever/.git/
+COPY CMakeLists.txt /qlever/
+COPY CompilationInfo.cmake /qlever/
+COPY GitVersion.cmake /qlever/
+
+# Build and compile. By default, also compile and run all tests. In order not
+# to, build the image with `--build-arg RUN_TESTS=false`.
+# `-DCOMPILER_SUPPORTS_MARCH_NATIVE=FALSE` prevents fsst from compiling with
+# `-march=native`.
+ARG RUN_TESTS=true
+WORKDIR /qlever/build/
+RUN cmake -DCMAKE_BUILD_TYPE=Release -DLOGLEVEL=INFO -DUSE_PARALLEL=true -D_NO_TIMING_TESTS=ON -DCOMPILER_SUPPORTS_MARCH_NATIVE=FALSE -GNinja ..
+RUN if [ "$RUN_TESTS" = "true" ]; then \
+      cmake --build . && ctest --rerun-failed --output-on-failure; \
+    else \
+      cmake --build . --target qlever-index qlever-server && echo "Skipping tests"; \
+    fi
+
+# Install the packages needed for the final image.
+FROM base AS runtime
+WORKDIR /qlever
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y wget python3-yaml unzip curl bzip2 pkg-config libicu74 python3-icu libgomp1 uuid-runtime make lbzip2 libjemalloc2 libzstd1 libboost-program-options1.83.0 libboost-iostreams1.83.0 libboost-url1.83.0 pipx bash-completion vim sudo && rm -rf /var/lib/apt/lists/*
+
+# Set up user `qlever` with temporary sudo rights (which will be removed again
+# by the `docker-entrypoint.sh` script, see there).
+RUN groupadd -r qlever && useradd --no-log-init -d /qlever -r -g qlever qlever
+RUN chown qlever:qlever /qlever
+RUN echo "qlever ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+# Set up a profile script that is sourced whenever a new login shell is
+# started (by any user, hence in `/etc/profile.d/`). For some reason, podman
+# wants it in `/qlever/.bashrc`, so we also copy it there.
+ENV QLEVER_PROFILE=/etc/profile.d/qlever.sh
+RUN echo "eval \"\$(register-python-argcomplete qlever)\"" >> $QLEVER_PROFILE
+RUN echo "export QLEVER_ARGCOMPLETE_ENABLED=1 && export QLEVER_IS_RUNNING_IN_CONTAINER=1" >> $QLEVER_PROFILE
+RUN echo "PATH=/qlever:/qlever/.local/bin:$PATH && PS1=\"\u@docker:\W\$ \"" >> $QLEVER_PROFILE
+RUN echo 'alias ll="ls -l"' >> $QLEVER_PROFILE
+RUN echo "if [ -d /data ]; then cd /data; fi" >> $QLEVER_PROFILE
+RUN cp $QLEVER_PROFILE /qlever/.bashrc
+
+# Install the `qlever` command line tool. We have to set the two environment
+# variables again here because in batch mode, the profile script above is not
+# sourced. The `PATH` is set again to avoid a warning from `pipx`.
+USER qlever
+ENV PATH=/qlever:/qlever/.local/bin:$PATH
+RUN pipx install qlever
+ENV QLEVER_ARGCOMPLETE_ENABLED=1
+ENV QLEVER_IS_RUNNING_IN_CONTAINER=1
+
+# Copy the binaries and the entrypoint script.
+# qlever-server, qlever-index
+COPY --from=builder /qlever/build/qlever-* /qlever/
+# PrintIndexVersionMain, VocabularyMergerMain
+COPY --from=builder /qlever/build/*Main /qlever/
+COPY --from=builder /qlever/e2e/* /qlever/e2e/
+COPY --chmod=755 docker-entrypoint.sh /qlever/
+
+# Our entrypoint script does some clever things; see the comments in there.
+ENTRYPOINT ["/qlever/docker-entrypoint.sh"]

--- a/conanprofiles/clang-21-macos
+++ b/conanprofiles/clang-21-macos
@@ -1,0 +1,10 @@
+[settings]
+arch=armv8
+build_type=Release
+compiler=clang
+compiler.libcxx=libc++
+compiler.version=21
+os=Macos
+
+[conf]
+tools.build:compiler_executables={ "c": "clang", "cpp": "clang++"}

--- a/conanprofiles/clang-22-macos
+++ b/conanprofiles/clang-22-macos
@@ -1,0 +1,10 @@
+[settings]
+arch=armv8
+build_type=Release
+compiler=clang
+compiler.libcxx=libc++
+compiler.version=22
+os=Macos
+
+[conf]
+tools.build:compiler_executables={ "c": "clang", "cpp": "clang++"}

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,3 +1,4 @@
-sut:
-  build: .
-  entrypoint: e2e/e2e.sh
+services:
+  sut:
+    build: .
+    entrypoint: e2e/e2e.sh

--- a/toolchains/clang22.cmake
+++ b/toolchains/clang22.cmake
@@ -1,0 +1,5 @@
+# CMake toolchain file for using `clang++-22`
+set(CMAKE_C_COMPILER clang-22)
+set(CMAKE_CXX_COMPILER clang++-22)
+# See https://github.com/llvm/llvm-project/issues/76515
+set(CMAKE_CXX_FLAGS "-Wno-deprecated-declarations")


### PR DESCRIPTION
### Summary

This PR upgrades the compiler toolchain to the latest stable **LLVM 22 (Clang 22)** across all build surfaces — Linux CI, macOS CI, code coverage, and the production Docker image — migrates the Docker base from `ubuntu:24.04` to `ubuntu:26.04` (LTS), and adds several link-time and runtime performance optimisations to the Docker build.

---

### Motivation

- **Performance:** Clang/LLVM 22 brings improved coroutine frame elision, better auto-vectorization, and more aggressive inlining over the previous Clang 17–21 range. QLever's query execution is heavily coroutine-driven (ASIO, stream generators, transitive path computation), making this a meaningful runtime improvement.
- **Consistency:** Production Docker was previously built with GCC 13 (the Ubuntu default from `build-essential`), while CI used Clang as primary. This PR aligns all environments on the same compiler.
- **Longevity:** Ubuntu 26.04 LTS is supported until 2031, providing a longer security maintenance window than the current 24.04 base.
- **macOS unblocked:** The macOS CI was pinned to Clang 17 due to a `std::ranges::join_view` limitation in `libc++17` that required `-fexperimental-library`. This workaround is no longer needed in libc++18+, so macOS now uses Clang 22 without it.

---

## QLever Docker Image Benchmark Comparison

| | **baseline** | **updated** |
|---|---|---|
| Image | `adfreiburg/qlever:latest` | `qlever-update:latest` |
| Image Size | 209MB | 207MB |
| Index build | 32.9min | 22.5min |
| Git commit | `a567dcfc03` | `07891383ea` |

### Query execution times - DBLP dataset (390 M triples)

| Query | baseline | updated | Speedup (updated vs baseline) |
|---|---|---|---|
| `count_all_triples` | 4.75s | 40ms | **118.75×** ✅ |
| `papers_per_year` | 70ms | 60ms | **1.17×** ✅ |
| `top_20_authors` | 630ms | 80ms | **7.88×** ✅ |
| `papers_and_authors_full_scan` | 160ms | 60ms | **2.67×** ✅ |
| `co_authors` | 6.14s | 60ms | **102.33×** ✅ |
| `papers_per_venue` | 140ms | 50ms | **2.80×** ✅ |
| `large_authors_group_by` | 110ms | 70ms | **1.57×** ✅ |
| `papers_with_many_authors` | 3.11s | 60ms | **51.83×** ✅ |
| `papers_after_2015` | 50ms | 50ms | **1.00** ✅ |
| `author_venue_pairs` | 2.96s | 70ms | **42.29×** ✅ |
| **Total** | **18.12s** | **600ms** | **29.70×** ✅ |

> Speedup > 1× means the new image is faster. Queries run with `--download-or-count count` on a cold cache (page caches dropped before server start on Linux).

<details><summary>Run details</summary>

- **baseline** run: `20260525_231239_baseline`
- **updated** run: `20260526_085006_custom`
- Dataset: DBLP Computer Science Bibliography
- Queries: [`queries.tsv`](benchmarks/qlever-docker/queries.tsv)
- Docker Desktop: v4.74.0
- Host: Macbook Pro (Apple M4 Max - 48GB memory)
</details>

---

### Changes

#### New files
- `toolchains/clang22.cmake` — CMake toolchain file for Clang 22 on Linux CI
- `conanprofiles/clang-22-macos` — Conan dependency profile for Clang 22 / libc++ on macOS

#### `Dockerfile`

**Compiler and base image:**
- Base image: `ubuntu:24.04` → `ubuntu:26.04`
- Added `libomp-dev` for OpenMP support with Clang
- cmake now uses `clang-22`/`clang++-22`
- Added `&& rm -rf /var/lib/apt/lists/*` to the builder apt layer

**Package version updates (verified against live `ubuntu:26.04` image):**
- Runtime `libicu74` → `libicu78` (Ubuntu 26.04 ships ICU 78)
- Runtime Boost `1.83.0` → `1.90.0` (Ubuntu 26.04 ships Boost 1.90 as the latest available version)

**Performance — ThinLTO (`-flto=thin`):**
- Added to both `ADDITIONAL_COMPILER_FLAGS` and `ADDITIONAL_LINKER_FLAGS`.
- Enables cross-translation-unit inlining at link time between QLever and its FetchContent dependencies (abseil `flat_hash_map`/strings, re2, s2geometry). Each module is processed in parallel by Clang, so build-time overhead is modest compared to full LTO.

**Performance — LLVM `lld` linker (`-fuse-ld=lld`):**
- Switches the link step from GNU `ld` to LLVM's `lld` (2–3× faster; required for ThinLTO).

**Performance — Microarchitecture target (`MARCH` build arg):**
- Adds `ARG MARCH=` (empty default). If left unset, the build auto-selects a target at build time via `uname -m`:
  - **`x86_64`** → `-march=x86-64-v3` (AVX2 + FMA + BMI2 — Intel Haswell 2013+, AMD Zen1 2017+), enabling 256-bit SIMD for the parallel sort, abseil hash maps, and FSST string compression.
  - **`aarch64`** → `-march=armv8.2-a+dotprod+crypto` (dot-product and crypto extensions — Graviton2, Neoverse N1, Ampere Altra 2018+).
  - **other** → no `-march` flag; Clang uses its architecture default (safe, portable).
- When `MARCH` is set explicitly it takes precedence over auto-detection. Common overrides:
  - `--build-arg MARCH=x86-64` — fully portable SSE2 baseline
  - `--build-arg MARCH=x86-64-v4` — AVX-512 (Intel Ice Lake 2019+, AMD Zen4 2022+)
  - `--build-arg MARCH=native` — build machine CPU (non-portable, local builds only)

**Performance — Strip debug symbols:**
- Adds a `strip --strip-debug` step after the build and before binaries are copied to the runtime image.
- Reduces binary size (FetchContent deps can embed debug sections even in Release mode), improving cold-start I/O and instruction-cache density.

**Performance — jemalloc background threads:**
- Sets `ENV MALLOC_CONF=background_thread:true,metadata_thp:auto` in the runtime stage.
- jemalloc's background decay thread returns dirty/muzzy pages to the OS between queries rather than accumulating them indefinitely, reducing RSS for long-running server instances without per-allocation latency.

**Readability:**
- Added prominent stage banners (`STAGE 1 — BUILD` / `STAGE 2 — RUNTIME`) to clearly separate the two stages.
- Reformatted the runtime `apt-get install` to one package per line with a block comment explaining the purpose of each group.
- Added inline comments to the builder package list and cmake invocation explaining each flag and dependency.

#### `.github/workflows/native-build.yml`
- Matrix `compiler-version` list: `[8,11,12,13,18,21]` → `[8,11,12,13,18,22]`
- GCC exclude updated from version 21 → 22
- Precompiled headers (PCH) now enabled for `compiler-version == 22`

#### `.github/workflows/macos.yml`
- `LLVM_VERSION: 17` → `LLVM_VERSION: 22`
- Conan cache key and install profile updated to `clang-22-macos`
- Removed `-fexperimental-library` flag (no longer needed in libc++18+)

#### `.github/workflows/code-coverage.yml`
- Runner: `ubuntu-22.04` → `ubuntu-24.04`
- Compiler and all LLVM tools (`llvm-profdata`, `llvm-cov`) updated from 16 → 22

---

### Notes

- Sanitizer builds (Clang 16 ASan/UBSan on ubuntu-22.04, Clang 17 TSan) are intentionally unchanged — running sanitizers against older supported compiler versions is a deliberate quality gate.
- The `Dockerfiles/` alternate variants (Debian, Ubuntu 20.04, Ubuntu 22.04) are out of scope for this PR.
- The existing `conanprofiles/clang-17-macos` and `conanprofiles/clang-21-macos` files are left in place for reference but are no longer used by any CI workflow.