### PR TITLE
Drop sort key logic from `LocaleManager`

### DIFF
--- a/src/index/StringSortComparator.h
+++ b/src/index/StringSortComparator.h
@@ -7,23 +7,25 @@
 #ifndef QLEVER_STRINGSORTCOMPARATOR_H
 #define QLEVER_STRINGSORTCOMPARATOR_H
 
+#include <unicode/bytestream.h>
 #include <unicode/casemap.h>
+#include <unicode/coleitr.h>
 #include <unicode/coll.h>
 #include <unicode/locid.h>
 #include <unicode/normalizer2.h>
-#include <unicode/unistr.h>
-#include <unicode/unorm2.h>
+#include <unicode/stringpiece.h>
+#include <unicode/tblcoll.h>
+#include <unicode/utf8.h>
 #include <unicode/utypes.h>
 
+#include <cstdint>
 #include <cstring>
 #include <memory>
+#include <stdexcept>
+#include <string>
+#include <string_view>
 
-#include "backports/StartsWithAndEndsWith.h"
-#include "backports/algorithm.h"
-#include "backports/memory_resource.h"
-#include "backports/three_way_comparison.h"
 #include "global/Constants.h"
-#include "util/Exception.h"
 #include "util/StringUtils.h"
 
 /**
@@ -45,48 +47,6 @@ class LocaleManager {
            // into account and then the result by strcmp. that way two strings
            // that have a different byte representation never compare equal
   };
-
-  /**
-   * A strong typedef for a string that contains unicode collation weights for
-   * another string. The actual storage can be a `std::string` or a
-   * `std::string_view`.
-   */
-  // TODO<GCC12> As soon as we have constexpr std::string, this class can
-  //  become constexpr.
-  using U8String = std::basic_string<uint8_t>;
-  using U8StringView = std::basic_string_view<uint8_t>;
-
-  CPP_template(typename T)(requires ad_utility::SimilarToAny<
-                           T, U8String, U8StringView>) class SortKeyImpl {
-   public:
-    SortKeyImpl() = default;
-    explicit SortKeyImpl(U8StringView sortKey) : sortKey_(sortKey) {}
-    [[nodiscard]] constexpr const T& get() const noexcept { return sortKey_; }
-    constexpr T& get() noexcept { return sortKey_; }
-
-    // Comparison of sort key is done lexicographically on the byte values
-    // of member `sortKey_`
-    template <typename U>
-    [[nodiscard]] int compare(const SortKeyImpl<U>& rhs) const noexcept {
-      return U8StringView{sortKey_}.compare(U8StringView{rhs.sortKey_});
-    }
-
-    QL_DEFINE_DEFAULTED_THREEWAY_OPERATOR_LOCAL(SortKeyImpl, sortKey_)
-
-    /// Is this sort key a prefix of another sort key. Note: This does not imply
-    /// any guarantees on the relation of the underlying strings.
-    bool starts_with(const SortKeyImpl& rhs) const noexcept {
-      return ql::starts_with(get(), rhs.get());
-    }
-
-    /// Return the number of bytes in the `SortKey`
-    std::string::size_type size() const noexcept { return get().size(); }
-
-   private:
-    T sortKey_;
-  };
-  using SortKey = SortKeyImpl<std::basic_string<uint8_t>>;
-  using SortKeyView = SortKeyImpl<std::basic_string_view<uint8_t>>;
 
   /// Copy constructor
   LocaleManager(const LocaleManager& rhs)
@@ -147,116 +107,10 @@ class LocaleManager {
                             const Level level) const {
     UErrorCode err = U_ZERO_ERROR;
     auto idx = static_cast<uint8_t>(level);
-    auto res = compToInd(
+    auto res = static_cast<int>(
         _collator[idx]->compareUTF8(toStringPiece(a), toStringPiece(b), err));
     raise(err);
     return res;
-  }
-
-  /**
-   * @brief Compare two WeightStrings. These have to be extracted by a call to
-   * getSortKey using the same level specification and on the same LocaleManager
-   * otherwise the behavior is undefined
-   * @param a
-   * @param b
-   * @param level This parameter is ignored but required to have a symmetric
-   * interface
-   * @return <0 iff a<b , >0 iff a>b,  0 iff a==b
-   */
-  template <typename T, typename U>
-  static int compare(const SortKeyImpl<T>& a, const SortKeyImpl<U>& b,
-                     [[maybe_unused]] const Level = Level::PRIMARY) {
-    return a.compare(b);
-  }
-
-  /**
-   * @brief Transform a UTF-8 string into a `SortKey`.
-   *
-   * We need this wrapper because ICU internally only works on utf16 and does
-   * not create c++ strings in large parts of the API
-   * @param s A UTF-8 encoded string.
-   * @param level The Collation Level for which we want to create the SortKey
-   * @return A `SortKey` s.t. compare(s, t, level) ==
-   * compare(getSortKey(s, level), getSortKey(t, level))
-   */
-  SortKey getSortKey(std::string_view s, const Level level) const {
-    auto utf16 = icu::UnicodeString::fromUTF8(toStringPiece(s));
-    auto& col = *_collator[static_cast<uint8_t>(level)];
-    std::vector<uint8_t> sortKeyBuffer;
-    // The actual computation of the sort key is very expensive, so we first
-    // allocate a buffer that is typically large enough to store the sort key.
-    static constexpr size_t maxBufferSize = std::numeric_limits<int32_t>::max();
-    sortKeyBuffer.resize(std::min(50 * s.size(), maxBufferSize));
-    static_assert(sizeof(uint8_t) == sizeof(std::string::value_type));
-    static constexpr auto intMax = std::numeric_limits<int32_t>::max();
-    auto sz = col.getSortKey(utf16, sortKeyBuffer.data(),
-                             static_cast<int32_t>(sortKeyBuffer.size()));
-    AD_CONTRACT_CHECK(sz >= 0);
-    // If the buffer was large enough, we only have to copy the sort key to the
-    // destination. Otherwise, we now know the exact size of the sort key and
-    // can retrigger the computation.
-    if (static_cast<size_t>(sz) > sortKeyBuffer.size()) {
-      sortKeyBuffer.clear();
-      sortKeyBuffer.resize(sz);
-      AD_CORRECTNESS_CHECK(sortKeyBuffer.size() <= static_cast<size_t>(intMax));
-      auto actualSz =
-          col.getSortKey(utf16, (sortKeyBuffer.data()),
-                         static_cast<int32_t>(sortKeyBuffer.size()));
-      AD_CONTRACT_CHECK(actualSz ==
-                        static_cast<decltype(sz)>(sortKeyBuffer.size()));
-    }
-    // since this is a c-api we still have a trailing '\0'. Trimming this is
-    // necessary for the prefix range to work correct.
-    AD_CORRECTNESS_CHECK(sz > 0);
-    --sz;
-    SortKey result;
-    U8String& resultView = result.get();
-    resultView.insert(resultView.end(), sortKeyBuffer.data(),
-                      sortKeyBuffer.data() + sz);
-    return result;
-  }
-
-  /// Get a `SortKey` for `Level::PRIMARY` that corresponds to a prefix of `s`.
-  /// \param s The input of which we want to obtain a sort key.
-  /// \param prefixLength Obtain a SortKey for `prefixLength` many relevant
-  /// characters
-  ///               (see below).
-  /// \return A `SortKey` that is a prefix of the `SortKey` for `s` w.r.t
-  ///         `Level::PRIMARY` and that also is a `SortKey` for a prefix "p"
-  ///         of `s`. "p" is the minimal prefix of `s` which consists of
-  ///         at least `prefixLength` codepoints and whose SortKey fulfills the
-  ///         first condition. Codepoints, which do not contribute to the
-  ///         `SortKey` because they are irrelevant for the `PRIMARY` level do
-  ///         not count towards `prefixLength`. The first element of the return
-  ///         value is the actual number of (contributing) codepoints in "p". If
-  ///         `s` contains less than `prefixLength` contributing codepoints,
-  ///         then {totalNumberOfContributingCodepoints, completeSortKey} is
-  ///         returned.
-  [[nodiscard]] std::pair<size_t, SortKey> getPrefixSortKey(
-      std::string_view s, size_t prefixLength) const {
-    size_t numContributingCodepoints = 0;
-    SortKey sortKey;
-    size_t prefixLengthSoFar = 1;
-    SortKey completeSortKey = getSortKey(s, Level::PRIMARY);
-    while (numContributingCodepoints < prefixLength ||
-           !completeSortKey.starts_with(sortKey)) {
-      auto [numCodepoints, prefix] =
-          ad_utility::getUTF8Prefix(s, prefixLengthSoFar);
-      auto nextLongerSortKey = getSortKey(prefix, Level::PRIMARY);
-      if (nextLongerSortKey != sortKey) {
-        // The `SortKey` changed by adding a codepoint, so that codepoint
-        // was contributing.
-        numContributingCodepoints++;
-        sortKey = std::move(nextLongerSortKey);
-      }
-      if (numCodepoints < prefixLengthSoFar) {
-        // We have checked the complete string without finding a sufficiently
-        // long contributing prefix.
-        break;
-      }
-      prefixLengthSoFar++;
-    }
-    return {numContributingCodepoints, std::move(sortKey)};
   }
 
   /**
@@ -293,6 +147,25 @@ class LocaleManager {
     _normalizer->normalizeUTF8(0, toStringPiece(input), sink, nullptr, err);
     raise(err);
     return res;
+  }
+
+  // Count the number of primary-weight collation elements (non-zero primary
+  // order) in a UTF-8 encoded string. Returns raw ICU element weights;
+  // UCOL_SHIFTED is not applied here, so variable characters (e.g.,
+  // punctuation) are still counted even when ignorePunctuation is true.
+  [[nodiscard]] size_t countPrimaryCollationElements(
+      std::string_view text) const {
+    return walkPrimaryElements(text, std::numeric_limits<size_t>::max())
+        .numElements;
+  }
+
+  // Return the byte length of the shortest UTF-8 prefix of `text` that
+  // contains exactly `numPrimaryElements` primary-weight collation elements.
+  // If `text` has fewer than `numPrimaryElements` primary elements, returns
+  // `text.size()`.
+  [[nodiscard]] size_t primaryCollationPrefixLength(
+      std::string_view text, size_t numPrimaryElements) const {
+    return walkPrimaryElements(text, numPrimaryElements).byteOffset;
   }
 
  private:
@@ -359,25 +232,73 @@ class LocaleManager {
     }
   }
 
-  // convert LESS EQUAL GREATER from icu to -1, 0, +1 to make results compatible
-  // to std::strcmp
-  static int compToInd(const UCollationResult res) {
-    switch (res) {
-      case UCOL_LESS:
-        return -1;
-      case UCOL_EQUAL:
-        return 0;
-      case UCOL_GREATER:
-        return 1;
-    }
-    throw std::runtime_error(
-        "Illegal value for UCollationResult. This should never happen!");
-  }
-
   /* This conversion is needed for "older" versions of ICU, e.g. ICU60 which is
    * contained in Ubuntu's LTS repositories */
   static icu::StringPiece toStringPiece(std::string_view s) {
     return icu::StringPiece(s.data(), s.size());
+  }
+
+  // Create a `icu::CollationElementIterator` for the given UTF-8 string.
+  std::unique_ptr<icu::CollationElementIterator> makeCollationElementIterator(
+      std::string_view input) const {
+    auto& collator = *_collator[static_cast<uint8_t>(Level::PRIMARY)];
+    icu::UnicodeString ustr =
+        icu::UnicodeString::fromUTF8(toStringPiece(input));
+    return std::unique_ptr<icu::CollationElementIterator>{
+        dynamic_cast<icu::RuleBasedCollator&>(collator)
+            .createCollationElementIterator(ustr)};
+  }
+
+  struct PrimaryWalkResult {
+    size_t numElements;
+    size_t byteOffset;
+  };
+
+  // Iterate through primary collation elements of `text`, stopping after
+  // `targetCount` non-ignorable primary elements (or at end-of-string).
+  // Returns the number of primary elements seen and the UTF-8 byte offset
+  // directly after the last one (`text.size()` if the string ended first).
+  [[nodiscard]] PrimaryWalkResult walkPrimaryElements(
+      std::string_view text, size_t targetCount) const {
+    if (targetCount == 0) {
+      return {0, 0};
+    }
+    UErrorCode err = U_ZERO_ERROR;
+    auto iter = makeCollationElementIterator(text);
+    size_t count = 0;
+    while (true) {
+      int32_t elem = iter->next(err);
+      raise(err);
+      if (elem == icu::CollationElementIterator::NULLORDER) {
+        break;
+      }
+      if (icu::CollationElementIterator::primaryOrder(elem) != 0) {
+        ++count;
+        if (count == targetCount) {
+          return {count, utf16OffsetToUtf8ByteOffset(text, iter->getOffset())};
+        }
+      }
+    }
+    return {count, text.size()};
+  }
+
+  // Walk the UTF-8 bytes of `utf8String`, counting UTF-16 code units, and
+  // return the byte offset that corresponds to `utf16Offset` UTF-16 code units
+  // from the start.
+  static size_t utf16OffsetToUtf8ByteOffset(std::string_view utf8String,
+                                            int32_t utf16Offset) {
+    const char* s = utf8String.data();
+    int32_t byteIdx = 0;
+    int32_t utf16Count = 0;
+    int32_t len = static_cast<int32_t>(utf8String.size());
+    while (byteIdx < len && utf16Count < utf16Offset) {
+      UChar32 c;
+      int32_t next = byteIdx;
+      U8_NEXT(s, next, len, c);
+      utf16Count += c > 0xFFFF ? 2 : 1;
+      byteIdx = next;
+    }
+    return static_cast<size_t>(byteIdx);
   }
 };
 
@@ -429,67 +350,6 @@ class SimpleStringComparator {
     return a.compare(b);
   }
 
-  /**
-   * @brief Compare a UTF-8 encoded string and a SortKey on the Primary Level
-   * CAVEAT: The Level l argument IS IGNORED
-   *
-   * Since this class only exports WeightStrings on the PRIMARY level via the
-   * transformToFirstPossibleBiggerValue method, we also always use the PRIMARY
-   * level for this function to avoid mistakes
-   * The Level argument is therefore ignored but left in as a dummy to make the
-   * getLowerBoundLambda api of the Vocabulary easier.
-   * @TODO<joka921> Allow prefix ranges on different levels.
-   * @param a A UTF-8 encoded string
-   * @param b This Weight string has to be obtained by a previous call to
-   * transformToFirstPossibleBiggerValue
-   * @
-   * @return true iff a comes before the string whose SortKey is b
-   */
-  bool operator()(std::string_view a, const LocaleManager::SortKey& b,
-                  [[maybe_unused]] const Level l) const {
-    auto aTrans = _locManager.getSortKey(a, Level::PRIMARY);
-    auto cmp = LocaleManager::compare(aTrans, b, Level::PRIMARY);
-    return cmp < 0;
-  }
-
-  // This method is left undefined on purpose, as it is only used for
-  // constraints checking in the <ranges> header for the UnicodeVocabulary
-  // class.
-  bool operator()(const LocaleManager::SortKey& a, std::string_view s,
-                  [[maybe_unused]] const Level l = Level::PRIMARY) const;
-
-  // Same goes for this function (undefined on purpose).
-  bool operator()(const LocaleManager::SortKey& a,
-                  const LocaleManager::SortKey& b,
-                  [[maybe_unused]] Level level = Level::PRIMARY) const;
-
-  /**
-   * @brief Transform a string s to the SortKey of the first possible
-   * string that compares greater to s according to the held locale on the
-   * PRIMARY level (other levels will cause an assertion fail.
-   *
-   * This is needed for calculating whether one string is a prefix of another
-   * CAVEAT: This currently only supports the primary collation Level!!!
-   * <TODO<joka921>: Implement this on every level, either by fixing ICU or by
-   * hacking the collation strings
-   *
-   * @param s A UTF-8 encoded string
-   * @return the PRIMARY level SortKey of the first possible string greater than
-   * s
-   */
-  [[nodiscard]] LocaleManager::SortKey transformToFirstPossibleBiggerValue(
-      std::string_view s, const Level level) const {
-    AD_CONTRACT_CHECK(level == Level::PRIMARY);
-    auto transformed = _locManager.getSortKey(s, Level::PRIMARY);
-    unsigned char last = transformed.get().back();
-    if (last < std::numeric_limits<unsigned char>::max()) {
-      transformed.get().back() += 1;
-    } else {
-      transformed.get().push_back('\0');
-    }
-    return transformed;
-  }
-
   /// Obtain access to the held LocaleManager
   [[nodiscard]] const LocaleManager& getLocaleManager() const {
     return _locManager;
@@ -526,53 +386,19 @@ class TripleComponentComparator {
   /// Construct according to the default locale in "../global/Constants.h"
   TripleComponentComparator() = default;
 
-  /**
-   * @brief An entry of the Vocabulary, split up into its components and
-   * possibly converted to a format that is easier to compare
-   *
-   * @tparam InnerString either LocaleManager::SortKey or std::string_view.
-   * Both variants differ greatly in their usage. Details can be found after the
-   * class definition, together with the explicit aliases `SplitVal` and
-   * `SplitValOwning` for the template instantiations that are actually used.
-   * the template instantiations
-   * @tparam LanguageTag and FullString, either `std::string` or
-   * `std::string_view`. They are used as deterministic tie breaks on the
-   * `TOTAL` sort level.
-   */
-  template <class InnerString, class LanguageTag, class FullString>
-  struct SplitValBase {
-    SplitValBase() = default;
-    SplitValBase(char fst, InnerString trans, LanguageTag l,
-                 FullString fullInputForTotalComparison)
-        : firstOriginalChar_(fst),
-          transformedVal_(std::move(trans)),
-          langtag_(std::move(l)),
-          fullInput_{std::move(fullInputForTotalComparison)} {}
-
-    /// The first char of the original value, used to distinguish between
-    /// different datatypes
-    char firstOriginalChar_ = '\0';
-    InnerString transformedVal_;  /// The original inner value, possibly
-                                  /// transformed by a locale().
-    LanguageTag langtag_;         /// The language tag, possibly empty.
-    FullString fullInput_;
+  // An entry of the Vocabulary, split up into its components. Used internally
+  // to implement `compare(std::string_view, std::string_view)` so that
+  // datatype/language tag tiebreaking is handled consistently.
+  struct SplitVal {
+    // The first char of the original value, used to distinguish between
+    // different datatypes
+    char firstOriginalChar_;
+    // The original inner value.
+    std::string_view innerValue_;
+    // The language tag, possibly empty.
+    std::string_view langtag_;
+    std::string_view fullInput_;
   };
-
-  /**
-   * This value owns all its contents.
-   * The inner value is the SortKey of the original inner value according to the
-   * held Locale. This is used to transform the inner value and to safely pass
-   * it around, e.g. when performing prefix comparisons in the vocabulary
-   */
-  using SplitVal =
-      SplitValBase<LocaleManager::SortKey, std::string, std::string>;
-
-  /**
-   * This only holds string_views to substrings of a string.
-   * Currently we only use this inside this class
-   */
-  using SplitValNonOwning =
-      SplitValBase<std::string_view, std::string_view, std::string_view>;
 
   /**
    * \brief Compare two elements from the Vocabulary.
@@ -583,44 +409,15 @@ class TripleComponentComparator {
     return compare(a, b, level) < 0;
   }
 
-  /**
-   * @brief Compare a string_view from the vocabulary to a SplitVal that was
-   * previously transformed
-   * @param a Element of the vocabulary
-   * @param spB this splitVal must have been obtained by a call to
-   * extractAndTransformComparable
-   * @param level
-   * @return a comes before the original value of spB in the vocabulary
-   */
-  bool operator()(std::string_view a, const SplitVal& spB,
-                  const Level level) const {
-    auto spA = extractAndTransformComparable(a, level);
-    return compare(spA, spB, level) < 0;
-  }
-
-  // Same operator, but with switched argument types.
-  bool operator()(const SplitVal& spA, std::string_view b,
-                  const Level level) const {
-    auto spB = extractAndTransformComparable(b, level);
-    return compare(spA, spB, level) < 0;
-  }
-
-  template <typename A, typename B, typename C>
-  bool operator()(const SplitValBase<A, B, C>& a,
-                  const SplitValBase<A, B, C>& b, const Level level) const {
-    return compare(a, b, level) < 0;
-  }
-
-  /// Compare two string_views from the Vocabulary. Return value according to
-  /// std::strcmp
+  // Compare two string_views from the Vocabulary. Return value according to
+  // std::strcmp
   [[nodiscard]] int compare(std::string_view a, std::string_view b,
                             const Level level = Level::QUARTERNARY) const {
-    auto splitA = extractComparable<SplitValNonOwning>(a, level);
-    auto splitB = extractComparable<SplitValNonOwning>(b, level);
+    auto splitA = extractComparable(a);
+    auto splitB = extractComparable(b);
     // We have to have a total ordering of unique elements in the vocabulary,
     // so if they compare equal according to the locale, use strcmp
-    auto cmp = compare(splitA, splitB, level);
-    return cmp;
+    return compare(splitA, splitB, level);
   }
 
   // Total comparison, using the "is external" flags as a tiebreaker. The
@@ -638,25 +435,9 @@ class TripleComponentComparator {
     return aIsExternal && !bIsExternal;
   }
 
-  /**
-   * @brief Split a literal or iri into its components and convert the inner
-   * value according to the held locale
-   */
-  [[nodiscard]] SplitVal extractAndTransformComparable(
-      std::string_view a, const Level level) const {
-    return extractComparable<SplitVal>(a, level);
-  }
-
-  /**
-   * @brief the inner comparison logic
-   *
-   * First compares the datatypes by the firstOriginalChar_, then the inner
-   * value and then the language tags
-   * @return <0 iff a<b, 0 iff a==b, >0 iff a>b
-   */
-  template <class A, class B, typename C>
-  [[nodiscard]] int compare(const SplitValBase<A, B, C>& a,
-                            const SplitValBase<A, B, C>& b,
+  // First compares the datatypes by the firstOriginalChar_, then the inner
+  // value and then the language tags.
+  [[nodiscard]] int compare(const SplitVal& a, const SplitVal& b,
                             const Level level) const {
     if (auto res =
             std::strncmp(&a.firstOriginalChar_, &b.firstOriginalChar_, 1);
@@ -664,10 +445,7 @@ class TripleComponentComparator {
       return res;  // different data types, decide on the datatype
     }
 
-    if (int res =
-            // this correctly dispatches between SortKeys (already transformed)
-            // and string_views (not-transformed, perform unicode collation)
-        _locManager.compare(a.transformedVal_, b.transformedVal_, level);
+    if (int res = _locManager.compare(a.innerValue_, b.innerValue_, level);
         res != 0 || level != Level::TOTAL) {
       return res;  // actual value differs
     }
@@ -680,44 +458,6 @@ class TripleComponentComparator {
     // Only if two literals are bytewise equal, we compare by the langtag or
     // datatype.
     return a.langtag_.compare(b.langtag_);
-  }
-
-  /**
-   *
-   * @brief Transform a string s from the vocabulary to the SplitVal of the
-   * first possible vocabulary string that compares greater to s according to
-   * the held locale on the PRIMARY level (other levels will cause an assertion
-   * fail.)
-   *
-   * This is needed for calculating whether one string is a prefix of another
-   * CAVEAT: This currently only supports the primary collation Level!!!
-   * <TODO<joka921>: Implement this on every level, either by fixing ICU or by
-   * hacking the collation strings
-   *
-   * @param s A UTF-8 encoded string that contains an element of an RDF triple
-   * @param level must be Level::PRIMARY
-   * @return the PRIMARY level SortKey of the first possible string greater than
-   * s
-   */
-  [[nodiscard]] SplitVal transformToFirstPossibleBiggerValue(
-      std::string_view s, const Level level) const {
-    AD_CONTRACT_CHECK(level == Level::PRIMARY);
-    auto transformed = extractAndTransformComparable(s, Level::PRIMARY);
-    // The `firstOriginalChar_` is either " or < or @
-    AD_CONTRACT_CHECK(
-        static_cast<unsigned char>(transformed.firstOriginalChar_) <
-        std::numeric_limits<unsigned char>::max());
-    if (transformed.transformedVal_.get().empty()) {
-      transformed.firstOriginalChar_ += 1;
-    } else {
-      unsigned char last = transformed.transformedVal_.get().back();
-      if (last < std::numeric_limits<unsigned char>::max()) {
-        transformed.transformedVal_.get().back() += 1;
-      } else {
-        transformed.transformedVal_.get().push_back('\1');
-      }
-    }
-    return transformed;
   }
 
   /// obtain const access to the held LocaleManager
@@ -733,23 +473,14 @@ class TripleComponentComparator {
     return _locManager.normalizeUtf8(sv);
   }
 
-  /// handle to the default collation level
-  Level& defaultLevel() { return _defaultLevel; }
-  [[nodiscard]] const Level& defaultLevel() const { return _defaultLevel; }
-
  private:
   LocaleManager _locManager;
-  Level _defaultLevel = Level::IDENTICAL;
 
-  /* Split a string into its components to prepare collation.
-   * SplitValType = SplitVal will transform the inner string according to the
-   * locale SplitValTye = SplitValNonOwning will leave the inner string as is.
-   */
-  template <class SplitValType>
-  [[nodiscard]] SplitValType extractComparable(
-      std::string_view a, [[maybe_unused]] const Level level) const {
-    std::string_view res = a;
-    const char first = a.empty() ? char{0} : a[0];
+  /// Split a string into its components (datatype-indicator first char, inner
+  /// value, language tag) to prepare locale-aware collation.
+  [[nodiscard]] static SplitVal extractComparable(std::string_view fullInput) {
+    std::string_view res = fullInput;
+    const char first = fullInput.empty() ? char{0} : fullInput[0];
     std::string_view langtag;
     if (first == '"') {
       // only remove the first character in case of literals that always start
@@ -768,14 +499,7 @@ class TripleComponentComparator {
         langtag = "";
       }
     }
-    if constexpr (std::is_same_v<SplitValType, SplitVal>) {
-      return {first, _locManager.getSortKey(res, level), std::string{langtag},
-              std::string{a}};
-    } else if constexpr (std::is_same_v<SplitValType, SplitValNonOwning>) {
-      return {first, res, langtag, a};
-    } else {
-      static_assert(ad_utility::alwaysFalse<SplitValType>);
-    }
+    return {first, res, langtag, fullInput};
   }
 };
 

--- a/src/index/TextIndexBuilder.cpp
+++ b/src/index/TextIndexBuilder.cpp
@@ -8,6 +8,7 @@
 
 #include "index/Postings.h"
 #include "index/TextIndexReadWrite.h"
+#include "util/StringUtils.h"
 
 // _____________________________________________________________________________
 void TextIndexBuilder::buildTextIndexFile(
@@ -386,11 +387,9 @@ void TextIndexBuilder::calculateBlockBoundariesImpl(
   // 2) shorter than the minimum prefix length
   // 3) The next word is shorter than the minimum prefix length
   // 4) word.substring(0, MIN_PREFIX_LENGTH) is different from the next.
-  // Note that the evaluation of 4) is difficult to perform in a meaningful way
-  // for all corner cases of Unicode. E.g. vivae and vivæ  compare equal on the
-  // PRIMARY level which is relevant, but have a different length (5 vs 4).
-  // We currently use several workarounds to get as close as possible to the
-  // desired behavior.
+  // Note that the evaluation of 4) is done via primary collation element
+  // counting, which handles Unicode corner cases correctly. E.g. vivae and vivæ
+  // compare equal on the PRIMARY level and both get a 4-element prefix.
   // A block boundary is always the last WordId in the block.
   // this way std::lower_bound will point to the correct bracket.
 
@@ -411,69 +410,21 @@ void TextIndexBuilder::calculateBlockBoundariesImpl(
   size_t numBlocks = 0;
   const auto& locManager = index.textVocab_.getLocaleManager();
 
-  // iterator over aaaa, ...,  zzzz
-  auto forcedBlockStarts = fourLetterPrefixes();
-  auto forcedBlockStartsIt = forcedBlockStarts.begin();
-
-  // If there is a four letter prefix aaaa, ...., zzzz in `forcedBlockStarts`
-  // the `SortKey` of which is a prefix of `prefixSortKey`, then set
-  // `prefixSortKey` to that `SortKey` and `prefixLength` to
-  // `MIN_WORD_PREFIX_SIZE` (4). This ensures that the blocks corresponding to
-  // these prefixes are never split up because of Unicode ligatures.
-  auto adjustPrefixSortKey = [&](auto& prefixSortKey, auto& prefixLength) {
-    while (true) {
-      if (forcedBlockStartsIt == forcedBlockStarts.end()) {
-        break;
-      }
-      auto forcedBlockStartSortKey = locManager.getSortKey(
-          *forcedBlockStartsIt, LocaleManager::Level::PRIMARY);
-      if (forcedBlockStartSortKey >= prefixSortKey) {
-        break;
-      }
-      if (prefixSortKey.starts_with(forcedBlockStartSortKey)) {
-        prefixSortKey = std::move(forcedBlockStartSortKey);
-        prefixLength = MIN_WORD_PREFIX_SIZE;
-        return;
-      }
-      forcedBlockStartsIt++;
-    }
+  auto getPrefix = [&](WordVocabIndex i) {
+    std::string_view word = index.textVocab_[i];
+    return word.substr(
+        0, locManager.primaryCollationPrefixLength(word, MIN_WORD_PREFIX_SIZE));
   };
-
-  auto getLengthAndPrefixSortKey = [&](WordVocabIndex i) {
-    auto word = index.textVocab_[i];
-    auto [len, prefixSortKey] =
-        locManager.getPrefixSortKey(word, MIN_WORD_PREFIX_SIZE);
-    if (len > MIN_WORD_PREFIX_SIZE) {
-      AD_LOG_DEBUG << "The prefix sort key for word \"" << word
-                   << "\" and prefix length " << MIN_WORD_PREFIX_SIZE
-                   << " actually refers to a prefix of size " << len << '\n';
-    }
-    // If we are in a block where one of the fourLetterPrefixes are contained,
-    // use those as the block start.
-    adjustPrefixSortKey(prefixSortKey, len);
-    return std::make_tuple(std::move(len), std::move(prefixSortKey));
-  };
-  auto [currentLen, prefixSortKey] =
-      getLengthAndPrefixSortKey(WordVocabIndex::make(0));
+  std::string_view currentPrefix = getPrefix(WordVocabIndex::make(0));
   for (size_t i = 0; i < index.textVocab_.size() - 1; ++i) {
-    // we need foo.value().get() because the vocab returns
-    // a std::optional<std::reference_wrapper<string>> and the "." currently
-    // doesn't implicitly convert to a true reference (unlike function calls)
-    const auto& [nextLen, nextPrefixSortKey] =
-        getLengthAndPrefixSortKey(WordVocabIndex::make(i + 1));
+    std::string_view nextPrefix = getPrefix(WordVocabIndex::make(i + 1));
 
-    bool tooShortButNotEqual =
-        (currentLen < MIN_WORD_PREFIX_SIZE || nextLen < MIN_WORD_PREFIX_SIZE) &&
-        (prefixSortKey != nextPrefixSortKey);
-    // The `startsWith` also correctly handles the case where
-    // `nextPrefixSortKey` is "longer" than `MIN_WORD_PREFIX_SIZE`, e.g. because
-    // of unicode ligatures.
-    bool samePrefix = nextPrefixSortKey.starts_with(prefixSortKey);
-    if (tooShortButNotEqual || !samePrefix) {
+    bool prefixDiffers = locManager.compare(currentPrefix, nextPrefix,
+                                            LocaleManager::Level::PRIMARY) != 0;
+    if (prefixDiffers) {
       blockBoundaryAction(i);
       numBlocks++;
-      currentLen = nextLen;
-      prefixSortKey = nextPrefixSortKey;
+      currentPrefix = nextPrefix;
     }
   }
   blockBoundaryAction(index.textVocab_.size() - 1);

--- a/src/index/vocabulary/UnicodeVocabulary.h
+++ b/src/index/vocabulary/UnicodeVocabulary.h
@@ -7,6 +7,7 @@
 
 #include "index/vocabulary/PolymorphicVocabulary.h"
 #include "index/vocabulary/VocabularyTypes.h"
+#include "util/Exception.h"
 
 /// Vocabulary with multi-level `UnicodeComparator` that allows comparison
 /// according to different Levels. Groups of words that are adjacent on a
@@ -38,7 +39,7 @@ class UnicodeVocabulary {
   /// `words_` are sorted according to the comparator (exactly like in
   /// `std::lower_bound`, which is used internally).
   /// Type `T` can be a string-like type (`string, string_view`) or
-  /// `UnicodeComparator::SortKey`
+  /// a UTF-8 string.
   template <typename T>
   WordAndIndex lower_bound(const T& word, SortLevel level) const {
     auto actualComparator = [this, level](const auto& a, const auto& b) {
@@ -52,7 +53,7 @@ class UnicodeVocabulary {
   /// are sorted according to the comparator (exactly like in
   /// `std::upper_bound`, which is used internally).
   /// Type `T` can be a string-like type (`string, string_view`) or
-  /// `UnicodeComparator::SortKey`
+  /// a UTF-8 string.
   template <typename T>
   WordAndIndex upper_bound(const T& word, SortLevel level) const {
     auto actualComparator = [this, level](const auto& a, const auto& b) {
@@ -85,8 +86,6 @@ class UnicodeVocabulary {
   /// word is equal to `prefix` on the `PRIMARY` level of the comparator.
   /// A value of `nullopt` in the entries means "the bound is higher than the
   /// largest word in the vocabulary".
-  /// TODO<joka921> Also support other levels, but this requires intrusive
-  /// hacking of ICU's SortKeys.
   [[nodiscard]] std::pair<std::optional<uint64_t>, std::optional<uint64_t>>
   prefix_range(std::string_view prefix) const {
     if (prefix.empty()) {
@@ -94,10 +93,20 @@ class UnicodeVocabulary {
     }
 
     auto lb = lower_bound(prefix, SortLevel::PRIMARY);
-    auto transformed = _comparator.transformToFirstPossibleBiggerValue(
-        prefix, SortLevel::PRIMARY);
 
-    auto ub = lower_bound(transformed, SortLevel::PRIMARY);
+    const auto& locManager = _comparator.getLocaleManager();
+    size_t numPrimaryElements =
+        locManager.countPrimaryCollationElements(prefix);
+    auto truncate = [&locManager, numPrimaryElements](std::string_view s) {
+      return s.substr(
+          0, locManager.primaryCollationPrefixLength(s, numPrimaryElements));
+    };
+    auto truncatedComp = [this, &truncate](std::string_view a,
+                                           std::string_view b) {
+      AD_EXPENSIVE_CHECK(a == truncate(a));
+      return _comparator(a, truncate(b), SortLevel::PRIMARY);
+    };
+    auto ub = _underlyingVocabulary.upper_bound(prefix, truncatedComp);
 
     auto toOptionalIndex = [](const WordAndIndex& wi) {
       return wi.isEnd() ? std::nullopt : std::optional{wi.index()};

--- a/test/StringSortComparatorTest.cpp
+++ b/test/StringSortComparatorTest.cpp
@@ -5,7 +5,6 @@
 #include <gtest/gtest.h>
 
 #include "./util/GTestHelpers.h"
-#include "backports/StartsWithAndEndsWith.h"
 #include "index/StringSortComparator.h"
 using namespace std::literals;
 using ad_utility::source_location;
@@ -113,40 +112,15 @@ TEST(StringSortComparatorTest, TripleComponentComparatorTotal) {
   auto comp = [&comparator](const auto& a, const auto& b) {
     return comparator(a, b, TripleComponentComparator::Level::TOTAL);
   };
-  // Test that the comparison between `a` and  `b` always yields the same
-  // result, no matter if it is done on the level of strings or on `SortKey`s.
-  auto assertConsistent = [&comparator, &comp](
-                              const auto& a, const auto& b,
-                              source_location l = AD_CURRENT_SOURCE_LOC()) {
-    auto tr = generateLocationTrace(l);
-    bool ab = comp(a, b);
-    bool ba = comp(b, a);
-    auto aSplit = comparator.extractAndTransformComparable(
-        a, TripleComponentComparator::Level::TOTAL);
-    auto bSplit = comparator.extractAndTransformComparable(
-        b, TripleComponentComparator::Level::TOTAL);
-    EXPECT_EQ(ab, comp(aSplit, bSplit));
-    EXPECT_EQ(ab, comp(a, bSplit));
-    EXPECT_EQ(ab, comp(aSplit, b));
-
-    EXPECT_EQ(ba, comp(bSplit, aSplit));
-    EXPECT_EQ(ba, comp(b, aSplit));
-    EXPECT_EQ(ba, comp(bSplit, a));
-  };
-
-  auto assertTrue = [&comp, &assertConsistent](
-                        const auto& a, const auto& b,
-                        source_location l = AD_CURRENT_SOURCE_LOC()) {
+  auto assertTrue = [&comp](const auto& a, const auto& b,
+                            source_location l = AD_CURRENT_SOURCE_LOC()) {
     auto tr = generateLocationTrace(l);
     ASSERT_TRUE(comp(a, b));
-    assertConsistent(a, b);
   };
-  auto assertFalse = [&comp, &assertConsistent](
-                         const auto& a, const auto& b,
-                         source_location l = AD_CURRENT_SOURCE_LOC()) {
+  auto assertFalse = [&comp](const auto& a, const auto& b,
+                             source_location l = AD_CURRENT_SOURCE_LOC()) {
     auto tr = generateLocationTrace(l);
     ASSERT_FALSE(comp(a, b));
-    assertConsistent(a, b);
   };
 
   // strange casings must not affect order
@@ -268,64 +242,53 @@ TEST(StringSortComparatorTest, SimpleStringComparator) {
   ASSERT_FALSE(comp("@u2", "\"@u2"));
 }
 
-TEST(LocaleManager, PrefixSortKey) {
-  SimpleStringComparator comp("en", "US", true);
-  LocaleManager locIgnorePunct = comp.getLocaleManager();
-  LocaleManager locRespectPunct("en", "US", false);
+// ______________________________________________________________________________________________
+TEST(LocaleManagerTest, CountPrimaryCollationElements) {
+  LocaleManager loc("en", "US", false);
+  EXPECT_EQ(loc.countPrimaryCollationElements(""), 0u);
+  EXPECT_EQ(loc.countPrimaryCollationElements("hello"), 5u);
+  // Accented characters count as one primary element each.
+  EXPECT_EQ(loc.countPrimaryCollationElements("héllo"), 5u);
+  // Multi-byte UTF-8: é = U+00E9 = 2 bytes, still 1 primary element.
+  EXPECT_EQ(loc.countPrimaryCollationElements("\xc3\xa9"), 1u);
+  // Punctuation has raw primary weight even with ignorePunctuation=true,
+  // because CollationElementIterator returns raw weights; UCOL_SHIFTED is only
+  // applied during comparison, not during element iteration.
+  EXPECT_EQ(loc.countPrimaryCollationElements(".hello"), 6u);
+  EXPECT_EQ(loc.countPrimaryCollationElements("hello world"), 11u);
+  EXPECT_EQ(loc.countPrimaryCollationElements("..."), 3u);
+}
 
-  auto print = []([[maybe_unused]] const auto& s) {
-    // The following code can be used for convenient debug output.
-    /*
-    for (const auto& ch : s) {
-      std::cout << int(ch) << ' ';
-    }
-    std::cout << std::endl;
-     */
-  };
+// ______________________________________________________________________________________________
+TEST(LocaleManagerTest, PrimaryCollationPrefixLength) {
+  LocaleManager loc("en", "US", false);
 
-  // Assert that all possible prefix sort keys of `s` are indeed prefixes
-  // of the `SortKey` of `s`.
-  auto testSortKeysForLocale = [print](std::string_view s,
-                                       const LocaleManager& loc) {
-    auto complete = loc.getSortKey(s, LocaleManager::Level::PRIMARY).get();
-    print(complete);
-    for (size_t i = 0; i < s.size(); ++i) {
-      auto [numCodepoints, partial] = loc.getPrefixSortKey(s, i);
-      (void)numCodepoints;
-      ASSERT_TRUE(ql::starts_with(complete, partial.get()));
-      print(partial.get());
-    }
-  };
+  // Edge cases.
+  EXPECT_EQ(loc.primaryCollationPrefixLength("hello", 0), 0u);
+  EXPECT_EQ(loc.primaryCollationPrefixLength("", 5), 0u);
+  // Fewer elements than requested: return the full string length.
+  EXPECT_EQ(loc.primaryCollationPrefixLength("hi", 10), 2u);
 
-  auto testSortKeys = [&testSortKeysForLocale, &locIgnorePunct,
-                       &locRespectPunct](std::string_view s) {
-    testSortKeysForLocale(s, locIgnorePunct);
-    testSortKeysForLocale(s, locRespectPunct);
-  };
+  // Basic ASCII: one byte per codepoint, one primary element per letter.
+  EXPECT_EQ(loc.primaryCollationPrefixLength("hello world", 5), 5u);
+  // 6th element is the space, so offset includes it.
+  EXPECT_EQ(loc.primaryCollationPrefixLength("hello world", 6), 6u);
 
-  testSortKeys("original");
-  testSortKeys("Häll!!ö.ö");
+  // Multi-byte UTF-8: é = U+00E9 = 2 bytes but 1 primary element.
+  // "héllo" = h(1) + é(2) + l(1) + l(1) + o(1) = 6 bytes total.
+  EXPECT_EQ(loc.primaryCollationPrefixLength("héllo", 1), 1u);  // "h"
+  EXPECT_EQ(loc.primaryCollationPrefixLength("héllo", 2), 3u);  // "hé"
+  EXPECT_EQ(loc.primaryCollationPrefixLength("héllo", 5), 6u);  // "héllo"
 
-  testSortKeys("vivæ");
-  testSortKeys("vivae");
-  testSortKeys("vivaret");
+  // "." has raw primary weight, so it counts as element 1.
+  EXPECT_EQ(loc.primaryCollationPrefixLength(".hello", 1), 1u);  // "."
+  EXPECT_EQ(loc.primaryCollationPrefixLength(".hello", 6), 6u);  // ".hello"
 
-  testSortKeys("viɡorous");
-  testSortKeys("vigorous");
-
-  // Show the current limitations:
-  // The words vivæ and vivae compare equal on the primary level, but they
-  // get different prefixSortKeys for prefix length 4, because "ae" are two
-  // codepoints, whereas "æ" is one.
-  auto a = locIgnorePunct.getPrefixSortKey("vivæ", 4).second;
-  auto b = locIgnorePunct.getPrefixSortKey("vivae", 4).second;
-
-  ASSERT_GT(a.size(), b.size());
-  ASSERT_TRUE(a.starts_with(b));
-  // Also test the defaulted consistent comparison.
-  ASSERT_GT(a, b);
-  ASSERT_EQ(a, a);
-  ASSERT_NE(a, b);
-  ASSERT_FALSE(comp("vivæ", "vivae", LocaleManager::Level::PRIMARY));
-  ASSERT_FALSE(comp("vivæ", "vivae", LocaleManager::Level::PRIMARY));
+  // Round-trip: countPrimaryCollationElements(s) elements should cover all of
+  // s.
+  for (std::string_view s :
+       {"hello"sv, "héllo"sv, ".hello"sv, "hello world"sv}) {
+    size_t n = loc.countPrimaryCollationElements(s);
+    EXPECT_EQ(loc.primaryCollationPrefixLength(s, n), s.size());
+  }
 }


### PR DESCRIPTION
#2856 fixed an issue that were a result of some niche sort key/direct unicode comparison discrepancies with some specific strings using some specific collation configuration.
This PR drops all sort-key specific logic and replaces the remaining usages with unicode-aware prefix comparison.
From my early testing it looks like there is no performance regression from this.
The text index seems to be working unchanged.