### PR TITLE
Move added `VALUES` clause to the end of the `SERVICE` body

### DIFF
--- a/src/engine/Service.cpp
+++ b/src/engine/Service.cpp
@@ -102,12 +102,15 @@ std::string Service::pushDownValues(std::string_view pattern,
   size_t index = pattern.find('{');
   AD_CORRECTNESS_CHECK(index != std::string::npos);
   pattern.remove_prefix(index + 1);
+  size_t lastBrace = pattern.rfind('}');
+  AD_CORRECTNESS_CHECK(lastBrace != std::string_view::npos);
+  std::string_view body = pattern.substr(0, lastBrace);
   // If we have a single subquery in the service clause, wrap it inside curly
   // braces so it remains valid syntax alongside a VALUES clause.
   if (ctre::starts_with<selectPatternRegex>(pattern)) {
-    return absl::StrCat("{\n", values, "\n{", pattern, "\n}");
+    return absl::StrCat("{\n{", body, "}\n", values, "\n}");
   }
-  return absl::StrCat("{\n", values, "\n", pattern);
+  return absl::StrCat("{\n", body, "\n", values, "\n}");
 }
 
 // _____________________________________________________________________________
@@ -424,7 +427,7 @@ std::optional<std::string> Service::getSiblingValuesClause() const {
     checkCancellation();
   }
 
-  return "VALUES " + vars + values + "} . ";
+  return "VALUES " + vars + values + "} ";
 }
 
 // ____________________________________________________________________________

--- a/src/engine/Service.h
+++ b/src/engine/Service.h
@@ -167,6 +167,7 @@ class Service : public Operation {
   FRIEND_TEST(ServiceTest, precomputeSiblingResultDoesNotWorkWithCaching);
   FRIEND_TEST(ServiceTest, precomputeSiblingResultDoesNotWorkWithLimit);
   FRIEND_TEST(ServiceTest, precomputeSiblingResult);
+  FRIEND_TEST(ServiceTest, pushDownValuesPlacesValuesAtEnd);
 };
 #else
 // In the C++17 mode, where the If we disable the `Service` operation isled,

--- a/test/ServiceTest.cpp
+++ b/test/ServiceTest.cpp
@@ -425,9 +425,8 @@ TEST_F(ServiceTest, computeResult) {
 
     std::string_view expectedSparqlQuery5 =
         "PREFIX doof: <http://doof.org> SELECT ?x ?y ?z2 "
-        "{ VALUES (?x ?y) { (<x> <y>) (<blu> <bla>) } . ?x <ble> ?y "
-        ". ?y "
-        "<is-a> ?z2 . }";
+        "{ ?x <ble> ?y . ?y <is-a> ?z2 . VALUES (?x ?y) { (<x> <y>) "
+        "(<blu> <bla>) } }";
 
     Service serviceOperation5{
         testQec, parsedServiceClause5,
@@ -498,8 +497,7 @@ TEST_F(ServiceTest, computeResultWrapSubqueriesWithSibling) {
       false};
 
   std::string_view expectedSparqlQuery =
-      " SELECT ?a { VALUES (?a) { (<a>) } . { SELECT ?obj WHERE { ?a ?b "
-      "?c } } }";
+      " SELECT ?a { { SELECT ?obj WHERE { ?a ?b ?c } } VALUES (?a) { (<a>) } }";
 
   Service serviceOperation{
       testQec, parsedServiceClause,
@@ -508,6 +506,27 @@ TEST_F(ServiceTest, computeResultWrapSubqueriesWithSibling) {
 
   serviceOperation.siblingInfo_.emplace(siblingInfoFromOp(sibling));
   EXPECT_NO_THROW(serviceOperation.computeResultOnlyForTesting());
+}
+
+// _____________________________________________________________________________
+TEST_F(ServiceTest, pushDownValuesPlacesValuesAtEnd) {
+  // Normal body: VALUES clause appears after the body content.
+  EXPECT_EQ(
+      Service::pushDownValues("{ ?x <ble> ?y . }", "VALUES (?x) { (<a>) } "),
+      "{\n ?x <ble> ?y . \nVALUES (?x) { (<a>) } \n}");
+
+  // Subquery body: subquery is wrapped in braces and VALUES appears after.
+  EXPECT_EQ(Service::pushDownValues("{ SELECT ?a WHERE { ?a ?b ?c } }",
+                                    "VALUES (?a) { (<a>) } "),
+            "{\n{ SELECT ?a WHERE { ?a ?b ?c } }\nVALUES (?a) { (<a>) } \n}");
+
+  // BIND body: VALUES is placed AFTER the BIND so the remote endpoint does not
+  // see the variable as already bound when it evaluates the BIND expression.
+  // Reproducer: SELECT * WHERE { VALUES ?x { 1 }
+  //             SERVICE <...> { BIND (1 AS ?x) } }
+  EXPECT_EQ(
+      Service::pushDownValues("{ BIND (1 AS ?x) }", "VALUES (?x) { (1) } "),
+      "{\n BIND (1 AS ?x) \nVALUES (?x) { (1) } \n}");
 }
 
 // _____________________________________________________________________________


### PR DESCRIPTION
When the body of a `SERVICE` clause shares variables with the surrounding graph pattern, and the surrounding graph pattern restricts these variables to a number of bindings that is at most the value of the runtime parameter `service-max-value-rows`, then these bindings are added as a `VALUES` clause to the body of the `SERVICE` clause in order to reduce the size of the results that has to be computed and transferred. So far, this `VALUES` clause was added at the beginning of the `SERVICE` body. For example, for the query
```sparql
SELECT * {
  VALUES ?x { 1 }
  SERVICE <https://qlever.dev/api/wikidata> { BIND (1 AS ?x) }
}
```
the body of the `SERVICE` request became `VALUES ?x { 1 } BIND (1 AS ?x)`, which resulted in an error message because the `BIND` requires that the target variable of the `AS` clause is not bound by the previous graph patterns. The simple fix is to add the `VALUES` clause at the end of the body of the `SERVICE` request; for the example `BIND (1 AS ?x) VALUES ?x { 1 }`. Fixes #2900
