### PR TITLE
Use 7 chars instead of 6 for git hash

### DIFF
--- a/CompilationInfo.cmake
+++ b/CompilationInfo.cmake
@@ -23,7 +23,7 @@ message(STATUS "PROJECT_VERSION is ${PROJECT_VERSION}")
 set(CONSTANTS "#include \"CompilationInfo.h\"
 namespace qlever::version {
 constexpr std::string_view GitHash = ${GIT_HASH};
-constexpr std::string_view GitShortHash = GitHash.substr(0, 6);
+constexpr std::string_view GitShortHash = GitHash.substr(0, 7);
 constexpr std::string_view DatetimeOfCompilation = ${DATETIME_OF_COMPILATION};
 constexpr std::string_view ProjectVersion = ${PROJECT_VERSION};
 


### PR DESCRIPTION
Several places in the code use s short hash of the current commit, notably the first lines in the logs of `qlever-server` and `qlever-index`. So far, this short hash was six characters long. This is now changed to the more standard seven characters