### PR TITLE
Fix handling of prefix regexes with character class escapes

### DIFF
--- a/src/engine/sparqlExpressions/RegexExpression.cpp
+++ b/src/engine/sparqlExpressions/RegexExpression.cpp
@@ -118,13 +118,10 @@ std::optional<std::string> PrefixRegexExpression::getPrefixRegex(
     if (!escaped && isControlChar) {
       return std::nullopt;
     } else if (escaped && !isControlChar) {
-      const std::string error =
-          "Escaping the character "s + c +
-          " is not allowed in QLever's regex filters. (Regex was " + regex +
-          ") Please note that "
-          "there are two levels of escaping in place here: One for SPARQL "
-          "and one for the regex engine";
-      throw std::runtime_error(error);
+      // The regex contains an escape of a non-special char (e.g. `\d`).
+      // This is a valid regex feature (handled by RE2 in the general path),
+      // but it is not expressible as a simple prefix filter, so bail out.
+      return std::nullopt;
     }
     escaped = false;
   }

--- a/test/RegexExpressionTest.cpp
+++ b/test/RegexExpressionTest.cpp
@@ -163,6 +163,11 @@ TEST(RegexExpression, nonPrefixRegex) {
   // A prefix regex, but not a fixed string.
   test("?vocab", "^a.*", {F, T, F});
 
+  // Regression test for issue #2920: a regex starting with `^` that uses `\d`
+  // (or any other RE2-supported character class escape) must not throw but
+  // simply be routed to the code for processing general regexes.
+  test("?vocab", R"(^\\d+)", {F, F, F});
+
   test("?mixed", "x", {U, U, U});
   test("?mixed", "x", {F, F, T}, true);
   test("?mixed", "1$", {U, U, U});
@@ -315,9 +320,10 @@ TEST(RegexExpression, getPrefixRegex) {
   ASSERT_EQ("alpha", PrefixRegexExpression::getPrefixRegex("^alpha"));
   ASSERT_EQ(R"(\al*ph.a()",
             PrefixRegexExpression::getPrefixRegex(R"(^\\al\*ph\.a\()"));
-  // Invalid escaping of `"` (no need to escape it).
-  ASSERT_THROW(PrefixRegexExpression::getPrefixRegex(R"(^\")"),
-               std::runtime_error);
+  // Escapes of non-special characters (e.g. `\"`) are valid regex features
+  // handled by RE2 in the general regex path, so the prefix check declines
+  // (returns `std::nullopt`) rather than throwing.
+  ASSERT_EQ(std::nullopt, PrefixRegexExpression::getPrefixRegex(R"(^\")"));
 }
 
 // _____________________________________________________________________________


### PR DESCRIPTION
QLever handles regexes starting with `^` differently: if the part that follows is a fixed string (and some other conditions are met), the regex is evaluated via binary searches instead of checking the regex for every candidate.

So far, when a regex started with `^` and also contained a character class escape (e.g., `"^\\d"`), an exception was thrown. Instead, the processing should just continue as for other regexes. This is now fixed. Fixes #2920