### PR TITLE
Bump Docker GitHub Actions to drop the `Node 20` deprecation

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -32,11 +32,11 @@ jobs:
         # Generate metadata for the docker image based on the GH Actions environment.
       - name: Generate image metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.IMAGE }}
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Login to Docker Hub
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
@@ -44,7 +44,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build ${{ matrix.platform }}
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         id: build
         with:
           context: .
@@ -78,7 +78,7 @@ jobs:
         # seems to be the recommended way to do it.
       - name: Setup E2E test image
         if: matrix.platform == 'linux/amd64'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           # The cache should already provide this. So no rebuild should occur.
           context: .
@@ -100,7 +100,7 @@ jobs:
         uses: actions/checkout@v6
       - name: Generate image metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         env:
           # We build multiplatform images which have an image index above the
           # image manifests. Attach the annotations directly to the image index.
@@ -108,7 +108,7 @@ jobs:
         with:
           images: ${{ env.IMAGE }}
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
So far, the `docker-publish` workflow's `docker/metadata-action@v5`, `docker/setup-buildx-action@v3`, and `docker/build-push-action@v6` ran on Node.js 20, which GitHub Actions will force to Node.js 24 starting 2026-06-16 and remove entirely on 2026-09-16. Now these three actions are bumped to their respective next major versions (`v6`, `v4`, `v7`), which natively support Node.js 24.