### PR TITLE
WIP: Change Result::idTable() to return IdTableView<0>

### DIFF
--- a/src/engine/Bind.cpp
+++ b/src/engine/Bind.cpp
@@ -105,7 +105,7 @@ std::vector<QueryExecutionTree*> Bind::getChildren() {
 }
 
 // _____________________________________________________________________________
-IdTable Bind::cloneSubView(const IdTable& idTable,
+IdTable Bind::cloneSubView(IdTableView<0> idTable,
                            const std::pair<size_t, size_t>& subrange) {
   IdTable result(idTable.numColumns(), idTable.getAllocator());
   result.resize(subrange.second - subrange.first);
@@ -178,9 +178,9 @@ IdTable Bind::computeExpressionBind(
     LocalVocab* localVocab, IdTable idTable,
     const sparqlExpression::SparqlExpression* expression) const {
   sparqlExpression::EvaluationContext evaluationContext(
-      *getExecutionContext(), _subtree->getVariableColumns(), idTable,
-      getExecutionContext()->getAllocator(), *localVocab, cancellationHandle_,
-      deadline_);
+      *getExecutionContext(), _subtree->getVariableColumns(),
+      idTable.asStaticView<0>(), getExecutionContext()->getAllocator(),
+      *localVocab, cancellationHandle_, deadline_);
 
   sparqlExpression::ExpressionResult expressionResult =
       expression->evaluate(&evaluationContext);

--- a/src/engine/Bind.h
+++ b/src/engine/Bind.h
@@ -49,7 +49,7 @@ class Bind : public Operation {
  private:
   Result computeResult(bool requestLaziness) override;
 
-  static IdTable cloneSubView(const IdTable& idTable,
+  static IdTable cloneSubView(IdTableView<0> idTable,
                               const std::pair<size_t, size_t>& subrange);
 
   // Implementation for the binding of arbitrary expressions.

--- a/src/engine/CartesianProductJoin.cpp
+++ b/src/engine/CartesianProductJoin.cpp
@@ -209,7 +209,8 @@ CPP_template_def(typename R)(requires ql::ranges::random_access_range<R>)
   // single result is left. This can probably be done by using the
   // `Result`.
 
-  auto sizesView = ql::views::transform(idTables, &IdTable::size);
+  auto sizesView =
+      ql::views::transform(idTables, &ql::ranges::range_value_t<R>::size);
   auto totalResultSize =
       ::ranges::accumulate(sizesView, 1UL, std::multiplies{});
 
@@ -240,9 +241,9 @@ CPP_template_def(typename R)(requires ql::ranges::random_access_range<R>)
     // The index of the next column in the output that hasn't been written so
     // far.
     size_t resultColIdx = 0;
-    for (const auto& input : idTables) {
-      size_t extraOffset =
-          &input == &idTables.back() ? lastTableOffset * groupSize : 0;
+    auto last = ql::ranges::size(idTables) - 1;
+    for (const auto& [idx, input] : ::ranges::views::enumerate(idTables)) {
+      size_t extraOffset = idx == last ? lastTableOffset * groupSize : 0;
       for (const auto& inputCol : input.getColumns()) {
         decltype(auto) resultCol = result.getColumn(resultColIdx);
         writeResultColumn(resultCol, inputCol, groupSize, offset - extraOffset);
@@ -369,55 +370,50 @@ Result::LazyResult CartesianProductJoin::createLazyConsumer(
     std::vector<std::shared_ptr<const Result>> subresults,
     std::shared_ptr<const Result> lazyResult) const {
   AD_CONTRACT_CHECK(lazyResult);
-  std::vector<std::shared_ptr<const IdTable>> idTables;
+  std::vector<IdTableView<0>> idTables;
   idTables.reserve(subresults.size() + 1);
-  for (auto& result : subresults) {
-    auto* idTable = &result->idTable();
-    idTables.emplace_back(std::move(result), idTable);
+  for (const auto& result : subresults) {
+    idTables.emplace_back(result->idTable());
   }
-  // Placeholder, will be replaced with the current `IdTable` from the lazy
-  // result.
-  idTables.emplace_back(std::make_shared<IdTable>(IdTable{0, allocator()}));
-
-  auto generatedTables = lazyResult->idTables();
-
   auto get = [self = this, staticMergedVocab = std::move(staticMergedVocab),
               limit = getLimitOffset().limitOrDefault(),
               offset = getLimitOffset()._offset, idTables = std::move(idTables),
               lastTableOffset = size_t{0}, producedTableSize = size_t{0},
-              lazyResult =
-                  std::move(lazyResult)](auto& idTableVocabPair) mutable {
+              idTableOpt = std::optional<Result::IdTableVocabPair>{}](
+                 auto& idTableVocabPair) mutable {
     // These things have to be done after handling a single input, so we do them
     // at the beginning of each but the last iteration.
-    lastTableOffset += idTables.back()->size();
-    limit -= producedTableSize;
-    offset += producedTableSize;
-    producedTableSize = 0;
+    if (idTableOpt.has_value()) {
+      idTables.pop_back();
+      lastTableOffset += idTableOpt->idTable_.size();
+      limit -= producedTableSize;
+      offset += producedTableSize;
+      producedTableSize = 0;
+    }
 
-    auto& [idTable, localVocab] = idTableVocabPair;
-    // We know that the last id table is mutable (we inserted it ourselves), so
-    // we can replace it without paying the cost of creating and destroying a
-    // shared pointer.
-    const_cast<IdTable&>(*idTables.back()) = std::move(idTable);
-    if (idTables.back()->empty()) {
+    idTableOpt = std::move(idTableVocabPair);
+    auto& [idTable, localVocab] = idTableOpt.value();
+    if (idTable.empty()) {
       return Result::IdTableLoopControl::makeContinue();
     }
 
+    idTables.emplace_back(idTable.asStaticView<0>());
     localVocab.mergeWith(staticMergedVocab);
 
     return Result::IdTableLoopControl::yieldAll(
         ad_utility::InputRangeTypeErased{
             ad_utility::OwningView{self->produceTablesLazily(
                 std::move(localVocab),
-                ql::views::transform(idTables, ad_utility::dereference), offset,
-                limit, lastTableOffset)} |
+                ql::views::transform(
+                    idTables, ad_utility::staticCast<const IdTableView<0>&>),
+                offset, limit, lastTableOffset)} |
             ql::views::transform([&producedTableSize](auto& tableAndVocab) {
               producedTableSize += tableAndVocab.idTable_.size();
               return std::move(tableAndVocab);
             })});
   };
   return Result::LazyResult(ad_utility::CachingContinuableTransformInputRange(
-      std::move(generatedTables), std::move(get)));
+      lazyResult->idTables(), std::move(get)));
 }
 
 // _____________________________________________________________________________

--- a/src/engine/CountAvailablePredicates.cpp
+++ b/src/engine/CountAvailablePredicates.cpp
@@ -218,10 +218,10 @@ class MergeableHashMap : public ad_utility::HashMap<T, size_t> {
 // _____________________________________________________________________________
 template <size_t WIDTH>
 void CountAvailablePredicates::computePatternTrick(
-    const IdTable& dynInput, IdTable* dynResult,
+    IdTableView<0> dynInput, IdTable* dynResult,
     const CompactVectorOfStrings<Id>& patterns, const size_t subjectColumnIdx,
     const size_t patternColumnIdx, RuntimeInformation& runtimeInfo) {
-  const IdTableView<WIDTH> input = dynInput.asStaticView<WIDTH>();
+  const auto& input = dynInput.template asStaticView<WIDTH>();
   IdTableStatic<2> result = std::move(*dynResult).toStatic<2>();
   AD_LOG_DEBUG << "For " << input.size() << " entities in column "
                << subjectColumnIdx << std::endl;

--- a/src/engine/CountAvailablePredicates.h
+++ b/src/engine/CountAvailablePredicates.h
@@ -90,7 +90,7 @@ class CountAvailablePredicates : public Operation {
    * obtained via a scan of the `ql:has-pattern` predicate.
    */
   template <size_t I>
-  static void computePatternTrick(const IdTable& input, IdTable* result,
+  static void computePatternTrick(IdTableView<0> input, IdTable* result,
                                   const CompactVectorOfStrings<Id>& patterns,
                                   size_t subjectColumnIdx,
                                   size_t patternColumnIdx,

--- a/src/engine/Distinct.cpp
+++ b/src/engine/Distinct.cpp
@@ -178,7 +178,7 @@ IdTable Distinct::distinct(
 
 // _____________________________________________________________________________
 template <size_t WIDTH>
-IdTable Distinct::outOfPlaceDistinct(const IdTable& dynInput) const {
+IdTable Distinct::outOfPlaceDistinct(IdTableView<0> dynInput) const {
   AD_CONTRACT_CHECK(keepIndices_.size() <= dynInput.numColumns());
   AD_LOG_DEBUG << "Distinct on " << dynInput.size() << " elements.\n";
   auto inputView = dynInput.asStaticView<WIDTH>();

--- a/src/engine/Distinct.h
+++ b/src/engine/Distinct.h
@@ -92,7 +92,7 @@ class Distinct : public Operation {
   // Out-of-place implementation of the unique algorithm. Does only copy values
   // if they're actually unique.
   template <size_t WIDTH>
-  IdTable outOfPlaceDistinct(const IdTable& dynInput) const;
+  IdTable outOfPlaceDistinct(IdTableView<0> dynInput) const;
 
   FRIEND_TEST(Distinct, distinct);
   FRIEND_TEST(Distinct, distinctWithEmptyInput);

--- a/src/engine/ExecuteUpdate.cpp
+++ b/src/engine/ExecuteUpdate.cpp
@@ -177,7 +177,7 @@ ExecuteUpdate::transformTriplesTemplate(
 }
 
 // _____________________________________________________________________________
-std::optional<Id> ExecuteUpdate::resolveVariable(const IdTable& idTable,
+std::optional<Id> ExecuteUpdate::resolveVariable(IdTableView<0> idTable,
                                                  const uint64_t& rowIdx,
                                                  IdOrVariableIndex idOrVar) {
   auto visitId = [](const Id& id) {
@@ -195,7 +195,7 @@ std::optional<Id> ExecuteUpdate::resolveVariable(const IdTable& idTable,
 // _____________________________________________________________________________
 void ExecuteUpdate::computeAndAddQuadsForResultRow(
     const std::vector<TransformedTriple>& templates,
-    std::vector<IdTriple<>>& result, const IdTable& idTable,
+    std::vector<IdTriple<>>& result, IdTableView<0> idTable,
     const uint64_t rowIdx) {
   for (const auto& [s, p, o, g] : templates) {
     auto subject = resolveVariable(idTable, rowIdx, s);

--- a/src/engine/ExecuteUpdate.h
+++ b/src/engine/ExecuteUpdate.h
@@ -49,7 +49,7 @@ class ExecuteUpdate {
   // result row. The `Id`s will never be undefined. If (and only if) the input
   // `Id` or the `Id` looked up in the `IdTable` is undefined then
   // `std::nullopt` is returned.
-  static std::optional<Id> resolveVariable(const IdTable& idTable,
+  static std::optional<Id> resolveVariable(IdTableView<0> idTable,
                                            const uint64_t& rowIdx,
                                            IdOrVariableIndex idOrVar);
   FRIEND_TEST(ExecuteUpdate, resolveVariable);
@@ -59,7 +59,7 @@ class ExecuteUpdate {
   // consist of only `Id`s.
   static void computeAndAddQuadsForResultRow(
       const std::vector<TransformedTriple>& templates,
-      std::vector<IdTriple<>>& result, const IdTable& idTable, uint64_t rowIdx);
+      std::vector<IdTriple<>>& result, IdTableView<0> idTable, uint64_t rowIdx);
   FRIEND_TEST(ExecuteUpdate, computeAndAddQuadsForResultRow);
 
   struct IdTriplesAndLocalVocab {

--- a/src/engine/ExistsJoin.cpp
+++ b/src/engine/ExistsJoin.cpp
@@ -329,8 +329,7 @@ struct LazyExistsJoinImpl
   // Store the ranges of the child results. The left result is owned, the right
   // is just a view to the wrapped `IdTable`s.
   ad_utility::InputRangeTypeErased<Result::IdTableVocabPair> leftRange_;
-  ad_utility::InputRangeTypeErased<std::reference_wrapper<const IdTable>>
-      rightRange_;
+  ad_utility::InputRangeTypeErased<IdTableView<0>> rightRange_;
 
   // Store the join columns.
   ColumnIndex leftJoinColumn_;
@@ -338,8 +337,7 @@ struct LazyExistsJoinImpl
 
   // Store the current result of the right child. This is a view to the current
   // `IdTable`.
-  std::optional<std::reference_wrapper<const IdTable>> currentRight_ =
-      std::nullopt;
+  std::optional<IdTableView<0>> currentRight_ = std::nullopt;
   // Store the current index in the right child that was last being checked.
   size_t currentRightIndex_ = 0;
 
@@ -363,16 +361,16 @@ struct LazyExistsJoinImpl
   }
 
   // Convert result to a view of `IdTable`s. This is used for the right side.
-  static ad_utility::InputRangeTypeErased<std::reference_wrapper<const IdTable>>
-  toRangeView(const std::shared_ptr<const Result>& result) {
+  static ad_utility::InputRangeTypeErased<IdTableView<0>> toRangeView(
+      const std::shared_ptr<const Result>& result) {
     if (result->isFullyMaterialized()) {
-      return ad_utility::InputRangeTypeErased{
-          std::array{std::cref(result->idTable())}};
+      return ad_utility::InputRangeTypeErased{std::array{result->idTable()}};
     }
     return ad_utility::InputRangeTypeErased{
         ad_utility::CachingTransformInputRange{
-            result->idTables(),
-            [](const auto& pair) { return std::cref(pair.idTable_); }}};
+            result->idTables(), [](const auto& pair) {
+              return pair.idTable_.template asStaticView<0>();
+            }}};
   }
 
   // Construct an instance of `LazyExistsJoinImpl` with the given left and right
@@ -393,7 +391,7 @@ struct LazyExistsJoinImpl
   void fetchNextRightBlock() {
     do {
       currentRight_ = rightRange_.get();
-    } while (currentRight_.has_value() && currentRight_.value().get().empty());
+    } while (currentRight_.has_value() && currentRight_.value().empty());
   }
 
   // Increment `currentRightIndex_` by one, or fetch the next non-empty element
@@ -402,7 +400,7 @@ struct LazyExistsJoinImpl
     currentRightIndex_++;
     // Get the next block from the range if we couldn't find a matching value
     // in this one.
-    if (currentRightIndex_ == currentRight_.value().get().size()) {
+    if (currentRightIndex_ == currentRight_.value().size()) {
       fetchNextRightBlock();
       currentRightIndex_ = 0;
       // Optimization to copy all remaining blocks in one.
@@ -424,9 +422,9 @@ struct LazyExistsJoinImpl
     // Search for the next match.
     while (currentRight_.has_value()) {
       AD_CORRECTNESS_CHECK(currentRightIndex_ <
-                           currentRight_.value().get().size());
+                           currentRight_.value().size());
       auto comparison = ql::compareThreeWay(
-          currentRight_.value().get().at(currentRightIndex_, rightJoinColumn_),
+          currentRight_.value().at(currentRightIndex_, rightJoinColumn_),
           id);
       if (comparison == 0) {
         return true;
@@ -446,7 +444,7 @@ struct LazyExistsJoinImpl
         allRowsFromLeftExist_ == FastForwardState::Unknown) {
       fetchNextRightBlock();
       if (currentRight_.has_value()) {
-        if (currentRight_.value().get().at(0, rightJoinColumn_).isUndefined()) {
+        if (currentRight_.value().at(0, rightJoinColumn_).isUndefined()) {
           allRowsFromLeftExist_ = FastForwardState::Yes;
         }
       } else {

--- a/src/engine/ExportQueryExecutionTrees.cpp
+++ b/src/engine/ExportQueryExecutionTrees.cpp
@@ -114,7 +114,8 @@ ExportQueryExecutionTrees::getIdTables(const Result& result) {
 
   return InputRangeTypeErased(CachingTransformInputRange(
       result.idTables(), [](const Result::IdTableVocabPair& pair) {
-        return TableConstRefWithVocab{pair.idTable_, pair.localVocab_};
+        return TableConstRefWithVocab{pair.idTable_.asStaticView<0>(),
+                                      pair.localVocab_};
       }));
 }
 
@@ -336,7 +337,7 @@ ExportQueryExecutionTrees::constructQueryResultBindingsToQLeverJSON(
 nlohmann::json idTableToQLeverJSONRow(
     const QueryExecutionTree& qet,
     const QueryExecutionTree::ColumnIndicesAndTypes& columns,
-    const LocalVocab& localVocab, const size_t rowIndex, const IdTable& data) {
+    const LocalVocab& localVocab, const size_t rowIndex, IdTableView<0> data) {
   // We need the explicit `array` constructor for the special case of zero
   // variables.
   auto row = nlohmann::json::array();

--- a/src/engine/Filter.cpp
+++ b/src/engine/Filter.cpp
@@ -114,7 +114,8 @@ Result Filter::computeResult(bool requestLaziness) {
 }
 
 // _____________________________________________________________________________
-CPP_template_def(typename Table)(requires ad_utility::SimilarTo<Table, IdTable>)
+CPP_template_def(typename Table)(
+    requires ad_utility::SimilarToAny<Table, IdTable, IdTableView<0>>)
     IdTable Filter::filterIdTable(std::vector<ColumnIndex> sortedBy,
                                   Table&& idTable) const {
   size_t width = idTable.numColumns();
@@ -130,7 +131,7 @@ CPP_template_def(typename Table)(requires ad_utility::SimilarTo<Table, IdTable>)
 
 // _____________________________________________________________________________
 CPP_template_def(int WIDTH, typename Table)(
-    requires ad_utility::SimilarTo<Table, IdTable>) void Filter::
+    requires ad_utility::SimilarToAny<Table, IdTable, IdTableView<0>>) void Filter::
     computeFilterImpl(IdTable& dynamicResultTable, Table&& inputTable,
                       std::vector<ColumnIndex> sortedBy) const {
   LocalVocab dummyLocalVocab{};
@@ -138,7 +139,8 @@ CPP_template_def(int WIDTH, typename Table)(
   IdTableStatic<WIDTH> resultTable =
       std::move(dynamicResultTable).toStatic<static_cast<size_t>(WIDTH)>();
   sparqlExpression::EvaluationContext evaluationContext(
-      *getExecutionContext(), _subtree->getVariableColumns(), inputTable,
+      *getExecutionContext(), _subtree->getVariableColumns(),
+      inputTable.template asStaticView<0>(),
       getExecutionContext()->getAllocator(), dummyLocalVocab,
       cancellationHandle_, deadline_);
 
@@ -178,7 +180,13 @@ CPP_template_def(int WIDTH, typename Table)(
         // The binary filter contains all elements of the input, and we have
         // no previous results, so we can simply copy or move the complete
         // table.
-        dynamicResultTable = AD_FWD(inputTable).moveOrClone();
+        if constexpr (ad_utility::isSimilar<Table, IdTableView<0>>) {
+          // TODO<joka921> figure out why moveOrClone doesn't work for
+          // IdTableView.
+          dynamicResultTable = inputTable.clone();
+        } else {
+          dynamicResultTable = AD_FWD(inputTable).moveOrClone();
+        }
         return;
       }
       checkCancellation();

--- a/src/engine/Filter.h
+++ b/src/engine/Filter.h
@@ -74,15 +74,15 @@ class Filter : public Operation {
 
   // Perform the actual filter operation of the data provided.
   CPP_template(int WIDTH, typename Table)(
-      requires ad_utility::SimilarTo<
-          Table, IdTable>) void computeFilterImpl(IdTable& dynamicResultTable,
+      requires ad_utility::SimilarToAny<
+          Table, IdTable, IdTableView<0>>) void computeFilterImpl(IdTable& dynamicResultTable,
                                                   Table&& input,
                                                   std::vector<ColumnIndex>
                                                       sortedBy) const;
 
   // Run `computeFilterImpl` on the provided IdTable
   CPP_template(typename Table)(
-      requires ad_utility::SimilarTo<Table, IdTable>) IdTable
+      requires ad_utility::SimilarToAny<Table, IdTable, IdTableView<0>>) IdTable
       filterIdTable(std::vector<ColumnIndex> sortedBy, Table&& idTable) const;
 };
 

--- a/src/engine/GroupByImpl.cpp
+++ b/src/engine/GroupByImpl.cpp
@@ -154,7 +154,7 @@ class LazyGroupByRange
     }
 
     sparqlExpression::EvaluationContext evaluationContext =
-        parent_->createEvaluationContext(currentLocalVocab_, idTable);
+        parent_->createEvaluationContext(currentLocalVocab_, idTable.asStaticView<0>());
 
     size_t lastBlockStart = parent_->searchBlockBoundaries(
         [this, &evaluationContext](size_t a, size_t b) {
@@ -214,7 +214,7 @@ class LazyGroupByRange
     }
 
     sparqlExpression::EvaluationContext evaluationContext =
-        parent_->createEvaluationContext(currentLocalVocab_, idTable);
+        parent_->createEvaluationContext(currentLocalVocab_, idTable.asStaticView<0>());
 
     lazyGroupBy_->commitRow(resultTable_, evaluationContext,
                             currentGroupBlock_);
@@ -458,7 +458,7 @@ void GroupByImpl::processGroup(
 
 // _____________________________________________________________________________
 template <size_t IN_WIDTH, size_t OUT_WIDTH>
-IdTable GroupByImpl::doGroupBy(const IdTable& inTable,
+IdTable GroupByImpl::doGroupBy(IdTableView<0> inTable,
                                const vector<size_t>& groupByCols,
                                const vector<Aggregate>& aggregates,
                                LocalVocab* outLocalVocab) const {
@@ -505,7 +505,7 @@ IdTable GroupByImpl::doGroupBy(const IdTable& inTable,
 
 // _____________________________________________________________________________
 sparqlExpression::EvaluationContext GroupByImpl::createEvaluationContext(
-    LocalVocab& localVocab, const IdTable& idTable) const {
+    LocalVocab& localVocab, IdTableView<0> idTable) const {
   sparqlExpression::EvaluationContext evaluationContext{
       *getExecutionContext(),
       _subtree->getVariableColumns(),
@@ -612,8 +612,9 @@ Result GroupByImpl::computeResult(bool requestLaziness) {
     // of results, so if the result is fully materialized, we create an array
     // with a single element.
     if (subresult->isFullyMaterialized()) {
+      auto idTableView = subresult->idTable();
       return computeWithHashMap(
-          std::array{std::pair{std::cref(subresult->idTable()),
+          std::array{std::pair{std::cref(idTableView),
                                std::cref(subresult->localVocab())}});
     } else {
       return computeWithHashMap(subresult->idTables());
@@ -717,7 +718,7 @@ void GroupByImpl::processEmptyImplicitGroup(
   IdTable idTable{inWidth, ad_utility::makeAllocatorWithLimit<Id>(0_B)};
 
   sparqlExpression::EvaluationContext evaluationContext =
-      createEvaluationContext(*localVocab, idTable);
+      createEvaluationContext(*localVocab, idTable.asStaticView<0>());
   resultTable.emplace_back();
 
   IdTableStatic<OUT_WIDTH> table = std::move(resultTable).toStatic<OUT_WIDTH>();
@@ -1661,7 +1662,7 @@ IdTable GroupByImpl::createResultFromHashMap(
 
   // Initialize evaluation context
   sparqlExpression::EvaluationContext evaluationContext =
-      createEvaluationContext(*localVocab, result);
+      createEvaluationContext(*localVocab, result.asStaticView<0>());
 
   ad_utility::Timer evaluationAndResultsTimer{ad_utility::Timer::Started};
   for (size_t i = 0; i < numberOfGroups; i += GROUP_BY_HASH_MAP_BLOCK_SIZE) {
@@ -1728,7 +1729,13 @@ Result GroupByImpl::computeGroupByForHashMapOptimization(
   ad_utility::Timer lookupTimer{ad_utility::Timer::Stopped};
   ad_utility::Timer aggregationTimer{ad_utility::Timer::Stopped};
   for (const auto& [inputTableRef, inputLocalVocabRef] : subresults) {
-    const IdTable& inputTable = inputTableRef;
+    const auto& inputTable = [&]() -> decltype(auto) {
+      if constexpr (requires { inputTableRef.get(); }) {
+        return inputTableRef.get();
+      } else {
+        return (inputTableRef);
+      }
+    }();
     const LocalVocab& inputLocalVocab = inputLocalVocabRef;
 
     // Merge the local vocab of each input block.
@@ -1738,7 +1745,8 @@ Result GroupByImpl::computeGroupByForHashMapOptimization(
     localVocab.mergeWith(inputLocalVocab);
     // Setup the `EvaluationContext` for this input block.
     sparqlExpression::EvaluationContext evaluationContext(
-        *getExecutionContext(), _subtree->getVariableColumns(), inputTable,
+        *getExecutionContext(), _subtree->getVariableColumns(),
+        inputTable.template asStaticView<0>(),
         getExecutionContext()->getAllocator(), localVocab, cancellationHandle_,
         deadline_);
     evaluationContext._groupedVariables = ad_utility::HashSet<Variable>{

--- a/src/engine/GroupByImpl.h
+++ b/src/engine/GroupByImpl.h
@@ -108,7 +108,7 @@ class GroupByImpl : public Operation {
   // Helper function to create evaluation contexts in various places for the
   // GROUP BY operation.
   sparqlExpression::EvaluationContext createEvaluationContext(
-      LocalVocab& localVocab, const IdTable& idTable) const;
+      LocalVocab& localVocab, IdTableView<0> idTable) const;
 
   // Find the boundaries of blocks in a sorted `IdTable`. If these represent a
   // whole group they can be aggregated into ids afterwards. This can happen by
@@ -163,7 +163,7 @@ class GroupByImpl : public Operation {
                     size_t resultColumn, LocalVocab* localVocab) const;
 
   template <size_t IN_WIDTH, size_t OUT_WIDTH>
-  IdTable doGroupBy(const IdTable& inTable, const vector<size_t>& groupByCols,
+  IdTable doGroupBy(IdTableView<0> inTable, const vector<size_t>& groupByCols,
                     const vector<Aggregate>& aggregates,
                     LocalVocab* outLocalVocab) const;
 

--- a/src/engine/HasPredicateScan.cpp
+++ b/src/engine/HasPredicateScan.cpp
@@ -268,9 +268,12 @@ Result HasPredicateScan::computeResult([[maybe_unused]] bool requestLaziness) {
   // The `callback` is invoked with a single-value span of the `idTable` if the
   // result is fully materialized, because it expects a range of `IdTable`s.
   // Because of caching we can potentially get a fully materialized result here.
-  auto runOnResult = [&result](auto callback) {
+  auto idTableView = result->isFullyMaterialized()
+                         ? std::optional{result->idTable()}
+                         : std::nullopt;
+  auto runOnResult = [&result, &idTableView](auto callback) {
     if (result->isFullyMaterialized()) {
-      return std::invoke(callback, ql::span{&result->idTable(), 1});
+      return std::invoke(callback, ql::span{&*idTableView, 1});
     }
     auto idTables = result->idTables();
     return std::invoke(

--- a/src/engine/Join.cpp
+++ b/src/engine/Join.cpp
@@ -297,7 +297,7 @@ void Join::computeSizeEstimateAndMultiplicities() {
 
 // ______________________________________________________________________________
 
-void Join::join(const IdTable& a, const IdTable& b, IdTable* result) const {
+void Join::join(IdTableView<0> a, IdTableView<0> b, IdTable* result) const {
   AD_LOG_DEBUG << "Performing join between two tables.\n";
   AD_LOG_DEBUG << "A: width = " << a.numColumns() << ", size = " << a.size()
                << "\n";
@@ -603,7 +603,7 @@ Result Join::computeResultForIndexScanAndIdTable(
        resultWithIdTable = std::move(resultWithIdTable),
        joinColMap = std::move(joinColMap)](
           std::function<void(IdTable&, LocalVocab&)> yieldTable) {
-        const IdTable& idTable = resultWithIdTable->idTable();
+        const auto& idTable = resultWithIdTable->idTable();
         auto rowAdder = makeRowAdder(std::move(yieldTable));
 
         auto permutationIdTable =

--- a/src/engine/Join.h
+++ b/src/engine/Join.h
@@ -90,7 +90,7 @@ class Join : public Operation {
    * TODO Move the merge join into it's own function and make this function
    * a proper switch.
    **/
-  void join(const IdTable& a, const IdTable& b, IdTable* result) const;
+  void join(IdTableView<0> a, IdTableView<0> b, IdTable* result) const;
 
  public:
   // Fallback implementation of a join that is used when at least one of the two

--- a/src/engine/Minus.cpp
+++ b/src/engine/Minus.cpp
@@ -113,7 +113,7 @@ size_t Minus::getCostEstimate() {
 }
 
 // _____________________________________________________________________________
-auto Minus::makeUndefRangesChecker(bool left, const IdTable& idTable) const {
+auto Minus::makeUndefRangesChecker(bool left, IdTableView<0> idTable) const {
   const auto& operation = left ? _left : _right;
   bool alwaysDefined = ql::ranges::all_of(
       _matchedColumns, [&operation, left, &idTable](const auto& cols) {
@@ -136,7 +136,7 @@ auto Minus::makeUndefRangesChecker(bool left, const IdTable& idTable) const {
 // _____________________________________________________________________________
 template <typename T>
 IdTable Minus::copyMatchingRows(
-    const IdTable& left, T reference,
+    IdTableView<0> left, T reference,
     const std::vector<T, ad_utility::AllocatorWithLimit<T>>& keepEntry) const {
   IdTable result{getResultWidth(), left.getAllocator()};
   AD_CORRECTNESS_CHECK(result.numColumns() == left.numColumns());
@@ -164,7 +164,7 @@ IdTable Minus::copyMatchingRows(
 }
 // _____________________________________________________________________________
 IdTable Minus::computeMinus(
-    const IdTable& left, const IdTable& right,
+    IdTableView<0> left, IdTableView<0> right,
     const std::vector<std::array<ColumnIndex, 2>>& joinColumns) const {
   if (left.empty()) {
     return IdTable{getResultWidth(), getExecutionContext()->getAllocator()};
@@ -247,7 +247,7 @@ std::optional<Result> Minus::tryIndexNestedLoopJoinIfSuitable() {
   }
 
   auto leftRes = _left->getResult(false);
-  const IdTable& leftTable = leftRes->idTable();
+  const auto& leftTable = leftRes->idTable();
   auto rightRes = qlever::joinHelpers::computeResultSkipChild(sort);
 
   LocalVocab localVocab = leftRes->getCopyOfLocalVocab();

--- a/src/engine/Minus.h
+++ b/src/engine/Minus.h
@@ -52,13 +52,13 @@ class Minus : public Operation {
   // `std::variant<ad_utility::Noop, ad_utility::FindSmallerUndefRanges>` to
   // avoid including expensive headers that are only relevant for the
   // implementation of this function.
-  auto makeUndefRangesChecker(bool left, const IdTable& idTable) const;
+  auto makeUndefRangesChecker(bool left, IdTableView<0> idTable) const;
 
   // Helper function to copy all rows from `left` that have a corresponding
   // value of `reference` in `keepEntry`.
   template <typename T>
   IdTable copyMatchingRows(
-      const IdTable& left, T reference,
+      IdTableView<0> left, T reference,
       const std::vector<T, ad_utility::AllocatorWithLimit<T>>& keepEntry) const;
 
  public:
@@ -78,7 +78,7 @@ class Minus : public Operation {
    *        This method is made public here for unit testing purposes.
    **/
   IdTable computeMinus(
-      const IdTable& a, const IdTable& b,
+      IdTableView<0> a, IdTableView<0> b,
       const std::vector<std::array<ColumnIndex, 2>>& matchedColumns) const;
 
  private:

--- a/src/engine/MultiColumnJoin.cpp
+++ b/src/engine/MultiColumnJoin.cpp
@@ -206,7 +206,7 @@ void MultiColumnJoin::computeSizeEstimateAndMultiplicities() {
 
 // _______________________________________________________________________
 void MultiColumnJoin::computeMultiColumnJoin(
-    const IdTable& left, const IdTable& right,
+    IdTableView<0> left, IdTableView<0> right,
     const std::vector<std::array<ColumnIndex, 2>>& joinColumns,
     IdTable* result) {
   // check for trivial cases

--- a/src/engine/MultiColumnJoin.h
+++ b/src/engine/MultiColumnJoin.h
@@ -65,7 +65,7 @@ class MultiColumnJoin : public Operation {
    *This method is made public here for unit testing purposes.
    **/
   void computeMultiColumnJoin(
-      const IdTable& left, const IdTable& right,
+      IdTableView<0> left, IdTableView<0> right,
       const std::vector<std::array<ColumnIndex, 2>>& joinColumns,
       IdTable* resultMightBeUnsorted);
 

--- a/src/engine/Operation.cpp
+++ b/src/engine/Operation.cpp
@@ -230,7 +230,7 @@ Result Operation::runComputation(const ad_utility::Timer& timer,
     externalLimitApplied_ = !limitOffset_.isUnconstrained();
     result.applyLimitOffset(
         limitOffset_,
-        [this](std::chrono::microseconds limitTime, const IdTable& idTable) {
+        [this](std::chrono::microseconds limitTime, const auto& idTable) {
           updateRuntimeStats(true, idTable.numRows(), idTable.numColumns(),
                              limitTime);
         });

--- a/src/engine/OptionalJoin.cpp
+++ b/src/engine/OptionalJoin.cpp
@@ -308,7 +308,7 @@ void OptionalJoin::computeSizeEstimateAndMultiplicities() {
 
 // ______________________________________________________________
 auto OptionalJoin::computeImplementationFromIdTables(
-    const IdTable& left, const IdTable& right,
+    IdTableView<0> left, IdTableView<0> right,
     const std::vector<std::array<ColumnIndex, 2>>& joinColumns)
     -> Implementation {
   auto implementation = Implementation::NoUndef;
@@ -352,7 +352,7 @@ bool OptionalJoin::columnOriginatesFromGraphOrUndef(
 
 // ______________________________________________________________
 void OptionalJoin::optionalJoin(
-    const IdTable& left, const IdTable& right,
+    IdTableView<0> left, IdTableView<0> right,
     const std::vector<std::array<ColumnIndex, 2>>& joinColumns, IdTable* result,
     Implementation implementation) {
   // check for trivial cases

--- a/src/engine/OptionalJoin.h
+++ b/src/engine/OptionalJoin.h
@@ -72,7 +72,7 @@ class OptionalJoin : public Operation {
   // Joins two result tables on any number of columns, inserting the special
   // value `Id::makeUndefined()` for any entries marked as optional.
   void optionalJoin(
-      const IdTable& left, const IdTable& right,
+      IdTableView<0> left, IdTableView<0> right,
       const std::vector<std::array<ColumnIndex, 2>>& joinColumns,
       IdTable* dynResult,
       Implementation implementation = Implementation::GeneralCase);
@@ -119,7 +119,7 @@ class OptionalJoin : public Operation {
   // Check which of the join columns in `left` and `right` contain UNDEF values
   // and return the appropriate `Implementation`.
   static Implementation computeImplementationFromIdTables(
-      const IdTable& left, const IdTable& right,
+      IdTableView<0> left, IdTableView<0> right,
       const std::vector<std::array<ColumnIndex, 2>>&);
 };
 

--- a/src/engine/PathSearch.cpp
+++ b/src/engine/PathSearch.cpp
@@ -21,7 +21,7 @@
 using namespace pathSearch;
 
 // _____________________________________________________________________________
-BinSearchWrapper::BinSearchWrapper(const IdTable& table, size_t startCol,
+BinSearchWrapper::BinSearchWrapper(IdTableView<0> table, size_t startCol,
                                    size_t endCol, std::vector<size_t> edgeCols)
     : table_(table),
       startCol_(startCol),
@@ -234,7 +234,7 @@ Result PathSearch::computeResult([[maybe_unused]] bool requestLaziness) {
   IdTable idTable{allocator()};
   idTable.setNumColumns(getResultWidth());
 
-  const IdTable& dynSub = subRes->idTable();
+  const auto& dynSub = subRes->idTable();
   if (!dynSub.empty()) {
     auto timer = ad_utility::Timer(ad_utility::Timer::Started);
 

--- a/src/engine/PathSearch.h
+++ b/src/engine/PathSearch.h
@@ -58,13 +58,13 @@ using PathsLimited = std::vector<Path, ad_utility::AllocatorWithLimit<Path>>;
  *
  */
 class BinSearchWrapper {
-  const IdTable& table_;
+  IdTableView<0> table_;
   size_t startCol_;
   size_t endCol_;
   std::vector<size_t> edgeCols_;
 
  public:
-  BinSearchWrapper(const IdTable& table, size_t startCol, size_t endCol,
+  BinSearchWrapper(IdTableView<0> table, size_t startCol, size_t endCol,
                    std::vector<size_t> edgeCols);
 
   /**

--- a/src/engine/QueryExecutionContext.h
+++ b/src/engine/QueryExecutionContext.h
@@ -48,7 +48,8 @@ class CacheValue {
     return runtimeInfo_;
   }
 
-  static ad_utility::MemorySize getSize(const IdTable& idTable) {
+  template <typename IdTableT>
+  static ad_utility::MemorySize getSize(const IdTableT& idTable) {
     return ad_utility::MemorySize::bytes(idTable.size() * idTable.numColumns() *
                                          sizeof(Id));
   }

--- a/src/engine/QueryExportTypes.h
+++ b/src/engine/QueryExportTypes.h
@@ -14,10 +14,10 @@
 // Helper type that provides const ref access to the underlying `IdTable` and
 // `LocalVocab` associated with the `IdTable`.
 struct TableConstRefWithVocab {
-  std::reference_wrapper<const IdTable> idTable_;
+  IdTableView<0> idTable_;
   std::reference_wrapper<const LocalVocab> localVocab_;
 
-  const IdTable& idTable() const { return idTable_.get(); }
+  IdTableView<0> idTable() const { return idTable_; }
 
   const LocalVocab& localVocab() const { return localVocab_.get(); }
 };

--- a/src/engine/Result.cpp
+++ b/src/engine/Result.cpp
@@ -54,7 +54,8 @@ auto compareRowsBySortColumns(const std::vector<ColumnIndex>& sortedBy) {
 namespace {
 // _____________________________________________________________________________
 // Check if sort order promised by `sortedBy` is kept within `idTable`.
-void assertSortOrderIsRespected(const IdTable& idTable,
+template <typename IdTableT>
+void assertSortOrderIsRespected(const IdTableT& idTable,
                                 const std::vector<ColumnIndex>& sortedBy) {
   AD_CONTRACT_CHECK(
       ql::ranges::all_of(sortedBy, [&idTable](ColumnIndex colIndex) {
@@ -98,6 +99,18 @@ Result::Result(IdTable idTable, std::vector<ColumnIndex> sortedBy,
                LocalVocab&& localVocab)
     : Result{std::move(idTable), std::move(sortedBy),
              SharedLocalVocabWrapper{std::move(localVocab)}} {}
+
+// _____________________________________________________________________________
+Result::Result(IdTableView<0> idTableView, std::vector<ColumnIndex> sortedBy,
+               LocalVocab&& localVocab)
+    : data_{IdTableSharedLocalVocabPair{
+          std::move(idTableView),
+          std::make_shared<const LocalVocab>(std::move(localVocab))}},
+      sortedBy_{std::move(sortedBy)} {
+  AD_CONTRACT_CHECK(std::get<IdTableSharedLocalVocabPair>(data_).localVocab_ !=
+                    nullptr);
+  assertSortOrderIsRespected(this->idTable(), sortedBy_);
+}
 
 // _____________________________________________________________________________
 Result::Result(IdTableVocabPair pair, std::vector<ColumnIndex> sortedBy)
@@ -162,7 +175,7 @@ IdTable makeResizedClone(const IdTable& idTable,
 // _____________________________________________________________________________
 void Result::applyLimitOffset(
     const LimitOffsetClause& limitOffset,
-    std::function<void(std::chrono::microseconds, const IdTable&)>
+    std::function<void(std::chrono::microseconds, const IdTableView<0>&)>
         limitTimeCallback) {
   // Apply the OFFSET clause. If the offset is `0` or the offset is larger
   // than the size of the `IdTable`, then this has no effect and runtime
@@ -176,13 +189,23 @@ void Result::applyLimitOffset(
     auto& tableOrPtr =
         std::get<IdTableSharedLocalVocabPair>(data_).idTableOrPtr_;
     std::visit(
-        [&limitOffset](auto& arg) {
-          if constexpr (ad_utility::isSimilar<decltype(arg), IdTable>) {
+        [&limitOffset, &tableOrPtr](auto& arg) {
+          using T = std::decay_t<decltype(arg)>;
+          if constexpr (ad_utility::isSimilar<T, IdTable>) {
             resizeIdTable(arg, limitOffset);
-          } else {
-            static_assert(ad_utility::isSimilar<decltype(arg), IdTablePtr>);
+          } else if constexpr (ad_utility::isSimilar<T, IdTablePtr>) {
             arg = std::make_shared<const IdTable>(
                 makeResizedClone(*arg, limitOffset));
+          } else {
+            static_assert(ad_utility::isSimilar<T, IdTableView<0>>);
+            // For IdTableView, we need to convert to owned IdTable.
+            // Note: This loses the zero-copy benefit, but LIMIT/OFFSET
+            // requires modification.
+            IdTable clonedTable = arg.clone();
+            IdTablePtr newPtr = std::make_shared<const IdTable>(
+                makeResizedClone(clonedTable, limitOffset));
+            // Replace the variant with the new pointer.
+            tableOrPtr = std::move(newPtr);
           }
         },
         tableOrPtr);
@@ -206,7 +229,8 @@ void Result::applyLimitOffset(
             limitOffset._limit.value() -=
                 limitOffset.actualSize(originalSize - offsetDelta);
           }
-          limitTimeCallback(limitTimer.value(), idTable);
+          // TODO<joka921> This is slightly inefficient.
+          limitTimeCallback(limitTimer.value(), idTable.asStaticView<0>());
           if (limitOffset._offset == 0) {
             return IdTableLoopControl::yieldValue(std::move(pair));
           } else {
@@ -238,7 +262,7 @@ void Result::assertThatLimitWasRespected(const LimitOffsetClause& limitOffset) {
 
 // _____________________________________________________________________________
 void Result::checkDefinedness(const VariableToColumnMap& varColMap) {
-  auto performCheck = [](const auto& map, const IdTable& idTable) {
+  auto performCheck = [](const auto& map, const auto& idTable) {
     return ql::ranges::all_of(map, [&](const auto& varAndCol) {
       const auto& [columnIndex, mightContainUndef] = varAndCol.second;
       if (mightContainUndef == ColumnIndexAndTypeInfo::AlwaysDefined) {
@@ -307,16 +331,18 @@ void Result::runOnNewChunkComputed(
 }
 
 // _____________________________________________________________________________
-const IdTable& Result::idTable() const {
+IdTableView<0> Result::idTable() const {
   AD_CONTRACT_CHECK(isFullyMaterialized());
   return std::visit(
-      [](const auto& arg) -> const IdTable& {
+      [](const auto& arg) -> MaterializedTable {
         using T = std::decay_t<decltype(arg)>;
         if constexpr (std::is_same_v<T, IdTable>) {
-          return arg;
+          return arg.template asStaticView<0>();
+        } else if constexpr (std::is_same_v<T, IdTablePtr>) {
+          return arg->template asStaticView<0>();
         } else {
-          static_assert(std::is_same_v<T, IdTablePtr>);
-          return *arg;
+          static_assert(std::is_same_v<T, IdTableView<0>>);
+          return arg;  // Already a view.
         }
       },
       std::get<IdTableSharedLocalVocabPair>(data_).idTableOrPtr_);

--- a/src/engine/Result.h
+++ b/src/engine/Result.h
@@ -77,9 +77,11 @@ class Result {
   // is useful when the result is still being constructed (because it is
   // mutable), the latter is useful when the result is read from a cache (e.g.
   // the named query cache), because the shared ownership doesn't require a copy
-  // of the result.
+  // of the result. Additionally, for zero-copy deserialization from a blob, the
+  // result can be stored as an `IdTableView<0>`.
   struct IdTableSharedLocalVocabPair {
-    std::variant<IdTable, std::shared_ptr<const IdTable>> idTableOrPtr_;
+    std::variant<IdTable, std::shared_ptr<const IdTable>, IdTableView<0>>
+        idTableOrPtr_;
     // The local vocabulary of the result.
     LocalVocabPtr localVocab_;
   };
@@ -142,6 +144,9 @@ class Result {
   Result(std::shared_ptr<const IdTable> idTablePtr,
          std::vector<ColumnIndex> sortedBy, LocalVocab&& localVocab);
   Result(IdTableVocabPair pair, std::vector<ColumnIndex> sortedBy);
+  // Constructor for zero-copy deserialization with IdTableView.
+  Result(IdTableView<0> idTableView, std::vector<ColumnIndex> sortedBy,
+         LocalVocab&& localVocab);
 #ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
   Result(Generator idTables, std::vector<ColumnIndex> sortedBy);
 #endif
@@ -154,6 +159,8 @@ class Result {
   // Moving of a result table is OK.
   Result(Result&& other) = default;
   Result& operator=(Result&& other) = default;
+
+  using MaterializedTable = IdTableView<0>;
 
   // Wrap the generator stored in `data_` within a new generator that calls
   // `onNewChunk` every time a new `IdTableVocabPair` is yielded by the original
@@ -188,7 +195,7 @@ class Result {
 
   // Const access to the underlying `IdTable`. Throw if this result is not fully
   // materialized.
-  const IdTable& idTable() const;
+  IdTableView<0> idTable() const;
 
   // Access to the underlying `IdTable`s. Throw an `ad_utility::Exception`
   // if the underlying `data_` member holds the wrong variant or if the result
@@ -271,7 +278,7 @@ class Result {
   // those are still correct after performing this operation.
   void applyLimitOffset(
       const LimitOffsetClause& limitOffset,
-      std::function<void(std::chrono::microseconds, const IdTable&)>
+      std::function<void(std::chrono::microseconds, const MaterializedTable&)>
           limitTimeCallback);
 
   // Check if the operation did fulfill its contract and only returns as many

--- a/src/engine/Sort.cpp
+++ b/src/engine/Sort.cpp
@@ -80,13 +80,13 @@ Result Sort::computeResult(bool requestLaziness) {
 
   // For fully materialized input, we know the size upfront.
   if (input->isFullyMaterialized()) {
-    const IdTable& inputTable = input->idTable();
+    const auto& inputTable = input->idTable();
     if (inputTable.numRows() <= maxNumRowsToBeSortedInMemory) {
       return computeResultInMemory(inputTable.clone(),
                                    input->getCopyOfLocalVocab());
     } else {
       LocalVocab localVocab = input->getCopyOfLocalVocab();
-      std::span<const IdTable> inputTableSpan{&inputTable, 1};
+      ql::span<const IdTableView<0>> inputTableSpan{&inputTable, 1};
       return computeResultExternal({}, std::move(localVocab),
                                    inputTableSpan.begin(), inputTableSpan.end(),
                                    std::move(input), requestLaziness);
@@ -182,7 +182,7 @@ Result Sort::computeResultExternal(std::vector<IdTable> collectedBlocks,
   }
   while (it != end) {
     checkCancellation();
-    if constexpr (ad_utility::isSimilar<std::iter_value_t<Iterator>,
+    if constexpr (ad_utility::isSimilar<ql::iter_value_t<Iterator>,
                                         Result::IdTableVocabPair>) {
       auto& idTableAndLocalVocab = *it;
       sorter->pushBlock(std::move(idTableAndLocalVocab.idTable_));

--- a/src/engine/SortedUnionImpl.h
+++ b/src/engine/SortedUnionImpl.h
@@ -17,7 +17,7 @@ namespace sortedUnion {
 // Helper struct that has the same layout as Result::IdTableVocabPair but
 // doesn't own the data.
 struct Wrapper {
-  const IdTable& idTable_;
+  IdTableView<0> idTable_;
   const LocalVocab& localVocab_;
 };
 

--- a/src/engine/SpatialJoin.cpp
+++ b/src/engine/SpatialJoin.cpp
@@ -440,8 +440,8 @@ VariableToColumnMap SpatialJoin::getVarColMapPayloadVars() const {
 PreparedSpatialJoinParams SpatialJoin::prepareJoin() const {
   auto getIdTable = [](std::shared_ptr<QueryExecutionTree> child) {
     std::shared_ptr<const Result> resTable = child->getResult();
-    auto idTablePtr = &resTable->idTable();
-    return std::pair{idTablePtr, std::move(resTable)};
+    auto idTableView = resTable->idTable();
+    return std::pair{idTableView, std::move(resTable)};
   };
 
   // Swap sides for within spatial join type computed using contains

--- a/src/engine/SpatialJoin.h
+++ b/src/engine/SpatialJoin.h
@@ -18,9 +18,9 @@
 
 // helper struct to improve readability in prepareJoin()
 struct PreparedSpatialJoinParams {
-  const IdTable* const idTableLeft_;
+  IdTableView<0> idTableLeft_;
   std::shared_ptr<const Result> resultLeft_;
-  const IdTable* const idTableRight_;
+  IdTableView<0> idTableRight_;
   std::shared_ptr<const Result> resultRight_;
   ColumnIndex leftJoinCol_;
   ColumnIndex rightJoinCol_;

--- a/src/engine/SpatialJoinAlgorithms.cpp
+++ b/src/engine/SpatialJoinAlgorithms.cpp
@@ -100,7 +100,7 @@ SpatialJoinAlgorithms::libspatialjoinParse(
   static constexpr auto batchSize =
       ad_utility::detail::parallel_wkt_parser::WKT_PARSER_BATCH_SIZE;
   static_assert(batchSize > 0);
-  size_t requiredBatches = (idTable->size() + batchSize - 1ULL) / batchSize;
+  size_t requiredBatches = (idTable.size() + batchSize - 1ULL) / batchSize;
   numThreads = std::min(numThreads, requiredBatches);
 
   // Initialize the parser.
@@ -110,9 +110,9 @@ SpatialJoinAlgorithms::libspatialjoinParse(
 
   // Iterate over all rows in `idTable` and add the geometries from `column` to
   // the parallel WKT parser.
-  const auto& geoms = idTable->getColumn(column);
+  const auto& geoms = idTable.getColumn(column);
   ad_utility::chunkedForLoop<wktParserChunkSizeForCancellationCheck>(
-      0, idTable->size(),
+      0, idTable.size(),
       [&parser, &geoms, &leftOrRightSide](size_t row) {
         parser.addValueIdToQueue(geoms[row], row, leftOrRightSide);
       },
@@ -123,7 +123,7 @@ SpatialJoinAlgorithms::libspatialjoinParse(
   parser.done();
 
   auto numGeomsDropped = parser.getPrefilterCounter();
-  auto numGeomsParsed = idTable->size() - numGeomsDropped;
+  auto numGeomsParsed = idTable.size() - numGeomsDropped;
   return {parser.getBoundingBox(), numGeomsParsed, numGeomsDropped, numThreads};
 }
 
@@ -139,10 +139,10 @@ size_t SpatialJoinAlgorithms::getNumThreads() {
 }
 
 // ____________________________________________________________________________
-std::optional<GeoPoint> SpatialJoinAlgorithms::getPoint(const IdTable* restable,
+std::optional<GeoPoint> SpatialJoinAlgorithms::getPoint(IdTableView<0> restable,
                                                         size_t row,
                                                         ColumnIndex col) {
-  auto id = restable->at(row, col);
+  auto id = restable.at(row, col);
   return id.getDatatype() == Datatype::GeoPoint
              ? std::optional{id.getGeoPoint()}
              : std::nullopt;
@@ -150,7 +150,7 @@ std::optional<GeoPoint> SpatialJoinAlgorithms::getPoint(const IdTable* restable,
 
 // ____________________________________________________________________________
 std::optional<S2Polyline> SpatialJoinAlgorithms::getPolyline(
-    const IdTable& restable, size_t row, ColumnIndex col, const Index& index) {
+    IdTableView<0> restable, size_t row, ColumnIndex col, const Index& index) {
   using namespace util::geo;
   auto id = restable.at(row, col);
   auto str = ExportQueryExecutionTrees::idToStringAndType(index, id, {});
@@ -179,7 +179,7 @@ std::string_view SpatialJoinAlgorithms::betweenQuotes(
 }
 
 std::optional<size_t> SpatialJoinAlgorithms::getAnyGeometry(
-    const IdTable* idtable, size_t row, size_t col) {
+    IdTableView<0> idtable, size_t row, size_t col) {
   auto printWarning = [this, &spatialJoin = spatialJoin_]() {
     if (this->numFailedParsedGeometries_ == 0) {
       std::string warning =
@@ -203,7 +203,7 @@ std::optional<size_t> SpatialJoinAlgorithms::getAnyGeometry(
   // precision), and then the full geometry would only need to be read, when
   // the exact distance is wanted
   std::string str(betweenQuotes(ExportQueryExecutionTrees::idToStringAndType(
-                                    qec_->getIndex(), idtable->at(row, col), {})
+                                    qec_->getIndex(), idtable.at(row, col), {})
                                     .value()
                                     .first));
   AnyGeometry geometry;
@@ -265,8 +265,8 @@ Id SpatialJoinAlgorithms::computeDist(RtreeEntry& geo1, RtreeEntry& geo2) {
 
 // ____________________________________________________________________________
 void SpatialJoinAlgorithms::addResultTableEntry(IdTable* result,
-                                                const IdTable* idTableLeft,
-                                                const IdTable* idTableRight,
+                                                IdTableView<0> idTableLeft,
+                                                IdTableView<0> idTableRight,
                                                 size_t rowLeft, size_t rowRight,
                                                 Id distance) const {
   // this lambda function copies values from copyFrom into the table res only if
@@ -274,15 +274,15 @@ void SpatialJoinAlgorithms::addResultTableEntry(IdTable* result,
   // nullopt, all columns are added. It copies them into the row rowIndRes and
   // column column colIndRes. It returns the column number until which elements
   // were copied
-  auto addColumns = [](IdTable* res, const IdTable* copyFrom, size_t rowIndRes,
+  auto addColumns = [](IdTable* res, IdTableView<0> copyFrom, size_t rowIndRes,
                        size_t colIndRes, size_t rowIndCopy,
                        std::optional<std::vector<ColumnIndex>> sourceColumns =
                            std::nullopt) {
     size_t nCols = sourceColumns.has_value() ? sourceColumns.value().size()
-                                             : copyFrom->numColumns();
+                                             : copyFrom.numColumns();
     for (size_t i = 0; i < nCols; i++) {
       auto col = sourceColumns.has_value() ? sourceColumns.value()[i] : i;
-      res->at(rowIndRes, colIndRes + i) = (*copyFrom).at(rowIndCopy, col);
+      res->at(rowIndRes, colIndRes + i) = copyFrom.at(rowIndCopy, col);
     }
     return colIndRes + nCols;
   };
@@ -315,7 +315,7 @@ Result SpatialJoinAlgorithms::BaselineAlgorithm() {
 
   // cartesian product between the two tables, pairs are restricted according to
   // `maxDistance_` and `maxResults_`
-  for (size_t rowLeft = 0; rowLeft < idTableLeft->size(); rowLeft++) {
+  for (size_t rowLeft = 0; rowLeft < idTableLeft.size(); rowLeft++) {
     // This priority queue stores the intermediate best results if `maxResults_`
     // is used. Each intermediate result is stored as a pair of its `rowRight`
     // and distance. Since the queue will hold at most `maxResults_ + 1` items,
@@ -332,7 +332,7 @@ Result SpatialJoinAlgorithms::BaselineAlgorithm() {
     auto entryLeft = getRtreeEntry(idTableLeft, rowLeft, leftJoinCol);
 
     // Inner loop of cartesian product
-    for (size_t rowRight = 0; rowRight < idTableRight->size(); rowRight++) {
+    for (size_t rowRight = 0; rowRight < idTableRight.size(); rowRight++) {
       auto entryRight = getRtreeEntry(idTableRight, rowRight, rightJoinCol);
 
       if (!entryLeft || !entryRight) {
@@ -510,7 +510,7 @@ Result SpatialJoinAlgorithms::LibspatialjoinAlgorithm() {
   IdTableAndJoinColumn leftTableAndCol{idTableLeft, leftJoinCol};
   IdTableAndJoinColumn rightTableAndCol{idTableRight, rightJoinCol};
   bool nonEmptyChildren =
-      idTableLeft->size() < idTableRight->size()
+      idTableLeft.size() < idTableRight.size()
           ? runParser(leftTableAndCol, rightTableAndCol, false)
           : runParser(rightTableAndCol, leftTableAndCol, true);
 
@@ -572,12 +572,12 @@ Result SpatialJoinAlgorithms::S2geometryAlgorithm() {
   // Optimization: If we only search by maximum distance, the operation is
   // symmetric, so the larger table can be used for the index
   bool indexOfRight =
-      (maxResults.has_value() || (idTableLeft->size() > idTableRight->size()));
+      (maxResults.has_value() || (idTableLeft.size() > idTableRight.size()));
   auto indexTable = indexOfRight ? idTableRight : idTableLeft;
   auto indexJoinCol = indexOfRight ? rightJoinCol : leftJoinCol;
 
   // Populate the index
-  for (size_t row = 0; row < indexTable->size(); row++) {
+  for (size_t row = 0; row < indexTable.size(); row++) {
     auto p = getPoint(indexTable, row, indexJoinCol);
     if (p.has_value()) {
       s2index.Add(toS2Point(p.value()), row);
@@ -601,7 +601,7 @@ Result SpatialJoinAlgorithms::S2geometryAlgorithm() {
   auto searchTable = indexOfRight ? idTableLeft : idTableRight;
   auto searchJoinCol = indexOfRight ? leftJoinCol : rightJoinCol;
   // Use the index to lookup the points of the other table
-  for (size_t searchRow = 0; searchRow < searchTable->size(); searchRow++) {
+  for (size_t searchRow = 0; searchRow < searchTable.size(); searchRow++) {
     auto p = getPoint(searchTable, searchRow, searchJoinCol);
     if (!p.has_value()) {
       continue;
@@ -650,7 +650,7 @@ Result SpatialJoinAlgorithms::S2PointPolylineAlgorithm() {
   ad_utility::Timer timerWrite{ad_utility::Timer::Stopped};
 
   // Use the index to lookup the points of the other table
-  for (size_t rowLeft = 0; rowLeft < idTableLeft->size(); rowLeft++) {
+  for (size_t rowLeft = 0; rowLeft < idTableLeft.size(); rowLeft++) {
     auto p = getPoint(idTableLeft, rowLeft, leftJoinCol);
     if (!p.has_value()) {
       continue;
@@ -910,7 +910,7 @@ double SpatialJoinAlgorithms::getMaxDistFromMidpointToAnyPointInsideTheBox(
 
 // ____________________________________________________________________________
 std::optional<RtreeEntry> SpatialJoinAlgorithms::getRtreeEntry(
-    const IdTable* idTable, const size_t row, const ColumnIndex col) {
+    IdTableView<0> idTable, const size_t row, const ColumnIndex col) {
   RtreeEntry entry{row, std::nullopt, std::nullopt, std::nullopt};
   entry.geoPoint_ = getPoint(idTable, row, col);
 
@@ -972,7 +972,7 @@ Result SpatialJoinAlgorithms::BoundingBoxAlgorithm() {
   bool leftResSmaller = true;
   auto smallerResJoinCol = leftJoinCol;
   auto otherResJoinCol = rightJoinCol;
-  if (idTableLeft->numRows() > idTableRight->numRows()) {
+  if (idTableLeft.numRows() > idTableRight.numRows()) {
     std::swap(smallerResult, otherResult);
     leftResSmaller = false;
     std::swap(smallerResJoinCol, otherResJoinCol);
@@ -983,7 +983,7 @@ Result SpatialJoinAlgorithms::BoundingBoxAlgorithm() {
              bgi::equal_to<Value>, ad_utility::AllocatorWithLimit<Value>>
       rtree(bgi::quadratic<16>{}, bgi::indexable<Value>{},
             bgi::equal_to<Value>{}, qec_->getAllocator());
-  for (size_t i = 0; i < smallerResult->numRows(); i++) {
+  for (size_t i = 0; i < smallerResult.numRows(); i++) {
     throwIfCancelled();
 
     // add every box together with the additional information into the rtree
@@ -1002,7 +1002,7 @@ Result SpatialJoinAlgorithms::BoundingBoxAlgorithm() {
   // query rtree with the other child
   std::vector<Value, ad_utility::AllocatorWithLimit<Value>> results{
       qec_->getAllocator()};
-  for (size_t i = 0; i < otherResult->numRows(); i++) {
+  for (size_t i = 0; i < otherResult.numRows(); i++) {
     throwIfCancelled();
 
     std::optional<RtreeEntry> entry =

--- a/src/engine/SpatialJoinAlgorithms.h
+++ b/src/engine/SpatialJoinAlgorithms.h
@@ -149,11 +149,11 @@ class SpatialJoinAlgorithms {
       const Box& box, std::optional<Point> midpoint = std::nullopt) const;
 
   // this function gets the string which represents the area from the idtable.
-  std::optional<size_t> getAnyGeometry(const IdTable* idtable, size_t row,
+  std::optional<size_t> getAnyGeometry(IdTableView<0> idtable, size_t row,
                                        size_t col);
 
   // wrapper to access non const private function for testing
-  std::optional<RtreeEntry> onlyForTestingGetRtreeEntry(const IdTable* idTable,
+  std::optional<RtreeEntry> onlyForTestingGetRtreeEntry(IdTableView<0> idTable,
                                                         const size_t row,
                                                         const ColumnIndex col) {
     return getRtreeEntry(idTable, row, col);
@@ -176,7 +176,7 @@ class SpatialJoinAlgorithms {
   // added geometries, which may be used as a prefilter at next call and the
   // number of geometries added. This function is only `public` for testing
   // purposes and should otherwise not be used outside of this class.
-  using IdTableAndJoinColumn = std::pair<const IdTable*, const ColumnIndex>;
+  using IdTableAndJoinColumn = std::pair<IdTableView<0>, const ColumnIndex>;
   struct LibSpatialJoinParseMetadata {
     // Aggregated bounding box of all parsed geometries
     util::geo::I32Box aggBoundingBox_;
@@ -208,12 +208,12 @@ class SpatialJoinAlgorithms {
 
   // Helper function which returns a GeoPoint if the element of the given table
   // represents a GeoPoint
-  static std::optional<GeoPoint> getPoint(const IdTable* restable, size_t row,
+  static std::optional<GeoPoint> getPoint(IdTableView<0> restable, size_t row,
                                           ColumnIndex col);
 
   // Helper function to retrieve and parse a line string from the given cell of
   // an `IdTable` and convert it to an `S2Polyline`.
-  static std::optional<S2Polyline> getPolyline(const IdTable& restable,
+  static std::optional<S2Polyline> getPolyline(IdTableView<0> restable,
                                                size_t row, ColumnIndex col,
                                                const Index& index);
 
@@ -225,8 +225,8 @@ class SpatialJoinAlgorithms {
   // Helper function, which adds a row, which belongs to the result to the
   // result table. As inputs it uses a row of the left and a row of the right
   // child result table.
-  void addResultTableEntry(IdTable* result, const IdTable* resultLeft,
-                           const IdTable* resultRight, size_t rowLeft,
+  void addResultTableEntry(IdTable* result, IdTableView<0> resultLeft,
+                           IdTableView<0> resultRight, size_t rowLeft,
                            size_t rowRight, Id distance) const;
 
   // This helper function calculates the bounding boxes based on a box, where
@@ -254,7 +254,7 @@ class SpatialJoinAlgorithms {
   // this helper function takes an idtable, a row and a column. It then tries
   // to parse a geometry or a geoPoint of that cell in the idtable. If it
   // succeeds, it returns an rtree entry of that geometry/geopoint
-  std::optional<RtreeEntry> getRtreeEntry(const IdTable* idTable,
+  std::optional<RtreeEntry> getRtreeEntry(IdTableView<0> idTable,
                                           const size_t row,
                                           const ColumnIndex col);
 

--- a/src/engine/SpatialJoinCachedIndex.cpp
+++ b/src/engine/SpatialJoinCachedIndex.cpp
@@ -22,7 +22,7 @@ class SpatialJoinCachedIndexImpl {
   using ShapeIndexToRow = SpatialJoinCachedIndex::ShapeIndexToRow;
 
   // Construct the index, and return the mapping from shape indices to rows.
-  ShapeIndexToRow populate(ColumnIndex col, const IdTable& restable,
+  ShapeIndexToRow populate(ColumnIndex col, IdTableView<0> restable,
                            const Index& index) {
     ShapeIndexToRow shapeIndexToRow;
     AD_CORRECTNESS_CHECK(s2index_.num_shape_ids() == 0);
@@ -46,7 +46,7 @@ class SpatialJoinCachedIndexImpl {
 // ____________________________________________________________________________
 SpatialJoinCachedIndex::SpatialJoinCachedIndex(Variable geometryColumn,
                                                ColumnIndex col,
-                                               const IdTable& restable,
+                                               IdTableView<0> restable,
                                                const Index& index)
     : geometryColumn_{std::move(geometryColumn)},
       pimpl_{std::make_shared<SpatialJoinCachedIndexImpl>()} {

--- a/src/engine/SpatialJoinCachedIndex.h
+++ b/src/engine/SpatialJoinCachedIndex.h
@@ -43,7 +43,7 @@ class SpatialJoinCachedIndex {
   // the `IdTable`. Currently only line strings are supported for the
   // experimental S2 point polyline algorithm.
   SpatialJoinCachedIndex(Variable geometryColumn, ColumnIndex col,
-                         const IdTable& restable, const Index& index);
+                         IdTableView<0> restable, const Index& index);
 
   // Getters
   const Variable& getGeometryColumn() const;

--- a/src/engine/TransitivePathBinSearch.cpp
+++ b/src/engine/TransitivePathBinSearch.cpp
@@ -155,7 +155,7 @@ TransitivePathBinSearch::TransitivePathBinSearch(
 
 // _____________________________________________________________________________
 BinSearchMap TransitivePathBinSearch::setupEdgesMap(
-    const IdTable& dynSub, const TransitivePathSide& startSide,
+    const IdTableView<0>& dynSub, const TransitivePathSide& startSide,
     const TransitivePathSide& targetSide) const {
   return BinSearchMap{
       dynSub.getColumn(startSide.subCol_), dynSub.getColumn(targetSide.subCol_),

--- a/src/engine/TransitivePathBinSearch.h
+++ b/src/engine/TransitivePathBinSearch.h
@@ -88,7 +88,7 @@ class TransitivePathBinSearch : public TransitivePathImpl<BinSearchMap> {
   // with either two columns (without graph variable) or three columns (with
   // graph variable).
   BinSearchMap setupEdgesMap(
-      const IdTable& edges, const TransitivePathSide& startSide,
+      const IdTableView<0>& edges, const TransitivePathSide& startSide,
       const TransitivePathSide& targetSide) const override;
 
   // Alternative subtree sorted by (graph, target, source). This is used then

--- a/src/engine/TransitivePathHashMap.cpp
+++ b/src/engine/TransitivePathHashMap.cpp
@@ -68,7 +68,7 @@ void HashMapWrapper::setGraphId(Id graphId) {
 
 // _____________________________________________________________________________
 HashMapWrapper TransitivePathHashMap::setupEdgesMap(
-    const IdTable& sub, const TransitivePathSide& startSide,
+    const IdTableView<0>& sub, const TransitivePathSide& startSide,
     const TransitivePathSide& targetSide) const {
   decltype(auto) startCol = sub.getColumn(startSide.subCol_);
   decltype(auto) targetCol = sub.getColumn(targetSide.subCol_);

--- a/src/engine/TransitivePathHashMap.h
+++ b/src/engine/TransitivePathHashMap.h
@@ -76,7 +76,7 @@ class TransitivePathHashMap : public TransitivePathImpl<HashMapWrapper> {
 
   // Initialize the map from the subresult.
   HashMapWrapper setupEdgesMap(
-      const IdTable& sub, const TransitivePathSide& startSide,
+      const IdTableView<0>& sub, const TransitivePathSide& startSide,
       const TransitivePathSide& targetSide) const override;
 };
 

--- a/src/engine/TransitivePathImpl.h
+++ b/src/engine/TransitivePathImpl.h
@@ -328,7 +328,7 @@ class TransitivePathImpl : public TransitivePathBase {
    * @param edges Templated datastructure representing the edges of the graph
    * @return Set A set of starting nodes for the transitive hull computation
    */
-  SetWithGraph setupNodes(const IdTable& sub,
+  SetWithGraph setupNodes(const IdTableView<0>& sub,
                           const TransitivePathSide& startSide,
                           const T& edges) const {
     AD_CORRECTNESS_CHECK(minDist_ != 0,
@@ -392,7 +392,7 @@ class TransitivePathImpl : public TransitivePathBase {
     };
 
     auto toView = [columnsWithoutJoinColumns = std::move(
-                       columnsWithoutJoinColumns)](const IdTable& idTable) {
+                       columnsWithoutJoinColumns)](const auto& idTable) {
       return idTable.asColumnSubsetView(columnsWithoutJoinColumns);
     };
 
@@ -401,7 +401,7 @@ class TransitivePathImpl : public TransitivePathBase {
           [toView = std::move(toView),
            columnsToRange = std::move(columnsToRange),
            startSideResult = std::move(startSideResult)]() {
-            const IdTable& idTable = startSideResult->idTable();
+            const auto& idTable = startSideResult->idTable();
             return TableColumnWithVocab{toView(idTable),
                                         columnsToRange(idTable),
                                         startSideResult->getCopyOfLocalVocab()};
@@ -422,7 +422,7 @@ class TransitivePathImpl : public TransitivePathBase {
         }));
   }
 
-  virtual T setupEdgesMap(const IdTable& dynSub,
+  virtual T setupEdgesMap(const IdTableView<0>& dynSub,
                           const TransitivePathSide& startSide,
                           const TransitivePathSide& targetSide) const = 0;
 

--- a/src/engine/Union.cpp
+++ b/src/engine/Union.cpp
@@ -263,7 +263,7 @@ Result Union::computeResult(bool requestLaziness) {
 
 // _____________________________________________________________________________
 IdTable Union::computeUnion(
-    const IdTable& left, const IdTable& right,
+    IdTableView<0> left, IdTableView<0> right,
     const std::vector<std::array<size_t, 2>>& columnOrigins) const {
   IdTable res{getResultWidth(), getExecutionContext()->getAllocator()};
   res.resize(left.size() + right.size());

--- a/src/engine/Union.h
+++ b/src/engine/Union.h
@@ -61,7 +61,7 @@ class Union : public Operation {
 
   // The method is declared here to make it unit testable
   IdTable computeUnion(
-      const IdTable& left, const IdTable& right,
+      IdTableView<0> left, IdTableView<0> right,
       const std::vector<std::array<size_t, 2>>& columnOrigins) const;
 
   std::vector<QueryExecutionTree*> getChildren() override {

--- a/src/engine/idTable/CompressedExternalIdTable.h
+++ b/src/engine/idTable/CompressedExternalIdTable.h
@@ -521,6 +521,7 @@ class CompressedExternalIdTableSorterTypeErased {
  public:
   // Push a complete block at once.
   virtual void pushBlock(const IdTableStatic<0>& block) = 0;
+  virtual void pushBlock(const IdTableView<0>& block) = 0;
   // Get the sorted output after all blocks have been pushed. If `blocksize ==
   // nullopt`, the size of the returned blocks will be chosen automatically.
   virtual ad_utility::InputRangeTypeErased<IdTableStatic<0>> getSortedOutput(
@@ -666,6 +667,11 @@ class CompressedExternalIdTableSorter
   // The implementation of the type-erased interface. Push a complete block at
   // once.
   void pushBlock(const IdTableStatic<0>& block) override {
+    AD_CONTRACT_CHECK(block.numColumns() == this->numColumns_);
+    ql::ranges::for_each(block,
+                         [ptr = this](const auto& row) { ptr->push(row); });
+  }
+  void pushBlock(const IdTableView<0>& block) override {
     AD_CONTRACT_CHECK(block.numColumns() == this->numColumns_);
     ql::ranges::for_each(block,
                          [ptr = this](const auto& row) { ptr->push(row); });

--- a/src/engine/idTable/IdTable.h
+++ b/src/engine/idTable/IdTable.h
@@ -923,4 +923,16 @@ using IdTableView =
     columnBasedIdTable::IdTable<Id, COLS, detail::IdVector,
                                 columnBasedIdTable::IsView::True>;
 
+// Free-function `operator==` to allow comparing `IdTableView` with `IdTable`
+// and vice versa. The member `operator==` is only defined for non-view types.
+template <int COLS>
+inline bool operator==(const IdTableView<COLS>& view, const IdTable& table) {
+  return table == view.clone();
+}
+
+template <int COLS>
+inline bool operator==(const IdTable& table, const IdTableView<COLS>& view) {
+  return table == view.clone();
+}
+
 #endif  // QLEVER_SRC_ENGINE_IDTABLE_IDTABLE_H

--- a/src/engine/sparqlExpressions/SparqlExpressionTypes.cpp
+++ b/src/engine/sparqlExpressions/SparqlExpressionTypes.cpp
@@ -26,7 +26,7 @@ void PrintTo(const IdOrLiteralOrIri& var, std::ostream* os) {
 // _____________________________________________________________________________
 EvaluationContext::EvaluationContext(
     const QueryExecutionContext& qec,
-    const VariableToColumnMap& variableToColumnMap, const IdTable& inputTable,
+    const VariableToColumnMap& variableToColumnMap, IdTableView<0> inputTable,
     const ad_utility::AllocatorWithLimit<Id>& allocator, LocalVocab& localVocab,
     ad_utility::SharedCancellationHandle cancellationHandle, TimePoint deadline)
     : _qec{qec},

--- a/src/engine/sparqlExpressions/SparqlExpressionTypes.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionTypes.h
@@ -166,7 +166,7 @@ struct EvaluationContext {
   const VariableToColumnMap& _variableToColumnMap;
 
   /// The input of the expression.
-  const IdTable& _inputTable;
+  IdTableView<0> _inputTable;
 
   /// The indices of the actual range of rows in the _inputTable on which the
   /// expression is evaluated. For BIND expressions this is always [0,
@@ -217,7 +217,7 @@ struct EvaluationContext {
   /// Constructor for evaluating an expression on the complete input.
   EvaluationContext(const QueryExecutionContext& qec,
                     const VariableToColumnMap& variableToColumnMap,
-                    const IdTable& inputTable,
+                    IdTableView<0> inputTable,
                     const ad_utility::AllocatorWithLimit<Id>& allocator,
                     LocalVocab& localVocab,
                     ad_utility::SharedCancellationHandle cancellationHandle,

--- a/src/parser/data/ConstructQueryExportContext.h
+++ b/src/parser/data/ConstructQueryExportContext.h
@@ -17,7 +17,7 @@ enum struct PositionInTriple : int { SUBJECT, PREDICATE, OBJECT };
 struct ConstructQueryExportContext {
   // idx of row of result table for WHERE-clause
   const size_t resultTableRowIndex_;
-  const IdTable& idTable_;
+  IdTableView<0> idTable_;
   const LocalVocab& localVocab_;
   const VariableToColumnMap& _variableColumns;
   const Index& _qecIndex;

--- a/src/util/JoinAlgorithms/IndexNestedLoopJoin.h
+++ b/src/util/JoinAlgorithms/IndexNestedLoopJoin.h
@@ -146,7 +146,7 @@ class OptionalJoinRange
   std::shared_ptr<const Result> leftResult_;
   std::shared_ptr<const Result> rightResult_;
   const LocalVocab& leftVocab_;
-  const IdTable& leftTable_;
+  IdTableView<0> leftTable_;
   Result::LazyResult rightTables_;
   Adder matchTracker_;
   size_t resultWidth_;
@@ -157,7 +157,7 @@ class OptionalJoinRange
  public:
   OptionalJoinRange(std::shared_ptr<const Result> leftResult,
                     std::shared_ptr<const Result> rightResult,
-                    const LocalVocab& leftVocab, const IdTable& leftTable,
+                    const LocalVocab& leftVocab, IdTableView<0> leftTable,
                     Result::LazyResult rightTables, Adder matchTracker,
                     size_t resultWidth,
                     ad_utility::JoinColumnMapping joinColumnData,
@@ -280,7 +280,7 @@ class IndexNestedLoopJoin {
                   .asColumnSubsetView(leftColumns)
                   .template asStaticView<JOIN_COLUMNS>();
           auto matchHelper = [&matchTracker, &leftTable,
-                              &rightColumns](const IdTable& idTable) {
+                              &rightColumns](const auto& idTable) {
             matchLeft(matchTracker, leftTable,
                       idTable.asColumnSubsetView(rightColumns)
                           .template asStaticView<JOIN_COLUMNS>());
@@ -312,7 +312,7 @@ class IndexNestedLoopJoin {
          keepJoinColumns](auto JOIN_COLUMNS_PAR) -> Result::LazyResult {
           static constexpr auto JOIN_COLUMNS =
               static_cast<size_t>(JOIN_COLUMNS_PAR);
-          const IdTable& leftTable = leftResult_->idTable();
+          const auto& leftTable = leftResult_->idTable();
           size_t numColsLeft = leftTable.numColumns();
           ad_utility::JoinColumnMapping joinColumnData{
               joinColumns_, numColsLeft, numColsRight, keepJoinColumns};
@@ -321,7 +321,7 @@ class IndexNestedLoopJoin {
                   .template asStaticView<JOIN_COLUMNS>();
           auto matchHelper = [&matchTracker, &leftTableView,
                               rightColumns = joinColumnData.jcsRight()](
-                                 const IdTable& idTable) {
+                                 const auto& idTable) {
             matchLeft(matchTracker, leftTableView,
                       idTable.asColumnSubsetView(rightColumns)
                           .template asStaticView<JOIN_COLUMNS>());

--- a/test/LoadTest.cpp
+++ b/test/LoadTest.cpp
@@ -146,7 +146,7 @@ TEST_F(LoadTest, computeResult) {
                 responseBody, boost::beast::http::status::ok, contentType)};
         auto res = load.computeResultOnlyForTesting();
 
-        auto& idTable = res.idTable();
+        auto idTable = res.idTable();
         auto& lv = res.localVocab();
 
         std::vector<std::vector<IntOrId>> idVector;

--- a/test/MinusTest.cpp
+++ b/test/MinusTest.cpp
@@ -106,14 +106,14 @@ TEST(Minus, computeMinus) {
               qec, b.clone(),
               std::vector<std::optional<Variable>>{
                   Variable{"?b"}, Variable{"?a"}, std::nullopt, std::nullopt})};
-  IdTable res = m.computeMinus(a, b, jcls);
+  IdTable res = m.computeMinus(a.asStaticView<0>(), b.asStaticView<0>(), jcls);
 
   EXPECT_EQ(res, makeIdTableFromVector({{1, 2, 1}, {5, 4, 1}, {8, 2, 3}}));
 
   // Test subtracting without matching columns
   res.clear();
   jcls.clear();
-  res = m.computeMinus(a, b, jcls);
+  res = m.computeMinus(a.asStaticView<0>(), b.asStaticView<0>(), jcls);
   EXPECT_EQ(res, a);
 
   // Test minus with variable sized data.
@@ -137,7 +137,7 @@ TEST(Minus, computeMinus) {
                std::vector<std::optional<Variable>>{
                    Variable{"?a"}, Variable{"?b"}, std::nullopt})};
 
-  IdTable vres = vm.computeMinus(va, vb, jcls);
+  IdTable vres = vm.computeMinus(va.asStaticView<0>(), vb.asStaticView<0>(), jcls);
 
   EXPECT_EQ(vres, makeIdTableFromVector({{7, 6, 5, 4, 3, 2}}));
 }
@@ -239,12 +239,12 @@ TEST(Minus, computeMinusWithEmptyTables) {
           std::vector<std::optional<Variable>>{Variable{"?a"}, std::nullopt})};
 
   {
-    IdTable res = m.computeMinus(empty, nonEmpty, jcls);
+    IdTable res = m.computeMinus(empty.asStaticView<0>(), nonEmpty.asStaticView<0>(), jcls);
 
     EXPECT_EQ(res, empty);
   }
   {
-    IdTable res = m.computeMinus(nonEmpty, empty, jcls);
+    IdTable res = m.computeMinus(nonEmpty.asStaticView<0>(), empty.asStaticView<0>(), jcls);
 
     EXPECT_EQ(res, nonEmpty);
   }
@@ -272,7 +272,7 @@ TEST(Minus, computeMinusWithUndefined) {
               std::vector<std::optional<Variable>>{
                   Variable{"?b"}, Variable{"?a"}, std::nullopt})};
 
-  IdTable res = m.computeMinus(a, b, jcls);
+  IdTable res = m.computeMinus(a.asStaticView<0>(), b.asStaticView<0>(), jcls);
   EXPECT_EQ(res, makeIdTableFromVector({{U, U, 10}, {1, U, 12}, {5, 4, 13}}));
 }
 

--- a/test/MultiColumnJoinTest.cpp
+++ b/test/MultiColumnJoinTest.cpp
@@ -41,7 +41,7 @@ TEST(EngineTest, multiColumnJoinTest) {
   // a have to equal those of column 2 of b and vice versa).
   MultiColumnJoin{qec, idTableToExecutionTree(qec, a),
                   idTableToExecutionTree(qec, b)}
-      .computeMultiColumnJoin(a, b, jcls, &res);
+      .computeMultiColumnJoin(a.asStaticView<0>(), b.asStaticView<0>(), jcls, &res);
 
   auto expected = makeIdTableFromVector({{2, 1, 3, 3}, {1, 3, 1, 1}});
   ASSERT_EQ(expected, res);
@@ -64,7 +64,7 @@ TEST(EngineTest, multiColumnJoinTest) {
 
   MultiColumnJoin{qec, idTableToExecutionTree(qec, a),
                   idTableToExecutionTree(qec, b)}
-      .computeMultiColumnJoin(va, vb, jcls, &vres);
+      .computeMultiColumnJoin(va.asStaticView<0>(), vb.asStaticView<0>(), jcls, &vres);
 
   ASSERT_EQ(4u, vres.size());
   ASSERT_EQ(7u, vres.numColumns());

--- a/test/RelationalExpressionTest.cpp
+++ b/test/RelationalExpressionTest.cpp
@@ -493,7 +493,7 @@ auto testNotComparableHelper(T leftValue, U rightValue,
   sparqlExpression::EvaluationContext context{
       *TestContext{}.qec,
       map,
-      table,
+      table.asStaticView<0>(),
       alloc,
       localVocab,
       std::make_shared<ad_utility::CancellationHandle<>>(),

--- a/test/SparqlExpressionTestHelpers.h
+++ b/test/SparqlExpressionTestHelpers.h
@@ -45,7 +45,7 @@ struct TestContext {
   sparqlExpression::EvaluationContext context{
       *qec,
       varToColMap,
-      table,
+      table.asStaticView<0>(),
       qec->getAllocator(),
       localVocab,
       std::make_shared<ad_utility::CancellationHandle<>>(),

--- a/test/util/JoinHelpers.h
+++ b/test/util/JoinHelpers.h
@@ -84,7 +84,7 @@ inline auto makeJoinLambda() {
         auto rightTree = ad_utility::makeExecutionTree<ValuesForTesting>(
             qec, b.clone(), std::move(rightVariables), false, std::vector{jc2});
         Join join{qec, leftTree, rightTree, jc1, jc2, true, false};
-        return join.join(a, b, result);
+        return join.join(a.asStaticView<0>(), b.asStaticView<0>(), result);
       }};
 }
 


### PR DESCRIPTION
This allows the `Result` class to refer to an `IdTableView` which it doesn't own, and in particular which might not be even backed by an `IdTable`, but manually stitched together by columns that are directly zero-copy initialized from a buffer.