### PR TITLE
Drop redundant member from `TaskQueue`

### DIFF
--- a/src/util/TaskQueue.h
+++ b/src/util/TaskQueue.h
@@ -37,8 +37,7 @@ class TaskQueue {
 
   ql::atomic_flag startedFinishing_{false};
   ql::atomic_flag finishedFinishing_{false};
-  size_t queueMaxSize_ = 1;
-  Queue queuedTasks_{queueMaxSize_};
+  Queue queuedTasks_;
   std::vector<ad_utility::JThread> threads_;
   std::string name_;
   // Keep track of the time spent waiting in the push/pop operation
@@ -61,8 +60,8 @@ class TaskQueue {
   /// workers are at least as fast as the "pusher", but the pusher is faster
   /// sometimes (which the queue can then accommodate).
   TaskQueue(size_t maxQueueSize, size_t numThreads, std::string name = "")
-      : queueMaxSize_{maxQueueSize}, name_{std::move(name)} {
-    AD_CONTRACT_CHECK(queueMaxSize_ > 0);
+      : queuedTasks_{maxQueueSize}, name_{std::move(name)} {
+    AD_CONTRACT_CHECK(maxQueueSize > 0);
     threads_.reserve(numThreads);
     for (size_t i = 0; i < numThreads; ++i) {
       threads_.emplace_back(&TaskQueue::function_for_thread, this);

--- a/src/util/ThreadSafeQueue.h
+++ b/src/util/ThreadSafeQueue.h
@@ -40,6 +40,9 @@ class ThreadSafeQueue {
   using value_type = T;
   explicit ThreadSafeQueue(size_t maxSize) : maxSize_{maxSize} {}
 
+  // Return the maximal size of the queue.
+  size_t maxSize() const { return maxSize_; }
+
   // We can neither copy nor move this class
   ThreadSafeQueue(const ThreadSafeQueue&) = delete;
   const ThreadSafeQueue& operator=(const ThreadSafeQueue&) = delete;

--- a/test/CompressedRelationsTest.cpp
+++ b/test/CompressedRelationsTest.cpp
@@ -1327,7 +1327,7 @@ TEST(CompressedRelationWriter, scanWithGraphs) {
 namespace ad_utility {
 std::pair<size_t, size_t> getThreadCountAndTaskSize(
     const TaskQueue<false>& taskQueue) {
-  return {taskQueue.threads_.size(), taskQueue.queueMaxSize_};
+  return {taskQueue.threads_.size(), taskQueue.queuedTasks_.maxSize()};
 }
 }  // namespace ad_utility
 


### PR DESCRIPTION
So far, `TaskQueue` kept a separate `queueMaxSize_` member solely to seed its internal `ThreadSafeQueue` at construction. Now `ThreadSafeQueue` exposes a `maxSize()` accessor and the redundant member is gone.