### PR TITLE
Introduce `BufferedWriteSerializer`

### DIFF
--- a/src/index/VocabularyMergerImpl.h
+++ b/src/index/VocabularyMergerImpl.h
@@ -19,7 +19,7 @@
 #include "util/Log.h"
 #include "util/ParallelMultiwayMerge.h"
 #include "util/ProgressBar.h"
-#include "util/Serializer/ByteBufferSerializer.h"
+#include "util/Serializer/BufferedSerializer.h"
 #include "util/Serializer/FileSerializer.h"
 #include "util/Serializer/SerializeString.h"
 #include "util/Timer.h"
@@ -213,27 +213,16 @@ inline void writePartialVocabularyToFile(const ItemVec& els,
                                          const std::string& fileName) {
   AD_LOG_DEBUG << "Writing partial vocabulary to: " << fileName << "\n";
 
-  static constexpr size_t flushThreshold = 16ULL * 1024 * 1024;  // 16 MB
-
-  ad_utility::serialization::FileWriteSerializer serializer{fileName};
-  // TODO<RobinTF> Ideally the `FileWriteSerializer` should come with its own
-  // buffer to avoid having to implement this logic here. Despite `fwrite`
-  // (which is called by `FileWriteSerializer::serializeBytes`) buffering data
-  // on its own it is faster to buffer with our own buffer, presumably because
-  // `fwrite` is thread-safe and therefore has to acquire a mutex for every
-  // call.
-  ad_utility::serialization::ByteBufferWriteSerializer byteBuffer;
-  byteBuffer.reserve(flushThreshold + 1024);  // + slack for the last item
+  // We buffer the data with our own buffer before passing it to the file in
+  // large chunks. Despite `fwrite` (which is ultimately called by
+  // `FileWriteSerializer::serializeBytes`) buffering data on its own, it is
+  // faster to buffer with our own buffer, presumably because `fwrite` is
+  // thread-safe and therefore has to acquire a mutex for every call.
+  serialization::BufferedWriteSerializer serializer{
+      serialization::FileWriteSerializer{fileName}, 16_MB};
 
   uint64_t size = els.size();
-  byteBuffer << size;
-
-  auto flush = [&]() {
-    ad_utility::TimeBlockAndLog t{"performing the actual write"};
-    serializer.serializeBytes(byteBuffer.data().data(),
-                              byteBuffer.data().size());
-    byteBuffer.clear();
-  };
+  serializer << size;
 
   // This is essentially a `VectorIncrementalSerializer` with a custom
   // serialization function, which the infrastructure currently does not
@@ -242,17 +231,11 @@ inline void writePartialVocabularyToFile(const ItemVec& els,
     // When merging the vocabulary, we need the actual word, the (internal) id
     // we have assigned to this word, and the information, whether this word
     // belongs to the internal or external vocabulary.
-    byteBuffer << word;
-    byteBuffer << idAndExternal.isExternal();
-    byteBuffer << idAndExternal.id();
-
-    if (byteBuffer.data().size() >= flushThreshold) {
-      flush();
-    }
+    serializer << word;
+    serializer << idAndExternal.isExternal();
+    serializer << idAndExternal.id();
   }
 
-  // Flush remaining data.
-  flush();
   serializer.close();
 
   AD_LOG_DEBUG << "Done writing partial vocabulary\n";

--- a/src/util/Serializer/BufferedSerializer.h
+++ b/src/util/Serializer/BufferedSerializer.h
@@ -1,0 +1,142 @@
+//  Copyright 2026 The QLever Authors, in particular:
+//
+//  2025 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+//  2026 Robin Textor-Falconi <textorr@informatik.uni-freiburg.de>, UFR
+//
+//  UFR = University of Freiburg, Chair of Algorithms and Data Structures
+
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#ifndef QLEVER_SRC_UTIL_SERIALIZER_BUFFEREDSERIALIZER_H
+#define QLEVER_SRC_UTIL_SERIALIZER_BUFFEREDSERIALIZER_H
+
+#include <optional>
+#include <vector>
+
+#include "backports/span.h"
+#include "util/Exception.h"
+#include "util/ExceptionHandling.h"
+#include "util/MemorySize/MemorySize.h"
+#include "util/Serializer/Serializer.h"
+#include "util/UninitializedAllocator.h"
+
+namespace ad_utility::serialization {
+
+// A `vector<char>` where a `resize`/`insert` doesn't zero-initialize the new
+// bytes (for efficiency reasons).
+using UninitializedBuffer = std::vector<char, default_init_allocator<char>>;
+
+// The default `BlockProcessor` for the `BufferedWriteSerializer` below. It
+// writes each buffered block verbatim to the underlying serializer, making the
+// `BufferedWriteSerializer` completely transparent: the bytes arrive at the
+// underlying serializer in exactly the same order, just batched into larger
+// chunks.
+struct PassthroughBlockProcessor {
+  CPP_template(typename UnderlyingSerializer)(
+      requires WriteSerializer<UnderlyingSerializer>) void
+  operator()(ql::span<const char> block,
+             UnderlyingSerializer& underlyingSerializer) const {
+    underlyingSerializer.serializeBytes(block.data(), block.size());
+  }
+};
+
+// A `WriteSerializer` that buffers the incoming bytes and only forwards them to
+// the `UnderlyingSerializer` (which must be a `WriteSerializer`) once a full
+// block (of the size passed to the constructor) has accumulated. This reduces
+// the number of (potentially expensive) calls to the underlying serializer.
+//
+// The optional `BlockProcessor` can be used to transform each full block before
+// it is written to the underlying serializer (see e.g. the
+// `CompressedWriteSerializer`, which uses this to compress each block). By
+// default, the block is written as-is (see `PassthroughBlockProcessor`).
+CPP_template(typename UnderlyingSerializer,
+             typename BlockProcessor = PassthroughBlockProcessor)(
+    requires WriteSerializer<
+        UnderlyingSerializer>) class BufferedWriteSerializer {
+ public:
+  using SerializerType = WriteSerializerTag;
+
+ private:
+  std::optional<UnderlyingSerializer> underlyingSerializer_;
+  BlockProcessor blockProcessor_;
+  size_t blocksize_;
+  // The buffer for the not-yet-forwarded data. Its capacity is never exceeded,
+  // so it is never reallocated after the initial `reserve`.
+  UninitializedBuffer buffer_;
+
+ public:
+  // Create from the underlying serializer and the `blocksize` (the amount of
+  // data that is buffered before a block is forwarded). The optional
+  // `blockProcessor` transforms each block before forwarding it (see above).
+  //
+  // NOTE: We deliberately have no default value for the `blocksize`, as good
+  // values depend on the use case.
+  BufferedWriteSerializer(UnderlyingSerializer underlyingSerializer,
+                          MemorySize blocksize,
+                          BlockProcessor blockProcessor = {})
+      : underlyingSerializer_{std::in_place, std::move(underlyingSerializer)},
+        blockProcessor_{std::move(blockProcessor)},
+        blocksize_{blocksize.getBytes()} {
+    buffer_.reserve(blocksize_);
+  }
+
+  // This is a move-only class.
+  BufferedWriteSerializer(const BufferedWriteSerializer&) = delete;
+  BufferedWriteSerializer& operator=(const BufferedWriteSerializer&) = delete;
+  BufferedWriteSerializer(BufferedWriteSerializer&&) = default;
+  BufferedWriteSerializer& operator=(BufferedWriteSerializer&&) = default;
+
+  ~BufferedWriteSerializer() {
+    ad_utility::terminateIfThrows(
+        [this]() { close(); },
+        "The closing of a `BufferedWriteSerializer` failed");
+  }
+
+  // Main serialization function.
+  void serializeBytes(const char* bytePointer, size_t numBytes) {
+    while (numBytes > 0) {
+      size_t capacity = buffer_.capacity() - buffer_.size();
+      size_t bytesToCopy = std::min(capacity, numBytes);
+      buffer_.insert(buffer_.end(), bytePointer, bytePointer + bytesToCopy);
+      if (bytesToCopy < capacity) {
+        return;
+      }
+      flushBlock();
+      numBytes -= bytesToCopy;
+      bytePointer += bytesToCopy;
+    }
+  }
+
+  // After a call to `close` no more calls to `serializeBytes` are allowed.
+  void close() {
+    if (underlyingSerializer_.has_value()) {
+      flushBlock();
+      underlyingSerializer_.reset();
+    }
+  }
+
+  // Flush the remaining buffered data, and then move out the underlying
+  // serializer.
+  UnderlyingSerializer underlyingSerializer() && {
+    AD_CORRECTNESS_CHECK(underlyingSerializer_.has_value());
+    flushBlock();
+    return std::move(*underlyingSerializer_);
+  }
+
+ private:
+  // Forward the contents of the `buffer_` to the `blockProcessor_` (which
+  // writes them to the underlying serializer) and clear it.
+  void flushBlock() {
+    if (buffer_.empty()) {
+      return;
+    }
+    std::invoke(blockProcessor_, ql::span<const char>{buffer_},
+                *underlyingSerializer_);
+    buffer_.clear();
+  }
+};
+
+}  // namespace ad_utility::serialization
+
+#endif  // QLEVER_SRC_UTIL_SERIALIZER_BUFFEREDSERIALIZER_H

--- a/src/util/Serializer/BufferedSerializer.h
+++ b/src/util/Serializer/BufferedSerializer.h
@@ -75,7 +75,7 @@ CPP_template(typename UnderlyingSerializer,
   BufferedWriteSerializer(UnderlyingSerializer underlyingSerializer,
                           MemorySize blocksize,
                           BlockProcessor blockProcessor = {})
-      : underlyingSerializer_{std::in_place, std::move(underlyingSerializer)},
+      : underlyingSerializer_{std::move(underlyingSerializer)},
         blockProcessor_{std::move(blockProcessor)},
         blocksize_{blocksize.getBytes()} {
     buffer_.reserve(blocksize_);
@@ -121,7 +121,9 @@ CPP_template(typename UnderlyingSerializer,
   UnderlyingSerializer underlyingSerializer() && {
     AD_CORRECTNESS_CHECK(underlyingSerializer_.has_value());
     flushBlock();
-    return std::move(*underlyingSerializer_);
+    UnderlyingSerializer serializer = std::move(underlyingSerializer_.value());
+    underlyingSerializer_.reset();
+    return serializer;
   }
 
  private:
@@ -132,7 +134,7 @@ CPP_template(typename UnderlyingSerializer,
       return;
     }
     std::invoke(blockProcessor_, ql::span<const char>{buffer_},
-                *underlyingSerializer_);
+                underlyingSerializer_.value());
     buffer_.clear();
   }
 };

--- a/src/util/Serializer/CompressedSerializer.h
+++ b/src/util/Serializer/CompressedSerializer.h
@@ -45,7 +45,7 @@ CPP_template(typename CompressionFunction)(
   explicit CompressingBlockProcessor(CompressionFunction compressionFunction)
       : compressionFunction_{std::move(compressionFunction)} {}
 
-  CPP_template(typename UnderlyingSerializer)(
+  CPP_template_2(typename UnderlyingSerializer)(
       requires WriteSerializer<UnderlyingSerializer>) void
   operator()(ql::span<const char> block,
              UnderlyingSerializer& underlyingSerializer) {

--- a/src/util/Serializer/CompressedSerializer.h
+++ b/src/util/Serializer/CompressedSerializer.h
@@ -19,6 +19,7 @@
 #include "util/CompressionUsingZstd/ZstdWrapper.h"
 #include "util/ExceptionHandling.h"
 #include "util/MemorySize/MemorySize.h"
+#include "util/Serializer/BufferedSerializer.h"
 #include "util/Serializer/SerializeVector.h"
 #include "util/Serializer/Serializer.h"
 #include "util/TypeTraits.h"
@@ -26,13 +27,37 @@
 
 namespace ad_utility::serialization {
 
-// A `vector<char>` where a `resize` doesn't zero-initialize the new bytes
-// (for efficiency reasons).
-using UninitializedBuffer =
-    std::vector<char, ad_utility::default_init_allocator<char>>;
+// A `BlockProcessor` (see `BufferedWriteSerializer`) that compresses each block
+// using the provided `CompressionFunction` (which must be a callable that takes
+// a span of chars and a target buffer to store the compressed result in) and
+// writes it (prefixed with the uncompressed size) to the underlying serializer.
+CPP_template(typename CompressionFunction)(
+    requires ql::concepts::invocable<
+        CompressionFunction, ql::span<const char>,
+        UninitializedBuffer&>) class CompressingBlockProcessor {
+ private:
+  CompressionFunction compressionFunction_;
+  // We need to temporarily store a single compressed block before flushing it.
+  // Using a member variable for this purpose avoids reallocations.
+  UninitializedBuffer compressedBuffer_;
 
-// A write serializer that writes the data in compressed blocks to the
-// `UnderlyingSerializer` (which must be a `WriteSerializer') using the
+ public:
+  explicit CompressingBlockProcessor(CompressionFunction compressionFunction)
+      : compressionFunction_{std::move(compressionFunction)} {}
+
+  CPP_template(typename UnderlyingSerializer)(
+      requires WriteSerializer<UnderlyingSerializer>) void
+  operator()(ql::span<const char> block,
+             UnderlyingSerializer& underlyingSerializer) {
+    size_t uncompressedSize = block.size();
+    underlyingSerializer << uncompressedSize;
+    std::invoke(compressionFunction_, block, compressedBuffer_);
+    underlyingSerializer << compressedBuffer_;
+  }
+};
+
+// A `WriteSerializer` that writes the data in compressed blocks to the
+// `UnderlyingSerializer` (which must be a `WriteSerializer`) using the
 // provided `CompressionFunction` (which must be callable that takes a
 // span of chars and returns a vector of chars).
 //
@@ -40,22 +65,21 @@ using UninitializedBuffer =
 // exceeds the block size. Then the full block is compressed and serialized as a
 // vector to the underlying serializer. The last, possibly incomplete block is
 // written on destruction or when `close()` is called.
+//
+// The buffering itself is performed by the `BufferedWriteSerializer`; the
+// `CompressedWriteSerializer` merely plugs in a `CompressingBlockProcessor`
+// that transforms (compresses) each block before it is passed to the next
+// layer.
 CPP_template(typename UnderlyingSerializer, typename CompressionFunction)(
     requires WriteSerializer<UnderlyingSerializer> CPP_and ql::concepts::
         invocable<CompressionFunction, ql::span<const char>,
-                  UninitializedBuffer&>) class CompressedWriteSerializer {
- public:
-  using SerializerType = WriteSerializerTag;
-
- private:
-  std::optional<UnderlyingSerializer> underlyingSerializer_;
-  CompressionFunction compressionFunction_;
-  size_t blocksize_;
-  // A buffer for the uncompressed data.
-  UninitializedBuffer buffer_;
-  // We need to temporarily store a single compressed block before flushing it.
-  // Using a member variable for this purpose avoids reallocations.
-  UninitializedBuffer compressedBuffer_;
+                  UninitializedBuffer&>) class CompressedWriteSerializer
+    : public BufferedWriteSerializer<
+          UnderlyingSerializer,
+          CompressingBlockProcessor<CompressionFunction>> {
+  using Base =
+      BufferedWriteSerializer<UnderlyingSerializer,
+                              CompressingBlockProcessor<CompressionFunction>>;
 
  public:
   // Create from the underlying serializer, the function used for compression,
@@ -66,73 +90,9 @@ CPP_template(typename UnderlyingSerializer, typename CompressionFunction)(
   CompressedWriteSerializer(UnderlyingSerializer underlyingSerializer,
                             CompressionFunction compressionFunction,
                             ad_utility::MemorySize blocksize)
-      : underlyingSerializer_{std::in_place, std::move(underlyingSerializer)},
-        compressionFunction_{std::move(compressionFunction)},
-        blocksize_{blocksize.getBytes()} {
-    buffer_.reserve(blocksize_);
-  }
-
-  // This is a move-only class.
-  CompressedWriteSerializer(const CompressedWriteSerializer&) = delete;
-  CompressedWriteSerializer& operator=(const CompressedWriteSerializer&) =
-      delete;
-  CompressedWriteSerializer(CompressedWriteSerializer&&) = default;
-  CompressedWriteSerializer& operator=(CompressedWriteSerializer&&) = default;
-
-  ~CompressedWriteSerializer() {
-    ad_utility::terminateIfThrows(
-        [this]() { close(); },
-        "The closing of a `CompressedWriteSerializer` failed");
-  }
-
-  // Main serialization function.
-  void serializeBytes(const char* bytePointer, size_t numBytes) {
-    while (numBytes > 0) {
-      size_t capacity = buffer_.capacity() - buffer_.size();
-      size_t bytesToCopy = std::min(capacity, numBytes);
-      buffer_.insert(buffer_.end(), bytePointer, bytePointer + bytesToCopy);
-      if (bytesToCopy < capacity) {
-        return;
-      }
-      flushBlock();
-      numBytes -= bytesToCopy;
-      bytePointer += bytesToCopy;
-    }
-  }
-
-  // After a call to `close` no more calls to `serializeBytes` are allowed.
-  void close() {
-    if (underlyingSerializer_.has_value()) {
-      flushBlock();
-      underlyingSerializer_.reset();
-    }
-  }
-
-  // Flush the temporary buffer, and then move out the underlying serializer.
-  UnderlyingSerializer underlyingSerializer() && {
-    AD_CORRECTNESS_CHECK(underlyingSerializer_.has_value());
-    flushBlock();
-    return std::move(*underlyingSerializer_);
-  }
-
- private:
-  // Flush the `buffer_` by compressing it and writing to the
-  // `underlyingSerializer_`.
-  //
-  // NOTE: By the logic of `serializeBytes`, it is enforced that `buffer_` is
-  // never larger than `blocksize_`. This lets us avoid unnecessary memory
-  // allocations.
-  void flushBlock() {
-    if (buffer_.empty()) {
-      return;
-    }
-    AD_CORRECTNESS_CHECK(buffer_.size() <= blocksize_);
-    size_t uncompressedSize = buffer_.size();
-    *underlyingSerializer_ << uncompressedSize;
-    compressionFunction_(buffer_, compressedBuffer_);
-    *underlyingSerializer_ << compressedBuffer_;
-    buffer_.clear();
-  }
+      : Base{std::move(underlyingSerializer), blocksize,
+             CompressingBlockProcessor<CompressionFunction>{
+                 std::move(compressionFunction)}} {}
 };
 
 // A read serializer that decompresses data in blocks from the

--- a/test/SerializerTest.cpp
+++ b/test/SerializerTest.cpp
@@ -13,6 +13,7 @@
 #include "util/GTestHelpers.h"
 #include "util/MemorySize/MemorySize.h"
 #include "util/Random.h"
+#include "util/Serializer/BufferedSerializer.h"
 #include "util/Serializer/ByteBufferSerializer.h"
 #include "util/Serializer/CompressedSerializer.h"
 #include "util/Serializer/FileSerializer.h"
@@ -26,6 +27,8 @@
 #include "util/Serializer/Serializer.h"
 
 using namespace ad_utility;
+using namespace memory_literals;
+using ad_utility::serialization::BufferedWriteSerializer;
 using ad_utility::serialization::ByteBufferReadSerializer;
 using ad_utility::serialization::ByteBufferWriteSerializer;
 using ad_utility::serialization::CompressedReadSerializer;
@@ -883,4 +886,86 @@ TEST(ZstdSerializer, RoundtripWithFileSerializer) {
     reader >> read;
     EXPECT_EQ(original, read);
   }
+}
+
+// _____________________________________________________________________________
+TEST(BufferedWriteSerializer, TransparentPassthrough) {
+  std::array<std::string_view, 4> strings{"alpha", "beta", "gamma", "delta"};
+
+  ByteBufferWriteSerializer expectedWriter;
+  expectedWriter << strings;
+  auto expected = std::move(expectedWriter).data();
+
+  for (MemorySize blockSize : {1_B, 7_B, 64_B, 1024_B}) {
+    BufferedWriteSerializer writer{ByteBufferWriteSerializer{}, blockSize};
+    writer << strings;
+    auto actual = std::move(writer).underlyingSerializer().data();
+    EXPECT_EQ(actual, expected) << "block size was " << blockSize;
+  }
+}
+
+// _____________________________________________________________________________
+TEST(BufferedWriteSerializer, RoundtripWithByteBuffer) {
+  std::vector<int> original;
+  for (int i = 0; i < 10'000; ++i) {
+    original.push_back(i);
+  }
+
+  BufferedWriteSerializer writer{ByteBufferWriteSerializer{}, 7_B};
+  writer << original;
+  auto buffer = std::move(writer).underlyingSerializer();
+
+  ByteBufferReadSerializer reader{std::move(buffer).data()};
+  std::vector<int> read;
+  reader >> read;
+  EXPECT_EQ(original, read);
+}
+
+// _____________________________________________________________________________
+TEST(BufferedWriteSerializer, RoundtripWithFileSerializerViaClose) {
+  std::string filename = gtestCurrentTestName();
+  auto cleanup = absl::Cleanup{[&filename]() { deleteFile(filename); }};
+  auto blockSize = 13_B;
+
+  std::vector<std::string> original{"alpha", "beta", "gamma", "delta"};
+
+  {
+    BufferedWriteSerializer writer{FileWriteSerializer{filename}, blockSize};
+    writer << original;
+    // `close` flushes the remaining buffered data to the file.
+    writer.close();
+  }
+
+  {
+    FileReadSerializer reader{filename};
+    std::vector<std::string> read;
+    reader >> read;
+    EXPECT_EQ(original, read);
+  }
+}
+
+// _____________________________________________________________________________
+TEST(BufferedWriteSerializer, FlushOnDestruction) {
+  // The remaining, incomplete block is flushed on destruction, even if neither
+  // `close` nor `underlyingSerializer` is called explicitly.
+  std::string filename = gtestCurrentTestName();
+  auto cleanup = absl::Cleanup{[&filename]() { deleteFile(filename); }};
+
+  std::vector<int> original = {1, 2, 3, 4, 5};
+  {
+    BufferedWriteSerializer writer{FileWriteSerializer{filename}, 1_MB};
+    writer << original;
+  }
+
+  FileReadSerializer reader{filename};
+  std::vector<int> read;
+  reader >> read;
+  EXPECT_EQ(original, read);
+}
+
+// _____________________________________________________________________________
+TEST(BufferedWriteSerializer, IsWriteSerializer) {
+  static_assert(WriteSerializer<BufferedWriteSerializer<FileWriteSerializer>>);
+  static_assert(
+      WriteSerializer<BufferedWriteSerializer<ByteBufferWriteSerializer>>);
 }


### PR DESCRIPTION
Adds a `BufferedWriteSerializer` that wraps any `WriteSerializer` and forwards data only once a full block (of configurable `MemorySize`) has accumulated, with an optional `BlockProcessor` to transform each block before forwarding (defaulting to a pass-through). The vocabulary merger and `CompressedWriteSerializer` both previously had their own hand-rolled buffering; they now use `BufferedWriteSerializer`. `CompressedWriteSerializer` transforms each block before writing via a new `CompressingBlockProcessor`.