### PR TITLE
Add `VariableCounter` utility to count variable occurrences in a parsed query

### DIFF
--- a/src/parser/CMakeLists.txt
+++ b/src/parser/CMakeLists.txt
@@ -32,5 +32,6 @@ add_library(parser
         MaterializedViewQuery.cpp
         GraphPatternAnalysis.cpp
         ExternalValuesQuery.cpp
+        VariableCounter.cpp
 )
 qlever_target_link_libraries(parser sparqlParser parserData sparqlExpressions rdfEscaping global re2::re2 util engine index rdfTypes)

--- a/src/parser/GraphPatternOperation.h
+++ b/src/parser/GraphPatternOperation.h
@@ -121,8 +121,9 @@ struct GroupGraphPattern {
   enum class GraphVariableBehaviour { ALL, NAMED };
   // If not `monostate`, then this group is a `GRAPH` clause, either with a
   // fixed graph IRI, or with a variable.
-  using GraphSpec = std::variant<std::monostate, TripleComponent::Iri,
-                                 std::pair<Variable, GraphVariableBehaviour>>;
+  using GraphVar = std::pair<Variable, GraphVariableBehaviour>;
+  using GraphSpec =
+      std::variant<std::monostate, TripleComponent::Iri, GraphVar>;
   GraphSpec graphSpec_ = std::monostate{};
 
   // Constructors for all legal constellations.

--- a/src/parser/VariableCounter.cpp
+++ b/src/parser/VariableCounter.cpp
@@ -21,9 +21,9 @@ void VariableCounter::operator()(const GraphPattern& gp) {
 }
 
 // _____________________________________________________________________________
-CPP_template_def(typename T)(requires ql::ranges::input_range<
-                             std::remove_cvref_t<T>>) void VariableCounter::
-operator()(T&& range) {
+CPP_template_def(typename T)(
+    requires ql::ranges::input_range<
+        std::remove_cvref_t<T>>) void VariableCounter::operator()(T && range) {
   for (const auto& elem : range) {
     (*this)(elem);  // dispatch each element to existing overloads
   }

--- a/src/parser/VariableCounter.cpp
+++ b/src/parser/VariableCounter.cpp
@@ -21,9 +21,9 @@ void VariableCounter::operator()(const GraphPattern& gp) {
 }
 
 // _____________________________________________________________________________
-CPP_template_def(typename T)(
-    requires ql::ranges::input_range<
-        std::remove_cvref_t<T>>) void VariableCounter::operator()(T && range) {
+CPP_template_def(typename T)(requires ql::ranges::input_range<
+                             std::remove_cvref_t<T>>) void VariableCounter::
+operator()(T&& range) {
   for (const auto& elem : range) {
     (*this)(elem);  // dispatch each element to existing overloads
   }
@@ -46,6 +46,11 @@ void VariableCounter::operator()(const SparqlFilter& filter) {
 // _____________________________________________________________________________
 void VariableCounter::operator()(const GraphPatternOperation& gpo) {
   std::visit(*this, gpo);
+}
+
+// _____________________________________________________________________________
+void VariableCounter::operator()(const Subquery& op) {
+  (*this)(op.get()._rootGraphPattern);
 }
 
 // _____________________________________________________________________________

--- a/src/parser/VariableCounter.cpp
+++ b/src/parser/VariableCounter.cpp
@@ -128,7 +128,6 @@ void VariableCounter::operator()(const SpatialQuery& op) {
 
 // _____________________________________________________________________________
 void VariableCounter::operator()(const TextSearchQuery& op) {
-  op.configVarToConfigs_.at(Variable{""});
   (*this)(op.configVarToConfigs_ | ql::views::keys);
   (*this)(op.configVarToConfigs_ | ql::views::values);
   (*this)(op.childGraphPattern_);

--- a/src/parser/VariableCounter.cpp
+++ b/src/parser/VariableCounter.cpp
@@ -9,6 +9,8 @@
 
 #include "parser/VariableCounter.h"
 
+#include "util/VariantRangeFilter.h"
+
 namespace parsedQuery {
 
 // _____________________________________________________________________________
@@ -19,9 +21,9 @@ void VariableCounter::operator()(const GraphPattern& gp) {
 }
 
 // _____________________________________________________________________________
-CPP_template_def(typename T)(
-    requires ql::ranges::input_range<T>) void VariableCounter::
-operator()(const T& range) {
+CPP_template_def(typename T)(requires ql::ranges::input_range<
+                             std::remove_cvref_t<T>>) void VariableCounter::
+operator()(T&& range) {
   for (const auto& elem : range) {
     (*this)(elem);  // dispatch each element to existing overloads
   }
@@ -77,8 +79,8 @@ void VariableCounter::operator()(const Bind& op) {
 }
 
 // _____________________________________________________________________________
-void VariableCounter::operator()(const SparqlTriple& var) {
-  var.forEachVariable(*this);
+void VariableCounter::operator()(const SparqlTriple& triple) {
+  triple.forEachVariable(*this);
 }
 
 // _____________________________________________________________________________
@@ -100,30 +102,74 @@ void VariableCounter::operator()(const Service& op) {
 void VariableCounter::operator()(const Minus& op) { (*this)(op._child); }
 
 // _____________________________________________________________________________
-void VariableCounter::operator()(const GroupGraphPattern& op) {
-  (*this)(op._child);
+void VariableCounter::operator()(const GroupGraphPattern& pattern) {
+  (*this)(pattern._child);
   // Graph variable.
-  std::visit(
-      [this](const auto& gs) {
-        using T = std::decay_t<decltype(gs)>;
-        if constexpr (std::is_same_v<
-                          T, std::pair<Variable, GroupGraphPattern::
-                                                     GraphVariableBehaviour>>) {
-          (*this)(gs.first);
-        }
-      },
-      op.graphSpec_);
+  if (std::holds_alternative<GroupGraphPattern::GraphVar>(pattern.graphSpec_)) {
+    (*this)(std::get<GroupGraphPattern::GraphVar>(pattern.graphSpec_).first);
+  }
 }
 
-// TODO
-void VariableCounter::operator()(const PathQuery& op) {}
-void VariableCounter::operator()(const SpatialQuery& op) {}
-void VariableCounter::operator()(const TextSearchQuery& op) {}
-void VariableCounter::operator()(const Describe& op) {}
-void VariableCounter::operator()(const Load& op) {}
+// _____________________________________________________________________________
+void VariableCounter::operator()(const PathQuery& op) {
+  (*this)(op.pathColumn_);
+  (*this)(op.edgeColumn_);
+  (*this)(op.edgeProperties_);
+  (*this)(op.end_);
+  (*this)(op.sources_);
+  (*this)(op.start_);
+  (*this)(op.targets_);
+  (*this)(op.childGraphPattern_);
+}
 
+// _____________________________________________________________________________
+void VariableCounter::operator()(const SpatialQuery& op) {
+  (*this)(op.distanceVariable_);
+  if (!op.payloadVariables_.isAll()) {
+    (*this)(op.payloadVariables_.getVariables());
+  }
+  (*this)(op.left_);
+  (*this)(op.right_);
+  (*this)(op.childGraphPattern_);
+}
+
+// _____________________________________________________________________________
+void VariableCounter::operator()(const TextSearchQuery& op) {
+  op.configVarToConfigs_.at(Variable{""});
+  (*this)(op.configVarToConfigs_ | ql::views::keys);
+  (*this)(op.configVarToConfigs_ | ql::views::values);
+  (*this)(op.childGraphPattern_);
+}
+
+// _____________________________________________________________________________
+void VariableCounter::operator()(const TextSearchConfig& op) {
+  (*this)(op.textVar_);
+  (*this)(op.matchVar_);
+  (*this)(op.scoreVar_);
+  if (op.entity_.has_value()) {
+    const auto& variant = op.entity_.value();
+    if (std::holds_alternative<Variable>(variant)) {
+      (*this)(std::get<Variable>(variant));
+    }
+  }
+}
+
+// _____________________________________________________________________________
+void VariableCounter::operator()(const Describe& op) {
+  (*this)(op.whereClause_);
+  (*this)(ad_utility::filterRangeOfVariantsByType<Variable>(op.resources_));
+}
+
+// _____________________________________________________________________________
+void VariableCounter::operator()(const Load&) {
+  // `LOAD` does not have any variables.
+}
+
+// _____________________________________________________________________________
 void VariableCounter::operator()(const NamedCachedResult& op) {
-  // TODO
+  // `NamedCachedResult` does not know any variables at parsing time if the user
+  // does not fill in a no-op child graph pattern to make them visible.
+  (*this)(op.childGraphPattern_);
 }
 
 // _____________________________________________________________________________

--- a/src/parser/VariableCounter.cpp
+++ b/src/parser/VariableCounter.cpp
@@ -30,7 +30,7 @@ operator()(T&& range) {
 }
 
 // _____________________________________________________________________________
-void VariableCounter::operator()(const Variable& var) { count_[var]++; }
+void VariableCounter::operator()(const Variable& var) { counts_[var]++; }
 
 // _____________________________________________________________________________
 void VariableCounter::operator()(const Variable* var) {
@@ -80,7 +80,9 @@ void VariableCounter::operator()(const Bind& op) {
 
 // _____________________________________________________________________________
 void VariableCounter::operator()(const SparqlTriple& triple) {
-  triple.forEachVariable(*this);
+  // `std::ref` is important here as we would otherwise pass a copy which would
+  // count on its own.
+  triple.forEachVariable(std::ref(*this));
 }
 
 // _____________________________________________________________________________

--- a/src/parser/VariableCounter.cpp
+++ b/src/parser/VariableCounter.cpp
@@ -21,15 +21,6 @@ void VariableCounter::operator()(const GraphPattern& gp) {
 }
 
 // _____________________________________________________________________________
-CPP_template_def(typename T)(requires ql::ranges::input_range<
-                             std::remove_cvref_t<T>>) void VariableCounter::
-operator()(T&& range) {
-  for (const auto& elem : range) {
-    (*this)(elem);  // dispatch each element to existing overloads
-  }
-}
-
-// _____________________________________________________________________________
 void VariableCounter::operator()(const Variable& var) { counts_[var]++; }
 
 // _____________________________________________________________________________
@@ -41,11 +32,6 @@ void VariableCounter::operator()(const Variable* var) {
 // _____________________________________________________________________________
 void VariableCounter::operator()(const SparqlFilter& filter) {
   (*this)(filter.expression_.containedVariables());
-}
-
-// _____________________________________________________________________________
-void VariableCounter::operator()(const GraphPatternOperation& gpo) {
-  std::visit(*this, gpo);
 }
 
 // _____________________________________________________________________________
@@ -188,14 +174,6 @@ void VariableCounter::operator()(const MaterializedViewQuery& op) {
 // _____________________________________________________________________________
 void VariableCounter::operator()(const ExternalValuesQuery& op) {
   (*this)(op.variables_);
-}
-
-// _____________________________________________________________________________
-template <typename T>
-void VariableCounter::operator()(const std::optional<T>& opt) {
-  if (opt.has_value()) {
-    (*this)(opt.value());
-  }
 }
 
 }  // namespace parsedQuery

--- a/src/parser/VariableCounter.cpp
+++ b/src/parser/VariableCounter.cpp
@@ -1,0 +1,148 @@
+// Copyright 2026 The QLever Authors, in particular:
+//
+// 2026 Christoph Ullinger <ullingec@informatik.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#include "parser/VariableCounter.h"
+
+namespace parsedQuery {
+
+// _____________________________________________________________________________
+void VariableCounter::operator()(const GraphPattern& gp) {
+  (*this)(gp._filters);
+  (*this)(gp._graphPatterns);
+  (*this)(gp.textLimits_ | ql::views::keys);
+}
+
+// _____________________________________________________________________________
+CPP_template_def(typename T)(
+    requires ql::ranges::input_range<T>) void VariableCounter::
+operator()(const T& range) {
+  for (const auto& elem : range) {
+    (*this)(elem);  // dispatch each element to existing overloads
+  }
+}
+
+// _____________________________________________________________________________
+void VariableCounter::operator()(const Variable& var) { count_[var]++; }
+
+// _____________________________________________________________________________
+void VariableCounter::operator()(const Variable* var) {
+  AD_CORRECTNESS_CHECK(var != nullptr);
+  (*this)(*var);
+}
+
+// _____________________________________________________________________________
+void VariableCounter::operator()(const SparqlFilter& filter) {
+  (*this)(filter.expression_.containedVariables());
+}
+
+// _____________________________________________________________________________
+void VariableCounter::operator()(const GraphPatternOperation& gpo) {
+  std::visit(*this, gpo);
+}
+
+// _____________________________________________________________________________
+void VariableCounter::operator()(const Optional& op) { (*this)(op._child); }
+
+// _____________________________________________________________________________
+void VariableCounter::operator()(const Union& op) {
+  (*this)(op._child1);
+  (*this)(op._child2);
+}
+
+// _____________________________________________________________________________
+void VariableCounter::operator()(const TripleComponent& tc) {
+  if (tc.isVariable()) {
+    (*this)(tc.getVariable());
+  }
+}
+
+// _____________________________________________________________________________
+void VariableCounter::operator()(const TransPath& op) {
+  (*this)(op._childGraphPattern);
+  (*this)(op._innerLeft);
+  (*this)(op._innerRight);
+  (*this)(op._left);
+  (*this)(op._right);
+}
+
+// _____________________________________________________________________________
+void VariableCounter::operator()(const Bind& op) {
+  (*this)(op.containedVariables());
+}
+
+// _____________________________________________________________________________
+void VariableCounter::operator()(const SparqlTriple& var) {
+  var.forEachVariable(*this);
+}
+
+// _____________________________________________________________________________
+void VariableCounter::operator()(const BasicGraphPattern& op) {
+  (*this)(op._triples);
+}
+
+// _____________________________________________________________________________
+void VariableCounter::operator()(const Values& op) {
+  (*this)(op._inlineValues._variables);
+}
+
+// _____________________________________________________________________________
+void VariableCounter::operator()(const Service& op) {
+  (*this)(op.visibleVariables_);
+}
+
+// _____________________________________________________________________________
+void VariableCounter::operator()(const Minus& op) { (*this)(op._child); }
+
+// _____________________________________________________________________________
+void VariableCounter::operator()(const GroupGraphPattern& op) {
+  (*this)(op._child);
+  // Graph variable.
+  std::visit(
+      [this](const auto& gs) {
+        using T = std::decay_t<decltype(gs)>;
+        if constexpr (std::is_same_v<
+                          T, std::pair<Variable, GroupGraphPattern::
+                                                     GraphVariableBehaviour>>) {
+          (*this)(gs.first);
+        }
+      },
+      op.graphSpec_);
+}
+
+// TODO
+void VariableCounter::operator()(const PathQuery& op) {}
+void VariableCounter::operator()(const SpatialQuery& op) {}
+void VariableCounter::operator()(const TextSearchQuery& op) {}
+void VariableCounter::operator()(const Describe& op) {}
+void VariableCounter::operator()(const Load& op) {}
+
+void VariableCounter::operator()(const NamedCachedResult& op) {
+  // TODO
+}
+
+// _____________________________________________________________________________
+void VariableCounter::operator()(const MaterializedViewQuery& op) {
+  (*this)(op.scanCol_);
+  (*this)(op.requestedColumns_ | ql::views::keys);
+}
+
+// _____________________________________________________________________________
+void VariableCounter::operator()(const ExternalValuesQuery& op) {
+  (*this)(op.variables_);
+}
+
+// _____________________________________________________________________________
+template <typename T>
+void VariableCounter::operator()(const std::optional<T>& opt) {
+  if (opt.has_value()) {
+    (*this)(opt.value());
+  }
+}
+
+}  // namespace parsedQuery

--- a/src/parser/VariableCounter.h
+++ b/src/parser/VariableCounter.h
@@ -14,6 +14,7 @@
 
 #include "parser/GraphPattern.h"
 #include "parser/GraphPatternOperation.h"
+#include "parser/ParsedQuery.h"
 #include "parser/SparqlTriple.h"
 
 namespace parsedQuery {
@@ -32,7 +33,7 @@ struct VariableCounter {
 
   // Count variables from a view or range, e.g. `std::vector<GraphPattern>`.
   CPP_template(typename T)(
-      requires ql::ranges::input_range<std::remove_cvref_t<T>>) void
+      requires ql::ranges::input_range<ql::remove_cvref_t<T>>) void
   operator()(T&& range) {
     for (const auto& elem : range) {
       (*this)(elem);

--- a/src/parser/VariableCounter.h
+++ b/src/parser/VariableCounter.h
@@ -29,20 +29,42 @@ struct VariableCounter {
  public:
   const Map& counts() const { return counts_; }
 
+  // Count variables from a view or range, e.g. `std::vector<GraphPattern>`.
   CPP_template(typename T)(
       requires ql::ranges::input_range<std::remove_cvref_t<T>>) void
-  operator()(T&& rng);
+  operator()(T&& range) {
+    for (const auto& elem : range) {
+      (*this)(elem);
+    }
+  }
 
+  // Unwrap a `std::optional<...>`.
   template <typename T>
-  void operator()(const std::optional<T>& opt);
+  void operator()(const std::optional<T>& opt) {
+    if (opt.has_value()) {
+      (*this)(opt.value());
+    }
+  }
 
+  // `GraphPatternOperation` is a `std::variant`. The individual operations are
+  // handled by the overloads below. We want to prevent implicit conversion here
+  // and generate a compiler error when an overload is missing, not a runtime
+  // stack overflow .
+  CPP_template(typename T)(
+      requires std::is_same_v<T, GraphPatternOperation>) void
+  operator()(const T& gpo) {
+    std::visit(*this, gpo);
+  }
+
+  // Overloads for helper types.
   void operator()(const Variable& var);
-  void operator()(const TripleComponent& var);
-  void operator()(const SparqlTriple& var);
   void operator()(const Variable* var);
-  void operator()(const GraphPattern& gp);
-  void operator()(const SparqlFilter& filter);
-  void operator()(const GraphPatternOperation& gpo);
+  void operator()(const TripleComponent& tc);
+  void operator()(const SparqlTriple& triple);
+
+  // Overloads for the individual operations.
+  void operator()(const GraphPattern& op);
+  void operator()(const SparqlFilter& op);
   void operator()(const Subquery& op);
   void operator()(const Optional& op);
   void operator()(const Union& op);

--- a/src/parser/VariableCounter.h
+++ b/src/parser/VariableCounter.h
@@ -43,6 +43,7 @@ struct VariableCounter {
   void operator()(const GraphPattern& gp);
   void operator()(const SparqlFilter& filter);
   void operator()(const GraphPatternOperation& gpo);
+  void operator()(const Subquery& op);
   void operator()(const Optional& op);
   void operator()(const Union& op);
   void operator()(const TransPath& op);

--- a/src/parser/VariableCounter.h
+++ b/src/parser/VariableCounter.h
@@ -1,0 +1,79 @@
+// Copyright 2026 The QLever Authors, in particular:
+//
+// 2026 Christoph Ullinger <ullingec@informatik.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#ifndef QLEVER_SRC_PARSER_VARIABLECOUNTER_H
+#define QLEVER_SRC_PARSER_VARIABLECOUNTER_H
+
+#include <cstddef>
+
+#include "parser/GraphPattern.h"
+#include "parser/SparqlTriple.h"
+
+namespace parsedQuery {
+
+// Forward declarations.
+struct GraphPatternOperation;
+struct Optional;
+struct Union;
+struct TransPath;
+struct Bind;
+struct BasicGraphPattern;
+struct Values;
+struct Service;
+struct PathQuery;
+struct SpatialQuery;
+struct TextSearchQuery;
+struct Minus;
+struct GroupGraphPattern;
+struct Describe;
+struct Load;
+class NamedCachedResult;
+struct MaterializedViewQuery;
+struct ExternalValuesQuery;
+
+// Visits the various types of graph patterns to extract how often a variable
+// appears.
+struct VariableCounter {
+  ad_utility::HashMap<Variable, size_t> count_;
+
+  CPP_template(typename T)(requires ql::ranges::input_range<T>) void operator()(
+      const T& rng);
+
+  template <typename T>
+  void operator()(const std::optional<T>& opt);
+
+  void operator()(const Variable& var);
+  void operator()(const TripleComponent& var);
+  void operator()(const SparqlTriple& var);
+  void operator()(const Variable* var);
+  void operator()(const GraphPattern& gp);
+  void operator()(const SparqlFilter& filter);
+  void operator()(const GraphPatternOperation& gpo);
+  void operator()(const Optional& op);
+  void operator()(const Union& op);
+  void operator()(const TransPath& op);
+  void operator()(const Bind& op);
+  void operator()(const BasicGraphPattern& op);
+  void operator()(const Values& op);
+  void operator()(const Service& op);
+  void operator()(const PathQuery& op);
+  void operator()(const SpatialQuery& op);
+  void operator()(const TextSearchQuery& op);
+  void operator()(const Minus& op);
+  void operator()(const GroupGraphPattern& op);
+  void operator()(const Describe& op);
+  void operator()(const Load& op);
+  void operator()(const NamedCachedResult& op);
+  void operator()(const MaterializedViewQuery& op);
+  void operator()(const ExternalValuesQuery& op);
+};
+
+}  // namespace parsedQuery
+
+#endif  // QLEVER_SRC_PARSER_VARIABLECOUNTER_H

--- a/src/parser/VariableCounter.h
+++ b/src/parser/VariableCounter.h
@@ -11,6 +11,7 @@
 #define QLEVER_SRC_PARSER_VARIABLECOUNTER_H
 
 #include <cstddef>
+#include <variant>
 
 #include "parser/GraphPattern.h"
 #include "parser/GraphPatternOperation.h"

--- a/src/parser/VariableCounter.h
+++ b/src/parser/VariableCounter.h
@@ -13,6 +13,7 @@
 #include <cstddef>
 
 #include "parser/GraphPattern.h"
+#include "parser/GraphPatternOperation.h"
 #include "parser/SparqlTriple.h"
 
 namespace parsedQuery {

--- a/src/parser/VariableCounter.h
+++ b/src/parser/VariableCounter.h
@@ -17,33 +17,14 @@
 
 namespace parsedQuery {
 
-// Forward declarations.
-struct GraphPatternOperation;
-struct Optional;
-struct Union;
-struct TransPath;
-struct Bind;
-struct BasicGraphPattern;
-struct Values;
-struct Service;
-struct PathQuery;
-struct SpatialQuery;
-struct TextSearchQuery;
-struct Minus;
-struct GroupGraphPattern;
-struct Describe;
-struct Load;
-class NamedCachedResult;
-struct MaterializedViewQuery;
-struct ExternalValuesQuery;
-
 // Visits the various types of graph patterns to extract how often a variable
 // appears.
 struct VariableCounter {
   ad_utility::HashMap<Variable, size_t> count_;
 
-  CPP_template(typename T)(requires ql::ranges::input_range<T>) void operator()(
-      const T& rng);
+  CPP_template(typename T)(
+      requires ql::ranges::input_range<std::remove_cvref_t<T>>) void
+  operator()(T&& rng);
 
   template <typename T>
   void operator()(const std::optional<T>& opt);
@@ -65,6 +46,7 @@ struct VariableCounter {
   void operator()(const PathQuery& op);
   void operator()(const SpatialQuery& op);
   void operator()(const TextSearchQuery& op);
+  void operator()(const TextSearchConfig& op);
   void operator()(const Minus& op);
   void operator()(const GroupGraphPattern& op);
   void operator()(const Describe& op);

--- a/src/parser/VariableCounter.h
+++ b/src/parser/VariableCounter.h
@@ -56,7 +56,7 @@ struct VariableCounter {
   CPP_template(typename T)(
       requires std::is_same_v<T, GraphPatternOperation>) void
   operator()(const T& gpo) {
-    std::visit(*this, gpo);
+    gpo.visit(*this);
   }
 
   // Overloads for helper types.

--- a/src/parser/VariableCounter.h
+++ b/src/parser/VariableCounter.h
@@ -20,7 +20,14 @@ namespace parsedQuery {
 // Visits the various types of graph patterns to extract how often a variable
 // appears.
 struct VariableCounter {
-  ad_utility::HashMap<Variable, size_t> count_;
+ public:
+  using Map = ad_utility::HashMap<Variable, size_t>;
+
+ private:
+  Map counts_;
+
+ public:
+  const Map& counts() const { return counts_; }
 
   CPP_template(typename T)(
       requires ql::ranges::input_range<std::remove_cvref_t<T>>) void

--- a/src/parser/VariableCounter.h
+++ b/src/parser/VariableCounter.h
@@ -47,10 +47,10 @@ struct VariableCounter {
     }
   }
 
-  // `GraphPatternOperation` is a `std::variant`. The individual operations are
-  // handled by the overloads below. We want to prevent implicit conversion here
-  // and generate a compiler error when an overload is missing, not a runtime
-  // stack overflow .
+  // `GraphPatternOperation` is a `std::variant`, which we visit. If an overload
+  // for one of the variant types were missing, the compiler would implicitly
+  // convert it to `GraphPatternOperation` and we would have a stack overflow.
+  // Therefore we prevent implicit conversion here.
   CPP_template(typename T)(
       requires std::is_same_v<T, GraphPatternOperation>) void
   operator()(const T& gpo) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -159,6 +159,8 @@ addLinkAndDiscoverTest(ValueIdComparatorsTest util)
 
 addLinkAndDiscoverTest(SparqlParserTest parser engine sparqlExpressions)
 
+addLinkAndDiscoverTest(VariableCounterTest parser engine)
+
 addLinkAndDiscoverTest(StringUtilsTest util)
 
 addLinkAndDiscoverTestNoLibs(ConstexprSmallStringTest)

--- a/test/VariableCounterTest.cpp
+++ b/test/VariableCounterTest.cpp
@@ -1,0 +1,114 @@
+// Copyright 2026 The QLever Authors, in particular:
+//
+// 2026 Christoph Ullinger <ullingec@informatik.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#include <gmock/gmock.h>
+
+#include "./util/GTestHelpers.h"
+#include "parser/SparqlParser.h"
+#include "parser/VariableCounter.h"
+
+// _____________________________________________________________________________
+namespace {
+
+using namespace ::testing;
+using parsedQuery::VariableCounter;
+using V = Variable;
+
+// Apply `VariableCounter` to the root graph pattern of the given SPARQL query.
+VariableCounter parseAndCount(const std::string& sparql) {
+  static EncodedIriManager encodedIriManager;
+  auto pq = SparqlParser::parseQuery(&encodedIriManager, sparql);
+  VariableCounter counter;
+  counter(pq._rootGraphPattern);
+  return counter;
+}
+
+// Shorthand matcher for `VariableCounter`.
+Matcher<VariableCounter> counts(VariableCounter::Map expected) {
+  return AD_PROPERTY(VariableCounter, counts,
+                     UnorderedElementsAreArray(std::move(expected)));
+}
+
+// _____________________________________________________________________________
+TEST(VariableCounterTest, VariableCounts) {
+  // Basic graph patterns.
+  EXPECT_THAT(parseAndCount("SELECT * { <s> <p> <o> }"), counts({}));
+  EXPECT_THAT(parseAndCount("SELECT * { ?x <p> ?y }"),
+              counts({{V{"?x"}, 1}, {V{"?y"}, 1}}));
+  EXPECT_THAT(parseAndCount("SELECT * { ?x <p> ?x }"), counts({{V{"?x"}, 2}}));
+  EXPECT_THAT(parseAndCount("SELECT * { ?x <p> ?y . ?y <q> ?z }"),
+              counts({{V{"?x"}, 1}, {V{"?y"}, 2}, {V{"?z"}, 1}}));
+  EXPECT_THAT(parseAndCount("SELECT * { ?x ?p ?y }"),
+              counts({{V{"?x"}, 1}, {V{"?p"}, 1}, {V{"?y"}, 1}}));
+
+  // Filter.
+  EXPECT_THAT(parseAndCount("SELECT * { ?x <p> ?y . FILTER(?x < ?y) }"),
+              counts({{V{"?x"}, 2}, {V{"?y"}, 2}}));
+  EXPECT_THAT(parseAndCount("SELECT * { ?x <p> <o> . FILTER(BOUND(?z)) }"),
+              counts({{V{"?x"}, 1}, {V{"?z"}, 1}}));
+
+  // Optional.
+  EXPECT_THAT(parseAndCount("SELECT * { ?x <p> ?y . OPTIONAL { ?y <q> ?z } }"),
+              counts({{V{"?x"}, 1}, {V{"?y"}, 2}, {V{"?z"}, 1}}));
+  EXPECT_THAT(
+      parseAndCount(
+          "SELECT * { ?x <p> ?y . OPTIONAL { ?y <q> ?z . FILTER(?z > 0) } "
+          "}"),
+      counts({{V{"?x"}, 1}, {V{"?y"}, 2}, {V{"?z"}, 2}}));
+  EXPECT_THAT(parseAndCount("SELECT * { ?x <p> ?y . OPTIONAL { ?y <q> ?z . "
+                            " } OPTIONAL { ?z <r> ?w } }"),
+              counts({{V{"?x"}, 1}, {V{"?y"}, 2}, {V{"?z"}, 2}, {V{"?w"}, 1}}));
+
+  // Union.
+  EXPECT_THAT(parseAndCount("SELECT * { { ?x <p> ?y } UNION { ?a <q> ?b } }"),
+              counts({{V{"?x"}, 1}, {V{"?y"}, 1}, {V{"?a"}, 1}, {V{"?b"}, 1}}));
+  EXPECT_THAT(parseAndCount("SELECT * { { ?x <p> ?y } UNION { ?x <q> ?z } }"),
+              counts({{V{"?x"}, 2}, {V{"?y"}, 1}, {V{"?z"}, 1}}));
+
+  // Minus.
+  EXPECT_THAT(parseAndCount("SELECT * { ?x <p> ?y . MINUS { ?x <q> ?z } }"),
+              counts({{V{"?x"}, 2}, {V{"?y"}, 1}, {V{"?z"}, 1}}));
+
+  // Bind.
+  EXPECT_THAT(parseAndCount("SELECT * { ?x <p> ?y . BIND(?x + ?y AS ?z) }"),
+              counts({{V{"?x"}, 2}, {V{"?y"}, 2}, {V{"?z"}, 1}}));
+  EXPECT_THAT(parseAndCount("SELECT * { <s> <p> <o> . BIND(42 AS ?result) }"),
+              counts({{V{"?result"}, 1}}));
+  EXPECT_THAT(parseAndCount("SELECT * { BIND(42 AS ?o) . ?s ?p ?o }"),
+              counts({{V{"?s"}, 1}, {V{"?p"}, 1}, {V{"?o"}, 2}}));
+
+  // Values.
+  EXPECT_THAT(
+      parseAndCount("SELECT * { VALUES (?x ?y) { (<a> <b>) (<c> <d>) } }"),
+      counts({{V{"?x"}, 1}, {V{"?y"}, 1}}));
+  EXPECT_THAT(parseAndCount("SELECT * { VALUES ?x { <a> <b> <c> } }"),
+              counts({{V{"?x"}, 1}}));
+  EXPECT_THAT(
+      parseAndCount("SELECT * { ?s ?p ?o . VALUES ?o { <a> <b> <c> } }"),
+      counts({{V{"?s"}, 1}, {V{"?p"}, 1}, {V{"?o"}, 2}}));
+
+  // Service.
+  EXPECT_THAT(
+      parseAndCount(
+          "SELECT * { SERVICE <http://example.org/sparql> { ?x ?y ?z } }"),
+      counts({{V{"?x"}, 1}, {V{"?y"}, 1}, {V{"?z"}, 1}}));
+
+  // Graph.
+  EXPECT_THAT(parseAndCount("SELECT * { GRAPH ?g { ?x <p> ?y } }"),
+              counts({{V{"?g"}, 1}, {V{"?x"}, 1}, {V{"?y"}, 1}}));
+  EXPECT_THAT(
+      parseAndCount("SELECT * { GRAPH <http://example.org/g> { ?x <p> ?y } }"),
+      counts({{V{"?x"}, 1}, {V{"?y"}, 1}}));
+
+  // Transitive path.
+  EXPECT_THAT(parseAndCount("SELECT ?x ?y WHERE { ?x <p>+ ?y }"),
+              counts({{V{"?x"}, 1}, {V{"?y"}, 1}}));
+}
+
+}  // namespace

--- a/test/VariableCounterTest.cpp
+++ b/test/VariableCounterTest.cpp
@@ -109,6 +109,11 @@ TEST(VariableCounterTest, VariableCounts) {
   // Transitive path.
   EXPECT_THAT(parseAndCount("SELECT ?x ?y WHERE { ?x <p>+ ?y }"),
               counts({{V{"?x"}, 1}, {V{"?y"}, 1}}));
+
+  // Subquery.
+  EXPECT_THAT(
+      parseAndCount("SELECT * { ?x <p> ?y . { SELECT * { ?y <q> ?z } } }"),
+      counts({{V{"?x"}, 1}, {V{"?y"}, 2}, {V{"?z"}, 1}}));
 }
 
 }  // namespace

--- a/test/VariableCounterTest.cpp
+++ b/test/VariableCounterTest.cpp
@@ -10,7 +10,9 @@
 #include <gmock/gmock.h>
 
 #include "./util/GTestHelpers.h"
+#include "parser/GraphPatternOperation.h"
 #include "parser/SparqlParser.h"
+#include "parser/TripleComponent.h"
 #include "parser/VariableCounter.h"
 
 // _____________________________________________________________________________
@@ -114,6 +116,161 @@ TEST(VariableCounterTest, VariableCounts) {
   EXPECT_THAT(
       parseAndCount("SELECT * { ?x <p> ?y . { SELECT * { ?y <q> ?z } } }"),
       counts({{V{"?x"}, 1}, {V{"?y"}, 2}, {V{"?z"}, 1}}));
+
+  // Describe.
+  EXPECT_THAT(parseAndCount("DESCRIBE <x>"), counts({}));
+  EXPECT_THAT(parseAndCount("DESCRIBE ?x"), counts({{V{"?x"}, 1}}));
+  EXPECT_THAT(parseAndCount("DESCRIBE ?y WHERE { ?y <p> ?z }"),
+              counts({{V{"?y"}, 2}, {V{"?z"}, 1}}));
+
+  // Load.
+  {
+    VariableCounter count;
+    count(parsedQuery::Load{
+        TripleComponent::Iri::fromIriref("<https://example.org>"), false});
+    EXPECT_THAT(count, counts({}));
+  }
+
+  // `TripleComponent`.
+  {
+    VariableCounter count;
+    count(TripleComponent{V{"?x"}});
+    EXPECT_THAT(count, counts({{V{"?x"}, 1}}));
+  }
+}
+
+// _____________________________________________________________________________
+TEST(VariableCounterTest, MagicServices) {
+  // Path search.
+  EXPECT_THAT(
+      parseAndCount(
+          "PREFIX pathSearch: <https://qlever.cs.uni-freiburg.de/pathSearch/>"
+          "SELECT ?start ?end ?path ?edge WHERE {"
+          "SERVICE pathSearch: {"
+          "_:p pathSearch:algorithm pathSearch:allPaths ;"
+          "pathSearch:source <x> ;"
+          "pathSearch:target <z> ;"
+          "pathSearch:pathColumn ?path ;"
+          "pathSearch:edgeColumn ?edge ;"
+          "pathSearch:start ?start ;"
+          "pathSearch:end ?end ."
+          "{ SELECT * WHERE { ?start <p> ?end } }"
+          "}}"),
+      counts({{V{"?start"}, 2},
+              {V{"?end"}, 2},
+              {V{"?path"}, 1},
+              {V{"?edge"}, 1}}));
+  EXPECT_THAT(
+      parseAndCount(
+          "PREFIX pathSearch: <https://qlever.cs.uni-freiburg.de/pathSearch/>"
+          "SELECT * WHERE {"
+          "SERVICE pathSearch: {"
+          "_:p pathSearch:algorithm pathSearch:allPaths ;"
+          "pathSearch:source ?src ;"
+          "pathSearch:target <z> ;"
+          "pathSearch:pathColumn ?path ;"
+          "pathSearch:edgeColumn ?edge ;"
+          "pathSearch:edgeProperty ?ep ;"
+          "pathSearch:start ?start ;"
+          "pathSearch:end ?end ."
+          "{ SELECT * WHERE { ?start <p> ?end } }"
+          "}}"),
+      counts({{V{"?start"}, 2},
+              {V{"?end"}, 2},
+              {V{"?path"}, 1},
+              {V{"?edge"}, 1},
+              {V{"?src"}, 1},
+              {V{"?ep"}, 1}}));
+
+  // Spatial search.
+  EXPECT_THAT(
+      parseAndCount(
+          "PREFIX qlss: <https://qlever.cs.uni-freiburg.de/spatialSearch/>"
+          "SELECT * WHERE {"
+          "SERVICE qlss: {"
+          "_:config qlss:left ?e ;"
+          "qlss:right ?z ;"
+          "qlss:maxDistance 500 . } }"),
+      counts({{V{"?e"}, 1}, {V{"?z"}, 1}}));
+  EXPECT_THAT(
+      parseAndCount(
+          "PREFIX qlss: <https://qlever.cs.uni-freiburg.de/spatialSearch/>"
+          "SELECT * WHERE {"
+          "SERVICE qlss: {"
+          "_:config qlss:left ?e ;"
+          "qlss:right ?z ;"
+          "qlss:maxDistance 500 ;"
+          "qlss:bindDistance ?dist . } }"),
+      counts({{V{"?e"}, 1}, {V{"?z"}, 1}, {V{"?dist"}, 1}}));
+  EXPECT_THAT(
+      parseAndCount(
+          "PREFIX qlss: <https://qlever.cs.uni-freiburg.de/spatialSearch/>"
+          "SELECT * WHERE {"
+          "SERVICE qlss: {"
+          "_:config qlss:left ?e ;"
+          "qlss:right ?z ;"
+          "qlss:numNearestNeighbors 3 ;"
+          "qlss:payload ?z ;"
+          "qlss:payload ?w ."
+          "{ ?a <q> ?z . ?b <r> ?w } } }"),
+      counts({{V{"?e"}, 1},
+              {V{"?z"}, 3},
+              {V{"?w"}, 2},
+              {V{"?a"}, 1},
+              {V{"?b"}, 1}}));
+
+  // Text search.
+  EXPECT_THAT(parseAndCount(
+                  "PREFIX qlts: <https://qlever.cs.uni-freiburg.de/textSearch/>"
+                  "SELECT * WHERE {"
+                  "SERVICE qlts: {"
+                  "?t qlts:contains ?conf ."
+                  "?conf qlts:word \"test\" . } }"),
+              counts({{V{"?conf"}, 1}, {V{"?t"}, 1}}));
+  EXPECT_THAT(parseAndCount(
+                  "PREFIX qlts: <https://qlever.cs.uni-freiburg.de/textSearch/>"
+                  "SELECT * WHERE {"
+                  "SERVICE qlts: {"
+                  "?t qlts:contains ?conf ."
+                  "?conf qlts:word \"test\" ."
+                  "?conf qlts:score ?sc . } }"),
+              counts({{V{"?conf"}, 1}, {V{"?t"}, 1}, {V{"?sc"}, 1}}));
+  EXPECT_THAT(
+      parseAndCount(
+          "PREFIX qlts: <https://qlever.cs.uni-freiburg.de/textSearch/>"
+          "SELECT * WHERE {"
+          "SERVICE qlts: {"
+          "?t qlts:contains ?c1 ."
+          "?c1 qlts:word \"test\" ."
+          "?t qlts:contains ?c2 ."
+          "?c2 qlts:entity ?e . } }"),
+      counts({{V{"?c1"}, 1}, {V{"?c2"}, 1}, {V{"?t"}, 2}, {V{"?e"}, 1}}));
+
+  // Named cached result: no variables.
+  EXPECT_THAT(parseAndCount(
+                  "SELECT * { SERVICE ql:cached-result-with-name-myQuery {} }"),
+              counts({}));
+
+  // Materialized view.
+  EXPECT_THAT(
+      parseAndCount(
+          "PREFIX view: <https://qlever.cs.uni-freiburg.de/materializedView/>"
+          "SELECT * {"
+          "SERVICE view:myView {"
+          "_:config view:column-s ?s ;"
+          "view:column-p ?p . } }"),
+      counts({{V{"?s"}, 1}, {V{"?p"}, 1}}));
+
+  // External values.
+  EXPECT_THAT(
+      parseAndCount(
+          "PREFIX qlext: <https://qlever.cs.uni-freiburg.de/external-values/>"
+          "SELECT * {"
+          "SERVICE qlext: {"
+          "_:b qlext:name \"myId\" ;"
+          "qlext:variable ?x ;"
+          "qlext:variable ?y . } }"),
+      counts({{V{"?x"}, 1}, {V{"?y"}, 1}}));
 }
 
 }  // namespace

--- a/test/VariableCounterTest.cpp
+++ b/test/VariableCounterTest.cpp
@@ -21,9 +21,9 @@ using parsedQuery::VariableCounter;
 using V = Variable;
 
 // Apply `VariableCounter` to the root graph pattern of the given SPARQL query.
-VariableCounter parseAndCount(const std::string& sparql) {
+VariableCounter parseAndCount(std::string sparql) {
   static EncodedIriManager encodedIriManager;
-  auto pq = SparqlParser::parseQuery(&encodedIriManager, sparql);
+  auto pq = SparqlParser::parseQuery(&encodedIriManager, std::move(sparql));
   VariableCounter counter;
   counter(pq._rootGraphPattern);
   return counter;

--- a/test/VariableCounterTest.cpp
+++ b/test/VariableCounterTest.cpp
@@ -137,6 +137,18 @@ TEST(VariableCounterTest, VariableCounts) {
     count(TripleComponent{V{"?x"}});
     EXPECT_THAT(count, counts({{V{"?x"}, 1}}));
   }
+
+  // `TransPath`.
+  {
+    VariableCounter count;
+    parsedQuery::TransPath tp{
+        {V{"?left"}}, {V{"?right"}}, {V{"?ileft"}}, {V{"?iright"}}, 0, 5, {}};
+    count(tp);
+    EXPECT_THAT(count, counts({{V{"?left"}, 1},
+                               {V{"?right"}, 1},
+                               {V{"?ileft"}, 1},
+                               {V{"?iright"}, 1}}));
+  }
 }
 
 // _____________________________________________________________________________


### PR DESCRIPTION
So far there was no central way to count variable occurrences in a `ParsedQuery`. There is now a utility `VariableCounter`, which is a visitor that walks the graph-pattern tree and accumulates a `HashMap<Variable, size_t>` of counts. Preparation for #2937