### PR TITLE
Accept any `InputRangeTypeErased` for `InputFileSpecification`, not just `std::vector`

### DIFF
--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -80,15 +80,16 @@ IndexBuilderDataAsFirstPermutationSorter IndexImpl::createIdTriplesAndVocab(
 
 // _____________________________________________________________________________
 std::unique_ptr<RdfParserBase> IndexImpl::makeRdfParser(
-    const std::vector<Index::InputFileSpecification>& files) const {
+    ad_utility::InputRangeTypeErased<qlever::InputFileSpecification> files)
+    const {
   AD_CONTRACT_CHECK(
       parserBufferSize().getBytes() > 0,
       "The buffer size of the RDF parser must be greater than zero");
   AD_CONTRACT_CHECK(
       memoryLimitIndexBuilding().getBytes() > 0,
       " memory limit for index building must be greater than zero");
-  return std::make_unique<RdfMultifileParser>(files, &encodedIriManager(),
-                                              parserBufferSize());
+  return std::make_unique<RdfMultifileParser>(
+      std::move(files), &encodedIriManager(), parserBufferSize());
 }
 
 // Several helper functions for joining the OSP permutation with the patterns.
@@ -376,6 +377,13 @@ void IndexImpl::updateInputFileSpecificationsAndLog(
 // _____________________________________________________________________________
 void IndexImpl::createFromFiles(
     std::vector<Index::InputFileSpecification> files) {
+  updateInputFileSpecificationsAndLog(files, useParallelParser_);
+  createFromFiles(ad_utility::InputRangeTypeErased{std::move(files)});
+}
+
+// _____________________________________________________________________________
+void IndexImpl::createFromFiles(
+    ad_utility::InputRangeTypeErased<qlever::InputFileSpecification> files) {
   if (!loadAllPermutations_ && usePatterns_) {
     throw std::runtime_error{
         "The patterns can only be built when all 6 permutations are created"};
@@ -387,9 +395,8 @@ void IndexImpl::createFromFiles(
 
   readIndexBuilderSettingsFromFile();
 
-  updateInputFileSpecificationsAndLog(files, useParallelParser_);
   IndexBuilderDataAsFirstPermutationSorter indexBuilderData =
-      createIdTriplesAndVocab(makeRdfParser(files));
+      createIdTriplesAndVocab(makeRdfParser(std::move(files)));
 
   // Write the configuration already at this point, so we have it available in
   // case any of the permutations fail.

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -40,6 +40,7 @@
 #include "util/BufferedVector.h"
 #include "util/File.h"
 #include "util/Forward.h"
+#include "util/Iterators.h"
 #include "util/MemorySize/MemorySize.h"
 #include "util/json.h"
 
@@ -239,6 +240,9 @@ class IndexImpl {
   // !! The index can not directly be used after this call, but has to be setup
   // by createFromOnDiskIndex after this call.
   void createFromFiles(std::vector<Index::InputFileSpecification> files);
+
+  void createFromFiles(
+      ad_utility::InputRangeTypeErased<qlever::InputFileSpecification> files);
 
   // Creates an index object from an on disk index that has previously been
   // constructed. Read necessary meta data into memory and opens file handles.
@@ -548,7 +552,8 @@ class IndexImpl {
   // CTRE-based relaxed parser or not, depending on the settings of the
   // corresponding member variables.
   std::unique_ptr<RdfParserBase> makeRdfParser(
-      const std::vector<Index::InputFileSpecification>& files) const;
+      ad_utility::InputRangeTypeErased<qlever::InputFileSpecification> files)
+      const;
 
   template <typename Func>
   FirstPermutationSorterAndInternalTriplesAsPso convertPartialToGlobalIds(

--- a/src/parser/RdfParser.cpp
+++ b/src/parser/RdfParser.cpp
@@ -1340,54 +1340,50 @@ std::optional<std::vector<TurtleTriple>> RdfParserBase::getBatch() {
   return result;
 }
 
+// _____________________________________________________________________________
+void RdfMultifileParser::parseFileAndPushBatches(
+    const qlever::InputFileSpecification& file,
+    ad_utility::MemorySize bufferSize) {
+  try {
+    auto parser =
+        makeSingleRdfParser<Tokenizer>(file, &encodedIriManager(), bufferSize);
+    while (auto batch = parser->getBatch()) {
+      bool active = finishedBatchQueue_.push(std::move(batch.value()));
+      if (!active) {
+        // The queue was finished prematurely; stop to avoid deadlocks.
+        return;
+      }
+    }
+  } catch (...) {
+    finishedBatchQueue_.pushException(std::current_exception());
+  }
+}
+
 // ______________________________________________________________
 RdfMultifileParser::RdfMultifileParser(
-    const std::vector<qlever::InputFileSpecification>& files,
+    ad_utility::InputRangeTypeErased<qlever::InputFileSpecification> files,
     const EncodedIriManager* encodedIriManager,
     ad_utility::MemorySize bufferSize)
     : RdfParserBase(encodedIriManager) {
-  using namespace qlever;
-
-  // This lambda parses a single file and pushes the results and all occurring
-  // exceptions to the `finishedBatchQueue_`.
-  auto parseFile = [this, encodedIriManager](
-                       const InputFileSpecification& file,
-                       ad_utility::MemorySize bufferSize) {
-    try {
-      auto parser =
-          makeSingleRdfParser<Tokenizer>(file, encodedIriManager, bufferSize);
-      while (auto batch = parser->getBatch()) {
-        bool active = finishedBatchQueue_.push(std::move(batch.value()));
-        if (!active) {
-          // The queue was finished prematurely, stop this thread. This is
-          // important to avoid deadlocks.
-          return;
-        }
-      }
-    } catch (...) {
-      finishedBatchQueue_.pushException(std::current_exception());
-    }
-  };
-
   // Feed all the input files to the `parsingQueue_`.
-  auto makeParsers = [files, bufferSize, this, parseFile]() {
-    for (const auto& file : files) {
-      bool active =
-          parsingQueue_.push(absl::bind_front(parseFile, file, bufferSize));
+  auto makeParsers = [files = std::move(files), bufferSize, this]() mutable {
+    for (auto& file : files) {
+      bool active = parsingQueue_.push(
+          absl::bind_front(&RdfMultifileParser::parseFileAndPushBatches, this,
+                           file, bufferSize));
       if (!active) {
-        // The queue was finished prematurely, stop this thread. This is
-        // important to avoid deadlocks.
+        // The queue was finished prematurely; stop to avoid deadlocks.
         break;
       }
     }
     // Every input has been fed into the `parsingQueue_`. After the call to
     // `finish()` returns, the parsing has completed and all the results have
-    // been pushed into the `finishedBatchQueue`, which we then also finish to
+    // been pushed into the `finishedBatchQueue_`, which we then also finish to
     // inform the consuming code, that there will be no more parse results.
     parsingQueue_.finish();
     finishedBatchQueue_.finish();
   };
-  feederThread_ = ad_utility::JThread{makeParsers};
+  feederThread_ = ad_utility::JThread{std::move(makeParsers)};
 }
 
 // _____________________________________________________________________________

--- a/src/parser/RdfParser.cpp
+++ b/src/parser/RdfParser.cpp
@@ -1370,7 +1370,7 @@ RdfMultifileParser::RdfMultifileParser(
     for (auto& file : files) {
       bool active = parsingQueue_.push(
           absl::bind_front(&RdfMultifileParser::parseFileAndPushBatches, this,
-                           file, bufferSize));
+                           std::move(file), bufferSize));
       if (!active) {
         // The queue was finished prematurely; stop to avoid deadlocks.
         break;

--- a/src/parser/RdfParser.h
+++ b/src/parser/RdfParser.h
@@ -30,6 +30,7 @@
 #include "parser/data/BlankNode.h"
 #include "util/Exception.h"
 #include "util/HashMap.h"
+#include "util/Iterators.h"
 #include "util/Log.h"
 #include "util/ParseException.h"
 #include "util/TaskQueue.h"
@@ -721,10 +722,10 @@ class RdfMultifileParser : public RdfParserBase {
   explicit RdfMultifileParser(const EncodedIriManager* encodedIriManager)
       : RdfParserBase{encodedIriManager} {};
 
-  // Construct the parser from a vector of file specifications and eagerly start
-  // parsing them on background threads.
+  // Construct the parser from a type-erased input range of file specifications
+  // and eagerly start parsing them on background threads.
   RdfMultifileParser(
-      const std::vector<qlever::InputFileSpecification>& files,
+      ad_utility::InputRangeTypeErased<qlever::InputFileSpecification> files,
       const EncodedIriManager* encodedIriManager,
       ad_utility::MemorySize bufferSize = DEFAULT_PARSER_BUFFER_SIZE);
 
@@ -766,6 +767,11 @@ class RdfMultifileParser : public RdfParserBase {
 
   // A thread that feeds the file specifications to the actual parser threads.
   ad_utility::JThread feederThread_;
+
+  // Parse a single file and push all resulting triple batches (and any
+  // exception) into `finishedBatchQueue_`.
+  void parseFileAndPushBatches(const qlever::InputFileSpecification& file,
+                               ad_utility::MemorySize bufferSize);
 };
 
 #endif  // QLEVER_SRC_PARSER_RDFPARSER_H

--- a/test/RdfParserTest.cpp
+++ b/test/RdfParserTest.cpp
@@ -892,9 +892,11 @@ std::vector<TurtleTriple> parseFromFile(
     ad_utility::MemorySize bufferSize = 1_kB) {
   auto parser = [&]() {
     if constexpr (ad_utility::isSimilar<Parser, RdfMultifileParser>) {
-      return Parser{{{filename, qlever::Filetype::Turtle, std::nullopt}},
-                    encodedIriManager(),
-                    bufferSize};
+      return Parser{
+          ad_utility::InputRangeTypeErased{
+              std::vector<qlever::InputFileSpecification>{
+                  {filename, qlever::Filetype::Turtle, std::nullopt}}},
+          encodedIriManager(), bufferSize};
     } else {
       return Parser{
           std::make_unique<ParallelFileBuffer>(bufferSize.getBytes(), filename),
@@ -1239,9 +1241,11 @@ TEST(RdfParserTest, stopParsingOnOutsideFailure) {
     {
       [[maybe_unused]] Parser parserChild = [&]() {
         if constexpr (ad_utility::isSimilar<Parser, RdfMultifileParser>) {
-          return Parser{{{filename, qlever::Filetype::Turtle, std::nullopt}},
-                        encodedIriManager(),
-                        40_B};
+          return Parser{
+              ad_utility::InputRangeTypeErased{
+                  std::vector<qlever::InputFileSpecification>{
+                      {filename, qlever::Filetype::Turtle, std::nullopt}}},
+              encodedIriManager(), 40_B};
         } else {
           return Parser{std::make_unique<ParallelFileBuffer>(40, filename),
                         encodedIriManager(),
@@ -1362,7 +1366,8 @@ TEST(RdfParserTest, multifileParser) {
                        useParallelParser);
     specs.emplace_back(file2, qlever::Filetype::NQuad, "defaultGraphNQ",
                        useParallelParser);
-    Parser p{specs, encodedIriManager()};
+    Parser p{ad_utility::InputRangeTypeErased{std::move(specs)},
+             encodedIriManager()};
     std::vector<TurtleTriple> result;
     while (auto batch = p.getBatch()) {
       ql::ranges::copy(batch.value(), std::back_inserter(result));


### PR DESCRIPTION
Previously, an index could only be built from a `vector<InputFileSpecification>`, now it can be built from an arbitrary
`InputRangeTypeErased<InputFileSpecification>`. In particular, this is preparation for processing input files that are posted via HTTP; see #2365. So far, input files have to be specified upfront and there is a limit on their number that is determined by the length of the command line.