### PR TITLE
Add mode to `HttpServer` for lazy streaming of HTTP body

### DIFF
--- a/src/util/http/HttpServer.h
+++ b/src/util/http/HttpServer.h
@@ -11,6 +11,7 @@
 
 #include "util/Exception.h"
 #include "util/Log.h"
+#include "util/ThreadSafeQueue.h"
 #include "util/http/HttpUtils.h"
 #include "util/http/beast.h"
 #include "util/http/websocket/WebSocketSession.h"
@@ -23,6 +24,17 @@ using tcp = boost::asio::ip::tcp;  // from <boost/asio/ip/tcp.hpp>
 // Including the `RuntimeParameters` header is expensive. Move functions that
 // require it into an implementation file.
 ad_utility::MemorySize getRequestBodyLimit();
+
+// Selects whether an HttpServer reads the full request body into memory before
+// calling the handler (Eager) or streams it to the handler chunk by chunk
+// while sending the response (Lazy).
+enum class BodyReadMode { Eager, Lazy };
+
+// Type aliases for the lazy-mode chunk queue shared between the HTTP session
+// (producer) and the HttpBodyParallelBuffer (consumer).
+using LazyChunkQueue =
+    ad_utility::data_structures::ThreadSafeQueue<std::vector<char>>;
+using SharedLazyChunkQueue = std::shared_ptr<LazyChunkQueue>;
 
 /*
  * \brief A Simple HttpServer, based on Boost::Beast. It can be configured via
@@ -50,7 +62,8 @@ ad_utility::MemorySize getRequestBodyLimit();
  * a `net::awaitable<void>`. It is only called if the request is a valid
  * websocket upgrade request and the URL represents a valid path.
  */
-CPP_template(typename HttpHandler, typename WebSocketHandler)(
+CPP_template(BodyReadMode bodyReadMode, typename HttpHandler,
+             typename WebSocketHandler)(
     requires ad_utility::InvocableWithExactReturnType<
         WebSocketHandler, net::awaitable<void>,
         const http::request<http::string_body>&,
@@ -249,43 +262,107 @@ CPP_template(typename HttpHandler, typename WebSocketHandler)(
       // the `catch`.
       std::optional<http::response<http::string_body>> errorResponse;
 
+      // In lazy mode, the chunk queue for the current request body. Null until
+      // the lazy branch initialises it; accessible in the catch block so that
+      // network errors can be forwarded to the parser thread.
+      SharedLazyChunkQueue chunkQueue;
+
       try {
         // Set the timeout for reading the next request.
         stream.expires_after(std::chrono::seconds(30));
 
-        // Read a request. Use a parser so that we can control the limit of the
-        // request size.
-        http::request_parser<http::string_body> requestParser;
-        auto bodyLimit = getRequestBodyLimit().getBytes();
-        requestParser.body_limit(bodyLimit == 0
-                                     ? boost::none
-                                     : boost::optional<uint64_t>(bodyLimit));
-        co_await http::async_read(stream, buffer, requestParser,
-                                  boost::asio::use_awaitable);
-        http::request<http::string_body> req = requestParser.release();
+        if constexpr (bodyReadMode == BodyReadMode::Eager) {
+          // ===== EAGER MODE =====
+          // Read a request. Use a parser so that we can control the limit of
+          // the request size.
+          http::request_parser<http::string_body> requestParser;
+          auto bodyLimit = getRequestBodyLimit().getBytes();
+          requestParser.body_limit(bodyLimit == 0
+                                       ? boost::none
+                                       : boost::optional<uint64_t>(bodyLimit));
+          co_await http::async_read(stream, buffer, requestParser,
+                                    boost::asio::use_awaitable);
+          http::request<http::string_body> req = requestParser.release();
 
-        // Let request be handled by `WebSocketSession` if the HTTP
-        // request is a WebSocket handshake
-        if (beast::websocket::is_upgrade(req)) {
-          auto websocketErrorResponse = ad_utility::websocket::
-              WebSocketSession::getErrorResponseIfPathIsInvalid(req);
-          if (websocketErrorResponse.has_value()) {
-            co_await sendMessage(std::move(websocketErrorResponse.value()));
+          // Let request be handled by `WebSocketSession` if the HTTP
+          // request is a WebSocket handshake.
+          if (beast::websocket::is_upgrade(req)) {
+            auto websocketErrorResponse = ad_utility::websocket::
+                WebSocketSession::getErrorResponseIfPathIsInvalid(req);
+            if (websocketErrorResponse.has_value()) {
+              co_await sendMessage(std::move(websocketErrorResponse.value()));
+            } else {
+              // Prevent cleanup after socket has been moved from.
+              releaseConnection.cancel();
+              co_await std::invoke(webSocketHandler_, req,
+                                   std::move(stream.socket()));
+              co_return;
+            }
           } else {
-            // prevent cleanup after socket has been moved from
-            releaseConnection.cancel();
-            co_await std::invoke(webSocketHandler_, req,
-                                 std::move(stream.socket()));
-            co_return;
+            // Currently there is no timeout on the server side, this is
+            // handled by QLever's timeout mechanism.
+            stream.expires_never();
+
+            // Handle the http request. Note that `httpHandler_` is also
+            // responsible for sending the message via the `sendMessage` lambda.
+            co_await httpHandler_(std::move(req), sendMessage);
           }
         } else {
-          // Currently there is no timeout on the server side, this is handled
-          // by QLever's timeout mechanism.
-          stream.expires_never();
+          // ===== LAZY MODE =====
+          // Read only the request headers first; the body is streamed to the
+          // handler's chunk queue after the response is sent.
+          // Note: WebSocket upgrades are not supported in lazy mode.
+          http::request_parser<http::buffer_body> requestParser;
+          requestParser.body_limit(boost::none);
+          co_await http::async_read_header(stream, buffer, requestParser,
+                                           boost::asio::use_awaitable);
 
-          // Handle the http request. Note that `httpHandler_` is also
-          // responsible for sending the message via the `sendMessage` lambda.
-          co_await httpHandler_(std::move(req), sendMessage);
+          // Build a header-only request to pass to the handler.
+          http::request<http::empty_body> headersReq;
+          headersReq.method(requestParser.get().method());
+          headersReq.target(std::string(requestParser.get().target()));
+          headersReq.version(requestParser.get().version());
+          headersReq.keep_alive(requestParser.get().keep_alive());
+          for (auto const& f : requestParser.get()) {
+            headersReq.insert(f.name_string(), f.value());
+          }
+
+          // Create the chunk queue and call the handler. The handler sends
+          // the response; body bytes arrive afterwards.
+          chunkQueue = std::make_shared<LazyChunkQueue>(4);
+          stream.expires_never();
+          co_await httpHandler_(std::move(headersReq), chunkQueue, sendMessage);
+
+          // Stream the remaining body bytes into the chunk queue.
+          constexpr size_t kChunkSize = 1 << 20;  // 1 MB per chunk
+          while (!requestParser.is_done()) {
+            std::vector<char> chunk(kChunkSize);
+            requestParser.get().body().data = chunk.data();
+            requestParser.get().body().size = chunk.size();
+            boost::system::error_code ec;
+            co_await http::async_read_some(
+                stream, buffer, requestParser,
+                boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+            if (ec && ec != http::error::need_buffer) {
+              // Propagate the network error to the parser thread, then rethrow
+              // so the catch block handles connection teardown.
+              chunkQueue->pushException(
+                  std::make_exception_ptr(boost::system::system_error{ec}));
+              chunkQueue = nullptr;  // prevent double-push in catch block
+              throw boost::system::system_error{ec};
+            }
+            size_t bytesRead = kChunkSize - requestParser.get().body().size;
+            if (bytesRead > 0) {
+              chunk.resize(bytesRead);
+              // May briefly block if the queue is full (parser thread is slow),
+              // which is acceptable for InputFileServer's single-upload model.
+              chunkQueue->push(std::move(chunk));
+            }
+          }
+          chunkQueue->finish();
+          // Lazy mode always closes the connection after each request because
+          // the stream is occupied by body streaming until the body is done.
+          streamNeedsClosing = true;
         }
 
         // The closing of the stream is done in the exception handler.
@@ -293,19 +370,29 @@ CPP_template(typename HttpHandler, typename WebSocketHandler)(
           throw beast::system_error{http::error::end_of_stream};
         }
       } catch (const boost::system::system_error& error) {
+        // In lazy mode, forward unexpected network errors to the parser thread
+        // so it can terminate cleanly instead of blocking forever.
+        if constexpr (bodyReadMode == BodyReadMode::Lazy) {
+          if (chunkQueue && error.code() != http::error::end_of_stream) {
+            chunkQueue->pushException(std::current_exception());
+          }
+        }
+
         if (error.code() == http::error::end_of_stream) {
           // The stream has ended, gracefully close the connection.
           beast::error_code ec;
           stream.socket().shutdown(tcp::socket::shutdown_send, ec);
         } else if (error.code() == http::error::body_limit) {
-          errorResponse = ad_utility::httpUtils::createHttpResponseFromString(
-              absl::StrCat(
-                  "Request body size exceeds the allowed size (",
-                  getRequestBodyLimit().asString(),
-                  "), send a smaller request or set the allowed size via the ",
-                  "runtime parameter `request-body-limit`"),
-              http::status::payload_too_large, ad_utility::MediaType::textPlain,
-              std::nullopt, 11);
+          if constexpr (bodyReadMode == BodyReadMode::Eager) {
+            errorResponse = ad_utility::httpUtils::createHttpResponseFromString(
+                absl::StrCat(
+                    "Request body size exceeds the allowed size (",
+                    getRequestBodyLimit().asString(),
+                    "), send a smaller request or set the allowed size "
+                    "via the runtime parameter `request-body-limit`"),
+                http::status::payload_too_large,
+                ad_utility::MediaType::textPlain, std::nullopt, 11);
+          }
         } else {
           // This is the error "The socket was closed due to a timeout" or if
           // the client stream ended unexpectedly.
@@ -318,15 +405,25 @@ CPP_template(typename HttpHandler, typename WebSocketHandler)(
           }
         }
         // If we have an error response send it outside the `catch` block. (We
-        // can not `co_await` in the `catch` block) Otherwise close the
+        // can not `co_await` in the `catch` block.) Otherwise close the
         // session by returning.
         if (!errorResponse) {
           co_return;
         }
       } catch (const std::exception& error) {
+        if constexpr (bodyReadMode == BodyReadMode::Lazy) {
+          if (chunkQueue) {
+            chunkQueue->pushException(std::current_exception());
+          }
+        }
         AD_LOG_ERROR << error.what() << std::endl;
         co_return;
       } catch (...) {
+        if constexpr (bodyReadMode == BodyReadMode::Lazy) {
+          if (chunkQueue) {
+            chunkQueue->pushException(std::current_exception());
+          }
+        }
         AD_LOG_ERROR << "Weird exception not inheriting from std::exception, "
                         "this shouldn't happen"
                      << std::endl;
@@ -342,12 +439,13 @@ CPP_template(typename HttpHandler, typename WebSocketHandler)(
   }
 };
 
-/// Deduction guide, so you don't have to specify the types explicitly
-/// when creating an instance of this class.
+/// Deduction guide for eager mode (the default). Specify BodyReadMode::Lazy
+/// explicitly when creating a lazy-mode server.
 template <typename HttpHandler, typename WebSocketHandlerSupplier>
 HttpServer(unsigned short, const std::string&, int, HttpHandler,
            WebSocketHandlerSupplier)
-    -> HttpServer<HttpHandler, std::invoke_result_t<WebSocketHandlerSupplier,
-                                                    net::io_context&>>;
+    -> HttpServer<
+        BodyReadMode::Eager, HttpHandler,
+        std::invoke_result_t<WebSocketHandlerSupplier, net::io_context&>>;
 
 #endif  // QLEVER_HTTPSERVER_H

--- a/src/util/http/HttpServer.h
+++ b/src/util/http/HttpServer.h
@@ -8,6 +8,7 @@
 
 #include <cstdlib>
 #include <future>
+#include <span>
 
 #include "util/Exception.h"
 #include "util/Log.h"
@@ -39,9 +40,9 @@ enum class BodyReadMode { Eager, Lazy };
  * - `BodyReadMode::Eager`: `handler(http::request<http::string_body>, send)`.
  *   The full request body is read into memory before the handler is called.
  *
- * - `BodyReadMode::Lazy`: `handler(http::request<http::empty_body>, bodyGetter,
- *   send)`. Only headers are read before the handler is called. `bodyGetter` is
- *   a callable with signature `() ->
+ * - `BodyReadMode::Lazy`: `handler(http::request<http::empty_body>, send,
+ *   bodyGetter)`. Only headers are read before the handler is called.
+ *   `bodyGetter` is a callable with signature `() ->
  * net::awaitable<std::optional<std::string_view>>`. Each `co_await
  * bodyGetter()` reads the next body chunk; the returned view is valid until the
  * next call. `co_await bodyGetter()` returns `std::nullopt` when the body is
@@ -85,6 +86,9 @@ CPP_template(BodyReadMode bodyReadMode, typename HttpHandler,
   /// server will listen, as well as the HttpHandler. This constructor only
   /// initializes several member functions
   ///
+  // `lazyBodyChunkSize` is only used in `BodyReadMode::Lazy` mode: the body is
+  // read in chunks of `lazyBodyChunkSize` bytes; each chunk is filled
+  // completely before being yielded, trading latency for throughput.
   // Note: The following constraint can not be written with a single declaration
   // in the `std::enable_if_t` world, because of the following bug in GCC 11:
   // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105268
@@ -103,12 +107,6 @@ CPP_template(BodyReadMode bodyReadMode, typename HttpHandler,
                                                 HandlerSupplier
                                                     webSocketHandlerSupplier =
                                                         {},
-                                                // Only used in lazy mode: the
-                                                // body is read in chunks of
-                                                // this size; each chunk is
-                                                // filled completely before
-                                                // being yielded, trading
-                                                // latency for throughput.
                                                 size_t lazyBodyChunkSize =
                                                     1u << 20u)
       : httpHandler_{std::move(handler)},
@@ -239,21 +237,18 @@ CPP_template(BodyReadMode bodyReadMode, typename HttpHandler,
     co_return false;
   }
 
-  // Read at most `bodyLimit` bytes from `requestParser` into a string and
-  // return it. If `bodyLimit` is 0 (unlimited), at most 100'000 bytes are
-  // consumed; WebSocket upgrade requests are never that large.
-  static net::awaitable<std::string> materializeBody(
+  // Reads bytes from `requestParser` into `outputBuffer` until the buffer is
+  // full or the body is exhausted. Returns the number of bytes written.
+  // `need_buffer` (buffer segment full, more data remains) is treated as a
+  // non-error stop condition; all other errors are thrown.
+  static net::awaitable<size_t> readIntoBuffer(
       beast::tcp_stream& stream, beast::flat_buffer& buffer,
       http::request_parser<http::buffer_body>& requestParser,
-      size_t bodyLimit) {
-    const size_t effectiveLimit = (bodyLimit == 0) ? 100'000 : bodyLimit;
-    std::string result;
-    std::vector<char> chunk(std::min(effectiveLimit, size_t{4096}));
-    while (!requestParser.is_done() && result.size() < effectiveLimit) {
-      const size_t toRead =
-          std::min(effectiveLimit - result.size(), chunk.size());
-      requestParser.get().body().data = chunk.data();
-      requestParser.get().body().size = toRead;
+      std::span<char> outputBuffer) {
+    size_t totalRead = 0;
+    while (!requestParser.is_done() && totalRead < outputBuffer.size()) {
+      requestParser.get().body().data = outputBuffer.data() + totalRead;
+      requestParser.get().body().size = outputBuffer.size() - totalRead;
       boost::system::error_code ec;
       co_await http::async_read_some(
           stream, buffer, requestParser,
@@ -261,20 +256,36 @@ CPP_template(BodyReadMode bodyReadMode, typename HttpHandler,
       if (ec && ec != http::error::need_buffer) {
         throw boost::system::system_error{ec};
       }
-      const size_t bytesRead = toRead - requestParser.get().body().size;
+      totalRead +=
+          (outputBuffer.size() - totalRead) - requestParser.get().body().size;
+      // `need_buffer` means the buffer segment is full; stop here.
+      if (ec == http::error::need_buffer) break;
+    }
+    co_return totalRead;
+  }
+
+  // Reads at most `bodyLimit` bytes from `requestParser` into a string and
+  // returns it.
+  static net::awaitable<std::string> materializeBody(
+      beast::tcp_stream& stream, beast::flat_buffer& buffer,
+      http::request_parser<http::buffer_body>& requestParser,
+      size_t bodyLimit) {
+    std::string result;
+    std::vector<char> chunk(std::min(bodyLimit, size_t{4096}));
+    while (!requestParser.is_done() && result.size() < bodyLimit) {
+      const size_t toRead = std::min(bodyLimit - result.size(), chunk.size());
+      const size_t bytesRead = co_await readIntoBuffer(
+          stream, buffer, requestParser, std::span<char>{chunk.data(), toRead});
       result.append(chunk.data(), bytesRead);
+      if (bytesRead == 0) break;
     }
     co_return result;
   }
 
-  // Callable passed to the lazy-mode `httpHandler_` as `bodyGetter`. Each
-  // call to `operator()` starts a fresh coroutine that reads the next body
-  // chunk (up to `chunkSize_` bytes) into `chunkBuffer_` and returns a
-  // `string_view` into it, or `nullopt` when the body is exhausted. The
-  // members are templated so that concrete types are deduced at the call
-  // site. `operator()` is not itself a coroutine; it immediately invokes a
-  // capture-free coroutine lambda with the members as arguments, avoiding
-  // an ICE in GCC 11 triggered by coroutine lambdas that have captures.
+  // Callable passed to the lazy-mode `httpHandler_` as `bodyGetter`. Holds
+  // references to the stream state; `operator()` reads the next body chunk
+  // (up to `chunkSize_` bytes) into `chunkBuffer_` and returns a `string_view`
+  // into it, or `nullopt` when the body is exhausted.
   template <typename Stream, typename Buffer, typename RequestParser,
             typename ChunkBuffer>
   struct BodyChunkReader {
@@ -285,35 +296,11 @@ CPP_template(BodyReadMode bodyReadMode, typename HttpHandler,
     size_t chunkSize_;
 
     net::awaitable<std::optional<std::string_view>> operator()() {
-      return [](auto& stream, auto& buffer, auto& requestParser,
-                auto& chunkBuffer, size_t chunkSize)
-                 -> net::awaitable<std::optional<std::string_view>> {
-        size_t totalBytesRead = 0;
-        while (!requestParser.is_done() && totalBytesRead < chunkSize) {
-          requestParser.get().body().data = chunkBuffer.data() + totalBytesRead;
-          requestParser.get().body().size = chunkSize - totalBytesRead;
-          boost::system::error_code ec;
-          // `need_buffer` is returned when the provided buffer segment is
-          // completely full but more body data remains; it is not a real error.
-          co_await http::async_read_some(
-              stream, buffer, requestParser,
-              boost::asio::redirect_error(boost::asio::use_awaitable, ec));
-          if (ec && ec != http::error::need_buffer) {
-            throw boost::system::system_error{ec};
-          }
-          size_t bytesRead =
-              (chunkSize - totalBytesRead) - requestParser.get().body().size;
-          totalBytesRead += bytesRead;
-          if (ec == http::error::need_buffer) {
-            // Buffer segment is full; yield what we have.
-            break;
-          }
-        }
-        if (totalBytesRead > 0) {
-          co_return std::string_view{chunkBuffer.data(), totalBytesRead};
-        }
-        co_return std::nullopt;
-      }(stream_, buffer_, requestParser_, chunkBuffer_, chunkSize_);
+      const size_t bytesRead = co_await HttpServer::readIntoBuffer(
+          stream_, buffer_, requestParser_,
+          std::span<char>{chunkBuffer_.data(), chunkSize_});
+      if (bytesRead == 0) co_return std::nullopt;
+      co_return std::string_view{chunkBuffer_.data(), bytesRead};
     }
   };
 
@@ -341,8 +328,13 @@ CPP_template(BodyReadMode bodyReadMode, typename HttpHandler,
         ad_utility::httpUtils::getHeaderOnlyRequest(requestParser.get());
 
     if (beast::websocket::is_upgrade(headersReq)) {
-      std::string body = co_await materializeBody(
-          stream, buffer, requestParser, getRequestBodyLimit().getBytes());
+      static constexpr size_t kMaxWebSocketBodyBytes = 100'000;
+      const size_t configLimit = getRequestBodyLimit().getBytes();
+      const size_t wsBodyLimit =
+          std::min(configLimit != 0 ? configLimit : kMaxWebSocketBodyBytes,
+                   kMaxWebSocketBodyBytes);
+      std::string body =
+          co_await materializeBody(stream, buffer, requestParser, wsBodyLimit);
       auto stringReq = ad_utility::httpUtils::getStringBodyRequest(
           headersReq, std::move(body));
       co_await handleWebsocketUpgrade(stream, stringReq, sendMessage,
@@ -355,18 +347,13 @@ CPP_template(BodyReadMode bodyReadMode, typename HttpHandler,
     const size_t chunkSize = lazyBodyChunkSize_;
     std::vector<char> chunkBuffer(chunkSize);
 
-    // Yields up to `chunkSize` bytes from the request body as a `string_view`
-    // into `chunkBuffer`, or `nullopt` when the body is exhausted. Each chunk
-    // is filled completely before being returned (except possibly the last).
-    // `BodyChunkReader` avoids captures inside a coroutine context (which
-    // trigger an ICE in GCC 11) by holding state as reference members and
-    // invoking a capture-free coroutine lambda from `operator()`.
+    // `bodyGetter` yields body chunks; see `BodyChunkReader`.
     BodyChunkReader bodyGetter{stream, buffer, requestParser, chunkBuffer,
                                chunkSize};
 
     stream.expires_never();
-    co_await httpHandler_(std::move(headersReq), std::move(bodyGetter),
-                          sendMessage);
+    co_await httpHandler_(std::move(headersReq), sendMessage,
+                          std::move(bodyGetter));
     co_return false;
   }
 
@@ -460,8 +447,11 @@ CPP_template(BodyReadMode bodyReadMode, typename HttpHandler,
           bool shouldExit = co_await handleLazyRequest(
               stream, buffer, sendMessage, releaseConnection);
           if (shouldExit) co_return;
-          // Non-WebSocket lazy requests always close the connection since body
-          // consumption by the handler is not guaranteed.
+          // Reusing the stream for keep-alive is only safe if the full request
+          // body has been consumed. In lazy mode the handler controls body
+          // consumption, so we cannot guarantee it. This could be improved in
+          // the future by draining any remaining body bytes after the handler
+          // returns.
           streamNeedsClosing = true;
         }
 

--- a/src/util/http/HttpServer.h
+++ b/src/util/http/HttpServer.h
@@ -11,7 +11,6 @@
 
 #include "util/Exception.h"
 #include "util/Log.h"
-#include "util/ThreadSafeQueue.h"
 #include "util/http/HttpUtils.h"
 #include "util/http/beast.h"
 #include "util/http/websocket/WebSocketSession.h"
@@ -30,29 +29,27 @@ ad_utility::MemorySize getRequestBodyLimit();
 // while sending the response (Lazy).
 enum class BodyReadMode { Eager, Lazy };
 
-// Type aliases for the lazy-mode chunk queue shared between the HTTP session
-// (producer) and the HttpBodyParallelBuffer (consumer).
-using LazyChunkQueue =
-    ad_utility::data_structures::ThreadSafeQueue<std::vector<char>>;
-using SharedLazyChunkQueue = std::shared_ptr<LazyChunkQueue>;
-
 /*
  * \brief A Simple HttpServer, based on Boost::Beast. It can be configured via
  * the mandatory HttpHandler parameter.
  *
- * \tparam HttpHandler A callable type that takes two parameters, a
- * `http::request<...>` , and a `sendAction` and returns an awaitable<void>
- * type. sendAction always is a callable that takes a http::message, and returns
- * an awaitable<void>.
+ * \tparam HttpHandler A callable returning `net::awaitable<void>`. Its
+ * signature depends on `bodyReadMode`:
  *
- * The behavior is then as follows: as soon as the server receives a HTTP
- * request, co_await httpHandler_(move(request), sendAction) is called.
- * (httpHandler_ is a member of type HttpHandler). The expected behavior of this
- * call is that httpHandler_ takes the request, computes the corresponding
- * `response`, and calls co_await sendAction(response). The `sendAction` is
- * needed because the `response` can have different types (in beast, a
- * http::message is templated on the body type). For this reason, this approach
- * is more flexible, than having httpHandler_ simply return the response.
+ * - `BodyReadMode::Eager`: `handler(http::request<http::string_body>, send)`.
+ *   The full request body is read into memory before the handler is called.
+ *
+ * - `BodyReadMode::Lazy`: `handler(http::request<http::empty_body>, bodyGetter,
+ *   send)`. Only headers are read before the handler is called. `bodyGetter` is
+ *   a callable with signature `() ->
+ * net::awaitable<std::optional<std::string_view>>`. Each `co_await
+ * bodyGetter()` reads the next body chunk; the returned view is valid until the
+ * next call. `co_await bodyGetter()` returns `std::nullopt` when the body is
+ * fully consumed and throws on network errors.
+ *
+ * In both modes `send` is a callable that takes a `http::message` and returns
+ * `net::awaitable<void>`; the handler is responsible for sending the response
+ * via `co_await send(response)`.
  *
  * A very basic HttpHandler, which simply serves files from a directory, can be
  * obtained via `ad_utility::httpUtils::makeFileServer()`.
@@ -262,11 +259,6 @@ CPP_template(BodyReadMode bodyReadMode, typename HttpHandler,
       // the `catch`.
       std::optional<http::response<http::string_body>> errorResponse;
 
-      // In lazy mode, the chunk queue for the current request body. Null until
-      // the lazy branch initialises it; accessible in the catch block so that
-      // network errors can be forwarded to the parser thread.
-      SharedLazyChunkQueue chunkQueue;
-
       try {
         // Set the timeout for reading the next request.
         stream.expires_after(std::chrono::seconds(30));
@@ -309,8 +301,11 @@ CPP_template(BodyReadMode bodyReadMode, typename HttpHandler,
           }
         } else {
           // ===== LAZY MODE =====
-          // Read only the request headers first; the body is streamed to the
-          // handler's chunk queue after the response is sent.
+          // Read only the request headers; the body is delivered to the handler
+          // chunk by chunk via a `bodyGetter` callable. Each `co_await` of
+          // `bodyGetter()` reads the next chunk from the socket into a buffer
+          // whose lifetime is tied to this coroutine frame. The returned
+          // `string_view` is valid only until the next call to `bodyGetter()`.
           // Note: WebSocket upgrades are not supported in lazy mode.
           http::request_parser<http::buffer_body> requestParser;
           requestParser.body_limit(boost::none);
@@ -327,39 +322,38 @@ CPP_template(BodyReadMode bodyReadMode, typename HttpHandler,
             headersReq.insert(f.name_string(), f.value());
           }
 
-          // Create the chunk queue and call the handler. The handler sends
-          // the response; body bytes arrive afterwards.
-          chunkQueue = std::make_shared<LazyChunkQueue>(4);
-          stream.expires_never();
-          co_await httpHandler_(std::move(headersReq), chunkQueue, sendMessage);
+          // Buffer for body chunks. Lives in this coroutine frame, so its
+          // lifetime covers the entire handler invocation.
+          constexpr size_t kChunkSize = 1 << 20;  // 1 MB per chunk.
+          std::vector<char> chunkBuffer(kChunkSize);
 
-          // Stream the remaining body bytes into the chunk queue.
-          constexpr size_t kChunkSize = 1 << 20;  // 1 MB per chunk
-          while (!requestParser.is_done()) {
-            std::vector<char> chunk(kChunkSize);
-            requestParser.get().body().data = chunk.data();
-            requestParser.get().body().size = chunk.size();
-            boost::system::error_code ec;
-            co_await http::async_read_some(
-                stream, buffer, requestParser,
-                boost::asio::redirect_error(boost::asio::use_awaitable, ec));
-            if (ec && ec != http::error::need_buffer) {
-              // Propagate the network error to the parser thread, then rethrow
-              // so the catch block handles connection teardown.
-              chunkQueue->pushException(
-                  std::make_exception_ptr(boost::system::system_error{ec}));
-              chunkQueue = nullptr;  // prevent double-push in catch block
-              throw boost::system::system_error{ec};
+          // Callable that reads the next body chunk into `chunkBuffer` and
+          // returns a view into it. Returns `nullopt` when the body is fully
+          // consumed. Throws `boost::system::system_error` on network error.
+          // The returned view is valid only until the next invocation.
+          auto bodyGetter =
+              [&]() -> net::awaitable<std::optional<std::string_view>> {
+            while (!requestParser.is_done()) {
+              requestParser.get().body().data = chunkBuffer.data();
+              requestParser.get().body().size = chunkBuffer.size();
+              boost::system::error_code ec;
+              co_await http::async_read_some(
+                  stream, buffer, requestParser,
+                  boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+              if (ec && ec != http::error::need_buffer) {
+                throw boost::system::system_error{ec};
+              }
+              size_t bytesRead = kChunkSize - requestParser.get().body().size;
+              if (bytesRead > 0) {
+                co_return std::string_view{chunkBuffer.data(), bytesRead};
+              }
             }
-            size_t bytesRead = kChunkSize - requestParser.get().body().size;
-            if (bytesRead > 0) {
-              chunk.resize(bytesRead);
-              // May briefly block if the queue is full (parser thread is slow),
-              // which is acceptable for InputFileServer's single-upload model.
-              chunkQueue->push(std::move(chunk));
-            }
-          }
-          chunkQueue->finish();
+            co_return std::nullopt;
+          };
+
+          stream.expires_never();
+          co_await httpHandler_(std::move(headersReq), std::move(bodyGetter),
+                                sendMessage);
           // Lazy mode always closes the connection after each request because
           // the stream is occupied by body streaming until the body is done.
           streamNeedsClosing = true;
@@ -370,14 +364,6 @@ CPP_template(BodyReadMode bodyReadMode, typename HttpHandler,
           throw beast::system_error{http::error::end_of_stream};
         }
       } catch (const boost::system::system_error& error) {
-        // In lazy mode, forward unexpected network errors to the parser thread
-        // so it can terminate cleanly instead of blocking forever.
-        if constexpr (bodyReadMode == BodyReadMode::Lazy) {
-          if (chunkQueue && error.code() != http::error::end_of_stream) {
-            chunkQueue->pushException(std::current_exception());
-          }
-        }
-
         if (error.code() == http::error::end_of_stream) {
           // The stream has ended, gracefully close the connection.
           beast::error_code ec;
@@ -411,19 +397,9 @@ CPP_template(BodyReadMode bodyReadMode, typename HttpHandler,
           co_return;
         }
       } catch (const std::exception& error) {
-        if constexpr (bodyReadMode == BodyReadMode::Lazy) {
-          if (chunkQueue) {
-            chunkQueue->pushException(std::current_exception());
-          }
-        }
         AD_LOG_ERROR << error.what() << std::endl;
         co_return;
       } catch (...) {
-        if constexpr (bodyReadMode == BodyReadMode::Lazy) {
-          if (chunkQueue) {
-            chunkQueue->pushException(std::current_exception());
-          }
-        }
         AD_LOG_ERROR << "Weird exception not inheriting from std::exception, "
                         "this shouldn't happen"
                      << std::endl;

--- a/src/util/http/HttpServer.h
+++ b/src/util/http/HttpServer.h
@@ -267,6 +267,56 @@ CPP_template(BodyReadMode bodyReadMode, typename HttpHandler,
     co_return result;
   }
 
+  // Callable passed to the lazy-mode `httpHandler_` as `bodyGetter`. Each
+  // call to `operator()` starts a fresh coroutine that reads the next body
+  // chunk (up to `chunkSize_` bytes) into `chunkBuffer_` and returns a
+  // `string_view` into it, or `nullopt` when the body is exhausted. The
+  // members are templated so that concrete types are deduced at the call
+  // site. `operator()` is not itself a coroutine; it immediately invokes a
+  // capture-free coroutine lambda with the members as arguments, avoiding
+  // an ICE in GCC 11 triggered by coroutine lambdas that have captures.
+  template <typename Stream, typename Buffer, typename RequestParser,
+            typename ChunkBuffer>
+  struct BodyChunkReader {
+    Stream& stream_;
+    Buffer& buffer_;
+    RequestParser& requestParser_;
+    ChunkBuffer& chunkBuffer_;
+    size_t chunkSize_;
+
+    net::awaitable<std::optional<std::string_view>> operator()() {
+      return [](auto& stream, auto& buffer, auto& requestParser,
+                auto& chunkBuffer, size_t chunkSize)
+                 -> net::awaitable<std::optional<std::string_view>> {
+        size_t totalBytesRead = 0;
+        while (!requestParser.is_done() && totalBytesRead < chunkSize) {
+          requestParser.get().body().data = chunkBuffer.data() + totalBytesRead;
+          requestParser.get().body().size = chunkSize - totalBytesRead;
+          boost::system::error_code ec;
+          // `need_buffer` is returned when the provided buffer segment is
+          // completely full but more body data remains; it is not a real error.
+          co_await http::async_read_some(
+              stream, buffer, requestParser,
+              boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+          if (ec && ec != http::error::need_buffer) {
+            throw boost::system::system_error{ec};
+          }
+          size_t bytesRead =
+              (chunkSize - totalBytesRead) - requestParser.get().body().size;
+          totalBytesRead += bytesRead;
+          if (ec == http::error::need_buffer) {
+            // Buffer segment is full; yield what we have.
+            break;
+          }
+        }
+        if (totalBytesRead > 0) {
+          co_return std::string_view{chunkBuffer.data(), totalBytesRead};
+        }
+        co_return std::nullopt;
+      }(stream_, buffer_, requestParser_, chunkBuffer_, chunkSize_);
+    }
+  };
+
   // Handle one lazy-mode request: read only the headers, then check for a
   // WebSocket upgrade or pass a `bodyGetter` callable to `httpHandler_`.
   // For WebSocket upgrades the remaining body is materialized and
@@ -308,42 +358,11 @@ CPP_template(BodyReadMode bodyReadMode, typename HttpHandler,
     // Yields up to `chunkSize` bytes from the request body as a `string_view`
     // into `chunkBuffer`, or `nullopt` when the body is exhausted. Each chunk
     // is filled completely before being returned (except possibly the last).
-    // The outer lambda is a plain factory (not a coroutine itself); the inner
-    // lambda is the coroutine and receives all state as arguments rather than
-    // captures, avoiding captures inside a coroutine context.
-    auto bodyGetter =
-        [&stream, &buffer, &requestParser, &chunkBuffer,
-         chunkSize]() -> net::awaitable<std::optional<std::string_view>> {
-      return [](auto& stream, auto& buffer, auto& requestParser,
-                auto& chunkBuffer, size_t chunkSize)
-                 -> net::awaitable<std::optional<std::string_view>> {
-        size_t totalBytesRead = 0;
-        while (!requestParser.is_done() && totalBytesRead < chunkSize) {
-          requestParser.get().body().data = chunkBuffer.data() + totalBytesRead;
-          requestParser.get().body().size = chunkSize - totalBytesRead;
-          boost::system::error_code ec;
-          // `need_buffer` is returned when the provided buffer segment is
-          // completely full but more body data remains; it is not a real error.
-          co_await http::async_read_some(
-              stream, buffer, requestParser,
-              boost::asio::redirect_error(boost::asio::use_awaitable, ec));
-          if (ec && ec != http::error::need_buffer) {
-            throw boost::system::system_error{ec};
-          }
-          size_t bytesRead =
-              (chunkSize - totalBytesRead) - requestParser.get().body().size;
-          totalBytesRead += bytesRead;
-          if (ec == http::error::need_buffer) {
-            // Buffer segment is full; yield what we have.
-            break;
-          }
-        }
-        if (totalBytesRead > 0) {
-          co_return std::string_view{chunkBuffer.data(), totalBytesRead};
-        }
-        co_return std::nullopt;
-      }(stream, buffer, requestParser, chunkBuffer, chunkSize);
-    };
+    // `BodyChunkReader` avoids captures inside a coroutine context (which
+    // trigger an ICE in GCC 11) by holding state as reference members and
+    // invoking a capture-free coroutine lambda from `operator()`.
+    BodyChunkReader bodyGetter{stream, buffer, requestParser, chunkBuffer,
+                               chunkSize};
 
     stream.expires_never();
     co_await httpHandler_(std::move(headersReq), std::move(bodyGetter),

--- a/src/util/http/HttpServer.h
+++ b/src/util/http/HttpServer.h
@@ -302,6 +302,15 @@ CPP_template(BodyReadMode bodyReadMode, typename HttpHandler,
     ChunkBuffer& chunkBuffer_;
     size_t chunkSize_;
 
+    BodyChunkReader(Stream& stream, Buffer& buffer,
+                    RequestParser& requestParser, ChunkBuffer& chunkBuffer,
+                    size_t chunkSize)
+        : stream_(stream),
+          buffer_(buffer),
+          requestParser_(requestParser),
+          chunkBuffer_(chunkBuffer),
+          chunkSize_(chunkSize) {}
+
     net::awaitable<std::optional<std::string_view>> operator()() {
       return [](auto& stream, auto& buffer, auto& requestParser,
                 auto& chunkBuffer, size_t chunkSize)
@@ -314,6 +323,17 @@ CPP_template(BodyReadMode bodyReadMode, typename HttpHandler,
       }(stream_, buffer_, requestParser_, chunkBuffer_, chunkSize_);
     }
   };
+
+  // Factory for `BodyChunkReader` using function template argument deduction,
+  // avoiding CTAD for a nested class template (broken in clang < 18).
+  template <typename Stream, typename Buffer, typename RequestParser,
+            typename ChunkBuffer>
+  static auto makeBodyChunkReader(Stream& stream, Buffer& buffer,
+                                  RequestParser& requestParser,
+                                  ChunkBuffer& chunkBuffer, size_t chunkSize) {
+    return BodyChunkReader<Stream, Buffer, RequestParser, ChunkBuffer>{
+        stream, buffer, requestParser, chunkBuffer, chunkSize};
+  }
 
   // Handle one lazy-mode request: read only the headers, then check for a
   // WebSocket upgrade or pass a `bodyGetter` callable to `httpHandler_`.
@@ -359,8 +379,8 @@ CPP_template(BodyReadMode bodyReadMode, typename HttpHandler,
     std::vector<char> chunkBuffer(chunkSize);
 
     // `bodyGetter` yields body chunks; see `BodyChunkReader`.
-    BodyChunkReader bodyGetter{stream, buffer, requestParser, chunkBuffer,
-                               chunkSize};
+    auto bodyGetter = makeBodyChunkReader(stream, buffer, requestParser,
+                                          chunkBuffer, chunkSize);
 
     stream.expires_never();
     co_await httpHandler_(std::move(headersReq), sendMessage,

--- a/src/util/http/HttpServer.h
+++ b/src/util/http/HttpServer.h
@@ -241,6 +241,7 @@ CPP_template(BodyReadMode bodyReadMode, typename HttpHandler,
     co_return SessionControl::Continue;
   }
 
+ public:
   // Reads bytes from `requestParser` into `outputBuffer` until the buffer is
   // full or the body is exhausted. Returns the number of bytes written.
   // `need_buffer` (buffer segment full, more data remains) is treated as a
@@ -301,6 +302,7 @@ CPP_template(BodyReadMode bodyReadMode, typename HttpHandler,
     }(stream, buffer, requestParser, bodyLimit);
   }
 
+ private:
   // Callable passed to the lazy-mode `httpHandler_` as `bodyGetter`. Holds
   // references to the stream state; `operator()` reads the next body chunk
   // (up to `chunkSize_` bytes) into `chunkBuffer_` and returns a `string_view`

--- a/src/util/http/HttpServer.h
+++ b/src/util/http/HttpServer.h
@@ -67,11 +67,15 @@ CPP_template(BodyReadMode bodyReadMode, typename HttpHandler,
         const http::request<http::string_body>&,
         tcp::socket>) class HttpServer {
  private:
+  // Returned by `handleEagerRequest` and `handleLazyRequest` to indicate
+  // whether the session loop should close the connection after this request.
+  enum class SessionControl { Continue, Close };
+
   HttpHandler httpHandler_;
   int numServerThreads_;
   net::io_context ioContext_;
   WebSocketHandler webSocketHandler_;
-  size_t lazyBodyChunkSize_;
+  ad_utility::MemorySize lazyBodyChunkSize_;
   // All code that uses the `acceptor_` must run within this strand.
   // Note that the `acceptor_` might be concurrently accessed by the `listener`
   // and the `shutdown` function, the latter of which is currently only used in
@@ -107,8 +111,10 @@ CPP_template(BodyReadMode bodyReadMode, typename HttpHandler,
                                                 HandlerSupplier
                                                     webSocketHandlerSupplier =
                                                         {},
-                                                size_t lazyBodyChunkSize =
-                                                    1u << 20u)
+                                                ad_utility::MemorySize
+                                                    lazyBodyChunkSize =
+                                                        ad_utility::MemorySize::
+                                                            megabytes(1))
       : httpHandler_{std::move(handler)},
         // We need at least two threads to avoid blocking.
         // TODO<joka921> why is that?
@@ -209,13 +215,12 @@ CPP_template(BodyReadMode bodyReadMode, typename HttpHandler,
 
   // Handle one eager-mode request: read the full body, then dispatch to
   // `httpHandler_` (or `handleWebsocketUpgrade` for WebSocket upgrades).
-  // Returns true when the session should exit (WebSocket was handled), false
-  // when the session should continue accepting further requests.
+  // Returns `SessionControl::Close` when the session should exit (WebSocket was
+  // handled), `SessionControl::Continue` otherwise.
   template <typename SendMessage, typename ReleaseConnection>
-  net::awaitable<bool> handleEagerRequest(beast::tcp_stream& stream,
-                                          beast::flat_buffer& buffer,
-                                          SendMessage& sendMessage,
-                                          ReleaseConnection& releaseConnection)
+  net::awaitable<SessionControl> handleEagerRequest(
+      beast::tcp_stream& stream, beast::flat_buffer& buffer,
+      SendMessage& sendMessage, ReleaseConnection& releaseConnection)
       requires(bodyReadMode == BodyReadMode::Eager) {
     http::request_parser<http::string_body> requestParser;
     auto bodyLimit = getRequestBodyLimit().getBytes();
@@ -228,19 +233,24 @@ CPP_template(BodyReadMode bodyReadMode, typename HttpHandler,
     if (beast::websocket::is_upgrade(req)) {
       co_await handleWebsocketUpgrade(stream, req, sendMessage,
                                       releaseConnection);
-      co_return true;
+      co_return SessionControl::Close;
     }
     // Currently there is no timeout on the server side, this is handled by
     // QLever's timeout mechanism.
     stream.expires_never();
     co_await httpHandler_(std::move(req), sendMessage);
-    co_return false;
+    co_return SessionControl::Continue;
   }
 
   // Reads bytes from `requestParser` into `outputBuffer` until the buffer is
   // full or the body is exhausted. Returns the number of bytes written.
   // `need_buffer` (buffer segment full, more data remains) is treated as a
   // non-error stop condition; all other errors are thrown.
+  //
+  // The outer function is a non-coroutine factory that returns an
+  // immediately-invoked coroutine lambda. This pattern works around a GCC 11
+  // internal compiler error (ICE) that occurs when a `static` member function
+  // is itself a coroutine and calls another coroutine `static` member function.
   static net::awaitable<size_t> readIntoBuffer(
       beast::tcp_stream& stream, beast::flat_buffer& buffer,
       http::request_parser<http::buffer_body>& requestParser,
@@ -269,6 +279,9 @@ CPP_template(BodyReadMode bodyReadMode, typename HttpHandler,
 
   // Reads at most `bodyLimit` bytes from `requestParser` into a string and
   // returns it.
+  //
+  // Uses the same IIFE factory pattern as `readIntoBuffer` to avoid a GCC 11
+  // ICE (see comment there for details).
   static net::awaitable<std::string> materializeBody(
       beast::tcp_stream& stream, beast::flat_buffer& buffer,
       http::request_parser<http::buffer_body>& requestParser,
@@ -293,6 +306,10 @@ CPP_template(BodyReadMode bodyReadMode, typename HttpHandler,
   // references to the stream state; `operator()` reads the next body chunk
   // (up to `chunkSize_` bytes) into `chunkBuffer_` and returns a `string_view`
   // into it, or `nullopt` when the body is exhausted.
+  //
+  // `operator()` cannot be implemented as a nested coroutine lambda because
+  // that triggers the same GCC 11 ICE described in `readIntoBuffer`. The
+  // IIFE factory pattern is used instead.
   template <typename Stream, typename Buffer, typename RequestParser,
             typename ChunkBuffer>
   struct BodyChunkReader {
@@ -338,20 +355,24 @@ CPP_template(BodyReadMode bodyReadMode, typename HttpHandler,
   // Handle one lazy-mode request: read only the headers, then check for a
   // WebSocket upgrade or pass a `bodyGetter` callable to `httpHandler_`.
   // For WebSocket upgrades the remaining body is materialized and
-  // `handleWebsocketUpgrade` is called; returns `true` so the caller exits
-  // the session loop. For normal requests each `co_await bodyGetter()` reads
-  // the next chunk (up to `lazyBodyChunkSize_` bytes) into a buffer that
-  // lives in this function's stack frame and returns a `string_view` into it;
-  // the view is valid only until the next call; `nullopt` signals end-of-body;
-  // throws on network errors. Returns `false` for normal requests.
+  // `handleWebsocketUpgrade` is called; returns `SessionControl::Close` so the
+  // caller exits the session loop. For normal requests each
+  // `co_await bodyGetter()` reads the next chunk (up to `lazyBodyChunkSize_`
+  // bytes) into a buffer that lives in this function's stack frame and returns
+  // a `string_view` into it; the view is valid only until the next call;
+  // `nullopt` signals end-of-body; throws on network errors. Returns
+  // `SessionControl::Continue` for normal requests.
   template <typename SendMessage, typename ReleaseConnection>
-  net::awaitable<bool> handleLazyRequest(beast::tcp_stream& stream,
-                                         beast::flat_buffer& buffer,
-                                         SendMessage& sendMessage,
-                                         ReleaseConnection& releaseConnection)
+  net::awaitable<SessionControl> handleLazyRequest(
+      beast::tcp_stream& stream, beast::flat_buffer& buffer,
+      SendMessage& sendMessage, ReleaseConnection& releaseConnection)
       requires(bodyReadMode == BodyReadMode::Lazy) {
     http::request_parser<http::buffer_body> requestParser;
-    requestParser.body_limit(boost::none);
+    // Apply the configured body limit (same as eager mode) to guard against
+    // excessively large requests.
+    const auto bodyLimit = getRequestBodyLimit().getBytes();
+    requestParser.body_limit(
+        bodyLimit == 0 ? boost::none : boost::optional<uint64_t>(bodyLimit));
     co_await http::async_read_header(stream, buffer, requestParser,
                                      boost::asio::use_awaitable);
 
@@ -359,23 +380,23 @@ CPP_template(BodyReadMode bodyReadMode, typename HttpHandler,
         ad_utility::httpUtils::getHeaderOnlyRequest(requestParser.get());
 
     if (beast::websocket::is_upgrade(headersReq)) {
-      static constexpr size_t kMaxWebSocketBodyBytes = 100'000;
-      const size_t configLimit = getRequestBodyLimit().getBytes();
-      const size_t wsBodyLimit =
-          std::min(configLimit != 0 ? configLimit : kMaxWebSocketBodyBytes,
-                   kMaxWebSocketBodyBytes);
+      static constexpr size_t maxWebSocketBodyBytes = 100'000;
+      const size_t configBodyLimit = getRequestBodyLimit().getBytes();
+      const size_t wsBodyLimit = std::min(
+          configBodyLimit != 0 ? configBodyLimit : maxWebSocketBodyBytes,
+          maxWebSocketBodyBytes);
       std::string body =
           co_await materializeBody(stream, buffer, requestParser, wsBodyLimit);
       auto stringReq = ad_utility::httpUtils::getStringBodyRequest(
           headersReq, std::move(body));
       co_await handleWebsocketUpgrade(stream, stringReq, sendMessage,
                                       releaseConnection);
-      co_return true;
+      co_return SessionControl::Close;
     }
 
     // Buffer for body chunks; its lifetime covers the entire handler
     // invocation.
-    const size_t chunkSize = lazyBodyChunkSize_;
+    const size_t chunkSize = lazyBodyChunkSize_.getBytes();
     std::vector<char> chunkBuffer(chunkSize);
 
     // `bodyGetter` yields body chunks; see `BodyChunkReader`.
@@ -385,7 +406,7 @@ CPP_template(BodyReadMode bodyReadMode, typename HttpHandler,
     stream.expires_never();
     co_await httpHandler_(std::move(headersReq), sendMessage,
                           std::move(bodyGetter));
-    co_return false;
+    co_return SessionControl::Continue;
   }
 
   // The loop which accepts TCP connections and delegates their handling
@@ -471,13 +492,13 @@ CPP_template(BodyReadMode bodyReadMode, typename HttpHandler,
         stream.expires_after(std::chrono::seconds(30));
 
         if constexpr (bodyReadMode == BodyReadMode::Eager) {
-          bool shouldExit = co_await handleEagerRequest(
+          auto control = co_await handleEagerRequest(
               stream, buffer, sendMessage, releaseConnection);
-          if (shouldExit) co_return;
+          if (control == SessionControl::Close) co_return;
         } else {
-          bool shouldExit = co_await handleLazyRequest(
-              stream, buffer, sendMessage, releaseConnection);
-          if (shouldExit) co_return;
+          auto control = co_await handleLazyRequest(stream, buffer, sendMessage,
+                                                    releaseConnection);
+          if (control == SessionControl::Close) co_return;
           // Reusing the stream for keep-alive is only safe if the full request
           // body has been consumed. In lazy mode the handler controls body
           // consumption, so we cannot guarantee it. This could be improved in

--- a/src/util/http/HttpServer.h
+++ b/src/util/http/HttpServer.h
@@ -245,23 +245,26 @@ CPP_template(BodyReadMode bodyReadMode, typename HttpHandler,
       beast::tcp_stream& stream, beast::flat_buffer& buffer,
       http::request_parser<http::buffer_body>& requestParser,
       std::span<char> outputBuffer) {
-    size_t totalRead = 0;
-    while (!requestParser.is_done() && totalRead < outputBuffer.size()) {
-      requestParser.get().body().data = outputBuffer.data() + totalRead;
-      requestParser.get().body().size = outputBuffer.size() - totalRead;
-      boost::system::error_code ec;
-      co_await http::async_read_some(
-          stream, buffer, requestParser,
-          boost::asio::redirect_error(boost::asio::use_awaitable, ec));
-      if (ec && ec != http::error::need_buffer) {
-        throw boost::system::system_error{ec};
+    return [](auto& stream, auto& buffer, auto& requestParser,
+              auto outputBuffer) -> net::awaitable<size_t> {
+      size_t totalRead = 0;
+      while (!requestParser.is_done() && totalRead < outputBuffer.size()) {
+        requestParser.get().body().data = outputBuffer.data() + totalRead;
+        requestParser.get().body().size = outputBuffer.size() - totalRead;
+        boost::system::error_code ec;
+        co_await http::async_read_some(
+            stream, buffer, requestParser,
+            boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+        if (ec && ec != http::error::need_buffer) {
+          throw boost::system::system_error{ec};
+        }
+        totalRead +=
+            (outputBuffer.size() - totalRead) - requestParser.get().body().size;
+        // `need_buffer` means the buffer segment is full; stop here.
+        if (ec == http::error::need_buffer) break;
       }
-      totalRead +=
-          (outputBuffer.size() - totalRead) - requestParser.get().body().size;
-      // `need_buffer` means the buffer segment is full; stop here.
-      if (ec == http::error::need_buffer) break;
-    }
-    co_return totalRead;
+      co_return totalRead;
+    }(stream, buffer, requestParser, outputBuffer);
   }
 
   // Reads at most `bodyLimit` bytes from `requestParser` into a string and
@@ -270,16 +273,20 @@ CPP_template(BodyReadMode bodyReadMode, typename HttpHandler,
       beast::tcp_stream& stream, beast::flat_buffer& buffer,
       http::request_parser<http::buffer_body>& requestParser,
       size_t bodyLimit) {
-    std::string result;
-    std::vector<char> chunk(std::min(bodyLimit, size_t{4096}));
-    while (!requestParser.is_done() && result.size() < bodyLimit) {
-      const size_t toRead = std::min(bodyLimit - result.size(), chunk.size());
-      const size_t bytesRead = co_await readIntoBuffer(
-          stream, buffer, requestParser, std::span<char>{chunk.data(), toRead});
-      result.append(chunk.data(), bytesRead);
-      if (bytesRead == 0) break;
-    }
-    co_return result;
+    return [](auto& stream, auto& buffer, auto& requestParser,
+              size_t bodyLimit) -> net::awaitable<std::string> {
+      std::string result;
+      std::vector<char> chunk(std::min(bodyLimit, size_t{4096}));
+      while (!requestParser.is_done() && result.size() < bodyLimit) {
+        const size_t toRead = std::min(bodyLimit - result.size(), chunk.size());
+        const size_t bytesRead = co_await HttpServer::readIntoBuffer(
+            stream, buffer, requestParser,
+            std::span<char>{chunk.data(), toRead});
+        result.append(chunk.data(), bytesRead);
+        if (bytesRead == 0) break;
+      }
+      co_return result;
+    }(stream, buffer, requestParser, bodyLimit);
   }
 
   // Callable passed to the lazy-mode `httpHandler_` as `bodyGetter`. Holds
@@ -296,11 +303,15 @@ CPP_template(BodyReadMode bodyReadMode, typename HttpHandler,
     size_t chunkSize_;
 
     net::awaitable<std::optional<std::string_view>> operator()() {
-      const size_t bytesRead = co_await HttpServer::readIntoBuffer(
-          stream_, buffer_, requestParser_,
-          std::span<char>{chunkBuffer_.data(), chunkSize_});
-      if (bytesRead == 0) co_return std::nullopt;
-      co_return std::string_view{chunkBuffer_.data(), bytesRead};
+      return [](auto& stream, auto& buffer, auto& requestParser,
+                auto& chunkBuffer, size_t chunkSize)
+                 -> net::awaitable<std::optional<std::string_view>> {
+        const size_t bytesRead = co_await HttpServer::readIntoBuffer(
+            stream, buffer, requestParser,
+            std::span<char>{chunkBuffer.data(), chunkSize});
+        if (bytesRead == 0) co_return std::nullopt;
+        co_return std::string_view{chunkBuffer.data(), bytesRead};
+      }(stream_, buffer_, requestParser_, chunkBuffer_, chunkSize_);
     }
   };
 

--- a/src/util/http/HttpServer.h
+++ b/src/util/http/HttpServer.h
@@ -103,6 +103,12 @@ CPP_template(BodyReadMode bodyReadMode, typename HttpHandler,
                                                 HandlerSupplier
                                                     webSocketHandlerSupplier =
                                                         {},
+                                                // Only used in lazy mode: the
+                                                // body is read in chunks of
+                                                // this size; each chunk is
+                                                // filled completely before
+                                                // being yielded, trading
+                                                // latency for throughput.
                                                 size_t lazyBodyChunkSize =
                                                     1u << 20u)
       : httpHandler_{std::move(handler)},
@@ -233,16 +239,48 @@ CPP_template(BodyReadMode bodyReadMode, typename HttpHandler,
     co_return false;
   }
 
-  // Handle one lazy-mode request: read only the headers, then pass a
-  // `bodyGetter` callable to `httpHandler_`. Each `co_await bodyGetter()` reads
-  // the next chunk (up to `lazyBodyChunkSize_` bytes) into a buffer that lives
-  // in this function's stack frame and returns a `string_view` into it. The
-  // view is valid only until the next call. Returns `nullopt` when the body is
-  // fully consumed; throws on network errors.
-  template <typename SendMessage>
-  net::awaitable<void> handleLazyRequest(beast::tcp_stream& stream,
+  // Read at most `bodyLimit` bytes from `requestParser` into a string and
+  // return it. If `bodyLimit` is 0 (unlimited), at most 100'000 bytes are
+  // consumed; WebSocket upgrade requests are never that large.
+  static net::awaitable<std::string> materializeBody(
+      beast::tcp_stream& stream, beast::flat_buffer& buffer,
+      http::request_parser<http::buffer_body>& requestParser,
+      size_t bodyLimit) {
+    const size_t effectiveLimit = (bodyLimit == 0) ? 100'000 : bodyLimit;
+    std::string result;
+    std::vector<char> chunk(std::min(effectiveLimit, size_t{4096}));
+    while (!requestParser.is_done() && result.size() < effectiveLimit) {
+      const size_t toRead =
+          std::min(effectiveLimit - result.size(), chunk.size());
+      requestParser.get().body().data = chunk.data();
+      requestParser.get().body().size = toRead;
+      boost::system::error_code ec;
+      co_await http::async_read_some(
+          stream, buffer, requestParser,
+          boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+      if (ec && ec != http::error::need_buffer) {
+        throw boost::system::system_error{ec};
+      }
+      const size_t bytesRead = toRead - requestParser.get().body().size;
+      result.append(chunk.data(), bytesRead);
+    }
+    co_return result;
+  }
+
+  // Handle one lazy-mode request: read only the headers, then check for a
+  // WebSocket upgrade or pass a `bodyGetter` callable to `httpHandler_`.
+  // For WebSocket upgrades the remaining body is materialized and
+  // `handleWebsocketUpgrade` is called; returns `true` so the caller exits
+  // the session loop. For normal requests each `co_await bodyGetter()` reads
+  // the next chunk (up to `lazyBodyChunkSize_` bytes) into a buffer that
+  // lives in this function's stack frame and returns a `string_view` into it;
+  // the view is valid only until the next call; `nullopt` signals end-of-body;
+  // throws on network errors. Returns `false` for normal requests.
+  template <typename SendMessage, typename ReleaseConnection>
+  net::awaitable<bool> handleLazyRequest(beast::tcp_stream& stream,
                                          beast::flat_buffer& buffer,
-                                         SendMessage& sendMessage)
+                                         SendMessage& sendMessage,
+                                         ReleaseConnection& releaseConnection)
       requires(bodyReadMode == BodyReadMode::Lazy) {
     http::request_parser<http::buffer_body> requestParser;
     requestParser.body_limit(boost::none);
@@ -252,49 +290,65 @@ CPP_template(BodyReadMode bodyReadMode, typename HttpHandler,
     http::request<http::empty_body> headersReq =
         ad_utility::httpUtils::getHeaderOnlyRequest(requestParser.get());
 
+    if (beast::websocket::is_upgrade(headersReq)) {
+      std::string body = co_await materializeBody(
+          stream, buffer, requestParser, getRequestBodyLimit().getBytes());
+      auto stringReq = ad_utility::httpUtils::getStringBodyRequest(
+          headersReq, std::move(body));
+      co_await handleWebsocketUpgrade(stream, stringReq, sendMessage,
+                                      releaseConnection);
+      co_return true;
+    }
+
     // Buffer for body chunks; its lifetime covers the entire handler
     // invocation.
     const size_t chunkSize = lazyBodyChunkSize_;
     std::vector<char> chunkBuffer(chunkSize);
 
-    // Fills `chunkBuffer` with up to `chunkSize` bytes from the request body
-    // and returns a view into it, or `nullopt` when the body is exhausted.
-    // Loops internally until the buffer is completely full or the body ends, so
-    // callers always receive a maximally-sized chunk (except possibly the
-    // last).
+    // Yields up to `chunkSize` bytes from the request body as a `string_view`
+    // into `chunkBuffer`, or `nullopt` when the body is exhausted. Each chunk
+    // is filled completely before being returned (except possibly the last).
+    // The outer lambda is a plain factory (not a coroutine itself); the inner
+    // lambda is the coroutine and receives all state as arguments rather than
+    // captures, avoiding captures inside a coroutine context.
     auto bodyGetter =
         [&stream, &buffer, &requestParser, &chunkBuffer,
          chunkSize]() -> net::awaitable<std::optional<std::string_view>> {
-      size_t totalBytesRead = 0;
-      while (!requestParser.is_done() && totalBytesRead < chunkSize) {
-        requestParser.get().body().data = chunkBuffer.data() + totalBytesRead;
-        requestParser.get().body().size = chunkSize - totalBytesRead;
-        boost::system::error_code ec;
-        // `need_buffer` is returned when the provided buffer segment is
-        // completely full but more body data remains; it is not a real error.
-        co_await http::async_read_some(
-            stream, buffer, requestParser,
-            boost::asio::redirect_error(boost::asio::use_awaitable, ec));
-        if (ec && ec != http::error::need_buffer) {
-          throw boost::system::system_error{ec};
+      return [](auto& stream, auto& buffer, auto& requestParser,
+                auto& chunkBuffer, size_t chunkSize)
+                 -> net::awaitable<std::optional<std::string_view>> {
+        size_t totalBytesRead = 0;
+        while (!requestParser.is_done() && totalBytesRead < chunkSize) {
+          requestParser.get().body().data = chunkBuffer.data() + totalBytesRead;
+          requestParser.get().body().size = chunkSize - totalBytesRead;
+          boost::system::error_code ec;
+          // `need_buffer` is returned when the provided buffer segment is
+          // completely full but more body data remains; it is not a real error.
+          co_await http::async_read_some(
+              stream, buffer, requestParser,
+              boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+          if (ec && ec != http::error::need_buffer) {
+            throw boost::system::system_error{ec};
+          }
+          size_t bytesRead =
+              (chunkSize - totalBytesRead) - requestParser.get().body().size;
+          totalBytesRead += bytesRead;
+          if (ec == http::error::need_buffer) {
+            // Buffer segment is full; yield what we have.
+            break;
+          }
         }
-        size_t bytesRead =
-            (chunkSize - totalBytesRead) - requestParser.get().body().size;
-        totalBytesRead += bytesRead;
-        if (ec == http::error::need_buffer) {
-          // Buffer segment is full; yield what we have.
-          break;
+        if (totalBytesRead > 0) {
+          co_return std::string_view{chunkBuffer.data(), totalBytesRead};
         }
-      }
-      if (totalBytesRead > 0) {
-        co_return std::string_view{chunkBuffer.data(), totalBytesRead};
-      }
-      co_return std::nullopt;
+        co_return std::nullopt;
+      }(stream, buffer, requestParser, chunkBuffer, chunkSize);
     };
 
     stream.expires_never();
     co_await httpHandler_(std::move(headersReq), std::move(bodyGetter),
                           sendMessage);
+    co_return false;
   }
 
   // The loop which accepts TCP connections and delegates their handling
@@ -384,9 +438,11 @@ CPP_template(BodyReadMode bodyReadMode, typename HttpHandler,
               stream, buffer, sendMessage, releaseConnection);
           if (shouldExit) co_return;
         } else {
-          co_await handleLazyRequest(stream, buffer, sendMessage);
-          // Lazy mode always closes the connection after each request because
-          // the stream is occupied by body streaming until the body is done.
+          bool shouldExit = co_await handleLazyRequest(
+              stream, buffer, sendMessage, releaseConnection);
+          if (shouldExit) co_return;
+          // Non-WebSocket lazy requests always close the connection since body
+          // consumption by the handler is not guaranteed.
           streamNeedsClosing = true;
         }
 

--- a/src/util/http/HttpServer.h
+++ b/src/util/http/HttpServer.h
@@ -70,6 +70,7 @@ CPP_template(BodyReadMode bodyReadMode, typename HttpHandler,
   int numServerThreads_;
   net::io_context ioContext_;
   WebSocketHandler webSocketHandler_;
+  size_t lazyBodyChunkSize_;
   // All code that uses the `acceptor_` must run within this strand.
   // Note that the `acceptor_` might be concurrently accessed by the `listener`
   // and the `shutdown` function, the latter of which is currently only used in
@@ -101,14 +102,17 @@ CPP_template(BodyReadMode bodyReadMode, typename HttpHandler,
                                                     HttpHandler{},
                                                 HandlerSupplier
                                                     webSocketHandlerSupplier =
-                                                        {})
+                                                        {},
+                                                size_t lazyBodyChunkSize =
+                                                    1u << 20u)
       : httpHandler_{std::move(handler)},
         // We need at least two threads to avoid blocking.
         // TODO<joka921> why is that?
         numServerThreads_{std::max(2, numServerThreads)},
         ioContext_{numServerThreads_},
         webSocketHandler_{
-            std::invoke(std::move(webSocketHandlerSupplier), ioContext_)} {
+            std::invoke(std::move(webSocketHandlerSupplier), ioContext_)},
+        lazyBodyChunkSize_{lazyBodyChunkSize} {
     try {
       tcp::endpoint endpoint{net::ip::make_address(ipAddress), port};
       // Open the acceptor.
@@ -179,6 +183,118 @@ CPP_template(BodyReadMode bodyReadMode, typename HttpHandler,
   // Format a boost/beast error and log it to console
   void logBeastError(beast::error_code ec, std::string_view message) {
     AD_LOG_ERROR << message << ": " << ec.message() << std::endl;
+  }
+
+  // Handle a WebSocket upgrade request: send an error response if the path is
+  // invalid, otherwise cancel `releaseConnection` and delegate to
+  // `webSocketHandler_`.
+  template <typename SendMessage, typename ReleaseConnection>
+  net::awaitable<void> handleWebsocketUpgrade(
+      beast::tcp_stream& stream, const http::request<http::string_body>& req,
+      SendMessage& sendMessage, ReleaseConnection& releaseConnection) {
+    auto websocketErrorResponse = ad_utility::websocket::WebSocketSession::
+        getErrorResponseIfPathIsInvalid(req);
+    if (websocketErrorResponse.has_value()) {
+      co_await sendMessage(std::move(websocketErrorResponse.value()));
+    } else {
+      // Prevent cleanup after socket has been moved from.
+      releaseConnection.cancel();
+      co_await std::invoke(webSocketHandler_, req, std::move(stream.socket()));
+    }
+  }
+
+  // Handle one eager-mode request: read the full body, then dispatch to
+  // `httpHandler_` (or `handleWebsocketUpgrade` for WebSocket upgrades).
+  // Returns true when the session should exit (WebSocket was handled), false
+  // when the session should continue accepting further requests.
+  template <typename SendMessage, typename ReleaseConnection>
+  net::awaitable<bool> handleEagerRequest(beast::tcp_stream& stream,
+                                          beast::flat_buffer& buffer,
+                                          SendMessage& sendMessage,
+                                          ReleaseConnection& releaseConnection)
+      requires(bodyReadMode == BodyReadMode::Eager) {
+    http::request_parser<http::string_body> requestParser;
+    auto bodyLimit = getRequestBodyLimit().getBytes();
+    requestParser.body_limit(
+        bodyLimit == 0 ? boost::none : boost::optional<uint64_t>(bodyLimit));
+    co_await http::async_read(stream, buffer, requestParser,
+                              boost::asio::use_awaitable);
+    http::request<http::string_body> req = requestParser.release();
+
+    if (beast::websocket::is_upgrade(req)) {
+      co_await handleWebsocketUpgrade(stream, req, sendMessage,
+                                      releaseConnection);
+      co_return true;
+    }
+    // Currently there is no timeout on the server side, this is handled by
+    // QLever's timeout mechanism.
+    stream.expires_never();
+    co_await httpHandler_(std::move(req), sendMessage);
+    co_return false;
+  }
+
+  // Handle one lazy-mode request: read only the headers, then pass a
+  // `bodyGetter` callable to `httpHandler_`. Each `co_await bodyGetter()` reads
+  // the next chunk (up to `lazyBodyChunkSize_` bytes) into a buffer that lives
+  // in this function's stack frame and returns a `string_view` into it. The
+  // view is valid only until the next call. Returns `nullopt` when the body is
+  // fully consumed; throws on network errors.
+  template <typename SendMessage>
+  net::awaitable<void> handleLazyRequest(beast::tcp_stream& stream,
+                                         beast::flat_buffer& buffer,
+                                         SendMessage& sendMessage)
+      requires(bodyReadMode == BodyReadMode::Lazy) {
+    http::request_parser<http::buffer_body> requestParser;
+    requestParser.body_limit(boost::none);
+    co_await http::async_read_header(stream, buffer, requestParser,
+                                     boost::asio::use_awaitable);
+
+    http::request<http::empty_body> headersReq =
+        ad_utility::httpUtils::getHeaderOnlyRequest(requestParser.get());
+
+    // Buffer for body chunks; its lifetime covers the entire handler
+    // invocation.
+    const size_t chunkSize = lazyBodyChunkSize_;
+    std::vector<char> chunkBuffer(chunkSize);
+
+    // Fills `chunkBuffer` with up to `chunkSize` bytes from the request body
+    // and returns a view into it, or `nullopt` when the body is exhausted.
+    // Loops internally until the buffer is completely full or the body ends, so
+    // callers always receive a maximally-sized chunk (except possibly the
+    // last).
+    auto bodyGetter =
+        [&stream, &buffer, &requestParser, &chunkBuffer,
+         chunkSize]() -> net::awaitable<std::optional<std::string_view>> {
+      size_t totalBytesRead = 0;
+      while (!requestParser.is_done() && totalBytesRead < chunkSize) {
+        requestParser.get().body().data = chunkBuffer.data() + totalBytesRead;
+        requestParser.get().body().size = chunkSize - totalBytesRead;
+        boost::system::error_code ec;
+        // `need_buffer` is returned when the provided buffer segment is
+        // completely full but more body data remains; it is not a real error.
+        co_await http::async_read_some(
+            stream, buffer, requestParser,
+            boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+        if (ec && ec != http::error::need_buffer) {
+          throw boost::system::system_error{ec};
+        }
+        size_t bytesRead =
+            (chunkSize - totalBytesRead) - requestParser.get().body().size;
+        totalBytesRead += bytesRead;
+        if (ec == http::error::need_buffer) {
+          // Buffer segment is full; yield what we have.
+          break;
+        }
+      }
+      if (totalBytesRead > 0) {
+        co_return std::string_view{chunkBuffer.data(), totalBytesRead};
+      }
+      co_return std::nullopt;
+    };
+
+    stream.expires_never();
+    co_await httpHandler_(std::move(headersReq), std::move(bodyGetter),
+                          sendMessage);
   }
 
   // The loop which accepts TCP connections and delegates their handling
@@ -264,96 +380,11 @@ CPP_template(BodyReadMode bodyReadMode, typename HttpHandler,
         stream.expires_after(std::chrono::seconds(30));
 
         if constexpr (bodyReadMode == BodyReadMode::Eager) {
-          // ===== EAGER MODE =====
-          // Read a request. Use a parser so that we can control the limit of
-          // the request size.
-          http::request_parser<http::string_body> requestParser;
-          auto bodyLimit = getRequestBodyLimit().getBytes();
-          requestParser.body_limit(bodyLimit == 0
-                                       ? boost::none
-                                       : boost::optional<uint64_t>(bodyLimit));
-          co_await http::async_read(stream, buffer, requestParser,
-                                    boost::asio::use_awaitable);
-          http::request<http::string_body> req = requestParser.release();
-
-          // Let request be handled by `WebSocketSession` if the HTTP
-          // request is a WebSocket handshake.
-          if (beast::websocket::is_upgrade(req)) {
-            auto websocketErrorResponse = ad_utility::websocket::
-                WebSocketSession::getErrorResponseIfPathIsInvalid(req);
-            if (websocketErrorResponse.has_value()) {
-              co_await sendMessage(std::move(websocketErrorResponse.value()));
-            } else {
-              // Prevent cleanup after socket has been moved from.
-              releaseConnection.cancel();
-              co_await std::invoke(webSocketHandler_, req,
-                                   std::move(stream.socket()));
-              co_return;
-            }
-          } else {
-            // Currently there is no timeout on the server side, this is
-            // handled by QLever's timeout mechanism.
-            stream.expires_never();
-
-            // Handle the http request. Note that `httpHandler_` is also
-            // responsible for sending the message via the `sendMessage` lambda.
-            co_await httpHandler_(std::move(req), sendMessage);
-          }
+          bool shouldExit = co_await handleEagerRequest(
+              stream, buffer, sendMessage, releaseConnection);
+          if (shouldExit) co_return;
         } else {
-          // ===== LAZY MODE =====
-          // Read only the request headers; the body is delivered to the handler
-          // chunk by chunk via a `bodyGetter` callable. Each `co_await` of
-          // `bodyGetter()` reads the next chunk from the socket into a buffer
-          // whose lifetime is tied to this coroutine frame. The returned
-          // `string_view` is valid only until the next call to `bodyGetter()`.
-          // Note: WebSocket upgrades are not supported in lazy mode.
-          http::request_parser<http::buffer_body> requestParser;
-          requestParser.body_limit(boost::none);
-          co_await http::async_read_header(stream, buffer, requestParser,
-                                           boost::asio::use_awaitable);
-
-          // Build a header-only request to pass to the handler.
-          http::request<http::empty_body> headersReq;
-          headersReq.method(requestParser.get().method());
-          headersReq.target(std::string(requestParser.get().target()));
-          headersReq.version(requestParser.get().version());
-          headersReq.keep_alive(requestParser.get().keep_alive());
-          for (auto const& f : requestParser.get()) {
-            headersReq.insert(f.name_string(), f.value());
-          }
-
-          // Buffer for body chunks. Lives in this coroutine frame, so its
-          // lifetime covers the entire handler invocation.
-          constexpr size_t kChunkSize = 1 << 20;  // 1 MB per chunk.
-          std::vector<char> chunkBuffer(kChunkSize);
-
-          // Callable that reads the next body chunk into `chunkBuffer` and
-          // returns a view into it. Returns `nullopt` when the body is fully
-          // consumed. Throws `boost::system::system_error` on network error.
-          // The returned view is valid only until the next invocation.
-          auto bodyGetter =
-              [&]() -> net::awaitable<std::optional<std::string_view>> {
-            while (!requestParser.is_done()) {
-              requestParser.get().body().data = chunkBuffer.data();
-              requestParser.get().body().size = chunkBuffer.size();
-              boost::system::error_code ec;
-              co_await http::async_read_some(
-                  stream, buffer, requestParser,
-                  boost::asio::redirect_error(boost::asio::use_awaitable, ec));
-              if (ec && ec != http::error::need_buffer) {
-                throw boost::system::system_error{ec};
-              }
-              size_t bytesRead = kChunkSize - requestParser.get().body().size;
-              if (bytesRead > 0) {
-                co_return std::string_view{chunkBuffer.data(), bytesRead};
-              }
-            }
-            co_return std::nullopt;
-          };
-
-          stream.expires_never();
-          co_await httpHandler_(std::move(headersReq), std::move(bodyGetter),
-                                sendMessage);
+          co_await handleLazyRequest(stream, buffer, sendMessage);
           // Lazy mode always closes the connection after each request because
           // the stream is occupied by body streaming until the body is done.
           streamNeedsClosing = true;

--- a/src/util/http/HttpServer.h
+++ b/src/util/http/HttpServer.h
@@ -8,8 +8,8 @@
 
 #include <cstdlib>
 #include <future>
-#include <span>
 
+#include "backports/span.h"
 #include "util/Exception.h"
 #include "util/Log.h"
 #include "util/http/HttpUtils.h"
@@ -30,36 +30,35 @@ ad_utility::MemorySize getRequestBodyLimit();
 // while sending the response (Lazy).
 enum class BodyReadMode { Eager, Lazy };
 
-/*
- * \brief A Simple HttpServer, based on Boost::Beast. It can be configured via
- * the mandatory HttpHandler parameter.
- *
- * \tparam HttpHandler A callable returning `net::awaitable<void>`. Its
- * signature depends on `bodyReadMode`:
- *
- * - `BodyReadMode::Eager`: `handler(http::request<http::string_body>, send)`.
- *   The full request body is read into memory before the handler is called.
- *
- * - `BodyReadMode::Lazy`: `handler(http::request<http::empty_body>, send,
- *   bodyGetter)`. Only headers are read before the handler is called.
- *   `bodyGetter` is a callable with signature `() ->
- * net::awaitable<std::optional<std::string_view>>`. Each `co_await
- * bodyGetter()` reads the next body chunk; the returned view is valid until the
- * next call. `co_await bodyGetter()` returns `std::nullopt` when the body is
- * fully consumed and throws on network errors.
- *
- * In both modes `send` is a callable that takes a `http::message` and returns
- * `net::awaitable<void>`; the handler is responsible for sending the response
- * via `co_await send(response)`.
- *
- * A very basic HttpHandler, which simply serves files from a directory, can be
- * obtained via `ad_utility::httpUtils::makeFileServer()`.
- *
- * \tparam WebSocketHandler A callable type that receives a `http::request<...>`
- * and the underlying socket that was used to receive the request and returns
- * a `net::awaitable<void>`. It is only called if the request is a valid
- * websocket upgrade request and the URL represents a valid path.
- */
+// A simple `HttpServer`, based on Boost::Beast. It can be configured via
+// the mandatory `HttpHandler` parameter.
+//
+// `HttpHandler` is a callable returning `net::awaitable<void>`. Its signature
+// depends on `bodyReadMode`:
+//
+// - `BodyReadMode::Eager`: `handler(http::request<http::string_body>, send)`.
+//   The full request body is read into memory before the handler is called.
+//
+// - `BodyReadMode::Lazy`: `handler(http::request<http::empty_body>, send,
+//   bodyGetter)`. Only headers are read before the handler is called.
+//   `bodyGetter` is a callable with signature `() ->
+//   net::awaitable<std::optional<std::string_view>>`. Each `co_await
+//   bodyGetter()` reads the next body chunk; the returned view is valid until
+//   the next call. `co_await bodyGetter()` returns `std::nullopt` when the
+//   body is fully consumed and throws on network errors.
+//
+// In both modes `send` is a callable that takes a `http::message` and returns
+// `net::awaitable<void>`; the handler is responsible for sending the response
+// via `co_await send(response)`.
+//
+// A very basic `HttpHandler`, which simply serves files from a directory, can
+// be obtained via `ad_utility::httpUtils::makeFileServer()`.
+//
+// `WebSocketHandler` is a callable type that receives a
+// `http::request<...>` and the underlying socket that was used to receive the
+// request and returns a `net::awaitable<void>`. It is only called if the
+// request is a valid websocket upgrade request and the URL represents a valid
+// path.
 CPP_template(BodyReadMode bodyReadMode, typename HttpHandler,
              typename WebSocketHandler)(
     requires ad_utility::InvocableWithExactReturnType<
@@ -254,7 +253,7 @@ CPP_template(BodyReadMode bodyReadMode, typename HttpHandler,
   static net::awaitable<size_t> readIntoBuffer(
       beast::tcp_stream& stream, beast::flat_buffer& buffer,
       http::request_parser<http::buffer_body>& requestParser,
-      std::span<char> outputBuffer) {
+      ql::span<char> outputBuffer) {
     return [](auto& stream, auto& buffer, auto& requestParser,
               auto outputBuffer) -> net::awaitable<size_t> {
       size_t totalRead = 0;
@@ -294,7 +293,7 @@ CPP_template(BodyReadMode bodyReadMode, typename HttpHandler,
         const size_t toRead = std::min(bodyLimit - result.size(), chunk.size());
         const size_t bytesRead = co_await HttpServer::readIntoBuffer(
             stream, buffer, requestParser,
-            std::span<char>{chunk.data(), toRead});
+            ql::span<char>{chunk.data(), toRead});
         result.append(chunk.data(), bytesRead);
         if (bytesRead == 0) break;
       }
@@ -334,7 +333,7 @@ CPP_template(BodyReadMode bodyReadMode, typename HttpHandler,
                  -> net::awaitable<std::optional<std::string_view>> {
         const size_t bytesRead = co_await HttpServer::readIntoBuffer(
             stream, buffer, requestParser,
-            std::span<char>{chunkBuffer.data(), chunkSize});
+            ql::span<char>{chunkBuffer.data(), chunkSize});
         if (bytesRead == 0) co_return std::nullopt;
         co_return std::string_view{chunkBuffer.data(), bytesRead};
       }(stream_, buffer_, requestParser_, chunkBuffer_, chunkSize_);

--- a/src/util/http/HttpUtils.h
+++ b/src/util/http/HttpUtils.h
@@ -105,6 +105,18 @@ http::request<http::empty_body, Fields> getHeaderOnlyRequest(
   return result;
 }
 
+// Construct a `http::request<http::string_body>` from any Beast HTTP request by
+// copying all header fields and assigning `body` as the string body. Mirrors
+// `getHeaderOnlyRequest` but retains a non-empty body.
+template <typename Body, typename Fields>
+http::request<http::string_body, Fields> getStringBodyRequest(
+    const http::request<Body, Fields>& req, std::string body) {
+  http::request<http::string_body, Fields> result;
+  result.base() = req.base();
+  result.body() = std::move(body);
+  return result;
+}
+
 // The response type used for almost all cases. Only when there is an error
 // parsing the request, then another response type is used.
 using ResponseT = http::response<streamable_body>;

--- a/src/util/http/HttpUtils.h
+++ b/src/util/http/HttpUtils.h
@@ -93,6 +93,18 @@ static constexpr bool isHttpRequest<http::request<Body, Fields>> = true;
 template <typename T>
 CPP_concept HttpRequest = detail::isHttpRequest<T>;
 
+// Extract the header fields (method, target, version, and all header fields)
+// from any Beast HTTP request into a new `http::request<http::empty_body>`.
+// Beast provides no built-in facility for cross-body-type conversion, so we
+// copy via the shared `http::header` base.
+template <typename Body, typename Fields>
+http::request<http::empty_body, Fields> getHeaderOnlyRequest(
+    const http::request<Body, Fields>& req) {
+  http::request<http::empty_body, Fields> result;
+  result.base() = req.base();
+  return result;
+}
+
 // The response type used for almost all cases. Only when there is an error
 // parsing the request, then another response type is used.
 using ResponseT = http::response<streamable_body>;

--- a/test/HttpTest.cpp
+++ b/test/HttpTest.cpp
@@ -587,3 +587,141 @@ TYPED_TEST(HttpServerBodyTest, Redirects) {
   }
   server.shutDown();
 }
+
+namespace {
+
+// Minimal stubs to instantiate `HttpServer` solely for accessing its public
+// static helpers `readIntoBuffer` and `materializeBody`. No actual server is
+// constructed.
+struct DummyWsHandler {
+  net::awaitable<void> operator()(const http::request<http::string_body>&,
+                                  tcp::socket) const {
+    co_return;
+  }
+};
+struct DummyHttpHandler {
+  template <typename Send>
+  net::awaitable<void> operator()(http::request<http::string_body>,
+                                  Send&&) const {
+    co_return;
+  }
+};
+using TestServer =
+    HttpServer<BodyReadMode::Eager, DummyHttpHandler, DummyWsHandler>;
+
+// Sets up a local TCP loopback pair. The writer side sends `body` as the body
+// of a POST request; the reader side reads only the request headers and then
+// co_awaits `fn(stream, buffer, parser)`. Everything runs on the calling
+// executor so a single `io_context::run()` drives both sides to completion.
+template <typename Fn>
+net::awaitable<void> withParsedRequest(std::string body, Fn fn) {
+  auto ex = co_await net::this_coro::executor;
+  tcp::acceptor acceptor(ex, {tcp::v4(), 0});
+  const auto port = acceptor.local_endpoint().port();
+
+  // Use a capture-free IIFE to avoid a GCC 11 ICE with capturing coroutine
+  // lambdas defined inside a coroutine.
+  net::co_spawn(
+      ex,
+      [](std::string body, unsigned short port) -> net::awaitable<void> {
+        tcp::socket sock(co_await net::this_coro::executor);
+        co_await sock.async_connect(tcp::endpoint(tcp::v4(), port),
+                                    net::use_awaitable);
+        std::string request = absl::StrCat(
+            "POST / HTTP/1.1\r\nHost: localhost\r\nContent-Length: ",
+            body.size(), "\r\n\r\n", body);
+        co_await net::async_write(sock, net::buffer(request),
+                                  net::use_awaitable);
+        sock.shutdown(tcp::socket::shutdown_send);
+      }(std::move(body), port),
+      net::detached);
+
+  tcp::socket sock = co_await acceptor.async_accept(net::use_awaitable);
+  beast::tcp_stream stream(std::move(sock));
+  beast::flat_buffer buffer;
+  http::request_parser<http::buffer_body> parser;
+  parser.body_limit(boost::none);
+  co_await http::async_read_header(stream, buffer, parser, net::use_awaitable);
+  co_await fn(stream, buffer, parser);
+}
+
+// Runs `coro` on a fresh `io_context` to exhaustion on the calling thread.
+// Rethrows any exception raised by the coroutine.
+void runCoroutine(net::awaitable<void> coro) {
+  net::io_context ioc;
+  std::exception_ptr eptr;
+  net::co_spawn(ioc.get_executor(), std::move(coro),
+                [&eptr](std::exception_ptr p) { eptr = p; });
+  ioc.run();
+  if (eptr) std::rethrow_exception(eptr);
+}
+
+}  // namespace
+
+// Test `HttpServer::readIntoBuffer` in isolation, covering three cases:
+// body fits in the output buffer (all bytes read); output buffer smaller than
+// the body (exactly `bufferSize` bytes read); body and buffer the same size.
+TYPED_TEST(HttpServerBodyTest, ReadIntoBuffer) {
+  struct Case {
+    std::string body;
+    size_t bufferSize;
+    size_t expectedRead;
+    std::string name;
+  };
+  const std::vector<Case> cases = {
+      {"hello", 100, 5, "bodyFitsInBuffer"},
+      {std::string(200, 'b'), 50, 50, "bufferSmallerThanBody"},
+      {std::string(100, 'c'), 100, 100, "exactFit"},
+  };
+  for (const auto& c : cases) {
+    SCOPED_TRACE(c.name);
+    runCoroutine(withParsedRequest(
+        c.body,
+        [expectedBody = c.body.substr(0, c.expectedRead),
+         bufferSize = c.bufferSize, expectedRead = c.expectedRead](
+            beast::tcp_stream& stream, beast::flat_buffer& buffer,
+            http::request_parser<http::buffer_body>& parser)
+            -> net::awaitable<void> {
+          std::vector<char> out(bufferSize, '\0');
+          const size_t n = co_await TestServer::readIntoBuffer(
+              stream, buffer, parser, ql::span<char>{out.data(), bufferSize});
+          EXPECT_EQ(n, expectedRead);
+          EXPECT_EQ((std::string{out.data(), n}), expectedBody);
+        }));
+  }
+}
+
+// Test `HttpServer::materializeBody` in isolation. The internal read chunk is
+// `min(bodyLimit, 4096)` bytes, so a body larger than 4096 bytes forces the
+// loop to iterate more than once. Cases covered: small body (single chunk,
+// body exhausted early); body exactly one chunk; body spanning two chunks
+// (loop iterates twice); body truncated by `bodyLimit`; two full chunks.
+TYPED_TEST(HttpServerBodyTest, MaterializeBody) {
+  struct Case {
+    std::string body;
+    size_t limit;
+    std::string expected;
+    std::string name;
+  };
+  const std::vector<Case> cases = {
+      {"hello", 100, "hello", "smallBody"},
+      {std::string(4096, 'a'), 4096, std::string(4096, 'a'), "exactOneChunk"},
+      {std::string(5000, 'b'), 5000, std::string(5000, 'b'), "loopRequired"},
+      {std::string(5000, 'c'), 3000, std::string(3000, 'c'),
+       "truncatedByLimit"},
+      {std::string(8192, 'd'), 8192, std::string(8192, 'd'), "twoFullChunks"},
+  };
+  for (const auto& c : cases) {
+    SCOPED_TRACE(c.name);
+    runCoroutine(withParsedRequest(
+        c.body,
+        [expected = c.expected, limit = c.limit](
+            beast::tcp_stream& stream, beast::flat_buffer& buffer,
+            http::request_parser<http::buffer_body>& parser)
+            -> net::awaitable<void> {
+          auto result = co_await TestServer::materializeBody(stream, buffer,
+                                                             parser, limit);
+          EXPECT_EQ(result, expected);
+        }));
+  }
+}

--- a/test/HttpTest.cpp
+++ b/test/HttpTest.cpp
@@ -35,33 +35,6 @@ std::string toString(cppcoro::generator<ql::span<std::byte>> generator) {
 }
 }  // namespace
 
-// Unit test for `getHeaderOnlyRequest` (defined in `HttpUtils.h`).
-TEST(HttpUtils, GetHeaderOnlyRequest) {
-  http::request<http::string_body> original;
-  original.method(verb::post);
-  original.target("/api/test");
-  original.version(11);
-  original.keep_alive(true);
-  original.set(http::field::content_type, "text/plain");
-  original.set(http::field::authorization, "Bearer token123");
-  original.body() = "some body that must not appear in the header-only copy";
-
-  auto headerOnly = ad_utility::httpUtils::getHeaderOnlyRequest(original);
-
-  EXPECT_EQ(headerOnly.method(), verb::post);
-  EXPECT_EQ(headerOnly.target(), "/api/test");
-  EXPECT_EQ(headerOnly.version(), 11);
-  EXPECT_TRUE(headerOnly.keep_alive());
-  EXPECT_EQ(headerOnly.at(http::field::content_type), "text/plain");
-  EXPECT_EQ(headerOnly.at(http::field::authorization), "Bearer token123");
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Typed tests: run the same body-echo scenarios for both BodyReadMode::Eager
-// and BodyReadMode::Lazy.  A small chunk size (100 bytes) is used for lazy
-// mode so that multi-chunk tests do not need large bodies.
-// ─────────────────────────────────────────────────────────────────────────────
-
 namespace {
 
 // Returns a string representation of an HTTP verb for use in echo responses.
@@ -76,64 +49,51 @@ std::string_view verbName(verb v) {
   }
 }
 
-// Returns an echo handler for eager mode: echoes "METHOD\nTARGET\nBODY".
-auto makeEagerEchoHandler() {
-  return [](auto req, auto&& send) -> boost::asio::awaitable<void> {
-    co_await send(createOkResponse(std::string(verbName(req.method())) + "\n" +
-                                       std::string(toStd(req.target())) + "\n" +
-                                       req.body(),
-                                   req, ad_utility::MediaType::textPlain));
-  };
+// Assembles the full request body from an eager-mode request (reads from
+// `req.body()`) or a lazy-mode `bodyGetter` (accumulates chunks). Both
+// overloads return `net::awaitable<std::string>` so callers can uniformly
+// use `co_await consumeBody(req, args...)`.
+boost::asio::awaitable<std::string> consumeBody(
+    http::request<http::string_body> req) {
+  co_return req.body();
+}
+boost::asio::awaitable<std::string> consumeBody(const auto& /*req*/,
+                                                auto bodyGetter) {
+  std::string body;
+  while (auto chunk = co_await bodyGetter()) body += *chunk;
+  co_return body;
 }
 
-// Returns an echo handler for lazy mode: assembles body from chunks and echoes
-// "METHOD\nTARGET\nBODY".
-auto makeLazyEchoHandler() {
-  return [](auto req, auto bodyGetter,
-            auto&& send) -> boost::asio::awaitable<void> {
-    std::string body;
-    while (auto chunk = co_await bodyGetter()) {
-      body += *chunk;
-    }
-    co_await send(createOkResponse(std::string(verbName(req.method())) + "\n" +
-                                       std::string(toStd(req.target())) + "\n" +
-                                       body,
-                                   req, ad_utility::MediaType::textPlain));
-  };
+// Echo handler: sends "METHOD\nTARGET\nBODY". Works for both eager mode
+// (no extra args) and lazy mode (bodyGetter as last arg) via variadic `args`.
+auto makeEchoHandler() {
+  return
+      [](auto req, auto&& send, auto... args) -> boost::asio::awaitable<void> {
+        std::string body = co_await consumeBody(req, args...);
+        co_await send(
+            createOkResponse(std::string(verbName(req.method())) + "\n" +
+                                 std::string(toStd(req.target())) + "\n" + body,
+                             req, ad_utility::MediaType::textPlain));
+      };
 }
 
 // Creates an echo server for `mode` with the given chunk size and returns it.
 template <BodyReadMode mode>
 auto makeEchoServer(size_t chunkSize) {
-  if constexpr (mode == BodyReadMode::Eager) {
-    return TestHttpServer<decltype(makeEagerEchoHandler()), mode>(
-        makeEagerEchoHandler(), chunkSize);
-  } else {
-    return TestHttpServer<decltype(makeLazyEchoHandler()), mode>(
-        makeLazyEchoHandler(), chunkSize);
-  }
+  auto handler = makeEchoHandler();
+  return TestHttpServer<decltype(handler), mode>(std::move(handler), chunkSize);
 }
 
 // Creates an ignore-body server for `mode`: always responds with a fixed
 // string without reading the request body.
 template <BodyReadMode mode>
 auto makeIgnoreBodyServer(size_t chunkSize) {
-  if constexpr (mode == BodyReadMode::Eager) {
-    auto handler = [](auto req, auto&& send) -> boost::asio::awaitable<void> {
-      co_await send(createOkResponse("ignored body", req,
-                                     ad_utility::MediaType::textPlain));
-    };
-    return TestHttpServer<decltype(handler), mode>(std::move(handler),
-                                                   chunkSize);
-  } else {
-    auto handler = [](auto req, auto /*bodyGetter*/,
-                      auto&& send) -> boost::asio::awaitable<void> {
-      co_await send(createOkResponse("ignored body", req,
-                                     ad_utility::MediaType::textPlain));
-    };
-    return TestHttpServer<decltype(handler), mode>(std::move(handler),
-                                                   chunkSize);
-  }
+  auto handler = [](auto req, auto&& send,
+                    auto...) -> boost::asio::awaitable<void> {
+    co_await send(createOkResponse("ignored body", req,
+                                   ad_utility::MediaType::textPlain));
+  };
+  return TestHttpServer<decltype(handler), mode>(std::move(handler), chunkSize);
 }
 
 // Sends an echo response (METHOD\nTARGET\nBODY) and then rethrows `exception`.
@@ -151,25 +111,12 @@ boost::asio::awaitable<void> throwingEchoBody(const auto& req, auto& send,
 // Creates an echo server that throws `exception` after sending the response.
 template <BodyReadMode mode>
 auto makeThrowingEchoServer(std::exception_ptr exception, size_t chunkSize) {
-  if constexpr (mode == BodyReadMode::Eager) {
-    auto handler = [exception](auto req,
-                               auto&& send) -> boost::asio::awaitable<void> {
-      co_return co_await throwingEchoBody(req, send, req.body(), exception);
-    };
-    return TestHttpServer<decltype(handler), mode>(std::move(handler),
-                                                   chunkSize);
-  } else {
-    auto handler = [exception](auto req, auto bodyGetter,
-                               auto&& send) -> boost::asio::awaitable<void> {
-      std::string body;
-      while (auto chunk = co_await bodyGetter()) {
-        body += *chunk;
-      }
-      co_return co_await throwingEchoBody(req, send, body, exception);
-    };
-    return TestHttpServer<decltype(handler), mode>(std::move(handler),
-                                                   chunkSize);
-  }
+  auto handler = [exception](auto req, auto&& send,
+                             auto... args) -> boost::asio::awaitable<void> {
+    std::string body = co_await consumeBody(req, args...);
+    co_return co_await throwingEchoBody(req, send, body, exception);
+  };
+  return TestHttpServer<decltype(handler), mode>(std::move(handler), chunkSize);
 }
 
 // Common redirect/success handler logic: inspects URL parameters to redirect
@@ -202,24 +149,15 @@ boost::asio::awaitable<void> redirectHandlerCore(const auto& req, auto& send,
 }
 
 // Creates a redirect/success server for `mode`. The redirect logic is
-// body-mode-agnostic; the lazy variant simply ignores `bodyGetter`.
+// body-mode-agnostic; `args` is empty in eager mode or holds `bodyGetter`
+// in lazy mode.
 template <BodyReadMode mode>
 auto makeRedirectServer(std::string& lastTarget, size_t chunkSize) {
-  if constexpr (mode == BodyReadMode::Eager) {
-    auto handler = [&lastTarget](auto req,
-                                 auto&& send) -> boost::asio::awaitable<void> {
-      co_return co_await redirectHandlerCore(req, send, lastTarget);
-    };
-    return TestHttpServer<decltype(handler), mode>(std::move(handler),
-                                                   chunkSize);
-  } else {
-    auto handler = [&lastTarget](auto req, auto /*bodyGetter*/,
-                                 auto&& send) -> boost::asio::awaitable<void> {
-      co_return co_await redirectHandlerCore(req, send, lastTarget);
-    };
-    return TestHttpServer<decltype(handler), mode>(std::move(handler),
-                                                   chunkSize);
-  }
+  auto handler = [&lastTarget](auto req, auto&& send,
+                               auto...) -> boost::asio::awaitable<void> {
+    co_return co_await redirectHandlerCore(req, send, lastTarget);
+  };
+  return TestHttpServer<decltype(handler), mode>(std::move(handler), chunkSize);
 }
 
 }  // namespace
@@ -502,6 +440,10 @@ TYPED_TEST(HttpServerBodyTest, RequestBodySizeLimit) {
          &expectRequestHelper](const ad_utility::MemorySize& requestBodySize) {
           const ad_utility::MemorySize currentLimit =
               getRuntimeParameter<&RuntimeParameters::requestBodyLimit_>();
+          // For large requests we get an exception while writing to the request
+          // stream when going over the limit. For small requests we get the
+          // response normally. We would need the HttpClient to return the
+          // response even if it couldn't send the request fully in that case.
           expectRequestHelper(
               requestBodySize,
               "Request body size exceeds the allowed size (" +
@@ -517,19 +459,26 @@ TYPED_TEST(HttpServerBodyTest, RequestBodySizeLimit) {
                               ResponseMetadata(status::ok, "text/plain"));
         };
     constexpr auto testingRequestBodyLimit = 50_kB;
+
     // Set a smaller limit for testing. The default of 100 MB is quite large.
     setRuntimeParameter<&RuntimeParameters::requestBodyLimit_>(50_kB);
+    // Requests with bodies smaller than the request body limit are processed.
     expectRequestSucceeds(3_B);
+    // Exactly the limit is allowed.
     expectRequestSucceeds(testingRequestBodyLimit);
+    // Larger than the limit is forbidden.
     expectRequestFails(testingRequestBodyLimit + 1_B);
 
+    // Setting a smaller request-body limit.
     setRuntimeParameter<&RuntimeParameters::requestBodyLimit_>(1_B);
     expectRequestFails(3_B);
-    // An empty body is allowed even when the limit is 1 byte.
+    // Only the request body size counts. The empty body is allowed even if the
+    // body is limited to 1 byte.
     expectRequestSucceeds(0_B);
 
-    // Disable the limit (0 = unlimited).
+    // Disable the request body limit, by setting it to 0.
     setRuntimeParameter<&RuntimeParameters::requestBodyLimit_>(0_B);
+    // Arbitrarily large requests are now allowed.
     expectRequestSucceeds(10_kB);
     expectRequestSucceeds(5_MB);
   } else {
@@ -564,6 +513,7 @@ TYPED_TEST(HttpServerBodyTest, Redirects) {
         absl::StrCat("http://localhost:", server.getPort(),
                      "/?status=", redirectStatus, "&location=%2Fok");
 
+    // Send request with `maxRedirects = 1'.
     auto response = sendHttpOrHttpsRequest(Url{redirectUrl}, this->handle_,
                                            verb::get, "", "", "", 1);
     EXPECT_EQ(response.status_, status::ok);
@@ -613,6 +563,7 @@ TYPED_TEST(HttpServerBodyTest, Redirects) {
         "http://localhost:", server.getPort(),
         "/?status=301&location=%2Fredirect%3Fstatus%3D301%26location%3D%2Fok");
 
+    // With maxRedirects=1, this should fail (needs 2 redirects)
     AD_EXPECT_THROW_WITH_MESSAGE(
         sendHttpOrHttpsRequest(Url{url}, this->handle_, verb::get, "", "", "",
                                1),

--- a/test/HttpTest.cpp
+++ b/test/HttpTest.cpp
@@ -12,6 +12,7 @@
 #include "HttpTestHelpers.h"
 #include "global/RuntimeParameters.h"
 #include "util/GTestHelpers.h"
+#include "util/Random.h"
 #include "util/http/HttpClient.h"
 #include "util/http/HttpServer.h"
 #include "util/http/HttpUtils.h"
@@ -33,469 +34,6 @@ std::string toString(cppcoro::generator<ql::span<std::byte>> generator) {
   return result;
 }
 }  // namespace
-
-TEST(HttpServer, HttpTest) {
-  ad_utility::SharedCancellationHandle handle =
-      std::make_shared<ad_utility::CancellationHandle<>>();
-  // This test used to spuriously crash because of something that we (joka92,
-  // RobinTF) currently consider to be a bug in Boost::ASIO. (See
-  // `util/http/beast.h` for details). Repeat this test several times to make
-  // such failures less spurious should they ever reoccur in the future.
-  for (size_t k = 0; k < 10; ++k) {
-    // Create and run an HTTP server, which replies to each request with three
-    // lines: the request method (GET, POST, or OTHER), a copy of the request
-    // target (might be empty), and a copy of the request body (might be empty).
-    TestHttpServer httpServer([](auto request,
-                                 auto&& send) -> boost::asio::awaitable<void> {
-      std::string methodName;
-      switch (request.method()) {
-        case boost::beast::http::verb::get:
-          methodName = "GET";
-          break;
-        case boost::beast::http::verb::post:
-          methodName = "POST";
-          break;
-        default:
-          methodName = "OTHER";
-      }
-
-      auto response = [](std::string methodName, std::string target,
-                         std::string body) -> cppcoro::generator<std::string> {
-        co_yield methodName;
-        co_yield "\n";
-        co_yield target;
-        co_yield "\n";
-        co_yield body;
-      }(methodName, std::string(toStd(request.target())), request.body());
-
-      co_return co_await send(createOkResponse(
-          std::move(response), request, ad_utility::MediaType::textPlain));
-    });
-    httpServer.runInOwnThread();
-
-    // Create a client, and send a GET request.
-    // The constants in those test loops can be increased to find threading
-    // issues using the thread sanitizer. However, these constants can't be
-    // higher by default because the checks on GitHub actions will run forever
-    // if they are.
-    {
-      std::vector<ad_utility::JThread> threads;
-      for (size_t i = 0; i < 2; ++i) {
-        threads.emplace_back([&]() {
-          for (size_t j = 0; j < 20; ++j) {
-            {
-              auto httpClient = std::make_unique<HttpClient>(
-                  "localhost", std::to_string(httpServer.getPort()));
-
-              auto response =
-                  HttpClient::sendRequest(std::move(httpClient), verb::get,
-                                          "localhost", "target1", handle);
-              ASSERT_EQ(response.status_, boost::beast::http::status::ok);
-              ASSERT_EQ(response.contentType_, "text/plain");
-              ASSERT_EQ(toString(std::move(response.body_)), "GET\ntarget1\n");
-            }
-          }
-        });
-      }
-    }
-
-    // Do the same thing in a second session (to check if everything is still
-    // fine with the server after we have communicated with it for one session).
-    {
-      auto httpClient = std::make_unique<HttpClient>(
-          "localhost", std::to_string(httpServer.getPort()));
-      auto response =
-          HttpClient::sendRequest(std::move(httpClient), verb::post,
-                                  "localhost", "target2", handle, "body2");
-      ASSERT_EQ(response.status_, boost::beast::http::status::ok);
-      ASSERT_EQ(response.contentType_, "text/plain");
-      ASSERT_EQ(toString(std::move(response.body_)), "POST\ntarget2\nbody2");
-    }
-
-    // Test if websocket is correctly opened and closed
-    for (size_t i = 0; i < 20; ++i) {
-      {
-        HttpClient httpClient("localhost",
-                              std::to_string(httpServer.getPort()));
-        auto response = httpClient.sendWebSocketHandshake(
-            verb::get, "localhost", "/watch/some-id");
-        // verify request is upgraded
-        ASSERT_EQ(response.base().result(), http::status::switching_protocols);
-      }
-    }
-
-    // Test if websocket is denied on wrong paths
-    {
-      HttpClient httpClient("localhost", std::to_string(httpServer.getPort()));
-      auto response = httpClient.sendWebSocketHandshake(verb::get, "localhost",
-                                                        "/other-path");
-      // Check for not found error
-      ASSERT_EQ(response.base().result(), http::status::not_found);
-    }
-
-    // Also test the convenience function `sendHttpOrHttpsRequest` (which
-    // creates an own client for each request).
-    {
-      Url url{
-          absl::StrCat("http://localhost:", httpServer.getPort(), "/target")};
-      ASSERT_EQ(toString(sendHttpOrHttpsRequest(url, handle, verb::get).body_),
-                "GET\n/target\n");
-      ASSERT_EQ(
-          toString(
-              sendHttpOrHttpsRequest(url, handle, verb::post, "body").body_),
-          "POST\n/target\nbody");
-    }
-
-    // Check that after shutting down, no more new connections are accepted.
-    httpServer.shutDown();
-    ASSERT_ANY_THROW(
-        HttpClient("localhost", std::to_string(httpServer.getPort())));
-  }
-}
-
-// Test the various `catch` clauses in `HttpServer::session`.
-TEST(HttpServer, ErrorHandlingInSession) {
-  // We will interfere with the logging to test it, so we have to reset the
-  // logging after we are done.
-  absl::Cleanup cleanup{
-      []() { ad_utility::setGlobalLoggingStream(&std::cout); }};
-  ad_utility::SharedCancellationHandle handle =
-      std::make_shared<ad_utility::CancellationHandle<>>();
-
-  // Create an HTTP server, which replies to each request with three
-  // lines: the request method (GET, POST, or OTHER), a copy of the request
-  // target (might be empty), and a copy of the request body (might be empty).
-  // After sending the response, the exception denoted by the `exceptionPtr`
-  // will be thrown. This exception will be propagated to the
-  // `HttpServer::session` method, the exception behavior of which we want to
-  // test.
-  auto makeHttpServer = [](std::exception_ptr exceptionPtr) {
-    AD_CORRECTNESS_CHECK(exceptionPtr);
-    return TestHttpServer([exception = std::move(exceptionPtr)](
-                              auto request,
-                              auto&& send) -> boost::asio::awaitable<void> {
-      std::string methodName;
-      switch (request.method()) {
-        case boost::beast::http::verb::get:
-          methodName = "GET";
-          break;
-        case boost::beast::http::verb::post:
-          methodName = "POST";
-          break;
-        default:
-          methodName = "OTHER";
-      }
-
-      auto response = [](std::string methodName, std::string target,
-                         std::string body) -> cppcoro::generator<std::string> {
-        co_yield methodName;
-        co_yield "\n";
-        co_yield target;
-        co_yield "\n";
-        co_yield body;
-      }(methodName, std::string(toStd(request.target())), request.body());
-
-      // First send a response, to make the client happy.
-      co_await send(createOkResponse(std::move(response), request,
-                                     ad_utility::MediaType::textPlain));
-      // Then throw an exception.
-      AD_CORRECTNESS_CHECK(exception);
-      std::rethrow_exception(exception);
-    });
-  };
-
-  // Do the following: Create an HtttpServer using the above method that throws
-  // the `exceptionObject` after sending the response. Then send an HTTP request
-  // to that server to trigger the exception. Capture the log of the server and
-  // return it, s.t. it can be tested.
-  auto throwAndCaptureLog = [&makeHttpServer, &handle](auto exceptionObject) {
-    // Redirect the log, s.t. we can return it later.
-    std::stringstream logStream;
-    ad_utility::setGlobalLoggingStream(&logStream);
-
-    // Convert the `exceptionObject` to an `exception_ptr`
-    std::exception_ptr exception;
-    try {
-      throw exceptionObject;
-    } catch (...) {
-      exception = std::current_exception();
-    }
-
-    // Create and run a server and send a request to it. The exception will be
-    // caught by the `session` method, and a log statement will be issued
-    // depending on the exception. Note: We need a separate server for each
-    // test, because we need to shut down the server before extracting its log,
-    // otherwise we have a race condition on the logging. An alternative would
-    // be to implement a threadsafe `stringstream`, but the chosen approach also
-    // works for our purposes.
-    auto httpServer = makeHttpServer(exception);
-    httpServer.runInOwnThread();
-    auto httpClient = std::make_unique<HttpClient>(
-        "localhost", std::to_string(httpServer.getPort()));
-
-    auto response = HttpClient::sendRequest(std::move(httpClient), verb::get,
-                                            "localhost", "target1", handle);
-    // Check the response.
-    EXPECT_EQ(response.status_, boost::beast::http::status::ok);
-    EXPECT_EQ(response.contentType_, "text/plain");
-    EXPECT_EQ(toString(std::move(response.body_)), "GET\ntarget1\n");
-
-    // We need to shut down the server first to not have a race condition on the
-    // logging stream.
-    httpServer.shutDown();
-    // logStream.emit();
-    return logStream.str();
-  };
-
-  using namespace ::testing;
-  // Logging of a general `boost` exception.
-  std::string result;
-  auto s = throwAndCaptureLog(
-      beast::system_error{boost::asio::error::host_not_found_try_again});
-
-  // TODO<joka921> Actually this always should yield `not found`, but on the
-  // Docker cross-compilation build for ARM, this test sometimes fails because
-  // we don't land in the correct catch clause for some reason. This needs
-  // further debugging.
-  EXPECT_THAT(s, AnyOf(HasSubstr("not found"), Eq("")));
-
-  // The `timeout`and `eof` exceptions are only logged in the `TRACE` level,
-  // normally they are silently caught and ignored.
-  s = throwAndCaptureLog(beast::system_error{beast::error::timeout});
-  s += throwAndCaptureLog(beast::system_error{boost::asio::error::eof});
-  if (LOGLEVEL >= TRACE) {
-    EXPECT_THAT(s,
-                AllOf(HasSubstr("due to a timeout"), HasSubstr("End of file")));
-  } else {
-    EXPECT_THAT(s, Eq(""));
-  }
-
-  // Handling of `std::exception`.
-  if constexpr (LOGLEVEL >= ERROR) {
-    s = throwAndCaptureLog(std::runtime_error{"The runtime error for testing"});
-    EXPECT_THAT(s, HasSubstr("The runtime error for testing"));
-  }
-
-  // Thrown object that is not a `std::exception`.
-  if constexpr (LOGLEVEL >= ERROR) {
-    s = throwAndCaptureLog(47);
-    EXPECT_THAT(
-        s, HasSubstr("Weird exception not inheriting from std::exception"));
-  }
-}
-
-// Test the request body size limit
-TEST(HttpServer, RequestBodySizeLimit) {
-  ad_utility::SharedCancellationHandle handle =
-      std::make_shared<ad_utility::CancellationHandle<>>();
-
-  TestHttpServer httpServer([](auto request,
-                               auto&& send) -> boost::asio::awaitable<void> {
-    std::string methodName;
-    switch (request.method()) {
-      case verb::get:
-        methodName = "GET";
-        break;
-      case verb::post:
-        methodName = "POST";
-        break;
-      default:
-        methodName = "OTHER";
-    }
-
-    auto response = [](std::string methodName,
-                       std::string target) -> cppcoro::generator<std::string> {
-      co_yield methodName;
-      co_yield "\n";
-      co_yield target;
-    }(methodName, std::string(toStd(request.target())));
-
-    // Send a response.
-    co_await send(createOkResponse(std::move(response), request,
-                                   ad_utility::MediaType::textPlain));
-  });
-
-  httpServer.runInOwnThread();
-
-  auto ResponseMetadata = [](const status status,
-                             std::string_view content_type) {
-    return AllOf(
-        AD_FIELD(HttpOrHttpsResponse, status_, testing::Eq(status)),
-        AD_FIELD(HttpOrHttpsResponse, contentType_, testing::Eq(content_type)));
-  };
-  auto expectRequestHelper = [&httpServer](
-                                 const ad_utility::MemorySize& requestBodySize,
-                                 const std::string& expectedBody,
-                                 const auto& responseMatcher) {
-    ad_utility::SharedCancellationHandle handle =
-        std::make_shared<ad_utility::CancellationHandle<>>();
-
-    auto httpClient = std::make_unique<HttpClient>(
-        "localhost", std::to_string(httpServer.getPort()));
-
-    const std::string body(requestBodySize.getBytes(), 'f');
-
-    auto response = HttpClient::sendRequest(
-        std::move(httpClient), verb::post, "localhost", "target", handle, body);
-    EXPECT_THAT(response, responseMatcher);
-    EXPECT_THAT(toString(std::move(response.body_)), expectedBody);
-  };
-
-  auto expectRequestFails = [&ResponseMetadata, &expectRequestHelper](
-                                const ad_utility::MemorySize& requestBodySize) {
-    const ad_utility::MemorySize currentLimit =
-        getRuntimeParameter<&RuntimeParameters::requestBodyLimit_>();
-    // For large requests we get an exception while writing to the request
-    // stream when going over the limit. For small requests we get the response
-    // normally. We would need the HttpClient to return the response even
-    // if it couldn't send the request fully in that case.
-    expectRequestHelper(
-        requestBodySize,
-        "Request body size exceeds the allowed size (" +
-            currentLimit.asString() +
-            "), send a smaller request or set the allowed size via the runtime "
-            "parameter `request-body-limit`",
-        ResponseMetadata(status::payload_too_large, "text/plain"));
-  };
-  auto expectRequestSucceeds =
-      [&expectRequestHelper,
-       &ResponseMetadata](const ad_utility::MemorySize requestBodySize) {
-        expectRequestHelper(requestBodySize, "POST\ntarget",
-                            ResponseMetadata(status::ok, "text/plain"));
-      };
-  constexpr auto testingRequestBodyLimit = 50_kB;
-
-  // Set a smaller limit for testing. The default of 100 MB is quite large.
-  setRuntimeParameter<&RuntimeParameters::requestBodyLimit_>(50_kB);
-  // Requests with bodies smaller than the request body limit are processed.
-  expectRequestSucceeds(3_B);
-  // Exactly the limit is allowed.
-  expectRequestSucceeds(testingRequestBodyLimit);
-  // Larger than the limit is forbidden.
-  expectRequestFails(testingRequestBodyLimit + 1_B);
-
-  // Setting a smaller request-body limit.
-  setRuntimeParameter<&RuntimeParameters::requestBodyLimit_>(1_B);
-  expectRequestFails(3_B);
-  // Only the request body size counts. The empty body is allowed even if the
-  // body is limited to 1 byte.
-  expectRequestSucceeds(0_B);
-
-  // Disable the request body limit, by setting it to 0.
-  setRuntimeParameter<&RuntimeParameters::requestBodyLimit_>(0_B);
-  // Arbitrarily large requests are now allowed.
-  expectRequestSucceeds(10_kB);
-  expectRequestSucceeds(5_MB);
-}
-
-// Test HTTP redirect handling in `sendHttpOrHttpsRequest`.
-TEST(HttpClient, Redirects) {
-  using ::testing::AllOf;
-  ad_utility::SharedCancellationHandle handle =
-      std::make_shared<ad_utility::CancellationHandle<>>();
-
-  std::string lastTarget;
-
-  TestHttpServer server(
-      [&lastTarget](auto request, auto&& send) -> boost::asio::awaitable<void> {
-        boost::url_view url{request.target()};
-        lastTarget = request.target();
-        auto redirectIt = url.params().find("location");
-        if (redirectIt == url.params().end()) {
-          co_return co_await send(createOkResponse(
-              "Success", request, ad_utility::MediaType::textPlain));
-        }
-        http::response<http::string_body> resp;
-        unsigned redirectStatus = 200;
-        auto statusIt = url.params().find("status");
-        if (statusIt != url.params().end()) {
-          std::string statusString = (*statusIt)->value;
-          auto result = std::from_chars(
-              statusString.data(), statusString.data() + statusString.size(),
-              redirectStatus);
-          AD_CORRECTNESS_CHECK(result.ec == std::errc());
-        }
-        resp.result(redirectStatus);
-        resp.set(http::field::content_type, "text/plain");
-        resp.set(http::field::location, (*redirectIt)->value.data());
-        resp.body() = "";
-        resp.prepare_payload();
-        co_await send(std::move(resp));
-      });
-  server.runInOwnThread();
-
-  // Test that all four redirect types (301, 302, 307, 308) work.
-  for (auto redirectStatus :
-       {status::moved_permanently, status::found, status::temporary_redirect,
-        status::permanent_redirect}) {
-    std::string redirectUrl =
-        absl::StrCat("http://localhost:", server.getPort(),
-                     "/?status=", redirectStatus, "&location=%2Fok");
-
-    // Send request with `maxRedirects = 1'.
-    auto response = sendHttpOrHttpsRequest(Url{redirectUrl}, handle, verb::get,
-                                           "", "", "", 1);
-    EXPECT_EQ(response.status_, status::ok);
-    EXPECT_EQ(toString(std::move(response.body_)), "Success");
-  }
-
-  // Test that redirect with empty `Location` header throws.
-  {
-    std::string url = absl::StrCat("http://localhost:", server.getPort(),
-                                   "/?status=301&location=");
-
-    AD_EXPECT_THROW_WITH_MESSAGE(
-        sendHttpOrHttpsRequest(Url{url}, handle, verb::get, "", "", "", 1),
-        AllOf(HasSubstr("redirect status code"),
-              HasSubstr("no Location header")));
-  }
-
-  // Test that redirect with invalid `Location` header throws.
-  {
-    std::string url =
-        absl::StrCat("http://localhost:", server.getPort(),
-                     "/?status=301&location=Not%20a%20valid%20URL");
-
-    AD_EXPECT_THROW_WITH_MESSAGE(
-        sendHttpOrHttpsRequest(Url{url}, handle, verb::get, "", "", "", 1),
-        AllOf(HasSubstr("redirect status code")));
-  }
-
-  // Test that relative URLs are properly resolved.
-  {
-    std::string url =
-        absl::StrCat("http://localhost:", server.getPort(),
-                     "/some/relative/path?status=301&location=..%2Fabc");
-
-    auto response =
-        sendHttpOrHttpsRequest(Url{url}, handle, verb::get, "", "", "", 1);
-    EXPECT_EQ(lastTarget, "/some/abc");
-    EXPECT_EQ(response.status_, status::ok);
-    EXPECT_EQ(toString(std::move(response.body_)), "Success");
-  }
-
-  // Test that exceeding max redirects throws, using a chain of two redirects.
-  {
-    std::string url = absl::StrCat(
-        "http://localhost:", server.getPort(),
-        "/?status=301&location=%2Fredirect%3Fstatus%3D301%26location%3D%2Fok");
-
-    // With maxRedirects=1, this should fail (needs 2 redirects)
-    AD_EXPECT_THROW_WITH_MESSAGE(
-        sendHttpOrHttpsRequest(Url{url}, handle, verb::get, "", "", "", 1),
-        AllOf(HasSubstr("exceeded"), HasSubstr("redirect limit")));
-  }
-
-  // Test that `maxRedirects = 0` means no redirects are followed.
-  {
-    std::string url = absl::StrCat("http://localhost:", server.getPort(),
-                                   "/?status=301&location=%2F");
-    AD_EXPECT_THROW_WITH_MESSAGE(
-        sendHttpOrHttpsRequest(Url{url}, handle, verb::get, "", "", "", 0),
-        AllOf(HasSubstr("exceeded"), HasSubstr("redirect limit")));
-  }
-  server.shutDown();
-}
 
 // Unit test for `getHeaderOnlyRequest` (defined in `HttpUtils.h`).
 TEST(HttpUtils, GetHeaderOnlyRequest) {
@@ -598,6 +136,92 @@ auto makeIgnoreBodyServer(size_t chunkSize) {
   }
 }
 
+// Sends an echo response (METHOD\nTARGET\nBODY) and then rethrows `exception`.
+// Shared between eager and lazy `makeThrowingEchoServer` handlers.
+boost::asio::awaitable<void> throwingEchoBody(const auto& req, auto& send,
+                                              std::string_view body,
+                                              std::exception_ptr exception) {
+  co_await send(createOkResponse(std::string(verbName(req.method())) + "\n" +
+                                     std::string(toStd(req.target())) + "\n" +
+                                     std::string(body),
+                                 req, ad_utility::MediaType::textPlain));
+  std::rethrow_exception(exception);
+}
+
+// Creates an echo server that throws `exception` after sending the response.
+template <BodyReadMode mode>
+auto makeThrowingEchoServer(std::exception_ptr exception, size_t chunkSize) {
+  if constexpr (mode == BodyReadMode::Eager) {
+    auto handler = [exception](auto req,
+                               auto&& send) -> boost::asio::awaitable<void> {
+      co_return co_await throwingEchoBody(req, send, req.body(), exception);
+    };
+    return TestHttpServer<decltype(handler), mode>(std::move(handler),
+                                                   chunkSize);
+  } else {
+    auto handler = [exception](auto req, auto bodyGetter,
+                               auto&& send) -> boost::asio::awaitable<void> {
+      std::string body;
+      while (auto chunk = co_await bodyGetter()) {
+        body += *chunk;
+      }
+      co_return co_await throwingEchoBody(req, send, body, exception);
+    };
+    return TestHttpServer<decltype(handler), mode>(std::move(handler),
+                                                   chunkSize);
+  }
+}
+
+// Common redirect/success handler logic: inspects URL parameters to redirect
+// or respond with "Success", and sets `lastTarget` to the request target.
+boost::asio::awaitable<void> redirectHandlerCore(const auto& req, auto& send,
+                                                 std::string& lastTarget) {
+  boost::url_view url{req.target()};
+  lastTarget = req.target();
+  auto redirectIt = url.params().find("location");
+  if (redirectIt == url.params().end()) {
+    co_return co_await send(
+        createOkResponse("Success", req, ad_utility::MediaType::textPlain));
+  }
+  http::response<http::string_body> resp;
+  unsigned redirectStatus = 200;
+  auto statusIt = url.params().find("status");
+  if (statusIt != url.params().end()) {
+    std::string statusString = (*statusIt)->value;
+    auto result = std::from_chars(statusString.data(),
+                                  statusString.data() + statusString.size(),
+                                  redirectStatus);
+    AD_CORRECTNESS_CHECK(result.ec == std::errc());
+  }
+  resp.result(redirectStatus);
+  resp.set(http::field::content_type, "text/plain");
+  resp.set(http::field::location, (*redirectIt)->value.data());
+  resp.body() = "";
+  resp.prepare_payload();
+  co_await send(std::move(resp));
+}
+
+// Creates a redirect/success server for `mode`. The redirect logic is
+// body-mode-agnostic; the lazy variant simply ignores `bodyGetter`.
+template <BodyReadMode mode>
+auto makeRedirectServer(std::string& lastTarget, size_t chunkSize) {
+  if constexpr (mode == BodyReadMode::Eager) {
+    auto handler = [&lastTarget](auto req,
+                                 auto&& send) -> boost::asio::awaitable<void> {
+      co_return co_await redirectHandlerCore(req, send, lastTarget);
+    };
+    return TestHttpServer<decltype(handler), mode>(std::move(handler),
+                                                   chunkSize);
+  } else {
+    auto handler = [&lastTarget](auto req, auto /*bodyGetter*/,
+                                 auto&& send) -> boost::asio::awaitable<void> {
+      co_return co_await redirectHandlerCore(req, send, lastTarget);
+    };
+    return TestHttpServer<decltype(handler), mode>(std::move(handler),
+                                                   chunkSize);
+  }
+}
+
 }  // namespace
 
 // Fixture type tag: wraps `BodyReadMode` as a type so it can be used with
@@ -609,10 +233,8 @@ template <typename T>
 class HttpServerBodyTest : public ::testing::Test {
  protected:
   static constexpr BodyReadMode kMode = T::value;
-  // Use a 100-byte chunk size for lazy mode so multi-chunk tests only need
-  // 300-byte bodies instead of multi-megabyte ones.
-  static constexpr size_t kChunkSize =
-      (kMode == BodyReadMode::Lazy) ? 100u : (1u << 20u);
+  // Eager mode ignores the chunk size; 100 bytes keeps lazy-mode tests small.
+  static constexpr size_t lazyChunkSize = 100u;
 
   ad_utility::SharedCancellationHandle handle_ =
       std::make_shared<ad_utility::CancellationHandle<>>();
@@ -624,7 +246,7 @@ TYPED_TEST_SUITE(HttpServerBodyTest, AllBodyReadModes);
 
 // POST with a small body is echoed correctly.
 TYPED_TEST(HttpServerBodyTest, EchoPostSmallBody) {
-  auto server = makeEchoServer<TypeParam::value>(this->kChunkSize);
+  auto server = makeEchoServer<TypeParam::value>(this->lazyChunkSize);
   server.runInOwnThread();
 
   auto httpClient = std::make_unique<HttpClient>(
@@ -639,7 +261,7 @@ TYPED_TEST(HttpServerBodyTest, EchoPostSmallBody) {
 // GET with no body: `bodyGetter` immediately yields nullopt in lazy mode;
 // `req.body()` is empty in eager mode.
 TYPED_TEST(HttpServerBodyTest, EchoGetNoBody) {
-  auto server = makeEchoServer<TypeParam::value>(this->kChunkSize);
+  auto server = makeEchoServer<TypeParam::value>(this->lazyChunkSize);
   server.runInOwnThread();
 
   auto httpClient = std::make_unique<HttpClient>(
@@ -650,13 +272,14 @@ TYPED_TEST(HttpServerBodyTest, EchoGetNoBody) {
   EXPECT_EQ(toString(std::move(response.body_)), "GET\n/other\n");
 }
 
-// Body that spans multiple chunks (3 × kChunkSize bytes) is echoed in full.
-// For lazy mode kChunkSize = 100 bytes so only 300 bytes are needed.
+// Body that spans multiple chunks (3 × lazyChunkSize bytes) is echoed in full.
 TYPED_TEST(HttpServerBodyTest, EchoPostMultipleChunks) {
-  auto server = makeEchoServer<TypeParam::value>(this->kChunkSize);
+  auto server = makeEchoServer<TypeParam::value>(this->lazyChunkSize);
   server.runInOwnThread();
 
-  std::string largeBody(3 * this->kChunkSize, 'x');
+  ad_utility::SlowRandomIntGenerator<char> gen('a', 'z');
+  std::string largeBody(3 * this->lazyChunkSize, '\0');
+  std::generate(largeBody.begin(), largeBody.end(), std::ref(gen));
   auto httpClient = std::make_unique<HttpClient>(
       "localhost", std::to_string(server.getPort()));
   auto response =
@@ -669,7 +292,7 @@ TYPED_TEST(HttpServerBodyTest, EchoPostMultipleChunks) {
 // The handler may send a response without consuming the body; the connection
 // should still close cleanly.
 TYPED_TEST(HttpServerBodyTest, EarlyResponse) {
-  auto server = makeIgnoreBodyServer<TypeParam::value>(this->kChunkSize);
+  auto server = makeIgnoreBodyServer<TypeParam::value>(this->lazyChunkSize);
   server.runInOwnThread();
 
   auto httpClient = std::make_unique<HttpClient>(
@@ -679,4 +302,331 @@ TYPED_TEST(HttpServerBodyTest, EarlyResponse) {
                               "/skip", this->handle_, "unread body content");
   EXPECT_EQ(response.status_, status::ok);
   EXPECT_EQ(toString(std::move(response.body_)), "ignored body");
+}
+
+// Runs GET/POST echo, WebSocket upgrade and rejection, and
+// `sendHttpOrHttpsRequest` for both body-read modes.
+TYPED_TEST(HttpServerBodyTest, HttpTest) {
+  // This test used to spuriously crash because of something that we (joka92,
+  // RobinTF) currently consider to be a bug in Boost::ASIO. (See
+  // `util/http/beast.h` for details). Repeat this test several times to make
+  // such failures less spurious should they ever reoccur in the future.
+  for (size_t k = 0; k < 10; ++k) {
+    auto httpServer = makeEchoServer<TypeParam::value>(this->lazyChunkSize);
+    httpServer.runInOwnThread();
+
+    // Create a client, and send a GET request.
+    // The constants in those test loops can be increased to find threading
+    // issues using the thread sanitizer. However, these constants can't be
+    // higher by default because the checks on GitHub actions will run forever
+    // if they are.
+    {
+      std::vector<ad_utility::JThread> threads;
+      for (size_t i = 0; i < 2; ++i) {
+        threads.emplace_back([&]() {
+          for (size_t j = 0; j < 20; ++j) {
+            {
+              auto httpClient = std::make_unique<HttpClient>(
+                  "localhost", std::to_string(httpServer.getPort()));
+              auto response = HttpClient::sendRequest(std::move(httpClient),
+                                                      verb::get, "localhost",
+                                                      "target1", this->handle_);
+              ASSERT_EQ(response.status_, boost::beast::http::status::ok);
+              ASSERT_EQ(response.contentType_, "text/plain");
+              ASSERT_EQ(toString(std::move(response.body_)), "GET\ntarget1\n");
+            }
+          }
+        });
+      }
+    }
+
+    // Do the same thing in a second session (to check if everything is still
+    // fine with the server after we have communicated with it for one session).
+    {
+      auto httpClient = std::make_unique<HttpClient>(
+          "localhost", std::to_string(httpServer.getPort()));
+      auto response = HttpClient::sendRequest(std::move(httpClient), verb::post,
+                                              "localhost", "target2",
+                                              this->handle_, "body2");
+      ASSERT_EQ(response.status_, boost::beast::http::status::ok);
+      ASSERT_EQ(response.contentType_, "text/plain");
+      ASSERT_EQ(toString(std::move(response.body_)), "POST\ntarget2\nbody2");
+    }
+
+    // Test if websocket is correctly opened and closed.
+    for (size_t i = 0; i < 20; ++i) {
+      {
+        HttpClient httpClient("localhost",
+                              std::to_string(httpServer.getPort()));
+        auto response = httpClient.sendWebSocketHandshake(
+            verb::get, "localhost", "/watch/some-id");
+        ASSERT_EQ(response.base().result(), http::status::switching_protocols);
+      }
+    }
+
+    // Test if websocket is denied on wrong paths.
+    {
+      HttpClient httpClient("localhost", std::to_string(httpServer.getPort()));
+      auto response = httpClient.sendWebSocketHandshake(verb::get, "localhost",
+                                                        "/other-path");
+      ASSERT_EQ(response.base().result(), http::status::not_found);
+    }
+
+    // Also test the convenience function `sendHttpOrHttpsRequest`.
+    {
+      Url url{
+          absl::StrCat("http://localhost:", httpServer.getPort(), "/target")};
+      ASSERT_EQ(
+          toString(sendHttpOrHttpsRequest(url, this->handle_, verb::get).body_),
+          "GET\n/target\n");
+      ASSERT_EQ(toString(sendHttpOrHttpsRequest(url, this->handle_, verb::post,
+                                                "body")
+                             .body_),
+                "POST\n/target\nbody");
+    }
+
+    // Check that after shutting down, no more new connections are accepted.
+    httpServer.shutDown();
+    ASSERT_ANY_THROW(
+        HttpClient("localhost", std::to_string(httpServer.getPort())));
+  }
+}
+
+// Test the various `catch` clauses in `HttpServer::session`.
+TYPED_TEST(HttpServerBodyTest, ErrorHandlingInSession) {
+  // We will interfere with the logging to test it, so we have to reset the
+  // logging after we are done.
+  absl::Cleanup cleanup{
+      []() { ad_utility::setGlobalLoggingStream(&std::cout); }};
+
+  // Do the following: Create an HttpServer that echoes the response and then
+  // throws `exceptionObject`. Send an HTTP request to trigger the exception.
+  // Capture the server log and return it for inspection.
+  // Note: We need a separate server for each call because we must shut down
+  // before reading the log to avoid a race condition on the logging stream.
+  auto throwAndCaptureLog = [this](auto exceptionObject) {
+    std::stringstream logStream;
+    ad_utility::setGlobalLoggingStream(&logStream);
+
+    std::exception_ptr exception;
+    try {
+      throw exceptionObject;
+    } catch (...) {
+      exception = std::current_exception();
+    }
+
+    auto httpServer = makeThrowingEchoServer<TypeParam::value>(
+        exception, this->lazyChunkSize);
+    httpServer.runInOwnThread();
+    auto httpClient = std::make_unique<HttpClient>(
+        "localhost", std::to_string(httpServer.getPort()));
+
+    auto response =
+        HttpClient::sendRequest(std::move(httpClient), verb::get, "localhost",
+                                "target1", this->handle_);
+    EXPECT_EQ(response.status_, boost::beast::http::status::ok);
+    EXPECT_EQ(response.contentType_, "text/plain");
+    EXPECT_EQ(toString(std::move(response.body_)), "GET\ntarget1\n");
+
+    httpServer.shutDown();
+    return logStream.str();
+  };
+
+  using namespace ::testing;
+  // Logging of a general `boost` exception.
+  std::string result;
+  auto s = throwAndCaptureLog(
+      beast::system_error{boost::asio::error::host_not_found_try_again});
+
+  // TODO<joka921> Actually this always should yield `not found`, but on the
+  // Docker cross-compilation build for ARM, this test sometimes fails because
+  // we don't land in the correct catch clause for some reason. This needs
+  // further debugging.
+  EXPECT_THAT(s, AnyOf(HasSubstr("not found"), Eq("")));
+
+  // The `timeout` and `eof` exceptions are only logged at `TRACE` level;
+  // normally they are silently caught and ignored.
+  s = throwAndCaptureLog(beast::system_error{beast::error::timeout});
+  s += throwAndCaptureLog(beast::system_error{boost::asio::error::eof});
+  if (LOGLEVEL >= TRACE) {
+    EXPECT_THAT(s,
+                AllOf(HasSubstr("due to a timeout"), HasSubstr("End of file")));
+  } else {
+    EXPECT_THAT(s, Eq(""));
+  }
+
+  // Handling of `std::exception`.
+  if constexpr (LOGLEVEL >= ERROR) {
+    s = throwAndCaptureLog(std::runtime_error{"The runtime error for testing"});
+    EXPECT_THAT(s, HasSubstr("The runtime error for testing"));
+  }
+
+  // Thrown object that is not a `std::exception`.
+  if constexpr (LOGLEVEL >= ERROR) {
+    s = throwAndCaptureLog(47);
+    EXPECT_THAT(
+        s, HasSubstr("Weird exception not inheriting from std::exception"));
+  }
+}
+
+// Test the request body size limit (eager mode) and basic body handling (lazy).
+TYPED_TEST(HttpServerBodyTest, RequestBodySizeLimit) {
+  constexpr BodyReadMode kMode = TypeParam::value;
+  auto httpServer = makeIgnoreBodyServer<TypeParam::value>(this->lazyChunkSize);
+  httpServer.runInOwnThread();
+
+  auto ResponseMetadata = [](const status status,
+                             std::string_view content_type) {
+    return AllOf(
+        AD_FIELD(HttpOrHttpsResponse, status_, testing::Eq(status)),
+        AD_FIELD(HttpOrHttpsResponse, contentType_, testing::Eq(content_type)));
+  };
+  auto expectRequestHelper = [&httpServer](
+                                 const ad_utility::MemorySize& requestBodySize,
+                                 const std::string& expectedBody,
+                                 const auto& responseMatcher) {
+    ad_utility::SharedCancellationHandle handle =
+        std::make_shared<ad_utility::CancellationHandle<>>();
+    auto httpClient = std::make_unique<HttpClient>(
+        "localhost", std::to_string(httpServer.getPort()));
+    const std::string body(requestBodySize.getBytes(), 'f');
+    auto response = HttpClient::sendRequest(
+        std::move(httpClient), verb::post, "localhost", "target", handle, body);
+    EXPECT_THAT(response, responseMatcher);
+    EXPECT_THAT(toString(std::move(response.body_)), expectedBody);
+  };
+
+  if constexpr (kMode == BodyReadMode::Eager) {
+    auto expectRequestFails =
+        [&ResponseMetadata,
+         &expectRequestHelper](const ad_utility::MemorySize& requestBodySize) {
+          const ad_utility::MemorySize currentLimit =
+              getRuntimeParameter<&RuntimeParameters::requestBodyLimit_>();
+          expectRequestHelper(
+              requestBodySize,
+              "Request body size exceeds the allowed size (" +
+                  currentLimit.asString() +
+                  "), send a smaller request or set the allowed size via the "
+                  "runtime parameter `request-body-limit`",
+              ResponseMetadata(status::payload_too_large, "text/plain"));
+        };
+    auto expectRequestSucceeds =
+        [&expectRequestHelper,
+         &ResponseMetadata](const ad_utility::MemorySize requestBodySize) {
+          expectRequestHelper(requestBodySize, "ignored body",
+                              ResponseMetadata(status::ok, "text/plain"));
+        };
+    constexpr auto testingRequestBodyLimit = 50_kB;
+    // Set a smaller limit for testing. The default of 100 MB is quite large.
+    setRuntimeParameter<&RuntimeParameters::requestBodyLimit_>(50_kB);
+    expectRequestSucceeds(3_B);
+    expectRequestSucceeds(testingRequestBodyLimit);
+    expectRequestFails(testingRequestBodyLimit + 1_B);
+
+    setRuntimeParameter<&RuntimeParameters::requestBodyLimit_>(1_B);
+    expectRequestFails(3_B);
+    // An empty body is allowed even when the limit is 1 byte.
+    expectRequestSucceeds(0_B);
+
+    // Disable the limit (0 = unlimited).
+    setRuntimeParameter<&RuntimeParameters::requestBodyLimit_>(0_B);
+    expectRequestSucceeds(10_kB);
+    expectRequestSucceeds(5_MB);
+  } else {
+    // In lazy mode the server does not enforce a body size limit; verify that
+    // requests of various sizes all succeed. Use small bodies to avoid broken-
+    // pipe issues when the handler ignores the body.
+    auto expectSucceeds = [&expectRequestHelper,
+                           &ResponseMetadata](ad_utility::MemorySize size) {
+      expectRequestHelper(size, "ignored body",
+                          ResponseMetadata(status::ok, "text/plain"));
+    };
+    expectSucceeds(0_B);
+    expectSucceeds(3_B);
+    expectSucceeds(100_B);
+  }
+}
+
+// Test HTTP redirect handling in `sendHttpOrHttpsRequest`.
+TYPED_TEST(HttpServerBodyTest, Redirects) {
+  using ::testing::AllOf;
+
+  std::string lastTarget;
+  auto server =
+      makeRedirectServer<TypeParam::value>(lastTarget, this->lazyChunkSize);
+  server.runInOwnThread();
+
+  // Test that all four redirect types (301, 302, 307, 308) work.
+  for (auto redirectStatus :
+       {status::moved_permanently, status::found, status::temporary_redirect,
+        status::permanent_redirect}) {
+    std::string redirectUrl =
+        absl::StrCat("http://localhost:", server.getPort(),
+                     "/?status=", redirectStatus, "&location=%2Fok");
+
+    auto response = sendHttpOrHttpsRequest(Url{redirectUrl}, this->handle_,
+                                           verb::get, "", "", "", 1);
+    EXPECT_EQ(response.status_, status::ok);
+    EXPECT_EQ(toString(std::move(response.body_)), "Success");
+  }
+
+  // Test that redirect with empty `Location` header throws.
+  {
+    std::string url = absl::StrCat("http://localhost:", server.getPort(),
+                                   "/?status=301&location=");
+
+    AD_EXPECT_THROW_WITH_MESSAGE(
+        sendHttpOrHttpsRequest(Url{url}, this->handle_, verb::get, "", "", "",
+                               1),
+        AllOf(HasSubstr("redirect status code"),
+              HasSubstr("no Location header")));
+  }
+
+  // Test that redirect with invalid `Location` header throws.
+  {
+    std::string url =
+        absl::StrCat("http://localhost:", server.getPort(),
+                     "/?status=301&location=Not%20a%20valid%20URL");
+
+    AD_EXPECT_THROW_WITH_MESSAGE(
+        sendHttpOrHttpsRequest(Url{url}, this->handle_, verb::get, "", "", "",
+                               1),
+        AllOf(HasSubstr("redirect status code")));
+  }
+
+  // Test that relative URLs are properly resolved.
+  {
+    std::string url =
+        absl::StrCat("http://localhost:", server.getPort(),
+                     "/some/relative/path?status=301&location=..%2Fabc");
+
+    auto response = sendHttpOrHttpsRequest(Url{url}, this->handle_, verb::get,
+                                           "", "", "", 1);
+    EXPECT_EQ(lastTarget, "/some/abc");
+    EXPECT_EQ(response.status_, status::ok);
+    EXPECT_EQ(toString(std::move(response.body_)), "Success");
+  }
+
+  // Test that exceeding max redirects throws, using a chain of two redirects.
+  {
+    std::string url = absl::StrCat(
+        "http://localhost:", server.getPort(),
+        "/?status=301&location=%2Fredirect%3Fstatus%3D301%26location%3D%2Fok");
+
+    AD_EXPECT_THROW_WITH_MESSAGE(
+        sendHttpOrHttpsRequest(Url{url}, this->handle_, verb::get, "", "", "",
+                               1),
+        AllOf(HasSubstr("exceeded"), HasSubstr("redirect limit")));
+  }
+
+  // Test that `maxRedirects = 0` means no redirects are followed.
+  {
+    std::string url = absl::StrCat("http://localhost:", server.getPort(),
+                                   "/?status=301&location=%2F");
+    AD_EXPECT_THROW_WITH_MESSAGE(
+        sendHttpOrHttpsRequest(Url{url}, this->handle_, verb::get, "", "", "",
+                               0),
+        AllOf(HasSubstr("exceeded"), HasSubstr("redirect limit")));
+  }
+  server.shutDown();
 }

--- a/test/HttpTest.cpp
+++ b/test/HttpTest.cpp
@@ -496,3 +496,102 @@ TEST(HttpClient, Redirects) {
   }
   server.shutDown();
 }
+
+// Shared lazy-mode handler: echoes "METHOD\nTARGET\nBODY" where BODY is
+// assembled by consuming all chunks from `bodyGetter`.
+auto makeEchoLazyHandler() {
+  return [](auto req, auto bodyGetter,
+            auto&& send) -> boost::asio::awaitable<void> {
+    std::string methodName;
+    switch (req.method()) {
+      case boost::beast::http::verb::get:
+        methodName = "GET";
+        break;
+      case boost::beast::http::verb::post:
+        methodName = "POST";
+        break;
+      default:
+        methodName = "OTHER";
+    }
+    std::string body;
+    while (auto chunk = co_await bodyGetter()) {
+      body += *chunk;
+    }
+    co_await send(createOkResponse(
+        methodName + "\n" + std::string(toStd(req.target())) + "\n" + body, req,
+        ad_utility::MediaType::textPlain));
+  };
+}
+
+// Test lazy mode with a small POST body and a bodyless GET request.
+TEST(HttpServer, LazyModeBasic) {
+  ad_utility::SharedCancellationHandle handle =
+      std::make_shared<ad_utility::CancellationHandle<>>();
+
+  TestLazyHttpServer httpServer(makeEchoLazyHandler());
+  httpServer.runInOwnThread();
+
+  // POST with a small body.
+  {
+    auto httpClient = std::make_unique<HttpClient>(
+        "localhost", std::to_string(httpServer.getPort()));
+    auto response =
+        HttpClient::sendRequest(std::move(httpClient), verb::post, "localhost",
+                                "/target", handle, "hello body");
+    EXPECT_EQ(response.status_, status::ok);
+    EXPECT_EQ(toString(std::move(response.body_)), "POST\n/target\nhello body");
+  }
+
+  // GET with no body: `bodyGetter` should immediately yield nullopt.
+  {
+    auto httpClient = std::make_unique<HttpClient>(
+        "localhost", std::to_string(httpServer.getPort()));
+    auto response = HttpClient::sendRequest(std::move(httpClient), verb::get,
+                                            "localhost", "/other", handle);
+    EXPECT_EQ(response.status_, status::ok);
+    EXPECT_EQ(toString(std::move(response.body_)), "GET\n/other\n");
+  }
+}
+
+// Test lazy mode with a body that spans multiple 1 MB chunks.
+TEST(HttpServer, LazyModeMultipleChunks) {
+  ad_utility::SharedCancellationHandle handle =
+      std::make_shared<ad_utility::CancellationHandle<>>();
+
+  TestLazyHttpServer httpServer(makeEchoLazyHandler());
+  httpServer.runInOwnThread();
+
+  // 3 MB body — forces at least 3 calls to the body getter.
+  std::string largeBody(3 * (1 << 20), 'x');
+  auto httpClient = std::make_unique<HttpClient>(
+      "localhost", std::to_string(httpServer.getPort()));
+  auto response =
+      HttpClient::sendRequest(std::move(httpClient), verb::post, "localhost",
+                              "/large", handle, largeBody);
+  EXPECT_EQ(response.status_, status::ok);
+  EXPECT_EQ(toString(std::move(response.body_)), "POST\n/large\n" + largeBody);
+}
+
+// Test that the handler may send a response without consuming the body and
+// the server still closes the connection cleanly.
+TEST(HttpServer, LazyModeEarlyResponse) {
+  ad_utility::SharedCancellationHandle handle =
+      std::make_shared<ad_utility::CancellationHandle<>>();
+
+  TestLazyHttpServer httpServer(
+      [](auto req, auto /*bodyGetter*/,
+         auto&& send) -> boost::asio::awaitable<void> {
+        // Deliberately do not consume the body.
+        co_await send(createOkResponse("ignored body", req,
+                                       ad_utility::MediaType::textPlain));
+      });
+  httpServer.runInOwnThread();
+
+  auto httpClient = std::make_unique<HttpClient>(
+      "localhost", std::to_string(httpServer.getPort()));
+  auto response = HttpClient::sendRequest(std::move(httpClient), verb::post,
+                                          "localhost", "/skip", handle,
+                                          "some body that will not be read");
+  EXPECT_EQ(response.status_, status::ok);
+  EXPECT_EQ(toString(std::move(response.body_)), "ignored body");
+}

--- a/test/HttpTest.cpp
+++ b/test/HttpTest.cpp
@@ -313,7 +313,8 @@ TYPED_TEST(HttpServerBodyTest, HttpTest) {
       ASSERT_EQ(response.base().result(), http::status::not_found);
     }
 
-    // Also test the convenience function `sendHttpOrHttpsRequest`.
+    // Also test the convenience function `sendHttpOrHttpsRequest`, which
+    // creates an own client for each request.
     {
       Url url{
           absl::StrCat("http://localhost:", httpServer.getPort(), "/target")};
@@ -349,6 +350,7 @@ TYPED_TEST(HttpServerBodyTest, ErrorHandlingInSession) {
     std::stringstream logStream;
     ad_utility::setGlobalLoggingStream(&logStream);
 
+    // Convert the `exceptionObject` to an `exception_ptr`.
     std::exception_ptr exception;
     try {
       throw exceptionObject;

--- a/test/HttpTest.cpp
+++ b/test/HttpTest.cpp
@@ -295,6 +295,7 @@ TYPED_TEST(HttpServerBodyTest, HttpTest) {
                               std::to_string(httpServer.getPort()));
         auto response = httpClient.sendWebSocketHandshake(
             verb::get, "localhost", "/watch/some-id");
+        // verify request is upgraded
         ASSERT_EQ(response.base().result(), http::status::switching_protocols);
       }
     }
@@ -304,6 +305,7 @@ TYPED_TEST(HttpServerBodyTest, HttpTest) {
       HttpClient httpClient("localhost", std::to_string(httpServer.getPort()));
       auto response = httpClient.sendWebSocketHandshake(verb::get, "localhost",
                                                         "/other-path");
+      // Check for not found error
       ASSERT_EQ(response.base().result(), http::status::not_found);
     }
 
@@ -365,6 +367,8 @@ TYPED_TEST(HttpServerBodyTest, ErrorHandlingInSession) {
     EXPECT_EQ(response.contentType_, "text/plain");
     EXPECT_EQ(toString(std::move(response.body_)), "GET\ntarget1\n");
 
+    // We need to shut down the server first to not have a race condition on the
+    // logging stream.
     httpServer.shutDown();
     return logStream.str();
   };
@@ -424,9 +428,12 @@ TYPED_TEST(HttpServerBodyTest, RequestBodySizeLimit) {
                                  const auto& responseMatcher) {
     ad_utility::SharedCancellationHandle handle =
         std::make_shared<ad_utility::CancellationHandle<>>();
+
     auto httpClient = std::make_unique<HttpClient>(
         "localhost", std::to_string(httpServer.getPort()));
+
     const std::string body(requestBodySize.getBytes(), 'f');
+
     auto response = HttpClient::sendRequest(
         std::move(httpClient), verb::post, "localhost", "target", handle, body);
     EXPECT_THAT(response, responseMatcher);

--- a/test/HttpTest.cpp
+++ b/test/HttpTest.cpp
@@ -60,7 +60,9 @@ boost::asio::awaitable<std::string> consumeBody(
 boost::asio::awaitable<std::string> consumeBody(const auto& /*req*/,
                                                 auto bodyGetter) {
   std::string body;
-  while (auto chunk = co_await bodyGetter()) body += *chunk;
+  while (auto chunk = co_await bodyGetter()) {
+    body += chunk.value();
+  }
   co_return body;
 }
 

--- a/test/HttpTest.cpp
+++ b/test/HttpTest.cpp
@@ -497,101 +497,186 @@ TEST(HttpClient, Redirects) {
   server.shutDown();
 }
 
-// Shared lazy-mode handler: echoes "METHOD\nTARGET\nBODY" where BODY is
-// assembled by consuming all chunks from `bodyGetter`.
-auto makeEchoLazyHandler() {
+// Unit test for `getHeaderOnlyRequest` (defined in `HttpUtils.h`).
+TEST(HttpUtils, GetHeaderOnlyRequest) {
+  http::request<http::string_body> original;
+  original.method(verb::post);
+  original.target("/api/test");
+  original.version(11);
+  original.keep_alive(true);
+  original.set(http::field::content_type, "text/plain");
+  original.set(http::field::authorization, "Bearer token123");
+  original.body() = "some body that must not appear in the header-only copy";
+
+  auto headerOnly = ad_utility::httpUtils::getHeaderOnlyRequest(original);
+
+  EXPECT_EQ(headerOnly.method(), verb::post);
+  EXPECT_EQ(headerOnly.target(), "/api/test");
+  EXPECT_EQ(headerOnly.version(), 11);
+  EXPECT_TRUE(headerOnly.keep_alive());
+  EXPECT_EQ(headerOnly.at(http::field::content_type), "text/plain");
+  EXPECT_EQ(headerOnly.at(http::field::authorization), "Bearer token123");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Typed tests: run the same body-echo scenarios for both BodyReadMode::Eager
+// and BodyReadMode::Lazy.  A small chunk size (100 bytes) is used for lazy
+// mode so that multi-chunk tests do not need large bodies.
+// ─────────────────────────────────────────────────────────────────────────────
+
+namespace {
+
+// Returns a string representation of an HTTP verb for use in echo responses.
+std::string_view verbName(verb v) {
+  switch (v) {
+    case verb::get:
+      return "GET";
+    case verb::post:
+      return "POST";
+    default:
+      return "OTHER";
+  }
+}
+
+// Returns an echo handler for eager mode: echoes "METHOD\nTARGET\nBODY".
+auto makeEagerEchoHandler() {
+  return [](auto req, auto&& send) -> boost::asio::awaitable<void> {
+    co_await send(createOkResponse(std::string(verbName(req.method())) + "\n" +
+                                       std::string(toStd(req.target())) + "\n" +
+                                       req.body(),
+                                   req, ad_utility::MediaType::textPlain));
+  };
+}
+
+// Returns an echo handler for lazy mode: assembles body from chunks and echoes
+// "METHOD\nTARGET\nBODY".
+auto makeLazyEchoHandler() {
   return [](auto req, auto bodyGetter,
             auto&& send) -> boost::asio::awaitable<void> {
-    std::string methodName;
-    switch (req.method()) {
-      case boost::beast::http::verb::get:
-        methodName = "GET";
-        break;
-      case boost::beast::http::verb::post:
-        methodName = "POST";
-        break;
-      default:
-        methodName = "OTHER";
-    }
     std::string body;
     while (auto chunk = co_await bodyGetter()) {
       body += *chunk;
     }
-    co_await send(createOkResponse(
-        methodName + "\n" + std::string(toStd(req.target())) + "\n" + body, req,
-        ad_utility::MediaType::textPlain));
+    co_await send(createOkResponse(std::string(verbName(req.method())) + "\n" +
+                                       std::string(toStd(req.target())) + "\n" +
+                                       body,
+                                   req, ad_utility::MediaType::textPlain));
   };
 }
 
-// Test lazy mode with a small POST body and a bodyless GET request.
-TEST(HttpServer, LazyModeBasic) {
-  ad_utility::SharedCancellationHandle handle =
-      std::make_shared<ad_utility::CancellationHandle<>>();
-
-  TestLazyHttpServer httpServer(makeEchoLazyHandler());
-  httpServer.runInOwnThread();
-
-  // POST with a small body.
-  {
-    auto httpClient = std::make_unique<HttpClient>(
-        "localhost", std::to_string(httpServer.getPort()));
-    auto response =
-        HttpClient::sendRequest(std::move(httpClient), verb::post, "localhost",
-                                "/target", handle, "hello body");
-    EXPECT_EQ(response.status_, status::ok);
-    EXPECT_EQ(toString(std::move(response.body_)), "POST\n/target\nhello body");
-  }
-
-  // GET with no body: `bodyGetter` should immediately yield nullopt.
-  {
-    auto httpClient = std::make_unique<HttpClient>(
-        "localhost", std::to_string(httpServer.getPort()));
-    auto response = HttpClient::sendRequest(std::move(httpClient), verb::get,
-                                            "localhost", "/other", handle);
-    EXPECT_EQ(response.status_, status::ok);
-    EXPECT_EQ(toString(std::move(response.body_)), "GET\n/other\n");
+// Creates an echo server for `mode` with the given chunk size and returns it.
+template <BodyReadMode mode>
+auto makeEchoServer(size_t chunkSize) {
+  if constexpr (mode == BodyReadMode::Eager) {
+    return TestHttpServer<decltype(makeEagerEchoHandler()), mode>(
+        makeEagerEchoHandler(), chunkSize);
+  } else {
+    return TestHttpServer<decltype(makeLazyEchoHandler()), mode>(
+        makeLazyEchoHandler(), chunkSize);
   }
 }
 
-// Test lazy mode with a body that spans multiple 1 MB chunks.
-TEST(HttpServer, LazyModeMultipleChunks) {
-  ad_utility::SharedCancellationHandle handle =
+// Creates an ignore-body server for `mode`: always responds with a fixed
+// string without reading the request body.
+template <BodyReadMode mode>
+auto makeIgnoreBodyServer(size_t chunkSize) {
+  if constexpr (mode == BodyReadMode::Eager) {
+    auto handler = [](auto req, auto&& send) -> boost::asio::awaitable<void> {
+      co_await send(createOkResponse("ignored body", req,
+                                     ad_utility::MediaType::textPlain));
+    };
+    return TestHttpServer<decltype(handler), mode>(std::move(handler),
+                                                   chunkSize);
+  } else {
+    auto handler = [](auto req, auto /*bodyGetter*/,
+                      auto&& send) -> boost::asio::awaitable<void> {
+      co_await send(createOkResponse("ignored body", req,
+                                     ad_utility::MediaType::textPlain));
+    };
+    return TestHttpServer<decltype(handler), mode>(std::move(handler),
+                                                   chunkSize);
+  }
+}
+
+}  // namespace
+
+// Fixture type tag: wraps `BodyReadMode` as a type so it can be used with
+// `TYPED_TEST_SUITE`.
+template <BodyReadMode M>
+using ModeTag = std::integral_constant<BodyReadMode, M>;
+
+template <typename T>
+class HttpServerBodyTest : public ::testing::Test {
+ protected:
+  static constexpr BodyReadMode kMode = T::value;
+  // Use a 100-byte chunk size for lazy mode so multi-chunk tests only need
+  // 300-byte bodies instead of multi-megabyte ones.
+  static constexpr size_t kChunkSize =
+      (kMode == BodyReadMode::Lazy) ? 100u : (1u << 20u);
+
+  ad_utility::SharedCancellationHandle handle_ =
       std::make_shared<ad_utility::CancellationHandle<>>();
+};
 
-  TestLazyHttpServer httpServer(makeEchoLazyHandler());
-  httpServer.runInOwnThread();
+using AllBodyReadModes =
+    ::testing::Types<ModeTag<BodyReadMode::Eager>, ModeTag<BodyReadMode::Lazy>>;
+TYPED_TEST_SUITE(HttpServerBodyTest, AllBodyReadModes);
 
-  // 3 MB body — forces at least 3 calls to the body getter.
-  std::string largeBody(3 * (1 << 20), 'x');
+// POST with a small body is echoed correctly.
+TYPED_TEST(HttpServerBodyTest, EchoPostSmallBody) {
+  auto server = makeEchoServer<TypeParam::value>(this->kChunkSize);
+  server.runInOwnThread();
+
   auto httpClient = std::make_unique<HttpClient>(
-      "localhost", std::to_string(httpServer.getPort()));
+      "localhost", std::to_string(server.getPort()));
   auto response =
       HttpClient::sendRequest(std::move(httpClient), verb::post, "localhost",
-                              "/large", handle, largeBody);
+                              "/target", this->handle_, "hello body");
+  EXPECT_EQ(response.status_, status::ok);
+  EXPECT_EQ(toString(std::move(response.body_)), "POST\n/target\nhello body");
+}
+
+// GET with no body: `bodyGetter` immediately yields nullopt in lazy mode;
+// `req.body()` is empty in eager mode.
+TYPED_TEST(HttpServerBodyTest, EchoGetNoBody) {
+  auto server = makeEchoServer<TypeParam::value>(this->kChunkSize);
+  server.runInOwnThread();
+
+  auto httpClient = std::make_unique<HttpClient>(
+      "localhost", std::to_string(server.getPort()));
+  auto response = HttpClient::sendRequest(std::move(httpClient), verb::get,
+                                          "localhost", "/other", this->handle_);
+  EXPECT_EQ(response.status_, status::ok);
+  EXPECT_EQ(toString(std::move(response.body_)), "GET\n/other\n");
+}
+
+// Body that spans multiple chunks (3 × kChunkSize bytes) is echoed in full.
+// For lazy mode kChunkSize = 100 bytes so only 300 bytes are needed.
+TYPED_TEST(HttpServerBodyTest, EchoPostMultipleChunks) {
+  auto server = makeEchoServer<TypeParam::value>(this->kChunkSize);
+  server.runInOwnThread();
+
+  std::string largeBody(3 * this->kChunkSize, 'x');
+  auto httpClient = std::make_unique<HttpClient>(
+      "localhost", std::to_string(server.getPort()));
+  auto response =
+      HttpClient::sendRequest(std::move(httpClient), verb::post, "localhost",
+                              "/large", this->handle_, largeBody);
   EXPECT_EQ(response.status_, status::ok);
   EXPECT_EQ(toString(std::move(response.body_)), "POST\n/large\n" + largeBody);
 }
 
-// Test that the handler may send a response without consuming the body and
-// the server still closes the connection cleanly.
-TEST(HttpServer, LazyModeEarlyResponse) {
-  ad_utility::SharedCancellationHandle handle =
-      std::make_shared<ad_utility::CancellationHandle<>>();
-
-  TestLazyHttpServer httpServer(
-      [](auto req, auto /*bodyGetter*/,
-         auto&& send) -> boost::asio::awaitable<void> {
-        // Deliberately do not consume the body.
-        co_await send(createOkResponse("ignored body", req,
-                                       ad_utility::MediaType::textPlain));
-      });
-  httpServer.runInOwnThread();
+// The handler may send a response without consuming the body; the connection
+// should still close cleanly.
+TYPED_TEST(HttpServerBodyTest, EarlyResponse) {
+  auto server = makeIgnoreBodyServer<TypeParam::value>(this->kChunkSize);
+  server.runInOwnThread();
 
   auto httpClient = std::make_unique<HttpClient>(
-      "localhost", std::to_string(httpServer.getPort()));
-  auto response = HttpClient::sendRequest(std::move(httpClient), verb::post,
-                                          "localhost", "/skip", handle,
-                                          "some body that will not be read");
+      "localhost", std::to_string(server.getPort()));
+  auto response =
+      HttpClient::sendRequest(std::move(httpClient), verb::post, "localhost",
+                              "/skip", this->handle_, "unread body content");
   EXPECT_EQ(response.status_, status::ok);
   EXPECT_EQ(toString(std::move(response.body_)), "ignored body");
 }

--- a/test/HttpTest.cpp
+++ b/test/HttpTest.cpp
@@ -653,7 +653,9 @@ void runCoroutine(net::awaitable<void> coro) {
   net::co_spawn(ioc.get_executor(), std::move(coro),
                 [&eptr](std::exception_ptr p) { eptr = p; });
   ioc.run();
-  if (eptr) std::rethrow_exception(eptr);
+  if (eptr) {
+    std::rethrow_exception(eptr);
+  }
 }
 
 }  // namespace

--- a/test/HttpTest.cpp
+++ b/test/HttpTest.cpp
@@ -38,16 +38,7 @@ std::string toString(cppcoro::generator<ql::span<std::byte>> generator) {
 namespace {
 
 // Returns a string representation of an HTTP verb for use in echo responses.
-std::string_view verbName(verb v) {
-  switch (v) {
-    case verb::get:
-      return "GET";
-    case verb::post:
-      return "POST";
-    default:
-      return "OTHER";
-  }
-}
+std::string_view verbName(verb v) { return toStd(to_string(v)); }
 
 // Assembles the full request body from an eager-mode request (reads from
 // `req.body()`) or a lazy-mode `bodyGetter` (accumulates chunks). Both
@@ -57,8 +48,8 @@ boost::asio::awaitable<std::string> consumeBody(
     http::request<http::string_body> req) {
   co_return req.body();
 }
-boost::asio::awaitable<std::string> consumeBody(const auto& /*req*/,
-                                                auto bodyGetter) {
+boost::asio::awaitable<std::string> consumeBody(
+    [[maybe_unused]] const auto& request, auto bodyGetter) {
   std::string body;
   while (auto chunk = co_await bodyGetter()) {
     body += chunk.value();
@@ -73,8 +64,8 @@ auto makeEchoHandler() {
       [](auto req, auto&& send, auto... args) -> boost::asio::awaitable<void> {
         std::string body = co_await consumeBody(req, args...);
         co_await send(
-            createOkResponse(std::string(verbName(req.method())) + "\n" +
-                                 std::string(toStd(req.target())) + "\n" + body,
+            createOkResponse(absl::StrCat(verbName(req.method()), "\n",
+                                          toStd(req.target()), "\n", body),
                              req, ad_utility::MediaType::textPlain));
       };
 }
@@ -103,9 +94,8 @@ auto makeIgnoreBodyServer(size_t chunkSize) {
 boost::asio::awaitable<void> throwingEchoBody(const auto& req, auto& send,
                                               std::string_view body,
                                               std::exception_ptr exception) {
-  co_await send(createOkResponse(std::string(verbName(req.method())) + "\n" +
-                                     std::string(toStd(req.target())) + "\n" +
-                                     std::string(body),
+  co_await send(createOkResponse(absl::StrCat(verbName(req.method()), "\n",
+                                              toStd(req.target()), "\n", body),
                                  req, ad_utility::MediaType::textPlain));
   std::rethrow_exception(exception);
 }
@@ -219,8 +209,12 @@ TYPED_TEST(HttpServerBodyTest, EchoPostMultipleChunks) {
 
   ad_utility::SlowRandomIntGenerator<int> gen('a', 'z');
   std::string largeBody(3 * this->lazyChunkSize, '\0');
-  std::generate(largeBody.begin(), largeBody.end(),
-                [&gen]() { return static_cast<char>(gen()); });
+  // Note: we need the explicit casting to `char`, because
+  // `SlowRandomIntGenerator<char>` doesn't compile on AppleClang, because the
+  // libc++ variation there requires actual integer types for the random
+  // distributions.
+  ql::ranges::generate(largeBody,
+                       [&gen]() { return static_cast<char>(gen()); });
   auto httpClient = std::make_unique<HttpClient>(
       "localhost", std::to_string(server.getPort()));
   auto response =

--- a/test/HttpTest.cpp
+++ b/test/HttpTest.cpp
@@ -215,9 +215,10 @@ TYPED_TEST(HttpServerBodyTest, EchoPostMultipleChunks) {
   auto server = makeEchoServer<TypeParam::value>(this->lazyChunkSize);
   server.runInOwnThread();
 
-  ad_utility::SlowRandomIntGenerator<char> gen('a', 'z');
+  ad_utility::SlowRandomIntGenerator<int> gen('a', 'z');
   std::string largeBody(3 * this->lazyChunkSize, '\0');
-  std::generate(largeBody.begin(), largeBody.end(), std::ref(gen));
+  std::generate(largeBody.begin(), largeBody.end(),
+                [&gen]() { return static_cast<char>(gen()); });
   auto httpClient = std::make_unique<HttpClient>(
       "localhost", std::to_string(server.getPort()));
   auto response =

--- a/test/HttpTestHelpers.h
+++ b/test/HttpTestHelpers.h
@@ -37,7 +37,9 @@ class TestHttpServer {
       decltype(webSocketSessionSupplier(std::declval<net::io_context&>()));
 
   // The server.
-  std::shared_ptr<HttpServer<HttpHandler, WebSocketHandlerType>> server_;
+  std::shared_ptr<
+      HttpServer<BodyReadMode::Eager, HttpHandler, WebSocketHandlerType>>
+      server_;
 
   // The own thread in which the server is running.
   //
@@ -54,7 +56,8 @@ class TestHttpServer {
   // Create server on localhost. Port 0 instructs the operating system to choose
   // a free port of its choice.
   explicit TestHttpServer(HttpHandler httpHandler) {
-    server_ = std::make_shared<HttpServer<HttpHandler, WebSocketHandlerType>>(
+    server_ = std::make_shared<
+        HttpServer<BodyReadMode::Eager, HttpHandler, WebSocketHandlerType>>(
         0, "0.0.0.0", 1, std::move(httpHandler), webSocketSessionSupplier);
   }
 

--- a/test/HttpTestHelpers.h
+++ b/test/HttpTestHelpers.h
@@ -19,8 +19,9 @@
 
 using namespace std::literals;
 
-// Test HTTP Server.
-template <typename HttpHandler>
+// Test HTTP Server, parameterised on the body-read mode. Defaults to
+// `BodyReadMode::Eager` so existing tests are unaffected.
+template <typename HttpHandler, BodyReadMode readMode = BodyReadMode::Eager>
 class TestHttpServer {
  private:
   static constexpr auto webSocketSessionSupplier =
@@ -37,8 +38,7 @@ class TestHttpServer {
       decltype(webSocketSessionSupplier(std::declval<net::io_context&>()));
 
   // The server.
-  std::shared_ptr<
-      HttpServer<BodyReadMode::Eager, HttpHandler, WebSocketHandlerType>>
+  std::shared_ptr<HttpServer<readMode, HttpHandler, WebSocketHandlerType>>
       server_;
 
   // The own thread in which the server is running.
@@ -54,11 +54,14 @@ class TestHttpServer {
 
  public:
   // Create server on localhost. Port 0 instructs the operating system to choose
-  // a free port of its choice.
-  explicit TestHttpServer(HttpHandler httpHandler) {
+  // a free port of its choice. `lazyBodyChunkSize` controls the internal buffer
+  // size for lazy body streaming (ignored in eager mode).
+  explicit TestHttpServer(HttpHandler httpHandler,
+                          size_t lazyBodyChunkSize = 1u << 20u) {
     server_ = std::make_shared<
-        HttpServer<BodyReadMode::Eager, HttpHandler, WebSocketHandlerType>>(
-        0, "0.0.0.0", 1, std::move(httpHandler), webSocketSessionSupplier);
+        HttpServer<readMode, HttpHandler, WebSocketHandlerType>>(
+        0, "0.0.0.0", 1, std::move(httpHandler), webSocketSessionSupplier,
+        lazyBodyChunkSize);
   }
 
   // Get port on which this server is running.
@@ -109,69 +112,6 @@ class TestHttpServer {
   // Since we detach the server thread in `runInOwnThread`, we need to make sure
   // that the server is always shut down when this object does out of scope.
   ~TestHttpServer() { shutDown(); }
-};
-
-// Test HTTP server for lazy body streaming. The handler receives headers, a
-// `bodyGetter` callable (`() -> awaitable<optional<string_view>>`), and a
-// `send` callable, instead of a pre-read body string.
-template <typename HttpHandler>
-class TestLazyHttpServer {
- private:
-  static constexpr auto webSocketSessionSupplier =
-      [](net::io_context& ioContext) {
-        using namespace ad_utility::websocket;
-        return [queryHub = QueryHub{ioContext}, registry = QueryRegistry{}](
-                   const http::request<http::string_body>& request,
-                   tcp::socket socket) mutable {
-          return WebSocketSession::handleSession(queryHub, registry, request,
-                                                 std::move(socket));
-        };
-      };
-  using WebSocketHandlerType =
-      decltype(webSocketSessionSupplier(std::declval<net::io_context&>()));
-
-  std::shared_ptr<
-      HttpServer<BodyReadMode::Lazy, HttpHandler, WebSocketHandlerType>>
-      server_;
-
-  std::unique_ptr<ad_utility::JThread> serverThread_;
-  std::atomic<bool> hasBeenShutDown_ = false;
-
- public:
-  explicit TestLazyHttpServer(HttpHandler httpHandler) {
-    server_ = std::make_shared<
-        HttpServer<BodyReadMode::Lazy, HttpHandler, WebSocketHandlerType>>(
-        0, "0.0.0.0", 1, std::move(httpHandler), webSocketSessionSupplier);
-  }
-
-  auto getPort() const { return server_->getPort(); }
-
-  void runInOwnThread() {
-    auto runnerTask =
-        std::packaged_task<void()>{[server = server_]() { server->run(); }};
-    auto runnerFuture = runnerTask.get_future();
-    serverThread_ =
-        std::make_unique<ad_utility::JThread>(std::move(runnerTask));
-    auto waitTimeUntilServerIsUp = 100ms;
-    auto status = runnerFuture.wait_for(waitTimeUntilServerIsUp);
-    if (status == std::future_status::ready) {
-      runnerFuture.get();
-    }
-    if (!server_->serverIsReady()) {
-      serverThread_->detach();
-      throw std::runtime_error(absl::StrCat("HttpServer was not up after ",
-                                            waitTimeUntilServerIsUp.count(),
-                                            "ms, this should not happen"));
-    }
-  }
-
-  void shutDown() {
-    if (server_->serverIsReady() && !hasBeenShutDown_.exchange(true)) {
-      server_->shutDown();
-    }
-  }
-
-  ~TestLazyHttpServer() { shutDown(); }
 };
 
 #endif  // QLEVER_TEST_HTTPTESTHELPERS_H

--- a/test/HttpTestHelpers.h
+++ b/test/HttpTestHelpers.h
@@ -57,7 +57,7 @@ class TestHttpServer {
   // a free port of its choice. `lazyBodyChunkSize` controls the internal buffer
   // size for lazy body streaming (ignored in eager mode).
   explicit TestHttpServer(HttpHandler httpHandler,
-                          size_t lazyBodyChunkSize = 1u << 20u) {
+                          size_t lazyBodyChunkSize = 100u) {
     server_ = std::make_shared<
         HttpServer<readMode, HttpHandler, WebSocketHandlerType>>(
         0, "0.0.0.0", 1, std::move(httpHandler), webSocketSessionSupplier,

--- a/test/HttpTestHelpers.h
+++ b/test/HttpTestHelpers.h
@@ -61,7 +61,7 @@ class TestHttpServer {
     server_ = std::make_shared<
         HttpServer<readMode, HttpHandler, WebSocketHandlerType>>(
         0, "0.0.0.0", 1, std::move(httpHandler), webSocketSessionSupplier,
-        lazyBodyChunkSize);
+        ad_utility::MemorySize::bytes(lazyBodyChunkSize));
   }
 
   // Get port on which this server is running.

--- a/test/HttpTestHelpers.h
+++ b/test/HttpTestHelpers.h
@@ -111,4 +111,67 @@ class TestHttpServer {
   ~TestHttpServer() { shutDown(); }
 };
 
+// Test HTTP server for lazy body streaming. The handler receives headers, a
+// `bodyGetter` callable (`() -> awaitable<optional<string_view>>`), and a
+// `send` callable, instead of a pre-read body string.
+template <typename HttpHandler>
+class TestLazyHttpServer {
+ private:
+  static constexpr auto webSocketSessionSupplier =
+      [](net::io_context& ioContext) {
+        using namespace ad_utility::websocket;
+        return [queryHub = QueryHub{ioContext}, registry = QueryRegistry{}](
+                   const http::request<http::string_body>& request,
+                   tcp::socket socket) mutable {
+          return WebSocketSession::handleSession(queryHub, registry, request,
+                                                 std::move(socket));
+        };
+      };
+  using WebSocketHandlerType =
+      decltype(webSocketSessionSupplier(std::declval<net::io_context&>()));
+
+  std::shared_ptr<
+      HttpServer<BodyReadMode::Lazy, HttpHandler, WebSocketHandlerType>>
+      server_;
+
+  std::unique_ptr<ad_utility::JThread> serverThread_;
+  std::atomic<bool> hasBeenShutDown_ = false;
+
+ public:
+  explicit TestLazyHttpServer(HttpHandler httpHandler) {
+    server_ = std::make_shared<
+        HttpServer<BodyReadMode::Lazy, HttpHandler, WebSocketHandlerType>>(
+        0, "0.0.0.0", 1, std::move(httpHandler), webSocketSessionSupplier);
+  }
+
+  auto getPort() const { return server_->getPort(); }
+
+  void runInOwnThread() {
+    auto runnerTask =
+        std::packaged_task<void()>{[server = server_]() { server->run(); }};
+    auto runnerFuture = runnerTask.get_future();
+    serverThread_ =
+        std::make_unique<ad_utility::JThread>(std::move(runnerTask));
+    auto waitTimeUntilServerIsUp = 100ms;
+    auto status = runnerFuture.wait_for(waitTimeUntilServerIsUp);
+    if (status == std::future_status::ready) {
+      runnerFuture.get();
+    }
+    if (!server_->serverIsReady()) {
+      serverThread_->detach();
+      throw std::runtime_error(absl::StrCat("HttpServer was not up after ",
+                                            waitTimeUntilServerIsUp.count(),
+                                            "ms, this should not happen"));
+    }
+  }
+
+  void shutDown() {
+    if (server_->serverIsReady() && !hasBeenShutDown_.exchange(true)) {
+      server_->shutDown();
+    }
+  }
+
+  ~TestLazyHttpServer() { shutDown(); }
+};
+
 #endif  // QLEVER_TEST_HTTPTESTHELPERS_H

--- a/test/HttpUtilsTest.cpp
+++ b/test/HttpUtilsTest.cpp
@@ -43,6 +43,27 @@ TEST(HttpUtils, Url) {
   ASSERT_ANY_THROW(Url("http://host.name:8x"));
 }
 
+TEST(HttpUtils, GetHeaderOnlyRequest) {
+  namespace http = boost::beast::http;
+  http::request<http::string_body> original;
+  original.method(http::verb::post);
+  original.target("/api/test");
+  original.version(11);
+  original.keep_alive(true);
+  original.set(http::field::content_type, "text/plain");
+  original.set(http::field::authorization, "Bearer token123");
+  original.body() = "some body that must not appear in the header-only copy";
+
+  auto headerOnly = ad_utility::httpUtils::getHeaderOnlyRequest(original);
+
+  EXPECT_EQ(headerOnly.method(), http::verb::post);
+  EXPECT_EQ(headerOnly.target(), "/api/test");
+  EXPECT_EQ(headerOnly.version(), 11);
+  EXPECT_TRUE(headerOnly.keep_alive());
+  EXPECT_EQ(headerOnly.at(http::field::content_type), "text/plain");
+  EXPECT_EQ(headerOnly.at(http::field::authorization), "Bearer token123");
+}
+
 TEST(HttpUtils, GetStringBodyRequest) {
   namespace http = boost::beast::http;
   http::request<http::string_body> original;

--- a/test/HttpUtilsTest.cpp
+++ b/test/HttpUtilsTest.cpp
@@ -11,6 +11,7 @@
 
 using ad_utility::httpUtils::Url;
 
+// ___________________________________________________________________________
 TEST(HttpUtils, Url) {
   const auto& HTTP = Url::Protocol::HTTP;
   const auto& HTTPS = Url::Protocol::HTTPS;
@@ -43,6 +44,7 @@ TEST(HttpUtils, Url) {
   ASSERT_ANY_THROW(Url("http://host.name:8x"));
 }
 
+// ___________________________________________________________________________
 TEST(HttpUtils, GetHeaderOnlyRequest) {
   namespace http = boost::beast::http;
   http::request<http::string_body> original;
@@ -64,6 +66,7 @@ TEST(HttpUtils, GetHeaderOnlyRequest) {
   EXPECT_EQ(headerOnly.at(http::field::authorization), "Bearer token123");
 }
 
+// ___________________________________________________________________________
 TEST(HttpUtils, GetStringBodyRequest) {
   namespace http = boost::beast::http;
   http::request<http::string_body> original;

--- a/test/HttpUtilsTest.cpp
+++ b/test/HttpUtilsTest.cpp
@@ -7,6 +7,7 @@
 #include <tuple>
 
 #include "util/http/HttpUtils.h"
+#include "util/http/beast.h"
 
 using ad_utility::httpUtils::Url;
 
@@ -40,4 +41,27 @@ TEST(HttpUtils, Url) {
   ASSERT_ANY_THROW(Url("htt://host.name/tar/get"));
   ASSERT_ANY_THROW(Url("http://host.name:8x/tar/get"));
   ASSERT_ANY_THROW(Url("http://host.name:8x"));
+}
+
+TEST(HttpUtils, GetStringBodyRequest) {
+  namespace http = boost::beast::http;
+  http::request<http::string_body> original;
+  original.method(http::verb::post);
+  original.target("/api/test");
+  original.version(11);
+  original.keep_alive(true);
+  original.set(http::field::content_type, "text/plain");
+  original.set(http::field::authorization, "Bearer token123");
+  original.body() = "original body (must not appear in result)";
+
+  auto result =
+      ad_utility::httpUtils::getStringBodyRequest(original, "new body");
+
+  EXPECT_EQ(result.method(), http::verb::post);
+  EXPECT_EQ(result.target(), "/api/test");
+  EXPECT_EQ(result.version(), 11);
+  EXPECT_TRUE(result.keep_alive());
+  EXPECT_EQ(result.at(http::field::content_type), "text/plain");
+  EXPECT_EQ(result.at(http::field::authorization), "Bearer token123");
+  EXPECT_EQ(result.body(), "new body");
 }


### PR DESCRIPTION
Extends `HttpServer` so the handler can consume the body lazily, without having to materialize it fully in RAM. This is the basis for implementing an HTTP file server to which files can be posted during index building. It also can be used for lazy parsing of large SPARQL updates. Some implementation details:

1.  Add a template parameter `BodyReadMode` to `HttpServer` with two options: `Eager` and `Lazy`
2. In `Lazy` mode, the request body is streamed chunk-by-chunk to the handler, by passing a callable to the handler that it has to invoke to get the next result chunk
3. The `Eager` mode works just like the `HttpServer` did so far, without modification
4. The tests for `HttpServer` were refactored and extended such that it is now easy to write tests for both modes