### PR TITLE
Delegate management of index, cache, etc. from `Server` to `Qlever` class

### DIFF
--- a/src/ServerMain.cpp
+++ b/src/ServerMain.cpp
@@ -75,8 +75,9 @@ int main(int argc, char** argv) {
       po::value<NonNegative>(&numSimultaneousQueries)->default_value(1),
       "The number of queries that can be processed simultaneously.");
   add("memory-max-size,m",
-      po::value<ad_utility::MemorySize>()->notifier(
-          [&config](auto v) { config.memoryLimit_ = v; }),
+      po::value<ad_utility::MemorySize>()
+          ->default_value(DEFAULT_MEM_FOR_QUERIES)
+          ->notifier([&config](auto v) { config.memoryLimit_ = v; }),
       "Limit on the total amount of memory that can be used for "
       "query processing and caching. If exceeded, query will return with "
       "an error, but the engine will not crash.");

--- a/src/ServerMain.cpp
+++ b/src/ServerMain.cpp
@@ -229,9 +229,10 @@ int main(int argc, char** argv) {
 
   try {
     Server server(port, numSimultaneousQueries, memoryMaxSize,
-                  std::move(accessToken), noAccessCheck, !noPatterns);
-    server.run(indexBasename, text, !noPatterns, !onlyPsoAndPosPermutations,
-               persistUpdates, preloadMaterializedViews);
+                  std::move(accessToken), indexBasename, text, !noPatterns,
+                  !onlyPsoAndPosPermutations, persistUpdates,
+                  preloadMaterializedViews, noAccessCheck, !noPatterns);
+    server.run();
   } catch (const std::exception& e) {
     // This code should never be reached as all exceptions should be handled
     // within server.run()

--- a/src/ServerMain.cpp
+++ b/src/ServerMain.cpp
@@ -15,6 +15,7 @@
 #include "engine/Server.h"
 #include "global/Constants.h"
 #include "global/RuntimeParameters.h"
+#include "libqlever/Qlever.h"
 #include "util/MemorySize/MemorySize.h"
 #include "util/ParseableDuration.h"
 #include "util/ProgramOptionsHelpers.h"
@@ -228,10 +229,15 @@ int main(int argc, char** argv) {
               << std::endl;
 
   try {
-    Server server(port, numSimultaneousQueries, memoryMaxSize,
-                  std::move(accessToken), indexBasename, text, !noPatterns,
-                  !onlyPsoAndPosPermutations, persistUpdates,
-                  preloadMaterializedViews, noAccessCheck, !noPatterns);
+    qlever::EngineConfig config;
+    config.baseName_ = indexBasename;
+    config.loadTextIndex_ = text;
+    config.noPatterns_ = noPatterns;
+    config.onlyPsoAndPos_ = onlyPsoAndPosPermutations;
+    config.persistUpdates_ = persistUpdates;
+    config.memoryLimit_ = memoryMaxSize;
+    Server server(port, numSimultaneousQueries, std::move(accessToken), config,
+                  preloadMaterializedViews, noAccessCheck);
     server.run();
   } catch (const std::exception& e) {
     // This code should never be reached as all exceptions should be handled

--- a/src/ServerMain.cpp
+++ b/src/ServerMain.cpp
@@ -236,8 +236,9 @@ int main(int argc, char** argv) {
     config.onlyPsoAndPos_ = onlyPsoAndPosPermutations;
     config.persistUpdates_ = persistUpdates;
     config.memoryLimit_ = memoryMaxSize;
+    config.preloadMaterializedViews_ = preloadMaterializedViews;
     Server server(port, numSimultaneousQueries, std::move(accessToken), config,
-                  preloadMaterializedViews, noAccessCheck);
+                  noAccessCheck);
     server.run();
   } catch (const std::exception& e) {
     // This code should never be reached as all exceptions should be handled

--- a/src/ServerMain.cpp
+++ b/src/ServerMain.cpp
@@ -45,18 +45,11 @@ int main(int argc, char** argv) {
   // filled / set depending on the options.
   using ad_utility::NonNegative;
 
-  std::string indexBasename;
+  qlever::EngineConfig config;
   std::string accessToken;
   bool noAccessCheck = false;
-  bool text = false;
   unsigned short port;
   NonNegative numSimultaneousQueries = 1;
-  bool noPatterns;
-  bool onlyPsoAndPosPermutations;
-  bool persistUpdates;
-  std::vector<std::string> preloadMaterializedViews;
-
-  ad_utility::MemorySize memoryMaxSize;
 
   ad_utility::ParameterToProgramOptionFactory optionFactory{
       &globalRuntimeParameters};
@@ -68,7 +61,7 @@ int main(int argc, char** argv) {
   add("help,h", "Produce this help message.");
   add("version,v", "Print version information.");
   // TODO<joka921> Can we output the "required" automatically?
-  add("index-basename,i", po::value<std::string>(&indexBasename)->required(),
+  add("index-basename,i", po::value<std::string>(&config.baseName_)->required(),
       "The basename of the index files (required).");
   add("port,p", po::value<unsigned short>(&port)->required(),
       "The port on which HTTP requests are served (required).");
@@ -82,8 +75,8 @@ int main(int argc, char** argv) {
       po::value<NonNegative>(&numSimultaneousQueries)->default_value(1),
       "The number of queries that can be processed simultaneously.");
   add("memory-max-size,m",
-      po::value<ad_utility::MemorySize>(&memoryMaxSize)
-          ->default_value(DEFAULT_MEM_FOR_QUERIES),
+      po::value<ad_utility::MemorySize>()->notifier(
+          [&config](auto v) { config.memoryLimit_ = v; }),
       "Limit on the total amount of memory that can be used for "
       "query processing and caching. If exceeded, query will return with "
       "an error, but the engine will not crash.");
@@ -109,14 +102,14 @@ int main(int argc, char** argv) {
       "least-recently used non-pinned entries from the cache. Note that "
       "this condition and the size limit specified via --cache-max-size "
       "both have to hold (logical AND).");
-  add("no-patterns,P", po::bool_switch(&noPatterns),
+  add("no-patterns,P", po::bool_switch(&config.noPatterns_),
       "Disable the use of patterns. If disabled, the special predicate "
       "`ql:has-predicate` is not available.");
-  add("text,t", po::bool_switch(&text),
+  add("text,t", po::bool_switch(&config.loadTextIndex_),
       "Also load the text index. The text index must have been built before "
       "using `qlever-index` with options `-d` and `- w`.");
   add("only-pso-and-pos-permutations,o",
-      po::bool_switch(&onlyPsoAndPosPermutations),
+      po::bool_switch(&config.onlyPsoAndPos_),
       "Only load the PSO and POS permutations. This disables queries with "
       "predicate variables.");
   add("default-query-timeout,s",
@@ -147,7 +140,7 @@ int main(int argc, char** argv) {
       "endpoint might change at any point in time. If you control the "
       "endpoints, you can override this setting. This will disable the sibling "
       "optimization where VALUES are dynamically pushed into `SERVICE`.");
-  add("persist-updates", po::bool_switch(&persistUpdates),
+  add("persist-updates", po::bool_switch(&config.persistUpdates_),
       "If set, then SPARQL UPDATES will be persisted on disk. Otherwise they "
       "will be lost when the engine is stopped");
   add("syntax-test-mode",
@@ -179,7 +172,7 @@ int main(int argc, char** argv) {
       "Memory limit for sorting rows during the writing of materialized "
       "views.");
   add("preload-materialized-views,l",
-      po::value<std::vector<std::string>>(&preloadMaterializedViews)
+      po::value<std::vector<std::string>>(&config.preloadMaterializedViews_)
           ->multitoken(),
       "The names of materialized views to be loaded automatically on server "
       "start (this option takes an arbitrary number of arguments).");
@@ -229,14 +222,6 @@ int main(int argc, char** argv) {
               << std::endl;
 
   try {
-    qlever::EngineConfig config;
-    config.baseName_ = indexBasename;
-    config.loadTextIndex_ = text;
-    config.noPatterns_ = noPatterns;
-    config.onlyPsoAndPos_ = onlyPsoAndPosPermutations;
-    config.persistUpdates_ = persistUpdates;
-    config.memoryLimit_ = memoryMaxSize;
-    config.preloadMaterializedViews_ = preloadMaterializedViews;
     Server server(port, numSimultaneousQueries, std::move(accessToken), config,
                   noAccessCheck);
     server.run();

--- a/src/engine/CMakeLists.txt
+++ b/src/engine/CMakeLists.txt
@@ -39,4 +39,5 @@ if (NOT REDUCED_FEATURE_SET_FOR_CPP17)
 endif()
 
 add_library(server Server.cpp)
-qlever_target_link_libraries(server engine util index parser global http SortPerformanceEstimator)
+qlever_target_link_libraries(server engine util index parser global http
+SortPerformanceEstimator qlever)

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -52,6 +52,9 @@ using ad_utility::MediaType;
 // __________________________________________________________________________
 Server::Server(unsigned short port, size_t numThreads,
                ad_utility::MemorySize maxMem, std::string accessToken,
+               const std::string& indexBaseName, bool useText, bool usePatterns,
+               bool loadAllPermutations, bool persistUpdates,
+               std::vector<std::string> preloadMaterializedViews,
                bool noAccessCheck, bool usePatternTrick)
     : maxMem_{maxMem},
       numThreads_(numThreads),
@@ -59,16 +62,12 @@ Server::Server(unsigned short port, size_t numThreads,
       accessToken_(std::move(accessToken)),
       noAccessCheck_(noAccessCheck),
       enablePatternTrick_(usePatternTrick),
-      queryThreadPool_{numThreads} {}
-
-// __________________________________________________________________________
-void Server::initialize(const std::string& indexBaseName, bool useText,
-                        bool usePatterns, bool loadAllPermutations,
-                        bool persistUpdates,
-                        std::vector<std::string> preloadMaterializedViews) {
+      queryThreadPool_{numThreads} {
   AD_LOG_INFO << "Initializing server ..." << std::endl;
 
   // Creating `EngineConfig` for the `Qlever` object.
+  // The config object is needed only for initiliazitaion of qlever Object,
+  // therefore exists only here.
   qlever::EngineConfig config;
   config.baseName_ = indexBaseName;
   config.loadTextIndex_ = useText;
@@ -104,10 +103,7 @@ void Server::initialize(const std::string& indexBaseName, bool useText,
 }
 
 // _____________________________________________________________________________
-void Server::run(const std::string& indexBaseName, bool useText,
-                 bool usePatterns, bool loadAllPermutations,
-                 bool persistUpdates,
-                 std::vector<std::string> preloadMaterializedViews) {
+void Server::run() {
   using namespace ad_utility::httpUtils;
 
   // Function that handles a request asynchronously, will be passed as argument
@@ -188,8 +184,8 @@ void Server::run(const std::string& indexBaseName, bool useText,
                                std::move(webSocketSessionSupplier)};
 
   // Initialize the index
-  initialize(indexBaseName, useText, usePatterns, loadAllPermutations,
-             persistUpdates, std::move(preloadMaterializedViews));
+  //  initialize(indexBaseName, useText, usePatterns, loadAllPermutations,
+  //           persistUpdates, std::move(preloadMaterializedViews));
 
   AD_LOG_INFO << "The server is ready, listening for requests on port "
               << std::to_string(httpServer.getPort()) << " ..." << std::endl;

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -68,7 +68,7 @@ void Server::initialize(const std::string& indexBaseName, bool useText,
                         std::vector<std::string> preloadMaterializedViews) {
   AD_LOG_INFO << "Initializing server ..." << std::endl;
 
-  // creating engine config for the qlever object
+  // Creating `EngineConfig` for the `Qlever` object.
   qlever::EngineConfig config;
   config.baseName_ = indexBaseName;
   config.loadTextIndex_ = useText;
@@ -79,7 +79,7 @@ void Server::initialize(const std::string& indexBaseName, bool useText,
   // that can be processed simultaneously.
   config.memoryLimit_ = maxMem_;
 
-  // Initialize the Qlever object (in the constructor is the index created)
+  // Initialize the `Qlever` object (in the constructor is the index created).
   qlever_.emplace(config);
 
   // Preload materialized views as requested by the user. This is done in a

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -30,6 +30,7 @@
 #include "global/RuntimeParameters.h"
 #include "index/IndexImpl.h"
 #include "index/IndexRebuilder.h"
+#include "libqlever/Qlever.h"
 #include "parser/SparqlParser.h"
 #include "util/AsioHelpers.h"
 #include "util/Exception.h"
@@ -50,43 +51,24 @@ using Awaitable = Server::Awaitable<T>;
 using ad_utility::MediaType;
 
 // __________________________________________________________________________
-Server::Server(unsigned short port, size_t numThreads,
-               ad_utility::MemorySize maxMem, std::string accessToken,
-               const std::string& indexBaseName, bool useText, bool usePatterns,
-               bool loadAllPermutations, bool persistUpdates,
+Server::Server(unsigned short port, size_t numThreads, std::string accessToken,
+               const qlever::EngineConfig& config,
                std::vector<std::string> preloadMaterializedViews,
-               bool noAccessCheck, bool usePatternTrick)
-    : maxMem_{maxMem},
+               bool noAccessCheck)
+    : qlever_(config),
       numThreads_(numThreads),
       port_(port),
       accessToken_(std::move(accessToken)),
       noAccessCheck_(noAccessCheck),
-      enablePatternTrick_(usePatternTrick),
       queryThreadPool_{numThreads} {
   AD_LOG_INFO << "Initializing server ..." << std::endl;
-
-  // Creating `EngineConfig` for the `Qlever` object.
-  // The config object is needed only for initiliazitaion of qlever Object,
-  // therefore exists only here.
-  qlever::EngineConfig config;
-  config.baseName_ = indexBaseName;
-  config.loadTextIndex_ = useText;
-  config.noPatterns_ = !usePatterns;
-  config.onlyPsoAndPos_ = !loadAllPermutations;
-  config.persistUpdates_ = persistUpdates;
-  // The number of server threads currently also is the number of queries
-  // that can be processed simultaneously.
-  config.memoryLimit_ = maxMem_;
-
-  // Initialize the `Qlever` object (in the constructor is the index created).
-  qlever_.emplace(config);
 
   // Preload materialized views as requested by the user. This is done in a
   // try-catch block to prevent an exception during loading of a view from
   // blocking the server start.
   for (const auto& viewName : preloadMaterializedViews) {
     try {
-      qlever_->loadMaterializedView(viewName);
+      qlever_.loadMaterializedView(viewName);
     } catch (const std::exception& ex) {
       AD_LOG_ERROR << "Preloading materialized view '" << viewName
                    << "' failed: " << ex.what() << "." << std::endl;

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -53,31 +53,13 @@ using ad_utility::MediaType;
 Server::Server(unsigned short port, size_t numThreads,
                ad_utility::MemorySize maxMem, std::string accessToken,
                bool noAccessCheck, bool usePatternTrick)
-    : numThreads_(numThreads),
+    : maxMem_{maxMem},
+      numThreads_(numThreads),
       port_(port),
       accessToken_(std::move(accessToken)),
       noAccessCheck_(noAccessCheck),
-      allocator_{ad_utility::makeAllocationMemoryLeftThreadsafeObject(maxMem),
-                 [this](ad_utility::MemorySize numMemoryToAllocate) {
-                   cache_.makeRoomAsMuchAsPossible(MAKE_ROOM_SLACK_FACTOR *
-                                                   numMemoryToAllocate);
-                 }},
-      index_{std::make_shared<Index>(allocator_)},
       enablePatternTrick_(usePatternTrick),
-      // The number of server threads currently also is the number of queries
-      // that can be processed simultaneously.
-      queryThreadPool_{numThreads} {
-  // This also directly triggers the update functions and propagates the
-  // values of the parameters to the cache.
-  globalRuntimeParameters.wlock()->cacheMaxNumEntries_.setOnUpdateAction(
-      [this](size_t newValue) { cache_.setMaxNumEntries(newValue); });
-  globalRuntimeParameters.wlock()->cacheMaxSize_.setOnUpdateAction(
-      [this](ad_utility::MemorySize newValue) { cache_.setMaxSize(newValue); });
-  globalRuntimeParameters.wlock()->cacheMaxSizeSingleEntry_.setOnUpdateAction(
-      [this](ad_utility::MemorySize newValue) {
-        cache_.setMaxSizeSingleEntry(newValue);
-      });
-}
+      queryThreadPool_{numThreads} {}
 
 // __________________________________________________________________________
 void Server::initialize(const std::string& indexBaseName, bool useText,
@@ -86,32 +68,31 @@ void Server::initialize(const std::string& indexBaseName, bool useText,
                         std::vector<std::string> preloadMaterializedViews) {
   AD_LOG_INFO << "Initializing server ..." << std::endl;
 
-  index().usePatterns() = usePatterns;
-  index().loadAllPermutations() = loadAllPermutations;
+  // creating engine config for the qlever object
+  qlever::EngineConfig config;
+  config.baseName_ = indexBaseName;
+  config.loadTextIndex_ = useText;
+  config.noPatterns_ = !usePatterns;
+  config.onlyPsoAndPos_ = !loadAllPermutations;
+  config.persistUpdates_ = persistUpdates;
+  // The number of server threads currently also is the number of queries
+  // that can be processed simultaneously.
+  config.memoryLimit_ = maxMem_;
 
-  // Init the index.
-  index().createFromOnDiskIndex(indexBaseName, persistUpdates);
-  if (useText) {
-    index().addTextFromOnDiskIndex();
-  }
-
-  materializedViewsManager_->setOnDiskBase(indexBaseName);
+  // Initialize the Qlever object (in the constructor is the index created)
+  qlever_.emplace(config);
 
   // Preload materialized views as requested by the user. This is done in a
   // try-catch block to prevent an exception during loading of a view from
   // blocking the server start.
   for (const auto& viewName : preloadMaterializedViews) {
     try {
-      materializedViewsManager_->loadView(viewName);
+      qlever_->loadMaterializedView(viewName);
     } catch (const std::exception& ex) {
       AD_LOG_ERROR << "Preloading materialized view '" << viewName
                    << "' failed: " << ex.what() << "." << std::endl;
     }
   }
-
-  sortPerformanceEstimator_.computeEstimatesExpensively(
-      allocator_, index().numTriples().normalAndInternal_() *
-                      PERCENTAGE_OF_TRIPLES_FOR_SORT_ESTIMATE / 100);
 
   if (noAccessCheck_) {
     AD_LOG_INFO << "No access token required for restricted API calls"
@@ -328,8 +309,9 @@ auto Server::prepareOperation(
       std::make_shared<ad_utility::websocket::MessageSender>(
           std::move(messageSender));
   auto qec = std::make_shared<QueryExecutionContext>(
-      index_, &cache_, allocator_, sortPerformanceEstimator_,
-      &namedResultCache_, materializedViewsManager_,
+      qlever_->sharedIndex(), &qlever_->cache(), qlever_->allocator(),
+      qlever_->sortPerformanceEstimator(), &qlever_->namedResultCache(),
+      qlever_->materializedViewsManager(),
       [sharedMessageSender = std::move(sharedMessageSender)](std::string json) {
         (*sharedMessageSender)(std::move(json));
       },
@@ -430,17 +412,17 @@ CPP_template_def(typename RequestT, typename ResponseT)(
     response = createJsonResponse(composeCacheStatsJson(), request);
   } else if (auto cmd = checkParameter("cmd", "clear-cache")) {
     logCommand(cmd, "clear the cache (unpinned elements only)");
-    cache_.clearUnpinnedOnly();
+    qlever_->cache().clearUnpinnedOnly();
     response = createJsonResponse(composeCacheStatsJson(), request);
   } else if (auto cmd = checkParameter("cmd", "clear-cache-complete")) {
     requireValidAccessToken("clear-cache-complete");
     logCommand(cmd, "clear cache completely (including unpinned elements)");
-    cache_.clearAll();
+    qlever_->cache().clearAll();
     response = createJsonResponse(composeCacheStatsJson(), request);
   } else if (auto cmd = checkParameter("cmd", "clear-named-cache")) {
     requireValidAccessToken("clear-named-cache");
     logCommand(cmd, "clear the cache for named results");
-    namedResultCache_.clear();
+    qlever_->namedResultCache().clear();
     response = createJsonResponse(composeCacheStatsJson(), request);
   } else if (auto cmd = checkParameter("cmd", "clear-delta-triples")) {
     requireValidAccessToken("clear-delta-triples");
@@ -590,7 +572,7 @@ CPP_template_def(typename RequestT, typename ResponseT)(
         parameters, "view-name");
     AD_CONTRACT_CHECK(name.has_value());
 
-    materializedViewsManager_->loadView(name.value());
+    qlever_->materializedViewsManager()->loadView(name.value());
 
     // Construct simple response JSON.
     nlohmann::json json{{"materialized-view-loaded", name.value()}};
@@ -837,42 +819,59 @@ nlohmann::json Server::composeErrorResponseJson(
 
 // _____________________________________________________________________________
 nlohmann::json Server::composeStatsJson() const {
+  // default settings needed because there is now a window between Server
+  // construction and the Qlever object construction in the Initialise() (index
+  // is now in the qlever_ member variable.
   json result;
-  result["name-index"] = index().getKbName();
-  result["git-hash-index"] = index().getGitShortHash();
   result["git-hash-server"] =
       *qlever::version::gitShortHashWithoutLinking.wlock();
-  result["num-permutations"] = (index().hasAllPermutations() ? 6 : 2);
-  result["num-predicates-normal"] = index().numDistinctPredicates().normal;
-  result["num-predicates-internal"] = index().numDistinctPredicates().internal;
-  if (index().hasAllPermutations()) {
-    result["num-subjects-normal"] = index().numDistinctSubjects().normal;
-    result["num-subjects-internal"] = index().numDistinctSubjects().internal;
-    result["num-objects-normal"] = index().numDistinctObjects().normal;
-    result["num-objects-internal"] = index().numDistinctObjects().internal;
-  }
+  result["name-index"] = "";
+  result["git-hash-index"] = "git short hash not set";
+  result["num-permutations"] = 2;
+  result["num-predicates-normal"] = 0;
+  result["num-predicates-internal"] = 0;
+  result["num-triples-normal"] = 0;
+  result["num-triples-internal"] = 0;
+  result["name-text-index"] = "";
+  result["num-text-records"] = 0;
+  result["num-word-occurrences"] = 0;
+  result["num-entity-occurrences"] = 0;
 
-  auto numTriples = index().numTriples();
-  result["num-triples-normal"] = numTriples.normal;
-  result["num-triples-internal"] = numTriples.internal;
-  result["name-text-index"] = index().getTextName();
-  result["num-text-records"] = index().getNofTextRecords();
-  result["num-word-occurrences"] = index().getNofWordPostings();
-  result["num-entity-occurrences"] = index().getNofEntityPostings();
+  if (qlever_.has_value()) {
+    result["name-index"] = index().getKbName();
+    result["git-hash-index"] = index().getGitShortHash();
+    result["num-permutations"] = (index().hasAllPermutations() ? 6 : 2);
+    result["num-predicates-normal"] = index().numDistinctPredicates().normal;
+    result["num-predicates-internal"] =
+        index().numDistinctPredicates().internal;
+    if (index().hasAllPermutations()) {
+      result["num-subjects-normal"] = index().numDistinctSubjects().normal;
+      result["num-subjects-internal"] = index().numDistinctSubjects().internal;
+      result["num-objects-normal"] = index().numDistinctObjects().normal;
+      result["num-objects-internal"] = index().numDistinctObjects().internal;
+    }
+    auto numTriples = index().numTriples();
+    result["num-triples-normal"] = numTriples.normal;
+    result["num-triples-internal"] = numTriples.internal;
+    result["name-text-index"] = index().getTextName();
+    result["num-text-records"] = index().getNofTextRecords();
+    result["num-word-occurrences"] = index().getNofWordPostings();
+    result["num-entity-occurrences"] = index().getNofEntityPostings();
+  }
   return result;
 }
 
 // _______________________________________
 nlohmann::json Server::composeCacheStatsJson() const {
   nlohmann::json result;
-  result["num-results-unpinned"] = cache_.numNonPinnedEntries();
-  result["num-results-pinned-unnamed"] = cache_.numPinnedEntries();
-  result["num-results-pinned-named"] = namedResultCache_.numEntries();
+  result["num-results-unpinned"] = qlever_->cache().numNonPinnedEntries();
+  result["num-results-pinned-unnamed"] = qlever_->cache().numPinnedEntries();
+  result["num-results-pinned-named"] = qlever_->namedResultCache().numEntries();
 
   // TODO: Get rid of the `getByte()`, once `MemorySize` has it's own JSON
   // converter.
-  result["cache-size-unpinned"] = cache_.nonPinnedSize().getBytes();
-  result["cache-size-pinned"] = cache_.pinnedSize().getBytes();
+  result["cache-size-unpinned"] = qlever_->cache().nonPinnedSize().getBytes();
+  result["cache-size-pinned"] = qlever_->cache().pinnedSize().getBytes();
   return result;
 }
 
@@ -1185,8 +1184,8 @@ UpdateMetadata Server::processUpdateImpl(
   // Clear the cache, because all cache entries have been invalidated by
   // the update anyway (The index of the located triples snapshot is
   // part of the cache key).
-  cache_.clearAll();
-  namedResultCache_.clear();
+  qlever_->cache().clearAll();
+  qlever_->namedResultCache().clear();
   tracer.endTrace("clearCache");
 
   return updateMetadata;
@@ -1487,15 +1486,16 @@ void Server::writeMaterializedView(
   auto parsedQuery = SparqlParser::parseQuery(
       &index().encodedIriManager(), query.query_, query.datasetClauses_);
   auto qec = std::make_shared<QueryExecutionContext>(
-      index_, &cache_, allocator_, sortPerformanceEstimator_,
-      &namedResultCache_, materializedViewsManager_);
+      qlever_->sharedIndex(), &qlever_->cache(), qlever_->allocator(),
+      qlever_->sortPerformanceEstimator(), &qlever_->namedResultCache(),
+      qlever_->materializedViewsManager());
   auto plan = planQuery(std::move(parsedQuery), requestTimer, timeLimit, *qec,
                         cancellationHandle);
   auto qet = std::make_shared<QueryExecutionTree>(
       std::move(plan.queryExecutionTree()));
   auto memoryLimit =
       getRuntimeParameter<&RuntimeParameters::materializedViewWriterMemory_>();
-  materializedViewsManager_->writeViewToDisk(
+  qlever_->materializedViewsManager()->writeViewToDisk(
       name, {qet, qec, std::move(plan.parsedQuery())}, memoryLimit);
 }
 

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -309,9 +309,8 @@ auto Server::prepareOperation(
       std::make_shared<ad_utility::websocket::MessageSender>(
           std::move(messageSender));
   auto qec = std::make_shared<QueryExecutionContext>(
-      qlever_->sharedIndex(), &qlever_->cache(), qlever_->allocator(),
-      qlever_->sortPerformanceEstimator(), &qlever_->namedResultCache(),
-      qlever_->materializedViewsManager(),
+      sharedIndex(), &cache(), allocator(), sortPerformanceEstimator(),
+      &namedResultCache(), materializedViewsManager(),
       [sharedMessageSender = std::move(sharedMessageSender)](std::string json) {
         (*sharedMessageSender)(std::move(json));
       },
@@ -412,17 +411,17 @@ CPP_template_def(typename RequestT, typename ResponseT)(
     response = createJsonResponse(composeCacheStatsJson(), request);
   } else if (auto cmd = checkParameter("cmd", "clear-cache")) {
     logCommand(cmd, "clear the cache (unpinned elements only)");
-    qlever_->cache().clearUnpinnedOnly();
+    cache().clearUnpinnedOnly();
     response = createJsonResponse(composeCacheStatsJson(), request);
   } else if (auto cmd = checkParameter("cmd", "clear-cache-complete")) {
     requireValidAccessToken("clear-cache-complete");
     logCommand(cmd, "clear cache completely (including unpinned elements)");
-    qlever_->cache().clearAll();
+    cache().clearAll();
     response = createJsonResponse(composeCacheStatsJson(), request);
   } else if (auto cmd = checkParameter("cmd", "clear-named-cache")) {
     requireValidAccessToken("clear-named-cache");
     logCommand(cmd, "clear the cache for named results");
-    qlever_->namedResultCache().clear();
+    namedResultCache().clear();
     response = createJsonResponse(composeCacheStatsJson(), request);
   } else if (auto cmd = checkParameter("cmd", "clear-delta-triples")) {
     requireValidAccessToken("clear-delta-triples");
@@ -572,7 +571,7 @@ CPP_template_def(typename RequestT, typename ResponseT)(
         parameters, "view-name");
     AD_CONTRACT_CHECK(name.has_value());
 
-    qlever_->materializedViewsManager()->loadView(name.value());
+    materializedViewsManager()->loadView(name.value());
 
     // Construct simple response JSON.
     nlohmann::json json{{"materialized-view-loaded", name.value()}};
@@ -819,59 +818,42 @@ nlohmann::json Server::composeErrorResponseJson(
 
 // _____________________________________________________________________________
 nlohmann::json Server::composeStatsJson() const {
-  // default settings needed because there is now a window between Server
-  // construction and the Qlever object construction in the Initialise() (index
-  // is now in the qlever_ member variable.
   json result;
+  result["name-index"] = index().getKbName();
+  result["git-hash-index"] = index().getGitShortHash();
   result["git-hash-server"] =
       *qlever::version::gitShortHashWithoutLinking.wlock();
-  result["name-index"] = "";
-  result["git-hash-index"] = "git short hash not set";
-  result["num-permutations"] = 2;
-  result["num-predicates-normal"] = 0;
-  result["num-predicates-internal"] = 0;
-  result["num-triples-normal"] = 0;
-  result["num-triples-internal"] = 0;
-  result["name-text-index"] = "";
-  result["num-text-records"] = 0;
-  result["num-word-occurrences"] = 0;
-  result["num-entity-occurrences"] = 0;
-
-  if (qlever_.has_value()) {
-    result["name-index"] = index().getKbName();
-    result["git-hash-index"] = index().getGitShortHash();
-    result["num-permutations"] = (index().hasAllPermutations() ? 6 : 2);
-    result["num-predicates-normal"] = index().numDistinctPredicates().normal;
-    result["num-predicates-internal"] =
-        index().numDistinctPredicates().internal;
-    if (index().hasAllPermutations()) {
-      result["num-subjects-normal"] = index().numDistinctSubjects().normal;
-      result["num-subjects-internal"] = index().numDistinctSubjects().internal;
-      result["num-objects-normal"] = index().numDistinctObjects().normal;
-      result["num-objects-internal"] = index().numDistinctObjects().internal;
-    }
-    auto numTriples = index().numTriples();
-    result["num-triples-normal"] = numTriples.normal;
-    result["num-triples-internal"] = numTriples.internal;
-    result["name-text-index"] = index().getTextName();
-    result["num-text-records"] = index().getNofTextRecords();
-    result["num-word-occurrences"] = index().getNofWordPostings();
-    result["num-entity-occurrences"] = index().getNofEntityPostings();
+  result["num-permutations"] = (index().hasAllPermutations() ? 6 : 2);
+  result["num-predicates-normal"] = index().numDistinctPredicates().normal;
+  result["num-predicates-internal"] = index().numDistinctPredicates().internal;
+  if (index().hasAllPermutations()) {
+    result["num-subjects-normal"] = index().numDistinctSubjects().normal;
+    result["num-subjects-internal"] = index().numDistinctSubjects().internal;
+    result["num-objects-normal"] = index().numDistinctObjects().normal;
+    result["num-objects-internal"] = index().numDistinctObjects().internal;
   }
+
+  auto numTriples = index().numTriples();
+  result["num-triples-normal"] = numTriples.normal;
+  result["num-triples-internal"] = numTriples.internal;
+  result["name-text-index"] = index().getTextName();
+  result["num-text-records"] = index().getNofTextRecords();
+  result["num-word-occurrences"] = index().getNofWordPostings();
+  result["num-entity-occurrences"] = index().getNofEntityPostings();
   return result;
 }
 
 // _______________________________________
 nlohmann::json Server::composeCacheStatsJson() const {
   nlohmann::json result;
-  result["num-results-unpinned"] = qlever_->cache().numNonPinnedEntries();
-  result["num-results-pinned-unnamed"] = qlever_->cache().numPinnedEntries();
-  result["num-results-pinned-named"] = qlever_->namedResultCache().numEntries();
+  result["num-results-unpinned"] = cache().numNonPinnedEntries();
+  result["num-results-pinned-unnamed"] = cache().numPinnedEntries();
+  result["num-results-pinned-named"] = namedResultCache().numEntries();
 
   // TODO: Get rid of the `getByte()`, once `MemorySize` has it's own JSON
   // converter.
-  result["cache-size-unpinned"] = qlever_->cache().nonPinnedSize().getBytes();
-  result["cache-size-pinned"] = qlever_->cache().pinnedSize().getBytes();
+  result["cache-size-unpinned"] = cache().nonPinnedSize().getBytes();
+  result["cache-size-pinned"] = cache().pinnedSize().getBytes();
   return result;
 }
 
@@ -1184,8 +1166,8 @@ UpdateMetadata Server::processUpdateImpl(
   // Clear the cache, because all cache entries have been invalidated by
   // the update anyway (The index of the located triples snapshot is
   // part of the cache key).
-  qlever_->cache().clearAll();
-  qlever_->namedResultCache().clear();
+  cache().clearAll();
+  namedResultCache().clear();
   tracer.endTrace("clearCache");
 
   return updateMetadata;
@@ -1486,16 +1468,15 @@ void Server::writeMaterializedView(
   auto parsedQuery = SparqlParser::parseQuery(
       &index().encodedIriManager(), query.query_, query.datasetClauses_);
   auto qec = std::make_shared<QueryExecutionContext>(
-      qlever_->sharedIndex(), &qlever_->cache(), qlever_->allocator(),
-      qlever_->sortPerformanceEstimator(), &qlever_->namedResultCache(),
-      qlever_->materializedViewsManager());
+      sharedIndex(), &cache(), allocator(), sortPerformanceEstimator(),
+      &namedResultCache(), materializedViewsManager());
   auto plan = planQuery(std::move(parsedQuery), requestTimer, timeLimit, *qec,
                         cancellationHandle);
   auto qet = std::make_shared<QueryExecutionTree>(
       std::move(plan.queryExecutionTree()));
   auto memoryLimit =
       getRuntimeParameter<&RuntimeParameters::materializedViewWriterMemory_>();
-  qlever_->materializedViewsManager()->writeViewToDisk(
+  materializedViewsManager()->writeViewToDisk(
       name, {qet, qec, std::move(plan.parsedQuery())}, memoryLimit);
 }
 

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -272,14 +272,11 @@ auto Server::prepareOperation(
   auto sharedMessageSender =
       std::make_shared<ad_utility::websocket::MessageSender>(
           std::move(messageSender));
-  auto qec = std::make_shared<QueryExecutionContext>(
-      sharedIndex(), &cache(), allocator(), sortPerformanceEstimator(),
-      &namedResultCache(), materializedViewsManager(),
+  auto qec = qlever().createQueryExecutionContext(
       [sharedMessageSender = std::move(sharedMessageSender)](std::string json) {
         (*sharedMessageSender)(std::move(json));
       },
       pinSubtrees, pinResult);
-
   configurePinnedResultWithName(pinResultWithName, pinNamedGeoIndex,
                                 accessTokenOk, *qec);
   return std::make_tuple(std::move(qec), std::move(cancellationHandle),
@@ -1431,9 +1428,7 @@ void Server::writeMaterializedView(
     TimeLimit timeLimit) {
   auto parsedQuery = SparqlParser::parseQuery(
       &index().encodedIriManager(), query.query_, query.datasetClauses_);
-  auto qec = std::make_shared<QueryExecutionContext>(
-      sharedIndex(), &cache(), allocator(), sortPerformanceEstimator(),
-      &namedResultCache(), materializedViewsManager());
+  auto qec = qlever().createQueryExecutionContext();
   auto plan = planQuery(std::move(parsedQuery), requestTimer, timeLimit, *qec,
                         cancellationHandle);
   auto qet = std::make_shared<QueryExecutionTree>(

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -151,10 +151,6 @@ void Server::run() {
                                std::move(httpSessionHandler),
                                std::move(webSocketSessionSupplier)};
 
-  // Initialize the index
-  //  initialize(indexBaseName, useText, usePatterns, loadAllPermutations,
-  //           persistUpdates, std::move(preloadMaterializedViews));
-
   AD_LOG_INFO << "The server is ready, listening for requests on port "
               << std::to_string(httpServer.getPort()) << " ..." << std::endl;
 

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -52,9 +52,7 @@ using ad_utility::MediaType;
 
 // __________________________________________________________________________
 Server::Server(unsigned short port, size_t numThreads, std::string accessToken,
-               const qlever::EngineConfig& config,
-               std::vector<std::string> preloadMaterializedViews,
-               bool noAccessCheck)
+               const qlever::EngineConfig& config, bool noAccessCheck)
     : qlever_(config),
       numThreads_(numThreads),
       port_(port),
@@ -62,18 +60,6 @@ Server::Server(unsigned short port, size_t numThreads, std::string accessToken,
       noAccessCheck_(noAccessCheck),
       queryThreadPool_{numThreads} {
   AD_LOG_INFO << "Initializing server ..." << std::endl;
-
-  // Preload materialized views as requested by the user. This is done in a
-  // try-catch block to prevent an exception during loading of a view from
-  // blocking the server start.
-  for (const auto& viewName : preloadMaterializedViews) {
-    try {
-      qlever_.loadMaterializedView(viewName);
-    } catch (const std::exception& ex) {
-      AD_LOG_ERROR << "Preloading materialized view '" << viewName
-                   << "' failed: " << ex.what() << "." << std::endl;
-    }
-  }
 
   if (noAccessCheck_) {
     AD_LOG_INFO << "No access token required for restricted API calls"

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -76,13 +76,36 @@ class Server {
            bool persistUpdates = false,
            std::vector<std::string> preloadMaterializedViews = {});
 
-  Index& index() {
-    AD_CONTRACT_CHECK(qlever_.has_value());
-    return qlever_->index();
+  // Getters for the Qlever instance (require initialize() to be called first)
+  qlever::Qlever& qlever() { return qlever_.value(); }
+  const qlever::Qlever& qlever() const { return qlever_.value(); }
+
+  Index& index() { return qlever().index(); }
+  const Index& index() const { return qlever().index(); }
+  std::shared_ptr<const Index> sharedIndex() const {
+    return qlever().sharedIndex();
   }
-  const Index& index() const {
-    AD_CONTRACT_CHECK(qlever_.has_value());
-    return qlever_->index();
+
+  QueryResultCache& cache() { return qlever().cache(); }
+  const QueryResultCache& cache() const { return qlever().cache(); }
+  ad_utility::AllocatorWithLimit<Id>& allocator() {
+    return qlever().allocator();
+  }
+  const ad_utility::AllocatorWithLimit<Id>& allocator() const {
+    return qlever().allocator();
+  }
+  SortPerformanceEstimator& sortPerformanceEstimator() {
+    return qlever().sortPerformanceEstimator();
+  }
+  const SortPerformanceEstimator& sortPerformanceEstimator() const {
+    return qlever().sortPerformanceEstimator();
+  }
+  NamedResultCache& namedResultCache() { return qlever().namedResultCache(); }
+  const NamedResultCache& namedResultCache() const {
+    return qlever().namedResultCache();
+  }
+  std::shared_ptr<MaterializedViewsManager> materializedViewsManager() const {
+    return qlever().materializedViewsManager();
   }
 
   // Get server statistics.

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -56,12 +56,9 @@ class Server {
 
  public:
   explicit Server(unsigned short port, size_t numThreads,
-                  ad_utility::MemorySize maxMem, std::string accessToken,
-                  const std::string& indexBaseName, bool useText = false,
-                  bool usePatterns = true, bool loadAllPermutations = true,
-                  bool persistUpdates = false,
+                  std::string accessToken, const qlever::EngineConfig& config,
                   std::vector<std::string> preloadMaterializedViews = {},
-                  bool noAccessCheck = false, bool usePatternTrick = true);
+                  bool noAccessCheck = false);
 
   virtual ~Server() = default;
 
@@ -109,14 +106,12 @@ class Server {
   };
 
  private:
-  std::optional<qlever::Qlever> qlever_;
-  ad_utility::MemorySize maxMem_;
+  qlever::Qlever qlever_;
   const size_t numThreads_;
   unsigned short port_;
   std::string accessToken_;
   bool noAccessCheck_;
   ad_utility::websocket::QueryRegistry queryRegistry_{};
-  bool enablePatternTrick_;
 
   /// Non-owning reference to the `QueryHub` instance living inside
   /// the `WebSocketHandler` created for `HttpServer`.
@@ -378,10 +373,9 @@ class Server {
   Awaitable<void> rebuildIndex(const std::string& indexBaseName);
 
  private:
-  // Getters for the `Qlever` instance, as well as its data members. (require
-  // `initialize()` to be called first).
-  qlever::Qlever& qlever() { return qlever_.value(); }
-  const qlever::Qlever& qlever() const { return qlever_.value(); }
+  // Getters for the `Qlever` instance, as well as its data members.
+  qlever::Qlever& qlever() { return qlever_; }
+  const qlever::Qlever& qlever() const { return qlever_; }
 
   Index& index() { return qlever().index(); }
   const Index& index() const { return qlever().index(); }

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -57,7 +57,6 @@ class Server {
  public:
   explicit Server(unsigned short port, size_t numThreads,
                   std::string accessToken, const qlever::EngineConfig& config,
-                  std::vector<std::string> preloadMaterializedViews = {},
                   bool noAccessCheck = false);
 
   virtual ~Server() = default;

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -76,7 +76,6 @@ class Server {
            bool persistUpdates = false,
            std::vector<std::string> preloadMaterializedViews = {});
 
-
   // Get server statistics.
   json composeStatsJson() const;
   json composeCacheStatsJson() const;
@@ -385,7 +384,8 @@ class Server {
   Awaitable<void> rebuildIndex(const std::string& indexBaseName);
 
  private:
-  // Getters for the `Qlever` instance, as well as its data members. (require `initialize()` to be called first).
+  // Getters for the `Qlever` instance, as well as its data members. (require
+  // `initialize()` to be called first).
   qlever::Qlever& qlever() { return qlever_.value(); }
   const qlever::Qlever& qlever() const { return qlever_.value(); }
 

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -10,6 +10,7 @@
 #ifndef QLEVER_SRC_ENGINE_SERVER_H
 #define QLEVER_SRC_ENGINE_SERVER_H
 
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -21,6 +22,7 @@
 #include "engine/SortPerformanceEstimator.h"
 #include "index/IdTableUtils.h"
 #include "index/Index.h"
+#include "libqlever/Qlever.h"
 #include "util/AllocatorWithLimit.h"
 #include "util/MemorySize/MemorySize.h"
 #include "util/ParseException.h"
@@ -74,8 +76,14 @@ class Server {
            bool persistUpdates = false,
            std::vector<std::string> preloadMaterializedViews = {});
 
-  Index& index() { return *index_; }
-  const Index& index() const { return *index_; }
+  Index& index() {
+    AD_CONTRACT_CHECK(qlever_.has_value());
+    return qlever_->index();
+  }
+  const Index& index() const {
+    AD_CONTRACT_CHECK(qlever_.has_value());
+    return qlever_->index();
+  }
 
   // Get server statistics.
   json composeStatsJson() const;
@@ -116,19 +124,13 @@ class Server {
   };
 
  private:
+  std::optional<qlever::Qlever> qlever_;
+  ad_utility::MemorySize maxMem_;
   const size_t numThreads_;
   unsigned short port_;
   std::string accessToken_;
   bool noAccessCheck_;
-  QueryResultCache cache_;
-  NamedResultCache namedResultCache_;
-  std::shared_ptr<MaterializedViewsManager> materializedViewsManager_ =
-      std::make_shared<MaterializedViewsManager>();
-  ad_utility::AllocatorWithLimit<Id> allocator_;
-  SortPerformanceEstimator sortPerformanceEstimator_;
-  std::shared_ptr<Index> index_;
   ad_utility::websocket::QueryRegistry queryRegistry_{};
-
   bool enablePatternTrick_;
 
   /// Non-owning reference to the `QueryHub` instance living inside

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -76,37 +76,6 @@ class Server {
            bool persistUpdates = false,
            std::vector<std::string> preloadMaterializedViews = {});
 
-  // Getters for the Qlever instance (require initialize() to be called first)
-  qlever::Qlever& qlever() { return qlever_.value(); }
-  const qlever::Qlever& qlever() const { return qlever_.value(); }
-
-  Index& index() { return qlever().index(); }
-  const Index& index() const { return qlever().index(); }
-  std::shared_ptr<const Index> sharedIndex() const {
-    return qlever().sharedIndex();
-  }
-
-  QueryResultCache& cache() { return qlever().cache(); }
-  const QueryResultCache& cache() const { return qlever().cache(); }
-  ad_utility::AllocatorWithLimit<Id>& allocator() {
-    return qlever().allocator();
-  }
-  const ad_utility::AllocatorWithLimit<Id>& allocator() const {
-    return qlever().allocator();
-  }
-  SortPerformanceEstimator& sortPerformanceEstimator() {
-    return qlever().sortPerformanceEstimator();
-  }
-  const SortPerformanceEstimator& sortPerformanceEstimator() const {
-    return qlever().sortPerformanceEstimator();
-  }
-  NamedResultCache& namedResultCache() { return qlever().namedResultCache(); }
-  const NamedResultCache& namedResultCache() const {
-    return qlever().namedResultCache();
-  }
-  std::shared_ptr<MaterializedViewsManager> materializedViewsManager() const {
-    return qlever().materializedViewsManager();
-  }
 
   // Get server statistics.
   json composeStatsJson() const;
@@ -414,6 +383,39 @@ class Server {
   // index. This assumes that the access token has already been checked and no
   // other build is currently in progress.
   Awaitable<void> rebuildIndex(const std::string& indexBaseName);
+
+ private:
+  // Getters for the `Qlever` instance, as well as its data members. (require `initialize()` to be called first).
+  qlever::Qlever& qlever() { return qlever_.value(); }
+  const qlever::Qlever& qlever() const { return qlever_.value(); }
+
+  Index& index() { return qlever().index(); }
+  const Index& index() const { return qlever().index(); }
+  std::shared_ptr<const Index> sharedIndex() const {
+    return qlever().sharedIndex();
+  }
+
+  QueryResultCache& cache() { return qlever().cache(); }
+  const QueryResultCache& cache() const { return qlever().cache(); }
+  ad_utility::AllocatorWithLimit<Id>& allocator() {
+    return qlever().allocator();
+  }
+  const ad_utility::AllocatorWithLimit<Id>& allocator() const {
+    return qlever().allocator();
+  }
+  SortPerformanceEstimator& sortPerformanceEstimator() {
+    return qlever().sortPerformanceEstimator();
+  }
+  const SortPerformanceEstimator& sortPerformanceEstimator() const {
+    return qlever().sortPerformanceEstimator();
+  }
+  NamedResultCache& namedResultCache() { return qlever().namedResultCache(); }
+  const NamedResultCache& namedResultCache() const {
+    return qlever().namedResultCache();
+  }
+  std::shared_ptr<MaterializedViewsManager> materializedViewsManager() const {
+    return qlever().materializedViewsManager();
+  }
 };
 
 #endif  // QLEVER_SRC_ENGINE_SERVER_H

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -57,24 +57,18 @@ class Server {
  public:
   explicit Server(unsigned short port, size_t numThreads,
                   ad_utility::MemorySize maxMem, std::string accessToken,
+                  const std::string& indexBaseName, bool useText = false,
+                  bool usePatterns = true, bool loadAllPermutations = true,
+                  bool persistUpdates = false,
+                  std::vector<std::string> preloadMaterializedViews = {},
                   bool noAccessCheck = false, bool usePatternTrick = true);
 
   virtual ~Server() = default;
 
- private:
-  //! Initialize the server.
-  void initialize(const std::string& indexBaseName, bool useText,
-                  bool usePatterns = true, bool loadAllPermutations = true,
-                  bool persistUpdates = false,
-                  std::vector<std::string> preloadMaterializedViews = {});
-
  public:
   // First initialize the server. Then loop, wait for requests and trigger
   // processing. This method never returns except when throwing an exception.
-  void run(const std::string& indexBaseName, bool useText,
-           bool usePatterns = true, bool loadAllPermutations = true,
-           bool persistUpdates = false,
-           std::vector<std::string> preloadMaterializedViews = {});
+  void run();
 
   // Get server statistics.
   json composeStatsJson() const;

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -61,7 +61,6 @@ class Server {
 
   virtual ~Server() = default;
 
- public:
   // First initialize the server. Then loop, wait for requests and trigger
   // processing. This method never returns except when throwing an exception.
   void run();
@@ -371,7 +370,6 @@ class Server {
   // other build is currently in progress.
   Awaitable<void> rebuildIndex(const std::string& indexBaseName);
 
- private:
   // Getters for the `Qlever` instance, as well as its data members.
   qlever::Qlever& qlever() { return qlever_; }
   const qlever::Qlever& qlever() const { return qlever_; }

--- a/src/libqlever/Qlever.cpp
+++ b/src/libqlever/Qlever.cpp
@@ -19,7 +19,11 @@ namespace qlever {
 Qlever::Qlever(const EngineConfig& config)
     : allocator_{ad_utility::AllocatorWithLimit<Id>{
           ad_utility::makeAllocationMemoryLeftThreadsafeObject(
-              config.memoryLimit_.value_or(DEFAULT_MEM_FOR_QUERIES))}},
+              config.memoryLimit_.value_or(DEFAULT_MEM_FOR_QUERIES)),
+          [this](ad_utility::MemorySize numMemoryToAllocate) {
+            cache_.makeRoomAsMuchAsPossible(MAKE_ROOM_SLACK_FACTOR *
+                                            numMemoryToAllocate);
+          }}},
       index_{std::make_shared<Index>(allocator_)},
       enablePatternTrick_{!config.noPatterns_},
       disableCaching_{config.disableCaching_} {

--- a/src/libqlever/Qlever.cpp
+++ b/src/libqlever/Qlever.cpp
@@ -62,11 +62,8 @@ Qlever::Qlever(const EngineConfig& config)
   // Preload materialized views as requested by the user.
   for (const auto& viewName : config.preloadMaterializedViews_) {
     try {
-      loadMaterializedView(viewName);
-    } catch (const std::runtime_error& ex) {
-      // Any failure while preloading a view should only be logged.
-      // The preloading/initiliazit can continue to operate without the
-      // preloaded view.
+      materializedViewsManager_->loadView(viewName);
+    } catch (const std::exception& ex) {
       AD_LOG_ERROR << "Preloading materialized view '" << viewName
                    << "' failed: " << ex.what() << "." << std::endl;
     }
@@ -258,7 +255,7 @@ void Qlever::loadMaterializedView(std::string name) const {
 
 // ___________________________________________________________________________
 std::shared_ptr<QueryExecutionContext> Qlever::createQueryExecutionContext(
-    std::function<void(const std::string&)> updateCallback, bool pinSubtrees,
+    std::function<void(std::string)> updateCallback, bool pinSubtrees,
     bool pinResult) {
   return std::make_shared<QueryExecutionContext>(
       sharedIndex(), &cache_, allocator_, sortPerformanceEstimator_,

--- a/src/libqlever/Qlever.cpp
+++ b/src/libqlever/Qlever.cpp
@@ -6,12 +6,16 @@
 
 #include "libqlever/Qlever.h"
 
+#include <memory>
+
 #include "engine/ExportQueryExecutionTrees.h"
 #include "engine/MaterializedViews.h"
+#include "engine/QueryExecutionContext.h"
 #include "index/IndexImpl.h"
 #include "index/TextIndexBuilder.h"
 #include "libqlever/QleverTypes.h"
 #include "parser/SparqlParser.h"
+#include "util/http/UrlParser.h"
 
 namespace qlever {
 
@@ -248,4 +252,13 @@ void Qlever::loadMaterializedView(std::string name) const {
   materializedViewsManager_->loadView(name);
 }
 
+// ___________________________________________________________________________
+std::shared_ptr<QueryExecutionContext> Qlever::createQueryExecutionContext(
+    std::function<void(std::string)> updateCallback, bool pinSubtrees,
+    bool pinResult) {
+  return std::make_shared<QueryExecutionContext>(
+      sharedIndex(), &cache_, allocator_, sortPerformanceEstimator_,
+      &namedResultCache_, materializedViewsManager_, updateCallback,
+      pinSubtrees, pinResult);
+}
 }  // namespace qlever

--- a/src/libqlever/Qlever.cpp
+++ b/src/libqlever/Qlever.cpp
@@ -53,6 +53,16 @@ Qlever::Qlever(const EngineConfig& config)
   sortPerformanceEstimator_.computeEstimatesExpensively(
       allocator_, index_->numTriples().normalAndInternal_() *
                       PERCENTAGE_OF_TRIPLES_FOR_SORT_ESTIMATE / 100);
+
+  // Preload materialized views as requested by the user.
+  for (const auto& viewName : config.preloadMaterializedViews_) {
+    try {
+      loadMaterializedView(viewName);
+    } catch (const std::exception& ex) {
+      AD_LOG_ERROR << "Preloading materialized view '" << viewName
+                   << "' failed: " << ex.what() << "." << std::endl;
+    }
+  }
 }
 
 // _____________________________________________________________________________

--- a/src/libqlever/Qlever.cpp
+++ b/src/libqlever/Qlever.cpp
@@ -7,6 +7,7 @@
 #include "libqlever/Qlever.h"
 
 #include <memory>
+#include <stdexcept>
 
 #include "engine/ExportQueryExecutionTrees.h"
 #include "engine/MaterializedViews.h"
@@ -62,7 +63,10 @@ Qlever::Qlever(const EngineConfig& config)
   for (const auto& viewName : config.preloadMaterializedViews_) {
     try {
       loadMaterializedView(viewName);
-    } catch (const std::exception& ex) {
+    } catch (const std::runtime_error& ex) {
+      // Any failure while preloading a view should only be logged.
+      // The preloading/initiliazit can continue to operate without the
+      // preloaded view.
       AD_LOG_ERROR << "Preloading materialized view '" << viewName
                    << "' failed: " << ex.what() << "." << std::endl;
     }
@@ -254,7 +258,7 @@ void Qlever::loadMaterializedView(std::string name) const {
 
 // ___________________________________________________________________________
 std::shared_ptr<QueryExecutionContext> Qlever::createQueryExecutionContext(
-    std::function<void(std::string)> updateCallback, bool pinSubtrees,
+    std::function<void(const std::string&)> updateCallback, bool pinSubtrees,
     bool pinResult) {
   return std::make_shared<QueryExecutionContext>(
       sharedIndex(), &cache_, allocator_, sortPerformanceEstimator_,

--- a/src/libqlever/Qlever.h
+++ b/src/libqlever/Qlever.h
@@ -296,7 +296,7 @@ class Qlever {
   // query.
   std::shared_ptr<QueryExecutionContext> createQueryExecutionContext(
       std::function<void(const std::string&)> updateCallback =
-          [](const std::string&) { /* the default is a noop*/ },
+          [](std::string) { /* the default is a noop*/ },
       bool pinSubtrees = false, bool pinResult = false);
 
   // Low-level access to the QLever API, use with care.

--- a/src/libqlever/Qlever.h
+++ b/src/libqlever/Qlever.h
@@ -289,7 +289,31 @@ class Qlever {
   }
 
   // Low-level access to the QLever API, use with care.
+  std::shared_ptr<const Index> sharedIndex() const { return index_; }
   Index& index() { return *index_; }
+  const Index& index() const { return *index_; }
+
+  QueryResultCache& cache() { return cache_; }
+  const QueryResultCache& cache() const { return cache_; }
+
+  ad_utility::AllocatorWithLimit<Id>& allocator() { return allocator_; }
+  const ad_utility::AllocatorWithLimit<Id>& allocator() const {
+    return allocator_;
+  }
+
+  SortPerformanceEstimator& sortPerformanceEstimator() {
+    return sortPerformanceEstimator_;
+  }
+  const SortPerformanceEstimator& sortPerformanceEstimator() const {
+    return sortPerformanceEstimator_;
+  }
+
+  NamedResultCache& namedResultCache() { return namedResultCache_; }
+  const NamedResultCache& namedResultCache() const { return namedResultCache_; }
+
+  std::shared_ptr<MaterializedViewsManager> materializedViewsManager() const {
+    return materializedViewsManager_;
+  }
 };
 }  // namespace qlever
 

--- a/src/libqlever/Qlever.h
+++ b/src/libqlever/Qlever.h
@@ -41,8 +41,7 @@ struct CommonConfig {
   // An upper bound on the amount of memory that QLever will use during index
   // building and query processing. If more memory is required, an exception
   // is thrown.
-  std::optional<ad_utility::MemorySize> memoryLimit_ =
-      ad_utility::MemorySize::gigabytes(1);
+  std::optional<ad_utility::MemorySize> memoryLimit_ = std::nullopt;
 
   // Option to disable the pre-computation of QLever's so-called "patterns". If
   // enabled, QLever pre-computes the set of distinct predicates for each

--- a/src/libqlever/Qlever.h
+++ b/src/libqlever/Qlever.h
@@ -296,7 +296,8 @@ class Qlever {
   // Create a Query Execution Context needed for execution of single SPARQL
   // query.
   std::shared_ptr<QueryExecutionContext> createQueryExecutionContext(
-      std::function<void(std::string)> updateCallback = [](std::string) {},
+      std::function<void(const std::string&)> updateCallback =
+          [](const std::string&) { /* the default is a noop*/ },
       bool pinSubtrees = false, bool pinResult = false);
 
   // Low-level access to the QLever API, use with care.

--- a/src/libqlever/Qlever.h
+++ b/src/libqlever/Qlever.h
@@ -295,7 +295,7 @@ class Qlever {
   // Create a Query Execution Context needed for execution of single SPARQL
   // query.
   std::shared_ptr<QueryExecutionContext> createQueryExecutionContext(
-      std::function<void(const std::string&)> updateCallback =
+      std::function<void(std::string)> updateCallback =
           [](std::string) { /* the default is a noop*/ },
       bool pinSubtrees = false, bool pinResult = false);
 

--- a/src/libqlever/Qlever.h
+++ b/src/libqlever/Qlever.h
@@ -190,6 +190,10 @@ struct EngineConfig : CommonConfig {
   // to for each operation query the corresponding runtime parameter.
   QueryExecutionContext::DisableCaching disableCaching_ =
       QueryExecutionContext::DisableCaching::FromRuntimeParameter;
+
+  // Names of materialized views to load from disk during initialization.
+  // If a view doesn't exist, a warning is logged and startup continues.
+  std::vector<std::string> preloadMaterializedViews_ = {};
 };
 
 // Class to use QLever as an embedded database, without the HTTP server. See

--- a/src/libqlever/Qlever.h
+++ b/src/libqlever/Qlever.h
@@ -7,6 +7,7 @@
 #ifndef QLEVER_SRC_LIBQLEVER_QLEVER_H
 #define QLEVER_SRC_LIBQLEVER_QLEVER_H
 
+#include <memory>
 #include <optional>
 #include <string>
 #include <utility>
@@ -291,6 +292,12 @@ class Qlever {
   void readNamedResultCacheFromDisk(Serializer& serializer) {
     namedResultCache_.readFromSerializer(serializer, allocator_, index());
   }
+
+  // Create a Query Execution Context needed for execution of single SPARQL
+  // query.
+  std::shared_ptr<QueryExecutionContext> createQueryExecutionContext(
+      std::function<void(std::string)> updateCallback = [](std::string) {},
+      bool pinSubtrees = false, bool pinResult = false);
 
   // Low-level access to the QLever API, use with care.
   std::shared_ptr<const Index> sharedIndex() const { return index_; }

--- a/test/MaterializedViewsTest.cpp
+++ b/test/MaterializedViewsTest.cpp
@@ -775,8 +775,8 @@ TEST_F(MaterializedViewsTest, serverIntegration) {
   // the `Server` class.
   {
     // Initialize but do not start a `Server` instance on our test index.
-    Server server{4321, 1, ad_utility::MemorySize::megabytes(1), "accessToken"};
-    server.initialize(testIndexBase_, false);
+    Server server{4321, 1, ad_utility::MemorySize::megabytes(1), "accessToken",
+                  testIndexBase_};
 
     ad_utility::url_parser::sparqlOperation::Query query{simpleWriteQuery_, {}};
     ad_utility::Timer requestTimer{ad_utility::Timer::InitialStatus::Started};
@@ -791,9 +791,16 @@ TEST_F(MaterializedViewsTest, serverIntegration) {
   // Test the preloading of materialized views on server start.
   {
     qlv().writeMaterializedView("testViewForServerPreload", simpleWriteQuery_);
-    Server server{4321, 1, ad_utility::MemorySize::megabytes(1), "accessToken"};
-    server.initialize(testIndexBase_, false, true, true, false,
-                      {"testViewForServerPreload"});
+    Server server{4321,
+                  1,
+                  ad_utility::MemorySize::megabytes(1),
+                  "accessToken",
+                  testIndexBase_,
+                  false,
+                  true,
+                  true,
+                  false,
+                  {"testViewForServerPreload"}};
     EXPECT_TRUE(server.qlever_->materializedViewsManager()->isViewLoaded(
         "testViewForServerPreload"));
   }

--- a/test/MaterializedViewsTest.cpp
+++ b/test/MaterializedViewsTest.cpp
@@ -794,7 +794,7 @@ TEST_F(MaterializedViewsTest, serverIntegration) {
     Server server{4321, 1, ad_utility::MemorySize::megabytes(1), "accessToken"};
     server.initialize(testIndexBase_, false, true, true, false,
                       {"testViewForServerPreload"});
-    EXPECT_TRUE(server.materializedViewsManager_->isViewLoaded(
+    EXPECT_TRUE(server.qlever_->materializedViewsManager()->isViewLoaded(
         "testViewForServerPreload"));
   }
 

--- a/test/MaterializedViewsTest.cpp
+++ b/test/MaterializedViewsTest.cpp
@@ -793,8 +793,9 @@ TEST_F(MaterializedViewsTest, serverIntegration) {
   // Test the preloading of materialized views on server start.
   {
     config.persistUpdates_ = false;
+    config.preloadMaterializedViews_ = {"testViewForServerPreload"};
     qlv().writeMaterializedView("testViewForServerPreload", simpleWriteQuery_);
-    Server server{4321, 1, "accessToken", config, {"testViewForServerPreload"}};
+    Server server{4321, 1, "accessToken", config};
     EXPECT_TRUE(server.qlever_.materializedViewsManager()->isViewLoaded(
         "testViewForServerPreload"));
   }

--- a/test/MaterializedViewsTest.cpp
+++ b/test/MaterializedViewsTest.cpp
@@ -31,6 +31,7 @@
 #include "engine/sparqlExpressions/LiteralExpression.h"
 #include "engine/sparqlExpressions/SparqlExpressionPimpl.h"
 #include "index/EncodedIriManager.h"
+#include "libqlever/Qlever.h"
 #include "parser/MaterializedViewQuery.h"
 #include "parser/SparqlParser.h"
 #include "parser/SparqlTriple.h"
@@ -770,13 +771,14 @@ TEST_F(MaterializedViewsTest, serverIntegration) {
   SKIP_IF_LOGLEVEL_IS_LOWER(INFO);
   using namespace serverTestHelpers;
   SimulateHttpRequest simulateHttpRequest{testIndexBase_};
+  qlever::EngineConfig config;
+  config.baseName_ = testIndexBase_;
 
   // Write a new materialized view using the `writeMaterializedView` method of
   // the `Server` class.
   {
     // Initialize but do not start a `Server` instance on our test index.
-    Server server{4321, 1, ad_utility::MemorySize::megabytes(1), "accessToken",
-                  testIndexBase_};
+    Server server{4321, 1, "accessToken", config};
 
     ad_utility::url_parser::sparqlOperation::Query query{simpleWriteQuery_, {}};
     ad_utility::Timer requestTimer{ad_utility::Timer::InitialStatus::Started};
@@ -790,18 +792,10 @@ TEST_F(MaterializedViewsTest, serverIntegration) {
 
   // Test the preloading of materialized views on server start.
   {
+    config.persistUpdates_ = false;
     qlv().writeMaterializedView("testViewForServerPreload", simpleWriteQuery_);
-    Server server{4321,
-                  1,
-                  ad_utility::MemorySize::megabytes(1),
-                  "accessToken",
-                  testIndexBase_,
-                  false,
-                  true,
-                  true,
-                  false,
-                  {"testViewForServerPreload"}};
-    EXPECT_TRUE(server.qlever_->materializedViewsManager()->isViewLoaded(
+    Server server{4321, 1, "accessToken", config, {"testViewForServerPreload"}};
+    EXPECT_TRUE(server.qlever_.materializedViewsManager()->isViewLoaded(
         "testViewForServerPreload"));
   }
 

--- a/test/ServerTest.cpp
+++ b/test/ServerTest.cpp
@@ -146,12 +146,8 @@ TEST(ServerTest, chooseBestFittingMediaType) {
 // _____________________________________________________________________________
 TEST(ServerTest, getQueryId) {
   using namespace ad_utility::websocket;
-  auto qec = ad_utility::testing::getQec("<a> <b> <c>");
 
-  qlever::EngineConfig config;
-  config.baseName_ = qec->getIndex().getOnDiskBase();
-
-  Server server{9999, 1, "accessToken", config};
+  Server server{9999, 1, "accessToken", serverTestHelpers::getDefaultConfig()};
   auto reqWithExplicitQueryId = makeGetRequest("/");
   reqWithExplicitQueryId.set("Query-Id", "100");
   const auto req = makeGetRequest("/");
@@ -176,12 +172,7 @@ TEST(ServerTest, getQueryId) {
 
 // _____________________________________________________________________________
 TEST(ServerTest, composeStatsJson) {
-  auto qec = ad_utility::testing::getQec("<a> <b> <c>");
-
-  qlever::EngineConfig config;
-  config.baseName_ = qec->getIndex().getOnDiskBase();
-
-  Server server{9999, 1, "accessToken", config};
+  Server server{9999, 1, "accessToken", serverTestHelpers::getDefaultConfig()};
   json expectedJson{{"git-hash-index", "git short hash not set"},
                     {"git-hash-server", "git short hash not set"},
                     {"name-index", ""},
@@ -203,12 +194,7 @@ TEST(ServerTest, composeStatsJson) {
 
 // _____________________________________________________________________________
 TEST(ServerTest, createMessageSender) {
-  auto qec = ad_utility::testing::getQec("<a> <b> <c>");
-
-  qlever::EngineConfig config;
-  config.baseName_ = qec->getIndex().getOnDiskBase();
-
-  Server server{9999, 1, "accessToken", config};
+  Server server{9999, 1, "accessToken", serverTestHelpers::getDefaultConfig()};
   auto reqWithExplicitQueryId = makeGetRequest("/");
   std::string customQueryId = "100";
   reqWithExplicitQueryId.set("Query-Id", customQueryId);
@@ -400,11 +386,7 @@ TEST(ServerTest, configurePinnedResultWithName) {
 
 // _____________________________________________________________________________
 TEST(ServerTest, checkAccessToken) {
-  auto qec = ad_utility::testing::getQec("<a> <b> <c>");
-
-  qlever::EngineConfig config;
-  config.baseName_ = qec->getIndex().getOnDiskBase();
-
+  auto config = serverTestHelpers::getDefaultConfig();
   Server server{4321, 1, "accessToken", config};
   EXPECT_TRUE(server.checkAccessToken("accessToken"));
 
@@ -413,7 +395,6 @@ TEST(ServerTest, checkAccessToken) {
       testing::HasSubstr("Access token was provided but it was invalid"));
 
   config.persistUpdates_ = false;
-  config.noPatterns_ = false;
 
   Server server2{
       1234, 1, "", config, true,

--- a/test/ServerTest.cpp
+++ b/test/ServerTest.cpp
@@ -170,19 +170,8 @@ TEST(ServerTest, getQueryId) {
 // _____________________________________________________________________________
 TEST(ServerTest, composeStatsJson) {
   Server server{9999, 1, ad_utility::MemorySize::megabytes(1), "accessToken"};
-  json expectedJson{{"git-hash-index", "git short hash not set"},
-                    {"git-hash-server", "git short hash not set"},
-                    {"name-index", ""},
-                    {"name-text-index", ""},
-                    {"num-entity-occurrences", 0},
-                    {"num-permutations", 2},
-                    {"num-predicates-internal", 0},
-                    {"num-predicates-normal", 0},
-                    {"num-text-records", 0},
-                    {"num-triples-internal", 0},
-                    {"num-triples-normal", 0},
-                    {"num-word-occurrences", 0}};
-  EXPECT_THAT(server.composeStatsJson(), testing::Eq(expectedJson));
+  AD_EXPECT_THROW_WITH_MESSAGE(server.composeStatsJson(),
+                               testing::HasSubstr("bad optional access"));
 }
 
 // _____________________________________________________________________________

--- a/test/ServerTest.cpp
+++ b/test/ServerTest.cpp
@@ -3,8 +3,10 @@
 // Author: Julian Mundhahs (mundhahj@tf.uni-freiburg.de)
 
 #include <gmock/gmock.h>
+#include <gtest/gtest.h>
 
 #include <boost/beast/http.hpp>
+#include <optional>
 
 #include "ServerTestHelpers.h"
 #include "engine/HttpError.h"
@@ -170,8 +172,7 @@ TEST(ServerTest, getQueryId) {
 // _____________________________________________________________________________
 TEST(ServerTest, composeStatsJson) {
   Server server{9999, 1, ad_utility::MemorySize::megabytes(1), "accessToken"};
-  AD_EXPECT_THROW_WITH_MESSAGE(server.composeStatsJson(),
-                               testing::HasSubstr("bad optional access"));
+  EXPECT_THROW(server.composeStatsJson(), std::bad_optional_access);
 }
 
 // _____________________________________________________________________________

--- a/test/ServerTest.cpp
+++ b/test/ServerTest.cpp
@@ -147,8 +147,11 @@ TEST(ServerTest, chooseBestFittingMediaType) {
 TEST(ServerTest, getQueryId) {
   using namespace ad_utility::websocket;
   auto qec = ad_utility::testing::getQec("<a> <b> <c>");
-  Server server{9999, 1, ad_utility::MemorySize::megabytes(1), "accessToken",
-                qec->getIndex().getOnDiskBase()};
+
+  qlever::EngineConfig config;
+  config.baseName_ = qec->getIndex().getOnDiskBase();
+
+  Server server{9999, 1, "accessToken", config};
   auto reqWithExplicitQueryId = makeGetRequest("/");
   reqWithExplicitQueryId.set("Query-Id", "100");
   const auto req = makeGetRequest("/");
@@ -174,8 +177,11 @@ TEST(ServerTest, getQueryId) {
 // _____________________________________________________________________________
 TEST(ServerTest, composeStatsJson) {
   auto qec = ad_utility::testing::getQec("<a> <b> <c>");
-  Server server{9999, 1, ad_utility::MemorySize::megabytes(1), "accessToken",
-                qec->getIndex().getOnDiskBase()};
+
+  qlever::EngineConfig config;
+  config.baseName_ = qec->getIndex().getOnDiskBase();
+
+  Server server{9999, 1, "accessToken", config};
   json expectedJson{{"git-hash-index", "git short hash not set"},
                     {"git-hash-server", "git short hash not set"},
                     {"name-index", ""},
@@ -198,8 +204,11 @@ TEST(ServerTest, composeStatsJson) {
 // _____________________________________________________________________________
 TEST(ServerTest, createMessageSender) {
   auto qec = ad_utility::testing::getQec("<a> <b> <c>");
-  Server server{9999, 1, ad_utility::MemorySize::megabytes(1), "accessToken",
-                qec->getIndex().getOnDiskBase()};
+
+  qlever::EngineConfig config;
+  config.baseName_ = qec->getIndex().getOnDiskBase();
+
+  Server server{9999, 1, "accessToken", config};
   auto reqWithExplicitQueryId = makeGetRequest("/");
   std::string customQueryId = "100";
   reqWithExplicitQueryId.set("Query-Id", customQueryId);
@@ -392,26 +401,23 @@ TEST(ServerTest, configurePinnedResultWithName) {
 // _____________________________________________________________________________
 TEST(ServerTest, checkAccessToken) {
   auto qec = ad_utility::testing::getQec("<a> <b> <c>");
-  Server server{4321, 1, ad_utility::MemorySize::megabytes(1), "accessToken",
-                qec->getIndex().getOnDiskBase()};
+
+  qlever::EngineConfig config;
+  config.baseName_ = qec->getIndex().getOnDiskBase();
+
+  Server server{4321, 1, "accessToken", config};
   EXPECT_TRUE(server.checkAccessToken("accessToken"));
 
   AD_EXPECT_THROW_WITH_MESSAGE(
       server.checkAccessToken("invalidAccessToken"),
       testing::HasSubstr("Access token was provided but it was invalid"));
 
-  Server server2{1234,
-                 1,
-                 ad_utility::MemorySize::megabytes(1),
-                 "",
-                 qec->getIndex().getOnDiskBase(),
-                 false,
-                 true,
-                 true,
-                 false,
-                 {},
-                 true,
-                 true};
+  config.persistUpdates_ = false;
+  config.noPatterns_ = false;
+
+  Server server2{
+      1234, 1, "", config, {}, true,
+  };
   EXPECT_TRUE(server2.checkAccessToken(std::nullopt));
 }
 

--- a/test/ServerTest.cpp
+++ b/test/ServerTest.cpp
@@ -416,7 +416,7 @@ TEST(ServerTest, checkAccessToken) {
   config.noPatterns_ = false;
 
   Server server2{
-      1234, 1, "", config, {}, true,
+      1234, 1, "", config, true,
   };
   EXPECT_TRUE(server2.checkAccessToken(std::nullopt));
 }

--- a/test/ServerTest.cpp
+++ b/test/ServerTest.cpp
@@ -146,7 +146,9 @@ TEST(ServerTest, chooseBestFittingMediaType) {
 // _____________________________________________________________________________
 TEST(ServerTest, getQueryId) {
   using namespace ad_utility::websocket;
-  Server server{9999, 1, ad_utility::MemorySize::megabytes(1), "accessToken"};
+  auto qec = ad_utility::testing::getQec("<a> <b> <c>");
+  Server server{9999, 1, ad_utility::MemorySize::megabytes(1), "accessToken",
+                qec->getIndex().getOnDiskBase()};
   auto reqWithExplicitQueryId = makeGetRequest("/");
   reqWithExplicitQueryId.set("Query-Id", "100");
   const auto req = makeGetRequest("/");
@@ -171,13 +173,33 @@ TEST(ServerTest, getQueryId) {
 
 // _____________________________________________________________________________
 TEST(ServerTest, composeStatsJson) {
-  Server server{9999, 1, ad_utility::MemorySize::megabytes(1), "accessToken"};
-  EXPECT_THROW(server.composeStatsJson(), std::bad_optional_access);
+  auto qec = ad_utility::testing::getQec("<a> <b> <c>");
+  Server server{9999, 1, ad_utility::MemorySize::megabytes(1), "accessToken",
+                qec->getIndex().getOnDiskBase()};
+  json expectedJson{{"git-hash-index", "git short hash not set"},
+                    {"git-hash-server", "git short hash not set"},
+                    {"name-index", ""},
+                    {"name-text-index", ""},
+                    {"num-entity-occurrences", 0},
+                    {"num-objects-internal", 0},
+                    {"num-objects-normal", 1},
+                    {"num-permutations", 6},
+                    {"num-predicates-internal", 1},
+                    {"num-predicates-normal", 1},
+                    {"num-subjects-internal", 0},
+                    {"num-subjects-normal", 1},
+                    {"num-text-records", 0},
+                    {"num-triples-internal", 1},
+                    {"num-triples-normal", 1},
+                    {"num-word-occurrences", 0}};
+  EXPECT_THAT(server.composeStatsJson(), testing::Eq(expectedJson));
 }
 
 // _____________________________________________________________________________
 TEST(ServerTest, createMessageSender) {
-  Server server{9999, 1, ad_utility::MemorySize::megabytes(1), "accessToken"};
+  auto qec = ad_utility::testing::getQec("<a> <b> <c>");
+  Server server{9999, 1, ad_utility::MemorySize::megabytes(1), "accessToken",
+                qec->getIndex().getOnDiskBase()};
   auto reqWithExplicitQueryId = makeGetRequest("/");
   std::string customQueryId = "100";
   reqWithExplicitQueryId.set("Query-Id", customQueryId);
@@ -369,14 +391,27 @@ TEST(ServerTest, configurePinnedResultWithName) {
 
 // _____________________________________________________________________________
 TEST(ServerTest, checkAccessToken) {
-  Server server{4321, 1, ad_utility::MemorySize::megabytes(1), "accessToken"};
+  auto qec = ad_utility::testing::getQec("<a> <b> <c>");
+  Server server{4321, 1, ad_utility::MemorySize::megabytes(1), "accessToken",
+                qec->getIndex().getOnDiskBase()};
   EXPECT_TRUE(server.checkAccessToken("accessToken"));
 
   AD_EXPECT_THROW_WITH_MESSAGE(
       server.checkAccessToken("invalidAccessToken"),
       testing::HasSubstr("Access token was provided but it was invalid"));
 
-  Server server2{1234, 1, ad_utility::MemorySize::megabytes(1), "", true};
+  Server server2{1234,
+                 1,
+                 ad_utility::MemorySize::megabytes(1),
+                 "",
+                 qec->getIndex().getOnDiskBase(),
+                 false,
+                 true,
+                 true,
+                 false,
+                 {},
+                 true,
+                 true};
   EXPECT_TRUE(server2.checkAccessToken(std::nullopt));
 }
 

--- a/test/ServerTestHelpers.h
+++ b/test/ServerTestHelpers.h
@@ -8,8 +8,12 @@
 #define QLEVER_TEST_SERVERTESTHELPERS_H_
 
 #include <boost/beast/http.hpp>
+#include <string>
+#include <utility>
 
 #include "engine/Server.h"
+#include "libqlever/Qlever.h"
+#include "util/IndexTestHelpers.h"
 
 namespace serverTestHelpers {
 
@@ -21,14 +25,6 @@ using ResT = http::response<ad_utility::httpUtils::streamable_body>;
 // Test the HTTP request processing of the `Server` class.
 struct SimulateHttpRequest {
   std::string indexBaseName_;
-
-  struct ServerSettings {
-    bool useText = false;
-    bool usePatterns = true;
-    bool loadAllPermutations = true;
-    bool persistUpdates = false;
-  };
-  ServerSettings serverSettings_{};
 
   static std::string bodyToString(
       ad_utility::httpUtils::streamable_body::value_type body) {
@@ -46,15 +42,11 @@ struct SimulateHttpRequest {
     boost::asio::io_context io;
     std::future<ResT> fut = co_spawn(
         io,
-        [](auto request, auto indexName, const ServerSettings& serverSettings,
+        [](auto request, auto indexName,
            auto& io) -> boost::asio::awaitable<ResT> {
+          // Initialize but do not start a `Server` instance on our test index.
           qlever::EngineConfig config;
           config.baseName_ = indexName;
-          config.loadTextIndex_ = serverSettings.useText;
-          config.noPatterns_ = !serverSettings.usePatterns;
-          config.onlyPsoAndPos_ = !serverSettings.loadAllPermutations;
-          config.persistUpdates_ = serverSettings.persistUpdates;
-          // Initialize but do not start a `Server` instance on our test index.
           Server server{4321, 1, "accessToken", config};
 
           auto queryHub = std::make_shared<ad_utility::websocket::QueryHub>(io);
@@ -66,7 +58,7 @@ struct SimulateHttpRequest {
                   .template onlyForTestingProcess<decltype(request), ResT>(
                       request);
           co_return result;
-        }(request, indexBaseName_, serverSettings_, io),
+        }(request, indexBaseName_, io),
         boost::asio::use_future);
     io.run();
     return fut.get();
@@ -100,6 +92,14 @@ struct SimulateHttpRequest {
     return bodyToString(std::move(response.body()));
   }
 };
+
+// Helper function creating a simple config for testing.
+inline qlever::EngineConfig getDefaultConfig() {
+  auto qec = ad_utility::testing::getQec("<a> <b> <c>");
+  qlever::EngineConfig config;
+  config.baseName_ = qec->getIndex().getOnDiskBase();
+  return config;
+}
 
 }  // namespace serverTestHelpers
 

--- a/test/ServerTestHelpers.h
+++ b/test/ServerTestHelpers.h
@@ -49,12 +49,16 @@ struct SimulateHttpRequest {
         [](auto request, auto indexName, const ServerSettings& serverSettings,
            auto& io) -> boost::asio::awaitable<ResT> {
           // Initialize but do not start a `Server` instance on our test index.
-          Server server{4321, 1, ad_utility::MemorySize::megabytes(1),
-                        "accessToken"};
-          server.initialize(indexName, serverSettings.useText,
-                            serverSettings.usePatterns,
-                            serverSettings.loadAllPermutations,
-                            serverSettings.persistUpdates);
+          Server server{4321,
+                        1,
+                        ad_utility::MemorySize::megabytes(1),
+                        "accessToken",
+                        indexName,
+                        serverSettings.useText,
+                        serverSettings.usePatterns,
+                        serverSettings.loadAllPermutations,
+                        serverSettings.persistUpdates};
+
           auto queryHub = std::make_shared<ad_utility::websocket::QueryHub>(io);
           server.queryHub_ = queryHub;
 

--- a/test/ServerTestHelpers.h
+++ b/test/ServerTestHelpers.h
@@ -98,6 +98,7 @@ inline qlever::EngineConfig getDefaultConfig() {
   auto qec = ad_utility::testing::getQec("<a> <b> <c>");
   qlever::EngineConfig config;
   config.baseName_ = qec->getIndex().getOnDiskBase();
+  config.memoryLimit_ = ad_utility::MemorySize::gigabytes(1);
   return config;
 }
 

--- a/test/ServerTestHelpers.h
+++ b/test/ServerTestHelpers.h
@@ -46,6 +46,7 @@ struct SimulateHttpRequest {
            auto& io) -> boost::asio::awaitable<ResT> {
           // Initialize but do not start a `Server` instance on our test index.
           qlever::EngineConfig config;
+          config.persistUpdates_ = false;
           config.baseName_ = indexName;
           Server server{4321, 1, "accessToken", config};
 

--- a/test/ServerTestHelpers.h
+++ b/test/ServerTestHelpers.h
@@ -48,16 +48,14 @@ struct SimulateHttpRequest {
         io,
         [](auto request, auto indexName, const ServerSettings& serverSettings,
            auto& io) -> boost::asio::awaitable<ResT> {
+          qlever::EngineConfig config;
+          config.baseName_ = indexName;
+          config.loadTextIndex_ = serverSettings.useText;
+          config.noPatterns_ = !serverSettings.usePatterns;
+          config.onlyPsoAndPos_ = !serverSettings.loadAllPermutations;
+          config.persistUpdates_ = serverSettings.persistUpdates;
           // Initialize but do not start a `Server` instance on our test index.
-          Server server{4321,
-                        1,
-                        ad_utility::MemorySize::megabytes(1),
-                        "accessToken",
-                        indexName,
-                        serverSettings.useText,
-                        serverSettings.usePatterns,
-                        serverSettings.loadAllPermutations,
-                        serverSettings.persistUpdates};
+          Server server{4321, 1, "accessToken", config};
 
           auto queryHub = std::make_shared<ad_utility::websocket::QueryHub>(io);
           server.queryHub_ = queryHub;

--- a/test/index/IndexRebuilderTest.cpp
+++ b/test/index/IndexRebuilderTest.cpp
@@ -22,6 +22,7 @@
 #include "index/IndexRebuilder.h"
 #include "index/IndexRebuilderImpl.h"
 #include "index/vocabulary/VocabularyType.h"
+#include "libqlever/Qlever.h"
 
 using namespace qlever::indexRebuilder;
 using namespace std::string_literals;
@@ -594,8 +595,9 @@ TEST(IndexRebuilder, serverIntegration) {
   std::string indexName = "IndexRebuilder_serverIntegration";
   ad_utility::testing::makeTestIndex(indexName, "<a> <b> <c> .");
 
-  Server server{4321, 1, ad_utility::MemorySize::megabytes(1), "accessToken",
-                indexName};
+  qlever::EngineConfig config;
+  config.baseName_ = indexName;
+  Server server{4321, 1, "accessToken", config};
   auto performRequest = [&threadPool, &server](auto& request) {
     using ResT = ad_utility::httpUtils::ResponseT;
     auto task =

--- a/test/index/IndexRebuilderTest.cpp
+++ b/test/index/IndexRebuilderTest.cpp
@@ -594,8 +594,8 @@ TEST(IndexRebuilder, serverIntegration) {
   std::string indexName = "IndexRebuilder_serverIntegration";
   ad_utility::testing::makeTestIndex(indexName, "<a> <b> <c> .");
 
-  Server server{4321, 1, ad_utility::MemorySize::megabytes(1), "accessToken"};
-  server.initialize(indexName, false);
+  Server server{4321, 1, ad_utility::MemorySize::megabytes(1), "accessToken",
+                indexName};
   auto performRequest = [&threadPool, &server](auto& request) {
     using ResT = ad_utility::httpUtils::ResponseT;
     auto task =


### PR DESCRIPTION
So far, the `Server` class serves three purposes: 1. Handling the SPARQL HTTP protocol, 2. Managing a QLever instance (index, engine, cache, etc.), 3. Providing execution resources (in particular threads) for 1. and 2. This change is a first step to separate these three concerns by delegating functionality from 2. to the `Qlever` class from `libqlever`. In particular:

1. The `Server` now owns a single `Qlever` object instead of a separate `Index`, `Cache`, etc. By default all access is trivially (via getters) delegated to the members of this class.
2. The creation of a `QueryExecutionContext` is now delegated to a dedicated function inside `libqlever`. In the future, more of the SPARQL functionality of the server will be delegated to `libqlever` directly.
3. Get rid of the two-phase initialization of the server (some arguments to the constructor, some to the `run/initialize` functions). Now there is only a constructor that takes a single argument of type `qlever::EngineConfig` for the SPARQL engine configuration, together with the server-specific arguments (e.g. the port). The `run()` function is now parameterless.
4. Refactor the parser of the command-line arguments in `ServerMain` such that it directly fills an `EngineConfig` object, which then is directly passed to the `Server` object.
