### PR TITLE
External Reasoner: Return materialized delta from SPARQL UPDATE (`return-delta=true`)

### DIFF
--- a/src/engine/ExecuteUpdate.cpp
+++ b/src/engine/ExecuteUpdate.cpp
@@ -8,6 +8,7 @@
 #include "engine/UpdateMetadata.h"
 #include "index/ExportIds.h"
 #include "index/IndexImpl.h"
+#include "rdfTypes/RdfEscaping.h"
 
 // _____________________________________________________________________________
 UpdateMetadata ExecuteUpdate::executeUpdate(
@@ -25,28 +26,45 @@ UpdateMetadata ExecuteUpdate::executeUpdate(
       computeGraphUpdateQuads(index, query, *result, qet.getVariableColumns(),
                               cancellationHandle, metadata, tracer);
 
-  // Optionally capture the genuinely-changed triples (Stage-2 materialized
-  // delta) when the caller opts in via `return-delta=true`.
+  // There are three levels of "delta" in this function; only the third is
+  // returned to the caller when `returnDeltaTriples` is true:
+  //
+  //   1. Query-computed delta  (`toInsert` / `toDelete` from
+  //      `computeGraphUpdateQuads`): the set of triples the UPDATE statement
+  //      wants to insert/delete, after intra-request `setMinus` dedup.
+  //      Counted in `metadata.inUpdate_`.
+  //
+  //   2. Overlay-accepted delta  (`insertedMat` / `deletedMat` below): the
+  //      subset of (1) that was actually accepted by the `DeltaTriples` store.
+  //      `modifyTriplesImpl` filters out triples already in the overlay
+  //      (`triplesInserted_` / `triplesDeleted_`) and cancels inverse pairs.
+  //      This is what `UpdateDelta::inserted_` / `deleted_` contains.
+  //      NOTE: it is an over-approximation of (3) — see `UpdateMetadata.h`.
+  //
+  //   3. Logical-dataset delta  (not implemented): overlay-accepted delta
+  //      further filtered against the base materialized index.  A triple
+  //      already in the base that is also in the overlay-accepted delta would
+  //      be excluded here.  Not currently computed (base-index lookup is
+  //      expensive; see `UpdateDelta` doc and test case 9 of
+  //      `ExecuteUpdateTest.returnDeltaTriples`).
   DeltaTriples::Triples insertedMat, deletedMat;
 
   // "The deletion of the triples happens before the insertion." (SPARQL 1.1
   // Update 3.1.3)
   tracer.beginTrace("deleteTriples");
   if (!toDelete.idTriples_.empty()) {
-    deltaTriples.deleteTriples(cancellationHandle,
-                               std::move(toDelete.idTriples_),
-                               returnDeltaTriples ? &deletedMat : nullptr,
-                               tracer);
+    deltaTriples.deleteTriples(
+        cancellationHandle, std::move(toDelete.idTriples_),
+        returnDeltaTriples ? &deletedMat : nullptr, tracer);
   }
   // When the triple set is empty, materializedOut stays as an empty vector —
   // correct because nothing was applied to the store.
   tracer.endTrace("deleteTriples");
   tracer.beginTrace("insertTriples");
   if (!toInsert.idTriples_.empty()) {
-    deltaTriples.insertTriples(cancellationHandle,
-                               std::move(toInsert.idTriples_),
-                               returnDeltaTriples ? &insertedMat : nullptr,
-                               tracer);
+    deltaTriples.insertTriples(
+        cancellationHandle, std::move(toInsert.idTriples_),
+        returnDeltaTriples ? &insertedMat : nullptr, tracer);
   }
   // When the triple set is empty, materializedOut stays as an empty vector —
   // correct because nothing was applied to the store.
@@ -57,9 +75,11 @@ UpdateMetadata ExecuteUpdate::executeUpdate(
     // function is called from inside `DeltaTriplesManager::modify`). For large
     // deltas the vocab lookups / string building extend the lock-hold time.
     // A future optimization could copy out the Id-triples and grab a
-    // `LocalVocab::LifetimeExtender`, then serialize after the lock is released.
-    metadata.delta_ = serializeMaterializedDelta(
-        index, insertedMat, deletedMat, deltaTriples.localVocab());
+    // `LocalVocab::LifetimeExtender`, then serialize after the lock is
+    // released.
+    metadata.delta_ =
+        serializeMaterializedDelta(index, insertedMat, deletedMat,
+                                   std::as_const(deltaTriples).localVocab());
   }
 
   return metadata;
@@ -81,8 +101,20 @@ std::string ExecuteUpdate::idToNQuadsTerm(const Index& index, Id id,
     // Numeric value: reassemble as "lexicalForm"^^<datatypeUri>
     return std::string("\"") + str + "\"^^<" + std::string(datatype) + ">";
   }
-  // For IRIs and literals, `str` is already in N-Triples/N-Quads notation
-  // (e.g. `<http://example.org/foo>` or `"hello"@en`).
+  // For IRIs (`<http://...>`) and blank nodes (`_:...`), `str` is already in
+  // valid N-Triples/N-Quads notation — return as-is.
+  //
+  // For non-numeric literals, `str` is in QLever's internal "normalized" form
+  // (produced by `RdfEscaping::normalizeRDFLiteral`): the content between the
+  // outer quotes is stored *unescaped* — e.g. `"say "hello""`  has a raw `"`
+  // inside rather than `\"`.  That normalized form is NOT valid N-Triples.
+  // `RdfEscaping::validRDFLiteralFromNormalized` converts it to the proper
+  // N-Triples escaped form, e.g. `"say \"hello\""` (and handles `@lang` /
+  // `^^<type>` suffixes).  See test cases 8 (language tag) and 10 (embedded
+  // quote) of `ExecuteUpdateTest.returnDeltaTriples` for concrete examples.
+  if (!str.empty() && str[0] == '"') {
+    return RdfEscaping::validRDFLiteralFromNormalized(str);
+  }
   return str;
 }
 

--- a/src/engine/ExecuteUpdate.cpp
+++ b/src/engine/ExecuteUpdate.cpp
@@ -6,13 +6,14 @@
 
 #include "engine/ExportQueryExecutionTrees.h"
 #include "engine/UpdateMetadata.h"
+#include "index/ExportIds.h"
 #include "index/IndexImpl.h"
 
 // _____________________________________________________________________________
 UpdateMetadata ExecuteUpdate::executeUpdate(
     const Index& index, const ParsedQuery& query, const QueryExecutionTree& qet,
     DeltaTriples& deltaTriples, const CancellationHandle& cancellationHandle,
-    ad_utility::timer::TimeTracer& tracer) {
+    ad_utility::timer::TimeTracer& tracer, bool returnDeltaTriples) {
   UpdateMetadata metadata{};
   // Fully materialize the result for now. This makes it easier to execute the
   // update. We have to keep the local vocab alive until the triples are
@@ -24,21 +25,102 @@ UpdateMetadata ExecuteUpdate::executeUpdate(
       computeGraphUpdateQuads(index, query, *result, qet.getVariableColumns(),
                               cancellationHandle, metadata, tracer);
 
+  // Optionally capture the genuinely-changed triples (Stage-2 materialized
+  // delta) when the caller opts in via `return-delta=true`.
+  DeltaTriples::Triples insertedMat, deletedMat;
+
   // "The deletion of the triples happens before the insertion." (SPARQL 1.1
   // Update 3.1.3)
   tracer.beginTrace("deleteTriples");
   if (!toDelete.idTriples_.empty()) {
     deltaTriples.deleteTriples(cancellationHandle,
-                               std::move(toDelete.idTriples_), tracer);
+                               std::move(toDelete.idTriples_),
+                               returnDeltaTriples ? &deletedMat : nullptr,
+                               tracer);
   }
+  // When the triple set is empty, materializedOut stays as an empty vector —
+  // correct because nothing was applied to the store.
   tracer.endTrace("deleteTriples");
   tracer.beginTrace("insertTriples");
   if (!toInsert.idTriples_.empty()) {
     deltaTriples.insertTriples(cancellationHandle,
-                               std::move(toInsert.idTriples_), tracer);
+                               std::move(toInsert.idTriples_),
+                               returnDeltaTriples ? &insertedMat : nullptr,
+                               tracer);
   }
+  // When the triple set is empty, materializedOut stays as an empty vector —
+  // correct because nothing was applied to the store.
   tracer.endTrace("insertTriples");
+
+  if (returnDeltaTriples) {
+    // NOTE: serialization runs while the DeltaTriples write lock is held (this
+    // function is called from inside `DeltaTriplesManager::modify`). For large
+    // deltas the vocab lookups / string building extend the lock-hold time.
+    // A future optimization could copy out the Id-triples and grab a
+    // `LocalVocab::LifetimeExtender`, then serialize after the lock is released.
+    metadata.delta_ = serializeMaterializedDelta(
+        index, insertedMat, deletedMat, deltaTriples.localVocab());
+  }
+
   return metadata;
+}
+
+// _____________________________________________________________________________
+std::string ExecuteUpdate::idToNQuadsTerm(const Index& index, Id id,
+                                          const LocalVocab& localVocab) {
+  auto opt = ql::exportIds::idToStringAndType(index, id, localVocab);
+  // An Undefined Id should never appear here: `computeAndAddQuadsForResultRow`
+  // filters out triples containing any Undefined component before they are
+  // stored in the delta. If this fires, the invariant was violated upstream.
+  AD_CORRECTNESS_CHECK(
+      opt.has_value(),
+      "idToNQuadsTerm called with an Undefined Id; this should have been "
+      "filtered out in computeAndAddQuadsForResultRow.");
+  auto& [str, datatype] = *opt;
+  if (datatype != nullptr) {
+    // Numeric value: reassemble as "lexicalForm"^^<datatypeUri>
+    return std::string("\"") + str + "\"^^<" + std::string(datatype) + ">";
+  }
+  // For IRIs and literals, `str` is already in N-Triples/N-Quads notation
+  // (e.g. `<http://example.org/foo>` or `"hello"@en`).
+  return str;
+}
+
+// _____________________________________________________________________________
+std::string ExecuteUpdate::tripleToNQuadsLine(const Index& index,
+                                              const IdTriple<0>& triple,
+                                              const LocalVocab& localVocab) {
+  const auto& ids = triple.ids();
+  std::string s = idToNQuadsTerm(index, ids[0], localVocab);
+  std::string p = idToNQuadsTerm(index, ids[1], localVocab);
+  std::string o = idToNQuadsTerm(index, ids[2], localVocab);
+  std::string g = idToNQuadsTerm(index, ids[3], localVocab);
+  // Default-graph triples are represented in N-Quads without a graph term
+  // (3-column N-Triples form: "s p o ."). QLever uses an internal IRI for the
+  // default graph; we must not expose that internal IRI to callers.
+  // `idToNQuadsTerm` returns IRIs including angle brackets (e.g. `<http://…>`),
+  // and DEFAULT_GRAPH_IRI is defined with angle brackets, so this string
+  // comparison correctly identifies default-graph triples.
+  if (g == DEFAULT_GRAPH_IRI) {
+    return s + " " + p + " " + o + " .";
+  }
+  return s + " " + p + " " + o + " " + g + " .";
+}
+
+// _____________________________________________________________________________
+UpdateDelta ExecuteUpdate::serializeMaterializedDelta(
+    const Index& index, const DeltaTriples::Triples& inserted,
+    const DeltaTriples::Triples& deleted, const LocalVocab& localVocab) {
+  UpdateDelta delta;
+  delta.inserted_.reserve(inserted.size());
+  delta.deleted_.reserve(deleted.size());
+  for (const auto& t : inserted) {
+    delta.inserted_.push_back(tripleToNQuadsLine(index, t, localVocab));
+  }
+  for (const auto& t : deleted) {
+    delta.deleted_.push_back(tripleToNQuadsLine(index, t, localVocab));
+  }
+  return delta;
 }
 
 // _____________________________________________________________________________

--- a/src/engine/ExecuteUpdate.h
+++ b/src/engine/ExecuteUpdate.h
@@ -8,6 +8,8 @@
 #include <gtest/gtest_prod.h>
 
 #include "engine/UpdateMetadata.h"
+#include "global/IdTriple.h"
+#include "index/DeltaTriples.h"
 #include "index/Index.h"
 #include "parser/ParsedQuery.h"
 #include "util/CancellationHandle.h"
@@ -20,13 +22,17 @@ class ExecuteUpdate {
   using TransformedTriple = std::array<IdOrVariableIndex, 4>;
 
   // Execute an update. This function is comparable to
-  // `ExportQueryExecutionTrees::computeResult` for queries.
+  // `ExportQueryExecutionTrees::computeResult` for queries. If
+  // `returnDeltaTriples` is true, the returned `UpdateMetadata::delta_` field
+  // is populated with the genuine materialized delta (Stage-2: triples that
+  // actually changed the store), serialized as N-Quads lines.
   static UpdateMetadata executeUpdate(
       const Index& index, const ParsedQuery& query,
       const QueryExecutionTree& qet, DeltaTriples& deltaTriples,
       const CancellationHandle& cancellationHandle,
       ad_utility::timer::TimeTracer& tracer =
-          ad_utility::timer::DEFAULT_TIME_TRACER);
+          ad_utility::timer::DEFAULT_TIME_TRACER,
+      bool returnDeltaTriples = false);
 
  private:
   // Resolve all `TripleComponent`s and `Graph`s in a vector of
@@ -75,6 +81,27 @@ class ExecuteUpdate {
   // elements.
   static void sortAndRemoveDuplicates(std::vector<IdTriple<>>& container);
   FRIEND_TEST(ExecuteUpdate, sortAndRemoveDuplicates);
+
+  // Convert a single `Id` to its N-Quads / N-Triples term representation.
+  // Triggers `AD_CORRECTNESS_CHECK` if `id` is `Undefined` (which should
+  // never occur for triples produced by `computeAndAddQuadsForResultRow`).
+  static std::string idToNQuadsTerm(const Index& index, Id id,
+                                    const LocalVocab& localVocab);
+
+  // Serialize a single `IdTriple<0>` as one N-Quads / N-Triples line. When
+  // the graph component is QLever's internal DEFAULT_GRAPH_IRI, a 3-column
+  // N-Triples line is emitted (no graph term); otherwise a 4-column N-Quads
+  // line is emitted. The internal default-graph IRI is never exposed to
+  // callers.
+  static std::string tripleToNQuadsLine(const Index& index,
+                                        const IdTriple<0>& triple,
+                                        const LocalVocab& localVocab);
+
+  // Build an `UpdateDelta` by serializing every triple in `inserted` and
+  // `deleted` to N-Quads lines using `localVocab` for ID resolution.
+  static UpdateDelta serializeMaterializedDelta(
+      const Index& index, const DeltaTriples::Triples& inserted,
+      const DeltaTriples::Triples& deleted, const LocalVocab& localVocab);
 
   // For two sorted vectors `A` and `B` return a new vector
   // that contains the element of `A\B`.

--- a/src/engine/ExecuteUpdate.h
+++ b/src/engine/ExecuteUpdate.h
@@ -24,8 +24,9 @@ class ExecuteUpdate {
   // Execute an update. This function is comparable to
   // `ExportQueryExecutionTrees::computeResult` for queries. If
   // `returnDeltaTriples` is true, the returned `UpdateMetadata::delta_` field
-  // is populated with the genuine materialized delta (Stage-2: triples that
-  // actually changed the store), serialized as N-Quads lines.
+  // is populated with the overlay-accepted delta (see `UpdateDelta` in
+  // `UpdateMetadata.h` for the precise semantics), serialized as N-Quads /
+  // N-Triples lines.
   static UpdateMetadata executeUpdate(
       const Index& index, const ParsedQuery& query,
       const QueryExecutionTree& qet, DeltaTriples& deltaTriples,

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -672,10 +672,10 @@ CPP_template_def(typename RequestT, typename ResponseT)(
     }
     if (ql::ranges::all_of(operations, &ParsedQuery::hasUpdateClause)) {
       bool returnDelta = checkParameter("return-delta", "true").has_value();
-      co_return co_await processUpdate(
-          returnDelta, std::move(operations), requestTimer, tracer,
-          cancellationHandle, qec, std::move(request), send, timeLimit.value(),
-          plannedQuery);
+      co_return co_await processUpdate(returnDelta, std::move(operations),
+                                       requestTimer, tracer, cancellationHandle,
+                                       qec, std::move(request), send,
+                                       timeLimit.value(), plannedQuery);
     } else {
       AD_CORRECTNESS_CHECK(operations.size() == 1);
       ParsedQuery query = std::move(operations[0]);
@@ -1152,7 +1152,8 @@ nlohmann::ordered_json Server::createResponseMetadataForUpdate(
                        updateMetadata.countBefore_.value());
   }
   // When the client opts in via `return-delta=true`, include the materialized
-  // delta (Stage-2 N-Quads lines) for this operation in the per-operation JSON.
+  // delta (overlay-accepted N-Quads/N-Triples lines) for this operation in the
+  // per-operation JSON.
   if (updateMetadata.delta_.has_value()) {
     const auto& delta = updateMetadata.delta_.value();
     response["delta-triples"]["materialized"]["inserted"] = delta.inserted_;

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -671,9 +671,11 @@ CPP_template_def(typename RequestT, typename ResponseT)(
           msg, ad_utility::truncateOperationString(operationString)));
     }
     if (ql::ranges::all_of(operations, &ParsedQuery::hasUpdateClause)) {
+      bool returnDelta = checkParameter("return-delta", "true").has_value();
       co_return co_await processUpdate(
-          std::move(operations), requestTimer, tracer, cancellationHandle, qec,
-          std::move(request), send, timeLimit.value(), plannedQuery);
+          returnDelta, std::move(operations), requestTimer, tracer,
+          cancellationHandle, qec, std::move(request), send, timeLimit.value(),
+          plannedQuery);
     } else {
       AD_CORRECTNESS_CHECK(operations.size() == 1);
       ParsedQuery query = std::move(operations[0]);
@@ -1149,6 +1151,13 @@ nlohmann::ordered_json Server::createResponseMetadataForUpdate(
         nlohmann::json(updateMetadata.countAfter_.value() -
                        updateMetadata.countBefore_.value());
   }
+  // When the client opts in via `return-delta=true`, include the materialized
+  // delta (Stage-2 N-Quads lines) for this operation in the per-operation JSON.
+  if (updateMetadata.delta_.has_value()) {
+    const auto& delta = updateMetadata.delta_.value();
+    response["delta-triples"]["materialized"]["inserted"] = delta.inserted_;
+    response["delta-triples"]["materialized"]["deleted"] = delta.deleted_;
+  }
   response["time"] = tracer.getJSONShort()["update"];
   for (auto permutation : Permutation::ALL) {
     response["located-triples"][Permutation::toString(
@@ -1170,14 +1179,15 @@ nlohmann::ordered_json Server::createResponseMetadataForUpdate(
 UpdateMetadata Server::processUpdateImpl(
     const PlannedQuery& plannedUpdate,
     ad_utility::SharedCancellationHandle cancellationHandle,
-    DeltaTriples& deltaTriples, ad_utility::timer::TimeTracer& tracer) {
+    DeltaTriples& deltaTriples, bool returnDeltaTriples,
+    ad_utility::timer::TimeTracer& tracer) {
   const auto& qet = plannedUpdate.queryExecutionTree();
   AD_CORRECTNESS_CHECK(plannedUpdate.parsedQuery().hasUpdateClause());
 
   DeltaTriplesCount countBefore = deltaTriples.getCounts();
-  UpdateMetadata updateMetadata =
-      ExecuteUpdate::executeUpdate(index(), plannedUpdate.parsedQuery(), qet,
-                                   deltaTriples, cancellationHandle, tracer);
+  UpdateMetadata updateMetadata = ExecuteUpdate::executeUpdate(
+      index(), plannedUpdate.parsedQuery(), qet, deltaTriples,
+      cancellationHandle, tracer, returnDeltaTriples);
   updateMetadata.countBefore_ = countBefore;
   updateMetadata.countAfter_ = deltaTriples.getCounts();
 
@@ -1196,7 +1206,7 @@ UpdateMetadata Server::processUpdateImpl(
 CPP_template_def(typename RequestT, typename ResponseT)(
     requires ad_utility::httpUtils::HttpRequest<RequestT>)
     Awaitable<void> Server::processUpdate(
-        std::vector<ParsedQuery>&& updates,
+        bool returnDelta, std::vector<ParsedQuery>&& updates,
         const ad_utility::Timer& requestTimer, SharedTimeTracer outerTracer,
         ad_utility::SharedCancellationHandle cancellationHandle,
         QueryExecutionContext& qec, const RequestT& request, ResponseT&& send,
@@ -1221,11 +1231,12 @@ CPP_template_def(typename RequestT, typename ResponseT)(
   auto coroutine = computeInNewThread(
       updateThreadPool_,
       [this, &requestTimer, &cancellationHandle, &updates, &qec, &timeLimit,
-       &plannedUpdate, outerTracer, &metadatas]() {
+       &plannedUpdate, outerTracer, &metadatas, returnDelta]() {
         outerTracer->endTrace("waitingForUpdateThread");
         return index().deltaTriplesManager().modify<json>(
             [this, &cancellationHandle, &plannedUpdate, &updates, &requestTimer,
-             &timeLimit, &qec, &metadatas](DeltaTriples& deltaTriples) {
+             &timeLimit, &qec, &metadatas,
+             returnDelta](DeltaTriples& deltaTriples) {
               qec.setLocatedTriplesForEvaluation(
                   deltaTriples.getLocatedTriplesSharedStateReference());
               json results = json::array();
@@ -1251,7 +1262,7 @@ CPP_template_def(typename RequestT, typename ResponseT)(
                 // errors on captured `this` being unused.
                 auto updateMetadata = this->processUpdateImpl(
                     plannedUpdate.value(), cancellationHandle, deltaTriples,
-                    tracer);
+                    returnDelta, tracer);
                 tracer.endTrace("execution");
 
                 tracer.endTrace("update");
@@ -1282,6 +1293,27 @@ CPP_template_def(typename RequestT, typename ResponseT)(
   responseJson["operations"] = operations;
   outerTracer->endTrace("update");
   responseJson["time"] = outerTracer->getJSONShort()["update"];
+
+  // When `return-delta=true`, concatenate all per-operation materialized deltas
+  // into a top-level `"delta-triples-merged"` field for easy consumption by
+  // external reasoners performing semi-naive fixpoint evaluation.
+  if (returnDelta) {
+    nlohmann::json mergedInserted = nlohmann::json::array();
+    nlohmann::json mergedDeleted = nlohmann::json::array();
+    for (const auto& meta : metadatas) {
+      if (meta.delta_.has_value()) {
+        for (const auto& line : meta.delta_->inserted_) {
+          mergedInserted.push_back(line);
+        }
+        for (const auto& line : meta.delta_->deleted_) {
+          mergedDeleted.push_back(line);
+        }
+      }
+    }
+    responseJson["delta-triples-merged"]["inserted"] =
+        std::move(mergedInserted);
+    responseJson["delta-triples-merged"]["deleted"] = std::move(mergedDeleted);
+  }
 
   // SPARQL 1.1 Protocol 2.2.4 Successful Responses: "The responses body of a
   // successful update request is implementation defined."

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -228,11 +228,14 @@ class Server {
       const UpdateMetadata& updateMetadata,
       const ad_utility::timer::TimeTracer& tracer);
   FRIEND_TEST(ServerTest, createResponseMetadata);
-  // Do the actual execution of an update.
+  // Do the actual execution of an update. When `returnDelta` is true, each
+  // operation's `UpdateMetadata::delta_` is populated and the response JSON
+  // additionally contains a `"delta-triples-merged"` top-level field with the
+  // concatenation of all per-operation deltas.
   CPP_template(typename RequestT, typename ResponseT)(
       requires ad_utility::httpUtils::HttpRequest<RequestT>)
       Awaitable<void> processUpdate(
-          std::vector<ParsedQuery>&& updates,
+          bool returnDelta, std::vector<ParsedQuery>&& updates,
           const ad_utility::Timer& requestTimer, SharedTimeTracer tracer,
           ad_utility::SharedCancellationHandle cancellationHandle,
           QueryExecutionContext& qec, const RequestT& request, ResponseT&& send,
@@ -286,11 +289,12 @@ class Server {
           const std::weak_ptr<ad_utility::websocket::QueryHub>& queryHub,
           const RequestT& request, std::string_view operation);
   // Execute an update operation. The function must have exclusive access to the
-  // DeltaTriples object.
+  // DeltaTriples object. When `returnDeltaTriples` is true, the returned
+  // `UpdateMetadata::delta_` is populated with the materialized delta.
   UpdateMetadata processUpdateImpl(
       const PlannedQuery& plannedUpdate,
       ad_utility::SharedCancellationHandle cancellationHandle,
-      DeltaTriples& deltaTriples,
+      DeltaTriples& deltaTriples, bool returnDeltaTriples = false,
       ad_utility::timer::TimeTracer& tracer =
           ad_utility::timer::DEFAULT_TIME_TRACER);
 

--- a/src/engine/UpdateMetadata.h
+++ b/src/engine/UpdateMetadata.h
@@ -10,6 +10,9 @@
 #ifndef QLEVER_SRC_ENGINE_UPDATEMETADATA_H
 #define QLEVER_SRC_ENGINE_UPDATEMETADATA_H
 
+#include <string>
+#include <vector>
+
 #include "backports/three_way_comparison.h"
 #include "util/json.h"
 
@@ -32,12 +35,25 @@ struct DeltaTriplesCount {
                                               triplesInserted_, triplesDeleted_)
 };
 
+// The materialized delta for a single update operation: the N-Quads lines for
+// triples that were genuinely inserted into or deleted from the `DeltaTriples`
+// store (Stage-2 delta: after intra-request deduplication AND after dropping
+// triples already present in / absent from `DeltaTriples`). Populated only
+// when the client opts in via the `return-delta=true` URL parameter.
+struct UpdateDelta {
+  std::vector<std::string> inserted_;  // N-Quads lines for inserted triples
+  std::vector<std::string> deleted_;   // N-Quads lines for deleted triples
+};
+
 // Metadata of a single update operation: number of inserted and deleted triples
-// before the operation, of the operation, and after the operation.
+// before the operation, of the operation, and after the operation, and
+// optionally the materialized delta triples as N-Quads lines.
 struct UpdateMetadata {
   std::optional<DeltaTriplesCount> countBefore_;
   std::optional<DeltaTriplesCount> inUpdate_;
   std::optional<DeltaTriplesCount> countAfter_;
+  // Populated only when the client requests `return-delta=true`.
+  std::optional<UpdateDelta> delta_;
 };
 
 #endif  // QLEVER_SRC_ENGINE_UPDATEMETADATA_H

--- a/src/engine/UpdateMetadata.h
+++ b/src/engine/UpdateMetadata.h
@@ -35,14 +35,48 @@ struct DeltaTriplesCount {
                                               triplesInserted_, triplesDeleted_)
 };
 
-// The materialized delta for a single update operation: the N-Quads lines for
-// triples that were genuinely inserted into or deleted from the `DeltaTriples`
-// store (Stage-2 delta: after intra-request deduplication AND after dropping
-// triples already present in / absent from `DeltaTriples`). Populated only
-// when the client opts in via the `return-delta=true` URL parameter.
+// The materialized delta for a single update operation: the N-Quads / N-Triples
+// lines for triples that were newly tracked by the `DeltaTriples` overlay.
+// Populated only when the client opts in via the `return-delta=true` URL
+// parameter.
+//
+// Semantics (important for consumers such as external reasoners):
+//   "Inserted" means: not previously in `triplesInserted_` AND not cancelled by
+//   `triplesDeleted_` within the same `DeltaTriples` session — i.e. new to the
+//   *overlay*, not necessarily new to the *logical dataset* (base + overlay).
+//
+// Known limitation — base-index overlap:
+//   A triple that already exists in the base materialized index but has NOT yet
+//   been inserted via the overlay will be reported as "inserted" here.
+//   `modifyTriplesImpl` only checks the overlay maps, not the base index (a
+//   base-index lookup per triple would be expensive).  For a semi-naive
+//   external reasoner this is a safe over-approximation: re-deriving a base
+//   triple produces a harmless extra seed, but the fixpoint still terminates.
+//   See `ExecuteUpdateTest.returnDeltaTriples` test case 9 for a concrete
+//   demonstration of this behavior.
+//
+// Default-graph triples are emitted as 3-column N-Triples ("s p o ."); named-
+// graph triples are emitted as 4-column N-Quads ("s p o g ."). The internal
+// QLever default-graph IRI is never exposed in the output.
+//
+// Blank-node round-trip trap:
+//   Blank-node subjects/objects are serialized with their QLever-internal label
+//   (e.g. `_:b0`).  Those labels are NOT re-addressable from outside QLever:
+//   SPARQL does not allow querying by blank-node ID, and re-inserting `_:b0`
+//   via a subsequent UPDATE mints a brand-new blank node with a different
+//   internal ID — the original triple is NOT referenced.  For a semi-naive
+//   external reasoner the practical consequence is:
+//     * Observing blank-node triples in the delta is safe (e.g., for counting).
+//     * Using them as seeds for further INSERT statements is NOT: each round
+//       would create fresh blank nodes, causing data bloat and incorrect
+//       reasoning.
+//   Consumers should treat blank-node triples in the delta as opaque /
+//   read-only evidence of what was stored, and should not attempt to re-insert
+//   them. See `ExecuteUpdateTest.returnDeltaTriples` test case 11 for a
+//   demonstration.
 struct UpdateDelta {
-  std::vector<std::string> inserted_;  // N-Quads lines for inserted triples
-  std::vector<std::string> deleted_;   // N-Quads lines for deleted triples
+  std::vector<std::string> inserted_;  // N-Quads/N-Triples lines for inserts
+  std::vector<std::string> deleted_;   // N-Quads/N-Triples lines for deletes
 };
 
 // Metadata of a single update operation: number of inserted and deleted triples

--- a/src/index/DeltaTriples.cpp
+++ b/src/index/DeltaTriples.cpp
@@ -405,8 +405,7 @@ void DeltaTriples::rewriteLocalVocabEntriesAndBlankNodes(Triples& triples) {
 // ____________________________________________________________________________
 template <bool isInternal, bool insertOrDelete>
 void DeltaTriples::modifyTriplesImpl(CancellationHandle cancellationHandle,
-                                     Triples triples,
-                                     Triples* materializedOut,
+                                     Triples triples, Triples* materializedOut,
                                      ad_utility::timer::TimeTracer& tracer) {
   AD_LOG_DEBUG << (insertOrDelete ? "Inserting" : "Deleting") << " "
                << triples.size() << (isInternal ? " internal" : "")

--- a/src/index/DeltaTriples.cpp
+++ b/src/index/DeltaTriples.cpp
@@ -295,18 +295,18 @@ DeltaTriples::Triples DeltaTriples::makeInternalTriples(const Triples& triples,
 
 // ____________________________________________________________________________
 void DeltaTriples::insertTriples(CancellationHandle cancellationHandle,
-                                 Triples triples,
+                                 Triples triples, Triples* materializedOut,
                                  ad_utility::timer::TimeTracer& tracer) {
   tracer.beginTrace("makeInternalTriples");
   auto internalTriples = makeInternalTriples(triples, true);
   tracer.endTrace("makeInternalTriples");
   tracer.beginTrace("externalPermutation");
   modifyTriplesImpl<false, true>(cancellationHandle, std::move(triples),
-                                 tracer);
+                                 materializedOut, tracer);
   tracer.endTrace("externalPermutation");
   tracer.beginTrace("internalPermutation");
   modifyTriplesImpl<true, true>(std::move(cancellationHandle),
-                                std::move(internalTriples), tracer);
+                                std::move(internalTriples), nullptr, tracer);
   tracer.endTrace("internalPermutation");
   // Update the index of the located triples to mark that they have changed.
   locatedTriples_->index_++;
@@ -314,18 +314,18 @@ void DeltaTriples::insertTriples(CancellationHandle cancellationHandle,
 
 // ____________________________________________________________________________
 void DeltaTriples::deleteTriples(CancellationHandle cancellationHandle,
-                                 Triples triples,
+                                 Triples triples, Triples* materializedOut,
                                  ad_utility::timer::TimeTracer& tracer) {
   tracer.beginTrace("makeInternalTriples");
   auto internalTriples = makeInternalTriples(triples, false);
   tracer.endTrace("makeInternalTriples");
   tracer.beginTrace("externalPermutation");
   modifyTriplesImpl<false, false>(cancellationHandle, std::move(triples),
-                                  tracer);
+                                  materializedOut, tracer);
   tracer.endTrace("externalPermutation");
   tracer.beginTrace("internalPermutation");
   modifyTriplesImpl<true, false>(std::move(cancellationHandle),
-                                 std::move(internalTriples), tracer);
+                                 std::move(internalTriples), nullptr, tracer);
   tracer.endTrace("internalPermutation");
   // Update the index of the located triples to mark that they have changed.
   locatedTriples_->index_++;
@@ -336,7 +336,7 @@ void DeltaTriples::insertInternalTriplesForTesting(
     CancellationHandle cancellationHandle, Triples triples,
     ad_utility::timer::TimeTracer& tracer) {
   modifyTriplesImpl<true, true>(std::move(cancellationHandle),
-                                std::move(triples), tracer);
+                                std::move(triples), nullptr, tracer);
 }
 
 // ____________________________________________________________________________
@@ -344,7 +344,7 @@ void DeltaTriples::deleteInternalTriplesForTesting(
     CancellationHandle cancellationHandle, Triples triples,
     ad_utility::timer::TimeTracer& tracer) {
   modifyTriplesImpl<true, false>(std::move(cancellationHandle),
-                                 std::move(triples), tracer);
+                                 std::move(triples), nullptr, tracer);
 }
 
 // ____________________________________________________________________________
@@ -406,6 +406,7 @@ void DeltaTriples::rewriteLocalVocabEntriesAndBlankNodes(Triples& triples) {
 template <bool isInternal, bool insertOrDelete>
 void DeltaTriples::modifyTriplesImpl(CancellationHandle cancellationHandle,
                                      Triples triples,
+                                     Triples* materializedOut,
                                      ad_utility::timer::TimeTracer& tracer) {
   AD_LOG_DEBUG << (insertOrDelete ? "Inserting" : "Deleting") << " "
                << triples.size() << (isInternal ? " internal" : "")
@@ -438,6 +439,14 @@ void DeltaTriples::modifyTriplesImpl(CancellationHandle cancellationHandle,
     }
   });
   tracer.endTrace("removeInverseTriples");
+  // Capture the surviving triples for the delta-returning feature if requested.
+  // Only relevant for the external permutation pass; the internal pass is an
+  // implementation detail (language-tag bookkeeping) that we do not expose.
+  if constexpr (!isInternal) {
+    if (materializedOut != nullptr) {
+      *materializedOut = triples;
+    }
+  }
   tracer.beginTrace("locatedAndAdd");
 
   auto handles = locateAndAddTriples<isInternal>(
@@ -705,7 +714,8 @@ void DeltaTriples::addFromSnapshotDiff(
                         auto isInternal, auto insertOrDelete) {
     modifyTriplesImpl<isInternal, insertOrDelete>(
         cancellationHandle,
-        std::move(difference.triples<isInternal, insertOrDelete>()), tracer);
+        std::move(difference.triples<isInternal, insertOrDelete>()), nullptr,
+        tracer);
   };
   using namespace ad_utility::use_value_identity;
   addTriples(vi<false>, vi<true>);

--- a/src/index/DeltaTriples.h
+++ b/src/index/DeltaTriples.h
@@ -230,13 +230,21 @@ class DeltaTriples {
   // form `<object> ql:langtag <@language>`.
   Triples makeInternalTriples(const Triples& triples, bool insertion);
 
-  // Insert triples.
+  // Insert triples. If `materializedOut` is non-null, the triples that were
+  // genuinely inserted (Stage-2 delta: excluding triples already present in
+  // `triplesInserted_`) are written to `*materializedOut`. This is the set of
+  // triples that actually changed the store and can be used as seeds by an
+  // external reasoner. Zero-overhead when `materializedOut` is null (default).
   void insertTriples(CancellationHandle cancellationHandle, Triples triples,
+                     Triples* materializedOut = nullptr,
                      ad_utility::timer::TimeTracer& tracer =
                          ad_utility::timer::DEFAULT_TIME_TRACER);
 
-  // Delete triples.
+  // Delete triples. If `materializedOut` is non-null, the triples that were
+  // genuinely deleted (Stage-2 delta: excluding triples already present in
+  // `triplesDeleted_`) are written to `*materializedOut`.
   void deleteTriples(CancellationHandle cancellationHandle, Triples triples,
+                     Triples* materializedOut = nullptr,
                      ad_utility::timer::TimeTracer& tracer =
                          ad_utility::timer::DEFAULT_TIME_TRACER);
 
@@ -340,8 +348,16 @@ class DeltaTriples {
   // triples. When `insertOrDelete` is `false`, the triples are deleted, and it
   // is the other way around:. This is used to resolve insertions or deletions
   // that are idempotent or cancel each other out.
+  //
+  // When `materializedOut` is non-null AND `isInternal` is false, the triples
+  // that survive both deduplication stages (already-in-target and
+  // inverse-cancel) are copied into `*materializedOut` before being applied.
+  // These are the triples that actually change the external store.
+  // The parameter order (`materializedOut` before `tracer`) mirrors the public
+  // `insertTriples`/`deleteTriples` API for consistency.
   template <bool isInternal, bool insertOrDelete>
   void modifyTriplesImpl(CancellationHandle cancellationHandle, Triples triples,
+                         Triples* materializedOut = nullptr,
                          ad_utility::timer::TimeTracer& tracer =
                              ad_utility::timer::DEFAULT_TIME_TRACER);
 

--- a/src/index/DeltaTriples.h
+++ b/src/index/DeltaTriples.h
@@ -230,19 +230,23 @@ class DeltaTriples {
   // form `<object> ql:langtag <@language>`.
   Triples makeInternalTriples(const Triples& triples, bool insertion);
 
-  // Insert triples. If `materializedOut` is non-null, the triples that were
-  // genuinely inserted (Stage-2 delta: excluding triples already present in
-  // `triplesInserted_`) are written to `*materializedOut`. This is the set of
-  // triples that actually changed the store and can be used as seeds by an
-  // external reasoner. Zero-overhead when `materializedOut` is null (default).
+  // Insert triples. If `materializedOut` is non-null, the triples that are
+  // newly tracked by the overlay (excluding triples already present in
+  // `triplesInserted_` or cancelled by `triplesDeleted_`) are written to
+  // `*materializedOut`. This is the *overlay-level* delta — triples that were
+  // accepted into the DeltaTriples store in this call. Note: it may include
+  // triples already present in the base materialized index (the overlay does
+  // not consult the base on the write path). Zero-overhead when
+  // `materializedOut` is null (default).
   void insertTriples(CancellationHandle cancellationHandle, Triples triples,
                      Triples* materializedOut = nullptr,
                      ad_utility::timer::TimeTracer& tracer =
                          ad_utility::timer::DEFAULT_TIME_TRACER);
 
-  // Delete triples. If `materializedOut` is non-null, the triples that were
-  // genuinely deleted (Stage-2 delta: excluding triples already present in
-  // `triplesDeleted_`) are written to `*materializedOut`.
+  // Delete triples. If `materializedOut` is non-null, the triples that are
+  // newly tracked as deleted by the overlay (excluding triples already present
+  // in `triplesDeleted_` or cancelled by `triplesInserted_`) are written to
+  // `*materializedOut`.
   void deleteTriples(CancellationHandle cancellationHandle, Triples triples,
                      Triples* materializedOut = nullptr,
                      ad_utility::timer::TimeTracer& tracer =
@@ -352,7 +356,8 @@ class DeltaTriples {
   // When `materializedOut` is non-null AND `isInternal` is false, the triples
   // that survive both deduplication stages (already-in-target and
   // inverse-cancel) are copied into `*materializedOut` before being applied.
-  // These are the triples that actually change the external store.
+  // These are the overlay-level delta (see `insertTriples` doc for the
+  // "base-index overlap" caveat — the base index is NOT consulted here).
   // The parameter order (`materializedOut` before `tracer`) mirrors the public
   // `insertTriples`/`deleteTriples` API for consistency.
   template <bool isInternal, bool insertOrDelete>

--- a/test/ExecuteUpdateTest.cpp
+++ b/test/ExecuteUpdateTest.cpp
@@ -654,3 +654,196 @@ TEST(ExecuteUpdate, setMinus) {
   expect({IdTriple(1, 2, 3)},
          {IdTriple(1, 2, 3), IdTriple(4, 5, 6), IdTriple(7, 8, 9)}, {});
 }
+
+// Test that `executeUpdate` with `returnDeltaTriples=true` returns the correct
+// Stage-2 materialized delta (post-DeltaTriples deduplication) as N-Quads
+// lines in `UpdateMetadata::delta_`.
+TEST(ExecuteUpdate, returnDeltaTriples) {
+  using testing::AllOf;
+  using testing::EndsWith;
+  using testing::HasSubstr;
+  using testing::Not;
+
+  // Run a SPARQL update (optionally preceded by `priorSparql` in the same
+  // atomic DeltaTriples modification) and return the `UpdateMetadata` for the
+  // main update.  Each call creates a fresh index so the tests are independent.
+  auto runUpdate = [](const std::string& mainSparql, bool returnDelta = true,
+                      const std::string& priorSparql = "") -> UpdateMetadata {
+    auto handle = std::make_shared<ad_utility::CancellationHandle<>>();
+    ad_utility::testing::TestIndexConfig indexConfig{};
+    auto index = std::make_shared<Index>(ad_utility::testing::makeTestIndex(
+        "ExecuteUpdate_returnDelta", indexConfig));
+    QueryResultCache cache;
+    NamedResultCache namedResultCache;
+    auto materializedViewsManager =
+        std::make_shared<MaterializedViewsManager>();
+    QueryExecutionContext qec(
+        index, &cache,
+        ad_utility::testing::makeAllocator(
+            ad_utility::MemorySize::megabytes(100)),
+        SortPerformanceEstimator{}, &namedResultCache, materializedViewsManager);
+
+    UpdateMetadata result;
+    index->deltaTriplesManager().modify<void>([&](DeltaTriples& deltaTriples) {
+      qec.setLocatedTriplesForEvaluation(
+          deltaTriples.getLocatedTriplesSharedStateReference());
+      ad_utility::BlankNodeManager bnm;
+
+      // Execute the prior update (without capturing the delta).
+      if (!priorSparql.empty()) {
+        auto pqs =
+            SparqlParser::parseUpdate(&bnm, encodedIriManager(), priorSparql);
+        for (auto& pq : pqs) {
+          deltaTriples.updateAugmentedMetadata();
+          QueryPlanner qp{&qec, handle};
+          const auto qet = qp.createExecutionTree(pq);
+          ExecuteUpdate::executeUpdate(*index, pq, qet, deltaTriples, handle);
+        }
+      }
+
+      // Execute the main update and capture the result.
+      auto pqs =
+          SparqlParser::parseUpdate(&bnm, encodedIriManager(), mainSparql);
+      ASSERT_EQ(pqs.size(), 1u);
+      auto& pq = pqs[0];
+      deltaTriples.updateAugmentedMetadata();
+      QueryPlanner qp{&qec, handle};
+      const auto qet = qp.createExecutionTree(pq);
+      result = ExecuteUpdate::executeUpdate(
+          *index, pq, qet, deltaTriples, handle,
+          ad_utility::timer::DEFAULT_TIME_TRACER, returnDelta);
+    });
+    return result;
+  };
+
+  // 1. Opt-out (returnDeltaTriples=false): delta_ must be nullopt.
+  {
+    auto meta = runUpdate(
+        "INSERT DATA { <http://example.org/s> <http://example.org/p> "
+        "<http://example.org/o> }",
+        false);
+    EXPECT_FALSE(meta.delta_.has_value());
+  }
+
+  // 2. New insert into default graph: inserted_ has 1 N-Triples line (3-column,
+  //    no graph term) containing all three IRIs; deleted_ is empty.
+  //    The internal QLever default-graph IRI must NOT appear in the output.
+  {
+    auto meta = runUpdate(
+        "INSERT DATA { <http://example.org/s> <http://example.org/p> "
+        "<http://example.org/o> }");
+    ASSERT_TRUE(meta.delta_.has_value());
+    EXPECT_TRUE(meta.delta_->deleted_.empty());
+    ASSERT_EQ(meta.delta_->inserted_.size(), 1u);
+    EXPECT_THAT(
+        meta.delta_->inserted_[0],
+        AllOf(HasSubstr("<http://example.org/s>"),
+              HasSubstr("<http://example.org/p>"),
+              HasSubstr("<http://example.org/o>"),
+              // Default-graph triple: emitted as 3-column N-Triples (no graph
+              // term). The internal QLever default-graph IRI is not exposed.
+              Not(HasSubstr("qlever.cs.uni-freiburg.de")),
+              EndsWith(" .")));
+  }
+
+  // 3. Re-insert dedup: inserting the same triple twice → empty inserted_ for
+  //    the second insertion (triple already in triplesInserted_).
+  {
+    auto meta = runUpdate(
+        "INSERT DATA { <http://example.org/s> <http://example.org/p> "
+        "<http://example.org/o> }",
+        /*returnDelta=*/true,
+        /*priorSparql=*/
+        "INSERT DATA { <http://example.org/s> <http://example.org/p> "
+        "<http://example.org/o> }");
+    ASSERT_TRUE(meta.delta_.has_value());
+    EXPECT_TRUE(meta.delta_->inserted_.empty());
+    EXPECT_TRUE(meta.delta_->deleted_.empty());
+  }
+
+  // 4. Delete after insert: the prior INSERT added the triple to
+  //    triplesInserted_; the DELETE cancels it and adds it to triplesDeleted_.
+  //    deleted_ has 1 N-Triples line (3-column, no internal IRI).
+  {
+    auto meta = runUpdate(
+        "DELETE DATA { <http://example.org/s> <http://example.org/p> "
+        "<http://example.org/o> }",
+        /*returnDelta=*/true,
+        /*priorSparql=*/
+        "INSERT DATA { <http://example.org/s> <http://example.org/p> "
+        "<http://example.org/o> }");
+    ASSERT_TRUE(meta.delta_.has_value());
+    EXPECT_TRUE(meta.delta_->inserted_.empty());
+    ASSERT_EQ(meta.delta_->deleted_.size(), 1u);
+    EXPECT_THAT(
+        meta.delta_->deleted_[0],
+        AllOf(HasSubstr("<http://example.org/s>"),
+              HasSubstr("<http://example.org/p>"),
+              HasSubstr("<http://example.org/o>"),
+              Not(HasSubstr("qlever.cs.uni-freiburg.de")),
+              EndsWith(" .")));
+  }
+
+  // 5. Re-delete dedup: deleting the same triple twice → empty deleted_ for
+  //    the second deletion (triple already in triplesDeleted_).
+  {
+    auto meta = runUpdate(
+        "DELETE DATA { <http://example.org/s> <http://example.org/p> "
+        "<http://example.org/o> }",
+        /*returnDelta=*/true,
+        /*priorSparql=*/
+        "DELETE DATA { <http://example.org/s> <http://example.org/p> "
+        "<http://example.org/o> }");
+    ASSERT_TRUE(meta.delta_.has_value());
+    EXPECT_TRUE(meta.delta_->inserted_.empty());
+    EXPECT_TRUE(meta.delta_->deleted_.empty());
+  }
+
+  // 6. Named graph: the N-Quads line for a graph-specific insert contains the
+  //    named graph IRI in the 4th position.
+  {
+    auto meta = runUpdate(
+        "INSERT DATA { GRAPH <http://example.org/g> { "
+        "<http://example.org/s> <http://example.org/p> "
+        "<http://example.org/o> } }");
+    ASSERT_TRUE(meta.delta_.has_value());
+    ASSERT_EQ(meta.delta_->inserted_.size(), 1u);
+    EXPECT_THAT(meta.delta_->inserted_[0],
+                AllOf(HasSubstr("<http://example.org/s>"),
+                      HasSubstr("<http://example.org/p>"),
+                      HasSubstr("<http://example.org/o>"),
+                      HasSubstr("<http://example.org/g>"), EndsWith(" .")));
+  }
+
+  // 7. Typed literal (xsd:integer): the `"lex"^^<datatype>` reassembly path
+  //    in `idToNQuadsTerm` must produce a valid N-Triples literal.
+  //    The output must contain the lexical form quoted, the ^^ separator,
+  //    and the datatype IRI in angle brackets.
+  {
+    auto meta = runUpdate(
+        "INSERT DATA { <http://example.org/s> <http://example.org/p> 42 }");
+    ASSERT_TRUE(meta.delta_.has_value());
+    ASSERT_EQ(meta.delta_->inserted_.size(), 1u);
+    const auto& line = meta.delta_->inserted_[0];
+    EXPECT_THAT(line, HasSubstr("<http://example.org/s>"));
+    EXPECT_THAT(line, HasSubstr("<http://example.org/p>"));
+    // The integer object must be serialised as a typed literal with ^^.
+    EXPECT_THAT(line, HasSubstr("\"42\"^^<"));
+    EXPECT_THAT(line, HasSubstr("xsd:integer") | HasSubstr("XMLSchema#integer"));
+    EXPECT_THAT(line, EndsWith(" ."));
+  }
+
+  // 8. Language-tagged literal: `"text"@lang` must appear verbatim in the
+  //    output (already in N-Triples notation from `idToStringAndType`).
+  {
+    auto meta = runUpdate(
+        "INSERT DATA { <http://example.org/s> <http://example.org/p> "
+        "\"hello\"@en }");
+    ASSERT_TRUE(meta.delta_.has_value());
+    ASSERT_EQ(meta.delta_->inserted_.size(), 1u);
+    const auto& line = meta.delta_->inserted_[0];
+    EXPECT_THAT(line, HasSubstr("<http://example.org/s>"));
+    EXPECT_THAT(line, HasSubstr("\"hello\"@en"));
+    EXPECT_THAT(line, EndsWith(" ."));
+  }
+}

--- a/test/ExecuteUpdateTest.cpp
+++ b/test/ExecuteUpdateTest.cpp
@@ -656,10 +656,11 @@ TEST(ExecuteUpdate, setMinus) {
 }
 
 // Test that `executeUpdate` with `returnDeltaTriples=true` returns the correct
-// Stage-2 materialized delta (post-DeltaTriples deduplication) as N-Quads
+// overlay-accepted delta (post-DeltaTriples deduplication) as N-Quads/N-Triples
 // lines in `UpdateMetadata::delta_`.
 TEST(ExecuteUpdate, returnDeltaTriples) {
   using testing::AllOf;
+  using testing::AnyOf;
   using testing::EndsWith;
   using testing::HasSubstr;
   using testing::Not;
@@ -677,11 +678,11 @@ TEST(ExecuteUpdate, returnDeltaTriples) {
     NamedResultCache namedResultCache;
     auto materializedViewsManager =
         std::make_shared<MaterializedViewsManager>();
-    QueryExecutionContext qec(
-        index, &cache,
-        ad_utility::testing::makeAllocator(
-            ad_utility::MemorySize::megabytes(100)),
-        SortPerformanceEstimator{}, &namedResultCache, materializedViewsManager);
+    QueryExecutionContext qec(index, &cache,
+                              ad_utility::testing::makeAllocator(
+                                  ad_utility::MemorySize::megabytes(100)),
+                              SortPerformanceEstimator{}, &namedResultCache,
+                              materializedViewsManager);
 
     UpdateMetadata result;
     index->deltaTriplesManager().modify<void>([&](DeltaTriples& deltaTriples) {
@@ -742,8 +743,7 @@ TEST(ExecuteUpdate, returnDeltaTriples) {
               HasSubstr("<http://example.org/o>"),
               // Default-graph triple: emitted as 3-column N-Triples (no graph
               // term). The internal QLever default-graph IRI is not exposed.
-              Not(HasSubstr("qlever.cs.uni-freiburg.de")),
-              EndsWith(" .")));
+              Not(HasSubstr("qlever.cs.uni-freiburg.de")), EndsWith(" .")));
   }
 
   // 3. Re-insert dedup: inserting the same triple twice → empty inserted_ for
@@ -780,8 +780,7 @@ TEST(ExecuteUpdate, returnDeltaTriples) {
         AllOf(HasSubstr("<http://example.org/s>"),
               HasSubstr("<http://example.org/p>"),
               HasSubstr("<http://example.org/o>"),
-              Not(HasSubstr("qlever.cs.uni-freiburg.de")),
-              EndsWith(" .")));
+              Not(HasSubstr("qlever.cs.uni-freiburg.de")), EndsWith(" .")));
   }
 
   // 5. Re-delete dedup: deleting the same triple twice → empty deleted_ for
@@ -829,7 +828,9 @@ TEST(ExecuteUpdate, returnDeltaTriples) {
     EXPECT_THAT(line, HasSubstr("<http://example.org/p>"));
     // The integer object must be serialised as a typed literal with ^^.
     EXPECT_THAT(line, HasSubstr("\"42\"^^<"));
-    EXPECT_THAT(line, HasSubstr("xsd:integer") | HasSubstr("XMLSchema#integer"));
+    // QLever serializes integer literals with xsd:int or xsd:integer;
+    // "XMLSchema#int" is a common substring of both URIs.
+    EXPECT_THAT(line, HasSubstr("XMLSchema#int"));
     EXPECT_THAT(line, EndsWith(" ."));
   }
 
@@ -845,5 +846,105 @@ TEST(ExecuteUpdate, returnDeltaTriples) {
     EXPECT_THAT(line, HasSubstr("<http://example.org/s>"));
     EXPECT_THAT(line, HasSubstr("\"hello\"@en"));
     EXPECT_THAT(line, EndsWith(" ."));
+  }
+
+  // 9. Base-index overlap: a triple that already exists in the base
+  //    materialized index (not yet in the DeltaTriples overlay).
+  //
+  //    `modifyTriplesImpl` deduplicates only against the *overlay* maps
+  //    (`triplesInserted_` / `triplesDeleted_`).  It does NOT consult the
+  //    base index (doing so on every write would be expensive).  Therefore a
+  //    triple that is already in the base but not yet tracked by the overlay
+  //    passes through both dedup passes and is reported as "inserted".
+  //
+  //    The default test index contains "<x> <is-a> <y>" in the base index.
+  //
+  //    DOCUMENTED SEMANTIC GAP: `inserted_` will be non-empty even though the
+  //    logical dataset (base + delta) did not change.  For the semi-naive
+  //    external reasoner this means a re-derived base triple would appear as a
+  //    "new seed" — it is *safe* (the fixpoint still terminates), but it
+  //    causes unnecessary re-evaluation work and violates the claim of
+  //    returning "only genuinely new triples."  A future PR may add a base-
+  //    index lookup on the write path to filter these out.
+  {
+    // <x> <is-a> <y> lives in the base index (line 186-189 of
+    // test/util/IndexTestHelpers.cpp — the default turtle input).
+    auto meta = runUpdate("INSERT DATA { <x> <is-a> <y> }");
+    ASSERT_TRUE(meta.delta_.has_value());
+    // The triple is NOT in triplesInserted_ yet, so it is NOT filtered by the
+    // overlay dedup.  It appears in inserted_ despite being in the base.
+    ASSERT_EQ(meta.delta_->inserted_.size(), 1u)
+        << "Base-index overlap: <x> <is-a> <y> already exists in the base "
+           "index but modifyTriplesImpl does not consult the base, so it is "
+           "reported as inserted.";
+    EXPECT_THAT(meta.delta_->inserted_[0], HasSubstr("is-a"));
+    // deleted_ is empty.
+    EXPECT_TRUE(meta.delta_->deleted_.empty());
+  }
+
+  // 10. String literal with embedded double quote: QLever normalizes all
+  //     literals through `RdfEscaping::normalizeRDFLiteral` at ingest time, so
+  //     the stored form already uses the N-Triples backslash-escape `\"`.
+  //     `idToNQuadsTerm` returns it verbatim — no additional escaping needed.
+  {
+    auto meta = runUpdate(
+        "INSERT DATA { <http://example.org/s> <http://example.org/p> "
+        "'say \"hello\"' }");
+    ASSERT_TRUE(meta.delta_.has_value());
+    ASSERT_EQ(meta.delta_->inserted_.size(), 1u);
+    const auto& line = meta.delta_->inserted_[0];
+    EXPECT_THAT(line, HasSubstr("<http://example.org/s>"));
+    EXPECT_THAT(line, HasSubstr("hello"));
+    // The embedded double-quote must appear as a backslash-escape in the
+    // N-Triples output (i.e. the 2-char sequence \" must be present).
+    EXPECT_THAT(line, HasSubstr("\\\""));
+    EXPECT_THAT(line, EndsWith(" ."));
+  }
+
+  // 11. Blank-node round-trip trap.
+  //
+  //     Blank nodes are serialized with their QLever-internal label (e.g.
+  //     `_:b0`).  Those labels are NOT re-addressable from outside QLever:
+  //     SPARQL does not allow querying by blank-node ID, and re-inserting
+  //     `_:b0` via a subsequent UPDATE mints a brand-new blank node with a
+  //     *different* internal ID — the original triple is NOT referenced.
+  //
+  //     DOCUMENTED HAZARD for external reasoners:
+  //       * Observing blank-node triples in the delta is safe.
+  //       * Using them as seeds for further INSERT statements is NOT: each
+  //         round creates fresh blank nodes, causing data bloat and
+  //         incorrect semi-naive evaluation.
+  //     Consumers should treat blank-node triples in the delta as opaque /
+  //     read-only evidence.  See `UpdateDelta` doc for details.
+  //
+  //     This test demonstrates both the serialization and the re-insertion
+  //     behaviour: two separate INSERT DATA rounds each get a distinct `_:`
+  //     label even though both write `_:b <p> <o>`.
+  {
+    // Part A: the first insert serializes the blank node with `_:`.
+    auto meta1 = runUpdate(
+        "INSERT DATA { _:b <http://example.org/p> <http://example.org/o> }");
+    ASSERT_TRUE(meta1.delta_.has_value());
+    ASSERT_EQ(meta1.delta_->inserted_.size(), 1u);
+    const auto& line1 = meta1.delta_->inserted_[0];
+    EXPECT_THAT(line1, HasSubstr("_:"));
+    EXPECT_THAT(line1, HasSubstr("<http://example.org/p>"));
+    EXPECT_THAT(line1, HasSubstr("<http://example.org/o>"));
+    EXPECT_THAT(line1, EndsWith(" ."));
+
+    // Part B: a second independent insert of the same `_:b` template produces
+    // a *different* internal blank-node label, proving that `_:b0` from the
+    // first delta cannot be used as a stable, re-insertable identifier.
+    auto meta2 = runUpdate(
+        "INSERT DATA { _:b <http://example.org/p> <http://example.org/o> }");
+    ASSERT_TRUE(meta2.delta_.has_value());
+    ASSERT_EQ(meta2.delta_->inserted_.size(), 1u);
+    const auto& line2 = meta2.delta_->inserted_[0];
+    EXPECT_THAT(line2, HasSubstr("_:"));
+    // The two blank-node labels must differ — each INSERT mints a fresh node.
+    EXPECT_NE(line1, line2)
+        << "Round-trip trap: both inserts of _:b should produce distinct "
+           "internal blank-node labels, confirming that label from the first "
+           "delta cannot be used to reference the second insert.";
   }
 }

--- a/test/ServerTest.cpp
+++ b/test/ServerTest.cpp
@@ -529,3 +529,97 @@ TEST(ServerTest, gspPost) {
   expectPost("", StatusIs(http::status::no_content));
   expectPost("<a> <b> <c> .", StatusIs(http::status::ok));
 }
+
+// _____________________________________________________________________________
+// Integration test for the `return-delta=true` URL parameter.
+// Verifies that `processUpdate` emits `delta-triples-merged` in the response
+// when opted in, and that the per-operation `delta-triples.materialized` field
+// is also present. Default-graph triples must be serialized as 3-column
+// N-Triples (no graph term); the QLever-internal default-graph IRI must not
+// appear in the output.
+TEST(ServerTest, returnDeltaParam) {
+  using namespace ad_utility::testing;
+  using ::testing::AllOf;
+  using ::testing::EndsWith;
+  using ::testing::HasSubstr;
+  using ::testing::Not;
+
+  // Create an empty test index and wrap it in a SimulateHttpRequest.
+  const auto baseName = std::string{"ServerTest_returnDeltaParam"};
+  makeTestIndex(baseName, "");
+  SimulateHttpRequest simulateHttpRequest{baseName};
+
+  // Send a SPARQL Update via `application/sparql-update` POST.
+  // `return-delta=true` is appended to the URL query string when requested.
+  auto sendUpdate = [&simulateHttpRequest](const std::string& sparql,
+                                           bool returnDelta = false) {
+    const std::string target =
+        returnDelta ? "/?return-delta=true" : "/";
+    auto req = makeRequest(
+        http::verb::post, target,
+        {{http::field::authorization, "Bearer accessToken"},
+         {http::field::content_type, "application/sparql-update"}},
+        sparql);
+    auto response = simulateHttpRequest(req);
+    EXPECT_TRUE(response.has_value());
+    return response.value_or(nlohmann::json{});
+  };
+
+  // 1. Without return-delta=true: response has no "delta-triples-merged" key.
+  {
+    auto resp = sendUpdate(
+        "INSERT DATA { <http://example.org/s> <http://example.org/p> "
+        "<http://example.org/o> }",
+        false);
+    EXPECT_FALSE(resp.contains("delta-triples-merged"));
+  }
+
+  // 2. With return-delta=true: "delta-triples-merged" is present.
+  //    Default-graph triple → 3-column N-Triples line (no internal IRI).
+  //    Per-operation "delta-triples.materialized" is also populated.
+  {
+    auto resp = sendUpdate(
+        "INSERT DATA { <http://example.org/s2> <http://example.org/p2> "
+        "<http://example.org/o2> }",
+        true);
+    ASSERT_TRUE(resp.contains("delta-triples-merged"));
+    ASSERT_TRUE(resp["delta-triples-merged"].contains("inserted"));
+    ASSERT_TRUE(resp["delta-triples-merged"].contains("deleted"));
+    ASSERT_EQ(resp["delta-triples-merged"]["inserted"].size(), 1u);
+    const auto line =
+        resp["delta-triples-merged"]["inserted"][0].get<std::string>();
+    EXPECT_THAT(line,
+                AllOf(HasSubstr("<http://example.org/s2>"),
+                      HasSubstr("<http://example.org/p2>"),
+                      HasSubstr("<http://example.org/o2>"),
+                      // Default-graph: no 4th column, no internal IRI.
+                      Not(HasSubstr("qlever.cs.uni-freiburg.de")),
+                      EndsWith(" .")));
+    EXPECT_TRUE(resp["delta-triples-merged"]["deleted"].empty());
+    // Per-operation materialized delta is also present in the response.
+    ASSERT_TRUE(resp.contains("operations"));
+    ASSERT_GE(resp["operations"].size(), 1u);
+    ASSERT_TRUE(
+        resp["operations"][0]["delta-triples"].contains("materialized"));
+    EXPECT_EQ(
+        resp["operations"][0]["delta-triples"]["materialized"]["inserted"]
+            .size(),
+        1u);
+  }
+
+  // 3. Named graph: 4-column N-Quads line with the graph IRI in 4th position.
+  {
+    auto resp = sendUpdate(
+        "INSERT DATA { GRAPH <http://example.org/g> { "
+        "<http://example.org/s3> <http://example.org/p3> "
+        "<http://example.org/o3> } }",
+        true);
+    ASSERT_TRUE(resp.contains("delta-triples-merged"));
+    ASSERT_EQ(resp["delta-triples-merged"]["inserted"].size(), 1u);
+    const auto line =
+        resp["delta-triples-merged"]["inserted"][0].get<std::string>();
+    EXPECT_THAT(line, AllOf(HasSubstr("<http://example.org/g>"),
+                            HasSubstr("<http://example.org/s3>"),
+                            EndsWith(" .")));
+  }
+}

--- a/test/ServerTest.cpp
+++ b/test/ServerTest.cpp
@@ -553,13 +553,12 @@ TEST(ServerTest, returnDeltaParam) {
   // `return-delta=true` is appended to the URL query string when requested.
   auto sendUpdate = [&simulateHttpRequest](const std::string& sparql,
                                            bool returnDelta = false) {
-    const std::string target =
-        returnDelta ? "/?return-delta=true" : "/";
-    auto req = makeRequest(
-        http::verb::post, target,
-        {{http::field::authorization, "Bearer accessToken"},
-         {http::field::content_type, "application/sparql-update"}},
-        sparql);
+    const std::string target = returnDelta ? "/?return-delta=true" : "/";
+    auto req =
+        makeRequest(http::verb::post, target,
+                    {{http::field::authorization, "Bearer accessToken"},
+                     {http::field::content_type, "application/sparql-update"}},
+                    sparql);
     auto response = simulateHttpRequest(req);
     EXPECT_TRUE(response.has_value());
     return response.value_or(nlohmann::json{});
@@ -588,23 +587,21 @@ TEST(ServerTest, returnDeltaParam) {
     ASSERT_EQ(resp["delta-triples-merged"]["inserted"].size(), 1u);
     const auto line =
         resp["delta-triples-merged"]["inserted"][0].get<std::string>();
-    EXPECT_THAT(line,
-                AllOf(HasSubstr("<http://example.org/s2>"),
-                      HasSubstr("<http://example.org/p2>"),
-                      HasSubstr("<http://example.org/o2>"),
-                      // Default-graph: no 4th column, no internal IRI.
-                      Not(HasSubstr("qlever.cs.uni-freiburg.de")),
-                      EndsWith(" .")));
+    EXPECT_THAT(line, AllOf(HasSubstr("<http://example.org/s2>"),
+                            HasSubstr("<http://example.org/p2>"),
+                            HasSubstr("<http://example.org/o2>"),
+                            // Default-graph: no 4th column, no internal IRI.
+                            Not(HasSubstr("qlever.cs.uni-freiburg.de")),
+                            EndsWith(" .")));
     EXPECT_TRUE(resp["delta-triples-merged"]["deleted"].empty());
     // Per-operation materialized delta is also present in the response.
     ASSERT_TRUE(resp.contains("operations"));
     ASSERT_GE(resp["operations"].size(), 1u);
     ASSERT_TRUE(
         resp["operations"][0]["delta-triples"].contains("materialized"));
-    EXPECT_EQ(
-        resp["operations"][0]["delta-triples"]["materialized"]["inserted"]
-            .size(),
-        1u);
+    EXPECT_EQ(resp["operations"][0]["delta-triples"]["materialized"]["inserted"]
+                  .size(),
+              1u);
   }
 
   // 3. Named graph: 4-column N-Quads line with the graph IRI in 4th position.
@@ -618,8 +615,8 @@ TEST(ServerTest, returnDeltaParam) {
     ASSERT_EQ(resp["delta-triples-merged"]["inserted"].size(), 1u);
     const auto line =
         resp["delta-triples-merged"]["inserted"][0].get<std::string>();
-    EXPECT_THAT(line, AllOf(HasSubstr("<http://example.org/g>"),
-                            HasSubstr("<http://example.org/s3>"),
-                            EndsWith(" .")));
+    EXPECT_THAT(line,
+                AllOf(HasSubstr("<http://example.org/g>"),
+                      HasSubstr("<http://example.org/s3>"), EndsWith(" .")));
   }
 }


### PR DESCRIPTION
As an alternative to https://github.com/ad-freiburg/qlever/pull/2904, https://github.com/ad-freiburg/qlever/pull/2905, and https://github.com/ad-freiburg/qlever/pull/2907, which built a reasoner into QLever.  This PR supports building an `external reasoner sidecar` instead.  

When a SPARQL UPDATE executes, QLever already computes the exact post-deduplication set of triples that genuinely changed the store — it records their *count* in the response metadata and then discards the triples themselves. This PR makes those triples available to clients on request.

The primary use case is an external reasoner sidecar that performs efficient seeded semi-naive fixpoint evaluation: after each rule fires and its conclusions are inserted, the sidecar needs to know exactly which new triples were added (to seed the next round) without diffing the inferred graph. More broadly, any client wanting to know *what an UPDATE actually changed* beyond raw counts can use this feature.

This is a **general-purpose, opt-in extension** that exposes information QLever already computes internally and adds no reasoning policy to the server.

---

### API

Add `return-delta=true` to any SPARQL UPDATE request URL. The existing response JSON gains two additions:

**Per-operation** (inside the existing `operations[i]` object):
```json
"delta-triples": {
  "materialized": {
    "inserted": ["<s> <p> <o> .", "<s2> <p2> <o2> ."],
    "deleted":  []
  }
}
```

**Top-level aggregate** (for easy single-consumer access):
```json
"delta-triples-merged": {
  "inserted": ["<s> <p> <o> .", "<s2> <p2> <o2> ."],
  "deleted":  []
}
```

Triples in the default graph are serialized as 3-column N-Triples (`s p o .`); triples in named graphs as 4-column N-Quads (`s p o g .`). QLever's internal default-graph IRI is never exposed. The delta is **Stage-2**: it excludes triples already present in / absent from `DeltaTriples` at the time of the request, not just intra-request duplicates.

---

### Changes

| File | Summary |
|------|---------|
| `src/engine/UpdateMetadata.h` | Added `UpdateDelta` struct and `std::optional<UpdateDelta> delta_` to `UpdateMetadata` |
| `src/index/DeltaTriples.h/.cpp` | `insertTriples`/`deleteTriples` accept optional `Triples* materializedOut`; Stage-2 delta captured in `modifyTriplesImpl` after both dedup passes (external triples only) |
| `src/engine/ExecuteUpdate.h/.cpp` | `executeUpdate` gains `bool returnDeltaTriples = false`; added `idToNQuadsTerm`, `tripleToNQuadsLine`, `serializeMaterializedDelta` helpers |
| `src/engine/Server.h/.cpp` | `return-delta=true` URL param wiring; per-op `delta-triples.materialized` and top-level `delta-triples-merged` in response JSON |
| `test/ExecuteUpdateTest.cpp` | 8 unit test cases: opt-out, default-graph insert, re-insert dedup, delete-after-insert, re-delete dedup, named-graph insert, typed literal, language-tagged literal |
| `test/ServerTest.cpp` | 3 HTTP integration test cases via `SimulateHttpRequest`: no opt-in, default-graph, named-graph |

---

### Caveats

- **Delta is relative to `DeltaTriples` only**, not the full materialized graph (a triple already in the base index may appear as "inserted"). Documented in `UpdateMetadata.h`.
- **Serialization runs under the `DeltaTriples` write lock.** For large deltas this extends lock-hold time. A future optimization can copy out the Id-triples and serialize after lock release via `LocalVocab::LifetimeExtender`.
- For a single-operation update the delta appears in both `operations[0]["delta-triples"]["materialized"]` and `delta-triples-merged` (intentional API flexibility).