### PR TITLE
Hash join

### DIFF
--- a/src/engine/CMakeLists.txt
+++ b/src/engine/CMakeLists.txt
@@ -3,7 +3,7 @@ add_library(SortPerformanceEstimator SortPerformanceEstimator.cpp)
 qlever_target_link_libraries(SortPerformanceEstimator parser)
 add_library(engine
         QueryExecutionTree.cpp Operation.cpp Result.cpp
-        IndexScan.cpp Join.cpp Sort.cpp
+        IndexScan.cpp Join.cpp HashJoin.cpp Sort.cpp
         Distinct.cpp OrderBy.cpp Filter.cpp
         QueryPlanner.cpp QueryPlanningCostFactors.cpp QueryRewriteUtils.cpp
         OptionalJoin.cpp CountAvailablePredicates.cpp GroupByImpl.cpp GroupBy.cpp HasPredicateScan.cpp

--- a/src/engine/HashJoin.cpp
+++ b/src/engine/HashJoin.cpp
@@ -77,7 +77,7 @@ HashJoin::HashJoin(QueryExecutionContext* qec, std::shared_ptr<QueryExecutionTre
 // _____________________________________________________________________________
 string HashJoin::getCacheKeyImpl() const {
   std::ostringstream os;
-  os << "JOIN\n"
+  os << "HASHJOIN\n"
      << left_->getCacheKey() << " join-column: [" << leftJoinCol_ << "]\n";
   os << "|X|\n"
      << right_->getCacheKey() << " join-column: [" << rightJoinCol_ << "]";
@@ -202,70 +202,63 @@ float HashJoin::getMultiplicity(size_t col) {
 
 // _____________________________________________________________________________
 size_t HashJoin::getCostEstimate() {
-  // 1. Fetch necessary information
-  // Set cost estimate to infinity if hash join is not supported due to:
-  // compare estimated size of hash map with available memory.
+  if (!hashJoinIsApplicable()) {
+    return vetoCostEstimate();
+  } else {
+    // Cost Calculation: Build HashMap + Probe HashMap + Cost of Subtrees
+    return
+      left_->getSizeEstimate() + right_->getSizeEstimate() +
+      left_->getCostEstimate() + right_->getCostEstimate();
+  }
+}
+
+// _____________________________________________________________________________
+bool HashJoin::hashJoinIsApplicable() const {
+  return hashMapFitsInMemory() && !biggerInputSortedOnJoinCol() && !eitherSideIsIndexScan();
+}
+
+// _____________________________________________________________________________
+bool HashJoin::hashMapFitsInMemory() const {
   auto leftSize = left_->getSizeEstimate();
   auto rightSize = right_->getSizeEstimate();
-  auto leftCost = left_->getCostEstimate();
-  auto rightCost = right_->getCostEstimate();
   bool leftIsSmaller = leftSize <= rightSize;
   size_t buildSize = leftIsSmaller ? leftSize : rightSize;
   size_t numCols = leftIsSmaller ? 
                    left_->getResultWidth() : right_->getResultWidth();
   ad_utility::MemorySize estimatedHashMapSize = 
     ad_utility::MemorySize::bytes(buildSize * numCols * sizeof(Id));
+  return (estimatedHashMapSize <= allocator().amountMemoryLeft());
+}
 
-  // Max value to return for excludes.
-  // We want to return a value, that is bigger than any possible combination
-  // of Sort + Join of children, but not bigger than `std::numeric_limits<size_t>::max()`, because then we can get an
-  // overflow.
-  auto calculateMaxSize = [this, leftSize, rightSize, leftCost, rightCost]() {
-    size_t sortCost = leftSize * log(leftSize) + rightSize * log(rightSize);
-    size_t joinCost = getSizeEstimateBeforeLimit() + leftCost + rightCost;
-    return sortCost + joinCost + 1;
-  };
-  size_t maxSize = calculateMaxSize();
-
-  // 2. Excludes
-  if (estimatedHashMapSize > allocator().amountMemoryLeft()) {
-    return maxSize;
-  }
-
-  // If both sides are sorted on the join column, prefer the merge join (Join
-  // class) which can exploit the sortedness for free.
-  auto isSortedOnJoinCol = [](const auto& tree, ColumnIndex joinCol) {
-    auto sorted = tree->resultSortedOn();
-    return !sorted.empty() && sorted[0] == joinCol;
-  };
-  if (isSortedOnJoinCol(left_, leftJoinCol_) &&
-      isSortedOnJoinCol(right_, rightJoinCol_)) {
-    return maxSize;
-  }
-
-  // If the bigger side is already sorted on the join column, a merge join is
-  // more efficient than hashing.
+// _____________________________________________________________________________
+bool HashJoin::biggerInputSortedOnJoinCol() const {
+  bool leftIsSmaller = left_->getSizeEstimate() <= right_->getSizeEstimate();
   auto biggerResultSortedOn =
-      leftIsSmaller ? right_->resultSortedOn() : left_->resultSortedOn();
+    leftIsSmaller ? right_->resultSortedOn() : left_->resultSortedOn();
   if (!biggerResultSortedOn.empty()) {
     auto biggerJoinCol = leftIsSmaller ? rightJoinCol_ : leftJoinCol_;
     if (biggerResultSortedOn[0] == biggerJoinCol) {
-      return maxSize;
+      return true;
     }
   }
+  return false;
+}
 
-  // Exclude if both sides are IndexScans
-  if (std::dynamic_pointer_cast<IndexScan>(left_->getRootOperation()) &&
-      std::dynamic_pointer_cast<IndexScan>(right_->getRootOperation())) {
-    return maxSize;
-  }
+// _____________________________________________________________________________
+bool HashJoin::eitherSideIsIndexScan() const {
+  return std::dynamic_pointer_cast<IndexScan>(left_->getRootOperation()) ||
+         std::dynamic_pointer_cast<IndexScan>(right_->getRootOperation());
+}
 
-  // 3. Actual calculation of cost estimate
-  // Build HashMap + Probe HashMap + Cost of Subtrees
-  size_t costBuild = leftSize;
-  size_t costProbe = rightSize;
-  size_t costSubtrees = left_->getCostEstimate() + right_->getCostEstimate();
-  return costBuild + costProbe + costSubtrees;
+// _____________________________________________________________________________
+size_t HashJoin::vetoCostEstimate() {
+  auto leftSize = left_->getSizeEstimate();
+  auto rightSize = right_->getSizeEstimate();
+  auto leftCost = left_->getCostEstimate();
+  auto rightCost = right_->getCostEstimate();
+  size_t sortCost = leftSize * log(leftSize) + rightSize * log(rightSize);
+  size_t joinCost = getSizeEstimateBeforeLimit() + leftCost + rightCost;
+  return sortCost + joinCost + VETO_COST_OFFSET;
 }
 
 // _____________________________________________________________________________

--- a/src/engine/HashJoin.cpp
+++ b/src/engine/HashJoin.cpp
@@ -202,19 +202,34 @@ float HashJoin::getMultiplicity(size_t col) {
 
 // _____________________________________________________________________________
 size_t HashJoin::getCostEstimate() {
+  // 1. Fetch necessary information
   // Set cost estimate to infinity if hash join is not supported due to:
   // compare estimated size of hash map with available memory.
   auto leftSize = left_->getSizeEstimate();
   auto rightSize = right_->getSizeEstimate();
+  auto leftCost = left_->getCostEstimate();
+  auto rightCost = right_->getCostEstimate();
   bool leftIsSmaller = leftSize <= rightSize;
   size_t buildSize = leftIsSmaller ? leftSize : rightSize;
   size_t numCols = leftIsSmaller ? 
                    left_->getResultWidth() : right_->getResultWidth();
   ad_utility::MemorySize estimatedHashMapSize = 
     ad_utility::MemorySize::bytes(buildSize * numCols * sizeof(Id));
-  // TODO: sollte noch verfeinert werden.
+
+  // Max value to return for excludes.
+  // We want to return a value, that is bigger than any possible combination
+  // of Sort + Join of children, but not bigger than `std::numeric_limits<size_t>::max()`, because then we can get an
+  // overflow.
+  auto calculateMaxSize = [this, leftSize, rightSize, leftCost, rightCost]() {
+    size_t sortCost = leftSize * log(leftSize) + rightSize * log(rightSize);
+    size_t joinCost = getSizeEstimateBeforeLimit() + leftCost + rightCost;
+    return sortCost + joinCost + 1;
+  };
+  size_t maxSize = calculateMaxSize();
+
+  // 2. Excludes
   if (estimatedHashMapSize > allocator().amountMemoryLeft()) {
-    return std::numeric_limits<size_t>::max();
+    return maxSize;
   }
 
   // If both sides are sorted on the join column, prefer the merge join (Join
@@ -225,8 +240,9 @@ size_t HashJoin::getCostEstimate() {
   };
   if (isSortedOnJoinCol(left_, leftJoinCol_) &&
       isSortedOnJoinCol(right_, rightJoinCol_)) {
-    return std::numeric_limits<size_t>::max();
+    return maxSize;
   }
+
   // If the bigger side is already sorted on the join column, a merge join is
   // more efficient than hashing.
   auto biggerResultSortedOn =
@@ -234,16 +250,17 @@ size_t HashJoin::getCostEstimate() {
   if (!biggerResultSortedOn.empty()) {
     auto biggerJoinCol = leftIsSmaller ? rightJoinCol_ : leftJoinCol_;
     if (biggerResultSortedOn[0] == biggerJoinCol) {
-      return std::numeric_limits<size_t>::max();
+      return maxSize;
     }
   }
 
-  // Exclude index scans
-  if (std::dynamic_pointer_cast<IndexScan>(left_->getRootOperation()) ||
+  // Exclude if both sides are IndexScans
+  if (std::dynamic_pointer_cast<IndexScan>(left_->getRootOperation()) &&
       std::dynamic_pointer_cast<IndexScan>(right_->getRootOperation())) {
-    return std::numeric_limits<size_t>::max();
+    return maxSize;
   }
 
+  // 3. Actual calculation of cost estimate
   // Build HashMap + Probe HashMap + Cost of Subtrees
   size_t costBuild = leftSize;
   size_t costProbe = rightSize;

--- a/src/engine/HashJoin.cpp
+++ b/src/engine/HashJoin.cpp
@@ -1,0 +1,430 @@
+// Copyright 2026, University of Freiburg,
+// Chair of Algorithms and Data Structures.
+// Author: Mark Veser (veser@informatik.uni-freiburg.de)
+
+#include "engine/HashJoin.h"
+
+#include <sstream>
+#include <vector>
+
+#include "JoinWithIndexScanHelpers.h"
+#include "backports/functional.h"
+#include "backports/type_traits.h"
+#include "engine/AddCombinedRowToTable.h"
+#include "engine/CallFixedSize.h"
+#include "engine/IndexScan.h"
+#include "engine/JoinHelpers.h"
+#include "engine/OperationBindPushDownImpl.h"
+#include "engine/Service.h"
+#include "global/Constants.h"
+#include "global/Id.h"
+#include "global/RuntimeParameters.h"
+#include "util/Algorithm.h"
+#include "util/Exception.h"
+#include "util/Generators.h"
+#include "util/HashMap.h"
+#include "util/Iterators.h"
+#include "util/JoinAlgorithms/JoinAlgorithms.h"
+
+using namespace qlever::joinHelpers;
+using namespace qlever::joinWithIndexScanHelpers;
+using std::endl;
+using std::string;
+
+// _____________________________________________________________________________
+HashJoin::HashJoin(QueryExecutionContext* qec, std::shared_ptr<QueryExecutionTree> t1,
+           std::shared_ptr<QueryExecutionTree> t2, ColumnIndex t1JoinCol,
+           ColumnIndex t2JoinCol, bool keepJoinColumn,
+           bool allowSwappingChildrenOnlyForTesting)
+    : Operation(qec), keepJoinColumn_{keepJoinColumn} {
+  AD_CONTRACT_CHECK(t1 && t2);
+
+  // Make the order of the two subtrees deterministic. That way, queries that
+  // are identical except for the order of the join operands, are easier to
+  // identify.
+  auto swapChildren = [&]() {
+    // This can be disabled by tests to fix the order of the subtrees.
+    if (allowSwappingChildrenOnlyForTesting) {
+      std::swap(t1, t2);
+      std::swap(t1JoinCol, t2JoinCol);
+    }
+  };
+  if (t1->getCacheKey() > t2->getCacheKey()) {
+    swapChildren();
+  }
+  // If one of the inputs is a SCAN and the other one is not, always make the
+  // SCAN the right child (which also gives a deterministic order of the
+  // subtrees). This simplifies several branches in the `computeResult` method.
+  if (std::dynamic_pointer_cast<IndexScan>(t1->getRootOperation()) &&
+      !std::dynamic_pointer_cast<IndexScan>(t2->getRootOperation())) {
+    swapChildren();
+  }
+  left_ = std::move(t1);
+  leftJoinCol_ = t1JoinCol;
+  right_ = std::move(t2);
+  rightJoinCol_ = t2JoinCol;
+  sizeEstimate_ = 0;
+  sizeEstimateComputed_ = false;
+  multiplicities_.clear();
+  auto findJoinVar = [](const QueryExecutionTree& tree,
+                        ColumnIndex joinCol) -> Variable {
+    return tree.getVariableAndInfoByColumnIndex(joinCol).first;
+  };
+  joinVar_ = findJoinVar(*left_, leftJoinCol_);
+  AD_CONTRACT_CHECK(joinVar_ == findJoinVar(*right_, rightJoinCol_));
+}
+
+// _____________________________________________________________________________
+string HashJoin::getCacheKeyImpl() const {
+  std::ostringstream os;
+  os << "JOIN\n"
+     << left_->getCacheKey() << " join-column: [" << leftJoinCol_ << "]\n";
+  os << "|X|\n"
+     << right_->getCacheKey() << " join-column: [" << rightJoinCol_ << "]";
+  os << "keep join Col " << keepJoinColumn_;
+  return std::move(os).str();
+}
+
+// _____________________________________________________________________________
+string HashJoin::getDescriptor() const { return "HashJoin on " + joinVar_.name(); }
+
+// _____________________________________________________________________________
+Result HashJoin::computeResult(bool requestLaziness) {
+  AD_LOG_DEBUG << "Getting sub-results for join result computation..." << endl;
+  if (left_->knownEmptyResult() || right_->knownEmptyResult()) {
+    left_->getRootOperation()->updateRuntimeInformationWhenOptimizedOut();
+    right_->getRootOperation()->updateRuntimeInformationWhenOptimizedOut();
+    return createEmptyResult();
+  }
+
+  // TODO: consider different cases (IndexScan, Service, etc.). Respectively
+  // should probably be considered in the cost estimation and not end up here.
+  auto leftResult = left_->getResult(requestLaziness);
+  auto rightResult = right_->getResult(requestLaziness);
+
+  auto leftIsSmaller = left_->getSizeEstimate() <= right_->getSizeEstimate();
+  return hashJoin(std::move(leftResult), std::move(rightResult), leftIsSmaller);
+}
+
+// _____________________________________________________________________________
+Result HashJoin::hashJoin(std::shared_ptr<const Result> left,
+                          std::shared_ptr<const Result> right,
+                          bool leftIsSmaller) {
+  // Build Map from smaller Input. I want to keep left and right as they are
+  // because in the resulting Table left input should come first.
+  const auto& small = leftIsSmaller ? left : right;
+  const auto& large = leftIsSmaller ? right : left;
+  auto jcSmall = leftIsSmaller ? leftJoinCol_ : rightJoinCol_;
+  auto jcLarge = leftIsSmaller ? rightJoinCol_ : leftJoinCol_;
+  // Helper function for hash map creation
+  ad_utility::HashMap<Id, std::vector<IdTable::row_type>> map;
+  LocalVocab localVocab;
+  auto buildHashMap = [&map, jcSmall](const auto& table) {
+    for (const auto& row : table) {
+      map[row[jcSmall]].push_back(row);
+    }
+  };
+  // Build Hash Map using the smaller result.
+  // both fully materialized and lazy tables are supported
+  if (small->isFullyMaterialized()) {
+    buildHashMap(small->idTable());
+    localVocab.mergeWith(small->localVocab());
+  } else {
+    for (const auto& table : small->idTables()) {
+      buildHashMap(table.idTable_);
+      localVocab.mergeWith(table.localVocab_);
+    }
+  }
+  // Probing phase: check for matching rows in the larger table
+  IdTable result{getResultWidth(), allocator()};
+  auto probeRow = [this, &map, jcLarge, jcSmall, leftIsSmaller,
+                   &result](const auto& table) {
+    for (const auto& row : table) {
+      auto entry = map.find(row[jcLarge]);
+      if (entry != map.end()) {
+        for (const auto& rowSmall : entry->second) {
+          // the order of the resulting table has to be in the following order:
+          // left table + right table. Since the right table could be the smaller one
+          // we have to cover both cases and make sure the original left side remains
+          // on the left side.
+          if (leftIsSmaller) {
+            addCombinedRowToIdTable(rowSmall, row, jcSmall, jcLarge, keepJoinColumn_, &result);
+          } else {
+            addCombinedRowToIdTable(row, rowSmall, jcLarge, jcSmall, keepJoinColumn_, &result);
+          }
+        }
+      }
+    }
+  };
+  // both fully materialized and lazy tables are supported
+  if (large->isFullyMaterialized()) {
+    probeRow(large->idTable());
+    localVocab.mergeWith(large->localVocab());
+  } else {
+    for (const auto& table : large->idTables()) {
+      probeRow(table.idTable_);
+      localVocab.mergeWith(table.localVocab_);
+    }
+  }
+  return Result{std::move(result), resultSortedOn(),
+                std::move(localVocab)};
+}
+
+// _____________________________________________________________________________
+VariableToColumnMap HashJoin::computeVariableToColumnMap() const {
+  return makeVarToColMapForJoinOperation(
+      left_->getVariableColumns(), right_->getVariableColumns(),
+      {{leftJoinCol_, rightJoinCol_}}, BinOpType::Join, left_->getResultWidth(),
+      keepJoinColumn_);
+}
+
+// _____________________________________________________________________________
+size_t HashJoin::getResultWidth() const {
+  auto sumOfChildWidths = left_->getResultWidth() + right_->getResultWidth();
+  AD_CORRECTNESS_CHECK(sumOfChildWidths >= 2);
+  return sumOfChildWidths - 1 - static_cast<size_t>(!keepJoinColumn_);
+}
+
+// _____________________________________________________________________________
+std::vector<ColumnIndex> HashJoin::resultSortedOn() const {
+  // TODO: Needs to be consider if smaller side is sorted
+  return {};
+}
+
+// _____________________________________________________________________________
+float HashJoin::getMultiplicity(size_t col) {
+  if (multiplicities_.empty()) {
+    computeSizeEstimateAndMultiplicities();
+    sizeEstimateComputed_ = true;
+  }
+  return multiplicities_.at(col);
+}
+
+// _____________________________________________________________________________
+size_t HashJoin::getCostEstimate() {
+  // Set cost estimate to infinity if hash join is not supported due to:
+  // compare estimated size of hash map with available memory.
+  auto leftSize = left_->getSizeEstimate();
+  auto rightSize = right_->getSizeEstimate();
+  bool leftIsSmaller = leftSize <= rightSize;
+  size_t buildSize = leftIsSmaller ? leftSize : rightSize;
+  size_t numCols = leftIsSmaller ? 
+                   left_->getResultWidth() : right_->getResultWidth();
+  ad_utility::MemorySize estimatedHashMapSize = 
+    ad_utility::MemorySize::bytes(buildSize * numCols * sizeof(Id));
+  // TODO: sollte noch verfeinert werden.
+  if (estimatedHashMapSize > allocator().amountMemoryLeft()) {
+    return std::numeric_limits<size_t>::max();
+  }
+
+  // If both sides are sorted on the join column, prefer the merge join (Join
+  // class) which can exploit the sortedness for free.
+  auto isSortedOnJoinCol = [](const auto& tree, ColumnIndex joinCol) {
+    auto sorted = tree->resultSortedOn();
+    return !sorted.empty() && sorted[0] == joinCol;
+  };
+  if (isSortedOnJoinCol(left_, leftJoinCol_) &&
+      isSortedOnJoinCol(right_, rightJoinCol_)) {
+    return std::numeric_limits<size_t>::max();
+  }
+  // If the bigger side is already sorted on the join column, a merge join is
+  // more efficient than hashing.
+  auto biggerResultSortedOn =
+      leftIsSmaller ? right_->resultSortedOn() : left_->resultSortedOn();
+  if (!biggerResultSortedOn.empty()) {
+    auto biggerJoinCol = leftIsSmaller ? rightJoinCol_ : leftJoinCol_;
+    if (biggerResultSortedOn[0] == biggerJoinCol) {
+      return std::numeric_limits<size_t>::max();
+    }
+  }
+
+  // Exclude index scans
+  if (std::dynamic_pointer_cast<IndexScan>(left_->getRootOperation()) ||
+      std::dynamic_pointer_cast<IndexScan>(right_->getRootOperation())) {
+    return std::numeric_limits<size_t>::max();
+  }
+
+  // Build HashMap + Probe HashMap + Cost of Subtrees
+  size_t costBuild = leftSize;
+  size_t costProbe = rightSize;
+  size_t costSubtrees = left_->getCostEstimate() + right_->getCostEstimate();
+  return costBuild + costProbe + costSubtrees;
+}
+
+// _____________________________________________________________________________
+void HashJoin::computeSizeEstimateAndMultiplicities() {
+  multiplicities_.clear();
+  if (left_->getSizeEstimate() == 0 || right_->getSizeEstimate() == 0) {
+    for (size_t i = 0; i < getResultWidth(); ++i) {
+      multiplicities_.emplace_back(1);
+    }
+    return;
+  }
+
+  // nof := number of
+  size_t nofDistinctLeft = std::max(
+      size_t(1), static_cast<size_t>(left_->getSizeEstimate() /
+                                     left_->getMultiplicity(leftJoinCol_)));
+  size_t nofDistinctRight = std::max(
+      size_t(1), static_cast<size_t>(right_->getSizeEstimate() /
+                                     right_->getMultiplicity(rightJoinCol_)));
+
+  size_t nofDistinctInResult = std::min(nofDistinctLeft, nofDistinctRight);
+
+  double adaptSizeLeft =
+      left_->getSizeEstimate() *
+      (static_cast<double>(nofDistinctInResult) / nofDistinctLeft);
+  double adaptSizeRight =
+      right_->getSizeEstimate() *
+      (static_cast<double>(nofDistinctInResult) / nofDistinctRight);
+
+  double corrFactor = _executionContext
+                          ? _executionContext->getCostFactor(
+                                "JOIN_SIZE_ESTIMATE_CORRECTION_FACTOR")
+                          : 1.0;
+
+  double jcMultiplicityInResult = left_->getMultiplicity(leftJoinCol_) *
+                                  right_->getMultiplicity(rightJoinCol_);
+  sizeEstimate_ = std::max(
+      size_t(1), static_cast<size_t>(corrFactor * jcMultiplicityInResult *
+                                     nofDistinctInResult));
+
+  AD_LOG_TRACE << "Estimated size as: " << sizeEstimate_ << " := " << corrFactor
+               << " * " << jcMultiplicityInResult << " * "
+               << nofDistinctInResult << std::endl;
+
+  for (auto i = ColumnIndex{0}; i < left_->getResultWidth(); ++i) {
+    double oldMult = left_->getMultiplicity(i);
+    double m = std::max(
+        1.0, oldMult * right_->getMultiplicity(rightJoinCol_) * corrFactor);
+    if (i != leftJoinCol_ && nofDistinctLeft != nofDistinctInResult) {
+      double oldDist = left_->getSizeEstimate() / oldMult;
+      double newDist = std::min(oldDist, adaptSizeLeft);
+      m = (sizeEstimate_ / corrFactor) / newDist;
+    }
+    if (i != leftJoinCol_ || keepJoinColumn_) {
+      multiplicities_.emplace_back(m);
+    }
+  }
+  for (auto i = ColumnIndex{0}; i < right_->getResultWidth(); ++i) {
+    if (i == rightJoinCol_) {
+      continue;
+    }
+    double oldMult = right_->getMultiplicity(i);
+    double m = std::max(
+        1.0, oldMult * left_->getMultiplicity(leftJoinCol_) * corrFactor);
+    if (i != rightJoinCol_ && nofDistinctRight != nofDistinctInResult) {
+      double oldDist = right_->getSizeEstimate() / oldMult;
+      double newDist = std::min(oldDist, adaptSizeRight);
+      m = (sizeEstimate_ / corrFactor) / newDist;
+    }
+    multiplicities_.emplace_back(m);
+  }
+  assert(multiplicities_.size() == getResultWidth());
+}
+
+
+// ___________________________________________________________________________
+template <typename ROW_A, typename ROW_B, int TABLE_WIDTH>
+void HashJoin::addCombinedRowToIdTable(const ROW_A& rowA, const ROW_B& rowB,
+                                   ColumnIndex jcRowA, ColumnIndex jcRowB,
+                                   bool keepJoinColumn,
+                                   IdTableStatic<TABLE_WIDTH>* table) {
+  // Add a new, empty row.
+  const size_t backIndex = table->size();
+  table->emplace_back();
+  ColumnIndex resultCol = 0;
+
+  // Copy the entire rowA in the table.
+  for (auto h = ColumnIndex{0}; h < rowA.numColumns(); h++) {
+    if (!keepJoinColumn && h == jcRowA) continue;
+    (*table)(backIndex, resultCol++) = rowA[h];
+  }
+  // Copy rowB except the join column.
+  for (auto h = ColumnIndex{0}; h < rowB.numColumns(); h++) {
+    if (h == jcRowB) continue;
+    (*table)(backIndex, resultCol++) = rowB[h];
+  }
+}
+
+// _____________________________________________________________________________
+Result HashJoin::createEmptyResult() const {
+  return {IdTable{getResultWidth(), allocator()}, resultSortedOn(),
+          LocalVocab{}};
+}
+
+// _____________________________________________________________________________
+ad_utility::JoinColumnMapping HashJoin::getJoinColumnMapping() const {
+  return ad_utility::JoinColumnMapping{{{leftJoinCol_, rightJoinCol_}},
+                                       left_->getResultWidth(),
+                                       right_->getResultWidth(),
+                                       keepJoinColumn_};
+}
+
+// _____________________________________________________________________________
+ad_utility::AddCombinedRowToIdTable HashJoin::makeRowAdder(
+    std::function<void(IdTable&, LocalVocab&)> callback) const {
+  return ad_utility::AddCombinedRowToIdTable{
+      1,
+      IdTable{getResultWidth(), allocator()},
+      cancellationHandle_,
+      keepJoinColumn_,
+      CHUNK_SIZE,
+      std::move(callback)};
+}
+
+// _____________________________________________________________________________
+std::unique_ptr<Operation> HashJoin::cloneImpl() const {
+  auto copy = std::make_unique<HashJoin>(*this);
+  copy->left_ = left_->clone();
+  copy->right_ = right_->clone();
+  return copy;
+}
+
+// _____________________________________________________________________________
+bool HashJoin::columnOriginatesFromGraphOrUndef(const Variable& variable) const {
+  AD_CONTRACT_CHECK(getExternallyVisibleVariableColumns().contains(variable));
+  // For the join column we don't union the elements, we intersect them so we
+  // can have a more efficient implementation.
+  if (variable == joinVar_) {
+    return doesJoinProduceGuaranteedGraphValuesOrUndef(left_, right_, variable);
+  }
+  return Operation::columnOriginatesFromGraphOrUndef(variable);
+}
+
+// _____________________________________________________________________________
+std::optional<std::shared_ptr<QueryExecutionTree>>
+HashJoin::makeTreeWithStrippedColumns(const std::set<Variable>& variables) const {
+  std::set<Variable> newVariables;
+  const auto* vars = &variables;
+  if (!ad_utility::contains(variables, joinVar_)) {
+    newVariables = variables;
+    newVariables.insert(joinVar_);
+    vars = &newVariables;
+  }
+
+  // TODO<joka921> Code duplication including a former copy-paste bug.
+  auto left = QueryExecutionTree::makeTreeWithStrippedColumns(left_, *vars);
+  auto right = QueryExecutionTree::makeTreeWithStrippedColumns(right_, *vars);
+  auto leftCol = left->getVariableColumn(joinVar_);
+  auto rightCol = right->getVariableColumn(joinVar_);
+  return ad_utility::makeExecutionTree<HashJoin>(
+      getExecutionContext(), std::move(left), std::move(right), leftCol,
+      rightCol, ad_utility::contains(variables, joinVar_));
+}
+
+// _____________________________________________________________________________
+std::optional<std::shared_ptr<QueryExecutionTree>> HashJoin::makeTreeWithBindColumn(
+    const parsedQuery::Bind& bind) const {
+  return pushDownBindToAnyChild(
+      bind, {left_, right_},
+      [this](std::vector<std::shared_ptr<QueryExecutionTree>> newChildren) {
+        auto& left = newChildren.at(0);
+        auto& right = newChildren.at(1);
+        auto leftCol = left->getVariableColumn(joinVar_);
+        auto rightCol = right->getVariableColumn(joinVar_);
+        return ad_utility::makeExecutionTree<HashJoin>(
+            getExecutionContext(), std::move(left), std::move(right), leftCol,
+            rightCol);
+      });
+}

--- a/src/engine/HashJoin.h
+++ b/src/engine/HashJoin.h
@@ -31,6 +31,9 @@ class HashJoin : public Operation {
   // If set to false, the join column will not be part of the result.
   bool keepJoinColumn_ = true;
 
+  // Offset for cost estimation to ensure a greater value than the Join Class
+  static constexpr size_t VETO_COST_OFFSET = 1;
+
  public:
   // `allowSwappingChildrenOnlyForTesting` should only ever be changed by tests.
   HashJoin(QueryExecutionContext* qec, std::shared_ptr<QueryExecutionTree> t1,
@@ -129,6 +132,25 @@ class HashJoin : public Operation {
   // Helper function to create the commonly used instance of this class.
   ad_utility::AddCombinedRowToIdTable makeRowAdder(
       std::function<void(IdTable&, LocalVocab&)> callback) const;
+
+  // Value to return, if hash join is not applicable and merge join is to be
+  // preferred by the Query Planner. This function returns a value that is
+  // greater than the cost of the Join Class, but doesn't exceed the maximum
+  // value of size_t, to avoid overflow issues.
+  size_t vetoCostEstimate();
+
+  // Uses hashMapFitsInMemory and biggerInputSortedOnJoinCol to check if hash
+  // join is applicable for given inputs.
+  bool hashJoinIsApplicable() const;
+
+  // estimates if smaller side of join inputs still fits into memory when
+  // building the hash map.
+  bool hashMapFitsInMemory() const;
+
+  // checks if the bigger input (probe side) is already sorted on the join
+  // column.
+  bool biggerInputSortedOnJoinCol() const;
+  bool eitherSideIsIndexScan() const;
 };
 
 #endif  // QLEVER_SRC_ENGINE_HASHJOIN_H

--- a/src/engine/HashJoin.h
+++ b/src/engine/HashJoin.h
@@ -1,0 +1,134 @@
+// Copyright 2026, University of Freiburg,
+// Chair of Algorithms and Data Structures.
+// Author: Mark Veser (veser@informatik.uni-freiburg.de)
+
+#ifndef QLEVER_SRC_ENGINE_HASHJOIN_H
+#define QLEVER_SRC_ENGINE_HASHJOIN_H
+
+#include "backports/concepts.h"
+#include "engine/AddCombinedRowToTable.h"
+#include "engine/IndexScan.h"
+#include "engine/Operation.h"
+#include "engine/QueryExecutionTree.h"
+#include "util/JoinAlgorithms/JoinColumnMapping.h"
+#include "util/TypeTraits.h"
+
+class HashJoin : public Operation {
+ private:
+  std::shared_ptr<QueryExecutionTree> left_;
+  std::shared_ptr<QueryExecutionTree> right_;
+
+  ColumnIndex leftJoinCol_;
+  ColumnIndex rightJoinCol_;
+
+  Variable joinVar_{"?notSet"};
+
+  bool sizeEstimateComputed_;
+  size_t sizeEstimate_;
+
+  std::vector<float> multiplicities_;
+
+  // If set to false, the join column will not be part of the result.
+  bool keepJoinColumn_ = true;
+
+ public:
+  // `allowSwappingChildrenOnlyForTesting` should only ever be changed by tests.
+  HashJoin(QueryExecutionContext* qec, std::shared_ptr<QueryExecutionTree> t1,
+       std::shared_ptr<QueryExecutionTree> t2, ColumnIndex t1JoinCol,
+       ColumnIndex t2JoinCol, bool keepJoinColumn = true,
+       bool allowSwappingChildrenOnlyForTesting = true);
+
+  using OptionalPermutation = std::optional<std::vector<ColumnIndex>>;
+
+  std::string getDescriptor() const override;
+
+  size_t getResultWidth() const override;
+
+  std::vector<ColumnIndex> resultSortedOn() const override;
+
+  size_t getCostEstimate() override;
+
+  bool knownEmptyResult() override {
+    return left_->knownEmptyResult() || right_->knownEmptyResult();
+  }
+
+  void computeSizeEstimateAndMultiplicities();
+
+  float getMultiplicity(size_t col) override;
+
+  std::vector<QueryExecutionTree*> getChildren() override {
+    return {left_.get(), right_.get()};
+  }
+
+  bool columnOriginatesFromGraphOrUndef(
+      const Variable& variable) const override;
+
+  /** 
+   * @brief Performs actual hashJoin operation.
+   * leftIsSmaller is necessary to decide which side is used for building
+   * the hash map. The left / right destinction is important for the correct
+   * order of the columns in the result.
+  **/
+  Result hashJoin(std::shared_ptr<const Result> left,
+                  std::shared_ptr<const Result> right,
+                  bool leftIsSmaller);
+
+ protected:
+  virtual std::string getCacheKeyImpl() const override;
+
+ private:
+  uint64_t getSizeEstimateBeforeLimit() override {
+    if (!sizeEstimateComputed_) {
+      computeSizeEstimateAndMultiplicities();
+      sizeEstimateComputed_ = true;
+    }
+    return sizeEstimate_;
+  }
+
+  std::unique_ptr<Operation> cloneImpl() const override;
+
+  Result computeResult(bool requestLaziness) override;
+
+  VariableToColumnMap computeVariableToColumnMap() const override;
+
+  std::optional<std::shared_ptr<QueryExecutionTree>>
+  makeTreeWithStrippedColumns(
+      const std::set<Variable>& variables) const override;
+
+  std::optional<std::shared_ptr<QueryExecutionTree>> makeTreeWithBindColumn(
+      const parsedQuery::Bind& bind) const override;
+
+  /*
+   * @brief Combines 2 rows like in a join and inserts the result in the
+   * given table.
+   *
+   *@tparam The amount of columns in the rows and the table.
+   *
+   * @param[in] The left row of the join.
+   * @param[in] The right row of the join.
+   * @param[in] The numerical position of the join column of row a.
+   * @param[in] The numerical position of the join column of row b.
+   * @param[in] The table, in which the new combined row should be inserted.
+   * Must be static.
+   */
+  template <typename ROW_A, typename ROW_B, int TABLE_WIDTH>
+  static void addCombinedRowToIdTable(const ROW_A& rowA, const ROW_B& rowB,
+                                      ColumnIndex jcRowA, ColumnIndex jcRowB,
+                                      bool keepJoinColumn,
+                                      IdTableStatic<TABLE_WIDTH>* table);
+
+  // Commonly used code for the various known-to-be-empty cases.
+  Result createEmptyResult() const;
+
+  // Get permutation of input and output columns to apply before and after
+  // joining. This is required because the join algorithms expect the join
+  // columns to be the first columns of the input tables and the result to be in
+  // the order of the input tables.
+  ad_utility::JoinColumnMapping getJoinColumnMapping() const;
+
+  // Helper function to create the commonly used instance of this class.
+  ad_utility::AddCombinedRowToIdTable makeRowAdder(
+      std::function<void(IdTable&, LocalVocab&)> callback) const;
+};
+
+#endif  // QLEVER_SRC_ENGINE_HASHJOIN_H

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -31,6 +31,7 @@
 #include "engine/HasPredicateScan.h"
 #include "engine/IndexScan.h"
 #include "engine/Join.h"
+#include "engine/HashJoin.h"
 #include "engine/Load.h"
 #include "engine/MaterializedViews.h"
 #include "engine/Minus.h"
@@ -2326,6 +2327,12 @@ std::vector<SubtreePlan> QueryPlanner::createJoinCandidates(
       makeSubtreePlan<Join>(_qec, a._qet, b._qet, jcs[0][0], jcs[0][1]);
   mergeSubtreePlanIds(plan, a, b);
   candidates.push_back(std::move(plan));
+
+  // "HashJoin" Case:
+  SubtreePlan hashJoinPlan =
+      makeSubtreePlan<HashJoin>(_qec, a._qet, b._qet, jcs[0][0], jcs[0][1]);
+  mergeSubtreePlanIds(hashJoinPlan, a, b);
+  candidates.push_back(std::move(hashJoinPlan));
 
   return candidates;
 }

--- a/test/JoinTest.cpp
+++ b/test/JoinTest.cpp
@@ -108,6 +108,7 @@ void runTestCasesForAllJoinAlgorithms(
   // over to helper functions.
   auto hashJoinLambda = makeHashJoinLambda();
   auto joinLambda = makeJoinLambda();
+  auto hashJoinLambdaNew = makeHashJoinLambdaNew();
 
   // For sorting IdTableAndJoinColumn by their join column.
   auto sortByJoinColumn = [](IdTableAndJoinColumn& idTableAndJC) {
@@ -126,6 +127,7 @@ void runTestCasesForAllJoinAlgorithms(
     testCase.resultMustBeSortedByJoinColumn = false;
   });
   goThroughSetOfTestsWithJoinFunction(testSet, hashJoinLambda);
+  goThroughSetOfTestsWithJoinFunction(testSet, hashJoinLambdaNew);
 
   // Sort the larger table by join column, run hashJoin, check result (this time
   // it's sorted).
@@ -139,6 +141,7 @@ void runTestCasesForAllJoinAlgorithms(
     testCase.resultMustBeSortedByJoinColumn = true;
   });
   goThroughSetOfTestsWithJoinFunction(testSet, hashJoinLambda);
+  goThroughSetOfTestsWithJoinFunction(testSet, hashJoinLambdaNew);
 
   // Sort both tables, run merge join and hash join, check result. (Which has to
   // be sorted.)
@@ -149,6 +152,7 @@ void runTestCasesForAllJoinAlgorithms(
   });
   goThroughSetOfTestsWithJoinFunction(testSet, joinLambda);
   goThroughSetOfTestsWithJoinFunction(testSet, hashJoinLambda);
+  goThroughSetOfTestsWithJoinFunction(testSet, hashJoinLambdaNew);
 }
 
 /*

--- a/test/util/JoinHelpers.h
+++ b/test/util/JoinHelpers.h
@@ -106,9 +106,9 @@ inline auto makeHashJoinLambdaNew() {
           rightVariables.resize(b.numColumns());
           auto* qec = ad_utility::testing::getQec();
           auto leftTree = ad_utility::makeExecutionTree<ValuesForTesting>(
-              qec, a.clone(), std::move(leftVariables), false, std::vector{jc1});
+              qec, a.clone(), std::move(leftVariables), false, std::vector<ColumnIndex>{});
           auto rightTree = ad_utility::makeExecutionTree<ValuesForTesting>(
-              qec, b.clone(), std::move(rightVariables), false, std::vector{jc2});
+              qec, b.clone(), std::move(rightVariables), false, std::vector<ColumnIndex>{});
           HashJoin hashJoin{qec, leftTree, rightTree, jc1, jc2, true, false};
           auto joinResult = hashJoin.hashJoin(leftTree->getResult(), rightTree->getResult(), leftIsSmaller);
           *result = joinResult.idTable().clone();

--- a/test/util/JoinHelpers.h
+++ b/test/util/JoinHelpers.h
@@ -13,6 +13,7 @@
 #include "IndexTestHelpers.h"
 #include "engine/CallFixedSize.h"
 #include "engine/Join.h"
+#include "engine/HashJoin.h"
 #include "engine/idTable/IdTable.h"
 #include "index/IdTableUtils.h"
 #include "util/Forward.h"
@@ -86,6 +87,32 @@ inline auto makeJoinLambda() {
         Join join{qec, leftTree, rightTree, jc1, jc2, true, false};
         return join.join(a, b, result);
       }};
+}
+
+/*
+* @brief Returns a lambda for calling 'HashJoin::hashJoin' via
+*  `ad_utility::callFixedSize`.
+*/
+inline auto makeHashJoinLambdaNew() {
+  return ad_utility::ApplyAsValueIdentity{
+      [](auto /*valueIdentityA*/, auto /*valueIdentityB*/,
+         auto /*valueIdentityC*/,
+         const IdTable& a, ColumnIndex jc1, const IdTable& b, ColumnIndex jc2,
+         IdTable* result) {
+            bool leftIsSmaller = a.numRows() <= b.numRows();
+          std::vector<std::optional<Variable>> leftVariables{{Variable{"?x"}}};
+          leftVariables.resize(a.numColumns());
+          std::vector<std::optional<Variable>> rightVariables{{Variable{"?x"}}};
+          rightVariables.resize(b.numColumns());
+          auto* qec = ad_utility::testing::getQec();
+          auto leftTree = ad_utility::makeExecutionTree<ValuesForTesting>(
+              qec, a.clone(), std::move(leftVariables), false, std::vector{jc1});
+          auto rightTree = ad_utility::makeExecutionTree<ValuesForTesting>(
+              qec, b.clone(), std::move(rightVariables), false, std::vector{jc2});
+          HashJoin hashJoin{qec, leftTree, rightTree, jc1, jc2, true, false};
+          auto joinResult = hashJoin.hashJoin(leftTree->getResult(), rightTree->getResult(), leftIsSmaller);
+          *result = joinResult.idTable().clone();
+         }};
 }
 
 #endif  // QLEVER_TEST_UTIL_JOINHELPERS_H


### PR DESCRIPTION
First version of a standalone `HashJoin` class, created as part of my bachelor's project supervised by @joka921.

The hash join is used when one input is small enough that the hash map still fits into memory, and the other input is not sorted on the join column.

## Status
- New `HashJoin` class
- Rudimentary cost function that determines when the `QueryPlanner` selects `HashJoin`
- `HashJoin` is covered by the existing `JoinTest` via `runTestCasesForAllJoinAlgorithms()`

## For discussion
- A lot of code is currently copied from the `Join` class — how should we factor out the shared parts?

## Open
- Cost function: the hash map size estimation is incorrect and needs rework
- Cost function: the `IndexScan` exclusion is not correct yet
- Add dedicated `HashJoin` tests
- Write the hash map to disk when RAM is exceeded (external hash join)
- Result is currently not sorted