### PR TITLE
Don't propagate limit and offset through explicit `INTERNAL SORT BY`

### DIFF
--- a/src/engine/QueryExecutionTree.cpp
+++ b/src/engine/QueryExecutionTree.cpp
@@ -179,7 +179,7 @@ QueryExecutionTree::createSortedTreeAnyPermutation(
 // ________________________________________________________________________________________________________________
 std::shared_ptr<QueryExecutionTree> QueryExecutionTree::createSortedTree(
     std::shared_ptr<QueryExecutionTree> qet,
-    const std::vector<ColumnIndex>& sortColumns) {
+    const std::vector<ColumnIndex>& sortColumns, bool explicitSort) {
   const auto& rootOperation = qet->getRootOperation();
   if (rootOperation->isSortedBy(sortColumns)) {
     return qet;
@@ -196,7 +196,8 @@ std::shared_ptr<QueryExecutionTree> QueryExecutionTree::createSortedTree(
   }
 
   return ad_utility::makeExecutionTree<Sort>(
-      rootOperation->getExecutionContext(), std::move(qet), sortColumns);
+      rootOperation->getExecutionContext(), std::move(qet), sortColumns,
+      explicitSort);
 }
 
 // _____________________________________________________________________________

--- a/src/engine/QueryExecutionTree.h
+++ b/src/engine/QueryExecutionTree.h
@@ -173,10 +173,14 @@ class QueryExecutionTree {
 
   // Create a `QueryExecutionTree` that produces exactly the same result as
   // `qet`, but sorted according to the `sortColumns`. If `qet` is already
-  // sorted accordingly, it is simply returned.
+  // sorted accordingly, it is simply returned. If `explicitSort` is `true` and
+  // a `Sort` operation has to be created, that `Sort` will not propagate a
+  // `LIMIT`/`OFFSET` to its subtree. This is used for explicit `INTERNAL SORT
+  // BY` clauses, where the complete sorted result is requested and the
+  // limit-pushdown optimization is undesired.
   static std::shared_ptr<QueryExecutionTree> createSortedTree(
       std::shared_ptr<QueryExecutionTree> qet,
-      const std::vector<ColumnIndex>& sortColumns);
+      const std::vector<ColumnIndex>& sortColumns, bool explicitSort = false);
 
   // Similar to `createSortedTree` (see directly above), but create the sorted
   // trees for two different trees, the sort columns of which are specified as

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -476,7 +476,10 @@ std::vector<SubtreePlan> QueryPlanner::getOrderByRow(
         AD_CONTRACT_CHECK(!isDescending);
         sortColumns.push_back(index);
       }
-      tree = QueryExecutionTree::createSortedTree(parent._qet, sortColumns);
+      // An explicit `INTERNAL SORT BY` requests the complete sorted result, so
+      // we must not let the `Sort` propagate a `LIMIT`/`OFFSET` to its subtree.
+      tree =
+          QueryExecutionTree::createSortedTree(parent._qet, sortColumns, true);
     } else {
       AD_CONTRACT_CHECK(pq._isInternalSort == IsInternalSort::False);
       // Note: As the internal ordering is different from the semantic ordering

--- a/src/engine/Sort.cpp
+++ b/src/engine/Sort.cpp
@@ -34,10 +34,11 @@ size_t Sort::getResultWidth() const { return subtree_->getResultWidth(); }
 // _____________________________________________________________________________
 Sort::Sort(QueryExecutionContext* qec,
            std::shared_ptr<QueryExecutionTree> subtree,
-           std::vector<ColumnIndex> sortColumnIndices)
+           std::vector<ColumnIndex> sortColumnIndices, bool explicitSort)
     : Operation{qec},
       subtree_{std::move(subtree)},
-      sortColumnIndices_{std::move(sortColumnIndices)} {}
+      sortColumnIndices_{std::move(sortColumnIndices)},
+      explicitSort_{explicitSort} {}
 
 // _____________________________________________________________________________
 std::string Sort::getCacheKeyImpl() const {
@@ -68,6 +69,12 @@ std::string Sort::getDescriptor() const {
 
 // _____________________________________________________________________________
 void Sort::onLimitOffsetChanged(const LimitOffsetClause& limitOffset) {
+  // For an explicit `INTERNAL SORT BY` we deliberately keep the complete sorted
+  // result and let the `LIMIT`/`OFFSET` be applied externally (see
+  // `handlesLimitOffset()`), so we must not push it down to the subtree.
+  if (explicitSort_) {
+    return;
+  }
   subtree_ = subtree_->clone();
   subtree_->applyLimitOffset(limitOffset);
 }
@@ -249,13 +256,13 @@ std::optional<std::shared_ptr<QueryExecutionTree>> Sort::makeSortedTree(
          "different sort order. This indicates a flaw during query planning."
       << std::endl;
   return ad_utility::makeExecutionTree<Sort>(_executionContext, subtree_,
-                                             sortColumns);
+                                             sortColumns, explicitSort_);
 }
 
 // _____________________________________________________________________________
 std::unique_ptr<Operation> Sort::cloneImpl() const {
   return std::make_unique<Sort>(_executionContext, subtree_->clone(),
-                                sortColumnIndices_);
+                                sortColumnIndices_, explicitSort_);
 }
 
 // _____________________________________________________________________________
@@ -284,6 +291,7 @@ Sort::makeTreeWithStrippedColumns(const std::set<Variable>& variables) const {
     sortColumnIndices.push_back(subtree->getVariableColumn(var));
   }
 
-  return ad_utility::makeExecutionTree<Sort>(
-      getExecutionContext(), std::move(subtree), sortColumnIndices);
+  return ad_utility::makeExecutionTree<Sort>(getExecutionContext(),
+                                             std::move(subtree),
+                                             sortColumnIndices, explicitSort_);
 }

--- a/src/engine/Sort.h
+++ b/src/engine/Sort.h
@@ -29,10 +29,15 @@ class Sort : public Operation {
  private:
   std::shared_ptr<QueryExecutionTree> subtree_;
   std::vector<ColumnIndex> sortColumnIndices_;
+  // If `true`, this `Sort` was created from an explicit `INTERNAL SORT BY`
+  // clause. In that case we deliberately do not propagate a `LIMIT`/`OFFSET`
+  // to the subtree, because the user explicitly asked for the complete sorted
+  // result (see `handlesLimitOffset()`).
+  bool explicitSort_;
 
  public:
   Sort(QueryExecutionContext* qec, std::shared_ptr<QueryExecutionTree> subtree,
-       std::vector<ColumnIndex> sortColumnIndices);
+       std::vector<ColumnIndex> sortColumnIndices, bool explicitSort = false);
 
  public:
   virtual std::string getDescriptor() const override;
@@ -72,9 +77,14 @@ class Sort : public Operation {
   // For a `Sort` with `LIMIT N`, any N rows are fine as long as they are
   // sorted: there is no user-defined order that the `LIMIT` is taken against
   // (user-facing `ORDER BY` goes through `OrderBy`, not `Sort`). So we can
-  // let the subtree compute only N rows and sort those.
+  // let the subtree compute only N rows and sort those. The exception is an
+  // explicit `INTERNAL SORT BY`: there the user explicitly requested the
+  // complete sorted result, so we do not handle (and hence do not propagate)
+  // the `LIMIT`/`OFFSET` here, but let it be applied externally on the full
+  // sorted output.
   LimitOffsetHandling handlesLimitOffset() const override {
-    return LimitOffsetHandling::FULL;
+    return explicitSort_ ? LimitOffsetHandling::NONE
+                         : LimitOffsetHandling::FULL;
   }
 
   [[nodiscard]] size_t getResultWidth() const override;

--- a/test/SortTest.cpp
+++ b/test/SortTest.cpp
@@ -443,3 +443,28 @@ TEST(Sort, limitOffsetIsPropagated) {
   // We expect that the original subtree is unchanged.
   EXPECT_TRUE(subtree->getRootOperation()->getLimitOffset().isUnconstrained());
 }
+
+// _____________________________________________________________________________
+TEST(Sort, limitOffsetIsNotPropagatedForExplicitSort) {
+  auto qec = ad_utility::testing::getQec();
+  auto inputTable = makeIdTableFromVector({{1}, {2}, {3}});
+
+  std::vector<std::optional<Variable>> vars = {Variable{"?x"}};
+  auto subtree = ad_utility::makeExecutionTree<ValuesForTesting>(
+      qec, std::move(inputTable), vars);
+
+  auto tree = QueryExecutionTree::createSortedTree(subtree, {0}, true);
+  auto sort = std::dynamic_pointer_cast<Sort>(tree->getRootOperation());
+  ASSERT_NE(sort, nullptr);
+  EXPECT_EQ(sort->handlesLimitOffset(), LimitOffsetHandling::NONE);
+
+  sort->applyLimitOffset({2, 1});
+
+  EXPECT_EQ(sort->getLimitOffset(), LimitOffsetClause(2, 1));
+  EXPECT_TRUE(sort->getChildren()
+                  .at(0)
+                  ->getRootOperation()
+                  ->getLimitOffset()
+                  .isUnconstrained());
+  EXPECT_TRUE(subtree->getRootOperation()->getLimitOffset().isUnconstrained());
+}


### PR DESCRIPTION
Since #2797, limit and offset are propagated through a `Sort` operation. This optimization can speed up query times, but is not consistent in the sense that the `N`-th result row of a query without limit and offset is not the same as the result of the query with `OFFSET N-1 LIMIT 1` appended. This kind of consistency is not required by the standard, but assumed by some applications, including https://github.com/ad-freiburg/qlever-petrimaps.

Now the optimization is deactivated for `Sort` operations created from an explicit `INTERNAL SORT BY` in the query. Note that `INTERNAL SORT BY` is an extension of the SPARQL standard.