### PR TITLE
Drop accidental array wrap from SPARQL update response

### DIFF
--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -1255,11 +1255,11 @@ CPP_template_def(typename RequestT, typename ResponseT)(
                 tracer.endTrace("execution");
 
                 tracer.endTrace("update");
-                results.push_back(json{createResponseMetadataForUpdate(
+                results.push_back(createResponseMetadataForUpdate(
                     index(),
                     *deltaTriples.getLocatedTriplesSharedStateReference(),
                     *plannedUpdate, plannedUpdate->queryExecutionTree(),
-                    updateMetadata, tracer)});
+                    updateMetadata, tracer));
                 metadatas.push_back(std::move(updateMetadata));
 
                 AD_LOG_INFO << "Done processing update, total time was "


### PR DESCRIPTION
The recently merged #2883 (compile-time improvements) inadvertently changed `results.push_back(X)` to `results.push_back(json{X})` in the SPARQL update response. Since `nlohmann::json{x}` is the brace-init-list constructor and builds `[x]` rather than `x`, each per-operation entry ended up wrapped in a redundant single-element JSON array, breaking clients that read `operations[i]["delta-triples"][...]`. In particular, the statistics extraction in `qlever update-wikidata` raised `TypeError: list indices must be integers or slices, not str` on every update. The wrap is now removed, restoring the old response shape.