### PR TITLE
Fix `cmake` compiler flags for `ninja` with `clang`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,13 +115,16 @@ set(CMAKE_CXX_FLAGS_ASAN
         CACHE STRING "Flags used by the C++ compiler during AddressSanitizer builds."
         FORCE)
 
-# Add colored output for Ninja
+# Add colored output for Ninja. Use per-language compiler-ID generator expressions so that
+# flags are only passed to the compiler that actually supports them (e.g. uriparser can be
+# compiled by /usr/bin/cc even when the main build uses Clang).
 if ("${CMAKE_GENERATOR}" STREQUAL "Ninja")
-    if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-        add_compile_options(-fdiagnostics-color=always)
-    elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
-        add_compile_options(-fcolor-diagnostics)
-    endif ()
+    add_compile_options(
+        $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CXX_COMPILER_ID:GNU>>:-fdiagnostics-color=always>
+        $<$<AND:$<COMPILE_LANGUAGE:C>,$<C_COMPILER_ID:GNU>>:-fdiagnostics-color=always>
+        $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CXX_COMPILER_ID:Clang,AppleClang>>:-fcolor-diagnostics>
+        $<$<AND:$<COMPILE_LANGUAGE:C>,$<C_COMPILER_ID:Clang,AppleClang>>:-fcolor-diagnostics>
+    )
 endif ()
 
 # Enable the manual usage of the C++ 17 backports (currently `range-v3` instead


### PR DESCRIPTION
PR #2780 added a new dependency on `uriparser`. This C library is compiled with GCC even when the main build uses Clang, which caused `-fcolor-diagnostics` (added by the Ninja colour-output block) to be passed to `cc` and fail. The fix uses per-language compiler-ID generator expressions so the colour-diagnostic flag is only emitted for translation units whose actual compiler supports it.