### PR TITLE
Fix `use-after-stack-return` in cheap compilation mode

### DIFF
--- a/src/engine/sparqlExpressions/NaryExpressionImpl.h
+++ b/src/engine/sparqlExpressions/NaryExpressionImpl.h
@@ -280,7 +280,12 @@ struct TypeErasedNaryHelper;
 
 template <typename Func, typename... VGs>
 struct TypeErasedNaryHelper<Func, std::tuple<VGs...>> {
-  using Res = std::invoke_result_t<Func, typename VGs::Value...>;
+  // `std::decay_t` ensures a value type, not a reference. Without it,
+  // `ql::identity` would yield `T&&` via `invoke_result_t`, producing
+  // `std::function<T&&(T)>` which returns a dangling reference to its own
+  // by-value parameter (stack-use-after-return). The strongly-typed path
+  // handles the same issue in `applyFunction`.
+  using Res = std::decay_t<std::invoke_result_t<Func, typename VGs::Value...>>;
   using BaseType = NaryExpressionTypeErasedImpl<Res, typename VGs::Value...>;
   static auto makeGetters() {
     return typename BaseType::Getters{TypeErasedValueGetter<VGs>{}...};

--- a/src/engine/sparqlExpressions/NaryExpressionImpl.h
+++ b/src/engine/sparqlExpressions/NaryExpressionImpl.h
@@ -280,11 +280,10 @@ struct TypeErasedNaryHelper;
 
 template <typename Func, typename... VGs>
 struct TypeErasedNaryHelper<Func, std::tuple<VGs...>> {
-  // `std::decay_t` ensures a value type, not a reference. Without it,
-  // `ql::identity` would yield `T&&` via `invoke_result_t`, producing
-  // `std::function<T&&(T)>` which returns a dangling reference to its own
-  // by-value parameter (stack-use-after-return). The strongly-typed path
-  // handles the same issue in `applyFunction`.
+  // `std::decay_t` ensures a value type, not a reference. Without this,
+  // expressions that use `ql:identity` as their functor, because the
+  // `ValueGetter`s do all the work would lead to dangling stack references.
+  // The strongly-typed path handles the same issue in `applyFunction`.
   using Res = std::decay_t<std::invoke_result_t<Func, typename VGs::Value...>>;
   using BaseType = NaryExpressionTypeErasedImpl<Res, typename VGs::Value...>;
   static auto makeGetters() {


### PR DESCRIPTION
This fixes a regression introduced in #2735, which was caught by ASAN. One-line code change; the comment above it explains it.