### PR TITLE
Remove `static` keyword from free functions in headers

### DIFF
--- a/benchmark/infrastructure/BenchmarkMeasurementContainer.h
+++ b/benchmark/infrastructure/BenchmarkMeasurementContainer.h
@@ -34,10 +34,10 @@ namespace ad_benchmark {
 */
 CPP_template(typename Function)(requires(
     ql::concepts::invocable<
-        Function>)) static float measureTimeOfFunction(const Function&
-                                                           functionToMeasure,
-                                                       std::string_view
-                                                           measurementSubjectIdentifier) {
+        Function>)) float measureTimeOfFunction(const Function&
+                                                    functionToMeasure,
+                                                std::string_view
+                                                    measurementSubjectIdentifier) {
   AD_LOG_INFO << "Running measurement \"" << measurementSubjectIdentifier
               << "\" ..." << std::endl;
 

--- a/src/engine/idTable/IdTableConcepts.h
+++ b/src/engine/idTable/IdTableConcepts.h
@@ -31,7 +31,7 @@ CPP_requires(HasGetLocalVocab, requires(T& table)(table.getLocalVocab()));
 // Unwrap type `T` to get an `IdTableView<0>`, even if it's not an
 // `IdTableView<0>`. Identity for `IdTableView<0>`.
 template <typename T>
-static IdTableView<0> toView(const T& table) {
+IdTableView<0> toView(const T& table) {
   if constexpr (CPP_requires_ref(concepts::HasAsStaticView, T)) {
     return table.template asStaticView<0>();
   } else {
@@ -42,8 +42,8 @@ static IdTableView<0> toView(const T& table) {
 // Merge the local vocab contained in `T` with the `targetVocab` and set the
 // passed pointer reference to that vocab.
 template <typename T>
-static void mergeVocabInto(const T& table, const LocalVocab*& currentVocab,
-                           LocalVocab& targetVocab) {
+void mergeVocabInto(const T& table, const LocalVocab*& currentVocab,
+                    LocalVocab& targetVocab) {
   AD_CORRECTNESS_CHECK(currentVocab == nullptr);
   if constexpr (CPP_requires_ref(detail::concepts::HasGetLocalVocab, T)) {
     currentVocab = &table.getLocalVocab();

--- a/src/global/SpecialIds.h
+++ b/src/global/SpecialIds.h
@@ -51,7 +51,7 @@ inline const ad_utility::HashMap<std::string, Id>& specialIds() {
 // Return the [lowerBound, upperBound) for the special Ids.
 // This range can be used to filter them out in cases where we want to ignore
 // triples that were added by QLever for internal reasons.
-static constexpr std::pair<Id, Id> getBoundsForSpecialIds() {
+constexpr std::pair<Id, Id> getBoundsForSpecialIds() {
   constexpr auto upperBound = Id::makeFromBool(false);
   static_assert(static_cast<int>(Datatype::Undefined) == 0);
   static_assert(upperBound.getBits() == 1UL << Id::numDataBits);

--- a/src/util/BatchedPipeline.h
+++ b/src/util/BatchedPipeline.h
@@ -661,8 +661,8 @@ auto setupPipeline(size_t batchSize, Creator&& creator, Ts&&... transformers) {
  * signalizes the last value.
  */
 template <size_t... Parallelisms, typename Creator, typename... Ts>
-static auto setupParallelPipeline(size_t batchSize, Creator&& creator,
-                                  Ts&&... transformers) {
+auto setupParallelPipeline(size_t batchSize, Creator&& creator,
+                           Ts&&... transformers) {
   return detail::Interface::setupParallelPipeline<Parallelisms...>(
       batchSize, std::forward<Creator>(creator),
       std::forward<Ts>(transformers)...);

--- a/src/util/CtreHelpers.h
+++ b/src/util/CtreHelpers.h
@@ -41,13 +41,13 @@ constexpr ctll::fixed_string<A + B - 1> operator+(
 
 /// Create a regex group by putting the argument in parentheses
 template <size_t N>
-static constexpr auto grp(const ctll::fixed_string<N>& s) {
+constexpr auto grp(const ctll::fixed_string<N>& s) {
   return ctll::fixed_string("(") + s + ctll::fixed_string(")");
 }
 
 /// Create a regex character class by putting the argument in square brackets
 template <size_t N>
-static constexpr auto cls(const ctll::fixed_string<N>& s) {
+constexpr auto cls(const ctll::fixed_string<N>& s) {
   return ctll::fixed_string("[") + s + ctll::fixed_string("]");
 }
 

--- a/src/util/MemorySize/MemorySize.h
+++ b/src/util/MemorySize/MemorySize.h
@@ -193,8 +193,7 @@ Needed, because there is no `std` division function, that takes unconverted
 however, should be about as precise as possible, when having the return type
 `double`.
 */
-constexpr static double sizeTDivision(const size_t dividend,
-                                      const size_t divisor) {
+constexpr double sizeTDivision(const size_t dividend, const size_t divisor) {
   size_t quotient = dividend / divisor;
   return static_cast<double>(quotient) +
          static_cast<double>(dividend % divisor) / static_cast<double>(divisor);

--- a/src/util/http/HttpUtils.h
+++ b/src/util/http/HttpUtils.h
@@ -101,11 +101,11 @@ using ResponseT = http::response<streamable_body>;
 // compression is specified in the request, this method is applied to the
 // body and the corresponding response headers are set.
 CPP_template(typename RequestType)(
-    requires HttpRequest<
-        RequestType>) static void setBody(ResponseT& response,
-                                          const RequestType& request,
-                                          cppcoro::generator<std::string>&&
-                                              generator) {
+    requires HttpRequest<RequestType>) void setBody(ResponseT& response,
+                                                    const RequestType& request,
+                                                    cppcoro::generator<
+                                                        std::string>&&
+                                                        generator) {
   using ad_utility::content_encoding::CompressionMethod;
 
   CompressionMethod method =
@@ -211,9 +211,9 @@ CPP_template(typename RequestType)(
 // the same as createHttpResponseFromString.
 CPP_template(typename RequestType)(
     requires HttpRequest<
-        RequestType>) static auto createOkResponse(std::string text,
-                                                   const RequestType& request,
-                                                   MediaType mediaType) {
+        RequestType>) auto createOkResponse(std::string text,
+                                            const RequestType& request,
+                                            MediaType mediaType) {
   return createHttpResponseFromString(std::move(text), http::status::ok,
                                       request, mediaType);
 }
@@ -221,11 +221,10 @@ CPP_template(typename RequestType)(
 // Create a HttpResponse from a generator with status 200 OK.
 CPP_template(typename RequestType)(
     requires HttpRequest<
-        RequestType>) static auto createOkResponse(cppcoro::
-                                                       generator<std::string>&&
-                                                           generator,
-                                                   const RequestType& request,
-                                                   MediaType mediaType) {
+        RequestType>) auto createOkResponse(cppcoro::generator<std::string>&&
+                                                generator,
+                                            const RequestType& request,
+                                            MediaType mediaType) {
   return createHttpResponseFromGenerator(std::move(generator), http::status::ok,
                                          request, mediaType, true);
 }
@@ -233,8 +232,8 @@ CPP_template(typename RequestType)(
 // Create a HttpResponse from a string with status 200 OK and mime type
 // "application/json". Otherwise behaves the same as
 // createHttpResponseFromString.
-static auto createJsonResponse(std::string text, const auto& request,
-                               http::status status = http::status::ok) {
+auto createJsonResponse(std::string text, const auto& request,
+                        http::status status = http::status::ok) {
   return createHttpResponseFromString(std::move(text), status, request,
                                       MediaType::json);
 }
@@ -244,12 +243,9 @@ CPP_concept IsJson = SameAsAny<T, nlohmann::json, nlohmann::ordered_json>;
 
 // Create a HttpResponse from a json object with status 200 OK and mime type
 // "application/json".
-CPP_template(typename Json)(
-    requires IsJson<
-        Json>) static auto createJsonResponse(const Json& j,
-                                              const auto& request,
-                                              http::status status =
-                                                  http::status::ok) {
+CPP_template(typename Json)(requires IsJson<Json>) auto createJsonResponse(
+    const Json& j, const auto& request,
+    http::status status = http::status::ok) {
   // Argument `4` leads to a human-readable indentation.
   return createJsonResponse(j.dump(4), request, status);
 }
@@ -257,13 +253,11 @@ CPP_template(typename Json)(
 // Create a HttpResponse with an empty body.
 CPP_template(typename RequestType)(
     requires HttpRequest<
-        RequestType>) static auto createResponseWithEmptyBody(http::status
-                                                                  status,
-                                                              const RequestType&
-                                                                  request,
-                                                              std::optional<
-                                                                  MediaType>
-                                                                  mediaType) {
+        RequestType>) auto createResponseWithEmptyBody(http::status status,
+                                                       const RequestType&
+                                                           request,
+                                                       std::optional<MediaType>
+                                                           mediaType) {
   // `prepare_payload` throws an error if it cannot guarantee that the response
   // body is empty. The size is unknown for `streamable_body`. So don't
   // call it.
@@ -275,10 +269,8 @@ CPP_template(typename RequestType)(
 // Create a HttpResponse with status 404 Not Found.
 CPP_template(typename RequestType)(
     requires HttpRequest<
-        RequestType>) static auto createNotFoundResponse(const std::string&
-                                                             errorMsg,
-                                                         const RequestType&
-                                                             request) {
+        RequestType>) auto createNotFoundResponse(const std::string& errorMsg,
+                                                  const RequestType& request) {
   return createHttpResponseFromString(errorMsg, http::status::not_found,
                                       request, MediaType::textPlain);
 }
@@ -286,10 +278,8 @@ CPP_template(typename RequestType)(
 // Create a HttpResponse with status 403 Forbidden.
 CPP_template(typename RequestType)(
     requires HttpRequest<
-        RequestType>) static auto createForbiddenResponse(const std::string&
-                                                              errorMsg,
-                                                          const RequestType&
-                                                              request) {
+        RequestType>) auto createForbiddenResponse(const std::string& errorMsg,
+                                                   const RequestType& request) {
   return createHttpResponseFromString(errorMsg, http::status::forbidden,
                                       request, MediaType::textPlain);
 }
@@ -297,9 +287,9 @@ CPP_template(typename RequestType)(
 // Create a HttpResponse with status 400 Bad Request.
 CPP_template(typename RequestType)(
     requires HttpRequest<
-        RequestType>) static auto createBadRequestResponse(std::string body,
-                                                           const RequestType&
-                                                               request) {
+        RequestType>) auto createBadRequestResponse(std::string body,
+                                                    const RequestType&
+                                                        request) {
   return createHttpResponseFromString(std::move(body),
                                       http::status::bad_request, request,
                                       MediaType::textPlain);

--- a/test/util/BenchmarkMeasurementContainerHelpers.h
+++ b/test/util/BenchmarkMeasurementContainerHelpers.h
@@ -34,7 +34,7 @@ parameter.
 arguments. Should be passed per deduction.
 */
 template <typename Function>
-static void doForTypeInResultTableEntryType(Function function) {
+void doForTypeInResultTableEntryType(Function function) {
   ad_utility::forEachTypeInTemplateTypeWithTI(
       ad_utility::use_type_identity::ti<ad_benchmark::ResultTable::EntryType>,
       [&function](auto t) {

--- a/test/util/ConfigOptionHelpers.h
+++ b/test/util/ConfigOptionHelpers.h
@@ -17,7 +17,7 @@
 arguments. Should be passed per deduction.
 */
 template <typename Function>
-static void doForTypeInConfigOptionValueType(Function function) {
+void doForTypeInConfigOptionValueType(Function function) {
   ad_utility::forEachTypeInTemplateType<
       ad_utility::ConfigOption::AvailableTypes>(function);
 }

--- a/test/util/IdTableHelpers.h
+++ b/test/util/IdTableHelpers.h
@@ -58,7 +58,7 @@ using VectorTable = std::vector<std::vector<IntOrId>>;
 
 // Helper: construct a single-column VectorTable containing the exclusive
 // integer range [a, b). If a >= b, returns an empty table.
-static inline VectorTable makeRangeVectorTable(size_t a, size_t b) {
+inline VectorTable makeRangeVectorTable(size_t a, size_t b) {
   VectorTable vt;
   if (a >= b) return vt;
   for (size_t i = a; i < b; ++i) {


### PR DESCRIPTION
Using `static` on free functions in headers is an anti-pattern: it forces internal linkage, so the compiler emits a separate copy of the function in every translation unit that includes the header. All affected functions are either templates or `constexpr` (implicitly inline at namespace scope), so the change is purely a clean-up.