### PR TITLE
Replace `const IdTable&` by `IdTableView<0>` in several operations

### DIFF
--- a/src/engine/Bind.cpp
+++ b/src/engine/Bind.cpp
@@ -159,7 +159,7 @@ Result Bind::computeResult(bool requestLaziness) {
     // via`shared_ptr`s, so the following is also efficient if the BIND adds no
     // new words.
     LocalVocab localVocab = subRes->getCopyOfLocalVocab();
-    IdTable result = applyBind(IdTable{subRes->idTable().clone()}, &localVocab);
+    IdTable result = applyBind(subRes->cloneIdTable(), &localVocab);
     AD_LOG_DEBUG << "BIND result computation done." << std::endl;
     return {std::move(result), resultSortedOn(), std::move(localVocab)};
   }

--- a/src/engine/Bind.cpp
+++ b/src/engine/Bind.cpp
@@ -112,7 +112,7 @@ std::vector<QueryExecutionTree*> Bind::getChildren() {
 }
 
 // _____________________________________________________________________________
-IdTable Bind::cloneSubView(const IdTable& idTable,
+IdTable Bind::cloneSubView(const IdTableView<0>& idTable,
                            const std::pair<size_t, size_t>& subrange) {
   IdTable result(idTable.numColumns(), idTable.getAllocator());
   result.resize(subrange.second - subrange.first);
@@ -145,7 +145,7 @@ Result Bind::computeResult(bool requestLaziness) {
         auto start = chunk.front();
         auto end = start + ::ranges::size(chunk);
         IdTable idTable = applyBind(
-            Bind::cloneSubView(subRes->idTable(), {start, end}), &outVocab);
+            Bind::cloneSubView(subRes->idTableView(), {start, end}), &outVocab);
 
         return Result::IdTableVocabPair{std::move(idTable),
                                         std::move(outVocab)};
@@ -159,7 +159,7 @@ Result Bind::computeResult(bool requestLaziness) {
     // via`shared_ptr`s, so the following is also efficient if the BIND adds no
     // new words.
     LocalVocab localVocab = subRes->getCopyOfLocalVocab();
-    IdTable result = applyBind(subRes->idTable().clone(), &localVocab);
+    IdTable result = applyBind(IdTable{subRes->idTable().clone()}, &localVocab);
     AD_LOG_DEBUG << "BIND result computation done." << std::endl;
     return {std::move(result), resultSortedOn(), std::move(localVocab)};
   }
@@ -185,9 +185,9 @@ IdTable Bind::computeExpressionBind(
     LocalVocab* localVocab, IdTable idTable,
     const sparqlExpression::SparqlExpression* expression) const {
   sparqlExpression::EvaluationContext evaluationContext(
-      *getExecutionContext(), _subtree->getVariableColumns(), idTable,
-      getExecutionContext()->getAllocator(), *localVocab, cancellationHandle_,
-      deadline_);
+      *getExecutionContext(), _subtree->getVariableColumns(),
+      idTable.asStaticView<0>(), getExecutionContext()->getAllocator(),
+      *localVocab, cancellationHandle_, deadline_);
 
   sparqlExpression::ExpressionResult expressionResult =
       expression->evaluate(&evaluationContext);

--- a/src/engine/Bind.h
+++ b/src/engine/Bind.h
@@ -50,7 +50,7 @@ class Bind : public Operation {
  private:
   Result computeResult(bool requestLaziness) override;
 
-  static IdTable cloneSubView(const IdTable& idTable,
+  static IdTable cloneSubView(const IdTableView<0>& idTable,
                               const std::pair<size_t, size_t>& subrange);
 
   // Implementation for the binding of arbitrary expressions.

--- a/src/engine/CountAvailablePredicates.cpp
+++ b/src/engine/CountAvailablePredicates.cpp
@@ -146,7 +146,7 @@ Result CountAvailablePredicates::computeResult(
     size_t width = subresult->idTable().numColumns();
     size_t patternColumn = subtree_->getVariableColumn(predicateVariable_);
     ad_utility::callFixedSizeVi(width, [&](auto width) {
-      return computePatternTrick<width>(subresult->idTable(), &idTable,
+      return computePatternTrick<width>(subresult->idTableView(), &idTable,
                                         patterns, subjectColumnIndex_,
                                         patternColumn, runtimeInfo());
     });
@@ -218,7 +218,7 @@ class MergeableHashMap : public ad_utility::HashMap<T, size_t> {
 // _____________________________________________________________________________
 template <size_t WIDTH>
 void CountAvailablePredicates::computePatternTrick(
-    const IdTable& dynInput, IdTable* dynResult,
+    const IdTableView<0>& dynInput, IdTable* dynResult,
     const CompactVectorOfStrings<Id>& patterns, const size_t subjectColumnIdx,
     const size_t patternColumnIdx, RuntimeInformation& runtimeInfo) {
   const IdTableView<WIDTH> input = dynInput.asStaticView<WIDTH>();

--- a/src/engine/CountAvailablePredicates.h
+++ b/src/engine/CountAvailablePredicates.h
@@ -90,7 +90,7 @@ class CountAvailablePredicates : public Operation {
    * obtained via a scan of the `ql:has-pattern` predicate.
    */
   template <size_t I>
-  static void computePatternTrick(const IdTable& input, IdTable* result,
+  static void computePatternTrick(const IdTableView<0>& input, IdTable* result,
                                   const CompactVectorOfStrings<Id>& patterns,
                                   size_t subjectColumnIdx,
                                   size_t patternColumnIdx,

--- a/src/engine/Join.cpp
+++ b/src/engine/Join.cpp
@@ -298,7 +298,8 @@ void Join::computeSizeEstimateAndMultiplicities() {
 
 // ______________________________________________________________________________
 
-void Join::join(IdTableView<0> a, IdTableView<0> b, IdTable* result) const {
+void Join::join(const IdTableView<0>& a, const IdTableView<0>& b,
+                IdTable* result) const {
   AD_LOG_DEBUG << "Performing join between two tables.\n";
   AD_LOG_DEBUG << "A: width = " << a.numColumns() << ", size = " << a.size()
                << "\n";

--- a/src/engine/Join.cpp
+++ b/src/engine/Join.cpp
@@ -298,7 +298,7 @@ void Join::computeSizeEstimateAndMultiplicities() {
 
 // ______________________________________________________________________________
 
-void Join::join(const IdTable& a, const IdTable& b, IdTable* result) const {
+void Join::join(IdTableView<0> a, IdTableView<0> b, IdTable* result) const {
   AD_LOG_DEBUG << "Performing join between two tables.\n";
   AD_LOG_DEBUG << "A: width = " << a.numColumns() << ", size = " << a.size()
                << "\n";
@@ -701,7 +701,7 @@ Result Join::computeResultForTwoMaterializedInputs(
     std::shared_ptr<const Result> leftRes,
     std::shared_ptr<const Result> rightRes) const {
   IdTable idTable{getResultWidth(), allocator()};
-  join(leftRes->idTable(), rightRes->idTable(), &idTable);
+  join(leftRes->idTableView(), rightRes->idTableView(), &idTable);
   checkCancellation();
 
   return {std::move(idTable), resultSortedOn(),

--- a/src/engine/Join.h
+++ b/src/engine/Join.h
@@ -90,7 +90,7 @@ class Join : public Operation {
    * TODO Move the merge join into it's own function and make this function
    * a proper switch.
    **/
-  void join(const IdTable& a, const IdTable& b, IdTable* result) const;
+  void join(IdTableView<0> a, IdTableView<0> b, IdTable* result) const;
 
  public:
   // Fallback implementation of a join that is used when at least one of the two

--- a/src/engine/Join.h
+++ b/src/engine/Join.h
@@ -90,7 +90,8 @@ class Join : public Operation {
    * TODO Move the merge join into it's own function and make this function
    * a proper switch.
    **/
-  void join(IdTableView<0> a, IdTableView<0> b, IdTable* result) const;
+  void join(const IdTableView<0>& a, const IdTableView<0>& b,
+            IdTable* result) const;
 
  public:
   // Fallback implementation of a join that is used when at least one of the two

--- a/src/engine/Minus.cpp
+++ b/src/engine/Minus.cpp
@@ -138,10 +138,11 @@ auto Minus::makeUndefRangesChecker(bool left,
 }
 
 // _____________________________________________________________________________
-template <typename Left, typename T>
+template <typename IdTableT, typename T>
 IdTable Minus::copyMatchingRows(
-    const Left& left, T reference,
+    const IdTableT& left, T reference,
     const std::vector<T, ad_utility::AllocatorWithLimit<T>>& keepEntry) const {
+  static_assert(IdTableLike<IdTableT>);
   IdTable result{getResultWidth(), left.getAllocator()};
   AD_CORRECTNESS_CHECK(result.numColumns() == left.numColumns());
 

--- a/src/engine/Minus.cpp
+++ b/src/engine/Minus.cpp
@@ -71,8 +71,8 @@ Result Minus::computeResult(bool requestLaziness) {
                << leftResult->idTable().size() << " and "
                << rightResult->idTable().size() << endl;
 
-  IdTable idTable = computeMinus(leftResult->idTable(), rightResult->idTable(),
-                                 _matchedColumns);
+  IdTable idTable = computeMinus(leftResult->idTableView(),
+                                 rightResult->idTableView(), _matchedColumns);
 
   AD_LOG_DEBUG << "Minus result computation done" << endl;
   return {std::move(idTable), resultSortedOn(),
@@ -116,7 +116,8 @@ size_t Minus::getCostEstimate() {
 }
 
 // _____________________________________________________________________________
-auto Minus::makeUndefRangesChecker(bool left, const IdTable& idTable) const {
+auto Minus::makeUndefRangesChecker(bool left,
+                                   const IdTableView<0>& idTable) const {
   const auto& operation = left ? _left : _right;
   bool alwaysDefined = ql::ranges::all_of(
       _matchedColumns, [&operation, left, &idTable](const auto& cols) {
@@ -137,9 +138,9 @@ auto Minus::makeUndefRangesChecker(bool left, const IdTable& idTable) const {
 }
 
 // _____________________________________________________________________________
-template <typename T>
+template <typename Left, typename T>
 IdTable Minus::copyMatchingRows(
-    const IdTable& left, T reference,
+    const Left& left, T reference,
     const std::vector<T, ad_utility::AllocatorWithLimit<T>>& keepEntry) const {
   IdTable result{getResultWidth(), left.getAllocator()};
   AD_CORRECTNESS_CHECK(result.numColumns() == left.numColumns());
@@ -167,14 +168,14 @@ IdTable Minus::copyMatchingRows(
 }
 // _____________________________________________________________________________
 IdTable Minus::computeMinus(
-    const IdTable& left, const IdTable& right,
+    const IdTableView<0>& left, const IdTableView<0>& right,
     const std::vector<std::array<ColumnIndex, 2>>& joinColumns) const {
   if (left.empty()) {
     return IdTable{getResultWidth(), getExecutionContext()->getAllocator()};
   }
 
   if (right.empty() || joinColumns.empty()) {
-    return left.clone();
+    return IdTable{left.clone()};
   }
 
   ad_utility::JoinColumnMapping joinColumnData{joinColumns, left.numColumns(),
@@ -280,7 +281,7 @@ std::optional<Result> Minus::tryRightIndexNestedLoopJoinIfSuitable(
   joinAlgorithms::indexNestedLoop::IndexNestedLoopJoin nestedLoopJoin{
       _matchedColumns, std::move(leftRes), std::move(rightRes)};
   auto result = nestedLoopJoin.computeRightExistance(
-      [this](const IdTable& idTable, LocalVocab localVocab,
+      [this](const auto& idTable, LocalVocab localVocab,
              const std::vector<bool, ad_utility::AllocatorWithLimit<bool>>&
                  matchingTracker) {
         return Result::IdTableVocabPair{

--- a/src/engine/Minus.h
+++ b/src/engine/Minus.h
@@ -52,13 +52,13 @@ class Minus : public Operation {
   // `std::variant<ad_utility::Noop, ad_utility::FindSmallerUndefRanges>` to
   // avoid including expensive headers that are only relevant for the
   // implementation of this function.
-  auto makeUndefRangesChecker(bool left, const IdTable& idTable) const;
+  auto makeUndefRangesChecker(bool left, const IdTableView<0>& idTable) const;
 
   // Helper function to copy all rows from `left` that have a corresponding
   // value of `reference` in `keepEntry`.
-  template <typename T>
+  template <typename Left, typename T>
   IdTable copyMatchingRows(
-      const IdTable& left, T reference,
+      const Left& left, T reference,
       const std::vector<T, ad_utility::AllocatorWithLimit<T>>& keepEntry) const;
 
  public:
@@ -78,7 +78,7 @@ class Minus : public Operation {
    *        This method is made public here for unit testing purposes.
    **/
   IdTable computeMinus(
-      const IdTable& a, const IdTable& b,
+      const IdTableView<0>& a, const IdTableView<0>& b,
       const std::vector<std::array<ColumnIndex, 2>>& matchedColumns) const;
 
  private:

--- a/src/engine/Minus.h
+++ b/src/engine/Minus.h
@@ -56,9 +56,9 @@ class Minus : public Operation {
 
   // Helper function to copy all rows from `left` that have a corresponding
   // value of `reference` in `keepEntry`.
-  template <typename Left, typename T>
+  template <typename IdTableT, typename T>
   IdTable copyMatchingRows(
-      const Left& left, T reference,
+      const IdTableT& left, T reference,
       const std::vector<T, ad_utility::AllocatorWithLimit<T>>& keepEntry) const;
 
  public:

--- a/src/engine/MultiColumnJoin.cpp
+++ b/src/engine/MultiColumnJoin.cpp
@@ -78,7 +78,7 @@ Result MultiColumnJoin::computeResult([[maybe_unused]] bool requestLaziness) {
                << leftResult->idTable().size() << " and "
                << rightResult->idTable().size() << endl;
 
-  computeMultiColumnJoin(leftResult->idTable(), rightResult->idTable(),
+  computeMultiColumnJoin(leftResult->idTableView(), rightResult->idTableView(),
                          _joinColumns, &idTable);
 
   checkCancellation();
@@ -206,7 +206,7 @@ void MultiColumnJoin::computeSizeEstimateAndMultiplicities() {
 
 // _______________________________________________________________________
 void MultiColumnJoin::computeMultiColumnJoin(
-    const IdTable& left, const IdTable& right,
+    const IdTableView<0>& left, const IdTableView<0>& right,
     const std::vector<std::array<ColumnIndex, 2>>& joinColumns,
     IdTable* result) {
   // check for trivial cases

--- a/src/engine/MultiColumnJoin.h
+++ b/src/engine/MultiColumnJoin.h
@@ -65,7 +65,7 @@ class MultiColumnJoin : public Operation {
    *This method is made public here for unit testing purposes.
    **/
   void computeMultiColumnJoin(
-      const IdTable& left, const IdTable& right,
+      const IdTableView<0>& left, const IdTableView<0>& right,
       const std::vector<std::array<ColumnIndex, 2>>& joinColumns,
       IdTable* resultMightBeUnsorted);
 

--- a/src/engine/OptionalJoin.cpp
+++ b/src/engine/OptionalJoin.cpp
@@ -184,8 +184,8 @@ Result OptionalJoin::computeResult(bool requestLaziness) {
                << leftResult->idTable().size() << " and "
                << rightResult->idTable().size() << endl;
 
-  optionalJoin(leftResult->idTable(), rightResult->idTable(), _joinColumns,
-               &idTable, implementation_);
+  optionalJoin(leftResult->idTableView(), rightResult->idTableView(),
+               _joinColumns, &idTable, implementation_);
 
   checkCancellation();
 
@@ -329,7 +329,7 @@ void OptionalJoin::computeSizeEstimateAndMultiplicities() {
 
 // ______________________________________________________________
 auto OptionalJoin::computeImplementationFromIdTables(
-    const IdTable& left, const IdTable& right,
+    IdTableView<0> left, IdTableView<0> right,
     const std::vector<std::array<ColumnIndex, 2>>& joinColumns)
     -> Implementation {
   auto implementation = Implementation::NoUndef;
@@ -373,7 +373,7 @@ bool OptionalJoin::columnOriginatesFromGraphOrUndef(
 
 // ______________________________________________________________
 void OptionalJoin::optionalJoin(
-    const IdTable& left, const IdTable& right,
+    IdTableView<0> left, IdTableView<0> right,
     const std::vector<std::array<ColumnIndex, 2>>& joinColumns, IdTable* result,
     Implementation implementation) {
   // check for trivial cases

--- a/src/engine/OptionalJoin.cpp
+++ b/src/engine/OptionalJoin.cpp
@@ -329,7 +329,7 @@ void OptionalJoin::computeSizeEstimateAndMultiplicities() {
 
 // ______________________________________________________________
 auto OptionalJoin::computeImplementationFromIdTables(
-    IdTableView<0> left, IdTableView<0> right,
+    const IdTableView<0>& left, const IdTableView<0>& right,
     const std::vector<std::array<ColumnIndex, 2>>& joinColumns)
     -> Implementation {
   auto implementation = Implementation::NoUndef;
@@ -373,7 +373,7 @@ bool OptionalJoin::columnOriginatesFromGraphOrUndef(
 
 // ______________________________________________________________
 void OptionalJoin::optionalJoin(
-    IdTableView<0> left, IdTableView<0> right,
+    const IdTableView<0>& left, const IdTableView<0>& right,
     const std::vector<std::array<ColumnIndex, 2>>& joinColumns, IdTable* result,
     Implementation implementation) {
   // check for trivial cases

--- a/src/engine/OptionalJoin.h
+++ b/src/engine/OptionalJoin.h
@@ -82,7 +82,7 @@ class OptionalJoin : public Operation {
   // Joins two result tables on any number of columns, inserting the special
   // value `Id::makeUndefined()` for any entries marked as optional.
   void optionalJoin(
-      const IdTable& left, const IdTable& right,
+      IdTableView<0> left, IdTableView<0> right,
       const std::vector<std::array<ColumnIndex, 2>>& joinColumns,
       IdTable* dynResult,
       Implementation implementation = Implementation::GeneralCase);
@@ -129,7 +129,7 @@ class OptionalJoin : public Operation {
   // Check which of the join columns in `left` and `right` contain UNDEF values
   // and return the appropriate `Implementation`.
   static Implementation computeImplementationFromIdTables(
-      const IdTable& left, const IdTable& right,
+      IdTableView<0> left, IdTableView<0> right,
       const std::vector<std::array<ColumnIndex, 2>>&);
 };
 

--- a/src/engine/OptionalJoin.h
+++ b/src/engine/OptionalJoin.h
@@ -82,7 +82,7 @@ class OptionalJoin : public Operation {
   // Joins two result tables on any number of columns, inserting the special
   // value `Id::makeUndefined()` for any entries marked as optional.
   void optionalJoin(
-      IdTableView<0> left, IdTableView<0> right,
+      const IdTableView<0>& left, const IdTableView<0>& right,
       const std::vector<std::array<ColumnIndex, 2>>& joinColumns,
       IdTable* dynResult,
       Implementation implementation = Implementation::GeneralCase);
@@ -129,7 +129,7 @@ class OptionalJoin : public Operation {
   // Check which of the join columns in `left` and `right` contain UNDEF values
   // and return the appropriate `Implementation`.
   static Implementation computeImplementationFromIdTables(
-      IdTableView<0> left, IdTableView<0> right,
+      const IdTableView<0>& left, const IdTableView<0>& right,
       const std::vector<std::array<ColumnIndex, 2>>&);
 };
 

--- a/src/engine/Result.cpp
+++ b/src/engine/Result.cpp
@@ -232,7 +232,7 @@ void Result::IdTableSharedLocalVocabPair::applyLimitOffset(
 // _____________________________________________________________________________
 void Result::applyLimitOffset(
     const LimitOffsetClause& limitOffset,
-    std::function<void(std::chrono::microseconds, const IdTable&)>
+    std::function<void(std::chrono::microseconds, const MaterializedTable&)>
         limitTimeCallback) {
   // Apply the OFFSET clause. If the offset is `0` or the offset is larger
   // than the size of the `IdTable`, then this has no effect and runtime

--- a/src/engine/Result.cpp
+++ b/src/engine/Result.cpp
@@ -232,7 +232,7 @@ void Result::IdTableSharedLocalVocabPair::applyLimitOffset(
 // _____________________________________________________________________________
 void Result::applyLimitOffset(
     const LimitOffsetClause& limitOffset,
-    std::function<void(std::chrono::microseconds, const MaterializedTable&)>
+    std::function<void(std::chrono::microseconds, const IdTable&)>
         limitTimeCallback) {
   // Apply the OFFSET clause. If the offset is `0` or the offset is larger
   // than the size of the `IdTable`, then this has no effect and runtime
@@ -381,6 +381,9 @@ const IdTableView<0>& Result::idTableView() const {
   AD_CONTRACT_CHECK(isFullyMaterialized());
   return std::get<IdTableSharedLocalVocabPair>(data_).idTableView();
 }
+
+// _____________________________________________________________________________
+IdTable Result::cloneIdTable() const { return IdTable{idTable().clone()}; }
 
 // _____________________________________________________________________________
 Result::LazyResult Result::idTables() const {

--- a/src/engine/Result.h
+++ b/src/engine/Result.h
@@ -191,8 +191,6 @@ class Result {
   Result(Result&& other) = default;
   Result& operator=(Result&& other) = default;
 
-  using MaterializedTable = IdTable;
-
   // Wrap the generator stored in `data_` within a new generator that calls
   // `onNewChunk` every time a new `IdTableVocabPair` is yielded by the original
   // generator and passed this new `IdTableVocabPair` along with microsecond
@@ -235,6 +233,11 @@ class Result {
   // `Result`; `applyLimitOffset()` refreshes the view in place, so copies of
   // the view value taken before that call should not be reused afterwards.
   const IdTableView<0>& idTableView() const;
+
+  // Returns a clone of the materialized `idTable()`. Throw if not fully
+  // materialized. This operation is potentially expensive as it copies all
+  // data.
+  IdTable cloneIdTable() const;
 
   // Access to the underlying `IdTable`s. Throw an `ad_utility::Exception`
   // if the underlying `data_` member holds the wrong variant or if the result
@@ -317,7 +320,7 @@ class Result {
   // those are still correct after performing this operation.
   void applyLimitOffset(
       const LimitOffsetClause& limitOffset,
-      std::function<void(std::chrono::microseconds, const MaterializedTable&)>
+      std::function<void(std::chrono::microseconds, const IdTable&)>
           limitTimeCallback);
 
   // Check if the operation did fulfill its contract and only returns as many

--- a/src/engine/Result.h
+++ b/src/engine/Result.h
@@ -191,6 +191,8 @@ class Result {
   Result(Result&& other) = default;
   Result& operator=(Result&& other) = default;
 
+  using MaterializedTable = IdTable;
+
   // Wrap the generator stored in `data_` within a new generator that calls
   // `onNewChunk` every time a new `IdTableVocabPair` is yielded by the original
   // generator and passed this new `IdTableVocabPair` along with microsecond
@@ -315,7 +317,7 @@ class Result {
   // those are still correct after performing this operation.
   void applyLimitOffset(
       const LimitOffsetClause& limitOffset,
-      std::function<void(std::chrono::microseconds, const IdTable&)>
+      std::function<void(std::chrono::microseconds, const MaterializedTable&)>
           limitTimeCallback);
 
   // Check if the operation did fulfill its contract and only returns as many

--- a/src/engine/SortedUnionImpl.h
+++ b/src/engine/SortedUnionImpl.h
@@ -14,10 +14,10 @@
 #include "index/LocalVocab.h"
 
 namespace sortedUnion {
-// Helper struct that has the same layout as Result::IdTableVocabPair but
+// Helper struct that has the same layout as `Result::IdTableVocabPair` but
 // doesn't own the data.
 struct Wrapper {
-  const IdTable& idTable_;
+  IdTableView<0> idTable_;
   const LocalVocab& localVocab_;
 };
 

--- a/src/engine/SortedUnionImpl.h
+++ b/src/engine/SortedUnionImpl.h
@@ -17,7 +17,7 @@ namespace sortedUnion {
 // Helper struct that has the same layout as `Result::IdTableVocabPair` but
 // doesn't own the data.
 struct Wrapper {
-  IdTableView<0> idTable_;
+  const IdTableView<0>& idTable_;
   const LocalVocab& localVocab_;
 };
 

--- a/src/engine/Union.cpp
+++ b/src/engine/Union.cpp
@@ -251,8 +251,8 @@ Result Union::computeResult(bool requestLaziness) {
 
   AD_LOG_DEBUG << "Union subresult computation done." << std::endl;
 
-  IdTable idTable =
-      computeUnion(subRes1->idTable(), subRes2->idTable(), _columnOrigins);
+  IdTable idTable = computeUnion(subRes1->idTableView(), subRes2->idTableView(),
+                                 _columnOrigins);
 
   AD_LOG_DEBUG << "Union result computation done" << std::endl;
   // If only one of the two operands has a non-empty local vocabulary, share
@@ -263,7 +263,7 @@ Result Union::computeResult(bool requestLaziness) {
 
 // _____________________________________________________________________________
 IdTable Union::computeUnion(
-    const IdTable& left, const IdTable& right,
+    const IdTableView<0>& left, const IdTableView<0>& right,
     const std::vector<std::array<size_t, 2>>& columnOrigins) const {
   IdTable res{getResultWidth(), getExecutionContext()->getAllocator()};
   res.resize(left.size() + right.size());
@@ -406,7 +406,7 @@ Result::LazyResult Union::computeResultKeepOrder(
   auto toRange = [](const auto& result) {
     return result->isFullyMaterialized()
                ? Range{std::array{
-                     Wrapper{result->idTable(), result->localVocab()}}}
+                     Wrapper{result->idTableView(), result->localVocab()}}}
                : Range{std::move(result->idTables())};
   };
   Range leftRange = toRange(result1);

--- a/src/engine/Union.h
+++ b/src/engine/Union.h
@@ -59,9 +59,9 @@ class Union : public Operation {
 
   static constexpr size_t chunkSize = 1'000'000;
 
-  // The method is declared here to make it unit testable
+  // The method is declared here to make it unit testable.
   IdTable computeUnion(
-      const IdTable& left, const IdTable& right,
+      const IdTableView<0>& left, const IdTableView<0>& right,
       const std::vector<std::array<size_t, 2>>& columnOrigins) const;
 
   std::vector<QueryExecutionTree*> getChildren() override {

--- a/src/engine/idTable/IdTable.h
+++ b/src/engine/idTable/IdTable.h
@@ -953,14 +953,11 @@ inline bool operator==(const IdTable& table, const IdTableView<COLS>& view) {
   if (table.numRows() != view.numRows()) {
     return false;
   }
-  const auto& cols = table.getColumns();
-  const auto& viewCols = view.getColumns();
-  for (size_t i = 0; i < table.numColumns(); ++i) {
-    if (!ql::ranges::equal(cols[i], viewCols[i])) {
-      return false;
-    }
-  }
-  return true;
+  return ql::ranges::all_of(
+      ::ranges::views::zip(table.getColumns(), view.getColumns()),
+      [](const auto& pair) {
+        return ql::ranges::equal(pair.first, pair.second);
+      });
 }
 
 template <int COLS>

--- a/src/engine/idTable/IdTable.h
+++ b/src/engine/idTable/IdTable.h
@@ -928,4 +928,16 @@ using IdTableView =
     columnBasedIdTable::IdTable<Id, COLS, detail::IdVector,
                                 columnBasedIdTable::IsView::True>;
 
+// Free-function `operator==` to allow comparing `IdTableView` with `IdTable`
+// and vice versa. The member `operator==` is only defined for non-view types.
+template <int COLS>
+inline bool operator==(const IdTableView<COLS>& view, const IdTable& table) {
+  return table == view.clone();
+}
+
+template <int COLS>
+inline bool operator==(const IdTable& table, const IdTableView<COLS>& view) {
+  return table == view.clone();
+}
+
 #endif  // QLEVER_SRC_ENGINE_IDTABLE_IDTABLE_H

--- a/src/engine/idTable/IdTable.h
+++ b/src/engine/idTable/IdTable.h
@@ -928,16 +928,44 @@ using IdTableView =
     columnBasedIdTable::IdTable<Id, COLS, detail::IdVector,
                                 columnBasedIdTable::IsView::True>;
 
+// Concept that matches any type that is or inherits from any instantiation of
+// `columnBasedIdTable::IdTable` — including `IdTable`, `IdTableStatic<COLS>`,
+// and `IdTableView<COLS>`.
+namespace detail {
+template <typename ValType, int NumCols, typename Storage,
+          columnBasedIdTable::IsView isView>
+std::true_type isIdTableLike(
+    const columnBasedIdTable::IdTable<ValType, NumCols, Storage, isView>&);
+std::false_type isIdTableLike(...);
+}  // namespace detail
+
+template <typename T>
+CPP_concept IdTableLike =
+    decltype(detail::isIdTableLike(std::declval<const T&>()))::value;
+
 // Free-function `operator==` to allow comparing `IdTableView` with `IdTable`
 // and vice versa. The member `operator==` is only defined for non-view types.
 template <int COLS>
-inline bool operator==(const IdTableView<COLS>& view, const IdTable& table) {
-  return table == view.clone();
+inline bool operator==(const IdTable& table, const IdTableView<COLS>& view) {
+  if (table.numColumns() != view.numColumns()) {
+    return table.empty() && view.empty();
+  }
+  if (table.numRows() != view.numRows()) {
+    return false;
+  }
+  const auto& cols = table.getColumns();
+  const auto& viewCols = view.getColumns();
+  for (size_t i = 0; i < table.numColumns(); ++i) {
+    if (!ql::ranges::equal(cols[i], viewCols[i])) {
+      return false;
+    }
+  }
+  return true;
 }
 
 template <int COLS>
-inline bool operator==(const IdTable& table, const IdTableView<COLS>& view) {
-  return table == view.clone();
+inline bool operator==(const IdTableView<COLS>& view, const IdTable& table) {
+  return table == view;
 }
 
 #endif  // QLEVER_SRC_ENGINE_IDTABLE_IDTABLE_H

--- a/test/MinusTest.cpp
+++ b/test/MinusTest.cpp
@@ -106,14 +106,14 @@ TEST(Minus, computeMinus) {
               qec, b.clone(),
               std::vector<std::optional<Variable>>{
                   Variable{"?b"}, Variable{"?a"}, std::nullopt, std::nullopt})};
-  IdTable res = m.computeMinus(a, b, jcls);
+  IdTable res = m.computeMinus(a.asStaticView<0>(), b.asStaticView<0>(), jcls);
 
   EXPECT_EQ(res, makeIdTableFromVector({{1, 2, 1}, {5, 4, 1}, {8, 2, 3}}));
 
   // Test subtracting without matching columns
   res.clear();
   jcls.clear();
-  res = m.computeMinus(a, b, jcls);
+  res = m.computeMinus(a.asStaticView<0>(), b.asStaticView<0>(), jcls);
   EXPECT_EQ(res, a);
 
   // Test minus with variable sized data.
@@ -137,7 +137,8 @@ TEST(Minus, computeMinus) {
                std::vector<std::optional<Variable>>{
                    Variable{"?a"}, Variable{"?b"}, std::nullopt})};
 
-  IdTable vres = vm.computeMinus(va, vb, jcls);
+  IdTable vres =
+      vm.computeMinus(va.asStaticView<0>(), vb.asStaticView<0>(), jcls);
 
   EXPECT_EQ(vres, makeIdTableFromVector({{7, 6, 5, 4, 3, 2}}));
 }
@@ -378,12 +379,14 @@ TEST(Minus, computeMinusWithEmptyTables) {
           std::vector<std::optional<Variable>>{Variable{"?a"}, std::nullopt})};
 
   {
-    IdTable res = m.computeMinus(empty, nonEmpty, jcls);
+    IdTable res = m.computeMinus(empty.asStaticView<0>(),
+                                 nonEmpty.asStaticView<0>(), jcls);
 
     EXPECT_EQ(res, empty);
   }
   {
-    IdTable res = m.computeMinus(nonEmpty, empty, jcls);
+    IdTable res = m.computeMinus(nonEmpty.asStaticView<0>(),
+                                 empty.asStaticView<0>(), jcls);
 
     EXPECT_EQ(res, nonEmpty);
   }
@@ -411,7 +414,7 @@ TEST(Minus, computeMinusWithUndefined) {
               std::vector<std::optional<Variable>>{
                   Variable{"?b"}, Variable{"?a"}, std::nullopt})};
 
-  IdTable res = m.computeMinus(a, b, jcls);
+  IdTable res = m.computeMinus(a.asStaticView<0>(), b.asStaticView<0>(), jcls);
   EXPECT_EQ(res, makeIdTableFromVector({{U, U, 10}, {1, U, 12}, {5, 4, 13}}));
 }
 

--- a/test/MultiColumnJoinTest.cpp
+++ b/test/MultiColumnJoinTest.cpp
@@ -41,7 +41,8 @@ TEST(EngineTest, multiColumnJoinTest) {
   // a have to equal those of column 2 of b and vice versa).
   MultiColumnJoin{qec, idTableToExecutionTree(qec, a),
                   idTableToExecutionTree(qec, b)}
-      .computeMultiColumnJoin(a, b, jcls, &res);
+      .computeMultiColumnJoin(a.asStaticView<0>(), b.asStaticView<0>(), jcls,
+                              &res);
 
   auto expected = makeIdTableFromVector({{2, 1, 3, 3}, {1, 3, 1, 1}});
   ASSERT_EQ(expected, res);
@@ -64,7 +65,8 @@ TEST(EngineTest, multiColumnJoinTest) {
 
   MultiColumnJoin{qec, idTableToExecutionTree(qec, a),
                   idTableToExecutionTree(qec, b)}
-      .computeMultiColumnJoin(va, vb, jcls, &vres);
+      .computeMultiColumnJoin(va.asStaticView<0>(), vb.asStaticView<0>(), jcls,
+                              &vres);
 
   ASSERT_EQ(4u, vres.size());
   ASSERT_EQ(7u, vres.numColumns());

--- a/test/ResultTest.cpp
+++ b/test/ResultTest.cpp
@@ -553,8 +553,8 @@ TEST(Result, verifyApplyLimitOffsetHandlesNonZeroOffsetWithoutLimitCorrectly) {
         limitOffset, [&](std::chrono::microseconds, const IdTable& innerTable) {
           for (const auto& row : innerTable) {
             ASSERT_EQ(row.size(), 2);
-            // Make sure we never get values that were
-            // supposed to be filtered out.
+            // Make sure we never get values that were supposed to be filtered
+            // out.
             EXPECT_NE(row[0].getVocabIndex().get(), 0);
             EXPECT_NE(row[1].getVocabIndex().get(), 7);
           }

--- a/test/ResultTest.cpp
+++ b/test/ResultTest.cpp
@@ -88,6 +88,24 @@ TEST(Result, idTableViewThrowsWhenActuallyLazy) {
 }
 
 // _____________________________________________________________________________
+TEST(Result, cloneIdTableReturnsCopy) {
+  auto idTable = makeIdTableFromVector({{1, 2}, {3, 4}});
+  Result result{idTable.clone(), {}, LocalVocab{}};
+  ASSERT_TRUE(result.isFullyMaterialized());
+  IdTable cloned = result.cloneIdTable();
+  EXPECT_EQ(cloned, idTable);
+  // Verify it is a deep copy, not a reference to the same data.
+  EXPECT_NE(&cloned(0, 0), &result.idTable()(0, 0));
+}
+
+// _____________________________________________________________________________
+TEST(Result, cloneIdTableThrowsWhenActuallyLazy) {
+  Result result{[]() -> Result::Generator { co_return; }(), {}};
+  EXPECT_FALSE(result.isFullyMaterialized());
+  EXPECT_THROW(result.cloneIdTable(), ad_utility::Exception);
+}
+
+// _____________________________________________________________________________
 TEST(Result, verifyIdTableThrowsOnSecondAccess) {
   const Result result{[]() -> Result::Generator { co_return; }(), {}};
   // First access should work
@@ -428,8 +446,7 @@ TEST(Result, verifyApplyLimitOffsetDoesCorrectlyApplyLimitAndOffset) {
   {
     auto comparisonTable = makeIdTableFromVector({{2, 7}, {3, 6}});
     uint32_t callCounter = 0;
-    auto callback = [&](std::chrono::microseconds,
-                        const Result::MaterializedTable& innerTable) {
+    auto callback = [&](std::chrono::microseconds, const IdTable& innerTable) {
       // NOTE: duration can't be tested here, processors are too fast
       EXPECT_EQ(innerTable, comparisonTable);
       ++callCounter;
@@ -455,8 +472,7 @@ TEST(Result, verifyApplyLimitOffsetDoesCorrectlyApplyLimitAndOffset) {
     uint32_t totalRows = 0;
     Result result{std::move(generator), {}};
     result.applyLimitOffset(
-        limitOffset, [&](std::chrono::microseconds,
-                         const Result::MaterializedTable& innerTable) {
+        limitOffset, [&](std::chrono::microseconds, const IdTable& innerTable) {
           // NOTE: duration can't be tested here, processors are too fast
           for (const auto& row : innerTable) {
             ASSERT_EQ(row.size(), 2);
@@ -494,12 +510,11 @@ TEST(Result, verifyApplyLimitOffsetHandlesZeroLimitCorrectly) {
   {
     uint32_t callCounter = 0;
     Result result{idTable.clone(), {}, LocalVocab{}};
-    result.applyLimitOffset(limitOffset,
-                            [&](std::chrono::microseconds,
-                                const Result::MaterializedTable& innerTable) {
-                              EXPECT_EQ(innerTable.numRows(), 0);
-                              ++callCounter;
-                            });
+    result.applyLimitOffset(
+        limitOffset, [&](std::chrono::microseconds, const IdTable& innerTable) {
+          EXPECT_EQ(innerTable.numRows(), 0);
+          ++callCounter;
+        });
     EXPECT_EQ(callCounter, 1);
   }
 
@@ -507,8 +522,8 @@ TEST(Result, verifyApplyLimitOffsetHandlesZeroLimitCorrectly) {
     uint32_t callCounter = 0;
     Result result{std::move(generator), {}};
     result.applyLimitOffset(
-        limitOffset, [&](std::chrono::microseconds,
-                         const Result::MaterializedTable&) { ++callCounter; });
+        limitOffset,
+        [&](std::chrono::microseconds, const IdTable&) { ++callCounter; });
 
     consumeGenerator(result.idTables());
 
@@ -523,30 +538,28 @@ TEST(Result, verifyApplyLimitOffsetHandlesNonZeroOffsetWithoutLimitCorrectly) {
   {
     uint32_t callCounter = 0;
     Result result{idTable.clone(), {}, LocalVocab{}};
-    result.applyLimitOffset(limitOffset,
-                            [&](std::chrono::microseconds,
-                                const Result::MaterializedTable& innerTable) {
-                              EXPECT_EQ(innerTable.numRows(), 3);
-                              ++callCounter;
-                            });
+    result.applyLimitOffset(
+        limitOffset, [&](std::chrono::microseconds, const IdTable& innerTable) {
+          EXPECT_EQ(innerTable.numRows(), 3);
+          ++callCounter;
+        });
     EXPECT_EQ(callCounter, 1);
   }
 
   for (auto& generator : getAllSubSplits(idTable)) {
     uint32_t callCounter = 0;
     Result result{std::move(generator), {}};
-    result.applyLimitOffset(limitOffset,
-                            [&](std::chrono::microseconds,
-                                const Result::MaterializedTable& innerTable) {
-                              for (const auto& row : innerTable) {
-                                ASSERT_EQ(row.size(), 2);
-                                // Make sure we never get values that were
-                                // supposed to be filtered out.
-                                EXPECT_NE(row[0].getVocabIndex().get(), 0);
-                                EXPECT_NE(row[1].getVocabIndex().get(), 7);
-                              }
-                              ++callCounter;
-                            });
+    result.applyLimitOffset(
+        limitOffset, [&](std::chrono::microseconds, const IdTable& innerTable) {
+          for (const auto& row : innerTable) {
+            ASSERT_EQ(row.size(), 2);
+            // Make sure we never get values that were
+            // supposed to be filtered out.
+            EXPECT_NE(row[0].getVocabIndex().get(), 0);
+            EXPECT_NE(row[1].getVocabIndex().get(), 7);
+          }
+          ++callCounter;
+        });
 
     consumeGenerator(result.idTables());
 
@@ -562,16 +575,16 @@ TEST(Result, verifyApplyLimitOffsetIsNoOpWhenLimitClauseIsRedundant) {
   {
     Result result{idTable.clone(), {}, LocalVocab{}};
     result.applyLimitOffset(
-        limitOffset, [&](std::chrono::microseconds,
-                         const Result::MaterializedTable&) { ++callCounter; });
+        limitOffset,
+        [&](std::chrono::microseconds, const IdTable&) { ++callCounter; });
     EXPECT_EQ(callCounter, 0);
   }
 
   for (auto& generator : getAllSubSplits(idTable)) {
     Result result{std::move(generator), {}};
     result.applyLimitOffset(
-        limitOffset, [&](std::chrono::microseconds,
-                         const Result::MaterializedTable&) { ++callCounter; });
+        limitOffset,
+        [&](std::chrono::microseconds, const IdTable&) { ++callCounter; });
 
     consumeGenerator(result.idTables());
 

--- a/test/ResultTest.cpp
+++ b/test/ResultTest.cpp
@@ -428,7 +428,8 @@ TEST(Result, verifyApplyLimitOffsetDoesCorrectlyApplyLimitAndOffset) {
   {
     auto comparisonTable = makeIdTableFromVector({{2, 7}, {3, 6}});
     uint32_t callCounter = 0;
-    auto callback = [&](std::chrono::microseconds, const IdTable& innerTable) {
+    auto callback = [&](std::chrono::microseconds,
+                        const Result::MaterializedTable& innerTable) {
       // NOTE: duration can't be tested here, processors are too fast
       EXPECT_EQ(innerTable, comparisonTable);
       ++callCounter;
@@ -454,7 +455,8 @@ TEST(Result, verifyApplyLimitOffsetDoesCorrectlyApplyLimitAndOffset) {
     uint32_t totalRows = 0;
     Result result{std::move(generator), {}};
     result.applyLimitOffset(
-        limitOffset, [&](std::chrono::microseconds, const IdTable& innerTable) {
+        limitOffset, [&](std::chrono::microseconds,
+                         const Result::MaterializedTable& innerTable) {
           // NOTE: duration can't be tested here, processors are too fast
           for (const auto& row : innerTable) {
             ASSERT_EQ(row.size(), 2);
@@ -492,11 +494,12 @@ TEST(Result, verifyApplyLimitOffsetHandlesZeroLimitCorrectly) {
   {
     uint32_t callCounter = 0;
     Result result{idTable.clone(), {}, LocalVocab{}};
-    result.applyLimitOffset(
-        limitOffset, [&](std::chrono::microseconds, const IdTable& innerTable) {
-          EXPECT_EQ(innerTable.numRows(), 0);
-          ++callCounter;
-        });
+    result.applyLimitOffset(limitOffset,
+                            [&](std::chrono::microseconds,
+                                const Result::MaterializedTable& innerTable) {
+                              EXPECT_EQ(innerTable.numRows(), 0);
+                              ++callCounter;
+                            });
     EXPECT_EQ(callCounter, 1);
   }
 
@@ -504,8 +507,8 @@ TEST(Result, verifyApplyLimitOffsetHandlesZeroLimitCorrectly) {
     uint32_t callCounter = 0;
     Result result{std::move(generator), {}};
     result.applyLimitOffset(
-        limitOffset,
-        [&](std::chrono::microseconds, const IdTable&) { ++callCounter; });
+        limitOffset, [&](std::chrono::microseconds,
+                         const Result::MaterializedTable&) { ++callCounter; });
 
     consumeGenerator(result.idTables());
 
@@ -520,28 +523,30 @@ TEST(Result, verifyApplyLimitOffsetHandlesNonZeroOffsetWithoutLimitCorrectly) {
   {
     uint32_t callCounter = 0;
     Result result{idTable.clone(), {}, LocalVocab{}};
-    result.applyLimitOffset(
-        limitOffset, [&](std::chrono::microseconds, const IdTable& innerTable) {
-          EXPECT_EQ(innerTable.numRows(), 3);
-          ++callCounter;
-        });
+    result.applyLimitOffset(limitOffset,
+                            [&](std::chrono::microseconds,
+                                const Result::MaterializedTable& innerTable) {
+                              EXPECT_EQ(innerTable.numRows(), 3);
+                              ++callCounter;
+                            });
     EXPECT_EQ(callCounter, 1);
   }
 
   for (auto& generator : getAllSubSplits(idTable)) {
     uint32_t callCounter = 0;
     Result result{std::move(generator), {}};
-    result.applyLimitOffset(
-        limitOffset, [&](std::chrono::microseconds, const IdTable& innerTable) {
-          for (const auto& row : innerTable) {
-            ASSERT_EQ(row.size(), 2);
-            // Make sure we never get values that were supposed to be filtered
-            // out.
-            EXPECT_NE(row[0].getVocabIndex().get(), 0);
-            EXPECT_NE(row[1].getVocabIndex().get(), 7);
-          }
-          ++callCounter;
-        });
+    result.applyLimitOffset(limitOffset,
+                            [&](std::chrono::microseconds,
+                                const Result::MaterializedTable& innerTable) {
+                              for (const auto& row : innerTable) {
+                                ASSERT_EQ(row.size(), 2);
+                                // Make sure we never get values that were
+                                // supposed to be filtered out.
+                                EXPECT_NE(row[0].getVocabIndex().get(), 0);
+                                EXPECT_NE(row[1].getVocabIndex().get(), 7);
+                              }
+                              ++callCounter;
+                            });
 
     consumeGenerator(result.idTables());
 
@@ -557,16 +562,16 @@ TEST(Result, verifyApplyLimitOffsetIsNoOpWhenLimitClauseIsRedundant) {
   {
     Result result{idTable.clone(), {}, LocalVocab{}};
     result.applyLimitOffset(
-        limitOffset,
-        [&](std::chrono::microseconds, const IdTable&) { ++callCounter; });
+        limitOffset, [&](std::chrono::microseconds,
+                         const Result::MaterializedTable&) { ++callCounter; });
     EXPECT_EQ(callCounter, 0);
   }
 
   for (auto& generator : getAllSubSplits(idTable)) {
     Result result{std::move(generator), {}};
     result.applyLimitOffset(
-        limitOffset,
-        [&](std::chrono::microseconds, const IdTable&) { ++callCounter; });
+        limitOffset, [&](std::chrono::microseconds,
+                         const Result::MaterializedTable&) { ++callCounter; });
 
     consumeGenerator(result.idTables());
 

--- a/test/engine/OptionalJoinTest.cpp
+++ b/test/engine/OptionalJoinTest.cpp
@@ -44,7 +44,8 @@ void testOptionalJoin(const IdTable& inputA, const IdTable& inputB,
     // a have to equal those of column 2 of b and vice versa).
     OptionalJoin{qec, idTableToExecutionTree(qec, inputA),
                  idTableToExecutionTree(qec, inputB)}
-        .optionalJoin(inputA, inputB, jcls, &result);
+        .optionalJoin(inputA.asStaticView<0>(), inputB.asStaticView<0>(), jcls,
+                      &result);
     ASSERT_EQ(expectedResult, result);
   }
 

--- a/test/util/IdTableHelpers.h
+++ b/test/util/IdTableHelpers.h
@@ -134,8 +134,29 @@ struct MatchesIdTable {
     // gets rid of all possibly lifetime and mutability issues.
     return operator()(table.clone());
   }
+
+  // Overload for `IdTableView<0>`, which uses a `Truly` matcher to compare
+  // via the free `operator==(IdTableView, IdTable)`. Uses `shared_ptr`
+  // to keep `IdTable` alive since `IdTable` is non-copyable.
+  template <int N>
+  auto operator()(const IdTableView<N>& view) const {
+    auto expected = std::make_shared<IdTable>(IdTable{view.clone()});
+    return ::testing::Truly(
+        [expected = std::move(expected)](const auto& actual) {
+          return actual == *expected;
+        });
+  }
 };
 static constexpr MatchesIdTable matchesIdTable;
+
+// Allow comparing `IdTableView<N>` with `CopyShield<IdTable>` in gtest
+// matchers. The actual comparison clones the view into an `IdTable`.
+template <int N>
+inline bool operator==(const IdTableView<N>& view,
+                       const CopyShield<IdTable>& shield) {
+  IdTable viewAsTable{view.clone()};
+  return shield == viewAsTable;
+}
 
 /*
  * @brief Tests, whether the given IdTable has the same content as the sample

--- a/test/util/JoinHelpers.h
+++ b/test/util/JoinHelpers.h
@@ -84,7 +84,7 @@ inline auto makeJoinLambda() {
         auto rightTree = ad_utility::makeExecutionTree<ValuesForTesting>(
             qec, b.clone(), std::move(rightVariables), false, std::vector{jc2});
         Join join{qec, leftTree, rightTree, jc1, jc2, true, false};
-        return join.join(a, b, result);
+        return join.join(a.asStaticView<0>(), b.asStaticView<0>(), result);
       }};
 }
 


### PR DESCRIPTION
Continues #2933 as the second step toward supporting fully non-owning `IdTableViews` as native result storage. This mostly updates classes to use the new `Result::idTableView()` interface, where that change is trivial and mechanical. The following operations were updated: `Bind`, `CountAvailablePredicates`, `Join`, `Minus`, `MultiColumnJoin`, `OptionalJoin`, `Union`. Notes:

1. Great care was taken to also pass the `IdTableView<0>` by `const&` wherever possible. Copying them is much cheaper than for a fully materialized `IdTable`, but far from being free
2. A new function `Result::cloneIdTable` was introduced and used to make the places where the materialized results must be copied more visible. Currently, this is only used in `Bind`; note that the deep copy was already in place before this change
3. A new `CPP_concept` `IdTableLike` is introduced that can be used to constrain templates to any of `IdTable`, `IdTableView`, `IdTableStatic`, etc., as these types all share a common interface