### PR TITLE
Change code to be more compatible with `libc++`

### DIFF
--- a/src/parser/RdfParser.cpp
+++ b/src/parser/RdfParser.cpp
@@ -340,9 +340,10 @@ void TurtleParser<T>::parseDoubleConstant(std::string_view input) {
   if (ql::starts_with(input, '+')) {
     input.remove_prefix(1);
   }
+  const char* end = input.data() + input.size();
   auto [firstNonMatching, errorCode] =
-      absl::from_chars(input.data(), input.data() + input.size(), result);
-  if (firstNonMatching != input.end() || errorCode != std::errc{}) {
+      absl::from_chars(input.data(), end, result);
+  if (firstNonMatching != end || errorCode != std::errc{}) {
     auto errorMessage = absl::StrCat(
         "Value ", input, " could not be parsed as a floating point value");
     raiseOrIgnoreTriple(errorMessage);
@@ -378,7 +379,7 @@ void TurtleParser<T>::parseIntegerConstant(std::string_view input) {
           "\"parser-integer-overflow-behavior\"");
       raiseOrIgnoreTriple(errorMessage);
     }
-  } else if (firstNonMatching != input.end()) {
+  } else if (firstNonMatching != input.data() + input.size()) {
     auto errorMessage = absl::StrCat(
         "Value ", input, " could not be parsed as an integer value");
     raiseOrIgnoreTriple(errorMessage);
@@ -944,7 +945,7 @@ RdfStreamParser<T>::backupState() const {
   TurtleParserBackupState b;
   b.numBlankNodes_ = this->numBlankNodes_;
   b.numTriples_ = this->triples_.size();
-  b.tokenizerPosition_ = this->tok_.data().begin();
+  b.tokenizerPosition_ = this->tok_.data().data();
   b.tokenizerSize_ = this->tok_.data().size();
   return b;
 }
@@ -976,7 +977,7 @@ bool RdfStreamParser<T>::resetStateAndRead(
   // function "raise").
   numBytesBeforeCurrentBatch_ += byteVec_.size() - tok_.data().size();
   buf.resize(tok_.data().size() + nextBytes.size());
-  memcpy(buf.data(), tok_.data().begin(), tok_.data().size());
+  memcpy(buf.data(), tok_.data().data(), tok_.data().size());
   memcpy(buf.data() + tok_.data().size(), nextBytes.data(), nextBytes.size());
   byteVec_ = std::move(buf);
   tok_.reset(byteVec_.data(), byteVec_.size());

--- a/src/parser/RdfParser.h
+++ b/src/parser/RdfParser.h
@@ -521,7 +521,9 @@ CPP_template(typename Parser)(requires ql::concepts::derived_from<
   // return the current position of the tokenizer in the input string
   // can be used to test if the advancing of the tokenizer works
   // as expected
-  size_t getPosition() const { return this->tok_.begin() - tmpToParse_.data(); }
+  size_t getPosition() const {
+    return this->tok_.data().data() - tmpToParse_.data();
+  }
 
   // Disable use of @base, @prefix and multiline string literals for turtle
   // parsers during parallel parsing.

--- a/src/parser/Tokenizer.cpp
+++ b/src/parser/Tokenizer.cpp
@@ -26,7 +26,7 @@ std::tuple<bool, size_t, std::string> Tokenizer::getNextToken(
 
   // we have to remember the current position of data so we can rewind after a
   // successful match
-  const char* beg = _data.begin();
+  const char* beg = _data.data();
   size_t dataSize = _data.size();
 
   for (size_t i = 0; i < regs.size(); i++) {

--- a/src/parser/Tokenizer.h
+++ b/src/parser/Tokenizer.h
@@ -299,7 +299,7 @@ class Tokenizer : public SkipWhitespaceAndCommentsMixin<Tokenizer> {
 
   template <TurtleTokenId fst, TurtleTokenId... ids>
   std::tuple<bool, size_t, std::string_view> getNextTokenMultiple() {
-    const char* beg = _data.begin();
+    const char* beg = _data.data();
     size_t dataSize = _data.size();
 
     auto innerResult = getNextTokenRecurse<0, fst, ids...>();
@@ -320,7 +320,7 @@ class Tokenizer : public SkipWhitespaceAndCommentsMixin<Tokenizer> {
     // TODO<joka921> : write unit tests for this Overload!!
     const auto [success, unusedIdx, content] =
         getNextTokenRecurse<idx + 1, ids...>();
-    const char* beg = _data.begin();
+    const char* beg = _data.data();
     size_t dataSize = _data.size();
     const auto [currentSuccess, res] = getNextToken<fst>();
     reset(beg, dataSize);

--- a/src/parser/TokenizerCtre.h
+++ b/src/parser/TokenizerCtre.h
@@ -188,7 +188,7 @@ class TokenizerCtre : public SkipWhitespaceAndCommentsMixin<TokenizerCtre> {
    */
   template <TurtleTokenId fst, TurtleTokenId... ids>
   std::tuple<bool, size_t, std::string_view> getNextTokenMultiple() {
-    const char* beg = _data.begin();
+    const char* beg = _data.data();
     size_t dataSize = _data.size();
 
     auto innerResult = getNextTokenRecurse<0, fst, ids...>();
@@ -322,7 +322,7 @@ class TokenizerCtre : public SkipWhitespaceAndCommentsMixin<TokenizerCtre> {
   std::tuple<bool, size_t, std::string_view> getNextTokenRecurse() {
     const auto [success, unusedIdx, content] =
         getNextTokenRecurse<idx + 1, ids...>();
-    const char* beg = _data.begin();
+    const char* beg = _data.data();
     size_t dataSize = _data.size();
     const auto [currentSuccess, res] = getNextToken<fst>();
     reset(beg, dataSize);

--- a/src/parser/WordsAndDocsFileParser.h
+++ b/src/parser/WordsAndDocsFileParser.h
@@ -117,7 +117,7 @@ struct LiteralsTokenizationDelimiter {
         return text.substr(oldPos, pos - oldPos);
       }
     }
-    return {text.end(), 0};
+    return text.substr(text.size());
   }
 };
 

--- a/src/rdfTypes/RdfEscaping.cpp
+++ b/src/rdfTypes/RdfEscaping.cpp
@@ -90,8 +90,12 @@ void unescapeStringAndNumericEscapes(std::string_view input,
                                                            size_t length) {
     if constexpr (!acceptOnlyBackslashAndNewline) {
       AD_CONTRACT_CHECK(iterator + length <= endIterator);
+      // Use `&*iterator` to obtain a raw pointer rather than passing the
+      // iterator directly: newer libc++ wraps the string-view iterator in
+      // `__wrap_iter` and no longer converts it implicitly to `const char*`.
+      // `length` is always positive here, so dereferencing is safe.
       auto unesc =
-          hexadecimalCharactersToUtf8(std::string_view(iterator, length));
+          hexadecimalCharactersToUtf8(std::string_view(&*iterator, length));
       std::copy(unesc.begin(), unesc.end(), outputIterator);
     } else {
       (void)outputIterator;

--- a/src/util/MemorySize/MemorySize.cpp
+++ b/src/util/MemorySize/MemorySize.cpp
@@ -83,7 +83,8 @@ MemorySize MemorySize::parse(std::string_view str) {
     // `std::from_chars` which is currently not supported by the standard
     // library used by our macOS build.
     double amount;
-    absl::from_chars(amountString.begin(), amountString.end(), amount);
+    absl::from_chars(amountString.data(),
+                     amountString.data() + amountString.size(), amount);
     auto unitString = matcher.get<unitGroup>().to_view();
     switch (std::tolower(unitString.at(0))) {
       case 'b':

--- a/src/util/StringUtils.h
+++ b/src/util/StringUtils.h
@@ -11,6 +11,7 @@
 #include "backports/algorithm.h"
 #include "backports/iterator.h"
 #include "backports/keywords.h"
+#include "backports/span.h"
 #include "util/Concepts.h"
 #include "util/ConstexprSmallString.h"
 
@@ -161,13 +162,13 @@ std::string insertThousandSeparator(const std::string_view str,
 // and compare the hashes instead of the actual strings.
 inline QL_CONSTEXPR bool constantTimeEquals(std::string_view view1,
                                             std::string_view view2) {
-  using byte_view = std::basic_string_view<volatile std::byte>;
+  using byte_view = ql::span<const volatile std::byte>;
   auto impl = [](byte_view str1, byte_view str2) {
-    if (str1.length() != str2.length()) {
+    if (str1.size() != str2.size()) {
       return false;
     }
     volatile std::byte mismatchFound{0};
-    for (size_t i = 0; i < str1.length(); ++i) {
+    for (size_t i = 0; i < str1.size(); ++i) {
       // In C++20 compound assignment of volatile variables causes a warning,
       // so we can't use 'mismatchFound |=' until compiling with C++23 where it
       // is fine again. mismatchFound can be interpreted as bool and "is false"
@@ -180,9 +181,9 @@ inline QL_CONSTEXPR bool constantTimeEquals(std::string_view view1,
     // Casting is safe because both types have the same size
     static_assert(sizeof(std::string_view::value_type) ==
                   sizeof(byte_view::value_type));
-    return {
-        static_cast<const std::byte*>(static_cast<const void*>(view.data())),
-        view.size()};
+    return byte_view(static_cast<const volatile std::byte*>(
+                         static_cast<const void*>(view.data())),
+                     view.size());
   };
   return impl(toVolatile(view1), toVolatile(view2));
 }

--- a/src/util/StringUtilsImpl.h
+++ b/src/util/StringUtilsImpl.h
@@ -82,25 +82,21 @@ std::string insertThousandSeparator(const std::string_view str,
   static constexpr ctll::fixed_string regexPatDigitSequence{
       "(?:^|[^\\d" + adjustFloatingPointSignifierForRegex() +
       "])(?<digit>\\d{4,})"};
-  auto parseIterator = std::begin(str);
+  const char* parsePointer = str.data();
   ql::ranges::for_each(
       ctre::search_all<regexPatDigitSequence>(str),
-      [&parseIterator, &ostream, &insertSeparator](const auto& match) {
-        /*
-        The digit sequence, that must be transformed. Note: The string view
-        iterators point to entries in the `str` string.
-        */
-        const std::string_view& digitSequence{
-            match.template get<detail::digitCaptureGroup>()};
+      [&parsePointer, &ostream, &insertSeparator](const auto& match) {
+        auto digitSequence =
+            match.template get<detail::digitCaptureGroup>().to_view();
 
         // Insert the transformed digit sequence, and the string between it
-        // and the `parseIterator`, into the stream.
-        ostream << std::string_view(parseIterator,
-                                    std::begin(digitSequence) - parseIterator);
+        // and the `parsePointer`, into the stream.
+        ostream << std::string_view(parsePointer,
+                                    digitSequence.data() - parsePointer);
         insertSeparator(digitSequence);
-        parseIterator = std::end(digitSequence);
+        parsePointer = digitSequence.data() + digitSequence.size();
       });
-  ostream << std::string_view(parseIterator, std::end(str) - parseIterator);
+  ostream << str.substr(parsePointer - str.data());
   return ostream.str();
 }
 

--- a/test/TokenTest.cpp
+++ b/test/TokenTest.cpp
@@ -355,28 +355,28 @@ TEST(TokenizerTest, WhitespaceAndComments) {
     std::string s2("#only Comment\n");
     Tokenizer tok(s2);
     tok.skipComments();
-    ASSERT_EQ(tok.data().begin() - s2.data(), 14);
+    ASSERT_EQ(tok.data().data() - s2.data(), 14);
     std::string s("    #comment of some way\n  start");
     tok.reset(s.data(), s.size());
     auto [success2, ws] = tok.getNextToken(tok._tokens.Comment);
     (void)ws;
     ASSERT_FALSE(success2);
     tok.skipWhitespaceAndComments();
-    ASSERT_EQ(tok.data().begin() - s.data(), 27);
+    ASSERT_EQ(tok.data().data() - s.data(), 27);
   }
 
   {
     std::string s2("#only Comment\n");
     TokenizerCtre tok(s2);
     tok.skipComments();
-    ASSERT_EQ(tok.data().begin() - s2.data(), 14);
+    ASSERT_EQ(tok.data().data() - s2.data(), 14);
     std::string s("    #comment of some way\n  start");
     tok.reset(s.data(), s.size());
     auto [success2, ws] = tok.getNextToken<TurtleTokenId::Comment>();
     (void)ws;
     ASSERT_FALSE(success2);
     tok.skipWhitespaceAndComments();
-    ASSERT_EQ(tok.data().begin() - s.data(), 27);
+    ASSERT_EQ(tok.data().data() - s.data(), 27);
   }
 }
 


### PR DESCRIPTION
This is a subset of #2849 that increases the compatibility with `libc++` (the standard library of LLVM). In particular:

* In `libc++`, `std::string_view::begin()` and `end()` do not return a `const char*` but a wrapped iterator type, so `.data()` has to be used wherever a raw `const char*` is required (for example, for `std::from_chars`).
* `libc++` provides no `char_traits` for non-`char` types, so `std::basic_string_view<std::byte>` is replaced by a `span<std::byte>`. NOTE: This PR does not yet address all instances of this second issue; for the remaining ones there are several possible solutions (some uglier than others), which will be handled in a follow-up.

NOTE: This change does not alter any behavior; it only replaces non-portable uses of the standard library by portable ones.