### PR TITLE
Migrate join, path, and spatial-join call sites to `Result::idTableView()`

### DIFF
--- a/src/engine/Operation.cpp
+++ b/src/engine/Operation.cpp
@@ -470,7 +470,7 @@ void Operation::storeToNamedResultCache(const Result& result) {
                         .at(geoIndexVar.value())
                         .columnIndex_;
     return SpatialJoinCachedIndex{geoIndexVar.value(), colIndex,
-                                  result.idTable(),
+                                  result.idTableView(),
                                   _executionContext->getIndex()};
   };
 

--- a/src/engine/PathSearch.cpp
+++ b/src/engine/PathSearch.cpp
@@ -21,7 +21,7 @@
 using namespace pathSearch;
 
 // _____________________________________________________________________________
-BinSearchWrapper::BinSearchWrapper(const IdTable& table, size_t startCol,
+BinSearchWrapper::BinSearchWrapper(const IdTableView<0>& table, size_t startCol,
                                    size_t endCol, std::vector<size_t> edgeCols)
     : table_(table),
       startCol_(startCol),
@@ -234,7 +234,7 @@ Result PathSearch::computeResult([[maybe_unused]] bool requestLaziness) {
   IdTable idTable{allocator()};
   idTable.setNumColumns(getResultWidth());
 
-  const IdTable& dynSub = subRes->idTable();
+  const IdTableView<0> dynSub = subRes->idTableView();
   if (!dynSub.empty()) {
     auto timer = ad_utility::Timer(ad_utility::Timer::Started);
 

--- a/src/engine/PathSearch.cpp
+++ b/src/engine/PathSearch.cpp
@@ -234,7 +234,7 @@ Result PathSearch::computeResult([[maybe_unused]] bool requestLaziness) {
   IdTable idTable{allocator()};
   idTable.setNumColumns(getResultWidth());
 
-  const IdTableView<0> dynSub = subRes->idTableView();
+  const IdTableView<0>& dynSub = subRes->idTableView();
   if (!dynSub.empty()) {
     auto timer = ad_utility::Timer(ad_utility::Timer::Started);
 
@@ -302,13 +302,13 @@ PathSearch::handleSearchSides() const {
 
   if (sourceAndTargetTree_.has_value()) {
     auto resultTable = sourceAndTargetTree_.value()->getResult();
-    sourceIds = resultTable->idTable().getColumn(sourceCol_.value());
-    targetIds = resultTable->idTable().getColumn(targetCol_.value());
+    sourceIds = resultTable->idTableView().getColumn(sourceCol_.value());
+    targetIds = resultTable->idTableView().getColumn(targetCol_.value());
     return {sourceIds, targetIds};
   }
 
   if (sourceTree_.has_value()) {
-    sourceIds = sourceTree_.value()->getResult()->idTable().getColumn(
+    sourceIds = sourceTree_.value()->getResult()->idTableView().getColumn(
         sourceCol_.value());
   } else if (config_.sourceIsVariable()) {
     sourceIds = {};
@@ -317,7 +317,7 @@ PathSearch::handleSearchSides() const {
   }
 
   if (targetTree_.has_value()) {
-    targetIds = targetTree_.value()->getResult()->idTable().getColumn(
+    targetIds = targetTree_.value()->getResult()->idTableView().getColumn(
         targetCol_.value());
   } else if (config_.targetIsVariable()) {
     targetIds = {};

--- a/src/engine/PathSearch.h
+++ b/src/engine/PathSearch.h
@@ -58,13 +58,13 @@ using PathsLimited = std::vector<Path, ad_utility::AllocatorWithLimit<Path>>;
  *
  */
 class BinSearchWrapper {
-  const IdTable& table_;
+  IdTableView<0> table_;
   size_t startCol_;
   size_t endCol_;
   std::vector<size_t> edgeCols_;
 
  public:
-  BinSearchWrapper(const IdTable& table, size_t startCol, size_t endCol,
+  BinSearchWrapper(const IdTableView<0>& table, size_t startCol, size_t endCol,
                    std::vector<size_t> edgeCols);
 
   /**

--- a/src/engine/PathSearch.h
+++ b/src/engine/PathSearch.h
@@ -58,7 +58,7 @@ using PathsLimited = std::vector<Path, ad_utility::AllocatorWithLimit<Path>>;
  *
  */
 class BinSearchWrapper {
-  IdTableView<0> table_;
+  const IdTableView<0>& table_;
   size_t startCol_;
   size_t endCol_;
   std::vector<size_t> edgeCols_;

--- a/src/engine/SpatialJoin.cpp
+++ b/src/engine/SpatialJoin.cpp
@@ -463,8 +463,8 @@ VariableToColumnMap SpatialJoin::getVarColMapPayloadVars() const {
 PreparedSpatialJoinParams SpatialJoin::prepareJoin() const {
   auto getIdTable = [](std::shared_ptr<QueryExecutionTree> child) {
     std::shared_ptr<const Result> resTable = child->getResult();
-    auto idTablePtr = &resTable->idTable();
-    return std::pair{idTablePtr, std::move(resTable)};
+    IdTableView<0> view = resTable->idTableView();
+    return std::pair{view, std::move(resTable)};
   };
 
   // Swap sides for within spatial join type computed using contains

--- a/src/engine/SpatialJoin.cpp
+++ b/src/engine/SpatialJoin.cpp
@@ -463,8 +463,8 @@ VariableToColumnMap SpatialJoin::getVarColMapPayloadVars() const {
 PreparedSpatialJoinParams SpatialJoin::prepareJoin() const {
   auto getIdTable = [](std::shared_ptr<QueryExecutionTree> child) {
     std::shared_ptr<const Result> resTable = child->getResult();
-    IdTableView<0> view = resTable->idTableView();
-    return std::pair{view, std::move(resTable)};
+    auto idTablePtr = &resTable->idTableView();
+    return std::pair{idTablePtr, std::move(resTable)};
   };
 
   // Swap sides for within spatial join type computed using contains

--- a/src/engine/SpatialJoin.h
+++ b/src/engine/SpatialJoin.h
@@ -26,9 +26,9 @@ using SpatialJoinBoundingBoxColumns =
 
 // helper struct to improve readability in prepareJoin()
 struct PreparedSpatialJoinParams {
-  const IdTable* const idTableLeft_;
+  IdTableView<0> idTableLeft_;
   std::shared_ptr<const Result> resultLeft_;
-  const IdTable* const idTableRight_;
+  IdTableView<0> idTableRight_;
   std::shared_ptr<const Result> resultRight_;
   ColumnIndex leftJoinCol_;
   ColumnIndex rightJoinCol_;

--- a/src/engine/SpatialJoin.h
+++ b/src/engine/SpatialJoin.h
@@ -26,9 +26,9 @@ using SpatialJoinBoundingBoxColumns =
 
 // helper struct to improve readability in prepareJoin()
 struct PreparedSpatialJoinParams {
-  IdTableView<0> idTableLeft_;
+  const IdTableView<0>* const idTableLeft_;
   std::shared_ptr<const Result> resultLeft_;
-  IdTableView<0> idTableRight_;
+  const IdTableView<0>* const idTableRight_;
   std::shared_ptr<const Result> resultRight_;
   ColumnIndex leftJoinCol_;
   ColumnIndex rightJoinCol_;

--- a/src/engine/SpatialJoinAlgorithms.cpp
+++ b/src/engine/SpatialJoinAlgorithms.cpp
@@ -119,7 +119,7 @@ SpatialJoinAlgorithms::libspatialjoinParse(
   static constexpr auto batchSize =
       ad_utility::detail::parallel_wkt_parser::WKT_PARSER_BATCH_SIZE;
   static_assert(batchSize > 0);
-  size_t requiredBatches = (idTable.size() + batchSize - 1ULL) / batchSize;
+  size_t requiredBatches = (idTable->size() + batchSize - 1ULL) / batchSize;
   numThreads = std::min(numThreads, requiredBatches);
 
   // Initialize the parser.
@@ -129,9 +129,9 @@ SpatialJoinAlgorithms::libspatialjoinParse(
 
   // Iterate over all rows in `idTable` and add the geometries from `column`
   // to the parallel WKT parser.
-  const auto& geoms = idTable.getColumn(column);
+  const auto& geoms = idTable->getColumn(column);
   ad_utility::chunkedForLoop<wktParserChunkSizeForCancellationCheck>(
-      0, idTable.size(),
+      0, idTable->size(),
       [&parser, &geoms, &leftOrRightSide, &idTable,
        &boundingBoxes](size_t row) {
         parser.addValueIdToQueue(
@@ -145,20 +145,20 @@ SpatialJoinAlgorithms::libspatialjoinParse(
   parser.done();
 
   auto numGeomsDropped = parser.getPrefilterCounter();
-  auto numGeomsParsed = idTable.size() - numGeomsDropped;
+  auto numGeomsParsed = idTable->size() - numGeomsDropped;
   return {parser.getBoundingBox(), numGeomsParsed, numGeomsDropped, numThreads};
 }
 
 // ____________________________________________________________________________
 std::optional<ad_utility::BoundingBox>
 SpatialJoinAlgorithms::getBoundingBoxFromIdTable(
-    const IdTableView<0>& idTable,
+    const IdTableView<0>* idTable,
     const SpatialJoinBoundingBoxColumns& boundingBoxes, size_t row) {
   if (!boundingBoxes.has_value()) {
     return std::nullopt;
   }
-  auto idLowerLeft = idTable.at(row, boundingBoxes.value().first);
-  auto idUpperRight = idTable.at(row, boundingBoxes.value().second);
+  auto idLowerLeft = idTable->at(row, boundingBoxes.value().first);
+  auto idUpperRight = idTable->at(row, boundingBoxes.value().second);
   if (idLowerLeft.getDatatype() != Datatype::GeoPoint ||
       idUpperRight.getDatatype() != Datatype::GeoPoint) {
     return std::nullopt;
@@ -180,8 +180,8 @@ size_t SpatialJoinAlgorithms::getNumThreads() {
 
 // ____________________________________________________________________________
 std::optional<GeoPoint> SpatialJoinAlgorithms::getPoint(
-    const IdTableView<0>& restable, size_t row, ColumnIndex col) {
-  auto id = restable.at(row, col);
+    const IdTableView<0>* restable, size_t row, ColumnIndex col) {
+  auto id = restable->at(row, col);
   return id.getDatatype() == Datatype::GeoPoint
              ? std::optional{id.getGeoPoint()}
              : std::nullopt;
@@ -219,7 +219,7 @@ std::string_view SpatialJoinAlgorithms::betweenQuotes(
 }
 
 std::optional<size_t> SpatialJoinAlgorithms::getAnyGeometry(
-    const IdTableView<0>& idtable, size_t row, size_t col) {
+    const IdTableView<0>* idtable, size_t row, size_t col) {
 #ifdef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
   throw std::runtime_error("not supported in C++17 mode currently");
 #else
@@ -246,7 +246,7 @@ std::optional<size_t> SpatialJoinAlgorithms::getAnyGeometry(
   // precision), and then the full geometry would only need to be read, when
   // the exact distance is wanted
   std::string str(betweenQuotes(ql::exportIds::idToStringAndType(
-                                    qec_->getIndex(), idtable.at(row, col), {})
+                                    qec_->getIndex(), idtable->at(row, col), {})
                                     .value()
                                     .first));
   AnyGeometry geometry;
@@ -309,23 +309,23 @@ Id SpatialJoinAlgorithms::computeDist(RtreeEntry& geo1, RtreeEntry& geo2) {
 
 // ____________________________________________________________________________
 void SpatialJoinAlgorithms::addResultTableEntry(
-    IdTable* result, const IdTableView<0>& idTableLeft,
-    const IdTableView<0>& idTableRight, size_t rowLeft, size_t rowRight,
+    IdTable* result, const IdTableView<0>* idTableLeft,
+    const IdTableView<0>* idTableRight, size_t rowLeft, size_t rowRight,
     Id distance) const {
   // this lambda function copies values from copyFrom into the table res only if
   // the column of the value is specified in sourceColumns. If sourceColumns is
   // nullopt, all columns are added. It copies them into the row rowIndRes and
   // column column colIndRes. It returns the column number until which elements
   // were copied
-  auto addColumns = [](IdTable* res, const IdTableView<0>& copyFrom,
+  auto addColumns = [](IdTable* res, const IdTableView<0>* copyFrom,
                        size_t rowIndRes, size_t colIndRes, size_t rowIndCopy,
                        std::optional<std::vector<ColumnIndex>> sourceColumns =
                            std::nullopt) {
     size_t nCols = sourceColumns.has_value() ? sourceColumns.value().size()
-                                             : copyFrom.numColumns();
+                                             : copyFrom->numColumns();
     for (size_t i = 0; i < nCols; i++) {
       auto col = sourceColumns.has_value() ? sourceColumns.value()[i] : i;
-      res->at(rowIndRes, colIndRes + i) = copyFrom.at(rowIndCopy, col);
+      res->at(rowIndRes, colIndRes + i) = (*copyFrom).at(rowIndCopy, col);
     }
     return colIndRes + nCols;
   };
@@ -361,7 +361,7 @@ Result SpatialJoinAlgorithms::BaselineAlgorithm() {
 
   // cartesian product between the two tables, pairs are restricted according to
   // `maxDistance_` and `maxResults_`
-  for (size_t rowLeft = 0; rowLeft < idTableLeft.size(); rowLeft++) {
+  for (size_t rowLeft = 0; rowLeft < idTableLeft->size(); rowLeft++) {
     // This priority queue stores the intermediate best results if `maxResults_`
     // is used. Each intermediate result is stored as a pair of its `rowRight`
     // and distance. Since the queue will hold at most `maxResults_ + 1` items,
@@ -378,7 +378,7 @@ Result SpatialJoinAlgorithms::BaselineAlgorithm() {
     auto entryLeft = getRtreeEntry(idTableLeft, rowLeft, leftJoinCol);
 
     // Inner loop of cartesian product
-    for (size_t rowRight = 0; rowRight < idTableRight.size(); rowRight++) {
+    for (size_t rowRight = 0; rowRight < idTableRight->size(); rowRight++) {
       auto entryRight = getRtreeEntry(idTableRight, rowRight, rightJoinCol);
 
       if (!entryLeft || !entryRight) {
@@ -558,7 +558,7 @@ Result SpatialJoinAlgorithms::LibspatialjoinAlgorithm() {
   LibSpatialJoinParseInput rightTableAndCol{idTableRight, rightJoinCol,
                                             bbRight};
   bool nonEmptyChildren =
-      idTableLeft.size() < idTableRight.size()
+      idTableLeft->size() < idTableRight->size()
           ? runParser(leftTableAndCol, rightTableAndCol, false)
           : runParser(rightTableAndCol, leftTableAndCol, true);
 
@@ -620,12 +620,12 @@ Result SpatialJoinAlgorithms::S2geometryAlgorithm() {
   // Optimization: If we only search by maximum distance, the operation is
   // symmetric, so the larger table can be used for the index
   bool indexOfRight =
-      (maxResults.has_value() || (idTableLeft.size() > idTableRight.size()));
+      (maxResults.has_value() || (idTableLeft->size() > idTableRight->size()));
   auto indexTable = indexOfRight ? idTableRight : idTableLeft;
   auto indexJoinCol = indexOfRight ? rightJoinCol : leftJoinCol;
 
   // Populate the index
-  for (size_t row = 0; row < indexTable.size(); row++) {
+  for (size_t row = 0; row < indexTable->size(); row++) {
     auto p = getPoint(indexTable, row, indexJoinCol);
     if (p.has_value()) {
       s2index.Add(toS2Point(p.value()), row);
@@ -649,7 +649,7 @@ Result SpatialJoinAlgorithms::S2geometryAlgorithm() {
   auto searchTable = indexOfRight ? idTableLeft : idTableRight;
   auto searchJoinCol = indexOfRight ? leftJoinCol : rightJoinCol;
   // Use the index to lookup the points of the other table
-  for (size_t searchRow = 0; searchRow < searchTable.size(); searchRow++) {
+  for (size_t searchRow = 0; searchRow < searchTable->size(); searchRow++) {
     auto p = getPoint(searchTable, searchRow, searchJoinCol);
     if (!p.has_value()) {
       continue;
@@ -698,7 +698,7 @@ Result SpatialJoinAlgorithms::S2PointPolylineAlgorithm() {
   ad_utility::Timer timerWrite{ad_utility::Timer::Stopped};
 
   // Use the index to lookup the points of the other table
-  for (size_t rowLeft = 0; rowLeft < idTableLeft.size(); rowLeft++) {
+  for (size_t rowLeft = 0; rowLeft < idTableLeft->size(); rowLeft++) {
     auto p = getPoint(idTableLeft, rowLeft, leftJoinCol);
     if (!p.has_value()) {
       continue;
@@ -958,7 +958,7 @@ double SpatialJoinAlgorithms::getMaxDistFromMidpointToAnyPointInsideTheBox(
 
 // ____________________________________________________________________________
 std::optional<RtreeEntry> SpatialJoinAlgorithms::getRtreeEntry(
-    const IdTableView<0>& idTable, const size_t row, const ColumnIndex col) {
+    const IdTableView<0>* idTable, const size_t row, const ColumnIndex col) {
 #ifdef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
   throw std::runtime_error("getRtreeEntry is not supported in this build");
 #else
@@ -1028,7 +1028,7 @@ Result SpatialJoinAlgorithms::BoundingBoxAlgorithm() {
   bool leftResSmaller = true;
   auto smallerResJoinCol = leftJoinCol;
   auto otherResJoinCol = rightJoinCol;
-  if (idTableLeft.numRows() > idTableRight.numRows()) {
+  if (idTableLeft->numRows() > idTableRight->numRows()) {
     std::swap(smallerResult, otherResult);
     leftResSmaller = false;
     std::swap(smallerResJoinCol, otherResJoinCol);
@@ -1039,7 +1039,7 @@ Result SpatialJoinAlgorithms::BoundingBoxAlgorithm() {
              bgi::equal_to<Value>, ad_utility::AllocatorWithLimit<Value>>
       rtree(bgi::quadratic<16>{}, bgi::indexable<Value>{},
             bgi::equal_to<Value>{}, qec_->getAllocator());
-  for (size_t i = 0; i < smallerResult.numRows(); i++) {
+  for (size_t i = 0; i < smallerResult->numRows(); i++) {
     throwIfCancelled();
 
     // add every box together with the additional information into the rtree
@@ -1058,7 +1058,7 @@ Result SpatialJoinAlgorithms::BoundingBoxAlgorithm() {
   // query rtree with the other child
   std::vector<Value, ad_utility::AllocatorWithLimit<Value>> results{
       qec_->getAllocator()};
-  for (size_t i = 0; i < otherResult.numRows(); i++) {
+  for (size_t i = 0; i < otherResult->numRows(); i++) {
     throwIfCancelled();
 
     std::optional<RtreeEntry> entry =

--- a/src/engine/SpatialJoinAlgorithms.cpp
+++ b/src/engine/SpatialJoinAlgorithms.cpp
@@ -119,7 +119,7 @@ SpatialJoinAlgorithms::libspatialjoinParse(
   static constexpr auto batchSize =
       ad_utility::detail::parallel_wkt_parser::WKT_PARSER_BATCH_SIZE;
   static_assert(batchSize > 0);
-  size_t requiredBatches = (idTable->size() + batchSize - 1ULL) / batchSize;
+  size_t requiredBatches = (idTable.size() + batchSize - 1ULL) / batchSize;
   numThreads = std::min(numThreads, requiredBatches);
 
   // Initialize the parser.
@@ -129,9 +129,9 @@ SpatialJoinAlgorithms::libspatialjoinParse(
 
   // Iterate over all rows in `idTable` and add the geometries from `column`
   // to the parallel WKT parser.
-  const auto& geoms = idTable->getColumn(column);
+  const auto& geoms = idTable.getColumn(column);
   ad_utility::chunkedForLoop<wktParserChunkSizeForCancellationCheck>(
-      0, idTable->size(),
+      0, idTable.size(),
       [&parser, &geoms, &leftOrRightSide, &idTable,
        &boundingBoxes](size_t row) {
         parser.addValueIdToQueue(
@@ -145,20 +145,20 @@ SpatialJoinAlgorithms::libspatialjoinParse(
   parser.done();
 
   auto numGeomsDropped = parser.getPrefilterCounter();
-  auto numGeomsParsed = idTable->size() - numGeomsDropped;
+  auto numGeomsParsed = idTable.size() - numGeomsDropped;
   return {parser.getBoundingBox(), numGeomsParsed, numGeomsDropped, numThreads};
 }
 
 // ____________________________________________________________________________
 std::optional<ad_utility::BoundingBox>
 SpatialJoinAlgorithms::getBoundingBoxFromIdTable(
-    const IdTable* idTable, const SpatialJoinBoundingBoxColumns& boundingBoxes,
-    size_t row) {
+    const IdTableView<0>& idTable,
+    const SpatialJoinBoundingBoxColumns& boundingBoxes, size_t row) {
   if (!boundingBoxes.has_value()) {
     return std::nullopt;
   }
-  auto idLowerLeft = idTable->at(row, boundingBoxes.value().first);
-  auto idUpperRight = idTable->at(row, boundingBoxes.value().second);
+  auto idLowerLeft = idTable.at(row, boundingBoxes.value().first);
+  auto idUpperRight = idTable.at(row, boundingBoxes.value().second);
   if (idLowerLeft.getDatatype() != Datatype::GeoPoint ||
       idUpperRight.getDatatype() != Datatype::GeoPoint) {
     return std::nullopt;
@@ -179,10 +179,9 @@ size_t SpatialJoinAlgorithms::getNumThreads() {
 }
 
 // ____________________________________________________________________________
-std::optional<GeoPoint> SpatialJoinAlgorithms::getPoint(const IdTable* restable,
-                                                        size_t row,
-                                                        ColumnIndex col) {
-  auto id = restable->at(row, col);
+std::optional<GeoPoint> SpatialJoinAlgorithms::getPoint(
+    const IdTableView<0>& restable, size_t row, ColumnIndex col) {
+  auto id = restable.at(row, col);
   return id.getDatatype() == Datatype::GeoPoint
              ? std::optional{id.getGeoPoint()}
              : std::nullopt;
@@ -190,7 +189,8 @@ std::optional<GeoPoint> SpatialJoinAlgorithms::getPoint(const IdTable* restable,
 
 // ____________________________________________________________________________
 std::optional<S2Polyline> SpatialJoinAlgorithms::getPolyline(
-    const IdTable& restable, size_t row, ColumnIndex col, const Index& index) {
+    const IdTableView<0>& restable, size_t row, ColumnIndex col,
+    const Index& index) {
   using namespace util::geo;
   auto id = restable.at(row, col);
   auto str = ql::exportIds::idToStringAndType(index, id, {});
@@ -219,7 +219,7 @@ std::string_view SpatialJoinAlgorithms::betweenQuotes(
 }
 
 std::optional<size_t> SpatialJoinAlgorithms::getAnyGeometry(
-    const IdTable* idtable, size_t row, size_t col) {
+    const IdTableView<0>& idtable, size_t row, size_t col) {
 #ifdef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
   throw std::runtime_error("not supported in C++17 mode currently");
 #else
@@ -246,7 +246,7 @@ std::optional<size_t> SpatialJoinAlgorithms::getAnyGeometry(
   // precision), and then the full geometry would only need to be read, when
   // the exact distance is wanted
   std::string str(betweenQuotes(ql::exportIds::idToStringAndType(
-                                    qec_->getIndex(), idtable->at(row, col), {})
+                                    qec_->getIndex(), idtable.at(row, col), {})
                                     .value()
                                     .first));
   AnyGeometry geometry;
@@ -308,25 +308,24 @@ Id SpatialJoinAlgorithms::computeDist(RtreeEntry& geo1, RtreeEntry& geo2) {
 }
 
 // ____________________________________________________________________________
-void SpatialJoinAlgorithms::addResultTableEntry(IdTable* result,
-                                                const IdTable* idTableLeft,
-                                                const IdTable* idTableRight,
-                                                size_t rowLeft, size_t rowRight,
-                                                Id distance) const {
+void SpatialJoinAlgorithms::addResultTableEntry(
+    IdTable* result, const IdTableView<0>& idTableLeft,
+    const IdTableView<0>& idTableRight, size_t rowLeft, size_t rowRight,
+    Id distance) const {
   // this lambda function copies values from copyFrom into the table res only if
   // the column of the value is specified in sourceColumns. If sourceColumns is
   // nullopt, all columns are added. It copies them into the row rowIndRes and
   // column column colIndRes. It returns the column number until which elements
   // were copied
-  auto addColumns = [](IdTable* res, const IdTable* copyFrom, size_t rowIndRes,
-                       size_t colIndRes, size_t rowIndCopy,
+  auto addColumns = [](IdTable* res, const IdTableView<0>& copyFrom,
+                       size_t rowIndRes, size_t colIndRes, size_t rowIndCopy,
                        std::optional<std::vector<ColumnIndex>> sourceColumns =
                            std::nullopt) {
     size_t nCols = sourceColumns.has_value() ? sourceColumns.value().size()
-                                             : copyFrom->numColumns();
+                                             : copyFrom.numColumns();
     for (size_t i = 0; i < nCols; i++) {
       auto col = sourceColumns.has_value() ? sourceColumns.value()[i] : i;
-      res->at(rowIndRes, colIndRes + i) = (*copyFrom).at(rowIndCopy, col);
+      res->at(rowIndRes, colIndRes + i) = copyFrom.at(rowIndCopy, col);
     }
     return colIndRes + nCols;
   };
@@ -362,7 +361,7 @@ Result SpatialJoinAlgorithms::BaselineAlgorithm() {
 
   // cartesian product between the two tables, pairs are restricted according to
   // `maxDistance_` and `maxResults_`
-  for (size_t rowLeft = 0; rowLeft < idTableLeft->size(); rowLeft++) {
+  for (size_t rowLeft = 0; rowLeft < idTableLeft.size(); rowLeft++) {
     // This priority queue stores the intermediate best results if `maxResults_`
     // is used. Each intermediate result is stored as a pair of its `rowRight`
     // and distance. Since the queue will hold at most `maxResults_ + 1` items,
@@ -379,7 +378,7 @@ Result SpatialJoinAlgorithms::BaselineAlgorithm() {
     auto entryLeft = getRtreeEntry(idTableLeft, rowLeft, leftJoinCol);
 
     // Inner loop of cartesian product
-    for (size_t rowRight = 0; rowRight < idTableRight->size(); rowRight++) {
+    for (size_t rowRight = 0; rowRight < idTableRight.size(); rowRight++) {
       auto entryRight = getRtreeEntry(idTableRight, rowRight, rightJoinCol);
 
       if (!entryLeft || !entryRight) {
@@ -559,7 +558,7 @@ Result SpatialJoinAlgorithms::LibspatialjoinAlgorithm() {
   LibSpatialJoinParseInput rightTableAndCol{idTableRight, rightJoinCol,
                                             bbRight};
   bool nonEmptyChildren =
-      idTableLeft->size() < idTableRight->size()
+      idTableLeft.size() < idTableRight.size()
           ? runParser(leftTableAndCol, rightTableAndCol, false)
           : runParser(rightTableAndCol, leftTableAndCol, true);
 
@@ -621,12 +620,12 @@ Result SpatialJoinAlgorithms::S2geometryAlgorithm() {
   // Optimization: If we only search by maximum distance, the operation is
   // symmetric, so the larger table can be used for the index
   bool indexOfRight =
-      (maxResults.has_value() || (idTableLeft->size() > idTableRight->size()));
+      (maxResults.has_value() || (idTableLeft.size() > idTableRight.size()));
   auto indexTable = indexOfRight ? idTableRight : idTableLeft;
   auto indexJoinCol = indexOfRight ? rightJoinCol : leftJoinCol;
 
   // Populate the index
-  for (size_t row = 0; row < indexTable->size(); row++) {
+  for (size_t row = 0; row < indexTable.size(); row++) {
     auto p = getPoint(indexTable, row, indexJoinCol);
     if (p.has_value()) {
       s2index.Add(toS2Point(p.value()), row);
@@ -650,7 +649,7 @@ Result SpatialJoinAlgorithms::S2geometryAlgorithm() {
   auto searchTable = indexOfRight ? idTableLeft : idTableRight;
   auto searchJoinCol = indexOfRight ? leftJoinCol : rightJoinCol;
   // Use the index to lookup the points of the other table
-  for (size_t searchRow = 0; searchRow < searchTable->size(); searchRow++) {
+  for (size_t searchRow = 0; searchRow < searchTable.size(); searchRow++) {
     auto p = getPoint(searchTable, searchRow, searchJoinCol);
     if (!p.has_value()) {
       continue;
@@ -699,7 +698,7 @@ Result SpatialJoinAlgorithms::S2PointPolylineAlgorithm() {
   ad_utility::Timer timerWrite{ad_utility::Timer::Stopped};
 
   // Use the index to lookup the points of the other table
-  for (size_t rowLeft = 0; rowLeft < idTableLeft->size(); rowLeft++) {
+  for (size_t rowLeft = 0; rowLeft < idTableLeft.size(); rowLeft++) {
     auto p = getPoint(idTableLeft, rowLeft, leftJoinCol);
     if (!p.has_value()) {
       continue;
@@ -959,7 +958,7 @@ double SpatialJoinAlgorithms::getMaxDistFromMidpointToAnyPointInsideTheBox(
 
 // ____________________________________________________________________________
 std::optional<RtreeEntry> SpatialJoinAlgorithms::getRtreeEntry(
-    const IdTable* idTable, const size_t row, const ColumnIndex col) {
+    const IdTableView<0>& idTable, const size_t row, const ColumnIndex col) {
 #ifdef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
   throw std::runtime_error("getRtreeEntry is not supported in this build");
 #else
@@ -1029,7 +1028,7 @@ Result SpatialJoinAlgorithms::BoundingBoxAlgorithm() {
   bool leftResSmaller = true;
   auto smallerResJoinCol = leftJoinCol;
   auto otherResJoinCol = rightJoinCol;
-  if (idTableLeft->numRows() > idTableRight->numRows()) {
+  if (idTableLeft.numRows() > idTableRight.numRows()) {
     std::swap(smallerResult, otherResult);
     leftResSmaller = false;
     std::swap(smallerResJoinCol, otherResJoinCol);
@@ -1040,7 +1039,7 @@ Result SpatialJoinAlgorithms::BoundingBoxAlgorithm() {
              bgi::equal_to<Value>, ad_utility::AllocatorWithLimit<Value>>
       rtree(bgi::quadratic<16>{}, bgi::indexable<Value>{},
             bgi::equal_to<Value>{}, qec_->getAllocator());
-  for (size_t i = 0; i < smallerResult->numRows(); i++) {
+  for (size_t i = 0; i < smallerResult.numRows(); i++) {
     throwIfCancelled();
 
     // add every box together with the additional information into the rtree
@@ -1059,7 +1058,7 @@ Result SpatialJoinAlgorithms::BoundingBoxAlgorithm() {
   // query rtree with the other child
   std::vector<Value, ad_utility::AllocatorWithLimit<Value>> results{
       qec_->getAllocator()};
-  for (size_t i = 0; i < otherResult->numRows(); i++) {
+  for (size_t i = 0; i < otherResult.numRows(); i++) {
     throwIfCancelled();
 
     std::optional<RtreeEntry> entry =

--- a/src/engine/SpatialJoinAlgorithms.h
+++ b/src/engine/SpatialJoinAlgorithms.h
@@ -154,12 +154,12 @@ class SpatialJoinAlgorithms {
       const Box& box, std::optional<Point> midpoint = std::nullopt) const;
 
   // this function gets the string which represents the area from the idtable.
-  std::optional<size_t> getAnyGeometry(const IdTableView<0>& idtable,
+  std::optional<size_t> getAnyGeometry(const IdTableView<0>* idtable,
                                        size_t row, size_t col);
 
   // wrapper to access non const private function for testing
   std::optional<RtreeEntry> onlyForTestingGetRtreeEntry(
-      const IdTableView<0>& idTable, const size_t row, const ColumnIndex col) {
+      const IdTableView<0>* idTable, const size_t row, const ColumnIndex col) {
     return getRtreeEntry(idTable, row, col);
   }
 
@@ -181,7 +181,7 @@ class SpatialJoinAlgorithms {
   // number of geometries added. This function is only `public` for testing
   // purposes and should otherwise not be used outside of this class.
   struct LibSpatialJoinParseInput {
-    IdTableView<0> idTable_;
+    const IdTableView<0>* idTable_;
     ColumnIndex geomsCol_;
     SpatialJoinBoundingBoxColumns boundingBoxCols_;
   };
@@ -216,7 +216,7 @@ class SpatialJoinAlgorithms {
   // Helper for `libspatialjoinParse` to get the bounding box from an
   // `IdTable` if available.
   static std::optional<ad_utility::BoundingBox> getBoundingBoxFromIdTable(
-      const IdTableView<0>& idTable,
+      const IdTableView<0>* idTable,
       const SpatialJoinBoundingBoxColumns& boundingBoxes, size_t row);
 
   // Retrieve the number of threads to be used for `libspatialjoinParse` and
@@ -225,7 +225,7 @@ class SpatialJoinAlgorithms {
 
   // Helper function which returns a GeoPoint if the element of the given table
   // represents a GeoPoint
-  static std::optional<GeoPoint> getPoint(const IdTableView<0>& restable,
+  static std::optional<GeoPoint> getPoint(const IdTableView<0>* restable,
                                           size_t row, ColumnIndex col);
 
   // Helper function to retrieve and parse a line string from the given cell of
@@ -242,8 +242,8 @@ class SpatialJoinAlgorithms {
   // Helper function, which adds a row, which belongs to the result to the
   // result table. As inputs it uses a row of the left and a row of the right
   // child result table.
-  void addResultTableEntry(IdTable* result, const IdTableView<0>& resultLeft,
-                           const IdTableView<0>& resultRight, size_t rowLeft,
+  void addResultTableEntry(IdTable* result, const IdTableView<0>* resultLeft,
+                           const IdTableView<0>* resultRight, size_t rowLeft,
                            size_t rowRight, Id distance) const;
 
   // This helper function calculates the bounding boxes based on a box, where
@@ -271,7 +271,7 @@ class SpatialJoinAlgorithms {
   // this helper function takes an idtable, a row and a column. It then tries
   // to parse a geometry or a geoPoint of that cell in the idtable. If it
   // succeeds, it returns an rtree entry of that geometry/geopoint
-  std::optional<RtreeEntry> getRtreeEntry(const IdTableView<0>& idTable,
+  std::optional<RtreeEntry> getRtreeEntry(const IdTableView<0>* idTable,
                                           const size_t row,
                                           const ColumnIndex col);
 

--- a/src/engine/SpatialJoinAlgorithms.h
+++ b/src/engine/SpatialJoinAlgorithms.h
@@ -154,13 +154,12 @@ class SpatialJoinAlgorithms {
       const Box& box, std::optional<Point> midpoint = std::nullopt) const;
 
   // this function gets the string which represents the area from the idtable.
-  std::optional<size_t> getAnyGeometry(const IdTable* idtable, size_t row,
-                                       size_t col);
+  std::optional<size_t> getAnyGeometry(const IdTableView<0>& idtable,
+                                       size_t row, size_t col);
 
   // wrapper to access non const private function for testing
-  std::optional<RtreeEntry> onlyForTestingGetRtreeEntry(const IdTable* idTable,
-                                                        const size_t row,
-                                                        const ColumnIndex col) {
+  std::optional<RtreeEntry> onlyForTestingGetRtreeEntry(
+      const IdTableView<0>& idTable, const size_t row, const ColumnIndex col) {
     return getRtreeEntry(idTable, row, col);
   }
 
@@ -182,7 +181,7 @@ class SpatialJoinAlgorithms {
   // number of geometries added. This function is only `public` for testing
   // purposes and should otherwise not be used outside of this class.
   struct LibSpatialJoinParseInput {
-    const IdTable* idTable_;
+    IdTableView<0> idTable_;
     ColumnIndex geomsCol_;
     SpatialJoinBoundingBoxColumns boundingBoxCols_;
   };
@@ -217,7 +216,7 @@ class SpatialJoinAlgorithms {
   // Helper for `libspatialjoinParse` to get the bounding box from an
   // `IdTable` if available.
   static std::optional<ad_utility::BoundingBox> getBoundingBoxFromIdTable(
-      const IdTable* idTable,
+      const IdTableView<0>& idTable,
       const SpatialJoinBoundingBoxColumns& boundingBoxes, size_t row);
 
   // Retrieve the number of threads to be used for `libspatialjoinParse` and
@@ -226,12 +225,12 @@ class SpatialJoinAlgorithms {
 
   // Helper function which returns a GeoPoint if the element of the given table
   // represents a GeoPoint
-  static std::optional<GeoPoint> getPoint(const IdTable* restable, size_t row,
-                                          ColumnIndex col);
+  static std::optional<GeoPoint> getPoint(const IdTableView<0>& restable,
+                                          size_t row, ColumnIndex col);
 
   // Helper function to retrieve and parse a line string from the given cell of
   // an `IdTable` and convert it to an `S2Polyline`.
-  static std::optional<S2Polyline> getPolyline(const IdTable& restable,
+  static std::optional<S2Polyline> getPolyline(const IdTableView<0>& restable,
                                                size_t row, ColumnIndex col,
                                                const Index& index);
 
@@ -243,8 +242,8 @@ class SpatialJoinAlgorithms {
   // Helper function, which adds a row, which belongs to the result to the
   // result table. As inputs it uses a row of the left and a row of the right
   // child result table.
-  void addResultTableEntry(IdTable* result, const IdTable* resultLeft,
-                           const IdTable* resultRight, size_t rowLeft,
+  void addResultTableEntry(IdTable* result, const IdTableView<0>& resultLeft,
+                           const IdTableView<0>& resultRight, size_t rowLeft,
                            size_t rowRight, Id distance) const;
 
   // This helper function calculates the bounding boxes based on a box, where
@@ -272,7 +271,7 @@ class SpatialJoinAlgorithms {
   // this helper function takes an idtable, a row and a column. It then tries
   // to parse a geometry or a geoPoint of that cell in the idtable. If it
   // succeeds, it returns an rtree entry of that geometry/geopoint
-  std::optional<RtreeEntry> getRtreeEntry(const IdTable* idTable,
+  std::optional<RtreeEntry> getRtreeEntry(const IdTableView<0>& idTable,
                                           const size_t row,
                                           const ColumnIndex col);
 

--- a/src/engine/SpatialJoinCachedIndex.cpp
+++ b/src/engine/SpatialJoinCachedIndex.cpp
@@ -46,7 +46,7 @@ class SpatialJoinCachedIndexImpl {
 // ____________________________________________________________________________
 SpatialJoinCachedIndex::SpatialJoinCachedIndex(Variable geometryColumn,
                                                ColumnIndex col,
-                                               IdTableView<0> restable,
+                                               const IdTableView<0>& restable,
                                                const Index& index)
     : geometryColumn_{std::move(geometryColumn)},
       pimpl_{std::make_shared<SpatialJoinCachedIndexImpl>()} {

--- a/src/engine/SpatialJoinCachedIndex.cpp
+++ b/src/engine/SpatialJoinCachedIndex.cpp
@@ -22,7 +22,7 @@ class SpatialJoinCachedIndexImpl {
   using ShapeIndexToRow = SpatialJoinCachedIndex::ShapeIndexToRow;
 
   // Construct the index, and return the mapping from shape indices to rows.
-  ShapeIndexToRow populate(ColumnIndex col, const IdTable& restable,
+  ShapeIndexToRow populate(ColumnIndex col, const IdTableView<0>& restable,
                            const Index& index) {
     ShapeIndexToRow shapeIndexToRow;
     AD_CORRECTNESS_CHECK(s2index_.num_shape_ids() == 0);
@@ -46,7 +46,7 @@ class SpatialJoinCachedIndexImpl {
 // ____________________________________________________________________________
 SpatialJoinCachedIndex::SpatialJoinCachedIndex(Variable geometryColumn,
                                                ColumnIndex col,
-                                               const IdTable& restable,
+                                               IdTableView<0> restable,
                                                const Index& index)
     : geometryColumn_{std::move(geometryColumn)},
       pimpl_{std::make_shared<SpatialJoinCachedIndexImpl>()} {

--- a/src/engine/SpatialJoinCachedIndex.h
+++ b/src/engine/SpatialJoinCachedIndex.h
@@ -43,7 +43,7 @@ class SpatialJoinCachedIndex {
   // the `IdTable`. Currently only line strings are supported for the
   // experimental S2 point polyline algorithm.
   SpatialJoinCachedIndex(Variable geometryColumn, ColumnIndex col,
-                         const IdTable& restable, const Index& index);
+                         IdTableView<0> restable, const Index& index);
 
   // Getters
   const Variable& getGeometryColumn() const;

--- a/src/engine/SpatialJoinCachedIndex.h
+++ b/src/engine/SpatialJoinCachedIndex.h
@@ -43,7 +43,7 @@ class SpatialJoinCachedIndex {
   // the `IdTable`. Currently only line strings are supported for the
   // experimental S2 point polyline algorithm.
   SpatialJoinCachedIndex(Variable geometryColumn, ColumnIndex col,
-                         IdTableView<0> restable, const Index& index);
+                         const IdTableView<0>& restable, const Index& index);
 
   // Getters
   const Variable& getGeometryColumn() const;

--- a/src/engine/TransitivePathBinSearch.cpp
+++ b/src/engine/TransitivePathBinSearch.cpp
@@ -154,7 +154,7 @@ TransitivePathBinSearch::TransitivePathBinSearch(
 
 // _____________________________________________________________________________
 BinSearchMap TransitivePathBinSearch::setupEdgesMap(
-    const IdTable& dynSub, const TransitivePathSide& startSide,
+    const IdTableView<0>& dynSub, const TransitivePathSide& startSide,
     const TransitivePathSide& targetSide) const {
   return BinSearchMap{
       dynSub.getColumn(startSide.subCol_), dynSub.getColumn(targetSide.subCol_),

--- a/src/engine/TransitivePathBinSearch.h
+++ b/src/engine/TransitivePathBinSearch.h
@@ -88,7 +88,7 @@ class TransitivePathBinSearch : public TransitivePathImpl<BinSearchMap> {
   // with either two columns (without graph variable) or three columns (with
   // graph variable).
   BinSearchMap setupEdgesMap(
-      const IdTable& edges, const TransitivePathSide& startSide,
+      const IdTableView<0>& edges, const TransitivePathSide& startSide,
       const TransitivePathSide& targetSide) const override;
 
   // Alternative subtree sorted by (graph, target, source). This is used then

--- a/src/engine/TransitivePathHashMap.cpp
+++ b/src/engine/TransitivePathHashMap.cpp
@@ -68,7 +68,7 @@ void HashMapWrapper::setGraphId(Id graphId) {
 
 // _____________________________________________________________________________
 HashMapWrapper TransitivePathHashMap::setupEdgesMap(
-    const IdTable& sub, const TransitivePathSide& startSide,
+    const IdTableView<0>& sub, const TransitivePathSide& startSide,
     const TransitivePathSide& targetSide) const {
   decltype(auto) startCol = sub.getColumn(startSide.subCol_);
   decltype(auto) targetCol = sub.getColumn(targetSide.subCol_);

--- a/src/engine/TransitivePathHashMap.h
+++ b/src/engine/TransitivePathHashMap.h
@@ -76,7 +76,7 @@ class TransitivePathHashMap : public TransitivePathImpl<HashMapWrapper> {
 
   // Initialize the map from the subresult.
   HashMapWrapper setupEdgesMap(
-      const IdTable& sub, const TransitivePathSide& startSide,
+      const IdTableView<0>& sub, const TransitivePathSide& startSide,
       const TransitivePathSide& targetSide) const override;
 };
 

--- a/src/engine/TransitivePathImpl.h
+++ b/src/engine/TransitivePathImpl.h
@@ -99,7 +99,7 @@ class TransitivePathImpl : public TransitivePathBase {
       std::shared_ptr<const Result> startSideResult, bool yieldOnce) const {
     ad_utility::Timer timer{ad_utility::Timer::Started};
 
-    auto edges = setupEdgesMap(sub->idTable(), startSide, targetSide);
+    auto edges = setupEdgesMap(sub->idTableView(), startSide, targetSide);
     auto nodes = setupNodes(startSide, std::move(startSideResult));
     // Setup nodes returns a generator, so this time measurement won't include
     // the time for each iteration, but every iteration step should have
@@ -140,8 +140,8 @@ class TransitivePathImpl : public TransitivePathBase {
                                           bool yieldOnce) const {
     ad_utility::Timer timer{ad_utility::Timer::Started};
 
-    auto edges = setupEdgesMap(sub->idTable(), startSide, targetSide);
-    auto nodes = setupNodes(sub->idTable(), startSide, edges);
+    auto edges = setupEdgesMap(sub->idTableView(), startSide, targetSide);
+    auto nodes = setupNodes(sub->idTableView(), startSide, edges);
 
     runtimeInfo().addDetail("Initialization time", timer.msecs());
 
@@ -297,7 +297,7 @@ class TransitivePathImpl : public TransitivePathBase {
    * @param edges Templated datastructure representing the edges of the graph
    * @return Set A set of starting nodes for the transitive hull computation
    */
-  SetWithGraph setupNodes(const IdTable& sub,
+  SetWithGraph setupNodes(const IdTableView<0>& sub,
                           const TransitivePathSide& startSide,
                           const T& edges) const {
     AD_CORRECTNESS_CHECK(minDist_ != 0,
@@ -361,7 +361,7 @@ class TransitivePathImpl : public TransitivePathBase {
     };
 
     auto toView = [columnsWithoutJoinColumns = std::move(
-                       columnsWithoutJoinColumns)](const IdTable& idTable) {
+                       columnsWithoutJoinColumns)](const auto& idTable) {
       return idTable.asColumnSubsetView(columnsWithoutJoinColumns);
     };
 
@@ -391,7 +391,7 @@ class TransitivePathImpl : public TransitivePathBase {
         }));
   }
 
-  virtual T setupEdgesMap(const IdTable& dynSub,
+  virtual T setupEdgesMap(const IdTableView<0>& dynSub,
                           const TransitivePathSide& startSide,
                           const TransitivePathSide& targetSide) const = 0;
 

--- a/src/engine/TransitivePathImpl.h
+++ b/src/engine/TransitivePathImpl.h
@@ -370,7 +370,7 @@ class TransitivePathImpl : public TransitivePathBase {
           [toView = std::move(toView),
            columnsToRange = std::move(columnsToRange),
            startSideResult = std::move(startSideResult)]() {
-            const IdTable& idTable = startSideResult->idTable();
+            const IdTableView<0>& idTable = startSideResult->idTableView();
             return TableColumnWithVocab{toView(idTable),
                                         columnsToRange(idTable),
                                         startSideResult->getCopyOfLocalVocab()};

--- a/src/util/JoinAlgorithms/IndexNestedLoopJoin.h
+++ b/src/util/JoinAlgorithms/IndexNestedLoopJoin.h
@@ -162,7 +162,7 @@ class OptionalJoinRange
   std::shared_ptr<const Result> leftResult_;
   std::shared_ptr<const Result> rightResult_;
   const LocalVocab& leftVocab_;
-  const IdTable& leftTable_;
+  IdTableView<0> leftTable_;
   Result::LazyResult rightTables_;
   Adder matchTracker_;
   size_t resultWidth_;
@@ -173,7 +173,7 @@ class OptionalJoinRange
  public:
   OptionalJoinRange(std::shared_ptr<const Result> leftResult,
                     std::shared_ptr<const Result> rightResult,
-                    const LocalVocab& leftVocab, const IdTable& leftTable,
+                    const LocalVocab& leftVocab, IdTableView<0> leftTable,
                     Result::LazyResult rightTables, Adder matchTracker,
                     size_t resultWidth,
                     ad_utility::JoinColumnMapping joinColumnData,
@@ -220,10 +220,11 @@ class OptionalJoinRange
 };
 
 // Helper function for common pattern.
-template <size_t JOIN_COLUMNS>
+template <size_t JOIN_COLUMNS, typename IdTableT>
 IdTableView<JOIN_COLUMNS> toStaticView(
-    const IdTable& idTable, const std::vector<ColumnIndex>& joinColumns) {
-  return idTable.asColumnSubsetView(joinColumns).asStaticView<JOIN_COLUMNS>();
+    const IdTableT& idTable, const std::vector<ColumnIndex>& joinColumns) {
+  return idTable.asColumnSubsetView(joinColumns)
+      .template asStaticView<JOIN_COLUMNS>();
 }
 }  // namespace detail
 
@@ -309,8 +310,9 @@ class IndexNestedLoopJoin {
                                       matchTracker.matchTracker_);
           };
           if (leftResult_->isFullyMaterialized()) {
-            return Result::LazyResult{std::array{matchHelper(
-                leftResult_->idTable(), leftResult_->getCopyOfLocalVocab())}};
+            return Result::LazyResult{
+                std::array{matchHelper(leftResult_->idTable().clone(),
+                                       leftResult_->getCopyOfLocalVocab())}};
           }
           return Result::LazyResult{ad_utility::CachingTransformInputRange{
               leftResult_->idTables(),
@@ -344,7 +346,7 @@ class IndexNestedLoopJoin {
           auto leftTable = detail::toStaticView<JOIN_COLUMNS>(
               leftResult_->idTable(), leftColumns);
           auto matchHelper = [&matchTracker, &leftTable,
-                              &rightColumns](const IdTable& idTable) {
+                              &rightColumns](const auto& idTable) {
             matchLeft(
                 matchTracker, leftTable,
                 detail::toStaticView<JOIN_COLUMNS>(idTable, rightColumns));
@@ -383,13 +385,13 @@ class IndexNestedLoopJoin {
               joinColumns_, numColsLeft, numColsRight, keepJoinColumns};
           auto leftTableView = detail::toStaticView<JOIN_COLUMNS>(
               leftTable, joinColumnData.jcsLeft());
-          auto matchHelper = [&matchTracker, &leftTableView,
-                              rightColumns = joinColumnData.jcsRight()](
-                                 const IdTable& idTable) {
-            matchLeft(
-                matchTracker, leftTableView,
-                detail::toStaticView<JOIN_COLUMNS>(idTable, rightColumns));
-          };
+          auto matchHelper =
+              [&matchTracker, &leftTableView,
+               rightColumns = joinColumnData.jcsRight()](const auto& idTable) {
+                matchLeft(
+                    matchTracker, leftTableView,
+                    detail::toStaticView<JOIN_COLUMNS>(idTable, rightColumns));
+              };
           IdTable resultTable{resultWidth, leftTable.getAllocator()};
           LocalVocab mergedVocab = leftResult_->getCopyOfLocalVocab();
           if (rightResult_->isFullyMaterialized()) {
@@ -423,8 +425,8 @@ class IndexNestedLoopJoin {
             auto rightColumns = joinColumnData.jcsRight();
             return Result::LazyResult{detail::OptionalJoinRange{
                 std::move(leftResult_), std::move(rightResult_), leftVocab,
-                leftTable, std::move(rightTables), std::move(matchTracker),
-                resultWidth, std::move(joinColumnData),
+                leftTable.asStaticView<0>(), std::move(rightTables),
+                std::move(matchTracker), resultWidth, std::move(joinColumnData),
                 [leftTableView = std::move(leftTableView),
                  rightColumns = std::move(rightColumns)](
                     detail::Adder& adder, const IdTable& rightTable) {

--- a/src/util/JoinAlgorithms/IndexNestedLoopJoin.h
+++ b/src/util/JoinAlgorithms/IndexNestedLoopJoin.h
@@ -162,7 +162,7 @@ class OptionalJoinRange
   std::shared_ptr<const Result> leftResult_;
   std::shared_ptr<const Result> rightResult_;
   const LocalVocab& leftVocab_;
-  IdTableView<0> leftTable_;
+  const IdTableView<0>& leftTable_;
   Result::LazyResult rightTables_;
   Adder matchTracker_;
   size_t resultWidth_;
@@ -173,7 +173,8 @@ class OptionalJoinRange
  public:
   OptionalJoinRange(std::shared_ptr<const Result> leftResult,
                     std::shared_ptr<const Result> rightResult,
-                    const LocalVocab& leftVocab, IdTableView<0> leftTable,
+                    const LocalVocab& leftVocab,
+                    const IdTableView<0>& leftTable,
                     Result::LazyResult rightTables, Adder matchTracker,
                     size_t resultWidth,
                     ad_utility::JoinColumnMapping joinColumnData,
@@ -223,6 +224,7 @@ class OptionalJoinRange
 template <size_t JOIN_COLUMNS, typename IdTableT>
 IdTableView<JOIN_COLUMNS> toStaticView(
     const IdTableT& idTable, const std::vector<ColumnIndex>& joinColumns) {
+  static_assert(IdTableLike<IdTableT>);
   return idTable.asColumnSubsetView(joinColumns)
       .template asStaticView<JOIN_COLUMNS>();
 }
@@ -295,7 +297,7 @@ class IndexNestedLoopJoin {
          transformationFunc =
              std::move(transformationFunc)](auto JOIN_COLUMNS) {
           auto rightTable = detail::toStaticView<JOIN_COLUMNS>(
-              rightResult_->idTable(), rightColumns);
+              rightResult_->idTableView(), rightColumns);
           auto matchHelper =
               [rightTable = std::move(rightTable), leftColumns, JOIN_COLUMNS,
                transformationFunc = std::move(transformationFunc),
@@ -310,9 +312,14 @@ class IndexNestedLoopJoin {
                                       matchTracker.matchTracker_);
           };
           if (leftResult_->isFullyMaterialized()) {
-            return Result::LazyResult{
-                std::array{matchHelper(leftResult_->idTable().clone(),
-                                       leftResult_->getCopyOfLocalVocab())}};
+            // NOTE: We deliberately pass the owning `idTable()` (and not
+            // `idTableView()`) here: the `transformationFunc` of `Minus` only
+            // reads the table (no copy), whereas the one of `ExistsJoin` needs
+            // to take ownership via `moveOrClone()`. Passing the owning
+            // reference lets `Minus` avoid a copy while `ExistsJoin` clones
+            // only when it actually has to.
+            return Result::LazyResult{std::array{matchHelper(
+                leftResult_->idTable(), leftResult_->getCopyOfLocalVocab())}};
           }
           return Result::LazyResult{ad_utility::CachingTransformInputRange{
               leftResult_->idTables(),
@@ -329,8 +336,8 @@ class IndexNestedLoopJoin {
   computeLeftExistance() {
     AD_CONTRACT_CHECK(leftResult_->isFullyMaterialized());
     detail::Filler matchTracker{
-        leftResult_->idTable().size(),
-        leftResult_->idTable().getAllocator().as<char>()};
+        leftResult_->idTableView().size(),
+        leftResult_->idTableView().getAllocator().as<char>()};
     std::vector<ColumnIndex> leftColumns;
     std::vector<ColumnIndex> rightColumns;
     for (const auto& [leftCol, rightCol] : joinColumns_) {
@@ -344,7 +351,7 @@ class IndexNestedLoopJoin {
           static constexpr size_t JOIN_COLUMNS =
               static_cast<size_t>(JOIN_COLUMNS_PAR);
           auto leftTable = detail::toStaticView<JOIN_COLUMNS>(
-              leftResult_->idTable(), leftColumns);
+              leftResult_->idTableView(), leftColumns);
           auto matchHelper = [&matchTracker, &leftTable,
                               &rightColumns](const auto& idTable) {
             matchLeft(
@@ -352,7 +359,7 @@ class IndexNestedLoopJoin {
                 detail::toStaticView<JOIN_COLUMNS>(idTable, rightColumns));
           };
           if (rightResult_->isFullyMaterialized()) {
-            matchHelper(rightResult_->idTable());
+            matchHelper(rightResult_->idTableView());
           } else {
             for (const auto& [idTable, _] : rightResult_->idTables()) {
               matchHelper(idTable);
@@ -369,17 +376,17 @@ class IndexNestedLoopJoin {
       ad_utility::SharedCancellationHandle cancellationHandle,
       size_t numColsRight, bool keepJoinColumns) && {
     AD_CONTRACT_CHECK(leftResult_->isFullyMaterialized());
-    detail::Adder matchTracker{leftResult_->idTable().size(),
-                               leftResult_->idTable().getAllocator().as<char>(),
-                               std::move(cancellationHandle),
-                               joinColumns_.size(), keepJoinColumns};
+    detail::Adder matchTracker{
+        leftResult_->idTableView().size(),
+        leftResult_->idTableView().getAllocator().as<char>(),
+        std::move(cancellationHandle), joinColumns_.size(), keepJoinColumns};
     return ad_utility::callFixedSizeVi(
         static_cast<int>(joinColumns_.size()),
         [this, &matchTracker, yieldOnce, resultWidth, numColsRight,
          keepJoinColumns](auto JOIN_COLUMNS_PAR) -> Result::LazyResult {
           static constexpr auto JOIN_COLUMNS =
               static_cast<size_t>(JOIN_COLUMNS_PAR);
-          const IdTable& leftTable = leftResult_->idTable();
+          const IdTableView<0>& leftTable = leftResult_->idTableView();
           size_t numColsLeft = leftTable.numColumns();
           ad_utility::JoinColumnMapping joinColumnData{
               joinColumns_, numColsLeft, numColsRight, keepJoinColumns};
@@ -395,11 +402,11 @@ class IndexNestedLoopJoin {
           IdTable resultTable{resultWidth, leftTable.getAllocator()};
           LocalVocab mergedVocab = leftResult_->getCopyOfLocalVocab();
           if (rightResult_->isFullyMaterialized()) {
-            matchHelper(rightResult_->idTable());
+            matchHelper(rightResult_->idTableView());
             matchTracker.materializeTables(
                 resultTable,
                 leftTable.asColumnSubsetView(joinColumnData.permutationLeft()),
-                rightResult_->idTable().asColumnSubsetView(
+                rightResult_->idTableView().asColumnSubsetView(
                     joinColumnData.permutationRight()));
             matchTracker.materializeMissing(
                 resultTable,
@@ -425,8 +432,8 @@ class IndexNestedLoopJoin {
             auto rightColumns = joinColumnData.jcsRight();
             return Result::LazyResult{detail::OptionalJoinRange{
                 std::move(leftResult_), std::move(rightResult_), leftVocab,
-                leftTable.asStaticView<0>(), std::move(rightTables),
-                std::move(matchTracker), resultWidth, std::move(joinColumnData),
+                leftTable, std::move(rightTables), std::move(matchTracker),
+                resultWidth, std::move(joinColumnData),
                 [leftTableView = std::move(leftTableView),
                  rightColumns = std::move(rightColumns)](
                     detail::Adder& adder, const IdTable& rightTable) {

--- a/test/LanguageExpressionsTest.cpp
+++ b/test/LanguageExpressionsTest.cpp
@@ -52,7 +52,7 @@ struct TestContext {
   sparqlExpression::EvaluationContext context{
       *qec,
       varToColMap,
-      table,
+      table.asStaticView<0>(),
       qec->getAllocator(),
       localVocab,
       std::make_shared<ad_utility::CancellationHandle<>>(),

--- a/test/RelationalExpressionTest.cpp
+++ b/test/RelationalExpressionTest.cpp
@@ -497,7 +497,7 @@ auto testNotComparableHelper(T leftValue, U rightValue,
   sparqlExpression::EvaluationContext context{
       *TestContext{}.qec,
       map,
-      table,
+      table.asStaticView<0>(),
       alloc,
       localVocab,
       std::make_shared<ad_utility::CancellationHandle<>>(),

--- a/test/SparqlExpressionTestHelpers.h
+++ b/test/SparqlExpressionTestHelpers.h
@@ -45,7 +45,7 @@ struct TestContext {
   sparqlExpression::EvaluationContext context{
       *qec,
       varToColMap,
-      table,
+      table.asStaticView<0>(),
       qec->getAllocator(),
       localVocab,
       std::make_shared<ad_utility::CancellationHandle<>>(),

--- a/test/ValueGetterTestHelpers.h
+++ b/test/ValueGetterTestHelpers.h
@@ -42,7 +42,7 @@ struct TestContextWithGivenTTl {
   sparqlExpression::EvaluationContext context{
       *qec,
       varToColMap,
-      table,
+      table.asStaticView<0>(),
       qec->getAllocator(),
       localVocab,
       std::make_shared<ad_utility::CancellationHandle<>>(),

--- a/test/engine/SpatialJoinAlgorithmsTest.cpp
+++ b/test/engine/SpatialJoinAlgorithmsTest.cpp
@@ -1594,7 +1594,7 @@ TEST(SpatialJoin, areaFormat) {
   // product. (Lines which can't be parsed will be ignored (and a warning gets
   // printed) and therefore the cross product of all parsed lines would be
   // smaller then 36)
-  ASSERT_EQ(res->idTable().numRows(), 36);
+  ASSERT_EQ(res->idTableView().numRows(), 36);
 }
 
 // _____________________________________________________________________________
@@ -1688,7 +1688,7 @@ TEST(SpatialJoin, mixedDataSet) {
     // Here we only test, that the distance between GeoPoints and areas gets
     // computed correctly. For this purpose it is sufficient to check the number
     // of rows in the result table
-    ASSERT_EQ(res.idTable().numRows(), nrResultRows);
+    ASSERT_EQ(res.idTableView().numRows(), nrResultRows);
   };
   auto qec = buildMixedAreaPointQEC();
   testDist(qec, 1, 5);

--- a/test/engine/SpatialJoinAlgorithmsTest.cpp
+++ b/test/engine/SpatialJoinAlgorithmsTest.cpp
@@ -1776,7 +1776,7 @@ TEST(SpatialJoin, GetPolylineGeometryTypeCheck) {
   auto col = scan->getVariableColumn(Variable{"?geo"});
 
   auto check = [&](size_t row) {
-    return SpatialJoinAlgorithms::getPolyline(result->idTable(), row, col,
+    return SpatialJoinAlgorithms::getPolyline(result->idTableView(), row, col,
                                               qec->getIndex());
   };
 

--- a/test/engine/SpatialJoinPrefilterTestHelpers.h
+++ b/test/engine/SpatialJoinPrefilterTestHelpers.h
@@ -255,13 +255,13 @@ inline void runParsingAndSweeper(
     auto varToCol = spatialJoin->computeVariableToColumnMap();
     auto leftCol = varToCol.at(varLeft).columnIndex_;
     auto rightCol = varToCol.at(varRight).columnIndex_;
-    auto resultNumRows = result.idTable().numRows();
+    auto resultNumRows = result.idTableView().numRows();
     testResult = SweeperTestResult{};
     testResult.results_.reserve(resultNumRows);
-    for (size_t i = 0; i < result.idTable().numRows(); i++) {
+    for (size_t i = 0; i < result.idTableView().numRows(); i++) {
       testResult.results_.emplace_back(sjTask.joinType_,
-                                       result.idTable().at(i, leftCol),
-                                       result.idTable().at(i, rightCol), 0);
+                                       result.idTableView().at(i, leftCol),
+                                       result.idTableView().at(i, rightCol), 0);
     }
     if (spatialJoin->runtimeInfo().details_.contains(
             "num-geoms-dropped-by-prefilter")) {
@@ -336,9 +336,9 @@ inline void runParsingAndSweeper(
     }
 
     const auto [sjType, leftIdx, rightIdx] = results.at(0).at(row);
-    auto valIdLeft = prepared.idTableLeft_.at(leftIdx, prepared.leftJoinCol_);
+    auto valIdLeft = prepared.idTableLeft_->at(leftIdx, prepared.leftJoinCol_);
     auto valIdRight =
-        prepared.idTableRight_.at(rightIdx, prepared.rightJoinCol_);
+        prepared.idTableRight_->at(rightIdx, prepared.rightJoinCol_);
 
     resultMatched.emplace_back(sjType, valIdLeft, valIdRight, dist);
   }

--- a/test/engine/SpatialJoinPrefilterTestHelpers.h
+++ b/test/engine/SpatialJoinPrefilterTestHelpers.h
@@ -336,9 +336,9 @@ inline void runParsingAndSweeper(
     }
 
     const auto [sjType, leftIdx, rightIdx] = results.at(0).at(row);
-    auto valIdLeft = prepared.idTableLeft_->at(leftIdx, prepared.leftJoinCol_);
+    auto valIdLeft = prepared.idTableLeft_.at(leftIdx, prepared.leftJoinCol_);
     auto valIdRight =
-        prepared.idTableRight_->at(rightIdx, prepared.rightJoinCol_);
+        prepared.idTableRight_.at(rightIdx, prepared.rightJoinCol_);
 
     resultMatched.emplace_back(sjType, valIdLeft, valIdRight, dist);
   }

--- a/test/engine/SpatialJoinTest.cpp
+++ b/test/engine/SpatialJoinTest.cpp
@@ -382,10 +382,10 @@ class SpatialJoinVarColParamTest
         // test, that the column contains the correct values
         ColumnIndex ind =
             varColMap[Variable{expectedColumns.at(i).first}].columnIndex_;
-        const IdTable& r = resultTable.idTable();
-        ASSERT_LT(0, r.numRows());
-        ASSERT_LT(ind, r.numColumns());
-        ValueId tableEntry = r.at(0, ind);
+        const IdTableView<0>* r = &resultTable.idTableView();
+        ASSERT_LT(0, r->numRows());
+        ASSERT_LT(ind, r->numColumns());
+        ValueId tableEntry = r->at(0, ind);
 
         if (tableEntry.getDatatype() == Datatype::VocabIndex) {
           std::string value =
@@ -454,13 +454,13 @@ class SpatialJoinVarColParamTest
         // test, that the column contains the correct values
         ColumnIndex ind =
             varColMap[Variable{expectedColumns.at(i).first}].columnIndex_;
-        const IdTable& r = resultTable.idTable();
-        ASSERT_LT(0, r.numRows());
-        ASSERT_LT(ind, r.numColumns());
+        const IdTableView<0>* r = &resultTable.idTableView();
+        ASSERT_LT(0, r->numRows());
+        ASSERT_LT(ind, r->numColumns());
 
-        auto col = r.getColumn(ind);
+        auto col = r->getColumn(ind);
         std::vector<std::string> columnEntries;
-        columnEntries.reserve(r.numRows());
+        columnEntries.reserve(r->numRows());
         for (const auto& valueId : col) {
           auto [value, type] =
               ql::exportIds::idToStringAndType(qec->getIndex(), valueId, {})
@@ -653,7 +653,7 @@ TEST(SpatialJoinVarColParamTest, testLibspatialjoinFromvalues) {
   auto spatialJoin = static_cast<SpatialJoin*>(spJoin2.get());
 
   auto resultTable = spatialJoin->computeResult(false);
-  ASSERT_EQ(resultTable.idTable().numRows(), 1);
+  ASSERT_EQ(resultTable.idTableView().numRows(), 1);
 }
 
 TEST_P(SpatialJoinVarColParamTest, payloadVariables) {

--- a/test/engine/SpatialJoinTest.cpp
+++ b/test/engine/SpatialJoinTest.cpp
@@ -382,10 +382,10 @@ class SpatialJoinVarColParamTest
         // test, that the column contains the correct values
         ColumnIndex ind =
             varColMap[Variable{expectedColumns.at(i).first}].columnIndex_;
-        const IdTable* r = &resultTable.idTable();
-        ASSERT_LT(0, r->numRows());
-        ASSERT_LT(ind, r->numColumns());
-        ValueId tableEntry = r->at(0, ind);
+        const IdTable& r = resultTable.idTable();
+        ASSERT_LT(0, r.numRows());
+        ASSERT_LT(ind, r.numColumns());
+        ValueId tableEntry = r.at(0, ind);
 
         if (tableEntry.getDatatype() == Datatype::VocabIndex) {
           std::string value =
@@ -454,13 +454,13 @@ class SpatialJoinVarColParamTest
         // test, that the column contains the correct values
         ColumnIndex ind =
             varColMap[Variable{expectedColumns.at(i).first}].columnIndex_;
-        const IdTable* r = &resultTable.idTable();
-        ASSERT_LT(0, r->numRows());
-        ASSERT_LT(ind, r->numColumns());
+        const IdTable& r = resultTable.idTable();
+        ASSERT_LT(0, r.numRows());
+        ASSERT_LT(ind, r.numColumns());
 
-        auto col = r->getColumn(ind);
+        auto col = r.getColumn(ind);
         std::vector<std::string> columnEntries;
-        columnEntries.reserve(r->numRows());
+        columnEntries.reserve(r.numRows());
         for (const auto& valueId : col) {
           auto [value, type] =
               ql::exportIds::idToStringAndType(qec->getIndex(), valueId, {})

--- a/test/engine/SpatialJoinTestHelpers.h
+++ b/test/engine/SpatialJoinTestHelpers.h
@@ -523,9 +523,11 @@ inline SpatialJoinAlgorithms getDummySpatialJoinAlgsForWrapperTesting(
   std::shared_ptr<Operation> op = spatialJoinOperation->getRootOperation();
   SpatialJoin* spatialJoin = static_cast<SpatialJoin*>(op.get());
 
-  PreparedSpatialJoinParams params{nullptr,
+  static IdTable emptyLeft{0, ad_utility::makeUnlimitedAllocator<Id>()};
+  static IdTable emptyRight{0, ad_utility::makeUnlimitedAllocator<Id>()};
+  PreparedSpatialJoinParams params{emptyLeft.asStaticView<0>(),
                                    nullptr,
-                                   nullptr,
+                                   emptyRight.asStaticView<0>(),
                                    nullptr,
                                    0,
                                    0,

--- a/test/engine/SpatialJoinTestHelpers.h
+++ b/test/engine/SpatialJoinTestHelpers.h
@@ -294,11 +294,11 @@ const std::string approximatedAreaGermany = makeAreaLiteral(
 inline std::vector<std::string> printTable(const QueryExecutionContext* qec,
                                            const Result* table) {
   std::vector<std::string> output;
-  for (size_t i = 0; i < table->idTable().numRows(); i++) {
+  for (size_t i = 0; i < table->idTableView().numRows(); i++) {
     std::string line = "";
-    for (size_t k = 0; k < table->idTable().numColumns(); k++) {
+    for (size_t k = 0; k < table->idTableView().numColumns(); k++) {
       auto test = ql::exportIds::idToStringAndType(
-          qec->getIndex(), table->idTable().at(i, k), {});
+          qec->getIndex(), table->idTableView().at(i, k), {});
       line += test.value().first;
       line += " ";
     }
@@ -523,11 +523,9 @@ inline SpatialJoinAlgorithms getDummySpatialJoinAlgsForWrapperTesting(
   std::shared_ptr<Operation> op = spatialJoinOperation->getRootOperation();
   SpatialJoin* spatialJoin = static_cast<SpatialJoin*>(op.get());
 
-  static IdTable emptyLeft{0, ad_utility::makeUnlimitedAllocator<Id>()};
-  static IdTable emptyRight{0, ad_utility::makeUnlimitedAllocator<Id>()};
-  PreparedSpatialJoinParams params{emptyLeft.asStaticView<0>(),
+  PreparedSpatialJoinParams params{nullptr,
                                    nullptr,
-                                   emptyRight.asStaticView<0>(),
+                                   nullptr,
                                    nullptr,
                                    0,
                                    0,

--- a/test/parser/SparqlAntlrParserTest.cpp
+++ b/test/parser/SparqlAntlrParserTest.cpp
@@ -115,7 +115,7 @@ TEST(SparqlExpressionParser, First) {
   sparqlExpression::EvaluationContext input{
       *ad_utility::testing::getQec(),
       map,
-      table,
+      table.asStaticView<0>(),
       alloc,
       localVocab,
       std::make_shared<ad_utility::CancellationHandle<>>(),


### PR DESCRIPTION
Continues #2933 and #2999, which make a non-owning `IdTableView<0>` the canonical value of a materialized `Result`. Now also the transitive-path, path-search, spatial-join, and index-nested-loop-join call sites take `IdTableView<0>` (via `Result::idTableView()`) instead of the owning `IdTable&`. The one deliberate exception is the `Minus`/`ExistsJoin` path in `IndexNestedLoopJoin`, which keeps the owning `idTable()` so `ExistsJoin` can still take ownership via `moveOrClone()`. This is a pure refactor with no behavioural change.