### PR TITLE
Refactor `BasicGraphPatternsInvariantTo` using `VariableCounter`

### DIFF
--- a/src/engine/MaterializedViewsQueryAnalysis.cpp
+++ b/src/engine/MaterializedViewsQueryAnalysis.cpp
@@ -414,9 +414,7 @@ bool QueryPatternCache::analyzeView(ViewPtr view) {
 // _____________________________________________________________________________
 std::vector<parsedQuery::GraphPatternOperation> graphPatternInvariantFilter(
     const ParsedQuery& parsed) {
-  BasicGraphPatternsInvariantTo invariantCheck{
-      getVariablesPresentInFirstBasicGraphPattern(
-          parsed._rootGraphPattern._graphPatterns)};
+  BasicGraphPatternsInvariantTo invariantCheck{parsed._rootGraphPattern};
 
   // Filter out graph patterns that do not change the result of the basic graph
   // pattern analyzed.

--- a/src/parser/GraphPatternAnalysis.cpp
+++ b/src/parser/GraphPatternAnalysis.cpp
@@ -27,7 +27,7 @@ bool BasicGraphPatternsInvariantTo::operator()(
   return
       // There is exactly one row inside the `VALUES`.
       values.size() == 1 &&
-      // The `VALUES` doesn't bind to any of the `variables_`.
+      // Each `VALUES` variable appears at most once across the whole pattern.
       ql::ranges::all_of(variables, [this](const auto& var) {
         return variableAppearsAtMostOnce(var);
       });

--- a/src/parser/GraphPatternAnalysis.cpp
+++ b/src/parser/GraphPatternAnalysis.cpp
@@ -9,9 +9,15 @@
 namespace graphPatternAnalysis {
 
 // _____________________________________________________________________________
+BasicGraphPatternsInvariantTo::BasicGraphPatternsInvariantTo(
+    const parsedQuery::GraphPattern& gp) {
+  variableCounts_(gp);
+}
+
+// _____________________________________________________________________________
 bool BasicGraphPatternsInvariantTo::operator()(
     const parsedQuery::Bind& bind) const {
-  return !variables_.contains(bind._target);
+  return checkVariable(bind._target);
 }
 
 // _____________________________________________________________________________
@@ -22,9 +28,15 @@ bool BasicGraphPatternsInvariantTo::operator()(
       // There is exactly one row inside the `VALUES`.
       values.size() == 1 &&
       // The `VALUES` doesn't bind to any of the `variables_`.
-      ql::ranges::none_of(variables, [this](const auto& var) {
-        return variables_.contains(var);
-      });
+      ql::ranges::all_of(
+          variables, [this](const auto& var) { return checkVariable(var); });
+}
+
+// _____________________________________________________________________________
+bool BasicGraphPatternsInvariantTo::checkVariable(const Variable& var) const {
+  const auto& counts = variableCounts_.counts();
+  auto it = counts.find(var);
+  return it == counts.end() || it->second <= 1;
 }
 
 }  // namespace graphPatternAnalysis

--- a/src/parser/GraphPatternAnalysis.cpp
+++ b/src/parser/GraphPatternAnalysis.cpp
@@ -17,7 +17,7 @@ BasicGraphPatternsInvariantTo::BasicGraphPatternsInvariantTo(
 // _____________________________________________________________________________
 bool BasicGraphPatternsInvariantTo::operator()(
     const parsedQuery::Bind& bind) const {
-  return checkVariable(bind._target);
+  return variableAppearsAtMostOnce(bind._target);
 }
 
 // _____________________________________________________________________________
@@ -28,12 +28,14 @@ bool BasicGraphPatternsInvariantTo::operator()(
       // There is exactly one row inside the `VALUES`.
       values.size() == 1 &&
       // The `VALUES` doesn't bind to any of the `variables_`.
-      ql::ranges::all_of(
-          variables, [this](const auto& var) { return checkVariable(var); });
+      ql::ranges::all_of(variables, [this](const auto& var) {
+        return variableAppearsAtMostOnce(var);
+      });
 }
 
 // _____________________________________________________________________________
-bool BasicGraphPatternsInvariantTo::checkVariable(const Variable& var) const {
+bool BasicGraphPatternsInvariantTo::variableAppearsAtMostOnce(
+    const Variable& var) const {
   const auto& counts = variableCounts_.counts();
   auto it = counts.find(var);
   return it == counts.end() || it->second <= 1;

--- a/src/parser/GraphPatternAnalysis.h
+++ b/src/parser/GraphPatternAnalysis.h
@@ -56,7 +56,8 @@ struct BasicGraphPatternsInvariantTo {
   }
 
  private:
-  bool checkVariable(const Variable& var) const;
+  // Check that the given variable is counted at most once by `variableCounts_`.
+  bool variableAppearsAtMostOnce(const Variable& var) const;
 };
 
 }  // namespace graphPatternAnalysis

--- a/src/parser/GraphPatternAnalysis.h
+++ b/src/parser/GraphPatternAnalysis.h
@@ -15,14 +15,17 @@
 // _____________________________________________________________________________
 namespace graphPatternAnalysis {
 
-// Check whether certain graph patterns can be ignored when we are only
-// interested in the bindings for variables from `variables_` as they do not
-// affect the result for these `variables_`.
+// Check whether a given `GraphPatternOperation` is invariant with respect to
+// the variable usage in the surrounding `GraphPattern`, meaning that removing
+// it would not affect the result of the query. The variable usage is counted
+// once up front (across the whole `GraphPattern`) into `variableCounts_`; a
+// later `operator()(op)` query then asks whether `op`'s variables appear at
+// most once in the pattern (i.e. only inside `op` itself).
 //
-// For example: A basic graph pattern (a list of triples) is invariant to a
-// `BIND` statement whose target variable is not contained in the basic graph
-// pattern, because the `BIND` only adds its own column, but neither adds nor
-// deletes result rows.
+// For example: a `BIND(... AS ?y)` is invariant when `?y` is not referenced
+// anywhere else in the pattern (the `BIND` only adds its own column without
+// adding or removing rows). A single-row `VALUES` clause is invariant when
+// none of its variables are referenced elsewhere.
 //
 // This is currently used for the `MaterializedViewsManager`'s
 // `QueryPatternCache`.

--- a/src/parser/GraphPatternAnalysis.h
+++ b/src/parser/GraphPatternAnalysis.h
@@ -8,6 +8,7 @@
 #define QLEVER_SRC_PARSER_GRAPHPATTERNANALYSIS_H_
 
 #include "parser/GraphPatternOperation.h"
+#include "parser/VariableCounter.h"
 
 // This module contains helpers for analyzing the structure of graph patterns.
 
@@ -29,7 +30,13 @@ namespace graphPatternAnalysis {
 // NOTE: This does not guarantee completeness, so it might return `false` even
 // though we could be invariant to a `GraphPatternOperation`.
 struct BasicGraphPatternsInvariantTo {
-  ad_utility::HashSet<Variable> variables_;
+  parsedQuery::VariableCounter variableCounts_;
+
+  // Initialize with a `GraphPattern`.
+  explicit BasicGraphPatternsInvariantTo(const parsedQuery::GraphPattern& gp);
+
+  explicit BasicGraphPatternsInvariantTo(parsedQuery::VariableCounter vc)
+      : variableCounts_{std::move(vc)} {}
 
   bool operator()(const parsedQuery::Bind& bind) const;
   bool operator()(const parsedQuery::Values& values) const;
@@ -47,6 +54,9 @@ struct BasicGraphPatternsInvariantTo {
             pq::ExternalValuesQuery>);
     return false;
   }
+
+ private:
+  bool checkVariable(const Variable& var) const;
 };
 
 }  // namespace graphPatternAnalysis

--- a/src/parser/GraphPatternOperation.cpp
+++ b/src/parser/GraphPatternOperation.cpp
@@ -91,17 +91,4 @@ void BasicGraphPattern::collectAllContainedVariables(
   }
 }
 
-// _____________________________________________________________________________
-ad_utility::HashSet<Variable> getVariablesPresentInFirstBasicGraphPattern(
-    const std::vector<parsedQuery::GraphPatternOperation>& graphPatterns) {
-  ad_utility::HashSet<Variable> vars;
-  auto basicGraphPatterns =
-      ad_utility::filterRangeOfVariantsByType<parsedQuery::BasicGraphPattern>(
-          graphPatterns);
-  if (!ql::ranges::empty(basicGraphPatterns)) {
-    (*basicGraphPatterns.begin()).collectAllContainedVariables(vars);
-  }
-  return vars;
-}
-
 }  // namespace parsedQuery

--- a/src/parser/GraphPatternOperation.h
+++ b/src/parser/GraphPatternOperation.h
@@ -87,21 +87,6 @@ struct BasicGraphPattern {
   void collectAllContainedVariables(ad_utility::HashSet<Variable>& vars) const;
 };
 
-// Helper for a special use case: Extract all variables present in the first
-// `BasicGraphPattern` contained in a vector of `GraphPatternOperation`s.
-//
-// For example: If the vector contains a `BIND`, followed by two
-// `BasicGraphPattern`s, this would return the variables from the first of the
-// two `BasicGraphPattern`s.
-//
-// It is used for skipping some graph patterns in
-// `MaterializedViewQueryAnalysis.cpp`.
-//
-// IMPORTANT: This function does not consider variables that are contained in
-// other types of `GraphPatternOperation`s.
-ad_utility::HashSet<Variable> getVariablesPresentInFirstBasicGraphPattern(
-    const std::vector<parsedQuery::GraphPatternOperation>& graphPatterns);
-
 /// A `Values` clause
 struct Values {
   SparqlValues _inlineValues;

--- a/src/parser/VariableCounter.cpp
+++ b/src/parser/VariableCounter.cpp
@@ -167,7 +167,7 @@ void VariableCounter::operator()(const NamedCachedResult& op) {
 // _____________________________________________________________________________
 void VariableCounter::operator()(const MaterializedViewQuery& op) {
   (*this)(op.scanCol_);
-  (*this)(op.requestedColumns_ | ql::views::keys);
+  (*this)(op.requestedColumns_ | ql::views::values);
 }
 
 // _____________________________________________________________________________

--- a/test/VariableCounterTest.cpp
+++ b/test/VariableCounterTest.cpp
@@ -269,9 +269,9 @@ TEST(VariableCounterTest, MagicServices) {
           "PREFIX view: <https://qlever.cs.uni-freiburg.de/materializedView/>"
           "SELECT * {"
           "SERVICE view:myView {"
-          "_:config view:column-s ?s ;"
-          "view:column-p ?p . } }"),
-      counts({{V{"?s"}, 1}, {V{"?p"}, 1}}));
+          "_:config view:column-s ?x ;"
+          "view:column-p ?y . } }"),
+      counts({{V{"?x"}, 1}, {V{"?y"}, 1}}));
 
   // External values.
   EXPECT_THAT(

--- a/test/parser/GraphPatternAnalysisTest.cpp
+++ b/test/parser/GraphPatternAnalysisTest.cpp
@@ -9,12 +9,17 @@
 #include "parser/GraphPatternAnalysis.h"
 #include "parser/GraphPatternOperation.h"
 #include "parser/SparqlTriple.h"
+#include "parser/VariableCounter.h"
 
 using namespace graphPatternAnalysis;
+using parsedQuery::VariableCounter;
+using V = Variable;
 
 // _____________________________________________________________________________
 TEST(BasicGraphPatternsInvariantToTest, Bind) {
-  BasicGraphPatternsInvariantTo invariantTo{{Variable{"?x"}, Variable{"?y"}}};
+  VariableCounter counter;
+  counter(std::vector{V{"?x"}, V{"?x"}, V{"?y"}});
+  BasicGraphPatternsInvariantTo invariantTo{counter};
 
   // Test that BIND is invariant when its target variable is not in our set.
   parsedQuery::Bind bind1{
@@ -32,7 +37,7 @@ TEST(BasicGraphPatternsInvariantToTest, Bind) {
   EXPECT_FALSE(invariantTo(bind2));
 
   // Test that BIND is invariant when we have no variables to check.
-  BasicGraphPatternsInvariantTo invariantTo2{{}};
+  BasicGraphPatternsInvariantTo invariantTo2{VariableCounter{}};
   parsedQuery::Bind bind{
       sparqlExpression::SparqlExpressionPimpl::makeVariableExpression(
           Variable{"?a"}),
@@ -42,7 +47,9 @@ TEST(BasicGraphPatternsInvariantToTest, Bind) {
 
 // _____________________________________________________________________________
 TEST(BasicGraphPatternsInvariantToTest, Values) {
-  BasicGraphPatternsInvariantTo invariantTo{{Variable{"?x"}, Variable{"?y"}}};
+  VariableCounter counter;
+  counter(std::vector{V{"?x"}, V{"?x"}, V{"?y"}});
+  BasicGraphPatternsInvariantTo invariantTo{counter};
 
   // Test VALUES with exactly one row and no variable overlap.
   parsedQuery::Values values;
@@ -79,7 +86,9 @@ TEST(BasicGraphPatternsInvariantToTest, Values) {
 // _____________________________________________________________________________
 TEST(BasicGraphPatternsInvariantToTest, NotInvariant) {
   // Test the base case: is not invariant.
-  BasicGraphPatternsInvariantTo invariantTo{{Variable{"?x"}}};
+  VariableCounter counter;
+  counter(V{"?x"});
+  BasicGraphPatternsInvariantTo invariantTo{counter};
 
   SparqlTripleSimple example{Variable{"?s"}, Variable{"?p"}, Variable{"?o"}};
   auto triple = SparqlTriple::fromSimple(example);

--- a/test/parser/GraphPatternOperationTest.cpp
+++ b/test/parser/GraphPatternOperationTest.cpp
@@ -8,31 +8,29 @@
 
 #include "parser/GraphPatternOperation.h"
 #include "parser/SparqlTriple.h"
+#include "rdfTypes/Variable.h"
+
+namespace {
+
+using V = Variable;
 
 // _____________________________________________________________________________
 TEST(GraphPatternOperationTest, BasicPatternContainedVars) {
-  SparqlTripleSimple example1{Variable{"?s"}, Variable{"?p"}, Variable{"?o"}};
+  SparqlTripleSimple example1{V{"?s"}, V{"?p"}, V{"?o"}};
   SparqlTripleSimple example2{
       ad_utility::triple_component::Iri::fromIriref("<s>"),
-      ad_utility::triple_component::Iri::fromIriref("<p>"), Variable{"?o2"}};
+      ad_utility::triple_component::Iri::fromIriref("<p>"), V{"?o2"}};
 
   auto triple1 = SparqlTriple::fromSimple(example1);
   auto triple2 = SparqlTriple::fromSimple(example2);
 
   parsedQuery::BasicGraphPattern bgp{{triple1, triple2}};
 
-  ad_utility::HashSet<Variable> vars;
+  ad_utility::HashSet<V> vars;
   bgp.collectAllContainedVariables(vars);
-  auto expectedVarsMatcher = ::testing::UnorderedElementsAre(
-      ::testing::Eq(Variable{"?s"}), ::testing::Eq(Variable{"?p"}),
-      ::testing::Eq(Variable{"?o"}), ::testing::Eq(Variable{"?o2"}));
+  auto expectedVarsMatcher = ::testing::UnorderedElementsAreArray(
+      std::vector{V{"?s"}, V{"?p"}, V{"?o"}, V{"?o2"}});
   EXPECT_THAT(vars, expectedVarsMatcher);
-
-  parsedQuery::Bind bind{
-      sparqlExpression::SparqlExpressionPimpl::makeVariableExpression(
-          Variable{"?x"}),
-      Variable{"?y"}};
-  std::vector<parsedQuery::GraphPatternOperation> graphPatterns{bind, bgp};
-  EXPECT_THAT(getVariablesPresentInFirstBasicGraphPattern(graphPatterns),
-              expectedVarsMatcher);
 }
+
+}  // namespace


### PR DESCRIPTION
This change contains refactoring to make `BasicGraphPatternsInvariantTo` robust for cases that were not needed so far, but will be needed when cache-key-based query rewriting for materialized views is implemented. This is based on #2958, and preparation for #2937.  Specifically:

The existing checks to see if a graph pattern can be safely left out during materialized view detection were only checking the variables present in the first `BasicGraphPattern` of the query. This was fine because our rewriting for stars and chains doesn't support other queries (than `BasicGraphPattern` followed by zero or more `BIND`) anyway. With the new cache-key-based query rewriting, we have much more complicated queries (for example queries including `OPTIONAL`, `MINUS`, etc). When analyzing `BIND`'s in these queries, it would be wrong to only look at the first `BasicGraphPattern`. With this change, we now use the `VariableCounter` to ensure that we only ignore a `BIND` or single-variable single-row `VALUES` if the target variable does not appear in any other graph pattern.