### PR TITLE
Fix `ZipMergeUniqueViewTest` compilation on Clang-16

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -186,7 +186,7 @@ addLinkAndDiscoverTest(LocatedTriplesTest index)
 
 addLinkAndDiscoverTest(IdTripleTest index)
 
-addLinkAndDiscoverTest(ZipMergeUniqueViewTest)
+addLinkAndDiscoverTestNoLibs(ZipMergeUniqueViewTest)
 
 addLinkAndDiscoverTest(DeltaTriplesTest index)
 

--- a/test/ZipMergeUniqueViewTest.cpp
+++ b/test/ZipMergeUniqueViewTest.cpp
@@ -16,11 +16,12 @@
 #include "util/GTestHelpers.h"
 #include "util/views/ZipMergeUniqueView.h"
 
-// `PrintTo` in the `ad_utility` namespace is found by GTest via ADL and takes
-// priority over range-v3's `view_interface::operator<<` (which requires
-// `operator<<` on the element type). `::testing::PrintToString` already falls
-// back to a hex byte representation for non-streamable types, so no SFINAE
-// machinery is needed here.
+// We need to explicitly tell GTest how to print a `ZipMergeUniqueView`,
+// because the latter inherits an implicit `operator<<` from `range-v3`s
+// `view_interface`. That operator leads to a hard compile error if the value
+// type of the view not printable. Note: `::testing::PrintToString`
+// already falls back to a hex byte representation for non-streamable types, so
+// no SFINAE machinery is needed here.
 namespace ad_utility {
 template <typename V1, typename V2, typename Compare, typename Projection>
 void PrintTo(const ZipMergeUniqueView<V1, V2, Compare, Projection>& view,

--- a/test/ZipMergeUniqueViewTest.cpp
+++ b/test/ZipMergeUniqueViewTest.cpp
@@ -16,13 +16,25 @@
 #include "util/GTestHelpers.h"
 #include "util/views/ZipMergeUniqueView.h"
 
-// Needed for range-v3's range `operator<<` which prints elements with `<<`.
-// Without this, printing `ZipMergeUniqueView<..., std::pair<int,int>>` fails
-// to compile on compilers building in C++17 mode.
-template <typename T, typename U>
-std::ostream& operator<<(std::ostream& os, const std::pair<T, U>& p) {
-  return os << '(' << p.first << ", " << p.second << ')';
+// `PrintTo` in the `ad_utility` namespace is found by GTest via ADL and takes
+// priority over range-v3's `view_interface::operator<<` (which requires
+// `operator<<` on the element type). `::testing::PrintToString` already falls
+// back to a hex byte representation for non-streamable types, so no SFINAE
+// machinery is needed here.
+namespace ad_utility {
+template <typename V1, typename V2, typename Compare, typename Projection>
+void PrintTo(const ZipMergeUniqueView<V1, V2, Compare, Projection>& view,
+             std::ostream* os) {
+  *os << '[';
+  bool first = true;
+  for (const auto& elem : view) {
+    if (!first) *os << ',';
+    *os << ::testing::PrintToString(elem);
+    first = false;
+  }
+  *os << ']';
 }
+}  // namespace ad_utility
 
 // Pair of the two container types passed to `ZipMergeUniqueView` for testing
 // different input types. The difference to a normal `std::pair` is that this

--- a/test/ZipMergeUniqueViewTest.cpp
+++ b/test/ZipMergeUniqueViewTest.cpp
@@ -11,9 +11,7 @@
 
 #include <forward_list>
 #include <ostream>
-#include <string>
 #include <utility>
-#include <vector>
 
 #include "util/GTestHelpers.h"
 #include "util/StringUtils.h"
@@ -29,12 +27,13 @@ namespace ad_utility {
 template <typename V1, typename V2, typename Compare, typename Projection>
 void PrintTo(const ZipMergeUniqueView<V1, V2, Compare, Projection>& view,
              std::ostream* os) {
-  std::vector<std::string> strs;
-  for (const auto& elem : view) {
-    strs.push_back(::testing::PrintToString(elem));
-  }
   *os << '[';
-  lazyStrJoin(os, strs, ",");
+  lazyStrJoin(os,
+              ql::views::transform(ql::ranges::ref_view{view},
+                                   [](const auto& elem) {
+                                     return ::testing::PrintToString(elem);
+                                   }),
+              ",");
   *os << ']';
 }
 }  // namespace ad_utility

--- a/test/ZipMergeUniqueViewTest.cpp
+++ b/test/ZipMergeUniqueViewTest.cpp
@@ -11,28 +11,30 @@
 
 #include <forward_list>
 #include <ostream>
+#include <string>
 #include <utility>
+#include <vector>
 
 #include "util/GTestHelpers.h"
+#include "util/StringUtils.h"
 #include "util/views/ZipMergeUniqueView.h"
 
 // We need to explicitly tell GTest how to print a `ZipMergeUniqueView`,
 // because the latter inherits an implicit `operator<<` from `range-v3`s
 // `view_interface`. That operator leads to a hard compile error if the value
-// type of the view not printable. Note: `::testing::PrintToString`
+// type of the view is not printable. Note: `::testing::PrintToString`
 // already falls back to a hex byte representation for non-streamable types, so
 // no SFINAE machinery is needed here.
 namespace ad_utility {
 template <typename V1, typename V2, typename Compare, typename Projection>
 void PrintTo(const ZipMergeUniqueView<V1, V2, Compare, Projection>& view,
              std::ostream* os) {
-  *os << '[';
-  bool first = true;
+  std::vector<std::string> strs;
   for (const auto& elem : view) {
-    if (!first) *os << ',';
-    *os << ::testing::PrintToString(elem);
-    first = false;
+    strs.push_back(::testing::PrintToString(elem));
   }
+  *os << '[';
+  lazyStrJoin(os, strs, ",");
   *os << ']';
 }
 }  // namespace ad_utility


### PR DESCRIPTION
The recent merge of #2975 lead to compiler errors in Clang-16. The reason was a missing print facility for the newly introduced `ZipMergeUniqueView`, which was required by GTest, and only implicitly available in newer compilers. 
This PR fixes this issue by explicitly implementing a `PrintTo` method for the `ZipMergeUniqueView`.