### PR TITLE
Add `ql:simplifyGeometry` function

### DIFF
--- a/src/engine/sparqlExpressions/GeoExpression.cpp
+++ b/src/engine/sparqlExpressions/GeoExpression.cpp
@@ -78,6 +78,10 @@ NARY_EXPRESSION(
     GeometryNExpression, 2,
     FV<ad_utility::WktGeometryN, GeoPointOrWktValueGetter, IntValueGetter>);
 
+NARY_EXPRESSION(
+    SimplifyPolygonExpression, 2,
+    FV<ad_utility::WktSimplify, GeoPointOrWktValueGetter, NumericValueGetter>);
+
 template <SpatialJoinType Relation>
 NARY_EXPRESSION(
     GeoRelationExpression, 2,
@@ -176,6 +180,13 @@ SparqlExpression::Ptr makeGeometryNExpression(SparqlExpression::Ptr child1,
                                               SparqlExpression::Ptr child2) {
   return std::make_unique<GeometryNExpression>(std::move(child1),
                                                std::move(child2));
+}
+
+// _____________________________________________________________________________
+SparqlExpression::Ptr makeSimplifyPolygonExpression(
+    SparqlExpression::Ptr child1, SparqlExpression::Ptr child2) {
+  return std::make_unique<SimplifyPolygonExpression>(std::move(child1),
+                                                     std::move(child2));
 }
 
 // _____________________________________________________________________________

--- a/src/engine/sparqlExpressions/GeoExpression.cpp
+++ b/src/engine/sparqlExpressions/GeoExpression.cpp
@@ -79,7 +79,7 @@ NARY_EXPRESSION(
     FV<ad_utility::WktGeometryN, GeoPointOrWktValueGetter, IntValueGetter>);
 
 NARY_EXPRESSION(
-    SimplifyPolygonExpression, 2,
+    SimplifyGeometryExpression, 2,
     FV<ad_utility::WktSimplify, GeoPointOrWktValueGetter, NumericValueGetter>);
 
 template <SpatialJoinType Relation>
@@ -183,10 +183,10 @@ SparqlExpression::Ptr makeGeometryNExpression(SparqlExpression::Ptr child1,
 }
 
 // _____________________________________________________________________________
-SparqlExpression::Ptr makeSimplifyPolygonExpression(
+SparqlExpression::Ptr makeSimplifyGeometryExpression(
     SparqlExpression::Ptr child1, SparqlExpression::Ptr child2) {
-  return std::make_unique<SimplifyPolygonExpression>(std::move(child1),
-                                                     std::move(child2));
+  return std::make_unique<SimplifyGeometryExpression>(std::move(child1),
+                                                      std::move(child2));
 }
 
 // _____________________________________________________________________________

--- a/src/engine/sparqlExpressions/NaryExpression.h
+++ b/src/engine/sparqlExpressions/NaryExpression.h
@@ -81,7 +81,7 @@ SparqlExpression::Ptr makeLengthExpression(SparqlExpression::Ptr child1,
 SparqlExpression::Ptr makeMetricLengthExpression(SparqlExpression::Ptr child);
 SparqlExpression::Ptr makeGeometryNExpression(SparqlExpression::Ptr child1,
                                               SparqlExpression::Ptr child2);
-SparqlExpression::Ptr makeSimplifyPolygonExpression(
+SparqlExpression::Ptr makeSimplifyGeometryExpression(
     SparqlExpression::Ptr child1, SparqlExpression::Ptr child2);
 
 template <ad_utility::BoundingCoordinate RequestedCoordinate>

--- a/src/engine/sparqlExpressions/NaryExpression.h
+++ b/src/engine/sparqlExpressions/NaryExpression.h
@@ -81,6 +81,8 @@ SparqlExpression::Ptr makeLengthExpression(SparqlExpression::Ptr child1,
 SparqlExpression::Ptr makeMetricLengthExpression(SparqlExpression::Ptr child);
 SparqlExpression::Ptr makeGeometryNExpression(SparqlExpression::Ptr child1,
                                               SparqlExpression::Ptr child2);
+SparqlExpression::Ptr makeSimplifyPolygonExpression(
+    SparqlExpression::Ptr child1, SparqlExpression::Ptr child2);
 
 template <ad_utility::BoundingCoordinate RequestedCoordinate>
 SparqlExpression::Ptr makeBoundingCoordinateExpression(

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -305,6 +305,8 @@ ExpressionPtr Visitor::processIriFunctionCall(
       return createUnary(unaryInternalFuncs.at(functionName));
     } else if (functionName == "prefix-match") {
       return createBinary(&makePrefixMatchExpression);
+    } else if (functionName == "simplifyPolygon") {
+      return createBinary(&makeSimplifyPolygonExpression);
     }
   }
 

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -305,8 +305,8 @@ ExpressionPtr Visitor::processIriFunctionCall(
       return createUnary(unaryInternalFuncs.at(functionName));
     } else if (functionName == "prefix-match") {
       return createBinary(&makePrefixMatchExpression);
-    } else if (functionName == "simplifyPolygon") {
-      return createBinary(&makeSimplifyPolygonExpression);
+    } else if (functionName == "simplifyGeometry") {
+      return createBinary(&makeSimplifyGeometryExpression);
     }
   }
 

--- a/src/rdfTypes/GeometryInfoHelpersImpl.h
+++ b/src/rdfTypes/GeometryInfoHelpersImpl.h
@@ -557,6 +557,24 @@ struct GeometryNVisitor {
 
 static constexpr GeometryNVisitor getGeometryN;
 
+// Simplify a parsed geometry using the Douglas-Peucker algorithm provided by
+// `pb_util`. The `tolerance` is interpreted in the coordinate units of the
+// geometry (that is, degrees for WGS84 `geo:wktLiteral`s). Points and
+// multipoints are returned unchanged, while lines and polygons (including their
+// multi-variants and geometry collections) are simplified. Returns
+// `std::nullopt` if the given geometry could not be parsed.
+inline std::optional<ParsedWkt> simplifyGeometry(
+    const std::optional<ParsedWkt>& geometry, double tolerance) {
+  if (!geometry.has_value()) {
+    return std::nullopt;
+  }
+  return std::visit(
+      [tolerance](const auto& geom) -> ParsedWkt {
+        return ParsedWkt{::util::geo::simplify(geom, tolerance)};
+      },
+      geometry.value());
+}
+
 // Implements the web mercator projection for points. Use together via
 // `ProjectionVisitor<WebMercatorProjection>` for other geometry types.
 struct WebMercatorProjection {

--- a/src/util/GeoSparqlHelpers.cpp
+++ b/src/util/GeoSparqlHelpers.cpp
@@ -63,6 +63,12 @@ std::optional<std::string> geometryNAsWkt(GeoPointOrWkt wkt, int64_t n) {
 }
 
 // _____________________________________________________________________________
+std::optional<std::string> simplifyWkt(GeoPointOrWkt wkt, double tolerance) {
+  auto [type, parsed] = parseGeoPointOrWkt(wkt);
+  return utilGeomToWkt(simplifyGeometry(parsed, tolerance));
+}
+
+// _____________________________________________________________________________
 std::optional<double> wktDistLibSpatialJoinImpl(const GeoPointOrWkt& a,
                                                 const GeoPointOrWkt& b) {
   return computeMetricDistance(projectWebMerc(a), projectWebMerc(b));

--- a/src/util/GeoSparqlHelpers.h
+++ b/src/util/GeoSparqlHelpers.h
@@ -46,9 +46,8 @@ double wktDistImpl(GeoPoint point1, GeoPoint point2);
 // Helper to avoid including `GeometryInfoHelpersImpl.h`
 std::optional<std::string> geometryNAsWkt(GeoPointOrWkt wkt, int64_t n);
 
-// Simplify a WKT geometry using the Douglas-Peucker algorithm (helper to avoid
-// including `GeometryInfoHelpersImpl.h`). The returned WKT string has neither
-// quotation marks nor a datatype.
+// Simplify a WKT geometry using `pb_util`. The returned WKT string has neither
+// quotation marks nor a datatype yet.
 std::optional<std::string> simplifyWkt(GeoPointOrWkt wkt, double tolerance);
 
 const auto wktLiteralIri =
@@ -236,14 +235,8 @@ class WktGeometryN {
   }
 };
 
-// Simplify a WKT geometry using the Douglas-Peucker algorithm. The first
-// argument is the geometry (a `geo:wktLiteral`); this is intended primarily for
-// (multi-)polygons, but lines are simplified as well, and points are returned
-// unchanged. The second argument is the simplification tolerance, interpreted
-// in the coordinate units of the geometry (that is, degrees for WGS84
-// geometries). The result is a new `geo:wktLiteral`. If the input is not a
-// valid geometry, or the tolerance is not a positive, finite number, `UNDEF` is
-// returned.
+// Simplify a WKT geometry using `pb_util`. Tolerance, interpreted in the
+// coordinate units of the geometry.
 class WktSimplify {
  public:
   template <typename NumericVariant>
@@ -255,8 +248,7 @@ class WktSimplify {
       return ValueId::makeUndefined();
     }
 
-    // Extract the tolerance as a `double` from the numeric value variant
-    // (`std::variant<NotNumeric, double, int64_t>`).
+    // Extract the tolerance as a `double`.
     auto tol = std::visit(
         [](const auto& value) -> std::optional<double> {
           using T = std::decay_t<decltype(value)>;

--- a/src/util/GeoSparqlHelpers.h
+++ b/src/util/GeoSparqlHelpers.h
@@ -259,7 +259,7 @@ class WktSimplify {
           }
         },
         tolerance);
-    if (!tol.has_value() || !(tol.value() > 0) || !std::isfinite(tol.value())) {
+    if (!tol.has_value() || tol.value() <= 0 || !std::isfinite(tol.value())) {
       return ValueId::makeUndefined();
     }
 

--- a/src/util/GeoSparqlHelpers.h
+++ b/src/util/GeoSparqlHelpers.h
@@ -8,9 +8,12 @@
 
 #include <absl/strings/str_cat.h>
 
+#include <cmath>
 #include <limits>
 #include <optional>
 #include <string_view>
+#include <type_traits>
+#include <variant>
 
 #include "engine/SpatialJoinConfig.h"
 #include "engine/sparqlExpressions/SparqlExpressionTypes.h"
@@ -42,6 +45,11 @@ double wktDistImpl(GeoPoint point1, GeoPoint point2);
 
 // Helper to avoid including `GeometryInfoHelpersImpl.h`
 std::optional<std::string> geometryNAsWkt(GeoPointOrWkt wkt, int64_t n);
+
+// Simplify a WKT geometry using the Douglas-Peucker algorithm (helper to avoid
+// including `GeometryInfoHelpersImpl.h`). The returned WKT string has neither
+// quotation marks nor a datatype.
+std::optional<std::string> simplifyWkt(GeoPointOrWkt wkt, double tolerance);
 
 const auto wktLiteralIri =
     triple_component::Iri::fromIrirefWithoutBrackets(GEO_WKT_LITERAL);
@@ -219,6 +227,51 @@ class WktGeometryN {
 
     auto resultWkt = detail::geometryNAsWkt(wkt.value(), n.value());
 
+    if (!resultWkt.has_value()) {
+      return ValueId::makeUndefined();
+    }
+    auto lit = Literal::literalWithoutQuotes(resultWkt.value());
+    lit.addDatatype(detail::wktLiteralIri);
+    return {LiteralOrIri{std::move(lit)}};
+  }
+};
+
+// Simplify a WKT geometry using the Douglas-Peucker algorithm. The first
+// argument is the geometry (a `geo:wktLiteral`); this is intended primarily for
+// (multi-)polygons, but lines are simplified as well, and points are returned
+// unchanged. The second argument is the simplification tolerance, interpreted
+// in the coordinate units of the geometry (that is, degrees for WGS84
+// geometries). The result is a new `geo:wktLiteral`. If the input is not a
+// valid geometry, or the tolerance is not a positive, finite number, `UNDEF` is
+// returned.
+class WktSimplify {
+ public:
+  template <typename NumericVariant>
+  sparqlExpression::IdOrLiteralOrIri operator()(
+      const std::optional<GeoPointOrWkt>& geom,
+      const NumericVariant& tolerance) const {
+    using namespace triple_component;
+    if (!geom.has_value()) {
+      return ValueId::makeUndefined();
+    }
+
+    // Extract the tolerance as a `double` from the numeric value variant
+    // (`std::variant<NotNumeric, double, int64_t>`).
+    auto tol = std::visit(
+        [](const auto& value) -> std::optional<double> {
+          using T = std::decay_t<decltype(value)>;
+          if constexpr (std::is_arithmetic_v<T>) {
+            return static_cast<double>(value);
+          } else {
+            return std::nullopt;
+          }
+        },
+        tolerance);
+    if (!tol.has_value() || !(tol.value() > 0) || !std::isfinite(tol.value())) {
+      return ValueId::makeUndefined();
+    }
+
+    auto resultWkt = detail::simplifyWkt(geom.value(), tol.value());
     if (!resultWkt.has_value()) {
       return ValueId::makeUndefined();
     }

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -1765,14 +1765,14 @@ TEST(SparqlExpression, geoSparqlExpressions) {
 }
 
 // ________________________________________________________________________________________
-TEST(SparqlExpression, geoSimplifyPolygon) {
-  // `ql:simplifyPolygon(?geometry, ?tolerance)` simplifies a WKT geometry using
-  // the Douglas-Peucker algorithm. The tolerance is given in the coordinate
-  // units of the geometry (degrees for WGS84). It is intended primarily for
-  // (multi-)polygons, but lines are simplified as well and points are returned
-  // unchanged.
+TEST(SparqlExpression, geoSimplifyGeometry) {
+  // `ql:simplifyGeometry(?geometry, ?tolerance)` simplifies a WKT geometry
+  // using the Douglas-Peucker algorithm. The tolerance is given in the
+  // coordinate units of the geometry (degrees for WGS84). It is intended
+  // primarily for (multi-)polygons, but lines are simplified as well and points
+  // are returned unchanged.
   auto checkSimplify =
-      std::bind_front(testNaryExpression, &makeSimplifyPolygonExpression);
+      std::bind_front(testNaryExpression, &makeSimplifyGeometryExpression);
 
   const IdOrLocalVocabEntryVec geometries{
       // 1. Undefined input geometry.

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -1765,6 +1765,66 @@ TEST(SparqlExpression, geoSparqlExpressions) {
 }
 
 // ________________________________________________________________________________________
+TEST(SparqlExpression, geoSimplifyPolygon) {
+  // `ql:simplifyPolygon(?geometry, ?tolerance)` simplifies a WKT geometry using
+  // the Douglas-Peucker algorithm. The tolerance is given in the coordinate
+  // units of the geometry (degrees for WGS84). It is intended primarily for
+  // (multi-)polygons, but lines are simplified as well and points are returned
+  // unchanged.
+  auto checkSimplify =
+      std::bind_front(testNaryExpression, &makeSimplifyPolygonExpression);
+
+  const IdOrLocalVocabEntryVec geometries{
+      // 1. Undefined input geometry.
+      U,
+      // 2. Line with a vertex that is removed for this tolerance.
+      geoLit("LINESTRING(0 0,5 0.1,10 0)"),
+      // 3. Line whose middle vertex is too far from the simplified segment and
+      //    is therefore kept.
+      geoLit("LINESTRING(0 0,5 5,10 0)"),
+      // 4. Polygon with a near-collinear vertex that is removed.
+      geoLit("POLYGON((0 0,5 0.1,10 0,10 10,0 10,0 0))"),
+      // 5. Multipolygon: each member is simplified independently.
+      geoLit(
+          "MULTIPOLYGON(((0 0,5 0.1,10 0,10 10,0 10,0 0)),((20 20,25 20.1,30 "
+          "20,30 30,20 30,20 20)))"),
+      // 6. Points are returned unchanged.
+      geoLit("POINT(1 2)"),
+      // 7. Tolerance of zero is invalid -> UNDEF.
+      geoLit("POLYGON((0 0,5 0.1,10 0,10 10,0 10,0 0))"),
+      // 8. Negative tolerance is invalid -> UNDEF.
+      geoLit("LINESTRING(0 0,5 0.1,10 0)"),
+      // 9. Non-numeric (undefined) tolerance -> UNDEF.
+      geoLit("LINESTRING(0 0,5 0.1,10 0)"),
+      // 10. Non-geometry literal -> UNDEF.
+      IdOrLocalVocabEntry{lit("NotAGeometry")},
+      // 11. Invalid WKT with the correct datatype -> UNDEF.
+      geoLit("NOTWKT(1 2)"),
+      // 12. An integer tolerance is accepted just like a double.
+      geoLit("LINESTRING(0 0,5 0.1,10 0)"),
+  };
+  const Ids tolerances{D(1.0), D(1.0),  D(1.0), D(1.0), D(1.0), D(1.0),
+                       D(0.0), D(-1.0), U,      D(1.0), D(1.0), I(1)};
+  const IdOrLocalVocabEntryVec expected{
+      U,
+      geoLit("LINESTRING(0 0,10 0)"),
+      geoLit("LINESTRING(0 0,5 5,10 0)"),
+      geoLit("POLYGON((10 10,0 10,0 0,10 0,10 10))"),
+      geoLit(
+          "MULTIPOLYGON(((10 10,0 10,0 0,10 0,10 10)),((30 30,20 30,20 20,30 "
+          "20,30 30)))"),
+      geoLit("POINT(1 2)"),
+      U,
+      U,
+      U,
+      U,
+      U,
+      geoLit("LINESTRING(0 0,10 0)"),
+  };
+  checkSimplify(expected, geometries, tolerances);
+}
+
+// ________________________________________________________________________________________
 TEST(SparqlExpression, ifAndCoalesce) {
   auto checkIf = TestNaryExpressionVec<&makeIfExpression>{};
   auto checkCoalesce = TestNaryExpressionVec<makeCoalesceExpressionVariadic>{};

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -1762,15 +1762,8 @@ TEST(SparqlExpression, geoSparqlExpressions) {
           geoLit("LINESTRING(2 8,4 6)"),
       },
       exampleMultiGeoms, Ids{I(2), I(2), I(2), I(2), I(2)});
-}
 
-// ________________________________________________________________________________________
-TEST(SparqlExpression, geoSimplifyGeometry) {
-  // `ql:simplifyGeometry(?geometry, ?tolerance)` simplifies a WKT geometry
-  // using the Douglas-Peucker algorithm. The tolerance is given in the
-  // coordinate units of the geometry (degrees for WGS84). It is intended
-  // primarily for (multi-)polygons, but lines are simplified as well and points
-  // are returned unchanged.
+  // The internal function `ql:simplifyGeometry`.
   auto checkSimplify =
       std::bind_front(testNaryExpression, &makeSimplifyGeometryExpression);
 

--- a/test/parser/SparqlAntlrParserExpressionTest.cpp
+++ b/test/parser/SparqlAntlrParserExpressionTest.cpp
@@ -425,6 +425,11 @@ TEST(SparqlParser, FunctionCall) {
       absl::StrCat(geof, "geometryN>(?a, ?b)"),
       matchNary(&makeGeometryNExpression, Variable{"?a"}, Variable{"?b"}));
 
+  // Simplify polygon (QLever-internal function)
+  expectFunctionCall(absl::StrCat(ql, "simplifyPolygon>(?a, ?b)"),
+                     matchNary(&makeSimplifyPolygonExpression, Variable{"?a"},
+                               Variable{"?b"}));
+
   // Geometric relation functions
   expectFunctionCall(
       absl::StrCat(geof, "sfIntersects>(?a, ?b)"),

--- a/test/parser/SparqlAntlrParserExpressionTest.cpp
+++ b/test/parser/SparqlAntlrParserExpressionTest.cpp
@@ -426,8 +426,8 @@ TEST(SparqlParser, FunctionCall) {
       matchNary(&makeGeometryNExpression, Variable{"?a"}, Variable{"?b"}));
 
   // Simplify polygon (QLever-internal function)
-  expectFunctionCall(absl::StrCat(ql, "simplifyPolygon>(?a, ?b)"),
-                     matchNary(&makeSimplifyPolygonExpression, Variable{"?a"},
+  expectFunctionCall(absl::StrCat(ql, "simplifyGeometry>(?a, ?b)"),
+                     matchNary(&makeSimplifyGeometryExpression, Variable{"?a"},
                                Variable{"?b"}));
 
   // Geometric relation functions

--- a/test/parser/SparqlAntlrParserExpressionTest.cpp
+++ b/test/parser/SparqlAntlrParserExpressionTest.cpp
@@ -425,7 +425,7 @@ TEST(SparqlParser, FunctionCall) {
       absl::StrCat(geof, "geometryN>(?a, ?b)"),
       matchNary(&makeGeometryNExpression, Variable{"?a"}, Variable{"?b"}));
 
-  // Simplify polygon (QLever-internal function)
+  // Simplify geometry (QLever-internal function)
   expectFunctionCall(absl::StrCat(ql, "simplifyGeometry>(?a, ?b)"),
                      matchNary(&makeSimplifyGeometryExpression, Variable{"?a"},
                                Variable{"?b"}));


### PR DESCRIPTION
Add support for a new internal function `ql:simplifyGeometry`, which simplifies a given `LINESTRING`, `MULTILINESTRING`, `POLYGON`, `MULTIPOLYGON`, or `GEOMETRYCOLLECTION` to a given tolerance using the existing Douglas-Peucker implementation from `pb_util`. The tolerance is interpreted in the coordinate units of the geometry, that is, in degrees for a WGS84 `geo:wktLiteral`. A `POINT` or `MULTIPOINT` is returned unchanged. For example, this query computes a simplified geometry for Germany on an osm-planet endpoint:
```sparql
SELECT ?simplified_geom {
  osmrel:51477 geo:hasGeometry/geo:asWKT ?full_geom .
  BIND(ql:simplifyGeometry(?full_geom, 0.1) AS ?simplified_geom)
}
```