### PR TITLE
Introduce `IndexAndViews` and snapshot it per request

### DIFF
--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -252,6 +252,8 @@ auto Server::setupCancellationHandle(
 
 // ____________________________________________________________________________
 auto Server::prepareOperation(
+    std::shared_ptr<Index> index,
+    std::shared_ptr<MaterializedViewsManager> materializedViewsManager,
     std::string_view operationName, std::string_view operationSPARQL,
     ad_utility::websocket::MessageSender messageSender,
     const ad_utility::url_parser::ParamValueMap& params, TimeLimit timeLimit,
@@ -287,6 +289,7 @@ auto Server::prepareOperation(
       std::make_shared<ad_utility::websocket::MessageSender>(
           std::move(messageSender));
   auto qec = qlever().createQueryExecutionContext(
+      std::move(index), std::move(materializedViewsManager),
       [sharedMessageSender = std::move(sharedMessageSender)](std::string json) {
         (*sharedMessageSender)(std::move(json));
       },
@@ -324,6 +327,11 @@ CPP_template_def(typename RequestT, typename ResponseT)(
     requires ad_utility::httpUtils::HttpRequest<RequestT>)
     Awaitable<void> Server::process(RequestT& request, ResponseT&& send) {
   using namespace ad_utility::httpUtils;
+  // Acquire the current index and the materialized views manager exactly once
+  // for the whole request, under a single read lock. This way a concurrent
+  // rebuild that swaps both in cannot make different helpers observe a
+  // mismatched (index, manager) pair.
+  auto [index, materializedViewsManager] = indexAndViewsSnapshot();
 
   // Log some basic information about the request. Start with an empty line so
   // that in a low-traffic scenario (or when the query processing is very fast),
@@ -380,7 +388,7 @@ CPP_template_def(typename RequestT, typename ResponseT)(
   };
   if (auto cmd = checkParameter("cmd", "stats")) {
     logCommand(cmd, "get index statistics");
-    response = createJsonResponse(composeStatsJson(), request);
+    response = createJsonResponse(composeStatsJson(*index), request);
   } else if (auto cmd = checkParameter("cmd", "cache-stats")) {
     logCommand(cmd, "get cache statistics");
     response = createJsonResponse(composeCacheStatsJson(), request);
@@ -408,15 +416,14 @@ CPP_template_def(typename RequestT, typename ResponseT)(
     // Conan setup.
     auto coroutine = computeInNewThread(
         updateThreadPool_,
-        [this] {
+        [index] {
           // Use `this` explicitly to silence false-positive errors on the
           // captured `this` being unused.
-          auto counts =
-              this->index().deltaTriplesManager().modify<DeltaTriplesCount>(
-                  [](auto& deltaTriples) {
-                    deltaTriples.clear();
-                    return deltaTriples.getCounts();
-                  });
+          auto counts = index->deltaTriplesManager().modify<DeltaTriplesCount>(
+              [](auto& deltaTriples) {
+                deltaTriples.clear();
+                return deltaTriples.getCounts();
+              });
           return counts;
         },
         handle);
@@ -441,10 +448,10 @@ CPP_template_def(typename RequestT, typename ResponseT)(
 
     auto coroutine = computeInNewThread(
         updateThreadPool_,
-        [this, handle] {
+        [index, handle] {
           // Use `this` explicitly to silence false-positive errors on the
           // captured `this` being unused.
-          return this->index().deltaTriplesManager().modify<nlohmann::json>(
+          return index->deltaTriplesManager().modify<nlohmann::json>(
               [handle](auto& deltaTriples) {
                 return deltaTriples.vacuum(handle);
               });
@@ -459,7 +466,7 @@ CPP_template_def(typename RequestT, typename ResponseT)(
   } else if (auto cmd = checkParameter("cmd", "get-index-id")) {
     logCommand(cmd, "get index ID");
     response =
-        createOkResponse(index().getIndexId(), request, MediaType::textPlain);
+        createOkResponse(index->getIndexId(), request, MediaType::textPlain);
   } else if (auto cmd = checkParameter("cmd", "dump-active-queries")) {
     requireValidAccessToken("dump-active-queries");
     logCommand(cmd, "dump active queries");
@@ -546,7 +553,7 @@ CPP_template_def(typename RequestT, typename ResponseT)(
         parameters, "view-name");
     AD_CONTRACT_CHECK(name.has_value());
 
-    materializedViewsManager()->loadView(name.value());
+    materializedViewsManager->loadView(name.value());
 
     // Construct simple response JSON.
     nlohmann::json json{{"materialized-view-loaded", name.value()}};
@@ -570,8 +577,8 @@ CPP_template_def(typename RequestT, typename ResponseT)(
     requireValidAccessToken("index-description");
     AD_LOG_INFO << "Setting index description to: \"" << description.value()
                 << "\"" << std::endl;
-    index().setKbName(std::string{description.value()});
-    response = createJsonResponse(composeStatsJson(), request);
+    index->setKbName(std::string{description.value()});
+    response = createJsonResponse(composeStatsJson(*index), request);
   }
 
   // Set description of text index.
@@ -579,8 +586,8 @@ CPP_template_def(typename RequestT, typename ResponseT)(
     requireValidAccessToken("text-description");
     AD_LOG_INFO << "Setting text description to: \"" << description.value()
                 << "\"" << std::endl;
-    index().setTextName(std::string{description.value()});
-    response = createJsonResponse(composeStatsJson(), request);
+    index->setTextName(std::string{description.value()});
+    response = createJsonResponse(composeStatsJson(*index), request);
   }
 
   // Set one or several of the runtime parameters.
@@ -602,7 +609,7 @@ CPP_template_def(typename RequestT, typename ResponseT)(
   std::optional<PlannedQuery> plannedQuery;
   auto visitOperation =
       [&checkParameter, &accessTokenOk, &request, &send, &parameters,
-       &requestTimer, &plannedQuery, this](
+       &requestTimer, &plannedQuery, &index, &materializedViewsManager, this](
           std::vector<ParsedQuery> operations, std::string operationName,
           const std::string operationString,
           std::function<bool(const ParsedQuery&)> expectedOperation,
@@ -624,8 +631,8 @@ CPP_template_def(typename RequestT, typename ResponseT)(
     // Outside the `try`: `qecPtr` owns the id whose destructor writes the
     // `end` event, so the status must be set before it unwinds.
     auto [qecPtr, cancellationHandle, cancelTimeoutOnDestruction] =
-        prepareOperation(operationName, operationString,
-                         std::move(messageSender), parameters,
+        prepareOperation(index, materializedViewsManager, operationName,
+                         operationString, std::move(messageSender), parameters,
                          timeLimit.value(), accessTokenOk, clientIp);
     auto& qec = *qecPtr;
     try {
@@ -634,9 +641,10 @@ CPP_template_def(typename RequestT, typename ResponseT)(
             msg, ad_utility::truncateOperationString(operationString)));
       }
       if (ql::ranges::all_of(operations, &ParsedQuery::hasUpdateClause)) {
-        co_await processUpdate(std::move(operations), requestTimer, tracer,
-                               cancellationHandle, qec, std::move(request),
-                               send, timeLimit.value(), plannedQuery);
+        co_await processUpdate(index, std::move(operations), requestTimer,
+                               tracer, cancellationHandle, qec,
+                               std::move(request), send, timeLimit.value(),
+                               plannedQuery);
       } else {
         AD_CORRECTNESS_CHECK(operations.size() == 1);
         ParsedQuery query = std::move(operations[0]);
@@ -655,11 +663,11 @@ CPP_template_def(typename RequestT, typename ResponseT)(
       throw;
     }
   };
-  auto visitQuery = [this, &visitOperation](Query query) -> Awaitable<void> {
+  auto visitQuery = [&index, &visitOperation](Query query) -> Awaitable<void> {
     // We need to copy the query string because `visitOperation` below also
     // needs it.
     auto parsedQuery = SparqlParser::parseQuery(
-        &index().encodedIriManager(), query.query_, query.datasetClauses_);
+        &index->encodedIriManager(), query.query_, query.datasetClauses_);
     auto dummy = std::make_shared<ad_utility::timer::TimeTracer>("dummy");
     return visitOperation(
         {std::move(parsedQuery)}, "SPARQL query", std::move(query.query_),
@@ -668,7 +676,7 @@ CPP_template_def(typename RequestT, typename ResponseT)(
         "following update was sent instead of an query: ",
         dummy);
   };
-  auto visitUpdate = [this, &visitOperation, &requireValidAccessToken](
+  auto visitUpdate = [&index, &visitOperation, &requireValidAccessToken](
                          Update update) -> Awaitable<void> {
     requireValidAccessToken("SPARQL Update");
     // We need to copy the update string because `visitOperation` below also
@@ -676,7 +684,7 @@ CPP_template_def(typename RequestT, typename ResponseT)(
     auto tracer = std::make_shared<ad_utility::timer::TimeTracer>("update");
     tracer->beginTrace("parsing");
     auto parsedUpdates = SparqlParser::parseUpdate(
-        index().getBlankNodeManager(), &index().encodedIriManager(),
+        index->getBlankNodeManager(), &index->encodedIriManager(),
         update.update_, update.datasetClauses_);
     tracer->endTrace("parsing");
     return visitOperation(
@@ -688,12 +696,12 @@ CPP_template_def(typename RequestT, typename ResponseT)(
   };
   auto visitGraphStore =
       [&request, &visitOperation, &requireValidAccessToken,
-       this](GraphStoreOperation operation) -> Awaitable<void> {
+       &index](GraphStoreOperation operation) -> Awaitable<void> {
     auto tracer = std::make_shared<ad_utility::timer::TimeTracer>("update");
     tracer->beginTrace("parsing");
     std::vector<ParsedQuery> parsedOperations =
         GraphStoreProtocol::transformGraphStoreProtocol(std::move(operation),
-                                                        request, index());
+                                                        request, *index);
     tracer->endTrace("parsing");
 
     if (ql::ranges::any_of(parsedOperations, &ParsedQuery::hasUpdateClause)) {
@@ -807,29 +815,29 @@ nlohmann::json Server::composeErrorResponseJson(
 }
 
 // _____________________________________________________________________________
-nlohmann::json Server::composeStatsJson() const {
+nlohmann::json Server::composeStatsJson(const Index& index) {
   json result;
-  result["name-index"] = index().getKbName();
-  result["git-hash-index"] = index().getGitShortHash();
+  result["name-index"] = index.getKbName();
+  result["git-hash-index"] = index.getGitShortHash();
   result["git-hash-server"] =
       *qlever::version::gitShortHashWithoutLinking.wlock();
-  result["num-permutations"] = (index().hasAllPermutations() ? 6 : 2);
-  result["num-predicates-normal"] = index().numDistinctPredicates().normal;
-  result["num-predicates-internal"] = index().numDistinctPredicates().internal;
-  if (index().hasAllPermutations()) {
-    result["num-subjects-normal"] = index().numDistinctSubjects().normal;
-    result["num-subjects-internal"] = index().numDistinctSubjects().internal;
-    result["num-objects-normal"] = index().numDistinctObjects().normal;
-    result["num-objects-internal"] = index().numDistinctObjects().internal;
+  result["num-permutations"] = (index.hasAllPermutations() ? 6 : 2);
+  result["num-predicates-normal"] = index.numDistinctPredicates().normal;
+  result["num-predicates-internal"] = index.numDistinctPredicates().internal;
+  if (index.hasAllPermutations()) {
+    result["num-subjects-normal"] = index.numDistinctSubjects().normal;
+    result["num-subjects-internal"] = index.numDistinctSubjects().internal;
+    result["num-objects-normal"] = index.numDistinctObjects().normal;
+    result["num-objects-internal"] = index.numDistinctObjects().internal;
   }
 
-  auto numTriples = index().numTriples();
+  auto numTriples = index.numTriples();
   result["num-triples-normal"] = numTriples.normal;
   result["num-triples-internal"] = numTriples.internal;
-  result["name-text-index"] = index().getTextName();
-  result["num-text-records"] = index().getNofTextRecords();
-  result["num-word-occurrences"] = index().getNofWordPostings();
-  result["num-entity-occurrences"] = index().getNofEntityPostings();
+  result["name-text-index"] = index.getTextName();
+  result["num-text-records"] = index.getNofTextRecords();
+  result["num-word-occurrences"] = index.getNofWordPostings();
+  result["num-entity-occurrences"] = index.getNofEntityPostings();
   return result;
 }
 
@@ -1141,7 +1149,7 @@ nlohmann::ordered_json Server::createResponseMetadataForUpdate(
 
 // ____________________________________________________________________________
 UpdateMetadata Server::processUpdateImpl(
-    const PlannedQuery& plannedUpdate,
+    const Index& index, const PlannedQuery& plannedUpdate,
     ad_utility::SharedCancellationHandle cancellationHandle,
     DeltaTriples& deltaTriples, ad_utility::timer::TimeTracer& tracer) {
   const auto& qet = plannedUpdate.queryExecutionTree();
@@ -1149,7 +1157,7 @@ UpdateMetadata Server::processUpdateImpl(
 
   DeltaTriplesCount countBefore = deltaTriples.getCounts();
   UpdateMetadata updateMetadata =
-      ExecuteUpdate::executeUpdate(index(), plannedUpdate.parsedQuery(), qet,
+      ExecuteUpdate::executeUpdate(index, plannedUpdate.parsedQuery(), qet,
                                    deltaTriples, cancellationHandle, tracer);
   updateMetadata.countBefore_ = countBefore;
   updateMetadata.countAfter_ = deltaTriples.getCounts();
@@ -1169,7 +1177,7 @@ UpdateMetadata Server::processUpdateImpl(
 CPP_template_def(typename RequestT, typename ResponseT)(
     requires ad_utility::httpUtils::HttpRequest<RequestT>)
     Awaitable<void> Server::processUpdate(
-        std::vector<ParsedQuery>&& updates,
+        std::shared_ptr<Index> index, std::vector<ParsedQuery>&& updates,
         const ad_utility::Timer& requestTimer, SharedTimeTracer outerTracer,
         ad_utility::SharedCancellationHandle cancellationHandle,
         QueryExecutionContext& qec, const RequestT& request, ResponseT&& send,
@@ -1193,12 +1201,13 @@ CPP_template_def(typename RequestT, typename ResponseT)(
   static_assert(UPDATE_THREAD_POOL_SIZE == 1);
   auto coroutine = computeInNewThread(
       updateThreadPool_,
-      [this, &requestTimer, &cancellationHandle, &updates, &qec, &timeLimit,
-       &plannedUpdate, outerTracer, &metadatas]() {
+      [this, index, &requestTimer, &cancellationHandle, &updates, &qec,
+       &timeLimit, &plannedUpdate, outerTracer, &metadatas]() {
         outerTracer->endTrace("waitingForUpdateThread");
-        return index().deltaTriplesManager().modify<json>(
-            [this, &cancellationHandle, &plannedUpdate, &updates, &requestTimer,
-             &timeLimit, &qec, &metadatas](DeltaTriples& deltaTriples) {
+        return index->deltaTriplesManager().modify<json>(
+            [this, &index, &cancellationHandle, &plannedUpdate, &updates,
+             &requestTimer, &timeLimit, &qec,
+             &metadatas](DeltaTriples& deltaTriples) {
               qec.setLocatedTriplesForEvaluation(
                   deltaTriples.getLocatedTriplesSharedStateReference());
               json results = json::array();
@@ -1223,13 +1232,13 @@ CPP_template_def(typename RequestT, typename ResponseT)(
                 // Use `this` explicitly to silence false-positive
                 // errors on captured `this` being unused.
                 auto updateMetadata = this->processUpdateImpl(
-                    plannedUpdate.value(), cancellationHandle, deltaTriples,
-                    tracer);
+                    *index, plannedUpdate.value(), cancellationHandle,
+                    deltaTriples, tracer);
                 tracer.endTrace("execution");
 
                 tracer.endTrace("update");
                 results.push_back(createResponseMetadataForUpdate(
-                    index(),
+                    *index,
                     *deltaTriples.getLocatedTriplesSharedStateReference(),
                     *plannedUpdate, plannedUpdate->queryExecutionTree(),
                     updateMetadata, tracer));
@@ -1459,17 +1468,20 @@ void Server::writeMaterializedView(
     const ad_utility::Timer& requestTimer,
     ad_utility::SharedCancellationHandle cancellationHandle,
     TimeLimit timeLimit) {
+  // Acquire the index and the manager via a single read lock so they are
+  // guaranteed to come from the same swap generation.
+  auto [index, manager] = indexAndViewsSnapshot();
   auto parsedQuery = SparqlParser::parseQuery(
-      &index().encodedIriManager(), query.query_, query.datasetClauses_);
-  auto qec = qlever().createQueryExecutionContext();
+      &index->encodedIriManager(), query.query_, query.datasetClauses_);
+  auto qec = qlever().createQueryExecutionContext(index, manager);
   auto plan = planQuery(std::move(parsedQuery), requestTimer, timeLimit, *qec,
-                        cancellationHandle);
+                        std::move(cancellationHandle));
   auto qet = std::make_shared<QueryExecutionTree>(
       std::move(plan.queryExecutionTree()));
   auto memoryLimit =
       getRuntimeParameter<&RuntimeParameters::materializedViewWriterMemory_>();
-  materializedViewsManager()->writeViewToDisk(
-      name, {qet, qec, std::move(plan.parsedQuery())}, memoryLimit);
+  manager->writeViewToDisk(name, {qet, qec, std::move(plan.parsedQuery())},
+                           memoryLimit);
 }
 
 // _____________________________________________________________________________

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -1486,13 +1486,14 @@ void Server::writeMaterializedView(
 
 // _____________________________________________________________________________
 Awaitable<void> Server::rebuildIndex(const std::string& indexBaseName) {
+  const auto& [index, _] = indexAndViewsSnapshot();
   if (qlever::util::doesDirectoryContainFileWithBasename(indexBaseName)) {
     throw std::runtime_error{absl::StrCat(
         "Can't build index with base name \"", indexBaseName,
         "\" because there are already files with the same base name "
         "in the same directory")};
   }
-  if (!qlever::util::isSubdirectoryOf(indexBaseName, index().getOnDiskBase())) {
+  if (!qlever::util::isSubdirectoryOf(indexBaseName, index->getOnDiskBase())) {
     throw std::runtime_error{absl::StrCat(
         "Can't build index with base name \"", indexBaseName,
         "\" because it is not located in the same directory as the "
@@ -1504,13 +1505,12 @@ Awaitable<void> Server::rebuildIndex(const std::string& indexBaseName) {
   // Conan setup.
   auto coroutine = computeInNewThread(
       queryThreadPool_,
-      [this, &handle, &indexBaseName] {
+      [&index, &handle, &indexBaseName] {
         auto logFileName = indexBaseName + ".rebuild-index-log.txt";
         auto [currentSnapshot, localVocabCopy, ownedBlocks] =
-            index()
-                .deltaTriplesManager()
+            index->deltaTriplesManager()
                 .getCurrentLocatedTriplesSharedStateWithVocab();
-        qlever::materializeToIndex(index().getImpl(), indexBaseName,
+        qlever::materializeToIndex(index->getImpl(), indexBaseName,
                                    currentSnapshot, localVocabCopy, ownedBlocks,
                                    handle, logFileName);
       },

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -252,8 +252,7 @@ auto Server::setupCancellationHandle(
 
 // ____________________________________________________________________________
 auto Server::prepareOperation(
-    std::shared_ptr<Index> index,
-    std::shared_ptr<MaterializedViewsManager> materializedViewsManager,
+    std::shared_ptr<qlever::Qlever::IndexAndViews> indexAndViews,
     std::string_view operationName, std::string_view operationSPARQL,
     ad_utility::websocket::MessageSender messageSender,
     const ad_utility::url_parser::ParamValueMap& params, TimeLimit timeLimit,
@@ -289,7 +288,7 @@ auto Server::prepareOperation(
       std::make_shared<ad_utility::websocket::MessageSender>(
           std::move(messageSender));
   auto qec = qlever().createQueryExecutionContext(
-      std::move(index), std::move(materializedViewsManager),
+      std::move(indexAndViews),
       [sharedMessageSender = std::move(sharedMessageSender)](std::string json) {
         (*sharedMessageSender)(std::move(json));
       },
@@ -331,7 +330,8 @@ CPP_template_def(typename RequestT, typename ResponseT)(
   // for the whole request, under a single read lock. This way a concurrent
   // rebuild that swaps both in cannot make different helpers observe a
   // mismatched (index, manager) pair.
-  auto [index, materializedViewsManager] = indexAndViewsSnapshot();
+  auto indexAndViews = indexAndViewsSnapshot();
+  auto& index = indexAndViews->index_;
 
   // Log some basic information about the request. Start with an empty line so
   // that in a low-traffic scenario (or when the query processing is very fast),
@@ -388,7 +388,7 @@ CPP_template_def(typename RequestT, typename ResponseT)(
   };
   if (auto cmd = checkParameter("cmd", "stats")) {
     logCommand(cmd, "get index statistics");
-    response = createJsonResponse(composeStatsJson(*index), request);
+    response = createJsonResponse(composeStatsJson(index), request);
   } else if (auto cmd = checkParameter("cmd", "cache-stats")) {
     logCommand(cmd, "get cache statistics");
     response = createJsonResponse(composeCacheStatsJson(), request);
@@ -416,10 +416,10 @@ CPP_template_def(typename RequestT, typename ResponseT)(
     // Conan setup.
     auto coroutine = computeInNewThread(
         updateThreadPool_,
-        [index] {
+        [&index] {
           // Use `this` explicitly to silence false-positive errors on the
           // captured `this` being unused.
-          auto counts = index->deltaTriplesManager().modify<DeltaTriplesCount>(
+          auto counts = index.deltaTriplesManager().modify<DeltaTriplesCount>(
               [](auto& deltaTriples) {
                 deltaTriples.clear();
                 return deltaTriples.getCounts();
@@ -448,10 +448,10 @@ CPP_template_def(typename RequestT, typename ResponseT)(
 
     auto coroutine = computeInNewThread(
         updateThreadPool_,
-        [index, handle] {
+        [&index, handle] {
           // Use `this` explicitly to silence false-positive errors on the
           // captured `this` being unused.
-          return index->deltaTriplesManager().modify<nlohmann::json>(
+          return index.deltaTriplesManager().modify<nlohmann::json>(
               [handle](auto& deltaTriples) {
                 return deltaTriples.vacuum(handle);
               });
@@ -466,7 +466,7 @@ CPP_template_def(typename RequestT, typename ResponseT)(
   } else if (auto cmd = checkParameter("cmd", "get-index-id")) {
     logCommand(cmd, "get index ID");
     response =
-        createOkResponse(index->getIndexId(), request, MediaType::textPlain);
+        createOkResponse(index.getIndexId(), request, MediaType::textPlain);
   } else if (auto cmd = checkParameter("cmd", "dump-active-queries")) {
     requireValidAccessToken("dump-active-queries");
     logCommand(cmd, "dump active queries");
@@ -553,7 +553,7 @@ CPP_template_def(typename RequestT, typename ResponseT)(
         parameters, "view-name");
     AD_CONTRACT_CHECK(name.has_value());
 
-    materializedViewsManager->loadView(name.value());
+    indexAndViews->materializedViewsManager_.loadView(name.value());
 
     // Construct simple response JSON.
     nlohmann::json json{{"materialized-view-loaded", name.value()}};
@@ -577,8 +577,8 @@ CPP_template_def(typename RequestT, typename ResponseT)(
     requireValidAccessToken("index-description");
     AD_LOG_INFO << "Setting index description to: \"" << description.value()
                 << "\"" << std::endl;
-    index->setKbName(std::string{description.value()});
-    response = createJsonResponse(composeStatsJson(*index), request);
+    index.setKbName(std::string{description.value()});
+    response = createJsonResponse(composeStatsJson(index), request);
   }
 
   // Set description of text index.
@@ -586,8 +586,8 @@ CPP_template_def(typename RequestT, typename ResponseT)(
     requireValidAccessToken("text-description");
     AD_LOG_INFO << "Setting text description to: \"" << description.value()
                 << "\"" << std::endl;
-    index->setTextName(std::string{description.value()});
-    response = createJsonResponse(composeStatsJson(*index), request);
+    index.setTextName(std::string{description.value()});
+    response = createJsonResponse(composeStatsJson(index), request);
   }
 
   // Set one or several of the runtime parameters.
@@ -609,7 +609,7 @@ CPP_template_def(typename RequestT, typename ResponseT)(
   std::optional<PlannedQuery> plannedQuery;
   auto visitOperation =
       [&checkParameter, &accessTokenOk, &request, &send, &parameters,
-       &requestTimer, &plannedQuery, &index, &materializedViewsManager, this](
+       &requestTimer, &plannedQuery, &indexAndViews, this](
           std::vector<ParsedQuery> operations, std::string operationName,
           const std::string operationString,
           std::function<bool(const ParsedQuery&)> expectedOperation,
@@ -631,8 +631,8 @@ CPP_template_def(typename RequestT, typename ResponseT)(
     // Outside the `try`: `qecPtr` owns the id whose destructor writes the
     // `end` event, so the status must be set before it unwinds.
     auto [qecPtr, cancellationHandle, cancelTimeoutOnDestruction] =
-        prepareOperation(index, materializedViewsManager, operationName,
-                         operationString, std::move(messageSender), parameters,
+        prepareOperation(indexAndViews, operationName, operationString,
+                         std::move(messageSender), parameters,
                          timeLimit.value(), accessTokenOk, clientIp);
     auto& qec = *qecPtr;
     try {
@@ -641,8 +641,8 @@ CPP_template_def(typename RequestT, typename ResponseT)(
             msg, ad_utility::truncateOperationString(operationString)));
       }
       if (ql::ranges::all_of(operations, &ParsedQuery::hasUpdateClause)) {
-        co_await processUpdate(index, std::move(operations), requestTimer,
-                               tracer, cancellationHandle, qec,
+        co_await processUpdate(indexAndViews, std::move(operations),
+                               requestTimer, tracer, cancellationHandle, qec,
                                std::move(request), send, timeLimit.value(),
                                plannedQuery);
       } else {
@@ -667,7 +667,7 @@ CPP_template_def(typename RequestT, typename ResponseT)(
     // We need to copy the query string because `visitOperation` below also
     // needs it.
     auto parsedQuery = SparqlParser::parseQuery(
-        &index->encodedIriManager(), query.query_, query.datasetClauses_);
+        &index.encodedIriManager(), query.query_, query.datasetClauses_);
     auto dummy = std::make_shared<ad_utility::timer::TimeTracer>("dummy");
     return visitOperation(
         {std::move(parsedQuery)}, "SPARQL query", std::move(query.query_),
@@ -684,8 +684,8 @@ CPP_template_def(typename RequestT, typename ResponseT)(
     auto tracer = std::make_shared<ad_utility::timer::TimeTracer>("update");
     tracer->beginTrace("parsing");
     auto parsedUpdates = SparqlParser::parseUpdate(
-        index->getBlankNodeManager(), &index->encodedIriManager(),
-        update.update_, update.datasetClauses_);
+        index.getBlankNodeManager(), &index.encodedIriManager(), update.update_,
+        update.datasetClauses_);
     tracer->endTrace("parsing");
     return visitOperation(
         std::move(parsedUpdates), "SPARQL update", std::move(update.update_),
@@ -701,7 +701,7 @@ CPP_template_def(typename RequestT, typename ResponseT)(
     tracer->beginTrace("parsing");
     std::vector<ParsedQuery> parsedOperations =
         GraphStoreProtocol::transformGraphStoreProtocol(std::move(operation),
-                                                        request, *index);
+                                                        request, index);
     tracer->endTrace("parsing");
 
     if (ql::ranges::any_of(parsedOperations, &ParsedQuery::hasUpdateClause)) {
@@ -1177,11 +1177,13 @@ UpdateMetadata Server::processUpdateImpl(
 CPP_template_def(typename RequestT, typename ResponseT)(
     requires ad_utility::httpUtils::HttpRequest<RequestT>)
     Awaitable<void> Server::processUpdate(
-        std::shared_ptr<Index> index, std::vector<ParsedQuery>&& updates,
+        std::shared_ptr<qlever::Qlever::IndexAndViews> indexAndViews,
+        std::vector<ParsedQuery>&& updates,
         const ad_utility::Timer& requestTimer, SharedTimeTracer outerTracer,
         ad_utility::SharedCancellationHandle cancellationHandle,
         QueryExecutionContext& qec, const RequestT& request, ResponseT&& send,
         TimeLimit timeLimit, std::optional<PlannedQuery>& plannedUpdate) {
+  auto& index = indexAndViews->index_;
   outerTracer->beginTrace("waitingForUpdateThread");
   AD_CORRECTNESS_CHECK(ql::ranges::all_of(
       updates, [](const ParsedQuery& p) { return p.hasUpdateClause(); }));
@@ -1201,10 +1203,10 @@ CPP_template_def(typename RequestT, typename ResponseT)(
   static_assert(UPDATE_THREAD_POOL_SIZE == 1);
   auto coroutine = computeInNewThread(
       updateThreadPool_,
-      [this, index, &requestTimer, &cancellationHandle, &updates, &qec,
+      [this, &index, &requestTimer, &cancellationHandle, &updates, &qec,
        &timeLimit, &plannedUpdate, outerTracer, &metadatas]() {
         outerTracer->endTrace("waitingForUpdateThread");
-        return index->deltaTriplesManager().modify<json>(
+        return index.deltaTriplesManager().modify<json>(
             [this, &index, &cancellationHandle, &plannedUpdate, &updates,
              &requestTimer, &timeLimit, &qec,
              &metadatas](DeltaTriples& deltaTriples) {
@@ -1232,13 +1234,13 @@ CPP_template_def(typename RequestT, typename ResponseT)(
                 // Use `this` explicitly to silence false-positive
                 // errors on captured `this` being unused.
                 auto updateMetadata = this->processUpdateImpl(
-                    *index, plannedUpdate.value(), cancellationHandle,
+                    index, plannedUpdate.value(), cancellationHandle,
                     deltaTriples, tracer);
                 tracer.endTrace("execution");
 
                 tracer.endTrace("update");
                 results.push_back(createResponseMetadataForUpdate(
-                    *index,
+                    index,
                     *deltaTriples.getLocatedTriplesSharedStateReference(),
                     *plannedUpdate, plannedUpdate->queryExecutionTree(),
                     updateMetadata, tracer));
@@ -1470,30 +1472,32 @@ void Server::writeMaterializedView(
     TimeLimit timeLimit) {
   // Acquire the index and the manager via a single read lock so they are
   // guaranteed to come from the same swap generation.
-  auto [index, manager] = indexAndViewsSnapshot();
-  auto parsedQuery = SparqlParser::parseQuery(
-      &index->encodedIriManager(), query.query_, query.datasetClauses_);
-  auto qec = qlever().createQueryExecutionContext(index, manager);
+  auto indexAndViews = indexAndViewsSnapshot();
+  auto parsedQuery =
+      SparqlParser::parseQuery(&indexAndViews->index_.encodedIriManager(),
+                               query.query_, query.datasetClauses_);
+  auto qec = qlever().createQueryExecutionContext(indexAndViews);
   auto plan = planQuery(std::move(parsedQuery), requestTimer, timeLimit, *qec,
                         std::move(cancellationHandle));
   auto qet = std::make_shared<QueryExecutionTree>(
       std::move(plan.queryExecutionTree()));
   auto memoryLimit =
       getRuntimeParameter<&RuntimeParameters::materializedViewWriterMemory_>();
-  manager->writeViewToDisk(name, {qet, qec, std::move(plan.parsedQuery())},
-                           memoryLimit);
+  indexAndViews->materializedViewsManager_.writeViewToDisk(
+      name, {qet, qec, std::move(plan.parsedQuery())}, memoryLimit);
 }
 
 // _____________________________________________________________________________
 Awaitable<void> Server::rebuildIndex(const std::string& indexBaseName) {
-  const auto& [index, _] = indexAndViewsSnapshot();
+  auto indexAndViews = indexAndViewsSnapshot();
+  auto& index = indexAndViews->index_;
   if (qlever::util::doesDirectoryContainFileWithBasename(indexBaseName)) {
     throw std::runtime_error{absl::StrCat(
         "Can't build index with base name \"", indexBaseName,
         "\" because there are already files with the same base name "
         "in the same directory")};
   }
-  if (!qlever::util::isSubdirectoryOf(indexBaseName, index->getOnDiskBase())) {
+  if (!qlever::util::isSubdirectoryOf(indexBaseName, index.getOnDiskBase())) {
     throw std::runtime_error{absl::StrCat(
         "Can't build index with base name \"", indexBaseName,
         "\" because it is not located in the same directory as the "
@@ -1508,9 +1512,9 @@ Awaitable<void> Server::rebuildIndex(const std::string& indexBaseName) {
       [&index, &handle, &indexBaseName] {
         auto logFileName = indexBaseName + ".rebuild-index-log.txt";
         auto [currentSnapshot, localVocabCopy, ownedBlocks] =
-            index->deltaTriplesManager()
+            index.deltaTriplesManager()
                 .getCurrentLocatedTriplesSharedStateWithVocab();
-        qlever::materializeToIndex(index->getImpl(), indexBaseName,
+        qlever::materializeToIndex(index.getImpl(), indexBaseName,
                                    currentSnapshot, localVocabCopy, ownedBlocks,
                                    handle, logFileName);
       },

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -252,8 +252,8 @@ auto Server::setupCancellationHandle(
 
 // ____________________________________________________________________________
 auto Server::prepareOperation(
-    std::shared_ptr<qlever::Qlever::IndexAndViews> indexAndViews,
-    std::string_view operationName, std::string_view operationSPARQL,
+    SharedIndexAndView indexAndViews, std::string_view operationName,
+    std::string_view operationSPARQL,
     ad_utility::websocket::MessageSender messageSender,
     const ad_utility::url_parser::ParamValueMap& params, TimeLimit timeLimit,
     bool accessTokenOk, std::string_view clientIp) {
@@ -1177,8 +1177,7 @@ UpdateMetadata Server::processUpdateImpl(
 CPP_template_def(typename RequestT, typename ResponseT)(
     requires ad_utility::httpUtils::HttpRequest<RequestT>)
     Awaitable<void> Server::processUpdate(
-        std::shared_ptr<qlever::Qlever::IndexAndViews> indexAndViews,
-        std::vector<ParsedQuery>&& updates,
+        SharedIndexAndView indexAndViews, std::vector<ParsedQuery>&& updates,
         const ad_utility::Timer& requestTimer, SharedTimeTracer outerTracer,
         ad_utility::SharedCancellationHandle cancellationHandle,
         QueryExecutionContext& qec, const RequestT& request, ResponseT&& send,

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -48,6 +48,7 @@ struct SimulateHttpRequest;
 //! The HTTP Server used.
 class Server {
   using json = nlohmann::json;
+  using SharedIndexAndView = std::shared_ptr<qlever::Qlever::IndexAndViews>;
   FRIEND_TEST(ServerTest, getQueryId);
   FRIEND_TEST(ServerTest, composeStatsJson);
   FRIEND_TEST(ServerTest, createMessageSender);
@@ -218,8 +219,7 @@ class Server {
   CPP_template(typename RequestT, typename ResponseT)(
       requires ad_utility::httpUtils::HttpRequest<RequestT>)
       Awaitable<void> processUpdate(
-          std::shared_ptr<qlever::Qlever::IndexAndViews> indexAndViews,
-          std::vector<ParsedQuery>&& updates,
+          SharedIndexAndView indexAndViews, std::vector<ParsedQuery>&& updates,
           const ad_utility::Timer& requestTimer, SharedTimeTracer tracer,
           ad_utility::SharedCancellationHandle cancellationHandle,
           QueryExecutionContext& qec, const RequestT& request, ResponseT&& send,
@@ -240,12 +240,13 @@ class Server {
       const ad_utility::url_parser::ParamValueMap& params);
   FRIEND_TEST(ServerTest, determineResultPinning);
   //  Prepare the execution of an operation.
-  auto prepareOperation(
-      std::shared_ptr<qlever::Qlever::IndexAndViews> indexAndViews,
-      std::string_view operationName, std::string_view operationSPARQL,
-      ad_utility::websocket::MessageSender messageSender,
-      const ad_utility::url_parser::ParamValueMap& params, TimeLimit timeLimit,
-      bool accessTokenOk, std::string_view clientIp);
+  auto prepareOperation(SharedIndexAndView indexAndViews,
+                        std::string_view operationName,
+                        std::string_view operationSPARQL,
+                        ad_utility::websocket::MessageSender messageSender,
+                        const ad_utility::url_parser::ParamValueMap& params,
+                        TimeLimit timeLimit, bool accessTokenOk,
+                        std::string_view clientIp);
   // Sets the export limit (`send` parameter) and offset on the ParsedQuery;
   static void adjustParsedQueryLimitOffset(
       PlannedQuery& plannedQuery, const ad_utility::MediaType& mediaType,
@@ -407,7 +408,7 @@ class Server {
   // under a single read lock, so that all code paths handling a single request
   // observe a matching pair even if a concurrent rebuild swaps the pointers
   // between two reads.
-  std::shared_ptr<qlever::Qlever::IndexAndViews> indexAndViewsSnapshot() const {
+  SharedIndexAndView indexAndViewsSnapshot() const {
     return qlever().indexAndViewsSnapshot();
   }
 };

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -27,7 +27,6 @@
 #include "util/AllocatorWithLimit.h"
 #include "util/MemorySize/MemorySize.h"
 #include "util/ParseException.h"
-#include "util/Synchronized.h"
 #include "util/TypeTraits.h"
 #include "util/http/HttpUtils.h"
 #include "util/http/streamable_body.h"
@@ -385,12 +384,6 @@ class Server {
   qlever::Qlever& qlever() { return qlever_; }
   const qlever::Qlever& qlever() const { return qlever_; }
 
-  Index& index() { return qlever().index(); }
-  const Index& index() const { return qlever().index(); }
-  std::shared_ptr<const Index> sharedIndex() const {
-    return qlever().sharedIndex();
-  }
-
   QueryResultCache& cache() { return qlever().cache(); }
   const QueryResultCache& cache() const { return qlever().cache(); }
   ad_utility::AllocatorWithLimit<Id>& allocator() {
@@ -408,9 +401,6 @@ class Server {
   NamedResultCache& namedResultCache() { return qlever().namedResultCache(); }
   const NamedResultCache& namedResultCache() const {
     return qlever().namedResultCache();
-  }
-  std::shared_ptr<MaterializedViewsManager> materializedViewsManager() const {
-    return qlever().materializedViewsManager();
   }
 
   // Atomically snapshot both the `Index` and the `MaterializedViewsManager`

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -27,6 +27,7 @@
 #include "util/AllocatorWithLimit.h"
 #include "util/MemorySize/MemorySize.h"
 #include "util/ParseException.h"
+#include "util/Synchronized.h"
 #include "util/TypeTraits.h"
 #include "util/http/HttpUtils.h"
 #include "util/http/streamable_body.h"
@@ -49,6 +50,7 @@ struct SimulateHttpRequest;
 class Server {
   using json = nlohmann::json;
   FRIEND_TEST(ServerTest, getQueryId);
+  FRIEND_TEST(ServerTest, composeStatsJson);
   FRIEND_TEST(ServerTest, createMessageSender);
   FRIEND_TEST(ServerTest, adjustParsedQueryLimitOffset);
   FRIEND_TEST(ServerTest, configurePinnedResultWithName);
@@ -71,7 +73,7 @@ class Server {
   void configureQueryEventLog(const std::filesystem::path& path);
 
   // Get server statistics.
-  json composeStatsJson() const;
+  static json composeStatsJson(const Index& index);
   json composeCacheStatsJson() const;
 
   // Helper struct bundling a parsed query with a query execution tree.
@@ -217,7 +219,7 @@ class Server {
   CPP_template(typename RequestT, typename ResponseT)(
       requires ad_utility::httpUtils::HttpRequest<RequestT>)
       Awaitable<void> processUpdate(
-          std::vector<ParsedQuery>&& updates,
+          std::shared_ptr<Index> index, std::vector<ParsedQuery>&& updates,
           const ad_utility::Timer& requestTimer, SharedTimeTracer tracer,
           ad_utility::SharedCancellationHandle cancellationHandle,
           QueryExecutionContext& qec, const RequestT& request, ResponseT&& send,
@@ -237,13 +239,14 @@ class Server {
   static std::pair<bool, bool> determineResultPinning(
       const ad_utility::url_parser::ParamValueMap& params);
   FRIEND_TEST(ServerTest, determineResultPinning);
-  //  Prepare the execution of an operation
-  auto prepareOperation(std::string_view operationName,
-                        std::string_view operationSPARQL,
-                        ad_utility::websocket::MessageSender messageSender,
-                        const ad_utility::url_parser::ParamValueMap& params,
-                        TimeLimit timeLimit, bool accessTokenOk,
-                        std::string_view clientIp);
+  //  Prepare the execution of an operation.
+  auto prepareOperation(
+      std::shared_ptr<Index> index,
+      std::shared_ptr<MaterializedViewsManager> materializedViewsManager,
+      std::string_view operationName, std::string_view operationSPARQL,
+      ad_utility::websocket::MessageSender messageSender,
+      const ad_utility::url_parser::ParamValueMap& params, TimeLimit timeLimit,
+      bool accessTokenOk, std::string_view clientIp);
   // Sets the export limit (`send` parameter) and offset on the ParsedQuery;
   static void adjustParsedQueryLimitOffset(
       PlannedQuery& plannedQuery, const ad_utility::MediaType& mediaType,
@@ -275,7 +278,7 @@ class Server {
   // Execute an update operation. The function must have exclusive access to the
   // DeltaTriples object.
   UpdateMetadata processUpdateImpl(
-      const PlannedQuery& plannedUpdate,
+      const Index& index, const PlannedQuery& plannedUpdate,
       ad_utility::SharedCancellationHandle cancellationHandle,
       DeltaTriples& deltaTriples,
       ad_utility::timer::TimeTracer& tracer =
@@ -408,6 +411,14 @@ class Server {
   }
   std::shared_ptr<MaterializedViewsManager> materializedViewsManager() const {
     return qlever().materializedViewsManager();
+  }
+
+  // Atomically snapshot both the `Index` and the `MaterializedViewsManager`
+  // under a single read lock, so that all code paths handling a single request
+  // observe a matching pair even if a concurrent rebuild swaps the pointers
+  // between two reads.
+  qlever::Qlever::IndexAndViews indexAndViewsSnapshot() const {
+    return qlever().indexAndViewsSnapshot();
   }
 };
 

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -218,7 +218,8 @@ class Server {
   CPP_template(typename RequestT, typename ResponseT)(
       requires ad_utility::httpUtils::HttpRequest<RequestT>)
       Awaitable<void> processUpdate(
-          std::shared_ptr<Index> index, std::vector<ParsedQuery>&& updates,
+          std::shared_ptr<qlever::Qlever::IndexAndViews> indexAndViews,
+          std::vector<ParsedQuery>&& updates,
           const ad_utility::Timer& requestTimer, SharedTimeTracer tracer,
           ad_utility::SharedCancellationHandle cancellationHandle,
           QueryExecutionContext& qec, const RequestT& request, ResponseT&& send,
@@ -240,8 +241,7 @@ class Server {
   FRIEND_TEST(ServerTest, determineResultPinning);
   //  Prepare the execution of an operation.
   auto prepareOperation(
-      std::shared_ptr<Index> index,
-      std::shared_ptr<MaterializedViewsManager> materializedViewsManager,
+      std::shared_ptr<qlever::Qlever::IndexAndViews> indexAndViews,
       std::string_view operationName, std::string_view operationSPARQL,
       ad_utility::websocket::MessageSender messageSender,
       const ad_utility::url_parser::ParamValueMap& params, TimeLimit timeLimit,
@@ -407,7 +407,7 @@ class Server {
   // under a single read lock, so that all code paths handling a single request
   // observe a matching pair even if a concurrent rebuild swaps the pointers
   // between two reads.
-  qlever::Qlever::IndexAndViews indexAndViewsSnapshot() const {
+  std::shared_ptr<qlever::Qlever::IndexAndViews> indexAndViewsSnapshot() const {
     return qlever().indexAndViewsSnapshot();
   }
 };

--- a/src/libqlever/Qlever.cpp
+++ b/src/libqlever/Qlever.cpp
@@ -29,7 +29,9 @@ Qlever::Qlever(const EngineConfig& config)
             cache_.makeRoomAsMuchAsPossible(MAKE_ROOM_SLACK_FACTOR *
                                             numMemoryToAllocate);
           }}},
-      index_{std::make_shared<Index>(allocator_)},
+      indexAndViews_{
+          IndexAndViews{std::make_shared<Index>(allocator_),
+                        std::make_shared<MaterializedViewsManager>()}},
       enablePatternTrick_{!config.noPatterns_},
       disableCaching_{config.disableCaching_} {
   // Set runtime parameters relevant for caching and propagate them to the
@@ -43,26 +45,34 @@ Qlever::Qlever(const EngineConfig& config)
         cache_.setMaxSizeSingleEntry(newValue);
       });
 
+  // Grab the freshly constructed `Index` and `MaterializedViewsManager` once.
+  // No other thread can observe them yet, so reading the snapshot here is safe.
+  // `snapshot` keeps the `shared_ptr`s alive for the references below.
+  auto snapshot = indexAndViewsSnapshot();
+  Index& index = *snapshot.index_;
+  MaterializedViewsManager& materializedViewsManager =
+      *snapshot.materializedViewsManager_;
+
   // Load the index from disk.
-  index_->usePatterns() = enablePatternTrick_;
-  index_->loadAllPermutations() = !config.onlyPsoAndPos_;
-  index_->doNotLoadPermutations() = config.doNotLoadPermutations_;
-  index_->createFromOnDiskIndex(config.baseName_, config.persistUpdates_);
+  index.usePatterns() = enablePatternTrick_;
+  index.loadAllPermutations() = !config.onlyPsoAndPos_;
+  index.doNotLoadPermutations() = config.doNotLoadPermutations_;
+  index.createFromOnDiskIndex(config.baseName_, config.persistUpdates_);
   if (config.loadTextIndex_) {
-    index_->addTextFromOnDiskIndex();
+    index.addTextFromOnDiskIndex();
   }
 
-  materializedViewsManager_->setOnDiskBase(config.baseName_);
+  materializedViewsManager.setOnDiskBase(config.baseName_);
 
   // Estimate the cost of sorting operations (needed for query planning).
   sortPerformanceEstimator_.computeEstimatesExpensively(
-      allocator_, index_->numTriples().normalAndInternal_() *
+      allocator_, index.numTriples().normalAndInternal_() *
                       PERCENTAGE_OF_TRIPLES_FOR_SORT_ESTIMATE / 100);
 
   // Preload materialized views as requested by the user.
   for (const auto& viewName : config.preloadMaterializedViews_) {
     try {
-      materializedViewsManager_->loadView(viewName);
+      materializedViewsManager.loadView(viewName);
     } catch (const std::exception& ex) {
       AD_LOG_ERROR << "Preloading materialized view '" << viewName
                    << "' failed: " << ex.what() << "." << std::endl;
@@ -200,13 +210,14 @@ void Qlever::eraseResultWithName(std::string name) {
 
 // ___________________________________________________________________________
 Qlever::QueryPlan Qlever::parseAndPlanQuery(std::string query) const {
+  auto [index, materializedViewsManager] = indexAndViewsSnapshot();
   auto qecPtr = std::make_shared<QueryExecutionContext>(
-      index_, &cache_, allocator_, sortPerformanceEstimator_,
-      &namedResultCache_, materializedViewsManager_, [](std::string) {}, false,
-      false, disableCaching_);
+      index, &cache_, allocator_, sortPerformanceEstimator_, &namedResultCache_,
+      materializedViewsManager, [](std::string) {}, false, false,
+      disableCaching_);
   // TODO<joka921> support Dataset clauses.
   auto parsedQuery = SparqlParser::parseQuery(
-      &index_->getImpl().encodedIriManager(), std::move(query), {});
+      &index->getImpl().encodedIriManager(), std::move(query), {});
   auto handle = std::make_shared<ad_utility::CancellationHandle<>>();
   QueryPlanner qp{qecPtr.get(), handle};
   qp.setEnablePatternTrick(enablePatternTrick_);
@@ -239,27 +250,29 @@ void IndexBuilderConfig::validate() const {
 
 // ___________________________________________________________________________
 void Qlever::writeMaterializedView(std::string name, std::string query) const {
-  materializedViewsManager_->writeViewToDisk(
+  materializedViewsManager()->writeViewToDisk(
       std::move(name), parseAndPlanQuery(std::move(query)));
 }
 
 // ___________________________________________________________________________
 bool Qlever::isMaterializedViewLoaded(const std::string& name) const {
-  return materializedViewsManager_->isViewLoaded(name);
+  return materializedViewsManager()->isViewLoaded(name);
 }
 
 // ___________________________________________________________________________
 void Qlever::loadMaterializedView(std::string name) const {
-  materializedViewsManager_->loadView(name);
+  materializedViewsManager()->loadView(name);
 }
 
 // ___________________________________________________________________________
 std::shared_ptr<QueryExecutionContext> Qlever::createQueryExecutionContext(
+    std::shared_ptr<const Index> index,
+    std::shared_ptr<MaterializedViewsManager> materializedViewsManager,
     std::function<void(std::string)> updateCallback, bool pinSubtrees,
     bool pinResult) {
   return std::make_shared<QueryExecutionContext>(
-      sharedIndex(), &cache_, allocator_, sortPerformanceEstimator_,
-      &namedResultCache_, materializedViewsManager_, updateCallback,
-      pinSubtrees, pinResult);
+      std::move(index), &cache_, allocator_, sortPerformanceEstimator_,
+      &namedResultCache_, std::move(materializedViewsManager),
+      std::move(updateCallback), pinSubtrees, pinResult);
 }
 }  // namespace qlever

--- a/src/libqlever/Qlever.cpp
+++ b/src/libqlever/Qlever.cpp
@@ -30,7 +30,7 @@ Qlever::Qlever(const EngineConfig& config)
                                             numMemoryToAllocate);
           }}},
       indexAndViews_{std::make_shared<IndexAndViews>(
-          IndexAndViews{Index{allocator_}, MaterializedViewsManager{}})},
+          Index{allocator_}, MaterializedViewsManager{})},
       enablePatternTrick_{!config.noPatterns_},
       disableCaching_{config.disableCaching_} {
   // Set runtime parameters relevant for caching and propagate them to the
@@ -48,9 +48,7 @@ Qlever::Qlever(const EngineConfig& config)
   // No other thread can observe them yet, so reading the snapshot here is safe.
   // `snapshot` keeps the `shared_ptr`s alive for the references below.
   auto snapshot = indexAndViewsSnapshot();
-  Index& index = snapshot->index_;
-  MaterializedViewsManager& materializedViewsManager =
-      snapshot->materializedViewsManager_;
+  auto& [index, materializedViewsManager] = *snapshot;
 
   // Load the index from disk.
   index.usePatterns() = enablePatternTrick_;
@@ -209,10 +207,11 @@ void Qlever::eraseResultWithName(std::string name) {
 
 // ___________________________________________________________________________
 Qlever::QueryPlan Qlever::parseAndPlanQuery(std::string query) const {
-  auto indexAndViews = indexAndViewsSnapshot();
   auto qecPtr = createQueryExecutionContext(
-      std::move(indexAndViews), [](std::string) {}, false, false,
-      disableCaching_);
+      indexAndViewsSnapshot(),
+      [](const std::
+             string&) { /* No runtime updates for this interface yet. */ },
+      false, false, disableCaching_);
   // TODO<joka921> support Dataset clauses.
   auto parsedQuery = SparqlParser::parseQuery(
       &qecPtr->getIndex().getImpl().encodedIriManager(), std::move(query), {});
@@ -268,10 +267,7 @@ std::shared_ptr<QueryExecutionContext> Qlever::createQueryExecutionContext(
     std::function<void(std::string)> updateCallback, bool pinSubtrees,
     bool pinResult,
     QueryExecutionContext::DisableCaching disableCaching) const {
-  std::shared_ptr<Index> index{indexAndViews, &indexAndViews->index_};
-  auto& viewsManagerRef = indexAndViews->materializedViewsManager_;
-  std::shared_ptr<MaterializedViewsManager> viewsManager{
-      std::move(indexAndViews), &viewsManagerRef};
+  auto [index, viewsManager] = getPointerPair(std::move(indexAndViews));
   return std::make_shared<QueryExecutionContext>(
       std::move(index), &cache_, allocator_, sortPerformanceEstimator_,
       &namedResultCache_, std::move(viewsManager), std::move(updateCallback),

--- a/src/libqlever/Qlever.cpp
+++ b/src/libqlever/Qlever.cpp
@@ -210,16 +210,12 @@ void Qlever::eraseResultWithName(std::string name) {
 // ___________________________________________________________________________
 Qlever::QueryPlan Qlever::parseAndPlanQuery(std::string query) const {
   auto indexAndViews = indexAndViewsSnapshot();
-  std::shared_ptr<Index> index{indexAndViews, &indexAndViews->index_};
-  std::shared_ptr<MaterializedViewsManager> materializedViewsManager{
-      indexAndViews, &indexAndViews->materializedViewsManager_};
-  auto qecPtr = std::make_shared<QueryExecutionContext>(
-      index, &cache_, allocator_, sortPerformanceEstimator_, &namedResultCache_,
-      materializedViewsManager, [](std::string) {}, false, false,
+  auto qecPtr = createQueryExecutionContext(
+      std::move(indexAndViews), [](std::string) {}, false, false,
       disableCaching_);
   // TODO<joka921> support Dataset clauses.
   auto parsedQuery = SparqlParser::parseQuery(
-      &index->getImpl().encodedIriManager(), std::move(query), {});
+      &qecPtr->getIndex().getImpl().encodedIriManager(), std::move(query), {});
   auto handle = std::make_shared<ad_utility::CancellationHandle<>>();
   QueryPlanner qp{qecPtr.get(), handle};
   qp.setEnablePatternTrick(enablePatternTrick_);
@@ -270,7 +266,8 @@ void Qlever::loadMaterializedView(std::string name) const {
 std::shared_ptr<QueryExecutionContext> Qlever::createQueryExecutionContext(
     std::shared_ptr<IndexAndViews> indexAndViews,
     std::function<void(std::string)> updateCallback, bool pinSubtrees,
-    bool pinResult) {
+    bool pinResult,
+    QueryExecutionContext::DisableCaching disableCaching) const {
   std::shared_ptr<Index> index{indexAndViews, &indexAndViews->index_};
   auto& viewsManagerRef = indexAndViews->materializedViewsManager_;
   std::shared_ptr<MaterializedViewsManager> viewsManager{
@@ -278,6 +275,6 @@ std::shared_ptr<QueryExecutionContext> Qlever::createQueryExecutionContext(
   return std::make_shared<QueryExecutionContext>(
       std::move(index), &cache_, allocator_, sortPerformanceEstimator_,
       &namedResultCache_, std::move(viewsManager), std::move(updateCallback),
-      pinSubtrees, pinResult);
+      pinSubtrees, pinResult, disableCaching);
 }
 }  // namespace qlever

--- a/src/libqlever/Qlever.cpp
+++ b/src/libqlever/Qlever.cpp
@@ -29,9 +29,8 @@ Qlever::Qlever(const EngineConfig& config)
             cache_.makeRoomAsMuchAsPossible(MAKE_ROOM_SLACK_FACTOR *
                                             numMemoryToAllocate);
           }}},
-      indexAndViews_{
-          IndexAndViews{std::make_shared<Index>(allocator_),
-                        std::make_shared<MaterializedViewsManager>()}},
+      indexAndViews_{std::make_shared<IndexAndViews>(
+          IndexAndViews{Index{allocator_}, MaterializedViewsManager{}})},
       enablePatternTrick_{!config.noPatterns_},
       disableCaching_{config.disableCaching_} {
   // Set runtime parameters relevant for caching and propagate them to the
@@ -49,9 +48,9 @@ Qlever::Qlever(const EngineConfig& config)
   // No other thread can observe them yet, so reading the snapshot here is safe.
   // `snapshot` keeps the `shared_ptr`s alive for the references below.
   auto snapshot = indexAndViewsSnapshot();
-  Index& index = *snapshot.index_;
+  Index& index = snapshot->index_;
   MaterializedViewsManager& materializedViewsManager =
-      *snapshot.materializedViewsManager_;
+      snapshot->materializedViewsManager_;
 
   // Load the index from disk.
   index.usePatterns() = enablePatternTrick_;
@@ -210,7 +209,10 @@ void Qlever::eraseResultWithName(std::string name) {
 
 // ___________________________________________________________________________
 Qlever::QueryPlan Qlever::parseAndPlanQuery(std::string query) const {
-  auto [index, materializedViewsManager] = indexAndViewsSnapshot();
+  auto indexAndViews = indexAndViewsSnapshot();
+  std::shared_ptr<Index> index{indexAndViews, &indexAndViews->index_};
+  std::shared_ptr<MaterializedViewsManager> materializedViewsManager{
+      indexAndViews, &indexAndViews->materializedViewsManager_};
   auto qecPtr = std::make_shared<QueryExecutionContext>(
       index, &cache_, allocator_, sortPerformanceEstimator_, &namedResultCache_,
       materializedViewsManager, [](std::string) {}, false, false,
@@ -266,13 +268,16 @@ void Qlever::loadMaterializedView(std::string name) const {
 
 // ___________________________________________________________________________
 std::shared_ptr<QueryExecutionContext> Qlever::createQueryExecutionContext(
-    std::shared_ptr<const Index> index,
-    std::shared_ptr<MaterializedViewsManager> materializedViewsManager,
+    std::shared_ptr<IndexAndViews> indexAndViews,
     std::function<void(std::string)> updateCallback, bool pinSubtrees,
     bool pinResult) {
+  std::shared_ptr<Index> index{indexAndViews, &indexAndViews->index_};
+  auto& viewsManagerRef = indexAndViews->materializedViewsManager_;
+  std::shared_ptr<MaterializedViewsManager> viewsManager{
+      std::move(indexAndViews), &viewsManagerRef};
   return std::make_shared<QueryExecutionContext>(
       std::move(index), &cache_, allocator_, sortPerformanceEstimator_,
-      &namedResultCache_, std::move(materializedViewsManager),
-      std::move(updateCallback), pinSubtrees, pinResult);
+      &namedResultCache_, std::move(viewsManager), std::move(updateCallback),
+      pinSubtrees, pinResult);
 }
 }  // namespace qlever

--- a/src/libqlever/Qlever.h
+++ b/src/libqlever/Qlever.h
@@ -297,7 +297,9 @@ class Qlever {
   // Read the contents of the `NamedResultCache` from disk.
   template <typename Serializer>
   void readNamedResultCacheFromDisk(Serializer& serializer) {
-    namedResultCache_.readFromSerializer(serializer, allocator_, index());
+    auto indexAndViews = indexAndViewsSnapshot();
+    namedResultCache_.readFromSerializer(serializer, allocator_,
+                                         indexAndViews->index_);
   }
 
   // Create a Query Execution Context needed for execution of single SPARQL
@@ -325,18 +327,6 @@ class Qlever {
   void swapIndexAndViews(std::shared_ptr<IndexAndViews> indexAndViews) {
     *indexAndViews_.wlock() = std::move(indexAndViews);
   }
-
-  // Low-level access to the QLever API, use with care. NOTE: The `Index&`
-  // overloads return a reference into the currently active index; do not hold
-  // on to it across a potential index rebuild. Use `sharedIndex()` or
-  // `indexAndViewsSnapshot()` if you need a stable handle.
-  std::shared_ptr<const Index> sharedIndex() const {
-    auto snapshot = *indexAndViews_.rlock();
-    const Index* index = &snapshot->index_;
-    return {std::move(snapshot), index};
-  }
-  Index& index() { return (*indexAndViews_.rlock())->index_; }
-  const Index& index() const { return (*indexAndViews_.rlock())->index_; }
 
   QueryResultCache& cache() { return cache_; }
   const QueryResultCache& cache() const { return cache_; }

--- a/src/libqlever/Qlever.h
+++ b/src/libqlever/Qlever.h
@@ -24,6 +24,7 @@
 #include "libqlever/QleverTypes.h"
 #include "util/AllocatorWithLimit.h"
 #include "util/MemorySize/MemorySize.h"
+#include "util/Synchronized.h"
 #include "util/http/MediaTypes.h"
 
 namespace qlever {
@@ -199,15 +200,22 @@ struct EngineConfig : CommonConfig {
 // Class to use QLever as an embedded database, without the HTTP server. See
 // `src/engine/LibQleverExample.cpp` for an example use.
 class Qlever {
+ public:
+  // Bundle the `Index` and the `MaterializedViewsManager` under a single mutex
+  // so that an index rebuild can atomically swap both in, while other threads
+  // continue to read the previous instances via the `shared_ptr`s they hold.
+  struct IndexAndViews {
+    std::shared_ptr<Index> index_;
+    std::shared_ptr<MaterializedViewsManager> materializedViewsManager_;
+  };
+
  private:
   // The cache is threadsafe, so making it `mutable` is reasonably safe.
   mutable QueryResultCache cache_;
   ad_utility::AllocatorWithLimit<Id> allocator_;
   SortPerformanceEstimator sortPerformanceEstimator_;
-  std::shared_ptr<Index> index_;
   mutable NamedResultCache namedResultCache_;
-  std::shared_ptr<MaterializedViewsManager> materializedViewsManager_ =
-      std::make_shared<MaterializedViewsManager>();
+  ad_utility::Synchronized<IndexAndViews> indexAndViews_;
   bool enablePatternTrick_;
   QueryExecutionContext::DisableCaching disableCaching_;
 
@@ -293,16 +301,43 @@ class Qlever {
   }
 
   // Create a Query Execution Context needed for execution of single SPARQL
-  // query.
+  // query. Use an explicitly snapshotted `Index` and `MaterializedViewsManager`
+  // (see `indexAndViewsSnapshot()`).
   std::shared_ptr<QueryExecutionContext> createQueryExecutionContext(
+      std::shared_ptr<const Index> index,
+      std::shared_ptr<MaterializedViewsManager> materializedViewsManager,
       std::function<void(std::string)> updateCallback =
           [](std::string) { /* the default is a noop*/ },
       bool pinSubtrees = false, bool pinResult = false);
 
-  // Low-level access to the QLever API, use with care.
-  std::shared_ptr<const Index> sharedIndex() const { return index_; }
-  Index& index() { return *index_; }
-  const Index& index() const { return *index_; }
+  // Atomically snapshot both the `Index` and the `MaterializedViewsManager`
+  // under a single read lock, so that all code paths handling a single request
+  // observe a matching pair even if a concurrent rebuild swaps the pointers
+  // between two reads.
+  IndexAndViews indexAndViewsSnapshot() const {
+    return *indexAndViews_.rlock();
+  }
+
+  // Atomically swap in a freshly built `Index` and `MaterializedViewsManager`.
+  // Old instances stay alive as long as some `shared_ptr` (e.g. obtained via
+  // `indexAndViewsSnapshot()`) still references them.
+  void swapIndexAndViews(
+      std::shared_ptr<Index> index,
+      std::shared_ptr<MaterializedViewsManager> materializedViewsManager) {
+    auto lock = indexAndViews_.wlock();
+    lock->index_ = std::move(index);
+    lock->materializedViewsManager_ = std::move(materializedViewsManager);
+  }
+
+  // Low-level access to the QLever API, use with care. NOTE: The `Index&`
+  // overloads return a reference into the currently active index; do not hold
+  // on to it across a potential index rebuild. Use `sharedIndex()` or
+  // `indexAndViewsSnapshot()` if you need a stable handle.
+  std::shared_ptr<const Index> sharedIndex() const {
+    return indexAndViews_.rlock()->index_;
+  }
+  Index& index() { return *indexAndViews_.rlock()->index_; }
+  const Index& index() const { return *indexAndViews_.rlock()->index_; }
 
   QueryResultCache& cache() { return cache_; }
   const QueryResultCache& cache() const { return cache_; }
@@ -323,7 +358,7 @@ class Qlever {
   const NamedResultCache& namedResultCache() const { return namedResultCache_; }
 
   std::shared_ptr<MaterializedViewsManager> materializedViewsManager() const {
-    return materializedViewsManager_;
+    return indexAndViews_.rlock()->materializedViewsManager_;
   }
 };
 }  // namespace qlever

--- a/src/libqlever/Qlever.h
+++ b/src/libqlever/Qlever.h
@@ -207,6 +207,30 @@ class Qlever {
   struct IndexAndViews {
     Index index_;
     MaterializedViewsManager materializedViewsManager_;
+
+    // Create an instance.
+    IndexAndViews(Index index,
+                  MaterializedViewsManager materializedViewsManager)
+        : index_{std::move(index)},
+          materializedViewsManager_{std::move(materializedViewsManager)} {}
+
+    // Make sue this is only passed around as a shared pointer or reference.
+    IndexAndViews(IndexAndViews&&) noexcept = delete;
+    IndexAndViews& operator=(IndexAndViews&&) noexcept = delete;
+    IndexAndViews(const IndexAndViews&) noexcept = delete;
+    IndexAndViews& operator=(const IndexAndViews&) noexcept = delete;
+
+    // Helper function to decompose `self` into a pair of two shared pointers
+    // pointing to the individual members via aliasing semantics.
+    friend std::pair<std::shared_ptr<Index>,
+                     std::shared_ptr<MaterializedViewsManager>>
+    getPointerPair(std::shared_ptr<IndexAndViews> self) {
+      std::shared_ptr<Index> index{self, &self->index_};
+      auto& viewsManagerRef = self->materializedViewsManager_;
+      return std::pair{std::move(index),
+                       std::shared_ptr<MaterializedViewsManager>{
+                           std::move(self), &viewsManagerRef}};
+    }
   };
 
  private:

--- a/src/libqlever/Qlever.h
+++ b/src/libqlever/Qlever.h
@@ -205,8 +205,8 @@ class Qlever {
   // so that an index rebuild can atomically swap both in, while other threads
   // continue to read the previous instances via the `shared_ptr`s they hold.
   struct IndexAndViews {
-    std::shared_ptr<Index> index_;
-    std::shared_ptr<MaterializedViewsManager> materializedViewsManager_;
+    Index index_;
+    MaterializedViewsManager materializedViewsManager_;
   };
 
  private:
@@ -215,7 +215,7 @@ class Qlever {
   ad_utility::AllocatorWithLimit<Id> allocator_;
   SortPerformanceEstimator sortPerformanceEstimator_;
   mutable NamedResultCache namedResultCache_;
-  ad_utility::Synchronized<IndexAndViews> indexAndViews_;
+  ad_utility::Synchronized<std::shared_ptr<IndexAndViews>> indexAndViews_;
   bool enablePatternTrick_;
   QueryExecutionContext::DisableCaching disableCaching_;
 
@@ -301,11 +301,10 @@ class Qlever {
   }
 
   // Create a Query Execution Context needed for execution of single SPARQL
-  // query. Use an explicitly snapshotted `Index` and `MaterializedViewsManager`
-  // (see `indexAndViewsSnapshot()`).
+  // query. Use an explicitly snapshotted `IndexAndViews` to make sure we have a
+  // consistent state.
   std::shared_ptr<QueryExecutionContext> createQueryExecutionContext(
-      std::shared_ptr<const Index> index,
-      std::shared_ptr<MaterializedViewsManager> materializedViewsManager,
+      std::shared_ptr<IndexAndViews> indexAndViews,
       std::function<void(std::string)> updateCallback =
           [](std::string) { /* the default is a noop*/ },
       bool pinSubtrees = false, bool pinResult = false);
@@ -314,19 +313,15 @@ class Qlever {
   // under a single read lock, so that all code paths handling a single request
   // observe a matching pair even if a concurrent rebuild swaps the pointers
   // between two reads.
-  IndexAndViews indexAndViewsSnapshot() const {
+  std::shared_ptr<IndexAndViews> indexAndViewsSnapshot() const {
     return *indexAndViews_.rlock();
   }
 
-  // Atomically swap in a freshly built `Index` and `MaterializedViewsManager`.
-  // Old instances stay alive as long as some `shared_ptr` (e.g. obtained via
-  // `indexAndViewsSnapshot()`) still references them.
-  void swapIndexAndViews(
-      std::shared_ptr<Index> index,
-      std::shared_ptr<MaterializedViewsManager> materializedViewsManager) {
-    auto lock = indexAndViews_.wlock();
-    lock->index_ = std::move(index);
-    lock->materializedViewsManager_ = std::move(materializedViewsManager);
+  // Atomically swap in a freshly built `IndexAndViews`. The old instance stays
+  // alive as long as some `shared_ptr` (e.g. obtained via
+  // `indexAndViewsSnapshot()`) still references it.
+  void swapIndexAndViews(std::shared_ptr<IndexAndViews> indexAndViews) {
+    *indexAndViews_.wlock() = std::move(indexAndViews);
   }
 
   // Low-level access to the QLever API, use with care. NOTE: The `Index&`
@@ -334,10 +329,12 @@ class Qlever {
   // on to it across a potential index rebuild. Use `sharedIndex()` or
   // `indexAndViewsSnapshot()` if you need a stable handle.
   std::shared_ptr<const Index> sharedIndex() const {
-    return indexAndViews_.rlock()->index_;
+    auto snapshot = *indexAndViews_.rlock();
+    const Index* index = &snapshot->index_;
+    return {std::move(snapshot), index};
   }
-  Index& index() { return *indexAndViews_.rlock()->index_; }
-  const Index& index() const { return *indexAndViews_.rlock()->index_; }
+  Index& index() { return (*indexAndViews_.rlock())->index_; }
+  const Index& index() const { return (*indexAndViews_.rlock())->index_; }
 
   QueryResultCache& cache() { return cache_; }
   const QueryResultCache& cache() const { return cache_; }
@@ -358,7 +355,9 @@ class Qlever {
   const NamedResultCache& namedResultCache() const { return namedResultCache_; }
 
   std::shared_ptr<MaterializedViewsManager> materializedViewsManager() const {
-    return indexAndViews_.rlock()->materializedViewsManager_;
+    auto snapshot = *indexAndViews_.rlock();
+    MaterializedViewsManager* manager = &snapshot->materializedViewsManager_;
+    return {std::move(snapshot), manager};
   }
 };
 }  // namespace qlever

--- a/src/libqlever/Qlever.h
+++ b/src/libqlever/Qlever.h
@@ -307,7 +307,9 @@ class Qlever {
       std::shared_ptr<IndexAndViews> indexAndViews,
       std::function<void(std::string)> updateCallback =
           [](std::string) { /* the default is a noop*/ },
-      bool pinSubtrees = false, bool pinResult = false);
+      bool pinSubtrees = false, bool pinResult = false,
+      QueryExecutionContext::DisableCaching disableCaching =
+          QueryExecutionContext::DisableCaching::FromRuntimeParameter) const;
 
   // Atomically snapshot both the `Index` and the `MaterializedViewsManager`
   // under a single read lock, so that all code paths handling a single request

--- a/test/ServerTest.cpp
+++ b/test/ServerTest.cpp
@@ -190,7 +190,7 @@ TEST(ServerTest, composeStatsJson) {
                     {"num-triples-internal", 1},
                     {"num-triples-normal", 1},
                     {"num-word-occurrences", 0}};
-  EXPECT_THAT(server.composeStatsJson(*server.indexAndViewsSnapshot().index_),
+  EXPECT_THAT(server.composeStatsJson(server.indexAndViewsSnapshot()->index_),
               testing::Eq(expectedJson));
 }
 

--- a/test/ServerTest.cpp
+++ b/test/ServerTest.cpp
@@ -190,7 +190,8 @@ TEST(ServerTest, composeStatsJson) {
                     {"num-triples-internal", 1},
                     {"num-triples-normal", 1},
                     {"num-word-occurrences", 0}};
-  EXPECT_THAT(server.composeStatsJson(), testing::Eq(expectedJson));
+  EXPECT_THAT(server.composeStatsJson(*server.indexAndViewsSnapshot().index_),
+              testing::Eq(expectedJson));
 }
 
 // _____________________________________________________________________________

--- a/test/libqlever/QleverTest.cpp
+++ b/test/libqlever/QleverTest.cpp
@@ -218,7 +218,8 @@ TEST(LibQlever, loadIndexWithoutPermutations) {
 
   // Test that the `setKbName` function silently does nothing, if we have no
   // index.
-  EXPECT_NO_THROW(engine.index().setKbName("we have no triples!"));
+  EXPECT_NO_THROW(
+      engine.indexAndViewsSnapshot()->index_.setKbName("we have no triples!"));
 
   // Run a query that doesn't need to access permutations (constant expression).
   std::string query = "SELECT (3 + 5 AS ?result) {}";


### PR DESCRIPTION
In `Qlever.cpp` and `Server.cpp` there is now a struct `IndexAndViews` that ties an `Index` and a `MaterializedViewsManager` together in a `shared_ptr`. The code in `Server.cpp` has been restructured such that, at the beginning of each request, it obtains a `shared_ptr<IndexAndViews>`, which is then used consistently throughout the request. This way, each request sees a consistent `(index, views)` pair even when a concurrent rebuild swaps both in mid-request. In particular, this is a prerequisite for enabling an index rebuild and index swap from within the process.