### PR TITLE
Move query planning from `Server` class into `Qlever` class

### DIFF
--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -763,20 +763,10 @@ Server::PlannedQuery Server::planQuery(
     ParsedQuery&& operation, const ad_utility::Timer& requestTimer,
     TimeLimit timeLimit, QueryExecutionContext& qec,
     ad_utility::SharedCancellationHandle handle) const {
-  QueryPlanner qp(&qec, handle);
-  auto executionTree = qp.createExecutionTree(operation);
-  PlannedQuery plannedQuery{std::move(operation), std::move(executionTree),
-                            qec};
-  handle->throwIfCancelled();
-  // Set some additional attributes on the `PlannedQuery`.
-  plannedQuery.queryExecutionTree()
-      .getRootOperation()
-      ->recursivelySetCancellationHandle(std::move(handle));
-  plannedQuery.queryExecutionTree()
-      .getRootOperation()
-      ->recursivelySetTimeConstraint(timeLimit);
+  PlannedQuery plannedQuery = qlever().planQuery(
+      std::move(operation), timeLimit, qec, std::move(handle));
+
   auto& qet = plannedQuery.queryExecutionTree();
-  qet.isRoot() = true;  // allow pinning of the final result
   auto timeForQueryPlanning = requestTimer.msecs();
   auto& runtimeInfoWholeQuery =
       qet.getRootOperation()->getRuntimeInfoWholeQuery();

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -764,15 +764,14 @@ Server::PlannedQuery Server::planQuery(
     TimeLimit timeLimit, QueryExecutionContext& qec,
     ad_utility::SharedCancellationHandle handle) const {
   PlannedQuery plannedQuery = qlever().planQuery(
-      std::move(operation), timeLimit, qec, std::move(handle));
+      std::move(operation), requestTimer, timeLimit, qec, std::move(handle));
 
   auto& qet = plannedQuery.queryExecutionTree();
-  auto timeForQueryPlanning = requestTimer.msecs();
   auto& runtimeInfoWholeQuery =
       qet.getRootOperation()->getRuntimeInfoWholeQuery();
-  runtimeInfoWholeQuery.timeQueryPlanning = timeForQueryPlanning;
-  AD_LOG_INFO << "Query planning done in " << timeForQueryPlanning.count()
-              << " ms" << std::endl;
+  AD_LOG_INFO << "Query planning done in "
+              << runtimeInfoWholeQuery.timeQueryPlanning.count() << " ms"
+              << std::endl;
   AD_LOG_TRACE << qet.getCacheKey() << std::endl;
   return plannedQuery;
 }

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -764,13 +764,12 @@ Server::PlannedQuery Server::planQuery(
     TimeLimit timeLimit, QueryExecutionContext& qec,
     ad_utility::SharedCancellationHandle handle) const {
   PlannedQuery plannedQuery = qlever().planQuery(
-      std::move(operation), timeLimit, qec, std::move(handle));
+      std::move(operation), timeLimit, qec, std::move(handle), requestTimer);
 
   auto& qet = plannedQuery.queryExecutionTree();
-  auto timeForQueryPlanning = requestTimer.msecs();
   auto& runtimeInfoWholeQuery =
       qet.getRootOperation()->getRuntimeInfoWholeQuery();
-  runtimeInfoWholeQuery.timeQueryPlanning = timeForQueryPlanning;
+  auto timeForQueryPlanning = runtimeInfoWholeQuery.timeQueryPlanning;
   AD_LOG_INFO << "Query planning done in " << timeForQueryPlanning.count()
               << " ms" << std::endl;
   AD_LOG_TRACE << qet.getCacheKey() << std::endl;

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -766,8 +766,8 @@ Server::PlannedQuery Server::planQuery(
   PlannedQuery plannedQuery = qlever().planQuery(
       std::move(operation), timeLimit, qec, std::move(handle), requestTimer);
 
-  auto& qet = plannedQuery.queryExecutionTree();
-  auto& runtimeInfoWholeQuery =
+  const auto& qet = plannedQuery.queryExecutionTree();
+  const auto& runtimeInfoWholeQuery =
       qet.getRootOperation()->getRuntimeInfoWholeQuery();
   auto timeForQueryPlanning = runtimeInfoWholeQuery.timeQueryPlanning;
   AD_LOG_INFO << "Query planning done in " << timeForQueryPlanning.count()

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -764,14 +764,15 @@ Server::PlannedQuery Server::planQuery(
     TimeLimit timeLimit, QueryExecutionContext& qec,
     ad_utility::SharedCancellationHandle handle) const {
   PlannedQuery plannedQuery = qlever().planQuery(
-      std::move(operation), requestTimer, timeLimit, qec, std::move(handle));
+      std::move(operation), timeLimit, qec, std::move(handle));
 
   auto& qet = plannedQuery.queryExecutionTree();
+  auto timeForQueryPlanning = requestTimer.msecs();
   auto& runtimeInfoWholeQuery =
       qet.getRootOperation()->getRuntimeInfoWholeQuery();
-  AD_LOG_INFO << "Query planning done in "
-              << runtimeInfoWholeQuery.timeQueryPlanning.count() << " ms"
-              << std::endl;
+  runtimeInfoWholeQuery.timeQueryPlanning = timeForQueryPlanning;
+  AD_LOG_INFO << "Query planning done in " << timeForQueryPlanning.count()
+              << " ms" << std::endl;
   AD_LOG_TRACE << qet.getCacheKey() << std::endl;
   return plannedQuery;
 }

--- a/src/libqlever/Qlever.cpp
+++ b/src/libqlever/Qlever.cpp
@@ -206,14 +206,35 @@ void Qlever::eraseResultWithName(std::string name) {
 }
 
 // ___________________________________________________________________________
+PlannedQuery Qlever::planQuery(
+    ParsedQuery&& operation, std::optional<TimeLimit> timeLimit,
+    QueryExecutionContext& qec,
+    ad_utility::SharedCancellationHandle handle) const {
+  handle->throwIfCancelled();
+  QueryPlanner qp{&qec, handle};
+
+  qp.setEnablePatternTrick(enablePatternTrick_);
+  auto qet = qp.createExecutionTree(operation);
+  qet.isRoot() = true;
+  PlannedQuery plannedQuery = {std::move(operation), std::move(qet), qec};
+
+  auto& rootOperation = *plannedQuery.queryExecutionTree().getRootOperation();
+  // Propagate the `cancellationHandle` and the `timeLimit` through the
+  // `queryExecutionTree`.
+  rootOperation.recursivelySetCancellationHandle(std::move(handle));
+  if (timeLimit.has_value()) {
+    rootOperation.recursivelySetTimeConstraint(timeLimit.value());
+  }
+  return plannedQuery;
+}
+
+// ___________________________________________________________________________
 PlannedQuery Qlever::parseAndPlanQuery(
     std::string query, const std::vector<DatasetClause>& datasetClauses,
     ad_utility::SharedCancellationHandle handle,
     std::optional<TimeLimit> timeLimit,
     std::function<void(std::string)> updateCallback, bool pinSubtrees,
     bool pinResult) const {
-  ad_utility::Timer planningTimer{ad_utility::Timer::InitialStatus::Started};
-
   auto qecPtr = createQueryExecutionContext(
       indexAndViewsSnapshot(), std::move(updateCallback), pinSubtrees,
       pinResult, disableCaching_);
@@ -222,23 +243,7 @@ PlannedQuery Qlever::parseAndPlanQuery(
       &qecPtr->getIndex().getImpl().encodedIriManager(), std::move(query),
       datasetClauses);
 
-  QueryPlanner qp{qecPtr.get(), handle};
-
-  qp.setEnablePatternTrick(enablePatternTrick_);
-  auto qet = qp.createExecutionTree(parsedQuery);
-  qet.isRoot() = true;
-  PlannedQuery plannedQuery{std::move(parsedQuery), std::move(qet), *qecPtr};
-
-  handle->throwIfCancelled();
-  auto& rootOperation = *plannedQuery.queryExecutionTree().getRootOperation();
-  // Propagate the `cancellationHandle` and the `timeLimit` through the
-  // `queryExecutionTree`.
-  rootOperation.recursivelySetCancellationHandle(std::move(handle));
-  if (timeLimit.has_value()) {
-    rootOperation.recursivelySetTimeConstraint(timeLimit.value());
-  }
-
-  return plannedQuery;
+  return planQuery(std::move(parsedQuery), timeLimit, *qecPtr, handle);
 }
 
 // ___________________________________________________________________________

--- a/src/libqlever/Qlever.cpp
+++ b/src/libqlever/Qlever.cpp
@@ -207,8 +207,8 @@ void Qlever::eraseResultWithName(std::string name) {
 
 // ___________________________________________________________________________
 PlannedQuery Qlever::planQuery(
-    ParsedQuery&& operation, const ad_utility::Timer& requestTimer,
-    std::optional<TimeLimit> timeLimit, QueryExecutionContext& qec,
+    ParsedQuery&& operation, std::optional<TimeLimit> timeLimit,
+    QueryExecutionContext& qec,
     ad_utility::SharedCancellationHandle handle) const {
   handle->throwIfCancelled();
   QueryPlanner qp{&qec, handle};
@@ -225,10 +225,6 @@ PlannedQuery Qlever::planQuery(
   if (timeLimit.has_value()) {
     rootOperation.recursivelySetTimeConstraint(timeLimit.value());
   }
-  auto timeForQueryPlanning = requestTimer.msecs();
-  auto& runtimeInfoWholeQuery =
-      qet.getRootOperation()->getRuntimeInfoWholeQuery();
-  runtimeInfoWholeQuery.timeQueryPlanning = timeForQueryPlanning;
   return plannedQuery;
 }
 

--- a/src/libqlever/Qlever.cpp
+++ b/src/libqlever/Qlever.cpp
@@ -6,6 +6,7 @@
 
 #include "libqlever/Qlever.h"
 
+#include <boost/optional.hpp>
 #include <functional>
 #include <memory>
 #include <stdexcept>
@@ -207,16 +208,16 @@ void Qlever::eraseResultWithName(std::string name) {
 
 // ___________________________________________________________________________
 PlannedQuery Qlever::planQuery(
-    ParsedQuery&& operation, std::optional<TimeLimit> timeLimit,
-    QueryExecutionContext& qec,
-    ad_utility::SharedCancellationHandle handle) const {
+    ParsedQuery&& parsedQuery, std::optional<TimeLimit> timeLimit,
+    QueryExecutionContext& qec, ad_utility::SharedCancellationHandle handle,
+    boost::optional<const ad_utility::Timer&> requestTimer) const {
   handle->throwIfCancelled();
   QueryPlanner qp{&qec, handle};
 
   qp.setEnablePatternTrick(enablePatternTrick_);
-  auto qet = qp.createExecutionTree(operation);
+  auto qet = qp.createExecutionTree(parsedQuery);
   qet.isRoot() = true;
-  PlannedQuery plannedQuery = {std::move(operation), std::move(qet), qec};
+  PlannedQuery plannedQuery = {std::move(parsedQuery), std::move(qet), qec};
 
   auto& rootOperation = *plannedQuery.queryExecutionTree().getRootOperation();
   // Propagate the `cancellationHandle` and the `timeLimit` through the
@@ -224,6 +225,14 @@ PlannedQuery Qlever::planQuery(
   rootOperation.recursivelySetCancellationHandle(std::move(handle));
   if (timeLimit.has_value()) {
     rootOperation.recursivelySetTimeConstraint(timeLimit.value());
+  }
+
+  if (requestTimer.has_value()) {
+    auto& qet = plannedQuery.queryExecutionTree();
+    auto timeForQueryPlanning = requestTimer->msecs();
+    auto& runtimeInfoWholeQuery =
+        qet.getRootOperation()->getRuntimeInfoWholeQuery();
+    runtimeInfoWholeQuery.timeQueryPlanning = timeForQueryPlanning;
   }
   return plannedQuery;
 }
@@ -243,7 +252,8 @@ PlannedQuery Qlever::parseAndPlanQuery(
       &qecPtr->getIndex().getImpl().encodedIriManager(), std::move(query),
       datasetClauses);
 
-  return planQuery(std::move(parsedQuery), timeLimit, *qecPtr, handle);
+  return planQuery(std::move(parsedQuery), timeLimit, *qecPtr,
+                   std::move(handle));
 }
 
 // ___________________________________________________________________________

--- a/src/libqlever/Qlever.cpp
+++ b/src/libqlever/Qlever.cpp
@@ -207,8 +207,8 @@ void Qlever::eraseResultWithName(std::string name) {
 
 // ___________________________________________________________________________
 PlannedQuery Qlever::planQuery(
-    ParsedQuery&& operation, std::optional<TimeLimit> timeLimit,
-    QueryExecutionContext& qec,
+    ParsedQuery&& operation, const ad_utility::Timer& requestTimer,
+    std::optional<TimeLimit> timeLimit, QueryExecutionContext& qec,
     ad_utility::SharedCancellationHandle handle) const {
   handle->throwIfCancelled();
   QueryPlanner qp{&qec, handle};
@@ -225,6 +225,10 @@ PlannedQuery Qlever::planQuery(
   if (timeLimit.has_value()) {
     rootOperation.recursivelySetTimeConstraint(timeLimit.value());
   }
+  auto timeForQueryPlanning = requestTimer.msecs();
+  auto& runtimeInfoWholeQuery =
+      qet.getRootOperation()->getRuntimeInfoWholeQuery();
+  runtimeInfoWholeQuery.timeQueryPlanning = timeForQueryPlanning;
   return plannedQuery;
 }
 

--- a/src/libqlever/Qlever.h
+++ b/src/libqlever/Qlever.h
@@ -277,6 +277,12 @@ class Qlever {
   // class.
   using PlannedQuery = qlever::PlannedQuery;
 
+  // Plan a parsed query.
+  PlannedQuery planQuery(ParsedQuery&& operation,
+                         std::optional<TimeLimit> timeLimit,
+                         QueryExecutionContext& qec,
+                         SharedCancellationHandle handle) const;
+
   PlannedQuery parseAndPlanQuery(
       std::string query, const std::vector<DatasetClause>& datasetClauses = {},
       ad_utility::SharedCancellationHandle handle =

--- a/src/libqlever/Qlever.h
+++ b/src/libqlever/Qlever.h
@@ -279,7 +279,6 @@ class Qlever {
 
   // Plan a parsed query.
   PlannedQuery planQuery(ParsedQuery&& operation,
-                         const ad_utility::Timer& requestTimer,
                          std::optional<TimeLimit> timeLimit,
                          QueryExecutionContext& qec,
                          SharedCancellationHandle handle) const;

--- a/src/libqlever/Qlever.h
+++ b/src/libqlever/Qlever.h
@@ -261,6 +261,11 @@ class Qlever {
   // ParsedQuery::hasUpdateClause()); this function handles both cases
   // uniformly.
   //
+  // If `requestTimer` is set, the elapsed time of that timer at the end of
+  // query planning is stored in the query's runtime information as
+  // `timeQueryPlanning`. This information can be accessed via the
+  // query execution tree's root operation.
+  //
   // TODO<joka921,damekt> The `timeLimit` is currently only used for
   // non-cancelable operations (in particular sorting). The time limit applies
   // from the time this function is called until the execution of the query

--- a/src/libqlever/Qlever.h
+++ b/src/libqlever/Qlever.h
@@ -279,6 +279,7 @@ class Qlever {
 
   // Plan a parsed query.
   PlannedQuery planQuery(ParsedQuery&& operation,
+                         const ad_utility::Timer& requestTimer,
                          std::optional<TimeLimit> timeLimit,
                          QueryExecutionContext& qec,
                          SharedCancellationHandle handle) const;

--- a/src/libqlever/Qlever.h
+++ b/src/libqlever/Qlever.h
@@ -7,6 +7,7 @@
 #ifndef QLEVER_SRC_LIBQLEVER_QLEVER_H
 #define QLEVER_SRC_LIBQLEVER_QLEVER_H
 
+#include <boost/optional.hpp>
 #include <memory>
 #include <optional>
 #include <string>
@@ -277,11 +278,15 @@ class Qlever {
   // class.
   using PlannedQuery = qlever::PlannedQuery;
 
-  // Plan a parsed query.
-  PlannedQuery planQuery(ParsedQuery&& operation,
-                         std::optional<TimeLimit> timeLimit,
-                         QueryExecutionContext& qec,
-                         SharedCancellationHandle handle) const;
+  // Run the query planner on `parsedQuery`. Despite the name, `ParsedQuery`
+  // is also used to represent SPARQL update operations (see
+  // ParsedQuery::hasUpdateClause()); this function handles both cases
+  // uniformly.
+  PlannedQuery planQuery(
+      ParsedQuery&& parsedQuery, std::optional<TimeLimit> timeLimit,
+      QueryExecutionContext& qec, SharedCancellationHandle handle,
+      boost::optional<const ad_utility::Timer&> requestTimer =
+          boost::none) const;
 
   PlannedQuery parseAndPlanQuery(
       std::string query, const std::vector<DatasetClause>& datasetClauses = {},

--- a/src/libqlever/Qlever.h
+++ b/src/libqlever/Qlever.h
@@ -254,9 +254,31 @@ class Qlever {
   // explained above.
   explicit Qlever(const EngineConfig& config);
 
-  // Parse and plan the given `query`.
+  using PlannedQuery = qlever::PlannedQuery;
+
+  // Run the query planner on `parsedQuery`. Despite the name, `ParsedQuery`
+  // is also used to represent SPARQL update operations (see
+  // ParsedQuery::hasUpdateClause()); this function handles both cases
+  // uniformly.
   //
-  // NOTE: This is useful as a separate function for the following reasons.
+  // TODO<joka921,damekt> The `timeLimit` is currently only used for
+  // non-cancelable operations (in particular sorting). The time limit applies
+  // from the time this function is called until the execution of the query
+  // has finished. This might be very unintuitive when the `PlannedQuery` is
+  // stored for later execution. This is not an issue for now (only the
+  // `Server` actually imposes time limits and then executes the queries right
+  // away), but should be addressed in the future once the timeout management
+  // also is moved into the `QLever` class.
+  PlannedQuery planQuery(
+      ParsedQuery&& parsedQuery, std::optional<TimeLimit> timeLimit,
+      QueryExecutionContext& qec, SharedCancellationHandle handle,
+      boost::optional<const ad_utility::Timer&> requestTimer =
+          boost::none) const;
+
+  // Parse and plan the given `query` (see `planQuery` above; despite the
+  // name, `query` may also be a SPARQL update operation).
+  //
+  // NOTES: This is useful as a separate function for the following reasons.
   //
   // 1. Using a `PlannedQuery`, one can execute a `query` multiple times without
   // having to parse and plan it again.
@@ -269,25 +291,12 @@ class Qlever {
   //
   // TODO<joka921,damekt> The `timeLimit` is currently only used for
   // non-cancelable operations (in particular sorting). The time limit applies
-  // from the time `parseAndPlanQuery` is called until the execution of the
-  // query has finished. This might be very unintuitive when the `PlannedQuery`
-  // is stored for later execution.
-  // This is not an issue for now (only the `Server` actually imposes time
-  // limits and then executes the queries right away), but should be addressed
-  // in the future once the timeout management also is moved into the `QLever`
-  // class.
-  using PlannedQuery = qlever::PlannedQuery;
-
-  // Run the query planner on `parsedQuery`. Despite the name, `ParsedQuery`
-  // is also used to represent SPARQL update operations (see
-  // ParsedQuery::hasUpdateClause()); this function handles both cases
-  // uniformly.
-  PlannedQuery planQuery(
-      ParsedQuery&& parsedQuery, std::optional<TimeLimit> timeLimit,
-      QueryExecutionContext& qec, SharedCancellationHandle handle,
-      boost::optional<const ad_utility::Timer&> requestTimer =
-          boost::none) const;
-
+  // from the time this function is called until the execution of the query
+  // has finished. This might be very unintuitive when the `PlannedQuery` is
+  // stored for later execution. This is not an issue for now (only the
+  // `Server` actually imposes time limits and then executes the queries right
+  // away), but should be addressed in the future once the timeout management
+  // also is moved into the `QLever` class.
   PlannedQuery parseAndPlanQuery(
       std::string query, const std::vector<DatasetClause>& datasetClauses = {},
       ad_utility::SharedCancellationHandle handle =


### PR DESCRIPTION
Previously, the `Server` class and `libqlever` contained duplicated code for running the query planner on an already parsed query. This code is now unified in `Qlever::planQuery`, which is used by both `Qlever::parseAndPlanQuery` and `Server::planQuery`. The latter becomes a very thin wrapper that calls into `libqlever` and only adds some logging.