### PR TITLE
Update `abseil-cpp`, `s2geometry`, `re2`, and `googletest`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -378,7 +378,7 @@ set(ABSL_PROPAGATE_CXX_STD ON)
 FetchContent_Declare(
         abseil
         GIT_REPOSITORY https://github.com/abseil/abseil-cpp.git
-        GIT_TAG 93ac3a4f9ee7792af399cebd873ee99ce15aed08  # 2024-05-16
+        GIT_TAG 20260107.1  # LTS 2026-01-07
         EXCLUDE_FROM_ALL
 )
 
@@ -389,7 +389,7 @@ set(BUILD_TESTS OFF CACHE BOOL "no tests for s2")
 FetchContent_Declare(
         s2
         GIT_REPOSITORY https://github.com/google/s2geometry.git
-        GIT_TAG 5b5eccd54a08ae03b4467e79ffbb076d0b5f221e  #version 0.11.1
+        GIT_TAG v0.13.1  #version 0.13.1
         SYSTEM
         EXCLUDE_FROM_ALL
 )
@@ -452,7 +452,7 @@ set(RE2_BUILD_TESTING OFF CACHE BOOL "enable testing for RE2" FORCE)
 FetchContent_Declare(
         re2
         GIT_REPOSITORY https://github.com/google/re2.git
-        GIT_TAG bc0faab533e2b27b85b8ad312abf061e33ed6b5d # v.2023-11-01
+        GIT_TAG 2025-11-05  # v.2025-11-05
         GIT_SHALLOW TRUE
         OVERRIDE_FIND_PACKAGE
         SYSTEM
@@ -482,8 +482,8 @@ set(URIPARSER_BUILD_WCHAR_T OFF CACHE BOOL "" FORCE)
 ################################
 FetchContent_MakeAvailable(googletest ctre abseil re2 fsst s2 nlohmann-json antlr range-v3 spatialjoin uriparser)
 # Disable some warnings in RE2 and GTEST
-target_compile_options(s2 PRIVATE -Wno-sign-compare -Wno-unused-parameter -Wno-class-memaccess -Wno-comment -Wno-redundant-move -Wno-unknown-warning-option -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-unused-but-set-variable -Wno-unused-function)
-target_compile_options(re2 PRIVATE -Wno-unused-parameter)
+target_compile_options(s2 PRIVATE -Wno-sign-compare -Wno-unused-parameter -Wno-class-memaccess -Wno-comment -Wno-redundant-move -Wno-unknown-warning-option -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-unused-but-set-variable -Wno-unused-function -Wno-nullability-completeness)
+target_compile_options(re2 PRIVATE -Wno-unused-parameter -Wno-deprecated-declarations)
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     target_compile_options(gtest PRIVATE -Wno-maybe-uninitialized)
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,7 +149,7 @@ include(FetchContent)
 FetchContent_Declare(
         googletest
         GIT_REPOSITORY https://github.com/google/googletest.git
-        GIT_TAG 7917641ff965959afae189afb5f052524395525c # main branch on 2025/09/11
+        GIT_TAG 973323ed64a05b128418e7eab67016db5ba049df # main branch on 2026/06/30
         SYSTEM
         EXCLUDE_FROM_ALL
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -452,7 +452,7 @@ set(RE2_BUILD_TESTING OFF CACHE BOOL "enable testing for RE2" FORCE)
 FetchContent_Declare(
         re2
         GIT_REPOSITORY https://github.com/google/re2.git
-        GIT_TAG 2025-11-05  # v.2025-11-05
+        GIT_TAG 972a15cedd008d846f1a39b2e88ce48d7f166cbd  # main branch from January 23 2026
         GIT_SHALLOW TRUE
         OVERRIDE_FIND_PACKAGE
         SYSTEM

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -378,7 +378,7 @@ set(ABSL_PROPAGATE_CXX_STD ON)
 FetchContent_Declare(
         abseil
         GIT_REPOSITORY https://github.com/abseil/abseil-cpp.git
-        GIT_TAG 20260107.1  # LTS 2026-01-07
+        GIT_TAG 255c84dadd029fd8ad25c5efb5933e47beaa00c7  # tag 20260107.1 (LTS 2026-01-07)
         EXCLUDE_FROM_ALL
 )
 
@@ -389,7 +389,7 @@ set(BUILD_TESTS OFF CACHE BOOL "no tests for s2")
 FetchContent_Declare(
         s2
         GIT_REPOSITORY https://github.com/google/s2geometry.git
-        GIT_TAG v0.13.1  #version 0.13.1
+        GIT_TAG a37aba69f14af676e9605cd9515c8aca6cef8342  # tag v0.13.1
         SYSTEM
         EXCLUDE_FROM_ALL
 )

--- a/src/engine/SpatialJoinCachedIndex.cpp
+++ b/src/engine/SpatialJoinCachedIndex.cpp
@@ -5,6 +5,7 @@
 #include "engine/SpatialJoinCachedIndex.h"
 
 #include <s2/mutable_s2shape_index.h>
+#include <s2/s2error.h>
 #include <s2/s2polyline.h>
 #include <s2/s2shapeutil_coding.h>
 
@@ -77,9 +78,10 @@ void SpatialJoinCachedIndex::populateFromSerialized(
     std::string_view serializedShapes) {
   AD_CORRECTNESS_CHECK(pimpl_ != nullptr);
   Decoder decoder(serializedShapes.data(), serializedShapes.size());
+  S2Error error;
   bool success = pimpl_->s2index_.Init(
-      &decoder, s2shapeutil::FullDecodeShapeFactory(&decoder));
-  AD_CORRECTNESS_CHECK(success,
+      &decoder, s2shapeutil::FullDecodeShapeFactory(&decoder, error));
+  AD_CORRECTNESS_CHECK(success && error.ok(),
                        "Initializing the S2 index from its serialized form "
                        "failed, probably the input data is corrupt");
   // We call `ForceBuild` when initializing the index, and the serialization

--- a/test/CompressedRelationsTest.cpp
+++ b/test/CompressedRelationsTest.cpp
@@ -947,7 +947,7 @@ TEST(CompressedRelationReader, makeCanBeSkippedForBlock) {
 
   // The block contains graph `1`, but we only want graph `3`, so the block can
   // be skipped.
-  graphs.insert(V(3));
+  graphs = ad_utility::HashSet<Id>{V(3)};
   graphFilter = GF::Whitelist(std::move(graphs));
   EXPECT_TRUE(filter.canBlockBeSkipped(metadata));
 


### PR DESCRIPTION
The versions of these third-party dependencies were up to two years old and, in particular, too old for building QLever on Windows. Update `abseil-cpp` to the LTS release 20260107.1 (which includes the `cctz` fixes needed for MinGW), `s2geometry` to v0.13.1 and `re2` to a recent commit (both of which are needed to go along with the new `abseil-cpp`), and `googletest` to a recent commit. The code is adapted in two places: the new `s2` decoding API takes an explicit `S2Error`, and a use-after-move in a test, which the new `abseil-cpp` no longer tolerates, is fixed. Third step after #3045 and #3046 towards addressing #3044 (build on Windows).