### PR TITLE
Save and restore the global logging stream in tests

### DIFF
--- a/src/util/Log.h
+++ b/src/util/Log.h
@@ -142,12 +142,6 @@ struct LogstreamChoice {
   std::ostream* _stream = &std::cout;
 };
 
-// After this call, every use of `AD_LOG_...` will use the specified stream.
-// Used in various tests to redirect or suppress logging output.
-inline void setGlobalLoggingStream(std::ostream* stream) {
-  LogstreamChoice::get().setStream(stream);
-}
-
 // Helper class to get thousandth separators in a locale
 class CommaNumPunct : public std::numpunct<char> {
  protected:

--- a/src/util/Log.h
+++ b/src/util/Log.h
@@ -142,6 +142,13 @@ struct LogstreamChoice {
   std::ostream* _stream = &std::cout;
 };
 
+// After this call, every use of `AD_LOG_...` will use the specified stream.
+// In tests use `setGlobalLoggingStreamForTesting` from `GTestHelpers.h` which
+// also restores the previous value.
+inline void setGlobalLoggingStream(std::ostream* stream) {
+  LogstreamChoice::get().setStream(stream);
+}
+
 // Helper class to get thousandth separators in a locale
 class CommaNumPunct : public std::numpunct<char> {
  protected:

--- a/test/CancellationHandleTest.cpp
+++ b/test/CancellationHandleTest.cpp
@@ -308,8 +308,7 @@ TEST(CancellationHandle, verifyCheckAfterDeadlineMissDoesReportProperly) {
   SKIP_IF_LOGLEVEL_IS_LOWER(DEBUG);
   CancellationHandle<ENABLED> handle;
 
-  std::ostringstream testStream;
-  auto cleanup = setGlobalLoggingStreamForTesting(&testStream);
+  auto [cleanup, testStream] = setGlobalLoggingStreamToStringStream();
 
   handle.startTimeoutWindow_ = std::chrono::steady_clock::now();
   handle.cancellationState_ = CHECK_WINDOW_MISSED;
@@ -333,8 +332,7 @@ TEST(CancellationHandle, verifyPleaseWatchDogReportsOnlyWhenNecessary) {
   SKIP_IF_LOGLEVEL_IS_LOWER(DEBUG);
   CancellationHandle<ENABLED> handle;
 
-  std::ostringstream testStream;
-  auto cleanup = setGlobalLoggingStreamForTesting(&testStream);
+  auto [cleanup, testStream] = setGlobalLoggingStreamToStringStream();
 
   handle.startTimeoutWindow_ = std::chrono::steady_clock::now();
   handle.cancellationState_ = CHECK_WINDOW_MISSED;
@@ -414,8 +412,7 @@ TEST(CancellationHandle, verifyIsCancelledDoesPleaseWatchDog) {
   SKIP_IF_LOGLEVEL_IS_LOWER(DEBUG);
   CancellationHandle<ENABLED> handle;
 
-  std::ostringstream testStream;
-  auto cleanup = setGlobalLoggingStreamForTesting(&testStream);
+  auto [cleanup, testStream] = setGlobalLoggingStreamToStringStream();
 
   handle.startTimeoutWindow_ = std::chrono::steady_clock::now();
   handle.cancellationState_ = CHECK_WINDOW_MISSED;

--- a/test/CancellationHandleTest.cpp
+++ b/test/CancellationHandleTest.cpp
@@ -306,14 +306,10 @@ TEST(CancellationHandle, verifyCheckDoesNotOverrideCancelledState) {
 
 TEST(CancellationHandle, verifyCheckAfterDeadlineMissDoesReportProperly) {
   SKIP_IF_LOGLEVEL_IS_LOWER(DEBUG);
-  auto& choice = ad_utility::LogstreamChoice::get();
   CancellationHandle<ENABLED> handle;
 
-  auto& originalOStream = choice.getStream();
-  absl::Cleanup cleanup{[&]() { choice.setStream(&originalOStream); }};
-
   std::ostringstream testStream;
-  choice.setStream(&testStream);
+  auto cleanup = setGlobalLoggingStreamForTesting(&testStream);
 
   handle.startTimeoutWindow_ = std::chrono::steady_clock::now();
   handle.cancellationState_ = CHECK_WINDOW_MISSED;
@@ -335,14 +331,10 @@ TEST(CancellationHandle, verifyCheckAfterDeadlineMissDoesReportProperly) {
 
 TEST(CancellationHandle, verifyPleaseWatchDogReportsOnlyWhenNecessary) {
   SKIP_IF_LOGLEVEL_IS_LOWER(DEBUG);
-  auto& choice = ad_utility::LogstreamChoice::get();
   CancellationHandle<ENABLED> handle;
 
-  auto& originalOStream = choice.getStream();
-  absl::Cleanup cleanup{[&]() { choice.setStream(&originalOStream); }};
-
   std::ostringstream testStream;
-  choice.setStream(&testStream);
+  auto cleanup = setGlobalLoggingStreamForTesting(&testStream);
 
   handle.startTimeoutWindow_ = std::chrono::steady_clock::now();
   handle.cancellationState_ = CHECK_WINDOW_MISSED;
@@ -420,14 +412,10 @@ TEST(CancellationHandle, verifyPleaseWatchDogDoesNotAcceptInvalidState) {
 
 TEST(CancellationHandle, verifyIsCancelledDoesPleaseWatchDog) {
   SKIP_IF_LOGLEVEL_IS_LOWER(DEBUG);
-  auto& choice = ad_utility::LogstreamChoice::get();
   CancellationHandle<ENABLED> handle;
 
-  auto& originalOStream = choice.getStream();
-  absl::Cleanup cleanup{[&]() { choice.setStream(&originalOStream); }};
-
   std::ostringstream testStream;
-  choice.setStream(&testStream);
+  auto cleanup = setGlobalLoggingStreamForTesting(&testStream);
 
   handle.startTimeoutWindow_ = std::chrono::steady_clock::now();
   handle.cancellationState_ = CHECK_WINDOW_MISSED;

--- a/test/ExceptionHandlingTest.cpp
+++ b/test/ExceptionHandlingTest.cpp
@@ -102,9 +102,7 @@ TEST(ExceptionCollector, isNoOpWhenEmpty) {
 // _____________________________________________________________________________
 TEST(ExceptionCollector, asCompletionHandler) {
   std::ostringstream logStream;
-  ad_utility::setGlobalLoggingStream(&logStream);
-  absl::Cleanup cleanup{
-      []() { ad_utility::setGlobalLoggingStream(&std::cout); }};
+  auto cleanup = setGlobalLoggingStreamForTesting(&logStream);
 
   ad_utility::ExceptionCollector collector;
   try {

--- a/test/ExceptionHandlingTest.cpp
+++ b/test/ExceptionHandlingTest.cpp
@@ -101,8 +101,7 @@ TEST(ExceptionCollector, isNoOpWhenEmpty) {
 
 // _____________________________________________________________________________
 TEST(ExceptionCollector, asCompletionHandler) {
-  std::ostringstream logStream;
-  auto cleanup = setGlobalLoggingStreamForTesting(&logStream);
+  auto [cleanup, logStream] = setGlobalLoggingStreamToStringStream();
 
   ad_utility::ExceptionCollector collector;
   try {

--- a/test/HttpTest.cpp
+++ b/test/HttpTest.cpp
@@ -338,11 +338,8 @@ TYPED_TEST(HttpServerBodyTest, ErrorHandlingInSession) {
   // Note: We need a separate server for each call because we must shut down
   // before reading the log to avoid a race condition on the logging stream.
   auto throwAndCaptureLog = [this](auto exceptionObject) {
-    // We interfere with the logging to test it. The returned cleanup restores
-    // the previous logging stream once this lambda returns (after the log has
-    // been read below).
-    std::stringstream logStream;
-    auto cleanup = setGlobalLoggingStreamForTesting(&logStream);
+    // We interfere with the logging to test it.
+    auto [cleanup, logStream] = setGlobalLoggingStreamToStringStream();
 
     // Convert the `exceptionObject` to an `exception_ptr`.
     std::exception_ptr exception;

--- a/test/HttpTest.cpp
+++ b/test/HttpTest.cpp
@@ -332,19 +332,17 @@ TYPED_TEST(HttpServerBodyTest, HttpTest) {
 
 // Test the various `catch` clauses in `HttpServer::session`.
 TYPED_TEST(HttpServerBodyTest, ErrorHandlingInSession) {
-  // We will interfere with the logging to test it, so we have to reset the
-  // logging after we are done.
-  absl::Cleanup cleanup{
-      []() { ad_utility::setGlobalLoggingStream(&std::cout); }};
-
   // Do the following: Create an HttpServer that echoes the response and then
   // throws `exceptionObject`. Send an HTTP request to trigger the exception.
   // Capture the server log and return it for inspection.
   // Note: We need a separate server for each call because we must shut down
   // before reading the log to avoid a race condition on the logging stream.
   auto throwAndCaptureLog = [this](auto exceptionObject) {
+    // We interfere with the logging to test it. The returned cleanup restores
+    // the previous logging stream once this lambda returns (after the log has
+    // been read below).
     std::stringstream logStream;
-    ad_utility::setGlobalLoggingStream(&logStream);
+    auto cleanup = setGlobalLoggingStreamForTesting(&logStream);
 
     // Convert the `exceptionObject` to an `exception_ptr`.
     std::exception_ptr exception;

--- a/test/IoUringManagerTest.cpp
+++ b/test/IoUringManagerTest.cpp
@@ -435,9 +435,7 @@ TEST(IoUringManagerDrop, dropSyncManagerHasNothingInFlight) {
 
   // Capture the log so we can assert that the destructor stays silent.
   std::ostringstream logStream;
-  ad_utility::setGlobalLoggingStream(&logStream);
-  absl::Cleanup restoreLog{
-      [] { ad_utility::setGlobalLoggingStream(&std::cout); }};
+  auto restoreLog = setGlobalLoggingStreamForTesting(&logStream);
 
   ReadBatchForTesting batch;
   batch.add({{8, 4}, {0, 4}, {12, 4}});
@@ -467,9 +465,7 @@ TEST(IoUringManagerDrop, dropRunningManager) {
   // Redirect the global logging stream so we can assert on the destructor's
   // warning.
   std::ostringstream logStream;
-  ad_utility::setGlobalLoggingStream(&logStream);
-  absl::Cleanup restoreLog{
-      [] { ad_utility::setGlobalLoggingStream(&std::cout); }};
+  auto restoreLog = setGlobalLoggingStreamForTesting(&logStream);
 
   ReadBatchForTesting batch;
   batch.add({{8, 4}, {0, 4}, {12, 4}});

--- a/test/IoUringManagerTest.cpp
+++ b/test/IoUringManagerTest.cpp
@@ -434,8 +434,7 @@ TEST(IoUringManagerDrop, dropSyncManagerHasNothingInFlight) {
   auto [tmp, fd] = makeTempFile("AAAABBBBCCCCDDDD");
 
   // Capture the log so we can assert that the destructor stays silent.
-  std::ostringstream logStream;
-  auto restoreLog = setGlobalLoggingStreamForTesting(&logStream);
+  auto [restoreLog, logStream] = setGlobalLoggingStreamToStringStream();
 
   ReadBatchForTesting batch;
   batch.add({{8, 4}, {0, 4}, {12, 4}});
@@ -464,8 +463,7 @@ TEST(IoUringManagerDrop, dropRunningManager) {
 
   // Redirect the global logging stream so we can assert on the destructor's
   // warning.
-  std::ostringstream logStream;
-  auto restoreLog = setGlobalLoggingStreamForTesting(&logStream);
+  auto [restoreLog, logStream] = setGlobalLoggingStreamToStringStream();
 
   ReadBatchForTesting batch;
   batch.add({{8, 4}, {0, 4}, {12, 4}});

--- a/test/LogTest.cpp
+++ b/test/LogTest.cpp
@@ -72,8 +72,7 @@ TEST(LogTest, StreamFiltering) {
   // FATAL (0) always passes compile-time guards. ERROR (1) is suppressed at
   // runtime when the level is set to FATAL.
   auto levelCleanup = setLoglevelForTesting(LogLevel::Enum::FATAL);
-  std::stringstream ss;
-  auto streamCleanup = setGlobalLoggingStreamForTesting(&ss);
+  auto [streamCleanup, ss] = setGlobalLoggingStreamToStringStream();
 
   AD_LOG_FATAL << "hello-fatal";
   EXPECT_THAT(ss.str(), ::testing::HasSubstr("hello-fatal"));
@@ -88,9 +87,7 @@ TEST(LogTest, ThreadSafety) {
   static constexpr size_t numThreads = 8;
   static constexpr size_t msgsPerThread = 200;
 
-  // Redirect all logging to a local stringstream for the duration of the test.
-  std::stringstream ss;
-  auto streamCleanup = setGlobalLoggingStreamForTesting(&ss);
+  auto [streamCleanup, ss] = setGlobalLoggingStreamToStringStream();
 
   // Spawn N threads; each logs M lines using multiple `<<` operators. The
   // multi-part write is intentional: if the mutex were absent, partial writes

--- a/test/LogTest.cpp
+++ b/test/LogTest.cpp
@@ -73,9 +73,7 @@ TEST(LogTest, StreamFiltering) {
   // runtime when the level is set to FATAL.
   auto levelCleanup = setLoglevelForTesting(LogLevel::Enum::FATAL);
   std::stringstream ss;
-  ad_utility::setGlobalLoggingStream(&ss);
-  auto streamCleanup =
-      absl::MakeCleanup([] { ad_utility::setGlobalLoggingStream(&std::cout); });
+  auto streamCleanup = setGlobalLoggingStreamForTesting(&ss);
 
   AD_LOG_FATAL << "hello-fatal";
   EXPECT_THAT(ss.str(), ::testing::HasSubstr("hello-fatal"));
@@ -92,9 +90,7 @@ TEST(LogTest, ThreadSafety) {
 
   // Redirect all logging to a local stringstream for the duration of the test.
   std::stringstream ss;
-  ad_utility::setGlobalLoggingStream(&ss);
-  auto streamCleanup =
-      absl::MakeCleanup([] { ad_utility::setGlobalLoggingStream(&std::cout); });
+  auto streamCleanup = setGlobalLoggingStreamForTesting(&ss);
 
   // Spawn N threads; each logs M lines using multiple `<<` operators. The
   // multi-part write is intentional: if the mutex were absent, partial writes

--- a/test/MaterializedViewsStarRewriteTest.cpp
+++ b/test/MaterializedViewsStarRewriteTest.cpp
@@ -54,7 +54,7 @@ TEST_P(MaterializedViewsStarRewriteTest, starRewrite) {
   const std::string viewName = "testViewStar";
 
   materializedViewsTestHelpers::makeTestIndex(onDiskBase, starTtl);
-  auto cleanUp = absl::MakeCleanup(
+  auto cleanUp = absl::Cleanup(
       [&]() { materializedViewsTestHelpers::removeTestIndex(onDiskBase); });
   qlever::EngineConfig config;
   config.baseName_ = onDiskBase;

--- a/test/MaterializedViewsTest.cpp
+++ b/test/MaterializedViewsTest.cpp
@@ -1499,7 +1499,7 @@ TEST(MaterializedViewsSpatialJoinTest, BoundingBoxBindRewrite) {
 
   // Initialize engine on test index.
   materializedViewsTestHelpers::makeTestIndex(onDiskBase, std::string{geoTtl});
-  auto cleanUp = absl::MakeCleanup(
+  auto cleanUp = absl::Cleanup(
       [&]() { materializedViewsTestHelpers::removeTestIndex(onDiskBase); });
   qlever::EngineConfig config;
   config.baseName_ = onDiskBase;
@@ -1614,7 +1614,7 @@ TEST_P(MaterializedViewsChainRewriteTest, simpleChain) {
 
   // Initialized libqlever.
   materializedViewsTestHelpers::makeTestIndex(onDiskBase, chainTtl);
-  auto cleanUp = absl::MakeCleanup(
+  auto cleanUp = absl::Cleanup(
       [&]() { materializedViewsTestHelpers::removeTestIndex(onDiskBase); });
   qlever::EngineConfig config;
   config.baseName_ = onDiskBase;

--- a/test/MaterializedViewsTestHelpers.h
+++ b/test/MaterializedViewsTestHelpers.h
@@ -67,6 +67,8 @@ class MaterializedViewsTest : public ::testing::Test {
   const std::string testIndexBase_ = gtestCurrentTestName();
   const std::string simpleWriteQuery_ = "SELECT * { ?s ?p ?o . BIND(1 AS ?g) }";
   std::stringstream log_;
+  std::optional<decltype(setGlobalLoggingStreamForTesting(nullptr))>
+      logStreamCleanup_;
 
   // ___________________________________________________________________________
   virtual std::string getDummyTurtle() const {
@@ -75,7 +77,7 @@ class MaterializedViewsTest : public ::testing::Test {
 
   // ___________________________________________________________________________
   void SetUp() override {
-    ad_utility::setGlobalLoggingStream(&log_);
+    logStreamCleanup_.emplace(setGlobalLoggingStreamForTesting(&log_));
     makeTestIndex(testIndexBase_, getDummyTurtle());
     qlever::EngineConfig config;
     config.baseName_ = testIndexBase_;
@@ -86,7 +88,8 @@ class MaterializedViewsTest : public ::testing::Test {
   void TearDown() override {
     qlv_ = nullptr;
     removeTestIndex(testIndexBase_);
-    ad_utility::setGlobalLoggingStream(&std::cout);
+    // Calls the cleanup, restoring the log stream to the previous value.
+    logStreamCleanup_.reset();
   }
 
   // ___________________________________________________________________________
@@ -163,12 +166,19 @@ class MaterializedViewsQueryRewriteTest
     : public ::testing::TestWithParam<RewriteTestParams> {
  protected:
   std::stringstream log_;
+  std::optional<decltype(setGlobalLoggingStreamForTesting(nullptr))>
+      logStreamCleanup_;
 
   // ___________________________________________________________________________
-  void SetUp() override { ad_utility::setGlobalLoggingStream(&log_); }
+  void SetUp() override {
+    logStreamCleanup_.emplace(setGlobalLoggingStreamForTesting(&log_));
+  }
 
   // ___________________________________________________________________________
-  void TearDown() override { ad_utility::setGlobalLoggingStream(&std::cout); }
+  void TearDown() override {
+    // Calls the cleanup, restoring the log stream to the previous value.
+    logStreamCleanup_.reset();
+  }
 };
 
 // We make subclasses of `MaterializedViewsQueryRewriteTest` here s.t. we can

--- a/test/RdfParserTest.cpp
+++ b/test/RdfParserTest.cpp
@@ -1694,8 +1694,7 @@ TEST(RdfParserTest, getLineRethrowsOnTooLargeBufferWithPendingException) {
   auto oldLimit = limit;
   limit = ad_utility::MemorySize::bytes(128);
   absl::Cleanup cleanup{[&limit, oldLimit] { limit = oldLimit; }};
-  std::stringstream logStream;
-  auto logCleanup = setGlobalLoggingStreamForTesting(&logStream);
+  auto [logCleanup, logStream] = setGlobalLoggingStreamToStringStream();
 
   // `@prefix` without a terminating dot raises a `ParseException` on every
   // attempt, so a pending exception is always present when the buffer limit
@@ -1734,8 +1733,7 @@ TEST(RdfParserTest, getLineRaisesOnTooLargeBufferWithoutPendingException) {
   auto oldLimit = limit;
   limit = ad_utility::MemorySize::bytes(128);
   absl::Cleanup cleanup{[&limit, oldLimit] { limit = oldLimit; }};
-  std::stringstream logStream;
-  auto logCleanup = setGlobalLoggingStreamForTesting(&logStream);
+  auto [logCleanup, logStream] = setGlobalLoggingStreamToStringStream();
 
   // `<a> <b> <c>\n` parses successfully up to the (missing) dot, so
   // `statement()` returns false without raising. The parser is forced to
@@ -1780,9 +1778,8 @@ TEST(RdfParserTest, getLineLogsRemainingUnparsedBytesWhenInputExhausted) {
     auto of = ad_utility::makeOfstream(filename);
     of << "<a> <b> <c> .\n" << trailingGarbage;
   }
-  std::stringstream logStream;
   absl::Cleanup cleanup{[&] { ad_utility::deleteFile(filename); }};
-  auto logCleanup = setGlobalLoggingStreamForTesting(&logStream);
+  auto [logCleanup, logStream] = setGlobalLoggingStreamToStringStream();
 
   Parser parser{qlever::InputFileSpecification{
                     filename, qlever::Filetype::Turtle, std::nullopt},

--- a/test/RdfParserTest.cpp
+++ b/test/RdfParserTest.cpp
@@ -1693,12 +1693,9 @@ TEST(RdfParserTest, getLineRethrowsOnTooLargeBufferWithPendingException) {
   auto& limit = RDF_PARSER_MAX_TOTAL_BUFFER_SIZE();
   auto oldLimit = limit;
   limit = ad_utility::MemorySize::bytes(128);
-  absl::Cleanup cleanup{[&limit, oldLimit] {
-    limit = oldLimit;
-    ad_utility::setGlobalLoggingStream(&std::cout);
-  }};
+  absl::Cleanup cleanup{[&limit, oldLimit] { limit = oldLimit; }};
   std::stringstream logStream;
-  ad_utility::setGlobalLoggingStream(&logStream);
+  auto logCleanup = setGlobalLoggingStreamForTesting(&logStream);
 
   // `@prefix` without a terminating dot raises a `ParseException` on every
   // attempt, so a pending exception is always present when the buffer limit
@@ -1736,12 +1733,9 @@ TEST(RdfParserTest, getLineRaisesOnTooLargeBufferWithoutPendingException) {
   auto& limit = RDF_PARSER_MAX_TOTAL_BUFFER_SIZE();
   auto oldLimit = limit;
   limit = ad_utility::MemorySize::bytes(128);
-  absl::Cleanup cleanup{[&limit, oldLimit] {
-    limit = oldLimit;
-    ad_utility::setGlobalLoggingStream(&std::cout);
-  }};
+  absl::Cleanup cleanup{[&limit, oldLimit] { limit = oldLimit; }};
   std::stringstream logStream;
-  ad_utility::setGlobalLoggingStream(&logStream);
+  auto logCleanup = setGlobalLoggingStreamForTesting(&logStream);
 
   // `<a> <b> <c>\n` parses successfully up to the (missing) dot, so
   // `statement()` returns false without raising. The parser is forced to
@@ -1787,11 +1781,8 @@ TEST(RdfParserTest, getLineLogsRemainingUnparsedBytesWhenInputExhausted) {
     of << "<a> <b> <c> .\n" << trailingGarbage;
   }
   std::stringstream logStream;
-  absl::Cleanup cleanup{[&] {
-    ad_utility::setGlobalLoggingStream(&std::cout);
-    ad_utility::deleteFile(filename);
-  }};
-  ad_utility::setGlobalLoggingStream(&logStream);
+  absl::Cleanup cleanup{[&] { ad_utility::deleteFile(filename); }};
+  auto logCleanup = setGlobalLoggingStreamForTesting(&logStream);
 
   Parser parser{qlever::InputFileSpecification{
                     filename, qlever::Filetype::Turtle, std::nullopt},

--- a/test/TransitivePathGraphSearchTest.cpp
+++ b/test/TransitivePathGraphSearchTest.cpp
@@ -269,10 +269,7 @@ TEST(GraphSearchTestExtraTests, cancellationCheck) {
   GraphSearchExecutionParams ep(
       std::make_shared<ad_utility::CancellationHandle<>>(), allocator);
 
-  // Redirect logging stream to a stream object which we can test on. The
-  // returned cleanup resets the logging stream when the scope exits.
-  std::stringstream stream;
-  auto cleanup = setGlobalLoggingStreamForTesting(&stream);
+  auto [cleanup, stream] = setGlobalLoggingStreamToStringStream();
 
   // Trigger a `CHECK_WINDOW_MISSED` cancellation state which will make the
   // handle's watchdog write logs containing the algorithmName specified in

--- a/test/TransitivePathGraphSearchTest.cpp
+++ b/test/TransitivePathGraphSearchTest.cpp
@@ -269,13 +269,10 @@ TEST(GraphSearchTestExtraTests, cancellationCheck) {
   GraphSearchExecutionParams ep(
       std::make_shared<ad_utility::CancellationHandle<>>(), allocator);
 
-  // Tell absl to reset the logging stream after scope exits.
-  absl::Cleanup cleanup{
-      []() { ad_utility::setGlobalLoggingStream(&std::cout); }};
-
-  // Redirect logging stream to a stream object which we can test on.
+  // Redirect logging stream to a stream object which we can test on. The
+  // returned cleanup resets the logging stream when the scope exits.
   std::stringstream stream;
-  ad_utility::setGlobalLoggingStream(&stream);
+  auto cleanup = setGlobalLoggingStreamForTesting(&stream);
 
   // Trigger a `CHECK_WINDOW_MISSED` cancellation state which will make the
   // handle's watchdog write logs containing the algorithmName specified in

--- a/test/util/GTestHelpers.h
+++ b/test/util/GTestHelpers.h
@@ -125,6 +125,19 @@ inline auto setLoglevelForTesting(LogLevel level) {
 }
 
 // _____________________________________________________________________________
+// Redirect the global logging stream to `stream` and return an `absl::Cleanup`
+// that restores the *previously active* stream when it goes out of scope. Use
+// this in tests that temporarily capture or suppress log output, so the global
+// stream is never left dangling or reset to the wrong value.
+inline auto setGlobalLoggingStreamForTesting(std::ostream* stream) {
+  auto& choice = ad_utility::LogstreamChoice::get();
+  auto* previous = &choice.getStream();
+  choice.setStream(stream);
+  return absl::MakeCleanup(
+      [previous] { ad_utility::LogstreamChoice::get().setStream(previous); });
+}
+
+// _____________________________________________________________________________
 
 // Helper matcher that allows to use matchers for strings that represent json
 // objects.

--- a/test/util/GTestHelpers.h
+++ b/test/util/GTestHelpers.h
@@ -11,7 +11,9 @@
 #include <absl/strings/str_replace.h>
 #include <gmock/gmock.h>
 
+#include <memory>
 #include <optional>
+#include <sstream>
 
 #include "backports/concepts.h"
 #include "backports/three_way_comparison.h"
@@ -130,11 +132,29 @@ inline auto setLoglevelForTesting(LogLevel level) {
 // this in tests that temporarily capture or suppress log output, so the global
 // stream is never left dangling or reset to the wrong value.
 inline auto setGlobalLoggingStreamForTesting(std::ostream* stream) {
-  auto& choice = ad_utility::LogstreamChoice::get();
-  auto* previous = &choice.getStream();
-  choice.setStream(stream);
+  auto* previous = &ad_utility::LogstreamChoice::get().getStream();
+  ad_utility::setGlobalLoggingStream(stream);
   return absl::MakeCleanup(
-      [previous] { ad_utility::LogstreamChoice::get().setStream(previous); });
+      [previous] { ad_utility::setGlobalLoggingStream(previous); });
+}
+
+// _____________________________________________________________________________
+// Redirect the global logging stream to a fresh `std::ostringstream` and return
+// a pair of an `absl::Cleanup` (which restores the previously active stream
+// when it goes out of scope) and a reference to that stream. Typical usage is
+// `auto [cleanup, logStream] = setGlobalLoggingStreamToStringStream();`.
+// NOTE: The returned reference is only valid as long as the `cleanup` is alive,
+// as the underlying stream is owned by the `cleanup`.
+inline auto setGlobalLoggingStreamToStringStream() {
+  auto stream = std::make_shared<std::ostringstream>();
+  auto& streamRef = *stream;
+  auto* previous = &ad_utility::LogstreamChoice::get().getStream();
+  ad_utility::setGlobalLoggingStream(stream.get());
+  auto cleanup = absl::MakeCleanup([previous, stream = std::move(stream)] {
+    ad_utility::setGlobalLoggingStream(previous);
+  });
+  return std::pair<decltype(cleanup), std::ostringstream&>{std::move(cleanup),
+                                                           streamRef};
 }
 
 // _____________________________________________________________________________

--- a/test/util/GTestHelpers.h
+++ b/test/util/GTestHelpers.h
@@ -120,7 +120,7 @@ https://github.com/google/googletest/blob/main/docs/reference/matchers.md#matche
 inline auto setLoglevelForTesting(LogLevel level) {
   auto previous = ::ad_utility::detail::runtimeLogLevel.exchange(
       level.value(), std::memory_order_relaxed);
-  return absl::MakeCleanup([previous] {
+  return absl::Cleanup([previous] {
     ::ad_utility::detail::runtimeLogLevel.store(previous,
                                                 std::memory_order_relaxed);
   });
@@ -134,7 +134,7 @@ inline auto setLoglevelForTesting(LogLevel level) {
 inline auto setGlobalLoggingStreamForTesting(std::ostream* stream) {
   auto* previous = &ad_utility::LogstreamChoice::get().getStream();
   ad_utility::setGlobalLoggingStream(stream);
-  return absl::MakeCleanup(
+  return absl::Cleanup(
       [previous] { ad_utility::setGlobalLoggingStream(previous); });
 }
 
@@ -148,9 +148,12 @@ inline auto setGlobalLoggingStreamForTesting(std::ostream* stream) {
 inline auto setGlobalLoggingStreamToStringStream() {
   auto stream = std::make_shared<std::ostringstream>();
   auto& streamRef = *stream;
+  // `setGlobalLoggingStreamForTesting` cannot be used here because we have to
+  // move the shared pointer to the string stream into the cleanup to keep it
+  // alive.
   auto* previous = &ad_utility::LogstreamChoice::get().getStream();
   ad_utility::setGlobalLoggingStream(stream.get());
-  auto cleanup = absl::MakeCleanup([previous, stream = std::move(stream)] {
+  auto cleanup = absl::Cleanup([previous, stream = std::move(stream)] {
     ad_utility::setGlobalLoggingStream(previous);
   });
   return std::pair<decltype(cleanup), std::ostringstream&>{std::move(cleanup),

--- a/test/util/IndexTestHelpers.cpp
+++ b/test/util/IndexTestHelpers.cpp
@@ -158,9 +158,10 @@ void checkConsistencyBetweenPatternPredicateAndAdditionalColumn(
 // _____________________________________________________________________________
 Index makeTestIndex(const std::string& indexBasename, TestIndexConfig c) {
   // Ignore the (irrelevant) log output of the index building and loading during
-  // these tests.
-  static std::ostringstream ignoreLogStream;
-  ad_utility::setGlobalLoggingStream(&ignoreLogStream);
+  // these tests. The returned cleanup restores the previously active logging
+  // stream when it goes out of scope at the end of this function.
+  std::ostringstream ignoreLogStream;
+  auto logCleanup = setGlobalLoggingStreamForTesting(&ignoreLogStream);
   // Remove previous index files. This is necessary because if we previously
   // built the same index without patterns or all 6 permutations, we wouldn't
   // overwrite the patterns or the missing permutations. This would lead to a
@@ -305,7 +306,6 @@ Index makeTestIndex(const std::string& indexBasename, TestIndexConfig c) {
   if (c.createTextIndex) {
     index.addTextFromOnDiskIndex();
   }
-  ad_utility::setGlobalLoggingStream(&std::cout);
 
   if (c.usePatterns && c.loadAllPermutations) {
     checkConsistencyBetweenPatternPredicateAndAdditionalColumn(index);


### PR DESCRIPTION
Add `setGlobalLoggingStreamForTesting` and `setGlobalLoggingStreamToStringStream`. These helpers not only redirect the `AD_LOG_...` macros to a different stream than `cout`, but also return a `Cleanup` object that will automatically restore the previous value of the logging stream. Also consistently apply these helpers in tests.

This fixes a bug in the `MaterializedViewsTest[Helpers]`, where one explicit stream was set in the test setup which would break with a second redirect that doesn't restore properly, which led to spurious test failures on ARM builds when building an index (which redirects the stream without a proper restore).
 
NOTE: We don't fully understand why those test failures don't appear consistently. Nevertheless, this change is a clear improvement regarding correctness and code clarity.