### PR TITLE
Add zero-copy deserialization for the named result cache

### DIFF
--- a/src/engine/ExplicitIdTableOperation.cpp
+++ b/src/engine/ExplicitIdTableOperation.cpp
@@ -14,6 +14,7 @@ ExplicitIdTableOperation::ExplicitIdTableOperation(
     LocalVocab localVocab, std::string cacheKey)
     : Operation(ctx),
       idTable_(std::move(table)),
+      view_(viewOf(idTable_)),
       variables_(std::move(variables)),
       sortedColumns_(std::move(sortedColumns)),
       localVocab_(std::move(localVocab)),

--- a/src/engine/ExplicitIdTableOperation.cpp
+++ b/src/engine/ExplicitIdTableOperation.cpp
@@ -9,7 +9,7 @@
 
 // _____________________________________________________________________________
 ExplicitIdTableOperation::ExplicitIdTableOperation(
-    QueryExecutionContext* ctx, std::shared_ptr<const IdTable> table,
+    QueryExecutionContext* ctx, IdTableOrView table,
     VariableToColumnMap variables, std::vector<ColumnIndex> sortedColumns,
     LocalVocab localVocab, std::string cacheKey)
     : Operation(ctx),
@@ -26,9 +26,36 @@ ExplicitIdTableOperation::ExplicitIdTableOperation(
 }
 
 // _____________________________________________________________________________
+IdTableView<0> ExplicitIdTableOperation::viewOf(const IdTableOrView& table) {
+  return std::visit(
+      [](const auto& arg) -> IdTableView<0> {
+        using T = std::decay_t<decltype(arg)>;
+        if constexpr (std::is_same_v<T, std::shared_ptr<const IdTable>>) {
+          AD_CONTRACT_CHECK(arg != nullptr);
+          return arg->template asStaticView<0>();
+        } else {
+          static_assert(std::is_same_v<T, IdTableView<0>>);
+          return arg;
+        }
+      },
+      table);
+}
+
+// _____________________________________________________________________________
 Result ExplicitIdTableOperation::computeResult(
     [[maybe_unused]] bool requestLaziness) {
-  return {idTable_, resultSortedOn(), localVocab_.clone()};
+  // Pass the `shared_ptr<const IdTable>` alternative through to `Result`
+  // as-is (instead of converting it to a view) so that `Result` keeps its own
+  // independent claim on the underlying `IdTable` via reference counting,
+  // rather than depending on this `ExplicitIdTableOperation` to stay alive.
+  // The `IdTableView<0>` alternative is passed through unchanged; its
+  // lifetime is guaranteed by whoever created the view (e.g. the `Qlever`
+  // instance that owns the deserialized blob).
+  return std::visit(
+      [this](const auto& arg) -> Result {
+        return {arg, resultSortedOn(), localVocab_.clone()};
+      },
+      idTable_);
 }
 
 // _____________________________________________________________________________
@@ -48,7 +75,7 @@ std::string ExplicitIdTableOperation::getDescriptor() const {
 
 // _____________________________________________________________________________
 size_t ExplicitIdTableOperation::getResultWidth() const {
-  return idTable_->numColumns();
+  return idTableView().numColumns();
 }
 
 // The result is ready immediately.
@@ -67,7 +94,9 @@ float ExplicitIdTableOperation::getMultiplicity([[maybe_unused]] size_t col) {
 }
 
 // _____________________________________________________________________________
-bool ExplicitIdTableOperation::knownEmptyResult() { return idTable_->empty(); }
+bool ExplicitIdTableOperation::knownEmptyResult() {
+  return idTableView().empty();
+}
 
 // _____________________________________________________________________________
 std::unique_ptr<Operation> ExplicitIdTableOperation::cloneImpl() const {

--- a/src/engine/ExplicitIdTableOperation.h
+++ b/src/engine/ExplicitIdTableOperation.h
@@ -29,6 +29,14 @@ class ExplicitIdTableOperation : public Operation {
 
  private:
   IdTableOrView idTable_;
+  // A non-owning view of `idTable_`, computed once in the constructor and
+  // reused by `idTableView()`. This avoids rebuilding an `IdTableView<0>`
+  // (which copies the small but non-trivial `ViewSpans` of column pointers)
+  // on every call. This caching is safe because `idTable_` is never
+  // reassigned after construction: in the owning `shared_ptr<const IdTable>`
+  // alternative, the pointee is `const`, so it cannot be mutated (via this
+  // class) after `view_` has been computed from it.
+  IdTableView<0> view_;
   VariableToColumnMap variables_;
   std::vector<ColumnIndex> sortedColumns_;
   LocalVocab localVocab_;
@@ -45,9 +53,10 @@ class ExplicitIdTableOperation : public Operation {
   // `IdTableOrView` (e.g. `NamedResultCache::Value`).
   static IdTableView<0> viewOf(const IdTableOrView& table);
 
-  // Return a non-owning view of the underlying table, regardless of which
-  // alternative of `IdTableOrView` is currently active.
-  IdTableView<0> idTableView() const { return viewOf(idTable_); }
+  // Return the cached non-owning view of the underlying table (see `view_`
+  // above), regardless of which alternative of `IdTableOrView` is currently
+  // active.
+  const IdTableView<0>& idTableView() const { return view_; }
 
   // Const and public getter for testing.
   size_t sizeEstimate() const { return idTableView().numRows(); }

--- a/src/engine/ExplicitIdTableOperation.h
+++ b/src/engine/ExplicitIdTableOperation.h
@@ -8,29 +8,49 @@
 #ifndef QLEVER_SRC_ENGINE_EXPLICITIDTABLEOPERATION_H
 #define QLEVER_SRC_ENGINE_EXPLICITIDTABLEOPERATION_H
 
+#include <variant>
+
 #include "engine/Operation.h"
 #include "engine/QueryExecutionContext.h"
 #include "engine/Result.h"
 
-// An operation that owns its explicit `Result` via `shared_ptr`s and just
-// returns this result when `computeResult` is called.
+// An operation that owns its explicit `Result` via `shared_ptr`s (or a
+// non-owning view) and just returns this result when `computeResult` is
+// called.
 class ExplicitIdTableOperation : public Operation {
+ public:
+  // The underlying table is either an owning `shared_ptr<const IdTable>`
+  // (e.g. coming from a cache), or a non-owning `IdTableView<0>` (e.g. coming
+  // from a zero-copy deserialized blob). In the latter case, the caller is
+  // responsible for ensuring that the underlying data outlives this
+  // `ExplicitIdTableOperation` and any `Result` computed from it.
+  using IdTableOrView =
+      std::variant<std::shared_ptr<const IdTable>, IdTableView<0>>;
+
  private:
-  std::shared_ptr<const IdTable> idTable_;
+  IdTableOrView idTable_;
   VariableToColumnMap variables_;
   std::vector<ColumnIndex> sortedColumns_;
   LocalVocab localVocab_;
   std::string cacheKey_;
 
  public:
-  ExplicitIdTableOperation(QueryExecutionContext* ctx,
-                           std::shared_ptr<const IdTable> table,
+  ExplicitIdTableOperation(QueryExecutionContext* ctx, IdTableOrView table,
                            VariableToColumnMap variables,
                            std::vector<ColumnIndex> sortedColumns,
                            LocalVocab localVocab, std::string cacheKey);
 
+  // Return a non-owning view of `table`, regardless of which alternative of
+  // `IdTableOrView` is currently active. Also useful for other holders of an
+  // `IdTableOrView` (e.g. `NamedResultCache::Value`).
+  static IdTableView<0> viewOf(const IdTableOrView& table);
+
+  // Return a non-owning view of the underlying table, regardless of which
+  // alternative of `IdTableOrView` is currently active.
+  IdTableView<0> idTableView() const { return viewOf(idTable_); }
+
   // Const and public getter for testing.
-  size_t sizeEstimate() const { return idTable_->numRows(); }
+  size_t sizeEstimate() const { return idTableView().numRows(); }
 
   // Overridden methods from the `Operation` base class.
   std::vector<QueryExecutionTree*> getChildren() override;

--- a/src/engine/NamedResultCache.h
+++ b/src/engine/NamedResultCache.h
@@ -30,7 +30,13 @@ class NamedResultCache {
   // geometry index `cachedGeoIndex_` can be precomputed on a column of the
   // result table for spatial joins with a constant (right) child.
   struct Value {
-    std::shared_ptr<const IdTable> result_;
+    // The result can either be an owning `shared_ptr<const IdTable>` or a
+    // non-owning `IdTableView<0>`. The latter is used when the value was
+    // deserialized as a zero-copy view directly into an externally-owned
+    // buffer (e.g. a memory-mapped or in-memory blob); the caller is then
+    // responsible for keeping that buffer alive for at least as long as this
+    // `Value` (and any `ExplicitIdTableOperation`/`Result` derived from it).
+    ExplicitIdTableOperation::IdTableOrView result_;
     VariableToColumnMap varToColMap_;
     std::vector<ColumnIndex> resultSortedOn_;
     LocalVocab localVocab_;

--- a/src/engine/NamedResultCacheSerializer.h
+++ b/src/engine/NamedResultCacheSerializer.h
@@ -8,13 +8,28 @@
 #define QLEVER_SRC_ENGINE_NAMEDRESULTCACHESERIALIZER_H
 
 #include <boost/math/tools/roots.hpp>
+#include <cstdint>
 
 #include "engine/NamedResultCache.h"
 #include "util/AllocatorWithLimit.h"
+#include "util/Exception.h"
 #include "util/Serializer/SerializeString.h"
 #include "util/Serializer/SerializeVector.h"
 #include "util/Serializer/Serializer.h"
 #include "util/Serializer/TripleSerializer.h"
+
+namespace {
+// An arbitrary magic byte that is written at the very beginning of a
+// serialized `NamedResultCache`. Used by `readFromSerializer` to give a clear
+// error message when the input is not a serialized `NamedResultCache`.
+constexpr uint8_t magicByte = 0xC3;
+
+// The version of the (de)serialization format implemented below. Increment
+// this whenever the format changes in a way that is incompatible with
+// previously serialized data, s.t. `readFromSerializer` can detect and reject
+// data that was written by an incompatible version of QLever.
+constexpr uint16_t formatVersion = 1;
+}  // namespace
 
 // _____________________________________________________________________________
 CPP_template_def(typename Serializer)(
@@ -22,6 +37,11 @@ CPP_template_def(typename Serializer)(
         Serializer>) void NamedResultCache::writeToSerializer(Serializer&
                                                                   serializer)
     const {
+  // Write the magic byte and format version first, s.t. `readFromSerializer`
+  // can detect and reject incompatible or unrelated input.
+  serializer << magicByte;
+  serializer << formatVersion;
+
   auto lock = cache_.wlock();
   std::vector<std::pair<Key, std::shared_ptr<const Value>>> entries;
   for (const auto& key : lock->getAllNonpinnedKeys()) {
@@ -47,6 +67,27 @@ CPP_template_def(typename Serializer)(
                        const LocalVocabContext& context) {
   // Clear the cache first.
   clear();
+
+  // Read and check the magic byte and format version written by
+  // `writeToSerializer`.
+  uint8_t readMagicByte;
+  serializer >> readMagicByte;
+  if (readMagicByte != magicByte) {
+    AD_THROW(
+        "The given input is not a serialized `NamedResultCache` (the magic "
+        "byte does not match)");
+  }
+  uint16_t readFormatVersion;
+  serializer >> readFormatVersion;
+  if (readFormatVersion != formatVersion) {
+    AD_THROW(absl::StrCat(
+        "The serialized `NamedResultCache` has format version ",
+        readFormatVersion,
+        ", but this version of QLever only supports format version ",
+        formatVersion,
+        ". The named result cache was probably written by an incompatible "
+        "version of QLever"));
+  }
 
   // Deserialize the number of entries.
   size_t numEntries;

--- a/src/engine/NamedResultCacheSerializer.h
+++ b/src/engine/NamedResultCacheSerializer.h
@@ -82,9 +82,10 @@ AD_SERIALIZE_FUNCTION_WITH_CONSTRAINT(
 
     // Serialize the IdTable (uses the `serializeIds` helper which handles
     // LocalVocab IDs).
-    serializer << arg.result_->numRows();
-    serializer << arg.result_->numColumns();
-    for (const auto& col : arg.result_->getColumns()) {
+    auto resultView = ExplicitIdTableOperation::viewOf(arg.result_);
+    serializer << resultView.numRows();
+    serializer << resultView.numColumns();
+    for (const auto& col : resultView.getColumns()) {
       // NOTE: Although the code for serialization of a local vocab above is
       // already incorporated, we currently still let local vocab entries throw
       // an exception, because there are some caveats in the serialization that
@@ -141,10 +142,36 @@ AD_SERIALIZE_FUNCTION_WITH_CONSTRAINT(
     serializer >> numColumns;
 
     AD_CORRECTNESS_CHECK(arg.allocatorForSerialization_.has_value());
-    IdTable idTable{numColumns, arg.allocatorForSerialization_.value()};
-    idTable.resize(numRows);
-    for (auto&& col : idTable.getColumns()) {
-      ad_utility::detail::deserializeIds(serializer, mapping, col);
+    ExplicitIdTableOperation::IdTableOrView resultTable;
+    if constexpr (ZeroCopyReadSerializer<S>) {
+      // Zero-copy path: build a non-owning `IdTableView<0>` directly from
+      // spans into the serializer's buffer, without copying the column data.
+      // Since the writing side (see above) rejects any entry that contains a
+      // `LocalVocabIndex` id, `mapping` can never actually apply to any id in
+      // the columns, so skipping `deserializeIds`'s remapping step here is
+      // safe. We still defensively re-check the invariant.
+      IdTableView<0>::ViewSpans columns;
+      columns.reserve(numColumns);
+      for (size_t i = 0; i < numColumns; ++i) {
+        auto column = zeroCopyDeserializeToSpan<Id>(serializer);
+        AD_CORRECTNESS_CHECK(column.size() == numRows);
+        AD_CORRECTNESS_CHECK(
+            ql::ranges::find(column, Datatype::LocalVocabIndex,
+                             &Id::getDatatype) == column.end(),
+            "Named result cache entries that contain local vocab entries "
+            "currently cannot be deserialized.");
+        columns.push_back(column);
+      }
+      resultTable =
+          IdTableView<0>::fromColumns(std::move(columns), numColumns, numRows,
+                                      arg.allocatorForSerialization_.value());
+    } else {
+      IdTable idTable{numColumns, arg.allocatorForSerialization_.value()};
+      idTable.resize(numRows);
+      for (auto&& col : idTable.getColumns()) {
+        ad_utility::detail::deserializeIds(serializer, mapping, col);
+      }
+      resultTable = std::make_shared<const IdTable>(std::move(idTable));
     }
 
     // Deserialize VariableToColumnMap manually.
@@ -178,12 +205,9 @@ AD_SERIALIZE_FUNCTION_WITH_CONSTRAINT(
 
     // Construct the `Value`.
     arg = NamedResultCache::Value{
-        std::make_shared<const IdTable>(std::move(idTable)),
-        std::move(varToColMap),
-        std::move(resultSortedOn),
-        std::move(localVocab),
-        std::move(cacheKey),
-        std::move(cachedGeoIndex)};
+        std::move(resultTable),    std::move(varToColMap),
+        std::move(resultSortedOn), std::move(localVocab),
+        std::move(cacheKey),       std::move(cachedGeoIndex)};
   }
 }
 

--- a/src/engine/NamedResultCacheSerializer.h
+++ b/src/engine/NamedResultCacheSerializer.h
@@ -18,7 +18,7 @@
 #include "util/Serializer/Serializer.h"
 #include "util/Serializer/TripleSerializer.h"
 
-namespace {
+namespace namedResultCacheSerializer::detail {
 // An arbitrary magic byte that is written at the very beginning of a
 // serialized `NamedResultCache`. Used by `readFromSerializer` to give a clear
 // error message when the input is not a serialized `NamedResultCache`.
@@ -29,7 +29,7 @@ constexpr uint8_t magicByte = 0xC3;
 // previously serialized data, s.t. `readFromSerializer` can detect and reject
 // data that was written by an incompatible version of QLever.
 constexpr uint16_t formatVersion = 1;
-}  // namespace
+}  // namespace namedResultCacheSerializer::detail
 
 // _____________________________________________________________________________
 CPP_template_def(typename Serializer)(
@@ -39,8 +39,8 @@ CPP_template_def(typename Serializer)(
     const {
   // Write the magic byte and format version first, s.t. `readFromSerializer`
   // can detect and reject incompatible or unrelated input.
-  serializer << magicByte;
-  serializer << formatVersion;
+  serializer << namedResultCacheSerializer::detail::magicByte;
+  serializer << namedResultCacheSerializer::detail::formatVersion;
 
   auto lock = cache_.wlock();
   std::vector<std::pair<Key, std::shared_ptr<const Value>>> entries;
@@ -72,19 +72,19 @@ CPP_template_def(typename Serializer)(
   // `writeToSerializer`.
   uint8_t readMagicByte;
   serializer >> readMagicByte;
-  if (readMagicByte != magicByte) {
+  if (readMagicByte != namedResultCacheSerializer::detail::magicByte) {
     AD_THROW(
         "The given input is not a serialized `NamedResultCache` (the magic "
         "byte does not match)");
   }
   uint16_t readFormatVersion;
   serializer >> readFormatVersion;
-  if (readFormatVersion != formatVersion) {
+  if (readFormatVersion != namedResultCacheSerializer::detail::formatVersion) {
     AD_THROW(absl::StrCat(
         "The serialized `NamedResultCache` has format version ",
         readFormatVersion,
         ", but this version of QLever only supports format version ",
-        formatVersion,
+        namedResultCacheSerializer::detail::formatVersion,
         ". The named result cache was probably written by an incompatible "
         "version of QLever"));
   }

--- a/src/engine/NamedResultCacheSerializer.h
+++ b/src/engine/NamedResultCacheSerializer.h
@@ -82,7 +82,7 @@ AD_SERIALIZE_FUNCTION_WITH_CONSTRAINT(
 
     // Serialize the IdTable (uses the `serializeIds` helper which handles
     // LocalVocab IDs).
-    auto resultView = ExplicitIdTableOperation::viewOf(arg.result_);
+    const auto& resultView = ExplicitIdTableOperation::viewOf(arg.result_);
     serializer << resultView.numRows();
     serializer << resultView.numColumns();
     for (const auto& col : resultView.getColumns()) {

--- a/src/engine/idTable/IdTable.h
+++ b/src/engine/idTable/IdTable.h
@@ -604,6 +604,25 @@ class IdTable {
         std::move(viewSpans), numColumns_, numRows_, allocator_};
   }
 
+  // Construct a non-owning view directly from a set of column spans, without
+  // requiring an already-existing owning `IdTable`. This is used e.g. to
+  // build a view directly from spans that were obtained via zero-copy
+  // deserialization from a buffer (see `zeroCopyDeserializeToSpan` in
+  // `util/Serializer/SerializeVector.h`). The caller is responsible for
+  // ensuring that the memory backing `columns` outlives the returned view.
+  CPP_template(typename = void)(requires(isView)) static IdTable
+      fromColumns(ViewSpans columns, size_t numColumns, size_t numRows,
+                  Allocator allocator) {
+    if constexpr (!isDynamic) {
+      AD_CONTRACT_CHECK(numColumns == NumColumns);
+    }
+    AD_CONTRACT_CHECK(columns.size() == numColumns);
+    AD_CONTRACT_CHECK(ql::ranges::all_of(
+        columns, [numRows](const auto& col) { return col.size() == numRows; }));
+    return IdTable{std::move(columns), numColumns, numRows,
+                   std::move(allocator)};
+  }
+
   // Return a non-owning view of the rows [offset, offset + size). Requires
   // `offset + size <= numRows()`.
   IdTable<T, NumColumns, ColumnStorage, IsView::True> subView(

--- a/src/global/ValueId.h
+++ b/src/global/ValueId.h
@@ -64,7 +64,7 @@ constexpr bool isDatatypeTrivial(Datatype datatype) {
   return ad_utility::contains(trivialDatatypes, datatype);
 }
 
-/// Convert the `Datatype` enum to the corresponding string
+// Convert the `Datatype` enum to the corresponding string
 inline QL_CONSTEXPR std::string_view toString(Datatype type) {
   switch (type) {
     case Datatype::Undefined:
@@ -96,8 +96,8 @@ inline QL_CONSTEXPR std::string_view toString(Datatype type) {
   AD_FAIL();
 }
 
-/// Encode values of different types (the types from the `Datatype` enum above)
-/// using 4 bits for the datatype and 60 bits for the value.
+// Encode values of different types (the types from the `Datatype` enum above)
+// using 4 bits for the datatype and 60 bits for the value.
 class ValueId {
  public:
   using T = uint64_t;
@@ -106,15 +106,15 @@ class ValueId {
 
   using IntegerType = ad_utility::NBitInteger<numDataBits>;
 
-  /// The maximum value for the unsigned types that are used as indices
-  /// (currently VocabIndex, LocalVocabIndex and Text).
+  // The maximum value for the unsigned types that are used as indices
+  // (currently VocabIndex, LocalVocabIndex and Text).
   static constexpr T maxIndex = (1ull << numDataBits) - 1;
 
-  /// The smallest double > 0 that will not be rounded to zero by the precision
-  /// loss of `FoldedId`. Symmetrically, `-minPositiveDouble` is the largest
-  /// double <0 that will not be rounded to zero.
-  /// Note: This constant is currently only used in unit tests, and cannot be
-  /// computed at compile time in C++17.
+  // The smallest double > 0 that will not be rounded to zero by the precision
+  // loss of `FoldedId`. Symmetrically, `-minPositiveDouble` is the largest
+  // double <0 that will not be rounded to zero.
+  // Note: This constant is currently only used in unit tests, and cannot be
+  // computed at compile time in C++17.
 #ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
   static constexpr double minPositiveDouble =
       absl::bit_cast<double>(1ull << numDatatypeBits);
@@ -146,9 +146,9 @@ class ValueId {
   // ValueId.
   static_assert(numDataBits == GeoPoint::numDataBits);
 
-  /// This exception is thrown if we try to store a value of an index type
-  /// (VocabIndex, LocalVocabIndex, TextRecordIndex) that is larger than
-  /// `maxIndex`.
+  // This exception is thrown if we try to store a value of an index type
+  // (VocabIndex, LocalVocabIndex, TextRecordIndex) that is larger than
+  // `maxIndex`.
   struct IndexTooLargeException : public std::exception {
    private:
     std::string errorMessage_;
@@ -165,8 +165,8 @@ class ValueId {
     const char* what() const noexcept override { return errorMessage_.c_str(); }
   };
 
-  /// A struct that represents the single undefined value. This is required for
-  /// generic code like in the `visit` method.
+  // A struct that represents the single undefined value. This is required for
+  // generic code like in the `visit` method.
   struct UndefinedType {};
 
  private:
@@ -174,17 +174,17 @@ class ValueId {
   T _bits;
 
  public:
-  /// Default construction of an uninitialized id.
+  // Default construction of an uninitialized id.
   ValueId() = default;
 
-  /// Comparison is performed directly on the underlying representation. Note
-  /// that because the type bits are the most significant bits, all values of
-  /// the same `Datatype` will be adjacent to each other. Unsigned index types
-  /// are also ordered correctly. Signed integers are ordered as follows: first
-  /// the positive integers in order and then the negative integers in order.
-  /// For doubles it is first the positive doubles in order, then the negative
-  /// doubles in reversed order. This is a direct consequence of comparing the
-  /// bit representation of these values as unsigned integers.
+  // Comparison is performed directly on the underlying representation. Note
+  // that because the type bits are the most significant bits, all values of
+  // the same `Datatype` will be adjacent to each other. Unsigned index types
+  // are also ordered correctly. Signed integers are ordered as follows: first
+  // the positive integers in order and then the negative integers in order.
+  // For doubles it is first the positive doubles in order, then the negative
+  // doubles in reversed order. This is a direct consequence of comparing the
+  // bit representation of these values as unsigned integers.
   constexpr auto compareThreeWay(const ValueId& other) const {
     using enum Datatype;
     auto type = getDatatype();
@@ -240,64 +240,64 @@ class ValueId {
     return ql::compareThreeWay(_bits, other._bits);
   }
 
-  /// Get the underlying bit representation, e.g. for compression etc.
+  // Get the underlying bit representation, e.g. for compression etc.
   [[nodiscard]] constexpr T getBits() const noexcept { return _bits; }
-  /// Construct from the underlying bit representation. `bits` must have been
-  /// obtained by a call to `getBits()` on a valid `ValueId`.
+  // Construct from the underlying bit representation. `bits` must have been
+  // obtained by a call to `getBits()` on a valid `ValueId`.
   static constexpr ValueId fromBits(T bits) noexcept { return {bits}; }
 
-  /// Get the datatype.
+  // Get the datatype.
   [[nodiscard]] constexpr Datatype getDatatype() const noexcept {
     return static_cast<Datatype>(_bits >> numDataBits);
   }
 
-  /// Create a `ValueId` of the `Undefined` type. There is only one such ID and
-  /// it is guaranteed to be smaller than all IDs of other types. This helps
-  /// implementing the correct join behavior in presence of undefined values.
+  // Create a `ValueId` of the `Undefined` type. There is only one such ID and
+  // it is guaranteed to be smaller than all IDs of other types. This helps
+  // implementing the correct join behavior in presence of undefined values.
   constexpr static ValueId makeUndefined() noexcept { return {0}; }
 
-  /// Returns an object of `UndefinedType`. In many scenarios this function is
-  /// unnecessary because `getDatatype() == Undefined` already identifies the
-  /// single undefined value correctly, but it is very useful for generic code
-  /// like the `visit` member function.
+  // Returns an object of `UndefinedType`. In many scenarios this function is
+  // unnecessary because `getDatatype() == Undefined` already identifies the
+  // single undefined value correctly, but it is very useful for generic code
+  // like the `visit` member function.
   [[nodiscard]] UndefinedType getUndefined() const noexcept { return {}; }
   bool isUndefined() const noexcept { return *this == makeUndefined(); }
 
-  /// Create a `ValueId` for a double value. The conversion will reduce the
-  /// precision of the mantissa of an IEEE double precision floating point
-  /// number from 53 to 49 significant bits.
+  // Create a `ValueId` for a double value. The conversion will reduce the
+  // precision of the mantissa of an IEEE double precision floating point
+  // number from 53 to 49 significant bits.
   static ValueId makeFromDouble(double d) {
     auto shifted = absl::bit_cast<T>(d) >> numDatatypeBits;
     return addDatatypeBits(shifted, Datatype::Double);
   }
-  /// Obtain the `double` that this `ValueId` encodes. If `getDatatype() !=
-  /// Double` then the result is unspecified.
+  // Obtain the `double` that this `ValueId` encodes. If `getDatatype() !=
+  // Double` then the result is unspecified.
   [[nodiscard]] double getDouble() const noexcept {
     return absl::bit_cast<double>(_bits << numDatatypeBits);
   }
 
-  /// Create a `ValueId` for a signed integer value. Integers in the range
-  /// [-2^59, 2^59-1] can be represented. Integers outside of this range will
-  /// overflow according to the semantics of `NBitInteger<60>`.
+  // Create a `ValueId` for a signed integer value. Integers in the range
+  // [-2^59, 2^59-1] can be represented. Integers outside of this range will
+  // overflow according to the semantics of `NBitInteger<60>`.
   static ValueId makeFromInt(int64_t i) noexcept {
     auto nbit = IntegerType::toNBit(i);
     return addDatatypeBits(nbit, Datatype::Int);
   }
 
-  /// Obtain the signed integer that this `ValueId` encodes. If `getDatatype()
-  /// != Int` then the result is unspecified.
+  // Obtain the signed integer that this `ValueId` encodes. If `getDatatype()
+  // != Int` then the result is unspecified.
   [[nodiscard]] int64_t getInt() const noexcept {
     return IntegerType::fromNBit(_bits);
   }
 
-  /// Create a `ValueId` for a boolean value.
+  // Create a `ValueId` for a boolean value.
   static constexpr ValueId makeFromBool(bool b) noexcept {
     auto bits = static_cast<T>(b);
     return addDatatypeBits(bits, Datatype::Bool);
   }
 
-  /// Create a `ValueId` for a boolean value, represented as "0" or "1" instead
-  /// of "false" or "true".
+  // Create a `ValueId` for a boolean value, represented as "0" or "1" instead
+  // of "false" or "true".
   static constexpr ValueId makeBoolFromZeroOrOne(bool b) noexcept {
     auto bits = static_cast<T>(b);
     bits |= static_cast<T>(true) << 1;
@@ -320,10 +320,10 @@ class ValueId {
     return value ? "true" : "false";
   }
 
-  /// Create a `ValueId` for an unsigned index of type
-  /// `VocabIndex|TextRecordIndex|LocalVocabIndex`. These types can
-  /// represent values in the range [0, 2^60]. When `index` is outside of this
-  /// range, and `IndexTooLargeException` is thrown.
+  // Create a `ValueId` for an unsigned index of type
+  // `VocabIndex|TextRecordIndex|LocalVocabIndex`. These types can
+  // represent values in the range [0, 2^60]. When `index` is outside of this
+  // range, and `IndexTooLargeException` is thrown.
   static ValueId makeFromVocabIndex(VocabIndex index) {
     return makeFromIndex(index.get(), Datatype::VocabIndex);
   }
@@ -349,9 +349,9 @@ class ValueId {
     return makeFromIndex(index.get(), Datatype::BlankNodeIndex);
   }
 
-  /// Obtain the unsigned index that this `ValueId` encodes. If `getDatatype()
-  /// != [VocabIndex|TextRecordIndex|LocalVocabIndex]` then the result is
-  /// unspecified.
+  // Obtain the unsigned index that this `ValueId` encodes. If `getDatatype()
+  // != [VocabIndex|TextRecordIndex|LocalVocabIndex]` then the result is
+  // unspecified.
   [[nodiscard]] constexpr VocabIndex getVocabIndex() const noexcept {
     return VocabIndex::make(removeDatatypeBits(_bits));
   }
@@ -385,14 +385,14 @@ class ValueId {
 
   // TODO<joka921> implement dates
 
-  /// Create a `ValueId` for a GeoPoint object (representing a POINT from WKT).
+  // Create a `ValueId` for a GeoPoint object (representing a POINT from WKT).
   static ValueId makeFromGeoPoint(GeoPoint p) {
     return addDatatypeBits(p.toBitRepresentation(), Datatype::GeoPoint);
   }
 
-  /// Obtain a new `GeoPoint` object representing the pair of coordinates that
-  /// this `ValueId` encodes. If `getDatatype() != GeoPoint` then the result
-  /// is unspecified.
+  // Obtain a new `GeoPoint` object representing the pair of coordinates that
+  // this `ValueId` encodes. If `getDatatype() != GeoPoint` then the result
+  // is unspecified.
   GeoPoint getGeoPoint() const {
     T bits = removeDatatypeBits(_bits);
     return GeoPoint::fromBitRepresentation(bits);
@@ -419,8 +419,8 @@ class ValueId {
       !isTypeBitwiseComparable_.at(
           static_cast<size_t>(Datatype::LocalVocabIndex));
 
-  /// Return the smallest and largest possible `ValueId` wrt the underlying
-  /// representation
+  // Return the smallest and largest possible `ValueId` wrt the underlying
+  // representation
   constexpr static ValueId min() noexcept {
     return {std::numeric_limits<T>::min()};
   }
@@ -428,8 +428,8 @@ class ValueId {
     return {std::numeric_limits<T>::max()};
   }
 
-  /// Enable hashing in abseil for `ValueId` (required by `ad_utility::HashSet`
-  /// and `ad_utility::HashMap`
+  // Enable hashing in abseil for `ValueId` (required by `ad_utility::HashSet`
+  // and `ad_utility::HashMap`
   template <typename H>
   friend H AbslHashValue(H h, const ValueId& id) {
     // Adding 0/1 to the hash is required to ensure that for two unequal
@@ -448,27 +448,20 @@ class ValueId {
     return H::combine(std::move(h), *id.getLocalVocabIndex(), 1);
   }
 
-  /// Enable the serialization of `ValueId` in the `ad_utility::serialization`
-  /// framework. `ValueId` consists of a single trivially-copyable `_bits`
-  /// member with no padding, so it is serialized as a raw byte copy via the
-  /// generic `TriviallySerializable` mechanism (see `Serializer.h`), which
-  /// also enables the bulk and zero-copy (de)serialization paths for
-  /// `std::vector<ValueId>`/`ql::span<ValueId>`. Note: This must be the only
-  /// way `ValueId` opts into the serialization framework -- additionally
-  /// defining a custom `AD_SERIALIZE_FRIEND_FUNCTION` would make every call
-  /// to `serialize(serializer, someValueId)` ambiguous.
+  // Enable the serialization of `ValueId` in the `ad_utility::serialization`
+  // framework.
   friend void allowTrivialSerialization(ValueId, auto);
 
-  /// Similar to `std::visit` for `std::variant`. First gets the datatype and
-  /// then calls `visitor(getTYPE)` where `getTYPE` is the correct getter method
-  /// for the datatype (e.g. `getDouble` for `Datatype::Double`). Visitor must
-  /// be callable with all of the possible return types of the `getTYPE`
-  /// functions.
-  /// TODO<joka921> This currently still has limited functionality because
-  /// VocabIndex, LocalVocabIndex, TextRecordIndex,  and EncodedVal are all of
-  /// the same type `uint64_t` and the visitor cannot distinguish between them.
-  /// Create strong types for these indices and make the `ValueId` class use
-  /// them.
+  // Similar to `std::visit` for `std::variant`. First gets the datatype and
+  // then calls `visitor(getTYPE)` where `getTYPE` is the correct getter method
+  // for the datatype (e.g. `getDouble` for `Datatype::Double`). Visitor must
+  // be callable with all of the possible return types of the `getTYPE`
+  // functions.
+  // TODO<joka921> This currently still has limited functionality because
+  // VocabIndex, LocalVocabIndex, TextRecordIndex,  and EncodedVal are all of
+  // the same type `uint64_t` and the visitor cannot distinguish between them.
+  // Create strong types for these indices and make the `ValueId` class use
+  // them.
   template <typename Visitor>
   decltype(auto) visit(Visitor&& visitor) const {
     switch (getDatatype()) {
@@ -500,8 +493,8 @@ class ValueId {
     AD_FAIL();
   }
 
-  /// This operator is only for debugging and testing. It returns a
-  /// human-readable representation.
+  // This operator is only for debugging and testing. It returns a
+  // human-readable representation.
   friend std::ostream& operator<<(std::ostream& ostr, const ValueId& id) {
     ostr << toString(id.getDatatype())[0] << ':';
     if (id.getDatatype() == Datatype::Undefined) {

--- a/src/global/ValueId.h
+++ b/src/global/ValueId.h
@@ -449,8 +449,15 @@ class ValueId {
   }
 
   /// Enable the serialization of `ValueId` in the `ad_utility::serialization`
-  /// framework.
-  AD_SERIALIZE_FRIEND_FUNCTION(ValueId) { serializer | arg._bits; }
+  /// framework. `ValueId` consists of a single trivially-copyable `_bits`
+  /// member with no padding, so it is serialized as a raw byte copy via the
+  /// generic `TriviallySerializable` mechanism (see `Serializer.h`), which
+  /// also enables the bulk and zero-copy (de)serialization paths for
+  /// `std::vector<ValueId>`/`ql::span<ValueId>`. Note: This must be the only
+  /// way `ValueId` opts into the serialization framework -- additionally
+  /// defining a custom `AD_SERIALIZE_FRIEND_FUNCTION` would make every call
+  /// to `serialize(serializer, someValueId)` ambiguous.
+  friend void allowTrivialSerialization(ValueId, auto);
 
   /// Similar to `std::visit` for `std::variant`. First gets the datatype and
   /// then calls `visitor(getTYPE)` where `getTYPE` is the correct getter method

--- a/test/IdTableTest.cpp
+++ b/test/IdTableTest.cpp
@@ -1264,6 +1264,10 @@ TEST(IdTable, fromColumns) {
   for (size_t i = 0; i < 3; ++i) {
     EXPECT_EQ(view(i, 0), col0[i]);
     EXPECT_EQ(view(i, 1), col1[i]);
+    // The view must not copy the data: its elements are the very same
+    // objects as those in `col0`/`col1`.
+    EXPECT_EQ(&view(i, 0), &col0[i]);
+    EXPECT_EQ(&view(i, 1), &col1[i]);
   }
 
   // The `columns` and the passed in `numColumns` must be consistent.
@@ -1289,6 +1293,8 @@ TEST(IdTable, fromColumns) {
   for (size_t i = 0; i < 3; ++i) {
     EXPECT_EQ(staticView(i, 0), col0[i]);
     EXPECT_EQ(staticView(i, 1), col1[i]);
+    EXPECT_EQ(&staticView(i, 0), &col0[i]);
+    EXPECT_EQ(&staticView(i, 1), &col1[i]);
   }
 }
 

--- a/test/IdTableTest.cpp
+++ b/test/IdTableTest.cpp
@@ -1251,6 +1251,48 @@ TEST(IdTable, moveOrCloneOnView) {
 }
 
 // ____________________________________________________________________________
+TEST(IdTable, fromColumns) {
+  std::vector<Id> col0{V(1), V(2), V(3)};
+  std::vector<Id> col1{V(4), V(5), V(6)};
+  auto allocator = makeAllocator();
+
+  IdTableView<0>::ViewSpans columns{col0, col1};
+  auto view = IdTableView<0>::fromColumns(columns, 2, 3, allocator);
+
+  ASSERT_EQ(view.numColumns(), 2u);
+  ASSERT_EQ(view.numRows(), 3u);
+  for (size_t i = 0; i < 3; ++i) {
+    EXPECT_EQ(view(i, 0), col0[i]);
+    EXPECT_EQ(view(i, 1), col1[i]);
+  }
+
+  // The `columns` and the passed in `numColumns` must be consistent.
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      IdTableView<0>::fromColumns(columns, 3, 3, allocator),
+      ::testing::HasSubstr("Assertion"));
+
+  // Each of the `columns` must have exactly `numRows` elements.
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      IdTableView<0>::fromColumns(columns, 2, 2, allocator),
+      ::testing::HasSubstr("Assertion"));
+
+  // A statically-sized `IdTableView<N>` requires `numColumns == N`.
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      IdTableView<2>::fromColumns(columns, 3, 3, allocator),
+      ::testing::HasSubstr("Assertion"));
+
+  // Constructing a static `IdTableView<2>` with the correct `numColumns`
+  // works and yields the same contents as the dynamic view above.
+  auto staticView = IdTableView<2>::fromColumns(columns, 2, 3, allocator);
+  ASSERT_EQ(staticView.numColumns(), 2u);
+  ASSERT_EQ(staticView.numRows(), 3u);
+  for (size_t i = 0; i < 3; ++i) {
+    EXPECT_EQ(staticView(i, 0), col0[i]);
+    EXPECT_EQ(staticView(i, 1), col1[i]);
+  }
+}
+
+// ____________________________________________________________________________
 // Typed test fixture for `subView`, covering both owned `IdTable` and
 // `IdTableView<0>`.
 template <typename T>

--- a/test/engine/ExplicitIdTableOperationTest.cpp
+++ b/test/engine/ExplicitIdTableOperationTest.cpp
@@ -51,8 +51,12 @@ VariableToColumnMap createTestVariableMap(size_t numVars) {
   return map;
 }
 
-// Test fixture for ExplicitIdTableOperation tests
-class ExplicitIdTableOperationTest : public ::testing::Test {
+// Test fixture for ExplicitIdTableOperation tests. Parameterized over
+// whether the `IdTableOrView` passed to the operation should be the owning
+// `shared_ptr<const IdTable>` alternative (`GetParam() == false`) or the
+// non-owning `IdTableView<0>` alternative (`GetParam() == true`), so that
+// every test in this fixture exercises both cases.
+class ExplicitIdTableOperationTest : public ::testing::TestWithParam<bool> {
  protected:
   void SetUp() override {
     qec_ = getTestQec();
@@ -64,6 +68,19 @@ class ExplicitIdTableOperationTest : public ::testing::Test {
     testCacheKey_ = "[dummy cache key]";
   }
 
+  // Wrap `table` as an `ExplicitIdTableOperation::IdTableOrView`, either as
+  // the owning `shared_ptr<const IdTable>` alternative, or as a non-owning
+  // `IdTableView<0>` alternative, depending on `GetParam()`. The caller is
+  // responsible for keeping `table` alive for as long as the returned
+  // `IdTableOrView` (and anything constructed from it) is in use.
+  ExplicitIdTableOperation::IdTableOrView wrapTable(
+      const std::shared_ptr<IdTable>& table) const {
+    if (GetParam()) {
+      return table->asStaticView<0>();
+    }
+    return std::shared_ptr<const IdTable>{table};
+  }
+
   QueryExecutionContext* qec_;
   std::shared_ptr<IdTable> testTable_;
   VariableToColumnMap testVariables_;
@@ -72,9 +89,16 @@ class ExplicitIdTableOperationTest : public ::testing::Test {
   std::string testCacheKey_;
 };
 
+// _____________________________________________________________________________
+INSTANTIATE_TEST_SUITE_P(OwningAndView, ExplicitIdTableOperationTest,
+                         ::testing::Bool(),
+                         [](const ::testing::TestParamInfo<bool>& info) {
+                           return info.param ? "View" : "Owning";
+                         });
+
 // Test trivial member functions
-TEST_F(ExplicitIdTableOperationTest, TrivialGetters) {
-  ExplicitIdTableOperation op(qec_, testTable_, testVariables_,
+TEST_P(ExplicitIdTableOperationTest, TrivialGetters) {
+  ExplicitIdTableOperation op(qec_, wrapTable(testTable_), testVariables_,
                               testSortedColumns_, testLocalVocab_.clone(),
                               testCacheKey_);
 
@@ -114,30 +138,30 @@ TEST_F(ExplicitIdTableOperationTest, TrivialGetters) {
 }
 
 // _____________________________________________________________________________
-TEST_F(ExplicitIdTableOperationTest, isDeterministic) {
-  ExplicitIdTableOperation op(qec_, testTable_, testVariables_,
+TEST_P(ExplicitIdTableOperationTest, isDeterministic) {
+  ExplicitIdTableOperation op(qec_, wrapTable(testTable_), testVariables_,
                               testSortedColumns_, testLocalVocab_.clone(),
                               testCacheKey_);
   EXPECT_TRUE(op.isDeterministic());
 }
 
-TEST_F(ExplicitIdTableOperationTest, KnownEmptyResult) {
+TEST_P(ExplicitIdTableOperationTest, KnownEmptyResult) {
   {
     auto emptyTable = std::make_shared<IdTable>(2, makeAllocator());
-    ExplicitIdTableOperation op(qec_, emptyTable, testVariables_, {},
+    ExplicitIdTableOperation op(qec_, wrapTable(emptyTable), testVariables_, {},
                                 LocalVocab{}, "empty");
     EXPECT_TRUE(op.knownEmptyResult());
   }
   {
-    ExplicitIdTableOperation op(qec_, testTable_, testVariables_, {},
+    ExplicitIdTableOperation op(qec_, wrapTable(testTable_), testVariables_, {},
                                 LocalVocab{}, "empty");
     EXPECT_FALSE(op.knownEmptyResult());
   }
 }
 
 // Test computeResult functionality
-TEST_F(ExplicitIdTableOperationTest, ComputeResultBasic) {
-  ExplicitIdTableOperation op(qec_, testTable_, testVariables_,
+TEST_P(ExplicitIdTableOperationTest, ComputeResultBasic) {
+  ExplicitIdTableOperation op(qec_, wrapTable(testTable_), testVariables_,
                               testSortedColumns_, testLocalVocab_.clone(),
                               testCacheKey_);
 
@@ -152,8 +176,8 @@ TEST_F(ExplicitIdTableOperationTest, ComputeResultBasic) {
   EXPECT_THAT(result.sortedBy(), ElementsAre(ColumnIndex{0}));
 }
 
-TEST_F(ExplicitIdTableOperationTest, ComputeResultWithLaziness) {
-  ExplicitIdTableOperation op(qec_, testTable_, testVariables_,
+TEST_P(ExplicitIdTableOperationTest, ComputeResultWithLaziness) {
+  ExplicitIdTableOperation op(qec_, wrapTable(testTable_), testVariables_,
                               testSortedColumns_, testLocalVocab_.clone(),
                               testCacheKey_);
 
@@ -168,13 +192,13 @@ TEST_F(ExplicitIdTableOperationTest, ComputeResultWithLaziness) {
 }
 
 // _____________________________________________________________________________
-TEST_F(ExplicitIdTableOperationTest, ComputeResultWithLocalVocab) {
+TEST_P(ExplicitIdTableOperationTest, ComputeResultWithLocalVocab) {
   LocalVocab localVocab;
   LocalVocabEntry testEntry = LocalVocabEntry::fromStringRepresentation(
       "\"test_word\"", qec_->getLocalVocabContext());
   localVocab.getIndexAndAddIfNotContained(testEntry);
 
-  ExplicitIdTableOperation op(qec_, testTable_, testVariables_,
+  ExplicitIdTableOperation op(qec_, wrapTable(testTable_), testVariables_,
                               testSortedColumns_, std::move(localVocab),
                               testCacheKey_);
 
@@ -187,13 +211,13 @@ TEST_F(ExplicitIdTableOperationTest, ComputeResultWithLocalVocab) {
 }
 
 // Test cloneImpl functionality
-TEST_F(ExplicitIdTableOperationTest, CloneImpl) {
+TEST_P(ExplicitIdTableOperationTest, CloneImpl) {
   LocalVocab localVocab;
   LocalVocabEntry testEntry = LocalVocabEntry::fromStringRepresentation(
       "\"clone_test\"", qec_->getLocalVocabContext());
   localVocab.getIndexAndAddIfNotContained(testEntry);
 
-  ExplicitIdTableOperation original(qec_, testTable_, testVariables_,
+  ExplicitIdTableOperation original(qec_, wrapTable(testTable_), testVariables_,
                                     testSortedColumns_, std::move(localVocab),
                                     testCacheKey_);
 
@@ -225,21 +249,21 @@ TEST_F(ExplicitIdTableOperationTest, CloneImpl) {
   EXPECT_TRUE(ad_utility::contains(clonedWords, testEntry));
 }
 
-TEST_F(ExplicitIdTableOperationTest, ConstructionWithSortedColumns) {
+TEST_P(ExplicitIdTableOperationTest, ConstructionWithSortedColumns) {
   std::vector<ColumnIndex> sortedCols = {ColumnIndex{1}, ColumnIndex{0}};
-  ExplicitIdTableOperation op(qec_, testTable_, testVariables_, sortedCols,
-                              LocalVocab{}, testCacheKey_);
+  ExplicitIdTableOperation op(qec_, wrapTable(testTable_), testVariables_,
+                              sortedCols, LocalVocab{}, testCacheKey_);
 
   EXPECT_THAT(op.resultSortedOn(), ElementsAre(ColumnIndex{1}, ColumnIndex{0}));
 }
 
 // Test with different table sizes
-TEST_F(ExplicitIdTableOperationTest, DifferentTableSizes) {
+TEST_P(ExplicitIdTableOperationTest, DifferentTableSizes) {
   // Test with single row
   auto singleRowTable = createTestIdTable(1, 3);
   auto singleRowVars = createTestVariableMap(3);
-  ExplicitIdTableOperation singleRowOp(qec_, singleRowTable, singleRowVars, {},
-                                       {}, testCacheKey_);
+  ExplicitIdTableOperation singleRowOp(qec_, wrapTable(singleRowTable),
+                                       singleRowVars, {}, {}, testCacheKey_);
 
   EXPECT_EQ(singleRowOp.sizeEstimate(), 1u);
   EXPECT_EQ(singleRowOp.getResultWidth(), 3u);
@@ -248,8 +272,8 @@ TEST_F(ExplicitIdTableOperationTest, DifferentTableSizes) {
   // Test with many rows
   auto largeTable = createTestIdTable(100, 1);
   auto largeTableVars = createTestVariableMap(1);
-  ExplicitIdTableOperation largeOp(qec_, largeTable, largeTableVars, {}, {},
-                                   testCacheKey_);
+  ExplicitIdTableOperation largeOp(qec_, wrapTable(largeTable), largeTableVars,
+                                   {}, {}, testCacheKey_);
 
   EXPECT_EQ(largeOp.sizeEstimate(), 100u);
   EXPECT_EQ(largeOp.getResultWidth(), 1u);
@@ -257,12 +281,12 @@ TEST_F(ExplicitIdTableOperationTest, DifferentTableSizes) {
 }
 
 // Test variable to column mapping
-TEST_F(ExplicitIdTableOperationTest, VariableToColumnMapping) {
+TEST_P(ExplicitIdTableOperationTest, VariableToColumnMapping) {
   VariableToColumnMap customVars;
   customVars[Variable("?subject")] = makeAlwaysDefinedColumn(0);
   customVars[Variable("?predicate")] = makeAlwaysDefinedColumn(1);
 
-  ExplicitIdTableOperation op(qec_, testTable_, customVars, {}, {},
+  ExplicitIdTableOperation op(qec_, wrapTable(testTable_), customVars, {}, {},
                               testCacheKey_);
 
   auto computedVars = op.computeVariableToColumnMap();

--- a/test/engine/NamedResultCacheSerializerTest.cpp
+++ b/test/engine/NamedResultCacheSerializerTest.cpp
@@ -18,7 +18,6 @@
 
 using namespace ad_utility::serialization;
 using ::testing::ElementsAre;
-using ::testing::Pointee;
 using ::testing::UnorderedElementsAreArray;
 
 namespace {
@@ -89,8 +88,13 @@ TEST_F(NamedResultCacheSerializerTest, ValueSerialization) {
 
   auto deserializedValue = serializeAndDeserializeValue(value);
 
-  // Check the result pointer is valid.
-  ASSERT_NE(deserializedValue.result_, nullptr);
+  // Check the result pointer is valid (the non-aligned serializer used here
+  // always deserializes into the owning `shared_ptr<const IdTable>`
+  // alternative, never a zero-copy view).
+  ASSERT_TRUE(std::holds_alternative<std::shared_ptr<const IdTable>>(
+      deserializedValue.result_));
+  ASSERT_NE(std::get<std::shared_ptr<const IdTable>>(deserializedValue.result_),
+            nullptr);
 
   // Check the local vocab.
   auto deserWords = deserializedValue.localVocab_.getAllWordsForTesting();
@@ -100,12 +104,51 @@ TEST_F(NamedResultCacheSerializerTest, ValueSerialization) {
               deserWords[i].toStringRepresentation());
   }
   // Check the result
-  EXPECT_THAT(deserializedValue.result_, Pointee(matchesIdTable(table)));
+  EXPECT_THAT(ExplicitIdTableOperation::viewOf(deserializedValue.result_),
+              matchesIdTable(table));
   EXPECT_THAT(deserializedValue.varToColMap_,
               UnorderedElementsAreArray(varColMap));
   EXPECT_THAT(deserializedValue.resultSortedOn_, ElementsAre(0, 1));
   EXPECT_EQ(deserializedValue.cacheKey_, cacheKey);
   EXPECT_FALSE(deserializedValue.cachedGeoIndex_.has_value());
+}
+
+// Test that deserializing from an `AlignedByteBufferReadSerializer` (which
+// supports zero-copy deserialization) yields a non-owning `IdTableView<0>`
+// that points directly into the serializer's buffer, instead of an owning
+// `shared_ptr<const IdTable>`.
+TEST_F(NamedResultCacheSerializerTest, ValueSerializationZeroCopy) {
+  auto table = makeIdTableFromVector({{0, 7}, {9, 11}, {13, 17}});
+
+  VariableToColumnMap varColMap;
+  varColMap[Variable{"?x"}] = makeAlwaysDefinedColumn(0);
+  varColMap[Variable{"?y"}] = makePossiblyUndefinedColumn(1);
+
+  NamedResultCache::Value value{std::make_shared<const IdTable>(table.clone()),
+                                varColMap,
+                                {0, 1},
+                                LocalVocab{},
+                                "test-cache-key",
+                                std::nullopt};
+
+  AlignedByteBufferWriteSerializer writeSerializer;
+  writeSerializer << value;
+  AlignedByteBufferReadSerializer readSerializer{
+      std::move(writeSerializer).data()};
+
+  NamedResultCache::Value deserializedValue;
+  deserializedValue.allocatorForSerialization_ = alloc_;
+  deserializedValue.contextForSerialization_ = &qec_->getIndex().getImpl();
+  readSerializer >> deserializedValue;
+
+  ASSERT_TRUE(
+      std::holds_alternative<IdTableView<0>>(deserializedValue.result_));
+  EXPECT_THAT(ExplicitIdTableOperation::viewOf(deserializedValue.result_),
+              matchesIdTable(table));
+  EXPECT_THAT(deserializedValue.varToColMap_,
+              UnorderedElementsAreArray(varColMap));
+  EXPECT_THAT(deserializedValue.resultSortedOn_, ElementsAre(0, 1));
+  EXPECT_EQ(deserializedValue.cacheKey_, "test-cache-key");
 }
 
 // Test serialization of the entire NamedResultCache.
@@ -168,14 +211,16 @@ TEST_F(NamedResultCacheSerializerTest, CacheSerialization) {
 
   auto result1 = cache2.get("query-1");
   ASSERT_NE(result1, nullptr);
-  EXPECT_THAT(result1->result_, Pointee(matchesIdTable(table1)));
+  EXPECT_THAT(ExplicitIdTableOperation::viewOf(result1->result_),
+              matchesIdTable(table1));
   EXPECT_THAT(result1->varToColMap_, UnorderedElementsAreArray(varColMap1));
   EXPECT_THAT(result1->resultSortedOn_, ElementsAre(0));
   EXPECT_EQ(result1->cacheKey_, "key1");
 
   auto result2 = cache2.get("query-2");
   ASSERT_NE(result2, nullptr);
-  EXPECT_THAT(result2->result_, Pointee(matchesIdTable(table2)));
+  EXPECT_THAT(ExplicitIdTableOperation::viewOf(result2->result_),
+              matchesIdTable(table2));
   EXPECT_THAT(result2->varToColMap_, UnorderedElementsAreArray(varColMap2));
   EXPECT_THAT(result2->resultSortedOn_, ElementsAre(1, 0));
   EXPECT_EQ(result2->cacheKey_, "key2");

--- a/test/engine/NamedResultCacheSerializerTest.cpp
+++ b/test/engine/NamedResultCacheSerializerTest.cpp
@@ -9,6 +9,7 @@
 
 #include <filesystem>
 
+#include "../util/GTestHelpers.h"
 #include "../util/IdTableHelpers.h"
 #include "../util/IndexTestHelpers.h"
 #include "engine/NamedResultCache.h"
@@ -242,6 +243,42 @@ TEST_F(NamedResultCacheSerializerTest, EmptyCacheSerialization) {
     return cache2;
   }();
   EXPECT_EQ(cache2.numEntries(), 0);
+}
+
+// Test that `readFromSerializer` throws a helpful error message when the
+// magic byte or the format version of the input do not match, instead of
+// silently misinterpreting unrelated or incompatible data.
+TEST_F(NamedResultCacheSerializerTest, WrongMagicByteOrFormatVersionThrows) {
+  NamedResultCache cache;
+  ByteBufferWriteSerializer writer;
+  cache.writeToSerializer(writer);
+  auto data = std::move(writer).data();
+  ASSERT_GE(data.size(), 3u);
+
+  // Corrupt the magic byte, which is the very first byte of the serialized
+  // data.
+  auto dataWithWrongMagicByte = data;
+  dataWithWrongMagicByte[0] = static_cast<char>(~dataWithWrongMagicByte[0]);
+  ByteBufferReadSerializer readerWithWrongMagicByte{
+      std::move(dataWithWrongMagicByte)};
+  NamedResultCache cacheForWrongMagicByte;
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      cacheForWrongMagicByte.readFromSerializer(
+          readerWithWrongMagicByte, ad_utility::makeUnlimitedAllocator<Id>(),
+          qec_->getLocalVocabContext()),
+      ::testing::HasSubstr("magic byte"));
+
+  // Corrupt the format version, which directly follows the magic byte.
+  auto dataWithWrongVersion = data;
+  dataWithWrongVersion[1] = static_cast<char>(dataWithWrongVersion[1] + 1);
+  ByteBufferReadSerializer readerWithWrongVersion{
+      std::move(dataWithWrongVersion)};
+  NamedResultCache cacheForWrongVersion;
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      cacheForWrongVersion.readFromSerializer(
+          readerWithWrongVersion, ad_utility::makeUnlimitedAllocator<Id>(),
+          qec_->getLocalVocabContext()),
+      ::testing::HasSubstr("format version"));
 }
 
 }  // namespace

--- a/test/engine/NamedResultCacheSerializerTest.cpp
+++ b/test/engine/NamedResultCacheSerializerTest.cpp
@@ -91,10 +91,9 @@ TEST_F(NamedResultCacheSerializerTest, ValueSerialization) {
   // Check the result pointer is valid (the non-aligned serializer used here
   // always deserializes into the owning `shared_ptr<const IdTable>`
   // alternative, never a zero-copy view).
-  ASSERT_TRUE(std::holds_alternative<std::shared_ptr<const IdTable>>(
-      deserializedValue.result_));
-  ASSERT_NE(std::get<std::shared_ptr<const IdTable>>(deserializedValue.result_),
-            nullptr);
+  ASSERT_THAT(deserializedValue.result_,
+              ::testing::VariantWith<std::shared_ptr<const IdTable>>(
+                  ::testing::Ne(nullptr)));
 
   // Check the local vocab.
   auto deserWords = deserializedValue.localVocab_.getAllWordsForTesting();

--- a/test/engine/NamedResultCacheTest.cpp
+++ b/test/engine/NamedResultCacheTest.cpp
@@ -57,7 +57,8 @@ TEST(NamedResultCache, basicWorkflow) {
 
     const auto& [outTable, outVarColMap, outSortedOn, outLocalVocab,
                  outCacheKey, outGeoIndex, alloc, blankNodeManager] = *res;
-    EXPECT_THAT(*outTable, matchesIdTable(table));
+    EXPECT_THAT(ExplicitIdTableOperation::viewOf(outTable),
+                matchesIdTable(table));
     EXPECT_THAT(outVarColMap, ::testing::UnorderedElementsAreArray(varColMap));
     EXPECT_THAT(outSortedOn, ::testing::ElementsAre(1, 0));
     EXPECT_THAT(outLocalVocab, matchLocalVocab());
@@ -71,7 +72,8 @@ TEST(NamedResultCache, basicWorkflow) {
 
     const auto& [outTable, outVarColMap, outSortedOn, outLocalVocab,
                  outCacheKey, outGeoIndex, alloc, blankNodeManager] = *res;
-    EXPECT_THAT(*outTable, matchesIdTable(table2));
+    EXPECT_THAT(ExplicitIdTableOperation::viewOf(outTable),
+                matchesIdTable(table2));
     EXPECT_THAT(outVarColMap, ::testing::UnorderedElementsAreArray(varColMap));
     EXPECT_THAT(outSortedOn, ::testing::ElementsAre(1, 0));
     EXPECT_THAT(outLocalVocab, matchLocalVocab());
@@ -93,7 +95,8 @@ TEST(NamedResultCache, basicWorkflow) {
 
     const auto& [outTable, outVarColMap, outSortedOn, outLocalVocab,
                  outCacheKey, outGeoIndex, alloc, blankNodeManager] = *res;
-    EXPECT_THAT(*outTable, matchesIdTable(table2));
+    EXPECT_THAT(ExplicitIdTableOperation::viewOf(outTable),
+                matchesIdTable(table2));
     EXPECT_THAT(outVarColMap, ::testing::UnorderedElementsAreArray(varColMap));
     EXPECT_THAT(outSortedOn, ::testing::ElementsAre(1, 0));
     EXPECT_THAT(outLocalVocab, matchLocalVocab());

--- a/test/engine/SpatialJoinCachedIndexTest.cpp
+++ b/test/engine/SpatialJoinCachedIndexTest.cpp
@@ -67,10 +67,9 @@ TEST_P(SpatialJoinCachedIndexTest, Basic) {
   auto cacheEntry = qec->namedResultCache().get("dummy");
 
   ASSERT_NE(cacheEntry.get(), nullptr);
-  ASSERT_TRUE(std::holds_alternative<std::shared_ptr<const IdTable>>(
-      cacheEntry->result_));
-  ASSERT_NE(std::get<std::shared_ptr<const IdTable>>(cacheEntry->result_),
-            nullptr);
+  ASSERT_THAT(cacheEntry->result_,
+              ::testing::VariantWith<std::shared_ptr<const IdTable>>(
+                  ::testing::Ne(nullptr)));
   auto resultView = ExplicitIdTableOperation::viewOf(cacheEntry->result_);
   EXPECT_EQ(resultView.numColumns(), 2);
   EXPECT_EQ(resultView.numRows(), 5);

--- a/test/engine/SpatialJoinCachedIndexTest.cpp
+++ b/test/engine/SpatialJoinCachedIndexTest.cpp
@@ -67,9 +67,13 @@ TEST_P(SpatialJoinCachedIndexTest, Basic) {
   auto cacheEntry = qec->namedResultCache().get("dummy");
 
   ASSERT_NE(cacheEntry.get(), nullptr);
-  ASSERT_NE(cacheEntry->result_.get(), nullptr);
-  EXPECT_EQ(cacheEntry->result_->numColumns(), 2);
-  EXPECT_EQ(cacheEntry->result_->numRows(), 5);
+  ASSERT_TRUE(std::holds_alternative<std::shared_ptr<const IdTable>>(
+      cacheEntry->result_));
+  ASSERT_NE(std::get<std::shared_ptr<const IdTable>>(cacheEntry->result_),
+            nullptr);
+  auto resultView = ExplicitIdTableOperation::viewOf(cacheEntry->result_);
+  EXPECT_EQ(resultView.numColumns(), 2);
+  EXPECT_EQ(resultView.numRows(), 5);
 
   ASSERT_TRUE(cacheEntry->cachedGeoIndex_.has_value());
   EXPECT_EQ(cacheEntry->cachedGeoIndex_.value().getGeometryColumn().name(),
@@ -137,8 +141,9 @@ TEST_P(SpatialJoinCachedIndexTest, UseOfIndexByS2PointPolylineAlgorithm) {
 
   // Check expected cache size
   const auto cacheEntry = qec->namedResultCache().get("dummy");
-  EXPECT_EQ(cacheEntry->result_->numColumns(), 2);
-  EXPECT_EQ(cacheEntry->result_->numRows(), 5);
+  auto resultView = ExplicitIdTableOperation::viewOf(cacheEntry->result_);
+  EXPECT_EQ(resultView.numColumns(), 2);
+  EXPECT_EQ(resultView.numRows(), 5);
   EXPECT_TRUE(cacheEntry->cachedGeoIndex_.has_value());
 
   // Prepare a spatial join using the s2 point polyline algorithm on this


### PR DESCRIPTION
So far, deserializing an entry of the named result cache (which acts as an in-memory materialized view) always copied the column data into a freshly allocated `IdTable`. Now the cache entry can also hold a non-owning `IdTableView`, and when reading from a serializer that supports zero-copy access (see #3063), the columns of the result are deserialized as spans that point directly into the underlying buffer, without copying. The owner of that buffer (for example, a memory-mapped blob) is responsible for keeping it alive for as long as the cache entry and any results derived from it; the lifetime contracts are documented at the respective hand-over points. For `Id`s this requires (and this change adds) trivial serialization of `ValueId`, which writes the same bytes as before.