### PR TITLE
Fix missing `\r` escaping in TSV export of literals with mixed line endings

### DIFF
--- a/src/rdfTypes/RdfEscaping.cpp
+++ b/src/rdfTypes/RdfEscaping.cpp
@@ -25,7 +25,7 @@ namespace detail {
 
 // CTRE regex patterns for C++17 compatibility
 constexpr ctll::fixed_string csvSpecialCharsRegex = "[\r\n\",]";
-constexpr ctll::fixed_string tsvSpecialCharsRegex = "[\n\t]";
+constexpr ctll::fixed_string tsvSpecialCharsRegex = "[\r\n\t]";
 constexpr ctll::fixed_string xmlSpecialCharsRegex = "[&\"<>']";
 
 /// Turn a sequence of characters that encode hexadecimal numbers(e.g. "00e4")
@@ -301,7 +301,7 @@ std::string escapeForCsv(std::string input) {
 // __________________________________________________________________________
 std::string escapeForTsv(std::string input) {
   if (ctre::search<detail::tsvSpecialCharsRegex>(input)) [[unlikely]] {
-    absl::StrReplaceAll({{"\t", " "}, {"\n", "\\n"}}, &input);
+    absl::StrReplaceAll({{"\t", " "}, {"\n", "\\n"}, {"\r", "\\r"}}, &input);
   }
   return input;
 }

--- a/src/rdfTypes/RdfEscaping.h
+++ b/src/rdfTypes/RdfEscaping.h
@@ -129,7 +129,10 @@ std::string escapeForCsv(std::string input);
 
 /**
  * Escape a string to be compatible with the IANA-TSV specification by
- * replacing tabs with spaces and newlines with '\n'.
+ * replacing tabs with spaces, newlines ('\n') with '\\n', and carriage
+ * returns ('\r') with '\\r'. This makes sure that none of the various
+ * line-ending conventions ('\n', '\r', or '\r\n') can break the row structure
+ * of the resulting TSV.
  *
  * See https://www.iana.org/assignments/media-types/text/tab-separated-values
  * for more information.

--- a/test/ExportQueryExecutionTreesTest.cpp
+++ b/test/ExportQueryExecutionTreesTest.cpp
@@ -14,6 +14,7 @@
 #include "parser/NormalizedString.h"
 #include "parser/SparqlParser.h"
 #include "rdfTypes/Literal.h"
+#include "rdfTypes/RdfEscaping.h"
 #include "util/GTestHelpers.h"
 #include "util/IdTableHelpers.h"
 #include "util/IdTestHelpers.h"
@@ -1065,7 +1066,7 @@ TEST(ExportQueryExecutionTrees, TestWithIriExtendedEscaped) {
       "?o\n"
       "<iriescaped\x01o\x02"
       "e\x03i\x04o\x05u\x06"
-      "e\ag\bc u\\ne\ve\fa\rd\x0En\x0F?\x10u\x11u\x12u\x13### d>\n",
+      "e\ag\bc u\\ne\ve\fa\\rd\x0En\x0F?\x10u\x11u\x12u\x13### d>\n",
       // CSV
       "o\n"
       "\"iriescaped\x01o\x02"
@@ -2035,4 +2036,38 @@ TEST(ExportQueryExecutionTrees, SparqlJsonWithMetaField) {
     ASSERT_TRUE(result["head"].contains("vars"));
     ASSERT_FALSE(result.contains("meta"));
   }
+}
+
+// _____________________________________________________________________________
+// Regression test for https://github.com/ad-freiburg/qlever/issues/3055:
+// literals that contain raw line-ending characters (`\n`, `\r`, or `\r\n`)
+// must be escaped such that the row structure of the CSV/TSV export is
+// preserved.
+TEST(ExportQueryExecutionTrees, NewlinesInLiteralsAreEscapedForCsvAndTsv) {
+  using enum ad_utility::MediaType;
+  std::string kg =
+      "<s> <p1> \"windows\\r\\nlineending\" ."
+      "<s> <p2> \"unixlineending\\n\" ."
+      "<s> <p3> \"oldmac\\rlineending\" .";
+
+  // CSV already wraps the field in quotes (and doubles any inner quotes)
+  // whenever it contains `\r`, `\n`, `\"` or `,`, so the row structure is
+  // preserved even though the raw line-ending characters remain in the
+  // field. This is valid according to RFC4180.
+  EXPECT_EQ(runQueryStreamableResult(kg, "SELECT ?o WHERE {?s <p1> ?o}", csv),
+            "o\n\"windows\r\nlineending\"\n");
+  EXPECT_EQ(runQueryStreamableResult(kg, "SELECT ?o WHERE {?s <p2> ?o}", csv),
+            "o\n\"unixlineending\n\"\n");
+  EXPECT_EQ(runQueryStreamableResult(kg, "SELECT ?o WHERE {?s <p3> ?o}", csv),
+            "o\n\"oldmac\rlineending\"\n");
+
+  // TSV has no quoting mechanism, so `\n` and `\r` must both be replaced by
+  // their two-character escape sequences (`\n` -> `\n`, `\r` -> `\r`,
+  // literally spelled out) to keep each result row on a single line.
+  EXPECT_EQ(runQueryStreamableResult(kg, "SELECT ?o WHERE {?s <p1> ?o}", tsv),
+            "?o\n\"windows\\r\\nlineending\"\n");
+  EXPECT_EQ(runQueryStreamableResult(kg, "SELECT ?o WHERE {?s <p2> ?o}", tsv),
+            "?o\n\"unixlineending\\n\"\n");
+  EXPECT_EQ(runQueryStreamableResult(kg, "SELECT ?o WHERE {?s <p3> ?o}", tsv),
+            "?o\n\"oldmac\\rlineending\"\n");
 }

--- a/test/rdfTypes/RdfEscapingTest.cpp
+++ b/test/rdfTypes/RdfEscapingTest.cpp
@@ -16,12 +16,24 @@ TEST(RdfEscapingTest, escapeForCsv) {
   ASSERT_EQ(escapeForCsv("\""), "\"\"\"\"");
   ASSERT_EQ(escapeForCsv("a\"b"), "\"a\"\"b\"");
   ASSERT_EQ(escapeForCsv("a\"\"c"), "\"a\"\"\"\"c\"");
+  // Regression test for https://github.com/ad-freiburg/qlever/issues/3055:
+  // literals with any of the three common line-ending conventions (`\n`
+  // only, `\r` only, or `\r\n`) must be wrapped in quotes, even if no other
+  // special character is present.
+  ASSERT_EQ(escapeForCsv("a\nb"), "\"a\nb\"");
+  ASSERT_EQ(escapeForCsv("a\rb"), "\"a\rb\"");
+  ASSERT_EQ(escapeForCsv("a\r\nb"), "\"a\r\nb\"");
 }
 
 // ___________________________________________________________________________
 TEST(RdfEscapingTest, escapeForTsv) {
   ASSERT_EQ(escapeForTsv("abc"), "abc");
   ASSERT_EQ(escapeForTsv("a\nb\tc"), "a\\nb c");
+  // Regression test for https://github.com/ad-freiburg/qlever/issues/3055:
+  // a lone `\r` (the old Mac line ending) must be escaped just like `\n`,
+  // otherwise the raw control character ends up unescaped in the TSV output.
+  ASSERT_EQ(escapeForTsv("a\rb"), "a\\rb");
+  ASSERT_EQ(escapeForTsv("a\r\nb"), "a\\r\\nb");
 }
 
 // ___________________________________________________________________________


### PR DESCRIPTION
## Summary

Fixes #3055 ("Newlines in SPARQL CSV output are not properly escaped").

I investigated the reported symptom (literals with mixed line endings breaking the tabular export formats) and confirmed the following:

- **CSV is already correct.** `RdfEscaping::escapeForCsv` already treats `\r`, `\n`, `"`, and `,` as the RFC4180 special characters and wraps the field in quotes whenever any of them occurs, for `\n`-only, `\r`-only, and `\r\n` literals alike. I verified this end-to-end (index build + real `qlever-server` + `curl`) and round-tripped the resulting CSV through Python's `csv` module to confirm it parses back into the correct rows/columns.
- **TSV had the actual bug.** `RdfEscaping::escapeForTsv` only checked for `\t` and `\n` (`tsvSpecialCharsRegex = "[\n\t]"`) and only replaced those two characters. A literal containing a lone `\r` (the "old Mac" line ending) was passed through **unescaped**, leaving a raw carriage-return control byte in the TSV output — this can confuse tools that treat a bare `\r` as a row separator, matching the "different line endings" description in the issue.

## Changes

- `src/rdfTypes/RdfEscaping.cpp` / `.h`: `escapeForTsv` now also escapes `\r` to `\r` (the two-character sequence), consistent with how `\n` is already escaped to `\n`.
- `test/rdfTypes/RdfEscapingTest.cpp`: added regression tests for `escapeForCsv` and `escapeForTsv` covering `\n`-only, `\r`-only, and `\r\n` literals.
- `test/ExportQueryExecutionTreesTest.cpp`: added an integration-level regression test (`NewlinesInLiteralsAreEscapedForCsvAndTsv`) that runs actual SELECT queries against a small knowledge graph and checks the full CSV/TSV output for all three line-ending styles. Also updated the pre-existing `TestWithIriExtendedEscaped` test's expected TSV output, since it contained a `\r` character that is now correctly escaped.

## Test plan

- [x] `RdfEscapingTest` passes, including new regression tests for `escapeForCsv`/`escapeForTsv`.
- [x] `ExportQueryExecutionTreesTest` passes (43/43), including the new `NewlinesInLiteralsAreEscapedForCsvAndTsv` test.
- [x] Verified the new TSV test fails without the fix (confirmed by reverting `RdfEscaping.cpp`/`.h` locally and re-running).
- [x] Verified CSV correctness end-to-end via a real `qlever-index`/`qlever-server` build and `curl`, round-tripped through Python's `csv` module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)