### PR TITLE
Move `writeMaterializedView` from `Server` into the `Qlever` class

### DIFF
--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -539,10 +539,9 @@ CPP_template_def(typename RequestT, typename ResponseT)(
         queryThreadPool_,
         [name, query, requestTimer, cancellationHandle, timeLimit,
          this]() mutable {
-          qlever().writeMaterializedView(name.value(), std::move(query.query_),
-                                         requestTimer, query.datasetClauses_,
-                                         std::move(cancellationHandle),
-                                         timeLimit.value());
+          qlever().writeMaterializedView(
+              name.value(), std::move(query.query_), query.datasetClauses_,
+              std::move(cancellationHandle), timeLimit.value(), requestTimer);
         },
         cancellationHandle);
     co_await std::move(coroutine);
@@ -769,11 +768,11 @@ std::pair<bool, bool> Server::determineResultPinning(
 
 // ____________________________________________________________________________
 Server::PlannedQuery Server::planQuery(
-    ParsedQuery&& operation, const ad_utility::Timer& requestTimer,
-    TimeLimit timeLimit, QueryExecutionContext& qec,
-    ad_utility::SharedCancellationHandle handle) const {
+    ParsedQuery&& operation, QueryExecutionContext& qec,
+    ad_utility::SharedCancellationHandle handle, TimeLimit timeLimit,
+    const ad_utility::Timer& requestTimer) const {
   PlannedQuery plannedQuery = qlever().planQuery(
-      std::move(operation), timeLimit, qec, std::move(handle), requestTimer);
+      std::move(operation), qec, std::move(handle), timeLimit, requestTimer);
 
   const auto& qet = plannedQuery.queryExecutionTree();
   const auto& runtimeInfoWholeQuery =
@@ -1044,8 +1043,8 @@ CPP_template_def(typename RequestT, typename ResponseT)(
       queryThreadPool_,
       [this, &query, &requestTimer, &timeLimit, &qec,
        &cancellationHandle]() -> std::optional<PlannedQuery> {
-        return this->planQuery(std::move(query), requestTimer, timeLimit, qec,
-                               cancellationHandle);
+        return this->planQuery(std::move(query), qec, cancellationHandle,
+                               timeLimit, requestTimer);
       },
       cancellationHandle);
   plannedQuery = co_await std::move(coroutine);
@@ -1223,8 +1222,9 @@ CPP_template_def(typename RequestT, typename ResponseT)(
                 }
                 tracer.endTrace("updateMetadata");
                 tracer.beginTrace("planning");
-                plannedUpdate = planQuery(std::move(update), requestTimer,
-                                          timeLimit, qec, cancellationHandle);
+                plannedUpdate =
+                    planQuery(std::move(update), qec, cancellationHandle,
+                              timeLimit, requestTimer);
                 tracer.endTrace("planning");
                 tracer.beginTrace("execution");
                 // Update the delta triples.

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -1463,19 +1463,11 @@ void Server::writeMaterializedView(
     const ad_utility::Timer& requestTimer,
     ad_utility::SharedCancellationHandle cancellationHandle,
     TimeLimit timeLimit) {
-  // Acquire the index and the manager via a single read lock so they are
-  // guaranteed to come from the same swap generation.
-  auto indexAndViews = indexAndViewsSnapshot();
-  auto parsedQuery =
-      SparqlParser::parseQuery(&indexAndViews->index_.encodedIriManager(),
-                               query.query_, query.datasetClauses_);
-  auto qec = qlever().createQueryExecutionContext(indexAndViews);
-  auto plan = planQuery(std::move(parsedQuery), requestTimer, timeLimit, *qec,
-                        std::move(cancellationHandle));
   auto memoryLimit =
       getRuntimeParameter<&RuntimeParameters::materializedViewWriterMemory_>();
-  indexAndViews->materializedViewsManager_.writeViewToDisk(name, plan,
-                                                           memoryLimit);
+  qlever().writeMaterializedView(
+      name, query.query_, requestTimer, query.datasetClauses_,
+      std::move(cancellationHandle), timeLimit, memoryLimit);
 }
 
 // _____________________________________________________________________________

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -1458,16 +1458,13 @@ Server::createMessageSender<http::request<http::string_body>>(
     std::string_view);
 
 // _____________________________________________________________________________
-void Server::writeMaterializedView(
-    const std::string& name, const Query& query,
-    const ad_utility::Timer& requestTimer,
-    ad_utility::SharedCancellationHandle cancellationHandle,
-    TimeLimit timeLimit) {
-  auto memoryLimit =
-      getRuntimeParameter<&RuntimeParameters::materializedViewWriterMemory_>();
-  qlever().writeMaterializedView(
-      name, query.query_, requestTimer, query.datasetClauses_,
-      std::move(cancellationHandle), timeLimit, memoryLimit);
+void Server::writeMaterializedView(const std::string& name, const Query& query,
+                                   const ad_utility::Timer& requestTimer,
+                                   SharedCancellationHandle cancellationHandle,
+                                   TimeLimit timeLimit) {
+  qlever().writeMaterializedView(name, query.query_, requestTimer,
+                                 query.datasetClauses_,
+                                 std::move(cancellationHandle), timeLimit);
 }
 
 // _____________________________________________________________________________

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -529,16 +529,19 @@ CPP_template_def(typename RequestT, typename ResponseT)(
         checkParameter("timeout", std::nullopt), accessTokenOk, request, send);
     AD_CONTRACT_CHECK(timeLimit.has_value(), "Missing timeout");
 
-    // Call `Server::writeMaterializedView` with the extracted parameters. Note
-    // that storing the coroutine in a variable first and then awaiting it is
-    // required due to lifetime issues on certain compilers.
+    // Call `Qlever::writeMaterializedView` with the extracted parameters. This
+    // assumes that the access token has already been checked. Note that storing
+    // the coroutine in a variable first and then awaiting it is required due to
+    // lifetime issues on certain compilers.
     auto cancellationHandle =
         std::make_shared<ad_utility::CancellationHandle<>>();
     auto coroutine = computeInNewThread(
         queryThreadPool_,
         [name, query, requestTimer, cancellationHandle, timeLimit, this] {
-          writeMaterializedView(name.value(), query, requestTimer,
-                                cancellationHandle, timeLimit.value());
+          qlever().writeMaterializedView(name.value(), std::move(query.query_),
+                                         requestTimer, query.datasetClauses_,
+                                         std::move(cancellationHandle),
+                                         timeLimit.value());
         },
         cancellationHandle);
     co_await std::move(coroutine);
@@ -1456,16 +1459,6 @@ Server::createMessageSender<http::request<http::string_body>>(
     const std::weak_ptr<ad_utility::websocket::QueryHub>&,
     const http::request<http::string_body>&, std::string_view,
     std::string_view);
-
-// _____________________________________________________________________________
-void Server::writeMaterializedView(const std::string& name, const Query& query,
-                                   const ad_utility::Timer& requestTimer,
-                                   SharedCancellationHandle cancellationHandle,
-                                   TimeLimit timeLimit) {
-  qlever().writeMaterializedView(name, query.query_, requestTimer,
-                                 query.datasetClauses_,
-                                 std::move(cancellationHandle), timeLimit);
-}
 
 // _____________________________________________________________________________
 Awaitable<void> Server::rebuildIndex(const std::string& indexBaseName) {

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -537,13 +537,14 @@ CPP_template_def(typename RequestT, typename ResponseT)(
         std::make_shared<ad_utility::CancellationHandle<>>();
     auto coroutine = computeInNewThread(
         queryThreadPool_,
-        [name, query, requestTimer, cancellationHandle, timeLimit, this] {
+        [name, query, requestTimer, cancellationHandle, timeLimit,
+         this]() mutable {
           qlever().writeMaterializedView(name.value(), std::move(query.query_),
                                          requestTimer, query.datasetClauses_,
                                          std::move(cancellationHandle),
                                          timeLimit.value());
         },
-        cancellationHandle);
+        std::move(cancellationHandle));
     co_await std::move(coroutine);
 
     // Construct simple response JSON.

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -544,7 +544,7 @@ CPP_template_def(typename RequestT, typename ResponseT)(
                                          std::move(cancellationHandle),
                                          timeLimit.value());
         },
-        std::move(cancellationHandle));
+        cancellationHandle);
     co_await std::move(coroutine);
 
     // Construct simple response JSON.

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -332,8 +332,6 @@ class Server {
           const QueryExecutionTree& qet, const ad_utility::Timer& requestTimer,
           SharedCancellationHandle cancellationHandle) const;
 
-  // Grants `serverIntegration` access to private members (in particular
-  // `qlever_`) for direct inspection in tests.
   FRIEND_TEST(MaterializedViewsTest, serverIntegration);
 
   // Trigger an index rebuild with `indexBaseName` as the base name for the new

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -26,6 +26,7 @@
 #include "libqlever/Qlever.h"
 #include "libqlever/QleverTypes.h"
 #include "util/AllocatorWithLimit.h"
+#include "util/MemorySize/MemorySize.h"
 #include "util/ParseException.h"
 #include "util/TypeTraits.h"
 #include "util/http/HttpUtils.h"
@@ -339,8 +340,7 @@ class Server {
       const std::string& name,
       const ad_utility::url_parser::sparqlOperation::Query& query,
       const ad_utility::Timer& requestTimer,
-      ad_utility::SharedCancellationHandle cancellationHandle,
-      TimeLimit timeLimit);
+      SharedCancellationHandle cancellationHandle, TimeLimit timeLimit);
   FRIEND_TEST(MaterializedViewsTest, serverIntegration);
 
   // Trigger an index rebuild with `indexBaseName` as the base name for the new

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -332,14 +332,8 @@ class Server {
           const QueryExecutionTree& qet, const ad_utility::Timer& requestTimer,
           SharedCancellationHandle cancellationHandle) const;
 
-  // Given a name and query, compute the query result and write a new
-  // materialized view of this result to disk. This assumes that the access
-  // token has already been checked.
-  void writeMaterializedView(
-      const std::string& name,
-      const ad_utility::url_parser::sparqlOperation::Query& query,
-      const ad_utility::Timer& requestTimer,
-      SharedCancellationHandle cancellationHandle, TimeLimit timeLimit);
+  // Grants `serverIntegration` access to private members (in particular
+  // `qlever_`) for direct inspection in tests.
   FRIEND_TEST(MaterializedViewsTest, serverIntegration);
 
   // Trigger an index rebuild with `indexBaseName` as the base name for the new

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -26,7 +26,6 @@
 #include "libqlever/Qlever.h"
 #include "libqlever/QleverTypes.h"
 #include "util/AllocatorWithLimit.h"
-#include "util/MemorySize/MemorySize.h"
 #include "util/ParseException.h"
 #include "util/TypeTraits.h"
 #include "util/http/HttpUtils.h"

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -231,10 +231,9 @@ class Server {
       QueryExecutionContext& qec);
 
   // Plan a parsed query.
-  PlannedQuery planQuery(ParsedQuery&& operation,
-                         const ad_utility::Timer& requestTimer,
-                         TimeLimit timeLimit, QueryExecutionContext& qec,
-                         SharedCancellationHandle handle) const;
+  PlannedQuery planQuery(ParsedQuery&& operation, QueryExecutionContext& qec,
+                         SharedCancellationHandle handle, TimeLimit timeLimit,
+                         const ad_utility::Timer& requestTimer) const;
   // Creates a `MessageSender` for the given operation.
   CPP_template(typename RequestT)(
       requires ad_utility::httpUtils::HttpRequest<RequestT>)

--- a/src/libqlever/Qlever.cpp
+++ b/src/libqlever/Qlever.cpp
@@ -209,7 +209,7 @@ void Qlever::eraseResultWithName(std::string name) {
 // ___________________________________________________________________________
 PlannedQuery Qlever::planQuery(
     ParsedQuery&& parsedQuery, std::optional<TimeLimit> timeLimit,
-    QueryExecutionContext& qec, ad_utility::SharedCancellationHandle handle,
+    QueryExecutionContext& qec, SharedCancellationHandle handle,
     boost::optional<const ad_utility::Timer&> requestTimer) const {
   handle->throwIfCancelled();
   QueryPlanner qp{&qec, handle};
@@ -240,8 +240,7 @@ PlannedQuery Qlever::planQuery(
 // ___________________________________________________________________________
 PlannedQuery Qlever::parseAndPlanQuery(
     std::string query, const std::vector<DatasetClause>& datasetClauses,
-    ad_utility::SharedCancellationHandle handle,
-    std::optional<TimeLimit> timeLimit,
+    SharedCancellationHandle handle, std::optional<TimeLimit> timeLimit,
     std::function<void(std::string)> updateCallback, bool pinSubtrees,
     bool pinResult) const {
   auto qecPtr = createQueryExecutionContext(
@@ -278,28 +277,26 @@ void IndexBuilderConfig::validate() const {
 
 // ___________________________________________________________________________
 void Qlever::writeMaterializedView(
-    std::string name, std::string query, const ad_utility::Timer& requestTimer,
+    std::string name, std::string query,
+    boost::optional<const ad_utility::Timer&> requestTimer,
     const std::vector<DatasetClause>& datasetClauses,
     SharedCancellationHandle cancellationHandle,
-    std::optional<TimeLimit> timeLimit,
-    std::optional<ad_utility::MemorySize> memoryLimit) const {
+    std::optional<TimeLimit> timeLimit) const {
   // Acquire the index and the manager via a single read lock so they are
   // guaranteed to come from the same swap generation.
   auto indexAndViews = indexAndViewsSnapshot();
-  auto parsedQuery = SparqlParser::parseQuery(
-      &indexAndViews->index_.encodedIriManager(), query, datasetClauses);
+  auto parsedQuery =
+      SparqlParser::parseQuery(&indexAndViews->index_.encodedIriManager(),
+                               std::move(query), datasetClauses);
 
   auto qec = createQueryExecutionContext(indexAndViews);
-  auto plan = planQuery(std::move(parsedQuery), requestTimer, timeLimit, *qec,
-                        std::move(cancellationHandle));
+  auto plan = planQuery(std::move(parsedQuery), timeLimit, *qec,
+                        std::move(cancellationHandle), requestTimer);
 
-  if (memoryLimit.has_value()) {
-    materializedViewsManager()->writeViewToDisk(
-        std::move(name), std::move(plan), memoryLimit.value());
-  } else {
-    materializedViewsManager()->writeViewToDisk(std::move(name),
-                                                std::move(plan));
-  }
+  auto memoryLimit =
+      getRuntimeParameter<&RuntimeParameters::materializedViewWriterMemory_>();
+  materializedViewsManager()->writeViewToDisk(std::move(name), std::move(plan),
+                                              memoryLimit);
 }
 
 // ___________________________________________________________________________

--- a/src/libqlever/Qlever.cpp
+++ b/src/libqlever/Qlever.cpp
@@ -283,30 +283,26 @@ void Qlever::writeMaterializedView(
     SharedCancellationHandle cancellationHandle,
     std::optional<TimeLimit> timeLimit,
     boost::optional<const ad_utility::Timer&> requestTimer) const {
-  // Acquire the index and the manager via a single read lock so they are
-  // guaranteed to come from the same swap generation.
-  auto indexAndViews = indexAndViewsSnapshot();
-  auto parsedQuery =
-      SparqlParser::parseQuery(&indexAndViews->index_.encodedIriManager(),
-                               std::move(query), datasetClauses);
-
-  auto qec = createQueryExecutionContext(indexAndViews);
-  auto plan = planQuery(std::move(parsedQuery), *qec,
+  auto plan =
+      parseAndPlanQuery(std::move(query), datasetClauses,
                         std::move(cancellationHandle), timeLimit, requestTimer);
+  const auto& viewsManager =
+      plan.queryExecutionContext().materializedViewsManager();
   auto memoryLimit =
       getRuntimeParameter<&RuntimeParameters::materializedViewWriterMemory_>();
-  indexAndViews->materializedViewsManager_.writeViewToDisk(std::move(name),
-                                                           plan, memoryLimit);
+  viewsManager.writeViewToDisk(std::move(name), plan, memoryLimit);
 }
 
 // ___________________________________________________________________________
 bool Qlever::isMaterializedViewLoaded(const std::string& name) const {
-  return materializedViewsManager()->isViewLoaded(name);
+  const auto indexAndViews = indexAndViewsSnapshot();
+  return indexAndViews->materializedViewsManager_.isViewLoaded(name);
 }
 
 // ___________________________________________________________________________
 void Qlever::loadMaterializedView(std::string name) const {
-  materializedViewsManager()->loadView(name);
+  const auto indexAndViews = indexAndViewsSnapshot();
+  indexAndViews->materializedViewsManager_.loadView(name);
 }
 
 // ___________________________________________________________________________

--- a/src/libqlever/Qlever.cpp
+++ b/src/libqlever/Qlever.cpp
@@ -288,7 +288,7 @@ void Qlever::writeMaterializedView(
                         std::move(cancellationHandle), timeLimit, requestTimer);
   auto memoryLimit =
       getRuntimeParameter<&RuntimeParameters::materializedViewWriterMemory_>();
-  materializedViewsManager()->writeViewToDisk(std::move(name), std::move(plan),
+  materializedViewsManager()->writeViewToDisk(std::move(name), plan,
                                               memoryLimit);
 }
 

--- a/src/libqlever/Qlever.cpp
+++ b/src/libqlever/Qlever.cpp
@@ -277,9 +277,29 @@ void IndexBuilderConfig::validate() const {
 }
 
 // ___________________________________________________________________________
-void Qlever::writeMaterializedView(std::string name, std::string query) const {
-  materializedViewsManager()->writeViewToDisk(
-      std::move(name), parseAndPlanQuery(std::move(query)));
+void Qlever::writeMaterializedView(
+    std::string name, std::string query, const ad_utility::Timer& requestTimer,
+    const std::vector<DatasetClause>& datasetClauses,
+    SharedCancellationHandle cancellationHandle,
+    std::optional<TimeLimit> timeLimit,
+    std::optional<ad_utility::MemorySize> memoryLimit) const {
+  // Acquire the index and the manager via a single read lock so they are
+  // guaranteed to come from the same swap generation.
+  auto indexAndViews = indexAndViewsSnapshot();
+  auto parsedQuery = SparqlParser::parseQuery(
+      &indexAndViews->index_.encodedIriManager(), query, datasetClauses);
+
+  auto qec = createQueryExecutionContext(indexAndViews);
+  auto plan = planQuery(std::move(parsedQuery), requestTimer, timeLimit, *qec,
+                        std::move(cancellationHandle));
+
+  if (memoryLimit.has_value()) {
+    materializedViewsManager()->writeViewToDisk(
+        std::move(name), std::move(plan), memoryLimit.value());
+  } else {
+    materializedViewsManager()->writeViewToDisk(std::move(name),
+                                                std::move(plan));
+  }
 }
 
 // ___________________________________________________________________________

--- a/src/libqlever/Qlever.cpp
+++ b/src/libqlever/Qlever.cpp
@@ -208,8 +208,8 @@ void Qlever::eraseResultWithName(std::string name) {
 
 // ___________________________________________________________________________
 PlannedQuery Qlever::planQuery(
-    ParsedQuery&& parsedQuery, std::optional<TimeLimit> timeLimit,
-    QueryExecutionContext& qec, SharedCancellationHandle handle,
+    ParsedQuery&& parsedQuery, QueryExecutionContext& qec,
+    SharedCancellationHandle handle, std::optional<TimeLimit> timeLimit,
     boost::optional<const ad_utility::Timer&> requestTimer) const {
   handle->throwIfCancelled();
   QueryPlanner qp{&qec, handle};
@@ -252,8 +252,8 @@ PlannedQuery Qlever::parseAndPlanQuery(
       &qecPtr->getIndex().getImpl().encodedIriManager(), std::move(query),
       datasetClauses);
 
-  return planQuery(std::move(parsedQuery), timeLimit, *qecPtr,
-                   std::move(handle), requestTimer);
+  return planQuery(std::move(parsedQuery), *qecPtr, std::move(handle),
+                   timeLimit, requestTimer);
 }
 
 // ___________________________________________________________________________
@@ -279,17 +279,24 @@ void IndexBuilderConfig::validate() const {
 // ___________________________________________________________________________
 void Qlever::writeMaterializedView(
     std::string name, std::string query,
-    boost::optional<const ad_utility::Timer&> requestTimer,
     const std::vector<DatasetClause>& datasetClauses,
     SharedCancellationHandle cancellationHandle,
-    std::optional<TimeLimit> timeLimit) const {
-  auto plan =
-      parseAndPlanQuery(std::move(query), datasetClauses,
+    std::optional<TimeLimit> timeLimit,
+    boost::optional<const ad_utility::Timer&> requestTimer) const {
+  // Acquire the index and the manager via a single read lock so they are
+  // guaranteed to come from the same swap generation.
+  auto indexAndViews = indexAndViewsSnapshot();
+  auto parsedQuery =
+      SparqlParser::parseQuery(&indexAndViews->index_.encodedIriManager(),
+                               std::move(query), datasetClauses);
+
+  auto qec = createQueryExecutionContext(indexAndViews);
+  auto plan = planQuery(std::move(parsedQuery), *qec,
                         std::move(cancellationHandle), timeLimit, requestTimer);
   auto memoryLimit =
       getRuntimeParameter<&RuntimeParameters::materializedViewWriterMemory_>();
-  materializedViewsManager()->writeViewToDisk(std::move(name), plan,
-                                              memoryLimit);
+  indexAndViews->materializedViewsManager_.writeViewToDisk(std::move(name),
+                                                           plan, memoryLimit);
 }
 
 // ___________________________________________________________________________

--- a/src/libqlever/Qlever.cpp
+++ b/src/libqlever/Qlever.cpp
@@ -241,6 +241,7 @@ PlannedQuery Qlever::planQuery(
 PlannedQuery Qlever::parseAndPlanQuery(
     std::string query, const std::vector<DatasetClause>& datasetClauses,
     SharedCancellationHandle handle, std::optional<TimeLimit> timeLimit,
+    boost::optional<const ad_utility::Timer&> requestTimer,
     std::function<void(std::string)> updateCallback, bool pinSubtrees,
     bool pinResult) const {
   auto qecPtr = createQueryExecutionContext(
@@ -252,7 +253,7 @@ PlannedQuery Qlever::parseAndPlanQuery(
       datasetClauses);
 
   return planQuery(std::move(parsedQuery), timeLimit, *qecPtr,
-                   std::move(handle));
+                   std::move(handle), requestTimer);
 }
 
 // ___________________________________________________________________________
@@ -282,17 +283,9 @@ void Qlever::writeMaterializedView(
     const std::vector<DatasetClause>& datasetClauses,
     SharedCancellationHandle cancellationHandle,
     std::optional<TimeLimit> timeLimit) const {
-  // Acquire the index and the manager via a single read lock so they are
-  // guaranteed to come from the same swap generation.
-  auto indexAndViews = indexAndViewsSnapshot();
-  auto parsedQuery =
-      SparqlParser::parseQuery(&indexAndViews->index_.encodedIriManager(),
-                               std::move(query), datasetClauses);
-
-  auto qec = createQueryExecutionContext(indexAndViews);
-  auto plan = planQuery(std::move(parsedQuery), timeLimit, *qec,
-                        std::move(cancellationHandle), requestTimer);
-
+  auto plan =
+      parseAndPlanQuery(std::move(query), datasetClauses,
+                        std::move(cancellationHandle), timeLimit, requestTimer);
   auto memoryLimit =
       getRuntimeParameter<&RuntimeParameters::materializedViewWriterMemory_>();
   materializedViewsManager()->writeViewToDisk(std::move(name), std::move(plan),

--- a/src/libqlever/Qlever.h
+++ b/src/libqlever/Qlever.h
@@ -304,7 +304,7 @@ class Qlever {
   // also is moved into the `QLever` class.
   PlannedQuery parseAndPlanQuery(
       std::string query, const std::vector<DatasetClause>& datasetClauses = {},
-      ad_utility::SharedCancellationHandle handle =
+      SharedCancellationHandle handle =
           std::make_shared<ad_utility::CancellationHandle<>>(),
       std::optional<TimeLimit> timeLimit = std::nullopt,
       std::function<void(std::string)> updateCallback =
@@ -348,14 +348,27 @@ class Qlever {
 
   // Write a new materialized view with `name` to disk and store the result of
   // `query`.
+  //
+  // `requestTimer`, `timeLimit`, and `handle` are forwarded to `planQuery`
+  // (see there for their exact semantics). If omitted, the query is planned
+  // and executed without a timer, without a time limit, and with a fresh,
+  // never-triggered cancellation handle, i.e. it always runs to completion.
+  //
+  // TODO<joka921,damekt> The `timeLimit` is currently only used for
+  // non-cancelable operations (in particular sorting). The time limit applies
+  // from the time this function is called until the execution of the query
+  // has finished. This might be very unintuitive when the `PlannedQuery` is
+  // stored for later execution. This is not an issue for now (only the
+  // `Server` actually imposes time limits and then executes the queries right
+  // away), but should be addressed in the future once the timeout management
+  // also is moved into the `QLever` class.
   void writeMaterializedView(
       std::string name, std::string query,
-      const ad_utility::Timer& requestTimer,
+      boost::optional<const ad_utility::Timer&> requestTimer = boost::none,
       const std::vector<DatasetClause>& datasetClauses = {},
-      ad_utility::SharedCancellationHandle handle =
+      SharedCancellationHandle handle =
           std::make_shared<ad_utility::CancellationHandle<>>(),
-      std::optional<TimeLimit> timeLimit = std::nullopt,
-      std::optional<ad_utility::MemorySize> memoryLimit = std::nullopt) const;
+      std::optional<TimeLimit> timeLimit = std::nullopt) const;
 
   // Preload a materialized view s.t. the first query to the view does not have
   // to load the view.

--- a/src/libqlever/Qlever.h
+++ b/src/libqlever/Qlever.h
@@ -348,7 +348,14 @@ class Qlever {
 
   // Write a new materialized view with `name` to disk and store the result of
   // `query`.
-  void writeMaterializedView(std::string name, std::string query) const;
+  void writeMaterializedView(
+      std::string name, std::string query,
+      const ad_utility::Timer& requestTimer,
+      const std::vector<DatasetClause>& datasetClauses = {},
+      ad_utility::SharedCancellationHandle handle =
+          std::make_shared<ad_utility::CancellationHandle<>>(),
+      std::optional<TimeLimit> timeLimit = std::nullopt,
+      std::optional<ad_utility::MemorySize> memoryLimit = std::nullopt) const;
 
   // Preload a materialized view s.t. the first query to the view does not have
   // to load the view.

--- a/src/libqlever/Qlever.h
+++ b/src/libqlever/Qlever.h
@@ -307,6 +307,7 @@ class Qlever {
       SharedCancellationHandle handle =
           std::make_shared<ad_utility::CancellationHandle<>>(),
       std::optional<TimeLimit> timeLimit = std::nullopt,
+      boost::optional<const ad_utility::Timer&> requestTimer = boost::none,
       std::function<void(std::string)> updateCallback =
           [](std::string) { /* the default is a noop*/ },
       bool pinSubtrees = false, bool pinResult = false) const;
@@ -353,15 +354,6 @@ class Qlever {
   // (see there for their exact semantics). If omitted, the query is planned
   // and executed without a timer, without a time limit, and with a fresh,
   // never-triggered cancellation handle, i.e. it always runs to completion.
-  //
-  // TODO<joka921,damekt> The `timeLimit` is currently only used for
-  // non-cancelable operations (in particular sorting). The time limit applies
-  // from the time this function is called until the execution of the query
-  // has finished. This might be very unintuitive when the `PlannedQuery` is
-  // stored for later execution. This is not an issue for now (only the
-  // `Server` actually imposes time limits and then executes the queries right
-  // away), but should be addressed in the future once the timeout management
-  // also is moved into the `QLever` class.
   void writeMaterializedView(
       std::string name, std::string query,
       boost::optional<const ad_utility::Timer&> requestTimer = boost::none,

--- a/src/libqlever/Qlever.h
+++ b/src/libqlever/Qlever.h
@@ -427,12 +427,6 @@ class Qlever {
 
   NamedResultCache& namedResultCache() { return namedResultCache_; }
   const NamedResultCache& namedResultCache() const { return namedResultCache_; }
-
-  std::shared_ptr<MaterializedViewsManager> materializedViewsManager() const {
-    auto snapshot = *indexAndViews_.rlock();
-    MaterializedViewsManager* manager = &snapshot->materializedViewsManager_;
-    return {std::move(snapshot), manager};
-  }
 };
 }  // namespace qlever
 

--- a/src/libqlever/Qlever.h
+++ b/src/libqlever/Qlever.h
@@ -274,11 +274,11 @@ class Qlever {
   // `Server` actually imposes time limits and then executes the queries right
   // away), but should be addressed in the future once the timeout management
   // also is moved into the `QLever` class.
-  PlannedQuery planQuery(
-      ParsedQuery&& parsedQuery, std::optional<TimeLimit> timeLimit,
-      QueryExecutionContext& qec, SharedCancellationHandle handle,
-      boost::optional<const ad_utility::Timer&> requestTimer =
-          boost::none) const;
+  PlannedQuery planQuery(ParsedQuery&& parsedQuery, QueryExecutionContext& qec,
+                         SharedCancellationHandle handle,
+                         std::optional<TimeLimit> timeLimit,
+                         boost::optional<const ad_utility::Timer&>
+                             requestTimer = boost::none) const;
 
   // Parse and plan the given `query` (see `planQuery` above; despite the
   // name, `query` may also be a SPARQL update operation).
@@ -356,11 +356,12 @@ class Qlever {
   // never-triggered cancellation handle, i.e. it always runs to completion.
   void writeMaterializedView(
       std::string name, std::string query,
-      boost::optional<const ad_utility::Timer&> requestTimer = boost::none,
       const std::vector<DatasetClause>& datasetClauses = {},
       SharedCancellationHandle handle =
           std::make_shared<ad_utility::CancellationHandle<>>(),
-      std::optional<TimeLimit> timeLimit = std::nullopt) const;
+      std::optional<TimeLimit> timeLimit = std::nullopt,
+      boost::optional<const ad_utility::Timer&> requestTimer =
+          boost::none) const;
 
   // Preload a materialized view s.t. the first query to the view does not have
   // to load the view.

--- a/test/MaterializedViewsTest.cpp
+++ b/test/MaterializedViewsTest.cpp
@@ -789,8 +789,8 @@ TEST_F(MaterializedViewsTest, serverIntegration) {
     static constexpr size_t dummyTimeLimit = 1000 * 60 * 60;  // 1 hour
     std::chrono::milliseconds timeLimit{dummyTimeLimit};
     server.qlever().writeMaterializedView(
-        "testViewFromServer", std::move(query.query_), requestTimer,
-        query.datasetClauses_, std::move(cancellationHandle), timeLimit);
+        "testViewFromServer", std::move(query.query_), query.datasetClauses_,
+        std::move(cancellationHandle), timeLimit, requestTimer);
   }
 
   // Test the preloading of materialized views on server start.

--- a/test/MaterializedViewsTest.cpp
+++ b/test/MaterializedViewsTest.cpp
@@ -777,7 +777,7 @@ TEST_F(MaterializedViewsTest, serverIntegration) {
   config.baseName_ = testIndexBase_;
 
   // Write a new materialized view using the `writeMaterializedView` method of
-  // the `Server` class.
+  // the `Qlever` class.
   {
     // Initialize but do not start a `Server` instance on our test index.
     Server server{4321, 1, "accessToken", config};
@@ -788,8 +788,9 @@ TEST_F(MaterializedViewsTest, serverIntegration) {
         std::make_shared<ad_utility::CancellationHandle<>>();
     static constexpr size_t dummyTimeLimit = 1000 * 60 * 60;  // 1 hour
     std::chrono::milliseconds timeLimit{dummyTimeLimit};
-    server.writeMaterializedView("testViewFromServer", query, requestTimer,
-                                 cancellationHandle, timeLimit);
+    server.qlever().writeMaterializedView(
+        "testViewFromServer", std::move(query.query_), requestTimer,
+        query.datasetClauses_, std::move(cancellationHandle), timeLimit);
   }
 
   // Test the preloading of materialized views on server start.

--- a/test/MaterializedViewsTest.cpp
+++ b/test/MaterializedViewsTest.cpp
@@ -799,8 +799,8 @@ TEST_F(MaterializedViewsTest, serverIntegration) {
     config.preloadMaterializedViews_ = {"testViewForServerPreload"};
     qlv().writeMaterializedView("testViewForServerPreload", simpleWriteQuery_);
     Server server{4321, 1, "accessToken", config};
-    EXPECT_TRUE(server.qlever_.materializedViewsManager()->isViewLoaded(
-        "testViewForServerPreload"));
+    EXPECT_TRUE(
+        server.qlever_.isMaterializedViewLoaded("testViewForServerPreload"));
   }
 
   // Try loading the new view.


### PR DESCRIPTION
Continues the extraction of functionality from the `Server` class into the `Qlever` class; see #3011 (which unified `QueryPlan` and `PlannedQuery`) and #3038 (which moved the query planning). Remove `Server::writeMaterializedView`; the server now directly calls `Qlever::writeMaterializedView`, which is extended by optional arguments for the dataset clauses, timing, cancellation, and a time limit. The defaults keep the previous behavior for embedded use, except that the `materialized-view-writer-memory` runtime parameter now also applies there.