### PR TITLE
Add `ad_utility::NullStream` utility

### DIFF
--- a/src/util/NullStream.h
+++ b/src/util/NullStream.h
@@ -1,0 +1,34 @@
+// Copyright 2026 The QLever Authors, in particular:
+//
+// 2026 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#ifndef QLEVER_SRC_UTIL_NULLSTREAM_H
+#define QLEVER_SRC_UTIL_NULLSTREAM_H
+
+#include <ostream>
+#include <streambuf>
+
+namespace ad_utility {
+
+// An output stream that silently discards everything written to it. Useful for
+// example to suppress optional logging output without changing call sites.
+class NullStream : public std::ostream {
+ private:
+  class NullBuffer : public std::streambuf {
+   public:
+    int overflow(int c) override { return c; }
+  };
+  NullBuffer buffer_;
+
+ public:
+  NullStream() : std::ostream(&buffer_) {}
+};
+
+}  // namespace ad_utility
+
+#endif  // QLEVER_SRC_UTIL_NULLSTREAM_H

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -156,6 +156,8 @@ addLinkAndDiscoverTest(StringUtilsTest util)
 
 addLinkAndDiscoverTestNoLibs(ConstexprSmallStringTest)
 
+addLinkAndDiscoverTestNoLibs(NullStreamTest)
+
 addLinkAndDiscoverTest(CryptographicHashUtilsTest util)
 
 addLinkAndDiscoverTest(CacheTest)

--- a/test/NullStreamTest.cpp
+++ b/test/NullStreamTest.cpp
@@ -1,0 +1,39 @@
+// Copyright 2026 The QLever Authors, in particular:
+//
+// 2026 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "util/NullStream.h"
+
+using ad_utility::NullStream;
+
+// Writing arbitrary data to a `NullStream` discards it and leaves the stream in
+// a valid, good state.
+TEST(NullStream, discardsInputAndStaysGood) {
+  NullStream stream;
+  EXPECT_TRUE(stream.good());
+
+  stream << "some text" << 42 << ' ' << 3.14 << std::string(1000, 'x');
+
+  EXPECT_TRUE(stream.good());
+  EXPECT_FALSE(stream.fail());
+  EXPECT_FALSE(stream.bad());
+}
+
+// A `NullStream` can be used through a `std::ostream&` reference like any other
+// output stream.
+TEST(NullStream, usableAsOstreamReference) {
+  NullStream stream;
+  std::ostream& out = stream;
+  out << "written via base-class reference";
+  EXPECT_TRUE(out.good());
+}


### PR DESCRIPTION
## What

Adds a small, header-only utility `src/util/NullStream.h` defining `ad_utility::NullStream`: an output stream that silently discards everything written to it.

Because it derives from `std::ostream`, it can be passed anywhere a `std::ostream&` is expected. This is useful, for example, to suppress optional logging output without touching call sites — just point the stream at a `NullStream` instead of `std::cout`.

## Details

- The implementation uses a private `std::streambuf` whose `overflow` is a no-op, so all characters are consumed and dropped while the stream stays in a good state.
- Added `test/NullStreamTest.cpp` verifying that writing various data types discards the input and leaves the stream `good()` (not `fail()`/`bad()`), and that it works through a `std::ostream&` reference. Registered via `addLinkAndDiscoverTestNoLibs(NullStreamTest)`.

## Verification

- Configured a Release build with CMake/Ninja.
- Built the `NullStreamTest` target and ran it; both test cases pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)