### PR TITLE
Update `libspatialjoin` and use its new `SweeperCfg::forceTwoSided` option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,7 +202,7 @@ FetchContent_Declare(
 FetchContent_Declare(
         spatialjoin
         GIT_REPOSITORY https://github.com/ad-freiburg/spatialjoin
-        GIT_TAG 2d2a6d74ddf28447afabb75943913a6445a27d4f
+        GIT_TAG 344a3fa41e96db38ac775cc78224847255d0152f
         SYSTEM
         EXCLUDE_FROM_ALL
 )

--- a/src/engine/SpatialJoinAlgorithms.cpp
+++ b/src/engine/SpatialJoinAlgorithms.cpp
@@ -459,6 +459,10 @@ sj::SweeperCfg SpatialJoinAlgorithms::libspatialjoinSweeperConfig(
   cfg.useInnerOuter = false;
   cfg.noGeometryChecks = false;
   cfg.computeDE9IM = false;
+  // Never let `libspatialjoin` fall back to a self-join when it considers one
+  // side to be empty; QLever's callbacks rely on the first geometry of each
+  // result pair coming from the left side and the second one from the right
+  // side (see #3068).
   cfg.forceTwoSided = true;
   cfg.writeRelCb = {};
   cfg.logCb = {};

--- a/src/engine/SpatialJoinAlgorithms.cpp
+++ b/src/engine/SpatialJoinAlgorithms.cpp
@@ -459,6 +459,7 @@ sj::SweeperCfg SpatialJoinAlgorithms::libspatialjoinSweeperConfig(
   cfg.useInnerOuter = false;
   cfg.noGeometryChecks = false;
   cfg.computeDE9IM = false;
+  cfg.forceTwoSided = true;
   cfg.writeRelCb = {};
   cfg.logCb = {};
   cfg.statsCb = {};

--- a/test/engine/SpatialJoinPrefilterTestHelpers.h
+++ b/test/engine/SpatialJoinPrefilterTestHelpers.h
@@ -194,6 +194,7 @@ inline sj::SweeperCfg makeSweeperCfg(const LibSpatialJoinConfig& libSJConfig,
   sj::SweeperCfg cfg =
       SpatialJoinAlgorithms::libspatialjoinSweeperConfig(1, 1_GB);
   cfg.withinDist = withinDist;
+  cfg.forceTwoSided = true;
   auto joinTypeVal = libSJConfig.joinType_;
   cfg.writeRelCb = [&results, &resultDists, joinTypeVal](
                        size_t t, const char* a, size_t, const char* b, size_t,

--- a/test/engine/SpatialJoinPrefilterTestHelpers.h
+++ b/test/engine/SpatialJoinPrefilterTestHelpers.h
@@ -194,7 +194,6 @@ inline sj::SweeperCfg makeSweeperCfg(const LibSpatialJoinConfig& libSJConfig,
   sj::SweeperCfg cfg =
       SpatialJoinAlgorithms::libspatialjoinSweeperConfig(1, 1_GB);
   cfg.withinDist = withinDist;
-  cfg.forceTwoSided = true;
   auto joinTypeVal = libSJConfig.joinType_;
   cfg.writeRelCb = [&results, &resultDists, joinTypeVal](
                        size_t t, const char* a, size_t, const char* b, size_t,


### PR DESCRIPTION
This is a follow-up to #3068: the join in `libspatialjoin` is now always enforced to be two-sided, using the new option `SweeperCfg::forceTwoSided` introduced in <https://github.com/ad-freiburg/spatialjoin/pull/19>. Even with this change, #3068 still makes sense for consistency, as well as for adding the regression test and runtime info detail.