### PR TITLE
EXPERIMENTAL DRAFT, VIBE CODED: Store full 64-bit payloads in `ValueId` and split `IdTable` columns

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -305,6 +305,12 @@ function(qlever_target_link_libraries target)
             absl::flat_hash_set absl::strings absl::str_format ICU::uc
             ICU::i18n OpenSSL::SSL OpenSSL::Crypto GTest::gtest GTest::gmock fsst nlohmann_json::nlohmann_json Boost::container uriparser)
 
+    # The 16-byte `std::atomic`s (e.g. for the cached vocabulary position in
+    # `LocalVocabEntry`) require `libatomic` on Linux with GCC and Clang.
+    if (UNIX AND NOT APPLE)
+        target_link_libraries(${target} atomic)
+    endif ()
+
     # memorySize is a utility library for defining memory sizes.
     if (NOT ${target} STREQUAL "memorySize")
         target_link_libraries(${target} memorySize)

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -36,4 +36,10 @@ if (NOT _NO_BENCHMARK)
 
     addAndLinkBenchmark(GroupByHashMapBenchmark engine testUtil gtest gmock)
 
+    # Standalone microbenchmark binary (with its own `main`, deliberately not
+    # using the benchmark infrastructure, s.t. single kernels can be isolated
+    # for `perf`).
+    add_executable(IdKernelBenchmarks IdKernelBenchmarks.cpp)
+    qlever_target_link_libraries(IdKernelBenchmarks engine testUtil gtest gmock)
+
 endif()

--- a/benchmark/IdKernelBenchmarks.cpp
+++ b/benchmark/IdKernelBenchmarks.cpp
@@ -1,0 +1,321 @@
+// Copyright 2026 The QLever Authors, in particular:
+//
+// 2026 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+// Standalone microbenchmarks for the three core algorithms that are most
+// sensitive to the underlying `Id` storage format: the merge join on a
+// single join column without UNDEF values, the in-memory sort of a fully
+// materialized `IdTable` by a single column, and the GROUP BY on sorted
+// input. Each kernel exercises the actual production code path.
+//
+// This is deliberately a plain command-line binary (and not part of the
+// macro-based benchmark infrastructure), s.t. a single kernel can be
+// isolated cleanly for `perf record`/`perf stat`.
+//
+// Note: This file deliberately only uses interfaces that exist both on
+// `master` (packed 64-bit IDs) and on the `64-bit-payloads` branch (split
+// payload/datatype storage), s.t. the identical file can be compiled on
+// both branches to obtain a true baseline comparison.
+//
+// Usage examples:
+//   IdKernelBenchmarks join    --rows 10000000 --cols 2 --types 3 --reps 5
+//   IdKernelBenchmarks sort    --rows 10000000 --cols 5 --types 3 --reps 5
+//   IdKernelBenchmarks groupby --rows 10000000 --groupsize 100 --reps 5
+
+#include <chrono>
+#include <cstdint>
+#include <iostream>
+#include <random>
+#include <string>
+#include <vector>
+
+#include "../test/engine/ValuesForTesting.h"
+#include "../test/util/IndexTestHelpers.h"
+#include "engine/AddCombinedRowToTable.h"
+#include "engine/GroupBy.h"
+#include "engine/QueryExecutionTree.h"
+#include "engine/sparqlExpressions/AggregateExpression.h"
+#include "engine/sparqlExpressions/LiteralExpression.h"
+#include "global/Id.h"
+#include "index/IdTableUtils.h"
+#include "util/AllocatorWithLimit.h"
+#include "util/JoinAlgorithms/JoinAlgorithms.h"
+#include "util/JoinAlgorithms/JoinColumnMapping.h"
+
+namespace {
+
+using namespace std::chrono;
+
+// Command-line options with defaults.
+struct Options {
+  std::string kernel_;
+  size_t numRows_ = 10'000'000;
+  // Number of payload columns (in addition to the join/sort/group column).
+  size_t numPayloadCols_ = 2;
+  // Number of distinct datatypes in the key column (1 = only `VocabIndex`,
+  // up to 3 = `VocabIndex`, `Int`, `Double`).
+  size_t numTypes_ = 1;
+  // Average number of occurrences of each distinct key (controls the number
+  // of groups for `groupby` and the match density for `join`).
+  size_t groupSize_ = 10;
+  size_t reps_ = 5;
+  uint64_t seed_ = 42;
+};
+
+// _____________________________________________________________________________
+Options parseOptions(int argc, char** argv) {
+  Options opts;
+  if (argc < 2) {
+    std::cerr << "Usage: " << argv[0]
+              << " <join|sort|groupby> [--rows N] [--cols C] [--types K] "
+                 "[--groupsize G] [--reps R] [--seed S]\n";
+    std::exit(1);
+  }
+  opts.kernel_ = argv[1];
+  for (int i = 2; i + 1 < argc; i += 2) {
+    std::string flag = argv[i];
+    uint64_t value = std::stoull(argv[i + 1]);
+    if (flag == "--rows") {
+      opts.numRows_ = value;
+    } else if (flag == "--cols") {
+      opts.numPayloadCols_ = value;
+    } else if (flag == "--types") {
+      opts.numTypes_ = value;
+    } else if (flag == "--groupsize") {
+      opts.groupSize_ = value;
+    } else if (flag == "--reps") {
+      opts.reps_ = value;
+    } else if (flag == "--seed") {
+      opts.seed_ = value;
+    } else {
+      std::cerr << "Unknown flag " << flag << '\n';
+      std::exit(1);
+    }
+  }
+  return opts;
+}
+
+// Make an `Id` of one of up to three datatypes from an integer key. The
+// mapping is strictly monotonic in (`type`, `key`), so sorting a vector of
+// keys and mapping them yields a sorted vector of `Id`s.
+Id makeIdOfType(size_t type, uint64_t key) {
+  switch (type) {
+    case 0:
+      return Id::makeFromVocabIndex(VocabIndex::make(key));
+    case 1:
+      return Id::makeFromInt(static_cast<int64_t>(key));
+    default:
+      return Id::makeFromDouble(static_cast<double>(key));
+  }
+}
+
+// The datatype-major sort order of the types created by `makeIdOfType` (for
+// nonnegative keys): `Int` < `Double` < `VocabIndex`.
+constexpr std::array<size_t, 3> typeSortOrder{1, 2, 0};
+
+ad_utility::AllocatorWithLimit<Id>& allocator() {
+  static ad_utility::AllocatorWithLimit<Id> alloc{
+      ad_utility::makeAllocationMemoryLeftThreadsafeObject(
+          ad_utility::MemorySize::gigabytes(20))};
+  return alloc;
+}
+
+// Generate a table with `numRows` rows and `1 + numPayloadCols` columns.
+// Column 0 contains keys drawn uniformly from `[0, numRows / groupSize)`,
+// mapped to `numTypes` different datatypes; if `sorted`, column 0 is sorted
+// (datatype-major, exactly as the engine would produce it). The payload
+// columns contain random `Int` ids.
+IdTable makeTable(const Options& opts, bool sorted, uint64_t seedOffset) {
+  std::mt19937_64 rng(opts.seed_ + seedOffset);
+  size_t numKeys = std::max<size_t>(1, opts.numRows_ / opts.groupSize_);
+  std::uniform_int_distribution<uint64_t> keyDist(0, numKeys - 1);
+
+  // Draw (type, key) pairs and sort them if requested.
+  std::vector<std::pair<size_t, uint64_t>> keys;
+  keys.reserve(opts.numRows_);
+  for (size_t i = 0; i < opts.numRows_; ++i) {
+    uint64_t key = keyDist(rng);
+    size_t type =
+        opts.numTypes_ <= 1
+            ? 0
+            : typeSortOrder[key % std::min<size_t>(opts.numTypes_, size_t{3})];
+    keys.emplace_back(type, key);
+  }
+  if (sorted) {
+    // Sort by the datatype-major order of the resulting `Id`s. Note: For a
+    // single type this is simply sorting by key.
+    std::sort(keys.begin(), keys.end(), [](const auto& a, const auto& b) {
+      auto rank = [](const auto& p) {
+        auto it =
+            std::find(typeSortOrder.begin(), typeSortOrder.end(), p.first);
+        return std::pair{it - typeSortOrder.begin(), p.second};
+      };
+      return rank(a) < rank(b);
+    });
+  }
+
+  IdTable table{1 + opts.numPayloadCols_, allocator()};
+  table.resize(opts.numRows_);
+  {
+    decltype(auto) keyCol = table.getColumn(0);
+    for (size_t i = 0; i < opts.numRows_; ++i) {
+      keyCol[i] = makeIdOfType(keys[i].first, keys[i].second);
+    }
+  }
+  for (size_t c = 1; c <= opts.numPayloadCols_; ++c) {
+    decltype(auto) col = table.getColumn(c);
+    for (size_t i = 0; i < opts.numRows_; ++i) {
+      col[i] = Id::makeFromInt(static_cast<int64_t>(rng() >> 2));
+    }
+  }
+  return table;
+}
+
+// A simple cross-branch-stable checksum over a table (row count and a hash
+// of the datatypes and row positions of the key column).
+uint64_t checksum(const auto& table) {
+  uint64_t result = table.numRows() * 31 + table.numColumns();
+  decltype(auto) col = table.getColumn(0);
+  size_t stride = std::max<size_t>(1, table.numRows() / 1000);
+  for (size_t i = 0; i < table.numRows(); i += stride) {
+    result = result * 1099511628211ull +
+             static_cast<uint64_t>(static_cast<Id>(col[i]).getDatatype());
+  }
+  return result;
+}
+
+// Run `kernel` `reps` times and report the times and the median.
+template <typename Setup, typename Kernel>
+void runAndReport(const std::string& name, size_t reps, Setup setup,
+                  Kernel kernel) {
+  std::vector<double> times;
+  for (size_t i = 0; i < reps; ++i) {
+    auto state = setup();
+    auto start = steady_clock::now();
+    auto result = kernel(std::move(state));
+    auto stop = steady_clock::now();
+    double ms = duration_cast<microseconds>(stop - start).count() / 1000.0;
+    times.push_back(ms);
+    std::cout << name << " rep " << i << ": " << ms << " ms (checksum "
+              << result << ")" << std::endl;
+  }
+  std::sort(times.begin(), times.end());
+  std::cout << name << " MEDIAN: " << times[times.size() / 2] << " ms"
+            << std::endl;
+}
+
+// _____________________________________________________________________________
+// Kernel 1: The merge join on a single join column without UNDEF values.
+// This replicates the exact code path of `JoinImpl::join` (zipper join +
+// `AddCombinedRowToIdTable`).
+void benchJoin(const Options& opts) {
+  IdTable left = makeTable(opts, true, 0);
+  IdTable right = makeTable(opts, true, 1);
+
+  auto handle = std::make_shared<ad_utility::CancellationHandle<>>();
+
+  auto setup = [&]() { return 0; };
+  auto kernel = [&](int) {
+    auto a = left.asStaticView<0>();
+    auto b = right.asStaticView<0>();
+    ad_utility::JoinColumnMapping joinColumnData{
+        {{0, 0}}, a.numColumns(), b.numColumns()};
+    auto joinColumnL = a.getColumn(0);
+    auto joinColumnR = b.getColumn(0);
+    auto aPermuted = a.asColumnSubsetView(joinColumnData.permutationLeft());
+    auto bPermuted = b.asColumnSubsetView(joinColumnData.permutationRight());
+
+    IdTable result{a.numColumns() + b.numColumns() - 1, allocator()};
+    auto rowAdder = ad_utility::AddCombinedRowToIdTable(
+        1, aPermuted, bPermuted, std::move(result), handle);
+    auto addRow = [beginLeft = joinColumnL.begin(),
+                   beginRight = joinColumnR.begin(),
+                   &rowAdder](const auto& itLeft, const auto& itRight) {
+      rowAdder.addRow(itLeft - beginLeft, itRight - beginRight);
+    };
+    [[maybe_unused]] auto numOutOfOrder = ad_utility::zipperJoinWithUndef(
+        joinColumnL, joinColumnR, ql::ranges::less{}, addRow, ad_utility::noop,
+        ad_utility::noop, {}, ad_utility::noop);
+    auto resultTable = std::move(rowAdder).resultTable();
+    resultTable.setColumnSubset(joinColumnData.permutationResult());
+    return checksum(resultTable);
+  };
+  runAndReport("join", opts.reps_, setup, kernel);
+}
+
+// _____________________________________________________________________________
+// Kernel 2: Sort a fully materialized `IdTable` by a single column. This is
+// the exact code path of `Sort::computeResultInMemory`.
+void benchSort(const Options& opts) {
+  IdTable input = makeTable(opts, false, 0);
+
+  auto setup = [&]() { return input.clone(); };
+  auto kernel = [&](IdTable table) {
+    IdTableUtils::sort(table, std::vector<ColumnIndex>{0});
+    return checksum(table);
+  };
+  runAndReport("sort", opts.reps_, setup, kernel);
+}
+
+// _____________________________________________________________________________
+// Kernel 3: GROUP BY on sorted input with a single group column and a
+// `SUM(?b)` aggregate. This exercises the sorted (non-hash-map) path of
+// `GroupByImpl` through the full operation.
+void benchGroupBy(const Options& opts, bool lazy) {
+  using namespace sparqlExpression;
+  auto qec = ad_utility::testing::getQec();
+  Variable varA{"?a"}, varB{"?b"};
+
+  Options tableOpts = opts;
+  tableOpts.numPayloadCols_ = 1;
+  IdTable input = makeTable(tableOpts, true, 0);
+
+  auto setup = [&]() {
+    qec->getQueryTreeCache().clearAll();
+    std::vector<std::optional<Variable>> vars{varA, varB};
+    auto valuesTree = ad_utility::makeExecutionTree<ValuesForTesting>(
+        qec, input.clone(), vars, false, std::vector<ColumnIndex>{0},
+        LocalVocab{}, std::nullopt, !lazy);
+    auto sumExpr = std::make_unique<SumExpression>(
+        false, std::make_unique<VariableExpression>(varB));
+    Alias alias{SparqlExpressionPimpl{std::move(sumExpr), "SUM(?b)"},
+                Variable{"?sum"}};
+    return std::make_unique<GroupBy>(qec, std::vector<Variable>{varA},
+                                     std::vector<Alias>{std::move(alias)},
+                                     std::move(valuesTree));
+  };
+  auto kernel = [&](std::unique_ptr<GroupBy> groupBy) {
+    auto result = groupBy->getResult(false);
+    return checksum(result->idTableView());
+  };
+  runAndReport(lazy ? "groupby-lazy" : "groupby", opts.reps_, setup, kernel);
+}
+
+}  // namespace
+
+// _____________________________________________________________________________
+int main(int argc, char** argv) {
+  Options opts = parseOptions(argc, argv);
+  std::cout << "kernel=" << opts.kernel_ << " rows=" << opts.numRows_
+            << " payloadCols=" << opts.numPayloadCols_
+            << " types=" << opts.numTypes_ << " groupsize=" << opts.groupSize_
+            << " reps=" << opts.reps_ << std::endl;
+  if (opts.kernel_ == "join") {
+    benchJoin(opts);
+  } else if (opts.kernel_ == "sort") {
+    benchSort(opts);
+  } else if (opts.kernel_ == "groupby") {
+    benchGroupBy(opts, false);
+  } else if (opts.kernel_ == "groupby-lazy") {
+    benchGroupBy(opts, true);
+  } else {
+    std::cerr << "Unknown kernel " << opts.kernel_ << '\n';
+    return 1;
+  }
+  return 0;
+}

--- a/benchmark/IdKernelBenchmarks.cpp
+++ b/benchmark/IdKernelBenchmarks.cpp
@@ -29,6 +29,7 @@
 
 #include <chrono>
 #include <cstdint>
+#include <deque>
 #include <iostream>
 #include <random>
 #include <string>
@@ -65,6 +66,10 @@ struct Options {
   size_t groupSize_ = 10;
   size_t reps_ = 5;
   uint64_t seed_ = 42;
+  // Number of rows per block for the `join-blocks` kernel.
+  size_t blockSize_ = 100'000;
+  // Per-mille of `LocalVocabIndex` IDs in the key column.
+  size_t localVocabPerMille_ = 0;
 };
 
 // _____________________________________________________________________________
@@ -92,6 +97,10 @@ Options parseOptions(int argc, char** argv) {
       opts.reps_ = value;
     } else if (flag == "--seed") {
       opts.seed_ = value;
+    } else if (flag == "--blocksize") {
+      opts.blockSize_ = value;
+    } else if (flag == "--lvpermille") {
+      opts.localVocabPerMille_ = value;
     } else {
       std::cerr << "Unknown flag " << flag << '\n';
       std::exit(1);
@@ -123,6 +132,29 @@ ad_utility::AllocatorWithLimit<Id>& allocator() {
       ad_utility::makeAllocationMemoryLeftThreadsafeObject(
           ad_utility::MemorySize::gigabytes(20))};
   return alloc;
+}
+
+// A pool that owns `LocalVocabEntry`s for the benchmark (the entries must
+// outlive all tables that contain IDs pointing to them).
+struct LocalVocabPool {
+  std::deque<LocalVocabEntry> entries_;
+  ad_utility::HashMap<uint64_t, const LocalVocabEntry*> byKey_;
+
+  Id getId(uint64_t key, const LocalVocabContext& context) {
+    auto it = byKey_.find(key);
+    if (it == byKey_.end()) {
+      std::string word = absl::StrFormat("\"lv%012d\"", key);
+      entries_.push_back(
+          LocalVocabEntry::fromStringRepresentation(std::move(word), context));
+      it = byKey_.emplace(key, &entries_.back()).first;
+    }
+    return Id::makeFromLocalVocabIndex(it->second);
+  }
+};
+
+LocalVocabPool& localVocabPool() {
+  static LocalVocabPool pool;
+  return pool;
 }
 
 // Generate a table with `numRows` rows and `1 + numPayloadCols` columns.
@@ -159,12 +191,34 @@ IdTable makeTable(const Options& opts, bool sorted, uint64_t seedOffset) {
     });
   }
 
+  // Materialize the key ids (a fraction of them may be `LocalVocabIndex`
+  // IDs). In the latter case the ids are sorted semantically afterwards.
+  std::vector<Id> keyIds;
+  keyIds.reserve(opts.numRows_);
+  if (opts.localVocabPerMille_ > 0) {
+    const auto& context = ad_utility::testing::getQec()->getLocalVocabContext();
+    for (const auto& [type, key] : keys) {
+      if (key % 1000 < opts.localVocabPerMille_) {
+        keyIds.push_back(localVocabPool().getId(key, context));
+      } else {
+        keyIds.push_back(makeIdOfType(type, key));
+      }
+    }
+    if (sorted) {
+      std::sort(keyIds.begin(), keyIds.end());
+    }
+  } else {
+    for (const auto& [type, key] : keys) {
+      keyIds.push_back(makeIdOfType(type, key));
+    }
+  }
+
   IdTable table{1 + opts.numPayloadCols_, allocator()};
   table.resize(opts.numRows_);
   {
     decltype(auto) keyCol = table.getColumn(0);
     for (size_t i = 0; i < opts.numRows_; ++i) {
-      keyCol[i] = makeIdOfType(keys[i].first, keys[i].second);
+      keyCol[i] = keyIds[i];
     }
   }
   for (size_t c = 1; c <= opts.numPayloadCols_; ++c) {
@@ -249,6 +303,42 @@ void benchJoin(const Options& opts) {
 }
 
 // _____________________________________________________________________________
+// Kernel 1b: The same merge join, but through the blockwise (lazy) zipper
+// join that is used for joins of prefiltered index scans
+// (`zipperJoinForBlocksWithoutUndef`).
+void benchJoinBlocks(const Options& opts) {
+  IdTable left = makeTable(opts, true, 0);
+  IdTable right = makeTable(opts, true, 1);
+  auto handle = std::make_shared<ad_utility::CancellationHandle<>>();
+
+  // Split a table into blocks of `opts.blockSize_` rows.
+  auto toBlocks = [&](const IdTable& table) {
+    std::vector<ad_utility::IdTableAndFirstCols<1, IdTable>> blocks;
+    for (size_t begin = 0; begin < table.numRows(); begin += opts.blockSize_) {
+      size_t size = std::min(opts.blockSize_, table.numRows() - begin);
+      IdTable block{table.numColumns(), allocator()};
+      block.insertAtEnd(table, begin, begin + size);
+      blocks.push_back(ad_utility::makeIdTableAndFirstCols<1>(std::move(block),
+                                                              LocalVocab{}));
+    }
+    return blocks;
+  };
+  // Note: The blocks have to be recreated for every repetition, because
+  // the blockwise join consumes them.
+  auto setup = [&]() { return std::pair{toBlocks(left), toBlocks(right)}; };
+  auto kernel = [&](auto blocks) {
+    IdTable result{left.numColumns() + right.numColumns() - 1, allocator()};
+    auto rowAdder =
+        ad_utility::AddCombinedRowToIdTable(1, std::move(result), handle);
+    ad_utility::zipperJoinForBlocksWithoutUndef(blocks.first, blocks.second,
+                                                std::less{}, rowAdder);
+    auto resultTable = std::move(rowAdder).resultTable();
+    return checksum(resultTable);
+  };
+  runAndReport("join-blocks", opts.reps_, setup, kernel);
+}
+
+// _____________________________________________________________________________
 // Kernel 2: Sort a fully materialized `IdTable` by a single column. This is
 // the exact code path of `Sort::computeResultInMemory`.
 void benchSort(const Options& opts) {
@@ -307,6 +397,8 @@ int main(int argc, char** argv) {
             << " reps=" << opts.reps_ << std::endl;
   if (opts.kernel_ == "join") {
     benchJoin(opts);
+  } else if (opts.kernel_ == "join-blocks") {
+    benchJoinBlocks(opts);
   } else if (opts.kernel_ == "sort") {
     benchSort(opts);
   } else if (opts.kernel_ == "groupby") {

--- a/benchmark/IdKernelBenchmarks.cpp
+++ b/benchmark/IdKernelBenchmarks.cpp
@@ -38,10 +38,14 @@
 #include "../test/engine/ValuesForTesting.h"
 #include "../test/util/IndexTestHelpers.h"
 #include "engine/AddCombinedRowToTable.h"
+#include "engine/Distinct.h"
+#include "engine/ExistsJoin.h"
+#include "engine/Filter.h"
 #include "engine/GroupBy.h"
 #include "engine/QueryExecutionTree.h"
 #include "engine/sparqlExpressions/AggregateExpression.h"
 #include "engine/sparqlExpressions/LiteralExpression.h"
+#include "engine/sparqlExpressions/RelationalExpressions.h"
 #include "global/Id.h"
 #include "index/IdTableUtils.h"
 #include "util/AllocatorWithLimit.h"
@@ -224,7 +228,7 @@ IdTable makeTable(const Options& opts, bool sorted, uint64_t seedOffset) {
   for (size_t c = 1; c <= opts.numPayloadCols_; ++c) {
     decltype(auto) col = table.getColumn(c);
     for (size_t i = 0; i < opts.numRows_; ++i) {
-      col[i] = Id::makeFromInt(static_cast<int64_t>(rng() >> 2));
+      col[i] = Id::makeFromInt(static_cast<int64_t>(rng() >> 5));
     }
   }
   return table;
@@ -353,6 +357,141 @@ void benchSort(const Options& opts) {
 }
 
 // _____________________________________________________________________________
+// Split a table into blocks of `blockSize` rows (as inputs for the lazy
+// operation variants).
+std::vector<Result::IdTableVocabPair> splitIntoBlocks(const IdTable& table,
+                                                      size_t blockSize) {
+  std::vector<Result::IdTableVocabPair> blocks;
+  for (size_t begin = 0; begin < table.numRows(); begin += blockSize) {
+    size_t size = std::min(blockSize, table.numRows() - begin);
+    IdTable block{table.numColumns(), allocator()};
+    block.insertAtEnd(table, begin, begin + size);
+    blocks.emplace_back(std::move(block), LocalVocab{});
+  }
+  return blocks;
+}
+
+// Consume a `Result` (materialized or lazy) and return a checksum.
+uint64_t consumeResult(std::shared_ptr<const Result> result) {
+  if (result->isFullyMaterialized()) {
+    return checksum(result->idTableView());
+  }
+  uint64_t sum = 1;
+  for (auto& pair : result->idTables()) {
+    sum = sum * 31 + checksum(pair.idTable_);
+  }
+  return sum;
+}
+
+// Make a `ValuesForTesting` tree, either fully materialized or as lazy
+// blocks.
+std::shared_ptr<QueryExecutionTree> makeInputTree(
+    QueryExecutionContext* qec, const IdTable& table,
+    std::vector<std::optional<Variable>> vars, bool lazy, bool sorted,
+    size_t blockSize) {
+  std::vector<ColumnIndex> sortedColumns =
+      sorted ? std::vector<ColumnIndex>{0} : std::vector<ColumnIndex>{};
+  if (lazy) {
+    return ad_utility::makeExecutionTree<ValuesForTesting>(
+        qec, splitIntoBlocks(table, blockSize), std::move(vars), false,
+        sortedColumns);
+  }
+  return ad_utility::makeExecutionTree<ValuesForTesting>(
+      qec, table.clone(), std::move(vars), false, sortedColumns, LocalVocab{},
+      std::nullopt, true);
+}
+
+// _____________________________________________________________________________
+// Kernel 4: FILTER with a conceptually simple expression (`?b < constant`
+// with ~50% selectivity, where `?b` is a random `Int` column).
+void benchFilter(const Options& opts, bool lazy) {
+  using namespace sparqlExpression;
+  auto qec = ad_utility::testing::getQec();
+  IdTable input = makeTable(opts, false, 0);
+  std::vector<std::optional<Variable>> vars;
+  for (size_t i = 0; i < input.numColumns(); ++i) {
+    vars.emplace_back(Variable{absl::StrCat("?v", i)});
+  }
+  // The payload columns contain uniform 59-bit random integers (which are
+  // exactly representable on both ID layouts), so this threshold yields a
+  // selectivity of ~50%.
+  Id threshold = Id::makeFromInt(int64_t{1} << 58);
+
+  auto setup = [&]() {
+    qec->getQueryTreeCache().clearAll();
+    auto tree = makeInputTree(qec, input, vars, lazy, false, opts.blockSize_);
+    auto expression = std::make_unique<LessThanExpression>(
+        std::array<SparqlExpression::Ptr, 2>{
+            std::make_unique<VariableExpression>(Variable{"?v1"}),
+            std::make_unique<IdExpression>(threshold)});
+    return std::make_unique<Filter>(
+        qec, std::move(tree),
+        SparqlExpressionPimpl{std::move(expression), "?v1 < threshold"});
+  };
+  auto kernel = [&](std::unique_ptr<Filter> filter) {
+    return consumeResult(
+        filter->getResult(false, lazy ? ComputationMode::LAZY_IF_SUPPORTED
+                                      : ComputationMode::FULLY_MATERIALIZED));
+  };
+  runAndReport(lazy ? "filter-lazy" : "filter", opts.reps_, setup, kernel);
+}
+
+// _____________________________________________________________________________
+// Kernel 5: DISTINCT on the sorted key column (column 0).
+void benchDistinct(const Options& opts, bool lazy) {
+  auto qec = ad_utility::testing::getQec();
+  IdTable input = makeTable(opts, true, 0);
+  std::vector<std::optional<Variable>> vars;
+  for (size_t i = 0; i < input.numColumns(); ++i) {
+    vars.emplace_back(Variable{absl::StrCat("?v", i)});
+  }
+
+  auto setup = [&]() {
+    qec->getQueryTreeCache().clearAll();
+    auto tree = makeInputTree(qec, input, vars, lazy, true, opts.blockSize_);
+    return std::make_unique<Distinct>(qec, std::move(tree),
+                                      std::vector<ColumnIndex>{0});
+  };
+  auto kernel = [&](std::unique_ptr<Distinct> distinct) {
+    return consumeResult(
+        distinct->getResult(false, lazy ? ComputationMode::LAZY_IF_SUPPORTED
+                                        : ComputationMode::FULLY_MATERIALIZED));
+  };
+  runAndReport(lazy ? "distinct-lazy" : "distinct", opts.reps_, setup, kernel);
+}
+
+// _____________________________________________________________________________
+// Kernel 6: EXISTS join on the sorted key column.
+void benchExists(const Options& opts, bool lazy) {
+  auto qec = ad_utility::testing::getQec();
+  IdTable left = makeTable(opts, true, 0);
+  IdTable right = makeTable(opts, true, 1);
+  std::vector<std::optional<Variable>> varsLeft;
+  std::vector<std::optional<Variable>> varsRight;
+  for (size_t i = 0; i < left.numColumns(); ++i) {
+    varsLeft.emplace_back(Variable{absl::StrCat("?v", i)});
+    varsRight.emplace_back(
+        Variable{absl::StrCat(i == 0 ? "?v" : "?w", i == 0 ? 0 : i)});
+  }
+
+  auto setup = [&]() {
+    qec->getQueryTreeCache().clearAll();
+    auto leftTree =
+        makeInputTree(qec, left, varsLeft, lazy, true, opts.blockSize_);
+    auto rightTree =
+        makeInputTree(qec, right, varsRight, lazy, true, opts.blockSize_);
+    return std::make_unique<ExistsJoin>(
+        qec, std::move(leftTree), std::move(rightTree), Variable{"?exists"});
+  };
+  auto kernel = [&](std::unique_ptr<ExistsJoin> exists) {
+    return consumeResult(
+        exists->getResult(false, lazy ? ComputationMode::LAZY_IF_SUPPORTED
+                                      : ComputationMode::FULLY_MATERIALIZED));
+  };
+  runAndReport(lazy ? "exists-lazy" : "exists", opts.reps_, setup, kernel);
+}
+
+// _____________________________________________________________________________
 // Kernel 3: GROUP BY on sorted input with a single group column and a
 // `SUM(?b)` aggregate. This exercises the sorted (non-hash-map) path of
 // `GroupByImpl` through the full operation.
@@ -401,6 +540,18 @@ int main(int argc, char** argv) {
     benchJoinBlocks(opts);
   } else if (opts.kernel_ == "sort") {
     benchSort(opts);
+  } else if (opts.kernel_ == "filter") {
+    benchFilter(opts, false);
+  } else if (opts.kernel_ == "filter-lazy") {
+    benchFilter(opts, true);
+  } else if (opts.kernel_ == "distinct") {
+    benchDistinct(opts, false);
+  } else if (opts.kernel_ == "distinct-lazy") {
+    benchDistinct(opts, true);
+  } else if (opts.kernel_ == "exists") {
+    benchExists(opts, false);
+  } else if (opts.kernel_ == "exists-lazy") {
+    benchExists(opts, true);
   } else if (opts.kernel_ == "groupby") {
     benchGroupBy(opts, false);
   } else if (opts.kernel_ == "groupby-lazy") {

--- a/benchmark/JoinAlgorithmBenchmark.cpp
+++ b/benchmark/JoinAlgorithmBenchmark.cpp
@@ -113,14 +113,14 @@ struct SetOfIdTableColumnElements {
   However, accessing a hash map entry based on index position takes linear time,
   instead of constant.
   */
-  std::vector<std::reference_wrapper<const ValueId>> uniqueElements_{};
+  std::vector<ValueId> uniqueElements_{};
   ad_utility::HashMap<ValueId, size_t> numOccurrences_{};
 
   /*
   Set the member variables for the given column.
   */
   explicit SetOfIdTableColumnElements(
-      const ql::span<const ValueId>& idTableColumnRef) {
+      columnBasedIdTable::ConstIdColumnSpan idTableColumnRef) {
     ql::ranges::for_each(idTableColumnRef, [this](const ValueId& id) {
       if (auto numOccurrencesIterator = numOccurrences_.find(id);
           numOccurrencesIterator != numOccurrences_.end()) {
@@ -194,13 +194,12 @@ static size_t createOverlapRandomly(IdTableAndJoinColumn* const smallerTable,
   size_t newOverlapMatches{0};
 
   // Create the overlap.
-  ad_utility::HashMap<ValueId, std::reference_wrapper<const ValueId>>
-      smallerTableElementToNewElement{};
+  ad_utility::HashMap<ValueId, ValueId> smallerTableElementToNewElement{};
   ql::ranges::for_each(
       smallerTableJoinColumnRef,
       [&randomDouble, &probabilityToCreateOverlap,
        &smallerTableElementToNewElement, &randomBiggerTableElement,
-       &newOverlapMatches, &biggerTableJoinColumnSet](auto& id) {
+       &newOverlapMatches, &biggerTableJoinColumnSet](auto&& id) {
         /*
         If a value has no hash map value, with which it will be overwritten, we
         either assign it its own value, or an element from the bigger table.
@@ -333,7 +332,7 @@ static size_t createOverlapRandomly(IdTableAndJoinColumn* const smallerTable,
 
   // Overwrite the designated values in the smaller table.
   ql::ranges::for_each(
-      smallerTableJoinColumnRef, [&smallerTableElementToNewElement](auto& id) {
+      smallerTableJoinColumnRef, [&smallerTableElementToNewElement](auto&& id) {
         if (auto newValueIterator = smallerTableElementToNewElement.find(id);
             newValueIterator != smallerTableElementToNewElement.end()) {
           id = newValueIterator->second;

--- a/src/engine/AddCombinedRowToTable.h
+++ b/src/engine/AddCombinedRowToTable.h
@@ -299,45 +299,60 @@ class AddCombinedRowToIdTable {
     AD_CORRECTNESS_CHECK(inputLeftAndRight_.has_value());
     result.resize(oldSize + nextIndex_);
 
-    // Precondition: `a` and `b` compare equal or at least one of them is UNDEF
-    // If exactly one of them is UNDEF, return the other one, else return any of
-    // them (they are equal anyway).
-    auto getJoinValue = [](const ValueId a, const ValueId b) {
-      // NOTE: For localVocabIndices we might have different pointers that
-      // compare equal because they point to the same word. Therefore we cannot
-      // use a simple bitwise operation to handle the "one of them is UNDEF"
-      // case as we previously did.
-      if (a.isUndefined()) {
-        return b;
-      }
-      return a;
+    // The following lambdas operate directly on the payload and datatype
+    // arrays of the split column storage, which is considerably faster than
+    // materializing single `Id`s. Note: The check for UNDEF can be performed
+    // bitwise here, because the undefined `Id` has a unique bit
+    // representation (datatype byte and payload both zero).
+    static_assert(static_cast<uint8_t>(Datatype::Undefined) == 0);
+    auto isUndef = [](uint64_t payload, uint8_t type) {
+      return static_cast<size_t>((type == 0) & (payload == 0));
     };
 
     // A lambda that writes the join column with the given `colIdx` to the
     // `nextResultColIdx`-th column of the result.
-    auto writeJoinColumn = [&result, &getJoinValue, oldSize, this](
+    // Precondition (from the join): the left and the right value compare
+    // equal, or at least one of them is UNDEF. If the left one is UNDEF we
+    // take the right one, else the left one. (When both are defined they
+    // compare equal, but e.g. for local vocab entries the bit representations
+    // may still differ, so we have to consistently pick one side.)
+    auto writeJoinColumn = [&result, &isUndef, oldSize, this](
                                size_t colIdx, size_t resultColIdx) {
-      const auto& colLeft = inputLeft().getColumn(colIdx);
-      const auto& colRight = inputRight().getColumn(colIdx);
+      auto colLeft = inputLeft().getColumn(colIdx);
+      auto colRight = inputRight().getColumn(colIdx);
+      auto leftPayloads = colLeft.payloadSpan();
+      auto leftTypes = colLeft.datatypeSpan();
+      auto rightPayloads = colRight.payloadSpan();
+      auto rightTypes = colRight.datatypeSpan();
       // TODO<joka921> Implement prefetching.
       decltype(auto) resultCol = result.getColumn(resultColIdx);
-      size_t& numUndef = numUndefinedPerColumn_.at(resultColIdx);
+      auto resultPayloads = resultCol.payloadSpan();
+      auto resultTypes = resultCol.datatypeSpan();
+      size_t numUndef = 0;
 
       // Write the matching rows.
       for (const auto& [targetIndex, sourceIndices] : indexBuffer_) {
-        auto resultId =
-            getJoinValue(colLeft[sourceIndices[0]], colRight[sourceIndices[1]]);
-        numUndef += static_cast<size_t>(resultId.isUndefined());
-        resultCol[oldSize + targetIndex] = resultId;
+        uint64_t payload = leftPayloads[sourceIndices[0]];
+        uint8_t type = leftTypes[sourceIndices[0]];
+        if (isUndef(payload, type)) {
+          payload = rightPayloads[sourceIndices[1]];
+          type = rightTypes[sourceIndices[1]];
+          numUndef += isUndef(payload, type);
+        }
+        resultPayloads[oldSize + targetIndex] = payload;
+        resultTypes[oldSize + targetIndex] = type;
       }
 
       // Write the optional rows. For the right input those are always
       // undefined.
       for (const auto& [targetIndex, sourceIndex] : optionalIndexBuffer_) {
-        Id id = colLeft[sourceIndex];
-        resultCol[oldSize + targetIndex] = id;
-        numUndef += static_cast<size_t>(id.isUndefined());
+        uint64_t payload = leftPayloads[sourceIndex];
+        uint8_t type = leftTypes[sourceIndex];
+        numUndef += isUndef(payload, type);
+        resultPayloads[oldSize + targetIndex] = payload;
+        resultTypes[oldSize + targetIndex] = type;
       }
+      numUndefinedPerColumn_.at(resultColIdx) += numUndef;
     };
 
     // A lambda that writes the non-join-column `colIdx` to the
@@ -347,39 +362,46 @@ class AddCombinedRowToIdTable {
     // previous one. I have tried to unify them but this lead to template-heavy
     // code that was very hard to read for humans.
     auto writeNonJoinColumn = ad_utility::ApplyAsValueIdentity{
-        [&result, oldSize, this](auto isColFromLeft, size_t colIdx,
-                                 size_t resultColIdx) {
+        [&result, &isUndef, oldSize, this](auto isColFromLeft, size_t colIdx,
+                                           size_t resultColIdx) {
           decltype(auto) col = isColFromLeft ? inputLeft().getColumn(colIdx)
                                              : inputRight().getColumn(colIdx);
+          auto payloads = col.payloadSpan();
+          auto types = col.datatypeSpan();
           // TODO<joka921> Implement prefetching.
           decltype(auto) resultCol = result.getColumn(resultColIdx);
-          size_t& numUndef = numUndefinedPerColumn_.at(resultColIdx);
+          auto resultPayloads = resultCol.payloadSpan();
+          auto resultTypes = resultCol.datatypeSpan();
+          size_t numUndef = 0;
 
           // Write the matching rows.
           static constexpr size_t idx = isColFromLeft ? 0 : 1;
           for (const auto& [targetIndex, sourceIndices] : indexBuffer_) {
-            auto resultId = col[sourceIndices[idx]];
-            numUndef += static_cast<size_t>(resultId == Id::makeUndefined());
-            resultCol[oldSize + targetIndex] = resultId;
+            uint64_t payload = payloads[sourceIndices[idx]];
+            uint8_t type = types[sourceIndices[idx]];
+            numUndef += isUndef(payload, type);
+            resultPayloads[oldSize + targetIndex] = payload;
+            resultTypes[oldSize + targetIndex] = type;
           }
 
           // Write the optional rows. For the right input those are always
           // undefined.
           for (const auto& [targetIndex, sourceIndex] : optionalIndexBuffer_) {
-            Id id = [&col, isColFromLeft, sourceIndex = sourceIndex]() {
-              // Note: `if constexpr` doesn't work here for QCC 8.3 for some
-              // reason which has yet to be analyzed.
-              if QL_CONSTEXPR (isColFromLeft) {
-                return col[sourceIndex];
-              } else {
-                (void)col;
-                (void)sourceIndex;
-                return Id::makeUndefined();
-              }
-            }();
-            resultCol[oldSize + targetIndex] = id;
-            numUndef += static_cast<size_t>(id.isUndefined());
+            uint64_t payload = 0;
+            uint8_t type = 0;
+            // Note: `if constexpr` doesn't work here for QCC 8.3 for some
+            // reason which has yet to be analyzed.
+            if QL_CONSTEXPR (isColFromLeft) {
+              payload = payloads[sourceIndex];
+              type = types[sourceIndex];
+            } else {
+              (void)sourceIndex;
+            }
+            numUndef += isUndef(payload, type);
+            resultPayloads[oldSize + targetIndex] = payload;
+            resultTypes[oldSize + targetIndex] = type;
           }
+          numUndefinedPerColumn_.at(resultColIdx) += numUndef;
         }};
 
     size_t nextResultColIdx = 0;

--- a/src/engine/CartesianProductJoin.cpp
+++ b/src/engine/CartesianProductJoin.cpp
@@ -106,10 +106,10 @@ bool CartesianProductJoin::knownEmptyResult() {
 }
 
 // ____________________________________________________________________________
-void CartesianProductJoin::writeResultColumn(ql::span<Id> targetColumn,
-                                             ql::span<const Id> inputColumn,
-                                             size_t groupSize,
-                                             size_t offset) const {
+void CartesianProductJoin::writeResultColumn(
+    columnBasedIdTable::MutableIdColumnSpan targetColumn,
+    columnBasedIdTable::ConstIdColumnSpan inputColumn, size_t groupSize,
+    size_t offset) const {
   // Copy each element from the `inputColumn` `groupSize` times to
   // the `targetColumn`, repeat until the `targetColumn` is completely filled.
   size_t numRowsWritten = 0;

--- a/src/engine/CartesianProductJoin.h
+++ b/src/engine/CartesianProductJoin.h
@@ -106,9 +106,9 @@ class CartesianProductJoin : public Operation {
   // `targetColumn`. Repeat until the `targetColumn` is completely filled. Skip
   // the first `offset` write operations to the `targetColumn`. Call
   // `checkCancellation` after each write.
-  void writeResultColumn(ql::span<Id> targetColumn,
-                         ql::span<const Id> inputColumn, size_t groupSize,
-                         size_t offset) const;
+  void writeResultColumn(columnBasedIdTable::MutableIdColumnSpan targetColumn,
+                         columnBasedIdTable::ConstIdColumnSpan inputColumn,
+                         size_t groupSize, size_t offset) const;
 
   // Write all columns of the subresults into an `IdTable` and return it.
   // `offset` indicates how many rows to skip in the result and `limit` how many

--- a/src/engine/Describe.cpp
+++ b/src/engine/Describe.cpp
@@ -102,7 +102,8 @@ VariableToColumnMap Describe::computeVariableToColumnMap() const {
 template <typename Allocator>
 static IdTable getNewBlankNodes(
     const Allocator& allocator,
-    ad_utility::HashSetWithMemoryLimit<Id>& alreadySeen, ql::span<Id> input) {
+    ad_utility::HashSetWithMemoryLimit<Id>& alreadySeen,
+    columnBasedIdTable::ConstIdColumnSpan input) {
   IdTable result{1, allocator};
   result.resize(input.size());
   decltype(auto) resultColumn = result.getColumn(0);

--- a/src/engine/Distinct.cpp
+++ b/src/engine/Distinct.cpp
@@ -115,6 +115,61 @@ Result Distinct::computeResult(bool requestLaziness) {
                       resultSortedOn()};
 }
 
+namespace {
+// Return the indices of all rows of the `table` (a table or a view) with
+// `index >= startIndex` that differ from their predecessor row in at least
+// one of the `keepIndices` columns. The comparison is performed directly on
+// the datatype bytes and payload words of the split column storage; only
+// where IDs of type `LocalVocabIndex` are involved (those do not compare
+// bitwise), the semantic `Id` comparison is used. `checkCancellation` is
+// called periodically.
+template <typename Table>
+std::vector<size_t> indicesOfRowsThatDifferFromPredecessor(
+    const Table& table, ql::span<const ColumnIndex> keepIndices,
+    size_t startIndex, const auto& checkCancellation) {
+  constexpr uint8_t localVocabType =
+      static_cast<uint8_t>(Datatype::LocalVocabIndex);
+  struct ColumnSpans {
+    ql::span<const uint64_t> payloads_;
+    ql::span<const uint8_t> types_;
+  };
+  std::vector<ColumnSpans> columns;
+  columns.reserve(keepIndices.size());
+  for (ColumnIndex keepIndex : keepIndices) {
+    auto column = table.getColumn(keepIndex);
+    columns.push_back({column.payloadSpan(), column.datatypeSpan()});
+  }
+
+  auto rowsDiffer = [&columns](size_t a, size_t b) {
+    for (const auto& [payloads, types] : columns) {
+      if (payloads[a] != payloads[b] || types[a] != types[b]) {
+        // Bitwise different. This means semantically different, unless an
+        // ID of type `LocalVocabIndex` is involved.
+        if (types[a] != localVocabType && types[b] != localVocabType) {
+          return true;
+        }
+        if (Id::fromBits({types[a], payloads[a]}) !=
+            Id::fromBits({types[b], payloads[b]})) {
+          return true;
+        }
+      }
+    }
+    return false;
+  };
+
+  std::vector<size_t> result;
+  for (size_t i = std::max<size_t>(startIndex, 1); i < table.numRows(); ++i) {
+    if (rowsDiffer(i, i - 1)) {
+      result.push_back(i);
+    }
+    if ((i & ((size_t{1} << 16) - 1)) == 0) {
+      checkCancellation();
+    }
+  }
+  return result;
+}
+}  // namespace
+
 // _____________________________________________________________________________
 template <typename T1, typename T2>
 bool Distinct::matchesRow(const T1& a, const T2& b) const {
@@ -130,46 +185,41 @@ IdTable Distinct::distinct(
   AD_CONTRACT_CHECK(keepIndices_.size() <= dynInput.numColumns());
   AD_LOG_DEBUG << "Distinct on " << dynInput.size() << " elements.\n";
   IdTableStatic<WIDTH> result = std::move(dynInput).toStatic<WIDTH>();
-
-  // Variant of `ql::ranges::unique` that allows to skip the begin rows of
-  // elements found in the previous table.
-  auto begin =
-      ql::ranges::find_if(result, [this, &previousRow](const auto& row) {
-        // Without explicit this clang seems to
-        // think the this capture is redundant.
-        return !previousRow.has_value() ||
-               !this->matchesRow(row, previousRow.value());
-      });
-  auto end = result.end();
-
-  auto dest = result.begin();
-  if (begin == dest) {
-    // Optimization to avoid redundant move operations.
-    begin = ql::ranges::adjacent_find(begin, end,
-                                      [this](const auto& a, const auto& b) {
-                                        // Without explicit this clang seems to
-                                        // think the this capture is redundant.
-                                        return this->matchesRow(a, b);
-                                      });
-    dest = begin;
-    if (begin != end) {
-      ++begin;
-    }
-  } else if (begin != end) {
-    *dest = std::move(*begin);
+  if (result.empty()) {
+    return std::move(result).toDynamic();
   }
 
-  if (begin != end) {
-    while (++begin != end) {
-      if (!matchesRow(*dest, *begin)) {
-        *++dest = std::move(*begin);
-        checkCancellation();
-      }
-    }
-    ++dest;
+  // Compute the indices of the rows that are kept: the first row is kept iff
+  // it differs from the last row of the previous table, all other rows are
+  // kept iff they differ from their predecessor.
+  auto checkCancellationLambda = [this] { checkCancellation(); };
+  std::vector<size_t> keptIndices = indicesOfRowsThatDifferFromPredecessor(
+      result, keepIndices_, 1, checkCancellationLambda);
+  bool keepFirstRow =
+      !previousRow.has_value() || !matchesRow(result[0], previousRow.value());
+  if (keepFirstRow) {
+    keptIndices.insert(keptIndices.begin(), 0);
   }
   checkCancellation();
-  result.erase(dest, end);
+
+  if (keptIndices.size() == result.size()) {
+    // All rows are distinct, no copying is required at all.
+    return std::move(result).toDynamic();
+  }
+
+  // Move the kept rows to the front, column by column. Note: The kept
+  // indices are ascending and `keptIndices[k] >= k` always holds, so the
+  // forward copy is safe.
+  for (size_t c = 0; c < result.numColumns(); ++c) {
+    decltype(auto) column = result.getColumn(c);
+    auto payloads = column.payloadSpan();
+    auto types = column.datatypeSpan();
+    for (size_t k = 0; k < keptIndices.size(); ++k) {
+      payloads[k] = payloads[keptIndices[k]];
+      types[k] = types[keptIndices[k]];
+    }
+  }
+  result.resize(keptIndices.size());
   checkCancellation();
 
   AD_LOG_DEBUG << "Distinct done.\n";
@@ -183,35 +233,19 @@ IdTable Distinct::outOfPlaceDistinct(const IdTableView<0>& dynInput) const {
   AD_LOG_DEBUG << "Distinct on " << dynInput.size() << " elements.\n";
   auto inputView = dynInput.asStaticView<WIDTH>();
   IdTableStatic<WIDTH> output{dynInput.numColumns(), allocator()};
-
-  auto begin = inputView.begin();
-  auto end = inputView.end();
-  while (begin < end) {
-    int64_t allowedOffset = std::min(end - begin, CHUNK_SIZE);
-    begin = ql::ranges::unique_copy(begin, begin + allowedOffset,
-                                    std::back_inserter(output),
-                                    [this](const auto& a, const auto& b) {
-                                      // Without explicit this clang seems to
-                                      // think the this capture is redundant.
-                                      return this->matchesRow(a, b);
-                                    })
-                .in;
-    checkCancellation();
-    // Skip to next unique value
-    do {
-      allowedOffset = std::min(end - begin, CHUNK_SIZE);
-      // This can only be called when dynInput is not empty, so `begin[-1]` is
-      // always valid.
-      auto lastRow = begin[-1];
-      begin = ql::ranges::find_if(begin, begin + allowedOffset,
-                                  [this, &lastRow](const auto& row) {
-                                    // Without explicit this clang seems to
-                                    // think the this capture is redundant.
-                                    return !this->matchesRow(row, lastRow);
-                                  });
-      checkCancellation();
-    } while (begin != end && matchesRow(*begin, begin[-1]));
+  if (inputView.empty()) {
+    return std::move(output).toDynamic();
   }
+
+  // Compute the indices of the distinct rows (the first row is always kept)
+  // and then copy them to the output column by column.
+  auto checkCancellationLambda = [this] { checkCancellation(); };
+  std::vector<size_t> keptIndices = indicesOfRowsThatDifferFromPredecessor(
+      inputView, keepIndices_, 1, checkCancellationLambda);
+  keptIndices.insert(keptIndices.begin(), 0);
+  checkCancellation();
+  output.insertSubsetAtEnd(inputView, keptIndices);
+  checkCancellation();
 
   AD_LOG_DEBUG << "Distinct done.\n";
   return std::move(output).toDynamic();

--- a/src/engine/ExistsJoin.cpp
+++ b/src/engine/ExistsJoin.cpp
@@ -10,6 +10,7 @@
 #include "engine/QueryPlanner.h"
 #include "engine/Result.h"
 #include "engine/Sort.h"
+#include "engine/idTable/IdColumnAlgorithms.h"
 #include "engine/sparqlExpressions/ExistsExpression.h"
 #include "engine/sparqlExpressions/SparqlExpression.h"
 #include "util/ChunkedForLoop.h"
@@ -220,7 +221,21 @@ Result ExistsJoin::computeResult(bool requestLaziness) {
       runZipperJoin(ad_utility::findSmallerUndefRanges);
     }
   };
-  ad_utility::callFixedSizeVi(numJoinColumns, runForNumJoinCols);
+  if (numJoinColumns == 1 && isCheap) {
+    // Fast path: For a single join column without UNDEF values, compute the
+    // non-existing rows directly on the datatype bytes and payload words of
+    // the split column storage (IDs of type `LocalVocabIndex` are handled
+    // gracefully inside).
+    columnBasedIdTable::zipperJoinIdColumns(
+        joinColumnsLeft.getColumn(0), joinColumnsRight.getColumn(0),
+        ad_utility::noop, ad_utility::noop,
+        [&notExistsIndices](size_t index) {
+          notExistsIndices.push_back(index);
+        },
+        [this] { checkCancellation(); });
+  } else {
+    ad_utility::callFixedSizeVi(numJoinColumns, runForNumJoinCols);
+  }
 
   // Add the result column from the computed `notExistsIndices` (which tell us
   // where the value should be `false`).
@@ -455,12 +470,23 @@ struct LazyExistsJoinImpl
         leftJoinColumn_{leftJoinColumn},
         rightJoinColumn_{rightJoinColumn} {}
 
+  // The payload words and datatype bytes of the join column of the current
+  // right block. Cached, s.t. the hot comparison loop can work directly on
+  // the split column storage.
+  ql::span<const uint64_t> rightPayloads_;
+  ql::span<const uint8_t> rightTypes_;
+
   // Fetch and store the next non-empty result from `rightRange_` in
   // `currentRight_`.
   void fetchNextRightBlock() {
     do {
       currentRight_ = rightRange_.get();
     } while (currentRight_.has_value() && currentRight_.value().empty());
+    if (currentRight_.has_value()) {
+      auto column = currentRight_.value().getColumn(rightJoinColumn_);
+      rightPayloads_ = column.payloadSpan();
+      rightTypes_ = column.datatypeSpan();
+    }
   }
 
   // Increment `currentRightIndex_` by one, or fetch the next non-empty element
@@ -479,20 +505,36 @@ struct LazyExistsJoinImpl
     }
   }
 
-  // Check if the `id` has a match on the right side. This will increment the
-  // index until a match is found, or no matches exist.
-  bool hasMatch(Id id) {
-    if (id.isUndefined()) {
-      // This is correct, because undefined values are processed first and
-      // `currentRight_` is not-reassigned until a non-undefined value is
-      // processed.
+  // Check if the ID given by `type` and `payload` has a match on the right
+  // side. This will increment the index until a match is found, or no
+  // matches exist. The comparisons are performed directly on the datatype
+  // bytes and payload words; only where IDs of type `LocalVocabIndex` are
+  // involved, the semantic `Id` comparison is used.
+  bool hasMatch(uint8_t type, uint64_t payload) {
+    constexpr uint8_t localVocabType =
+        static_cast<uint8_t>(Datatype::LocalVocabIndex);
+    if (type == 0 && payload == 0) {
+      // The ID is undefined. This is correct, because undefined values are
+      // processed first and `currentRight_` is not-reassigned until a
+      // non-undefined value is processed.
       return currentRight_.has_value();
     }
     // Search for the next match.
     while (currentRight_.has_value()) {
       AD_CORRECTNESS_CHECK(currentRightIndex_ < currentRight_.value().size());
-      auto comparison = ql::compareThreeWay(
-          currentRight_.value().at(currentRightIndex_, rightJoinColumn_), id);
+      uint8_t rightType = rightTypes_[currentRightIndex_];
+      uint64_t rightPayload = rightPayloads_[currentRightIndex_];
+      int comparison;
+      if (rightType != localVocabType && type != localVocabType) [[likely]] {
+        comparison = rightType != type ? (rightType < type ? -1 : 1)
+                                       : (rightPayload < payload    ? -1
+                                          : rightPayload == payload ? 0
+                                                                    : 1);
+      } else {
+        auto res = Id::fromBits({rightType, rightPayload})
+                       .compareThreeWay(Id::fromBits({type, payload}));
+        comparison = res < 0 ? -1 : res == 0 ? 0 : 1;
+      }
       if (comparison == 0) {
         return true;
       }
@@ -531,11 +573,20 @@ struct LazyExistsJoinImpl
                                                         FastForwardState::Yes));
       } else {
         auto leftJoinColumn = idTable.getColumn(leftJoinColumn_);
+        auto leftPayloads = leftJoinColumn.payloadSpan();
+        auto leftTypes = leftJoinColumn.datatypeSpan();
+        auto outputPayloads = outputColumn.payloadSpan();
+        auto outputTypes = outputColumn.datatypeSpan();
+        const auto trueBits = Id::makeFromBool(true).getBits();
+        const auto falseBits = Id::makeFromBool(false).getBits();
 
         for (size_t rowIndex = 0; rowIndex < leftJoinColumn.size();
              rowIndex++) {
-          outputColumn[rowIndex] =
-              Id::makeFromBool(hasMatch(leftJoinColumn[rowIndex]));
+          const auto& bits =
+              hasMatch(leftTypes[rowIndex], leftPayloads[rowIndex]) ? trueBits
+                                                                    : falseBits;
+          outputPayloads[rowIndex] = bits.payload_;
+          outputTypes[rowIndex] = bits.datatype_;
         }
       }
     }

--- a/src/engine/ExistsJoin.cpp
+++ b/src/engine/ExistsJoin.cpp
@@ -175,10 +175,12 @@ Result ExistsJoin::computeResult(bool requestLaziness) {
   AD_CORRECTNESS_CHECK(numJoinColumns == joinColumnsRight.numColumns());
   bool isCheap = ql::ranges::none_of(
       ad_utility::integerRange(numJoinColumns), [&](const auto& col) {
-        return (ql::ranges::any_of(joinColumnsRight.getColumn(col),
-                                   &Id::isUndefined)) ||
-               (ql::ranges::any_of(joinColumnsLeft.getColumn(col),
-                                   &Id::isUndefined));
+        return (ql::ranges::any_of(
+                   joinColumnsRight.getColumn(col),
+                   [](const Id& id) { return id.isUndefined(); })) ||
+               (ql::ranges::any_of(
+                   joinColumnsLeft.getColumn(col),
+                   [](const Id& id) { return id.isUndefined(); }));
       });
 
   // Nothing to do for the actual matches.

--- a/src/engine/ExportQueryExecutionTrees.cpp
+++ b/src/engine/ExportQueryExecutionTrees.cpp
@@ -481,10 +481,11 @@ STREAMABLE_GENERATOR_TYPE ExportQueryExecutionTrees::selectQueryResultToStream(
          getRowIndices(limitAndOffset, *result, resultSize)) {
       for (uint64_t i : range) {
         for (const auto& columnIndex : selectedColumnIndices) {
+          // Materialize the `Id`, as the table stores the payload and
+          // datatype in separate columns.
+          Id id = pair.idTable()(i, columnIndex.value().columnIndex_);
           STREAMABLE_YIELD(
-              std::string_view{reinterpret_cast<const char*>(&pair.idTable()(
-                                   i, columnIndex.value().columnIndex_)),
-                               sizeof(Id)});
+              std::string_view{reinterpret_cast<const char*>(&id), sizeof(Id)});
         }
         cancellationHandle->throwIfCancelled();
       }

--- a/src/engine/Filter.cpp
+++ b/src/engine/Filter.cpp
@@ -208,14 +208,23 @@ CPP_template_def(int WIDTH,
 
       using ValueGetter = sparqlExpression::detail::EffectiveBooleanValueGetter;
       ValueGetter valueGetter{};
+      // First collect the indices of all matching rows and then copy them to
+      // the result in one go. This is much faster than copying the matching
+      // rows one at a time, because the copy can be performed column by
+      // column.
+      std::vector<size_t> matchingIndices;
       for (auto&& resultValue : resultGenerator) {
         if (valueGetter(resultValue, &evaluationContext) ==
             ValueGetter::Result::True) {
-          resultTable.push_back(input[i]);
+          matchingIndices.push_back(i);
         }
-        checkCancellation();
         ++i;
+        if ((i & ((size_t{1} << 16) - 1)) == 0) {
+          checkCancellation();
+        }
       }
+      checkCancellation();
+      resultTable.insertSubsetAtEnd(input, matchingIndices);
     }
   };
   std::visit(computeResult, std::move(expressionResult));

--- a/src/engine/GroupByImpl.cpp
+++ b/src/engine/GroupByImpl.cpp
@@ -9,6 +9,8 @@
 
 #include <absl/strings/str_join.h>
 
+#include <cstring>
+
 #include "backports/algorithm.h"
 #include "engine/CallFixedSize.h"
 #include "engine/ExistsJoin.h"
@@ -673,6 +675,48 @@ size_t GroupByImpl::searchBlockBoundaries(const T& onBlockChange,
                                           const IdTableView<COLS>& idTable,
                                           GroupBlock& currentGroupBlock) const {
   size_t blockStart = 0;
+
+  // Fast path for a single group column that contains no `LocalVocabIndex`
+  // IDs (those don't compare bitwise): find the group boundaries directly on
+  // the datatype bytes and payload words of the split column storage.
+  if (currentGroupBlock.size() == 1) {
+    auto column = idTable.getColumn(currentGroupBlock.at(0).first);
+    auto types = column.datatypeSpan();
+    auto payloads = column.payloadSpan();
+    if (std::memchr(types.data(), static_cast<int>(Datatype::LocalVocabIndex),
+                    types.size()) == nullptr) {
+      auto& currentValue = currentGroupBlock.at(0).second;
+      size_t pos = 0;
+      // Skip the prefix that still belongs to the current group. Note: The
+      // value in `currentGroupBlock` can stem from a previous table (in the
+      // lazy case) and can therefore be of type `LocalVocabIndex`, so this
+      // prefix has to be compared with the semantic `Id` comparison.
+      while (pos < idTable.size() && Id{column[pos]} == currentValue) {
+        ++pos;
+      }
+      if (pos < idTable.size()) {
+        // A boundary at `pos == 0` correctly reports an empty first block
+        // (exactly like the generic loop below).
+        onBlockChange(blockStart, pos);
+        blockStart = pos;
+        currentValue = column[pos];
+        // All further rows can be compared bitwise against their
+        // predecessor.
+        for (++pos; pos < idTable.size(); ++pos) {
+          if ((pos & ((size_t{1} << 16) - 1)) == 0) {
+            checkCancellation();
+          }
+          if (payloads[pos] != payloads[pos - 1] ||
+              types[pos] != types[pos - 1]) {
+            onBlockChange(blockStart, pos);
+            blockStart = pos;
+            currentValue = column[pos];
+          }
+        }
+      }
+      return blockStart;
+    }
+  }
 
   for (size_t pos = 0; pos < idTable.size(); pos++) {
     checkCancellation();

--- a/src/engine/GroupByImpl.cpp
+++ b/src/engine/GroupByImpl.cpp
@@ -434,7 +434,7 @@ void GroupByImpl::processGroup(
   sparqlExpression::ExpressionResult expressionResult =
       aggregate._expression.getPimpl()->evaluate(&evaluationContext);
 
-  auto& resultEntry = result->operator()(resultRow, resultColumn);
+  auto resultEntry = result->operator()(resultRow, resultColumn);
 
   // Copy the result to the evaluation context in case one of the following
   // aliases has to reuse it.
@@ -1451,7 +1451,7 @@ GroupByImpl::substituteAllAggregates(
 template <size_t NUM_GROUP_COLUMNS>
 std::vector<size_t>
 GroupByImpl::HashMapAggregationData<NUM_GROUP_COLUMNS>::getHashEntries(
-    const ArrayOrVector<ql::span<const Id>>& groupByCols) {
+    const ArrayOrVector<columnBasedIdTable::ConstIdColumnSpan>& groupByCols) {
   AD_CONTRACT_CHECK(groupByCols.size() > 0);
 
   std::vector<size_t> hashEntries;
@@ -1817,8 +1817,8 @@ Result GroupByImpl::computeGroupByForHashMapOptimization(
       auto currentBlockSize = evaluationContext.size();
 
       // Perform HashMap lookup once for all groups in current block
-      using U = typename HashMapAggregationData<
-          NUM_GROUP_COLUMNS>::template ArrayOrVector<ql::span<const Id>>;
+      using U = typename HashMapAggregationData<NUM_GROUP_COLUMNS>::
+          template ArrayOrVector<columnBasedIdTable::ConstIdColumnSpan>;
       U groupValues;
       resizeIfVector(groupValues, columnIndices.size());
 

--- a/src/engine/GroupByImpl.h
+++ b/src/engine/GroupByImpl.h
@@ -395,7 +395,8 @@ class GroupByImpl : public Operation {
     // Returns a vector containing the offsets for all ids of `groupByCols`,
     // inserting entries if necessary.
     std::vector<size_t> getHashEntries(
-        const ArrayOrVector<ql::span<const Id>>& groupByCols);
+        const ArrayOrVector<columnBasedIdTable::ConstIdColumnSpan>&
+            groupByCols);
 
     // Return the index of `id`.
     [[nodiscard]] size_t getIndex(const ArrayOrVector<Id>& ids) const {

--- a/src/engine/IndexScan.cpp
+++ b/src/engine/IndexScan.cpp
@@ -549,7 +549,7 @@ IndexScan::lazyScanForJoinOfTwoScans(const IndexScan& s1, const IndexScan& s2) {
 // _____________________________________________________________________________
 CompressedRelationReader::IdTableGeneratorInputRange
 IndexScan::lazyScanForJoinOfColumnWithScan(
-    ql::span<const Id> joinColumn) const {
+    columnBasedIdTable::ConstIdColumnSpan joinColumn) const {
   AD_EXPENSIVE_CHECK(ql::ranges::is_sorted(joinColumn));
   AD_CORRECTNESS_CHECK(numVariables_ <= 3 && numVariables_ > 0);
 

--- a/src/engine/IndexScan.h
+++ b/src/engine/IndexScan.h
@@ -123,7 +123,8 @@ class IndexScan final : public Operation {
   // join between the first column of the result with the `joinColumn`.
   // Requires that the `joinColumn` is sorted, else the behavior is undefined.
   CompressedRelationReader::IdTableGeneratorInputRange
-  lazyScanForJoinOfColumnWithScan(ql::span<const Id> joinColumn) const;
+  lazyScanForJoinOfColumnWithScan(
+      columnBasedIdTable::ConstIdColumnSpan joinColumn) const;
 
   // Return two generators, the first of which yields exactly the elements of
   // `input` and the second of which yields the matching blocks, skipping the

--- a/src/engine/JoinImpl.cpp
+++ b/src/engine/JoinImpl.cpp
@@ -371,22 +371,22 @@ void JoinImpl::join(const IdTableView<0>& a, const IdTableView<0>& b,
 
     auto numOutOfOrder = [&]() {
       if (numUndefB == 0 && numUndefA == 0) {
-        // Fast path: If neither join column contains `LocalVocabIndex` IDs
-        // (which don't compare bitwise), the join can be performed on the
-        // datatype runs and the plain payload words of the split column
-        // storage, which is much faster than comparing materialized IDs.
-        if (columnBasedIdTable::tryZipperJoinOnDatatypeRuns(
-                joinColumnL, joinColumnR,
-                [&rowAdder](size_t leftIndex, size_t rightIndex) {
-                  rowAdder.addRow(leftIndex, rightIndex);
-                },
-                cancellationCallback)) {
-          return size_t{0};
-        }
-        return ad_utility::zipperJoinWithUndef(
-            joinColumnL, joinColumnR, ql::ranges::less{}, addRow,
-            ad_utility::noop, ad_utility::noop, {}, cancellationCallback);
-
+        // Fast path: perform the join on the datatype bytes and plain
+        // payload words of the split column storage, which is much faster
+        // than comparing materialized IDs (`LocalVocabIndex` IDs are handled
+        // gracefully inside).
+        columnBasedIdTable::zipperJoinIdColumns(
+            joinColumnL, joinColumnR,
+            [&rowAdder](size_t leftIndex, size_t rightIndex) {
+              rowAdder.addRow(leftIndex, rightIndex);
+            },
+            [&rowAdder](size_t beginLeft, size_t endLeft, size_t beginRight,
+                        size_t endRight) {
+              rowAdder.addRows(ql::views::iota(beginLeft, endLeft),
+                               ql::views::iota(beginRight, endRight));
+            },
+            ad_utility::noop, cancellationCallback);
+        return size_t{0};
       } else {
         return ad_utility::zipperJoinWithUndef(
             joinColumnL, joinColumnR, ql::ranges::less{}, addRow,

--- a/src/engine/JoinImpl.cpp
+++ b/src/engine/JoinImpl.cpp
@@ -25,6 +25,7 @@
 #include "engine/JoinHelpers.h"
 #include "engine/OperationBindPushDownImpl.h"
 #include "engine/Service.h"
+#include "engine/idTable/IdColumnAlgorithms.h"
 #include "global/Constants.h"
 #include "global/Id.h"
 #include "global/RuntimeParameters.h"
@@ -370,6 +371,18 @@ void JoinImpl::join(const IdTableView<0>& a, const IdTableView<0>& b,
 
     auto numOutOfOrder = [&]() {
       if (numUndefB == 0 && numUndefA == 0) {
+        // Fast path: If neither join column contains `LocalVocabIndex` IDs
+        // (which don't compare bitwise), the join can be performed on the
+        // datatype runs and the plain payload words of the split column
+        // storage, which is much faster than comparing materialized IDs.
+        if (columnBasedIdTable::tryZipperJoinOnDatatypeRuns(
+                joinColumnL, joinColumnR,
+                [&rowAdder](size_t leftIndex, size_t rightIndex) {
+                  rowAdder.addRow(leftIndex, rightIndex);
+                },
+                cancellationCallback)) {
+          return size_t{0};
+        }
         return ad_utility::zipperJoinWithUndef(
             joinColumnL, joinColumnR, ql::ranges::less{}, addRow,
             ad_utility::noop, ad_utility::noop, {}, cancellationCallback);

--- a/src/engine/Minus.cpp
+++ b/src/engine/Minus.cpp
@@ -128,8 +128,9 @@ auto Minus::makeUndefRangesChecker(bool left,
             info.mightContainUndef_ ==
             ColumnIndexAndTypeInfo::UndefStatus::AlwaysDefined;
         return colAlwaysDefined ||
-               ql::ranges::none_of(idTable.getColumn(tableColumn),
-                                   &Id::isUndefined);
+               ql::ranges::none_of(
+                   idTable.getColumn(tableColumn),
+                   [](const Id& id) { return id.isUndefined(); });
       });
   // Use expensive operation if one of the columns might contain undef.
   using RT = std::variant<ad_utility::Noop, ad_utility::FindSmallerUndefRanges>;

--- a/src/engine/MultiColumnJoin.cpp
+++ b/src/engine/MultiColumnJoin.cpp
@@ -243,8 +243,11 @@ void MultiColumnJoin::computeMultiColumnJoin(
   // for a later PR.
   bool isCheap = ql::ranges::none_of(joinColumns, [&](const auto& jcs) {
     auto [leftCol, rightCol] = jcs;
-    return (ql::ranges::any_of(right.getColumn(rightCol), &Id::isUndefined)) ||
-           (ql::ranges::any_of(left.getColumn(leftCol), &Id::isUndefined));
+    return (ql::ranges::any_of(
+               right.getColumn(rightCol),
+               [](const Id& id) { return id.isUndefined(); })) ||
+           (ql::ranges::any_of(left.getColumn(leftCol),
+                               [](const Id& id) { return id.isUndefined(); }));
   });
 
   auto checkCancellationLambda = [this] { checkCancellation(); };

--- a/src/engine/NamedResultCacheSerializer.h
+++ b/src/engine/NamedResultCacheSerializer.h
@@ -95,7 +95,8 @@ AD_SERIALIZE_FUNCTION_WITH_CONSTRAINT(
       // TODO<joka921> Mitigate the inconsistencies in the serializer, and then
       // allow local vocab entries here.
       AD_CORRECTNESS_CHECK(
-          ql::ranges::find(col, Datatype::LocalVocabIndex, &Id::getDatatype) ==
+          ql::ranges::find(col, Datatype::LocalVocabIndex,
+                           [](const Id& id) { return id.getDatatype(); }) ==
               col.end(),
           "Named result cache entries that contain local vocab entries "
           "currently cannot be serialized. Note that local vocab entries can "

--- a/src/engine/OptionalJoin.cpp
+++ b/src/engine/OptionalJoin.cpp
@@ -334,7 +334,8 @@ auto OptionalJoin::computeImplementationFromIdTables(
     -> Implementation {
   auto implementation = Implementation::NoUndef;
   auto anyIsUndefined = [](auto column) {
-    return ql::ranges::any_of(column, &Id::isUndefined);
+    return ql::ranges::any_of(column,
+                              [](const Id& id) { return id.isUndefined(); });
   };
   for (size_t i = 0; i < joinColumns.size(); ++i) {
     auto [leftCol, rightCol] = joinColumns.at(i);

--- a/src/engine/PathSearch.cpp
+++ b/src/engine/PathSearch.cpp
@@ -295,21 +295,29 @@ VariableToColumnMap PathSearch::computeVariableToColumnMap() const {
 };
 
 // _____________________________________________________________________________
-std::pair<ql::span<const Id>, ql::span<const Id>>
-PathSearch::handleSearchSides() const {
-  ql::span<const Id> sourceIds;
-  ql::span<const Id> targetIds;
+std::pair<std::vector<Id>, std::vector<Id>> PathSearch::handleSearchSides()
+    const {
+  std::vector<Id> sourceIds;
+  std::vector<Id> targetIds;
+
+  // Helper to materialize a column of an `IdTable` into a vector.
+  auto toVector = [](auto&& column) {
+    return std::vector<Id>(column.begin(), column.end());
+  };
 
   if (sourceAndTargetTree_.has_value()) {
     auto resultTable = sourceAndTargetTree_.value()->getResult();
-    sourceIds = resultTable->idTableView().getColumn(sourceCol_.value());
-    targetIds = resultTable->idTableView().getColumn(targetCol_.value());
-    return {sourceIds, targetIds};
+    sourceIds =
+        toVector(resultTable->idTableView().getColumn(sourceCol_.value()));
+    targetIds =
+        toVector(resultTable->idTableView().getColumn(targetCol_.value()));
+    return {std::move(sourceIds), std::move(targetIds)};
   }
 
   if (sourceTree_.has_value()) {
-    sourceIds = sourceTree_.value()->getResult()->idTableView().getColumn(
-        sourceCol_.value());
+    sourceIds =
+        toVector(sourceTree_.value()->getResult()->idTableView().getColumn(
+            sourceCol_.value()));
   } else if (config_.sourceIsVariable()) {
     sourceIds = {};
   } else {
@@ -317,8 +325,9 @@ PathSearch::handleSearchSides() const {
   }
 
   if (targetTree_.has_value()) {
-    targetIds = targetTree_.value()->getResult()->idTableView().getColumn(
-        targetCol_.value());
+    targetIds =
+        toVector(targetTree_.value()->getResult()->idTableView().getColumn(
+            targetCol_.value()));
   } else if (config_.targetIsVariable()) {
     targetIds = {};
   } else {
@@ -330,18 +339,19 @@ PathSearch::handleSearchSides() const {
 
 // _____________________________________________________________________________
 PathsLimited PathSearch::findPaths(
-    const Id& source, const std::unordered_set<uint64_t>& targets,
+    const Id& source, const std::unordered_set<Id::BitRepresentation>& targets,
     const BinSearchWrapper& binSearch,
     std::optional<uint64_t> numPathsPerTarget) const {
   std::vector<Edge> edgeStack;
   Path currentPath{EdgesLimited(allocator())};
+  using BitRep = Id::BitRepresentation;
   std::unordered_map<
-      uint64_t, uint64_t, std::hash<uint64_t>, std::equal_to<uint64_t>,
-      ad_utility::AllocatorWithLimit<std::pair<const uint64_t, uint64_t>>>
+      BitRep, uint64_t, std::hash<BitRep>, std::equal_to<BitRep>,
+      ad_utility::AllocatorWithLimit<std::pair<const BitRep, uint64_t>>>
       numPathsPerNode{allocator()};
   PathsLimited result{allocator()};
-  std::unordered_set<uint64_t, std::hash<uint64_t>, std::equal_to<uint64_t>,
-                     ad_utility::AllocatorWithLimit<uint64_t>>
+  std::unordered_set<BitRep, std::hash<BitRep>, std::equal_to<BitRep>,
+                     ad_utility::AllocatorWithLimit<BitRep>>
       visited{allocator()};
 
   visited.insert(source.getBits());
@@ -395,7 +405,7 @@ PathsLimited PathSearch::allPaths(
   Path path{EdgesLimited(allocator())};
 
   if (cartesian || sources.size() != targets.size()) {
-    std::unordered_set<uint64_t> targetSet;
+    std::unordered_set<Id::BitRepresentation> targetSet;
     for (auto target : targets) {
       targetSet.insert(target.getBits());
     }

--- a/src/engine/PathSearch.h
+++ b/src/engine/PathSearch.h
@@ -258,14 +258,15 @@ class PathSearch : public Operation {
 
   std::unique_ptr<Operation> cloneImpl() const override;
 
-  std::pair<ql::span<const Id>, ql::span<const Id>> handleSearchSides() const;
+  std::pair<std::vector<Id>, std::vector<Id>> handleSearchSides() const;
 
   /**
    * @brief Finds paths based on the configured algorithm.
    * @return A vector of paths.
    */
   pathSearch::PathsLimited findPaths(
-      const Id& source, const std::unordered_set<uint64_t>& targets,
+      const Id& source,
+      const std::unordered_set<Id::BitRepresentation>& targets,
       const pathSearch::BinSearchWrapper& binSearch,
       std::optional<uint64_t> numPathsPerTarget) const;
 

--- a/src/engine/Result.cpp
+++ b/src/engine/Result.cpp
@@ -149,8 +149,7 @@ void resizeIdTable(IdTable& idTable, const LimitOffsetClause& limitOffset) {
   ql::ranges::for_each(
       idTable.getColumns(),
       [offset = limitOffset.actualOffset(idTable.numRows()),
-       upperBound =
-           limitOffset.upperBound(idTable.numRows())](ql::span<Id> column) {
+       upperBound = limitOffset.upperBound(idTable.numRows())](auto column) {
         ql::shift_left(column.begin(), column.begin() + upperBound, offset);
       });
   // Resize the `IdTable` if necessary.

--- a/src/engine/StringMapping.cpp
+++ b/src/engine/StringMapping.cpp
@@ -57,11 +57,10 @@ Id StringMapping::remapId(Id id) {
   static_assert(checkDatatypes());
   size_t distinctIndex =
       stringMapping_.try_emplace(id, stringMapping_.size()).first->second;
-  // `Id::makeFromLocalVocabIndex` assumes that the last `numDatatypeBits` bits
-  // are all zero and then performs a right shift. We have to shift the
-  // `dinstinctIndex` left by the same amount to counter this effect.
-  return Id::makeFromLocalVocabIndex(reinterpret_cast<::LocalVocabIndex>(
-      distinctIndex << Id::numDatatypeBits));
+  // `Id::makeFromLocalVocabIndex` stores the pointer verbatim, so we can
+  // directly use the `distinctIndex` as a fake pointer.
+  return Id::makeFromLocalVocabIndex(
+      reinterpret_cast<::LocalVocabIndex>(distinctIndex));
 }
 
 }  // namespace qlever::binary_export

--- a/src/engine/TransitivePathBinSearch.cpp
+++ b/src/engine/TransitivePathBinSearch.cpp
@@ -14,12 +14,14 @@
 #include "engine/TransitivePathBase.h"
 
 // _____________________________________________________________________________
-BinSearchMap::BinSearchMap(ql::span<const Id> startIds,
-                           ql::span<const Id> targetIds,
-                           const std::optional<ql::span<const Id>>& graphIds)
+BinSearchMap::BinSearchMap(
+    columnBasedIdTable::ConstIdColumnSpan startIds,
+    columnBasedIdTable::ConstIdColumnSpan targetIds,
+    const std::optional<columnBasedIdTable::ConstIdColumnSpan>& graphIds)
     : startIds_{startIds},
       targetIds_{targetIds},
-      graphIds_{graphIds.has_value() ? graphIds.value() : ql::span<const Id>{}},
+      graphIds_{graphIds.has_value() ? graphIds.value()
+                                     : columnBasedIdTable::ConstIdColumnSpan{}},
       // Set size to zero if graphs are active to avoid undefined behaviour in
       // case we forget to call `setActiveGraph`.
       sizeOfActiveGraph_{graphIds.has_value() ? 0 : startIds_.size()} {
@@ -35,7 +37,7 @@ BinSearchMap::BinSearchMap(ql::span<const Id> startIds,
 }
 
 // _____________________________________________________________________________
-ql::span<const Id> BinSearchMap::successors(Id node) const {
+columnBasedIdTable::ConstIdColumnSpan BinSearchMap::successors(Id node) const {
   auto range = ql::ranges::equal_range(
       startIds_.subspan(offsetOfActiveGraph_, sizeOfActiveGraph_), node);
 

--- a/src/engine/TransitivePathBinSearch.h
+++ b/src/engine/TransitivePathBinSearch.h
@@ -30,9 +30,9 @@ class BinSearchMap {
   // source node. The first two ranges have the same size. The third one either
   // has the same size (for a transitive path operation inside a GRAPH clause)
   // or otherwise is empty.
-  ql::span<const Id> startIds_;
-  ql::span<const Id> targetIds_;
-  ql::span<const Id> graphIds_;
+  columnBasedIdTable::ConstIdColumnSpan startIds_;
+  columnBasedIdTable::ConstIdColumnSpan targetIds_;
+  columnBasedIdTable::ConstIdColumnSpan graphIds_;
 
   // The index of the first edge of the currently active graph and the number
   // of edges in that graph.
@@ -43,13 +43,14 @@ class BinSearchMap {
   // Construct with the given edges. The `sizeOfActiveGraph_` is set to the
   // total number of edges if no graphs are given, or to zero otherwise. In the
   // latter case, the correct size has to be set via `setGraphId`.
-  BinSearchMap(
-      ql::span<const Id> startIds, ql::span<const Id> targetIds,
-      const std::optional<ql::span<const Id>>& graphIds = std::nullopt);
+  BinSearchMap(columnBasedIdTable::ConstIdColumnSpan startIds,
+               columnBasedIdTable::ConstIdColumnSpan targetIds,
+               const std::optional<columnBasedIdTable::ConstIdColumnSpan>&
+                   graphIds = std::nullopt);
 
   // Return all target nodes for the given source node in the currently
   // active graph.
-  ql::span<const Id> successors(Id node) const;
+  columnBasedIdTable::ConstIdColumnSpan successors(Id node) const;
 
   // Find all `Id`s in `startIds_` that are equal to `id` together with the
   // corresponding graph `Id`s, with the following special cases:

--- a/src/engine/TransitivePathImpl.h
+++ b/src/engine/TransitivePathImpl.h
@@ -72,8 +72,8 @@ struct TableColumnWithVocab {
 template <typename T>
 class TransitivePathImpl : public TransitivePathBase {
   // Tuple-like class
-  using ZippedType = ql::ranges::range_value_t<
-      ::ranges::zip_view<ql::span<const Id>, ::ranges::repeat_view<Id>>>;
+  using ZippedType = ql::ranges::range_value_t<::ranges::zip_view<
+      columnBasedIdTable::ConstIdColumnSpan, ::ranges::repeat_view<Id>>>;
   using TableColumnWithVocab = detail::TableColumnWithVocab<
       ad_utility::InputRangeTypeErased<ZippedType>>;
 
@@ -353,7 +353,7 @@ class TransitivePathImpl : public TransitivePathBase {
         computeColumnsWithoutJoinColumns(joinColumn, cols, graphColumn);
     auto columnsToRange = [graphColumn = std::move(graphColumn),
                            joinColumn](const auto& idTable) {
-      ql::span<const Id> startNodes = idTable.getColumn(joinColumn);
+      auto startNodes = idTable.getColumn(joinColumn);
       return graphColumn.has_value()
                  ? InputRangeTypeErased{zipColumns(
                        startNodes, idTable.getColumn(graphColumn.value()))}
@@ -416,14 +416,14 @@ class TransitivePathImpl : public TransitivePathBase {
 
   // Create a zipped view that returns `Id::makeUndefined()` for the graph
   // column.
-  static auto padWithMissingGraph(ql::span<const Id> input) {
+  static auto padWithMissingGraph(columnBasedIdTable::ConstIdColumnSpan input) {
     return ::ranges::views::zip(input,
                                 ::ranges::views::repeat(Id::makeUndefined()));
   }
 
   // Create a zipped view from two columns.
-  static auto zipColumns(ql::span<const Id> input,
-                         ql::span<const Id> graphInput) {
+  static auto zipColumns(columnBasedIdTable::ConstIdColumnSpan input,
+                         columnBasedIdTable::ConstIdColumnSpan graphInput) {
     return ::ranges::views::zip(input, graphInput);
   }
 };

--- a/src/engine/idTable/CompressedExternalIdTable.h
+++ b/src/engine/idTable/CompressedExternalIdTable.h
@@ -14,6 +14,7 @@
 
 #include "backports/algorithm.h"
 #include "engine/CallFixedSize.h"
+#include "engine/idTable/IdColumnAlgorithms.h"
 #include "engine/idTable/IdTable.h"
 #include "util/AsyncStream.h"
 #include "util/CompressionUsingZstd/ZstdWrapper.h"
@@ -621,6 +622,15 @@ struct BlockSorter {
   [[no_unique_address]] Comparator comparator_{};
   template <typename T>
   void operator()(T& block) {
+    // Fast path: If the comparator exposes its key columns (e.g. the
+    // `SortTriple` comparators used during index building), sort via the
+    // compact key/index array instead of a comparison sort on the rows.
+    if constexpr (requires { Comparator::sortedKeyColumnIndices_; }) {
+      if (columnBasedIdTable::trySortByKeyColumnsBitwise(
+              block, Comparator::sortedKeyColumnIndices_)) {
+        return;
+      }
+    }
 #ifdef _PARALLEL_SORT
     ad_utility::parallel_sort(std::begin(block), std::end(block), comparator_);
 #else
@@ -749,12 +759,29 @@ class CompressedExternalIdTableSorter
   }
 
  private:
-  // Common implementation for the two `pushBlock` overloads above.
+  // Common implementation for the two `pushBlock` overloads above. Copy the
+  // input into the current block column-wise in chunks that respect the block
+  // size, instead of pushing the rows one by one.
   template <typename IdTableLike>
   void pushBlockImpl(const IdTableLike& block) {
     AD_CONTRACT_CHECK(block.numColumns() == this->numColumns_);
-    ql::ranges::for_each(block,
-                         [ptr = this](const auto& row) { ptr->push(row); });
+    size_t begin = 0;
+    const size_t numRows = block.numRows();
+    while (begin < numRows) {
+      auto& currentBlock = this->currentBlock_;
+      const size_t chunk =
+          std::min(this->blocksize_ - currentBlock.numRows(), numRows - begin);
+      currentBlock.insertAtEnd(block, begin, begin + chunk);
+      this->numElementsPushed_ += chunk;
+      begin += chunk;
+      if (currentBlock.size() >= this->blocksize_) {
+        // Note: Explicitly call the `pushBlock` of the base class, the
+        // `pushBlock` overloads of this class would be found first by the
+        // unqualified name lookup.
+        Base::pushBlock(std::move(currentBlock));
+        this->resetCurrentBlock(true);
+      }
+    }
   }
 
   template <typename RowGenVectorType, typename CompType>
@@ -829,6 +856,196 @@ class CompressedExternalIdTableSorter
     }
   };
 
+  // A block-based k-way merge that is used instead of the row-based
+  // `SortState` when the comparator exposes `sortedKeyColumnIndices_` (see
+  // e.g. `SortTriple` in `ExternalSortFunctors.h`). Such comparators order
+  // rows lexicographically by the bitwise `(datatype, payload)` representation
+  // of the key columns (i.e. by `Id::compareWithoutLocalVocab`), which allows
+  // two crucial optimizations:
+  // 1. Heap comparisons work directly on the raw payload and datatype arrays
+  //    of the current blocks (no materialization of row proxies or
+  //    `ValueId`s).
+  // 2. Consecutive rows from the same input that are all `<=` the smallest
+  //    row of the other inputs (found via galloping search) are copied to the
+  //    output in a single columnar `insertAtEnd` call.
+  template <size_t NumKeys>
+  struct BlockMergeState
+      : ad_utility::InputRangeMixin<BlockMergeState<NumKeys>> {
+    using Block = IdTableStatic<NumStaticCols>;
+    using BlockGenerator = ad_utility::InputRangeTypeErased<Block>;
+
+    // The state of a single sorted input: its generator of sorted blocks, the
+    // current block with the current row inside it, and raw pointers to the
+    // key columns of the current block.
+    struct Source {
+      BlockGenerator generator_;
+      std::optional<Block> block_ = std::nullopt;
+      size_t row_ = 0;
+      std::array<const uint64_t*, NumKeys> payloads_{};
+      std::array<const uint8_t*, NumKeys> types_{};
+    };
+
+    // Note: The heap only contains indices into the vector of sources, s.t.
+    // the (comparatively large) `Source` objects don't have to be moved
+    // around by the heap operations.
+    std::vector<Source> sources_;
+    std::vector<size_t> heap_;
+    std::array<size_t, NumKeys> keyColumns_;
+    bool isFinished_ = false;
+    Block result_;
+    CompressedExternalIdTableSorter* sorter_;
+    size_t numPopped_{0};
+    size_t blockSizeOutput_;
+
+    BlockMergeState(size_t numCols,
+                    const ad_utility::AllocatorWithLimit<Id>& allocator,
+                    const std::array<size_t, NumKeys>& keyColumns,
+                    std::vector<BlockGenerator> generators, size_t blockSize,
+                    CompressedExternalIdTableSorter* sorter)
+        : keyColumns_{keyColumns},
+          result_{numCols, allocator},
+          sorter_{sorter},
+          blockSizeOutput_{blockSize} {
+      sources_.reserve(generators.size());
+      for (auto& gen : generators) {
+        sources_.push_back(Source{std::move(gen)});
+      }
+    }
+
+    void start() {
+      for (size_t i = 0; i < sources_.size(); ++i) {
+        if (advanceBlock(sources_[i])) {
+          heap_.push_back(i);
+        }
+      }
+      ql::ranges::make_heap(heap_, heapComparator());
+      // Without that call, `begin() != end()` would always hold (even for
+      // empty sorters), and `*begin()` would always yield an empty block
+      // (even for non-empty sorters).
+      next();
+    }
+
+    bool isFinished() {
+      if (isFinished_) {
+        AD_CORRECTNESS_CHECK(numPopped_ == sorter_->numElementsPushed_, [this] {
+          return absl::StrCat("numPopped: ", numPopped_, "num elements pushed:",
+                              sorter_->numElementsPushed_);
+        });
+        return true;
+      } else {
+        return false;
+      }
+    }
+    auto& get() { return result_; }
+
+    void next() {
+      result_.clear();
+      result_.reserve(blockSizeOutput_);
+      const auto comparator = heapComparator();
+      while (!heap_.empty() && result_.size() < blockSizeOutput_) {
+        ql::ranges::pop_heap(heap_, comparator);
+        Source& source = sources_[heap_.back()];
+        // Determine the longest run of rows from this source that can be
+        // copied to the output before another source has to be consulted.
+        size_t runEnd = heap_.size() == 1
+                            ? source.block_->numRows()
+                            : findRunEnd(source, sources_[heap_.front()]);
+        runEnd =
+            std::min(runEnd, source.row_ + (blockSizeOutput_ - result_.size()));
+        result_.insertAtEnd(*source.block_, source.row_, runEnd);
+        source.row_ = runEnd;
+        if (source.row_ == source.block_->numRows() && !advanceBlock(source)) {
+          heap_.pop_back();
+        } else {
+          ql::ranges::push_heap(heap_, comparator);
+        }
+      }
+      numPopped_ += result_.numRows();
+      isFinished_ = result_.empty();
+    }
+
+   private:
+    // Store raw pointers to the payloads and datatypes of the key columns of
+    // the current block of the `source`.
+    void refreshColumnPointers(Source& source) {
+      for (size_t k = 0; k < NumKeys; ++k) {
+        auto column = source.block_->getColumn(keyColumns_[k]);
+        source.payloads_[k] = column.payloadSpan().data();
+        source.types_[k] = column.datatypeSpan().data();
+      }
+    }
+
+    // Compare the row `rowA` of source `a` with the current row of source `b`
+    // lexicographically by the bitwise `(datatype, payload)` representation
+    // of the key columns. Return `true` if the former is less than or equal
+    // to the latter.
+    bool rowNotGreater(const Source& a, size_t rowA, const Source& b) const {
+      for (size_t k = 0; k < NumKeys; ++k) {
+        uint8_t typeA = a.types_[k][rowA];
+        uint8_t typeB = b.types_[k][b.row_];
+        if (typeA != typeB) {
+          return typeA < typeB;
+        }
+        uint64_t payloadA = a.payloads_[k][rowA];
+        uint64_t payloadB = b.payloads_[k][b.row_];
+        if (payloadA != payloadB) {
+          return payloadA < payloadB;
+        }
+      }
+      return true;
+    }
+
+    // Return a comparator for the heap of source indices. The heap is a
+    // max-heap w.r.t. this comparator, so the comparison is inverted to
+    // obtain the source with the smallest current row at the top. As the
+    // bitwise key order is total, `b < a` is equivalent to `!(a <= b)`.
+    auto heapComparator() {
+      return [this](size_t a, size_t b) {
+        return !rowNotGreater(sources_[a], sources_[a].row_, sources_[b]);
+      };
+    }
+
+    // Return the index of the first row in the current block of `source`
+    // (starting after its current row) whose key is greater than the current
+    // row of `bound`, using galloping search. The current row of `source` is
+    // known to be `<=` the current row of `bound`.
+    size_t findRunEnd(const Source& source, const Source& bound) const {
+      const size_t numRows = source.block_->numRows();
+      size_t base = source.row_;
+      size_t step = 1;
+      while (base + step < numRows &&
+             rowNotGreater(source, base + step, bound)) {
+        base += step;
+        step *= 2;
+      }
+      size_t lo = base + 1;
+      size_t hi = std::min(base + step, numRows);
+      while (lo < hi) {
+        size_t mid = lo + (hi - lo) / 2;
+        if (rowNotGreater(source, mid, bound)) {
+          lo = mid + 1;
+        } else {
+          hi = mid;
+        }
+      }
+      return lo;
+    }
+
+    // Fetch the next nonempty block from the generator of the `source` and
+    // reset the current row. Return `false` if the source is exhausted.
+    bool advanceBlock(Source& source) {
+      do {
+        source.block_ = source.generator_.get();
+        if (!source.block_.has_value()) {
+          return false;
+        }
+      } while (source.block_->empty());
+      source.row_ = 0;
+      refreshColumnPointers(source);
+      return true;
+    }
+  };
+
   void clearUnderlying() override { this->clear(); }
   // Transition from the input phase, where `push()` may be called, to the
   // output phase and return an input range that yields the sorted elements.
@@ -871,6 +1088,26 @@ class CompressedExternalIdTableSorter
       return ad_utility::InputRangeTypeErased(std::move(chunked));
     }
 
+    // Fast path: If the comparator exposes the indices of its key columns
+    // (which implies that it sorts by the bitwise representation of those
+    // columns, see `SortTriple`), use the block-based columnar merge.
+    if constexpr (requires { Comparator::sortedKeyColumnIndices_; }) {
+      auto blockGenerators =
+          this->writer_.template getAllGenerators<NumStaticCols>();
+      const size_t blockSizeOutput = blocksize.value_or(
+          computeBlockSizeForMergePhase(blockGenerators.size()));
+      static constexpr auto keyColumns = Comparator::sortedKeyColumnIndices_;
+      auto toStaticBlock = [](auto& table) -> IdTableStatic<N> {
+        return std::move(table).template toStatic<N>();
+      };
+      using namespace ad_utility;
+      return InputRangeTypeErased{CachingTransformInputRange{
+          BlockMergeState<keyColumns.size()>{
+              this->writer_.numColumns(), this->writer_.allocator(), keyColumns,
+              std::move(blockGenerators), blockSizeOutput, this},
+          toStaticBlock}};
+    }
+
     auto rowGenerators =
         this->writer_.template getAllRowGenerators<NumStaticCols>();
 
@@ -900,6 +1137,13 @@ class CompressedExternalIdTableSorter
 
   // _____________________________________________________________
   void sortBlockInPlace(IdTableStatic<NumStaticCols>& block) const {
+    // Fast path, see `BlockSorter::operator()` above.
+    if constexpr (requires { Comparator::sortedKeyColumnIndices_; }) {
+      if (columnBasedIdTable::trySortByKeyColumnsBitwise(
+              block, Comparator::sortedKeyColumnIndices_)) {
+        return;
+      }
+    }
 #ifdef _PARALLEL_SORT
     ad_utility::parallel_sort(block.begin(), block.end(), comparator_);
 #else

--- a/src/engine/idTable/CompressedExternalIdTable.h
+++ b/src/engine/idTable/CompressedExternalIdTable.h
@@ -52,11 +52,16 @@ static constexpr ad_utility::MemorySize DEFAULT_BLOCKSIZE_EXTERNAL_ID_TABLE =
 class CompressedExternalIdTableWriter {
  private:
   // Metadata for a compressed block of bytes. A block is a contiguous part of a
-  // column of an `IdTable`.
+  // column of an `IdTable`. The compressed payload words and the compressed
+  // datatype bytes of the block are stored adjacently (first the payloads,
+  // then the datatypes).
   struct CompressedBlockMetadata {
     // The sizes are in Bytes.
     size_t compressedSize_;
-    size_t uncompressedSize_;
+    // The compressed size of only the payload part.
+    size_t compressedSizePayloads_;
+    // The number of rows (`Id`s) stored in this block.
+    size_t numRows_;
     size_t offsetInFile_;
   };
 
@@ -122,7 +127,9 @@ class CompressedExternalIdTableWriter {
           "over");
     }
     AD_CONTRACT_CHECK(table.numColumns() == numColumns());
-    size_t blockSize = blockSizeUncompressed_.getBytes() / sizeof(Id);
+    // Note: The block size is interpreted in terms of the 8-byte payload
+    // words of the IDs (the datatype bytes are a small constant overhead).
+    size_t blockSize = blockSizeUncompressed_.getBytes() / sizeof(uint64_t);
     AD_CONTRACT_CHECK(blockSize > 0);
     startOfSingleIdTables_.push_back(blocksPerColumn_.at(0).size());
     // The columns are compressed and stored in parallel.
@@ -131,26 +138,35 @@ class CompressedExternalIdTableWriter {
     // parallelism.
     std::vector<std::future<void>> compressColumFutures;
     for (auto i : ql::views::iota(0u, numColumns())) {
-      compressColumFutures.push_back(
-          std::async(std::launch::async, [this, i, blockSize, &table]() {
-            auto& blockMetadata = blocksPerColumn_.at(i);
-            decltype(auto) column = table.getColumn(i);
-            // TODO<C++23> Use `ql::views::chunkd`
-            for (size_t lower = 0; lower < column.size(); lower += blockSize) {
-              size_t upper = std::min<size_t>(lower + blockSize, column.size());
-              auto thisBlockSizeUncompressed = (upper - lower) * sizeof(Id);
-              auto compressed = ZstdWrapper::compress(
-                  column.data() + lower, thisBlockSizeUncompressed);
-              size_t offset = 0;
-              file_.withWriteLock(
-                  [&offset, &compressed](ad_utility::File& file) {
-                    offset = file.tell();
-                    file.write(compressed.data(), compressed.size());
-                  });
-              blockMetadata.push_back(
-                  {compressed.size(), thisBlockSizeUncompressed, offset});
-            }
-          }));
+      compressColumFutures.push_back(std::async(std::launch::async, [this, i,
+                                                                     blockSize,
+                                                                     &table]() {
+        auto& blockMetadata = blocksPerColumn_.at(i);
+        decltype(auto) column = table.getColumn(i);
+        // TODO<C++23> Use `ql::views::chunkd`
+        for (size_t lower = 0; lower < column.size(); lower += blockSize) {
+          size_t upper = std::min<size_t>(lower + blockSize, column.size());
+          auto numRows = upper - lower;
+          // Compress the payload words and the datatype bytes of this
+          // part of the column separately and store them adjacently.
+          auto payloads = column.payloadSpan().subspan(lower, numRows);
+          auto datatypes = column.datatypeSpan().subspan(lower, numRows);
+          auto compressedPayloads = ZstdWrapper::compress(
+              payloads.data(), payloads.size() * sizeof(payloads[0]));
+          auto compressedDatatypes = ZstdWrapper::compress(
+              datatypes.data(), datatypes.size() * sizeof(datatypes[0]));
+          size_t offset = 0;
+          file_.withWriteLock([&offset, &compressedPayloads,
+                               &compressedDatatypes](ad_utility::File& file) {
+            offset = file.tell();
+            file.write(compressedPayloads.data(), compressedPayloads.size());
+            file.write(compressedDatatypes.data(), compressedDatatypes.size());
+          });
+          blockMetadata.push_back(
+              {compressedPayloads.size() + compressedDatatypes.size(),
+               compressedPayloads.size(), numRows, offset});
+        }
+      }));
     }
     for (auto& fut : compressColumFutures) {
       fut.get();
@@ -242,19 +258,26 @@ class CompressedExternalIdTableWriter {
     AD_CORRECTNESS_CHECK(numBytesRead >= 0 &&
                          static_cast<size_t>(numBytesRead) ==
                              metaData.compressedSize_);
-    auto numBytesDecompressed =
-        ZstdWrapper::decompressToBuffer(compressed.data(), compressed.size(),
-                                        col.data(), metaData.uncompressedSize_);
-    AD_CORRECTNESS_CHECK(numBytesDecompressed == metaData.uncompressedSize_);
+    // The compressed payload words and the compressed datatype bytes are
+    // stored adjacently; decompress them separately into the split storage
+    // of the column.
+    auto sizePayloads = metaData.compressedSizePayloads_;
+    auto numRows = metaData.numRows_;
+    auto numPayloadBytes = ZstdWrapper::decompressToBuffer(
+        compressed.data(), sizePayloads, col.payloadData(),
+        numRows * sizeof(uint64_t));
+    AD_CORRECTNESS_CHECK(numPayloadBytes == numRows * sizeof(uint64_t));
+    auto numDatatypeBytes = ZstdWrapper::decompressToBuffer(
+        compressed.data() + sizePayloads, compressed.size() - sizePayloads,
+        col.datatypeData(), numRows * sizeof(uint8_t));
+    AD_CORRECTNESS_CHECK(numDatatypeBytes == numRows * sizeof(uint8_t));
   }
 
   // Allocate and size an IdTableStatic for the block at `blockIdx`.
   template <size_t NumCols = 0>
   IdTableStatic<NumCols> makeBlock(size_t blockIdx) {
     IdTableStatic<NumCols> block{numColumns(), allocator_};
-    size_t blockSize =
-        blocksPerColumn_.at(0).at(blockIdx).uncompressedSize_ / sizeof(Id);
-    block.resize(blockSize);
+    block.resize(blocksPerColumn_.at(0).at(blockIdx).numRows_);
     return block;
   }
 
@@ -344,7 +367,7 @@ CPP_class_template(size_t NumStaticCols,
   // The division by two is there because we store two blocks at the same time:
   // One that is currently being sorted and written to disk in the background,
   // and one that is used to collect rows in the calls to `push`.
-  size_t blocksize_{memory_.getBytes() / (numColumns_ * sizeof(Id) * 2)};
+  size_t blocksize_{memory_.getBytes() / (numColumns_ * sizeof(uint64_t) * 2)};
   CompressedExternalIdTableWriter writer_;
   std::future<void> compressAndWriteFuture_;
 
@@ -916,7 +939,7 @@ class CompressedExternalIdTableSorter
                    maxOutputBlocksize_);
 
       size_t blockSizeForOutput =
-          blockSizeOutputMemory.getBytes() / (sizeof(Id) * numColumns);
+          blockSizeOutputMemory.getBytes() / (sizeof(uint64_t) * numColumns);
       // If blocks are smaller than this, the performance will probably be poor
       // because of the coroutine and vector resetting overhead.
       if (blockSizeForOutput <= 10'000) {

--- a/src/engine/idTable/IdColumn.h
+++ b/src/engine/idTable/IdColumn.h
@@ -20,6 +20,7 @@
 #include "global/Id.h"
 #include "util/Enums.h"
 #include "util/Exception.h"
+#include "util/TypeTraits.h"
 
 // This file contains the types that implement the storage-efficient columns
 // of `Id`s that are used by the `IdTable` class. A materialized `ValueId`
@@ -557,9 +558,22 @@ class IdColumnVectorImpl {
            std::is_constructible_v<IdColumnVectorImpl, const Allocator&>)
   IdColumnVectorImpl(It first, It last, const Allocator& allocator)
       : IdColumnVectorImpl{allocator} {
-    reserve(static_cast<size_t>(last - first));
-    for (; first != last; ++first) {
-      push_back(*first);
+    const auto numElements = static_cast<size_t>(last - first);
+    if constexpr (ad_utility::SimilarToAny<
+                      It, IdColumnIterator<ad_utility::IsConst::False>,
+                      IdColumnIterator<ad_utility::IsConst::True>>) {
+      // Fast path for iterators into another split column: directly copy
+      // the contiguous payload and datatype arrays (`memcpy` speed). This
+      // is in particular the path taken by `IdTable::clone()`.
+      payloads_.insert(payloads_.end(), first.payloadPtr(),
+                       first.payloadPtr() + numElements);
+      types_.insert(types_.end(), first.datatypePtr(),
+                    first.datatypePtr() + numElements);
+    } else {
+      reserve(numElements);
+      for (; first != last; ++first) {
+        push_back(*first);
+      }
     }
   }
 

--- a/src/engine/idTable/IdColumn.h
+++ b/src/engine/idTable/IdColumn.h
@@ -1,0 +1,695 @@
+// Copyright 2026 The QLever Authors, in particular:
+//
+// 2026 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#ifndef QLEVER_SRC_ENGINE_IDTABLE_IDCOLUMN_H
+#define QLEVER_SRC_ENGINE_IDTABLE_IDCOLUMN_H
+
+#include <cstdint>
+#include <iterator>
+#include <memory>
+#include <vector>
+
+#include "backports/algorithm.h"
+#include "backports/span.h"
+#include "global/Id.h"
+#include "util/Enums.h"
+#include "util/Exception.h"
+
+// This file contains the types that implement the storage-efficient columns
+// of `Id`s that are used by the `IdTable` class. A materialized `ValueId`
+// consists of a full 64-bit word of payload and a single datatype byte, and
+// therefore occupies 16 bytes (including 7 padding bytes) when stored
+// directly. To avoid wasting the padding memory, a column of `Id`s is stored
+// as two separate arrays: one contiguous array for the 64-bit payloads and
+// one contiguous array for the datatype bytes (structure-of-arrays layout,
+// 9 bytes per entry).
+//
+// As a consequence, there is no contiguous array of materialized `ValueId`s
+// anymore, so (similar to `std::vector<bool>` and to the row references of
+// the `IdTable`) proxy types are required:
+//
+// - `IdRef`/`ConstIdRef`: a reference to a single `Id` inside a split
+//   column. It can be converted to and assigned from a materialized
+//   `ValueId` and mirrors the read-only interface of `ValueId`.
+// - `IdColumnIterator`: a random-access proxy iterator over a split column.
+// - `IdColumnSpan`/`ConstIdColumnSpan`: the replacement for
+//   `ql::span<Id>`/`ql::span<const Id>`, with `subspan` etc.
+// - `IdColumnVector`: the owning, dynamically growing split column (the
+//   replacement for `std::vector<Id>` as the column storage of an
+//   `IdTable`).
+//
+// Note: This file deliberately uses plain C++20 `requires` clauses (and not
+// the `CPP_...` backport macros), because the proxy machinery fundamentally
+// requires C++20 (customization points `iter_move`/`iter_swap`, constrained
+// special member functions).
+
+namespace columnBasedIdTable {
+
+// A proxy reference to a single `Id` that is stored inside a split column
+// (see above). It stores a pointer to the payload bits and a pointer to the
+// datatype byte.
+template <ad_utility::IsConst isConstTag>
+class IdRefBase {
+ public:
+  static constexpr bool isConst = isConstTag == ad_utility::IsConst::True;
+  using PayloadPtr = std::conditional_t<isConst, const uint64_t*, uint64_t*>;
+  using DatatypePtr = std::conditional_t<isConst, const uint8_t*, uint8_t*>;
+
+ private:
+  PayloadPtr payload_ = nullptr;
+  DatatypePtr datatype_ = nullptr;
+
+ public:
+  IdRefBase() = default;
+  constexpr IdRefBase(PayloadPtr payload, DatatypePtr datatype)
+      : payload_{payload}, datatype_{datatype} {}
+
+  // Implicit conversion from a mutable to a const reference. Note: This
+  // must be a template, s.t. it never collides with the copy constructor.
+  template <ad_utility::IsConst C>
+  requires(isConst && C == ad_utility::IsConst::False)
+  constexpr IdRefBase(const IdRefBase<C>& other)
+      : payload_{other.payloadPtr()}, datatype_{other.datatypePtr()} {}
+
+  // Access to the underlying pointers (mostly needed internally and for the
+  // conversion between the const and mutable variant).
+  constexpr PayloadPtr payloadPtr() const { return payload_; }
+  constexpr DatatypePtr datatypePtr() const { return datatype_; }
+
+  // Materialize the `ValueId` that this reference points to. The conversion
+  // is implicit on purpose, s.t. the proxy reference can be used like an
+  // `Id` in most places.
+  constexpr operator ValueId() const {
+    return ValueId::fromBits({*datatype_, *payload_});
+  }
+  // Explicitly materialize the `ValueId` (more readable than a
+  // `static_cast` at some call sites).
+  constexpr ValueId materialize() const { return static_cast<ValueId>(*this); }
+
+  // Assignment from a materialized `ValueId` writes through to the
+  // underlying column. Note: The assignment operator is `const`-qualified
+  // because it does not change the proxy itself, but only the underlying
+  // storage. This is also required to fulfill `std::indirectly_writable`.
+  constexpr const IdRefBase& operator=(const ValueId& id) const
+      requires(!isConst) {
+    auto bits = id.getBits();
+    *payload_ = bits.payload_;
+    *datatype_ = bits.datatype_;
+    return *this;
+  }
+
+  // The copy and move constructors copy the pointers (a copy of a reference
+  // refers to the same `Id`).
+  IdRefBase(const IdRefBase&) = default;
+  IdRefBase(IdRefBase&&) noexcept = default;
+
+  // For mutable proxy references, ALL assignments from another reference
+  // must write the referenced value through to the underlying storage (they
+  // must never rebind the pointers, which the implicitly generated
+  // assignment operators would do).
+  constexpr IdRefBase& operator=(const IdRefBase& other) requires(!isConst) {
+    *this = static_cast<ValueId>(other);
+    return *this;
+  }
+  constexpr IdRefBase& operator=(IdRefBase&& other) noexcept requires(!isConst)
+  {
+    *this = static_cast<ValueId>(other);
+    return *this;
+  }
+  constexpr const IdRefBase& operator=(const IdRefBase& other) const
+      requires(!isConst) {
+    return *this = static_cast<ValueId>(other);
+  }
+  // Assignment from a const reference to a mutable reference. Note: This
+  // must be a template, else it would collide with the copy assignment
+  // operator in the `isConst` instantiation.
+  template <ad_utility::IsConst C>
+  requires(!isConst && C == ad_utility::IsConst::True)
+  constexpr const IdRefBase& operator=(const IdRefBase<C>& other) const {
+    return *this = static_cast<ValueId>(other);
+  }
+  // Const proxy references cannot be assigned through, so the default
+  // (pointer-copying) assignment is fine for them.
+  IdRefBase& operator=(const IdRefBase& other) requires(isConst) = default;
+  IdRefBase& operator=(IdRefBase&& other) noexcept requires(isConst) = default;
+
+  // Swap the two referenced `Id`s (not the references themselves). Note:
+  // The arguments are taken by value because the proxy references are
+  // typically obtained as prvalues (e.g. from dereferencing an iterator).
+  friend constexpr void swap(IdRefBase a, IdRefBase b) requires(!isConst) {
+    std::swap(*a.payload_, *b.payload_);
+    std::swap(*a.datatype_, *b.datatype_);
+  }
+
+  // ___________________________________________________________________________
+  // Mirror the read-only interface of `ValueId`, s.t. most code that operates
+  // on `Id` values can simply use the proxy reference instead. The
+  // implementations materialize the `ValueId`, which is cheap (at most two
+  // loads).
+  constexpr Datatype getDatatype() const {
+    return static_cast<Datatype>(*datatype_);
+  }
+  constexpr ValueId::BitRepresentation getBits() const {
+    return {*datatype_, *payload_};
+  }
+  constexpr uint64_t getPayloadBits() const { return *payload_; }
+  constexpr bool isUndefined() const { return materialize().isUndefined(); }
+  ValueId::UndefinedType getUndefined() const { return {}; }
+  constexpr bool getBool() const { return materialize().getBool(); }
+  std::string_view getBoolLiteral() const {
+    return materialize().getBoolLiteral();
+  }
+  double getDouble() const { return materialize().getDouble(); }
+  int64_t getInt() const { return materialize().getInt(); }
+  constexpr VocabIndex getVocabIndex() const {
+    return materialize().getVocabIndex();
+  }
+  constexpr uint64_t getEncodedVal() const {
+    return materialize().getEncodedVal();
+  }
+  constexpr TextRecordIndex getTextRecordIndex() const {
+    return materialize().getTextRecordIndex();
+  }
+  LocalVocabIndex getLocalVocabIndex() const {
+    return materialize().getLocalVocabIndex();
+  }
+  constexpr WordVocabIndex getWordVocabIndex() const {
+    return materialize().getWordVocabIndex();
+  }
+  constexpr BlankNodeIndex getBlankNodeIndex() const {
+    return materialize().getBlankNodeIndex();
+  }
+  DateYearOrDuration getDate() const { return materialize().getDate(); }
+  GeoPoint getGeoPoint() const { return materialize().getGeoPoint(); }
+  constexpr bool isTrivial() const { return materialize().isTrivial(); }
+  constexpr bool canBeComparedBitwise() const {
+    return materialize().canBeComparedBitwise();
+  }
+  auto compareWithoutLocalVocab(const ValueId& other) const {
+    return materialize().compareWithoutLocalVocab(other);
+  }
+  template <typename Visitor>
+  decltype(auto) visit(Visitor&& visitor) const {
+    return materialize().visit(AD_FWD(visitor));
+  }
+
+  // Comparisons between two (possibly differently const) proxy references
+  // and between a proxy reference and a `ValueId`. They compare the
+  // materialized `ValueId`s. Note: The reversed and heterogeneous variants
+  // are synthesized by the C++20 rules.
+  template <ad_utility::IsConst C>
+  friend constexpr bool operator==(const IdRefBase& a, const IdRefBase<C>& b) {
+    return static_cast<ValueId>(a) == static_cast<ValueId>(b);
+  }
+  friend constexpr bool operator==(const IdRefBase& a, const ValueId& b) {
+    return static_cast<ValueId>(a) == b;
+  }
+  template <ad_utility::IsConst C>
+  friend constexpr auto operator<=>(const IdRefBase& a, const IdRefBase<C>& b) {
+    return ql::compareThreeWay(static_cast<ValueId>(a),
+                               static_cast<ValueId>(b));
+  }
+  friend constexpr auto operator<=>(const IdRefBase& a, const ValueId& b) {
+    return ql::compareThreeWay(static_cast<ValueId>(a), b);
+  }
+
+  // Support for `operator<<` (only used for debugging and testing).
+  friend std::ostream& operator<<(std::ostream& ostr, const IdRefBase& ref) {
+    return ostr << static_cast<ValueId>(ref);
+  }
+
+  // Hashing of a proxy reference hashes the referenced `Id`.
+  template <typename H>
+  friend H AbslHashValue(H h, const IdRefBase& ref) {
+    return AbslHashValue(std::move(h), static_cast<ValueId>(ref));
+  }
+};
+
+using IdRef = IdRefBase<ad_utility::IsConst::False>;
+using ConstIdRef = IdRefBase<ad_utility::IsConst::True>;
+
+// A random-access proxy iterator over a split column of `Id`s. Dereferencing
+// yields an `IdRef`/`ConstIdRef` (see above), the `value_type` is the
+// materialized `ValueId`.
+template <ad_utility::IsConst isConstTag>
+class IdColumnIterator {
+ public:
+  static constexpr bool isConst = isConstTag == ad_utility::IsConst::True;
+  using PayloadPtr = std::conditional_t<isConst, const uint64_t*, uint64_t*>;
+  using DatatypePtr = std::conditional_t<isConst, const uint8_t*, uint8_t*>;
+
+  using value_type = ValueId;
+  using reference = IdRefBase<isConstTag>;
+  using pointer = void;
+  using difference_type = std::ptrdiff_t;
+  using iterator_category = std::random_access_iterator_tag;
+  using iterator_concept = std::random_access_iterator_tag;
+
+ private:
+  PayloadPtr payload_ = nullptr;
+  DatatypePtr datatype_ = nullptr;
+
+ public:
+  IdColumnIterator() = default;
+  constexpr IdColumnIterator(PayloadPtr payload, DatatypePtr datatype)
+      : payload_{payload}, datatype_{datatype} {}
+
+  IdColumnIterator(const IdColumnIterator&) = default;
+  IdColumnIterator(IdColumnIterator&&) noexcept = default;
+  IdColumnIterator& operator=(const IdColumnIterator&) = default;
+  IdColumnIterator& operator=(IdColumnIterator&&) noexcept = default;
+
+  // Implicit conversion from a mutable to a const iterator. Note: This must
+  // be a template, s.t. it never collides with the copy constructor (which
+  // it would otherwise suppress in the mutable instantiation).
+  template <ad_utility::IsConst C>
+  requires(isConst && C == ad_utility::IsConst::False)
+  constexpr IdColumnIterator(const IdColumnIterator<C>& other)
+      : payload_{other.payloadPtr()}, datatype_{other.datatypePtr()} {}
+
+  constexpr PayloadPtr payloadPtr() const { return payload_; }
+  constexpr DatatypePtr datatypePtr() const { return datatype_; }
+
+  constexpr reference operator*() const { return {payload_, datatype_}; }
+  constexpr reference operator[](difference_type n) const {
+    return {payload_ + n, datatype_ + n};
+  }
+
+  constexpr IdColumnIterator& operator++() {
+    ++payload_;
+    ++datatype_;
+    return *this;
+  }
+  constexpr IdColumnIterator operator++(int) {
+    auto copy = *this;
+    ++*this;
+    return copy;
+  }
+  constexpr IdColumnIterator& operator--() {
+    --payload_;
+    --datatype_;
+    return *this;
+  }
+  constexpr IdColumnIterator operator--(int) {
+    auto copy = *this;
+    --*this;
+    return copy;
+  }
+  constexpr IdColumnIterator& operator+=(difference_type n) {
+    payload_ += n;
+    datatype_ += n;
+    return *this;
+  }
+  constexpr IdColumnIterator& operator-=(difference_type n) {
+    payload_ -= n;
+    datatype_ -= n;
+    return *this;
+  }
+  friend constexpr IdColumnIterator operator+(IdColumnIterator it,
+                                              difference_type n) {
+    it += n;
+    return it;
+  }
+  friend constexpr IdColumnIterator operator+(difference_type n,
+                                              IdColumnIterator it) {
+    return it + n;
+  }
+  friend constexpr IdColumnIterator operator-(IdColumnIterator it,
+                                              difference_type n) {
+    it -= n;
+    return it;
+  }
+
+  // The difference and the comparisons are also defined between const and
+  // mutable iterators.
+  template <ad_utility::IsConst C>
+  friend constexpr difference_type operator-(const IdColumnIterator& a,
+                                             const IdColumnIterator<C>& b) {
+    return a.payloadPtr() - b.payloadPtr();
+  }
+  template <ad_utility::IsConst C>
+  friend constexpr bool operator==(const IdColumnIterator& a,
+                                   const IdColumnIterator<C>& b) {
+    return a.payloadPtr() == b.payloadPtr();
+  }
+  template <ad_utility::IsConst C>
+  friend constexpr auto operator<=>(const IdColumnIterator& a,
+                                    const IdColumnIterator<C>& b) {
+    return a.payloadPtr() <=> b.payloadPtr();
+  }
+
+  // Customization points for the C++20 ranges machinery: moving out of a
+  // proxy reference materializes the `ValueId`, swapping through iterators
+  // swaps the underlying values.
+  friend constexpr ValueId iter_move(const IdColumnIterator& it) {
+    return static_cast<ValueId>(*it);
+  }
+  friend constexpr void iter_swap(const IdColumnIterator& a,
+                                  const IdColumnIterator& b) requires(!isConst)
+  {
+    swap(*a, *b);
+  }
+};
+
+// The replacement for `ql::span<Id>`/`ql::span<const Id>` on a split column:
+// a non-owning view consisting of a pointer to the payloads, a pointer to
+// the datatype bytes, and a size.
+template <ad_utility::IsConst isConstTag>
+class IdColumnSpan {
+ public:
+  static constexpr bool isConst = isConstTag == ad_utility::IsConst::True;
+  using PayloadPtr = std::conditional_t<isConst, const uint64_t*, uint64_t*>;
+  using DatatypePtr = std::conditional_t<isConst, const uint8_t*, uint8_t*>;
+
+  using value_type = ValueId;
+  using reference = IdRefBase<isConstTag>;
+  using iterator = IdColumnIterator<isConstTag>;
+  using const_iterator = IdColumnIterator<ad_utility::IsConst::True>;
+  using size_type = size_t;
+  using difference_type = std::ptrdiff_t;
+
+ private:
+  PayloadPtr payload_ = nullptr;
+  DatatypePtr datatype_ = nullptr;
+  size_t size_ = 0;
+
+ public:
+  IdColumnSpan() = default;
+  constexpr IdColumnSpan(PayloadPtr payload, DatatypePtr datatype, size_t size)
+      : payload_{payload}, datatype_{datatype}, size_{size} {}
+  constexpr IdColumnSpan(iterator begin, size_t size)
+      : payload_{begin.payloadPtr()},
+        datatype_{begin.datatypePtr()},
+        size_{size} {}
+  constexpr IdColumnSpan(iterator begin, iterator end)
+      : IdColumnSpan{begin, static_cast<size_t>(end - begin)} {}
+
+  IdColumnSpan(const IdColumnSpan&) = default;
+  IdColumnSpan(IdColumnSpan&&) noexcept = default;
+  IdColumnSpan& operator=(const IdColumnSpan&) = default;
+  IdColumnSpan& operator=(IdColumnSpan&&) noexcept = default;
+
+  // Implicit conversion from a mutable to a const span. Note: This must be a
+  // template, s.t. it never collides with the copy constructor (which it
+  // would otherwise suppress in the mutable instantiation).
+  template <ad_utility::IsConst C>
+  requires(isConst && C == ad_utility::IsConst::False)
+  constexpr IdColumnSpan(const IdColumnSpan<C>& other)
+      : payload_{other.payloadData()},
+        datatype_{other.datatypeData()},
+        size_{other.size()} {}
+
+  constexpr size_t size() const { return size_; }
+  constexpr bool empty() const { return size_ == 0; }
+
+  // Direct access to the underlying split storage. This is important for
+  // performance-critical code like compression and block I/O that wants to
+  // operate on contiguous memory.
+  constexpr PayloadPtr payloadData() const { return payload_; }
+  constexpr DatatypePtr datatypeData() const { return datatype_; }
+  constexpr ql::span<std::remove_pointer_t<PayloadPtr>> payloadSpan() const {
+    return {payload_, size_};
+  }
+  constexpr ql::span<std::remove_pointer_t<DatatypePtr>> datatypeSpan() const {
+    return {datatype_, size_};
+  }
+
+  constexpr iterator begin() const { return {payload_, datatype_}; }
+  constexpr iterator end() const {
+    return {payload_ + size_, datatype_ + size_};
+  }
+  constexpr const_iterator cbegin() const { return begin(); }
+  constexpr const_iterator cend() const { return end(); }
+
+  constexpr reference operator[](size_t i) const {
+    return {payload_ + i, datatype_ + i};
+  }
+  constexpr reference front() const { return (*this)[0]; }
+  constexpr reference back() const { return (*this)[size_ - 1]; }
+
+  // The usual `subspan`, `first`, and `last` members, analogous to
+  // `ql::span`.
+  constexpr IdColumnSpan subspan(size_t offset,
+                                 size_t count = size_t(-1)) const {
+    AD_EXPENSIVE_CHECK(offset <= size_);
+    auto actualCount = count == size_t(-1) ? size_ - offset : count;
+    AD_EXPENSIVE_CHECK(offset + actualCount <= size_);
+    return {payload_ + offset, datatype_ + offset, actualCount};
+  }
+  constexpr IdColumnSpan first(size_t count) const { return subspan(0, count); }
+  constexpr IdColumnSpan last(size_t count) const {
+    return subspan(size_ - count, count);
+  }
+};
+
+using MutableIdColumnSpan = IdColumnSpan<ad_utility::IsConst::False>;
+using ConstIdColumnSpan = IdColumnSpan<ad_utility::IsConst::True>;
+
+}  // namespace columnBasedIdTable
+
+// Opt into the C++20 ranges machinery: an `IdColumnSpan` is a cheaply
+// copyable view, and its iterators may outlive the span object itself
+// (borrowed range), exactly like `std::span`.
+template <ad_utility::IsConst C>
+inline constexpr bool
+    std::ranges::enable_view<columnBasedIdTable::IdColumnSpan<C>> = true;
+template <ad_utility::IsConst C>
+inline constexpr bool
+    std::ranges::enable_borrowed_range<columnBasedIdTable::IdColumnSpan<C>> =
+        true;
+
+// The same opt-ins for `range-v3`.
+template <ad_utility::IsConst C>
+inline constexpr bool ranges::enable_view<columnBasedIdTable::IdColumnSpan<C>> =
+    true;
+template <ad_utility::IsConst C>
+inline constexpr bool
+    ranges::enable_borrowed_range<columnBasedIdTable::IdColumnSpan<C>> = true;
+
+namespace columnBasedIdTable {
+
+// The owning, dynamically growing split column of `Id`s: the drop-in
+// replacement for `std::vector<Id>` as the column storage of an `IdTable`.
+// It is templated on the two underlying containers for the payloads and the
+// datatype bytes, s.t. it can also be instantiated with other vector-like
+// containers (e.g. `BufferedVector` for the external `IdTable`s).
+template <typename PayloadStorage, typename TypeStorage>
+class IdColumnVectorImpl {
+ public:
+  using value_type = ValueId;
+  using reference = IdRef;
+  using const_reference = ConstIdRef;
+  using iterator = IdColumnIterator<ad_utility::IsConst::False>;
+  using const_iterator = IdColumnIterator<ad_utility::IsConst::True>;
+  using size_type = size_t;
+  using difference_type = std::ptrdiff_t;
+
+ private:
+  // Helper to detect whether the underlying storages have allocators.
+  template <typename S>
+  static constexpr bool hasAllocator =
+      requires(const S& s) { s.get_allocator(); };
+
+ public:
+  // The allocator type that is exposed to the outside is the `Id`-typed
+  // allocator; it is rebound internally to the allocators of the two
+  // underlying storages.
+  template <typename A, typename U>
+  using Rebound = typename std::allocator_traits<A>::template rebind_alloc<U>;
+
+ private:
+  PayloadStorage payloads_;
+  TypeStorage types_;
+
+ public:
+  IdColumnVectorImpl() = default;
+
+  // Helper concept: `Allocator` is a type for which the rebinding to the
+  // allocators of the underlying storages may be attempted. In particular,
+  // this must not be `IdColumnVectorImpl` itself (which is probed e.g. by
+  // `std::is_constructible` checks of surrounding containers and for which
+  // computing `rebind_alloc` triggers a hard error inside
+  // `std::allocator_traits`).
+  template <typename Allocator>
+  static constexpr bool isPotentialAllocator =
+      !std::is_same_v<std::remove_cvref_t<Allocator>, IdColumnVectorImpl>;
+
+  // Constructors from an `Id`-typed allocator (rebound internally). These
+  // only participate if the underlying storages are allocator-aware.
+  template <typename Allocator>
+  requires(isPotentialAllocator<Allocator> &&
+           std::is_constructible_v<PayloadStorage,
+                                   Rebound<Allocator, uint64_t>> &&
+           std::is_constructible_v<TypeStorage, Rebound<Allocator, uint8_t>>)
+  explicit IdColumnVectorImpl(const Allocator& allocator)
+      : payloads_{Rebound<Allocator, uint64_t>{allocator}},
+        types_{Rebound<Allocator, uint8_t>{allocator}} {}
+
+  template <typename Allocator>
+  requires(isPotentialAllocator<Allocator> &&
+           std::is_constructible_v<PayloadStorage, size_t,
+                                   Rebound<Allocator, uint64_t>> &&
+           std::is_constructible_v<TypeStorage, size_t,
+                                   Rebound<Allocator, uint8_t>>)
+  IdColumnVectorImpl(size_t size, const Allocator& allocator)
+      : payloads_(size, Rebound<Allocator, uint64_t>{allocator}),
+        types_(size, Rebound<Allocator, uint8_t>{allocator}) {}
+
+  // Construct directly from the two underlying storages. They must have the
+  // same size.
+  IdColumnVectorImpl(PayloadStorage payloads, TypeStorage types)
+      : payloads_{std::move(payloads)}, types_{std::move(types)} {
+    AD_CONTRACT_CHECK(payloads_.size() == types_.size());
+  }
+
+  // Construct from an iterator range of `Id`s (or `Id` proxy references) and
+  // an `Id`-typed allocator. This is used by `IdTable::clone`.
+  template <typename It, typename Allocator>
+  requires(isPotentialAllocator<Allocator> &&
+           std::is_constructible_v<IdColumnVectorImpl, const Allocator&>)
+  IdColumnVectorImpl(It first, It last, const Allocator& allocator)
+      : IdColumnVectorImpl{allocator} {
+    reserve(static_cast<size_t>(last - first));
+    for (; first != last; ++first) {
+      push_back(*first);
+    }
+  }
+
+  IdColumnVectorImpl(const IdColumnVectorImpl&) = default;
+  IdColumnVectorImpl(IdColumnVectorImpl&&) noexcept = default;
+  IdColumnVectorImpl& operator=(const IdColumnVectorImpl&) = default;
+  IdColumnVectorImpl& operator=(IdColumnVectorImpl&&) noexcept = default;
+
+  // Return the `Id`-typed allocator (rebound from the allocator of the
+  // payload storage).
+  auto get_allocator() const requires hasAllocator<PayloadStorage> {
+    using A = std::decay_t<decltype(payloads_.get_allocator())>;
+    return Rebound<A, ValueId>{payloads_.get_allocator()};
+  }
+
+  constexpr size_t size() const { return payloads_.size(); }
+  constexpr bool empty() const { return payloads_.empty(); }
+  size_t capacity() const { return payloads_.capacity(); }
+
+  void resize(size_t newSize) {
+    payloads_.resize(newSize);
+    types_.resize(newSize);
+  }
+  void reserve(size_t newCapacity) {
+    payloads_.reserve(newCapacity);
+    types_.reserve(newCapacity);
+  }
+  void clear() {
+    payloads_.clear();
+    types_.clear();
+  }
+  void shrink_to_fit() {
+    payloads_.shrink_to_fit();
+    types_.shrink_to_fit();
+  }
+
+  void push_back(const ValueId& id) {
+    auto bits = id.getBits();
+    payloads_.push_back(bits.payload_);
+    types_.push_back(bits.datatype_);
+  }
+  // Append a new (uninitialized or zeroed, depending on the underlying
+  // storages) `Id` at the end.
+  void emplace_back() {
+    payloads_.emplace_back();
+    types_.emplace_back();
+  }
+
+  reference operator[](size_t i) {
+    return {payloads_.data() + i, types_.data() + i};
+  }
+  const_reference operator[](size_t i) const {
+    return {payloads_.data() + i, types_.data() + i};
+  }
+  reference at(size_t i) {
+    AD_CONTRACT_CHECK(i < size());
+    return (*this)[i];
+  }
+  const_reference at(size_t i) const {
+    AD_CONTRACT_CHECK(i < size());
+    return (*this)[i];
+  }
+  reference front() { return (*this)[0]; }
+  const_reference front() const { return (*this)[0]; }
+  reference back() { return (*this)[size() - 1]; }
+  const_reference back() const { return (*this)[size() - 1]; }
+
+  iterator begin() { return {payloads_.data(), types_.data()}; }
+  iterator end() { return {payloads_.data() + size(), types_.data() + size()}; }
+  const_iterator begin() const { return {payloads_.data(), types_.data()}; }
+  const_iterator end() const {
+    return {payloads_.data() + size(), types_.data() + size()};
+  }
+  const_iterator cbegin() const { return begin(); }
+  const_iterator cend() const { return end(); }
+
+  // Erase the elements in `[first, last)`, analogous to `std::vector::erase`.
+  void erase(const_iterator first, const_iterator last) {
+    auto beginIdx = static_cast<size_t>(first - cbegin());
+    auto endIdx = static_cast<size_t>(last - cbegin());
+    payloads_.erase(payloads_.begin() + beginIdx, payloads_.begin() + endIdx);
+    types_.erase(types_.begin() + beginIdx, types_.begin() + endIdx);
+  }
+
+  // Insert the range `[first, last)` (iterators into another split column)
+  // before `pos`. This directly copies the underlying payload and datatype
+  // arrays, which is much faster than an elementwise copy.
+  template <ad_utility::IsConst C>
+  void insert(const_iterator pos, IdColumnIterator<C> first,
+              IdColumnIterator<C> last) {
+    auto posIdx = static_cast<size_t>(pos - cbegin());
+    payloads_.insert(payloads_.begin() + posIdx, first.payloadPtr(),
+                     last.payloadPtr());
+    types_.insert(types_.begin() + posIdx, first.datatypePtr(),
+                  last.datatypePtr());
+  }
+
+  // Direct access to the underlying split storage.
+  uint64_t* payloadData() { return payloads_.data(); }
+  const uint64_t* payloadData() const { return payloads_.data(); }
+  uint8_t* datatypeData() { return types_.data(); }
+  const uint8_t* datatypeData() const { return types_.data(); }
+  PayloadStorage& payloads() { return payloads_; }
+  const PayloadStorage& payloads() const { return payloads_; }
+  TypeStorage& types() { return types_; }
+  const TypeStorage& types() const { return types_; }
+
+  // Conversion to the non-owning span types.
+  operator MutableIdColumnSpan() {
+    return {payloads_.data(), types_.data(), size()};
+  }
+  operator ConstIdColumnSpan() const {
+    return {payloads_.data(), types_.data(), size()};
+  }
+
+  bool operator==(const IdColumnVectorImpl& other) const {
+    return payloads_ == other.payloads_ && types_ == other.types_;
+  }
+};
+
+// The default owning split column, templated on an `Id`-typed allocator.
+// Note: If default initialization (no zeroing on `resize`) is desired, then
+// an allocator that is already wrapped in
+// `ad_utility::default_init_allocator` must be passed (the rebinding
+// preserves the wrapper).
+template <typename Allocator = std::allocator<Id>>
+using IdColumnVector = IdColumnVectorImpl<
+    std::vector<uint64_t, typename std::allocator_traits<
+                              Allocator>::template rebind_alloc<uint64_t>>,
+    std::vector<uint8_t, typename std::allocator_traits<
+                             Allocator>::template rebind_alloc<uint8_t>>>;
+
+}  // namespace columnBasedIdTable
+
+#endif  // QLEVER_SRC_ENGINE_IDTABLE_IDCOLUMN_H

--- a/src/engine/idTable/IdColumn.h
+++ b/src/engine/idTable/IdColumn.h
@@ -435,15 +435,17 @@ class IdColumnSpan {
 
   // The usual `subspan`, `first`, and `last` members, analogous to
   // `ql::span`.
-  constexpr IdColumnSpan subspan(size_t offset,
-                                 size_t count = size_t(-1)) const {
+  // Note: The following functions are not `constexpr`, because the check
+  // macros call non-`constexpr` functions (GCC rejects this with
+  // `-Winvalid-constexpr`).
+  IdColumnSpan subspan(size_t offset, size_t count = size_t(-1)) const {
     AD_EXPENSIVE_CHECK(offset <= size_);
     auto actualCount = count == size_t(-1) ? size_ - offset : count;
     AD_EXPENSIVE_CHECK(offset + actualCount <= size_);
     return {payload_ + offset, datatype_ + offset, actualCount};
   }
-  constexpr IdColumnSpan first(size_t count) const { return subspan(0, count); }
-  constexpr IdColumnSpan last(size_t count) const {
+  IdColumnSpan first(size_t count) const { return subspan(0, count); }
+  IdColumnSpan last(size_t count) const {
     return subspan(size_ - count, count);
   }
 };

--- a/src/engine/idTable/IdColumnAlgorithms.h
+++ b/src/engine/idTable/IdColumnAlgorithms.h
@@ -36,131 +36,226 @@
 
 namespace columnBasedIdTable {
 
-// A contiguous range `[begin_, end_)` of positions of a column that all have
-// the same datatype.
-struct DatatypeRun {
-  Datatype type_;
-  size_t begin_;
-  size_t end_;
-};
-
-// Compute the runs of equal datatypes of the `column`. For columns that are
-// sorted in the datatype-major ID order this yields at most one run per
-// datatype. This is a single cheap pass over the datatype bytes.
-inline std::vector<DatatypeRun> computeDatatypeRuns(ConstIdColumnSpan column) {
-  std::vector<DatatypeRun> runs;
-  auto types = column.datatypeSpan();
-  size_t i = 0;
-  while (i < types.size()) {
-    uint8_t type = types[i];
-    // Find the end of the run. `memchr`-style scanning would also be
-    // possible, but this loop is already memory-bound and vectorizes well.
-    size_t end = i + 1;
-    while (end < types.size() && types[end] == type) {
-      ++end;
-    }
-    runs.push_back({static_cast<Datatype>(type), i, end});
-    i = end;
-  }
-  return runs;
-}
-
-// Return true iff any of the `runs` has the `LocalVocabIndex` datatype.
-inline bool anyRunIsLocalVocab(const std::vector<DatatypeRun>& runs) {
-  return std::any_of(runs.begin(), runs.end(), [](const DatatypeRun& run) {
-    return run.type_ == Datatype::LocalVocabIndex;
-  });
-}
-
 // Try to perform a merge/zipper join of two sorted columns without UNDEF
-// values. On success, call `addRow(leftIndex, rightIndex)` for each matching
-// pair of positions (in the same order as the generic zipper join) and
-// return `true`. Return `false` without calling `addRow` if any of the
-// columns contains IDs of type `LocalVocabIndex` (see above); the caller
-// then has to use the generic join.
+// values. Call `addRow(leftIndex, rightIndex)` for single matching pairs and
+// `addRows(leftBegin, leftEnd, rightBegin, rightEnd)` for the Cartesian
+// product of groups of equal elements, in the same order as the generic
+// zipper join. `notFoundAction(leftIndex)` is called for all elements of the
+// left column without a matching element in the right column (pass
+// `ad_utility::noop` unless this is an OPTIONAL join or a MINUS).
 //
-// The join first merges the datatype runs of the two columns (runs of
-// datatypes that only appear on one side are skipped in O(1)) and then joins
-// the runs of equal datatypes on the plain payload words.
-CPP_template(typename AddRow, typename CancelCallback)(
+// The algorithm compares the datatype bytes and payload words of the split
+// column storage directly and thus avoids materializing `Id`s in the hot
+// loop. IDs of type `LocalVocabIndex` (which do not compare bitwise, but by
+// their position in the vocabulary) are handled gracefully: the columns are
+// processed in maximal chunks that contain no `LocalVocabIndex` IDs (these
+// chunks are joined by the fast bitwise loop), and only the elements at and
+// around the `LocalVocabIndex` positions are compared with the semantic `Id`
+// comparison.
+CPP_template(typename AddRow, typename AddRows, typename NotFoundAction,
+             typename CancelCallback)(
     requires ql::concepts::invocable<AddRow, size_t, size_t> CPP_and
-        ql::concepts::invocable<
-            CancelCallback>) bool tryZipperJoinOnDatatypeRuns(ConstIdColumnSpan
+        ql::concepts::invocable<AddRows, size_t, size_t, size_t, size_t>
+            CPP_and ql::concepts::invocable<NotFoundAction, size_t>
+                CPP_and ql::concepts::invocable<
+                    CancelCallback>) void zipperJoinIdColumns(ConstIdColumnSpan
                                                                   left,
                                                               ConstIdColumnSpan
                                                                   right,
                                                               AddRow addRow,
+                                                              AddRows addRows,
+                                                              NotFoundAction
+                                                                  notFoundAction,
                                                               CancelCallback
                                                                   cancelCallback) {
-  auto runsLeft = computeDatatypeRuns(left);
-  auto runsRight = computeDatatypeRuns(right);
-  if (anyRunIsLocalVocab(runsLeft) || anyRunIsLocalVocab(runsRight)) {
-    return false;
-  }
+  constexpr uint8_t localVocabType =
+      static_cast<uint8_t>(Datatype::LocalVocabIndex);
+  const auto typesLeft = left.datatypeSpan();
+  const auto typesRight = right.datatypeSpan();
+  const auto payloadsLeft = left.payloadSpan();
+  const auto payloadsRight = right.payloadSpan();
+  const size_t numLeft = left.size();
+  const size_t numRight = right.size();
 
-  auto payloadsLeft = left.payloadSpan();
-  auto payloadsRight = right.payloadSpan();
+  auto makeId = [](uint8_t type, uint64_t payload) {
+    return Id::fromBits({type, payload});
+  };
 
-  // Join two runs of the same datatype on the plain payloads. This is a
-  // classic merge join on `uint64_t` values, including the cross product for
-  // duplicate values.
-  size_t stepsUntilCancelCheck = 0;
-  auto joinRuns = [&](const DatatypeRun& runLeft, const DatatypeRun& runRight) {
-    size_t l = runLeft.begin_;
-    size_t r = runRight.begin_;
-    while (l < runLeft.end_ && r < runRight.end_) {
-      if (++stepsUntilCancelCheck >= (1ull << 20)) {
-        stepsUntilCancelCheck = 0;
-        cancelCallback();
+  // Return the position of the next ID of type `LocalVocabIndex` at or after
+  // the position `from` (or the size of the column if there is none).
+  auto nextLocalVocab = [](ql::span<const uint8_t> types, size_t from) {
+    const void* pointer =
+        std::memchr(types.data() + from, localVocabType, types.size() - from);
+    return pointer == nullptr
+               ? types.size()
+               : static_cast<size_t>(static_cast<const uint8_t*>(pointer) -
+                                     types.data());
+  };
+
+  // Return the end of the group of elements that compare equal to the
+  // element at position `group`. The group is first extended bitwise; if the
+  // group then borders an ID of type `LocalVocabIndex` (or starts with one),
+  // it is extended further using the semantic `Id` comparison (groups of
+  // equivalent elements can contain interleaved `LocalVocabIndex` and
+  // `VocabIndex`/`EncodedVal` IDs with different bit representations).
+  auto groupEnd = [&makeId](ql::span<const uint8_t> types,
+                            ql::span<const uint64_t> payloads, size_t numRows,
+                            size_t group) {
+    size_t end = group + 1;
+    while (end < numRows && types[end] == types[group] &&
+           payloads[end] == payloads[group]) {
+      ++end;
+    }
+    if (end < numRows &&
+        (types[end] == localVocabType || types[group] == localVocabType)) {
+      Id representative = makeId(types[group], payloads[group]);
+      while (end < numRows &&
+             representative == makeId(types[end], payloads[end])) {
+        ++end;
       }
-      uint64_t valueLeft = payloadsLeft[l];
-      uint64_t valueRight = payloadsRight[r];
-      if (valueLeft < valueRight) {
+    }
+    return end;
+  };
+
+  size_t l = 0;
+  size_t r = 0;
+  // Cached positions of the next `LocalVocabIndex` IDs. They are recomputed
+  // lazily, s.t. the total cost of all the `memchr` calls stays linear.
+  size_t nextLocalVocabLeft = nextLocalVocab(typesLeft, 0);
+  size_t nextLocalVocabRight = nextLocalVocab(typesRight, 0);
+  size_t stepsUntilCancelCheck = 0;
+
+  // Return the end of the run of equal datatype bytes that starts at `begin`
+  // (bounded by `end`).
+  auto typeRunEnd = [](ql::span<const uint8_t> types, size_t begin,
+                       size_t end) {
+    uint8_t type = types[begin];
+    size_t position = begin + 1;
+    while (position < end && types[position] == type) {
+      ++position;
+    }
+    return position;
+  };
+
+  while (l < numLeft && r < numRight) {
+    if (nextLocalVocabLeft < l) {
+      nextLocalVocabLeft = nextLocalVocab(typesLeft, l);
+    }
+    if (nextLocalVocabRight < r) {
+      nextLocalVocabRight = nextLocalVocab(typesRight, r);
+    }
+
+    // Phase 1: Bitwise merging of the chunks before the next
+    // `LocalVocabIndex` IDs. The chunks are further subdivided into runs of
+    // equal datatypes: runs of a datatype that only appears on one side are
+    // skipped wholesale, and runs of equal datatypes are joined with a
+    // payload-only merge loop (a single 64-bit comparison per step, exactly
+    // as fast as with packed 64-bit IDs).
+    bool groupTouchesChunkEnd = false;
+    while (l < nextLocalVocabLeft && r < nextLocalVocabRight &&
+           !groupTouchesChunkEnd) {
+      uint8_t typeLeft = typesLeft[l];
+      uint8_t typeRight = typesRight[r];
+      if (typeLeft != typeRight) {
+        // The datatype-major ID order guarantees that the smaller type run
+        // has no matches on the other side, so it can be skipped completely.
+        if (typeLeft < typeRight) {
+          size_t runEnd = typeRunEnd(typesLeft, l, nextLocalVocabLeft);
+          for (; l < runEnd; ++l) {
+            notFoundAction(l);
+          }
+        } else {
+          r = typeRunEnd(typesRight, r, nextLocalVocabRight);
+        }
+        continue;
+      }
+      // Both current elements have the same datatype: merge the two type
+      // runs on the payloads only.
+      const size_t runEndLeft = typeRunEnd(typesLeft, l, nextLocalVocabLeft);
+      const size_t runEndRight = typeRunEnd(typesRight, r, nextLocalVocabRight);
+      while (l < runEndLeft && r < runEndRight) {
+        if (++stepsUntilCancelCheck >= (1ull << 20)) {
+          stepsUntilCancelCheck = 0;
+          cancelCallback();
+        }
+        uint64_t payloadLeft = payloadsLeft[l];
+        uint64_t payloadRight = payloadsRight[r];
+        if (payloadLeft < payloadRight) {
+          notFoundAction(l);
+          ++l;
+        } else if (payloadRight < payloadLeft) {
+          ++r;
+        } else {
+          // Find the ranges of equal payloads on both sides. Note: The
+          // scans stop at the run ends, which is correct because the
+          // elements there differ in their datatype byte.
+          size_t endLeft = l + 1;
+          while (endLeft < runEndLeft && payloadsLeft[endLeft] == payloadLeft) {
+            ++endLeft;
+          }
+          size_t endRight = r + 1;
+          while (endRight < runEndRight &&
+                 payloadsRight[endRight] == payloadRight) {
+            ++endRight;
+          }
+          // If a group extends up to a following `LocalVocabIndex` ID, the
+          // group might semantically continue there, so it must be handled
+          // by the semantic phase below.
+          if ((endLeft == nextLocalVocabLeft && endLeft < numLeft) ||
+              (endRight == nextLocalVocabRight && endRight < numRight)) {
+            groupTouchesChunkEnd = true;
+            break;
+          }
+          if (endLeft == l + 1 && endRight == r + 1) {
+            addRow(l, r);
+          } else {
+            addRows(l, endLeft, r, endRight);
+          }
+          l = endLeft;
+          r = endRight;
+        }
+      }
+    }
+    if (l >= numLeft || r >= numRight) {
+      break;
+    }
+
+    // Phase 2: Semantic merging. Compare the current elements as `Id`s
+    // (this correctly handles IDs of type `LocalVocabIndex`) and process
+    // single elements or whole groups of equivalent elements. Keep going as
+    // long as one of the current elements is of type `LocalVocabIndex`
+    // (this processes contiguous regions of `LocalVocabIndex` IDs in one
+    // tight loop).
+    do {
+      cancelCallback();
+      Id idLeft = makeId(typesLeft[l], payloadsLeft[l]);
+      Id idRight = makeId(typesRight[r], payloadsRight[r]);
+      auto comparison = idLeft.compareThreeWay(idRight);
+      if (comparison < 0) {
+        notFoundAction(l);
         ++l;
-      } else if (valueRight < valueLeft) {
+      } else if (comparison > 0) {
         ++r;
       } else {
-        // Find the ranges of equal values on both sides and add their cross
-        // product.
-        size_t endLeft = l + 1;
-        while (endLeft < runLeft.end_ && payloadsLeft[endLeft] == valueLeft) {
-          ++endLeft;
-        }
-        size_t endRight = r + 1;
-        while (endRight < runRight.end_ &&
-               payloadsRight[endRight] == valueLeft) {
-          ++endRight;
-        }
-        for (size_t i = l; i < endLeft; ++i) {
-          for (size_t j = r; j < endRight; ++j) {
-            addRow(i, j);
-          }
+        size_t endLeft = groupEnd(typesLeft, payloadsLeft, numLeft, l);
+        size_t endRight = groupEnd(typesRight, payloadsRight, numRight, r);
+        if (endLeft == l + 1 && endRight == r + 1) {
+          addRow(l, r);
+        } else {
+          addRows(l, endLeft, r, endRight);
         }
         l = endLeft;
         r = endRight;
       }
-    }
-  };
-
-  // Merge the datatype runs. Note: The datatype-major ID order guarantees
-  // that the runs of a sorted column are sorted by their datatype.
-  size_t indexLeft = 0;
-  size_t indexRight = 0;
-  while (indexLeft < runsLeft.size() && indexRight < runsRight.size()) {
-    cancelCallback();
-    const auto& runLeft = runsLeft[indexLeft];
-    const auto& runRight = runsRight[indexRight];
-    if (runLeft.type_ < runRight.type_) {
-      ++indexLeft;
-    } else if (runRight.type_ < runLeft.type_) {
-      ++indexRight;
-    } else {
-      joinRuns(runLeft, runRight);
-      ++indexLeft;
-      ++indexRight;
-    }
+    } while (
+        l < numLeft && r < numRight &&
+        (typesLeft[l] == localVocabType || typesRight[r] == localVocabType));
   }
-  return true;
+  // Report the unmatched trailing elements of the left column (relevant for
+  // OPTIONAL joins and MINUS).
+  for (; l < numLeft; ++l) {
+    notFoundAction(l);
+  }
 }
 
 // Try to sort the `table` by the single column with index `keyColumn`. On

--- a/src/engine/idTable/IdColumnAlgorithms.h
+++ b/src/engine/idTable/IdColumnAlgorithms.h
@@ -1,0 +1,252 @@
+// Copyright 2026 The QLever Authors, in particular:
+//
+// 2026 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#ifndef QLEVER_SRC_ENGINE_IDTABLE_IDCOLUMNALGORITHMS_H
+#define QLEVER_SRC_ENGINE_IDTABLE_IDCOLUMNALGORITHMS_H
+
+#include <algorithm>
+#include <cstring>
+#include <vector>
+
+#include "backports/concepts.h"
+#include "engine/idTable/IdColumn.h"
+#include "engine/idTable/IdTable.h"
+#include "global/Constants.h"
+#include "global/Id.h"
+
+// This file contains algorithms that exploit the split storage layout of the
+// `Id` columns (see `IdColumn.h`): because the datatype bytes and the payload
+// words are stored in separate contiguous arrays, algorithms on sorted
+// columns can first cheaply partition the input into runs of equal datatypes
+// and then work on the plain `uint64_t` payloads only. This makes the hot
+// loops as fast as with the previous packed 64-bit ID layout (or faster,
+// because the datatype handling is amortized per run instead of per element).
+//
+// IMPORTANT: All algorithms in this file compare IDs bitwise. They must
+// therefore only be used if the involved columns contain no IDs of type
+// `LocalVocabIndex` (those compare by their position in the vocabulary, not
+// by their bits). All entry points below therefore detect this case and
+// report it, s.t. the caller can fall back to the generic implementation.
+
+namespace columnBasedIdTable {
+
+// A contiguous range `[begin_, end_)` of positions of a column that all have
+// the same datatype.
+struct DatatypeRun {
+  Datatype type_;
+  size_t begin_;
+  size_t end_;
+};
+
+// Compute the runs of equal datatypes of the `column`. For columns that are
+// sorted in the datatype-major ID order this yields at most one run per
+// datatype. This is a single cheap pass over the datatype bytes.
+inline std::vector<DatatypeRun> computeDatatypeRuns(ConstIdColumnSpan column) {
+  std::vector<DatatypeRun> runs;
+  auto types = column.datatypeSpan();
+  size_t i = 0;
+  while (i < types.size()) {
+    uint8_t type = types[i];
+    // Find the end of the run. `memchr`-style scanning would also be
+    // possible, but this loop is already memory-bound and vectorizes well.
+    size_t end = i + 1;
+    while (end < types.size() && types[end] == type) {
+      ++end;
+    }
+    runs.push_back({static_cast<Datatype>(type), i, end});
+    i = end;
+  }
+  return runs;
+}
+
+// Return true iff any of the `runs` has the `LocalVocabIndex` datatype.
+inline bool anyRunIsLocalVocab(const std::vector<DatatypeRun>& runs) {
+  return std::any_of(runs.begin(), runs.end(), [](const DatatypeRun& run) {
+    return run.type_ == Datatype::LocalVocabIndex;
+  });
+}
+
+// Try to perform a merge/zipper join of two sorted columns without UNDEF
+// values. On success, call `addRow(leftIndex, rightIndex)` for each matching
+// pair of positions (in the same order as the generic zipper join) and
+// return `true`. Return `false` without calling `addRow` if any of the
+// columns contains IDs of type `LocalVocabIndex` (see above); the caller
+// then has to use the generic join.
+//
+// The join first merges the datatype runs of the two columns (runs of
+// datatypes that only appear on one side are skipped in O(1)) and then joins
+// the runs of equal datatypes on the plain payload words.
+CPP_template(typename AddRow, typename CancelCallback)(
+    requires ql::concepts::invocable<AddRow, size_t, size_t> CPP_and
+        ql::concepts::invocable<
+            CancelCallback>) bool tryZipperJoinOnDatatypeRuns(ConstIdColumnSpan
+                                                                  left,
+                                                              ConstIdColumnSpan
+                                                                  right,
+                                                              AddRow addRow,
+                                                              CancelCallback
+                                                                  cancelCallback) {
+  auto runsLeft = computeDatatypeRuns(left);
+  auto runsRight = computeDatatypeRuns(right);
+  if (anyRunIsLocalVocab(runsLeft) || anyRunIsLocalVocab(runsRight)) {
+    return false;
+  }
+
+  auto payloadsLeft = left.payloadSpan();
+  auto payloadsRight = right.payloadSpan();
+
+  // Join two runs of the same datatype on the plain payloads. This is a
+  // classic merge join on `uint64_t` values, including the cross product for
+  // duplicate values.
+  size_t stepsUntilCancelCheck = 0;
+  auto joinRuns = [&](const DatatypeRun& runLeft, const DatatypeRun& runRight) {
+    size_t l = runLeft.begin_;
+    size_t r = runRight.begin_;
+    while (l < runLeft.end_ && r < runRight.end_) {
+      if (++stepsUntilCancelCheck >= (1ull << 20)) {
+        stepsUntilCancelCheck = 0;
+        cancelCallback();
+      }
+      uint64_t valueLeft = payloadsLeft[l];
+      uint64_t valueRight = payloadsRight[r];
+      if (valueLeft < valueRight) {
+        ++l;
+      } else if (valueRight < valueLeft) {
+        ++r;
+      } else {
+        // Find the ranges of equal values on both sides and add their cross
+        // product.
+        size_t endLeft = l + 1;
+        while (endLeft < runLeft.end_ && payloadsLeft[endLeft] == valueLeft) {
+          ++endLeft;
+        }
+        size_t endRight = r + 1;
+        while (endRight < runRight.end_ &&
+               payloadsRight[endRight] == valueLeft) {
+          ++endRight;
+        }
+        for (size_t i = l; i < endLeft; ++i) {
+          for (size_t j = r; j < endRight; ++j) {
+            addRow(i, j);
+          }
+        }
+        l = endLeft;
+        r = endRight;
+      }
+    }
+  };
+
+  // Merge the datatype runs. Note: The datatype-major ID order guarantees
+  // that the runs of a sorted column are sorted by their datatype.
+  size_t indexLeft = 0;
+  size_t indexRight = 0;
+  while (indexLeft < runsLeft.size() && indexRight < runsRight.size()) {
+    cancelCallback();
+    const auto& runLeft = runsLeft[indexLeft];
+    const auto& runRight = runsRight[indexRight];
+    if (runLeft.type_ < runRight.type_) {
+      ++indexLeft;
+    } else if (runRight.type_ < runLeft.type_) {
+      ++indexRight;
+    } else {
+      joinRuns(runLeft, runRight);
+      ++indexLeft;
+      ++indexRight;
+    }
+  }
+  return true;
+}
+
+// Try to sort the `table` by the single column with index `keyColumn`. On
+// success return `true`. Return `false` without modifying the table if the
+// key column contains IDs of type `LocalVocabIndex` (see above); the caller
+// then has to use the generic sort.
+//
+// The sort works as follows:
+// 1. Partition the (payload, rowIndex) pairs of the key column by their
+//    datatype using a counting sort on the datatype bytes.
+// 2. Sort each datatype partition by the plain payload words (which is
+//    exactly the datatype-major ID order within a partition).
+// 3. Apply the resulting permutation to all columns of the table, one column
+//    at a time (gather into a scratch buffer, then copy back). This avoids
+//    the expensive row-wise swaps of the comparison sort, which have to
+//    touch all payload and datatype buffers of the table for every swap.
+inline bool trySortBySingleKeyColumn(::IdTable& table, ColumnIndex keyColumn) {
+  const size_t numRows = table.numRows();
+  if (numRows == 0) {
+    return true;
+  }
+  auto key = std::as_const(table).getColumn(keyColumn);
+  auto keyTypes = key.datatypeSpan();
+  auto keyPayloads = key.payloadSpan();
+  if (std::memchr(keyTypes.data(), static_cast<int>(Datatype::LocalVocabIndex),
+                  keyTypes.size()) != nullptr) {
+    return false;
+  }
+
+  // Step 1: Counting sort of the (payload, rowIndex) pairs by datatype.
+  struct PayloadAndIndex {
+    uint64_t payload_;
+    uint64_t index_;
+  };
+  std::array<size_t, 256> counts{};
+  for (uint8_t type : keyTypes) {
+    ++counts[type];
+  }
+  std::array<size_t, 257> offsets{};
+  for (size_t t = 0; t < 256; ++t) {
+    offsets[t + 1] = offsets[t] + counts[t];
+  }
+  std::vector<PayloadAndIndex> permutation(numRows);
+  {
+    std::array<size_t, 256> positions{};
+    std::copy(offsets.begin(), offsets.end() - 1, positions.begin());
+    for (size_t i = 0; i < numRows; ++i) {
+      permutation[positions[keyTypes[i]]++] = {keyPayloads[i], i};
+    }
+  }
+
+  // Step 2: Sort each datatype partition by the payload.
+  auto comparator = [](const PayloadAndIndex& a, const PayloadAndIndex& b) {
+    return a.payload_ < b.payload_;
+  };
+  for (size_t t = 0; t < 256; ++t) {
+    if (counts[t] > 1) {
+      auto begin = permutation.begin() + offsets[t];
+      auto end = permutation.begin() + offsets[t + 1];
+      if constexpr (USE_PARALLEL_SORT) {
+        ad_utility::parallel_sort(begin, end, comparator,
+                                  ad_utility::parallel_tag(NUM_SORT_THREADS));
+      } else {
+        std::sort(begin, end, comparator);
+      }
+    }
+  }
+
+  // Step 3: Apply the permutation to all columns, one column at a time.
+  std::vector<uint64_t> scratchPayloads(numRows);
+  std::vector<uint8_t> scratchTypes(numRows);
+  for (size_t c = 0; c < table.numColumns(); ++c) {
+    auto column = table.getColumn(c);
+    auto payloads = column.payloadSpan();
+    auto types = column.datatypeSpan();
+    for (size_t i = 0; i < numRows; ++i) {
+      scratchPayloads[i] = payloads[permutation[i].index_];
+      scratchTypes[i] = types[permutation[i].index_];
+    }
+    std::memcpy(payloads.data(), scratchPayloads.data(),
+                numRows * sizeof(uint64_t));
+    std::memcpy(types.data(), scratchTypes.data(), numRows * sizeof(uint8_t));
+  }
+  return true;
+}
+
+}  // namespace columnBasedIdTable
+
+#endif  // QLEVER_SRC_ENGINE_IDTABLE_IDCOLUMNALGORITHMS_H

--- a/src/engine/idTable/IdColumnAlgorithms.h
+++ b/src/engine/idTable/IdColumnAlgorithms.h
@@ -12,6 +12,7 @@
 
 #include <algorithm>
 #include <cstring>
+#include <limits>
 #include <vector>
 
 #include "backports/concepts.h"
@@ -339,6 +340,186 @@ inline bool trySortBySingleKeyColumn(::IdTable& table, ColumnIndex keyColumn) {
                 numRows * sizeof(uint64_t));
     std::memcpy(types.data(), scratchTypes.data(), numRows * sizeof(uint8_t));
   }
+  return true;
+}
+
+namespace detail {
+
+// Return `true` iff all elements of the `values` are equal.
+template <typename T>
+bool allElementsEqual(ql::span<T> values) {
+  if (values.empty()) {
+    return true;
+  }
+  const auto first = values.front();
+  for (const auto& value : values) {
+    if (value != first) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// The implementation of `trySortByKeyColumnsBitwise` below for a fixed number
+// of (non-constant) key columns. All preconditions (no `LocalVocabIndex` IDs
+// in the key columns, at most `uint32_t` many rows) have already been checked
+// by the caller.
+template <size_t NumKeys, typename Table>
+void sortByKeyColumnsBitwiseImpl(
+    Table& table, const std::array<size_t, NumKeys>& keyColumns) {
+  const size_t numRows = table.numRows();
+  struct Entry {
+    std::array<uint64_t, NumKeys> payloads_;
+    uint32_t index_;
+    std::array<uint8_t, NumKeys> types_;
+  };
+  std::vector<Entry> entries(numRows);
+  // Fill the entries row-major in a single pass (reads from `NumKeys`
+  // sequential streams, writes each entry exactly once).
+  {
+    std::array<const uint64_t*, NumKeys> payloads;
+    std::array<const uint8_t*, NumKeys> types;
+    for (size_t k = 0; k < NumKeys; ++k) {
+      auto column = table.getColumn(keyColumns[k]);
+      payloads[k] = column.payloadSpan().data();
+      types[k] = column.datatypeSpan().data();
+    }
+#pragma omp parallel for
+    for (size_t i = 0; i < numRows; ++i) {
+      auto& entry = entries[i];
+      for (size_t k = 0; k < NumKeys; ++k) {
+        entry.payloads_[k] = payloads[k][i];
+        entry.types_[k] = types[k][i];
+      }
+      entry.index_ = static_cast<uint32_t>(i);
+    }
+  }
+
+  auto comparator = [](const Entry& a, const Entry& b) {
+    for (size_t k = 0; k < NumKeys; ++k) {
+      if (a.types_[k] != b.types_[k]) {
+        return a.types_[k] < b.types_[k];
+      }
+      if (a.payloads_[k] != b.payloads_[k]) {
+        return a.payloads_[k] < b.payloads_[k];
+      }
+    }
+    return false;
+  };
+  if constexpr (USE_PARALLEL_SORT) {
+    // Note: Deliberately no thread limit here; this replaces the unlimited
+    // `parallel_sort` calls of the external sorter.
+    ad_utility::parallel_sort(entries.begin(), entries.end(), comparator);
+  } else {
+    std::sort(entries.begin(), entries.end(), comparator);
+  }
+
+  // Apply the permutation to all columns. The scratch buffers are reused
+  // across the columns, the gather loop is parallelized within each column.
+  const auto numColumns = table.numColumns();
+  std::vector<uint64_t> scratchPayloads(numRows);
+  std::vector<uint8_t> scratchTypes(numRows);
+  for (size_t c = 0; c < numColumns; ++c) {
+    decltype(auto) column = table.getColumn(c);
+    auto payloads = column.payloadSpan();
+    auto types = column.datatypeSpan();
+    // Constant columns are invariant under the permutation.
+    if (allElementsEqual(ql::span<const uint64_t>{payloads}) &&
+        allElementsEqual(ql::span<const uint8_t>{types})) {
+      continue;
+    }
+#pragma omp parallel for
+    for (size_t i = 0; i < numRows; ++i) {
+      scratchPayloads[i] = payloads[entries[i].index_];
+      scratchTypes[i] = types[entries[i].index_];
+    }
+    std::memcpy(payloads.data(), scratchPayloads.data(),
+                numRows * sizeof(uint64_t));
+    std::memcpy(types.data(), scratchTypes.data(), numRows * sizeof(uint8_t));
+  }
+}
+
+// Call `sortByKeyColumnsBitwiseImpl` with the first `numActive` entries of
+// the `activeKeys` as the (compile-time sized) array of key columns.
+CPP_template(size_t N, size_t MaxKeys, typename Table)(requires(
+    N >= 1 &&
+    N <= MaxKeys)) void sortByKeyColumnsBitwiseDispatch(Table& table,
+                                                        const std::array<
+                                                            size_t, MaxKeys>&
+                                                            activeKeys,
+                                                        size_t numActive) {
+  AD_CORRECTNESS_CHECK(numActive >= 1 && numActive <= MaxKeys);
+  if (numActive == N) {
+    std::array<size_t, N> keys;
+    std::copy(activeKeys.begin(), activeKeys.begin() + N, keys.begin());
+    sortByKeyColumnsBitwiseImpl<N>(table, keys);
+    return;
+  }
+  if constexpr (N > 1) {
+    sortByKeyColumnsBitwiseDispatch<N - 1>(table, activeKeys, numActive);
+  }
+}
+
+}  // namespace detail
+
+// Try to sort the `table` by the given `keyColumns` (compared in order,
+// each datatype-major bitwise, which is exactly the ID order as long as no
+// IDs of type `LocalVocabIndex` are involved). On success return `true`.
+// Return `false` without modifying the table if one of the key columns
+// contains an ID of type `LocalVocabIndex` (the caller then has to use a
+// generic comparison sort), or if the table has more than `uint32_t` many
+// rows (which in practice never happens for the blockwise sorts this
+// function is used for).
+//
+// The sort extracts the keys and row indices into a compact contiguous
+// array, sorts that array (in parallel if enabled), and then applies the
+// resulting permutation to all columns of the table, one column at a time.
+// This is much faster than a comparison sort on the rows of the table,
+// which has to touch all payload and datatype buffers of the table for
+// every swap (or, for the parallel multiway mergesort, has to materialize
+// complete rows into its temporary buffers). Key columns whose value is
+// constant within the `table` (e.g. typically the graph column) don't
+// influence the order and are excluded, which makes the key entries smaller
+// and the comparisons cheaper.
+CPP_template(size_t NumKeys, typename Table)(requires(
+    NumKeys >=
+    1)) bool trySortByKeyColumnsBitwise(Table& table,
+                                        const std::array<size_t, NumKeys>&
+                                            keyColumns) {
+  const size_t numRows = table.numRows();
+  if (numRows <= 1) {
+    return true;
+  }
+  if (numRows > std::numeric_limits<uint32_t>::max()) {
+    return false;
+  }
+  for (size_t keyColumn : keyColumns) {
+    auto types = table.getColumn(keyColumn).datatypeSpan();
+    if (std::memchr(types.data(), static_cast<int>(Datatype::LocalVocabIndex),
+                    types.size()) != nullptr) {
+      return false;
+    }
+  }
+
+  // Determine the key columns that are not constant.
+  std::array<size_t, NumKeys> activeKeys{};
+  size_t numActive = 0;
+  for (size_t keyColumn : keyColumns) {
+    auto column = table.getColumn(keyColumn);
+    if (!(detail::allElementsEqual(
+              ql::span<const uint64_t>{column.payloadSpan()}) &&
+          detail::allElementsEqual(
+              ql::span<const uint8_t>{column.datatypeSpan()}))) {
+      activeKeys[numActive] = keyColumn;
+      ++numActive;
+    }
+  }
+  // If all key columns are constant, the table is trivially sorted.
+  if (numActive == 0) {
+    return true;
+  }
+  detail::sortByKeyColumnsBitwiseDispatch<NumKeys>(table, activeKeys,
+                                                   numActive);
   return true;
 }
 

--- a/src/engine/idTable/IdTable.h
+++ b/src/engine/idTable/IdTable.h
@@ -15,6 +15,7 @@
 #include "backports/algorithm.h"
 #include "backports/functional.h"
 #include "backports/span.h"
+#include "engine/idTable/IdColumn.h"
 #include "engine/idTable/IdTableRow.h"
 #include "engine/idTable/VectorWithElementwiseMove.h"
 #include "global/Id.h"
@@ -28,6 +29,32 @@
 #include "util/Views.h"
 
 namespace columnBasedIdTable {
+
+// Traits that describe how the entries of a single column of an `IdTable`
+// are accessed, depending on the underlying storage type of the column.
+// The general case covers storages with contiguous elements of type `T`
+// (e.g. `std::vector<T>`), where a reference to an entry is a plain `T&` and
+// a whole column can be viewed as a `ql::span`.
+template <typename ColumnStorage, typename T>
+struct ColumnStorageTraits {
+  using reference = T&;
+  using const_reference = const T&;
+  using View = ql::span<T>;
+  using ConstView = ql::span<const T>;
+};
+
+// The specialization for the storage-efficient split columns of `Id`s (see
+// `IdColumn.h`): references are the `IdRef` proxy types and the views are
+// the `IdColumnSpan` types.
+template <typename PayloadStorage, typename TypeStorage>
+struct ColumnStorageTraits<IdColumnVectorImpl<PayloadStorage, TypeStorage>,
+                           Id> {
+  using reference = IdRef;
+  using const_reference = ConstIdRef;
+  using View = MutableIdColumnSpan;
+  using ConstView = ConstIdColumnSpan;
+};
+
 // The `IdTable` class is QLever's central data structure. It is used to store
 // all intermediate and final query results in the ID space.
 //
@@ -126,7 +153,15 @@ class IdTable {
   static constexpr size_t numInlinedColumns = 10;
   using Storage = detail::VectorWithElementwiseMove<
       ColumnStorage, absl::InlinedVector<ColumnStorage, numInlinedColumns>>;
-  using ViewSpans = absl::InlinedVector<ql::span<const T>, numInlinedColumns>;
+  // The types for the access to single entries and whole columns, which
+  // depend on the underlying column storage (see `ColumnStorageTraits`
+  // above).
+  using Traits = ColumnStorageTraits<ColumnStorage, T>;
+  using single_value_reference = typename Traits::reference;
+  using const_single_value_reference = typename Traits::const_reference;
+  using column_view = typename Traits::View;
+  using const_column_view = typename Traits::ConstView;
+  using ViewSpans = absl::InlinedVector<const_column_view, numInlinedColumns>;
   using Data = std::conditional_t<isView, ViewSpans, Storage>;
   using Allocator = decltype(std::declval<ColumnStorage&>().get_allocator());
 
@@ -335,10 +370,13 @@ class IdTable {
   // Note: Since this class has a column-based layout, the usage of the
   // column-based interface (`getColumn` and `getColumns`) should be preferred
   // for performance reason whenever possible.
+  // Note: For the storage-efficient split `Id` columns, the returned
+  // "reference" is a proxy object of type `IdRef`/`ConstIdRef` (see
+  // `IdColumn.h`).
   // TODO<joka921, C++23> Use the multidimensional subscript operator.
   // TODO<joka921, C++23> Use explicit object parameters ("deducing this").
-  CPP_template(typename = void)(requires(!isView)) T& operator()(
-      size_t row, size_t column) {
+  CPP_template(typename = void)(requires(!isView)) single_value_reference
+  operator()(size_t row, size_t column) {
     AD_EXPENSIVE_CHECK(column < data().size(), [&]() {
       return absl::StrCat(row, " , ", column, ", ", data().size(), " ",
                           numColumns(), ", ", numStaticColumns);
@@ -346,25 +384,25 @@ class IdTable {
     AD_EXPENSIVE_CHECK(row < data().at(column).size());
     return data()[column][row];
   }
-  const T& operator()(size_t row, size_t column) const {
+  const_single_value_reference operator()(size_t row, size_t column) const {
     return data()[column][row];
   }
 
   // Get safe access to a single element specified by the row and the column.
   // Throw if the row or the column is out of bounds. See the note for
   // `operator()` above.
-  CPP_template(typename = void)(requires(!isView)) T& at(size_t row,
-                                                         size_t column) {
+  CPP_template(typename = void)(requires(!isView)) single_value_reference
+      at(size_t row, size_t column) {
     return data().at(column).at(row);
   }
   // TODO<C++26> Remove overload for `isView` and drop requires clause.
-  CPP_template(typename = void)(requires(!isView)) const T& at(
-      size_t row, size_t column) const {
+  CPP_template(typename = void)(requires(!isView)) const_single_value_reference
+      at(size_t row, size_t column) const {
     return data().at(column).at(row);
   }
   // `std::span::at` is a C++26 feature, so we have to implement it ourselves.
-  CPP_template(typename = void)(requires(isView)) const T& at(
-      size_t row, size_t column) const {
+  CPP_template(typename = void)(requires(isView)) const_single_value_reference
+      at(size_t row, size_t column) const {
     const auto& col = data().at(column);
     AD_CONTRACT_CHECK(row < col.size());
     return col[row];
@@ -612,7 +650,7 @@ class IdTable {
     auto viewSpans = ::ranges::to<ViewSpans>(
         ad_utility::allView(getColumns()) |
         ql::views::transform(
-            [offset, size](const auto& col) -> ql::span<const T> {
+            [offset, size](const auto& col) -> const_column_view {
               return col.subspan(offset, size);
             }));
     return IdTable<T, NumColumns, ColumnStorage, IsView::True>{
@@ -850,12 +888,16 @@ class IdTable {
     return true;
   }
 
-  // Get the `i`-th column. It is stored contiguously in memory.
-  CPP_template(typename = void)(requires(!isView)) ql::span<T> getColumn(
-      size_t i) {
-    return {data().at(i)};
+  // Get the `i`-th column. Note: For the storage-efficient split `Id`
+  // columns the return type is not a `ql::span`, but an `IdColumnSpan` (see
+  // `IdColumn.h`), which provides a very similar interface.
+  CPP_template(typename = void)(requires(!isView)) column_view
+      getColumn(size_t i) {
+    return column_view{data().at(i)};
   }
-  ql::span<const T> getColumn(size_t i) const { return {data().at(i)}; }
+  const_column_view getColumn(size_t i) const {
+    return const_column_view{data().at(i)};
+  }
 
   // Return all the columns as a `std::vector` (if `isDynamic`) or as a
   // `std::array` (else). The elements of the vector/array are `ql::span<T>`
@@ -897,7 +939,9 @@ class IdTable {
 namespace detail {
 using DefaultAllocator =
     ad_utility::default_init_allocator<Id, ad_utility::AllocatorWithLimit<Id>>;
-using IdVector = std::vector<Id, DefaultAllocator>;
+// The default column storage for `Id`s: the storage-efficient split column
+// (payloads and datatype bytes in separate arrays, see `IdColumn.h`).
+using IdVector = columnBasedIdTable::IdColumnVector<DefaultAllocator>;
 }  // namespace detail
 
 /// The general IdTable class. Can be modified and owns its data. If COLS > 0,

--- a/src/engine/idTable/IdTable.h
+++ b/src/engine/idTable/IdTable.h
@@ -834,9 +834,25 @@ class IdTable {
             ql::ranges::fill(getColumn(i).subspan(oldSize), defaultValue);
             return;
           }
-          ql::ranges::copy(
-              table.getColumn(mappedIndex).subspan(begin, numInserted),
-              getColumn(i).begin() + oldSize);
+          auto sourceColumn = table.getColumn(mappedIndex);
+          auto targetColumn = getColumn(i);
+          // Fast path for the split-column storage: Copy the payloads and
+          // the datatype bytes separately (this compiles down to `memcpy`,
+          // whereas the generic path copies element-wise via proxies).
+          if constexpr (requires {
+                          sourceColumn.payloadSpan();
+                          targetColumn.payloadSpan();
+                        }) {
+            ql::ranges::copy(
+                sourceColumn.payloadSpan().subspan(begin, numInserted),
+                targetColumn.payloadSpan().begin() + oldSize);
+            ql::ranges::copy(
+                sourceColumn.datatypeSpan().subspan(begin, numInserted),
+                targetColumn.datatypeSpan().begin() + oldSize);
+          } else {
+            ql::ranges::copy(sourceColumn.subspan(begin, numInserted),
+                             targetColumn.begin() + oldSize);
+          }
         });
   }
 
@@ -855,9 +871,13 @@ class IdTable {
     const size_t oldSize = size();
     resize(numRows() + numInserted);
     // For each column, copy the requested rows into the reserved tail.
-    for (auto&& [destination, source] :
+    for (auto&& destinationAndSource :
          ::ranges::views::zip(ad_utility::allView(getColumns()),
                               ad_utility::allView(table.getColumns()))) {
+      // Note: No structured bindings here, because those cannot be captured
+      // in lambdas when compiling with OpenMP (`USE_PARALLEL`).
+      auto& destination = std::get<0>(destinationAndSource);
+      auto& source = std::get<1>(destinationAndSource);
       if constexpr (requires {
                       destination.payloadSpan();
                       source.payloadSpan();

--- a/src/engine/idTable/IdTable.h
+++ b/src/engine/idTable/IdTable.h
@@ -858,8 +858,24 @@ class IdTable {
     for (auto&& [destination, source] :
          ::ranges::views::zip(ad_utility::allView(getColumns()),
                               ad_utility::allView(table.getColumns()))) {
-      ql::ranges::transform(indices, destination.begin() + oldSize,
-                            [&source](size_t idx) { return source[idx]; });
+      if constexpr (requires {
+                      destination.payloadSpan();
+                      source.payloadSpan();
+                    }) {
+        // Fast path for split `Id` columns: gather directly on the payload
+        // and datatype arrays.
+        auto destinationPayloads = destination.payloadSpan();
+        auto destinationTypes = destination.datatypeSpan();
+        auto sourcePayloads = source.payloadSpan();
+        auto sourceTypes = source.datatypeSpan();
+        for (size_t k = 0; k < numInserted; ++k) {
+          destinationPayloads[oldSize + k] = sourcePayloads[indices[k]];
+          destinationTypes[oldSize + k] = sourceTypes[indices[k]];
+        }
+      } else {
+        ql::ranges::transform(indices, destination.begin() + oldSize,
+                              [&source](size_t idx) { return source[idx]; });
+      }
     }
   }
 

--- a/src/engine/idTable/IdTableRow.h
+++ b/src/engine/idTable/IdTableRow.h
@@ -180,30 +180,32 @@ class RowReferenceImpl {
         : table_{table}, row_{row} {}
 
    protected:
-    // The actual implementation of operator[].
+    // The actual implementation of operator[]. Note: The returned
+    // "reference" is either a plain reference or a proxy object (e.g.
+    // `IdRef` for the storage-efficient split `Id` columns), depending on
+    // the underlying table, so the return type is deduced.
     CPP_template(typename SelfType)(
         requires CPP_NOT(std::is_const_v<std::remove_reference_t<SelfType>>)
-            CPP_and CPP_NOT(
-                isConst)) static T& operatorBracketImpl(SelfType& self,
-                                                        size_t i) {
+            CPP_and CPP_NOT(isConst)) static decltype(auto)
+        operatorBracketImpl(SelfType& self, size_t i) {
       return (*self.table_)(self.row_, i);
     }
     template <typename Self>
-    static const T& operatorBracketImpl(const Self& self, size_t i) {
+    static decltype(auto) operatorBracketImpl(const Self& self, size_t i) {
       return (*self.table_)(self.row_, i);
     }
 
    public:
     // Access to the `i`-th columns of this row. Only allowed for const values
     // and for rvalues.
-    CPP_template_2(typename = void)(requires(!isConst)) T& operator[](
-        size_t i) && {
+    CPP_template_2(typename = void)(requires(!isConst)) decltype(auto)
+    operator[](size_t i) && {
       return operatorBracketImpl(*this, i);
     }
-    const T& operator[](size_t i) const& {
+    decltype(auto) operator[](size_t i) const& {
       return operatorBracketImpl(*this, i);
     }
-    const T& operator[](size_t i) const&& {
+    decltype(auto) operator[](size_t i) const&& {
       return operatorBracketImpl(*this, i);
     }
 
@@ -216,14 +218,17 @@ class RowReferenceImpl {
                                                                 colIdx);
       }
     };
+    // Note: The `value_type` is explicitly set to `T`, because the entries
+    // of the row are proxy references when the underlying table stores split
+    // `Id` columns.
     using iterator = ad_utility::IteratorForAccessOperator<
         RowReferenceWithRestrictedAccess,
         IteratorHelper<RowReferenceWithRestrictedAccess>,
-        ad_utility::IsConst::False>;
+        ad_utility::IsConst::False, T>;
     using const_iterator = ad_utility::IteratorForAccessOperator<
         RowReferenceWithRestrictedAccess,
         IteratorHelper<RowReferenceWithRestrictedAccess>,
-        ad_utility::IsConst::True>;
+        ad_utility::IsConst::True, T>;
     // Non-const iterators allow non-const access and are therefore only allowed
     // on rvalues.
     iterator begin() && { return {this, 0}; };
@@ -248,8 +253,12 @@ class RowReferenceImpl {
     // value or by reference).
     CPP_template(typename AType, typename BType)(
         requires(!isConst)) static void swapImpl(AType&& a, BType&& b) {
+      // Note: The unqualified call with the `using`-declaration also finds
+      // the `swap` functions of proxy references (e.g. `IdRef`) via argument
+      // dependent lookup.
+      using std::swap;
       for (size_t i = 0; i < a.numColumns(); ++i) {
-        std::swap(operatorBracketImpl(a, i), operatorBracketImpl(b, i));
+        swap(operatorBracketImpl(a, i), operatorBracketImpl(b, i));
       }
     }
 
@@ -391,10 +400,11 @@ class RowReference
   using Base::Base;
 
   // Access to the `i`-th column of this row.
-  CPP_template_2(typename = void)(requires(!isConst)) T& operator[](size_t i) {
+  CPP_template_2(typename = void)(requires(!isConst)) decltype(auto) operator[](
+      size_t i) {
     return Base::operatorBracketImpl(base(), i);
   }
-  const T& operator[](size_t i) const {
+  decltype(auto) operator[](size_t i) const {
     return Base::operatorBracketImpl(base(), i);
   }
 

--- a/src/engine/sparqlExpressions/AggregateExpression.h
+++ b/src/engine/sparqlExpressions/AggregateExpression.h
@@ -46,7 +46,7 @@ inline auto getUniqueElements = [](const EvaluationContext* context,
   return ad_utility::ForceInputView(
       ad_utility::OwningView(std::move(operandGenerator)) |
       ::ranges::views::filter(
-          [set = std::move(uniqueHashSet)](auto& operand) mutable {
+          [set = std::move(uniqueHashSet)](const auto& operand) mutable {
             return set.insert(operand).second;
           }));
 };

--- a/src/engine/sparqlExpressions/GroupConcatExpression.cpp
+++ b/src/engine/sparqlExpressions/GroupConcatExpression.cpp
@@ -29,7 +29,7 @@ sparqlExpression::GroupConcatExpression::evaluate(
       // TODO<joka921> Make this a configurable constant.
       result.reserve(20000);
       bool firstIteration = true;
-      for (auto& inp : generator) {
+      for (auto&& inp : generator) {
         auto literal = detail::LiteralValueGetterWithoutStrFunction{}(
             std::move(inp), context);
         if (firstIteration) {

--- a/src/engine/sparqlExpressions/LiteralExpression.h
+++ b/src/engine/sparqlExpressions/LiteralExpression.h
@@ -208,7 +208,7 @@ class LiteralExpression : public SparqlExpression {
           "A non-grouped variable outside of an aggregate should have been "
           "rejected by the parser");
       const auto& table = context->_inputTable;
-      auto constantValue = table.at(context->_beginIndex, column.value());
+      Id constantValue = table.at(context->_beginIndex, column.value());
       AD_EXPENSIVE_CHECK((
           std::all_of(table.begin() + context->_beginIndex,
                       table.begin() + context->_endIndex, [&](const auto& row) {

--- a/src/engine/sparqlExpressions/SampleExpression.cpp
+++ b/src/engine/sparqlExpressions/SampleExpression.cpp
@@ -27,9 +27,9 @@ ExpressionResult SampleExpression::evaluate(EvaluationContext* context) const {
     } else if constexpr (std::is_same_v<T, ::Variable>) {
       // TODO<joka921> Can't this be a simpler function (getIdAt)
       AD_CORRECTNESS_CHECK(context->_endIndex > context->_beginIndex);
-      ql::span<const ValueId> idOfFirstAsVector = detail::getIdsFromVariable(
+      auto idOfFirstAsVector = detail::getIdsFromVariable(
           childResult, context, context->_beginIndex, context->_endIndex);
-      return ExpressionResult{idOfFirstAsVector[0]};
+      return ExpressionResult{Id{idOfFirstAsVector[0]}};
     } else {
       static_assert(isConstantResult<T>);
       return childResult;

--- a/src/engine/sparqlExpressions/SparqlExpressionGenerators.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionGenerators.h
@@ -30,7 +30,7 @@ namespace sparqlExpression::detail {
 
 /// Convert a variable to a vector of all the Ids it is bound to in the
 /// `context`.
-inline ql::span<const ValueId> getIdsFromVariable(
+inline columnBasedIdTable::ConstIdColumnSpan getIdsFromVariable(
     const ::Variable& variable, const EvaluationContext* context,
     size_t beginIndex, size_t endIndex) {
   const auto& inputTable = context->_inputTable;
@@ -41,17 +41,16 @@ inline ql::span<const ValueId> getIdsFromVariable(
 
   const size_t columnIndex = it->second.columnIndex_;
 
-  ql::span<const ValueId> completeColumn = inputTable.getColumn(columnIndex);
+  auto completeColumn = inputTable.getColumn(columnIndex);
 
   AD_CONTRACT_CHECK(beginIndex <= endIndex &&
                     endIndex <= completeColumn.size());
-  return {completeColumn.begin() + beginIndex,
-          completeColumn.begin() + endIndex};
+  return completeColumn.subspan(beginIndex, endIndex - beginIndex);
 }
 
 // Overload that reads the `beginIndex` and the `endIndex` directly from the
 // `context
-inline ql::span<const ValueId> getIdsFromVariable(
+inline columnBasedIdTable::ConstIdColumnSpan getIdsFromVariable(
     const ::Variable& variable, const EvaluationContext* context) {
   return getIdsFromVariable(variable, context, context->_beginIndex,
                             context->_endIndex);
@@ -93,8 +92,27 @@ CPP_template(typename T, typename Transformation = ql::identity)(
         T>) auto resultGeneratorImpl(T&& vector, size_t numItems,
                                      Transformation transformation = {}) {
   AD_CONTRACT_CHECK(numItems == vector.size());
-  return ad_utility::allView(AD_FWD(vector)) |
-         ql::views::transform(std::move(transformation));
+  using Reference = ql::ranges::range_reference_t<std::remove_reference_t<T>>;
+  if constexpr (ad_utility::SimilarToAny<std::decay_t<Reference>,
+                                         columnBasedIdTable::IdRef,
+                                         columnBasedIdTable::ConstIdRef>) {
+    // The elements of a split column of `Id`s are proxy references (`IdRef`,
+    // see `IdColumn.h`). They are materialized to `ValueId`s here, s.t. all
+    // downstream code (in particular the `ValueGetter`s) continues to work
+    // on plain `ValueId`s.
+    // IMPORTANT: The lambda deliberately returns by value (plain `auto`, not
+    // `decltype(auto)`): the `transformation` (e.g. `ql::identity`) may
+    // return a reference into the materialized temporary, which would
+    // otherwise dangle.
+    return ad_utility::allView(AD_FWD(vector)) |
+           ql::views::transform(
+               [transformation = std::move(transformation)](auto&& element) {
+                 return transformation(static_cast<ValueId>(AD_FWD(element)));
+               });
+  } else {
+    return ad_utility::allView(AD_FWD(vector)) |
+           ql::views::transform(std::move(transformation));
+  }
 }
 
 #ifdef QLEVER_EXPRESSION_GENERATOR_BACKPORTS_FOR_CPP17

--- a/src/engine/sparqlExpressions/StdevExpression.cpp
+++ b/src/engine/sparqlExpressions/StdevExpression.cpp
@@ -35,7 +35,7 @@ ExpressionResult DeviationExpression::evaluate(
     VectorWithMemoryLimit<double> childResults{context->_allocator};
 
     // Collect values as doubles
-    for (auto& inp : generator) {
+    for (auto&& inp : generator) {
       const auto& n = detail::NumericValueGetter{}(std::move(inp), context);
       auto v = std::visit(numValVisitor, n);
       if (v.has_value()) {

--- a/src/engine/sparqlExpressions/StringExpressions.cpp
+++ b/src/engine/sparqlExpressions/StringExpressions.cpp
@@ -485,7 +485,7 @@ class ConcatExpression : public detail::VariadicExpression {
         auto& resultAsVec = std::get<LiteralVec>(result);
         // TODO<C++23> Use `ql::views::zip` or `enumerate`.
         size_t i = 0;
-        for (auto& el : gen) {
+        for (auto&& el : gen) {
           auto literal = valueGetter(std::move(el), ctx);
           concatOrSetLiteral(resultAsVec[i], literal, isFirstLiteral);
           ctx->cancellationHandle_->throwIfCancelled();

--- a/src/global/IdTriple.h
+++ b/src/global/IdTriple.h
@@ -17,6 +17,10 @@
 #include "index/KeyOrder.h"
 
 template <size_t N = 0>
+// TODO<joka921> The triple stores materialized 16-byte `Id`s (7 padding
+// bytes each). In the future this should probably be rewritten to an
+// efficient format that stores first the four payloads and then the four
+// datatype bytes.
 struct IdTriple {
   // A triple has four components: subject, predicate, object, and graph.
   //

--- a/src/global/Pattern.h
+++ b/src/global/Pattern.h
@@ -24,6 +24,10 @@
  *        that a set of entities has (e.g. for autocompletion of relations
  *        while writing a query).
  */
+// TODO<joka921> The pattern stores materialized 16-byte `Id`s (7 padding
+// bytes each). In the future this should probably be rewritten to an
+// efficient format that stores first all payloads and then all datatype
+// bytes.
 struct Pattern : std::vector<Id> {
   using PatternId = int32_t;
   static constexpr PatternId NoPattern = std::numeric_limits<PatternId>::max();

--- a/src/global/SpecialIds.h
+++ b/src/global/SpecialIds.h
@@ -25,10 +25,10 @@ inline const ad_utility::HashMap<std::string, Id>& specialIds() {
   static const auto ids = []() {
     using S = std::string;
     ad_utility::HashMap<std::string, Id> result{
-        {S{HAS_PREDICATE_PREDICATE}, Id::fromBits(1)},
-        {S{HAS_PATTERN_PREDICATE}, Id::fromBits(2)},
-        {S{DEFAULT_GRAPH_IRI}, Id::fromBits(3)},
-        {S{QLEVER_INTERNAL_GRAPH_IRI}, Id::fromBits(4)}};
+        {S{HAS_PREDICATE_PREDICATE}, Id::fromBits({0, 1})},
+        {S{HAS_PATTERN_PREDICATE}, Id::fromBits({0, 2})},
+        {S{DEFAULT_GRAPH_IRI}, Id::fromBits({0, 3})},
+        {S{QLEVER_INTERNAL_GRAPH_IRI}, Id::fromBits({0, 4})}};
 
     // Perform the following checks: All the special IDs are unique, all of them
     // have the `Undefined` datatype, but none of them is equal to the "actual"
@@ -54,8 +54,10 @@ inline const ad_utility::HashMap<std::string, Id>& specialIds() {
 constexpr std::pair<Id, Id> getBoundsForSpecialIds() {
   constexpr auto upperBound = Id::makeFromBool(false);
   static_assert(static_cast<int>(Datatype::Undefined) == 0);
-  static_assert(upperBound.getBits() == uint64_t{1} << Id::numDataBits);
-  return {Id::fromBits(1), upperBound};
+  // The `upperBound` is the smallest ID that does not have the `Undefined`
+  // datatype.
+  static_assert(upperBound.getBits() == ValueId::BitRepresentation{1, 0});
+  return {Id::fromBits({0, 1}), upperBound};
 }
 }  // namespace qlever
 

--- a/src/global/ValueId.h
+++ b/src/global/ValueId.h
@@ -17,6 +17,7 @@
 #include "backports/three_way_comparison.h"
 #include "global/Constants.h"
 #include "global/IndexTypes.h"
+#include "global/ValueIdBitRepresentation.h"
 #include "rdfTypes/GeoPoint.h"
 #include "util/Algorithm.h"
 #include "util/BitUtils.h"
@@ -97,30 +98,26 @@ inline QL_CONSTEXPR std::string_view toString(Datatype type) {
 }
 
 /// Encode values of different types (the types from the `Datatype` enum above)
-/// using 4 bits for the datatype and 60 bits for the value.
+/// using a full byte for the datatype and a full 64-bit word for the value.
+/// The ordering of `ValueId`s is datatype-major: IDs are first ordered by
+/// their datatype byte and then by their payload bits (interpreted as an
+/// unsigned 64-bit integer).
 class ValueId {
  public:
+  // The type of the payload bits.
   using T = uint64_t;
-  static constexpr T numDatatypeBits = 4;
-  static constexpr T numDataBits = 64 - numDatatypeBits;
+  static constexpr T numDatatypeBits = 8;
+  static constexpr T numDataBits = 64;
 
   using IntegerType = ad_utility::NBitInteger<numDataBits>;
 
   /// The maximum value for the unsigned types that are used as indices
-  /// (currently VocabIndex, LocalVocabIndex and Text).
-  static constexpr T maxIndex = (1ull << numDataBits) - 1;
+  /// (currently VocabIndex, LocalVocabIndex and Text). Since the payload now
+  /// consists of a full 64-bit word, all values of `T` are valid indices.
+  static constexpr T maxIndex = std::numeric_limits<T>::max();
 
-  /// The smallest double > 0 that will not be rounded to zero by the precision
-  /// loss of `FoldedId`. Symmetrically, `-minPositiveDouble` is the largest
-  /// double <0 that will not be rounded to zero.
-  /// Note: This constant is currently only used in unit tests, and cannot be
-  /// computed at compile time in C++17.
-#ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
-  static constexpr double minPositiveDouble =
-      absl::bit_cast<double>(1ull << numDatatypeBits);
-#endif
-
-  // The largest representable integer value.
+  // The largest representable integer value. As the payload is a full 64-bit
+  // word, this is the full range of `int64_t`.
   static constexpr int64_t maxInt = IntegerType::max();
   // All types that store strings. Together, the IDs of all the items of these
   // types form a consecutive range of IDs when sorted. Within this range, the
@@ -142,55 +139,51 @@ class ValueId {
                     static_cast<size_t>(minStringType_) + 1 ==
                 stringTypes_.size());
 
-  // Assert that the size of an encoded GeoPoint equals the available bits in a
-  // ValueId.
-  static_assert(numDataBits == GeoPoint::numDataBits);
-
-  /// This exception is thrown if we try to store a value of an index type
-  /// (VocabIndex, LocalVocabIndex, TextRecordIndex) that is larger than
-  /// `maxIndex`.
-  struct IndexTooLargeException : public std::exception {
-   private:
-    std::string errorMessage_;
-
-   public:
-    explicit IndexTooLargeException(
-        T tooBigValue,
-        ad_utility::source_location s = AD_CURRENT_SOURCE_LOC()) {
-      errorMessage_ = absl::StrCat(
-          s.file_name(), ", line ", s.line(), ": The given value ", tooBigValue,
-          " is bigger than what the maxIndex of ValueId allows.");
-    }
-
-    const char* what() const noexcept override { return errorMessage_.c_str(); }
-  };
+  // Assert that an encoded `GeoPoint` fits into the payload of a `ValueId`.
+  static_assert(numDataBits >= GeoPoint::numDataBits);
 
   /// A struct that represents the single undefined value. This is required for
   /// generic code like in the `visit` method.
   struct UndefinedType {};
 
+  /// The raw bit representation of a `ValueId`: a single datatype byte and a
+  /// full 64-bit word of payload. See `ValueIdBitRepresentation.h` for
+  /// details.
+  using BitRepresentation = ValueIdBitRepresentation;
+
  private:
-  // The actual bits.
-  T _bits;
+  // The actual data: a full 64-bit word of payload and a single byte for the
+  // datatype. Together with the explicitly stored `padding_` this makes a
+  // `ValueId` occupy 16 bytes when stored directly. The `IdTable` therefore
+  // stores the payload and datatype in separate columns to avoid wasting
+  // memory for the padding.
+  T payload_;
+  uint8_t datatype_;
+  // Explicit padding bytes. They are always set to zero by all factory
+  // functions, s.t. all valid `ValueId`s have a deterministic byte
+  // representation (e.g. for hashing raw bytes or writing them to disk).
+  // Note: Default-constructed `ValueId`s are deliberately uninitialized (see
+  // the default constructor below).
+  std::array<uint8_t, 7> padding_;
 
  public:
   /// Default construction of an uninitialized id.
   ValueId() = default;
 
-  /// Comparison is performed directly on the underlying representation. Note
-  /// that because the type bits are the most significant bits, all values of
-  /// the same `Datatype` will be adjacent to each other. Unsigned index types
-  /// are also ordered correctly. Signed integers are ordered as follows: first
-  /// the positive integers in order and then the negative integers in order.
-  /// For doubles it is first the positive doubles in order, then the negative
-  /// doubles in reversed order. This is a direct consequence of comparing the
-  /// bit representation of these values as unsigned integers.
+  /// Comparison is performed datatype-major, i.e. first on the datatype byte
+  /// and then on the payload bits (as unsigned integers). All values of the
+  /// same `Datatype` are therefore adjacent to each other. Unsigned index
+  /// types are also ordered correctly. Signed integers are ordered as follows:
+  /// first the positive integers in order and then the negative integers in
+  /// order. For doubles it is first the positive doubles in order, then the
+  /// negative doubles in reversed order. This is a direct consequence of
+  /// comparing the bit representation of these values as unsigned integers.
   constexpr auto compareThreeWay(const ValueId& other) const {
     using enum Datatype;
     auto type = getDatatype();
     auto otherType = other.getDatatype();
     if (type != LocalVocabIndex && otherType != LocalVocabIndex) {
-      return ql::compareThreeWay(_bits, other._bits);
+      return compareBitwiseImpl(other);
     }
     if (type == LocalVocabIndex && otherType == LocalVocabIndex) [[unlikely]] {
       return ql::compareThreeWay(*getLocalVocabIndex(),
@@ -216,7 +209,7 @@ class ValueId {
     // One of the types is `LocalVocab`, and the other one is a non-string
     // type like `Integer` or `Undefined. Then the comparison by bits
     // automatically compares by the datatype.
-    return ql::compareThreeWay(_bits, other._bits);
+    return compareBitwiseImpl(other);
   }
   QL_DEFINE_CUSTOM_THREEWAY_OPERATOR_LOCAL_CONSTEXPR(ValueId)
 
@@ -231,69 +224,72 @@ class ValueId {
   // on the underlying bits, which allows much better code generation (e.g.
   // vectorization). In particular, this method should for example be used
   // during index building.
-  auto compareWithoutLocalVocab(const ValueId& other) const {
+  constexpr auto compareWithoutLocalVocab(const ValueId& other) const {
     // NOTE: If this static assertion is violated at some point, make sure to
     // check all callers of this function if they are still correct.
     static_assert(isOnlyLocalVocabNotBitwiseComparable);
     AD_EXPENSIVE_CHECK(canBeComparedBitwise());
     AD_EXPENSIVE_CHECK(other.canBeComparedBitwise());
-    return ql::compareThreeWay(_bits, other._bits);
+    return compareBitwiseImpl(other);
   }
 
   /// Get the underlying bit representation, e.g. for compression etc.
-  [[nodiscard]] constexpr T getBits() const noexcept { return _bits; }
+  [[nodiscard]] constexpr BitRepresentation getBits() const noexcept {
+    return {datatype_, payload_};
+  }
+  /// Get only the payload bits (without the datatype byte).
+  [[nodiscard]] constexpr T getPayloadBits() const noexcept { return payload_; }
   /// Construct from the underlying bit representation. `bits` must have been
   /// obtained by a call to `getBits()` on a valid `ValueId`.
-  static constexpr ValueId fromBits(T bits) noexcept { return {bits}; }
+  static constexpr ValueId fromBits(BitRepresentation bits) noexcept {
+    return {bits.payload_, bits.datatype_};
+  }
 
   /// Get the datatype.
   [[nodiscard]] constexpr Datatype getDatatype() const noexcept {
-    return static_cast<Datatype>(_bits >> numDataBits);
+    return static_cast<Datatype>(datatype_);
   }
 
   /// Create a `ValueId` of the `Undefined` type. There is only one such ID and
   /// it is guaranteed to be smaller than all IDs of other types. This helps
   /// implementing the correct join behavior in presence of undefined values.
-  constexpr static ValueId makeUndefined() noexcept { return {0}; }
+  constexpr static ValueId makeUndefined() noexcept { return {0, 0}; }
 
   /// Returns an object of `UndefinedType`. In many scenarios this function is
   /// unnecessary because `getDatatype() == Undefined` already identifies the
   /// single undefined value correctly, but it is very useful for generic code
   /// like the `visit` member function.
   [[nodiscard]] UndefinedType getUndefined() const noexcept { return {}; }
-  bool isUndefined() const noexcept { return *this == makeUndefined(); }
+  constexpr bool isUndefined() const noexcept {
+    return *this == makeUndefined();
+  }
 
-  /// Create a `ValueId` for a double value. The conversion will reduce the
-  /// precision of the mantissa of an IEEE double precision floating point
-  /// number from 53 to 49 significant bits.
+  /// Create a `ValueId` for a double value. The full precision of the IEEE
+  /// double precision floating point number is preserved.
   static ValueId makeFromDouble(double d) {
-    auto shifted = absl::bit_cast<T>(d) >> numDatatypeBits;
-    return addDatatypeBits(shifted, Datatype::Double);
+    return {absl::bit_cast<T>(d), Datatype::Double};
   }
   /// Obtain the `double` that this `ValueId` encodes. If `getDatatype() !=
   /// Double` then the result is unspecified.
   [[nodiscard]] double getDouble() const noexcept {
-    return absl::bit_cast<double>(_bits << numDatatypeBits);
+    return absl::bit_cast<double>(payload_);
   }
 
-  /// Create a `ValueId` for a signed integer value. Integers in the range
-  /// [-2^59, 2^59-1] can be represented. Integers outside of this range will
-  /// overflow according to the semantics of `NBitInteger<60>`.
+  /// Create a `ValueId` for a signed integer value. The full range of
+  /// `int64_t` can be represented.
   static ValueId makeFromInt(int64_t i) noexcept {
-    auto nbit = IntegerType::toNBit(i);
-    return addDatatypeBits(nbit, Datatype::Int);
+    return {IntegerType::toNBit(i), Datatype::Int};
   }
 
   /// Obtain the signed integer that this `ValueId` encodes. If `getDatatype()
   /// != Int` then the result is unspecified.
   [[nodiscard]] int64_t getInt() const noexcept {
-    return IntegerType::fromNBit(_bits);
+    return IntegerType::fromNBit(payload_);
   }
 
   /// Create a `ValueId` for a boolean value.
   static constexpr ValueId makeFromBool(bool b) noexcept {
-    auto bits = static_cast<T>(b);
-    return addDatatypeBits(bits, Datatype::Bool);
+    return {static_cast<T>(b), Datatype::Bool};
   }
 
   /// Create a `ValueId` for a boolean value, represented as "0" or "1" instead
@@ -301,12 +297,12 @@ class ValueId {
   static constexpr ValueId makeBoolFromZeroOrOne(bool b) noexcept {
     auto bits = static_cast<T>(b);
     bits |= static_cast<T>(true) << 1;
-    return addDatatypeBits(bits, Datatype::Bool);
+    return {bits, Datatype::Bool};
   }
 
   // Obtain the boolean value.
-  [[nodiscard]] bool getBool() const noexcept {
-    return static_cast<bool>(removeDatatypeBits(_bits) & 1);
+  [[nodiscard]] constexpr bool getBool() const noexcept {
+    return static_cast<bool>(payload_ & 1);
   }
 
   // Obtain the boolean value as a string view. In particular, return either
@@ -314,7 +310,7 @@ class ValueId {
   // via `makeFromBool` or `makeBoolFromZeroOrOne` (see above).
   std::string_view getBoolLiteral() const noexcept {
     bool value = getBool();
-    if (_bits & 0b10) {
+    if (payload_ & 0b10) {
       return value ? "1" : "0";
     }
     return value ? "true" : "false";
@@ -322,80 +318,76 @@ class ValueId {
 
   /// Create a `ValueId` for an unsigned index of type
   /// `VocabIndex|TextRecordIndex|LocalVocabIndex`. These types can
-  /// represent values in the range [0, 2^60]. When `index` is outside of this
-  /// range, and `IndexTooLargeException` is thrown.
-  static ValueId makeFromVocabIndex(VocabIndex index) {
-    return makeFromIndex(index.get(), Datatype::VocabIndex);
+  /// represent all values of `uint64_t`.
+  static constexpr ValueId makeFromVocabIndex(VocabIndex index) noexcept {
+    return {index.get(), Datatype::VocabIndex};
   }
 
-  static ValueId makeFromEncodedVal(uint64_t idx) {
-    return makeFromIndex(idx, Datatype::EncodedVal);
+  static constexpr ValueId makeFromEncodedVal(uint64_t idx) noexcept {
+    return {idx, Datatype::EncodedVal};
   }
 
-  static ValueId makeFromTextRecordIndex(TextRecordIndex index) {
-    return makeFromIndex(index.get(), Datatype::TextRecordIndex);
+  static constexpr ValueId makeFromTextRecordIndex(
+      TextRecordIndex index) noexcept {
+    return {index.get(), Datatype::TextRecordIndex};
   }
-  static ValueId makeFromLocalVocabIndex(LocalVocabIndex index) {
-    // The last `numDatatypeBits` of a `LocalVocabIndex` are always zero, so we
-    // can reuse them for the datatype.
-    static_assert(alignof(decltype(*index)) >= (1u << numDatatypeBits));
-    return makeFromIndex(reinterpret_cast<T>(index) >> numDatatypeBits,
-                         Datatype::LocalVocabIndex);
+  static ValueId makeFromLocalVocabIndex(LocalVocabIndex index) noexcept {
+    // The pointer is stored verbatim in the payload.
+    return {reinterpret_cast<T>(index), Datatype::LocalVocabIndex};
   }
-  static ValueId makeFromWordVocabIndex(WordVocabIndex index) {
-    return makeFromIndex(index.get(), Datatype::WordVocabIndex);
+  static constexpr ValueId makeFromWordVocabIndex(
+      WordVocabIndex index) noexcept {
+    return {index.get(), Datatype::WordVocabIndex};
   }
-  static ValueId makeFromBlankNodeIndex(BlankNodeIndex index) {
-    return makeFromIndex(index.get(), Datatype::BlankNodeIndex);
+  static constexpr ValueId makeFromBlankNodeIndex(
+      BlankNodeIndex index) noexcept {
+    return {index.get(), Datatype::BlankNodeIndex};
   }
 
   /// Obtain the unsigned index that this `ValueId` encodes. If `getDatatype()
   /// != [VocabIndex|TextRecordIndex|LocalVocabIndex]` then the result is
   /// unspecified.
   [[nodiscard]] constexpr VocabIndex getVocabIndex() const noexcept {
-    return VocabIndex::make(removeDatatypeBits(_bits));
+    return VocabIndex::make(payload_);
   }
 
   [[nodiscard]] constexpr uint64_t getEncodedVal() const noexcept {
-    return removeDatatypeBits(_bits);
+    return payload_;
   }
 
   [[nodiscard]] constexpr TextRecordIndex getTextRecordIndex() const noexcept {
-    return TextRecordIndex::make(removeDatatypeBits(_bits));
+    return TextRecordIndex::make(payload_);
   }
   [[nodiscard]] LocalVocabIndex getLocalVocabIndex() const noexcept {
-    return reinterpret_cast<LocalVocabIndex>(_bits << numDatatypeBits);
+    return reinterpret_cast<LocalVocabIndex>(payload_);
   }
   [[nodiscard]] constexpr WordVocabIndex getWordVocabIndex() const noexcept {
-    return WordVocabIndex::make(removeDatatypeBits(_bits));
+    return WordVocabIndex::make(payload_);
   }
 
   [[nodiscard]] constexpr BlankNodeIndex getBlankNodeIndex() const noexcept {
-    return BlankNodeIndex::make(removeDatatypeBits(_bits));
+    return BlankNodeIndex::make(payload_);
   }
 
   // Store or load a `Date` object.
   static ValueId makeFromDate(DateYearOrDuration d) noexcept {
-    return addDatatypeBits(absl::bit_cast<uint64_t>(d), Datatype::Date);
+    return {absl::bit_cast<uint64_t>(d), Datatype::Date};
   }
 
   DateYearOrDuration getDate() const noexcept {
-    return absl::bit_cast<DateYearOrDuration>(removeDatatypeBits(_bits));
+    return absl::bit_cast<DateYearOrDuration>(payload_);
   }
-
-  // TODO<joka921> implement dates
 
   /// Create a `ValueId` for a GeoPoint object (representing a POINT from WKT).
   static ValueId makeFromGeoPoint(GeoPoint p) {
-    return addDatatypeBits(p.toBitRepresentation(), Datatype::GeoPoint);
+    return {p.toBitRepresentation(), Datatype::GeoPoint};
   }
 
   /// Obtain a new `GeoPoint` object representing the pair of coordinates that
   /// this `ValueId` encodes. If `getDatatype() != GeoPoint` then the result
   /// is unspecified.
   GeoPoint getGeoPoint() const {
-    T bits = removeDatatypeBits(_bits);
-    return GeoPoint::fromBitRepresentation(bits);
+    return GeoPoint::fromBitRepresentation(payload_);
   }
 
   // An ID is considered trivial, if its datatype is trivial (see
@@ -420,12 +412,12 @@ class ValueId {
           static_cast<size_t>(Datatype::LocalVocabIndex));
 
   /// Return the smallest and largest possible `ValueId` wrt the underlying
-  /// representation
-  constexpr static ValueId min() noexcept {
-    return {std::numeric_limits<T>::min()};
-  }
+  /// representation. Note: The datatype byte of `max()` is `0xFF`, which is
+  /// not a valid `Datatype`. Such IDs must only be used as sentinel values
+  /// for comparisons, never as actual values.
+  constexpr static ValueId min() noexcept { return {0, 0}; }
   constexpr static ValueId max() noexcept {
-    return {std::numeric_limits<T>::max()};
+    return {std::numeric_limits<T>::max(), uint8_t{0xFF}};
   }
 
   /// Enable hashing in abseil for `ValueId` (required by `ad_utility::HashSet`
@@ -439,7 +431,7 @@ class ValueId {
     // the LocalVocabEntry).
     if (id.getDatatype() != Datatype::LocalVocabIndex) {
       static_assert(isOnlyLocalVocabNotBitwiseComparable);
-      return H::combine(std::move(h), id._bits, 0);
+      return H::combine(std::move(h), id.datatype_, id.payload_, 0);
     }
     auto [lower, upper] = id.getLocalVocabIndex()->positionInVocab();
     if (upper != lower) {
@@ -449,8 +441,11 @@ class ValueId {
   }
 
   /// Enable the serialization of `ValueId` in the `ad_utility::serialization`
-  /// framework.
-  AD_SERIALIZE_FRIEND_FUNCTION(ValueId) { serializer | arg._bits; }
+  /// framework by simply copying the 16 raw bytes (including the zeroed
+  /// padding). This is much faster than serializing the datatype and payload
+  /// separately, especially for large contiguous arrays of IDs.
+  template <typename U>
+  friend std::true_type allowTrivialSerialization(ValueId, U);
 
   /// Similar to `std::visit` for `std::variant`. First gets the datatype and
   /// then calls `visitor(getTYPE)` where `getTYPE` is the correct getter method
@@ -498,7 +493,7 @@ class ValueId {
   friend std::ostream& operator<<(std::ostream& ostr, const ValueId& id) {
     ostr << toString(id.getDatatype())[0] << ':';
     if (id.getDatatype() == Datatype::Undefined) {
-      return ostr << id.getBits();
+      return ostr << id.getPayloadBits();
     }
 
     auto visitor = [&ostr](auto&& value) {
@@ -541,31 +536,29 @@ class ValueId {
     }
   }
 
-  // Private constructor that implicitly converts from the underlying
-  // representation. Used in the implementation of the static factory methods
-  // `Double()`, `Int()` etc.
-  constexpr ValueId(T bits) : _bits{bits} {}
-
-  // Set the first 4 bits of `bits` to a 4-bit representation of `type`.
-  // Requires that the first four bits of `bits` are all zero.
-  static constexpr ValueId addDatatypeBits(T bits, Datatype type) {
-    auto mask = static_cast<T>(type) << numDataBits;
-    return {bits | mask};
+  // The datatype-major bitwise comparison: first compare the datatype byte,
+  // then the payload bits as unsigned integers. This is only correct if
+  // neither of the involved IDs has the `LocalVocabIndex` datatype.
+  constexpr ql::strong_ordering compareBitwiseImpl(const ValueId& other) const {
+    auto typeComparison = ql::compareThreeWay(datatype_, other.datatype_);
+    return typeComparison != 0 ? typeComparison
+                               : ql::compareThreeWay(payload_, other.payload_);
   }
 
-  // Set the datatype bits of `bits` to zero.
-  static constexpr T removeDatatypeBits(T bits) noexcept {
-    auto mask = ad_utility::bitMaskForLowerBits(numDataBits);
-    return bits & mask;
-  }
-
-  // Helper function for the implementation of the unsigned index types.
-  static constexpr ValueId makeFromIndex(T id, Datatype type) {
-    if (id > maxIndex) {
-      throw IndexTooLargeException(id);
-    }
-    return addDatatypeBits(id, type);
-  }
+  // Private constructors from the payload bits and the datatype (byte). They
+  // are used in the implementation of the static factory methods
+  // `makeFromDouble()`, `makeFromInt()` etc. Note: The explicit `padding_`
+  // bytes are always initialized to zero, s.t. all valid `ValueId`s have a
+  // deterministic byte representation.
+  constexpr ValueId(T payload, uint8_t datatype)
+      : payload_{payload}, datatype_{datatype}, padding_{} {}
+  constexpr ValueId(T payload, Datatype datatype)
+      : ValueId{payload, static_cast<uint8_t>(datatype)} {}
 };
+
+// The materialized `ValueId` must be trivially copyable (e.g. for the
+// serialization) and 16 bytes in size.
+static_assert(std::is_trivially_copyable_v<ValueId>);
+static_assert(sizeof(ValueId) == 16);
 
 #endif  // QLEVER_SRC_GLOBAL_VALUEID_H

--- a/src/global/ValueId.h
+++ b/src/global/ValueId.h
@@ -224,7 +224,7 @@ class ValueId {
   // on the underlying bits, which allows much better code generation (e.g.
   // vectorization). In particular, this method should for example be used
   // during index building.
-  constexpr auto compareWithoutLocalVocab(const ValueId& other) const {
+  auto compareWithoutLocalVocab(const ValueId& other) const {
     // NOTE: If this static assertion is violated at some point, make sure to
     // check all callers of this function if they are still correct.
     static_assert(isOnlyLocalVocabNotBitwiseComparable);

--- a/src/global/ValueIdBitRepresentation.h
+++ b/src/global/ValueIdBitRepresentation.h
@@ -1,0 +1,89 @@
+// Copyright 2026 The QLever Authors, in particular:
+//
+// 2026 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#ifndef QLEVER_SRC_GLOBAL_VALUEIDBITREPRESENTATION_H
+#define QLEVER_SRC_GLOBAL_VALUEIDBITREPRESENTATION_H
+
+#include <cstdint>
+#include <functional>
+#include <limits>
+#include <ostream>
+#include <string>
+#include <type_traits>
+
+#include "backports/three_way_comparison.h"
+
+// The raw bit representation of a `ValueId` (see `ValueId.h`): a single
+// datatype byte and a full 64-bit word of payload. The comparison is
+// datatype-major (first by `datatype_`, then by `payload_`), which is
+// consistent with the ordering of the corresponding `ValueId`s (as long as no
+// `LocalVocabIndex` is involved).
+// Note: This struct lives in its own header (and not inside the `ValueId`
+// class) because `LocalVocabEntry.h` needs it and must not include
+// `ValueId.h` (cyclic dependency).
+struct ValueIdBitRepresentation {
+  uint8_t datatype_;
+  uint64_t payload_;
+
+  // The default three-way comparison is datatype-major because `datatype_`
+  // is declared before `payload_`.
+  QL_DEFINE_DEFAULTED_THREEWAY_OPERATOR_LOCAL_CONSTEXPR(
+      ValueIdBitRepresentation, datatype_, payload_)
+
+  // Return the bit representation of the smallest `ValueId` that is greater
+  // than the `ValueId` of this bit representation. The overflow of the
+  // payload carries into the datatype byte, analogously to the increment of
+  // the single integer in the previous packed 64-bit representation.
+  constexpr ValueIdBitRepresentation incremented() const {
+    if (payload_ == std::numeric_limits<uint64_t>::max()) {
+      return {static_cast<uint8_t>(datatype_ + 1), 0};
+    }
+    return {datatype_, payload_ + 1};
+  }
+
+  // Enable hashing in abseil (required by `ad_utility::HashSet` and
+  // `ad_utility::HashMap`).
+  template <typename H>
+  friend H AbslHashValue(H h, const ValueIdBitRepresentation& rep) {
+    return H::combine(std::move(h), rep.datatype_, rep.payload_);
+  }
+
+  // The bit representation can be serialized by simply copying its bytes.
+  // Note: The padding bytes between `datatype_` and `payload_` are not
+  // guaranteed to be zero, so the byte-level output is not deterministic,
+  // but roundtripping works correctly.
+  template <typename U>
+  friend std::true_type allowTrivialSerialization(ValueIdBitRepresentation, U);
+
+  // Support for `absl::StrCat` etc., analogous to the stringification of the
+  // previous single-integer bit representation.
+  template <typename Sink>
+  friend void AbslStringify(Sink& sink, const ValueIdBitRepresentation& rep) {
+    sink.Append(std::to_string(rep.datatype_));
+    sink.Append(":");
+    sink.Append(std::to_string(rep.payload_));
+  }
+
+  // This operator is only used for debugging and testing.
+  friend std::ostream& operator<<(std::ostream& ostr,
+                                  const ValueIdBitRepresentation& rep) {
+    return ostr << static_cast<int>(rep.datatype_) << ':' << rep.payload_;
+  }
+};
+
+// Make `ValueIdBitRepresentation` usable as a key of `std` hash containers.
+template <>
+struct std::hash<ValueIdBitRepresentation> {
+  size_t operator()(const ValueIdBitRepresentation& rep) const noexcept {
+    return std::hash<uint64_t>{}(rep.payload_ ^
+                                 (static_cast<uint64_t>(rep.datatype_) << 56));
+  }
+};
+
+#endif  // QLEVER_SRC_GLOBAL_VALUEIDBITREPRESENTATION_H

--- a/src/index/CompressedRelation.cpp
+++ b/src/index/CompressedRelation.cpp
@@ -80,7 +80,7 @@ CompressedBlockMetadataNoBlockIndex::OffsetAndCompressedSize
 CompressedBlockMetadataNoBlockIndex::getOffsetAndCompressedSizeForColumn(
     ColumnIndex columnIndex) const {
   if (!offsetsAndCompressedSize_.has_value()) {
-    return {0, 0};
+    return {0, 0, 0};
   }
   return offsetsAndCompressedSize_.value().at(columnIndex);
 }
@@ -616,7 +616,7 @@ Id CompressedRelationReader::getRelevantIdFromTriple(
 
 // _____________________________________________________________________________
 auto CompressedRelationReader::getBlocksForJoin(
-    ql::span<const Id> joinColumn,
+    columnBasedIdTable::ConstIdColumnSpan joinColumn,
     const ScanSpecAndBlocksAndBounds& metadataAndBlocks)
     -> GetBlocksForJoinResult {
   if (joinColumn.empty() || metadataAndBlocks.getBlockMetadataView().empty()) {
@@ -1143,8 +1143,10 @@ CompressedBlock CompressedRelationReader::readCompressedBlockFromFile(
     const auto& offset =
         blockMetaData.getOffsetAndCompressedSizeForColumn(columnIndices[i]);
     auto& currentCol = compressedBuffer[i];
-    currentCol.resize(offset.compressedSize_);
-    file_.read(currentCol.data(), offset.compressedSize_, offset.offsetInFile_);
+    currentCol.data_.resize(offset.compressedSize_);
+    currentCol.compressedSizePayloads_ = offset.compressedSizePayloads_;
+    file_.read(currentCol.data_.data(), offset.compressedSize_,
+               offset.offsetInFile_);
   }
   return compressedBuffer;
 }
@@ -1155,8 +1157,8 @@ DecompressedBlock CompressedRelationReader::decompressBlock(
   DecompressedBlock decompressedBlock{compressedBlock.size(), allocator_};
   decompressedBlock.resize(numRowsToRead);
   for (size_t i = 0; i < compressedBlock.size(); ++i) {
-    auto col = decompressedBlock.getColumn(i);
-    decompressColumn(compressedBlock[i], numRowsToRead, col.data());
+    decompressColumn(compressedBlock[i], numRowsToRead,
+                     decompressedBlock.getColumn(i));
   }
   return decompressedBlock;
 }
@@ -1190,15 +1192,23 @@ CompressedRelationReader::decompressAndPostprocessBlock(
 }
 
 // ____________________________________________________________________________
-template <typename Iterator>
 void CompressedRelationReader::decompressColumn(
-    const std::vector<char>& compressedBlock, size_t numRowsToRead,
-    Iterator iterator) {
-  auto numBytesActuallyRead = ZstdWrapper::decompressToBuffer(
-      compressedBlock.data(), compressedBlock.size(), iterator,
-      numRowsToRead * sizeof(*iterator));
-  static_assert(sizeof(Id) == sizeof(*iterator));
-  AD_CORRECTNESS_CHECK(numRowsToRead * sizeof(Id) == numBytesActuallyRead);
+    const CompressedColumn& compressedColumn, size_t numRowsToRead,
+    columnBasedIdTable::MutableIdColumnSpan column) {
+  // The compressed payload words and the compressed datatype bytes are
+  // stored adjacently and are decompressed separately into the split storage
+  // of the `column`.
+  const auto& data = compressedColumn.data_;
+  auto sizePayloads = compressedColumn.compressedSizePayloads_;
+  AD_CORRECTNESS_CHECK(sizePayloads <= data.size());
+  auto numPayloadBytes = ZstdWrapper::decompressToBuffer(
+      data.data(), sizePayloads, column.payloadData(),
+      numRowsToRead * sizeof(uint64_t));
+  AD_CORRECTNESS_CHECK(numRowsToRead * sizeof(uint64_t) == numPayloadBytes);
+  auto numDatatypeBytes = ZstdWrapper::decompressToBuffer(
+      data.data() + sizePayloads, data.size() - sizePayloads,
+      column.datatypeData(), numRowsToRead * sizeof(uint8_t));
+  AD_CORRECTNESS_CHECK(numRowsToRead * sizeof(uint8_t) == numDatatypeBytes);
 }
 
 // ____________________________________________________________________________
@@ -1218,14 +1228,23 @@ CompressedRelationReader::readAndDecompressBlock(
 
 // ____________________________________________________________________________
 CompressedBlockMetadata::OffsetAndCompressedSize
-CompressedRelationWriter::compressAndWriteColumn(ql::span<const Id> column) {
-  std::vector<char> compressedBlock = ZstdWrapper::compress(
-      (void*)(column.data()), column.size() * sizeof(column[0]));
-  auto compressedSize = compressedBlock.size();
+CompressedRelationWriter::compressAndWriteColumn(
+    columnBasedIdTable::ConstIdColumnSpan column) {
+  // Compress the payload words and the datatype bytes separately and store
+  // them adjacently.
+  auto payloads = column.payloadSpan();
+  auto datatypes = column.datatypeSpan();
+  std::vector<char> compressedPayloads = ZstdWrapper::compress(
+      (void*)(payloads.data()), payloads.size() * sizeof(payloads[0]));
+  std::vector<char> compressedDatatypes = ZstdWrapper::compress(
+      (void*)(datatypes.data()), datatypes.size() * sizeof(datatypes[0]));
+  auto compressedSizePayloads = compressedPayloads.size();
+  auto compressedSize = compressedSizePayloads + compressedDatatypes.size();
   auto file = outfile_.wlock();
   auto offsetInFile = file->tell();
-  file->write(compressedBlock.data(), compressedBlock.size());
-  return {offsetInFile, compressedSize};
+  file->write(compressedPayloads.data(), compressedPayloads.size());
+  file->write(compressedDatatypes.data(), compressedDatatypes.size());
+  return {offsetInFile, compressedSize, compressedSizePayloads};
 }
 
 // _____________________________________________________________________________

--- a/src/index/CompressedRelation.h
+++ b/src/index/CompressedRelation.h
@@ -52,7 +52,15 @@ struct DecompressedBlockAndMetadata {
 
 // After compression the columns have different sizes, so we cannot use an
 // `IdTable`.
-using CompressedBlock = std::vector<std::vector<char>>;
+// The compressed data of a single column of a block: the concatenation of
+// the compressed payload words and the compressed datatype bytes, together
+// with the size of the compressed payload part (which is needed to split the
+// two parts when decompressing).
+struct CompressedColumn {
+  std::vector<char> data_;
+  size_t compressedSizePayloads_;
+};
+using CompressedBlock = std::vector<CompressedColumn>;
 
 // The metadata of a compressed block of ID triples in an index permutation.
 struct CompressedBlockMetadataNoBlockIndex {
@@ -60,9 +68,14 @@ struct CompressedBlockMetadataNoBlockIndex {
   // stored separately (but adjacently).
   struct OffsetAndCompressedSize {
     off_t offsetInFile_;
+    // The total compressed size of the column (compressed payload words
+    // directly followed by the compressed datatype bytes).
     size_t compressedSize_;
+    // The compressed size of only the payload part.
+    size_t compressedSizePayloads_;
     QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(OffsetAndCompressedSize,
-                                                offsetInFile_, compressedSize_)
+                                                offsetInFile_, compressedSize_,
+                                                compressedSizePayloads_)
   };
 
   using GraphInfo = std::optional<std::vector<Id>>;
@@ -89,6 +102,10 @@ struct CompressedBlockMetadataNoBlockIndex {
   // example, for Wikidata, we have only around 50K blocks with block size 8M
   // and around 5M blocks with block size 80K; even the latter takes only half
   // a GB in total.
+  // TODO<joka921> The `PermutedTriple` stores materialized 16-byte `Id`s
+  // (7 padding bytes each). In the future this should probably be rewritten
+  // to an efficient format that stores first the four payloads and then the
+  // four datatype bytes.
   struct PermutedTriple {
     Id col0Id_;
     Id col1Id_;
@@ -203,6 +220,7 @@ struct CompressedBlockMetadata : CompressedBlockMetadataNoBlockIndex {
 AD_SERIALIZE_FUNCTION(CompressedBlockMetadata::OffsetAndCompressedSize) {
   serializer | arg.offsetInFile_;
   serializer | arg.compressedSize_;
+  serializer | arg.compressedSizePayloads_;
 }
 
 // Serialization of the block metadata.
@@ -448,7 +466,7 @@ class CompressedRelationWriter {
   size_t blocksize() const {
     return std::max(
         size_t{1},
-        size_t{uncompressedBlocksizePerColumn_.getBytes() / sizeof(Id)});
+        size_t{uncompressedBlocksizePerColumn_.getBytes() / sizeof(uint64_t)});
   }
 
  private:
@@ -468,10 +486,12 @@ class CompressedRelationWriter {
   // data of the written block. Then clear `smallRelationsBuffer_`.
   void writeBufferedRelationsToSingleBlock();
 
-  // Compress the `column` and write it to the `outfile_`. Return the offset and
-  // size of the compressed column in the `outfile_`.
+  // Compress the `column` (the payload part and the datatype part are
+  // compressed separately and stored adjacently) and write it to the
+  // `outfile_`. Return the offset and sizes of the compressed column in the
+  // `outfile_`.
   CompressedBlockMetadata::OffsetAndCompressedSize compressAndWriteColumn(
-      ql::span<const Id> column);
+      columnBasedIdTable::ConstIdColumnSpan column);
 
   // Return the number of columns that is stored inside the blocks.
   size_t numColumns() const { return numColumns_; }
@@ -746,7 +766,7 @@ class CompressedRelationReader {
     size_t numHandledBlocks{0};
   };
   static GetBlocksForJoinResult getBlocksForJoin(
-      ql::span<const Id> joinColumn,
+      columnBasedIdTable::ConstIdColumnSpan joinColumn,
       const ScanSpecAndBlocksAndBounds& metadataAndBlocks);
 
   // For each of `metadataAndBlocks, metadataAndBlocks2` get the blocks (an
@@ -895,11 +915,11 @@ class CompressedRelationReader {
 
   // Helper function used by `decompressBlock` and
   // `decompressBlockToExistingIdTable`. Decompress the `compressedColumn` and
-  // store the result at the `iterator`. For the `numRowsToRead` argument, see
+  // store the result in the `column`. For the `numRowsToRead` argument, see
   // the documentation of `decompressBlock`.
-  template <typename Iterator>
-  static void decompressColumn(const std::vector<char>& compressedColumn,
-                               size_t numRowsToRead, Iterator iterator);
+  static void decompressColumn(const CompressedColumn& compressedColumn,
+                               size_t numRowsToRead,
+                               columnBasedIdTable::MutableIdColumnSpan column);
 
   // Read and decompress the parts of the block given by `blockMetaData` (which
   // identifies the block) and `scanConfig` (which specifies the part of that

--- a/src/index/CompressedRelationHelpersImpl.h
+++ b/src/index/CompressedRelationHelpersImpl.h
@@ -20,8 +20,11 @@ static constexpr size_t c2Idx = 2;
 // ignores the first column as well as any payload columns).
 struct ComparatorForConstCol0 {
   bool operator()(const auto& a, const auto& b) const {
-    return std::tie(a[c1Idx], a[c2Idx], a[ADDITIONAL_COLUMN_GRAPH_ID]) <
-           std::tie(b[c1Idx], b[c2Idx], b[ADDITIONAL_COLUMN_GRAPH_ID]);
+    auto key = [](const auto& row) {
+      return std::tuple<Id, Id, Id>{row[c1Idx], row[c2Idx],
+                                    row[ADDITIONAL_COLUMN_GRAPH_ID]};
+    };
+    return key(a) < key(b);
   }
 };
 

--- a/src/index/CompressedRelationPermutationWriterImpl.h
+++ b/src/index/CompressedRelationPermutationWriterImpl.h
@@ -9,6 +9,7 @@
 #define QLEVER_SRC_INDEX_COMPRESSEDRELATIONPERMUTATIONWRITERIMPL_H_
 
 #include "engine/idTable/CompressedExternalIdTable.h"
+#include "engine/idTable/IdColumnAlgorithms.h"
 #include "index/CompressedRelation.h"
 #include "index/CompressedRelationHelpersImpl.h"
 #include "util/ProgressBar.h"
@@ -28,16 +29,19 @@ struct CompressedRelationWriter::AddBlockOfSmallRelationsToSwitched {
     blockOfSmallRelations.swapColumns(c1Idx, c2Idx);
 
     // We only need to sort by the columns of the triple + the graph
-    // column, not the additional payload. Note: We could also use
-    // `compareWithoutLocalVocab` to compare the IDs cheaper, but this
-    // sort is far from being a performance bottleneck.
-    auto compare = [](const auto& a, const auto& b) {
-      auto key = [](const auto& row) {
-        return std::tuple<Id, Id, Id, Id>{row[0], row[1], row[2], row[3]};
+    // column, not the additional payload. During the index build there are
+    // no local vocab entries, so we can use the fast columnar sort (with a
+    // fallback to a generic comparison sort).
+    if (!columnBasedIdTable::trySortByKeyColumnsBitwise(
+            blockOfSmallRelations, std::array<size_t, 4>{0, 1, 2, 3})) {
+      auto compare = [](const auto& a, const auto& b) {
+        auto key = [](const auto& row) {
+          return std::tuple<Id, Id, Id, Id>{row[0], row[1], row[2], row[3]};
+        };
+        return key(a) < key(b);
       };
-      return key(a) < key(b);
-    };
-    ql::ranges::sort(blockOfSmallRelations, compare);
+      ql::ranges::sort(blockOfSmallRelations, compare);
+    }
     AD_CORRECTNESS_CHECK(!blockOfSmallRelations.empty());
     // Note: it is important that we store these two IDs before moving the
     // `relation`, because the evaluation order of function arguments is

--- a/src/index/CompressedRelationPermutationWriterImpl.h
+++ b/src/index/CompressedRelationPermutationWriterImpl.h
@@ -32,8 +32,10 @@ struct CompressedRelationWriter::AddBlockOfSmallRelationsToSwitched {
     // `compareWithoutLocalVocab` to compare the IDs cheaper, but this
     // sort is far from being a performance bottleneck.
     auto compare = [](const auto& a, const auto& b) {
-      return std::tie(a[0], a[1], a[2], a[3]) <
-             std::tie(b[0], b[1], b[2], b[3]);
+      auto key = [](const auto& row) {
+        return std::tuple<Id, Id, Id, Id>{row[0], row[1], row[2], row[3]};
+      };
+      return key(a) < key(b);
     };
     ql::ranges::sort(blockOfSmallRelations, compare);
     AD_CORRECTNESS_CHECK(!blockOfSmallRelations.empty());

--- a/src/index/DeltaTriples.cpp
+++ b/src/index/DeltaTriples.cpp
@@ -248,8 +248,8 @@ DeltaTriples::Triples DeltaTriples::makeInternalTriples(const Triples& triples,
         !optionalLiteralOrIri.value().hasLanguageTag()) {
       continue;
     }
-    const auto& predicate =
-        predicateCache_.getOrCompute(ids.at(1).getBits(), [this](Id::T bits) {
+    const auto& predicate = predicateCache_.getOrCompute(
+        ids.at(1).getBits(), [this](Id::BitRepresentation bits) {
           auto optionalPredicate = ql::exportIds::idToLiteralOrIri(
               index_, Id::fromBits(bits), localVocab_, true);
           AD_CORRECTNESS_CHECK(optionalPredicate.has_value());

--- a/src/index/DeltaTriples.h
+++ b/src/index/DeltaTriples.h
@@ -136,7 +136,8 @@ class DeltaTriples {
   // of `makeInternalTriples`. For example in wikidata `wdt:P31`, or `wdt:P279`
   // are frequently used, so we try to avoid an expensive lookup from disk.
   static constexpr size_t predicateCacheSize_ = 1000;
-  ad_utility::util::LRUCache<Id::T, ad_utility::triple_component::Iri>
+  ad_utility::util::LRUCache<Id::BitRepresentation,
+                             ad_utility::triple_component::Iri>
       predicateCache_{predicateCacheSize_};
 
   // Assert that the Permutation Enum values have the expected int values.

--- a/src/index/ExternalSortFunctors.h
+++ b/src/index/ExternalSortFunctors.h
@@ -35,7 +35,9 @@ struct SortTriple {
       AD_EXPENSIVE_CHECK(a.size() >= ADDITIONAL_COLUMN_GRAPH_ID &&
                          b.size() >= ADDITIONAL_COLUMN_GRAPH_ID);
     }
-    constexpr auto compare = &Id::compareWithoutLocalVocab;
+    constexpr auto compare = [](const Id& x, const Id& y) {
+      return x.compareWithoutLocalVocab(y);
+    };
     // TODO<joka921> The manual invoking is ugly, probably we could use
     // `ql::ranges::lexicographical_compare`, but we have to carefully measure
     // that this change doesn't slow down the index build.

--- a/src/index/ExternalSortFunctors.h
+++ b/src/index/ExternalSortFunctors.h
@@ -26,6 +26,21 @@
 template <int i0, int i1, int i2, bool hasGraphColumn = true>
 struct SortTriple {
   using T = std::array<Id, 3>;
+
+  // The indices of the columns that this comparator sorts by (in order).
+  // They are used by the `CompressedExternalIdTableSorter` to sort blocks
+  // with a fast columnar sort instead of a comparison sort on the rows (see
+  // `trySortByKeyColumnsBitwise`).
+  static constexpr size_t numKeyColumns = hasGraphColumn ? 4 : 3;
+  static constexpr std::array<size_t, numKeyColumns> sortedKeyColumnIndices_ =
+      []() {
+        if constexpr (hasGraphColumn) {
+          return std::array<size_t, 4>{size_t{i0}, size_t{i1}, size_t{i2},
+                                       ADDITIONAL_COLUMN_GRAPH_ID};
+        } else {
+          return std::array<size_t, 3>{size_t{i0}, size_t{i1}, size_t{i2}};
+        }
+      }();
   // comparison function
   template <typename T1, typename T2>
   bool operator()(const T1& a, const T2& b) const {

--- a/src/index/IdTableUtils.cpp
+++ b/src/index/IdTableUtils.cpp
@@ -5,6 +5,7 @@
 #include "index/IdTableUtils.h"
 
 #include "engine/CallFixedSize.h"
+#include "engine/idTable/IdColumnAlgorithms.h"
 #include "util/ChunkedForLoop.h"
 #include "util/Exception.h"
 
@@ -23,6 +24,14 @@ void IdTableUtils::sort(IdTable& idTable,
   // TODO<joka921> Also experiment with sorting algorithms that take the
   // column-based structure of the `IdTable` into account.
   if (sortCols.size() == 1) {
+    // Fast path: If the key column contains no `LocalVocabIndex` IDs (which
+    // don't compare bitwise), sort a (payload, rowIndex) permutation
+    // (partitioned by datatype) and apply it to the columns. This is much
+    // faster than the comparison sort on the row proxies, which has to touch
+    // all payload and datatype buffers of the table for every swap.
+    if (columnBasedIdTable::trySortBySingleKeyColumn(idTable, sortCols[0])) {
+      return;
+    }
     ad_utility::callFixedSizeVi(width, [&idTable, col = sortCols[0]](auto I) {
       IdTableUtils::sort<I>(&idTable, col);
     });

--- a/src/index/IndexBuilderTypes.h
+++ b/src/index/IndexBuilderTypes.h
@@ -84,12 +84,12 @@ class PartialVocabIndexWithExternalFlag {
  public:
   PartialVocabIndexWithExternalFlag(uint64_t id, bool isExternal)
       : encodedId_{(uint64_t(isExternal) << 63) | id} {
-    // The top four bits of any partial-vocab id must be zero: in the final
-    // `Id` they are occupied by the datatype tag (see `ValueId::numDataBits`).
-    // This guard catches future regressions that funnel a tagged value or an
-    // underflowed counter through here, which would otherwise silently
-    // collide with the `isExternal` bit and corrupt the vocabulary mapping.
-    AD_EXPENSIVE_CHECK(id < (uint64_t{1} << ValueId::numDataBits));
+    // The topmost bit of any partial-vocab id must be zero, because it is
+    // occupied by the `isExternal` flag. This guard catches future regressions
+    // that funnel a tagged value or an underflowed counter through here, which
+    // would otherwise silently collide with the `isExternal` bit and corrupt
+    // the vocabulary mapping.
+    AD_EXPENSIVE_CHECK(id < (uint64_t{1} << 63));
   }
 
   PartialVocabIndexWithExternalFlag() = default;

--- a/src/index/IndexFormatVersion.h
+++ b/src/index/IndexFormatVersion.h
@@ -40,7 +40,7 @@ struct IndexFormatVersion {
 // The actual index version. Change it once the binary format of the index
 // changes.
 inline const IndexFormatVersion& indexFormatVersion{
-    1572, DateYearOrDuration{Date{2024, 10, 22}}};
+    3048, DateYearOrDuration{Date{2026, 7, 10}}};
 }  // namespace qlever
 
 #endif  // QLEVER_SRC_INDEX_INDEXFORMATVERSION_H

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -770,20 +770,35 @@ auto IndexImpl::convertPartialToGlobalIds(
   ad_utility::TaskQueue<true> writeQueue(30, 1, "Writing global Ids to file");
 
   // For all triple elements find their mapping from partial to global ids.
-  auto transformTriple = [](Buffer::row_reference& curTriple, auto& idMap) {
-    for (auto&& id : curTriple) {
-      // TODO<joka92> Since the mapping only maps `VocabIndex->VocabIndex`,
-      // probably the mapping should also be defined as `HashMap<VocabIndex,
-      // VocabIndex>` instead of `HashMap<Id, Id>`
-      if (id.getDatatype() != Datatype::VocabIndex) {
-        // Check that all the internal, special IDs which we have introduced
-        // for performance reasons are eliminated.
-        AD_CORRECTNESS_CHECK(id.getDatatype() != Datatype::Undefined);
-        continue;
+  // Work column-wise directly on the datatype bytes and payload words to
+  // avoid materializing the `Id`s for the (frequent) elements that don't have
+  // to be changed.
+  auto transformTriples = [](Buffer& triples, auto& idMap) {
+    // TODO<joka92> Since the mapping only maps `VocabIndex->VocabIndex`,
+    // probably the mapping should also be defined as `HashMap<VocabIndex,
+    // VocabIndex>` instead of `HashMap<Id, Id>`
+    static constexpr auto vocabType =
+        static_cast<uint8_t>(Datatype::VocabIndex);
+    static constexpr auto undefinedType =
+        static_cast<uint8_t>(Datatype::Undefined);
+    for (size_t col = 0; col < triples.numColumns(); ++col) {
+      auto column = triples.getColumn(col);
+      auto payloads = column.payloadSpan();
+      auto types = column.datatypeSpan();
+      for (size_t i = 0; i < types.size(); ++i) {
+        if (types[i] != vocabType) {
+          // Check that all the internal, special IDs which we have introduced
+          // for performance reasons are eliminated.
+          AD_CORRECTNESS_CHECK(types[i] != undefinedType);
+          continue;
+        }
+        auto iterator =
+            idMap.find(Id::makeFromVocabIndex(VocabIndex::make(payloads[i])));
+        AD_CORRECTNESS_CHECK(iterator != idMap.end());
+        const auto bits = iterator->second.getBits();
+        types[i] = bits.datatype_;
+        payloads[i] = bits.payload_;
       }
-      auto iterator = idMap.find(id);
-      AD_CORRECTNESS_CHECK(iterator != idMap.end());
-      id = iterator->second;
     }
   };
 
@@ -813,16 +828,14 @@ auto IndexImpl::convertPartialToGlobalIds(
   // Return a lambda that for each of the `triples` transforms its partial to
   // global IDs using the `idMap`. The map is passed as a `shared_ptr` because
   // multiple batches need access to the same map.
-  auto getLookupTask = [&isQLeverInternalTriple, &writeQueue, &transformTriple,
+  auto getLookupTask = [&isQLeverInternalTriple, &writeQueue, &transformTriples,
                         &getWriteTask](Buffer triples,
                                        std::shared_ptr<Map> idMap) {
     return [&isQLeverInternalTriple, &writeQueue,
             triples = std::make_shared<Buffer>(std::move(triples)),
             idMap = std::move(idMap), &getWriteTask,
-            &transformTriple]() mutable {
-      for (Buffer::row_reference triple : *triples) {
-        transformTriple(triple, *idMap);
-      }
+            &transformTriples]() mutable {
+      transformTriples(*triples, *idMap);
       auto beginInternal =
           std::partition(triples->begin(), triples->end(),
                          [&isQLeverInternalTriple](const auto& row) {

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -119,7 +119,7 @@ template <typename T1, typename T2, typename F>
 static auto lazyOptionalJoinOnFirstColumn(T1& leftInput, T2& rightInput,
                                           F resultCallback) {
   auto projection = [](const auto& row) -> Id { return row[0]; };
-  auto projectionForComparator = [](const auto& rowOrId) -> const Id& {
+  auto projectionForComparator = [](const auto& rowOrId) -> Id {
     using T = std::decay_t<decltype(rowOrId)>;
     if constexpr (ad_utility::SimilarTo<T, Id>) {
       return rowOrId;
@@ -173,8 +173,10 @@ static auto fixBlockAfterPatternJoin(T block) {
   block.value().setColumnSubset(permutation);
   ql::ranges::for_each(
       block.value().getColumn(ADDITIONAL_COLUMN_INDEX_OBJECT_PATTERN),
-      [](Id& id) {
-        id = id.isUndefined() ? Id::makeFromInt(Pattern::NoPattern) : id;
+      [](auto&& id) {
+        if (id.isUndefined()) {
+          id = Id::makeFromInt(Pattern::NoPattern);
+        }
       });
   return std::move(block.value()).template toStatic<0>();
 }
@@ -300,7 +302,7 @@ IndexImpl::buildOspWithPatterns(
   // TODO<joka921> Simply get the output unsorted (should be cheaper).
   for (const auto& row : hasPatternPredicateSortedByPSO->sortedView()) {
     internalTripleSorter.push(
-        std::array{row[0], row[1], row[2], internalGraph});
+        std::array<Id, 4>{row[0], row[1], row[2], internalGraph});
   }
   hasPatternPredicateSortedByPSO->clear();
   return thirdSorter;
@@ -769,7 +771,7 @@ auto IndexImpl::convertPartialToGlobalIds(
 
   // For all triple elements find their mapping from partial to global ids.
   auto transformTriple = [](Buffer::row_reference& curTriple, auto& idMap) {
-    for (auto& id : curTriple) {
+    for (auto&& id : curTriple) {
       // TODO<joka92> Since the mapping only maps `VocabIndex->VocabIndex`,
       // probably the mapping should also be defined as `HashMap<VocabIndex,
       // VocabIndex>` instead of `HashMap<Id, Id>`
@@ -1891,7 +1893,8 @@ CPP_template_def(typename... NextSorter)(requires(sizeof...(NextSorter) <= 1))
       static_assert(NumColumnsIndexBuilding == 4,
                     "this place probably has to be changed when additional "
                     "payload columns are added");
-      auto tripleArr = std::array{triple[0], triple[1], triple[2], triple[3]};
+      auto tripleArr =
+          std::array<Id, 4>{triple[0], triple[1], triple[2], triple[3]};
       patternCreator.processTriple(tripleArr, ignoreForPatterns);
     };
     size_t numSubjects = createPermutationPair(

--- a/src/index/IndexRebuilder.cpp
+++ b/src/index/IndexRebuilder.cpp
@@ -259,9 +259,10 @@ ad_utility::InputRangeTypeErased<IdTableStatic<0>> readIndexAndRemap(
   auto remapId = [&insertionPositions, &localVocabMapping, &blankNodeBlocks,
                   minBlankNodeIndex, lastId = Id::makeUndefined(),
                   mappedId = Id::makeUndefined(),
-                  vocabHint = size_t{0}](Id& id) mutable {
+                  vocabHint = size_t{0}](auto&& idRef) mutable {
+    Id id = idRef;
     if (lastId.getBits() == id.getBits()) {
-      id = mappedId;
+      idRef = mappedId;
       return;
     }
     lastId = id;
@@ -275,6 +276,7 @@ ad_utility::InputRangeTypeErased<IdTableStatic<0>> readIndexAndRemap(
       id = remapBlankNodeId(id, blankNodeBlocks, minBlankNodeIndex);
     }
     mappedId = id;
+    idRef = id;
   };
 
   return ad_utility::InputRangeTypeErased{

--- a/src/index/IndexRebuilderTypes.h
+++ b/src/index/IndexRebuilderTypes.h
@@ -19,7 +19,7 @@ using OwnedBlocksEntry =
     ad_utility::BlankNodeManager::LocalBlankNodeManager::OwnedBlocksEntry;
 using OwnedBlocks = std::vector<OwnedBlocksEntry>;
 using InsertionPositions = std::vector<VocabIndex>;
-using LocalVocabMapping = ad_utility::HashMap<Id::T, Id>;
+using LocalVocabMapping = ad_utility::HashMap<Id::BitRepresentation, Id>;
 using BlankNodeBlocks = std::vector<uint64_t>;
 
 // Helper struct that groups together the data required to remap IDs from the

--- a/src/index/LocalVocabEntry.cpp
+++ b/src/index/LocalVocabEntry.cpp
@@ -38,7 +38,8 @@ auto LocalVocabEntry::positionInVocabExpensiveCase() const -> PositionInVocab {
     if (auto opt =
             context_->encodedIriManager().encode(toStringRepresentation());
         opt.has_value()) {
-      return std::pair{opt.value(), Id::fromBits(opt.value().getBits() + 1)};
+      return std::pair{opt.value(),
+                       Id::fromBits(opt.value().getBits().incremented())};
     }
     auto [l, u] = vocab.getPositionOfWord(toStringRepresentation());
     AD_CORRECTNESS_CHECK(u.get() - l.get() <= 1);

--- a/src/index/LocalVocabEntry.h
+++ b/src/index/LocalVocabEntry.h
@@ -13,6 +13,7 @@
 #include "backports/keywords.h"
 #include "backports/three_way_comparison.h"
 #include "global/TypedIndex.h"
+#include "global/ValueIdBitRepresentation.h"
 #include "global/VocabIndex.h"
 #include "parser/LiteralOrIri.h"
 #include "util/CopyableSynchronization.h"
@@ -35,7 +36,7 @@ class alignas(16) LocalVocabEntry
   // Note: The values here actually are `Id`s, but we cannot store the `Id` type
   // directly because of cyclic dependencies.
   static constexpr ad_utility::IndexTag proxyTag = "LveIdProxy";
-  using IdProxy = ad_utility::TypedIndex<uint64_t, proxyTag>;
+  using IdProxy = ad_utility::TypedIndex<ValueIdBitRepresentation, proxyTag>;
 
   FRIEND_TEST(TripleComponent, toValueId);
 

--- a/src/index/LocatedTriples.cpp
+++ b/src/index/LocatedTriples.cpp
@@ -87,8 +87,10 @@ namespace {
 // This code works for `std::integer_sequence` as well as
 // `ad_utility::ValueSequence`.
 template <typename Row, template <typename T, T...> typename Tp, size_t... I>
-auto tieHelper(Row& row, Tp<size_t, I...>) {
-  return std::tie(row[I]...);
+auto tieHelper(Row&& row, Tp<size_t, I...>) {
+  // Note: The entries of an `IdTable` row are proxy references, so we
+  // materialize them into a tuple of `Id`s (`std::tie` does not work here).
+  return std::tuple{Id{row[I]}...};
 };
 }  // namespace
 
@@ -99,7 +101,7 @@ auto tieHelper(Row& row, Tp<size_t, I...>) {
 CPP_template(size_t numIndexColumns, bool includeGraphColumn,
              typename T)(requires(numIndexColumns >= 1 &&
                                   numIndexColumns <=
-                                      3)) auto tieIdTableRow(T& row) {
+                                      3)) auto tieIdTableRow(T&& row) {
   return tieHelper(
       row, std::make_index_sequence<numIndexColumns +
                                     static_cast<size_t>(includeGraphColumn)>{});
@@ -271,14 +273,10 @@ VacuumStatistics processBlockForVacuum(
     }(std::make_index_sequence<4>{})};
   };
 
-  auto ltProj = [](const LocatedTriple& lt)
-      -> std::tuple<const Id&, const Id&, const Id&, const Id&> {
+  auto ltProj = [](const LocatedTriple& lt) {
     return tieLocatedTripleValue<3, true>(lt);
   };
-  auto rowProj = [](const auto& row)
-      -> std::tuple<const Id&, const Id&, const Id&, const Id&> {
-    return tieIdTableRow<3, true>(row);
-  };
+  auto rowProj = [](const auto& row) { return tieIdTableRow<3, true>(row); };
 
   auto rowsAsTuple = idTable | ql::views::transform(rowProj);
   auto filteredTriples = [&](bool isInsertion) {

--- a/src/index/vocabulary/SplitVocabulary.h
+++ b/src/index/vocabulary/SplitVocabulary.h
@@ -85,9 +85,7 @@ class SplitVocabulary {
   static constexpr uint64_t markerBitMaskSize = ad_utility::bitMaskSizeForValue(
       numberOfVocabs - 1);  // Range of marker: [0..numberOfVocabs-1]
   static constexpr uint64_t markerBitMask =
-      ad_utility::bitMaskForHigherBits(ValueId::numDatatypeBits +
-                                       markerBitMaskSize) &
-      ad_utility::bitMaskForLowerBits(ValueId::numDataBits);
+      ad_utility::bitMaskForHigherBits(markerBitMaskSize);
   static constexpr uint64_t markerShift =
       ValueId::numDataBits - markerBitMaskSize;
   static constexpr uint64_t vocabIndexBitMask =
@@ -103,8 +101,7 @@ class SplitVocabulary {
 
  public:
   // Check validity of vocabIndex and marker, then return a new 64 bit index
-  // that contains the marker and vocabIndex. The result is guaranteed to be
-  // zero in all ValueId datatype bits.
+  // that contains the marker (in the topmost bits) and the vocabIndex.
   static uint64_t addMarker(uint64_t vocabIndex, uint8_t marker) {
     AD_CORRECTNESS_CHECK(marker < numberOfVocabs &&
                          vocabIndex <= vocabIndexBitMask);

--- a/src/rdfTypes/GeometryInfo.cpp
+++ b/src/rdfTypes/GeometryInfo.cpp
@@ -25,15 +25,14 @@ GeometryInfo::GeometryInfo(uint8_t wktType, const BoundingBox& boundingBox,
       numGeometries_{numGeometries.numGeometries()},
       metricLength_{metricLength},
       metricArea_{metricArea} {
-  // The WktType only has 8 different values and we have 4 unused bits for the
-  // ValueId datatype of the centroid (it is always a point). Therefore we fold
+  // The WktType only has 8 different values and the encoding of the centroid
+  // (it is always a point) leaves the upper 4 bits unused. Therefore we fold
   // the attributes together. On OSM planet this will save approx. 1 GiB in
   // index size.
-  AD_CORRECTNESS_CHECK(
-      wktType <= 7 && wktType < (1 << ValueId::numDatatypeBits) - 1,
-      "WKT Type out of range");
+  AD_CORRECTNESS_CHECK(wktType <= 7 && wktType < (1 << numGeometryTypeBits) - 1,
+                       "WKT Type out of range");
   AD_CORRECTNESS_CHECK(wktType > 0, "WKT Type indicates invalid geometry");
-  uint64_t typeBits = static_cast<uint64_t>(wktType) << ValueId::numDataBits;
+  uint64_t typeBits = static_cast<uint64_t>(wktType) << GeoPoint::numDataBits;
   uint64_t centroidBits = centroid.centroid().toBitRepresentation();
   AD_CORRECTNESS_CHECK((centroidBits & bitMaskGeometryType) == 0,
                        "Centroid bit representation exceeds available bits.");
@@ -113,7 +112,7 @@ GeometryInfo GeometryInfo::fromGeoPoint(const GeoPoint& point) {
 GeometryType GeometryInfo::getWktType() const {
   return GeometryType{
       static_cast<uint8_t>((geometryTypeAndCentroid_ & bitMaskGeometryType) >>
-                           ValueId::numDataBits)};
+                           GeoPoint::numDataBits)};
 }
 
 // ____________________________________________________________________________

--- a/src/rdfTypes/GeometryInfo.h
+++ b/src/rdfTypes/GeometryInfo.h
@@ -184,10 +184,14 @@ class GeometryInfo {
   // attributes
   //   int64_t parsedGeometryOffset_ = -1;
 
+  // The `geometryTypeAndCentroid_` member stores the WKT geometry type in
+  // the (upper) bits that are not used by the encoding of the centroid
+  // `GeoPoint` (which only uses `GeoPoint::numDataBits` many bits).
+  static constexpr uint64_t numGeometryTypeBits = 64 - GeoPoint::numDataBits;
   static constexpr uint64_t bitMaskGeometryType =
-      bitMaskForHigherBits(ValueId::numDatatypeBits);
+      bitMaskForHigherBits(numGeometryTypeBits);
   static constexpr uint64_t bitMaskCentroid =
-      bitMaskForLowerBits(ValueId::numDataBits);
+      bitMaskForLowerBits(GeoPoint::numDataBits);
 
  public:
   GeometryInfo(uint8_t wktType, const BoundingBox& boundingBox,

--- a/src/util/BlankNodeManager.h
+++ b/src/util/BlankNodeManager.h
@@ -49,9 +49,11 @@ class BlankNodeManager {
   // Number of indices that make up a single block.
   static constexpr uint32_t blockSize_ = 1000;
 
-  // Number of blocks available.
+  // Number of blocks available. Note: As `maxIndex` is the maximum value of
+  // `uint64_t`, we must not add 1 to the difference (this would overflow for
+  // `minIndex_ == 0`), so we deliberately ignore the very last index.
   const uint64_t totalAvailableBlocks_ =
-      (ValueId::maxIndex - minIndex_ + 1) / blockSize_;
+      (ValueId::maxIndex - minIndex_) / blockSize_;
 
  private:
   // Forward declaration because of cyclic dependency.

--- a/src/util/JoinAlgorithms/FindUndefRanges.h
+++ b/src/util/JoinAlgorithms/FindUndefRanges.h
@@ -127,7 +127,7 @@ CPP_template(typename It)(requires ql::concepts::random_access_iterator<It>)  //
            auto begOfUndef = std::lower_bound(
                begin, end, row, ql::ranges::lexicographical_compare);
            row[numDefinedColumns - 1] =
-               Id::fromBits(row[numDefinedColumns - 1].getBits() + 1);
+               Id::fromBits(row[numDefinedColumns - 1].getBits().incremented());
            auto endOfUndef = std::lower_bound(
                begin, end, row, ql::ranges::lexicographical_compare);
            resultMightBeUnsorted = true;

--- a/src/util/JoinAlgorithms/JoinAlgorithms.h
+++ b/src/util/JoinAlgorithms/JoinAlgorithms.h
@@ -15,6 +15,7 @@
 #include "backports/algorithm.h"
 #include "backports/concepts.h"
 #include "backports/span.h"
+#include "engine/idTable/IdColumnAlgorithms.h"
 #include "engine/idTable/IdTable.h"
 #include "global/Id.h"
 #include "util/InputRangeUtils.h"
@@ -1649,10 +1650,56 @@ CPP_template(typename LeftSide, typename RightSide, typename LessThan,
       const FindSmallerUndefRangesRight& findSmallerUndefRangesRight,
       ElFromFirstNotFoundAction elFromFirstNotFoundAction,
       CheckCancellation checkCancellation, CoverUndefRanges coverUndefRanges) {
-    [[maybe_unused]] auto res = zipperJoinWithUndef(
-        subrangeLeft, subrangeRight, this->lessThan_, rowIndexAdder,
-        findSmallerUndefRangesLeft, findSmallerUndefRangesRight,
-        elFromFirstNotFoundAction, checkCancellation, coverUndefRanges);
+    // Fast path: If the join is on single split `Id` columns (i.e. the
+    // iterators are `IdColumnIterator`s), the comparison is the default
+    // `Id` order, and there is no UNDEF machinery (which is also the case
+    // at runtime for the "potentially UNDEF" variant if no UNDEF values
+    // were found), then perform the join directly on the datatype bytes and
+    // payload words of the split column storage. This is used by all joins
+    // of prefiltered index scans (lazy and materialized).
+    using LeftIterator = ql::ranges::iterator_t<const SubrangeLeft>;
+    using RightIterator = ql::ranges::iterator_t<const SubrangeRight>;
+    namespace cbit = columnBasedIdTable;
+    constexpr bool areIdColumns =
+        SimilarToAny<LeftIterator,
+                     cbit::IdColumnIterator<ad_utility::IsConst::False>,
+                     cbit::IdColumnIterator<ad_utility::IsConst::True>> &&
+        SimilarToAny<RightIterator,
+                     cbit::IdColumnIterator<ad_utility::IsConst::False>,
+                     cbit::IdColumnIterator<ad_utility::IsConst::True>>;
+    constexpr bool isDefaultLess =
+        SimilarToAny<LessThan, std::less<>, std::less<Id>, ql::ranges::less>;
+    constexpr bool hasNoUndefMachinery =
+        isSimilar<FindSmallerUndefRangesLeft, decltype(ad_utility::noop)> &&
+        isSimilar<FindSmallerUndefRangesRight, decltype(ad_utility::noop)> &&
+        isSimilar<CoverUndefRanges, std::true_type>;
+    if constexpr (areIdColumns && isDefaultLess && hasNoUndefMachinery) {
+      auto beginLeft = subrangeLeft.begin();
+      auto beginRight = subrangeRight.begin();
+      cbit::ConstIdColumnSpan left{beginLeft.payloadPtr(),
+                                   beginLeft.datatypePtr(),
+                                   static_cast<size_t>(subrangeLeft.size())};
+      cbit::ConstIdColumnSpan right{beginRight.payloadPtr(),
+                                    beginRight.datatypePtr(),
+                                    static_cast<size_t>(subrangeRight.size())};
+      cbit::zipperJoinIdColumns(
+          left, right,
+          [&](size_t l, size_t r) {
+            rowIndexAdder(beginLeft + l, beginRight + r);
+          },
+          [&](size_t beginL, size_t endL, size_t beginR, size_t endR) {
+            rowIndexAdder.addRows(beginLeft + beginL, beginLeft + endL,
+                                  beginRight + beginR, beginRight + endR);
+          },
+          [&](size_t l) { elFromFirstNotFoundAction(beginLeft + l); },
+          checkCancellation);
+      return;
+    } else {
+      [[maybe_unused]] auto res = zipperJoinWithUndef(
+          subrangeLeft, subrangeRight, this->lessThan_, rowIndexAdder,
+          findSmallerUndefRangesLeft, findSmallerUndefRangesRight,
+          elFromFirstNotFoundAction, checkCancellation, coverUndefRanges);
+    }
   }
 };
 

--- a/src/util/JoinAlgorithms/JoinAlgorithms.h
+++ b/src/util/JoinAlgorithms/JoinAlgorithms.h
@@ -620,7 +620,8 @@ CPP_template(typename LeftTableLike, typename RightTableLike,
     // TODO<joka921> We could probably also apply this optimization if both
     // inputs contain UNDEF values only in the last column, and possibly
     // also not only for `OPTIONAL` joins.
-    auto endOfUndef = ql::ranges::find_if_not(leftSub, &Id::isUndefined);
+    auto endOfUndef = ql::ranges::find_if_not(
+        leftSub, [](const Id& id) { return id.isUndefined(); });
 
     auto findSmallerUndefRangeLeft = [leftSub, endOfUndef](auto&&...) {
       return ad_utility::IteratorRange{leftSub.begin(), endOfUndef};
@@ -1790,7 +1791,8 @@ CPP_template(typename NumJoinColumnsT, typename LeftSide, typename RightSide,
 
     // Set up the generator for UNDEF values in the left last column.
     // TODO<joka921> Could optimize the case that there is no UNDEF at all.
-    auto endOfUndef = ql::ranges::find_if_not(lastColLeft, &Id::isUndefined);
+    auto endOfUndef = ql::ranges::find_if_not(
+        lastColLeft, [](const Id& id) { return id.isUndefined(); });
     auto findSmallerUndefRangeLeft = [&lastColLeft, endOfUndef](auto&&...) {
       return ad_utility::IteratorRange{lastColLeft.begin(), endOfUndef};
     };

--- a/src/util/JoinAlgorithms/JoinColumnMapping.h
+++ b/src/util/JoinAlgorithms/JoinColumnMapping.h
@@ -121,7 +121,9 @@ struct GetColsFromTable {
       return ::ranges::views::zip(table.getColumn(I)...) |
              ::ranges::views::transform([](auto&& tuple) {
                return std::apply(
-                   [](auto&... refs) { return std::array{refs...}; },
+                   [](auto&&... refs) {
+                     return std::array<Id, sizeof...(refs)>{AD_FWD(refs)...};
+                   },
                    AD_FWD(tuple));
              });
     }(std::make_index_sequence<numCols>());
@@ -198,7 +200,8 @@ struct IdTableAndFirstCols {
 };
 
 // Specialization of `IdTableAndFirstCol` for only a single column where we
-// don't need to copy into an `array`, but directly return single `Id&`.
+// don't need to copy into an `array`, but directly return single (proxy)
+// references to `Id`s.
 
 // Note: this changes the interface (in particular the single rows can't be
 // iterated over), but currently this is used by the `Join` class, which expects
@@ -231,9 +234,9 @@ struct IdTableAndFirstCols<1, Table> {
 
   bool empty() const { return col().empty(); }
 
-  const Id& operator[](size_t idx) const { return col()[idx]; }
-  const Id& front() const { return col().front(); }
-  const Id& back() const { return col().back(); }
+  decltype(auto) operator[](size_t idx) const { return col()[idx]; }
+  decltype(auto) front() const { return col().front(); }
+  decltype(auto) back() const { return col().back(); }
 
   size_t size() const { return col().size(); }
 

--- a/src/util/Serializer/TripleSerializer.h
+++ b/src/util/Serializer/TripleSerializer.h
@@ -95,9 +95,13 @@ CPP_template(typename Serializer)(
 
 // Deserialize the local vocabulary from the input stream.
 CPP_template(typename Serializer)(
-    requires serialization::ReadSerializer<Serializer>) std::
-    tuple<LocalVocab, absl::flat_hash_map<Id::T, Id>> deserializeLocalVocab(
-        Serializer& serializer, const LocalVocabContext& context) {
+    requires serialization::ReadSerializer<Serializer>)
+    std::tuple<
+        LocalVocab,
+        absl::flat_hash_map<Id::BitRepresentation,
+                            Id>> deserializeLocalVocab(Serializer& serializer,
+                                                       const LocalVocabContext&
+                                                           context) {
   LocalVocab vocab;
   vocab.reserveBlankNodeBlocksFromExplicitIndices(
       readValue<std::vector<
@@ -107,24 +111,36 @@ CPP_template(typename Serializer)(
   auto size = readValue<uint64_t>(serializer);
   // Note:: It might happen that the `size` is zero because the local vocab was
   // empty.
-  absl::flat_hash_map<Id::T, Id> mapping{};
+  absl::flat_hash_map<Id::BitRepresentation, Id> mapping{};
   mapping.reserve(size);
   for (uint64_t i = 0; i < size; ++i) {
-    auto id = readValue<Id::T>(serializer);
+    auto id = readValue<Id>(serializer);
     auto s = readValue<std::string>(serializer);
     auto localVocabIndex = vocab.getIndexAndAddIfNotContained(
         LocalVocabEntry::fromStringRepresentation(std::move(s), context));
-    mapping.emplace(id, Id::makeFromLocalVocabIndex(localVocabIndex));
+    mapping.emplace(id.getBits(), Id::makeFromLocalVocabIndex(localVocabIndex));
   }
   return {std::move(vocab), std::move(mapping)};
 }
+
+// Helper concept: `Range` is a split column of `Id`s (see `IdColumn.h`)
+// that exposes contiguous spans for the payloads and the datatype bytes.
+template <typename Range>
+CPP_concept IsIdColumnSpanLike = requires(const Range& r) {
+  r.payloadSpan();
+  r.datatypeSpan();
+};
 
 // Serialize a range of Ids to the output stream. If an Id is of type
 // LocalVocabIndex, apply the mapping to the Id before writing it.
 CPP_template(typename Range, typename Serializer)(
     requires ql::ranges::range<Range>) void serializeIds(Serializer& serializer,
                                                          Range&& range) {
-  if constexpr (ql::ranges::contiguous_range<std::decay_t<Range>>) {
+  if constexpr (IsIdColumnSpanLike<std::decay_t<Range>>) {
+    // Split columns of `Id`s are serialized as their two contiguous parts.
+    serializer << range.payloadSpan();
+    serializer << range.datatypeSpan();
+  } else if constexpr (ql::ranges::contiguous_range<std::decay_t<Range>>) {
     serializer << ql::span{range};
   } else {
     ad_utility::serialization::VectorIncrementalSerializer<Id, Serializer>
@@ -137,10 +153,15 @@ CPP_template(typename Range, typename Serializer)(
   }
 }
 
-// TODO<joka921> Comments.
-inline void remapLocalVocab(ql::span<Id> ids,
-                            const absl::flat_hash_map<Id::T, Id>& mapping) {
-  for (Id& id : ids) {
+// Remap all `Id`s of type `LocalVocabIndex` in the given range according to
+// the `mapping`. The range may consist of plain `Id`s or of proxy references
+// to a split column.
+CPP_template(typename Range)(
+    requires ql::ranges::range<
+        Range>) void remapLocalVocab(Range&& ids,
+                                     const absl::flat_hash_map<
+                                         Id::BitRepresentation, Id>& mapping) {
+  for (auto&& id : ids) {
     if (id.getDatatype() == Datatype::LocalVocabIndex) {
       id = mapping.at(id.getBits());
     }
@@ -150,17 +171,33 @@ inline void remapLocalVocab(ql::span<Id> ids,
 // Deserialize a range of Ids from the input stream. If an Id is of type
 // LocalVocabIndex, apply the mapping to the Id after reading it.
 template <typename Serializer>
-void deserializeIds(Serializer& serializer,
-                    const absl::flat_hash_map<Id::T, Id>& mapping,
-                    ql::span<Id> ids) {
+void deserializeIds(
+    Serializer& serializer,
+    const absl::flat_hash_map<Id::BitRepresentation, Id>& mapping,
+    ql::span<Id> ids) {
   serializer >> ids;
+  remapLocalVocab(ids, mapping);
+}
+
+// Overload of `deserializeIds` for a split column of `Id`s, which is read
+// back as its two contiguous parts (see `serializeIds` above).
+template <typename Serializer>
+void deserializeIds(
+    Serializer& serializer,
+    const absl::flat_hash_map<Id::BitRepresentation, Id>& mapping,
+    columnBasedIdTable::MutableIdColumnSpan ids) {
+  auto payloads = ids.payloadSpan();
+  auto datatypes = ids.datatypeSpan();
+  serializer >> payloads;
+  serializer >> datatypes;
   remapLocalVocab(ids, mapping);
 }
 // Deserialize a range of Ids from the input stream. If an Id is of type
 // LocalVocabIndex, apply the mapping to the Id after reading it.
 template <typename Serializer>
-std::vector<Id> deserializeIds(Serializer& serializer,
-                               const absl::flat_hash_map<Id::T, Id>& mapping) {
+std::vector<Id> deserializeIds(
+    Serializer& serializer,
+    const absl::flat_hash_map<Id::BitRepresentation, Id>& mapping) {
   std::vector<Id> ids = readValue<std::vector<Id>>(serializer);
   remapLocalVocab(ids, mapping);
   return ids;

--- a/test/AggregateExpressionTest.cpp
+++ b/test/AggregateExpressionTest.cpp
@@ -274,7 +274,7 @@ TEST(AggregateExpression, CountStar) {
   t.table.push_back(t.table[0]);
 
   auto setToUndef = [](IdTable::row_reference row) {
-    for (Id& id : row) {
+    for (auto&& id : row) {
       id = Id::makeUndefined();
     }
   };

--- a/test/CompressedRelationsTest.cpp
+++ b/test/CompressedRelationsTest.cpp
@@ -324,7 +324,9 @@ void testCompressedRelations(const auto& inputsOriginalBeforeCopy,
         false};
   };
 
-  AD_EXPECT_NULLOPT(getMetadataFromId(V(Id::maxIndex - 1)).first);
+  AD_EXPECT_NULLOPT(getMetadataFromId(Id::makeFromVocabIndex(
+                                          VocabIndex::make(Id::maxIndex - 1)))
+                        .first);
 
   // return a `pair<RelationMetadata, bool>` (see above), but for the `i`-th
   // relation specified by the `inputs`.
@@ -718,8 +720,10 @@ TEST(CompressedRelationReader, getBlocksForJoinWithColumn) {
                   size_t numHandledBlocksExpected,
                   source_location l = AD_CURRENT_SOURCE_LOC()) {
     auto t = generateLocationTrace(l);
+    columnBasedIdTable::IdColumnVector<> joinColumnSplit{
+        joinColumn.begin(), joinColumn.end(), std::allocator<Id>{}};
     auto [result, numHandledBlocks] =
-        CompressedRelationReader::getBlocksForJoin(joinColumn,
+        CompressedRelationReader::getBlocksForJoin(joinColumnSplit,
                                                    *metadataAndBlocks);
     EXPECT_THAT(result, ::testing::ElementsAreArray(expectedBlocks));
     EXPECT_EQ(numHandledBlocks, numHandledBlocksExpected);

--- a/test/ExportQueryExecutionTreesTest.cpp
+++ b/test/ExportQueryExecutionTreesTest.cpp
@@ -562,7 +562,7 @@ TEST(ExportQueryExecutionTrees, Floats) {
     <binding name="o"><literal datatype="http://www.w3.org/2001/XMLSchema#double">-INF</literal></binding>
   </result>
   <result>
-    <binding name="o"><literal datatype="http://www.w3.org/2001/XMLSchema#decimal">-42019234865780982022144.0</literal></binding>
+    <binding name="o"><literal datatype="http://www.w3.org/2001/XMLSchema#decimal">-42019234865780998799360.0</literal></binding>
   </result>
   <result>
     <binding name="o"><literal datatype="http://www.w3.org/2001/XMLSchema#decimal">4.012934858174e-12</literal></binding>
@@ -593,7 +593,7 @@ TEST(ExportQueryExecutionTrees, Floats) {
       // TSV
       "?o\n"
       "-INF\n"
-      "-42019234865780982022144.0\n"
+      "-42019234865780998799360.0\n"
       "4.012934858174e-12\n"
       "1e-10\n"
       "42.2\n"
@@ -605,7 +605,7 @@ TEST(ExportQueryExecutionTrees, Floats) {
       // CSV
       "o\n"
       "-INF\n"
-      "-42019234865780982022144.0\n"
+      "-42019234865780998799360.0\n"
       "4.012934858174e-12\n"
       "1e-10\n"
       "42.2\n"
@@ -616,7 +616,7 @@ TEST(ExportQueryExecutionTrees, Floats) {
       "NaN\n",
       makeExpectedQLeverJSON(
           {"\"-INF\"^^<http://www.w3.org/2001/XMLSchema#double>"s,
-           "\"-42019234865780982022144.0\"^^<http://www.w3.org/2001/XMLSchema#decimal>"s,
+           "\"-42019234865780998799360.0\"^^<http://www.w3.org/2001/XMLSchema#decimal>"s,
            "\"4.012934858174e-12\"^^<http://www.w3.org/2001/XMLSchema#decimal>"s,
            "\"1e-10\"^^<http://www.w3.org/2001/XMLSchema#decimal>"s,
            "\"42.2\"^^<http://www.w3.org/2001/XMLSchema#decimal>"s,
@@ -629,7 +629,7 @@ TEST(ExportQueryExecutionTrees, Floats) {
           {makeJSONBinding("http://www.w3.org/2001/XMLSchema#double", "literal",
                            "-INF"),
            makeJSONBinding("http://www.w3.org/2001/XMLSchema#decimal",
-                           "literal", "-42019234865780982022144.0"),
+                           "literal", "-42019234865780998799360.0"),
            makeJSONBinding("http://www.w3.org/2001/XMLSchema#decimal",
                            "literal", "4.012934858174e-12"),
            makeJSONBinding("http://www.w3.org/2001/XMLSchema#decimal",
@@ -653,7 +653,7 @@ TEST(ExportQueryExecutionTrees, Floats) {
       kg, "CONSTRUCT {?s ?p ?o} WHERE {?s ?p ?o} ORDER BY ?o", 10, 10,
       // TSV
       "<s>\t<p>\t\"-INF\"^^<http://www.w3.org/2001/XMLSchema#double>\n"
-      "<s>\t<p>\t-42019234865780982022144.0\n"
+      "<s>\t<p>\t-42019234865780998799360.0\n"
       "<s>\t<p>\t4.012934858174e-12\n"
       "<s>\t<p>\t1e-10\n"
       "<s>\t<p>\t42.2\n"
@@ -664,7 +664,7 @@ TEST(ExportQueryExecutionTrees, Floats) {
       "<s>\t<p>\t\"NaN\"^^<http://www.w3.org/2001/XMLSchema#double>\n",
       // CSV
       "<s>,<p>,\"\"\"-INF\"\"^^<http://www.w3.org/2001/XMLSchema#double>\"\n"
-      "<s>,<p>,-42019234865780982022144.0\n"
+      "<s>,<p>,-42019234865780998799360.0\n"
       "<s>,<p>,4.012934858174e-12\n"
       "<s>,<p>,1e-10\n"
       "<s>,<p>,42.2\n"
@@ -675,7 +675,7 @@ TEST(ExportQueryExecutionTrees, Floats) {
       "<s>,<p>,\"\"\"NaN\"\"^^<http://www.w3.org/2001/XMLSchema#double>\"\n",
       // Turtle
       "<s> <p> \"-INF\"^^<http://www.w3.org/2001/XMLSchema#double> .\n"
-      "<s> <p> -42019234865780982022144.0 .\n"
+      "<s> <p> -42019234865780998799360.0 .\n"
       "<s> <p> 4.012934858174e-12 .\n"
       "<s> <p> 1e-10 .\n"
       "<s> <p> 42.2 .\n"
@@ -689,7 +689,7 @@ TEST(ExportQueryExecutionTrees, Floats) {
         j.push_back(std::vector{
             "<s>"s, "<p>"s,
             "\"-INF\"^^<http://www.w3.org/2001/XMLSchema#double>"s});
-        j.push_back(std::vector{"<s>"s, "<p>"s, "-42019234865780982022144.0"s});
+        j.push_back(std::vector{"<s>"s, "<p>"s, "-42019234865780998799360.0"s});
         j.push_back(std::vector{"<s>"s, "<p>"s, "4.012934858174e-12"s});
         j.push_back(std::vector{"<s>"s, "<p>"s, "1e-10"s});
         j.push_back(std::vector{"<s>"s, "<p>"s, "42.2"s});

--- a/test/GroupByTest.cpp
+++ b/test/GroupByTest.cpp
@@ -1099,9 +1099,10 @@ TEST_F(GroupByOptimizations, hashMapOptimizationMinMaxSum) {
       {Variable{"?w"}, {3, PossiblyUndefined}}};
   EXPECT_THAT(groupBy.getExternallyVisibleVariableColumns(),
               ::testing::UnorderedElementsAreArray(expectedVariables));
-  auto expected = makeIdTableFromVector({{d(1), i(3), i(42), d(54)},
-                                         {d(3), d(1), d(13.37), d(18.37)},
-                                         {d(4), undef, undef, undef}});
+  auto expected =
+      makeIdTableFromVector({{d(1), i(3), i(42), d(54)},
+                             {d(3), d(1), d(13.37), d(13.37 + 1.0 + 4.0)},
+                             {d(4), undef, undef, undef}});
   EXPECT_EQ(table, expected);
 }
 

--- a/test/IdTableTest.cpp
+++ b/test/IdTableTest.cpp
@@ -1161,19 +1161,26 @@ TEST(IdTable, shrinkToFit) {
   auto memory = ad_utility::makeAllocationMemoryLeftThreadsafeObject(1_kB);
   IdTable table{2, ad_utility::AllocatorWithLimit<Id>{memory}};
   using namespace ad_utility::memory_literals;
+  // The number of bytes that one entry of an `IdTable` occupies: 8 bytes of
+  // payload and 1 byte for the datatype (stored in separate columns).
+  constexpr auto bytesPerEntry =
+      ad_utility::MemorySize::bytes(sizeof(uint64_t) + sizeof(uint8_t));
   ASSERT_EQ(memory.ptr().get()->wlock()->amountMemoryLeft(), 1_kB);
   table.reserve(20);
   ASSERT_TRUE(table.empty());
-  // 20 rows * 2 columns * 8 bytes per ID were allocated.
-  ASSERT_EQ(memory.ptr().get()->wlock()->amountMemoryLeft(), 680_B);
+  // 20 rows * 2 columns entries were allocated.
+  ASSERT_EQ(memory.ptr().get()->wlock()->amountMemoryLeft(),
+            1_kB - 20 * 2 * bytesPerEntry);
   table.emplace_back();
   table.emplace_back();
   ASSERT_EQ(table.numRows(), 2u);
-  ASSERT_EQ(memory.ptr().get()->wlock()->amountMemoryLeft(), 680_B);
+  ASSERT_EQ(memory.ptr().get()->wlock()->amountMemoryLeft(),
+            1_kB - 20 * 2 * bytesPerEntry);
   table.shrinkToFit();
   ASSERT_EQ(table.numRows(), 2u);
-  // Now only 2 rows * 2 columns * 8 bytes were allocated.
-  ASSERT_EQ(memory.ptr().get()->wlock()->amountMemoryLeft(), 968_B);
+  // Now only 2 rows * 2 columns entries are allocated.
+  ASSERT_EQ(memory.ptr().get()->wlock()->amountMemoryLeft(),
+            1_kB - 2 * 2 * bytesPerEntry);
 }
 
 TEST(IdTable, staticAsserts) {
@@ -1241,13 +1248,13 @@ TEST(IdTable, moveOrCloneOnView) {
   // `moveOrClone()` on a view (lvalue) returns a deep-owned clone, not a view.
   IdTable cloned = view.moveOrClone();
   EXPECT_EQ(cloned, table);
-  EXPECT_NE(&cloned(0, 0), &table(0, 0));
+  EXPECT_NE(cloned(0, 0).payloadPtr(), table(0, 0).payloadPtr());
 
   // `moveOrClone()` on a view rvalue also returns a deep-owned clone, since
   // views cannot transfer ownership.
   IdTable cloned2 = std::move(view).moveOrClone();
   EXPECT_EQ(cloned2, table);
-  EXPECT_NE(&cloned2(0, 0), &table(0, 0));
+  EXPECT_NE(cloned2(0, 0).payloadPtr(), table(0, 0).payloadPtr());
 }
 
 // ____________________________________________________________________________
@@ -1293,8 +1300,8 @@ TYPED_TEST(IdTableSubViewTest, subView) {
     EXPECT_EQ(sliceView(1, 0), V(20));
 
     // `subView` is non-owning: data pointers point into the original table.
-    EXPECT_EQ(&sliceView(0, 0), &table(1, 0));
-    EXPECT_EQ(&sliceView(1, 0), &table(2, 0));
+    EXPECT_EQ(sliceView(0, 0).payloadPtr(), table(1, 0).payloadPtr());
+    EXPECT_EQ(sliceView(1, 0).payloadPtr(), table(2, 0).payloadPtr());
 
     // Out-of-range access must trigger a contract check.
     EXPECT_ANY_THROW(target.subView(3, 3));  // offset + size > numRows.

--- a/test/JoinAlgorithmsTest.cpp
+++ b/test/JoinAlgorithmsTest.cpp
@@ -629,15 +629,16 @@ struct IdRowAdder {
     auto rightPayload = rightTable_(rightIndex, 2);
     AD_CONTRACT_CHECK(x1 == y1);
     AD_CONTRACT_CHECK(x2.isUndefined() || x2 == y2);
-    target_->push_back(
-        std::array{x1, x2.isUndefined() ? y2 : x2, leftPayload, rightPayload});
+    target_->push_back(std::array<Id, 4>{x1, x2.isUndefined() ? Id{y2} : Id{x2},
+                                         leftPayload, rightPayload});
   }
 
   void addOptionalRow(size_t leftIndex) {
     auto x1 = leftTable_(leftIndex, 0);
     auto x2 = leftTable_(leftIndex, 1);
     auto leftPayload = leftTable_(leftIndex, 2);
-    target_->emplace_back(std::array{x1, x2, leftPayload, Id::makeUndefined()});
+    target_->emplace_back(
+        std::array<Id, 4>{x1, x2, leftPayload, Id::makeUndefined()});
   }
 
   template <typename R1, typename R2>

--- a/test/JoinTest.cpp
+++ b/test/JoinTest.cpp
@@ -240,9 +240,10 @@ namespace {
 
 // A hash map that connects variables to the expected contents of the
 // corresponding result column and the `UndefStatus`.
-using ExpectedColumns = ad_utility::HashMap<
-    Variable,
-    std::pair<ql::span<const Id>, ColumnIndexAndTypeInfo::UndefStatus>>;
+using ExpectedColumns =
+    ad_utility::HashMap<Variable,
+                        std::pair<columnBasedIdTable::ConstIdColumnSpan,
+                                  ColumnIndexAndTypeInfo::UndefStatus>>;
 
 // Test that the result of the `join` matches the `expected` outcome.
 // If `requestLaziness` is true, the join is requested to be lazy. If

--- a/test/ResultTest.cpp
+++ b/test/ResultTest.cpp
@@ -95,7 +95,7 @@ TEST(Result, cloneIdTableReturnsCopy) {
   IdTable cloned = result.cloneIdTable();
   EXPECT_EQ(cloned, idTable);
   // Verify it is a deep copy, not a reference to the same data.
-  EXPECT_NE(&cloned(0, 0), &result.idTableView()(0, 0));
+  EXPECT_NE(cloned(0, 0).payloadPtr(), result.idTableView()(0, 0).payloadPtr());
 }
 
 // _____________________________________________________________________________
@@ -701,7 +701,8 @@ TEST(Result, viewBackedResultIsFullyMaterialized) {
   Result result{view, {}, LocalVocab{}};
   EXPECT_TRUE(result.isFullyMaterialized());
   // The returned view must alias the original data, not a copy.
-  EXPECT_EQ(&result.idTableView()(0, 0), &idTable(0, 0));
+  EXPECT_EQ(result.idTableView()(0, 0).payloadPtr(),
+            idTable(0, 0).payloadPtr());
   EXPECT_EQ(result.idTableView(), idTable);
 }
 
@@ -713,7 +714,7 @@ TEST(Result, viewBackedResultCloneIdTable) {
   IdTable cloned = result.cloneIdTable();
   EXPECT_EQ(cloned, idTable);
   // Must be a deep copy, not an alias into the original data.
-  EXPECT_NE(&cloned(0, 0), &idTable(0, 0));
+  EXPECT_NE(cloned(0, 0).payloadPtr(), idTable(0, 0).payloadPtr());
 }
 
 // _____________________________________________________________________________
@@ -737,13 +738,14 @@ TEST(Result, viewBackedApplyLimitOffset) {
                                            const IdTableView<0>& innerTable) {
     EXPECT_EQ(innerTable, comparisonTable);
     // The sub-view must alias the original data at offset 2 (no copy).
-    EXPECT_EQ(&innerTable(0, 0), &idTable(2, 0));
+    EXPECT_EQ(innerTable(0, 0).payloadPtr(), idTable(2, 0).payloadPtr());
     ++callCounter;
   });
   EXPECT_EQ(callCounter, 1);
   EXPECT_EQ(result.idTableView(), comparisonTable);
   // After the limit/offset the result view still aliases the original data.
-  EXPECT_EQ(&result.idTableView()(0, 0), &idTable(2, 0));
+  EXPECT_EQ(result.idTableView()(0, 0).payloadPtr(),
+            idTable(2, 0).payloadPtr());
 }
 
 // _____________________________________________________________________________

--- a/test/SortTest.cpp
+++ b/test/SortTest.cpp
@@ -281,9 +281,11 @@ TEST(Sort, externalSortLazyInput) {
   const auto& table = result->idTableView();
   EXPECT_EQ(8000u, table.numRows());
   for (size_t i = 1; i < table.numRows(); ++i) {
-    bool isLessOrEqual =
-        std::tie(table(i - 1, 0), table(i - 1, 1), table(i - 1, 2)) <=
-        std::tie(table(i, 0), table(i, 1), table(i, 2));
+    auto rowTuple = [&table](size_t row) {
+      return std::tuple<Id, Id, Id>{table(row, 0), table(row, 1),
+                                    table(row, 2)};
+    };
+    bool isLessOrEqual = rowTuple(i - 1) <= rowTuple(i);
     EXPECT_TRUE(isLessOrEqual) << "Row " << i << " is not in order";
   }
 }
@@ -326,9 +328,11 @@ TEST(Sort, externalSortMaterializedInput) {
   const auto& table = result->idTableView();
   EXPECT_EQ(5000u, table.numRows());
   for (size_t i = 1; i < table.numRows(); ++i) {
-    bool isLessOrEqual =
-        std::tie(table(i - 1, 0), table(i - 1, 1), table(i - 1, 2)) <=
-        std::tie(table(i, 0), table(i, 1), table(i, 2));
+    auto rowTuple = [&table](size_t row) {
+      return std::tuple<Id, Id, Id>{table(row, 0), table(row, 1),
+                                    table(row, 2)};
+    };
+    bool isLessOrEqual = rowTuple(i - 1) <= rowTuple(i);
     EXPECT_TRUE(isLessOrEqual) << "Row " << i << " is not in order";
   }
 }
@@ -419,9 +423,11 @@ TEST(Sort, inMemorySortMaterializedInput) {
   const auto& table = result->idTableView();
   EXPECT_EQ(100u, table.numRows());
   for (size_t i = 1; i < table.numRows(); ++i) {
-    bool isLessOrEqual =
-        std::tie(table(i - 1, 0), table(i - 1, 1), table(i - 1, 2)) <=
-        std::tie(table(i, 0), table(i, 1), table(i, 2));
+    auto rowTuple = [&table](size_t row) {
+      return std::tuple<Id, Id, Id>{table(row, 0), table(row, 1),
+                                    table(row, 2)};
+    };
+    bool isLessOrEqual = rowTuple(i - 1) <= rowTuple(i);
     EXPECT_TRUE(isLessOrEqual) << "Row " << i << " is not in order";
   }
 }

--- a/test/TransitivePathGraphSearchTest.cpp
+++ b/test/TransitivePathGraphSearchTest.cpp
@@ -40,8 +40,8 @@ class GraphSearchTest : public Test {
   std::vector<T> graphs_;
   // When testing using BinSearchMap, store the data for the startIds and
   // targetIds spans here.
-  std::vector<std::vector<Id>> binSearchMapStartIds_;
-  std::vector<std::vector<Id>> binSearchMapTargetIds_;
+  std::vector<columnBasedIdTable::IdColumnVector<>> binSearchMapStartIds_;
+  std::vector<columnBasedIdTable::IdColumnVector<>> binSearchMapTargetIds_;
 
   // Easy-to-read-and-change representation of the graphs that will be tested
   // on. Will be converted to template type T and stored in `graphs_` in the
@@ -123,8 +123,8 @@ class GraphSearchTest : public Test {
       for (const AdjacencyList& adjList : graphsAdjListRepresentation_) {
         // Create new storage on the heap for a new BinSearchMap's startId and
         // targetId spans.
-        binSearchMapStartIds_.push_back(std::vector<Id>());
-        binSearchMapTargetIds_.push_back(std::vector<Id>());
+        binSearchMapStartIds_.emplace_back();
+        binSearchMapTargetIds_.emplace_back();
         auto& startIds = binSearchMapStartIds_.back();
         auto& targetIds = binSearchMapTargetIds_.back();
 
@@ -134,12 +134,11 @@ class GraphSearchTest : public Test {
 
         for (const size_t startNode : keys) {
           for (const size_t targetNode : adjList.at(startNode)) {
-            startIds.emplace_back(Id::makeFromInt(startNode));
-            targetIds.emplace_back(Id::makeFromInt(targetNode));
+            startIds.push_back(Id::makeFromInt(startNode));
+            targetIds.push_back(Id::makeFromInt(targetNode));
           }
         }
-        graphs_.push_back(BinSearchMap(ql::span<const Id>(startIds),
-                                       ql::span<const Id>(targetIds)));
+        graphs_.push_back(BinSearchMap(startIds, targetIds));
       }
     }
   }

--- a/test/TransitivePathTest.cpp
+++ b/test/TransitivePathTest.cpp
@@ -1957,8 +1957,9 @@ namespace {
 // _____________________________________________________________________________
 HashMapWrapper::MapOfMaps columnsToMap(
     const ad_utility::AllocatorWithLimit<Id>& allocator,
-    ql::span<const Id> startCol, ql::span<const Id> targetCol,
-    ql::span<const Id> graphCol) {
+    columnBasedIdTable::ConstIdColumnSpan startCol,
+    columnBasedIdTable::ConstIdColumnSpan targetCol,
+    columnBasedIdTable::ConstIdColumnSpan graphCol) {
   HashMapWrapper::MapOfMaps edgesWithGraph{allocator};
   for (size_t i = 0; i < startCol.size(); i++) {
     auto it1 = edgesWithGraph.try_emplace(graphCol[i], allocator).first;
@@ -1971,7 +1972,8 @@ HashMapWrapper::MapOfMaps columnsToMap(
 // _____________________________________________________________________________
 HashMapWrapper::Map columnsToMap(
     const ad_utility::AllocatorWithLimit<Id>& allocator,
-    ql::span<const Id> startCol, ql::span<const Id> targetCol) {
+    columnBasedIdTable::ConstIdColumnSpan startCol,
+    columnBasedIdTable::ConstIdColumnSpan targetCol) {
   HashMapWrapper::Map edges{allocator};
 
   for (size_t i = 0; i < startCol.size(); i++) {

--- a/test/TripleSerializerTest.cpp
+++ b/test/TripleSerializerTest.cpp
@@ -179,7 +179,8 @@ TEST(TripleSerializer, multipleWordSetsInASerializedLocalVocab) {
   };
   auto fromMappingOrigin = [&]() {
     return ::ranges::to<std::vector>(
-        mapping | ql::views::keys | ql::views::transform([](Id::T id) {
+        mapping | ql::views::keys |
+        ql::views::transform([](Id::BitRepresentation id) {
           return *Id::fromBits(id).getLocalVocabIndex();
         }));
   };

--- a/test/ValueIdTest.cpp
+++ b/test/ValueIdTest.cpp
@@ -25,86 +25,55 @@ struct ValueIdTest : public ::testing::Test {
 };
 
 TEST_F(ValueIdTest, makeFromDouble) {
+  // The payload of a `ValueId` is a full 64-bit word, so every double
+  // (including subnormals) is representable exactly.
   auto testRepresentableDouble = [](double d) {
     auto id = ValueId::makeFromDouble(d);
     ASSERT_EQ(id.getDatatype(), Datatype::Double);
-    // We lose `numDatatypeBits` bits of precision, so `ASSERT_DOUBLE_EQ` would
-    // fail.
-    ASSERT_FLOAT_EQ(id.getDouble(), d);
-    // This check expresses the precision more exactly
-    if (id.getDouble() != d) {
-      // The if is needed for the case of += infinity.
-      ASSERT_NEAR(
-          id.getDouble(), d,
-          std::abs(d / (uint64_t{1} << (52 - ValueId::numDatatypeBits))));
-    }
+    ASSERT_EQ(absl::bit_cast<uint64_t>(id.getDouble()),
+              absl::bit_cast<uint64_t>(d));
   };
 
-  auto testNonRepresentableSubnormal = [](double d) {
-    auto id = ValueId::makeFromDouble(d);
-    ASSERT_EQ(id.getDatatype(), Datatype::Double);
-    // Subnormal numbers with a too small fraction are rounded to zero.
-    ASSERT_EQ(id.getDouble(), 0.0);
-  };
   for (size_t i = 0; i < 10'000; ++i) {
     testRepresentableDouble(positiveRepresentableDoubleGenerator());
     testRepresentableDouble(negativeRepresentableDoubleGenerator());
-    auto nonRepresentable = nonRepresentableDoubleGenerator();
-    // The random number generator includes the edge cases which would make the
-    // tests fail.
-    if (nonRepresentable != ValueId::minPositiveDouble &&
-        nonRepresentable != -ValueId::minPositiveDouble) {
-      testNonRepresentableSubnormal(nonRepresentable);
-    }
   }
 
   testRepresentableDouble(std::numeric_limits<double>::infinity());
   testRepresentableDouble(-std::numeric_limits<double>::infinity());
+  testRepresentableDouble(std::numeric_limits<double>::denorm_min());
+  testRepresentableDouble(-std::numeric_limits<double>::denorm_min());
 
   // Test positive and negative 0.
   ASSERT_NE(absl::bit_cast<uint64_t>(0.0), absl::bit_cast<uint64_t>(-0.0));
   ASSERT_EQ(0.0, -0.0);
   testRepresentableDouble(0.0);
   testRepresentableDouble(-0.0);
-  testNonRepresentableSubnormal(0.0);
-  testNonRepresentableSubnormal(0.0);
 
   auto quietNan = std::numeric_limits<double>::quiet_NaN();
   auto signalingNan = std::numeric_limits<double>::signaling_NaN();
   ASSERT_TRUE(std::isnan(ValueId::makeFromDouble(quietNan).getDouble()));
   ASSERT_TRUE(std::isnan(ValueId::makeFromDouble(signalingNan).getDouble()));
-
-  // Test that the value of `minPositiveDouble` is correct.
-  auto testSmallestNumber = [](double d) {
-    ASSERT_EQ(ValueId::makeFromDouble(d).getDouble(), d);
-    ASSERT_NE(d / 2, 0.0);
-    ASSERT_EQ(ValueId::makeFromDouble(d / 2).getDouble(), 0.0);
-  };
-  testSmallestNumber(ValueId::minPositiveDouble);
-  testSmallestNumber(-ValueId::minPositiveDouble);
 }
 
 TEST_F(ValueIdTest, makeFromInt) {
+  // The payload of a `ValueId` is a full 64-bit word, so the whole range of
+  // `int64_t` is representable and no overflow is possible.
   for (size_t i = 0; i < 10'000; ++i) {
     auto value = nonOverflowingNBitGenerator();
     auto id = ValueId::makeFromInt(value);
     ASSERT_EQ(id.getDatatype(), Datatype::Int);
     ASSERT_EQ(id.getInt(), value);
   }
-
-  auto testOverflow = [](auto generator) {
-    using I = ValueId::IntegerType;
-    for (size_t i = 0; i < 10'000; ++i) {
-      auto value = generator();
-      auto id = ValueId::makeFromInt(value);
-      ASSERT_EQ(id.getDatatype(), Datatype::Int);
-      ASSERT_EQ(id.getInt(), I::fromNBit(I::toNBit(value)));
-      ASSERT_NE(id.getInt(), value);
-    }
+  auto testSingle = [](int64_t value) {
+    auto id = ValueId::makeFromInt(value);
+    ASSERT_EQ(id.getDatatype(), Datatype::Int);
+    ASSERT_EQ(id.getInt(), value);
   };
-
-  testOverflow(overflowingNBitGenerator);
-  testOverflow(underflowingNBitGenerator);
+  testSingle(std::numeric_limits<int64_t>::max());
+  testSingle(std::numeric_limits<int64_t>::min());
+  testSingle(0);
+  testSingle(-1);
 }
 
 // _____________________________________________________________________________
@@ -121,38 +90,37 @@ TEST_F(ValueIdTest, makeFromBool) {
 }
 
 TEST_F(ValueIdTest, Indices) {
-  auto testRandomIds = [&](auto makeId, auto getFromId, Datatype type) {
+  auto testRandomIds = [&](auto makeId, auto getFromId, Datatype type,
+                           auto& generator, uint64_t maxValue) {
     auto testSingle = [&](auto value) {
       auto id = makeId(value);
       ASSERT_EQ(id.getDatatype(), type);
-      ASSERT_EQ(std::invoke(getFromId, id), value);
+      ASSERT_EQ(static_cast<uint64_t>(std::invoke(getFromId, id)), value);
     };
     for (size_t idx = 0; idx < 10'000; ++idx) {
-      testSingle(indexGenerator());
+      testSingle(generator() % (maxValue - 1));
     }
     testSingle(0);
-    testSingle(ValueId::maxIndex);
-
-    if (type != Datatype::LocalVocabIndex) {
-      for (size_t idx = 0; idx < 10'000; ++idx) {
-        auto value = invalidIndexGenerator();
-        ASSERT_THROW(makeId(value), ValueId::IndexTooLargeException);
-        AD_EXPECT_THROW_WITH_MESSAGE(
-            makeId(value), ::testing::ContainsRegex("is bigger than"));
-      }
-    }
+    testSingle(maxValue);
   };
 
+  // The full range of `uint64_t` is valid for indices.
   testRandomIds(&makeTextRecordId, &getTextRecordIndex,
-                Datatype::TextRecordIndex);
-  testRandomIds(&makeVocabId, &getVocabIndex, Datatype::VocabIndex);
+                Datatype::TextRecordIndex, indexGenerator, ValueId::maxIndex);
+  testRandomIds(&makeVocabId, &getVocabIndex, Datatype::VocabIndex,
+                indexGenerator, ValueId::maxIndex);
 
+  // Note: For the `LocalVocabIndex` the roundtrip goes through the decimal
+  // string representation and `std::atoll`, so only values that fit into an
+  // `int64_t` can be tested this way.
   auto localVocabWordToInt = [](const auto& input) {
     return std::atoll(getLocalVocabIndex(input).c_str());
   };
   testRandomIds(&makeLocalVocabId, localVocabWordToInt,
-                Datatype::LocalVocabIndex);
-  testRandomIds(&makeWordVocabId, &getWordVocabIndex, Datatype::WordVocabIndex);
+                Datatype::LocalVocabIndex, indexGenerator,
+                uint64_t{std::numeric_limits<int64_t>::max()});
+  testRandomIds(&makeWordVocabId, &getWordVocabIndex, Datatype::WordVocabIndex,
+                indexGenerator, ValueId::maxIndex);
 }
 
 TEST_F(ValueIdTest, Undefined) {
@@ -354,9 +322,8 @@ TEST_F(ValueIdTest, toDebugString) {
   // Values with type undefined can usually only have one value (all data bits
   // zero). Sometimes ValueIds with type undefined but non-zero data bits are
   // used. The following test tests one of these internal ValueIds.
-  ValueId customUndefined = ValueId::fromBits(
-      ValueId::IntegerType::fromNBit(100) |
-      (static_cast<ValueId::T>(Datatype::Undefined) << ValueId::numDataBits));
+  ValueId customUndefined =
+      ValueId::fromBits({static_cast<uint8_t>(Datatype::Undefined), 100});
   test(customUndefined, "U:100");
   test(ValueId::makeFromDouble(42.0), "D:42.000000");
   test(ValueId::makeFromBool(false), "B:false");

--- a/test/ValueIdTestHelpers.h
+++ b/test/ValueIdTestHelpers.h
@@ -16,29 +16,22 @@ static constexpr size_t numElements = 10'000;
 static constexpr size_t numElements = 10;
 #endif
 
+// Note: Since the payload of a `ValueId` is a full 64-bit word, all doubles,
+// all values of `int64_t`, and all indices of `uint64_t` are exactly
+// representable.
 inline auto positiveRepresentableDoubleGenerator =
-    ad_utility::RandomDoubleGenerator(ValueId::minPositiveDouble,
+    ad_utility::RandomDoubleGenerator(std::numeric_limits<double>::denorm_min(),
                                       std::numeric_limits<double>::max());
 inline auto negativeRepresentableDoubleGenerator =
-    ad_utility::RandomDoubleGenerator(-std::numeric_limits<double>::max(),
-                                      -ValueId::minPositiveDouble);
-inline auto nonRepresentableDoubleGenerator = ad_utility::RandomDoubleGenerator(
-    -ValueId::minPositiveDouble, ValueId::minPositiveDouble);
+    ad_utility::RandomDoubleGenerator(
+        -std::numeric_limits<double>::max(),
+        -std::numeric_limits<double>::denorm_min());
 inline auto indexGenerator =
     ad_utility::SlowRandomIntGenerator<uint64_t>(0, ValueId::maxIndex);
-inline auto invalidIndexGenerator =
-    ad_utility::SlowRandomIntGenerator<uint64_t>(
-        ValueId::maxIndex, std::numeric_limits<uint64_t>::max());
 
 inline auto nonOverflowingNBitGenerator =
     ad_utility::SlowRandomIntGenerator<int64_t>(ValueId::IntegerType::min(),
                                                 ValueId::IntegerType::max());
-inline auto overflowingNBitGenerator =
-    ad_utility::SlowRandomIntGenerator<int64_t>(
-        ValueId::IntegerType::max() + 1, std::numeric_limits<int64_t>::max());
-inline auto underflowingNBitGenerator =
-    ad_utility::SlowRandomIntGenerator<int64_t>(
-        std::numeric_limits<int64_t>::min(), ValueId::IntegerType::min() - 1);
 
 // Some helper functions to convert uint64_t values directly to and from index
 // type `ValueId`s.
@@ -116,8 +109,6 @@ inline auto makeRandomIds = []() {
   addIdsFromGenerator(indexGenerator, &makeWordVocabId, ids);
   addIdsFromGenerator(indexGenerator, &makeBlankNodeId, ids);
   addIdsFromGenerator(nonOverflowingNBitGenerator, &ValueId::makeFromInt, ids);
-  addIdsFromGenerator(overflowingNBitGenerator, &ValueId::makeFromInt, ids);
-  addIdsFromGenerator(underflowingNBitGenerator, &ValueId::makeFromInt, ids);
 
   for (size_t i = 0; i < numElements; ++i) {
     ids.push_back(ValueId::makeUndefined());

--- a/test/VocabularyGeneratorTest.cpp
+++ b/test/VocabularyGeneratorTest.cpp
@@ -199,7 +199,7 @@ TEST_F(MergeVocabularyTest, mergeVocabulary) {
           ql::ends_with(
               word, "\"^^<http://www.opengis.net/ont/geosparql#wktLiteral>")) {
         geoMergeResult.emplace_back(word, isExternal);
-        return (geoMergeResult.size() - 1) | (1ull << 59);
+        return (geoMergeResult.size() - 1) | (1ull << 63);
       } else {
         mergeResult.emplace_back(word, isExternal);
         return mergeResult.size() - 1;

--- a/test/engine/CartesianProductJoinTest.cpp
+++ b/test/engine/CartesianProductJoinTest.cpp
@@ -386,7 +386,7 @@ class CartesianProductJoinLazyTest
     join.getExecutionContext()->getQueryTreeCache().clearAll();
     Result result = join.computeResultOnlyForTesting(true);
     ASSERT_FALSE(result.isFullyMaterialized());
-    std::vector<std::unordered_map<uint64_t, size_t>> counter{
+    std::vector<std::unordered_map<Id::BitRepresentation, size_t>> counter{
         occurenceCounts.size()};
     size_t elementCounter = 0;
     for (auto& [idTable, localVocab] : result.idTables()) {

--- a/test/engine/IndexScanTest.cpp
+++ b/test/engine/IndexScanTest.cpp
@@ -152,7 +152,7 @@ void testLazyScanForJoinWithColumn(
   auto t = generateLocationTrace(l);
   auto qec = getQec(kg);
   IndexScan scan{qec, Permutation::PSO, scanTriple};
-  std::vector<Id> column;
+  columnBasedIdTable::IdColumnVector<> column;
   for (const auto& entry : columnEntries) {
     column.push_back(entry.toValueId(qec->getIndex()).value());
   }
@@ -170,7 +170,7 @@ void testLazyScanWithColumnThrows(
   auto t = generateLocationTrace(l);
   auto qec = getQec(kg);
   IndexScan s1{qec, Permutation::PSO, scanTriple};
-  std::vector<Id> column;
+  columnBasedIdTable::IdColumnVector<> column;
   for (const auto& entry : columnEntries) {
     column.push_back(entry.toValueId(qec->getIndex()).value());
   }

--- a/test/engine/OptionalJoinTest.cpp
+++ b/test/engine/OptionalJoinTest.cpp
@@ -1167,7 +1167,8 @@ TEST_P(OptionalJoinWithIndexScan, twoColumnsLocalVocabPropagation) {
   EXPECT_EQ(actual.numColumns(), 3);
 
   const auto& payload = actual.getColumn(2);
-  const auto& payloadBits = payload | ql::views::transform(&Id::getBits);
+  const auto& payloadBits =
+      payload | ql::views::transform([](const Id& id) { return id.getBits(); });
   EXPECT_TRUE(ad_utility::contains(payloadBits, l1.getBits()));
   EXPECT_TRUE(ad_utility::contains(payloadBits, l2.getBits()));
   EXPECT_TRUE(ad_utility::contains(payloadBits, l3.getBits()));

--- a/test/engine/StringMappingTest.cpp
+++ b/test/engine/StringMappingTest.cpp
@@ -20,7 +20,7 @@ TEST(StringMapping, remapId) {
   auto* qec = ad_utility::testing::getQec("<a> <b> <c> .");
   auto toMappedId = [](size_t count) {
     return Id::makeFromLocalVocabIndex(
-        reinterpret_cast<LocalVocabIndex>(count << ValueId::numDatatypeBits));
+        reinterpret_cast<LocalVocabIndex>(count));
   };
 
   auto binaryEq = [](Id a, Id b,

--- a/test/index/EncodedIriManagerTest.cpp
+++ b/test/index/EncodedIriManagerTest.cpp
@@ -49,7 +49,7 @@ TEST(EncodedIriManger, EncodingAndDecoding) {
     EXPECT_EQ(encodedIriManager.toString(id.value()), wdq)
         << std::hex << id.value().getBits();
     stringsAndEncodings.push_back(
-        std::pair{std::move(wdq), id.value().getBits()});
+        std::pair{std::move(wdq), id.value().getEncodedVal()});
   }
 
   // Test the sorting;

--- a/test/index/IndexRebuilderTest.cpp
+++ b/test/index/IndexRebuilderTest.cpp
@@ -362,7 +362,7 @@ TEST(IndexRebuilder, readIndexAndRemap) {
     return Id::makeFromLocalVocabIndex(entry);
   });
 
-  ad_utility::HashMap<Id::T, Id> localVocabMapping{
+  ad_utility::HashMap<Id::BitRepresentation, Id> localVocabMapping{
       {Id::makeFromLocalVocabIndex(vocabEntries.at(0)).getBits(),
        Id::makeFromVocabIndex(VocabIndex::make(1))},
       {Id::makeFromLocalVocabIndex(vocabEntries.at(1)).getBits(),
@@ -475,7 +475,7 @@ TEST(IndexRebuilder, createPermutationWriterTask) {
       std::make_shared<ad_utility::SharedCancellationHandle::element_type>();
   auto state =
       index.deltaTriplesManager().getCurrentLocatedTriplesSharedState();
-  ad_utility::HashMap<Id::T, Id> localVocabMapping;
+  ad_utility::HashMap<Id::BitRepresentation, Id> localVocabMapping;
   std::vector<VocabIndex> insertionPositions;
   std::vector<uint64_t> blankNodeBlocks;
   auto task = createPermutationWriterTask(

--- a/test/index/vocabulary/SplitVocabularyTest.cpp
+++ b/test/index/vocabulary/SplitVocabularyTest.cpp
@@ -77,26 +77,26 @@ TEST(Vocabulary, SplitGeoVocab) {
   ASSERT_EQ(SGV::getMarkerForWord("\"\"^^<http://example.com>"), 0);
 
   // Add marker bit
-  ASSERT_EQ(SGV::addMarker(0, 1), (1ULL << 59));
-  ASSERT_EQ(SGV::addMarker(25, 1), (1ULL << 59) | 25);
+  ASSERT_EQ(SGV::addMarker(0, 1), (1ULL << 63));
+  ASSERT_EQ(SGV::addMarker(25, 1), (1ULL << 63) | 25);
 
   // Get vocab index
   ASSERT_EQ(SGV::getVocabIndex(0), 0);
   ASSERT_EQ(SGV::getVocabIndex(1), 1);
-  ASSERT_EQ(SGV::getVocabIndex(1ULL << 59), 0);
-  ASSERT_EQ(SGV::getVocabIndex((1ULL << 59) | 25), 25);
+  ASSERT_EQ(SGV::getVocabIndex(1ULL << 63), 0);
+  ASSERT_EQ(SGV::getVocabIndex((1ULL << 63) | 25), 25);
 
   // Vocab index is out of range
-  EXPECT_ANY_THROW(SGV::addMarker((1ULL << 60) | 42, 5));
-  EXPECT_ANY_THROW(SGV::addMarker(1ULL << 59, 5));
+  EXPECT_ANY_THROW(SGV::addMarker((1ULL << 63) | 42, 5));
+  EXPECT_ANY_THROW(SGV::addMarker(1ULL << 63, 5));
 
   // Check marker bit
-  ASSERT_TRUE(SGV::isSpecialVocabIndex((1ULL << 59) | 42));
-  ASSERT_TRUE(SGV::isSpecialVocabIndex(1ULL << 59));
+  ASSERT_TRUE(SGV::isSpecialVocabIndex((1ULL << 63) | 42));
+  ASSERT_TRUE(SGV::isSpecialVocabIndex(1ULL << 63));
   ASSERT_FALSE(SGV::isSpecialVocabIndex(0));
   ASSERT_FALSE(SGV::isSpecialVocabIndex(42));
-  ASSERT_FALSE(SGV::isSpecialVocabIndex((1ULL << 59) - 1));
-  ASSERT_FALSE(SGV::isSpecialVocabIndex(1ULL << 58));
+  ASSERT_FALSE(SGV::isSpecialVocabIndex((1ULL << 63) - 1));
+  ASSERT_FALSE(SGV::isSpecialVocabIndex(1ULL << 62));
 
   // Geometry info
   ASSERT_TRUE(SGV::isGeoInfoAvailable());
@@ -112,26 +112,26 @@ TEST(Vocabulary, SplitVocabularyCustomWithTwoVocabs) {
 
   ASSERT_EQ(sv.numberOfVocabs, 2);
   ASSERT_EQ(sv.markerBitMaskSize, 1);
-  ASSERT_EQ(sv.markerBitMask, 1ULL << 59);
-  ASSERT_EQ(sv.markerShift, 59);
-  ASSERT_EQ(sv.vocabIndexBitMask, (1ULL << 59) - 1);
+  ASSERT_EQ(sv.markerBitMask, 1ULL << 63);
+  ASSERT_EQ(sv.markerShift, 63);
+  ASSERT_EQ(sv.vocabIndexBitMask, (1ULL << 63) - 1);
 
   ASSERT_EQ(sv.addMarker(42, 0), 42);
-  ASSERT_EQ(sv.addMarker(42, 1), (1ULL << 59) | 42);
-  ASSERT_ANY_THROW(sv.addMarker(1ULL << 60, 1));
+  ASSERT_EQ(sv.addMarker(42, 1), (1ULL << 63) | 42);
+  ASSERT_ANY_THROW(sv.addMarker(1ULL << 63, 1));
   ASSERT_ANY_THROW(sv.addMarker(5, 2));
 
-  ASSERT_EQ(sv.getMarker((1ULL << 59) | 42), 1);
+  ASSERT_EQ(sv.getMarker((1ULL << 63) | 42), 1);
   ASSERT_EQ(sv.getMarker(42), 0);
 
-  ASSERT_EQ(sv.getVocabIndex((1ULL << 59) | 42), 42);
-  ASSERT_EQ(sv.getVocabIndex(1ULL << 59), 0);
+  ASSERT_EQ(sv.getVocabIndex((1ULL << 63) | 42), 42);
+  ASSERT_EQ(sv.getVocabIndex(1ULL << 63), 0);
   ASSERT_EQ(sv.getVocabIndex(0), 0);
-  ASSERT_EQ(sv.getVocabIndex((1ULL << 59) - 1), (1ULL << 59) - 1);
+  ASSERT_EQ(sv.getVocabIndex((1ULL << 63) - 1), (1ULL << 63) - 1);
   ASSERT_EQ(sv.getVocabIndex(42), 42);
 
-  ASSERT_TRUE(sv.isSpecialVocabIndex((1ULL << 59) | 42));
-  ASSERT_TRUE(sv.isSpecialVocabIndex(1ULL << 59));
+  ASSERT_TRUE(sv.isSpecialVocabIndex((1ULL << 63) | 42));
+  ASSERT_TRUE(sv.isSpecialVocabIndex(1ULL << 63));
   ASSERT_FALSE(sv.isSpecialVocabIndex(42));
   ASSERT_FALSE(sv.isSpecialVocabIndex(0));
 
@@ -150,7 +150,7 @@ TEST(Vocabulary, SplitVocabularyCustomWithTwoVocabs) {
   sv.readFromFile("twoSplitVocab.dat");
   ASSERT_EQ(sv.size(), 4);
   ASSERT_EQ(sv[1], "\"xyz\"");
-  ASSERT_EQ(sv[(1ULL << 59) | 1], "\"axyz\"");
+  ASSERT_EQ(sv[(1ULL << 63) | 1], "\"axyz\"");
 
   // Test access to and content of underlying vocabs
   std::visit(
@@ -209,8 +209,8 @@ TEST(Vocabulary, SplitVocabularyCustomWithTwoVocabs) {
   // `GeoVocabulary`
   ASSERT_FALSE(sv.getGeoInfo(0).has_value());
   ASSERT_FALSE(sv.getGeoInfo(1).has_value());
-  ASSERT_FALSE(sv.getGeoInfo(1ULL << 59).has_value());
-  ASSERT_FALSE(sv.getGeoInfo((1ULL << 59) | 1).has_value());
+  ASSERT_FALSE(sv.getGeoInfo(1ULL << 63).has_value());
+  ASSERT_FALSE(sv.getGeoInfo((1ULL << 63) | 1).has_value());
 
   sv.close();
 }
@@ -225,31 +225,31 @@ TEST(Vocabulary, SplitVocabularyCustomWithThreeVocabs) {
 
   ASSERT_EQ(sv.numberOfVocabs, 3);
   ASSERT_EQ(sv.markerBitMaskSize, 2);
-  ASSERT_EQ(sv.markerBitMask, 3ULL << 58);
-  ASSERT_EQ(sv.markerShift, 58);
-  ASSERT_EQ(sv.vocabIndexBitMask, (1ULL << 58) - 1);
+  ASSERT_EQ(sv.markerBitMask, 3ULL << 62);
+  ASSERT_EQ(sv.markerShift, 62);
+  ASSERT_EQ(sv.vocabIndexBitMask, (1ULL << 62) - 1);
 
   ASSERT_EQ(sv.addMarker(42, 0), 42);
-  ASSERT_EQ(sv.addMarker(42, 1), (1ULL << 58) | 42);
-  ASSERT_EQ(sv.addMarker(42, 2), (2ULL << 58) | 42);
-  ASSERT_ANY_THROW(sv.addMarker(1ULL << 60, 1));
+  ASSERT_EQ(sv.addMarker(42, 1), (1ULL << 62) | 42);
+  ASSERT_EQ(sv.addMarker(42, 2), (2ULL << 62) | 42);
+  ASSERT_ANY_THROW(sv.addMarker(1ULL << 62, 1));
   ASSERT_ANY_THROW(sv.addMarker(5, 3));
 
-  ASSERT_EQ(sv.getMarker((1ULL << 58) | 42), 1);
-  ASSERT_EQ(sv.getMarker((2ULL << 58) | 42), 2);
+  ASSERT_EQ(sv.getMarker((1ULL << 62) | 42), 1);
+  ASSERT_EQ(sv.getMarker((2ULL << 62) | 42), 2);
   ASSERT_EQ(sv.getMarker(42), 0);
 
-  ASSERT_EQ(sv.getVocabIndex((1ULL << 58) | 42), 42);
-  ASSERT_EQ(sv.getVocabIndex((2ULL << 58) | 42), 42);
-  ASSERT_EQ(sv.getVocabIndex(1ULL << 58), 0);
-  ASSERT_EQ(sv.getVocabIndex(2ULL << 58), 0);
+  ASSERT_EQ(sv.getVocabIndex((1ULL << 62) | 42), 42);
+  ASSERT_EQ(sv.getVocabIndex((2ULL << 62) | 42), 42);
+  ASSERT_EQ(sv.getVocabIndex(1ULL << 62), 0);
+  ASSERT_EQ(sv.getVocabIndex(2ULL << 62), 0);
   ASSERT_EQ(sv.getVocabIndex(0), 0);
-  ASSERT_EQ(sv.getVocabIndex((1ULL << 58) - 1), (1ULL << 58) - 1);
+  ASSERT_EQ(sv.getVocabIndex((1ULL << 62) - 1), (1ULL << 62) - 1);
   ASSERT_EQ(sv.getVocabIndex(42), 42);
 
-  ASSERT_TRUE(sv.isSpecialVocabIndex((1ULL << 58) | 42));
-  ASSERT_TRUE(sv.isSpecialVocabIndex((2ULL << 58) | 42));
-  ASSERT_TRUE(sv.isSpecialVocabIndex(1ULL << 58));
+  ASSERT_TRUE(sv.isSpecialVocabIndex((1ULL << 62) | 42));
+  ASSERT_TRUE(sv.isSpecialVocabIndex((2ULL << 62) | 42));
+  ASSERT_TRUE(sv.isSpecialVocabIndex(1ULL << 62));
   ASSERT_FALSE(sv.isSpecialVocabIndex(42));
   ASSERT_FALSE(sv.isSpecialVocabIndex(0));
 
@@ -271,9 +271,9 @@ TEST(Vocabulary, SplitVocabularyCustomWithThreeVocabs) {
   sv.readFromFile("threeSplitVocab.dat");
   ASSERT_EQ(sv.size(), 6);
   ASSERT_EQ(sv[2], "\"axyz\"");
-  ASSERT_EQ(sv[2ULL << 58], "\"xyz\"^^<blabliblu>");
-  ASSERT_EQ(sv[(2ULL << 58) | 1], "\"zzz\"^^<blabliblu>");
-  ASSERT_EQ(sv[1ULL << 58], "\"xyz\"^^<http://example.com>");
+  ASSERT_EQ(sv[2ULL << 62], "\"xyz\"^^<blabliblu>");
+  ASSERT_EQ(sv[(2ULL << 62) | 1], "\"zzz\"^^<blabliblu>");
+  ASSERT_EQ(sv[1ULL << 62], "\"xyz\"^^<http://example.com>");
 }
 
 // _____________________________________________________________________________
@@ -303,13 +303,13 @@ TEST(Vocabulary, SplitVocabularyItemAt) {
 
   // Out of range indices
   EXPECT_ANY_THROW(v[VocabIndex::make(42)]);
-  EXPECT_ANY_THROW(v[VocabIndex::make((1ULL << 59) | 42)]);
+  EXPECT_ANY_THROW(v[VocabIndex::make((1ULL << 63) | 42)]);
 
-  auto idx = VocabIndex::make(1ULL << 59);
+  auto idx = VocabIndex::make(1ULL << 63);
   ASSERT_EQ(v[idx],
             "\"LINESTRING(1 2, 3 4)\""
             "^^<http://www.opengis.net/ont/geosparql#wktLiteral>");
-  idx = VocabIndex::make(static_cast<uint64_t>(1) << 59 | 1);
+  idx = VocabIndex::make(static_cast<uint64_t>(1) << 63 | 1);
   ASSERT_EQ(v[idx],
             "\"POLYGON((1 2, 3 4))\""
             "^^<http://www.opengis.net/ont/geosparql#wktLiteral>");
@@ -332,14 +332,14 @@ TEST(Vocabulary, SplitVocabularyWordWriterAndGetPosition) {
       (*wordCallback)("\"LINESTRING(1 2, 3 4)\""
                       "^^<http://www.opengis.net/ont/geosparql#wktLiteral>",
                       true),
-      (1ULL << 59));
+      (1ULL << 63));
   ASSERT_EQ((*wordCallback)("\"ba\"", true), 2);
   ASSERT_EQ((*wordCallback)("\"car\"@en", true), 3);
   ASSERT_EQ(
       (*wordCallback)("\"POLYGON((1 2, 3 4))\""
                       "^^<http://www.opengis.net/ont/geosparql#wktLiteral>",
                       true),
-      (1ULL << 59) | 1);
+      (1ULL << 63) | 1);
 
   wordCallback->finish();
 
@@ -364,8 +364,8 @@ TEST(Vocabulary, SplitVocabularyWordWriterAndGetPosition) {
       vocabulary.getId("\"LINESTRING(1 2, 3 4)\""
                        "^^<http://www.opengis.net/ont/geosparql#wktLiteral>",
                        &idx));
-  ASSERT_EQ(idx.get(), 1ULL << 59);
-  ASSERT_EQ(vocabulary[VocabIndex::make(1ULL << 59)],
+  ASSERT_EQ(idx.get(), 1ULL << 63);
+  ASSERT_EQ(vocabulary[VocabIndex::make(1ULL << 63)],
             "\"LINESTRING(1 2, 3 4)\""
             "^^<http://www.opengis.net/ont/geosparql#wktLiteral>");
 
@@ -373,8 +373,8 @@ TEST(Vocabulary, SplitVocabularyWordWriterAndGetPosition) {
       vocabulary.getId("\"POLYGON((1 2, 3 4))\""
                        "^^<http://www.opengis.net/ont/geosparql#wktLiteral>",
                        &idx));
-  ASSERT_EQ(idx.get(), (1ULL << 59) | 1);
-  ASSERT_EQ(vocabulary[VocabIndex::make((1ULL << 59) | 1)],
+  ASSERT_EQ(idx.get(), (1ULL << 63) | 1);
+  ASSERT_EQ(vocabulary[VocabIndex::make((1ULL << 63) | 1)],
             "\"POLYGON((1 2, 3 4))\""
             "^^<http://www.opengis.net/ont/geosparql#wktLiteral>");
 
@@ -401,22 +401,22 @@ TEST(Vocabulary, SplitVocabularyWordWriterAndGetPosition) {
   auto [l4, u4] = vocabulary.getPositionOfWord(
       "\"POLYGON((0 0, 3 4))\""
       "^^<http://www.opengis.net/ont/geosparql#wktLiteral>");
-  ASSERT_EQ(l4, VocabIndex::make((1ULL << 59) | 1));
-  ASSERT_EQ(u4, VocabIndex::make((1ULL << 59) | 1));
+  ASSERT_EQ(l4, VocabIndex::make((1ULL << 63) | 1));
+  ASSERT_EQ(u4, VocabIndex::make((1ULL << 63) | 1));
 
   //  - Non-existing split word, at the end
   auto [l5, u5] = vocabulary.getPositionOfWord(
       "\"POLYGON((9 9, 9 9))\""
       "^^<http://www.opengis.net/ont/geosparql#wktLiteral>");
-  ASSERT_EQ(l5, VocabIndex::make((1ULL << 59) | 2));
-  ASSERT_EQ(u5, VocabIndex::make((1ULL << 59) | 2));
+  ASSERT_EQ(l5, VocabIndex::make((1ULL << 63) | 2));
+  ASSERT_EQ(u5, VocabIndex::make((1ULL << 63) | 2));
 
   //  - Existing split word
   auto [l6, u6] = vocabulary.getPositionOfWord(
       "\"POLYGON((1 2, 3 4))\""
       "^^<http://www.opengis.net/ont/geosparql#wktLiteral>");
-  ASSERT_EQ(l6, VocabIndex::make((1ULL << 59) | 1));
-  ASSERT_EQ(u6, VocabIndex::make((1ULL << 59) | 2));
+  ASSERT_EQ(l6, VocabIndex::make((1ULL << 63) | 1));
+  ASSERT_EQ(u6, VocabIndex::make((1ULL << 63) | 2));
 
   //  - Non-existing prefix of an existing split word
   auto [l7, u7] = vocabulary.getPositionOfWord("\"POLYGON((1 2, 3 4))");


### PR DESCRIPTION
`ValueId` now consists of a single datatype byte and a full 64-bit payload word. Integers cover the whole `int64_t` range, doubles keep their full IEEE precision, and all index types can use 64 bits. `getBits()` returns a `ValueIdBitRepresentation` struct with datatype-major ordering (the overall ID ordering semantics are unchanged).

Because a materialized `ValueId` occupies 16 bytes (7 bytes padding), the `IdTable` now stores its `Id` columns in a storage-efficient split layout: one contiguous array for the 64-bit payloads and one for the datatype bytes (9 bytes per entry). New proxy types (`IdRef`, `ConstIdRef`, `IdColumnIterator`, `IdColumnSpan`, `IdColumnVector` in `src/engine/idTable/IdColumn.h`) keep the existing `IdTable` and `Id` interfaces intact; `IdRef` mirrors the full read API of `ValueId`. Tables of other element types (e.g. `int` in tests) keep their plain `std::vector` storage via the new `ColumnStorageTraits`.

The permutation blocks and the external sorter compress the payload words and the datatype bytes of each column as two adjacent zstd streams. This is a breaking change of the on-disk index format; the index version is bumped accordingly.