### PR TITLE
Add programmatic index building via an injected RDF parser to `libqlever`

### DIFF
--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -386,6 +386,19 @@ void IndexImpl::createFromFiles(
 // _____________________________________________________________________________
 void IndexImpl::createFromFiles(
     ad_utility::InputRangeTypeErased<qlever::InputFileSpecification> files) {
+  // The `shared_ptr` makes the lambda copyable (as `std::function` requires);
+  // the factory is only ever invoked once.
+  auto sharedFiles = std::make_shared<
+      ad_utility::InputRangeTypeErased<qlever::InputFileSpecification>>(
+      std::move(files));
+  createFromParser(
+      [this, sharedFiles = std::move(sharedFiles)](const EncodedIriManager*) {
+        return makeRdfParser(std::move(*sharedFiles));
+      });
+}
+
+// _____________________________________________________________________________
+void IndexImpl::createFromParser(const ParserFactory& parserFactory) {
   if (!loadAllPermutations_ && usePatterns_) {
     throw std::runtime_error{
         "The patterns can only be built when all 6 permutations are created"};
@@ -398,7 +411,7 @@ void IndexImpl::createFromFiles(
   readIndexBuilderSettingsFromFile();
 
   IndexBuilderDataAsFirstPermutationSorter indexBuilderData =
-      createIdTriplesAndVocab(makeRdfParser(std::move(files)));
+      createIdTriplesAndVocab(parserFactory(&encodedIriManager()));
 
   // Write the configuration already at this point, so we have it available in
   // case any of the permutations fail.

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -9,6 +9,7 @@
 
 #include <gtest/gtest_prod.h>
 
+#include <functional>
 #include <memory>
 #include <optional>
 #include <string>
@@ -236,6 +237,21 @@ class IndexImpl {
 
   void createFromFiles(
       ad_utility::InputRangeTypeErased<qlever::InputFileSpecification> files);
+
+  // Type-erased parser factory for programmatic index building (triples
+  // supplied by an embedding application instead of input files). It is a
+  // factory rather than a parser because the `EncodedIriManager` is only
+  // configured during index building, shortly before the parser is needed.
+  using ParserFactory =
+      std::function<std::unique_ptr<RdfParserBase>(const EncodedIriManager*)>;
+
+  // Creates an index from the triples yielded by the parser produced by
+  // `parserFactory`. Same orchestration as `createFromFiles` (vocabulary
+  // creation, conversion to global IDs, permutations, patterns), with the
+  // input source injected. The same restriction applies: the index cannot be
+  // used directly after this call, but has to be set up by
+  // `createFromOnDiskIndex`.
+  void createFromParser(const ParserFactory& parserFactory);
 
   // Creates an index object from an on disk index that has previously been
   // constructed. Read necessary meta data into memory and opens file handles.

--- a/src/libqlever/Qlever.cpp
+++ b/src/libqlever/Qlever.cpp
@@ -81,6 +81,12 @@ Qlever::Qlever(const EngineConfig& config)
 
 // _____________________________________________________________________________
 void Qlever::buildIndex(IndexBuilderConfig config) {
+  buildIndex(std::move(config), ParserFactory{});
+}
+
+// _____________________________________________________________________________
+void Qlever::buildIndex(IndexBuilderConfig config,
+                        ParserFactory parserFactory) {
   Index index{ad_utility::makeUnlimitedAllocator<Id>()};
 
   // Set memory limit and parser buffer size if specified.
@@ -112,8 +118,12 @@ void Qlever::buildIndex(IndexBuilderConfig config) {
 
   // Build text index if requested (various options).
   if (!config.onlyAddTextIndex_) {
-    AD_CONTRACT_CHECK(!config.inputFiles_.empty());
-    index.createFromFiles(config.inputFiles_);
+    if (parserFactory) {
+      index.getImpl().createFromParser(std::move(parserFactory));
+    } else {
+      AD_CONTRACT_CHECK(!config.inputFiles_.empty());
+      index.createFromFiles(config.inputFiles_);
+    }
   }
 
   if (config.wordsAndDocsFileSpecified() || config.addWordsFromLiterals_) {

--- a/src/libqlever/Qlever.h
+++ b/src/libqlever/Qlever.h
@@ -8,6 +8,7 @@
 #define QLEVER_SRC_LIBQLEVER_QLEVER_H
 
 #include <boost/optional.hpp>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <string>
@@ -20,6 +21,7 @@
 #include "engine/QueryExecutionContext.h"
 #include "engine/QueryPlanner.h"
 #include "global/RuntimeParameters.h"
+#include "index/EncodedIriManager.h"
 #include "index/Index.h"
 #include "index/InputFileSpecification.h"
 #include "libqlever/QleverTypes.h"
@@ -28,7 +30,15 @@
 #include "util/Synchronized.h"
 #include "util/http/MediaTypes.h"
 
+class RdfParserBase;
+
 namespace qlever {
+
+// Type-erased parser factory for programmatic index building (triples
+// supplied by the embedding application instead of input files). See
+// `IndexImpl::ParserFactory` for why this is a factory and not a parser.
+using ParserFactory =
+    std::function<std::unique_ptr<RdfParserBase>(const EncodedIriManager*)>;
 
 // The common configuration shared by the index building and query execution.
 struct CommonConfig {
@@ -249,6 +259,14 @@ class Qlever {
  public:
   // Build an index, using an `IndexBuilderConfig` as explained above.
   static void buildIndex(IndexBuilderConfig config);
+
+  // Build an index from triples supplied programmatically by the parser
+  // produced by `parserFactory` (`config.inputFiles_` is then ignored; an
+  // empty factory means "build from `config.inputFiles_`" as above). This
+  // allows embedding applications to feed triples from their own data
+  // structures without serializing them to an RDF text format first.
+  static void buildIndex(IndexBuilderConfig config,
+                         ParserFactory parserFactory);
 
   // Create a QLever instance for querying using an `EngineConfig` as
   // explained above.

--- a/test/libqlever/QleverTest.cpp
+++ b/test/libqlever/QleverTest.cpp
@@ -12,6 +12,7 @@
 #include "../util/RuntimeParametersTestHelpers.h"
 #include "engine/ExternalValues.h"
 #include "libqlever/Qlever.h"
+#include "parser/RdfParser.h"
 
 using namespace qlever;
 using namespace testing;
@@ -102,6 +103,62 @@ TEST(LibQlever, buildIndexAndRunQuery) {
   ec.loadTextIndex_ = true;
   Qlever engine{ec};
 #endif
+}
+
+namespace {
+// A minimal parser that yields a fixed set of programmatically created
+// triples, for testing the parser-injecting `buildIndex` overload.
+class VectorTripleParser : public RdfParserBase {
+  std::vector<TurtleTriple> triples_;
+  size_t next_ = 0;
+
+ public:
+  VectorTripleParser(std::vector<TurtleTriple> triples,
+                     const EncodedIriManager* encodedIriManager)
+      : RdfParserBase{encodedIriManager}, triples_{std::move(triples)} {}
+
+  bool getLineImpl(TurtleTriple* triple) override {
+    if (next_ >= triples_.size()) {
+      return false;
+    }
+    *triple = triples_[next_++];
+    return true;
+  }
+  size_t getParsePosition() const override { return next_; }
+};
+}  // namespace
+
+// _____________________________________________________________________________
+TEST(LibQlever, buildIndexFromInjectedParser) {
+  IndexBuilderConfig c;
+  c.baseName_ = "LibQlever.buildIndexFromInjectedParser";
+
+  auto iri = [](std::string_view s) {
+    return TripleComponent{TripleComponent::Iri::fromIriref(s)};
+  };
+  std::vector<TurtleTriple> triples{
+      {iri("<s>"), iri("<p>"), iri("<o>")},
+      {iri("<s2>"), iri("<p>"),
+       TripleComponent{TripleComponent::Literal::literalWithoutQuotes(
+           "kartoffel und salat")}}};
+
+  // Build the index from the injected parser (no input files involved) and
+  // check that the triples are queryable.
+  Qlever::buildIndex(c, [&triples](const EncodedIriManager* encodedIriManager) {
+    return std::make_unique<VectorTripleParser>(triples, encodedIriManager);
+  });
+
+  EngineConfig ec{c};
+  Qlever engine{ec};
+  auto res = engine.query("SELECT ?s WHERE { ?s <p> <o> }",
+                          ad_utility::MediaType::tsv);
+  EXPECT_EQ(res, "?s\n<s>\n");
+  res = engine.query("SELECT * WHERE { <s2> <p> ?o }",
+                     ad_utility::MediaType::csv);
+  EXPECT_EQ(res, "o\nkartoffel und salat\n");
+
+  // An empty factory falls back to `config.inputFiles_`, which are empty here.
+  EXPECT_ANY_THROW(Qlever::buildIndex(c, ParserFactory{}));
 }
 
 // _____________________________________________________________________________


### PR DESCRIPTION
Resolves #3075 (related: #2961, which covers streaming *text* input via byte-source `InputFileSpecification`s, but not triples that never exist as RDF text). Embedders of `libqlever` whose data already lives in structured or columnar form currently have to serialize it to Turtle/N-Quads and have QLever re-parse that text. This adds `Qlever::buildIndex(IndexBuilderConfig, ParserFactory)`, which builds an index from the triples yielded by an injected `RdfParserBase` (an empty factory behaves like the existing overload and builds from `config.inputFiles_`). It is implemented by extracting the orchestration of the range-based `IndexImpl::createFromFiles` (vocabulary creation, conversion to global IDs, permutations, patterns) into a public `createFromParser(ParserFactory)`, with `createFromFiles` becoming a thin wrapper that injects the existing file-based `RdfMultifileParser`; the injection point is a factory rather than a parser because the `EncodedIriManager` is only configured during the index build, shortly before the parser is needed. No behavior change for existing callers; a unit test builds an index from programmatically created triples and queries it. In our embedding (the `triplets` Python library, which feeds triples zero-copy from Apache Arrow columns), this removed the serialize-and-re-parse leg of the index build entirely, with the embedder-side cost dropping from ~370 ms to ~3 ms per 1.14M triples.

**Before** — the build orchestration was reachable only through file specifications:

```mermaid
flowchart LR
    F1["InputFileSpecification<br/>(file / byte stream, #2961)"] --> C1["createFromFiles<br/>(orchestration hardwired<br/>to makeRdfParser)"]
    C1 --> P1["RdfMultifileParser<br/>(RDF text parsing)"]
    P1 --> V1["createIdTriplesAndVocab<br/>→ permutations / patterns"]
```

**After** — the same orchestration, with the parser injected; the file path is unchanged and becomes one caller of it:

```mermaid
flowchart LR
    F2["InputFileSpecification<br/>(file / byte stream)"] --> W["createFromFiles<br/>(thin wrapper, injects<br/>RdfMultifileParser)"]
    A["application triples<br/>(any RdfParserBase)"] --> PF["ParserFactory"]
    W --> O["createFromParser<br/>(orchestration, parser-agnostic)"]
    PF --> O
    O --> V2["createIdTriplesAndVocab<br/>→ permutations / patterns"]
```


**On the shape of the injection point:** a factory was chosen over a plain `std::unique_ptr<RdfParserBase>` because `RdfMultifileParser` parses eagerly from its constructor and the `EncodedIriManager` only exists inside the build — a ready-made parser could neither be constructed at the right time on the file path nor receive the correct manager on the embedder path.
