### PR TITLE
Make `LocalVocabEntry` comparisons independent of the index lifetime

### DIFF
--- a/src/index/LocalVocabEntry.cpp
+++ b/src/index/LocalVocabEntry.cpp
@@ -9,7 +9,7 @@
 
 // ___________________________________________________________________________
 std::shared_ptr<const TripleComponentComparator>
-localVocabEntryDetail::comparatorFromContext(
+LocalVocabEntry::comparatorFromContext(
     const LocalVocabContext& context) noexcept {
   return context.getVocab().getCaseComparatorPtr();
 }

--- a/src/index/LocalVocabEntry.cpp
+++ b/src/index/LocalVocabEntry.cpp
@@ -8,11 +8,21 @@
 #include "index/IndexImpl.h"
 
 // ___________________________________________________________________________
+std::shared_ptr<const TripleComponentComparator>
+localVocabEntryDetail::comparatorFromContext(
+    const LocalVocabContext& context) noexcept {
+  return context.getVocab().getCaseComparatorPtr();
+}
+
+// ___________________________________________________________________________
 ql::strong_ordering LocalVocabEntry::compareThreeWay(
     const LocalVocabEntry& rhs) const {
-  int i = context_->getVocab().getCaseComparator().compare(
-      toStringRepresentation(), rhs.toStringRepresentation(),
-      LocaleManager::Level::TOTAL);
+  // NOTE: Deliberately use the shared `comparator_` and not the `context_`:
+  // this way the comparison also works for entries that outlive the index
+  // they were created with (e.g. entries in a cached query result).
+  int i = comparator_->compare(toStringRepresentation(),
+                               rhs.toStringRepresentation(),
+                               LocaleManager::Level::TOTAL);
   if (i < 0) {
     return ql::strong_ordering::less;
   } else if (i > 0) {

--- a/src/index/LocalVocabEntry.h
+++ b/src/index/LocalVocabEntry.h
@@ -8,6 +8,7 @@
 #include <gtest/gtest_prod.h>
 
 #include <atomic>
+#include <memory>
 
 #include "backports/algorithm.h"
 #include "backports/keywords.h"
@@ -20,6 +21,15 @@
 
 class IndexImpl;
 using LocalVocabContext = IndexImpl;
+class TripleComponentComparator;
+
+namespace localVocabEntryDetail {
+// Return shared ownership of the case comparator of the vocabulary of the
+// given context (implemented in the `.cpp` file because it needs the full
+// definition of `IndexImpl`).
+std::shared_ptr<const TripleComponentComparator> comparatorFromContext(
+    const LocalVocabContext& context) noexcept;
+}  // namespace localVocabEntryDetail
 
 // This is the type we use to store literals and IRIs in the `LocalVocab`.
 // It consists of a `LiteralOrIri` and a cache to store the position, where
@@ -41,7 +51,16 @@ class alignas(16) LocalVocabEntry
 
  private:
   // Pointer to keep this object assignable.
+  // NOTE: The `context_` is only used to (lazily) compute the position in the
+  // vocabulary (see below), so it must stay valid until the position has been
+  // cached. Comparisons between entries (`compareThreeWay`) deliberately do
+  // NOT use the `context_`, but the shared `comparator_` below, so that they
+  // also work for entries that outlive the index they were created with (e.g.
+  // entries that are part of a cached query result).
   const LocalVocabContext* context_;
+  // Shared ownership of the case comparator of the vocabulary, see the NOTE
+  // above.
+  std::shared_ptr<const TripleComponentComparator> comparator_;
   // The cache for the position in the vocabulary. As usual, the `lowerBound` is
   // inclusive, the `upperBound` is not, so if `lowerBound == upperBound`, then
   // the entry is not part of the globalVocabulary, and `lowerBound` points to
@@ -55,21 +74,30 @@ class alignas(16) LocalVocabEntry
 
  public:
   LocalVocabEntry(LiteralT literal, const LocalVocabContext& context)
-      : Base{std::move(literal)}, context_{&context} {}
+      : Base{std::move(literal)},
+        context_{&context},
+        comparator_{localVocabEntryDetail::comparatorFromContext(context)} {}
   LocalVocabEntry(IriT iri, const LocalVocabContext& context) noexcept
-      : Base{std::move(iri)}, context_{&context} {}
+      : Base{std::move(iri)},
+        context_{&context},
+        comparator_{localVocabEntryDetail::comparatorFromContext(context)} {}
 
   // Deliberately allow implicit conversion from `LiteralOrIri`.
   LocalVocabEntry(const Base& base, const LocalVocabContext& context)
-      : Base{base}, context_{&context} {}
+      : Base{base},
+        context_{&context},
+        comparator_{localVocabEntryDetail::comparatorFromContext(context)} {}
   LocalVocabEntry(Base&& base, const LocalVocabContext& context) noexcept
-      : Base{std::move(base)}, context_{&context} {}
+      : Base{std::move(base)},
+        context_{&context},
+        comparator_{localVocabEntryDetail::comparatorFromContext(context)} {}
 
   // Constructor for when the position in the vocab is already known.
   LocalVocabEntry(Base&& base, auto lower, auto upper,
                   const LocalVocabContext& context)
       : Base{std::move(base)},
         context_{&context},
+        comparator_{localVocabEntryDetail::comparatorFromContext(context)},
         lowerBoundInVocab_(IdProxy::make(lower.getBits())),
         upperBoundInVocab_(IdProxy::make(upper.getBits())),
         positionInVocabKnown_(true) {

--- a/src/index/LocalVocabEntry.h
+++ b/src/index/LocalVocabEntry.h
@@ -23,14 +23,6 @@ class IndexImpl;
 using LocalVocabContext = IndexImpl;
 class TripleComponentComparator;
 
-namespace localVocabEntryDetail {
-// Return shared ownership of the case comparator of the vocabulary of the
-// given context (implemented in the `.cpp` file because it needs the full
-// definition of `IndexImpl`).
-std::shared_ptr<const TripleComponentComparator> comparatorFromContext(
-    const LocalVocabContext& context) noexcept;
-}  // namespace localVocabEntryDetail
-
 // This is the type we use to store literals and IRIs in the `LocalVocab`.
 // It consists of a `LiteralOrIri` and a cache to store the position, where
 // the entry would be in the global vocabulary of the Index. This position is
@@ -61,6 +53,12 @@ class alignas(16) LocalVocabEntry
   // Shared ownership of the case comparator of the vocabulary, see the NOTE
   // above.
   std::shared_ptr<const TripleComponentComparator> comparator_;
+
+  // Return shared ownership of the case comparator of the vocabulary of the
+  // given context (implemented in the `.cpp` file because it needs the full
+  // definition of `IndexImpl`).
+  static std::shared_ptr<const TripleComponentComparator> comparatorFromContext(
+      const LocalVocabContext& context) noexcept;
   // The cache for the position in the vocabulary. As usual, the `lowerBound` is
   // inclusive, the `upperBound` is not, so if `lowerBound == upperBound`, then
   // the entry is not part of the globalVocabulary, and `lowerBound` points to
@@ -76,28 +74,28 @@ class alignas(16) LocalVocabEntry
   LocalVocabEntry(LiteralT literal, const LocalVocabContext& context)
       : Base{std::move(literal)},
         context_{&context},
-        comparator_{localVocabEntryDetail::comparatorFromContext(context)} {}
+        comparator_{comparatorFromContext(context)} {}
   LocalVocabEntry(IriT iri, const LocalVocabContext& context) noexcept
       : Base{std::move(iri)},
         context_{&context},
-        comparator_{localVocabEntryDetail::comparatorFromContext(context)} {}
+        comparator_{comparatorFromContext(context)} {}
 
   // Deliberately allow implicit conversion from `LiteralOrIri`.
   LocalVocabEntry(const Base& base, const LocalVocabContext& context)
       : Base{base},
         context_{&context},
-        comparator_{localVocabEntryDetail::comparatorFromContext(context)} {}
+        comparator_{comparatorFromContext(context)} {}
   LocalVocabEntry(Base&& base, const LocalVocabContext& context) noexcept
       : Base{std::move(base)},
         context_{&context},
-        comparator_{localVocabEntryDetail::comparatorFromContext(context)} {}
+        comparator_{comparatorFromContext(context)} {}
 
   // Constructor for when the position in the vocab is already known.
   LocalVocabEntry(Base&& base, auto lower, auto upper,
                   const LocalVocabContext& context)
       : Base{std::move(base)},
         context_{&context},
-        comparator_{localVocabEntryDetail::comparatorFromContext(context)},
+        comparator_{comparatorFromContext(context)},
         lowerBoundInVocab_(IdProxy::make(lower.getBits())),
         upperBoundInVocab_(IdProxy::make(upper.getBits())),
         positionInVocabKnown_(true) {

--- a/src/index/Vocabulary.cpp
+++ b/src/index/Vocabulary.cpp
@@ -260,8 +260,6 @@ void Vocabulary<S, ComparatorType, I>::setLocale(const std::string& language,
                                                  bool ignorePunctuation) {
   vocabulary_.getComparator() =
       ComparatorType(language, country, ignorePunctuation);
-  vocabulary_.getComparator() =
-      ComparatorType(language, country, ignorePunctuation);
 }
 
 // _____________________________________________________________________________

--- a/src/index/Vocabulary.h
+++ b/src/index/Vocabulary.h
@@ -11,6 +11,7 @@
 #define QLEVER_SRC_INDEX_VOCABULARY_H
 
 #include <cassert>
+#include <memory>
 #include <optional>
 #include <string>
 #include <string_view>

--- a/src/index/Vocabulary.h
+++ b/src/index/Vocabulary.h
@@ -204,6 +204,12 @@ class Vocabulary {
     return vocabulary_.getComparator();
   }
 
+  // Shared ownership of the comparator, for objects that may outlive this
+  // vocabulary (e.g. `LocalVocabEntry`, see there for details).
+  std::shared_ptr<const ComparatorType> getCaseComparatorPtr() const {
+    return vocabulary_.getComparatorPtr();
+  }
+
   // Get prefix ranges for the given prefix.
   PrefixRanges prefixRanges(std::string_view prefix) const;
 

--- a/src/index/vocabulary/UnicodeVocabulary.h
+++ b/src/index/vocabulary/UnicodeVocabulary.h
@@ -5,6 +5,8 @@
 #ifndef QLEVER_SRC_INDEX_VOCABULARY_UNICODEVOCABULARY_H
 #define QLEVER_SRC_INDEX_VOCABULARY_UNICODEVOCABULARY_H
 
+#include <memory>
+
 #include "index/vocabulary/PolymorphicVocabulary.h"
 #include "index/vocabulary/VocabularyTypes.h"
 
@@ -18,7 +20,10 @@ class UnicodeVocabulary {
   using SortLevel = typename UnicodeComparator::Level;
 
  private:
-  UnicodeComparator _comparator;
+  // The comparator is stored via a `shared_ptr` so that it can be safely
+  // shared with objects that may outlive this vocabulary (in particular
+  // `LocalVocabEntry`, see `getComparatorPtr` below).
+  std::shared_ptr<UnicodeComparator> _comparator;
   UnderlyingVocabulary _underlyingVocabulary;
 
  public:
@@ -26,7 +31,7 @@ class UnicodeVocabulary {
   template <typename... Args>
   explicit UnicodeVocabulary(UnicodeComparator comparator = UnicodeComparator{},
                              Args&&... args)
-      : _comparator{std::move(comparator)},
+      : _comparator{std::make_shared<UnicodeComparator>(std::move(comparator))},
         _underlyingVocabulary{std::forward<Args>(args)...} {}
 
   auto operator[](uint64_t id) const { return _underlyingVocabulary[id]; }
@@ -42,7 +47,7 @@ class UnicodeVocabulary {
   template <typename T>
   WordAndIndex lower_bound(const T& word, SortLevel level) const {
     auto actualComparator = [this, level](const auto& a, const auto& b) {
-      return _comparator(a, b, level);
+      return (*_comparator)(a, b, level);
     };
     return _underlyingVocabulary.lower_bound(word, actualComparator);
   }
@@ -56,7 +61,7 @@ class UnicodeVocabulary {
   template <typename T>
   WordAndIndex upper_bound(const T& word, SortLevel level) const {
     auto actualComparator = [this, level](const auto& a, const auto& b) {
-      return _comparator(a, b, level);
+      return (*_comparator)(a, b, level);
     };
     return _underlyingVocabulary.upper_bound(word, actualComparator);
   }
@@ -67,7 +72,7 @@ class UnicodeVocabulary {
   template <typename T>
   std::pair<uint64_t, uint64_t> getPositionOfWord(const T& word) const {
     auto actualComparator = [this](const auto& a, const auto& b) {
-      return _comparator(a, b, SortLevel::TOTAL);
+      return (*_comparator)(a, b, SortLevel::TOTAL);
     };
     if constexpr (HasSpecialGetPositionOfWord<UnderlyingVocabulary>) {
       return _underlyingVocabulary.getPositionOfWord(word, actualComparator);
@@ -94,7 +99,7 @@ class UnicodeVocabulary {
     }
 
     auto lb = lower_bound(prefix, SortLevel::PRIMARY);
-    auto transformed = _comparator.transformToFirstPossibleBiggerValue(
+    auto transformed = _comparator->transformToFirstPossibleBiggerValue(
         prefix, SortLevel::PRIMARY);
 
     auto ub = lower_bound(transformed, SortLevel::PRIMARY);
@@ -119,8 +124,15 @@ class UnicodeVocabulary {
     return _underlyingVocabulary;
   }
 
-  UnicodeComparator& getComparator() { return _comparator; }
-  const UnicodeComparator& getComparator() const { return _comparator; }
+  UnicodeComparator& getComparator() { return *_comparator; }
+  const UnicodeComparator& getComparator() const { return *_comparator; }
+
+  // Shared ownership of the comparator, for objects that must be able to
+  // compare words even after this vocabulary (or the index that contains it)
+  // has been destroyed, e.g. `LocalVocabEntry`.
+  std::shared_ptr<const UnicodeComparator> getComparatorPtr() const {
+    return _comparator;
+  }
 
   void close() { _underlyingVocabulary.close(); }
 

--- a/src/index/vocabulary/UnicodeVocabulary.h
+++ b/src/index/vocabulary/UnicodeVocabulary.h
@@ -23,6 +23,9 @@ class UnicodeVocabulary {
   // The comparator is stored via a `shared_ptr` so that it can be safely
   // shared with objects that may outlive this vocabulary (in particular
   // `LocalVocabEntry`, see `getComparatorPtr` below).
+  // NOTE: A moved-from `UnicodeVocabulary` therefore has a null comparator
+  // (previously it held a valid but unspecified value), so a moved-from
+  // vocabulary must not be used except for assignment or destruction.
   std::shared_ptr<UnicodeComparator> _comparator;
   UnderlyingVocabulary _underlyingVocabulary;
 

--- a/test/LocalVocabTest.cpp
+++ b/test/LocalVocabTest.cpp
@@ -667,3 +667,26 @@ TEST(LocalVocab, reserveBlankNodeBlocksFromExplicitIndices_PreconditionCheck) {
       vocab.reserveBlankNodeBlocksFromExplicitIndices(indices, &bnm),
       ::testing::HasSubstr("Assertion"));
 }
+
+// _____________________________________________________________________________
+// Regression test: comparing two `LocalVocabEntry`s must also work after the
+// index they were created with has been destroyed. This happens e.g. for
+// entries that are part of a cached query result, or for entries that are
+// carried over when a rebuilt index is swapped in at runtime. It used to be a
+// use-after-free of the ICU collator of the destroyed index's vocabulary.
+TEST(LocalVocabEntry, comparisonWorksAfterIndexIsDestroyed) {
+  std::optional<LocalVocabEntry> a;
+  std::optional<LocalVocabEntry> b;
+  {
+    Index index = ad_utility::testing::makeTestIndex(
+        "LocalVocabEntryComparisonAfterIndexDestroyed", "<x> <y> <z>.");
+    a = LocalVocabEntry::fromIriref("<http://example.org/a>", index.getImpl());
+    b = LocalVocabEntry::fromIriref("<http://example.org/b>", index.getImpl());
+  }
+  // The index is gone; the comparison must still work because each entry
+  // shares ownership of the comparator.
+  EXPECT_EQ(a->compareThreeWay(*b), ql::strong_ordering::less);
+  EXPECT_EQ(b->compareThreeWay(*a), ql::strong_ordering::greater);
+  EXPECT_EQ(a->compareThreeWay(*a), ql::strong_ordering::equal);
+  EXPECT_TRUE(*a < *b);
+}


### PR DESCRIPTION
So far, `LocalVocabEntry::compareThreeWay` obtained the case comparator through its raw `context_` pointer to the `IndexImpl` it was created with. If an entry outlives that index (e.g. entries in a cached query result, or entries carried over when a rebuilt index is swapped in at runtime, see #2832), this is a use-after-free of the destroyed vocabulary's ICU collator (confirmed with ASAN; manifests as `U_UNSUPPORTED_ERROR` or a crash).

The vocabulary now holds its comparator via a `shared_ptr`, and each `LocalVocabEntry` shares ownership of it, so comparisons between entries work regardless of whether the originating index is still alive. The `context_` pointer remains and is only used for the lazy computation of the position in the vocabulary, which inherently requires the index to be alive.

Also remove a duplicated assignment in `Vocabulary::setLocale`.

NOTE: This shares ownership of the *comparator* only — a small locale-configuration object of a few KB — and NOT of the index. Old indexes are therefore not kept alive by surviving `LocalVocabEntry`s: when an index is destroyed (e.g. replaced via #2832), its vocabulary data, mmaps, and file handles are freed exactly as before; only the comparator outlives it. This makes comparisons between entries self-sufficient, which also covers paths that a re-anchoring of the entries at the index swap cannot cover (e.g. results computed against the old index that are still held in the query cache or by a caller).
