### PR TITLE
Avoid structured bindings in coroutines to work around a GCC 15 leak

### DIFF
--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -635,10 +635,18 @@ CPP_template_def(typename RequestT, typename ResponseT)(
     auto queryStatus = messageSender.sharedStatus();
     // Outside the `try`: `qecPtr` owns the id whose destructor writes the
     // `end` event, so the status must be set before it unwinds.
-    auto [qecPtr, cancellationHandle, cancelTimeoutOnDestruction] =
-        prepareOperation(indexAndViews, operationName, operationString,
-                         std::move(messageSender), parameters,
-                         timeLimit.value(), accessTokenOk, clientIp);
+    // NOTE: This is deliberately NOT a structured binding: with GCC 15, the
+    // compiler-generated object behind a structured binding in this coroutine
+    // is never destroyed, which leaks the `QueryExecutionContext` (and with it
+    // the `OwningQueryId`, whose destructor writes the `end` event to the
+    // query event log) on every request.
+    auto preparedOperation = prepareOperation(
+        indexAndViews, operationName, operationString, std::move(messageSender),
+        parameters, timeLimit.value(), accessTokenOk, clientIp);
+    auto& qecPtr = std::get<0>(preparedOperation);
+    auto& cancellationHandle = std::get<1>(preparedOperation);
+    [[maybe_unused]] auto& cancelTimeoutOnDestruction =
+        std::get<2>(preparedOperation);
     auto& qec = *qecPtr;
     try {
       if (!ql::ranges::all_of(operations, expectedOperation)) {

--- a/src/index/IndexRebuilder.cpp
+++ b/src/index/IndexRebuilder.cpp
@@ -377,11 +377,15 @@ boost::asio::awaitable<void> createPermutationWriterTask(
           permutation, isInternal);
     };
   };
-  auto [resultA, resultB] =
-      co_await (asCoroutine(makeTaskForPermutation(permutationA)) &&
-                asCoroutine(makeTaskForPermutation(permutationB)));
-  auto& [_, metaA] = resultA;
-  auto& [__, metaB] = resultB;
+  // NOTE: `results` is deliberately a named tuple, not a structured binding.
+  // See `Server::process`: with GCC 15 the hidden object behind a structured
+  // binding in a coroutine is never destroyed, which would leak the
+  // permutation results. The `auto&` bindings below are references (no such
+  // hidden object) and are fine.
+  auto results = co_await (asCoroutine(makeTaskForPermutation(permutationA)) &&
+                           asCoroutine(makeTaskForPermutation(permutationB)));
+  auto& [_, metaA] = std::get<0>(results);
+  auto& [__, metaB] = std::get<1>(results);
   metaA.exchangeMultiplicities(metaB);
 
   auto makeFinalizerTasks = [&newIndex, isInternal](

--- a/src/util/http/websocket/UpdateFetcher.cpp
+++ b/src/util/http/websocket/UpdateFetcher.cpp
@@ -12,9 +12,12 @@ net::awaitable<UpdateFetcher::PayloadType> UpdateFetcher::waitForEvent() {
   AD_CORRECTNESS_CHECK(distributor_);
   AD_EXPENSIVE_CHECK(strand().running_in_this_thread());
 
-  auto [data, latest] =
+  // NOTE: Deliberately not a structured binding. See `Server::process`: with
+  // GCC 15 the hidden object behind a structured binding in a coroutine is
+  // never destroyed, which would leak the payload on every update.
+  auto dataAndLatest =
       co_await distributor_->waitForNextDataPiece(currentIndex_);
-  currentIndex_ = latest;
-  co_return data;
+  currentIndex_ = dataAndLatest.second;
+  co_return dataAndLatest.first;
 }
 }  // namespace ad_utility::websocket


### PR DESCRIPTION
With GCC 15, the hidden object that a structured binding (`auto [a, b] = f();`) materializes is never destroyed when the binding sits directly in a coroutine body, so whatever it owns leaks on every invocation. QLever has three such coroutines. All three now use a named tuple and access its elements (via `std::get`) instead of a structured binding. Reference bindings (`auto& [...]`) have no such hidden object and are left as is.