### PR TITLE
Add the `ql::filesystem` backport and use it instead of `std::filesystem`

### DIFF
--- a/.github/workflows/install-dependencies-ubuntu/action.yml
+++ b/.github/workflows/install-dependencies-ubuntu/action.yml
@@ -67,7 +67,7 @@ runs:
 
     - name: Install boost from PPA
       if: inputs.install-third-party-libraries == 'true'
-      run: sudo add-apt-repository -y ppa:mhier/libboost-latest && sudo apt update && sudo apt install -y libboost1.83-all-dev libboost-url1.83-dev libboost-container1.83-dev
+      run: sudo add-apt-repository -y ppa:mhier/libboost-latest && sudo apt update && sudo apt install -y libboost1.83-all-dev libboost-url1.83-dev libboost-container1.83-dev libboost-filesystem1.83-dev
       shell: bash
 
     - name: Install Python packages for E2E tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,8 +134,14 @@ option(USE_CPP_17_BACKPORTS "Use the C++17 backports (range-v3 and enable_if_t i
 if (${USE_CPP_17_BACKPORTS} OR ${RANGE_V3_REQUIRED_BY_COMPILER} OR (CMAKE_CXX_STANDARD LESS 20))
     MESSAGE(STATUS "Using the C++17 backports (e.g. range-v3)")
     add_compile_definitions(QLEVER_CPP_17 CPP_CXX_CONCEPTS=0)
+    # In the C++17 backports mode, `ql::filesystem` (see `backports/filesystem.h`)
+    # aliases `boost::filesystem` instead of `std::filesystem`, so we then need
+    # `Boost::filesystem` as a dependency. Without the backports we use
+    # `std::filesystem` and must not depend on `boost::filesystem` at all.
+    set(QLEVER_CPP_17_BACKPORTS_ENABLED ON)
 else ()
     add_compile_definitions(RANGE_V3_COMBINE_WITH_STD)
+    set(QLEVER_CPP_17_BACKPORTS_ENABLED OFF)
 endif ()
 
 ###############################################################################
@@ -278,12 +284,21 @@ endif ()
 ######################################
 # BOOST
 ######################################
+# `Boost::filesystem` is only needed in the C++17 backports mode, where
+# `ql::filesystem` aliases `boost::filesystem` (see `backports/filesystem.h`).
+# Without the backports we use `std::filesystem` and must not depend on
+# `boost::filesystem`, so only request the component when the backports are on.
+if (QLEVER_CPP_17_BACKPORTS_ENABLED)
+  set(QLEVER_BOOST_FILESYSTEM_COMPONENT filesystem)
+else()
+  set(QLEVER_BOOST_FILESYSTEM_COMPONENT "")
+endif()
 if (REDUCED_FEATURE_SET_FOR_CPP17)
   # The reduced feature set (which also implies compatibility with older Boost versions) doesn't use `Boost::url`
   # which is only available in Boost versions >= 1.81
-  find_package(Boost 1.71 COMPONENTS iostreams program_options container filesystem REQUIRED CONFIG)
+  find_package(Boost 1.71 COMPONENTS iostreams program_options container ${QLEVER_BOOST_FILESYSTEM_COMPONENT} REQUIRED CONFIG)
 else()
-  find_package(Boost 1.81 COMPONENTS iostreams program_options url container filesystem REQUIRED CONFIG)
+  find_package(Boost 1.81 COMPONENTS iostreams program_options url container ${QLEVER_BOOST_FILESYSTEM_COMPONENT} REQUIRED CONFIG)
 endif()
 include_directories(${Boost_INCLUDE_DIR})
 
@@ -301,9 +316,17 @@ find_package(OpenSSL REQUIRED)
 # is a drop-in replacement for `target_link_libraries` that additionally links
 # against the common libraries.
 function(qlever_target_link_libraries target)
+    # Only link `Boost::filesystem` in the C++17 backports mode (see the `BOOST`
+    # section above); without the backports `ql::filesystem` is `std::filesystem`
+    # and `boost::filesystem` must not be a dependency.
+    if (QLEVER_CPP_17_BACKPORTS_ENABLED)
+        set(QLEVER_BOOST_FILESYSTEM_LIB Boost::filesystem)
+    else()
+        set(QLEVER_BOOST_FILESYSTEM_LIB "")
+    endif()
     target_link_libraries(${target} ${ARGN} absl::compare absl::flat_hash_map
             absl::flat_hash_set absl::strings absl::str_format ICU::uc
-            ICU::i18n OpenSSL::SSL OpenSSL::Crypto GTest::gtest GTest::gmock fsst nlohmann_json::nlohmann_json Boost::container Boost::filesystem uriparser)
+            ICU::i18n OpenSSL::SSL OpenSSL::Crypto GTest::gtest GTest::gmock fsst nlohmann_json::nlohmann_json Boost::container ${QLEVER_BOOST_FILESYSTEM_LIB} uriparser)
 
     # memorySize is a utility library for defining memory sizes.
     if (NOT ${target} STREQUAL "memorySize")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -281,9 +281,9 @@ endif ()
 if (REDUCED_FEATURE_SET_FOR_CPP17)
   # The reduced feature set (which also implies compatibility with older Boost versions) doesn't use `Boost::url`
   # which is only available in Boost versions >= 1.81
-  find_package(Boost 1.71 COMPONENTS iostreams program_options container REQUIRED CONFIG)
+  find_package(Boost 1.71 COMPONENTS iostreams program_options container filesystem REQUIRED CONFIG)
 else()
-  find_package(Boost 1.81 COMPONENTS iostreams program_options url container REQUIRED CONFIG)
+  find_package(Boost 1.81 COMPONENTS iostreams program_options url container filesystem REQUIRED CONFIG)
 endif()
 include_directories(${Boost_INCLUDE_DIR})
 
@@ -303,7 +303,7 @@ find_package(OpenSSL REQUIRED)
 function(qlever_target_link_libraries target)
     target_link_libraries(${target} ${ARGN} absl::compare absl::flat_hash_map
             absl::flat_hash_set absl::strings absl::str_format ICU::uc
-            ICU::i18n OpenSSL::SSL OpenSSL::Crypto GTest::gtest GTest::gmock fsst nlohmann_json::nlohmann_json Boost::container uriparser)
+            ICU::i18n OpenSSL::SSL OpenSSL::Crypto GTest::gtest GTest::gmock fsst nlohmann_json::nlohmann_json Boost::container Boost::filesystem uriparser)
 
     # memorySize is a utility library for defining memory sizes.
     if (NOT ${target} STREQUAL "memorySize")

--- a/benchmark/infrastructure/BenchmarkMain.cpp
+++ b/benchmark/infrastructure/BenchmarkMain.cpp
@@ -7,7 +7,6 @@
 #include <boost/program_options.hpp>
 #include <boost/program_options/value_semantic.hpp>
 #include <cstdlib>
-#include <filesystem>
 #include <fstream>
 #include <iomanip>
 #include <ios>
@@ -21,6 +20,7 @@
 #include "../benchmark/infrastructure/BenchmarkToString.h"
 #include "BenchmarkMetadata.h"
 #include "backports/StartsWithAndEndsWith.h"
+#include "backports/filesystem.h"
 #include "util/Algorithm.h"
 #include "util/ConfigManager/ConfigManager.h"
 #include "util/Exception.h"
@@ -47,8 +47,7 @@ be treated as `false`.
 static void writeBenchmarkClassAndBenchmarkResultsToJsonFile(
     const std::vector<std::pair<const BenchmarkInterface*, BenchmarkResults>>&
         benchmarkClassAndResults,
-    const std::filesystem::path& jsonFileName,
-    bool appendToJsonInFile = false) {
+    const ql::filesystem::path& jsonFileName, bool appendToJsonInFile = false) {
   AD_CORRECTNESS_CHECK(jsonFileName.extension() == ".json");
   // Convert to json.
   nlohmann::ordered_json benchmarkClassAndBenchmarkResultsAsJson(
@@ -59,8 +58,8 @@ static void writeBenchmarkClassAndBenchmarkResultsToJsonFile(
   Add the old json array entries to the new json array entries, if a non empty
   file exists. Otherwise, we create/fill the file.
   */
-  if (appendToJsonInFile && std::filesystem::exists(jsonFileName) &&
-      !std::filesystem::is_empty(jsonFileName)) {
+  if (appendToJsonInFile && ql::filesystem::exists(jsonFileName) &&
+      !ql::filesystem::is_empty(jsonFileName)) {
     /*
     By parsing the file as json and working with `nlohmann::ordered_json`,
     instead of the json string representation, we first make sure, that the file

--- a/src/ServerMain.cpp
+++ b/src/ServerMain.cpp
@@ -12,7 +12,6 @@
 #include <vector>
 
 #include "CompilationInfo.h"
-#include "backports/filesystem.h"
 #include "engine/Server.h"
 #include "global/Constants.h"
 #include "global/RuntimeParameters.h"

--- a/src/ServerMain.cpp
+++ b/src/ServerMain.cpp
@@ -7,12 +7,12 @@
 
 #include <boost/program_options.hpp>
 #include <cstdlib>
-#include <filesystem>
 #include <iostream>
 #include <string>
 #include <vector>
 
 #include "CompilationInfo.h"
+#include "backports/filesystem.h"
 #include "engine/Server.h"
 #include "global/Constants.h"
 #include "global/RuntimeParameters.h"

--- a/src/backports/filesystem.h
+++ b/src/backports/filesystem.h
@@ -1,7 +1,7 @@
 // Copyright 2026 The QLever Authors, in particular:
 //
 // 2026 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
-
+//
 // UFR = University of Freiburg, Chair of Algorithms and Data Structures
 
 // You may not use this file except in compliance with the Apache 2.0 License,

--- a/src/backports/filesystem.h
+++ b/src/backports/filesystem.h
@@ -14,9 +14,9 @@
 // `std::filesystem`. By default (in C++20 mode) it is a simple alias for
 // `std::filesystem`. If `QLEVER_CPP_17` is defined (the C++17 backports mode
 // that also uses `range-v3`), it aliases `boost::filesystem` instead, because
-// the compilers targeted in that mode (e.g. GCC 8) don't provide a usable
-// `std::filesystem`. Note that the backported version requires linking against
-// `Boost::filesystem`.
+// some toolchains targeted in that mode (e.g. QCC 8 used in QNX) don't provide
+// a usable `std::filesystem`. Note that the backported version requires linking
+// against `Boost::filesystem`.
 //
 // The APIs of `std::filesystem` and `boost::filesystem` are almost identical
 // for the subset of functionality used by QLever. The one notable difference is

--- a/src/backports/filesystem.h
+++ b/src/backports/filesystem.h
@@ -31,6 +31,8 @@
 #include <filesystem>
 #endif
 
+#include <utility>
+
 namespace ql {
 #ifdef QLEVER_CPP_17
 namespace filesystem = ::boost::filesystem;
@@ -46,6 +48,36 @@ static constexpr auto filesystem_perms_none =
 #else
 static constexpr auto filesystem_perms_none = ::std::filesystem::perms::none;
 #endif
+
+// A range over the entries of a directory. Prefer this over using a
+// `ql::filesystem::directory_iterator` directly as a range (for example in a
+// `ql::ranges` algorithm). In the C++17 backports mode `directory_iterator` is
+// `boost::filesystem::directory_iterator`, whose non-member `begin`/`end` take
+// the iterator by `const&` and therefore lose in overload resolution against
+// `range-v3`'s deleted poison-pill `begin`/`end` overloads. As a result the
+// iterator is not recognized as a range by `range-v3`. This wrapper instead
+// exposes member `begin()`/`end()`, which sidesteps the problem and works with
+// both `std::filesystem` and `boost::filesystem`.
+class DirectoryRange {
+ private:
+  filesystem::path directory_;
+
+ public:
+  explicit DirectoryRange(filesystem::path directory)
+      : directory_{std::move(directory)} {}
+
+  filesystem::directory_iterator begin() const {
+    return filesystem::directory_iterator{directory_};
+  }
+  filesystem::directory_iterator end() const {
+    return filesystem::directory_iterator{};
+  }
+};
+
+// Return a `DirectoryRange` over the entries of `directory`.
+inline DirectoryRange directoryRange(filesystem::path directory) {
+  return DirectoryRange{std::move(directory)};
+}
 }  // namespace ql
 
 #endif  // QLEVER_SRC_BACKPORTS_FILESYSTEM_H

--- a/src/backports/filesystem.h
+++ b/src/backports/filesystem.h
@@ -27,8 +27,10 @@
 
 #ifdef QLEVER_CPP_17
 #include <boost/filesystem.hpp>
+#include <boost/system/error_code.hpp>
 #else
 #include <filesystem>
+#include <system_error>
 #endif
 
 #include <utility>
@@ -38,6 +40,16 @@ namespace ql {
 namespace filesystem = ::boost::filesystem;
 #else
 namespace filesystem = ::std::filesystem;
+#endif
+
+// A drop-in replacement for `std::error_code`. The `error_code`-taking
+// overloads of `boost::filesystem` expect a `boost::system::error_code`, not a
+// `std::error_code`, so in the C++17 backports mode we alias the former. Both
+// types provide the `operator bool` and `message()` members that QLever uses.
+#ifdef QLEVER_CPP_17
+using error_code = ::boost::system::error_code;
+#else
+using error_code = ::std::error_code;
 #endif
 
 // The `perms` value that represents "no permissions", spelled `perms::none` in

--- a/src/backports/filesystem.h
+++ b/src/backports/filesystem.h
@@ -1,0 +1,51 @@
+// Copyright 2026 The QLever Authors, in particular:
+//
+// 2026 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#ifndef QLEVER_SRC_BACKPORTS_FILESYSTEM_H
+#define QLEVER_SRC_BACKPORTS_FILESYSTEM_H
+
+// This file defines the `ql::filesystem` namespace as a drop-in replacement for
+// `std::filesystem`. By default (in C++20 mode) it is a simple alias for
+// `std::filesystem`. If `QLEVER_CPP_17` is defined (the C++17 backports mode
+// that also uses `range-v3`), it aliases `boost::filesystem` instead, because
+// the compilers targeted in that mode (e.g. GCC 8) don't provide a usable
+// `std::filesystem`. Note that the backported version requires linking against
+// `Boost::filesystem`.
+//
+// The APIs of `std::filesystem` and `boost::filesystem` are almost identical
+// for the subset of functionality used by QLever. The one notable difference is
+// the `perms` enum, where `std::filesystem` uses the scoped enumerator
+// `perms::none` while `boost::filesystem` uses the (unscoped)
+// `perms::no_perms`. Use `ql::filesystem_perms_none` (defined below) instead of
+// either.
+
+#ifdef QLEVER_CPP_17
+#include <boost/filesystem.hpp>
+#else
+#include <filesystem>
+#endif
+
+namespace ql {
+#ifdef QLEVER_CPP_17
+namespace filesystem = ::boost::filesystem;
+#else
+namespace filesystem = ::std::filesystem;
+#endif
+
+// The `perms` value that represents "no permissions", spelled `perms::none` in
+// `std::filesystem` and `perms::no_perms` in `boost::filesystem`.
+#ifdef QLEVER_CPP_17
+static constexpr auto filesystem_perms_none =
+    ::boost::filesystem::perms::no_perms;
+#else
+static constexpr auto filesystem_perms_none = ::std::filesystem::perms::none;
+#endif
+}  // namespace ql
+
+#endif  // QLEVER_SRC_BACKPORTS_FILESYSTEM_H

--- a/src/backports/filesystem.h
+++ b/src/backports/filesystem.h
@@ -90,6 +90,21 @@ class DirectoryRange {
 inline DirectoryRange directoryRange(filesystem::path directory) {
   return DirectoryRange{std::move(directory)};
 }
+
+// Return the filename component of `path`, with `std::filesystem` semantics
+// even in the C++17 backports mode. A path with a trailing directory separator
+// has no filename component: `std::filesystem::path::filename()` returns an
+// empty path for such a path, whereas `boost::filesystem::path::filename()`
+// returns ".". Normalize to the `std::filesystem` behavior so that callers
+// behave identically for both backends.
+inline filesystem::path pathFilename(const filesystem::path& path) {
+  const auto& native = path.native();
+  if (!native.empty() &&
+      native.back() == filesystem::path::preferred_separator) {
+    return {};
+  }
+  return path.filename();
+}
 }  // namespace ql
 
 #endif  // QLEVER_SRC_BACKPORTS_FILESYSTEM_H

--- a/src/engine/MaterializedViews.cpp
+++ b/src/engine/MaterializedViews.cpp
@@ -11,11 +11,11 @@
 
 #include <absl/strings/str_cat.h>
 
-#include <filesystem>
 #include <memory>
 #include <nlohmann/json.hpp>
 #include <stdexcept>
 
+#include "backports/filesystem.h"
 #include "engine/IndexScan.h"
 #include "engine/Join.h"
 #include "engine/MaterializedViewsQueryAnalysis.h"
@@ -352,7 +352,7 @@ MaterializedView::MaterializedView(std::string onDiskBase, std::string name)
   auto filename = getFilenameBase(onDiskBase_, name_);
 
   auto metadataFilename = absl::StrCat(filename, ".viewinfo.json");
-  if (!std::filesystem::exists(metadataFilename)) {
+  if (!ql::filesystem::exists(metadataFilename)) {
     throw std::runtime_error(
         absl::StrCat("The materialized view '", name_, "' does not exist."));
   }

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -18,6 +18,7 @@
 #include <vector>
 
 #include "CompilationInfo.h"
+#include "backports/filesystem.h"
 #include "engine/ExecuteUpdate.h"
 #include "engine/ExportQueryExecutionTrees.h"
 #include "engine/GraphStoreProtocol.h"
@@ -72,7 +73,7 @@ Server::Server(unsigned short port, size_t numThreads, std::string accessToken,
 }
 
 // _____________________________________________________________________________
-void Server::configureQueryEventLog(const std::filesystem::path& path) {
+void Server::configureQueryEventLog(const ql::filesystem::path& path) {
   // One log, owned by a `shared_ptr` copied into both callbacks, so its
   // lifetime follows the callbacks (and thus the registry).
   auto log = std::make_shared<ad_utility::QueryEventLog>();

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -10,11 +10,11 @@
 #ifndef QLEVER_SRC_ENGINE_SERVER_H
 #define QLEVER_SRC_ENGINE_SERVER_H
 
-#include <filesystem>
 #include <optional>
 #include <string>
 #include <vector>
 
+#include "backports/filesystem.h"
 #include "engine/ExecuteUpdate.h"
 #include "engine/MaterializedViews.h"
 #include "engine/NamedResultCache.h"
@@ -70,7 +70,7 @@ class Server {
 
   // Open `path` and register start/end callbacks on the query registry that
   // write one JSONL line per query event to it. Call once, after construction.
-  void configureQueryEventLog(const std::filesystem::path& path);
+  void configureQueryEventLog(const ql::filesystem::path& path);
 
   // Get server statistics.
   static json composeStatsJson(const Index& index);

--- a/src/engine/SpatialJoinAlgorithms.cpp
+++ b/src/engine/SpatialJoinAlgorithms.cpp
@@ -23,9 +23,9 @@
 #include <util/geo/Geo.h>
 
 #include <cmath>
-#include <filesystem>
 #include <set>
 
+#include "backports/filesystem.h"
 #include "backports/three_way_comparison.h"
 #include "engine/ExportQueryExecutionTrees.h"
 #include "engine/NamedResultCache.h"
@@ -512,7 +512,7 @@ Result SpatialJoinAlgorithms::LibspatialjoinAlgorithm() {
   };
   sweeperCfg.sweepCancellationCb = [this]() { throwIfCancelled(); };
 
-  auto basePath = std::filesystem::path(qec_->getIndex().getOnDiskBase());
+  auto basePath = ql::filesystem::path(qec_->getIndex().getOnDiskBase());
 
   std::string sweeperTmpPath = basePath.parent_path().string();
 

--- a/src/engine/SpatialJoinAlgorithms.cpp
+++ b/src/engine/SpatialJoinAlgorithms.cpp
@@ -521,7 +521,7 @@ Result SpatialJoinAlgorithms::LibspatialjoinAlgorithm() {
     sweeperTmpPath = ".";
   }
 
-  std::string baseName = basePath.filename().string();
+  std::string baseName = ql::pathFilename(basePath).string();
 
   // The prefix added before each spatialjoin file.
   //

--- a/src/index/DeltaTriples.cpp
+++ b/src/index/DeltaTriples.cpp
@@ -16,6 +16,7 @@
 
 #include "Permutation.h"
 #include "backports/algorithm.h"
+#include "backports/filesystem.h"
 #include "engine/ExecuteUpdate.h"
 #include "engine/ExportQueryExecutionTrees.h"
 #include "index/ExportIds.h"
@@ -657,13 +658,13 @@ void DeltaTriples::writeToDisk() const {
                }) |
            ql::views::join;
   };
-  std::filesystem::path tempPath = filenameForPersisting_.value();
+  ql::filesystem::path tempPath = filenameForPersisting_.value();
   tempPath += ".tmp";
   ad_utility::serializeIds(
       tempPath, localVocab_,
       std::array{toRange(triplesSetsNormal_.triplesDeleted_),
                  toRange(triplesSetsNormal_.triplesInserted_)});
-  std::filesystem::rename(tempPath, filenameForPersisting_.value());
+  ql::filesystem::rename(tempPath, filenameForPersisting_.value());
 }
 
 // _____________________________________________________________________________

--- a/src/index/GraphNameManager.cpp
+++ b/src/index/GraphNameManager.cpp
@@ -9,8 +9,7 @@
 
 #include "index/GraphNameManager.h"
 
-#include <filesystem>
-
+#include "backports/filesystem.h"
 #include "util/Serializer/FileSerializer.h"
 
 // _____________________________________________________________________________
@@ -35,7 +34,7 @@ void GraphNameManager::writeToDisk() const {
   tempPath += ".tmp";
   ad_utility::serialization::FileWriteSerializer serializer{tempPath.c_str()};
   serializer | *this;
-  std::filesystem::rename(tempPath, path);
+  ql::filesystem::rename(tempPath, path);
 }
 
 // _____________________________________________________________________________
@@ -43,7 +42,7 @@ void GraphNameManager::readFromDisk() {
   if (!filenameForPersisting_.has_value()) {
     return;
   }
-  if (!std::filesystem::exists(filenameForPersisting_.value())) {
+  if (!ql::filesystem::exists(filenameForPersisting_.value())) {
     return;
   }
 
@@ -54,7 +53,7 @@ void GraphNameManager::readFromDisk() {
 
 // _____________________________________________________________________________
 void GraphNameManager::setFilenameForPersistingAndReadFromDisk(
-    std::filesystem::path filename) {
+    ql::filesystem::path filename) {
   filenameForPersisting_ = std::move(filename);
   readFromDisk();
 }

--- a/src/index/GraphNameManager.h
+++ b/src/index/GraphNameManager.h
@@ -10,6 +10,7 @@
 #ifndef QLEVER_SRC_INDEX_GRAPHNAMEMANAGER_H
 #define QLEVER_SRC_INDEX_GRAPHNAMEMANAGER_H
 
+#include "backports/filesystem.h"
 #include "global/Constants.h"
 #include "gtest/gtest_prod.h"
 #include "rdfTypes/Iri.h"
@@ -31,7 +32,7 @@ class GraphNameManager {
   ad_utility::CopyableAtomic<uint64_t> nextUnallocatedGraph_ = 1;
 
   // File where the state is persisted to.
-  std::optional<std::filesystem::path> filenameForPersisting_;
+  std::optional<ql::filesystem::path> filenameForPersisting_;
 
   FRIEND_TEST(GraphNameManager, storeAndRestoreData);
   FRIEND_TEST(GraphNameManager, readFromDisk);
@@ -64,7 +65,7 @@ class GraphNameManager {
   // Read the state from disk to restore it after a restart.
   void readFromDisk();
   // Set the file where the state is persisted to and try to read the state.
-  void setFilenameForPersistingAndReadFromDisk(std::filesystem::path filename);
+  void setFilenameForPersistingAndReadFromDisk(ql::filesystem::path filename);
 
   AD_SERIALIZE_FRIEND_FUNCTION(GraphNameManager) {
     serializer | arg.prefixWithoutBraces_;

--- a/src/index/TextIndexBuilder.cpp
+++ b/src/index/TextIndexBuilder.cpp
@@ -9,8 +9,8 @@
 #include <absl/cleanup/cleanup.h>
 
 #include <charconv>
-#include <filesystem>
 
+#include "backports/filesystem.h"
 #include "index/Postings.h"
 #include "index/TextIndexReadWrite.h"
 
@@ -505,7 +505,7 @@ void TextIndexBuilder::buildDocsDB(const std::string& docsFileName) const {
   // To avoid excessive use of RAM, we stream the offsets into a temporary file
   // and append them to the end of the docsDB file once all text records have
   // been written.
-  std::filesystem::path offsetsFilename = onDiskBase_ + ".text.docsDB.tmp";
+  ql::filesystem::path offsetsFilename = onDiskBase_ + ".text.docsDB.tmp";
   absl::Cleanup deleteOffsetsFile{[&offsetsFilename]() {
     ad_utility::deleteFile(offsetsFilename, /*warnOnFailure=*/false);
   }};

--- a/src/util/File.h
+++ b/src/util/File.h
@@ -14,12 +14,12 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <string>
 #include <utility>
 
+#include "backports/filesystem.h"
 #include "util/Exception.h"
 #include "util/Forward.h"
 #include "util/Log.h"
@@ -208,9 +208,9 @@ class File {
  * @brief Delete the file at a given path
  * @param path
  */
-inline void deleteFile(const std::filesystem::path& path,
+inline void deleteFile(const ql::filesystem::path& path,
                        bool warnOnFailure = true) {
-  if (!std::filesystem::remove(path)) {
+  if (!ql::filesystem::remove(path)) {
     if (warnOnFailure) {
       AD_LOG_WARN << "Deletion of file '" << path << "' was not successful"
                   << std::endl;
@@ -220,7 +220,7 @@ inline void deleteFile(const std::filesystem::path& path,
 
 namespace detail {
 template <typename Stream, bool forWriting>
-Stream makeFilestream(const std::filesystem::path& path, auto&&... args) {
+Stream makeFilestream(const ql::filesystem::path& path, auto&&... args) {
   Stream stream{path.string(), AD_FWD(args)...};
   std::string_view mode = forWriting ? "for writing" : "for reading";
   if (!stream.is_open()) {
@@ -228,7 +228,7 @@ Stream makeFilestream(const std::filesystem::path& path, auto&&... args) {
         absl::StrCat("Could not open file \"", path.string(), "\" ", mode,
                      ". Possible causes: The file does not exist or the "
                      "permissions are insufficient. The absolute path is \"",
-                     std::filesystem::absolute(path).string(), "\".");
+                     ql::filesystem::absolute(path).string(), "\".");
     throw std::runtime_error{error};
   }
   return stream;
@@ -238,12 +238,12 @@ Stream makeFilestream(const std::filesystem::path& path, auto&&... args) {
 // Open and return a std::ifstream from a given filename and optional
 // additional `args`. Throw an exception stating the filename and the absolute
 // path when the file can't be opened.
-std::ifstream makeIfstream(const std::filesystem::path& path, auto&&... args) {
+std::ifstream makeIfstream(const ql::filesystem::path& path, auto&&... args) {
   return detail::makeFilestream<std::ifstream, false>(path, AD_FWD(args)...);
 }
 
 // Similar to `makeIfstream`, but returns `std::ofstream`
-std::ofstream makeOfstream(const std::filesystem::path& path, auto&&... args) {
+std::ofstream makeOfstream(const ql::filesystem::path& path, auto&&... args) {
   return detail::makeFilestream<std::ofstream, true>(path, AD_FWD(args)...);
 }
 

--- a/src/util/FilesystemHelpers.cpp
+++ b/src/util/FilesystemHelpers.cpp
@@ -32,7 +32,7 @@ bool doesDirectoryContainFileWithBasename(const std::string& baseName) {
 
   std::string prefix = base.filename().string();
   return ql::ranges::any_of(
-      fs::directory_iterator(dir), [&prefix](const auto& entry) {
+      ql::directoryRange(dir), [&prefix](const auto& entry) {
         std::string name = entry.path().filename().string();
         return ql::starts_with(name, prefix);
       });

--- a/src/util/FilesystemHelpers.cpp
+++ b/src/util/FilesystemHelpers.cpp
@@ -46,7 +46,7 @@ bool doesDirectoryContainFileWithBasename(const std::string& baseName) {
 // _____________________________________________________________________________
 size_t deleteFilesInDirectory(
     const fs::path& directory,
-    const std::function<bool(const fs::path&)>& shouldDelete) {
+    absl::FunctionRef<bool(const fs::path&)> shouldDelete) {
   if (!fs::exists(directory) || !fs::is_directory(directory)) {
     return 0;
   }

--- a/src/util/FilesystemHelpers.cpp
+++ b/src/util/FilesystemHelpers.cpp
@@ -9,14 +9,14 @@
 
 #include "util/FilesystemHelpers.h"
 
-#include <filesystem>
 #include <string>
 
 #include "backports/StartsWithAndEndsWith.h"
 #include "backports/algorithm.h"
+#include "backports/filesystem.h"
 
 namespace qlever::util {
-namespace fs = std::filesystem;
+namespace fs = ql::filesystem;
 
 // _____________________________________________________________________________
 bool doesDirectoryContainFileWithBasename(const std::string& baseName) {

--- a/src/util/FilesystemHelpers.cpp
+++ b/src/util/FilesystemHelpers.cpp
@@ -10,10 +10,12 @@
 #include "util/FilesystemHelpers.h"
 
 #include <string>
+#include <vector>
 
 #include "backports/StartsWithAndEndsWith.h"
 #include "backports/algorithm.h"
 #include "backports/filesystem.h"
+#include "util/File.h"
 
 namespace qlever::util {
 namespace fs = ql::filesystem;
@@ -39,6 +41,29 @@ bool doesDirectoryContainFileWithBasename(const std::string& baseName) {
         std::string name = entry.path().filename().string();
         return ql::starts_with(name, prefix);
       });
+}
+
+// _____________________________________________________________________________
+size_t deleteFilesInDirectory(
+    const fs::path& directory,
+    const std::function<bool(const fs::path&)>& shouldDelete) {
+  if (!fs::exists(directory) || !fs::is_directory(directory)) {
+    return 0;
+  }
+  // Collect the matching regular files first and delete them only afterwards.
+  // Deleting entries while iterating a directory is unspecified behavior and
+  // can cause entries to be skipped on some platforms (observed on macOS),
+  // leaving leftover files behind.
+  std::vector<fs::path> toDelete;
+  for (const auto& entry : ql::directoryRange(directory)) {
+    if (entry.is_regular_file() && shouldDelete(entry.path())) {
+      toDelete.push_back(entry.path());
+    }
+  }
+  for (const auto& path : toDelete) {
+    ad_utility::deleteFile(path);
+  }
+  return toDelete.size();
 }
 
 // _____________________________________________________________________________

--- a/src/util/FilesystemHelpers.cpp
+++ b/src/util/FilesystemHelpers.cpp
@@ -30,7 +30,10 @@ bool doesDirectoryContainFileWithBasename(const std::string& baseName) {
     return true;
   }
 
-  std::string prefix = base.filename().string();
+  // Use `ql::pathFilename` (not `base.filename()`) so that a trailing separator
+  // yields an empty prefix (matching any file in `dir`) for both `std` and
+  // `boost` filesystem; see the comment on `ql::pathFilename`.
+  std::string prefix = ql::pathFilename(base).string();
   return ql::ranges::any_of(
       ql::directoryRange(dir), [&prefix](const auto& entry) {
         std::string name = entry.path().filename().string();

--- a/src/util/FilesystemHelpers.h
+++ b/src/util/FilesystemHelpers.h
@@ -10,8 +10,9 @@
 #ifndef QLEVER_SRC_UTIL_FILESYSTEMHELPERS_H
 #define QLEVER_SRC_UTIL_FILESYSTEMHELPERS_H
 
+#include <absl/functional/function_ref.h>
+
 #include <cstddef>
-#include <functional>
 #include <string>
 
 #include "backports/filesystem.h"
@@ -33,7 +34,7 @@ bool doesDirectoryContainFileWithBasename(const std::string& path);
 // is returned.
 size_t deleteFilesInDirectory(
     const ql::filesystem::path& directory,
-    const std::function<bool(const ql::filesystem::path&)>& shouldDelete);
+    absl::FunctionRef<bool(const ql::filesystem::path&)> shouldDelete);
 
 // Return `true` if the directory from `path1` is a subdirectory of the
 // directory from `path2`; otherwise return `false`.

--- a/src/util/FilesystemHelpers.h
+++ b/src/util/FilesystemHelpers.h
@@ -10,13 +10,30 @@
 #ifndef QLEVER_SRC_UTIL_FILESYSTEMHELPERS_H
 #define QLEVER_SRC_UTIL_FILESYSTEMHELPERS_H
 
+#include <cstddef>
+#include <functional>
 #include <string>
+
+#include "backports/filesystem.h"
 
 namespace qlever::util {
 // Return `true` if the directory from `path` contains at least one file whose
 // name starts with the base name of `path`; otherwise return `false`. If the
 // base name is empty, return `false` if and only if the directory is empty.
 bool doesDirectoryContainFileWithBasename(const std::string& path);
+
+// Delete every regular file directly contained in `directory` for which
+// `shouldDelete(entryPath)` returns `true`, and return the number of files that
+// were deleted. The matching files are collected first and deleted only
+// afterwards, because deleting directory entries while iterating a directory is
+// unspecified behavior that can cause entries to be skipped on some platforms
+// (observed on macOS), leaving leftover files behind. Non-regular entries (e.g.
+// subdirectories) are never passed to `shouldDelete` and never deleted. If
+// `directory` does not exist or is not a directory, nothing is deleted and `0`
+// is returned.
+size_t deleteFilesInDirectory(
+    const ql::filesystem::path& directory,
+    const std::function<bool(const ql::filesystem::path&)>& shouldDelete);
 
 // Return `true` if the directory from `path1` is a subdirectory of the
 // directory from `path2`; otherwise return `false`.

--- a/src/util/QueryEventLog.cpp
+++ b/src/util/QueryEventLog.cpp
@@ -8,6 +8,7 @@
 
 #include "util/QueryEventLog.h"
 
+#include "backports/filesystem.h"
 #include "util/Exception.h"
 
 namespace ad_utility {
@@ -22,7 +23,7 @@ QueryEventLog::~QueryEventLog() {
 }
 
 // _____________________________________________________________________________
-void QueryEventLog::setOutputFile(const std::filesystem::path& path) {
+void QueryEventLog::setOutputFile(const ql::filesystem::path& path) {
   AD_CONTRACT_CHECK(!configured_.exchange(true),
                     "QueryEventLog::setOutputFile may only be called once.");
   // Open stream and construct queue before spawning the writer; it

--- a/src/util/QueryEventLog.cpp
+++ b/src/util/QueryEventLog.cpp
@@ -28,7 +28,7 @@ void QueryEventLog::setOutputFile(const ql::filesystem::path& path) {
                     "QueryEventLog::setOutputFile may only be called once.");
   // Open stream and construct queue before spawning the writer; it
   // captures `this` and starts popping immediately.
-  stream_.open(path, std::ios::app | std::ios::out);
+  stream_.open(path.string(), std::ios::app | std::ios::out);
   AD_CONTRACT_CHECK(stream_.is_open(),
                     "QueryEventLog: failed to open output file.");
   queue_ = std::make_unique<data_structures::ThreadSafeQueue<std::string>>(

--- a/src/util/QueryEventLog.h
+++ b/src/util/QueryEventLog.h
@@ -10,11 +10,11 @@
 #define QLEVER_SRC_UTIL_QUERYEVENTLOG_H
 
 #include <atomic>
-#include <filesystem>
 #include <fstream>
 #include <memory>
 #include <string>
 
+#include "backports/filesystem.h"
 #include "util/ThreadSafeQueue.h"
 #include "util/jthread.h"
 
@@ -38,7 +38,7 @@ class QueryEventLog {
 
   // Open `path` in append mode and spawn the writer thread. Must be
   // called at most once per instance; a second call throws.
-  void setOutputFile(const std::filesystem::path& path);
+  void setOutputFile(const ql::filesystem::path& path);
 
   // Enqueue one already-formatted line; the writer appends the trailing
   // newline. No-op if the sink has not been configured.

--- a/src/util/ResourceMonitor.cpp
+++ b/src/util/ResourceMonitor.cpp
@@ -125,7 +125,7 @@ ResourceMonitor::~ResourceMonitor() {
 }
 
 // _____________________________________________________________________________
-void ResourceMonitor::start(const std::filesystem::path& path, Mode mode,
+void ResourceMonitor::start(const ql::filesystem::path& path, Mode mode,
                             std::chrono::milliseconds interval) {
   AD_CONTRACT_CHECK(!started_.exchange(true),
                     "ResourceMonitor::start may only be called once.");
@@ -134,7 +134,7 @@ void ResourceMonitor::start(const std::filesystem::path& path, Mode mode,
 #if defined(__APPLE__) || defined(__linux__)
   // Monitoring is optional: on an unwritable file, warn and let QLever run
   // on rather than aborting the process.
-  namespace fs = std::filesystem;
+  namespace fs = ql::filesystem;
   // Decide about the header before opening: truncating destroys the
   // old file size. A missing file or failed stat also gets a header.
   std::error_code ec;

--- a/src/util/ResourceMonitor.cpp
+++ b/src/util/ResourceMonitor.cpp
@@ -137,7 +137,7 @@ void ResourceMonitor::start(const ql::filesystem::path& path, Mode mode,
   namespace fs = ql::filesystem;
   // Decide about the header before opening: truncating destroys the
   // old file size. A missing file or failed stat also gets a header.
-  std::error_code ec;
+  ql::error_code ec;
   auto oldSize = fs::file_size(path, ec);
   bool writeHeader = mode == Mode::Truncate || ec || oldSize == 0;
   auto openMode = mode == Mode::Truncate ? std::ios::trunc : std::ios::app;

--- a/src/util/ResourceMonitor.h
+++ b/src/util/ResourceMonitor.h
@@ -15,13 +15,13 @@
 #include <chrono>
 #include <condition_variable>
 #include <cstdint>
-#include <filesystem>
 #include <fstream>
 #include <istream>
 #include <mutex>
 #include <optional>
 #include <string>
 
+#include "backports/filesystem.h"
 #include "util/jthread.h"
 
 namespace ad_utility {
@@ -89,7 +89,7 @@ class ResourceMonitor {
   // non-empty file) and start sampling. An unopenable file only warns
   // and disables monitoring. Throws if called more than once or if
   // `interval` is not positive.
-  void start(const std::filesystem::path& path, Mode mode,
+  void start(const ql::filesystem::path& path, Mode mode,
              std::chrono::milliseconds interval);
 
   // Test-only: swap the OS readers before `start`, e.g. a throwing reader to

--- a/src/util/Serializer/TripleSerializer.h
+++ b/src/util/Serializer/TripleSerializer.h
@@ -7,11 +7,11 @@
 #include <absl/container/flat_hash_map.h>
 
 #include <array>
-#include <filesystem>
 #include <fstream>
 
 #include "backports/algorithm.h"
 #include "backports/concepts.h"
+#include "backports/filesystem.h"
 #include "backports/type_traits.h"
 #include "global/Id.h"
 #include "index/IndexImpl.h"
@@ -170,7 +170,7 @@ std::vector<Id> deserializeIds(Serializer& serializer,
 // Serialize the local vocabulary and the given ranges of Ids to the given path.
 CPP_template(typename Range)(
     requires ql::ranges::range<
-        Range>) void serializeIds(const std::filesystem::path& path,
+        Range>) void serializeIds(const ql::filesystem::path& path,
                                   const LocalVocab& vocab, Range&& idRanges) {
   serialization::FileWriteSerializer serializer{path.c_str()};
   detail::writeHeader(serializer);
@@ -182,12 +182,12 @@ CPP_template(typename Range)(
 }
 
 inline std::tuple<LocalVocab, std::vector<std::vector<Id>>> deserializeIds(
-    const std::filesystem::path& path, const LocalVocabContext& context) {
+    const ql::filesystem::path& path, const LocalVocabContext& context) {
   // This is a minor TOCTOU issue, the file might be gone after this check and
   // before the call to `fopen`, done by `FileReadSerializer`, so ideally we'd
   // handle this as a special exception type of our own `File` class, which
   // doesn't exist yet.
-  if (!std::filesystem::exists(path)) {
+  if (!ql::filesystem::exists(path)) {
     return {};
   }
   auto serializer = [p = path.c_str()]() {

--- a/test/DeltaTriplesTest.cpp
+++ b/test/DeltaTriplesTest.cpp
@@ -747,7 +747,7 @@ TEST_F(DeltaTriplesTest, storeAndRestoreFromEmptySet) {
   // Make sure no artifacts from previous crashed runs exists.
   ql::filesystem::remove(tmpFile);
   absl::Cleanup cleanup{[&tmpFile]() { ql::filesystem::remove(tmpFile); }};
-  deltaTriples.setPersists(tmpFile);
+  deltaTriples.setPersists(tmpFile.string());
   // Write "empty" file
   EXPECT_NO_THROW(deltaTriples.writeToDisk());
 
@@ -819,7 +819,7 @@ TEST_F(DeltaTriplesTest, storeAndRestoreFromEmptySet) {
 
   std::array<char, expectedContent.size()> actualContent{};
 
-  std::ifstream tmpFileStream{tmpFile, std::ios::binary};
+  std::ifstream tmpFileStream{tmpFile.string(), std::ios::binary};
   tmpFileStream.read(actualContent.data(), actualContent.size());
   EXPECT_TRUE(tmpFileStream.good());
   EXPECT_EQ(tmpFileStream.peek(), std::char_traits<char>::eof());
@@ -848,7 +848,7 @@ TEST_F(DeltaTriplesTest, storeAndRestoreData) {
   const auto& localVocabContext = testQec->getLocalVocabContext();
   {
     DeltaTriples deltaTriples{testQec->getIndex()};
-    deltaTriples.setPersists(tmpFile);
+    deltaTriples.setPersists(tmpFile.string());
     deltaTriples.readFromDisk();
 
     auto cancellationHandle =
@@ -870,7 +870,7 @@ TEST_F(DeltaTriplesTest, storeAndRestoreData) {
   }
   {
     DeltaTriples deltaTriples{testQec->getIndex()};
-    deltaTriples.setPersists(tmpFile);
+    deltaTriples.setPersists(tmpFile.string());
     deltaTriples.readFromDisk();
 
     EXPECT_EQ(deltaTriples.numDeleted(), 1);

--- a/test/DeltaTriplesTest.cpp
+++ b/test/DeltaTriplesTest.cpp
@@ -17,6 +17,7 @@
 #include "./util/GTestHelpers.h"
 #include "./util/IndexTestHelpers.h"
 #include "./util/RuntimeParametersTestHelpers.h"
+#include "backports/filesystem.h"
 #include "engine/ExportQueryExecutionTrees.h"
 #include "index/DeltaTriples.h"
 #include "index/IndexImpl.h"
@@ -742,10 +743,10 @@ TEST_F(DeltaTriplesTest, restoreFromNonExistingFile) {
 TEST_F(DeltaTriplesTest, storeAndRestoreFromEmptySet) {
   DeltaTriples deltaTriples{testQec->getIndex()};
   auto tmpFile =
-      std::filesystem::temp_directory_path() / "testEmptyDeltaTriples";
+      ql::filesystem::temp_directory_path() / "testEmptyDeltaTriples";
   // Make sure no artifacts from previous crashed runs exists.
-  std::filesystem::remove(tmpFile);
-  absl::Cleanup cleanup{[&tmpFile]() { std::filesystem::remove(tmpFile); }};
+  ql::filesystem::remove(tmpFile);
+  absl::Cleanup cleanup{[&tmpFile]() { ql::filesystem::remove(tmpFile); }};
   deltaTriples.setPersists(tmpFile);
   // Write "empty" file
   EXPECT_NO_THROW(deltaTriples.writeToDisk());
@@ -836,10 +837,10 @@ TEST_F(DeltaTriplesTest, storeAndRestoreFromEmptySet) {
 TEST_F(DeltaTriplesTest, storeAndRestoreData) {
   using namespace ::testing;
   using ad_utility::triple_component::LiteralOrIri;
-  auto tmpFile = std::filesystem::temp_directory_path() / "testDeltaTriples";
+  auto tmpFile = ql::filesystem::temp_directory_path() / "testDeltaTriples";
   // Make sure no file like this exists
-  std::filesystem::remove(tmpFile);
-  absl::Cleanup cleanup{[&tmpFile]() { std::filesystem::remove(tmpFile); }};
+  ql::filesystem::remove(tmpFile);
+  absl::Cleanup cleanup{[&tmpFile]() { ql::filesystem::remove(tmpFile); }};
   auto defaultGraph =
       TripleComponent(TripleComponent::Iri::fromIriref(DEFAULT_GRAPH_IRI))
           .toValueId(testQec->getIndex().getImpl())

--- a/test/FilesystemHelpersTest.cpp
+++ b/test/FilesystemHelpersTest.cpp
@@ -19,6 +19,7 @@
 #include "util/Log.h"
 
 namespace fs = ql::filesystem;
+using qlever::util::deleteFilesInDirectory;
 using qlever::util::doesDirectoryContainFileWithBasename;
 using ::testing::HasSubstr;
 
@@ -171,4 +172,98 @@ TEST(IsSubdirectoryOf, differentPaths) {
   // This only works if the test is not run inside `/`, but this should be fine.
   EXPECT_FALSE(isSubdirectoryOf("/malicious-path", "relative-path"));
   EXPECT_FALSE(isSubdirectoryOf("../malicious-path", "relative-path"));
+}
+
+// _____________________________________________________________________________
+TEST(DeleteFilesInDirectory, deletesOnlyMatchingRegularFiles) {
+  TempDir tmp;
+  touch(tmp.path() / "del_1.txt");
+  touch(tmp.path() / "del_2.txt");
+  touch(tmp.path() / "keep.txt");
+
+  size_t deleted = deleteFilesInDirectory(tmp.path(), [](const fs::path& p) {
+    return p.filename().string().rfind("del_", 0) == 0;
+  });
+
+  EXPECT_EQ(deleted, 2u);
+  EXPECT_FALSE(fs::exists(tmp.path() / "del_1.txt"));
+  EXPECT_FALSE(fs::exists(tmp.path() / "del_2.txt"));
+  EXPECT_TRUE(fs::exists(tmp.path() / "keep.txt"));
+}
+
+// _____________________________________________________________________________
+TEST(DeleteFilesInDirectory, deletesAllMatchingFiles) {
+  TempDir tmp;
+  constexpr int numMatching = 25;
+  for (int i = 0; i < numMatching; ++i) {
+    touch(tmp.path() / absl::StrCat("del_", i, ".tmp"));
+  }
+  touch(tmp.path() / "keep");
+
+  size_t deleted = deleteFilesInDirectory(tmp.path(), [](const fs::path& p) {
+    return p.extension().string() == ".tmp";
+  });
+
+  EXPECT_EQ(deleted, static_cast<size_t>(numMatching));
+  EXPECT_TRUE(fs::exists(tmp.path() / "keep"));
+  // No matching file is left behind (this is what the collect-then-delete
+  // strategy guarantees, even on platforms where deleting while iterating would
+  // skip entries).
+  size_t remaining = 0;
+  for (const auto& entry : ql::directoryRange(tmp.path())) {
+    if (entry.path().extension().string() == ".tmp") {
+      ++remaining;
+    }
+  }
+  EXPECT_EQ(remaining, 0u);
+}
+
+// _____________________________________________________________________________
+TEST(DeleteFilesInDirectory, ignoresSubdirectories) {
+  TempDir tmp;
+  touch(tmp.path() / "match_file");
+  fs::create_directory(tmp.path() / "match_dir");
+
+  // The predicate matches both, but only the regular file must be deleted.
+  size_t deleted = deleteFilesInDirectory(tmp.path(), [](const fs::path& p) {
+    return p.filename().string().rfind("match_", 0) == 0;
+  });
+
+  EXPECT_EQ(deleted, 1u);
+  EXPECT_FALSE(fs::exists(tmp.path() / "match_file"));
+  EXPECT_TRUE(fs::exists(tmp.path() / "match_dir"));
+}
+
+// _____________________________________________________________________________
+TEST(DeleteFilesInDirectory, predicateMatchingNothingDeletesNothing) {
+  TempDir tmp;
+  touch(tmp.path() / "a");
+  touch(tmp.path() / "b");
+
+  size_t deleted =
+      deleteFilesInDirectory(tmp.path(), [](const fs::path&) { return false; });
+
+  EXPECT_EQ(deleted, 0u);
+  EXPECT_TRUE(fs::exists(tmp.path() / "a"));
+  EXPECT_TRUE(fs::exists(tmp.path() / "b"));
+}
+
+// _____________________________________________________________________________
+TEST(DeleteFilesInDirectory, nonExistentDirectoryReturnsZero) {
+  TempDir tmp;
+  fs::path missing = tmp.path() / "does-not-exist";
+  size_t deleted =
+      deleteFilesInDirectory(missing, [](const fs::path&) { return true; });
+  EXPECT_EQ(deleted, 0u);
+}
+
+// _____________________________________________________________________________
+TEST(DeleteFilesInDirectory, pathThatIsNotADirectoryReturnsZero) {
+  TempDir tmp;
+  auto file = tmp.path() / "a-file";
+  touch(file);
+  size_t deleted =
+      deleteFilesInDirectory(file, [](const fs::path&) { return true; });
+  EXPECT_EQ(deleted, 0u);
+  EXPECT_TRUE(fs::exists(file));
 }

--- a/test/FilesystemHelpersTest.cpp
+++ b/test/FilesystemHelpersTest.cpp
@@ -38,7 +38,7 @@ class TempDir {
   }
 
   ~TempDir() {
-    std::error_code ec;
+    ql::error_code ec;
     fs::remove_all(path_, ec);
     if (ec) {
       AD_LOG_WARN << "Could not remove temporary directory " << path_ << ": "
@@ -57,7 +57,7 @@ class TempDir {
 
 // Convenience helper to create an empty file at the given path.
 void touch(const fs::path& p) {
-  std::ofstream out{p};
+  std::ofstream out{p.string()};
   ASSERT_TRUE(out.good()) << "Could not create file: " << p;
 }
 

--- a/test/FilesystemHelpersTest.cpp
+++ b/test/FilesystemHelpersTest.cpp
@@ -10,15 +10,15 @@
 #include <absl/strings/str_cat.h>
 #include <gmock/gmock.h>
 
-#include <filesystem>
 #include <fstream>
 #include <string>
 
+#include "backports/filesystem.h"
 #include "util/FilesystemHelpers.h"
 #include "util/GTestHelpers.h"
 #include "util/Log.h"
 
-namespace fs = std::filesystem;
+namespace fs = ql::filesystem;
 using qlever::util::doesDirectoryContainFileWithBasename;
 using ::testing::HasSubstr;
 
@@ -135,7 +135,7 @@ TEST(DoesDirectoryContainFileWithBasename, parentIsNotADirectoryReturnsTrue) {
 TEST(DoesDirectoryContainFileWithBasename,
      trailingSlashHasNoFilenameComponent) {
   TempDir tmp;
-  // A path ending in a separator has an empty filename() in std::filesystem.
+  // A path ending in a separator has an empty filename() in ql::filesystem.
   std::string base = tmp.path().string() + "/";
   touch(tmp.path() / "some-file.txt");
   EXPECT_TRUE(doesDirectoryContainFileWithBasename(base));

--- a/test/IndexTest.cpp
+++ b/test/IndexTest.cpp
@@ -15,6 +15,7 @@
 #include "./util/IdTableHelpers.h"
 #include "./util/TripleComponentTestHelpers.h"
 #include "CompilationInfo.h"
+#include "backports/filesystem.h"
 #include "index/Index.h"
 #include "index/IndexFormatVersion.h"
 #include "index/IndexImpl.h"
@@ -110,12 +111,12 @@ auto makeTemporaryDirectory(std::string_view name) {
   AD_CORRECTNESS_CHECK(!ql::starts_with(name, '/'));
   directory += name;
   // Create directory.
-  std::filesystem::create_directory(directory);
+  ql::filesystem::create_directory(directory);
 
   // Remove all files in directory when done.
   absl::Cleanup cleanup{[directory]() {
     std::error_code ec;
-    std::filesystem::remove_all(directory, ec);
+    ql::filesystem::remove_all(directory, ec);
     if (ec) {
       AD_LOG(ERROR) << "Could not remove temporary directory " << directory
                     << ": " << ec.message();
@@ -850,8 +851,8 @@ TEST(IndexImpl, createPermutation) {
   index.finalizePermutation(meta, permutation, false);
 
   EXPECT_EQ(uniquePredicates, 3);
-  EXPECT_TRUE(std::filesystem::exists(onDiskBase + ".index.pso"));
-  EXPECT_TRUE(std::filesystem::exists(onDiskBase + ".index.pso.meta"));
+  EXPECT_TRUE(ql::filesystem::exists(onDiskBase + ".index.pso"));
+  EXPECT_TRUE(ql::filesystem::exists(onDiskBase + ".index.pso.meta"));
 
   auto [uniqueInternalPredicates, internalMeta] =
       index.createPermutationWithoutMetadata(
@@ -860,8 +861,8 @@ TEST(IndexImpl, createPermutation) {
   index.finalizePermutation(internalMeta, permutation, true);
 
   EXPECT_EQ(uniqueInternalPredicates, 3);
-  EXPECT_TRUE(std::filesystem::exists(onDiskBase + ".internal.index.pso"));
-  EXPECT_TRUE(std::filesystem::exists(onDiskBase + ".internal.index.pso.meta"));
+  EXPECT_TRUE(ql::filesystem::exists(onDiskBase + ".internal.index.pso"));
+  EXPECT_TRUE(ql::filesystem::exists(onDiskBase + ".internal.index.pso.meta"));
 
   permutation.loadFromDisk(onDiskBase, true);
   index.deltaTriplesManager().modify<void>(
@@ -910,7 +911,7 @@ TEST(IndexImpl, writePatternsToFile) {
   index.getPatterns() = CompactVectorOfStrings{data};
   index.writePatternsToFile();
 
-  ASSERT_TRUE(std::filesystem::exists(onDiskBase + ".index.patterns"));
+  ASSERT_TRUE(ql::filesystem::exists(onDiskBase + ".index.patterns"));
 
   double avgNumDistinctSubjectsPerPredicate;
   double avgNumDistinctPredicatesPerSubject;

--- a/test/IndexTest.cpp
+++ b/test/IndexTest.cpp
@@ -115,7 +115,7 @@ auto makeTemporaryDirectory(std::string_view name) {
 
   // Remove all files in directory when done.
   absl::Cleanup cleanup{[directory]() {
-    std::error_code ec;
+    ql::error_code ec;
     ql::filesystem::remove_all(directory, ec);
     if (ec) {
       AD_LOG(ERROR) << "Could not remove temporary directory " << directory

--- a/test/MaterializedViewsTestHelpers.h
+++ b/test/MaterializedViewsTestHelpers.h
@@ -18,6 +18,7 @@
 #include "engine/MaterializedViews.h"
 #include "libqlever/Qlever.h"
 #include "util/Exception.h"
+#include "util/FilesystemHelpers.h"
 
 namespace materializedViewsTestHelpers {
 
@@ -50,12 +51,10 @@ inline void makeTestIndex(const std::string& basename, const std::string& kg) {
 inline void removeTestIndex(const std::string& basename) {
   std::regex pattern(absl::StrCat(basename, "\\..*"));
   std::cout << "Removing test files " << basename << ".*" << std::endl;
-  for (const auto& entry : ql::directoryRange(ql::filesystem::current_path())) {
-    if (entry.is_regular_file() &&
-        std::regex_match(entry.path().filename().string(), pattern)) {
-      ql::filesystem::remove(entry.path());
-    }
-  }
+  qlever::util::deleteFilesInDirectory(
+      ql::filesystem::current_path(), [&pattern](const auto& path) {
+        return std::regex_match(path.filename().string(), pattern);
+      });
 }
 
 // _____________________________________________________________________________

--- a/test/MaterializedViewsTestHelpers.h
+++ b/test/MaterializedViewsTestHelpers.h
@@ -50,8 +50,7 @@ inline void makeTestIndex(const std::string& basename, const std::string& kg) {
 inline void removeTestIndex(const std::string& basename) {
   std::regex pattern(absl::StrCat(basename, "\\..*"));
   std::cout << "Removing test files " << basename << ".*" << std::endl;
-  for (const auto& entry :
-       ql::filesystem::directory_iterator(ql::filesystem::current_path())) {
+  for (const auto& entry : ql::directoryRange(ql::filesystem::current_path())) {
     if (entry.is_regular_file() &&
         std::regex_match(entry.path().filename().string(), pattern)) {
       ql::filesystem::remove(entry.path());

--- a/test/MaterializedViewsTestHelpers.h
+++ b/test/MaterializedViewsTestHelpers.h
@@ -14,6 +14,7 @@
 
 #include "./QueryPlannerTestHelpers.h"
 #include "./util/GTestHelpers.h"
+#include "backports/filesystem.h"
 #include "engine/MaterializedViews.h"
 #include "libqlever/Qlever.h"
 #include "util/Exception.h"
@@ -50,10 +51,10 @@ inline void removeTestIndex(const std::string& basename) {
   std::regex pattern(absl::StrCat(basename, "\\..*"));
   std::cout << "Removing test files " << basename << ".*" << std::endl;
   for (const auto& entry :
-       std::filesystem::directory_iterator(std::filesystem::current_path())) {
+       ql::filesystem::directory_iterator(ql::filesystem::current_path())) {
     if (entry.is_regular_file() &&
         std::regex_match(entry.path().filename().string(), pattern)) {
-      std::filesystem::remove(entry.path());
+      ql::filesystem::remove(entry.path());
     }
   }
 }

--- a/test/QueryEventLogTest.cpp
+++ b/test/QueryEventLogTest.cpp
@@ -10,7 +10,6 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include <filesystem>
 #include <fstream>
 #include <set>
 #include <string>
@@ -19,10 +18,11 @@
 #include <vector>
 
 #include "./util/FileTestHelpers.h"
+#include "backports/filesystem.h"
 #include "util/QueryEventLog.h"
 
 namespace {
-namespace fs = std::filesystem;
+namespace fs = ql::filesystem;
 using ad_utility::QueryEventLog;
 using ad_utility::testing::readLines;
 }  // namespace

--- a/test/ResourceMonitorTest.cpp
+++ b/test/ResourceMonitorTest.cpp
@@ -17,7 +17,6 @@
 #include <algorithm>
 #include <chrono>
 #include <cstdint>
-#include <filesystem>
 #include <fstream>
 #include <optional>
 #include <sstream>
@@ -29,10 +28,11 @@
 
 #include "./util/FileTestHelpers.h"
 #include "./util/GTestHelpers.h"
+#include "backports/filesystem.h"
 #include "util/ResourceMonitor.h"
 
 namespace {
-namespace fs = std::filesystem;
+namespace fs = ql::filesystem;
 using ad_utility::ResourceMonitor;
 using ad_utility::resource_monitor::CpuPercentTracker;
 using ad_utility::resource_monitor::cpuTimeSeconds;

--- a/test/ServerTest.cpp
+++ b/test/ServerTest.cpp
@@ -10,6 +10,7 @@
 
 #include "./util/FileTestHelpers.h"
 #include "ServerTestHelpers.h"
+#include "backports/filesystem.h"
 #include "engine/HttpError.h"
 #include "engine/QueryPlanner.h"
 #include "engine/Server.h"
@@ -677,7 +678,7 @@ TEST(ServerTest, gspPostCreateNewGraph) {
 // _____________________________________________________________________________
 // Read a query-event-log file and parse each JSONL line.
 namespace {
-std::vector<json> parseEventLog(const std::filesystem::path& path) {
+std::vector<json> parseEventLog(const ql::filesystem::path& path) {
   std::vector<json> events;
   for (const auto& line : ad_utility::testing::readLines(path)) {
     events.push_back(json::parse(line));

--- a/test/ServerTestHelpers.h
+++ b/test/ServerTestHelpers.h
@@ -8,11 +8,11 @@
 #define QLEVER_TEST_SERVERTESTHELPERS_H_
 
 #include <boost/beast/http.hpp>
-#include <filesystem>
 #include <optional>
 #include <string>
 #include <utility>
 
+#include "backports/filesystem.h"
 #include "engine/Server.h"
 #include "libqlever/Qlever.h"
 #include "util/IndexTestHelpers.h"
@@ -64,7 +64,7 @@ class ServerForTesting {
   }
 
   // Forwards to `Server::configureQueryEventLog`.
-  void configureQueryEventLog(const std::filesystem::path& path) {
+  void configureQueryEventLog(const ql::filesystem::path& path) {
     server_->configureQueryEventLog(path);
   }
 
@@ -130,7 +130,7 @@ inline qlever::EngineConfig getDefaultConfig() {
 // to that file.
 inline ServerForTesting makeServerForTesting(
     std::string baseName,
-    std::optional<std::filesystem::path> eventLogPath = std::nullopt) {
+    std::optional<ql::filesystem::path> eventLogPath = std::nullopt) {
   ServerForTesting server{1, "accessToken",
                           getDefaultConfigWithName(std::move(baseName))};
   if (eventLogPath.has_value()) {

--- a/test/TripleSerializerTest.cpp
+++ b/test/TripleSerializerTest.cpp
@@ -204,7 +204,7 @@ TEST(TripleSerializer, rethrowsOnInvalidFileAccess) {
   auto* qec = ad_utility::testing::getQec();
   auto tmpFile = ql::filesystem::temp_directory_path() / "fileNoPermissions";
   // Create empty file
-  std::ofstream{tmpFile}.close();
+  std::ofstream{tmpFile.string()}.close();
   absl::Cleanup cleanup{[&tmpFile]() { ql::filesystem::remove(tmpFile); }};
   // Remove all permissions to make read fail
   ql::filesystem::permissions(tmpFile, ql::filesystem_perms_none);

--- a/test/TripleSerializerTest.cpp
+++ b/test/TripleSerializerTest.cpp
@@ -5,6 +5,7 @@
 #include <gmock/gmock.h>
 
 #include "./util/IdTestHelpers.h"
+#include "backports/filesystem.h"
 #include "util/GTestHelpers.h"
 #include "util/IndexTestHelpers.h"
 #include "util/Serializer/ByteBufferSerializer.h"
@@ -201,12 +202,12 @@ TEST(TripleSerializer, multipleWordSetsInASerializedLocalVocab) {
 TEST(TripleSerializer, rethrowsOnInvalidFileAccess) {
   using namespace ::testing;
   auto* qec = ad_utility::testing::getQec();
-  auto tmpFile = std::filesystem::temp_directory_path() / "fileNoPermissions";
+  auto tmpFile = ql::filesystem::temp_directory_path() / "fileNoPermissions";
   // Create empty file
   std::ofstream{tmpFile}.close();
-  absl::Cleanup cleanup{[&tmpFile]() { std::filesystem::remove(tmpFile); }};
+  absl::Cleanup cleanup{[&tmpFile]() { ql::filesystem::remove(tmpFile); }};
   // Remove all permissions to make read fail
-  std::filesystem::permissions(tmpFile, std::filesystem::perms::none);
+  ql::filesystem::permissions(tmpFile, ql::filesystem_perms_none);
 
   if (FILE* handle = fopen(tmpFile.c_str(), "r")) {
     fclose(handle);

--- a/test/VocabularyGeneratorTest.cpp
+++ b/test/VocabularyGeneratorTest.cpp
@@ -7,13 +7,13 @@
 
 #include <cstdlib>
 #include <ctime>
-#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <string>
 
 #include "./util/IdTestHelpers.h"
 #include "backports/StartsWithAndEndsWith.h"
+#include "backports/filesystem.h"
 #include "global/Constants.h"
 #include "index/ConstantsIndexBuilding.h"
 #include "index/Index.h"
@@ -78,7 +78,7 @@ class MergeVocabularyTest : public ::testing::Test {
     // Create a subdirectory for the test files in the working directory.
     _basePath = _basePath + "/";
     std::error_code errorCode;
-    std::filesystem::create_directories(_basePath, errorCode);
+    ql::filesystem::create_directories(_basePath, errorCode);
     if (errorCode) {
       std::cerr << "Could not create the directory for the test files. This "
                    "might lead to test failures\n";
@@ -162,7 +162,7 @@ class MergeVocabularyTest : public ::testing::Test {
   ~MergeVocabularyTest() {
     // Delete the test files (to debug a test failure, comment this out).
     std::error_code errorCode;
-    std::filesystem::remove_all(_basePath, errorCode);
+    ql::filesystem::remove_all(_basePath, errorCode);
   }
 
   // read all bytes from a file (e.g. to check equality of small test files)

--- a/test/VocabularyGeneratorTest.cpp
+++ b/test/VocabularyGeneratorTest.cpp
@@ -77,7 +77,7 @@ class MergeVocabularyTest : public ::testing::Test {
 
     // Create a subdirectory for the test files in the working directory.
     _basePath = _basePath + "/";
-    std::error_code errorCode;
+    ql::error_code errorCode;
     ql::filesystem::create_directories(_basePath, errorCode);
     if (errorCode) {
       std::cerr << "Could not create the directory for the test files. This "
@@ -161,7 +161,7 @@ class MergeVocabularyTest : public ::testing::Test {
   // __________________________________________________________________
   ~MergeVocabularyTest() {
     // Delete the test files (to debug a test failure, comment this out).
-    std::error_code errorCode;
+    ql::error_code errorCode;
     ql::filesystem::remove_all(_basePath, errorCode);
   }
 

--- a/test/engine/NamedResultCacheSerializerTest.cpp
+++ b/test/engine/NamedResultCacheSerializerTest.cpp
@@ -9,7 +9,6 @@
 
 #include "../util/IdTableHelpers.h"
 #include "../util/IndexTestHelpers.h"
-#include "backports/filesystem.h"
 #include "engine/NamedResultCache.h"
 #include "engine/NamedResultCacheSerializer.h"
 #include "index/LocalVocabEntry.h"

--- a/test/engine/NamedResultCacheSerializerTest.cpp
+++ b/test/engine/NamedResultCacheSerializerTest.cpp
@@ -7,10 +7,9 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include <filesystem>
-
 #include "../util/IdTableHelpers.h"
 #include "../util/IndexTestHelpers.h"
+#include "backports/filesystem.h"
 #include "engine/NamedResultCache.h"
 #include "engine/NamedResultCacheSerializer.h"
 #include "index/LocalVocabEntry.h"

--- a/test/engine/SpatialJoinAlgorithmsTest.cpp
+++ b/test/engine/SpatialJoinAlgorithmsTest.cpp
@@ -19,6 +19,7 @@
 #include "../util/IndexTestHelpers.h"
 #include "../util/RuntimeParametersTestHelpers.h"
 #include "./SpatialJoinTestHelpers.h"
+#include "backports/filesystem.h"
 #include "engine/IndexScan.h"
 #include "engine/QueryExecutionTree.h"
 #include "engine/SpatialJoin.h"
@@ -1785,7 +1786,7 @@ TEST(SpatialJoin, LibspatialJoinWithAbsoluteOnDiskBase) {
   addArea(kg, "1", "\"Uni Freiburg TF Area\"", areaUniFreiburg);
   addArea(kg, "2", "\"Minster Freiburg Area\"", areaMuenster);
 
-  auto base = std::filesystem::current_path() / "_spatialjoinAbsTestIndex";
+  auto base = ql::filesystem::current_path() / "_spatialjoinAbsTestIndex";
 
   ad_utility::testing::TestIndexConfig idxConfig{kg};
   std::optional<ad_utility::VocabularyType> vocabType = std::nullopt;

--- a/test/index/IndexRebuilderTest.cpp
+++ b/test/index/IndexRebuilderTest.cpp
@@ -25,6 +25,7 @@
 #include "index/IndexRebuilderImpl.h"
 #include "index/vocabulary/VocabularyType.h"
 #include "libqlever/Qlever.h"
+#include "util/FilesystemHelpers.h"
 
 using namespace qlever::indexRebuilder;
 using namespace std::string_literals;
@@ -643,25 +644,11 @@ void cleanFilesWithPrefix(std::string_view prefix) {
   AD_CONTRACT_CHECK(!prefix.empty(),
                     "This function is not meant to delete all files in the "
                     "current directory. Please specify a prefix.");
-  namespace fs = ql::filesystem;
-  // Collect the matching entries first and delete them only afterwards.
-  // Deleting entries while iterating the directory is unspecified behavior and
-  // can cause entries to be skipped on some platforms (observed on macOS),
-  // leaving leftover files behind.
-  std::vector<fs::directory_entry> toDelete;
-  ql::ranges::copy_if(ql::directoryRange("."), std::back_inserter(toDelete),
-                      [prefix](const auto& e) {
-                        return ql::starts_with(e.path().filename().string(),
-                                               prefix);
-                      });
-  AD_CONTRACT_CHECK(
-      ql::ranges::all_of(
-          toDelete, [](const auto& entry) { return entry.is_regular_file(); }),
-      "All entries matching the prefix must be regular files, this function "
-      "does not delete directories.");
-  for (const auto& entry : toDelete) {
-    ad_utility::deleteFile(entry.path());
-  }
+  // `deleteFilesInDirectory` collects the matching entries first and deletes
+  // them only afterwards, and only deletes regular files (not directories).
+  qlever::util::deleteFilesInDirectory(".", [prefix](const auto& path) {
+    return ql::starts_with(path.filename().string(), prefix);
+  });
 }
 }  // namespace
 

--- a/test/index/IndexRebuilderTest.cpp
+++ b/test/index/IndexRebuilderTest.cpp
@@ -12,7 +12,6 @@
 #include <boost/asio/detached.hpp>
 #include <boost/asio/thread_pool.hpp>
 #include <boost/asio/use_future.hpp>
-#include <filesystem>
 
 #include "../util/GTestHelpers.h"
 #include "../util/HttpRequestHelpers.h"
@@ -20,6 +19,7 @@
 #include "../util/IdTestHelpers.h"
 #include "../util/IndexTestHelpers.h"
 #include "../util/TripleComponentTestHelpers.h"
+#include "backports/filesystem.h"
 #include "engine/Server.h"
 #include "index/IndexRebuilder.h"
 #include "index/IndexRebuilderImpl.h"
@@ -486,7 +486,7 @@ TEST(IndexRebuilder, createPermutationWriterTask) {
 
   // Assert nothing has happened yet
   for (std::string_view suffix : suffixes) {
-    EXPECT_FALSE(std::filesystem::exists(prefix + suffix))
+    EXPECT_FALSE(ql::filesystem::exists(prefix + suffix))
         << "File " << prefix + suffix
         << " should not exist before the task is executed.";
   }
@@ -503,7 +503,7 @@ TEST(IndexRebuilder, createPermutationWriterTask) {
   net::co_spawn(threadPool, std::move(task), net::detached);
   threadPool.join();
   for (std::string_view suffix : suffixes) {
-    EXPECT_TRUE(std::filesystem::exists(prefix + suffix));
+    EXPECT_TRUE(ql::filesystem::exists(prefix + suffix));
     EXPECT_EQ(fileToBuffer(index.getOnDiskBase() + suffix),
               fileToBuffer(prefix + suffix));
   }
@@ -541,13 +541,13 @@ TEST(IndexRebuilder, materializeToIndex) {
         index.deltaTriplesManager()
             .getCurrentLocatedTriplesSharedStateWithVocab();
 
-    std::filesystem::create_directory(baseFolder);
+    ql::filesystem::create_directory(baseFolder);
     absl::Cleanup removeIndexFiles{
-        [&baseFolder] { std::filesystem::remove_all(baseFolder); }};
+        [&baseFolder] { ql::filesystem::remove_all(baseFolder); }};
 
     qlever::materializeToIndex(index.getImpl(), newIndexName, state, vocab,
                                blankNodes, cancellationHandle, logFile);
-    EXPECT_TRUE(std::filesystem::exists(logFile));
+    EXPECT_TRUE(ql::filesystem::exists(logFile));
 
     IndexImpl newIndex{ad_utility::makeUnlimitedAllocator<Id>()};
     newIndex.usePatterns() = usePatterns;
@@ -606,9 +606,9 @@ TEST(IndexRebuilder, materializeToIndexWithZeroMemorySourceIndex) {
       index.deltaTriplesManager()
           .getCurrentLocatedTriplesSharedStateWithVocab();
 
-  std::filesystem::create_directory(baseFolder);
+  ql::filesystem::create_directory(baseFolder);
   absl::Cleanup removeIndexFiles{
-      [&baseFolder] { std::filesystem::remove_all(baseFolder); }};
+      [&baseFolder] { ql::filesystem::remove_all(baseFolder); }};
 
   EXPECT_NO_THROW(qlever::materializeToIndex(index.getImpl(), newIndexName,
                                              state, vocab, blankNodes,
@@ -643,7 +643,7 @@ void cleanFilesWithPrefix(std::string_view prefix) {
   AD_CONTRACT_CHECK(!prefix.empty(),
                     "This function is not meant to delete all files in the "
                     "current directory. Please specify a prefix.");
-  namespace fs = std::filesystem;
+  namespace fs = ql::filesystem;
   // Collect the matching entries first and delete them only afterwards.
   // Deleting entries while iterating the directory is unspecified behavior and
   // can cause entries to be skipped on some platforms (observed on macOS),
@@ -714,14 +714,14 @@ TEST(IndexRebuilder, serverIntegration) {
 
   // We use this config as a proxy for the index rebuilder having finished
   // successfully.
-  EXPECT_TRUE(std::filesystem::exists("my-name.meta-data.json"));
+  EXPECT_TRUE(ql::filesystem::exists("my-name.meta-data.json"));
 
   auto request3 = ad_utility::testing::makeGetRequest(
       "/?cmd=rebuild-index&access-token=accessToken");
   auto response3 = performRequest(request3).get();
   EXPECT_EQ(response3.base().result(), boost::beast::http::status::ok);
   // By default QLever should assign a default name for the new index.
-  EXPECT_TRUE(std::filesystem::exists("new_index.meta-data.json"));
+  EXPECT_TRUE(ql::filesystem::exists("new_index.meta-data.json"));
 
   // The index with the same name already exists, so we don't want to overwrite
   // it.

--- a/test/index/IndexRebuilderTest.cpp
+++ b/test/index/IndexRebuilderTest.cpp
@@ -649,7 +649,7 @@ void cleanFilesWithPrefix(std::string_view prefix) {
   // can cause entries to be skipped on some platforms (observed on macOS),
   // leaving leftover files behind.
   std::vector<fs::directory_entry> toDelete;
-  ql::ranges::copy_if(fs::directory_iterator("."), std::back_inserter(toDelete),
+  ql::ranges::copy_if(ql::directoryRange("."), std::back_inserter(toDelete),
                       [prefix](const auto& e) {
                         return ql::starts_with(e.path().filename().string(),
                                                prefix);

--- a/test/index/InputFileSpecificationTest.cpp
+++ b/test/index/InputFileSpecificationTest.cpp
@@ -73,7 +73,7 @@ TEST(InputFileSpecification, FiletypeFromMediaType) {
 TEST(InputFileSpecification, MakeAsyncBlockSourceFileBased) {
   ql::filesystem::path tmpFile =
       ql::filesystem::temp_directory_path() / "qlever_ifs_test.ttl";
-  std::ofstream{tmpFile} << "<s> <p> <o> .\n";
+  std::ofstream{tmpFile.string()} << "<s> <p> <o> .\n";
 
   boost::asio::thread_pool pool{1};
   InputFileSpecification spec{tmpFile.string(), Filetype::Turtle, std::nullopt};

--- a/test/index/InputFileSpecificationTest.cpp
+++ b/test/index/InputFileSpecificationTest.cpp
@@ -10,9 +10,9 @@
 #include <gmock/gmock.h>
 
 #include <boost/asio/thread_pool.hpp>
-#include <filesystem>
 #include <fstream>
 
+#include "backports/filesystem.h"
 #include "index/InputFileSpecification.h"
 #include "parser/AsyncBlockSource.h"
 #include "util/MemorySize/MemorySize.h"
@@ -71,8 +71,8 @@ TEST(InputFileSpecification, FiletypeFromMediaType) {
 
 // _____________________________________________________________________________
 TEST(InputFileSpecification, MakeAsyncBlockSourceFileBased) {
-  std::filesystem::path tmpFile =
-      std::filesystem::temp_directory_path() / "qlever_ifs_test.ttl";
+  ql::filesystem::path tmpFile =
+      ql::filesystem::temp_directory_path() / "qlever_ifs_test.ttl";
   std::ofstream{tmpFile} << "<s> <p> <o> .\n";
 
   boost::asio::thread_pool pool{1};
@@ -82,7 +82,7 @@ TEST(InputFileSpecification, MakeAsyncBlockSourceFileBased) {
   EXPECT_NE(dynamic_cast<qlever::parser::AsyncFileBlockSource*>(src.get()),
             nullptr);
 
-  std::filesystem::remove(tmpFile);
+  ql::filesystem::remove(tmpFile);
 }
 
 // _____________________________________________________________________________

--- a/test/index/VocabularyMergerImplTest.cpp
+++ b/test/index/VocabularyMergerImplTest.cpp
@@ -13,7 +13,6 @@
 
 #include <string>
 
-#include "backports/filesystem.h"
 #include "index/VocabularyMergerImpl.h"
 #include "util/Serializer/FileSerializer.h"
 #include "util/Serializer/SerializeString.h"

--- a/test/index/VocabularyMergerImplTest.cpp
+++ b/test/index/VocabularyMergerImplTest.cpp
@@ -11,9 +11,9 @@
 #include <absl/strings/str_cat.h>
 #include <gtest/gtest.h>
 
-#include <filesystem>
 #include <string>
 
+#include "backports/filesystem.h"
 #include "index/VocabularyMergerImpl.h"
 #include "util/Serializer/FileSerializer.h"
 #include "util/Serializer/SerializeString.h"

--- a/test/util/FileTestHelpers.h
+++ b/test/util/FileTestHelpers.h
@@ -12,19 +12,19 @@
 
 #include <absl/cleanup/cleanup.h>
 
-#include <filesystem>
 #include <fstream>
 #include <string>
 #include <vector>
 
+#include "backports/filesystem.h"
 #include "util/Random.h"
 
 namespace ad_utility::testing {
 inline auto filenameForTesting() {
-  auto tmpFile = std::filesystem::temp_directory_path() / UuidGenerator()();
+  auto tmpFile = ql::filesystem::temp_directory_path() / UuidGenerator()();
   // Make sure no file like this exists
-  std::filesystem::remove(tmpFile);
-  absl::Cleanup cleanup{[tmpFile]() { std::filesystem::remove(tmpFile); }};
+  ql::filesystem::remove(tmpFile);
+  absl::Cleanup cleanup{[tmpFile]() { ql::filesystem::remove(tmpFile); }};
   return std::make_pair(std::move(tmpFile), std::move(cleanup));
 }
 
@@ -32,7 +32,7 @@ inline auto filenameForTesting() {
 // that need to inspect the contents of a file written by another
 // component (e.g. a background writer thread that has already drained
 // and closed the stream).
-inline std::vector<std::string> readLines(const std::filesystem::path& path) {
+inline std::vector<std::string> readLines(const ql::filesystem::path& path) {
   std::ifstream in{path};
   std::vector<std::string> lines;
   std::string line;

--- a/test/util/FileTestHelpers.h
+++ b/test/util/FileTestHelpers.h
@@ -33,7 +33,7 @@ inline auto filenameForTesting() {
 // component (e.g. a background writer thread that has already drained
 // and closed the stream).
 inline std::vector<std::string> readLines(const ql::filesystem::path& path) {
-  std::ifstream in{path};
+  std::ifstream in{path.string()};
   std::vector<std::string> lines;
   std::string line;
   while (std::getline(in, line)) {

--- a/test/util/IndexTestHelpers.cpp
+++ b/test/util/IndexTestHelpers.cpp
@@ -4,9 +4,14 @@
 
 #include "IndexTestHelpers.h"
 
+#include <absl/strings/str_cat.h>
+
+#include <array>
+
 #include "./GTestHelpers.h"
 #include "./TripleComponentTestHelpers.h"
 #include "backports/StartsWithAndEndsWith.h"
+#include "backports/algorithm.h"
 #include "backports/filesystem.h"
 #include "engine/MaterializedViews.h"
 #include "engine/NamedResultCache.h"
@@ -171,15 +176,15 @@ Index makeTestIndex(const std::string& indexBasename, TestIndexConfig c) {
   // permutations are not present, because they would actually be present from
   // the previous index build.
   namespace fs = ql::filesystem;
+  static constexpr std::array<std::string_view, 6> suffixes{
+      VOCAB_SUFFIX,       ".index",          ".internal.index",
+      CONFIGURATION_FILE, ".update-triples", ".allocated-graphs-state"};
   qlever::util::deleteFilesInDirectory(
       fs::current_path(), [&indexBasename](const auto& path) {
         std::string name = path.filename().string();
-        return ql::starts_with(name, indexBasename + VOCAB_SUFFIX) ||
-               ql::starts_with(name, indexBasename + ".index") ||
-               ql::starts_with(name, indexBasename + ".internal.index") ||
-               ql::starts_with(name, indexBasename + CONFIGURATION_FILE) ||
-               ql::starts_with(name, indexBasename + ".update-triples") ||
-               ql::starts_with(name, indexBasename + ".allocated-graphs-state");
+        return ql::ranges::any_of(suffixes, [&](std::string_view suffix) {
+          return ql::starts_with(name, absl::StrCat(indexBasename, suffix));
+        });
       });
   std::string inputFilename = indexBasename + ".ttl";
   if (!c.turtleInput.has_value()) {

--- a/test/util/IndexTestHelpers.cpp
+++ b/test/util/IndexTestHelpers.cpp
@@ -14,6 +14,7 @@
 #include "index/IndexImpl.h"
 #include "index/TextIndexBuilder.h"
 #include "index/vocabulary/VocabularyType.h"
+#include "util/FilesystemHelpers.h"
 #include "util/ProgressBar.h"
 
 using qlever::TextScoringMetric;
@@ -170,20 +171,16 @@ Index makeTestIndex(const std::string& indexBasename, TestIndexConfig c) {
   // permutations are not present, because they would actually be present from
   // the previous index build.
   namespace fs = ql::filesystem;
-  for (const auto& entry : ql::directoryRange(fs::current_path())) {
-    if (!entry.is_regular_file()) continue;
-
-    std::string name = entry.path().filename().string();
-
-    if (ql::starts_with(name, indexBasename + VOCAB_SUFFIX) ||
-        ql::starts_with(name, indexBasename + ".index") ||
-        ql::starts_with(name, indexBasename + ".internal.index") ||
-        ql::starts_with(name, indexBasename + CONFIGURATION_FILE) ||
-        ql::starts_with(name, indexBasename + ".update-triples") ||
-        ql::starts_with(name, indexBasename + ".allocated-graphs-state")) {
-      ad_utility::deleteFile(entry.path());
-    }
-  }
+  qlever::util::deleteFilesInDirectory(
+      fs::current_path(), [&indexBasename](const auto& path) {
+        std::string name = path.filename().string();
+        return ql::starts_with(name, indexBasename + VOCAB_SUFFIX) ||
+               ql::starts_with(name, indexBasename + ".index") ||
+               ql::starts_with(name, indexBasename + ".internal.index") ||
+               ql::starts_with(name, indexBasename + CONFIGURATION_FILE) ||
+               ql::starts_with(name, indexBasename + ".update-triples") ||
+               ql::starts_with(name, indexBasename + ".allocated-graphs-state");
+      });
   std::string inputFilename = indexBasename + ".ttl";
   if (!c.turtleInput.has_value()) {
     c.turtleInput =

--- a/test/util/IndexTestHelpers.cpp
+++ b/test/util/IndexTestHelpers.cpp
@@ -170,7 +170,7 @@ Index makeTestIndex(const std::string& indexBasename, TestIndexConfig c) {
   // permutations are not present, because they would actually be present from
   // the previous index build.
   namespace fs = ql::filesystem;
-  for (const auto& entry : fs::directory_iterator(fs::current_path())) {
+  for (const auto& entry : ql::directoryRange(fs::current_path())) {
     if (!entry.is_regular_file()) continue;
 
     std::string name = entry.path().filename().string();

--- a/test/util/IndexTestHelpers.cpp
+++ b/test/util/IndexTestHelpers.cpp
@@ -7,6 +7,7 @@
 #include "./GTestHelpers.h"
 #include "./TripleComponentTestHelpers.h"
 #include "backports/StartsWithAndEndsWith.h"
+#include "backports/filesystem.h"
 #include "engine/MaterializedViews.h"
 #include "engine/NamedResultCache.h"
 #include "global/SpecialIds.h"
@@ -168,7 +169,7 @@ Index makeTestIndex(const std::string& indexBasename, TestIndexConfig c) {
   // false positive when we later check that the patterns or the missing
   // permutations are not present, because they would actually be present from
   // the previous index build.
-  namespace fs = std::filesystem;
+  namespace fs = ql::filesystem;
   for (const auto& entry : fs::directory_iterator(fs::current_path())) {
     if (!entry.is_regular_file()) continue;
 


### PR DESCRIPTION
In the QNX toolchain, which we target with the C++17 builds, `std::filesystem` is not yet available. There is now a namespace `ql::filesystem`, which is an alias for either `std::filesystem` or `boost::filesystem`, depending on the build configuration. The two are almost drop-in replacements for each other; the few differences that matter for QLever are unified by small helpers in `backports/filesystem.h`.

There is also a new helper that deletes all regular files in a directory that match a given predicate. It first collects the matching filenames and only then deletes them, because deleting entries while iterating a directory is unspecified behavior and can skip entries on some platforms (observed on macOS). This replaces several hand-written cleanup loops in the tests, of which only one had this problem fixed before.
