### PR TITLE
Fix a race when inserting a computed result into the query cache

### DIFF
--- a/src/util/ConcurrentCache.h
+++ b/src/util/ConcurrentCache.h
@@ -239,14 +239,7 @@ class ConcurrentCache {
   void tryInsertIfNotPresent(bool pinned, const Key& key,
                              std::shared_ptr<Value> value) {
     auto lockPtr = _cacheAndInProgressMap.wlock();
-    auto& cache = lockPtr->_cache;
-    if (pinned) {
-      if (!cache.containsAndMakePinnedIfExists(key)) {
-        cache.insertPinned(key, std::move(value));
-      }
-    } else if (!cache.contains(key)) {
-      cache.insert(key, std::move(value));
-    }
+    insertIfNotPresent(lockPtr->_cache, pinned, key, std::move(value));
   }
 
   /// Clear the cache (but not the pinned entries)
@@ -356,23 +349,31 @@ class ConcurrentCache {
     auto lockPtr = _cacheAndInProgressMap.wlock();
     AD_CONTRACT_CHECK(lockPtr->_inProgress.contains(key));
     bool pinned = lockPtr->_inProgress[key].first;
-    auto& cache = lockPtr->_cache;
-    //
     // NOTE: The key might already be present in the cache: If the computation
     // of this key is canceled after it has deregistered the key from
     // `_inProgress`, then a thread that was waiting for that computation
     // recomputes the result itself and inserts it (see `computeOnceImpl`),
     // all before the canceled computation propagates its exception and dies.
     // A thread that starts a fresh computation of the same key in that window
-    // ends up here with the key already inserted.
+    // ends up here with the key already inserted. Hence the
+    // `insertIfNotPresent` instead of an unconditional insert.
+    insertIfNotPresent(lockPtr->_cache, pinned, key,
+                       std::move(computationResult));
+    lockPtr->_inProgress.erase(key);
+  }
+
+  // Insert `value` under `key` into `cache` if the key is not already present.
+  // Assume that the caller holds the lock on the cache. If `pinned` is true and
+  // the key already exists, pin the existing entry.
+  static void insertIfNotPresent(Cache& cache, bool pinned, const Key& key,
+                                 std::shared_ptr<Value> value) {
     if (pinned) {
       if (!cache.containsAndMakePinnedIfExists(key)) {
-        cache.insertPinned(key, std::move(computationResult));
+        cache.insertPinned(key, std::move(value));
       }
     } else if (!cache.contains(key)) {
-      cache.insert(key, std::move(computationResult));
+      cache.insert(key, std::move(value));
     }
-    lockPtr->_inProgress.erase(key);
   }
 
  private:

--- a/src/util/ConcurrentCache.h
+++ b/src/util/ConcurrentCache.h
@@ -340,23 +340,26 @@ class ConcurrentCache {
   // make the whole class thread-safe by making all the data members thread-safe
   using SyncCache = ad_utility::Synchronized<CacheAndInProgressMap, std::mutex>;
 
-  // delete the operation with the key from the hash map of the operations that
-  // are in progress, and add it to the cache using the computationResult
-  // Will crash if the key cannot be found in the hash map
+  // Delete the operation with the key from the hash map of the operations
+  // that are in progress, and add it to the cache using the computationResult
+  // (unless the key is already present, see the NOTE below). Will crash if
+  // the key cannot be found in the hash map.
   void moveFromInProgressToCache(Key key,
                                  std::shared_ptr<Value> computationResult) {
     // Obtain a lock for the whole operation, making it atomic.
     auto lockPtr = _cacheAndInProgressMap.wlock();
     AD_CONTRACT_CHECK(lockPtr->_inProgress.contains(key));
     bool pinned = lockPtr->_inProgress[key].first;
-    // NOTE: The key might already be present in the cache: If the computation
-    // of this key is canceled after it has deregistered the key from
-    // `_inProgress`, then a thread that was waiting for that computation
-    // recomputes the result itself and inserts it (see `computeOnceImpl`),
-    // all before the canceled computation propagates its exception and dies.
-    // A thread that starts a fresh computation of the same key in that window
-    // ends up here with the key already inserted. Hence the
-    // `insertIfNotPresent` instead of an unconditional insert.
+    // NOTE: The key might already be present in the cache: If a computation
+    // finishes with a result that is unsuitable for caching, it deregisters
+    // the key without inserting and signals a null result, whereupon a thread
+    // that was waiting for it computes the result itself and inserts it via
+    // `tryInsertIfNotPresent` (see `computeOnceImpl`). The same can happen via
+    // direct calls to `tryInsertIfNotPresent` (this is how lazy results are
+    // cached once they have been fully consumed). A thread that started a
+    // fresh computation of the same key in that window ends up here with the
+    // key already inserted. Hence the `insertIfNotPresent` instead of an
+    // unconditional insert.
     insertIfNotPresent(lockPtr->_cache, pinned, key,
                        std::move(computationResult));
     lockPtr->_inProgress.erase(key);

--- a/src/util/ConcurrentCache.h
+++ b/src/util/ConcurrentCache.h
@@ -356,11 +356,21 @@ class ConcurrentCache {
     auto lockPtr = _cacheAndInProgressMap.wlock();
     AD_CONTRACT_CHECK(lockPtr->_inProgress.contains(key));
     bool pinned = lockPtr->_inProgress[key].first;
+    auto& cache = lockPtr->_cache;
+    //
+    // NOTE: The key might already be present in the cache: If the computation
+    // of this key is canceled after it has deregistered the key from
+    // `_inProgress`, then a thread that was waiting for that computation
+    // recomputes the result itself and inserts it (see `computeOnceImpl`),
+    // all before the canceled computation propagates its exception and dies.
+    // A thread that starts a fresh computation of the same key in that window
+    // ends up here with the key already inserted.
     if (pinned) {
-      lockPtr->_cache.insertPinned(std::move(key),
-                                   std::move(computationResult));
-    } else {
-      lockPtr->_cache.insert(std::move(key), std::move(computationResult));
+      if (!cache.containsAndMakePinnedIfExists(key)) {
+        cache.insertPinned(key, std::move(computationResult));
+      }
+    } else if (!cache.contains(key)) {
+      cache.insert(key, std::move(computationResult));
     }
     lockPtr->_inProgress.erase(key);
   }

--- a/test/ConcurrentCacheTest.cpp
+++ b/test/ConcurrentCacheTest.cpp
@@ -497,18 +497,16 @@ TEST(ConcurrentCache,
 // inserted into the cache, which used to crash with "Trying to insert a cache
 // key which was already present". The deterministic interleaving is:
 //   1. Thread `A` computes the key, but its result is unsuitable for caching,
-//   so
-//      it deregisters the key from `_inProgress` and signals `finish(nullptr)`
-//      without inserting anything into the cache.
+//      so it deregisters the key from `_inProgress` and signals
+//      `finish(nullptr)` without inserting anything into the cache.
 //   2. Thread `W` was waiting for `A`. Because `A` finished with a null result
 //      (rather than throwing, which would make `W` throw as well), `W` falls
 //      back to computing the result itself and inserts it into the cache via
 //      the guarded `tryInsertIfNotPresent`.
 //   3. Thread `C` starts a fresh computation of the same key in the window
-//   after
-//      `A` deregistered the key but before `W` inserted it. `C` becomes the
-//      "must compute" thread and eventually calls `moveFromInProgressToCache`
-//      with the key already present in the cache.
+//      after `A` deregistered the key but before `W` inserted it. `C`
+//      becomes the "must compute" thread and eventually calls
+//      `moveFromInProgressToCache` with the key already present in the cache.
 // Before the fix, step 3 crashed; now the insert is skipped.
 TEST(ConcurrentCache, moveFromInProgressToCacheSkipsAlreadyPresentKey) {
   SimpleConcurrentLruCache cache{};

--- a/test/ConcurrentCacheTest.cpp
+++ b/test/ConcurrentCacheTest.cpp
@@ -492,6 +492,89 @@ TEST(ConcurrentCache,
 }
 
 // _____________________________________________________________________________
+// Regression test for a race in `moveFromInProgressToCache`. A fresh
+// computation could end up inserting a key that a concurrent thread had already
+// inserted into the cache, which used to crash with "Trying to insert a cache
+// key which was already present". The deterministic interleaving is:
+//   1. Thread `A` computes the key, but its result is unsuitable for caching,
+//   so
+//      it deregisters the key from `_inProgress` and signals `finish(nullptr)`
+//      without inserting anything into the cache.
+//   2. Thread `W` was waiting for `A`. Because `A` finished with a null result
+//      (rather than throwing, which would make `W` throw as well), `W` falls
+//      back to computing the result itself and inserts it into the cache via
+//      the guarded `tryInsertIfNotPresent`.
+//   3. Thread `C` starts a fresh computation of the same key in the window
+//   after
+//      `A` deregistered the key but before `W` inserted it. `C` becomes the
+//      "must compute" thread and eventually calls `moveFromInProgressToCache`
+//      with the key already present in the cache.
+// Before the fix, step 3 crashed; now the insert is skipped.
+TEST(ConcurrentCache, moveFromInProgressToCacheSkipsAlreadyPresentKey) {
+  SimpleConcurrentLruCache cache{};
+  auto returnFalse = [](const auto&) { return false; };
+
+  // The three computations are gated by their own signals so that we can force
+  // the exact interleaving described above.
+  StartStopSignal signalA;
+  StartStopSignal signalW;
+  StartStopSignal signalC;
+
+  // Step 1: `A` registers the key in `_inProgress`, but its result is
+  // unsuitable for the cache.
+  auto futA = std::async(std::launch::async, [&]() {
+    return cache.computeOnce(0, waiting_function("a"s, 0, &signalA), false,
+                             returnFalse);
+  });
+  signalA.hasStartedSignal_.wait();
+
+  // Step 2: `W` starts and waits for `A`'s in-progress computation.
+  UseCounter useCounter{cache};
+  auto futW = std::async(std::launch::async, [&]() {
+    return cache.computeOnce(0, waiting_function("w"s, 0, &signalW), false,
+                             returnTrue);
+  });
+  useCounter.waitForChange();
+
+  // Let `A` finish. Because its result is unsuitable, it deregisters the key
+  // and signals `finish(nullptr)`, so `W` falls back to computing the result
+  // itself. `W`'s fallback computation then blocks on `signalW`, before it
+  // inserts.
+  signalA.mayFinishSignal_.notify();
+  signalW.hasStartedSignal_.wait();
+
+  // Step 3: `C` now starts a fresh computation. Since the key is no longer in
+  // `_inProgress` and not yet in the cache, `C` becomes the "must compute"
+  // thread. It blocks on `signalC`, before calling `moveFromInProgressToCache`.
+  auto futC = std::async(std::launch::async, [&]() {
+    return cache.computeOnce(0, waiting_function("c"s, 0, &signalC), false,
+                             returnTrue);
+  });
+  signalC.hasStartedSignal_.wait();
+
+  // Let `W` finish: it inserts the key into the cache.
+  signalW.mayFinishSignal_.notify();
+  auto resultW = futW.get();
+  EXPECT_THAT(resultW._resultPointer, Pointee("w"s));
+  EXPECT_TRUE(cache.cacheContains(0));
+
+  // Let `C` finish: `moveFromInProgressToCache` now finds the key already
+  // present. Before the fix this threw; now the insert is skipped.
+  signalC.mayFinishSignal_.notify();
+  EXPECT_NO_THROW(futC.get());
+
+  // `A`'s computation completed normally (its result was just not cached).
+  EXPECT_THAT(futA.get()._resultPointer, Pointee("a"s));
+
+  // The in-progress entry was properly removed and the cache holds `W`'s value.
+  EXPECT_TRUE(cache.getStorage().wlock()->_inProgress.empty());
+  EXPECT_EQ(cache.numNonPinnedEntries(), 1);
+  auto contained = cache.getIfContained(0);
+  ASSERT_TRUE(contained.has_value());
+  EXPECT_THAT(contained->_resultPointer, Pointee("w"s));
+}
+
+// _____________________________________________________________________________
 TEST(ConcurrentCache, testTryInsertIfNotPresentDoesWorkCorrectly) {
   auto hasValue = [](std::string value) {
     using namespace ::testing;

--- a/test/ConcurrentCacheTest.cpp
+++ b/test/ConcurrentCacheTest.cpp
@@ -491,22 +491,23 @@ TEST(ConcurrentCache,
       ad_utility::Exception);
 }
 
-// _____________________________________________________________________________
 // Regression test for a race in `moveFromInProgressToCache`. A fresh
 // computation could end up inserting a key that a concurrent thread had already
 // inserted into the cache, which used to crash with "Trying to insert a cache
 // key which was already present". The deterministic interleaving is:
-//   1. Thread `A` computes the key, but its result is unsuitable for caching,
-//      so it deregisters the key from `_inProgress` and signals
-//      `finish(nullptr)` without inserting anything into the cache.
-//   2. Thread `W` was waiting for `A`. Because `A` finished with a null result
-//      (rather than throwing, which would make `W` throw as well), `W` falls
-//      back to computing the result itself and inserts it into the cache via
-//      the guarded `tryInsertIfNotPresent`.
-//   3. Thread `C` starts a fresh computation of the same key in the window
-//      after `A` deregistered the key but before `W` inserted it. `C`
-//      becomes the "must compute" thread and eventually calls
-//      `moveFromInProgressToCache` with the key already present in the cache.
+//
+// 1. Thread `A` computes the key, but its result is unsuitable for caching, so
+//    it deregisters the key from `_inProgress` and signals
+//    `finish(nullptr)` without inserting anything into the cache.
+// 2. Thread `W` was waiting for `A`. Because `A` finished with a null result
+//    (rather than throwing, which would make `W` throw as well), `W` falls
+//    back to computing the result itself and inserts it into the cache via
+//    the guarded `tryInsertIfNotPresent`.
+// 3. Thread `C` starts a fresh computation of the same key in the window
+//    after `A` deregistered the key but before `W` inserted it. `C`
+//    becomes the "must compute" thread and eventually calls
+//    `moveFromInProgressToCache` with the key already present in the cache.
+//
 // Before the fix, step 3 crashed; now the insert is skipped.
 TEST(ConcurrentCache, moveFromInProgressToCacheSkipsAlreadyPresentKey) {
   SimpleConcurrentLruCache cache{};


### PR DESCRIPTION
Under concurrent load, queries could sporadically fail with the error "Trying to insert a cache key which was already present" (an HTTP 500 for the client). The reason is that a result can be inserted into the query cache by a thread that is not registered as currently computing it: this happens when a registered computation produces a result that is unsuitable for caching (a thread that waited for it then computes and inserts the result itself), and when a lazy result is cached after it has been fully consumed. A thread that registered a fresh computation for the same key in the meantime then failed because it inserted its result unconditionally. This is now fixed by keeping the result that is already in the cache (results for the same key are interchangeable). Also fixed is a latent bug in the same code: the key was used again after it had been moved from, so that finished computations were not properly deregistered.

There is a new regression test that deterministically produces the interleaving described above and fails without the fix. The bug is unrelated to #2832, but became frequent in the evaluation of that PR (concurrent queries with continuous updates, which continually change the cache keys), where it occurred once every few seconds. Fixes #2030