### PR TITLE
Add runtime parameter `rebuild-index-scan-num-threads`

### DIFF
--- a/src/global/RuntimeParameters.cpp
+++ b/src/global/RuntimeParameters.cpp
@@ -27,6 +27,7 @@ RuntimeParameters::RuntimeParameters() {
   add(cacheMaxSizeSingleEntry_);
   add(lazyIndexScanQueueSize_);
   add(lazyIndexScanNumThreads_);
+  add(rebuildIndexScanNumThreads_);
   add(lazyIndexScanMaxSizeMaterialization_);
   add(useBinsearchTransitivePath_);
   add(groupByHashMapEnabled_);

--- a/src/global/RuntimeParameters.h
+++ b/src/global/RuntimeParameters.h
@@ -59,10 +59,9 @@ struct RuntimeParameters {
   // The number of threads used to read and decompress blocks during the scan of
   // the old permutations in a runtime index rebuild (see `IndexRebuilder`).
   // This read/decompress work dominates the rebuild's CPU usage, so lowering it
-  // reduces the rebuild's peak CPU - without affecting query scans, which are
-  // unaffected by this parameter. A value of 0 (the default) falls back to
-  // `lazy-index-scan-num-threads` (i.e. the same as query scans, which is the
-  // historical behavior).
+  // reduces the rebuild's peak CPU without affecting query scans. A value of 0
+  // (the default) falls back to `lazy-index-scan-num-threads`, the same value
+  // as for query scans, which is the historical behavior.
   SizeT rebuildIndexScanNumThreads_{0, "rebuild-index-scan-num-threads"};
   Duration<std::chrono::seconds> defaultQueryTimeout_{std::chrono::seconds(30),
                                                       "default-query-timeout"};

--- a/src/global/RuntimeParameters.h
+++ b/src/global/RuntimeParameters.h
@@ -56,6 +56,14 @@ struct RuntimeParameters {
       ad_utility::MemorySize::gigabytes(5), "cache-max-size-single-entry"};
   SizeT lazyIndexScanQueueSize_{20, "lazy-index-scan-queue-size"};
   SizeT lazyIndexScanNumThreads_{10, "lazy-index-scan-num-threads"};
+  // The number of threads used to read and decompress blocks during the scan of
+  // the old permutations in a runtime index rebuild (see `IndexRebuilder`).
+  // This read/decompress work dominates the rebuild's CPU usage, so lowering it
+  // reduces the rebuild's peak CPU - without affecting query scans, which are
+  // unaffected by this parameter. A value of 0 (the default) falls back to
+  // `lazy-index-scan-num-threads` (i.e. the same as query scans, which is the
+  // historical behavior).
+  SizeT rebuildIndexScanNumThreads_{0, "rebuild-index-scan-num-threads"};
   Duration<std::chrono::seconds> defaultQueryTimeout_{std::chrono::seconds(30),
                                                       "default-query-timeout"};
   SizeT lazyIndexScanMaxSizeMaterialization_{

--- a/src/global/RuntimeParameters.h
+++ b/src/global/RuntimeParameters.h
@@ -56,12 +56,14 @@ struct RuntimeParameters {
       ad_utility::MemorySize::gigabytes(5), "cache-max-size-single-entry"};
   SizeT lazyIndexScanQueueSize_{20, "lazy-index-scan-queue-size"};
   SizeT lazyIndexScanNumThreads_{10, "lazy-index-scan-num-threads"};
-  // The number of threads used to read and decompress blocks during the scan of
-  // the old permutations in a runtime index rebuild (see `IndexRebuilder`).
-  // This read/decompress work dominates the rebuild's CPU usage, so lowering it
-  // reduces the rebuild's peak CPU without affecting query scans. A value of 0
-  // (the default) falls back to `lazy-index-scan-num-threads`, the same value
-  // as for query scans, which is the historical behavior.
+  // The number of threads used to read and decompress blocks when scanning
+  // permutations during a runtime index rebuild (see `IndexRebuilder`), both
+  // for the main scan of the old permutations and for the statistics
+  // recomputation. This read/decompress work dominates the rebuild's CPU
+  // usage, so lowering it reduces the rebuild's peak CPU without affecting
+  // query scans. A value of 0 (the default) falls back to
+  // `lazy-index-scan-num-threads`, the same value as for query scans, which is
+  // the historical behavior.
   SizeT rebuildIndexScanNumThreads_{0, "rebuild-index-scan-num-threads"};
   Duration<std::chrono::seconds> defaultQueryTimeout_{std::chrono::seconds(30),
                                                       "default-query-timeout"};

--- a/src/index/CompressedRelation.cpp
+++ b/src/index/CompressedRelation.cpp
@@ -178,8 +178,11 @@ CompressedRelationReader::asyncParallelBlockGenerator(
           reader_{reader} {}
 
     void start() {
-      auto numThreads{
-          getRuntimeParameter<&RuntimeParameters::lazyIndexScanNumThreads_>()};
+      // The rebuild's dedicated reader may override the thread count (to reduce
+      // the rebuild's peak CPU); otherwise use the runtime parameter, which is
+      // what all query scans use.
+      auto numThreads{reader_->lazyScanNumThreadsOverride_.value_or(
+          getRuntimeParameter<&RuntimeParameters::lazyIndexScanNumThreads_>())};
       auto queueSize{
           getRuntimeParameter<&RuntimeParameters::lazyIndexScanQueueSize_>()};
       auto producer{std::bind(&Generator::readAndDecompressBlock, this)};

--- a/src/index/CompressedRelation.h
+++ b/src/index/CompressedRelation.h
@@ -7,6 +7,7 @@
 
 #include <gtest/gtest_prod.h>
 
+#include <optional>
 #include <vector>
 
 #include "backports/algorithm.h"
@@ -545,6 +546,15 @@ class CompressedRelationReader {
   using ColumnIndicesRef = ql::span<const ColumnIndex>;
   using ColumnIndices = std::vector<ColumnIndex>;
   using CancellationHandle = ad_utility::SharedCancellationHandle;
+
+  // Optional override for the number of threads used to read and decompress
+  // blocks in `asyncParallelBlockGenerator`. When set, it takes precedence over
+  // the `lazy-index-scan-num-threads` runtime parameter. This is used by the
+  // runtime index rebuild, which scans the old permutations through a dedicated
+  // reader (see `Permutation::lazyScanWithUnlimitedReader`), to throttle its
+  // read/decompress parallelism without affecting query scans (which use the
+  // permutation's shared reader, where this stays `nullopt`).
+  std::optional<size_t> lazyScanNumThreadsOverride_ = std::nullopt;
 
   // This struct stores a reference to the (optional) graphs by which a result
   // is filtered, the column in which the graph ID will reside in a result,

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -22,6 +22,7 @@
 #include "CompilationInfo.h"
 #include "backports/algorithm.h"
 #include "engine/AddCombinedRowToTable.h"
+#include "global/RuntimeParameters.h"
 #include "index/Index.h"
 #include "index/IndexFormatVersion.h"
 #include "index/VocabularyMerger.h"
@@ -2067,9 +2068,20 @@ std::packaged_task<void()> computeStatistics(
         std::make_shared<ad_utility::SharedCancellationHandle::element_type>();
     ScanSpecification scanSpec{std::nullopt, std::nullopt, std::nullopt};
     std::array<ColumnIndex, 1> additionalColumns{ADDITIONAL_COLUMN_GRAPH_ID};
+    // The statistics are only recomputed as part of a runtime index rebuild
+    // (see `IndexRebuilder`), so this scan is also throttled by
+    // `rebuild-index-scan-num-threads` (several permutations are scanned in
+    // parallel, so without the throttle this short phase has a high peak
+    // CPU). A value of 0 means "fall back to `lazy-index-scan-num-threads`".
+    auto rebuildScanThreads =
+        getRuntimeParameter<&RuntimeParameters::rebuildIndexScanNumThreads_>();
+    std::optional<size_t> numThreadsOverride =
+        rebuildScanThreads == 0 ? std::nullopt
+                                : std::optional<size_t>{rebuildScanThreads};
     auto [reader, tables] = permutation.lazyScanWithUnlimitedReader(
         permutation.getScanSpecAndBlocks(scanSpec, *locatedTriplesSharedState),
-        additionalColumns, cancellationHandle, *locatedTriplesSharedState);
+        additionalColumns, cancellationHandle, *locatedTriplesSharedState,
+        numThreadsOverride);
     std::optional<Id> lastCol0 = std::nullopt;
     for (const auto& table : tables) {
       std::invoke(customAction, table);

--- a/src/index/IndexRebuilder.cpp
+++ b/src/index/IndexRebuilder.cpp
@@ -28,6 +28,7 @@
 #include "backports/algorithm.h"
 #include "engine/idTable/IdTable.h"
 #include "global/Id.h"
+#include "global/RuntimeParameters.h"
 #include "index/IndexImpl.h"
 #include "index/IndexRebuilderImpl.h"
 #include "index/LocalVocabEntry.h"
@@ -252,9 +253,18 @@ ad_utility::InputRangeTypeErased<IdTableStatic<0>> readIndexAndRemap(
   Permutation::ScanSpecAndBlocks scanSpecAndBlocks{
       ScanSpecification{std::nullopt, std::nullopt, std::nullopt},
       blockMetadataRanges};
+  // A value of 0 means "fall back to `lazy-index-scan-num-threads`" (the same
+  // thread count as query scans); a positive value throttles the rebuild's
+  // read/decompress parallelism only, reducing its peak CPU without touching
+  // queries.
+  auto rebuildScanThreads =
+      getRuntimeParameter<&RuntimeParameters::rebuildIndexScanNumThreads_>();
+  std::optional<size_t> numThreadsOverride =
+      rebuildScanThreads == 0 ? std::nullopt
+                              : std::optional<size_t>{rebuildScanThreads};
   auto [reader, fullScan] = permutation.lazyScanWithUnlimitedReader(
       scanSpecAndBlocks, additionalColumns, cancellationHandle,
-      *locatedTriplesSharedState);
+      *locatedTriplesSharedState, numThreadsOverride);
 
   auto remapId = [&insertionPositions, &localVocabMapping, &blankNodeBlocks,
                   minBlankNodeIndex, lastId = Id::makeUndefined(),

--- a/src/index/Permutation.cpp
+++ b/src/index/Permutation.cpp
@@ -246,10 +246,14 @@ Permutation::LazyScanWithReader Permutation::lazyScanWithUnlimitedReader(
     const ScanSpecAndBlocks& scanSpecAndBlocks,
     ColumnIndicesRef additionalColumns,
     const CancellationHandle& cancellationHandle,
-    const LocatedTriplesState& locatedTriplesState) const {
+    const LocatedTriplesState& locatedTriplesState,
+    std::optional<size_t> numThreadsOverride) const {
   auto independentReader = std::make_unique<CompressedRelationReader>(
       reader().makeReaderWithReboundAllocator(
           ad_utility::makeUnlimitedAllocator<Id>()));
+  // Applies only to this dedicated reader; query scans use the shared reader
+  // and are unaffected.
+  independentReader->lazyScanNumThreadsOverride_ = numThreadsOverride;
   auto blocks = lazyScanImpl(*independentReader, scanSpecAndBlocks,
                              std::nullopt, additionalColumns,
                              cancellationHandle, locatedTriplesState, {});

--- a/src/index/Permutation.h
+++ b/src/index/Permutation.h
@@ -162,11 +162,18 @@ class Permutation {
   // `CompressedRelationReader` with an unlimited-memory allocator instead of
   // this permutation's shared reader. This allows the scan to run independently
   // of memory constraints imposed on most queries.
+  //
+  // `numThreadsOverride`, if set, overrides the number of block read/decompress
+  // threads for this scan (otherwise the `lazy-index-scan-num-threads` runtime
+  // parameter is used, as for query scans). The runtime index rebuild uses this
+  // to throttle its read parallelism (and hence peak CPU) without affecting
+  // queries.
   LazyScanWithReader lazyScanWithUnlimitedReader(
       const ScanSpecAndBlocks& scanSpecAndBlocks,
       ColumnIndicesRef additionalColumns,
       const CancellationHandle& cancellationHandle,
-      const LocatedTriplesState& locatedTriplesState) const;
+      const LocatedTriplesState& locatedTriplesState,
+      std::optional<size_t> numThreadsOverride = std::nullopt) const;
 
   // Returns the corresponding `CompressedRelationReader::ScanSpecAndBlocks`
   // with relevant `BlockMetadataRanges`.

--- a/test/index/IndexRebuilderTest.cpp
+++ b/test/index/IndexRebuilderTest.cpp
@@ -19,6 +19,7 @@
 #include "../util/IdTableHelpers.h"
 #include "../util/IdTestHelpers.h"
 #include "../util/IndexTestHelpers.h"
+#include "../util/RuntimeParametersTestHelpers.h"
 #include "../util/TripleComponentTestHelpers.h"
 #include "backports/filesystem.h"
 #include "engine/Server.h"
@@ -750,4 +751,42 @@ TEST(IndexRebuilder, serverIntegration) {
       ::testing::HasSubstr("not located in the same directory"));
 
   threadPool.join();
+}
+
+// _____________________________________________________________________________
+// The thread-count override for the rebuild's scans must be set on the
+// dedicated reader created by `lazyScanWithUnlimitedReader` (and only there);
+// the permutation's shared reader, which is used by the query scans, must
+// never carry an override.
+TEST(IndexRebuilder, lazyScanNumThreadsOverride) {
+  auto index = ad_utility::testing::makeTestIndex("lazyScanNumThreadsOverride",
+                                                  "<a> <b> <c> .");
+  const auto& permutation =
+      index.getImpl().getPermutation(Permutation::Enum::PSO);
+  auto cancellationHandle =
+      std::make_shared<ad_utility::SharedCancellationHandle::element_type>();
+  auto state =
+      index.deltaTriplesManager().getCurrentLocatedTriplesSharedState();
+  ScanSpecification scanSpec{std::nullopt, std::nullopt, std::nullopt};
+  std::array<ColumnIndex, 1> additionalColumns{ADDITIONAL_COLUMN_GRAPH_ID};
+
+  auto scanWithOverride = [&](std::optional<size_t> numThreadsOverride) {
+    return permutation.lazyScanWithUnlimitedReader(
+        permutation.getScanSpecAndBlocks(scanSpec, *state), additionalColumns,
+        cancellationHandle, *state, numThreadsOverride);
+  };
+  auto [reader, scan] = scanWithOverride(3);
+  EXPECT_EQ(reader->lazyScanNumThreadsOverride_, std::optional<size_t>{3});
+  auto [readerDefault, scanDefault] = scanWithOverride(std::nullopt);
+  EXPECT_EQ(readerDefault->lazyScanNumThreadsOverride_, std::nullopt);
+  EXPECT_EQ(permutation.reader().lazyScanNumThreadsOverride_, std::nullopt);
+
+  // Recomputing the statistics with the throttle set must give exactly the
+  // same result as with the default (0, which means "fall back to
+  // `lazy-index-scan-num-threads`"). This exercises the translation of the
+  // runtime parameter to the override at both of its use sites.
+  auto statsDefault = index.getImpl().recomputeStatistics(state);
+  auto cleanup = setRuntimeParameterForTest<
+      &RuntimeParameters::rebuildIndexScanNumThreads_>(2);
+  EXPECT_EQ(index.getImpl().recomputeStatistics(state), statsDefault);
 }


### PR DESCRIPTION
During a runtime index rebuild (part of the ongoing work in #2832), the old permutations are scanned to build the new ones, and reading and decompressing the blocks of those scans dominates the rebuild's CPU usage. The number of threads for this was so far governed by `lazy-index-scan-num-threads`, which also governs the scans of normal queries, so the rebuild's CPU usage could not be reduced without also throttling queries. There is now a runtime parameter `rebuild-index-scan-num-threads` that applies only to the scans of the rebuild: both the main scan of the old permutations and the statistics recomputation, which scans four permutations in parallel and hence has a high peak CPU despite being short. The default is 0, which falls back to `lazy-index-scan-num-threads` (the previous behavior). On a 16-core machine serving live queries, a value of 2 reduced the rebuild's CPU usage by roughly ten cores, at the cost of about 20% longer rebuild time.