### PR TITLE
Record the index build datetime in the `.meta-data.json`

### DIFF
--- a/src/global/Constants.h
+++ b/src/global/Constants.h
@@ -227,6 +227,11 @@ constexpr inline std::string_view VOCAB_SUFFIX = ".vocabulary";
 constexpr inline std::string_view META_FILE_SUFFIX = ".meta";
 constexpr inline std::string_view CONFIGURATION_FILE = ".meta-data.json";
 
+// The datetime format used for the `date-of-index-build` entry in the index
+// configuration (the time when the build started), e.g.
+// `2026-07-12T14:03:52Z` (UTC).
+constexpr inline const char* DATE_OF_INDEX_BUILD_FORMAT = "%Y-%m-%dT%H:%M:%SZ";
+
 constexpr inline std::string_view ERROR_IGNORE_CASE_UNSUPPORTED =
     "Key \"ignore-case\" is no longer supported. Please remove this key from "
     "your settings.json and rebuild your index. You can optionally specify the "

--- a/src/global/Constants.h
+++ b/src/global/Constants.h
@@ -234,7 +234,8 @@ constexpr std::string_view DATE_OF_INDEX_BUILD_KEY = "date-of-index-build";
 // The datetime format used for the `date-of-index-build` entry in the index
 // configuration (the time when the build started), e.g.
 // `2026-07-12T14:03:52Z` (UTC).
-constexpr inline const char* DATE_OF_INDEX_BUILD_FORMAT = "%Y-%m-%dT%H:%M:%SZ";
+constexpr inline std::string_view DATE_OF_INDEX_BUILD_FORMAT =
+    "%Y-%m-%dT%H:%M:%SZ";
 
 constexpr inline std::string_view ERROR_IGNORE_CASE_UNSUPPORTED =
     "Key \"ignore-case\" is no longer supported. Please remove this key from "

--- a/src/global/Constants.h
+++ b/src/global/Constants.h
@@ -214,6 +214,10 @@ constexpr std::string_view VOCAB_SUFFIX = ".vocabulary";
 constexpr std::string_view META_FILE_SUFFIX = ".meta";
 constexpr std::string_view CONFIGURATION_FILE = ".meta-data.json";
 
+// The key under which the datetime when the index build started is stored in
+// the index configuration.
+constexpr std::string_view DATE_OF_INDEX_BUILD_KEY = "date-of-index-build";
+
 // The datetime format used for the `date-of-index-build` entry in the index
 // configuration (the time when the build started), e.g.
 // `2026-07-12T14:03:52Z` (UTC).

--- a/src/global/Constants.h
+++ b/src/global/Constants.h
@@ -18,31 +18,32 @@
 // For access to `memorySize` literals.
 using namespace ad_utility::memory_literals;
 
-constexpr ad_utility::MemorySize DEFAULT_MEMORY_LIMIT_INDEX_BUILDING = 5_GB;
-constexpr ad_utility::MemorySize DEFAULT_PARSER_BUFFER_SIZE = 10_MB;
+constexpr inline ad_utility::MemorySize DEFAULT_MEMORY_LIMIT_INDEX_BUILDING =
+    5_GB;
+constexpr inline ad_utility::MemorySize DEFAULT_PARSER_BUFFER_SIZE = 10_MB;
 
-constexpr ad_utility::MemorySize DEFAULT_MEM_FOR_QUERIES = 4_GB;
+constexpr inline ad_utility::MemorySize DEFAULT_MEM_FOR_QUERIES = 4_GB;
 
-constexpr uint64_t MAX_NOF_ROWS_IN_RESULT = 1'000'000;
-constexpr size_t MIN_WORD_PREFIX_SIZE = 4;
-constexpr char PREFIX_CHAR = '*';
+constexpr inline uint64_t MAX_NOF_ROWS_IN_RESULT = 1'000'000;
+constexpr inline size_t MIN_WORD_PREFIX_SIZE = 4;
+constexpr inline char PREFIX_CHAR = '*';
 
-constexpr size_t BUFFER_SIZE_DOCSFILE_LINE = 100'000'000;
+constexpr inline size_t BUFFER_SIZE_DOCSFILE_LINE = 100'000'000;
 
-constexpr size_t TEXT_PREDICATE_CARDINALITY_ESTIMATE = 1'000'000'000;
+constexpr inline size_t TEXT_PREDICATE_CARDINALITY_ESTIMATE = 1'000'000'000;
 
-constexpr size_t GALLOP_THRESHOLD = 1000;
+constexpr inline size_t GALLOP_THRESHOLD = 1000;
 
-constexpr char QLEVER_INTERNAL_PREFIX_NAME[] = "ql";
-constexpr std::string_view QLEVER_INTERNAL_PREFIX_URL =
+constexpr inline char QLEVER_INTERNAL_PREFIX_NAME[] = "ql";
+constexpr inline std::string_view QLEVER_INTERNAL_PREFIX_URL =
     "http://qlever.cs.uni-freiburg.de/builtin-functions/";
 
 // Make a QLever-internal IRI from `QL_INTERNAL_PREFIX_URL` by appending the
 // concatenation of the given `suffixes` and enclosing the result in angle
 // brackets (const and non-const version).
 namespace string_constants::detail {
-constexpr std::string_view openAngle = "<";
-constexpr std::string_view closeAngle = ">";
+constexpr inline std::string_view openAngle = "<";
+constexpr inline std::string_view closeAngle = ">";
 }  // namespace string_constants::detail
 template <const std::string_view&... suffixes>
 constexpr std::string_view makeQleverInternalIriConst() {
@@ -56,53 +57,54 @@ inline std::string makeQleverInternalIri(const T&... suffixes) {
 }
 
 namespace string_constants::detail {
-constexpr std::string_view empty = "";
+constexpr inline std::string_view empty = "";
 }  // namespace string_constants::detail
-constexpr std::string_view QLEVER_INTERNAL_PREFIX_IRI =
+constexpr inline std::string_view QLEVER_INTERNAL_PREFIX_IRI =
     makeQleverInternalIriConst<string_constants::detail::empty>();
-constexpr std::string_view QLEVER_INTERNAL_PREFIX_IRI_WITHOUT_CLOSING_BRACKET =
-    ad_utility::constexprStrCat<string_constants::detail::openAngle,
-                                QLEVER_INTERNAL_PREFIX_URL>();
+constexpr inline std::string_view
+    QLEVER_INTERNAL_PREFIX_IRI_WITHOUT_CLOSING_BRACKET =
+        ad_utility::constexprStrCat<string_constants::detail::openAngle,
+                                    QLEVER_INTERNAL_PREFIX_URL>();
 namespace string_constants::detail {
-constexpr std::string_view contains_entity = "contains-entity";
+constexpr inline std::string_view contains_entity = "contains-entity";
 }  // namespace string_constants::detail
-constexpr std::string_view CONTAINS_ENTITY_PREDICATE =
+constexpr inline std::string_view CONTAINS_ENTITY_PREDICATE =
     makeQleverInternalIriConst<string_constants::detail::contains_entity>();
 namespace string_constants::detail {
-constexpr std::string_view contains_word = "contains-word";
+constexpr inline std::string_view contains_word = "contains-word";
 }  // namespace string_constants::detail
-constexpr std::string_view CONTAINS_WORD_PREDICATE =
+constexpr inline std::string_view CONTAINS_WORD_PREDICATE =
     makeQleverInternalIriConst<string_constants::detail::contains_word>();
 
 namespace string_constants::detail {
-constexpr std::string_view text = "text";
+constexpr inline std::string_view text = "text";
 }  // namespace string_constants::detail
-constexpr std::string_view QLEVER_INTERNAL_TEXT_MATCH_PREDICATE =
+constexpr inline std::string_view QLEVER_INTERNAL_TEXT_MATCH_PREDICATE =
     makeQleverInternalIriConst<string_constants::detail::text>();
 namespace string_constants::detail {
-constexpr std::string_view has_predicate = "has-predicate";
+constexpr inline std::string_view has_predicate = "has-predicate";
 }  // namespace string_constants::detail
-constexpr std::string_view HAS_PREDICATE_PREDICATE =
+constexpr inline std::string_view HAS_PREDICATE_PREDICATE =
     makeQleverInternalIriConst<string_constants::detail::has_predicate>();
 namespace string_constants::detail {
-constexpr std::string_view has_pattern = "has-pattern";
+constexpr inline std::string_view has_pattern = "has-pattern";
 }  // namespace string_constants::detail
-constexpr std::string_view HAS_PATTERN_PREDICATE =
+constexpr inline std::string_view HAS_PATTERN_PREDICATE =
     makeQleverInternalIriConst<string_constants::detail::has_pattern>();
 namespace string_constants::detail {
-constexpr std::string_view default_graph = "default-graph";
+constexpr inline std::string_view default_graph = "default-graph";
 }  // namespace string_constants::detail
-constexpr std::string_view DEFAULT_GRAPH_IRI =
+constexpr inline std::string_view DEFAULT_GRAPH_IRI =
     makeQleverInternalIriConst<string_constants::detail::default_graph>();
 namespace string_constants::detail {
-constexpr std::string_view internal_graph = "internal-graph";
+constexpr inline std::string_view internal_graph = "internal-graph";
 }  // namespace string_constants::detail
-constexpr std::string_view QLEVER_INTERNAL_GRAPH_IRI =
+constexpr inline std::string_view QLEVER_INTERNAL_GRAPH_IRI =
     makeQleverInternalIriConst<string_constants::detail::internal_graph>();
 namespace string_constants::detail {
-constexpr std::string_view blank_node_prefix = "blank-node/";
+constexpr inline std::string_view blank_node_prefix = "blank-node/";
 }  // namespace string_constants::detail
-constexpr std::string_view QLEVER_INTERNAL_BLANK_NODE_IRI_PREFIX =
+constexpr inline std::string_view QLEVER_INTERNAL_BLANK_NODE_IRI_PREFIX =
     ad_utility::constexprStrCat<string_constants::detail::openAngle,
                                 QLEVER_INTERNAL_PREFIX_URL,
                                 string_constants::detail::blank_node_prefix>();
@@ -110,98 +112,109 @@ constexpr std::string_view QLEVER_INTERNAL_BLANK_NODE_IRI_PREFIX =
 // The prefix of the new graph IRIs that are generated when a Graph Store
 // Protocol PUT is made without specifying a graph.
 namespace string_constants::detail {
-constexpr std::string_view new_graph_prefix = "graph/";
+constexpr inline std::string_view new_graph_prefix = "graph/";
 }  // namespace string_constants::detail
-constexpr std::string_view QLEVER_NEW_GRAPH_PREFIX =
+constexpr inline std::string_view QLEVER_NEW_GRAPH_PREFIX =
     ad_utility::constexprStrCat<QLEVER_INTERNAL_PREFIX_URL,
                                 string_constants::detail::new_graph_prefix>();
 
 // The prefix of the SERVICE IRI used for a cached result with a name. Use as
 // in `SERVICE <ql:cached-result-with-name-$query-name$> {}`.
 namespace string_constants::detail {
-constexpr std::string_view cachedResultWithNamePrefix =
+constexpr inline std::string_view cachedResultWithNamePrefix =
     "cached-result-with-name-";
 }  // namespace string_constants::detail
-constexpr std::string_view CACHED_RESULT_WITH_NAME_PREFIX =
+constexpr inline std::string_view CACHED_RESULT_WITH_NAME_PREFIX =
     ad_utility::constexprStrCat<
         QLEVER_INTERNAL_PREFIX_URL,
         string_constants::detail::cachedResultWithNamePrefix>();
 
-constexpr std::pair<std::string_view, std::string_view> GEOF_PREFIX = {
+constexpr inline std::pair<std::string_view, std::string_view> GEOF_PREFIX = {
     "geof:", "http://www.opengis.net/def/function/geosparql/"};
-constexpr std::pair<std::string_view, std::string_view> MATH_PREFIX = {
+constexpr inline std::pair<std::string_view, std::string_view> MATH_PREFIX = {
     "math:", "http://www.w3.org/2005/xpath-functions/math#"};
-constexpr std::pair<std::string_view, std::string_view> XSD_PREFIX = {
+constexpr inline std::pair<std::string_view, std::string_view> XSD_PREFIX = {
     "xsd", "http://www.w3.org/2001/XMLSchema#"};
-constexpr std::pair<std::string_view, std::string_view> QL_PREFIX = {
+constexpr inline std::pair<std::string_view, std::string_view> QL_PREFIX = {
     QLEVER_INTERNAL_PREFIX_NAME, QLEVER_INTERNAL_PREFIX_URL};
 
-constexpr std::string_view QLEVER_INTERNAL_VARIABLE_PREFIX =
+constexpr inline std::string_view QLEVER_INTERNAL_VARIABLE_PREFIX =
     "?_QLever_internal_variable_";
 
-constexpr std::string_view QLEVER_INTERNAL_BLANKNODE_VARIABLE_PREFIX =
+constexpr inline std::string_view QLEVER_INTERNAL_BLANKNODE_VARIABLE_PREFIX =
     "?_QLever_internal_variable_bn_";
 
-constexpr std::string_view QLEVER_INTERNAL_VARIABLE_QUERY_PLANNER_PREFIX =
-    "?_QLever_internal_variable_qp_";
+constexpr inline std::string_view
+    QLEVER_INTERNAL_VARIABLE_QUERY_PLANNER_PREFIX =
+        "?_QLever_internal_variable_qp_";
 
-constexpr std::string_view SCORE_VARIABLE_PREFIX = "?ql_score_";
-constexpr std::string_view MATCHINGWORD_VARIABLE_PREFIX = "?ql_matchingword_";
+constexpr inline std::string_view SCORE_VARIABLE_PREFIX = "?ql_score_";
+constexpr inline std::string_view MATCHINGWORD_VARIABLE_PREFIX =
+    "?ql_matchingword_";
 
 namespace constants::details::strings {
-constexpr std::string_view langtag{"langtag"};
-constexpr std::string_view hasWord{"has-word"};
+constexpr inline std::string_view langtag{"langtag"};
+constexpr inline std::string_view hasWord{"has-word"};
 }  // namespace constants::details::strings
-constexpr std::string_view LANGUAGE_PREDICATE =
+constexpr inline std::string_view LANGUAGE_PREDICATE =
     makeQleverInternalIriConst<constants::details::strings::langtag>();
-constexpr std::string_view HAS_WORD_PREDICATE =
+constexpr inline std::string_view HAS_WORD_PREDICATE =
     makeQleverInternalIriConst<constants::details::strings::hasWord>();
 
 // TODO<joka921> Move them to their own file, make them strings, remove
 // duplications, etc.
-constexpr char XSD_STRING[] = "http://www.w3.org/2001/XMLSchema#string";
-constexpr char XSD_DATETIME_TYPE[] =
+constexpr inline char XSD_STRING[] = "http://www.w3.org/2001/XMLSchema#string";
+constexpr inline char XSD_DATETIME_TYPE[] =
     "http://www.w3.org/2001/XMLSchema#dateTime";
-constexpr char XSD_DATE_TYPE[] = "http://www.w3.org/2001/XMLSchema#date";
-constexpr char XSD_GYEAR_TYPE[] = "http://www.w3.org/2001/XMLSchema#gYear";
-constexpr char XSD_GYEARMONTH_TYPE[] =
+constexpr inline char XSD_DATE_TYPE[] = "http://www.w3.org/2001/XMLSchema#date";
+constexpr inline char XSD_GYEAR_TYPE[] =
+    "http://www.w3.org/2001/XMLSchema#gYear";
+constexpr inline char XSD_GYEARMONTH_TYPE[] =
     "http://www.w3.org/2001/XMLSchema#gYearMonth";
-constexpr char XSD_DAYTIME_DURATION_TYPE[] =
+constexpr inline char XSD_DAYTIME_DURATION_TYPE[] =
     "http://www.w3.org/2001/XMLSchema#dayTimeDuration";
 
-constexpr char XSD_INT_TYPE[] = "http://www.w3.org/2001/XMLSchema#int";
-constexpr char XSD_INTEGER_TYPE[] = "http://www.w3.org/2001/XMLSchema#integer";
-constexpr char XSD_FLOAT_TYPE[] = "http://www.w3.org/2001/XMLSchema#float";
-constexpr char XSD_DOUBLE_TYPE[] = "http://www.w3.org/2001/XMLSchema#double";
-constexpr char XSD_DECIMAL_TYPE[] = "http://www.w3.org/2001/XMLSchema#decimal";
+constexpr inline char XSD_INT_TYPE[] = "http://www.w3.org/2001/XMLSchema#int";
+constexpr inline char XSD_INTEGER_TYPE[] =
+    "http://www.w3.org/2001/XMLSchema#integer";
+constexpr inline char XSD_FLOAT_TYPE[] =
+    "http://www.w3.org/2001/XMLSchema#float";
+constexpr inline char XSD_DOUBLE_TYPE[] =
+    "http://www.w3.org/2001/XMLSchema#double";
+constexpr inline char XSD_DECIMAL_TYPE[] =
+    "http://www.w3.org/2001/XMLSchema#decimal";
 
-constexpr char XSD_NON_POSITIVE_INTEGER_TYPE[] =
+constexpr inline char XSD_NON_POSITIVE_INTEGER_TYPE[] =
     "http://www.w3.org/2001/XMLSchema#nonPositiveInteger";
-constexpr char XSD_NEGATIVE_INTEGER_TYPE[] =
+constexpr inline char XSD_NEGATIVE_INTEGER_TYPE[] =
     "http://www.w3.org/2001/XMLSchema#negativeInteger";
-constexpr char XSD_LONG_TYPE[] = "http://www.w3.org/2001/XMLSchema#long";
-constexpr char XSD_SHORT_TYPE[] = "http://www.w3.org/2001/XMLSchema#short";
-constexpr char XSD_BYTE_TYPE[] = "http://www.w3.org/2001/XMLSchema#byte";
-constexpr char XSD_NON_NEGATIVE_INTEGER_TYPE[] =
+constexpr inline char XSD_LONG_TYPE[] = "http://www.w3.org/2001/XMLSchema#long";
+constexpr inline char XSD_SHORT_TYPE[] =
+    "http://www.w3.org/2001/XMLSchema#short";
+constexpr inline char XSD_BYTE_TYPE[] = "http://www.w3.org/2001/XMLSchema#byte";
+constexpr inline char XSD_NON_NEGATIVE_INTEGER_TYPE[] =
     "http://www.w3.org/2001/XMLSchema#nonNegativeInteger";
-constexpr char XSD_UNSIGNED_LONG_TYPE[] =
+constexpr inline char XSD_UNSIGNED_LONG_TYPE[] =
     "http://www.w3.org/2001/XMLSchema#unsignedLong";
-constexpr char XSD_UNSIGNED_INT_TYPE[] =
+constexpr inline char XSD_UNSIGNED_INT_TYPE[] =
     "http://www.w3.org/2001/XMLSchema#unsignedInt";
-constexpr char XSD_UNSIGNED_SHORT_TYPE[] =
+constexpr inline char XSD_UNSIGNED_SHORT_TYPE[] =
     "http://www.w3.org/2001/XMLSchema#unsignedShort";
-constexpr char XSD_POSITIVE_INTEGER_TYPE[] =
+constexpr inline char XSD_POSITIVE_INTEGER_TYPE[] =
     "http://www.w3.org/2001/XMLSchema#positiveInteger";
-constexpr char XSD_BOOLEAN_TYPE[] = "http://www.w3.org/2001/XMLSchema#boolean";
-constexpr char XSD_ANYURI_TYPE[] = "http://www.w3.org/2001/XMLSchema#anyURI";
-constexpr char RDF_PREFIX[] = "http://www.w3.org/1999/02/22-rdf-syntax-ns#";
-constexpr char RDF_LANGTAG_STRING[] =
+constexpr inline char XSD_BOOLEAN_TYPE[] =
+    "http://www.w3.org/2001/XMLSchema#boolean";
+constexpr inline char XSD_ANYURI_TYPE[] =
+    "http://www.w3.org/2001/XMLSchema#anyURI";
+constexpr inline char RDF_PREFIX[] =
+    "http://www.w3.org/1999/02/22-rdf-syntax-ns#";
+constexpr inline char RDF_LANGTAG_STRING[] =
     "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString";
 
-constexpr std::string_view GEO_WKT_LITERAL =
+constexpr inline std::string_view GEO_WKT_LITERAL =
     "http://www.opengis.net/ont/geosparql#wktLiteral";
 namespace string_constants::detail {
-constexpr std::string_view geo_literal_prefix = "\"^^<";
+constexpr inline std::string_view geo_literal_prefix = "\"^^<";
 }  // namespace string_constants::detail
 static constexpr std::string_view GEO_LITERAL_SUFFIX =
     ad_utility::constexprStrCat<string_constants::detail::geo_literal_prefix,
@@ -210,9 +223,9 @@ static constexpr std::string_view GEO_LITERAL_SUFFIX =
 
 constexpr std::string_view SF_PREFIX = "http://www.opengis.net/ont/sf#";
 
-constexpr std::string_view VOCAB_SUFFIX = ".vocabulary";
-constexpr std::string_view META_FILE_SUFFIX = ".meta";
-constexpr std::string_view CONFIGURATION_FILE = ".meta-data.json";
+constexpr inline std::string_view VOCAB_SUFFIX = ".vocabulary";
+constexpr inline std::string_view META_FILE_SUFFIX = ".meta";
+constexpr inline std::string_view CONFIGURATION_FILE = ".meta-data.json";
 
 // The key under which the datetime when the index build started is stored in
 // the index configuration.
@@ -221,13 +234,13 @@ constexpr std::string_view DATE_OF_INDEX_BUILD_KEY = "date-of-index-build";
 // The datetime format used for the `date-of-index-build` entry in the index
 // configuration (the time when the build started), e.g.
 // `2026-07-12T14:03:52Z` (UTC).
-constexpr const char* DATE_OF_INDEX_BUILD_FORMAT = "%Y-%m-%dT%H:%M:%SZ";
+constexpr inline const char* DATE_OF_INDEX_BUILD_FORMAT = "%Y-%m-%dT%H:%M:%SZ";
 
-constexpr std::string_view ERROR_IGNORE_CASE_UNSUPPORTED =
+constexpr inline std::string_view ERROR_IGNORE_CASE_UNSUPPORTED =
     "Key \"ignore-case\" is no longer supported. Please remove this key from "
     "your settings.json and rebuild your index. You can optionally specify the "
     "\"locale\" key, otherwise \"en.US\" will be used as default";
-constexpr std::string_view WARNING_ASCII_ONLY_PREFIXES =
+constexpr inline std::string_view WARNING_ASCII_ONLY_PREFIXES =
     "You specified \"ascii-prefixes-only = true\", which enables faster "
     "parsing for well-behaved TTL files";
 // " but only works correctly if there are no escape sequences in "
@@ -236,12 +249,12 @@ constexpr std::string_view WARNING_ASCII_ONLY_PREFIXES =
 // "Most Turtle files fulfill these properties (e.g. that from Wikidata), "
 // "but not all";
 
-constexpr std::string_view WARNING_PARALLEL_PARSING =
+constexpr inline std::string_view WARNING_PARALLEL_PARSING =
     "You specified \"parallel-parsing = true\", which enables faster parsing "
     "for TTL files with a well-behaved use of newlines";
-constexpr std::string_view LOCALE_DEFAULT_LANG = "en";
-constexpr std::string_view LOCALE_DEFAULT_COUNTRY = "US";
-constexpr bool LOCALE_DEFAULT_IGNORE_PUNCTUATION = false;
+constexpr inline std::string_view LOCALE_DEFAULT_LANG = "en";
+constexpr inline std::string_view LOCALE_DEFAULT_COUNTRY = "US";
+constexpr inline bool LOCALE_DEFAULT_IGNORE_PUNCTUATION = false;
 
 // Constants for the range of valid compression prefixes
 // all ASCII- printable characters are left out.
@@ -250,20 +263,20 @@ constexpr bool LOCALE_DEFAULT_IGNORE_PUNCTUATION = false;
 // All prefix codes have a most significant bit of 1. This means the prefix
 // codes are never valid UTF-8 and thus it is always able to determine, whether
 // this vocabulary was compressed or not.
-constexpr uint8_t MIN_COMPRESSION_PREFIX = 129;
-constexpr uint8_t NUM_COMPRESSION_PREFIXES = 126;
+constexpr inline uint8_t MIN_COMPRESSION_PREFIX = 129;
+constexpr inline uint8_t NUM_COMPRESSION_PREFIXES = 126;
 // if this is the first character of a compressed string, this means that no
 // compression has been applied to  a word
-constexpr uint8_t NO_PREFIX_CHAR =
+constexpr inline uint8_t NO_PREFIX_CHAR =
     MIN_COMPRESSION_PREFIX + NUM_COMPRESSION_PREFIXES;
 
 // When initializing a sort performance estimator, at most this percentage of
 // the number of triples in the index is being sorted at once.
-constexpr size_t PERCENTAGE_OF_TRIPLES_FOR_SORT_ESTIMATE = 5;
+constexpr inline size_t PERCENTAGE_OF_TRIPLES_FOR_SORT_ESTIMATE = 5;
 
 // When asked to make room for X ids in the cache, actually make room for X
 // times this factor.
-constexpr size_t MAKE_ROOM_SLACK_FACTOR = 2;
+constexpr inline size_t MAKE_ROOM_SLACK_FACTOR = 2;
 
 // The maximal number of columns an `IdTable` (an intermediate result of
 // query evaluation) may have to be able to use the more efficient `static`
@@ -276,28 +289,29 @@ constexpr size_t MAKE_ROOM_SLACK_FACTOR = 2;
 // Under QLEVER_CHEAPER_COMPILATION the value is lowered to reduce the number
 // of template instantiations and thereby speed up debug builds.
 #ifdef QLEVER_CHEAPER_COMPILATION
-constexpr int DEFAULT_MAX_NUM_COLUMNS_STATIC_ID_TABLE = 1;
+constexpr inline int DEFAULT_MAX_NUM_COLUMNS_STATIC_ID_TABLE = 1;
 #else
-constexpr int DEFAULT_MAX_NUM_COLUMNS_STATIC_ID_TABLE = 5;
+constexpr inline int DEFAULT_MAX_NUM_COLUMNS_STATIC_ID_TABLE = 5;
 #endif
 
 // Interval in which an enabled watchdog would check if
 // `CancellationHandle::throwIfCancelled` is called regularly.
-constexpr std::chrono::milliseconds DESIRED_CANCELLATION_CHECK_INTERVAL{50};
+constexpr inline std::chrono::milliseconds DESIRED_CANCELLATION_CHECK_INTERVAL{
+    50};
 
 // In all permutations, the graph ID of the triple is stored as the fourth
 // entry. During the index building it is important that this is the first
 // column after the "actual" triple.
-constexpr size_t ADDITIONAL_COLUMN_GRAPH_ID = 3;
+constexpr inline size_t ADDITIONAL_COLUMN_GRAPH_ID = 3;
 
 // In the PSO and PSO permutations the patterns of the subject and object are
 // stored at the following indices. Note that the col0 (the P) is not part of
 // the result, so the column order for PSO is S O PatternS PatternO.
-constexpr size_t ADDITIONAL_COLUMN_INDEX_SUBJECT_PATTERN = 4;
-constexpr size_t ADDITIONAL_COLUMN_INDEX_OBJECT_PATTERN = 5;
+constexpr inline size_t ADDITIONAL_COLUMN_INDEX_SUBJECT_PATTERN = 4;
+constexpr inline size_t ADDITIONAL_COLUMN_INDEX_OBJECT_PATTERN = 5;
 
 #ifdef _PARALLEL_SORT
-constexpr bool USE_PARALLEL_SORT = true;
+constexpr inline bool USE_PARALLEL_SORT = true;
 #include <parallel/algorithm>
 namespace ad_utility {
 template <typename... Args>
@@ -309,7 +323,7 @@ using parallel_tag = __gnu_parallel::parallel_tag;
 }  // namespace ad_utility
 
 #else
-constexpr bool USE_PARALLEL_SORT = false;
+constexpr inline bool USE_PARALLEL_SORT = false;
 namespace ad_utility {
 template <typename... Args>
 auto parallel_sort([[maybe_unused]] Args&&... args) {
@@ -320,22 +334,22 @@ auto parallel_sort([[maybe_unused]] Args&&... args) {
 using parallel_tag = int;
 }  // namespace ad_utility
 #endif
-constexpr size_t NUM_SORT_THREADS = 4;
+constexpr inline size_t NUM_SORT_THREADS = 4;
 /// ANSI escape sequence for bold text in the console
-constexpr std::string_view EMPH_ON = "\033[1m";
+constexpr inline std::string_view EMPH_ON = "\033[1m";
 /// ANSI escape sequence to print "normal" text again in the console.
-constexpr std::string_view EMPH_OFF = "\033[22m";
+constexpr inline std::string_view EMPH_OFF = "\033[22m";
 
 // Allowed range for geographical coordinates from WTK Text
-constexpr double COORDINATE_LAT_MAX = 90.0;
-constexpr double COORDINATE_LNG_MAX = 180.0;
+constexpr inline double COORDINATE_LAT_MAX = 90.0;
+constexpr inline double COORDINATE_LNG_MAX = 180.0;
 
 // When operation results are returned as `application/qlever-results+json` the
 // Operation string is echoed. This operation string is truncated to ensure
 // performance.
-constexpr size_t MAX_LENGTH_OPERATION_ECHO = 5000;
+constexpr inline size_t MAX_LENGTH_OPERATION_ECHO = 5000;
 
-constexpr std::string_view GSP_DIRECT_GRAPH_IDENTIFICATION_PREFIX =
+constexpr inline std::string_view GSP_DIRECT_GRAPH_IDENTIFICATION_PREFIX =
     "http-graph-store";
 
 #endif  // QLEVER_SRC_GLOBAL_CONSTANTS_H

--- a/src/global/Constants.h
+++ b/src/global/Constants.h
@@ -229,7 +229,8 @@ constexpr inline std::string_view CONFIGURATION_FILE = ".meta-data.json";
 
 // The key under which the datetime when the index build started is stored in
 // the index configuration.
-constexpr std::string_view DATE_OF_INDEX_BUILD_KEY = "date-of-index-build";
+constexpr inline std::string_view DATE_OF_INDEX_BUILD_KEY =
+    "date-of-index-build";
 
 // The datetime format used for the `date-of-index-build` entry in the index
 // configuration (the time when the build started), e.g.

--- a/src/global/Constants.h
+++ b/src/global/Constants.h
@@ -18,32 +18,31 @@
 // For access to `memorySize` literals.
 using namespace ad_utility::memory_literals;
 
-constexpr inline ad_utility::MemorySize DEFAULT_MEMORY_LIMIT_INDEX_BUILDING =
-    5_GB;
-constexpr inline ad_utility::MemorySize DEFAULT_PARSER_BUFFER_SIZE = 10_MB;
+constexpr ad_utility::MemorySize DEFAULT_MEMORY_LIMIT_INDEX_BUILDING = 5_GB;
+constexpr ad_utility::MemorySize DEFAULT_PARSER_BUFFER_SIZE = 10_MB;
 
-constexpr inline ad_utility::MemorySize DEFAULT_MEM_FOR_QUERIES = 4_GB;
+constexpr ad_utility::MemorySize DEFAULT_MEM_FOR_QUERIES = 4_GB;
 
-constexpr inline uint64_t MAX_NOF_ROWS_IN_RESULT = 1'000'000;
-constexpr inline size_t MIN_WORD_PREFIX_SIZE = 4;
-constexpr inline char PREFIX_CHAR = '*';
+constexpr uint64_t MAX_NOF_ROWS_IN_RESULT = 1'000'000;
+constexpr size_t MIN_WORD_PREFIX_SIZE = 4;
+constexpr char PREFIX_CHAR = '*';
 
-constexpr inline size_t BUFFER_SIZE_DOCSFILE_LINE = 100'000'000;
+constexpr size_t BUFFER_SIZE_DOCSFILE_LINE = 100'000'000;
 
-constexpr inline size_t TEXT_PREDICATE_CARDINALITY_ESTIMATE = 1'000'000'000;
+constexpr size_t TEXT_PREDICATE_CARDINALITY_ESTIMATE = 1'000'000'000;
 
-constexpr inline size_t GALLOP_THRESHOLD = 1000;
+constexpr size_t GALLOP_THRESHOLD = 1000;
 
-constexpr inline char QLEVER_INTERNAL_PREFIX_NAME[] = "ql";
-constexpr inline std::string_view QLEVER_INTERNAL_PREFIX_URL =
+constexpr char QLEVER_INTERNAL_PREFIX_NAME[] = "ql";
+constexpr std::string_view QLEVER_INTERNAL_PREFIX_URL =
     "http://qlever.cs.uni-freiburg.de/builtin-functions/";
 
 // Make a QLever-internal IRI from `QL_INTERNAL_PREFIX_URL` by appending the
 // concatenation of the given `suffixes` and enclosing the result in angle
 // brackets (const and non-const version).
 namespace string_constants::detail {
-constexpr inline std::string_view openAngle = "<";
-constexpr inline std::string_view closeAngle = ">";
+constexpr std::string_view openAngle = "<";
+constexpr std::string_view closeAngle = ">";
 }  // namespace string_constants::detail
 template <const std::string_view&... suffixes>
 constexpr std::string_view makeQleverInternalIriConst() {
@@ -57,54 +56,53 @@ inline std::string makeQleverInternalIri(const T&... suffixes) {
 }
 
 namespace string_constants::detail {
-constexpr inline std::string_view empty = "";
+constexpr std::string_view empty = "";
 }  // namespace string_constants::detail
-constexpr inline std::string_view QLEVER_INTERNAL_PREFIX_IRI =
+constexpr std::string_view QLEVER_INTERNAL_PREFIX_IRI =
     makeQleverInternalIriConst<string_constants::detail::empty>();
-constexpr inline std::string_view
-    QLEVER_INTERNAL_PREFIX_IRI_WITHOUT_CLOSING_BRACKET =
-        ad_utility::constexprStrCat<string_constants::detail::openAngle,
-                                    QLEVER_INTERNAL_PREFIX_URL>();
+constexpr std::string_view QLEVER_INTERNAL_PREFIX_IRI_WITHOUT_CLOSING_BRACKET =
+    ad_utility::constexprStrCat<string_constants::detail::openAngle,
+                                QLEVER_INTERNAL_PREFIX_URL>();
 namespace string_constants::detail {
-constexpr inline std::string_view contains_entity = "contains-entity";
+constexpr std::string_view contains_entity = "contains-entity";
 }  // namespace string_constants::detail
-constexpr inline std::string_view CONTAINS_ENTITY_PREDICATE =
+constexpr std::string_view CONTAINS_ENTITY_PREDICATE =
     makeQleverInternalIriConst<string_constants::detail::contains_entity>();
 namespace string_constants::detail {
-constexpr inline std::string_view contains_word = "contains-word";
+constexpr std::string_view contains_word = "contains-word";
 }  // namespace string_constants::detail
-constexpr inline std::string_view CONTAINS_WORD_PREDICATE =
+constexpr std::string_view CONTAINS_WORD_PREDICATE =
     makeQleverInternalIriConst<string_constants::detail::contains_word>();
 
 namespace string_constants::detail {
-constexpr inline std::string_view text = "text";
+constexpr std::string_view text = "text";
 }  // namespace string_constants::detail
-constexpr inline std::string_view QLEVER_INTERNAL_TEXT_MATCH_PREDICATE =
+constexpr std::string_view QLEVER_INTERNAL_TEXT_MATCH_PREDICATE =
     makeQleverInternalIriConst<string_constants::detail::text>();
 namespace string_constants::detail {
-constexpr inline std::string_view has_predicate = "has-predicate";
+constexpr std::string_view has_predicate = "has-predicate";
 }  // namespace string_constants::detail
-constexpr inline std::string_view HAS_PREDICATE_PREDICATE =
+constexpr std::string_view HAS_PREDICATE_PREDICATE =
     makeQleverInternalIriConst<string_constants::detail::has_predicate>();
 namespace string_constants::detail {
-constexpr inline std::string_view has_pattern = "has-pattern";
+constexpr std::string_view has_pattern = "has-pattern";
 }  // namespace string_constants::detail
-constexpr inline std::string_view HAS_PATTERN_PREDICATE =
+constexpr std::string_view HAS_PATTERN_PREDICATE =
     makeQleverInternalIriConst<string_constants::detail::has_pattern>();
 namespace string_constants::detail {
-constexpr inline std::string_view default_graph = "default-graph";
+constexpr std::string_view default_graph = "default-graph";
 }  // namespace string_constants::detail
-constexpr inline std::string_view DEFAULT_GRAPH_IRI =
+constexpr std::string_view DEFAULT_GRAPH_IRI =
     makeQleverInternalIriConst<string_constants::detail::default_graph>();
 namespace string_constants::detail {
-constexpr inline std::string_view internal_graph = "internal-graph";
+constexpr std::string_view internal_graph = "internal-graph";
 }  // namespace string_constants::detail
-constexpr inline std::string_view QLEVER_INTERNAL_GRAPH_IRI =
+constexpr std::string_view QLEVER_INTERNAL_GRAPH_IRI =
     makeQleverInternalIriConst<string_constants::detail::internal_graph>();
 namespace string_constants::detail {
-constexpr inline std::string_view blank_node_prefix = "blank-node/";
+constexpr std::string_view blank_node_prefix = "blank-node/";
 }  // namespace string_constants::detail
-constexpr inline std::string_view QLEVER_INTERNAL_BLANK_NODE_IRI_PREFIX =
+constexpr std::string_view QLEVER_INTERNAL_BLANK_NODE_IRI_PREFIX =
     ad_utility::constexprStrCat<string_constants::detail::openAngle,
                                 QLEVER_INTERNAL_PREFIX_URL,
                                 string_constants::detail::blank_node_prefix>();
@@ -112,109 +110,98 @@ constexpr inline std::string_view QLEVER_INTERNAL_BLANK_NODE_IRI_PREFIX =
 // The prefix of the new graph IRIs that are generated when a Graph Store
 // Protocol PUT is made without specifying a graph.
 namespace string_constants::detail {
-constexpr inline std::string_view new_graph_prefix = "graph/";
+constexpr std::string_view new_graph_prefix = "graph/";
 }  // namespace string_constants::detail
-constexpr inline std::string_view QLEVER_NEW_GRAPH_PREFIX =
+constexpr std::string_view QLEVER_NEW_GRAPH_PREFIX =
     ad_utility::constexprStrCat<QLEVER_INTERNAL_PREFIX_URL,
                                 string_constants::detail::new_graph_prefix>();
 
 // The prefix of the SERVICE IRI used for a cached result with a name. Use as
 // in `SERVICE <ql:cached-result-with-name-$query-name$> {}`.
 namespace string_constants::detail {
-constexpr inline std::string_view cachedResultWithNamePrefix =
+constexpr std::string_view cachedResultWithNamePrefix =
     "cached-result-with-name-";
 }  // namespace string_constants::detail
-constexpr inline std::string_view CACHED_RESULT_WITH_NAME_PREFIX =
+constexpr std::string_view CACHED_RESULT_WITH_NAME_PREFIX =
     ad_utility::constexprStrCat<
         QLEVER_INTERNAL_PREFIX_URL,
         string_constants::detail::cachedResultWithNamePrefix>();
 
-constexpr inline std::pair<std::string_view, std::string_view> GEOF_PREFIX = {
+constexpr std::pair<std::string_view, std::string_view> GEOF_PREFIX = {
     "geof:", "http://www.opengis.net/def/function/geosparql/"};
-constexpr inline std::pair<std::string_view, std::string_view> MATH_PREFIX = {
+constexpr std::pair<std::string_view, std::string_view> MATH_PREFIX = {
     "math:", "http://www.w3.org/2005/xpath-functions/math#"};
-constexpr inline std::pair<std::string_view, std::string_view> XSD_PREFIX = {
+constexpr std::pair<std::string_view, std::string_view> XSD_PREFIX = {
     "xsd", "http://www.w3.org/2001/XMLSchema#"};
-constexpr inline std::pair<std::string_view, std::string_view> QL_PREFIX = {
+constexpr std::pair<std::string_view, std::string_view> QL_PREFIX = {
     QLEVER_INTERNAL_PREFIX_NAME, QLEVER_INTERNAL_PREFIX_URL};
 
-constexpr inline std::string_view QLEVER_INTERNAL_VARIABLE_PREFIX =
+constexpr std::string_view QLEVER_INTERNAL_VARIABLE_PREFIX =
     "?_QLever_internal_variable_";
 
-constexpr inline std::string_view QLEVER_INTERNAL_BLANKNODE_VARIABLE_PREFIX =
+constexpr std::string_view QLEVER_INTERNAL_BLANKNODE_VARIABLE_PREFIX =
     "?_QLever_internal_variable_bn_";
 
-constexpr inline std::string_view
-    QLEVER_INTERNAL_VARIABLE_QUERY_PLANNER_PREFIX =
-        "?_QLever_internal_variable_qp_";
+constexpr std::string_view QLEVER_INTERNAL_VARIABLE_QUERY_PLANNER_PREFIX =
+    "?_QLever_internal_variable_qp_";
 
-constexpr inline std::string_view SCORE_VARIABLE_PREFIX = "?ql_score_";
-constexpr inline std::string_view MATCHINGWORD_VARIABLE_PREFIX =
-    "?ql_matchingword_";
+constexpr std::string_view SCORE_VARIABLE_PREFIX = "?ql_score_";
+constexpr std::string_view MATCHINGWORD_VARIABLE_PREFIX = "?ql_matchingword_";
 
 namespace constants::details::strings {
-constexpr inline std::string_view langtag{"langtag"};
-constexpr inline std::string_view hasWord{"has-word"};
+constexpr std::string_view langtag{"langtag"};
+constexpr std::string_view hasWord{"has-word"};
 }  // namespace constants::details::strings
-constexpr inline std::string_view LANGUAGE_PREDICATE =
+constexpr std::string_view LANGUAGE_PREDICATE =
     makeQleverInternalIriConst<constants::details::strings::langtag>();
-constexpr inline std::string_view HAS_WORD_PREDICATE =
+constexpr std::string_view HAS_WORD_PREDICATE =
     makeQleverInternalIriConst<constants::details::strings::hasWord>();
 
 // TODO<joka921> Move them to their own file, make them strings, remove
 // duplications, etc.
-constexpr inline char XSD_STRING[] = "http://www.w3.org/2001/XMLSchema#string";
-constexpr inline char XSD_DATETIME_TYPE[] =
+constexpr char XSD_STRING[] = "http://www.w3.org/2001/XMLSchema#string";
+constexpr char XSD_DATETIME_TYPE[] =
     "http://www.w3.org/2001/XMLSchema#dateTime";
-constexpr inline char XSD_DATE_TYPE[] = "http://www.w3.org/2001/XMLSchema#date";
-constexpr inline char XSD_GYEAR_TYPE[] =
-    "http://www.w3.org/2001/XMLSchema#gYear";
-constexpr inline char XSD_GYEARMONTH_TYPE[] =
+constexpr char XSD_DATE_TYPE[] = "http://www.w3.org/2001/XMLSchema#date";
+constexpr char XSD_GYEAR_TYPE[] = "http://www.w3.org/2001/XMLSchema#gYear";
+constexpr char XSD_GYEARMONTH_TYPE[] =
     "http://www.w3.org/2001/XMLSchema#gYearMonth";
-constexpr inline char XSD_DAYTIME_DURATION_TYPE[] =
+constexpr char XSD_DAYTIME_DURATION_TYPE[] =
     "http://www.w3.org/2001/XMLSchema#dayTimeDuration";
 
-constexpr inline char XSD_INT_TYPE[] = "http://www.w3.org/2001/XMLSchema#int";
-constexpr inline char XSD_INTEGER_TYPE[] =
-    "http://www.w3.org/2001/XMLSchema#integer";
-constexpr inline char XSD_FLOAT_TYPE[] =
-    "http://www.w3.org/2001/XMLSchema#float";
-constexpr inline char XSD_DOUBLE_TYPE[] =
-    "http://www.w3.org/2001/XMLSchema#double";
-constexpr inline char XSD_DECIMAL_TYPE[] =
-    "http://www.w3.org/2001/XMLSchema#decimal";
+constexpr char XSD_INT_TYPE[] = "http://www.w3.org/2001/XMLSchema#int";
+constexpr char XSD_INTEGER_TYPE[] = "http://www.w3.org/2001/XMLSchema#integer";
+constexpr char XSD_FLOAT_TYPE[] = "http://www.w3.org/2001/XMLSchema#float";
+constexpr char XSD_DOUBLE_TYPE[] = "http://www.w3.org/2001/XMLSchema#double";
+constexpr char XSD_DECIMAL_TYPE[] = "http://www.w3.org/2001/XMLSchema#decimal";
 
-constexpr inline char XSD_NON_POSITIVE_INTEGER_TYPE[] =
+constexpr char XSD_NON_POSITIVE_INTEGER_TYPE[] =
     "http://www.w3.org/2001/XMLSchema#nonPositiveInteger";
-constexpr inline char XSD_NEGATIVE_INTEGER_TYPE[] =
+constexpr char XSD_NEGATIVE_INTEGER_TYPE[] =
     "http://www.w3.org/2001/XMLSchema#negativeInteger";
-constexpr inline char XSD_LONG_TYPE[] = "http://www.w3.org/2001/XMLSchema#long";
-constexpr inline char XSD_SHORT_TYPE[] =
-    "http://www.w3.org/2001/XMLSchema#short";
-constexpr inline char XSD_BYTE_TYPE[] = "http://www.w3.org/2001/XMLSchema#byte";
-constexpr inline char XSD_NON_NEGATIVE_INTEGER_TYPE[] =
+constexpr char XSD_LONG_TYPE[] = "http://www.w3.org/2001/XMLSchema#long";
+constexpr char XSD_SHORT_TYPE[] = "http://www.w3.org/2001/XMLSchema#short";
+constexpr char XSD_BYTE_TYPE[] = "http://www.w3.org/2001/XMLSchema#byte";
+constexpr char XSD_NON_NEGATIVE_INTEGER_TYPE[] =
     "http://www.w3.org/2001/XMLSchema#nonNegativeInteger";
-constexpr inline char XSD_UNSIGNED_LONG_TYPE[] =
+constexpr char XSD_UNSIGNED_LONG_TYPE[] =
     "http://www.w3.org/2001/XMLSchema#unsignedLong";
-constexpr inline char XSD_UNSIGNED_INT_TYPE[] =
+constexpr char XSD_UNSIGNED_INT_TYPE[] =
     "http://www.w3.org/2001/XMLSchema#unsignedInt";
-constexpr inline char XSD_UNSIGNED_SHORT_TYPE[] =
+constexpr char XSD_UNSIGNED_SHORT_TYPE[] =
     "http://www.w3.org/2001/XMLSchema#unsignedShort";
-constexpr inline char XSD_POSITIVE_INTEGER_TYPE[] =
+constexpr char XSD_POSITIVE_INTEGER_TYPE[] =
     "http://www.w3.org/2001/XMLSchema#positiveInteger";
-constexpr inline char XSD_BOOLEAN_TYPE[] =
-    "http://www.w3.org/2001/XMLSchema#boolean";
-constexpr inline char XSD_ANYURI_TYPE[] =
-    "http://www.w3.org/2001/XMLSchema#anyURI";
-constexpr inline char RDF_PREFIX[] =
-    "http://www.w3.org/1999/02/22-rdf-syntax-ns#";
-constexpr inline char RDF_LANGTAG_STRING[] =
+constexpr char XSD_BOOLEAN_TYPE[] = "http://www.w3.org/2001/XMLSchema#boolean";
+constexpr char XSD_ANYURI_TYPE[] = "http://www.w3.org/2001/XMLSchema#anyURI";
+constexpr char RDF_PREFIX[] = "http://www.w3.org/1999/02/22-rdf-syntax-ns#";
+constexpr char RDF_LANGTAG_STRING[] =
     "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString";
 
-constexpr inline std::string_view GEO_WKT_LITERAL =
+constexpr std::string_view GEO_WKT_LITERAL =
     "http://www.opengis.net/ont/geosparql#wktLiteral";
 namespace string_constants::detail {
-constexpr inline std::string_view geo_literal_prefix = "\"^^<";
+constexpr std::string_view geo_literal_prefix = "\"^^<";
 }  // namespace string_constants::detail
 static constexpr std::string_view GEO_LITERAL_SUFFIX =
     ad_utility::constexprStrCat<string_constants::detail::geo_literal_prefix,
@@ -223,20 +210,20 @@ static constexpr std::string_view GEO_LITERAL_SUFFIX =
 
 constexpr std::string_view SF_PREFIX = "http://www.opengis.net/ont/sf#";
 
-constexpr inline std::string_view VOCAB_SUFFIX = ".vocabulary";
-constexpr inline std::string_view META_FILE_SUFFIX = ".meta";
-constexpr inline std::string_view CONFIGURATION_FILE = ".meta-data.json";
+constexpr std::string_view VOCAB_SUFFIX = ".vocabulary";
+constexpr std::string_view META_FILE_SUFFIX = ".meta";
+constexpr std::string_view CONFIGURATION_FILE = ".meta-data.json";
 
 // The datetime format used for the `date-of-index-build` entry in the index
 // configuration (the time when the build started), e.g.
 // `2026-07-12T14:03:52Z` (UTC).
-constexpr inline const char* DATE_OF_INDEX_BUILD_FORMAT = "%Y-%m-%dT%H:%M:%SZ";
+constexpr const char* DATE_OF_INDEX_BUILD_FORMAT = "%Y-%m-%dT%H:%M:%SZ";
 
-constexpr inline std::string_view ERROR_IGNORE_CASE_UNSUPPORTED =
+constexpr std::string_view ERROR_IGNORE_CASE_UNSUPPORTED =
     "Key \"ignore-case\" is no longer supported. Please remove this key from "
     "your settings.json and rebuild your index. You can optionally specify the "
     "\"locale\" key, otherwise \"en.US\" will be used as default";
-constexpr inline std::string_view WARNING_ASCII_ONLY_PREFIXES =
+constexpr std::string_view WARNING_ASCII_ONLY_PREFIXES =
     "You specified \"ascii-prefixes-only = true\", which enables faster "
     "parsing for well-behaved TTL files";
 // " but only works correctly if there are no escape sequences in "
@@ -245,12 +232,12 @@ constexpr inline std::string_view WARNING_ASCII_ONLY_PREFIXES =
 // "Most Turtle files fulfill these properties (e.g. that from Wikidata), "
 // "but not all";
 
-constexpr inline std::string_view WARNING_PARALLEL_PARSING =
+constexpr std::string_view WARNING_PARALLEL_PARSING =
     "You specified \"parallel-parsing = true\", which enables faster parsing "
     "for TTL files with a well-behaved use of newlines";
-constexpr inline std::string_view LOCALE_DEFAULT_LANG = "en";
-constexpr inline std::string_view LOCALE_DEFAULT_COUNTRY = "US";
-constexpr inline bool LOCALE_DEFAULT_IGNORE_PUNCTUATION = false;
+constexpr std::string_view LOCALE_DEFAULT_LANG = "en";
+constexpr std::string_view LOCALE_DEFAULT_COUNTRY = "US";
+constexpr bool LOCALE_DEFAULT_IGNORE_PUNCTUATION = false;
 
 // Constants for the range of valid compression prefixes
 // all ASCII- printable characters are left out.
@@ -259,20 +246,20 @@ constexpr inline bool LOCALE_DEFAULT_IGNORE_PUNCTUATION = false;
 // All prefix codes have a most significant bit of 1. This means the prefix
 // codes are never valid UTF-8 and thus it is always able to determine, whether
 // this vocabulary was compressed or not.
-constexpr inline uint8_t MIN_COMPRESSION_PREFIX = 129;
-constexpr inline uint8_t NUM_COMPRESSION_PREFIXES = 126;
+constexpr uint8_t MIN_COMPRESSION_PREFIX = 129;
+constexpr uint8_t NUM_COMPRESSION_PREFIXES = 126;
 // if this is the first character of a compressed string, this means that no
 // compression has been applied to  a word
-constexpr inline uint8_t NO_PREFIX_CHAR =
+constexpr uint8_t NO_PREFIX_CHAR =
     MIN_COMPRESSION_PREFIX + NUM_COMPRESSION_PREFIXES;
 
 // When initializing a sort performance estimator, at most this percentage of
 // the number of triples in the index is being sorted at once.
-constexpr inline size_t PERCENTAGE_OF_TRIPLES_FOR_SORT_ESTIMATE = 5;
+constexpr size_t PERCENTAGE_OF_TRIPLES_FOR_SORT_ESTIMATE = 5;
 
 // When asked to make room for X ids in the cache, actually make room for X
 // times this factor.
-constexpr inline size_t MAKE_ROOM_SLACK_FACTOR = 2;
+constexpr size_t MAKE_ROOM_SLACK_FACTOR = 2;
 
 // The maximal number of columns an `IdTable` (an intermediate result of
 // query evaluation) may have to be able to use the more efficient `static`
@@ -285,29 +272,28 @@ constexpr inline size_t MAKE_ROOM_SLACK_FACTOR = 2;
 // Under QLEVER_CHEAPER_COMPILATION the value is lowered to reduce the number
 // of template instantiations and thereby speed up debug builds.
 #ifdef QLEVER_CHEAPER_COMPILATION
-constexpr inline int DEFAULT_MAX_NUM_COLUMNS_STATIC_ID_TABLE = 1;
+constexpr int DEFAULT_MAX_NUM_COLUMNS_STATIC_ID_TABLE = 1;
 #else
-constexpr inline int DEFAULT_MAX_NUM_COLUMNS_STATIC_ID_TABLE = 5;
+constexpr int DEFAULT_MAX_NUM_COLUMNS_STATIC_ID_TABLE = 5;
 #endif
 
 // Interval in which an enabled watchdog would check if
 // `CancellationHandle::throwIfCancelled` is called regularly.
-constexpr inline std::chrono::milliseconds DESIRED_CANCELLATION_CHECK_INTERVAL{
-    50};
+constexpr std::chrono::milliseconds DESIRED_CANCELLATION_CHECK_INTERVAL{50};
 
 // In all permutations, the graph ID of the triple is stored as the fourth
 // entry. During the index building it is important that this is the first
 // column after the "actual" triple.
-constexpr inline size_t ADDITIONAL_COLUMN_GRAPH_ID = 3;
+constexpr size_t ADDITIONAL_COLUMN_GRAPH_ID = 3;
 
 // In the PSO and PSO permutations the patterns of the subject and object are
 // stored at the following indices. Note that the col0 (the P) is not part of
 // the result, so the column order for PSO is S O PatternS PatternO.
-constexpr inline size_t ADDITIONAL_COLUMN_INDEX_SUBJECT_PATTERN = 4;
-constexpr inline size_t ADDITIONAL_COLUMN_INDEX_OBJECT_PATTERN = 5;
+constexpr size_t ADDITIONAL_COLUMN_INDEX_SUBJECT_PATTERN = 4;
+constexpr size_t ADDITIONAL_COLUMN_INDEX_OBJECT_PATTERN = 5;
 
 #ifdef _PARALLEL_SORT
-constexpr inline bool USE_PARALLEL_SORT = true;
+constexpr bool USE_PARALLEL_SORT = true;
 #include <parallel/algorithm>
 namespace ad_utility {
 template <typename... Args>
@@ -319,7 +305,7 @@ using parallel_tag = __gnu_parallel::parallel_tag;
 }  // namespace ad_utility
 
 #else
-constexpr inline bool USE_PARALLEL_SORT = false;
+constexpr bool USE_PARALLEL_SORT = false;
 namespace ad_utility {
 template <typename... Args>
 auto parallel_sort([[maybe_unused]] Args&&... args) {
@@ -330,22 +316,22 @@ auto parallel_sort([[maybe_unused]] Args&&... args) {
 using parallel_tag = int;
 }  // namespace ad_utility
 #endif
-constexpr inline size_t NUM_SORT_THREADS = 4;
+constexpr size_t NUM_SORT_THREADS = 4;
 /// ANSI escape sequence for bold text in the console
-constexpr inline std::string_view EMPH_ON = "\033[1m";
+constexpr std::string_view EMPH_ON = "\033[1m";
 /// ANSI escape sequence to print "normal" text again in the console.
-constexpr inline std::string_view EMPH_OFF = "\033[22m";
+constexpr std::string_view EMPH_OFF = "\033[22m";
 
 // Allowed range for geographical coordinates from WTK Text
-constexpr inline double COORDINATE_LAT_MAX = 90.0;
-constexpr inline double COORDINATE_LNG_MAX = 180.0;
+constexpr double COORDINATE_LAT_MAX = 90.0;
+constexpr double COORDINATE_LNG_MAX = 180.0;
 
 // When operation results are returned as `application/qlever-results+json` the
 // Operation string is echoed. This operation string is truncated to ensure
 // performance.
-constexpr inline size_t MAX_LENGTH_OPERATION_ECHO = 5000;
+constexpr size_t MAX_LENGTH_OPERATION_ECHO = 5000;
 
-constexpr inline std::string_view GSP_DIRECT_GRAPH_IDENTIFICATION_PREFIX =
+constexpr std::string_view GSP_DIRECT_GRAPH_IDENTIFICATION_PREFIX =
     "http-graph-store";
 
 #endif  // QLEVER_SRC_GLOBAL_CONSTANTS_H

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -395,7 +395,7 @@ void IndexImpl::createFromFiles(
   }
 
   configurationJson_["encoded-iri-prefixes"] = encodedIriManager();
-  configurationJson_["date-of-index-build"] = absl::FormatTime(
+  configurationJson_[DATE_OF_INDEX_BUILD_KEY] = absl::FormatTime(
       DATE_OF_INDEX_BUILD_FORMAT, absl::Now(), absl::UTCTimeZone());
 
   vocab_.resetToType(vocabularyTypeForIndexBuilding_);
@@ -1253,18 +1253,19 @@ void IndexImpl::writeConfiguration() const {
 
 // ____________________________________________________________________________
 std::string IndexImpl::dateOfIndexBuild() const {
-  if (configurationJson_.contains("date-of-index-build")) {
-    return configurationJson_["date-of-index-build"].get<std::string>();
+  if (configurationJson_.contains(DATE_OF_INDEX_BUILD_KEY)) {
+    return configurationJson_[DATE_OF_INDEX_BUILD_KEY].get<std::string>();
   }
   // For indexes that were built before the build date was recorded in the
-  // configuration, fall back to the modification time of the configuration
+  // configuration, fall back to the last write time of the configuration
   // file (it is written at the end of the index build).
-  struct stat fileStat;
-  AD_CONTRACT_CHECK(
-      stat((onDiskBase_ + CONFIGURATION_FILE).c_str(), &fileStat) == 0);
+  auto time =
+      std::filesystem::last_write_time(onDiskBase_ + CONFIGURATION_FILE);
+  // `last_write_time` returns a time point on the `file_clock`, but
+  // `absl::FromChrono` expects one on the `system_clock`, so convert first.
+  auto systemTime = std::chrono::clock_cast<std::chrono::system_clock>(time);
   return absl::FormatTime(DATE_OF_INDEX_BUILD_FORMAT,
-                          absl::FromTimeT(fileStat.st_mtime),
-                          absl::UTCTimeZone());
+                          absl::FromChrono(systemTime), absl::UTCTimeZone());
 }
 
 // ___________________________________________________________________________

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -1257,18 +1257,17 @@ std::string IndexImpl::dateOfIndexBuild() const {
     return configurationJson_[DATE_OF_INDEX_BUILD_KEY].get<std::string>();
   }
   // For indexes that were built before the build date was recorded in the
-  // configuration, fall back to the last write time of the configuration
-  // file (it is written at the end of the index build).
-  auto time =
-      std::filesystem::last_write_time(onDiskBase_ + CONFIGURATION_FILE);
-  // `last_write_time` returns a time point on the `file_clock`. We cannot
-  // convert it via `std::chrono::clock_cast` that is not available in C++17
-  // and not implemented by the libc++.
-  auto systemTime =
-      std::chrono::system_clock::now() +
-      std::chrono::duration_cast<std::chrono::system_clock::duration>(
-          time - std::filesystem::file_time_type::clock::now());
-  return formatIndexBuildTime(absl::FromChrono(systemTime));
+  // configuration, fall back to the last modification time of the
+  // configuration file, which is written at the end of the index build. We
+  // deliberately use `stat` and not `std::filesystem::last_write_time`: the
+  // latter returns a time point on the `file_clock`, which cannot be
+  // converted portably to a wall-clock time in C++17 (`clock_cast` requires
+  // C++20), and `std::filesystem` is not available on all toolchains that
+  // QLever targets.
+  struct stat fileStat {};
+  auto configFilename = onDiskBase_ + CONFIGURATION_FILE;
+  AD_CONTRACT_CHECK(stat(configFilename.c_str(), &fileStat) == 0);
+  return formatIndexBuildTime(absl::FromTimeT(fileStat.st_mtime));
 }
 
 // ____________________________________________________________________________

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -395,8 +395,8 @@ void IndexImpl::createFromFiles(
   }
 
   configurationJson_["encoded-iri-prefixes"] = encodedIriManager();
-  configurationJson_[DATE_OF_INDEX_BUILD_KEY] = absl::FormatTime(
-      DATE_OF_INDEX_BUILD_FORMAT, absl::Now(), absl::UTCTimeZone());
+  configurationJson_[DATE_OF_INDEX_BUILD_KEY] =
+      formatIndexBuildTime(absl::Now());
 
   vocab_.resetToType(vocabularyTypeForIndexBuilding_);
 
@@ -1261,11 +1261,20 @@ std::string IndexImpl::dateOfIndexBuild() const {
   // file (it is written at the end of the index build).
   auto time =
       std::filesystem::last_write_time(onDiskBase_ + CONFIGURATION_FILE);
-  // `last_write_time` returns a time point on the `file_clock`, but
-  // `absl::FromChrono` expects one on the `system_clock`, so convert first.
-  auto systemTime = std::chrono::clock_cast<std::chrono::system_clock>(time);
-  return absl::FormatTime(DATE_OF_INDEX_BUILD_FORMAT,
-                          absl::FromChrono(systemTime), absl::UTCTimeZone());
+  // `last_write_time` returns a time point on the `file_clock`. We cannot
+  // convert it via `std::chrono::clock_cast` that is not available in C++17
+  // and not implemented by the libc++.
+  auto systemTime =
+      std::chrono::system_clock::now() +
+      std::chrono::duration_cast<std::chrono::system_clock::duration>(
+          time - std::filesystem::file_time_type::clock::now());
+  return formatIndexBuildTime(absl::FromChrono(systemTime));
+}
+
+// ____________________________________________________________________________
+std::string IndexImpl::formatIndexBuildTime(absl::Time time) {
+  return absl::FormatTime(DATE_OF_INDEX_BUILD_FORMAT, time,
+                          absl::UTCTimeZone());
 }
 
 // ___________________________________________________________________________

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -7,6 +7,9 @@
 
 #include <absl/cleanup/cleanup.h>
 #include <absl/strings/str_join.h>
+#include <absl/time/clock.h>
+#include <absl/time/time.h>
+#include <sys/stat.h>
 
 #include <atomic>
 #include <cstdio>
@@ -392,6 +395,8 @@ void IndexImpl::createFromFiles(
   }
 
   configurationJson_["encoded-iri-prefixes"] = encodedIriManager();
+  configurationJson_["date-of-index-build"] = absl::FormatTime(
+      DATE_OF_INDEX_BUILD_FORMAT, absl::Now(), absl::UTCTimeZone());
 
   vocab_.resetToType(vocabularyTypeForIndexBuilding_);
 
@@ -1244,6 +1249,22 @@ void IndexImpl::writeConfiguration() const {
   configuration["index-format-version"] = qlever::indexFormatVersion;
   auto f = ad_utility::makeOfstream(onDiskBase_ + CONFIGURATION_FILE);
   f << configuration;
+}
+
+// ____________________________________________________________________________
+std::string IndexImpl::dateOfIndexBuild() const {
+  if (configurationJson_.contains("date-of-index-build")) {
+    return configurationJson_["date-of-index-build"].get<std::string>();
+  }
+  // For indexes that were built before the build date was recorded in the
+  // configuration, fall back to the modification time of the configuration
+  // file (it is written at the end of the index build).
+  struct stat fileStat;
+  AD_CONTRACT_CHECK(
+      stat((onDiskBase_ + CONFIGURATION_FILE).c_str(), &fileStat) == 0);
+  return absl::FormatTime(DATE_OF_INDEX_BUILD_FORMAT,
+                          absl::FromTimeT(fileStat.st_mtime),
+                          absl::UTCTimeZone());
 }
 
 // ___________________________________________________________________________

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -7,6 +7,7 @@
 #ifndef QLEVER_SRC_INDEX_INDEXIMPL_H
 #define QLEVER_SRC_INDEX_INDEXIMPL_H
 
+#include <absl/time/time.h>
 #include <gtest/gtest_prod.h>
 
 #include <memory>
@@ -489,6 +490,10 @@ class IndexImpl {
   // configuration file is used instead (which approximates the END of the
   // build).
   std::string dateOfIndexBuild() const;
+
+  // Format the given time as a UTC timestamp string in the
+  // `DATE_OF_INDEX_BUILD_FORMAT` (e.g. `2026-07-12T14:03:52Z`).
+  static std::string formatIndexBuildTime(absl::Time time);
 
   size_t getNofTextRecords() const { return textMeta_.getNofTextRecords(); }
   size_t getNofWordPostings() const { return textMeta_.getNofWordPostings(); }

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -483,6 +483,13 @@ class IndexImpl {
   const std::string& getIndexId() const { return indexId_; }
   const std::string& getGitShortHash() const { return gitShortHash_; }
 
+  // Return the datetime when the build of this index started, in the format
+  // `2026-07-12T14:03:52Z` (UTC). For indexes that were built before this
+  // date was recorded in the configuration, the modification time of the
+  // configuration file is used instead (which approximates the END of the
+  // build).
+  std::string dateOfIndexBuild() const;
+
   size_t getNofTextRecords() const { return textMeta_.getNofTextRecords(); }
   size_t getNofWordPostings() const { return textMeta_.getNofWordPostings(); }
   size_t getNofEntityPostings() const {

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -722,6 +722,7 @@ class IndexImpl {
   FRIEND_TEST(IndexImpl, recomputeStatistics);
   FRIEND_TEST(IndexImpl, writePatternsToFile);
   FRIEND_TEST(IndexImpl, loadConfigFromOldIndex);
+  FRIEND_TEST(IndexImpl, dateOfIndexBuild);
 
   bool isLiteral(std::string_view object) const;
 

--- a/src/index/IndexRebuilder.cpp
+++ b/src/index/IndexRebuilder.cpp
@@ -435,7 +435,7 @@ indexRebuilder::IndexRebuildMapping materializeToIndex(
   REBUILD_LOG_INFO << "Recomputing statistics ..." << std::endl;
 
   auto newStats = index.recomputeStatistics(locatedTriplesSharedState);
-  newStats["date-of-index-build"] = dateOfIndexBuild;
+  newStats[DATE_OF_INDEX_BUILD_KEY] = dateOfIndexBuild;
 
   auto minBlankNodeIndex = index.getBlankNodeManager()->minIndex_;
 

--- a/src/index/IndexRebuilder.cpp
+++ b/src/index/IndexRebuilder.cpp
@@ -414,8 +414,7 @@ indexRebuilder::IndexRebuildMapping materializeToIndex(
   // The rebuilt index gets its own build date, namely the time when the
   // rebuild started (the statistics below are derived from the configuration
   // of the old index and hence contain the old date).
-  auto dateOfIndexBuild = absl::FormatTime(DATE_OF_INDEX_BUILD_FORMAT,
-                                           absl::Now(), absl::UTCTimeZone());
+  auto dateOfIndexBuild = IndexImpl::formatIndexBuildTime(absl::Now());
 
   auto logFile = ad_utility::makeOfstream(logFileName);
 

--- a/src/index/IndexRebuilder.cpp
+++ b/src/index/IndexRebuilder.cpp
@@ -10,6 +10,9 @@
 #ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
 #include "index/IndexRebuilder.h"
 
+#include <absl/time/clock.h>
+#include <absl/time/time.h>
+
 #include <array>
 #include <boost/asio/awaitable.hpp>
 #include <boost/asio/co_spawn.hpp>
@@ -408,6 +411,12 @@ indexRebuilder::IndexRebuildMapping materializeToIndex(
   using namespace indexRebuilder;
   AD_CONTRACT_CHECK(!logFileName.empty(), "Log file name must not be empty");
 
+  // The rebuilt index gets its own build date, namely the time when the
+  // rebuild started (the statistics below are derived from the configuration
+  // of the old index and hence contain the old date).
+  auto dateOfIndexBuild = absl::FormatTime(DATE_OF_INDEX_BUILD_FORMAT,
+                                           absl::Now(), absl::UTCTimeZone());
+
   auto logFile = ad_utility::makeOfstream(logFileName);
 
   // Macro for rebuild-specific logging with the same syntax as AD_LOG_INFO
@@ -426,6 +435,7 @@ indexRebuilder::IndexRebuildMapping materializeToIndex(
   REBUILD_LOG_INFO << "Recomputing statistics ..." << std::endl;
 
   auto newStats = index.recomputeStatistics(locatedTriplesSharedState);
+  newStats["date-of-index-build"] = dateOfIndexBuild;
 
   auto minBlankNodeIndex = index.getBlankNodeManager()->minIndex_;
 

--- a/test/IndexTest.cpp
+++ b/test/IndexTest.cpp
@@ -1006,8 +1006,8 @@ TEST(IndexImpl, dateOfIndexBuild) {
   auto systemTime =
       std::chrono::clock_cast<std::chrono::system_clock>(fileTime);
   auto expectedFallback =
-      absl::FormatTime(DATE_OF_INDEX_BUILD_FORMAT,
-                       absl::FromChrono(systemTime), absl::UTCTimeZone());
+      absl::FormatTime(DATE_OF_INDEX_BUILD_FORMAT, absl::FromChrono(systemTime),
+                       absl::UTCTimeZone());
   EXPECT_EQ(indexImpl.dateOfIndexBuild(), expectedFallback);
 }
 

--- a/test/IndexTest.cpp
+++ b/test/IndexTest.cpp
@@ -999,16 +999,19 @@ TEST(IndexImpl, dateOfIndexBuild) {
 
   // For indexes that were built before the build date was recorded in the
   // configuration, `dateOfIndexBuild()` falls back to the last modification
-  // time of the configuration file.
+  // time of the configuration file, which was just written. Since the format
+  // only has second precision, we don't compare the timestamp exactly, but
+  // check that it lies within the last second.
   indexImpl.configurationJson_.erase(std::string{DATE_OF_INDEX_BUILD_KEY});
-  auto fileTime = std::filesystem::last_write_time(
-      indexImpl.getOnDiskBase() + std::string{CONFIGURATION_FILE});
-  auto systemTime =
-      std::chrono::clock_cast<std::chrono::system_clock>(fileTime);
-  auto expectedFallback =
-      absl::FormatTime(DATE_OF_INDEX_BUILD_FORMAT, absl::FromChrono(systemTime),
-                       absl::UTCTimeZone());
-  EXPECT_EQ(indexImpl.dateOfIndexBuild(), expectedFallback);
+  absl::Time fallbackTime;
+  std::string parseError;
+  ASSERT_TRUE(absl::ParseTime(DATE_OF_INDEX_BUILD_FORMAT,
+                              indexImpl.dateOfIndexBuild(), absl::UTCTimeZone(),
+                              &fallbackTime, &parseError))
+      << parseError;
+  EXPECT_THAT(absl::Now() - fallbackTime,
+              ::testing::AllOf(::testing::Ge(absl::ZeroDuration()),
+                               ::testing::Le(absl::Seconds(1))));
 }
 
 // _____________________________________________________________________________

--- a/test/IndexTest.cpp
+++ b/test/IndexTest.cpp
@@ -5,10 +5,13 @@
 //          Hannah Bast <bast@cs.uni-freiburg.de>
 
 #include <absl/cleanup/cleanup.h>
+#include <absl/time/time.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <chrono>
 #include <cstdio>
+#include <filesystem>
 #include <fstream>
 
 #include "./util/GTestHelpers.h"
@@ -972,6 +975,40 @@ TEST(IndexImpl, loadConfigFromOldIndex) {
   nlohmann::json jsonFromFile;
   in >> jsonFromFile;
   EXPECT_EQ(stats, jsonFromFile);
+}
+
+// _____________________________________________________________________________
+TEST(IndexImpl, dateOfIndexBuild) {
+  auto index = makeTestIndex("dateOfIndexBuild", "<a> <b> <c> .");
+  auto& indexImpl = index.getImpl();
+
+  // A freshly built index records the build date under
+  // `DATE_OF_INDEX_BUILD_KEY` in its configuration, and `dateOfIndexBuild()`
+  // returns exactly that value.
+  ASSERT_TRUE(indexImpl.configurationJson_.contains(DATE_OF_INDEX_BUILD_KEY));
+  auto storedDate =
+      indexImpl.configurationJson_[DATE_OF_INDEX_BUILD_KEY].get<std::string>();
+  EXPECT_EQ(indexImpl.dateOfIndexBuild(), storedDate);
+
+  // The stored value is a valid UTC timestamp in the expected format.
+  absl::Time parsed;
+  std::string error;
+  EXPECT_TRUE(absl::ParseTime(DATE_OF_INDEX_BUILD_FORMAT, storedDate,
+                              absl::UTCTimeZone(), &parsed, &error))
+      << error;
+
+  // For indexes that were built before the build date was recorded in the
+  // configuration, `dateOfIndexBuild()` falls back to the last modification
+  // time of the configuration file.
+  indexImpl.configurationJson_.erase(std::string{DATE_OF_INDEX_BUILD_KEY});
+  auto fileTime = std::filesystem::last_write_time(
+      indexImpl.getOnDiskBase() + std::string{CONFIGURATION_FILE});
+  auto systemTime =
+      std::chrono::clock_cast<std::chrono::system_clock>(fileTime);
+  auto expectedFallback =
+      absl::FormatTime(DATE_OF_INDEX_BUILD_FORMAT,
+                       absl::FromChrono(systemTime), absl::UTCTimeZone());
+  EXPECT_EQ(indexImpl.dateOfIndexBuild(), expectedFallback);
 }
 
 // _____________________________________________________________________________

--- a/test/IndexTest.cpp
+++ b/test/IndexTest.cpp
@@ -1001,7 +1001,7 @@ TEST(IndexImpl, dateOfIndexBuild) {
   // configuration, `dateOfIndexBuild()` falls back to the last modification
   // time of the configuration file, which was just written. Since the format
   // only has second precision, we don't compare the timestamp exactly, but
-  // check that it lies within the last second.
+  // check that it lies within the last second + tolerance.
   indexImpl.configurationJson_.erase(std::string{DATE_OF_INDEX_BUILD_KEY});
   absl::Time fallbackTime;
   std::string parseError;
@@ -1011,7 +1011,7 @@ TEST(IndexImpl, dateOfIndexBuild) {
       << parseError;
   EXPECT_THAT(absl::Now() - fallbackTime,
               ::testing::AllOf(::testing::Ge(absl::ZeroDuration()),
-                               ::testing::Le(absl::Seconds(1))));
+                               ::testing::Lt(absl::Seconds(2))));
 }
 
 // _____________________________________________________________________________

--- a/test/index/IndexRebuilderTest.cpp
+++ b/test/index/IndexRebuilderTest.cpp
@@ -5,6 +5,7 @@
 //  UFR = University of Freiburg, Chair of Algorithms and Data Structures
 
 #include <absl/strings/str_cat.h>
+#include <absl/time/time.h>
 #include <gmock/gmock.h>
 
 #include <boost/asio/awaitable.hpp>
@@ -21,6 +22,7 @@
 #include "../util/IndexTestHelpers.h"
 #include "../util/TripleComponentTestHelpers.h"
 #include "engine/Server.h"
+#include "global/Constants.h"
 #include "index/IndexRebuilder.h"
 #include "index/IndexRebuilderImpl.h"
 #include "index/vocabulary/VocabularyType.h"
@@ -545,6 +547,8 @@ TEST(IndexRebuilder, materializeToIndex) {
     absl::Cleanup removeIndexFiles{
         [&baseFolder] { std::filesystem::remove_all(baseFolder); }};
 
+    auto sourceDate = index.getImpl().dateOfIndexBuild();
+
     qlever::materializeToIndex(index.getImpl(), newIndexName, state, vocab,
                                blankNodes, cancellationHandle, logFile);
     EXPECT_TRUE(std::filesystem::exists(logFile));
@@ -553,6 +557,20 @@ TEST(IndexRebuilder, materializeToIndex) {
     newIndex.usePatterns() = usePatterns;
     newIndex.loadAllPermutations() = loadAllPermutations;
     newIndex.createFromOnDiskIndex(newIndexName, false);
+
+    // The rebuilt index gets its own, more recent build date. Both dates are
+    // recorded with second resolution, so the rebuild may happen within the
+    // same second as the original build; hence we only assert "not older".
+    auto parseDate = [](const std::string& date) {
+      absl::Time result;
+      std::string error;
+      EXPECT_TRUE(absl::ParseTime(DATE_OF_INDEX_BUILD_FORMAT, date,
+                                  absl::UTCTimeZone(), &result, &error))
+          << error;
+      return result;
+    };
+    EXPECT_GE(parseDate(newIndex.dateOfIndexBuild()), parseDate(sourceDate));
+
     EXPECT_EQ(newIndex.getBlankNodeManager()->minIndex_,
               index.getBlankNodeManager()->minIndex_ +
                   ad_utility::BlankNodeManager::blockSize_);


### PR DESCRIPTION
So far, an index did not know when it was built; the only approximation were the modification times of its files, which are not preserved by a plain copy. Now the datetime when the index build started is recorded in the `.meta-data.json` file under the key `date-of-index-build` (ISO 8601 UTC, for example `2026-07-12T14:03:52Z`), and there is an accessor for it. A rebuilt index gets the time when the rebuild started. For indexes built before this change, the accessor falls back to the modification time of the `.meta-data.json` file, which approximates the end of the build.