### PR TITLE
Re-open files of the active index via `dup` instead of by path

### DIFF
--- a/src/index/CompressedRelation.h
+++ b/src/index/CompressedRelation.h
@@ -871,11 +871,13 @@ class CompressedRelationReader {
   const Allocator& allocator() const { return allocator_; }
 
   // Allow to construct a `CompressedRelationReader` using a different
-  // allocator.
+  // allocator. The underlying file descriptor is duplicated (instead of
+  // opening the file again by name), so this also works when the file has
+  // been renamed since it was opened (see `File::duplicateForReading`).
   CompressedRelationReader makeReaderWithReboundAllocator(
       Allocator allocator) const {
     return CompressedRelationReader{std::move(allocator),
-                                    ad_utility::File{file_.name(), "r"},
+                                    file_.duplicateForReading(),
                                     useGraphPostProcessing_};
   }
 

--- a/src/util/File.h
+++ b/src/util/File.h
@@ -111,10 +111,10 @@ class File {
   // during `Qlever::swapInRebuiltIndex`).
   [[nodiscard]] File duplicateForReading() const {
     AD_CONTRACT_CHECK(isOpen());
-    int newFd = dup(fd());
+    int newFd = ::dup(fd());
     AD_CONTRACT_CHECK(newFd != -1, "Duplicating the file descriptor for file ",
                       name_, " failed");
-    FILE* newFile = fdopen(newFd, "r");
+    FILE* newFile = ::fdopen(newFd, "r");
     AD_CONTRACT_CHECK(newFile != nullptr);
     File result;
     result.name_ = name_;

--- a/src/util/File.h
+++ b/src/util/File.h
@@ -104,6 +104,24 @@ class File {
     return fileno(file_);
   }
 
+  // Return a new `File` for the same underlying file, with an independent
+  // read position, by duplicating the file descriptor. In contrast to opening
+  // the file again by name, this also works when the file has been renamed
+  // since it was opened (which happens to the files of the active index
+  // during `Qlever::swapInRebuiltIndex`).
+  [[nodiscard]] File duplicateForReading() const {
+    AD_CONTRACT_CHECK(isOpen());
+    int newFd = dup(fd());
+    AD_CONTRACT_CHECK(newFd != -1, "Duplicating the file descriptor for file ",
+                      name_, " failed");
+    FILE* newFile = fdopen(newFd, "r");
+    AD_CONTRACT_CHECK(newFile != nullptr);
+    File result;
+    result.name_ = name_;
+    result.file_ = newFile;
+    return result;
+  }
+
   //! Close file.
   bool close() {
     if (not isOpen()) {

--- a/src/util/File.h
+++ b/src/util/File.h
@@ -104,17 +104,25 @@ class File {
     return fileno(file_);
   }
 
-  // Return a new `File` for the same underlying file, with an independent
-  // read position, by duplicating the file descriptor. In contrast to opening
-  // the file again by name, this also works when the file has been renamed
-  // since it was opened (which happens to the files of the active index
-  // during `Qlever::swapInRebuiltIndex`).
+  // Return a new `File` for the same underlying file by duplicating the file
+  // descriptor. In contrast to opening the file again by name, this also
+  // works when the file has been renamed since it was opened (which happens
+  // to the files of the active index when a rebuilt index is swapped in at
+  // runtime, see #2832).
+  //
+  // NOTE: The duplicate shares the file offset with the original, so on the
+  // two `File`s only the positioned `read` overload (which uses `pread`) can
+  // be used independently; the sequential `read`/`seek` interface must not
+  // be mixed across duplicates.
   [[nodiscard]] File duplicateForReading() const {
     AD_CONTRACT_CHECK(isOpen());
     int newFd = ::dup(fd());
     AD_CONTRACT_CHECK(newFd != -1, "Duplicating the file descriptor for file ",
                       name_, " failed");
     FILE* newFile = ::fdopen(newFd, "r");
+    if (newFile == nullptr) {
+      ::close(newFd);
+    }
     AD_CONTRACT_CHECK(newFile != nullptr);
     File result;
     result.name_ = name_;

--- a/test/FileTest.cpp
+++ b/test/FileTest.cpp
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 
 #include <array>
+#include <filesystem>
 
 #include "util/File.h"
 #include "util/GTestHelpers.h"
@@ -81,6 +82,54 @@ TEST(File, getLastOffset) {
   ASSERT_EQ(lastOffsetOffset, 2 * sizeof(off_t));
   ASSERT_EQ(lastOffset, offsets.back());
   reader.close();
+}
+
+// _____________________________________________________________________________
+TEST(File, duplicateForReadingClosedFileThrows) {
+  // Duplicating a default-constructed (not open) file violates the contract.
+  ad_utility::File closedFile;
+  ASSERT_FALSE(closedFile.isOpen());
+  AD_EXPECT_THROW_WITH_MESSAGE((void)closedFile.duplicateForReading(),
+                               ::testing::HasSubstr("isOpen()"));
+}
+
+// _____________________________________________________________________________
+TEST(File, duplicateForReadingIsIndependentOfFileName) {
+  std::string_view testData = "0123456789";
+  std::string filename = gtestCurrentTestName();
+  std::string renamedFilename = filename + ".renamed";
+  absl::Cleanup cleanup = [&filename, &renamedFilename]() {
+    ad_utility::deleteFile(filename, false);
+    ad_utility::deleteFile(renamedFilename, false);
+  };
+  {
+    ad_utility::File writer{filename, "w"};
+    ASSERT_TRUE(writer.isOpen());
+    writer.write(testData.data(), testData.size());
+  }
+
+  ad_utility::File original{filename, "r"};
+  ASSERT_TRUE(original.isOpen());
+
+  // The duplicate refers to the same file and carries over the name.
+  ad_utility::File duplicate = original.duplicateForReading();
+  ASSERT_TRUE(duplicate.isOpen());
+  EXPECT_EQ(duplicate.name(), original.name());
+  EXPECT_NE(duplicate.fd(), original.fd());
+
+  // Closing one file leaves the other fully functional (independent handles).
+  original.close();
+  ASSERT_FALSE(original.isOpen());
+  ASSERT_TRUE(duplicate.isOpen());
+
+  std::filesystem::rename(filename, renamedFilename);
+
+  ad_utility::File duplicate2 = duplicate.duplicateForReading();
+  ASSERT_TRUE(duplicate2.isOpen());
+  std::string buffer;
+  buffer.resize(testData.size());
+  ASSERT_EQ(duplicate.read(buffer.data(), testData.size(), 0), testData.size());
+  EXPECT_EQ(buffer, testData);
 }
 
 // _____________________________________________________________________________


### PR DESCRIPTION
So far, `CompressedRelationReader` re-opened the underlying index file by its path whenever a reader with its own allocator was needed. This breaks when the file has been renamed in the meantime: the path then points to nothing (or to a different file), even though the already open file descriptor remains perfectly valid. There is now `File::duplicateForReading`, which duplicates the file descriptor via `dup` and is hence immune to renames, and the reader uses it. This is required for moving the files of the active index while the server is running (the runtime index swap in #2832), but is a robustness improvement on its own. Note that the duplicate shares the file offset with the original, so it is only suitable for positioned reads, which is all that the reader does.