### PR TITLE
Fix missing consolidation and stale local-vocab entries in `DeltaTriples::addFromSnapshotDiff`

### DIFF
--- a/src/index/DeltaTriples.cpp
+++ b/src/index/DeltaTriples.cpp
@@ -746,18 +746,7 @@ void DeltaTriples::addFromSnapshotDiff(
   tracer.beginTrace("computeLocatedTriplesDiff");
   auto difference = computeLocatedTriplesDiff(oldState, newState);
   difference.remapIds([this, &idMapping](Id& id) {
-    remapId(idMapping, id);
-    // Ids that remain of type `LocalVocabIndex` (words first seen by updates
-    // after the rebuild snapshot was taken) still point to entries that are
-    // anchored to the OLD index; in particular, their lazily cached position
-    // refers to the old vocabulary. Insert a *re-anchored* copy (anchored to
-    // the new index, with an empty position cache) into our local vocab and
-    // rewrite the id, so that no entry of the new index references the old
-    // index, which is destroyed after the swap.
-    if (id.getDatatype() == Datatype::LocalVocabIndex) {
-      id = Id::makeFromLocalVocabIndex(localVocab_.getIndexAndAddIfNotContained(
-          LocalVocabEntry{id.getLocalVocabIndex()->asLiteralOrIri(), index_}));
-    }
+    remapId(idMapping, id, localVocab_, index_);
   });
   tracer.endTrace("computeLocatedTriplesDiff");
   tracer.beginTrace("insertDiffedTriples");
@@ -786,7 +775,8 @@ void DeltaTriples::addFromSnapshotDiff(
 
 // _____________________________________________________________________________
 AD_ALWAYS_INLINE void DeltaTriples::remapId(
-    const qlever::indexRebuilder::IndexRebuildMapping& idMapping, Id& id) {
+    const qlever::indexRebuilder::IndexRebuildMapping& idMapping, Id& id,
+    LocalVocab& localVocab, const IndexImpl& index) {
   const auto& [insertionPositions, localVocabMapping, blankNodeBlocks,
                minBlankNodeIndex] = idMapping;
   auto type = id.getDatatype();
@@ -795,11 +785,19 @@ AD_ALWAYS_INLINE void DeltaTriples::remapId(
   } else if (type == Datatype::LocalVocabIndex) {
     auto it = localVocabMapping.find(id.getBits());
     // If we have a mapping, this means that the new index used this to make a
-    // vocab index out of it and we have to do the same. If we don't have a
-    // mapping it remains a local vocab index; a re-anchored copy of its entry
-    // is then added to the delta triples vocabulary in `addFromSnapshotDiff`.
+    // vocab index out of it and we have to do the same.
     if (it != localVocabMapping.end()) {
       id = it->second;
+    } else {
+      // Without a mapping the id remains of type `LocalVocabIndex` (a word
+      // first seen by updates after the rebuild snapshot was taken). It still
+      // points to an entry that is anchored to the OLD index; in particular,
+      // its lazily cached position refers to the old vocabulary. Insert a
+      // *re-anchored* copy (anchored to the new index, with an empty position
+      // cache) into the local vocab and rewrite the id, so that no entry of the
+      // new index references the old index, which is destroyed after the swap.
+      id = Id::makeFromLocalVocabIndex(localVocab.getIndexAndAddIfNotContained(
+          LocalVocabEntry{id.getLocalVocabIndex()->asLiteralOrIri(), index}));
     }
   } else if (type == Datatype::BlankNodeIndex) {
     auto value = qlever::indexRebuilder::tryRemapBlankNodeId(

--- a/src/index/DeltaTriples.cpp
+++ b/src/index/DeltaTriples.cpp
@@ -760,6 +760,13 @@ void DeltaTriples::addFromSnapshotDiff(
   addTriples(vi<true>, vi<true>);
   addTriples(vi<true>, vi<false>);
   tracer.endTrace("insertDiffedTriples");
+  // The four calls above bypass `insertTriples`/`deleteTriples` and thus do
+  // not consolidate. Consolidation is required before any read access, in
+  // particular before the `updateAugmentedMetadata` that follows in
+  // `DeltaTriplesManager::modify`.
+  tracer.beginTrace("consolidate");
+  consolidateAll();
+  tracer.endTrace("consolidate");
   // Update the index of the located triples to mark that they have changed.
   locatedTriples_->index_++;
 }

--- a/src/index/DeltaTriples.cpp
+++ b/src/index/DeltaTriples.cpp
@@ -745,7 +745,20 @@ void DeltaTriples::addFromSnapshotDiff(
     ad_utility::timer::TimeTracer& tracer) {
   tracer.beginTrace("computeLocatedTriplesDiff");
   auto difference = computeLocatedTriplesDiff(oldState, newState);
-  difference.remapIds([&idMapping](Id& id) { remapId(idMapping, id); });
+  difference.remapIds([this, &idMapping](Id& id) {
+    remapId(idMapping, id);
+    // Ids that remain of type `LocalVocabIndex` (words first seen by updates
+    // after the rebuild snapshot was taken) still point to entries that are
+    // anchored to the OLD index; in particular, their lazily cached position
+    // refers to the old vocabulary. Insert a *re-anchored* copy (anchored to
+    // the new index, with an empty position cache) into our local vocab and
+    // rewrite the id, so that no entry of the new index references the old
+    // index, which is destroyed after the swap.
+    if (id.getDatatype() == Datatype::LocalVocabIndex) {
+      id = Id::makeFromLocalVocabIndex(localVocab_.getIndexAndAddIfNotContained(
+          LocalVocabEntry{id.getLocalVocabIndex()->asLiteralOrIri(), index_}));
+    }
+  });
   tracer.endTrace("computeLocatedTriplesDiff");
   tracer.beginTrace("insertDiffedTriples");
   auto addTriples = [this, &cancellationHandle, &difference, &tracer](
@@ -783,8 +796,8 @@ AD_ALWAYS_INLINE void DeltaTriples::remapId(
     auto it = localVocabMapping.find(id.getBits());
     // If we have a mapping, this means that the new index used this to make a
     // vocab index out of it and we have to do the same. If we don't have a
-    // mapping it will remain a local vocab index that is then copied into the
-    // delta triples vocabulary and remapped then.
+    // mapping it remains a local vocab index; a re-anchored copy of its entry
+    // is then added to the delta triples vocabulary in `addFromSnapshotDiff`.
     if (it != localVocabMapping.end()) {
       id = it->second;
     }

--- a/src/index/DeltaTriples.h
+++ b/src/index/DeltaTriples.h
@@ -320,9 +320,12 @@ class DeltaTriples {
  private:
   // Remap the `Id` from the old index to the new index using the given
   // `idMapping`. If the `Id` can't be remapped, this means that it was added
-  // after the mapping was created and will be left unchanged.
+  // after the mapping was created and is left unchanged, except for local vocab
+  // ids, which are re-anchored to the new `index` by inserting a copy of their
+  // entry into `localVocab`.
   static void remapId(
-      const qlever::indexRebuilder::IndexRebuildMapping& idMapping, Id& id);
+      const qlever::indexRebuilder::IndexRebuildMapping& idMapping, Id& id,
+      LocalVocab& localVocab, const IndexImpl& index);
 #endif
 
   // Call `consolidateAll()` iff `consolidate` is `Consolidate::Yes`. Used by

--- a/src/index/LocalVocabEntry.cpp
+++ b/src/index/LocalVocabEntry.cpp
@@ -10,6 +10,11 @@
 // ___________________________________________________________________________
 ql::strong_ordering LocalVocabEntry::compareThreeWay(
     const LocalVocabEntry& rhs) const {
+  AD_EXPENSIVE_CHECK(
+      context_ == rhs.context_,
+      "Contexts of LocalVocabEntries has to be identical. If this is not the "
+      "case this means that stale entries associated with an old index are "
+      "falsely carried over somewhere.");
   int i = context_->getVocab().getCaseComparator().compare(
       toStringRepresentation(), rhs.toStringRepresentation(),
       LocaleManager::Level::TOTAL);

--- a/src/index/LocalVocabEntry.cpp
+++ b/src/index/LocalVocabEntry.cpp
@@ -12,7 +12,7 @@ ql::strong_ordering LocalVocabEntry::compareThreeWay(
     const LocalVocabEntry& rhs) const {
   AD_EXPENSIVE_CHECK(
       context_ == rhs.context_,
-      "Contexts of LocalVocabEntries has to be identical. If this is not the "
+      "Contexts of LocalVocabEntries have to be identical. If this is not the "
       "case this means that stale entries associated with an old index are "
       "falsely carried over somewhere.");
   int i = context_->getVocab().getCaseComparator().compare(

--- a/src/index/LocalVocabEntry.h
+++ b/src/index/LocalVocabEntry.h
@@ -143,6 +143,9 @@ class alignas(16) LocalVocabEntry
   ql::strong_ordering compareThreeWay(const LocalVocabEntry& rhs) const;
   QL_DEFINE_CUSTOM_THREEWAY_OPERATOR_LOCAL(LocalVocabEntry)
 
+  // Expose `context_` for testing.
+  const LocalVocabContext& getContextForTesting() const { return *context_; }
+
  private:
   // The expensive case of looking up the position in vocab.
   PositionInVocab positionInVocabExpensiveCase() const;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -342,6 +342,8 @@ addLinkAndDiscoverTest(RegexExpressionTest parser sparqlExpressions index engine
 
 addLinkAndDiscoverTest(LocalVocabTest engine)
 
+addLinkAndDiscoverTest(LocalVocabEntryTest index)
+
 addLinkAndDiscoverTest(ValuesTest engine)
 
 addLinkAndDiscoverTest(ServiceTest engine)

--- a/test/DeltaTriplesTest.cpp
+++ b/test/DeltaTriplesTest.cpp
@@ -1057,15 +1057,32 @@ TEST_F(DeltaTriplesTest, remapId) {
   auto I = &Id::makeFromInt;
   auto V = &makeVocabId;
   auto B = &makeBlankNodeId;
+  const IndexImpl& index = testQec->getIndex().getImpl();
   qlever::indexRebuilder::IndexRebuildMapping idMapping;
-  Id entryId = makeLocalVocabId(10101010);
-  auto remap = [&idMapping](Id id) {
-    DeltaTriples::remapId(idMapping, id);
+  LocalVocab localVocab;
+
+  LocalVocabEntry sourceEntry =
+      LocalVocabEntry::fromStringRepresentation("<entry>", index);
+  Id entryId = Id::makeFromLocalVocabIndex(&sourceEntry);
+
+  auto remap = [&idMapping, &localVocab, &index](Id id) {
+    DeltaTriples::remapId(idMapping, id, localVocab, index);
     return id;
   };
 
   EXPECT_EQ(remap(I(69)), I(69));
-  EXPECT_EQ(remap(entryId), entryId);
+
+  // Without a mapping, a local vocab id is re-anchored: it now points into
+  // `localVocab` (so the id itself changes), but the referenced word is
+  // unchanged.
+  Id reAnchored = remap(entryId);
+  EXPECT_NE(reAnchored.getBits(), entryId.getBits());
+  EXPECT_EQ(localVocab.size(), 1);
+  ASSERT_EQ(reAnchored.getDatatype(), Datatype::LocalVocabIndex);
+  EXPECT_EQ(reAnchored.getLocalVocabIndex()->asLiteralOrIri(),
+            entryId.getLocalVocabIndex()->asLiteralOrIri());
+
+  // With a mapping, the id is replaced by the mapped id.
   idMapping.localVocabMapping_.emplace(entryId.getBits(), I(42));
   EXPECT_EQ(remap(entryId), I(42));
 

--- a/test/DeltaTriplesTest.cpp
+++ b/test/DeltaTriplesTest.cpp
@@ -1228,4 +1228,86 @@ TEST_F(DeltaTriplesTest, addFromSnapshotDiff) {
                                          ::testing::Eq(Datatype::VocabIndex)),
                              newGraph));
 }
+
+// _____________________________________________________________________________
+// Regression test: local vocab entries that are carried over from the old to
+// the new index by `addFromSnapshotDiff` must be re-anchored to the new index.
+// A plain copy would keep the raw pointer to the old index (use-after-free
+// once the old index is destroyed after the swap) and the cached position in
+// the OLD vocabulary (silently wrong comparison results in the new index).
+TEST_F(DeltaTriplesTest, addFromSnapshotDiffReanchorsLocalVocabEntries) {
+  using ad_utility::testing::makeTestIndex;
+  auto cancellationHandle =
+      std::make_shared<ad_utility::CancellationHandle<>>();
+  ad_utility::timer::TimeTracer tracer{"testReanchor"};
+
+  // NOTE: The literals in the new index are essential for this test: they
+  // sort before the carried word "zzz-reanchor", so its position in the NEW
+  // vocabulary differs numerically from its position in the OLD vocabulary
+  // (which contains no literals). Otherwise, the position assertion below
+  // would hold by coincidence even for a plain (not re-anchored) copy.
+  Index newIndex = makeTestIndex(
+      "reanchorNewIndex", "<a> <b> \"aaa\" . <a> <b> \"mmm\" . <a> <b> <c> .");
+  DeltaTriples newDeltaTriples(newIndex);
+
+  {
+    Index oldIndex = makeTestIndex("reanchorOldIndex", "<x> <y> <z> .");
+    DeltaTriples oldDeltaTriples(oldIndex);
+    LocalVocab localVocab;
+
+    // The snapshot is taken BEFORE the update, so the rebuild mapping is
+    // empty and the word below is carried over as a local vocab entry.
+    auto originalSnapshot = oldDeltaTriples.getLocatedTriplesSharedStateCopy();
+    oldDeltaTriples.insertTriples(cancellationHandle,
+                                  makeIdTriples(oldIndex.getImpl(), localVocab,
+                                                {"<x> <y> \"zzz-reanchor\""}));
+    auto newSnapshot = oldDeltaTriples.getLocatedTriplesSharedStateCopy();
+
+    // Force the entries to compute and cache their position in the OLD
+    // vocabulary (this happens whenever they are used in comparisons before
+    // the swap).
+    auto [entries, blocks] = oldDeltaTriples.copyLocalVocab();
+    for (const auto& entry : entries) {
+      entry->positionInVocab();
+    }
+
+    qlever::indexRebuilder::IndexRebuildMapping emptyMapping{};
+    newDeltaTriples.addFromSnapshotDiff(*originalSnapshot, *newSnapshot,
+                                        emptyMapping, cancellationHandle,
+                                        tracer);
+  }  // The old index is destroyed here, just like after a real index swap.
+
+  // Find the carried local vocab entry among the located triples.
+  const LocalVocabEntry* carried = nullptr;
+  auto locatedTriples =
+      newDeltaTriples.getLocatedTriplesForPermutation(Permutation::SPO);
+  for (size_t block = 0; block < 1000; ++block) {
+    auto updates = locatedTriples.getUpdatesIfPresent(block);
+    if (!updates.has_value()) {
+      continue;
+    }
+    for (const auto& locatedTriple : updates.value().getSortedView()) {
+      for (const Id& id : locatedTriple.triple_.ids()) {
+        if (id.getDatatype() == Datatype::LocalVocabIndex) {
+          carried = id.getLocalVocabIndex();
+        }
+      }
+    }
+    if (carried != nullptr) {
+      break;
+    }
+  }
+  ASSERT_NE(carried, nullptr);
+  EXPECT_EQ(carried->asLiteralOrIri().toStringRepresentation(),
+            "\"zzz-reanchor\"");
+
+  // The carried entry must behave exactly like a fresh entry that was created
+  // with the new index: same position in the NEW vocabulary (a plain copy
+  // would have kept the stale position cached against the old vocabulary),
+  // and comparing must not access the old index (checked by the ASAN build,
+  // since the old index no longer exists at this point).
+  LocalVocabEntry fresh{carried->asLiteralOrIri(), newIndex.getImpl()};
+  EXPECT_EQ(carried->positionInVocab(), fresh.positionInVocab());
+  EXPECT_EQ(*carried, fresh);
+}
 #endif

--- a/test/DeltaTriplesTest.cpp
+++ b/test/DeltaTriplesTest.cpp
@@ -1170,7 +1170,9 @@ TEST_F(DeltaTriplesTest, addFromSnapshotDiff) {
   newDeltaTriples.addFromSnapshotDiff(*originalSnapshot, *newSnapshot,
                                       idMapping, std::move(cancellationHandle),
                                       tracer);
-  newDeltaTriples.consolidateAll();
+  ASSERT_NO_THROW(
+      newDeltaTriples.getLocatedTriplesForPermutation(Permutation::SPO)
+          .numTriplesForTesting());
 
   EXPECT_THAT(newDeltaTriples, NumTriples(2, 1, 3, 2, 0));
   auto locatedTriples =

--- a/test/DeltaTriplesTest.cpp
+++ b/test/DeltaTriplesTest.cpp
@@ -1243,35 +1243,33 @@ TEST_F(DeltaTriplesTest, addFromSnapshotDiffReanchorsLocalVocabEntries) {
       std::make_shared<ad_utility::CancellationHandle<>>();
   ad_utility::timer::TimeTracer tracer{"testReanchor"};
 
-  // NOTE: The literals in the new index are essential for this test: they
-  // sort before the carried word "zzz-reanchor", so its position in the NEW
-  // vocabulary differs numerically from its position in the OLD vocabulary
-  // (which contains no literals). Otherwise, the position assertion below
-  // would hold by coincidence even for a plain (not re-anchored) copy.
+  std::string prefix = gtestCurrentTestName();
+
   Index newIndex = makeTestIndex(
-      "reanchorNewIndex", "<a> <b> \"aaa\" . <a> <b> \"mmm\" . <a> <b> <c> .");
+      prefix + "-new", "<a> <b> \"aaa\" . <a> <b> \"mmm\" . <a> <b> <c> .");
   DeltaTriples newDeltaTriples(newIndex);
 
   {
-    Index oldIndex = makeTestIndex("reanchorOldIndex", "<x> <y> <z> .");
+    Index oldIndex = makeTestIndex(prefix + "-old", "<x> <y> <z> .");
     DeltaTriples oldDeltaTriples(oldIndex);
     LocalVocab localVocab;
 
     // The snapshot is taken BEFORE the update, so the rebuild mapping is
     // empty and the word below is carried over as a local vocab entry.
     auto originalSnapshot = oldDeltaTriples.getLocatedTriplesSharedStateCopy();
-    oldDeltaTriples.insertTriples(cancellationHandle,
-                                  makeIdTriples(oldIndex.getImpl(), localVocab,
-                                                {"<x> <y> \"zzz-reanchor\""}));
+    oldDeltaTriples.insertTriples(
+        cancellationHandle,
+        makeIdTriples(oldIndex.getImpl(), localVocab, {"<x> <y> \"zzz\""}));
     auto newSnapshot = oldDeltaTriples.getLocatedTriplesSharedStateCopy();
 
     // Force the entries to compute and cache their position in the OLD
-    // vocabulary (this happens whenever they are used in comparisons before
-    // the swap).
+    // vocabulary, such that we can check that the cached value is properly
+    // cleared.
     auto [entries, blocks] = oldDeltaTriples.copyLocalVocab();
     for (const auto& entry : entries) {
-      entry->positionInVocab();
+      (void)entry->positionInVocab();
     }
+    EXPECT_THAT(entries, ::testing::Not(::testing::IsEmpty()));
 
     qlever::indexRebuilder::IndexRebuildMapping emptyMapping{};
     newDeltaTriples.addFromSnapshotDiff(*originalSnapshot, *newSnapshot,
@@ -1280,29 +1278,12 @@ TEST_F(DeltaTriplesTest, addFromSnapshotDiffReanchorsLocalVocabEntries) {
   }  // The old index is destroyed here, just like after a real index swap.
 
   // Find the carried local vocab entry among the located triples.
-  const LocalVocabEntry* carried = nullptr;
-  auto locatedTriples =
-      newDeltaTriples.getLocatedTriplesForPermutation(Permutation::SPO);
-  for (size_t block = 0; block < 1000; ++block) {
-    auto updates = locatedTriples.getUpdatesIfPresent(block);
-    if (!updates.has_value()) {
-      continue;
-    }
-    for (const auto& locatedTriple : updates.value().getSortedView()) {
-      for (const Id& id : locatedTriple.triple_.ids()) {
-        if (id.getDatatype() == Datatype::LocalVocabIndex) {
-          carried = id.getLocalVocabIndex();
-        }
-      }
-    }
-    if (carried != nullptr) {
-      break;
-    }
-  }
+  auto [entries, blocks] = newDeltaTriples.copyLocalVocab();
+  ASSERT_THAT(entries, ::testing::SizeIs(1));
+  const LocalVocabEntry* carried = entries.at(0);
   ASSERT_NE(carried, nullptr);
   EXPECT_EQ(&carried->getContextForTesting(), &newIndex.getImpl());
-  EXPECT_EQ(carried->asLiteralOrIri().toStringRepresentation(),
-            "\"zzz-reanchor\"");
+  EXPECT_EQ(carried->asLiteralOrIri().toStringRepresentation(), "\"zzz\"");
 
   // The carried entry must behave exactly like a fresh entry that was created
   // with the new index: same position in the NEW vocabulary (a plain copy

--- a/test/DeltaTriplesTest.cpp
+++ b/test/DeltaTriplesTest.cpp
@@ -1300,6 +1300,7 @@ TEST_F(DeltaTriplesTest, addFromSnapshotDiffReanchorsLocalVocabEntries) {
     }
   }
   ASSERT_NE(carried, nullptr);
+  EXPECT_EQ(&carried->getContextForTesting(), &newIndex.getImpl());
   EXPECT_EQ(carried->asLiteralOrIri().toStringRepresentation(),
             "\"zzz-reanchor\"");
 

--- a/test/LocalVocabEntryTest.cpp
+++ b/test/LocalVocabEntryTest.cpp
@@ -1,0 +1,34 @@
+// Copyright 2026 The QLever Authors, in particular:
+//
+// 2026 Robin Textor-Falconi <textorr@informatik.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "./util/GTestHelpers.h"
+#include "./util/IndexTestHelpers.h"
+#include "index/IndexImpl.h"
+#include "index/LocalVocabEntry.h"
+
+// _____________________________________________________________________________
+TEST(LocalVocabEntry, compareThreeWayRequiresMatchingContexts) {
+  if constexpr (!ad_utility::areExpensiveChecksEnabled) {
+    GTEST_SKIP() << "This test only makes sense with expensive checks enabled.";
+  }
+  using ad_utility::testing::makeTestIndex;
+  Index index1 = makeTestIndex(gtestCurrentTestName() + "-1", "<a> <b> <c> .");
+  Index index2 = makeTestIndex(gtestCurrentTestName() + "-2", "<a> <b> <c> .");
+
+  LocalVocabEntry entry1 = LocalVocabEntry::fromIriref("<x>", index1.getImpl());
+  LocalVocabEntry entry2 = LocalVocabEntry::fromIriref("<x>", index2.getImpl());
+
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      (void)(entry1 < entry2),
+      ::testing::HasSubstr(
+          "Contexts of LocalVocabEntries have to be identical"));
+}


### PR DESCRIPTION
When delta triples are carried across an index rebuild (`DeltaTriples::addFromSnapshotDiff`, part of the runtime index rebuild that is being developed in #2832), two things went wrong. First, the carried triples were inserted via a path that bypasses the usual insert functions and hence never consolidated the located triples, which is required before any read access. Second, local vocab entries that were first seen by updates after the rebuild snapshot was taken were plain-copied into the new index's delta triples. Such a copy keeps a raw pointer to the old index (a use-after-free once the old index is destroyed after the swap, confirmed with ASAN) and the lazily cached position in the old vocabulary (silently wrong comparison results, for example a wrong `ORDER BY`, verified on DBLP). Both are now fixed: the insertion consolidates, and each carried entry is re-anchored to the new index with an empty position cache. There is also a new expensive check that comparing two local vocab entries anchored to different indexes throws, plus regression tests for all of the above.