### PR TITLE
Replace `auto`-typed function parameters by explicit templates

### DIFF
--- a/benchmark/JoinAlgorithmBenchmark.cpp
+++ b/benchmark/JoinAlgorithmBenchmark.cpp
@@ -1351,14 +1351,15 @@ class GeneralInterfaceImplementation : public BenchmarkInterface {
   single measurement took longer than was allowed via configuration options, or
   the stop function returned `true`.
   */
+  template <QL_CONCEPT_OR_TYPENAME(ad_utility::SameAsAny<float, size_t>)
+                ChangingParameterValue,
+            QL_CONCEPT_OR_TYPENAME(ad_utility::InvocableWithExactReturnType<
+                                   bool, float, size_t, size_t, size_t, size_t,
+                                   float, float>) StopFunction>
   bool addNewRowToBenchmarkTable(
-      ResultTable* table,
-      const QL_CONCEPT_OR_NOTHING(
-          ad_utility::SameAsAny<float, size_t>) auto changingParameterValue,
-      QL_CONCEPT_OR_NOTHING(ad_utility::InvocableWithExactReturnType<
-                            bool, float, size_t, size_t, size_t, size_t, float,
-                            float>) auto stopFunction,
-      const float overlap, const std::optional<size_t>& resultTableNumRows,
+      ResultTable* table, const ChangingParameterValue changingParameterValue,
+      StopFunction stopFunction, const float overlap,
+      const std::optional<size_t>& resultTableNumRows,
       ad_utility::RandomSeed randomSeed, const bool smallerTableSorted,
       const bool biggerTableSorted, const float& ratioRows,
       const size_t& smallerTableNumRows, const size_t& smallerTableNumColumns,

--- a/benchmark/util/ResultTableColumnOperations.h
+++ b/benchmark/util/ResultTableColumnOperations.h
@@ -31,9 +31,9 @@ CPP_template(typename Type)(
 // clang-format off
 CPP_variadic_template(typename ColumnReturnType, typename Generator,
                       typename... ColumnInputTypes)
-  (requires(sizeof...(ColumnInputTypes) > 0) CPP_and
-       ad_utility::InvocableWithSimilarReturnType<
-           Generator, ColumnReturnType, const ColumnInputTypes&...>)
+  (requires(sizeof...(ColumnInputTypes) > 0 &&
+            ad_utility::InvocableWithSimilarReturnType<
+                Generator, ColumnReturnType, const ColumnInputTypes&...>))
     // clang-format on
     void generateColumnWithColumnInput(
         ResultTable* const table, Generator&& generator,

--- a/benchmark/util/ResultTableColumnOperations.h
+++ b/benchmark/util/ResultTableColumnOperations.h
@@ -29,14 +29,14 @@ CPP_template(typename Type)(
 };
 
 // clang-format off
-CPP_variadic_template(typename ColumnReturnType, typename... ColumnInputTypes)
-  (requires(sizeof...(ColumnInputTypes) > 0))
+CPP_variadic_template(typename ColumnReturnType, typename Generator,
+                      typename... ColumnInputTypes)
+  (requires(sizeof...(ColumnInputTypes) > 0) CPP_and
+       ad_utility::InvocableWithSimilarReturnType<
+           Generator, ColumnReturnType, const ColumnInputTypes&...>)
     // clang-format on
     void generateColumnWithColumnInput(
-        ResultTable* const table,
-        QL_CONCEPT_OR_NOTHING(
-            ad_utility::InvocableWithSimilarReturnType<
-                ColumnReturnType, const ColumnInputTypes&...>) auto&& generator,
+        ResultTable* const table, Generator&& generator,
         const ColumnNumWithType<ColumnReturnType>& columnToPutResultIn,
         const ColumnNumWithType<ColumnInputTypes>&... inputColumns) {
   // Using a column more than once is the sign of an error.

--- a/src/engine/idTable/IdTable.h
+++ b/src/engine/idTable/IdTable.h
@@ -690,7 +690,8 @@ class IdTable {
   // `ad_utility::IteratorForAccessOperator` template.
   template <typename ReferenceType>
   struct IteratorHelper {
-    auto operator()(auto&& idTable, size_t rowIdx) const {
+    template <typename Table>
+    auto operator()(Table&& idTable, size_t rowIdx) const {
       return ReferenceType{&idTable, rowIdx};
     }
   };

--- a/src/engine/sparqlExpressions/RelationalExpressions.cpp
+++ b/src/engine/sparqlExpressions/RelationalExpressions.cpp
@@ -309,8 +309,10 @@ RelationalExpression<Comp>::getLanguageFilterExpression() const {
 
 namespace {
 // _____________________________________________________________________________
+template <typename Children>
 SparqlExpression::Estimates getEstimatesForFilterExpressionImpl(
-    uint64_t inputSizeEstimate, uint64_t reductionFactor, const auto& children,
+    uint64_t inputSizeEstimate, uint64_t reductionFactor,
+    const Children& children,
     const std::optional<Variable>& firstSortedVariable) {
   AD_CORRECTNESS_CHECK(children.size() >= 1);
   // Prevent division by zero.

--- a/src/index/CompressedRelation.h
+++ b/src/index/CompressedRelation.h
@@ -187,7 +187,9 @@ struct CompressedBlockMetadata : CompressedBlockMetadataNoBlockIndex {
   // Return true if a sequence of `CompressedBlockMetadata` is sorted, and if
   // all the triples that are the same when disregarding the graph are in the
   // same block.
-  static bool checkInvariantsForSortedBlocks(const auto& sequenceOfBlocks) {
+  template <typename SequenceOfBlocks>
+  static bool checkInvariantsForSortedBlocks(
+      const SequenceOfBlocks& sequenceOfBlocks) {
     return ::ranges::all_of(
         ::ranges::views::sliding(sequenceOfBlocks, 2),
         [](const auto& adjacent) {

--- a/src/index/CompressedRelationHelpersImpl.h
+++ b/src/index/CompressedRelationHelpersImpl.h
@@ -19,7 +19,8 @@ static constexpr size_t c2Idx = 2;
 // Compares two rows based on the second, third and fourth column only (it
 // ignores the first column as well as any payload columns).
 struct ComparatorForConstCol0 {
-  bool operator()(const auto& a, const auto& b) const {
+  template <typename A, typename B>
+  bool operator()(const A& a, const B& b) const {
     return std::tie(a[c1Idx], a[c2Idx], a[ADDITIONAL_COLUMN_GRAPH_ID]) <
            std::tie(b[c1Idx], b[c2Idx], b[ADDITIONAL_COLUMN_GRAPH_ID]);
   }

--- a/src/index/CompressedRelationPermutationWriterImpl.h
+++ b/src/index/CompressedRelationPermutationWriterImpl.h
@@ -263,7 +263,8 @@ struct CompressedRelationWriter::PermutationWriter {
   // 1. The relation buffer is at the block size limit, AND
   // 2. The current triple has different first three columns than the last
   //    triple in the buffer (to ensure equal triples stay in same block)
-  bool isEndOfBlockForLargeRelation(const auto& curRemainingCols) {
+  template <typename CurRemainingCols>
+  bool isEndOfBlockForLargeRelation(const CurRemainingCols& curRemainingCols) {
     if (relation_.size() < blocksize_) {
       return false;
     }

--- a/src/index/DeltaTriples.cpp
+++ b/src/index/DeltaTriples.cpp
@@ -92,9 +92,11 @@ void DeltaTriples::clear() {
 }
 
 // ____________________________________________________________________________
+template <typename IsInternal>
 void DeltaTriples::eraseTriplesInPermutation(
     Permutation::Enum permutation, ql::span<const IdTriple<0>> triples,
-    auto isInternal, ad_utility::SharedCancellationHandle cancellationHandle) {
+    IsInternal isInternal,
+    ad_utility::SharedCancellationHandle cancellationHandle) {
   // The requested `Permutation` and `LocatedTriplesPerBlock` for that
   // permutation from which the triples are erased.
   const auto& perm = index_.getPermutation(permutation);

--- a/src/index/DeltaTriples.h
+++ b/src/index/DeltaTriples.h
@@ -394,9 +394,11 @@ class DeltaTriples {
 
   // Drop multiple update triples in a permutation.
   // Note: This is currently used for `vacuum`.
+  template <typename IsInternal>
   void eraseTriplesInPermutation(
       Permutation::Enum permutation, ql::span<const IdTriple<0>> triples,
-      auto isInternal, ad_utility::SharedCancellationHandle cancellationHandle);
+      IsInternal isInternal,
+      ad_utility::SharedCancellationHandle cancellationHandle);
 
   friend class DeltaTriplesManager;
   FRIEND_TEST(DeltaTriplesTest, remapId);

--- a/src/index/ExternalSortFunctors.h
+++ b/src/index/ExternalSortFunctors.h
@@ -70,7 +70,8 @@ using SortByOSP = SortTriple<2, 0, 1>;
 
 struct SortText {
   // < comparator
-  bool operator()(const auto& a, const auto& b) const {
+  template <typename A, typename B>
+  bool operator()(const A& a, const B& b) const {
     return ql::ranges::lexicographical_compare(
         a, b, [](const Id& x, const Id& y) {
           return x.compareWithoutLocalVocab(y) < 0;

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -906,7 +906,8 @@ auto IndexImpl::convertPartialToGlobalIds(
 namespace {
 // Lift a callback that works on single elements to a callback that works on
 // blocks.
-auto liftCallback(auto callback) {
+template <typename Callback>
+auto liftCallback(Callback callback) {
   return [callback = std::move(callback)](const auto& block) mutable {
     ql::ranges::for_each(block, callback);
   };
@@ -2025,9 +2026,10 @@ namespace {
 // over all tables produced by scanning the given permutation. The customAction
 // is invoked for each table to allow for additional computations while
 // scanning.
+template <typename CustomAction>
 std::packaged_task<void()> computeStatistics(
     const LocatedTriplesSharedState& locatedTriplesSharedState, size_t& counter,
-    const Permutation& permutation, auto customAction) {
+    const Permutation& permutation, CustomAction customAction) {
   return std::packaged_task<void()>{[&counter, &permutation,
                                      &locatedTriplesSharedState,
                                      customAction = std::move(customAction)]() {

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -834,8 +834,9 @@ class IndexImpl {
   // of only two permutations (where we have to build the Pxx permutations). In
   // all other cases the Sxx permutations are built first because we need the
   // patterns.
+  template <typename... Args>
   std::optional<PatternCreator::TripleSorter> createFirstPermutationPair(
-      auto&&... args) {
+      Args&&... args) {
     static_assert(std::is_same_v<FirstPermutation, SortBySPO>);
     static_assert(std::is_same_v<SecondPermutation, SortByOSP>);
     if (loadAllPermutations()) {

--- a/src/index/LocalVocabEntry.h
+++ b/src/index/LocalVocabEntry.h
@@ -66,7 +66,8 @@ class alignas(16) LocalVocabEntry
       : Base{std::move(base)}, context_{&context} {}
 
   // Constructor for when the position in the vocab is already known.
-  LocalVocabEntry(Base&& base, auto lower, auto upper,
+  template <typename Lower, typename Upper>
+  LocalVocabEntry(Base&& base, Lower lower, Upper upper,
                   const LocalVocabContext& context)
       : Base{std::move(base)},
         context_{&context},

--- a/src/util/ConstexprUtils.h
+++ b/src/util/ConstexprUtils.h
@@ -298,8 +298,8 @@ constexpr void forEachTypeInParameterPack(const F& lambda) {
 
 // Same as the function above, but the types are passed to the lambda as a first
 // argument `ql::type_identity<T>{}`.
-template <typename... Ts>
-constexpr void forEachTypeInParameterPackWithTI(const auto& lambda) {
+template <typename... Ts, typename Lambda>
+constexpr void forEachTypeInParameterPackWithTI(const Lambda& lambda) {
   (lambda(use_type_identity::ti<Ts>), ...);
 }
 
@@ -326,7 +326,8 @@ struct forEachTypeInTemplateTypeWithTIImpl;
 
 template <template <typename...> typename Template, typename... Ts>
 struct forEachTypeInTemplateTypeWithTIImpl<Template<Ts...>> {
-  constexpr void operator()(const auto& lambda) const {
+  template <typename Lambda>
+  constexpr void operator()(const Lambda& lambda) const {
     forEachTypeInParameterPackWithTI<Ts...>(lambda);
   }
 };
@@ -343,9 +344,9 @@ constexpr void forEachTypeInTemplateType(const F& lambda) {
 
 // Same as the function above, but the template type is passed in as a
 // `ql::type_identity<TemplateType>`.
-template <typename TemplateType>
+template <typename TemplateType, typename Lambda>
 constexpr void forEachTypeInTemplateTypeWithTI(
-    use_type_identity::TI<TemplateType>, const auto& lambda) {
+    use_type_identity::TI<TemplateType>, const Lambda& lambda) {
   detail::forEachTypeInTemplateTypeWithTIImpl<TemplateType>{}(lambda);
 }
 

--- a/src/util/Exception.h
+++ b/src/util/Exception.h
@@ -178,9 +178,10 @@ std::string concatMessages(Args&&... messages) {
 // For  details on the usage see the documentation of `AD_CONTRACT_CHECK` above
 // as well as the examples in `ExceptionTest.cpp`
 namespace ad_utility::detail {
+template <typename... AdditionalMessages>
 inline void adCorrectnessCheckImpl(bool condition, std::string_view message,
                                    ad_utility::source_location location,
-                                   auto&&... additionalMessages) {
+                                   AdditionalMessages&&... additionalMessages) {
   AD_CHECK_IMPL(condition, message, location, additionalMessages...);
 }
 }  // namespace ad_utility::detail

--- a/src/util/File.h
+++ b/src/util/File.h
@@ -219,8 +219,8 @@ inline void deleteFile(const std::filesystem::path& path,
 }
 
 namespace detail {
-template <typename Stream, bool forWriting>
-Stream makeFilestream(const std::filesystem::path& path, auto&&... args) {
+template <typename Stream, bool forWriting, typename... Args>
+Stream makeFilestream(const std::filesystem::path& path, Args&&... args) {
   Stream stream{path.string(), AD_FWD(args)...};
   std::string_view mode = forWriting ? "for writing" : "for reading";
   if (!stream.is_open()) {
@@ -238,12 +238,14 @@ Stream makeFilestream(const std::filesystem::path& path, auto&&... args) {
 // Open and return a std::ifstream from a given filename and optional
 // additional `args`. Throw an exception stating the filename and the absolute
 // path when the file can't be opened.
-std::ifstream makeIfstream(const std::filesystem::path& path, auto&&... args) {
+template <typename... Args>
+std::ifstream makeIfstream(const std::filesystem::path& path, Args&&... args) {
   return detail::makeFilestream<std::ifstream, false>(path, AD_FWD(args)...);
 }
 
 // Similar to `makeIfstream`, but returns `std::ofstream`
-std::ofstream makeOfstream(const std::filesystem::path& path, auto&&... args) {
+template <typename... Args>
+std::ofstream makeOfstream(const std::filesystem::path& path, Args&&... args) {
   return detail::makeFilestream<std::ofstream, true>(path, AD_FWD(args)...);
 }
 

--- a/src/util/JoinAlgorithms/FindUndefRanges.h
+++ b/src/util/JoinAlgorithms/FindUndefRanges.h
@@ -85,9 +85,10 @@ CPP_template(typename R,
 
 // TODO<joka921> We could also implement a version that is optimized on the
 // [begin, end] range not having UNDEF values in some of the columns
-CPP_template(typename It)(requires ql::concepts::random_access_iterator<It>)  //
+CPP_template(typename It, typename RowT)(
+    requires ql::concepts::random_access_iterator<It>)  //
     auto findSmallerUndefRangesForRowsWithUndefInLastColumns(
-        const auto& row, const size_t numLastUndefined, It begin, It end,
+        const RowT& row, const size_t numLastUndefined, It begin, It end,
         bool& resultMightBeUnsorted) {
   using Row = typename std::iterator_traits<It>::value_type;
   const size_t numJoinColumns = row.size();
@@ -138,8 +139,9 @@ CPP_template(typename It)(requires ql::concepts::random_access_iterator<It>)  //
 
 // This function has no additional preconditions, but runs in `O((end - begin) *
 // numColumns)`.
-CPP_template(typename It)(requires ql::concepts::random_access_iterator<It>)  //
-    auto findSmallerUndefRangesArbitrary(const auto& row, It begin, It end,
+CPP_template(typename It, typename RowT)(
+    requires ql::concepts::random_access_iterator<It>)  //
+    auto findSmallerUndefRangesArbitrary(const RowT& row, It begin, It end,
                                          bool& resultMightBeUnsorted) {
   assert(row.size() == (*begin).size());
   assert(

--- a/src/util/JoinAlgorithms/IndexNestedLoopJoin.h
+++ b/src/util/JoinAlgorithms/IndexNestedLoopJoin.h
@@ -284,7 +284,9 @@ class IndexNestedLoopJoin {
  public:
   // Function for MINUS and EXISTS operations when the right side is fully
   // materialized.
-  Result::LazyResult computeRightExistance(auto transformationFunc) {
+  template <typename TransformationFunc>
+  Result::LazyResult computeRightExistance(
+      TransformationFunc transformationFunc) {
     std::vector<ColumnIndex> leftColumns;
     std::vector<ColumnIndex> rightColumns;
     for (const auto& [leftCol, rightCol] : joinColumns_) {

--- a/src/util/JoinAlgorithms/JoinAlgorithms.h
+++ b/src/util/JoinAlgorithms/JoinAlgorithms.h
@@ -515,12 +515,12 @@ using CompareEqButLast = CompareAllButLastImpl<decltype(ql::ranges::equal)>;
  */
 CPP_template(typename LeftTableLike, typename RightTableLike,
              typename CompatibleActionT, typename NotFoundActionT,
-             typename CancellationFuncT)(
+             typename CancellationFuncT, typename NumColsT)(
     requires BinaryIteratorFunction<CompatibleActionT, LeftTableLike,
                                     RightTableLike>
         CPP_and UnaryIteratorFunction<NotFoundActionT, LeftTableLike>
             CPP_and ql::concepts::invocable<
-                CancellationFuncT>) void specialOptionalJoin(auto
+                CancellationFuncT>) void specialOptionalJoin(NumColsT
                                                                  numJoinColumnsArg,
                                                              const LeftTableLike&
                                                                  left,
@@ -824,8 +824,14 @@ template <typename F1, typename F2>
 struct RowIndexAdder {
   F1 f1;
   F2 f2;
-  void operator()(auto&&... args) const { return f1(AD_FWD(args)...); }
-  void addRows(auto&&... args) const { return f2(AD_FWD(args)...); }
+  template <typename... Args>
+  void operator()(Args&&... args) const {
+    return f1(AD_FWD(args)...);
+  }
+  template <typename... Args>
+  void addRows(Args&&... args) const {
+    return f2(AD_FWD(args)...);
+  }
 };
 template <typename F1, typename F2>
 RowIndexAdder(F1, F2) -> RowIndexAdder<std::decay_t<F1>, std::decay_t<F2>>;
@@ -954,7 +960,11 @@ CPP_template(typename Derived, typename LeftSide, typename RightSide,
   // blocks that contain elements <= `currentEl` have been added, and `false` if
   // the function returned because `FETCH_BLOCKS` blocks were added without
   // fulfilling the condition.
-  bool fillEqualToCurrentEl(Side& side, const ProjectedEl& currentEl) {
+  CPP_template_2(typename S)(
+      requires SameAsAny<
+          S, LeftSide, RightSide>) bool fillEqualToCurrentEl(S& side,
+                                                             const ProjectedEl&
+                                                                 currentEl) {
     auto& it = side.it_;
     auto& end = side.end_;
     for (size_t numBlocksRead = 0; it != end && numBlocksRead < FETCH_BLOCKS;
@@ -1002,8 +1012,12 @@ CPP_template(typename Derived, typename LeftSide, typename RightSide,
   // `rightSide_.currentBlocks`) s.t. only elements `> lastProcessedElement`
   // remain. This effectively removes all blocks completely, except maybe the
   // last one.
-  void removeEqualToCurrentEl(Blocks& blocks,
-                              const ProjectedEl& lastProcessedElement) {
+  CPP_template_2(typename B)(
+      requires SameAsAny<
+          B, LeftBlocks,
+          RightBlocks>) void removeEqualToCurrentEl(B& blocks,
+                                                    const ProjectedEl&
+                                                        lastProcessedElement) {
     // Erase all but the last block.
     AD_CORRECTNESS_CHECK(!blocks.empty());
     if (blocks.size() > 1 && !blocks.front().empty()) {
@@ -1027,8 +1041,11 @@ CPP_template(typename Derived, typename LeftSide, typename RightSide,
   // * A reference to the first full block
   // * The currently active subrange of that block
   // * An iterator pointing to the first element ` >= currentEl` in the block.
-  auto getFirstBlock(const Blocks& currentBlocks,
-                     const ProjectedEl& currentEl) {
+  CPP_template_2(typename B)(
+      requires SameAsAny<
+          B, LeftBlocks,
+          RightBlocks>) auto getFirstBlock(const B& currentBlocks,
+                                           const ProjectedEl& currentEl) {
     AD_CORRECTNESS_CHECK(!currentBlocks.empty());
     const auto& first = currentBlocks.at(0);
     // TODO<joka921> ql::ranges::lower_bound doesn't work here.
@@ -1040,7 +1057,9 @@ CPP_template(typename Derived, typename LeftSide, typename RightSide,
   }
 
   // Check if a side contains undefined values.
-  static bool hasUndef(const Side& side) {
+  CPP_template_2(typename S)(
+      requires SameAsAny<S, LeftSide,
+                         RightSide>) static bool hasUndef(const S& side) {
     if constexpr (potentiallyHasUndef) {
       return !side.undefBlocks_.empty();
     }
@@ -1092,7 +1111,11 @@ CPP_template(typename Derived, typename LeftSide, typename RightSide,
   // `currentEl`. Effectively, these subranges cover all the blocks completely
   // except maybe the last one, which might contain elements `> currentEl` at
   // the end.
-  auto getEqualToCurrentEl(const Blocks& blocks, const ProjectedEl& currentEl) {
+  CPP_template_2(typename B)(
+      requires SameAsAny<
+          B, LeftBlocks,
+          RightBlocks>) auto getEqualToCurrentEl(const B& blocks,
+                                                 const ProjectedEl& currentEl) {
     auto result = blocks;
     if (result.empty()) {
       return result;
@@ -1255,7 +1278,9 @@ CPP_template(typename Derived, typename LeftSide, typename RightSide,
 
   // If the `targetBuffer` is empty, read the next nonempty block from `[it,
   // end)` if there is one.
-  void fillWithAtLeastOne(Side& side) {
+  CPP_template_2(typename S)(
+      requires SameAsAny<S, LeftSide,
+                         RightSide>) void fillWithAtLeastOne(S& side) {
     auto& targetBuffer = side.currentBlocks_;
     auto& it = side.it_;
     const auto& end = side.end_;
@@ -1410,8 +1435,12 @@ CPP_template(typename Derived, typename LeftSide, typename RightSide,
   // Consume all remaining blocks from one side and add the Cartesian product of
   // those blocks with the undef blocks from the other side.
   // `reverse` is used to determine if the left or right side is consumed.
-  template <bool reversed>
-  void consumeRemainingBlocks(Side& side, const Blocks& undefBlocks) {
+  CPP_template_2(bool reversed, typename S, typename B)(
+      requires SameAsAny<S, LeftSide, RightSide> CPP_and_2
+          SameAsAny<B, LeftBlocks,
+                    RightBlocks>) void consumeRemainingBlocks(S& side,
+                                                              const B&
+                                                                  undefBlocks) {
     while (side.it_ != side.end_) {
       const auto& lBlock = *side.it_;
       for (const auto& rBlock : undefBlocks) {
@@ -1457,7 +1486,9 @@ CPP_template(typename Derived, typename LeftSide, typename RightSide,
   // `side.undefBlocks_` and skipped for subsequent processing. The first block
   // containing defined values is split and the defined part is stored in
   // `side.currentBlocks_`.
-  void findFirstBlockWithoutUndef(Side& side) {
+  CPP_template_2(typename S)(
+      requires SameAsAny<S, LeftSide,
+                         RightSide>) void findFirstBlockWithoutUndef(S& side) {
     // The reference of `it` is there on purpose.
     for (auto& it = side.it_; it != side.end_; ++it) {
       auto& el = *it;
@@ -1851,10 +1882,10 @@ CPP_template(typename NumJoinColumnsT, typename LeftSide, typename RightSide,
 // `rightBlocks`. The join matches on all-but-last columns, then performs a join
 // on the last column within matching groups.
 template <typename LeftBlocks, typename RightBlocks,
-          typename CompatibleRowAction>
+          typename CompatibleRowAction, typename NumJoinCols>
 void specialOptionalJoinForBlocks(LeftBlocks&& leftBlocks,
                                   RightBlocks&& rightBlocks,
-                                  auto numJoinColumns,
+                                  NumJoinCols numJoinColumns,
                                   CompatibleRowAction& compatibleRowAction) {
   using ProjectedLeft = ql::ranges::range_value_t<
       ql::ranges::range_value_t<std::decay_t<LeftBlocks>>>;

--- a/src/util/JoinAlgorithms/JoinAlgorithms.h
+++ b/src/util/JoinAlgorithms/JoinAlgorithms.h
@@ -922,15 +922,19 @@ CPP_template(typename Derived, typename LeftSide, typename RightSide,
   using LeftBlocks = typename LeftSide::CurrentBlocks;
   using RightBlocks = typename RightSide::CurrentBlocks;
 
-// We can't define aliases for these concepts, so we use macros instead. They
-// expand to a type constraint on a template parameter in C++20 and to a plain
-// `typename` under the C++17 backports, so they can be used as
-// `template <Side S> ... f(S& side)`.
-#if defined(Side) || defined(Blocks)
-#error Side or Blocks are already defined
+// We can't define aliases for these concepts, so we use macros instead. The
+// `Side` and `Blocks` macros expand to a type constraint on a template
+// parameter in C++20 and to a plain `typename` under the C++17 backports, so
+// they can be used as `template <Side S> ... f(S& side)`. The `SideC` and
+// `BlocksC` macros are the constrained-`auto` counterparts for use as (lambda)
+// parameter types, e.g. `[](const SideC& side) {...}`.
+#if defined(Side) || defined(Blocks) || defined(SideC) || defined(BlocksC)
+#error Side, Blocks, SideC or BlocksC are already defined
 #endif
 #define Side QL_CONCEPT_OR_TYPENAME(SameAsAny<LeftSide, RightSide>)
 #define Blocks QL_CONCEPT_OR_TYPENAME(SameAsAny<LeftBlocks, RightBlocks>)
+#define SideC QL_CONCEPT_OR_NOTHING(SameAsAny<LeftSide, RightSide>) auto
+#define BlocksC QL_CONCEPT_OR_NOTHING(SameAsAny<LeftBlocks, RightBlocks>) auto
 
   // Type alias for the result of the projection. Elements from the left and
   // right input must be projected to the same type.
@@ -949,7 +953,7 @@ CPP_template(typename Derived, typename LeftSide, typename RightSide,
   // Recompute the `currentEl`. It is the minimum of the last element in the
   // first block of either of the join sides.
   ProjectedEl getCurrentEl() {
-    auto getFirst = [](const auto& side) -> ProjectedEl {
+    auto getFirst = [](const SideC& side) -> ProjectedEl {
       return side.projection_(side.currentBlocks_.front().back());
     };
     return std::min(getFirst(leftSide_), getFirst(rightSide_), lessThan_);
@@ -1342,8 +1346,8 @@ CPP_template(typename Derived, typename LeftSide, typename RightSide,
     auto equalToCurrentElRight =
         getEqualToCurrentEl(currentBlocksRight, currentEl);
 
-    auto getNextBlocks = [this, &currentEl, &blockStatus](auto& target,
-                                                          auto& side) {
+    auto getNextBlocks = [this, &currentEl, &blockStatus](BlocksC& target,
+                                                          SideC& side) {
       // Explicit this to avoid false positive warning in clang.
       this->removeEqualToCurrentEl(side.currentBlocks_, currentEl);
       bool allBlocksWereFilled = fillEqualToCurrentEl(side, currentEl);
@@ -1590,6 +1594,8 @@ CPP_template(typename Derived, typename LeftSide, typename RightSide,
   // Don't clutter other compilation units with these aliases.
 #undef Side
 #undef Blocks
+#undef SideC
+#undef BlocksC
 };
 
 // Concrete implementation of BlockZipperJoinImpl that provides the default

--- a/src/util/JoinAlgorithms/JoinAlgorithms.h
+++ b/src/util/JoinAlgorithms/JoinAlgorithms.h
@@ -922,12 +922,15 @@ CPP_template(typename Derived, typename LeftSide, typename RightSide,
   using LeftBlocks = typename LeftSide::CurrentBlocks;
   using RightBlocks = typename RightSide::CurrentBlocks;
 
-// We can't define aliases for these concepts, so we use macros instead.
+// We can't define aliases for these concepts, so we use macros instead. They
+// expand to a type constraint on a template parameter in C++20 and to a plain
+// `typename` under the C++17 backports, so they can be used as
+// `template <Side S> ... f(S& side)`.
 #if defined(Side) || defined(Blocks)
 #error Side or Blocks are already defined
 #endif
-#define Side QL_CONCEPT_OR_NOTHING(SameAsAny<LeftSide, RightSide>) auto
-#define Blocks QL_CONCEPT_OR_NOTHING(SameAsAny<LeftBlocks, RightBlocks>) auto
+#define Side QL_CONCEPT_OR_TYPENAME(SameAsAny<LeftSide, RightSide>)
+#define Blocks QL_CONCEPT_OR_TYPENAME(SameAsAny<LeftBlocks, RightBlocks>)
 
   // Type alias for the result of the projection. Elements from the left and
   // right input must be projected to the same type.
@@ -946,7 +949,7 @@ CPP_template(typename Derived, typename LeftSide, typename RightSide,
   // Recompute the `currentEl`. It is the minimum of the last element in the
   // first block of either of the join sides.
   ProjectedEl getCurrentEl() {
-    auto getFirst = [](const Side& side) -> ProjectedEl {
+    auto getFirst = [](const auto& side) -> ProjectedEl {
       return side.projection_(side.currentBlocks_.front().back());
     };
     return std::min(getFirst(leftSide_), getFirst(rightSide_), lessThan_);
@@ -960,11 +963,8 @@ CPP_template(typename Derived, typename LeftSide, typename RightSide,
   // blocks that contain elements <= `currentEl` have been added, and `false` if
   // the function returned because `FETCH_BLOCKS` blocks were added without
   // fulfilling the condition.
-  CPP_template_2(typename S)(
-      requires SameAsAny<
-          S, LeftSide, RightSide>) bool fillEqualToCurrentEl(S& side,
-                                                             const ProjectedEl&
-                                                                 currentEl) {
+  template <Side S>
+  bool fillEqualToCurrentEl(S& side, const ProjectedEl& currentEl) {
     auto& it = side.it_;
     auto& end = side.end_;
     for (size_t numBlocksRead = 0; it != end && numBlocksRead < FETCH_BLOCKS;
@@ -1012,12 +1012,9 @@ CPP_template(typename Derived, typename LeftSide, typename RightSide,
   // `rightSide_.currentBlocks`) s.t. only elements `> lastProcessedElement`
   // remain. This effectively removes all blocks completely, except maybe the
   // last one.
-  CPP_template_2(typename B)(
-      requires SameAsAny<
-          B, LeftBlocks,
-          RightBlocks>) void removeEqualToCurrentEl(B& blocks,
-                                                    const ProjectedEl&
-                                                        lastProcessedElement) {
+  template <Blocks B>
+  void removeEqualToCurrentEl(B& blocks,
+                              const ProjectedEl& lastProcessedElement) {
     // Erase all but the last block.
     AD_CORRECTNESS_CHECK(!blocks.empty());
     if (blocks.size() > 1 && !blocks.front().empty()) {
@@ -1041,11 +1038,8 @@ CPP_template(typename Derived, typename LeftSide, typename RightSide,
   // * A reference to the first full block
   // * The currently active subrange of that block
   // * An iterator pointing to the first element ` >= currentEl` in the block.
-  CPP_template_2(typename B)(
-      requires SameAsAny<
-          B, LeftBlocks,
-          RightBlocks>) auto getFirstBlock(const B& currentBlocks,
-                                           const ProjectedEl& currentEl) {
+  template <Blocks B>
+  auto getFirstBlock(const B& currentBlocks, const ProjectedEl& currentEl) {
     AD_CORRECTNESS_CHECK(!currentBlocks.empty());
     const auto& first = currentBlocks.at(0);
     // TODO<joka921> ql::ranges::lower_bound doesn't work here.
@@ -1057,9 +1051,8 @@ CPP_template(typename Derived, typename LeftSide, typename RightSide,
   }
 
   // Check if a side contains undefined values.
-  CPP_template_2(typename S)(
-      requires SameAsAny<S, LeftSide,
-                         RightSide>) static bool hasUndef(const S& side) {
+  template <Side S>
+  static bool hasUndef(const S& side) {
     if constexpr (potentiallyHasUndef) {
       return !side.undefBlocks_.empty();
     }
@@ -1111,11 +1104,8 @@ CPP_template(typename Derived, typename LeftSide, typename RightSide,
   // `currentEl`. Effectively, these subranges cover all the blocks completely
   // except maybe the last one, which might contain elements `> currentEl` at
   // the end.
-  CPP_template_2(typename B)(
-      requires SameAsAny<
-          B, LeftBlocks,
-          RightBlocks>) auto getEqualToCurrentEl(const B& blocks,
-                                                 const ProjectedEl& currentEl) {
+  template <Blocks B>
+  auto getEqualToCurrentEl(const B& blocks, const ProjectedEl& currentEl) {
     auto result = blocks;
     if (result.empty()) {
       return result;
@@ -1278,9 +1268,8 @@ CPP_template(typename Derived, typename LeftSide, typename RightSide,
 
   // If the `targetBuffer` is empty, read the next nonempty block from `[it,
   // end)` if there is one.
-  CPP_template_2(typename S)(
-      requires SameAsAny<S, LeftSide,
-                         RightSide>) void fillWithAtLeastOne(S& side) {
+  template <Side S>
+  void fillWithAtLeastOne(S& side) {
     auto& targetBuffer = side.currentBlocks_;
     auto& it = side.it_;
     const auto& end = side.end_;
@@ -1353,8 +1342,8 @@ CPP_template(typename Derived, typename LeftSide, typename RightSide,
     auto equalToCurrentElRight =
         getEqualToCurrentEl(currentBlocksRight, currentEl);
 
-    auto getNextBlocks = [this, &currentEl, &blockStatus](Blocks& target,
-                                                          Side& side) {
+    auto getNextBlocks = [this, &currentEl, &blockStatus](auto& target,
+                                                          auto& side) {
       // Explicit this to avoid false positive warning in clang.
       this->removeEqualToCurrentEl(side.currentBlocks_, currentEl);
       bool allBlocksWereFilled = fillEqualToCurrentEl(side, currentEl);
@@ -1435,12 +1424,8 @@ CPP_template(typename Derived, typename LeftSide, typename RightSide,
   // Consume all remaining blocks from one side and add the Cartesian product of
   // those blocks with the undef blocks from the other side.
   // `reverse` is used to determine if the left or right side is consumed.
-  CPP_template_2(bool reversed, typename S, typename B)(
-      requires SameAsAny<S, LeftSide, RightSide> CPP_and_2
-          SameAsAny<B, LeftBlocks,
-                    RightBlocks>) void consumeRemainingBlocks(S& side,
-                                                              const B&
-                                                                  undefBlocks) {
+  template <bool reversed, Side S, Blocks B>
+  void consumeRemainingBlocks(S& side, const B& undefBlocks) {
     while (side.it_ != side.end_) {
       const auto& lBlock = *side.it_;
       for (const auto& rBlock : undefBlocks) {
@@ -1486,9 +1471,8 @@ CPP_template(typename Derived, typename LeftSide, typename RightSide,
   // `side.undefBlocks_` and skipped for subsequent processing. The first block
   // containing defined values is split and the defined part is stored in
   // `side.currentBlocks_`.
-  CPP_template_2(typename S)(
-      requires SameAsAny<S, LeftSide,
-                         RightSide>) void findFirstBlockWithoutUndef(S& side) {
+  template <Side S>
+  void findFirstBlockWithoutUndef(S& side) {
     // The reference of `it` is there on purpose.
     for (auto& it = side.it_; it != side.end_; ++it) {
       auto& el = *it;

--- a/src/util/SortedSequence.h
+++ b/src/util/SortedSequence.h
@@ -48,7 +48,8 @@ class SortedSequence {
   [[no_unique_address]] Projection proj_ = {};
 
   // Helper for the overloads of `smallPart`/`largePart`.
-  static auto partImpl(auto& self, bool wantSmall) {
+  template <typename Self>
+  static auto partImpl(Self& self, bool wantSmall) {
     auto mid = self.elements_.begin() + self.numItemsLargePart_;
     return wantSmall ? ql::ranges::subrange(mid, self.elements_.end())
                      : ql::ranges::subrange(self.elements_.begin(), mid);
@@ -191,7 +192,8 @@ class SortedSequence {
 
  private:
   // Helper for the overloads of `getSortedView`.
-  auto getSortedViewImpl(auto& self) const {
+  template <typename Self>
+  auto getSortedViewImpl(Self& self) const {
     AD_CONTRACT_CHECK(self.isConsolidated());
     auto mid = self.elements_.begin() + self.numItemsLargePart_;
     return ZipMergeUniqueView(ql::ranges::subrange(self.elements_.begin(), mid),

--- a/src/util/http/HttpUtils.h
+++ b/src/util/http/HttpUtils.h
@@ -256,7 +256,8 @@ CPP_template(typename RequestType)(
 // Create a HttpResponse from a string with status 200 OK and mime type
 // "application/json". Otherwise behaves the same as
 // createHttpResponseFromString.
-auto createJsonResponse(std::string text, const auto& request,
+template <typename Request>
+auto createJsonResponse(std::string text, const Request& request,
                         http::status status = http::status::ok) {
   return createHttpResponseFromString(std::move(text), status, request,
                                       MediaType::json);
@@ -267,9 +268,11 @@ CPP_concept IsJson = SameAsAny<T, nlohmann::json, nlohmann::ordered_json>;
 
 // Create a HttpResponse from a json object with status 200 OK and mime type
 // "application/json".
-CPP_template(typename Json)(requires IsJson<Json>) auto createJsonResponse(
-    const Json& j, const auto& request,
-    http::status status = http::status::ok) {
+CPP_template(typename Json, typename Request)(
+    requires IsJson<Json>) auto createJsonResponse(const Json& j,
+                                                   const Request& request,
+                                                   http::status status =
+                                                       http::status::ok) {
   // Argument `4` leads to a human-readable indentation.
   return createJsonResponse(j.dump(4), request, status);
 }

--- a/test/BenchmarkMeasurementContainerTest.cpp
+++ b/test/BenchmarkMeasurementContainerTest.cpp
@@ -98,9 +98,10 @@ TEST(BenchmarkMeasurementContainerTest, ResultGroup) {
 /*
 Check the content of a `Result` row.
 */
+template <typename... WantedContent>
 static void checkResultTableRow(const ResultTable& table,
                                 const size_t& rowNumber,
-                                const auto&... wantedContent) {
+                                const WantedContent&... wantedContent) {
   // Calls the correct assert function based on type.
   auto assertEqual = [](const auto& a, const auto& b) {
     static_assert(std::is_same_v<decltype(a), decltype(b)>,

--- a/test/CompactStringVectorTest.cpp
+++ b/test/CompactStringVectorTest.cpp
@@ -15,7 +15,8 @@
 namespace {
 
 // _____________________________________________________________________________
-auto iterablesEqual(const auto& a, const auto& b) {
+template <typename A, typename B>
+auto iterablesEqual(const A& a, const B& b) {
   ASSERT_EQ(a.size(), b.size());
   for (size_t i = 0; i < a.size(); ++i) {
     ASSERT_EQ(a[i], b[i]);

--- a/test/CompressedRelationsTest.cpp
+++ b/test/CompressedRelationsTest.cpp
@@ -96,7 +96,8 @@ size_t getNumColumns(const std::vector<RelationInput>& vec) {
 // Check that `expected` and `actual` have the same contents. The `int`s in
 // expected are converted to `Id`s of type `VocabIndex` using the `V`-function
 // before the comparison.
-void checkThatTablesAreEqual(const auto& expected, const IdTable& actual,
+template <typename Expected>
+void checkThatTablesAreEqual(const Expected& expected, const IdTable& actual,
                              source_location l = AD_CURRENT_SOURCE_LOC()) {
   auto trace = generateLocationTrace(l);
 
@@ -270,7 +271,8 @@ auto writeAndOpenRelations(const std::vector<RelationInput>& inputs,
 // Run a set of tests on a permutation that is defined by the `inputs`. The
 // `inputs` must be ordered wrt the `col0_`.  `blocksize` is the size of the
 // blocks in which the permutation will be compressed and stored on disk.
-void testCompressedRelations(const auto& inputsOriginalBeforeCopy,
+template <typename Inputs>
+void testCompressedRelations(const Inputs& inputsOriginalBeforeCopy,
                              ad_utility::MemorySize blocksize,
                              float locatedTriplesProbability = 0.5) {
   using ScanSpecAndBlocks = CompressedRelationReader::ScanSpecAndBlocks;

--- a/test/ConfigManagerTest.cpp
+++ b/test/ConfigManagerTest.cpp
@@ -1231,13 +1231,13 @@ not be checked via the validator.
 to `addValidatorToConfigManager`.
 */
 struct TestGeneratedValidatorsOfConfigManager {
-  template <typename... Ts>
-  auto operator()(
-      size_t variantStart, size_t variantEnd, ConfigManager& m,
-      const nlohmann::json& defaultValues,
-      const QL_CONCEPT_OR_NOTHING(
-          ql::concepts::same_as<
-              nlohmann::json::json_pointer>) auto&... configOptionPaths)
+  template <typename... Ts,
+            QL_CONCEPT_OR_TYPENAME(
+                ql::concepts::same_as<
+                    nlohmann::json::json_pointer>)... ConfigOptionPaths>
+  auto operator()(size_t variantStart, size_t variantEnd, ConfigManager& m,
+                  const nlohmann::json& defaultValues,
+                  const ConfigOptionPaths&... configOptionPaths)
       -> CPP_ret(void)(requires(sizeof...(Ts) ==
                                 sizeof...(configOptionPaths))) {
     // Using the invariant of our function generator, to create valid

--- a/test/ConstexprUtilsTest.cpp
+++ b/test/ConstexprUtilsTest.cpp
@@ -240,7 +240,8 @@ struct PushToVector {
 struct PushToVectorWithTI {
   std::vector<std::string>* typeToStringVector;
 
-  void operator()(auto t) const {
+  template <typename TT>
+  void operator()(TT t) const {
     using T = typename decltype(t)::type;
     if constexpr (ad_utility::isSimilar<T, int>) {
       typeToStringVector->emplace_back("int");
@@ -276,9 +277,9 @@ auto typeToStringFactoryWithTI(std::vector<std::string>* typeToStringVector) {
 parameter pack and a lambda function argument, which it passes to a
 `constExprForEachType` function in the correct form.
 */
-template <typename F>
+template <typename F, typename Factory>
 void testConstExprForEachNormalCall(
-    const F& callToForEachWrapper, auto callToTypeToStringFactory,
+    const F& callToForEachWrapper, Factory callToTypeToStringFactory,
     ad_utility::source_location l = AD_CURRENT_SOURCE_LOC()) {
   // For generating better messages, when failing a test.
   auto trace{generateLocationTrace(l, "testConstExprForEachNormalCall")};

--- a/test/ConstexprUtilsTest.cpp
+++ b/test/ConstexprUtilsTest.cpp
@@ -240,9 +240,8 @@ struct PushToVector {
 struct PushToVectorWithTI {
   std::vector<std::string>* typeToStringVector;
 
-  template <typename TT>
-  void operator()(TT t) const {
-    using T = typename decltype(t)::type;
+  template <typename T>
+  void operator()(use_type_identity::TI<T>) const {
     if constexpr (ad_utility::isSimilar<T, int>) {
       typeToStringVector->emplace_back("int");
     } else if constexpr (ad_utility::isSimilar<T, bool>) {

--- a/test/GroupByTest.cpp
+++ b/test/GroupByTest.cpp
@@ -118,9 +118,9 @@ TEST(GroupBy, clone) {
 namespace {
 // All the operations take a `QueryExecutionContext` as a first argument.
 // Todo: Continue the comment.
-template <typename Operation>
+template <typename Operation, typename... Args>
 std::shared_ptr<QueryExecutionTree> makeExecutionTree(
-    QueryExecutionContext* qec, auto&&... args) {
+    QueryExecutionContext* qec, Args&&... args) {
   return std::make_shared<QueryExecutionTree>(
       qec, std::make_shared<Operation>(qec, AD_FWD(args)...));
 }

--- a/test/HttpTest.cpp
+++ b/test/HttpTest.cpp
@@ -48,8 +48,9 @@ boost::asio::awaitable<std::string> consumeBody(
     http::request<http::string_body> req) {
   co_return req.body();
 }
+template <typename Request, typename BodyGetter>
 boost::asio::awaitable<std::string> consumeBody(
-    [[maybe_unused]] const auto& request, auto bodyGetter) {
+    [[maybe_unused]] const Request& request, BodyGetter bodyGetter) {
   std::string body;
   while (auto chunk = co_await bodyGetter()) {
     body += chunk.value();
@@ -91,7 +92,8 @@ auto makeIgnoreBodyServer(size_t chunkSize) {
 
 // Sends an echo response (METHOD\nTARGET\nBODY) and then rethrows `exception`.
 // Shared between eager and lazy `makeThrowingEchoServer` handlers.
-boost::asio::awaitable<void> throwingEchoBody(const auto& req, auto& send,
+template <typename Req, typename Send>
+boost::asio::awaitable<void> throwingEchoBody(const Req& req, Send& send,
                                               std::string_view body,
                                               std::exception_ptr exception) {
   co_await send(createOkResponse(absl::StrCat(verbName(req.method()), "\n",
@@ -113,7 +115,8 @@ auto makeThrowingEchoServer(std::exception_ptr exception, size_t chunkSize) {
 
 // Common redirect/success handler logic: inspects URL parameters to redirect
 // or respond with "Success", and sets `lastTarget` to the request target.
-boost::asio::awaitable<void> redirectHandlerCore(const auto& req, auto& send,
+template <typename Req, typename Send>
+boost::asio::awaitable<void> redirectHandlerCore(const Req& req, Send& send,
                                                  std::string& lastTarget) {
   boost::url_view url{req.target()};
   lastTarget = req.target();

--- a/test/IdTableTest.cpp
+++ b/test/IdTableTest.cpp
@@ -260,7 +260,8 @@ void runTestForDifferentTypes(T testCase, std::string testCaseName) {
 // member function needs additional arguments. Currently, the only additional
 // argument is the filename for the copy for `IdTables` that store their data in
 // a `BufferedVector`. For an example usage see the test cases below.
-auto clone(const auto& table, auto... args) {
+template <typename Table, typename... Args>
+auto clone(const Table& table, Args... args) {
   if constexpr (requires { table.clone(); }) {
     return table.clone();
   } else {

--- a/test/JoinAlgorithmsTest.cpp
+++ b/test/JoinAlgorithmsTest.cpp
@@ -610,12 +610,14 @@ struct IdRowAdder {
   IdTableView<0> rightTable_{2, ad_utility::testing::makeAllocator()};
 
   // Called by cartesian product path with materialized tables.
-  void setInput(const auto& left, const auto& right) {
+  template <typename Left, typename Right>
+  void setInput(const Left& left, const Right& right) {
     leftTable_ = left.template asStaticView<0>();
     rightTable_ = right.template asStaticView<0>();
   }
 
-  void setOnlyLeftInputForOptionalJoin(const auto& left) {
+  template <typename Left>
+  void setOnlyLeftInputForOptionalJoin(const Left& left) {
     leftTable_ = left.template asStaticView<0>();
   }
 

--- a/test/MaterializedViewsTestHelpers.h
+++ b/test/MaterializedViewsTestHelpers.h
@@ -196,7 +196,8 @@ inline void PrintTo(const RewriteTestParams& p, std::ostream* os) {
 }
 
 // _____________________________________________________________________________
-inline void qpExpect(qlever::Qlever& qlv, const auto& query,
+template <typename Query>
+inline void qpExpect(qlever::Qlever& qlv, const Query& query,
                      ::testing::Matcher<const QueryExecutionTree&> matcher,
                      source_location sourceLocation = AD_CURRENT_SOURCE_LOC()) {
   auto l = generateLocationTrace(sourceLocation);
@@ -227,9 +228,10 @@ inline auto viewScanSimple(std::string viewName, std::string a, std::string b,
 };
 
 // _____________________________________________________________________________
+template <typename ViewName, typename Query>
 inline void expectNotSuitableForRewrite(
     const qlever::Qlever& qlv, const MaterializedViewsManager& manager,
-    const auto& viewName, const auto& query,
+    const ViewName& viewName, const Query& query,
     source_location sourceLocation = AD_CURRENT_SOURCE_LOC()) {
   auto l = generateLocationTrace(sourceLocation);
   materializedViewsQueryAnalysis::QueryPatternCache qpc;

--- a/test/QueryPlannerTestHelpers.h
+++ b/test/QueryPlannerTestHelpers.h
@@ -634,8 +634,8 @@ inline QueryExecutionTree parseAndPlan(std::string query,
 // be controlled to choose between the greedy and the dynamic programming
 // planner. This function only serves as a common implementation, for the
 // actual tests the three functions below should be used.
-template <typename QueryPlannerClass = QueryPlanner>
-void expectWithGivenBudget(std::string query, auto matcher,
+template <typename QueryPlannerClass = QueryPlanner, typename MatcherT>
+void expectWithGivenBudget(std::string query, MatcherT matcher,
                            std::optional<QueryExecutionContext*> optQec,
                            size_t queryPlanningBudget,
                            source_location l = AD_CURRENT_SOURCE_LOC()) {
@@ -661,8 +661,8 @@ void expectWithGivenBudget(std::string query, auto matcher,
 }
 
 // Same as `expectWithGivenBudget` but allows multiple budgets to be tested.
-template <typename QueryPlannerClass = QueryPlanner>
-void expectWithGivenBudgets(std::string query, auto matcher,
+template <typename QueryPlannerClass = QueryPlanner, typename MatcherT>
+void expectWithGivenBudgets(std::string query, MatcherT matcher,
                             std::optional<QueryExecutionContext*> optQec,
                             std::vector<size_t> queryPlanningBudgets,
                             source_location l = AD_CURRENT_SOURCE_LOC()) {
@@ -673,8 +673,8 @@ void expectWithGivenBudgets(std::string query, auto matcher,
 
 // Same as `expectWithGivenBudget` above, but always use the greedy query
 // planner.
-template <typename QueryPlannerClass = QueryPlanner>
-void expectGreedy(std::string query, auto matcher,
+template <typename QueryPlannerClass = QueryPlanner, typename MatcherT>
+void expectGreedy(std::string query, MatcherT matcher,
                   std::optional<QueryExecutionContext*> optQec = std::nullopt,
                   source_location l = AD_CURRENT_SOURCE_LOC()) {
   expectWithGivenBudget<QueryPlannerClass>(std::move(query), std::move(matcher),
@@ -682,9 +682,9 @@ void expectGreedy(std::string query, auto matcher,
 }
 // Same as `expectWithGivenBudget` above, but always use the dynamic
 // programming query planner.
-template <typename QueryPlannerClass = QueryPlanner>
+template <typename QueryPlannerClass = QueryPlanner, typename MatcherT>
 void expectDynamicProgramming(
-    std::string query, auto matcher,
+    std::string query, MatcherT matcher,
     std::optional<QueryExecutionContext*> optQec = std::nullopt,
     source_location l = AD_CURRENT_SOURCE_LOC()) {
   expectWithGivenBudget<QueryPlannerClass>(
@@ -695,8 +695,8 @@ void expectDynamicProgramming(
 // Same as `expectWithGivenBudget` above, but run the test for different
 // query planning budgets. This is guaranteed to run with both the greedy
 // query planner and the dynamic-programming based query planner.
-template <typename QueryPlannerClass = QueryPlanner>
-void expect(std::string query, auto matcher,
+template <typename QueryPlannerClass = QueryPlanner, typename MatcherT>
+void expect(std::string query, MatcherT matcher,
             std::optional<QueryExecutionContext*> optQec = std::nullopt,
             source_location l = AD_CURRENT_SOURCE_LOC()) {
   expectWithGivenBudgets<QueryPlannerClass>(

--- a/test/RdfParserTest.cpp
+++ b/test/RdfParserTest.cpp
@@ -922,17 +922,20 @@ std::vector<TurtleTriple> parseFromFile(
 // `useBatchInterface` argument) and possible additional args, and run this
 // function for all the different parsers that can read from a file (stream and
 // parallel parser, with all the combinations of the different tokenizers).
-auto forAllParallelParsers(const auto& function, const auto&... args) {
+template <typename Function, typename... Args>
+auto forAllParallelParsers(const Function& function, const Args&... args) {
   function(ti<RdfParallelParser<TurtleParser<Tokenizer>>>, true, args...);
   function(ti<RdfParallelParser<TurtleParser<Tokenizer>>>, false, args...);
   function(ti<RdfParallelParser<TurtleParser<TokenizerCtre>>>, true, args...);
   function(ti<RdfParallelParser<TurtleParser<TokenizerCtre>>>, false, args...);
 }
-auto forAllMultifileParsers(const auto& function, const auto&... args) {
+template <typename Function, typename... Args>
+auto forAllMultifileParsers(const Function& function, const Args&... args) {
   function(ti<RdfMultifileParser>, true, args...);
 }
 
-auto forAllParsers(const auto& function, const auto&... args) {
+template <typename Function, typename... Args>
+auto forAllParsers(const Function& function, const Args&... args) {
   function(ti<RdfStreamParser<TurtleParser<Tokenizer>>>, true, args...);
   function(ti<RdfStreamParser<TurtleParser<Tokenizer>>>, false, args...);
   function(ti<RdfStreamParser<TurtleParser<TokenizerCtre>>>, true, args...);

--- a/test/RelationalExpressionTest.cpp
+++ b/test/RelationalExpressionTest.cpp
@@ -237,7 +237,8 @@ void testLessThanGreaterThanEqual(std::pair<L, R> lessThanPair,
 // Test that all comparisons between `leftValue` and `rightValue` result in a
 // single boolean that is false. The only exception is the `not equal`
 // comparison, for which true is expected.
-void testNotEqualHelper(auto leftValueIn, auto rightValueIn,
+template <typename LeftValueIn, typename RightValueIn>
+void testNotEqualHelper(LeftValueIn leftValueIn, RightValueIn rightValueIn,
                         source_location l = AD_CURRENT_SOURCE_LOC()) {
   auto leftValue = liftToValueId(leftValueIn);
   auto rightValue = liftToValueId(rightValueIn);
@@ -260,7 +261,8 @@ void testNotEqualHelper(auto leftValueIn, auto rightValueIn,
   False(makeExpression<GE>(makeCopy(rightValue), makeCopy(leftValue)));
 }
 
-void testUndefHelper(auto leftValueIn, auto rightValueIn,
+template <typename LeftValueIn, typename RightValueIn>
+void testUndefHelper(LeftValueIn leftValueIn, RightValueIn rightValueIn,
                      source_location l = AD_CURRENT_SOURCE_LOC()) {
   auto leftValue = liftToValueId(leftValueIn);
   auto rightValue = liftToValueId(rightValueIn);
@@ -286,7 +288,8 @@ void testUndefHelper(auto leftValueIn, auto rightValueIn,
 // following combinations: `leftValue` is converted to a ValueID before the
 // call. `rightValue` "" both values "" Requires that both `leftValue` and
 // `rightValue` are numeric constants.
-void testNotEqual(auto leftValue, auto rightValue,
+template <typename LeftValue, typename RightValue>
+void testNotEqual(LeftValue leftValue, RightValue rightValue,
                   source_location l = AD_CURRENT_SOURCE_LOC()) {
   auto trace = generateLocationTrace(l, "testNotEqual was called here");
   testNotEqualHelper(liftToValueId(leftValue), liftToValueId(rightValue));

--- a/test/WebSocketSessionTest.cpp
+++ b/test/WebSocketSessionTest.cpp
@@ -42,7 +42,9 @@ auto toBuffer(std::string_view view) {
 // server logic. Note that the client logic and the server logic are run
 // separately, meaning that they can't be cancelled and both have to run to
 // completion on their own.
-net::awaitable<void> runTest(auto executor, net::awaitable<void> serverLogic,
+template <typename Executor>
+net::awaitable<void> runTest(Executor executor,
+                             net::awaitable<void> serverLogic,
                              net::awaitable<void> clientLogic) {
   auto fut = std::async(std::launch::async, [&]() {
     net::co_spawn(executor, std::move(clientLogic), net::use_future).get();

--- a/test/engine/GroupByHashMapOptimizationTest.cpp
+++ b/test/engine/GroupByHashMapOptimizationTest.cpp
@@ -28,7 +28,8 @@ class GroupByHashMapOptimizationTest : public ::testing::Test {
       std::make_shared<ad_utility::CancellationHandle<>>(),
       sparqlExpression::EvaluationContext::TimePoint::max()};
 
-  Id calculate(const auto& data) {
+  template <typename Data>
+  Id calculate(const Data& data) {
     return data.calculateResult(qec_->getIndex(), &localVocab_);
   }
 

--- a/test/engine/IndexScanTest.cpp
+++ b/test/engine/IndexScanTest.cpp
@@ -929,10 +929,11 @@ class IndexScanWithLazyJoin : public ::testing::TestWithParam<bool>,
 
   // Consume range `first` first and store it in a vector, then do the same
   // with `second`.
+  template <typename PostCondition>
   static std::pair<std::vector<Result::IdTableVocabPair>,
                    std::vector<Result::IdTableVocabPair>>
   consumeSequentially(Result::LazyResult first, Result::LazyResult second,
-                      auto postCondition) {
+                      PostCondition postCondition) {
     std::vector<Result::IdTableVocabPair> firstResult;
     std::vector<Result::IdTableVocabPair> secondResult;
 

--- a/test/parser/SparqlAntlrParserExpressionTest.cpp
+++ b/test/parser/SparqlAntlrParserExpressionTest.cpp
@@ -603,9 +603,10 @@ using namespace sparqlExpression;
 // points to an `AggregateExpr`, that the distinctness and the child variable of
 // the aggregate expression match, and that the `AggregateExpr`(via dynamic
 // cast) matches all the `additionalMatchers`.
-template <typename AggregateExpr>
+template <typename AggregateExpr, typename... AdditionalMatchers>
 ::testing::Matcher<const SparqlExpression::Ptr&> matchAggregate(
-    bool distinct, const Variable& child, const auto&... additionalMatchers) {
+    bool distinct, const Variable& child,
+    const AdditionalMatchers&... additionalMatchers) {
   using namespace ::testing;
   using namespace m::builtInCall;
   using Exp = SparqlExpression;

--- a/test/parser/SparqlAntlrParserTestHelpers.h
+++ b/test/parser/SparqlAntlrParserTestHelpers.h
@@ -742,27 +742,32 @@ inline auto RootGraphPattern = [](const Matcher<const p::GraphPattern&>& m)
 
 template <auto SubMatcherLambda>
 struct MatcherWithDefaultFilters {
+  template <typename... ChildMatchers>
   Matcher<const p::GraphPatternOperation&> operator()(
-      std::vector<std::string>&& filters, const auto&... childMatchers) {
+      std::vector<std::string>&& filters,
+      const ChildMatchers&... childMatchers) {
     return SubMatcherLambda(std::move(filters), childMatchers...);
   }
 
+  template <typename... ChildMatchers>
   Matcher<const p::GraphPatternOperation&> operator()(
-      const auto&... childMatchers) {
+      const ChildMatchers&... childMatchers) {
     return SubMatcherLambda({}, childMatchers...);
   }
 };
 
 template <auto SubMatcherLambda>
 struct MatcherWithDefaultFiltersAndOptional {
+  template <typename... ChildMatchers>
   Matcher<const ParsedQuery::GraphPattern&> operator()(
       bool optional, std::vector<std::string>&& filters,
-      const auto&... childMatchers) {
+      const ChildMatchers&... childMatchers) {
     return SubMatcherLambda(optional, std::move(filters), childMatchers...);
   }
 
+  template <typename... ChildMatchers>
   Matcher<const ParsedQuery::GraphPattern&> operator()(
-      const auto&... childMatchers) {
+      const ChildMatchers&... childMatchers) {
     return SubMatcherLambda(false, {}, childMatchers...);
   }
 };
@@ -1059,8 +1064,9 @@ CPP_template(typename Expression, typename... Children)(requires(
 // (via `dynamic_cast`) to an object of the same type that a call to the
 // `makeFunction` yields. The matcher also checks that the expression's children
 // match the `childrenMatchers`.
-auto matchNaryWithChildrenMatchers(auto makeFunction,
-                                   auto&&... childrenMatchers)
+template <typename MakeFunction, typename... ChildrenMatchers>
+auto matchNaryWithChildrenMatchers(MakeFunction makeFunction,
+                                   ChildrenMatchers&&... childrenMatchers)
     -> Matcher<const SparqlExpression::Ptr&> {
   using namespace sparqlExpression;
   auto typeIdLambda = [](const auto& ptr) {
@@ -1089,9 +1095,10 @@ inline auto idExpressionMatcher = [](Id id) {
 // (via `dynamic_cast`) to an object of the same type that a call to the
 // `makeFunction` yields. The matcher also checks that the expression's children
 // are the `variables`.
-auto matchNary(auto makeFunction,
-               QL_CONCEPT_OR_NOTHING(
-                   ad_utility::SimilarTo<::Variable>) auto&&... variables)
+template <
+    typename MakeFunction,
+    QL_CONCEPT_OR_TYPENAME(ad_utility::SimilarTo<::Variable>)... Variables>
+auto matchNary(MakeFunction makeFunction, Variables&&... variables)
     -> Matcher<const sparqlExpression::SparqlExpression::Ptr&> {
   using namespace sparqlExpression;
   return matchNaryWithChildrenMatchers(makeFunction,


### PR DESCRIPTION
In C++20, function parameters can be declared with `auto` (e.g. `void f(auto x) {...}`), which is not part of C++17. While GCC-8 accepts such parameters with a warning even in C++17 mode, we want to get rid of this warning to have a proper C++17 subset build for the QNX/QCC target platform. All these implicit template parameters are now replaced by explicit template parameters, without any change in behavior. For the same reason, the helper macros in the block-zipper join, which expanded to `auto` parameters constrained by a concept, are split into one variant for template heads and one for lambda parameters.