### PR TITLE
Fix integer overflow when computing a permutation's triple count

### DIFF
--- a/src/index/IndexMetaData.cpp
+++ b/src/index/IndexMetaData.cpp
@@ -92,7 +92,14 @@ std::string IndexMetaData::statistics() const {
 // __________________________________________________________________
 void IndexMetaData::calculateStatistics(size_t numDistinctCol0) {
   numDistinctCol0_ = numDistinctCol0;
-  totalElements_ = ::ranges::accumulate(blockData(), 0, {},
+  // NOTE: The accumulator must be a `size_t`. With the literal `0` the
+  // accumulator was an `int`, which overflows once a permutation has more than
+  // ~2^31 rows and wraps `totalElements_` to a garbage value. Since
+  // `totalElements_` is `Permutation::numTriples()`, which feeds the query
+  // planner's size estimates, such a wrapped value (e.g. a large count that
+  // wraps to a huge `size_t` near 2^64) leads to catastrophically wrong plans,
+  // not just a wrong number in the log.
+  totalElements_ = ::ranges::accumulate(blockData(), size_t{0}, {},
                                         &CompressedBlockMetadata::numRows_);
 }
 


### PR DESCRIPTION
With #2971, `IndexMetaData::calculateStatistics` sums the per-block row counts into an `int` accumulator (the literal `0`). For a permutation with more than ~2^31 rows this overflows and wraps `totalElements_` to a garbage value. This value is used in query planning for estimating the size of a full index scans. This can lead to catastrophic query plans, resulting in queries that never finish. The fix is simple: Use a `size_t` accumulator so the sum no longer overflows.

NOTE: the value is serialized into the trailing metadata of each permutation file at build time, so indexes built with an affected binary keep the wrong value and must be rebuilt to benefit from this fix.