### PR TITLE
Use the `mold` linker and `PRE_TEST` gtest discovery in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ FROM base AS builder
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y wget
 RUN wget https://apt.kitware.com/kitware-archive.sh && chmod +x kitware-archive.sh && ./kitware-archive.sh
-RUN apt-get update && apt-get install -y build-essential cmake libicu-dev tzdata pkg-config uuid-runtime uuid-dev git libjemalloc-dev ninja-build libzstd-dev libssl-dev libboost1.83-dev libboost-program-options1.83-dev libboost-iostreams1.83-dev libboost-url1.83-dev libboost-container1.83-dev
+RUN apt-get update && apt-get install -y build-essential cmake libicu-dev tzdata pkg-config uuid-runtime uuid-dev git libjemalloc-dev ninja-build libzstd-dev libssl-dev mold libboost1.83-dev libboost-program-options1.83-dev libboost-iostreams1.83-dev libboost-url1.83-dev libboost-container1.83-dev
 
 # Copy everything we need to build the binaries.
 #
@@ -34,9 +34,15 @@ COPY GitVersion.cmake /qlever/
 # to, build the image with `--build-arg RUN_TESTS=false`.
 # `-DCOMPILER_SUPPORTS_MARCH_NATIVE=FALSE` prevents fsst from compiling with
 # `-march=native`.
+# `-fuse-ld=mold` uses the `mold` linker, which is faster and much more
+# memory-efficient than the default linker (this helps to avoid OOM-like
+# crashes on our ARM64 CI). `CMAKE_GTEST_DISCOVER_TESTS_DISCOVERY_MODE=PRE_TEST`
+# defers GoogleTest test discovery from build time to test time, which avoids
+# running all test binaries in parallel right after building (another source of
+# excessive memory usage on the ARM64 CI).
 ARG RUN_TESTS=true
 WORKDIR /qlever/build/
-RUN cmake -DCMAKE_BUILD_TYPE=Release -DLOGLEVEL=INFO -DUSE_PARALLEL=true -D_NO_TIMING_TESTS=ON -DCOMPILER_SUPPORTS_MARCH_NATIVE=FALSE -GNinja ..
+RUN cmake -DCMAKE_BUILD_TYPE=Release -DLOGLEVEL=INFO -DUSE_PARALLEL=true -D_NO_TIMING_TESTS=ON -DCOMPILER_SUPPORTS_MARCH_NATIVE=FALSE -DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=mold" -DCMAKE_SHARED_LINKER_FLAGS="-fuse-ld=mold" -DCMAKE_GTEST_DISCOVER_TESTS_DISCOVERY_MODE=PRE_TEST -GNinja ..
 RUN if [ "$RUN_TESTS" = "true" ]; then \
       cmake --build . && ctest --rerun-failed --output-on-failure; \
     else \

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,14 +35,17 @@ COPY GitVersion.cmake /qlever/
 # `-DCOMPILER_SUPPORTS_MARCH_NATIVE=FALSE` prevents fsst from compiling with
 # `-march=native`.
 # `-fuse-ld=mold` uses the `mold` linker, which is faster and much more
-# memory-efficient than the default linker (this helps to avoid OOM-like
-# crashes on our ARM64 CI). `CMAKE_GTEST_DISCOVER_TESTS_DISCOVERY_MODE=PRE_TEST`
+# memory-efficient than the default linker. `CMAKE_GTEST_DISCOVER_TESTS_DISCOVERY_MODE=PRE_TEST`
 # defers GoogleTest test discovery from build time to test time, which avoids
-# running all test binaries in parallel right after building (another source of
-# excessive memory usage on the ARM64 CI).
+# running all test binaries while building/linking other tests. Both these
+# changes aim to mitigate crashes in the CI for ARM64 docker builds, which we
+# suspect to be caused by the OOM-killer.
+# `-Wno-psabi` silences very frequent notes in the ARM build that inform us that
+# QLever might not be ABI-compatible on ARM with software compiled on a compiler
+# older than GCC10.
 ARG RUN_TESTS=true
 WORKDIR /qlever/build/
-RUN cmake -DCMAKE_BUILD_TYPE=Release -DLOGLEVEL=INFO -DUSE_PARALLEL=true -D_NO_TIMING_TESTS=ON -DCOMPILER_SUPPORTS_MARCH_NATIVE=FALSE -DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=mold" -DCMAKE_SHARED_LINKER_FLAGS="-fuse-ld=mold" -DCMAKE_GTEST_DISCOVER_TESTS_DISCOVERY_MODE=PRE_TEST -GNinja ..
+RUN cmake -DCMAKE_BUILD_TYPE=Release -DLOGLEVEL=INFO -DUSE_PARALLEL=true -D_NO_TIMING_TESTS=ON -DCOMPILER_SUPPORTS_MARCH_NATIVE=FALSE -DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=mold" -DCMAKE_SHARED_LINKER_FLAGS="-fuse-ld=mold" -DCMAKE_GTEST_DISCOVER_TESTS_DISCOVERY_MODE=PRE_TEST -DCMAKE_CXX_FLAGS="-Wno-psabi" -GNinja ..
 RUN if [ "$RUN_TESTS" = "true" ]; then \
       cmake --build . && ctest --rerun-failed --output-on-failure; \
     else \

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && apt-get install -y build-essential cmake libicu-dev tzdata
 # NOTE: We are deliberately explicit here, for two reasons. First, so that we
 # don't copy more than necessary without having to rely on `.dockerignore`.
 # Second, so that we can copy `docker-entrypoint.sh` separately below (we don't
-# to rebuild the whole container when making a small change in there).
+# want to rebuild the whole container when making a small change in there).
 COPY src /qlever/src/
 COPY test /qlever/test/
 COPY e2e /qlever/e2e/
@@ -36,10 +36,11 @@ COPY GitVersion.cmake /qlever/
 # `-march=native`.
 # `-fuse-ld=mold` uses the `mold` linker, which is faster and much more
 # memory-efficient than the default linker. `CMAKE_GTEST_DISCOVER_TESTS_DISCOVERY_MODE=PRE_TEST`
-# defers GoogleTest test discovery from build time to test time, which avoids
-# running all test binaries while building/linking other tests. Both these
-# changes aim to mitigate crashes in the CI for ARM64 docker builds, which we
-# suspect to be caused by the OOM-killer.
+# defers GoogleTest test discovery from build time to test time; by default,
+# each test binary is executed right after it is built to enumerate its test
+# cases, which costs memory while other tests are still being compiled and
+# linked. Both these changes aim to mitigate crashes in the CI for ARM64
+# docker builds, which we suspect to be caused by the OOM-killer.
 # `-Wno-psabi` silences very frequent notes in the ARM build that inform us that
 # QLever might not be ABI-compatible on ARM with software compiled on a compiler
 # older than GCC10.


### PR DESCRIPTION
For two days now, the ARM Docker builds in the CI have been crashing consistently, at inconsistent places, which looks like the work of the OOM killer (the ARM build is emulated and hence particularly memory-constrained). This is addressed by three changes to the `Dockerfile`:

1. Link with the `mold` linker (`-fuse-ld=mold`), which is faster and consumes much less RAM than the default linker.
2. Let CMake discover the unit tests only when `ctest` is run (`CMAKE_GTEST_DISCOVER_TESTS_DISCOVERY_MODE=PRE_TEST`); by default, each test executable is run for test discovery right after it is built, while other tests are still being compiled and linked.
3. Silence the very frequent note in the ARM build about ABI incompatibility with compilers older than GCC 10 (`-Wno-psabi`).

The first two reduce the RAM consumption during compilation and linking. The third makes the log of the ARM build readable again: the note appears so often that GitHub truncates the log, which is capped at 2 MB.