### PR TITLE
Add a fast path for materialized and lazy merge joins without LocalVocabs and UNDEFs

### DIFF
--- a/src/engine/JoinImpl.cpp
+++ b/src/engine/JoinImpl.cpp
@@ -306,7 +306,7 @@ void JoinImpl::computeSizeEstimateAndMultiplicities() {
 // ______________________________________________________________________________
 
 void JoinImpl::join(const IdTableView<0>& a, const IdTableView<0>& b,
-                    IdTable* result) const {
+                    IdTable* result, bool joinColumnsAreBitComparable) const {
   AD_LOG_DEBUG << "Performing join between two tables.\n";
   AD_LOG_DEBUG << "A: width = " << a.numColumns() << ", size = " << a.size()
                << "\n";
@@ -332,6 +332,16 @@ void JoinImpl::join(const IdTableView<0>& a, const IdTableView<0>& b,
                  beginRight = joinColumnR.begin(),
                  &rowAdder](const auto& itLeft, const auto& itRight) {
     rowAdder.addRow(itLeft - beginLeft, itRight - beginRight);
+  };
+  // Run emitter for the fast path below, using the same `addRow`/`addRows`.
+  auto emitRun = [&rowAdder](size_t iBegin, size_t iEnd, size_t jBegin,
+                             size_t jEnd) {
+    if (iEnd - iBegin == 1 && jEnd - jBegin == 1) {
+      rowAdder.addRow(iBegin, jBegin);
+    } else {
+      rowAdder.addRows(ql::views::iota(iBegin, iEnd),
+                       ql::views::iota(jBegin, jEnd));
+    }
   };
 
   // The UNDEF values are right at the start, so this calculation works.
@@ -368,8 +378,16 @@ void JoinImpl::join(const IdTableView<0>& a, const IdTableView<0>& b,
       return ad_utility::IteratorRange{undefRangeB.first, undefRangeB.second};
     };
 
-    auto numOutOfOrder = [&]() {
+    auto numOutOfOrder = [&]() -> size_t {
       if (numUndefB == 0 && numUndefA == 0) {
+        bool useBitComparison =
+            joinColumnsAreBitComparable &&
+            getRuntimeParameter<&RuntimeParameters::enableJoinBitComparison_>();
+        if (useBitComparison) {
+          ad_utility::zipperJoinWithoutUndefOrLocalVocab(
+              joinColumnL, joinColumnR, emitRun, cancellationCallback);
+          return 0;  // no UNDEF, so the output is sorted
+        }
         return ad_utility::zipperJoinWithUndef(
             joinColumnL, joinColumnR, ql::ranges::less{}, addRow,
             ad_utility::noop, ad_utility::noop, {}, cancellationCallback);
@@ -710,7 +728,11 @@ Result JoinImpl::computeResultForTwoMaterializedInputs(
     std::shared_ptr<const Result> leftRes,
     std::shared_ptr<const Result> rightRes) const {
   IdTable idTable{getResultWidth(), allocator()};
-  join(leftRes->idTableView(), rightRes->idTableView(), &idTable);
+  // Empty local vocabs -> no `LocalVocabIndex` -> bitwise comparable.
+  bool bitComparable =
+      leftRes->localVocab().empty() && rightRes->localVocab().empty();
+  join(leftRes->idTableView(), rightRes->idTableView(), &idTable,
+       bitComparable);
   checkCancellation();
 
   return {std::move(idTable), resultSortedOn(),

--- a/src/engine/JoinImpl.h
+++ b/src/engine/JoinImpl.h
@@ -93,8 +93,8 @@ class JoinImpl : public Operation {
    * TODO Move the merge join into it's own function and make this function
    * a proper switch.
    **/
-  void join(const IdTableView<0>& a, const IdTableView<0>& b,
-            IdTable* result) const;
+  void join(const IdTableView<0>& a, const IdTableView<0>& b, IdTable* result,
+            bool joinColumnsAreBitComparable) const;
 
  public:
   // Fallback implementation of a join that is used when at least one of the two

--- a/src/global/RuntimeParameters.cpp
+++ b/src/global/RuntimeParameters.cpp
@@ -53,6 +53,7 @@ RuntimeParameters::RuntimeParameters() {
   add(defaultQueryTimeout_);
   add(sortInMemoryThreshold_);
   add(prefilteredOptionalJoin_);
+  add(enableJoinBitComparison_);
   add(enableMaterializedViewQueryRewrite_);
   add(serviceAllowedIriPrefixes_);
   add(permutationWriterNumThreads_);

--- a/src/global/RuntimeParameters.h
+++ b/src/global/RuntimeParameters.h
@@ -149,6 +149,11 @@ struct RuntimeParameters {
 
   Bool prefilteredOptionalJoin_{true, "prefiltered-optional-join"};
 
+  // Fast path for the sort-merge `Join` comparing `Id`s via
+  // `compareWithoutLocalVocab` when no join column has UNDEF or local-vocab
+  // values. Off forces the general join.
+  Bool enableJoinBitComparison_{true, "enable-join-bit-comparison"};
+
   // If set, the query planner checks if suitable materialized views are loaded
   // to substitute more expensive query plans.
   Bool enableMaterializedViewQueryRewrite_{

--- a/src/util/JoinAlgorithms/JoinAlgorithms.h
+++ b/src/util/JoinAlgorithms/JoinAlgorithms.h
@@ -347,6 +347,74 @@ CPP_template(typename Range1, typename Range2, typename LessThan,
   return numOutOfOrder;
 }
 
+// Merge-join two sorted, UNDEF-free, bitwise-comparable `Id` ranges via
+// `ValueId::compareWithoutLocalVocab`, matching `zipperJoinWithUndef` but
+// skipping its datatype-dispatching `compareThreeWay`.
+CPP_template(typename Range1, typename Range2, typename EmitRun,
+             typename CheckCancellation = decltype(noop))(
+    requires ql::ranges::random_access_range<Range1> CPP_and
+        ql::ranges::random_access_range<
+            Range2>) void zipperJoinWithoutUndefOrLocalVocab(const Range1& left,
+                                                             const Range2&
+                                                                 right,
+                                                             const EmitRun&
+                                                                 emitRun,
+                                                             CheckCancellation
+                                                                 checkCancellation =
+                                                                     {}) {
+  const size_t n = ql::ranges::size(left);
+  const size_t m = ql::ranges::size(right);
+  auto l = ql::ranges::begin(left);
+  auto r = ql::ranges::begin(right);
+
+  AD_EXPENSIVE_CHECK(ql::ranges::is_sorted(left));
+  AD_EXPENSIVE_CHECK(ql::ranges::is_sorted(right));
+  AD_EXPENSIVE_CHECK(ql::ranges::all_of(
+      left, [](Id id) { return id.canBeComparedBitwise(); }));
+  AD_EXPENSIVE_CHECK(ql::ranges::all_of(
+      right, [](Id id) { return id.canBeComparedBitwise(); }));
+  // UNDEF is bitwise comparable but needs the general join's UNDEF handling.
+  AD_EXPENSIVE_CHECK(
+      ql::ranges::none_of(left, [](Id id) { return id.isUndefined(); }));
+  AD_EXPENSIVE_CHECK(
+      ql::ranges::none_of(right, [](Id id) { return id.isUndefined(); }));
+
+  constexpr size_t CANCELLATION_STRIDE = size_t{1} << 16;
+  size_t sinceCancellation = 0;
+
+  size_t i = 0;
+  size_t j = 0;
+  while (i < n && j < m) {
+    const size_t rowsBefore = i + j;
+    const Id a = l[i];
+    const Id b = r[j];
+    const auto c = a.compareWithoutLocalVocab(b);
+    if (c < 0) {
+      ++i;
+    } else if (c > 0) {
+      ++j;
+    } else {
+      size_t iEnd = i + 1;
+      while (iEnd < n && l[iEnd].compareWithoutLocalVocab(a) == 0) {
+        ++iEnd;
+      }
+      size_t jEnd = j + 1;
+      while (jEnd < m && r[jEnd].compareWithoutLocalVocab(b) == 0) {
+        ++jEnd;
+      }
+      emitRun(i, iEnd, j, jEnd);
+      i = iEnd;
+      j = jEnd;
+    }
+    // Count rows consumed, not iterations (a duplicate run advances by many).
+    sinceCancellation += (i + j) - rowsBefore;
+    if (sinceCancellation >= CANCELLATION_STRIDE) {
+      checkCancellation();
+      sinceCancellation = 0;
+    }
+  }
+}
+
 /**
  *
  * @brief Perform the galloping join algorithm on a `smaller` and a `larger`

--- a/src/util/JoinAlgorithms/JoinAlgorithms.h
+++ b/src/util/JoinAlgorithms/JoinAlgorithms.h
@@ -17,6 +17,7 @@
 #include "backports/span.h"
 #include "engine/idTable/IdTable.h"
 #include "global/Id.h"
+#include "global/RuntimeParameters.h"
 #include "util/InputRangeUtils.h"
 #include "util/JoinAlgorithms/FindUndefRanges.h"
 #include "util/JoinAlgorithms/JoinColumnMapping.h"
@@ -30,7 +31,14 @@ namespace ad_utility {
 namespace joinAlgorithms::detail {
 template <typename T, typename U>
 CPP_requires(HasMinus, requires(T&& a, U&& b)(a - b));
-}
+
+// Block types exposing `getLocalVocab()` (e.g. `IdTableAndFirstCols`); gates
+// the fast path out for generic block containers that lack it.
+template <typename T>
+CPP_requires(HasGetLocalVocabRequires, requires(const T& t)(t.getLocalVocab()));
+template <typename T>
+CPP_concept HasGetLocalVocab = CPP_requires_ref(HasGetLocalVocabRequires, T);
+}  // namespace joinAlgorithms::detail
 
 // A  function `F` fulfills `UnaryIteratorFunction` if it can be called with a
 // single argument of the `Range`'s iterator type (NOT value type).
@@ -969,6 +977,9 @@ CPP_template(typename Derived, typename LeftSide, typename RightSide,
   // The callback that is called for each pair of matching rows.
   CompatibleRowAction& compatibleRowAction_;
   [[no_unique_address]] IsUndef isUndefined_{};
+  // The bit fast-path flag, read once per join instead of per block pair.
+  bool enableBitComparison_ =
+      getRuntimeParameter<&RuntimeParameters::enableJoinBitComparison_>();
 
   // Constructor.
   BlockZipperJoinImplCRTP(LeftSide leftSide, RightSide rightSide,
@@ -1293,6 +1304,35 @@ CPP_template(typename Derived, typename LeftSide, typename RightSide,
           ql::ranges::subrange{subrangeRight.begin(), currentElItR},
           RowIndexAdder{addRowIndex, addRowIndices}, AD_FWD(args)...);
     };
+    // Fast path for a plain inner JOIN on one `Id` column, `std::less`, and no
+    // local vocab (always true for index-scan blocks). Emits via the same
+    // `addRowIndices` as `doJoin`; returns whether it handled the join.
+    auto tryFastPath = [&]() -> bool {
+      // Only `std::less` agrees with raw bit order (excludes e.g. the special
+      // optional join's `CompareAllButLast`).
+      if constexpr (!DoOptionalJoinOrMinus &&
+                    ql::concepts::same_as<ProjectedEl, Id> &&
+                    std::is_same_v<LessThan, std::less<>> &&
+                    joinAlgorithms::detail::HasGetLocalVocab<
+                        std::decay_t<decltype(fullBlockLeft)>> &&
+                    joinAlgorithms::detail::HasGetLocalVocab<
+                        std::decay_t<decltype(fullBlockRight)>>) {
+        if (enableBitComparison_ && fullBlockLeft.getLocalVocab().empty() &&
+            fullBlockRight.getLocalVocab().empty()) {
+          auto subLBegin = subrangeLeft.begin();
+          auto subRBegin = subrangeRight.begin();
+          auto emitRun = [&](size_t i, size_t iEnd, size_t j, size_t jEnd) {
+            addRowIndices(subLBegin + i, subLBegin + iEnd, subRBegin + j,
+                          subRBegin + jEnd);
+          };
+          ad_utility::zipperJoinWithoutUndefOrLocalVocab(
+              ql::ranges::subrange{subLBegin, currentElItL},
+              ql::ranges::subrange{subRBegin, currentElItR}, emitRun);
+          return true;
+        }
+      }
+      return false;
+    };
     // If we have undefined values stored, we need to provide a generator that
     // yields iterators to the individual undefined values.
     if constexpr (potentiallyHasUndef) {
@@ -1300,7 +1340,9 @@ CPP_template(typename Derived, typename LeftSide, typename RightSide,
       // use the simpler code path (with std::true_type for coverage).
       if (!hasUndef(leftSide_) && !hasUndef(rightSide_)) {
         // No UNDEFs found at runtime, use the simpler code path.
-        doJoin(noop, noop, addNotFoundRowIndex, noop, std::true_type{});
+        if (!tryFastPath()) {
+          doJoin(noop, noop, addNotFoundRowIndex, noop, std::true_type{});
+        }
       } else {
         // We pass `std::false_type`, to disable coverage checks for the
         // undefined values that are stored in `side.undefBlocks_`, which we
@@ -1312,7 +1354,9 @@ CPP_template(typename Derived, typename LeftSide, typename RightSide,
             addNotFoundRowIndex, noop, std::false_type{});
       }
     } else {
-      doJoin(noop, noop, addNotFoundRowIndex, noop, std::true_type{});
+      if (!tryFastPath()) {
+        doJoin(noop, noop, addNotFoundRowIndex, noop, std::true_type{});
+      }
     }
     compatibleRowAction_.flush();
 

--- a/test/JoinTest.cpp
+++ b/test/JoinTest.cpp
@@ -321,10 +321,21 @@ auto I = ad_utility::testing::IntId;
 using Var = Variable;
 }  // namespace
 
-struct JoinTestParametrized : public ::testing::TestWithParam<bool> {};
+struct JoinTestParametrized
+    : public ::testing::TestWithParam<std::tuple<bool, bool>> {
+ protected:
+  bool keepJoinColumn() const { return std::get<0>(GetParam()); }
+  // The second parameter forces the bit fast path off and on, so every test
+  // below runs both ways.
+  decltype(setRuntimeParameterForTest<
+           &RuntimeParameters::enableJoinBitComparison_>(
+      true)) bitComparisonCleanup_ =
+      setRuntimeParameterForTest<&RuntimeParameters::enableJoinBitComparison_>(
+          static_cast<bool>(std::get<1>(GetParam())));
+};
 
 TEST_P(JoinTestParametrized, joinWithFullScanPSO) {
-  bool keepJoinCol = GetParam();
+  bool keepJoinCol = keepJoinColumn();
   auto qec = ad_utility::testing::getQec("<x> <p> 1. <x> <o> <x>. <x> <a> 3.");
   // Expressions in HAVING clauses are converted to special internal aliases.
   // Test the combination of parsing and evaluating such queries.
@@ -389,7 +400,7 @@ TEST_P(JoinTestParametrized, joinWithFullScanPSO) {
 // maximal size for materialized index scans. That's why they are run twice with
 // different settings.
 TEST_P(JoinTestParametrized, joinWithColumnAndScan) {
-  bool keepJoinCol = GetParam();
+  bool keepJoinCol = keepJoinColumn();
   auto test = [keepJoinCol](size_t materializationThreshold) {
     auto qec = ad_utility::testing::getQec("<x> <p> 1. <x2> <p> 2. <x> <a> 3.");
     auto cleanup = setRuntimeParameterForTest<
@@ -427,7 +438,7 @@ TEST_P(JoinTestParametrized, joinWithColumnAndScan) {
 }
 
 TEST_P(JoinTestParametrized, joinWithColumnAndScanEmptyInput) {
-  auto keepJoinCol = GetParam();
+  auto keepJoinCol = keepJoinColumn();
   auto test = [keepJoinCol](size_t materializationThreshold,
                             bool lazyJoinValues) {
     auto qec = ad_utility::testing::getQec("<x> <p> 1. <x2> <p> 2. <x> <a> 3.");
@@ -470,7 +481,7 @@ TEST_P(JoinTestParametrized, joinWithColumnAndScanEmptyInput) {
 }
 
 TEST_P(JoinTestParametrized, joinWithColumnAndScanUndefValues) {
-  auto keepJoinCol = GetParam();
+  auto keepJoinCol = keepJoinColumn();
   auto test = [keepJoinCol](size_t materializationThreshold,
                             bool lazyJoinValues) {
     auto qec = ad_utility::testing::getQec("<x> <p> 1. <x2> <p> 2. <x> <a> 3.");
@@ -524,7 +535,7 @@ TEST_P(JoinTestParametrized, joinWithColumnAndScanUndefValues) {
 }
 
 TEST_P(JoinTestParametrized, joinTwoScans) {
-  auto keepJoinCol = GetParam();
+  auto keepJoinCol = keepJoinColumn();
   auto test = [keepJoinCol](size_t materializationThreshold) {
     auto qec = ad_utility::testing::getQec(
         "<x> <p> 1. <x2> <p> 2. <x> <p2> 3 . <x2> <p2> 4. <x3> <p2> 7. ");
@@ -575,7 +586,7 @@ TEST_P(JoinTestParametrized, joinTwoScans) {
 // https://github.com/ad-freiburg/qlever/issues/1893 and heavily simplified so
 // it can be reproduced in a unit test.
 TEST_P(JoinTestParametrized, joinTwoScansWithDifferentGraphs) {
-  auto keepJoinCol = GetParam();
+  auto keepJoinCol = keepJoinColumn();
   ad_utility::testing::TestIndexConfig config{
       "<x> <p1> <1> <g1> . <x> <p1> <2> <g1> . <x> <p2> <1> <g2> ."
       " <x> <p2> <2> <g2> ."};
@@ -618,7 +629,7 @@ TEST_P(JoinTestParametrized, joinTwoScansWithDifferentGraphs) {
 TEST_P(JoinTestParametrized, joinTwoScansWithSubjectInMultipleBlocks) {
   // Default block size is 16 bytes for testing, so the triples are spread
   // across 3 blocks in total.
-  auto keepJoinCol = GetParam();
+  auto keepJoinCol = keepJoinColumn();
   auto qec = ad_utility::testing::getQec(
       "<x> <p1> <1> . <x> <p1> <2> . <x> <p1> <3> . <x> <p1> <4> ."
       " <x> <p2> <5>");
@@ -666,7 +677,7 @@ TEST(JoinTest, invalidJoinVariable) {
 
 // _____________________________________________________________________________
 TEST_P(JoinTestParametrized, joinTwoLazyOperationsWithAndWithoutUndefValues) {
-  auto keepJoinCol = GetParam();
+  auto keepJoinCol = keepJoinColumn();
   auto performJoin =
       [keepJoinCol](std::vector<IdTable> leftTables,
                     std::vector<IdTable> rightTables, const IdTable& expectedIn,
@@ -758,7 +769,7 @@ TEST_P(JoinTestParametrized, joinTwoLazyOperationsWithAndWithoutUndefValues) {
 // _____________________________________________________________________________
 TEST_P(JoinTestParametrized,
        joinLazyAndNonLazyOperationWithAndWithoutUndefValues) {
-  auto keepJoinCol = GetParam();
+  auto keepJoinCol = keepJoinColumn();
   auto performJoin =
       [keepJoinCol](IdTable leftTable, std::vector<IdTable> rightTables,
                     const IdTable& expectedIn,
@@ -841,7 +852,7 @@ TEST_P(JoinTestParametrized,
 
 // _____________________________________________________________________________
 TEST_P(JoinTestParametrized, errorInSeparateThreadIsPropagatedCorrectly) {
-  auto keepJoinCol = GetParam();
+  auto keepJoinCol = keepJoinColumn();
   auto qec = ad_utility::testing::getQec();
   auto cleanup = setRuntimeParameterForTest<
       &RuntimeParameters::lazyIndexScanMaxSizeMaterialization_>(0);
@@ -863,7 +874,7 @@ TEST_P(JoinTestParametrized, errorInSeparateThreadIsPropagatedCorrectly) {
 
 // _____________________________________________________________________________
 TEST_P(JoinTestParametrized, verifyColumnPermutationsAreAppliedCorrectly) {
-  auto keepJoinCol = GetParam();
+  auto keepJoinCol = keepJoinColumn();
   auto qec =
       ad_utility::testing::getQec("<x> <p> <g>. <x2> <p> <h>. <x> <a> <i>.");
   auto cleanup = setRuntimeParameterForTest<
@@ -954,7 +965,7 @@ TEST(JoinTest, clone) {
 
 // _____________________________________________________________________________
 TEST_P(JoinTestParametrized, columnOriginatesFromGraphOrUndef) {
-  auto keepJoinCol = GetParam();
+  auto keepJoinCol = keepJoinColumn();
   using ad_utility::triple_component::Iri;
   auto* qec = ad_utility::testing::getQec();
   // Not in graph no undef
@@ -1092,4 +1103,6 @@ TEST(JoinTest, lazyJoinIndexScanDetails) {
 
 // _____________________________________________________________________________
 INSTANTIATE_TEST_SUITE_P(JoinTestWithAndWithoutKeptJoinColumn,
-                         JoinTestParametrized, ::testing::Values(true, false));
+                         JoinTestParametrized,
+                         ::testing::Combine(::testing::Values(true, false),
+                                            ::testing::Values(true, false)));

--- a/test/JoinTest.cpp
+++ b/test/JoinTest.cpp
@@ -229,6 +229,17 @@ TEST(JoinTest, joinTest) {
   runTestCasesForAllJoinAlgorithms(createJoinTestSet());
 };
 
+// The bit fast path (default on) must produce the same results as the general
+// join: run the shared test set with `enable-join-bit-comparison` forced off
+// and on, each checked against the same expected results.
+TEST(JoinTest, bitFastPathMatchesGeneralJoin) {
+  for (bool enabled : {false, true}) {
+    auto cleanup = setRuntimeParameterForTest<
+        &RuntimeParameters::enableJoinBitComparison_>(enabled);
+    runTestCasesForAllJoinAlgorithms(createJoinTestSet());
+  }
+};
+
 // Several helpers for the test cases below.
 namespace {
 

--- a/test/util/JoinHelpers.h
+++ b/test/util/JoinHelpers.h
@@ -84,7 +84,14 @@ inline auto makeJoinLambda() {
         auto rightTree = ad_utility::makeExecutionTree<ValuesForTesting>(
             qec, b.clone(), std::move(rightVariables), false, std::vector{jc2});
         JoinImpl join{qec, leftTree, rightTree, jc1, jc2, true, false};
-        return join.join(a.asStaticView<0>(), b.asStaticView<0>(), result);
+        bool bitComparable =
+            ql::ranges::all_of(
+                a.getColumn(jc1),
+                [](Id id) { return id.canBeComparedBitwise(); }) &&
+            ql::ranges::all_of(b.getColumn(jc2),
+                               [](Id id) { return id.canBeComparedBitwise(); });
+        return join.join(a.asStaticView<0>(), b.asStaticView<0>(), result,
+                         bitComparable);
       }};
 }
 


### PR DESCRIPTION
When both sides of a join don't have `LocalVocab` and  there are no UNDEFs we can safely use  `compareWithoutLocalVocab` instead of `compareThreeWay`. In my experience it is an extremely common path in real queries.

I put it behind a flag for easy testing and there is a lot of code for that plumbing, but I think the flag is not actually needed.

some relevant sparqloscope results:

### wikidata truthy
| Query | Before (s) | After (s) | Speedup |
| :--- | ---: | ---: | ---: |
| join-2-large-large | 40.02 | 19.50 | 2.05× |
| join-2-largest-result | 30.86 | 21.24 | 1.45× |
| join-2-large-large-with-large-result | 18.29 | 11.30 | 1.62× |
| join-2-large-large-with-small-result | 0.63 | 0.33 | 1.94× |
| join-3-star-largest-sum-of-join-sizes | 24.14 | 13.58 | 1.78× |
| union-constraint-from-star | 21.17 | 11.75 | 1.80× |

### dblp

| Query | Before (ms) | After (ms) | Speedup |
| :--- | ---: | ---: | ---: |
| join-2-large-large | 355 | 201 | 1.77× |
| join-2-largest-result | 561 | 286 | 1.96× |
| join-2-large-large-with-large-result | 586 | 270 | 2.17× |
| join-3-star-largest-sum-of-join-sizes | 2383 | 1465 | 1.63× |
| union-constraint-from-star | 1660 | 656 | 2.53× |
| union-constraint-small-join | 129 | 58 | 2.22× |
| union-constraint-large-join | 1045 | 480 | 2.18× |

