### PR TITLE
Use an explicit loopback address in `HttpTest` for portability

### DIFF
--- a/test/HttpTest.cpp
+++ b/test/HttpTest.cpp
@@ -378,7 +378,9 @@ TYPED_TEST(HttpServerBodyTest, ErrorHandlingInSession) {
   // Docker cross-compilation build for ARM, this test sometimes fails because
   // we don't land in the correct catch clause for some reason. This needs
   // further debugging.
-  EXPECT_THAT(s, AnyOf(HasSubstr("not found"), Eq("")));
+  std::string expectedHostNotFound =
+      beast::system_error{boost::asio::error::host_not_found_try_again}.what();
+  EXPECT_THAT(s, AnyOf(HasSubstr(expectedHostNotFound), Eq("")));
 
   // The `timeout` and `eof` exceptions are only logged at `TRACE` level;
   // normally they are silently caught and ignored.
@@ -620,8 +622,9 @@ net::awaitable<void> withParsedRequest(std::string body, Fn fn) {
       ex,
       [](std::string body, unsigned short port) -> net::awaitable<void> {
         tcp::socket sock(co_await net::this_coro::executor);
-        co_await sock.async_connect(tcp::endpoint(tcp::v4(), port),
-                                    net::use_awaitable);
+        co_await sock.async_connect(
+            tcp::endpoint(net::ip::address_v4::loopback(), port),
+            net::use_awaitable);
         std::string request = absl::StrCat(
             "POST / HTTP/1.1\r\nHost: localhost\r\nContent-Length: ",
             body.size(), "\r\n\r\n", body);


### PR DESCRIPTION
So far, the test helper connected to the `0.0.0.0` wildcard address, which is not a valid connect target on all platforms, and the error-handling test checked the log against a hardcoded English substring of the host-not-found message, which is equally platform-dependent. Now the helper connects to the loopback address, and the test compares against the exact message of the very error that it throws itself.