### PR TITLE
For discussion: function registry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -585,6 +585,9 @@ add_subdirectory(src/util)
 add_subdirectory(src/rdfTypes)
 add_subdirectory(src/global)
 add_subdirectory(src/libqlever)
+# Compile-time extensions; before the binaries so their object libraries can be
+# linked into them below.
+add_subdirectory(src/extensions)
 
 ##################################################
 # Precompiled headers
@@ -685,6 +688,26 @@ if (NOT _EMSCRIPTEN_NO_INDEXBUILDER_AND_SERVER)
         RUNTIME DESTINATION bin
     )
 endif()
+
+# Aggregate the auto-detected extension object libraries into one interface
+# target. Linking it adds the objects directly to the consumer (not via an
+# archive), so their self-registrations survive the link. Any target that parses
+# queries must link it -- the query-parsing binaries below, and out-of-tree
+# embedders of the `qlever` library likewise (otherwise custom functions are
+# absent).
+get_property(extensionObjLibs GLOBAL PROPERTY QLEVER_EXTENSION_OBJLIBS)
+add_library(qleverExtensions INTERFACE)
+foreach (objLib ${extensionObjLibs})
+    # The object files, plus the library's own link dependencies and usage
+    # requirements (so an extension that pulls in extra libraries still links).
+    target_link_libraries(qleverExtensions INTERFACE
+            ${objLib} $<TARGET_OBJECTS:${objLib}>)
+endforeach ()
+foreach (target qlever-server qlever-index LibQLeverExample)
+    if (TARGET ${target})
+        target_link_libraries(${target} qleverExtensions)
+    endif ()
+endforeach ()
 
 ###############################################################
 # CPack packaging

--- a/src/extensions/CMakeLists.txt
+++ b/src/extensions/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Auto-detected extensions (e.g. custom SPARQL functions). Each subdirectory is
+# an OBJECT library, linked into the binaries by the top-level CMakeLists.
+file(GLOB entries CONFIGURE_DEPENDS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
+     ${CMAKE_CURRENT_SOURCE_DIR}/*)
+foreach (entry ${entries})
+    if (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${entry} AND
+        EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${entry}/CMakeLists.txt)
+        add_subdirectory(${entry})
+    endif ()
+endforeach ()

--- a/src/extensions/exampleFunctions/CMakeLists.txt
+++ b/src/extensions/exampleFunctions/CMakeLists.txt
@@ -1,0 +1,6 @@
+# Example custom-function extension: `increment`/`plus`, self-registering.
+add_library(extension_exampleFunctions OBJECT ExampleFunctions.cpp)
+qlever_target_link_libraries(extension_exampleFunctions parser sparqlExpressions
+        engine global)
+set_property(GLOBAL APPEND PROPERTY QLEVER_EXTENSION_OBJLIBS
+        extension_exampleFunctions)

--- a/src/extensions/exampleFunctions/ExampleFunctions.cpp
+++ b/src/extensions/exampleFunctions/ExampleFunctions.cpp
@@ -1,0 +1,52 @@
+// Copyright 2026 The QLever Authors, in particular:
+//
+// 2026 Artem <artem@rem.sh>
+
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+// Example custom SPARQL function extension (`increment`/`plus`). A template for
+// your own: copy this folder and change the IRIs and factories.
+
+#include <memory>
+
+#include "engine/sparqlExpressions/LiteralExpression.h"
+#include "engine/sparqlExpressions/NaryExpression.h"
+#include "global/Id.h"
+#include "parser/SparqlFunctionRegistry.h"
+
+namespace {
+using Expr = parsedQuery::SparqlFunctionRegistry::ExpressionPtr;
+using Args = parsedQuery::SparqlFunctionRegistry::ArgList;
+
+// increment(x) == x + 1
+Expr makeIncrement(Args args) {
+  if (args.size() != 1) {
+    throw parsedQuery::InvalidSparqlFunctionCall{
+        "increment() takes exactly one argument"};
+  }
+  return sparqlExpression::makeAddExpression(
+      std::move(args.at(0)),
+      std::make_unique<sparqlExpression::IdExpression>(Id::makeFromInt(1)));
+}
+
+// plus(x, y) == x + y
+Expr makePlus(Args args) {
+  if (args.size() != 2) {
+    throw parsedQuery::InvalidSparqlFunctionCall{
+        "plus() takes exactly two arguments"};
+  }
+  return sparqlExpression::makeAddExpression(std::move(args.at(0)),
+                                             std::move(args.at(1)));
+}
+
+// Self-register at load.
+[[maybe_unused]] const bool registered = [] {
+  auto& registry = parsedQuery::SparqlFunctionRegistry::get();
+  registry.addExact("<http://qlever.cs.uni-freiburg.de/example/increment>",
+                    &makeIncrement);
+  registry.addExact("<http://qlever.cs.uni-freiburg.de/example/plus>",
+                    &makePlus);
+  return true;
+}();
+}  // namespace

--- a/src/parser/CMakeLists.txt
+++ b/src/parser/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(parser
         TripleComponent.cpp
         GraphPatternOperation.cpp
         MagicServiceQuery.cpp
+        SparqlFunctionRegistry.cpp
         NamedCachedResult.cpp
         PathQuery.cpp
         SpatialQuery.cpp

--- a/src/parser/SparqlFunctionRegistry.cpp
+++ b/src/parser/SparqlFunctionRegistry.cpp
@@ -1,0 +1,48 @@
+// Copyright 2026 The QLever Authors, in particular:
+//
+// 2026 Artem <artem@rem.sh>
+
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#include "parser/SparqlFunctionRegistry.h"
+
+#include "rdfTypes/Iri.h"
+#include "util/Exception.h"
+
+namespace parsedQuery {
+
+// _____________________________________________________________________________
+SparqlFunctionRegistry& SparqlFunctionRegistry::get() {
+  static SparqlFunctionRegistry instance;
+  return instance;
+}
+
+// _____________________________________________________________________________
+void SparqlFunctionRegistry::addExact(std::string iri, Factory factory) {
+  AD_CONTRACT_CHECK(
+      !entries_.contains(iri),
+      "A custom SPARQL function is already registered for: ", iri);
+  // A valid IRI is unchanged by a round-trip through `Iri`, so it matches what
+  // `lookup` receives.
+  AD_CONTRACT_CHECK(
+      iri.size() >= 2 && iri.front() == '<' && iri.back() == '>' &&
+          ad_utility::triple_component::Iri::fromIriref(iri)
+                  .toStringRepresentation() == iri,
+      "A custom SPARQL function IRI must be a well-formed bracketed IRI, e.g. "
+      "`<http://example.org/f>`, but got: ",
+      iri);
+  entries_.try_emplace(std::move(iri), std::move(factory));
+}
+
+// _____________________________________________________________________________
+std::optional<SparqlFunctionRegistry::Factory> SparqlFunctionRegistry::lookup(
+    std::string_view iri) const {
+  auto it = entries_.find(iri);
+  if (it == entries_.end()) {
+    return std::nullopt;
+  }
+  return it->second;
+}
+
+}  // namespace parsedQuery

--- a/src/parser/SparqlFunctionRegistry.h
+++ b/src/parser/SparqlFunctionRegistry.h
@@ -1,0 +1,57 @@
+// Copyright 2026 The QLever Authors, in particular:
+//
+// 2026 Artem <artem@rem.sh>
+
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#ifndef QLEVER_SRC_PARSER_SPARQLFUNCTIONREGISTRY_H
+#define QLEVER_SRC_PARSER_SPARQLFUNCTIONREGISTRY_H
+
+#include <functional>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "util/HashMap.h"
+
+namespace sparqlExpression {
+class SparqlExpression;
+}
+
+namespace parsedQuery {
+
+// A factory throws this on a bad call (wrong arity or argument kinds); the
+// parser reports it as a query error. Any other exception propagates as an
+// internal error.
+class InvalidSparqlFunctionCall : public std::runtime_error {
+  using std::runtime_error::runtime_error;
+};
+
+// Registry of custom SPARQL functions: a function-call IRI to a factory that
+// builds its `SparqlExpression`. Functions come from drop-in extensions under
+// `src/extensions` that self-register at load.
+class SparqlFunctionRegistry {
+ public:
+  using ExpressionPtr = std::unique_ptr<sparqlExpression::SparqlExpression>;
+  using ArgList = std::vector<ExpressionPtr>;
+  using Factory = std::function<ExpressionPtr(ArgList)>;
+
+  static SparqlFunctionRegistry& get();
+
+  // `iri` is the function's well-formed bracketed IRI, e.g.
+  // `<http://example.org/f>`.
+  void addExact(std::string iri, Factory factory);
+
+  std::optional<Factory> lookup(std::string_view iri) const;
+
+ private:
+  ad_utility::HashMap<std::string, Factory> entries_;
+};
+
+}  // namespace parsedQuery
+
+#endif  // QLEVER_SRC_PARSER_SPARQLFUNCTIONREGISTRY_H

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -45,6 +45,7 @@
 #include "parser/PathQuery.h"
 #include "parser/Quads.h"
 #include "parser/RdfParser.h"
+#include "parser/SparqlFunctionRegistry.h"
 #include "parser/SparqlParser.h"
 #include "parser/SpatialQuery.h"
 #include "parser/TextSearchQuery.h"
@@ -52,6 +53,7 @@
 #include "rdfTypes/GeometryInfo.h"
 #include "rdfTypes/Variable.h"
 #include "util/Algorithm.h"
+#include "util/ParseException.h"
 #include "util/StringUtils.h"
 #include "util/TransparentFunctors.h"
 #include "util/TypeIdentity.h"
@@ -308,6 +310,16 @@ ExpressionPtr Visitor::processIriFunctionCall(
       return createBinary(&makePrefixMatchExpression);
     } else if (functionName == "simplifyGeometry") {
       return createBinary(&makeSimplifyGeometryExpression);
+    }
+  }
+
+  // Custom functions registered via `SparqlFunctionRegistry`.
+  if (auto factory = parsedQuery::SparqlFunctionRegistry::get().lookup(
+          iri.toStringRepresentation())) {
+    try {
+      return (*factory)(std::move(argList));
+    } catch (const parsedQuery::InvalidSparqlFunctionCall& e) {
+      reportError(ctx, e.what());
     }
   }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -551,3 +551,6 @@ addLinkAndDiscoverTest(LogTest)
 addLinkAndDiscoverTest(QueryEventLogTest util)
 
 addLinkAndDiscoverTest(ResourceMonitorTest util)
+
+# Tests for the extensions under `src/extensions`.
+add_subdirectory(extensions)

--- a/test/extensions/CMakeLists.txt
+++ b/test/extensions/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Auto-detected tests for the extensions under `src/extensions`.
+file(GLOB entries CONFIGURE_DEPENDS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
+     ${CMAKE_CURRENT_SOURCE_DIR}/*)
+foreach (entry ${entries})
+    if (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${entry} AND
+        EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${entry}/CMakeLists.txt)
+        add_subdirectory(${entry})
+    endif ()
+endforeach ()

--- a/test/extensions/exampleFunctions/CMakeLists.txt
+++ b/test/extensions/exampleFunctions/CMakeLists.txt
@@ -1,0 +1,3 @@
+# Links the extension object library so its self-registration runs.
+addLinkAndDiscoverTest(ExampleFunctionsTest extension_exampleFunctions parser
+        sparqlExpressions engine)

--- a/test/extensions/exampleFunctions/ExampleFunctionsTest.cpp
+++ b/test/extensions/exampleFunctions/ExampleFunctionsTest.cpp
@@ -1,0 +1,67 @@
+// Copyright 2026 The QLever Authors, in particular:
+//
+// 2026 Artem <artem@rem.sh>
+
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+// Verifies the example extension self-registered and computes correct values.
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <initializer_list>
+#include <memory>
+#include <string_view>
+#include <variant>
+
+#include "../../SparqlExpressionTestHelpers.h"
+#include "engine/sparqlExpressions/LiteralExpression.h"
+#include "global/Id.h"
+#include "parser/SparqlFunctionRegistry.h"
+
+namespace {
+using Registry = parsedQuery::SparqlFunctionRegistry;
+constexpr std::string_view kIncrement =
+    "<http://qlever.cs.uni-freiburg.de/example/increment>";
+constexpr std::string_view kPlus =
+    "<http://qlever.cs.uni-freiburg.de/example/plus>";
+
+// An argument list of integer-constant expressions.
+Registry::ArgList intArgs(std::initializer_list<int64_t> values) {
+  Registry::ArgList args;
+  for (int64_t v : values) {
+    args.push_back(
+        std::make_unique<sparqlExpression::IdExpression>(Id::makeFromInt(v)));
+  }
+  return args;
+}
+
+// Evaluate a constant expression to a single `Id`.
+Id evalConstant(Registry::ExpressionPtr expr) {
+  sparqlExpression::TestContext testContext;
+  return std::get<Id>(expr->evaluate(&testContext.context));
+}
+
+TEST(ExampleFunctions, selfRegistered) {
+  const auto& registry = Registry::get();
+  EXPECT_TRUE(registry.lookup(kIncrement).has_value());
+  EXPECT_TRUE(registry.lookup(kPlus).has_value());
+}
+
+TEST(ExampleFunctions, computeAndValidateArity) {
+  auto increment = Registry::get().lookup(kIncrement);
+  auto plus = Registry::get().lookup(kPlus);
+  ASSERT_TRUE(increment.has_value());
+  ASSERT_TRUE(plus.has_value());
+
+  // increment(41) == 42, plus(2, 3) == 5.
+  EXPECT_EQ(evalConstant((*increment)(intArgs({41}))), Id::makeFromInt(42));
+  EXPECT_EQ(evalConstant((*plus)(intArgs({2, 3}))), Id::makeFromInt(5));
+
+  // Wrong arity is rejected.
+  EXPECT_THROW((*increment)(intArgs({1, 2})),
+               parsedQuery::InvalidSparqlFunctionCall);
+  EXPECT_THROW((*plus)(intArgs({1})), parsedQuery::InvalidSparqlFunctionCall);
+}
+}  // namespace

--- a/test/parser/SparqlAntlrParserExpressionTest.cpp
+++ b/test/parser/SparqlAntlrParserExpressionTest.cpp
@@ -19,7 +19,9 @@
 #include "engine/sparqlExpressions/RelationalExpressions.h"
 #include "engine/sparqlExpressions/SampleExpression.h"
 #include "engine/sparqlExpressions/UuidExpressions.h"
+#include "parser/SparqlFunctionRegistry.h"
 #include "rdfTypes/GeometryInfo.h"
+#include "util/ParseException.h"
 
 namespace {
 using namespace sparqlParserHelpers;
@@ -552,6 +554,68 @@ TEST(SparqlParser, FunctionCall) {
       absl::StrCat(prefixNexistepas, "nada>(?x)"),
       matchPtr<IdExpression>(AD_PROPERTY(IdExpression, value,
                                          ::testing::Eq(Id::makeUndefined()))));
+}
+
+// ______________________________________________________________________________
+// A custom function registered in the `SparqlFunctionRegistry`.
+TEST(SparqlParser, customFunctionRegistry) {
+  using namespace sparqlExpression;
+  using namespace m::builtInCall;
+  auto expectFunctionCall = ExpectCompleteParse<&Parser::functionCall>{};
+  auto expectFunctionCallFails = ExpectParseFails<&Parser::functionCall>{};
+
+  const std::string funcIri = "<http://example.org/qlever-test/f>";
+  parsedQuery::SparqlFunctionRegistry::get().addExact(
+      funcIri,
+      [](parsedQuery::SparqlFunctionRegistry::ArgList args)
+          -> parsedQuery::SparqlFunctionRegistry::ExpressionPtr {
+        if (args.size() != 1) {
+          throw parsedQuery::InvalidSparqlFunctionCall{
+              "f() takes exactly one argument"};
+        }
+        return std::make_unique<IdExpression>(IntId(42));
+      });
+
+  expectFunctionCall(absl::StrCat(funcIri, "(?x)"),
+                     matchPtr<IdExpression>(AD_PROPERTY(
+                         IdExpression, value, ::testing::Eq(IntId(42)))));
+  // `InvalidSparqlFunctionCall` becomes a query error (400).
+  AD_EXPECT_THROW_WITH_MESSAGE_AND_TYPE(
+      parse<&Parser::functionCall>(absl::StrCat(funcIri, "(?x, ?y)")),
+      ::testing::HasSubstr("f() takes exactly one argument"),
+      InvalidSparqlQueryException);
+
+  // Any other exception propagates (500).
+  const std::string boomIri = "<http://example.org/qlever-test/boom>";
+  parsedQuery::SparqlFunctionRegistry::get().addExact(
+      boomIri,
+      [](parsedQuery::SparqlFunctionRegistry::ArgList)
+          -> parsedQuery::SparqlFunctionRegistry::ExpressionPtr {
+        throw std::runtime_error{"internal boom"};
+      });
+  AD_EXPECT_THROW_WITH_MESSAGE_AND_TYPE(
+      parse<&Parser::functionCall>(absl::StrCat(boomIri, "(?x)")),
+      ::testing::HasSubstr("internal boom"), std::runtime_error);
+
+  // An unregistered IRI is still an unknown function.
+  expectFunctionCallFails("<http://example.org/qlever-test/unregistered>(?x)");
+}
+
+// ______________________________________________________________________________
+// Malformed or duplicate registrations are rejected with a diagnostic.
+TEST(SparqlParser, customFunctionRegistryRejectsBadRegistrations) {
+  auto& registry = parsedQuery::SparqlFunctionRegistry::get();
+  auto noop = [](parsedQuery::SparqlFunctionRegistry::ArgList)
+      -> parsedQuery::SparqlFunctionRegistry::ExpressionPtr { return nullptr; };
+  // A non-bracketed IRI could never match the parser's IRIs.
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      registry.addExact("http://example.org/qlever-test/unbracketed", noop),
+      ::testing::HasSubstr("bracketed IRI"));
+  // A duplicate IRI is rejected.
+  const std::string iri = "<http://example.org/qlever-test/dup>";
+  registry.addExact(iri, noop);
+  AD_EXPECT_THROW_WITH_MESSAGE(registry.addExact(iri, noop),
+                               ::testing::HasSubstr("already registered"));
 }
 
 // ______________________________________________________________________________


### PR DESCRIPTION
The idea is to have a well defined extension interface so when one wants to add custom functions in a fork they don't need to touch any core source files or build scripts. So the fork can be easily rebased on mainline. 
Also when people want to do something like that they don't need to deep dive into clever code and can simply copy an example and have it running in no time.

The same approach can be also used for operations and indexing, but functions are kind of a first step as a PoC. I think there is also a benefit for qlever because features like geo and vector indices can live in they own folders and if necessary on can very easy have a build of only core engine or together with selected extensions.