### PR TITLE
Use `PRE_TEST` gtest discovery in the macOS CI build

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -75,7 +75,9 @@ jobs:
 
       - name: Build
         # Build your program with the given configuration
-        # Sourcing the conanrun.sh even for building is required to make gtest_discover_tests pass reliably.
+        # Sourcing the conanrun.sh is not strictly needed for building anymore
+        # (with `PRE_TEST` discovery, no test binaries are executed during the
+        # build), but it is harmless and we keep it to be safe.
         run: |
           df -h
           source ${{github.workspace}}/build/conanrun.sh

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Configure CMake
         # For std::ranges::join_view we need the -fexperimental-library flag on libc++17.
         # We currently cannot use the parallel algorithms, as the parallel sort requires a GNU-extension, and we build with `libc++`.
-        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build-type}} -DCMAKE_TOOLCHAIN_FILE="$(pwd)/build/conan_toolchain.cmake" -DUSE_PARALLEL=false -DRUN_EXPENSIVE_TESTS=false -DENABLE_EXPENSIVE_CHECKS=true -DADDITIONAL_COMPILER_FLAGS="-fexperimental-library" -D_NO_TIMING_TESTS=ON
+        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build-type}} -DCMAKE_TOOLCHAIN_FILE="$(pwd)/build/conan_toolchain.cmake" -DUSE_PARALLEL=false -DRUN_EXPENSIVE_TESTS=false -DENABLE_EXPENSIVE_CHECKS=true -DADDITIONAL_COMPILER_FLAGS="-fexperimental-library" -D_NO_TIMING_TESTS=ON -DCMAKE_GTEST_DISCOVER_TESTS_DISCOVERY_MODE=PRE_TEST
 
       - name: Build
         # Build your program with the given configuration

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -87,10 +87,13 @@ jobs:
         working-directory: ${{github.workspace}}/build/test
         # Execute tests defined by the CMake configuration.
         # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+        # With `PRE_TEST` discovery, the tests are only discovered here, so make
+        # sure that an (unlikely) complete failure of the discovery fails the
+        # job instead of silently running zero tests.
         run: |
           df -h
           source ${{github.workspace}}/build/conanrun.sh
-          env CTEST_OUTPUT_ON_FAILURE=1 ctest -C ${{matrix.build-type}} -j $(sysctl -n hw.ncpu) .
+          env CTEST_OUTPUT_ON_FAILURE=1 ctest --no-tests=error -C ${{matrix.build-type}} -j $(sysctl -n hw.ncpu) .
 
       - name: Running and printing the benchmark examples.
         working-directory: ${{github.workspace}}/build


### PR DESCRIPTION
So far, the macOS build discovered the test cases of each test binary at build time, by running the binary right after linking. On the macOS runners this sporadically fails (an empty discovery output or a silent linker error on an unrelated test binary), which makes unrelated PRs red. Now the discovery is deferred to test time, like for the Docker builds since #3090.