### PR TITLE
Suppress a false-positive GCC 12 warning in `IdTableTest`

### DIFF
--- a/src/engine/idTable/IdTable.h
+++ b/src/engine/idTable/IdTable.h
@@ -20,6 +20,7 @@
 #include "global/Id.h"
 #include "util/Algorithm.h"
 #include "util/AllocatorWithLimit.h"
+#include "util/CompilerWarnings.h"
 #include "util/Iterators.h"
 #include "util/LambdaHelpers.h"
 #include "util/ResetWhenMoved.h"
@@ -419,8 +420,16 @@ class IdTable {
   // Note: The semantics of this function is similar to `std::vector::resize`.
   // To set the capacity, use the `reserve` function.
   CPP_template(typename = void)(requires(!isView)) void resize(size_t numRows) {
-    ql::ranges::for_each(data(),
-                         [numRows](auto& column) { column.resize(numRows); });
+    ql::ranges::for_each(data(), [numRows](auto& column) {
+      // GCC 12 emits a spurious `-Wstringop-overflow` for the
+      // `__builtin_memmove` in libstdc++'s bitwise-relocate path of
+      // `std::vector` growth when instantiated with `ValueId`: it derives a
+      // bogus `[2^63, 2^64)` size range for the (unreachable) copy and treats
+      // it as an overflow.
+      DISABLE_STRINGOP_OVERFLOW_WARNINGS
+      column.resize(numRows);
+      GCC_REENABLE_WARNINGS
+    });
     numRows_ = numRows;
   }
 

--- a/src/engine/idTable/IdTable.h
+++ b/src/engine/idTable/IdTable.h
@@ -20,7 +20,6 @@
 #include "global/Id.h"
 #include "util/Algorithm.h"
 #include "util/AllocatorWithLimit.h"
-#include "util/CompilerWarnings.h"
 #include "util/Iterators.h"
 #include "util/LambdaHelpers.h"
 #include "util/ResetWhenMoved.h"
@@ -420,16 +419,8 @@ class IdTable {
   // Note: The semantics of this function is similar to `std::vector::resize`.
   // To set the capacity, use the `reserve` function.
   CPP_template(typename = void)(requires(!isView)) void resize(size_t numRows) {
-    ql::ranges::for_each(data(), [numRows](auto& column) {
-      // GCC 12 emits a spurious `-Wstringop-overflow` for the
-      // `__builtin_memmove` in libstdc++'s bitwise-relocate path of
-      // `std::vector` growth when instantiated with `ValueId`: it derives a
-      // bogus `[2^63, 2^64)` size range for the (unreachable) copy and treats
-      // it as an overflow.
-      DISABLE_STRINGOP_OVERFLOW_WARNINGS
-      column.resize(numRows);
-      GCC_REENABLE_WARNINGS
-    });
+    ql::ranges::for_each(data(),
+                         [numRows](auto& column) { column.resize(numRows); });
     numRows_ = numRows;
   }
 

--- a/test/IdTableTest.cpp
+++ b/test/IdTableTest.cpp
@@ -17,6 +17,7 @@
 #include "./util/IdTestHelpers.h"
 #include "engine/idTable/IdTable.h"
 #include "global/Id.h"
+#include "util/CompilerWarnings.h"
 #include "util/TypeIdentity.h"
 
 using namespace ad_utility::testing;
@@ -345,7 +346,15 @@ TEST(IdTable, at) {
     constexpr size_t NUM_COLS = 4;
 
     Table t1{NUM_COLS, std::move(additionalArgs.at(0))...};
+    // GCC 12 emits a spurious `-Wstringop-overflow` for the `__builtin_memmove`
+    // in libstdc++'s bitwise-relocate path of `std::vector` growth when the
+    // column storage is instantiated with `ValueId`: it derives a bogus
+    // `[2^63, 2^64)` size range for the (unreachable) copy and treats it as an
+    // overflow. This only surfaces here in the test, so we suppress it locally
+    // instead of in `IdTable::resize` itself.
+    DISABLE_STRINGOP_OVERFLOW_WARNINGS
     t1.resize(1);
+    GCC_REENABLE_WARNINGS
     t1.at(0, 0) = make(42);
     ASSERT_EQ(t1.at(0, 0), make(42));
     ASSERT_EQ(std::as_const(t1).at(0, 0), make(42));


### PR DESCRIPTION
Since #2972, the GCC 12 build of master fails: for the `IdTable` instantiation with the test-only `VectorWithExtraConstructor` column type, GCC 12 derives an impossible size range for the `__builtin_memmove` in libstdc++'s relocation path of `std::vector` and reports `stringop-overflow`, which `-Werror` turns into an error. The warning is now suppressed exactly around the one `resize` call in the test that triggers it.

NOTE: The GCC 12 build runs only on pushes to master, not on pull requests. This is why the breakage did not show in the checks of #2972, and why the checks of this pull request cannot show the fix either; it was therefore verified locally with GCC 12 (the false positive is still present in GCC 12.5, the latest point release).