### PR TITLE
Fix the false unbound-variable warning for variables inside `EXISTS`

### DIFF
--- a/src/engine/sparqlExpressions/SparqlExpression.cpp
+++ b/src/engine/sparqlExpressions/SparqlExpression.cpp
@@ -10,20 +10,25 @@
 namespace sparqlExpression {
 
 // _____________________________________________________________________________
-std::vector<const Variable*> SparqlExpression::containedVariables() const {
+std::vector<const Variable*> SparqlExpression::containedVariables(
+    bool excludeExists) const {
+  // An `EXISTS` is a scope boundary: the variables of its body are only visible
+  // inside the `EXISTS` (correlated variables are resolved later via the
+  // `ExistsJoin`). Hence, when `excludeExists` is set, we do not descend into
+  // it.
+  if (excludeExists && isExistsExpression()) {
+    return {};
+  }
   std::vector<const Variable*> result;
-  // Recursively aggregate the strings from all children.
+  // Recursively aggregate the variables from all children.
   for (const auto& child : children()) {
-    auto variablesFromChild = child->containedVariables();
-    result.insert(result.end(), variablesFromChild.begin(),
-                  variablesFromChild.end());
+    ad_utility::appendVector(result, child->containedVariables(excludeExists));
   }
 
-  // Add the strings from this expression.
-  auto locallyAdded = getContainedVariablesNonRecursive();
-  for (auto& el : locallyAdded) {
-    result.push_back(&el);
-  }
+  // Add the variables from this expression.
+  ql::ranges::copy(getContainedVariablesNonRecursive() |
+                       ql::views::transform(ad_utility::addressOf),
+                   std::back_inserter(result));
   return result;
 }
 

--- a/src/engine/sparqlExpressions/SparqlExpression.h
+++ b/src/engine/sparqlExpressions/SparqlExpression.h
@@ -30,8 +30,14 @@ class SparqlExpression {
   // Evaluate a Sparql expression.
   virtual ExpressionResult evaluate(EvaluationContext*) const = 0;
 
-  // Return all variables, needed for certain parser methods.
-  virtual std::vector<const Variable*> containedVariables() const final;
+  // Return all variables, needed for certain parser methods. If `excludeExists`
+  // is true, `EXISTS` is treated as a scope boundary: variables that occur only
+  // inside the body of an `EXISTS` are not returned, because they live in their
+  // own scope and thus need not be bound by the surrounding query. This is used
+  // by the parser to check that all variables used in a clause are actually
+  // bound (see e.g. `ParsedQuery::checkUsedVariablesAreVisible`).
+  virtual std::vector<const Variable*> containedVariables(
+      bool excludeExists = false) const final;
 
   // Return all the variables that occur in the expression, but are not
   // aggregated. These variables must be grouped in a GROUP BY. The default

--- a/src/engine/sparqlExpressions/SparqlExpressionPimpl.cpp
+++ b/src/engine/sparqlExpressions/SparqlExpressionPimpl.cpp
@@ -22,8 +22,9 @@ SparqlExpressionPimpl::SparqlExpressionPimpl(
 SparqlExpressionPimpl::~SparqlExpressionPimpl() = default;
 
 // ___________________________________________________________________________
-std::vector<const Variable*> SparqlExpressionPimpl::containedVariables() const {
-  return _pimpl->containedVariables();
+std::vector<const Variable*> SparqlExpressionPimpl::containedVariables(
+    bool excludeExists) const {
+  return _pimpl->containedVariables(excludeExists);
 }
 
 // ____________________________________________________________________________

--- a/src/engine/sparqlExpressions/SparqlExpressionPimpl.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionPimpl.h
@@ -99,7 +99,10 @@ class SparqlExpressionPimpl {
   SparqlExpressionPimpl(const SparqlExpressionPimpl&);
   SparqlExpressionPimpl& operator=(const SparqlExpressionPimpl&);
 
-  std::vector<const Variable*> containedVariables() const;
+  // If `excludeExists` is true, `EXISTS` is treated as a scope boundary: the
+  // variables that occur only inside the body of an `EXISTS` are not returned.
+  std::vector<const Variable*> containedVariables(
+      bool excludeExists = false) const;
 
   // Return true iff the `Variable` is used inside the expression.
   bool isVariableContained(const Variable&) const;

--- a/src/parser/ParsedQuery.cpp
+++ b/src/parser/ParsedQuery.cpp
@@ -403,7 +403,10 @@ void ParsedQuery::checkUsedVariablesAreVisible(
     const std::string& locationDescription,
     const ad_utility::HashSet<Variable>& additionalVisibleVariables,
     std::string_view otherPossibleLocationDescription) {
-  for (const auto* var : expression.containedVariables()) {
+  // Note: We pass `excludeExists = true`, because the variables that occur only
+  // inside the body of an `EXISTS` live in their own scope and thus need not be
+  // bound by the surrounding query.
+  for (const auto* var : expression.containedVariables(true)) {
     checkVariableIsVisible(*var,
                            locationDescription + " in expression \"" +
                                expression.getDescriptor() + "\"",

--- a/src/parser/ParsedQuery.cpp
+++ b/src/parser/ParsedQuery.cpp
@@ -404,8 +404,8 @@ void ParsedQuery::checkUsedVariablesAreVisible(
     const ad_utility::HashSet<Variable>& additionalVisibleVariables,
     std::string_view otherPossibleLocationDescription) {
   // Note: We pass `excludeExists = true`, because the variables that occur only
-  // inside the body of an `EXISTS` live in their own scope and thus need not be
-  // bound by the surrounding query.
+  // inside the body of an `EXISTS` live in their own scope and thus are not
+  // visible in the surrounding query.
   for (const auto* var : expression.containedVariables(true)) {
     checkVariableIsVisible(*var,
                            locationDescription + " in expression \"" +

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -1736,7 +1736,10 @@ template <typename Context>
 void Visitor::warnOrThrowIfUnboundVariables(
     Context* ctx, const SparqlExpressionPimpl& expression,
     std::string_view clauseName) {
-  for (const auto& var : expression.containedVariables()) {
+  // Note: We pass `excludeExists = true`, because the variables that occur only
+  // inside the body of an `EXISTS` live in their own scope and thus need not be
+  // bound by the surrounding query.
+  for (const auto& var : expression.containedVariables(true)) {
     if (!ad_utility::contains(visibleVariables_, *var)) {
       auto message = absl::StrCat(
           "The variable ", var->name(), " was used in the expression of a ",

--- a/src/util/TransparentFunctors.h
+++ b/src/util/TransparentFunctors.h
@@ -98,6 +98,14 @@ struct DereferenceImpl {
   }
 };
 
+// Implementation of `addressOf` (see below).
+struct AddressOfImpl {
+  template <typename X>
+  constexpr decltype(auto) operator()(X&& x) const {
+    return &AD_FWD(x);
+  }
+};
+
 // Implementation of `hasValue` (see below).
 struct HasValueImpl {
   template <typename X>
@@ -151,6 +159,9 @@ static constexpr detail::StaticCastImpl<T> staticCast{};
 
 // Transparent functor that dereferences a pointer or smart pointer.
 static constexpr detail::DereferenceImpl dereference;
+
+// Transparent functor that gets the address of an object via `operator&`.
+static constexpr detail::AddressOfImpl addressOf;
 
 // Transparent functor for `std::optional::has_value`.
 static constexpr detail::HasValueImpl hasValue;

--- a/test/TransparentFunctorsTest.cpp
+++ b/test/TransparentFunctorsTest.cpp
@@ -13,6 +13,7 @@
 #include "util/TransparentFunctors.h"
 #include "util/Views.h"
 
+// _____________________________________________________________________________
 TEST(TransparentFunctors, FirstOfPair) {
   std::pair<std::string, std::vector<int>> pair{"hello", {2}};
   auto first = ad_utility::first(pair);
@@ -24,6 +25,7 @@ TEST(TransparentFunctors, FirstOfPair) {
   ASSERT_TRUE(pair.first.empty());
 }
 
+// _____________________________________________________________________________
 TEST(TransparentFunctors, SecondOfPair) {
   std::pair<std::string, std::vector<int>> pair{"hello", {2}};
   auto second = ad_utility::second(pair);
@@ -35,6 +37,7 @@ TEST(TransparentFunctors, SecondOfPair) {
   ASSERT_TRUE(pair.second.empty());
 }
 
+// _____________________________________________________________________________
 TEST(TransparentFunctors, MemberProjection) {
   using Pair = std::pair<int, std::string>;
   ad_utility::MemberProjection<&Pair::first> first;
@@ -66,6 +69,55 @@ TEST(TransparentFunctors, MemberProjection) {
   }
 }
 
+// _____________________________________________________________________________
+TEST(TransparentFunctors, Dereference) {
+  {
+    std::string s = "hello";
+    std::string* ptr = &s;
+    EXPECT_EQ(ad_utility::dereference(ptr), "hello");
+    ad_utility::dereference(ptr) = "world";
+    EXPECT_EQ(s, "world");
+  }
+  {
+    std::vector<std::string> s{"foo", "bar", "baz"};
+    std::vector<std::string*> pointers{&s[0], &s[1], &s[2]};
+    auto values = pointers | ql::views::transform(ad_utility::dereference) |
+                  ::ranges::to<std::vector>();
+    EXPECT_THAT(values, testing::ElementsAre("foo", "bar", "baz"));
+  }
+}
+
+// _____________________________________________________________________________
+TEST(TransparentFunctors, ToBool) {
+  EXPECT_TRUE(ad_utility::toBool(1));
+  EXPECT_FALSE(ad_utility::toBool(0));
+
+  std::optional<int> sth = 42;
+  std::optional<int> null = std::nullopt;
+  EXPECT_TRUE(ad_utility::toBool(sth));
+  EXPECT_FALSE(ad_utility::toBool(null));
+
+  std::vector<int> values{0, 1, 2, 0, 3};
+  auto truthy = values | ql::views::filter(ad_utility::toBool) |
+                ::ranges::to<std::vector>();
+  EXPECT_THAT(truthy, testing::ElementsAre(1, 2, 3));
+}
+
+// _____________________________________________________________________________
+TEST(TransparentFunctors, AddressOf) {
+  {
+    std::string s = "hello";
+    EXPECT_EQ(ad_utility::addressOf(s), &s);
+  }
+  {
+    std::vector<std::string> s{"foo", "bar", "baz"};
+    auto pointers = s | ql::views::transform(ad_utility::addressOf) |
+                    ::ranges::to<std::vector>();
+    EXPECT_THAT(pointers, testing::ElementsAre(&s[0], &s[1], &s[2]));
+  }
+}
+
+// _____________________________________________________________________________
 TEST(TransparentFunctors, OptionalHandling) {
   {
     std::optional<std::string> null = std::nullopt;

--- a/test/parser/SparqlAntlrParserTest.cpp
+++ b/test/parser/SparqlAntlrParserTest.cpp
@@ -1433,6 +1433,18 @@ TEST(SparqlParser, Query) {
   expectQuery("SELECT * { } ORDER BY ?s",
               m::WarningsOfParsedQuery({"?s was used by ORDER BY"}));
 
+  // An `EXISTS` introduces its own scope: variables that occur only inside its
+  // body (here `?x`) must not trigger an "unbound variable" warning, neither in
+  // a `SELECT` alias nor in a `BIND`.
+  expectQuery("SELECT (EXISTS { ?a <p> ?x } AS ?e) { ?a <q> ?b }",
+              m::WarningsOfParsedQuery({}));
+  expectQuery("SELECT * { ?a <q> ?b BIND(EXISTS { ?a <p> ?x } AS ?e) }",
+              m::WarningsOfParsedQuery({}));
+  // Variables used directly (i.e. outside an `EXISTS`) are still checked: here
+  // `?unbound` is reported, but the `EXISTS`-internal `?x` is not.
+  expectQuery("SELECT (EXISTS { ?a <p> ?x } || ?unbound AS ?e) { ?a <q> ?b }",
+              m::WarningsOfParsedQuery({"?unbound was used by SELECT"}));
+
   // Now test the same queries with exceptions instead of warnings.
   auto cleanup =
       setRuntimeParameterForTest<&RuntimeParameters::throwOnUnboundVariables_>(
@@ -1443,6 +1455,13 @@ TEST(SparqlParser, Query) {
                    contains("?a was used in the expression of a BIND clause"));
   expectQueryFails("SELECT * { } ORDER BY ?s",
                    contains("?s was used by ORDER BY"));
+  // An `EXISTS`-internal variable must not throw either, but a variable used
+  // directly outside the `EXISTS` still does.
+  expectQuery("SELECT (EXISTS { ?a <p> ?x } AS ?e) { ?a <q> ?b }",
+              m::WarningsOfParsedQuery({}));
+  expectQueryFails(
+      "SELECT (EXISTS { ?a <p> ?x } || ?unbound AS ?e) { ?a <q> ?b }",
+      contains("?unbound was used by SELECT"));
 }
 
 // _____________________________________________________________________________


### PR DESCRIPTION
Whenever a variable occurred in the body of an `EXISTS`, but not in the surrounding query, QLever produced a false-positive warning that the variable is not defined in the query body. This affected `EXISTS` in all expression positions, for example in a `BIND` or in a `SELECT` alias. Here is a minimal example, where so far all of `?s`, `?p`, `?o` are warned about:
```sparql
SELECT * WHERE {
  BIND (EXISTS { ?s ?p ?o } AS ?exists)
}
```
The reason is that the check for unbound variables treated the variables inside the body of an `EXISTS` like ordinary variables of the expression. But the body of an `EXISTS` is its own scope, so its variables need not be bound in the surrounding query. The check now treats `EXISTS` as a scope boundary and ignores these variables. Variables that are used directly in the expression are still checked, and with the runtime parameter `throw-on-unbound-variables` they still throw.