### PR TITLE
Add a metric for whether a `rebuild-index` is in progress

### DIFF
--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -82,6 +82,7 @@ Server::Server(
         return (cache().nonPinnedSize() + cache().pinnedSize()).getBytes();
       },
       [this]() -> int64_t { return cache().getMaxSize().getBytes(); },
+      [this]() -> int64_t { return rebuildInProgress_.load() ? 1 : 0; },
       config.memoryLimit_);
   metrics_->registerCallbacks();
 

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -82,7 +82,9 @@ Server::Server(
         return (cache().nonPinnedSize() + cache().pinnedSize()).getBytes();
       },
       [this]() -> int64_t { return cache().getMaxSize().getBytes(); },
-      [this]() -> int64_t { return rebuildInProgress_.load() ? 1 : 0; },
+      [this]() -> int64_t {
+        return static_cast<int64_t>(rebuildInProgress_.load());
+      },
       config.memoryLimit_);
   metrics_->registerCallbacks();
 

--- a/src/util/metrics/ServerMetrics.cpp
+++ b/src/util/metrics/ServerMetrics.cpp
@@ -21,11 +21,13 @@ ServerMetrics::ServerMetrics(
     absl::AnyInvocable<int64_t() const> getMemoryLeft,
     absl::AnyInvocable<int64_t() const> getCacheUsed,
     absl::AnyInvocable<int64_t() const> getCacheLimit,
+    absl::AnyInvocable<int64_t() const> getRebuildInProgress,
     std::optional<ad_utility::MemorySize> maxMem)
     : getDeltaTriples_(std::move(getDeltaTriples)),
       getMemoryLeft_(std::move(getMemoryLeft)),
       getCacheUsed_(std::move(getCacheUsed)),
-      getCacheLimit_(std::move(getCacheLimit)) {
+      getCacheLimit_(std::move(getCacheLimit)),
+      getRebuildInProgress_(std::move(getRebuildInProgress)) {
   auto meter = opentelemetry::metrics::Provider::GetMeterProvider()->GetMeter(
       "qlever", "0.0.1");
   startTimeMetric_ = meter->CreateInt64Gauge(
@@ -65,6 +67,9 @@ ServerMetrics::ServerMetrics(
       "qlever.memory_cache_used", "Memory used for caching", "By");
   memoryCacheLimit_ = meter->CreateInt64ObservableGauge(
       "qlever.memory_cache_limit", "Memory allocated for caching", "By");
+  rebuildInProgressMetric_ = meter->CreateInt64ObservableGauge(
+      "qlever.index.rebuild_in_progress",
+      "Whether an index rebuild is currently in progress (1) or not (0)");
 
   auto now = std::chrono::duration_cast<std::chrono::seconds>(
                  std::chrono::system_clock::now().time_since_epoch())
@@ -100,6 +105,8 @@ ServerMetrics::~ServerMetrics() {
       &observeCallback<&ServerMetrics::getCacheUsed_>, this);
   memoryCacheLimit_->RemoveCallback(
       &observeCallback<&ServerMetrics::getCacheLimit_>, this);
+  rebuildInProgressMetric_->RemoveCallback(
+      &observeCallback<&ServerMetrics::getRebuildInProgress_>, this);
 }
 
 // _____________________________________________________________________________
@@ -112,6 +119,8 @@ void ServerMetrics::registerCallbacks() {
                                 this);
   memoryCacheLimit_->AddCallback(
       &observeCallback<&ServerMetrics::getCacheLimit_>, this);
+  rebuildInProgressMetric_->AddCallback(
+      &observeCallback<&ServerMetrics::getRebuildInProgress_>, this);
 }
 
 // _____________________________________________________________________________

--- a/src/util/metrics/ServerMetrics.h
+++ b/src/util/metrics/ServerMetrics.h
@@ -45,6 +45,7 @@ class ServerMetrics {
                 absl::AnyInvocable<int64_t() const> getMemoryLeft,
                 absl::AnyInvocable<int64_t() const> getCacheUsed,
                 absl::AnyInvocable<int64_t() const> getCacheLimit,
+                absl::AnyInvocable<int64_t() const> getRebuildInProgress,
                 std::optional<ad_utility::MemorySize> maxMem);
   void registerCallbacks();
 
@@ -59,6 +60,7 @@ class ServerMetrics {
   absl::AnyInvocable<int64_t() const> getMemoryLeft_;
   absl::AnyInvocable<int64_t() const> getCacheUsed_;
   absl::AnyInvocable<int64_t() const> getCacheLimit_;
+  absl::AnyInvocable<int64_t() const> getRebuildInProgress_;
 
   // Observable instruments: SDK invokes callbacks on scrape; RemoveCallback
   // in ~ServerMetrics() blocks until any in-flight callback returns.
@@ -70,6 +72,8 @@ class ServerMetrics {
       memoryCacheUsed_;
   std::shared_ptr<opentelemetry::metrics::ObservableInstrument>
       memoryCacheLimit_;
+  std::shared_ptr<opentelemetry::metrics::ObservableInstrument>
+      rebuildInProgressMetric_;
 };
 
 #endif  // QLEVER_SRC_UTIL_METRICS_SERVERMETRICS_H

--- a/test/ServerTest.cpp
+++ b/test/ServerTest.cpp
@@ -621,6 +621,8 @@ TEST(ServerTest, metricsEndpoint) {
       "qlever_sparql_operation_running";
   std::string_view qleverSparqlOperationErrorsTotal =
       "qlever_sparql_operation_errors_total";
+  std::string_view qleverIndexRebuildInProgress =
+      "qlever_index_rebuild_in_progress";
   ExpectMetricsChange(
       testing::AllOf(IsZero(qleverDeltaTriples),
                      IsZero(qleverSparqlOperationStartedTotal, update),
@@ -645,6 +647,11 @@ TEST(ServerTest, metricsEndpoint) {
                      MetricIs(qleverSparqlOperationStartedTotal, "1", query),
                      IsZero(qleverSparqlOperationRunning, update),
                      IsZero(qleverSparqlOperationRunning, query)));
+  // No rebuild is running during a normal query, so the rebuild-in-progress
+  // gauge reads 0 both before and after.
+  ExpectMetricsChange(IsZero(qleverIndexRebuildInProgress),
+                      QueryRequest("SELECT * WHERE { ?s ?p ?o } LIMIT 10"),
+                      IsZero(qleverIndexRebuildInProgress));
   ExpectMetricsChange(
       IsZero(qleverSparqlOperationErrorsTotal, syntaxError),
       QueryRequest("Foo"),


### PR DESCRIPTION
There is now a metric `qlever.index.rebuild_in_progress` at the `/metrics` endpoint that reports whether an index rebuild is currently in progress or not. It reads the same flag that guards against concurrent rebuilds, so it is `1` exactly while a rebuild request is being processed (including the failure case), and `0` otherwise.