### PR TITLE
Make `LocalVocab` comply with the memory limit

### DIFF
--- a/src/engine/AddCombinedRowToTable.h
+++ b/src/engine/AddCombinedRowToTable.h
@@ -41,7 +41,7 @@ class AddCombinedRowToIdTable {
   bool keepJoinColumns_ = true;
   std::optional<std::array<IdTableView<0>, 2>> inputLeftAndRight_;
   IdTable resultTable_;
-  LocalVocab mergedVocab_{};
+  LocalVocab mergedVocab_ = LocalVocab::unlimited();
   std::array<const LocalVocab*, 2> currentVocabs_{nullptr, nullptr};
 
  public:
@@ -201,7 +201,7 @@ class AddCombinedRowToIdTable {
       // optimize this case (clear the local vocab more often, but still
       // correctly) by considering the situation after all the relevant inputs
       // have been processed.
-      mergedVocab_ = LocalVocab{};
+      mergedVocab_ = LocalVocab::unlimited();
     }
   }
 
@@ -411,7 +411,7 @@ class AddCombinedRowToIdTable {
     // local vocabs again if all other sets were moved-out.
     if (resultTable_.empty()) {
       // Make sure to reset `mergedVocab_` so it is in a valid state again.
-      mergedVocab_ = LocalVocab{};
+      mergedVocab_ = LocalVocab::unlimited();
       // Only merge non-null vocabs.
       // Note: On QCC 8.3, the elegant lazy range pipeline gives us trouble, so
       // we use an `absl::InlinedVector<reference_wrapper>` instead, which can

--- a/src/engine/CartesianProductJoin.cpp
+++ b/src/engine/CartesianProductJoin.cpp
@@ -147,11 +147,11 @@ void CartesianProductJoin::writeResultColumn(ql::span<Id> targetColumn,
 Result CartesianProductJoin::computeResult(bool requestLaziness) {
   if (knownEmptyResult()) {
     return {IdTable{getResultWidth(), getExecutionContext()->getAllocator()},
-            resultSortedOn(), LocalVocab{}};
+            resultSortedOn(), LocalVocab::unlimited()};
   }
   auto [subResults, lazyResult] = calculateSubResults(requestLaziness);
 
-  LocalVocab staticMergedVocab{};
+  LocalVocab staticMergedVocab = LocalVocab::unlimited();
   staticMergedVocab.mergeWith(
       subResults |
       ql::views::transform([](const auto& result) -> const LocalVocab& {

--- a/src/engine/CountAvailablePredicates.cpp
+++ b/src/engine/CountAvailablePredicates.cpp
@@ -138,7 +138,7 @@ Result CountAvailablePredicates::computeResult(
     // Compute the predicates for all entities
     CountAvailablePredicates::computePatternTrickAllEntities(&idTable,
                                                              patterns);
-    return {std::move(idTable), resultSortedOn(), LocalVocab{}};
+    return {std::move(idTable), resultSortedOn(), makeLocalVocab()};
   } else {
     std::shared_ptr<const Result> subresult = subtree_->getResult();
     AD_LOG_DEBUG << "CountAvailablePredicates subresult computation done."

--- a/src/engine/Describe.cpp
+++ b/src/engine/Describe.cpp
@@ -166,7 +166,7 @@ IdTable Describe::makeAndExecuteJoinWithFullIndex(
       VariableToColumnMap{
           {subjectVar,
            ColumnIndexAndTypeInfo{0, ColumnIndexAndTypeInfo::AlwaysDefined}}},
-      std::vector<ColumnIndex>{}, LocalVocab{},
+      std::vector<ColumnIndex>{}, LocalVocab::unlimited(),
       absl::StrCat("INTERNAL DESCRIBE ", uniqueCounter++));
   SparqlTripleSimple triple{subjectVar, V{"?predicate"}, V{"?object"}};
   auto activeGraphs = describe_.datasetClauses_.activeDefaultGraphs();
@@ -235,7 +235,7 @@ IdTable Describe::getIdsToDescribe(const Result& result,
 
 // _____________________________________________________________________________
 Result Describe::computeResult([[maybe_unused]] bool requestLaziness) {
-  LocalVocab localVocab;
+  LocalVocab localVocab{getExecutionContext()->getAllocator()};
   // Compute the results of the WHERE clause and extract the `Id`s to describe.
   //
   // TODO<joka921> Would we benefit from computing `resultOfWhereClause` lazily?

--- a/src/engine/Distinct.cpp
+++ b/src/engine/Distinct.cpp
@@ -62,7 +62,8 @@ Result::LazyResult Distinct::lazyDistinct(Result::LazyResult input,
     return Result::LazyResult{lazySingleValueRange(
         [getDistinctResult,
          aggregateTable = IdTable{subtree_->getResultWidth(), allocator()},
-         aggregateVocab = LocalVocab{}, input = std::move(input)]() mutable {
+         aggregateVocab = LocalVocab::unlimited(),
+         input = std::move(input)]() mutable {
           for (auto& [idTable, localVocab] : input) {
             IdTable result = getDistinctResult(std::move(idTable));
             if (!result.empty()) {

--- a/src/engine/ExecuteUpdate.cpp
+++ b/src/engine/ExecuteUpdate.cpp
@@ -20,9 +20,9 @@ UpdateMetadata ExecuteUpdate::executeUpdate(
   tracer.beginTrace("evaluateWhere");
   auto result = qet.getResult(false);
   tracer.endTrace("evaluateWhere");
-  auto [toInsert, toDelete] =
-      computeGraphUpdateQuads(index, query, *result, qet.getVariableColumns(),
-                              cancellationHandle, metadata, tracer);
+  auto [toInsert, toDelete] = computeGraphUpdateQuads(
+      index, query, *result, qet.getVariableColumns(), cancellationHandle,
+      metadata, qet.getQec()->getAllocator(), tracer);
 
   // "The deletion of the triples happens before the insertion." (SPARQL 1.1
   // Update 3.1.3)
@@ -53,7 +53,8 @@ UpdateMetadata ExecuteUpdate::executeUpdate(
 std::pair<std::vector<ExecuteUpdate::TransformedTriple>, LocalVocab>
 ExecuteUpdate::transformTriplesTemplate(
     const IndexImpl& index, const VariableToColumnMap& variableColumns,
-    const std::vector<SparqlTripleSimpleWithGraph>& triples) {
+    const std::vector<SparqlTripleSimpleWithGraph>& triples,
+    const ad_utility::AllocatorWithLimit<Id>& allocator) {
   const auto& encodedIriManager = index.encodedIriManager();
   // We collect all `TripleComponent`s from `triples` in a hash set.
   ad_utility::HashSet<TripleComponent> lookupItems;
@@ -112,7 +113,7 @@ ExecuteUpdate::transformTriplesTemplate(
   // NOTE: Not necessarily all of these will be added to the `LocalVocab` of
   // the `DeltaTriple`. For example, with `<a> <b> ?c` in an `INSERT` template,
   // `<a>` and `<b>` would not become part of it if `?c` has no solutions.
-  LocalVocab localVocab{};
+  LocalVocab localVocab{allocator};
 
   // Lookup the `TripleComponent`s in sorted order.
   //
@@ -224,6 +225,7 @@ ExecuteUpdate::computeGraphUpdateQuads(
     const Index& index, const ParsedQuery& query, const Result& result,
     const VariableToColumnMap& variableColumns,
     const CancellationHandle& cancellationHandle, UpdateMetadata& metadata,
+    const ad_utility::AllocatorWithLimit<Id>& allocator,
     ad_utility::timer::TimeTracer& tracer) {
   AD_CONTRACT_CHECK(query.hasUpdateClause());
   const auto& updateClause = query.updateClause();
@@ -233,10 +235,11 @@ ExecuteUpdate::computeGraphUpdateQuads(
   tracer.beginTrace("computeIds");
 
   auto prepareTemplateAndResultContainer =
-      [&index, &variableColumns, &result](
+      [&index, &variableColumns, &result, &allocator](
           const std::vector<SparqlTripleSimpleWithGraph>& tripleTemplates) {
         auto [transformedTripleTemplates, localVocab] =
-            transformTriplesTemplate(index, variableColumns, tripleTemplates);
+            transformTriplesTemplate(index, variableColumns, tripleTemplates,
+                                     allocator);
         std::vector<IdTriple<>> updateTriples;
         // The maximum result size is size(query result) x num template rows.
         // The actual result can be smaller if there are template rows with

--- a/src/engine/ExecuteUpdate.h
+++ b/src/engine/ExecuteUpdate.h
@@ -34,7 +34,8 @@ class ExecuteUpdate {
   static std::pair<std::vector<ExecuteUpdate::TransformedTriple>, LocalVocab>
   transformTriplesTemplate(
       const IndexImpl& index, const VariableToColumnMap& variableColumns,
-      const std::vector<SparqlTripleSimpleWithGraph>& triples);
+      const std::vector<SparqlTripleSimpleWithGraph>& triples,
+      const ad_utility::AllocatorWithLimit<Id>& allocator);
   FRIEND_TEST(ExecuteUpdate, transformTriplesTemplate);
 
   // Resolve a single `IdOrVariable` to an `Id` by looking up the value in the
@@ -68,6 +69,7 @@ class ExecuteUpdate {
                           const VariableToColumnMap& variableColumns,
                           const CancellationHandle& cancellationHandle,
                           UpdateMetadata& metadata,
+                          const ad_utility::AllocatorWithLimit<Id>& allocator,
                           ad_utility::timer::TimeTracer& tracer =
                               ad_utility::timer::DEFAULT_TIME_TRACER);
   FRIEND_TEST(ExecuteUpdate, computeGraphUpdateQuads);

--- a/src/engine/Filter.cpp
+++ b/src/engine/Filter.cpp
@@ -98,7 +98,7 @@ Result Filter::computeResult(bool requestLaziness) {
   size_t width = getSubtree().get()->getResultWidth();
   IdTable result{width, getExecutionContext()->getAllocator()};
 
-  LocalVocab resultLocalVocab{};
+  LocalVocab resultLocalVocab = LocalVocab::unlimited();
   ad_utility::callFixedSizeVi(
       width, [this, &subRes, &result, &resultLocalVocab](auto WIDTH) {
         for (Result::IdTableVocabPair& pair : subRes->idTables()) {
@@ -133,7 +133,7 @@ CPP_template_def(int WIDTH,
                  typename Table)(requires IdTableLike<Table>) void Filter::
     computeFilterImpl(IdTable& dynamicResultTable, Table&& inputTable,
                       std::vector<ColumnIndex> sortedBy) const {
-  LocalVocab dummyLocalVocab{};
+  LocalVocab dummyLocalVocab = LocalVocab::unlimited();
   AD_CONTRACT_CHECK(inputTable.numColumns() == WIDTH || WIDTH == 0);
   IdTableStatic<WIDTH> resultTable =
       std::move(dynamicResultTable).toStatic<static_cast<size_t>(WIDTH)>();

--- a/src/engine/GroupByImpl.cpp
+++ b/src/engine/GroupByImpl.cpp
@@ -84,7 +84,8 @@ class LazyGroupByRange
         singleIdTable_(singleIdTable),
         inWidth_(subTreeResultWidth),
         resultTable_(parent->getResultWidth(),
-                     parent->getExecutionContext()->getAllocator()) {
+                     parent->getExecutionContext()->getAllocator()),
+        currentLocalVocab_(parent->getExecutionContext()->getAllocator()) {
     AD_CONTRACT_CHECK(inWidth_ == IN_WIDTH || IN_WIDTH == 0);
     AD_CONTRACT_CHECK(parent_ != nullptr);
   }
@@ -545,7 +546,7 @@ Result GroupByImpl::computeResult(bool requestLaziness) {
     // Note: The optimized group bys currently all include index scans and thus
     // can never produce local vocab entries. If this should ever change, then
     // we also have to take care of the local vocab here.
-    return {std::move(idTable).value(), resultSortedOn(), LocalVocab{}};
+    return {std::move(idTable).value(), resultSortedOn(), makeLocalVocab()};
   }
 
   std::vector<Aggregate> aggregates;
@@ -1775,7 +1776,7 @@ Result GroupByImpl::computeGroupByForHashMapOptimization(
     SubResults subresults, const std::vector<size_t>& columnIndices) const {
   AD_CORRECTNESS_CHECK(columnIndices.size() == NUM_GROUP_COLUMNS ||
                        NUM_GROUP_COLUMNS == 0);
-  LocalVocab localVocab;
+  LocalVocab localVocab{getExecutionContext()->getAllocator()};
 
   // Initialize the data for the aggregates of the GROUP BY operation.
   HashMapAggregationData<NUM_GROUP_COLUMNS> aggregationData(

--- a/src/engine/HasPredicateScan.cpp
+++ b/src/engine/HasPredicateScan.cpp
@@ -293,17 +293,17 @@ Result HasPredicateScan::computeResult([[maybe_unused]] bool requestLaziness) {
       runOnResult([this, &idTable, &getId, &patterns](auto hasPattern) {
         computeFreeS(&idTable, getId(object_), hasPattern, patterns);
       });
-      return {std::move(idTable), resultSortedOn(), LocalVocab{}};
+      return {std::move(idTable), resultSortedOn(), makeLocalVocab()};
     case ScanType::FREE_O:
       computeFreeO(&idTable, subject_, patterns);
-      return {std::move(idTable), resultSortedOn(), LocalVocab{}};
+      return {std::move(idTable), resultSortedOn(), makeLocalVocab()};
 
     case ScanType::FULL_SCAN:
       runOnResult([this, &idTable, &patterns](auto hasPattern) {
         computeFullScan(&idTable, hasPattern, patterns,
                         getIndex().getNumDistinctSubjectPredicatePairs());
       });
-      return {std::move(idTable), resultSortedOn(), LocalVocab{}};
+      return {std::move(idTable), resultSortedOn(), makeLocalVocab()};
     case ScanType::SUBQUERY_S:
 
       auto width = static_cast<int>(idTable.numColumns());

--- a/src/engine/IndexScan.cpp
+++ b/src/engine/IndexScan.cpp
@@ -310,9 +310,10 @@ IndexScan::makeCopyWithPrefilteredScanSpecAndBlocks(
 
 // _____________________________________________________________________________
 Result::LazyResult IndexScan::chunkedIndexScan() const {
-  return Result::LazyResult{
-      ad_utility::CachingTransformInputRange(getLazyScan(), [](auto& table) {
-        return Result::IdTableVocabPair{std::move(table), LocalVocab{}};
+  return Result::LazyResult{ad_utility::CachingTransformInputRange(
+      getLazyScan(), [allocator = allocator()](auto& table) {
+        return Result::IdTableVocabPair{std::move(table),
+                                        LocalVocab{allocator}};
       })};
 }
 
@@ -334,7 +335,7 @@ Result IndexScan::computeResult(bool requestLaziness) {
   if (requestLaziness) {
     return {chunkedIndexScan(), resultSortedOn()};
   }
-  return {materializedIndexScan(), getResultSortedOn(), LocalVocab{}};
+  return {materializedIndexScan(), getResultSortedOn(), makeLocalVocab()};
 }
 
 // _____________________________________________________________________________
@@ -837,10 +838,11 @@ Result::LazyResult IndexScan::createPrefilteredIndexScanSide(
           updateRuntimeInfoForLazyScan(scan->details(), Always);
           return LoopControl::breakWithYieldAll(
               ad_utility::CachingTransformInputRange(
-                  *scan, [this, scan](auto& table) mutable {
+                  *scan,
+                  [this, scan, allocator = allocator()](auto& table) mutable {
                     updateRuntimeInfoForLazyScan(scan->details(), IfDue);
                     return Result::IdTableVocabPair{std::move(table),
-                                                    LocalVocab{}};
+                                                    LocalVocab{allocator}};
                   }));
         }
 
@@ -869,12 +871,13 @@ Result::LazyResult IndexScan::createPrefilteredIndexScanSide(
         // Transform the scan to Result::IdTableVocabPair and yield all
         auto transformedScan = ad_utility::CachingTransformInputRange(
             std::move(scan),
-            [&metadata, &scanDetails,
-             originalMetadata = metadata](auto& table) mutable {
+            [&metadata, &scanDetails, originalMetadata = metadata,
+             allocator = allocator()](auto& table) mutable {
               // Make sure we don't add everything more than once.
               metadata = originalMetadata;
               metadata.aggregate(scanDetails);
-              return Result::IdTableVocabPair{std::move(table), LocalVocab{}};
+              return Result::IdTableVocabPair{std::move(table),
+                                              LocalVocab{allocator}};
             });
 
         return LoopControl::yieldAll(std::move(transformedScan));

--- a/src/engine/JoinHelpers.h
+++ b/src/engine/JoinHelpers.h
@@ -99,7 +99,7 @@ IteratorWithSingleCol<numJoinColumns> convertGeneratorFromScan(
         // IndexScans don't have a local vocabulary, so we can just use an empty
         // one.
         return makeIdTableAndFirstCols<numJoinColumns>(std::move(table),
-                                                       LocalVocab{});
+                                                       LocalVocab::unlimited());
       });
 
   return IteratorWithSingleCol<numJoinColumns>{std::move(range)};

--- a/src/engine/JoinImpl.cpp
+++ b/src/engine/JoinImpl.cpp
@@ -720,7 +720,7 @@ Result JoinImpl::computeResultForTwoMaterializedInputs(
 // _____________________________________________________________________________
 Result JoinImpl::createEmptyResult() const {
   return {IdTable{getResultWidth(), allocator()}, resultSortedOn(),
-          LocalVocab{}};
+          LocalVocab::unlimited()};
 }
 
 // _____________________________________________________________________________

--- a/src/engine/Load.cpp
+++ b/src/engine/Load.cpp
@@ -70,7 +70,7 @@ std::vector<ColumnIndex> Load::resultSortedOn() const { return {}; }
 Result Load::computeResult(bool requestLaziness) {
   auto makeSilentResult = [this]() -> Result {
     return {IdTable{getResultWidth(), getExecutionContext()->getAllocator()},
-            resultSortedOn(), LocalVocab{}};
+            resultSortedOn(), LocalVocab::unlimited()};
   };
 
   // In the syntax test mode we don't even try to compute the result, as this
@@ -145,7 +145,7 @@ Result Load::computeResultImpl([[maybe_unused]] bool requestLaziness) {
     body.append(reinterpret_cast<const char*>(bytes.data()), bytes.size());
   }
   parser.setInputStream(body);
-  LocalVocab lv;
+  LocalVocab lv{getExecutionContext()->getAllocator()};
   IdTable result{getResultWidth(), getExecutionContext()->getAllocator()};
   auto toId = [this, &lv](TripleComponent&& tc) {
     return std::move(tc).toValueId(getIndex(), lv);

--- a/src/engine/MaterializedViews.cpp
+++ b/src/engine/MaterializedViews.cpp
@@ -651,7 +651,7 @@ MaterializedView::makeEmptyLocatedTriplesState() const {
   emptyLocatedTriples.at(static_cast<size_t>(permutation_->permutation()))
       .setOriginalMetadata(permutation_->metaData().blockDataShared());
   LocatedTriplesPerBlockAllPermutations<true> emptyInternalLocatedTriples;
-  LocalVocab emptyVocab;
+  LocalVocab emptyVocab = LocalVocab::unlimited();
 
   return std::make_shared<LocatedTriplesState>(
       LocatedTriplesState{emptyLocatedTriples, emptyInternalLocatedTriples,

--- a/src/engine/MinusRowHandler.h
+++ b/src/engine/MinusRowHandler.h
@@ -29,7 +29,7 @@ class MinusRowHandler {
   // Output `IdTable`.
   IdTable resultTable_;
   // Output `LocalVocab`.
-  LocalVocab mergedVocab_{};
+  LocalVocab mergedVocab_ = LocalVocab::unlimited();
   // Pointer to the current `LocalVocab` of the left input.
   const LocalVocab* currentVocab_ = nullptr;
   // Non-matching indices of the left input, the ones to copy to the result.
@@ -88,7 +88,7 @@ class MinusRowHandler {
       // optimize this case (clear the local vocab more often, but still
       // correctly) by considering the situation after all the relevant inputs
       // have been processed.
-      mergedVocab_ = LocalVocab{};
+      mergedVocab_ = LocalVocab::unlimited();
     }
   }
 
@@ -158,7 +158,7 @@ class MinusRowHandler {
     // local vocabs again if all other sets were moved-out.
     if (resultTable_.empty()) {
       // Make sure to reset `mergedVocab_` so it is in a valid state again.
-      mergedVocab_ = LocalVocab{};
+      mergedVocab_ = LocalVocab::unlimited();
       // Only merge non-null vocabs.
       if (currentVocab_) {
         mergedVocab_.mergeWith(*currentVocab_);

--- a/src/engine/NeutralElementOperation.h
+++ b/src/engine/NeutralElementOperation.h
@@ -52,7 +52,7 @@ class NeutralElementOperation : public Operation {
     IdTable idTable{getExecutionContext()->getAllocator()};
     idTable.setNumColumns(0);
     idTable.resize(1);
-    return {std::move(idTable), resultSortedOn(), LocalVocab{}};
+    return {std::move(idTable), resultSortedOn(), makeLocalVocab()};
   }
 
   [[nodiscard]] VariableToColumnMap computeVariableToColumnMap()

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -383,6 +383,13 @@ class Operation {
     return getExecutionContext()->getAllocator();
   }
 
+  // Create a new, empty `LocalVocab` whose memory is accounted against this
+  // query's memory limit (via `allocator()`). Use this instead of a
+  // default-constructed `LocalVocab` for the result of an operation, so that
+  // the words stored in it (and in all `LocalVocab`s later cloned or merged
+  // from it) count towards the memory limit.
+  LocalVocab makeLocalVocab() const { return LocalVocab{allocator()}; }
+
   // If the result of this `Operation` is sorted (either because this
   // `Operation` enforces this sorting, or because it preserves the sorting of
   // its children), return the variable that is the primary sort key. Else

--- a/src/engine/Service.cpp
+++ b/src/engine/Service.cpp
@@ -313,7 +313,7 @@ Result::LazyResult Service::computeResultLazily(
   using LC = Result::IdTableLoopControl;
   auto get = [service = this, vars = std::move(vars), singleIdTable,
               inputRange = moveToCachingInputRange(std::move(body)),
-              localVocab = LocalVocab{},
+              localVocab = makeLocalVocab(),
               idTable = IdTable{getResultWidth(),
                                 getExecutionContext()->getAllocator()},
               rowIdx = size_t{0}, varsChecked = false,
@@ -337,7 +337,7 @@ Result::LazyResult Service::computeResultLazily(
           Result::IdTableVocabPair pair{std::move(idTable),
                                         std::move(localVocab)};
           idTable.clear();
-          localVocab = LocalVocab{};
+          localVocab = service->makeLocalVocab();
           rowIdx = 0;
           return LC::yieldValue(std::move(pair));
         }
@@ -495,7 +495,7 @@ Result Service::makeNeutralElementResultForSilentFail() const {
   for (size_t colIdx = 0; colIdx < getResultWidth(); ++colIdx) {
     idTable(0, colIdx) = Id::makeUndefined();
   }
-  return {std::move(idTable), resultSortedOn(), LocalVocab{}};
+  return {std::move(idTable), resultSortedOn(), makeLocalVocab()};
 }
 
 // ____________________________________________________________________________
@@ -694,7 +694,7 @@ void Service::precomputeSiblingResult(std::shared_ptr<Operation> left,
   Result::IdTableVocabPair siblingPair(
       IdTable{sibling->getResultWidth(),
               sibling->getExecutionContext()->getAllocator()},
-      LocalVocab{});
+      sibling->makeLocalVocab());
   siblingPair.idTable_.reserve(rows);
 
   for (auto& pair : resultPairs) {

--- a/src/engine/Sort.cpp
+++ b/src/engine/Sort.cpp
@@ -108,7 +108,7 @@ Result Sort::computeResult(bool requestLaziness) {
   // For lazy input, collect blocks until we exceed the threshold. Note that we
   // may exceed the threshold by the size of one block.
   std::vector<IdTable> collectedBlocks;
-  LocalVocab mergedLocalVocab;
+  LocalVocab mergedLocalVocab = LocalVocab::unlimited();
   size_t totalRows = 0;
   auto idTables = input->idTables();
   auto it = idTables.begin();

--- a/src/engine/SortedUnionImpl.h
+++ b/src/engine/SortedUnionImpl.h
@@ -103,7 +103,7 @@ struct SortedUnionImpl
 
   // Result storage.
   IdTable resultTable_;
-  LocalVocab localVocab_{};
+  LocalVocab localVocab_ = LocalVocab::unlimited();
 
   // Metadata
   ad_utility::AllocatorWithLimit<Id> allocator_;
@@ -182,7 +182,7 @@ struct SortedUnionImpl
                                            std::move(localVocab_)};
     resultTable_ = IdTable{resultTable_.numColumns(), allocator_};
     resultTable_.reserve(Union::chunkSize);
-    localVocab_ = LocalVocab{};
+    localVocab_ = LocalVocab::unlimited();
     return result;
   }
 

--- a/src/engine/StringMapping.cpp
+++ b/src/engine/StringMapping.cpp
@@ -13,7 +13,7 @@ namespace qlever::binary_export {
 
 // _____________________________________________________________________________
 std::vector<std::string> StringMapping::flush(const Index& index) {
-  LocalVocab dummy;
+  LocalVocab dummy = LocalVocab::unlimited();
   std::vector<std::string> sortedStrings;
   sortedStrings.resize(stringMapping_.size());
   for (const auto& [oldId, newId] : stringMapping_) {

--- a/src/engine/TextIndexScanForEntity.cpp
+++ b/src/engine/TextIndexScanForEntity.cpp
@@ -60,7 +60,7 @@ Result TextIndexScanForEntity::computeResult(
   }
   runtimeInfo().addDetail("word: ", config_.word_);
 
-  return {std::move(idTable), resultSortedOn(), LocalVocab{}};
+  return {std::move(idTable), resultSortedOn(), makeLocalVocab()};
 }
 
 // _____________________________________________________________________________

--- a/src/engine/TextIndexScanForWord.cpp
+++ b/src/engine/TextIndexScanForWord.cpp
@@ -50,7 +50,7 @@ Result TextIndexScanForWord::computeResult(
   // Add details to the runtimeInfo. This is has no effect on the result.
   runtimeInfo().addDetail("word: ", config_.word_);
 
-  return {std::move(idTable), resultSortedOn(), LocalVocab{}};
+  return {std::move(idTable), resultSortedOn(), makeLocalVocab()};
 }
 
 // _____________________________________________________________________________

--- a/src/engine/TransitivePathBase.cpp
+++ b/src/engine/TransitivePathBase.cpp
@@ -214,7 +214,7 @@ Result::Generator TransitivePathBase::fillTableWithHullImpl(
   ad_utility::Timer timer{ad_utility::Timer::Stopped};
   size_t outputRow = 0;
   IdTableStatic<OUTPUT_WIDTH> table{getResultWidth(), allocator()};
-  LocalVocab mergedVocab{};
+  LocalVocab mergedVocab = LocalVocab::unlimited();
   for (auto& [node, graph, linkedNodes, localVocab, idTable, inputRow] : hull) {
     timer.cont();
     // As an optimization nodes without any linked nodes should not get yielded

--- a/src/engine/TransitivePathImpl.h
+++ b/src/engine/TransitivePathImpl.h
@@ -148,7 +148,7 @@ class TransitivePathImpl : public TransitivePathBase {
     // Technically we should pass the localVocab of `sub` here, but this will
     // just lead to a merge with itself later on in the pipeline.
     detail::TableColumnWithVocab<const decltype(nodes)&> tableInfo{
-        std::nullopt, nodes, LocalVocab{}};
+        std::nullopt, nodes, LocalVocab::unlimited()};
 
     NodeGenerator hull = transitiveHull(
         std::move(edges), sub->getCopyOfLocalVocab(), ql::span{&tableInfo, 1},
@@ -228,7 +228,7 @@ class TransitivePathImpl : public TransitivePathBase {
     ad_utility::Timer timer{ad_utility::Timer::Stopped};
     // `targetId` is only ever used for comparisons, and never stored in the
     // result, so we use a separate local vocabulary.
-    LocalVocab targetHelper;
+    LocalVocab targetHelper = LocalVocab::unlimited();
     const auto& index = getIndex();
     std::optional<Id> targetId =
         target.isVariable()
@@ -279,7 +279,7 @@ class TransitivePathImpl : public TransitivePathBase {
             // Reset vocab to prevent merging the same vocab over and over
             // again.
             if (yieldOnce) {
-              mergedVocab = LocalVocab{};
+              mergedVocab = LocalVocab::unlimited();
             }
           }
         }
@@ -321,7 +321,7 @@ class TransitivePathImpl : public TransitivePathBase {
       return result;
     }
     // id -> var|id
-    LocalVocab helperVocab;
+    LocalVocab helperVocab = LocalVocab::unlimited();
     Id startId =
         TripleComponent{startSide.value_}.toValueId(getIndex(), helperVocab);
     // Make sure we retrieve the Id from an IndexScan, so we don't have to pass

--- a/src/engine/Values.cpp
+++ b/src/engine/Values.cpp
@@ -112,7 +112,7 @@ Result Values::computeResult([[maybe_unused]] bool requestLaziness) {
   IdTable idTable{getExecutionContext()->getAllocator()};
   idTable.setNumColumns(getResultWidth());
 
-  LocalVocab localVocab{};
+  LocalVocab localVocab = makeLocalVocab();
 
   // Fill the result table using the `writeValues` method below.
   size_t resWidth = getResultWidth();

--- a/src/engine/sparqlExpressions/PrefilterExpressionIndex.cpp
+++ b/src/engine/sparqlExpressions/PrefilterExpressionIndex.cpp
@@ -475,7 +475,7 @@ BlockMetadataRanges PrefixRegexExpression::evaluateImpl(
     BlockMetadataSpan blockRange, bool getTotalComplement) const {
   static_assert(Datatype::LocalVocabIndex > Datatype::VocabIndex);
   static_assert(Vocab::PrefixRanges::Ranges{}.size() == 1);
-  LocalVocab localVocab{};
+  LocalVocab localVocab = LocalVocab::unlimited();
   auto prefixQuoted =
       absl::StrCat("\"", asStringViewUnsafe(prefixLiteral_.getContent()));
   auto [lowerVocabIndex, upperVocabIndex] =
@@ -551,7 +551,7 @@ BlockMetadataRanges RelationalExpression<Comparison>::evaluateImpl(
   using namespace valueIdComparators;
   // If `rightSideReferenceValue_` contains a `LocalVocabEntry` value, we use
   // the here created `LocalVocab` to retrieve a corresponding `ValueId`.
-  LocalVocab localVocab{};
+  LocalVocab localVocab = LocalVocab::unlimited();
   auto referenceId =
       getValueIdFromIdOrLocalVocabEntry(rightSideReferenceValue_, localVocab);
   // Use getRangesForId (from valueIdComparators) to extract the ranges

--- a/src/index/LocalVocab.cpp
+++ b/src/index/LocalVocab.cpp
@@ -10,7 +10,8 @@
 
 // _____________________________________________________________________________
 LocalVocab LocalVocab::clone() const {
-  LocalVocab result;
+  // The clone draws from the same memory pool as this `LocalVocab`.
+  LocalVocab result{allocator_};
   result.mergeWith(*this);
   AD_CORRECTNESS_CHECK(result.size_ == size_);
   return result;
@@ -18,9 +19,24 @@ LocalVocab LocalVocab::clone() const {
 
 // _____________________________________________________________________________
 LocalVocab LocalVocab::merge(ql::span<const LocalVocab*> vocabs) {
-  LocalVocab result;
+  // The result draws from the same memory pool as the first of the merged
+  // `LocalVocab`s (if any), so that words later added to the result's primary
+  // set are accounted against the correct limit.
+  LocalVocab result =
+      vocabs.empty() ? LocalVocab{} : LocalVocab{vocabs.front()->allocator_};
   result.mergeWith(vocabs | ql::views::transform(ad_utility::dereference));
   return result;
+}
+
+// _____________________________________________________________________________
+ad_utility::MemorySize LocalVocab::memoryFootprint(
+    const LocalVocabEntry& entry) {
+  // A fixed overhead for the node itself (which stores short strings inline via
+  // SSO) plus the slot in the hash table's control array, plus the dynamically
+  // allocated part of the entry's string (which is empty for short strings).
+  static constexpr size_t fixedOverhead = sizeof(LocalVocabEntry) + 16;
+  return ad_utility::MemorySize::bytes(
+      fixedOverhead + entry.toStringRepresentation().capacity());
 }
 
 // _____________________________________________________________________________
@@ -39,7 +55,14 @@ LocalVocabIndex LocalVocab::getIndexAndAddIfNotContainedImpl(WordT&& word) {
   // implementations.
   AD_CORRECTNESS_CHECK(!copied_->load());
   auto [wordIterator, isNewWord] = primaryWordSet().insert(AD_FWD(word));
-  size_ += static_cast<size_t>(isNewWord);
+  if (isNewWord) {
+    ++size_;
+    // Account for the memory of the newly inserted word against the memory
+    // limit. This might throw an `AllocationExceedsLimitException`, in which
+    // case the query is aborted and this `LocalVocab` is destroyed shortly
+    // after, releasing all its reserved memory.
+    primaryWordSet_->reservation_.account(memoryFootprint(*wordIterator));
+  }
   // TODO<Libc++18> Use std::to_address (more idiomatic, but currently breaks
   // the MacOS build.
   return &(*wordIterator);

--- a/src/index/LocalVocab.h
+++ b/src/index/LocalVocab.h
@@ -17,6 +17,7 @@
 #include "backports/algorithm.h"
 #include "backports/span.h"
 #include "index/LocalVocabEntry.h"
+#include "util/AllocatorWithLimit.h"
 #include "util/BlankNodeManager.h"
 #include "util/Exception.h"
 
@@ -35,13 +36,30 @@
 // `LocalVocab`.
 class LocalVocab {
  private:
-  // The primary set of `LocalVocabEntry`s, which can grow dynamically.
+  // The type of the sets that store the `LocalVocabEntry`s.
   //
-  // NOTE: This is a `absl::node_hash_set` because we hand out pointers to
-  // the `LocalVocabEntry`s and it is hence essential that their addresses
-  // remain stable over their lifetime in the hash set.
-  using Set = absl::node_hash_set<LocalVocabEntry>;
-  std::shared_ptr<Set> primaryWordSet_ = std::make_shared<Set>();
+  // NOTE: This derives from `absl::node_hash_set` because we hand out pointers
+  // to the `LocalVocabEntry`s and it is hence essential that their addresses
+  // remain stable over their lifetime in the hash set. It additionally carries
+  // a `MemoryLimitReservation` that accounts for the memory used by its entries
+  // against the memory limit (see `allocator_` and `memoryFootprint`). As the
+  // sets are shared between `LocalVocab`s (see `mergeWith`), storing the
+  // reservation inside the set ensures that the memory is accounted for exactly
+  // as long as the set (and thus its entries) is alive.
+  struct Set : absl::node_hash_set<LocalVocabEntry> {
+    ad_utility::MemoryLimitReservation reservation_;
+    explicit Set(ad_utility::MemoryLimitReservation reservation)
+        : reservation_{std::move(reservation)} {}
+  };
+
+  // The allocator whose memory limit all the sets of this `LocalVocab` are
+  // accounted against. By default it is unlimited (see the default
+  // constructor), so that `LocalVocab`s that are not associated with a query
+  // (e.g. in tests) don't need to know about a limit.
+  ad_utility::AllocatorWithLimit<char> allocator_;
+
+  // The primary set of `LocalVocabEntry`s, which can grow dynamically.
+  std::shared_ptr<Set> primaryWordSet_;
 
   using LocalBlankNodeManager =
       ad_utility::BlankNodeManager::LocalBlankNodeManager;
@@ -61,8 +79,28 @@ class LocalVocab {
       std::make_unique<std::atomic_bool>(false);
 
  public:
-  // Create a new, empty local vocabulary.
-  LocalVocab() = default;
+  // Create a new, empty local vocabulary whose memory is not limited. This is
+  // used for `LocalVocab`s that are not associated with a query (e.g. in
+  // tests).
+  LocalVocab() : LocalVocab(ad_utility::makeUnlimitedAllocator<char>()) {}
+
+  // Create a new, empty local vocabulary whose memory is accounted against the
+  // limit of the given `allocator`. Typically the allocator is obtained via
+  // `QueryExecutionContext::getAllocator()`.
+  template <typename T>
+  explicit LocalVocab(const ad_utility::AllocatorWithLimit<T>& allocator)
+      : allocator_{allocator.template as<char>()},
+        primaryWordSet_{makeWordSet()} {}
+
+  // Create a new, empty local vocabulary whose memory is deliberately NOT
+  // accounted against any memory limit. For `LocalVocab`s that are part of a
+  // query result, prefer the allocator-taking constructor above (or
+  // `Operation::makeLocalVocab`). Use this named factory (instead of the
+  // default constructor) at the call sites where an unlimited local vocab is
+  // used on purpose (e.g. pass-through merges that never add new words, or code
+  // outside of query execution), so that these sites can be easily spotted
+  // during review.
+  static LocalVocab unlimited() { return LocalVocab{}; }
 
   // Prevent accidental copying of a local vocabulary.
   LocalVocab(const LocalVocab&) = delete;
@@ -223,6 +261,19 @@ class LocalVocab {
  private:
   // Accessors for the primary set.
   Set& primaryWordSet() { return *primaryWordSet_; }
+
+  // Create a new, empty `Set` with a fresh `MemoryLimitReservation` that draws
+  // from the pool of `allocator_`.
+  std::shared_ptr<Set> makeWordSet() const {
+    return std::make_shared<Set>(
+        ad_utility::MemoryLimitReservation{allocator_});
+  }
+
+  // Return the amount of memory that the given `entry`, when stored in a `Set`,
+  // occupies. This is the size of the node itself (which includes short strings
+  // via SSO) plus a fixed overhead for the slot in the hash table, plus the
+  // dynamically allocated part of the entry's string (empty for short strings).
+  static ad_utility::MemorySize memoryFootprint(const LocalVocabEntry& entry);
 
   // Common implementation for the two methods `getIndexAndAddIfNotContained`
   // and `getIndexOrNullopt` above.

--- a/src/util/AllocatorWithLimit.h
+++ b/src/util/AllocatorWithLimit.h
@@ -9,8 +9,10 @@
 #include <absl/strings/str_cat.h>
 
 #include <memory>
+#include <optional>
 
 #include "backports/functional.h"
+#include "util/Exception.h"
 #include "util/MemorySize/MemorySize.h"
 #include "util/Synchronized.h"
 
@@ -278,6 +280,97 @@ template <typename T>
 AllocatorWithLimit<T> makeUnlimitedAllocator() {
   return makeAllocatorWithLimit<T>(MemorySize::max());
 }
+
+// A coarse-grained (chunked) reservation of memory from the shared memory pool
+// of an `AllocatorWithLimit`. It is meant for data structures that consist of
+// very many small objects (like the `LocalVocab`, which stores many small
+// strings): instead of accounting each small object against the shared,
+// spinlock-guarded counter (which becomes a massive contention point when the
+// pool is shared by many threads), the reservation grabs memory from the pool
+// in large chunks (see `chunkSize_`). The shared counter is thus only touched
+// once per chunk, while the exact byte count is tracked locally without any
+// synchronization. On destruction, all reserved memory is returned to the pool.
+//
+// NOTE: This is a "soft" limit: the actually used memory may exceed the limit
+// by up to `chunkSize_` before an exception is thrown, which is acceptable for
+// enforcing a memory limit on query processing.
+class MemoryLimitReservation {
+ public:
+  // The granularity in which memory is reserved from (and returned to) the
+  // shared pool.
+  static constexpr MemorySize chunkSize_ = MemorySize::megabytes(1);
+
+ private:
+  // Handle to the shared pool. This is `nullopt` for a moved-from reservation.
+  std::optional<detail::AllocationMemoryLeftThreadsafe> memoryLeft_;
+  // The number of bytes currently reserved from the pool.
+  MemorySize reserved_{};
+  // The number of bytes that have actually been accounted as used. The
+  // invariant `used_ <= reserved_` holds at all times.
+  MemorySize used_{};
+
+ public:
+  // Create a reservation that draws from the pool of the given allocator.
+  template <typename T>
+  explicit MemoryLimitReservation(const AllocatorWithLimit<T>& allocator)
+      : memoryLeft_{allocator.getMemoryLeft()} {}
+
+  // Move operations transfer the reservation and leave the moved-from object
+  // empty, so that it does not return any memory to the pool on destruction.
+  MemoryLimitReservation(MemoryLimitReservation&& other) noexcept
+      : memoryLeft_{std::move(other.memoryLeft_)},
+        reserved_{other.reserved_},
+        used_{other.used_} {
+    other.memoryLeft_.reset();
+    other.reserved_ = MemorySize{};
+    other.used_ = MemorySize{};
+  }
+  MemoryLimitReservation& operator=(MemoryLimitReservation&& other) noexcept {
+    std::swap(memoryLeft_, other.memoryLeft_);
+    std::swap(reserved_, other.reserved_);
+    std::swap(used_, other.used_);
+    return *this;
+  }
+
+  // The reservation is not copyable.
+  MemoryLimitReservation(const MemoryLimitReservation&) = delete;
+  MemoryLimitReservation& operator=(const MemoryLimitReservation&) = delete;
+
+  // Return all reserved memory to the shared pool.
+  ~MemoryLimitReservation() { returnReservedMemory(); }
+
+  // Account for `additionalMemory` more used bytes. If this would exceed the
+  // currently reserved amount, reserve one or more additional chunks from the
+  // shared pool. Throw an `AllocationExceedsLimitException` if the limit of the
+  // pool is exceeded.
+  void account(MemorySize additionalMemory) {
+    AD_CORRECTNESS_CHECK(memoryLeft_.has_value());
+    MemorySize newUsed = used_ + additionalMemory;
+    if (newUsed > reserved_) {
+      // Round the missing amount up to a multiple of `chunkSize_`.
+      MemorySize missing = newUsed - reserved_;
+      size_t numChunks = (missing.getBytes() + chunkSize_.getBytes() - 1) /
+                         chunkSize_.getBytes();
+      MemorySize toReserve = chunkSize_ * numChunks;
+      memoryLeft_.value().ptr()->wlock()->decrease_if_enough_left_or_throw(
+          toReserve);
+      reserved_ += toReserve;
+    }
+    used_ = newUsed;
+  }
+
+  // The number of bytes currently reserved from the pool (for testing).
+  MemorySize reservedForTesting() const { return reserved_; }
+
+ private:
+  // Return all reserved memory to the shared pool and reset the reservation.
+  void returnReservedMemory() {
+    if (memoryLeft_.has_value() && reserved_ != MemorySize{}) {
+      memoryLeft_.value().ptr()->wlock()->increase(reserved_);
+      reserved_ = MemorySize{};
+    }
+  }
+};
 
 }  // namespace ad_utility
 

--- a/test/ExecuteUpdateTest.cpp
+++ b/test/ExecuteUpdateTest.cpp
@@ -249,8 +249,8 @@ TEST(ExecuteUpdate, computeGraphUpdateQuads) {
       UpdateMetadata metadata;
       auto result = qet.getResult(false);
       results.push_back(ExecuteUpdate::computeGraphUpdateQuads(
-          index, pq, *result, qet.getVariableColumns(), sharedHandle,
-          metadata));
+          index, pq, *result, qet.getVariableColumns(), sharedHandle, metadata,
+          ad_utility::makeUnlimitedAllocator<::Id>()));
       ExecuteUpdate::executeUpdate(index, pq, qet, deltaTriples, sharedHandle);
     }
     return results;
@@ -474,8 +474,9 @@ TEST(ExecuteUpdate, transformTriplesTemplate) {
               AD_CURRENT_SOURCE_LOC()) {
         auto loc = generateLocationTrace(sourceLocation);
         auto [transformedTriples, localVocab] =
-            ExecuteUpdate::transformTriplesTemplate(index, variableColumns,
-                                                    triples);
+            ExecuteUpdate::transformTriplesTemplate(
+                index, variableColumns, triples,
+                ad_utility::makeUnlimitedAllocator<::Id>());
         const auto transformedTriplesMatchers = ad_utility::transform(
             expectedTransformedTriples,
             [&localVocab, &TripleComponentMatcher](const auto& expectedTriple) {
@@ -495,9 +496,10 @@ TEST(ExecuteUpdate, transformTriplesTemplate) {
                ad_utility::source_location sourceLocation =
                    AD_CURRENT_SOURCE_LOC()) {
         auto loc = generateLocationTrace(sourceLocation);
+        auto unlimitedAllocator = ad_utility::makeUnlimitedAllocator<::Id>();
         AD_EXPECT_THROW_WITH_MESSAGE(
-            ExecuteUpdate::transformTriplesTemplate(index, variableColumns,
-                                                    std::move(triples)),
+            ExecuteUpdate::transformTriplesTemplate(
+                index, variableColumns, std::move(triples), unlimitedAllocator),
             messageMatcher);
       };
   // Transforming an empty vector of template results in no `TransformedTriple`s

--- a/test/LocalVocabTest.cpp
+++ b/test/LocalVocabTest.cpp
@@ -31,7 +31,9 @@
 #include "engine/sparqlExpressions/LiteralExpression.h"
 #include "global/Id.h"
 #include "global/Pattern.h"
+#include "util/AllocatorWithLimit.h"
 #include "util/IndexTestHelpers.h"
+#include "util/MemorySize/MemorySize.h"
 
 namespace {
 // Get test collection of words of a given size. The words are all distinct.
@@ -666,4 +668,74 @@ TEST(LocalVocab, reserveBlankNodeBlocksFromExplicitIndices_PreconditionCheck) {
   AD_EXPECT_THROW_WITH_MESSAGE(
       vocab.reserveBlankNodeBlocksFromExplicitIndices(indices, &bnm),
       ::testing::HasSubstr("Assertion"));
+}
+
+// _____________________________________________________________________________
+TEST(LocalVocab, reservesMemoryInChunksAndReleasesOnDestruction) {
+  using namespace ad_utility::memory_literals;
+  auto* qec = ad_utility::testing::getQec();
+  const auto& context = qec->getLocalVocabContext();
+  auto allocator = ad_utility::makeAllocatorWithLimit<char>(100_MB);
+  auto memoryWhenEmpty = allocator.amountMemoryLeft();
+  {
+    LocalVocab vocab{allocator};
+    // An empty `LocalVocab` does not reserve any memory.
+    EXPECT_EQ(allocator.amountMemoryLeft(), memoryWhenEmpty);
+
+    // Adding a single (short) word reserves exactly one chunk from the pool.
+    vocab.getIndexAndAddIfNotContained(
+        getTestCollectionOfWords(1, context).at(0));
+    EXPECT_EQ(allocator.amountMemoryLeft(),
+              memoryWhenEmpty - ad_utility::MemoryLimitReservation::chunkSize_);
+  }
+  // Destroying the `LocalVocab` returns all reserved memory to the pool.
+  EXPECT_EQ(allocator.amountMemoryLeft(), memoryWhenEmpty);
+}
+
+// _____________________________________________________________________________
+TEST(LocalVocab, respectsMemoryLimit) {
+  using namespace ad_utility::memory_literals;
+  auto* qec = ad_utility::testing::getQec();
+  const auto& context = qec->getLocalVocabContext();
+  // A small memory pool. Inserting sufficiently many distinct words must
+  // eventually exceed it and throw.
+  auto allocator = ad_utility::makeAllocatorWithLimit<char>(2_MB);
+  auto memoryWhenEmpty = allocator.amountMemoryLeft();
+  {
+    LocalVocab vocab{allocator};
+    auto words = getTestCollectionOfWords(200'000, context);
+    auto insertAll = [&vocab, &words]() {
+      for (auto& word : words) {
+        vocab.getIndexAndAddIfNotContained(word);
+      }
+    };
+    AD_EXPECT_THROW_WITH_MESSAGE(insertAll(),
+                                 ::testing::HasSubstr("Tried to allocate"));
+  }
+  // Even after the limit was exceeded, destroying the `LocalVocab` returns all
+  // reserved memory to the pool.
+  EXPECT_EQ(allocator.amountMemoryLeft(), memoryWhenEmpty);
+}
+
+// _____________________________________________________________________________
+TEST(LocalVocab, clonedVocabDrawsFromTheSamePool) {
+  using namespace ad_utility::memory_literals;
+  auto* qec = ad_utility::testing::getQec();
+  const auto& context = qec->getLocalVocabContext();
+  auto allocator = ad_utility::makeAllocatorWithLimit<char>(2_MB);
+  LocalVocab vocab{allocator};
+  vocab.getIndexAndAddIfNotContained(
+      getTestCollectionOfWords(1, context).at(0));
+  // The clone shares the (read-only) word set of the original and hence does
+  // not reserve additional memory, but writing to its own (empty) primary set
+  // is still accounted against the same limited pool.
+  LocalVocab clone = vocab.clone();
+  auto words = getTestCollectionOfWords(200'000, context);
+  auto insertAll = [&clone, &words]() {
+    for (auto& word : words) {
+      clone.getIndexAndAddIfNotContained(word);
+    }
+  };
+  AD_EXPECT_THROW_WITH_MESSAGE(insertAll(),
+                               ::testing::HasSubstr("Tried to allocate"));
 }


### PR DESCRIPTION
## What & why

The `LocalVocab` stores `LiteralOrIri`s that are created during query processing (e.g. by `BIND`, `GROUP_CONCAT`, string functions, `VALUES`, `SERVICE`, `LOAD`, `DESCRIBE`, and updates). Until now this memory was **not** accounted against the query's memory limit, so a query that creates very many new literals could use an unbounded amount of memory. This PR fixes that.

## Approach

QLever's allocator is a single **server-wide, spinlock-guarded** counter. Accounting each (small) word individually against it would turn that counter into a massive contention point. A micro-benchmark of `absl::node_hash_set` insertions confirmed this:

| scenario | std allocator | per-allocation limited allocator |
|---|---|---|
| small strings, single-thread | baseline | +24% |
| small strings, **8 threads (shared counter)** | baseline | **+587%** |

So instead of routing the containers through `AllocatorWithLimit`, the new `ad_utility::MemoryLimitReservation` draws from the shared pool in coarse **1 MB chunks** and tracks exact usage locally without synchronization. The shared counter is touched only once per chunk, while the limit is still enforced within one chunk of slack.

## Details

- **`AllocatorWithLimit.h`**: add `MemoryLimitReservation` — chunked reservation that throws `AllocationExceedsLimitException` on overflow and returns its memory on destruction.
- **`LocalVocab`**: the shared word `Set` now derives from `absl::node_hash_set` and additionally carries the reservation, so memory is accounted for exactly as long as the set (and its entries) is alive — correct across the `clone`/`mergeWith` sharing of sets. `clone`/`merge` propagate the allocator. The public API of `LocalVocab` is unchanged.
- The allocator is optional (default: unlimited). Operations seed their result vocab via the new `Operation::makeLocalVocab()`; since `clone`/`merge` propagate the allocator, the limit binds throughout the query tree (e.g. `BIND` clones its child's vocab).
- **`LocalVocab::unlimited()`**: a named factory for the (few) sites that use an unlimited local vocab on purpose — pass-through merges that never add new words, or code outside of query execution. These are now easy to spot (`grep LocalVocab::unlimited`) versus the accounted `makeLocalVocab()` sites.

## Tests

New `LocalVocabTest` cases: memory is reserved in chunks and released on destruction, the limit is enforced (throws), and a cloned vocab draws from the same pool. All existing `LocalVocabTest` and `ExecuteUpdateTest` cases still pass.