### PR TITLE
Use `PRE_TEST` gtest discovery in the native AppleClang macOS CI build

### DIFF
--- a/.github/workflows/macos-appleclang-native.yml
+++ b/.github/workflows/macos-appleclang-native.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Configure CMake
         working-directory: ${{ github.workspace }}/build
-        run: cmake -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -DCMAKE_OSX_DEPLOYMENT_TARGET=11.0 -DLOGLEVEL=INFO -DUSE_PARALLEL=false -D_NO_TIMING_TESTS=ON -DCOMPILER_SUPPORTS_MARCH_NATIVE=FALSE -DICU_ROOT=$(brew --prefix icu4c) -GNinja ..
+        run: cmake -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -DCMAKE_OSX_DEPLOYMENT_TARGET=11.0 -DLOGLEVEL=INFO -DUSE_PARALLEL=false -D_NO_TIMING_TESTS=ON -DCOMPILER_SUPPORTS_MARCH_NATIVE=FALSE -DICU_ROOT=$(brew --prefix icu4c) -GNinja -DCMAKE_GTEST_DISCOVER_TESTS_DISCOVERY_MODE=PRE_TEST ..
 
       - name: Build
         # Build your program with the given configuration
@@ -59,7 +59,10 @@ jobs:
       - name: Test
         id: complete_tests
         working-directory: ${{github.workspace}}/build/test
-        run: env CTEST_OUTPUT_ON_FAILURE=1 ctest -C ${{matrix.build-type}} -j $(sysctl -n hw.ncpu) .
+        # With `PRE_TEST` discovery, the tests are only discovered here, so make
+        # sure that an (unlikely) complete failure of the discovery fails the
+        # job instead of silently running zero tests.
+        run: env CTEST_OUTPUT_ON_FAILURE=1 ctest --no-tests=error -C ${{matrix.build-type}} -j $(sysctl -n hw.ncpu) .
 
       - name: Running and printing the benchmark examples.
         working-directory: ${{github.workspace}}/build


### PR DESCRIPTION
So far, the native AppleClang macOS build (`macos-appleclang-native.yml`) discovered the test cases of each test binary at build time, by running the binary right after linking. On the macOS runners this sporadically fails (an empty discovery output or a silent linker error on an unrelated test binary), which makes unrelated PRs red. Now the discovery is deferred to test time, like for the other macOS build in #3102 and the Docker builds since #3090.