### PR TITLE
Fix two bugs in the result columns of `SpatialJoin`

### DIFF
--- a/src/engine/SpatialJoin.cpp
+++ b/src/engine/SpatialJoin.cpp
@@ -491,6 +491,17 @@ PreparedSpatialJoinParams SpatialJoin::prepareJoin() const {
   auto bbLeft = getBoundingBoxColumnIndices(childLeft, joinVarLeft);
   auto bbRight = getBoundingBoxColumnIndices(childRight, joinVarRight);
 
+  // Filtering the left side is not possible through payload cols but there may
+  // be invisible columns, for example from a transitive path, that need to be
+  // taken into account. Also note that here `childLeft_` not `childLeft` is
+  // used, because `leftSelectedCols` and `rightSelectedCols` are applied after
+  // swapping tables back in case of a `WITHIN` join.
+  std::vector<ColumnIndex> leftSelectedCols;
+  for (auto [var, colInfo] :
+       copySortedByColumnIndex(childLeft_->getVariableColumns())) {
+    leftSelectedCols.push_back(colInfo.columnIndex_);
+  }
+
   // Payload cols and join col
   auto varsAndColInfo = copySortedByColumnIndex(getVarColMapPayloadVars());
   std::vector<ColumnIndex> rightSelectedCols;
@@ -506,7 +517,8 @@ PreparedSpatialJoinParams SpatialJoin::prepareJoin() const {
                                    std::move(resultRight),
                                    leftJoinCol,
                                    rightJoinCol,
-                                   rightSelectedCols,
+                                   std::move(leftSelectedCols),
+                                   std::move(rightSelectedCols),
                                    numColumns,
                                    getMaxDist(),
                                    getMaxResults(),

--- a/src/engine/SpatialJoin.h
+++ b/src/engine/SpatialJoin.h
@@ -32,6 +32,7 @@ struct PreparedSpatialJoinParams {
   std::shared_ptr<const Result> resultRight_;
   ColumnIndex leftJoinCol_;
   ColumnIndex rightJoinCol_;
+  std::vector<ColumnIndex> leftSelectedCols_;
   std::vector<ColumnIndex> rightSelectedCols_;
   size_t numColumns_;
   std::optional<double> maxDist_;

--- a/src/engine/SpatialJoinAlgorithms.cpp
+++ b/src/engine/SpatialJoinAlgorithms.cpp
@@ -312,32 +312,30 @@ Id SpatialJoinAlgorithms::computeDist(RtreeEntry& geo1, RtreeEntry& geo2) {
 void SpatialJoinAlgorithms::addResultTableEntry(
     IdTable* result, const IdTableView<0>* idTableLeft,
     const IdTableView<0>* idTableRight, size_t rowLeft, size_t rowRight,
-    Id distance) const {
-  // this lambda function copies values from copyFrom into the table res only if
-  // the column of the value is specified in sourceColumns. If sourceColumns is
-  // nullopt, all columns are added. It copies them into the row rowIndRes and
-  // column column colIndRes. It returns the column number until which elements
-  // were copied
-  auto addColumns = [](IdTable* res, const IdTableView<0>* copyFrom,
-                       size_t rowIndRes, size_t colIndRes, size_t rowIndCopy,
-                       std::optional<std::vector<ColumnIndex>> sourceColumns =
-                           std::nullopt) {
-    size_t nCols = sourceColumns.has_value() ? sourceColumns.value().size()
-                                             : copyFrom->numColumns();
-    for (size_t i = 0; i < nCols; i++) {
-      auto col = sourceColumns.has_value() ? sourceColumns.value()[i] : i;
-      res->at(rowIndRes, colIndRes + i) = (*copyFrom).at(rowIndCopy, col);
-    }
-    return colIndRes + nCols;
-  };
-
+    Id distance, bool swapLeftAndRight) const {
   auto resrow = result->numRows();
   result->emplace_back();
-  // add columns to result table
   size_t rescol = 0;
-  rescol = addColumns(result, idTableLeft, resrow, rescol, rowLeft);
-  rescol = addColumns(result, idTableRight, resrow, rescol, rowRight,
-                      params_.rightSelectedCols_);
+
+  // This helper copies values from `copyFrom` into the table `res` for all
+  // columns given in `sourceColumns`.
+  auto addColumns = [&resrow, &rescol, &result](
+                        const IdTableView<0>* copyFrom, size_t rowIndCopy,
+                        const std::vector<ColumnIndex>& sourceColumns) {
+    for (size_t col : sourceColumns) {
+      result->at(resrow, rescol) = copyFrom->at(rowIndCopy, col);
+      ++rescol;
+    }
+  };
+
+  if (swapLeftAndRight) {
+    // Swap back the tables from a `SpatialJoinType::WITHIN` join.
+    addColumns(idTableRight, rowRight, params_.leftSelectedCols_);
+    addColumns(idTableLeft, rowLeft, params_.rightSelectedCols_);
+  } else {
+    addColumns(idTableLeft, rowLeft, params_.leftSelectedCols_);
+    addColumns(idTableRight, rowRight, params_.rightSelectedCols_);
+  }
 
   if (config_.distanceVariable_.has_value()) {
     result->at(resrow, rescol) = distance;
@@ -356,8 +354,9 @@ Result SpatialJoinAlgorithms::BaselineAlgorithm() {
   throw std::runtime_error("not supported in C++17 mode currently");
 #else
   const auto [idTableLeft, resultLeft, idTableRight, resultRight, leftJoinCol,
-              rightJoinCol, rightSelectedCols, numColumns, maxDist, maxResults,
-              joinType, rightCacheName, bbLeft, bbRight] = params_;
+              rightJoinCol, leftSelectedCols, rightSelectedCols, numColumns,
+              maxDist, maxResults, joinType, rightCacheName, bbLeft, bbRight] =
+      params_;
   IdTable result{numColumns, qec_->getAllocator()};
 
   // cartesian product between the two tables, pairs are restricted according to
@@ -475,8 +474,9 @@ sj::SweeperCfg SpatialJoinAlgorithms::libspatialjoinSweeperConfig(
 // ____________________________________________________________________________
 Result SpatialJoinAlgorithms::LibspatialjoinAlgorithm() {
   const auto [idTableLeft, resultLeft, idTableRight, resultRight, leftJoinCol,
-              rightJoinCol, rightSelectedCols, numColumns, maxDist, maxResults,
-              joinType, rightCacheName, bbLeft, bbRight] = params_;
+              rightJoinCol, leftSelectedCols, rightSelectedCols, numColumns,
+              maxDist, maxResults, joinType, rightCacheName, bbLeft, bbRight] =
+      params_;
   // Setup.
   IdTable result{numColumns, qec_->getAllocator()};
   size_t NUM_THREADS = getNumThreads();
@@ -620,13 +620,8 @@ Result SpatialJoinAlgorithms::LibspatialjoinAlgorithm() {
       if (joinTypeVal == SpatialJoinType::WITHIN_DIST) {
         dist = resultDists[t][i];
       }
-      if (swapBack) {
-        addResultTableEntry(&result, idTableRight, idTableLeft, res.second,
-                            res.first, Id::makeFromDouble(dist));
-      } else {
-        addResultTableEntry(&result, idTableLeft, idTableRight, res.first,
-                            res.second, Id::makeFromDouble(dist));
-      }
+      addResultTableEntry(&result, idTableLeft, idTableRight, res.first,
+                          res.second, Id::makeFromDouble(dist), swapBack);
     }
   }
   spatialJoin_.value()->runtimeInfo().addDetail(
@@ -640,8 +635,9 @@ Result SpatialJoinAlgorithms::LibspatialjoinAlgorithm() {
 // ____________________________________________________________________________
 Result SpatialJoinAlgorithms::S2geometryAlgorithm() {
   const auto [idTableLeft, resultLeft, idTableRight, resultRight, leftJoinCol,
-              rightJoinCol, rightSelectedCols, numColumns, maxDist, maxResults,
-              joinType, rightCacheName, bbLeft, bbRight] = params_;
+              rightJoinCol, leftSelectedCols, rightSelectedCols, numColumns,
+              maxDist, maxResults, joinType, rightCacheName, bbLeft, bbRight] =
+      params_;
   IdTable result{numColumns, qec_->getAllocator()};
 
   S2PointIndex<size_t> s2index;
@@ -706,8 +702,9 @@ Result SpatialJoinAlgorithms::S2geometryAlgorithm() {
 // ____________________________________________________________________________
 Result SpatialJoinAlgorithms::S2PointPolylineAlgorithm() {
   const auto [idTableLeft, resultLeft, idTableRight, resultRight, leftJoinCol,
-              rightJoinCol, rightSelectedCols, numColumns, maxDist, maxResults,
-              joinType, rightCacheName, bbLeft, bbRight] = params_;
+              rightJoinCol, leftSelectedCols, rightSelectedCols, numColumns,
+              maxDist, maxResults, joinType, rightCacheName, bbLeft, bbRight] =
+      params_;
   IdTable result{numColumns, qec_->getAllocator()};
 
   AD_CORRECTNESS_CHECK(rightCacheName.has_value());
@@ -769,8 +766,9 @@ Result SpatialJoinAlgorithms::S2PointPolylineAlgorithm() {
 std::vector<Box> SpatialJoinAlgorithms::computeQueryBox(
     const Point& startPoint, double additionalDist) const {
   const auto [idTableLeft, resultLeft, idTableRight, resultRight, leftJoinCol,
-              rightJoinCol, rightSelectedCols, numColumns, maxDist, maxResults,
-              joinType, rightCacheName, bbLeft, bbRight] = params_;
+              rightJoinCol, leftSelectedCols, rightSelectedCols, numColumns,
+              maxDist, maxResults, joinType, rightCacheName, bbLeft, bbRight] =
+      params_;
   AD_CORRECTNESS_CHECK(maxDist.has_value(),
                        "Max distance must have a value for this operation");
   // haversine function
@@ -849,8 +847,9 @@ std::vector<Box> SpatialJoinAlgorithms::computeQueryBox(
 std::vector<Box> SpatialJoinAlgorithms::computeQueryBoxForLargeDistances(
     const Point& startPoint) const {
   const auto [idTableLeft, resultLeft, idTableRight, resultRight, leftJoinCol,
-              rightJoinCol, rightSelectedCols, numColumns, maxDist, maxResults,
-              joinType, rightCacheName, bbLeft, bbRight] = params_;
+              rightJoinCol, leftSelectedCols, rightSelectedCols, numColumns,
+              maxDist, maxResults, joinType, rightCacheName, bbLeft, bbRight] =
+      params_;
   AD_CORRECTNESS_CHECK(maxDist.has_value(),
                        "Max distance must have a value for this operation");
 
@@ -1047,8 +1046,9 @@ Result SpatialJoinAlgorithms::BoundingBoxAlgorithm() {
   };
 
   const auto [idTableLeft, resultLeft, idTableRight, resultRight, leftJoinCol,
-              rightJoinCol, rightSelectedCols, numColumns, maxDist, maxResults,
-              joinType, rightCacheName, bbLeft, bbRight] = params_;
+              rightJoinCol, leftSelectedCols, rightSelectedCols, numColumns,
+              maxDist, maxResults, joinType, rightCacheName, bbLeft, bbRight] =
+      params_;
   IdTable result{numColumns, qec_->getAllocator()};
 
   // create r-tree for smaller result table

--- a/src/engine/SpatialJoinAlgorithms.h
+++ b/src/engine/SpatialJoinAlgorithms.h
@@ -239,7 +239,7 @@ class SpatialJoinAlgorithms {
   // contain two quotes, the string is returned as a whole
   std::string_view betweenQuotes(std::string_view extractFrom) const;
 
-  // Helper to add a row to the result table. As combines the selected columns
+  // Helper to add a row to the result table. Combines the selected columns
   // (given in `params_`) from the given row in each input table respectively.
   // Input tables are swapped if requested (required for the `WITHIN` join).
   void addResultTableEntry(IdTable* result, const IdTableView<0>* resultLeft,

--- a/src/engine/SpatialJoinAlgorithms.h
+++ b/src/engine/SpatialJoinAlgorithms.h
@@ -239,12 +239,13 @@ class SpatialJoinAlgorithms {
   // contain two quotes, the string is returned as a whole
   std::string_view betweenQuotes(std::string_view extractFrom) const;
 
-  // Helper function, which adds a row, which belongs to the result to the
-  // result table. As inputs it uses a row of the left and a row of the right
-  // child result table.
+  // Helper to add a row to the result table. As combines the selected columns
+  // (given in `params_`) from the given row in each input table respectively.
+  // Input tables are swapped if requested (required for the `WITHIN` join).
   void addResultTableEntry(IdTable* result, const IdTableView<0>* resultLeft,
                            const IdTableView<0>* resultRight, size_t rowLeft,
-                           size_t rowRight, Id distance) const;
+                           size_t rowRight, Id distance,
+                           bool swapLeftAndRight = false) const;
 
   // This helper function calculates the bounding boxes based on a box, where
   // definitely no match can occur. This means every element in the anti

--- a/test/engine/SpatialJoinTest.cpp
+++ b/test/engine/SpatialJoinTest.cpp
@@ -34,7 +34,6 @@
 #include "global/Constants.h"
 #include "global/Id.h"
 #include "global/ValueId.h"
-#include "gmock/gmock.h"
 #include "index/ExportIds.h"
 #include "index/LocalVocabEntry.h"
 #include "parser/PayloadVariables.h"

--- a/test/engine/SpatialJoinTest.cpp
+++ b/test/engine/SpatialJoinTest.cpp
@@ -34,6 +34,7 @@
 #include "global/Constants.h"
 #include "global/Id.h"
 #include "global/ValueId.h"
+#include "gmock/gmock.h"
 #include "index/ExportIds.h"
 #include "index/LocalVocabEntry.h"
 #include "parser/PayloadVariables.h"
@@ -728,6 +729,63 @@ TEST(SpatialJoinVarColTest, ChildResultWidth) {
   };
   EXPECT_THAT(spatialJoin->getVariableColumns(),
               ::testing::UnorderedElementsAreArray(expectedVarToCol));
+}
+
+// Regression test for #3105.
+TEST(SpatialJoinVarColTest, InvisibleColumnsAndWithinSwap) {
+  // Test index with a rectangle polygon as the right side for `geof:sfWithin`.
+  std::string bb =
+      "\"POLYGON((0 0,5 0,5 5,0 5,0 0))\""
+      "^^<http://www.opengis.net/ont/geosparql#wktLiteral>";
+  auto* qec = ad_utility::testing::getQec("<a1> <a> " + bb + " .\n");
+  VocabIndex v;
+  ASSERT_TRUE(qec->getIndex().getVocab().getId(bb, &v));
+  auto bbId = ValueId::makeFromVocabIndex(v);
+  auto qetRight = ad_utility::makeExecutionTree<ValuesForTesting>(
+      qec, makeIdTableFromVector({{bbId}}),
+      std::vector<std::optional<Variable>>{V{"?c"}}, true);
+
+  // The left side has two points (contained in the polygon), one invisible
+  // column and one visible payload column.
+  auto p1Id = ValueId::makeFromGeoPoint({1, 1});
+  auto p2Id = ValueId::makeFromGeoPoint({2, 2});
+  auto invisible1Id = ValueId::makeFromInt(10);
+  auto invisible2Id = ValueId::makeFromInt(11);
+  auto payload1Id = ValueId::makeFromInt(1);
+  auto payload2Id = ValueId::makeFromInt(2);
+  auto qetLeft = ad_utility::makeExecutionTree<ValuesForTesting>(
+      qec,
+      makeIdTableFromVector(
+          {{p1Id, invisible1Id, payload1Id}, {p2Id, invisible2Id, payload2Id}}),
+      std::vector<std::optional<Variable>>{V{"?a"}, std::nullopt, V{"?b"}},
+      false);
+
+  // Run a `SpatialJoin` with `SpatialJoinType::WITHIN`.
+  auto spatialJoin = ad_utility::makeExecutionTree<SpatialJoin>(
+      qec,
+      SpatialJoinConfiguration{
+          LibSpatialJoinConfig{SpatialJoinType::WITHIN, std::nullopt},
+          Variable{"?a"}, Variable{"?c"}, std::nullopt, PayloadVariables::all(),
+          SpatialJoinAlgorithm::LIBSPATIALJOIN, SpatialJoinType::WITHIN},
+      qetLeft, qetRight);
+  auto result = spatialJoin->getResult();
+  ASSERT_TRUE(result->isFullyMaterialized());
+
+  // We expect the three visible columns (two join cols and the payload column)
+  // to be in the result, but not the invisible column.
+  VariableToColumnMap expectedVarToCol{
+      {Variable{"?a"}, makeAlwaysDefinedColumn(0)},
+      {Variable{"?b"}, makeAlwaysDefinedColumn(1)},
+      {Variable{"?c"}, makeAlwaysDefinedColumn(2)},
+  };
+  EXPECT_THAT(spatialJoin->getVariableColumns(),
+              ::testing::UnorderedElementsAreArray(expectedVarToCol));
+
+  // Check that the columns are correctly copied to the result.
+  EXPECT_THAT(result->idTableView(), matchesIdTableFromVector({
+                                         {p1Id, payload1Id, bbId},
+                                         {p2Id, payload2Id, bbId},
+                                     }));
 }
 
 }  // namespace variableColumnMapAndResultWidth

--- a/test/engine/SpatialJoinTestHelpers.h
+++ b/test/engine/SpatialJoinTestHelpers.h
@@ -530,6 +530,7 @@ inline SpatialJoinAlgorithms getDummySpatialJoinAlgsForWrapperTesting(
                                    0,
                                    0,
                                    std::vector<ColumnIndex>{},
+                                   std::vector<ColumnIndex>{},
                                    1,
                                    spatialJoin->getMaxDist(),
                                    std::nullopt,


### PR DESCRIPTION
Fixes two bugs in `SpatialJoinAlgorithms::addResultTableEntry` and thus #3105:

1. When swapping of join sides for the `libspatialjoin` algorithm with `SpatialJoinType::WITHIN` is active, the filtering of columns of the right side was applied to the left side.
2. All columns from the left side were always added (right side in the case of swapping), not taking into account invisible columns.