### PR TITLE
Treat certain IRIs as blank nodes and consistently remap them on updates

### DIFF
--- a/src/global/Constants.h
+++ b/src/global/Constants.h
@@ -224,6 +224,10 @@ static constexpr std::string_view GEO_LITERAL_SUFFIX =
 constexpr std::string_view SF_PREFIX = "http://www.opengis.net/ont/sf#";
 
 constexpr inline std::string_view VOCAB_SUFFIX = ".vocabulary";
+// Suffix for the dedicated vocabulary that stores the IRIs which were treated
+// as blank nodes during index building (see `BlankNodeIriVocabulary`).
+constexpr inline std::string_view BLANK_NODE_IRI_VOCAB_SUFFIX =
+    ".blanknode-iri-vocabulary";
 constexpr inline std::string_view META_FILE_SUFFIX = ".meta";
 constexpr inline std::string_view CONFIGURATION_FILE = ".meta-data.json";
 

--- a/src/index/BlankNodeIriVocabulary.cpp
+++ b/src/index/BlankNodeIriVocabulary.cpp
@@ -1,0 +1,90 @@
+// Copyright 2026 The QLever Authors, in particular:
+//
+// 2026 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+//
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#include "index/BlankNodeIriVocabulary.h"
+
+#include "backports/algorithm.h"
+#include "util/Exception.h"
+#include "util/Serializer/FileSerializer.h"
+#include "util/Serializer/SerializeVector.h"
+
+// ____________________________________________________________________________
+BlankNodeIriVocabulary::Writer::Writer(
+    std::unique_ptr<WordWriterBase> wordWriter, std::string chunksFilename)
+    : wordWriter_{std::move(wordWriter)},
+      chunksFilename_{std::move(chunksFilename)} {}
+
+// ____________________________________________________________________________
+void BlankNodeIriVocabulary::Writer::operator()(std::string_view iri,
+                                                uint64_t blankNodeIndex) {
+  AD_CORRECTNESS_CHECK(!finished_);
+  // The word writer assigns the positions `0, 1, 2, ...` in the order in which
+  // the words are pushed, so the position is always `nextVocabPos_`.
+  uint64_t position = (*wordWriter_)(iri, false);
+  AD_CORRECTNESS_CHECK(position == nextVocabPos_);
+  // Extend the current chunk if the blank node index is contiguous with it;
+  // otherwise start a new chunk.
+  if (!chunks_.empty() &&
+      chunks_.back().blankNodeStartIndex_ + chunks_.back().count_ ==
+          blankNodeIndex) {
+    ++chunks_.back().count_;
+  } else {
+    chunks_.push_back(Chunk{position, blankNodeIndex, 1});
+  }
+  ++nextVocabPos_;
+}
+
+// ____________________________________________________________________________
+void BlankNodeIriVocabulary::Writer::finish() {
+  if (finished_) {
+    return;
+  }
+  finished_ = true;
+  wordWriter_->finish();
+  ad_utility::serialization::FileWriteSerializer serializer{chunksFilename_};
+  serializer << chunks_;
+}
+
+// ____________________________________________________________________________
+void BlankNodeIriVocabulary::readFromFile(const std::string& vocabBaseName,
+                                          ad_utility::VocabularyType type,
+                                          const std::string& language,
+                                          const std::string& country,
+                                          bool ignorePunctuation) {
+  vocab_.resetToType(type);
+  vocab_.setLocale(language, country, ignorePunctuation);
+  vocab_.readFromFile(vocabBaseName);
+  ad_utility::serialization::FileReadSerializer serializer{
+      chunksFilename(vocabBaseName)};
+  serializer >> chunks_;
+}
+
+// ____________________________________________________________________________
+std::optional<uint64_t> BlankNodeIriVocabulary::getBlankNodeIndex(
+    std::string_view iri) const {
+  if (chunks_.empty()) {
+    return std::nullopt;
+  }
+  VocabIndex idx;
+  if (!vocab_.getId(iri, &idx)) {
+    return std::nullopt;
+  }
+  uint64_t position = idx.get();
+  // Find the chunk that contains `position`. The chunks are sorted by
+  // `vocabStartPos_` and cover the vocabulary positions contiguously, so the
+  // chunk before the first one whose `vocabStartPos_` exceeds `position` is the
+  // one we are looking for.
+  auto it =
+      ql::ranges::upper_bound(chunks_, position, {}, &Chunk::vocabStartPos_);
+  AD_CORRECTNESS_CHECK(it != chunks_.begin());
+  const Chunk& chunk = *std::prev(it);
+  AD_CORRECTNESS_CHECK(position >= chunk.vocabStartPos_ &&
+                       position < chunk.vocabStartPos_ + chunk.count_);
+  return chunk.blankNodeStartIndex_ + (position - chunk.vocabStartPos_);
+}

--- a/src/index/BlankNodeIriVocabulary.h
+++ b/src/index/BlankNodeIriVocabulary.h
@@ -1,0 +1,113 @@
+// Copyright 2026 The QLever Authors, in particular:
+//
+// 2026 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+//
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#ifndef QLEVER_SRC_INDEX_BLANKNODEIRIVOCABULARY_H
+#define QLEVER_SRC_INDEX_BLANKNODEIRIVOCABULARY_H
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "index/Vocabulary.h"
+#include "index/vocabulary/VocabularyType.h"
+#include "index/vocabulary/VocabularyTypes.h"
+#include "util/Serializer/Serializer.h"
+
+// Remembers which blank node index was assigned to each IRI that was treated as
+// a blank node during index building (see `IndexImpl::setBlankNodePrefixes`).
+// These IRIs are not stored in the main vocabulary, so this class provides the
+// only persistent record of the mapping. It is used to consistently remap such
+// IRIs to the same blank node when they are referenced again later (in
+// particular via SPARQL UPDATE).
+//
+// The matching IRIs are stored in a dedicated, sorted, on-disk vocabulary (so
+// the structure scales to very large numbers of IRIs). The mapping from IRI to
+// blank node index is stored compactly: the vocabulary merger processes words
+// in sorted order and hands out blank node indices sequentially, and because
+// all IRIs sort into a single contiguous block (separate from `_:` blank nodes
+// and from literals; see `TripleComponentComparator`), the matching IRIs
+// occupy contiguous runs of blank node indices. Each such run is stored as a
+// single `Chunk`, so in the common case a single `Chunk` describes the whole
+// mapping.
+class BlankNodeIriVocabulary {
+ public:
+  // A contiguous run: the vocabulary positions
+  // `[vocabStartPos_, vocabStartPos_ + count_)` map to the blank node indices
+  // `[blankNodeStartIndex_, blankNodeStartIndex_ + count_)`.
+  struct Chunk {
+    uint64_t vocabStartPos_ = 0;
+    uint64_t blankNodeStartIndex_ = 0;
+    uint64_t count_ = 0;
+
+    AD_SERIALIZE_FRIEND_FUNCTION(Chunk) {
+      serializer | arg.vocabStartPos_;
+      serializer | arg.blankNodeStartIndex_;
+      serializer | arg.count_;
+    }
+  };
+
+  // Incrementally write the vocabulary and its chunk metadata to disk. The
+  // matching IRIs together with their assigned blank node index have to be
+  // pushed via `operator()` in ascending (sorted) order, exactly as they are
+  // encountered by the vocabulary merger.
+  class Writer {
+   public:
+    // Create a writer that writes the IRIs via `wordWriter` and the chunk
+    // metadata to `chunksFilename` (only) once `finish()` is called.
+    Writer(std::unique_ptr<WordWriterBase> wordWriter,
+           std::string chunksFilename);
+
+    // Register that `iri` was assigned the blank node `blankNodeIndex`. Must be
+    // called in ascending vocabulary order.
+    void operator()(std::string_view iri, uint64_t blankNodeIndex);
+
+    // Finish the vocabulary and persist the chunk metadata. Idempotent.
+    void finish();
+
+   private:
+    std::unique_ptr<WordWriterBase> wordWriter_;
+    std::string chunksFilename_;
+    std::vector<Chunk> chunks_;
+    uint64_t nextVocabPos_ = 0;
+    bool finished_ = false;
+  };
+
+  // Default-constructed vocabulary is empty; the feature is then inactive.
+  BlankNodeIriVocabulary() = default;
+
+  // Load the vocabulary and the chunk metadata from disk. `vocabBaseName` is
+  // the base name that was passed to the `Writer` (the chunk file is derived
+  // from it via `chunksFilename`). The `type` and locale must match those of
+  // the main vocabulary so that lookups use the correct comparator.
+  void readFromFile(const std::string& vocabBaseName,
+                    ad_utility::VocabularyType type,
+                    const std::string& language, const std::string& country,
+                    bool ignorePunctuation);
+
+  // Return the blank node index that was assigned to `iri` during index
+  // building, or `std::nullopt` if `iri` was not treated as a blank node.
+  std::optional<uint64_t> getBlankNodeIndex(std::string_view iri) const;
+
+  // Return the filename for the chunk metadata that belongs to a vocabulary
+  // with the given base name.
+  static std::string chunksFilename(const std::string& vocabBaseName) {
+    return vocabBaseName + ".chunks";
+  }
+
+  // Whether this vocabulary contains any entries (i.e. the feature is active).
+  bool empty() const { return chunks_.empty(); }
+
+ private:
+  RdfsVocabulary vocab_;
+  std::vector<Chunk> chunks_;
+};
+
+#endif  // QLEVER_SRC_INDEX_BLANKNODEIRIVOCABULARY_H

--- a/src/index/CMakeLists.txt
+++ b/src/index/CMakeLists.txt
@@ -9,6 +9,7 @@ add_library(index
         PatternCreator.cpp ScanSpecification.cpp
         DeltaTriples.cpp LocalVocabEntry.cpp TextScoring.cpp TextScoringEnum.cpp TextIndexReadWrite.cpp
         TextIndexBuilder.cpp GraphFilter.cpp IndexRebuilder.cpp GraphNameManager.cpp
+        BlankNodeIriVocabulary.cpp
         IdTableUtils.cpp ExportIds.cpp LocalVocab.cpp
         CompressedExternalIdTableSorterInstantiations.cpp
         InputFileSpecification.cpp)

--- a/src/index/IndexBuilderMain.cpp
+++ b/src/index/IndexBuilderMain.cpp
@@ -282,6 +282,15 @@ int main(int argc, char** argv) {
       "among non-encoded IRIs is correct, but the order between encoded "
       "and non-encoded IRIs is not");
 
+  add("treat-as-blank-node",
+      po::value(&config.blankNodePrefixes_)->composing()->multitoken(),
+      "Space-separated list of regexes. IRIs whose vocabulary entry matches "
+      "one of these regexes (via RE2 partial match) are not stored in the "
+      "vocabulary, but converted to blank nodes. This saves memory for IRIs "
+      "that only act as internal connector nodes (e.g. statement nodes). NOTE: "
+      "Such IRIs then have blank-node semantics and can no longer be matched "
+      "by their IRI in a query.");
+
   // Options for the index building process.
   add("stxxl-memory,m", po::value(&config.memoryLimit_),
       "The amount of memory in to use for sorting during the index build. "

--- a/src/index/IndexBuilderMain.cpp
+++ b/src/index/IndexBuilderMain.cpp
@@ -288,8 +288,12 @@ int main(int argc, char** argv) {
       "one of these regexes (via RE2 partial match) are not stored in the "
       "vocabulary, but converted to blank nodes. This saves memory for IRIs "
       "that only act as internal connector nodes (e.g. statement nodes). NOTE: "
-      "Such IRIs then have blank-node semantics and can no longer be matched "
-      "by their IRI in a query.");
+      "Such IRIs then have blank-node semantics. The mapping from each such "
+      "IRI "
+      "to its blank node is remembered, so that references to the same IRI in "
+      "later SPARQL UPDATEs (and queries) are consistently mapped to the same "
+      "blank node. IRIs that match the regexes but were not part of the input "
+      "are not converted to blank nodes.");
 
   // Options for the index building process.
   add("stxxl-memory,m", po::value(&config.memoryLimit_),

--- a/src/index/IndexBuilderTypes.h
+++ b/src/index/IndexBuilderTypes.h
@@ -16,8 +16,11 @@
 
 #include <absl/container/inlined_vector.h>
 #include <absl/strings/str_cat.h>
+#include <re2/re2.h>
 
 #include <atomic>
+#include <memory>
+#include <vector>
 
 #include "backports/StartsWithAndEndsWith.h"
 #include "backports/memory_resource.h"
@@ -46,7 +49,25 @@ struct TripleComponentWithIndex {
   [[nodiscard]] auto& isExternal() { return isExternal_; }
   [[nodiscard]] const auto& iriOrLiteral() const { return iriOrLiteral_; }
   [[nodiscard]] auto& iriOrLiteral() { return iriOrLiteral_; }
-  bool isBlankNode() const { return ql::starts_with(iriOrLiteral_, "_:"); }
+  // Return true if this word is a blank node. A word is considered a blank
+  // node if it starts with `_:` or, when `blankNodePrefixes` is given, if it
+  // matches (via `RE2::PartialMatch`) any of the regexes in it. The latter is
+  // used to treat IRIs that only act as internal connector nodes as blank
+  // nodes (see `IndexImpl::setBlankNodePrefixes`).
+  bool isBlankNode(const std::vector<std::unique_ptr<re2::RE2>>*
+                       blankNodePrefixes = nullptr) const {
+    if (ql::starts_with(iriOrLiteral_, "_:")) {
+      return true;
+    }
+    if (blankNodePrefixes != nullptr) {
+      for (const auto& prefix : *blankNodePrefixes) {
+        if (re2::RE2::PartialMatch(iriOrLiteral_, *prefix)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
 
   AD_SERIALIZE_FRIEND_FUNCTION(TripleComponentWithIndex) {
     serializer | arg.iriOrLiteral_;

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -708,7 +708,8 @@ IndexBuilderDataAsExternalVector IndexImpl::passFileForVocabulary(
     wordCallback.readableName() = "internal vocabulary";
     auto mergedVocabMeta = ad_utility::vocabulary_merger::mergeVocabulary(
         onDiskBase_, numPartialVocabs, sortPred, wordCallback,
-        memoryLimitIndexBuilding());
+        memoryLimitIndexBuilding(),
+        blankNodePrefixes_.empty() ? nullptr : &blankNodePrefixes_);
     wordCallback.finish();
     return mergedVocabMeta;
   }();

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -21,8 +21,10 @@
 
 #include "CompilationInfo.h"
 #include "backports/algorithm.h"
+#include "backports/filesystem.h"
 #include "engine/AddCombinedRowToTable.h"
 #include "global/RuntimeParameters.h"
+#include "index/BlankNodeIriVocabulary.h"
 #include "index/Index.h"
 #include "index/IndexFormatVersion.h"
 #include "index/VocabularyMerger.h"
@@ -706,11 +708,34 @@ IndexBuilderDataAsExternalVector IndexImpl::passFileForVocabulary(
     auto wordCallbackPtr = vocab_.makeWordWriterPtr(onDiskBase_ + VOCAB_SUFFIX);
     auto& wordCallback = *wordCallbackPtr;
     wordCallback.readableName() = "internal vocabulary";
+
+    // If some IRIs are treated as blank nodes, remember the mapping from each
+    // such IRI to its assigned blank node index in a dedicated on-disk
+    // vocabulary (see `BlankNodeIriVocabulary`), so it can be applied
+    // consistently to later updates.
+    std::unique_ptr<BlankNodeIriVocabulary::Writer> blankNodeIriWriter;
+    ad_utility::vocabulary_merger::BlankNodeIriCallback blankNodeIriCallback;
+    if (!blankNodePrefixes_.empty()) {
+      std::string blankNodeIriBase = onDiskBase_ + BLANK_NODE_IRI_VOCAB_SUFFIX;
+      blankNodeIriWriter = std::make_unique<BlankNodeIriVocabulary::Writer>(
+          vocab_.makeWordWriterPtr(blankNodeIriBase),
+          BlankNodeIriVocabulary::chunksFilename(blankNodeIriBase));
+      blankNodeIriCallback = [&writer = *blankNodeIriWriter](
+                                 std::string_view iri,
+                                 uint64_t blankNodeIndex) {
+        writer(iri, blankNodeIndex);
+      };
+    }
+
     auto mergedVocabMeta = ad_utility::vocabulary_merger::mergeVocabulary(
         onDiskBase_, numPartialVocabs, sortPred, wordCallback,
         memoryLimitIndexBuilding(),
-        blankNodePrefixes_.empty() ? nullptr : &blankNodePrefixes_);
+        blankNodePrefixes_.empty() ? nullptr : &blankNodePrefixes_,
+        blankNodeIriCallback);
     wordCallback.finish();
+    if (blankNodeIriWriter) {
+      blankNodeIriWriter->finish();
+    }
     return mergedVocabMeta;
   }();
   AD_LOG_DEBUG << "Finished merging partial vocabularies" << std::endl;
@@ -1071,6 +1096,7 @@ void IndexImpl::createFromOnDiskIndex(const std::string& onDiskBase,
   setOnDiskBase(onDiskBase);
   readConfiguration();
   vocab_.readFromFile(onDiskBase_ + VOCAB_SUFFIX);
+  loadBlankNodeIriVocabulary();
 
   AD_LOG_DEBUG << "Number of words in internal and external vocabulary: "
                << vocab_.size() << std::endl;
@@ -1996,6 +2022,54 @@ std::unique_ptr<ExternalSorter<Comparator, I>> IndexImpl::makeSorterPtr(
 ad_utility::BlankNodeManager* IndexImpl::getBlankNodeManager() const {
   AD_CONTRACT_CHECK(blankNodeManager_);
   return blankNodeManager_.get();
+}
+
+// _____________________________________________________________________________
+void IndexImpl::loadBlankNodeIriVocabulary() {
+  std::string base = onDiskBase_ + BLANK_NODE_IRI_VOCAB_SUFFIX;
+  // Only load the mapping if it was persisted (i.e. the feature was used during
+  // index building).
+  if (!ql::filesystem::exists(BlankNodeIriVocabulary::chunksFilename(base))) {
+    return;
+  }
+  // Use the same vocabulary type and locale as the main vocabulary so that
+  // lookups use the correct comparator.
+  ad_utility::VocabularyType vocabType(
+      ad_utility::VocabularyType::Enum::OnDiskCompressed);
+  if (configurationJson_.count("vocabulary-type")) {
+    vocabType = static_cast<ad_utility::VocabularyType>(
+        configurationJson_["vocabulary-type"]);
+  }
+  std::string lang{LOCALE_DEFAULT_LANG};
+  std::string country{LOCALE_DEFAULT_COUNTRY};
+  bool ignorePunctuation = LOCALE_DEFAULT_IGNORE_PUNCTUATION;
+  if (configurationJson_.count("locale")) {
+    lang = std::string{configurationJson_["locale"]["language"]};
+    country = std::string{configurationJson_["locale"]["country"]};
+    ignorePunctuation =
+        bool{configurationJson_["locale"]["ignore-punctuation"]};
+  }
+  blankNodeIriVocabulary_.readFromFile(base, vocabType, lang, country,
+                                       ignorePunctuation);
+  AD_LOG_INFO << "Loaded the mapping from IRIs that are treated as blank nodes "
+                 "to their "
+                 "blank node indices"
+              << std::endl;
+}
+
+// _____________________________________________________________________________
+std::optional<Id> IndexImpl::getBlankNodeIndexForIri(
+    std::string_view iri) const {
+  if (blankNodeIriVocabulary_.empty()) {
+    return std::nullopt;
+  }
+  std::optional<uint64_t> blankNodeIndex =
+      blankNodeIriVocabulary_.getBlankNodeIndex(iri);
+  if (!blankNodeIndex.has_value()) {
+    return std::nullopt;
+  }
+  return Id::makeFromBlankNodeIndex(
+      BlankNodeIndex::make(blankNodeIndex.value()));
 }
 
 // _____________________________________________________________________________

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -19,6 +19,7 @@
 #include "engine/Result.h"
 #include "engine/idTable/CompressedExternalIdTable.h"
 #include "global/SpecialIds.h"
+#include "index/BlankNodeIriVocabulary.h"
 #include "index/CompressedRelation.h"
 #include "index/ConstantsIndexBuilding.h"
 #include "index/DeltaTriples.h"
@@ -196,6 +197,13 @@ class IndexImpl {
   // `setBlankNodePrefixes`.
   std::vector<std::string> blankNodePrefixes_;
 
+  // Remembers which blank node index was assigned to each IRI that was treated
+  // as a blank node during index building (see `setBlankNodePrefixes` and
+  // `BlankNodeIriVocabulary`). Loaded from disk in `createFromOnDiskIndex` and
+  // used to consistently remap such IRIs when they are referenced again later
+  // (e.g. via SPARQL UPDATE). Empty if the feature was not used.
+  BlankNodeIriVocabulary blankNodeIriVocabulary_;
+
   // BlankNodeManager, initialized during `readConfiguration`
   std::unique_ptr<ad_utility::BlankNodeManager> blankNodeManager_{nullptr};
 
@@ -301,13 +309,22 @@ class IndexImpl {
   // building. Each entry is an `RE2` regex; a vocabulary word matching any of
   // them (via `RE2::PartialMatch`) is stored as a blank node instead of in the
   // vocabulary. This is useful for IRIs that only act as internal connector
-  // nodes (e.g. statement nodes), to save vocabulary memory.
+  // nodes (e.g. statement nodes), to save vocabulary memory. The mapping from
+  // each such IRI to its blank node is remembered (see
+  // `BlankNodeIriVocabulary`) so that references to the same IRI in later
+  // updates and queries are mapped consistently to the same blank node.
   void setBlankNodePrefixes(std::vector<std::string> blankNodePrefixes) {
     blankNodePrefixes_ = std::move(blankNodePrefixes);
   }
   const std::vector<std::string>& getBlankNodePrefixes() const {
     return blankNodePrefixes_;
   }
+
+  // If `iri` was treated as a blank node during index building (see
+  // `setBlankNodePrefixes` and `BlankNodeIriVocabulary`), return the `Id` of
+  // the blank node that was assigned to it, so it can be remapped consistently
+  // (e.g. during SPARQL UPDATE). Return `std::nullopt` otherwise.
+  std::optional<Id> getBlankNodeIndexForIri(std::string_view iri) const;
 
   // Set the vocabulary type; see `ad_utility::VocabularyType` for details.
   void setVocabularyTypeForIndexBuilding(ad_utility::VocabularyType type) {
@@ -770,6 +787,11 @@ class IndexImpl {
 
   void writeConfiguration() const;
   void readConfiguration();
+
+  // Load the `BlankNodeIriVocabulary` from disk if it was persisted (i.e. the
+  // `--treat-as-blank-node` feature was used during index building). Must be
+  // called after `readConfiguration` and after the main vocabulary was loaded.
+  void loadBlankNodeIriVocabulary();
 
   // initialize the index-build-time settings for the vocabulary
   void readIndexBuilderSettingsFromFile();

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -191,6 +191,11 @@ class IndexImpl {
   ad_utility::VocabularyType vocabularyTypeForIndexBuilding_{
       ad_utility::VocabularyType::Enum::OnDiskCompressed};
 
+  // Regexes for IRIs that should be treated as blank nodes during index
+  // building (only relevant during index building); see
+  // `setBlankNodePrefixes`.
+  std::vector<std::string> blankNodePrefixes_;
+
   // BlankNodeManager, initialized during `readConfiguration`
   std::unique_ptr<ad_utility::BlankNodeManager> blankNodeManager_{nullptr};
 
@@ -291,6 +296,18 @@ class IndexImpl {
   // the `Id`; see `EncodedIriManager` for details.
   void setPrefixesForEncodedValues(
       std::vector<std::string> prefixesWithoutAngleBrackets);
+
+  // Set the regexes for IRIs that should be treated as blank nodes during index
+  // building. Each entry is an `RE2` regex; a vocabulary word matching any of
+  // them (via `RE2::PartialMatch`) is stored as a blank node instead of in the
+  // vocabulary. This is useful for IRIs that only act as internal connector
+  // nodes (e.g. statement nodes), to save vocabulary memory.
+  void setBlankNodePrefixes(std::vector<std::string> blankNodePrefixes) {
+    blankNodePrefixes_ = std::move(blankNodePrefixes);
+  }
+  const std::vector<std::string>& getBlankNodePrefixes() const {
+    return blankNodePrefixes_;
+  }
 
   // Set the vocabulary type; see `ad_utility::VocabularyType` for details.
   void setVocabularyTypeForIndexBuilding(ad_utility::VocabularyType type) {

--- a/src/index/VocabularyMerger.h
+++ b/src/index/VocabularyMerger.h
@@ -5,6 +5,7 @@
 #ifndef QLEVER_SRC_INDEX_VOCABULARYMERGER_H
 #define QLEVER_SRC_INDEX_VOCABULARYMERGER_H
 
+#include <functional>
 #include <memory>
 #include <optional>
 #include <string>
@@ -63,6 +64,13 @@ template <typename T>
 CPP_concept WordCallback =
     ad_utility::InvocableWithExactReturnType<T, uint64_t, std::string_view,
                                              bool>;
+
+// A callback that is invoked for every IRI which is treated as a blank node
+// because it matched one of the `blankNodePrefixes` (not for `_:`-prefixed
+// blank nodes). It receives the IRI and the blank node index that was assigned
+// to it, so that the mapping can be remembered (see `BlankNodeIriVocabulary`).
+// The IRIs are passed in ascending (sorted) order.
+using BlankNodeIriCallback = std::function<void(std::string_view, uint64_t)>;
 // Concept for a callable that compares two `string_view`s with respective
 // `isExternal` flags.
 template <typename T>
@@ -179,12 +187,15 @@ struct VocabularyMetaData {
 // is called for each merged word in the vocabulary in the order of their
 // appearance. Argument `blankNodePrefixes` is an optional pointer to a list of
 // regexes; words matching any of them are treated as blank nodes (see
-// `TripleComponentWithIndex::isBlankNode`).
+// `TripleComponentWithIndex::isBlankNode`). Argument `blankNodeIriCallback` is
+// invoked for every such IRI together with its assigned blank node index (see
+// `BlankNodeIriCallback`).
 template <typename W, typename C>
 auto mergeVocabulary(
     const std::string& basename, size_t numFiles, W comparator, C& wordCallback,
     ad_utility::MemorySize memoryToUse,
-    const std::vector<std::string>* blankNodePrefixes = nullptr)
+    const std::vector<std::string>* blankNodePrefixes = nullptr,
+    const BlankNodeIriCallback& blankNodeIriCallback = {})
     -> CPP_ret(VocabularyMetaData)(
         requires WordComparator<W>&& WordCallback<C>);
 
@@ -203,13 +214,17 @@ class VocabularyMerger {
   // Compiled regexes for IRIs that should be treated as blank nodes (see
   // `mergeVocabulary`). Empty if no such prefixes were specified.
   std::vector<std::unique_ptr<re2::RE2>> blankNodePrefixes_;
+  // Callback that remembers the mapping from a regex-matched IRI to its blank
+  // node index (see `BlankNodeIriCallback`). Empty if not needed.
+  BlankNodeIriCallback blankNodeIriCallback_;
 
   // Friend declaration for the publicly available function.
   template <typename W, typename C>
   friend auto mergeVocabulary(const std::string& basename, size_t numFiles,
                               W comparator, C& wordCallback,
                               ad_utility::MemorySize memoryToUse,
-                              const std::vector<std::string>* blankNodePrefixes)
+                              const std::vector<std::string>* blankNodePrefixes,
+                              const BlankNodeIriCallback& blankNodeIriCallback)
       -> CPP_ret(VocabularyMetaData)(
           requires WordComparator<W>&& WordCallback<C>);
   VocabularyMerger() = default;
@@ -221,7 +236,8 @@ class VocabularyMerger {
   auto mergeVocabulary(const std::string& basename, size_t numFiles,
                        W comparator, C& wordCallback,
                        ad_utility::MemorySize memoryToUse,
-                       const std::vector<std::string>* blankNodePrefixes)
+                       const std::vector<std::string>* blankNodePrefixes,
+                       const BlankNodeIriCallback& blankNodeIriCallback)
       -> CPP_ret(VocabularyMetaData)(
           requires WordComparator<W>&& WordCallback<C>);
 
@@ -273,6 +289,7 @@ class VocabularyMerger {
     lastTripleComponent_ = std::nullopt;
     idMaps_.clear();
     blankNodePrefixes_.clear();
+    blankNodeIriCallback_ = {};
   }
 };
 

--- a/src/index/VocabularyMerger.h
+++ b/src/index/VocabularyMerger.h
@@ -5,9 +5,11 @@
 #ifndef QLEVER_SRC_INDEX_VOCABULARYMERGER_H
 #define QLEVER_SRC_INDEX_VOCABULARYMERGER_H
 
+#include <memory>
 #include <optional>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "backports/StartsWithAndEndsWith.h"
 #include "backports/algorithm.h"
@@ -175,10 +177,14 @@ struct VocabularyMetaData {
 // language tagged predicates. Argument `comparator` gives the way to order
 // strings (case-sensitive or not). Argument `wordCallback`
 // is called for each merged word in the vocabulary in the order of their
-// appearance.
+// appearance. Argument `blankNodePrefixes` is an optional pointer to a list of
+// regexes; words matching any of them are treated as blank nodes (see
+// `TripleComponentWithIndex::isBlankNode`).
 template <typename W, typename C>
-auto mergeVocabulary(const std::string& basename, size_t numFiles, W comparator,
-                     C& wordCallback, ad_utility::MemorySize memoryToUse)
+auto mergeVocabulary(
+    const std::string& basename, size_t numFiles, W comparator, C& wordCallback,
+    ad_utility::MemorySize memoryToUse,
+    const std::vector<std::string>* blankNodePrefixes = nullptr)
     -> CPP_ret(VocabularyMetaData)(
         requires WordComparator<W>&& WordCallback<C>);
 
@@ -194,12 +200,16 @@ class VocabularyMerger {
   std::optional<TripleComponentWithIndex> lastTripleComponent_ = std::nullopt;
   // we will store pairs of <partialId, globalId>
   std::vector<IdMapWriter> idMaps_;
+  // Compiled regexes for IRIs that should be treated as blank nodes (see
+  // `mergeVocabulary`). Empty if no such prefixes were specified.
+  std::vector<std::unique_ptr<re2::RE2>> blankNodePrefixes_;
 
   // Friend declaration for the publicly available function.
   template <typename W, typename C>
   friend auto mergeVocabulary(const std::string& basename, size_t numFiles,
                               W comparator, C& wordCallback,
-                              ad_utility::MemorySize memoryToUse)
+                              ad_utility::MemorySize memoryToUse,
+                              const std::vector<std::string>* blankNodePrefixes)
       -> CPP_ret(VocabularyMetaData)(
           requires WordComparator<W>&& WordCallback<C>);
   VocabularyMerger() = default;
@@ -210,7 +220,8 @@ class VocabularyMerger {
   template <typename W, typename C>
   auto mergeVocabulary(const std::string& basename, size_t numFiles,
                        W comparator, C& wordCallback,
-                       ad_utility::MemorySize memoryToUse)
+                       ad_utility::MemorySize memoryToUse,
+                       const std::vector<std::string>* blankNodePrefixes)
       -> CPP_ret(VocabularyMetaData)(
           requires WordComparator<W>&& WordCallback<C>);
 
@@ -261,6 +272,7 @@ class VocabularyMerger {
     metaData_ = VocabularyMetaData{};
     lastTripleComponent_ = std::nullopt;
     idMaps_.clear();
+    blankNodePrefixes_.clear();
   }
 };
 

--- a/src/index/VocabularyMergerImpl.h
+++ b/src/index/VocabularyMergerImpl.h
@@ -29,22 +29,31 @@ namespace ad_utility::vocabulary_merger {
 template <typename W, typename C>
 auto mergeVocabulary(const std::string& basename, size_t numFiles, W comparator,
                      C& internalWordCallback,
-                     ad_utility::MemorySize memoryToUse)
+                     ad_utility::MemorySize memoryToUse,
+                     const std::vector<std::string>* blankNodePrefixes)
     -> CPP_ret(VocabularyMetaData)(
         requires WordComparator<W>&& WordCallback<C>) {
   VocabularyMerger merger;
   return merger.mergeVocabulary(basename, numFiles, std::move(comparator),
-                                internalWordCallback, memoryToUse);
+                                internalWordCallback, memoryToUse,
+                                blankNodePrefixes);
 }
 
 // _________________________________________________________________
 template <typename W, typename C>
-auto VocabularyMerger::mergeVocabulary(const std::string& basename,
-                                       size_t numFiles, W comparator,
-                                       C& wordCallback,
-                                       ad_utility::MemorySize memoryToUse)
+auto VocabularyMerger::mergeVocabulary(
+    const std::string& basename, size_t numFiles, W comparator, C& wordCallback,
+    ad_utility::MemorySize memoryToUse,
+    const std::vector<std::string>* blankNodePrefixes)
     -> CPP_ret(VocabularyMetaData)(
         requires WordComparator<W>&& WordCallback<C>) {
+  // Compile the regexes for the IRIs that should be treated as blank nodes.
+  if (blankNodePrefixes != nullptr) {
+    for (const auto& prefix : *blankNodePrefixes) {
+      blankNodePrefixes_.push_back(std::make_unique<re2::RE2>(prefix));
+    }
+  }
+
   // Return true iff p1 >= p2 according to the lexicographic order of the IRI
   // or literal.
   auto lessThan = [&comparator](const TripleComponentWithIndex& t1,
@@ -133,7 +142,7 @@ CPP_template_def(typename C, typename L)(
 
       // Write the new word to the vocabulary.
       auto& nextWord = lastTripleComponent_.value();
-      if (nextWord.isBlankNode()) {
+      if (nextWord.isBlankNode(&blankNodePrefixes_)) {
         nextWord.index_ = metaData_.getNextBlankNodeIndex();
       } else {
         nextWord.index_ =
@@ -151,7 +160,7 @@ CPP_template_def(typename C, typename L)(
     }
     const auto& word = lastTripleComponent_.value();
     Id targetId =
-        word.isBlankNode()
+        word.isBlankNode(&blankNodePrefixes_)
             ? Id::makeFromBlankNodeIndex(BlankNodeIndex::make(word.index_))
             : Id::makeFromVocabIndex(VocabIndex::make(word.index_));
     // Write pair of local and global ID to buffer.

--- a/src/index/VocabularyMergerImpl.h
+++ b/src/index/VocabularyMergerImpl.h
@@ -30,13 +30,14 @@ template <typename W, typename C>
 auto mergeVocabulary(const std::string& basename, size_t numFiles, W comparator,
                      C& internalWordCallback,
                      ad_utility::MemorySize memoryToUse,
-                     const std::vector<std::string>* blankNodePrefixes)
+                     const std::vector<std::string>* blankNodePrefixes,
+                     const BlankNodeIriCallback& blankNodeIriCallback)
     -> CPP_ret(VocabularyMetaData)(
         requires WordComparator<W>&& WordCallback<C>) {
   VocabularyMerger merger;
   return merger.mergeVocabulary(basename, numFiles, std::move(comparator),
                                 internalWordCallback, memoryToUse,
-                                blankNodePrefixes);
+                                blankNodePrefixes, blankNodeIriCallback);
 }
 
 // _________________________________________________________________
@@ -44,7 +45,8 @@ template <typename W, typename C>
 auto VocabularyMerger::mergeVocabulary(
     const std::string& basename, size_t numFiles, W comparator, C& wordCallback,
     ad_utility::MemorySize memoryToUse,
-    const std::vector<std::string>* blankNodePrefixes)
+    const std::vector<std::string>* blankNodePrefixes,
+    const BlankNodeIriCallback& blankNodeIriCallback)
     -> CPP_ret(VocabularyMetaData)(
         requires WordComparator<W>&& WordCallback<C>) {
   // Compile the regexes for the IRIs that should be treated as blank nodes.
@@ -53,6 +55,7 @@ auto VocabularyMerger::mergeVocabulary(
       blankNodePrefixes_.push_back(std::make_unique<re2::RE2>(prefix));
     }
   }
+  blankNodeIriCallback_ = blankNodeIriCallback;
 
   // Return true iff p1 >= p2 according to the lexicographic order of the IRI
   // or literal.
@@ -144,6 +147,15 @@ CPP_template_def(typename C, typename L)(
       auto& nextWord = lastTripleComponent_.value();
       if (nextWord.isBlankNode(&blankNodePrefixes_)) {
         nextWord.index_ = metaData_.getNextBlankNodeIndex();
+        // If this word is treated as a blank node because it matched one of the
+        // `blankNodePrefixes_` (i.e. it is an IRI, not a `_:`-prefixed blank
+        // node), remember the mapping from the IRI to the assigned blank node
+        // index, so it can be applied consistently to later updates (see
+        // `BlankNodeIriVocabulary`).
+        if (blankNodeIriCallback_ &&
+            !ql::starts_with(nextWord.iriOrLiteral(), "_:")) {
+          blankNodeIriCallback_(nextWord.iriOrLiteral(), nextWord.index_);
+        }
       } else {
         nextWord.index_ =
             wordCallback(nextWord.iriOrLiteral(), nextWord.isExternal());

--- a/src/libqlever/Qlever.cpp
+++ b/src/libqlever/Qlever.cpp
@@ -109,6 +109,7 @@ void Qlever::buildIndex(IndexBuilderConfig config) {
   index.addHasWordTriples() = config.addHasWordTriples_;
   index.getImpl().setVocabularyTypeForIndexBuilding(config.vocabType_);
   index.getImpl().setPrefixesForEncodedValues(config.prefixesForIdEncodedIris_);
+  index.getImpl().setBlankNodePrefixes(config.blankNodePrefixes_);
 
   // Build text index if requested (various options).
   if (!config.onlyAddTextIndex_) {

--- a/src/libqlever/Qlever.h
+++ b/src/libqlever/Qlever.h
@@ -107,6 +107,14 @@ struct IndexBuilderConfig : CommonConfig {
   // building the index are not deleted. This can be useful for debugging.
   bool keepTemporaryFiles_ = false;
 
+  // A list of regexes for IRIs that should be treated as blank nodes. During
+  // index building, a vocabulary word that matches any of these regexes (via
+  // `RE2::PartialMatch`) is not stored in the vocabulary, but converted to a
+  // blank node. This is useful for IRIs that only act as internal connector
+  // nodes (e.g. statement nodes), to save vocabulary memory. See
+  // `IndexImpl::setBlankNodePrefixes`.
+  std::vector<std::string> blankNodePrefixes_;
+
   // A list of IRI prefixes (without angle brackets). IRIs that start with one
   // of these prefixes, followed by a sequence of a bounded number of digits
   // are encoded directly in the internal ID. This reduces the size of the

--- a/src/parser/TripleComponent.cpp
+++ b/src/parser/TripleComponent.cpp
@@ -120,6 +120,17 @@ TripleComponent::toValueIdOrBounds(const IndexImpl& index) const {
   if (lower != upper) {
     return Id::makeFromVocabIndex(lower);
   }
+  // If the word is an IRI that was treated as a blank node during index
+  // building (and is therefore not in the vocabulary), remap it to the blank
+  // node that was assigned to it (see `BlankNodeIriVocabulary`). This makes
+  // references to such IRIs (in particular via SPARQL UPDATE) resolve
+  // consistently to the same blank node.
+  if (isIri()) {
+    if (std::optional<Id> blankNodeId =
+            index.getBlankNodeIndexForIri(content)) {
+      return blankNodeId.value();
+    }
+  }
   return std::pair(lower, upper);
 }
 

--- a/test/BlankNodeIriVocabularyTest.cpp
+++ b/test/BlankNodeIriVocabularyTest.cpp
@@ -1,0 +1,115 @@
+// Copyright 2026 The QLever Authors, in particular:
+//
+// 2026 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+//
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "backports/filesystem.h"
+#include "index/BlankNodeIriVocabulary.h"
+#include "index/Vocabulary.h"
+#include "index/vocabulary/VocabularyType.h"
+#include "util/FilesystemHelpers.h"
+#include "util/GTestHelpers.h"
+
+namespace {
+using ad_utility::VocabularyType;
+
+// Delete all files in the current directory whose name starts with `prefix`.
+void deleteFilesWithPrefix(const std::string& prefix) {
+  namespace fs = ql::filesystem;
+  qlever::util::deleteFilesInDirectory(
+      fs::current_path(), [&prefix](const auto& path) {
+        return ql::starts_with(path.filename().string(), prefix);
+      });
+}
+
+// Write the given `(iri, blankNodeIndex)` pairs (in the given order) to a fresh
+// `BlankNodeIriVocabulary`, then load it again and return it.
+BlankNodeIriVocabulary writeAndRead(
+    const std::string& base, VocabularyType type,
+    const std::vector<std::pair<std::string, uint64_t>>& entries) {
+  {
+    RdfsVocabulary vocab;
+    vocab.resetToType(type);
+    vocab.setLocale("en", "US", false);
+    BlankNodeIriVocabulary::Writer writer(
+        vocab.makeWordWriterPtr(base),
+        BlankNodeIriVocabulary::chunksFilename(base));
+    for (const auto& [iri, blankNodeIndex] : entries) {
+      writer(iri, blankNodeIndex);
+    }
+    writer.finish();
+  }
+  BlankNodeIriVocabulary result;
+  result.readFromFile(base, type, "en", "US", false);
+  return result;
+}
+}  // namespace
+
+// _____________________________________________________________________________
+TEST(BlankNodeIriVocabulary, singleContiguousChunk) {
+  for (auto type : {VocabularyType{VocabularyType::Enum::InMemoryUncompressed},
+                    VocabularyType{VocabularyType::Enum::OnDiskCompressed}}) {
+    std::string base = absl::StrCat(gtestCurrentTestName(), type.toString());
+    absl::Cleanup cleanup = [&base] { deleteFilesWithPrefix(base); };
+
+    // The IRIs must be pushed in ascending (sorted) order; the blank node
+    // indices are contiguous, so a single chunk describes the whole mapping.
+    auto vocab = writeAndRead(
+        base, type,
+        {{"<http://ex/a>", 3}, {"<http://ex/b>", 4}, {"<http://ex/c>", 5}});
+    EXPECT_FALSE(vocab.empty());
+    EXPECT_THAT(vocab.getBlankNodeIndex("<http://ex/a>"),
+                ::testing::Optional(3u));
+    EXPECT_THAT(vocab.getBlankNodeIndex("<http://ex/b>"),
+                ::testing::Optional(4u));
+    EXPECT_THAT(vocab.getBlankNodeIndex("<http://ex/c>"),
+                ::testing::Optional(5u));
+    // An IRI that was not stored is not found.
+    EXPECT_EQ(vocab.getBlankNodeIndex("<http://ex/d>"), std::nullopt);
+  }
+}
+
+// _____________________________________________________________________________
+TEST(BlankNodeIriVocabulary, multipleChunks) {
+  for (auto type : {VocabularyType{VocabularyType::Enum::InMemoryUncompressed},
+                    VocabularyType{VocabularyType::Enum::OnDiskCompressed}}) {
+    std::string base = absl::StrCat(gtestCurrentTestName(), type.toString());
+    absl::Cleanup cleanup = [&base] { deleteFilesWithPrefix(base); };
+
+    // The blank node indices are not contiguous (there are gaps, e.g. because
+    // `_:` blank nodes were interleaved at those positions), so the mapping is
+    // described by several chunks. The `IRI` order is still ascending.
+    auto vocab = writeAndRead(base, type,
+                              {{"<http://ex/a>", 0},
+                               {"<http://ex/b>", 1},
+                               {"<http://ex/m>", 10},
+                               {"<http://ex/n>", 11},
+                               {"<http://ex/z>", 100}});
+    EXPECT_THAT(vocab.getBlankNodeIndex("<http://ex/a>"),
+                ::testing::Optional(0u));
+    EXPECT_THAT(vocab.getBlankNodeIndex("<http://ex/b>"),
+                ::testing::Optional(1u));
+    EXPECT_THAT(vocab.getBlankNodeIndex("<http://ex/m>"),
+                ::testing::Optional(10u));
+    EXPECT_THAT(vocab.getBlankNodeIndex("<http://ex/n>"),
+                ::testing::Optional(11u));
+    EXPECT_THAT(vocab.getBlankNodeIndex("<http://ex/z>"),
+                ::testing::Optional(100u));
+    EXPECT_EQ(vocab.getBlankNodeIndex("<http://ex/c>"), std::nullopt);
+  }
+}
+
+// _____________________________________________________________________________
+TEST(BlankNodeIriVocabulary, empty) {
+  // A default-constructed vocabulary is empty and never returns a blank node.
+  BlankNodeIriVocabulary vocab;
+  EXPECT_TRUE(vocab.empty());
+  EXPECT_EQ(vocab.getBlankNodeIndex("<http://ex/a>"), std::nullopt);
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -205,6 +205,8 @@ addLinkAndDiscoverTest(GroupByTest engine)
 
 addLinkAndDiscoverTest(VocabularyGeneratorTest index)
 
+addLinkAndDiscoverTest(BlankNodeIriVocabularyTest index)
+
 addLinkAndDiscoverTest(HasPredicateScanTest engine)
 
 addLinkAndDiscoverTest(ExternalOverflowStorageTest)

--- a/test/ExecuteUpdateTest.cpp
+++ b/test/ExecuteUpdateTest.cpp
@@ -11,7 +11,10 @@
 #include "engine/MaterializedViews.h"
 #include "engine/NamedResultCache.h"
 #include "index/IndexImpl.h"
+#include "index/LocalVocab.h"
+#include "parser/TripleComponent.h"
 #include "parser/sparqlParser/SparqlQleverVisitor.h"
+#include "rdfTypes/Iri.h"
 #include "util/GTestHelpers.h"
 #include "util/IdTableHelpers.h"
 #include "util/IndexTestHelpers.h"
@@ -655,4 +658,81 @@ TEST(ExecuteUpdate, setMinus) {
          {IdTriple(4, 5, 6), IdTriple(7, 8, 9)}, {IdTriple(1, 2, 3)});
   expect({IdTriple(1, 2, 3)},
          {IdTriple(1, 2, 3), IdTriple(4, 5, 6), IdTriple(7, 8, 9)}, {});
+}
+
+// ____________________________________________________________________________
+TEST(ExecuteUpdate, treatAsBlankNodeConsistentRemapping) {
+  using namespace ad_utility::testing;
+  using Iri = ad_utility::triple_component::Iri;
+  using namespace deltaTriplesTestHelpers;
+
+  // Build an index in which `<http://ex/s/1>` only acts as an internal
+  // connector node and is therefore treated as a blank node.
+  TestIndexConfig config{"<a> <p> <http://ex/s/1> . <http://ex/s/1> <r> <b> ."};
+  config.blankNodePrefixes = std::vector<std::string>{"/s/"};
+  auto index = std::make_shared<Index>(
+      makeTestIndex("ExecuteUpdate_treatAsBlankNode", config));
+  const IndexImpl& impl = index->getImpl();
+
+  auto connector = [] {
+    return TripleComponent{Iri::fromIriref("<http://ex/s/1>")};
+  };
+  auto unknown = [] {
+    return TripleComponent{Iri::fromIriref("<http://ex/s/999>")};
+  };
+
+  // Read path: the connector IRI (which is not in the vocabulary) resolves to a
+  // global blank node via the remembered mapping.
+  std::optional<Id> blankNodeId = connector().toValueId(impl);
+  ASSERT_TRUE(blankNodeId.has_value());
+  EXPECT_EQ(blankNodeId->getDatatype(), Datatype::BlankNodeIndex);
+
+  // Update path (rvalue `toValueId`, as used by `ExecuteUpdate`): the IRI is
+  // remapped to the same blank node, and no new local vocab entry is created.
+  {
+    LocalVocab localVocab;
+    Id updateId = connector().toValueId(impl, localVocab);
+    EXPECT_EQ(updateId, blankNodeId.value());
+    EXPECT_EQ(localVocab.size(), 0u);
+  }
+
+  // An IRI that matches the pattern but was not part of the input is NOT
+  // remapped: in the read path it is not found, ...
+  EXPECT_EQ(unknown().toValueId(impl), std::nullopt);
+  // ... and in the update path it becomes a regular new local vocab entry.
+  {
+    LocalVocab localVocab;
+    Id unknownId = unknown().toValueId(impl, localVocab);
+    EXPECT_EQ(unknownId.getDatatype(), Datatype::LocalVocabIndex);
+  }
+
+  // Finally, run a real SPARQL UPDATE that inserts a triple referencing the
+  // connector IRI, and check that the pipeline succeeds and inserts exactly one
+  // triple (exercising `ExecuteUpdate` -> `transformTriplesTemplate` ->
+  // `toValueId`).
+  QueryResultCache cache;
+  NamedResultCache namedResultCache;
+  auto materializedViewsManager = std::make_shared<MaterializedViewsManager>();
+  QueryExecutionContext qec(
+      index, &cache, makeAllocator(ad_utility::MemorySize::megabytes(100)),
+      SortPerformanceEstimator{}, &namedResultCache, materializedViewsManager);
+  const auto handle = std::make_shared<ad_utility::CancellationHandle<>>();
+  ad_utility::BlankNodeManager bnm;
+  auto pqs = SparqlParser::parseUpdate(
+      &bnm, encodedIriManager(), "INSERT DATA { <http://ex/s/1> <r2> <b2> }");
+  index->deltaTriplesManager().modify<void>([&](DeltaTriples& deltaTriples) {
+    qec.setLocatedTriplesForEvaluation(
+        deltaTriples.getLocatedTriplesSharedStateReference());
+    for (auto& pq : pqs) {
+      deltaTriples.updateAugmentedMetadata();
+      QueryPlanner qp{&qec, handle};
+      const auto qet = qp.createExecutionTree(pq);
+      ExecuteUpdate::executeUpdate(*index, pq, qet, deltaTriples, handle);
+    }
+  });
+  index->deltaTriplesManager().modify<void>(
+      [](DeltaTriples& deltaTriples) {
+        EXPECT_THAT(deltaTriples, NumTriples(1, 0, 1));
+      },
+      false, false);
 }

--- a/test/VocabularyGeneratorTest.cpp
+++ b/test/VocabularyGeneratorTest.cpp
@@ -3,6 +3,7 @@
 // Authors: Johannes Kalmbach <kalmbacj@cs.uni-freiburg.de>
 //          Christoph Ullinger <ullingec@cs.uni-freiburg.de>
 
+#include <absl/cleanup/cleanup.h>
 #include <gmock/gmock.h>
 
 #include <cstdlib>
@@ -15,6 +16,7 @@
 #include "backports/StartsWithAndEndsWith.h"
 #include "backports/filesystem.h"
 #include "global/Constants.h"
+#include "global/ValueId.h"
 #include "index/ConstantsIndexBuilding.h"
 #include "index/Index.h"
 #include "index/Vocabulary.h"
@@ -23,6 +25,7 @@
 #include "index/vocabulary/SplitVocabulary.h"
 #include "index/vocabulary/VocabularyInternalExternal.h"
 #include "util/Algorithm.h"
+#include "util/File.h"
 #include "util/GTestHelpers.h"
 
 using namespace ad_utility::vocabulary_merger;
@@ -268,6 +271,70 @@ TEST(MergeVocabulary, mergeVocabularyAssertion) {
           },
           callback, 1_GB),
       ::testing::HasSubstr("vocabulary order violated"), ad_utility::Exception);
+}
+
+// _____________________________________________________________________________
+// Test that IRIs whose vocabulary word matches one of the `blankNodePrefixes`
+// regexes are treated as blank nodes during `mergeVocabulary`: they are not
+// passed to the vocabulary word callback, and are mapped to blank node `Id`s.
+TEST(MergeVocabulary, treatIrisAsBlankNodesViaRegex) {
+  std::string basePath = gtestCurrentTestName();
+  std::string wordsFile = absl::StrCat(basePath, PARTIAL_VOCAB_WORDS_INFIX, 0);
+  std::string idMapFile = absl::StrCat(basePath, PARTIAL_VOCAB_IDMAP_INFIX, 0);
+  absl::Cleanup cleanup = [&wordsFile, &idMapFile] {
+    ad_utility::deleteFile(wordsFile, false);
+    ad_utility::deleteFile(idMapFile, false);
+  };
+
+  // Write a single partial vocabulary. The words must be in ascending order
+  // according to the comparator used below (plain `std::less`).
+  std::array<std::string_view, 4> words{"<http://ex/apple>", "<http://ex/bn_1>",
+                                        "<http://ex/bn_2>",
+                                        "<http://ex/cherry>"};
+  {
+    ad_utility::serialization::FileWriteSerializer partialVocab(wordsFile);
+    partialVocab << words.size();
+    for (size_t localIdx = 0; localIdx < words.size(); ++localIdx) {
+      partialVocab << words.at(localIdx);
+      partialVocab << false;
+      partialVocab << localIdx;
+    }
+  }
+
+  // Collect the words that are actually written to the vocabulary (i.e. not
+  // treated as blank nodes).
+  std::vector<std::string> vocabularyWords;
+  auto wordCallback = [&vocabularyWords](std::string_view word,
+                                         bool) -> uint64_t {
+    vocabularyWords.emplace_back(word);
+    return vocabularyWords.size() - 1;
+  };
+
+  // Treat all IRIs that contain `bn_` as blank nodes.
+  std::vector<std::string> blankNodePrefixes{"bn_"};
+  mergeVocabulary(
+      basePath, 1,
+      [](std::string_view a, bool, std::string_view b, bool) {
+        return std::less{}(a, b);
+      },
+      wordCallback, 1_GB, &blankNodePrefixes);
+
+  // The two `bn_` IRIs became blank nodes; only the other two IRIs remain in
+  // the vocabulary.
+  EXPECT_THAT(vocabularyWords, ::testing::ElementsAre("<http://ex/apple>",
+                                                      "<http://ex/cherry>"));
+
+  // In the id map, exactly the two `bn_` IRIs map to blank node `Id`s, the
+  // other two to vocabulary `Id`s.
+  IdMap idMap = getIdMapFromFile(idMapFile);
+  size_t numBlankNodes = 0;
+  for (const auto& [localId, globalId] : idMap) {
+    if (globalId.getDatatype() == Datatype::BlankNodeIndex) {
+      ++numBlankNodes;
+    }
+  }
+  EXPECT_EQ(numBlankNodes, 2);
+  EXPECT_EQ(idMap.size(), words.size());
 }
 
 TEST(VocabularyGeneratorTest, createInternalMapping) {

--- a/test/util/IndexTestHelpers.cpp
+++ b/test/util/IndexTestHelpers.cpp
@@ -176,9 +176,14 @@ Index makeTestIndex(const std::string& indexBasename, TestIndexConfig c) {
   // permutations are not present, because they would actually be present from
   // the previous index build.
   namespace fs = ql::filesystem;
-  static constexpr std::array<std::string_view, 6> suffixes{
-      VOCAB_SUFFIX,       ".index",          ".internal.index",
-      CONFIGURATION_FILE, ".update-triples", ".allocated-graphs-state"};
+  static constexpr std::array<std::string_view, 7> suffixes{
+      VOCAB_SUFFIX,
+      ".index",
+      ".internal.index",
+      CONFIGURATION_FILE,
+      ".update-triples",
+      ".allocated-graphs-state",
+      BLANK_NODE_IRI_VOCAB_SUFFIX};
   qlever::util::deleteFilesInDirectory(
       fs::current_path(), [&indexBasename](const auto& path) {
         std::string name = path.filename().string();
@@ -233,6 +238,10 @@ Index makeTestIndex(const std::string& indexBasename, TestIndexConfig c) {
     if (c.encodedPrefixesWithoutAngleBrackets.has_value()) {
       index.getImpl().setPrefixesForEncodedValues(
           std::move(c.encodedPrefixesWithoutAngleBrackets.value()));
+    }
+    if (c.blankNodePrefixes.has_value()) {
+      index.getImpl().setBlankNodePrefixes(
+          std::move(c.blankNodePrefixes.value()));
     }
     index.createFromFiles({spec});
     if (c.createTextIndex) {

--- a/test/util/IndexTestHelpers.h
+++ b/test/util/IndexTestHelpers.h
@@ -69,6 +69,9 @@ struct TestIndexConfig {
   std::optional<VocabularyType> vocabularyType = std::nullopt;
   std::optional<std::vector<std::string>> encodedPrefixesWithoutAngleBrackets =
       std::nullopt;
+  // Regexes for IRIs that should be treated as blank nodes during index
+  // building (see `IndexImpl::setBlankNodePrefixes`).
+  std::optional<std::vector<std::string>> blankNodePrefixes = std::nullopt;
   // If true, add `ql:has-word` triples for each word in each literal during
   // index building.
   bool addHasWordTriples = false;
@@ -83,19 +86,20 @@ struct TestIndexConfig {
   // Hashing.
   template <typename H>
   friend H AbslHashValue(H h, const TestIndexConfig& c) {
-    return H::combine(
-        std::move(h), c.turtleInput, c.loadAllPermutations, c.usePatterns,
-        c.usePrefixCompression, c.blocksizePermutations, c.createTextIndex,
-        c.addWordsFromLiterals, c.contentsOfWordsFileAndDocsfile,
-        c.parserBufferSize, c.scoringMetric, c.bAndKParam, c.indexType,
-        c.encodedPrefixesWithoutAngleBrackets, c.addHasWordTriples);
+    return H::combine(std::move(h), c.turtleInput, c.loadAllPermutations,
+                      c.usePatterns, c.usePrefixCompression,
+                      c.blocksizePermutations, c.createTextIndex,
+                      c.addWordsFromLiterals, c.contentsOfWordsFileAndDocsfile,
+                      c.parserBufferSize, c.scoringMetric, c.bAndKParam,
+                      c.indexType, c.encodedPrefixesWithoutAngleBrackets,
+                      c.blankNodePrefixes, c.addHasWordTriples);
   }
   QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(
       TestIndexConfig, turtleInput, loadAllPermutations, usePatterns,
       usePrefixCompression, blocksizePermutations, createTextIndex,
       addWordsFromLiterals, contentsOfWordsFileAndDocsfile, parserBufferSize,
       scoringMetric, bAndKParam, indexType, vocabularyType,
-      encodedPrefixesWithoutAngleBrackets, addHasWordTriples)
+      encodedPrefixesWithoutAngleBrackets, blankNodePrefixes, addHasWordTriples)
 };
 
 // Create a test index at the given `indexBasename` and with the given `config`.


### PR DESCRIPTION
## Summary

This branch adds the `--treat-as-blank-node` index-build option and makes the resulting IRI→blank-node mapping persistent so it can be reapplied consistently later.

It contains two commits:

1. **Add option to treat certain IRIs as blank nodes during index building** (previously prepared). IRIs whose vocabulary entry matches an `RE2` regex are converted to blank nodes instead of being stored in the vocabulary. This saves vocabulary memory for IRIs that only act as internal connector nodes (e.g. statement nodes).
2. **Persist and reapply the IRI-to-blank-node mapping** (new). The concrete mapping from each such IRI to its assigned blank node index is now remembered, persisted with the index, and reapplied whenever the same IRI is referenced again — in particular via SPARQL UPDATE, but also in queries.

## How it works

- **`BlankNodeIriVocabulary`** (new): a dedicated, sorted, on-disk vocabulary of the matched IRIs plus a compact list of contiguous `Chunk`s (`{vocabStartPos, blankNodeStartIndex, count}`) persisted in an accompanying `.chunks` file. The matched IRIs occupy contiguous runs of blank-node indices: the vocabulary merger processes words in sorted order, and `TripleComponentComparator` orders literals, IRIs, and `_:` blank nodes into disjoint blocks by their first byte — so no per-IRI index array is needed. Everything is streamed in sorted order at build time (scales to very large inputs).
- A callback threaded through `mergeVocabulary` records each regex-matched (non-`_:`) IRI together with the exact blank-node index written to the permutations.
- `TripleComponent::toValueIdOrBounds` (the shared resolution path used by queries and by `ExecuteUpdate`) remaps an IRI that is absent from the main vocabulary but present in the `BlankNodeIriVocabulary` to its stored blank node.

## Scope / limitations

- IRIs that match a pattern but were **not** part of the original input are **not** converted to blank nodes (this would require allocating new blank-node vocabularies at update time); such IRIs are handled as before.
- Index **rebuild** (`IndexRebuilder`) does not currently regenerate the mapping, so the persisted `.blanknode-iri-vocabulary*` files can become stale after a rebuild. Left as a follow-up.

## Testing

- New `BlankNodeIriVocabularyTest`: round-trip write/read, single- and multi-chunk mappings, both vocabulary types.
- New `ExecuteUpdate.treatAsBlankNodeConsistentRemapping`: builds a real index with the feature and verifies that both `toValueId` overloads remap the connector IRI to the existing blank node, that an unknown matching IRI is not remapped, and that a real `INSERT DATA` succeeds.
- No regressions in `ExecuteUpdateTest`, `VocabularyGeneratorTest`, `TripleComponentTest`, `DeltaTriplesTest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)