### PR TITLE
Optionally treat certain IRIs as blank nodes during index building

### DIFF
--- a/src/index/IndexBuilderMain.cpp
+++ b/src/index/IndexBuilderMain.cpp
@@ -282,14 +282,17 @@ int main(int argc, char** argv) {
       "among non-encoded IRIs is correct, but the order between encoded "
       "and non-encoded IRIs is not");
 
-  add("treat-as-blank-node",
-      po::value(&config.blankNodePrefixes_)->composing()->multitoken(),
-      "Space-separated list of regexes. IRIs whose vocabulary entry matches "
-      "one of these regexes (via RE2 partial match) are not stored in the "
-      "vocabulary, but converted to blank nodes. This saves memory for IRIs "
-      "that only act as internal connector nodes (e.g. statement nodes). NOTE: "
-      "Such IRIs then have blank-node semantics and can no longer be matched "
-      "by their IRI in a query.");
+  add("iri-as-blank-node-regexes",
+      po::value(&config.blankNodeIriRegexes_)->composing()->multitoken(),
+      "Space-separated list of regexes. An IRI that matches one of these "
+      "regexes (via RE2 partial match) is not stored in the vocabulary, but "
+      "converted to a blank node. This saves memory for IRIs that only act as "
+      "internal connector nodes (e.g. statement nodes). The regex is matched "
+      "against the full IRI text including the angle brackets, e.g. the regex "
+      "`example\\.org/statement/` matches "
+      "`<https://example.org/statement/42>`. "
+      "Only IRIs are affected; a regex that happens to match inside a literal "
+      "does not turn that literal into a blank node.");
 
   // Options for the index building process.
   add("stxxl-memory,m", po::value(&config.memoryLimit_),

--- a/src/index/IndexBuilderMain.cpp
+++ b/src/index/IndexBuilderMain.cpp
@@ -292,7 +292,11 @@ int main(int argc, char** argv) {
       "`example\\.org/statement/` matches "
       "`<https://example.org/statement/42>`. "
       "Only IRIs are affected; a regex that happens to match inside a literal "
-      "does not turn that literal into a blank node.");
+      "does not turn that literal into a blank node. NOTE: This is an "
+      "experimental feature. The affected IRIs behave as ordinary blank nodes, "
+      "so they are no longer recognized as those IRIs if used, e.g., in a "
+      "query "
+      "or an update.");
 
   // Options for the index building process.
   add("stxxl-memory,m", po::value(&config.memoryLimit_),

--- a/src/index/IndexBuilderMain.cpp
+++ b/src/index/IndexBuilderMain.cpp
@@ -293,10 +293,9 @@ int main(int argc, char** argv) {
       "`<https://example.org/statement/42>`. "
       "Only IRIs are affected; a regex that happens to match inside a literal "
       "does not turn that literal into a blank node. NOTE: This is an "
-      "experimental feature. The affected IRIs behave as ordinary blank nodes, "
-      "so they are no longer recognized as those IRIs if used, e.g., in a "
-      "query "
-      "or an update.");
+      "experimental feature. The affected IRIs behave as ordinary blank "
+      "nodes, so they are no longer recognized as those IRIs if used, e.g., "
+      "in a query or an update.");
 
   // Options for the index building process.
   add("stxxl-memory,m", po::value(&config.memoryLimit_),

--- a/src/index/IndexBuilderMain.cpp
+++ b/src/index/IndexBuilderMain.cpp
@@ -282,6 +282,15 @@ int main(int argc, char** argv) {
       "among non-encoded IRIs is correct, but the order between encoded "
       "and non-encoded IRIs is not");
 
+  add("treat-as-blank-node",
+      po::value(&config.blankNodePrefixes_)->composing()->multitoken(),
+      "Space-separated list of regexes. IRIs whose vocabulary entry matches "
+      "one of these regexes (via RE2 partial match) are not stored in the "
+      "vocabulary, but converted to blank nodes. This saves memory for IRIs "
+      "that only act as internal connector nodes (e.g. statement nodes). NOTE: "
+      "Such IRIs then have blank-node semantics and can no longer be matched "
+      "by their IRI in a query.");
+
   // Options for the index building process.
   add("stxxl-memory,m", po::value(&config.memoryLimit_),
       "The amount of memory in to use for sorting during the index build. "

--- a/src/index/IndexBuilderMain.cpp
+++ b/src/index/IndexBuilderMain.cpp
@@ -284,18 +284,19 @@ int main(int argc, char** argv) {
 
   add("iri-as-blank-node-regexes",
       po::value(&config.blankNodeIriRegexes_)->composing()->multitoken(),
-      "Space-separated list of regexes. An IRI that matches one of these "
-      "regexes (via RE2 partial match) is not stored in the vocabulary, but "
+      "Space-separated list of regexes. An IRI that is fully matched by one of "
+      "these regexes (via RE2 full match) is not stored in the vocabulary, but "
       "converted to a blank node. This saves memory for IRIs that only act as "
       "internal connector nodes (e.g. statement nodes). The regex is matched "
-      "against the full IRI text including the angle brackets, e.g. the regex "
-      "`example\\.org/statement/` matches "
-      "`<https://example.org/statement/42>`. "
-      "Only IRIs are affected; a regex that happens to match inside a literal "
-      "does not turn that literal into a blank node. NOTE: This is an "
-      "experimental feature. The affected IRIs behave as ordinary blank "
-      "nodes, so they are no longer recognized as those IRIs if used, e.g., "
-      "in a query or an update.");
+      "against the full IRI text including the angle brackets and has to cover "
+      "the entire IRI, so each regex must start with `<`; to allow an "
+      "arbitrary "
+      "suffix, end it with `.*`, e.g. the regex "
+      "`<https://example\\.org/statement/.*>` matches "
+      "`<https://example.org/statement/42>`. Only IRIs are affected. NOTE: "
+      "This is an experimental feature. The affected IRIs behave as ordinary "
+      "blank nodes, so they are no longer recognized as those IRIs if used, "
+      "e.g., in a query or an update.");
 
   // Options for the index building process.
   add("stxxl-memory,m", po::value(&config.memoryLimit_),

--- a/src/index/IndexBuilderTypes.h
+++ b/src/index/IndexBuilderTypes.h
@@ -16,8 +16,11 @@
 
 #include <absl/container/inlined_vector.h>
 #include <absl/strings/str_cat.h>
+#include <re2/re2.h>
 
 #include <atomic>
+#include <memory>
+#include <vector>
 
 #include "backports/StartsWithAndEndsWith.h"
 #include "backports/memory_resource.h"
@@ -46,7 +49,25 @@ struct TripleComponentWithIndex {
   [[nodiscard]] auto& isExternal() { return isExternal_; }
   [[nodiscard]] const auto& iriOrLiteral() const { return iriOrLiteral_; }
   [[nodiscard]] auto& iriOrLiteral() { return iriOrLiteral_; }
-  bool isBlankNode() const { return ql::starts_with(iriOrLiteral_, "_:"); }
+  // Return true if this word is a blank node. A word is considered a blank
+  // node if it starts with `_:` or, when `blankNodePrefixes` is given, if it
+  // matches (via `RE2::PartialMatch`) any of the regexes in it. The latter is
+  // used to treat IRIs that only act as internal connector nodes as blank
+  // nodes (see `IndexImpl::setBlankNodePrefixes`).
+  bool isBlankNode(const std::vector<std::unique_ptr<re2::RE2>>*
+                       blankNodePrefixes = nullptr) const {
+    if (ql::starts_with(iriOrLiteral_, "_:")) {
+      return true;
+    }
+    if (blankNodePrefixes != nullptr) {
+      for (const auto& prefix : *blankNodePrefixes) {
+        if (re2::RE2::PartialMatch(iriOrLiteral_, *prefix)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
 
   AD_SERIALIZE_FRIEND_FUNCTION(TripleComponentWithIndex) {
     serializer | arg.iriOrLiteral_;

--- a/src/index/IndexBuilderTypes.h
+++ b/src/index/IndexBuilderTypes.h
@@ -61,17 +61,16 @@ struct TripleComponentWithIndex {
   // does not turn that literal into a blank node. See the
   // `--iri-as-blank-node-regexes` option of the index builder and
   // `IndexImpl::blankNodeIriRegexes`.
-  bool isBlankNode(const std::vector<std::unique_ptr<re2::RE2>>*
-                       blankNodeIriRegexes = nullptr) const {
+  bool isBlankNode(const std::vector<std::unique_ptr<re2::RE2>>&
+                       blankNodeIriRegexes = {}) const {
     if (ql::starts_with(iriOrLiteral_, "_:")) {
       return true;
     }
     // The regexes only apply to IRIs (which start with `<`).
-    if (blankNodeIriRegexes == nullptr ||
-        !ql::starts_with(iriOrLiteral_, "<")) {
+    if (!ql::starts_with(iriOrLiteral_, "<")) {
       return false;
     }
-    return ql::ranges::any_of(*blankNodeIriRegexes, [this](const auto& regex) {
+    return ql::ranges::any_of(blankNodeIriRegexes, [this](const auto& regex) {
       return re2::RE2::PartialMatch(iriOrLiteral_, *regex);
     });
   }

--- a/src/index/IndexBuilderTypes.h
+++ b/src/index/IndexBuilderTypes.h
@@ -49,24 +49,31 @@ struct TripleComponentWithIndex {
   [[nodiscard]] auto& isExternal() { return isExternal_; }
   [[nodiscard]] const auto& iriOrLiteral() const { return iriOrLiteral_; }
   [[nodiscard]] auto& iriOrLiteral() { return iriOrLiteral_; }
-  // Return true if this word is a blank node. A word is considered a blank
-  // node if it starts with `_:` or, when `blankNodePrefixes` is given, if it
-  // matches (via `RE2::PartialMatch`) any of the regexes in it. The latter is
-  // used to treat IRIs that only act as internal connector nodes as blank
-  // nodes (see `IndexImpl::setBlankNodePrefixes`).
+  // Return true if this word is a blank node. A word is a blank node if it
+  // starts with `_:`, or, when `blankNodeIriRegexes` is given, if it is an IRI
+  // that matches one of those regexes.
+  //
+  // The regexes are matched (via `RE2::PartialMatch`) against the full text of
+  // the word, *including* the surrounding angle brackets of an IRI. For
+  // example the regex `example\.org/statement/` matches the IRI
+  // `<https://example.org/statement/42>`. Only IRIs (words starting with `<`)
+  // are ever treated this way: a regex that happens to match inside a literal
+  // does not turn that literal into a blank node. See the
+  // `--iri-as-blank-node-regexes` option of the index builder and
+  // `IndexImpl::blankNodeIriRegexes`.
   bool isBlankNode(const std::vector<std::unique_ptr<re2::RE2>>*
-                       blankNodePrefixes = nullptr) const {
+                       blankNodeIriRegexes = nullptr) const {
     if (ql::starts_with(iriOrLiteral_, "_:")) {
       return true;
     }
-    if (blankNodePrefixes != nullptr) {
-      for (const auto& prefix : *blankNodePrefixes) {
-        if (re2::RE2::PartialMatch(iriOrLiteral_, *prefix)) {
-          return true;
-        }
-      }
+    // The regexes only apply to IRIs (which start with `<`).
+    if (blankNodeIriRegexes == nullptr ||
+        !ql::starts_with(iriOrLiteral_, "<")) {
+      return false;
     }
-    return false;
+    return ql::ranges::any_of(*blankNodeIriRegexes, [this](const auto& regex) {
+      return re2::RE2::PartialMatch(iriOrLiteral_, *regex);
+    });
   }
 
   AD_SERIALIZE_FRIEND_FUNCTION(TripleComponentWithIndex) {

--- a/src/index/IndexBuilderTypes.h
+++ b/src/index/IndexBuilderTypes.h
@@ -63,8 +63,8 @@ struct TripleComponentWithIndex {
   // required to describe IRIs (i.e. to start with `<`), which is enforced by
   // `IndexImpl::setBlankNodeIriRegexes`. See also the
   // `--iri-as-blank-node-regexes` option of the index builder.
-  bool isBlankNode(const std::vector<std::unique_ptr<re2::RE2>>&
-                       blankNodeIriRegexes = {}) const {
+  bool isBlankNode(
+      const std::vector<std::unique_ptr<re2::RE2>>& blankNodeIriRegexes) const {
     if (ql::starts_with(iriOrLiteral_, "_:")) {
       return true;
     }

--- a/src/index/IndexBuilderTypes.h
+++ b/src/index/IndexBuilderTypes.h
@@ -51,27 +51,30 @@ struct TripleComponentWithIndex {
   [[nodiscard]] auto& iriOrLiteral() { return iriOrLiteral_; }
   // Return true if this word is a blank node. A word is a blank node if it
   // starts with `_:`, or, when `blankNodeIriRegexes` is given, if it is an IRI
-  // that matches one of those regexes.
+  // that is fully matched by one of those regexes.
   //
-  // The regexes are matched (via `RE2::PartialMatch`) against the full text of
-  // the word, *including* the surrounding angle brackets of an IRI. For
-  // example the regex `example\.org/statement/` matches the IRI
+  // The regexes are matched (via `RE2::FullMatch`) against the full text of the
+  // word, *including* the surrounding angle brackets of an IRI. The match has
+  // to cover the entire word, so a regex must describe the whole IRI; to allow
+  // an arbitrary suffix, end it with `.*`. For example the regex
+  // `<https://example\.org/statement/.*>` matches the IRI
   // `<https://example.org/statement/42>`. Only IRIs (words starting with `<`)
-  // are ever treated this way: a regex that happens to match inside a literal
-  // does not turn that literal into a blank node. See the
-  // `--iri-as-blank-node-regexes` option of the index builder and
-  // `IndexImpl::blankNodeIriRegexes`.
+  // are ever treated this way; literals are never converted. The regexes are
+  // required to describe IRIs (i.e. to start with `<`), which is enforced by
+  // `IndexImpl::setBlankNodeIriRegexes`. See also the
+  // `--iri-as-blank-node-regexes` option of the index builder.
   bool isBlankNode(const std::vector<std::unique_ptr<re2::RE2>>&
                        blankNodeIriRegexes = {}) const {
     if (ql::starts_with(iriOrLiteral_, "_:")) {
       return true;
     }
-    // The regexes only apply to IRIs (which start with `<`).
+    // Only IRIs (which start with `<`) can be treated as blank nodes; this also
+    // avoids running the regexes for the common case of a literal.
     if (!ql::starts_with(iriOrLiteral_, "<")) {
       return false;
     }
     return ql::ranges::any_of(blankNodeIriRegexes, [this](const auto& regex) {
-      return re2::RE2::PartialMatch(iriOrLiteral_, *regex);
+      return re2::RE2::FullMatch(iriOrLiteral_, *regex);
     });
   }
 

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -708,7 +708,8 @@ IndexBuilderDataAsExternalVector IndexImpl::passFileForVocabulary(
     wordCallback.readableName() = "internal vocabulary";
     auto mergedVocabMeta = ad_utility::vocabulary_merger::mergeVocabulary(
         onDiskBase_, numPartialVocabs, sortPred, wordCallback,
-        memoryLimitIndexBuilding());
+        memoryLimitIndexBuilding(),
+        blankNodePrefixes_.empty() ? nullptr : &blankNodePrefixes_);
     wordCallback.finish();
     return mergedVocabMeta;
   }();

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -708,8 +708,7 @@ IndexBuilderDataAsExternalVector IndexImpl::passFileForVocabulary(
     wordCallback.readableName() = "internal vocabulary";
     auto mergedVocabMeta = ad_utility::vocabulary_merger::mergeVocabulary(
         onDiskBase_, numPartialVocabs, sortPred, wordCallback,
-        memoryLimitIndexBuilding(),
-        blankNodeIriRegexes_.empty() ? nullptr : &blankNodeIriRegexes_);
+        memoryLimitIndexBuilding(), blankNodeIriRegexes_);
     wordCallback.finish();
     return mergedVocabMeta;
   }();

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -709,7 +709,7 @@ IndexBuilderDataAsExternalVector IndexImpl::passFileForVocabulary(
     auto mergedVocabMeta = ad_utility::vocabulary_merger::mergeVocabulary(
         onDiskBase_, numPartialVocabs, sortPred, wordCallback,
         memoryLimitIndexBuilding(),
-        blankNodePrefixes_.empty() ? nullptr : &blankNodePrefixes_);
+        blankNodeIriRegexes_.empty() ? nullptr : &blankNodeIriRegexes_);
     wordCallback.finish();
     return mergedVocabMeta;
   }();

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -20,6 +20,7 @@
 #include <utility>
 
 #include "CompilationInfo.h"
+#include "backports/StartsWithAndEndsWith.h"
 #include "backports/algorithm.h"
 #include "engine/AddCombinedRowToTable.h"
 #include "global/RuntimeParameters.h"
@@ -2003,6 +2004,23 @@ void IndexImpl::setPrefixesForEncodedValues(
   encodedIriManager_ =
       EncodedIriManager{std::move(prefixesWithoutAngleBrackets)};
 }
+
+// _____________________________________________________________________________
+void IndexImpl::setBlankNodeIriRegexes(
+    std::vector<std::string> blankNodeIriRegexes) {
+  // The regexes are matched against the full IRI text (including the angle
+  // brackets), so each of them has to describe an IRI and must therefore start
+  // with `<`.
+  for (const auto& regex : blankNodeIriRegexes) {
+    AD_CONTRACT_CHECK(
+        ql::starts_with(regex, '<'),
+        "A regex for treating IRIs as blank nodes has to match a full IRI and "
+        "must therefore start with `<`, but got: ",
+        regex);
+  }
+  blankNodeIriRegexes_ = std::move(blankNodeIriRegexes);
+}
+
 // _____________________________________________________________________________
 void IndexImpl::writePatternsToFile() const {
   PatternStatistics statistics;

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -2009,22 +2009,20 @@ void IndexImpl::setPrefixesForEncodedValues(
 // _____________________________________________________________________________
 void IndexImpl::setBlankNodeIriRegexes(
     const std::vector<std::string>& blankNodeIriRegexes) {
-  // The regexes are matched against the full IRI text (including the angle
-  // brackets), so each of them has to describe an IRI and must therefore start
-  // with `<`.
-  ql::ranges::for_each(blankNodeIriRegexes, [](const std::string& regex) {
-    AD_CONTRACT_CHECK(
-        ql::starts_with(regex, '<'),
-        "A regex for treating IRIs as blank nodes has to match a full IRI and "
-        "must therefore start with `<`, but got: ",
-        regex);
-  });
-
-  // Compile the regexes. `RE2` does not throw for an invalid pattern but stores
-  // an error state, which we turn into a user-readable exception here.
   std::vector<std::unique_ptr<re2::RE2>> compiledRegexes;
   ql::ranges::for_each(
       blankNodeIriRegexes, [&compiledRegexes](const std::string& regex) {
+        // The regexes are matched against the full IRI text (including the
+        // angle brackets), so each of them has to describe an IRI and must
+        // therefore start with `<`.
+        if (!ql::starts_with(regex, '<')) {
+          throw std::runtime_error{absl::StrCat(
+              "A regex for treating IRIs as blank nodes has to match a full "
+              "IRI and must therefore start with `<`, but got: ",
+              regex)};
+        }
+        // `RE2` does not throw for an invalid pattern but stores an error
+        // state, which we turn into a user-readable exception here.
         auto compiledRegex = std::make_unique<re2::RE2>(regex, re2::RE2::Quiet);
         if (!compiledRegex->ok()) {
           throw std::runtime_error{absl::StrCat(

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -6,6 +6,7 @@
 #include "index/IndexImpl.h"
 
 #include <absl/cleanup/cleanup.h>
+#include <absl/strings/str_cat.h>
 #include <absl/strings/str_join.h>
 #include <absl/time/clock.h>
 #include <absl/time/time.h>
@@ -2007,18 +2008,40 @@ void IndexImpl::setPrefixesForEncodedValues(
 
 // _____________________________________________________________________________
 void IndexImpl::setBlankNodeIriRegexes(
-    std::vector<std::string> blankNodeIriRegexes) {
+    const std::vector<std::string>& blankNodeIriRegexes) {
   // The regexes are matched against the full IRI text (including the angle
   // brackets), so each of them has to describe an IRI and must therefore start
   // with `<`.
-  for (const auto& regex : blankNodeIriRegexes) {
+  ql::ranges::for_each(blankNodeIriRegexes, [](const std::string& regex) {
     AD_CONTRACT_CHECK(
         ql::starts_with(regex, '<'),
         "A regex for treating IRIs as blank nodes has to match a full IRI and "
         "must therefore start with `<`, but got: ",
         regex);
+  });
+
+  // Compile the regexes. `RE2` does not throw for an invalid pattern but stores
+  // an error state, which we turn into a user-readable exception here.
+  std::vector<std::unique_ptr<re2::RE2>> compiledRegexes;
+  try {
+    ql::ranges::for_each(
+        blankNodeIriRegexes, [&compiledRegexes](const std::string& regex) {
+          auto compiledRegex =
+              std::make_unique<re2::RE2>(regex, re2::RE2::Quiet);
+          if (!compiledRegex->ok()) {
+            throw std::runtime_error{
+                absl::StrCat("\"", regex, "\": ", compiledRegex->error())};
+          }
+          compiledRegexes.push_back(std::move(compiledRegex));
+        });
+  } catch (const std::exception& e) {
+    throw std::runtime_error{
+        absl::StrCat("A regex passed to `--iri-as-blank-node-regexes` is not a "
+                     "valid regular "
+                     "expression (as understood by Google's RE2 library): ",
+                     e.what())};
   }
-  blankNodeIriRegexes_ = std::move(blankNodeIriRegexes);
+  blankNodeIriRegexes_ = std::move(compiledRegexes);
 }
 
 // _____________________________________________________________________________

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -2023,24 +2023,18 @@ void IndexImpl::setBlankNodeIriRegexes(
   // Compile the regexes. `RE2` does not throw for an invalid pattern but stores
   // an error state, which we turn into a user-readable exception here.
   std::vector<std::unique_ptr<re2::RE2>> compiledRegexes;
-  try {
-    ql::ranges::for_each(
-        blankNodeIriRegexes, [&compiledRegexes](const std::string& regex) {
-          auto compiledRegex =
-              std::make_unique<re2::RE2>(regex, re2::RE2::Quiet);
-          if (!compiledRegex->ok()) {
-            throw std::runtime_error{
-                absl::StrCat("\"", regex, "\": ", compiledRegex->error())};
-          }
-          compiledRegexes.push_back(std::move(compiledRegex));
-        });
-  } catch (const std::exception& e) {
-    throw std::runtime_error{
-        absl::StrCat("A regex passed to `--iri-as-blank-node-regexes` is not a "
-                     "valid regular "
-                     "expression (as understood by Google's RE2 library): ",
-                     e.what())};
-  }
+  ql::ranges::for_each(
+      blankNodeIriRegexes, [&compiledRegexes](const std::string& regex) {
+        auto compiledRegex = std::make_unique<re2::RE2>(regex, re2::RE2::Quiet);
+        if (!compiledRegex->ok()) {
+          throw std::runtime_error{absl::StrCat(
+              "The regex \"", regex,
+              "\" passed to `--iri-as-blank-node-regexes` is not a valid "
+              "regular expression (as understood by Google's RE2 library): ",
+              compiledRegex->error())};
+        }
+        compiledRegexes.push_back(std::move(compiledRegex));
+      });
   blankNodeIriRegexes_ = std::move(compiledRegexes);
 }
 

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -192,7 +192,8 @@ class IndexImpl {
       ad_utility::VocabularyType::Enum::OnDiskCompressed};
 
   // Regexes for IRIs that should be treated as blank nodes during index
-  // building (only relevant during index building); see `blankNodeIriRegexes`.
+  // building (only relevant during index building); see
+  // `blankNodeIriRegexes()`.
   std::vector<std::string> blankNodeIriRegexes_;
 
   // BlankNodeManager, initialized during `readConfiguration`

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -191,6 +191,11 @@ class IndexImpl {
   ad_utility::VocabularyType vocabularyTypeForIndexBuilding_{
       ad_utility::VocabularyType::Enum::OnDiskCompressed};
 
+  // Regexes for IRIs that should be treated as blank nodes during index
+  // building (only relevant during index building); see
+  // `setBlankNodePrefixes`.
+  std::vector<std::string> blankNodePrefixes_;
+
   // BlankNodeManager, initialized during `readConfiguration`
   std::unique_ptr<ad_utility::BlankNodeManager> blankNodeManager_{nullptr};
 
@@ -291,6 +296,18 @@ class IndexImpl {
   // the `Id`; see `EncodedIriManager` for details.
   void setPrefixesForEncodedValues(
       std::vector<std::string> prefixesWithoutAngleBrackets);
+
+  // Set the regexes for IRIs that should be treated as blank nodes during index
+  // building. Each entry is an `RE2` regex; a vocabulary word matching any of
+  // them (via `RE2::PartialMatch`) is stored as a blank node instead of in the
+  // vocabulary. This is useful for IRIs that only act as internal connector
+  // nodes (e.g. statement nodes), to save vocabulary memory.
+  void setBlankNodePrefixes(std::vector<std::string> blankNodePrefixes) {
+    blankNodePrefixes_ = std::move(blankNodePrefixes);
+  }
+  const std::vector<std::string>& getBlankNodePrefixes() const {
+    return blankNodePrefixes_;
+  }
 
   // Set the vocabulary type; see `ad_utility::VocabularyType` for details.
   void setVocabularyTypeForIndexBuilding(ad_utility::VocabularyType type) {

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -192,9 +192,8 @@ class IndexImpl {
       ad_utility::VocabularyType::Enum::OnDiskCompressed};
 
   // Regexes for IRIs that should be treated as blank nodes during index
-  // building (only relevant during index building); see
-  // `setBlankNodePrefixes`.
-  std::vector<std::string> blankNodePrefixes_;
+  // building (only relevant during index building); see `blankNodeIriRegexes`.
+  std::vector<std::string> blankNodeIriRegexes_;
 
   // BlankNodeManager, initialized during `readConfiguration`
   std::unique_ptr<ad_utility::BlankNodeManager> blankNodeManager_{nullptr};
@@ -297,16 +296,17 @@ class IndexImpl {
   void setPrefixesForEncodedValues(
       std::vector<std::string> prefixesWithoutAngleBrackets);
 
-  // Set the regexes for IRIs that should be treated as blank nodes during index
-  // building. Each entry is an `RE2` regex; a vocabulary word matching any of
-  // them (via `RE2::PartialMatch`) is stored as a blank node instead of in the
+  // The regexes for IRIs that should be treated as blank nodes during index
+  // building. Each entry is an `RE2` regex; an IRI matching any of them (via
+  // `RE2::PartialMatch`) is stored as a blank node instead of in the
   // vocabulary. This is useful for IRIs that only act as internal connector
-  // nodes (e.g. statement nodes), to save vocabulary memory.
-  void setBlankNodePrefixes(std::vector<std::string> blankNodePrefixes) {
-    blankNodePrefixes_ = std::move(blankNodePrefixes);
+  // nodes (e.g. statement nodes), to save vocabulary memory. See
+  // `TripleComponentWithIndex::isBlankNode`.
+  std::vector<std::string>& blankNodeIriRegexes() {
+    return blankNodeIriRegexes_;
   }
-  const std::vector<std::string>& getBlankNodePrefixes() const {
-    return blankNodePrefixes_;
+  const std::vector<std::string>& blankNodeIriRegexes() const {
+    return blankNodeIriRegexes_;
   }
 
   // Set the vocabulary type; see `ad_utility::VocabularyType` for details.

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -9,6 +9,7 @@
 
 #include <absl/time/time.h>
 #include <gtest/gtest_prod.h>
+#include <re2/re2.h>
 
 #include <memory>
 #include <optional>
@@ -191,10 +192,10 @@ class IndexImpl {
   ad_utility::VocabularyType vocabularyTypeForIndexBuilding_{
       ad_utility::VocabularyType::Enum::OnDiskCompressed};
 
-  // Regexes for IRIs that should be treated as blank nodes during index
-  // building (only relevant during index building); see
-  // `setBlankNodeIriRegexes`.
-  std::vector<std::string> blankNodeIriRegexes_;
+  // Compiled regexes for IRIs that should be treated as blank nodes during
+  // index building (only relevant during index building). Set (and compiled
+  // from their string representation) via `setBlankNodeIriRegexes`.
+  std::vector<std::unique_ptr<re2::RE2>> blankNodeIriRegexes_;
 
   // BlankNodeManager, initialized during `readConfiguration`
   std::unique_ptr<ad_utility::BlankNodeManager> blankNodeManager_{nullptr};
@@ -301,11 +302,14 @@ class IndexImpl {
   // building. Each entry is an `RE2` regex; an IRI that is fully matched by any
   // of them (via `RE2::FullMatch`) is stored as a blank node instead of in the
   // vocabulary. This is useful for IRIs that only act as internal connector
-  // nodes (e.g. statement nodes), to save vocabulary memory. Each regex has to
-  // match a full IRI and must therefore start with `<`; this is checked with an
-  // `AD_CONTRACT_CHECK`. See `TripleComponentWithIndex::isBlankNode`.
-  void setBlankNodeIriRegexes(std::vector<std::string> blankNodeIriRegexes);
-  const std::vector<std::string>& getBlankNodeIriRegexes() const {
+  // nodes (e.g. statement nodes), to save vocabulary memory. The regexes are
+  // compiled here and stored in their compiled form. Each regex has to match a
+  // full IRI and must therefore start with `<` (checked with an
+  // `AD_CONTRACT_CHECK`); an invalid regex is reported with a user-readable
+  // error. See `TripleComponentWithIndex::isBlankNode`.
+  void setBlankNodeIriRegexes(
+      const std::vector<std::string>& blankNodeIriRegexes);
+  const std::vector<std::unique_ptr<re2::RE2>>& getBlankNodeIriRegexes() const {
     return blankNodeIriRegexes_;
   }
 

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -304,9 +304,9 @@ class IndexImpl {
   // vocabulary. This is useful for IRIs that only act as internal connector
   // nodes (e.g. statement nodes), to save vocabulary memory. The regexes are
   // compiled here and stored in their compiled form. Each regex has to match a
-  // full IRI and must therefore start with `<` (checked with an
-  // `AD_CONTRACT_CHECK`); an invalid regex is reported with a user-readable
-  // error. See `TripleComponentWithIndex::isBlankNode`.
+  // full IRI and must therefore start with `<`; a regex that violates this or
+  // is not a valid regular expression is reported with a user-readable
+  // exception. See `TripleComponentWithIndex::isBlankNode`.
   void setBlankNodeIriRegexes(
       const std::vector<std::string>& blankNodeIriRegexes);
   const std::vector<std::unique_ptr<re2::RE2>>& getBlankNodeIriRegexes() const {

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -193,7 +193,7 @@ class IndexImpl {
 
   // Regexes for IRIs that should be treated as blank nodes during index
   // building (only relevant during index building); see
-  // `blankNodeIriRegexes()`.
+  // `setBlankNodeIriRegexes`.
   std::vector<std::string> blankNodeIriRegexes_;
 
   // BlankNodeManager, initialized during `readConfiguration`
@@ -297,16 +297,15 @@ class IndexImpl {
   void setPrefixesForEncodedValues(
       std::vector<std::string> prefixesWithoutAngleBrackets);
 
-  // The regexes for IRIs that should be treated as blank nodes during index
-  // building. Each entry is an `RE2` regex; an IRI matching any of them (via
-  // `RE2::PartialMatch`) is stored as a blank node instead of in the
+  // Set the regexes for IRIs that should be treated as blank nodes during index
+  // building. Each entry is an `RE2` regex; an IRI that is fully matched by any
+  // of them (via `RE2::FullMatch`) is stored as a blank node instead of in the
   // vocabulary. This is useful for IRIs that only act as internal connector
-  // nodes (e.g. statement nodes), to save vocabulary memory. See
-  // `TripleComponentWithIndex::isBlankNode`.
-  std::vector<std::string>& blankNodeIriRegexes() {
-    return blankNodeIriRegexes_;
-  }
-  const std::vector<std::string>& blankNodeIriRegexes() const {
+  // nodes (e.g. statement nodes), to save vocabulary memory. Each regex has to
+  // match a full IRI and must therefore start with `<`; this is checked with an
+  // `AD_CONTRACT_CHECK`. See `TripleComponentWithIndex::isBlankNode`.
+  void setBlankNodeIriRegexes(std::vector<std::string> blankNodeIriRegexes);
+  const std::vector<std::string>& getBlankNodeIriRegexes() const {
     return blankNodeIriRegexes_;
   }
 

--- a/src/index/VocabularyMerger.h
+++ b/src/index/VocabularyMerger.h
@@ -5,6 +5,7 @@
 #ifndef QLEVER_SRC_INDEX_VOCABULARYMERGER_H
 #define QLEVER_SRC_INDEX_VOCABULARYMERGER_H
 
+#include <functional>
 #include <memory>
 #include <optional>
 #include <string>
@@ -63,6 +64,13 @@ template <typename T>
 CPP_concept WordCallback =
     ad_utility::InvocableWithExactReturnType<T, uint64_t, std::string_view,
                                              bool>;
+
+// A callback that is invoked for every IRI which is treated as a blank node
+// because it matched one of the `blankNodePrefixes` (not for `_:`-prefixed
+// blank nodes). It receives the IRI and the blank node index that was assigned
+// to it, so that the mapping can be remembered (see `BlankNodeIriVocabulary`).
+// The IRIs are passed in ascending (sorted) order.
+using BlankNodeIriCallback = std::function<void(std::string_view, uint64_t)>;
 // Concept for a callable that compares two `string_view`s with respective
 // `isExternal` flags.
 template <typename T>
@@ -179,12 +187,15 @@ struct VocabularyMetaData {
 // is called for each merged word in the vocabulary in the order of their
 // appearance. Argument `blankNodePrefixes` is an optional pointer to a list of
 // regexes; words matching any of them are treated as blank nodes (see
-// `TripleComponentWithIndex::isBlankNode`).
+// `TripleComponentWithIndex::isBlankNode`). Argument `blankNodeIriCallback` is
+// invoked for every such IRI together with its assigned blank node index (see
+// `BlankNodeIriCallback`).
 template <typename W, typename C>
 auto mergeVocabulary(
     const std::string& basename, size_t numFiles, W comparator, C& wordCallback,
     ad_utility::MemorySize memoryToUse,
-    const std::vector<std::string>* blankNodePrefixes = nullptr)
+    const std::vector<std::string>* blankNodePrefixes = nullptr,
+    const BlankNodeIriCallback& blankNodeIriCallback = {})
     -> CPP_ret(VocabularyMetaData)(
         requires WordComparator<W>&& WordCallback<C>);
 
@@ -203,13 +214,17 @@ class VocabularyMerger {
   // Compiled regexes for IRIs that should be treated as blank nodes (see
   // `mergeVocabulary`). Empty if no such prefixes were specified.
   std::vector<std::unique_ptr<re2::RE2>> blankNodePrefixes_;
+  // Callback that remembers the mapping from a regex-matched IRI to its blank
+  // node index (see `BlankNodeIriCallback`). Empty if not needed.
+  BlankNodeIriCallback blankNodeIriCallback_;
 
   // Friend declaration for the publicly available function.
   template <typename W, typename C>
   friend auto mergeVocabulary(const std::string& basename, size_t numFiles,
                               W comparator, C& wordCallback,
                               ad_utility::MemorySize memoryToUse,
-                              const std::vector<std::string>* blankNodePrefixes)
+                              const std::vector<std::string>* blankNodePrefixes,
+                              const BlankNodeIriCallback& blankNodeIriCallback)
       -> CPP_ret(VocabularyMetaData)(
           requires WordComparator<W>&& WordCallback<C>);
   VocabularyMerger() = default;
@@ -221,7 +236,8 @@ class VocabularyMerger {
   auto mergeVocabulary(const std::string& basename, size_t numFiles,
                        W comparator, C& wordCallback,
                        ad_utility::MemorySize memoryToUse,
-                       const std::vector<std::string>* blankNodePrefixes)
+                       const std::vector<std::string>* blankNodePrefixes,
+                       const BlankNodeIriCallback& blankNodeIriCallback)
       -> CPP_ret(VocabularyMetaData)(
           requires WordComparator<W>&& WordCallback<C>);
 
@@ -273,6 +289,7 @@ class VocabularyMerger {
     lastTripleComponent_ = std::nullopt;
     idMaps_.clear();
     blankNodePrefixes_.clear();
+    blankNodeIriCallback_ = {};
   }
 };
 

--- a/src/index/VocabularyMerger.h
+++ b/src/index/VocabularyMerger.h
@@ -63,7 +63,6 @@ template <typename T>
 CPP_concept WordCallback =
     ad_utility::InvocableWithExactReturnType<T, uint64_t, std::string_view,
                                              bool>;
-
 // Concept for a callable that compares two `string_view`s with respective
 // `isExternal` flags.
 template <typename T>
@@ -178,14 +177,13 @@ struct VocabularyMetaData {
 // language tagged predicates. Argument `comparator` gives the way to order
 // strings (case-sensitive or not). Argument `wordCallback`
 // is called for each merged word in the vocabulary in the order of their
-// appearance. Argument `blankNodeIriRegexes` is an optional pointer to a list
-// of regexes; IRIs matching any of them are treated as blank nodes (see
+// appearance. Argument `blankNodeIriRegexes` is a (possibly empty) list of
+// regexes; IRIs matching any of them are treated as blank nodes (see
 // `TripleComponentWithIndex::isBlankNode`).
 template <typename W, typename C>
-auto mergeVocabulary(
-    const std::string& basename, size_t numFiles, W comparator, C& wordCallback,
-    ad_utility::MemorySize memoryToUse,
-    const std::vector<std::string>* blankNodeIriRegexes = nullptr)
+auto mergeVocabulary(const std::string& basename, size_t numFiles, W comparator,
+                     C& wordCallback, ad_utility::MemorySize memoryToUse,
+                     const std::vector<std::string>& blankNodeIriRegexes = {})
     -> CPP_ret(VocabularyMetaData)(
         requires WordComparator<W>&& WordCallback<C>);
 
@@ -214,7 +212,7 @@ class VocabularyMerger {
   friend auto mergeVocabulary(
       const std::string& basename, size_t numFiles, W comparator,
       C& wordCallback, ad_utility::MemorySize memoryToUse,
-      const std::vector<std::string>* blankNodeIriRegexes)
+      const std::vector<std::string>& blankNodeIriRegexes)
       -> CPP_ret(VocabularyMetaData)(
           requires WordComparator<W>&& WordCallback<C>);
   VocabularyMerger() = default;
@@ -226,7 +224,7 @@ class VocabularyMerger {
   auto mergeVocabulary(const std::string& basename, size_t numFiles,
                        W comparator, C& wordCallback,
                        ad_utility::MemorySize memoryToUse,
-                       const std::vector<std::string>* blankNodeIriRegexes)
+                       const std::vector<std::string>& blankNodeIriRegexes)
       -> CPP_ret(VocabularyMetaData)(
           requires WordComparator<W>&& WordCallback<C>);
 

--- a/src/index/VocabularyMerger.h
+++ b/src/index/VocabularyMerger.h
@@ -5,9 +5,11 @@
 #ifndef QLEVER_SRC_INDEX_VOCABULARYMERGER_H
 #define QLEVER_SRC_INDEX_VOCABULARYMERGER_H
 
+#include <memory>
 #include <optional>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "backports/StartsWithAndEndsWith.h"
 #include "backports/algorithm.h"
@@ -175,10 +177,14 @@ struct VocabularyMetaData {
 // language tagged predicates. Argument `comparator` gives the way to order
 // strings (case-sensitive or not). Argument `wordCallback`
 // is called for each merged word in the vocabulary in the order of their
-// appearance.
+// appearance. Argument `blankNodePrefixes` is an optional pointer to a list of
+// regexes; words matching any of them are treated as blank nodes (see
+// `TripleComponentWithIndex::isBlankNode`).
 template <typename W, typename C>
-auto mergeVocabulary(const std::string& basename, size_t numFiles, W comparator,
-                     C& wordCallback, ad_utility::MemorySize memoryToUse)
+auto mergeVocabulary(
+    const std::string& basename, size_t numFiles, W comparator, C& wordCallback,
+    ad_utility::MemorySize memoryToUse,
+    const std::vector<std::string>* blankNodePrefixes = nullptr)
     -> CPP_ret(VocabularyMetaData)(
         requires WordComparator<W>&& WordCallback<C>);
 
@@ -194,12 +200,16 @@ class VocabularyMerger {
   std::optional<TripleComponentWithIndex> lastTripleComponent_ = std::nullopt;
   // we will store pairs of <partialId, globalId>
   std::vector<IdMapWriter> idMaps_;
+  // Compiled regexes for IRIs that should be treated as blank nodes (see
+  // `mergeVocabulary`). Empty if no such prefixes were specified.
+  std::vector<std::unique_ptr<re2::RE2>> blankNodePrefixes_;
 
   // Friend declaration for the publicly available function.
   template <typename W, typename C>
   friend auto mergeVocabulary(const std::string& basename, size_t numFiles,
                               W comparator, C& wordCallback,
-                              ad_utility::MemorySize memoryToUse)
+                              ad_utility::MemorySize memoryToUse,
+                              const std::vector<std::string>* blankNodePrefixes)
       -> CPP_ret(VocabularyMetaData)(
           requires WordComparator<W>&& WordCallback<C>);
   VocabularyMerger() = default;
@@ -210,7 +220,8 @@ class VocabularyMerger {
   template <typename W, typename C>
   auto mergeVocabulary(const std::string& basename, size_t numFiles,
                        W comparator, C& wordCallback,
-                       ad_utility::MemorySize memoryToUse)
+                       ad_utility::MemorySize memoryToUse,
+                       const std::vector<std::string>* blankNodePrefixes)
       -> CPP_ret(VocabularyMetaData)(
           requires WordComparator<W>&& WordCallback<C>);
 
@@ -261,6 +272,7 @@ class VocabularyMerger {
     metaData_ = VocabularyMetaData{};
     lastTripleComponent_ = std::nullopt;
     idMaps_.clear();
+    blankNodePrefixes_.clear();
   }
 };
 

--- a/src/index/VocabularyMerger.h
+++ b/src/index/VocabularyMerger.h
@@ -5,7 +5,6 @@
 #ifndef QLEVER_SRC_INDEX_VOCABULARYMERGER_H
 #define QLEVER_SRC_INDEX_VOCABULARYMERGER_H
 
-#include <functional>
 #include <memory>
 #include <optional>
 #include <string>
@@ -65,12 +64,6 @@ CPP_concept WordCallback =
     ad_utility::InvocableWithExactReturnType<T, uint64_t, std::string_view,
                                              bool>;
 
-// A callback that is invoked for every IRI which is treated as a blank node
-// because it matched one of the `blankNodeIriRegexes` (not for `_:`-prefixed
-// blank nodes). It receives the IRI and the blank node index that was assigned
-// to it, so that the mapping can be remembered (see `BlankNodeIriVocabulary`).
-// The IRIs are passed in ascending (sorted) order.
-using BlankNodeIriCallback = std::function<void(std::string_view, uint64_t)>;
 // Concept for a callable that compares two `string_view`s with respective
 // `isExternal` flags.
 template <typename T>
@@ -186,16 +179,13 @@ struct VocabularyMetaData {
 // strings (case-sensitive or not). Argument `wordCallback`
 // is called for each merged word in the vocabulary in the order of their
 // appearance. Argument `blankNodeIriRegexes` is an optional pointer to a list
-// of regexes; words matching any of them are treated as blank nodes (see
-// `TripleComponentWithIndex::isBlankNode`). Argument `blankNodeIriCallback` is
-// invoked for every such IRI together with its assigned blank node index (see
-// `BlankNodeIriCallback`).
+// of regexes; IRIs matching any of them are treated as blank nodes (see
+// `TripleComponentWithIndex::isBlankNode`).
 template <typename W, typename C>
 auto mergeVocabulary(
     const std::string& basename, size_t numFiles, W comparator, C& wordCallback,
     ad_utility::MemorySize memoryToUse,
-    const std::vector<std::string>* blankNodeIriRegexes = nullptr,
-    const BlankNodeIriCallback& blankNodeIriCallback = {})
+    const std::vector<std::string>* blankNodeIriRegexes = nullptr)
     -> CPP_ret(VocabularyMetaData)(
         requires WordComparator<W>&& WordCallback<C>);
 
@@ -209,22 +199,22 @@ class VocabularyMerger {
   // The result (mostly metadata) which we'll return.
   VocabularyMetaData metaData_;
   std::optional<TripleComponentWithIndex> lastTripleComponent_ = std::nullopt;
+  // Whether `lastTripleComponent_` is a blank node. Cached here so that
+  // `isBlankNode` (which may run a set of regexes) is evaluated only once per
+  // distinct word.
+  bool lastTripleComponentIsBlankNode_ = false;
   // we will store pairs of <partialId, globalId>
   std::vector<IdMapWriter> idMaps_;
   // Compiled regexes for IRIs that should be treated as blank nodes (see
-  // `mergeVocabulary`). Empty if no such prefixes were specified.
+  // `mergeVocabulary`). Empty if no such regexes were specified.
   std::vector<std::unique_ptr<re2::RE2>> blankNodeIriRegexes_;
-  // Callback that remembers the mapping from a regex-matched IRI to its blank
-  // node index (see `BlankNodeIriCallback`). Empty if not needed.
-  BlankNodeIriCallback blankNodeIriCallback_;
 
   // Friend declaration for the publicly available function.
   template <typename W, typename C>
   friend auto mergeVocabulary(
       const std::string& basename, size_t numFiles, W comparator,
       C& wordCallback, ad_utility::MemorySize memoryToUse,
-      const std::vector<std::string>* blankNodeIriRegexes,
-      const BlankNodeIriCallback& blankNodeIriCallback)
+      const std::vector<std::string>* blankNodeIriRegexes)
       -> CPP_ret(VocabularyMetaData)(
           requires WordComparator<W>&& WordCallback<C>);
   VocabularyMerger() = default;
@@ -236,8 +226,7 @@ class VocabularyMerger {
   auto mergeVocabulary(const std::string& basename, size_t numFiles,
                        W comparator, C& wordCallback,
                        ad_utility::MemorySize memoryToUse,
-                       const std::vector<std::string>* blankNodeIriRegexes,
-                       const BlankNodeIriCallback& blankNodeIriCallback)
+                       const std::vector<std::string>* blankNodeIriRegexes)
       -> CPP_ret(VocabularyMetaData)(
           requires WordComparator<W>&& WordCallback<C>);
 
@@ -287,9 +276,9 @@ class VocabularyMerger {
   void clear() {
     metaData_ = VocabularyMetaData{};
     lastTripleComponent_ = std::nullopt;
+    lastTripleComponentIsBlankNode_ = false;
     idMaps_.clear();
     blankNodeIriRegexes_.clear();
-    blankNodeIriCallback_ = {};
   }
 };
 

--- a/src/index/VocabularyMerger.h
+++ b/src/index/VocabularyMerger.h
@@ -66,7 +66,7 @@ CPP_concept WordCallback =
                                              bool>;
 
 // A callback that is invoked for every IRI which is treated as a blank node
-// because it matched one of the `blankNodePrefixes` (not for `_:`-prefixed
+// because it matched one of the `blankNodeIriRegexes` (not for `_:`-prefixed
 // blank nodes). It receives the IRI and the blank node index that was assigned
 // to it, so that the mapping can be remembered (see `BlankNodeIriVocabulary`).
 // The IRIs are passed in ascending (sorted) order.
@@ -185,8 +185,8 @@ struct VocabularyMetaData {
 // language tagged predicates. Argument `comparator` gives the way to order
 // strings (case-sensitive or not). Argument `wordCallback`
 // is called for each merged word in the vocabulary in the order of their
-// appearance. Argument `blankNodePrefixes` is an optional pointer to a list of
-// regexes; words matching any of them are treated as blank nodes (see
+// appearance. Argument `blankNodeIriRegexes` is an optional pointer to a list
+// of regexes; words matching any of them are treated as blank nodes (see
 // `TripleComponentWithIndex::isBlankNode`). Argument `blankNodeIriCallback` is
 // invoked for every such IRI together with its assigned blank node index (see
 // `BlankNodeIriCallback`).
@@ -194,7 +194,7 @@ template <typename W, typename C>
 auto mergeVocabulary(
     const std::string& basename, size_t numFiles, W comparator, C& wordCallback,
     ad_utility::MemorySize memoryToUse,
-    const std::vector<std::string>* blankNodePrefixes = nullptr,
+    const std::vector<std::string>* blankNodeIriRegexes = nullptr,
     const BlankNodeIriCallback& blankNodeIriCallback = {})
     -> CPP_ret(VocabularyMetaData)(
         requires WordComparator<W>&& WordCallback<C>);
@@ -213,18 +213,18 @@ class VocabularyMerger {
   std::vector<IdMapWriter> idMaps_;
   // Compiled regexes for IRIs that should be treated as blank nodes (see
   // `mergeVocabulary`). Empty if no such prefixes were specified.
-  std::vector<std::unique_ptr<re2::RE2>> blankNodePrefixes_;
+  std::vector<std::unique_ptr<re2::RE2>> blankNodeIriRegexes_;
   // Callback that remembers the mapping from a regex-matched IRI to its blank
   // node index (see `BlankNodeIriCallback`). Empty if not needed.
   BlankNodeIriCallback blankNodeIriCallback_;
 
   // Friend declaration for the publicly available function.
   template <typename W, typename C>
-  friend auto mergeVocabulary(const std::string& basename, size_t numFiles,
-                              W comparator, C& wordCallback,
-                              ad_utility::MemorySize memoryToUse,
-                              const std::vector<std::string>* blankNodePrefixes,
-                              const BlankNodeIriCallback& blankNodeIriCallback)
+  friend auto mergeVocabulary(
+      const std::string& basename, size_t numFiles, W comparator,
+      C& wordCallback, ad_utility::MemorySize memoryToUse,
+      const std::vector<std::string>* blankNodeIriRegexes,
+      const BlankNodeIriCallback& blankNodeIriCallback)
       -> CPP_ret(VocabularyMetaData)(
           requires WordComparator<W>&& WordCallback<C>);
   VocabularyMerger() = default;
@@ -236,7 +236,7 @@ class VocabularyMerger {
   auto mergeVocabulary(const std::string& basename, size_t numFiles,
                        W comparator, C& wordCallback,
                        ad_utility::MemorySize memoryToUse,
-                       const std::vector<std::string>* blankNodePrefixes,
+                       const std::vector<std::string>* blankNodeIriRegexes,
                        const BlankNodeIriCallback& blankNodeIriCallback)
       -> CPP_ret(VocabularyMetaData)(
           requires WordComparator<W>&& WordCallback<C>);
@@ -288,7 +288,7 @@ class VocabularyMerger {
     metaData_ = VocabularyMetaData{};
     lastTripleComponent_ = std::nullopt;
     idMaps_.clear();
-    blankNodePrefixes_.clear();
+    blankNodeIriRegexes_.clear();
     blankNodeIriCallback_ = {};
   }
 };

--- a/src/index/VocabularyMerger.h
+++ b/src/index/VocabularyMerger.h
@@ -178,12 +178,14 @@ struct VocabularyMetaData {
 // strings (case-sensitive or not). Argument `wordCallback`
 // is called for each merged word in the vocabulary in the order of their
 // appearance. Argument `blankNodeIriRegexes` is a (possibly empty) list of
-// regexes; IRIs matching any of them are treated as blank nodes (see
-// `TripleComponentWithIndex::isBlankNode`).
+// compiled regexes; IRIs that are fully matched by any of them are treated as
+// blank nodes (see `TripleComponentWithIndex::isBlankNode`). The regexes are
+// compiled by the caller (see `IndexImpl::setBlankNodeIriRegexes`).
 template <typename W, typename C>
-auto mergeVocabulary(const std::string& basename, size_t numFiles, W comparator,
-                     C& wordCallback, ad_utility::MemorySize memoryToUse,
-                     const std::vector<std::string>& blankNodeIriRegexes = {})
+auto mergeVocabulary(
+    const std::string& basename, size_t numFiles, W comparator, C& wordCallback,
+    ad_utility::MemorySize memoryToUse,
+    const std::vector<std::unique_ptr<re2::RE2>>& blankNodeIriRegexes = {})
     -> CPP_ret(VocabularyMetaData)(
         requires WordComparator<W>&& WordCallback<C>);
 
@@ -203,16 +205,13 @@ class VocabularyMerger {
   bool lastTripleComponentIsBlankNode_ = false;
   // we will store pairs of <partialId, globalId>
   std::vector<IdMapWriter> idMaps_;
-  // Compiled regexes for IRIs that should be treated as blank nodes (see
-  // `mergeVocabulary`). Empty if no such regexes were specified.
-  std::vector<std::unique_ptr<re2::RE2>> blankNodeIriRegexes_;
 
   // Friend declaration for the publicly available function.
   template <typename W, typename C>
   friend auto mergeVocabulary(
       const std::string& basename, size_t numFiles, W comparator,
       C& wordCallback, ad_utility::MemorySize memoryToUse,
-      const std::vector<std::string>& blankNodeIriRegexes)
+      const std::vector<std::unique_ptr<re2::RE2>>& blankNodeIriRegexes)
       -> CPP_ret(VocabularyMetaData)(
           requires WordComparator<W>&& WordCallback<C>);
   VocabularyMerger() = default;
@@ -221,10 +220,10 @@ class VocabularyMerger {
   // The function that performs the actual merge. See the static global
   // `mergeVocabulary` function for details.
   template <typename W, typename C>
-  auto mergeVocabulary(const std::string& basename, size_t numFiles,
-                       W comparator, C& wordCallback,
-                       ad_utility::MemorySize memoryToUse,
-                       const std::vector<std::string>& blankNodeIriRegexes)
+  auto mergeVocabulary(
+      const std::string& basename, size_t numFiles, W comparator,
+      C& wordCallback, ad_utility::MemorySize memoryToUse,
+      const std::vector<std::unique_ptr<re2::RE2>>& blankNodeIriRegexes)
       -> CPP_ret(VocabularyMetaData)(
           requires WordComparator<W>&& WordCallback<C>);
 
@@ -265,9 +264,10 @@ class VocabularyMerger {
       requires WordCallback<C> CPP_and ranges::predicate<
           L, TripleComponentWithIndex, TripleComponentWithIndex>)
       // clang-format on
-      void writeQueueWordsToIdMap(std::vector<QueueWord>& buffer,
-                                  C& wordCallback, const L& lessThan,
-                                  ad_utility::ProgressBar& progressBar);
+      void writeQueueWordsToIdMap(
+          std::vector<QueueWord>& buffer, C& wordCallback, const L& lessThan,
+          const std::vector<std::unique_ptr<re2::RE2>>& blankNodeIriRegexes,
+          ad_utility::ProgressBar& progressBar);
 
   // Close all associated files and file-based vectors and reset all internal
   // variables.
@@ -276,7 +276,6 @@ class VocabularyMerger {
     lastTripleComponent_ = std::nullopt;
     lastTripleComponentIsBlankNode_ = false;
     idMaps_.clear();
-    blankNodeIriRegexes_.clear();
   }
 };
 

--- a/src/index/VocabularyMergerImpl.h
+++ b/src/index/VocabularyMergerImpl.h
@@ -30,14 +30,14 @@ template <typename W, typename C>
 auto mergeVocabulary(const std::string& basename, size_t numFiles, W comparator,
                      C& internalWordCallback,
                      ad_utility::MemorySize memoryToUse,
-                     const std::vector<std::string>* blankNodePrefixes,
+                     const std::vector<std::string>* blankNodeIriRegexes,
                      const BlankNodeIriCallback& blankNodeIriCallback)
     -> CPP_ret(VocabularyMetaData)(
         requires WordComparator<W>&& WordCallback<C>) {
   VocabularyMerger merger;
   return merger.mergeVocabulary(basename, numFiles, std::move(comparator),
                                 internalWordCallback, memoryToUse,
-                                blankNodePrefixes, blankNodeIriCallback);
+                                blankNodeIriRegexes, blankNodeIriCallback);
 }
 
 // _________________________________________________________________
@@ -45,14 +45,14 @@ template <typename W, typename C>
 auto VocabularyMerger::mergeVocabulary(
     const std::string& basename, size_t numFiles, W comparator, C& wordCallback,
     ad_utility::MemorySize memoryToUse,
-    const std::vector<std::string>* blankNodePrefixes,
+    const std::vector<std::string>* blankNodeIriRegexes,
     const BlankNodeIriCallback& blankNodeIriCallback)
     -> CPP_ret(VocabularyMetaData)(
         requires WordComparator<W>&& WordCallback<C>) {
   // Compile the regexes for the IRIs that should be treated as blank nodes.
-  if (blankNodePrefixes != nullptr) {
-    for (const auto& prefix : *blankNodePrefixes) {
-      blankNodePrefixes_.push_back(std::make_unique<re2::RE2>(prefix));
+  if (blankNodeIriRegexes != nullptr) {
+    for (const auto& prefix : *blankNodeIriRegexes) {
+      blankNodeIriRegexes_.push_back(std::make_unique<re2::RE2>(prefix));
     }
   }
   blankNodeIriCallback_ = blankNodeIriCallback;
@@ -145,10 +145,10 @@ CPP_template_def(typename C, typename L)(
 
       // Write the new word to the vocabulary.
       auto& nextWord = lastTripleComponent_.value();
-      if (nextWord.isBlankNode(&blankNodePrefixes_)) {
+      if (nextWord.isBlankNode(&blankNodeIriRegexes_)) {
         nextWord.index_ = metaData_.getNextBlankNodeIndex();
         // If this word is treated as a blank node because it matched one of the
-        // `blankNodePrefixes_` (i.e. it is an IRI, not a `_:`-prefixed blank
+        // `blankNodeIriRegexes_` (i.e. it is an IRI, not a `_:`-prefixed blank
         // node), remember the mapping from the IRI to the assigned blank node
         // index, so it can be applied consistently to later updates (see
         // `BlankNodeIriVocabulary`).
@@ -172,7 +172,7 @@ CPP_template_def(typename C, typename L)(
     }
     const auto& word = lastTripleComponent_.value();
     Id targetId =
-        word.isBlankNode(&blankNodePrefixes_)
+        word.isBlankNode(&blankNodeIriRegexes_)
             ? Id::makeFromBlankNodeIndex(BlankNodeIndex::make(word.index_))
             : Id::makeFromVocabIndex(VocabIndex::make(word.index_));
     // Write pair of local and global ID to buffer.

--- a/src/index/VocabularyMergerImpl.h
+++ b/src/index/VocabularyMergerImpl.h
@@ -30,14 +30,13 @@ template <typename W, typename C>
 auto mergeVocabulary(const std::string& basename, size_t numFiles, W comparator,
                      C& internalWordCallback,
                      ad_utility::MemorySize memoryToUse,
-                     const std::vector<std::string>* blankNodeIriRegexes,
-                     const BlankNodeIriCallback& blankNodeIriCallback)
+                     const std::vector<std::string>* blankNodeIriRegexes)
     -> CPP_ret(VocabularyMetaData)(
         requires WordComparator<W>&& WordCallback<C>) {
   VocabularyMerger merger;
   return merger.mergeVocabulary(basename, numFiles, std::move(comparator),
                                 internalWordCallback, memoryToUse,
-                                blankNodeIriRegexes, blankNodeIriCallback);
+                                blankNodeIriRegexes);
 }
 
 // _________________________________________________________________
@@ -45,17 +44,15 @@ template <typename W, typename C>
 auto VocabularyMerger::mergeVocabulary(
     const std::string& basename, size_t numFiles, W comparator, C& wordCallback,
     ad_utility::MemorySize memoryToUse,
-    const std::vector<std::string>* blankNodeIriRegexes,
-    const BlankNodeIriCallback& blankNodeIriCallback)
+    const std::vector<std::string>* blankNodeIriRegexes)
     -> CPP_ret(VocabularyMetaData)(
         requires WordComparator<W>&& WordCallback<C>) {
   // Compile the regexes for the IRIs that should be treated as blank nodes.
   if (blankNodeIriRegexes != nullptr) {
-    for (const auto& prefix : *blankNodeIriRegexes) {
-      blankNodeIriRegexes_.push_back(std::make_unique<re2::RE2>(prefix));
+    for (const auto& regex : *blankNodeIriRegexes) {
+      blankNodeIriRegexes_.push_back(std::make_unique<re2::RE2>(regex));
     }
   }
-  blankNodeIriCallback_ = blankNodeIriCallback;
 
   // Return true iff p1 >= p2 according to the lexicographic order of the IRI
   // or literal.
@@ -145,17 +142,10 @@ CPP_template_def(typename C, typename L)(
 
       // Write the new word to the vocabulary.
       auto& nextWord = lastTripleComponent_.value();
-      if (nextWord.isBlankNode(&blankNodeIriRegexes_)) {
+      lastTripleComponentIsBlankNode_ =
+          nextWord.isBlankNode(&blankNodeIriRegexes_);
+      if (lastTripleComponentIsBlankNode_) {
         nextWord.index_ = metaData_.getNextBlankNodeIndex();
-        // If this word is treated as a blank node because it matched one of the
-        // `blankNodeIriRegexes_` (i.e. it is an IRI, not a `_:`-prefixed blank
-        // node), remember the mapping from the IRI to the assigned blank node
-        // index, so it can be applied consistently to later updates (see
-        // `BlankNodeIriVocabulary`).
-        if (blankNodeIriCallback_ &&
-            !ql::starts_with(nextWord.iriOrLiteral(), "_:")) {
-          blankNodeIriCallback_(nextWord.iriOrLiteral(), nextWord.index_);
-        }
       } else {
         nextWord.index_ =
             wordCallback(nextWord.iriOrLiteral(), nextWord.isExternal());
@@ -172,7 +162,7 @@ CPP_template_def(typename C, typename L)(
     }
     const auto& word = lastTripleComponent_.value();
     Id targetId =
-        word.isBlankNode(&blankNodeIriRegexes_)
+        lastTripleComponentIsBlankNode_
             ? Id::makeFromBlankNodeIndex(BlankNodeIndex::make(word.index_))
             : Id::makeFromVocabIndex(VocabIndex::make(word.index_));
     // Write pair of local and global ID to buffer.

--- a/src/index/VocabularyMergerImpl.h
+++ b/src/index/VocabularyMergerImpl.h
@@ -29,22 +29,31 @@ namespace ad_utility::vocabulary_merger {
 template <typename W, typename C>
 auto mergeVocabulary(const std::string& basename, size_t numFiles, W comparator,
                      C& internalWordCallback,
-                     ad_utility::MemorySize memoryToUse)
+                     ad_utility::MemorySize memoryToUse,
+                     const std::vector<std::string>* blankNodePrefixes)
     -> CPP_ret(VocabularyMetaData)(
         requires WordComparator<W>&& WordCallback<C>) {
   VocabularyMerger merger;
   return merger.mergeVocabulary(basename, numFiles, std::move(comparator),
-                                internalWordCallback, memoryToUse);
+                                internalWordCallback, memoryToUse,
+                                blankNodePrefixes);
 }
 
 // _________________________________________________________________
 template <typename W, typename C>
-auto VocabularyMerger::mergeVocabulary(const std::string& basename,
-                                       size_t numFiles, W comparator,
-                                       C& wordCallback,
-                                       ad_utility::MemorySize memoryToUse)
+auto VocabularyMerger::mergeVocabulary(
+    const std::string& basename, size_t numFiles, W comparator, C& wordCallback,
+    ad_utility::MemorySize memoryToUse,
+    const std::vector<std::string>* blankNodePrefixes)
     -> CPP_ret(VocabularyMetaData)(
         requires WordComparator<W>&& WordCallback<C>) {
+  // Compile the regexes for the IRIs that should be treated as blank nodes.
+  if (blankNodePrefixes != nullptr) {
+    for (const auto& prefix : *blankNodePrefixes) {
+      blankNodePrefixes_.push_back(std::make_unique<re2::RE2>(prefix));
+    }
+  }
+
   // Return true iff p1 >= p2 according to the lexicographic order of the IRI
   // or literal.
   auto lessThan = [&comparator](const TripleComponentWithIndex& t1,
@@ -133,7 +142,7 @@ CPP_template_def(typename C, typename L)(
 
       // Write the new word to the vocabulary.
       auto& nextWord = lastTripleComponent_.value();
-      if (nextWord.isBlankNode()) {
+      if (nextWord.isBlankNode(&blankNodePrefixes_)) {
         nextWord.index_ = metaData_.getNextBlankNodeIndex();
       } else {
         nextWord.index_ =
@@ -151,7 +160,7 @@ CPP_template_def(typename C, typename L)(
     }
     const auto& word = lastTripleComponent_.value();
     Id targetId =
-        word.isBlankNode()
+        word.isBlankNode(&blankNodePrefixes_)
             ? Id::makeFromBlankNodeIndex(BlankNodeIndex::make(word.index_))
             : Id::makeFromVocabIndex(VocabIndex::make(word.index_));
     // Write pair of local and global ID to buffer.

--- a/src/index/VocabularyMergerImpl.h
+++ b/src/index/VocabularyMergerImpl.h
@@ -30,7 +30,7 @@ template <typename W, typename C>
 auto mergeVocabulary(const std::string& basename, size_t numFiles, W comparator,
                      C& internalWordCallback,
                      ad_utility::MemorySize memoryToUse,
-                     const std::vector<std::string>* blankNodeIriRegexes)
+                     const std::vector<std::string>& blankNodeIriRegexes)
     -> CPP_ret(VocabularyMetaData)(
         requires WordComparator<W>&& WordCallback<C>) {
   VocabularyMerger merger;
@@ -44,14 +44,12 @@ template <typename W, typename C>
 auto VocabularyMerger::mergeVocabulary(
     const std::string& basename, size_t numFiles, W comparator, C& wordCallback,
     ad_utility::MemorySize memoryToUse,
-    const std::vector<std::string>* blankNodeIriRegexes)
+    const std::vector<std::string>& blankNodeIriRegexes)
     -> CPP_ret(VocabularyMetaData)(
         requires WordComparator<W>&& WordCallback<C>) {
   // Compile the regexes for the IRIs that should be treated as blank nodes.
-  if (blankNodeIriRegexes != nullptr) {
-    for (const auto& regex : *blankNodeIriRegexes) {
-      blankNodeIriRegexes_.push_back(std::make_unique<re2::RE2>(regex));
-    }
+  for (const auto& regex : blankNodeIriRegexes) {
+    blankNodeIriRegexes_.push_back(std::make_unique<re2::RE2>(regex));
   }
 
   // Return true iff p1 >= p2 according to the lexicographic order of the IRI
@@ -135,6 +133,8 @@ CPP_template_def(typename C, typename L)(
       lastTripleComponent_ =
           TripleComponentWithIndex{std::move(top.iriOrLiteral()),
                                    top.isExternal(), metaData_.numWordsTotal()};
+      lastTripleComponentIsBlankNode_ =
+          lastTripleComponent_.value().isBlankNode(blankNodeIriRegexes_);
 
       // TODO<optimization> If we aim to further speed this up, we could
       // order all the write requests to _outfile _externalOutfile and all the
@@ -142,8 +142,6 @@ CPP_template_def(typename C, typename L)(
 
       // Write the new word to the vocabulary.
       auto& nextWord = lastTripleComponent_.value();
-      lastTripleComponentIsBlankNode_ =
-          nextWord.isBlankNode(&blankNodeIriRegexes_);
       if (lastTripleComponentIsBlankNode_) {
         nextWord.index_ = metaData_.getNextBlankNodeIndex();
       } else {

--- a/src/index/VocabularyMergerImpl.h
+++ b/src/index/VocabularyMergerImpl.h
@@ -30,13 +30,14 @@ template <typename W, typename C>
 auto mergeVocabulary(const std::string& basename, size_t numFiles, W comparator,
                      C& internalWordCallback,
                      ad_utility::MemorySize memoryToUse,
-                     const std::vector<std::string>* blankNodePrefixes)
+                     const std::vector<std::string>* blankNodePrefixes,
+                     const BlankNodeIriCallback& blankNodeIriCallback)
     -> CPP_ret(VocabularyMetaData)(
         requires WordComparator<W>&& WordCallback<C>) {
   VocabularyMerger merger;
   return merger.mergeVocabulary(basename, numFiles, std::move(comparator),
                                 internalWordCallback, memoryToUse,
-                                blankNodePrefixes);
+                                blankNodePrefixes, blankNodeIriCallback);
 }
 
 // _________________________________________________________________
@@ -44,7 +45,8 @@ template <typename W, typename C>
 auto VocabularyMerger::mergeVocabulary(
     const std::string& basename, size_t numFiles, W comparator, C& wordCallback,
     ad_utility::MemorySize memoryToUse,
-    const std::vector<std::string>* blankNodePrefixes)
+    const std::vector<std::string>* blankNodePrefixes,
+    const BlankNodeIriCallback& blankNodeIriCallback)
     -> CPP_ret(VocabularyMetaData)(
         requires WordComparator<W>&& WordCallback<C>) {
   // Compile the regexes for the IRIs that should be treated as blank nodes.
@@ -53,6 +55,7 @@ auto VocabularyMerger::mergeVocabulary(
       blankNodePrefixes_.push_back(std::make_unique<re2::RE2>(prefix));
     }
   }
+  blankNodeIriCallback_ = blankNodeIriCallback;
 
   // Return true iff p1 >= p2 according to the lexicographic order of the IRI
   // or literal.
@@ -144,6 +147,15 @@ CPP_template_def(typename C, typename L)(
       auto& nextWord = lastTripleComponent_.value();
       if (nextWord.isBlankNode(&blankNodePrefixes_)) {
         nextWord.index_ = metaData_.getNextBlankNodeIndex();
+        // If this word is treated as a blank node because it matched one of the
+        // `blankNodePrefixes_` (i.e. it is an IRI, not a `_:`-prefixed blank
+        // node), remember the mapping from the IRI to the assigned blank node
+        // index, so it can be applied consistently to later updates (see
+        // `BlankNodeIriVocabulary`).
+        if (blankNodeIriCallback_ &&
+            !ql::starts_with(nextWord.iriOrLiteral(), "_:")) {
+          blankNodeIriCallback_(nextWord.iriOrLiteral(), nextWord.index_);
+        }
       } else {
         nextWord.index_ =
             wordCallback(nextWord.iriOrLiteral(), nextWord.isExternal());

--- a/src/index/VocabularyMergerImpl.h
+++ b/src/index/VocabularyMergerImpl.h
@@ -27,10 +27,10 @@
 namespace ad_utility::vocabulary_merger {
 // _________________________________________________________________
 template <typename W, typename C>
-auto mergeVocabulary(const std::string& basename, size_t numFiles, W comparator,
-                     C& internalWordCallback,
-                     ad_utility::MemorySize memoryToUse,
-                     const std::vector<std::string>& blankNodeIriRegexes)
+auto mergeVocabulary(
+    const std::string& basename, size_t numFiles, W comparator,
+    C& internalWordCallback, ad_utility::MemorySize memoryToUse,
+    const std::vector<std::unique_ptr<re2::RE2>>& blankNodeIriRegexes)
     -> CPP_ret(VocabularyMetaData)(
         requires WordComparator<W>&& WordCallback<C>) {
   VocabularyMerger merger;
@@ -44,14 +44,9 @@ template <typename W, typename C>
 auto VocabularyMerger::mergeVocabulary(
     const std::string& basename, size_t numFiles, W comparator, C& wordCallback,
     ad_utility::MemorySize memoryToUse,
-    const std::vector<std::string>& blankNodeIriRegexes)
+    const std::vector<std::unique_ptr<re2::RE2>>& blankNodeIriRegexes)
     -> CPP_ret(VocabularyMetaData)(
         requires WordComparator<W>&& WordCallback<C>) {
-  // Compile the regexes for the IRIs that should be treated as blank nodes.
-  for (const auto& regex : blankNodeIriRegexes) {
-    blankNodeIriRegexes_.push_back(std::make_unique<re2::RE2>(regex));
-  }
-
   // Return true iff p1 >= p2 according to the lexicographic order of the IRI
   // or literal.
   auto lessThan = [&comparator](const TripleComponentWithIndex& t1,
@@ -99,7 +94,8 @@ auto VocabularyMerger::mergeVocabulary(
   ad_utility::ProgressBar progressBar{metaData_.numWordsTotal(),
                                       "Words merged: "};
   for (std::vector<QueueWord>& currentWords : mergedWords) {
-    writeQueueWordsToIdMap(currentWords, wordCallback, lessThan, progressBar);
+    writeQueueWordsToIdMap(currentWords, wordCallback, lessThan,
+                           blankNodeIriRegexes, progressBar);
   }
 
   AD_LOG_INFO << progressBar.getFinalProgressString() << std::flush;
@@ -115,9 +111,10 @@ CPP_template_def(typename C, typename L)(
     requires WordCallback<C> CPP_and_def
         ranges::predicate<L, TripleComponentWithIndex,
                           TripleComponentWithIndex>) void VocabularyMerger::
-    writeQueueWordsToIdMap(std::vector<QueueWord>& buffer, C& wordCallback,
-                           const L& lessThan,
-                           ad_utility::ProgressBar& progressBar) {
+    writeQueueWordsToIdMap(
+        std::vector<QueueWord>& buffer, C& wordCallback, const L& lessThan,
+        const std::vector<std::unique_ptr<re2::RE2>>& blankNodeIriRegexes,
+        ad_utility::ProgressBar& progressBar) {
   AD_LOG_TIMING << "Start writing a batch of merged words\n";
 
   // Iterate (avoid duplicates).
@@ -134,7 +131,7 @@ CPP_template_def(typename C, typename L)(
           TripleComponentWithIndex{std::move(top.iriOrLiteral()),
                                    top.isExternal(), metaData_.numWordsTotal()};
       lastTripleComponentIsBlankNode_ =
-          lastTripleComponent_.value().isBlankNode(blankNodeIriRegexes_);
+          lastTripleComponent_.value().isBlankNode(blankNodeIriRegexes);
 
       // TODO<optimization> If we aim to further speed this up, we could
       // order all the write requests to _outfile _externalOutfile and all the

--- a/src/libqlever/Qlever.cpp
+++ b/src/libqlever/Qlever.cpp
@@ -109,6 +109,7 @@ void Qlever::buildIndex(IndexBuilderConfig config) {
   index.addHasWordTriples() = config.addHasWordTriples_;
   index.getImpl().setVocabularyTypeForIndexBuilding(config.vocabType_);
   index.getImpl().setPrefixesForEncodedValues(config.prefixesForIdEncodedIris_);
+  index.getImpl().setBlankNodePrefixes(config.blankNodePrefixes_);
 
   // Build text index if requested (various options).
   if (!config.onlyAddTextIndex_) {

--- a/src/libqlever/Qlever.cpp
+++ b/src/libqlever/Qlever.cpp
@@ -109,7 +109,7 @@ void Qlever::buildIndex(IndexBuilderConfig config) {
   index.addHasWordTriples() = config.addHasWordTriples_;
   index.getImpl().setVocabularyTypeForIndexBuilding(config.vocabType_);
   index.getImpl().setPrefixesForEncodedValues(config.prefixesForIdEncodedIris_);
-  index.getImpl().setBlankNodePrefixes(config.blankNodePrefixes_);
+  index.getImpl().blankNodeIriRegexes() = config.blankNodeIriRegexes_;
 
   // Build text index if requested (various options).
   if (!config.onlyAddTextIndex_) {

--- a/src/libqlever/Qlever.cpp
+++ b/src/libqlever/Qlever.cpp
@@ -109,7 +109,7 @@ void Qlever::buildIndex(IndexBuilderConfig config) {
   index.addHasWordTriples() = config.addHasWordTriples_;
   index.getImpl().setVocabularyTypeForIndexBuilding(config.vocabType_);
   index.getImpl().setPrefixesForEncodedValues(config.prefixesForIdEncodedIris_);
-  index.getImpl().blankNodeIriRegexes() = config.blankNodeIriRegexes_;
+  index.getImpl().setBlankNodeIriRegexes(config.blankNodeIriRegexes_);
 
   // Build text index if requested (various options).
   if (!config.onlyAddTextIndex_) {

--- a/src/libqlever/Qlever.h
+++ b/src/libqlever/Qlever.h
@@ -108,12 +108,14 @@ struct IndexBuilderConfig : CommonConfig {
   bool keepTemporaryFiles_ = false;
 
   // A list of regexes for IRIs that should be treated as blank nodes. During
-  // index building, a vocabulary word that matches any of these regexes (via
-  // `RE2::PartialMatch`) is not stored in the vocabulary, but converted to a
-  // blank node. This is useful for IRIs that only act as internal connector
-  // nodes (e.g. statement nodes), to save vocabulary memory. See
-  // `IndexImpl::setBlankNodePrefixes`.
-  std::vector<std::string> blankNodePrefixes_;
+  // index building, an IRI that matches any of these regexes (via
+  // `RE2::PartialMatch`, applied to the full IRI text including the angle
+  // brackets) is not stored in the vocabulary, but converted to a blank node.
+  // This is useful for IRIs that only act as internal connector nodes (e.g.
+  // statement nodes), to save vocabulary memory. Only IRIs are affected;
+  // literals are never converted, even if a regex matches inside them. See
+  // `TripleComponentWithIndex::isBlankNode`.
+  std::vector<std::string> blankNodeIriRegexes_;
 
   // A list of IRI prefixes (without angle brackets). IRIs that start with one
   // of these prefixes, followed by a sequence of a bounded number of digits

--- a/src/libqlever/Qlever.h
+++ b/src/libqlever/Qlever.h
@@ -107,6 +107,14 @@ struct IndexBuilderConfig : CommonConfig {
   // building the index are not deleted. This can be useful for debugging.
   bool keepTemporaryFiles_ = false;
 
+  // A list of regexes for IRIs that should be treated as blank nodes. During
+  // index building, a vocabulary word that matches any of these regexes (via
+  // `RE2::PartialMatch`) is not stored in the vocabulary, but converted to a
+  // blank node. This is useful for IRIs that only act as internal connector
+  // nodes (e.g. statement nodes), to save vocabulary memory. See
+  // `IndexImpl::setBlankNodePrefixes`.
+  std::vector<std::string> blankNodePrefixes_;
+
   // A list of IRI prefixes (without angle brackets). IRIs that start with one
   // of these prefixes, followed by a sequence of a bounded number of digits
   // are encoded directly in the internal ID. This reduces the size of the

--- a/src/libqlever/Qlever.h
+++ b/src/libqlever/Qlever.h
@@ -113,8 +113,11 @@ struct IndexBuilderConfig : CommonConfig {
   // brackets) is not stored in the vocabulary, but converted to a blank node.
   // This is useful for IRIs that only act as internal connector nodes (e.g.
   // statement nodes), to save vocabulary memory. Only IRIs are affected;
-  // literals are never converted, even if a regex matches inside them. See
-  // `TripleComponentWithIndex::isBlankNode`.
+  // literals are never converted, even if a regex matches inside them.
+  //
+  // NOTE: This is an experimental feature. The affected IRIs behave as ordinary
+  // blank nodes, so they are no longer recognized as those IRIs if used, e.g.,
+  // in a query or an update. See `TripleComponentWithIndex::isBlankNode`.
   std::vector<std::string> blankNodeIriRegexes_;
 
   // A list of IRI prefixes (without angle brackets). IRIs that start with one

--- a/src/libqlever/Qlever.h
+++ b/src/libqlever/Qlever.h
@@ -108,12 +108,15 @@ struct IndexBuilderConfig : CommonConfig {
   bool keepTemporaryFiles_ = false;
 
   // A list of regexes for IRIs that should be treated as blank nodes. During
-  // index building, an IRI that matches any of these regexes (via
-  // `RE2::PartialMatch`, applied to the full IRI text including the angle
+  // index building, an IRI that is fully matched by one of these regexes (via
+  // `RE2::FullMatch`, applied to the full IRI text including the angle
   // brackets) is not stored in the vocabulary, but converted to a blank node.
-  // This is useful for IRIs that only act as internal connector nodes (e.g.
-  // statement nodes), to save vocabulary memory. Only IRIs are affected;
-  // literals are never converted, even if a regex matches inside them.
+  // The match has to cover the entire IRI, so each regex must describe a full
+  // IRI and therefore has to start with `<`; to allow an arbitrary suffix, end
+  // it with `.*` (e.g. `<https://example\.org/statement/.*>`). This is useful
+  // for IRIs that only act as internal connector nodes (e.g. statement nodes),
+  // to save vocabulary memory. Only IRIs are affected; literals are never
+  // converted.
   //
   // NOTE: This is an experimental feature. The affected IRIs behave as ordinary
   // blank nodes, so they are no longer recognized as those IRIs if used, e.g.,

--- a/test/IndexTest.cpp
+++ b/test/IndexTest.cpp
@@ -517,6 +517,24 @@ TEST(IndexTest, processTriple) {
 }
 
 // _____________________________________________________________________________
+// The regexes passed to `setBlankNodeIriRegexes` must describe full IRIs and
+// therefore have to start with `<`; otherwise the setter throws.
+TEST(IndexTest, setBlankNodeIriRegexesRequiresIriPatterns) {
+  IndexImpl index{ad_utility::makeUnlimitedAllocator<Id>()};
+
+  // A regex that does not start with `<` cannot describe a (full) IRI and is
+  // rejected, even if other regexes in the same call are valid.
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      index.setBlankNodeIriRegexes({"<http://ex/ok.*>", "http://ex/bad.*"}),
+      ::testing::HasSubstr("must therefore start with `<`"));
+
+  // Valid IRI regexes are accepted and stored.
+  index.setBlankNodeIriRegexes({"<http://ex/bn_.*>", "<http://ex/other>"});
+  EXPECT_THAT(index.getBlankNodeIriRegexes(),
+              ::testing::ElementsAre("<http://ex/bn_.*>", "<http://ex/other>"));
+}
+
+// _____________________________________________________________________________
 TEST(IndexTest, ZeroCopyVocabularyBlob) {
   IndexImpl index{ad_utility::makeUnlimitedAllocator<Id>()};
   auto& vocab = index.getNonConstVocabForTesting();

--- a/test/IndexTest.cpp
+++ b/test/IndexTest.cpp
@@ -8,6 +8,7 @@
 #include <absl/time/time.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <re2/re2.h>
 
 #include <chrono>
 #include <cstdio>
@@ -517,9 +518,10 @@ TEST(IndexTest, processTriple) {
 }
 
 // _____________________________________________________________________________
-// The regexes passed to `setBlankNodeIriRegexes` must describe full IRIs and
-// therefore have to start with `<`; otherwise the setter throws.
-TEST(IndexTest, setBlankNodeIriRegexesRequiresIriPatterns) {
+// The regexes passed to `setBlankNodeIriRegexes` must describe full IRIs (and
+// therefore have to start with `<`) and must be valid regular expressions;
+// otherwise the setter throws. Valid regexes are compiled and stored.
+TEST(IndexTest, setBlankNodeIriRegexesRequiresValidIriPatterns) {
   IndexImpl index{ad_utility::makeUnlimitedAllocator<Id>()};
 
   // A regex that does not start with `<` cannot describe a (full) IRI and is
@@ -528,10 +530,18 @@ TEST(IndexTest, setBlankNodeIriRegexesRequiresIriPatterns) {
       index.setBlankNodeIriRegexes({"<http://ex/ok.*>", "http://ex/bad.*"}),
       ::testing::HasSubstr("must therefore start with `<`"));
 
-  // Valid IRI regexes are accepted and stored.
+  // A regex that is not a valid regular expression is reported with a
+  // user-readable message (here: an unclosed group).
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      index.setBlankNodeIriRegexes({"<http://ex/(unclosed"}),
+      ::testing::HasSubstr("not a valid regular expression"));
+
+  // Valid IRI regexes are accepted, compiled, and stored (in order).
   index.setBlankNodeIriRegexes({"<http://ex/bn_.*>", "<http://ex/other>"});
-  EXPECT_THAT(index.getBlankNodeIriRegexes(),
-              ::testing::ElementsAre("<http://ex/bn_.*>", "<http://ex/other>"));
+  const auto& regexes = index.getBlankNodeIriRegexes();
+  ASSERT_EQ(regexes.size(), 2);
+  EXPECT_EQ(regexes.at(0)->pattern(), "<http://ex/bn_.*>");
+  EXPECT_EQ(regexes.at(1)->pattern(), "<http://ex/other>");
 }
 
 // _____________________________________________________________________________

--- a/test/VocabularyGeneratorTest.cpp
+++ b/test/VocabularyGeneratorTest.cpp
@@ -10,14 +10,12 @@
 #include <ctime>
 #include <fstream>
 #include <iostream>
-#include <set>
 #include <string>
 
 #include "./util/IdTestHelpers.h"
 #include "backports/StartsWithAndEndsWith.h"
 #include "backports/filesystem.h"
 #include "global/Constants.h"
-#include "global/ValueId.h"
 #include "index/ConstantsIndexBuilding.h"
 #include "index/Index.h"
 #include "index/Vocabulary.h"
@@ -320,7 +318,7 @@ TEST(MergeVocabulary, treatIrisAsBlankNodesViaRegex) {
       [](std::string_view a, bool, std::string_view b, bool) {
         return std::less{}(a, b);
       },
-      wordCallback, 1_GB, &blankNodeIriRegexes);
+      wordCallback, 1_GB, blankNodeIriRegexes);
 
   // Only the two `bn_` IRIs became blank nodes; the two other IRIs and the
   // (regex-matching but non-IRI) literal remain in the vocabulary, in sorted
@@ -343,15 +341,6 @@ TEST(MergeVocabulary, treatIrisAsBlankNodesViaRegex) {
                          {V(2), BN(0)},    // <http://ex/bn_1>
                          {V(3), BN(1)},    // <http://ex/bn_2>
                          {V(4), V(2)}}));  // <http://ex/cherry>
-
-  // The blank node ids are distinct from each other.
-  std::set<Id> blankNodeIds;
-  for (const auto& [localId, globalId] : idMap) {
-    if (globalId.getDatatype() == Datatype::BlankNodeIndex) {
-      blankNodeIds.insert(globalId);
-    }
-  }
-  EXPECT_EQ(blankNodeIds.size(), 2);
 }
 
 TEST(VocabularyGeneratorTest, createInternalMapping) {

--- a/test/VocabularyGeneratorTest.cpp
+++ b/test/VocabularyGeneratorTest.cpp
@@ -3,6 +3,7 @@
 // Authors: Johannes Kalmbach <kalmbacj@cs.uni-freiburg.de>
 //          Christoph Ullinger <ullingec@cs.uni-freiburg.de>
 
+#include <absl/cleanup/cleanup.h>
 #include <gmock/gmock.h>
 
 #include <cstdlib>
@@ -15,6 +16,7 @@
 #include "backports/StartsWithAndEndsWith.h"
 #include "backports/filesystem.h"
 #include "global/Constants.h"
+#include "global/ValueId.h"
 #include "index/ConstantsIndexBuilding.h"
 #include "index/Index.h"
 #include "index/Vocabulary.h"
@@ -23,6 +25,7 @@
 #include "index/vocabulary/SplitVocabulary.h"
 #include "index/vocabulary/VocabularyInternalExternal.h"
 #include "util/Algorithm.h"
+#include "util/File.h"
 #include "util/GTestHelpers.h"
 
 using namespace ad_utility::vocabulary_merger;
@@ -268,6 +271,70 @@ TEST(MergeVocabulary, mergeVocabularyAssertion) {
           },
           callback, 1_GB),
       ::testing::HasSubstr("vocabulary order violated"), ad_utility::Exception);
+}
+
+// _____________________________________________________________________________
+// Test that IRIs whose vocabulary word matches one of the `blankNodePrefixes`
+// regexes are treated as blank nodes during `mergeVocabulary`: they are not
+// passed to the vocabulary word callback, and are mapped to blank node `Id`s.
+TEST(MergeVocabulary, treatIrisAsBlankNodesViaRegex) {
+  std::string basePath = gtestCurrentTestName();
+  std::string wordsFile = absl::StrCat(basePath, PARTIAL_VOCAB_WORDS_INFIX, 0);
+  std::string idMapFile = absl::StrCat(basePath, PARTIAL_VOCAB_IDMAP_INFIX, 0);
+  absl::Cleanup cleanup = [&wordsFile, &idMapFile] {
+    ad_utility::deleteFile(wordsFile, false);
+    ad_utility::deleteFile(idMapFile, false);
+  };
+
+  // Write a single partial vocabulary. The words must be in ascending order
+  // according to the comparator used below (plain `std::less`).
+  std::array<std::string_view, 4> words{"<http://ex/apple>", "<http://ex/bn_1>",
+                                        "<http://ex/bn_2>",
+                                        "<http://ex/cherry>"};
+  {
+    ad_utility::serialization::FileWriteSerializer partialVocab(wordsFile);
+    partialVocab << words.size();
+    for (size_t localIdx = 0; localIdx < words.size(); ++localIdx) {
+      partialVocab << words.at(localIdx);
+      partialVocab << false;
+      partialVocab << localIdx;
+    }
+  }
+
+  // Collect the words that are actually written to the vocabulary (i.e. not
+  // treated as blank nodes).
+  std::vector<std::string> vocabularyWords;
+  auto wordCallback = [&vocabularyWords](std::string_view word,
+                                         bool) -> uint64_t {
+    vocabularyWords.emplace_back(word);
+    return vocabularyWords.size() - 1;
+  };
+
+  // Treat all IRIs that contain `bn_` as blank nodes.
+  std::vector<std::string> blankNodePrefixes{"bn_"};
+  mergeVocabulary(
+      basePath, 1,
+      [](std::string_view a, bool, std::string_view b, bool) {
+        return std::less{}(a, b);
+      },
+      wordCallback, 1_GB, &blankNodePrefixes);
+
+  // The two `bn_` IRIs became blank nodes; only the other two IRIs remain in
+  // the vocabulary.
+  EXPECT_THAT(vocabularyWords, ::testing::ElementsAre("<http://ex/apple>",
+                                                      "<http://ex/cherry>"));
+
+  // In the id map, exactly the two `bn_` IRIs map to blank node `Id`s, the
+  // other two to vocabulary `Id`s.
+  IdMap idMap = getIdMapFromFile(idMapFile);
+  size_t numBlankNodes = 0;
+  for (const auto& [localId, globalId] : idMap) {
+    if (globalId.getDatatype() == Datatype::BlankNodeIndex) {
+      ++numBlankNodes;
+    }
+  }
+  EXPECT_EQ(numBlankNodes, 2);
+  EXPECT_EQ(idMap.size(), words.size());
 }
 
 TEST(VocabularyGeneratorTest, createInternalMapping) {

--- a/test/VocabularyGeneratorTest.cpp
+++ b/test/VocabularyGeneratorTest.cpp
@@ -10,6 +10,7 @@
 #include <ctime>
 #include <fstream>
 #include <iostream>
+#include <set>
 #include <string>
 
 #include "./util/IdTestHelpers.h"
@@ -46,6 +47,22 @@ bool vocabTestCompare(const IdMap& a, const std::vector<std::pair<Id, Id>>& b) {
 }
 
 auto V = ad_utility::testing::VocabId;
+
+// Write the given `words` as a partial vocabulary file at `path`, assigning
+// them consecutive local ids `0, 1, ...` in the given order and marking all of
+// them as not external.
+template <typename Range>
+void writePartialVocabularyFile(const std::string& path, const Range& words) {
+  ad_utility::serialization::FileWriteSerializer partialVocab(path);
+  partialVocab << words.size();
+  size_t localIdx = 0;
+  for (const auto& word : words) {
+    partialVocab << std::string_view{word};
+    partialVocab << false;
+    partialVocab << localIdx;
+    ++localIdx;
+  }
+}
 }  // namespace
 
 // Test fixture that sets up the binary files for partial vocabulary and
@@ -246,22 +263,12 @@ TEST(MergeVocabulary, mergeVocabularyAssertion) {
 
   std::string basePath = gtestCurrentTestName();
 
-  auto writeUnorderedFile = [](const auto& path) {
-    ad_utility::serialization::FileWriteSerializer partialVocab(path);
-    // Intentionally in wrong order.
-    std::array<std::string_view, 3> strings{"\"c\"", "\"b\"", "\"a\""};
-    partialVocab << strings.size();
-    size_t localIdx = 0;
-    for (auto s : strings) {
-      partialVocab << s;
-      partialVocab << false;
-      partialVocab << localIdx;
-      localIdx++;
-    }
-  };
-
-  writeUnorderedFile(absl::StrCat(basePath, PARTIAL_VOCAB_WORDS_INFIX, 0));
-  writeUnorderedFile(absl::StrCat(basePath, PARTIAL_VOCAB_WORDS_INFIX, 1));
+  // Intentionally in wrong order, so that the merge detects a violated order.
+  std::array<std::string_view, 3> unorderedWords{"\"c\"", "\"b\"", "\"a\""};
+  writePartialVocabularyFile(
+      absl::StrCat(basePath, PARTIAL_VOCAB_WORDS_INFIX, 0), unorderedWords);
+  writePartialVocabularyFile(
+      absl::StrCat(basePath, PARTIAL_VOCAB_WORDS_INFIX, 1), unorderedWords);
 
   AD_EXPECT_THROW_WITH_MESSAGE_AND_TYPE(
       mergeVocabulary(
@@ -274,9 +281,10 @@ TEST(MergeVocabulary, mergeVocabularyAssertion) {
 }
 
 // _____________________________________________________________________________
-// Test that IRIs whose vocabulary word matches one of the `blankNodePrefixes`
-// regexes are treated as blank nodes during `mergeVocabulary`: they are not
-// passed to the vocabulary word callback, and are mapped to blank node `Id`s.
+// Test that IRIs matching one of the `blankNodeIriRegexes` are treated as blank
+// nodes during `mergeVocabulary` (not passed to the vocabulary word callback,
+// and mapped to blank node `Id`s), while other IRIs and, in particular,
+// literals that match a regex are left untouched.
 TEST(MergeVocabulary, treatIrisAsBlankNodesViaRegex) {
   std::string basePath = gtestCurrentTestName();
   std::string wordsFile = absl::StrCat(basePath, PARTIAL_VOCAB_WORDS_INFIX, 0);
@@ -286,23 +294,18 @@ TEST(MergeVocabulary, treatIrisAsBlankNodesViaRegex) {
     ad_utility::deleteFile(idMapFile, false);
   };
 
-  // Write a single partial vocabulary. The words must be in ascending order
-  // according to the comparator used below (plain `std::less`).
-  std::array<std::string_view, 4> words{"<http://ex/apple>", "<http://ex/bn_1>",
-                                        "<http://ex/bn_2>",
+  // A single partial vocabulary. The words must be in ascending order according
+  // to the comparator used below (plain `std::less`); note that literals (which
+  // start with `"`) sort before IRIs (which start with `<`). The literal
+  // `"bn_lit"` also matches the regex below, but must NOT be treated as a blank
+  // node because only IRIs are.
+  std::array<std::string_view, 5> words{"\"bn_lit\"", "<http://ex/apple>",
+                                        "<http://ex/bn_1>", "<http://ex/bn_2>",
                                         "<http://ex/cherry>"};
-  {
-    ad_utility::serialization::FileWriteSerializer partialVocab(wordsFile);
-    partialVocab << words.size();
-    for (size_t localIdx = 0; localIdx < words.size(); ++localIdx) {
-      partialVocab << words.at(localIdx);
-      partialVocab << false;
-      partialVocab << localIdx;
-    }
-  }
+  writePartialVocabularyFile(wordsFile, words);
 
   // Collect the words that are actually written to the vocabulary (i.e. not
-  // treated as blank nodes).
+  // treated as blank nodes), together with the vocabulary index they get.
   std::vector<std::string> vocabularyWords;
   auto wordCallback = [&vocabularyWords](std::string_view word,
                                          bool) -> uint64_t {
@@ -311,30 +314,44 @@ TEST(MergeVocabulary, treatIrisAsBlankNodesViaRegex) {
   };
 
   // Treat all IRIs that contain `bn_` as blank nodes.
-  std::vector<std::string> blankNodePrefixes{"bn_"};
+  std::vector<std::string> blankNodeIriRegexes{"bn_"};
   mergeVocabulary(
       basePath, 1,
       [](std::string_view a, bool, std::string_view b, bool) {
         return std::less{}(a, b);
       },
-      wordCallback, 1_GB, &blankNodePrefixes);
+      wordCallback, 1_GB, &blankNodeIriRegexes);
 
-  // The two `bn_` IRIs became blank nodes; only the other two IRIs remain in
-  // the vocabulary.
-  EXPECT_THAT(vocabularyWords, ::testing::ElementsAre("<http://ex/apple>",
-                                                      "<http://ex/cherry>"));
+  // Only the two `bn_` IRIs became blank nodes; the two other IRIs and the
+  // (regex-matching but non-IRI) literal remain in the vocabulary, in sorted
+  // order.
+  EXPECT_THAT(vocabularyWords,
+              ::testing::ElementsAre("\"bn_lit\"", "<http://ex/apple>",
+                                     "<http://ex/cherry>"));
 
-  // In the id map, exactly the two `bn_` IRIs map to blank node `Id`s, the
-  // other two to vocabulary `Id`s.
+  // Check the exact id mapping. The local ids `0..4` are assigned in the input
+  // (sorted) order above; the two `bn_` IRIs get consecutive, distinct blank
+  // node ids, the other three words get vocabulary ids in their appearance
+  // order.
+  auto BN = [](uint64_t index) {
+    return Id::makeFromBlankNodeIndex(BlankNodeIndex::make(index));
+  };
   IdMap idMap = getIdMapFromFile(idMapFile);
-  size_t numBlankNodes = 0;
+  EXPECT_THAT(idMap, ::testing::ElementsAreArray(std::vector<std::pair<Id, Id>>{
+                         {V(0), V(0)},     // "bn_lit"
+                         {V(1), V(1)},     // <http://ex/apple>
+                         {V(2), BN(0)},    // <http://ex/bn_1>
+                         {V(3), BN(1)},    // <http://ex/bn_2>
+                         {V(4), V(2)}}));  // <http://ex/cherry>
+
+  // The blank node ids are distinct from each other.
+  std::set<Id> blankNodeIds;
   for (const auto& [localId, globalId] : idMap) {
     if (globalId.getDatatype() == Datatype::BlankNodeIndex) {
-      ++numBlankNodes;
+      blankNodeIds.insert(globalId);
     }
   }
-  EXPECT_EQ(numBlankNodes, 2);
-  EXPECT_EQ(idMap.size(), words.size());
+  EXPECT_EQ(blankNodeIds.size(), 2);
 }
 
 TEST(VocabularyGeneratorTest, createInternalMapping) {

--- a/test/VocabularyGeneratorTest.cpp
+++ b/test/VocabularyGeneratorTest.cpp
@@ -5,11 +5,13 @@
 
 #include <absl/cleanup/cleanup.h>
 #include <gmock/gmock.h>
+#include <re2/re2.h>
 
 #include <cstdlib>
 #include <ctime>
 #include <fstream>
 #include <iostream>
+#include <memory>
 #include <string>
 
 #include "./util/IdTestHelpers.h"
@@ -310,14 +312,16 @@ TEST(MergeVocabulary, treatIrisAsBlankNodesViaRegex) {
     return vocabularyWords.size() - 1;
   };
 
-  // Two regexes:
+  // Two (compiled) regexes:
   // - `<http://ex/bn_.*>` fully matches the two `bn_` IRIs (and neither the
   //   `"bn_lit"` literal, which is not an IRI, nor the other IRIs).
   // - `<http://ex/apple` only matches a prefix of `<http://ex/apple>` (the
   //   closing `>` is missing), so with *full* match it converts nothing. With a
   //   partial match it would have wrongly converted `<http://ex/apple>`.
-  std::vector<std::string> blankNodeIriRegexes{"<http://ex/bn_.*>",
-                                               "<http://ex/apple"};
+  std::vector<std::unique_ptr<re2::RE2>> blankNodeIriRegexes;
+  for (const char* pattern : {"<http://ex/bn_.*>", "<http://ex/apple"}) {
+    blankNodeIriRegexes.push_back(std::make_unique<re2::RE2>(pattern));
+  }
   mergeVocabulary(
       basePath, 1,
       [](std::string_view a, bool, std::string_view b, bool) {

--- a/test/VocabularyGeneratorTest.cpp
+++ b/test/VocabularyGeneratorTest.cpp
@@ -279,10 +279,11 @@ TEST(MergeVocabulary, mergeVocabularyAssertion) {
 }
 
 // _____________________________________________________________________________
-// Test that IRIs matching one of the `blankNodeIriRegexes` are treated as blank
-// nodes during `mergeVocabulary` (not passed to the vocabulary word callback,
-// and mapped to blank node `Id`s), while other IRIs and, in particular,
-// literals that match a regex are left untouched.
+// Test that IRIs fully matched by one of the `blankNodeIriRegexes` are treated
+// as blank nodes during `mergeVocabulary` (not passed to the vocabulary word
+// callback, and mapped to blank node `Id`s), while non-matching IRIs and
+// literals are left untouched. In particular, matching is a *full* match, so a
+// regex that only matches a prefix of an IRI does not convert it.
 TEST(MergeVocabulary, treatIrisAsBlankNodesViaRegex) {
   std::string basePath = gtestCurrentTestName();
   std::string wordsFile = absl::StrCat(basePath, PARTIAL_VOCAB_WORDS_INFIX, 0);
@@ -294,9 +295,7 @@ TEST(MergeVocabulary, treatIrisAsBlankNodesViaRegex) {
 
   // A single partial vocabulary. The words must be in ascending order according
   // to the comparator used below (plain `std::less`); note that literals (which
-  // start with `"`) sort before IRIs (which start with `<`). The literal
-  // `"bn_lit"` also matches the regex below, but must NOT be treated as a blank
-  // node because only IRIs are.
+  // start with `"`) sort before IRIs (which start with `<`).
   std::array<std::string_view, 5> words{"\"bn_lit\"", "<http://ex/apple>",
                                         "<http://ex/bn_1>", "<http://ex/bn_2>",
                                         "<http://ex/cherry>"};
@@ -311,8 +310,14 @@ TEST(MergeVocabulary, treatIrisAsBlankNodesViaRegex) {
     return vocabularyWords.size() - 1;
   };
 
-  // Treat all IRIs that contain `bn_` as blank nodes.
-  std::vector<std::string> blankNodeIriRegexes{"bn_"};
+  // Two regexes:
+  // - `<http://ex/bn_.*>` fully matches the two `bn_` IRIs (and neither the
+  //   `"bn_lit"` literal, which is not an IRI, nor the other IRIs).
+  // - `<http://ex/apple` only matches a prefix of `<http://ex/apple>` (the
+  //   closing `>` is missing), so with *full* match it converts nothing. With a
+  //   partial match it would have wrongly converted `<http://ex/apple>`.
+  std::vector<std::string> blankNodeIriRegexes{"<http://ex/bn_.*>",
+                                               "<http://ex/apple"};
   mergeVocabulary(
       basePath, 1,
       [](std::string_view a, bool, std::string_view b, bool) {
@@ -321,8 +326,7 @@ TEST(MergeVocabulary, treatIrisAsBlankNodesViaRegex) {
       wordCallback, 1_GB, blankNodeIriRegexes);
 
   // Only the two `bn_` IRIs became blank nodes; the two other IRIs and the
-  // (regex-matching but non-IRI) literal remain in the vocabulary, in sorted
-  // order.
+  // literal remain in the vocabulary, in sorted order.
   EXPECT_THAT(vocabularyWords,
               ::testing::ElementsAre("\"bn_lit\"", "<http://ex/apple>",
                                      "<http://ex/cherry>"));

--- a/test/VocabularyGeneratorTest.cpp
+++ b/test/VocabularyGeneratorTest.cpp
@@ -157,7 +157,7 @@ class MergeVocabularyTest : public ::testing::Test {
             w.index_ = localIdx;
             partialVocab << w;
             if (mapping) {
-              if (w.isBlankNode()) {
+              if (w.isBlankNode({})) {
                 mapping->emplace_back(
                     V(localIdx),
                     Id::makeFromBlankNodeIndex(BlankNodeIndex::make(globalId)));


### PR DESCRIPTION
There is now an option `--iri-as-blank-node-regexes` for the index builder that takes a list of regexes. An IRI that is fully matched by one of the regexes is not stored in the vocabulary, but converted to a blank node. This saves vocabulary space for IRIs that only act as internal connector nodes (for example, statement nodes). The regexes are matched against the full IRI including the angle brackets, so each regex has to start with `<`; for example, `--iri-as-blank-node-regexes '<https://example\.org/statement/.*>'` converts all IRIs with that prefix. Occurrences of the same IRI in different input files that are indexed together are fused into the same blank node.

NOTE: The original IRIs are lost. The affected IRIs behave exactly like ordinary blank nodes; in particular, they are no longer recognized as those IRIs when used in a query or an update.