### PR TITLE
Fix the codecov and SonarCloud uploads and bump `actions/checkout` to v7

### DIFF
--- a/.github/workflows/check_index_version.yml
+++ b/.github/workflows/check_index_version.yml
@@ -31,11 +31,11 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         submodules: 'recursive'
         path: 'pr'
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         submodules: 'recursive'
         path: 'master'

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -41,7 +41,7 @@ jobs:
 
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         submodules: "recursive"
 

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -18,6 +18,6 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Codespell
         uses: codespell-project/actions-codespell@v2

--- a/.github/workflows/cpp-17-libqlever.yml
+++ b/.github/workflows/cpp-17-libqlever.yml
@@ -44,7 +44,7 @@ jobs:
       compiler: gcc
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           submodules: 'recursive'
       - name: Install dependencies

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         # Generate metadata for the docker image based on the GH Actions environment.
       - name: Generate image metadata
         id: meta
@@ -102,7 +102,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Generate image metadata
         id: meta
         uses: docker/metadata-action@v6

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Install dependencies
         run: |
           # The version in the default Ubuntu repositories is too old (and has some breaking changes),

--- a/.github/workflows/macos-appleclang-native.yml
+++ b/.github/workflows/macos-appleclang-native.yml
@@ -27,7 +27,7 @@ jobs:
         build-type: [Release]
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install dependencies via Homebrew
         run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -29,7 +29,7 @@ jobs:
     env:
       LLVM_VERSION: 17
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install ICU dependency for python (only needed for E2E test)
         run: |

--- a/.github/workflows/native-build-conan.yml
+++ b/.github/workflows/native-build-conan.yml
@@ -30,7 +30,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         submodules: 'recursive'
 

--- a/.github/workflows/native-build-with-conan-and-emscripten.yml
+++ b/.github/workflows/native-build-with-conan-and-emscripten.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
 

--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Skip early if conditions are not met
         if: (github.event_name == 'pull_request' && matrix.skipIfPr)
         run: exit 0;
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           submodules: 'recursive'
       - name: Install dependencies

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         submodules: 'recursive'
 

--- a/.github/workflows/sparql-conformance.yml
+++ b/.github/workflows/sparql-conformance.yml
@@ -20,17 +20,17 @@ jobs:
       cmake-flags: "-DCMAKE_C_COMPILER=clang-16 -DCMAKE_CXX_COMPILER=clang++-16"
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           submodules: "recursive"
           path: qlever-code
       - name: Checkout sparql-test-suite-files
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: "w3c/rdf-tests"
           path: sparql-test-suite
       - name: Checkout qlever-test-suite
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: "ad-freiburg/sparql-conformance"
           path: qlever-test-suite

--- a/.github/workflows/upload-coverage.yml
+++ b/.github/workflows/upload-coverage.yml
@@ -70,13 +70,28 @@ jobs:
         # subdirectory `qlever-source`, otherwise the coverage report will
         # be overwritten. We then move all the files back into the working
         # directory such that Codecov will pick them up properly.
+      # SECURITY: This workflow runs on the `workflow_run` trigger and therefore
+      # has access to the repository secrets (see the note at the top of this
+      # file). Here we check out the (possibly forked) PR's head code. Since
+      # `actions/checkout` v6.1.0/v7 this is refused by default for
+      # `pull_request_target`/`workflow_run` to prevent "pwn requests"
+      # (https://gh.io/securely-using-pull_request_target), so we opt in
+      # explicitly via `allow-unsafe-pr-checkout`. This is acceptable here
+      # because the checked-out sources are only ever used as *data*: they are
+      # never built or executed in this job (we only move a `coverage.lcov` file
+      # into place and hand the sources to the Codecov uploader for path
+      # mapping). As defense in depth we also set `persist-credentials: false`
+      # so the `GITHUB_TOKEN` is not written into `.git/config` (no subsequent
+      # step performs authenticated git operations).
       - name: "Checkout"
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: ${{env.original_github_repository}}
           submodules: "recursive"
           ref: ${{env.original_github_ref}}
           path: qlever-source
+          allow-unsafe-pr-checkout: true
+          persist-credentials: false
       - name: "Move qlever sources up"
         run: shopt -s dotglob && mv qlever-source/* .
       # For the new version of the codecov action we have to move the coverage file back to its original location,

--- a/.github/workflows/upload-sonarcloud.yml
+++ b/.github/workflows/upload-sonarcloud.yml
@@ -98,14 +98,33 @@ jobs:
           full_name: ${{ github.event.repository.full_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # SECURITY: This workflow runs on the `workflow_run` trigger and therefore
+      # has access to the repository secrets (see the note at the top of this
+      # file). Here we check out the (possibly forked) PR's head code, which is
+      # subsequently *built* below in order to run the SonarCloud analysis.
+      # Since `actions/checkout` v6.1.0/v7 checking out fork PR code is refused
+      # by default for `pull_request_target`/`workflow_run` to prevent "pwn
+      # requests" (https://gh.io/securely-using-pull_request_target), so we opt
+      # in explicitly via `allow-unsafe-pr-checkout`.
+      #
+      # Building untrusted PR code with secrets available is an inherent
+      # requirement of SonarCloud's C/C++ PR analysis (the code must be compiled
+      # to be analyzed) and cannot be avoided. The residual risk is contained as
+      # follows: `SONAR_TOKEN` and `GITHUB_TOKEN` are NOT exposed to the build
+      # step (they are set as step-level `env:` only on the API/scanner steps),
+      # the workflow's `GITHUB_TOKEN` is read-only (see `permissions:` above),
+      # and `persist-credentials: false` keeps that token out of `.git/config`
+      # so the build cannot read it from there.
       - name: "Checkout"
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: ${{ github.event.workflow_run.head_repository.full_name }}
           ref: ${{ github.event.workflow_run.head_branch }}
           fetch-depth: 0
           submodules: "recursive"
           path: qlever-source
+          allow-unsafe-pr-checkout: true
+          persist-credentials: false
       - name: Checkout base branch
         working-directory: qlever-source
         if: github.event.workflow_run.event == 'pull_request'


### PR DESCRIPTION
The upload workflows for codecov and SonarCloud have recently been failing on master. The reason is a security fix in `actions/checkout`: since version 6.1.0, a workflow that has access to the repository secrets refuses to check out the code of a pull request from a fork, unless it explicitly declares that this is safe. Our two upload workflows are of exactly this kind: they run with access to the upload tokens and need the code of the pull request.

They now opt in via the new option `allow-unsafe-pr-checkout`, each with a comment that explains why this is safe (the coverage upload only reads the checked-out files; the SonarCloud analysis has to compile the code, but the tokens are only visible to the steps that talk to the SonarCloud and GitHub APIs). In addition, `persist-credentials: false` makes sure that the checkout does not store the `GITHUB_TOKEN` in the checked-out repository. All other workflows are bumped from `checkout@v6` to `checkout@v7` as well.