### PR TITLE
Add the `--log-level` option to `qlever-index`

### DIFF
--- a/src/ServerMain.cpp
+++ b/src/ServerMain.cpp
@@ -210,12 +210,15 @@ int main(int argc, char** argv) {
       "prefix are rejected. To disable all federated queries, set this option "
       "to an invalid IRI prefix like `-`. Magic services (for example spatial "
       "search or materialized views) are never affected.");
+  auto logLevelDescription = absl::StrCat(
+      "Runtime log level: FATAL, ERROR, WARN, INFO, DEBUG, TIMING, or TRACE. "
+      "Default is INFO. The compile-time level (",
+      LogLevel{LOGLEVEL}.toString(),
+      ") applies as an upper bound — messages above it are never emitted "
+      "regardless of this setting.");
   add("log-level",
       optionFactory.getProgramOption<&RuntimeParameters::logLevel_>(),
-      "Runtime log level: FATAL, ERROR, WARN, INFO, DEBUG, TIMING, or TRACE. "
-      "Default is INFO. The compile-time level (CMake -DLOGLEVEL=...) applies "
-      "as an upper bound — messages above it are never emitted regardless of "
-      "this setting.");
+      logLevelDescription.c_str());
   add("construct-deduplication",
       optionFactory
           .getProgramOption<&RuntimeParameters::constructDeduplication_>(),

--- a/src/index/IndexBuilderMain.cpp
+++ b/src/index/IndexBuilderMain.cpp
@@ -197,6 +197,9 @@ int main(int argc, char** argv) {
   bool noResourceUsageLog = false;
   uint32_t resourceUsageIntervalS = 1;
 
+  ad_utility::ParameterToProgramOptionFactory optionFactory{
+      &globalRuntimeParameters};
+
   boost::program_options::options_description boostOptions(
       "Options for qlever-index");
   auto add = [&boostOptions](auto&&... args) {
@@ -302,6 +305,12 @@ int main(int argc, char** argv) {
   add("resource-usage-interval-s",
       po::value(&resourceUsageIntervalS)->default_value(1),
       "The sampling interval of the resource-usage log in seconds.");
+  add("log-level",
+      optionFactory.getProgramOption<&RuntimeParameters::logLevel_>(),
+      "Runtime log level: FATAL, ERROR, WARN, INFO, DEBUG, TIMING, or TRACE. "
+      "Default is INFO. The compile-time level (CMake -DLOGLEVEL=...) applies "
+      "as an upper bound — messages above it are never emitted regardless of "
+      "this setting.");
 
   // Process command line arguments.
   po::variables_map optionsMap;

--- a/src/index/IndexBuilderMain.cpp
+++ b/src/index/IndexBuilderMain.cpp
@@ -305,12 +305,15 @@ int main(int argc, char** argv) {
   add("resource-usage-interval-s",
       po::value(&resourceUsageIntervalS)->default_value(1),
       "The sampling interval of the resource-usage log in seconds.");
+  auto logLevelDescription = absl::StrCat(
+      "Runtime log level: FATAL, ERROR, WARN, INFO, DEBUG, TIMING, or TRACE. "
+      "Default is INFO. The compile-time level (",
+      LogLevel{LOGLEVEL}.toString(),
+      ") applies as an upper bound — messages above it are never emitted "
+      "regardless of this setting.");
   add("log-level",
       optionFactory.getProgramOption<&RuntimeParameters::logLevel_>(),
-      "Runtime log level: FATAL, ERROR, WARN, INFO, DEBUG, TIMING, or TRACE. "
-      "Default is INFO. The compile-time level (CMake -DLOGLEVEL=...) applies "
-      "as an upper bound — messages above it are never emitted regardless of "
-      "this setting.");
+      logLevelDescription.c_str());
 
   // Process command line arguments.
   po::variables_map optionsMap;

--- a/src/util/Log.h
+++ b/src/util/Log.h
@@ -25,7 +25,7 @@
 #include "util/TypeTraits.h"
 
 #ifndef LOGLEVEL
-#define LOGLEVEL INFO
+#define LOGLEVEL DEBUG
 #endif
 
 namespace ad_utility {


### PR DESCRIPTION
The `qlever-index` binary now has the same `--log-level` option as `qlever-server`: it sets the runtime log level (FATAL, ERROR, WARN, INFO, DEBUG, TIMING, or TRACE; the default is INFO), with the compile-time level as an upper bound. The help text of the option, for both binaries, now shows the actual compile-time level of the binary instead of a generic hint. The fallback compile-time level in `Log.h`, which is only used when building without CMake (CMake always sets one), is changed from INFO to DEBUG, matching CMake's default.