### PR TITLE
Move `VectorWithMemoryLimit` to `ad_utility` and use it consistently

### DIFF
--- a/src/engine/ExistsJoin.cpp
+++ b/src/engine/ExistsJoin.cpp
@@ -15,6 +15,7 @@
 #include "util/ChunkedForLoop.h"
 #include "util/JoinAlgorithms/IndexNestedLoopJoin.h"
 #include "util/JoinAlgorithms/JoinAlgorithms.h"
+#include "util/VectorWithMemoryLimit.h"
 
 // _____________________________________________________________________________
 ExistsJoin::ExistsJoin(QueryExecutionContext* qec,
@@ -186,8 +187,7 @@ Result ExistsJoin::computeResult(bool requestLaziness) {
 
   // Store the indices of rows for which the value of the `EXISTS` (in the added
   // Boolean column) should be `false`.
-  std::vector<size_t, ad_utility::AllocatorWithLimit<size_t>> notExistsIndices{
-      allocator()};
+  ad_utility::VectorWithMemoryLimit<size_t> notExistsIndices{allocator()};
   // Helper lambda for computing the exists join with `callFixedSizeVi`, which
   // makes the number of join columns a template parameter.
   auto runForNumJoinCols = [&notExistsIndices, isCheap, &noopRowAdder,
@@ -343,8 +343,7 @@ std::optional<Result> ExistsJoin::tryRightIndexNestedLoopJoinIfSuitable(
       joinColumns_, std::move(leftRes), std::move(rightRes)};
   auto result = nestedLoopJoin.computeRightExistance(
       [this](auto&& idTable, LocalVocab localVocab,
-             const std::vector<bool, ad_utility::AllocatorWithLimit<bool>>&
-                 matchingTracker) {
+             const ad_utility::VectorWithMemoryLimit<bool>& matchingTracker) {
         IdTable resultTable = AD_FWD(idTable).moveOrClone();
         addExistsColumn(resultTable, matchingTracker);
         return Result::IdTableVocabPair{std::move(resultTable),

--- a/src/engine/Minus.cpp
+++ b/src/engine/Minus.cpp
@@ -141,7 +141,7 @@ auto Minus::makeUndefRangesChecker(bool left,
 template <typename IdTableT, typename T>
 IdTable Minus::copyMatchingRows(
     const IdTableT& left, T reference,
-    const std::vector<T, ad_utility::AllocatorWithLimit<T>>& keepEntry) const {
+    const ad_utility::VectorWithMemoryLimit<T>& keepEntry) const {
   static_assert(IdTableLike<IdTableT>);
   IdTable result{getResultWidth(), left.getAllocator()};
   AD_CORRECTNESS_CHECK(result.numColumns() == left.numColumns());
@@ -194,7 +194,8 @@ IdTable Minus::computeMinus(
       right.asColumnSubsetView(joinColumnData.permutationRight());
 
   // Keep all entries by default, set to false when matching.
-  std::vector keepEntry(left.size(), true, allocator().as<bool>());
+  ad_utility::VectorWithMemoryLimit<bool> keepEntry(left.size(), true,
+                                                    allocator().as<bool>());
 
   auto markForRemoval = [&keepEntry, &joinColumnsLeft](const auto& leftIt) {
     keepEntry.at(ql::ranges::distance(joinColumnsLeft.begin(), leftIt)) = false;
@@ -283,8 +284,7 @@ std::optional<Result> Minus::tryRightIndexNestedLoopJoinIfSuitable(
       _matchedColumns, std::move(leftRes), std::move(rightRes)};
   auto result = nestedLoopJoin.computeRightExistance(
       [this](const auto& idTable, LocalVocab localVocab,
-             const std::vector<bool, ad_utility::AllocatorWithLimit<bool>>&
-                 matchingTracker) {
+             const ad_utility::VectorWithMemoryLimit<bool>& matchingTracker) {
         return Result::IdTableVocabPair{
             copyMatchingRows(idTable, false, matchingTracker),
             std::move(localVocab)};

--- a/src/engine/Minus.h
+++ b/src/engine/Minus.h
@@ -10,6 +10,7 @@
 
 #include "engine/Operation.h"
 #include "engine/QueryExecutionTree.h"
+#include "util/VectorWithMemoryLimit.h"
 
 class Minus : public Operation {
  private:
@@ -59,7 +60,7 @@ class Minus : public Operation {
   template <typename IdTableT, typename T>
   IdTable copyMatchingRows(
       const IdTableT& left, T reference,
-      const std::vector<T, ad_utility::AllocatorWithLimit<T>>& keepEntry) const;
+      const ad_utility::VectorWithMemoryLimit<T>& keepEntry) const;
 
  public:
   size_t getCostEstimate() override;

--- a/src/engine/PathSearch.cpp
+++ b/src/engine/PathSearch.cpp
@@ -379,7 +379,8 @@ PathsLimited PathSearch::findPaths(const Id& source,
     currentPath.push_back(edge);
 
     if (targets.empty() || ad_utility::contains(targets, edgeEnd)) {
-      result.push_back(currentPath);
+      // `currentPath` keeps being extended below, so store an independent copy.
+      result.push_back(Path{currentPath.edges_.clone()});
     }
 
     // Only expand the frontier if we are still allowed to grow the spine.
@@ -413,17 +414,16 @@ PathsLimited PathSearch::allPaths(ql::span<const Id> sources,
       targetSet.insert(target.getBits());
     }
     for (auto source : sources) {
-      for (const auto& path : findPaths(source, targetSet, binSearch,
-                                        numPathsPerTarget, maxDepth)) {
-        paths.push_back(path);
+      for (auto& path : findPaths(source, targetSet, binSearch,
+                                  numPathsPerTarget, maxDepth)) {
+        paths.push_back(std::move(path));
       }
     }
   } else {
     for (size_t i = 0; i < sources.size(); i++) {
-      for (const auto& path :
-           findPaths(sources[i], {targets[i].getBits()}, binSearch,
-                     numPathsPerTarget, maxDepth)) {
-        paths.push_back(path);
+      for (auto& path : findPaths(sources[i], {targets[i].getBits()}, binSearch,
+                                  numPathsPerTarget, maxDepth)) {
+        paths.push_back(std::move(path));
       }
     }
   }
@@ -444,7 +444,7 @@ void PathSearch::pathsToResultTable(IdTable& tableDyn, PathsLimited& paths,
 
   size_t rowIndex = 0;
   for (size_t pathIndex = 0; pathIndex < paths.size(); pathIndex++) {
-    auto path = paths[pathIndex];
+    const auto& path = paths[pathIndex];
 
     std::optional<Id> sourceId = std::nullopt;
     if (config_.sourceIsVariable()) {

--- a/src/engine/PathSearch.cpp
+++ b/src/engine/PathSearch.cpp
@@ -380,7 +380,7 @@ PathsLimited PathSearch::findPaths(const Id& source,
 
     if (targets.empty() || ad_utility::contains(targets, edgeEnd)) {
       // `currentPath` keeps being extended below, so store an independent copy.
-      result.push_back(Path{currentPath.edges_.clone()});
+      result.push_back(currentPath.clone());
     }
 
     // Only expand the frontier if we are still allowed to grow the spine.

--- a/src/engine/PathSearch.h
+++ b/src/engine/PathSearch.h
@@ -14,6 +14,7 @@
 #include "engine/Operation.h"
 #include "global/Id.h"
 #include "util/AllocatorWithLimit.h"
+#include "util/VectorWithMemoryLimit.h"
 
 enum class PathSearchAlgorithm { ALL_PATHS };
 
@@ -32,7 +33,7 @@ struct Edge {
   size_t edgeRow_;
 };
 
-using EdgesLimited = std::vector<Edge, ad_utility::AllocatorWithLimit<Edge>>;
+using EdgesLimited = ad_utility::VectorWithMemoryLimit<Edge>;
 
 struct Path {
   EdgesLimited edges_;
@@ -48,7 +49,7 @@ struct Path {
   const Id& end() { return edges_.back().end_; }
 };
 
-using PathsLimited = std::vector<Path, ad_utility::AllocatorWithLimit<Path>>;
+using PathsLimited = ad_utility::VectorWithMemoryLimit<Path>;
 
 /**
  * @class BinSearchWrapper

--- a/src/engine/PathSearch.h
+++ b/src/engine/PathSearch.h
@@ -47,6 +47,11 @@ struct Path {
   void pop_back() { edges_.pop_back(); }
 
   const Id& end() { return edges_.back().end_; }
+
+  // `Path` is not copyable because its `edges_` are stored in a
+  // `VectorWithMemoryLimit`, which is not copyable (see there). Explicit copies
+  // can be made via `clone()`.
+  [[nodiscard]] Path clone() const { return Path{edges_.clone()}; }
 };
 
 using PathsLimited = ad_utility::VectorWithMemoryLimit<Path>;

--- a/src/engine/SpatialJoinAlgorithms.cpp
+++ b/src/engine/SpatialJoinAlgorithms.cpp
@@ -1085,8 +1085,7 @@ Result SpatialJoinAlgorithms::BoundingBoxAlgorithm() {
   }
 
   // query rtree with the other child
-  std::vector<Value, ad_utility::AllocatorWithLimit<Value>> results{
-      qec_->getAllocator()};
+  ad_utility::VectorWithMemoryLimit<Value> results{qec_->getAllocator()};
   for (size_t i = 0; i < otherResult->numRows(); i++) {
     throwIfCancelled();
 

--- a/src/engine/SpatialJoinAlgorithms.h
+++ b/src/engine/SpatialJoinAlgorithms.h
@@ -25,6 +25,7 @@
 #include "engine/Result.h"
 #include "engine/SpatialJoin.h"
 #include "util/GeoSparqlHelpers.h"
+#include "util/VectorWithMemoryLimit.h"
 
 namespace BoostGeometryNamespace {
 namespace bg = boost::geometry;
@@ -326,8 +327,7 @@ class SpatialJoinAlgorithms {
   size_t numFailedParsedGeometries_ = 0;
 
   // this vector stores the geometries, which have already been parsed
-  std::vector<AnyGeometry, ad_utility::AllocatorWithLimit<AnyGeometry>>
-      geometries_;
+  ad_utility::VectorWithMemoryLimit<AnyGeometry> geometries_;
 
   // After adding the given amount of rows to the WKT parser, it will be checked
   // if the user has cancelled their query.

--- a/src/engine/sparqlExpressions/SparqlExpressionTypes.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionTypes.h
@@ -19,80 +19,15 @@
 #include "util/AllocatorWithLimit.h"
 #include "util/HashSet.h"
 #include "util/TypeTraits.h"
+#include "util/VectorWithMemoryLimit.h"
 #include "util/VisitMixin.h"
 
 namespace sparqlExpression {
 
-// A std::vector<T, AllocatorWithLimit> with deleted copy constructor
-// and copy assignment. Used in the SparqlExpression module, where we want
-// no accidental copies of large intermediate results.
-template <typename T>
-class VectorWithMemoryLimit
-    : public std::vector<T, ad_utility::AllocatorWithLimit<T>> {
- public:
-  using Allocator = ad_utility::AllocatorWithLimit<T>;
-  using Base = std::vector<T, ad_utility::AllocatorWithLimit<T>>;
-
- private:
-  struct CloneTag {};
-
- public:
-  // The `AllocatorWithMemoryLimit` is not default-constructible (on purpose).
-  // Unfortunately, the support for such allocators is not really great in the
-  // standard library. In particular, the type trait
-  // `std::default_initializable<std::vector<T, Alloc>>` will be true, even if
-  // the `Alloc` is not default-initializable, which leads to hard compile
-  // errors with the ranges library. For this reason we cannot simply inherit
-  // all the constructors from `Base`, but explicitly have to forward all but
-  // the default constructor. In particular, we only forward constructors that
-  // have
-  // * at least one argument
-  // * the first argument must not be similar to `std::vector` or
-  // `VectorWithMemoryLimit` to not hide copy or move constructors
-  // * the last argument must be `AllocatorWithMemoryLimit` (all constructors to
-  // `vector` take the allocator as a last parameter)
-  // * there must be a constructor of `Base` for the given arguments.
-  CPP_template(typename... Args)(
-      requires(sizeof...(Args) > 0) CPP_and CPP_NOT(
-          concepts::derived_from<ql::remove_cvref_t<ad_utility::First<Args...>>,
-                                 Base>)
-          CPP_and concepts::convertible_to<ad_utility::Last<Args...>, Allocator>
-              CPP_and concepts::constructible_from<Base, Args&&...>)
-      QL_EXPLICIT(sizeof...(Args) == 1) VectorWithMemoryLimit(Args&&... args)
-      : Base{AD_FWD(args)...} {}
-
-  // We have to explicitly forward the `initializer_list` constructor because it
-  // for some reason is not covered by the above generic mechanism.
-  VectorWithMemoryLimit(std::initializer_list<T> init, const Allocator& alloc)
-      : Base(init, alloc) {}
-
-  // Disable copy constructor and copy assignment operator (copying is too
-  // expensive in the setting where we want to use this class and not
-  // necessary).
- public:
-  VectorWithMemoryLimit& operator=(const VectorWithMemoryLimit&) = delete;
-  VectorWithMemoryLimit(const VectorWithMemoryLimit&) = delete;
-  // Moving is fine.
-  VectorWithMemoryLimit(VectorWithMemoryLimit&&) noexcept = default;
-  VectorWithMemoryLimit& operator=(VectorWithMemoryLimit&&) noexcept = default;
-
-  // Allow copying via an explicit clone() function.
-  [[nodiscard]] VectorWithMemoryLimit clone() const {
-    // Call the private copy constructor.
-    return VectorWithMemoryLimit(CloneTag{}, *this);
-  }
-
- private:
-  // Constructor for copying, used to implement the `clone` function.
-  // We use the explicit tag, s.t. this constructor doesn't match the signature
-  // of a copy constructor, because otherwise type traits like `copyable` or
-  // `constructible_form` would be misled (they might return true for certain
-  // compilers in C++17 if the copy constructor is present but private.
-  VectorWithMemoryLimit(CloneTag, const VectorWithMemoryLimit& other)
-      : Base{static_cast<const Base&>(other)} {}
-};
-static_assert(!ql::concepts::default_initializable<VectorWithMemoryLimit<int>>);
-static_assert(!ql::concepts::copyable<VectorWithMemoryLimit<int>>);
+// `VectorWithMemoryLimit` used to live here, but has been moved to
+// `ad_utility`. Make it available under the (historic) `sparqlExpression`
+// namespace, where it is still used a lot.
+using ad_utility::VectorWithMemoryLimit;
 
 // The result of an expression that can yield an ID or a string (for example
 // IF and COALESCE). `IdOrLocalVocabEntry` is the fully resolved type used in

--- a/src/index/IdTableUtils.cpp
+++ b/src/index/IdTableUtils.cpp
@@ -7,6 +7,7 @@
 #include "engine/CallFixedSize.h"
 #include "util/ChunkedForLoop.h"
 #include "util/Exception.h"
+#include "util/VectorWithMemoryLimit.h"
 
 // The actual implementation of sorting an `IdTable` according to the
 // `sortCols`.
@@ -66,7 +67,7 @@ size_t IdTableUtils::countDistinct(
   }
   // Store whether the `i`-th entry in the `input` is equal to the `i+1`-th
   // entry in the columns that have already been checked.
-  std::vector<char, ad_utility::AllocatorWithLimit<char>> counter(
+  ad_utility::VectorWithMemoryLimit<char> counter(
       input.numRows() - 1, static_cast<char>(true), input.getAllocator());
 
   // For each column, set the entries in `counter` to 0 where there's a

--- a/src/util/AllocatorWithLimit.h
+++ b/src/util/AllocatorWithLimit.h
@@ -169,6 +169,12 @@ class AllocatorWithLimit {
   AllocatorWithLimit<U> as() const {
     return AllocatorWithLimit<U>(memoryLeft_);
   }
+  // This allocator has no default constructor, as it always requires a memory
+  // limit. Note: never store a `std::vector<T, AllocatorWithLimit<T>>`
+  // directly; use `ad_utility::VectorWithMemoryLimit<T>` instead. The latter is
+  // not `default_initializable`, which avoids hard compile errors with the
+  // ranges library on standard-library implementations (e.g. libc++) that
+  // wrongly consider such a `std::vector` default-constructible.
   AllocatorWithLimit() = delete;
 
   CPP_template(typename U)(requires(!ql::concepts::same_as<U, T>))

--- a/src/util/AllocatorWithLimit.h
+++ b/src/util/AllocatorWithLimit.h
@@ -134,6 +134,12 @@ inline ClearOnAllocation noClearOnAllocation = [](MemorySize) {};
  * // now the total amount of memory allocated by limitedIntVec and
  * limitedStringVec may never exceed limitInBytes
  *
+ * NOTE: For `std::vector` in particular, prefer the wrapper
+ * `ad_utility::VectorWithMemoryLimit` (see `VectorWithMemoryLimit.h`) over
+ * using this allocator directly as in the example above: it works around a
+ * libc++ problem with the deleted default constructor and prevents accidental
+ * copies.
+ *
  * @tparam T the type of Elements that this allocator allocates
  */
 template <typename T>

--- a/src/util/AllocatorWithLimit.h
+++ b/src/util/AllocatorWithLimit.h
@@ -169,12 +169,13 @@ class AllocatorWithLimit {
   AllocatorWithLimit<U> as() const {
     return AllocatorWithLimit<U>(memoryLeft_);
   }
+
   // This allocator has no default constructor, as it always requires a memory
-  // limit. Note: never store a `std::vector<T, AllocatorWithLimit<T>>`
-  // directly; use `ad_utility::VectorWithMemoryLimit<T>` instead. The latter is
-  // not `default_initializable`, which avoids hard compile errors with the
-  // ranges library on standard-library implementations (e.g. libc++) that
-  // wrongly consider such a `std::vector` default-constructible.
+  // limit. Note that some standard-library implementations (in particular
+  // libc++) sometimes behave strangely with non-default-constructible
+  // allocators; in particular, the default constructors of some
+  // standard-library containers are then no longer SFINAE-friendly. See
+  // `VectorWithMemoryLimit.h` for details.
   AllocatorWithLimit() = delete;
 
   CPP_template(typename U)(requires(!ql::concepts::same_as<U, T>))

--- a/src/util/JoinAlgorithms/IndexNestedLoopJoin.h
+++ b/src/util/JoinAlgorithms/IndexNestedLoopJoin.h
@@ -17,6 +17,7 @@
 #include "util/Exception.h"
 #include "util/JoinAlgorithms/JoinAlgorithms.h"
 #include "util/JoinAlgorithms/JoinColumnMapping.h"
+#include "util/VectorWithMemoryLimit.h"
 
 namespace joinAlgorithms::indexNestedLoop {
 
@@ -26,7 +27,7 @@ namespace detail {
 struct Filler {
   // Should conceptually be bool, but doesn't allow the compiler to use
   // memset in `matchLeft`.
-  std::vector<char, ad_utility::AllocatorWithLimit<char>> matchTracker_;
+  ad_utility::VectorWithMemoryLimit<char> matchTracker_;
 
   explicit Filler(size_t size,
                   const ad_utility::AllocatorWithLimit<char>& allocator)
@@ -42,7 +43,7 @@ struct Filler {
 // Helper class for `IndexNestedLoopJoin::matchLeft` that simply tracks which
 // rows from the right have found a match so far.
 struct RightFiller {
-  std::vector<bool, ad_utility::AllocatorWithLimit<bool>> matchTracker_;
+  ad_utility::VectorWithMemoryLimit<bool> matchTracker_;
 
   explicit RightFiller(size_t size,
                        const ad_utility::AllocatorWithLimit<bool>& allocator)
@@ -61,7 +62,7 @@ struct Adder {
   std::vector<std::array<size_t, 2>> matchingPairs_;
   // Should conceptually be bool, but doesn't allow the compiler to use
   // memset in `matchLeft`.
-  std::vector<char, ad_utility::AllocatorWithLimit<char>> missingIndices_;
+  ad_utility::VectorWithMemoryLimit<char> missingIndices_;
   ad_utility::SharedCancellationHandle cancellationHandle_;
   size_t numJoinColumns_;
   bool keepJoinColumns_;
@@ -329,8 +330,7 @@ class IndexNestedLoopJoin {
 
   // Function for MINUS and EXISTS operations when the left side is fully
   // materialized.
-  std::vector<char, ad_utility::AllocatorWithLimit<char>>
-  computeLeftExistance() {
+  ad_utility::VectorWithMemoryLimit<char> computeLeftExistance() {
     AD_CONTRACT_CHECK(leftResult_->isFullyMaterialized());
     detail::Filler matchTracker{
         leftResult_->idTableView().size(),

--- a/src/util/VectorWithMemoryLimit.h
+++ b/src/util/VectorWithMemoryLimit.h
@@ -1,0 +1,107 @@
+// Copyright 2021 - 2026, University of Freiburg, Chair of Algorithms and Data
+// Structures.
+//
+// Authors: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+//
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#ifndef QLEVER_SRC_UTIL_VECTORWITHMEMORYLIMIT_H
+#define QLEVER_SRC_UTIL_VECTORWITHMEMORYLIMIT_H
+
+#include <initializer_list>
+#include <vector>
+
+#include "backports/concepts.h"
+#include "backports/keywords.h"
+#include "backports/type_traits.h"
+#include "util/AllocatorWithLimit.h"
+#include "util/Forward.h"
+#include "util/TypeTraits.h"
+
+namespace ad_utility {
+
+// A `std::vector<T, AllocatorWithLimit>` with deleted copy constructor and copy
+// assignment. Used whenever we want no accidental copies of large intermediate
+// results (originally in the `SparqlExpression` module). Copying is only
+// possible via the explicit `clone()` member function.
+template <typename T>
+class VectorWithMemoryLimit
+    : public std::vector<T, ad_utility::AllocatorWithLimit<T>> {
+ public:
+  using Allocator = ad_utility::AllocatorWithLimit<T>;
+  using Base = std::vector<T, ad_utility::AllocatorWithLimit<T>>;
+
+ private:
+  struct CloneTag {};
+
+ public:
+  // The `AllocatorWithLimit` is not default-constructible (on purpose).
+  // Unfortunately, the support for such allocators is not really great in the
+  // standard library. In particular, the type trait
+  // `std::default_initializable<std::vector<T, Alloc>>` will be true, even if
+  // the `Alloc` is not default-initializable, which leads to hard compile
+  // errors with the ranges library. For this reason we cannot simply inherit
+  // all the constructors from `Base`, but explicitly have to forward all but
+  // the default constructor. In particular, we only forward constructors that
+  // have
+  // * at least one argument
+  // * the first argument must not be similar to `std::vector` or
+  // `VectorWithMemoryLimit` to not hide copy or move constructors
+  // * the last argument must be `AllocatorWithLimit` (all constructors to
+  // `vector` take the allocator as a last parameter)
+  // * there must be a constructor of `Base` for the given arguments.
+  CPP_template(typename... Args)(
+      requires(sizeof...(Args) > 0) CPP_and CPP_NOT(
+          concepts::derived_from<ql::remove_cvref_t<ad_utility::First<Args...>>,
+                                 Base>)
+          CPP_and concepts::convertible_to<ad_utility::Last<Args...>, Allocator>
+              CPP_and concepts::constructible_from<Base, Args&&...>)
+      QL_EXPLICIT(sizeof...(Args) == 1) VectorWithMemoryLimit(Args&&... args)
+      // NOTE: We deliberately use parentheses (not braces) to forward to the
+      // `Base` constructor, matching the constraint above
+      // (`constructible_from`) and the behavior of a plain `std::vector`.
+      // Braces would additionally forbid narrowing conversions (e.g. filling a
+      // `VectorWithMemoryLimit<char>` with an `int` value), which `std::vector`
+      // itself allows.
+      : Base(AD_FWD(args)...) {}
+
+  // We have to explicitly forward the `initializer_list` constructor because it
+  // for some reason is not covered by the above generic mechanism.
+  VectorWithMemoryLimit(std::initializer_list<T> init, const Allocator& alloc)
+      : Base(init, alloc) {}
+
+  // Disable copy constructor and copy assignment operator (copying is too
+  // expensive in the setting where we want to use this class and not
+  // necessary).
+ public:
+  VectorWithMemoryLimit& operator=(const VectorWithMemoryLimit&) = delete;
+  VectorWithMemoryLimit(const VectorWithMemoryLimit&) = delete;
+  // Moving is fine.
+  VectorWithMemoryLimit(VectorWithMemoryLimit&&) noexcept = default;
+  VectorWithMemoryLimit& operator=(VectorWithMemoryLimit&&) noexcept = default;
+
+  // Allow copying via an explicit clone() function.
+  [[nodiscard]] VectorWithMemoryLimit clone() const {
+    // Call the private copy constructor.
+    return VectorWithMemoryLimit(CloneTag{}, *this);
+  }
+
+ private:
+  // Constructor for copying, used to implement the `clone` function.
+  // We use the explicit tag, s.t. this constructor doesn't match the signature
+  // of a copy constructor, because otherwise type traits like `copyable` or
+  // `constructible_form` would be misled (they might return true for certain
+  // compilers in C++17 if the copy constructor is present but private.
+  VectorWithMemoryLimit(CloneTag, const VectorWithMemoryLimit& other)
+      : Base{static_cast<const Base&>(other)} {}
+};
+
+static_assert(!ql::concepts::default_initializable<VectorWithMemoryLimit<int>>);
+static_assert(!ql::concepts::copyable<VectorWithMemoryLimit<int>>);
+
+}  // namespace ad_utility
+
+#endif  // QLEVER_SRC_UTIL_VECTORWITHMEMORYLIMIT_H

--- a/src/util/VectorWithMemoryLimit.h
+++ b/src/util/VectorWithMemoryLimit.h
@@ -69,7 +69,6 @@ class VectorWithMemoryLimit
   // Disable copy constructor and copy assignment operator (copying is too
   // expensive in the setting where we want to use this class and not
   // necessary).
- public:
   VectorWithMemoryLimit& operator=(const VectorWithMemoryLimit&) = delete;
   VectorWithMemoryLimit(const VectorWithMemoryLimit&) = delete;
   // Moving is fine.

--- a/src/util/VectorWithMemoryLimit.h
+++ b/src/util/VectorWithMemoryLimit.h
@@ -42,7 +42,7 @@ class VectorWithMemoryLimit
   // standard library. In particular, the type trait
   // `std::default_initializable<std::vector<T, Alloc>>` will be true on
   // `libc++`, even if the `Alloc` is not default-initializable, which leads to
-  // hard compile errors with the `ql::ranges` library. For this reason we
+  // hard compiler errors with the `ql::ranges` library. For this reason we
   // cannot simply inherit all the constructors from `Base`, but explicitly
   // have to forward all but the default constructor. In particular, we only
   // forward constructors that have

--- a/src/util/VectorWithMemoryLimit.h
+++ b/src/util/VectorWithMemoryLimit.h
@@ -25,8 +25,7 @@ namespace ad_utility {
 
 // A `std::vector<T, AllocatorWithLimit>` with deleted copy constructor and copy
 // assignment. Used whenever we want no accidental copies of large intermediate
-// results (originally in the `SparqlExpression` module). Copying is only
-// possible via the explicit `clone()` member function.
+// results. Copying is only possible via the explicit `clone()` member function.
 template <typename T>
 class VectorWithMemoryLimit
     : public std::vector<T, ad_utility::AllocatorWithLimit<T>> {
@@ -41,12 +40,12 @@ class VectorWithMemoryLimit
   // The `AllocatorWithLimit` is not default-constructible (on purpose).
   // Unfortunately, the support for such allocators is not really great in the
   // standard library. In particular, the type trait
-  // `std::default_initializable<std::vector<T, Alloc>>` will be true, even if
-  // the `Alloc` is not default-initializable, which leads to hard compile
-  // errors with the ranges library. For this reason we cannot simply inherit
-  // all the constructors from `Base`, but explicitly have to forward all but
-  // the default constructor. In particular, we only forward constructors that
-  // have
+  // `std::default_initializable<std::vector<T, Alloc>>` will be true on
+  // `libc++`, even if the `Alloc` is not default-initializable, which leads to
+  // hard compile errors with the `ql::ranges` library. For this reason we
+  // cannot simply inherit all the constructors from `Base`, but explicitly
+  // have to forward all but the default constructor. In particular, we only
+  // forward constructors that have
   // * at least one argument
   // * the first argument must not be similar to `std::vector` or
   // `VectorWithMemoryLimit` to not hide copy or move constructors
@@ -60,12 +59,6 @@ class VectorWithMemoryLimit
           CPP_and concepts::convertible_to<ad_utility::Last<Args...>, Allocator>
               CPP_and concepts::constructible_from<Base, Args&&...>)
       QL_EXPLICIT(sizeof...(Args) == 1) VectorWithMemoryLimit(Args&&... args)
-      // NOTE: We deliberately use parentheses (not braces) to forward to the
-      // `Base` constructor, matching the constraint above
-      // (`constructible_from`) and the behavior of a plain `std::vector`.
-      // Braces would additionally forbid narrowing conversions (e.g. filling a
-      // `VectorWithMemoryLimit<char>` with an `int` value), which `std::vector`
-      // itself allows.
       : Base(AD_FWD(args)...) {}
 
   // We have to explicitly forward the `initializer_list` constructor because it

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -247,6 +247,8 @@ addLinkAndDiscoverTestNoLibs(SynchronizedTest)
 
 addLinkAndDiscoverTest(AllocatorWithLimitTest)
 
+addLinkAndDiscoverTest(VectorWithMemoryLimitTest)
+
 addLinkAndDiscoverTestNoLibs(AlignedAllocatorTest)
 
 addLinkAndDiscoverTest(MinusTest engine)

--- a/test/VectorWithMemoryLimitTest.cpp
+++ b/test/VectorWithMemoryLimitTest.cpp
@@ -1,0 +1,107 @@
+// Copyright 2026, University of Freiburg,
+//
+// Chair of Algorithms and Data Structures.
+//
+// Authors: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+//
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include "backports/concepts.h"
+#include "util/AllocatorWithLimit.h"
+#include "util/GTestHelpers.h"
+#include "util/VectorWithMemoryLimit.h"
+
+using ad_utility::AllocatorWithLimit;
+using ad_utility::makeAllocationMemoryLeftThreadsafeObject;
+using ad_utility::VectorWithMemoryLimit;
+using namespace ad_utility::memory_literals;
+
+namespace {
+// Create an `AllocatorWithLimit<T>` with the given `limit`.
+template <typename T = int>
+AllocatorWithLimit<T> makeAllocator(ad_utility::MemorySize limit) {
+  return AllocatorWithLimit<T>{makeAllocationMemoryLeftThreadsafeObject(limit)};
+}
+}  // namespace
+
+// _____________________________________________________________________________
+// The `VectorWithMemoryLimit` is neither default-constructible nor copyable,
+// but it is movable.
+TEST(VectorWithMemoryLimit, typeProperties) {
+  static_assert(
+      !ql::concepts::default_initializable<VectorWithMemoryLimit<int>>);
+  static_assert(!ql::concepts::copyable<VectorWithMemoryLimit<int>>);
+  static_assert(std::is_move_constructible_v<VectorWithMemoryLimit<int>>);
+  static_assert(std::is_move_assignable_v<VectorWithMemoryLimit<int>>);
+  static_assert(!std::is_copy_constructible_v<VectorWithMemoryLimit<int>>);
+  static_assert(!std::is_copy_assignable_v<VectorWithMemoryLimit<int>>);
+  // It really is a `std::vector` (with the limited allocator).
+  static_assert(std::is_base_of_v<std::vector<int, AllocatorWithLimit<int>>,
+                                  VectorWithMemoryLimit<int>>);
+}
+
+// _____________________________________________________________________________
+// Construction from an allocator and basic `std::vector` operations work.
+TEST(VectorWithMemoryLimit, constructionAndBasicOperations) {
+  VectorWithMemoryLimit<int> v{makeAllocator(2_MB)};
+  EXPECT_TRUE(v.empty());
+  v.push_back(1);
+  v.push_back(2);
+  v.push_back(3);
+  EXPECT_THAT(v, ::testing::ElementsAre(1, 2, 3));
+  EXPECT_EQ(v.size(), 3u);
+}
+
+// _____________________________________________________________________________
+// The `initializer_list` constructor is explicitly forwarded.
+TEST(VectorWithMemoryLimit, initializerListConstructor) {
+  VectorWithMemoryLimit<int> v{{4, 5, 6}, makeAllocator(2_MB)};
+  EXPECT_THAT(v, ::testing::ElementsAre(4, 5, 6));
+}
+
+// _____________________________________________________________________________
+// Moving transfers the contents and leaves the moved-from vector empty.
+TEST(VectorWithMemoryLimit, move) {
+  VectorWithMemoryLimit<int> v{makeAllocator(2_MB)};
+  v.push_back(1);
+  v.push_back(2);
+  VectorWithMemoryLimit<int> moved{std::move(v)};
+  EXPECT_THAT(moved, ::testing::ElementsAre(1, 2));
+
+  VectorWithMemoryLimit<int> moveAssigned{makeAllocator(2_MB)};
+  moveAssigned = std::move(moved);
+  EXPECT_THAT(moveAssigned, ::testing::ElementsAre(1, 2));
+}
+
+// _____________________________________________________________________________
+// `clone()` produces an independent deep copy.
+TEST(VectorWithMemoryLimit, clone) {
+  VectorWithMemoryLimit<int> v{makeAllocator(2_MB)};
+  v.push_back(1);
+  v.push_back(2);
+  VectorWithMemoryLimit<int> copy = v.clone();
+  EXPECT_THAT(copy, ::testing::ElementsAre(1, 2));
+  // The copy is independent of the original.
+  copy.push_back(3);
+  EXPECT_THAT(v, ::testing::ElementsAre(1, 2));
+  EXPECT_THAT(copy, ::testing::ElementsAre(1, 2, 3));
+}
+
+// _____________________________________________________________________________
+// The memory limit of the underlying allocator is enforced.
+TEST(VectorWithMemoryLimit, memoryLimitIsEnforced) {
+  // 18 bytes suffice for a few `int`s, but not for arbitrarily many.
+  VectorWithMemoryLimit<int> v{makeAllocator(18_B)};
+  v.push_back(5);  // allocate 4 bytes -> works.
+  v.push_back(4);  // allocate 8 bytes, then free 4 -> works.
+  EXPECT_THAT(v, ::testing::ElementsAre(5, 4));
+  // Allocate 16 bytes -> fails (allocate before freeing the old 8).
+  EXPECT_THROW(v.push_back(1),
+               ad_utility::detail::AllocationExceedsLimitException);
+}


### PR DESCRIPTION
So far, the class `VectorWithMemoryLimit` (a `std::vector` with an `AllocatorWithLimit`) lived in the `sparqlExpressions` module. Move it to the common `ad_utility` namespace and use it in all the places that used a raw `std::vector<T, AllocatorWithLimit<T>>` directly. The class has two important advantages over the raw vector:

1. It works around a problem in `libc++`, where the type trait `std::default_initializable<std::vector<T, Alloc>>` is wrongly `true` although the allocator (deliberately) has no default constructor, and actually instantiating the default constructor then leads to hard compiler errors deep inside the ranges library.

2. It is not implicitly copyable, copies require an explicit call to its `clone` method. This prevents accidental copies of large intermediate results (the code lives under a memory limit, so the vectors are probably large). Making the copies explicit immediately uncovered two loops in `PathSearch` that copied every path although a move or a reference suffices.

This is a preparation for #3122, which gets rid of the nasty explicit calls to `OwningView`, where the issue with these vectors arose at one point.