### PR TITLE
Add ICU-free implementations of the UTF-8 helpers in `StringUtils`

### DIFF
--- a/src/engine/sparqlExpressions/StringExpressions.cpp
+++ b/src/engine/sparqlExpressions/StringExpressions.cpp
@@ -158,21 +158,24 @@ struct UpperOrLowerCaseImpl {
   }
 };
 
-// `ad_utility::utf8ToLower` has an optional locale argument, so its address
-// cannot be used directly as the (single-argument) non-type template argument
-// of `UpperOrLowerCaseImpl`. Wrap it in a function with the exact required
-// signature.
-// TODO<RobinTF> This uses the locale-independent (root) lowercasing, as `LCASE`
-// always has. Note that this can differ from the (locale-dependent) lowercasing
-// the index uses for its vocabulary, which could in principle lead to missed
-// lookups; revisit once a locale can be wired into the n-ary string
-// expressions.
+// `ad_utility::utf8ToLower` and `ad_utility::utf8ToUpper` have an optional
+// locale argument, so their addresses cannot be used directly as the
+// (single-argument) non-type template argument of `UpperOrLowerCaseImpl`. Wrap
+// them in functions with the exact required signature.
+// TODO<RobinTF> These use the locale-independent (root) case conversion, as
+// `LCASE` and `UCASE` always have. Note that this can differ from the
+// (locale-dependent) lowercasing the index uses for its vocabulary, which could
+// in principle lead to missed lookups; revisit once a locale can be wired into
+// the n-ary string expressions.
 inline std::string utf8ToLowerRootLocale(std::string_view s) {
   return ad_utility::utf8ToLower(s);
 }
+inline std::string utf8ToUpperRootLocale(std::string_view s) {
+  return ad_utility::utf8ToUpper(s);
+}
 
 using UppercaseExpression =
-    LiteralExpressionImpl<1, UpperOrLowerCaseImpl<&ad_utility::utf8ToUpper<>>>;
+    LiteralExpressionImpl<1, UpperOrLowerCaseImpl<&utf8ToUpperRootLocale>>;
 using LowercaseExpression =
     LiteralExpressionImpl<1, UpperOrLowerCaseImpl<&utf8ToLowerRootLocale>>;
 

--- a/src/engine/sparqlExpressions/StringExpressions.cpp
+++ b/src/engine/sparqlExpressions/StringExpressions.cpp
@@ -172,7 +172,7 @@ inline std::string utf8ToLowerRootLocale(std::string_view s) {
 }
 
 using UppercaseExpression =
-    LiteralExpressionImpl<1, UpperOrLowerCaseImpl<&ad_utility::utf8ToUpper>>;
+    LiteralExpressionImpl<1, UpperOrLowerCaseImpl<&ad_utility::utf8ToUpper<>>>;
 using LowercaseExpression =
     LiteralExpressionImpl<1, UpperOrLowerCaseImpl<&utf8ToLowerRootLocale>>;
 

--- a/src/util/StringUtils.cpp
+++ b/src/util/StringUtils.cpp
@@ -84,10 +84,15 @@ bool isLanguageMatch(std::string& languageTag, std::string& languageRange) {
 
 // ___________________________________________________________________________
 void utf8EncodeCodepoint(uint32_t codepoint, std::string& output) {
-  // Encode `codepoint` according to the UTF-8 standard. Codepoints outside of
-  // the valid Unicode range are replaced by U+FFFD (the replacement character).
+  // Encode `codepoint` according to the UTF-8 standard. Codepoints that are
+  // not valid Unicode scalar values (larger than U+10FFFF, or in the surrogate
+  // range U+D800..U+DFFF, which is reserved for UTF-16 and must never appear
+  // in valid UTF-8) are replaced by U+FFFD (the replacement character).
   static constexpr uint32_t maxValidCodepoint = 0x10FFFF;
-  if (codepoint > maxValidCodepoint) {
+  static constexpr uint32_t firstSurrogate = 0xD800;
+  static constexpr uint32_t lastSurrogate = 0xDFFF;
+  if (codepoint > maxValidCodepoint ||
+      (codepoint >= firstSurrogate && codepoint <= lastSurrogate)) {
     codepoint = 0xFFFD;
   }
   // A UTF-8 continuation byte has the two-bit header `10` followed by the next

--- a/src/util/StringUtils.cpp
+++ b/src/util/StringUtils.cpp
@@ -7,8 +7,13 @@
 
 #include <absl/strings/str_cat.h>
 #include <absl/strings/str_replace.h>
+#ifndef QLEVER_NO_UNICODE
 #include <unicode/bytestream.h>
 #include <unicode/casemap.h>
+#endif
+
+#include <cctype>
+#include <iterator>
 
 #include "backports/StartsWithAndEndsWith.h"
 #include "global/Constants.h"
@@ -78,25 +83,76 @@ bool isLanguageMatch(std::string& languageTag, std::string& languageRange) {
 }
 
 // ___________________________________________________________________________
-std::pair<size_t, std::string_view> getUTF8Prefix(std::string_view sv,
-                                                  size_t prefixLength) {
-  const char* s = sv.data();
-  int32_t length = sv.length();
-  size_t numCodepoints = 0;
-  int32_t i = 0;
-  for (i = 0; i < length && numCodepoints < prefixLength;) {
-    UChar32 c;
-    U8_NEXT(s, i, length, c);
-    if (c >= 0) {
-      ++numCodepoints;
-    } else {
-      throw std::runtime_error(
-          "Illegal UTF sequence in ad_utility::getUTF8Prefix");
-    }
+void utf8EncodeCodepoint(uint32_t codepoint, std::string& output) {
+  // Encode `codepoint` according to the UTF-8 standard. Codepoints outside of
+  // the valid Unicode range are replaced by U+FFFD (the replacement character).
+  static constexpr uint32_t maxValidCodepoint = 0x10FFFF;
+  if (codepoint > maxValidCodepoint) {
+    codepoint = 0xFFFD;
   }
-  return {numCodepoints, sv.substr(0, i)};
+  // A UTF-8 continuation byte has the two-bit header `10` followed by the next
+  // six bits of the codepoint.
+  static constexpr uint32_t continuationHeader = 0b1000'0000;
+  static constexpr uint32_t lowestSixBits = 0b0011'1111;
+  auto continuationByte = [](uint32_t bits) {
+    return static_cast<char>(continuationHeader | (bits & lowestSixBits));
+  };
+  if (codepoint <= 0x7F) {
+    // Single byte: `0xxxxxxx`.
+    output += static_cast<char>(codepoint);
+  } else if (codepoint <= 0x7FF) {
+    // Two bytes: `110xxxxx 10xxxxxx`.
+    output += static_cast<char>(0b1100'0000 | (codepoint >> 6));
+    output += continuationByte(codepoint);
+  } else if (codepoint <= 0xFFFF) {
+    // Three bytes: `1110xxxx 10xxxxxx 10xxxxxx`.
+    output += static_cast<char>(0b1110'0000 | (codepoint >> 12));
+    output += continuationByte(codepoint >> 6);
+    output += continuationByte(codepoint);
+  } else {
+    // Four bytes: `11110xxx 10xxxxxx 10xxxxxx 10xxxxxx`.
+    output += static_cast<char>(0b1111'0000 | (codepoint >> 18));
+    output += continuationByte(codepoint >> 12);
+    output += continuationByte(codepoint >> 6);
+    output += continuationByte(codepoint);
+  }
 }
 
+// ___________________________________________________________________________
+template <bool useICU>
+std::pair<size_t, std::string_view> getUTF8Prefix(std::string_view sv,
+                                                  size_t prefixLength) {
+  if constexpr (useICU) {
+    QLEVER_UNICODE_ONLY("getUTF8Prefix", {
+      const char* s = sv.data();
+      int32_t length = sv.length();
+      size_t numCodepoints = 0;
+      int32_t i = 0;
+      for (i = 0; i < length && numCodepoints < prefixLength;) {
+        UChar32 c;
+        U8_NEXT(s, i, length, c);
+        if (c >= 0) {
+          ++numCodepoints;
+        } else {
+          throw std::runtime_error(
+              "Illegal UTF sequence in ad_utility::getUTF8Prefix");
+        }
+      }
+      return {numCodepoints, sv.substr(0, i)};
+    });
+  } else {
+    // Without ICU we treat every byte as a single codepoint.
+    auto length = std::min(prefixLength, sv.size());
+    return {length, sv.substr(0, length)};
+  }
+}
+// Explicit instantiations for both configurations.
+template std::pair<size_t, std::string_view> getUTF8Prefix<true>(
+    std::string_view, size_t);
+template std::pair<size_t, std::string_view> getUTF8Prefix<false>(
+    std::string_view, size_t);
+
+#ifndef QLEVER_NO_UNICODE
 namespace detail {
 // The common implementation of `utf8ToLower` and `utf8ToUpper` (for
 // details see below).
@@ -115,20 +171,48 @@ std::string utf8StringTransform(std::string_view s, const char* localeName,
   return result;
 }
 }  // namespace detail
+#endif  // QLEVER_NO_UNICODE
 
 // ____________________________________________________________________________
+template <bool useICU>
 std::string utf8ToLower(std::string_view s, const char* localeName) {
-  return detail::utf8StringTransform(s, localeName, [](auto&&... args) {
-    return icu::CaseMap::utf8ToLower(AD_FWD(args)...);
-  });
+  if constexpr (useICU) {
+    QLEVER_UNICODE_ONLY("utf8ToLower", {
+      return detail::utf8StringTransform(s, localeName, [](auto&&... args) {
+        return icu::CaseMap::utf8ToLower(AD_FWD(args)...);
+      });
+    });
+  } else {
+    (void)localeName;
+    return ::ranges::to<std::string>(
+        s | ql::views::transform([](unsigned char c) {
+          return static_cast<char>(std::tolower(c));
+        }));
+  }
 }
+// Explicit instantiations for both configurations.
+template std::string utf8ToLower<true>(std::string_view, const char*);
+template std::string utf8ToLower<false>(std::string_view, const char*);
 
 // ____________________________________________________________________________
+template <bool useICU>
 std::string utf8ToUpper(std::string_view s) {
-  return detail::utf8StringTransform(s, "", [](auto&&... args) {
-    return icu::CaseMap::utf8ToUpper(AD_FWD(args)...);
-  });
+  if constexpr (useICU) {
+    QLEVER_UNICODE_ONLY("utf8ToUpper", {
+      return detail::utf8StringTransform(s, "", [](auto&&... args) {
+        return icu::CaseMap::utf8ToUpper(AD_FWD(args)...);
+      });
+    });
+  } else {
+    return ::ranges::to<std::string>(
+        s | ql::views::transform([](unsigned char c) {
+          return static_cast<char>(std::toupper(c));
+        }));
+  }
 }
+// Explicit instantiations for both configurations.
+template std::string utf8ToUpper<true>(std::string_view);
+template std::string utf8ToUpper<false>(std::string_view);
 
 // ____________________________________________________________________________
 std::string_view getUTF8Substring(const std::string_view str, size_t start,

--- a/src/util/StringUtils.cpp
+++ b/src/util/StringUtils.cpp
@@ -173,6 +173,22 @@ std::string utf8StringTransform(std::string_view s, const char* localeName,
 }  // namespace detail
 #endif  // QLEVER_NO_UNICODE
 
+namespace {
+// The common ICU-free implementation of `utf8ToLower` and `utf8ToUpper` (for
+// details see below). Apply `transformation` to each byte of `s` separately,
+// which only affects the ASCII characters. `localeName` is deliberately
+// ignored, as locale-specific case folding requires ICU.
+template <typename F>
+std::string asciiStringTransform(std::string_view s,
+                                 [[maybe_unused]] const char* localeName,
+                                 F transformation) {
+  return ::ranges::to<std::string>(
+      s | ql::views::transform([&transformation](char c) {
+        return static_cast<char>(transformation(static_cast<unsigned char>(c)));
+      }));
+}
+}  // namespace
+
 // ____________________________________________________________________________
 template <bool useICU>
 std::string utf8ToLower(std::string_view s, const char* localeName) {
@@ -183,11 +199,8 @@ std::string utf8ToLower(std::string_view s, const char* localeName) {
       });
     });
   } else {
-    (void)localeName;
-    return ::ranges::to<std::string>(
-        s | ql::views::transform([](unsigned char c) {
-          return static_cast<char>(std::tolower(c));
-        }));
+    return asciiStringTransform(
+        s, localeName, [](unsigned char c) { return std::tolower(c); });
   }
 }
 // Explicit instantiations for both configurations.
@@ -196,23 +209,21 @@ template std::string utf8ToLower<false>(std::string_view, const char*);
 
 // ____________________________________________________________________________
 template <bool useICU>
-std::string utf8ToUpper(std::string_view s) {
+std::string utf8ToUpper(std::string_view s, const char* localeName) {
   if constexpr (useICU) {
     QLEVER_UNICODE_ONLY("utf8ToUpper", {
-      return detail::utf8StringTransform(s, "", [](auto&&... args) {
+      return detail::utf8StringTransform(s, localeName, [](auto&&... args) {
         return icu::CaseMap::utf8ToUpper(AD_FWD(args)...);
       });
     });
   } else {
-    return ::ranges::to<std::string>(
-        s | ql::views::transform([](unsigned char c) {
-          return static_cast<char>(std::toupper(c));
-        }));
+    return asciiStringTransform(
+        s, localeName, [](unsigned char c) { return std::toupper(c); });
   }
 }
 // Explicit instantiations for both configurations.
-template std::string utf8ToUpper<true>(std::string_view);
-template std::string utf8ToUpper<false>(std::string_view);
+template std::string utf8ToUpper<true>(std::string_view, const char*);
+template std::string utf8ToUpper<false>(std::string_view, const char*);
 
 // ____________________________________________________________________________
 std::string_view getUTF8Substring(const std::string_view str, size_t start,

--- a/src/util/StringUtils.h
+++ b/src/util/StringUtils.h
@@ -5,6 +5,7 @@
 #ifndef QLEVER_SRC_UTIL_STRINGUTILS_H
 #define QLEVER_SRC_UTIL_STRINGUTILS_H
 
+#include <cstdint>
 #include <string>
 #include <string_view>
 
@@ -14,6 +15,7 @@
 #include "backports/span.h"
 #include "util/Concepts.h"
 #include "util/ConstexprSmallString.h"
+#include "util/UnicodeSupport.h"
 
 namespace ad_utility {
 //! Utility functions for string. Can possibly be changed to
@@ -35,17 +37,40 @@ bool strIsLangTag(const std::string& strLangTag);
 // Implements a case insensitive `language-range` to `language-tag`comparison.
 bool isLanguageMatch(std::string& languageTag, std::string& languageRange);
 
-/*
- * @brief convert a UTF-8 String to lowercase
- * @param s UTF-8 encoded string
- * @param localeName The ICU locale name used for locale-specific case folding
- * (e.g. "tr" for Turkish). The default empty string uses the locale-independent
- * root rules.
- * @return The lowercase version of s, also encoded as UTF-8
- */
+// Encode the single Unicode `codepoint` as UTF-8 and append the resulting bytes
+// to `output`. Codepoints outside the valid Unicode range (> 0x10FFFF) are
+// encoded as the Unicode replacement character U+FFFD. This function does not
+// depend on ICU.
+void utf8EncodeCodepoint(uint32_t codepoint, std::string& output);
+
+// UTF-16 surrogate helpers. These are ICU-free equivalents of ICU's
+// `U16_IS_LEAD`, `U16_IS_TRAIL` and `U16_GET_SUPPLEMENTARY` macros; they are
+// used when decoding `\uXXXX` escape sequences.
+
+// Return true iff `c` is a high (leading) surrogate code unit.
+constexpr bool isHighSurrogate(uint32_t c) {
+  return c >= 0xD800 && c <= 0xDBFF;
+}
+
+// Return true iff `c` is a low (trailing) surrogate code unit.
+constexpr bool isLowSurrogate(uint32_t c) { return c >= 0xDC00 && c <= 0xDFFF; }
+
+// Combine a high and a low surrogate into the corresponding supplementary
+// Unicode codepoint.
+constexpr uint32_t combineSurrogates(uint32_t high, uint32_t low) {
+  return 0x10000 + ((high - 0xD800) << 10) + (low - 0xDC00);
+}
+
+// Convert a UTF-8 string to lowercase. `localeName` is the ICU locale name used
+// for locale-specific case folding (e.g. "tr" for Turkish); the default empty
+// string uses the locale-independent root rules. If `useICU == false`, only
+// ASCII characters are lowercased (each byte is treated individually) and
+// `localeName` is ignored.
+template <bool useICU = useICUDefault>
 std::string utf8ToLower(std::string_view s, const char* localeName = "");
 
-// Get the uppercase value. For details see `utf8ToLower` above
+// Get the uppercase value. For details see `utf8ToLower` above.
+template <bool useICU = useICUDefault>
 std::string utf8ToUpper(std::string_view s);
 
 /**
@@ -78,7 +103,11 @@ std::string_view getUTF8Substring(const std::string_view str, size_t start);
  * @param prefixLength The number of Unicode codepoints we want to extract.
  * @return the first max(prefixLength, numCodepointsInArgSP) Unicode
  * codepoints of sv, encoded as UTF-8
+ *
+ * If `useICU == false`, only an ASCII prefix is formed (each byte is treated as
+ * a codepoint).
  */
+template <bool useICU = useICUDefault>
 std::pair<size_t, std::string_view> getUTF8Prefix(std::string_view s,
                                                   size_t prefixLength);
 

--- a/src/util/StringUtils.h
+++ b/src/util/StringUtils.h
@@ -44,8 +44,7 @@ bool isLanguageMatch(std::string& languageTag, std::string& languageRange);
 void utf8EncodeCodepoint(uint32_t codepoint, std::string& output);
 
 // UTF-16 surrogate helpers. These are ICU-free equivalents of ICU's
-// `U16_IS_LEAD`, `U16_IS_TRAIL` and `U16_GET_SUPPLEMENTARY` macros; they are
-// used when decoding `\uXXXX` escape sequences.
+// `U16_IS_LEAD`, `U16_IS_TRAIL` and `U16_GET_SUPPLEMENTARY` macros.
 
 // Return true iff `c` is a high (leading) surrogate code unit.
 constexpr bool isHighSurrogate(uint32_t c) {
@@ -71,7 +70,7 @@ std::string utf8ToLower(std::string_view s, const char* localeName = "");
 
 // Get the uppercase value. For details see `utf8ToLower` above.
 template <bool useICU = useICUDefault>
-std::string utf8ToUpper(std::string_view s);
+std::string utf8ToUpper(std::string_view s, const char* localeName = "");
 
 /**
  * Get the substring from the UTF8-encoded str that starts at the start-th

--- a/src/util/StringUtils.h
+++ b/src/util/StringUtils.h
@@ -38,9 +38,9 @@ bool strIsLangTag(const std::string& strLangTag);
 bool isLanguageMatch(std::string& languageTag, std::string& languageRange);
 
 // Encode the single Unicode `codepoint` as UTF-8 and append the resulting bytes
-// to `output`. Codepoints outside the valid Unicode range (> 0x10FFFF) are
-// encoded as the Unicode replacement character U+FFFD. This function does not
-// depend on ICU.
+// to `output`. Codepoints that are not valid Unicode scalar values (larger than
+// 0x10FFFF, or in the surrogate range 0xD800-0xDFFF) are encoded as the Unicode
+// replacement character U+FFFD. This function does not depend on ICU.
 void utf8EncodeCodepoint(uint32_t codepoint, std::string& output);
 
 // Convert a UTF-8 string to lowercase. `localeName` is the ICU locale name used

--- a/src/util/StringUtils.h
+++ b/src/util/StringUtils.h
@@ -43,23 +43,6 @@ bool isLanguageMatch(std::string& languageTag, std::string& languageRange);
 // depend on ICU.
 void utf8EncodeCodepoint(uint32_t codepoint, std::string& output);
 
-// UTF-16 surrogate helpers. These are ICU-free equivalents of ICU's
-// `U16_IS_LEAD`, `U16_IS_TRAIL` and `U16_GET_SUPPLEMENTARY` macros.
-
-// Return true iff `c` is a high (leading) surrogate code unit.
-constexpr bool isHighSurrogate(uint32_t c) {
-  return c >= 0xD800 && c <= 0xDBFF;
-}
-
-// Return true iff `c` is a low (trailing) surrogate code unit.
-constexpr bool isLowSurrogate(uint32_t c) { return c >= 0xDC00 && c <= 0xDFFF; }
-
-// Combine a high and a low surrogate into the corresponding supplementary
-// Unicode codepoint.
-constexpr uint32_t combineSurrogates(uint32_t high, uint32_t low) {
-  return 0x10000 + ((high - 0xD800) << 10) + (low - 0xDC00);
-}
-
 // Convert a UTF-8 string to lowercase. `localeName` is the ICU locale name used
 // for locale-specific case folding (e.g. "tr" for Turkish); the default empty
 // string uses the locale-independent root rules. If `useICU == false`, only

--- a/src/util/UnicodeSupport.h
+++ b/src/util/UnicodeSupport.h
@@ -1,9 +1,9 @@
 // Copyright 2026 The QLever Authors, in particular:
 //
 // 2026 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
-
+//
 // UFR = University of Freiburg, Chair of Algorithms and Data Structures
-
+//
 // You may not use this file except in compliance with the Apache 2.0 License,
 // which can be found in the `LICENSE` file at the root of the QLever project.
 

--- a/src/util/UnicodeSupport.h
+++ b/src/util/UnicodeSupport.h
@@ -1,0 +1,50 @@
+// Copyright 2026 The QLever Authors, in particular:
+//
+// 2026 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#ifndef QLEVER_SRC_UTIL_UNICODESUPPORT_H
+#define QLEVER_SRC_UTIL_UNICODESUPPORT_H
+
+#include <stdexcept>
+
+namespace ad_utility {
+// The default value for the `useICU` template parameter of the various string
+// functions that have both an ICU-based and an ICU-free implementation (for
+// example `ad_utility::utf8ToLower`). It is `false` exactly if the
+// `QLEVER_NO_UNICODE` macro is defined. Currently there is deliberately no
+// build option that defines this macro (the unit tests instantiate the ICU-free
+// variants directly); a CMake option will follow, see the comment on
+// `LocaleManager` in `index/LocaleManager.h`.
+#ifdef QLEVER_NO_UNICODE
+inline constexpr bool useICUDefault = false;
+#else
+inline constexpr bool useICUDefault = true;
+#endif
+}  // namespace ad_utility
+
+// Macro for code that requires ICU. In a regular build
+// `QLEVER_UNICODE_ONLY(msg,
+// ...)` expands to its variadic arguments (the ICU code). In an ICU-free build
+// (`QLEVER_NO_UNICODE` defined) it instead throws a `std::runtime_error` and
+// discards the ICU code, so that the code is never compiled and no ICU symbols
+// are required. `msg` must be a string literal naming the call site. Terminate
+// the invocation with a semicolon like any statement.
+//
+// Note: the ICU code must not contain unbalanced parentheses or preprocessor
+// directives, as it is passed as a macro argument.
+#ifdef QLEVER_NO_UNICODE
+#define QLEVER_UNICODE_ONLY(msg, ...)                             \
+  throw std::runtime_error(                                       \
+      "The operation '" msg                                       \
+      "' requires ICU, but QLever was built without ICU support " \
+      "(the `QLEVER_NO_UNICODE` macro was defined).")
+#else
+#define QLEVER_UNICODE_ONLY(msg, ...) __VA_ARGS__
+#endif
+
+#endif  // QLEVER_SRC_UTIL_UNICODESUPPORT_H

--- a/test/StringUtilsTest.cpp
+++ b/test/StringUtilsTest.cpp
@@ -54,6 +54,15 @@ TEST(StringUtils, utf8ToUpper) {
 }
 
 // _____________________________________________________________________________
+TEST(StringUtils, utf8ToUpperWithLocale) {
+  // With the default (root) locale, ASCII `i` uppercases to `I`.
+  EXPECT_EQ("I", utf8ToUpper("i"));
+  EXPECT_EQ("I", utf8ToUpper("i", ""));
+  // The Turkish locale instead uppercases `i` to the dotted `İ` (U+0130).
+  EXPECT_EQ("İ", utf8ToUpper("i", "tr"));
+}
+
+// _____________________________________________________________________________
 // Test the ICU-free (`useICU == false`) implementations of `utf8ToLower` and
 // `utf8ToUpper`. These only fold ASCII characters; all other bytes (including
 // the bytes of multibyte UTF-8 characters) are passed through unchanged.
@@ -70,6 +79,12 @@ TEST(StringUtils, utf8ToLowerUpperNoICU) {
   EXPECT_EQ("CAFé", utf8ToUpper<false>("café"));
   EXPECT_EQ("aÔb", utf8ToLower<false>("AÔB"));
   EXPECT_EQ("AÔB", utf8ToUpper<false>("aÔb"));
+
+  // The `localeName` is ignored, as locale-specific case folding requires ICU.
+  // Compare the `utf8ToLowerWithLocale` and `utf8ToUpperWithLocale` tests
+  // above, where the Turkish locale yields `ı` and `İ` respectively.
+  EXPECT_EQ("i", utf8ToLower<false>("I", "tr"));
+  EXPECT_EQ("I", utf8ToUpper<false>("i", "tr"));
 
   // The `useICU == true` instantiation exists and behaves like the default.
   EXPECT_EQ(utf8ToLower<true>("Schindler's List"),
@@ -126,14 +141,48 @@ TEST(StringUtils, utf8EncodeCodepoint) {
 }
 
 // _____________________________________________________________________________
-// Test the ICU-free UTF-16 surrogate helpers against ICU's `U16_IS_LEAD`,
-// `U16_IS_TRAIL` and `U16_GET_SUPPLEMENTARY`.
+// Test the ICU-free UTF-16 surrogate helpers at the boundaries of the two
+// surrogate blocks, which are the interesting corner cases.
 TEST(StringUtils, surrogateHelpers) {
   using ad_utility::combineSurrogates;
   using ad_utility::isHighSurrogate;
   using ad_utility::isLowSurrogate;
-  // The predicates match ICU over the whole codepoint range (this includes the
-  // corner cases at the boundaries of the two surrogate blocks).
+  // The high surrogates are exactly the block [0xD800, 0xDBFF].
+  EXPECT_FALSE(isHighSurrogate(0xD7FF));
+  EXPECT_TRUE(isHighSurrogate(0xD800));
+  EXPECT_TRUE(isHighSurrogate(0xDBFF));
+  EXPECT_FALSE(isHighSurrogate(0xDC00));
+
+  // The low surrogates are exactly the block [0xDC00, 0xDFFF].
+  EXPECT_FALSE(isLowSurrogate(0xDBFF));
+  EXPECT_TRUE(isLowSurrogate(0xDC00));
+  EXPECT_TRUE(isLowSurrogate(0xDFFF));
+  EXPECT_FALSE(isLowSurrogate(0xE000));
+
+  // Ordinary codepoints are neither.
+  EXPECT_FALSE(isHighSurrogate(0x41));
+  EXPECT_FALSE(isLowSurrogate(0x41));
+
+  // The first and the last supplementary codepoint.
+  EXPECT_EQ(combineSurrogates(0xD800, 0xDC00), 0x10000u);
+  EXPECT_EQ(combineSurrogates(0xDBFF, 0xDFFF), 0x10FFFFu);
+  // U+1F600 (GRINNING FACE) is encoded as the surrogate pair D83D DE00.
+  EXPECT_EQ(combineSurrogates(0xD83D, 0xDE00), 0x1F600u);
+}
+
+// _____________________________________________________________________________
+// Exhaustively test the ICU-free UTF-16 surrogate helpers against ICU's
+// `U16_IS_LEAD`, `U16_IS_TRAIL` and `U16_GET_SUPPLEMENTARY`. This complements
+// the `surrogateHelpers` test above, which only covers the corner cases but
+// always runs.
+TEST(StringUtils, surrogateHelpersExhaustive) {
+#ifndef QLEVER_RUN_EXPENSIVE_TESTS
+  GTEST_SKIP();
+#endif
+  using ad_utility::combineSurrogates;
+  using ad_utility::isHighSurrogate;
+  using ad_utility::isLowSurrogate;
+  // The predicates match ICU over the whole codepoint range.
   for (uint32_t c = 0; c <= 0x10FFFF; ++c) {
     ASSERT_EQ(isHighSurrogate(c), static_cast<bool>(U16_IS_LEAD(c))) << c;
     ASSERT_EQ(isLowSurrogate(c), static_cast<bool>(U16_IS_TRAIL(c))) << c;

--- a/test/StringUtilsTest.cpp
+++ b/test/StringUtilsTest.cpp
@@ -7,6 +7,7 @@
 #include <absl/strings/str_cat.h>
 #include <gtest/gtest.h>
 #include <unicode/unistr.h>
+#include <unicode/utf16.h>
 
 #include <ranges>
 #include <sstream>
@@ -50,6 +51,100 @@ TEST(StringUtils, utf8ToUpper) {
   EXPECT_EQ("SCHINDLER'S LIST", utf8ToUpper("Schindler's List"));
   EXPECT_EQ("#+-_BIMM__BAMM++", utf8ToUpper("#+-_bImM__baMm++"));
   EXPECT_EQ("FÔÉSSAÉÉ", utf8ToUpper("FôéßaÉé"));
+}
+
+// _____________________________________________________________________________
+// Test the ICU-free (`useICU == false`) implementations of `utf8ToLower` and
+// `utf8ToUpper`. These only fold ASCII characters; all other bytes (including
+// the bytes of multibyte UTF-8 characters) are passed through unchanged.
+TEST(StringUtils, utf8ToLowerUpperNoICU) {
+  // For pure ASCII the result is identical to the ICU-based version.
+  EXPECT_EQ("schindler's list", utf8ToLower<false>("Schindler's List"));
+  EXPECT_EQ("#+-_foo__bar++", utf8ToLower<false>("#+-_foo__Bar++"));
+  EXPECT_EQ("SCHINDLER'S LIST", utf8ToUpper<false>("Schindler's List"));
+  EXPECT_EQ("#+-_BIMM__BAMM++", utf8ToUpper<false>("#+-_bImM__baMm++"));
+
+  // Non-ASCII characters are left untouched (no Unicode-aware case folding);
+  // only the ASCII letters are folded.
+  EXPECT_EQ("cafÉ", utf8ToLower<false>("CAFÉ"));
+  EXPECT_EQ("CAFé", utf8ToUpper<false>("café"));
+  EXPECT_EQ("aÔb", utf8ToLower<false>("AÔB"));
+  EXPECT_EQ("AÔB", utf8ToUpper<false>("aÔb"));
+
+  // The `useICU == true` instantiation exists and behaves like the default.
+  EXPECT_EQ(utf8ToLower<true>("Schindler's List"),
+            utf8ToLower("Schindler's List"));
+  EXPECT_EQ(utf8ToUpper<true>("Schindler's List"),
+            utf8ToUpper("Schindler's List"));
+}
+
+// _____________________________________________________________________________
+// Test the ICU-free (`useICU == false`) implementation of `getUTF8Prefix`,
+// which treats every byte as a single codepoint.
+TEST(StringUtils, getUTF8PrefixNoICU) {
+  using ad_utility::getUTF8Prefix;
+  // Pure ASCII: identical to the ICU-based version.
+  {
+    auto [num, prefix] = getUTF8Prefix<false>("Apfelsaft", 3);
+    EXPECT_EQ(num, 3u);
+    EXPECT_EQ(prefix, "Apf");
+  }
+  // "Flöhe" where 'ö' occupies two bytes (0xC3 0xB6).
+  {
+    // The ICU-free version cuts after two bytes ("Fl").
+    auto [num, prefix] = getUTF8Prefix<false>("Flöhe", 2);
+    EXPECT_EQ(num, 2u);
+    EXPECT_EQ(prefix, "Fl");
+    // The ICU-based version counts three codepoints ("Flö", four bytes).
+    auto [numIcu, prefixIcu] = getUTF8Prefix<true>("Flöhe", 3);
+    EXPECT_EQ(numIcu, 3u);
+    EXPECT_EQ(prefixIcu, "Flö");
+  }
+  // Requesting more bytes than available returns the whole string.
+  {
+    auto [num, prefix] = getUTF8Prefix<false>("ab", 100);
+    EXPECT_EQ(num, 2u);
+    EXPECT_EQ(prefix, "ab");
+  }
+}
+
+// _____________________________________________________________________________
+// Test the ICU-free `utf8EncodeCodepoint` for one-, two-, three- and four-byte
+// codepoints as well as the replacement of out-of-range codepoints.
+TEST(StringUtils, utf8EncodeCodepoint) {
+  auto encode = [](uint32_t cp) {
+    std::string out;
+    ad_utility::utf8EncodeCodepoint(cp, out);
+    return out;
+  };
+  EXPECT_EQ(encode(0x41), "A");              // one byte
+  EXPECT_EQ(encode(0x00E9), "é");            // two bytes (U+00E9)
+  EXPECT_EQ(encode(0x2702), "✂");            // three bytes
+  EXPECT_EQ(encode(0x1F605), "\U0001F605");  // four bytes
+  // Out-of-range codepoints are replaced by U+FFFD.
+  EXPECT_EQ(encode(0x110000), "�");
+}
+
+// _____________________________________________________________________________
+// Test the ICU-free UTF-16 surrogate helpers against ICU's `U16_IS_LEAD`,
+// `U16_IS_TRAIL` and `U16_GET_SUPPLEMENTARY`.
+TEST(StringUtils, surrogateHelpers) {
+  using ad_utility::combineSurrogates;
+  using ad_utility::isHighSurrogate;
+  using ad_utility::isLowSurrogate;
+  // The predicates match ICU over the whole codepoint range (this includes the
+  // corner cases at the boundaries of the two surrogate blocks).
+  for (uint32_t c = 0; c <= 0x10FFFF; ++c) {
+    ASSERT_EQ(isHighSurrogate(c), static_cast<bool>(U16_IS_LEAD(c))) << c;
+    ASSERT_EQ(isLowSurrogate(c), static_cast<bool>(U16_IS_TRAIL(c))) << c;
+  }
+  // Combining matches ICU for every valid (high, low) surrogate pair.
+  for (uint32_t high = 0xD800; high <= 0xDBFF; ++high) {
+    for (uint32_t low = 0xDC00; low <= 0xDFFF; ++low) {
+      ASSERT_EQ(combineSurrogates(high, low),
+                static_cast<uint32_t>(U16_GET_SUPPLEMENTARY(high, low)));
+    }
+  }
 }
 
 // _____________________________________________________________________________

--- a/test/StringUtilsTest.cpp
+++ b/test/StringUtilsTest.cpp
@@ -135,8 +135,21 @@ TEST(StringUtils, utf8EncodeCodepoint) {
   EXPECT_EQ(encode(0x00E9), "é");            // two bytes (U+00E9)
   EXPECT_EQ(encode(0x2702), "✂");            // three bytes
   EXPECT_EQ(encode(0x1F605), "\U0001F605");  // four bytes
+  // The boundaries between the one-, two-, three- and four-byte encodings.
+  EXPECT_EQ(encode(0x7F), "\x7F");
+  EXPECT_EQ(encode(0x80), "\xC2\x80");
+  EXPECT_EQ(encode(0x7FF), "\xDF\xBF");
+  EXPECT_EQ(encode(0x800), "\xE0\xA0\x80");
+  EXPECT_EQ(encode(0xFFFF), "\xEF\xBF\xBF");
+  EXPECT_EQ(encode(0x10000), "\xF0\x90\x80\x80");
   // Out-of-range codepoints are replaced by U+FFFD.
   EXPECT_EQ(encode(0x110000), "�");
+  // Surrogates (reserved for UTF-16, not valid Unicode scalar values) are also
+  // replaced by U+FFFD; their direct neighbors are encoded normally.
+  EXPECT_EQ(encode(0xD800), "�");
+  EXPECT_EQ(encode(0xDFFF), "�");
+  EXPECT_EQ(encode(0xD7FF), "\xED\x9F\xBF");
+  EXPECT_EQ(encode(0xE000), "\xEE\x80\x80");
 }
 
 // _____________________________________________________________________________

--- a/test/StringUtilsTest.cpp
+++ b/test/StringUtilsTest.cpp
@@ -7,7 +7,6 @@
 #include <absl/strings/str_cat.h>
 #include <gtest/gtest.h>
 #include <unicode/unistr.h>
-#include <unicode/utf16.h>
 
 #include <ranges>
 #include <sstream>
@@ -138,62 +137,6 @@ TEST(StringUtils, utf8EncodeCodepoint) {
   EXPECT_EQ(encode(0x1F605), "\U0001F605");  // four bytes
   // Out-of-range codepoints are replaced by U+FFFD.
   EXPECT_EQ(encode(0x110000), "�");
-}
-
-// _____________________________________________________________________________
-// Test the ICU-free UTF-16 surrogate helpers at the boundaries of the two
-// surrogate blocks, which are the interesting corner cases.
-TEST(StringUtils, surrogateHelpers) {
-  using ad_utility::combineSurrogates;
-  using ad_utility::isHighSurrogate;
-  using ad_utility::isLowSurrogate;
-  // The high surrogates are exactly the block [0xD800, 0xDBFF].
-  EXPECT_FALSE(isHighSurrogate(0xD7FF));
-  EXPECT_TRUE(isHighSurrogate(0xD800));
-  EXPECT_TRUE(isHighSurrogate(0xDBFF));
-  EXPECT_FALSE(isHighSurrogate(0xDC00));
-
-  // The low surrogates are exactly the block [0xDC00, 0xDFFF].
-  EXPECT_FALSE(isLowSurrogate(0xDBFF));
-  EXPECT_TRUE(isLowSurrogate(0xDC00));
-  EXPECT_TRUE(isLowSurrogate(0xDFFF));
-  EXPECT_FALSE(isLowSurrogate(0xE000));
-
-  // Ordinary codepoints are neither.
-  EXPECT_FALSE(isHighSurrogate(0x41));
-  EXPECT_FALSE(isLowSurrogate(0x41));
-
-  // The first and the last supplementary codepoint.
-  EXPECT_EQ(combineSurrogates(0xD800, 0xDC00), 0x10000u);
-  EXPECT_EQ(combineSurrogates(0xDBFF, 0xDFFF), 0x10FFFFu);
-  // U+1F600 (GRINNING FACE) is encoded as the surrogate pair D83D DE00.
-  EXPECT_EQ(combineSurrogates(0xD83D, 0xDE00), 0x1F600u);
-}
-
-// _____________________________________________________________________________
-// Exhaustively test the ICU-free UTF-16 surrogate helpers against ICU's
-// `U16_IS_LEAD`, `U16_IS_TRAIL` and `U16_GET_SUPPLEMENTARY`. This complements
-// the `surrogateHelpers` test above, which only covers the corner cases but
-// always runs.
-TEST(StringUtils, surrogateHelpersExhaustive) {
-#ifndef QLEVER_RUN_EXPENSIVE_TESTS
-  GTEST_SKIP();
-#endif
-  using ad_utility::combineSurrogates;
-  using ad_utility::isHighSurrogate;
-  using ad_utility::isLowSurrogate;
-  // The predicates match ICU over the whole codepoint range.
-  for (uint32_t c = 0; c <= 0x10FFFF; ++c) {
-    ASSERT_EQ(isHighSurrogate(c), static_cast<bool>(U16_IS_LEAD(c))) << c;
-    ASSERT_EQ(isLowSurrogate(c), static_cast<bool>(U16_IS_TRAIL(c))) << c;
-  }
-  // Combining matches ICU for every valid (high, low) surrogate pair.
-  for (uint32_t high = 0xD800; high <= 0xDBFF; ++high) {
-    for (uint32_t low = 0xDC00; low <= 0xDFFF; ++low) {
-      ASSERT_EQ(combineSurrogates(high, low),
-                static_cast<uint32_t>(U16_GET_SUPPLEMENTARY(high, low)));
-    }
-  }
 }
 
 // _____________________________________________________________________________


### PR DESCRIPTION
Following #3095, this is the second step towards optionally building QLever without Unicode support, and therefore without the ICU dependency. The helpers in `StringUtils` now have a `useICU` template parameter: with `useICU = false`, `utf8ToLower` and `utf8ToUpper` fold only ASCII characters, and `getUTF8Prefix` treats every byte as one codepoint. Both variants are always compiled, and the ICU-free code is covered by the unit tests of a regular build. The default is controlled by the `QLEVER_NO_UNICODE` macro. There is deliberately no build option yet that defines this macro, that will follow in a later step.

NOTE: The new function `utf8EncodeCodepoint`, which encodes a single codepoint as UTF-8 without ICU, has no caller yet. It will be used by upcoming code in modules where we keep the Unicode support even without ICU, because that makes the code easier to maintain.