### PR TITLE
Split `parseAndPlanQuery` in `libqlever` into `parseQuery` and `planQuery`

### DIFF
--- a/src/engine/SortPerformanceEstimator.h
+++ b/src/engine/SortPerformanceEstimator.h
@@ -49,6 +49,11 @@ class SortPerformanceEstimator {
       const ad_utility::AllocatorWithLimit<Id>& allocator,
       size_t maxNumberOfElementsToSort);
 
+  // Return true iff `computeEstimatesExpensively` has been called. If it
+  // returns false, `estimatedSortTime` always returns zero, and sorts thus
+  // never time out.
+  bool estimatesWereCalculated() const { return _estimatesWereCalculated; }
+
   // Throw an exception if the estimated time to sort an IdTable with the given
   // number of rows and columns is larger than `deadline - now()` *
   // `RuntimeParameters(sort-estimate-cancellaction-factor)`. The exception

--- a/src/libqlever/Qlever.cpp
+++ b/src/libqlever/Qlever.cpp
@@ -264,6 +264,19 @@ PlannedQuery Qlever::planQuery(
 }
 
 // ___________________________________________________________________________
+PlannedQuery Qlever::planQuery(
+    ParsedQueryAndContext parsedQuery, SharedCancellationHandle handle,
+    std::optional<TimeLimit> timeLimit,
+    boost::optional<const ad_utility::Timer&> requestTimer) const {
+  // NOTE: `qec` is a reference into `parsedQuery`, which is alive for the
+  // duration of this call, and the resulting `PlannedQuery` takes its own
+  // `shared_ptr` to the context.
+  auto& qec = parsedQuery.queryExecutionContext();
+  return planQuery(std::move(parsedQuery.parsedQuery()), qec, std::move(handle),
+                   timeLimit, requestTimer);
+}
+
+// ___________________________________________________________________________
 ParsedQueryAndContext Qlever::parseQuery(
     std::string query, const std::vector<DatasetClause>& datasetClauses,
     std::function<void(std::string)> updateCallback, bool pinSubtrees,
@@ -287,19 +300,6 @@ ParsedQueryAndContext Qlever::bindParsedQuery(
       indexAndViewsSnapshot(), std::move(updateCallback), pinSubtrees,
       pinResult, disableCaching_);
   return ParsedQueryAndContext{std::move(parsedQuery), std::move(qecPtr)};
-}
-
-// ___________________________________________________________________________
-PlannedQuery Qlever::planQuery(
-    ParsedQueryAndContext parsedQuery, SharedCancellationHandle handle,
-    std::optional<TimeLimit> timeLimit,
-    boost::optional<const ad_utility::Timer&> requestTimer) const {
-  // NOTE: `qec` is a reference into `parsedQuery`, which is alive for the
-  // duration of this call, and the resulting `PlannedQuery` takes its own
-  // `shared_ptr` to the context.
-  auto& qec = parsedQuery.queryExecutionContext();
-  return planQuery(std::move(parsedQuery.parsedQuery()), qec, std::move(handle),
-                   timeLimit, requestTimer);
 }
 
 // ___________________________________________________________________________

--- a/src/libqlever/Qlever.cpp
+++ b/src/libqlever/Qlever.cpp
@@ -79,10 +79,13 @@ Qlever::Qlever(const EngineConfig& config, bool skipLoading)
 
   materializedViewsManager.setOnDiskBase(config.baseName_);
 
-  // Estimate the cost of sorting operations (needed for query planning).
-  sortPerformanceEstimator_.computeEstimatesExpensively(
-      allocator_, index.numTriples().normalAndInternal_() *
-                      PERCENTAGE_OF_TRIPLES_FOR_SORT_ESTIMATE / 100);
+  // Estimate the cost of sorting operations (needed for query planning), unless
+  // the user disabled this (potentially expensive) step.
+  if (config.computeSortPerformanceEstimators_) {
+    sortPerformanceEstimator_.computeEstimatesExpensively(
+        allocator_, index.numTriples().normalAndInternal_() *
+                        PERCENTAGE_OF_TRIPLES_FOR_SORT_ESTIMATE / 100);
+  }
 
   // Preload materialized views as requested by the user.
   for (const auto& viewName : config.preloadMaterializedViews_) {
@@ -261,10 +264,8 @@ PlannedQuery Qlever::planQuery(
 }
 
 // ___________________________________________________________________________
-PlannedQuery Qlever::parseAndPlanQuery(
+ParsedQueryAndContext Qlever::parseQuery(
     std::string query, const std::vector<DatasetClause>& datasetClauses,
-    SharedCancellationHandle handle, std::optional<TimeLimit> timeLimit,
-    boost::optional<const ad_utility::Timer&> requestTimer,
     std::function<void(std::string)> updateCallback, bool pinSubtrees,
     bool pinResult) const {
   auto qecPtr = createQueryExecutionContext(
@@ -275,8 +276,43 @@ PlannedQuery Qlever::parseAndPlanQuery(
       &qecPtr->getIndex().getImpl().encodedIriManager(), std::move(query),
       datasetClauses);
 
-  return planQuery(std::move(parsedQuery), *qecPtr, std::move(handle),
+  return ParsedQueryAndContext{std::move(parsedQuery), std::move(qecPtr)};
+}
+
+// ___________________________________________________________________________
+ParsedQueryAndContext Qlever::bindParsedQuery(
+    ParsedQuery parsedQuery, std::function<void(std::string)> updateCallback,
+    bool pinSubtrees, bool pinResult) const {
+  auto qecPtr = createQueryExecutionContext(
+      indexAndViewsSnapshot(), std::move(updateCallback), pinSubtrees,
+      pinResult, disableCaching_);
+  return ParsedQueryAndContext{std::move(parsedQuery), std::move(qecPtr)};
+}
+
+// ___________________________________________________________________________
+PlannedQuery Qlever::planParsedQuery(
+    ParsedQueryAndContext parsedQuery, SharedCancellationHandle handle,
+    std::optional<TimeLimit> timeLimit,
+    boost::optional<const ad_utility::Timer&> requestTimer) const {
+  // NOTE: `qec` is a reference into `parsedQuery`, which is alive for the
+  // duration of this call, and the resulting `PlannedQuery` takes its own
+  // `shared_ptr` to the context.
+  auto& qec = parsedQuery.queryExecutionContext();
+  return planQuery(std::move(parsedQuery.parsedQuery()), qec, std::move(handle),
                    timeLimit, requestTimer);
+}
+
+// ___________________________________________________________________________
+PlannedQuery Qlever::parseAndPlanQuery(
+    std::string query, const std::vector<DatasetClause>& datasetClauses,
+    SharedCancellationHandle handle, std::optional<TimeLimit> timeLimit,
+    boost::optional<const ad_utility::Timer&> requestTimer,
+    std::function<void(std::string)> updateCallback, bool pinSubtrees,
+    bool pinResult) const {
+  return planParsedQuery(
+      parseQuery(std::move(query), datasetClauses, std::move(updateCallback),
+                 pinSubtrees, pinResult),
+      std::move(handle), timeLimit, requestTimer);
 }
 
 // ___________________________________________________________________________

--- a/src/libqlever/Qlever.cpp
+++ b/src/libqlever/Qlever.cpp
@@ -290,7 +290,7 @@ ParsedQueryAndContext Qlever::bindParsedQuery(
 }
 
 // ___________________________________________________________________________
-PlannedQuery Qlever::planParsedQuery(
+PlannedQuery Qlever::planQuery(
     ParsedQueryAndContext parsedQuery, SharedCancellationHandle handle,
     std::optional<TimeLimit> timeLimit,
     boost::optional<const ad_utility::Timer&> requestTimer) const {
@@ -309,7 +309,7 @@ PlannedQuery Qlever::parseAndPlanQuery(
     boost::optional<const ad_utility::Timer&> requestTimer,
     std::function<void(std::string)> updateCallback, bool pinSubtrees,
     bool pinResult) const {
-  return planParsedQuery(
+  return planQuery(
       parseQuery(std::move(query), datasetClauses, std::move(updateCallback),
                  pinSubtrees, pinResult),
       std::move(handle), timeLimit, requestTimer);

--- a/src/libqlever/Qlever.h
+++ b/src/libqlever/Qlever.h
@@ -255,7 +255,7 @@ struct EngineConfig : CommonConfig {
   // concrete machine. This step can take some time and can be disabled by
   // setting this flag to `false`. In that case, sort operations are always
   // started and run to completion (unless the query times out or is canceled
-  // before the operation starts).
+  // before the sort operation starts).
   bool computeSortPerformanceEstimators_ = true;
 
   // A list of IRI prefixes that are allowed as `SERVICE` endpoints. If empty
@@ -374,10 +374,10 @@ class Qlever {
   // `QueryExecutionContext` to plan and execute it against, see
   // `ParsedQueryAndContext`.
   //
-  // This is the first half of `parseAndPlanQuery`, the second half being
-  // `planParsedQuery`. Calling the two separately is useful to inspect or
-  // modify the `ParsedQuery` before it is planned, to measure the time for the
-  // parsing and the planning separately, and to reuse a parsed query (see
+  // This is the first half of `parseAndPlanQuery`, the second half being the
+  // `planQuery` overload below. Calling the two separately is useful to inspect
+  // or modify the `ParsedQuery` before it is planned, to measure the time for
+  // the parsing and the planning separately, and to reuse a parsed query (see
   // below).
   //
   // NOTE ON REUSING A PARSED QUERY: The `ParsedQuery` depends on the
@@ -413,11 +413,11 @@ class Qlever {
   // Plan a query that was parsed by `parseQuery` (or bundled by
   // `bindParsedQuery`). The query is planned against the
   // `QueryExecutionContext` that `parsedQuery` carries, so the two can not get
-  // out of sync.
+  // out of sync. Implemented in terms of the `planQuery` overload above.
   //
   // For the semantics of `handle`, `timeLimit`, and `requestTimer`, see
   // `planQuery` above.
-  PlannedQuery planParsedQuery(
+  PlannedQuery planQuery(
       ParsedQueryAndContext parsedQuery,
       SharedCancellationHandle handle =
           std::make_shared<ad_utility::CancellationHandle<>>(),
@@ -427,7 +427,7 @@ class Qlever {
 
   // Parse and plan the given `query` (see `planQuery` above; despite the
   // name, `query` may also be a SPARQL update operation). This is exactly
-  // `parseQuery` followed by `planParsedQuery`.
+  // `parseQuery` followed by `planQuery`.
   //
   // NOTES: This is useful as a separate function for the following reasons.
   //
@@ -546,7 +546,7 @@ class Qlever {
     blobManager_.deserialize(*this, blob, allocator);
   }
 
-  // Clear the (unnamed) query result cache.
+  // Clear the query result cache.
   void clearCache() { cache_.clearAll(); }
 
   // Create a Query Execution Context needed for execution of single SPARQL
@@ -641,7 +641,6 @@ class Qlever {
   NamedResultCache& namedResultCache() { return namedResultCache_; }
   const NamedResultCache& namedResultCache() const { return namedResultCache_; }
 };
-
 }  // namespace qlever
 
 #endif  // QLEVER_SRC_LIBQLEVER_QLEVER_H

--- a/src/libqlever/Qlever.h
+++ b/src/libqlever/Qlever.h
@@ -249,6 +249,15 @@ struct EngineConfig : CommonConfig {
   // separately).
   bool doNotLoadPermutations_ = false;
 
+  // QLever doesn't use a cancelable sorting algorithm, but before starting a
+  // sort estimates whether the sort will time out. To do so, on index load it
+  // sorts some `IdTable`s to measure the time that sorting takes on the
+  // concrete machine. This step can take some time and can be disabled by
+  // setting this flag to `false`. In that case, sort operations are always
+  // started and run to completion (unless the query times out or is canceled
+  // before the operation starts).
+  bool computeSortPerformanceEstimators_ = true;
+
   // A list of IRI prefixes that are allowed as `SERVICE` endpoints. If empty
   // (the default), all IRIs are allowed. If non-empty, `SERVICE` requests to
   // IRIs that do not start with any of the given prefixes are rejected.
@@ -268,6 +277,8 @@ struct EngineConfig : CommonConfig {
 // `src/engine/LibQleverExample.cpp` for an example use.
 class Qlever {
  public:
+  using PlannedQuery = qlever::PlannedQuery;
+
   // Bundle the `Index` and the `MaterializedViewsManager` under a single mutex
   // so that an index rebuild can atomically swap both in, while other threads
   // continue to read the previous instances via the `shared_ptr`s they hold.
@@ -334,8 +345,6 @@ class Qlever {
   // before it can answer queries.
   explicit Qlever(const EngineConfig& config, bool skipLoading = false);
 
-  using PlannedQuery = qlever::PlannedQuery;
-
   // Run the query planner on `parsedQuery`. Despite the name, `ParsedQuery`
   // is also used to represent SPARQL update operations (see
   // ParsedQuery::hasUpdateClause()); this function handles both cases
@@ -360,8 +369,65 @@ class Qlever {
                          boost::optional<const ad_utility::Timer&>
                              requestTimer = boost::none) const;
 
+  // Parse the given `query` (despite the name, `query` may also be a SPARQL
+  // update operation) and return it together with the
+  // `QueryExecutionContext` to plan and execute it against, see
+  // `ParsedQueryAndContext`.
+  //
+  // This is the first half of `parseAndPlanQuery`, the second half being
+  // `planParsedQuery`. Calling the two separately is useful to inspect or
+  // modify the `ParsedQuery` before it is planned, to measure the time for the
+  // parsing and the planning separately, and to reuse a parsed query (see
+  // below).
+  //
+  // NOTE ON REUSING A PARSED QUERY: The `ParsedQuery` depends on the
+  // `QueryExecutionContext` it was parsed with, but only through that context's
+  // `EncodedIriManager` (which determines which IRIs are encoded directly in
+  // the ID). It is therefore valid, and saves the repeated parsing of the same
+  // query, to take the `ParsedQuery` out of the result and plan it against a
+  // *different* context, as long as that context has an equivalent
+  // `EncodedIriManager` (see `bindParsedQuery`). This is in particular the case
+  // for several `Qlever` instances whose indexes were built with the same
+  // `IndexBuilderConfig::prefixesForIdEncodedIris_`. If the
+  // `EncodedIriManager`s differ, the affected IRIs are silently misinterpreted,
+  // so this has to be ensured by the caller.
+  ParsedQueryAndContext parseQuery(
+      std::string query, const std::vector<DatasetClause>& datasetClauses = {},
+      std::function<void(std::string)> updateCallback =
+          [](std::string) { /* the default is a noop*/ },
+      bool pinSubtrees = false, bool pinResult = false) const;
+
+  // Bundle an already-parsed query with a fresh `QueryExecutionContext` of this
+  // instance, so that it can be planned here. Together with `parseQuery` this
+  // makes it possible to parse a query once and plan it on several instances.
+  //
+  // PRECONDITION: `parsedQuery` must have been parsed with a context whose
+  // `EncodedIriManager` is equivalent to this instance's; see the note on
+  // reusing a parsed query in `parseQuery` above. This is not checked.
+  ParsedQueryAndContext bindParsedQuery(
+      ParsedQuery parsedQuery,
+      std::function<void(std::string)> updateCallback =
+          [](std::string) { /* the default is a noop*/ },
+      bool pinSubtrees = false, bool pinResult = false) const;
+
+  // Plan a query that was parsed by `parseQuery` (or bundled by
+  // `bindParsedQuery`). The query is planned against the
+  // `QueryExecutionContext` that `parsedQuery` carries, so the two can not get
+  // out of sync.
+  //
+  // For the semantics of `handle`, `timeLimit`, and `requestTimer`, see
+  // `planQuery` above.
+  PlannedQuery planParsedQuery(
+      ParsedQueryAndContext parsedQuery,
+      SharedCancellationHandle handle =
+          std::make_shared<ad_utility::CancellationHandle<>>(),
+      std::optional<TimeLimit> timeLimit = std::nullopt,
+      boost::optional<const ad_utility::Timer&> requestTimer =
+          boost::none) const;
+
   // Parse and plan the given `query` (see `planQuery` above; despite the
-  // name, `query` may also be a SPARQL update operation).
+  // name, `query` may also be a SPARQL update operation). This is exactly
+  // `parseQuery` followed by `planParsedQuery`.
   //
   // NOTES: This is useful as a separate function for the following reasons.
   //
@@ -480,6 +546,9 @@ class Qlever {
     blobManager_.deserialize(*this, blob, allocator);
   }
 
+  // Clear the (unnamed) query result cache.
+  void clearCache() { cache_.clearAll(); }
+
   // Create a Query Execution Context needed for execution of single SPARQL
   // query. Use an explicitly snapshotted `IndexAndViews` to make sure we have a
   // consistent state.
@@ -572,6 +641,7 @@ class Qlever {
   NamedResultCache& namedResultCache() { return namedResultCache_; }
   const NamedResultCache& namedResultCache() const { return namedResultCache_; }
 };
+
 }  // namespace qlever
 
 #endif  // QLEVER_SRC_LIBQLEVER_QLEVER_H

--- a/src/libqlever/Qlever.h
+++ b/src/libqlever/Qlever.h
@@ -369,13 +369,28 @@ class Qlever {
                          boost::optional<const ad_utility::Timer&>
                              requestTimer = boost::none) const;
 
+  // Plan a query that was parsed by `parseQuery` (or bundled by
+  // `bindParsedQuery`, both see below). The query is planned against the
+  // `QueryExecutionContext` that `parsedQuery` carries, so the two can not get
+  // out of sync. Implemented in terms of the `planQuery` overload above.
+  //
+  // For the semantics of `handle`, `timeLimit`, and `requestTimer`, see
+  // `planQuery` above.
+  PlannedQuery planQuery(
+      ParsedQueryAndContext parsedQuery,
+      SharedCancellationHandle handle =
+          std::make_shared<ad_utility::CancellationHandle<>>(),
+      std::optional<TimeLimit> timeLimit = std::nullopt,
+      boost::optional<const ad_utility::Timer&> requestTimer =
+          boost::none) const;
+
   // Parse the given `query` (despite the name, `query` may also be a SPARQL
   // update operation) and return it together with the
   // `QueryExecutionContext` to plan and execute it against, see
   // `ParsedQueryAndContext`.
   //
   // This is the first half of `parseAndPlanQuery`, the second half being the
-  // `planQuery` overload below. Calling the two separately is useful to inspect
+  // `planQuery` overload above. Calling the two separately is useful to inspect
   // or modify the `ParsedQuery` before it is planned, to measure the time for
   // the parsing and the planning separately, and to reuse a parsed query (see
   // below).
@@ -409,21 +424,6 @@ class Qlever {
       std::function<void(std::string)> updateCallback =
           [](std::string) { /* the default is a noop*/ },
       bool pinSubtrees = false, bool pinResult = false) const;
-
-  // Plan a query that was parsed by `parseQuery` (or bundled by
-  // `bindParsedQuery`). The query is planned against the
-  // `QueryExecutionContext` that `parsedQuery` carries, so the two can not get
-  // out of sync. Implemented in terms of the `planQuery` overload above.
-  //
-  // For the semantics of `handle`, `timeLimit`, and `requestTimer`, see
-  // `planQuery` above.
-  PlannedQuery planQuery(
-      ParsedQueryAndContext parsedQuery,
-      SharedCancellationHandle handle =
-          std::make_shared<ad_utility::CancellationHandle<>>(),
-      std::optional<TimeLimit> timeLimit = std::nullopt,
-      boost::optional<const ad_utility::Timer&> requestTimer =
-          boost::none) const;
 
   // Parse and plan the given `query` (see `planQuery` above; despite the
   // name, `query` may also be a SPARQL update operation). This is exactly

--- a/src/libqlever/Qlever.h
+++ b/src/libqlever/Qlever.h
@@ -32,6 +32,7 @@
 #include "util/AllocatorWithLimit.h"
 #include "util/MemorySize/MemorySize.h"
 #include "util/Synchronized.h"
+#include "util/TransparentFunctors.h"
 #include "util/http/MediaTypes.h"
 
 namespace qlever {
@@ -408,8 +409,7 @@ class Qlever {
   // so this has to be ensured by the caller.
   ParsedQueryAndContext parseQuery(
       std::string query, const std::vector<DatasetClause>& datasetClauses = {},
-      std::function<void(std::string)> updateCallback =
-          [](std::string) { /* the default is a noop*/ },
+      std::function<void(std::string)> updateCallback = ad_utility::noop,
       bool pinSubtrees = false, bool pinResult = false) const;
 
   // Bundle an already-parsed query with a fresh `QueryExecutionContext` of this
@@ -421,8 +421,7 @@ class Qlever {
   // reusing a parsed query in `parseQuery` above. This is not checked.
   ParsedQueryAndContext bindParsedQuery(
       ParsedQuery parsedQuery,
-      std::function<void(std::string)> updateCallback =
-          [](std::string) { /* the default is a noop*/ },
+      std::function<void(std::string)> updateCallback = ad_utility::noop,
       bool pinSubtrees = false, bool pinResult = false) const;
 
   // Parse and plan the given `query` (see `planQuery` above; despite the
@@ -454,8 +453,7 @@ class Qlever {
           std::make_shared<ad_utility::CancellationHandle<>>(),
       std::optional<TimeLimit> timeLimit = std::nullopt,
       boost::optional<const ad_utility::Timer&> requestTimer = boost::none,
-      std::function<void(std::string)> updateCallback =
-          [](std::string) { /* the default is a noop*/ },
+      std::function<void(std::string)> updateCallback = ad_utility::noop,
       bool pinSubtrees = false, bool pinResult = false) const;
 
   // Run the given parsed and planned query. The result is returned as a
@@ -554,8 +552,7 @@ class Qlever {
   // consistent state.
   std::shared_ptr<QueryExecutionContext> createQueryExecutionContext(
       std::shared_ptr<IndexAndViews> indexAndViews,
-      std::function<void(std::string)> updateCallback =
-          [](std::string) { /* the default is a noop*/ },
+      std::function<void(std::string)> updateCallback = ad_utility::noop,
       bool pinSubtrees = false, bool pinResult = false,
       QueryExecutionContext::DisableCaching disableCaching =
           QueryExecutionContext::DisableCaching::FromRuntimeParameter) const;

--- a/src/libqlever/QleverTypes.h
+++ b/src/libqlever/QleverTypes.h
@@ -20,7 +20,7 @@ namespace qlever {
 
 // A `ParsedQuery` together with the `QueryExecutionContext` that it was parsed
 // against and that it therefore has to be planned against. Returned by
-// `Qlever::parseQuery` and consumed by `Qlever::planParsedQuery`.
+// `Qlever::parseQuery` and consumed by `Qlever::planQuery`.
 //
 // NOTE: The two are bundled deliberately, so that a query is planned against
 // the context it was parsed with by default. Parsing depends on the context
@@ -102,12 +102,11 @@ struct PlannedQuery {
   // held by `shared_ptr`); calling this afterwards gives this `PlannedQuery` a
   // tree of its own, which can then be modified and executed without affecting
   // the other copies. That makes it possible to plan a query once and then
-  // instantiate it repeatedly, for example by injecting varying values into the
-  // `ExternalValues` placeholder of a pre-planned query template.
+  // modify and execute it repeatedly, for example by injecting varying values
+  // into the `ExternalValues` placeholder of a pre-planned query template.
   //
-  // NOTE: `QueryExecutionTree::clone` recursively clones the operations, but
-  // never copies the tree itself. The `QueryExecutionContext` is untouched and
-  // stays shared with the other copies.
+  // NOTE: The `QueryExecutionContext` is untouched and stays shared with the
+  // other copies of `*this`.
   void cloneQetInPlace() {
     queryExecutionTree_ = queryExecutionTree_->clone();
     AD_CORRECTNESS_CHECK(qec_.get() == queryExecutionTree_->getQec());

--- a/src/libqlever/QleverTypes.h
+++ b/src/libqlever/QleverTypes.h
@@ -18,6 +18,41 @@
 
 namespace qlever {
 
+// A `ParsedQuery` together with the `QueryExecutionContext` that it was parsed
+// against and that it therefore has to be planned against. Returned by
+// `Qlever::parseQuery` and consumed by `Qlever::planParsedQuery`.
+//
+// NOTE: The two are bundled deliberately, so that a query is planned against
+// the context it was parsed with by default. Parsing depends on the context
+// only through the context's `EncodedIriManager`, so a `ParsedQuery` may be
+// reused with a different context that has an equivalent `EncodedIriManager`;
+// see the note on reusing a parsed query in `Qlever::parseQuery` and
+// `Qlever::bindParsedQuery`.
+class ParsedQueryAndContext {
+ private:
+  // NOTE: As in `PlannedQuery` below, `qec_` is declared first so that it is
+  // destroyed last.
+  std::shared_ptr<QueryExecutionContext> qec_;
+  ParsedQuery parsedQuery_;
+
+ public:
+  ParsedQueryAndContext(ParsedQuery parsedQuery,
+                        std::shared_ptr<QueryExecutionContext> qec)
+      : qec_{std::move(qec)}, parsedQuery_{std::move(parsedQuery)} {
+    AD_CONTRACT_CHECK(qec_ != nullptr);
+  }
+
+  const ParsedQuery& parsedQuery() const { return parsedQuery_; }
+  ParsedQuery& parsedQuery() { return parsedQuery_; }
+
+  const QueryExecutionContext& queryExecutionContext() const { return *qec_; }
+  QueryExecutionContext& queryExecutionContext() { return *qec_; }
+  const std::shared_ptr<QueryExecutionContext>& sharedQueryExecutionContext()
+      const {
+    return qec_;
+  }
+};
+
 // Helper struct bundling a parsed query with a query execution tree.
 // We store both `QueryExecutionTree` and `QueryExecutionContext` as
 // `shared_ptr` to avoid lifetime issues especially in the asynchronous server
@@ -60,6 +95,22 @@ struct PlannedQuery {
   std::shared_ptr<const QueryExecutionContext> sharedQueryExecutionContext()
       const {
     return qec_;
+  }
+
+  // Replace the `QueryExecutionTree` of this `PlannedQuery` by a fresh clone of
+  // itself. Copying a `PlannedQuery` shares the tree between the copies (it is
+  // held by `shared_ptr`); calling this afterwards gives this `PlannedQuery` a
+  // tree of its own, which can then be modified and executed without affecting
+  // the other copies. That makes it possible to plan a query once and then
+  // instantiate it repeatedly, for example by injecting varying values into the
+  // `ExternalValues` placeholder of a pre-planned query template.
+  //
+  // NOTE: `QueryExecutionTree::clone` recursively clones the operations, but
+  // never copies the tree itself. The `QueryExecutionContext` is untouched and
+  // stays shared with the other copies.
+  void cloneQetInPlace() {
+    queryExecutionTree_ = queryExecutionTree_->clone();
+    AD_CORRECTNESS_CHECK(qec_.get() == queryExecutionTree_->getQec());
   }
 };
 }  // namespace qlever

--- a/test/libqlever/QleverTest.cpp
+++ b/test/libqlever/QleverTest.cpp
@@ -24,6 +24,35 @@
 using namespace qlever;
 using namespace testing;
 
+namespace {
+// Write `turtleContents` to a turtle file, build an index from it with all
+// settings at their default, and return an `EngineConfig` for that index. The
+// base name of both the turtle file and the index is derived from the name of
+// the currently running test and the optional `suffix`, so that a single test
+// can build several distinct indexes. The turtle file is deleted again before
+// this returns; the files of the index itself remain on disk.
+//
+// NOTE: An index that cannot be built throws, which `gtest` reports as a
+// failure of the running test. This is deliberately not an `EXPECT_NO_THROW`,
+// which would let the test continue with a nonexistent index.
+EngineConfig buildTestIndex(std::string_view turtleContents,
+                            std::string_view suffix = "") {
+  std::string basename = absl::StrCat(gtestCurrentTestName(), suffix);
+  std::string filename = absl::StrCat(basename, ".ttl");
+  {
+    auto ofs = ad_utility::makeOfstream(filename);
+    ofs << turtleContents;
+  }
+  absl::Cleanup cleanup = [&filename] { ad_utility::deleteFile(filename); };
+
+  IndexBuilderConfig config;
+  config.inputFiles_.push_back({filename, Filetype::Turtle, std::nullopt});
+  config.baseName_ = basename;
+  Qlever::buildIndex(config);
+  return EngineConfig{config};
+}
+}  // namespace
+
 // _____________________________________________________________________________
 TEST(LibQlever, buildIndexAndRunQuery) {
   std::string filename = "libQleverbuildIndexAndRunQuery.ttl";
@@ -215,22 +244,9 @@ TEST(IndexBuilderConfig, validate) {
 
 // _____________________________________________________________________________
 TEST(LibQlever, loadIndexWithoutPermutations) {
-  std::string filename = "libQleverLoadIndexWithoutPermutations.ttl";
-  {
-    auto ofs = ad_utility::makeOfstream(filename);
-    ofs << "<s> <p> <o>. <s2> <p2> \"literal\".";
-  }
-
-  IndexBuilderConfig c;
-  c.inputFiles_.push_back({filename, Filetype::Turtle, std::nullopt});
-  c.baseName_ = "LibQlever.loadIndexWithoutPermutations";
-  c.memoryLimit_ = std::nullopt;
-
-  // Build the index normally.
-  EXPECT_NO_THROW(Qlever::buildIndex(c));
+  EngineConfig ec = buildTestIndex("<s> <p> <o>. <s2> <p2> \"literal\".");
 
   // Load the index with `doNotLoadPermutations` set to true.
-  EngineConfig ec{c};
   ec.doNotLoadPermutations_ = true;
   Qlever engine{ec};
 
@@ -257,17 +273,7 @@ TEST(LibQlever, loadIndexWithoutPermutations) {
 // named result cache is not empty (its entries are only valid for one specific
 // snapshot). Uses `FRIEND_TEST` to reach the otherwise private method.
 TEST(LibQlever, swapIndexAndViewsThrowsWithNonEmptyNamedCache) {
-  std::string filename = "libQleverSwapIndexAndViews.ttl";
-  {
-    auto ofs = ad_utility::makeOfstream(filename);
-    ofs << "<s> <p> <o>.";
-  }
-  IndexBuilderConfig c;
-  c.inputFiles_.push_back({filename, Filetype::Turtle, std::nullopt});
-  c.baseName_ = "LibQlever.swapIndexAndViews";
-  EXPECT_NO_THROW(Qlever::buildIndex(c));
-
-  Qlever qlever{EngineConfig{c}};
+  Qlever qlever{buildTestIndex("<s> <p> <o>.")};
 
   // With an empty named result cache, swapping (here: with the current
   // snapshot) is allowed.
@@ -285,21 +291,7 @@ TEST(LibQlever, swapIndexAndViewsThrowsWithNonEmptyNamedCache) {
 
 // _____________________________________________________________________________
 TEST(LibQlever, disableCaching) {
-  std::string filename = "libQleverDisableCaching.ttl";
-  {
-    auto ofs = ad_utility::makeOfstream(filename);
-    ofs << "<s> <p> <o>. <s2> <p2> \"literal\".";
-  }
-
-  IndexBuilderConfig c;
-  c.inputFiles_.push_back({filename, Filetype::Turtle, std::nullopt});
-  c.baseName_ = "LibQlever.disableCaching";
-  c.memoryLimit_ = std::nullopt;
-
-  // Build the index normally.
-  EXPECT_NO_THROW(Qlever::buildIndex(c));
-
-  EngineConfig ec{c};
+  EngineConfig ec = buildTestIndex("<s> <p> <o>. <s2> <p2> \"literal\".");
   {
     // Load the index with `disableCaching` set to true.
     ec.disableCaching_ = QueryExecutionContext::DisableCaching::True;
@@ -344,18 +336,7 @@ TEST(LibQlever, disableCaching) {
 
 // _____________________________________________________________________________
 TEST(LibQlever, externallySpecifiedValues) {
-  std::string filename = "libQleverExternalValues.ttl";
-  {
-    auto ofs = ad_utility::makeOfstream(filename);
-    ofs << "<s1> <p> 1 . <s2> <p> 2 . <s3> <p> 3 .";
-  }
-
-  IndexBuilderConfig c;
-  c.inputFiles_.push_back({filename, Filetype::Turtle, std::nullopt});
-  c.baseName_ = "testIndexForExternalValues";
-  EXPECT_NO_THROW(Qlever::buildIndex(c));
-
-  EngineConfig ec{c};
+  EngineConfig ec = buildTestIndex("<s1> <p> 1 . <s2> <p> 2 . <s3> <p> 3 .");
   // Caching must be disabled for externally specified values.
   ec.disableCaching_ = QueryExecutionContext::DisableCaching::True;
   Qlever engine{ec};
@@ -652,19 +633,7 @@ TEST(Qlever, indexRebuildConfigRejectsCollidingBaseNames) {
 // its `QueryExecutionTree`, and `cloneQetInPlace` gives the copy a tree of its
 // own, which can then be modified without affecting the original.
 TEST(LibQlever, planQueryOfParsedQueryAndCloneQetInPlace) {
-  std::string filename = absl::StrCat(gtestCurrentTestName(), ".ttl");
-  {
-    auto ofs = ad_utility::makeOfstream(filename);
-    ofs << "<s1> <p> 1 . <s2> <p> 2 . <s3> <p> 3 .";
-  }
-  absl::Cleanup cleanup = [&filename] { ad_utility::deleteFile(filename); };
-
-  IndexBuilderConfig c;
-  c.inputFiles_.push_back({filename, Filetype::Turtle, std::nullopt});
-  c.baseName_ = gtestCurrentTestName();
-  EXPECT_NO_THROW(Qlever::buildIndex(c));
-
-  EngineConfig ec{c};
+  EngineConfig ec = buildTestIndex("<s1> <p> 1 . <s2> <p> 2 . <s3> <p> 3 .");
   // Caching must be disabled for externally specified values.
   ec.disableCaching_ = QueryExecutionContext::DisableCaching::True;
   Qlever engine{ec};
@@ -743,18 +712,7 @@ TEST(LibQlever, planQueryOfParsedQueryAndCloneQetInPlace) {
 // Test that `parseAndPlanQuery` is exactly `parseQuery` followed by
 // `planQuery`, and that all the arguments of the former reach the two halves.
 TEST(LibQlever, parseAndPlanQueryIsParseThenPlan) {
-  std::string filename = absl::StrCat(gtestCurrentTestName(), ".ttl");
-  {
-    auto ofs = ad_utility::makeOfstream(filename);
-    ofs << "<s> <p> <o> . <s2> <p> <o2> .";
-  }
-  absl::Cleanup cleanup = [&filename] { ad_utility::deleteFile(filename); };
-
-  IndexBuilderConfig c;
-  c.inputFiles_.push_back({filename, Filetype::Turtle, std::nullopt});
-  c.baseName_ = gtestCurrentTestName();
-  EXPECT_NO_THROW(Qlever::buildIndex(c));
-  Qlever engine{EngineConfig{c}};
+  Qlever engine{buildTestIndex("<s> <p> <o> . <s2> <p> <o2> .")};
 
   std::string query = "SELECT ?s WHERE { ?s <p> ?o }";
 
@@ -793,25 +751,11 @@ TEST(LibQlever, parseAndPlanQueryIsParseThenPlan) {
 // second `Qlever` instance, as long as that instance has an equivalent
 // `EncodedIriManager` (see the note on reusing a parsed query in `parseQuery`).
 TEST(LibQlever, bindParsedQueryReusesAParsedQuery) {
-  std::string filename = absl::StrCat(gtestCurrentTestName(), ".ttl");
-  {
-    auto ofs = ad_utility::makeOfstream(filename);
-    ofs << "<s> <p> <o> . <s2> <p> <o2> .";
-  }
-  absl::Cleanup cleanup = [&filename] { ad_utility::deleteFile(filename); };
-
   // Two indexes over the same data and with the same configuration, so their
   // `EncodedIriManager`s are equivalent.
-  IndexBuilderConfig c1;
-  c1.inputFiles_.push_back({filename, Filetype::Turtle, std::nullopt});
-  c1.baseName_ = absl::StrCat(gtestCurrentTestName(), ".first");
-  EXPECT_NO_THROW(Qlever::buildIndex(c1));
-  IndexBuilderConfig c2 = c1;
-  c2.baseName_ = absl::StrCat(gtestCurrentTestName(), ".second");
-  EXPECT_NO_THROW(Qlever::buildIndex(c2));
-
-  Qlever first{EngineConfig{c1}};
-  Qlever second{EngineConfig{c2}};
+  std::string_view turtle = "<s> <p> <o> . <s2> <p> <o2> .";
+  Qlever first{buildTestIndex(turtle, ".first")};
+  Qlever second{buildTestIndex(turtle, ".second")};
 
   std::string query = "SELECT ?s WHERE { ?s <p> ?o }";
   std::string expected = "?s\n<s>\n<s2>\n";
@@ -840,19 +784,7 @@ TEST(LibQlever, bindParsedQueryReusesAParsedQuery) {
 // expensive) estimates are computed by default, but not if the config disables
 // them.
 TEST(LibQlever, computeSortPerformanceEstimators) {
-  std::string filename = absl::StrCat(gtestCurrentTestName(), ".ttl");
-  {
-    auto ofs = ad_utility::makeOfstream(filename);
-    ofs << "<s> <p> <o> .";
-  }
-  absl::Cleanup cleanup = [&filename] { ad_utility::deleteFile(filename); };
-
-  IndexBuilderConfig c;
-  c.inputFiles_.push_back({filename, Filetype::Turtle, std::nullopt});
-  c.baseName_ = gtestCurrentTestName();
-  EXPECT_NO_THROW(Qlever::buildIndex(c));
-
-  EngineConfig ec{c};
+  EngineConfig ec = buildTestIndex("<s> <p> <o> .");
   ASSERT_TRUE(ec.computeSortPerformanceEstimators_);
   EXPECT_TRUE(Qlever{ec}.sortPerformanceEstimator().estimatesWereCalculated());
 
@@ -864,18 +796,7 @@ TEST(LibQlever, computeSortPerformanceEstimators) {
 // Test the trivial getters of `ParsedQueryAndContext`, both the `const` and the
 // non-`const` overloads. All of them refer to the same objects.
 TEST(LibQlever, parsedQueryAndContextGetters) {
-  std::string filename = absl::StrCat(gtestCurrentTestName(), ".ttl");
-  {
-    auto ofs = ad_utility::makeOfstream(filename);
-    ofs << "<s> <p> <o> .";
-  }
-  absl::Cleanup cleanup = [&filename] { ad_utility::deleteFile(filename); };
-
-  IndexBuilderConfig c;
-  c.inputFiles_.push_back({filename, Filetype::Turtle, std::nullopt});
-  c.baseName_ = gtestCurrentTestName();
-  EXPECT_NO_THROW(Qlever::buildIndex(c));
-  Qlever engine{EngineConfig{c}};
+  Qlever engine{buildTestIndex("<s> <p> <o> .")};
 
   std::string query = "SELECT ?s WHERE { ?s <p> ?o }";
   ParsedQueryAndContext parsedQuery = engine.parseQuery(query);
@@ -899,18 +820,7 @@ TEST(LibQlever, parsedQueryAndContextGetters) {
 // Test `Qlever::clearCache`, and trivially the `const` getter for the named
 // result cache.
 TEST(LibQlever, clearCache) {
-  std::string filename = absl::StrCat(gtestCurrentTestName(), ".ttl");
-  {
-    auto ofs = ad_utility::makeOfstream(filename);
-    ofs << "<s> <p> <o> . <s2> <p> <o2> .";
-  }
-  absl::Cleanup cleanup = [&filename] { ad_utility::deleteFile(filename); };
-
-  IndexBuilderConfig c;
-  c.inputFiles_.push_back({filename, Filetype::Turtle, std::nullopt});
-  c.baseName_ = gtestCurrentTestName();
-  EXPECT_NO_THROW(Qlever::buildIndex(c));
-  Qlever engine{EngineConfig{c}};
+  Qlever engine{buildTestIndex("<s> <p> <o> . <s2> <p> <o2> .")};
 
   // The cache starts out empty.
   ASSERT_EQ(engine.cache().numPinnedEntries(), 0U);

--- a/test/libqlever/QleverTest.cpp
+++ b/test/libqlever/QleverTest.cpp
@@ -644,3 +644,194 @@ TEST(Qlever, indexRebuildConfigRejectsCollidingBaseNames) {
       IndexRebuildConfig("index", "index.view", "previous/old", "newidx"),
       ::testing::HasSubstr("currently served index and the freshly rebuilt"));
 }
+
+// _____________________________________________________________________________
+// Test `parseQuery` + `planParsedQuery` + `PlannedQuery::cloneQetInPlace`,
+// which together make it possible to plan a query once and then execute it
+// repeatedly with varying values: copying the resulting `PlannedQuery` shares
+// its `QueryExecutionTree`, and `cloneQetInPlace` gives the copy a tree of its
+// own, which can then be modified without affecting the original.
+TEST(LibQlever, planParsedQueryAndCloneQetInPlace) {
+  std::string filename = absl::StrCat(gtestCurrentTestName(), ".ttl");
+  {
+    auto ofs = ad_utility::makeOfstream(filename);
+    ofs << "<s1> <p> 1 . <s2> <p> 2 . <s3> <p> 3 .";
+  }
+  absl::Cleanup cleanup = [&filename] { ad_utility::deleteFile(filename); };
+
+  IndexBuilderConfig c;
+  c.inputFiles_.push_back({filename, Filetype::Turtle, std::nullopt});
+  c.baseName_ = gtestCurrentTestName();
+  EXPECT_NO_THROW(Qlever::buildIndex(c));
+
+  EngineConfig ec{c};
+  // Caching must be disabled for externally specified values.
+  ec.disableCaching_ = QueryExecutionContext::DisableCaching::True;
+  Qlever engine{ec};
+
+  std::string query = R"(
+    SELECT ?x ?o WHERE {
+      ?x <p> ?o .
+      SERVICE <https://qlever.cs.uni-freiburg.de/external-values/> {
+        [] <name> "myValues" .
+        [] <variable> ?x .
+      }
+    } ORDER BY ?o
+  )";
+
+  // Parsing is instance-independent, planning is not, so the same
+  // `ParsedQuery` can be planned more than once.
+  // `parseQuery` returns the `ParsedQuery` together with the
+  // `QueryExecutionContext` it was parsed against, and `planParsedQuery` plans
+  // it against exactly that context.
+  ParsedQueryAndContext parsedQuery = engine.parseQuery(query);
+  EXPECT_EQ(&parsedQuery.queryExecutionContext(),
+            parsedQuery.sharedQueryExecutionContext().get());
+  PlannedQuery plan = engine.planParsedQuery(parsedQuery);
+  EXPECT_EQ(&plan.queryExecutionContext(),
+            &parsedQuery.queryExecutionContext());
+
+  // Inject `iris` into the single `ExternalValues` placeholder of `plan`,
+  // execute it, and return the objects that it yields (ordered by `?o`).
+  auto runWith = [](PlannedQuery& plan, const std::vector<std::string>& iris) {
+    std::vector<ExternalValues*> values;
+    plan.queryExecutionTree().getRootOperation()->getExternalValues(values);
+    AD_CONTRACT_CHECK(values.size() == 1);
+    parsedQuery::SparqlValues newValues;
+    newValues._variables = {Variable{"?x"}};
+    for (const auto& iri : iris) {
+      newValues._values.push_back({TripleComponent::Iri::fromIriref(iri)});
+    }
+    values.at(0)->updateValues(std::move(newValues));
+
+    const auto& qet = plan.queryExecutionTree();
+    auto result = qet.getResult();
+    auto objectColumn = qet.getVariableColumn(Variable{"?o"});
+    std::vector<int64_t> objects;
+    for (size_t i = 0; i < result->idTableView().numRows(); ++i) {
+      objects.push_back(result->idTableView()(i, objectColumn).getInt());
+    }
+    return objects;
+  };
+
+  // A copy of a `PlannedQuery` shares the `QueryExecutionTree`, so modifying
+  // the copy would also modify `plan`.
+  PlannedQuery firstCopy = plan;
+  EXPECT_EQ(&firstCopy.queryExecutionTree(), &plan.queryExecutionTree());
+
+  // `cloneQetInPlace` gives the copy its own tree, while the
+  // `QueryExecutionContext` stays shared.
+  firstCopy.cloneQetInPlace();
+  EXPECT_NE(&firstCopy.queryExecutionTree(), &plan.queryExecutionTree());
+  EXPECT_EQ(&firstCopy.queryExecutionContext(), &plan.queryExecutionContext());
+
+  PlannedQuery secondCopy = plan;
+  secondCopy.cloneQetInPlace();
+  EXPECT_NE(&secondCopy.queryExecutionTree(), &firstCopy.queryExecutionTree());
+
+  // The two copies can be given different values and executed independently.
+  EXPECT_THAT(runWith(firstCopy, {"<s1>", "<s3>"}), ElementsAre(1, 3));
+  EXPECT_THAT(runWith(secondCopy, {"<s2>"}), ElementsAre(2));
+
+  // `firstCopy` still has its own tree, so it can be given new values again,
+  // without `secondCopy` interfering.
+  EXPECT_THAT(runWith(firstCopy, {"<s1>", "<s2>"}), ElementsAre(1, 2));
+  EXPECT_THAT(runWith(secondCopy, {"<s3>"}), ElementsAre(3));
+}
+
+// _____________________________________________________________________________
+// Test that `parseAndPlanQuery` is exactly `parseQuery` followed by
+// `planParsedQuery`, and that all the arguments of the former reach the two
+// halves.
+TEST(LibQlever, parseAndPlanQueryIsParseThenPlan) {
+  std::string filename = absl::StrCat(gtestCurrentTestName(), ".ttl");
+  {
+    auto ofs = ad_utility::makeOfstream(filename);
+    ofs << "<s> <p> <o> . <s2> <p> <o2> .";
+  }
+  absl::Cleanup cleanup = [&filename] { ad_utility::deleteFile(filename); };
+
+  IndexBuilderConfig c;
+  c.inputFiles_.push_back({filename, Filetype::Turtle, std::nullopt});
+  c.baseName_ = gtestCurrentTestName();
+  EXPECT_NO_THROW(Qlever::buildIndex(c));
+  Qlever engine{EngineConfig{c}};
+
+  std::string query = "SELECT ?s WHERE { ?s <p> ?o }";
+
+  // Both paths produce the same result.
+  auto viaCombined =
+      engine.query(engine.parseAndPlanQuery(query), ad_utility::MediaType::tsv);
+  auto viaSplit = engine.query(engine.planParsedQuery(engine.parseQuery(query)),
+                               ad_utility::MediaType::tsv);
+  EXPECT_EQ(viaCombined, viaSplit);
+  EXPECT_EQ(viaCombined, "?s\n<s>\n<s2>\n");
+
+  // `requestTimer` reaches `planQuery` through `planParsedQuery` and ends up in
+  // the runtime information, just as it does via `parseAndPlanQuery`.
+  ad_utility::Timer requestTimer{ad_utility::Timer::Started};
+  auto plan = engine.planParsedQuery(
+      engine.parseQuery(query),
+      std::make_shared<ad_utility::CancellationHandle<>>(), std::nullopt,
+      requestTimer);
+  EXPECT_GT(plan.queryExecutionTree()
+                .getRootOperation()
+                ->getRuntimeInfoWholeQuery()
+                .timeQueryPlanning.count(),
+            -1);
+
+  // A cancellation handle that is already cancelled makes planning fail, which
+  // shows that the handle reaches `planQuery` as well.
+  auto cancelledHandle = std::make_shared<ad_utility::CancellationHandle<>>();
+  cancelledHandle->cancel(ad_utility::CancellationState::MANUAL);
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      engine.planParsedQuery(engine.parseQuery(query), cancelledHandle),
+      HasSubstr("manually cancelled"));
+}
+
+// _____________________________________________________________________________
+// Test `bindParsedQuery`: a query that was parsed once can be planned on a
+// second `Qlever` instance, as long as that instance has an equivalent
+// `EncodedIriManager` (see the note on reusing a parsed query in `parseQuery`).
+TEST(LibQlever, bindParsedQueryReusesAParsedQuery) {
+  std::string filename = absl::StrCat(gtestCurrentTestName(), ".ttl");
+  {
+    auto ofs = ad_utility::makeOfstream(filename);
+    ofs << "<s> <p> <o> . <s2> <p> <o2> .";
+  }
+  absl::Cleanup cleanup = [&filename] { ad_utility::deleteFile(filename); };
+
+  // Two indexes over the same data and with the same configuration, so their
+  // `EncodedIriManager`s are equivalent.
+  IndexBuilderConfig c1;
+  c1.inputFiles_.push_back({filename, Filetype::Turtle, std::nullopt});
+  c1.baseName_ = absl::StrCat(gtestCurrentTestName(), ".first");
+  EXPECT_NO_THROW(Qlever::buildIndex(c1));
+  IndexBuilderConfig c2 = c1;
+  c2.baseName_ = absl::StrCat(gtestCurrentTestName(), ".second");
+  EXPECT_NO_THROW(Qlever::buildIndex(c2));
+
+  Qlever first{EngineConfig{c1}};
+  Qlever second{EngineConfig{c2}};
+
+  std::string query = "SELECT ?s WHERE { ?s <p> ?o }";
+  std::string expected = "?s\n<s>\n<s2>\n";
+
+  // Parse once on `first`, then plan on both instances.
+  ParsedQueryAndContext parsedOnFirst = first.parseQuery(query);
+  EXPECT_EQ(first.query(first.planParsedQuery(parsedOnFirst),
+                        ad_utility::MediaType::tsv),
+            expected);
+
+  // `bindParsedQuery` pairs the parsed query with a context of `second`, so the
+  // parsing is not repeated. The context of the plan is one of `second`, not
+  // the one the query was parsed with.
+  ParsedQueryAndContext boundToSecond =
+      second.bindParsedQuery(parsedOnFirst.parsedQuery());
+  EXPECT_NE(&boundToSecond.queryExecutionContext(),
+            &parsedOnFirst.queryExecutionContext());
+  PlannedQuery planOnSecond = second.planParsedQuery(boundToSecond);
+  EXPECT_EQ(&planOnSecond.queryExecutionContext(),
+            &boundToSecond.queryExecutionContext());
+  EXPECT_EQ(second.query(planOnSecond, ad_utility::MediaType::tsv), expected);
+}

--- a/test/libqlever/QleverTest.cpp
+++ b/test/libqlever/QleverTest.cpp
@@ -39,10 +39,7 @@ EngineConfig buildTestIndex(std::string_view turtleContents,
                             std::string_view suffix = "") {
   std::string basename = absl::StrCat(gtestCurrentTestName(), suffix);
   std::string filename = absl::StrCat(basename, ".ttl");
-  {
-    auto ofs = ad_utility::makeOfstream(filename);
-    ofs << turtleContents;
-  }
+  ad_utility::makeOfstream(filename) << turtleContents;
   absl::Cleanup cleanup = [&filename] { ad_utility::deleteFile(filename); };
 
   IndexBuilderConfig config;

--- a/test/libqlever/QleverTest.cpp
+++ b/test/libqlever/QleverTest.cpp
@@ -826,8 +826,7 @@ TEST(LibQlever, clearCache) {
   // Run a query with `pinResult`, so that its result is stored in the cache as
   // a pinned entry.
   PlannedQuery plan = engine.planQuery(engine.parseQuery(
-      "SELECT ?s WHERE { ?s <p> ?o }", {},
-      [](std::string) { /* the default is a noop*/ }, false, true));
+      "SELECT ?s WHERE { ?s <p> ?o }", {}, ad_utility::noop, false, true));
   EXPECT_EQ(engine.query(plan, ad_utility::MediaType::tsv), "?s\n<s>\n<s2>\n");
   EXPECT_GT(engine.cache().numPinnedEntries(), 0U);
 

--- a/test/libqlever/QleverTest.cpp
+++ b/test/libqlever/QleverTest.cpp
@@ -646,12 +646,12 @@ TEST(Qlever, indexRebuildConfigRejectsCollidingBaseNames) {
 }
 
 // _____________________________________________________________________________
-// Test `parseQuery` + `planParsedQuery` + `PlannedQuery::cloneQetInPlace`,
-// which together make it possible to plan a query once and then execute it
+// Test `parseQuery` + `planQuery` + `PlannedQuery::cloneQetInPlace`, which
+// together make it possible to plan a query once and then execute it
 // repeatedly with varying values: copying the resulting `PlannedQuery` shares
 // its `QueryExecutionTree`, and `cloneQetInPlace` gives the copy a tree of its
 // own, which can then be modified without affecting the original.
-TEST(LibQlever, planParsedQueryAndCloneQetInPlace) {
+TEST(LibQlever, planQueryOfParsedQueryAndCloneQetInPlace) {
   std::string filename = absl::StrCat(gtestCurrentTestName(), ".ttl");
   {
     auto ofs = ad_utility::makeOfstream(filename);
@@ -682,12 +682,12 @@ TEST(LibQlever, planParsedQueryAndCloneQetInPlace) {
   // Parsing is instance-independent, planning is not, so the same
   // `ParsedQuery` can be planned more than once.
   // `parseQuery` returns the `ParsedQuery` together with the
-  // `QueryExecutionContext` it was parsed against, and `planParsedQuery` plans
-  // it against exactly that context.
+  // `QueryExecutionContext` it was parsed against, and `planQuery` plans it
+  // against exactly that context.
   ParsedQueryAndContext parsedQuery = engine.parseQuery(query);
   EXPECT_EQ(&parsedQuery.queryExecutionContext(),
             parsedQuery.sharedQueryExecutionContext().get());
-  PlannedQuery plan = engine.planParsedQuery(parsedQuery);
+  PlannedQuery plan = engine.planQuery(parsedQuery);
   EXPECT_EQ(&plan.queryExecutionContext(),
             &parsedQuery.queryExecutionContext());
 
@@ -741,8 +741,7 @@ TEST(LibQlever, planParsedQueryAndCloneQetInPlace) {
 
 // _____________________________________________________________________________
 // Test that `parseAndPlanQuery` is exactly `parseQuery` followed by
-// `planParsedQuery`, and that all the arguments of the former reach the two
-// halves.
+// `planQuery`, and that all the arguments of the former reach the two halves.
 TEST(LibQlever, parseAndPlanQueryIsParseThenPlan) {
   std::string filename = absl::StrCat(gtestCurrentTestName(), ".ttl");
   {
@@ -762,18 +761,18 @@ TEST(LibQlever, parseAndPlanQueryIsParseThenPlan) {
   // Both paths produce the same result.
   auto viaCombined =
       engine.query(engine.parseAndPlanQuery(query), ad_utility::MediaType::tsv);
-  auto viaSplit = engine.query(engine.planParsedQuery(engine.parseQuery(query)),
+  auto viaSplit = engine.query(engine.planQuery(engine.parseQuery(query)),
                                ad_utility::MediaType::tsv);
   EXPECT_EQ(viaCombined, viaSplit);
   EXPECT_EQ(viaCombined, "?s\n<s>\n<s2>\n");
 
-  // `requestTimer` reaches `planQuery` through `planParsedQuery` and ends up in
+  // `requestTimer` reaches the query planner through `planQuery` and ends up in
   // the runtime information, just as it does via `parseAndPlanQuery`.
   ad_utility::Timer requestTimer{ad_utility::Timer::Started};
-  auto plan = engine.planParsedQuery(
-      engine.parseQuery(query),
-      std::make_shared<ad_utility::CancellationHandle<>>(), std::nullopt,
-      requestTimer);
+  auto plan =
+      engine.planQuery(engine.parseQuery(query),
+                       std::make_shared<ad_utility::CancellationHandle<>>(),
+                       std::nullopt, requestTimer);
   EXPECT_GT(plan.queryExecutionTree()
                 .getRootOperation()
                 ->getRuntimeInfoWholeQuery()
@@ -781,11 +780,11 @@ TEST(LibQlever, parseAndPlanQueryIsParseThenPlan) {
             -1);
 
   // A cancellation handle that is already cancelled makes planning fail, which
-  // shows that the handle reaches `planQuery` as well.
+  // shows that the handle reaches the query planner as well.
   auto cancelledHandle = std::make_shared<ad_utility::CancellationHandle<>>();
   cancelledHandle->cancel(ad_utility::CancellationState::MANUAL);
   AD_EXPECT_THROW_WITH_MESSAGE(
-      engine.planParsedQuery(engine.parseQuery(query), cancelledHandle),
+      engine.planQuery(engine.parseQuery(query), cancelledHandle),
       HasSubstr("manually cancelled"));
 }
 
@@ -819,9 +818,9 @@ TEST(LibQlever, bindParsedQueryReusesAParsedQuery) {
 
   // Parse once on `first`, then plan on both instances.
   ParsedQueryAndContext parsedOnFirst = first.parseQuery(query);
-  EXPECT_EQ(first.query(first.planParsedQuery(parsedOnFirst),
-                        ad_utility::MediaType::tsv),
-            expected);
+  EXPECT_EQ(
+      first.query(first.planQuery(parsedOnFirst), ad_utility::MediaType::tsv),
+      expected);
 
   // `bindParsedQuery` pairs the parsed query with a context of `second`, so the
   // parsing is not repeated. The context of the plan is one of `second`, not
@@ -830,8 +829,108 @@ TEST(LibQlever, bindParsedQueryReusesAParsedQuery) {
       second.bindParsedQuery(parsedOnFirst.parsedQuery());
   EXPECT_NE(&boundToSecond.queryExecutionContext(),
             &parsedOnFirst.queryExecutionContext());
-  PlannedQuery planOnSecond = second.planParsedQuery(boundToSecond);
+  PlannedQuery planOnSecond = second.planQuery(boundToSecond);
   EXPECT_EQ(&planOnSecond.queryExecutionContext(),
             &boundToSecond.queryExecutionContext());
   EXPECT_EQ(second.query(planOnSecond, ad_utility::MediaType::tsv), expected);
+}
+
+// _____________________________________________________________________________
+// Test `EngineConfig::computeSortPerformanceEstimators_`: the (potentially
+// expensive) estimates are computed by default, but not if the config disables
+// them.
+TEST(LibQlever, computeSortPerformanceEstimators) {
+  std::string filename = absl::StrCat(gtestCurrentTestName(), ".ttl");
+  {
+    auto ofs = ad_utility::makeOfstream(filename);
+    ofs << "<s> <p> <o> .";
+  }
+  absl::Cleanup cleanup = [&filename] { ad_utility::deleteFile(filename); };
+
+  IndexBuilderConfig c;
+  c.inputFiles_.push_back({filename, Filetype::Turtle, std::nullopt});
+  c.baseName_ = gtestCurrentTestName();
+  EXPECT_NO_THROW(Qlever::buildIndex(c));
+
+  EngineConfig ec{c};
+  ASSERT_TRUE(ec.computeSortPerformanceEstimators_);
+  EXPECT_TRUE(Qlever{ec}.sortPerformanceEstimator().estimatesWereCalculated());
+
+  ec.computeSortPerformanceEstimators_ = false;
+  EXPECT_FALSE(Qlever{ec}.sortPerformanceEstimator().estimatesWereCalculated());
+}
+
+// _____________________________________________________________________________
+// Test the trivial getters of `ParsedQueryAndContext`, both the `const` and the
+// non-`const` overloads. All of them refer to the same objects.
+TEST(LibQlever, parsedQueryAndContextGetters) {
+  std::string filename = absl::StrCat(gtestCurrentTestName(), ".ttl");
+  {
+    auto ofs = ad_utility::makeOfstream(filename);
+    ofs << "<s> <p> <o> .";
+  }
+  absl::Cleanup cleanup = [&filename] { ad_utility::deleteFile(filename); };
+
+  IndexBuilderConfig c;
+  c.inputFiles_.push_back({filename, Filetype::Turtle, std::nullopt});
+  c.baseName_ = gtestCurrentTestName();
+  EXPECT_NO_THROW(Qlever::buildIndex(c));
+  Qlever engine{EngineConfig{c}};
+
+  std::string query = "SELECT ?s WHERE { ?s <p> ?o }";
+  ParsedQueryAndContext parsedQuery = engine.parseQuery(query);
+  const ParsedQueryAndContext& constParsedQuery = parsedQuery;
+
+  // The non-`const` and the `const` getter yield the same `ParsedQuery`, which
+  // is the one that was parsed from `query`.
+  EXPECT_EQ(&parsedQuery.parsedQuery(), &constParsedQuery.parsedQuery());
+  EXPECT_EQ(constParsedQuery.parsedQuery()._originalString, query);
+  EXPECT_TRUE(constParsedQuery.parsedQuery().hasSelectClause());
+
+  // The same holds for the `QueryExecutionContext`, which is also the one that
+  // the (only `const`) getter for the `shared_ptr` yields.
+  EXPECT_EQ(&parsedQuery.queryExecutionContext(),
+            &constParsedQuery.queryExecutionContext());
+  EXPECT_EQ(constParsedQuery.sharedQueryExecutionContext().get(),
+            &constParsedQuery.queryExecutionContext());
+}
+
+// _____________________________________________________________________________
+// Test `Qlever::clearCache`, and trivially the `const` getter for the named
+// result cache.
+TEST(LibQlever, clearCache) {
+  std::string filename = absl::StrCat(gtestCurrentTestName(), ".ttl");
+  {
+    auto ofs = ad_utility::makeOfstream(filename);
+    ofs << "<s> <p> <o> . <s2> <p> <o2> .";
+  }
+  absl::Cleanup cleanup = [&filename] { ad_utility::deleteFile(filename); };
+
+  IndexBuilderConfig c;
+  c.inputFiles_.push_back({filename, Filetype::Turtle, std::nullopt});
+  c.baseName_ = gtestCurrentTestName();
+  EXPECT_NO_THROW(Qlever::buildIndex(c));
+  Qlever engine{EngineConfig{c}};
+
+  // The cache starts out empty.
+  ASSERT_EQ(engine.cache().numPinnedEntries(), 0U);
+  ASSERT_EQ(engine.cache().numNonPinnedEntries(), 0U);
+
+  // Run a query with `pinResult`, so that its result is stored in the cache as
+  // a pinned entry.
+  PlannedQuery plan = engine.planQuery(engine.parseQuery(
+      "SELECT ?s WHERE { ?s <p> ?o }", {},
+      [](std::string) { /* the default is a noop*/ }, false, true));
+  EXPECT_EQ(engine.query(plan, ad_utility::MediaType::tsv), "?s\n<s>\n<s2>\n");
+  EXPECT_GT(engine.cache().numPinnedEntries(), 0U);
+
+  // `clearCache` clears the pinned as well as the unpinned entries.
+  engine.clearCache();
+  EXPECT_EQ(engine.cache().numPinnedEntries(), 0U);
+  EXPECT_EQ(engine.cache().numNonPinnedEntries(), 0U);
+
+  // The named result cache is a separate cache, and its `const` getter yields
+  // the same cache as the non-`const` one.
+  const Qlever& constEngine = engine;
+  EXPECT_EQ(&constEngine.namedResultCache(), &engine.namedResultCache());
 }


### PR DESCRIPTION
`Qlever::parseAndPlanQuery` is now exactly `parseQuery` followed by `planQuery` and has no logic of its own any more. Calling the two halves separately makes it possible to inspect or modify the `ParsedQuery` before it is planned, to measure the time for the parsing and the planning separately, and to parse a query once and plan it on several `Qlever` instances (via the new `bindParsedQuery`; this is only correct if the instances agree on the prefixes for `Id`-encoded IRIs, see the documentation in the code). The result of `parseQuery` is a new class `ParsedQueryAndContext` that bundles the parsed query with the `QueryExecutionContext` it was parsed against, so that parsing and planning cannot get out of sync by accident.

While at it, also add the following three smaller features to `libqlever`:

1. `PlannedQuery::cloneQetInPlace` replaces the execution tree of a `PlannedQuery` by a deep copy of itself. Copies of a `PlannedQuery` share their tree; this function gives a copy a tree of its own, which can then be modified and executed without affecting the others, for example by injecting varying values into a pre-planned query template.

2. The new `EngineConfig::computeSortPerformanceEstimators_` can be set to `false` to skip the potentially expensive sort performance measurements when an index is loaded. Sort operations are then never canceled preemptively based on their estimated time.

3. `Qlever::clearCache` clears the query result cache.