### PR TITLE
Move `GeoSparqlHelpers.h/.cpp` from `util` to `rdfTypes`

### DIFF
--- a/src/engine/SpatialJoin.cpp
+++ b/src/engine/SpatialJoin.cpp
@@ -41,9 +41,9 @@
 #include "global/RuntimeParameters.h"
 #include "global/ValueId.h"
 #include "parser/ParsedQuery.h"
+#include "rdfTypes/GeoSparqlHelpers.h"
 #include "util/AllocatorWithLimit.h"
 #include "util/Exception.h"
-#include "util/GeoSparqlHelpers.h"
 #include "util/MemorySize/MemorySize.h"
 
 // ____________________________________________________________________________

--- a/src/engine/SpatialJoinAlgorithms.cpp
+++ b/src/engine/SpatialJoinAlgorithms.cpp
@@ -34,11 +34,11 @@
 #include "global/RuntimeParameters.h"
 #include "global/ValueId.h"
 #include "index/ExportIds.h"
+#include "rdfTypes/GeoSparqlHelpers.h"
 #include "rdfTypes/GeometryInfoHelpersImpl.h"
 #include "util/ChunkedForLoop.h"
 #include "util/Exception.h"
 #include "util/GeoConverters.h"
-#include "util/GeoSparqlHelpers.h"
 
 using namespace BoostGeometryNamespace;
 using namespace geometryConverters;

--- a/src/engine/SpatialJoinAlgorithms.h
+++ b/src/engine/SpatialJoinAlgorithms.h
@@ -24,7 +24,7 @@
 
 #include "engine/Result.h"
 #include "engine/SpatialJoin.h"
-#include "util/GeoSparqlHelpers.h"
+#include "rdfTypes/GeoSparqlHelpers.h"
 #include "util/VectorWithMemoryLimit.h"
 
 namespace BoostGeometryNamespace {

--- a/src/engine/sparqlExpressions/GeoExpression.cpp
+++ b/src/engine/sparqlExpressions/GeoExpression.cpp
@@ -14,8 +14,8 @@
 #include "engine/sparqlExpressions/SparqlExpression.h"
 #include "engine/sparqlExpressions/SparqlExpressionValueGetters.h"
 #include "global/Constants.h"
+#include "rdfTypes/GeoSparqlHelpers.h"
 #include "rdfTypes/GeometryInfo.h"
-#include "util/GeoSparqlHelpers.h"
 
 namespace sparqlExpression {
 namespace detail {

--- a/src/engine/sparqlExpressions/RelationalExpressions.cpp
+++ b/src/engine/sparqlExpressions/RelationalExpressions.cpp
@@ -10,7 +10,7 @@
 #include "engine/sparqlExpressions/NaryExpression.h"
 #include "engine/sparqlExpressions/RelationalExpressionHelpers.h"
 #include "engine/sparqlExpressions/SparqlExpressionGenerators.h"
-#include "util/GeoSparqlHelpers.h"
+#include "rdfTypes/GeoSparqlHelpers.h"
 #include "util/LambdaHelpers.h"
 #include "util/TypeTraits.h"
 

--- a/src/engine/sparqlExpressions/SparqlExpressionValueGetters.cpp
+++ b/src/engine/sparqlExpressions/SparqlExpressionValueGetters.cpp
@@ -13,10 +13,10 @@
 #include "global/ValueId.h"
 #include "index/ExportIds.h"
 #include "parser/NormalizedString.h"
+#include "rdfTypes/GeoSparqlHelpers.h"
 #include "rdfTypes/GeometryInfo.h"
 #include "rdfTypes/Literal.h"
 #include "util/Conversions.h"
-#include "util/GeoSparqlHelpers.h"
 #include "util/ParsedUri.h"
 
 using namespace sparqlExpression::detail;

--- a/src/parser/TripleComponent.cpp
+++ b/src/parser/TripleComponent.cpp
@@ -9,11 +9,10 @@
 
 #include <absl/strings/str_cat.h>
 
-#include "engine/ExportQueryExecutionTrees.h"
 #include "index/ExportIds.h"
 #include "index/IndexImpl.h"
 #include "rdfTypes/GeoPoint.h"
-#include "util/GeoSparqlHelpers.h"
+#include "rdfTypes/GeoSparqlHelpers.h"
 
 // ____________________________________________________________________________
 std::ostream& operator<<(std::ostream& stream, const TripleComponent& obj) {

--- a/src/rdfTypes/CMakeLists.txt
+++ b/src/rdfTypes/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(rdfEscaping RdfEscaping.cpp)
 qlever_target_link_libraries(rdfEscaping)
 
-add_library(rdfTypes Iri.cpp Literal.cpp Variable.cpp GeoPoint.cpp GeometryInfo.cpp)
+add_library(rdfTypes Iri.cpp Literal.cpp Variable.cpp GeoPoint.cpp GeometryInfo.cpp GeoSparqlHelpers.cpp)
 qlever_target_link_libraries(rdfTypes pb_util pb_util_geo rdfEscaping sparqlParser)

--- a/src/rdfTypes/GeoPoint.cpp
+++ b/src/rdfTypes/GeoPoint.cpp
@@ -7,10 +7,11 @@
 #include <cmath>
 #include <optional>
 
+#include "global/Constants.h"
 #include "parser/NormalizedString.h"
+#include "rdfTypes/GeoSparqlHelpers.h"
 #include "rdfTypes/Literal.h"
 #include "util/Exception.h"
-#include "util/GeoSparqlHelpers.h"
 
 // _____________________________________________________________________________
 GeoPoint::GeoPoint(double lat, double lng) : lat_{lat}, lng_{lng} {

--- a/src/rdfTypes/GeoSparqlHelpers.cpp
+++ b/src/rdfTypes/GeoSparqlHelpers.cpp
@@ -3,7 +3,7 @@
 // Authors: Hannah Bast <bast@cs.uni-freiburg.de>,
 //          Christoph Ullinger <ullingec@cs.uni-freiburg.de>
 
-#include "util/GeoSparqlHelpers.h"
+#include "rdfTypes/GeoSparqlHelpers.h"
 
 #include <absl/strings/charconv.h>
 #include <s2/s2earth.h>

--- a/src/rdfTypes/GeoSparqlHelpers.h
+++ b/src/rdfTypes/GeoSparqlHelpers.h
@@ -3,8 +3,8 @@
 // Authors: Hannah Bast <bast@cs.uni-freiburg.de>,
 //          Christoph Ullinger <ullingec@cs.uni-freiburg.de>
 
-#ifndef QLEVER_GEOSPARQLHELPERS_H
-#define QLEVER_GEOSPARQLHELPERS_H
+#ifndef QLEVER_SRC_RDFTYPES_GEOSPARQLHELPERS_H
+#define QLEVER_SRC_RDFTYPES_GEOSPARQLHELPERS_H
 
 #include <absl/strings/str_cat.h>
 
@@ -332,4 +332,4 @@ class WktMetricArea {
 
 }  // namespace ad_utility
 
-#endif  // QLEVER_GEOSPARQLHELPERS_H
+#endif  // QLEVER_SRC_RDFTYPES_GEOSPARQLHELPERS_H

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_subdirectory(ConfigManager)
 add_subdirectory(MemorySize)
 add_subdirectory(http)
-add_library(qlever_util ParseableDuration.cpp GeoSparqlHelpers.cpp UnitOfMeasurement.cpp antlr/ANTLRErrorHandling.cpp ParseException.cpp Conversions.cpp Date.cpp DateYearDuration.cpp Duration.cpp antlr/GenerateAntlrExceptionMetadata.cpp CancellationHandle.cpp StringUtils.cpp LazyJsonParser.cpp BlankNodeManager.cpp IoUringManager.cpp FilesystemHelpers.cpp QueryEventLog.cpp ResourceMonitor.cpp)
+add_library(qlever_util ParseableDuration.cpp UnitOfMeasurement.cpp antlr/ANTLRErrorHandling.cpp ParseException.cpp Conversions.cpp Date.cpp DateYearDuration.cpp Duration.cpp antlr/GenerateAntlrExceptionMetadata.cpp CancellationHandle.cpp StringUtils.cpp LazyJsonParser.cpp BlankNodeManager.cpp IoUringManager.cpp FilesystemHelpers.cpp QueryEventLog.cpp ResourceMonitor.cpp)
 qlever_target_link_libraries(qlever_util re2::re2 s2 pb_util pb_util_geo antlr4_static)
 
 add_subdirectory(metrics)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -317,7 +317,7 @@ addLinkAndDiscoverTest(NBitIntegerTest)
 
 addLinkAndDiscoverTest(GeoPointTest)
 
-addLinkAndDiscoverTest(GeoSparqlHelpersTest qlever_util)
+addLinkAndDiscoverTest(GeoSparqlHelpersTest rdfTypes)
 
 addLinkAndDiscoverTest(GeoConvertersTest qlever_util)
 

--- a/test/GeoPointTest.cpp
+++ b/test/GeoPointTest.cpp
@@ -9,8 +9,8 @@
 
 #include "global/Constants.h"
 #include "rdfTypes/GeoPoint.h"
+#include "rdfTypes/GeoSparqlHelpers.h"
 #include "util/GTestHelpers.h"
-#include "util/GeoSparqlHelpers.h"
 #include "util/HashSet.h"
 
 // _____________________________________________________________________________

--- a/test/GeoSparqlHelpersTest.cpp
+++ b/test/GeoSparqlHelpersTest.cpp
@@ -11,9 +11,9 @@
 #include "engine/SpatialJoinConfig.h"
 #include "global/Constants.h"
 #include "rdfTypes/GeoPoint.h"
+#include "rdfTypes/GeoSparqlHelpers.h"
 #include "rdfTypes/Iri.h"
 #include "util/GTestHelpers.h"
-#include "util/GeoSparqlHelpers.h"
 
 namespace {
 

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -30,10 +30,10 @@
 #include "engine/sparqlExpressions/StdevExpression.h"
 #include "index/Index.h"
 #include "rdfTypes/GeoPoint.h"
+#include "rdfTypes/GeoSparqlHelpers.h"
 #include "rdfTypes/GeometryInfo.h"
 #include "util/AllocatorTestHelpers.h"
 #include "util/Conversions.h"
-#include "util/GeoSparqlHelpers.h"
 #include "util/IdTestHelpers.h"
 
 namespace {

--- a/test/engine/SpatialJoinAlgorithmsTest.cpp
+++ b/test/engine/SpatialJoinAlgorithmsTest.cpp
@@ -26,8 +26,8 @@
 #include "engine/SpatialJoinAlgorithms.h"
 #include "engine/SpatialJoinConfig.h"
 #include "index/vocabulary/VocabularyType.h"
+#include "rdfTypes/GeoSparqlHelpers.h"
 #include "rdfTypes/Variable.h"
-#include "util/GeoSparqlHelpers.h"
 #include "util/SourceLocation.h"
 
 namespace {  // anonymous namespace to avoid linker problems

--- a/test/engine/SpatialJoinPrefilterTestHelpers.h
+++ b/test/engine/SpatialJoinPrefilterTestHelpers.h
@@ -27,11 +27,11 @@
 #include "engine/SpatialJoinAlgorithms.h"
 #include "engine/SpatialJoinConfig.h"
 #include "global/RuntimeParameters.h"
+#include "rdfTypes/GeoSparqlHelpers.h"
 #include "rdfTypes/GeometryInfo.h"
 #include "rdfTypes/GeometryInfoHelpersImpl.h"
 #include "rdfTypes/Literal.h"
 #include "rdfTypes/Variable.h"
-#include "util/GeoSparqlHelpers.h"
 #include "util/SourceLocation.h"
 
 // _____________________________________________________________________________

--- a/test/engine/SpatialJoinTest.cpp
+++ b/test/engine/SpatialJoinTest.cpp
@@ -38,8 +38,8 @@
 #include "index/LocalVocabEntry.h"
 #include "parser/PayloadVariables.h"
 #include "parser/SparqlParser.h"
+#include "rdfTypes/GeoSparqlHelpers.h"
 #include "rdfTypes/Variable.h"
-#include "util/GeoSparqlHelpers.h"
 
 namespace {  // anonymous namespace to avoid linker problems
 

--- a/test/engine/SpatialJoinTestHelpers.h
+++ b/test/engine/SpatialJoinTestHelpers.h
@@ -13,8 +13,8 @@
 #include "engine/SpatialJoinAlgorithms.h"
 #include "index/ExportIds.h"
 #include "index/vocabulary/VocabularyType.h"
+#include "rdfTypes/GeoSparqlHelpers.h"
 #include "rdfTypes/Variable.h"
-#include "util/GeoSparqlHelpers.h"
 
 namespace SpatialJoinTestHelpers {
 


### PR DESCRIPTION
The `GeoSparqlHelpers` are conceptually part of the RDF type handling (they contain functions like "parse a WKT literal to a `GeoPoint`"), so move them from `src/util` to `src/rdfTypes` and from the `qlever_util` library to the `rdfTypes` library. All includes and the header guard of the moved file are adapted accordingly; the contents are unchanged. The rationale: `qlever_util` should not depend on any functionality outside of the `util` directory.

This is the first of several changes towards supporting shared-library and Bazel builds of QLever. Both require that the dependency graph between the sub-libraries of QLever is acyclic. This change breaks the cycle between `qlever_util` and `rdfTypes`. It is extracted as a separate change because it is trivial, but touches many files.

Additionally, remove the unneeded include of `ExportQueryExecutionTrees.h` in `TripleComponent.cpp`, and add an explicit include of `Constants.h` in `GeoPoint.cpp`, which was previously only pulled in transitively.