### PR TITLE
Add a generic option to set any runtime parameter at server start

### DIFF
--- a/src/ServerMain.cpp
+++ b/src/ServerMain.cpp
@@ -233,11 +233,6 @@ int main(int argc, char** argv) {
       "Enable metrics collection and expose a Prometheus /metrics endpoint on "
       "the main server port. Accessing the endpoint requires a valid access "
       "token.");
-  add("service-max-redirects",
-      optionFactory
-          .getProgramOption<&RuntimeParameters::serviceMaxRedirects_>(),
-      "The maximum number of redirects that will be done for query "
-      "federation.");
   std::vector<std::string> runtimeParameterAssignments;
   add("set-runtime-parameter",
       po::value<std::vector<std::string>>(&runtimeParameterAssignments)

--- a/src/ServerMain.cpp
+++ b/src/ServerMain.cpp
@@ -232,6 +232,11 @@ int main(int argc, char** argv) {
       "Enable metrics collection and expose a Prometheus /metrics endpoint on "
       "the main server port. Accessing the endpoint requires a valid access "
       "token.");
+  add("service-max-redirects",
+      optionFactory
+          .getProgramOption<&RuntimeParameters::serviceMaxRedirects_>(),
+      "The maximum number of redirects that will be done for query "
+      "federation.");
   po::variables_map optionsMap;
 
   try {

--- a/src/ServerMain.cpp
+++ b/src/ServerMain.cpp
@@ -17,6 +17,7 @@
 #include "global/Constants.h"
 #include "global/RuntimeParameters.h"
 #include "libqlever/Qlever.h"
+#include "util/Algorithm.h"
 #include "util/MemorySize/MemorySize.h"
 #include "util/ParseableDuration.h"
 #include "util/ProgramOptionsHelpers.h"
@@ -237,10 +238,32 @@ int main(int argc, char** argv) {
           .getProgramOption<&RuntimeParameters::serviceMaxRedirects_>(),
       "The maximum number of redirects that will be done for query "
       "federation.");
+  std::vector<std::string> runtimeParameterAssignments;
+  add("set-runtime-parameter",
+      po::value<std::vector<std::string>>(&runtimeParameterAssignments)
+          ->composing(),
+      "Set any runtime parameter at startup, in the form <name>=<value>, for "
+      "example `--set-runtime-parameter default-query-timeout=300s`. Can be "
+      "given multiple times. Use `--set-runtime-parameter help` to list all "
+      "runtime parameters together with their default values. The parameters "
+      "can also be changed while the server is running, via the API. If a "
+      "parameter can also be set by one of the dedicated options above, the "
+      "value given here wins.");
   po::variables_map optionsMap;
 
   try {
     po::store(po::parse_command_line(argc, argv, options), optionsMap);
+    if (optionsMap.count("set-runtime-parameter") &&
+        ad_utility::contains(
+            optionsMap["set-runtime-parameter"].as<std::vector<std::string>>(),
+            "help")) {
+      std::cout << "Available runtime parameters and their default values:\n";
+      auto parameters = globalRuntimeParameters.rlock()->toMap();
+      for (const auto& name : globalRuntimeParameters.rlock()->getKeys()) {
+        std::cout << "  " << name << " = " << parameters.at(name) << '\n';
+      }
+      return EXIT_SUCCESS;
+    }
     if (optionsMap.count("help")) {
       std::cout << options << '\n';
       return EXIT_SUCCESS;
@@ -260,6 +283,23 @@ int main(int argc, char** argv) {
               << ", compiled on " << qlever::version::DatetimeOfCompilation
               << " using git hash " << qlever::version::GitShortHash << EMPH_OFF
               << std::endl;
+
+  // Apply the `--set-runtime-parameter` assignments. This runs after
+  // `po::notify` above, so for parameters that can also be set by a dedicated
+  // option (like `--service-max-redirects`), the value given here wins. A bad
+  // name or value fails the startup with a readable message, before the index
+  // is loaded.
+  for (const auto& assignment : runtimeParameterAssignments) {
+    try {
+      globalRuntimeParameters.wlock()->setFromAssignment(assignment);
+    } catch (const std::exception& e) {
+      AD_LOG_ERROR << "Invalid argument to --set-runtime-parameter: "
+                   << e.what() << std::endl;
+      return EXIT_FAILURE;
+    }
+    AD_LOG_INFO << "Runtime parameter set from the command line: " << assignment
+                << std::endl;
+  }
 
   try {
     // Samples RSS and CPU usage, starting before the index is loaded.

--- a/src/global/RuntimeParameters.cpp
+++ b/src/global/RuntimeParameters.cpp
@@ -8,6 +8,8 @@
 
 #include "global/RuntimeParameters.h"
 
+#include <absl/strings/str_join.h>
+
 #include "backports/algorithm.h"
 #include "util/Algorithm.h"
 
@@ -94,8 +96,9 @@ RuntimeParameters::toMap() const {
 void RuntimeParameters::setFromString(const std::string& name,
                                       const std::string& value) {
   if (!ad_utility::contains(runtimeMap_, name)) {
-    throw std::runtime_error{"No parameter with name " + std::string{name} +
-                             " exists"};
+    throw std::runtime_error{
+        "No parameter with name " + std::string{name} +
+        " exists. Available parameters are: " + absl::StrJoin(getKeys(), ", ")};
   }
   try {
     runtimeMap_.at(name)->setFromString(value);
@@ -104,6 +107,18 @@ void RuntimeParameters::setFromString(const std::string& name,
                              " to value " + value +
                              ". Exception was: " + e.what());
   }
+}
+
+// _____________________________________________________________________________
+void RuntimeParameters::setFromAssignment(const std::string& assignment) {
+  auto positionOfEquals = assignment.find('=');
+  if (positionOfEquals == std::string::npos) {
+    throw std::runtime_error{
+        "Expected an assignment of the form <name>=<value>, but got \"" +
+        assignment + "\""};
+  }
+  setFromString(assignment.substr(0, positionOfEquals),
+                assignment.substr(positionOfEquals + 1));
 }
 
 // _____________________________________________________________________________

--- a/src/global/RuntimeParameters.h
+++ b/src/global/RuntimeParameters.h
@@ -218,6 +218,12 @@ struct RuntimeParameters {
   void setFromString(const std::string& parameterName,
                      const std::string& value);
 
+  // Set a parameter from a single string of the form `<name>=<value>` (split
+  // at the first `=`). Throws if the string contains no `=`, if the parameter
+  // does not exist, or if the value is invalid. Used for the
+  // `--set-runtime-parameter` option of `qlever-server`.
+  void setFromAssignment(const std::string& assignment);
+
   // Get all parameter names.
   std::vector<std::string> getKeys() const;
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -478,6 +478,8 @@ addLinkAndDiscoverTest(ParseableDurationTest)
 
 addLinkAndDiscoverTest(ConstantsTest)
 
+addLinkAndDiscoverTest(RuntimeParametersTest global)
+
 addLinkAndDiscoverTest(JThreadTest)
 
 addLinkAndDiscoverTest(ChunkedForLoopTest)

--- a/test/RuntimeParametersTest.cpp
+++ b/test/RuntimeParametersTest.cpp
@@ -46,4 +46,22 @@ TEST(RuntimeParameters, setFromAssignment) {
   AD_EXPECT_THROW_WITH_MESSAGE(
       params.setFromAssignment("default-query-timeout=banana"),
       HasSubstr("Could not set parameter default-query-timeout"));
+
+  // The use case that prompted this option (see #3031): set the maximal
+  // number of redirects for query federation at startup.
+  params.setFromAssignment("service-max-redirects=5");
+  EXPECT_EQ(params.serviceMaxRedirects_.get(), 5u);
+}
+
+// Test that `getKeys` and `toMap` (the building blocks of
+// `--set-runtime-parameter help`) are consistent with each other.
+TEST(RuntimeParameters, getKeysAndToMapAreConsistent) {
+  RuntimeParameters params;
+  auto keys = params.getKeys();
+  auto map = params.toMap();
+  EXPECT_FALSE(keys.empty());
+  EXPECT_EQ(keys.size(), map.size());
+  for (const auto& key : keys) {
+    EXPECT_TRUE(map.contains(key)) << key;
+  }
 }

--- a/test/RuntimeParametersTest.cpp
+++ b/test/RuntimeParametersTest.cpp
@@ -1,0 +1,49 @@
+// Copyright 2026 The QLever Authors, in particular:
+//
+// 2026 Hannah Bast <bast@cs.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "global/RuntimeParameters.h"
+#include "util/GTestHelpers.h"
+
+using ::testing::AllOf;
+using ::testing::HasSubstr;
+
+// Test setting a runtime parameter from a single `<name>=<value>` string, as
+// used by the `--set-runtime-parameter` option of `qlever-server`.
+TEST(RuntimeParameters, setFromAssignment) {
+  RuntimeParameters params;
+
+  // A valid assignment sets the parameter.
+  params.setFromAssignment("default-query-timeout=300s");
+  EXPECT_EQ(params.defaultQueryTimeout_.get(), std::chrono::seconds{300});
+
+  // The string is split at the FIRST `=`, so values containing `=` work.
+  params.setFromAssignment("default-query-timeout=150s");
+  EXPECT_EQ(params.defaultQueryTimeout_.get(), std::chrono::seconds{150});
+
+  // A missing `=` is rejected with a readable message.
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      params.setFromAssignment("no-equals-sign"),
+      HasSubstr("assignment of the form <name>=<value>"));
+
+  // An unknown parameter name is rejected, and the message lists the
+  // available parameters.
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      params.setFromAssignment("no-such-parameter=42"),
+      AllOf(HasSubstr("No parameter with name no-such-parameter"),
+            HasSubstr("Available parameters are:"),
+            HasSubstr("default-query-timeout")));
+
+  // An invalid value for an existing parameter is rejected.
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      params.setFromAssignment("default-query-timeout=banana"),
+      HasSubstr("Could not set parameter default-query-timeout"));
+}


### PR DESCRIPTION
When running QLever in a containerized environment like Kubernetes, all configuration is ideally done at startup. So far, only a handful of hand-picked runtime parameters had a dedicated command-line option, and all others could only be changed via the API after the server was already running.

There is now a repeatable option `--set-runtime-parameter <name>=<value>` that can set any of the currently 41 runtime parameters at startup, for example `--set-runtime-parameter service-max-redirects=5`. It uses the same parsing and validation as the API, so values behave identically in both cases. A bad name or value fails the startup with a readable message (for an unknown name, the message lists all available parameters) before the index is loaded, and every parameter set this way is logged at startup. `--set-runtime-parameter help` prints all runtime parameters together with their default values. In particular, fixes #3031.

NOTE: The assignments are applied after the dedicated options, so for a parameter that can be set both ways (for example `--default-query-timeout`), the value given with `--set-runtime-parameter` wins. Many of the dedicated options are now redundant in principle. The frequently used ones (like `-c`, `-e`, `-k`, `-s`) are worth keeping as convenient shortcuts, but the rarely used ones can be deprecated and eventually removed in a follow-up. This needs a deprecation period and a coordinated change in `qlever-control`, so it is deliberately not part of this PR.