### PR TITLE
Avoid a false-positive thread-sanitizer report when testing failing asynchronous operations

### DIFF
--- a/test/index/IndexRebuilderTest.cpp
+++ b/test/index/IndexRebuilderTest.cpp
@@ -34,6 +34,7 @@
 #include "index/IndexRebuilderImpl.h"
 #include "index/vocabulary/VocabularyType.h"
 #include "util/FilesystemHelpers.h"
+#include "util/SourceLocation.h"
 
 using namespace qlever::indexRebuilder;
 using namespace std::string_literals;
@@ -724,15 +725,15 @@ TEST(IndexRebuilder, serverIntegration) {
   // The exception must not be handed out of the coroutine (in particular not
   // via `net::use_future` + `AD_EXPECT_THROW_WITH_MESSAGE`), see
   // `AsioTestHelpers.h` for the reason.
-  auto expectRequestFailsWith =
-      [&threadPool, &makeTask](auto& request, const auto& matcher,
-                               ad_utility::source_location location =
-                                   ad_utility::source_location::current()) {
-        auto trace = generateLocationTrace(location);
-        EXPECT_THAT(ad_utility::testing::getErrorMessageOfCoroutine(
-                        threadPool, makeTask(request)),
-                    ::testing::Optional(matcher));
-      };
+  auto expectRequestFailsWith = [&threadPool, &makeTask](
+                                    auto& request, const auto& matcher,
+                                    ad_utility::source_location location =
+                                        AD_CURRENT_SOURCE_LOC()) {
+    auto trace = generateLocationTrace(location);
+    EXPECT_THAT(ad_utility::testing::getErrorMessageOfCoroutine(
+                    threadPool, makeTask(request)),
+                ::testing::Optional(matcher));
+  };
 
   // Without access token this operation is not allowed!
   auto request0 = makeRebuildRequest("&index-name=my-name", false);

--- a/test/index/IndexRebuilderTest.cpp
+++ b/test/index/IndexRebuilderTest.cpp
@@ -13,7 +13,12 @@
 #include <boost/asio/detached.hpp>
 #include <boost/asio/thread_pool.hpp>
 #include <boost/asio/use_future.hpp>
+#include <future>
+#include <optional>
+#include <string>
+#include <string_view>
 
+#include "../util/AsioTestHelpers.h"
 #include "../util/GTestHelpers.h"
 #include "../util/HttpRequestHelpers.h"
 #include "../util/IdTableHelpers.h"
@@ -687,28 +692,57 @@ TEST(IndexRebuilder, serverIntegration) {
 
   qlever::EngineConfig config;
   config.baseName_ = indexName;
-  Server server{4321, 1, "accessToken", config};
-  auto performRequest = [&threadPool, &server](auto& request) {
-    using ResT = ad_utility::httpUtils::ResponseT;
-    auto task =
-        server.template onlyForTestingProcess<std::decay_t<decltype(request)>,
-                                              ResT>(request);
-    return net::co_spawn(threadPool, std::move(task), net::use_future);
+  constexpr std::string_view accessToken = "accessToken";
+  Server server{4321, 1, std::string{accessToken}, config};
+
+  // Create a GET request that triggers a rebuild of the index. The
+  // `additionalParameters` are appended to the URL as they are, and the access
+  // token is added unless `withAccessToken` is false.
+  auto makeRebuildRequest = [accessToken](
+                                std::string_view additionalParameters = "",
+                                bool withAccessToken = true) {
+    return ad_utility::testing::makeGetRequest(absl::StrCat(
+        "/?cmd=rebuild-index", additionalParameters,
+        withAccessToken ? absl::StrCat("&access-token=", accessToken) : ""));
   };
 
-  // Without access token this operation is not allowed!
-  auto request0 = ad_utility::testing::makeGetRequest(
-      "/?cmd=rebuild-index&index-name=my-name");
-  AD_EXPECT_THROW_WITH_MESSAGE(performRequest(request0).get(),
-                               ::testing::HasSubstr("access token"));
+  // Create the coroutine that lets the `server` process the given `request`.
+  auto makeTask = [&server](auto& request) {
+    return server.template onlyForTestingProcess<
+        std::decay_t<decltype(request)>, ad_utility::httpUtils::ResponseT>(
+        request);
+  };
 
-  auto request1 = ad_utility::testing::makeGetRequest(
-      "/?cmd=rebuild-index&index-name=my-name&access-token="
-      "accessToken");
+  // Perform the given `request` on the `threadPool` and return a future for the
+  // response.
+  auto performRequest = [&threadPool, &makeTask](auto& request) {
+    return net::co_spawn(threadPool, makeTask(request), net::use_future);
+  };
+
+  // Perform the given `request` on the `threadPool`, expect it to fail, and
+  // check the message of the resulting exception against the `matcher`. NOTE:
+  // The exception must not be handed out of the coroutine (in particular not
+  // via `net::use_future` + `AD_EXPECT_THROW_WITH_MESSAGE`), see
+  // `AsioTestHelpers.h` for the reason.
+  auto expectRequestFailsWith =
+      [&threadPool, &makeTask](auto& request, const auto& matcher,
+                               ad_utility::source_location location =
+                                   ad_utility::source_location::current()) {
+        auto trace = generateLocationTrace(location);
+        EXPECT_THAT(ad_utility::testing::getErrorMessageOfCoroutine(
+                        threadPool, makeTask(request)),
+                    ::testing::Optional(matcher));
+      };
+
+  // Without access token this operation is not allowed!
+  auto request0 = makeRebuildRequest("&index-name=my-name", false);
+  expectRequestFailsWith(request0, ::testing::HasSubstr("access token"));
+
+  // The same request twice, the second one has to be rejected because a
+  // rebuild is already running.
+  auto request1 = makeRebuildRequest("&index-name=my-name");
   auto future1 = performRequest(request1);
-  auto request2 = ad_utility::testing::makeGetRequest(
-      "/?cmd=rebuild-index&index-name=my-name&access-token="
-      "accessToken");
+  auto request2 = makeRebuildRequest("&index-name=my-name");
   auto future2 = performRequest(request2);
 
   auto response1 = future1.get();
@@ -722,8 +756,7 @@ TEST(IndexRebuilder, serverIntegration) {
   // successfully.
   EXPECT_TRUE(ql::filesystem::exists("my-name.meta-data.json"));
 
-  auto request3 = ad_utility::testing::makeGetRequest(
-      "/?cmd=rebuild-index&access-token=accessToken");
+  auto request3 = makeRebuildRequest();
   auto response3 = performRequest(request3).get();
   EXPECT_EQ(response3.base().result(), boost::beast::http::status::ok);
   // By default QLever should assign a default name for the new index.
@@ -731,24 +764,18 @@ TEST(IndexRebuilder, serverIntegration) {
 
   // The index with the same name already exists, so we don't want to overwrite
   // it.
-  auto request4 = ad_utility::testing::makeGetRequest(
-      "/?cmd=rebuild-index&access-token=accessToken");
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      performRequest(request4).get(),
-      ::testing::HasSubstr("already files with the same base name"));
+  auto request4 = makeRebuildRequest();
+  expectRequestFailsWith(
+      request4, ::testing::HasSubstr("already files with the same base name"));
 
   // The index has to reside within the same directory as the original index.
-  auto request5 = ad_utility::testing::makeGetRequest(
-      "/?cmd=rebuild-index&access-token=accessToken&index-name=%2Fmy-name");
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      performRequest(request5).get(),
-      ::testing::HasSubstr("not located in the same directory"));
+  auto request5 = makeRebuildRequest("&index-name=%2Fmy-name");
+  expectRequestFailsWith(
+      request5, ::testing::HasSubstr("not located in the same directory"));
 
-  auto request6 = ad_utility::testing::makeGetRequest(
-      "/?cmd=rebuild-index&access-token=accessToken&index-name=..%2Fother");
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      performRequest(request6).get(),
-      ::testing::HasSubstr("not located in the same directory"));
+  auto request6 = makeRebuildRequest("&index-name=..%2Fother");
+  expectRequestFailsWith(
+      request6, ::testing::HasSubstr("not located in the same directory"));
 
   threadPool.join();
 }

--- a/test/parser/AsyncBlockSourceTest.cpp
+++ b/test/parser/AsyncBlockSourceTest.cpp
@@ -11,6 +11,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <boost/asio/deferred.hpp>
 #include <boost/asio/thread_pool.hpp>
 #include <boost/asio/use_future.hpp>
 #include <future>
@@ -27,7 +28,6 @@
 #include "parser/AsyncBlockSource.h"
 #include "util/Exception.h"
 #include "util/File.h"
-#include "util/Forward.h"
 #include "util/MemorySize/MemorySize.h"
 
 namespace {
@@ -52,9 +52,8 @@ DrainOutcome drainBlocks(qp::AsyncBlockSource& source) {
   DrainOutcome outcome;
   while (true) {
     auto blockOrError = ad_utility::testing::runAsyncOperationAndGetOutcome<
-        std::optional<qp::ByteBlock>>([&source](auto&& completionToken) {
-      return source.asyncGetNextBlock(AD_FWD(completionToken));
-    });
+        std::optional<qp::ByteBlock>>(
+        source.asyncGetNextBlock(boost::asio::deferred));
     if (blockOrError.failed()) {
       outcome.errorMessage_ = std::move(blockOrError.errorMessage_);
       return outcome;

--- a/test/parser/AsyncBlockSourceTest.cpp
+++ b/test/parser/AsyncBlockSourceTest.cpp
@@ -22,10 +22,12 @@
 #include <variant>
 #include <vector>
 
+#include "../util/AsioTestHelpers.h"
 #include "../util/GTestHelpers.h"
 #include "parser/AsyncBlockSource.h"
 #include "util/Exception.h"
 #include "util/File.h"
+#include "util/Forward.h"
 #include "util/MemorySize/MemorySize.h"
 
 namespace {
@@ -33,14 +35,44 @@ namespace {
 namespace qp = qlever::parser;
 using namespace ad_utility::memory_literals;
 
-// Synchronously drive an `AsyncBlockSource` until EOF and return all blocks
-// in order. Throws if the source signals an error.
-std::vector<qp::ByteBlock> drainAllBlocks(qp::AsyncBlockSource& source) {
-  std::vector<qp::ByteBlock> result;
-  while (auto opt = source.asyncGetNextBlock(boost::asio::use_future).get()) {
-    result.push_back(std::move(*opt));
+// The outcome of `drainBlocks` below: all the blocks that were read (in order)
+// and, if the source has signaled an error, the message of the corresponding
+// exception.
+struct DrainOutcome {
+  std::vector<qp::ByteBlock> blocks_;
+  std::optional<std::string> errorMessage_;
+};
+
+// Synchronously drive an `AsyncBlockSource` until EOF or until it signals an
+// error, and return the corresponding `DrainOutcome`. NOTE: The exception must
+// not be handed out of the thread that runs the source (in particular not via
+// `boost::asio::use_future` + `AD_EXPECT_THROW_WITH_MESSAGE`), see
+// `AsioTestHelpers.h` for the reason.
+DrainOutcome drainBlocks(qp::AsyncBlockSource& source) {
+  DrainOutcome outcome;
+  while (true) {
+    auto blockOrError = ad_utility::testing::runAsyncOperationAndGetOutcome<
+        std::optional<qp::ByteBlock>>([&source](auto&& completionToken) {
+      return source.asyncGetNextBlock(AD_FWD(completionToken));
+    });
+    if (blockOrError.failed()) {
+      outcome.errorMessage_ = std::move(blockOrError.errorMessage_);
+      return outcome;
+    }
+    if (!blockOrError.result_.has_value()) {
+      return outcome;
+    }
+    outcome.blocks_.push_back(std::move(blockOrError.result_).value());
   }
-  return result;
+}
+
+// Synchronously drive an `AsyncBlockSource` until EOF and return all blocks in
+// order. Fail the test if the source signals an error.
+std::vector<qp::ByteBlock> drainAllBlocks(qp::AsyncBlockSource& source) {
+  auto outcome = drainBlocks(source);
+  EXPECT_FALSE(outcome.errorMessage_.has_value())
+      << outcome.errorMessage_.value_or("");
+  return std::move(outcome.blocks_);
 }
 
 // Scan `sv` from the back and return the position right after the last digit
@@ -152,8 +184,9 @@ TEST(AsyncStatementBoundaryBlockSource, CutsAtBoundary) {
         std::make_unique<qp::FileBlockSource>(pool.get_executor(), blocksize,
                                               filename),
         findXToZ, "a letter from x to z");
-    AD_EXPECT_THROW_WITH_MESSAGE(
-        drainAllBlocks(buf), ::testing::ContainsRegex("No statement boundary"));
+    EXPECT_THAT(
+        drainBlocks(buf).errorMessage_,
+        ::testing::Optional(::testing::ContainsRegex("No statement boundary")));
   }
   {
     // The same example but with a larger blocksize, s.t. the complete input
@@ -228,8 +261,9 @@ TEST(BlockingBlockSource, ForwardsExceptionFromGetNextBlockImpl) {
   ScriptedBlockSource buf(
       pool.get_executor(), 4_B,
       {ScriptedBlockSource::Step{std::string{"boom from getNextBlockImpl"}}});
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      drainAllBlocks(buf), ::testing::HasSubstr("boom from getNextBlockImpl"));
+  EXPECT_THAT(
+      drainBlocks(buf).errorMessage_,
+      ::testing::Optional(::testing::HasSubstr("boom from getNextBlockImpl")));
 }
 
 // ________________________________________________________
@@ -245,8 +279,9 @@ TEST(AsyncStatementBoundaryBlockSource,
           ScriptedBlockSource::Step{std::string{"boom from initial fetch"}}});
   qp::AsyncStatementBoundaryBlockSource buf(
       pool.get_executor(), std::move(inner), findXToZ, "a letter from x to z");
-  AD_EXPECT_THROW_WITH_MESSAGE(drainAllBlocks(buf),
-                               ::testing::HasSubstr("boom from initial fetch"));
+  EXPECT_THAT(
+      drainBlocks(buf).errorMessage_,
+      ::testing::Optional(::testing::HasSubstr("boom from initial fetch")));
 }
 
 // ________________________________________________________
@@ -265,8 +300,8 @@ TEST(AsyncStatementBoundaryBlockSource, ForwardsExceptionFromPeek) {
           ScriptedBlockSource::Step{std::string{"boom from peek"}}});
   qp::AsyncStatementBoundaryBlockSource buf(
       pool.get_executor(), std::move(inner), findNever, "never found");
-  AD_EXPECT_THROW_WITH_MESSAGE(drainAllBlocks(buf),
-                               ::testing::HasSubstr("boom from peek"));
+  EXPECT_THAT(drainBlocks(buf).errorMessage_,
+              ::testing::Optional(::testing::HasSubstr("boom from peek")));
 }
 
 // ________________________________________________________
@@ -287,6 +322,7 @@ TEST(AsyncStatementBoundaryBlockSource,
   };
   qp::AsyncStatementBoundaryBlockSource buf(
       pool.get_executor(), std::move(inner), findThrows, "throwing finder");
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      drainAllBlocks(buf), ::testing::HasSubstr("boom from findEndPosition"));
+  EXPECT_THAT(
+      drainBlocks(buf).errorMessage_,
+      ::testing::Optional(::testing::HasSubstr("boom from findEndPosition")));
 }

--- a/test/util/AsioTestHelpers.h
+++ b/test/util/AsioTestHelpers.h
@@ -22,7 +22,8 @@
 #include "util/Forward.h"
 
 // Helpers for tests that run an asynchronous operation (typically on a
-// `boost::asio::thread_pool`) and expect that operation to fail.
+// `boost::asio::thread_pool`) and expect that operation to fail via an
+// `exception_ptr`.
 //
 // Such a test must not let the exception itself cross the thread boundary, in
 // particular not via `boost::asio::use_future` together with
@@ -58,6 +59,21 @@
 // `boost::asio::use_future`: for the transfer of a value, the
 // `std::promise`/`std::future` pair establishes synchronization that the thread
 // sanitizer does understand, because its mutex is intercepted.
+//
+// NOTE: There are two alternatives to the approach of these helpers, both of
+// which we have discarded:
+// 1. Build the standard library (`libc++` supports this via
+//    `LLVM_USE_SANITIZER=Thread`) as well as all our other dependencies with
+//    thread sanitizer instrumentation and use that in our CI. The sanitizer
+//    would then see the reference counting and the report would disappear.
+//    There are no prebuilt packages for such a setup, so this would be a large
+//    change to the CI.
+// 2. Exclude the affected places from the instrumentation, either via a
+//    suppression file (an entry like `called_from_lib:libstdc++.so.6`) or via
+//    `__attribute__((no_sanitize("thread")))` on the code that reads the
+//    message. Both are far coarser than the problem: they also hide real races,
+//    the suppression in everything that goes through the standard library, the
+//    attribute in the whole annotated function.
 namespace ad_utility::testing {
 
 // Return the message of the exception that `exception` refers to, or

--- a/test/util/AsioTestHelpers.h
+++ b/test/util/AsioTestHelpers.h
@@ -11,9 +11,10 @@
 #define QLEVER_TEST_UTIL_ASIOTESTHELPERS_H
 
 #include <boost/asio/co_spawn.hpp>
+#include <boost/asio/deferred.hpp>
+#include <boost/asio/use_future.hpp>
 #include <exception>
 #include <future>
-#include <memory>
 #include <optional>
 #include <string>
 #include <utility>
@@ -51,9 +52,12 @@
 //
 // The helpers below avoid this by converting the exception into a `std::string`
 // on the thread on which the operation completes, and by transferring only that
-// string. For the transfer of a value, the `std::promise`/`std::future` pair
-// establishes synchronization that the thread sanitizer does understand,
-// because its mutex is intercepted.
+// string. The conversion is expressed as a `boost::asio::deferred`
+// transformation, which Asio invokes inline in the completion handler of the
+// operation. The transfer to the calling thread is done by
+// `boost::asio::use_future`: for the transfer of a value, the
+// `std::promise`/`std::future` pair establishes synchronization that the thread
+// sanitizer does understand, because its mutex is intercepted.
 namespace ad_utility::testing {
 
 // Return the message of the exception that `exception` refers to, or
@@ -87,46 +91,57 @@ struct AsyncOutcome {
   bool failed() const { return errorMessage_.has_value(); }
 };
 
-// Run the asynchronous operation that is initiated by
-// `initiateOperation(completionToken)`, wait for its completion, and return the
-// corresponding `AsyncOutcome<Result>`. The exception (if any) is converted
-// into its message on the thread that completes the operation, see the comment
-// above for the reason.
+// A `boost::asio::deferred` transformation that replaces the
+// `std::exception_ptr` of a completion by the message of that exception and
+// discards the result of the operation. Pipe it onto an operation that was
+// initiated with the `boost::asio::deferred` completion token, for example
 //
-// NOTE: The `completionToken` is a plain completion handler. It is passed as a
-// copyable lvalue (with the promise inside a `std::shared_ptr`, just as
-// `boost::asio::use_future` does it), because some of Asio's initiating
-// functions require exactly that.
-template <typename Result, typename InitiateOperation>
+//   auto message = (source.asyncGetNextBlock(boost::asio::deferred)
+//                   | asErrorMessage() | boost::asio::use_future).get();
+//
+// Asio invokes the transformation inline in the completion handler of the
+// operation, which is exactly what the comment above requires.
+inline auto asErrorMessage() {
+  return boost::asio::deferred([](std::exception_ptr exception, auto&&...) {
+    return boost::asio::deferred.values(getMessageOfException(exception));
+  });
+}
+
+// Same as `asErrorMessage` above, but keep the result of the operation and
+// combine it with the message into an `AsyncOutcome<Result>`. The `Result` has
+// to be specified explicitly, because the arguments of the completion are
+// forwarded to the transformation exactly as the operation has passed them,
+// without a conversion to the types from its completion signature.
+template <typename Result>
+auto asOutcome() {
+  return boost::asio::deferred(
+      [](std::exception_ptr exception, auto&&... results) {
+        return boost::asio::deferred.values(AsyncOutcome<Result>{
+            getMessageOfException(exception), Result{AD_FWD(results)...}});
+      });
+}
+
+// Run the `deferredOperation` (an asynchronous operation that was initiated
+// with the `boost::asio::deferred` completion token), wait for its completion,
+// and return the corresponding `AsyncOutcome<Result>`.
+template <typename Result, typename DeferredOperation>
 AsyncOutcome<Result> runAsyncOperationAndGetOutcome(
-    InitiateOperation initiateOperation) {
-  auto outcomePromise = std::make_shared<std::promise<AsyncOutcome<Result>>>();
-  auto outcomeFuture = outcomePromise->get_future();
-  auto completionToken = [outcomePromise](std::exception_ptr exception,
-                                          auto&&... results) {
-    outcomePromise->set_value(AsyncOutcome<Result>{
-        getMessageOfException(exception), Result{AD_FWD(results)...}});
-  };
-  std::move(initiateOperation)(completionToken);
-  return outcomeFuture.get();
+    DeferredOperation deferredOperation) {
+  return (std::move(deferredOperation) | asOutcome<Result>() |
+          boost::asio::use_future)
+      .get();
 }
 
 // Same as `runAsyncOperationAndGetOutcome` above, but only return the message
 // of the exception that the operation has failed with (`std::nullopt` if it has
 // succeeded) and discard the result. This also works for operations that
 // complete without a result.
-template <typename InitiateOperation>
+template <typename DeferredOperation>
 std::optional<std::string> getErrorMessageOfAsyncOperation(
-    InitiateOperation initiateOperation) {
-  auto messagePromise =
-      std::make_shared<std::promise<std::optional<std::string>>>();
-  auto messageFuture = messagePromise->get_future();
-  auto completionToken = [messagePromise](std::exception_ptr exception,
-                                          auto&&...) {
-    messagePromise->set_value(getMessageOfException(exception));
-  };
-  std::move(initiateOperation)(completionToken);
-  return messageFuture.get();
+    DeferredOperation deferredOperation) {
+  return (std::move(deferredOperation) | asErrorMessage() |
+          boost::asio::use_future)
+      .get();
 }
 
 // `co_spawn` the coroutine `awaitable` onto the `executor` (which may also be
@@ -137,11 +152,8 @@ std::optional<std::string> getErrorMessageOfAsyncOperation(
 template <typename Executor, typename Awaitable>
 std::optional<std::string> getErrorMessageOfCoroutine(Executor&& executor,
                                                       Awaitable awaitable) {
-  return getErrorMessageOfAsyncOperation(
-      [&executor, awaitable = std::move(awaitable)](auto&& token) mutable {
-        return boost::asio::co_spawn(AD_FWD(executor), std::move(awaitable),
-                                     AD_FWD(token));
-      });
+  return getErrorMessageOfAsyncOperation(boost::asio::co_spawn(
+      AD_FWD(executor), std::move(awaitable), boost::asio::deferred));
 }
 }  // namespace ad_utility::testing
 

--- a/test/util/AsioTestHelpers.h
+++ b/test/util/AsioTestHelpers.h
@@ -1,0 +1,148 @@
+// Copyright 2026 The QLever Authors, in particular:
+//
+// 2026 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+//
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#ifndef QLEVER_TEST_UTIL_ASIOTESTHELPERS_H
+#define QLEVER_TEST_UTIL_ASIOTESTHELPERS_H
+
+#include <boost/asio/co_spawn.hpp>
+#include <exception>
+#include <future>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+
+#include "util/Forward.h"
+
+// Helpers for tests that run an asynchronous operation (typically on a
+// `boost::asio::thread_pool`) and expect that operation to fail.
+//
+// Such a test must not let the exception itself cross the thread boundary, in
+// particular not via `boost::asio::use_future` together with
+// `AD_EXPECT_THROW_WITH_MESSAGE(future.get(), ...)`. That pattern is correct
+// C++, but the thread sanitizer reports a data race for it, because it cannot
+// see the synchronization that makes it correct:
+//
+// 1. `std::future::get()` rethrows the exception that the completion handler
+//    has stored in the shared state of the corresponding `std::promise`.
+//    `std::rethrow_exception` does not copy the exception; it increments the
+//    reference count of the exception object (see `__cxa_refcounted_exception`
+//    of the Itanium ABI) and propagates that very object. The `catch` block of
+//    the test therefore reads `what()` directly from the exception object that
+//    was constructed on the thread pool.
+// 2. That object, and with it the buffer of the `std::string` that holds its
+//    message, is destroyed by whichever thread performs the last decrement of
+//    that reference count. Once the test has left its `catch` block, this can
+//    be the thread pool, which drops the last reference when it destroys the
+//    completion handler, the promise, and the shared state.
+// 3. The decrements are atomic, so the destruction is properly ordered after
+//    the reading of the message and there is no undefined behavior. But
+//    `__cxa_decrement_exception_refcount` lives in `libstdc++`, which is not
+//    compiled with `-fsanitize=thread`, so the sanitizer never observes those
+//    atomics. It does observe the `operator delete` of the message buffer
+//    (allocating functions are always intercepted), and hence reports a race
+//    between that `operator delete` and the reading of the message.
+//
+// The helpers below avoid this by converting the exception into a `std::string`
+// on the thread on which the operation completes, and by transferring only that
+// string. For the transfer of a value, the `std::promise`/`std::future` pair
+// establishes synchronization that the thread sanitizer does understand,
+// because its mutex is intercepted.
+namespace ad_utility::testing {
+
+// Return the message of the exception that `exception` refers to, or
+// `std::nullopt` if `exception` is empty. Call this on the thread that
+// completes the corresponding operation, see the comment above.
+inline std::optional<std::string> getMessageOfException(
+    const std::exception_ptr& exception) {
+  if (!exception) {
+    return std::nullopt;
+  }
+  try {
+    std::rethrow_exception(exception);
+  } catch (const std::exception& e) {
+    return e.what();
+  } catch (...) {
+    return "Unknown exception that does not derive from `std::exception`";
+  }
+}
+
+// The outcome of an asynchronous operation with the completion signature
+// `void(std::exception_ptr, Result)`: the message of the exception that the
+// operation has failed with (`std::nullopt` if it has succeeded), and the
+// result that it has completed with (value-initialized in the case of a
+// failure).
+template <typename Result>
+struct AsyncOutcome {
+  std::optional<std::string> errorMessage_;
+  Result result_;
+
+  // Return true if the operation has failed.
+  bool failed() const { return errorMessage_.has_value(); }
+};
+
+// Run the asynchronous operation that is initiated by
+// `initiateOperation(completionToken)`, wait for its completion, and return the
+// corresponding `AsyncOutcome<Result>`. The exception (if any) is converted
+// into its message on the thread that completes the operation, see the comment
+// above for the reason.
+//
+// NOTE: The `completionToken` is a plain completion handler. It is passed as a
+// copyable lvalue (with the promise inside a `std::shared_ptr`, just as
+// `boost::asio::use_future` does it), because some of Asio's initiating
+// functions require exactly that.
+template <typename Result, typename InitiateOperation>
+AsyncOutcome<Result> runAsyncOperationAndGetOutcome(
+    InitiateOperation initiateOperation) {
+  auto outcomePromise = std::make_shared<std::promise<AsyncOutcome<Result>>>();
+  auto outcomeFuture = outcomePromise->get_future();
+  auto completionToken = [outcomePromise](std::exception_ptr exception,
+                                          auto&&... results) {
+    outcomePromise->set_value(AsyncOutcome<Result>{
+        getMessageOfException(exception), Result{AD_FWD(results)...}});
+  };
+  std::move(initiateOperation)(completionToken);
+  return outcomeFuture.get();
+}
+
+// Same as `runAsyncOperationAndGetOutcome` above, but only return the message
+// of the exception that the operation has failed with (`std::nullopt` if it has
+// succeeded) and discard the result. This also works for operations that
+// complete without a result.
+template <typename InitiateOperation>
+std::optional<std::string> getErrorMessageOfAsyncOperation(
+    InitiateOperation initiateOperation) {
+  auto messagePromise =
+      std::make_shared<std::promise<std::optional<std::string>>>();
+  auto messageFuture = messagePromise->get_future();
+  auto completionToken = [messagePromise](std::exception_ptr exception,
+                                          auto&&...) {
+    messagePromise->set_value(getMessageOfException(exception));
+  };
+  std::move(initiateOperation)(completionToken);
+  return messageFuture.get();
+}
+
+// `co_spawn` the coroutine `awaitable` onto the `executor` (which may also be
+// an execution context, for example a `boost::asio::thread_pool`), wait for it
+// to complete, and return the message of the exception that it has failed with,
+// or `std::nullopt` if it has succeeded. The result of the coroutine is
+// discarded.
+template <typename Executor, typename Awaitable>
+std::optional<std::string> getErrorMessageOfCoroutine(Executor&& executor,
+                                                      Awaitable awaitable) {
+  return getErrorMessageOfAsyncOperation(
+      [&executor, awaitable = std::move(awaitable)](auto&& token) mutable {
+        return boost::asio::co_spawn(AD_FWD(executor), std::move(awaitable),
+                                     AD_FWD(token));
+      });
+}
+}  // namespace ad_utility::testing
+
+#endif  // QLEVER_TEST_UTIL_ASIOTESTHELPERS_H


### PR DESCRIPTION
`IndexRebuilder.serverIntegration` triggers a thread-sanitizer report between an `operator delete` and gmock's `HasSubstr` matcher (reliably when QLever is built as a shared library, rarely and so far unnoticed in the static builds). The report is a false positive: the test lets a `std::exception_ptr` cross a thread boundary, where one thread reads the exception message and another thread destroys the exception object. This is correct C++, because `std::exception_ptr` synchronizes with an atomic reference count. But that reference count lives in the compiled part of the standard library, which is not instrumented, so the sanitizer cannot see the synchronization and reports a race.

Since the sanitizer cannot be taught about this (the alternatives are discussed in a comment in the new file), the pattern is removed. New test helpers in `AsioTestHelpers.h` convert the exception into a `std::string` on the thread on which the operation completes and transfer only that string. The two tests that used the pattern (`IndexRebuilderTest` and `AsyncBlockSourceTest`) now use the helpers.