### PR TITLE
Add the release version of the server to `?cmd=stats`

### DIFF
--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -928,6 +928,8 @@ nlohmann::json Server::composeStatsJson(const Index& index) {
   result["git-hash-index"] = index.getGitShortHash();
   result["git-hash-server"] =
       *qlever::version::gitShortHashWithoutLinking.wlock();
+  result["version-server"] =
+      *qlever::version::projectVersionWithoutLinking.wlock();
   result["num-permutations"] = (index.hasAllPermutations() ? 6 : 2);
   result["num-predicates-normal"] = index.numDistinctPredicates().normal;
   result["num-predicates-internal"] = index.numDistinctPredicates().internal;

--- a/test/ServerTest.cpp
+++ b/test/ServerTest.cpp
@@ -178,6 +178,7 @@ TEST(ServerTest, composeStatsJson) {
   Server server{9999, 1, "accessToken", serverTestHelpers::getDefaultConfig()};
   json expectedJson{{"git-hash-index", "git short hash not set"},
                     {"git-hash-server", "git short hash not set"},
+                    {"version-server", "project version not set"},
                     {"name-index", ""},
                     {"name-text-index", ""},
                     {"num-entity-occurrences", 0},


### PR DESCRIPTION
The response of `?cmd=stats` now also contains the version of the server (field `version-server`), next to the already existing git hashes of the server and the index build. For most users the release version is more meaningful than the commit hash, for example in bug reports.

The value comes from `git describe --tags --always`. For a build exactly on a release tag (in particular, the Docker images of our releases), it is the plain release version, for example `v0.5.50`. For a build between releases, it additionally contains the number of commits since the release and the commit hash, for example `v0.5.50-55-gda8c02bb3`. If no tag is reachable at build time (for example, in a shallow clone via `git clone --depth 1`), it is just the commit hash, and if git is not available at all, it is `0.0.0-unknown`.