### PR TITLE
Use exclusive lock by default

### DIFF
--- a/src/engine/idTable/CompressedExternalIdTable.h
+++ b/src/engine/idTable/CompressedExternalIdTable.h
@@ -62,8 +62,7 @@ class CompressedExternalIdTableWriter {
 
   // The filename and actual file to which the `IdTable` is written .
   std::string filename_;
-  ad_utility::Synchronized<ad_utility::File, std::shared_mutex> file_{filename_,
-                                                                      "w+"};
+  ad_utility::Synchronized<ad_utility::File> file_{filename_, "w+"};
   // For a single column, the concatenation of the blocks for that column of all
   // `IdTables`.
   using ColumnMetadata = std::vector<CompressedBlockMetadata>;

--- a/src/index/DeltaTriples.h
+++ b/src/index/DeltaTriples.h
@@ -418,7 +418,7 @@ class DeltaTriples {
 // race conditions between concurrent updates and queries.
 class DeltaTriplesManager {
   ad_utility::Synchronized<DeltaTriples> deltaTriples_;
-  ad_utility::Synchronized<LocatedTriplesSharedState, std::shared_mutex>
+  ad_utility::Synchronized<LocatedTriplesSharedState>
       currentLocatedTriplesSharedState_;
 
  public:

--- a/src/util/Synchronized.h
+++ b/src/util/Synchronized.h
@@ -9,6 +9,7 @@
 
 #include <atomic>
 #include <condition_variable>
+#include <mutex>
 #include <shared_mutex>
 
 #include "backports/atomic_flag.h"
@@ -73,9 +74,9 @@ class LockPtr;
  *
  * @tparam T The actual type that is stored
  * @tparam Mutex A Mutex like type (e.g. std::mutex or std::shared_mutex).
- * Defaults to std::shared_mutex
+ * Defaults to std::mutex
  */
-template <typename T, typename Mutex = std::shared_mutex,
+template <typename T, typename Mutex = std::mutex,
           typename = std::enable_if_t<AllowsLocking<Mutex>::value>>
 class Synchronized {
  public:
@@ -149,20 +150,19 @@ class Synchronized {
     return f(data_);
   }
 
-  /** @brief Obtain a shared lock and then call f() on the underlying data type,
-   * return the result.
+  /** @brief Obtain a read-only lock and then call f() on the underlying data
+   * type, return the result.
    *
    * Note that return type deduction is done via auto which means,
    * that no references are passed out. This happens deliberately as
    * passing out references to the underlying type would ignore the locking.
-   * Only supported if the mutex allows shared locking and the
-   * function type F only treats its object as const.
+   * If the mutex supports shared locking, the lock is shared. Otherwise it is
+   * exclusive. The function type F must treat its object as const.
    */
-  template <typename F, bool s = isShared,
-            typename Res = std::invoke_result_t<F, const T&>>
-  std::enable_if_t<s, Res> withReadLock(F f) const {
-    std::shared_lock l(mutex());
-    return f(data_);
+  template <typename F, typename = std::invoke_result_t<F, const value_type&>>
+  auto withReadLock(F f) const {
+    auto lock = rlock();
+    return f(*lock);
   }
 
   /**
@@ -192,34 +192,28 @@ class Synchronized {
 
   /**
    * @brief Obtain a handle that can be treated like a const T* to the
-   * underlying type with shared access. Only works if the Mutex type allows
-   * shared locking.
+   * underlying type with read-only access. If the mutex supports shared
+   * locking, the lock is shared. Otherwise it is exclusive.
    *
-   * If the Return value is stored, then the T will remain shared_locked until
-   * the return value is destroyed. If the return value outlives the
-   * Synchronized element by which it was obtained, the behavior is undefined.
+   * If the return value is stored, then the T will remain locked until the
+   * return value is destroyed. If the return value outlives the Synchronized
+   * element by which it was obtained, the behavior is undefined.
    *
    * Examples:
    * Synchronized<std::vector<int>> s;
-   * cout << s.rlock()->size();  // obtain shared_lock, obtain size, release
-   * shared_lock
+   * cout << s.rlock()->size();  // obtain lock, obtain size, release lock
    * // s.rlock()->push_back(3);  // does not compile, because rlock() only
    * allows access to const members
    * {
-   *   auto l = s.rlock(); // s is now shared_locked by l;
-   *   cout << l->size(); // get size, remain shared_locked.
+   *   auto l = s.rlock(); // s is now locked by l;
+   *   cout << l->size(); // get size, remain locked.
    *   // s.wlock()->push_back(0) // would deadlock, because s is still locked
-   * by l; cout << s.rlock()->size(); // works because multiple shared locks at
-   * the same time are ok } // l goes out of scope and unlocks s again;
+   * by l;
+   * } // l goes out of scope and unlocks s again;
    * s.wlock()->push_back(7);
    *
    */
-  template <typename M = Mutex>
-  std::enable_if_t<AllowsSharedLocking<M>::value,
-                   LockPtr<Synchronized, true, true>>
-  rlock() const {
-    return LockPtr<Synchronized, true, true>{this};
-  };
+  auto rlock() const { return LockPtr<Synchronized, isShared, true>{this}; }
 
   // Return a `Synchronized` that uses a reference to this `Synchronized`'s
   // `_data` and `mutext_`. The reference is a reference of the Base class U.

--- a/test/SynchronizedTest.cpp
+++ b/test/SynchronizedTest.cpp
@@ -15,6 +15,7 @@ TEST(Synchronized, TypeTraits) {
   static_assert(!ad_utility::AllowsLocking<float>::value);
   static_assert(ad_utility::AllowsSharedLocking<std::shared_mutex>::value);
   static_assert(!ad_utility::AllowsSharedLocking<std::mutex>::value);
+  static_assert(!Synchronized<int>::isShared);
 }
 
 TEST(Synchronized, Exclusive) {
@@ -175,18 +176,18 @@ struct AllowsConstExclusiveAccess<
     : public std::true_type {};
 
 template <typename T, typename = void>
-struct AllowsConstSharedAccess : public std::false_type {};
+struct AllowsConstReadAccess : public std::false_type {};
 
 template <typename T>
-struct AllowsConstSharedAccess<
+struct AllowsConstReadAccess<
     T, std::void_t<decltype(std::declval<T>().rlock()->size())>>
     : public std::true_type {};
 
 template <typename T, typename = void>
-struct AllowsNonConstSharedAccess : public std::false_type {};
+struct AllowsNonConstReadAccess : public std::false_type {};
 
 template <typename T>
-struct AllowsNonConstSharedAccess<
+struct AllowsNonConstReadAccess<
     T, std::void_t<decltype(std::declval<T>().rlock()->push_back(3))>>
     : public std::true_type {};
 
@@ -220,18 +221,18 @@ struct AllowsConstExclusiveAccessLambda<
     : public std::true_type {};
 
 template <typename T, typename = void>
-struct AllowsConstSharedAccessLambda : public std::false_type {};
+struct AllowsConstReadAccessLambda : public std::false_type {};
 
 template <typename T>
-struct AllowsConstSharedAccessLambda<
+struct AllowsConstReadAccessLambda<
     T, std::void_t<decltype(std::declval<T>().withReadLock(std::declval<C>()))>>
     : public std::true_type {};
 
 template <typename T, typename = void>
-struct AllowsNonConstSharedAccessLambda : public std::false_type {};
+struct AllowsNonConstReadAccessLambda : public std::false_type {};
 
 template <typename T>
-struct AllowsNonConstSharedAccessLambda<
+struct AllowsNonConstReadAccessLambda<
     T,
     std::void_t<decltype(std::declval<T>().withReadLock(std::declval<NC>()))>>
     : public std::true_type {};
@@ -242,7 +243,9 @@ TEST(Synchronized, SFINAE) {
       AllowsNonConstExclusiveAccess<Synchronized<Vec, std::mutex>>::value);
   static_assert(
       AllowsConstExclusiveAccess<Synchronized<Vec, std::mutex>>::value);
-  static_assert(!AllowsConstSharedAccess<Synchronized<Vec, std::mutex>>::value);
+  static_assert(AllowsConstReadAccess<Synchronized<Vec, std::mutex>>::value);
+  static_assert(
+      !AllowsNonConstReadAccess<Synchronized<Vec, std::mutex>>::value);
   static_assert(
       AllowsNonConstExclusiveAccess<Synchronized<Vec, std::mutex>>::value);
   static_assert(AllowsNonConstExclusiveAccessLambda<
@@ -250,7 +253,9 @@ TEST(Synchronized, SFINAE) {
   static_assert(
       AllowsConstExclusiveAccessLambda<Synchronized<Vec, std::mutex>>::value);
   static_assert(
-      !AllowsConstSharedAccessLambda<Synchronized<Vec, std::mutex>>::value);
+      AllowsConstReadAccessLambda<Synchronized<Vec, std::mutex>>::value);
+  static_assert(
+      !AllowsNonConstReadAccessLambda<Synchronized<Vec, std::mutex>>::value);
   static_assert(AllowsNonConstExclusiveAccessLambda<
                 Synchronized<Vec, std::mutex>>::value);
 
@@ -259,25 +264,25 @@ TEST(Synchronized, SFINAE) {
   static_assert(
       AllowsConstExclusiveAccess<Synchronized<Vec, std::shared_mutex>>::value);
   static_assert(
-      AllowsConstSharedAccess<Synchronized<Vec, std::shared_mutex>>::value);
+      AllowsConstReadAccess<Synchronized<Vec, std::shared_mutex>>::value);
   static_assert(
-      !AllowsNonConstSharedAccess<Synchronized<Vec, std::shared_mutex>>::value);
+      !AllowsNonConstReadAccess<Synchronized<Vec, std::shared_mutex>>::value);
   static_assert(AllowsNonConstExclusiveAccessLambda<
                 Synchronized<Vec, std::shared_mutex>>::value);
   static_assert(AllowsConstExclusiveAccessLambda<
                 Synchronized<Vec, std::shared_mutex>>::value);
-  static_assert(AllowsConstSharedAccessLambda<
-                Synchronized<Vec, std::shared_mutex>>::value);
-  static_assert(!AllowsNonConstSharedAccessLambda<
+  static_assert(
+      AllowsConstReadAccessLambda<Synchronized<Vec, std::shared_mutex>>::value);
+  static_assert(!AllowsNonConstReadAccessLambda<
                 Synchronized<Vec, std::shared_mutex>>::value);
 
   static_assert(!AllowsNonConstExclusiveAccess<
                 const Synchronized<Vec, std::shared_mutex>>::value);
   static_assert(AllowsConstExclusiveAccess<
                 const Synchronized<Vec, std::shared_mutex>>::value);
-  static_assert(AllowsConstSharedAccess<
-                const Synchronized<Vec, std::shared_mutex>>::value);
-  static_assert(!AllowsNonConstSharedAccess<
+  static_assert(
+      AllowsConstReadAccess<const Synchronized<Vec, std::shared_mutex>>::value);
+  static_assert(!AllowsNonConstReadAccess<
                 const Synchronized<Vec, std::shared_mutex>>::value);
 
   // Outcommenting this does not compile and cannot be brought to compile
@@ -287,9 +292,9 @@ TEST(Synchronized, SFINAE) {
   // std::shared_mutex>>::value);
   static_assert(AllowsConstExclusiveAccessLambda<
                 const Synchronized<Vec, std::shared_mutex>>::value);
-  static_assert(AllowsConstSharedAccessLambda<
+  static_assert(AllowsConstReadAccessLambda<
                 const Synchronized<Vec, std::shared_mutex>>::value);
-  static_assert(!AllowsNonConstSharedAccessLambda<
+  static_assert(!AllowsNonConstReadAccessLambda<
                 const Synchronized<Vec, std::shared_mutex>>::value);
 
   static_assert(!AllowsNonConstExclusiveAccess<
@@ -297,9 +302,9 @@ TEST(Synchronized, SFINAE) {
   static_assert(
       AllowsConstExclusiveAccess<const Synchronized<Vec, std::mutex>>::value);
   static_assert(
-      !AllowsConstSharedAccess<const Synchronized<Vec, std::mutex>>::value);
+      AllowsConstReadAccess<const Synchronized<Vec, std::mutex>>::value);
   static_assert(
-      !AllowsNonConstSharedAccess<const Synchronized<Vec, std::mutex>>::value);
+      !AllowsNonConstReadAccess<const Synchronized<Vec, std::mutex>>::value);
 
   // Outcommenting this does not compile and cannot be brought to compile
   // without making usage of the Synchronized classes "withWriteLock" method
@@ -308,8 +313,8 @@ TEST(Synchronized, SFINAE) {
   // std::mutex>>::value);
   static_assert(AllowsConstExclusiveAccessLambda<
                 const Synchronized<Vec, std::mutex>>::value);
-  static_assert(!AllowsConstSharedAccessLambda<
-                const Synchronized<Vec, std::mutex>>::value);
-  static_assert(!AllowsNonConstSharedAccessLambda<
+  static_assert(
+      AllowsConstReadAccessLambda<const Synchronized<Vec, std::mutex>>::value);
+  static_assert(!AllowsNonConstReadAccessLambda<
                 const Synchronized<Vec, std::mutex>>::value);
 }


### PR DESCRIPTION
Why this change? While looking into Windows port I run into 4 bugs with shared mutexes there. So I started to wonder why `std:shared_mutex` is a default in qlever. My feeling is that its usage is not really necessary and simple mutex is actually better and conceptually simpler fit for all the use-cases. `Synchronized` still supports `shared_mutex` if there will be a real use case for it.

See a good explanation on why here https://abseil.io/tips/197 :

> If you spot ReaderLock, especially new uses of it, try to ask “Is the computation under this lock often long?” If it’s just looking up a value in a container, an exclusive lock is almost certainly a better solution.

There are a lot of usages where access is synchronized on trivial operations, like get size/counters reads. There are only few places that kind of do real work, so I tried to run a benchmark (with help of LLM) using DBLP dataset for such paths (in MaterializedViews and DeltaTriples)  comparing mutex vs shared_mutex and even there simple mutex is slightly faster under concurrent load.
