### PR TITLE
Export large-year datetimes with the timezone designator

### DIFF
--- a/src/util/DateYearDuration.cpp
+++ b/src/util/DateYearDuration.cpp
@@ -68,7 +68,11 @@ std::pair<std::string, const char*> DateYearOrDuration::toStringAndType()
 
   switch (getType()) {
     case Type::DateTime:
-      return impl(F{"%d-01-01T00:00:00"}, XSD_DATETIME_TYPE);
+      // NOTE: For years outside the range of the `Date` class, only the year
+      // is stored, so the original timezone is not available. Export the
+      // canonical UTC form (with the `Z`), consistent with the export of
+      // dates within the range (where a `Date` stores its timezone).
+      return impl(F{"%d-01-01T00:00:00Z"}, XSD_DATETIME_TYPE);
     case Type::Date:
       return impl(F{"%d-01-01"}, XSD_DATE_TYPE);
     case Type::YearMonth:

--- a/test/DateYearDurationTest.cpp
+++ b/test/DateYearDurationTest.cpp
@@ -487,8 +487,14 @@ TEST(Date, parseLargeYear) {
   testLargeYearDate("2039481726-01-01", 2039481726);
   testLargeYearDate("-2039481726-01-01", -2039481726);
 
-  testLargeYearDatetime("2039481726-01-01T00:00:00", 2039481726);
-  testLargeYearDatetime("-2039481726-01-01T00:00:00", -2039481726);
+  // NOTE: Only the year is stored, so the export is always in the canonical
+  // UTC form (with the `Z`), also when the input has no timezone.
+  testLargeYearDatetime("2039481726-01-01T00:00:00Z", 2039481726);
+  testLargeYearDatetime("-2039481726-01-01T00:00:00Z", -2039481726);
+  testLargeYearDatetime("2039481726-01-01T00:00:00", 2039481726,
+                        "2039481726-01-01T00:00:00Z");
+  testLargeYearDatetime("-2039481726-01-01T00:00:00", -2039481726,
+                        "-2039481726-01-01T00:00:00Z");
 }
 
 TEST(Date, parseLargeYearCornerCases) {
@@ -510,11 +516,11 @@ TEST(Date, parseLargeYearCornerCases) {
   testLargeYearDate("-2039481726-02-05", -2039481726, "-2039481726-01-01");
 
   testLargeYearDatetime("2039481726-01-01T12:00:00", 2039481726,
-                        "2039481726-01-01T00:00:00");
+                        "2039481726-01-01T00:00:00Z");
   testLargeYearDatetime("2039481726-01-01T00:13:00", 2039481726,
-                        "2039481726-01-01T00:00:00");
+                        "2039481726-01-01T00:00:00Z");
   testLargeYearDatetime("-2039481726-01-01T00:00:14", -2039481726,
-                        "-2039481726-01-01T00:00:00");
+                        "-2039481726-01-01T00:00:00Z");
 }
 
 TEST(Date, parseErrors) {

--- a/test/DateYearDurationTest.cpp
+++ b/test/DateYearDurationTest.cpp
@@ -495,6 +495,17 @@ TEST(Date, parseLargeYear) {
                         "2039481726-01-01T00:00:00Z");
   testLargeYearDatetime("-2039481726-01-01T00:00:00", -2039481726,
                         "-2039481726-01-01T00:00:00Z");
+
+  // Test the boundary of the year range of the `Date` class: `-9999` and
+  // `9999` are stored as a regular `Date` (which keeps its timezone), while
+  // `-10000` and `10000` are stored as a large year (where the export is
+  // always in the canonical UTC form).
+  testDatetime("9999-01-01T00:00:00Z", 9999, 1, 1, 0, 0, 0.0,
+               Date::TimeZoneZ{});
+  testDatetime("-9999-01-01T00:00:00Z", -9999, 1, 1, 0, 0, 0.0,
+               Date::TimeZoneZ{});
+  testLargeYearDatetime("10000-01-01T00:00:00Z", 10000);
+  testLargeYearDatetime("-10000-01-01T00:00:00Z", -10000);
 }
 
 TEST(Date, parseLargeYearCornerCases) {


### PR DESCRIPTION
A date with a year outside `[-9999, 9999]` was exported without the timezone designator, while dates within that range keep their timezone. For example, the value `"-11700-01-01T00:00:00Z"^^xsd:dateTime` (the beginning of the Holocene, from Wikidata) came back from a query as `"-11700-01-01T00:00:00"^^xsd:dateTime`, which is a different literal than the one that was inserted (an `xsd:dateTime` without a timezone denotes local time). The cutoff is exactly the year range of the `Date` class: `"-9999-01-01T00:00:00Z"` is exported unchanged, `"-10000-01-01T00:00:00Z"` loses the `Z`.

The reason is that for years outside the range of the `Date` class, `DateYearOrDuration` stores only the year (all payload bits are used by the year, so the timezone cannot be stored without shrinking the year range, which would change the meaning of the bits in existing indexes). This change exports the canonical UTC form (with the `Z`) for such values, which is consistent with the export of dates within the range and restores the round trip for all data whose times are in UTC (in particular, all of Wikidata).

NOTE: This was found by the new `qlever check-sync-with-wikidata` command (qlever-dev/qlever-control#308) on a random sample of entities: the start time of the Holocene on `Q18092102` was the only difference between the endpoint and `Special:EntityData` for that entity.