### PR TITLE
Improve the accuracy of the code coverage reports

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -66,7 +66,8 @@ jobs:
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_TOOLCHAIN_FILE="$(pwd)/toolchains/${{env.compiler}}${{env.compiler-version}}.cmake" -DCMAKE_BUILD_TYPE=${{env.build-type}} -DLOGLEVEL=TIMING -DADDITIONAL_COMPILER_FLAGS="${{env.warnings}} ${{env.asan-flags}} ${{env.ubsan-flags}} ${{env.coverage-flags}}" -DADDITIONAL_LINKER_FLAGS="${{env.coverage-flags}}" -DUSE_PARALLEL=false -DRUN_EXPENSIVE_TESTS=false -DSINGLE_TEST_BINARY=ON -DENABLE_EXPENSIVE_CHECKS=true -DADDITIONAL_LINKER_FLAGS="-fuse-ld=mold"
+      # Precompiled headers have to be disabled to make coverage deterministic.
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_TOOLCHAIN_FILE="$(pwd)/toolchains/${{env.compiler}}${{env.compiler-version}}.cmake" -DUSE_PRECOMPILED_HEADERS=OFF -DCMAKE_BUILD_TYPE=${{env.build-type}} -DLOGLEVEL=TIMING -DADDITIONAL_COMPILER_FLAGS="${{env.warnings}} ${{env.asan-flags}} ${{env.ubsan-flags}} ${{env.coverage-flags}}" -DADDITIONAL_LINKER_FLAGS="${{env.coverage-flags}}" -DUSE_PARALLEL=false -DRUN_EXPENSIVE_TESTS=false -DSINGLE_TEST_BINARY=ON -DENABLE_EXPENSIVE_CHECKS=true -DADDITIONAL_LINKER_FLAGS="-fuse-ld=mold"
 
     - name: Build
         # Build your program with the given configuration
@@ -88,7 +89,7 @@ jobs:
         # `llvm-cov` only warns about a nonexistent source filter, and then reports everything.
         test -d "${{github.workspace}}/src"
         llvm-profdata-${{env.compiler-version}} merge -sparse *.profraw -o default.profdata
-        llvm-cov-${{env.compiler-version}} export ./QLeverAllUnitTestsMain --format=lcov --instr-profile ./default.profdata --ignore-filename-regex="/generated/" "${{github.workspace}}/src" > ./coverage.lcov
+        llvm-cov-${{env.compiler-version}} export ./QLeverAllUnitTestsMain --dump --format=lcov --instr-profile ./default.profdata --ignore-filename-regex="/generated/" "${{github.workspace}}/src" > ./coverage.lcov
 
 # Only upload the coverage directly if this is not a pull request. In this
 # case we are on the master branch and have access to the Codecov token.

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -30,16 +30,17 @@ jobs:
   build:
     env:
           compiler: clang
-          compiler-version: 16
+          # The compiler and the LLVM coverage tools have to use the same major
+          # version, so this is the single place where it is specified.
+          compiler-version: 21
           build-type: Debug
           warnings: "-Wall -Wextra "
           # we disable the `assert()` macro as it messes with the coverage reports
           asan-flags: "-DNDEBUG"
           ubsan-flags: ""
           coverage-flags: "-fprofile-instr-generate -fcoverage-mapping"
-          cmake-flags: "-DCMAKE_C_COMPILER=clang-16 -DCMAKE_CXX_COMPILER=clang++-16"
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v7
       with:
@@ -50,22 +51,22 @@ jobs:
     - name: Install compiler
       uses: ./.github/workflows/install-compiler-ubuntu
       with:
-        compiler: "clang"
-        compiler-version: "16"
+        compiler: ${{env.compiler}}
+        compiler-version: ${{env.compiler-version}}
     - name: Install coverage tools
       run: |
-        sudo apt install -y llvm-16
+        sudo apt install -y llvm-${{env.compiler-version}}
         sudo apt install mold
     - name: Show path
       run: |
-        which llvm-profdata-16
-        which llvm-cov-16
+        which llvm-profdata-${{env.compiler-version}}
+        which llvm-cov-${{env.compiler-version}}
     - name: Create build directory
       run: mkdir ${{github.workspace}}/build
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build ${{env.cmake-flags}} -DCMAKE_BUILD_TYPE=${{env.build-type}} -DLOGLEVEL=TIMING -DADDITIONAL_COMPILER_FLAGS="${{env.warnings}} ${{env.asan-flags}} ${{env.ubsan-flags}} ${{env.coverage-flags}}" -DADDITIONAL_LINKER_FLAGS="${{env.coverage-flags}}" -DUSE_PARALLEL=false -DRUN_EXPENSIVE_TESTS=false -DSINGLE_TEST_BINARY=ON -DENABLE_EXPENSIVE_CHECKS=true -DADDITIONAL_LINKER_FLAGS="-fuse-ld=mold"
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_TOOLCHAIN_FILE="$(pwd)/toolchains/${{env.compiler}}${{env.compiler-version}}.cmake" -DCMAKE_BUILD_TYPE=${{env.build-type}} -DLOGLEVEL=TIMING -DADDITIONAL_COMPILER_FLAGS="${{env.warnings}} ${{env.asan-flags}} ${{env.ubsan-flags}} ${{env.coverage-flags}}" -DADDITIONAL_LINKER_FLAGS="${{env.coverage-flags}}" -DUSE_PARALLEL=false -DRUN_EXPENSIVE_TESTS=false -DSINGLE_TEST_BINARY=ON -DENABLE_EXPENSIVE_CHECKS=true -DADDITIONAL_LINKER_FLAGS="-fuse-ld=mold"
 
     - name: Build
         # Build your program with the given configuration
@@ -86,8 +87,8 @@ jobs:
       run: |
         # `llvm-cov` only warns about a nonexistent source filter, and then reports everything.
         test -d "${{github.workspace}}/src"
-        llvm-profdata-16 merge -sparse *.profraw -o default.profdata
-        llvm-cov-16 export ./QLeverAllUnitTestsMain --format=lcov --instr-profile ./default.profdata --ignore-filename-regex="/generated/" "${{github.workspace}}/src" > ./coverage.lcov
+        llvm-profdata-${{env.compiler-version}} merge -sparse *.profraw -o default.profdata
+        llvm-cov-${{env.compiler-version}} export ./QLeverAllUnitTestsMain --format=lcov --instr-profile ./default.profdata --ignore-filename-regex="/generated/" "${{github.workspace}}/src" > ./coverage.lcov
 
 # Only upload the coverage directly if this is not a pull request. In this
 # case we are on the master branch and have access to the Codecov token.

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -80,9 +80,14 @@ jobs:
 
     - name: Process coverage info
       working-directory: ${{github.workspace}}/build/test
-      run:  >
-        llvm-profdata-16 merge -sparse *.profraw -o default.profdata;
-        llvm-cov-16 export ./QLeverAllUnitTestsMain --dump --format=lcov --instr-profile ./default.profdata --ignore-filename-regex="/third_party/" --ignore-filename-regex="/generated/"  --ignore-filename-regex="/nlohmann/" --ignore-filename-regex="/ctre/"  --ignore-filename-regex="/test/" --ignore-filename-regex="/benchmark/" > ./coverage.lcov
+      # Only measure QLever's own sources. Everything else (the dependencies
+      # below `_deps`, the tests, the benchmarks) already lies outside of `src`;
+      # the generated parsers don't, hence the explicit exclusion.
+      run: |
+        # `llvm-cov` only warns about a nonexistent source filter, and then reports everything.
+        test -d "${{github.workspace}}/src"
+        llvm-profdata-16 merge -sparse *.profraw -o default.profdata
+        llvm-cov-16 export ./QLeverAllUnitTestsMain --format=lcov --instr-profile ./default.profdata --ignore-filename-regex="/generated/" "${{github.workspace}}/src" > ./coverage.lcov
 
 # Only upload the coverage directly if this is not a pull request. In this
 # case we are on the master branch and have access to the Codecov token.

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -96,7 +96,10 @@ jobs:
       if: github.event_name != 'pull_request'
       uses: codecov/codecov-action@v6
       with:
-        file: ${{github.workspace}}/build/test/coverage.lcov
+        files: ${{github.workspace}}/build/test/coverage.lcov
+        # Fail if the file above is missing, instead of silently searching for
+        # other coverage reports.
+        disable_search: true
         # Note: technically, a `token` is not required for codecov.io when
         # uploading from a public repository, but specifying it avoids the
         # nasty spurious failures due to GitHub's rate limit for codecov's

--- a/.github/workflows/upload-coverage.yml
+++ b/.github/workflows/upload-coverage.yml
@@ -101,7 +101,10 @@ jobs:
       - name: "Upload coverage report"
         uses: codecov/codecov-action@v6
         with:
-          file: ${{github.workspace}}/build/test/coverage.lcov
+          files: ${{github.workspace}}/build/test/coverage.lcov
+          # Fail if the file above is missing, instead of silently searching for
+          # other coverage reports.
+          disable_search: true
           # Note: technically, a `token` is not required for codecov.io when
           # uploading from a public repository, but specifying it avoids the
           # nasty spurious failures due to Github's rate limit for codecov's

--- a/test/engine/OptionalJoinTest.cpp
+++ b/test/engine/OptionalJoinTest.cpp
@@ -868,10 +868,20 @@ TEST(OptionalJoin, limitOffsetIsPropagated) {
   }
 }
 // Test fixture for testing optionalJoinWithIndexScan with prefiltering.
+// The first test parameter controls whether the result of the join is requested
+// lazily, the second one whether the left input of the join is a fully
+// materialized result. The latter selects between the two implementations
+// inside `OptionalJoin::optionalJoinWithIndexScan`.
 class OptionalJoinWithIndexScan
-    : public ::testing::TestWithParam<bool>,
+    : public ::testing::TestWithParam<std::tuple<bool, bool>>,
       public ad_utility::testing::LazyJoinTestHelper {
  protected:
+  // Whether the result of the join is requested lazily.
+  bool requestLaziness() const { return std::get<0>(GetParam()); }
+
+  // Whether the left input of the join is a fully materialized result.
+  bool materializeLeft() const { return std::get<1>(GetParam()); }
+
   void SetUp() override {
     // Create a small knowledge graph with controlled block structure.
     // Using 8 bytes per column gives us a single triple per block.
@@ -893,22 +903,24 @@ class OptionalJoinWithIndexScan
                                                     xpy);
   }
 
+  // Create a `ValuesForTesting` instance for the left side of the join from the
+  // given constructor arguments. Depending on the test parameter the operation
+  // is forced to return a fully materialized result.
+  template <typename... Args>
+  std::shared_ptr<QueryExecutionTree> makeLeftSideValues(
+      QueryExecutionContext* qec, Args&&... args) const {
+    auto values = std::make_shared<ValuesForTesting>(qec, AD_FWD(args)...);
+    values->forceFullyMaterialized() = materializeLeft();
+    return std::make_shared<QueryExecutionTree>(qec, std::move(values));
+  }
+
   // Create a ValuesForTesting instance for the left side (single column).
   std::shared_ptr<QueryExecutionTree> makeLeftSide(
       IdTable table, std::vector<ColumnIndex> sortedColumns = {0}) const {
-    return ad_utility::makeExecutionTree<ValuesForTesting>(
+    return makeLeftSideValues(
         qec_, std::move(table),
         std::vector<std::optional<Variable>>{Variable{"?x"}}, false,
         std::move(sortedColumns));
-  }
-
-  // Create a ValuesForTesting instance for the left side (two columns).
-  std::shared_ptr<QueryExecutionTree> makeLeftSide2Col(
-      IdTable table, std::vector<ColumnIndex> sortedColumns = {0, 1}) const {
-    return ad_utility::makeExecutionTree<ValuesForTesting>(
-        qec_, std::move(table),
-        std::vector<std::optional<Variable>>{Variable{"?x"}, Variable{"?z"}},
-        false, std::move(sortedColumns));
   }
 
   // Turn the `result` into an `IdTable`, no matter whether it was materialized
@@ -935,9 +947,8 @@ class OptionalJoinWithIndexScan
   // Helper to verify that lazy and materialized results match.
   void verifyLazyAndMaterializedMatch(OptionalJoin& optJoin,
                                       const IdTable& expected) const {
-    bool requestLaziness = GetParam();
-    auto result = optJoin.computeResultOnlyForTesting(requestLaziness);
-    auto actual = materializeResult(optJoin, result, requestLaziness);
+    auto result = optJoin.computeResultOnlyForTesting(requestLaziness());
+    auto actual = materializeResult(optJoin, result, requestLaziness());
     EXPECT_EQ(actual, expected);
   }
 
@@ -994,10 +1005,9 @@ TEST_P(OptionalJoinWithIndexScan, singleColumnWithUndef) {
   OptionalJoin optJoin{qec_, left, right};
   qec_->getQueryTreeCache().clearAll();
 
-  bool requestLaziness = GetParam();
-  auto result = optJoin.computeResultOnlyForTesting(requestLaziness);
+  auto result = optJoin.computeResultOnlyForTesting(requestLaziness());
 
-  IdTable actual = materializeResult(optJoin, result, requestLaziness);
+  IdTable actual = materializeResult(optJoin, result, requestLaziness());
 
   // UNDEF matches all 8 rows, and `<a>` matches 2 rows.
   EXPECT_EQ(actual.numRows(), 10);
@@ -1073,7 +1083,7 @@ TEST_P(OptionalJoinWithIndexScan, twoColumnsBasicFiltering) {
   leftTable.push_back({s1, o1});  // matches 1 row
   leftTable.push_back({s3, U});   // matches 1 row.
 
-  auto left = ad_utility::makeExecutionTree<ValuesForTesting>(
+  auto left = makeLeftSideValues(
       qec2, std::move(leftTable),
       std::vector<std::optional<Variable>>{Variable{"?x"}, Variable{"?y"}},
       false, std::vector<ColumnIndex>{0, 1});
@@ -1087,10 +1097,9 @@ TEST_P(OptionalJoinWithIndexScan, twoColumnsBasicFiltering) {
   OptionalJoin optJoin{qec2, left, right};
   qec2->getQueryTreeCache().clearAll();
 
-  bool requestLaziness = GetParam();
-  auto result = optJoin.computeResultOnlyForTesting(requestLaziness);
+  auto result = optJoin.computeResultOnlyForTesting(requestLaziness());
 
-  IdTable actual = materializeResult(optJoin, result, requestLaziness);
+  IdTable actual = materializeResult(optJoin, result, requestLaziness());
 
   // Result should have 2 rows (one for each left entry matched with <p>
   // predicate).
@@ -1138,7 +1147,7 @@ TEST_P(OptionalJoinWithIndexScan, twoColumnsLocalVocabPropagation) {
   auto l3 = Id::makeFromLocalVocabIndex(v3.getIndexAndAddIfNotContained(i(3)));
   tAndV.emplace_back(makeIdTableFromVector({{s1, o2, l3}}), std::move(v3));
 
-  auto left = ad_utility::makeExecutionTree<ValuesForTesting>(
+  auto left = makeLeftSideValues(
       qec2, std::move(tAndV),
       std::vector<std::optional<Variable>>{Variable{"?x"}, Variable{"?y"},
                                            Variable{"?payload"}},
@@ -1153,12 +1162,11 @@ TEST_P(OptionalJoinWithIndexScan, twoColumnsLocalVocabPropagation) {
   OptionalJoin optJoin{qec2, left, right};
   qec2->getQueryTreeCache().clearAll();
 
-  bool requestLaziness = GetParam();
-  auto result = optJoin.computeResultOnlyForTesting(requestLaziness);
+  auto result = optJoin.computeResultOnlyForTesting(requestLaziness());
 
   // `materializeResult` also verifies that each local vocab entry is in fact
   // being kep alive by the `LocalVocab`.
-  IdTable actual = materializeResult(optJoin, result, requestLaziness);
+  IdTable actual = materializeResult(optJoin, result, requestLaziness());
 
   // Result should have 2 rows (one for each left entry matched with <p>
   // predicate).
@@ -1200,7 +1208,7 @@ TEST_P(OptionalJoinWithIndexScan, twoColumnsMultipleMatches) {
   leftTable.push_back({s1, o3});  // doesn't match, but is added as undefined.
   leftTable.push_back({s2, U});
 
-  auto left = ad_utility::makeExecutionTree<ValuesForTesting>(
+  auto left = makeLeftSideValues(
       qec2, std::move(leftTable),
       std::vector<std::optional<Variable>>{Variable{"?x"}, Variable{"?y"}},
       false, std::vector<ColumnIndex>{0, 1});
@@ -1213,10 +1221,9 @@ TEST_P(OptionalJoinWithIndexScan, twoColumnsMultipleMatches) {
   OptionalJoin optJoin{qec2, left, right};
   qec2->getQueryTreeCache().clearAll();
 
-  bool requestLaziness = GetParam();
-  auto result = optJoin.computeResultOnlyForTesting(requestLaziness);
+  auto result = optJoin.computeResultOnlyForTesting(requestLaziness());
 
-  IdTable actual = materializeResult(optJoin, result, requestLaziness);
+  IdTable actual = materializeResult(optJoin, result, requestLaziness());
 
   // Should have 5 rows total (s1,U) with 2 matches, (s1,o1) with 1 match,, (s1,
   // o2) with zero matches, but optional;  s2 with 1 match).
@@ -1225,5 +1232,12 @@ TEST_P(OptionalJoinWithIndexScan, twoColumnsMultipleMatches) {
   checkPrefilteringStats(optJoin, 3, 4);
 }
 
-INSTANTIATE_TEST_SUITE_P(OptionalJoinWithIndexScanSuite,
-                         OptionalJoinWithIndexScan, ::testing::Bool());
+INSTANTIATE_TEST_SUITE_P(
+    OptionalJoinWithIndexScanSuite, OptionalJoinWithIndexScan,
+    ::testing::Combine(::testing::Bool(), ::testing::Bool()),
+    ([](const ::testing::TestParamInfo<OptionalJoinWithIndexScan::ParamType>&
+            info) {
+      const auto& [requestLaziness, materializeLeft] = info.param;
+      return absl::StrCat(requestLaziness ? "LazyResult" : "MaterializedResult",
+                          materializeLeft ? "MaterializedLeft" : "LazyLeft");
+    }));


### PR DESCRIPTION
So far, the coverage CI used clang 16. It now uses clang 21, whose coverage tooling merges the branch coverage of templated code across the different instantiations of a template. This removes the most common source of spuriously uncovered branches in QLever's reports and increases the reported coverage by 1.80% without any code change. The clang version is now specified in a single place, and precompiled headers are disabled for the coverage build (they are a known source of flaky coverage reports).

The coverage report is now restricted to QLever's own sources under `src` via a positive filter (instead of a list of exclude patterns), and the upload step fails if the report file is missing (instead of silently searching for some other report).

There is also one test improvement: the tests for `OptionalJoin::optionalJoinWithIndexScan` are now additionally parameterized by whether the left input is fully materialized, which covers a branch of that function that no test reached before.
