### PR TITLE
Pin the SPARQL conformance check to a fixed commit of the conformance tool

### DIFF
--- a/.github/workflows/sparql-conformance.yml
+++ b/.github/workflows/sparql-conformance.yml
@@ -33,6 +33,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           repository: "ad-freiburg/sparql-conformance"
+          ref: "7482f394873558d4d1ca3a5a3f91f593865e2a82"
           path: qlever-test-suite
       - name: Set up Python
         uses: actions/setup-python@v6


### PR DESCRIPTION
So far, the `sparql-conformance` workflow always used the latest version of the conformance tool from the `ad-freiburg/sparql-conformance` repository. It now checks out a fixed commit of that repository (the current tip, so nothing changes for now). This way, the new conformance tool can be merged into that repository without breaking the CI of this repository; the workflow will be switched to the new tool in a follow-up.
