### PR TITLE
Allow user-defined encoding schemes for IRIs

### DIFF
--- a/src/index/CMakeLists.txt
+++ b/src/index/CMakeLists.txt
@@ -20,6 +20,7 @@ add_subdirectory(vocabulary)
 # files into a proper library of their own.
 add_library(index
         Index.cpp IndexImpl.cpp IndexImpl.Text.cpp EncodedIriManager.cpp
+        EncodedIriScheme.cpp
         IndexMetaData.cpp MetaDataHandler.cpp
         Vocabulary.cpp ../parser/RdfParser.cpp
         LocatedTriples.cpp Permutation.cpp TextMetaData.cpp

--- a/src/index/EncodedIriManager.h
+++ b/src/index/EncodedIriManager.h
@@ -1,16 +1,20 @@
 // Copyright 2025, University of Freiburg
 // Chair of Algorithms and Data Structures
-// Authors: Johannes Kalmbach <kalmbacj@cs.uni-freiburg.de>
+// Authors: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
 
 #ifndef QLEVER_SRC_INDEX_ENCODEDVALUES_H
 #define QLEVER_SRC_INDEX_ENCODEDVALUES_H
 
 #include <absl/numeric/bits.h>
+#include <absl/strings/str_join.h>
+
+#include <limits>
 
 #include "backports/StartsWithAndEndsWith.h"
 #include "backports/algorithm.h"
 #include "backports/three_way_comparison.h"
 #include "global/Id.h"
+#include "index/EncodedIriScheme.h"
 #include "util/BitUtils.h"
 #include "util/Log.h"
 #include "util/json.h"
@@ -56,6 +60,12 @@ std::optional<std::string_view> matchDigitsPrefix(std::string_view repr);
 // if 4 times the number of digits is larger than `NumBitsTotal - NumBitsTags`,
 // the IRI will not be encoded (but stored as a regular IRI). See the bottom of
 // the file for the default values of `NumBitsTotal` and `NumBitsTags`.
+//
+// In addition to these plain prefixes, arbitrary user-defined encoding schemes
+// can be plugged in, see `EncodedIriScheme.h`. Such a scheme reserves a number
+// of tags and is free to choose the structure of the IRIs that it encodes, for
+// example `<somePrefix://num_123_anotherNum_24>`, where only the `123` and the
+// `24` are load-bearing.
 struct NoHardcodedPrefixes {
   // The fixed prefixes have to be wrapped into a struct because
   // `std::array<std::string_view>` cannot be passed as a template parameter
@@ -72,7 +82,7 @@ class EncodedIriManagerImpl {
   static constexpr size_t NumBitsEncoding = NumBitsTotal - NumBitsTags;
 
   // We use 4-bit nibbles per digit in the encoding.
-  static constexpr size_t NibbleSize = 4;
+  static constexpr size_t NibbleSize = qlever::encodedIri::NibbleSize;
   static constexpr size_t NumDigits = NumBitsEncoding / NibbleSize;
   static_assert(NumBitsEncoding % NibbleSize == 0);
 
@@ -80,27 +90,97 @@ class EncodedIriManagerImpl {
   static_assert(NumBitsTags <= 64);
   static_assert(NumDigits > 0);
 
-  // The prefixes of the IRIs that will be encoded.
-  std::vector<std::string> prefixes_;
-
   static constexpr auto maxNumPrefixes_ = 1ULL << NumBitsTags;
 
-  // By default, `prefixes_` is empty, so no IRI will be encoded.
+  // The marker for a `Slot` that belongs to a plain prefix and not to an
+  // `EncodedIriScheme`.
+  static constexpr size_t noScheme = std::numeric_limits<size_t>::max();
+
+  // A single tag. It either belongs to a plain prefix, or to one of the
+  // `EncodedIriScheme`s (see `EncodedIriScheme.h`).
+  struct Slot {
+    // The prefix with a leading `<`. For a slot that belongs to a scheme, this
+    // is the lexicographically smallest of the prefixes of that scheme; it is
+    // only used for the ordering of the tags and for error messages.
+    std::string prefix_;
+    // The index of the scheme in `schemes_`, or `noScheme` for a plain prefix.
+    size_t schemeIdx_ = noScheme;
+    // The index of this slot within its scheme, `0` for a plain prefix.
+    size_t localTag_ = 0;
+
+    // Return true if and only if this slot belongs to an `EncodedIriScheme`.
+    bool isScheme() const { return schemeIdx_ != noScheme; }
+
+    QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(Slot, prefix_, schemeIdx_,
+                                                localTag_)
+
+    template <typename H>
+    friend H AbslHashValue(H h, const Slot& slot) {
+      return H::combine(std::move(h), slot.prefix_, slot.schemeIdx_,
+                        slot.localTag_);
+    }
+  };
+
+  // A scheme together with the information where its tags live in this
+  // manager.
+  struct SchemeInfo {
+    qlever::EncodedIriSchemePtr scheme_;
+    // The tag of the slot with the local tag `0` of this scheme. The tags of
+    // the scheme are `[firstTag_, firstTag_ + numTags_)`.
+    size_t firstTag_ = 0;
+    size_t numTags_ = 1;
+    size_t numPayloadBits_ = 0;
+    // The payloads of the scheme are shifted to the left by this number of
+    // bits, such that they are left-aligned within the payload bits of the
+    // `Id` (which is required for the ordering of the encoded `Id`s).
+    size_t payloadShift_ = 0;
+  };
+
+ private:
+  // A single entry of the table that is used to dispatch an IRI to its plain
+  // prefix or to its scheme in `encode`.
+  struct DispatchEntry {
+    // The prefix with a leading `<`.
+    std::string prefix_;
+    // The tag of the prefix (for a plain prefix), or the first tag of the
+    // scheme (for a scheme).
+    size_t tag_ = 0;
+    // The index of the scheme in `schemes_`, or `noScheme` for a plain prefix.
+    size_t schemeIdx_ = noScheme;
+  };
+
+  // The tags, one entry per tag.
+  std::vector<Slot> slots_;
+  // The user-defined encoding schemes.
+  std::vector<SchemeInfo> schemes_;
+  // The dispatch table for `encode`, see `DispatchEntry` above.
+  std::vector<DispatchEntry> dispatch_;
+
+  // Tag type for the private constructor that restores a manager from JSON.
+  struct FromJson {};
+
+ public:
+  // By default, there are no prefixes and no schemes, so no IRI will be
+  // encoded.
   // NOTE: When loading an existing index, in particular one from an older
   // QLever version with different hardcoded prefixes, it is crucial to use the
   // deserialization from JSON to initialize the EncodedIriManager. See the
   // note in `from_json`.
   EncodedIriManagerImpl() : EncodedIriManagerImpl(std::vector<std::string>{}) {}
 
-  // Construct from the list of prefixes. The prefixes have to be specified
-  // without any brackets, so e.g. "http://example.org/" if IRIs of the form
-  // `<http://example.org/1234>` should be encoded.
+  // Construct from the list of prefixes and the (optional) list of
+  // user-defined encoding schemes. The prefixes have to be specified without
+  // any brackets, so e.g. "http://example.org/" if IRIs of the form
+  // `<http://example.org/1234>` should be encoded. The tags are assigned in
+  // the lexicographic order of the prefixes (where a scheme is ordered by its
+  // smallest prefix and occupies a contiguous range of tags).
   // NOTE: When loading an existing index, in particular one from an older
   // QLever version with different hardcoded prefixes, it is crucial to use the
   // deserialization from JSON to initialize the EncodedIriManager. See the
   // note in `from_json`.
   explicit EncodedIriManagerImpl(
-      std::vector<std::string> prefixesWithoutAngleBrackets) {
+      std::vector<std::string> prefixesWithoutAngleBrackets,
+      std::vector<qlever::EncodedIriSchemePtr> schemes = {}) {
     // Add hardcoded prefixes.
     for (const auto& prefix : HardcodedPrefixes) {
       // Adding a hardcoded prefix a second time in the constructor is an error.
@@ -108,9 +188,19 @@ class EncodedIriManagerImpl {
           !ad_utility::contains(prefixesWithoutAngleBrackets, prefix));
       prefixesWithoutAngleBrackets.emplace_back(prefix);
     }
-    if (prefixesWithoutAngleBrackets.empty()) {
+    if (prefixesWithoutAngleBrackets.empty() && schemes.empty()) {
       return;
     }
+
+    for (const auto& prefix : prefixesWithoutAngleBrackets) {
+      if (ql::starts_with(prefix, '<')) {
+        throw std::runtime_error(absl::StrCat(
+            "The prefixes specified with `--encode-as-id` must not "
+            "be enclosed in angle brackets; here is a violating prefix: \"",
+            prefix, "\""));
+      }
+    }
+
     // Sort the prefixes lexicographically to make the ordering deterministic
     // (provided that the prefixes do not end with digits).
     ql::ranges::sort(prefixesWithoutAngleBrackets);
@@ -123,68 +213,69 @@ class EncodedIriManagerImpl {
         ::ranges::unique(prefixesWithoutAngleBrackets),
         prefixesWithoutAngleBrackets.end());
 
-    if (prefixesWithoutAngleBrackets.size() > maxNumPrefixes_) {
-      throw std::runtime_error(absl::StrCat(
-          "Number of prefixes specified with `--encode-as-id` is ",
-          prefixesWithoutAngleBrackets.size(), ", which is too many; ",
-          "the maximum is ", maxNumPrefixes_));
+    // From now on, all prefixes are stored with a leading `<`. Note that this
+    // doesn't change their relative order.
+    std::vector<std::string> prefixes;
+    prefixes.reserve(prefixesWithoutAngleBrackets.size());
+    for (const auto& prefix : prefixesWithoutAngleBrackets) {
+      prefixes.push_back(absl::StrCat("<", prefix));
     }
 
-    // TODO<C++23> use `std::views::adjacent`.
-    for (size_t i = 0; i < prefixesWithoutAngleBrackets.size() - 1; ++i) {
-      const auto& a = prefixesWithoutAngleBrackets.at(i);
-      const auto& b = prefixesWithoutAngleBrackets.at(i + 1);
-      if (ql::starts_with(b, a)) {
-        throw std::runtime_error(absl::StrCat(
-            "None of the prefixes specified with `--encode-as-id` "
-            "may be a prefix of another; here is a violating pair: \"",
-            a, "\" and \"", b, "\"."));
+    // Set up the schemes, and compute the sort key (the smallest prefix) of
+    // each of them.
+    std::vector<std::pair<std::string, size_t>> sortKeysOfSchemes;
+    for (const auto& scheme : schemes) {
+      checkSchemeIsValid(scheme);
+      for (const auto& info : schemes_) {
+        if (info.scheme_->name() == scheme->name()) {
+          throw std::runtime_error(absl::StrCat(
+              "Two different encoding schemes for IRIs with the same name \"",
+              scheme->name(), "\" were specified"));
+        }
       }
+      sortKeysOfSchemes.emplace_back(smallestPrefixOfScheme(*scheme),
+                                     schemes_.size());
+      schemes_.push_back(makeSchemeInfo(scheme));
     }
-    prefixes_.reserve(prefixesWithoutAngleBrackets.size());
-    for (const auto& prefix : prefixesWithoutAngleBrackets) {
-      if (ql::starts_with(prefix, '<')) {
-        throw std::runtime_error(absl::StrCat(
-            "The prefixes specified with `--encode-as-id` must not "
-            "be enclosed in angle brackets; here is a violating prefix: \"",
-            prefix, "\""));
+
+    // Assign the tags in the lexicographic order of the prefixes, where the
+    // tags of a scheme are contiguous and sorted by its smallest prefix.
+    ql::ranges::sort(sortKeysOfSchemes);
+    auto prefixIt = prefixes.begin();
+    for (const auto& [sortKey, schemeIdx] : sortKeysOfSchemes) {
+      for (; prefixIt != prefixes.end() && *prefixIt < sortKey; ++prefixIt) {
+        slots_.push_back(Slot{std::move(*prefixIt), noScheme, 0});
       }
-      prefixes_.push_back(absl::StrCat("<", prefix));
+      addSlotsForScheme(schemeIdx, sortKey);
     }
+    for (; prefixIt != prefixes.end(); ++prefixIt) {
+      slots_.push_back(Slot{std::move(*prefixIt), noScheme, 0});
+    }
+    finishInitialization();
   }
 
   // Try to encode the given string as an `Id`. If the encoding fails, return
   // `std::nullopt`. This happens in one of the following cases:
   //
   // 1. The string is not an `<iriref-in-angle-brackets>`
-  // 2. The string does not start with any of the `prefixes_`
-  // 3. After the matching prefix, there are characters other than `[0-9]`
-  // 4. There are more digits than fit into `NumBitsEncoding` (4 bits / digit)
+  // 2. The string does not start with any of the prefixes (neither with one of
+  //    the plain prefixes, nor with one of the prefixes of one of the schemes)
+  // 3. For a plain prefix: after the matching prefix, there are characters
+  //    other than `[0-9]`, or there are more digits than fit into
+  //    `NumBitsEncoding` (4 bits / digit)
+  // 4. For a scheme: the scheme cannot encode the IRI
   std::optional<Id> encode(std::string_view repr) const {
-    // Find the matching prefix.
-    auto it = ql::ranges::find_if(prefixes_, [&repr](std::string_view prefix) {
-      return ql::starts_with(repr, prefix);
-    });
-    if (it == prefixes_.end()) {
-      return std::nullopt;
+    for (const auto& entry : dispatch_) {
+      if (!ql::starts_with(repr, entry.prefix_)) {
+        continue;
+      }
+      if (entry.schemeIdx_ == noScheme) {
+        return encodeWithPlainPrefix(repr.substr(entry.prefix_.size()),
+                                     entry.tag_);
+      }
+      return encodeWithScheme(repr, entry.schemeIdx_);
     }
-
-    // Check that after the prefix, the string contains only digits and the
-    // trailing '>'.
-    repr.remove_prefix(it->size());
-    auto numStringOpt = detail::matchDigitsPrefix(repr);
-    if (!numStringOpt.has_value()) {
-      return std::nullopt;
-    }
-    std::string_view numString = numStringOpt.value();
-    if (numString.size() > NumDigits) {
-      return std::nullopt;
-    }
-
-    // Get the index of the used prefix, and run the actual encoding.
-    auto prefixIndex = static_cast<size_t>(it - prefixes_.begin());
-    return makeIdFromPrefixIdxAndPayload(prefixIndex,
-                                         encodeDecimalToNBit(numString));
+    return std::nullopt;
   }
 
   // combine the integer representation of the prefix and of the payload into a
@@ -200,7 +291,28 @@ class EncodedIriManagerImpl {
     AD_CORRECTNESS_CHECK(id.getDatatype() == Datatype::EncodedVal);
     // Get only the rightmost bits that represent the digits.
     auto [prefixIdx, digitEncoding] = splitIntoPrefixIdxAndPayload(id);
-    return toStringWithGivenPrefix(digitEncoding, prefixes_.at(prefixIdx));
+    const auto& slot = slots_.at(prefixIdx);
+    if (!slot.isScheme()) {
+      return toStringWithGivenPrefix(digitEncoding, slot.prefix_);
+    }
+    const auto& info = schemes_.at(slot.schemeIdx_);
+    return info.scheme_->decode(slot.localTag_,
+                                digitEncoding >> info.payloadShift_);
+  }
+
+  // Extract the raw numbers that are encoded in the given `Id`, in the order
+  // in which they appear in the IRI. For a plain prefix this is always a
+  // single number, for a scheme it is whatever the scheme reports (e.g.
+  // `{123, 24}` for `<somePrefix://num_123_anotherNum_24>`).
+  qlever::EncodedIriScheme::Numbers decodeNumbers(Id id) const {
+    auto [prefixIdx, digitEncoding] = splitIntoPrefixIdxAndPayload(id);
+    const auto& slot = slots_.at(prefixIdx);
+    if (!slot.isScheme()) {
+      return {decodeDecimalFrom64Bit(digitEncoding)};
+    }
+    const auto& info = schemes_.at(slot.schemeIdx_);
+    return info.scheme_->decodeNumbers(slot.localTag_,
+                                       digitEncoding >> info.payloadShift_);
   }
 
   // The second half of `toString` above: combine the integer encoding of the
@@ -233,32 +345,92 @@ class EncodedIriManagerImpl {
   }
 
   // The same as `splitIntoPrefixIdxAndPayload` except that the payload is
-  // returned decoded.
+  // returned decoded. NOTE: This function assumes that the `Id` was encoded
+  // using a plain prefix; for the `Id`s of an `EncodedIriScheme` use
+  // `decodeNumbers` above.
   static std::pair<uint64_t, uint64_t> splitIntoPrefixIdxAndDecodedPayload(
       Id id) {
     auto [prefix, payload] = splitIntoPrefixIdxAndPayload(id);
     return {prefix, decodeDecimalFrom64Bit(payload)};
   }
 
-  // The index of a prefix. This is the same prefix that is used for
+  // The index of a plain prefix. This is the same prefix that is used for
   // `makeIdFromPrefixIdxAndPayload` and returned from
-  // `splitIntoPrefixIdxAndPayload`.
+  // `splitIntoPrefixIdxAndPayload`. Return `std::nullopt` if there is no plain
+  // prefix that is equal to the argument (in particular, the prefixes of the
+  // `EncodedIriScheme`s are not considered here).
   std::optional<uint64_t> getIndexOfPrefix(
       std::string_view prefixWithoutAngleBrackets) const {
-    auto it = ql::ranges::find(prefixes_,
-                               absl::StrCat("<", prefixWithoutAngleBrackets));
-    if (it == prefixes_.end()) {
+    auto prefix = absl::StrCat("<", prefixWithoutAngleBrackets);
+    auto it = ql::ranges::find_if(slots_, [&prefix](const Slot& slot) {
+      return !slot.isScheme() && slot.prefix_ == prefix;
+    });
+    if (it == slots_.end()) {
       return std::nullopt;
     }
-    return static_cast<size_t>(it - prefixes_.begin());
+    return static_cast<size_t>(it - slots_.begin());
+  }
+
+  // The schemes that are used by this manager, together with the tags that
+  // they occupy.
+  const std::vector<SchemeInfo>& schemes() const { return schemes_; }
+
+  // Check that the schemes of this manager are exactly the `expectedSchemes`
+  // (compared via their name and their JSON representation), and throw a
+  // descriptive exception if this is not the case. This is used to detect the
+  // case that an index was built with a different set of schemes than the one
+  // that the current process is configured with.
+  void checkSchemesMatch(
+      const std::vector<qlever::EncodedIriSchemePtr>& expectedSchemes) const {
+    auto toStrings = [](auto&& schemes, auto getScheme) {
+      std::vector<std::string> result;
+      for (const auto& scheme : schemes) {
+        result.push_back(getScheme(scheme)->toJsonWithName().dump());
+      }
+      ql::ranges::sort(result);
+      return result;
+    };
+    auto actual = toStrings(
+        schemes_, [](const SchemeInfo& info) { return info.scheme_; });
+    auto expected =
+        toStrings(expectedSchemes,
+                  [](const qlever::EncodedIriSchemePtr& p) { return p; });
+    if (actual != expected) {
+      throw std::runtime_error(absl::StrCat(
+          "The encoding schemes for IRIs that were configured differ from the "
+          "ones that the index was built with. Configured: [",
+          absl::StrJoin(expected, ", "), "], index: [",
+          absl::StrJoin(actual, ", "), "]"));
+    }
   }
 
   // Conversion to and from JSON.
   static constexpr const char* jsonKey_ =
       "prefixes-with-leading-angle-brackets";
+  static constexpr const char* schemesJsonKey_ = "encoding-schemes";
+  static constexpr const char* firstTagJsonKey_ = "first-tag";
+  static constexpr const char* schemeJsonKey_ = "scheme";
   friend void to_json(nlohmann::json& j,
                       const EncodedIriManagerImpl& encodedIriManager) {
-    j[jsonKey_] = encodedIriManager.prefixes_;
+    std::vector<std::string> plainPrefixes;
+    for (const auto& slot : encodedIriManager.slots_) {
+      if (!slot.isScheme()) {
+        plainPrefixes.push_back(slot.prefix_);
+      }
+    }
+    j[jsonKey_] = std::move(plainPrefixes);
+    // Only write the schemes if there are any, such that the JSON of an index
+    // that doesn't use any schemes is exactly the same as before.
+    if (encodedIriManager.schemes_.empty()) {
+      return;
+    }
+    auto& schemes = j[schemesJsonKey_] = nlohmann::json::array();
+    for (const auto& info : encodedIriManager.schemes_) {
+      nlohmann::json entry;
+      entry[firstTagJsonKey_] = info.firstTag_;
+      entry[schemeJsonKey_] = info.scheme_->toJsonWithName();
+      schemes.push_back(std::move(entry));
+    }
   }
   friend void from_json(const nlohmann::json& j,
                         EncodedIriManagerImpl& encodedIriManager) {
@@ -271,74 +443,276 @@ class EncodedIriManagerImpl {
     // This keeps compatibility with already built indices. Newly built indices
     // go through the normal constructor and use the current hardcoded
     // prefixes.
-    encodedIriManager.prefixes_ =
-        static_cast<std::vector<std::string>>(j[jsonKey_]);
+    //
+    // The same holds for the user-defined encoding schemes: their tags are
+    // taken from the JSON and not recomputed, and the scheme objects are
+    // restored via the global `EncodedIriSchemeRegistry`, which throws if a
+    // scheme that the index uses is not registered in this process.
+    auto prefixes = static_cast<std::vector<std::string>>(j[jsonKey_]);
+    std::vector<std::pair<size_t, qlever::EncodedIriSchemePtr>> schemes;
+    if (j.contains(schemesJsonKey_)) {
+      for (const auto& entry : j[schemesJsonKey_]) {
+        schemes.emplace_back(
+            entry.at(firstTagJsonKey_).get<size_t>(),
+            qlever::EncodedIriScheme::fromJsonWithName(entry[schemeJsonKey_]));
+      }
+    }
+    encodedIriManager =
+        EncodedIriManagerImpl{FromJson{}, std::move(prefixes), schemes};
   }
 
   // Hash support for use in `TestIndexConfig`.
   template <typename H>
   friend H AbslHashValue(H h, const EncodedIriManagerImpl& manager) {
-    return H::combine(std::move(h), manager.prefixes_);
+    h = H::combine(std::move(h), manager.slots_);
+    for (const auto& info : manager.schemes_) {
+      h = H::combine(std::move(h), info.scheme_->toJsonWithName().dump(),
+                     info.firstTag_);
+    }
+    return h;
   }
 
-  // Equality operator for use in `TestIndexConfig`.
-  QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(EncodedIriManagerImpl, prefixes_)
+  // Equality comparison for use in `TestIndexConfig`. Two managers are equal
+  // if they assign the same tags to the same prefixes and use equal schemes
+  // (compared via their JSON representation).
+  friend bool operator==(const EncodedIriManagerImpl& a,
+                         const EncodedIriManagerImpl& b) {
+    return a.slots_ == b.slots_ && a.schemesAsJson() == b.schemesAsJson();
+  }
+  friend bool operator!=(const EncodedIriManagerImpl& a,
+                         const EncodedIriManagerImpl& b) {
+    return !(a == b);
+  }
 
   // Encode the `numberStr` (which may only consist of digits) into a 64-bit
   // number.
   static constexpr uint64_t encodeDecimalToNBit(std::string_view numberStr) {
-    auto len = numberStr.size();
-    AD_CORRECTNESS_CHECK(len <= NumDigits);
-
-    uint64_t result = 0;
-
-    // Compute the starting shift (for the first digit).
-    uint64_t shift = NumBitsEncoding - NibbleSize;
-
-    for (const char digitChar : numberStr) {
-      // Deliberately encode [0, ..., 9] as [1, ..., A], so that the padding
-      // nibble `0`is smaller than any valid digit encoding.
-      uint8_t digit = (digitChar - '0') + 1;
-      result |= static_cast<uint64_t>(digit) << shift;
-      shift -= NibbleSize;
-    }
-    return result;
-  }
-
-  // Helper for decoding numbers. Calls `F` for every digit (from high to low)
-  // in the decoded representation of `encoded`.
-  template <typename F>
-  static void decodeDecimalFrom64BitHelper(F processDigit, uint64_t encoded) {
-    size_t shift = NumBitsEncoding - NibbleSize;
-    auto numTrailingZeros = absl::countr_zero(encoded);
-    size_t numTrailingZeroNibbles = numTrailingZeros / NibbleSize;
-    size_t len = NumDigits - numTrailingZeroNibbles;
-    for (size_t i = 0; i < len; ++i) {
-      processDigit(((encoded >> shift) & 0xF) - 1);
-      shift -= NibbleSize;
-    }
+    return qlever::encodedIri::encodeDecimalNibbles(numberStr, NumBitsEncoding);
   }
 
   // The inverse of `encodeDecimalToNBit`. The result is appended to the
   // `result` string.
   static void decodeDecimalFrom64Bit(std::string& result, uint64_t encoded) {
-    decodeDecimalFrom64BitHelper(
-        [&result](auto digit) {
-          result.push_back(static_cast<char>(digit + '0'));
-        },
-        encoded);
+    qlever::encodedIri::decodeDecimalNibbles(result, encoded, NumBitsEncoding);
   }
 
   // Overload of `decodeDecimalFrom64Bit` that returns the result as a
   // `uint64_t`.
   static uint64_t decodeDecimalFrom64Bit(uint64_t encoded) {
-    uint64_t result = 0;
-    decodeDecimalFrom64BitHelper(
-        [&result](auto digit) {
-          result *= 10;
-          result += digit;
-        },
-        encoded);
+    return qlever::encodedIri::decodeDecimalNibblesToNumber(encoded,
+                                                            NumBitsEncoding);
+  }
+
+ private:
+  // Restore a manager from its JSON representation (see `from_json`). In
+  // contrast to the public constructor, the tags are not computed from the
+  // order of the prefixes, but taken from the arguments: the schemes occupy
+  // the tags that are stored in `schemes` (a pair of the first tag and the
+  // scheme), and the `prefixesWithAngleBrackets` fill up the remaining tags in
+  // their given order.
+  EncodedIriManagerImpl(
+      FromJson, std::vector<std::string> prefixesWithAngleBrackets,
+      const std::vector<std::pair<size_t, qlever::EncodedIriSchemePtr>>&
+          schemes) {
+    if (prefixesWithAngleBrackets.empty() && schemes.empty()) {
+      return;
+    }
+    size_t numTagsTotal = prefixesWithAngleBrackets.size();
+    for (const auto& [firstTag, scheme] : schemes) {
+      checkSchemeIsValid(scheme);
+      numTagsTotal += scheme->numTags();
+    }
+    slots_.resize(numTagsTotal);
+    std::vector<bool> tagIsUsed(numTagsTotal, false);
+    for (const auto& [firstTag, scheme] : schemes) {
+      auto schemeIdx = schemes_.size();
+      schemes_.push_back(makeSchemeInfo(scheme));
+      schemes_.back().firstTag_ = firstTag;
+      auto prefix = smallestPrefixOfScheme(*scheme);
+      for (size_t localTag = 0; localTag < scheme->numTags(); ++localTag) {
+        size_t tag = firstTag + localTag;
+        if (tag >= numTagsTotal || tagIsUsed.at(tag)) {
+          throw std::runtime_error(absl::StrCat(
+              "The stored tags of the encoding schemes for IRIs are "
+              "inconsistent, the index seems to be corrupted (scheme \"",
+              scheme->name(), "\", tag ", tag, ")"));
+        }
+        tagIsUsed.at(tag) = true;
+        slots_.at(tag) = Slot{prefix, schemeIdx, localTag};
+      }
+    }
+    auto prefixIt = prefixesWithAngleBrackets.begin();
+    for (size_t tag = 0; tag < numTagsTotal; ++tag) {
+      if (tagIsUsed.at(tag)) {
+        continue;
+      }
+      AD_CORRECTNESS_CHECK(prefixIt != prefixesWithAngleBrackets.end());
+      slots_.at(tag) = Slot{std::move(*prefixIt), noScheme, 0};
+      ++prefixIt;
+    }
+    finishInitialization();
+  }
+
+  // Check that the `scheme` is not `nullptr` and that its parameters are
+  // consistent with this manager. Throw otherwise.
+  static void checkSchemeIsValid(const qlever::EncodedIriSchemePtr& scheme) {
+    AD_CONTRACT_CHECK(scheme != nullptr,
+                      "An encoding scheme for IRIs must not be `nullptr`");
+    AD_CONTRACT_CHECK(!scheme->name().empty(),
+                      "The name of an encoding scheme for IRIs must not be "
+                      "empty");
+    if (scheme->numTags() == 0) {
+      throw std::runtime_error(absl::StrCat(
+          "The encoding scheme for IRIs \"", scheme->name(),
+          "\" has to reserve at least one tag, but reserves zero"));
+    }
+    if (scheme->numPayloadBits() > NumBitsEncoding) {
+      throw std::runtime_error(absl::StrCat(
+          "The encoding scheme for IRIs \"", scheme->name(), "\" requires ",
+          scheme->numPayloadBits(), " bits for its payload, but at most ",
+          NumBitsEncoding, " bits are available"));
+    }
+    if (scheme->prefixes().empty()) {
+      throw std::runtime_error(
+          absl::StrCat("The encoding scheme for IRIs \"", scheme->name(),
+                       "\" has to specify at least one prefix, but specifies "
+                       "none"));
+    }
+    for (const auto& prefix : scheme->prefixes()) {
+      if (prefix.empty() || ql::starts_with(prefix, '<')) {
+        throw std::runtime_error(absl::StrCat(
+            "The prefixes of the encoding scheme for IRIs \"", scheme->name(),
+            "\" must be nonempty and must not be enclosed in angle brackets; "
+            "here is a violating prefix: \"",
+            prefix, "\""));
+      }
+    }
+  }
+
+  // Create the `SchemeInfo` for the given `scheme` (with the `firstTag_` still
+  // unset). The `scheme` must previously have been checked via
+  // `checkSchemeIsValid`.
+  static SchemeInfo makeSchemeInfo(const qlever::EncodedIriSchemePtr& scheme) {
+    SchemeInfo info;
+    info.scheme_ = scheme;
+    info.numTags_ = scheme->numTags();
+    info.numPayloadBits_ = scheme->numPayloadBits();
+    info.payloadShift_ = NumBitsEncoding - info.numPayloadBits_;
+    return info;
+  }
+
+  // The lexicographically smallest prefix of the `scheme`, with a leading `<`.
+  // It determines the position of the tags of the scheme in the global order
+  // of all tags.
+  static std::string smallestPrefixOfScheme(
+      const qlever::EncodedIriScheme& scheme) {
+    auto prefixes = scheme.prefixes();
+    AD_CORRECTNESS_CHECK(!prefixes.empty());
+    return absl::StrCat("<", *ql::ranges::min_element(prefixes));
+  }
+
+  // Append the slots of the scheme with the index `schemeIdx` to `slots_` and
+  // store the resulting first tag in the `SchemeInfo`.
+  void addSlotsForScheme(size_t schemeIdx, const std::string& prefix) {
+    auto& info = schemes_.at(schemeIdx);
+    info.firstTag_ = slots_.size();
+    for (size_t localTag = 0; localTag < info.numTags_; ++localTag) {
+      slots_.push_back(Slot{prefix, schemeIdx, localTag});
+    }
+  }
+
+  // Build the dispatch table from `slots_` and `schemes_`, and check that the
+  // number of tags and the prefixes are valid. This is the last step of both
+  // constructors.
+  void finishInitialization() {
+    if (slots_.size() > maxNumPrefixes_) {
+      throw std::runtime_error(absl::StrCat(
+          "The number of tags required by the prefixes specified with "
+          "`--encode-as-id` and by the encoding schemes for IRIs is ",
+          slots_.size(), ", which is too many; the maximum is ",
+          maxNumPrefixes_));
+    }
+    // TODO<C++23> use `std::views::enumerate`.
+    for (size_t tag = 0; tag < slots_.size(); ++tag) {
+      const auto& slot = slots_.at(tag);
+      if (!slot.isScheme()) {
+        dispatch_.push_back(DispatchEntry{slot.prefix_, tag, noScheme});
+        continue;
+      }
+      // A scheme is only added once, with all of its prefixes.
+      if (slot.localTag_ != 0) {
+        continue;
+      }
+      const auto& info = schemes_.at(slot.schemeIdx_);
+      for (const auto& prefix : info.scheme_->prefixes()) {
+        dispatch_.push_back(
+            DispatchEntry{absl::StrCat("<", prefix), tag, slot.schemeIdx_});
+      }
+    }
+    ql::ranges::sort(dispatch_,
+                     [](const DispatchEntry& a, const DispatchEntry& b) {
+                       return a.prefix_ < b.prefix_;
+                     });
+    // TODO<C++23> use `std::views::adjacent`.
+    for (size_t i = 0; i + 1 < dispatch_.size(); ++i) {
+      const auto& a = dispatch_.at(i).prefix_;
+      const auto& b = dispatch_.at(i + 1).prefix_;
+      if (ql::starts_with(b, a)) {
+        throw std::runtime_error(absl::StrCat(
+            "None of the prefixes specified with `--encode-as-id` or by an "
+            "encoding scheme for IRIs "
+            "may be a prefix of another; here is a violating pair: \"",
+            a.substr(1), "\" and \"", b.substr(1), "\"."));
+      }
+    }
+  }
+
+  // The part of `encode` for a plain prefix: `rest` is the input with the
+  // matching prefix already removed, and `tag` is the tag of that prefix.
+  static std::optional<Id> encodeWithPlainPrefix(std::string_view rest,
+                                                 size_t tag) {
+    // Check that after the prefix, the string contains only digits and the
+    // trailing '>'.
+    auto numStringOpt = detail::matchDigitsPrefix(rest);
+    if (!numStringOpt.has_value()) {
+      return std::nullopt;
+    }
+    std::string_view numString = numStringOpt.value();
+    if (numString.size() > NumDigits) {
+      return std::nullopt;
+    }
+    return makeIdFromPrefixIdxAndPayload(tag, encodeDecimalToNBit(numString));
+  }
+
+  // The part of `encode` for the scheme with the index `schemeIdx`.
+  std::optional<Id> encodeWithScheme(std::string_view repr,
+                                     size_t schemeIdx) const {
+    const auto& info = schemes_.at(schemeIdx);
+    auto tagAndPayload = info.scheme_->encode(repr);
+    if (!tagAndPayload.has_value()) {
+      return std::nullopt;
+    }
+    auto [localTag, payload] = tagAndPayload.value();
+    AD_CORRECTNESS_CHECK(localTag < info.numTags_,
+                         "An encoding scheme for IRIs returned a tag that is "
+                         "larger than the number of tags it reserved");
+    AD_CORRECTNESS_CHECK(
+        payload <= ad_utility::bitMaskForLowerBits(info.numPayloadBits_),
+        "An encoding scheme for IRIs returned a payload that doesn't fit into "
+        "the number of bits it reserved");
+    return makeIdFromPrefixIdxAndPayload(info.firstTag_ + localTag,
+                                         payload << info.payloadShift_);
+  }
+
+  // The JSON representations of all the schemes, together with their first
+  // tag. Used for equality comparison.
+  std::vector<std::pair<size_t, std::string>> schemesAsJson() const {
+    std::vector<std::pair<size_t, std::string>> result;
+    for (const auto& info : schemes_) {
+      result.emplace_back(info.firstTag_,
+                          info.scheme_->toJsonWithName().dump());
+    }
+    ql::ranges::sort(result);
     return result;
   }
 };

--- a/src/index/EncodedIriScheme.cpp
+++ b/src/index/EncodedIriScheme.cpp
@@ -1,0 +1,111 @@
+// Copyright 2026 The QLever Authors, in particular:
+//
+// 2026 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+//
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#include "index/EncodedIriScheme.h"
+
+#include <absl/strings/str_cat.h>
+#include <absl/strings/str_join.h>
+
+#include "backports/algorithm.h"
+
+namespace qlever {
+
+// ____________________________________________________________________________
+nlohmann::json EncodedIriScheme::toJsonWithName() const {
+  nlohmann::json j = toJson();
+  AD_CONTRACT_CHECK(j.is_object(),
+                    "The `toJson` function of an `EncodedIriScheme` has to "
+                    "return a JSON object");
+  AD_CONTRACT_CHECK(!j.contains(nameKey_),
+                    "The `toJson` function of an `EncodedIriScheme` must not "
+                    "use the key ",
+                    nameKey_);
+  j[nameKey_] = name();
+  return j;
+}
+
+// ____________________________________________________________________________
+EncodedIriSchemePtr EncodedIriScheme::fromJsonWithName(
+    const nlohmann::json& j) {
+  AD_CONTRACT_CHECK(j.contains(nameKey_),
+                    "The JSON representation of an `EncodedIriScheme` is "
+                    "missing the key ",
+                    nameKey_);
+  auto name = j[nameKey_].get<std::string>();
+  auto factory = EncodedIriSchemeRegistry::get().getFactory(name);
+  if (!factory.has_value()) {
+    throw std::runtime_error{absl::StrCat(
+        "The index uses the encoding scheme \"", name,
+        "\" for IRIs, but no such scheme is registered in this process. Make "
+        "sure that the corresponding class is compiled in and registered via "
+        "`qlever::registerEncodedIriScheme`. The registered schemes are: [",
+        absl::StrJoin(EncodedIriSchemeRegistry::get().registeredNames(), ", "),
+        "]")};
+  }
+  auto scheme = std::invoke(factory.value(), j);
+  AD_CORRECTNESS_CHECK(scheme != nullptr);
+  AD_CONTRACT_CHECK(
+      scheme->name() == name,
+      "An `EncodedIriScheme` was registered under a name that differs from "
+      "the name that it reports itself, this is a bug in the scheme");
+  return scheme;
+}
+
+// ____________________________________________________________________________
+EncodedIriSchemeRegistry& EncodedIriSchemeRegistry::get() {
+  static EncodedIriSchemeRegistry registry;
+  return registry;
+}
+
+// ____________________________________________________________________________
+void EncodedIriSchemeRegistry::add(std::string name, std::type_index type,
+                                   Factory factory) {
+  AD_CONTRACT_CHECK(!name.empty(),
+                    "The name of an `EncodedIriScheme` must not be empty");
+  auto ptr = schemes_.wlock();
+  auto it = ptr->find(name);
+  if (it != ptr->end()) {
+    // Registering the same class twice is a no-op, registering a different
+    // class under the same name is an error.
+    AD_CONTRACT_CHECK(
+        it->second.type_ == type,
+        "Two different classes were registered as an `EncodedIriScheme` with "
+        "the same name \"",
+        name, "\"");
+    return;
+  }
+  ptr->emplace(std::move(name), Entry{type, std::move(factory)});
+}
+
+// ____________________________________________________________________________
+std::optional<EncodedIriSchemeRegistry::Factory>
+EncodedIriSchemeRegistry::getFactory(const std::string& name) const {
+  auto ptr = schemes_.rlock();
+  auto it = ptr->find(name);
+  if (it == ptr->end()) {
+    return std::nullopt;
+  }
+  return it->second.factory_;
+}
+
+// ____________________________________________________________________________
+std::vector<std::string> EncodedIriSchemeRegistry::registeredNames() const {
+  std::vector<std::string> result;
+  {
+    auto ptr = schemes_.rlock();
+    result.reserve(ptr->size());
+    for (const auto& [name, entry] : *ptr) {
+      result.push_back(name);
+    }
+  }
+  ql::ranges::sort(result);
+  return result;
+}
+
+}  // namespace qlever

--- a/src/index/EncodedIriScheme.h
+++ b/src/index/EncodedIriScheme.h
@@ -1,0 +1,301 @@
+// Copyright 2026 The QLever Authors, in particular:
+//
+// 2026 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+//
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#ifndef QLEVER_SRC_INDEX_ENCODEDIRISCHEME_H
+#define QLEVER_SRC_INDEX_ENCODEDIRISCHEME_H
+
+#include <absl/container/inlined_vector.h>
+#include <absl/numeric/bits.h>
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <typeindex>
+#include <utility>
+#include <vector>
+
+#include "util/Exception.h"
+#include "util/HashMap.h"
+#include "util/Synchronized.h"
+#include "util/json.h"
+
+namespace qlever {
+
+class EncodedIriScheme;
+
+// `EncodedIriScheme`s are always handled via a `shared_ptr` to a `const`
+// object, because they are immutable and shared between all the copies of an
+// `EncodedIriManager`.
+using EncodedIriSchemePtr = std::shared_ptr<const EncodedIriScheme>;
+
+// Interface for user-defined schemes that encode IRIs directly into an `Id`
+// (see `EncodedIriManager.h` for the general mechanism). While the built-in
+// prefixes can only encode IRIs that consist of a fixed prefix followed by a
+// sequence of decimal digits, a scheme may encode arbitrarily structured IRIs,
+// for example `<somePrefix://num_123_anotherNum_24>`, where only the `123` and
+// the `24` are load-bearing.
+//
+// A scheme reserves `numTags()` of the tags (prefix indices) of the
+// `EncodedIriManager`; they are called the "local tags" of the scheme and are
+// numbered `[0, numTags())`. The manager maps them to a contiguous range of its
+// own tags. Which of its local tags a scheme uses for a given IRI is entirely
+// up to the scheme; a typical use case are IRIs with the same prefix but
+// different internal structure (see the tests for an example).
+//
+// The contract for implementations is the following:
+//
+// 1. All member functions must be `const`, deterministic, and thread-safe.
+//    In particular, `encode` is called concurrently by all the parser threads
+//    during index building, and by all the query threads at query time.
+// 2. `encode` and `decode` must be inverse to each other, and the same must
+//    hold for all future runs of QLever that load an index built with this
+//    scheme (see `toJson` below).
+// 3. The payload returned by `encode` must fit into the lowest
+//    `numPayloadBits()` bits. The manager left-aligns it within the bits that
+//    are available for the payload.
+// 4. Ideally the encoding is order-preserving, meaning that the order of the
+//    payloads is the same as the lexicographic order of the encoded IRIs. This
+//    is not required for correctness (`Join`, `GROUP BY`, `DISTINCT`, etc. only
+//    require a consistent order, see `LocalVocabEntry.cpp`), but if it is
+//    violated, then `ORDER BY` and range filters on the affected IRIs follow
+//    the order of the encoding and not the lexicographic order. The helpers in
+//    the `encodedIri` namespace at the bottom of this file encode decimal
+//    digits in an order-preserving way.
+// 5. All IRIs that a scheme can encode must start with one of the literal
+//    prefixes reported by `prefixes()`. None of these prefixes may be a prefix
+//    of any other prefix or scheme prefix used by the same manager.
+class EncodedIriScheme {
+ public:
+  // The numbers that are encoded in a single IRI, see `decodeNumbers`.
+  using Numbers = absl::InlinedVector<uint64_t, 4>;
+
+  // The result of a successful encoding: the local tag (in `[0, numTags())`)
+  // and the payload (in the lowest `numPayloadBits()` bits).
+  using TagAndPayload = std::pair<size_t, uint64_t>;
+
+  // The JSON key under which `toJsonWithName` stores the `name` of the scheme.
+  static constexpr const char* nameKey_ = "scheme-name";
+
+  virtual ~EncodedIriScheme() = default;
+
+  // The name of the scheme. It has to be unique among all the schemes that are
+  // used together, and stable across QLever versions, because it is stored in
+  // the index and used to look up the scheme in the
+  // `EncodedIriSchemeRegistry` (see below) when the index is loaded again.
+  virtual std::string name() const = 0;
+
+  // The literal prefixes (without angle brackets, e.g. `http://example.org/`)
+  // of all the IRIs that this scheme can encode. Used to dispatch to this
+  // scheme, and to determine the position of the tags of this scheme in the
+  // global order of all tags.
+  virtual std::vector<std::string> prefixes() const = 0;
+
+  // The number of tags that this scheme reserves. Must be at least one.
+  virtual size_t numTags() const = 0;
+
+  // The number of bits that this scheme uses for its payload. Must be at most
+  // the number of payload bits of the manager (52 for the default
+  // `EncodedIriManager`).
+  virtual size_t numPayloadBits() const = 0;
+
+  // Try to encode the given IRI (with angle brackets, e.g.
+  // `<http://example.org/12>`). Return `std::nullopt` if this scheme cannot
+  // encode the IRI; it is then stored in the vocabulary as usual. Note that
+  // this function is only called if the IRI starts with one of the `prefixes`.
+  virtual std::optional<TagAndPayload> encode(
+      std::string_view iriWithAngleBrackets) const = 0;
+
+  // The inverse of `encode`: convert the `localTag` and the `payload` back to
+  // the IRI (with angle brackets).
+  virtual std::string decode(size_t localTag, uint64_t payload) const = 0;
+
+  // Extract the raw numbers that make up the payload, in the order in which
+  // they appear in the IRI. For example, for
+  // `<somePrefix://num_123_anotherNum_24>` this should return `{123, 24}`.
+  virtual Numbers decodeNumbers(size_t localTag, uint64_t payload) const = 0;
+
+  // Serialize the scheme to JSON. The result has to contain all the
+  // information that the static `fromJson` function of the concrete class
+  // needs to restore an equivalent scheme. It must not use the key `nameKey_`,
+  // which is added by `toJsonWithName` below. Schemes without any
+  // configuration can simply return an empty JSON object.
+  virtual nlohmann::json toJson() const = 0;
+
+  // The `toJson` of the concrete scheme, with the `name` added under the key
+  // `nameKey_`. This is what is stored in the index.
+  nlohmann::json toJsonWithName() const;
+
+  // The inverse of `toJsonWithName`: look up the stored name in the
+  // `EncodedIriSchemeRegistry` and dispatch to the `fromJson` function of the
+  // corresponding class. Throw if no scheme with that name is registered in
+  // this process (see `registerEncodedIriScheme` below).
+  static EncodedIriSchemePtr fromJsonWithName(const nlohmann::json& j);
+};
+
+// The global registry of all the `EncodedIriScheme` classes that are known to
+// this process. It is used to restore the schemes of an index that is loaded
+// from disk. Classes are added to it via `registerEncodedIriScheme` below.
+class EncodedIriSchemeRegistry {
+ public:
+  // A function that restores a scheme from the JSON that was written by
+  // `EncodedIriScheme::toJson`.
+  using Factory = std::function<EncodedIriSchemePtr(const nlohmann::json&)>;
+
+ private:
+  // The registered classes, by name. The `type_index` is stored to detect
+  // whether the same class or a different class is registered twice.
+  struct Entry {
+    std::type_index type_;
+    Factory factory_;
+  };
+  ad_utility::Synchronized<ad_utility::HashMap<std::string, Entry>> schemes_;
+
+ public:
+  // Get the single global instance.
+  static EncodedIriSchemeRegistry& get();
+
+  // Register the class `type` under the given `name`. Registering the same
+  // class under the same name twice is a no-op, registering a different class
+  // under a name that is already taken throws.
+  void add(std::string name, std::type_index type, Factory factory);
+
+  // Get the factory for the given `name`, or `std::nullopt` if no scheme with
+  // that name is registered.
+  std::optional<Factory> getFactory(const std::string& name) const;
+
+  // The names of all registered schemes, sorted. Used for error messages.
+  std::vector<std::string> registeredNames() const;
+};
+
+// Register the `EncodedIriScheme` class `T` in the global registry, such that
+// indices that were built using `T` can be loaded again. `T` has to provide
+// the following two static functions:
+//
+//   static std::string T::schemeName();
+//   static EncodedIriSchemePtr T::fromJson(const nlohmann::json&);
+//
+// where `schemeName()` returns the same name as the virtual `name()`, and
+// `fromJson` is the inverse of the virtual `toJson`.
+//
+// NOTE: This function has to be called before an index that uses `T` is
+// loaded. Calling it twice for the same class is a no-op.
+template <typename T>
+void registerEncodedIriScheme() {
+  EncodedIriSchemeRegistry::get().add(
+      std::string{T::schemeName()}, std::type_index{typeid(T)},
+      [](const nlohmann::json& j) -> EncodedIriSchemePtr {
+        return T::fromJson(j);
+      });
+}
+
+}  // namespace qlever
+
+// Convenience macro for `qlever::registerEncodedIriScheme<Type>()`, to be used
+// at namespace scope in the `.cpp` file of the scheme.
+//
+// NOTE: If the scheme lives in a static library, then the linker may discard
+// the translation unit with the registration, unless something else from the
+// same translation unit is used. In that case, call
+// `qlever::registerEncodedIriScheme<Type>()` explicitly during the startup of
+// your application.
+#define AD_ENCODED_IRI_SCHEME_CONCAT_IMPL(a, b) a##b
+#define AD_ENCODED_IRI_SCHEME_CONCAT(a, b) \
+  AD_ENCODED_IRI_SCHEME_CONCAT_IMPL(a, b)
+#define AD_REGISTER_ENCODED_IRI_SCHEME(...)                        \
+  [[maybe_unused]] static const bool AD_ENCODED_IRI_SCHEME_CONCAT( \
+      encodedIriSchemeRegistration_, __LINE__) = [] {              \
+    ::qlever::registerEncodedIriScheme<__VA_ARGS__>();             \
+    return true;                                                   \
+  }()
+
+namespace qlever::encodedIri {
+
+// The number of bits that are used to encode a single decimal digit.
+static constexpr size_t NibbleSize = 4;
+
+// Encode the decimal digits in `numberStr` into the lowest `numBits` bits of
+// the result. Each digit `i` is encoded as the nibble `i + 1` (such that the
+// padding nibble `0` is smaller than any digit), and the nibbles are stored
+// left-aligned within the `numBits` bits. This makes the encoding
+// order-preserving: the order of the encodings is the same as the
+// lexicographic order of the digit strings. `numBits` has to be a multiple of
+// `NibbleSize`, and `numberStr` may consist of at most `numBits / NibbleSize`
+// digits (which the caller has to check, e.g. via `fitsIntoNibbles`).
+constexpr uint64_t encodeDecimalNibbles(std::string_view numberStr,
+                                        size_t numBits) {
+  AD_CONTRACT_CHECK(numBits % NibbleSize == 0 && numBits <= 64);
+  AD_CONTRACT_CHECK(numberStr.size() <= numBits / NibbleSize);
+
+  uint64_t result = 0;
+  // Compute the starting shift (for the first digit).
+  uint64_t shift = numBits - NibbleSize;
+  for (const char digitChar : numberStr) {
+    // Deliberately encode `[0, ..., 9]` as `[1, ..., A]`, so that the padding
+    // nibble `0` is smaller than any valid digit encoding.
+    uint8_t digit = static_cast<uint8_t>(digitChar - '0') + 1;
+    result |= static_cast<uint64_t>(digit) << shift;
+    shift -= NibbleSize;
+  }
+  return result;
+}
+
+// Return true if and only if `numberStr` (which may only consist of digits)
+// can be encoded into `numBits` bits by `encodeDecimalNibbles`.
+constexpr bool fitsIntoNibbles(std::string_view numberStr, size_t numBits) {
+  return numberStr.size() <= numBits / NibbleSize;
+}
+
+// Helper for decoding numbers. Call `processDigit` for every digit (from high
+// to low) in the decoded representation of `encoded`, which has to be an
+// encoding into `numBits` bits (see `encodeDecimalNibbles`).
+template <typename F>
+void decodeDecimalNibblesHelper(F processDigit, uint64_t encoded,
+                                size_t numBits) {
+  size_t numDigits = numBits / NibbleSize;
+  size_t shift = numBits - NibbleSize;
+  auto numTrailingZeros = static_cast<size_t>(absl::countr_zero(encoded));
+  size_t numTrailingZeroNibbles = numTrailingZeros / NibbleSize;
+  size_t len = numTrailingZeroNibbles >= numDigits
+                   ? 0
+                   : numDigits - numTrailingZeroNibbles;
+  for (size_t i = 0; i < len; ++i) {
+    processDigit(((encoded >> shift) & 0xF) - 1);
+    shift -= NibbleSize;
+  }
+}
+
+// The inverse of `encodeDecimalNibbles`. The digits are appended to `result`.
+inline void decodeDecimalNibbles(std::string& result, uint64_t encoded,
+                                 size_t numBits) {
+  decodeDecimalNibblesHelper(
+      [&result](auto digit) {
+        result.push_back(static_cast<char>(digit + '0'));
+      },
+      encoded, numBits);
+}
+
+// Overload of `decodeDecimalNibbles` that returns the decoded digits as a
+// number.
+inline uint64_t decodeDecimalNibblesToNumber(uint64_t encoded, size_t numBits) {
+  uint64_t result = 0;
+  decodeDecimalNibblesHelper(
+      [&result](auto digit) {
+        result *= 10;
+        result += digit;
+      },
+      encoded, numBits);
+  return result;
+}
+
+}  // namespace qlever::encodedIri
+
+#endif  // QLEVER_SRC_INDEX_ENCODEDIRISCHEME_H

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -1507,6 +1507,13 @@ void IndexImpl::applyConfiguration(const nlohmann::json& configuration) {
 
   loadDataMember("encoded-iri-prefixes", encodedIriManager_,
                  EncodedIriManager{});
+  // The schemes of the index (which were restored from the JSON above) are
+  // authoritative. If the user has also configured schemes, then they have to
+  // be exactly the same, else the encoding of IRIs would silently differ
+  // between the index building and the query processing.
+  if (!encodedIriSchemes_.empty()) {
+    encodedIriManager_.checkSchemesMatch(encodedIriSchemes_);
+  }
   loadDataMember("graphNameManager", graphNameManager_,
                  GraphNameManager(std::string(QLEVER_NEW_GRAPH_PREFIX), 1));
 }
@@ -2090,8 +2097,8 @@ ad_utility::BlankNodeManager* IndexImpl::getBlankNodeManager() const {
 // _____________________________________________________________________________
 void IndexImpl::setPrefixesForEncodedValues(
     std::vector<std::string> prefixesWithoutAngleBrackets) {
-  encodedIriManager_ =
-      EncodedIriManager{std::move(prefixesWithoutAngleBrackets)};
+  encodedIriManager_ = EncodedIriManager{
+      std::move(prefixesWithoutAngleBrackets), encodedIriSchemes_};
 }
 
 // _____________________________________________________________________________

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -118,6 +118,10 @@ class IndexImpl {
   Index::Vocab vocab_;
   Index::TextVocab textVocab_;
   EncodedIriManager encodedIriManager_;
+  // The user-defined encoding schemes for IRIs, see `EncodedIriScheme.h`. They
+  // are used to build the `encodedIriManager_` during index building, and to
+  // validate the schemes that are stored in the index when it is loaded.
+  std::vector<qlever::EncodedIriSchemePtr> encodedIriSchemes_;
   ScoreData scoreData_;
 
   TextMetaData textMeta_;
@@ -312,9 +316,20 @@ class IndexImpl {
   const auto& encodedIriManager() const { return encodedIriManager_; }
 
   // Set the prefixes of the IRIs that will be encoded directly into
-  // the `Id`; see `EncodedIriManager` for details.
+  // the `Id`; see `EncodedIriManager` for details. The encoding schemes that
+  // have previously been set via `setEncodedIriSchemes` are also applied, so
+  // that function has to be called first.
   void setPrefixesForEncodedValues(
       std::vector<std::string> prefixesWithoutAngleBrackets);
+
+  // Set the user-defined encoding schemes for IRIs; see `EncodedIriScheme.h`
+  // for details. This has to be called before `setPrefixesForEncodedValues`
+  // (when building an index) resp. before `createFromOnDiskIndex` (when
+  // loading an index, in which case the schemes are only used to validate
+  // that the index was built with exactly these schemes).
+  void setEncodedIriSchemes(std::vector<qlever::EncodedIriSchemePtr> schemes) {
+    encodedIriSchemes_ = std::move(schemes);
+  }
 
   // Set the regexes for IRIs that should be treated as blank nodes during index
   // building. Each entry is an `RE2` regex; an IRI that is fully matched by any

--- a/src/libqlever/Qlever.cpp
+++ b/src/libqlever/Qlever.cpp
@@ -72,6 +72,10 @@ Qlever::Qlever(const EngineConfig& config, bool skipLoading)
   index.usePatterns() = enablePatternTrick_;
   index.loadAllPermutations() = !config.onlyPsoAndPos_;
   index.doNotLoadPermutations() = config.doNotLoadPermutations_;
+  // The schemes are only used to validate that the index was built with
+  // exactly these schemes, the actual schemes are restored from the index (see
+  // `IndexImpl::setEncodedIriSchemes`).
+  index.getImpl().setEncodedIriSchemes(config.encodedIriSchemes_);
   index.createFromOnDiskIndex(config.baseName_, config.persistUpdates_);
   if (config.loadTextIndex_) {
     index.addTextFromOnDiskIndex();
@@ -127,6 +131,9 @@ void Qlever::buildIndex(IndexBuilderConfig config) {
   index.loadAllPermutations() = !config.onlyPsoAndPos_;
   index.addHasWordTriples() = config.addHasWordTriples_;
   index.getImpl().setVocabularyTypeForIndexBuilding(config.vocabType_);
+  // NOTE: The schemes have to be set before the prefixes, because the
+  // `EncodedIriManager` is built by the latter call.
+  index.getImpl().setEncodedIriSchemes(config.encodedIriSchemes_);
   index.getImpl().setPrefixesForEncodedValues(config.prefixesForIdEncodedIris_);
   index.getImpl().setBlankNodeIriRegexes(config.blankNodeIriRegexes_);
 

--- a/src/libqlever/Qlever.h
+++ b/src/libqlever/Qlever.h
@@ -25,6 +25,7 @@
 #include "engine/QueryExecutionContext.h"
 #include "engine/QueryPlanner.h"
 #include "global/RuntimeParameters.h"
+#include "index/EncodedIriScheme.h"
 #include "index/Index.h"
 #include "index/InputFileSpecification.h"
 #include "libqlever/NamedCachedQueryBlobManager.h"
@@ -76,6 +77,23 @@ struct CommonConfig {
   // each literal, a triple `<literal> ql:has-word "word"` is added for each
   // word in the literal. This is useful for keyword search in literals.
   bool addHasWordTriples_ = false;
+
+  // User-defined schemes for encoding IRIs directly into the internal ID, see
+  // `src/index/EncodedIriScheme.h`. In contrast to
+  // `IndexBuilderConfig::prefixesForIdEncodedIris_` (which can only encode a
+  // fixed prefix followed by a sequence of digits), such a scheme may encode
+  // arbitrarily structured IRIs, for example
+  // `<somePrefix://num_123_anotherNum_24>`, where only the `123` and the `24`
+  // are load-bearing. Each scheme reserves a number of the (in total 256)
+  // available prefix slots.
+  //
+  // NOTE: The schemes are stored in the index. When loading an index that was
+  // built with schemes, the schemes are restored from the index via the global
+  // `qlever::EncodedIriSchemeRegistry`, so every scheme class has to be
+  // registered via `qlever::registerEncodedIriScheme` before the index is
+  // loaded, else the loading fails. If the schemes are additionally specified
+  // here, they have to be exactly the ones that the index was built with.
+  std::vector<qlever::EncodedIriSchemePtr> encodedIriSchemes_;
 };
 
 // Configuration for relocating a runtime-rebuilt index. It bundles the four

--- a/test/IndexTest.cpp
+++ b/test/IndexTest.cpp
@@ -15,6 +15,7 @@
 #include <filesystem>
 #include <fstream>
 
+#include "./util/EncodedIriSchemeTestHelpers.h"
 #include "./util/FileTestHelpers.h"
 #include "./util/GTestHelpers.h"
 #include "./util/IdTableHelpers.h"
@@ -1166,5 +1167,59 @@ TEST(IndexImpl, allIndexFilesAreListed) {
     EXPECT_TRUE(isAllowedNonIndexFile)
         << "File is neither an index file nor an allowed exclusion: "
         << entry.path().string();
+  }
+}
+
+// _____________________________________________________________________________
+// Build an index that uses a user-defined encoding scheme for IRIs (see
+// `EncodedIriScheme.h`), and check that the scheme is properly applied during
+// the index building and restored when the index is loaded again.
+TEST(IndexImpl, encodedIriSchemeEndToEnd) {
+  auto [directory, cleanup] = makeTemporaryDirectory("encodedIriScheme");
+  std::string base = directory + "/index";
+  std::string inputFilename = base + ".ttl";
+  {
+    std::ofstream input{inputFilename};
+    input << "<a> <b> <somePrefix://num_123_anotherNum_24> . "
+             "<a> <b> <somePrefix://num_1_otherNum_2> . <a> <b> <c> .";
+  }
+  {
+    Index index = makeIndexWithTestSettings();
+    index.setOnDiskBase(base);
+    index.getImpl().setEncodedIriSchemes(
+        {ad_utility::testing::twoNumbersScheme()});
+    index.getImpl().setPrefixesForEncodedValues({});
+    index.createFromFiles(
+        {{inputFilename, qlever::Filetype::Turtle, std::nullopt}});
+  }
+
+  // Load the index again. The scheme is restored from the index via the global
+  // `EncodedIriSchemeRegistry`, so it doesn't have to be configured again.
+  {
+    Index index{ad_utility::makeUnlimitedAllocator<Id>()};
+    index.createFromOnDiskIndex(base, false);
+    const auto& manager = index.encodedIriManager();
+    std::string iri = "<somePrefix://num_123_anotherNum_24>";
+    auto id = manager.encode(iri);
+    ASSERT_TRUE(id.has_value());
+    EXPECT_EQ(id.value().getDatatype(), Datatype::EncodedVal);
+    EXPECT_EQ(manager.toString(id.value()), iri);
+    EXPECT_THAT(manager.decodeNumbers(id.value()),
+                ::testing::ElementsAre(123, 24));
+    // The IRIs of the scheme were encoded, so they are not in the vocabulary,
+    // in contrast to the other IRIs of the input.
+    VocabIndex vocabIndex;
+    EXPECT_FALSE(index.getVocab().getId(iri, &vocabIndex));
+    EXPECT_TRUE(index.getVocab().getId("<c>", &vocabIndex));
+  }
+
+  // Loading the index with a different configured scheme is an error.
+  {
+    Index index{ad_utility::makeUnlimitedAllocator<Id>()};
+    index.getImpl().setEncodedIriSchemes(
+        {ad_utility::testing::twoNumbersScheme("otherPrefix://num_")});
+    AD_EXPECT_THROW_WITH_MESSAGE(
+        index.createFromOnDiskIndex(base, false),
+        ::testing::HasSubstr("differ from the ones that the index was built"));
   }
 }

--- a/test/index/EncodedIriManagerTest.cpp
+++ b/test/index/EncodedIriManagerTest.cpp
@@ -4,12 +4,17 @@
 
 #include <gmock/gmock.h>
 
+#include "../util/EncodedIriSchemeTestHelpers.h"
 #include "../util/GTestHelpers.h"
 #include "index/EncodedIriManager.h"
+#include "index/EncodedIriScheme.h"
 #include "util/Random.h"
 #include "util/TransparentFunctors.h"
 
 namespace {
+using ad_utility::testing::TwoNumbersScheme;
+using ad_utility::testing::twoNumbersScheme;
+
 // Get `num` random indices in the range `[min, max]`. Additionally, add the min
 // and the max to the result explicitly, to automaticlaly test corner cases.0
 std::vector<size_t> getRandomIndices(size_t min, size_t max, size_t num) {
@@ -242,6 +247,267 @@ TEST(EncodedIriManager, cannotAddHarcodedPrefixes) {
       Manager({std::string{TestHardcodedPrefixes::value.at(0)}}),
       testing::HasSubstr(
           "!ad_utility::contains(prefixesWithoutAngleBrackets, prefix)"));
+}
+
+// A scheme that can be configured arbitrarily (in particular in invalid ways),
+// to test the validation of the schemes by the `EncodedIriManager`. It cannot
+// encode anything.
+class ConfigurableScheme : public qlever::EncodedIriScheme {
+ private:
+  std::string name_;
+  std::vector<std::string> prefixes_;
+  size_t numTags_;
+  size_t numPayloadBits_;
+
+ public:
+  ConfigurableScheme(std::string name, std::vector<std::string> prefixes,
+                     size_t numTags = 1, size_t numPayloadBits = 8)
+      : name_{std::move(name)},
+        prefixes_{std::move(prefixes)},
+        numTags_{numTags},
+        numPayloadBits_{numPayloadBits} {}
+
+  std::string name() const override { return name_; }
+  std::vector<std::string> prefixes() const override { return prefixes_; }
+  size_t numTags() const override { return numTags_; }
+  size_t numPayloadBits() const override { return numPayloadBits_; }
+  std::optional<TagAndPayload> encode(
+      [[maybe_unused]] std::string_view iriWithAngleBrackets) const override {
+    return std::nullopt;
+  }
+  std::string decode([[maybe_unused]] size_t localTag,
+                     [[maybe_unused]] uint64_t payload) const override {
+    AD_FAIL();
+  }
+  Numbers decodeNumbers([[maybe_unused]] size_t localTag,
+                        [[maybe_unused]] uint64_t payload) const override {
+    AD_FAIL();
+  }
+  nlohmann::json toJson() const override { return nlohmann::json::object(); }
+};
+
+// Helper to create a manager with the `TwoNumbersScheme` and the given plain
+// prefixes.
+EncodedIriManager managerWithTwoNumbersScheme(
+    std::vector<std::string> prefixes = {}) {
+  return EncodedIriManager{std::move(prefixes), {twoNumbersScheme()}};
+}
+
+// _____________________________________________________________________________
+TEST(EncodedIriManager, customSchemeEncodeAndDecode) {
+  auto manager = managerWithTwoNumbersScheme({"http://example.org/"});
+  for (const auto& iri : {"<somePrefix://num_123_anotherNum_24>",
+                          "<somePrefix://num_0_otherNum_0>",
+                          "<somePrefix://num_999999_anotherNum_1>"}) {
+    auto id = manager.encode(iri);
+    ASSERT_TRUE(id.has_value()) << iri;
+    EXPECT_EQ(manager.toString(id.value()), iri);
+  }
+
+  // The numbers can be extracted directly from the `Id`.
+  auto id = manager.encode("<somePrefix://num_123_anotherNum_24>");
+  ASSERT_TRUE(id.has_value());
+  EXPECT_THAT(manager.decodeNumbers(id.value()),
+              ::testing::ElementsAre(123, 24));
+
+  // For a plain prefix, `decodeNumbers` returns the single encoded number.
+  auto plainId = manager.encode("<http://example.org/42>");
+  ASSERT_TRUE(plainId.has_value());
+  EXPECT_THAT(manager.decodeNumbers(plainId.value()),
+              ::testing::ElementsAre(42));
+
+  // The two variants of the scheme use different tags.
+  auto first = manager.encode("<somePrefix://num_1_anotherNum_2>");
+  auto second = manager.encode("<somePrefix://num_1_otherNum_2>");
+  ASSERT_TRUE(first.has_value());
+  ASSERT_TRUE(second.has_value());
+  EXPECT_NE(
+      EncodedIriManager::splitIntoPrefixIdxAndPayload(first.value()).first,
+      EncodedIriManager::splitIntoPrefixIdxAndPayload(second.value()).first);
+}
+
+// _____________________________________________________________________________
+TEST(EncodedIriManager, customSchemeUnencodable) {
+  auto manager = managerWithTwoNumbersScheme();
+  std::vector<std::string> unencodable{
+      // Not the structure that the scheme expects.
+      "<somePrefix://num_123_yetAnotherNum_24>",
+      "<somePrefix://num_123_anotherNum_>",
+      "<somePrefix://num_123_anotherNum_24",
+      "<somePrefix://num_12a_anotherNum_24>",
+      // Too many digits for the 24 bits (6 digits) per number.
+      "<somePrefix://num_1234567_anotherNum_24>",
+      "<somePrefix://num_1_anotherNum_1234567>",
+      // Doesn't start with the prefix of the scheme.
+      "<someOtherPrefix://num_1_anotherNum_2>"};
+  for (const auto& iri : unencodable) {
+    EXPECT_FALSE(manager.encode(iri).has_value()) << iri;
+  }
+}
+
+// _____________________________________________________________________________
+TEST(EncodedIriManager, customSchemeReservesTags) {
+  // The tags are assigned in the lexicographic order of the prefixes, and the
+  // two tags of the scheme are contiguous. Note that the hardcoded prefix
+  // (`QLEVER_NEW_GRAPH_PREFIX`) also uses a tag.
+  auto manager = managerWithTwoNumbersScheme({"aaa", "zzz"});
+  auto tagOf = [&manager](const std::string& iri) {
+    auto id = manager.encode(iri);
+    AD_CONTRACT_CHECK(id.has_value());
+    return EncodedIriManager::splitIntoPrefixIdxAndPayload(id.value()).first;
+  };
+  // The tags are `<aaa` (0), the hardcoded `QLEVER_NEW_GRAPH_PREFIX` (1), the
+  // two tags of the scheme (2 and 3), and `<zzz` (4).
+  EXPECT_THAT(manager.getIndexOfPrefix("aaa"), ::testing::Optional(0u));
+  EXPECT_THAT(manager.getIndexOfPrefix(QLEVER_NEW_GRAPH_PREFIX),
+              ::testing::Optional(1u));
+  EXPECT_EQ(tagOf("<somePrefix://num_1_anotherNum_2>"), 2u);
+  EXPECT_EQ(tagOf("<somePrefix://num_1_otherNum_2>"), 3u);
+  EXPECT_EQ(tagOf("<zzz42>"), 4u);
+  // The prefixes of a scheme are not found by `getIndexOfPrefix`, which only
+  // deals with the plain prefixes.
+  EXPECT_EQ(manager.getIndexOfPrefix("somePrefix://num_"), std::nullopt);
+
+  ASSERT_EQ(manager.schemes().size(), 1u);
+  EXPECT_EQ(manager.schemes().at(0).firstTag_, 2u);
+  EXPECT_EQ(manager.schemes().at(0).numTags_, 2u);
+}
+
+// _____________________________________________________________________________
+TEST(EncodedIriManager, customSchemeOrdering) {
+  // The scheme encodes both numbers in an order-preserving way, so within one
+  // of its variants, the order of the `Id`s is the lexicographic order of the
+  // two digit strings.
+  auto manager = managerWithTwoNumbersScheme();
+  std::vector<std::pair<std::string, uint64_t>> pairsAndEncodings;
+  for (std::string_view first : {"1", "12", "2", "999999"}) {
+    for (std::string_view second : {"0", "10", "9"}) {
+      auto iri = absl::StrCat("<somePrefix://num_", first, "_anotherNum_",
+                              second, ">");
+      auto id = manager.encode(iri);
+      ASSERT_TRUE(id.has_value()) << iri;
+      pairsAndEncodings.emplace_back(absl::StrCat(first, " ", second),
+                                     id.value().getBits());
+    }
+  }
+  auto sortedByBits = pairsAndEncodings;
+  ql::ranges::sort(pairsAndEncodings, ql::ranges::less{}, ad_utility::first);
+  ql::ranges::sort(sortedByBits, ql::ranges::less{}, ad_utility::second);
+  EXPECT_THAT(pairsAndEncodings, ::testing::ElementsAreArray(sortedByBits));
+}
+
+// _____________________________________________________________________________
+TEST(EncodedIriManager, customSchemeJson) {
+  auto manager = managerWithTwoNumbersScheme({"http://example.org/"});
+  nlohmann::json j = manager;
+  auto manager2 = j.get<EncodedIriManager>();
+  // The tags and the schemes are exactly restored.
+  EXPECT_EQ(manager, manager2);
+  for (const auto& iri :
+       {"<somePrefix://num_123_anotherNum_24>",
+        "<somePrefix://num_123_otherNum_24>", "<http://example.org/42>"}) {
+    auto id = manager.encode(iri);
+    auto id2 = manager2.encode(iri);
+    ASSERT_TRUE(id.has_value()) << iri;
+    ASSERT_TRUE(id2.has_value()) << iri;
+    EXPECT_EQ(id2.value().getBits(), id.value().getBits());
+    EXPECT_EQ(manager2.toString(id.value()), iri);
+  }
+
+  // A manager without any schemes writes exactly the same JSON as before the
+  // schemes were introduced.
+  nlohmann::json withoutSchemes = EncodedIriManager{{"http://example.org/"}};
+  EXPECT_FALSE(withoutSchemes.contains(EncodedIriManager::schemesJsonKey_));
+}
+
+// _____________________________________________________________________________
+TEST(EncodedIriManager, customSchemeJsonUnknownScheme) {
+  nlohmann::json j = managerWithTwoNumbersScheme();
+  auto& scheme = j[EncodedIriManager::schemesJsonKey_][0]
+                  [EncodedIriManager::schemeJsonKey_];
+  scheme[qlever::EncodedIriScheme::nameKey_] = "a-scheme-that-is-not-linked-in";
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      j.get<EncodedIriManager>(),
+      ::testing::AllOf(::testing::HasSubstr("a-scheme-that-is-not-linked-in"),
+                       ::testing::HasSubstr("no such scheme is registered"),
+                       ::testing::HasSubstr(TwoNumbersScheme::schemeName())));
+}
+
+// _____________________________________________________________________________
+TEST(EncodedIriManager, customSchemeInvalidSchemes) {
+  using V = std::vector<std::string>;
+  using S = std::vector<qlever::EncodedIriSchemePtr>;
+  using ::testing::HasSubstr;
+  auto scheme = [](std::string name, V prefixes, size_t numTags = 1,
+                   size_t numPayloadBits = 8) {
+    return std::make_shared<ConfigurableScheme>(
+        std::move(name), std::move(prefixes), numTags, numPayloadBits);
+  };
+
+  AD_EXPECT_THROW_WITH_MESSAGE(EncodedIriManager(V{}, S{nullptr}),
+                               HasSubstr("must not be `nullptr`"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      EncodedIriManager(V{}, S{scheme("", V{"a"})}),
+      HasSubstr("name of an encoding scheme for IRIs must not be"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      EncodedIriManager(V{}, S{scheme("s", V{"a"}, 0)}),
+      HasSubstr("has to reserve at least one tag"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      EncodedIriManager(V{}, S{scheme("s", V{"a"}, 1, 53)}),
+      HasSubstr("requires 53 bits for its payload"));
+  AD_EXPECT_THROW_WITH_MESSAGE(EncodedIriManager(V{}, S{scheme("s", V{})}),
+                               HasSubstr("has to specify at least one prefix"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      EncodedIriManager(V{}, S{scheme("s", V{"<a"})}),
+      HasSubstr("must not be enclosed in angle brackets"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      EncodedIriManager(V{}, S{scheme("s", V{"a"}), scheme("s", V{"b"})}),
+      HasSubstr("same name"));
+  // A prefix of a scheme must not be a prefix of a plain prefix or of the
+  // prefix of another scheme.
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      EncodedIriManager(V{"abc"}, S{scheme("s", V{"ab"})}),
+      HasSubstr("may be a prefix of another"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      EncodedIriManager(V{}, S{scheme("s", V{"ab"}), scheme("t", V{"abc"})}),
+      HasSubstr("may be a prefix of another"));
+  // The tags of the schemes also count towards the maximum number of tags.
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      EncodedIriManager(V{}, S{scheme("s", V{"a"}, 256)}),
+      HasSubstr("which is too many"));
+}
+
+// _____________________________________________________________________________
+TEST(EncodedIriManager, checkSchemesMatch) {
+  auto manager = managerWithTwoNumbersScheme();
+  EXPECT_NO_THROW(manager.checkSchemesMatch({twoNumbersScheme()}));
+  // A scheme with a different configuration is detected.
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      manager.checkSchemesMatch({twoNumbersScheme("otherPrefix://num_")}),
+      ::testing::HasSubstr("differ from the ones that the index was built"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      manager.checkSchemesMatch({}),
+      ::testing::HasSubstr("differ from the ones that the index was built"));
+  EXPECT_NO_THROW(EncodedIriManager{}.checkSchemesMatch({}));
+}
+
+// _____________________________________________________________________________
+TEST(EncodedIriManager, schemeRegistry) {
+  // Registering the same class twice is a no-op.
+  EXPECT_NO_THROW(qlever::registerEncodedIriScheme<TwoNumbersScheme>());
+  // Registering a different class under the same name is an error. The
+  // `ConfigurableScheme` is not registered anywhere else, so this doesn't
+  // affect the other tests.
+  struct OtherScheme : ConfigurableScheme {
+    OtherScheme() : ConfigurableScheme{TwoNumbersScheme::schemeName(), {"a"}} {}
+    static std::string schemeName() { return TwoNumbersScheme::schemeName(); }
+    static qlever::EncodedIriSchemePtr fromJson(const nlohmann::json&) {
+      return std::make_shared<OtherScheme>();
+    }
+  };
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      qlever::registerEncodedIriScheme<OtherScheme>(),
+      ::testing::HasSubstr("Two different classes were registered"));
 }
 
 // _____________________________________________________________________________

--- a/test/util/EncodedIriSchemeTestHelpers.h
+++ b/test/util/EncodedIriSchemeTestHelpers.h
@@ -1,0 +1,144 @@
+// Copyright 2026 The QLever Authors, in particular:
+//
+// 2026 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+//
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#ifndef QLEVER_TEST_UTIL_ENCODEDIRISCHEMETESTHELPERS_H
+#define QLEVER_TEST_UTIL_ENCODEDIRISCHEMETESTHELPERS_H
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "backports/StartsWithAndEndsWith.h"
+#include "index/EncodedIriScheme.h"
+#include "util/BitUtils.h"
+#include "util/CtreHelpers.h"
+
+namespace ad_utility::testing {
+
+// A custom encoding scheme for IRIs that mixes constant strings with two
+// numbers, namely `<somePrefix://num_123_anotherNum_24>` and
+// `<somePrefix://num_123_otherNum_24>`, where only the `123` and the `24` are
+// load-bearing. The two variants use one tag each. The part before the first
+// number (`somePrefix://num_` in the example) is configurable, which is also
+// used to test the serialization of the configuration of a scheme.
+//
+// NOTE: This scheme is not order-preserving, because the constant string
+// between the two numbers starts with `_`, which is larger than any digit (see
+// the documentation of `EncodedIriScheme`).
+class TwoNumbersScheme : public qlever::EncodedIriScheme {
+ public:
+  // The number of bits that are used for each of the two numbers, so each of
+  // them may have at most six digits.
+  static constexpr size_t numBitsPerNumber = 24;
+  // The JSON key for the configurable prefix.
+  static constexpr const char* prefixKey_ = "prefix";
+
+ private:
+  // The prefix, without angle brackets, e.g. `somePrefix://num_`.
+  std::string prefix_;
+  // The same prefix with a leading `<`, to avoid a string concatenation for
+  // every call to `encode`.
+  std::string prefixWithAngleBracket_;
+
+ public:
+  explicit TwoNumbersScheme(std::string prefix = "somePrefix://num_")
+      : prefix_{std::move(prefix)},
+        prefixWithAngleBracket_{absl::StrCat("<", prefix_)} {}
+
+  // The name, both as a static function (which is required by
+  // `qlever::registerEncodedIriScheme`) and as the virtual function.
+  static std::string schemeName() { return "test-two-numbers"; }
+  std::string name() const override { return schemeName(); }
+
+  std::vector<std::string> prefixes() const override { return {prefix_}; }
+
+  size_t numTags() const override { return 2; }
+
+  size_t numPayloadBits() const override { return 2 * numBitsPerNumber; }
+
+  std::optional<TagAndPayload> encode(
+      std::string_view iriWithAngleBrackets) const override {
+    if (!ql::starts_with(iriWithAngleBrackets, prefixWithAngleBracket_)) {
+      return std::nullopt;
+    }
+    iriWithAngleBrackets.remove_prefix(prefixWithAngleBracket_.size());
+    static constexpr auto regex = ctll::fixed_string{
+        "(?<first>[0-9]+)_(?<kind>another|other)Num_(?<second>[0-9]+)>"};
+    auto match = ctre::match<regex>(iriWithAngleBrackets);
+    if (!match) {
+      return std::nullopt;
+    }
+    constexpr ctll::fixed_string firstGroup = "first";
+    constexpr ctll::fixed_string kindGroup = "kind";
+    constexpr ctll::fixed_string secondGroup = "second";
+    auto first = match.template get<firstGroup>().to_view();
+    auto second = match.template get<secondGroup>().to_view();
+    using namespace qlever::encodedIri;
+    if (!fitsIntoNibbles(first, numBitsPerNumber) ||
+        !fitsIntoNibbles(second, numBitsPerNumber)) {
+      return std::nullopt;
+    }
+    uint64_t payload =
+        (encodeDecimalNibbles(first, numBitsPerNumber) << numBitsPerNumber) |
+        encodeDecimalNibbles(second, numBitsPerNumber);
+    size_t localTag =
+        match.template get<kindGroup>().to_view() == "another" ? 0 : 1;
+    return TagAndPayload{localTag, payload};
+  }
+
+  std::string decode(size_t localTag, uint64_t payload) const override {
+    AD_CONTRACT_CHECK(localTag < numTags());
+    std::string result = prefixWithAngleBracket_;
+    qlever::encodedIri::decodeDecimalNibbles(
+        result, payload >> numBitsPerNumber, numBitsPerNumber);
+    result += localTag == 0 ? "_anotherNum_" : "_otherNum_";
+    qlever::encodedIri::decodeDecimalNibbles(result, lowerNumber(payload),
+                                             numBitsPerNumber);
+    result.push_back('>');
+    return result;
+  }
+
+  Numbers decodeNumbers(size_t localTag, uint64_t payload) const override {
+    AD_CONTRACT_CHECK(localTag < numTags());
+    using qlever::encodedIri::decodeDecimalNibblesToNumber;
+    return {
+        decodeDecimalNibblesToNumber(payload >> numBitsPerNumber,
+                                     numBitsPerNumber),
+        decodeDecimalNibblesToNumber(lowerNumber(payload), numBitsPerNumber)};
+  }
+
+  nlohmann::json toJson() const override {
+    nlohmann::json j;
+    j[prefixKey_] = prefix_;
+    return j;
+  }
+
+  static qlever::EncodedIriSchemePtr fromJson(const nlohmann::json& j) {
+    return std::make_shared<TwoNumbersScheme>(
+        j.at(prefixKey_).get<std::string>());
+  }
+
+ private:
+  // The encoding of the second number, which lives in the lower bits of the
+  // `payload`.
+  static uint64_t lowerNumber(uint64_t payload) {
+    return payload & ad_utility::bitMaskForLowerBits(numBitsPerNumber);
+  }
+};
+AD_REGISTER_ENCODED_IRI_SCHEME(TwoNumbersScheme);
+
+// Helper to create a `shared_ptr` to a `TwoNumbersScheme`.
+inline qlever::EncodedIriSchemePtr twoNumbersScheme(
+    std::string prefix = "somePrefix://num_") {
+  return std::make_shared<TwoNumbersScheme>(std::move(prefix));
+}
+
+}  // namespace ad_utility::testing
+
+#endif  // QLEVER_TEST_UTIL_ENCODEDIRISCHEMETESTHELPERS_H


### PR DESCRIPTION
So far, the `EncodedIriManager` can only encode IRIs that consist of one of a fixed set of prefixes followed by a sequence of decimal digits. This PR adds a customization point that allows a user of `libqlever` to plug in arbitrary encoding schemes via the new type-erased `EncodedIriScheme` interface (`src/index/EncodedIriScheme.h`), for example for IRIs of the form `<somePrefix://num_123_anotherNum_24>`, where only the `123` and the `24` are load-bearing.

### The interface

A scheme reports the literal prefixes of the IRIs it can encode (used for dispatch and for the ordering of the tags), the number of tags (prefix indices) it reserves, and the number of payload bits it needs. It then implements `encode`, `decode`, `decodeNumbers` (the raw numbers that make up the payload), and `toJson`. Schemes therefore have the same functionality as the plain prefixes, including the new `EncodedIriManager::decodeNumbers(Id)`, which also works for plain prefixes.

The manager assigns a contiguous range of tags to each scheme, orders all tags globally by their prefix, checks that no prefix is a prefix of another one (across plain prefixes and schemes), and left-aligns the payload of a scheme within the available payload bits. The plain prefixes keep their existing (non-virtual) code path, so nothing changes for indices that don't use any scheme.

Order-preservation of the encoding is documented as desirable but not required: only a consistent order is needed for correctness (see the note in `LocalVocabEntry.cpp`); a scheme that is not order-preserving makes `ORDER BY` and range filters on the affected IRIs follow the order of the encoding. The reusable helpers in the `qlever::encodedIri` namespace encode decimal digits in an order-preserving way (the plain prefixes now also use them, so there is only one implementation).

### Configuration and persistence

The schemes are installed via `qlever::CommonConfig::encodedIriSchemes_`. They are stored in the index (a new `encoding-schemes` key next to the existing list of prefixes; the JSON of an index without schemes is unchanged) and are restored when the index is loaded again, via a global registry of scheme classes (`qlever::registerEncodedIriScheme<T>()`, plus the convenience macro `AD_REGISTER_ENCODED_IRI_SCHEME`). Loading an index that uses a scheme which is not registered in the current process fails with a descriptive error message; the same holds if the configured schemes differ from the ones the index was built with.

### Tests

The tests use a scheme that mixes constant strings with two numbers (`<somePrefix://num_123_anotherNum_24>` and a second variant `<somePrefix://num_123_otherNum_24>`, so that a scheme with more than one tag is covered). They check encoding/decoding, the extraction of the raw numbers, the reservation and ordering of the tags, the JSON round trip, the error cases of the validation and of the registry, and, end to end, that an index that is built with a scheme encodes the affected IRIs (they are not in the vocabulary) and can be loaded again in a process that only has the scheme registered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)