### PR TITLE
Remove `AD_ALWAYS_INLINE` where it cannot take effect

### DIFF
--- a/src/index/DeltaTriples.cpp
+++ b/src/index/DeltaTriples.cpp
@@ -788,7 +788,7 @@ void DeltaTriples::addFromSnapshotDiff(
 }
 
 // _____________________________________________________________________________
-AD_ALWAYS_INLINE void DeltaTriples::remapId(
+void DeltaTriples::remapId(
     const qlever::indexRebuilder::IndexRebuildMapping& idMapping, Id& id,
     LocalVocab& localVocab, const IndexImpl& index) {
   const auto& [insertionPositions, localVocabMapping, blankNodeBlocks,

--- a/src/index/IndexRebuilder.cpp
+++ b/src/index/IndexRebuilder.cpp
@@ -143,22 +143,21 @@ BlankNodeBlocks flattenBlankNodeBlocks(const OwnedBlocks& ownedBlocks) {
 // _____________________________________________________________________________
 namespace {
 // Compute by what offset `value` needs to be increased to fit in the new index.
-AD_ALWAYS_INLINE size_t computeIndexOffset(
-    VocabIndex value, const InsertionPositions& insertionPositions) {
+size_t computeIndexOffset(VocabIndex value,
+                          const InsertionPositions& insertionPositions) {
   return ql::ranges::distance(
       insertionPositions.begin(),
       ql::ranges::upper_bound(insertionPositions, value, std::less{}));
 }
 
 // Apply `offset` to `value` and return the new `Id` resulting from this.
-AD_ALWAYS_INLINE Id applyOffset(VocabIndex value, size_t offset) {
+Id applyOffset(VocabIndex value, size_t offset) {
   return Id::makeFromVocabIndex(VocabIndex::make(value.get() + offset));
 }
 }  // namespace
 
 // _____________________________________________________________________________
-AD_ALWAYS_INLINE Id remapVocabId(Id original,
-                                 const InsertionPositions& insertionPositions) {
+Id remapVocabId(Id original, const InsertionPositions& insertionPositions) {
   AD_EXPENSIVE_CHECK(
       original.getDatatype() == Datatype::VocabIndex,
       "Only ids resembling a vocab index can be remapped with this function.");
@@ -167,9 +166,8 @@ AD_ALWAYS_INLINE Id remapVocabId(Id original,
 }
 
 // _____________________________________________________________________________
-AD_ALWAYS_INLINE Id remapVocabId(Id original,
-                                 const InsertionPositions& insertionPositions,
-                                 size_t& hint) {
+Id remapVocabId(Id original, const InsertionPositions& insertionPositions,
+                size_t& hint) {
   AD_EXPENSIVE_CHECK(
       original.getDatatype() == Datatype::VocabIndex,
       "Only ids resembling a vocab index can be remapped with this function.");

--- a/src/util/CompilerExtensions.h
+++ b/src/util/CompilerExtensions.h
@@ -14,9 +14,12 @@
 // 'always_inline' ...: function body can be overwritten at link time`, preceded
 // by a `-Wattributes` warning. The macro hence expands to nothing here.
 //
-// NOTE: It must not expand to `inline` either, because that would silently
-// change the linkage of the annotated function. Instead, every use must be on
-// a function that is implicitly or explicitly `inline` (GCC emits a
+// NOTE: It must not expand to `inline` either. An `inline` function must be
+// defined in every translation unit that uses it (and the compiler need not
+// emit an out-of-line symbol for it), so for a function that is declared in a
+// header but defined in a `.cpp` file, `inline` would break the callers in
+// other translation units. Instead, every use of the macro must be on a
+// function that is already implicitly or explicitly `inline` (GCC emits a
 // `-Wattributes` warning otherwise, because it cannot force the inlining of
 // an out-of-line function into other translation units).
 #define AD_ALWAYS_INLINE

--- a/src/util/CompilerExtensions.h
+++ b/src/util/CompilerExtensions.h
@@ -14,12 +14,11 @@
 // 'always_inline' ...: function body can be overwritten at link time`, preceded
 // by a `-Wattributes` warning. The macro hence expands to nothing here.
 //
-// NOTE: It must not expand to `inline` either. All uses inside a class body or
-// on a `constexpr` function are implicitly `inline` anyway, but the free
-// functions that are declared in a header and defined in a `.cpp` file (for
-// example `qlever::indexRebuilder::remapVocabId`) need external linkage,
-// because their only callers are in other translation units. Declaring those
-// `inline` would emit no symbol at all and break the link.
+// NOTE: It must not expand to `inline` either, because that would silently
+// change the linkage of the annotated function. Instead, every use must be on
+// a function that is implicitly or explicitly `inline` (GCC emits a
+// `-Wattributes` warning otherwise, because it cannot force the inlining of
+// an out-of-line function into other translation units).
 #define AD_ALWAYS_INLINE
 #elif defined(__clang__)
 #define AD_ALWAYS_INLINE [[clang::always_inline]]


### PR DESCRIPTION
Compiling the current master with GCC produces five `-Wattributes` warnings of the form `'always_inline' function might not be inlinable`, for the five functions that use `AD_ALWAYS_INLINE` on a definition in a `.cpp` file. The attribute cannot take effect on such a definition: inlining into other translation units is impossible for an out-of-line function, and within its own translation unit, the compiler inlines these small functions on its own anyway.

The attribute is removed from these five definitions, and the comment in `CompilerExtensions.h` now states the general rule: `AD_ALWAYS_INLINE` must only be used on functions that are implicitly or explicitly `inline`.