### PR TITLE
Store large sets of delta triples in an auxiliary index on disk

### DIFF
--- a/src/engine/OrderBy.cpp
+++ b/src/engine/OrderBy.cpp
@@ -102,7 +102,9 @@ Result OrderBy::computeResult([[maybe_unused]] bool requestLaziness) {
 
   // Return true iff `rowA` comes before `rowB` in the sort order specified by
   // `sortIndices_`.
-  auto comparison = [this](const auto& row1, const auto& row2) -> bool {
+  auto auxVocabOrdering = getExecutionContext()->getIndex().auxVocabOrdering();
+  auto comparison = [this, &auxVocabOrdering](const auto& row1,
+                                              const auto& row2) -> bool {
     for (auto& [column, isDescending] : sortIndices_) {
       if (row1[column] == row2[column]) {
         continue;
@@ -110,8 +112,9 @@ Result OrderBy::computeResult([[maybe_unused]] bool requestLaziness) {
       bool isLessThan =
           toBoolNotUndef(valueIdComparators::compareIds<
                          valueIdComparators::ComparisonForIncompatibleTypes::
-                             CompareByType>(
-              row1[column], row2[column], valueIdComparators::Comparison::LT));
+                             CompareByType>(row1[column], row2[column],
+                                            valueIdComparators::Comparison::LT,
+                                            auxVocabOrdering));
       return isLessThan != isDescending;
     }
     return false;

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -567,6 +567,20 @@ CPP_template_def(typename RequestT, typename ResponseT)(
       response =
           createOkResponse("Done writing", request, MediaType::textPlain);
     }
+  } else if (auto cmd = checkParameter("cmd", "build-aux-index")) {
+    requireValidAccessToken("build-aux-index");
+    logCommand(cmd, "build the auxiliary index from the delta triples");
+
+    auto handle = std::make_shared<ad_utility::CancellationHandle<>>();
+    // The build runs on the update executor, which is single-threaded, so that
+    // it is mutually exclusive with the updates; see the documentation of
+    // `Qlever::buildAuxIndex`.
+    auto coroutine = computeInNewThread(
+        updateThreadPool_, [this, handle] { qlever().buildAuxIndex(handle); },
+        handle);
+    co_await std::move(coroutine);
+    response = createJsonResponse(
+        composeStatsJson(indexAndViewsSnapshot()->index_), request);
   } else if (auto cmd = checkParameter("cmd", "write-materialized-view")) {
     requireValidAccessToken("write-materialized-view");
     logCommand(cmd, "write materialized view");
@@ -943,6 +957,16 @@ nlohmann::json Server::composeStatsJson(const Index& index) {
   auto numTriples = index.numTriples();
   result["num-triples-normal"] = numTriples.normal;
   result["num-triples-internal"] = numTriples.internal;
+
+  // The auxiliary index, if there is one (see `index/AuxIndex.h`).
+  const auto* auxIndex = index.getImpl().auxIndex();
+  if (auxIndex != nullptr) {
+    const auto& metadata = auxIndex->metadata();
+    result["aux-index"]["generation"] = metadata.generation_;
+    result["aux-index"]["num-inserted"] = metadata.numInserted_;
+    result["aux-index"]["num-deleted"] = metadata.numDeleted_;
+    result["aux-index"]["num-vocab-words"] = metadata.numVocabWords_;
+  }
   result["name-text-index"] = index.getTextName();
   result["num-text-records"] = index.getNofTextRecords();
   result["num-word-occurrences"] = index.getNofWordPostings();

--- a/src/engine/StringMapping.cpp
+++ b/src/engine/StringMapping.cpp
@@ -35,7 +35,8 @@ Id StringMapping::remapId(Id id) {
   // be directly encoded into the ID). All other IDs have to be serialized by
   // different mechanism.
   static constexpr std::array allowedDatatypes{VocabIndex, LocalVocabIndex,
-                                               TextRecordIndex, WordVocabIndex};
+                                               TextRecordIndex, WordVocabIndex,
+                                               AuxVocabIndex};
   AD_EXPENSIVE_CHECK(ad_utility::contains(allowedDatatypes, id.getDatatype()));
 
   // A static assertion that each datatype is either `trivial`, or `allowed`

--- a/src/engine/sparqlExpressions/PrefilterExpressionIndex.cpp
+++ b/src/engine/sparqlExpressions/PrefilterExpressionIndex.cpp
@@ -545,9 +545,8 @@ RelationalExpression<Comparison>::logicalComplement() const {
 //______________________________________________________________________________
 template <CompOp Comparison>
 BlockMetadataRanges RelationalExpression<Comparison>::evaluateImpl(
-    [[maybe_unused]] const LocalVocabContext& context,
-    const ValueIdSubrange& idRange, BlockMetadataSpan blockRange,
-    bool getTotalComplement) const {
+    const LocalVocabContext& context, const ValueIdSubrange& idRange,
+    BlockMetadataSpan blockRange, bool getTotalComplement) const {
   using namespace valueIdComparators;
   // If `rightSideReferenceValue_` contains a `LocalVocabEntry` value, we use
   // the here created `LocalVocab` to retrieve a corresponding `ValueId`.
@@ -560,11 +559,13 @@ BlockMetadataRanges RelationalExpression<Comparison>::evaluateImpl(
   // Reason: The referenceId could be contained within the bounds formed by
   // the IDs of firstTriple_ and lastTriple_ (set false flag to keep
   // empty ranges).
-  auto relevantIdRanges = Comparison != CompOp::EQ
-                              ? getRangesForId(idRange.begin(), idRange.end(),
-                                               referenceId, Comparison)
-                              : getRangesForId(idRange.begin(), idRange.end(),
-                                               referenceId, Comparison, false);
+  auto auxVocabOrdering = context.auxVocabOrdering();
+  auto relevantIdRanges =
+      Comparison != CompOp::EQ
+          ? getRangesForId(idRange.begin(), idRange.end(), referenceId,
+                           Comparison, auxVocabOrdering)
+          : getRangesForId(idRange.begin(), idRange.end(), referenceId,
+                           Comparison, auxVocabOrdering, false);
   return getTotalComplement
              ? detail::mapping::mapValueIdItRangesToBlockItRangesComplemented(
                    relevantIdRanges, idRange, blockRange)

--- a/src/engine/sparqlExpressions/RelationalExpressionHelpers.h
+++ b/src/engine/sparqlExpressions/RelationalExpressionHelpers.h
@@ -180,32 +180,38 @@ inline const auto compareIdsOrStrings =
   } else {
     auto x = makeValueId(a, ctx);
     auto y = makeValueId(b, ctx);
-    if constexpr (ranges::invocable<decltype(valueIdComparators::compareIds<
-                                             comparisonForIncompatibleTypes>),
-                                    decltype(x), decltype(y),
-                                    valueIdComparators::Comparison>) {
+    auto auxVocabOrdering = ctx->_qec.getIndex().auxVocabOrdering();
+    if constexpr (ranges::invocable<
+                      decltype(valueIdComparators::compareIds<
+                               comparisonForIncompatibleTypes>),
+                      decltype(x), decltype(y), valueIdComparators::Comparison,
+                      const valueIdComparators::AuxVocabOrdering&>) {
       // Compare two `ValueId`s
       return valueIdComparators::compareIds<comparisonForIncompatibleTypes>(
-          x, y, Comp);
+          x, y, Comp, auxVocabOrdering);
     } else if constexpr (ranges::invocable<
                              decltype(valueIdComparators::compareWithEqualIds<
                                       comparisonForIncompatibleTypes>),
                              decltype(x), decltype(y.first), decltype(y.second),
-                             valueIdComparators::Comparison>) {
+                             valueIdComparators::Comparison,
+                             const valueIdComparators::AuxVocabOrdering&>) {
       // Compare `ValueId` with range of equal `ValueId`s (used when `value2`
       // is `string` or `vector<string>`.
       return valueIdComparators::compareWithEqualIds<
-          comparisonForIncompatibleTypes>(x, y.first, y.second, Comp);
+          comparisonForIncompatibleTypes>(x, y.first, y.second, Comp,
+                                          auxVocabOrdering);
     } else if constexpr (ranges::invocable<
                              decltype(valueIdComparators::compareWithEqualIds<
                                       comparisonForIncompatibleTypes>),
                              decltype(y), decltype(x.first), decltype(x.second),
-                             valueIdComparators::Comparison>) {
+                             valueIdComparators::Comparison,
+                             const valueIdComparators::AuxVocabOrdering&>) {
       // Compare `ValueId` with range of equal `ValueId`s (used when `value2`
       // is `string` or `vector<string>`.
       return valueIdComparators::compareWithEqualIds<
           comparisonForIncompatibleTypes>(
-          y, x.first, x.second, getComparisonForSwappedArguments(Comp));
+          y, x.first, x.second, getComparisonForSwappedArguments(Comp),
+          auxVocabOrdering);
     } else {
       // The `variant` is such that both types are shown in the compiler error
       // message once the `static_assert` fails.

--- a/src/engine/sparqlExpressions/RelationalExpressions.cpp
+++ b/src/engine/sparqlExpressions/RelationalExpressions.cpp
@@ -102,11 +102,13 @@ ad_utility::SetOfIntervals evaluateWithBinarySearch(
 
   // Perform the actual evaluation.
   const auto resultRanges = [&]() {
+    auto auxVocabOrdering = context->_qec.getIndex().auxVocabOrdering();
     if (valueIdUpper) {
       return valueIdComparators::getRangesForEqualIds(
-          begin, end, valueId, valueIdUpper.value(), Comp);
+          begin, end, valueId, valueIdUpper.value(), Comp, auxVocabOrdering);
     } else {
-      return valueIdComparators::getRangesForId(begin, end, valueId, Comp);
+      return valueIdComparators::getRangesForId(begin, end, valueId, Comp,
+                                                auxVocabOrdering);
     }
   }();
 

--- a/src/global/FileSuffixConstants.h
+++ b/src/global/FileSuffixConstants.h
@@ -42,6 +42,22 @@ constexpr inline std::string_view UPDATE_TRIPLES_SUFFIX = ".update-triples";
 constexpr inline std::string_view ALLOCATED_GRAPHS_SUFFIX =
     ".allocated-graphs-state";
 
+// The files of an auxiliary index (see `index/AuxIndex.h`). They only exist if
+// at least one auxiliary index has been built for the index. The base name of
+// an auxiliary index is the base name of the main index, followed by
+// `AUX_INDEX_INFIX` and the generation number, so the files of the second
+// generation of the auxiliary index of `wikidata` are
+// `wikidata.aux1.vocabulary`, `wikidata.aux1.index.pso`, etc.
+constexpr inline std::string_view AUX_INDEX_INFIX = ".aux";
+// The array that stores, for each word of the vocabulary of an auxiliary index,
+// the position at which that word would be sorted into the vocabulary of the
+// main index.
+constexpr inline std::string_view AUX_VOCAB_POSITIONS_SUFFIX =
+    ".vocabulary.positions";
+// The metadata of an auxiliary index.
+constexpr inline std::string_view AUX_INDEX_CONFIGURATION_FILE =
+    ".aux-meta-data.json";
+
 // The build log of an index. QLever does not write this directly, but
 // `qlever-control` creates this file to persist QLever's `stdout` during the
 // index building. If it is present, we still move it alongside the index that

--- a/src/global/IndexTypes.h
+++ b/src/global/IndexTypes.h
@@ -20,6 +20,11 @@ inline constexpr ad_utility::IndexTag wordVocabIndexTag = "WordVocabIndex";
 using WordVocabIndex = ad_utility::TypedIndex<uint64_t, wordVocabIndexTag>;
 inline constexpr ad_utility::IndexTag blankNodeIndexTag = "BlankNodeIndex";
 using BlankNodeIndex = ad_utility::TypedIndex<uint64_t, blankNodeIndexTag>;
+// An index into the auxiliary vocabulary of an auxiliary index (see
+// `index/AuxIndex.h`), which holds the words that were added by updates after
+// the main index was built.
+inline constexpr ad_utility::IndexTag auxVocabIndexTag = "AuxVocabIndex";
+using AuxVocabIndex = ad_utility::TypedIndex<uint64_t, auxVocabIndexTag>;
 inline constexpr ad_utility::IndexTag documentIndexTag = "DocumentIndex";
 using DocumentIndex = ad_utility::TypedIndex<uint64_t, documentIndexTag>;
 

--- a/src/global/ValueId.h
+++ b/src/global/ValueId.h
@@ -42,7 +42,15 @@ enum struct Datatype {
   WordVocabIndex,
   BlankNodeIndex,
   EncodedVal,
-  MaxValue = EncodedVal
+  // An index into the auxiliary vocabulary of an auxiliary index (see
+  // `index/AuxIndex.h`). Because the datatype bits are the most significant
+  // bits, all IDs of this type are larger than all IDs of the other types.
+  // Words that are added by updates after the main index was built therefore
+  // are sorted after all words from the main vocabulary when comparing IDs
+  // bitwise. For the semantically correct (that is, by string value)
+  // comparison, see `valueIdComparators::AuxVocabOrdering`.
+  AuxVocabIndex,
+  MaxValue = AuxVocabIndex
   // Note: Unfortunately, we cannot easily get the size of an enum.
   // If members are added to this enum, then the `MaxValue`
   // alias must always be equal to the last member,
@@ -91,6 +99,8 @@ inline QL_CONSTEXPR std::string_view toString(Datatype type) {
       return "GeoPoint";
     case Datatype::BlankNodeIndex:
       return "BlankNodeIndex";
+    case Datatype::AuxVocabIndex:
+      return "AuxVocabIndex";
   }
   // This line is reachable if we cast an arbitrary invalid int to this enum
   AD_FAIL();
@@ -122,25 +132,37 @@ class ValueId {
 
   // The largest representable integer value.
   static constexpr int64_t maxInt = IntegerType::max();
-  // All types that store strings. Together, the IDs of all the items of these
-  // types form a consecutive range of IDs when sorted. Within this range, the
-  // IDs are ordered by their string values, not by their IDs (and hence also
-  // not by their types).
-  static constexpr std::array<Datatype, 2> stringTypes_{
-      Datatype::VocabIndex, Datatype::LocalVocabIndex};
+  // All types that store strings. Note that the IDs of these types do *not*
+  // form a consecutive range of IDs when sorted, because the IDs of the
+  // auxiliary vocabulary are all greater than the IDs of the other types (see
+  // `Datatype::AuxVocabIndex`). Within each of the two ranges, the IDs are
+  // ordered by their string values, not by their IDs (and hence also not by
+  // their types).
+  static constexpr std::array<Datatype, 3> stringTypes_{
+      Datatype::VocabIndex, Datatype::LocalVocabIndex, Datatype::AuxVocabIndex};
+
+  // Return true iff the `datatype` stores strings, see `stringTypes_`.
+  static constexpr bool isStringType(Datatype datatype) {
+    return ad_utility::contains(stringTypes_, datatype);
+  }
 
   // A mapping that decides if a Datatype is bitwise comparable or not. See
   // `canBeComparedBitwise()` below.
-  static constexpr std::array<bool, 12> isTypeBitwiseComparable_{
-      true, true, true, true, true, false, true, true, true, true, true, true};
+  static constexpr std::array<bool, 13> isTypeBitwiseComparable_{
+      true, true, true, true, true, false, true,
+      true, true, true, true, true, true};
 
-  // Assert that the types in `stringTypes_` are directly adjacent. This is
-  // required to make the comparison of IDs in `ValueIdComparators.h` work.
-  static constexpr Datatype maxStringType_ = ql::ranges::max(stringTypes_);
-  static constexpr Datatype minStringType_ = ql::ranges::min(stringTypes_);
-  static_assert(static_cast<size_t>(maxStringType_) -
-                    static_cast<size_t>(minStringType_) + 1 ==
-                stringTypes_.size());
+  // Return true iff IDs of the given `datatype` are compared to a
+  // `LocalVocabIndex` by looking up the position of the local vocab entry in
+  // the vocabularies of the index (see `compareVocabAndLocalVocab` below).
+  // These are exactly the string types whose IDs are ordered consistently with
+  // the bitwise order, that is all string types except `LocalVocabIndex`
+  // itself.
+  static constexpr bool comparesToLocalVocabByPosition(Datatype datatype) {
+    using enum Datatype;
+    return datatype == VocabIndex || datatype == EncodedVal ||
+           datatype == AuxVocabIndex;
+  }
 
   // Assert that the size of an encoded GeoPoint equals the available bits in a
   // ValueId.
@@ -185,6 +207,15 @@ class ValueId {
   // For doubles it is first the positive doubles in order, then the negative
   // doubles in reversed order. This is a direct consequence of comparing the
   // bit representation of these values as unsigned integers.
+  // NOTE: An `Id` of type `LocalVocabIndex` does not carry its value in its
+  // bits (they are a pointer), so it is ordered by the position that its word
+  // has in the vocabularies of the index (see
+  // `LocalVocabEntry::positionInVocab`). That position is an `Id` of one of the
+  // types for which `comparesToLocalVocabByPosition` holds, and the local vocab
+  // entry compares exactly like an `Id` at that position. In particular this
+  // also holds for the comparison against `Id`s of an unrelated datatype like
+  // `Int` or `Date`, which is required for the comparison to be a valid strict
+  // weak ordering (see `compareVocabAndLocalVocab`).
   constexpr auto compareThreeWay(const ValueId& other) const {
     using enum Datatype;
     auto type = getDatatype();
@@ -199,24 +230,17 @@ class ValueId {
 
     // GCC 11 issues a false positive warning here, so we try to avoid it by
     // being over-explicit about the branches here.
-    if ((type == VocabIndex || type == EncodedVal) &&
-        otherType == LocalVocabIndex) {
+    if (otherType == LocalVocabIndex) {
       return compareVocabAndLocalVocab(
           LocalVocabEntry::IdProxy::make(getBits()),
           other.getLocalVocabIndex());
-    } else if (type == LocalVocabIndex &&
-               (otherType == VocabIndex || otherType == EncodedVal)) {
+    } else {
       auto inverseOrder = compareVocabAndLocalVocab(
           LocalVocabEntry::IdProxy::make(other.getBits()),
           getLocalVocabIndex());
 
       return ql::compareThreeWay(0, inverseOrder);
     }
-
-    // One of the types is `LocalVocab`, and the other one is a non-string
-    // type like `Integer` or `Undefined. Then the comparison by bits
-    // automatically compares by the datatype.
-    return ql::compareThreeWay(_bits, other._bits);
   }
   QL_DEFINE_CUSTOM_THREEWAY_OPERATOR_LOCAL_CONSTEXPR(ValueId)
 
@@ -249,6 +273,24 @@ class ValueId {
   // Get the datatype.
   [[nodiscard]] constexpr Datatype getDatatype() const noexcept {
     return static_cast<Datatype>(_bits >> numDataBits);
+  }
+
+  // The datatype that determines the position of this `Id` in a range of `Id`s
+  // that is sorted by `compareThreeWay` (which is the order in which index
+  // scans emit their results). For all datatypes but `LocalVocabIndex` this
+  // simply is `getDatatype()`. An `Id` of type `LocalVocabIndex` is ordered by
+  // the position of its word in the vocabularies of the index, which is an `Id`
+  // of one of the types for which `comparesToLocalVocabByPosition` holds, so
+  // that position's datatype is returned instead. In particular, the sequence
+  // of the `datatypeForOrdering()` values of a sorted range of `Id`s is
+  // ascending, which is not true for `getDatatype()`.
+  [[nodiscard]] Datatype datatypeForOrdering() const {
+    auto datatype = getDatatype();
+    if (datatype != Datatype::LocalVocabIndex) {
+      return datatype;
+    }
+    return fromBits(getLocalVocabIndex()->positionInVocab().lowerBound_.get())
+        .getDatatype();
   }
 
   // Create a `ValueId` of the `Undefined` type. There is only one such ID and
@@ -348,6 +390,9 @@ class ValueId {
   static ValueId makeFromBlankNodeIndex(BlankNodeIndex index) {
     return makeFromIndex(index.get(), Datatype::BlankNodeIndex);
   }
+  static ValueId makeFromAuxVocabIndex(AuxVocabIndex index) {
+    return makeFromIndex(index.get(), Datatype::AuxVocabIndex);
+  }
 
   // Obtain the unsigned index that this `ValueId` encodes. If `getDatatype()
   // != [VocabIndex|TextRecordIndex|LocalVocabIndex]` then the result is
@@ -372,6 +417,10 @@ class ValueId {
 
   [[nodiscard]] constexpr BlankNodeIndex getBlankNodeIndex() const noexcept {
     return BlankNodeIndex::make(removeDatatypeBits(_bits));
+  }
+
+  [[nodiscard]] constexpr AuxVocabIndex getAuxVocabIndex() const noexcept {
+    return AuxVocabIndex::make(removeDatatypeBits(_bits));
   }
 
   // Store or load a `Date` object.
@@ -489,6 +538,8 @@ class ValueId {
         return std::invoke(visitor, getGeoPoint());
       case Datatype::BlankNodeIndex:
         return std::invoke(visitor, getBlankNodeIndex());
+      case Datatype::AuxVocabIndex:
+        return std::invoke(visitor, getAuxVocabIndex());
     }
     AD_FAIL();
   }

--- a/src/global/ValueIdComparators.h
+++ b/src/global/ValueIdComparators.h
@@ -11,6 +11,7 @@
 
 #include "backports/algorithm.h"
 #include "global/Id.h"
+#include "global/VocabIndexMarker.h"
 #include "util/Algorithm.h"
 #include "util/ComparisonWithNan.h"
 #include "util/OverloadCallOperator.h"
@@ -78,6 +79,188 @@ inline ValueId toValueId(ComparisonResult comparisonResult) {
 // representation of these values as unsigned integers.
 inline bool compareByBits(ValueId a, ValueId b) { return a < b; }
 
+// All the information that is required to compare `Id`s of type
+// `Datatype::AuxVocabIndex` by the string values that they represent instead of
+// by their bits. It consists of the positions at which the words of the
+// auxiliary vocabulary would be sorted into the main vocabulary, see
+// `AuxVocabulary` for the details. A default-constructed `AuxVocabOrdering`
+// means that the index has no auxiliary index; comparing an `Id` of type
+// `Datatype::AuxVocabIndex` then is a programming error (namely, forgetting to
+// pass the ordering of the auxiliary vocabulary that the `Id` came from).
+class AuxVocabOrdering {
+ private:
+  ql::span<const uint64_t> positionsInMainVocab_;
+  std::array<uint64_t, VocabIndexMarker::maxNumMarkers> markerOffsets_{};
+  VocabIndexMarker marker_;
+
+ public:
+  AuxVocabOrdering() = default;
+  AuxVocabOrdering(ql::span<const uint64_t> positionsInMainVocab,
+                   const std::array<uint64_t, VocabIndexMarker::maxNumMarkers>&
+                       markerOffsets,
+                   VocabIndexMarker marker)
+      : positionsInMainVocab_{positionsInMainVocab},
+        markerOffsets_{markerOffsets},
+        marker_{marker} {}
+
+  // The offset of the word of `auxId` (which must be of type
+  // `Datatype::AuxVocabIndex`), see the comment on
+  // `AuxVocabulary::positionsInMainVocab`. This is also the number of words of
+  // the auxiliary vocabulary that are smaller than that word, so it is directly
+  // comparable to the result of `numWordsSmallerThan` below.
+  uint64_t offsetOf(ValueId auxId) const {
+    AD_CORRECTNESS_CHECK(auxId.getDatatype() == Datatype::AuxVocabIndex);
+    auto index = auxId.getAuxVocabIndex().get();
+    uint64_t offset = markerOffsets_.at(marker_.getMarker(index)) +
+                      marker_.getIndexWithoutMarker(index);
+    AD_CORRECTNESS_CHECK(
+        offset < positionsInMainVocab_.size(),
+        "An `Id` of the auxiliary vocabulary was compared without the "
+        "corresponding `AuxVocabOrdering`, or with the one of a different "
+        "generation of the auxiliary index");
+    return offset;
+  }
+
+  // The raw bits of the `Id` of the first word of the main vocabulary that is
+  // greater than the word of `auxId` (which must be of type
+  // `Datatype::AuxVocabIndex`).
+  uint64_t positionInMainVocab(ValueId auxId) const {
+    return positionsInMainVocab_[offsetOf(auxId)];
+  }
+
+  // The number of words of the auxiliary vocabulary that are smaller than the
+  // word of the main vocabulary with the given `Id`.
+  uint64_t numWordsSmallerThan(ValueId mainVocabId) const {
+    // A word `w` of the auxiliary vocabulary is smaller than the word of the
+    // main vocabulary with the index `i` if and only if
+    // `positionInMainVocab(w) <= i`, and the positions are ascending. Note that
+    // this also holds across the sub-vocabularies of a split vocabulary: the
+    // marker sits in the highest bits of the payload of an `Id`, so comparing
+    // positions bitwise compares the markers first, and both the positions and
+    // the offsets are ordered by (marker, index within the sub-vocabulary).
+    auto it =
+        ql::ranges::upper_bound(positionsInMainVocab_, mainVocabId.getBits());
+    return static_cast<uint64_t>(it - positionsInMainVocab_.begin());
+  }
+};
+
+namespace detail {
+
+// The position of an `Id` of one of the string types (see
+// `ValueId::isStringType`) in the merged order of the main and the auxiliary
+// vocabulary. Comparing these positions lexicographically is the semantically
+// correct comparison of the string values, with the single exception of two
+// local vocab entries that fall into the same gap of both vocabularies, which
+// have to be compared by their strings.
+struct SemanticStringPosition {
+  // The raw bits of the `Id` of the first word of the main vocabulary that is
+  // greater than or equal to the word.
+  uint64_t mainVocabPosition_;
+  // True iff the word is the word of the main vocabulary at
+  // `mainVocabPosition_`, false iff it only would be sorted directly before it.
+  bool isWordAtMainVocabPosition_;
+  // Set iff the `Id` is of type `LocalVocabIndex`. Only used to break ties
+  // between two local vocab entries.
+  const LocalVocabEntry* localVocabEntry_;
+  // The number of words of the auxiliary vocabulary that are smaller than the
+  // word. Computing this is not free, so it is only computed on demand via
+  // `numSmallerAuxVocabWords()`, which is only necessary if the two members
+  // above are equal for both sides of a comparison.
+  ValueId id_;
+};
+
+// Compute the `SemanticStringPosition` of `id`, which must be of one of the
+// string types.
+inline SemanticStringPosition getSemanticStringPosition(
+    ValueId id, const AuxVocabOrdering& auxVocabOrdering) {
+  using enum Datatype;
+  auto datatype = id.getDatatype();
+  if (datatype == AuxVocabIndex) {
+    return {auxVocabOrdering.positionInMainVocab(id), false, nullptr, id};
+  }
+  if (datatype == VocabIndex) {
+    return {id.getBits(), true, nullptr, id};
+  }
+  AD_CORRECTNESS_CHECK(datatype == LocalVocabIndex);
+  const auto* entry = id.getLocalVocabIndex();
+  auto [lowerBound, upperBound] = entry->positionInVocab();
+  auto boundId = ValueId::fromBits(lowerBound.get());
+  // A local vocab entry whose word is stored in the auxiliary vocabulary is
+  // positioned exactly like the corresponding `Id` of that vocabulary.
+  if (boundId.getDatatype() == AuxVocabIndex) {
+    return {auxVocabOrdering.positionInMainVocab(boundId), false, entry,
+            boundId};
+  }
+  return {lowerBound.get(), lowerBound != upperBound, entry, id};
+}
+
+// The number of words of the auxiliary vocabulary that are smaller than the
+// word of `position`.
+inline uint64_t numSmallerAuxVocabWords(
+    const SemanticStringPosition& position,
+    const AuxVocabOrdering& auxVocabOrdering) {
+  using enum Datatype;
+  auto datatype = position.id_.getDatatype();
+  if (datatype == AuxVocabIndex) {
+    return auxVocabOrdering.offsetOf(position.id_);
+  }
+  if (datatype == LocalVocabIndex) {
+    return position.localVocabEntry_->numSmallerAuxVocabWords();
+  }
+  AD_CORRECTNESS_CHECK(datatype == VocabIndex);
+  return auxVocabOrdering.numWordsSmallerThan(position.id_);
+}
+
+}  // namespace detail
+
+// Compare two `Id`s that both are of one of the string types (see
+// `ValueId::isStringType`) by the string values that they represent. Note that
+// this is different from `ValueId::compareThreeWay`, which compares the words
+// of the auxiliary vocabulary as if they were all greater than all words of the
+// main vocabulary, because that is the order in which the index scans emit
+// them.
+inline ql::strong_ordering compareStringIdsSemantically(
+    ValueId a, ValueId b, const AuxVocabOrdering& auxVocabOrdering) {
+  AD_EXPENSIVE_CHECK(ValueId::isStringType(a.getDatatype()) &&
+                     ValueId::isStringType(b.getDatatype()));
+  auto positionA = detail::getSemanticStringPosition(a, auxVocabOrdering);
+  auto positionB = detail::getSemanticStringPosition(b, auxVocabOrdering);
+  if (positionA.mainVocabPosition_ != positionB.mainVocabPosition_) {
+    return positionA.mainVocabPosition_ < positionB.mainVocabPosition_
+               ? ql::strong_ordering::less
+               : ql::strong_ordering::greater;
+  }
+  // A word that is the word of the main vocabulary at that position is greater
+  // than a word that only would be sorted directly before it.
+  if (positionA.isWordAtMainVocabPosition_ !=
+      positionB.isWordAtMainVocabPosition_) {
+    return positionA.isWordAtMainVocabPosition_ ? ql::strong_ordering::greater
+                                                : ql::strong_ordering::less;
+  }
+  if (positionA.isWordAtMainVocabPosition_) {
+    // Both are the same word of the main vocabulary.
+    return ql::strong_ordering::equal;
+  }
+  // Both words fall into the same gap of the main vocabulary, so their
+  // positions in the auxiliary vocabulary decide.
+  auto numSmallerA =
+      detail::numSmallerAuxVocabWords(positionA, auxVocabOrdering);
+  auto numSmallerB =
+      detail::numSmallerAuxVocabWords(positionB, auxVocabOrdering);
+  if (numSmallerA != numSmallerB) {
+    return numSmallerA < numSmallerB ? ql::strong_ordering::less
+                                     : ql::strong_ordering::greater;
+  }
+  // The only remaining case is two local vocab entries that fall into the same
+  // gap of both vocabularies, which have to be compared by their strings.
+  if (positionA.localVocabEntry_ == nullptr ||
+      positionB.localVocabEntry_ == nullptr) {
+    return ql::strong_ordering::equal;
+  }
+  return positionA.localVocabEntry_->compareThreeWay(
+      *positionB.localVocabEntry_);
+}
+
 namespace detail {
 
 // Returns a comparator predicate `pred` that can be called with two arguments:
@@ -106,25 +289,19 @@ auto makeSymmetricComparator(Projection valueIdProjection,
 // For a range of `ValueId`s that is represented by `[begin, end)` and has to
 // be sorted according to `compareByBits`, return the contiguous range of
 // `ValueIds` (as a pair of iterators) where the Ids have the `datatype`.
+//
+// NOTE: The projection is `ValueId::datatypeForOrdering()`, not
+// `ValueId::getDatatype()`, because only the former is ascending in a sorted
+// range. In particular, an `Id` of type `LocalVocabIndex` is contained in the
+// range of the datatype of its position in the vocabularies (which is
+// `VocabIndex`, `EncodedVal`, or `AuxVocabIndex`), and the range for
+// `Datatype::LocalVocabIndex` is always empty.
 template <typename RandomIt>
 inline std::pair<RandomIt, RandomIt> getRangeForDatatype(RandomIt begin,
                                                          RandomIt end,
                                                          Datatype datatype) {
-  // In a sorted input, `VocabIndex` and `LocalVocabIndex` IDs might be
-  // interleaved because they logically both store strings. We therefore
-  // need the range where any of those Datatypes match.
-  auto comparatorForVocabTypes = [](Datatype d1, Datatype d2) {
-    auto containsStringType = [](Datatype d) {
-      return ad_utility::contains(ValueId::stringTypes_, d);
-    };
-    if (containsStringType(d1) && containsStringType(d2)) {
-      return false;
-    }
-    return d1 < d2;
-  };
-  auto comparator = detail::makeSymmetricComparator(&ValueId::getDatatype,
-                                                    comparatorForVocabTypes);
-
+  auto comparator =
+      detail::makeSymmetricComparator(&ValueId::datatypeForOrdering);
   return std::equal_range(begin, end, datatype, comparator);
 }
 
@@ -333,6 +510,50 @@ inline std::vector<std::pair<RandomIt, RandomIt>> getRangesForIndexTypes(
   return std::move(rangeFilter).getResult();
 }
 
+// The two ranges of a sorted range of `ValueId`s that hold the `Id`s of the
+// string types: those that are positioned in the main vocabulary (`VocabIndex`
+// and the local vocab entries whose word is in or between the words of the main
+// vocabulary) and those that are positioned in the auxiliary vocabulary
+// (`AuxVocabIndex` and the local vocab entries whose word is stored there).
+// The two ranges are not adjacent, see `ValueId::stringTypes_`.
+template <typename RandomIt>
+inline std::array<std::pair<RandomIt, RandomIt>, 2> getRangesForStringTypes(
+    RandomIt begin, RandomIt end) {
+  return {getRangeForDatatype(begin, end, Datatype::VocabIndex),
+          getRangeForDatatype(begin, end, Datatype::AuxVocabIndex)};
+}
+
+// This function is part of the implementation of `getRangesForId` and
+// `getRangesForEqualIds` for the string types. See the documentation there.
+// Unlike `getRangesForIndexTypes` below, this compares the `Id`s by the string
+// values they represent, which requires searching in both of the ranges of
+// `getRangesForStringTypes` above. If `valueIdEnd` is set, then all `Id`s in
+// `[valueIdBegin, valueIdEnd)` are considered to be equal, else exactly the
+// `Id`s that are semantically equal to `valueIdBegin` are.
+template <typename RandomIt>
+inline std::vector<std::pair<RandomIt, RandomIt>> getRangesForStringTypes(
+    RandomIt begin, RandomIt end, ValueId valueIdBegin,
+    std::optional<ValueId> valueIdEnd, Comparison comparison,
+    const AuxVocabOrdering& auxVocabOrdering) {
+  auto less = [&auxVocabOrdering](ValueId a, ValueId b) {
+    return compareStringIdsSemantically(a, b, auxVocabOrdering) < 0;
+  };
+  RangeFilter<RandomIt> rangeFilter{comparison};
+  for (auto [beginOfRange, endOfRange] : getRangesForStringTypes(begin, end)) {
+    auto eqBegin =
+        std::lower_bound(beginOfRange, endOfRange, valueIdBegin, less);
+    auto eqEnd =
+        valueIdEnd.has_value()
+            ? std::lower_bound(beginOfRange, endOfRange, valueIdEnd.value(),
+                               less)
+            : std::upper_bound(beginOfRange, endOfRange, valueIdBegin, less);
+    rangeFilter.addSmaller(beginOfRange, eqBegin);
+    rangeFilter.addEqual(eqBegin, eqEnd);
+    rangeFilter.addGreater(eqEnd, endOfRange);
+  }
+  return std::move(rangeFilter).getResult();
+}
+
 // This function is part of the implementation of `getRangesForEqualIds`. See
 // the documentation there.
 template <typename RandomIt>
@@ -391,10 +612,15 @@ auto simplifyRanges(std::vector<std::pair<RandomIt, RandomIt>> input,
 //
 // When setting the flag argument `removeEmptyRanges` to false, empty ranges
 // [`begin`, `end`] where `begin` is equal to `end` will not be discarded.
+//
+// The `auxVocabOrdering` is required to compare the `Id`s of the auxiliary
+// vocabulary by their string values, see `AuxVocabOrdering`. It may be left
+// empty if and only if neither `valueId` nor any of the `Id`s in the range are
+// of type `Datatype::AuxVocabIndex`.
 template <typename RandomIt>
 inline std::vector<std::pair<RandomIt, RandomIt>> getRangesForId(
     RandomIt begin, RandomIt end, ValueId valueId, Comparison comparison,
-    bool removeEmptyRanges = true) {
+    const AuxVocabOrdering& auxVocabOrdering, bool removeEmptyRanges = true) {
   switch (valueId.getDatatype()) {
     case Datatype::Double:
       return detail::simplifyRanges(
@@ -412,6 +638,11 @@ inline std::vector<std::pair<RandomIt, RandomIt>> getRangesForId(
       return {};
     case Datatype::VocabIndex:
     case Datatype::LocalVocabIndex:
+    case Datatype::AuxVocabIndex:
+      return detail::simplifyRanges(
+          detail::getRangesForStringTypes(begin, end, valueId, std::nullopt,
+                                          comparison, auxVocabOrdering),
+          removeEmptyRanges);
     case Datatype::WordVocabIndex:
     case Datatype::TextRecordIndex:
       // TODO<joka921> for the `EncodedVal` type, the behavior is only correct
@@ -439,7 +670,7 @@ inline std::vector<std::pair<RandomIt, RandomIt>> getRangesForId(
 template <typename RandomIt>
 inline std::vector<std::pair<RandomIt, RandomIt>> getRangesForEqualIds(
     RandomIt begin, RandomIt end, ValueId valueIdBegin, ValueId valueIdEnd,
-    Comparison comparison) {
+    Comparison comparison, const AuxVocabOrdering& auxVocabOrdering) {
   // For an explanation of the case `valueIdBegin == valueIdEnd`, see the
   // documentation of a similar check in `compareIds` below.
   AD_CONTRACT_CHECK(valueIdBegin <= valueIdEnd);
@@ -448,8 +679,7 @@ inline std::vector<std::pair<RandomIt, RandomIt>> getRangesForEqualIds(
   auto typeBegin = valueIdBegin.getDatatype();
   auto typeEnd = valueIdEnd.getDatatype();
   AD_CONTRACT_CHECK(typeBegin == typeEnd ||
-                    (ad_utility::contains(Id::stringTypes_, typeBegin) &&
-                     ad_utility::contains(Id::stringTypes_, typeEnd)));
+                    (Id::isStringType(typeBegin) && Id::isStringType(typeEnd)));
   switch (valueIdBegin.getDatatype()) {
     case Datatype::Double:
     case Datatype::Int:
@@ -459,10 +689,13 @@ inline std::vector<std::pair<RandomIt, RandomIt>> getRangesForEqualIds(
     case Datatype::GeoPoint:
     case Datatype::BlankNodeIndex:
       AD_FAIL();
-    // TODO<joka921> check what the correct behavior is here.
-    case Datatype::EncodedVal:
     case Datatype::VocabIndex:
     case Datatype::LocalVocabIndex:
+    case Datatype::AuxVocabIndex:
+      return detail::simplifyRanges(detail::getRangesForStringTypes(
+          begin, end, valueIdBegin, valueIdEnd, comparison, auxVocabOrdering));
+    // TODO<joka921> check what the correct behavior is here.
+    case Datatype::EncodedVal:
     case Datatype::WordVocabIndex:
     case Datatype::TextRecordIndex:
       return detail::simplifyRanges(detail::getRangesForIndexTypes(
@@ -481,9 +714,7 @@ inline bool areTypesCompatible(Datatype typeA, Datatype typeB) {
     return type == Datatype::Double || type == Datatype::Int;
   };
   // TODO<joka921> Make this work for the WordIndex also.
-  auto isString = [](Datatype type) {
-    return ad_utility::contains(ValueId::stringTypes_, type);
-  };
+  auto isString = [](Datatype type) { return ValueId::isStringType(type); };
   auto isUndefined = [](Datatype type) { return type == Datatype::Undefined; };
   // Note: Undefined values cannot be compared to other undefined values.
   return (!isUndefined(typeA)) &&
@@ -495,7 +726,8 @@ inline bool areTypesCompatible(Datatype typeA, Datatype typeB) {
 template <ComparisonForIncompatibleTypes comparisonForIncompatibleTypes =
               ComparisonForIncompatibleTypes::AlwaysUndef,
           typename Comparator>
-ComparisonResult compareIdsImpl(ValueId a, ValueId b, Comparator comparator) {
+ComparisonResult compareIdsImpl(ValueId a, ValueId b, Comparator comparator,
+                                const AuxVocabOrdering& auxVocabOrdering) {
   Datatype typeA = a.getDatatype();
   Datatype typeB = b.getDatatype();
   using enum ComparisonResult;
@@ -509,11 +741,18 @@ ComparisonResult compareIdsImpl(ValueId a, ValueId b, Comparator comparator) {
     }
   }
 
-  // If any of the entries is a `LocalVocabIndex`, then the ordinary comparison
-  // on ValueIds already does the right thing.
-  if (a.getDatatype() == Datatype::LocalVocabIndex ||
-      b.getDatatype() == Datatype::LocalVocabIndex) {
-    return fromBool(std::invoke(comparator, a, b));
+  // Both are of one of the string types, so compare them by the string values
+  // that they represent. Note that this differs from the comparison of the
+  // `Id`s (which is what the index scans are sorted by) for the `Id`s of the
+  // auxiliary vocabulary, see `compareStringIdsSemantically`.
+  if (ValueId::isStringType(typeA)) {
+    AD_CORRECTNESS_CHECK(ValueId::isStringType(typeB));
+    // Reduce the comparison to a comparison of two integers, such that it works
+    // with all the comparators (including the wrappers for `NaN` values, see
+    // `ad_utility::makeComparatorForNans`).
+    auto ordering = compareStringIdsSemantically(a, b, auxVocabOrdering);
+    int orderingAsInt = ordering < 0 ? -1 : (ordering > 0 ? 1 : 0);
+    return fromBool(std::invoke(comparator, orderingAsInt, 0));
   }
 
   // TODO<joka921> We currently don't perform correct comparisons (other than
@@ -562,8 +801,8 @@ ComparisonResult compareIdsImpl(ValueId a, ValueId b, Comparator comparator) {
 // see the documentation of the enum `ComparisonForIncompatibleTypes` above.
 template <ComparisonForIncompatibleTypes comparisonForIncompatibleTypes =
               ComparisonForIncompatibleTypes::AlwaysUndef>
-inline ComparisonResult compareIds(ValueId a, ValueId b,
-                                   Comparison comparison) {
+inline ComparisonResult compareIds(ValueId a, ValueId b, Comparison comparison,
+                                   const AuxVocabOrdering& auxVocabOrdering) {
   // A helper lambda to factor out common code
   auto compare = [&](auto comparator) {
     // For the `compareByType` mode, which is used by ORDER BY, we also need a
@@ -571,10 +810,11 @@ inline ComparisonResult compareIds(ValueId a, ValueId b,
     if constexpr (comparisonForIncompatibleTypes ==
                   ComparisonForIncompatibleTypes::CompareByType) {
       return detail::compareIdsImpl<comparisonForIncompatibleTypes>(
-          a, b, ad_utility::makeComparatorForNans(comparator));
+          a, b, ad_utility::makeComparatorForNans(comparator),
+          auxVocabOrdering);
     } else {
-      return detail::compareIdsImpl<comparisonForIncompatibleTypes>(a, b,
-                                                                    comparator);
+      return detail::compareIdsImpl<comparisonForIncompatibleTypes>(
+          a, b, comparator, auxVocabOrdering);
     }
   };
 
@@ -601,9 +841,9 @@ inline ComparisonResult compareIds(ValueId a, ValueId b,
 // are considered to be equal.
 template <ComparisonForIncompatibleTypes comparisonForIncompatibleTypes =
               ComparisonForIncompatibleTypes::AlwaysUndef>
-inline ComparisonResult compareWithEqualIds(ValueId a, ValueId bBegin,
-                                            ValueId bEnd,
-                                            Comparison comparison) {
+inline ComparisonResult compareWithEqualIds(
+    ValueId a, ValueId bBegin, ValueId bEnd, Comparison comparison,
+    const AuxVocabOrdering& auxVocabOrdering) {
   // The case `bBegin == bEnd` happens when IDs from QLever's vocabulary are
   // compared to "pseudo"-IDs that represent words that are not part of the
   // vocabulary. In this case the ID `bBegin` is the ID of the smallest
@@ -617,15 +857,18 @@ inline ComparisonResult compareWithEqualIds(ValueId a, ValueId bBegin,
   // factor it out.
   auto compareEqual = [&]() {
     return toBoolNotUndef(detail::compareIdsImpl<mode>(
-               a, bBegin, std::greater_equal<>())) &&
-           toBoolNotUndef(detail::compareIdsImpl<mode>(a, bEnd, std::less<>()));
+               a, bBegin, std::greater_equal<>(), auxVocabOrdering)) &&
+           toBoolNotUndef(detail::compareIdsImpl<mode>(a, bEnd, std::less<>(),
+                                                       auxVocabOrdering));
   };
   using enum Comparison;
   switch (comparison) {
     case LT:
-      return detail::compareIdsImpl<mode>(a, bBegin, std::less<>());
+      return detail::compareIdsImpl<mode>(a, bBegin, std::less<>(),
+                                          auxVocabOrdering);
     case LE:
-      return detail::compareIdsImpl<mode>(a, bEnd, std::less<>());
+      return detail::compareIdsImpl<mode>(a, bEnd, std::less<>(),
+                                          auxVocabOrdering);
     case EQ: {
       if constexpr (mode == ComparisonForIncompatibleTypes::AlwaysUndef) {
         bool typesAreCompatible =
@@ -650,9 +893,11 @@ inline ComparisonResult compareWithEqualIds(ValueId a, ValueId bBegin,
       }
     }
     case GE:
-      return detail::compareIdsImpl<mode>(a, bBegin, std::greater_equal<>());
+      return detail::compareIdsImpl<mode>(a, bBegin, std::greater_equal<>(),
+                                          auxVocabOrdering);
     case GT:
-      return detail::compareIdsImpl<mode>(a, bEnd, std::greater_equal<>());
+      return detail::compareIdsImpl<mode>(a, bEnd, std::greater_equal<>(),
+                                          auxVocabOrdering);
     default:
       AD_FAIL();
   }

--- a/src/global/VocabIndexMarker.h
+++ b/src/global/VocabIndexMarker.h
@@ -1,0 +1,84 @@
+// Copyright 2026 The QLever Authors, in particular:
+//
+// 2026 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+//
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#ifndef QLEVER_SRC_GLOBAL_VOCABINDEXMARKER_H
+#define QLEVER_SRC_GLOBAL_VOCABINDEXMARKER_H
+
+#include <cstdint>
+
+#include "global/ValueId.h"
+#include "util/BitUtils.h"
+#include "util/Exception.h"
+
+// The words of a vocabulary can be distributed over several sub-vocabularies
+// (see `SplitVocabulary`), for example to store all WKT literals separately.
+// Which sub-vocabulary a word belongs to is determined by the word alone, and
+// it is encoded in the highest bits of the payload of that word's `Id`, the
+// marker.
+//
+// As a consequence, the `Id`s of such a vocabulary form one contiguous
+// ascending range per marker, and their order is *not* the order of the string
+// values: a word of a sub-vocabulary with a higher marker is greater than every
+// word of a sub-vocabulary with a lower marker, no matter what the two words
+// are. QLever accepts this (the order only has to be consistent, see
+// `ValueId::compareThreeWay`), and the auxiliary vocabulary of an auxiliary
+// index (see `index/AuxVocabulary.h`) has to be consistent with it: it uses the
+// same split, and hence the same markers, as the vocabulary of the main index,
+// so that each of its sub-vocabularies can be sorted into the corresponding
+// sub-vocabulary of the main vocabulary.
+//
+// This class holds the marker arithmetic that the two of them share. Unlike
+// `SplitVocabulary`, the number of markers is a runtime value here, because the
+// auxiliary vocabulary has to adapt to whichever vocabulary type the main index
+// uses.
+class VocabIndexMarker {
+ private:
+  uint8_t numMarkers_ = 1;
+  uint64_t markerShift_ = ValueId::numDataBits;
+
+ public:
+  // The largest number of sub-vocabularies (and hence markers) that is
+  // supported. Note that `SplitVocabulary` allows up to 255 of them; if a split
+  // with more than `maxNumMarkers` sub-vocabularies is ever added, this
+  // constant has to be raised (a `static_assert` in `SplitVocabulary` enforces
+  // this).
+  static constexpr uint8_t maxNumMarkers = 4;
+
+  VocabIndexMarker() = default;
+  explicit VocabIndexMarker(uint8_t numMarkers) : numMarkers_{numMarkers} {
+    AD_CONTRACT_CHECK(numMarkers >= 1 && numMarkers <= maxNumMarkers);
+    markerShift_ =
+        ValueId::numDataBits - ad_utility::bitMaskSizeForValue(numMarkers - 1);
+  }
+
+  // The number of sub-vocabularies.
+  uint8_t numMarkers() const { return numMarkers_; }
+
+  // The marker of the given index (the payload of an `Id`, that is, its bits
+  // without the datatype bits).
+  uint8_t getMarker(uint64_t indexWithMarker) const {
+    auto marker = indexWithMarker >> markerShift_;
+    AD_CORRECTNESS_CHECK(marker < numMarkers_);
+    return static_cast<uint8_t>(marker);
+  }
+
+  // The index of the given index within its sub-vocabulary, that is, the index
+  // with the marker bits removed.
+  uint64_t getIndexWithoutMarker(uint64_t indexWithMarker) const {
+    return indexWithMarker & ad_utility::bitMaskForLowerBits(markerShift_);
+  }
+
+  // The marker of the payload of the given `Id`.
+  uint8_t getMarker(ValueId id) const {
+    return getMarker(id.getBits() &
+                     ad_utility::bitMaskForLowerBits(ValueId::numDataBits));
+  }
+};
+
+#endif  // QLEVER_SRC_GLOBAL_VOCABINDEXMARKER_H

--- a/src/index/AuxIndex.cpp
+++ b/src/index/AuxIndex.cpp
@@ -1,0 +1,246 @@
+// Copyright 2026 The QLever Authors, in particular:
+//
+// 2026 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+//
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#include "index/AuxIndex.h"
+
+#include <absl/strings/str_cat.h>
+
+#include <fstream>
+
+#include "backports/StartsWithAndEndsWith.h"
+#include "backports/algorithm.h"
+#include "global/Constants.h"
+#include "global/FileSuffixConstants.h"
+#include "index/DeltaTriples.h"
+#include "index/LocalVocab.h"
+#include "util/Exception.h"
+#include "util/File.h"
+#include "util/FilesystemHelpers.h"
+#include "util/Log.h"
+
+// ____________________________________________________________________________
+void to_json(nlohmann::json& j, const AuxIndexMetadata& metadata) {
+  j = nlohmann::json{{"generation", metadata.generation_},
+                     {"num-inserted", metadata.numInserted_},
+                     {"num-deleted", metadata.numDeleted_},
+                     {"num-vocab-words", metadata.numVocabWords_},
+                     {"vocabulary-type", metadata.vocabularyType_}};
+}
+
+// ____________________________________________________________________________
+void from_json(const nlohmann::json& j, AuxIndexMetadata& metadata) {
+  j.at("generation").get_to(metadata.generation_);
+  j.at("num-inserted").get_to(metadata.numInserted_);
+  j.at("num-deleted").get_to(metadata.numDeleted_);
+  j.at("num-vocab-words").get_to(metadata.numVocabWords_);
+  j.at("vocabulary-type").get_to(metadata.vocabularyType_);
+}
+
+// ____________________________________________________________________________
+std::string AuxIndex::makeBasename(std::string_view mainIndexBasename,
+                                   size_t generation) {
+  return absl::StrCat(mainIndexBasename, AUX_INDEX_INFIX, generation);
+}
+
+// ____________________________________________________________________________
+std::vector<ql::filesystem::path> AuxIndex::allFiles(
+    std::string_view basename) {
+  std::vector<ql::filesystem::path> result;
+  auto addIfExists = [&result](ql::filesystem::path file) {
+    if (ql::filesystem::exists(file)) {
+      result.push_back(std::move(file));
+    }
+  };
+  auto addPermutationFiles = [&addIfExists](auto isInternal,
+                                            std::string_view base) {
+    for (auto permutation : Permutation::all<isInternal>()) {
+      for (auto& file : Permutation::fileNames(permutation, base)) {
+        addIfExists(std::move(file));
+      }
+    }
+  };
+  addPermutationFiles(std::bool_constant<false>{}, basename);
+  addPermutationFiles(std::bool_constant<true>{},
+                      absl::StrCat(basename, QLEVER_INTERNAL_INDEX_INFIX));
+  addIfExists(absl::StrCat(basename, AUX_VOCAB_POSITIONS_SUFFIX));
+  addIfExists(absl::StrCat(basename, AUX_INDEX_CONFIGURATION_FILE));
+  // The set of vocabulary files depends on the vocabulary type, so enumerate
+  // them via their common prefix (the same mechanism as
+  // `IndexImpl::allIndexFiles`).
+  ql::ranges::move(qlever::util::filesWithBaseNameAndSuffix(
+                       std::string{basename}, VOCAB_SUFFIX),
+                   std::back_inserter(result));
+  // Remove duplicates: the file with the positions in the main vocabulary is
+  // also matched by the prefix of the vocabulary files above.
+  ql::ranges::sort(result);
+  result.erase(std::unique(result.begin(), result.end()), result.end());
+  return result;
+}
+
+// ____________________________________________________________________________
+std::vector<size_t> AuxIndex::generationsOnDisk(
+    std::string_view mainIndexBasename) {
+  std::vector<size_t> result;
+  // The metadata file is written last, so its presence marks a complete
+  // auxiliary index.
+  for (const auto& file : qlever::util::filesWithBaseNameAndSuffix(
+           std::string{mainIndexBasename}, AUX_INDEX_INFIX)) {
+    std::string_view name = file.native();
+    if (!ql::ends_with(name, AUX_INDEX_CONFIGURATION_FILE)) {
+      continue;
+    }
+    // Extract the generation, which is the part between `AUX_INDEX_INFIX` and
+    // `AUX_INDEX_CONFIGURATION_FILE`.
+    name.remove_suffix(AUX_INDEX_CONFIGURATION_FILE.size());
+    auto pos = name.rfind(AUX_INDEX_INFIX);
+    AD_CORRECTNESS_CHECK(pos != std::string_view::npos);
+    name.remove_prefix(pos + AUX_INDEX_INFIX.size());
+    size_t generation = 0;
+    if (name.empty() || !ql::ranges::all_of(name, [](char c) {
+          return c >= '0' && c <= '9';
+        })) {
+      continue;
+    }
+    generation = std::stoull(std::string{name});
+    result.push_back(generation);
+  }
+  ql::ranges::sort(result);
+  return result;
+}
+
+// ____________________________________________________________________________
+void AuxIndex::deleteFromDisk(std::string_view basename) {
+  // Delete the metadata file first, such that an interrupted deletion leaves
+  // behind an auxiliary index that is not reported by `generationsOnDisk` and
+  // hence never used.
+  ql::filesystem::path metadataFile =
+      absl::StrCat(basename, AUX_INDEX_CONFIGURATION_FILE);
+  if (ql::filesystem::exists(metadataFile)) {
+    ad_utility::deleteFile(metadataFile);
+  }
+  for (const auto& file : allFiles(basename)) {
+    ad_utility::deleteFile(file);
+  }
+}
+
+// ____________________________________________________________________________
+AuxIndex::AuxIndex(Allocator allocator) : allocator_{std::move(allocator)} {
+  for (auto permutation : Permutation::ALL) {
+    permutations_.at(static_cast<size_t>(permutation)) =
+        std::make_unique<Permutation>(permutation, allocator_);
+  }
+  for (auto permutation : Permutation::INTERNAL) {
+    internalPermutations_.at(static_cast<size_t>(permutation)) =
+        std::make_unique<Permutation>(permutation, allocator_);
+  }
+}
+
+// ____________________________________________________________________________
+Permutation& AuxIndex::getPermutationImpl(Permutation::Enum permutation,
+                                          bool internal) {
+  auto index = static_cast<size_t>(permutation);
+  if (internal) {
+    AD_CONTRACT_CHECK(index < internalPermutations_.size(),
+                      "An auxiliary index only has the internal permutations "
+                      "PSO and POS");
+    return *internalPermutations_.at(index);
+  }
+  return *permutations_.at(index);
+}
+
+// ____________________________________________________________________________
+const Permutation& AuxIndex::getPermutation(Permutation::Enum permutation,
+                                            bool internal) const {
+  AD_CONTRACT_CHECK(isLoaded_, "The auxiliary index has not been loaded");
+  return const_cast<AuxIndex&>(*this).getPermutationImpl(permutation, internal);
+}
+
+// ____________________________________________________________________________
+Permutation::LazyScanWithReader AuxIndex::scanFull(
+    Permutation::Enum permutationEnum, bool internal,
+    const ad_utility::SharedCancellationHandle& cancellationHandle) const {
+  const auto& permutation = getPermutation(permutationEnum, internal);
+  // An auxiliary index never has located triples of its own, so the block
+  // metadata is simply the one of the permutation. Note that it must *not* be
+  // taken from `emptyLocatedTriplesState()`, see the comment there.
+  BlockMetadataSpan blocks{permutation.metaData().blockData()};
+  Permutation::ScanSpecAndBlocks scanSpecAndBlocks{
+      ScanSpecification{std::nullopt, std::nullopt, std::nullopt},
+      BlockMetadataRanges{{blocks.begin(), blocks.end()}}};
+  std::vector<ColumnIndex> additionalColumns{ADDITIONAL_COLUMN_GRAPH_ID,
+                                             insertOrDeleteColumn};
+  return permutation.lazyScanWithUnlimitedReader(
+      scanSpecAndBlocks, additionalColumns, cancellationHandle,
+      emptyLocatedTriplesState());
+}
+
+// ____________________________________________________________________________
+void AuxIndex::loadFromDisk(const std::string& basename,
+                            const std::string& language,
+                            const std::string& country,
+                            bool ignorePunctuation) {
+  AD_CONTRACT_CHECK(!isLoaded_);
+  basename_ = basename;
+
+  std::string metadataFilename =
+      absl::StrCat(basename, AUX_INDEX_CONFIGURATION_FILE);
+  std::ifstream metadataFile{metadataFilename};
+  AD_CONTRACT_CHECK(metadataFile.is_open(),
+                    absl::StrCat("Could not read the metadata file \"",
+                                 metadataFilename, "\" of an auxiliary index"));
+  metadata_ = nlohmann::json::parse(metadataFile).get<AuxIndexMetadata>();
+
+  vocabulary_.open(basename, metadata_.vocabularyType_, language, country,
+                   ignorePunctuation);
+  AD_CORRECTNESS_CHECK(vocabulary_.numWords() == metadata_.numVocabWords_);
+
+  // The auxiliary permutations are read raw: the deduplication and the graph
+  // filtering are applied by the merge into the scan of the main index, not
+  // here, so the graph post-processing of the `CompressedRelationReader` has to
+  // be switched off (which is what `Type::MATERIALIZED_VIEW` does).
+  for (auto permutation : Permutation::ALL) {
+    getPermutationImpl(permutation, false)
+        .loadFromDisk(basename, false, Permutation::Type::MATERIALIZED_VIEW);
+  }
+  std::string internalBasename =
+      absl::StrCat(basename, QLEVER_INTERNAL_INDEX_INFIX);
+  for (auto permutation : Permutation::INTERNAL) {
+    getPermutationImpl(permutation, true)
+        .loadFromDisk(internalBasename, false,
+                      Permutation::Type::MATERIALIZED_VIEW);
+  }
+
+  // Set up the permanently empty `LocatedTriplesState` that the scans of the
+  // permutations of this auxiliary index use.
+  LocatedTriplesPerBlockAllPermutations<false> emptyLocatedTriples;
+  for (auto permutation : Permutation::ALL) {
+    emptyLocatedTriples.at(static_cast<size_t>(permutation))
+        .setOriginalMetadata(getPermutationImpl(permutation, false)
+                                 .metaData()
+                                 .blockDataShared());
+  }
+  LocatedTriplesPerBlockAllPermutations<true> emptyInternalLocatedTriples;
+  for (auto permutation : Permutation::INTERNAL) {
+    emptyInternalLocatedTriples.at(static_cast<size_t>(permutation))
+        .setOriginalMetadata(
+            getPermutationImpl(permutation, true).metaData().blockDataShared());
+  }
+  LocalVocab emptyLocalVocab;
+  emptyLocatedTriplesState_ = std::make_shared<const LocatedTriplesState>(
+      LocatedTriplesState{std::move(emptyLocatedTriples),
+                          std::move(emptyInternalLocatedTriples),
+                          emptyLocalVocab.getLifetimeExtender(), 0});
+
+  isLoaded_ = true;
+  AD_LOG_INFO << "Registered auxiliary index (generation "
+              << metadata_.generation_ << ") with " << metadata_.numInserted_
+              << " inserted and " << metadata_.numDeleted_
+              << " deleted triples, and " << metadata_.numVocabWords_
+              << " new words in its vocabulary" << std::endl;
+}

--- a/src/index/AuxIndex.h
+++ b/src/index/AuxIndex.h
@@ -1,0 +1,174 @@
+// Copyright 2026 The QLever Authors, in particular:
+//
+// 2026 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+//
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#ifndef QLEVER_SRC_INDEX_AUXINDEX_H
+#define QLEVER_SRC_INDEX_AUXINDEX_H
+
+#include <array>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "index/AuxVocabulary.h"
+#include "index/Permutation.h"
+#include "index/vocabulary/VocabularyType.h"
+#include "util/json.h"
+
+// The metadata of an auxiliary index, stored as a JSON file next to its other
+// files.
+struct AuxIndexMetadata {
+  // The generation of this auxiliary index. Generations start at zero and are
+  // incremented by one for each rebuild.
+  size_t generation_ = 0;
+  // The number of triples that this auxiliary index inserts into resp. deletes
+  // from the main index.
+  size_t numInserted_ = 0;
+  size_t numDeleted_ = 0;
+  // The number of words in the auxiliary vocabulary.
+  size_t numVocabWords_ = 0;
+  // The type of the auxiliary vocabulary. It is required to read the vocabulary
+  // back from disk, because the type is not encoded in the vocabulary's files.
+  ad_utility::VocabularyType vocabularyType_ =
+      ad_utility::VocabularyType::OnDiskCompressed;
+
+  friend void to_json(nlohmann::json& j, const AuxIndexMetadata& metadata);
+  friend void from_json(const nlohmann::json& j, AuxIndexMetadata& metadata);
+};
+
+// An auxiliary index: the on-disk representation of a large set of delta
+// triples (triples that were inserted or deleted after the main index was
+// built). It consists of
+// 1. the six permutations plus the two internal permutations of those triples,
+// 2. the auxiliary vocabulary with the words that the triples use and that are
+//    not part of the vocabulary of the main index (see `AuxVocabulary`), and
+// 3. the metadata above.
+//
+// Together with the delta triples that are still held in RAM (see
+// `DeltaTriples`) and the main index, an auxiliary index forms a three-level
+// log-structured merge tree: a scan of the main index merges in the union of
+// the RAM delta triples and the triples of the auxiliary index, where the RAM
+// delta triples take precedence (they are the more recent ones).
+//
+// The permutations of an auxiliary index have five columns: the three index
+// columns in the order of the permutation, the graph column, and a column that
+// stores whether the triple is inserted (`insertedId`) or deleted
+// (`deletedId`).
+//
+// An `AuxIndex` is immutable. A rebuild does not modify it, but creates a new
+// generation with a new set of files, and the `Id`s of its vocabulary are only
+// valid with respect to that one generation.
+class AuxIndex {
+ public:
+  using Allocator = ad_utility::AllocatorWithLimit<Id>;
+
+  // The number of columns of the permutations, see the class comment.
+  static constexpr size_t numColumns = 5;
+  // The index of the column that stores whether a triple is inserted or
+  // deleted.
+  static constexpr ColumnIndex insertOrDeleteColumn = 4;
+
+  // The values that are stored in the `insertOrDeleteColumn`.
+  static Id insertedId() { return Id::makeFromBool(true); }
+  static Id deletedId() { return Id::makeFromBool(false); }
+
+  // The base name of the files of the auxiliary index with the given
+  // `generation` for the main index with the given base name.
+  static std::string makeBasename(std::string_view mainIndexBasename,
+                                  size_t generation);
+
+  // All files of the auxiliary index with the given base name that currently
+  // exist on disk.
+  static std::vector<ql::filesystem::path> allFiles(std::string_view basename);
+
+  // The generations of all auxiliary indices that currently exist on disk for
+  // the main index with the given base name, in ascending order. Only
+  // generations whose metadata file exists are reported, so a generation whose
+  // build was interrupted is not included (but its files may still be there,
+  // see `deleteFromDisk`).
+  static std::vector<size_t> generationsOnDisk(
+      std::string_view mainIndexBasename);
+
+  // Delete all files of the auxiliary index with the given base name.
+  static void deleteFromDisk(std::string_view basename);
+
+  explicit AuxIndex(Allocator allocator);
+  AuxIndex(const AuxIndex&) = delete;
+  AuxIndex& operator=(const AuxIndex&) = delete;
+
+  // Read the auxiliary index with the given base name from disk. The locale has
+  // to be the locale of the main index, see `AuxVocabulary::open`.
+  void loadFromDisk(const std::string& basename, const std::string& language,
+                    const std::string& country, bool ignorePunctuation);
+
+  // The auxiliary vocabulary.
+  const AuxVocabulary& vocab() const { return vocabulary_; }
+
+  // The metadata.
+  const AuxIndexMetadata& metadata() const { return metadata_; }
+
+  // The generation, see `AuxIndexMetadata::generation_`.
+  size_t generation() const { return metadata_.generation_; }
+
+  // The base name of the files of this auxiliary index.
+  const std::string& basename() const { return basename_; }
+
+  // The permutation of the given kind. `internal` selects the internal
+  // permutations (of which only `PSO` and `POS` exist).
+  const Permutation& getPermutation(Permutation::Enum permutation,
+                                    bool internal) const;
+
+  // The (permanently empty) `LocatedTriplesState` that has to be passed to the
+  // scan functions of the permutations of this auxiliary index. The delta
+  // triples that are held in RAM are merged into the scan of the *main* index,
+  // not into the scan of an auxiliary index.
+  //
+  // NOTE: Do not use this to obtain the block metadata of a permutation of this
+  // auxiliary index via `Permutation::getAugmentedMetadataForPermutation`. That
+  // function looks the metadata up by the permutation's *external* slot unless
+  // the permutation's type is `INTERNAL`, and the permutations of an auxiliary
+  // index are deliberately typed as materialized views (see `loadFromDisk`), so
+  // for the internal ones it would return the metadata of the corresponding
+  // external permutation. Use `scanFull` below instead.
+  const LocatedTriplesState& emptyLocatedTriplesState() const {
+    return *emptyLocatedTriplesState_;
+  }
+
+  // A full scan of the given permutation of this auxiliary index. Each row
+  // holds the three index columns in the order of the permutation, the graph
+  // column, and the column that stores whether the triple is inserted or
+  // deleted (see `insertOrDeleteColumn`). The returned `LazyScanWithReader`
+  // owns the reader that its blocks borrow from, so it has to be kept alive
+  // while the blocks are being used.
+  Permutation::LazyScanWithReader scanFull(
+      Permutation::Enum permutation, bool internal,
+      const ad_utility::SharedCancellationHandle& cancellationHandle) const;
+
+  // Return true iff this auxiliary index contains no triples at all.
+  bool isEmpty() const {
+    return metadata_.numInserted_ + metadata_.numDeleted_ == 0;
+  }
+
+ private:
+  // Common implementation of the two `getPermutation` cases, also used during
+  // loading.
+  Permutation& getPermutationImpl(Permutation::Enum permutation, bool internal);
+
+  std::string basename_;
+  AuxIndexMetadata metadata_;
+  AuxVocabulary vocabulary_;
+  Allocator allocator_;
+  // The permutations. They are held as `unique_ptr`s because `Permutation` is
+  // not movable.
+  std::array<std::unique_ptr<Permutation>, 6> permutations_;
+  std::array<std::unique_ptr<Permutation>, 2> internalPermutations_;
+  std::shared_ptr<const LocatedTriplesState> emptyLocatedTriplesState_;
+  bool isLoaded_ = false;
+};
+
+#endif  // QLEVER_SRC_INDEX_AUXINDEX_H

--- a/src/index/AuxIndexBuilder.cpp
+++ b/src/index/AuxIndexBuilder.cpp
@@ -1,0 +1,553 @@
+// Copyright 2026 The QLever Authors, in particular:
+//
+// 2026 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+//
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#include "index/AuxIndexBuilder.h"
+
+#include <absl/strings/str_cat.h>
+
+#include <fstream>
+
+#include "backports/algorithm.h"
+#include "global/Constants.h"
+#include "global/FileSuffixConstants.h"
+#include "index/DeltaTriples.h"
+#include "index/ExternalSortFunctors.h"
+#include "index/IndexImpl.h"
+#include "util/Exception.h"
+#include "util/HashSet.h"
+#include "util/Log.h"
+#include "util/Serializer/FileSerializer.h"
+
+namespace qlever {
+
+// ____________________________________________________________________________
+std::optional<Id> AuxIndexIdMapping::map(Id id) const {
+  auto datatype = id.getDatatype();
+  if (datatype == Datatype::AuxVocabIndex) {
+    AD_CORRECTNESS_CHECK(previousAuxVocab_ != nullptr);
+    auto offset = previousAuxVocab_->offsetOf(id.getAuxVocabIndex());
+    AD_CORRECTNESS_CHECK(offset < newIdForOldAuxOffset_.size());
+    return newIdForOldAuxOffset_[offset];
+  }
+  if (datatype == Datatype::LocalVocabIndex) {
+    auto it = newIdForLocalVocabEntry_.find(id.getLocalVocabIndex());
+    if (it == newIdForLocalVocabEntry_.end()) {
+      return std::nullopt;
+    }
+    return it->second;
+  }
+  return id;
+}
+
+namespace {
+
+// The number of columns of the permutations of an auxiliary index. The columns
+// are the three index columns, the graph column, and the column that stores
+// whether a triple is inserted or deleted.
+constexpr size_t numColumns = AuxIndex::numColumns;
+static_assert(numColumns == NumColumnsIndexBuilding + 1);
+
+// A triple of an update, together with the information whether it is inserted
+// or deleted. The `Id`s are in the order of the permutation that the triples
+// are merged in (see `mergeUpdateTriples`), so *not* necessarily `(S, P, O,
+// G)`.
+struct UpdateTriple {
+  IdTriple<0> triple_;
+  bool insertOrDelete_;
+};
+
+// The permutation whose order the triples are merged in. There is no `SPO`
+// permutation for the internal triples, so the internal ones are merged in
+// `PSO` order.
+Permutation::Enum mergeOrder(bool isInternal) {
+  return isInternal ? Permutation::PSO : Permutation::SPO;
+}
+
+// The inverse of the `KeyOrder` of the given permutation, that is, the
+// permutation that maps a quad from the order of `permutation` back to
+// `(S, P, O, G)`.
+KeyOrder inverseKeyOrder(Permutation::Enum permutation) {
+  auto keys = Permutation::toKeyOrder(permutation).keys();
+  KeyOrder::Array inverse{};
+  for (size_t i = 0; i < keys.size(); ++i) {
+    inverse.at(keys.at(i)) = static_cast<KeyOrder::T>(i);
+  }
+  return KeyOrder{inverse.at(0), inverse.at(1), inverse.at(2), inverse.at(3)};
+}
+
+// All delta triples of the given `locatedTriplesState`, in the order of the
+// permutation that they are merged in, see `mergeOrder`.
+template <bool isInternal>
+std::vector<UpdateTriple> collectDeltaTriples(
+    const LocatedTriplesState& locatedTriplesState) {
+  const auto& locatedTriples =
+      locatedTriplesState.getLocatedTriplesForPermutation<isInternal>(
+          mergeOrder(isInternal));
+  // Computing the difference to an empty set of located triples yields all of
+  // them, split into insertions and deletions, each sorted.
+  LocatedTriplesPerBlock empty;
+  auto [inserted, deleted] = locatedTriples.computeDiff(empty);
+  std::vector<UpdateTriple> result;
+  result.reserve(inserted.size() + deleted.size());
+  // Merge the insertions and the deletions into a single sorted sequence. A
+  // triple is never both inserted and deleted, so there are no ties.
+  auto addInserted = [&result](const IdTriple<0>& triple) {
+    result.push_back({triple, true});
+  };
+  auto addDeleted = [&result](const IdTriple<0>& triple) {
+    result.push_back({triple, false});
+  };
+  auto itInserted = inserted.begin();
+  auto itDeleted = deleted.begin();
+  while (itInserted != inserted.end() && itDeleted != deleted.end()) {
+    if (*itInserted < *itDeleted) {
+      addInserted(*itInserted++);
+    } else {
+      AD_CORRECTNESS_CHECK(*itDeleted < *itInserted,
+                           "A triple must not be inserted and deleted at the "
+                           "same time");
+      addDeleted(*itDeleted++);
+    }
+  }
+  ql::ranges::for_each(ql::ranges::subrange{itInserted, inserted.end()},
+                       addInserted);
+  ql::ranges::for_each(ql::ranges::subrange{itDeleted, deleted.end()},
+                       addDeleted);
+  return result;
+}
+
+// Compare the triples of two `UpdateTriple`s (ignoring their insert/delete
+// flags). Both the delta triples and the triples of an auxiliary index are
+// sorted this way in the order that they are merged in.
+bool tripleLess(const IdTriple<0>& a, const IdTriple<0>& b) { return a < b; }
+
+// Call `callback(const UpdateTriple&)` for the merged sequence of the delta
+// triples in `deltaTriples` (which have to be sorted) and the triples of the
+// corresponding permutation of `previousAux` (which may be `nullptr`), in
+// ascending order. If both of them contain the same triple, the one from the
+// delta triples wins, because it is the more recent one.
+template <typename Callback>
+void mergeUpdateTriples(
+    const std::vector<UpdateTriple>& deltaTriples, const AuxIndex* previousAux,
+    bool isInternal,
+    const ad_utility::SharedCancellationHandle& cancellationHandle,
+    Callback callback) {
+  auto itDelta = deltaTriples.begin();
+  auto emitDelta = [&callback](const UpdateTriple& triple) {
+    callback(triple);
+  };
+  if (previousAux == nullptr || previousAux->isEmpty()) {
+    ql::ranges::for_each(deltaTriples, emitDelta);
+    return;
+  }
+
+  auto [reader, blocks] = previousAux->scanFull(mergeOrder(isInternal),
+                                                isInternal, cancellationHandle);
+
+  for (const IdTable& block : blocks) {
+    cancellationHandle->throwIfCancelled();
+    for (size_t row = 0; row < block.numRows(); ++row) {
+      UpdateTriple fromAux{
+          IdTriple<0>{std::array<Id, 4>{block(row, 0), block(row, 1),
+                                        block(row, 2), block(row, 3)}},
+          block(row, AuxIndex::insertOrDeleteColumn) == AuxIndex::insertedId()};
+      // Emit all delta triples that are smaller, and skip the triple from the
+      // auxiliary index if the delta triples also have an entry for it.
+      while (itDelta != deltaTriples.end() &&
+             tripleLess(itDelta->triple_, fromAux.triple_)) {
+        emitDelta(*itDelta++);
+      }
+      if (itDelta != deltaTriples.end() &&
+          !tripleLess(fromAux.triple_, itDelta->triple_)) {
+        emitDelta(*itDelta++);
+        continue;
+      }
+      callback(fromAux);
+    }
+  }
+  ql::ranges::for_each(ql::ranges::subrange{itDelta, deltaTriples.end()},
+                       emitDelta);
+}
+
+// The classification of an `Id` that is used by the delta triples or by the
+// previous generation of the auxiliary index.
+struct WordSource {
+  std::string word_;
+  uint8_t marker_;
+  // Exactly one of the two is set: the local vocab entry that the word comes
+  // from, or the `Id` that it has in the previous generation of the auxiliary
+  // vocabulary.
+  LocalVocabIndex localVocabEntry_ = nullptr;
+  Id previousAuxId_ = Id::makeUndefined();
+};
+
+// The words that need an `Id` in the new generation of the auxiliary
+// vocabulary, plus the local vocab entries whose word is already representable
+// in the main index (in its vocabulary or as an encoded value), which are
+// resolved directly.
+struct CollectedWords {
+  std::vector<WordSource> sources_;
+  ad_utility::HashMap<LocalVocabIndex, Id> resolvedLocalVocabEntries_;
+};
+
+// Collect the words of all `Id`s of the merged update triples that are not part
+// of the vocabulary of the main index, see `CollectedWords`.
+class WordCollector {
+ private:
+  const IndexImpl& index_;
+  const AuxIndex* previousAux_;
+  ad_utility::HashSet<LocalVocabIndex> seenLocalVocabEntries_;
+  ad_utility::HashSet<uint64_t> seenPreviousAuxOffsets_;
+  CollectedWords collected_;
+
+ public:
+  WordCollector(const IndexImpl& index, const AuxIndex* previousAux)
+      : index_{index}, previousAux_{previousAux} {}
+
+  // Process all `Id`s of `triple`.
+  void operator()(const UpdateTriple& triple) {
+    for (Id id : triple.triple_.ids()) {
+      addId(id);
+    }
+  }
+
+  CollectedWords getResult() && { return std::move(collected_); }
+
+ private:
+  // Add the word of a single `Id`, if it needs an `Id` in the new generation.
+  void addId(Id id) {
+    auto datatype = id.getDatatype();
+    if (datatype == Datatype::AuxVocabIndex) {
+      addPreviousAuxId(id);
+    } else if (datatype == Datatype::LocalVocabIndex) {
+      addLocalVocabEntry(id.getLocalVocabIndex());
+    }
+  }
+
+  // ___________________________________________________________________________
+  void addPreviousAuxId(Id id) {
+    AD_CORRECTNESS_CHECK(previousAux_ != nullptr);
+    const auto& vocab = previousAux_->vocab();
+    auto auxIndex = id.getAuxVocabIndex();
+    if (!seenPreviousAuxOffsets_.insert(vocab.offsetOf(auxIndex)).second) {
+      return;
+    }
+    std::string word{vocab[auxIndex]};
+    collected_.sources_.push_back(
+        {word, index_.getVocab().getMarkerForWord(word), nullptr, id});
+  }
+
+  // ___________________________________________________________________________
+  void addLocalVocabEntry(LocalVocabIndex entry) {
+    if (!seenLocalVocabEntries_.insert(entry).second) {
+      return;
+    }
+    auto [lowerBound, upperBound] = entry->positionInVocab();
+    if (lowerBound != upperBound) {
+      // The word is already representable in the main index: it is either
+      // contained in its vocabulary, or it is an encoded value. Note that it
+      // may also be contained in the previous generation of the auxiliary
+      // vocabulary, in which case it is resolved to that `Id`, which is then
+      // itself remapped when the mapping is assembled.
+      auto id = Id::fromBits(lowerBound.get());
+      collected_.resolvedLocalVocabEntries_.emplace(entry, id);
+      if (id.getDatatype() == Datatype::AuxVocabIndex) {
+        addPreviousAuxId(id);
+      }
+      return;
+    }
+    std::string word = entry->toStringRepresentation();
+    collected_.sources_.push_back({word,
+                                   index_.getVocab().getMarkerForWord(word),
+                                   entry, Id::makeUndefined()});
+  }
+};
+
+// Write the vocabulary of the new generation from the collected `words` and
+// return the mapping into the `Id` space of that new generation.
+AuxIndexIdMapping writeVocabularyAndMakeMapping(
+    const IndexImpl& index, const AuxIndex* previousAux,
+    const std::string& basename, ad_utility::VocabularyType vocabularyType,
+    CollectedWords words, size_t* numVocabWords) {
+  const auto& mainVocab = index.getVocab();
+  // The words have to be pushed grouped by their sub-vocabulary, and ascending
+  // within each group, see `AuxVocabulary::WordWriter`.
+  auto less = [&mainVocab](const WordSource& a, const WordSource& b) {
+    if (a.marker_ != b.marker_) {
+      return a.marker_ < b.marker_;
+    }
+    return mainVocab.getCaseComparator()(a.word_, b.word_,
+                                         RdfsVocabulary::SortLevel::TOTAL);
+  };
+  ql::ranges::sort(words.sources_, less);
+
+  std::vector<Id> newIdForOldAuxOffset(
+      previousAux == nullptr ? 0 : previousAux->vocab().numWords(),
+      Id::makeUndefined());
+  ad_utility::HashMap<LocalVocabIndex, Id> newIdForLocalVocabEntry;
+
+  {
+    AuxVocabulary::WordWriter writer{mainVocab, basename, vocabularyType};
+    std::optional<std::string> previousWord;
+    Id currentId = Id::makeUndefined();
+    for (const auto& source : words.sources_) {
+      // Several sources can yield the same word, in which case they all get the
+      // same `Id`. Note that the words are sorted, so equal words are adjacent.
+      if (!previousWord.has_value() || previousWord.value() != source.word_) {
+        currentId = Id::makeFromAuxVocabIndex(writer(source.word_));
+        previousWord = source.word_;
+      }
+      if (source.localVocabEntry_ != nullptr) {
+        newIdForLocalVocabEntry.insert_or_assign(source.localVocabEntry_,
+                                                 currentId);
+      } else {
+        AD_CORRECTNESS_CHECK(previousAux != nullptr);
+        auto offset = previousAux->vocab().offsetOf(
+            source.previousAuxId_.getAuxVocabIndex());
+        newIdForOldAuxOffset.at(offset) = currentId;
+      }
+    }
+    *numVocabWords = writer.numWords();
+    writer.finish();
+  }
+
+  // Add the local vocab entries whose word is already representable in the main
+  // index. Note that this has to happen *after* the loop above, because those
+  // entries whose word is stored in the previous generation of the auxiliary
+  // vocabulary need the mapping of that generation, which the loop above is
+  // what fills in. They are kept in a separate container until here, because
+  // otherwise they could not be told apart from the entries that the loop above
+  // has already mapped to an `Id` of the *new* generation.
+  for (const auto& [entry, resolvedId] : words.resolvedLocalVocabEntries_) {
+    Id id = resolvedId;
+    if (id.getDatatype() == Datatype::AuxVocabIndex) {
+      AD_CORRECTNESS_CHECK(previousAux != nullptr);
+      auto offset = previousAux->vocab().offsetOf(id.getAuxVocabIndex());
+      id = newIdForOldAuxOffset.at(offset);
+      AD_CORRECTNESS_CHECK(!id.isUndefined());
+    }
+    auto [it, inserted] = newIdForLocalVocabEntry.emplace(entry, id);
+    (void)it;
+    AD_CORRECTNESS_CHECK(inserted,
+                         "A local vocab entry must be resolved in exactly one "
+                         "way");
+  }
+
+  return AuxIndexIdMapping{
+      std::move(newIdForOldAuxOffset), std::move(newIdForLocalVocabEntry),
+      previousAux == nullptr ? nullptr : &previousAux->vocab()};
+}
+
+// The filename of the given permutation of the auxiliary index with the given
+// base name.
+std::string permutationFilename(const std::string& basename,
+                                Permutation::Enum permutation,
+                                bool isInternal) {
+  std::string base = isInternal
+                         ? absl::StrCat(basename, QLEVER_INTERNAL_INDEX_INFIX)
+                         : basename;
+  return Permutation::fileNames(permutation, base).at(0).string();
+}
+
+// Write the pair of permutations `permutation1` and `permutation2` (which have
+// to be twins, for example `PSO` and `POS`) of the auxiliary index with the
+// given base name, from the `sortedTriples` (which have to be sorted by the key
+// order of `permutation1`).
+void writePermutationPair(
+    const std::string& basename, Permutation::Enum permutation1,
+    Permutation::Enum permutation2, bool isInternal,
+    ad_utility::InputRangeTypeErased<IdTableStatic<0>> sortedTriples,
+    ad_utility::MemorySize blocksizePerColumn) {
+  auto makeWriterAndCallback = [&blocksizePerColumn](
+                                   IndexMetaData& metaData,
+                                   const std::string& filename) {
+    auto writer = std::make_unique<CompressedRelationWriter>(
+        numColumns, ad_utility::File(filename, "w"), blocksizePerColumn);
+    CompressedRelationWriter::MetadataCallback callback =
+        [&metaData](ql::span<const CompressedRelationMetadata> mds) {
+          for (const auto& md : mds) {
+            metaData.add(md);
+          }
+        };
+    return CompressedRelationWriter::WriterAndCallback{std::move(writer),
+                                                       std::move(callback)};
+  };
+
+  std::string filename1 =
+      permutationFilename(basename, permutation1, isInternal);
+  std::string filename2 =
+      permutationFilename(basename, permutation2, isInternal);
+  IndexMetaData metaData1;
+  IndexMetaData metaData2;
+  auto [numDistinctCol0, blockData1, blockData2] =
+      CompressedRelationWriter::createPermutationPair(
+          filename1, makeWriterAndCallback(metaData1, filename1),
+          makeWriterAndCallback(metaData2, filename2), std::move(sortedTriples),
+          Permutation::toKeyOrder(permutation1), {});
+  metaData1.blockData() = std::move(blockData1);
+  metaData2.blockData() = std::move(blockData2);
+
+  auto finalize = [numDistinctCol0 = numDistinctCol0](
+                      IndexMetaData& metaData, const std::string& filename) {
+    metaData.calculateStatistics(numDistinctCol0);
+    metaData.setName(filename);
+    ad_utility::File file{filename, "r+"};
+    ad_utility::File metaFile{absl::StrCat(filename, META_FILE_SUFFIX), "w"};
+    metaData.appendToFile(file, metaFile);
+  };
+  finalize(metaData1, filename1);
+  finalize(metaData2, filename2);
+}
+
+}  // namespace
+
+// ____________________________________________________________________________
+AuxIndexBuildResult buildAuxIndex(
+    const IndexImpl& index, const LocatedTriplesState& locatedTriplesState,
+    ad_utility::MemorySize memoryLimit,
+    const ad_utility::SharedCancellationHandle& cancellationHandle) {
+  const AuxIndex* previousAux = index.auxIndex();
+  size_t generation =
+      previousAux == nullptr ? 0 : previousAux->generation() + 1;
+  std::string basename =
+      AuxIndex::makeBasename(index.getOnDiskBase(), generation);
+  AD_LOG_INFO << "Building the auxiliary index (generation " << generation
+              << ") at " << basename << " ..." << std::endl;
+
+  auto deltaTriples = collectDeltaTriples<false>(locatedTriplesState);
+  auto internalDeltaTriples = collectDeltaTriples<true>(locatedTriplesState);
+  AD_LOG_INFO << "The auxiliary index is built from " << deltaTriples.size()
+              << " delta triples (plus " << internalDeltaTriples.size()
+              << " internal ones)"
+              << (previousAux == nullptr
+                      ? ""
+                      : " and the previous generation of the auxiliary index")
+              << std::endl;
+
+  // Pass one: determine the words that need an `Id` in the new generation.
+  auto vocabularyType = index.getVocabularyType();
+  AuxIndexIdMapping idMapping;
+  size_t numVocabWords = 0;
+  {
+    WordCollector collector{index, previousAux};
+    mergeUpdateTriples(deltaTriples, previousAux, false, cancellationHandle,
+                       std::ref(collector));
+    mergeUpdateTriples(internalDeltaTriples, previousAux, true,
+                       cancellationHandle, std::ref(collector));
+    idMapping = writeVocabularyAndMakeMapping(
+        index, previousAux, basename, vocabularyType,
+        std::move(collector).getResult(), &numVocabWords);
+  }
+  AD_LOG_INFO << "The vocabulary of the auxiliary index has " << numVocabWords
+              << " words" << std::endl;
+
+  // Pass two: remap the `Id`s and write the permutations. The triples are
+  // pushed into the external sorters in blocks of bounded size, so that only
+  // one such block is held in RAM at a time.
+  size_t numInserted = 0;
+  size_t numDeleted = 0;
+  auto memoryPerSorter = memoryLimit / 4;
+  static constexpr size_t blocksize = 100'000;
+
+  // Feed all triples of `triples` merged with the corresponding permutation of
+  // the previous generation (see `mergeUpdateTriples`) into all the `sorters`.
+  auto pushTriples = [&](const std::vector<UpdateTriple>& triples,
+                         bool isInternal, auto&... sorters) {
+    auto inverse = inverseKeyOrder(mergeOrder(isInternal));
+    IdTableStatic<0> block{numColumns,
+                           ad_utility::makeUnlimitedAllocator<Id>()};
+    block.reserve(blocksize);
+    auto flush = [&block, &sorters...]() {
+      if (block.empty()) {
+        return;
+      }
+      // Each sorter takes ownership of the block it is given, so all but the
+      // last one get a copy.
+      (..., sorters.pushBlock(block.clone()));
+      block.clear();
+    };
+    auto pushRow = [&](const UpdateTriple& triple) {
+      std::array<Id, 4> quad = triple.triple_.ids();
+      for (Id& id : quad) {
+        auto mapped = idMapping.map(id);
+        AD_CORRECTNESS_CHECK(
+            mapped.has_value(),
+            "A local vocab entry was used by a delta triple that is not part "
+            "of "
+            "the snapshot that the auxiliary index is built from");
+        id = mapped.value();
+      }
+      quad = inverse.permuteTuple(quad);
+      block.emplace_back();
+      auto row = block.numRows() - 1;
+      for (size_t i = 0; i < quad.size(); ++i) {
+        block(row, i) = quad.at(i);
+      }
+      block(row, AuxIndex::insertOrDeleteColumn) = triple.insertOrDelete_
+                                                       ? AuxIndex::insertedId()
+                                                       : AuxIndex::deletedId();
+      if (!isInternal) {
+        ++(triple.insertOrDelete_ ? numInserted : numDeleted);
+      }
+      if (block.numRows() >= blocksize) {
+        flush();
+      }
+    };
+    mergeUpdateTriples(triples, previousAux, isInternal, cancellationHandle,
+                       pushRow);
+    flush();
+  };
+
+  auto blocksizePerColumn = index.blocksizePermutationPerColumn();
+  {
+    ad_utility::CompressedExternalIdTableSorter<SortBySPO, numColumns>
+        spoSorter{absl::StrCat(basename, ".spo-sorter.dat"), memoryPerSorter,
+                  index.allocator()};
+    ad_utility::CompressedExternalIdTableSorter<SortByOSP, numColumns>
+        ospSorter{absl::StrCat(basename, ".osp-sorter.dat"), memoryPerSorter,
+                  index.allocator()};
+    ad_utility::CompressedExternalIdTableSorter<SortByPSO, numColumns>
+        psoSorter{absl::StrCat(basename, ".pso-sorter.dat"), memoryPerSorter,
+                  index.allocator()};
+    pushTriples(deltaTriples, false, spoSorter, ospSorter, psoSorter);
+    writePermutationPair(basename, Permutation::SPO, Permutation::SOP, false,
+                         spoSorter.getSortedBlocks<0>(), blocksizePerColumn);
+    writePermutationPair(basename, Permutation::OSP, Permutation::OPS, false,
+                         ospSorter.getSortedBlocks<0>(), blocksizePerColumn);
+    writePermutationPair(basename, Permutation::PSO, Permutation::POS, false,
+                         psoSorter.getSortedBlocks<0>(), blocksizePerColumn);
+  }
+  {
+    ad_utility::CompressedExternalIdTableSorter<SortByPSO, numColumns>
+        internalPsoSorter{absl::StrCat(basename, ".internal-pso-sorter.dat"),
+                          memoryPerSorter, index.allocator()};
+    pushTriples(internalDeltaTriples, true, internalPsoSorter);
+    writePermutationPair(basename, Permutation::PSO, Permutation::POS, true,
+                         internalPsoSorter.getSortedBlocks<0>(),
+                         blocksizePerColumn);
+  }
+
+  // Write the metadata last, such that an interrupted build leaves behind an
+  // auxiliary index that is never used, see `AuxIndex::generationsOnDisk`.
+  AuxIndexMetadata metadata{generation, numInserted, numDeleted, numVocabWords,
+                            vocabularyType};
+  {
+    std::ofstream metadataFile{
+        absl::StrCat(basename, AUX_INDEX_CONFIGURATION_FILE)};
+    AD_CORRECTNESS_CHECK(metadataFile.is_open());
+    nlohmann::json metadataJson = metadata;
+    metadataFile << metadataJson.dump(2);
+  }
+  AD_LOG_INFO << "Done building the auxiliary index (generation " << generation
+              << "): " << numInserted << " inserted and " << numDeleted
+              << " deleted triples" << std::endl;
+  return {std::move(basename), metadata, std::move(idMapping)};
+}
+
+}  // namespace qlever

--- a/src/index/AuxIndexBuilder.h
+++ b/src/index/AuxIndexBuilder.h
@@ -1,0 +1,106 @@
+// Copyright 2026 The QLever Authors, in particular:
+//
+// 2026 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+//
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#ifndef QLEVER_SRC_INDEX_AUXINDEXBUILDER_H
+#define QLEVER_SRC_INDEX_AUXINDEXBUILDER_H
+
+#include <string>
+#include <vector>
+
+#include "global/Id.h"
+#include "index/AuxIndex.h"
+#include "util/CancellationHandle.h"
+#include "util/HashMap.h"
+#include "util/MemorySize/MemorySize.h"
+
+class IndexImpl;
+struct LocatedTriplesState;
+
+namespace qlever {
+
+// The mapping that translates the `Id`s that the delta triples used *before* a
+// build of the auxiliary index into the `Id`s of the newly built generation. It
+// is required to carry over the updates that arrived while the build was
+// running (see `DeltaTriples::addFromSnapshotDiff`), because building an
+// auxiliary index moves words out of the local vocabulary and out of the
+// previous generation of the auxiliary vocabulary into the new one.
+class AuxIndexIdMapping {
+ private:
+  // For each offset (see `AuxVocabulary`) of the *previous* generation of the
+  // auxiliary vocabulary, the `Id` that its word has in the new generation.
+  std::vector<Id> newIdForOldAuxOffset_;
+  // For each local vocab entry that was used by the delta triples, the `Id`
+  // that its word has now. This is an `Id` of the new auxiliary vocabulary, or
+  // an `Id` of the main vocabulary resp. an encoded `Id` if the word turned out
+  // to be representable there.
+  ad_utility::HashMap<LocalVocabIndex, Id> newIdForLocalVocabEntry_;
+  // The previous generation of the auxiliary index, or `nullptr` if there was
+  // none. Required to turn an `Id` of that generation into an offset.
+  const AuxVocabulary* previousAuxVocab_ = nullptr;
+
+ public:
+  AuxIndexIdMapping() = default;
+  AuxIndexIdMapping(std::vector<Id> newIdForOldAuxOffset,
+                    ad_utility::HashMap<LocalVocabIndex, Id> newIdForLocalVocab,
+                    const AuxVocabulary* previousAuxVocab)
+      : newIdForOldAuxOffset_{std::move(newIdForOldAuxOffset)},
+        newIdForLocalVocabEntry_{std::move(newIdForLocalVocab)},
+        previousAuxVocab_{previousAuxVocab} {}
+
+  // Map `id` into the `Id` space of the new generation. `Id`s that are not
+  // affected (everything but the `Id`s of the previous auxiliary vocabulary and
+  // the local vocab entries) are returned unchanged. If a local vocab entry is
+  // not part of this mapping (because it was added after the mapping was
+  // created), `std::nullopt` is returned: such an `Id` has to be re-created in
+  // the local vocabulary of the new index instead.
+  std::optional<Id> map(Id id) const;
+
+  // The number of local vocab entries that this mapping covers.
+  size_t numLocalVocabEntries() const {
+    return newIdForLocalVocabEntry_.size();
+  }
+};
+
+// The result of building a new generation of the auxiliary index.
+struct AuxIndexBuildResult {
+  // The base name of the files of the new generation.
+  std::string basename_;
+  // The metadata of the new generation.
+  AuxIndexMetadata metadata_;
+  // The mapping into the `Id` space of the new generation, see above.
+  AuxIndexIdMapping idMapping_;
+};
+
+// Build a new generation of the auxiliary index of `index` from the delta
+// triples in `locatedTriplesState` merged with the current generation of the
+// auxiliary index of `index` (if it has one). The delta triples take
+// precedence: if both of them have an entry for the same triple, the one from
+// the delta triples wins, because it is the more recent one.
+//
+// Insertions of triples that the main index already contains and deletions of
+// triples that it does not contain are *not* removed, they are simply carried
+// over. (Removing them requires a lookup in the main index for each triple;
+// this is what `?cmd=vacuum-delta-triples` does and it is deliberately kept
+// separate.)
+//
+// The caller has to keep the words of the local vocabulary that
+// `locatedTriplesState` refers to alive for the duration of the call, see
+// `DeltaTriplesManager::getCurrentLocatedTriplesSharedStateWithVocab`.
+//
+// The new generation is only usable once its metadata file exists, which is
+// written last, so an interrupted or failed build leaves behind files that are
+// ignored (and that the caller should delete via `AuxIndex::deleteFromDisk`).
+AuxIndexBuildResult buildAuxIndex(
+    const IndexImpl& index, const LocatedTriplesState& locatedTriplesState,
+    ad_utility::MemorySize memoryLimit,
+    const ad_utility::SharedCancellationHandle& cancellationHandle);
+
+}  // namespace qlever
+
+#endif  // QLEVER_SRC_INDEX_AUXINDEXBUILDER_H

--- a/src/index/AuxLocatedTriples.cpp
+++ b/src/index/AuxLocatedTriples.cpp
@@ -1,0 +1,202 @@
+// Copyright 2026 The QLever Authors, in particular:
+//
+// 2026 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+//
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#include "index/AuxLocatedTriples.h"
+
+#include "backports/algorithm.h"
+#include "global/Constants.h"
+#include "index/GraphComputation.h"
+#include "util/Exception.h"
+
+namespace {
+// Compare two permuted triples ignoring their graph, which is how a triple is
+// attributed to a block, see `LocatedTriple::locateTriplesInPermutation`.
+bool lessWithoutGraph(const CompressedBlockMetadata::PermutedTriple& a,
+                      const CompressedBlockMetadata::PermutedTriple& b) {
+  return a.tieWithoutGraph() < b.tieWithoutGraph();
+}
+}  // namespace
+
+// ____________________________________________________________________________
+AuxLocatedTriples::AuxLocatedTriples(
+    std::shared_ptr<const AuxIndex> auxIndex, Permutation::Enum permutation,
+    bool isInternal, std::shared_ptr<const BlockMetadata> mainBlockMetadata)
+    : auxIndex_{std::move(auxIndex)},
+      permutation_{permutation},
+      isInternal_{isInternal},
+      mainBlockMetadata_{std::move(mainBlockMetadata)} {
+  AD_CONTRACT_CHECK(auxIndex_ != nullptr);
+  AD_CONTRACT_CHECK(mainBlockMetadata_ != nullptr);
+  auxBlockMetadata_ = auxIndex_->getPermutation(permutation_, isInternal_)
+                          .metaData()
+                          .blockData();
+  computeBlockInfos();
+}
+
+// ____________________________________________________________________________
+std::pair<size_t, size_t> AuxLocatedTriples::auxBlockRange(
+    size_t mainBlockIndex) const {
+  const auto& mainBlocks = *mainBlockMetadata_;
+  AD_CONTRACT_CHECK(mainBlockIndex <= mainBlocks.size());
+  // A triple `t` belongs to the block of the main index with the index
+  // `mainBlockIndex` if and only if `lastTriple_[mainBlockIndex - 1] < t <=
+  // lastTriple_[mainBlockIndex]` (compared without the graph), where the lower
+  // bound is missing for the first block and the upper bound is missing for the
+  // synthetic block after the last one.
+  //
+  // A block of the auxiliary index can contain such a triple if and only if its
+  // last triple is greater than the lower bound and its first triple is not
+  // greater than the upper bound.
+  size_t first = 0;
+  if (mainBlockIndex > 0) {
+    const auto& lowerBound = mainBlocks.at(mainBlockIndex - 1).lastTriple_;
+    first = ql::ranges::upper_bound(auxBlockMetadata_, lowerBound,
+                                    &lessWithoutGraph,
+                                    &CompressedBlockMetadata::lastTriple_) -
+            auxBlockMetadata_.begin();
+  }
+  size_t last = auxBlockMetadata_.size();
+  if (mainBlockIndex < mainBlocks.size()) {
+    const auto& upperBound = mainBlocks.at(mainBlockIndex).lastTriple_;
+    last = ql::ranges::upper_bound(auxBlockMetadata_, upperBound,
+                                   &lessWithoutGraph,
+                                   &CompressedBlockMetadata::firstTriple_) -
+           auxBlockMetadata_.begin();
+  }
+  // The two bounds can cross when no block of the auxiliary index falls into
+  // the range at all.
+  return {first, std::max(first, last)};
+}
+
+// ____________________________________________________________________________
+void AuxLocatedTriples::computeBlockInfos() {
+  if (auxBlockMetadata_.empty()) {
+    return;
+  }
+  // A single sequential pass over the whole permutation of the auxiliary index.
+  // The triples arrive in ascending order, so the blocks of the main index that
+  // they are attributed to are ascending as well, which means that the first
+  // and the last triple of each of them are simply the first and the last
+  // triple that is seen for it.
+  const auto& mainBlocks = *mainBlockMetadata_;
+  auto keyOrder = Permutation::toKeyOrder(permutation_);
+  auto inverse = keyOrder.inverse();
+  auto handle = std::make_shared<ad_utility::CancellationHandle<>>();
+  auto [reader, blocks] =
+      auxIndex_->scanFull(permutation_, isInternal_, handle);
+  for (const IdTable& block : blocks) {
+    for (size_t row = 0; row < block.numRows(); ++row) {
+      IdTriple<0> permutedTriple{std::array<Id, 4>{
+          block(row, 0), block(row, 1), block(row, 2), block(row, 3)}};
+      bool isInsert =
+          block(row, AuxIndex::insertOrDeleteColumn) == AuxIndex::insertedId();
+      size_t mainBlockIndex = LocatedTriple::locateTripleInPermutation(
+          permutedTriple.permute(inverse), mainBlocks, keyOrder);
+      auto triple = permutedTriple.toPermutedTriple();
+      auto [it, inserted] = blockInfos_.try_emplace(mainBlockIndex);
+      auto& info = it->second;
+      if (inserted) {
+        info.firstTriple_ = triple;
+      }
+      info.lastTriple_ = triple;
+      ++info.numTriples_;
+      if (isInsert && info.graphsOfInsertedTriples_.has_value()) {
+        info.graphsOfInsertedTriples_ =
+            computeDistinctGraphs(ql::span<const Id>{&triple.graphId_, 1},
+                                  info.graphsOfInsertedTriples_.value());
+      }
+    }
+  }
+}
+
+// ____________________________________________________________________________
+const AuxLocatedTriples::BlockInfo* AuxLocatedTriples::blockInfo(
+    size_t mainBlockIndex) const {
+  auto it = blockInfos_.find(mainBlockIndex);
+  return it == blockInfos_.end() ? nullptr : &it->second;
+}
+
+// ____________________________________________________________________________
+size_t AuxLocatedTriples::numTriples(size_t mainBlockIndex) const {
+  const auto* info = blockInfo(mainBlockIndex);
+  return info == nullptr ? 0 : info->numTriples_;
+}
+
+// ____________________________________________________________________________
+std::shared_ptr<const AuxLocatedTriples::AuxBlock>
+AuxLocatedTriples::getAuxBlock(size_t auxBlockIndex) const {
+  {
+    auto cache = blockCache_.wlock();
+    if (auto cached = cache->tryGet(auxBlockIndex)) {
+      return cached.value();
+    }
+  }
+  // Read the single block. Note that this deliberately happens without holding
+  // the lock on the cache: two threads may then read the same block
+  // concurrently, which wastes a little work but is much better than
+  // serializing all reads.
+  const auto& permutation =
+      auxIndex_->getPermutation(permutation_, isInternal_);
+  ql::span<const CompressedBlockMetadata> singleBlock{
+      auxBlockMetadata_.data() + auxBlockIndex, 1};
+  Permutation::ScanSpecAndBlocks scanSpecAndBlocks{
+      ScanSpecification{std::nullopt, std::nullopt, std::nullopt},
+      BlockMetadataRanges{{singleBlock.begin(), singleBlock.end()}}};
+  std::vector<ColumnIndex> additionalColumns{ADDITIONAL_COLUMN_GRAPH_ID,
+                                             AuxIndex::insertOrDeleteColumn};
+  auto handle = std::make_shared<ad_utility::CancellationHandle<>>();
+  IdTable table = permutation.scan(scanSpecAndBlocks, additionalColumns, handle,
+                                   auxIndex_->emptyLocatedTriplesState());
+
+  auto block = std::make_shared<AuxBlock>();
+  block->reserve(table.numRows());
+  for (size_t row = 0; row < table.numRows(); ++row) {
+    block->push_back(
+        {IdTriple<0>{std::array<Id, 4>{table(row, 0), table(row, 1),
+                                       table(row, 2), table(row, 3)}},
+         table(row, AuxIndex::insertOrDeleteColumn) == AuxIndex::insertedId()});
+  }
+  blockCache_.wlock()->insert(auxBlockIndex, block);
+  return block;
+}
+
+// ____________________________________________________________________________
+std::vector<LocatedTriple> AuxLocatedTriples::getTriplesForBlock(
+    size_t mainBlockIndex) const {
+  std::vector<LocatedTriple> result;
+  const auto* info = blockInfo(mainBlockIndex);
+  if (info == nullptr) {
+    return result;
+  }
+  result.reserve(info->numTriples_);
+  auto [first, last] = auxBlockRange(mainBlockIndex);
+  const auto& mainBlocks = *mainBlockMetadata_;
+  // The blocks of the auxiliary index that were selected via the block metadata
+  // may also contain triples that belong to a *different* block of the main
+  // index, so each triple has to be attributed exactly. Note that the triples
+  // of the auxiliary index are already in the order of the permutation, whereas
+  // `locateTripleInPermutation` expects the order `(S, P, O, G)`, so the
+  // permutation has to be undone first.
+  auto inverseKeyOrder = Permutation::toKeyOrder(permutation_).inverse();
+  for (size_t i = first; i < last; ++i) {
+    auto auxBlock = getAuxBlock(i);
+    for (const auto& auxTriple : *auxBlock) {
+      auto blockIndex = LocatedTriple::locateTripleInPermutation(
+          auxTriple.triple_.permute(inverseKeyOrder), mainBlocks,
+          Permutation::toKeyOrder(permutation_));
+      if (blockIndex == mainBlockIndex) {
+        result.push_back(
+            {mainBlockIndex, auxTriple.triple_, auxTriple.insertOrDelete_});
+      }
+    }
+  }
+  AD_CORRECTNESS_CHECK(ql::ranges::is_sorted(result));
+  AD_CORRECTNESS_CHECK(result.size() == info->numTriples_);
+  return result;
+}

--- a/src/index/AuxLocatedTriples.h
+++ b/src/index/AuxLocatedTriples.h
@@ -1,0 +1,140 @@
+// Copyright 2026 The QLever Authors, in particular:
+//
+// 2026 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+//
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#ifndef QLEVER_SRC_INDEX_AUXLOCATEDTRIPLES_H
+#define QLEVER_SRC_INDEX_AUXLOCATEDTRIPLES_H
+
+#include <memory>
+#include <vector>
+
+#include "index/AuxIndex.h"
+#include "index/LocatedTriples.h"
+#include "util/HashMap.h"
+#include "util/LruCache.h"
+#include "util/Synchronized.h"
+
+// The triples of one permutation of an auxiliary index (see
+// `index/AuxIndex.h`), presented as located triples of the corresponding
+// permutation of the main index, so that a scan of the main index can merge
+// them in exactly like it merges in the delta triples that are held in RAM (see
+// `LocatedTriplesPerBlock`, which owns an instance of this class).
+//
+// The triples are *not* held in RAM. Instead, they are read from the auxiliary
+// index on demand, one block of the main index at a time. This works well
+// because both permutations are sorted in the same order, so the triples that
+// belong to a block of the main index are a contiguous range of the auxiliary
+// permutation, and that range is found from the block metadata of the two
+// permutations alone (see `auxBlockRange`). To avoid decompressing the same
+// block of the auxiliary index once for each block of the main index that it
+// overlaps, the most recently used blocks are cached.
+class AuxLocatedTriples {
+ public:
+  // A single triple of the auxiliary index, in the order of its permutation.
+  struct AuxTriple {
+    IdTriple<0> triple_;
+    bool insertOrDelete_;
+  };
+  using AuxBlock = std::vector<AuxTriple>;
+
+  // What the triples of the auxiliary index contribute to one block of the main
+  // index. This is computed once, by a single sequential pass over the
+  // auxiliary permutation (see the constructor), because the augmented block
+  // metadata of the main permutation is recomputed after every update and needs
+  // the *exact* bounds: the blocks of the augmented metadata must not overlap
+  // (see `CompressedBlockMetadata::checkInvariantsForSortedBlocks`), and the
+  // bounds of the *blocks* of the auxiliary index are too coarse for that,
+  // because one of them can span many blocks of the main index.
+  //
+  // NOTE: This is the only part of the auxiliary index that is held in RAM, and
+  // it is one small entry per block of the main index that the auxiliary index
+  // has triples for -- not per triple.
+  struct BlockInfo {
+    CompressedBlockMetadata::PermutedTriple firstTriple_;
+    CompressedBlockMetadata::PermutedTriple lastTriple_;
+    size_t numTriples_ = 0;
+    // The graphs of the *inserted* triples, or `std::nullopt` if there are too
+    // many of them (see `computeDistinctGraphs`).
+    std::optional<std::vector<Id>> graphsOfInsertedTriples_{std::vector<Id>{}};
+  };
+
+ private:
+  using BlockMetadata = std::vector<CompressedBlockMetadata>;
+
+  std::shared_ptr<const AuxIndex> auxIndex_;
+  Permutation::Enum permutation_;
+  bool isInternal_;
+  // The block metadata of the corresponding permutation of the *main* index,
+  // which defines to which block of the main index a triple belongs.
+  std::shared_ptr<const BlockMetadata> mainBlockMetadata_;
+  // The block metadata of the permutation of the auxiliary index.
+  ql::span<const CompressedBlockMetadata> auxBlockMetadata_;
+
+  ad_utility::HashMap<size_t, BlockInfo> blockInfos_;
+
+  // The cache for the decompressed blocks of the auxiliary index, see the class
+  // comment. It is `mutable` because reading triples does not change the
+  // observable state of this class.
+  static constexpr size_t cacheSize_ = 32;
+  mutable ad_utility::Synchronized<
+      ad_utility::util::LRUCache<size_t, std::shared_ptr<const AuxBlock>>>
+      blockCache_{cacheSize_};
+
+ public:
+  // Construct from the given permutation of `auxIndex` and the block metadata
+  // of the corresponding permutation of the main index.
+  AuxLocatedTriples(std::shared_ptr<const AuxIndex> auxIndex,
+                    Permutation::Enum permutation, bool isInternal,
+                    std::shared_ptr<const BlockMetadata> mainBlockMetadata);
+
+  // Return true iff this permutation of the auxiliary index has no triples at
+  // all.
+  bool isEmpty() const { return auxBlockMetadata_.empty(); }
+
+  // Return true iff there are triples that belong to the block of the main
+  // index with the given index.
+  bool containsTriples(size_t mainBlockIndex) const {
+    return blockInfos_.contains(mainBlockIndex);
+  }
+
+  // The number of triples that belong to the block of the main index with the
+  // given index.
+  size_t numTriples(size_t mainBlockIndex) const;
+
+  // The triples that belong to the block of the main index with the given
+  // index, sorted, and with their `blockIndex_` set to `mainBlockIndex`. This
+  // reads the relevant blocks of the auxiliary index (possibly from the cache).
+  std::vector<LocatedTriple> getTriplesForBlock(size_t mainBlockIndex) const;
+
+  // The exact bounds of the triples that belong to the block of the main index
+  // with the given index, and the graphs of those of them that are insertions
+  // (`std::nullopt` means that there are too many graphs to keep track of).
+  // Used to make the augmented block metadata of the main permutation account
+  // for the triples of the auxiliary index, see
+  // `LocatedTriplesPerBlock::updateAugmentedMetadata`. Return `std::nullopt` if
+  // there are no such triples.
+  const BlockInfo* blockInfo(size_t mainBlockIndex) const;
+
+ private:
+  // The range `[first, last)` of blocks of the auxiliary index that may contain
+  // triples that belong to the block of the main index with the given index.
+  // Note that `mainBlockIndex == mainBlockMetadata_->size()` is valid and
+  // denotes the (synthetic) block that holds all triples that are larger than
+  // all triples of the main permutation.
+  std::pair<size_t, size_t> auxBlockRange(size_t mainBlockIndex) const;
+
+  // The triples of the block of the auxiliary index with the given index, read
+  // from disk or taken from the cache.
+  std::shared_ptr<const AuxBlock> getAuxBlock(size_t auxBlockIndex) const;
+
+  // Compute `blockInfos_` by a single sequential pass over the permutation of
+  // the auxiliary index. Called by the constructor.
+  void computeBlockInfos();
+};
+
+#endif  // QLEVER_SRC_INDEX_AUXLOCATEDTRIPLES_H

--- a/src/index/AuxVocabulary.cpp
+++ b/src/index/AuxVocabulary.cpp
@@ -1,0 +1,188 @@
+// Copyright 2026 The QLever Authors, in particular:
+//
+// 2026 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+//
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#include "index/AuxVocabulary.h"
+
+#include <absl/strings/str_cat.h>
+
+#include "backports/algorithm.h"
+#include "global/FileSuffixConstants.h"
+#include "index/vocabulary/PolymorphicVocabulary.h"
+#include "util/Exception.h"
+#include "util/FilesystemHelpers.h"
+#include "util/Serializer/FileSerializer.h"
+#include "util/Serializer/SerializeArrayOrTuple.h"
+#include "util/Serializer/SerializeVector.h"
+
+// The name of the file that stores the positions in the main vocabulary and the
+// offsets of the sub-vocabularies.
+static std::string positionsFilename(const std::string& basename) {
+  return absl::StrCat(basename, AUX_VOCAB_POSITIONS_SUFFIX);
+}
+
+// ____________________________________________________________________________
+std::vector<std::string> AuxVocabulary::fileNames(const std::string& basename) {
+  std::vector<std::string> result;
+  for (const auto& file :
+       qlever::util::filesWithBaseNameAndSuffix(basename, VOCAB_SUFFIX)) {
+    result.push_back(file.string());
+  }
+  return result;
+}
+
+// ____________________________________________________________________________
+void AuxVocabulary::open(const std::string& basename,
+                         ad_utility::VocabularyType type,
+                         const std::string& language,
+                         const std::string& country, bool ignorePunctuation) {
+  vocabulary_.resetToType(type);
+  vocabulary_.setLocale(language, country, ignorePunctuation);
+  vocabulary_.readFromFile(absl::StrCat(basename, VOCAB_SUFFIX));
+  marker_ =
+      VocabIndexMarker{PolymorphicVocabulary::numberOfSubVocabularies(type)};
+
+  ad_utility::serialization::FileReadSerializer reader{
+      positionsFilename(basename)};
+  reader >> positionsInMainVocab_;
+  reader >> markerOffsets_;
+  AD_CORRECTNESS_CHECK(
+      positionsInMainVocab_.size() == vocabulary_.size(),
+      "The number of positions in the main vocabulary does not match the "
+      "number of words of the auxiliary vocabulary");
+  AD_CORRECTNESS_CHECK(ql::ranges::is_sorted(positionsInMainVocab_),
+                       "The positions in the main vocabulary must be sorted");
+}
+
+// ____________________________________________________________________________
+std::pair<AuxVocabIndex, AuxVocabIndex> AuxVocabulary::getPositionOfWord(
+    std::string_view word) const {
+  return vocabulary_.getPositionOfWord(word);
+}
+
+// ____________________________________________________________________________
+std::optional<AuxVocabIndex> AuxVocabulary::getId(std::string_view word) const {
+  auto [lower, upper] = getPositionOfWord(word);
+  if (lower == upper) {
+    return std::nullopt;
+  }
+  AD_CORRECTNESS_CHECK(upper.get() - lower.get() == 1);
+  return lower;
+}
+
+// ____________________________________________________________________________
+uint64_t AuxVocabulary::numWordsSmallerThan(std::string_view word) const {
+  // `getPositionOfWord` returns the position within the sub-vocabulary that
+  // `word` belongs to (marker-encoded), so it has to be turned into an offset,
+  // which is dense and ordered across all sub-vocabularies. Note that the
+  // returned position may be the end of that sub-vocabulary, for which there is
+  // no word and hence no `offsetOf`; in that case the offset is the start of
+  // the next sub-vocabulary.
+  auto lower = getPositionOfWord(word).first;
+  auto marker = marker_.getMarker(lower.get());
+  uint64_t indexInSubVocab = marker_.getIndexWithoutMarker(lower.get());
+  return markerOffsets_.at(marker) + indexInSubVocab;
+}
+
+// ____________________________________________________________________________
+AuxVocabulary::WordWriter::WordWriter(const RdfsVocabulary& mainVocab,
+                                      const std::string& basename,
+                                      ad_utility::VocabularyType type)
+    : mainVocab_{mainVocab},
+      basename_{basename},
+      marker_{VocabIndexMarker{
+          PolymorphicVocabulary::numberOfSubVocabularies(type)}} {
+  // The `PolymorphicVocabulary` can create a writer for an arbitrary type
+  // without holding a vocabulary of that type, which is what we need here.
+  wordWriter_ = PolymorphicVocabulary::makeDiskWriterPtr(
+      absl::StrCat(basename, VOCAB_SUFFIX), type);
+}
+
+// ____________________________________________________________________________
+AuxVocabulary::WordWriter::~WordWriter() {
+  if (!finishWasCalled_ && wordWriter_ != nullptr) {
+    // The `WordWriterBase` destructor throws if `finish` was not called, which
+    // would be a bug in our code, but throwing from a destructor during stack
+    // unwinding must be avoided. `finish` of the underlying writer is safe to
+    // call here, we only skip writing the positions file (which then simply
+    // does not exist, so the incomplete auxiliary index cannot be opened).
+    wordWriter_->finish();
+  }
+}
+
+// ____________________________________________________________________________
+AuxVocabIndex AuxVocabulary::WordWriter::operator()(std::string_view word) {
+  AD_CONTRACT_CHECK(!finishWasCalled_);
+  const auto& comparator = mainVocab_.getCaseComparator();
+
+  // The words have to arrive grouped by their sub-vocabulary, in ascending
+  // order of the markers, and ascending within each group.
+  auto [lower, upper] = mainVocab_.getPositionOfWord(word);
+  AD_CONTRACT_CHECK(lower == upper,
+                    "A word that is contained in the vocabulary of the main "
+                    "index must not be added to an auxiliary vocabulary");
+  auto position = Id::makeFromVocabIndex(lower);
+  uint8_t marker = marker_.getMarker(position);
+  AD_CONTRACT_CHECK(
+      marker >= currentMarker_,
+      "The words of an auxiliary vocabulary have to be pushed grouped by their "
+      "sub-vocabulary, in ascending order of the markers of those "
+      "sub-vocabularies");
+  if (marker != currentMarker_) {
+    // A new sub-vocabulary starts at the current offset. Note that the
+    // sub-vocabularies in between (if any) are empty, so they get the same
+    // offset.
+    for (uint8_t m = currentMarker_ + 1; m <= marker; ++m) {
+      markerOffsets_.at(m) = positionsInMainVocab_.size();
+    }
+    currentMarker_ = marker;
+    previousWord_.reset();
+  } else if (previousWord_.has_value()) {
+    AD_CONTRACT_CHECK(
+        comparator(previousWord_.value(), word,
+                   RdfsVocabulary::SortLevel::TOTAL),
+        "The words of an auxiliary vocabulary have to be pushed in strictly "
+        "ascending order within each sub-vocabulary");
+  }
+  previousWord_ = std::string{word};
+  positionsInMainVocab_.push_back(position.getBits());
+
+  uint64_t index = (*wordWriter_)(word, mainVocab_.shouldBeExternalized(word));
+  // The index that the underlying (possibly split) vocabulary assigns has to
+  // agree with the offset that we computed from the position in the main
+  // vocabulary, else the two vocabularies split their words differently.
+  AD_CORRECTNESS_CHECK(
+      marker_.getMarker(index) == marker,
+      "The auxiliary vocabulary and the vocabulary of the main index assign a "
+      "word to different sub-vocabularies. They have to use the same "
+      "vocabulary type");
+  AD_CORRECTNESS_CHECK(
+      markerOffsets_.at(marker) + marker_.getIndexWithoutMarker(index) + 1 ==
+          positionsInMainVocab_.size(),
+      "The indices assigned by the word writer of an auxiliary vocabulary must "
+      "be consecutive within each sub-vocabulary");
+  return AuxVocabIndex::make(index);
+}
+
+// ____________________________________________________________________________
+void AuxVocabulary::WordWriter::finish() {
+  AD_CONTRACT_CHECK(!finishWasCalled_);
+  finishWasCalled_ = true;
+  // All sub-vocabularies after the last one that received a word are empty and
+  // start at the end.
+  for (uint8_t m = currentMarker_ + 1; m < marker_.numMarkers(); ++m) {
+    markerOffsets_.at(m) = positionsInMainVocab_.size();
+  }
+  wordWriter_->finish();
+  AD_CORRECTNESS_CHECK(ql::ranges::is_sorted(positionsInMainVocab_),
+                       "The positions in the main vocabulary must be sorted");
+  ad_utility::serialization::FileWriteSerializer writer{
+      positionsFilename(basename_)};
+  writer << positionsInMainVocab_;
+  writer << markerOffsets_;
+}

--- a/src/index/AuxVocabulary.h
+++ b/src/index/AuxVocabulary.h
@@ -1,0 +1,216 @@
+// Copyright 2026 The QLever Authors, in particular:
+//
+// 2026 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+//
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#ifndef QLEVER_SRC_INDEX_AUXVOCABULARY_H
+#define QLEVER_SRC_INDEX_AUXVOCABULARY_H
+
+#include <array>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "global/Id.h"
+#include "global/ValueIdComparators.h"
+#include "global/VocabIndexMarker.h"
+#include "index/Vocabulary.h"
+#include "index/vocabulary/VocabularyType.h"
+
+// The vocabulary of an auxiliary index (see `index/AuxIndex.h`). It stores
+// exactly those words that are used by the triples of that auxiliary index and
+// that are not part of the vocabulary of the main index. The words are stored
+// on disk, and the vocabulary uses the same `VocabularyType` as the main index,
+// so in particular it splits its words over the same sub-vocabularies (see
+// `SplitVocabulary` and `VocabIndexMarker`) as the main vocabulary and stores
+// the same precomputed data (for example the `GeometryInfo` of WKT literals).
+//
+// The `Id`s of the words of an `AuxVocabulary` have their own `Datatype`
+// (`Datatype::AuxVocabIndex`). Because the datatype bits are the most
+// significant bits of an `Id`, all of these `Id`s are greater than all `Id`s of
+// the main vocabulary when compared bitwise. This is what makes the auxiliary
+// index mergeable into a scan of the main index (both are sorted bitwise), but
+// it means that the bitwise order is not the order of the string values.
+//
+// For the semantically correct comparison, an `AuxVocabulary` additionally
+// holds an in-RAM array that stores, for each of its words, the position at
+// which that word would be sorted into the vocabulary of the main index (see
+// `positionsInMainVocab()`). A semantic comparison of a word from the auxiliary
+// vocabulary with a word from the main vocabulary therefore is a single random
+// access into RAM, see `valueIdComparators::AuxVocabOrdering`.
+//
+// NOTE: That array is indexed by the *offset* of a word, not by its `Id`. The
+// two differ when the vocabulary is split, because then the `Id`s of a
+// sub-vocabulary with a marker greater than zero start at a large value (the
+// marker sits in the highest bits of the payload). The offset is the position
+// of a word in the concatenation of all sub-vocabularies in the order of their
+// markers, so it is dense, and it is ascending in the (bitwise, and hence also
+// semantic) order of the `Id`s. That is exactly what makes the array of
+// positions ascending as well, which is required for the reverse lookup in
+// `numWordsSmallerThanMainVocabPosition`.
+class AuxVocabulary {
+ public:
+  // The vocabulary implementation. This is the same as `RdfsVocabulary` (in
+  // particular it is a `PolymorphicVocabulary`, so the concrete implementation
+  // can be chosen at runtime), only the index type differs.
+  using Vocab = Vocabulary<detail::UnderlyingVocabRdfsVocabulary,
+                           TripleComponentComparator, AuxVocabIndex>;
+  using AccessReturnType = typename Vocab::AccessReturnType;
+
+ private:
+  Vocab vocabulary_;
+  VocabIndexMarker marker_;
+  // For each word of `vocabulary_`, indexed by the word's offset (see the class
+  // comment), the raw bits of the `Id` of the first word of the main vocabulary
+  // that is greater than that word. Note that all words of an `AuxVocabulary`
+  // are absent from the main vocabulary, so there is no need to store an upper
+  // bound as well. The entries of this array are ascending.
+  std::vector<uint64_t> positionsInMainVocab_;
+  // For each marker, the offset at which the words of the corresponding
+  // sub-vocabulary start, that is, the exclusive prefix sums of the numbers of
+  // words of the sub-vocabularies.
+  std::array<uint64_t, VocabIndexMarker::maxNumMarkers> markerOffsets_{};
+
+ public:
+  // Return the file names of the auxiliary vocabulary with the given base name.
+  // Note that which of them exist depends on the `VocabularyType`, see
+  // `PolymorphicVocabulary`.
+  static std::vector<std::string> fileNames(const std::string& basename);
+
+  AuxVocabulary() = default;
+  AuxVocabulary(const AuxVocabulary&) = delete;
+  AuxVocabulary& operator=(const AuxVocabulary&) = delete;
+  AuxVocabulary(AuxVocabulary&&) noexcept = default;
+  AuxVocabulary& operator=(AuxVocabulary&&) noexcept = default;
+
+  // Read the auxiliary vocabulary that was written to `basename` by a
+  // `WordWriter` (see below). The `type` must be the same as the one that was
+  // used for writing, and the locale must be the one of the main vocabulary,
+  // else the order of the words is inconsistent with the main vocabulary.
+  void open(const std::string& basename, ad_utility::VocabularyType type,
+            const std::string& language, const std::string& country,
+            bool ignorePunctuation);
+
+  // The total number of words, summed over all sub-vocabularies. NOTE: This is
+  // *not* an upper bound for the `Id`s of this vocabulary if it is split, see
+  // the class comment.
+  size_t numWords() const { return positionsInMainVocab_.size(); }
+
+  // The word with the given index.
+  AccessReturnType operator[](AuxVocabIndex index) const {
+    return vocabulary_[index];
+  }
+
+  // The offset of the word with the given index, see the class comment.
+  uint64_t offsetOf(AuxVocabIndex index) const {
+    auto rawIndex = index.get();
+    uint64_t offset = markerOffsets_.at(marker_.getMarker(rawIndex)) +
+                      marker_.getIndexWithoutMarker(rawIndex);
+    AD_CORRECTNESS_CHECK(offset < positionsInMainVocab_.size());
+    return offset;
+  }
+
+  // The raw bits of the `Id` of the first word of the main vocabulary that is
+  // greater than the word with the given `index`.
+  uint64_t positionInMainVocab(AuxVocabIndex index) const {
+    return positionsInMainVocab_[offsetOf(index)];
+  }
+
+  // The whole array of positions, see the class comment.
+  ql::span<const uint64_t> positionsInMainVocab() const {
+    return positionsInMainVocab_;
+  }
+
+  // The information that is required to compare `Id`s of type
+  // `Datatype::AuxVocabIndex` semantically, that is, by the string values that
+  // they represent.
+  valueIdComparators::AuxVocabOrdering ordering() const {
+    return valueIdComparators::AuxVocabOrdering{positionsInMainVocab_,
+                                                markerOffsets_, marker_};
+  }
+
+  // Return the offset (see the class comment) of the first word of this
+  // vocabulary that is not smaller than the word of the main vocabulary with
+  // the given `Id`. This is the reverse direction of `positionInMainVocab` and
+  // is possible in logarithmic time because the positions are ascending. It is
+  // required to translate a bound in the main vocabulary into a bound in the
+  // auxiliary vocabulary.
+  uint64_t numWordsSmallerThanMainVocabPosition(Id mainVocabId) const {
+    return ordering().numWordsSmallerThan(mainVocabId);
+  }
+
+  // Look up `word`. Return its index if it is contained in this vocabulary, and
+  // `std::nullopt` otherwise.
+  std::optional<AuxVocabIndex> getId(std::string_view word) const;
+
+  // The position of `word` in this vocabulary. The `first` element is the index
+  // of the first word that is greater than or equal to `word`; the `second`
+  // element is `first + 1` if the word is contained, and equal to `first`
+  // otherwise. Note that the lookup happens in the sub-vocabulary that `word`
+  // belongs to, so both are marker-encoded. This mirrors
+  // `Vocabulary::getPositionOfWord`.
+  std::pair<AuxVocabIndex, AuxVocabIndex> getPositionOfWord(
+      std::string_view word) const;
+
+  // The offset (see the class comment) of the first word of this vocabulary
+  // that is not smaller than `word`. This is the value that the semantic
+  // comparison of a local vocab entry against a word of this vocabulary needs,
+  // see `LocalVocabEntry::numSmallerAuxVocabWords`.
+  uint64_t numWordsSmallerThan(std::string_view word) const;
+
+  // Direct access to the underlying vocabulary, for example for the
+  // `GeometryInfo` of a WKT literal.
+  const Vocab& vocab() const { return vocabulary_; }
+
+  // Writer for an `AuxVocabulary`. The words have to be pushed grouped by the
+  // sub-vocabulary that they belong to, in ascending order of the markers of
+  // those sub-vocabularies, and within each group in ascending order with
+  // respect to the comparator of the main vocabulary at the `TOTAL` level. None
+  // of the words may be contained in the main vocabulary. All of this is
+  // checked.
+  //
+  // The writer computes the positions in the main vocabulary itself, via one
+  // binary search per word.
+  class WordWriter {
+   private:
+    const RdfsVocabulary& mainVocab_;
+    std::string basename_;
+    VocabIndexMarker marker_;
+    std::unique_ptr<WordWriterBase> wordWriter_;
+    std::vector<uint64_t> positionsInMainVocab_;
+    std::array<uint64_t, VocabIndexMarker::maxNumMarkers> markerOffsets_{};
+    uint8_t currentMarker_ = 0;
+    std::optional<std::string> previousWord_;
+    bool finishWasCalled_ = false;
+
+   public:
+    // Create a writer that writes the vocabulary of the given `type` to files
+    // starting with `basename`. The `type` has to be the type of the main
+    // vocabulary, such that the two split their words in the same way. The
+    // `mainVocab` is required to compute the positions and to check the
+    // precondition that no word of the auxiliary vocabulary is contained in the
+    // main vocabulary.
+    WordWriter(const RdfsVocabulary& mainVocab, const std::string& basename,
+               ad_utility::VocabularyType type);
+    ~WordWriter();
+    WordWriter(const WordWriter&) = delete;
+    WordWriter& operator=(const WordWriter&) = delete;
+
+    // Add `word` and return the `Id` that was assigned to it.
+    AuxVocabIndex operator()(std::string_view word);
+
+    // Signal that the last word has been pushed and write the positions to
+    // disk. Must be called exactly once.
+    void finish();
+
+    // The number of words that have been pushed so far.
+    size_t numWords() const { return positionsInMainVocab_.size(); }
+  };
+};
+
+#endif  // QLEVER_SRC_INDEX_AUXVOCABULARY_H

--- a/src/index/CMakeLists.txt
+++ b/src/index/CMakeLists.txt
@@ -21,7 +21,8 @@ add_subdirectory(vocabulary)
 add_library(index
         Index.cpp IndexImpl.cpp IndexImpl.Text.cpp EncodedIriManager.cpp
         IndexMetaData.cpp MetaDataHandler.cpp
-        Vocabulary.cpp ../parser/RdfParser.cpp
+        Vocabulary.cpp AuxVocabulary.cpp AuxIndex.cpp AuxIndexBuilder.cpp AuxLocatedTriples.cpp
+        ../parser/RdfParser.cpp
         LocatedTriples.cpp Permutation.cpp TextMetaData.cpp
         DocsDB.cpp FTSAlgorithms.cpp
         PrefixHeuristic.cpp CompressedRelation.cpp

--- a/src/index/CompressedExternalIdTableSorterInstantiations.cpp
+++ b/src/index/CompressedExternalIdTableSorterInstantiations.cpp
@@ -28,6 +28,13 @@ namespace ad_utility {
 template class CompressedExternalIdTableSorter<SortByPSONoGraphColumn, 3>;
 template class CompressedExternalIdTableSorter<SortByOSP,
                                                NumColumnsIndexBuilding + 1>;
+// The permutations of an auxiliary index have one column more than those of the
+// main index (the column that stores whether a triple is inserted or deleted),
+// see `AuxIndex`.
+template class CompressedExternalIdTableSorter<SortBySPO,
+                                               NumColumnsIndexBuilding + 1>;
+template class CompressedExternalIdTableSorter<SortByPSO,
+                                               NumColumnsIndexBuilding + 1>;
 template class CompressedExternalIdTableSorter<SortBySPO,
                                                NumColumnsIndexBuilding>;
 template class CompressedExternalIdTableSorter<SortByOSP,

--- a/src/index/DeltaTriples.cpp
+++ b/src/index/DeltaTriples.cpp
@@ -19,6 +19,7 @@
 #include "backports/filesystem.h"
 #include "engine/ExecuteUpdate.h"
 #include "engine/ExportQueryExecutionTrees.h"
+#include "index/AuxLocatedTriples.h"
 #include "index/ExportIds.h"
 #include "index/Index.h"
 #include "index/IndexImpl.h"
@@ -601,6 +602,34 @@ DeltaTriplesManager::getCurrentLocatedTriplesSharedStateWithVocab() const {
 }
 
 // _____________________________________________________________________________
+uint64_t DeltaTriples::auxIndexGenerationOfIndex() const {
+  const auto* auxIndex = index_.auxIndex();
+  return auxIndex == nullptr ? ad_utility::detail::noAuxIndexGeneration
+                             : auxIndex->generation();
+}
+
+// _____________________________________________________________________________
+template <bool isInternal>
+void DeltaTriples::setAuxIndexImpl(
+    const std::shared_ptr<const AuxIndex>& auxIndex) {
+  for (auto permutation : Permutation::all<isInternal>()) {
+    auto& locatedTriples =
+        locatedTriples_->getLocatedTriplesForPermutation<isInternal>(
+            permutation);
+    locatedTriples.setAuxLocatedTriples(
+        std::make_shared<const AuxLocatedTriples>(
+            auxIndex, permutation, isInternal,
+            locatedTriples.originalMetadata()));
+  }
+}
+
+// _____________________________________________________________________________
+void DeltaTriples::setAuxIndex(std::shared_ptr<const AuxIndex> auxIndex) {
+  setAuxIndexImpl<false>(auxIndex);
+  setAuxIndexImpl<true>(auxIndex);
+}
+
+// _____________________________________________________________________________
 void DeltaTriples::setOriginalMetadata(
     Permutation::Enum permutation,
     std::shared_ptr<const std::vector<CompressedBlockMetadata>> metadata,
@@ -664,7 +693,8 @@ void DeltaTriples::writeToDisk() const {
   ad_utility::serializeIds(
       tempPath, localVocab_,
       std::array{toRange(triplesSetsNormal_.triplesDeleted_),
-                 toRange(triplesSetsNormal_.triplesInserted_)});
+                 toRange(triplesSetsNormal_.triplesInserted_)},
+      auxIndexGenerationOfIndex());
   ql::filesystem::rename(tempPath, filenameForPersisting_.value());
 }
 
@@ -674,8 +704,8 @@ void DeltaTriples::readFromDisk() {
     return;
   }
   AD_CONTRACT_CHECK(localVocab_.empty());
-  auto [vocab, idRanges] =
-      ad_utility::deserializeIds(filenameForPersisting_.value(), index_);
+  auto [vocab, idRanges] = ad_utility::deserializeIds(
+      filenameForPersisting_.value(), index_, auxIndexGenerationOfIndex());
   if (idRanges.empty()) {
     return;
   }
@@ -757,10 +787,35 @@ void DeltaTriples::addFromSnapshotDiff(
     const qlever::indexRebuilder::IndexRebuildMapping& idMapping,
     CancellationHandle cancellationHandle,
     ad_utility::timer::TimeTracer& tracer) {
+  addFromSnapshotDiff(
+      oldState, newState,
+      [this, &idMapping](Id id) -> std::optional<Id> {
+        remapId(idMapping, id, localVocab_, index_);
+        return id;
+      },
+      std::move(cancellationHandle), tracer);
+}
+
+// ____________________________________________________________________________
+void DeltaTriples::addFromSnapshotDiff(
+    const LocatedTriplesState& oldState, const LocatedTriplesState& newState,
+    const std::function<std::optional<Id>(Id)>& mapId,
+    CancellationHandle cancellationHandle,
+    ad_utility::timer::TimeTracer& tracer) {
   tracer.beginTrace("computeLocatedTriplesDiff");
   auto difference = computeLocatedTriplesDiff(oldState, newState);
-  difference.remapIds([this, &idMapping](Id& id) {
-    remapId(idMapping, id, localVocab_, index_);
+  difference.remapIds([this, &mapId](Id& id) {
+    if (auto mapped = mapId(id); mapped.has_value()) {
+      id = mapped.value();
+      return;
+    }
+    // The `Id` is a local vocab entry that the mapping does not know, so it
+    // still points to an entry that is anchored to the OLD index. Insert a
+    // re-anchored copy into the local vocabulary of this `DeltaTriples`, see
+    // the documentation of this function.
+    AD_CORRECTNESS_CHECK(id.getDatatype() == Datatype::LocalVocabIndex);
+    id = Id::makeFromLocalVocabIndex(localVocab_.getIndexAndAddIfNotContained(
+        LocalVocabEntry{id.getLocalVocabIndex()->asLiteralOrIri(), index_}));
   });
   tracer.endTrace("computeLocatedTriplesDiff");
   tracer.beginTrace("insertDiffedTriples");

--- a/src/index/DeltaTriples.h
+++ b/src/index/DeltaTriples.h
@@ -15,6 +15,7 @@
 #include "backports/three_way_comparison.h"
 #include "engine/UpdateMetadata.h"
 #include "global/IdTriple.h"
+#include "index/AuxIndex.h"
 #include "index/Index.h"
 #include "index/IndexBuilderTypes.h"
 #include "index/IndexRebuilderTypes.h"
@@ -271,6 +272,12 @@ class DeltaTriples {
   // false otherwise.
   bool persists() const;
 
+  // The generation of the auxiliary index of the index that these delta triples
+  // belong to, or `ad_utility::detail::noAuxIndexGeneration` if it has none.
+  // The persisted delta triples are stamped with it, because their `Id`s may
+  // refer to the vocabulary of that generation.
+  uint64_t auxIndexGenerationOfIndex() const;
+
   // Write the delta triples to disk to persist them between restarts.
   void writeToDisk() const;
 
@@ -288,6 +295,12 @@ class DeltaTriples {
   // evaluation.
   LocatedTriplesSharedState getLocatedTriplesSharedStateReference() const;
 
+  // Make all permutations merge in the triples of the given auxiliary index,
+  // see `LocatedTriplesPerBlock::setAuxLocatedTriples`. Has to be called after
+  // `setOriginalMetadata` was called for all permutations, and
+  // `updateAugmentedMetadata` has to be called afterwards.
+  void setAuxIndex(std::shared_ptr<const AuxIndex> auxIndex);
+
   // Register the original `metadata` for the given `permutation`. This has to
   // be called before any updates are processed. If `setInternalMetadata` is
   // true, this will set the metadata to the internal permutations instead.
@@ -296,6 +309,12 @@ class DeltaTriples {
       std::shared_ptr<const std::vector<CompressedBlockMetadata>> metadata,
       bool setInternalMetadata);
 
+  // Implementation of `setAuxIndex` for the external resp. the internal
+  // permutations.
+  template <bool isInternal>
+  void setAuxIndexImpl(const std::shared_ptr<const AuxIndex>& auxIndex);
+
+ public:
   // Consolidate the located triples in all permutations. Must be called after a
   // batch of insertTriples/deleteTriples, before any query access or metadata
   // update.
@@ -323,6 +342,19 @@ class DeltaTriples {
       const qlever::indexRebuilder::IndexRebuildMapping& idMapping,
       CancellationHandle cancellationHandle,
       ad_utility::timer::TimeTracer& tracer);
+
+  // Same as above, but with an explicit function that maps a single `Id`
+  // instead of the mapping of a full index rebuild. This is used for the build
+  // of an auxiliary index, which has its own (much smaller) mapping, see
+  // `qlever::AuxIndexIdMapping::map`. If `mapId` returns `std::nullopt`, the
+  // `Id` must be a local vocab entry that the mapping does not know (because it
+  // was created after the mapping was); a copy of it that is anchored to the
+  // index of *this* `DeltaTriples` is then added to its local vocabulary.
+  void addFromSnapshotDiff(const LocatedTriplesState& oldState,
+                           const LocatedTriplesState& newState,
+                           const std::function<std::optional<Id>(Id)>& mapId,
+                           CancellationHandle cancellationHandle,
+                           ad_utility::timer::TimeTracer& tracer);
 
  private:
   // Remap the `Id` from the old index to the new index using the given

--- a/src/index/ExportIds.cpp
+++ b/src/index/ExportIds.cpp
@@ -89,6 +89,7 @@ std::optional<Literal> idToLiteral(const IndexImpl& index, Id id,
                                 onlyReturnLiteralsWithXsdString);
     case VocabIndex:
     case LocalVocabIndex:
+    case AuxVocabIndex:
       return handleIriOrLiteral(
           getLiteralOrIriFromVocabIndex(index, id, localVocab),
           onlyReturnLiteralsWithXsdString);
@@ -155,6 +156,7 @@ std::optional<LiteralOrIri> idToLiteralOrIri(const IndexImpl& index, Id id,
       return getLiteralOrIriFromWordVocabIndex(index, id);
     case VocabIndex:
     case LocalVocabIndex:
+    case AuxVocabIndex:
     case EncodedVal:
       return ql::exportIds::getLiteralOrIriFromVocabIndex(index, id,
                                                           localVocab);
@@ -203,6 +205,15 @@ LiteralOrIri getLiteralOrIriFromVocabIndex(const IndexImpl& index, Id id,
       static_assert(ad_utility::SameAsAny<decltype(getEntity()), std::string,
                                           std::string_view>);
       return LiteralOrIri::fromStringRepresentation(std::string(getEntity()));
+    }
+    case Datatype::AuxVocabIndex: {
+      const auto* auxVocab = index.auxVocab();
+      AD_CORRECTNESS_CHECK(
+          auxVocab != nullptr,
+          "Encountered an `Id` of an auxiliary vocabulary, but "
+          "the index has no auxiliary index");
+      return LiteralOrIri::fromStringRepresentation(
+          std::string((*auxVocab)[id.getAuxVocabIndex()]));
     }
     case Datatype::EncodedVal:
       return encodedIdToLiteralOrIri(id, index);

--- a/src/index/ExportIds.h
+++ b/src/index/ExportIds.h
@@ -189,6 +189,7 @@ std::optional<std::pair<std::string, const char*>> idToStringAndType(
     }
     case VocabIndex:
     case LocalVocabIndex:
+    case AuxVocabIndex:
       return formatLiteralOrIri(
           getLiteralOrIriFromVocabIndex(index.getImpl(), id, localVocab));
     case EncodedVal:

--- a/src/index/ExternalSortFunctors.h
+++ b/src/index/ExternalSortFunctors.h
@@ -122,6 +122,10 @@ extern template class CompressedExternalIdTableSorter<SortByPSONoGraphColumn,
                                                       3>;
 extern template class CompressedExternalIdTableSorter<
     SortByOSP, NumColumnsIndexBuilding + 1>;
+extern template class CompressedExternalIdTableSorter<
+    SortBySPO, NumColumnsIndexBuilding + 1>;
+extern template class CompressedExternalIdTableSorter<
+    SortByPSO, NumColumnsIndexBuilding + 1>;
 extern template class CompressedExternalIdTableSorter<SortBySPO,
                                                       NumColumnsIndexBuilding>;
 extern template class CompressedExternalIdTableSorter<SortByOSP,

--- a/src/index/Index.cpp
+++ b/src/index/Index.cpp
@@ -293,3 +293,8 @@ GraphNameManager& Index::graphNameManager() {
 const GraphNameManager& Index::graphNameManager() const {
   return pimpl_->graphNameManager();
 }
+
+// _____________________________________________________________________________
+valueIdComparators::AuxVocabOrdering Index::auxVocabOrdering() const {
+  return pimpl_->auxVocabOrdering();
+}

--- a/src/index/Index.h
+++ b/src/index/Index.h
@@ -12,6 +12,7 @@
 
 #include "backports/three_way_comparison.h"
 #include "global/Id.h"
+#include "global/ValueIdComparators.h"
 #include "index/GraphNameManager.h"
 #include "index/InputFileSpecification.h"
 #include "index/Permutation.h"
@@ -241,6 +242,11 @@ class Index {
   // requires including the rather expensive `IndexImpl.h` header
   IndexImpl& getImpl() { return *pimpl_; }
   [[nodiscard]] const IndexImpl& getImpl() const { return *pimpl_; }
+
+  // The information that is required to compare `Id`s of type
+  // `Datatype::AuxVocabIndex` by the string values that they represent, see
+  // `IndexImpl::auxVocabOrdering`.
+  valueIdComparators::AuxVocabOrdering auxVocabOrdering() const;
 
   // Allow implicit conversions to `const IndexImpl&`.
   operator const IndexImpl&() const { return getImpl(); }

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -1148,9 +1148,47 @@ void IndexImpl::createFromOnDiskIndex(const std::string& onDiskBase,
       usePatterns_ = false;
     }
   }
+  loadNewestAuxIndexFromDisk();
+  connectAuxIndexToDeltaTriples();
   if (persistUpdatesOnDisk) {
     setFilenamesForPersistentUpdates(true);
   }
+}
+
+// _____________________________________________________________________________
+void IndexImpl::loadNewestAuxIndexFromDisk() {
+  AD_CORRECTNESS_CHECK(auxIndex_ == nullptr);
+  auto generations = AuxIndex::generationsOnDisk(onDiskBase_);
+  if (generations.empty()) {
+    return;
+  }
+  // Only the newest generation is used, the older ones are leftovers of
+  // rebuilds that were still in use by running queries when the server was shut
+  // down.
+  size_t generation = generations.back();
+  auto auxIndex = std::make_shared<AuxIndex>(allocator_);
+  const auto& locale = configurationJson_.at("locale");
+  auxIndex->loadFromDisk(AuxIndex::makeBasename(onDiskBase_, generation),
+                         std::string{locale.at("language")},
+                         std::string{locale.at("country")},
+                         bool{locale.at("ignore-punctuation")});
+  auxIndex_ = std::move(auxIndex);
+}
+
+// _____________________________________________________________________________
+void IndexImpl::connectAuxIndexToDeltaTriples() {
+  if (auxIndex_ == nullptr) {
+    return;
+  }
+  // The contents of the delta triples are not changed, so they do not have to
+  // be written to disk; the augmented block metadata on the other hand has to
+  // be recomputed, because it now also has to account for the triples of the
+  // auxiliary index.
+  deltaTriplesManager().modify<void>(
+      [this](DeltaTriples& deltaTriples) {
+        deltaTriples.setAuxIndex(auxIndex_);
+      },
+      false, true);
 }
 
 // _____________________________________________________________________________

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -21,6 +21,8 @@
 #include "engine/Result.h"
 #include "engine/idTable/CompressedExternalIdTable.h"
 #include "global/SpecialIds.h"
+#include "global/ValueIdComparators.h"
+#include "index/AuxIndex.h"
 #include "index/CompressedRelation.h"
 #include "index/ConstantsIndexBuilding.h"
 #include "index/DeltaTriples.h"
@@ -203,6 +205,16 @@ class IndexImpl {
 
   std::optional<DeltaTriplesManager> deltaTriples_;
 
+  // The auxiliary index (see `index/AuxIndex.h`), or `nullptr` if this index
+  // has no auxiliary index. Note that this member is immutable once the index
+  // has been loaded: a rebuild of the auxiliary index creates a new generation
+  // and publishes it by swapping in a freshly loaded `Index` (see
+  // `Qlever::buildAuxIndex`), such that queries that are still running keep
+  // using the `IndexImpl` and hence the auxiliary index generation that they
+  // started with. This is what makes the `Id`s of an auxiliary vocabulary,
+  // which are only valid for a single generation, safe to use.
+  std::shared_ptr<const AuxIndex> auxIndex_;
+
   GraphNameManager graphNameManager_ = GraphNameManager();
 
  public:
@@ -248,6 +260,18 @@ class IndexImpl {
   void createFromOnDiskIndex(const std::string& onDiskBase,
                              bool persistUpdatesOnDisk);
 
+  // Load the auxiliary index with the highest generation that exists on disk
+  // for the current `onDiskBase_`, if there is any. Older generations are
+  // leftovers of rebuilds that were still in use by running queries when the
+  // server was shut down, and are ignored.
+  void loadNewestAuxIndexFromDisk();
+
+  // Make the delta triples of this index merge in the triples of its auxiliary
+  // index, see `LocatedTriplesPerBlock::setAuxLocatedTriples`. Has to be called
+  // after the permutations and the auxiliary index have been loaded, and does
+  // nothing if this index has no auxiliary index.
+  void connectAuxIndexToDeltaTriples();
+
   // Configure the delta triples and the graph name manager to persist their
   // state to the files derived from the current `onDiskBase_`. If
   // `readFromDisk` is `true`, the already persisted state is additionally read
@@ -261,6 +285,34 @@ class IndexImpl {
 
   const auto& getVocab() const { return vocab_; };
   auto& getNonConstVocabForTesting() { return vocab_; }
+
+  // The auxiliary index of this index, or `nullptr` if it has none.
+  const AuxIndex* auxIndex() const { return auxIndex_.get(); }
+
+  // Set the auxiliary index. Only for testing: in production a new generation
+  // of the auxiliary index is published by swapping in a freshly loaded
+  // `Index`, see the documentation of `auxIndex_`.
+  void setAuxIndexForTesting(std::shared_ptr<const AuxIndex> auxIndex) {
+    auxIndex_ = std::move(auxIndex);
+    connectAuxIndexToDeltaTriples();
+  }
+
+  // The vocabulary of the auxiliary index of this index, or `nullptr` if it has
+  // no auxiliary index.
+  const AuxVocabulary* auxVocab() const {
+    return auxIndex_ == nullptr ? nullptr : &auxIndex_->vocab();
+  }
+
+  // The information that is required to compare `Id`s of type
+  // `Datatype::AuxVocabIndex` by the string values that they represent. It is
+  // empty if this index has no auxiliary index. Note that this must always be
+  // the ordering of the very `IndexImpl` that the compared `Id`s came from, see
+  // the documentation of `auxIndex_`.
+  valueIdComparators::AuxVocabOrdering auxVocabOrdering() const {
+    const auto* vocab = auxVocab();
+    return vocab == nullptr ? valueIdComparators::AuxVocabOrdering{}
+                            : vocab->ordering();
+  }
 
   // Replace the currently loaded vocabulary with a zero-copy view directly
   // into `serializer`'s buffer. See `Vocabulary::loadFromZeroCopyDeserializer`
@@ -536,6 +588,15 @@ class IndexImpl {
   const std::string& getTextName() const { return textMeta_.getName(); }
   const std::string& getKbName() const { return PSO().getKbName(); }
   const std::string& getOnDiskBase() const { return onDiskBase_; }
+
+  // The `VocabularyType` of the vocabulary of this index, as recorded in its
+  // configuration. Note that this is the type of an index that was loaded from
+  // disk; the type to be used for a *new* index is
+  // `vocabularyTypeForIndexBuilding_`.
+  ad_utility::VocabularyType getVocabularyType() const {
+    return configurationJson_.at("vocabulary-type")
+        .get<ad_utility::VocabularyType>();
+  }
   const std::string& getIndexId() const { return indexId_; }
   const std::string& getGitShortHash() const { return gitShortHash_; }
 

--- a/src/index/KeyOrder.h
+++ b/src/index/KeyOrder.h
@@ -34,6 +34,16 @@ class KeyOrder {
   // Get access to the keys.
   const auto& keys() const { return keys_; }
 
+  // The inverse permutation, that is, the `KeyOrder` that undoes this one:
+  // `keyOrder.inverse().permuteTuple(keyOrder.permuteTuple(x)) == x`.
+  KeyOrder inverse() const {
+    Array inverse{};
+    for (size_t i = 0; i < NumKeys; ++i) {
+      inverse[keys_[i]] = static_cast<T>(i);
+    }
+    return KeyOrder{inverse[0], inverse[1], inverse[2], inverse[3]};
+  }
+
   // Apply the permutation specified by this `KeyOrder` to the `input`.
   // The elements of the input are copied into the result.
   template <typename T>

--- a/src/index/LocalVocabEntry.cpp
+++ b/src/index/LocalVocabEntry.cpp
@@ -15,6 +15,33 @@ ql::strong_ordering LocalVocabEntry::compareThreeWay(
       "Contexts of LocalVocabEntries have to be identical. If this is not the "
       "case this means that stale entries associated with an old index are "
       "falsely carried over somewhere.");
+  // First compare the positions in the vocabulary, see the documentation of
+  // this function in the header for why this is required.
+  auto position = positionInVocab();
+  auto rhsPosition = rhs.positionInVocab();
+  if (position.lowerBound_ != rhsPosition.lowerBound_) {
+    return position.lowerBound_ < rhsPosition.lowerBound_
+               ? ql::strong_ordering::less
+               : ql::strong_ordering::greater;
+  }
+  // A word that is contained in one of the vocabularies (in which case the
+  // bounds differ) is greater than a word that only would be sorted at the same
+  // position (in which case the bounds are equal), because the latter is
+  // strictly smaller than the word at that position.
+  bool isContained = position.lowerBound_ != position.upperBound_;
+  bool rhsIsContained = rhsPosition.lowerBound_ != rhsPosition.upperBound_;
+  if (isContained != rhsIsContained) {
+    return isContained ? ql::strong_ordering::greater
+                       : ql::strong_ordering::less;
+  }
+  // Both words fall into the same gap of the main vocabulary, so the number of
+  // smaller words in the auxiliary vocabulary decides.
+  auto numSmallerAux = numSmallerAuxVocabWords();
+  auto rhsNumSmallerAux = rhs.numSmallerAuxVocabWords();
+  if (numSmallerAux != rhsNumSmallerAux) {
+    return numSmallerAux < rhsNumSmallerAux ? ql::strong_ordering::less
+                                            : ql::strong_ordering::greater;
+  }
   int i = context_->getVocab().getCaseComparator().compare(
       toStringRepresentation(), rhs.toStringRepresentation(),
       LocaleManager::Level::TOTAL);
@@ -47,6 +74,19 @@ auto LocalVocabEntry::positionInVocabExpensiveCase() const -> PositionInVocab {
     }
     auto [l, u] = vocab.getPositionOfWord(toStringRepresentation());
     AD_CORRECTNESS_CHECK(u.get() - l.get() <= 1);
+    if (l == u) {
+      // The word is not in the vocabulary of the main index, so it may be in
+      // the vocabulary of the auxiliary index. Note that the two vocabularies
+      // are disjoint, so we only have to look there if the lookup above failed.
+      const auto* auxVocab = context_->auxVocab();
+      if (auxVocab != nullptr) {
+        if (auto auxIndex = auxVocab->getId(toStringRepresentation());
+            auxIndex.has_value()) {
+          auto id = Id::makeFromAuxVocabIndex(auxIndex.value());
+          return std::pair{id, Id::fromBits(id.getBits() + 1)};
+        }
+      }
+    }
     return std::pair{Id::makeFromVocabIndex(l), Id::makeFromVocabIndex(u)};
   }();
   positionInVocab.lowerBound_ = IdProxy::make(lower.getBits());
@@ -58,6 +98,18 @@ auto LocalVocabEntry::positionInVocabExpensiveCase() const -> PositionInVocab {
                            std::memory_order_relaxed);
   positionInVocabKnown_.store(true, std::memory_order_release);
   return positionInVocab;
+}
+
+// ___________________________________________________________________________
+uint64_t LocalVocabEntry::numSmallerAuxVocabWordsExpensiveCase() const {
+  const auto* auxVocab = context_->auxVocab();
+  uint64_t result =
+      auxVocab == nullptr
+          ? 0
+          : auxVocab->numWordsSmallerThan(toStringRepresentation());
+  numSmallerAuxVocabWords_.store(result, std::memory_order_relaxed);
+  numSmallerAuxVocabWordsKnown_.store(true, std::memory_order_release);
+  return result;
 }
 
 // _____________________________________________________________________________

--- a/src/index/LocalVocabEntry.h
+++ b/src/index/LocalVocabEntry.h
@@ -46,12 +46,21 @@ class alignas(16) LocalVocabEntry
   // inclusive, the `upperBound` is not, so if `lowerBound == upperBound`, then
   // the entry is not part of the globalVocabulary, and `lowerBound` points to
   // the first *larger* word in the vocabulary. Note: we store the cache as
-  // three separate atomics to avoid mutexes. The downside is, that in parallel
-  // code multiple threads might look up the position concurrently, which wastes
-  // a bit of resources. However, we don't consider this case to be likely.
+  // several separate atomics to avoid mutexes. The downside is, that in
+  // parallel code multiple threads might look up the position concurrently,
+  // which wastes a bit of resources. However, we don't consider this case to be
+  // likely.
   mutable ad_utility::CopyableAtomic<IdProxy> lowerBoundInVocab_;
   mutable ad_utility::CopyableAtomic<IdProxy> upperBoundInVocab_;
   mutable ad_utility::CopyableAtomic<bool> positionInVocabKnown_ = false;
+  // A second, independent cache for the position in the auxiliary vocabulary of
+  // the index (see `numSmallerAuxVocabWords()` below). It is separate from the
+  // cache above because it is only required for the semantically correct
+  // comparison in `valueIdComparators`, whereas the bounds above are also
+  // required on the much hotter path of `Id::compareThreeWay`.
+  mutable ad_utility::CopyableAtomic<uint64_t> numSmallerAuxVocabWords_;
+  mutable ad_utility::CopyableAtomic<bool> numSmallerAuxVocabWordsKnown_ =
+      false;
 
  public:
   LocalVocabEntry(LiteralT literal, const LocalVocabContext& context)
@@ -65,7 +74,11 @@ class alignas(16) LocalVocabEntry
   LocalVocabEntry(Base&& base, const LocalVocabContext& context) noexcept
       : Base{std::move(base)}, context_{&context} {}
 
-  // Constructor for when the position in the vocab is already known.
+  // Constructor for when the position in the vocab is already known. Note that
+  // the caller has to guarantee that the word is contained in neither the main
+  // nor the auxiliary vocabulary, or that `lower` and `upper` are the bounds
+  // that `positionInVocabExpensiveCase` would compute (which is checked by the
+  // expensive check below).
   template <typename Lower, typename Upper>
   LocalVocabEntry(Base&& base, Lower lower, Upper upper,
                   const LocalVocabContext& context)
@@ -129,6 +142,22 @@ class alignas(16) LocalVocabEntry
     return positionInVocabExpensiveCase();
   }
 
+  // Return the number of words of the auxiliary vocabulary of the index (see
+  // `AuxVocabulary`) that are smaller than this word. Note that this is a dense
+  // offset across all sub-vocabularies of the auxiliary vocabulary, not an
+  // `AuxVocabIndex`, so that it is directly comparable across the
+  // sub-vocabularies of a split vocabulary. Together with
+  // `positionInVocab()` this pins down the position of this word in the merged
+  // order of the main and the auxiliary vocabulary, which is what the
+  // semantically correct comparison of `Id`s in `valueIdComparators` requires.
+  // Return zero if the index has no auxiliary index.
+  uint64_t numSmallerAuxVocabWords() const {
+    if (numSmallerAuxVocabWordsKnown_.load(std::memory_order_acquire)) {
+      return numSmallerAuxVocabWords_.load(std::memory_order_relaxed);
+    }
+    return numSmallerAuxVocabWordsExpensiveCase();
+  }
+
   // It suffices to hash the base class `LiteralOrIri` as the position in the
   // vocab is redundant for those purposes.
   template <typename H, typename V>
@@ -137,10 +166,14 @@ class alignas(16) LocalVocabEntry
     return H::combine(std::move(h), static_cast<const Base&>(entry));
   }
 
-  // Comparison between two entries could in theory also be sped up using the
-  // cached `position` if it has previously been computed for both of the
-  // entries, but it is currently questionable whether this gains much
-  // performance.
+  // Compare two entries. Note that this first compares the positions in the
+  // vocabulary (see `positionInVocab()`) and only falls back to the (expensive)
+  // comparison of the strings if those are equal. Comparing the strings alone
+  // would not be a valid strict weak ordering: for example, a word that is
+  // stored in the auxiliary vocabulary of the index is positioned after all
+  // words of the main vocabulary (see `AuxVocabulary`), so comparing it to a
+  // word that is in neither vocabulary has to yield the same result as
+  // comparing the corresponding `Id`s, which are compared by their positions.
   ql::strong_ordering compareThreeWay(const LocalVocabEntry& rhs) const;
   QL_DEFINE_CUSTOM_THREEWAY_OPERATOR_LOCAL(LocalVocabEntry)
 
@@ -150,6 +183,9 @@ class alignas(16) LocalVocabEntry
  private:
   // The expensive case of looking up the position in vocab.
   PositionInVocab positionInVocabExpensiveCase() const;
+
+  // The expensive case of looking up the position in the auxiliary vocabulary.
+  uint64_t numSmallerAuxVocabWordsExpensiveCase() const;
 };
 
 #endif  // QLEVER_SRC_INDEX_LOCALVOCABENTRY_H

--- a/src/index/LocatedTriples.cpp
+++ b/src/index/LocatedTriples.cpp
@@ -12,6 +12,7 @@
 
 #include "backports/algorithm.h"
 #include "global/RuntimeParameters.h"
+#include "index/AuxLocatedTriples.h"
 #include "index/CompressedRelation.h"
 #include "index/ConstantsIndexBuilding.h"
 #include "index/GraphComputation.h"
@@ -19,6 +20,28 @@
 #include "util/ChunkedForLoop.h"
 #include "util/Log.h"
 #include "util/ValueIdentity.h"
+
+// ____________________________________________________________________________
+size_t LocatedTriple::locateTripleInPermutation(
+    const IdTriple<0>& triple,
+    ql::span<const CompressedBlockMetadata> blockMetadata,
+    const qlever::KeyOrder& keyOrder) {
+  // A triple belongs to the first block that contains at least one triple
+  // that is larger than or equal to the triple. See `LocatedTriples.h` for a
+  // discussion of the corner cases.
+  return ql::ranges::lower_bound(
+             blockMetadata, triple.permute(keyOrder).toPermutedTriple(),
+             [](const auto& a, const auto& b) {
+               // All identical triples with different graphs are currently
+               // stored in the same block, so we don't need to check the
+               // graph. In particular, if this triple is equal (without
+               // graphs) to the first or last triple of a block, then this
+               // call to `lower_bound` will correctly identify this block.
+               return a.tieWithoutGraph() < b.tieWithoutGraph();
+             },
+             &CompressedBlockMetadata::lastTriple_) -
+         blockMetadata.begin();
+}
 
 // ____________________________________________________________________________
 std::vector<LocatedTriple> LocatedTriple::locateTriplesInPermutation(
@@ -31,24 +54,10 @@ std::vector<LocatedTriple> LocatedTriple::locateTriplesInPermutation(
   ad_utility::chunkedForLoop<10'000>(
       0, triples.size(),
       [&triples, &out, &blockMetadata, &keyOrder, &insertOrDelete](size_t i) {
-        auto triple = triples[i].permute(keyOrder);
-        // A triple belongs to the first block that contains at least one triple
-        // that larger than or equal to the triple. See `LocatedTriples.h` for a
-        // discussion of the corner cases.
-        size_t blockIndex =
-            ql::ranges::lower_bound(
-                blockMetadata, triple.toPermutedTriple(),
-                [](const auto& a, const auto& b) {
-                  // All identical triples with different graphs are currently
-                  // stored in the same block, so we don't need to check the
-                  // graph. In particular, if this triple is equal (without
-                  // graphs) to the first or last triple of a block, then this
-                  // call to `lower_bound` will correctly identify this block.
-                  return a.tieWithoutGraph() < b.tieWithoutGraph();
-                },
-                &CompressedBlockMetadata::lastTriple_) -
-            blockMetadata.begin();
-        out.push_back({blockIndex, triple, insertOrDelete});
+        size_t blockIndex = LocatedTriple::locateTripleInPermutation(
+            triples[i], blockMetadata, keyOrder);
+        out.push_back(
+            {blockIndex, triples[i].permute(keyOrder), insertOrDelete});
       },
       [&cancellationHandle]() { cancellationHandle->throwIfCancelled(); });
 
@@ -66,6 +75,70 @@ LocatedTriplesPerBlock::getUpdatesIfPresent(size_t blockIndex) const {
 }
 
 // ____________________________________________________________________________
+bool LocatedTriplesPerBlock::containsTriples(size_t blockIndex) const {
+  return map_.contains(blockIndex) ||
+         (auxTriples_ != nullptr && auxTriples_->containsTriples(blockIndex));
+}
+
+// ____________________________________________________________________________
+void LocatedTriplesPerBlock::setAuxLocatedTriples(
+    std::shared_ptr<const AuxLocatedTriples> auxTriples) {
+  auxTriples_ = std::move(auxTriples);
+}
+
+// ____________________________________________________________________________
+LocatedTriples LocatedTriplesPerBlock::getAllUpdatesForBlock(
+    size_t blockIndex) const {
+  auto fromMap = getUpdatesIfPresent(blockIndex);
+  if (auxTriples_ == nullptr) {
+    return fromMap.has_value() ? fromMap.value() : LocatedTriples{};
+  }
+  auto fromAux = auxTriples_->getTriplesForBlock(blockIndex);
+  if (!fromMap.has_value()) {
+    LocatedTriples result;
+    ql::ranges::for_each(
+        fromAux, [&result](const LocatedTriple& lt) { result.insert(lt); });
+    result.consolidate();
+    return result;
+  }
+  // Merge the two sorted sequences, where the triples of `map_` win, see the
+  // documentation of `auxTriples_`. Note that a triple that is inserted by one
+  // of them and deleted by the other must yield exactly one entry, namely the
+  // one of `map_`.
+  std::vector<LocatedTriple> merged;
+  merged.reserve(fromMap->sizeUpperBound() + fromAux.size());
+  auto sortedFromMap = fromMap->getSortedView();
+  auto itMap = sortedFromMap.begin();
+  auto itAux = fromAux.begin();
+  while (itMap != sortedFromMap.end() && itAux != fromAux.end()) {
+    const auto& fromMapTriple = (*itMap).triple_;
+    if (fromMapTriple < itAux->triple_) {
+      merged.push_back(*itMap);
+      ++itMap;
+    } else {
+      if (!(itAux->triple_ < fromMapTriple)) {
+        // The two agree on the triple, so the one of `map_` wins and the one of
+        // the auxiliary index is dropped.
+        merged.push_back(*itMap);
+        ++itMap;
+      } else {
+        merged.push_back(*itAux);
+      }
+      ++itAux;
+    }
+  }
+  ql::ranges::copy(ql::ranges::subrange{itMap, sortedFromMap.end()},
+                   std::back_inserter(merged));
+  ql::ranges::copy(ql::ranges::subrange{itAux, fromAux.end()},
+                   std::back_inserter(merged));
+  LocatedTriples result;
+  ql::ranges::for_each(
+      merged, [&result](const LocatedTriple& lt) { result.insert(lt); });
+  result.consolidate();
+  return result;
+}
+
+// ____________________________________________________________________________
 void LocatedTriplesPerBlock::consolidateAllBlocks() {
   ql::ranges::for_each(map_ | ql::views::values,
                        [](auto& lts) { lts.consolidate(); });
@@ -73,13 +146,16 @@ void LocatedTriplesPerBlock::consolidateAllBlocks() {
 
 // ____________________________________________________________________________
 NumAddedAndDeleted LocatedTriplesPerBlock::numTriples(size_t blockIndex) const {
+  // Simply return the number of located triples twice. See the comment in the
+  // header file for the reasons and potential improvements.
+  size_t numTriples = 0;
   if (auto blockUpdateTriples = getUpdatesIfPresent(blockIndex)) {
-    // Simply return the number of located triples twice. See the comment in the
-    // header file for the reasons and potential improvements.
-    return {blockUpdateTriples->sizeUpperBound(),
-            blockUpdateTriples->sizeUpperBound()};
+    numTriples += blockUpdateTriples->sizeUpperBound();
   }
-  return {0, 0};
+  if (auxTriples_ != nullptr) {
+    numTriples += auxTriples_->numTriples(blockIndex);
+  }
+  return {numTriples, numTriples};
 }
 
 namespace {
@@ -145,16 +221,18 @@ IdTable LocatedTriplesPerBlock::mergeTriplesImpl(size_t blockIndex,
                                                  const IdTable& block) const {
   // This method should only be called if there are located triples in the
   // specified block.
-  AD_CONTRACT_CHECK(map_.contains(blockIndex));
+  AD_CONTRACT_CHECK(containsTriples(blockIndex));
 
   AD_CONTRACT_CHECK(numIndexColumns + static_cast<size_t>(includeGraphColumn) <=
                     block.numColumns());
 
+  // The updates of this block, which are the ones held in RAM merged with those
+  // of the auxiliary index, if there is one.
+  LocatedTriples locatedTriples = getAllUpdatesForBlock(blockIndex);
+
   auto numInsertsAndDeletes = numTriples(blockIndex);
   IdTable result{block.numColumns(), block.getAllocator()};
   result.resize(block.numRows() + numInsertsAndDeletes.numAdded_);
-
-  const auto& locatedTriples = map_.at(blockIndex);
 
   auto lessThan = [](const auto& lt, const auto& row) {
     return tieLocatedTriple<numIndexColumns, includeGraphColumn>(lt) <
@@ -484,26 +562,86 @@ void LocatedTriplesPerBlock::updateAugmentedMetadata() {
                    blockUpdates->back().triple_.toPermutedTriple());
       updateGraphMetadata(blockMetadata, *blockUpdates);
     }
+    applyAuxMetadataContribution(blockMetadata, blockIndex, false);
     blockIndex++;
   }
   // Also account for the last block that contains the triples that are larger
   // than all the inserted triples.
-  if (auto blockUpdates = getUpdatesIfPresent(blockIndex)) {
-    auto firstTriple = blockUpdates->front().triple_.toPermutedTriple();
-    auto lastTriple = blockUpdates->back().triple_.toPermutedTriple();
-
+  auto blockUpdates = getUpdatesIfPresent(blockIndex);
+  bool auxHasTrailingTriples =
+      auxTriples_ != nullptr && auxTriples_->containsTriples(blockIndex);
+  if (blockUpdates.has_value() || auxHasTrailingTriples) {
     // The first `std::nullopt` means that this block contains only
     // `LocatedTriple`s.
-    CompressedBlockMetadataNoBlockIndex lastBlockN{
-        std::nullopt, 0, firstTriple, lastTriple, std::nullopt, true};
+    CompressedBlockMetadataNoBlockIndex lastBlockN{std::nullopt, 0,   {}, {},
+                                                   std::nullopt, true};
     lastBlockN.graphInfo_.emplace();
     CompressedBlockMetadata lastBlock{lastBlockN, blockIndex};
-    updateGraphMetadata(lastBlock, *blockUpdates);
+    if (blockUpdates.has_value()) {
+      lastBlock.firstTriple_ = blockUpdates->front().triple_.toPermutedTriple();
+      lastBlock.lastTriple_ = blockUpdates->back().triple_.toPermutedTriple();
+      updateGraphMetadata(lastBlock, *blockUpdates);
+    } else {
+      // Start from the bounds of the auxiliary index, which the call below then
+      // only widens.
+      const auto* contribution = auxTriples_->blockInfo(blockIndex);
+      AD_CORRECTNESS_CHECK(contribution != nullptr);
+      lastBlock.firstTriple_ = contribution->firstTriple_;
+      lastBlock.lastTriple_ = contribution->lastTriple_;
+    }
+    applyAuxMetadataContribution(lastBlock, blockIndex, true);
     augmentedMetadata_->push_back(lastBlock);
 
     AD_CORRECTNESS_CHECK(
         CompressedBlockMetadata::checkInvariantsForSortedBlocks(
             *augmentedMetadata_));
+  }
+}
+
+// ____________________________________________________________________________
+void LocatedTriplesPerBlock::applyAuxMetadataContribution(
+    CompressedBlockMetadata& blockMetadata, size_t blockIndex,
+    bool widenLastTriple) const {
+  if (auxTriples_ == nullptr) {
+    return;
+  }
+  const auto* contribution = auxTriples_->blockInfo(blockIndex);
+  if (contribution == nullptr) {
+    return;
+  }
+  // A triple of the auxiliary index that belongs to this block may be smaller
+  // than the first triple of this block (namely if it falls into the gap
+  // between this block and the previous one), so the lower bound has to be
+  // widened.
+  //
+  // The upper bound on the other hand must *not* be widened for the blocks that
+  // hold triples of the main index: the triples that belong to this block are
+  // by definition not greater than its last triple (up to a difference in the
+  // graph only, which is irrelevant for the bounds), whereas the bounds that
+  // `metadataContribution` reports are those of whole *blocks* of the auxiliary
+  // index, which may span several blocks of the main index. Widening with those
+  // would break the invariant that the last triples of the blocks are strictly
+  // ascending. Only for the synthetic block that holds everything after the
+  // last block of the main index there is no such upper bound.
+  blockMetadata.firstTriple_ =
+      std::min(blockMetadata.firstTriple_, contribution->firstTriple_);
+  if (widenLastTriple) {
+    blockMetadata.lastTriple_ =
+        std::max(blockMetadata.lastTriple_, contribution->lastTriple_);
+  }
+  // The graphs of the triples of the auxiliary index have to be added, and
+  // since it is not known from the block metadata alone whether any of them is
+  // an insertion, we conservatively have to assume that they introduce
+  // duplicates.
+  auto& graphs = blockMetadata.graphInfo_;
+  if (graphs.has_value()) {
+    const auto& auxGraphs = contribution->graphsOfInsertedTriples_;
+    graphs = auxGraphs.has_value() ? std::optional{computeDistinctGraphs(
+                                         auxGraphs.value(), graphs.value())}
+                                   : std::nullopt;
+  }
+  if (!hasOnlyOneGraph(graphs)) {
+    blockMetadata.containsDuplicatesWithDifferentGraphs_ = true;
   }
 }
 

--- a/src/index/LocatedTriples.h
+++ b/src/index/LocatedTriples.h
@@ -25,6 +25,7 @@
 #include "util/TypeTraits.h"
 
 class Permutation;
+class AuxLocatedTriples;
 
 struct NumAddedAndDeleted {
   size_t numAdded_;
@@ -87,6 +88,14 @@ struct LocatedTriple {
   // If `true`, the triple is inserted, otherwise it is deleted.
   bool insertOrDelete_;
 
+  // The index of the block of the given permutation that `triple` (which is in
+  // the order `(S, P, O, G)`) belongs to, according to the definition at the
+  // end of this file.
+  static size_t locateTripleInPermutation(
+      const IdTriple<0>& triple,
+      ql::span<const CompressedBlockMetadata> blockMetadata,
+      const qlever::KeyOrder& keyOrder);
+
   // Locate the given triples in the given permutation.
   static std::vector<LocatedTriple> locateTriplesInPermutation(
       ql::span<const IdTriple<0>> triples,
@@ -132,6 +141,33 @@ class LocatedTriplesPerBlock {
   std::optional<std::vector<CompressedBlockMetadata>> augmentedMetadata_;
   std::optional<std::shared_ptr<const std::vector<CompressedBlockMetadata>>>
       originalMetadata_;
+
+  // The triples of the corresponding permutation of the auxiliary index (see
+  // `index/AuxLocatedTriples.h`), or `nullptr` if the index has no auxiliary
+  // index. Unlike the triples in `map_`, these are not held in RAM but read
+  // from disk on demand.
+  //
+  // Together, `map_` and this form the update triples of the permutation, where
+  // `map_` takes precedence: if both of them have an entry for the same triple,
+  // the one in `map_` is the more recent one, because the auxiliary index only
+  // ever holds updates that were made *before* those in `map_`.
+  std::shared_ptr<const AuxLocatedTriples> auxTriples_;
+
+  // The update triples of the given block: the ones in `map_` merged with those
+  // of the auxiliary index, with the former winning (see above). The second
+  // element is an upper bound for the number of them. If there is no auxiliary
+  // index, this simply returns the entry of `map_`.
+  LocatedTriples getAllUpdatesForBlock(size_t blockIndex) const;
+
+  // Widen the bounds and the graph info of `blockMetadata` (which belongs to
+  // the block with the given index) such that they also cover the triples of
+  // the auxiliary index, see `updateAugmentedMetadata`. The upper bound is only
+  // widened if `widenLastTriple` is true, which must be the case exactly for
+  // the synthetic block after the last block of the main index; see the
+  // implementation for the reason.
+  void applyAuxMetadataContribution(CompressedBlockMetadata& blockMetadata,
+                                    size_t blockIndex,
+                                    bool widenLastTriple) const;
 
  public:
   void updateAugmentedMetadata();
@@ -182,10 +218,15 @@ class LocatedTriplesPerBlock {
                        size_t numIndexColumns, bool includeGraphColumn) const;
 
   // Return true iff there are located triples in the block with the given
-  // index.
-  bool containsTriples(size_t blockIndex) const {
-    return map_.contains(blockIndex);
-  }
+  // index. Note that this may be a false positive if the index has an auxiliary
+  // index, see `AuxLocatedTriples::mayContainTriples`.
+  bool containsTriples(size_t blockIndex) const;
+
+  // Set the triples of the corresponding permutation of the auxiliary index,
+  // see `auxTriples_`. Must be called before any updates are processed,
+  // together with `setOriginalMetadata`.
+  void setAuxLocatedTriples(
+      std::shared_ptr<const AuxLocatedTriples> auxTriples);
 
   // Add unsorted `locatedTriples` to the `LocatedTriplesPerBlock`.
   void add(ql::span<const LocatedTriple> locatedTriples,
@@ -230,6 +271,14 @@ class LocatedTriplesPerBlock {
             std::move(metadata)));
   }
 
+  // The original (that is, not augmented) block metadata that was set via
+  // `setOriginalMetadata`.
+  const std::shared_ptr<const std::vector<CompressedBlockMetadata>>&
+  originalMetadata() const {
+    AD_CONTRACT_CHECK(originalMetadata_.has_value());
+    return originalMetadata_.value();
+  }
+
   // Returns the block metadata where the block borders have been updated to
   // account for the update triples. All triples (both insert and delete) will
   // enlarge the block borders.
@@ -241,7 +290,9 @@ class LocatedTriplesPerBlock {
     return *originalMetadata_.value();
   };
 
-  // Remove all located triples.
+  // Remove all located triples. Note that this does not remove the triples of
+  // the auxiliary index, which are not updates of this `LocatedTriplesPerBlock`
+  // but part of the index.
   void clear() {
     map_.clear();
     augmentedMetadata_.reset();

--- a/src/index/Vocabulary.cpp
+++ b/src/index/Vocabulary.cpp
@@ -318,6 +318,9 @@ template class Vocabulary<detail::UnderlyingVocabRdfsVocabulary,
                           TripleComponentComparator, VocabIndex>;
 template class Vocabulary<detail::UnderlyingVocabTextVocabulary,
                           SimpleStringComparator, WordVocabIndex>;
+// The vocabulary of an auxiliary index, see `index/AuxVocabulary.h`.
+template class Vocabulary<detail::UnderlyingVocabRdfsVocabulary,
+                          TripleComponentComparator, AuxVocabIndex>;
 
 template void RdfsVocabulary::initializeInternalizedLangs<nlohmann::json>(
     const nlohmann::json&);

--- a/src/index/Vocabulary.h
+++ b/src/index/Vocabulary.h
@@ -217,6 +217,17 @@ class Vocabulary {
   // Get prefix ranges for the given prefix.
   PrefixRanges prefixRanges(std::string_view prefix) const;
 
+  // The marker of the sub-vocabulary that `word` belongs to, see
+  // `PolymorphicVocabulary::getMarkerForWord`. Always zero for vocabulary
+  // implementations that do not split their words.
+  uint8_t getMarkerForWord(std::string_view word) const {
+    if constexpr (std::is_same_v<UnderlyingVocabulary, PolymorphicVocabulary>) {
+      return vocabulary_.getUnderlyingVocabulary().getMarkerForWord(word);
+    } else {
+      return 0;
+    }
+  }
+
   [[nodiscard]] const LocaleManager& getLocaleManager() const {
     return getCaseComparator().getLocaleManager();
   }

--- a/src/index/vocabulary/PolymorphicVocabulary.cpp
+++ b/src/index/vocabulary/PolymorphicVocabulary.cpp
@@ -82,6 +82,25 @@ std::unique_ptr<WordWriterBase> PolymorphicVocabulary::makeDiskWriterPtr(
 }
 
 // _____________________________________________________________________________
+uint8_t PolymorphicVocabulary::numberOfSubVocabularies(VocabularyType type) {
+  // Use a temporary vocabulary of the given type to determine the number of
+  // sub-vocabularies of that type, such that this function does not have to be
+  // adapted when a new vocabulary type is added.
+  PolymorphicVocabulary dummyVocab;
+  dummyVocab.resetToType(type);
+  return std::visit(
+      [](const auto& vocab) -> uint8_t {
+        using T = std::decay_t<decltype(vocab)>;
+        if constexpr (ad_utility::isInstantiation<T, SplitVocabulary>) {
+          return T::numberOfVocabs;
+        } else {
+          return 1;
+        }
+      },
+      dummyVocab.vocab_);
+}
+
+// _____________________________________________________________________________
 void PolymorphicVocabulary::resetToType(VocabularyType type) {
   close();
   // The names of the enum values are the same as the type aliases for the

--- a/src/index/vocabulary/PolymorphicVocabulary.h
+++ b/src/index/vocabulary/PolymorphicVocabulary.h
@@ -194,6 +194,29 @@ class PolymorphicVocabulary {
         vocab_);
   }
 
+  // The marker of the sub-vocabulary that `word` belongs to, see
+  // `SplitVocabulary` and `VocabIndexMarker`. This is always zero for the
+  // vocabulary types that do not split their words. Note that this is
+  // determined by the word alone and requires no lookup.
+  uint8_t getMarkerForWord(std::string_view word) const {
+    return std::visit(
+        [&word](const auto& vocab) -> uint8_t {
+          using T = std::decay_t<decltype(vocab)>;
+          if constexpr (ad_utility::isInstantiation<T, SplitVocabulary>) {
+            return T::getMarkerForWord(word);
+          } else {
+            return 0;
+          }
+        },
+        vocab_);
+  }
+
+  // The number of sub-vocabularies that a vocabulary of the given `type` splits
+  // its words over, see `SplitVocabulary`. It is one for all the types that do
+  // not split. The sub-vocabulary that a word belongs to is encoded in the
+  // marker bits of its `Id`, see `VocabIndexMarker`.
+  static uint8_t numberOfSubVocabularies(VocabularyType type);
+
   // Create a `WordWriter` that will create a vocabulary with the given `type`
   // at the given `filename`.
   static std::unique_ptr<WordWriterBase> makeDiskWriterPtr(

--- a/src/index/vocabulary/SplitVocabulary.h
+++ b/src/index/vocabulary/SplitVocabulary.h
@@ -16,6 +16,7 @@
 #include "backports/algorithm.h"
 #include "backports/functional.h"
 #include "global/ValueId.h"
+#include "global/VocabIndexMarker.h"
 #include "index/vocabulary/GeoVocabulary.h"
 #include "index/vocabulary/VocabularyTypes.h"
 #include "util/BitUtils.h"
@@ -66,6 +67,12 @@ class SplitVocabulary {
                 sizeof...(UnderlyingVocabularies) <= 255);
   static constexpr uint8_t numberOfVocabs =
       static_cast<uint8_t>(sizeof...(UnderlyingVocabularies));
+
+  // The auxiliary vocabulary of an auxiliary index mirrors the split of the
+  // vocabulary of the main index, and its marker arithmetic (see
+  // `VocabIndexMarker`) supports at most `maxNumMarkers` sub-vocabularies. If
+  // this assertion fails, raise that constant.
+  static_assert(numberOfVocabs <= VocabIndexMarker::maxNumMarkers);
 
   // Because of the marker bits, a `SplitVocabulary` should not hold another
   // `SplitVocabulary` or a `PolymorphicVocabulary`, where it cannot be

--- a/src/libqlever/Qlever.cpp
+++ b/src/libqlever/Qlever.cpp
@@ -22,6 +22,7 @@
 #include "engine/QueryExecutionContext.h"
 #include "global/Constants.h"
 #include "global/FileSuffixConstants.h"
+#include "index/AuxIndexBuilder.h"
 #include "index/IndexImpl.h"
 #include "index/TextIndexBuilder.h"
 #include "libqlever/QleverTypes.h"
@@ -42,6 +43,7 @@ Qlever::Qlever(const EngineConfig& config, bool skipLoading)
           }}},
       indexAndViews_{std::make_shared<IndexAndViews>(
           Index{allocator_}, MaterializedViewsManager{})},
+      config_{config},
       enablePatternTrick_{!config.noPatterns_},
       disableCaching_{config.disableCaching_} {
   // Set runtime parameters relevant for caching and propagate them to the
@@ -96,6 +98,74 @@ Qlever::Qlever(const EngineConfig& config, bool skipLoading)
                    << "' failed: " << ex.what() << "." << std::endl;
     }
   }
+}
+
+// _____________________________________________________________________________
+void Qlever::buildAuxIndex(const SharedCancellationHandle& cancellationHandle) {
+  auto oldIndexAndViews = indexAndViewsSnapshot();
+  auto& oldIndex = oldIndexAndViews->index_;
+
+  // Build the files of the new generation. This is the expensive part and
+  // happens without any lock; the delta triples that arrive in the meantime are
+  // carried over below.
+  auto [stateAtStartOfBuild, localVocabEntries, ownedBlocks] =
+      oldIndex.deltaTriplesManager()
+          .getCurrentLocatedTriplesSharedStateWithVocab();
+  auto buildResult = qlever::buildAuxIndex(
+      oldIndex.getImpl(), *stateAtStartOfBuild,
+      config_.memoryLimit_.value_or(DEFAULT_MEM_FOR_QUERIES),
+      cancellationHandle);
+
+  // Load a fresh `Index` from the same files, which picks up the new generation
+  // of the auxiliary index. Note that the persisted updates must *not* be read
+  // back here: they still refer to the `Id`s of the previous generation. They
+  // are instead carried over below and written out again afterwards.
+  auto newIndexAndViews = std::make_shared<IndexAndViews>(
+      Index{allocator_}, MaterializedViewsManager{});
+  auto& newIndex = newIndexAndViews->index_;
+  newIndex.usePatterns() = enablePatternTrick_;
+  newIndex.loadAllPermutations() = !config_.onlyPsoAndPos_;
+  newIndex.doNotLoadPermutations() = config_.doNotLoadPermutations_;
+  newIndex.createFromOnDiskIndex(config_.baseName_, false);
+  if (config_.loadTextIndex_) {
+    newIndex.addTextFromOnDiskIndex();
+  }
+  bool persistUpdates = oldIndex.deltaTriplesManager().persists();
+  if (persistUpdates) {
+    // Only set the file name, do not read the file back (see above).
+    newIndex.getImpl().setFilenamesForPersistentUpdates(false);
+  }
+  newIndexAndViews->materializedViewsManager_.setOnDiskBase(config_.baseName_);
+
+  // Carry over the updates that arrived while the build was running,
+  // translating their `Id`s into those of the new generation, and publish the
+  // new index. Note that the caches have to be cleared: their entries hold
+  // `Id`s of the previous generation.
+  const auto& idMapping = buildResult.idMapping_;
+  // `Id`s that the mapping does not know are local vocab entries that were
+  // created after the build started; `addFromSnapshotDiff` re-anchors those to
+  // the new index itself.
+  auto mapId = [&idMapping](Id id) { return idMapping.map(id); };
+  auto& tracer = ad_utility::timer::DEFAULT_TIME_TRACER;
+  oldIndex.deltaTriplesManager().modify<void>(
+      [&](DeltaTriples& oldDeltaTriples) {
+        auto currentState =
+            oldDeltaTriples.getLocatedTriplesSharedStateReference();
+        newIndex.deltaTriplesManager().modify<void>(
+            [&](DeltaTriples& newDeltaTriples) {
+              newDeltaTriples.addFromSnapshotDiff(*stateAtStartOfBuild,
+                                                  *currentState, mapId,
+                                                  cancellationHandle, tracer);
+            },
+            persistUpdates, true);
+        cache_.clearAll();
+        namedResultCache_.clear();
+        swapIndexAndViews(newIndexAndViews);
+      },
+      false, false);
+  AD_LOG_INFO << "The auxiliary index of generation "
+              << buildResult.metadata_.generation_ << " is now in use"
+              << std::endl;
 }
 
 // _____________________________________________________________________________

--- a/src/libqlever/Qlever.h
+++ b/src/libqlever/Qlever.h
@@ -319,6 +319,10 @@ class Qlever {
   SortPerformanceEstimator sortPerformanceEstimator_;
   mutable NamedResultCache namedResultCache_;
   ad_utility::Synchronized<std::shared_ptr<IndexAndViews>> indexAndViews_;
+  // The configuration that this instance was created with. It is kept because
+  // publishing a new generation of the auxiliary index reloads the index from
+  // disk (see `buildAuxIndex`) and has to apply the same settings again.
+  EngineConfig config_;
   bool enablePatternTrick_;
   QueryExecutionContext::DisableCaching disableCaching_;
   using TimeLimit = std::chrono::milliseconds;
@@ -335,6 +339,26 @@ class Qlever {
   FRIEND_TEST(LibQlever, swapIndexAndViewsThrowsWithNonEmptyNamedCache);
 
  public:
+  // Build a new generation of the auxiliary index (see `index/AuxIndex.h`) from
+  // the delta triples that are currently held in RAM, and publish it. The
+  // triples then live on disk instead of in RAM, and are merged into the index
+  // scans from there.
+  //
+  // Publishing works by atomically swapping in a freshly loaded `Index` that
+  // uses the new generation. Queries that are still running keep the `Index`
+  // (and hence the generation of the auxiliary vocabulary) that they started
+  // with, which is what makes the `Id`s of an auxiliary vocabulary -- which are
+  // only valid for a single generation -- safe to use.
+  //
+  // PRECONDITION: No update may be applied concurrently, else it would be
+  // applied to the retired `Index` and hence be lost. The server guarantees
+  // this by running this on its single-threaded update executor. Note that the
+  // updates that arrive between the start of the build and the swap are carried
+  // over (see `DeltaTriples::addFromSnapshotDiff`), so moving the build off
+  // that executor only requires making the *swap* mutually exclusive with
+  // updates.
+  void buildAuxIndex(const SharedCancellationHandle& cancellationHandle);
+
   // Build an index, using an `IndexBuilderConfig` as explained above.
   static void buildIndex(IndexBuilderConfig config);
 

--- a/src/parser/TripleComponent.cpp
+++ b/src/parser/TripleComponent.cpp
@@ -119,6 +119,18 @@ TripleComponent::toValueIdOrBounds(const IndexImpl& index) const {
   if (lower != upper) {
     return Id::makeFromVocabIndex(lower);
   }
+  // The word may be stored in the vocabulary of the auxiliary index (see
+  // `AuxVocabulary`), which is disjoint from the vocabulary of the main index,
+  // so we only have to look there if the lookup above failed. This is in
+  // particular important for updates: a triple that mentions such a word has to
+  // use its `Id` of the auxiliary vocabulary, else it would not be recognized
+  // as a duplicate of, or as the deletion of, a triple of the auxiliary index.
+  const auto* auxVocab = index.auxVocab();
+  if (auxVocab != nullptr) {
+    if (auto auxIndex = auxVocab->getId(content); auxIndex.has_value()) {
+      return Id::makeFromAuxVocabIndex(auxIndex.value());
+    }
+  }
   return std::pair(lower, upper);
 }
 

--- a/src/util/Serializer/TripleSerializer.h
+++ b/src/util/Serializer/TripleSerializer.h
@@ -8,6 +8,7 @@
 
 #include <array>
 #include <fstream>
+#include <limits>
 
 #include "backports/algorithm.h"
 #include "backports/concepts.h"
@@ -32,7 +33,11 @@ constexpr std::array magicBytes{'Q', 'L', 'E', 'V', 'E', 'R', '.',
                                 'U', 'P', 'D', 'A', 'T', 'E'};
 
 // The `formatVersion` has to be increased when the format below is changed.
-constexpr uint16_t formatVersion = 1;
+constexpr uint16_t formatVersion = 2;
+
+// The value that is stored for the generation of the auxiliary index (see
+// `index/AuxIndex.h`) when the `Id`s do not belong to any auxiliary index.
+constexpr uint64_t noAuxIndexGeneration = std::numeric_limits<uint64_t>::max();
 
 // Read a value of type T from the `serializer`.
 CPP_template(typename T, typename Serializer)(
@@ -43,20 +48,30 @@ CPP_template(typename T, typename Serializer)(
   return value;
 }
 
-// Write the header of the file format to the output stream. We are currently at
-// version 1.
+// Write the header of the file format to the output stream. Besides the magic
+// bytes and the format version, the header stores the generation of the
+// auxiliary index that the serialized `Id`s belong to (see
+// `readHeader` for why).
 CPP_template(typename Serializer)(
     requires serialization::WriteSerializer<
-        Serializer>) void writeHeader(Serializer& serializer) {
+        Serializer>) void writeHeader(Serializer& serializer,
+                                      uint64_t auxIndexGeneration) {
   serializer << magicBytes;
   serializer << formatVersion;
+  serializer << auxIndexGeneration;
 }
 
 // Read the header of the file format from the input stream and ensure that it
-// is correct.
+// is correct. In particular, the serialized `Id`s may refer to the vocabulary
+// of a specific generation of the auxiliary index (see `index/AuxIndex.h`),
+// whose `Id`s are only valid for that one generation, so reading them back is
+// only allowed for exactly that generation; `expectedAuxIndexGeneration`
+// therefore has to be the generation of the auxiliary index of the index that
+// the `Id`s are read for.
 CPP_template(typename Serializer)(
     requires serialization::ReadSerializer<
-        Serializer>) void readHeader(Serializer& serializer) {
+        Serializer>) void readHeader(Serializer& serializer,
+                                     uint64_t expectedAuxIndexGeneration) {
   std::decay_t<decltype(magicBytes)> magicByteBuffer{};
   serializer >> magicByteBuffer;
   AD_CORRECTNESS_CHECK(magicByteBuffer == magicBytes);
@@ -70,6 +85,17 @@ CPP_template(typename Serializer)(
       version,
       ", As those features are currently still experimental, please contact "
       "the developers of QLever");
+  uint64_t auxIndexGeneration;
+  serializer >> auxIndexGeneration;
+  AD_CORRECTNESS_CHECK(
+      auxIndexGeneration == expectedAuxIndexGeneration,
+      "The serialized triples were written for the generation ",
+      auxIndexGeneration,
+      " of the auxiliary index, but the index currently has the generation ",
+      expectedAuxIndexGeneration,
+      ". The `Id`s of an auxiliary vocabulary are only valid for the "
+      "generation "
+      "that they were created for, so they cannot be read back");
 }
 
 // Serialize the local vocabulary to the output stream. Returns a mapping from
@@ -171,9 +197,11 @@ std::vector<Id> deserializeIds(Serializer& serializer,
 CPP_template(typename Range)(
     requires ql::ranges::range<
         Range>) void serializeIds(const ql::filesystem::path& path,
-                                  const LocalVocab& vocab, Range&& idRanges) {
+                                  const LocalVocab& vocab, Range&& idRanges,
+                                  uint64_t auxIndexGeneration =
+                                      detail::noAuxIndexGeneration) {
   serialization::FileWriteSerializer serializer{path.string()};
-  detail::writeHeader(serializer);
+  detail::writeHeader(serializer, auxIndexGeneration);
   detail::serializeLocalVocab(serializer, vocab);
   serializer << uint64_t{ql::ranges::size(idRanges)};
   for (const auto& ids : idRanges) {
@@ -182,7 +210,8 @@ CPP_template(typename Range)(
 }
 
 inline std::tuple<LocalVocab, std::vector<std::vector<Id>>> deserializeIds(
-    const ql::filesystem::path& path, const LocalVocabContext& context) {
+    const ql::filesystem::path& path, const LocalVocabContext& context,
+    uint64_t expectedAuxIndexGeneration = detail::noAuxIndexGeneration) {
   // This is a minor TOCTOU issue, the file might be gone after this check and
   // before the call to `fopen`, done by `FileReadSerializer`, so ideally we'd
   // handle this as a special exception type of our own `File` class, which
@@ -203,7 +232,7 @@ inline std::tuple<LocalVocab, std::vector<std::vector<Id>>> deserializeIds(
   }();
   AD_LOG_INFO << "Reading and processing persisted updates from " << path
               << " ..." << std::endl;
-  detail::readHeader(serializer);
+  detail::readHeader(serializer, expectedAuxIndexGeneration);
   auto [vocab, mapping] = detail::deserializeLocalVocab(serializer, context);
   std::vector<std::vector<Id>> idVectors;
   auto numRanges = detail::readValue<uint64_t>(serializer);

--- a/test/AuxIndexBuilderTest.cpp
+++ b/test/AuxIndexBuilderTest.cpp
@@ -1,0 +1,351 @@
+// Copyright 2026 The QLever Authors, in particular:
+//
+// 2026 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+//
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#include <absl/cleanup/cleanup.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "./util/GTestHelpers.h"
+#include "./util/IndexTestHelpers.h"
+#include "global/Constants.h"
+#include "index/AuxIndexBuilder.h"
+#include "index/DeltaTriples.h"
+#include "index/ExportIds.h"
+#include "index/IndexImpl.h"
+#include "parser/RdfParser.h"
+#include "parser/Tokenizer.h"
+#include "util/MemorySize/MemorySize.h"
+
+namespace {
+
+using namespace ad_utility::memory_literals;
+
+// A triple of an auxiliary index, as a human-readable representation of its
+// four components plus the information whether it is inserted or deleted. This
+// is what the tests below compare.
+struct ReadableUpdateTriple {
+  std::array<std::string, 4> quad_;
+  bool insertOrDelete_;
+
+  bool operator==(const ReadableUpdateTriple& other) const {
+    return quad_ == other.quad_ && insertOrDelete_ == other.insertOrDelete_;
+  }
+  friend std::ostream& operator<<(std::ostream& os,
+                                  const ReadableUpdateTriple& triple) {
+    os << (triple.insertOrDelete_ ? "+ " : "- ");
+    for (const auto& component : triple.quad_) {
+      os << component << ' ';
+    }
+    return os;
+  }
+};
+
+// Parse the given `turtle` into `IdTriple`s, adding new words to `localVocab`.
+// The triples are sorted and deduplicated, which `DeltaTriples` requires of its
+// callers (see `ExecuteUpdate::sortAndRemoveDuplicates`).
+std::vector<IdTriple<0>> makeIdTriples(const IndexImpl& index,
+                                       LocalVocab& localVocab,
+                                       const std::string& turtle) {
+  RdfStringParser<TurtleParser<Tokenizer>> parser{&index.encodedIriManager()};
+  parser.parseUtf8String(turtle);
+  return ad_utility::transform(
+      parser.getTriples(), [&index, &localVocab](TurtleTriple triple) {
+        if (triple.graphIri_ == qlever::specialIds().at(DEFAULT_GRAPH_IRI)) {
+          triple.graphIri_ = TripleComponent{
+              TripleComponent::Iri::fromIriref(DEFAULT_GRAPH_IRI)};
+        }
+        std::array<Id, 4> ids{
+            std::move(triple.subject_).toValueId(index, localVocab),
+            TripleComponent{triple.predicate_}.toValueId(index, localVocab),
+            std::move(triple.object_).toValueId(index, localVocab),
+            std::move(triple.graphIri_).toValueId(index, localVocab)};
+        return IdTriple<0>{ids};
+      });
+}
+
+// See above.
+std::vector<IdTriple<0>> makeSortedIdTriples(const IndexImpl& index,
+                                             LocalVocab& localVocab,
+                                             const std::string& turtle) {
+  auto triples = makeIdTriples(index, localVocab, turtle);
+  ql::ranges::sort(triples);
+  triples.erase(std::unique(triples.begin(), triples.end()), triples.end());
+  return triples;
+}
+
+// Read all triples of the given permutation of `auxIndex` and convert them into
+// their readable representation. The words are looked up in the vocabularies of
+// `index` and of `auxIndex`.
+std::vector<ReadableUpdateTriple> readAuxPermutation(
+    const IndexImpl& index, const AuxIndex& auxIndex,
+    Permutation::Enum permutationEnum, bool isInternal) {
+  auto handle = std::make_shared<ad_utility::CancellationHandle<>>();
+  auto [reader, blocks] =
+      auxIndex.scanFull(permutationEnum, isInternal, handle);
+
+  // Convert a single `Id` into a readable string. The `Id`s of the auxiliary
+  // vocabulary are resolved there, all others in the main index.
+  auto toString = [&index, &auxIndex](Id id) -> std::string {
+    if (id.getDatatype() == Datatype::AuxVocabIndex) {
+      return absl::StrCat("aux:",
+                          std::string(auxIndex.vocab()[id.getAuxVocabIndex()]));
+    }
+    LocalVocab emptyLocalVocab;
+    auto word = ql::exportIds::idToLiteralOrIri(index, id, emptyLocalVocab);
+    return word.has_value() ? word.value().toStringRepresentation()
+                            : absl::StrCat("id:", id.getBits());
+  };
+
+  std::vector<ReadableUpdateTriple> result;
+  for (const IdTable& block : blocks) {
+    for (size_t row = 0; row < block.numRows(); ++row) {
+      result.push_back({{toString(block(row, 0)), toString(block(row, 1)),
+                         toString(block(row, 2)), toString(block(row, 3))},
+                        block(row, AuxIndex::insertOrDeleteColumn) ==
+                            AuxIndex::insertedId()});
+    }
+  }
+  return result;
+}
+
+// Fixture that sets up an index, applies updates to it, and builds auxiliary
+// indices from them.
+class AuxIndexBuilderTest : public ::testing::Test {
+ protected:
+  static constexpr const char* testTurtle =
+      "<a> <p> <A> . <b> <p> <B> . <c> <p> <C> .";
+
+  // The index is owned by the test (not taken from the cache of `getQec`),
+  // because building an auxiliary index writes files next to it, and a leftover
+  // auxiliary index would be picked up by a later test that uses the same base
+  // name.
+  std::unique_ptr<Index> index_ =
+      std::make_unique<Index>(makeIndex(std::nullopt));
+  // The base names of all auxiliary indices that were built, so that their
+  // files can be removed again.
+  std::vector<std::string> auxBasenames_;
+
+  // Create the test index, with the given vocabulary type if it is set.
+  static Index makeIndex(
+      std::optional<ad_utility::VocabularyType> vocabularyType) {
+    // Remove the auxiliary indices of a previous run of this test, else the
+    // freshly built index would pick them up (see
+    // `IndexImpl::loadNewestAuxIndexFromDisk`).
+    std::string basename = gtestCurrentTestName();
+    for (size_t generation : AuxIndex::generationsOnDisk(basename)) {
+      AuxIndex::deleteFromDisk(AuxIndex::makeBasename(basename, generation));
+    }
+    ad_utility::testing::TestIndexConfig config{std::string{testTurtle}};
+    config.vocabularyType = vocabularyType;
+    // The WKT literals of the geo-split test are longer than the default parser
+    // buffer.
+    config.parserBufferSize = 10_kB;
+    return ad_utility::testing::makeTestIndex(basename, std::move(config));
+  }
+
+  ~AuxIndexBuilderTest() override {
+    for (const auto& basename : auxBasenames_) {
+      AuxIndex::deleteFromDisk(basename);
+    }
+  }
+
+  IndexImpl& impl() { return index_->getImpl(); }
+  const IndexImpl& impl() const { return index_->getImpl(); }
+
+  // Apply the given insertions and deletions to the delta triples of the index.
+  void update(const std::string& toInsert, const std::string& toDelete = "") {
+    auto handle = std::make_shared<ad_utility::CancellationHandle<>>();
+    index_->deltaTriplesManager().modify<void>(
+        [this, &toInsert, &toDelete, &handle](DeltaTriples& deltaTriples) {
+          LocalVocab localVocab;
+          if (!toDelete.empty()) {
+            deltaTriples.deleteTriples<DeltaTriples::Consolidate::No>(
+                handle, makeSortedIdTriples(impl(), localVocab, toDelete));
+          }
+          if (!toInsert.empty()) {
+            deltaTriples.insertTriples<DeltaTriples::Consolidate::No>(
+                handle, makeSortedIdTriples(impl(), localVocab, toInsert));
+          }
+          deltaTriples.consolidateAll();
+        },
+        false, true);
+  }
+
+  // Build a new generation of the auxiliary index from the current delta
+  // triples and load it.
+  std::pair<qlever::AuxIndexBuildResult, std::unique_ptr<AuxIndex>> build() {
+    auto handle = std::make_shared<ad_utility::CancellationHandle<>>();
+    auto [state, localVocabEntries, ownedBlocks] =
+        index_->deltaTriplesManager()
+            .getCurrentLocatedTriplesSharedStateWithVocab();
+    auto result = qlever::buildAuxIndex(impl(), *state, 10_MB, handle);
+    auxBasenames_.push_back(result.basename_);
+
+    auto auxIndex = std::make_unique<AuxIndex>(impl().allocator());
+    const auto& locale = impl().configurationJson().at("locale");
+    auxIndex->loadFromDisk(result.basename_, std::string{locale.at("language")},
+                           std::string{locale.at("country")},
+                           bool{locale.at("ignore-punctuation")});
+    return {std::move(result), std::move(auxIndex)};
+  }
+};
+
+// ____________________________________________________________________________
+TEST_F(AuxIndexBuilderTest, buildFromInsertionsAndDeletions) {
+  // `<d>` and `<D>` are new words, all the others are part of the vocabulary of
+  // the main index.
+  update("<d> <p> <D> .", "<a> <p> <A> .");
+  auto [result, auxIndex] = build();
+
+  EXPECT_EQ(result.metadata_.generation_, 0);
+  EXPECT_EQ(result.metadata_.numInserted_, 1);
+  EXPECT_EQ(result.metadata_.numDeleted_, 1);
+  // The two new words of the inserted triple.
+  EXPECT_EQ(result.metadata_.numVocabWords_, 2);
+  EXPECT_EQ(auxIndex->vocab().numWords(), 2);
+  EXPECT_EQ(auxIndex->vocab()[AuxVocabIndex::make(0)], "<d>");
+  EXPECT_EQ(auxIndex->vocab()[AuxVocabIndex::make(1)], "<D>");
+
+  // All six permutations hold both triples, each with its correct flag.
+  auto defaultGraph = std::string{DEFAULT_GRAPH_IRI};
+  EXPECT_THAT(
+      readAuxPermutation(impl(), *auxIndex, Permutation::SPO, false),
+      ::testing::UnorderedElementsAre(
+          ReadableUpdateTriple{{"<a>", "<p>", "<A>", defaultGraph}, false},
+          ReadableUpdateTriple{{"aux:<d>", "<p>", "aux:<D>", defaultGraph},
+                               true}));
+  EXPECT_THAT(
+      readAuxPermutation(impl(), *auxIndex, Permutation::OPS, false),
+      ::testing::UnorderedElementsAre(
+          ReadableUpdateTriple{{"<A>", "<p>", "<a>", defaultGraph}, false},
+          ReadableUpdateTriple{{"aux:<D>", "<p>", "aux:<d>", defaultGraph},
+                               true}));
+  EXPECT_THAT(
+      readAuxPermutation(impl(), *auxIndex, Permutation::PSO, false),
+      ::testing::UnorderedElementsAre(
+          ReadableUpdateTriple{{"<p>", "<a>", "<A>", defaultGraph}, false},
+          ReadableUpdateTriple{{"<p>", "aux:<d>", "aux:<D>", defaultGraph},
+                               true}));
+}
+
+// ____________________________________________________________________________
+TEST_F(AuxIndexBuilderTest, rebuildMergesWithPreviousGeneration) {
+  update("<d> <p> <D> .", "<a> <p> <A> .");
+  auto [firstResult, firstAux] = build();
+  ASSERT_EQ(firstResult.metadata_.generation_, 0);
+
+  std::string firstAuxVocabWord{firstAux->vocab()[AuxVocabIndex::make(0)]};
+  // Make the first generation the current auxiliary index of the index, exactly
+  // as the publication of a new generation does, and clear the delta triples
+  // that it now covers.
+  impl().setAuxIndexForTesting(std::move(firstAux));
+  index_->deltaTriplesManager().clear();
+
+  // The second round of updates: a new word `<e>`, a deletion of a triple that
+  // the first generation inserted, and a re-insertion of a triple that the
+  // first generation deleted. The latter two are exactly the cases where the
+  // delta triples have to win over the auxiliary index.
+  update("<e> <p> <a> . <a> <p> <A> .", "<d> <p> <D> .");
+  auto [secondResult, secondAux] = build();
+
+  EXPECT_EQ(secondResult.metadata_.generation_, 1);
+  // The surviving triples are: `<e> <p> <a>` and `<a> <p> <A>` as insertions
+  // and
+  // `<d> <p> <D>` as a deletion.
+  EXPECT_EQ(secondResult.metadata_.numInserted_, 2);
+  EXPECT_EQ(secondResult.metadata_.numDeleted_, 1);
+  // `<D>` and `<d>` are carried over from the first generation, `<e>` is new.
+  EXPECT_EQ(secondResult.metadata_.numVocabWords_, 3);
+
+  auto defaultGraph = std::string{DEFAULT_GRAPH_IRI};
+  EXPECT_THAT(
+      readAuxPermutation(impl(), *secondAux, Permutation::SPO, false),
+      ::testing::UnorderedElementsAre(
+          ReadableUpdateTriple{{"<a>", "<p>", "<A>", defaultGraph}, true},
+          ReadableUpdateTriple{{"aux:<d>", "<p>", "aux:<D>", defaultGraph},
+                               false},
+          ReadableUpdateTriple{{"aux:<e>", "<p>", "<a>", defaultGraph}, true}));
+
+  // The words that were carried over got new `Id`s, and the mapping translates
+  // the `Id`s of the first generation into them.
+  auto oldIdOfLowercaseD = Id::makeFromAuxVocabIndex(AuxVocabIndex::make(0));
+  ASSERT_EQ(firstAuxVocabWord, "<d>");
+  auto newId = secondResult.idMapping_.map(oldIdOfLowercaseD);
+  ASSERT_TRUE(newId.has_value());
+  EXPECT_EQ(secondAux->vocab()[newId.value().getAuxVocabIndex()], "<d>");
+}
+
+// ____________________________________________________________________________
+TEST_F(AuxIndexBuilderTest, buildWithGeoSplitVocabulary) {
+  // Rebuild the index with a geo-split vocabulary, so that the auxiliary
+  // vocabulary splits its words the same way (see `AuxVocabulary`).
+  index_ = std::make_unique<Index>(
+      makeIndex(ad_utility::VocabularyType::OnDiskCompressedGeoSplit));
+  ASSERT_TRUE(impl().getVocab().isGeoInfoAvailable());
+
+  // Insert two new ordinary IRIs and two new WKT literals, which end up in
+  // different sub-vocabularies of the auxiliary vocabulary. Note that a WKT
+  // literal that is a `POINT` would be converted into an `Id` of type
+  // `Datatype::GeoPoint` and would therefore not need a vocabulary entry at
+  // all.
+  auto wkt = [](std::string_view content) {
+    return absl::StrCat("\"", content, "\"^^<", GEO_WKT_LITERAL, ">");
+  };
+  update(absl::StrCat("<d> <p> ", wkt("LINESTRING(1 1, 2 2)"), " . <e> <p> ",
+                      wkt("POLYGON((1 1, 2 2, 3 1, 1 1))"), " ."));
+  auto [result, auxIndex] = build();
+
+  EXPECT_EQ(result.metadata_.numInserted_, 2);
+  // Two new IRIs and two new WKT literals.
+  EXPECT_EQ(result.metadata_.numVocabWords_, 4);
+
+  // The two IRIs are in the first sub-vocabulary, the two WKT literals in the
+  // second one, whose `Id`s carry the marker bit.
+  auto markerBit = uint64_t{1} << 59;
+  EXPECT_EQ(auxIndex->vocab()[AuxVocabIndex::make(0)], "<d>");
+  EXPECT_EQ(auxIndex->vocab()[AuxVocabIndex::make(1)], "<e>");
+  EXPECT_EQ(auxIndex->vocab()[AuxVocabIndex::make(markerBit)],
+            wkt("LINESTRING(1 1, 2 2)"));
+  EXPECT_EQ(auxIndex->vocab()[AuxVocabIndex::make(markerBit | 1)],
+            wkt("POLYGON((1 1, 2 2, 3 1, 1 1))"));
+  // The geometry information of the new WKT literals is precomputed, just as it
+  // is in the main index.
+  EXPECT_TRUE(auxIndex->vocab().vocab().isGeoInfoAvailable());
+  EXPECT_TRUE(auxIndex->vocab()
+                  .vocab()
+                  .getGeoInfo(AuxVocabIndex::make(markerBit))
+                  .has_value());
+
+  auto defaultGraph = std::string{DEFAULT_GRAPH_IRI};
+  EXPECT_THAT(
+      readAuxPermutation(impl(), *auxIndex, Permutation::SPO, false),
+      ::testing::UnorderedElementsAre(
+          ReadableUpdateTriple{
+              {"aux:<d>", "<p>",
+               absl::StrCat("aux:", wkt("LINESTRING(1 1, 2 2)")), defaultGraph},
+              true},
+          ReadableUpdateTriple{
+              {"aux:<e>", "<p>",
+               absl::StrCat("aux:", wkt("POLYGON((1 1, 2 2, 3 1, 1 1))")),
+               defaultGraph},
+              true}));
+}
+
+// ____________________________________________________________________________
+TEST_F(AuxIndexBuilderTest, buildWithoutAnyUpdates) {
+  auto [result, auxIndex] = build();
+  EXPECT_EQ(result.metadata_.numInserted_, 0);
+  EXPECT_EQ(result.metadata_.numDeleted_, 0);
+  EXPECT_EQ(result.metadata_.numVocabWords_, 0);
+  EXPECT_TRUE(auxIndex->isEmpty());
+  EXPECT_THAT(readAuxPermutation(impl(), *auxIndex, Permutation::SPO, false),
+              ::testing::IsEmpty());
+}
+
+}  // namespace

--- a/test/AuxIndexScanTest.cpp
+++ b/test/AuxIndexScanTest.cpp
@@ -1,0 +1,250 @@
+// Copyright 2026 The QLever Authors, in particular:
+//
+// 2026 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+//
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "./util/GTestHelpers.h"
+#include "./util/IndexTestHelpers.h"
+#include "global/Constants.h"
+#include "index/AuxIndexBuilder.h"
+#include "index/DeltaTriples.h"
+#include "index/ExportIds.h"
+#include "index/IndexImpl.h"
+#include "parser/RdfParser.h"
+#include "parser/Tokenizer.h"
+#include "util/MemorySize/MemorySize.h"
+
+namespace {
+using namespace ad_utility::memory_literals;
+
+// Parse the given `turtle` into sorted, deduplicated `IdTriple`s (which is what
+// `DeltaTriples` requires of its callers).
+std::vector<IdTriple<0>> makeSortedIdTriples(const IndexImpl& index,
+                                             LocalVocab& localVocab,
+                                             const std::string& turtle) {
+  RdfStringParser<TurtleParser<Tokenizer>> parser{&index.encodedIriManager()};
+  parser.parseUtf8String(turtle);
+  auto triples = ad_utility::transform(
+      parser.getTriples(), [&index, &localVocab](TurtleTriple triple) {
+        if (triple.graphIri_ == qlever::specialIds().at(DEFAULT_GRAPH_IRI)) {
+          triple.graphIri_ = TripleComponent{
+              TripleComponent::Iri::fromIriref(DEFAULT_GRAPH_IRI)};
+        }
+        std::array<Id, 4> ids{
+            std::move(triple.subject_).toValueId(index, localVocab),
+            TripleComponent{triple.predicate_}.toValueId(index, localVocab),
+            std::move(triple.object_).toValueId(index, localVocab),
+            std::move(triple.graphIri_).toValueId(index, localVocab)};
+        return IdTriple<0>{ids};
+      });
+  ql::ranges::sort(triples);
+  triples.erase(std::unique(triples.begin(), triples.end()), triples.end());
+  return triples;
+}
+
+// Fixture that builds an index, applies updates, moves them into an auxiliary
+// index, and then scans the index.
+class AuxIndexScanTest : public ::testing::Test {
+ protected:
+  static constexpr const char* testTurtle =
+      "<a> <p> <A> . <b> <p> <B> . <c> <p> <C> . <d> <p> <D> .";
+
+  std::unique_ptr<Index> index_ = std::make_unique<Index>(makeIndex());
+  std::vector<std::string> auxBasenames_;
+
+  static Index makeIndex() {
+    std::string basename = gtestCurrentTestName();
+    for (size_t generation : AuxIndex::generationsOnDisk(basename)) {
+      AuxIndex::deleteFromDisk(AuxIndex::makeBasename(basename, generation));
+    }
+    ad_utility::testing::TestIndexConfig config{std::string{testTurtle}};
+    // A tiny block size, so that the permutations have several blocks and the
+    // triples of the auxiliary index are distributed over them.
+    config.blocksizePermutations = 16_B;
+    return ad_utility::testing::makeTestIndex(basename, std::move(config));
+  }
+
+  ~AuxIndexScanTest() override {
+    for (const auto& basename : auxBasenames_) {
+      AuxIndex::deleteFromDisk(basename);
+    }
+  }
+
+  IndexImpl& impl() { return index_->getImpl(); }
+  const IndexImpl& impl() const { return index_->getImpl(); }
+
+  // Apply the given insertions and deletions to the delta triples.
+  void update(const std::string& toInsert, const std::string& toDelete = "") {
+    auto handle = std::make_shared<ad_utility::CancellationHandle<>>();
+    index_->deltaTriplesManager().modify<void>(
+        [this, &toInsert, &toDelete, &handle](DeltaTriples& deltaTriples) {
+          LocalVocab localVocab;
+          if (!toDelete.empty()) {
+            deltaTriples.deleteTriples<DeltaTriples::Consolidate::No>(
+                handle, makeSortedIdTriples(impl(), localVocab, toDelete));
+          }
+          if (!toInsert.empty()) {
+            deltaTriples.insertTriples<DeltaTriples::Consolidate::No>(
+                handle, makeSortedIdTriples(impl(), localVocab, toInsert));
+          }
+          deltaTriples.consolidateAll();
+        },
+        false, true);
+  }
+
+  // Move the current delta triples into a new generation of the auxiliary
+  // index, publish it, and clear the delta triples, so that from now on the
+  // triples are only in the auxiliary index.
+  void moveDeltaTriplesToAuxIndex() {
+    auto handle = std::make_shared<ad_utility::CancellationHandle<>>();
+    auto [state, entries, blocks] =
+        index_->deltaTriplesManager()
+            .getCurrentLocatedTriplesSharedStateWithVocab();
+    auto result = qlever::buildAuxIndex(impl(), *state, 10_MB, handle);
+    auxBasenames_.push_back(result.basename_);
+
+    auto auxIndex = std::make_shared<AuxIndex>(impl().allocator());
+    const auto& locale = impl().configurationJson().at("locale");
+    auxIndex->loadFromDisk(result.basename_, std::string{locale.at("language")},
+                           std::string{locale.at("country")},
+                           bool{locale.at("ignore-punctuation")});
+    index_->deltaTriplesManager().clear();
+    impl().setAuxIndexForTesting(std::move(auxIndex));
+  }
+
+  // Scan the given permutation for all triples and return them in a
+  // human-readable form (`subject predicate object`, in the order of the
+  // permutation).
+  std::vector<std::string> scanAll(Permutation::Enum permutationEnum) {
+    const auto& permutation = impl().getPermutation(permutationEnum);
+    auto state =
+        index_->deltaTriplesManager().getCurrentLocatedTriplesSharedState();
+    auto scanSpecAndBlocks = permutation.getScanSpecAndBlocks(
+        ScanSpecification{std::nullopt, std::nullopt, std::nullopt}, *state);
+    auto handle = std::make_shared<ad_utility::CancellationHandle<>>();
+    IdTable table = permutation.scan(scanSpecAndBlocks, {}, handle, *state);
+    LocalVocab emptyLocalVocab;
+    auto toString = [this, &emptyLocalVocab](Id id) -> std::string {
+      auto word = ql::exportIds::idToLiteralOrIri(impl(), id, emptyLocalVocab);
+      return word.has_value() ? word.value().toStringRepresentation()
+                              : absl::StrCat("id:", id.getBits());
+    };
+    std::vector<std::string> result;
+    for (size_t row = 0; row < table.numRows(); ++row) {
+      result.push_back(absl::StrCat(toString(table(row, 0)), " ",
+                                    toString(table(row, 1)), " ",
+                                    toString(table(row, 2))));
+    }
+    return result;
+  }
+};
+
+// ____________________________________________________________________________
+TEST_F(AuxIndexScanTest, insertionsAndDeletionsFromTheAuxIndexAreMergedIn) {
+  // The index contains `<a> <p> <A>` ... `<d> <p> <D>`. Delete two of them and
+  // insert two triples, one of which sorts in the middle of the existing ones
+  // and one of which is larger than all of them (so that it ends up in the
+  // block after the last one).
+  update("<b> <p> <Z> . <z> <p> <Z> .", "<a> <p> <A> . <c> <p> <C> .");
+  auto expected = scanAll(Permutation::SPO);
+  EXPECT_THAT(expected, ::testing::ElementsAre("<b> <p> <B>", "<b> <p> <Z>",
+                                               "<d> <p> <D>", "<z> <p> <Z>"));
+
+  // After moving the updates into the auxiliary index, a scan has to return
+  // exactly the same result, now with the triples coming from disk.
+  moveDeltaTriplesToAuxIndex();
+  EXPECT_EQ(scanAll(Permutation::SPO), expected);
+  // The delta triples are empty now, so the result really comes from the
+  // auxiliary index.
+  EXPECT_EQ(index_->deltaTriplesManager()
+                .getCurrentLocatedTriplesSharedState()
+                ->counts_.value()
+                .triplesInserted_,
+            0);
+
+  // The same in the other permutations.
+  EXPECT_THAT(scanAll(Permutation::OPS),
+              ::testing::ElementsAre("<B> <p> <b>", "<D> <p> <d>",
+                                     "<Z> <p> <b>", "<Z> <p> <z>"));
+  EXPECT_THAT(scanAll(Permutation::PSO),
+              ::testing::ElementsAre("<p> <b> <B>", "<p> <b> <Z>",
+                                     "<p> <d> <D>", "<p> <z> <Z>"));
+}
+
+// ____________________________________________________________________________
+TEST_F(AuxIndexScanTest, deltaTriplesTakePrecedenceOverTheAuxIndex) {
+  update("<b> <p> <Z> . <z> <p> <Z> .", "<a> <p> <A> .");
+  moveDeltaTriplesToAuxIndex();
+  ASSERT_THAT(
+      scanAll(Permutation::SPO),
+      ::testing::ElementsAre("<b> <p> <B>", "<b> <p> <Z>", "<c> <p> <C>",
+                             "<d> <p> <D>", "<z> <p> <Z>"));
+
+  // Now delete a triple that the auxiliary index inserted, re-insert a triple
+  // that it deleted, and delete a triple of the main index. All three have to
+  // take precedence over the auxiliary index.
+  update("<a> <p> <A> .", "<b> <p> <Z> . <d> <p> <D> .");
+  EXPECT_THAT(scanAll(Permutation::SPO),
+              ::testing::ElementsAre("<a> <p> <A>", "<b> <p> <B>",
+                                     "<c> <p> <C>", "<z> <p> <Z>"));
+}
+
+// ____________________________________________________________________________
+TEST_F(AuxIndexScanTest, scanWithFixedSubjectAndPredicate) {
+  update("<b> <p> <Z> . <z> <p> <Z> .", "<a> <p> <A> .");
+  moveDeltaTriplesToAuxIndex();
+
+  auto getId = ad_utility::testing::makeGetId(*index_);
+  auto state =
+      index_->deltaTriplesManager().getCurrentLocatedTriplesSharedState();
+  const auto& permutation = impl().getPermutation(Permutation::SPO);
+  auto handle = std::make_shared<ad_utility::CancellationHandle<>>();
+
+  // A scan for `<b> <p> ?o` has to return the object of the main index and the
+  // one that the auxiliary index inserted.
+  auto scanSpec = ScanSpecification{getId("<b>"), getId("<p>"), std::nullopt};
+  auto scanSpecAndBlocks = permutation.getScanSpecAndBlocks(scanSpec, *state);
+  IdTable table = permutation.scan(scanSpecAndBlocks, {}, handle, *state);
+  ASSERT_EQ(table.numColumns(), 1);
+  EXPECT_THAT(table.getColumn(0),
+              ::testing::ElementsAre(getId("<B>"), getId("<Z>")));
+
+  // A scan for `<a> <p> ?o` has to be empty, because the auxiliary index
+  // deleted the only such triple.
+  scanSpec = ScanSpecification{getId("<a>"), getId("<p>"), std::nullopt};
+  scanSpecAndBlocks = permutation.getScanSpecAndBlocks(scanSpec, *state);
+  table = permutation.scan(scanSpecAndBlocks, {}, handle, *state);
+  EXPECT_EQ(table.numRows(), 0);
+
+  // A scan for the subject that only exists in the auxiliary index.
+  scanSpec = ScanSpecification{getId("<z>"), getId("<p>"), std::nullopt};
+  scanSpecAndBlocks = permutation.getScanSpecAndBlocks(scanSpec, *state);
+  table = permutation.scan(scanSpecAndBlocks, {}, handle, *state);
+  EXPECT_THAT(table.getColumn(0), ::testing::ElementsAre(getId("<Z>")));
+}
+
+// ____________________________________________________________________________
+TEST_F(AuxIndexScanTest, scanSizesAccountForTheAuxIndex) {
+  update("<b> <p> <Z> . <z> <p> <Z> .", "<a> <p> <A> .");
+  moveDeltaTriplesToAuxIndex();
+  auto state =
+      index_->deltaTriplesManager().getCurrentLocatedTriplesSharedState();
+  const auto& permutation = impl().getPermutation(Permutation::SPO);
+  auto scanSpecAndBlocks = permutation.getScanSpecAndBlocks(
+      ScanSpecification{std::nullopt, std::nullopt, std::nullopt}, *state);
+  // Four triples in the main index, one deleted and two inserted.
+  EXPECT_EQ(permutation.getResultSizeOfScan(scanSpecAndBlocks, *state), 5);
+  auto [lower, upper] =
+      permutation.getSizeEstimateForScan(scanSpecAndBlocks, *state);
+  EXPECT_LE(lower, 5);
+  EXPECT_GE(upper, 5);
+}
+
+}  // namespace

--- a/test/AuxVocabularyTest.cpp
+++ b/test/AuxVocabularyTest.cpp
@@ -1,0 +1,343 @@
+// Copyright 2026 The QLever Authors, in particular:
+//
+// 2026 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+//
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#include <absl/cleanup/cleanup.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "./util/GTestHelpers.h"
+#include "global/Constants.h"
+#include "index/AuxVocabulary.h"
+#include "util/BitUtils.h"
+#include "util/File.h"
+#include "util/FilesystemHelpers.h"
+#include "util/HashSet.h"
+
+namespace {
+
+using ad_utility::VocabularyType;
+
+// A WKT literal, which the `SplitGeoVocabulary` stores in its second
+// sub-vocabulary.
+std::string wkt(std::string_view content) {
+  return absl::StrCat("\"", content, "\"^^<", GEO_WKT_LITERAL, ">");
+}
+
+// A main vocabulary of the given `type` that holds `words`, together with the
+// files that back it (which are removed when this object dies).
+class MainVocabulary {
+ private:
+  std::string filename_;
+  RdfsVocabulary vocabulary_;
+
+ public:
+  MainVocabulary(std::string filename,
+                 const ad_utility::HashSet<std::string>& words,
+                 VocabularyType type)
+      : filename_{std::move(filename)} {
+    vocabulary_.resetToType(type);
+    vocabulary_.createFromSet(words, filename_);
+  }
+  ~MainVocabulary() {
+    for (const auto& file :
+         qlever::util::filesWithBaseNameAndSuffix(filename_, "")) {
+      ad_utility::deleteFile(file);
+    }
+  }
+  MainVocabulary(const MainVocabulary&) = delete;
+  MainVocabulary& operator=(const MainVocabulary&) = delete;
+
+  const RdfsVocabulary& vocab() const { return vocabulary_; }
+};
+
+// Write an `AuxVocabulary` with the given `words` (which have to be pushed in
+// the order in which they are given, see `AuxVocabulary::WordWriter`) and read
+// it back.
+void writeAndOpen(AuxVocabulary& auxVocab, const RdfsVocabulary& mainVocab,
+                  const std::string& basename,
+                  const std::vector<std::string>& words, VocabularyType type) {
+  {
+    AuxVocabulary::WordWriter writer{mainVocab, basename, type};
+    for (const auto& word : words) {
+      writer(word);
+    }
+    writer.finish();
+  }
+  auxVocab.open(basename, type, "en", "US", false);
+}
+
+// Remove all files that belong to the auxiliary vocabulary with the given base
+// name.
+void deleteAuxVocabFiles(const std::string& basename) {
+  for (const auto& file :
+       qlever::util::filesWithBaseNameAndSuffix(basename, "")) {
+    ad_utility::deleteFile(file);
+  }
+}
+
+// ____________________________________________________________________________
+TEST(AuxVocabulary, positionsAndLookupWithoutSplit) {
+  auto type = VocabularyType{VocabularyType::OnDiskCompressed};
+  std::string mainFilename = absl::StrCat(gtestCurrentTestName(), ".main");
+  MainVocabulary main{mainFilename, {"\"a\"", "\"c\"", "\"e\""}, type};
+
+  std::string basename = absl::StrCat(gtestCurrentTestName(), ".aux");
+  absl::Cleanup cleanup = [&basename] { deleteAuxVocabFiles(basename); };
+  AuxVocabulary auxVocab;
+  // `"b"` is sorted between `"a"` and `"c"`, `"d"` between `"c"` and `"e"`, and
+  // `"f"` after all words of the main vocabulary.
+  writeAndOpen(auxVocab, main.vocab(), basename, {"\"b\"", "\"d\"", "\"f\""},
+               type);
+
+  ASSERT_EQ(auxVocab.numWords(), 3);
+  EXPECT_EQ(auxVocab[AuxVocabIndex::make(0)], "\"b\"");
+  EXPECT_EQ(auxVocab[AuxVocabIndex::make(1)], "\"d\"");
+  EXPECT_EQ(auxVocab[AuxVocabIndex::make(2)], "\"f\"");
+
+  // Without a split, the `Id`s of the auxiliary vocabulary are dense, so they
+  // agree with their offsets.
+  for (uint64_t i = 0; i < 3; ++i) {
+    EXPECT_EQ(auxVocab.offsetOf(AuxVocabIndex::make(i)), i);
+  }
+
+  // The positions are the indices of the first greater word of the main
+  // vocabulary: `"b"` before `"c"` (index 1), `"d"` before `"e"` (index 2), and
+  // `"f"` after the last word (index 3).
+  auto position = [&auxVocab](uint64_t i) {
+    return Id::fromBits(auxVocab.positionInMainVocab(AuxVocabIndex::make(i)))
+        .getVocabIndex()
+        .get();
+  };
+  EXPECT_EQ(position(0), 1);
+  EXPECT_EQ(position(1), 2);
+  EXPECT_EQ(position(2), 3);
+
+  // The reverse direction: how many words of the auxiliary vocabulary are
+  // smaller than a given word of the main vocabulary.
+  auto numSmaller = [&auxVocab](uint64_t mainIndex) {
+    return auxVocab.numWordsSmallerThanMainVocabPosition(
+        Id::makeFromVocabIndex(VocabIndex::make(mainIndex)));
+  };
+  EXPECT_EQ(numSmaller(0), 0);  // "a"
+  EXPECT_EQ(numSmaller(1), 1);  // "c", greater than "b"
+  EXPECT_EQ(numSmaller(2), 2);  // "e", greater than "b" and "d"
+
+  // Lookup by word.
+  EXPECT_EQ(auxVocab.getId("\"d\""), AuxVocabIndex::make(1));
+  EXPECT_EQ(auxVocab.getId("\"a\""), std::nullopt);
+  EXPECT_EQ(auxVocab.numWordsSmallerThan("\"a\""), 0);
+  EXPECT_EQ(auxVocab.numWordsSmallerThan("\"c\""), 1);
+  EXPECT_EQ(auxVocab.numWordsSmallerThan("\"g\""), 3);
+}
+
+// ____________________________________________________________________________
+TEST(AuxVocabulary, positionsAndLookupWithGeoSplit) {
+  auto type = VocabularyType{VocabularyType::OnDiskCompressedGeoSplit};
+  std::string mainFilename = absl::StrCat(gtestCurrentTestName(), ".main");
+  // The main vocabulary holds two ordinary literals and two WKT literals, the
+  // latter in its second sub-vocabulary.
+  MainVocabulary main{mainFilename,
+                      {"\"a\"", "\"c\"", wkt("POINT(1 1)"), wkt("POINT(3 3)")},
+                      type};
+
+  std::string basename = absl::StrCat(gtestCurrentTestName(), ".aux");
+  absl::Cleanup cleanup = [&basename] { deleteAuxVocabFiles(basename); };
+  AuxVocabulary auxVocab;
+  // The words have to be pushed grouped by sub-vocabulary, the ordinary
+  // literals (marker 0) first, the WKT literals (marker 1) afterwards.
+  writeAndOpen(auxVocab, main.vocab(), basename,
+               {"\"b\"", "\"d\"", wkt("POINT(2 2)"), wkt("POINT(4 4)")}, type);
+
+  ASSERT_EQ(auxVocab.numWords(), 4);
+
+  // The `Id`s of the second sub-vocabulary carry the marker bit, so they are
+  // *not* dense, but their offsets are.
+  auto markerBit = uint64_t{1} << 59;
+  EXPECT_EQ(auxVocab[AuxVocabIndex::make(0)], "\"b\"");
+  EXPECT_EQ(auxVocab[AuxVocabIndex::make(1)], "\"d\"");
+  EXPECT_EQ(auxVocab[AuxVocabIndex::make(markerBit)], wkt("POINT(2 2)"));
+  EXPECT_EQ(auxVocab[AuxVocabIndex::make(markerBit | 1)], wkt("POINT(4 4)"));
+
+  EXPECT_EQ(auxVocab.offsetOf(AuxVocabIndex::make(0)), 0);
+  EXPECT_EQ(auxVocab.offsetOf(AuxVocabIndex::make(1)), 1);
+  EXPECT_EQ(auxVocab.offsetOf(AuxVocabIndex::make(markerBit)), 2);
+  EXPECT_EQ(auxVocab.offsetOf(AuxVocabIndex::make(markerBit | 1)), 3);
+
+  // Each word is positioned in the sub-vocabulary of the main vocabulary that
+  // it belongs to, so the WKT literals get positions that carry the marker bit,
+  // which is what keeps the positions ascending.
+  auto position = [&auxVocab](uint64_t i) {
+    return auxVocab.positionInMainVocab(AuxVocabIndex::make(i)) &
+           ad_utility::bitMaskForLowerBits(ValueId::numDataBits);
+  };
+  EXPECT_EQ(position(0), 1);  // `"b"` before `"c"`
+  EXPECT_EQ(position(1), 2);  // `"d"` after all ordinary literals
+  EXPECT_EQ(position(markerBit), markerBit | 1);      // before `POINT(3 3)`
+  EXPECT_EQ(position(markerBit | 1), markerBit | 2);  // after all geometries
+
+  // The reverse direction has to respect the sub-vocabularies as well: all
+  // words of the first sub-vocabulary are smaller than every word of the second
+  // one.
+  auto numSmaller = [&auxVocab](uint64_t mainIndex) {
+    return auxVocab.numWordsSmallerThanMainVocabPosition(
+        Id::makeFromVocabIndex(VocabIndex::make(mainIndex)));
+  };
+  EXPECT_EQ(numSmaller(0), 0);              // `"a"`
+  EXPECT_EQ(numSmaller(1), 1);              // `"c"`, greater than `"b"`
+  EXPECT_EQ(numSmaller(markerBit), 2);      // `POINT(1 1)`
+  EXPECT_EQ(numSmaller(markerBit | 1), 3);  // `POINT(3 3)`
+
+  // Lookup by word routes to the correct sub-vocabulary.
+  EXPECT_EQ(auxVocab.getId(wkt("POINT(4 4)")),
+            AuxVocabIndex::make(markerBit | 1));
+  EXPECT_EQ(auxVocab.getId(wkt("POINT(1 1)")), std::nullopt);
+  EXPECT_EQ(auxVocab.getId("\"b\""), AuxVocabIndex::make(0));
+  EXPECT_EQ(auxVocab.numWordsSmallerThan(wkt("POINT(0 0)")), 2);
+  EXPECT_EQ(auxVocab.numWordsSmallerThan(wkt("POINT(3 3)")), 3);
+  EXPECT_EQ(auxVocab.numWordsSmallerThan("\"c\""), 1);
+
+  // The precomputed geometry information of the WKT literals is available, just
+  // as it is for the main vocabulary.
+  EXPECT_TRUE(auxVocab.vocab().isGeoInfoAvailable());
+  EXPECT_TRUE(
+      auxVocab.vocab().getGeoInfo(AuxVocabIndex::make(markerBit)).has_value());
+}
+
+// ____________________________________________________________________________
+TEST(AuxVocabulary, semanticComparisonAndRangesWithGeoSplit) {
+  using namespace valueIdComparators;
+  auto type = VocabularyType{VocabularyType::OnDiskCompressedGeoSplit};
+  std::string mainFilename = absl::StrCat(gtestCurrentTestName(), ".main");
+  MainVocabulary main{mainFilename,
+                      {"\"a\"", "\"c\"", wkt("POINT(1 1)"), wkt("POINT(3 3)")},
+                      type};
+
+  std::string basename = absl::StrCat(gtestCurrentTestName(), ".aux");
+  absl::Cleanup cleanup = [&basename] { deleteAuxVocabFiles(basename); };
+  AuxVocabulary auxVocab;
+  writeAndOpen(auxVocab, main.vocab(), basename,
+               {"\"b\"", "\"d\"", wkt("POINT(2 2)"), wkt("POINT(4 4)")}, type);
+  auto ordering = auxVocab.ordering();
+
+  auto markerBit = uint64_t{1} << 59;
+  auto mainId = [](uint64_t index) {
+    return Id::makeFromVocabIndex(VocabIndex::make(index));
+  };
+  auto auxId = [](uint64_t index) {
+    return Id::makeFromAuxVocabIndex(AuxVocabIndex::make(index));
+  };
+  // The merged order of the two vocabularies is
+  // "a" < "b" < "c" < "d" < POINT(1 1) < POINT(2 2) < POINT(3 3) < POINT(4 4),
+  // where the quoted literals come from the first and the WKT literals from the
+  // second sub-vocabulary.
+  std::vector<Id> semanticOrder{mainId(0),
+                                auxId(0),
+                                mainId(1),
+                                auxId(1),
+                                mainId(markerBit),
+                                auxId(markerBit),
+                                mainId(markerBit | 1),
+                                auxId(markerBit | 1)};
+  for (size_t i = 0; i < semanticOrder.size(); ++i) {
+    for (size_t j = 0; j < semanticOrder.size(); ++j) {
+      auto expected = i < j ? ql::strong_ordering::less
+                            : (i > j ? ql::strong_ordering::greater
+                                     : ql::strong_ordering::equal);
+      EXPECT_EQ(compareStringIdsSemantically(semanticOrder[i], semanticOrder[j],
+                                             ordering),
+                expected)
+          << i << " vs " << j;
+    }
+  }
+
+  // The `Id`s of the auxiliary vocabulary are all greater than those of the
+  // main vocabulary when compared bitwise, which is the order in which the
+  // index scans emit them and in which the range filters expect their input.
+  std::vector<Id> bitwiseOrder{
+      mainId(0), mainId(1), mainId(markerBit), mainId(markerBit | 1),
+      auxId(0),  auxId(1),  auxId(markerBit),  auxId(markerBit | 1)};
+  ASSERT_TRUE(ql::ranges::is_sorted(bitwiseOrder, compareByBits));
+
+  // Turn the ranges of iterators that the range filters return into index
+  // pairs.
+  auto rangesFor = [&bitwiseOrder, &ordering](Id referenceId,
+                                              Comparison comparison) {
+    std::vector<std::pair<size_t, size_t>> result;
+    for (auto [begin, end] :
+         getRangesForId(bitwiseOrder.begin(), bitwiseOrder.end(), referenceId,
+                        comparison, ordering)) {
+      result.emplace_back(begin - bitwiseOrder.begin(),
+                          end - bitwiseOrder.begin());
+    }
+    return result;
+  };
+  using Ranges = std::vector<std::pair<size_t, size_t>>;
+
+  // Everything smaller than `"c"`: `"a"` from the main and `"b"` from the
+  // auxiliary vocabulary, which are in two disjoint ranges.
+  EXPECT_THAT(rangesFor(mainId(1), Comparison::LT),
+              ::testing::Eq(Ranges{{0, 1}, {4, 5}}));
+  // Everything smaller than `POINT(1 1)`: all words of the first
+  // sub-vocabularies, no matter what they are.
+  EXPECT_THAT(rangesFor(mainId(markerBit), Comparison::LT),
+              ::testing::Eq(Ranges{{0, 2}, {4, 6}}));
+  // Everything greater than `POINT(2 2)`, which is a word of the auxiliary
+  // vocabulary.
+  EXPECT_THAT(rangesFor(auxId(markerBit), Comparison::GT),
+              ::testing::Eq(Ranges{{3, 4}, {7, 8}}));
+  // A word is only equal to itself, because the two vocabularies are disjoint.
+  EXPECT_THAT(rangesFor(auxId(markerBit), Comparison::EQ),
+              ::testing::Eq(Ranges{{6, 7}}));
+  EXPECT_THAT(rangesFor(mainId(1), Comparison::EQ),
+              ::testing::Eq(Ranges{{1, 2}}));
+}
+
+// ____________________________________________________________________________
+TEST(AuxVocabulary, wordWriterChecksPreconditions) {
+  auto type = VocabularyType{VocabularyType::OnDiskCompressed};
+  std::string mainFilename = absl::StrCat(gtestCurrentTestName(), ".main");
+  MainVocabulary main{mainFilename, {"\"a\"", "\"c\""}, type};
+
+  std::string basename = absl::StrCat(gtestCurrentTestName(), ".aux");
+  absl::Cleanup cleanup = [&basename] { deleteAuxVocabFiles(basename); };
+
+  // A word that is contained in the main vocabulary must not be added.
+  {
+    AuxVocabulary::WordWriter writer{main.vocab(), basename, type};
+    AD_EXPECT_THROW_WITH_MESSAGE(
+        writer("\"a\""),
+        ::testing::HasSubstr("contained in the vocabulary of the main index"));
+  }
+  // The words have to be strictly ascending.
+  {
+    AuxVocabulary::WordWriter writer{main.vocab(), basename, type};
+    writer("\"d\"");
+    AD_EXPECT_THROW_WITH_MESSAGE(
+        writer("\"b\""), ::testing::HasSubstr("strictly ascending order"));
+  }
+}
+
+// ____________________________________________________________________________
+TEST(AuxVocabulary, geoSplitWordWriterRequiresGroupedWords) {
+  auto type = VocabularyType{VocabularyType::OnDiskCompressedGeoSplit};
+  std::string mainFilename = absl::StrCat(gtestCurrentTestName(), ".main");
+  MainVocabulary main{mainFilename, {"\"a\""}, type};
+
+  std::string basename = absl::StrCat(gtestCurrentTestName(), ".aux");
+  absl::Cleanup cleanup = [&basename] { deleteAuxVocabFiles(basename); };
+
+  // Once a word of the second sub-vocabulary has been pushed, no word of the
+  // first one may follow.
+  AuxVocabulary::WordWriter writer{main.vocab(), basename, type};
+  writer(wkt("POINT(1 1)"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      writer("\"b\""), ::testing::HasSubstr("ascending order of the markers"));
+}
+
+}  // namespace

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -309,6 +309,9 @@ addLinkAndDiscoverTest(ContentEncodingHelperTest http)
 addLinkAndDiscoverTest(PrefixCompressorTest)
 
 addLinkAndDiscoverTest(VocabularyTest index)
+addLinkAndDiscoverTest(AuxVocabularyTest index)
+addLinkAndDiscoverTest(AuxIndexBuilderTest index engine)
+addLinkAndDiscoverTest(AuxIndexScanTest index engine)
 
 addLinkAndDiscoverTestNoLibs(IteratorTest)
 

--- a/test/DeltaTriplesTest.cpp
+++ b/test/DeltaTriplesTest.cpp
@@ -752,7 +752,7 @@ TEST_F(DeltaTriplesTest, storeAndRestoreFromEmptySet) {
   EXPECT_NO_THROW(deltaTriples.writeToDisk());
 
   // Check if file contents match
-  std::array<char, 55> expectedContent{
+  std::array<char, 63> expectedContent{
       // Magic bytes
       'Q',
       'L',
@@ -768,8 +768,18 @@ TEST_F(DeltaTriplesTest, storeAndRestoreFromEmptySet) {
       'T',
       'E',
       // Version
-      1,
+      2,
       0,
+      // The generation of the auxiliary index. The index of this test does not
+      // have one, so this is `ad_utility::detail::noAuxIndexGeneration`.
+      static_cast<char>(0xff),
+      static_cast<char>(0xff),
+      static_cast<char>(0xff),
+      static_cast<char>(0xff),
+      static_cast<char>(0xff),
+      static_cast<char>(0xff),
+      static_cast<char>(0xff),
+      static_cast<char>(0xff),
       // Size of `BlankNodeBlocks`.
       0,
       0,

--- a/test/PrefilterExpressionIndexTest.cpp
+++ b/test/PrefilterExpressionIndexTest.cpp
@@ -493,8 +493,9 @@ class PrefilterExpressionOnMetadataTest : public ::testing::Test {
     ValueIdSubrange inputRange{
         ValueIdIt{&evalBlocks, 0, accessValueIdOp},
         ValueIdIt{&evalBlocks, evalBlocks.size() * 2, accessValueIdOp}};
-    std::vector<ValueIdItPair> iteratorRanges = getRangesForId(
-        inputRange.begin(), inputRange.end(), referenceId, compOp);
+    std::vector<ValueIdItPair> iteratorRanges =
+        getRangesForId(inputRange.begin(), inputRange.end(), referenceId,
+                       compOp, valueIdComparators::AuxVocabOrdering{});
     using namespace prefilterExpressions::detail::mapping;
     ASSERT_TRUE(assertEqRelevantBlockItRanges(
         convertFromSpanIdxToSpanBlockItRanges(evalBlocks.begin(),

--- a/test/TripleSerializerTest.cpp
+++ b/test/TripleSerializerTest.cpp
@@ -101,11 +101,18 @@ TEST(TripleSerializer, blankNodesRemapper) {
 // _____________________________________________________________________________
 TEST(TripleSerializer, headerFormatIsCorrect) {
   ad_utility::serialization::ByteBufferWriteSerializer serializer;
-  ad_utility::detail::writeHeader(serializer);
+  // The header ends with the generation of the auxiliary index, here the
+  // sentinel that means "the `Id`s do not belong to an auxiliary index".
+  ad_utility::detail::writeHeader(serializer,
+                                  ad_utility::detail::noAuxIndexGeneration);
 
   EXPECT_THAT(serializer.data(),
-              ::testing::ElementsAre('Q', 'L', 'E', 'V', 'E', 'R', '.', 'U',
-                                     'P', 'D', 'A', 'T', 'E', 1, 0));
+              ::testing::ElementsAre(
+                  'Q', 'L', 'E', 'V', 'E', 'R', '.', 'U', 'P', 'D', 'A', 'T',
+                  'E', 2, 0, static_cast<char>(0xff), static_cast<char>(0xff),
+                  static_cast<char>(0xff), static_cast<char>(0xff),
+                  static_cast<char>(0xff), static_cast<char>(0xff),
+                  static_cast<char>(0xff), static_cast<char>(0xff)));
 }
 
 // _____________________________________________________________________________
@@ -115,21 +122,24 @@ TEST(TripleSerializer, errorOnWrongHeaderFormat) {
     ad_utility::serialization::ByteBufferReadSerializer serializer{
         {'q', 'L', 'E', 'V', 'E', 'R', '.', 'U', 'P', 'D', 'A', 'T', 'E', 1,
          0}};
-    EXPECT_THROW(ad_utility::detail::readHeader(serializer),
+    EXPECT_THROW(ad_utility::detail::readHeader(
+                     serializer, ad_utility::detail::noAuxIndexGeneration),
                  ad_utility::Exception);
   }
   {
     ad_utility::serialization::ByteBufferReadSerializer serializer{
         {'Q', 'L', 'E', 'V', 'E', 'R', '.', 'U', 'P', 'D', 'A', 'T', 'e', 0,
          0}};
-    EXPECT_THROW(ad_utility::detail::readHeader(serializer),
+    EXPECT_THROW(ad_utility::detail::readHeader(
+                     serializer, ad_utility::detail::noAuxIndexGeneration),
                  ad_utility::Exception);
   }
   // Too short magic bytes
   {
     ad_utility::serialization::ByteBufferReadSerializer serializer{
         {'Q', 'L', 'E', 'V', 'E', 'R', 'U', 'P', 'D', 'A', 'T', 'E', 0, 0}};
-    EXPECT_THROW(ad_utility::detail::readHeader(serializer),
+    EXPECT_THROW(ad_utility::detail::readHeader(
+                     serializer, ad_utility::detail::noAuxIndexGeneration),
                  ad_utility::Exception);
   }
   // Wrong version
@@ -137,15 +147,36 @@ TEST(TripleSerializer, errorOnWrongHeaderFormat) {
     ad_utility::serialization::ByteBufferReadSerializer serializer{
         {'Q', 'L', 'E', 'V', 'E', 'R', '.', 'U', 'P', 'D', 'A', 'T', 'E', 0,
          0}};
-    EXPECT_THROW(ad_utility::detail::readHeader(serializer),
+    EXPECT_THROW(ad_utility::detail::readHeader(
+                     serializer, ad_utility::detail::noAuxIndexGeneration),
                  ad_utility::Exception);
   }
   {
     ad_utility::serialization::ByteBufferReadSerializer serializer{
         {'Q', 'L', 'E', 'V', 'E', 'R', '.', 'U', 'P', 'D', 'A', 'T', 'E', 0,
          1}};
-    EXPECT_THROW(ad_utility::detail::readHeader(serializer),
+    EXPECT_THROW(ad_utility::detail::readHeader(
+                     serializer, ad_utility::detail::noAuxIndexGeneration),
                  ad_utility::Exception);
+  }
+  // A header for a different generation of the auxiliary index. Its `Id`s are
+  // only valid for that generation, so reading them back must fail.
+  {
+    ad_utility::serialization::ByteBufferWriteSerializer writeSerializer;
+    ad_utility::detail::writeHeader(writeSerializer, 3);
+    ad_utility::serialization::ByteBufferReadSerializer serializer{
+        std::move(writeSerializer).data()};
+    AD_EXPECT_THROW_WITH_MESSAGE(
+        ad_utility::detail::readHeader(serializer, 4),
+        ::testing::HasSubstr("only valid for the generation"));
+  }
+  // The matching generation works.
+  {
+    ad_utility::serialization::ByteBufferWriteSerializer writeSerializer;
+    ad_utility::detail::writeHeader(writeSerializer, 3);
+    ad_utility::serialization::ByteBufferReadSerializer serializer{
+        std::move(writeSerializer).data()};
+    EXPECT_NO_THROW(ad_utility::detail::readHeader(serializer, 3));
   }
 }
 

--- a/test/ValueIdComparatorsTest.cpp
+++ b/test/ValueIdComparatorsTest.cpp
@@ -61,13 +61,13 @@ TEST_F(ValueIdComparators, GetRangeForDatatype) {
   std::sort(ids.begin(), ids.end(), compareByBits);
   for (auto datatype : datatypes) {
     auto [begin, end] = getRangeForDatatype(ids.begin(), ids.end(), datatype);
+    // `getRangeForDatatype` groups the `Id`s by `datatypeForOrdering()`, which
+    // is the only datatype projection that is ascending in a sorted range. In
+    // particular, an `Id` of type `LocalVocabIndex` belongs to the range of the
+    // datatype of its position in the vocabulary (here always `VocabIndex`),
+    // and the range for `Datatype::LocalVocabIndex` is empty.
     auto hasMatchingDatatype = [&datatype](ValueId id) {
-      std::array vocabTypes{Datatype::VocabIndex, Datatype::LocalVocabIndex};
-      if (ad_utility::contains(vocabTypes, datatype)) {
-        return ad_utility::contains(vocabTypes, id.getDatatype());
-      } else {
-        return id.getDatatype() == datatype;
-      }
+      return id.datatypeForOrdering() == datatype;
     };
     for (auto it = ids.begin(); it < begin; ++it) {
       ASSERT_FALSE(hasMatchingDatatype(*it));
@@ -112,7 +112,8 @@ auto testGetRangesForId(It begin, It end, ValueId id,
   auto trage = generateLocationTrace(l);
   // Perform the testing for a single `Comparison`
   auto testImpl = [&](auto comparison) {
-    auto ranges = getRangesForId(begin, end, id, comparison);
+    auto ranges =
+        getRangesForId(begin, end, id, comparison, AuxVocabOrdering{});
     auto comparator = getComparisonFunctor<comparison>();
     auto it = begin;
 
@@ -130,14 +131,15 @@ auto testGetRangesForId(It begin, It end, ValueId id,
         ASSERT_FALSE(isMatching(*it, id))
             << *it << ' ' << id << comparison.value;
         auto expected = isMatchingDatatype(*it) ? False : Undef;
-        ASSERT_EQ(compareIds(*it, id, comparison), expected)
+        ASSERT_EQ(compareIds(*it, id, comparison, AuxVocabOrdering{}), expected)
             << *it << ' ' << id;
         ++it;
       }
       while (it != rangeEnd) {
         ASSERT_TRUE(isMatching(*it, id))
             << *it << ' ' << id << comparison.value;
-        ASSERT_EQ(compareIds(*it, id, comparison), True) << *it << ' ' << id;
+        ASSERT_EQ(compareIds(*it, id, comparison, AuxVocabOrdering{}), True)
+            << *it << ' ' << id;
         ++it;
       }
     }
@@ -145,7 +147,8 @@ auto testGetRangesForId(It begin, It end, ValueId id,
       ASSERT_FALSE(isMatching(*it, id))
           << *it << ", " << id << comparison.value;
       auto expected = isMatchingDatatype(*it) ? False : Undef;
-      ASSERT_EQ(compareIds(*it, id, comparison), expected) << *it << ' ' << id;
+      ASSERT_EQ(compareIds(*it, id, comparison, AuxVocabOrdering{}), expected)
+          << *it << ' ' << id;
       ++it;
     }
   };
@@ -212,8 +215,8 @@ TEST_F(ValueIdComparators, Undefined) {
 
   for (auto comparison : {Comparison::EQ, Comparison::LE, Comparison::GE,
                           Comparison::GT, Comparison::LT, Comparison::NE}) {
-    auto equalRange =
-        getRangesForId(ids.begin(), ids.end(), undefined, comparison);
+    auto equalRange = getRangesForId(ids.begin(), ids.end(), undefined,
+                                     comparison, AuxVocabOrdering{});
     ASSERT_EQ(equalRange.size(), 0);
   }
 }
@@ -230,12 +233,14 @@ auto testGetRangesForEqualIds(It begin, It end, ValueId idBegin, ValueId idEnd,
       EXPECT_TRUE(true);
     }
     using enum ComparisonResult;
-    auto ranges = getRangesForEqualIds(begin, end, idBegin, idEnd, comparison);
+    auto ranges = getRangesForEqualIds(begin, end, idBegin, idEnd, comparison,
+                                       AuxVocabOrdering{});
     auto it = begin;
     for (auto [rangeBegin, rangeEnd] : ranges) {
       while (it != rangeBegin) {
         // TODO<joka921> Correctly determine, which of these cases we want.
-        ASSERT_THAT(compareWithEqualIds(*it, idBegin, idEnd, comparison),
+        ASSERT_THAT(compareWithEqualIds(*it, idBegin, idEnd, comparison,
+                                        AuxVocabOrdering{}),
                     ::testing::AnyOf(False, Undef))
             << *it << " " << idBegin << ' ' << idEnd << ' '
             << static_cast<int>(comparison.value);
@@ -244,14 +249,17 @@ auto testGetRangesForEqualIds(It begin, It end, ValueId idBegin, ValueId idEnd,
       while (it != rangeEnd) {
         // The "not equal" relation also yields true for different datatypes.
         ASSERT_TRUE(isMatchingDatatype(*it) || comparison == Comparison::NE);
-        ASSERT_EQ(compareWithEqualIds(*it, idBegin, idEnd, comparison), True)
+        ASSERT_EQ(compareWithEqualIds(*it, idBegin, idEnd, comparison,
+                                      AuxVocabOrdering{}),
+                  True)
             << *it << ' ' << idBegin << ' ' << idEnd;
         ++it;
       }
     }
     while (it != end) {
       // TODO<joka921> Correctly determine, which of these cases we want.
-      ASSERT_THAT(compareWithEqualIds(*it, idBegin, idEnd, comparison),
+      ASSERT_THAT(compareWithEqualIds(*it, idBegin, idEnd, comparison,
+                                      AuxVocabOrdering{}),
                   ::testing::AnyOf(False, Undef));
       ++it;
     }
@@ -315,12 +323,12 @@ TEST_F(ValueIdComparators, IndexTypes) {
     }
   };
 
-  // TODO<joka921> The tests for local vocab and VocabIndex now have to be more
-  // complex....
   using ad_utility::use_value_identity::vi;
+  // Note: The `Id`s of type `LocalVocabIndex` are part of the range of the
+  // `VocabIndex`es (see `getRangeForDatatype`), so they are covered by the
+  // first of these calls and do not get one of their own.
   testImpl(vi<Datatype::VocabIndex>, &getVocabIndex);
   testImpl(vi<Datatype::TextRecordIndex>, &getTextRecordIndex);
-  testImpl(vi<Datatype::LocalVocabIndex>, &getLocalVocabIndex);
   testImpl(vi<Datatype::WordVocabIndex>, &getWordVocabIndex);
 }
 
@@ -329,19 +337,25 @@ TEST_F(ValueIdComparators, undefinedWithItself) {
   auto u = ValueId::makeUndefined();
   using enum ComparisonResult;
   using enum ComparisonForIncompatibleTypes;
-  ASSERT_EQ(compareIds(u, u, Comparison::LT), Undef);
-  ASSERT_EQ(compareIds(u, u, Comparison::LE), Undef);
-  ASSERT_EQ(compareIds(u, u, Comparison::EQ), Undef);
-  ASSERT_EQ(compareIds(u, u, Comparison::NE), Undef);
-  ASSERT_EQ(compareIds(u, u, Comparison::GT), Undef);
-  ASSERT_EQ(compareIds(u, u, Comparison::GE), Undef);
+  ASSERT_EQ(compareIds(u, u, Comparison::LT, AuxVocabOrdering{}), Undef);
+  ASSERT_EQ(compareIds(u, u, Comparison::LE, AuxVocabOrdering{}), Undef);
+  ASSERT_EQ(compareIds(u, u, Comparison::EQ, AuxVocabOrdering{}), Undef);
+  ASSERT_EQ(compareIds(u, u, Comparison::NE, AuxVocabOrdering{}), Undef);
+  ASSERT_EQ(compareIds(u, u, Comparison::GT, AuxVocabOrdering{}), Undef);
+  ASSERT_EQ(compareIds(u, u, Comparison::GE, AuxVocabOrdering{}), Undef);
 
-  ASSERT_EQ(compareIds<CompareByType>(u, u, Comparison::LT), False);
-  ASSERT_EQ(compareIds<CompareByType>(u, u, Comparison::LE), True);
-  ASSERT_EQ(compareIds<CompareByType>(u, u, Comparison::EQ), True);
-  ASSERT_EQ(compareIds<CompareByType>(u, u, Comparison::NE), False);
-  ASSERT_EQ(compareIds<CompareByType>(u, u, Comparison::GT), False);
-  ASSERT_EQ(compareIds<CompareByType>(u, u, Comparison::GE), True);
+  ASSERT_EQ(compareIds<CompareByType>(u, u, Comparison::LT, AuxVocabOrdering{}),
+            False);
+  ASSERT_EQ(compareIds<CompareByType>(u, u, Comparison::LE, AuxVocabOrdering{}),
+            True);
+  ASSERT_EQ(compareIds<CompareByType>(u, u, Comparison::EQ, AuxVocabOrdering{}),
+            True);
+  ASSERT_EQ(compareIds<CompareByType>(u, u, Comparison::NE, AuxVocabOrdering{}),
+            False);
+  ASSERT_EQ(compareIds<CompareByType>(u, u, Comparison::GT, AuxVocabOrdering{}),
+            False);
+  ASSERT_EQ(compareIds<CompareByType>(u, u, Comparison::GE, AuxVocabOrdering{}),
+            True);
 }
 
 // _______________________________________________________________________
@@ -349,10 +363,12 @@ TEST_F(ValueIdComparators, contractViolations) {
   auto u = ValueId::makeUndefined();
   auto I = ad_utility::testing::IntId;
   // Invalid value for the `Comparison` enum.
-  ASSERT_ANY_THROW((compareIds(u, u, static_cast<Comparison>(542))));
   ASSERT_ANY_THROW(
-      (compareWithEqualIds(u, u, u, static_cast<Comparison>(542))));
+      (compareIds(u, u, static_cast<Comparison>(542), AuxVocabOrdering{})));
+  ASSERT_ANY_THROW((compareWithEqualIds(u, u, u, static_cast<Comparison>(542),
+                                        AuxVocabOrdering{})));
 
   // The third argument must be >= the second.
-  ASSERT_ANY_THROW((compareWithEqualIds(I(3), I(25), I(12), Comparison::LE)));
+  ASSERT_ANY_THROW((compareWithEqualIds(I(3), I(25), I(12), Comparison::LE,
+                                        AuxVocabOrdering{})));
 }

--- a/test/libqlever/AuxIndexEndToEndTest.cpp
+++ b/test/libqlever/AuxIndexEndToEndTest.cpp
@@ -1,0 +1,177 @@
+// Copyright 2026 The QLever Authors, in particular:
+//
+// 2026 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+//
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#include <absl/cleanup/cleanup.h>
+#include <gmock/gmock.h>
+
+#include "../util/GTestHelpers.h"
+#include "engine/ExecuteUpdate.h"
+#include "index/AuxIndex.h"
+#include "index/IndexImpl.h"
+#include "libqlever/Qlever.h"
+#include "parser/SparqlParser.h"
+#include "util/File.h"
+
+using namespace qlever;
+
+namespace {
+
+// Build an index from `turtleContents` and return an `EngineConfig` for it. Any
+// auxiliary index of a previous run is removed first, else the freshly built
+// index would pick it up.
+EngineConfig buildTestIndex(std::string_view turtleContents) {
+  std::string basename = gtestCurrentTestName();
+  for (size_t generation : AuxIndex::generationsOnDisk(basename)) {
+    AuxIndex::deleteFromDisk(AuxIndex::makeBasename(basename, generation));
+  }
+  std::string filename = absl::StrCat(basename, ".ttl");
+  ad_utility::makeOfstream(filename) << turtleContents;
+  absl::Cleanup cleanup = [&filename] { ad_utility::deleteFile(filename); };
+
+  IndexBuilderConfig config;
+  config.inputFiles_.push_back({filename, Filetype::Turtle, std::nullopt});
+  config.baseName_ = basename;
+  Qlever::buildIndex(config);
+  return EngineConfig{config};
+}
+
+// Remove all auxiliary indices of the index with the given base name.
+void deleteAuxIndices(const std::string& basename) {
+  for (size_t generation : AuxIndex::generationsOnDisk(basename)) {
+    AuxIndex::deleteFromDisk(AuxIndex::makeBasename(basename, generation));
+  }
+}
+
+// Execute the given SPARQL update. `Qlever::query` only runs queries, so the
+// update is planned like a query (`ParsedQuery` represents both) and then
+// executed against the delta triples, exactly like `Server::processUpdate`
+// does.
+void executeUpdate(Qlever& engine, const std::string& update) {
+  auto indexAndViews = engine.indexAndViewsSnapshot();
+  auto& index = indexAndViews->index_;
+  auto handle = std::make_shared<ad_utility::CancellationHandle<>>();
+  index.deltaTriplesManager().modify<void>([&](DeltaTriples& deltaTriples) {
+    auto parsedUpdates = SparqlParser::parseUpdate(
+        index.getBlankNodeManager(), &index.getImpl().encodedIriManager(),
+        update, {});
+    for (auto& parsedUpdate : parsedUpdates) {
+      auto plannedUpdate =
+          engine.planQuery(engine.bindParsedQuery(std::move(parsedUpdate)),
+                           handle, std::nullopt);
+      ExecuteUpdate::executeUpdate(index, plannedUpdate.parsedQuery(),
+                                   plannedUpdate.queryExecutionTree(),
+                                   deltaTriples, handle);
+    }
+  });
+}
+
+// Run `SELECT ?s ?o { ?s <p> ?o }` and return the result as TSV.
+std::string queryAll(Qlever& engine) {
+  return engine.query("SELECT ?s ?o WHERE { ?s <p> ?o } ORDER BY ?s ?o",
+                      ad_utility::MediaType::tsv);
+}
+
+// The generation of the auxiliary index that `engine` currently uses, or
+// `std::nullopt` if it has none.
+std::optional<size_t> auxGeneration(const Qlever& engine) {
+  const auto* auxIndex =
+      engine.indexAndViewsSnapshot()->index_.getImpl().auxIndex();
+  return auxIndex == nullptr ? std::nullopt
+                             : std::optional{auxIndex->generation()};
+}
+
+// ____________________________________________________________________________
+TEST(AuxIndexEndToEnd, buildAuxIndexKeepsQueryResults) {
+  auto config = buildTestIndex("<a> <p> <A> . <b> <p> <B> . <c> <p> <C> .");
+  config.persistUpdates_ = false;
+  absl::Cleanup cleanup = [&config] { deleteAuxIndices(config.baseName_); };
+  Qlever engine{config};
+  auto handle = std::make_shared<ad_utility::CancellationHandle<>>();
+
+  // Insert a triple with two new words and delete an existing one.
+  executeUpdate(engine, "INSERT DATA { <d> <p> <D> }");
+  executeUpdate(engine, "DELETE DATA { <a> <p> <A> }");
+  auto expected = queryAll(engine);
+  EXPECT_THAT(expected, ::testing::HasSubstr("<d>"));
+  EXPECT_THAT(expected, ::testing::Not(::testing::HasSubstr("<a>")));
+  ASSERT_EQ(auxGeneration(engine), std::nullopt);
+
+  // Move the updates into an auxiliary index. The query result must not change.
+  engine.buildAuxIndex(handle);
+  EXPECT_EQ(auxGeneration(engine), 0);
+  EXPECT_EQ(queryAll(engine), expected);
+
+  // Further updates are applied on top of the auxiliary index, including the
+  // deletion of a triple that the auxiliary index inserted and the re-insertion
+  // of a triple that it deleted.
+  executeUpdate(engine, "DELETE DATA { <d> <p> <D> }");
+  executeUpdate(engine, "INSERT DATA { <a> <p> <A> . <e> <p> <E> }");
+  auto expectedAfterSecondUpdate = queryAll(engine);
+  EXPECT_THAT(expectedAfterSecondUpdate,
+              ::testing::Not(::testing::HasSubstr("<d>")));
+  EXPECT_THAT(expectedAfterSecondUpdate, ::testing::HasSubstr("<a>"));
+  EXPECT_THAT(expectedAfterSecondUpdate, ::testing::HasSubstr("<e>"));
+
+  // A rebuild merges them into a new generation, again without changing the
+  // result.
+  engine.buildAuxIndex(handle);
+  EXPECT_EQ(auxGeneration(engine), 1);
+  EXPECT_EQ(queryAll(engine), expectedAfterSecondUpdate);
+}
+
+// ____________________________________________________________________________
+TEST(AuxIndexEndToEnd, auxIndexAndPersistedUpdatesSurviveARestart) {
+  auto config = buildTestIndex("<a> <p> <A> . <b> <p> <B> .");
+  config.persistUpdates_ = true;
+  absl::Cleanup cleanup = [&config] {
+    deleteAuxIndices(config.baseName_);
+    auto updateFile = absl::StrCat(config.baseName_, UPDATE_TRIPLES_SUFFIX);
+    if (ql::filesystem::exists(updateFile)) {
+      ad_utility::deleteFile(updateFile);
+    }
+  };
+
+  std::string expected;
+  {
+    Qlever engine{config};
+    auto handle = std::make_shared<ad_utility::CancellationHandle<>>();
+    executeUpdate(engine, "INSERT DATA { <c> <p> <C> }");
+    engine.buildAuxIndex(handle);
+    // An update that arrives *after* the build stays in RAM and is persisted
+    // with the generation of the auxiliary index that it refers to.
+    executeUpdate(engine, "INSERT DATA { <d> <p> <D> }");
+    expected = queryAll(engine);
+    EXPECT_THAT(expected, ::testing::HasSubstr("<c>"));
+    EXPECT_THAT(expected, ::testing::HasSubstr("<d>"));
+  }
+
+  // A new instance loads the auxiliary index and replays the persisted updates
+  // on top of it.
+  {
+    Qlever engine{config};
+    EXPECT_EQ(auxGeneration(engine), 0);
+    EXPECT_EQ(queryAll(engine), expected);
+  }
+}
+
+// ____________________________________________________________________________
+TEST(AuxIndexEndToEnd, buildAuxIndexWithoutUpdates) {
+  auto config = buildTestIndex("<a> <p> <A> .");
+  config.persistUpdates_ = false;
+  absl::Cleanup cleanup = [&config] { deleteAuxIndices(config.baseName_); };
+  Qlever engine{config};
+  auto handle = std::make_shared<ad_utility::CancellationHandle<>>();
+
+  auto expected = queryAll(engine);
+  engine.buildAuxIndex(handle);
+  EXPECT_EQ(auxGeneration(engine), 0);
+  EXPECT_EQ(queryAll(engine), expected);
+}
+
+}  // namespace

--- a/test/libqlever/CMakeLists.txt
+++ b/test/libqlever/CMakeLists.txt
@@ -1,2 +1,3 @@
 addLinkAndDiscoverTestNoLibs(QleverTest qlever testUtil)
+addLinkAndDiscoverTestNoLibs(AuxIndexEndToEndTest qlever testUtil)
 addLinkAndDiscoverTestNoLibs(NamedCachedQueryBlobManagerTest qlever testUtil)


### PR DESCRIPTION
Currently all triples that are inserted or deleted after an index was built are held in RAM, roughly 350 bytes per triple (each is stored once per permutation, plus a heap-allocated `LocalVocabEntry` per new word). This makes large updates infeasible.

This PR adds an **auxiliary index**: an explicit command moves the delta triples into a small index on disk, which is then merged into the scans of the main index. Together with the delta triples still held in RAM this forms a three-level LSM tree, where RAM beats the auxiliary index, which beats the main index.

### Design

**Auxiliary vocabulary.** New words go into a vocabulary with its own datatype, `Datatype::AuxVocabIndex`. That is the first free datatype tag, so nothing is renumbered and the on-disk format of the permutations is unchanged. The vocabulary is on disk, sorted, and uses the **same `VocabularyType` as the main vocabulary**, so it splits its words over the same sub-vocabularies — in particular new WKT literals land in a `GeoVocabulary` and keep their precomputed `GeometryInfo`.

Because the datatype bits are the most significant bits of an `Id`, all `Id`s of the auxiliary vocabulary are greater than all `Id`s of the main vocabulary. That is what makes the two permutations mergeable (both are sorted bitwise), but it means the bitwise order is not the order of the string values. For the semantically correct comparison, the auxiliary vocabulary holds an in-RAM array with the position at which each of its words would be sorted into the main vocabulary, so a semantic comparison is a single random access into RAM. That ordering is passed explicitly to `getRangesForId`, `getRangesForEqualIds`, `compareIds` and `compareWithEqualIds` (no default argument — forgetting it is a compile error).

The array is indexed by a word's dense *offset* rather than by its `Id`. With a split vocabulary the two differ, and the offset ordering is what keeps the array of (marker-encoded) positions ascending, so one monotone array plus per-marker prefix offsets suffices and the comparison hot path needs no per-marker dispatch.

**Auxiliary index.** Six permutations plus the two internal ones, with a fifth column that says whether a triple is inserted or deleted. The triples are *not* held in RAM: they are read per block of the main index, found via binary search over the two block-metadata lists, with an LRU cache for decompressed blocks. The only RAM cost is one small entry per block of the main index that the auxiliary index has triples for — not per triple.

**Publishing.** A new generation is published by swapping in a freshly loaded `Index`, so queries that are still running keep the generation of the auxiliary vocabulary they started with (its `Id`s are only valid for one generation). Updates that arrive during the build are carried over via `DeltaTriples::addFromSnapshotDiff`. The persisted-updates file is stamped with the generation its `Id`s belong to, so reading it back against a different generation fails loudly instead of silently resolving `Id`s against the wrong vocabulary.

**Command.** `?cmd=build-aux-index` (access-token protected). `?cmd=stats` reports the generation and counts.

### Fixes to existing behavior

Three latent problems with the comparison of `Id`s that only became visible with a second vocabulary, but that already affected `Datatype::EncodedVal`:

- `ValueId::compareThreeWay` now positions a local vocab entry by its cached bounds against *every* other datatype, not just the string-like ones. Without this the comparison is not a valid strict weak ordering: an entry could be equal to an `EncodedVal` and at the same time smaller than a `TextRecordIndex` that is smaller than that `EncodedVal`.
- `LocalVocabEntry::compareThreeWay` compares the positions first and only falls back to the string comparison if those are equal, for the same reason.
- `getRangeForDatatype` projects the new `ValueId::datatypeForOrdering()`, which — unlike `getDatatype()` — is ascending in a sorted range.

Also fixed: `Id`s of the auxiliary vocabulary were not routed to the vocabulary in `idToLiteralOrIri`, `idToLiteral` and `idToStringAndType`, which would have made any query result containing such a word fail on serialization.

### Tests

- `AuxVocabularyTest` — positions, offsets, reverse lookup and word lookup, with and without the geo split; the full merged order of main and auxiliary words checked exhaustively; range filters over a merged `Id` space returning the two disjoint ranges; `GeometryInfo` for new WKT literals; the `WordWriter` preconditions.
- `AuxIndexBuilderTest` — build from insertions and deletions in all permutations; rebuild merging with a previous generation (including deleting what it inserted and re-inserting what it deleted); geo split; empty build.
- `AuxIndexScanTest` — scan results are identical before and after moving the updates into the auxiliary index; precedence of the RAM delta triples; restricted scans (which exercise block pruning); exact sizes and size estimates.
- `AuxIndexEndToEndTest` — real SPARQL `INSERT DATA`/`DELETE DATA` and `SELECT` through `libqlever`, including a rebuild to a second generation and a restart that reloads the auxiliary index and replays the persisted updates.

### Known limitations (follow-ups)

- The triples that are greater than all triples of the main index share a single synthetic block, so they are materialized as one table at scan time. This is exactly the current behavior for the delta triples in RAM, so it is not a regression; the `offsetsAndCompressedSize_ == nullopt` mechanism already supports splitting it.
- The build blocks updates for its duration (it runs on the single-threaded update executor). The catch-up of updates arriving during the build is implemented and exercised, so only the swap itself has to be made mutually exclusive with updates to lift this.
- Subjects added after the index build have no pattern (the same is true for `rebuild-index`).

### Review

This is large. The vocabulary and comparison layer is split out into a separate PR so it can be reviewed and iterated on first; this PR is stacked on top of that in spirit (the commits are not split, the other PR contains that subset against `master`).
