### PR TITLE
Add an auxiliary vocabulary for words that are added by updates

### DIFF
--- a/src/engine/OrderBy.cpp
+++ b/src/engine/OrderBy.cpp
@@ -102,7 +102,9 @@ Result OrderBy::computeResult([[maybe_unused]] bool requestLaziness) {
 
   // Return true iff `rowA` comes before `rowB` in the sort order specified by
   // `sortIndices_`.
-  auto comparison = [this](const auto& row1, const auto& row2) -> bool {
+  auto auxVocabOrdering = getExecutionContext()->getIndex().auxVocabOrdering();
+  auto comparison = [this, &auxVocabOrdering](const auto& row1,
+                                              const auto& row2) -> bool {
     for (auto& [column, isDescending] : sortIndices_) {
       if (row1[column] == row2[column]) {
         continue;
@@ -110,8 +112,9 @@ Result OrderBy::computeResult([[maybe_unused]] bool requestLaziness) {
       bool isLessThan =
           toBoolNotUndef(valueIdComparators::compareIds<
                          valueIdComparators::ComparisonForIncompatibleTypes::
-                             CompareByType>(
-              row1[column], row2[column], valueIdComparators::Comparison::LT));
+                             CompareByType>(row1[column], row2[column],
+                                            valueIdComparators::Comparison::LT,
+                                            auxVocabOrdering));
       return isLessThan != isDescending;
     }
     return false;

--- a/src/engine/StringMapping.cpp
+++ b/src/engine/StringMapping.cpp
@@ -35,7 +35,8 @@ Id StringMapping::remapId(Id id) {
   // be directly encoded into the ID). All other IDs have to be serialized by
   // different mechanism.
   static constexpr std::array allowedDatatypes{VocabIndex, LocalVocabIndex,
-                                               TextRecordIndex, WordVocabIndex};
+                                               TextRecordIndex, WordVocabIndex,
+                                               AuxVocabIndex};
   AD_EXPENSIVE_CHECK(ad_utility::contains(allowedDatatypes, id.getDatatype()));
 
   // A static assertion that each datatype is either `trivial`, or `allowed`

--- a/src/engine/sparqlExpressions/PrefilterExpressionIndex.cpp
+++ b/src/engine/sparqlExpressions/PrefilterExpressionIndex.cpp
@@ -545,9 +545,8 @@ RelationalExpression<Comparison>::logicalComplement() const {
 //______________________________________________________________________________
 template <CompOp Comparison>
 BlockMetadataRanges RelationalExpression<Comparison>::evaluateImpl(
-    [[maybe_unused]] const LocalVocabContext& context,
-    const ValueIdSubrange& idRange, BlockMetadataSpan blockRange,
-    bool getTotalComplement) const {
+    const LocalVocabContext& context, const ValueIdSubrange& idRange,
+    BlockMetadataSpan blockRange, bool getTotalComplement) const {
   using namespace valueIdComparators;
   // If `rightSideReferenceValue_` contains a `LocalVocabEntry` value, we use
   // the here created `LocalVocab` to retrieve a corresponding `ValueId`.
@@ -560,11 +559,13 @@ BlockMetadataRanges RelationalExpression<Comparison>::evaluateImpl(
   // Reason: The referenceId could be contained within the bounds formed by
   // the IDs of firstTriple_ and lastTriple_ (set false flag to keep
   // empty ranges).
-  auto relevantIdRanges = Comparison != CompOp::EQ
-                              ? getRangesForId(idRange.begin(), idRange.end(),
-                                               referenceId, Comparison)
-                              : getRangesForId(idRange.begin(), idRange.end(),
-                                               referenceId, Comparison, false);
+  auto auxVocabOrdering = context.auxVocabOrdering();
+  auto relevantIdRanges =
+      Comparison != CompOp::EQ
+          ? getRangesForId(idRange.begin(), idRange.end(), referenceId,
+                           Comparison, auxVocabOrdering)
+          : getRangesForId(idRange.begin(), idRange.end(), referenceId,
+                           Comparison, auxVocabOrdering, false);
   return getTotalComplement
              ? detail::mapping::mapValueIdItRangesToBlockItRangesComplemented(
                    relevantIdRanges, idRange, blockRange)

--- a/src/engine/sparqlExpressions/RelationalExpressionHelpers.h
+++ b/src/engine/sparqlExpressions/RelationalExpressionHelpers.h
@@ -180,32 +180,38 @@ inline const auto compareIdsOrStrings =
   } else {
     auto x = makeValueId(a, ctx);
     auto y = makeValueId(b, ctx);
-    if constexpr (ranges::invocable<decltype(valueIdComparators::compareIds<
-                                             comparisonForIncompatibleTypes>),
-                                    decltype(x), decltype(y),
-                                    valueIdComparators::Comparison>) {
+    auto auxVocabOrdering = ctx->_qec.getIndex().auxVocabOrdering();
+    if constexpr (ranges::invocable<
+                      decltype(valueIdComparators::compareIds<
+                               comparisonForIncompatibleTypes>),
+                      decltype(x), decltype(y), valueIdComparators::Comparison,
+                      const valueIdComparators::AuxVocabOrdering&>) {
       // Compare two `ValueId`s
       return valueIdComparators::compareIds<comparisonForIncompatibleTypes>(
-          x, y, Comp);
+          x, y, Comp, auxVocabOrdering);
     } else if constexpr (ranges::invocable<
                              decltype(valueIdComparators::compareWithEqualIds<
                                       comparisonForIncompatibleTypes>),
                              decltype(x), decltype(y.first), decltype(y.second),
-                             valueIdComparators::Comparison>) {
+                             valueIdComparators::Comparison,
+                             const valueIdComparators::AuxVocabOrdering&>) {
       // Compare `ValueId` with range of equal `ValueId`s (used when `value2`
       // is `string` or `vector<string>`.
       return valueIdComparators::compareWithEqualIds<
-          comparisonForIncompatibleTypes>(x, y.first, y.second, Comp);
+          comparisonForIncompatibleTypes>(x, y.first, y.second, Comp,
+                                          auxVocabOrdering);
     } else if constexpr (ranges::invocable<
                              decltype(valueIdComparators::compareWithEqualIds<
                                       comparisonForIncompatibleTypes>),
                              decltype(y), decltype(x.first), decltype(x.second),
-                             valueIdComparators::Comparison>) {
+                             valueIdComparators::Comparison,
+                             const valueIdComparators::AuxVocabOrdering&>) {
       // Compare `ValueId` with range of equal `ValueId`s (used when `value2`
       // is `string` or `vector<string>`.
       return valueIdComparators::compareWithEqualIds<
           comparisonForIncompatibleTypes>(
-          y, x.first, x.second, getComparisonForSwappedArguments(Comp));
+          y, x.first, x.second, getComparisonForSwappedArguments(Comp),
+          auxVocabOrdering);
     } else {
       // The `variant` is such that both types are shown in the compiler error
       // message once the `static_assert` fails.

--- a/src/engine/sparqlExpressions/RelationalExpressions.cpp
+++ b/src/engine/sparqlExpressions/RelationalExpressions.cpp
@@ -102,11 +102,13 @@ ad_utility::SetOfIntervals evaluateWithBinarySearch(
 
   // Perform the actual evaluation.
   const auto resultRanges = [&]() {
+    auto auxVocabOrdering = context->_qec.getIndex().auxVocabOrdering();
     if (valueIdUpper) {
       return valueIdComparators::getRangesForEqualIds(
-          begin, end, valueId, valueIdUpper.value(), Comp);
+          begin, end, valueId, valueIdUpper.value(), Comp, auxVocabOrdering);
     } else {
-      return valueIdComparators::getRangesForId(begin, end, valueId, Comp);
+      return valueIdComparators::getRangesForId(begin, end, valueId, Comp,
+                                                auxVocabOrdering);
     }
   }();
 

--- a/src/global/FileSuffixConstants.h
+++ b/src/global/FileSuffixConstants.h
@@ -42,6 +42,12 @@ constexpr inline std::string_view UPDATE_TRIPLES_SUFFIX = ".update-triples";
 constexpr inline std::string_view ALLOCATED_GRAPHS_SUFFIX =
     ".allocated-graphs-state";
 
+// The array that stores, for each word of an auxiliary vocabulary (see
+// `index/AuxVocabulary.h`), the position at which that word would be sorted
+// into the vocabulary of the main index.
+constexpr inline std::string_view AUX_VOCAB_POSITIONS_SUFFIX =
+    ".vocabulary.positions";
+
 // The build log of an index. QLever does not write this directly, but
 // `qlever-control` creates this file to persist QLever's `stdout` during the
 // index building. If it is present, we still move it alongside the index that

--- a/src/global/IndexTypes.h
+++ b/src/global/IndexTypes.h
@@ -20,6 +20,11 @@ inline constexpr ad_utility::IndexTag wordVocabIndexTag = "WordVocabIndex";
 using WordVocabIndex = ad_utility::TypedIndex<uint64_t, wordVocabIndexTag>;
 inline constexpr ad_utility::IndexTag blankNodeIndexTag = "BlankNodeIndex";
 using BlankNodeIndex = ad_utility::TypedIndex<uint64_t, blankNodeIndexTag>;
+// An index into the auxiliary vocabulary of an auxiliary index (see
+// `index/AuxIndex.h`), which holds the words that were added by updates after
+// the main index was built.
+inline constexpr ad_utility::IndexTag auxVocabIndexTag = "AuxVocabIndex";
+using AuxVocabIndex = ad_utility::TypedIndex<uint64_t, auxVocabIndexTag>;
 inline constexpr ad_utility::IndexTag documentIndexTag = "DocumentIndex";
 using DocumentIndex = ad_utility::TypedIndex<uint64_t, documentIndexTag>;
 

--- a/src/global/ValueId.h
+++ b/src/global/ValueId.h
@@ -42,7 +42,15 @@ enum struct Datatype {
   WordVocabIndex,
   BlankNodeIndex,
   EncodedVal,
-  MaxValue = EncodedVal
+  // An index into the auxiliary vocabulary of an auxiliary index (see
+  // `index/AuxIndex.h`). Because the datatype bits are the most significant
+  // bits, all IDs of this type are larger than all IDs of the other types.
+  // Words that are added by updates after the main index was built therefore
+  // are sorted after all words from the main vocabulary when comparing IDs
+  // bitwise. For the semantically correct (that is, by string value)
+  // comparison, see `valueIdComparators::AuxVocabOrdering`.
+  AuxVocabIndex,
+  MaxValue = AuxVocabIndex
   // Note: Unfortunately, we cannot easily get the size of an enum.
   // If members are added to this enum, then the `MaxValue`
   // alias must always be equal to the last member,
@@ -91,6 +99,8 @@ inline QL_CONSTEXPR std::string_view toString(Datatype type) {
       return "GeoPoint";
     case Datatype::BlankNodeIndex:
       return "BlankNodeIndex";
+    case Datatype::AuxVocabIndex:
+      return "AuxVocabIndex";
   }
   // This line is reachable if we cast an arbitrary invalid int to this enum
   AD_FAIL();
@@ -122,25 +132,37 @@ class ValueId {
 
   // The largest representable integer value.
   static constexpr int64_t maxInt = IntegerType::max();
-  // All types that store strings. Together, the IDs of all the items of these
-  // types form a consecutive range of IDs when sorted. Within this range, the
-  // IDs are ordered by their string values, not by their IDs (and hence also
-  // not by their types).
-  static constexpr std::array<Datatype, 2> stringTypes_{
-      Datatype::VocabIndex, Datatype::LocalVocabIndex};
+  // All types that store strings. Note that the IDs of these types do *not*
+  // form a consecutive range of IDs when sorted, because the IDs of the
+  // auxiliary vocabulary are all greater than the IDs of the other types (see
+  // `Datatype::AuxVocabIndex`). Within each of the two ranges, the IDs are
+  // ordered by their string values, not by their IDs (and hence also not by
+  // their types).
+  static constexpr std::array<Datatype, 3> stringTypes_{
+      Datatype::VocabIndex, Datatype::LocalVocabIndex, Datatype::AuxVocabIndex};
+
+  // Return true iff the `datatype` stores strings, see `stringTypes_`.
+  static constexpr bool isStringType(Datatype datatype) {
+    return ad_utility::contains(stringTypes_, datatype);
+  }
 
   // A mapping that decides if a Datatype is bitwise comparable or not. See
   // `canBeComparedBitwise()` below.
-  static constexpr std::array<bool, 12> isTypeBitwiseComparable_{
-      true, true, true, true, true, false, true, true, true, true, true, true};
+  static constexpr std::array<bool, 13> isTypeBitwiseComparable_{
+      true, true, true, true, true, false, true,
+      true, true, true, true, true, true};
 
-  // Assert that the types in `stringTypes_` are directly adjacent. This is
-  // required to make the comparison of IDs in `ValueIdComparators.h` work.
-  static constexpr Datatype maxStringType_ = ql::ranges::max(stringTypes_);
-  static constexpr Datatype minStringType_ = ql::ranges::min(stringTypes_);
-  static_assert(static_cast<size_t>(maxStringType_) -
-                    static_cast<size_t>(minStringType_) + 1 ==
-                stringTypes_.size());
+  // Return true iff IDs of the given `datatype` are compared to a
+  // `LocalVocabIndex` by looking up the position of the local vocab entry in
+  // the vocabularies of the index (see `compareVocabAndLocalVocab` below).
+  // These are exactly the string types whose IDs are ordered consistently with
+  // the bitwise order, that is all string types except `LocalVocabIndex`
+  // itself.
+  static constexpr bool comparesToLocalVocabByPosition(Datatype datatype) {
+    using enum Datatype;
+    return datatype == VocabIndex || datatype == EncodedVal ||
+           datatype == AuxVocabIndex;
+  }
 
   // Assert that the size of an encoded GeoPoint equals the available bits in a
   // ValueId.
@@ -185,6 +207,15 @@ class ValueId {
   // For doubles it is first the positive doubles in order, then the negative
   // doubles in reversed order. This is a direct consequence of comparing the
   // bit representation of these values as unsigned integers.
+  // NOTE: An `Id` of type `LocalVocabIndex` does not carry its value in its
+  // bits (they are a pointer), so it is ordered by the position that its word
+  // has in the vocabularies of the index (see
+  // `LocalVocabEntry::positionInVocab`). That position is an `Id` of one of the
+  // types for which `comparesToLocalVocabByPosition` holds, and the local vocab
+  // entry compares exactly like an `Id` at that position. In particular this
+  // also holds for the comparison against `Id`s of an unrelated datatype like
+  // `Int` or `Date`, which is required for the comparison to be a valid strict
+  // weak ordering (see `compareVocabAndLocalVocab`).
   constexpr auto compareThreeWay(const ValueId& other) const {
     using enum Datatype;
     auto type = getDatatype();
@@ -199,24 +230,17 @@ class ValueId {
 
     // GCC 11 issues a false positive warning here, so we try to avoid it by
     // being over-explicit about the branches here.
-    if ((type == VocabIndex || type == EncodedVal) &&
-        otherType == LocalVocabIndex) {
+    if (otherType == LocalVocabIndex) {
       return compareVocabAndLocalVocab(
           LocalVocabEntry::IdProxy::make(getBits()),
           other.getLocalVocabIndex());
-    } else if (type == LocalVocabIndex &&
-               (otherType == VocabIndex || otherType == EncodedVal)) {
+    } else {
       auto inverseOrder = compareVocabAndLocalVocab(
           LocalVocabEntry::IdProxy::make(other.getBits()),
           getLocalVocabIndex());
 
       return ql::compareThreeWay(0, inverseOrder);
     }
-
-    // One of the types is `LocalVocab`, and the other one is a non-string
-    // type like `Integer` or `Undefined. Then the comparison by bits
-    // automatically compares by the datatype.
-    return ql::compareThreeWay(_bits, other._bits);
   }
   QL_DEFINE_CUSTOM_THREEWAY_OPERATOR_LOCAL_CONSTEXPR(ValueId)
 
@@ -249,6 +273,24 @@ class ValueId {
   // Get the datatype.
   [[nodiscard]] constexpr Datatype getDatatype() const noexcept {
     return static_cast<Datatype>(_bits >> numDataBits);
+  }
+
+  // The datatype that determines the position of this `Id` in a range of `Id`s
+  // that is sorted by `compareThreeWay` (which is the order in which index
+  // scans emit their results). For all datatypes but `LocalVocabIndex` this
+  // simply is `getDatatype()`. An `Id` of type `LocalVocabIndex` is ordered by
+  // the position of its word in the vocabularies of the index, which is an `Id`
+  // of one of the types for which `comparesToLocalVocabByPosition` holds, so
+  // that position's datatype is returned instead. In particular, the sequence
+  // of the `datatypeForOrdering()` values of a sorted range of `Id`s is
+  // ascending, which is not true for `getDatatype()`.
+  [[nodiscard]] Datatype datatypeForOrdering() const {
+    auto datatype = getDatatype();
+    if (datatype != Datatype::LocalVocabIndex) {
+      return datatype;
+    }
+    return fromBits(getLocalVocabIndex()->positionInVocab().lowerBound_.get())
+        .getDatatype();
   }
 
   // Create a `ValueId` of the `Undefined` type. There is only one such ID and
@@ -348,6 +390,9 @@ class ValueId {
   static ValueId makeFromBlankNodeIndex(BlankNodeIndex index) {
     return makeFromIndex(index.get(), Datatype::BlankNodeIndex);
   }
+  static ValueId makeFromAuxVocabIndex(AuxVocabIndex index) {
+    return makeFromIndex(index.get(), Datatype::AuxVocabIndex);
+  }
 
   // Obtain the unsigned index that this `ValueId` encodes. If `getDatatype()
   // != [VocabIndex|TextRecordIndex|LocalVocabIndex]` then the result is
@@ -372,6 +417,10 @@ class ValueId {
 
   [[nodiscard]] constexpr BlankNodeIndex getBlankNodeIndex() const noexcept {
     return BlankNodeIndex::make(removeDatatypeBits(_bits));
+  }
+
+  [[nodiscard]] constexpr AuxVocabIndex getAuxVocabIndex() const noexcept {
+    return AuxVocabIndex::make(removeDatatypeBits(_bits));
   }
 
   // Store or load a `Date` object.
@@ -489,6 +538,8 @@ class ValueId {
         return std::invoke(visitor, getGeoPoint());
       case Datatype::BlankNodeIndex:
         return std::invoke(visitor, getBlankNodeIndex());
+      case Datatype::AuxVocabIndex:
+        return std::invoke(visitor, getAuxVocabIndex());
     }
     AD_FAIL();
   }

--- a/src/global/ValueIdComparators.h
+++ b/src/global/ValueIdComparators.h
@@ -11,6 +11,7 @@
 
 #include "backports/algorithm.h"
 #include "global/Id.h"
+#include "global/VocabIndexMarker.h"
 #include "util/Algorithm.h"
 #include "util/ComparisonWithNan.h"
 #include "util/OverloadCallOperator.h"
@@ -78,6 +79,188 @@ inline ValueId toValueId(ComparisonResult comparisonResult) {
 // representation of these values as unsigned integers.
 inline bool compareByBits(ValueId a, ValueId b) { return a < b; }
 
+// All the information that is required to compare `Id`s of type
+// `Datatype::AuxVocabIndex` by the string values that they represent instead of
+// by their bits. It consists of the positions at which the words of the
+// auxiliary vocabulary would be sorted into the main vocabulary, see
+// `AuxVocabulary` for the details. A default-constructed `AuxVocabOrdering`
+// means that the index has no auxiliary index; comparing an `Id` of type
+// `Datatype::AuxVocabIndex` then is a programming error (namely, forgetting to
+// pass the ordering of the auxiliary vocabulary that the `Id` came from).
+class AuxVocabOrdering {
+ private:
+  ql::span<const uint64_t> positionsInMainVocab_;
+  std::array<uint64_t, VocabIndexMarker::maxNumMarkers> markerOffsets_{};
+  VocabIndexMarker marker_;
+
+ public:
+  AuxVocabOrdering() = default;
+  AuxVocabOrdering(ql::span<const uint64_t> positionsInMainVocab,
+                   const std::array<uint64_t, VocabIndexMarker::maxNumMarkers>&
+                       markerOffsets,
+                   VocabIndexMarker marker)
+      : positionsInMainVocab_{positionsInMainVocab},
+        markerOffsets_{markerOffsets},
+        marker_{marker} {}
+
+  // The offset of the word of `auxId` (which must be of type
+  // `Datatype::AuxVocabIndex`), see the comment on
+  // `AuxVocabulary::positionsInMainVocab`. This is also the number of words of
+  // the auxiliary vocabulary that are smaller than that word, so it is directly
+  // comparable to the result of `numWordsSmallerThan` below.
+  uint64_t offsetOf(ValueId auxId) const {
+    AD_CORRECTNESS_CHECK(auxId.getDatatype() == Datatype::AuxVocabIndex);
+    auto index = auxId.getAuxVocabIndex().get();
+    uint64_t offset = markerOffsets_.at(marker_.getMarker(index)) +
+                      marker_.getIndexWithoutMarker(index);
+    AD_CORRECTNESS_CHECK(
+        offset < positionsInMainVocab_.size(),
+        "An `Id` of the auxiliary vocabulary was compared without the "
+        "corresponding `AuxVocabOrdering`, or with the one of a different "
+        "generation of the auxiliary index");
+    return offset;
+  }
+
+  // The raw bits of the `Id` of the first word of the main vocabulary that is
+  // greater than the word of `auxId` (which must be of type
+  // `Datatype::AuxVocabIndex`).
+  uint64_t positionInMainVocab(ValueId auxId) const {
+    return positionsInMainVocab_[offsetOf(auxId)];
+  }
+
+  // The number of words of the auxiliary vocabulary that are smaller than the
+  // word of the main vocabulary with the given `Id`.
+  uint64_t numWordsSmallerThan(ValueId mainVocabId) const {
+    // A word `w` of the auxiliary vocabulary is smaller than the word of the
+    // main vocabulary with the index `i` if and only if
+    // `positionInMainVocab(w) <= i`, and the positions are ascending. Note that
+    // this also holds across the sub-vocabularies of a split vocabulary: the
+    // marker sits in the highest bits of the payload of an `Id`, so comparing
+    // positions bitwise compares the markers first, and both the positions and
+    // the offsets are ordered by (marker, index within the sub-vocabulary).
+    auto it =
+        ql::ranges::upper_bound(positionsInMainVocab_, mainVocabId.getBits());
+    return static_cast<uint64_t>(it - positionsInMainVocab_.begin());
+  }
+};
+
+namespace detail {
+
+// The position of an `Id` of one of the string types (see
+// `ValueId::isStringType`) in the merged order of the main and the auxiliary
+// vocabulary. Comparing these positions lexicographically is the semantically
+// correct comparison of the string values, with the single exception of two
+// local vocab entries that fall into the same gap of both vocabularies, which
+// have to be compared by their strings.
+struct SemanticStringPosition {
+  // The raw bits of the `Id` of the first word of the main vocabulary that is
+  // greater than or equal to the word.
+  uint64_t mainVocabPosition_;
+  // True iff the word is the word of the main vocabulary at
+  // `mainVocabPosition_`, false iff it only would be sorted directly before it.
+  bool isWordAtMainVocabPosition_;
+  // Set iff the `Id` is of type `LocalVocabIndex`. Only used to break ties
+  // between two local vocab entries.
+  const LocalVocabEntry* localVocabEntry_;
+  // The number of words of the auxiliary vocabulary that are smaller than the
+  // word. Computing this is not free, so it is only computed on demand via
+  // `numSmallerAuxVocabWords()`, which is only necessary if the two members
+  // above are equal for both sides of a comparison.
+  ValueId id_;
+};
+
+// Compute the `SemanticStringPosition` of `id`, which must be of one of the
+// string types.
+inline SemanticStringPosition getSemanticStringPosition(
+    ValueId id, const AuxVocabOrdering& auxVocabOrdering) {
+  using enum Datatype;
+  auto datatype = id.getDatatype();
+  if (datatype == AuxVocabIndex) {
+    return {auxVocabOrdering.positionInMainVocab(id), false, nullptr, id};
+  }
+  if (datatype == VocabIndex) {
+    return {id.getBits(), true, nullptr, id};
+  }
+  AD_CORRECTNESS_CHECK(datatype == LocalVocabIndex);
+  const auto* entry = id.getLocalVocabIndex();
+  auto [lowerBound, upperBound] = entry->positionInVocab();
+  auto boundId = ValueId::fromBits(lowerBound.get());
+  // A local vocab entry whose word is stored in the auxiliary vocabulary is
+  // positioned exactly like the corresponding `Id` of that vocabulary.
+  if (boundId.getDatatype() == AuxVocabIndex) {
+    return {auxVocabOrdering.positionInMainVocab(boundId), false, entry,
+            boundId};
+  }
+  return {lowerBound.get(), lowerBound != upperBound, entry, id};
+}
+
+// The number of words of the auxiliary vocabulary that are smaller than the
+// word of `position`.
+inline uint64_t numSmallerAuxVocabWords(
+    const SemanticStringPosition& position,
+    const AuxVocabOrdering& auxVocabOrdering) {
+  using enum Datatype;
+  auto datatype = position.id_.getDatatype();
+  if (datatype == AuxVocabIndex) {
+    return auxVocabOrdering.offsetOf(position.id_);
+  }
+  if (datatype == LocalVocabIndex) {
+    return position.localVocabEntry_->numSmallerAuxVocabWords();
+  }
+  AD_CORRECTNESS_CHECK(datatype == VocabIndex);
+  return auxVocabOrdering.numWordsSmallerThan(position.id_);
+}
+
+}  // namespace detail
+
+// Compare two `Id`s that both are of one of the string types (see
+// `ValueId::isStringType`) by the string values that they represent. Note that
+// this is different from `ValueId::compareThreeWay`, which compares the words
+// of the auxiliary vocabulary as if they were all greater than all words of the
+// main vocabulary, because that is the order in which the index scans emit
+// them.
+inline ql::strong_ordering compareStringIdsSemantically(
+    ValueId a, ValueId b, const AuxVocabOrdering& auxVocabOrdering) {
+  AD_EXPENSIVE_CHECK(ValueId::isStringType(a.getDatatype()) &&
+                     ValueId::isStringType(b.getDatatype()));
+  auto positionA = detail::getSemanticStringPosition(a, auxVocabOrdering);
+  auto positionB = detail::getSemanticStringPosition(b, auxVocabOrdering);
+  if (positionA.mainVocabPosition_ != positionB.mainVocabPosition_) {
+    return positionA.mainVocabPosition_ < positionB.mainVocabPosition_
+               ? ql::strong_ordering::less
+               : ql::strong_ordering::greater;
+  }
+  // A word that is the word of the main vocabulary at that position is greater
+  // than a word that only would be sorted directly before it.
+  if (positionA.isWordAtMainVocabPosition_ !=
+      positionB.isWordAtMainVocabPosition_) {
+    return positionA.isWordAtMainVocabPosition_ ? ql::strong_ordering::greater
+                                                : ql::strong_ordering::less;
+  }
+  if (positionA.isWordAtMainVocabPosition_) {
+    // Both are the same word of the main vocabulary.
+    return ql::strong_ordering::equal;
+  }
+  // Both words fall into the same gap of the main vocabulary, so their
+  // positions in the auxiliary vocabulary decide.
+  auto numSmallerA =
+      detail::numSmallerAuxVocabWords(positionA, auxVocabOrdering);
+  auto numSmallerB =
+      detail::numSmallerAuxVocabWords(positionB, auxVocabOrdering);
+  if (numSmallerA != numSmallerB) {
+    return numSmallerA < numSmallerB ? ql::strong_ordering::less
+                                     : ql::strong_ordering::greater;
+  }
+  // The only remaining case is two local vocab entries that fall into the same
+  // gap of both vocabularies, which have to be compared by their strings.
+  if (positionA.localVocabEntry_ == nullptr ||
+      positionB.localVocabEntry_ == nullptr) {
+    return ql::strong_ordering::equal;
+  }
+  return positionA.localVocabEntry_->compareThreeWay(
+      *positionB.localVocabEntry_);
+}
+
 namespace detail {
 
 // Returns a comparator predicate `pred` that can be called with two arguments:
@@ -106,25 +289,19 @@ auto makeSymmetricComparator(Projection valueIdProjection,
 // For a range of `ValueId`s that is represented by `[begin, end)` and has to
 // be sorted according to `compareByBits`, return the contiguous range of
 // `ValueIds` (as a pair of iterators) where the Ids have the `datatype`.
+//
+// NOTE: The projection is `ValueId::datatypeForOrdering()`, not
+// `ValueId::getDatatype()`, because only the former is ascending in a sorted
+// range. In particular, an `Id` of type `LocalVocabIndex` is contained in the
+// range of the datatype of its position in the vocabularies (which is
+// `VocabIndex`, `EncodedVal`, or `AuxVocabIndex`), and the range for
+// `Datatype::LocalVocabIndex` is always empty.
 template <typename RandomIt>
 inline std::pair<RandomIt, RandomIt> getRangeForDatatype(RandomIt begin,
                                                          RandomIt end,
                                                          Datatype datatype) {
-  // In a sorted input, `VocabIndex` and `LocalVocabIndex` IDs might be
-  // interleaved because they logically both store strings. We therefore
-  // need the range where any of those Datatypes match.
-  auto comparatorForVocabTypes = [](Datatype d1, Datatype d2) {
-    auto containsStringType = [](Datatype d) {
-      return ad_utility::contains(ValueId::stringTypes_, d);
-    };
-    if (containsStringType(d1) && containsStringType(d2)) {
-      return false;
-    }
-    return d1 < d2;
-  };
-  auto comparator = detail::makeSymmetricComparator(&ValueId::getDatatype,
-                                                    comparatorForVocabTypes);
-
+  auto comparator =
+      detail::makeSymmetricComparator(&ValueId::datatypeForOrdering);
   return std::equal_range(begin, end, datatype, comparator);
 }
 
@@ -333,6 +510,50 @@ inline std::vector<std::pair<RandomIt, RandomIt>> getRangesForIndexTypes(
   return std::move(rangeFilter).getResult();
 }
 
+// The two ranges of a sorted range of `ValueId`s that hold the `Id`s of the
+// string types: those that are positioned in the main vocabulary (`VocabIndex`
+// and the local vocab entries whose word is in or between the words of the main
+// vocabulary) and those that are positioned in the auxiliary vocabulary
+// (`AuxVocabIndex` and the local vocab entries whose word is stored there).
+// The two ranges are not adjacent, see `ValueId::stringTypes_`.
+template <typename RandomIt>
+inline std::array<std::pair<RandomIt, RandomIt>, 2> getRangesForStringTypes(
+    RandomIt begin, RandomIt end) {
+  return {getRangeForDatatype(begin, end, Datatype::VocabIndex),
+          getRangeForDatatype(begin, end, Datatype::AuxVocabIndex)};
+}
+
+// This function is part of the implementation of `getRangesForId` and
+// `getRangesForEqualIds` for the string types. See the documentation there.
+// Unlike `getRangesForIndexTypes` below, this compares the `Id`s by the string
+// values they represent, which requires searching in both of the ranges of
+// `getRangesForStringTypes` above. If `valueIdEnd` is set, then all `Id`s in
+// `[valueIdBegin, valueIdEnd)` are considered to be equal, else exactly the
+// `Id`s that are semantically equal to `valueIdBegin` are.
+template <typename RandomIt>
+inline std::vector<std::pair<RandomIt, RandomIt>> getRangesForStringTypes(
+    RandomIt begin, RandomIt end, ValueId valueIdBegin,
+    std::optional<ValueId> valueIdEnd, Comparison comparison,
+    const AuxVocabOrdering& auxVocabOrdering) {
+  auto less = [&auxVocabOrdering](ValueId a, ValueId b) {
+    return compareStringIdsSemantically(a, b, auxVocabOrdering) < 0;
+  };
+  RangeFilter<RandomIt> rangeFilter{comparison};
+  for (auto [beginOfRange, endOfRange] : getRangesForStringTypes(begin, end)) {
+    auto eqBegin =
+        std::lower_bound(beginOfRange, endOfRange, valueIdBegin, less);
+    auto eqEnd =
+        valueIdEnd.has_value()
+            ? std::lower_bound(beginOfRange, endOfRange, valueIdEnd.value(),
+                               less)
+            : std::upper_bound(beginOfRange, endOfRange, valueIdBegin, less);
+    rangeFilter.addSmaller(beginOfRange, eqBegin);
+    rangeFilter.addEqual(eqBegin, eqEnd);
+    rangeFilter.addGreater(eqEnd, endOfRange);
+  }
+  return std::move(rangeFilter).getResult();
+}
+
 // This function is part of the implementation of `getRangesForEqualIds`. See
 // the documentation there.
 template <typename RandomIt>
@@ -391,10 +612,15 @@ auto simplifyRanges(std::vector<std::pair<RandomIt, RandomIt>> input,
 //
 // When setting the flag argument `removeEmptyRanges` to false, empty ranges
 // [`begin`, `end`] where `begin` is equal to `end` will not be discarded.
+//
+// The `auxVocabOrdering` is required to compare the `Id`s of the auxiliary
+// vocabulary by their string values, see `AuxVocabOrdering`. It may be left
+// empty if and only if neither `valueId` nor any of the `Id`s in the range are
+// of type `Datatype::AuxVocabIndex`.
 template <typename RandomIt>
 inline std::vector<std::pair<RandomIt, RandomIt>> getRangesForId(
     RandomIt begin, RandomIt end, ValueId valueId, Comparison comparison,
-    bool removeEmptyRanges = true) {
+    const AuxVocabOrdering& auxVocabOrdering, bool removeEmptyRanges = true) {
   switch (valueId.getDatatype()) {
     case Datatype::Double:
       return detail::simplifyRanges(
@@ -412,6 +638,11 @@ inline std::vector<std::pair<RandomIt, RandomIt>> getRangesForId(
       return {};
     case Datatype::VocabIndex:
     case Datatype::LocalVocabIndex:
+    case Datatype::AuxVocabIndex:
+      return detail::simplifyRanges(
+          detail::getRangesForStringTypes(begin, end, valueId, std::nullopt,
+                                          comparison, auxVocabOrdering),
+          removeEmptyRanges);
     case Datatype::WordVocabIndex:
     case Datatype::TextRecordIndex:
       // TODO<joka921> for the `EncodedVal` type, the behavior is only correct
@@ -439,7 +670,7 @@ inline std::vector<std::pair<RandomIt, RandomIt>> getRangesForId(
 template <typename RandomIt>
 inline std::vector<std::pair<RandomIt, RandomIt>> getRangesForEqualIds(
     RandomIt begin, RandomIt end, ValueId valueIdBegin, ValueId valueIdEnd,
-    Comparison comparison) {
+    Comparison comparison, const AuxVocabOrdering& auxVocabOrdering) {
   // For an explanation of the case `valueIdBegin == valueIdEnd`, see the
   // documentation of a similar check in `compareIds` below.
   AD_CONTRACT_CHECK(valueIdBegin <= valueIdEnd);
@@ -448,8 +679,7 @@ inline std::vector<std::pair<RandomIt, RandomIt>> getRangesForEqualIds(
   auto typeBegin = valueIdBegin.getDatatype();
   auto typeEnd = valueIdEnd.getDatatype();
   AD_CONTRACT_CHECK(typeBegin == typeEnd ||
-                    (ad_utility::contains(Id::stringTypes_, typeBegin) &&
-                     ad_utility::contains(Id::stringTypes_, typeEnd)));
+                    (Id::isStringType(typeBegin) && Id::isStringType(typeEnd)));
   switch (valueIdBegin.getDatatype()) {
     case Datatype::Double:
     case Datatype::Int:
@@ -459,10 +689,13 @@ inline std::vector<std::pair<RandomIt, RandomIt>> getRangesForEqualIds(
     case Datatype::GeoPoint:
     case Datatype::BlankNodeIndex:
       AD_FAIL();
-    // TODO<joka921> check what the correct behavior is here.
-    case Datatype::EncodedVal:
     case Datatype::VocabIndex:
     case Datatype::LocalVocabIndex:
+    case Datatype::AuxVocabIndex:
+      return detail::simplifyRanges(detail::getRangesForStringTypes(
+          begin, end, valueIdBegin, valueIdEnd, comparison, auxVocabOrdering));
+    // TODO<joka921> check what the correct behavior is here.
+    case Datatype::EncodedVal:
     case Datatype::WordVocabIndex:
     case Datatype::TextRecordIndex:
       return detail::simplifyRanges(detail::getRangesForIndexTypes(
@@ -481,9 +714,7 @@ inline bool areTypesCompatible(Datatype typeA, Datatype typeB) {
     return type == Datatype::Double || type == Datatype::Int;
   };
   // TODO<joka921> Make this work for the WordIndex also.
-  auto isString = [](Datatype type) {
-    return ad_utility::contains(ValueId::stringTypes_, type);
-  };
+  auto isString = [](Datatype type) { return ValueId::isStringType(type); };
   auto isUndefined = [](Datatype type) { return type == Datatype::Undefined; };
   // Note: Undefined values cannot be compared to other undefined values.
   return (!isUndefined(typeA)) &&
@@ -495,7 +726,8 @@ inline bool areTypesCompatible(Datatype typeA, Datatype typeB) {
 template <ComparisonForIncompatibleTypes comparisonForIncompatibleTypes =
               ComparisonForIncompatibleTypes::AlwaysUndef,
           typename Comparator>
-ComparisonResult compareIdsImpl(ValueId a, ValueId b, Comparator comparator) {
+ComparisonResult compareIdsImpl(ValueId a, ValueId b, Comparator comparator,
+                                const AuxVocabOrdering& auxVocabOrdering) {
   Datatype typeA = a.getDatatype();
   Datatype typeB = b.getDatatype();
   using enum ComparisonResult;
@@ -509,11 +741,18 @@ ComparisonResult compareIdsImpl(ValueId a, ValueId b, Comparator comparator) {
     }
   }
 
-  // If any of the entries is a `LocalVocabIndex`, then the ordinary comparison
-  // on ValueIds already does the right thing.
-  if (a.getDatatype() == Datatype::LocalVocabIndex ||
-      b.getDatatype() == Datatype::LocalVocabIndex) {
-    return fromBool(std::invoke(comparator, a, b));
+  // Both are of one of the string types, so compare them by the string values
+  // that they represent. Note that this differs from the comparison of the
+  // `Id`s (which is what the index scans are sorted by) for the `Id`s of the
+  // auxiliary vocabulary, see `compareStringIdsSemantically`.
+  if (ValueId::isStringType(typeA)) {
+    AD_CORRECTNESS_CHECK(ValueId::isStringType(typeB));
+    // Reduce the comparison to a comparison of two integers, such that it works
+    // with all the comparators (including the wrappers for `NaN` values, see
+    // `ad_utility::makeComparatorForNans`).
+    auto ordering = compareStringIdsSemantically(a, b, auxVocabOrdering);
+    int orderingAsInt = ordering < 0 ? -1 : (ordering > 0 ? 1 : 0);
+    return fromBool(std::invoke(comparator, orderingAsInt, 0));
   }
 
   // TODO<joka921> We currently don't perform correct comparisons (other than
@@ -562,8 +801,8 @@ ComparisonResult compareIdsImpl(ValueId a, ValueId b, Comparator comparator) {
 // see the documentation of the enum `ComparisonForIncompatibleTypes` above.
 template <ComparisonForIncompatibleTypes comparisonForIncompatibleTypes =
               ComparisonForIncompatibleTypes::AlwaysUndef>
-inline ComparisonResult compareIds(ValueId a, ValueId b,
-                                   Comparison comparison) {
+inline ComparisonResult compareIds(ValueId a, ValueId b, Comparison comparison,
+                                   const AuxVocabOrdering& auxVocabOrdering) {
   // A helper lambda to factor out common code
   auto compare = [&](auto comparator) {
     // For the `compareByType` mode, which is used by ORDER BY, we also need a
@@ -571,10 +810,11 @@ inline ComparisonResult compareIds(ValueId a, ValueId b,
     if constexpr (comparisonForIncompatibleTypes ==
                   ComparisonForIncompatibleTypes::CompareByType) {
       return detail::compareIdsImpl<comparisonForIncompatibleTypes>(
-          a, b, ad_utility::makeComparatorForNans(comparator));
+          a, b, ad_utility::makeComparatorForNans(comparator),
+          auxVocabOrdering);
     } else {
-      return detail::compareIdsImpl<comparisonForIncompatibleTypes>(a, b,
-                                                                    comparator);
+      return detail::compareIdsImpl<comparisonForIncompatibleTypes>(
+          a, b, comparator, auxVocabOrdering);
     }
   };
 
@@ -601,9 +841,9 @@ inline ComparisonResult compareIds(ValueId a, ValueId b,
 // are considered to be equal.
 template <ComparisonForIncompatibleTypes comparisonForIncompatibleTypes =
               ComparisonForIncompatibleTypes::AlwaysUndef>
-inline ComparisonResult compareWithEqualIds(ValueId a, ValueId bBegin,
-                                            ValueId bEnd,
-                                            Comparison comparison) {
+inline ComparisonResult compareWithEqualIds(
+    ValueId a, ValueId bBegin, ValueId bEnd, Comparison comparison,
+    const AuxVocabOrdering& auxVocabOrdering) {
   // The case `bBegin == bEnd` happens when IDs from QLever's vocabulary are
   // compared to "pseudo"-IDs that represent words that are not part of the
   // vocabulary. In this case the ID `bBegin` is the ID of the smallest
@@ -617,15 +857,18 @@ inline ComparisonResult compareWithEqualIds(ValueId a, ValueId bBegin,
   // factor it out.
   auto compareEqual = [&]() {
     return toBoolNotUndef(detail::compareIdsImpl<mode>(
-               a, bBegin, std::greater_equal<>())) &&
-           toBoolNotUndef(detail::compareIdsImpl<mode>(a, bEnd, std::less<>()));
+               a, bBegin, std::greater_equal<>(), auxVocabOrdering)) &&
+           toBoolNotUndef(detail::compareIdsImpl<mode>(a, bEnd, std::less<>(),
+                                                       auxVocabOrdering));
   };
   using enum Comparison;
   switch (comparison) {
     case LT:
-      return detail::compareIdsImpl<mode>(a, bBegin, std::less<>());
+      return detail::compareIdsImpl<mode>(a, bBegin, std::less<>(),
+                                          auxVocabOrdering);
     case LE:
-      return detail::compareIdsImpl<mode>(a, bEnd, std::less<>());
+      return detail::compareIdsImpl<mode>(a, bEnd, std::less<>(),
+                                          auxVocabOrdering);
     case EQ: {
       if constexpr (mode == ComparisonForIncompatibleTypes::AlwaysUndef) {
         bool typesAreCompatible =
@@ -650,9 +893,11 @@ inline ComparisonResult compareWithEqualIds(ValueId a, ValueId bBegin,
       }
     }
     case GE:
-      return detail::compareIdsImpl<mode>(a, bBegin, std::greater_equal<>());
+      return detail::compareIdsImpl<mode>(a, bBegin, std::greater_equal<>(),
+                                          auxVocabOrdering);
     case GT:
-      return detail::compareIdsImpl<mode>(a, bEnd, std::greater_equal<>());
+      return detail::compareIdsImpl<mode>(a, bEnd, std::greater_equal<>(),
+                                          auxVocabOrdering);
     default:
       AD_FAIL();
   }

--- a/src/global/VocabIndexMarker.h
+++ b/src/global/VocabIndexMarker.h
@@ -1,0 +1,84 @@
+// Copyright 2026 The QLever Authors, in particular:
+//
+// 2026 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+//
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#ifndef QLEVER_SRC_GLOBAL_VOCABINDEXMARKER_H
+#define QLEVER_SRC_GLOBAL_VOCABINDEXMARKER_H
+
+#include <cstdint>
+
+#include "global/ValueId.h"
+#include "util/BitUtils.h"
+#include "util/Exception.h"
+
+// The words of a vocabulary can be distributed over several sub-vocabularies
+// (see `SplitVocabulary`), for example to store all WKT literals separately.
+// Which sub-vocabulary a word belongs to is determined by the word alone, and
+// it is encoded in the highest bits of the payload of that word's `Id`, the
+// marker.
+//
+// As a consequence, the `Id`s of such a vocabulary form one contiguous
+// ascending range per marker, and their order is *not* the order of the string
+// values: a word of a sub-vocabulary with a higher marker is greater than every
+// word of a sub-vocabulary with a lower marker, no matter what the two words
+// are. QLever accepts this (the order only has to be consistent, see
+// `ValueId::compareThreeWay`), and the auxiliary vocabulary of an auxiliary
+// index (see `index/AuxVocabulary.h`) has to be consistent with it: it uses the
+// same split, and hence the same markers, as the vocabulary of the main index,
+// so that each of its sub-vocabularies can be sorted into the corresponding
+// sub-vocabulary of the main vocabulary.
+//
+// This class holds the marker arithmetic that the two of them share. Unlike
+// `SplitVocabulary`, the number of markers is a runtime value here, because the
+// auxiliary vocabulary has to adapt to whichever vocabulary type the main index
+// uses.
+class VocabIndexMarker {
+ private:
+  uint8_t numMarkers_ = 1;
+  uint64_t markerShift_ = ValueId::numDataBits;
+
+ public:
+  // The largest number of sub-vocabularies (and hence markers) that is
+  // supported. Note that `SplitVocabulary` allows up to 255 of them; if a split
+  // with more than `maxNumMarkers` sub-vocabularies is ever added, this
+  // constant has to be raised (a `static_assert` in `SplitVocabulary` enforces
+  // this).
+  static constexpr uint8_t maxNumMarkers = 4;
+
+  VocabIndexMarker() = default;
+  explicit VocabIndexMarker(uint8_t numMarkers) : numMarkers_{numMarkers} {
+    AD_CONTRACT_CHECK(numMarkers >= 1 && numMarkers <= maxNumMarkers);
+    markerShift_ =
+        ValueId::numDataBits - ad_utility::bitMaskSizeForValue(numMarkers - 1);
+  }
+
+  // The number of sub-vocabularies.
+  uint8_t numMarkers() const { return numMarkers_; }
+
+  // The marker of the given index (the payload of an `Id`, that is, its bits
+  // without the datatype bits).
+  uint8_t getMarker(uint64_t indexWithMarker) const {
+    auto marker = indexWithMarker >> markerShift_;
+    AD_CORRECTNESS_CHECK(marker < numMarkers_);
+    return static_cast<uint8_t>(marker);
+  }
+
+  // The index of the given index within its sub-vocabulary, that is, the index
+  // with the marker bits removed.
+  uint64_t getIndexWithoutMarker(uint64_t indexWithMarker) const {
+    return indexWithMarker & ad_utility::bitMaskForLowerBits(markerShift_);
+  }
+
+  // The marker of the payload of the given `Id`.
+  uint8_t getMarker(ValueId id) const {
+    return getMarker(id.getBits() &
+                     ad_utility::bitMaskForLowerBits(ValueId::numDataBits));
+  }
+};
+
+#endif  // QLEVER_SRC_GLOBAL_VOCABINDEXMARKER_H

--- a/src/index/AuxVocabulary.cpp
+++ b/src/index/AuxVocabulary.cpp
@@ -1,0 +1,188 @@
+// Copyright 2026 The QLever Authors, in particular:
+//
+// 2026 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+//
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#include "index/AuxVocabulary.h"
+
+#include <absl/strings/str_cat.h>
+
+#include "backports/algorithm.h"
+#include "global/FileSuffixConstants.h"
+#include "index/vocabulary/PolymorphicVocabulary.h"
+#include "util/Exception.h"
+#include "util/FilesystemHelpers.h"
+#include "util/Serializer/FileSerializer.h"
+#include "util/Serializer/SerializeArrayOrTuple.h"
+#include "util/Serializer/SerializeVector.h"
+
+// The name of the file that stores the positions in the main vocabulary and the
+// offsets of the sub-vocabularies.
+static std::string positionsFilename(const std::string& basename) {
+  return absl::StrCat(basename, AUX_VOCAB_POSITIONS_SUFFIX);
+}
+
+// ____________________________________________________________________________
+std::vector<std::string> AuxVocabulary::fileNames(const std::string& basename) {
+  std::vector<std::string> result;
+  for (const auto& file :
+       qlever::util::filesWithBaseNameAndSuffix(basename, VOCAB_SUFFIX)) {
+    result.push_back(file.string());
+  }
+  return result;
+}
+
+// ____________________________________________________________________________
+void AuxVocabulary::open(const std::string& basename,
+                         ad_utility::VocabularyType type,
+                         const std::string& language,
+                         const std::string& country, bool ignorePunctuation) {
+  vocabulary_.resetToType(type);
+  vocabulary_.setLocale(language, country, ignorePunctuation);
+  vocabulary_.readFromFile(absl::StrCat(basename, VOCAB_SUFFIX));
+  marker_ =
+      VocabIndexMarker{PolymorphicVocabulary::numberOfSubVocabularies(type)};
+
+  ad_utility::serialization::FileReadSerializer reader{
+      positionsFilename(basename)};
+  reader >> positionsInMainVocab_;
+  reader >> markerOffsets_;
+  AD_CORRECTNESS_CHECK(
+      positionsInMainVocab_.size() == vocabulary_.size(),
+      "The number of positions in the main vocabulary does not match the "
+      "number of words of the auxiliary vocabulary");
+  AD_CORRECTNESS_CHECK(ql::ranges::is_sorted(positionsInMainVocab_),
+                       "The positions in the main vocabulary must be sorted");
+}
+
+// ____________________________________________________________________________
+std::pair<AuxVocabIndex, AuxVocabIndex> AuxVocabulary::getPositionOfWord(
+    std::string_view word) const {
+  return vocabulary_.getPositionOfWord(word);
+}
+
+// ____________________________________________________________________________
+std::optional<AuxVocabIndex> AuxVocabulary::getId(std::string_view word) const {
+  auto [lower, upper] = getPositionOfWord(word);
+  if (lower == upper) {
+    return std::nullopt;
+  }
+  AD_CORRECTNESS_CHECK(upper.get() - lower.get() == 1);
+  return lower;
+}
+
+// ____________________________________________________________________________
+uint64_t AuxVocabulary::numWordsSmallerThan(std::string_view word) const {
+  // `getPositionOfWord` returns the position within the sub-vocabulary that
+  // `word` belongs to (marker-encoded), so it has to be turned into an offset,
+  // which is dense and ordered across all sub-vocabularies. Note that the
+  // returned position may be the end of that sub-vocabulary, for which there is
+  // no word and hence no `offsetOf`; in that case the offset is the start of
+  // the next sub-vocabulary.
+  auto lower = getPositionOfWord(word).first;
+  auto marker = marker_.getMarker(lower.get());
+  uint64_t indexInSubVocab = marker_.getIndexWithoutMarker(lower.get());
+  return markerOffsets_.at(marker) + indexInSubVocab;
+}
+
+// ____________________________________________________________________________
+AuxVocabulary::WordWriter::WordWriter(const RdfsVocabulary& mainVocab,
+                                      const std::string& basename,
+                                      ad_utility::VocabularyType type)
+    : mainVocab_{mainVocab},
+      basename_{basename},
+      marker_{VocabIndexMarker{
+          PolymorphicVocabulary::numberOfSubVocabularies(type)}} {
+  // The `PolymorphicVocabulary` can create a writer for an arbitrary type
+  // without holding a vocabulary of that type, which is what we need here.
+  wordWriter_ = PolymorphicVocabulary::makeDiskWriterPtr(
+      absl::StrCat(basename, VOCAB_SUFFIX), type);
+}
+
+// ____________________________________________________________________________
+AuxVocabulary::WordWriter::~WordWriter() {
+  if (!finishWasCalled_ && wordWriter_ != nullptr) {
+    // The `WordWriterBase` destructor throws if `finish` was not called, which
+    // would be a bug in our code, but throwing from a destructor during stack
+    // unwinding must be avoided. `finish` of the underlying writer is safe to
+    // call here, we only skip writing the positions file (which then simply
+    // does not exist, so the incomplete auxiliary index cannot be opened).
+    wordWriter_->finish();
+  }
+}
+
+// ____________________________________________________________________________
+AuxVocabIndex AuxVocabulary::WordWriter::operator()(std::string_view word) {
+  AD_CONTRACT_CHECK(!finishWasCalled_);
+  const auto& comparator = mainVocab_.getCaseComparator();
+
+  // The words have to arrive grouped by their sub-vocabulary, in ascending
+  // order of the markers, and ascending within each group.
+  auto [lower, upper] = mainVocab_.getPositionOfWord(word);
+  AD_CONTRACT_CHECK(lower == upper,
+                    "A word that is contained in the vocabulary of the main "
+                    "index must not be added to an auxiliary vocabulary");
+  auto position = Id::makeFromVocabIndex(lower);
+  uint8_t marker = marker_.getMarker(position);
+  AD_CONTRACT_CHECK(
+      marker >= currentMarker_,
+      "The words of an auxiliary vocabulary have to be pushed grouped by their "
+      "sub-vocabulary, in ascending order of the markers of those "
+      "sub-vocabularies");
+  if (marker != currentMarker_) {
+    // A new sub-vocabulary starts at the current offset. Note that the
+    // sub-vocabularies in between (if any) are empty, so they get the same
+    // offset.
+    for (uint8_t m = currentMarker_ + 1; m <= marker; ++m) {
+      markerOffsets_.at(m) = positionsInMainVocab_.size();
+    }
+    currentMarker_ = marker;
+    previousWord_.reset();
+  } else if (previousWord_.has_value()) {
+    AD_CONTRACT_CHECK(
+        comparator(previousWord_.value(), word,
+                   RdfsVocabulary::SortLevel::TOTAL),
+        "The words of an auxiliary vocabulary have to be pushed in strictly "
+        "ascending order within each sub-vocabulary");
+  }
+  previousWord_ = std::string{word};
+  positionsInMainVocab_.push_back(position.getBits());
+
+  uint64_t index = (*wordWriter_)(word, mainVocab_.shouldBeExternalized(word));
+  // The index that the underlying (possibly split) vocabulary assigns has to
+  // agree with the offset that we computed from the position in the main
+  // vocabulary, else the two vocabularies split their words differently.
+  AD_CORRECTNESS_CHECK(
+      marker_.getMarker(index) == marker,
+      "The auxiliary vocabulary and the vocabulary of the main index assign a "
+      "word to different sub-vocabularies. They have to use the same "
+      "vocabulary type");
+  AD_CORRECTNESS_CHECK(
+      markerOffsets_.at(marker) + marker_.getIndexWithoutMarker(index) + 1 ==
+          positionsInMainVocab_.size(),
+      "The indices assigned by the word writer of an auxiliary vocabulary must "
+      "be consecutive within each sub-vocabulary");
+  return AuxVocabIndex::make(index);
+}
+
+// ____________________________________________________________________________
+void AuxVocabulary::WordWriter::finish() {
+  AD_CONTRACT_CHECK(!finishWasCalled_);
+  finishWasCalled_ = true;
+  // All sub-vocabularies after the last one that received a word are empty and
+  // start at the end.
+  for (uint8_t m = currentMarker_ + 1; m < marker_.numMarkers(); ++m) {
+    markerOffsets_.at(m) = positionsInMainVocab_.size();
+  }
+  wordWriter_->finish();
+  AD_CORRECTNESS_CHECK(ql::ranges::is_sorted(positionsInMainVocab_),
+                       "The positions in the main vocabulary must be sorted");
+  ad_utility::serialization::FileWriteSerializer writer{
+      positionsFilename(basename_)};
+  writer << positionsInMainVocab_;
+  writer << markerOffsets_;
+}

--- a/src/index/AuxVocabulary.h
+++ b/src/index/AuxVocabulary.h
@@ -1,0 +1,216 @@
+// Copyright 2026 The QLever Authors, in particular:
+//
+// 2026 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+//
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#ifndef QLEVER_SRC_INDEX_AUXVOCABULARY_H
+#define QLEVER_SRC_INDEX_AUXVOCABULARY_H
+
+#include <array>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "global/Id.h"
+#include "global/ValueIdComparators.h"
+#include "global/VocabIndexMarker.h"
+#include "index/Vocabulary.h"
+#include "index/vocabulary/VocabularyType.h"
+
+// The vocabulary of an auxiliary index (see `index/AuxIndex.h`). It stores
+// exactly those words that are used by the triples of that auxiliary index and
+// that are not part of the vocabulary of the main index. The words are stored
+// on disk, and the vocabulary uses the same `VocabularyType` as the main index,
+// so in particular it splits its words over the same sub-vocabularies (see
+// `SplitVocabulary` and `VocabIndexMarker`) as the main vocabulary and stores
+// the same precomputed data (for example the `GeometryInfo` of WKT literals).
+//
+// The `Id`s of the words of an `AuxVocabulary` have their own `Datatype`
+// (`Datatype::AuxVocabIndex`). Because the datatype bits are the most
+// significant bits of an `Id`, all of these `Id`s are greater than all `Id`s of
+// the main vocabulary when compared bitwise. This is what makes the auxiliary
+// index mergeable into a scan of the main index (both are sorted bitwise), but
+// it means that the bitwise order is not the order of the string values.
+//
+// For the semantically correct comparison, an `AuxVocabulary` additionally
+// holds an in-RAM array that stores, for each of its words, the position at
+// which that word would be sorted into the vocabulary of the main index (see
+// `positionsInMainVocab()`). A semantic comparison of a word from the auxiliary
+// vocabulary with a word from the main vocabulary therefore is a single random
+// access into RAM, see `valueIdComparators::AuxVocabOrdering`.
+//
+// NOTE: That array is indexed by the *offset* of a word, not by its `Id`. The
+// two differ when the vocabulary is split, because then the `Id`s of a
+// sub-vocabulary with a marker greater than zero start at a large value (the
+// marker sits in the highest bits of the payload). The offset is the position
+// of a word in the concatenation of all sub-vocabularies in the order of their
+// markers, so it is dense, and it is ascending in the (bitwise, and hence also
+// semantic) order of the `Id`s. That is exactly what makes the array of
+// positions ascending as well, which is required for the reverse lookup in
+// `numWordsSmallerThanMainVocabPosition`.
+class AuxVocabulary {
+ public:
+  // The vocabulary implementation. This is the same as `RdfsVocabulary` (in
+  // particular it is a `PolymorphicVocabulary`, so the concrete implementation
+  // can be chosen at runtime), only the index type differs.
+  using Vocab = Vocabulary<detail::UnderlyingVocabRdfsVocabulary,
+                           TripleComponentComparator, AuxVocabIndex>;
+  using AccessReturnType = typename Vocab::AccessReturnType;
+
+ private:
+  Vocab vocabulary_;
+  VocabIndexMarker marker_;
+  // For each word of `vocabulary_`, indexed by the word's offset (see the class
+  // comment), the raw bits of the `Id` of the first word of the main vocabulary
+  // that is greater than that word. Note that all words of an `AuxVocabulary`
+  // are absent from the main vocabulary, so there is no need to store an upper
+  // bound as well. The entries of this array are ascending.
+  std::vector<uint64_t> positionsInMainVocab_;
+  // For each marker, the offset at which the words of the corresponding
+  // sub-vocabulary start, that is, the exclusive prefix sums of the numbers of
+  // words of the sub-vocabularies.
+  std::array<uint64_t, VocabIndexMarker::maxNumMarkers> markerOffsets_{};
+
+ public:
+  // Return the file names of the auxiliary vocabulary with the given base name.
+  // Note that which of them exist depends on the `VocabularyType`, see
+  // `PolymorphicVocabulary`.
+  static std::vector<std::string> fileNames(const std::string& basename);
+
+  AuxVocabulary() = default;
+  AuxVocabulary(const AuxVocabulary&) = delete;
+  AuxVocabulary& operator=(const AuxVocabulary&) = delete;
+  AuxVocabulary(AuxVocabulary&&) noexcept = default;
+  AuxVocabulary& operator=(AuxVocabulary&&) noexcept = default;
+
+  // Read the auxiliary vocabulary that was written to `basename` by a
+  // `WordWriter` (see below). The `type` must be the same as the one that was
+  // used for writing, and the locale must be the one of the main vocabulary,
+  // else the order of the words is inconsistent with the main vocabulary.
+  void open(const std::string& basename, ad_utility::VocabularyType type,
+            const std::string& language, const std::string& country,
+            bool ignorePunctuation);
+
+  // The total number of words, summed over all sub-vocabularies. NOTE: This is
+  // *not* an upper bound for the `Id`s of this vocabulary if it is split, see
+  // the class comment.
+  size_t numWords() const { return positionsInMainVocab_.size(); }
+
+  // The word with the given index.
+  AccessReturnType operator[](AuxVocabIndex index) const {
+    return vocabulary_[index];
+  }
+
+  // The offset of the word with the given index, see the class comment.
+  uint64_t offsetOf(AuxVocabIndex index) const {
+    auto rawIndex = index.get();
+    uint64_t offset = markerOffsets_.at(marker_.getMarker(rawIndex)) +
+                      marker_.getIndexWithoutMarker(rawIndex);
+    AD_CORRECTNESS_CHECK(offset < positionsInMainVocab_.size());
+    return offset;
+  }
+
+  // The raw bits of the `Id` of the first word of the main vocabulary that is
+  // greater than the word with the given `index`.
+  uint64_t positionInMainVocab(AuxVocabIndex index) const {
+    return positionsInMainVocab_[offsetOf(index)];
+  }
+
+  // The whole array of positions, see the class comment.
+  ql::span<const uint64_t> positionsInMainVocab() const {
+    return positionsInMainVocab_;
+  }
+
+  // The information that is required to compare `Id`s of type
+  // `Datatype::AuxVocabIndex` semantically, that is, by the string values that
+  // they represent.
+  valueIdComparators::AuxVocabOrdering ordering() const {
+    return valueIdComparators::AuxVocabOrdering{positionsInMainVocab_,
+                                                markerOffsets_, marker_};
+  }
+
+  // Return the offset (see the class comment) of the first word of this
+  // vocabulary that is not smaller than the word of the main vocabulary with
+  // the given `Id`. This is the reverse direction of `positionInMainVocab` and
+  // is possible in logarithmic time because the positions are ascending. It is
+  // required to translate a bound in the main vocabulary into a bound in the
+  // auxiliary vocabulary.
+  uint64_t numWordsSmallerThanMainVocabPosition(Id mainVocabId) const {
+    return ordering().numWordsSmallerThan(mainVocabId);
+  }
+
+  // Look up `word`. Return its index if it is contained in this vocabulary, and
+  // `std::nullopt` otherwise.
+  std::optional<AuxVocabIndex> getId(std::string_view word) const;
+
+  // The position of `word` in this vocabulary. The `first` element is the index
+  // of the first word that is greater than or equal to `word`; the `second`
+  // element is `first + 1` if the word is contained, and equal to `first`
+  // otherwise. Note that the lookup happens in the sub-vocabulary that `word`
+  // belongs to, so both are marker-encoded. This mirrors
+  // `Vocabulary::getPositionOfWord`.
+  std::pair<AuxVocabIndex, AuxVocabIndex> getPositionOfWord(
+      std::string_view word) const;
+
+  // The offset (see the class comment) of the first word of this vocabulary
+  // that is not smaller than `word`. This is the value that the semantic
+  // comparison of a local vocab entry against a word of this vocabulary needs,
+  // see `LocalVocabEntry::numSmallerAuxVocabWords`.
+  uint64_t numWordsSmallerThan(std::string_view word) const;
+
+  // Direct access to the underlying vocabulary, for example for the
+  // `GeometryInfo` of a WKT literal.
+  const Vocab& vocab() const { return vocabulary_; }
+
+  // Writer for an `AuxVocabulary`. The words have to be pushed grouped by the
+  // sub-vocabulary that they belong to, in ascending order of the markers of
+  // those sub-vocabularies, and within each group in ascending order with
+  // respect to the comparator of the main vocabulary at the `TOTAL` level. None
+  // of the words may be contained in the main vocabulary. All of this is
+  // checked.
+  //
+  // The writer computes the positions in the main vocabulary itself, via one
+  // binary search per word.
+  class WordWriter {
+   private:
+    const RdfsVocabulary& mainVocab_;
+    std::string basename_;
+    VocabIndexMarker marker_;
+    std::unique_ptr<WordWriterBase> wordWriter_;
+    std::vector<uint64_t> positionsInMainVocab_;
+    std::array<uint64_t, VocabIndexMarker::maxNumMarkers> markerOffsets_{};
+    uint8_t currentMarker_ = 0;
+    std::optional<std::string> previousWord_;
+    bool finishWasCalled_ = false;
+
+   public:
+    // Create a writer that writes the vocabulary of the given `type` to files
+    // starting with `basename`. The `type` has to be the type of the main
+    // vocabulary, such that the two split their words in the same way. The
+    // `mainVocab` is required to compute the positions and to check the
+    // precondition that no word of the auxiliary vocabulary is contained in the
+    // main vocabulary.
+    WordWriter(const RdfsVocabulary& mainVocab, const std::string& basename,
+               ad_utility::VocabularyType type);
+    ~WordWriter();
+    WordWriter(const WordWriter&) = delete;
+    WordWriter& operator=(const WordWriter&) = delete;
+
+    // Add `word` and return the `Id` that was assigned to it.
+    AuxVocabIndex operator()(std::string_view word);
+
+    // Signal that the last word has been pushed and write the positions to
+    // disk. Must be called exactly once.
+    void finish();
+
+    // The number of words that have been pushed so far.
+    size_t numWords() const { return positionsInMainVocab_.size(); }
+  };
+};
+
+#endif  // QLEVER_SRC_INDEX_AUXVOCABULARY_H

--- a/src/index/CMakeLists.txt
+++ b/src/index/CMakeLists.txt
@@ -21,7 +21,7 @@ add_subdirectory(vocabulary)
 add_library(index
         Index.cpp IndexImpl.cpp IndexImpl.Text.cpp EncodedIriManager.cpp
         IndexMetaData.cpp MetaDataHandler.cpp
-        Vocabulary.cpp ../parser/RdfParser.cpp
+        Vocabulary.cpp AuxVocabulary.cpp ../parser/RdfParser.cpp
         LocatedTriples.cpp Permutation.cpp TextMetaData.cpp
         DocsDB.cpp FTSAlgorithms.cpp
         PrefixHeuristic.cpp CompressedRelation.cpp

--- a/src/index/ExportIds.cpp
+++ b/src/index/ExportIds.cpp
@@ -89,6 +89,7 @@ std::optional<Literal> idToLiteral(const IndexImpl& index, Id id,
                                 onlyReturnLiteralsWithXsdString);
     case VocabIndex:
     case LocalVocabIndex:
+    case AuxVocabIndex:
       return handleIriOrLiteral(
           getLiteralOrIriFromVocabIndex(index, id, localVocab),
           onlyReturnLiteralsWithXsdString);
@@ -155,6 +156,7 @@ std::optional<LiteralOrIri> idToLiteralOrIri(const IndexImpl& index, Id id,
       return getLiteralOrIriFromWordVocabIndex(index, id);
     case VocabIndex:
     case LocalVocabIndex:
+    case AuxVocabIndex:
     case EncodedVal:
       return ql::exportIds::getLiteralOrIriFromVocabIndex(index, id,
                                                           localVocab);
@@ -203,6 +205,15 @@ LiteralOrIri getLiteralOrIriFromVocabIndex(const IndexImpl& index, Id id,
       static_assert(ad_utility::SameAsAny<decltype(getEntity()), std::string,
                                           std::string_view>);
       return LiteralOrIri::fromStringRepresentation(std::string(getEntity()));
+    }
+    case Datatype::AuxVocabIndex: {
+      const auto* auxVocab = index.auxVocab();
+      AD_CORRECTNESS_CHECK(
+          auxVocab != nullptr,
+          "Encountered an `Id` of an auxiliary vocabulary, but "
+          "the index has no auxiliary index");
+      return LiteralOrIri::fromStringRepresentation(
+          std::string((*auxVocab)[id.getAuxVocabIndex()]));
     }
     case Datatype::EncodedVal:
       return encodedIdToLiteralOrIri(id, index);

--- a/src/index/ExportIds.h
+++ b/src/index/ExportIds.h
@@ -189,6 +189,7 @@ std::optional<std::pair<std::string, const char*>> idToStringAndType(
     }
     case VocabIndex:
     case LocalVocabIndex:
+    case AuxVocabIndex:
       return formatLiteralOrIri(
           getLiteralOrIriFromVocabIndex(index.getImpl(), id, localVocab));
     case EncodedVal:

--- a/src/index/Index.cpp
+++ b/src/index/Index.cpp
@@ -298,3 +298,8 @@ GraphNameManager& Index::graphNameManager() {
 const GraphNameManager& Index::graphNameManager() const {
   return pimpl_->graphNameManager();
 }
+
+// _____________________________________________________________________________
+valueIdComparators::AuxVocabOrdering Index::auxVocabOrdering() const {
+  return pimpl_->auxVocabOrdering();
+}

--- a/src/index/Index.h
+++ b/src/index/Index.h
@@ -12,6 +12,7 @@
 
 #include "backports/three_way_comparison.h"
 #include "global/Id.h"
+#include "global/ValueIdComparators.h"
 #include "index/GraphNameManager.h"
 #include "index/InputFileSpecification.h"
 #include "index/Permutation.h"
@@ -241,6 +242,11 @@ class Index {
   // requires including the rather expensive `IndexImpl.h` header
   IndexImpl& getImpl() { return *pimpl_; }
   [[nodiscard]] const IndexImpl& getImpl() const { return *pimpl_; }
+
+  // The information that is required to compare `Id`s of type
+  // `Datatype::AuxVocabIndex` by the string values that they represent, see
+  // `IndexImpl::auxVocabOrdering`.
+  valueIdComparators::AuxVocabOrdering auxVocabOrdering() const;
 
   // Allow implicit conversions to `const IndexImpl&`.
   operator const IndexImpl&() const { return getImpl(); }

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -21,6 +21,8 @@
 #include "engine/Result.h"
 #include "engine/idTable/CompressedExternalIdTable.h"
 #include "global/SpecialIds.h"
+#include "global/ValueIdComparators.h"
+#include "index/AuxVocabulary.h"
 #include "index/CompressedRelation.h"
 #include "index/ConstantsIndexBuilding.h"
 #include "index/DeltaTriples.h"
@@ -203,6 +205,9 @@ class IndexImpl {
 
   std::optional<DeltaTriplesManager> deltaTriples_;
 
+  // The auxiliary vocabulary, see `auxVocab()`.
+  std::shared_ptr<const AuxVocabulary> auxVocab_;
+
   GraphNameManager graphNameManager_ = GraphNameManager();
 
  public:
@@ -261,6 +266,32 @@ class IndexImpl {
 
   const auto& getVocab() const { return vocab_; };
   auto& getNonConstVocabForTesting() { return vocab_; }
+
+  // The auxiliary vocabulary of this index (see `index/AuxVocabulary.h`), or
+  // `nullptr` if it has none. Note that this member is immutable once the index
+  // has been loaded, because the `Id`s of an auxiliary vocabulary are only
+  // valid for the very vocabulary that they were created for.
+  //
+  // TODO<joka921> Nothing sets this yet. It will be set by the auxiliary index,
+  // which follows in a separate PR; until then the only way to obtain an
+  // auxiliary vocabulary is `setAuxVocabForTesting`.
+  const AuxVocabulary* auxVocab() const { return auxVocab_.get(); }
+
+  // Set the auxiliary vocabulary, see above.
+  void setAuxVocabForTesting(std::shared_ptr<const AuxVocabulary> auxVocab) {
+    auxVocab_ = std::move(auxVocab);
+  }
+
+  // The information that is required to compare `Id`s of type
+  // `Datatype::AuxVocabIndex` by the string values that they represent. It is
+  // empty if this index has no auxiliary vocabulary. Note that this must always
+  // be the ordering of the very `IndexImpl` that the compared `Id`s came from,
+  // see the documentation of `auxVocab_`.
+  valueIdComparators::AuxVocabOrdering auxVocabOrdering() const {
+    const auto* vocab = auxVocab();
+    return vocab == nullptr ? valueIdComparators::AuxVocabOrdering{}
+                            : vocab->ordering();
+  }
 
   // Replace the currently loaded vocabulary with a zero-copy view directly
   // into `serializer`'s buffer. See `Vocabulary::loadFromZeroCopyDeserializer`

--- a/src/index/LocalVocabEntry.cpp
+++ b/src/index/LocalVocabEntry.cpp
@@ -15,6 +15,33 @@ ql::strong_ordering LocalVocabEntry::compareThreeWay(
       "Contexts of LocalVocabEntries have to be identical. If this is not the "
       "case this means that stale entries associated with an old index are "
       "falsely carried over somewhere.");
+  // First compare the positions in the vocabulary, see the documentation of
+  // this function in the header for why this is required.
+  auto position = positionInVocab();
+  auto rhsPosition = rhs.positionInVocab();
+  if (position.lowerBound_ != rhsPosition.lowerBound_) {
+    return position.lowerBound_ < rhsPosition.lowerBound_
+               ? ql::strong_ordering::less
+               : ql::strong_ordering::greater;
+  }
+  // A word that is contained in one of the vocabularies (in which case the
+  // bounds differ) is greater than a word that only would be sorted at the same
+  // position (in which case the bounds are equal), because the latter is
+  // strictly smaller than the word at that position.
+  bool isContained = position.lowerBound_ != position.upperBound_;
+  bool rhsIsContained = rhsPosition.lowerBound_ != rhsPosition.upperBound_;
+  if (isContained != rhsIsContained) {
+    return isContained ? ql::strong_ordering::greater
+                       : ql::strong_ordering::less;
+  }
+  // Both words fall into the same gap of the main vocabulary, so the number of
+  // smaller words in the auxiliary vocabulary decides.
+  auto numSmallerAux = numSmallerAuxVocabWords();
+  auto rhsNumSmallerAux = rhs.numSmallerAuxVocabWords();
+  if (numSmallerAux != rhsNumSmallerAux) {
+    return numSmallerAux < rhsNumSmallerAux ? ql::strong_ordering::less
+                                            : ql::strong_ordering::greater;
+  }
   int i = context_->getVocab().getCaseComparator().compare(
       toStringRepresentation(), rhs.toStringRepresentation(),
       LocaleManager::Level::TOTAL);
@@ -47,6 +74,19 @@ auto LocalVocabEntry::positionInVocabExpensiveCase() const -> PositionInVocab {
     }
     auto [l, u] = vocab.getPositionOfWord(toStringRepresentation());
     AD_CORRECTNESS_CHECK(u.get() - l.get() <= 1);
+    if (l == u) {
+      // The word is not in the vocabulary of the main index, so it may be in
+      // the vocabulary of the auxiliary index. Note that the two vocabularies
+      // are disjoint, so we only have to look there if the lookup above failed.
+      const auto* auxVocab = context_->auxVocab();
+      if (auxVocab != nullptr) {
+        if (auto auxIndex = auxVocab->getId(toStringRepresentation());
+            auxIndex.has_value()) {
+          auto id = Id::makeFromAuxVocabIndex(auxIndex.value());
+          return std::pair{id, Id::fromBits(id.getBits() + 1)};
+        }
+      }
+    }
     return std::pair{Id::makeFromVocabIndex(l), Id::makeFromVocabIndex(u)};
   }();
   positionInVocab.lowerBound_ = IdProxy::make(lower.getBits());
@@ -58,6 +98,18 @@ auto LocalVocabEntry::positionInVocabExpensiveCase() const -> PositionInVocab {
                            std::memory_order_relaxed);
   positionInVocabKnown_.store(true, std::memory_order_release);
   return positionInVocab;
+}
+
+// ___________________________________________________________________________
+uint64_t LocalVocabEntry::numSmallerAuxVocabWordsExpensiveCase() const {
+  const auto* auxVocab = context_->auxVocab();
+  uint64_t result =
+      auxVocab == nullptr
+          ? 0
+          : auxVocab->numWordsSmallerThan(toStringRepresentation());
+  numSmallerAuxVocabWords_.store(result, std::memory_order_relaxed);
+  numSmallerAuxVocabWordsKnown_.store(true, std::memory_order_release);
+  return result;
 }
 
 // _____________________________________________________________________________

--- a/src/index/LocalVocabEntry.h
+++ b/src/index/LocalVocabEntry.h
@@ -46,12 +46,21 @@ class alignas(16) LocalVocabEntry
   // inclusive, the `upperBound` is not, so if `lowerBound == upperBound`, then
   // the entry is not part of the globalVocabulary, and `lowerBound` points to
   // the first *larger* word in the vocabulary. Note: we store the cache as
-  // three separate atomics to avoid mutexes. The downside is, that in parallel
-  // code multiple threads might look up the position concurrently, which wastes
-  // a bit of resources. However, we don't consider this case to be likely.
+  // several separate atomics to avoid mutexes. The downside is, that in
+  // parallel code multiple threads might look up the position concurrently,
+  // which wastes a bit of resources. However, we don't consider this case to be
+  // likely.
   mutable ad_utility::CopyableAtomic<IdProxy> lowerBoundInVocab_;
   mutable ad_utility::CopyableAtomic<IdProxy> upperBoundInVocab_;
   mutable ad_utility::CopyableAtomic<bool> positionInVocabKnown_ = false;
+  // A second, independent cache for the position in the auxiliary vocabulary of
+  // the index (see `numSmallerAuxVocabWords()` below). It is separate from the
+  // cache above because it is only required for the semantically correct
+  // comparison in `valueIdComparators`, whereas the bounds above are also
+  // required on the much hotter path of `Id::compareThreeWay`.
+  mutable ad_utility::CopyableAtomic<uint64_t> numSmallerAuxVocabWords_;
+  mutable ad_utility::CopyableAtomic<bool> numSmallerAuxVocabWordsKnown_ =
+      false;
 
  public:
   LocalVocabEntry(LiteralT literal, const LocalVocabContext& context)
@@ -65,7 +74,11 @@ class alignas(16) LocalVocabEntry
   LocalVocabEntry(Base&& base, const LocalVocabContext& context) noexcept
       : Base{std::move(base)}, context_{&context} {}
 
-  // Constructor for when the position in the vocab is already known.
+  // Constructor for when the position in the vocab is already known. Note that
+  // the caller has to guarantee that the word is contained in neither the main
+  // nor the auxiliary vocabulary, or that `lower` and `upper` are the bounds
+  // that `positionInVocabExpensiveCase` would compute (which is checked by the
+  // expensive check below).
   template <typename Lower, typename Upper>
   LocalVocabEntry(Base&& base, Lower lower, Upper upper,
                   const LocalVocabContext& context)
@@ -129,6 +142,22 @@ class alignas(16) LocalVocabEntry
     return positionInVocabExpensiveCase();
   }
 
+  // Return the number of words of the auxiliary vocabulary of the index (see
+  // `AuxVocabulary`) that are smaller than this word. Note that this is a dense
+  // offset across all sub-vocabularies of the auxiliary vocabulary, not an
+  // `AuxVocabIndex`, so that it is directly comparable across the
+  // sub-vocabularies of a split vocabulary. Together with
+  // `positionInVocab()` this pins down the position of this word in the merged
+  // order of the main and the auxiliary vocabulary, which is what the
+  // semantically correct comparison of `Id`s in `valueIdComparators` requires.
+  // Return zero if the index has no auxiliary index.
+  uint64_t numSmallerAuxVocabWords() const {
+    if (numSmallerAuxVocabWordsKnown_.load(std::memory_order_acquire)) {
+      return numSmallerAuxVocabWords_.load(std::memory_order_relaxed);
+    }
+    return numSmallerAuxVocabWordsExpensiveCase();
+  }
+
   // It suffices to hash the base class `LiteralOrIri` as the position in the
   // vocab is redundant for those purposes.
   template <typename H, typename V>
@@ -137,10 +166,14 @@ class alignas(16) LocalVocabEntry
     return H::combine(std::move(h), static_cast<const Base&>(entry));
   }
 
-  // Comparison between two entries could in theory also be sped up using the
-  // cached `position` if it has previously been computed for both of the
-  // entries, but it is currently questionable whether this gains much
-  // performance.
+  // Compare two entries. Note that this first compares the positions in the
+  // vocabulary (see `positionInVocab()`) and only falls back to the (expensive)
+  // comparison of the strings if those are equal. Comparing the strings alone
+  // would not be a valid strict weak ordering: for example, a word that is
+  // stored in the auxiliary vocabulary of the index is positioned after all
+  // words of the main vocabulary (see `AuxVocabulary`), so comparing it to a
+  // word that is in neither vocabulary has to yield the same result as
+  // comparing the corresponding `Id`s, which are compared by their positions.
   ql::strong_ordering compareThreeWay(const LocalVocabEntry& rhs) const;
   QL_DEFINE_CUSTOM_THREEWAY_OPERATOR_LOCAL(LocalVocabEntry)
 
@@ -150,6 +183,9 @@ class alignas(16) LocalVocabEntry
  private:
   // The expensive case of looking up the position in vocab.
   PositionInVocab positionInVocabExpensiveCase() const;
+
+  // The expensive case of looking up the position in the auxiliary vocabulary.
+  uint64_t numSmallerAuxVocabWordsExpensiveCase() const;
 };
 
 #endif  // QLEVER_SRC_INDEX_LOCALVOCABENTRY_H

--- a/src/index/Vocabulary.cpp
+++ b/src/index/Vocabulary.cpp
@@ -318,6 +318,9 @@ template class Vocabulary<detail::UnderlyingVocabRdfsVocabulary,
                           TripleComponentComparator, VocabIndex>;
 template class Vocabulary<detail::UnderlyingVocabTextVocabulary,
                           SimpleStringComparator, WordVocabIndex>;
+// The vocabulary of an auxiliary index, see `index/AuxVocabulary.h`.
+template class Vocabulary<detail::UnderlyingVocabRdfsVocabulary,
+                          TripleComponentComparator, AuxVocabIndex>;
 
 template void RdfsVocabulary::initializeInternalizedLangs<nlohmann::json>(
     const nlohmann::json&);

--- a/src/index/Vocabulary.h
+++ b/src/index/Vocabulary.h
@@ -217,6 +217,17 @@ class Vocabulary {
   // Get prefix ranges for the given prefix.
   PrefixRanges prefixRanges(std::string_view prefix) const;
 
+  // The marker of the sub-vocabulary that `word` belongs to, see
+  // `PolymorphicVocabulary::getMarkerForWord`. Always zero for vocabulary
+  // implementations that do not split their words.
+  uint8_t getMarkerForWord(std::string_view word) const {
+    if constexpr (std::is_same_v<UnderlyingVocabulary, PolymorphicVocabulary>) {
+      return vocabulary_.getUnderlyingVocabulary().getMarkerForWord(word);
+    } else {
+      return 0;
+    }
+  }
+
   [[nodiscard]] const LocaleManager& getLocaleManager() const {
     return getCaseComparator().getLocaleManager();
   }

--- a/src/index/vocabulary/PolymorphicVocabulary.cpp
+++ b/src/index/vocabulary/PolymorphicVocabulary.cpp
@@ -82,6 +82,25 @@ std::unique_ptr<WordWriterBase> PolymorphicVocabulary::makeDiskWriterPtr(
 }
 
 // _____________________________________________________________________________
+uint8_t PolymorphicVocabulary::numberOfSubVocabularies(VocabularyType type) {
+  // Use a temporary vocabulary of the given type to determine the number of
+  // sub-vocabularies of that type, such that this function does not have to be
+  // adapted when a new vocabulary type is added.
+  PolymorphicVocabulary dummyVocab;
+  dummyVocab.resetToType(type);
+  return std::visit(
+      [](const auto& vocab) -> uint8_t {
+        using T = std::decay_t<decltype(vocab)>;
+        if constexpr (ad_utility::isInstantiation<T, SplitVocabulary>) {
+          return T::numberOfVocabs;
+        } else {
+          return 1;
+        }
+      },
+      dummyVocab.vocab_);
+}
+
+// _____________________________________________________________________________
 void PolymorphicVocabulary::resetToType(VocabularyType type) {
   close();
   // The names of the enum values are the same as the type aliases for the

--- a/src/index/vocabulary/PolymorphicVocabulary.h
+++ b/src/index/vocabulary/PolymorphicVocabulary.h
@@ -194,6 +194,29 @@ class PolymorphicVocabulary {
         vocab_);
   }
 
+  // The marker of the sub-vocabulary that `word` belongs to, see
+  // `SplitVocabulary` and `VocabIndexMarker`. This is always zero for the
+  // vocabulary types that do not split their words. Note that this is
+  // determined by the word alone and requires no lookup.
+  uint8_t getMarkerForWord(std::string_view word) const {
+    return std::visit(
+        [&word](const auto& vocab) -> uint8_t {
+          using T = std::decay_t<decltype(vocab)>;
+          if constexpr (ad_utility::isInstantiation<T, SplitVocabulary>) {
+            return T::getMarkerForWord(word);
+          } else {
+            return 0;
+          }
+        },
+        vocab_);
+  }
+
+  // The number of sub-vocabularies that a vocabulary of the given `type` splits
+  // its words over, see `SplitVocabulary`. It is one for all the types that do
+  // not split. The sub-vocabulary that a word belongs to is encoded in the
+  // marker bits of its `Id`, see `VocabIndexMarker`.
+  static uint8_t numberOfSubVocabularies(VocabularyType type);
+
   // Create a `WordWriter` that will create a vocabulary with the given `type`
   // at the given `filename`.
   static std::unique_ptr<WordWriterBase> makeDiskWriterPtr(

--- a/src/index/vocabulary/SplitVocabulary.h
+++ b/src/index/vocabulary/SplitVocabulary.h
@@ -16,6 +16,7 @@
 #include "backports/algorithm.h"
 #include "backports/functional.h"
 #include "global/ValueId.h"
+#include "global/VocabIndexMarker.h"
 #include "index/vocabulary/GeoVocabulary.h"
 #include "index/vocabulary/VocabularyTypes.h"
 #include "util/BitUtils.h"
@@ -66,6 +67,12 @@ class SplitVocabulary {
                 sizeof...(UnderlyingVocabularies) <= 255);
   static constexpr uint8_t numberOfVocabs =
       static_cast<uint8_t>(sizeof...(UnderlyingVocabularies));
+
+  // The auxiliary vocabulary of an auxiliary index mirrors the split of the
+  // vocabulary of the main index, and its marker arithmetic (see
+  // `VocabIndexMarker`) supports at most `maxNumMarkers` sub-vocabularies. If
+  // this assertion fails, raise that constant.
+  static_assert(numberOfVocabs <= VocabIndexMarker::maxNumMarkers);
 
   // Because of the marker bits, a `SplitVocabulary` should not hold another
   // `SplitVocabulary` or a `PolymorphicVocabulary`, where it cannot be

--- a/test/AuxVocabularyTest.cpp
+++ b/test/AuxVocabularyTest.cpp
@@ -1,0 +1,343 @@
+// Copyright 2026 The QLever Authors, in particular:
+//
+// 2026 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+//
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#include <absl/cleanup/cleanup.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "./util/GTestHelpers.h"
+#include "global/Constants.h"
+#include "index/AuxVocabulary.h"
+#include "util/BitUtils.h"
+#include "util/File.h"
+#include "util/FilesystemHelpers.h"
+#include "util/HashSet.h"
+
+namespace {
+
+using ad_utility::VocabularyType;
+
+// A WKT literal, which the `SplitGeoVocabulary` stores in its second
+// sub-vocabulary.
+std::string wkt(std::string_view content) {
+  return absl::StrCat("\"", content, "\"^^<", GEO_WKT_LITERAL, ">");
+}
+
+// A main vocabulary of the given `type` that holds `words`, together with the
+// files that back it (which are removed when this object dies).
+class MainVocabulary {
+ private:
+  std::string filename_;
+  RdfsVocabulary vocabulary_;
+
+ public:
+  MainVocabulary(std::string filename,
+                 const ad_utility::HashSet<std::string>& words,
+                 VocabularyType type)
+      : filename_{std::move(filename)} {
+    vocabulary_.resetToType(type);
+    vocabulary_.createFromSet(words, filename_);
+  }
+  ~MainVocabulary() {
+    for (const auto& file :
+         qlever::util::filesWithBaseNameAndSuffix(filename_, "")) {
+      ad_utility::deleteFile(file);
+    }
+  }
+  MainVocabulary(const MainVocabulary&) = delete;
+  MainVocabulary& operator=(const MainVocabulary&) = delete;
+
+  const RdfsVocabulary& vocab() const { return vocabulary_; }
+};
+
+// Write an `AuxVocabulary` with the given `words` (which have to be pushed in
+// the order in which they are given, see `AuxVocabulary::WordWriter`) and read
+// it back.
+void writeAndOpen(AuxVocabulary& auxVocab, const RdfsVocabulary& mainVocab,
+                  const std::string& basename,
+                  const std::vector<std::string>& words, VocabularyType type) {
+  {
+    AuxVocabulary::WordWriter writer{mainVocab, basename, type};
+    for (const auto& word : words) {
+      writer(word);
+    }
+    writer.finish();
+  }
+  auxVocab.open(basename, type, "en", "US", false);
+}
+
+// Remove all files that belong to the auxiliary vocabulary with the given base
+// name.
+void deleteAuxVocabFiles(const std::string& basename) {
+  for (const auto& file :
+       qlever::util::filesWithBaseNameAndSuffix(basename, "")) {
+    ad_utility::deleteFile(file);
+  }
+}
+
+// ____________________________________________________________________________
+TEST(AuxVocabulary, positionsAndLookupWithoutSplit) {
+  auto type = VocabularyType{VocabularyType::OnDiskCompressed};
+  std::string mainFilename = absl::StrCat(gtestCurrentTestName(), ".main");
+  MainVocabulary main{mainFilename, {"\"a\"", "\"c\"", "\"e\""}, type};
+
+  std::string basename = absl::StrCat(gtestCurrentTestName(), ".aux");
+  absl::Cleanup cleanup = [&basename] { deleteAuxVocabFiles(basename); };
+  AuxVocabulary auxVocab;
+  // `"b"` is sorted between `"a"` and `"c"`, `"d"` between `"c"` and `"e"`, and
+  // `"f"` after all words of the main vocabulary.
+  writeAndOpen(auxVocab, main.vocab(), basename, {"\"b\"", "\"d\"", "\"f\""},
+               type);
+
+  ASSERT_EQ(auxVocab.numWords(), 3);
+  EXPECT_EQ(auxVocab[AuxVocabIndex::make(0)], "\"b\"");
+  EXPECT_EQ(auxVocab[AuxVocabIndex::make(1)], "\"d\"");
+  EXPECT_EQ(auxVocab[AuxVocabIndex::make(2)], "\"f\"");
+
+  // Without a split, the `Id`s of the auxiliary vocabulary are dense, so they
+  // agree with their offsets.
+  for (uint64_t i = 0; i < 3; ++i) {
+    EXPECT_EQ(auxVocab.offsetOf(AuxVocabIndex::make(i)), i);
+  }
+
+  // The positions are the indices of the first greater word of the main
+  // vocabulary: `"b"` before `"c"` (index 1), `"d"` before `"e"` (index 2), and
+  // `"f"` after the last word (index 3).
+  auto position = [&auxVocab](uint64_t i) {
+    return Id::fromBits(auxVocab.positionInMainVocab(AuxVocabIndex::make(i)))
+        .getVocabIndex()
+        .get();
+  };
+  EXPECT_EQ(position(0), 1);
+  EXPECT_EQ(position(1), 2);
+  EXPECT_EQ(position(2), 3);
+
+  // The reverse direction: how many words of the auxiliary vocabulary are
+  // smaller than a given word of the main vocabulary.
+  auto numSmaller = [&auxVocab](uint64_t mainIndex) {
+    return auxVocab.numWordsSmallerThanMainVocabPosition(
+        Id::makeFromVocabIndex(VocabIndex::make(mainIndex)));
+  };
+  EXPECT_EQ(numSmaller(0), 0);  // "a"
+  EXPECT_EQ(numSmaller(1), 1);  // "c", greater than "b"
+  EXPECT_EQ(numSmaller(2), 2);  // "e", greater than "b" and "d"
+
+  // Lookup by word.
+  EXPECT_EQ(auxVocab.getId("\"d\""), AuxVocabIndex::make(1));
+  EXPECT_EQ(auxVocab.getId("\"a\""), std::nullopt);
+  EXPECT_EQ(auxVocab.numWordsSmallerThan("\"a\""), 0);
+  EXPECT_EQ(auxVocab.numWordsSmallerThan("\"c\""), 1);
+  EXPECT_EQ(auxVocab.numWordsSmallerThan("\"g\""), 3);
+}
+
+// ____________________________________________________________________________
+TEST(AuxVocabulary, positionsAndLookupWithGeoSplit) {
+  auto type = VocabularyType{VocabularyType::OnDiskCompressedGeoSplit};
+  std::string mainFilename = absl::StrCat(gtestCurrentTestName(), ".main");
+  // The main vocabulary holds two ordinary literals and two WKT literals, the
+  // latter in its second sub-vocabulary.
+  MainVocabulary main{mainFilename,
+                      {"\"a\"", "\"c\"", wkt("POINT(1 1)"), wkt("POINT(3 3)")},
+                      type};
+
+  std::string basename = absl::StrCat(gtestCurrentTestName(), ".aux");
+  absl::Cleanup cleanup = [&basename] { deleteAuxVocabFiles(basename); };
+  AuxVocabulary auxVocab;
+  // The words have to be pushed grouped by sub-vocabulary, the ordinary
+  // literals (marker 0) first, the WKT literals (marker 1) afterwards.
+  writeAndOpen(auxVocab, main.vocab(), basename,
+               {"\"b\"", "\"d\"", wkt("POINT(2 2)"), wkt("POINT(4 4)")}, type);
+
+  ASSERT_EQ(auxVocab.numWords(), 4);
+
+  // The `Id`s of the second sub-vocabulary carry the marker bit, so they are
+  // *not* dense, but their offsets are.
+  auto markerBit = uint64_t{1} << 59;
+  EXPECT_EQ(auxVocab[AuxVocabIndex::make(0)], "\"b\"");
+  EXPECT_EQ(auxVocab[AuxVocabIndex::make(1)], "\"d\"");
+  EXPECT_EQ(auxVocab[AuxVocabIndex::make(markerBit)], wkt("POINT(2 2)"));
+  EXPECT_EQ(auxVocab[AuxVocabIndex::make(markerBit | 1)], wkt("POINT(4 4)"));
+
+  EXPECT_EQ(auxVocab.offsetOf(AuxVocabIndex::make(0)), 0);
+  EXPECT_EQ(auxVocab.offsetOf(AuxVocabIndex::make(1)), 1);
+  EXPECT_EQ(auxVocab.offsetOf(AuxVocabIndex::make(markerBit)), 2);
+  EXPECT_EQ(auxVocab.offsetOf(AuxVocabIndex::make(markerBit | 1)), 3);
+
+  // Each word is positioned in the sub-vocabulary of the main vocabulary that
+  // it belongs to, so the WKT literals get positions that carry the marker bit,
+  // which is what keeps the positions ascending.
+  auto position = [&auxVocab](uint64_t i) {
+    return auxVocab.positionInMainVocab(AuxVocabIndex::make(i)) &
+           ad_utility::bitMaskForLowerBits(ValueId::numDataBits);
+  };
+  EXPECT_EQ(position(0), 1);  // `"b"` before `"c"`
+  EXPECT_EQ(position(1), 2);  // `"d"` after all ordinary literals
+  EXPECT_EQ(position(markerBit), markerBit | 1);      // before `POINT(3 3)`
+  EXPECT_EQ(position(markerBit | 1), markerBit | 2);  // after all geometries
+
+  // The reverse direction has to respect the sub-vocabularies as well: all
+  // words of the first sub-vocabulary are smaller than every word of the second
+  // one.
+  auto numSmaller = [&auxVocab](uint64_t mainIndex) {
+    return auxVocab.numWordsSmallerThanMainVocabPosition(
+        Id::makeFromVocabIndex(VocabIndex::make(mainIndex)));
+  };
+  EXPECT_EQ(numSmaller(0), 0);              // `"a"`
+  EXPECT_EQ(numSmaller(1), 1);              // `"c"`, greater than `"b"`
+  EXPECT_EQ(numSmaller(markerBit), 2);      // `POINT(1 1)`
+  EXPECT_EQ(numSmaller(markerBit | 1), 3);  // `POINT(3 3)`
+
+  // Lookup by word routes to the correct sub-vocabulary.
+  EXPECT_EQ(auxVocab.getId(wkt("POINT(4 4)")),
+            AuxVocabIndex::make(markerBit | 1));
+  EXPECT_EQ(auxVocab.getId(wkt("POINT(1 1)")), std::nullopt);
+  EXPECT_EQ(auxVocab.getId("\"b\""), AuxVocabIndex::make(0));
+  EXPECT_EQ(auxVocab.numWordsSmallerThan(wkt("POINT(0 0)")), 2);
+  EXPECT_EQ(auxVocab.numWordsSmallerThan(wkt("POINT(3 3)")), 3);
+  EXPECT_EQ(auxVocab.numWordsSmallerThan("\"c\""), 1);
+
+  // The precomputed geometry information of the WKT literals is available, just
+  // as it is for the main vocabulary.
+  EXPECT_TRUE(auxVocab.vocab().isGeoInfoAvailable());
+  EXPECT_TRUE(
+      auxVocab.vocab().getGeoInfo(AuxVocabIndex::make(markerBit)).has_value());
+}
+
+// ____________________________________________________________________________
+TEST(AuxVocabulary, semanticComparisonAndRangesWithGeoSplit) {
+  using namespace valueIdComparators;
+  auto type = VocabularyType{VocabularyType::OnDiskCompressedGeoSplit};
+  std::string mainFilename = absl::StrCat(gtestCurrentTestName(), ".main");
+  MainVocabulary main{mainFilename,
+                      {"\"a\"", "\"c\"", wkt("POINT(1 1)"), wkt("POINT(3 3)")},
+                      type};
+
+  std::string basename = absl::StrCat(gtestCurrentTestName(), ".aux");
+  absl::Cleanup cleanup = [&basename] { deleteAuxVocabFiles(basename); };
+  AuxVocabulary auxVocab;
+  writeAndOpen(auxVocab, main.vocab(), basename,
+               {"\"b\"", "\"d\"", wkt("POINT(2 2)"), wkt("POINT(4 4)")}, type);
+  auto ordering = auxVocab.ordering();
+
+  auto markerBit = uint64_t{1} << 59;
+  auto mainId = [](uint64_t index) {
+    return Id::makeFromVocabIndex(VocabIndex::make(index));
+  };
+  auto auxId = [](uint64_t index) {
+    return Id::makeFromAuxVocabIndex(AuxVocabIndex::make(index));
+  };
+  // The merged order of the two vocabularies is
+  // "a" < "b" < "c" < "d" < POINT(1 1) < POINT(2 2) < POINT(3 3) < POINT(4 4),
+  // where the quoted literals come from the first and the WKT literals from the
+  // second sub-vocabulary.
+  std::vector<Id> semanticOrder{mainId(0),
+                                auxId(0),
+                                mainId(1),
+                                auxId(1),
+                                mainId(markerBit),
+                                auxId(markerBit),
+                                mainId(markerBit | 1),
+                                auxId(markerBit | 1)};
+  for (size_t i = 0; i < semanticOrder.size(); ++i) {
+    for (size_t j = 0; j < semanticOrder.size(); ++j) {
+      auto expected = i < j ? ql::strong_ordering::less
+                            : (i > j ? ql::strong_ordering::greater
+                                     : ql::strong_ordering::equal);
+      EXPECT_EQ(compareStringIdsSemantically(semanticOrder[i], semanticOrder[j],
+                                             ordering),
+                expected)
+          << i << " vs " << j;
+    }
+  }
+
+  // The `Id`s of the auxiliary vocabulary are all greater than those of the
+  // main vocabulary when compared bitwise, which is the order in which the
+  // index scans emit them and in which the range filters expect their input.
+  std::vector<Id> bitwiseOrder{
+      mainId(0), mainId(1), mainId(markerBit), mainId(markerBit | 1),
+      auxId(0),  auxId(1),  auxId(markerBit),  auxId(markerBit | 1)};
+  ASSERT_TRUE(ql::ranges::is_sorted(bitwiseOrder, compareByBits));
+
+  // Turn the ranges of iterators that the range filters return into index
+  // pairs.
+  auto rangesFor = [&bitwiseOrder, &ordering](Id referenceId,
+                                              Comparison comparison) {
+    std::vector<std::pair<size_t, size_t>> result;
+    for (auto [begin, end] :
+         getRangesForId(bitwiseOrder.begin(), bitwiseOrder.end(), referenceId,
+                        comparison, ordering)) {
+      result.emplace_back(begin - bitwiseOrder.begin(),
+                          end - bitwiseOrder.begin());
+    }
+    return result;
+  };
+  using Ranges = std::vector<std::pair<size_t, size_t>>;
+
+  // Everything smaller than `"c"`: `"a"` from the main and `"b"` from the
+  // auxiliary vocabulary, which are in two disjoint ranges.
+  EXPECT_THAT(rangesFor(mainId(1), Comparison::LT),
+              ::testing::Eq(Ranges{{0, 1}, {4, 5}}));
+  // Everything smaller than `POINT(1 1)`: all words of the first
+  // sub-vocabularies, no matter what they are.
+  EXPECT_THAT(rangesFor(mainId(markerBit), Comparison::LT),
+              ::testing::Eq(Ranges{{0, 2}, {4, 6}}));
+  // Everything greater than `POINT(2 2)`, which is a word of the auxiliary
+  // vocabulary.
+  EXPECT_THAT(rangesFor(auxId(markerBit), Comparison::GT),
+              ::testing::Eq(Ranges{{3, 4}, {7, 8}}));
+  // A word is only equal to itself, because the two vocabularies are disjoint.
+  EXPECT_THAT(rangesFor(auxId(markerBit), Comparison::EQ),
+              ::testing::Eq(Ranges{{6, 7}}));
+  EXPECT_THAT(rangesFor(mainId(1), Comparison::EQ),
+              ::testing::Eq(Ranges{{1, 2}}));
+}
+
+// ____________________________________________________________________________
+TEST(AuxVocabulary, wordWriterChecksPreconditions) {
+  auto type = VocabularyType{VocabularyType::OnDiskCompressed};
+  std::string mainFilename = absl::StrCat(gtestCurrentTestName(), ".main");
+  MainVocabulary main{mainFilename, {"\"a\"", "\"c\""}, type};
+
+  std::string basename = absl::StrCat(gtestCurrentTestName(), ".aux");
+  absl::Cleanup cleanup = [&basename] { deleteAuxVocabFiles(basename); };
+
+  // A word that is contained in the main vocabulary must not be added.
+  {
+    AuxVocabulary::WordWriter writer{main.vocab(), basename, type};
+    AD_EXPECT_THROW_WITH_MESSAGE(
+        writer("\"a\""),
+        ::testing::HasSubstr("contained in the vocabulary of the main index"));
+  }
+  // The words have to be strictly ascending.
+  {
+    AuxVocabulary::WordWriter writer{main.vocab(), basename, type};
+    writer("\"d\"");
+    AD_EXPECT_THROW_WITH_MESSAGE(
+        writer("\"b\""), ::testing::HasSubstr("strictly ascending order"));
+  }
+}
+
+// ____________________________________________________________________________
+TEST(AuxVocabulary, geoSplitWordWriterRequiresGroupedWords) {
+  auto type = VocabularyType{VocabularyType::OnDiskCompressedGeoSplit};
+  std::string mainFilename = absl::StrCat(gtestCurrentTestName(), ".main");
+  MainVocabulary main{mainFilename, {"\"a\""}, type};
+
+  std::string basename = absl::StrCat(gtestCurrentTestName(), ".aux");
+  absl::Cleanup cleanup = [&basename] { deleteAuxVocabFiles(basename); };
+
+  // Once a word of the second sub-vocabulary has been pushed, no word of the
+  // first one may follow.
+  AuxVocabulary::WordWriter writer{main.vocab(), basename, type};
+  writer(wkt("POINT(1 1)"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      writer("\"b\""), ::testing::HasSubstr("ascending order of the markers"));
+}
+
+}  // namespace

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -309,6 +309,7 @@ addLinkAndDiscoverTest(ContentEncodingHelperTest http)
 addLinkAndDiscoverTest(PrefixCompressorTest)
 
 addLinkAndDiscoverTest(VocabularyTest index)
+addLinkAndDiscoverTest(AuxVocabularyTest index)
 
 addLinkAndDiscoverTestNoLibs(IteratorTest)
 

--- a/test/PrefilterExpressionIndexTest.cpp
+++ b/test/PrefilterExpressionIndexTest.cpp
@@ -493,8 +493,9 @@ class PrefilterExpressionOnMetadataTest : public ::testing::Test {
     ValueIdSubrange inputRange{
         ValueIdIt{&evalBlocks, 0, accessValueIdOp},
         ValueIdIt{&evalBlocks, evalBlocks.size() * 2, accessValueIdOp}};
-    std::vector<ValueIdItPair> iteratorRanges = getRangesForId(
-        inputRange.begin(), inputRange.end(), referenceId, compOp);
+    std::vector<ValueIdItPair> iteratorRanges =
+        getRangesForId(inputRange.begin(), inputRange.end(), referenceId,
+                       compOp, valueIdComparators::AuxVocabOrdering{});
     using namespace prefilterExpressions::detail::mapping;
     ASSERT_TRUE(assertEqRelevantBlockItRanges(
         convertFromSpanIdxToSpanBlockItRanges(evalBlocks.begin(),

--- a/test/ValueIdComparatorsTest.cpp
+++ b/test/ValueIdComparatorsTest.cpp
@@ -61,13 +61,13 @@ TEST_F(ValueIdComparators, GetRangeForDatatype) {
   std::sort(ids.begin(), ids.end(), compareByBits);
   for (auto datatype : datatypes) {
     auto [begin, end] = getRangeForDatatype(ids.begin(), ids.end(), datatype);
+    // `getRangeForDatatype` groups the `Id`s by `datatypeForOrdering()`, which
+    // is the only datatype projection that is ascending in a sorted range. In
+    // particular, an `Id` of type `LocalVocabIndex` belongs to the range of the
+    // datatype of its position in the vocabulary (here always `VocabIndex`),
+    // and the range for `Datatype::LocalVocabIndex` is empty.
     auto hasMatchingDatatype = [&datatype](ValueId id) {
-      std::array vocabTypes{Datatype::VocabIndex, Datatype::LocalVocabIndex};
-      if (ad_utility::contains(vocabTypes, datatype)) {
-        return ad_utility::contains(vocabTypes, id.getDatatype());
-      } else {
-        return id.getDatatype() == datatype;
-      }
+      return id.datatypeForOrdering() == datatype;
     };
     for (auto it = ids.begin(); it < begin; ++it) {
       ASSERT_FALSE(hasMatchingDatatype(*it));
@@ -112,7 +112,8 @@ auto testGetRangesForId(It begin, It end, ValueId id,
   auto trage = generateLocationTrace(l);
   // Perform the testing for a single `Comparison`
   auto testImpl = [&](auto comparison) {
-    auto ranges = getRangesForId(begin, end, id, comparison);
+    auto ranges =
+        getRangesForId(begin, end, id, comparison, AuxVocabOrdering{});
     auto comparator = getComparisonFunctor<comparison>();
     auto it = begin;
 
@@ -130,14 +131,15 @@ auto testGetRangesForId(It begin, It end, ValueId id,
         ASSERT_FALSE(isMatching(*it, id))
             << *it << ' ' << id << comparison.value;
         auto expected = isMatchingDatatype(*it) ? False : Undef;
-        ASSERT_EQ(compareIds(*it, id, comparison), expected)
+        ASSERT_EQ(compareIds(*it, id, comparison, AuxVocabOrdering{}), expected)
             << *it << ' ' << id;
         ++it;
       }
       while (it != rangeEnd) {
         ASSERT_TRUE(isMatching(*it, id))
             << *it << ' ' << id << comparison.value;
-        ASSERT_EQ(compareIds(*it, id, comparison), True) << *it << ' ' << id;
+        ASSERT_EQ(compareIds(*it, id, comparison, AuxVocabOrdering{}), True)
+            << *it << ' ' << id;
         ++it;
       }
     }
@@ -145,7 +147,8 @@ auto testGetRangesForId(It begin, It end, ValueId id,
       ASSERT_FALSE(isMatching(*it, id))
           << *it << ", " << id << comparison.value;
       auto expected = isMatchingDatatype(*it) ? False : Undef;
-      ASSERT_EQ(compareIds(*it, id, comparison), expected) << *it << ' ' << id;
+      ASSERT_EQ(compareIds(*it, id, comparison, AuxVocabOrdering{}), expected)
+          << *it << ' ' << id;
       ++it;
     }
   };
@@ -212,8 +215,8 @@ TEST_F(ValueIdComparators, Undefined) {
 
   for (auto comparison : {Comparison::EQ, Comparison::LE, Comparison::GE,
                           Comparison::GT, Comparison::LT, Comparison::NE}) {
-    auto equalRange =
-        getRangesForId(ids.begin(), ids.end(), undefined, comparison);
+    auto equalRange = getRangesForId(ids.begin(), ids.end(), undefined,
+                                     comparison, AuxVocabOrdering{});
     ASSERT_EQ(equalRange.size(), 0);
   }
 }
@@ -230,12 +233,14 @@ auto testGetRangesForEqualIds(It begin, It end, ValueId idBegin, ValueId idEnd,
       EXPECT_TRUE(true);
     }
     using enum ComparisonResult;
-    auto ranges = getRangesForEqualIds(begin, end, idBegin, idEnd, comparison);
+    auto ranges = getRangesForEqualIds(begin, end, idBegin, idEnd, comparison,
+                                       AuxVocabOrdering{});
     auto it = begin;
     for (auto [rangeBegin, rangeEnd] : ranges) {
       while (it != rangeBegin) {
         // TODO<joka921> Correctly determine, which of these cases we want.
-        ASSERT_THAT(compareWithEqualIds(*it, idBegin, idEnd, comparison),
+        ASSERT_THAT(compareWithEqualIds(*it, idBegin, idEnd, comparison,
+                                        AuxVocabOrdering{}),
                     ::testing::AnyOf(False, Undef))
             << *it << " " << idBegin << ' ' << idEnd << ' '
             << static_cast<int>(comparison.value);
@@ -244,14 +249,17 @@ auto testGetRangesForEqualIds(It begin, It end, ValueId idBegin, ValueId idEnd,
       while (it != rangeEnd) {
         // The "not equal" relation also yields true for different datatypes.
         ASSERT_TRUE(isMatchingDatatype(*it) || comparison == Comparison::NE);
-        ASSERT_EQ(compareWithEqualIds(*it, idBegin, idEnd, comparison), True)
+        ASSERT_EQ(compareWithEqualIds(*it, idBegin, idEnd, comparison,
+                                      AuxVocabOrdering{}),
+                  True)
             << *it << ' ' << idBegin << ' ' << idEnd;
         ++it;
       }
     }
     while (it != end) {
       // TODO<joka921> Correctly determine, which of these cases we want.
-      ASSERT_THAT(compareWithEqualIds(*it, idBegin, idEnd, comparison),
+      ASSERT_THAT(compareWithEqualIds(*it, idBegin, idEnd, comparison,
+                                      AuxVocabOrdering{}),
                   ::testing::AnyOf(False, Undef));
       ++it;
     }
@@ -315,12 +323,12 @@ TEST_F(ValueIdComparators, IndexTypes) {
     }
   };
 
-  // TODO<joka921> The tests for local vocab and VocabIndex now have to be more
-  // complex....
   using ad_utility::use_value_identity::vi;
+  // Note: The `Id`s of type `LocalVocabIndex` are part of the range of the
+  // `VocabIndex`es (see `getRangeForDatatype`), so they are covered by the
+  // first of these calls and do not get one of their own.
   testImpl(vi<Datatype::VocabIndex>, &getVocabIndex);
   testImpl(vi<Datatype::TextRecordIndex>, &getTextRecordIndex);
-  testImpl(vi<Datatype::LocalVocabIndex>, &getLocalVocabIndex);
   testImpl(vi<Datatype::WordVocabIndex>, &getWordVocabIndex);
 }
 
@@ -329,19 +337,25 @@ TEST_F(ValueIdComparators, undefinedWithItself) {
   auto u = ValueId::makeUndefined();
   using enum ComparisonResult;
   using enum ComparisonForIncompatibleTypes;
-  ASSERT_EQ(compareIds(u, u, Comparison::LT), Undef);
-  ASSERT_EQ(compareIds(u, u, Comparison::LE), Undef);
-  ASSERT_EQ(compareIds(u, u, Comparison::EQ), Undef);
-  ASSERT_EQ(compareIds(u, u, Comparison::NE), Undef);
-  ASSERT_EQ(compareIds(u, u, Comparison::GT), Undef);
-  ASSERT_EQ(compareIds(u, u, Comparison::GE), Undef);
+  ASSERT_EQ(compareIds(u, u, Comparison::LT, AuxVocabOrdering{}), Undef);
+  ASSERT_EQ(compareIds(u, u, Comparison::LE, AuxVocabOrdering{}), Undef);
+  ASSERT_EQ(compareIds(u, u, Comparison::EQ, AuxVocabOrdering{}), Undef);
+  ASSERT_EQ(compareIds(u, u, Comparison::NE, AuxVocabOrdering{}), Undef);
+  ASSERT_EQ(compareIds(u, u, Comparison::GT, AuxVocabOrdering{}), Undef);
+  ASSERT_EQ(compareIds(u, u, Comparison::GE, AuxVocabOrdering{}), Undef);
 
-  ASSERT_EQ(compareIds<CompareByType>(u, u, Comparison::LT), False);
-  ASSERT_EQ(compareIds<CompareByType>(u, u, Comparison::LE), True);
-  ASSERT_EQ(compareIds<CompareByType>(u, u, Comparison::EQ), True);
-  ASSERT_EQ(compareIds<CompareByType>(u, u, Comparison::NE), False);
-  ASSERT_EQ(compareIds<CompareByType>(u, u, Comparison::GT), False);
-  ASSERT_EQ(compareIds<CompareByType>(u, u, Comparison::GE), True);
+  ASSERT_EQ(compareIds<CompareByType>(u, u, Comparison::LT, AuxVocabOrdering{}),
+            False);
+  ASSERT_EQ(compareIds<CompareByType>(u, u, Comparison::LE, AuxVocabOrdering{}),
+            True);
+  ASSERT_EQ(compareIds<CompareByType>(u, u, Comparison::EQ, AuxVocabOrdering{}),
+            True);
+  ASSERT_EQ(compareIds<CompareByType>(u, u, Comparison::NE, AuxVocabOrdering{}),
+            False);
+  ASSERT_EQ(compareIds<CompareByType>(u, u, Comparison::GT, AuxVocabOrdering{}),
+            False);
+  ASSERT_EQ(compareIds<CompareByType>(u, u, Comparison::GE, AuxVocabOrdering{}),
+            True);
 }
 
 // _______________________________________________________________________
@@ -349,10 +363,12 @@ TEST_F(ValueIdComparators, contractViolations) {
   auto u = ValueId::makeUndefined();
   auto I = ad_utility::testing::IntId;
   // Invalid value for the `Comparison` enum.
-  ASSERT_ANY_THROW((compareIds(u, u, static_cast<Comparison>(542))));
   ASSERT_ANY_THROW(
-      (compareWithEqualIds(u, u, u, static_cast<Comparison>(542))));
+      (compareIds(u, u, static_cast<Comparison>(542), AuxVocabOrdering{})));
+  ASSERT_ANY_THROW((compareWithEqualIds(u, u, u, static_cast<Comparison>(542),
+                                        AuxVocabOrdering{})));
 
   // The third argument must be >= the second.
-  ASSERT_ANY_THROW((compareWithEqualIds(I(3), I(25), I(12), Comparison::LE)));
+  ASSERT_ANY_THROW((compareWithEqualIds(I(3), I(25), I(12), Comparison::LE,
+                                        AuxVocabOrdering{})));
 }


### PR DESCRIPTION
First part of the auxiliary index (which will store large sets of delta triples on disk instead of in RAM, see #3151): the vocabulary for the words that such updates introduce, plus the `Id` comparison that it requires. **Nothing creates such a vocabulary yet** — the auxiliary index that does follows in a separate PR — so this is a pure addition plus a few fixes to existing comparison behavior.

### What it does

An `AuxVocabulary` holds exactly those words that are used by the triples of an auxiliary index and that are not part of the vocabulary of the main index. It is on disk, sorted, and uses the **same `VocabularyType` as the main vocabulary**, so it splits its words over the same sub-vocabularies — in particular new WKT literals land in a `GeoVocabulary` and keep their precomputed `GeometryInfo`.

Its words get their own datatype, `Datatype::AuxVocabIndex`. That is the first free datatype tag, so nothing is renumbered and the on-disk format of the permutations is unchanged.

Because the datatype bits are the most significant bits of an `Id`, all of these `Id`s are greater than all `Id`s of the main vocabulary. That is what will make the permutations of an auxiliary index mergeable into a scan of the main index (both are sorted bitwise), but it means the bitwise order is not the order of the string values.

For the semantically correct comparison, an `AuxVocabulary` additionally holds an in-RAM array with the position at which each of its words would be sorted into the main vocabulary, so that a semantic comparison is a single random access into RAM. That ordering (`valueIdComparators::AuxVocabOrdering`) is passed explicitly to `getRangesForId`, `getRangesForEqualIds`, `compareIds` and `compareWithEqualIds`; there is deliberately no default argument, so forgetting it is a compile error. A range query on a string value consequently returns up to two disjoint ranges, one in the main and one in the auxiliary vocabulary.

The array is indexed by a word's dense **offset** rather than by its `Id`. The two differ for a split vocabulary, and the offset ordering is what keeps the array of marker-encoded positions ascending — so a single monotone array plus per-marker prefix offsets suffices, and the comparison hot path needs no per-marker dispatch. The marker arithmetic that the main and the auxiliary vocabulary share now lives in `VocabIndexMarker`, tied to `SplitVocabulary` by a `static_assert`.

### Fixes to existing behavior

Three latent problems with the comparison of `Id`s that only became visible with a second vocabulary, but that already affect `Datatype::EncodedVal` today:

- `ValueId::compareThreeWay` now positions a local vocab entry by its cached bounds against *every* other datatype, not just the string-like ones. Otherwise the comparison is not a valid strict weak ordering: an entry can be equal to an `EncodedVal` and at the same time smaller than a `TextRecordIndex` that is smaller than that `EncodedVal`.
- `LocalVocabEntry::compareThreeWay` compares the positions first and only falls back to the (expensive) string comparison if those are equal, for the same reason.
- `getRangeForDatatype` projects the new `ValueId::datatypeForOrdering()`, which — unlike `getDatatype()` — is ascending in a sorted range. This also removes the special handling of the adjacent string types that it needed before, since a local vocab entry now simply reports the datatype of its position.

Note that the last one changes an observable contract: `getRangeForDatatype(..., LocalVocabIndex)` is now always empty, because such `Id`s live in the range of the datatype of their position. `ValueIdComparatorsTest` is updated accordingly.

### Tests

`AuxVocabularyTest` covers, with and without the geo split: positions, offsets, the reverse lookup and word lookup; the full merged order of main and auxiliary words checked exhaustively over all pairs; range filters over a merged `Id` space returning the two disjoint ranges; `GeometryInfo` availability for new WKT literals; and the `WordWriter` preconditions (word already in the main vocabulary, non-ascending words, marker groups out of order).
