### PR TITLE
Split blocks with many update triples into several parts

### DIFF
--- a/src/global/RuntimeParameters.h
+++ b/src/global/RuntimeParameters.h
@@ -185,6 +185,14 @@ struct RuntimeParameters {
   // Only blocks of this size or larger will be considered for vacuuming.
   SizeT vacuumMinimumBlockSize_{100, "vacuum-minimum-block-size"};
 
+  // The maximal number of rows (the rows stored on disk plus the update
+  // triples) that a block may have before it is split into several parts, see
+  // `LocatedTriplesPerBlock::updateAugmentedMetadata`. Without such a split,
+  // all updates that fall into the same block would have to be merged into that
+  // block for every scan that touches it, no matter how selective the scan is.
+  // Set this to `0` to disable the splitting entirely.
+  SizeT maxBlockSizeWithUpdates_{64'000, "max-block-size-with-updates"};
+
   // The runtime log level. Messages with a higher level are suppressed. The
   // compile-time level (CMake LOGLEVEL) still applies as an upper bound.
   LogLevelParameter logLevel_{LogLevel{ad_utility::detail::defaultLogLevel},

--- a/src/index/CompressedRelation.cpp
+++ b/src/index/CompressedRelation.cpp
@@ -221,8 +221,11 @@ CompressedRelationReader::asyncParallelBlockGenerator(
       // holding the lock. We still perform it inside the lock to avoid
       // contention of the file. On a fast SSD we could possibly change this,
       // but this has to be investigated.
+      auto extendedColumns = columnsToReadForBlock(scanConfig_, blockMetadata);
       auto compressedBlock = reader_->readCompressedBlockFromFile(
-          blockMetadata, scanConfig_.scanColumns_);
+          blockMetadata, extendedColumns.empty()
+                             ? ColumnIndicesRef{scanConfig_.scanColumns_}
+                             : ColumnIndicesRef{extendedColumns});
 
       lock.unlock();
       auto decompressedBlockAndMetadata =
@@ -774,8 +777,11 @@ IdTable CompressedRelationReader::scan(
   IdTable result(columnIndices.size(), allocator_);
   // Compute an upper bound for the size and reserve enough space in the
   // result.
-  auto sizes = scanSpecAndBlocks.getBlockMetadataView() |
-               ql::views::transform(&CompressedBlockMetadata::numRows_);
+  auto sizes =
+      scanSpecAndBlocks.getBlockMetadataView() |
+      ql::views::transform([](const CompressedBlockMetadata& blockMetadata) {
+        return blockMetadata.numRowsEstimate();
+      });
   auto upperBoundSize = std::accumulate(sizes.begin(), sizes.end(), size_t{0});
   if (limitOffset._limit.has_value()) {
     upperBoundSize = std::min(upperBoundSize,
@@ -930,14 +936,13 @@ std::pair<size_t, size_t> CompressedRelationReader::getResultSizeImpl(
               ? 1
               : getRuntimeParameter<
                     &RuntimeParameters::smallIndexScanSizeEstimateDivisor_>();
-      const auto [ins, del] =
-          locatedTriplesPerBlock.numTriples(block.blockIndex_);
+      const auto [ins, del] = locatedTriplesPerBlock.numTriples(block);
       auto trunc = [divisor](size_t num) {
         return std::max<size_t>(std::min<size_t>(num, 1), num / divisor);
       };
       inserted += trunc(ins);
       deleted += trunc(del);
-      numResults += trunc(block.numRows_);
+      numResults += trunc(block.numRowsEstimate());
     }
   };
 
@@ -954,12 +959,13 @@ std::pair<size_t, size_t> CompressedRelationReader::getResultSizeImpl(
 
   ql::ranges::for_each(
       ql::ranges::subrange{beginBlock, endBlock}, [&](const auto& block) {
-        const auto [ins, del] =
-            locatedTriplesPerBlock.numTriples(block.blockIndex_);
-        if (!exactSize || (ins == 0 && del == 0)) {
+        const auto [ins, del] = locatedTriplesPerBlock.numTriples(block);
+        // Note: For a partial block, `numRowsEstimate()` is only an estimate,
+        // so we always have to read such a block if the exact size is required.
+        if (!exactSize || (ins == 0 && del == 0 && !block.isPartial())) {
           inserted += ins;
           deleted += del;
-          numResults += block.numRows_;
+          numResults += block.numRowsEstimate();
         } else {
           // TODO<joka921> We could cache the exact size as soon as we
           // have merged the block once since the last update.
@@ -1056,10 +1062,13 @@ IdTable CompressedRelationReader::getDistinctColIdsAndCounts(
   // the count from the metadata.
   for (const auto& [i, blockMetadata] : ranges::views::enumerate(blocks)) {
     // The `numRows_` metadata shortcut is safe iff all rows of the block
-    // agree on the grouped column AND the block has no delta triples. The
-    // column uniformity is equivalent to `firstTriple_` and `lastTriple_`
-    // agreeing on the first `columnIndex + 1` columns.
+    // agree on the grouped column AND the block has no delta triples AND the
+    // block is not only a part of an on-disk block (in which case `numRows_`
+    // refers to the whole on-disk block). The column uniformity is equivalent
+    // to `firstTriple_` and `lastTriple_` agreeing on the first `columnIndex +
+    // 1` columns.
     if (!blockMetadata.containsInconsistentTriples(columnIndex + 1) &&
+        !blockMetadata.isPartial() &&
         !locatedTriplesPerBlock.containsTriples(blockMetadata.blockIndex_)) {
       // The whole block has the same `colId` and no delta triples ->
       // we get all the information from the metadata.
@@ -1165,6 +1174,77 @@ DecompressedBlock CompressedRelationReader::decompressBlock(
 }
 
 // ____________________________________________________________________________
+size_t CompressedRelationReader::numAdditionalColumnsForPartialBlock(
+    const ScanImplConfig& scanConfig, const CompressedBlockMetadata& metadata) {
+  if (!metadata.isPartial()) {
+    return 0;
+  }
+  // Those leading columns of a triple that are fixed by the scan specification
+  // are not part of the `scanColumns_`, but we need them to compare the rows of
+  // the on-disk block with the bounds of the partial block. Note that we cannot
+  // simply take their values from the scan specification, because the on-disk
+  // block also contains the rows of the other parts, which may well have
+  // different values in those columns.
+  auto [numIndexColumns, includeGraphColumn] =
+      prepareLocatedTriples(scanConfig.scanColumns_);
+  return 3 - numIndexColumns;
+}
+
+// ____________________________________________________________________________
+std::vector<ColumnIndex> CompressedRelationReader::columnsToReadForBlock(
+    const ScanImplConfig& scanConfig, const CompressedBlockMetadata& metadata) {
+  size_t numAdditionalColumns =
+      numAdditionalColumnsForPartialBlock(scanConfig, metadata);
+  if (numAdditionalColumns == 0) {
+    return {};
+  }
+  std::vector<ColumnIndex> columns;
+  columns.reserve(numAdditionalColumns + scanConfig.scanColumns_.size());
+  ql::ranges::copy(ad_utility::integerRange(ColumnIndex{numAdditionalColumns}),
+                   std::back_inserter(columns));
+  ql::ranges::copy(scanConfig.scanColumns_, std::back_inserter(columns));
+  return columns;
+}
+
+// ____________________________________________________________________________
+void CompressedRelationReader::restrictBlockToPartialBlockBounds(
+    DecompressedBlock& block, const CompressedBlockMetadata& metadata,
+    size_t numAdditionalColumns) {
+  // Because of the `numAdditionalColumns` (see
+  // `numAdditionalColumnsForPartialBlock`), the first three columns of the
+  // `block` are exactly the three columns of a triple.
+  AD_CORRECTNESS_CHECK(block.numColumns() > 3);
+
+  // Return the index of the first row of the `block` that is greater than or
+  // equal to the `bound`, ignoring the graph.
+  auto lowerBoundRow =
+      [&block](const CompressedBlockMetadata::PermutedTriple& bound) {
+        std::array<Id, 3> boundIds{bound.col0Id_, bound.col1Id_, bound.col2Id_};
+        auto rowLessThanBound = [&boundIds](const auto& row) {
+          return std::array<Id, 3>{row[0], row[1], row[2]} < boundIds;
+        };
+        return static_cast<size_t>(
+            ql::ranges::partition_point(block, rowLessThanBound) -
+            block.begin());
+      };
+
+  auto lowerBound = metadata.inclusiveLowerBound();
+  auto upperBound = metadata.exclusiveUpperBound();
+  size_t end = upperBound.has_value() ? lowerBoundRow(upperBound.value())
+                                      : block.numRows();
+  size_t begin = lowerBound.has_value() ? lowerBoundRow(lowerBound.value()) : 0;
+  AD_CORRECTNESS_CHECK(begin <= end);
+  block.resize(end);
+  block.erase(block.begin(), block.begin() + begin);
+
+  // Remove the columns that were only read for the comparisons above.
+  for ([[maybe_unused]] size_t i :
+       ad_utility::integerRange(numAdditionalColumns)) {
+    block.deleteColumn(0);
+  }
+}
+
+// ____________________________________________________________________________
 DecompressedBlockAndMetadata
 CompressedRelationReader::decompressAndPostprocessBlock(
     const CompressedBlock& compressedBlock, size_t numRowsToRead,
@@ -1173,11 +1253,17 @@ CompressedRelationReader::decompressAndPostprocessBlock(
   auto decompressedBlock = decompressBlock(compressedBlock, numRowsToRead);
   auto [numIndexColumns, includeGraphColumn] =
       prepareLocatedTriples(scanConfig.scanColumns_);
+  // If the `metadata` describes only a part of the on-disk block, then drop all
+  // the rows that belong to a different part.
+  if (metadata.isPartial()) {
+    restrictBlockToPartialBlockBounds(
+        decompressedBlock, metadata,
+        numAdditionalColumnsForPartialBlock(scanConfig, metadata));
+  }
   bool hasUpdates = false;
-  if (scanConfig.locatedTriples_.containsTriples(metadata.blockIndex_)) {
+  if (scanConfig.locatedTriples_.containsTriples(metadata)) {
     decompressedBlock = scanConfig.locatedTriples_.mergeTriples(
-        metadata.blockIndex_, decompressedBlock, numIndexColumns,
-        includeGraphColumn);
+        metadata, decompressedBlock, numIndexColumns, includeGraphColumn);
     hasUpdates = true;
   }
   bool wasPostprocessed = false;
@@ -1212,8 +1298,11 @@ CompressedRelationReader::readAndDecompressBlock(
   if (scanConfig.graphFilter_.canBlockBeSkipped(blockMetaData)) {
     return std::nullopt;
   }
-  CompressedBlock compressedColumns =
-      readCompressedBlockFromFile(blockMetaData, scanConfig.scanColumns_);
+  auto extendedColumns = columnsToReadForBlock(scanConfig, blockMetaData);
+  CompressedBlock compressedColumns = readCompressedBlockFromFile(
+      blockMetaData, extendedColumns.empty()
+                         ? ColumnIndicesRef{scanConfig.scanColumns_}
+                         : ColumnIndicesRef{extendedColumns});
   const auto numRowsToRead = blockMetaData.numRows_;
   return decompressAndPostprocessBlock(compressedColumns, numRowsToRead,
                                        scanConfig, blockMetaData);
@@ -1641,12 +1730,24 @@ CompressedRelationReader::getMetadataForSmallRelation(
   // happen that a relation starts in a single block, but added triples land in
   // an adjacent block (because the relation was right at the end of a block).
   // In this case we might also see two blocks here.
-  AD_CONTRACT_CHECK(scanSpecAndBlocks.sizeBlockMetadata_ <= 2,
+  //
+  // Note: We count the distinct `blockIndex_`es, because a single block may be
+  // split into several parts because of the update triples (see
+  // `CompressedBlockMetadata::PartialBlockInfo`).
+  size_t numDistinctBlockIndices = 0;
+  std::optional<size_t> previousBlockIndex;
+  for (const auto& blockMetadata : blocks) {
+    if (blockMetadata.blockIndex_ != previousBlockIndex) {
+      ++numDistinctBlockIndices;
+      previousBlockIndex = blockMetadata.blockIndex_;
+    }
+  }
+  AD_CONTRACT_CHECK(numDistinctBlockIndices <= 2,
                     "Should only be called for small relations (contained in "
                     "at most one block), or relations that started in a single "
                     "block, but were extended into the adjacent block by "
                     "SPARQL UPDATE, but found a relation which spans ",
-                    scanSpecAndBlocks.sizeBlockMetadata_, "block.");
+                    numDistinctBlockIndices, "block.");
 
   ad_utility::HashSet<Id> distinctCol2;
   size_t numRowsTotal = 0;
@@ -1745,15 +1846,19 @@ CPP_template(typename Range)(
     return;
   }
 
+  // Note: Two consecutive blocks may have the same `blockIndex_`, namely if
+  // they are two parts of the same on-disk block (see
+  // `CompressedBlockMetadata::PartialBlockInfo`). Such blocks are still unique
+  // and strictly ordered w.r.t. their `lastTriple_`.
   auto checkUniquenessAndOrder = [](const auto& blockPair) {
     const auto& [b1, b2] = blockPair;
     // Blocks must be unique.
-    AD_CONTRACT_CHECK(b1 != b2 && b1.blockIndex_ != b2.blockIndex_, [&] {
+    AD_CONTRACT_CHECK(b1 != b2, [&] {
       return createErrorMessage(b1, b2, "Found block metadata duplicates\n");
     });
     // Blocks must adhere to ascending order.
     AD_CONTRACT_CHECK(
-        b1.lastTriple_ < b2.lastTriple_ && b1.blockIndex_ < b2.blockIndex_,
+        b1.lastTriple_ < b2.lastTriple_ && b1.blockIndex_ <= b2.blockIndex_,
         [&] {
           return createErrorMessage(b1, b2,
                                     "Found block metadata order violation\n");

--- a/src/index/CompressedRelation.h
+++ b/src/index/CompressedRelation.h
@@ -126,6 +126,71 @@ struct CompressedBlockMetadataNoBlockIndex {
   // blocks.
   bool containsDuplicatesWithDifferentGraphs_;
 
+  // Additional information for a block that only represents a *part* of an
+  // on-disk block. Such partial blocks are created when many update triples
+  // fall into the same on-disk block, which is then split into several parts,
+  // see `LocatedTriplesPerBlock::updateAugmentedMetadata`. All parts of an
+  // on-disk block share the same `blockIndex_`, the same
+  // `offsetsAndCompressedSize_` (unless a part provably contains no rows of the
+  // on-disk block, in which case those are `nullopt`), and the same `numRows_`.
+  // The part of the block (both of its rows and of its update triples) that
+  // belongs to a partial block is defined by the bounds below.
+  struct PartialBlockInfo {
+    // The estimated number of rows of the on-disk block that belong to this
+    // part. Note that `numRows_` always is the exact number of rows of the
+    // *whole* on-disk block, as it is required to decompress that block.
+    uint32_t numRowsEstimate_;
+    // If true, then `firstTriple_` is the inclusive lower bound of this part:
+    // all rows and update triples that are smaller (ignoring the graph) belong
+    // to a preceding part. If false, then this part has no lower bound.
+    bool firstTripleIsInclusiveLowerBound_;
+    // If true, then `lastTriple_` is the *exclusive* upper bound of this part:
+    // all rows and update triples that are greater than or equal to it
+    // (ignoring the graph) belong to a subsequent part. If false, then this
+    // part has no upper bound, and `lastTriple_` is inclusive, as it is for a
+    // block that is not partial.
+    bool lastTripleIsExclusiveUpperBound_;
+
+    QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(
+        PartialBlockInfo, numRowsEstimate_, firstTripleIsInclusiveLowerBound_,
+        lastTripleIsExclusiveUpperBound_)
+  };
+  std::optional<PartialBlockInfo> partialBlockInfo_ = std::nullopt;
+
+  // Return true iff this block only represents a part of an on-disk block, see
+  // `PartialBlockInfo` above.
+  bool isPartial() const { return partialBlockInfo_.has_value(); }
+
+  // The number of rows that this block contributes to a scan. For a partial
+  // block this is only an estimate. NOTE: Use `numRows_` (which is exact also
+  // for partial blocks) whenever the number of rows of the on-disk block is
+  // required, in particular for decompressing it.
+  size_t numRowsEstimate() const {
+    return isPartial() ? partialBlockInfo_.value().numRowsEstimate_ : numRows_;
+  }
+
+  // The inclusive lower bound of this block, or `nullopt` if it has none. All
+  // rows and update triples that are smaller (ignoring the graph) do not belong
+  // to this block.
+  std::optional<PermutedTriple> inclusiveLowerBound() const {
+    if (isPartial() &&
+        partialBlockInfo_.value().firstTripleIsInclusiveLowerBound_) {
+      return firstTriple_;
+    }
+    return std::nullopt;
+  }
+
+  // The exclusive upper bound of this block, or `nullopt` if it has none. All
+  // rows and update triples that are greater than or equal to it (ignoring the
+  // graph) do not belong to this block.
+  std::optional<PermutedTriple> exclusiveUpperBound() const {
+    if (isPartial() &&
+        partialBlockInfo_.value().lastTripleIsExclusiveUpperBound_) {
+      return lastTriple_;
+    }
+    return std::nullopt;
+  }
+
   // Check for constant values in `firstTriple_` and `lastTriple` over all
   // columns `< columnIndex`.
   // Returns `true` if the respective column values of `firstTriple_` and
@@ -145,7 +210,7 @@ struct CompressedBlockMetadataNoBlockIndex {
   QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(
       CompressedBlockMetadataNoBlockIndex, offsetsAndCompressedSize_, numRows_,
       firstTriple_, lastTriple_, graphInfo_,
-      containsDuplicatesWithDifferentGraphs_)
+      containsDuplicatesWithDifferentGraphs_, partialBlockInfo_)
 
   // Format CompressedBlockMetadata contents for debugging.
   friend std::ostream& operator<<(
@@ -161,6 +226,14 @@ struct CompressedBlockMetadataNoBlockIndex {
     }
     str << "[possibly] contains duplicates: "
         << blockMetadata.containsDuplicatesWithDifferentGraphs_ << '\n';
+    if (blockMetadata.isPartial()) {
+      const auto& info = blockMetadata.partialBlockInfo_.value();
+      str << "part of an on-disk block, est. num. rows: "
+          << info.numRowsEstimate_
+          << ", has lower bound: " << info.firstTripleIsInclusiveLowerBound_
+          << ", has exclusive upper bound: "
+          << info.lastTripleIsExclusiveUpperBound_ << '\n';
+    }
     return str;
   }
 };
@@ -188,6 +261,12 @@ struct CompressedBlockMetadata : CompressedBlockMetadataNoBlockIndex {
   // Return true if a sequence of `CompressedBlockMetadata` is sorted, and if
   // all the triples that are the same when disregarding the graph are in the
   // same block.
+  //
+  // NOTE: Two consecutive parts of the same on-disk block (see
+  // `PartialBlockInfo`) touch: the exclusive upper bound of the first part is
+  // the inclusive lower bound of the second part. Triples that are the same
+  // when disregarding the graph are still in the same block, because the bounds
+  // are compared while ignoring the graph.
   template <typename SequenceOfBlocks>
   static bool checkInvariantsForSortedBlocks(
       const SequenceOfBlocks& sequenceOfBlocks) {
@@ -196,6 +275,9 @@ struct CompressedBlockMetadata : CompressedBlockMetadataNoBlockIndex {
         [](const auto& adjacent) {
           const auto& first = adjacent.front().lastTriple_;
           const auto& second = adjacent.back().firstTriple_;
+          if (adjacent.front().exclusiveUpperBound().has_value()) {
+            return first <= second;
+          }
           return (first < second) &&
                  (first.tieWithoutGraph() != second.tieWithoutGraph());
         });
@@ -921,6 +1003,33 @@ class CompressedRelationReader {
   std::optional<DecompressedBlockAndMetadata> readAndDecompressBlock(
       const CompressedBlockMetadata& blockMetaData,
       const ScanImplConfig& scanConfig) const;
+
+  // The number of columns that have to be read from disk in addition to the
+  // `scanColumns_` of the `scanConfig` for the block described by the
+  // `metadata`. This is `0` unless that block is only a part of an on-disk
+  // block (see `CompressedBlockMetadata::PartialBlockInfo`), in which case the
+  // leading columns of a triple that are fixed by the scan specification are
+  // required to determine which rows of the on-disk block belong to that part.
+  static size_t numAdditionalColumnsForPartialBlock(
+      const ScanImplConfig& scanConfig,
+      const CompressedBlockMetadata& metadata);
+
+  // The columns that have to be read from disk for the block described by the
+  // `metadata`: the additional columns `0, 1, ...` (see above), followed by the
+  // `scanColumns_` of the `scanConfig`. Return an empty vector if no additional
+  // columns are required, which means that the `scanColumns_` can be used
+  // directly.
+  static std::vector<ColumnIndex> columnsToReadForBlock(
+      const ScanImplConfig& scanConfig,
+      const CompressedBlockMetadata& metadata);
+
+  // Erase all rows from the `block` (which is the decompressed on-disk block,
+  // read with the `numAdditionalColumns` additional columns) that do not belong
+  // to the part of that block which the `metadata` describes, and then erase
+  // those additional columns again.
+  static void restrictBlockToPartialBlockBounds(
+      DecompressedBlock& block, const CompressedBlockMetadata& metadata,
+      size_t numAdditionalColumns);
 
   // Like `readAndDecompressBlock`, and postprocess by merging the located
   // triples (if any) and applying the graph filters (if any), both specified

--- a/src/index/LocatedTriples.cpp
+++ b/src/index/LocatedTriples.cpp
@@ -82,6 +82,23 @@ NumAddedAndDeleted LocatedTriplesPerBlock::numTriples(size_t blockIndex) const {
   return {0, 0};
 }
 
+// ____________________________________________________________________________
+NumAddedAndDeleted LocatedTriplesPerBlock::numTriples(
+    const CompressedBlockMetadata& blockMetadata) const {
+  if (!blockMetadata.isPartial()) {
+    return numTriples(blockMetadata.blockIndex_);
+  }
+  auto blockUpdateTriples = getUpdatesIfPresent(blockMetadata.blockIndex_);
+  if (!blockUpdateTriples) {
+    return {0, 0};
+  }
+  // See the comment in the header file for why we return the same number twice.
+  size_t numTriplesInPart = blockUpdateTriples->sizeUpperBoundInRange(
+      blockMetadata.inclusiveLowerBound(), blockMetadata.exclusiveUpperBound(),
+      CompareTripleWithBlockBoundIgnoringGraph{});
+  return {numTriplesInPart, numTriplesInPart};
+}
+
 namespace {
 
 // This code works for `std::integer_sequence` as well as
@@ -141,20 +158,18 @@ CPP_template(size_t numIndexColumns, bool includeGraphColumn,
 
 // ____________________________________________________________________________
 template <size_t numIndexColumns, bool includeGraphColumn>
-IdTable LocatedTriplesPerBlock::mergeTriplesImpl(size_t blockIndex,
-                                                 const IdTable& block) const {
+IdTable LocatedTriplesPerBlock::mergeTriplesImpl(
+    const CompressedBlockMetadata& blockMetadata, const IdTable& block) const {
   // This method should only be called if there are located triples in the
   // specified block.
-  AD_CONTRACT_CHECK(map_.contains(blockIndex));
+  AD_CONTRACT_CHECK(map_.contains(blockMetadata.blockIndex_));
 
   AD_CONTRACT_CHECK(numIndexColumns + static_cast<size_t>(includeGraphColumn) <=
                     block.numColumns());
 
-  auto numInsertsAndDeletes = numTriples(blockIndex);
+  auto numInsertsAndDeletes = numTriples(blockMetadata);
   IdTable result{block.numColumns(), block.getAllocator()};
   result.resize(block.numRows() + numInsertsAndDeletes.numAdded_);
-
-  const auto& locatedTriples = map_.at(blockIndex);
 
   auto lessThan = [](const auto& lt, const auto& row) {
     return tieLocatedTriple<numIndexColumns, includeGraphColumn>(lt) <
@@ -166,7 +181,7 @@ IdTable LocatedTriplesPerBlock::mergeTriplesImpl(size_t blockIndex,
   };
 
   auto rowIt = block.begin();
-  auto sortedLocatedTriples = locatedTriples.getSortedView();
+  auto sortedLocatedTriples = getUpdatesForBlock(blockMetadata);
   auto locatedTripleIt = sortedLocatedTriples.begin();
   auto locatedTripleEnd = sortedLocatedTriples.end();
   auto resultIt = result.begin();
@@ -229,21 +244,20 @@ IdTable LocatedTriplesPerBlock::mergeTriplesImpl(size_t blockIndex,
 }
 
 // ____________________________________________________________________________
-IdTable LocatedTriplesPerBlock::mergeTriples(size_t blockIndex,
-                                             const IdTable& block,
-                                             size_t numIndexColumns,
-                                             bool includeGraphColumn) const {
+IdTable LocatedTriplesPerBlock::mergeTriples(
+    const CompressedBlockMetadata& blockMetadata, const IdTable& block,
+    size_t numIndexColumns, bool includeGraphColumn) const {
   // The following code does nothing more than turn `numIndexColumns` and
   // `includeGraphColumn` into template parameters of `mergeTriplesImpl`.
-  auto mergeTriplesImplHelper = [numIndexColumns, blockIndex, &block,
+  auto mergeTriplesImplHelper = [numIndexColumns, &blockMetadata, &block,
                                  this](auto hasGraphColumn) {
     if (numIndexColumns == 3) {
-      return mergeTriplesImpl<3, hasGraphColumn>(blockIndex, block);
+      return mergeTriplesImpl<3, hasGraphColumn>(blockMetadata, block);
     } else if (numIndexColumns == 2) {
-      return mergeTriplesImpl<2, hasGraphColumn>(blockIndex, block);
+      return mergeTriplesImpl<2, hasGraphColumn>(blockMetadata, block);
     } else {
       AD_CORRECTNESS_CHECK(numIndexColumns == 1);
-      return mergeTriplesImpl<1, hasGraphColumn>(blockIndex, block);
+      return mergeTriplesImpl<1, hasGraphColumn>(blockMetadata, block);
     }
   };
   using ad_utility::use_value_identity::vi;
@@ -432,79 +446,268 @@ void LocatedTriplesPerBlock::setOriginalMetadata(
   originalMetadata_ = std::move(metadata);
 }
 
+namespace {
+
+// The information about the update triples of a single part of a block that is
+// required to compute the metadata of that part. The parts of a block are
+// determined in `appendAugmentedMetadataForBlock`.
+struct UpdateInfoForPart {
+  using PermutedTriple = CompressedBlockMetadata::PermutedTriple;
+  // The first and the last update triple of this part.
+  PermutedTriple firstTriple_{};
+  PermutedTriple lastTriple_{};
+  // The distinct graphs of the *inserted* triples of this part. `nullopt` if
+  // there are more than `MAX_NUM_GRAPHS_STORED_IN_BLOCK_METADATA` of them.
+  std::optional<std::vector<Id>> insertedGraphs_{std::vector<Id>{}};
+  // True iff this part contains at least one inserted (as opposed to deleted)
+  // triple.
+  bool hasInsertions_ = false;
+  // The number of update triples of this part.
+  size_t numTriples_ = 0;
+
+  // Add a single update triple. The triples have to be added in sorted order.
+  void addTriple(const LocatedTriple& locatedTriple) {
+    auto triple = locatedTriple.triple_.toPermutedTriple();
+    if (numTriples_ == 0) {
+      firstTriple_ = triple;
+    }
+    lastTriple_ = triple;
+    ++numTriples_;
+    if (!locatedTriple.insertOrDelete_) {
+      return;
+    }
+    hasInsertions_ = true;
+    if (!insertedGraphs_.has_value()) {
+      return;
+    }
+    auto& graphs = insertedGraphs_.value();
+    // Note: We compare the bits, exactly as `computeDistinctGraphs` does.
+    if (ql::ranges::find(graphs, triple.graphId_.getBits(), &Id::getBits) !=
+        graphs.end()) {
+      return;
+    }
+    if (graphs.size() == MAX_NUM_GRAPHS_STORED_IN_BLOCK_METADATA) {
+      insertedGraphs_.reset();
+      return;
+    }
+    graphs.push_back(triple.graphId_);
+  }
+};
+
+// Return a copy of the `triple` that can be used as the bound between two parts
+// of a block. The graph is set to the minimal possible ID, because the bounds
+// are compared while ignoring the graph, and this makes the fact that all
+// triples that are equal to the `triple` except for their graph belong to the
+// part *after* this bound explicit.
+CompressedBlockMetadata::PermutedTriple makeBoundBetweenParts(
+    CompressedBlockMetadata::PermutedTriple triple) {
+  triple.graphId_ = Id::min();
+  return triple;
+}
+
 // Update the `blockMetadata`, such that its graph info is consistent with the
-// `locatedTriples` which are added to that block. In particular, all graphs to
-// which at least one triple is inserted become part of the graph info, and if
-// the number of total graphs becomes larger than the configured threshold, then
-// the graph info is set to `nullopt`, which means that there is no info.
+// update triples described by `updateInfo` which are added to that block. In
+// particular, all graphs to which at least one triple is inserted become part
+// of the graph info, and if the number of total graphs becomes larger than the
+// configured threshold, then the graph info is set to `nullopt`, which means
+// that there is no info.
 void updateGraphMetadata(CompressedBlockMetadata& blockMetadata,
-                         const LocatedTriples& locatedTriples) {
+                         const UpdateInfoForPart& updateInfo) {
   auto& graphs = blockMetadata.graphInfo_;
   // We only insert graphs, never delete them, so if `graphs` is already
   // `nullopt`, then it will stay `nullopt`.
   if (graphs.has_value()) {
-    graphs = computeDistinctGraphs(
-        locatedTriples.getSortedView() |
-            ql::views::filter(&LocatedTriple::insertOrDelete_) |
-            ql::views::transform([](const LocatedTriple& lt) {
-              return lt.triple_.ids().at(ADDITIONAL_COLUMN_GRAPH_ID);
-            }),
-        graphs.value());
+    if (updateInfo.insertedGraphs_.has_value()) {
+      graphs = computeDistinctGraphs(updateInfo.insertedGraphs_.value(),
+                                     graphs.value());
+    } else {
+      graphs.reset();
+    }
   }
 
   if (!hasOnlyOneGraph(graphs)) {
     // We do not know anything about the triples contained in the block, so we
-    // also cannot know if the `locatedTriples` introduces duplicates. We thus
-    // have to be conservative and assume that there are duplicates when data
-    // was inserted.
-    blockMetadata.containsDuplicatesWithDifferentGraphs_ |= ql::ranges::any_of(
-        locatedTriples.getSortedView(), &LocatedTriple::insertOrDelete_);
+    // also cannot know if the update triples introduce duplicates. We thus have
+    // to be conservative and assume that there are duplicates when data was
+    // inserted.
+    blockMetadata.containsDuplicatesWithDifferentGraphs_ |=
+        updateInfo.hasInsertions_;
+  }
+}
+
+}  // namespace
+
+// ____________________________________________________________________________
+void LocatedTriplesPerBlock::appendAugmentedMetadataForBlock(
+    std::vector<CompressedBlockMetadata>& result,
+    CompressedBlockMetadata blockMetadata, size_t blockIndex) const {
+  using PermutedTriple = CompressedBlockMetadata::PermutedTriple;
+  // Note: The `blockIndex` is the position of the block in the metadata, which
+  // is what the `LocatedTriple`s refer to. For metadata that was created by the
+  // `CompressedRelationWriter` it is equal to `blockMetadata.blockIndex_`.
+  auto blockUpdates = getUpdatesIfPresent(blockIndex);
+  if (!blockUpdates) {
+    result.push_back(std::move(blockMetadata));
+    return;
+  }
+  // A block without any rows in the underlying file consists of update triples
+  // only. This is the case for the very last block, which holds the update
+  // triples that are larger than all triples in the index.
+  const bool hasRowsInFile =
+      blockMetadata.offsetsAndCompressedSize_.has_value();
+  AD_CORRECTNESS_CHECK(hasRowsInFile || blockMetadata.numRows_ == 0);
+
+  // Determine into how many parts this block has to be split, such that each
+  // part has at most `maxBlockSize` rows (rows in the file plus update
+  // triples).
+  size_t maxBlockSize =
+      getRuntimeParameter<&RuntimeParameters::maxBlockSizeWithUpdates_>();
+  size_t numUpdates = blockUpdates->sizeUpperBound();
+  size_t totalSize = numUpdates + blockMetadata.numRows_;
+  size_t numParts = maxBlockSize > 0 && totalSize > maxBlockSize
+                        ? (totalSize + maxBlockSize - 1) / maxBlockSize
+                        : 1;
+  size_t numUpdatesPerPart =
+      std::max<size_t>(1, (numUpdates + numParts - 1) / numParts);
+
+  // Distribute the update triples over the parts. A new part is started as soon
+  // as the current part has at least `numUpdatesPerPart` triples, but only at a
+  // triple that differs from the previous one also when the graph is ignored,
+  // because triples that only differ in their graph must stay in the same part.
+  // Note: The number of parts computed above is only an upper bound for the
+  // number of parts that are actually created.
+  std::vector<UpdateInfoForPart> parts(1);
+  for (const LocatedTriple& locatedTriple : blockUpdates->getSortedView()) {
+    if (parts.back().numTriples_ >= numUpdatesPerPart &&
+        parts.back().lastTriple_.tieWithoutGraph() !=
+            locatedTriple.triple_.toPermutedTriple().tieWithoutGraph()) {
+      parts.emplace_back();
+    }
+    parts.back().addTriple(locatedTriple);
+  }
+  const bool isSplit = parts.size() > 1;
+
+  // Return true iff the part with the given bounds can contain rows of the
+  // underlying on-disk block. The rows in the file lie in the range
+  // `[firstTriple_, lastTriple_]` of the original metadata.
+  auto canContainRowsInFile =
+      [&blockMetadata, hasRowsInFile](
+          const std::optional<PermutedTriple>& lowerBound,
+          const std::optional<PermutedTriple>& upperBound) {
+        return hasRowsInFile &&
+               (!upperBound.has_value() ||
+                blockMetadata.firstTriple_.tieWithoutGraph() <
+                    upperBound.value().tieWithoutGraph()) &&
+               (!lowerBound.has_value() ||
+                lowerBound.value().tieWithoutGraph() <=
+                    blockMetadata.lastTriple_.tieWithoutGraph());
+      };
+
+  // The bounds of the part with the given index. The first part has no lower
+  // and the last part has no upper bound, such that the parts always cover the
+  // complete range of the original block. This is important, because update
+  // triples may be added after this function has been called; those then still
+  // belong to exactly one of the parts.
+  auto boundsOfPart = [&parts](size_t partIndex) {
+    std::optional<PermutedTriple> lowerBound;
+    std::optional<PermutedTriple> upperBound;
+    if (partIndex > 0) {
+      lowerBound = makeBoundBetweenParts(parts.at(partIndex).firstTriple_);
+    }
+    if (partIndex + 1 < parts.size()) {
+      upperBound = makeBoundBetweenParts(parts.at(partIndex + 1).firstTriple_);
+    }
+    return std::pair{lowerBound, upperBound};
+  };
+
+  // Distribute the rows in the file over those parts that can contain them.
+  size_t numPartsWithRowsInFile = 0;
+  for (size_t partIndex = 0; partIndex < parts.size(); ++partIndex) {
+    auto [lowerBound, upperBound] = boundsOfPart(partIndex);
+    numPartsWithRowsInFile +=
+        static_cast<size_t>(canContainRowsInFile(lowerBound, upperBound));
+  }
+  size_t numRowsPerPart =
+      numPartsWithRowsInFile == 0
+          ? 0
+          : (blockMetadata.numRows_ + numPartsWithRowsInFile - 1) /
+                numPartsWithRowsInFile;
+
+  for (size_t partIndex = 0; partIndex < parts.size(); ++partIndex) {
+    const auto& part = parts.at(partIndex);
+    auto [lowerBound, upperBound] = boundsOfPart(partIndex);
+    CompressedBlockMetadata metadata = blockMetadata;
+    // The first and last triple of a part. For the outermost parts, the triples
+    // in the file also have to be taken into account; for the parts in between,
+    // the first triple is the inclusive lower and the last triple is the
+    // *exclusive* upper bound of that part.
+    metadata.firstTriple_ = lowerBound.value_or(
+        std::min(blockMetadata.firstTriple_, part.firstTriple_));
+    metadata.lastTriple_ = upperBound.value_or(
+        std::max(blockMetadata.lastTriple_, part.lastTriple_));
+    if (isSplit) {
+      if (canContainRowsInFile(lowerBound, upperBound)) {
+        metadata.partialBlockInfo_ = CompressedBlockMetadata::PartialBlockInfo{
+            static_cast<uint32_t>(std::min<size_t>(
+                numRowsPerPart, std::numeric_limits<uint32_t>::max())),
+            lowerBound.has_value(), upperBound.has_value()};
+      } else {
+        // This part provably contains none of the rows in the file, so it does
+        // not have to be read from disk at all.
+        metadata.offsetsAndCompressedSize_.reset();
+        metadata.numRows_ = 0;
+        metadata.partialBlockInfo_ = CompressedBlockMetadata::PartialBlockInfo{
+            0, lowerBound.has_value(), upperBound.has_value()};
+      }
+    }
+    updateGraphMetadata(metadata, part);
+    result.push_back(std::move(metadata));
   }
 }
 
 // ____________________________________________________________________________
 void LocatedTriplesPerBlock::updateAugmentedMetadata() {
-  // TODO<C++23> use view::enumerate
-  size_t blockIndex = 0;
-  // Copy to preserve originalMetadata_.
+  static const std::vector<CompressedBlockMetadata> emptyMetadata{};
   if (!originalMetadata_.has_value()) {
     AD_LOG_WARN << "The original metadata has not been set, but updates are "
                    "being performed. This should only happen in unit tests\n";
-    augmentedMetadata_.emplace();
-  } else {
-    augmentedMetadata_ = *originalMetadata_.value();
   }
-  for (auto& blockMetadata : augmentedMetadata_.value()) {
-    if (auto blockUpdates = getUpdatesIfPresent(blockIndex)) {
-      blockMetadata.firstTriple_ =
-          std::min(blockMetadata.firstTriple_,
-                   blockUpdates->front().triple_.toPermutedTriple());
-      blockMetadata.lastTriple_ =
-          std::max(blockMetadata.lastTriple_,
-                   blockUpdates->back().triple_.toPermutedTriple());
-      updateGraphMetadata(blockMetadata, *blockUpdates);
-    }
-    blockIndex++;
+  const auto& originalMetadata = originalMetadata_.has_value()
+                                     ? *originalMetadata_.value()
+                                     : emptyMetadata;
+
+  std::vector<CompressedBlockMetadata> augmentedMetadata;
+  augmentedMetadata.reserve(originalMetadata.size() + 1);
+  // TODO<C++23> use `ql::views::enumerate`.
+  size_t blockIndex = 0;
+  for (const auto& blockMetadata : originalMetadata) {
+    appendAugmentedMetadataForBlock(augmentedMetadata, blockMetadata,
+                                    blockIndex);
+    ++blockIndex;
   }
   // Also account for the last block that contains the triples that are larger
-  // than all the inserted triples.
-  if (auto blockUpdates = getUpdatesIfPresent(blockIndex)) {
-    auto firstTriple = blockUpdates->front().triple_.toPermutedTriple();
-    auto lastTriple = blockUpdates->back().triple_.toPermutedTriple();
-
+  // than all the triples in the index.
+  size_t lastBlockIndex = originalMetadata.size();
+  if (containsTriples(lastBlockIndex)) {
     // The first `std::nullopt` means that this block contains only
-    // `LocatedTriple`s.
+    // `LocatedTriple`s, so it has no rows in the file. Its first and last
+    // triple are initialized to the largest and smallest possible triple
+    // respectively, such that computing the minimum and maximum with the update
+    // triples (in `appendAugmentedMetadataForBlock`) yields exactly the bounds
+    // of the update triples.
+    using PermutedTriple = CompressedBlockMetadata::PermutedTriple;
+    PermutedTriple maxTriple{Id::max(), Id::max(), Id::max(), Id::max()};
+    PermutedTriple minTriple{Id::min(), Id::min(), Id::min(), Id::min()};
     CompressedBlockMetadataNoBlockIndex lastBlockN{
-        std::nullopt, 0, firstTriple, lastTriple, std::nullopt, true};
+        std::nullopt, 0, maxTriple, minTriple, std::nullopt, true};
     lastBlockN.graphInfo_.emplace();
-    CompressedBlockMetadata lastBlock{lastBlockN, blockIndex};
-    updateGraphMetadata(lastBlock, *blockUpdates);
-    augmentedMetadata_->push_back(lastBlock);
-
-    AD_CORRECTNESS_CHECK(
-        CompressedBlockMetadata::checkInvariantsForSortedBlocks(
-            *augmentedMetadata_));
+    appendAugmentedMetadataForBlock(
+        augmentedMetadata, CompressedBlockMetadata{lastBlockN, lastBlockIndex},
+        lastBlockIndex);
   }
+  AD_CORRECTNESS_CHECK(CompressedBlockMetadata::checkInvariantsForSortedBlocks(
+      augmentedMetadata));
+  augmentedMetadata_ = std::move(augmentedMetadata);
 }
 
 // ____________________________________________________________________________

--- a/src/index/LocatedTriples.h
+++ b/src/index/LocatedTriples.h
@@ -112,6 +112,32 @@ using SortedLocatedTriplesVector = ad_utility::SortedSequence<
 
 using LocatedTriples = SortedLocatedTriplesVector;
 
+// Compare the triple of a `LocatedTriple` with one of the bounds of a partial
+// block (see `CompressedBlockMetadata::PartialBlockInfo`), ignoring the graph.
+// Ignoring the graph is important, because triples that only differ in their
+// graph must never be split across two blocks.
+// NOTE: All four combinations of the argument types are required, because the
+// standard algorithms require the comparison to be a strict weak order on the
+// union of the compared types.
+struct CompareTripleWithBlockBoundIgnoringGraph {
+  using PermutedTriple = CompressedBlockMetadata::PermutedTriple;
+  // Note: We deliberately return the IDs by value (and not, for example, via
+  // `PermutedTriple::tieWithoutGraph`), because the `IdTriple` overload would
+  // otherwise return references into a temporary.
+  static std::array<Id, 3> idsWithoutGraph(const IdTriple<0>& triple) {
+    return {triple.ids()[0], triple.ids()[1], triple.ids()[2]};
+  }
+  static std::array<Id, 3> idsWithoutGraph(const PermutedTriple& triple) {
+    return {triple.col0Id_, triple.col1Id_, triple.col2Id_};
+  }
+  CPP_template(typename T, typename U)(
+      requires ad_utility::SimilarToAny<T, IdTriple<0>, PermutedTriple> CPP_and
+          ad_utility::SimilarToAny<U, IdTriple<0>, PermutedTriple>) bool
+  operator()(const T& a, const U& b) const {
+    return idsWithoutGraph(a) < idsWithoutGraph(b);
+  }
+};
+
 // Sorted sets of located triples, grouped by block. We use this to store all
 // located triples for a permutation.
 class LocatedTriplesPerBlock {
@@ -125,7 +151,16 @@ class LocatedTriplesPerBlock {
   // Implementation of the `mergeTriples` function (which has `numIndexColumns`
   // as a normal argument, and translates it into a template argument).
   template <size_t numIndexColumns, bool includeGraphColumn>
-  IdTable mergeTriplesImpl(size_t blockIndex, const IdTable& block) const;
+  IdTable mergeTriplesImpl(const CompressedBlockMetadata& blockMetadata,
+                           const IdTable& block) const;
+
+  // Append the augmented metadata for the single block `blockMetadata`, which
+  // is the block with the index `blockIndex`, to the `result`. If the block is
+  // large (because many update triples fall into it), then it is split into
+  // several parts, see the documentation of `updateAugmentedMetadata` below.
+  void appendAugmentedMetadataForBlock(
+      std::vector<CompressedBlockMetadata>& result,
+      CompressedBlockMetadata blockMetadata, size_t blockIndex) const;
 
   // Stores the block metadata where the block borders have been adjusted for
   // the updated triples.
@@ -134,6 +169,23 @@ class LocatedTriplesPerBlock {
       originalMetadata_;
 
  public:
+  // Recompute the block metadata that is augmented for the update triples, see
+  // `getAugmentedMetadata` below. Must be called after the update triples have
+  // been modified (and consolidated), otherwise the augmented metadata is
+  // stale.
+  //
+  // A block into which many update triples fall is split into several parts,
+  // such that a scan does not have to merge all the update triples of that
+  // block even if it only touches a small part of it. All parts of a block
+  // share the same `blockIndex_` (which is the index of the block in the
+  // original metadata, and which is how the update triples of a block are
+  // found), and the key range that each part covers is delimited by the bounds
+  // in its `CompressedBlockMetadata::PartialBlockInfo`. In particular, several
+  // parts may share the same on-disk block, which is then read once per part,
+  // but each of its rows belongs to exactly one part. Parts that provably
+  // contain no rows of the on-disk block (for example all parts of the very
+  // last block, which consists of update triples only) are not read from disk
+  // at all.
   void updateAugmentedMetadata();
 
  public:
@@ -154,10 +206,28 @@ class LocatedTriplesPerBlock {
   // know whether an insertion or deletion is actually effective.
   NumAddedAndDeleted numTriples(size_t blockIndex) const;
 
+  // Same as above, but only count the located triples that belong to the part
+  // of the block that is described by `blockMetadata` (which is only relevant
+  // if that block is partial, see `CompressedBlockMetadata::PartialBlockInfo`).
+  NumAddedAndDeleted numTriples(
+      const CompressedBlockMetadata& blockMetadata) const;
+
   // Returns an optional reference to update triples for the block with the
   // index `blockIndex`. If no such block exists, return `std::nullopt`.
   boost::optional<const LocatedTriples&> getUpdatesIfPresent(
       size_t blockIndex) const;
+
+  // Return a view of those update triples of the block described by
+  // `blockMetadata` that belong to the part of that block that `blockMetadata`
+  // describes (which is all of them if that block is not partial, see
+  // `CompressedBlockMetadata::PartialBlockInfo`). The block must have update
+  // triples, that is, `containsTriples(blockMetadata)` must be `true`.
+  auto getUpdatesForBlock(const CompressedBlockMetadata& blockMetadata) const {
+    return map_.at(blockMetadata.blockIndex_)
+        .getSortedViewInRange(blockMetadata.inclusiveLowerBound(),
+                              blockMetadata.exclusiveUpperBound(),
+                              CompareTripleWithBlockBoundIgnoringGraph{});
+  }
 
   // Merge located triples for `blockIndex_` (there must be at least one,
   // otherwise this function must not be called) with the given input `block`.
@@ -178,13 +248,24 @@ class LocatedTriplesPerBlock {
   // and that `block` has block has two additional payload columns X and Y.
   // Then the result has five columns (like the input `block`), and each merged
   // located triple will have values for OSG and UNDEF for X and Y.
-  IdTable mergeTriples(size_t blockIndex, const IdTable& block,
-                       size_t numIndexColumns, bool includeGraphColumn) const;
+  IdTable mergeTriples(const CompressedBlockMetadata& blockMetadata,
+                       const IdTable& block, size_t numIndexColumns,
+                       bool includeGraphColumn) const;
 
   // Return true iff there are located triples in the block with the given
   // index.
   bool containsTriples(size_t blockIndex) const {
     return map_.contains(blockIndex);
+  }
+
+  // Same as above, but only consider the located triples that belong to the
+  // part of the block that is described by `blockMetadata` (which is only
+  // relevant if that block is partial, see
+  // `CompressedBlockMetadata::PartialBlockInfo`).
+  bool containsTriples(const CompressedBlockMetadata& blockMetadata) const {
+    return containsTriples(blockMetadata.blockIndex_) &&
+           (!blockMetadata.isPartial() ||
+            !ql::ranges::empty(getUpdatesForBlock(blockMetadata)));
   }
 
   // Add unsorted `locatedTriples` to the `LocatedTriplesPerBlock`.

--- a/src/util/SortedSequence.h
+++ b/src/util/SortedSequence.h
@@ -14,6 +14,7 @@
 
 #include <functional>
 #include <iterator>
+#include <optional>
 #include <vector>
 
 #include "backports/algorithm.h"
@@ -201,6 +202,24 @@ class SortedSequence {
                               self.comp_, self.proj_);
   }
 
+  // Restrict the `part` (which must be one of the two sorted parts) to the
+  // elements whose projected key lies in the half-open range `[lower, upper)`
+  // w.r.t. the given `comparator`. A bound that is `nullopt` means that the
+  // range is unbounded in that direction.
+  template <typename Range, typename Bound, typename Comparator>
+  auto restrictPartToRange(Range part, const std::optional<Bound>& lower,
+                           const std::optional<Bound>& upper,
+                           const Comparator& comparator) const {
+    auto begin = lower.has_value() ? ql::ranges::lower_bound(
+                                         part, lower.value(), comparator, proj_)
+                                   : ql::ranges::begin(part);
+    auto end = upper.has_value()
+                   ? ql::ranges::lower_bound(begin, ql::ranges::end(part),
+                                             upper.value(), comparator, proj_)
+                   : ql::ranges::end(part);
+    return ql::ranges::subrange(begin, end);
+  }
+
  public:
   // Return a view of the sorted and deduplicated elements in this container.
   // Requires `isConsolidated` to be true.
@@ -208,6 +227,38 @@ class SortedSequence {
   auto getSortedView() const& { return getSortedViewImpl(*this); }
   void getSortedView() && = delete;
   void getSortedView() const&& = delete;
+
+  // Like `getSortedView`, but only return the elements whose projected key lies
+  // in the half-open range `[lower, upper)`. A bound that is `nullopt` means
+  // that the range is unbounded in that direction. The bounds are compared to
+  // the projected keys using the `comparator`, which must be compatible with
+  // the order of this sequence (that is, this sequence must also be sorted with
+  // respect to the `comparator`). Requires `isConsolidated` to be true.
+  template <typename Bound, typename Comparator>
+  auto getSortedViewInRange(const std::optional<Bound>& lower,
+                            const std::optional<Bound>& upper,
+                            const Comparator& comparator) const {
+    AD_CONTRACT_CHECK(isConsolidated());
+    return ZipMergeUniqueView(
+        restrictPartToRange(largePart(), lower, upper, comparator),
+        restrictPartToRange(smallPart(), lower, upper, comparator), comp_,
+        proj_);
+  }
+
+  // Return an upper bound for the number of elements whose projected key lies
+  // in the half-open range `[lower, upper)`. For the meaning of the arguments
+  // and the reason why this is only an upper bound, see `getSortedViewInRange`
+  // and `sizeUpperBound`. Requires `isConsolidated` to be true.
+  template <typename Bound, typename Comparator>
+  size_t sizeUpperBoundInRange(const std::optional<Bound>& lower,
+                               const std::optional<Bound>& upper,
+                               const Comparator& comparator) const {
+    AD_CONTRACT_CHECK(isConsolidated());
+    return ql::ranges::size(
+               restrictPartToRange(largePart(), lower, upper, comparator)) +
+           ql::ranges::size(
+               restrictPartToRange(smallPart(), lower, upper, comparator));
+  }
 
  private:
   // Return the extreme (maximal if `wantMax`, else minimal) element w.r.t.

--- a/test/CompressedRelationsTest.cpp
+++ b/test/CompressedRelationsTest.cpp
@@ -150,7 +150,10 @@ compressedRelationTestWriteCompressedRelations(
   }));
 
   addGraphColumnIfNecessary(inputs);
-  size_t numColumns = getNumColumns(inputs) + 1;
+  // Note: For empty `inputs` the number of columns cannot be deduced, so we use
+  // the minimal number of columns (the three columns of a triple plus the graph
+  // column).
+  size_t numColumns = inputs.empty() ? 4 : getNumColumns(inputs) + 1;
   AD_CORRECTNESS_CHECK(numColumns >= 4);
   auto generator =
       [&](size_t sorterBlockSize) -> cppcoro::generator<IdTableStatic<0>> {
@@ -426,9 +429,20 @@ void testCompressedRelations(const Inputs& inputsOriginalBeforeCopy,
 // to find subtle rounding bugs when creating the blocks.
 void testWithDifferentBlockSizes(const std::vector<RelationInput>& inputs,
                                  float locatedTriplesProbability = 0.5) {
-  testCompressedRelations(inputs, 19_B, locatedTriplesProbability);
-  testCompressedRelations(inputs, 237_B, locatedTriplesProbability);
-  testCompressedRelations(inputs, 4096_B, locatedTriplesProbability);
+  auto testAllBlockSizes = [&inputs, locatedTriplesProbability]() {
+    testCompressedRelations(inputs, 19_B, locatedTriplesProbability);
+    testCompressedRelations(inputs, 237_B, locatedTriplesProbability);
+    testCompressedRelations(inputs, 4096_B, locatedTriplesProbability);
+  };
+  testAllBlockSizes();
+  // Repeat the tests with very small values for the maximal size of a block
+  // with updates, such that the blocks that contain update triples are split
+  // into several parts. The results must be exactly the same.
+  for (size_t maxBlockSizeWithUpdates : {1, 2, 7}) {
+    auto cleanup = setRuntimeParameterForTest<
+        &RuntimeParameters::maxBlockSizeWithUpdates_>(maxBlockSizeWithUpdates);
+    testAllBlockSizes();
+  }
 }
 }  // namespace
 
@@ -440,6 +454,20 @@ TEST(CompressedRelationWriter, SmallRelations) {
         RelationInput{i, {{i - 1, i + 1}, {i - 1, i + 2}, {i, i - 1}}});
   }
   testWithDifferentBlockSizes(inputs);
+}
+
+// Test the case that all the triples are update triples, that is, the
+// permutation on disk is completely empty. This is the important case of a user
+// who builds an index from an empty input and then inserts triples: all of
+// those triples end up in the same (artificial last) block, which then has to
+// be split.
+TEST(CompressedRelationWriter, OnlyUpdateTriples) {
+  std::vector<RelationInput> inputs;
+  for (int i = 1; i < 100; ++i) {
+    inputs.push_back(
+        RelationInput{i, {{i - 1, i + 1}, {i - 1, i + 2}, {i, i - 1}}});
+  }
+  testWithDifferentBlockSizes(inputs, 1.0);
 }
 
 // Internal matchers for the following two tests.

--- a/test/LocatedTriplesTest.cpp
+++ b/test/LocatedTriplesTest.cpp
@@ -46,6 +46,14 @@ auto CBM = [](const auto firstTriple, const auto lastTriple,
       dummyBlockIndex};
 };
 
+// A dummy block metadata for the block with the given index, which is not
+// partial. Only the `blockIndex_` is relevant for the functions that take a
+// block metadata to look up the update triples of that block.
+auto blockMetadataWithIndex = [](size_t blockIndex) {
+  return CompressedBlockMetadata{
+      {{}, 0, PT(0, 0, 0), PT(0, 0, 0), std::nullopt, false}, blockIndex};
+};
+
 auto numBlocks =
     [](size_t numBlocks) -> testing::Matcher<const LocatedTriplesPerBlock&> {
   return AD_PROPERTY(LocatedTriplesPerBlock, LocatedTriplesPerBlock::numBlocks,
@@ -260,14 +268,16 @@ TEST_F(LocatedTriplesTest, mergeTriples) {
         {4, 10, 10}   // LT 7
     });
 
-    auto merged = locatedTriplesPerBlock.mergeTriples(1, block, 3, false);
+    auto merged = locatedTriplesPerBlock.mergeTriples(blockMetadataWithIndex(1),
+                                                      block, 3, false);
     EXPECT_THAT(merged, testing::ElementsAreArray(resultExpected));
 
     // Run the same test with a constant graph column that is part of the
     // result.
     addGraphColumn(block);
     addGraphColumn(resultExpected);
-    merged = locatedTriplesPerBlock.mergeTriples(1, block, 3, true);
+    merged = locatedTriplesPerBlock.mergeTriples(blockMetadataWithIndex(1),
+                                                 block, 3, true);
     EXPECT_THAT(merged, testing::ElementsAreArray(resultExpected));
   }
 
@@ -302,14 +312,16 @@ TEST_F(LocatedTriplesTest, mergeTriples) {
         {30, 10}   // LT 5
     });
 
-    auto merged = locatedTriplesPerBlock.mergeTriples(1, block, 2, false);
+    auto merged = locatedTriplesPerBlock.mergeTriples(blockMetadataWithIndex(1),
+                                                      block, 2, false);
     EXPECT_THAT(merged, testing::ElementsAreArray(resultExpected));
 
     // Run the same test with a constant graph column that is part of the
     // result.
     addGraphColumn(block);
     addGraphColumn(resultExpected);
-    merged = locatedTriplesPerBlock.mergeTriples(1, block, 2, true);
+    merged = locatedTriplesPerBlock.mergeTriples(blockMetadataWithIndex(1),
+                                                 block, 2, true);
     EXPECT_THAT(merged, testing::ElementsAreArray(resultExpected));
   }
 
@@ -336,14 +348,16 @@ TEST_F(LocatedTriplesTest, mergeTriples) {
         {30}   // orig. Row 5
     });
 
-    auto merged = locatedTriplesPerBlock.mergeTriples(1, block, 1, false);
+    auto merged = locatedTriplesPerBlock.mergeTriples(blockMetadataWithIndex(1),
+                                                      block, 1, false);
     EXPECT_THAT(merged, testing::ElementsAreArray(resultExpected));
 
     // Run the same test with a constant graph column that is part of the
     // result.
     addGraphColumn(block);
     addGraphColumn(resultExpected);
-    merged = locatedTriplesPerBlock.mergeTriples(1, block, 1, true);
+    merged = locatedTriplesPerBlock.mergeTriples(blockMetadataWithIndex(1),
+                                                 block, 1, true);
     EXPECT_THAT(merged, testing::ElementsAreArray(resultExpected));
   }
 
@@ -354,14 +368,16 @@ TEST_F(LocatedTriplesTest, mergeTriples) {
         makeLocatedTriplesPerBlock({LT{1, IT(1, 3, 5), true}});
     IdTable resultExpected = block.clone();
 
-    auto merged = locatedTriplesPerBlock.mergeTriples(1, block, 3, false);
+    auto merged = locatedTriplesPerBlock.mergeTriples(blockMetadataWithIndex(1),
+                                                      block, 3, false);
     EXPECT_THAT(merged, testing::ElementsAreArray(resultExpected));
 
     // Run the same test with a constant graph column that is part of the
     // result.
     addGraphColumn(block);
     addGraphColumn(resultExpected);
-    merged = locatedTriplesPerBlock.mergeTriples(1, block, 3, true);
+    merged = locatedTriplesPerBlock.mergeTriples(blockMetadataWithIndex(1),
+                                                 block, 3, true);
     EXPECT_THAT(merged, testing::ElementsAreArray(resultExpected));
   }
 
@@ -373,14 +389,16 @@ TEST_F(LocatedTriplesTest, mergeTriples) {
          LT{1, IT(1, 3, 5), false}});
     IdTable resultExpected = makeIdTableFromVector({{1, 2, 3}, {1, 7, 9}});
 
-    auto merged = locatedTriplesPerBlock.mergeTriples(1, block, 3, false);
+    auto merged = locatedTriplesPerBlock.mergeTriples(blockMetadataWithIndex(1),
+                                                      block, 3, false);
     EXPECT_THAT(merged, testing::ElementsAreArray(resultExpected));
 
     // Run the same test with a constant graph column that is part of the
     // result.
     addGraphColumn(block);
     addGraphColumn(resultExpected);
-    merged = locatedTriplesPerBlock.mergeTriples(1, block, 3, true);
+    merged = locatedTriplesPerBlock.mergeTriples(blockMetadataWithIndex(1),
+                                                 block, 3, true);
     EXPECT_THAT(merged, testing::ElementsAreArray(resultExpected));
   }
 
@@ -399,7 +417,8 @@ TEST_F(LocatedTriplesTest, mergeTriples) {
                                {1, 3, 6, UndefId(), UndefId()},
                                {1, 7, 9, IntId(13), IntId(14)}});
 
-    auto merged = locatedTriplesPerBlock.mergeTriples(1, block, 3, false);
+    auto merged = locatedTriplesPerBlock.mergeTriples(blockMetadataWithIndex(1),
+                                                      block, 3, false);
     EXPECT_THAT(merged, testing::ElementsAreArray(resultExpected));
 
     // Run the same test with a constant graph column that is part of the
@@ -409,7 +428,8 @@ TEST_F(LocatedTriplesTest, mergeTriples) {
     block.setColumnSubset(std::array<ColumnIndex, 6>{0u, 1u, 2u, 5u, 3u, 4u});
     resultExpected.setColumnSubset(
         std::array<ColumnIndex, 6>{0u, 1u, 2u, 5u, 3u, 4u});
-    merged = locatedTriplesPerBlock.mergeTriples(1, block, 3, true);
+    merged = locatedTriplesPerBlock.mergeTriples(blockMetadataWithIndex(1),
+                                                 block, 3, true);
     EXPECT_THAT(merged, testing::ElementsAreArray(resultExpected));
   }
 
@@ -434,7 +454,8 @@ TEST_F(LocatedTriplesTest, mergeTriples) {
         LT{1, IT(4, 10, 10), true},   // Insert after row 5
     });
 
-    EXPECT_THROW(locatedTriplesPerBlock.mergeTriples(2, block, 3, false),
+    EXPECT_THROW(locatedTriplesPerBlock.mergeTriples(blockMetadataWithIndex(2),
+                                                     block, 3, false),
                  ad_utility::Exception);
   }
 
@@ -460,7 +481,8 @@ TEST_F(LocatedTriplesTest, mergeTriples) {
         LT{1, IT(3, 30, 30), false},  // Delete row 5
         LT{1, IT(4, 10, 10), true},   // Insert after row 5
     });
-    EXPECT_THROW(locatedTriplesPerBlock.mergeTriples(1, block, 3, false),
+    EXPECT_THROW(locatedTriplesPerBlock.mergeTriples(blockMetadataWithIndex(1),
+                                                     block, 3, false),
                  ad_utility::Exception);
   }
 
@@ -485,7 +507,8 @@ TEST_F(LocatedTriplesTest, mergeTriples) {
         LT{1, IT(3, 30, 30), false},  // Delete row 5
         LT{1, IT(4, 10, 10), true},   // Insert after row 5
     });
-    EXPECT_THROW(locatedTriplesPerBlock.mergeTriples(1, block, 4, false),
+    EXPECT_THROW(locatedTriplesPerBlock.mergeTriples(blockMetadataWithIndex(1),
+                                                     block, 4, false),
                  ad_utility::Exception);
   }
 
@@ -503,7 +526,8 @@ TEST_F(LocatedTriplesTest, mergeTriples) {
         LT{1, IT(1, 5, 10), true},   // Insert before row 0
         LT{1, IT(2, 11, 10), true},  // Insert before row 1
     });
-    EXPECT_THROW(locatedTriplesPerBlock.mergeTriples(1, block, 0, false),
+    EXPECT_THROW(locatedTriplesPerBlock.mergeTriples(blockMetadataWithIndex(1),
+                                                     block, 0, false),
                  ad_utility::Exception);
   }
 }
@@ -542,7 +566,8 @@ TEST_F(LocatedTriplesTest, mergeTriplesWithGraph) {
         {3, 30, 30, 0}   // Row 6
     });
 
-    auto merged = locatedTriplesPerBlock.mergeTriples(1, block, 3, true);
+    auto merged = locatedTriplesPerBlock.mergeTriples(blockMetadataWithIndex(1),
+                                                      block, 3, true);
     EXPECT_THAT(merged, testing::ElementsAreArray(resultExpected));
   }
 
@@ -569,7 +594,8 @@ TEST_F(LocatedTriplesTest, mergeTriplesWithGraph) {
                                                     {15, 30, 1},    // Row 2
                                                     {20, 10, 2}});  // Row 3
 
-    auto merged = locatedTriplesPerBlock.mergeTriples(1, block, 2, true);
+    auto merged = locatedTriplesPerBlock.mergeTriples(blockMetadataWithIndex(1),
+                                                      block, 2, true);
     EXPECT_THAT(merged, testing::ElementsAreArray(resultExpected));
   }
 
@@ -592,7 +618,8 @@ TEST_F(LocatedTriplesTest, mergeTriplesWithGraph) {
         {20, 0}   // Row 3
     });
 
-    auto merged = locatedTriplesPerBlock.mergeTriples(1, block, 1, true);
+    auto merged = locatedTriplesPerBlock.mergeTriples(blockMetadataWithIndex(1),
+                                                      block, 1, true);
     EXPECT_THAT(merged, testing::ElementsAreArray(resultExpected));
   }
 
@@ -611,7 +638,8 @@ TEST_F(LocatedTriplesTest, mergeTriplesWithGraph) {
                                {1, 2, 3, 1, UndefId(), UndefId()},
                                {1, 2, 3, 2, IntId(12), IntId(11)}});
 
-    auto merged = locatedTriplesPerBlock.mergeTriples(1, block, 3, true);
+    auto merged = locatedTriplesPerBlock.mergeTriples(blockMetadataWithIndex(1),
+                                                      block, 3, true);
     EXPECT_THAT(merged, testing::ElementsAreArray(resultExpected));
   }
 }
@@ -829,6 +857,121 @@ TEST_F(LocatedTriplesTest, augmentedMetadata) {
   {
     LocatedTriplesPerBlock ltpb;
     EXPECT_THROW(ltpb.getAugmentedMetadata(), ad_utility::Exception);
+  }
+}
+
+// _____________________________________________________________________________
+TEST_F(LocatedTriplesTest, augmentedMetadataWithSplitBlocks) {
+  using B = CompressedBlockMetadata;
+  using LT = LocatedTriple;
+  // A bound between two parts of a block; its graph is the smallest possible ID
+  // (see `LocatedTriples.cpp`).
+  auto boundPT = [](const auto& c1, const auto& c2, const auto& c3) {
+    return B::PermutedTriple{V(c1), V(c2), V(c3), Id::min()};
+  };
+  // Matcher for a single part of a block.
+  auto isPart = [](B::PermutedTriple firstTriple, B::PermutedTriple lastTriple,
+                   size_t numRowsEstimate, bool hasLowerBound,
+                   bool hasUpperBound) -> testing::Matcher<const B&> {
+    auto hasValue = [](auto getter, bool expected) {
+      return testing::ResultOf(
+          [getter](const B& block) {
+            return std::invoke(getter, block).has_value();
+          },
+          testing::Eq(expected));
+    };
+    return testing::AllOf(
+        AD_FIELD(B, firstTriple_, testing::Eq(firstTriple)),
+        AD_FIELD(B, lastTriple_, testing::Eq(lastTriple)),
+        AD_PROPERTY(B, isPartial, testing::IsTrue()),
+        AD_PROPERTY(B, numRowsEstimate, testing::Eq(numRowsEstimate)),
+        hasValue(&B::inclusiveLowerBound, hasLowerBound),
+        hasValue(&B::exclusiveUpperBound, hasUpperBound));
+  };
+  // Split blocks as soon as they have more than two rows (rows in the file plus
+  // update triples).
+  auto cleanup =
+      setRuntimeParameterForTest<&RuntimeParameters::maxBlockSizeWithUpdates_>(
+          2);
+
+  // A block that has four rows in the file (from `(1, 1, 1)` to `(1, 1, 7)`),
+  // and three update triples, one of which lies before all the rows in the
+  // file.
+  {
+    std::vector<CompressedBlockMetadata::OffsetAndCompressedSize> offsets{
+        {0, 17}};
+    std::vector<CompressedBlockMetadata> metadata{CompressedBlockMetadata{
+        {offsets, 4, PT(1, 1, 1), PT(1, 1, 7), std::nullopt, false}, 0}};
+    auto ltpb = makeLocatedTriplesPerBlock({LT{0, IT(1, 1, 0), true},
+                                            LT{0, IT(1, 1, 3), true},
+                                            LT{0, IT(1, 1, 5), false}});
+    ltpb.setOriginalMetadata(metadata);
+    ltpb.updateAugmentedMetadata();
+
+    // The block is split into one part per update triple. The rows in the file
+    // are distributed evenly over the parts (which is only an estimate; all
+    // four of them might as well lie in a single part).
+    EXPECT_THAT(ltpb.getAugmentedMetadata(),
+                testing::ElementsAre(
+                    isPart(PT(1, 1, 0), boundPT(1, 1, 3), 2, false, true),
+                    isPart(boundPT(1, 1, 3), boundPT(1, 1, 5), 2, true, true),
+                    isPart(boundPT(1, 1, 5), PT(1, 1, 7), 2, true, false)));
+    // Each of the parts sees exactly its own update triple.
+    for (const auto& part : ltpb.getAugmentedMetadata()) {
+      EXPECT_TRUE(ltpb.containsTriples(part));
+      EXPECT_EQ(ltpb.numTriples(part), (NumAddedAndDeleted{1, 1}));
+    }
+  }
+
+  // A block that consists of update triples only (this is the case for the
+  // artificial last block, and in particular for all updates if the index was
+  // empty when it was built). Such parts are never read from disk.
+  {
+    LocatedTriplesPerBlock ltpb = makeLocatedTriplesPerBlock(
+        {LT{0, IT(1, 1, 1), true}, LT{0, IT(1, 1, 2), true},
+         LT{0, IT(2, 2, 2), true}, LT{0, IT(3, 3, 3), false}});
+    ltpb.setOriginalMetadata(std::vector<CompressedBlockMetadata>{});
+    ltpb.updateAugmentedMetadata();
+
+    EXPECT_THAT(ltpb.getAugmentedMetadata(),
+                testing::ElementsAre(
+                    isPart(PT(1, 1, 1), boundPT(2, 2, 2), 0, false, true),
+                    isPart(boundPT(2, 2, 2), PT(3, 3, 3), 0, true, false)));
+    EXPECT_THAT(ltpb.getAugmentedMetadata(),
+                testing::Each(AD_FIELD(B, offsetsAndCompressedSize_,
+                                       testing::Eq(std::nullopt))));
+    const auto& parts = ltpb.getAugmentedMetadata();
+    EXPECT_EQ(ltpb.numTriples(parts.at(0)), (NumAddedAndDeleted{2, 2}));
+    EXPECT_EQ(ltpb.numTriples(parts.at(1)), (NumAddedAndDeleted{2, 2}));
+  }
+
+  // Update triples that are all equal when ignoring the graph must not be
+  // split, because they have to stay in the same block.
+  {
+    LocatedTriplesPerBlock ltpb = makeLocatedTriplesPerBlock(
+        {LT{0, IT(1, 1, 1, 10), true}, LT{0, IT(1, 1, 1, 11), true},
+         LT{0, IT(1, 1, 1, 12), true}});
+    ltpb.setOriginalMetadata(std::vector<CompressedBlockMetadata>{});
+    ltpb.updateAugmentedMetadata();
+
+    EXPECT_THAT(
+        ltpb.getAugmentedMetadata(),
+        testing::ElementsAre(AD_PROPERTY(B, isPartial, testing::IsFalse())));
+  }
+
+  // If the splitting is disabled, then large blocks stay unsplit.
+  {
+    auto cleanupInner = setRuntimeParameterForTest<
+        &RuntimeParameters::maxBlockSizeWithUpdates_>(0);
+    LocatedTriplesPerBlock ltpb = makeLocatedTriplesPerBlock(
+        {LT{0, IT(1, 1, 1), true}, LT{0, IT(2, 2, 2), true},
+         LT{0, IT(3, 3, 3), true}});
+    ltpb.setOriginalMetadata(std::vector<CompressedBlockMetadata>{});
+    ltpb.updateAugmentedMetadata();
+
+    EXPECT_THAT(
+        ltpb.getAugmentedMetadata(),
+        testing::ElementsAre(AD_PROPERTY(B, isPartial, testing::IsFalse())));
   }
 }
 

--- a/test/engine/IndexScanTest.cpp
+++ b/test/engine/IndexScanTest.cpp
@@ -15,13 +15,16 @@
 #include "../util/GTestHelpers.h"
 #include "../util/IdTableHelpers.h"
 #include "../util/IndexTestHelpers.h"
+#include "../util/RuntimeParametersTestHelpers.h"
 #include "../util/TripleComponentTestHelpers.h"
 #include "./LazyJoinTestHelpers.h"
 #include "engine/IndexScan.h"
 #include "engine/MaterializedViews.h"
 #include "engine/NamedResultCache.h"
+#include "engine/QueryPlanner.h"
 #include "index/IndexImpl.h"
 #include "parser/ParsedQuery.h"
+#include "parser/SparqlParser.h"
 
 using namespace ad_utility::testing;
 using namespace std::chrono_literals;
@@ -623,6 +626,117 @@ TEST(IndexScan, getResultSizeOfScanWithDeltaTriples) {
     auto scan = makeScan();
     EXPECT_EQ(scan.getSizeEstimate(), 3);
     EXPECT_FALSE(scan.sizeEstimateIsExactForTesting());
+  }
+}
+
+// _____________________________________________________________________________
+// Check that the results of scans and joins do not depend on whether the blocks
+// that contain the delta triples are split into several parts, see
+// `LocatedTriplesPerBlock::updateAugmentedMetadata`.
+TEST(IndexScan, resultsDontDependOnSplittingOfBlocksWithUpdates) {
+  std::string turtle;
+  for (size_t i = 0; i < 5; ++i) {
+    absl::StrAppend(&turtle, "<s", i, "> <p> <s", i, "> . ");
+  }
+  auto index = std::make_shared<Index>(
+      makeTestIndex("resultsDontDependOnSplittingOfBlocksWithUpdates", turtle));
+  auto getId = makeGetId(*index);
+  auto graph = qlever::specialIds().at(QLEVER_INTERNAL_GRAPH_IRI);
+  auto predicate = getId("<p>");
+
+  // Insert all combinations `<si> <p> <sj>`, most of which are not yet
+  // contained in the index. All of them are located in very few blocks.
+  std::vector<IdTriple<0>> triples;
+  for (size_t i = 0; i < 5; ++i) {
+    for (size_t j = 0; j < 5; ++j) {
+      triples.push_back(
+          IdTriple<0>{std::array{getId(absl::StrCat("<s", i, ">")), predicate,
+                                 getId(absl::StrCat("<s", j, ">")), graph}});
+    }
+  }
+  ql::ranges::sort(triples);
+  index->deltaTriplesManager().modify<void>([&](DeltaTriples& deltaTriples) {
+    deltaTriples.insertTriples(
+        std::make_shared<ad_utility::CancellationHandle<>>(), triples);
+  });
+
+  // Run a scan of the complete permutation, as well as a join of two scans, and
+  // return their results as vectors of rows, together with the number of blocks
+  // of the augmented metadata. Note: The rows are extracted via the variables,
+  // such that the comparison of the results does not depend on the chosen query
+  // plan.
+  using Rows = std::vector<std::array<Id, 3>>;
+  auto runQueries = [&index]() {
+    // The blocks are split when the augmented metadata is computed, which
+    // happens at the end of each modification of the delta triples. We thus
+    // have to trigger a recomputation after the runtime parameter has been
+    // changed.
+    index->deltaTriplesManager().modify<void>([](DeltaTriples&) {});
+    size_t numAugmentedBlocks =
+        index->deltaTriplesManager()
+            .getCurrentLocatedTriplesSharedState()
+            ->getLocatedTriplesForPermutation<false>(Permutation::Enum::PSO)
+            .getAugmentedMetadata()
+            .size();
+    QueryResultCache cache;
+    NamedResultCache namedCache;
+    auto materializedViewsManager =
+        std::make_shared<MaterializedViewsManager>();
+    QueryExecutionContext qec{
+        index,
+        &cache,
+        makeAllocator(ad_utility::MemorySize::megabytes(100)),
+        SortPerformanceEstimator{},
+        &namedCache,
+        materializedViewsManager};
+    IndexScan scan{&qec, Permutation::Enum::PSO,
+                   SparqlTripleSimple{Var{"?x"}, Var{"?y"}, Var{"?z"}}};
+    auto scanResult = scan.computeResultOnlyForTesting();
+    EXPECT_EQ(scanResult.idTableView().numRows(), scan.getExactSize());
+    Rows scanRows;
+    for (const auto& row : scanResult.idTableView()) {
+      scanRows.push_back({row[0], row[1], row[2]});
+    }
+
+    auto cancellationHandle =
+        std::make_shared<ad_utility::CancellationHandle<>>();
+    QueryPlanner queryPlanner{&qec, cancellationHandle};
+    auto parsedQuery = SparqlParser::parseQuery(
+        &index->getImpl().encodedIriManager(),
+        "SELECT * WHERE { ?x <p> ?y . ?y <p> ?z } ORDER BY ?x ?y ?z");
+    auto queryExecutionTree = queryPlanner.createExecutionTree(parsedQuery);
+    auto joinResult = queryExecutionTree.getResult();
+    Rows joinRows;
+    auto column = [&queryExecutionTree](const std::string& variable) {
+      return queryExecutionTree.getVariableColumn(Var{variable});
+    };
+    for (const auto& row : joinResult->idTableView()) {
+      joinRows.push_back(
+          {row[column("?x")], row[column("?y")], row[column("?z")]});
+    }
+    return std::tuple{std::move(scanRows), std::move(joinRows),
+                      numAugmentedBlocks};
+  };
+
+  // The reference results, computed with the splitting disabled.
+  auto cleanup =
+      setRuntimeParameterForTest<&RuntimeParameters::maxBlockSizeWithUpdates_>(
+          0);
+  auto [expectedScanResult, expectedJoinResult, numBlocksWithoutSplitting] =
+      runQueries();
+  EXPECT_EQ(expectedScanResult.size(), 25);
+
+  for (size_t maxBlockSizeWithUpdates : {1, 2, 7}) {
+    auto trace = generateLocationTrace(
+        AD_CURRENT_SOURCE_LOC(),
+        absl::StrCat("maxBlockSizeWithUpdates = ", maxBlockSizeWithUpdates));
+    auto cleanupInner = setRuntimeParameterForTest<
+        &RuntimeParameters::maxBlockSizeWithUpdates_>(maxBlockSizeWithUpdates);
+    auto [scanResult, joinResult, numBlocks] = runQueries();
+    // The blocks with the update triples were actually split.
+    EXPECT_GT(numBlocks, numBlocksWithoutSplitting);
+    EXPECT_EQ(scanResult, expectedScanResult);
+    EXPECT_EQ(joinResult, expectedJoinResult);
   }
 }
 


### PR DESCRIPTION
Until now, the located triples of an update always had to be merged into the on-disk block that they belong to *as a whole*, no matter how selective a scan was. If many updates fall into the same block, every single scan of that block had to merge all of those updates. In the extreme case of an index that was built from an empty input, all updates end up in the same artificial last block, so even a lookup of a single triple was linear in the total number of inserted triples.

The augmented block metadata now splits such a block into several parts of at most `max-block-size-with-updates` rows (a new runtime parameter, default 64000, `0` disables the splitting).

### How it works

* The bounds at which a block is split are derived from the update triples alone, so no additional data has to be read from disk. They are advanced such that triples which are equal apart from their graph always stay in the same part.
* All parts of a block share the same `blockIndex_`, which is how the update triples of a block are found. The only place that required a unique `blockIndex_` was the block metadata order/uniqueness check, which now only requires it to be non-decreasing (the order is still strict w.r.t. `lastTriple_`). `getMetadataForSmallRelation` now counts the *distinct* `blockIndex_`es.
* Several parts may share the same on-disk block, which is then read once per part. Each row of that block belongs to exactly one part: for a partial block, the rows outside of its bounds are dropped after decompression. To be able to compare the rows with the bounds, a partial block additionally reads those leading columns of a triple that are fixed by the scan specification (they cannot be taken from the scan specification, because the on-disk block also holds the rows of the other parts, which may differ in those columns).
* Parts that provably contain none of the rows of the on-disk block are not read from disk at all. This is the case for all parts of the last block, and hence for all updates on an index that was built from an empty input.
* The bounds of a partial block are stored in its `firstTriple_` (inclusive) and `lastTriple_` (exclusive), so consecutive parts touch. The `numRows_` of a partial block still is the exact number of rows of the whole on-disk block (it is required to decompress that block); the new `numRowsEstimate()` is used for the size estimates instead.
* The first part of a block has no lower and the last part no upper bound, so the parts always tile the complete key range of the original block. Update triples that are added before the metadata is recomputed therefore still belong to exactly one part.

No change of the index format: the additional metadata is not serialized.

### Effect

Debug build, 200k triples inserted into an empty permutation, 20 selective scans:

| `max-block-size-with-updates` | augmented blocks | metadata update | 20 scans |
|---|---|---|---|
| 0 (off) | 2 | 19 ms | 3551 ms |
| 64000 (default) | 5 | 18 ms | 1778 ms |
| 8000 | 26 | 18 ms | 143 ms |
| 1000 | 201 | 19 ms | 38 ms |

The splitting has no measurable cost on the update path.

### Tests

* The existing `testCompressedRelations` battery (scans, lazy scans, LIMIT/OFFSET, exact sizes, small-relation metadata) now additionally runs with `max-block-size-with-updates` in `{1, 2, 7}`, so that the blocks with updates are split into many parts; the results have to be exactly the same.
* `CompressedRelationWriter.OnlyUpdateTriples`: the permutation on disk is empty and all triples are update triples.
* `LocatedTriplesTest.augmentedMetadataWithSplitBlocks`: the bounds, flags, row estimates and per-part update counts of the parts, including the cases that a block consists of update triples only, that all update triples are equal apart from their graph, and that the splitting is disabled.
* `IndexScan.resultsDontDependOnSplittingOfBlocksWithUpdates`: a scan and a join, executed through the query planner, must yield the same results with and without the splitting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)