### PR TITLE
Report the progress of each phase of a `rebuild-index`

### DIFF
--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -2208,9 +2208,7 @@ std::packaged_task<void()> computeStatistics(
     for (const auto& table : tables) {
       std::invoke(customAction, table);
       IndexImpl::countDistinct(lastCol0, counter, table);
-      if (progress) {
-        progress(table.numRows());
-      }
+      progress(table.numRows());
     }
   }};
 }

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -2181,9 +2181,10 @@ namespace {
 template <typename CustomAction>
 std::packaged_task<void()> computeStatistics(
     const LocatedTriplesSharedState& locatedTriplesSharedState, size_t& counter,
-    const Permutation& permutation, CustomAction customAction) {
+    const Permutation& permutation, CustomAction customAction,
+    const std::function<void(size_t)>& progress) {
   return std::packaged_task<void()>{[&counter, &permutation,
-                                     &locatedTriplesSharedState,
+                                     &locatedTriplesSharedState, progress,
                                      customAction = std::move(customAction)]() {
     auto cancellationHandle =
         std::make_shared<ad_utility::SharedCancellationHandle::element_type>();
@@ -2207,6 +2208,9 @@ std::packaged_task<void()> computeStatistics(
     for (const auto& table : tables) {
       std::invoke(customAction, table);
       IndexImpl::countDistinct(lastCol0, counter, table);
+      if (progress) {
+        progress(table.numRows());
+      }
     }
   }};
 }
@@ -2214,7 +2218,8 @@ std::packaged_task<void()> computeStatistics(
 
 // _____________________________________________________________________________
 nlohmann::json IndexImpl::recomputeStatistics(
-    const LocatedTriplesSharedState& locatedTriplesSharedState) const {
+    const LocatedTriplesSharedState& locatedTriplesSharedState,
+    const std::function<void(size_t)>& progress) const {
   size_t numTriples = 0;
   size_t numTriplesInternal = 0;
   size_t numSubjects = 0;
@@ -2224,11 +2229,11 @@ nlohmann::json IndexImpl::recomputeStatistics(
 
   std::vector<std::packaged_task<void()>> tasks;
 
-  auto getCounterTask = [&locatedTriplesSharedState](
+  auto getCounterTask = [&locatedTriplesSharedState, &progress](
                             size_t& counter, const Permutation& permutation,
                             auto customAction) {
     return computeStatistics(locatedTriplesSharedState, counter, permutation,
-                             customAction);
+                             customAction, progress);
   };
 
   tasks.push_back(getCounterTask(

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -988,12 +988,12 @@ class IndexImpl {
                             const IdTable& table);
 
   // Recompute the statistics about the index based on the passed located
-  // triples shared state. If `progress` is nonempty, it is called (possibly
-  // from several threads) with the number of newly scanned rows; this is used
-  // by the index rebuild for progress reporting.
+  // triples shared state. `progress` is called (possibly from several
+  // threads) with the number of newly scanned rows; this is used by the index
+  // rebuild for progress reporting and defaults to a no-op.
   nlohmann::json recomputeStatistics(
       const LocatedTriplesSharedState& locatedTriplesSharedState,
-      const std::function<void(size_t)>& progress = {}) const;
+      const std::function<void(size_t)>& progress = [](size_t) {}) const;
 };
 
 #endif  // QLEVER_SRC_INDEX_INDEXIMPL_H

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -987,9 +987,12 @@ class IndexImpl {
                             const IdTable& table);
 
   // Recompute the statistics about the index based on the passed located
-  // triples shared state.
+  // triples shared state. If `progress` is nonempty, it is called (possibly
+  // from several threads) with the number of newly scanned rows; this is used
+  // by the index rebuild for progress reporting.
   nlohmann::json recomputeStatistics(
-      const LocatedTriplesSharedState& locatedTriplesSharedState) const;
+      const LocatedTriplesSharedState& locatedTriplesSharedState,
+      const std::function<void(size_t)>& progress = {}) const;
 };
 
 #endif  // QLEVER_SRC_INDEX_INDEXIMPL_H

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -45,6 +45,7 @@
 #include "util/Forward.h"
 #include "util/Iterators.h"
 #include "util/MemorySize/MemorySize.h"
+#include "util/TransparentFunctors.h"
 #include "util/json.h"
 
 template <typename Comparator, size_t I = NumColumnsIndexBuilding>
@@ -993,7 +994,7 @@ class IndexImpl {
   // rebuild for progress reporting and defaults to a no-op.
   nlohmann::json recomputeStatistics(
       const LocatedTriplesSharedState& locatedTriplesSharedState,
-      const std::function<void(size_t)>& progress = [](size_t) {}) const;
+      const std::function<void(size_t)>& progress = ad_utility::noop) const;
 };
 
 #endif  // QLEVER_SRC_INDEX_INDEXIMPL_H

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -11,6 +11,7 @@
 #include <gtest/gtest_prod.h>
 #include <re2/re2.h>
 
+#include <functional>
 #include <memory>
 #include <optional>
 #include <string>

--- a/src/index/IndexRebuilder.cpp
+++ b/src/index/IndexRebuilder.cpp
@@ -14,6 +14,7 @@
 #include <absl/time/time.h>
 
 #include <array>
+#include <atomic>
 #include <boost/asio/awaitable.hpp>
 #include <boost/asio/co_spawn.hpp>
 #include <boost/asio/experimental/awaitable_operators.hpp>
@@ -23,6 +24,8 @@
 #include <boost/asio/use_awaitable.hpp>
 #include <cstdint>
 #include <fstream>
+#include <functional>
+#include <mutex>
 #include <string>
 #include <string_view>
 #include <tuple>
@@ -43,6 +46,9 @@
 #include "util/HashMap.h"
 #include "util/InputRangeUtils.h"
 #include "util/Log.h"
+#include "util/ProgressBar.h"
+#include "util/StringUtils.h"
+#include "util/Timer.h"
 
 namespace qlever::indexRebuilder {
 
@@ -66,22 +72,34 @@ struct InsertionInfo {
 // representation (for cheaper hash functions) to new `Id`s.
 LocalVocabMapping mergeVocabs(const std::string& vocabularyName,
                               const Index::Vocab& vocab,
-                              const std::vector<InsertionInfo>& insertInfo) {
+                              const std::vector<InsertionInfo>& insertInfo,
+                              const std::function<void(size_t)>& progress) {
   auto vocabWriter = vocab.makeWordWriterPtr(vocabularyName);
   LocalVocabMapping localVocabMapping;
-  auto writeWordFromVocab = [&vocab,
-                             &vocabWriter](const IndexAndWord& indexAndWord) {
+  // Report the number of written words to `progress` in batches (a call per
+  // word would be needlessly expensive).
+  size_t wordsSinceLastProgress = 0;
+  auto noteWord = [&progress, &wordsSinceLastProgress]() {
+    if (progress && ++wordsSinceLastProgress == 65536) {
+      progress(wordsSinceLastProgress);
+      wordsSinceLastProgress = 0;
+    }
+  };
+  auto writeWordFromVocab = [&vocab, &vocabWriter,
+                             &noteWord](const IndexAndWord& indexAndWord) {
     const auto& [_, word] = indexAndWord;
     (*vocabWriter)(word, vocab.shouldBeExternalized(word));
+    noteWord();
   };
-  auto writeWordFromLocalVocab =
-      [&vocab, &vocabWriter, &localVocabMapping](const InsertionInfo& info) {
-        const auto& [_, word, originalId] = info;
-        auto newIndex = (*vocabWriter)(word, vocab.shouldBeExternalized(word));
-        localVocabMapping.emplace(
-            originalId.getBits(),
-            Id::makeFromVocabIndex(VocabIndex::make(newIndex)));
-      };
+  auto writeWordFromLocalVocab = [&vocab, &vocabWriter, &localVocabMapping,
+                                  &noteWord](const InsertionInfo& info) {
+    const auto& [_, word, originalId] = info;
+    auto newIndex = (*vocabWriter)(word, vocab.shouldBeExternalized(word));
+    localVocabMapping.emplace(
+        originalId.getBits(),
+        Id::makeFromVocabIndex(VocabIndex::make(newIndex)));
+    noteWord();
+  };
   ad_utility::OverloadCallOperator writer{std::move(writeWordFromVocab),
                                           std::move(writeWordFromLocalVocab)};
   ql::ranges::merge(
@@ -96,6 +114,9 @@ LocalVocabMapping mergeVocabs(const std::string& vocabularyName,
       [tag = 0](const InsertionInfo& info) {
         return std::tie(info.insertionPosition_.get(), tag);
       });
+  if (progress && wordsSinceLastProgress > 0) {
+    progress(wordsSinceLastProgress);
+  }
   return localVocabMapping;
 }
 }  // namespace
@@ -103,7 +124,8 @@ LocalVocabMapping mergeVocabs(const std::string& vocabularyName,
 // _____________________________________________________________________________
 std::tuple<InsertionPositions, LocalVocabMapping> materializeLocalVocab(
     const std::vector<LocalVocabIndex>& entries, const Index::Vocab& vocab,
-    const std::string& newIndexName) {
+    const std::string& newIndexName,
+    const std::function<void(size_t)>& progress) {
   std::vector<InsertionInfo> insertInfo;
   insertInfo.reserve(entries.size());
 
@@ -124,7 +146,7 @@ std::tuple<InsertionPositions, LocalVocabMapping> materializeLocalVocab(
   });
 
   LocalVocabMapping localVocabMapping =
-      mergeVocabs(newIndexName + VOCAB_SUFFIX, vocab, insertInfo);
+      mergeVocabs(newIndexName + VOCAB_SUFFIX, vocab, insertInfo, progress);
   auto denseInfo = insertInfo |
                    ql::views::transform(&InsertionInfo::insertionPosition_) |
                    ::ranges::to<std::vector>;
@@ -371,24 +393,34 @@ boost::asio::awaitable<void> createPermutationWriterTask(
     const LocalVocabMapping& localVocabMapping,
     const InsertionPositions& insertionPositions,
     const BlankNodeBlocks& blankNodeBlocks, uint64_t minBlankNodeIndex,
-    const ad_utility::SharedCancellationHandle& cancellationHandle) {
+    const ad_utility::SharedCancellationHandle& cancellationHandle,
+    std::function<void(size_t)> progress) {
   namespace net = boost::asio;
   using namespace net::experimental::awaitable_operators;
   auto makeTaskForPermutation = [&](const Permutation& permutation) {
     return [&newIndex, &permutation, isInternal, &locatedTriplesSharedState,
             &localVocabMapping, &insertionPositions, &blankNodeBlocks,
-            minBlankNodeIndex, &cancellationHandle]() {
+            minBlankNodeIndex, &cancellationHandle, progress]() {
       auto blockMetadataRanges = permutation.getAugmentedMetadataForPermutation(
           *locatedTriplesSharedState);
       auto [numColumns, additionalColumns] =
           getNumberOfColumnsAndAdditionalColumns(blockMetadataRanges);
+      // Wrap the input range so that the number of processed triples is
+      // reported to `progress` per block.
+      auto countingStream = ad_utility::InputRangeTypeErased<IdTableStatic<0>>{
+          ad_utility::CachingTransformInputRange{
+              readIndexAndRemap(
+                  permutation, blockMetadataRanges, locatedTriplesSharedState,
+                  localVocabMapping, insertionPositions, blankNodeBlocks,
+                  minBlankNodeIndex, cancellationHandle, additionalColumns),
+              [progress](IdTableStatic<0>& table) {
+                if (progress) {
+                  progress(table.numRows());
+                }
+                return std::move(table);
+              }}};
       return newIndex.createPermutationWithoutMetadata(
-          numColumns,
-          readIndexAndRemap(
-              permutation, blockMetadataRanges, locatedTriplesSharedState,
-              localVocabMapping, insertionPositions, blankNodeBlocks,
-              minBlankNodeIndex, cancellationHandle, additionalColumns),
-          permutation, isInternal);
+          numColumns, std::move(countingStream), permutation, isInternal);
     };
   };
   // Workaround for a GCC 15/16 bug: the hidden object of a by-value
@@ -415,6 +447,70 @@ boost::asio::awaitable<void> createPermutationWriterTask(
 
 // _____________________________________________________________________________
 namespace qlever {
+namespace {
+// Thread-safe progress reporting for one phase of the index rebuild.
+// Aggregates the number of processed steps over concurrent workers and
+// writes a line with a percentage and the average speed to the rebuild's
+// log file roughly every `batchSize_` steps (about 50 lines per phase, but
+// at least every `DEFAULT_PROGRESS_BAR_BATCH_SIZE` steps). This is a
+// sibling of `ad_utility::ProgressBar` (which the normal index build uses)
+// for the case where the total is known in advance, several threads
+// contribute, and the output goes to a dedicated log file.
+class ConcurrentProgress {
+ public:
+  ConcurrentProgress(std::ostream& logFile, std::string prefix,
+                     size_t totalSteps)
+      : logFile_{logFile},
+        prefix_{std::move(prefix)},
+        totalSteps_{std::max<size_t>(totalSteps, 1)},
+        batchSize_{std::max(DEFAULT_PROGRESS_BAR_BATCH_SIZE, totalSteps_ / 50)},
+        nextPrintAt_{batchSize_} {}
+
+  // Report `numSteps` newly processed steps. Threadsafe.
+  void add(size_t numSteps) {
+    size_t processed =
+        processed_.fetch_add(numSteps, std::memory_order_relaxed) + numSteps;
+    size_t nextPrintAt = nextPrintAt_.load(std::memory_order_relaxed);
+    if (processed >= nextPrintAt &&
+        nextPrintAt_.compare_exchange_strong(
+            nextPrintAt, (processed / batchSize_ + 1) * batchSize_)) {
+      print(processed);
+    }
+  }
+
+  // Write a final line with the total number of processed steps (typically
+  // showing 100%).
+  void finish() { print(processed_.load()); }
+
+ private:
+  void print(size_t processed) {
+    double seconds = static_cast<double>(timer_.msecs().count()) / 1000.0;
+    double percentage = std::min(100.0, 100.0 * static_cast<double>(processed) /
+                                            static_cast<double>(totalSteps_));
+    std::lock_guard lock{mutex_};
+    logFile_ << ad_utility::Log::getTimeStamp() << " - INFO: " << prefix_
+             << ad_utility::insertThousandSeparator(std::to_string(processed),
+                                                    ',')
+             << " of "
+             << ad_utility::insertThousandSeparator(std::to_string(totalSteps_),
+                                                    ',')
+             << absl::StrFormat(" (%.1f%%)", percentage) << " [average speed "
+             << DEFAULT_SPEED_DESCRIPTION_FUNCTION(
+                    static_cast<double>(processed) / std::max(seconds, 0.001))
+             << "]" << std::endl;
+  }
+
+  std::ostream& logFile_;
+  std::string prefix_;
+  size_t totalSteps_;
+  size_t batchSize_;
+  std::atomic<size_t> processed_ = 0;
+  std::atomic<size_t> nextPrintAt_;
+  ad_utility::Timer timer_{ad_utility::Timer::Started};
+  std::mutex mutex_;
+};
+}  // namespace
+
 indexRebuilder::IndexRebuildMapping materializeToIndex(
     const IndexImpl& index, const std::string& newIndexName,
     const LocatedTriplesSharedState& locatedTriplesSharedState,
@@ -442,12 +538,28 @@ indexRebuilder::IndexRebuildMapping materializeToIndex(
   REBUILD_LOG_INFO << "Writing new vocabulary ..." << std::endl;
 
   auto blankNodeBlocks = flattenBlankNodeBlocks(ownedBlocks);
-  auto [insertionPositions, localVocabMapping] =
-      materializeLocalVocab(entries, index.getVocab(), newIndexName);
+  ConcurrentProgress vocabProgress{
+      logFile, "Words written: ", index.getVocab().size() + entries.size()};
+  auto [insertionPositions, localVocabMapping] = materializeLocalVocab(
+      entries, index.getVocab(), newIndexName,
+      [&vocabProgress](size_t numWords) { vocabProgress.add(numWords); });
+  vocabProgress.finish();
 
   REBUILD_LOG_INFO << "Recomputing statistics ..." << std::endl;
 
-  auto newStats = index.recomputeStatistics(locatedTriplesSharedState);
+  // The totals for the progress reports below are taken from the statistics
+  // of the old index; they are exact up to the delta triples, which is good
+  // enough for a percentage. The statistics phase scans the PSO permutation,
+  // its internal counterpart, and (if present) the SPO and OSP permutations.
+  auto numTriplesOld = index.numTriples();
+  size_t statsTotal =
+      (index.hasAllPermutations() ? 3 : 1) * numTriplesOld.normal +
+      numTriplesOld.internal;
+  ConcurrentProgress statsProgress{logFile, "Triples counted: ", statsTotal};
+  auto newStats = index.recomputeStatistics(
+      locatedTriplesSharedState,
+      [&statsProgress](size_t numRows) { statsProgress.add(numRows); });
+  statsProgress.finish();
   newStats[DATE_OF_INDEX_BUILD_KEY] = dateOfIndexBuild;
 
   auto minBlankNodeIndex = index.getBlankNodeManager()->minIndex_;
@@ -465,6 +577,17 @@ indexRebuilder::IndexRebuildMapping materializeToIndex(
   newIndex.loadConfigFromOldIndex(newIndexName, index, newStats);
 
   REBUILD_LOG_INFO << "Writing new permutations ..." << std::endl;
+
+  // Each of the (up to 6) normal permutations writes all normal triples,
+  // each of the two internal permutations all internal triples.
+  size_t permutationsTotal =
+      (index.hasAllPermutations() ? 6 : 2) * numTriplesOld.normal +
+      2 * numTriplesOld.internal;
+  ConcurrentProgress permutationsProgress{
+      logFile, "Triples written: ", permutationsTotal};
+  auto permutationsProgressCallback = [&permutationsProgress](size_t numRows) {
+    permutationsProgress.add(numRows);
+  };
 
   auto patternThreads = static_cast<size_t>(index.usePatterns());
   size_t numberOfPermutations = index.hasAllPermutations() ? 8 : 4;
@@ -510,17 +633,18 @@ indexRebuilder::IndexRebuildMapping materializeToIndex(
       return isInternal ? perm.internalPermutation() : perm;
     };
 
-    net::co_spawn(
-        threadPool,
-        createPermutationWriterTask(
-            newIndex, getPermutation(a), getPermutation(b), isInternal,
-            locatedTriplesSharedState, localVocabMapping, insertionPositions,
-            blankNodeBlocks, minBlankNodeIndex, cancellationHandle),
-        std::ref(exceptionCollector));
+    net::co_spawn(threadPool,
+                  createPermutationWriterTask(
+                      newIndex, getPermutation(a), getPermutation(b),
+                      isInternal, locatedTriplesSharedState, localVocabMapping,
+                      insertionPositions, blankNodeBlocks, minBlankNodeIndex,
+                      cancellationHandle, permutationsProgressCallback),
+                  std::ref(exceptionCollector));
   }
 
   threadPool.join();
   exceptionCollector.rethrowIfException();
+  permutationsProgress.finish();
 
   REBUILD_LOG_INFO << "Index rebuild completed" << std::endl;
 

--- a/src/index/IndexRebuilder.cpp
+++ b/src/index/IndexRebuilder.cpp
@@ -54,6 +54,14 @@ namespace qlever::indexRebuilder {
 
 namespace {
 
+// The number of processed steps (e.g. written words) that are accumulated
+// locally before they are reported to a progress callback. Each report is an
+// atomic addition on a shared counter (see `ConcurrentProgress` below), so
+// reporting every single step would be needlessly expensive. The exact value
+// is not important; it only has to be large enough to amortize the callback
+// and small enough for smooth progress output.
+constexpr size_t PROGRESS_REPORTING_BATCH_SIZE = 65536;
+
 // Helper struct that stores where a local vocab entry should be inserted into
 // the original vocab and what the original `Id` of the local vocab entry was
 // (so that we can create the mapping from old.
@@ -76,11 +84,14 @@ LocalVocabMapping mergeVocabs(const std::string& vocabularyName,
                               const std::function<void(size_t)>& progress) {
   auto vocabWriter = vocab.makeWordWriterPtr(vocabularyName);
   LocalVocabMapping localVocabMapping;
-  // Report the number of written words to `progress` in batches (a call per
-  // word would be needlessly expensive).
+  // Report the number of written words to `progress` in batches, see
+  // `PROGRESS_REPORTING_BATCH_SIZE`.
   size_t wordsSinceLastProgress = 0;
   auto noteWord = [&progress, &wordsSinceLastProgress]() {
-    if (progress && ++wordsSinceLastProgress == 65536) {
+    if (!progress) {
+      return;
+    }
+    if (++wordsSinceLastProgress == PROGRESS_REPORTING_BATCH_SIZE) {
       progress(wordsSinceLastProgress);
       wordsSinceLastProgress = 0;
     }

--- a/src/index/IndexRebuilder.cpp
+++ b/src/index/IndexRebuilder.cpp
@@ -521,8 +521,14 @@ indexRebuilder::IndexRebuildMapping materializeToIndex(
   size_t statsTotal =
       (index.hasAllPermutations() ? 3 : 1) * numTriplesOld.normal +
       numTriplesOld.internal;
-  ad_utility::ConcurrentProgressBar statsProgress{"Triples counted: ",
-                                                  statsTotal};
+  // For the two phases with very large totals, choose the batch size such
+  // that about 50 progress lines are written per phase (but no more often
+  // than the default batch size).
+  auto batchSizeFor = [](size_t total) {
+    return std::max(DEFAULT_PROGRESS_BAR_BATCH_SIZE, total / 50);
+  };
+  ad_utility::ConcurrentProgressBar statsProgress{
+      "Triples counted: ", statsTotal, batchSizeFor(statsTotal)};
   auto newStats =
       index.recomputeStatistics(locatedTriplesSharedState,
                                 [&logProgress, &statsProgress](size_t numRows) {
@@ -553,8 +559,8 @@ indexRebuilder::IndexRebuildMapping materializeToIndex(
   size_t permutationsTotal =
       (index.hasAllPermutations() ? 6 : 2) * numTriplesOld.normal +
       2 * numTriplesOld.internal;
-  ad_utility::ConcurrentProgressBar permutationsProgress{"Triples written: ",
-                                                         permutationsTotal};
+  ad_utility::ConcurrentProgressBar permutationsProgress{
+      "Triples written: ", permutationsTotal, batchSizeFor(permutationsTotal)};
   auto permutationsProgressCallback = [&logProgress,
                                        &permutationsProgress](size_t numRows) {
     logProgress(permutationsProgress, numRows);

--- a/src/index/IndexRebuilder.cpp
+++ b/src/index/IndexRebuilder.cpp
@@ -483,12 +483,10 @@ indexRebuilder::IndexRebuildMapping materializeToIndex(
   REBUILD_LOG_INFO << "Rebuilding index from current data (including updates)"
                    << std::endl;
 
-  // The phase headers say in parentheses what exactly is being processed, so
-  // that the totals of the progress lines below are self-explanatory.
+  // Phase 1: write the new vocabulary.
   REBUILD_LOG_INFO << "Writing new vocabulary (merging existing and new "
                       "words) ..."
                    << std::endl;
-
   auto blankNodeBlocks = flattenBlankNodeBlocks(ownedBlocks);
   ad_utility::ConcurrentProgressBar vocabProgress{
       logFile, "Words written: ", index.getVocab().size() + entries.size()};
@@ -497,31 +495,30 @@ indexRebuilder::IndexRebuildMapping materializeToIndex(
       [&vocabProgress](size_t numWords) { vocabProgress.add(numWords); });
   vocabProgress.finish();
 
+  // Phase 2: recompute statistics.
+  //
+  // NOTE: The totals for the progress bar are taken from the statistics
+  // of the old index; they are exact up to the delta triples, which is good
+  // enough for a progress bar.
   REBUILD_LOG_INFO << "Recomputing statistics (from "
                    << (index.hasAllPermutations()
                            ? "4 permutations, 3 normal and 1 internal"
                            : "2 permutations, 1 normal and 1 internal")
                    << ") ..." << std::endl;
-
-  // The totals for the progress reports below are taken from the statistics
-  // of the old index; they are exact up to the delta triples, which is good
-  // enough for a percentage. The statistics phase scans the PSO permutation,
-  // its internal counterpart, and (if present) the SPO and OSP permutations.
   auto numTriplesOld = index.numTriples();
   size_t statsTotal =
       (index.hasAllPermutations() ? 3 : 1) * numTriplesOld.normal +
       numTriplesOld.internal;
-  ad_utility::ConcurrentProgressBar statsProgress{logFile,
-                                               "Triples counted: ", statsTotal};
+  ad_utility::ConcurrentProgressBar statsProgress{
+      logFile, "Triples counted: ", statsTotal};
   auto newStats = index.recomputeStatistics(
       locatedTriplesSharedState,
       [&statsProgress](size_t numRows) { statsProgress.add(numRows); });
   statsProgress.finish();
   newStats[DATE_OF_INDEX_BUILD_KEY] = dateOfIndexBuild;
 
-  auto minBlankNodeIndex = index.getBlankNodeManager()->minIndex_;
-
   // Set newer lower bound for dynamic blank node indices.
+  auto minBlankNodeIndex = index.getBlankNodeManager()->minIndex_;
   newStats["num-blank-nodes-total"] =
       minBlankNodeIndex +
       blankNodeBlocks.size() * ad_utility::BlankNodeManager::blockSize_;
@@ -533,14 +530,12 @@ indexRebuilder::IndexRebuildMapping materializeToIndex(
   IndexImpl newIndex{ad_utility::makeAllocatorWithLimit<Id>(0_B)};
   newIndex.loadConfigFromOldIndex(newIndexName, index, newStats);
 
+  // Phase 3: write the new index (permutations and patterns).
   REBUILD_LOG_INFO << "Writing new index ("
                    << (index.hasAllPermutations()
                            ? "8 permutations, 6 normal and 2 internal"
                            : "4 permutations, 2 normal and 2 internal")
                    << ") ..." << std::endl;
-
-  // Each of the (up to 6) normal permutations writes all normal triples,
-  // each of the two internal permutations all internal triples.
   size_t permutationsTotal =
       (index.hasAllPermutations() ? 6 : 2) * numTriplesOld.normal +
       2 * numTriplesOld.internal;

--- a/src/index/IndexRebuilder.cpp
+++ b/src/index/IndexRebuilder.cpp
@@ -493,13 +493,21 @@ indexRebuilder::IndexRebuildMapping materializeToIndex(
     }
   };
 
+  // Choose the batch size of each phase's progress bar such that about 50
+  // progress lines are written per phase (but no more often than the default
+  // batch size).
+  auto batchSizeFor = [](size_t total) {
+    return std::max(DEFAULT_PROGRESS_BAR_BATCH_SIZE, total / 50);
+  };
+
   // Phase 1: write the new vocabulary.
   REBUILD_LOG_INFO << "Writing new vocabulary (merging existing and new "
                       "words) ..."
                    << std::endl;
   auto blankNodeBlocks = flattenBlankNodeBlocks(ownedBlocks);
-  ad_utility::ConcurrentProgressBar vocabProgress{
-      "Words written: ", index.getVocab().size() + entries.size()};
+  size_t vocabTotal = index.getVocab().size() + entries.size();
+  ad_utility::ConcurrentProgressBar vocabProgress{"Words written: ", vocabTotal,
+                                                  batchSizeFor(vocabTotal)};
   auto [insertionPositions, localVocabMapping] =
       materializeLocalVocab(entries, index.getVocab(), newIndexName,
                             [&logProgress, &vocabProgress](size_t numWords) {
@@ -521,12 +529,6 @@ indexRebuilder::IndexRebuildMapping materializeToIndex(
   size_t statsTotal =
       (index.hasAllPermutations() ? 3 : 1) * numTriplesOld.normal +
       numTriplesOld.internal;
-  // For the two phases with very large totals, choose the batch size such
-  // that about 50 progress lines are written per phase (but no more often
-  // than the default batch size).
-  auto batchSizeFor = [](size_t total) {
-    return std::max(DEFAULT_PROGRESS_BAR_BATCH_SIZE, total / 50);
-  };
   ad_utility::ConcurrentProgressBar statsProgress{
       "Triples counted: ", statsTotal, batchSizeFor(statsTotal)};
   auto newStats =

--- a/src/index/IndexRebuilder.cpp
+++ b/src/index/IndexRebuilder.cpp
@@ -54,15 +54,6 @@ namespace qlever::indexRebuilder {
 
 namespace {
 
-// The number of processed steps (e.g. written words) that are accumulated
-// locally before they are reported to a progress callback. Each report is a
-// mutex-protected addition on a shared counter (see
-// `ad_utility::ConcurrentProgressBar`), so reporting every single step would be
-// needlessly expensive. The exact value is not important; it only has to be
-// large enough to amortize the callback and small enough for smooth progress
-// output.
-constexpr size_t PROGRESS_REPORTING_BATCH_SIZE = 65536;
-
 // Helper struct that stores where a local vocab entry should be inserted into
 // the original vocab and what the original `Id` of the local vocab entry was
 // (so that we can create the mapping from old.
@@ -85,14 +76,16 @@ LocalVocabMapping mergeVocabs(const std::string& vocabularyName,
                               const std::function<void(size_t)>& progress) {
   auto vocabWriter = vocab.makeWordWriterPtr(vocabularyName);
   LocalVocabMapping localVocabMapping;
-  // Report the number of written words to `progress` in batches, see
-  // `PROGRESS_REPORTING_BATCH_SIZE`.
+  // Report the number of written words to `progress` in batches: each report
+  // is a mutex-protected addition on a shared counter (see
+  // `ad_utility::ConcurrentProgressBar`), so reporting every single word
+  // would be needlessly expensive. The exact batch size is not important.
   size_t wordsSinceLastProgress = 0;
   auto noteWord = [&progress, &wordsSinceLastProgress]() {
     if (!progress) {
       return;
     }
-    if (++wordsSinceLastProgress == PROGRESS_REPORTING_BATCH_SIZE) {
+    if (++wordsSinceLastProgress == 65536) {
       progress(wordsSinceLastProgress);
       wordsSinceLastProgress = 0;
     }

--- a/src/index/IndexRebuilder.cpp
+++ b/src/index/IndexRebuilder.cpp
@@ -55,11 +55,12 @@ namespace qlever::indexRebuilder {
 namespace {
 
 // The number of processed steps (e.g. written words) that are accumulated
-// locally before they are reported to a progress callback. Each report is an
-// atomic addition on a shared counter (see `ConcurrentProgress` below), so
-// reporting every single step would be needlessly expensive. The exact value
-// is not important; it only has to be large enough to amortize the callback
-// and small enough for smooth progress output.
+// locally before they are reported to a progress callback. Each report is a
+// mutex-protected addition on a shared counter (see
+// `ad_utility::ConcurrentProgress`), so reporting every single step would be
+// needlessly expensive. The exact value is not important; it only has to be
+// large enough to amortize the callback and small enough for smooth progress
+// output.
 constexpr size_t PROGRESS_REPORTING_BATCH_SIZE = 65536;
 
 // Helper struct that stores where a local vocab entry should be inserted into
@@ -458,83 +459,6 @@ boost::asio::awaitable<void> createPermutationWriterTask(
 
 // _____________________________________________________________________________
 namespace qlever {
-namespace {
-// Thread-safe progress reporting for one phase of the index rebuild.
-// Aggregates the number of processed steps over concurrent workers and
-// writes a line with a percentage and the average speed to the rebuild's
-// log file roughly every `batchSize_` steps (about 50 lines per phase, but
-// at least every `DEFAULT_PROGRESS_BAR_BATCH_SIZE` steps). This is a
-// sibling of `ad_utility::ProgressBar` (which the normal index build uses)
-// for the case where the total is known in advance, several threads
-// contribute, and the output goes to a dedicated log file.
-class ConcurrentProgress {
- public:
-  ConcurrentProgress(std::ostream& logFile, std::string prefix,
-                     size_t totalSteps)
-      : logFile_{logFile},
-        prefix_{std::move(prefix)},
-        totalSteps_{std::max<size_t>(totalSteps, 1)},
-        batchSize_{std::max(DEFAULT_PROGRESS_BAR_BATCH_SIZE, totalSteps_ / 50)},
-        nextPrintAt_{batchSize_} {}
-
-  // Report `numSteps` newly processed steps. Threadsafe.
-  void add(size_t numSteps) {
-    size_t processed =
-        processed_.fetch_add(numSteps, std::memory_order_relaxed) + numSteps;
-    size_t nextPrintAt = nextPrintAt_.load(std::memory_order_relaxed);
-    if (processed >= nextPrintAt &&
-        nextPrintAt_.compare_exchange_strong(
-            nextPrintAt, (processed / batchSize_ + 1) * batchSize_)) {
-      print(processed);
-    }
-  }
-
-  // Write a final line with the total number of processed steps (typically
-  // showing 100%).
-  void finish() { print(processed_.load(), true); }
-
- private:
-  // Like `ad_utility::ProgressBar` with `ReuseLine`, intermediate updates end
-  // with `\r`, so that a viewer of the log file (e.g. `qlever rebuild-index`)
-  // shows them on one line that updates in place; only the final line of a
-  // phase ends with `\n`. When a line is shorter than its predecessor (e.g.
-  // because the average speed dropped by a digit), it is padded with spaces
-  // to the widest line so far, so that the `\r` overwrites all of it and no
-  // leftover characters remain.
-  void print(size_t processed, bool final = false) {
-    double seconds = static_cast<double>(timer_.msecs().count()) / 1000.0;
-    double percentage = std::min(100.0, 100.0 * static_cast<double>(processed) /
-                                            static_cast<double>(totalSteps_));
-    std::string line = absl::StrCat(
-        prefix_,
-        ad_utility::insertThousandSeparator(std::to_string(processed), ','),
-        " of ",
-        ad_utility::insertThousandSeparator(std::to_string(totalSteps_), ','),
-        absl::StrFormat(" (%.1f%%)", percentage), " [average speed ",
-        DEFAULT_SPEED_DESCRIPTION_FUNCTION(static_cast<double>(processed) /
-                                           std::max(seconds, 0.001)),
-        "]");
-    std::lock_guard lock{mutex_};
-    maxLineWidth_ = std::max(maxLineWidth_, line.size());
-    line.resize(maxLineWidth_, ' ');
-    logFile_ << ad_utility::Log::getTimeStamp() << " - INFO: " << line
-             << (final ? "\n" : "\r") << std::flush;
-  }
-
-  std::ostream& logFile_;
-  std::string prefix_;
-  size_t totalSteps_;
-  size_t batchSize_;
-  std::atomic<size_t> processed_ = 0;
-  std::atomic<size_t> nextPrintAt_;
-  ad_utility::Timer timer_{ad_utility::Timer::Started};
-  std::mutex mutex_;
-  // The width of the widest line printed so far, used to pad shorter lines so
-  // that a `\r` update leaves no leftover characters (see `print`).
-  size_t maxLineWidth_ = 0;
-};
-}  // namespace
-
 indexRebuilder::IndexRebuildMapping materializeToIndex(
     const IndexImpl& index, const std::string& newIndexName,
     const LocatedTriplesSharedState& locatedTriplesSharedState,
@@ -562,7 +486,7 @@ indexRebuilder::IndexRebuildMapping materializeToIndex(
   REBUILD_LOG_INFO << "Writing new vocabulary ..." << std::endl;
 
   auto blankNodeBlocks = flattenBlankNodeBlocks(ownedBlocks);
-  ConcurrentProgress vocabProgress{
+  ad_utility::ConcurrentProgress vocabProgress{
       logFile, "Words written: ", index.getVocab().size() + entries.size()};
   auto [insertionPositions, localVocabMapping] = materializeLocalVocab(
       entries, index.getVocab(), newIndexName,
@@ -579,7 +503,8 @@ indexRebuilder::IndexRebuildMapping materializeToIndex(
   size_t statsTotal =
       (index.hasAllPermutations() ? 3 : 1) * numTriplesOld.normal +
       numTriplesOld.internal;
-  ConcurrentProgress statsProgress{logFile, "Triples counted: ", statsTotal};
+  ad_utility::ConcurrentProgress statsProgress{logFile,
+                                               "Triples counted: ", statsTotal};
   auto newStats = index.recomputeStatistics(
       locatedTriplesSharedState,
       [&statsProgress](size_t numRows) { statsProgress.add(numRows); });
@@ -607,7 +532,7 @@ indexRebuilder::IndexRebuildMapping materializeToIndex(
   size_t permutationsTotal =
       (index.hasAllPermutations() ? 6 : 2) * numTriplesOld.normal +
       2 * numTriplesOld.internal;
-  ConcurrentProgress permutationsProgress{
+  ad_utility::ConcurrentProgress permutationsProgress{
       logFile, "Triples written: ", permutationsTotal};
   auto permutationsProgressCallback = [&permutationsProgress](size_t numRows) {
     permutationsProgress.add(numRows);

--- a/src/index/IndexRebuilder.cpp
+++ b/src/index/IndexRebuilder.cpp
@@ -486,22 +486,28 @@ class ConcurrentProgress {
   // Like `ad_utility::ProgressBar` with `ReuseLine`, intermediate updates end
   // with `\r`, so that a viewer of the log file (e.g. `qlever rebuild-index`)
   // shows them on one line that updates in place; only the final line of a
-  // phase ends with `\n`.
+  // phase ends with `\n`. When a line is shorter than its predecessor (e.g.
+  // because the average speed dropped by a digit), it is padded with spaces
+  // to the widest line so far, so that the `\r` overwrites all of it and no
+  // leftover characters remain.
   void print(size_t processed, bool final = false) {
     double seconds = static_cast<double>(timer_.msecs().count()) / 1000.0;
     double percentage = std::min(100.0, 100.0 * static_cast<double>(processed) /
                                             static_cast<double>(totalSteps_));
+    std::string line = absl::StrCat(
+        prefix_,
+        ad_utility::insertThousandSeparator(std::to_string(processed), ','),
+        " of ",
+        ad_utility::insertThousandSeparator(std::to_string(totalSteps_), ','),
+        absl::StrFormat(" (%.1f%%)", percentage), " [average speed ",
+        DEFAULT_SPEED_DESCRIPTION_FUNCTION(static_cast<double>(processed) /
+                                           std::max(seconds, 0.001)),
+        "]");
     std::lock_guard lock{mutex_};
-    logFile_ << ad_utility::Log::getTimeStamp() << " - INFO: " << prefix_
-             << ad_utility::insertThousandSeparator(std::to_string(processed),
-                                                    ',')
-             << " of "
-             << ad_utility::insertThousandSeparator(std::to_string(totalSteps_),
-                                                    ',')
-             << absl::StrFormat(" (%.1f%%)", percentage) << " [average speed "
-             << DEFAULT_SPEED_DESCRIPTION_FUNCTION(
-                    static_cast<double>(processed) / std::max(seconds, 0.001))
-             << "]" << (final ? "\n" : "\r") << std::flush;
+    maxLineWidth_ = std::max(maxLineWidth_, line.size());
+    line.resize(maxLineWidth_, ' ');
+    logFile_ << ad_utility::Log::getTimeStamp() << " - INFO: " << line
+             << (final ? "\n" : "\r") << std::flush;
   }
 
   std::ostream& logFile_;
@@ -512,6 +518,9 @@ class ConcurrentProgress {
   std::atomic<size_t> nextPrintAt_;
   ad_utility::Timer timer_{ad_utility::Timer::Started};
   std::mutex mutex_;
+  // The width of the widest line printed so far, used to pad shorter lines so
+  // that a `\r` update leaves no leftover characters (see `print`).
+  size_t maxLineWidth_ = 0;
 };
 }  // namespace
 

--- a/src/index/IndexRebuilder.cpp
+++ b/src/index/IndexRebuilder.cpp
@@ -480,10 +480,14 @@ class ConcurrentProgress {
 
   // Write a final line with the total number of processed steps (typically
   // showing 100%).
-  void finish() { print(processed_.load()); }
+  void finish() { print(processed_.load(), true); }
 
  private:
-  void print(size_t processed) {
+  // Like `ad_utility::ProgressBar` with `ReuseLine`, intermediate updates end
+  // with `\r`, so that a viewer of the log file (e.g. `qlever rebuild-index`)
+  // shows them on one line that updates in place; only the final line of a
+  // phase ends with `\n`.
+  void print(size_t processed, bool final = false) {
     double seconds = static_cast<double>(timer_.msecs().count()) / 1000.0;
     double percentage = std::min(100.0, 100.0 * static_cast<double>(processed) /
                                             static_cast<double>(totalSteps_));
@@ -497,7 +501,7 @@ class ConcurrentProgress {
              << absl::StrFormat(" (%.1f%%)", percentage) << " [average speed "
              << DEFAULT_SPEED_DESCRIPTION_FUNCTION(
                     static_cast<double>(processed) / std::max(seconds, 0.001))
-             << "]" << std::endl;
+             << "]" << (final ? "\n" : "\r") << std::flush;
   }
 
   std::ostream& logFile_;

--- a/src/index/IndexRebuilder.cpp
+++ b/src/index/IndexRebuilder.cpp
@@ -483,17 +483,29 @@ indexRebuilder::IndexRebuildMapping materializeToIndex(
   REBUILD_LOG_INFO << "Rebuilding index from current data (including updates)"
                    << std::endl;
 
+  // Pass `numSteps` newly processed steps on to `progressBar` and write a
+  // progress line to the rebuild's log file whenever one is due.
+  auto logProgress = [&logFile](ad_utility::ConcurrentProgressBar& progressBar,
+                                size_t numSteps) {
+    progressBar.add(numSteps);
+    if (auto update = progressBar.update()) {
+      REBUILD_LOG_INFO << update->getProgressString() << std::flush;
+    }
+  };
+
   // Phase 1: write the new vocabulary.
   REBUILD_LOG_INFO << "Writing new vocabulary (merging existing and new "
                       "words) ..."
                    << std::endl;
   auto blankNodeBlocks = flattenBlankNodeBlocks(ownedBlocks);
   ad_utility::ConcurrentProgressBar vocabProgress{
-      logFile, "Words written: ", index.getVocab().size() + entries.size()};
-  auto [insertionPositions, localVocabMapping] = materializeLocalVocab(
-      entries, index.getVocab(), newIndexName,
-      [&vocabProgress](size_t numWords) { vocabProgress.add(numWords); });
-  vocabProgress.finish();
+      "Words written: ", index.getVocab().size() + entries.size()};
+  auto [insertionPositions, localVocabMapping] =
+      materializeLocalVocab(entries, index.getVocab(), newIndexName,
+                            [&logProgress, &vocabProgress](size_t numWords) {
+                              logProgress(vocabProgress, numWords);
+                            });
+  REBUILD_LOG_INFO << vocabProgress.getFinalProgressString() << std::flush;
 
   // Phase 2: recompute statistics.
   //
@@ -509,12 +521,14 @@ indexRebuilder::IndexRebuildMapping materializeToIndex(
   size_t statsTotal =
       (index.hasAllPermutations() ? 3 : 1) * numTriplesOld.normal +
       numTriplesOld.internal;
-  ad_utility::ConcurrentProgressBar statsProgress{
-      logFile, "Triples counted: ", statsTotal};
-  auto newStats = index.recomputeStatistics(
-      locatedTriplesSharedState,
-      [&statsProgress](size_t numRows) { statsProgress.add(numRows); });
-  statsProgress.finish();
+  ad_utility::ConcurrentProgressBar statsProgress{"Triples counted: ",
+                                                  statsTotal};
+  auto newStats =
+      index.recomputeStatistics(locatedTriplesSharedState,
+                                [&logProgress, &statsProgress](size_t numRows) {
+                                  logProgress(statsProgress, numRows);
+                                });
+  REBUILD_LOG_INFO << statsProgress.getFinalProgressString() << std::flush;
   newStats[DATE_OF_INDEX_BUILD_KEY] = dateOfIndexBuild;
 
   // Set newer lower bound for dynamic blank node indices.
@@ -539,10 +553,11 @@ indexRebuilder::IndexRebuildMapping materializeToIndex(
   size_t permutationsTotal =
       (index.hasAllPermutations() ? 6 : 2) * numTriplesOld.normal +
       2 * numTriplesOld.internal;
-  ad_utility::ConcurrentProgressBar permutationsProgress{
-      logFile, "Triples written: ", permutationsTotal};
-  auto permutationsProgressCallback = [&permutationsProgress](size_t numRows) {
-    permutationsProgress.add(numRows);
+  ad_utility::ConcurrentProgressBar permutationsProgress{"Triples written: ",
+                                                         permutationsTotal};
+  auto permutationsProgressCallback = [&logProgress,
+                                       &permutationsProgress](size_t numRows) {
+    logProgress(permutationsProgress, numRows);
   };
 
   auto patternThreads = static_cast<size_t>(index.usePatterns());
@@ -600,7 +615,8 @@ indexRebuilder::IndexRebuildMapping materializeToIndex(
 
   threadPool.join();
   exceptionCollector.rethrowIfException();
-  permutationsProgress.finish();
+  REBUILD_LOG_INFO << permutationsProgress.getFinalProgressString()
+                   << std::flush;
 
   REBUILD_LOG_INFO << "Index rebuild completed" << std::endl;
 

--- a/src/index/IndexRebuilder.cpp
+++ b/src/index/IndexRebuilder.cpp
@@ -57,7 +57,7 @@ namespace {
 // The number of processed steps (e.g. written words) that are accumulated
 // locally before they are reported to a progress callback. Each report is a
 // mutex-protected addition on a shared counter (see
-// `ad_utility::ConcurrentProgress`), so reporting every single step would be
+// `ad_utility::ConcurrentProgressBar`), so reporting every single step would be
 // needlessly expensive. The exact value is not important; it only has to be
 // large enough to amortize the callback and small enough for smooth progress
 // output.
@@ -490,7 +490,7 @@ indexRebuilder::IndexRebuildMapping materializeToIndex(
                    << std::endl;
 
   auto blankNodeBlocks = flattenBlankNodeBlocks(ownedBlocks);
-  ad_utility::ConcurrentProgress vocabProgress{
+  ad_utility::ConcurrentProgressBar vocabProgress{
       logFile, "Words written: ", index.getVocab().size() + entries.size()};
   auto [insertionPositions, localVocabMapping] = materializeLocalVocab(
       entries, index.getVocab(), newIndexName,
@@ -511,7 +511,7 @@ indexRebuilder::IndexRebuildMapping materializeToIndex(
   size_t statsTotal =
       (index.hasAllPermutations() ? 3 : 1) * numTriplesOld.normal +
       numTriplesOld.internal;
-  ad_utility::ConcurrentProgress statsProgress{logFile,
+  ad_utility::ConcurrentProgressBar statsProgress{logFile,
                                                "Triples counted: ", statsTotal};
   auto newStats = index.recomputeStatistics(
       locatedTriplesSharedState,
@@ -544,7 +544,7 @@ indexRebuilder::IndexRebuildMapping materializeToIndex(
   size_t permutationsTotal =
       (index.hasAllPermutations() ? 6 : 2) * numTriplesOld.normal +
       2 * numTriplesOld.internal;
-  ad_utility::ConcurrentProgress permutationsProgress{
+  ad_utility::ConcurrentProgressBar permutationsProgress{
       logFile, "Triples written: ", permutationsTotal};
   auto permutationsProgressCallback = [&permutationsProgress](size_t numRows) {
     permutationsProgress.add(numRows);

--- a/src/index/IndexRebuilder.cpp
+++ b/src/index/IndexRebuilder.cpp
@@ -509,15 +509,18 @@ indexRebuilder::IndexRebuildMapping materializeToIndex(
   // NOTE: The totals for the progress bar are taken from the statistics
   // of the old index; they are exact up to the delta triples, which is good
   // enough for a progress bar.
-  REBUILD_LOG_INFO << "Recomputing statistics (from "
-                   << (index.hasAllPermutations()
-                           ? "4 permutations, 3 normal and 1 internal"
-                           : "2 permutations, 1 normal and 1 internal")
-                   << ") ..." << std::endl;
+  // The number of normal (non-internal) permutations; there are always two
+  // internal permutations (PSO and POS) in addition.
+  size_t numNormalPermutations = index.hasAllPermutations() ? 6 : 2;
+  // The statistics scan one permutation per normal pair, plus the internal
+  // PSO permutation.
+  size_t numStatsScans = numNormalPermutations / 2;
+  REBUILD_LOG_INFO << "Recomputing statistics (from " << numStatsScans + 1
+                   << " permutations, " << numStatsScans
+                   << " normal and 1 internal) ..." << std::endl;
   auto numTriplesOld = index.numTriples();
   size_t statsTotal =
-      (index.hasAllPermutations() ? 3 : 1) * numTriplesOld.normal +
-      numTriplesOld.internal;
+      numStatsScans * numTriplesOld.normal + numTriplesOld.internal;
   ad_utility::ConcurrentProgressBar statsProgress{
       "Triples counted: ", statsTotal, batchSizeFor(statsTotal)};
   auto newStats = index.recomputeStatistics(locatedTriplesSharedState,
@@ -539,20 +542,18 @@ indexRebuilder::IndexRebuildMapping materializeToIndex(
   newIndex.loadConfigFromOldIndex(newIndexName, index, newStats);
 
   // Phase 3: write the new index (permutations and patterns).
-  REBUILD_LOG_INFO << "Writing new index ("
-                   << (index.hasAllPermutations()
-                           ? "8 permutations, 6 normal and 2 internal"
-                           : "4 permutations, 2 normal and 2 internal")
-                   << ") ..." << std::endl;
+  REBUILD_LOG_INFO << "Writing new index (" << numNormalPermutations + 2
+                   << " permutations, " << numNormalPermutations
+                   << " normal and 2 internal) ..." << std::endl;
+  // Each triple is written once per permutation.
   size_t permutationsTotal =
-      (index.hasAllPermutations() ? 6 : 2) * numTriplesOld.normal +
-      2 * numTriplesOld.internal;
+      numNormalPermutations * numTriplesOld.normal + 2 * numTriplesOld.internal;
   ad_utility::ConcurrentProgressBar permutationsProgress{
       "Triples written: ", permutationsTotal, batchSizeFor(permutationsTotal)};
   auto permutationsProgressCallback = progressCallbackFor(permutationsProgress);
 
   auto patternThreads = static_cast<size_t>(index.usePatterns());
-  size_t numberOfPermutations = index.hasAllPermutations() ? 8 : 4;
+  size_t numberOfPermutations = numNormalPermutations + 2;
   namespace net = boost::asio;
   net::thread_pool threadPool{patternThreads + numberOfPermutations};
 

--- a/src/index/IndexRebuilder.cpp
+++ b/src/index/IndexRebuilder.cpp
@@ -82,9 +82,6 @@ LocalVocabMapping mergeVocabs(const std::string& vocabularyName,
   // would be needlessly expensive. The exact batch size is not important.
   size_t wordsSinceLastProgress = 0;
   auto noteWord = [&progress, &wordsSinceLastProgress]() {
-    if (!progress) {
-      return;
-    }
     if (++wordsSinceLastProgress == 65536) {
       progress(wordsSinceLastProgress);
       wordsSinceLastProgress = 0;
@@ -119,7 +116,7 @@ LocalVocabMapping mergeVocabs(const std::string& vocabularyName,
       [tag = 0](const InsertionInfo& info) {
         return std::tie(info.insertionPosition_.get(), tag);
       });
-  if (progress && wordsSinceLastProgress > 0) {
+  if (wordsSinceLastProgress > 0) {
     progress(wordsSinceLastProgress);
   }
   return localVocabMapping;
@@ -419,9 +416,7 @@ boost::asio::awaitable<void> createPermutationWriterTask(
                   localVocabMapping, insertionPositions, blankNodeBlocks,
                   minBlankNodeIndex, cancellationHandle, additionalColumns),
               [progress](IdTableStatic<0>& table) {
-                if (progress) {
-                  progress(table.numRows());
-                }
+                progress(table.numRows());
                 return std::move(table);
               }}};
       return newIndex.createPermutationWithoutMetadata(
@@ -478,13 +473,16 @@ indexRebuilder::IndexRebuildMapping materializeToIndex(
 
   // Pass `numSteps` newly processed steps on to `progressBar` and write a
   // progress line to the rebuild's log file whenever one is due.
-  auto logProgress = [&logFile](ad_utility::ConcurrentProgressBar& progressBar,
-                                size_t numSteps) {
-    progressBar.add(numSteps);
-    if (auto update = progressBar.update()) {
-      REBUILD_LOG_INFO << update->getProgressString() << std::flush;
-    }
-  };
+  // NOTE: `REBUILD_LOG_INFO` writes to the captured `logFile`.
+  auto progressCallbackFor =
+      [&logFile](ad_utility::ConcurrentProgressBar& progressBar) {
+        return [&logFile, &progressBar](size_t numSteps) {
+          progressBar.add(numSteps);
+          if (auto update = progressBar.update()) {
+            REBUILD_LOG_INFO << update->getProgressString() << std::flush;
+          }
+        };
+      };
 
   // Choose the batch size of each phase's progress bar such that about 50
   // progress lines are written per phase (but no more often than the default
@@ -503,9 +501,7 @@ indexRebuilder::IndexRebuildMapping materializeToIndex(
                                                   batchSizeFor(vocabTotal)};
   auto [insertionPositions, localVocabMapping] =
       materializeLocalVocab(entries, index.getVocab(), newIndexName,
-                            [&logProgress, &vocabProgress](size_t numWords) {
-                              logProgress(vocabProgress, numWords);
-                            });
+                            progressCallbackFor(vocabProgress));
   REBUILD_LOG_INFO << vocabProgress.getFinalProgressString() << std::flush;
 
   // Phase 2: recompute statistics.
@@ -524,11 +520,8 @@ indexRebuilder::IndexRebuildMapping materializeToIndex(
       numTriplesOld.internal;
   ad_utility::ConcurrentProgressBar statsProgress{
       "Triples counted: ", statsTotal, batchSizeFor(statsTotal)};
-  auto newStats =
-      index.recomputeStatistics(locatedTriplesSharedState,
-                                [&logProgress, &statsProgress](size_t numRows) {
-                                  logProgress(statsProgress, numRows);
-                                });
+  auto newStats = index.recomputeStatistics(locatedTriplesSharedState,
+                                            progressCallbackFor(statsProgress));
   REBUILD_LOG_INFO << statsProgress.getFinalProgressString() << std::flush;
   newStats[DATE_OF_INDEX_BUILD_KEY] = dateOfIndexBuild;
 
@@ -556,10 +549,7 @@ indexRebuilder::IndexRebuildMapping materializeToIndex(
       2 * numTriplesOld.internal;
   ad_utility::ConcurrentProgressBar permutationsProgress{
       "Triples written: ", permutationsTotal, batchSizeFor(permutationsTotal)};
-  auto permutationsProgressCallback = [&logProgress,
-                                       &permutationsProgress](size_t numRows) {
-    logProgress(permutationsProgress, numRows);
-  };
+  auto permutationsProgressCallback = progressCallbackFor(permutationsProgress);
 
   auto patternThreads = static_cast<size_t>(index.usePatterns());
   size_t numberOfPermutations = index.hasAllPermutations() ? 8 : 4;

--- a/src/index/IndexRebuilder.cpp
+++ b/src/index/IndexRebuilder.cpp
@@ -483,7 +483,11 @@ indexRebuilder::IndexRebuildMapping materializeToIndex(
   REBUILD_LOG_INFO << "Rebuilding index from current data (including updates)"
                    << std::endl;
 
-  REBUILD_LOG_INFO << "Writing new vocabulary ..." << std::endl;
+  // The phase headers say in parentheses what exactly is being processed, so
+  // that the totals of the progress lines below are self-explanatory.
+  REBUILD_LOG_INFO << "Writing new vocabulary (merging existing and new "
+                      "words) ..."
+                   << std::endl;
 
   auto blankNodeBlocks = flattenBlankNodeBlocks(ownedBlocks);
   ad_utility::ConcurrentProgress vocabProgress{
@@ -493,7 +497,11 @@ indexRebuilder::IndexRebuildMapping materializeToIndex(
       [&vocabProgress](size_t numWords) { vocabProgress.add(numWords); });
   vocabProgress.finish();
 
-  REBUILD_LOG_INFO << "Recomputing statistics ..." << std::endl;
+  REBUILD_LOG_INFO << "Recomputing statistics (from "
+                   << (index.hasAllPermutations()
+                           ? "4 permutations, 3 normal and 1 internal"
+                           : "2 permutations, 1 normal and 1 internal")
+                   << ") ..." << std::endl;
 
   // The totals for the progress reports below are taken from the statistics
   // of the old index; they are exact up to the delta triples, which is good
@@ -525,7 +533,11 @@ indexRebuilder::IndexRebuildMapping materializeToIndex(
   IndexImpl newIndex{ad_utility::makeAllocatorWithLimit<Id>(0_B)};
   newIndex.loadConfigFromOldIndex(newIndexName, index, newStats);
 
-  REBUILD_LOG_INFO << "Writing new permutations ..." << std::endl;
+  REBUILD_LOG_INFO << "Writing new index ("
+                   << (index.hasAllPermutations()
+                           ? "8 permutations, 6 normal and 2 internal"
+                           : "4 permutations, 2 normal and 2 internal")
+                   << ") ..." << std::endl;
 
   // Each of the (up to 6) normal permutations writes all normal triples,
   // each of the two internal permutations all internal triples.

--- a/src/index/IndexRebuilderImpl.h
+++ b/src/index/IndexRebuilderImpl.h
@@ -12,6 +12,7 @@
 
 #include <boost/asio/awaitable.hpp>
 #include <cstdint>
+#include <functional>
 #include <tuple>
 #include <utility>
 #include <vector>
@@ -30,9 +31,12 @@ namespace qlever::indexRebuilder {
 // positions (the `VocabIndex` of the `LocalVocabEntry`s position in the old
 // `vocab`) and a mapping from old local vocab `Id`s bit representation (for
 // cheaper hash functions) to new vocab `Id`s.
+// If `progress` is nonempty, it is called with the number of newly written
+// words (in batches), for progress reporting.
 std::tuple<InsertionPositions, LocalVocabMapping> materializeLocalVocab(
     const std::vector<LocalVocabIndex>& entries, const Index::Vocab& vocab,
-    const std::string& newIndexName);
+    const std::string& newIndexName,
+    const std::function<void(size_t)>& progress = {});
 
 // Turn a vector of `OwnedBlocksEntry`s into a vector of `uint64_t`s
 // representing the block ids of the generated blocks.
@@ -62,7 +66,9 @@ size_t getNumColumns(const BlockMetadataRanges& blockMetadataRanges);
 
 // Create a `boost::asio::awaitable<void>` that writes a pair of new
 // permutations according to the settings of `newIndex`, based on the data of
-// the current index.
+// the current index. If `progress` is nonempty, it is called (possibly from
+// several threads) with the number of newly processed triples, for progress
+// reporting.
 boost::asio::awaitable<void> createPermutationWriterTask(
     IndexImpl& newIndex, const Permutation& permutationA,
     const Permutation& permutationB, bool isInternal,
@@ -70,7 +76,8 @@ boost::asio::awaitable<void> createPermutationWriterTask(
     const LocalVocabMapping& localVocabMapping,
     const InsertionPositions& insertionPositions,
     const BlankNodeBlocks& blankNodeBlocks, uint64_t minBlankNodeIndex,
-    const ad_utility::SharedCancellationHandle& cancellationHandle);
+    const ad_utility::SharedCancellationHandle& cancellationHandle,
+    std::function<void(size_t)> progress = {});
 
 // Analyze how many columns the new permutation will have and which additional
 // columns it will have based on the given `blockMetadataRanges`. The number of

--- a/src/index/IndexRebuilderImpl.h
+++ b/src/index/IndexRebuilderImpl.h
@@ -23,6 +23,7 @@
 #include "index/IndexRebuilderTypes.h"
 #include "util/CancellationHandle.h"
 #include "util/InputRangeUtils.h"
+#include "util/TransparentFunctors.h"
 
 namespace qlever::indexRebuilder {
 
@@ -36,7 +37,7 @@ namespace qlever::indexRebuilder {
 std::tuple<InsertionPositions, LocalVocabMapping> materializeLocalVocab(
     const std::vector<LocalVocabIndex>& entries, const Index::Vocab& vocab,
     const std::string& newIndexName,
-    const std::function<void(size_t)>& progress = [](size_t) {});
+    const std::function<void(size_t)>& progress = ad_utility::noop);
 
 // Turn a vector of `OwnedBlocksEntry`s into a vector of `uint64_t`s
 // representing the block ids of the generated blocks.
@@ -77,7 +78,7 @@ boost::asio::awaitable<void> createPermutationWriterTask(
     const InsertionPositions& insertionPositions,
     const BlankNodeBlocks& blankNodeBlocks, uint64_t minBlankNodeIndex,
     const ad_utility::SharedCancellationHandle& cancellationHandle,
-    std::function<void(size_t)> progress = [](size_t) {});
+    std::function<void(size_t)> progress = ad_utility::noop);
 
 // Analyze how many columns the new permutation will have and which additional
 // columns it will have based on the given `blockMetadataRanges`. The number of

--- a/src/index/IndexRebuilderImpl.h
+++ b/src/index/IndexRebuilderImpl.h
@@ -31,12 +31,12 @@ namespace qlever::indexRebuilder {
 // positions (the `VocabIndex` of the `LocalVocabEntry`s position in the old
 // `vocab`) and a mapping from old local vocab `Id`s bit representation (for
 // cheaper hash functions) to new vocab `Id`s.
-// If `progress` is nonempty, it is called with the number of newly written
-// words (in batches), for progress reporting.
+// `progress` is called with the number of newly written words (in batches),
+// for progress reporting; it defaults to a no-op.
 std::tuple<InsertionPositions, LocalVocabMapping> materializeLocalVocab(
     const std::vector<LocalVocabIndex>& entries, const Index::Vocab& vocab,
     const std::string& newIndexName,
-    const std::function<void(size_t)>& progress = {});
+    const std::function<void(size_t)>& progress = [](size_t) {});
 
 // Turn a vector of `OwnedBlocksEntry`s into a vector of `uint64_t`s
 // representing the block ids of the generated blocks.
@@ -66,9 +66,9 @@ size_t getNumColumns(const BlockMetadataRanges& blockMetadataRanges);
 
 // Create a `boost::asio::awaitable<void>` that writes a pair of new
 // permutations according to the settings of `newIndex`, based on the data of
-// the current index. If `progress` is nonempty, it is called (possibly from
-// several threads) with the number of newly processed triples, for progress
-// reporting.
+// the current index. `progress` is called (possibly from several threads)
+// with the number of newly processed triples, for progress reporting; it
+// defaults to a no-op.
 boost::asio::awaitable<void> createPermutationWriterTask(
     IndexImpl& newIndex, const Permutation& permutationA,
     const Permutation& permutationB, bool isInternal,
@@ -77,7 +77,7 @@ boost::asio::awaitable<void> createPermutationWriterTask(
     const InsertionPositions& insertionPositions,
     const BlankNodeBlocks& blankNodeBlocks, uint64_t minBlankNodeIndex,
     const ad_utility::SharedCancellationHandle& cancellationHandle,
-    std::function<void(size_t)> progress = {});
+    std::function<void(size_t)> progress = [](size_t) {});
 
 // Analyze how many columns the new permutation will have and which additional
 // columns it will have based on the given `blockMetadataRanges`. The number of

--- a/src/util/ProgressBar.h
+++ b/src/util/ProgressBar.h
@@ -186,14 +186,10 @@ class ProgressBar {
   Timer::Duration maxBatchDuration_ = Timer::Duration::min();
 };
 
-// Thread-safe progress reporting for a phase of a computation whose total
-// number of steps is known in advance. Several threads concurrently report
-// their processed steps via `add`; roughly every `batchSize` steps, a line
-// with the number of processed steps, the percentage of the total, and the
-// average speed is written to the given output stream. This is a sibling of
-// `ProgressBar` above for the case where the total is known in advance,
-// several threads contribute, and the output goes to a dedicated stream
-// (e.g. the log file of a runtime index rebuild).
+// A class for the same general goal as `ProgressBar` above (reporting progress
+// of a long-running computation), but with two differences: (1) the total
+// number of steps is known in advance, and (2) the computation is done by
+// several threads that concurrently report their progress.
 class ConcurrentProgressBar {
  public:
   // Construct with the output stream, a prefix for each line (e.g. "Words
@@ -201,8 +197,8 @@ class ConcurrentProgressBar {
   // default) means: choose automatically, namely such that about 50 lines
   // are written per phase, but at least every
   // `DEFAULT_PROGRESS_BAR_BATCH_SIZE` steps.
-  ConcurrentProgressBar(std::ostream& out, std::string prefix, size_t totalSteps,
-                     size_t batchSize = 0)
+  ConcurrentProgressBar(std::ostream& out, std::string prefix,
+                        size_t totalSteps, size_t batchSize = 0)
       : out_{out},
         prefix_{std::move(prefix)},
         totalSteps_{totalSteps},

--- a/src/util/ProgressBar.h
+++ b/src/util/ProgressBar.h
@@ -9,12 +9,12 @@
 #include <absl/strings/str_format.h>
 
 #include <algorithm>
+#include <functional>
 #include <mutex>
-#include <ostream>
+#include <optional>
 #include <string>
 
 #include "util/Exception.h"
-#include "util/Log.h"
 #include "util/StringUtils.h"
 #include "util/Timer.h"
 
@@ -30,7 +30,7 @@ inline std::string DEFAULT_SPEED_DESCRIPTION_FUNCTION(double stepsPerSecond) {
 namespace ad_utility {
 
 // A class that keeps track of the progress of a long-running computation which
-// processed in (typically many and small) steps (for example, the lines of a
+// proceeds in (typically many and small) steps (for example, the lines of a
 // large input file or the triples of a permutation). The total number of steps
 // does not have to be known in advance.
 //
@@ -71,7 +71,7 @@ class ProgressBar {
   // NOTE: The variable for counting the number of steps must come from the
   // outside (and be incremented there). That is because the calling code
   // typically has such a variable anyway (also for other purposes) and it
-  // would we unnatural to have it originally in this class.
+  // would be unnatural to have it originally in this class.
   CPP_template(typename SizeT)(requires ad_utility::SimilarTo<SizeT, size_t>)
       ProgressBar(SizeT& numStepsProcessed, std::string displayStringPrefix,
                   size_t statisticsBatchSize = DEFAULT_PROGRESS_BAR_BATCH_SIZE,
@@ -88,7 +88,7 @@ class ProgressBar {
   // should be displayed, `false` otherwise.
   //
   // IMPORTANT: This call is (and should) return `false` most of the time, in
-  // which case it is (and should be) very cheap (namely, and increment and a
+  // which case it is (and should be) very cheap (namely, an increment and a
   // simple check).
   bool update() {
     if (numStepsProcessed_ < updateWhenThisManyStepsProcessed_) {
@@ -186,121 +186,201 @@ class ProgressBar {
   Timer::Duration maxBatchDuration_ = Timer::Duration::min();
 };
 
-// A class for the same general goal as `ProgressBar` above (reporting progress
-// of a long-running computation), but with two differences: (1) the total
-// number of steps is known in advance, and (2) the computation is done by
-// several threads that concurrently report their progress. Unlike for
-// `ProgressBar`, the counter therefore lives inside the class, and the class
-// writes its output (timestamped lines) to the given stream itself.
+// A class for the same general goal as `ProgressBar` above (reporting the
+// progress of a long-running computation), but with two differences: (1) the
+// total number of steps is known in advance, so the progress is also shown as
+// a percentage of the total, and (2) the computation is done by several
+// threads that concurrently report their progress. The counter therefore
+// lives inside this class, and the progress string is only handed out via a
+// lock-holding `Update` object, so that the output of concurrent updates can
+// neither interleave nor overtake each other.
 //
-// Typical usage:
+// NOTE: Unlike for `ProgressBar`, only the average speed is shown. Statistics
+// per batch (last, fastest, slowest) are not meaningful here, because a batch
+// boundary is crossed by whichever thread happens to report next.
 //
-// ad_utility::ConcurrentProgressBar progressBar(
-//     std::cout, "Triples processed: ", numTriplesTotal);
+// Typical usage (note the `std::flush` at the end of the `AD_LOG_INFO` calls
+// in order to ensure a flush for lines ending in `\r` instead of `\n`):
+//
+// ad_utility::ConcurrentProgressBar progressBar("Triples processed: ",
+//                                               numTriplesTotal);
 // std::vector<std::thread> threads;
 // for (size_t i = 0; i < numThreads; ++i) {
 //   threads.emplace_back([&]() {
 //     while (...) {
 //       // Code that processes one chunk of triples.
 //       progressBar.add(chunk.size());
+//       if (auto update = progressBar.update()) {
+//         AD_LOG_INFO << update->getProgressString() << std::flush;
+//       }
 //     }
 //   });
 // }
 // for (auto& thread : threads) {
 //   thread.join();
 // }
-// progressBar.finish();
+// AD_LOG_INFO << progressBar.getFinalProgressString() << std::flush;
+//
 class ConcurrentProgressBar {
  public:
-  // Create and initialize a concurrent progress bar that writes its progress
-  // lines to `out`.
+  using SpeedDescriptionFunction = ProgressBar::SpeedDescriptionFunction;
+  using DisplayUpdateOptions = ProgressBar::DisplayUpdateOptions;
+
+  // The result of a successful `update()`: provides the progress string, and
+  // holds a lock until it is destroyed, so that the display of this update
+  // cannot interleave with (or be overtaken by) the display of updates from
+  // other threads. Hence write the string while the `Update` object is still
+  // alive, as in the typical usage above.
+  class Update {
+   public:
+    const std::string& getProgressString() const { return progressString_; }
+
+   private:
+    friend class ConcurrentProgressBar;
+    Update(std::unique_lock<std::mutex> displayLock, std::string progressString)
+        : displayLock_{std::move(displayLock)},
+          progressString_{std::move(progressString)} {}
+    std::unique_lock<std::mutex> displayLock_;
+    std::string progressString_;
+  };
+
+  // Create and initialize a concurrent progress bar.
   //
-  // NOTE: A `batchSize` of `0` (the default) means that the batch size is
-  // chosen automatically, namely such that about 50 lines are written in
-  // total, but at least one line every `DEFAULT_PROGRESS_BAR_BATCH_SIZE`
-  // steps.
-  ConcurrentProgressBar(std::ostream& out, std::string prefix,
-                        size_t totalSteps, size_t batchSize = 0)
-      : out_{out},
-        prefix_{std::move(prefix)},
-        totalSteps_{totalSteps},
-        batchSize_{batchSize != 0 ? batchSize
-                                  : std::max(DEFAULT_PROGRESS_BAR_BATCH_SIZE,
-                                             totalSteps / 50)},
-        nextPrintAt_{batchSize_} {}
+  // NOTE: A `statisticsBatchSize` of `0` (the default) means that the batch
+  // size is chosen automatically, namely such that about 50 progress strings
+  // are produced in total, but at least one every
+  // `DEFAULT_PROGRESS_BAR_BATCH_SIZE` steps. This is possible here (and not
+  // for `ProgressBar`) because the total number of steps is known.
+  ConcurrentProgressBar(
+      std::string displayStringPrefix, size_t totalSteps,
+      size_t statisticsBatchSize = 0,
+      SpeedDescriptionFunction getSpeedDescription =
+          DEFAULT_SPEED_DESCRIPTION_FUNCTION,
+      DisplayUpdateOptions displayUpdateOptions = ProgressBar::ReuseLine)
+      : displayStringPrefix_(std::move(displayStringPrefix)),
+        totalSteps_(totalSteps),
+        statisticsBatchSize_(
+            statisticsBatchSize != 0
+                ? statisticsBatchSize
+                : std::max(DEFAULT_PROGRESS_BAR_BATCH_SIZE, totalSteps / 50)),
+        getSpeedDescription_(std::move(getSpeedDescription)),
+        displayUpdateOptions_(displayUpdateOptions) {}
 
   // Call this whenever one or more units have been processed. Threadsafe.
   //
   // IMPORTANT: Each call takes a lock, so callers in hot loops should
   // accumulate steps locally and report them in larger batches.
   void add(size_t numSteps) {
-    std::lock_guard lock{mutex_};
-    processed_ += numSteps;
-    if (processed_ >= nextPrintAt_) {
-      nextPrintAt_ = (processed_ / batchSize_ + 1) * batchSize_;
-      print(false);
-    }
+    std::lock_guard lock{countMutex_};
+    numStepsProcessed_ += numSteps;
   }
 
-  // Write a final progress line with the total number of processed steps
-  // (typically showing 100%), ended by a newline instead of a carriage
-  // return. Should only be called once, after all threads have finished.
-  void finish() {
-    std::lock_guard lock{mutex_};
-    print(true);
+  // Call this after `add`. Returns an `Update` if an update should be
+  // displayed and this thread is the one that should display it, and
+  // `std::nullopt` otherwise. Threadsafe.
+  std::optional<Update> update() {
+    {
+      std::lock_guard lock{countMutex_};
+      if (numStepsProcessed_ < updateWhenThisManyStepsProcessed_) {
+        return std::nullopt;
+      }
+      // This thread claims the display; other threads get `std::nullopt`
+      // until the next multiple of the batch size is reached.
+      updateWhenThisManyStepsProcessed_ =
+          (numStepsProcessed_ / statisticsBatchSize_ + 1) *
+          statisticsBatchSize_;
+    }
+    // NOTE: The progress string is composed after acquiring the display lock
+    // (and from the current count, not from the count at the time of the
+    // claim above), so that a display that happens to be delayed can never
+    // show a smaller count than its predecessor.
+    std::unique_lock displayLock{displayMutex_};
+    return Update{std::move(displayLock), getProgressStringImpl(false)};
+  }
+
+  // Final progress string (should only be called once, after all threads
+  // have finished). Always ends with a newline.
+  std::string getFinalProgressString() {
+    AD_CONTRACT_CHECK(!finished_,
+                      "`ConcurrentProgressBar::getFinalProgressString()` "
+                      "should only be called once after the computation has "
+                      "finished");
+    timer_.stop();
+    finished_ = true;
+    std::unique_lock displayLock{displayMutex_};
+    return getProgressStringImpl(true);
   }
 
  private:
-  // Write one progress line; requires that `mutex_` is held. Like
-  // `ProgressBar` with `ReuseLine`, intermediate updates end with `\r`, so
-  // that a viewer of the stream shows them on one line that updates in
-  // place; only the final line ends with `\n`. When a line is shorter than
-  // its predecessor (e.g. because the average speed dropped by a digit), it
-  // is padded with spaces to the widest line so far, so that the `\r`
-  // overwrites all of it and no leftover characters remain.
-  void print(bool final) {
-    double seconds = Timer::toSeconds(timer_.value());
-    // A phase with a total of zero steps is trivially complete.
+  // Compose one progress string; requires that `displayMutex_` is held. Like
+  // for `ProgressBar` with `ReuseLine`, intermediate updates end with `\r`,
+  // so that a viewer of the output shows them on one line that updates in
+  // place; only the final string ends with `\n`. When a string is shorter
+  // than its predecessor (e.g., because the average speed dropped by a
+  // digit), it is padded with spaces to the widest string so far, so that
+  // the `\r` overwrites all of it and no leftover characters remain.
+  std::string getProgressStringImpl(bool final) {
+    size_t numStepsProcessed;
+    {
+      std::lock_guard lock{countMutex_};
+      numStepsProcessed = numStepsProcessed_;
+    }
+    // A total of zero steps is trivially complete.
     double percentage =
         totalSteps_ == 0
             ? 100.0
-            : std::min(100.0, 100.0 * static_cast<double>(processed_) /
+            : std::min(100.0, 100.0 * static_cast<double>(numStepsProcessed) /
                                   static_cast<double>(totalSteps_));
-    std::string line = absl::StrCat(
-        prefix_, insertThousandSeparator(std::to_string(processed_), ','),
-        " of ", insertThousandSeparator(std::to_string(totalSteps_), ','),
+    auto withThousandSeparators = [](size_t number) {
+      return ad_utility::insertThousandSeparator(std::to_string(number), ',');
+    };
+    std::string progressString = absl::StrCat(
+        displayStringPrefix_, withThousandSeparators(numStepsProcessed), " of ",
+        withThousandSeparators(totalSteps_),
         absl::StrFormat(" (%.1f%%)", percentage), " [average speed ",
-        DEFAULT_SPEED_DESCRIPTION_FUNCTION(static_cast<double>(processed_) /
-                                           std::max(seconds, 0.001)),
+        getSpeedDescription_(static_cast<double>(numStepsProcessed) /
+                             std::max(Timer::toSeconds(timer_.value()), 0.001)),
         "]");
-    maxLineWidth_ = std::max(maxLineWidth_, line.size());
-    line.resize(maxLineWidth_, ' ');
-    out_ << Log::getTimeStamp() << " - INFO: " << line << (final ? "\n" : "\r")
-         << std::flush;
+    bool reuseLine = displayUpdateOptions_ == ProgressBar::ReuseLine;
+    if (reuseLine) {
+      maxStringWidth_ = std::max(maxStringWidth_, progressString.size());
+      progressString.resize(maxStringWidth_, ' ');
+    }
+    return absl::StrCat(progressString, reuseLine && !final ? "\r" : "\n");
   }
 
-  // The stream to which the progress lines are written (e.g., the log file
-  // of a runtime index rebuild).
-  std::ostream& out_;
-  // The first part of each progress line (e.g., "Triples processed: ").
-  std::string prefix_;
+  // The first part of the display string (e.g., "Triples processed: ").
+  std::string displayStringPrefix_;
   // The total number of steps, known in advance.
   size_t totalSteps_;
-  // Write a progress line every this many steps.
-  size_t batchSize_;
-  // Write the next progress line when this many steps have been processed.
-  size_t nextPrintAt_;
-  // The total number of units that have been processed so far.
-  size_t processed_ = 0;
+  // Produce a progress string every this many steps.
+  size_t statisticsBatchSize_;
+  // Function that returns a string with a speed description (e.g., "3.4
+  // M/s") given a speed in steps per second.
+  SpeedDescriptionFunction getSpeedDescription_;
+  // See `ProgressBar::DisplayUpdateOptions`.
+  DisplayUpdateOptions displayUpdateOptions_;
+
   // Timer that is started as soon as this progress bar is created.
   Timer timer_{Timer::Started};
-  // Mutex that protects the counters above as well as the writes to `out_`.
-  std::mutex mutex_;
-  // The width of the widest line printed so far, used to pad shorter lines,
-  // see `print`.
-  size_t maxLineWidth_ = 0;
+  // Finished yet or not.
+  bool finished_ = false;
+  // The total number of units that have been processed so far. Protected by
+  // `countMutex_`.
+  size_t numStepsProcessed_ = 0;
+  // Produce the next progress string when at least this many steps have been
+  // processed. Protected by `countMutex_`.
+  size_t updateWhenThisManyStepsProcessed_ = statisticsBatchSize_;
+  // The width of the widest progress string so far, used to pad shorter
+  // strings, see `getProgressStringImpl`. Protected by `displayMutex_`.
+  size_t maxStringWidth_ = 0;
+  // Mutex that protects the two counters above. It is taken on every `add`,
+  // so it must never be held while an update is displayed.
+  std::mutex countMutex_;
+  // Mutex that is held while an update is displayed (via the `Update` class
+  // above), so that concurrent displays cannot interleave.
+  std::mutex displayMutex_;
 };
-
 }  // namespace ad_utility
 
 #endif  // QLEVER_SRC_UTIL_PROGRESSBAR_H

--- a/src/util/ProgressBar.h
+++ b/src/util/ProgressBar.h
@@ -258,7 +258,12 @@ class ConcurrentProgressBar {
         totalSteps_(totalSteps),
         statisticsBatchSize_(statisticsBatchSize),
         getSpeedDescription_(std::move(getSpeedDescription)),
-        displayUpdateOptions_(displayUpdateOptions) {}
+        displayUpdateOptions_(displayUpdateOptions) {
+    // NOTE: `update()` divides by the batch size.
+    AD_CONTRACT_CHECK(statisticsBatchSize_ > 0,
+                      "The batch size of a `ConcurrentProgressBar` must not "
+                      "be zero");
+  }
 
   // Call this whenever one or more units have been processed (threadsafe).
   //

--- a/src/util/ProgressBar.h
+++ b/src/util/ProgressBar.h
@@ -29,6 +29,12 @@ inline std::string DEFAULT_SPEED_DESCRIPTION_FUNCTION(double stepsPerSecond) {
 
 namespace ad_utility {
 
+// Format `number` with thousand separators (e.g., 1234567 becomes
+// "1,234,567"), as used in the progress strings of the two classes below.
+inline std::string withThousandSeparators(size_t number) {
+  return insertThousandSeparator(std::to_string(number), ',');
+}
+
 // A class that keeps track of the progress of a long-running computation which
 // proceeds in (typically many and small) steps (for example, the lines of a
 // large input file or the triples of a permutation). The total number of steps
@@ -106,10 +112,7 @@ class ProgressBar {
   // Progress string with statistics.
   std::string getProgressString() const {
     bool notYetFinished = timer_.isRunning();
-    // Two helper functions.
-    auto withThousandSeparators = [](size_t number) {
-      return ad_utility::insertThousandSeparator(std::to_string(number), ',');
-    };
+    // Helper function for the speed description.
     auto speed = [this](size_t numSteps, Timer::Duration duration) {
       return this->getSpeedDescription_(static_cast<double>(numSteps) /
                                         Timer::toSeconds(duration));
@@ -257,10 +260,10 @@ class ConcurrentProgressBar {
         getSpeedDescription_(std::move(getSpeedDescription)),
         displayUpdateOptions_(displayUpdateOptions) {}
 
-  // Call this whenever one or more units have been processed. Threadsafe.
+  // Call this whenever one or more units have been processed (threadsafe).
   //
-  // IMPORTANT: Each call takes a lock, so callers in hot loops should
-  // accumulate steps locally and report them in larger batches.
+  // NOTE: Each call takes a lock, so callers in hot loops should accumulate
+  // steps locally and report them in larger batches.
   void add(size_t numSteps) {
     std::lock_guard lock{countMutex_};
     numStepsProcessed_ += numSteps;
@@ -322,9 +325,6 @@ class ConcurrentProgressBar {
             ? 100.0
             : std::min(100.0, 100.0 * static_cast<double>(numStepsProcessed) /
                                   static_cast<double>(totalSteps_));
-    auto withThousandSeparators = [](size_t number) {
-      return ad_utility::insertThousandSeparator(std::to_string(number), ',');
-    };
     std::string progressString = absl::StrCat(
         displayStringPrefix_, withThousandSeparators(numStepsProcessed), " of ",
         withThousandSeparators(totalSteps_),

--- a/src/util/ProgressBar.h
+++ b/src/util/ProgressBar.h
@@ -187,20 +187,20 @@ class ProgressBar {
 };
 
 // A class for the same general goal as `ProgressBar` above (reporting the
-// progress of a long-running computation), but with two differences: (1) the
-// total number of steps is known in advance, so the progress is also shown as
-// a percentage of the total, and (2) the computation is done by several
-// threads that concurrently report their progress. The counter therefore
-// lives inside this class, and the progress string is only handed out via a
-// lock-holding `Update` object, so that the output of concurrent updates can
-// neither interleave nor overtake each other.
+// progress of a long-running computation), but with two differences:
 //
-// NOTE: Unlike for `ProgressBar`, only the average speed is shown. Statistics
-// per batch (last, fastest, slowest) are not meaningful here, because a batch
-// boundary is crossed by whichever thread happens to report next.
+// 1. The total number of steps is known in advance, so the progress can be
+// shown as a percentage of the total, together with the average speed; no need
+// to show the last, fastest, and slowest batch speeds like for `ProgressBar`.
 //
-// Typical usage (note the `std::flush` at the end of the `AD_LOG_INFO` calls
-// in order to ensure a flush for lines ending in `\r` instead of `\n`):
+// 2. The computation is done by several threads that concurrently report their
+// progress. The progress counter therefore lives inside this class, and the
+// progress string is only handed out via a lock-holding `Update` object, so
+// that the output of concurrent updates can neither interleave nor overtake
+// each other.
+//
+// Typical usage, analogous to the usage of `ProgressBar` above; in particular,
+// the `std::flush` at the end of the `AD_LOG_INFO` calls is important.
 //
 // ad_utility::ConcurrentProgressBar progressBar("Triples processed: ",
 //                                               numTriplesTotal);
@@ -245,24 +245,15 @@ class ConcurrentProgressBar {
   };
 
   // Create and initialize a concurrent progress bar.
-  //
-  // NOTE: A `statisticsBatchSize` of `0` (the default) means that the batch
-  // size is chosen automatically, namely such that about 50 progress strings
-  // are produced in total, but at least one every
-  // `DEFAULT_PROGRESS_BAR_BATCH_SIZE` steps. This is possible here (and not
-  // for `ProgressBar`) because the total number of steps is known.
   ConcurrentProgressBar(
       std::string displayStringPrefix, size_t totalSteps,
-      size_t statisticsBatchSize = 0,
+      size_t statisticsBatchSize = DEFAULT_PROGRESS_BAR_BATCH_SIZE,
       SpeedDescriptionFunction getSpeedDescription =
           DEFAULT_SPEED_DESCRIPTION_FUNCTION,
       DisplayUpdateOptions displayUpdateOptions = ProgressBar::ReuseLine)
       : displayStringPrefix_(std::move(displayStringPrefix)),
         totalSteps_(totalSteps),
-        statisticsBatchSize_(
-            statisticsBatchSize != 0
-                ? statisticsBatchSize
-                : std::max(DEFAULT_PROGRESS_BAR_BATCH_SIZE, totalSteps / 50)),
+        statisticsBatchSize_(statisticsBatchSize),
         getSpeedDescription_(std::move(getSpeedDescription)),
         displayUpdateOptions_(displayUpdateOptions) {}
 

--- a/src/util/ProgressBar.h
+++ b/src/util/ProgressBar.h
@@ -189,14 +189,36 @@ class ProgressBar {
 // A class for the same general goal as `ProgressBar` above (reporting progress
 // of a long-running computation), but with two differences: (1) the total
 // number of steps is known in advance, and (2) the computation is done by
-// several threads that concurrently report their progress.
+// several threads that concurrently report their progress. Unlike for
+// `ProgressBar`, the counter therefore lives inside the class, and the class
+// writes its output (timestamped lines) to the given stream itself.
+//
+// Typical usage:
+//
+// ad_utility::ConcurrentProgressBar progressBar(
+//     std::cout, "Triples processed: ", numTriplesTotal);
+// std::vector<std::thread> threads;
+// for (size_t i = 0; i < numThreads; ++i) {
+//   threads.emplace_back([&]() {
+//     while (...) {
+//       // Code that processes one chunk of triples.
+//       progressBar.add(chunk.size());
+//     }
+//   });
+// }
+// for (auto& thread : threads) {
+//   thread.join();
+// }
+// progressBar.finish();
 class ConcurrentProgressBar {
  public:
-  // Construct with the output stream, a prefix for each line (e.g. "Words
-  // written: "), and the total number of steps. A `batchSize` of `0` (the
-  // default) means: choose automatically, namely such that about 50 lines
-  // are written per phase, but at least every
-  // `DEFAULT_PROGRESS_BAR_BATCH_SIZE` steps.
+  // Create and initialize a concurrent progress bar that writes its progress
+  // lines to `out`.
+  //
+  // NOTE: A `batchSize` of `0` (the default) means that the batch size is
+  // chosen automatically, namely such that about 50 lines are written in
+  // total, but at least one line every `DEFAULT_PROGRESS_BAR_BATCH_SIZE`
+  // steps.
   ConcurrentProgressBar(std::ostream& out, std::string prefix,
                         size_t totalSteps, size_t batchSize = 0)
       : out_{out},
@@ -207,9 +229,10 @@ class ConcurrentProgressBar {
                                              totalSteps / 50)},
         nextPrintAt_{batchSize_} {}
 
-  // Report `numSteps` newly processed steps. Threadsafe. NOTE: this takes a
-  // lock, so callers in hot loops should accumulate steps locally and report
-  // them in batches.
+  // Call this whenever one or more units have been processed. Threadsafe.
+  //
+  // IMPORTANT: Each call takes a lock, so callers in hot loops should
+  // accumulate steps locally and report them in larger batches.
   void add(size_t numSteps) {
     std::lock_guard lock{mutex_};
     processed_ += numSteps;
@@ -219,8 +242,9 @@ class ConcurrentProgressBar {
     }
   }
 
-  // Write a final line with the total number of processed steps (typically
-  // showing 100%), ended by a newline. Threadsafe.
+  // Write a final progress line with the total number of processed steps
+  // (typically showing 100%), ended by a newline instead of a carriage
+  // return. Should only be called once, after all threads have finished.
   void finish() {
     std::lock_guard lock{mutex_};
     print(true);
@@ -255,13 +279,22 @@ class ConcurrentProgressBar {
          << std::flush;
   }
 
+  // The stream to which the progress lines are written (e.g., the log file
+  // of a runtime index rebuild).
   std::ostream& out_;
+  // The first part of each progress line (e.g., "Triples processed: ").
   std::string prefix_;
+  // The total number of steps, known in advance.
   size_t totalSteps_;
+  // Write a progress line every this many steps.
   size_t batchSize_;
+  // Write the next progress line when this many steps have been processed.
   size_t nextPrintAt_;
+  // The total number of units that have been processed so far.
   size_t processed_ = 0;
+  // Timer that is started as soon as this progress bar is created.
   Timer timer_{Timer::Started};
+  // Mutex that protects the counters above as well as the writes to `out_`.
   std::mutex mutex_;
   // The width of the widest line printed so far, used to pad shorter lines,
   // see `print`.

--- a/src/util/ProgressBar.h
+++ b/src/util/ProgressBar.h
@@ -8,9 +8,13 @@
 #include <absl/strings/str_cat.h>
 #include <absl/strings/str_format.h>
 
+#include <algorithm>
+#include <mutex>
+#include <ostream>
 #include <string>
 
 #include "util/Exception.h"
+#include "util/Log.h"
 #include "util/StringUtils.h"
 #include "util/Timer.h"
 
@@ -180,6 +184,92 @@ class ProgressBar {
   Timer::Duration minBatchDuration_ = Timer::Duration::max();
   // Duration of slowest batch.
   Timer::Duration maxBatchDuration_ = Timer::Duration::min();
+};
+
+// Thread-safe progress reporting for a phase of a computation whose total
+// number of steps is known in advance. Several threads concurrently report
+// their processed steps via `add`; roughly every `batchSize` steps, a line
+// with the number of processed steps, the percentage of the total, and the
+// average speed is written to the given output stream. This is a sibling of
+// `ProgressBar` above for the case where the total is known in advance,
+// several threads contribute, and the output goes to a dedicated stream
+// (e.g. the log file of a runtime index rebuild).
+class ConcurrentProgress {
+ public:
+  // Construct with the output stream, a prefix for each line (e.g. "Words
+  // written: "), and the total number of steps. A `batchSize` of `0` (the
+  // default) means: choose automatically, namely such that about 50 lines
+  // are written per phase, but at least every
+  // `DEFAULT_PROGRESS_BAR_BATCH_SIZE` steps.
+  ConcurrentProgress(std::ostream& out, std::string prefix, size_t totalSteps,
+                     size_t batchSize = 0)
+      : out_{out},
+        prefix_{std::move(prefix)},
+        totalSteps_{totalSteps},
+        batchSize_{batchSize != 0 ? batchSize
+                                  : std::max(DEFAULT_PROGRESS_BAR_BATCH_SIZE,
+                                             totalSteps / 50)},
+        nextPrintAt_{batchSize_} {}
+
+  // Report `numSteps` newly processed steps. Threadsafe. NOTE: this takes a
+  // lock, so callers in hot loops should accumulate steps locally and report
+  // them in batches.
+  void add(size_t numSteps) {
+    std::lock_guard lock{mutex_};
+    processed_ += numSteps;
+    if (processed_ >= nextPrintAt_) {
+      nextPrintAt_ = (processed_ / batchSize_ + 1) * batchSize_;
+      print(false);
+    }
+  }
+
+  // Write a final line with the total number of processed steps (typically
+  // showing 100%), ended by a newline. Threadsafe.
+  void finish() {
+    std::lock_guard lock{mutex_};
+    print(true);
+  }
+
+ private:
+  // Write one progress line; requires that `mutex_` is held. Like
+  // `ProgressBar` with `ReuseLine`, intermediate updates end with `\r`, so
+  // that a viewer of the stream shows them on one line that updates in
+  // place; only the final line ends with `\n`. When a line is shorter than
+  // its predecessor (e.g. because the average speed dropped by a digit), it
+  // is padded with spaces to the widest line so far, so that the `\r`
+  // overwrites all of it and no leftover characters remain.
+  void print(bool final) {
+    double seconds = static_cast<double>(timer_.msecs().count()) / 1000.0;
+    // A phase with a total of zero steps is trivially complete.
+    double percentage =
+        totalSteps_ == 0
+            ? 100.0
+            : std::min(100.0, 100.0 * static_cast<double>(processed_) /
+                                  static_cast<double>(totalSteps_));
+    std::string line = absl::StrCat(
+        prefix_, insertThousandSeparator(std::to_string(processed_), ','),
+        " of ", insertThousandSeparator(std::to_string(totalSteps_), ','),
+        absl::StrFormat(" (%.1f%%)", percentage), " [average speed ",
+        DEFAULT_SPEED_DESCRIPTION_FUNCTION(static_cast<double>(processed_) /
+                                           std::max(seconds, 0.001)),
+        "]");
+    maxLineWidth_ = std::max(maxLineWidth_, line.size());
+    line.resize(maxLineWidth_, ' ');
+    out_ << Log::getTimeStamp() << " - INFO: " << line << (final ? "\n" : "\r")
+         << std::flush;
+  }
+
+  std::ostream& out_;
+  std::string prefix_;
+  size_t totalSteps_;
+  size_t batchSize_;
+  size_t nextPrintAt_;
+  size_t processed_ = 0;
+  Timer timer_{Timer::Started};
+  std::mutex mutex_;
+  // The width of the widest line printed so far, used to pad shorter lines,
+  // see `print`.
+  size_t maxLineWidth_ = 0;
 };
 
 }  // namespace ad_utility

--- a/src/util/ProgressBar.h
+++ b/src/util/ProgressBar.h
@@ -284,7 +284,11 @@ class ConcurrentProgressBar {
         return std::nullopt;
       }
       // This thread claims the display; other threads get `std::nullopt`
-      // until the next multiple of the batch size is reached.
+      // until the next multiple of the batch size is reached. Rounding UP to
+      // the next multiple (instead of adding the batch size) matters when a
+      // single bulk `add` jumps over several batch boundaries: exactly one
+      // thread wins, and the next display is due one batch size after the
+      // current count, not several displays in a row for long-passed counts.
       updateWhenThisManyStepsProcessed_ =
           (numStepsProcessed_ / statisticsBatchSize_ + 1) *
           statisticsBatchSize_;
@@ -318,7 +322,7 @@ class ConcurrentProgressBar {
   // than its predecessor (e.g., because the average speed dropped by a
   // digit), it is padded with spaces to the widest string so far, so that
   // the `\r` overwrites all of it and no leftover characters remain.
-  std::string getProgressStringImpl(bool final) {
+  std::string getProgressStringImpl(bool isFinal) {
     size_t numStepsProcessed;
     {
       std::lock_guard lock{countMutex_};
@@ -342,7 +346,7 @@ class ConcurrentProgressBar {
       maxStringWidth_ = std::max(maxStringWidth_, progressString.size());
       progressString.resize(maxStringWidth_, ' ');
     }
-    return absl::StrCat(progressString, reuseLine && !final ? "\r" : "\n");
+    return absl::StrCat(progressString, reuseLine && !isFinal ? "\r" : "\n");
   }
 
   // The first part of the display string (e.g., "Triples processed: ").

--- a/src/util/ProgressBar.h
+++ b/src/util/ProgressBar.h
@@ -194,14 +194,14 @@ class ProgressBar {
 // `ProgressBar` above for the case where the total is known in advance,
 // several threads contribute, and the output goes to a dedicated stream
 // (e.g. the log file of a runtime index rebuild).
-class ConcurrentProgress {
+class ConcurrentProgressBar {
  public:
   // Construct with the output stream, a prefix for each line (e.g. "Words
   // written: "), and the total number of steps. A `batchSize` of `0` (the
   // default) means: choose automatically, namely such that about 50 lines
   // are written per phase, but at least every
   // `DEFAULT_PROGRESS_BAR_BATCH_SIZE` steps.
-  ConcurrentProgress(std::ostream& out, std::string prefix, size_t totalSteps,
+  ConcurrentProgressBar(std::ostream& out, std::string prefix, size_t totalSteps,
                      size_t batchSize = 0)
       : out_{out},
         prefix_{std::move(prefix)},

--- a/src/util/ProgressBar.h
+++ b/src/util/ProgressBar.h
@@ -239,7 +239,7 @@ class ConcurrentProgress {
   // is padded with spaces to the widest line so far, so that the `\r`
   // overwrites all of it and no leftover characters remain.
   void print(bool final) {
-    double seconds = static_cast<double>(timer_.msecs().count()) / 1000.0;
+    double seconds = Timer::toSeconds(timer_.value());
     // A phase with a total of zero steps is trivially complete.
     double percentage =
         totalSteps_ == 0

--- a/test/ProgressBarTest.cpp
+++ b/test/ProgressBarTest.cpp
@@ -2,10 +2,14 @@
 // Chair of Algorithms and Data Structures
 // Author: Hannah Bast <bast@cs.uni-freiburg.de>
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <chrono>
+#include <sstream>
 #include <thread>
+#include <vector>
 
 #include "../test/util/GTestHelpers.h"
 #include "util/ProgressBar.h"
@@ -93,4 +97,73 @@ TEST(ProgressBar, getTimer) {
 #endif
   ASSERT_THAT(progressBar.getFinalProgressString(),
               MatchesRegex(expectedUpdateRegex));
+}
+
+// _____________________________________________________________________________
+// Tests for `ConcurrentProgress`, see `ProgressBar.h`.
+
+// Single-threaded: lines are printed when the batch size is crossed, with the
+// correct counts and percentages; intermediate lines end with `\r`, only the
+// final line with `\n`.
+TEST(ConcurrentProgress, singleThreaded) {
+  std::ostringstream out;
+  ad_utility::ConcurrentProgress progress{out, "Steps: ", 100, 10};
+  progress.add(5);
+  EXPECT_TRUE(out.str().empty());
+  progress.add(5);
+  progress.add(90);
+  progress.finish();
+  std::string s = out.str();
+  EXPECT_THAT(s, ::testing::HasSubstr("Steps: 10 of 100 (10.0%)"));
+  EXPECT_THAT(s, ::testing::HasSubstr("Steps: 100 of 100 (100.0%)"));
+  EXPECT_EQ(std::count(s.begin(), s.end(), '\r'), 2);
+  EXPECT_EQ(std::count(s.begin(), s.end(), '\n'), 1);
+  EXPECT_EQ(s.back(), '\n');
+}
+
+// A phase with a total of zero steps is reported as trivially complete.
+TEST(ConcurrentProgress, zeroTotalIsComplete) {
+  std::ostringstream out;
+  ad_utility::ConcurrentProgress progress{out, "Steps: ", 0};
+  progress.finish();
+  EXPECT_THAT(out.str(), ::testing::HasSubstr("Steps: 0 of 0 (100.0%)"));
+}
+
+// Concurrent `add` calls from several threads are summed up correctly.
+TEST(ConcurrentProgress, concurrentAdds) {
+  std::ostringstream out;
+  // Batch size larger than the total, so only `finish` prints.
+  ad_utility::ConcurrentProgress progress{out, "Steps: ", 1000, 100'000};
+  std::vector<std::thread> threads;
+  for (size_t i = 0; i < 4; ++i) {
+    threads.emplace_back([&progress]() {
+      for (size_t j = 0; j < 250; ++j) {
+        progress.add(1);
+      }
+    });
+  }
+  for (auto& thread : threads) {
+    thread.join();
+  }
+  progress.finish();
+  EXPECT_THAT(out.str(),
+              ::testing::HasSubstr("Steps: 1,000 of 1,000 (100.0%)"));
+}
+
+// A line that is shorter than its predecessor is padded with spaces, so that
+// the `\r` overwrites all leftover characters of the previous line.
+TEST(ConcurrentProgress, shorterLinesArePadded) {
+  std::ostringstream out;
+  // The line for 1,000 of 1,000,000 is longer than the final line would
+  // naturally be for the prefix and count alone, so the final line must be
+  // padded to at least the same width.
+  ad_utility::ConcurrentProgress progress{out, "Steps: ", 1'000'000, 1'000};
+  progress.add(1'000);
+  progress.finish();
+  std::string s = out.str();
+  size_t carriageReturn = s.find('\r');
+  ASSERT_NE(carriageReturn, std::string::npos);
+  size_t newline = s.find('\n');
+  ASSERT_NE(newline, std::string::npos);
+  EXPECT_GE(newline - carriageReturn - 1, carriageReturn);
 }

--- a/test/ProgressBarTest.cpp
+++ b/test/ProgressBarTest.cpp
@@ -100,14 +100,14 @@ TEST(ProgressBar, getTimer) {
 }
 
 // _____________________________________________________________________________
-// Tests for `ConcurrentProgress`, see `ProgressBar.h`.
+// Tests for `ConcurrentProgressBar`, see `ProgressBar.h`.
 
 // Single-threaded: lines are printed when the batch size is crossed, with the
 // correct counts and percentages; intermediate lines end with `\r`, only the
 // final line with `\n`.
-TEST(ConcurrentProgress, singleThreaded) {
+TEST(ConcurrentProgressBar, singleThreaded) {
   std::ostringstream out;
-  ad_utility::ConcurrentProgress progress{out, "Steps: ", 100, 10};
+  ad_utility::ConcurrentProgressBar progress{out, "Steps: ", 100, 10};
   progress.add(5);
   EXPECT_TRUE(out.str().empty());
   progress.add(5);
@@ -122,18 +122,18 @@ TEST(ConcurrentProgress, singleThreaded) {
 }
 
 // A phase with a total of zero steps is reported as trivially complete.
-TEST(ConcurrentProgress, zeroTotalIsComplete) {
+TEST(ConcurrentProgressBar, zeroTotalIsComplete) {
   std::ostringstream out;
-  ad_utility::ConcurrentProgress progress{out, "Steps: ", 0};
+  ad_utility::ConcurrentProgressBar progress{out, "Steps: ", 0};
   progress.finish();
   EXPECT_THAT(out.str(), ::testing::HasSubstr("Steps: 0 of 0 (100.0%)"));
 }
 
 // Concurrent `add` calls from several threads are summed up correctly.
-TEST(ConcurrentProgress, concurrentAdds) {
+TEST(ConcurrentProgressBar, concurrentAdds) {
   std::ostringstream out;
   // Batch size larger than the total, so only `finish` prints.
-  ad_utility::ConcurrentProgress progress{out, "Steps: ", 1000, 100'000};
+  ad_utility::ConcurrentProgressBar progress{out, "Steps: ", 1000, 100'000};
   std::vector<std::thread> threads;
   for (size_t i = 0; i < 4; ++i) {
     threads.emplace_back([&progress]() {
@@ -152,12 +152,12 @@ TEST(ConcurrentProgress, concurrentAdds) {
 
 // A line that is shorter than its predecessor is padded with spaces, so that
 // the `\r` overwrites all leftover characters of the previous line.
-TEST(ConcurrentProgress, shorterLinesArePadded) {
+TEST(ConcurrentProgressBar, shorterLinesArePadded) {
   std::ostringstream out;
   // The line for 1,000 of 1,000,000 is longer than the final line would
   // naturally be for the prefix and count alone, so the final line must be
   // padded to at least the same width.
-  ad_utility::ConcurrentProgress progress{out, "Steps: ", 1'000'000, 1'000};
+  ad_utility::ConcurrentProgressBar progress{out, "Steps: ", 1'000'000, 1'000};
   progress.add(1'000);
   progress.finish();
   std::string s = out.str();

--- a/test/ProgressBarTest.cpp
+++ b/test/ProgressBarTest.cpp
@@ -126,7 +126,7 @@ TEST(ConcurrentProgressBar, singleThreaded) {
     out << update->getProgressString();
   }
   out << progressBar.getFinalProgressString();
-  std::string s = out.str();
+  std::string s = std::move(out).str();
   EXPECT_THAT(s, ::testing::HasSubstr("Steps: 10 of 100 (10.0%)"));
   EXPECT_THAT(s, ::testing::HasSubstr("Steps: 100 of 100 (100.0%)"));
   EXPECT_EQ(std::count(s.begin(), s.end(), '\r'), 2);
@@ -146,12 +146,14 @@ TEST(ConcurrentProgressBar, zeroTotalIsComplete) {
 // shared stream, and the displayed counts never decrease.
 TEST(ConcurrentProgressBar, concurrentAddsAndUpdates) {
   std::ostringstream out;
-  ad_utility::ConcurrentProgressBar progressBar{"Steps: ", 1000, 100};
+  ad_utility::ConcurrentProgressBar progressBar{"Steps: ", 3000, 100};
   std::vector<std::thread> threads;
   for (size_t i = 0; i < 4; ++i) {
     threads.emplace_back([&progressBar, &out]() {
+      // Varying step sizes (cycling through 1..5, 750 steps per thread in
+      // total), so that single `add` calls also jump over batch boundaries.
       for (size_t j = 0; j < 250; ++j) {
-        progressBar.add(1);
+        progressBar.add(j % 5 + 1);
         if (auto update = progressBar.update()) {
           out << update->getProgressString();
         }
@@ -162,8 +164,8 @@ TEST(ConcurrentProgressBar, concurrentAddsAndUpdates) {
     thread.join();
   }
   out << progressBar.getFinalProgressString();
-  std::string s = out.str();
-  EXPECT_THAT(s, ::testing::HasSubstr("Steps: 1,000 of 1,000 (100.0%)"));
+  std::string s = std::move(out).str();
+  EXPECT_THAT(s, ::testing::HasSubstr("Steps: 3,000 of 3,000 (100.0%)"));
   // Every progress string is intact (in particular, not interleaved with
   // another one), and the displayed counts never decrease.
   size_t previousCount = 0;

--- a/test/ProgressBarTest.cpp
+++ b/test/ProgressBarTest.cpp
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <chrono>
 #include <sstream>
+#include <string_view>
 #include <thread>
 #include <vector>
 
@@ -102,17 +103,30 @@ TEST(ProgressBar, getTimer) {
 // _____________________________________________________________________________
 // Tests for `ConcurrentProgressBar`, see `ProgressBar.h`.
 
-// Single-threaded: lines are printed when the batch size is crossed, with the
-// correct counts and percentages; intermediate lines end with `\r`, only the
-// final line with `\n`.
+// Single-threaded: an `Update` is returned exactly when the batch size is
+// crossed, with the correct counts and percentages; intermediate progress
+// strings end with `\r`, only the final one with `\n`.
 TEST(ConcurrentProgressBar, singleThreaded) {
   std::ostringstream out;
-  ad_utility::ConcurrentProgressBar progress{out, "Steps: ", 100, 10};
-  progress.add(5);
-  EXPECT_TRUE(out.str().empty());
-  progress.add(5);
-  progress.add(90);
-  progress.finish();
+  ad_utility::ConcurrentProgressBar progressBar{"Steps: ", 100, 10};
+  progressBar.add(5);
+  EXPECT_FALSE(progressBar.update().has_value());
+  progressBar.add(5);
+  {
+    auto update = progressBar.update();
+    ASSERT_TRUE(update.has_value());
+    out << update->getProgressString();
+  }
+  // The display for this batch has been claimed, so no further `Update` is
+  // returned before the next multiple of the batch size is reached.
+  EXPECT_FALSE(progressBar.update().has_value());
+  progressBar.add(90);
+  {
+    auto update = progressBar.update();
+    ASSERT_TRUE(update.has_value());
+    out << update->getProgressString();
+  }
+  out << progressBar.getFinalProgressString();
   std::string s = out.str();
   EXPECT_THAT(s, ::testing::HasSubstr("Steps: 10 of 100 (10.0%)"));
   EXPECT_THAT(s, ::testing::HasSubstr("Steps: 100 of 100 (100.0%)"));
@@ -121,49 +135,68 @@ TEST(ConcurrentProgressBar, singleThreaded) {
   EXPECT_EQ(s.back(), '\n');
 }
 
-// A phase with a total of zero steps is reported as trivially complete.
+// A computation with a total of zero steps is reported as trivially complete.
 TEST(ConcurrentProgressBar, zeroTotalIsComplete) {
-  std::ostringstream out;
-  ad_utility::ConcurrentProgressBar progress{out, "Steps: ", 0};
-  progress.finish();
-  EXPECT_THAT(out.str(), ::testing::HasSubstr("Steps: 0 of 0 (100.0%)"));
+  ad_utility::ConcurrentProgressBar progressBar{"Steps: ", 0};
+  EXPECT_THAT(progressBar.getFinalProgressString(),
+              ::testing::HasSubstr("Steps: 0 of 0 (100.0%)"));
 }
 
-// Concurrent `add` calls from several threads are summed up correctly.
-TEST(ConcurrentProgressBar, concurrentAdds) {
+// Concurrent `add` and `update` calls from several threads: the counts are
+// summed up correctly, the `Update` objects serialize the writes to the
+// shared stream, and the displayed counts never decrease.
+TEST(ConcurrentProgressBar, concurrentAddsAndUpdates) {
   std::ostringstream out;
-  // Batch size larger than the total, so only `finish` prints.
-  ad_utility::ConcurrentProgressBar progress{out, "Steps: ", 1000, 100'000};
+  ad_utility::ConcurrentProgressBar progressBar{"Steps: ", 1000, 100};
   std::vector<std::thread> threads;
   for (size_t i = 0; i < 4; ++i) {
-    threads.emplace_back([&progress]() {
+    threads.emplace_back([&progressBar, &out]() {
       for (size_t j = 0; j < 250; ++j) {
-        progress.add(1);
+        progressBar.add(1);
+        if (auto update = progressBar.update()) {
+          out << update->getProgressString();
+        }
       }
     });
   }
   for (auto& thread : threads) {
     thread.join();
   }
-  progress.finish();
-  EXPECT_THAT(out.str(),
-              ::testing::HasSubstr("Steps: 1,000 of 1,000 (100.0%)"));
+  out << progressBar.getFinalProgressString();
+  std::string s = out.str();
+  EXPECT_THAT(s, ::testing::HasSubstr("Steps: 1,000 of 1,000 (100.0%)"));
+  // Every progress string is intact (in particular, not interleaved with
+  // another one), and the displayed counts never decrease.
+  size_t previousCount = 0;
+  size_t numProgressStrings = 0;
+  for (std::string_view rest{s}; !rest.empty();) {
+    size_t lineEnd = rest.find_first_of("\r\n");
+    ASSERT_NE(lineEnd, std::string_view::npos);
+    std::string_view line = rest.substr(0, lineEnd);
+    rest.remove_prefix(lineEnd + 1);
+    if (line.empty()) {
+      continue;  // Padding of a `\r` string that was followed by another.
+    }
+    ASSERT_TRUE(line.starts_with("Steps: "));
+    std::string countString{line.substr(7, line.find(" of ") - 7)};
+    std::erase(countString, ',');
+    size_t count = std::stoul(countString);
+    EXPECT_GE(count, previousCount);
+    previousCount = count;
+    ++numProgressStrings;
+  }
+  EXPECT_GE(numProgressStrings, 2u);
 }
 
-// A line that is shorter than its predecessor is padded with spaces, so that
-// the `\r` overwrites all leftover characters of the previous line.
-TEST(ConcurrentProgressBar, shorterLinesArePadded) {
-  std::ostringstream out;
-  // The line for 1,000 of 1,000,000 is longer than the final line would
-  // naturally be for the prefix and count alone, so the final line must be
-  // padded to at least the same width.
-  ad_utility::ConcurrentProgressBar progress{out, "Steps: ", 1'000'000, 1'000};
-  progress.add(1'000);
-  progress.finish();
-  std::string s = out.str();
-  size_t carriageReturn = s.find('\r');
-  ASSERT_NE(carriageReturn, std::string::npos);
-  size_t newline = s.find('\n');
-  ASSERT_NE(newline, std::string::npos);
-  EXPECT_GE(newline - carriageReturn - 1, carriageReturn);
+// A progress string that is shorter than its predecessor is padded with
+// spaces, so that the `\r` overwrites all leftover characters.
+TEST(ConcurrentProgressBar, shorterStringsArePadded) {
+  ad_utility::ConcurrentProgressBar progressBar{"Steps: ", 1'000'000, 1'000};
+  progressBar.add(1'000);
+  auto update = progressBar.update();
+  ASSERT_TRUE(update.has_value());
+  size_t firstWidth = update->getProgressString().size();
+  update.reset();
+  std::string finalString = progressBar.getFinalProgressString();
+  EXPECT_GE(finalString.size(), firstWidth);
 }

--- a/test/ProgressBarTest.cpp
+++ b/test/ProgressBarTest.cpp
@@ -199,3 +199,10 @@ TEST(ConcurrentProgressBar, shorterStringsArePadded) {
   std::string finalString = progressBar.getFinalProgressString();
   EXPECT_GE(finalString.size(), firstWidth);
 }
+
+// A batch size of zero is rejected (`update()` divides by it).
+TEST(ConcurrentProgressBar, zeroBatchSizeIsRejected) {
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      ad_utility::ConcurrentProgressBar("Steps: ", 100, 0),
+      ::testing::HasSubstr("must not be zero"));
+}

--- a/test/ProgressBarTest.cpp
+++ b/test/ProgressBarTest.cpp
@@ -206,3 +206,28 @@ TEST(ConcurrentProgressBar, zeroBatchSizeIsRejected) {
       ad_utility::ConcurrentProgressBar("Steps: ", 100, 0),
       ::testing::HasSubstr("must not be zero"));
 }
+
+// With `UseNewLine`, every progress string ends with `\n` (and no padding is
+// needed).
+TEST(ConcurrentProgressBar, useNewLine) {
+  ad_utility::ConcurrentProgressBar progressBar{
+      "Steps: ", 100, 10, DEFAULT_SPEED_DESCRIPTION_FUNCTION,
+      ad_utility::ProgressBar::UseNewLine};
+  progressBar.add(10);
+  auto update = progressBar.update();
+  ASSERT_TRUE(update.has_value());
+  EXPECT_THAT(update->getProgressString(),
+              ::testing::HasSubstr("Steps: 10 of 100"));
+  EXPECT_EQ(update->getProgressString().back(), '\n');
+  update.reset();
+  EXPECT_EQ(progressBar.getFinalProgressString().back(), '\n');
+}
+
+// The final progress string may only be requested once.
+TEST(ConcurrentProgressBar, getFinalProgressStringOnlyOnce) {
+  ad_utility::ConcurrentProgressBar progressBar{"Steps: ", 10};
+  progressBar.getFinalProgressString();
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      progressBar.getFinalProgressString(),
+      ::testing::HasSubstr("should only be called once"));
+}

--- a/test/ProgressBarTest.cpp
+++ b/test/ProgressBarTest.cpp
@@ -100,7 +100,6 @@ TEST(ProgressBar, getTimer) {
               MatchesRegex(expectedUpdateRegex));
 }
 
-// _____________________________________________________________________________
 // Tests for `ConcurrentProgressBar`, see `ProgressBar.h`.
 
 // Single-threaded: an `Update` is returned exactly when the batch size is

--- a/test/index/IndexRebuilderTest.cpp
+++ b/test/index/IndexRebuilderTest.cpp
@@ -5,6 +5,7 @@
 //  UFR = University of Freiburg, Chair of Algorithms and Data Structures
 
 #include <absl/strings/str_cat.h>
+#include <absl/strings/str_format.h>
 #include <absl/time/time.h>
 #include <gmock/gmock.h>
 
@@ -13,9 +14,11 @@
 #include <boost/asio/detached.hpp>
 #include <boost/asio/thread_pool.hpp>
 #include <boost/asio/use_future.hpp>
+#include <deque>
 #include <fstream>
 #include <future>
 #include <iterator>
+#include <numeric>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -202,6 +205,51 @@ TEST(IndexRebuilder, materializeLocalVocab) {
   EXPECT_EQ(newVocab[VocabIndex::make(14)], "<k>");
   EXPECT_EQ(newVocab[VocabIndex::make(15)], "<l>");
   EXPECT_EQ(newVocab[VocabIndex::make(16)], "<m>");
+}
+
+// _____________________________________________________________________________
+// With more words than the progress batch size, the progress callback is
+// called once per full batch plus once for the remainder, and the reported
+// numbers add up to the total number of written words.
+TEST(IndexRebuilder, materializeLocalVocabProgressBatches) {
+  // Must match `PROGRESS_REPORTING_BATCH_SIZE` in `IndexRebuilder.cpp`.
+  constexpr size_t batchSize = 65'536;
+  constexpr size_t numEntries = batchSize + 1'000;
+
+  auto type = ad_utility::VocabularyType::random();
+  ad_utility::testing::TestIndexConfig config{"<a> <c> <e> . <g> <i> <k> ."};
+  config.vocabularyType = type;
+  auto oldIndex = ad_utility::testing::makeTestIndex(
+      "materializeLocalVocabProgressBatches", std::move(config));
+  std::string vocabPrefix = gtestCurrentTestName();
+  absl::Cleanup removeVocabFiles{[&vocabPrefix, &type] {
+    deleteVocabFiles(vocabPrefix + VOCAB_SUFFIX, type.value());
+  }};
+
+  // A `deque` is used for stable addresses, because `materializeLocalVocab`
+  // takes pointers to the entries.
+  std::deque<LocalVocabEntry> entryStorage;
+  std::vector<LocalVocabIndex> entries;
+  for (size_t i = 0; i < numEntries; ++i) {
+    entryStorage.emplace_back(
+        ad_utility::testing::iri(absl::StrFormat("<z%06d>", i)),
+        oldIndex.getLocalVocabContext());
+    entries.push_back(&entryStorage.back());
+  }
+
+  std::vector<size_t> reportedBatches;
+  auto [insertionPositions, localVocabMapping] =
+      materializeLocalVocab(entries, oldIndex.getVocab(), vocabPrefix,
+                            [&reportedBatches](size_t numWords) {
+                              reportedBatches.push_back(numWords);
+                            });
+  EXPECT_EQ(insertionPositions.size(), numEntries);
+  EXPECT_EQ(localVocabMapping.size(), numEntries);
+  ASSERT_GE(reportedBatches.size(), 2u);
+  EXPECT_EQ(reportedBatches.front(), batchSize);
+  EXPECT_EQ(std::accumulate(reportedBatches.begin(), reportedBatches.end(),
+                            size_t{0}),
+            oldIndex.getVocab().size() + numEntries);
 }
 
 // _____________________________________________________________________________
@@ -570,12 +618,29 @@ TEST(IndexRebuilder, materializeToIndex) {
                                blankNodes, cancellationHandle, logFile);
     EXPECT_TRUE(ql::filesystem::exists(logFile));
 
-    // Each phase writes at least its final progress line (with a percentage
-    // and an average speed) to the rebuild's log file.
+    // Each phase writes its header (which says what is being processed,
+    // depending on which permutations the index has) and at least its final
+    // progress line (with a percentage and an average speed) to the rebuild's
+    // log file.
     {
       std::ifstream logStream{logFile};
       std::string logContent{std::istreambuf_iterator<char>{logStream}, {}};
       using ::testing::HasSubstr;
+      EXPECT_THAT(logContent, HasSubstr("Writing new vocabulary (merging "
+                                        "existing and new words) ..."));
+      EXPECT_THAT(
+          logContent,
+          HasSubstr(loadAllPermutations
+                        ? "Recomputing statistics (from 4 permutations, 3 "
+                          "normal and 1 internal) ..."
+                        : "Recomputing statistics (from 2 permutations, 1 "
+                          "normal and 1 internal) ..."));
+      EXPECT_THAT(logContent,
+                  HasSubstr(loadAllPermutations
+                                ? "Writing new index (8 permutations, 6 "
+                                  "normal and 2 internal) ..."
+                                : "Writing new index (4 permutations, 2 "
+                                  "normal and 2 internal) ..."));
       EXPECT_THAT(logContent, HasSubstr("Words written: "));
       EXPECT_THAT(logContent, HasSubstr("Triples counted: "));
       EXPECT_THAT(logContent, HasSubstr("Triples written: "));

--- a/test/index/IndexRebuilderTest.cpp
+++ b/test/index/IndexRebuilderTest.cpp
@@ -211,7 +211,8 @@ TEST(IndexRebuilder, materializeLocalVocab) {
 // called once per full batch plus once for the remainder, and the reported
 // numbers add up to the total number of written words.
 TEST(IndexRebuilder, materializeLocalVocabProgressBatches) {
-  // Must match `PROGRESS_REPORTING_BATCH_SIZE` in `IndexRebuilder.cpp`.
+  // Must match the reporting batch size in `mergeVocabs` in
+  // `IndexRebuilder.cpp`.
   constexpr size_t batchSize = 65'536;
   constexpr size_t numEntries = batchSize + 1'000;
 

--- a/test/index/IndexRebuilderTest.cpp
+++ b/test/index/IndexRebuilderTest.cpp
@@ -13,7 +13,9 @@
 #include <boost/asio/detached.hpp>
 #include <boost/asio/thread_pool.hpp>
 #include <boost/asio/use_future.hpp>
+#include <fstream>
 #include <future>
+#include <iterator>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -567,6 +569,19 @@ TEST(IndexRebuilder, materializeToIndex) {
     qlever::materializeToIndex(index.getImpl(), newIndexName, state, vocab,
                                blankNodes, cancellationHandle, logFile);
     EXPECT_TRUE(ql::filesystem::exists(logFile));
+
+    // Each phase writes at least its final progress line (with a percentage
+    // and an average speed) to the rebuild's log file.
+    {
+      std::ifstream logStream{logFile};
+      std::string logContent{std::istreambuf_iterator<char>{logStream}, {}};
+      using ::testing::HasSubstr;
+      EXPECT_THAT(logContent, HasSubstr("Words written: "));
+      EXPECT_THAT(logContent, HasSubstr("Triples counted: "));
+      EXPECT_THAT(logContent, HasSubstr("Triples written: "));
+      EXPECT_THAT(logContent, HasSubstr("(100.0%)"));
+      EXPECT_THAT(logContent, HasSubstr("[average speed "));
+    }
 
     IndexImpl newIndex{ad_utility::makeUnlimitedAllocator<Id>()};
     newIndex.usePatterns() = usePatterns;

--- a/test/index/IndexRebuilderTest.cpp
+++ b/test/index/IndexRebuilderTest.cpp
@@ -207,7 +207,6 @@ TEST(IndexRebuilder, materializeLocalVocab) {
   EXPECT_EQ(newVocab[VocabIndex::make(16)], "<m>");
 }
 
-// _____________________________________________________________________________
 // With more words than the progress batch size, the progress callback is
 // called once per full batch plus once for the remainder, and the reported
 // numbers add up to the total number of written words.

--- a/test/index/IndexRebuilderTest.cpp
+++ b/test/index/IndexRebuilderTest.cpp
@@ -39,6 +39,7 @@
 #include "index/IndexRebuilderImpl.h"
 #include "index/TripleComponentConversions.h"
 #include "index/vocabulary/VocabularyType.h"
+#include "util/File.h"
 #include "util/FilesystemHelpers.h"
 #include "util/SourceLocation.h"
 
@@ -220,7 +221,7 @@ TEST(IndexRebuilder, materializeLocalVocabProgressBatches) {
   ad_utility::testing::TestIndexConfig config{"<a> <c> <e> . <g> <i> <k> ."};
   config.vocabularyType = type;
   auto oldIndex = ad_utility::testing::makeTestIndex(
-      "materializeLocalVocabProgressBatches", std::move(config));
+      gtestCurrentTestName() + "-index", std::move(config));
   std::string vocabPrefix = gtestCurrentTestName();
   absl::Cleanup removeVocabFiles{[&vocabPrefix, &type] {
     deleteVocabFiles(vocabPrefix + VOCAB_SUFFIX, type.value());
@@ -623,7 +624,7 @@ TEST(IndexRebuilder, materializeToIndex) {
     // progress line (with a percentage and an average speed) to the rebuild's
     // log file.
     {
-      std::ifstream logStream{logFile};
+      auto logStream = ad_utility::makeIfstream(logFile);
       std::string logContent{std::istreambuf_iterator<char>{logStream}, {}};
       using ::testing::HasSubstr;
       EXPECT_THAT(logContent, HasSubstr("Writing new vocabulary (merging "


### PR DESCRIPTION
So far, the log file of a runtime index rebuild (`cmd=rebuild-index`) only recorded the start of each phase (vocabulary, statistics, permutations). Each phase now writes progress lines in the style of the progress bar of the normal index build, for example `Triples written: 35,404,000,000 of 141,616,445,040 (25.0%) [average speed 98.3 M/s]`. The totals of all three phases are known in advance, so the lines also contain a percentage. This makes it easy to see how far along a rebuild is, in particular when following the log via `qlever rebuild-index`. The header line of each phase now also says in parentheses what exactly is being processed, for example, `Writing new index (8 permutations, 6 normal and 2 internal) ...`, so that the totals of the progress lines are self-explanatory.

This requires a new class `ConcurrentProgressBar`, which aggregates the processed steps over the concurrent workers of a phase in a mutex-protected counter. It is a sibling of `ProgressBar` in the same header and with an analogous interface. Like for `ProgressBar`, the writing of the progress lines is left to the caller: `update()` returns a lock-holding `Update` object with the progress string, so that the output of concurrent updates can neither interleave nor overtake each other. The phases report their progress via plain callbacks, so the signatures of `materializeLocalVocab`, `recomputeStatistics`, and `createPermutationWriterTask` only gain an optional `std::function` parameter.

NOTE: This does not slow down the `rebuild-index` in a measureable way. The progress counters are updated infrequently, and there are only 50 updates to the progress line per phase.