### PR TITLE
Update the `qlever.index.load_time` metric after a `rebuild-index`

### DIFF
--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -1696,6 +1696,10 @@ Awaitable<qlever::IndexRebuildConfig> Server::rebuildIndex(
         oldManager.retireOnDiskFiles();
         qlever().swapInRebuiltIndex(index, std::move(rebuildResult), handle,
                                     config);
+        auto now = std::chrono::duration_cast<std::chrono::seconds>(
+                       std::chrono::system_clock::now().time_since_epoch())
+                       .count();
+        metrics_->indexLoadMetric_->Record(now);
       },
       net::use_awaitable);
   co_await std::move(swapRoutine);


### PR DESCRIPTION
The metric `qlever.index.load_time` (the Unix timestamp when the current index was loaded) was set only once, when the server starts. After a `rebuild-index`, the server swaps in a newly built index, but the metric kept reporting the load time of the old index. With this change, the metric is updated right after the new index has been swapped in. A failed rebuild (which does not swap) leaves it untouched.