### PR TITLE
Automatically rebuild the index when there are many delta triples

### DIFF
--- a/src/ServerMain.cpp
+++ b/src/ServerMain.cpp
@@ -58,7 +58,7 @@ int main(int argc, char** argv) {
   bool noMetricsLog = false;
   bool noResourceUsageLog = false;
   uint32_t resourceUsageIntervalS = 2;
-  std::string rebuildIndexStrategy = "manual";
+  std::string rebuildIndexStrategy;
 
   ad_utility::ParameterToProgramOptionFactory optionFactory{
       &globalRuntimeParameters};

--- a/src/ServerMain.cpp
+++ b/src/ServerMain.cpp
@@ -58,6 +58,7 @@ int main(int argc, char** argv) {
   bool noMetricsLog = false;
   bool noResourceUsageLog = false;
   uint32_t resourceUsageIntervalS = 2;
+  std::string rebuildIndexStrategy = "manual";
 
   ad_utility::ParameterToProgramOptionFactory optionFactory{
       &globalRuntimeParameters};
@@ -163,6 +164,14 @@ int main(int argc, char** argv) {
   add("persist-updates", po::bool_switch(&config.persistUpdates_),
       "If set, then SPARQL UPDATES will be persisted on disk. Otherwise they "
       "will be lost when the engine is stopped");
+  add("rebuild-index-strategy",
+      po::value<std::string>(&rebuildIndexStrategy)->default_value("manual"),
+      "When to rebuild the index from the current data (including updates). "
+      "\"manual\" (the default): only when explicitly requested via the "
+      "`cmd=rebuild-index` HTTP request. A non-negative number: additionally "
+      "trigger a rebuild automatically in the background whenever the number "
+      "of delta triples (inserted plus deleted) after an update exceeds that "
+      "number.");
   add("syntax-test-mode",
       optionFactory.getProgramOption<&RuntimeParameters::syntaxTestMode_>(),
       "Make several query patterns that are syntactially valid, but otherwise "
@@ -293,6 +302,23 @@ int main(int argc, char** argv) {
       return EXIT_FAILURE;
     }
     AD_LOG_INFO << "Runtime parameter set from the command line: " << assignment
+                << std::endl;
+  }
+
+  // Resolve the `--rebuild-index-strategy` option. A bad value fails the
+  // startup with a readable message, before the index is loaded.
+  try {
+    config.rebuildIndexDeltaTriplesThreshold_ =
+        Server::parseRebuildIndexStrategy(rebuildIndexStrategy);
+  } catch (const std::exception& e) {
+    AD_LOG_ERROR << "Invalid argument to --rebuild-index-strategy: " << e.what()
+                 << std::endl;
+    return EXIT_FAILURE;
+  }
+  if (config.rebuildIndexDeltaTriplesThreshold_.has_value()) {
+    AD_LOG_INFO << "Automatic index rebuild whenever the number of delta "
+                   "triples exceeds "
+                << config.rebuildIndexDeltaTriplesThreshold_.value()
                 << std::endl;
   }
 

--- a/src/ServerMain.cpp
+++ b/src/ServerMain.cpp
@@ -168,10 +168,12 @@ int main(int argc, char** argv) {
       po::value<std::string>(&rebuildIndexStrategy)->default_value("manual"),
       "When to rebuild the index from the current data (including updates). "
       "\"manual\" (the default): only when explicitly requested via the "
-      "`cmd=rebuild-index` HTTP request. A non-negative number: additionally "
-      "trigger a rebuild automatically in the background whenever the number "
-      "of delta triples (inserted plus deleted) after an update exceeds that "
-      "number.");
+      "`cmd=rebuild-index` HTTP request. \"min:max:fraction\": additionally "
+      "trigger a rebuild automatically in the background after an update, once "
+      "the number of delta triples (inserted plus deleted) reaches the given "
+      "`fraction` (a number greater than 0) of the number of index triples, "
+      "but never below `min` and always at `max` (e.g. "
+      "\"10000:1000000:0.1\").");
   add("syntax-test-mode",
       optionFactory.getProgramOption<&RuntimeParameters::syntaxTestMode_>(),
       "Make several query patterns that are syntactially valid, but otherwise "
@@ -308,18 +310,16 @@ int main(int argc, char** argv) {
   // Resolve the `--rebuild-index-strategy` option. A bad value fails the
   // startup with a readable message, before the index is loaded.
   try {
-    config.rebuildIndexDeltaTriplesThreshold_ =
-        Server::parseRebuildIndexStrategy(rebuildIndexStrategy);
+    config.rebuildIndexStrategy_ =
+        qlever::RebuildIndexStrategy::parse(rebuildIndexStrategy);
   } catch (const std::exception& e) {
     AD_LOG_ERROR << "Invalid argument to --rebuild-index-strategy: " << e.what()
                  << std::endl;
     return EXIT_FAILURE;
   }
-  if (config.rebuildIndexDeltaTriplesThreshold_.has_value()) {
-    AD_LOG_INFO << "Automatic index rebuild whenever the number of delta "
-                   "triples exceeds "
-                << config.rebuildIndexDeltaTriplesThreshold_.value()
-                << std::endl;
+  if (config.rebuildIndexStrategy_.has_value()) {
+    AD_LOG_INFO << "Automatic index rebuild enabled (--rebuild-index-strategy "
+                << rebuildIndexStrategy << ")" << std::endl;
   }
 
   try {

--- a/src/ServerMain.cpp
+++ b/src/ServerMain.cpp
@@ -168,12 +168,12 @@ int main(int argc, char** argv) {
       po::value<std::string>(&rebuildIndexStrategy)->default_value("manual"),
       "When to rebuild the index from the current data (including updates). "
       "\"manual\" (the default): only when explicitly requested via the "
-      "`cmd=rebuild-index` HTTP request. \"min:max:fraction\": additionally "
-      "trigger a rebuild automatically in the background after an update, once "
-      "the number of delta triples (inserted plus deleted) reaches the given "
-      "`fraction` (a number greater than 0) of the number of index triples, "
-      "but never below `min` and always at `max` (e.g. "
-      "\"10000:1000000:0.1\").");
+      "`cmd=rebuild-index` HTTP request. \"automatic:min:max:fraction\": "
+      "additionally trigger a rebuild automatically in the background after "
+      "an update, once the number of delta triples (inserted plus deleted) "
+      "reaches the given `fraction` (a number greater than 0) of the number "
+      "of index triples, but never below `min` and always at `max` (e.g. "
+      "\"automatic:10000:1000000:0.1\").");
   add("syntax-test-mode",
       optionFactory.getProgramOption<&RuntimeParameters::syntaxTestMode_>(),
       "Make several query patterns that are syntactially valid, but otherwise "

--- a/src/engine/RebuildIndexStrategy.h
+++ b/src/engine/RebuildIndexStrategy.h
@@ -58,10 +58,12 @@ struct RebuildIndexStrategy {
   // The number of delta triples at which a rebuild is triggered, given the
   // current number of index triples, see the class comment. The fractional
   // value is rounded up to a whole number of triples.
+  //
+  // NOTE: The comparison with `max` must happen in `double` (casting the raw
+  // value first would be undefined behavior when it exceeds the range of
+  // `size_t`).
   size_t rebuildThreshold(size_t numIndexTriples) const {
     double raw = fractionOfIndexTriples_ * static_cast<double>(numIndexTriples);
-    // NOTE: The comparison must happen in `double` (casting `raw` first would
-    // be undefined behavior when it exceeds the range of `size_t`).
     if (raw >= static_cast<double>(maxDeltaTriples_)) {
       return maxDeltaTriples_;
     }

--- a/src/engine/RebuildIndexStrategy.h
+++ b/src/engine/RebuildIndexStrategy.h
@@ -28,7 +28,7 @@ namespace qlever {
 
 // Strategy for automatically rebuilding the index from the current data
 // (including updates), configured via the `--rebuild-index-strategy` option of
-// `qlever-server`.
+// `qlever-server` (`manual` or `automatic:min:max:fraction`, see `parse`).
 //
 // The idea is a single threshold on the number of delta triples (inserted plus
 // deleted): a rebuild is triggered once the delta triples reach that many. The
@@ -81,24 +81,34 @@ struct RebuildIndexStrategy {
   // Parse the value of the `--rebuild-index-strategy` option:
   // - "manual": returns `std::nullopt`, i.e. rebuilds are only triggered
   //   manually via the `cmd=rebuild-index` HTTP request.
-  // - "min:max:fraction": the strategy above, where `min` and `max` are
-  //   non-negative numbers of delta triples and `fraction` is a floating-point
-  //   number greater than zero (e.g. `10000:1000000:0.1`).
-  // Throws `std::runtime_error` for any other value.
+  // - "automatic:min:max:fraction": the strategy above, where `min` and `max`
+  //   are non-negative numbers of delta triples and `fraction` is a
+  //   floating-point number greater than zero (e.g.
+  //   `automatic:10000:1000000:0.1`).
+  // Throws `std::runtime_error` for any other value. In particular, a plain
+  // "automatic" (with universal default values for `min`, `max`, and
+  // `fraction`) is reserved for the future, but not supported yet; it gets a
+  // dedicated error message.
   static std::optional<RebuildIndexStrategy> parse(std::string_view strategy) {
     if (strategy == "manual") {
       return std::nullopt;
     }
+    if (strategy == "automatic") {
+      throw std::runtime_error(
+          "A plain \"automatic\" (with default values) is not supported yet; "
+          "please specify \"automatic:min:max:fraction\" explicitly");
+    }
     std::vector<std::string_view> parts = absl::StrSplit(strategy, ':');
-    if (parts.size() != 3) {
-      throw std::runtime_error(absl::StrCat(
-          "The value \"", strategy,
-          "\" is neither \"manual\" nor of the form \"min:max:fraction\""));
+    if (parts.size() != 4 || parts[0] != "automatic") {
+      throw std::runtime_error(
+          absl::StrCat("The value \"", strategy,
+                       "\" is neither \"manual\" nor of the form "
+                       "\"automatic:min:max:fraction\""));
     }
     RebuildIndexStrategy result;
-    result.minDeltaTriples_ = parseCount(parts[0], "min");
-    result.maxDeltaTriples_ = parseCount(parts[1], "max");
-    if (!absl::SimpleAtod(parts[2], &result.fractionOfIndexTriples_) ||
+    result.minDeltaTriples_ = parseCount(parts[1], "min");
+    result.maxDeltaTriples_ = parseCount(parts[2], "max");
+    if (!absl::SimpleAtod(parts[3], &result.fractionOfIndexTriples_) ||
         !(result.fractionOfIndexTriples_ > 0.0)) {
       throw std::runtime_error(absl::StrCat(
           "The fraction \"", parts[2],

--- a/src/engine/RebuildIndexStrategy.h
+++ b/src/engine/RebuildIndexStrategy.h
@@ -15,6 +15,7 @@
 #include <absl/strings/str_split.h>
 
 #include <algorithm>
+#include <cmath>
 #include <optional>
 #include <stdexcept>
 #include <string>
@@ -55,20 +56,23 @@ struct RebuildIndexStrategy {
   double fractionOfIndexTriples_ = 0.0;
 
   // The number of delta triples at which a rebuild is triggered, given the
-  // current number of index triples, see the class comment.
-  double rebuildThreshold(size_t numIndexTriples) const {
-    return std::clamp(
-        fractionOfIndexTriples_ * static_cast<double>(numIndexTriples),
-        static_cast<double>(minDeltaTriples_),
-        static_cast<double>(maxDeltaTriples_));
+  // current number of index triples, see the class comment. The fractional
+  // value is rounded up to a whole number of triples.
+  size_t rebuildThreshold(size_t numIndexTriples) const {
+    double raw = fractionOfIndexTriples_ * static_cast<double>(numIndexTriples);
+    // NOTE: The comparison must happen in `double` (casting `raw` first would
+    // be undefined behavior when it exceeds the range of `size_t`).
+    if (raw >= static_cast<double>(maxDeltaTriples_)) {
+      return maxDeltaTriples_;
+    }
+    return std::max(minDeltaTriples_, static_cast<size_t>(std::ceil(raw)));
   }
 
   // Decide whether a rebuild should be triggered: `true` iff the number of
   // delta triples has reached `rebuildThreshold`.
   bool shouldTriggerRebuild(size_t numDeltaTriples,
                             size_t numIndexTriples) const {
-    return static_cast<double>(numDeltaTriples) >=
-           rebuildThreshold(numIndexTriples);
+    return numDeltaTriples >= rebuildThreshold(numIndexTriples);
   }
 
   // Parse the value of the `--rebuild-index-strategy` option:

--- a/src/engine/RebuildIndexStrategy.h
+++ b/src/engine/RebuildIndexStrategy.h
@@ -1,0 +1,130 @@
+//  Copyright 2026 The QLever Authors, in particular:
+//
+//  2026 Hannah Bast <bast@cs.uni-freiburg.de>, UFR
+//
+//  UFR = University of Freiburg, Chair of Algorithms and Data Structures
+
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#ifndef QLEVER_SRC_ENGINE_REBUILDINDEXSTRATEGY_H
+#define QLEVER_SRC_ENGINE_REBUILDINDEXSTRATEGY_H
+
+#include <absl/strings/numbers.h>
+#include <absl/strings/str_cat.h>
+#include <absl/strings/str_split.h>
+
+#include <algorithm>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "backports/three_way_comparison.h"
+
+namespace qlever {
+
+// Strategy for automatically rebuilding the index from the current data
+// (including updates), configured via the `--rebuild-index-strategy` option of
+// `qlever-server`.
+//
+// The idea is a single threshold on the number of delta triples (inserted plus
+// deleted): a rebuild is triggered once the delta triples reach that many. The
+// threshold is `fraction` of the number of triples in the current index (so
+// that it adapts to the index size), but never smaller than `min` and never
+// larger than `max`. In other words, the threshold is
+//
+//   clamp(fraction * numIndexTriples, min, max)
+//
+// so `min` avoids frequent rebuilds when the index is still small or empty (a
+// fraction of little is little), and `max` bounds the absolute cost of
+// querying and updating the delta. Setting `min == max` makes the threshold a
+// fixed number of delta triples, independent of the index size.
+struct RebuildIndexStrategy {
+  // Lower bound on the rebuild threshold: never rebuild before the delta
+  // triples reach this many.
+  size_t minDeltaTriples_ = 0;
+
+  // Upper bound on the rebuild threshold: always rebuild once the delta
+  // triples reach this many.
+  size_t maxDeltaTriples_ = 0;
+
+  // The rebuild threshold as a fraction of the number of index triples, before
+  // clamping to `[min, max]`.
+  double fractionOfIndexTriples_ = 0.0;
+
+  // The number of delta triples at which a rebuild is triggered, given the
+  // current number of index triples, see the class comment.
+  double rebuildThreshold(size_t numIndexTriples) const {
+    return std::clamp(
+        fractionOfIndexTriples_ * static_cast<double>(numIndexTriples),
+        static_cast<double>(minDeltaTriples_),
+        static_cast<double>(maxDeltaTriples_));
+  }
+
+  // Decide whether a rebuild should be triggered: `true` iff the number of
+  // delta triples has reached `rebuildThreshold`.
+  bool shouldTriggerRebuild(size_t numDeltaTriples,
+                            size_t numIndexTriples) const {
+    return static_cast<double>(numDeltaTriples) >=
+           rebuildThreshold(numIndexTriples);
+  }
+
+  // Parse the value of the `--rebuild-index-strategy` option:
+  // - "manual": returns `std::nullopt`, i.e. rebuilds are only triggered
+  //   manually via the `cmd=rebuild-index` HTTP request.
+  // - "min:max:fraction": the strategy above, where `min` and `max` are
+  //   non-negative numbers of delta triples and `fraction` is a floating-point
+  //   number greater than zero (e.g. `10000:1000000:0.1`).
+  // Throws `std::runtime_error` for any other value.
+  static std::optional<RebuildIndexStrategy> parse(std::string_view strategy) {
+    if (strategy == "manual") {
+      return std::nullopt;
+    }
+    std::vector<std::string_view> parts = absl::StrSplit(strategy, ':');
+    if (parts.size() != 3) {
+      throw std::runtime_error(absl::StrCat(
+          "The value \"", strategy,
+          "\" is neither \"manual\" nor of the form \"min:max:fraction\""));
+    }
+    RebuildIndexStrategy result;
+    result.minDeltaTriples_ = parseCount(parts[0], "min");
+    result.maxDeltaTriples_ = parseCount(parts[1], "max");
+    if (!absl::SimpleAtod(parts[2], &result.fractionOfIndexTriples_) ||
+        !(result.fractionOfIndexTriples_ > 0.0)) {
+      throw std::runtime_error(absl::StrCat(
+          "The fraction \"", parts[2],
+          "\" in the rebuild index strategy must be a number greater than 0"));
+    }
+    if (result.minDeltaTriples_ > result.maxDeltaTriples_) {
+      throw std::runtime_error(absl::StrCat(
+          "In the rebuild index strategy, `min` (", result.minDeltaTriples_,
+          ") must not be larger than `max` (", result.maxDeltaTriples_, ")"));
+    }
+    return result;
+  }
+
+  QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(RebuildIndexStrategy,
+                                              minDeltaTriples_,
+                                              maxDeltaTriples_,
+                                              fractionOfIndexTriples_)
+
+ private:
+  // Parse a non-negative number of delta triples, `name` is used in the error
+  // message.
+  static size_t parseCount(std::string_view number, std::string_view name) {
+    size_t result = 0;
+    if (!absl::SimpleAtoi(number, &result)) {
+      throw std::runtime_error(
+          absl::StrCat("The value \"", number, "\" for `", name,
+                       "` in the rebuild index strategy is not a "
+                       "non-negative number"));
+    }
+    return result;
+  }
+};
+
+}  // namespace qlever
+
+#endif  // QLEVER_SRC_ENGINE_REBUILDINDEXSTRATEGY_H

--- a/src/engine/RebuildIndexStrategy.h
+++ b/src/engine/RebuildIndexStrategy.h
@@ -59,9 +59,10 @@ struct RebuildIndexStrategy {
   // current number of index triples, see the class comment. The fractional
   // value is rounded up to a whole number of triples.
   //
-  // NOTE: The comparison with `max` must happen in `double` (casting the raw
-  // value first would be undefined behavior when it exceeds the range of
-  // `size_t`).
+  // NOTE: The `raw >= max` branch is the ordinary clamp to `max` (on a large
+  // index, this is the common case). Comparing in `double` also means that
+  // the cast below only happens for values below `max`, so it cannot be
+  // undefined behavior (which a cast beyond the range of `size_t` would be).
   size_t rebuildThreshold(size_t numIndexTriples) const {
     double raw = fractionOfIndexTriples_ * static_cast<double>(numIndexTriples);
     if (raw >= static_cast<double>(maxDeltaTriples_)) {

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -565,18 +565,16 @@ CPP_template_def(typename RequestT, typename ResponseT)(
     response = createJsonResponse(json, request);
   } else if (auto cmd = checkParameter("cmd", "rebuild-index")) {
     requireValidAccessToken("rebuild-index");
-
-    if (rebuildInProgress_.exchange(true)) {
+    logCommand(cmd, "rebuilding index");
+    auto config = co_await rebuildIndexUnlessInProgress(
+        checkParameter("rebuild-tmp-dir", std::nullopt),
+        checkParameter("rebuild-previous-index-dir", std::nullopt));
+    if (config.has_value()) {
+      response = createJsonResponse(config->successResponseAsJson(), request);
+    } else {
       response = createHttpResponseFromString(
           "Another rebuild is currently in progress!",
           http::status::too_many_requests, request, MediaType::textPlain);
-    } else {
-      absl::Cleanup cleanup{[this]() { rebuildInProgress_.store(false); }};
-      logCommand(cmd, "rebuilding index");
-      auto config = co_await rebuildIndex(
-          checkParameter("rebuild-tmp-dir", std::nullopt),
-          checkParameter("rebuild-previous-index-dir", std::nullopt));
-      response = createJsonResponse(config.successResponseAsJson(), request);
     }
   } else if (auto cmd = checkParameter("cmd", "write-materialized-view")) {
     requireValidAccessToken("write-materialized-view");
@@ -1713,6 +1711,19 @@ Awaitable<qlever::IndexRebuildConfig> Server::rebuildIndex(
 }
 
 // _____________________________________________________________________________
+Awaitable<std::optional<qlever::IndexRebuildConfig>>
+Server::rebuildIndexUnlessInProgress(
+    std::optional<std::string> rebuildTmpDir,
+    std::optional<std::string> rebuildPreviousIndexDir) {
+  if (rebuildInProgress_.exchange(true)) {
+    co_return std::nullopt;
+  }
+  absl::Cleanup cleanup{[this]() { rebuildInProgress_.store(false); }};
+  co_return co_await rebuildIndex(std::move(rebuildTmpDir),
+                                  std::move(rebuildPreviousIndexDir));
+}
+
+// _____________________________________________________________________________
 std::optional<size_t> Server::parseRebuildIndexStrategy(
     std::string_view strategy) {
   if (strategy == "manual") {
@@ -1740,12 +1751,13 @@ void Server::triggerRebuildIfDeltaTriplesThresholdExceeded(
   if (numDeltaTriples <= threshold) {
     return;
   }
-  // The same guard as for the `cmd=rebuild-index` HTTP request, so that a
-  // manual and an automatic rebuild can never run concurrently. If a rebuild
-  // is already in progress, do nothing; the delta triples that accumulate
-  // while it runs are carried over into the new index by the swap, and the
-  // next update after the swap re-evaluates the threshold.
-  if (rebuildInProgress_.exchange(true)) {
+  // Cheap early return while a rebuild is running, so that the updates that
+  // arrive during it (whose delta triples are carried over into the new index
+  // by the swap) do not each spawn a coroutine only to find the guard taken.
+  // The authoritative check is the guard in `rebuildIndexUnlessInProgress`,
+  // which is shared with the `cmd=rebuild-index` HTTP request, so that a
+  // manual and an automatic rebuild can never run concurrently.
+  if (rebuildInProgress_.load()) {
     return;
   }
   AD_LOG_INFO << "Triggering an automatic index rebuild, the number of delta "
@@ -1755,11 +1767,17 @@ void Server::triggerRebuildIfDeltaTriplesThresholdExceeded(
   net::co_spawn(
       queryThreadPool_,
       [this]() -> Awaitable<void> {
-        absl::Cleanup cleanup{[this]() { rebuildInProgress_.store(false); }};
-        co_await rebuildIndex(std::nullopt, std::nullopt);
-        AD_LOG_INFO << "Automatic index rebuild completed, the new index has "
-                       "been swapped in"
-                    << std::endl;
+        auto config =
+            co_await rebuildIndexUnlessInProgress(std::nullopt, std::nullopt);
+        if (config.has_value()) {
+          AD_LOG_INFO << "Automatic index rebuild completed, the new index "
+                         "has been swapped in"
+                      << std::endl;
+        } else {
+          AD_LOG_INFO << "Automatic index rebuild skipped, another rebuild "
+                         "started concurrently"
+                      << std::endl;
+        }
       },
       [](std::exception_ptr exception) {
         if (!exception) {

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -1729,8 +1729,10 @@ void Server::triggerRebuildIfStrategySaysSo(const DeltaTriplesCount& count,
   if (!rebuildIndexStrategy_.has_value()) {
     return;
   }
-  auto numDeltaTriples =
-      static_cast<size_t>(count.triplesInserted_ + count.triplesDeleted_);
+  // NOTE: Cast before adding: the counts are non-negative here (they are set
+  // sizes), and the unsigned addition cannot overflow.
+  auto numDeltaTriples = static_cast<size_t>(count.triplesInserted_) +
+                         static_cast<size_t>(count.triplesDeleted_);
   if (!rebuildIndexStrategy_->shouldTriggerRebuild(numDeltaTriples,
                                                    numIndexTriples)) {
     return;

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -1752,32 +1752,35 @@ void Server::triggerRebuildIfStrategySaysSo(const DeltaTriplesCount& count,
               << rebuildIndexStrategy_->rebuildThreshold(numIndexTriples)
               << ") for the current index size (" << numIndexTriples
               << " triples)" << std::endl;
-  net::co_spawn(
-      queryThreadPool_,
-      [this]() -> Awaitable<void> {
-        auto config =
-            co_await rebuildIndexUnlessInProgress(std::nullopt, std::nullopt);
-        if (config.has_value()) {
-          AD_LOG_INFO << "Automatic index rebuild completed, the new index "
-                         "has been swapped in"
-                      << std::endl;
-        } else {
-          AD_LOG_INFO << "Automatic index rebuild skipped, another rebuild "
-                         "started concurrently"
-                      << std::endl;
-        }
-      },
-      [](std::exception_ptr exception) {
-        if (!exception) {
-          return;
-        }
-        try {
-          std::rethrow_exception(exception);
-        } catch (const std::exception& e) {
-          AD_LOG_ERROR << "Automatic index rebuild failed: " << e.what()
-                       << std::endl;
-        }
-      });
+  net::co_spawn(queryThreadPool_, runAutomaticRebuild(),
+                &Server::logAutomaticRebuildFailure);
+}
+
+// _____________________________________________________________________________
+Awaitable<void> Server::runAutomaticRebuild() {
+  auto config =
+      co_await rebuildIndexUnlessInProgress(std::nullopt, std::nullopt);
+  if (config.has_value()) {
+    AD_LOG_INFO << "Automatic index rebuild completed, the new index "
+                   "has been swapped in"
+                << std::endl;
+  } else {
+    AD_LOG_INFO << "Automatic index rebuild skipped, another rebuild "
+                   "started concurrently"
+                << std::endl;
+  }
+}
+
+// _____________________________________________________________________________
+void Server::logAutomaticRebuildFailure(std::exception_ptr exception) {
+  if (!exception) {
+    return;
+  }
+  try {
+    std::rethrow_exception(exception);
+  } catch (const std::exception& e) {
+    AD_LOG_ERROR << "Automatic index rebuild failed: " << e.what() << std::endl;
+  }
 }
 
 // For helper function `Server::onlyForTestingProcess`

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -1747,8 +1747,7 @@ void Server::triggerRebuildIfStrategySaysSo(const DeltaTriplesCount& count,
   AD_LOG_INFO << "Triggering an automatic index rebuild, the number of delta "
                  "triples ("
               << numDeltaTriples << ") has reached the threshold ("
-              << static_cast<size_t>(
-                     rebuildIndexStrategy_->rebuildThreshold(numIndexTriples))
+              << rebuildIndexStrategy_->rebuildThreshold(numIndexTriples)
               << ") for the current index size (" << numIndexTriples
               << " triples)" << std::endl;
   net::co_spawn(

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -10,6 +10,7 @@
 #include "engine/Server.h"
 
 #include <absl/functional/bind_front.h>
+#include <absl/strings/numbers.h>
 #include <absl/strings/str_cat.h>
 #include <absl/strings/str_join.h>
 
@@ -61,6 +62,8 @@ Server::Server(
       accessToken_(std::move(accessToken)),
       noAccessCheck_(noAccessCheck),
       queryThreadPool_{numThreads},
+      rebuildIndexDeltaTriplesThreshold_(
+          config.rebuildIndexDeltaTriplesThreshold_),
       metricsReader_(std::move(metricsReader)) {
   AD_LOG_INFO << "Initializing server ..." << std::endl;
 
@@ -1410,6 +1413,13 @@ CPP_template_def(typename RequestT, typename ResponseT)(
       static_cast<double>(requestTimer.msecs().count()),
       {OperationType::update});
   metrics_->finishedSparqlOperations_->Add(1, {OperationType::update});
+  // With `--rebuild-index-strategy <number>`, an update can push the number
+  // of delta triples over the threshold, in which case an index rebuild is
+  // started in the background here (without delaying the response below).
+  if (!metadatas.empty() && metadatas.back().countAfter_.has_value()) {
+    triggerRebuildIfDeltaTriplesThresholdExceeded(
+        metadatas.back().countAfter_.value());
+  }
   auto responseJson = nlohmann::ordered_json();
   responseJson["operations"] = operations;
   outerTracer->endTrace("update");
@@ -1700,6 +1710,68 @@ Awaitable<qlever::IndexRebuildConfig> Server::rebuildIndex(
       net::use_awaitable);
   co_await std::move(swapRoutine);
   co_return config;
+}
+
+// _____________________________________________________________________________
+std::optional<size_t> Server::parseRebuildIndexStrategy(
+    std::string_view strategy) {
+  if (strategy == "manual") {
+    return std::nullopt;
+  }
+  size_t threshold = 0;
+  if (!absl::SimpleAtoi(strategy, &threshold)) {
+    throw std::runtime_error(absl::StrCat(
+        "The value \"", strategy,
+        "\" is neither \"manual\" nor a non-negative number of delta "
+        "triples"));
+  }
+  return threshold;
+}
+
+// _____________________________________________________________________________
+void Server::triggerRebuildIfDeltaTriplesThresholdExceeded(
+    const DeltaTriplesCount& count) {
+  if (!rebuildIndexDeltaTriplesThreshold_.has_value()) {
+    return;
+  }
+  size_t threshold = rebuildIndexDeltaTriplesThreshold_.value();
+  auto numDeltaTriples =
+      static_cast<size_t>(count.triplesInserted_ + count.triplesDeleted_);
+  if (numDeltaTriples <= threshold) {
+    return;
+  }
+  // The same guard as for the `cmd=rebuild-index` HTTP request, so that a
+  // manual and an automatic rebuild can never run concurrently. If a rebuild
+  // is already in progress, do nothing; the delta triples that accumulate
+  // while it runs are carried over into the new index by the swap, and the
+  // next update after the swap re-evaluates the threshold.
+  if (rebuildInProgress_.exchange(true)) {
+    return;
+  }
+  AD_LOG_INFO << "Triggering an automatic index rebuild, the number of delta "
+                 "triples ("
+              << numDeltaTriples << ") exceeds the threshold (" << threshold
+              << ")" << std::endl;
+  net::co_spawn(
+      queryThreadPool_,
+      [this]() -> Awaitable<void> {
+        absl::Cleanup cleanup{[this]() { rebuildInProgress_.store(false); }};
+        co_await rebuildIndex(std::nullopt, std::nullopt);
+        AD_LOG_INFO << "Automatic index rebuild completed, the new index has "
+                       "been swapped in"
+                    << std::endl;
+      },
+      [](std::exception_ptr exception) {
+        if (!exception) {
+          return;
+        }
+        try {
+          std::rethrow_exception(exception);
+        } catch (const std::exception& e) {
+          AD_LOG_ERROR << "Automatic index rebuild failed: " << e.what()
+                       << std::endl;
+        }
+      });
 }
 
 // For helper function `Server::onlyForTestingProcess`

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -10,7 +10,6 @@
 #include "engine/Server.h"
 
 #include <absl/functional/bind_front.h>
-#include <absl/strings/numbers.h>
 #include <absl/strings/str_cat.h>
 #include <absl/strings/str_join.h>
 
@@ -62,8 +61,7 @@ Server::Server(
       accessToken_(std::move(accessToken)),
       noAccessCheck_(noAccessCheck),
       queryThreadPool_{numThreads},
-      rebuildIndexDeltaTriplesThreshold_(
-          config.rebuildIndexDeltaTriplesThreshold_),
+      rebuildIndexStrategy_(config.rebuildIndexStrategy_),
       metricsReader_(std::move(metricsReader)) {
   AD_LOG_INFO << "Initializing server ..." << std::endl;
 
@@ -1411,12 +1409,14 @@ CPP_template_def(typename RequestT, typename ResponseT)(
       static_cast<double>(requestTimer.msecs().count()),
       {OperationType::update});
   metrics_->finishedSparqlOperations_->Add(1, {OperationType::update});
-  // With `--rebuild-index-strategy <number>`, an update can push the number
-  // of delta triples over the threshold, in which case an index rebuild is
+  // With `--rebuild-index-strategy` set, an update can bring the delta triples
+  // to a state where the strategy asks for a rebuild, in which case one is
   // started in the background here (without delaying the response below).
   if (!metadatas.empty() && metadatas.back().countAfter_.has_value()) {
-    triggerRebuildIfDeltaTriplesThresholdExceeded(
-        metadatas.back().countAfter_.value());
+    auto numIndexTriples = static_cast<size_t>(
+        indexAndViewsSnapshot()->index_.numTriples().normal);
+    triggerRebuildIfStrategySaysSo(metadatas.back().countAfter_.value(),
+                                   numIndexTriples);
   }
   auto responseJson = nlohmann::ordered_json();
   responseJson["operations"] = operations;
@@ -1724,31 +1724,15 @@ Server::rebuildIndexUnlessInProgress(
 }
 
 // _____________________________________________________________________________
-std::optional<size_t> Server::parseRebuildIndexStrategy(
-    std::string_view strategy) {
-  if (strategy == "manual") {
-    return std::nullopt;
-  }
-  size_t threshold = 0;
-  if (!absl::SimpleAtoi(strategy, &threshold)) {
-    throw std::runtime_error(absl::StrCat(
-        "The value \"", strategy,
-        "\" is neither \"manual\" nor a non-negative number of delta "
-        "triples"));
-  }
-  return threshold;
-}
-
-// _____________________________________________________________________________
-void Server::triggerRebuildIfDeltaTriplesThresholdExceeded(
-    const DeltaTriplesCount& count) {
-  if (!rebuildIndexDeltaTriplesThreshold_.has_value()) {
+void Server::triggerRebuildIfStrategySaysSo(const DeltaTriplesCount& count,
+                                            size_t numIndexTriples) {
+  if (!rebuildIndexStrategy_.has_value()) {
     return;
   }
-  size_t threshold = rebuildIndexDeltaTriplesThreshold_.value();
   auto numDeltaTriples =
       static_cast<size_t>(count.triplesInserted_ + count.triplesDeleted_);
-  if (numDeltaTriples <= threshold) {
+  if (!rebuildIndexStrategy_->shouldTriggerRebuild(numDeltaTriples,
+                                                   numIndexTriples)) {
     return;
   }
   // Cheap early return while a rebuild is running, so that the updates that
@@ -1762,8 +1746,11 @@ void Server::triggerRebuildIfDeltaTriplesThresholdExceeded(
   }
   AD_LOG_INFO << "Triggering an automatic index rebuild, the number of delta "
                  "triples ("
-              << numDeltaTriples << ") exceeds the threshold (" << threshold
-              << ")" << std::endl;
+              << numDeltaTriples << ") has reached the threshold ("
+              << static_cast<size_t>(
+                     rebuildIndexStrategy_->rebuildThreshold(numIndexTriples))
+              << ") for the current index size (" << numIndexTriples
+              << " triples)" << std::endl;
   net::co_spawn(
       queryThreadPool_,
       [this]() -> Awaitable<void> {

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -91,15 +91,6 @@ class Server {
   static json composeStatsJson(const Index& index);
   json composeCacheStatsJson() const;
 
-  // Parse the value of the `--rebuild-index-strategy` option of
-  // `qlever-server`: "manual" yields `std::nullopt` (rebuilds are only
-  // triggered via the `cmd=rebuild-index` HTTP request), a non-negative
-  // number yields that number (a rebuild is additionally triggered
-  // automatically when the number of delta triples exceeds it). Throws
-  // `std::runtime_error` for any other value.
-  static std::optional<size_t> parseRebuildIndexStrategy(
-      std::string_view strategy);
-
  private:
   qlever::Qlever qlever_;
   const size_t numThreads_;
@@ -125,11 +116,10 @@ class Server {
   // triggering this twice.
   std::atomic_bool rebuildInProgress_{false};
 
-  // If set, an index rebuild is triggered automatically whenever the number
-  // of delta triples after an update exceeds this threshold, see
-  // `triggerRebuildIfDeltaTriplesThresholdExceeded`. Set via the
-  // `--rebuild-index-strategy` option of `qlever-server`.
-  std::optional<size_t> rebuildIndexDeltaTriplesThreshold_;
+  // If set, an index rebuild is triggered automatically after an update
+  // whenever the strategy says so, see `triggerRebuildIfStrategySaysSo`. Set
+  // via the `--rebuild-index-strategy` option of `qlever-server`.
+  std::optional<qlever::RebuildIndexStrategy> rebuildIndexStrategy_;
 
   // MetricsReader for serving the /metrics endpoint. `nullptr` when metrics are
   // disabled (--enable-metrics not passed).
@@ -412,12 +402,13 @@ class Server {
       std::optional<std::string> rebuildTmpDir,
       std::optional<std::string> rebuildPreviousIndexDir);
 
-  // If `rebuildIndexDeltaTriplesThreshold_` is set and `count` (the number of
-  // delta triples after an update) exceeds it, trigger an index rebuild in
-  // the background, unless one is already in progress. Returns immediately;
-  // the rebuild runs detached and logs its success or failure.
-  void triggerRebuildIfDeltaTriplesThresholdExceeded(
-      const DeltaTriplesCount& count);
+  // If `rebuildIndexStrategy_` is set and it says a rebuild should be
+  // triggered for `count` (the number of delta triples after an update) and
+  // the given number of triples in the current index, trigger an index
+  // rebuild in the background, unless one is already in progress. Returns
+  // immediately; the rebuild runs detached and logs its success or failure.
+  void triggerRebuildIfStrategySaysSo(const DeltaTriplesCount& count,
+                                      size_t numIndexTriples);
 
   // Getters for the `Qlever` instance, as well as its data members.
   qlever::Qlever& qlever() { return qlever_; }

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -410,6 +410,13 @@ class Server {
   void triggerRebuildIfStrategySaysSo(const DeltaTriplesCount& count,
                                       size_t numIndexTriples);
 
+  // The background coroutine spawned by `triggerRebuildIfStrategySaysSo`:
+  // run the rebuild (unless one is already in progress) and log the outcome.
+  Awaitable<void> runAutomaticRebuild();
+
+  // Completion handler of that coroutine: log the exception, if there is one.
+  static void logAutomaticRebuildFailure(std::exception_ptr exception);
+
   // Getters for the `Qlever` instance, as well as its data members.
   qlever::Qlever& qlever() { return qlever_; }
   const qlever::Qlever& qlever() const { return qlever_; }

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -67,6 +67,7 @@ class Server {
   FRIEND_TEST(ServerTest, configurePinnedResultWithName);
   FRIEND_TEST(IndexRebuilder, serverIntegration);
   FRIEND_TEST(IndexRebuilder, serverIntegrationDroppedStateWarnings);
+  FRIEND_TEST(IndexRebuilder, serverIntegrationAutomaticRebuild);
   friend serverTestHelpers::ServerForTesting;
 
  public:
@@ -89,6 +90,15 @@ class Server {
   // Get server statistics.
   static json composeStatsJson(const Index& index);
   json composeCacheStatsJson() const;
+
+  // Parse the value of the `--rebuild-index-strategy` option of
+  // `qlever-server`: "manual" yields `std::nullopt` (rebuilds are only
+  // triggered via the `cmd=rebuild-index` HTTP request), a non-negative
+  // number yields that number (a rebuild is additionally triggered
+  // automatically when the number of delta triples exceeds it). Throws
+  // `std::runtime_error` for any other value.
+  static std::optional<size_t> parseRebuildIndexStrategy(
+      std::string_view strategy);
 
  private:
   qlever::Qlever qlever_;
@@ -114,6 +124,12 @@ class Server {
   // Indicates if an index rebuild is currently in progress so that we prevent
   // triggering this twice.
   std::atomic_bool rebuildInProgress_{false};
+
+  // If set, an index rebuild is triggered automatically whenever the number
+  // of delta triples after an update exceeds this threshold, see
+  // `triggerRebuildIfDeltaTriplesThresholdExceeded`. Set via the
+  // `--rebuild-index-strategy` option of `qlever-server`.
+  std::optional<size_t> rebuildIndexDeltaTriplesThreshold_;
 
   // MetricsReader for serving the /metrics endpoint. `nullptr` when metrics are
   // disabled (--enable-metrics not passed).
@@ -385,6 +401,14 @@ class Server {
   Awaitable<qlever::IndexRebuildConfig> rebuildIndex(
       std::optional<std::string> rebuildTmpDir,
       std::optional<std::string> rebuildPreviousIndexDir);
+
+  // If `rebuildIndexDeltaTriplesThreshold_` is set and `count` (the number of
+  // delta triples after an update) exceeds it, trigger an index rebuild in
+  // the background, unless one is already in progress. Returns immediately;
+  // the rebuild (the same operation as for the `cmd=rebuild-index` HTTP
+  // request) runs detached and logs its success or failure.
+  void triggerRebuildIfDeltaTriplesThresholdExceeded(
+      const DeltaTriplesCount& count);
 
   // Getters for the `Qlever` instance, as well as its data members.
   qlever::Qlever& qlever() { return qlever_; }

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -402,11 +402,20 @@ class Server {
       std::optional<std::string> rebuildTmpDir,
       std::optional<std::string> rebuildPreviousIndexDir);
 
+  // Like `rebuildIndex` above, but do nothing and return `std::nullopt` if
+  // another rebuild is currently in progress (the `rebuildInProgress_` flag
+  // is held for the duration of the rebuild). This is the common
+  // implementation behind the two ways of triggering a rebuild: the manual
+  // `cmd=rebuild-index` HTTP request and the automatic trigger below.
+  Awaitable<std::optional<qlever::IndexRebuildConfig>>
+  rebuildIndexUnlessInProgress(
+      std::optional<std::string> rebuildTmpDir,
+      std::optional<std::string> rebuildPreviousIndexDir);
+
   // If `rebuildIndexDeltaTriplesThreshold_` is set and `count` (the number of
   // delta triples after an update) exceeds it, trigger an index rebuild in
   // the background, unless one is already in progress. Returns immediately;
-  // the rebuild (the same operation as for the `cmd=rebuild-index` HTTP
-  // request) runs detached and logs its success or failure.
+  // the rebuild runs detached and logs its success or failure.
   void triggerRebuildIfDeltaTriplesThresholdExceeded(
       const DeltaTriplesCount& count);
 

--- a/src/libqlever/Qlever.cpp
+++ b/src/libqlever/Qlever.cpp
@@ -498,13 +498,40 @@ IndexRebuildConfig Qlever::makeIndexRebuildConfig(
   // The defaults are: build the new index in `rebuild.<current datetime>.tmp`
   // and move the old index to `previous.<datetime of the build of the current
   // index>`.
+  //
+  // The datetime of the index build has a granularity of one second, so when
+  // rebuilds happen in quick succession (e.g. automatic rebuilds on a small
+  // index, see `--rebuild-index-strategy`), two index generations can carry
+  // the same datetime, and the default directory for the second of them is
+  // then already taken. Append `.1`, `.2`, ... in that case (like the
+  // numbered backups of `logrotate`). Without this, the rebuild would fail,
+  // and since a failed rebuild does not swap (and hence does not re-stamp the
+  // datetime of the served index), all subsequent rebuilds would fail the
+  // same way. Only the default name is uniquified; an explicitly given
+  // directory that is taken remains an error (see the checks below). NOTE:
+  // the check-then-use is not atomic; this is fine because rebuilds are
+  // serialized (see `Server::rebuildInProgress_`).
+  auto uniquify = [](const std::string& directory) {
+    std::string candidate = directory;
+    for (size_t i = 1; fs::exists(candidate); ++i) {
+      if (i > 99) {
+        throw std::runtime_error{absl::StrCat(
+            "The directories \"", directory, "\" and \"", directory,
+            ".1\" through \"", directory,
+            ".99\" all already exist; remove some of them or specify a "
+            "directory explicitly via `rebuild-previous-index-dir`")};
+      }
+      candidate = absl::StrCat(directory, ".", i);
+    }
+    return candidate;
+  };
   std::string baseNameForRebuild = resolveBaseName(
       std::move(rebuildTmpDir),
       absl::StrCat("rebuild.", IndexImpl::formatIndexBuildTime(absl::Now()),
                    ".tmp"));
   std::string baseNameForOldIndex = resolveBaseName(
       std::move(rebuildPreviousIndexDir),
-      absl::StrCat("previous.", index.getImpl().dateOfIndexBuild()));
+      uniquify(absl::StrCat("previous.", index.getImpl().dateOfIndexBuild())));
 
   // Check the two base names that were derived from the arguments: they must be
   // relative (they are resolved against the working directory of the engine,

--- a/src/libqlever/Qlever.cpp
+++ b/src/libqlever/Qlever.cpp
@@ -508,9 +508,10 @@ IndexRebuildConfig Qlever::makeIndexRebuildConfig(
   // and since a failed rebuild does not swap (and hence does not re-stamp the
   // datetime of the served index), all subsequent rebuilds would fail the
   // same way. Only the default name is uniquified; an explicitly given
-  // directory that is taken remains an error (see the checks below). NOTE:
-  // the check-then-use is not atomic; this is fine because rebuilds are
-  // serialized (see `Server::rebuildInProgress_`).
+  // directory that is taken remains an error (see the checks below).
+  //
+  // NOTE: The check-then-use is not atomic; this is fine because rebuilds
+  // are serialized (see `Server::rebuildInProgress_`).
   auto uniquify = [](const std::string& directory) {
     std::string candidate = directory;
     for (size_t i = 1; fs::exists(candidate); ++i) {

--- a/src/libqlever/Qlever.h
+++ b/src/libqlever/Qlever.h
@@ -253,6 +253,13 @@ struct EngineConfig : CommonConfig {
   // simply delete this file.
   bool persistUpdates_ = true;
 
+  // If set, an index rebuild (the same operation as the `cmd=rebuild-index`
+  // HTTP request) is triggered automatically in the background as soon as the
+  // total number of delta triples (inserted plus deleted) after an update
+  // exceeds this threshold. If `nullopt` (the default), rebuilds are only
+  // triggered manually.
+  std::optional<size_t> rebuildIndexDeltaTriplesThreshold_ = std::nullopt;
+
   // If set to true, no permutations will be loaded from disk. This is useful
   // when only queries that don't require accessing the permutations need to be
   // executed (e.g., queries that only compute constant expressions, or query

--- a/src/libqlever/Qlever.h
+++ b/src/libqlever/Qlever.h
@@ -25,6 +25,7 @@
 #include "engine/NamedResultCacheSerializer.h"
 #include "engine/QueryExecutionContext.h"
 #include "engine/QueryPlanner.h"
+#include "engine/RebuildIndexStrategy.h"
 #include "global/RuntimeParameters.h"
 #include "index/DeltaTriples.h"
 #include "index/Index.h"
@@ -254,11 +255,10 @@ struct EngineConfig : CommonConfig {
   bool persistUpdates_ = true;
 
   // If set, an index rebuild (the same operation as the `cmd=rebuild-index`
-  // HTTP request) is triggered automatically in the background as soon as the
-  // total number of delta triples (inserted plus deleted) after an update
-  // exceeds this threshold. If `nullopt` (the default), rebuilds are only
-  // triggered manually.
-  std::optional<size_t> rebuildIndexDeltaTriplesThreshold_ = std::nullopt;
+  // HTTP request) is triggered automatically in the background after an update,
+  // whenever `RebuildIndexStrategy::shouldTriggerRebuild` says so. If `nullopt`
+  // (the default), rebuilds are only triggered manually.
+  std::optional<RebuildIndexStrategy> rebuildIndexStrategy_ = std::nullopt;
 
   // If set to true, no permutations will be loaded from disk. This is useful
   // when only queries that don't require accessing the permutations need to be

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -194,6 +194,8 @@ addLinkAndDiscoverTestNoLibs(ZipMergeUniqueViewTest)
 
 addLinkAndDiscoverTestNoLibs(SortedSequenceTest)
 
+addLinkAndDiscoverTest(RebuildIndexStrategyTest qlever_util)
+
 addLinkAndDiscoverTest(DeltaTriplesTest index)
 
 addLinkAndDiscoverTest(UpdateMetadataTest index)

--- a/test/RebuildIndexStrategyTest.cpp
+++ b/test/RebuildIndexStrategyTest.cpp
@@ -1,0 +1,95 @@
+//  Copyright 2026 The QLever Authors, in particular:
+//
+//  2026 Hannah Bast <bast@cs.uni-freiburg.de>, UFR
+//
+//  UFR = University of Freiburg, Chair of Algorithms and Data Structures
+
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <optional>
+
+#include "engine/RebuildIndexStrategy.h"
+#include "util/GTestHelpers.h"
+
+using qlever::RebuildIndexStrategy;
+using ::testing::HasSubstr;
+using ::testing::Optional;
+
+// _____________________________________________________________________________
+TEST(RebuildIndexStrategy, parseManual) {
+  // "manual" means "no automatic rebuild".
+  EXPECT_EQ(RebuildIndexStrategy::parse("manual"), std::nullopt);
+}
+
+// _____________________________________________________________________________
+TEST(RebuildIndexStrategy, parseMinMaxFraction) {
+  EXPECT_THAT(RebuildIndexStrategy::parse("10000:1000000:0.1"),
+              Optional(RebuildIndexStrategy{10'000, 1'000'000, 0.1}));
+  // `min` may be zero, and the fraction may exceed 1 (the delta can be larger
+  // than the index, e.g. after many deletes).
+  EXPECT_THAT(RebuildIndexStrategy::parse("0:100:2.5"),
+              Optional(RebuildIndexStrategy{0, 100, 2.5}));
+  // `min == max` makes the threshold a fixed number of delta triples.
+  EXPECT_THAT(RebuildIndexStrategy::parse("500:500:1"),
+              Optional(RebuildIndexStrategy{500, 500, 1.0}));
+}
+
+// _____________________________________________________________________________
+TEST(RebuildIndexStrategy, parseErrors) {
+  auto expectThrows = [](std::string_view strategy, std::string_view message) {
+    AD_EXPECT_THROW_WITH_MESSAGE(RebuildIndexStrategy::parse(strategy),
+                                 HasSubstr(message));
+  };
+  // Anything that is not "manual" and not three colon-separated parts.
+  expectThrows("", "neither \"manual\" nor");
+  expectThrows("automatic", "neither \"manual\" nor");
+  expectThrows("500000", "neither \"manual\" nor");
+  expectThrows("10:20", "neither \"manual\" nor");
+  expectThrows("10:20:30:40", "neither \"manual\" nor");
+  // `min` and `max` must be non-negative numbers.
+  expectThrows("x:20:0.1", "for `min`");
+  expectThrows("10:y:0.1", "for `max`");
+  // The fraction must be a number greater than zero.
+  expectThrows("10:20:0", "greater than 0");
+  expectThrows("10:20:-1", "greater than 0");
+  expectThrows("10:20:abc", "greater than 0");
+  // `min` must not be larger than `max`.
+  expectThrows("100:10:0.1", "must not be larger than");
+}
+
+// _____________________________________________________________________________
+TEST(RebuildIndexStrategy, rebuildThresholdMinMaxFraction) {
+  // Threshold is 10% of the index size, clamped to [10000, 1000000].
+  RebuildIndexStrategy strategy{10'000, 1'000'000, 0.1};
+  EXPECT_EQ(strategy.rebuildThreshold(0), 10'000);           // clamped to min
+  EXPECT_EQ(strategy.rebuildThreshold(50'000), 10'000);      // 5000 -> min
+  EXPECT_EQ(strategy.rebuildThreshold(1'000'000), 100'000);  // 10%
+  EXPECT_EQ(strategy.rebuildThreshold(50'000'000), 1'000'000);  // clamped max
+}
+
+// _____________________________________________________________________________
+TEST(RebuildIndexStrategy, shouldTriggerRebuildMinMaxFraction) {
+  // Rebuild when the delta reaches 10% of the index, but never below 10000
+  // delta triples, and always at 1000000.
+  RebuildIndexStrategy strategy{10'000, 1'000'000, 0.1};
+
+  // Below `min`, never rebuild, even at a high fraction.
+  EXPECT_FALSE(strategy.shouldTriggerRebuild(9'999, 0));
+  EXPECT_FALSE(strategy.shouldTriggerRebuild(9'999, 1));
+  // At `min`, rebuild (the threshold is `min` here).
+  EXPECT_TRUE(strategy.shouldTriggerRebuild(10'000, 0));
+
+  // Between `min` and `max`, rebuild exactly when the fraction is reached.
+  EXPECT_FALSE(strategy.shouldTriggerRebuild(50'000, 1'000'000));  // 5%
+  EXPECT_TRUE(strategy.shouldTriggerRebuild(100'000, 1'000'000));  // 10%
+  EXPECT_TRUE(strategy.shouldTriggerRebuild(200'000, 1'000'000));  // 20%
+  // At least `min`, but the fraction is not yet reached.
+  EXPECT_FALSE(strategy.shouldTriggerRebuild(10'000, 100'000'000));
+
+  // At `max`, always rebuild, even far below the fraction.
+  EXPECT_TRUE(strategy.shouldTriggerRebuild(1'000'000, 100'000'000'000ULL));
+}

--- a/test/RebuildIndexStrategyTest.cpp
+++ b/test/RebuildIndexStrategyTest.cpp
@@ -27,14 +27,14 @@ TEST(RebuildIndexStrategy, parseManual) {
 
 // _____________________________________________________________________________
 TEST(RebuildIndexStrategy, parseMinMaxFraction) {
-  EXPECT_THAT(RebuildIndexStrategy::parse("10000:1000000:0.1"),
+  EXPECT_THAT(RebuildIndexStrategy::parse("automatic:10000:1000000:0.1"),
               Optional(RebuildIndexStrategy{10'000, 1'000'000, 0.1}));
   // `min` may be zero, and the fraction may exceed 1 (the delta can be larger
   // than the index, e.g. after many deletes).
-  EXPECT_THAT(RebuildIndexStrategy::parse("0:100:2.5"),
+  EXPECT_THAT(RebuildIndexStrategy::parse("automatic:0:100:2.5"),
               Optional(RebuildIndexStrategy{0, 100, 2.5}));
   // `min == max` makes the threshold a fixed number of delta triples.
-  EXPECT_THAT(RebuildIndexStrategy::parse("500:500:1"),
+  EXPECT_THAT(RebuildIndexStrategy::parse("automatic:500:500:1"),
               Optional(RebuildIndexStrategy{500, 500, 1.0}));
 }
 
@@ -44,21 +44,27 @@ TEST(RebuildIndexStrategy, parseErrors) {
     AD_EXPECT_THROW_WITH_MESSAGE(RebuildIndexStrategy::parse(strategy),
                                  HasSubstr(message));
   };
-  // Anything that is not "manual" and not three colon-separated parts.
+  // Anything that is not "manual" and not "automatic:" plus three
+  // colon-separated parts.
   expectThrows("", "neither \"manual\" nor");
-  expectThrows("automatic", "neither \"manual\" nor");
   expectThrows("500000", "neither \"manual\" nor");
   expectThrows("10:20", "neither \"manual\" nor");
+  // The old form without the "automatic:" prefix is rejected.
+  expectThrows("10000:1000000:0.1", "neither \"manual\" nor");
   expectThrows("10:20:30:40", "neither \"manual\" nor");
+  expectThrows("manual:10:20:0.1", "neither \"manual\" nor");
+  // A plain "automatic" (with default values) is reserved, but not
+  // supported yet, and gets a dedicated error message.
+  expectThrows("automatic", "not supported yet");
   // `min` and `max` must be non-negative numbers.
-  expectThrows("x:20:0.1", "for `min`");
-  expectThrows("10:y:0.1", "for `max`");
+  expectThrows("automatic:x:20:0.1", "for `min`");
+  expectThrows("automatic:10:y:0.1", "for `max`");
   // The fraction must be a number greater than zero.
-  expectThrows("10:20:0", "greater than 0");
-  expectThrows("10:20:-1", "greater than 0");
-  expectThrows("10:20:abc", "greater than 0");
+  expectThrows("automatic:10:20:0", "greater than 0");
+  expectThrows("automatic:10:20:-1", "greater than 0");
+  expectThrows("automatic:10:20:abc", "greater than 0");
   // `min` must not be larger than `max`.
-  expectThrows("100:10:0.1", "must not be larger than");
+  expectThrows("automatic:100:10:0.1", "must not be larger than");
 }
 
 // _____________________________________________________________________________

--- a/test/RebuildIndexStrategyTest.cpp
+++ b/test/RebuildIndexStrategyTest.cpp
@@ -69,6 +69,17 @@ TEST(RebuildIndexStrategy, rebuildThresholdMinMaxFraction) {
   EXPECT_EQ(strategy.rebuildThreshold(50'000), 10'000);      // 5000 -> min
   EXPECT_EQ(strategy.rebuildThreshold(1'000'000), 100'000);  // 10%
   EXPECT_EQ(strategy.rebuildThreshold(50'000'000), 1'000'000);  // clamped max
+
+  // A fractional raw threshold is rounded up to a whole number of triples.
+  RebuildIndexStrategy roundingStrategy{1, 1'000'000, 0.1};
+  EXPECT_EQ(roundingStrategy.rebuildThreshold(105), 11);  // ceil(10.5)
+  EXPECT_FALSE(roundingStrategy.shouldTriggerRebuild(10, 105));
+  EXPECT_TRUE(roundingStrategy.shouldTriggerRebuild(11, 105));
+
+  // A raw threshold beyond the range of `size_t` is clamped to `max` (and in
+  // particular does not overflow in the conversion).
+  RebuildIndexStrategy hugeFractionStrategy{1, 1'000'000, 1e30};
+  EXPECT_EQ(hugeFractionStrategy.rebuildThreshold(1'000'000), 1'000'000);
 }
 
 // _____________________________________________________________________________

--- a/test/ServerTest.cpp
+++ b/test/ServerTest.cpp
@@ -980,22 +980,3 @@ TEST(ServerTest, queryEventLogRecordsFailedStatus) {
   EXPECT_EQ(end.at("qid").get<std::string>(),
             start.at("qid").get<std::string>());
 }
-
-// _____________________________________________________________________________
-TEST(ServerTest, parseRebuildIndexStrategy) {
-  using ::testing::HasSubstr;
-  using ::testing::Optional;
-  EXPECT_EQ(Server::parseRebuildIndexStrategy("manual"), std::nullopt);
-  EXPECT_THAT(Server::parseRebuildIndexStrategy("0"), Optional(0u));
-  EXPECT_THAT(Server::parseRebuildIndexStrategy("500000"), Optional(500'000u));
-  auto expectThrows = [](std::string_view strategy) {
-    AD_EXPECT_THROW_WITH_MESSAGE(
-        Server::parseRebuildIndexStrategy(strategy),
-        HasSubstr("neither \"manual\" nor a non-negative number"));
-  };
-  expectThrows("");
-  expectThrows("automatic");
-  expectThrows("-5");
-  expectThrows("10x");
-  expectThrows("1.5");
-}

--- a/test/ServerTest.cpp
+++ b/test/ServerTest.cpp
@@ -980,3 +980,22 @@ TEST(ServerTest, queryEventLogRecordsFailedStatus) {
   EXPECT_EQ(end.at("qid").get<std::string>(),
             start.at("qid").get<std::string>());
 }
+
+// _____________________________________________________________________________
+TEST(ServerTest, parseRebuildIndexStrategy) {
+  using ::testing::HasSubstr;
+  using ::testing::Optional;
+  EXPECT_EQ(Server::parseRebuildIndexStrategy("manual"), std::nullopt);
+  EXPECT_THAT(Server::parseRebuildIndexStrategy("0"), Optional(0u));
+  EXPECT_THAT(Server::parseRebuildIndexStrategy("500000"), Optional(500'000u));
+  auto expectThrows = [](std::string_view strategy) {
+    AD_EXPECT_THROW_WITH_MESSAGE(
+        Server::parseRebuildIndexStrategy(strategy),
+        HasSubstr("neither \"manual\" nor a non-negative number"));
+  };
+  expectThrows("");
+  expectThrows("automatic");
+  expectThrows("-5");
+  expectThrows("10x");
+  expectThrows("1.5");
+}

--- a/test/index/IndexRebuilderTest.cpp
+++ b/test/index/IndexRebuilderTest.cpp
@@ -1076,6 +1076,40 @@ TEST(IndexRebuilder, serverIntegrationAutomaticRebuild) {
       serverTestHelpers::responseBodyToString(std::move(response.body())),
       ::testing::HasSubstr("\"value\":\"l\""));
 
+  // The remaining paths of the trigger machinery, each deterministically:
+  // without a strategy (manual mode) the trigger does nothing; while a
+  // rebuild is (apparently) in progress, it returns early without spawning
+  // anything, and the background coroutine logs that it skipped; the
+  // completion handler logs a failure and ignores the no-exception case.
+  {
+    auto [logCleanup, logStream] = setGlobalLoggingStreamToStringStream();
+    DeltaTriplesCount hugeCount{1000, 1000};
+    auto strategy =
+        std::exchange(server.server().rebuildIndexStrategy_, std::nullopt);
+    server.server().triggerRebuildIfStrategySaysSo(hugeCount, 1);
+    server.server().rebuildIndexStrategy_ = strategy;
+    server.server().rebuildInProgress_.store(true);
+    server.server().triggerRebuildIfStrategySaysSo(hugeCount, 1);
+    EXPECT_THAT(logStream.str(),
+                ::testing::Not(::testing::HasSubstr("Triggering")));
+
+    boost::asio::thread_pool threadPool{1};
+    boost::asio::co_spawn(threadPool, server.server().runAutomaticRebuild(),
+                          boost::asio::use_future)
+        .get();
+    EXPECT_THAT(
+        logStream.str(),
+        ::testing::HasSubstr("Automatic index rebuild skipped, another rebuild "
+                             "started concurrently"));
+    server.server().rebuildInProgress_.store(false);
+
+    Server::logAutomaticRebuildFailure(
+        std::make_exception_ptr(std::runtime_error{"boom"}));
+    EXPECT_THAT(logStream.str(),
+                ::testing::HasSubstr("Automatic index rebuild failed: boom"));
+    Server::logAutomaticRebuildFailure(nullptr);
+  }
+
   cleanDirsWithPrefix("previous.");
 }
 #endif  // __EMSCRIPTEN__

--- a/test/index/IndexRebuilderTest.cpp
+++ b/test/index/IndexRebuilderTest.cpp
@@ -932,9 +932,10 @@ TEST(IndexRebuilder, serverIntegrationAutomaticRebuild) {
   qlever::EngineConfig config;
   config.baseName_ = indexName;
   config.persistUpdates_ = false;
-  // Corresponds to `--rebuild-index-strategy 2`: trigger an automatic rebuild
-  // as soon as there are more than two delta triples.
-  config.rebuildIndexDeltaTriplesThreshold_ = 2;
+  // `min == max == 3` makes the threshold a fixed three delta triples,
+  // independent of the index size: trigger an automatic rebuild as soon as the
+  // number of delta triples reaches three.
+  config.rebuildIndexStrategy_ = qlever::RebuildIndexStrategy{3, 3, 1.0};
   serverTestHelpers::ServerForTesting server{1, "accessToken", config};
 
   auto performUpdate = [&server](std::string_view update) {
@@ -955,7 +956,7 @@ TEST(IndexRebuilder, serverIntegrationAutomaticRebuild) {
     return inserted + deleted;
   };
 
-  // Two delta triples do not exceed the threshold of two, so no rebuild is
+  // Two delta triples do not reach the threshold of three, so no rebuild is
   // triggered. This is checked race-free: the trigger decision is made before
   // the response is sent, so after the update has returned, the flag can only
   // be set if a rebuild was started.
@@ -964,7 +965,7 @@ TEST(IndexRebuilder, serverIntegrationAutomaticRebuild) {
   EXPECT_FALSE(server.server().rebuildInProgress_.load());
   EXPECT_TRUE(dirsWithPrefix("previous.").empty());
 
-  // The third delta triple exceeds the threshold and triggers a rebuild in
+  // The third delta triple reaches the threshold and triggers a rebuild in
   // the background. Wait until it has completed, which is observable by the
   // delta triples being merged into the new index (their number drops to
   // zero) and the old index appearing in a `previous.<datetime>` directory.

--- a/test/index/IndexRebuilderTest.cpp
+++ b/test/index/IndexRebuilderTest.cpp
@@ -13,11 +13,14 @@
 #include <boost/asio/detached.hpp>
 #include <boost/asio/thread_pool.hpp>
 #include <boost/asio/use_future.hpp>
+#include <chrono>
 #include <future>
 #include <optional>
 #include <string>
 #include <string_view>
+#include <thread>
 
+#include "../ServerTestHelpers.h"
 #include "../util/AsioTestHelpers.h"
 #include "../util/GTestHelpers.h"
 #include "../util/HttpRequestHelpers.h"
@@ -912,4 +915,79 @@ TEST(IndexRebuilder, lazyScanNumThreadsOverride) {
   auto cleanup = setRuntimeParameterForTest<
       &RuntimeParameters::rebuildIndexScanNumThreads_>(2);
   EXPECT_EQ(index.getImpl().recomputeStatistics(state), statsDefault);
+}
+
+// _____________________________________________________________________________
+TEST(IndexRebuilder, serverIntegrationAutomaticRebuild) {
+#ifdef __EMSCRIPTEN__
+  GTEST_SKIP() << "Skipped under Emscripten: this test hangs (threaded server "
+                  "integration).";
+#endif
+  cleanDirsWithPrefix("previous.");
+  cleanDirsWithPrefix("rebuild.");
+
+  std::string indexName = "IndexRebuilder_serverIntegrationAutomaticRebuild";
+  ad_utility::testing::makeTestIndex(indexName, "<a> <b> <c> .");
+
+  qlever::EngineConfig config;
+  config.baseName_ = indexName;
+  config.persistUpdates_ = false;
+  // Corresponds to `--rebuild-index-strategy 2`: trigger an automatic rebuild
+  // as soon as there are more than two delta triples.
+  config.rebuildIndexDeltaTriplesThreshold_ = 2;
+  serverTestHelpers::ServerForTesting server{1, "accessToken", config};
+
+  auto performUpdate = [&server](std::string_view update) {
+    auto request = ad_utility::testing::makePostRequest(
+        "/?access-token=accessToken", "application/sparql-update",
+        std::string{update});
+    auto response = server.process(request);
+    EXPECT_EQ(response.base().result(), boost::beast::http::status::ok);
+  };
+
+  // The number of delta triples of the currently active index.
+  auto numDeltaTriples = [&server]() -> int64_t {
+    auto counts = server.deltaTriplesManager()
+                      .getCurrentLocatedTriplesSharedState()
+                      ->counts_;
+    AD_CORRECTNESS_CHECK(counts.has_value());
+    auto [inserted, deleted] = counts.value();
+    return inserted + deleted;
+  };
+
+  // Two delta triples do not exceed the threshold of two, so no rebuild is
+  // triggered. This is checked race-free: the trigger decision is made before
+  // the response is sent, so after the update has returned, the flag can only
+  // be set if a rebuild was started.
+  performUpdate("INSERT DATA { <d> <e> <f> . <g> <h> <i> . }");
+  EXPECT_EQ(numDeltaTriples(), 2);
+  EXPECT_FALSE(server.server().rebuildInProgress_.load());
+  EXPECT_TRUE(dirsWithPrefix("previous.").empty());
+
+  // The third delta triple exceeds the threshold and triggers a rebuild in
+  // the background. Wait until it has completed, which is observable by the
+  // delta triples being merged into the new index (their number drops to
+  // zero) and the old index appearing in a `previous.<datetime>` directory.
+  performUpdate("INSERT DATA { <j> <k> <l> . }");
+  auto deadline = std::chrono::steady_clock::now() + std::chrono::minutes(2);
+  while (
+      (numDeltaTriples() != 0 || server.server().rebuildInProgress_.load()) &&
+      std::chrono::steady_clock::now() < deadline) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  }
+  EXPECT_EQ(numDeltaTriples(), 0);
+  EXPECT_FALSE(server.server().rebuildInProgress_.load());
+  EXPECT_EQ(dirsWithPrefix("previous.").size(), 1u);
+  EXPECT_TRUE(std::filesystem::exists(indexName + ".meta-data.json"));
+
+  // The rebuilt index answers queries and contains the update triples.
+  auto request = ad_utility::testing::makeGetRequest(
+      "/?query=SELECT%20%2A%20WHERE%20%7B%20%3Cj%3E%20%3Fp%20%3Fo%20%7D");
+  auto response = server.process(request);
+  EXPECT_EQ(response.base().result(), boost::beast::http::status::ok);
+  EXPECT_THAT(
+      serverTestHelpers::responseBodyToString(std::move(response.body())),
+      ::testing::HasSubstr("\"value\":\"l\""));
+
+  cleanDirsWithPrefix("previous.");
 }

--- a/test/index/IndexRebuilderTest.cpp
+++ b/test/index/IndexRebuilderTest.cpp
@@ -682,8 +682,8 @@ TEST(IndexRebuilder, materializeToIndexNoLogFileName) {
 namespace {
 // Return the directories in the current directory whose name starts with
 // `prefix`.
-std::vector<std::filesystem::path> dirsWithPrefix(std::string_view prefix) {
-  namespace fs = std::filesystem;
+std::vector<ql::filesystem::path> dirsWithPrefix(std::string_view prefix) {
+  namespace fs = ql::filesystem;
   std::vector<fs::path> result;
   for (const auto& entry : fs::directory_iterator(".")) {
     if (entry.is_directory() &&
@@ -702,7 +702,7 @@ void cleanDirsWithPrefix(std::string_view prefix) {
                     "This function is not meant to delete all directories in "
                     "the current directory. Please specify a prefix.");
   for (const auto& dir : dirsWithPrefix(prefix)) {
-    std::filesystem::remove_all(dir);
+    ql::filesystem::remove_all(dir);
   }
 }
 }  // namespace
@@ -924,15 +924,14 @@ TEST(IndexRebuilder, lazyScanNumThreadsOverride) {
 }
 
 // _____________________________________________________________________________
+// Compiled out under Emscripten like `serverIntegration` above: the `server`
+// library it needs is not built there.
+#ifndef __EMSCRIPTEN__
 TEST(IndexRebuilder, serverIntegrationAutomaticRebuild) {
-#ifdef __EMSCRIPTEN__
-  GTEST_SKIP() << "Skipped under Emscripten: this test hangs (threaded server "
-                  "integration).";
-#endif
   cleanDirsWithPrefix("previous.");
   cleanDirsWithPrefix("rebuild.");
 
-  std::string indexName = "IndexRebuilder_serverIntegrationAutomaticRebuild";
+  std::string indexName = gtestCurrentTestName();
   ad_utility::testing::makeTestIndex(indexName, "<a> <b> <c> .");
 
   qlever::EngineConfig config;
@@ -985,7 +984,7 @@ TEST(IndexRebuilder, serverIntegrationAutomaticRebuild) {
   EXPECT_EQ(numDeltaTriples(), 0);
   EXPECT_FALSE(server.server().rebuildInProgress_.load());
   EXPECT_EQ(dirsWithPrefix("previous.").size(), 1u);
-  EXPECT_TRUE(std::filesystem::exists(indexName + ".meta-data.json"));
+  EXPECT_TRUE(ql::filesystem::exists(indexName + ".meta-data.json"));
 
   // The rebuilt index answers queries and contains the update triples.
   auto request = ad_utility::testing::makeGetRequest(
@@ -998,3 +997,4 @@ TEST(IndexRebuilder, serverIntegrationAutomaticRebuild) {
 
   cleanDirsWithPrefix("previous.");
 }
+#endif  // __EMSCRIPTEN__

--- a/test/index/IndexRebuilderTest.cpp
+++ b/test/index/IndexRebuilderTest.cpp
@@ -794,7 +794,7 @@ void cleanDirsWithPrefix(std::string_view prefix) {
 // under Emscripten anyway (threaded server integration).
 #ifndef __EMSCRIPTEN__
 TEST(IndexRebuilder, serverIntegration) {
-  namespace fs = std::filesystem;
+  namespace fs = ql::filesystem;
   cleanDirsWithPrefix("previous.");
   cleanDirsWithPrefix("rebuild.");
   cleanDirsWithPrefix("serverIntegration.");

--- a/test/libqlever/QleverTest.cpp
+++ b/test/libqlever/QleverTest.cpp
@@ -1015,4 +1015,36 @@ TEST(Qlever, makeIndexRebuildConfig) {
   // ... and must lie inside the directory of the current index.
   AD_EXPECT_THROW_WITH_MESSAGE(makeConfig("../outside", std::nullopt),
                                HasSubstr("not a subdirectory"));
+
+  // The default directory for the old index is `previous.<datetime of the
+  // build of the current index>`, which has a granularity of one second. When
+  // that directory is already taken by a previous rebuild (e.g. rebuilds in
+  // quick succession with `--rebuild-index-strategy`), `.1`, `.2`, ... is
+  // appended; an occupied directory must not fail the rebuild, because the
+  // datetime of the served index only changes on a successful swap, so all
+  // subsequent rebuilds would fail with the same name.
+  {
+    std::string defaultPreviousDir =
+        absl::StrCat("previous.", index.getImpl().dateOfIndexBuild());
+    ql::filesystem::create_directory(defaultPreviousDir);
+    ad_utility::makeOfstream(defaultPreviousDir + "/index.meta-data.json")
+        << "occupied";
+    EXPECT_EQ(makeConfig(std::nullopt, std::nullopt).oldIndexTarget(),
+              absl::StrCat(defaultPreviousDir, ".1/index"));
+    ql::filesystem::create_directory(defaultPreviousDir + ".1");
+    ad_utility::makeOfstream(defaultPreviousDir + ".1/index.meta-data.json")
+        << "occupied";
+    EXPECT_EQ(makeConfig(std::nullopt, std::nullopt).oldIndexTarget(),
+              absl::StrCat(defaultPreviousDir, ".2/index"));
+
+    // After `.99`, the rebuild fails with a readable message.
+    for (size_t i = 2; i <= 99; ++i) {
+      ql::filesystem::create_directory(
+          absl::StrCat(defaultPreviousDir, ".", i));
+    }
+    AD_EXPECT_THROW_WITH_MESSAGE(
+        makeConfig(std::nullopt, std::nullopt),
+        AllOf(HasSubstr("all already exist"),
+              HasSubstr("rebuild-previous-index-dir")));
+  }
 }


### PR DESCRIPTION
So far, a `rebuild-index` could be triggered manually. With this change, `qlever-server` has the option to rebuild its index automatically when the number of delta triples becomes large, controlled by the new option `--rebuild-index-strategy`:

* `manual` (the default): rebuilds are only triggered explicitly via `cmd=rebuild-index`, exactly as before.

* `automatic:min:max:fraction`, e.g. `automatic:10000:1000000:0.1`: after each update, a rebuild is triggered in the background (without delaying the response) once the number of delta triples reaches a threshold, namely the given `fraction` of the number of index triples, clamped to `[min, max]`.

The decision logic lives in the new unit-tested class `RebuildIndexStrategy`, and the manual and automatic triggers share the same in-progress guard, so at most one rebuild runs at any time.

The change also fixes a pre-existing bug that frequent rebuilds exposed: the default directory for the old index is `previous.<datetime of the build of the current index>`, with a granularity of one second. When two rebuilds happened within the same second, the second one found its target directory taken and failed, and because a failed rebuild does not swap (and hence never re-stamps the datetime of the served index), all subsequent rebuilds failed with the same name. The default directory name now gets a `.1`, `.2`, ... suffix in that case. An explicitly given directory that is taken remains an error.