### PR TITLE
Fix several ways in which a `LIMIT`/`OFFSET` was dropped or misapplied

### DIFF
--- a/src/engine/OptionalJoin.cpp
+++ b/src/engine/OptionalJoin.cpp
@@ -94,7 +94,12 @@ string OptionalJoin::getCacheKeyImpl() const {
 }
 
 // _____________________________________________________________________________
-void OptionalJoin::onLimitOffsetChanged(const LimitOffsetClause& limitOffset) {
+void OptionalJoin::onLimitOffsetChanged(const LimitOffsetClause&) {
+  // Note that we use the merged `getLimitOffset()` and not the clause that was
+  // passed in, which only holds the increment that was just added. The bound
+  // below depends on the total limit and offset, so for nested subqueries the
+  // increment alone would be too small.
+  const auto& limitOffset = getLimitOffset();
   if (limitOffset._limit.has_value()) {
     std::optional<uint64_t> safeLimit = std::nullopt;
     auto limit = limitOffset._limit.value();

--- a/src/engine/QueryExecutionTree.cpp
+++ b/src/engine/QueryExecutionTree.cpp
@@ -199,8 +199,8 @@ std::shared_ptr<QueryExecutionTree> QueryExecutionTree::createSortedTree(
         "implementations.");
     // We cannot use `applyLimitOffset` here, because this might get propagated
     // to children of this operation, where the limit/offset has already been
-    // set correctly. We just reapply a previously set limit which was removed
-    // by the re-sorting.
+    // set correctly. We just reapply a previously set limit to the newly
+    // created re-sorted operation, which was removed by the re-sorting.
     sortedRootOperation->setLimitOffsetDirectlyWithoutTriggeringHooks(
         rootOperation->getLimitOffset());
     return std::move(sortedQet).value();

--- a/src/engine/QueryExecutionTree.cpp
+++ b/src/engine/QueryExecutionTree.cpp
@@ -190,8 +190,19 @@ std::shared_ptr<QueryExecutionTree> QueryExecutionTree::createSortedTree(
     AD_CORRECTNESS_CHECK(sortedQet.value() != nullptr);
     AD_CORRECTNESS_CHECK(qet->getVariableColumns() ==
                          sortedQet.value()->getVariableColumns());
+    const auto& sortedRootOperation = sortedQet.value()->getRootOperation();
+    AD_CORRECTNESS_CHECK(sortedRootOperation->isSortedBy(sortColumns));
     AD_CORRECTNESS_CHECK(
-        sortedQet.value()->getRootOperation()->isSortedBy(sortColumns));
+        sortedRootOperation->getLimitOffset().isUnconstrained(),
+        "`LIMIT` and `OFFSET` are applied by "
+        "`QueryExecutionTree::createSortedTree` not by the individual "
+        "implementations.");
+    // We cannot use `applyLimitOffset` here, because this might get propagated
+    // to children of this operation, where the limit/offset has already been
+    // set correctly. We just reapply a previously set limit which was removed
+    // by the re-sorting.
+    sortedRootOperation->setLimitOffsetDirectlyWithoutTriggeringHooks(
+        rootOperation->getLimitOffset());
     return std::move(sortedQet).value();
   }
 

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -2476,6 +2476,14 @@ auto QueryPlanner::applyJoinDistributivelyToUnion(
       return;
     }
 
+    // Don't distribute over a UNION that has a LIMIT or OFFSET attached to it.
+    // Such a LIMIT/OFFSET applies to the union of both children and can neither
+    // be pushed into the individual children nor be applied to the result of
+    // the join, so the optimization is simply not applicable here.
+    if (!unionOperation->getLimitOffset().isUnconstrained()) {
+      return;
+    }
+
     auto findJoinCandidates = [this, flipped](const SubtreePlan& plan1,
                                               const SubtreePlan& plan2,
                                               const JoinColumns& jcs) {

--- a/src/engine/Sort.cpp
+++ b/src/engine/Sort.cpp
@@ -251,9 +251,20 @@ std::optional<std::shared_ptr<QueryExecutionTree>> Sort::makeSortedTree(
   AD_CONTRACT_CHECK(!isSortedBy(sortColumns));
   // For an explicit `INTERNAL SORT BY` with a `LIMIT`/`OFFSET` the sort order
   // determines which rows are part of the result, so we must not replace it by
-  // a different one. Return `std::nullopt` such that an additional `Sort` is
-  // placed on top of this operation instead. Without a `LIMIT`/`OFFSET` the
-  // sort order is not observable, because the result is re-sorted anyway.
+  // a different one:
+  //
+  //   SELECT * {
+  //     { SELECT * { ?x <p> ?y . ?y <q> ?z }
+  //       INTERNAL SORT BY ?z LIMIT 5 OFFSET 7 }
+  //     ?x <r> ?w
+  //   }
+  //
+  // The subquery uses the cheap `INTERNAL SORT BY ?z` (instead of an
+  // `ORDER BY`) to obtain a deterministic subset. The outer join needs `?x`
+  // order, but sorting by `?x` instead of `?z` would change which 5 rows
+  // survive. We therefore return `std::nullopt`, such that a second `Sort` (on
+  // `?x`) is stacked on top of this one (on `?z`). Without a `LIMIT`/`OFFSET`
+  // the sort order is not observable, because the result is re-sorted anyway.
   if (explicitSort_ && !getLimitOffset().isUnconstrained()) {
     return std::nullopt;
   }

--- a/src/engine/Sort.cpp
+++ b/src/engine/Sort.cpp
@@ -249,6 +249,14 @@ Result Sort::computeResultExternal(std::vector<IdTable> collectedBlocks,
 std::optional<std::shared_ptr<QueryExecutionTree>> Sort::makeSortedTree(
     const std::vector<ColumnIndex>& sortColumns) const {
   AD_CONTRACT_CHECK(!isSortedBy(sortColumns));
+  // For an explicit `INTERNAL SORT BY` with a `LIMIT`/`OFFSET` the sort order
+  // determines which rows are part of the result, so we must not replace it by
+  // a different one. Return `std::nullopt` such that an additional `Sort` is
+  // placed on top of this operation instead. Without a `LIMIT`/`OFFSET` the
+  // sort order is not observable, because the result is re-sorted anyway.
+  if (explicitSort_ && !getLimitOffset().isUnconstrained()) {
+    return std::nullopt;
+  }
   AD_LOG_DEBUG
       << "Tried to re-sort a subtree that is already sorted by `Sort` with a "
          "different sort order. This indicates a flaw during query planning."

--- a/src/engine/Union.cpp
+++ b/src/engine/Union.cpp
@@ -390,6 +390,32 @@ std::unique_ptr<Operation> Union::cloneImpl() const {
 }
 
 // _____________________________________________________________________________
+void Union::onLimitOffsetChanged(const LimitOffsetClause&) {
+  // Note that we use the merged `getLimitOffset()` and not the clause that was
+  // passed in, which only holds the increment that was just added. The bound
+  // below depends on the total limit and offset, so for nested subqueries the
+  // increment alone would be too small.
+  const auto& limitOffset = getLimitOffset();
+  if (!limitOffset._limit.has_value()) {
+    return;
+  }
+  uint64_t limit = limitOffset._limit.value();
+  uint64_t offset = limitOffset._offset;
+  // We have to be careful to not cause an overflow when adding the offset and
+  // the limit.
+  if (limit > std::numeric_limits<uint64_t>::max() - offset) {
+    return;
+  }
+  // Both children only have to supply their first `limit + offset` rows: Each
+  // row of the result consumes exactly one row of one of the children, no
+  // matter whether they are concatenated or merged according to `targetOrder_`.
+  for (auto& subtree : _subtrees) {
+    subtree = subtree->clone();
+    subtree->applyLimitOffset(LimitOffsetClause{limit + offset});
+  }
+}
+
+// _____________________________________________________________________________
 std::optional<std::shared_ptr<QueryExecutionTree>> Union::makeSortedTree(
     const std::vector<ColumnIndex>& sortColumns) const {
   AD_CONTRACT_CHECK(!isSortedBy(sortColumns));

--- a/src/engine/Union.h
+++ b/src/engine/Union.h
@@ -92,7 +92,17 @@ class Union : public Operation {
   std::optional<ColumnIndex> getOriginalColumn(bool leftChild,
                                                ColumnIndex unionColumn) const;
 
+  // We propagate part of the `LimitOffsetClause` to both children to
+  // potentially speed them up and save memory, but `Union` does not actually
+  // apply its own `LimitOffsetClause` to itself, this still needs to be done by
+  // the `Operation` base class.
+  LimitOffsetHandling handlesLimitOffset() const override {
+    return LimitOffsetHandling::PARTIAL;
+  }
+
  private:
+  void onLimitOffsetChanged(const LimitOffsetClause&) override;
+
   [[nodiscard]] bool isDeterministicImpl() const override { return true; }
 
   std::unique_ptr<Operation> cloneImpl() const override;

--- a/src/engine/Union.h
+++ b/src/engine/Union.h
@@ -96,6 +96,16 @@ class Union : public Operation {
   // potentially speed them up and save memory, but `Union` does not actually
   // apply its own `LimitOffsetClause` to itself, this still needs to be done by
   // the `Operation` base class.
+  //
+  // Concretely, each child gets a `LIMIT` of `limit + offset` and no `OFFSET`
+  // (see `onLimitOffsetChanged`). This is always correct, because every row of
+  // the union's result consumes exactly one row of one of the children, so the
+  // first `limit + offset` rows of this operation can never require more than
+  // the first `limit + offset` rows of either child. It is however only a good
+  // optimization for small `OFFSET` values: the `OFFSET` cannot be pushed down,
+  // as we don't know upfront how the skipped rows are distributed between the
+  // two children, so for a large `OFFSET` both children still have to compute
+  // almost all of their rows.
   LimitOffsetHandling handlesLimitOffset() const override {
     return LimitOffsetHandling::PARTIAL;
   }

--- a/src/parser/data/LimitOffsetClause.h
+++ b/src/parser/data/LimitOffsetClause.h
@@ -66,7 +66,7 @@ struct LimitOffsetClause {
   bool isUnconstrained() const { return !_limit.has_value() && _offset == 0; }
 
   QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(LimitOffsetClause, _limit,
-                                              textLimit_, exportLimit_)
+                                              _offset, textLimit_, exportLimit_)
 
   // Merge two clauses together. This adds the offsets and takes the minimum of
   // both limits. If the other limit is not set, the current limit is kept.

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -3046,6 +3046,27 @@ TEST(QueryPlanner, ensureRuntimeParameterDisablesDistributiveUnion) {
 }
 
 // _____________________________________________________________________________
+TEST(QueryPlanner, distributiveJoinInUnionIsNotAppliedIfUnionHasLimit) {
+  // Make sure that the optimization is enabled, so that this test actually
+  // tests something.
+  auto cleanup =
+      setRuntimeParameterForTest<&RuntimeParameters::enableDistributiveUnion_>(
+          true);
+  // Regression test for https://github.com/ad-freiburg/qlever/issues/3162. The
+  // `LIMIT` of the subquery applies to the `UNION` as a whole. Pushing the join
+  // into the children of the `UNION` would drop the `LIMIT` and thus change the
+  // semantics of the query, so the `UNION` has to be kept intact.
+  h::expect(
+      "SELECT * { VALUES ?s { <x> } "
+      "{ SELECT * { { ?s <label> ?o } UNION { ?s <is-a> ?o } } LIMIT 1 } }",
+      h::Join(h::Sort(h::ValuesClause("VALUES (?s) { (<x>) }")),
+              h::WithLimitOffset(
+                  LimitOffsetClause{1},
+                  h::Union(h::IndexScanFromStrings("?s", "<label>", "?o"),
+                           h::IndexScanFromStrings("?s", "<is-a>", "?o")))));
+}
+
+// _____________________________________________________________________________
 TEST(QueryPlanner, testDistributiveJoinInUnionRecursive) {
   auto* qec = ad_utility::testing::getQec(
       "<a> <P279> <b> . <c> <P279> <d> . <e> <P279> <f> . <g> <P279> <h> ."

--- a/test/QueryPlannerTestHelpers.h
+++ b/test/QueryPlannerTestHelpers.h
@@ -492,6 +492,15 @@ constexpr auto OrderBy = [](const ::OrderBy::SortedVariables& sortedVariables,
 // Match a `UNION` operation.
 constexpr auto Union = MatchTypeAndOrderedChildren<::Union>;
 
+// Match a subtree that matches the `actualMatcher` and additionally has the
+// given `LIMIT`/`OFFSET` attached to its root operation.
+inline QetMatcher WithLimitOffset(const LimitOffsetClause& limitOffset,
+                                  const QetMatcher& actualMatcher) {
+  return AllOf(RootOperationBase(
+                   AD_PROPERTY(::Operation, getLimitOffset, Eq(limitOffset))),
+               actualMatcher);
+}
+
 // Match a `DISTINCT` operation.
 constexpr auto Distinct = [](const std::vector<ColumnIndex>& distinctColumns,
                              const QetMatcher& childMatcher) {

--- a/test/SortTest.cpp
+++ b/test/SortTest.cpp
@@ -27,7 +27,8 @@ using ad_utility::source_location;
 namespace {
 
 // Create a `Sort` operation that sorts the `input` by the `sortColumns`.
-Sort makeSort(IdTable input, const std::vector<ColumnIndex>& sortColumns) {
+Sort makeSort(IdTable input, const std::vector<ColumnIndex>& sortColumns,
+              bool explicitSort = false) {
   std::vector<std::optional<Variable>> vars;
   auto qec = ad_utility::testing::getQec();
   for (ColumnIndex i = 0; i < input.numColumns(); ++i) {
@@ -35,7 +36,7 @@ Sort makeSort(IdTable input, const std::vector<ColumnIndex>& sortColumns) {
   }
   auto subtree = ad_utility::makeExecutionTree<ValuesForTesting>(
       ad_utility::testing::getQec(), std::move(input), vars);
-  return Sort{qec, subtree, sortColumns};
+  return Sort{qec, subtree, sortColumns, explicitSort};
 }
 
 // Test that the `input`, when being sorted by its 0-th column as its primary
@@ -207,6 +208,20 @@ TEST(Sort, checkSortedCloneIsProperlyHandled) {
         *operation.value()->getRootOperation()->getChildren().at(0);
     EXPECT_NE(typeid(childReference), typeid(Sort));
   }
+}
+
+// _____________________________________________________________________________
+TEST(Sort, explicitSortIsOnlyKeptIfALimitIsPresent) {
+  VectorTable input{{0, 0}, {1, 1}};
+  auto inputTable = makeIdTableFromVector(input, &Id::makeFromInt);
+  Sort sort = makeSort(std::move(inputTable), {0, 1}, true);
+  // Without a `LIMIT`/`OFFSET` the sort order of an explicit `INTERNAL SORT BY`
+  // is not observable, so it may be replaced by a different one.
+  EXPECT_TRUE(sort.makeSortedTree({1, 0}).has_value());
+  // With a `LIMIT` the sort order determines which rows are part of the result,
+  // so an additional `Sort` has to be placed on top of this operation instead.
+  sort.applyLimitOffset({1});
+  EXPECT_FALSE(sort.makeSortedTree({1, 0}).has_value());
 }
 
 // _____________________________________________________________________________

--- a/test/UnionTest.cpp
+++ b/test/UnionTest.cpp
@@ -785,14 +785,19 @@ TEST(Union, limitAndOffsetArePushedDownToChildren) {
         Vars{Var{"?a"}});
     return Union{qec, std::move(leftT), std::move(rightT)};
   };
-  auto expectChildLimits = [](Union& unionOperation,
-                              std::optional<uint64_t> limit) {
-    for (const auto* child : unionOperation.getChildren()) {
-      EXPECT_EQ(child->getRootOperation()->getLimitOffset(),
-                LimitOffsetClause{limit});
-    }
-  };
-  auto expectResult = [qec](Union& unionOperation, const IdTable& expected) {
+  auto expectChildLimits =
+      [](Union& unionOperation, std::optional<uint64_t> limit,
+         ad_utility::source_location loc = AD_CURRENT_SOURCE_LOC()) {
+        auto trace = generateLocationTrace(loc);
+        for (const auto* child : unionOperation.getChildren()) {
+          EXPECT_EQ(child->getRootOperation()->getLimitOffset(),
+                    LimitOffsetClause{limit});
+        }
+      };
+  auto expectResult = [qec](Union& unionOperation, const IdTable& expected,
+                            ad_utility::source_location loc =
+                                AD_CURRENT_SOURCE_LOC()) {
+    auto trace = generateLocationTrace(loc);
     qec->getQueryTreeCache().clearAll();
     EXPECT_EQ(unionOperation.getResult(false)->idTableView(), expected);
   };

--- a/test/UnionTest.cpp
+++ b/test/UnionTest.cpp
@@ -770,3 +770,65 @@ TEST(Union, getCostEstimate) {
   EXPECT_GT(unsortedUnionSmall.getCostEstimate(),
             valuesSmall->getCostEstimate() * 2);
 }
+
+// _____________________________________________________________________________
+TEST(Union, limitAndOffsetArePushedDownToChildren) {
+  using Var = Variable;
+  auto* qec = ad_utility::testing::getQec();
+  // The left child yields 1 to 5 and the right child yields 6 to 10, so the
+  // union yields the numbers 1 to 10 in that order.
+  auto makeUnion = [qec]() {
+    auto leftT = ad_utility::makeExecutionTree<ValuesForTesting>(
+        qec, makeIdTableFromVector({{1}, {2}, {3}, {4}, {5}}), Vars{Var{"?a"}});
+    auto rightT = ad_utility::makeExecutionTree<ValuesForTesting>(
+        qec, makeIdTableFromVector({{6}, {7}, {8}, {9}, {10}}),
+        Vars{Var{"?a"}});
+    return Union{qec, std::move(leftT), std::move(rightT)};
+  };
+  auto expectChildLimits = [](Union& unionOperation,
+                              std::optional<uint64_t> limit) {
+    for (const auto* child : unionOperation.getChildren()) {
+      const auto& limitOffset = child->getRootOperation()->getLimitOffset();
+      EXPECT_EQ(limitOffset._limit, limit);
+      EXPECT_EQ(limitOffset._offset, 0);
+    }
+  };
+  auto expectResult = [qec](Union& unionOperation, const IdTable& expected) {
+    qec->getQueryTreeCache().clearAll();
+    EXPECT_EQ(unionOperation.getResult(false)->idTableView(), expected);
+  };
+
+  {
+    // Both children only have to supply `limit + offset` rows.
+    auto unionOperation = makeUnion();
+    unionOperation.applyLimitOffset({2, 3});
+    expectChildLimits(unionOperation, 5);
+    // The `Union` still has to apply the `LIMIT`/`OFFSET` to its own result.
+    expectResult(unionOperation, makeIdTableFromVector({{4}, {5}}));
+  }
+  {
+    // A `LIMIT`/`OFFSET` that is applied on top of a previous one (which
+    // happens for nested subqueries) must not shrink the limit of the children
+    // too much. Here the result consists of the rows 5 and 6 of the union, so
+    // the children still have to supply 7 rows.
+    auto unionOperation = makeUnion();
+    unionOperation.applyLimitOffset({10, 5});
+    expectChildLimits(unionOperation, 15);
+    unionOperation.applyLimitOffset({2, 0});
+    expectChildLimits(unionOperation, 7);
+    expectResult(unionOperation, makeIdTableFromVector({{6}, {7}}));
+  }
+  {
+    // Adding up the limit and the offset must not overflow.
+    auto unionOperation = makeUnion();
+    unionOperation.applyLimitOffset({std::numeric_limits<uint64_t>::max(), 1});
+    expectChildLimits(unionOperation, std::nullopt);
+  }
+  {
+    // Without a limit there is no bound that could be pushed down.
+    auto unionOperation = makeUnion();
+    unionOperation.applyLimitOffset({std::nullopt, 8});
+    expectChildLimits(unionOperation, std::nullopt);
+    expectResult(unionOperation, makeIdTableFromVector({{9}, {10}}));
+  }
+}

--- a/test/UnionTest.cpp
+++ b/test/UnionTest.cpp
@@ -788,9 +788,8 @@ TEST(Union, limitAndOffsetArePushedDownToChildren) {
   auto expectChildLimits = [](Union& unionOperation,
                               std::optional<uint64_t> limit) {
     for (const auto* child : unionOperation.getChildren()) {
-      const auto& limitOffset = child->getRootOperation()->getLimitOffset();
-      EXPECT_EQ(limitOffset._limit, limit);
-      EXPECT_EQ(limitOffset._offset, 0);
+      EXPECT_EQ(child->getRootOperation()->getLimitOffset(),
+                LimitOffsetClause{limit});
     }
   };
   auto expectResult = [qec](Union& unionOperation, const IdTable& expected) {

--- a/test/engine/OptionalJoinTest.cpp
+++ b/test/engine/OptionalJoinTest.cpp
@@ -565,7 +565,10 @@ TEST(OptionalJoin, limitAndOffsetArePushedDownToLeftChild) {
                         idTableToExecutionTree(qec, a)};
   };
   auto expectChildLimits = [](OptionalJoin& optionalJoin,
-                              std::optional<uint64_t> limit) {
+                              std::optional<uint64_t> limit,
+                              ad_utility::source_location loc =
+                                  AD_CURRENT_SOURCE_LOC()) {
+    auto trace = generateLocationTrace(loc);
     auto children = optionalJoin.getChildren();
     EXPECT_EQ(children.at(0)->getRootOperation()->getLimitOffset(),
               LimitOffsetClause{limit});

--- a/test/engine/OptionalJoinTest.cpp
+++ b/test/engine/OptionalJoinTest.cpp
@@ -557,6 +557,57 @@ TEST(OptionalJoin, clone) {
 }
 
 // _____________________________________________________________________________
+TEST(OptionalJoin, limitAndOffsetArePushedDownToLeftChild) {
+  auto qec = ad_utility::testing::getQec();
+  auto a = makeIdTableFromVector({{0}});
+  auto makeOptionalJoin = [&qec, &a]() {
+    return OptionalJoin{qec, idTableToExecutionTree(qec, a),
+                        idTableToExecutionTree(qec, a)};
+  };
+  auto expectChildLimits = [](OptionalJoin& optionalJoin,
+                              std::optional<uint64_t> limit) {
+    auto children = optionalJoin.getChildren();
+    const auto& limitOffset =
+        children.at(0)->getRootOperation()->getLimitOffset();
+    EXPECT_EQ(limitOffset._limit, limit);
+    EXPECT_EQ(limitOffset._offset, 0);
+    // The right side is optional, so reducing it could drop matches.
+    EXPECT_TRUE(
+        children.at(1)->getRootOperation()->getLimitOffset().isUnconstrained());
+  };
+
+  {
+    // The left child only has to supply `limit + offset` rows.
+    auto optionalJoin = makeOptionalJoin();
+    optionalJoin.applyLimitOffset({2, 3});
+    expectChildLimits(optionalJoin, 5);
+  }
+  {
+    // A `LIMIT`/`OFFSET` that is applied on top of a previous one (which
+    // happens for nested subqueries) must not shrink the limit of the left
+    // child too much. Here the result consists of the rows 5 and 6, so the
+    // left child still has to supply 7 rows.
+    auto optionalJoin = makeOptionalJoin();
+    optionalJoin.applyLimitOffset({10, 5});
+    expectChildLimits(optionalJoin, 15);
+    optionalJoin.applyLimitOffset({2, 0});
+    expectChildLimits(optionalJoin, 7);
+  }
+  {
+    // Adding up the limit and the offset must not overflow.
+    auto optionalJoin = makeOptionalJoin();
+    optionalJoin.applyLimitOffset({std::numeric_limits<uint64_t>::max(), 1});
+    expectChildLimits(optionalJoin, std::nullopt);
+  }
+  {
+    // Without a limit there is no bound that could be pushed down.
+    auto optionalJoin = makeOptionalJoin();
+    optionalJoin.applyLimitOffset({std::nullopt, 8});
+    expectChildLimits(optionalJoin, std::nullopt);
+  }
+}
+
+// _____________________________________________________________________________
 TEST(OptionalJoin, lazyOptionalJoin) {
   std::vector<IdTable> expected;
   expected.push_back(makeIdTableFromVector({{V(1), V(11), U},

--- a/test/engine/OptionalJoinTest.cpp
+++ b/test/engine/OptionalJoinTest.cpp
@@ -567,10 +567,8 @@ TEST(OptionalJoin, limitAndOffsetArePushedDownToLeftChild) {
   auto expectChildLimits = [](OptionalJoin& optionalJoin,
                               std::optional<uint64_t> limit) {
     auto children = optionalJoin.getChildren();
-    const auto& limitOffset =
-        children.at(0)->getRootOperation()->getLimitOffset();
-    EXPECT_EQ(limitOffset._limit, limit);
-    EXPECT_EQ(limitOffset._offset, 0);
+    EXPECT_EQ(children.at(0)->getRootOperation()->getLimitOffset(),
+              LimitOffsetClause{limit});
     // The right side is optional, so reducing it could drop matches.
     EXPECT_TRUE(
         children.at(1)->getRootOperation()->getLimitOffset().isUnconstrained());

--- a/test/engine/QueryExecutionTreeTest.cpp
+++ b/test/engine/QueryExecutionTreeTest.cpp
@@ -135,6 +135,47 @@ TEST(QueryExecutionTree, limitAndOffsetIsPropagatedWhenStrippingColumns) {
 }
 
 // _____________________________________________________________________________
+TEST(QueryExecutionTree, limitAndOffsetIsPropagatedWhenCreatingSortedTree) {
+  using Var = Variable;
+  using Vars = std::vector<std::optional<Variable>>;
+  auto* qec = getQec();
+
+  LimitOffsetClause limitOffset{2, 3};
+
+  auto leftT = ad_utility::makeExecutionTree<ValuesForTesting>(
+      qec, makeIdTableFromVector({{1}}), Vars{Var{"?a"}});
+  auto rightT = ad_utility::makeExecutionTree<ValuesForTesting>(
+      qec, makeIdTableFromVector({{0}}), Vars{Var{"?a"}});
+
+  // `Union` natively supports creating a sorted variant of itself, which
+  // replaces the root operation and therefore has to restore the limit.
+  auto unionTree = ad_utility::makeExecutionTree<Union>(qec, leftT, rightT);
+  unionTree->applyLimitOffset(limitOffset);
+
+  auto sortedTree = QueryExecutionTree::createSortedTree(unionTree, {0});
+  ASSERT_TRUE(std::dynamic_pointer_cast<Union>(sortedTree->getRootOperation()));
+  const auto& sortedLimitOffset =
+      sortedTree->getRootOperation()->getLimitOffset();
+  EXPECT_EQ(sortedLimitOffset._limit, limitOffset._limit);
+  EXPECT_EQ(sortedLimitOffset._offset, limitOffset._offset);
+
+  // `ValuesForTesting` doesn't support this natively, so an additional `Sort`
+  // is added on top and the limit stays where it is.
+  auto valuesForTesting = ad_utility::makeExecutionTree<ValuesForTesting>(
+      qec, makeIdTableFromVector({{1}, {0}}), Vars{Var{"?a"}});
+  valuesForTesting->applyLimitOffset(limitOffset);
+
+  auto sortedValues =
+      QueryExecutionTree::createSortedTree(valuesForTesting, {0});
+  ASSERT_TRUE(
+      std::dynamic_pointer_cast<Sort>(sortedValues->getRootOperation()));
+  EXPECT_TRUE(
+      sortedValues->getRootOperation()->getLimitOffset().isUnconstrained());
+  EXPECT_EQ(valuesForTesting->getRootOperation()->getLimitOffset()._offset,
+            limitOffset._offset);
+}
+
+// _____________________________________________________________________________
 TEST(QueryExecutionTree, strippingColumnsIsNoOpWhenAllVariablesAreKept) {
   using Vars = std::vector<std::optional<Variable>>;
   Vars vars{std::nullopt, std::nullopt, std::nullopt};

--- a/test/engine/QueryExecutionTreeTest.cpp
+++ b/test/engine/QueryExecutionTreeTest.cpp
@@ -154,10 +154,7 @@ TEST(QueryExecutionTree, limitAndOffsetIsPropagatedWhenCreatingSortedTree) {
 
   auto sortedTree = QueryExecutionTree::createSortedTree(unionTree, {0});
   ASSERT_TRUE(std::dynamic_pointer_cast<Union>(sortedTree->getRootOperation()));
-  const auto& sortedLimitOffset =
-      sortedTree->getRootOperation()->getLimitOffset();
-  EXPECT_EQ(sortedLimitOffset._limit, limitOffset._limit);
-  EXPECT_EQ(sortedLimitOffset._offset, limitOffset._offset);
+  EXPECT_EQ(sortedTree->getRootOperation()->getLimitOffset(), limitOffset);
 
   // `ValuesForTesting` doesn't support this natively, so an additional `Sort`
   // is added on top and the limit stays where it is.
@@ -171,8 +168,8 @@ TEST(QueryExecutionTree, limitAndOffsetIsPropagatedWhenCreatingSortedTree) {
       std::dynamic_pointer_cast<Sort>(sortedValues->getRootOperation()));
   EXPECT_TRUE(
       sortedValues->getRootOperation()->getLimitOffset().isUnconstrained());
-  EXPECT_EQ(valuesForTesting->getRootOperation()->getLimitOffset()._offset,
-            limitOffset._offset);
+  EXPECT_EQ(valuesForTesting->getRootOperation()->getLimitOffset(),
+            limitOffset);
 }
 
 // _____________________________________________________________________________


### PR DESCRIPTION
A `LIMIT`/`OFFSET` on a `UNION` subquery was silently dropped when the query planner distributively pushed a join into the `UNION` (#3162). This change fixes that bug together with several related ones, and adds an optimization:
- Joins are no longer pushed into a `UNION` that has a `LIMIT`/`OFFSET`
- A `LIMIT`/`OFFSET` is no longer lost when an operation is replaced by a re-sorted variant of itself
- An explicit `INTERNAL SORT BY` with a `LIMIT`/`OFFSET` is no longer replaced by a different sort order, which changed which rows survive
- `OptionalJoin` no longer pushes a too-small limit into its left child for nested subqueries
- The equality comparison of `LimitOffsetClause` takes the offset into account again (a regression from #2364)
- As an optimization, `Union` now pushes `LIMIT + OFFSET` down to both of its children