### PR TITLE
Add I/O stall, process I/O, and page-cache columns to the resource-usage log

### DIFF
--- a/src/util/ResourceMonitor.cpp
+++ b/src/util/ResourceMonitor.cpp
@@ -10,6 +10,10 @@
 
 #include <absl/strings/str_format.h>
 
+#include <charconv>
+#include <sstream>
+
+#include "backports/StartsWithAndEndsWith.h"
 #include "util/Exception.h"
 #include "util/Log.h"
 #include "util/Timer.h"
@@ -83,6 +87,104 @@ std::optional<double> cpuTimeSeconds() {
 }
 
 // _____________________________________________________________________________
+std::optional<double> ioStallSeconds() {
+#if defined(__linux__)
+  std::ifstream pressure{"/proc/pressure/io"};
+  return ioStallSecondsFromPressure(pressure);
+#else
+  return std::nullopt;
+#endif
+}
+
+// _____________________________________________________________________________
+std::optional<IoBytes> currentIoBytes() {
+#if defined(__linux__)
+  std::ifstream io{"/proc/self/io"};
+  return ioBytesFromProcIo(io);
+#else
+  return std::nullopt;
+#endif
+}
+
+// _____________________________________________________________________________
+std::optional<uint64_t> currentCachedBytes() {
+#if defined(__linux__)
+  std::ifstream meminfo{"/proc/meminfo"};
+  return cachedBytesFromMeminfo(meminfo);
+#else
+  return std::nullopt;
+#endif
+}
+
+#if defined(__linux__)
+// _____________________________________________________________________________
+std::optional<double> ioStallSecondsFromPressure(std::istream& pressure) {
+  // The relevant line is `some avg10=... avg60=... avg300=... total=<n>`,
+  // where `total` is the cumulative stall time in microseconds. (The `full`
+  // line, where ALL tasks were stalled simultaneously, is system-wide and
+  // hence almost always zero on a busy server; `some` is the useful signal.)
+  std::string line;
+  while (std::getline(pressure, line)) {
+    if (!ql::starts_with(line, "some")) {
+      continue;
+    }
+    auto pos = line.rfind("total=");
+    if (pos == std::string::npos) {
+      return std::nullopt;
+    }
+    uint64_t micros = 0;
+    auto result = std::from_chars(line.data() + pos + 6,
+                                  line.data() + line.size(), micros);
+    if (result.ec != std::errc{}) {
+      return std::nullopt;
+    }
+    return static_cast<double>(micros) / 1e6;
+  }
+  return std::nullopt;
+}
+
+// _____________________________________________________________________________
+std::optional<IoBytes> ioBytesFromProcIo(std::istream& io) {
+  // The relevant lines are `read_bytes: <n>` and `write_bytes: <n>`.
+  std::optional<uint64_t> readBytes;
+  std::optional<uint64_t> writeBytes;
+  std::string key;
+  uint64_t value;
+  while (io >> key >> value) {
+    if (key == "read_bytes:") {
+      readBytes = value;
+    } else if (key == "write_bytes:") {
+      writeBytes = value;
+    }
+  }
+  if (!readBytes.has_value() || !writeBytes.has_value()) {
+    return std::nullopt;
+  }
+  return IoBytes{readBytes.value(), writeBytes.value()};
+}
+
+// _____________________________________________________________________________
+std::optional<uint64_t> cachedBytesFromMeminfo(std::istream& meminfo) {
+  // The relevant line is `Cached: <n> kB`. Parse line-wise: most lines end
+  // in a unit suffix (`kB`), which a token-wise `>> key >> value` loop would
+  // trip over.
+  std::string line;
+  while (std::getline(meminfo, line)) {
+    if (!ql::starts_with(line, "Cached:")) {
+      continue;
+    }
+    uint64_t kilobytes = 0;
+    std::istringstream fields{line.substr(std::string_view{"Cached:"}.size())};
+    if (!(fields >> kilobytes)) {
+      return std::nullopt;
+    }
+    return kilobytes * 1024;
+  }
+  return std::nullopt;
+}
+#endif
+
+// _____________________________________________________________________________
 std::optional<double> CpuPercentTracker::update(
     std::optional<double> cpuSeconds, double elapsed) {
   // Keep the old baseline on a failed reading, so the next value averages
@@ -103,12 +205,28 @@ std::optional<double> CpuPercentTracker::update(
 // _____________________________________________________________________________
 std::string formatTsvRow(double elapsed, int64_t timestampMs,
                          std::optional<uint64_t> rss,
-                         std::optional<double> cpuPercent) {
-  return absl::StrFormat("%.1f\t%d\t%s\t%s\n", elapsed, timestampMs,
-                         rss.has_value() ? std::to_string(rss.value()) : "",
-                         cpuPercent.has_value()
-                             ? absl::StrFormat("%.1f", cpuPercent.value())
-                             : "");
+                         std::optional<double> cpuPercent,
+                         std::optional<double> ioStallPercent,
+                         std::optional<IoBytes> ioBytes,
+                         std::optional<uint64_t> cachedBytes) {
+  auto integerOrEmpty = [](std::optional<uint64_t> value) {
+    return value.has_value() ? std::to_string(value.value()) : std::string{};
+  };
+  auto percentOrEmpty = [](std::optional<double> value) {
+    return value.has_value() ? absl::StrFormat("%.1f", value.value())
+                             : std::string{};
+  };
+  return absl::StrFormat(
+      "%.1f\t%d\t%s\t%s\t%s\t%s\t%s\t%s\n", elapsed, timestampMs,
+      integerOrEmpty(rss), percentOrEmpty(cpuPercent),
+      percentOrEmpty(ioStallPercent),
+      integerOrEmpty(ioBytes.has_value()
+                         ? std::optional{ioBytes.value().readBytes_}
+                         : std::nullopt),
+      integerOrEmpty(ioBytes.has_value()
+                         ? std::optional{ioBytes.value().writeBytes_}
+                         : std::nullopt),
+      integerOrEmpty(cachedBytes));
 }
 
 }  // namespace ad_utility::resource_monitor
@@ -140,6 +258,30 @@ void ResourceMonitor::start(const ql::filesystem::path& path, Mode mode,
   ql::error_code ec;
   auto oldSize = fs::file_size(path, ec);
   bool writeHeader = mode == Mode::Truncate || ec || oldSize == 0;
+  if (!writeHeader) {
+    // Appending to an existing file: if it was written by a QLever version
+    // with a different TSV format (its header differs), rotate it away, so
+    // that every file is internally consistent (header matches all rows).
+    std::ifstream existing{path};
+    std::string firstLine;
+    std::getline(existing, firstLine);
+    if (firstLine != resource_monitor::tsvHeader) {
+      auto rotated = path;
+      rotated += ".old";
+      fs::rename(path, rotated, ec);
+      if (ec) {
+        AD_LOG_WARN << "ResourceMonitor: could not move the resource-usage "
+                       "log of an older format out of the way; appending "
+                       "rows in the current format to it."
+                    << std::endl;
+      } else {
+        AD_LOG_INFO << "ResourceMonitor: moved the resource-usage log of an "
+                       "older format to \""
+                    << rotated.string() << "\"" << std::endl;
+      }
+      writeHeader = true;
+    }
+  }
   auto openMode = mode == Mode::Truncate ? std::ios::trunc : std::ios::app;
   stream_.open(path, std::ios::out | openMode);
   if (!stream_.is_open()) {
@@ -149,7 +291,7 @@ void ResourceMonitor::start(const ql::filesystem::path& path, Mode mode,
     return;
   }
   if (writeHeader) {
-    stream_ << "elapsed_s\ttimestamp_ms\trss\tcpu_percent\n" << std::flush;
+    stream_ << resource_monitor::tsvHeader << '\n' << std::flush;
   }
   // Spawn last: the thread uses the stream right away. An exception
   // escaping a thread would terminate the process, so catch everything.
@@ -190,6 +332,8 @@ void ResourceMonitor::setReadersForTesting(
 void ResourceMonitor::runLoop(std::chrono::milliseconds interval) {
   Timer timer{Timer::Started};
   resource_monitor::CpuPercentTracker cpuTracker{cpuReader_()};
+  resource_monitor::CpuPercentTracker ioStallTracker{
+      resource_monitor::ioStallSeconds()};
 
   // Absolute deadlines keep the ticks on a steady grid, no matter how
   // long each sample takes.
@@ -204,9 +348,12 @@ void ResourceMonitor::runLoop(std::chrono::milliseconds interval) {
     double elapsed = Timer::toSeconds(timer.value());
     auto rss = rssReader_();
     auto cpuPercent = cpuTracker.update(cpuReader_(), elapsed);
+    auto ioStallPercent =
+        ioStallTracker.update(resource_monitor::ioStallSeconds(), elapsed);
     stream_ << resource_monitor::formatTsvRow(
-        elapsed, epochMillis(std::chrono::system_clock::now()), rss,
-        cpuPercent);
+        elapsed, epochMillis(std::chrono::system_clock::now()), rss, cpuPercent,
+        ioStallPercent, resource_monitor::currentIoBytes(),
+        resource_monitor::currentCachedBytes());
     stream_.flush();
     if (stream_.fail()) {
       AD_LOG_WARN << "ResourceMonitor: writing to the output file failed; "

--- a/src/util/ResourceMonitor.h
+++ b/src/util/ResourceMonitor.h
@@ -28,6 +28,25 @@ namespace ad_utility {
 
 namespace resource_monitor {
 
+// The columns of the resource-usage TSV. `rss` is the resident set size of
+// the process in bytes; `cpu_percent` is its CPU usage as a percentage of
+// one core; `io_stall_percent` is the percentage of wall time in which at
+// least one task (system-wide) was stalled on I/O; `read_bytes` and
+// `write_bytes` are the cumulative bytes this process has read from and
+// written to the storage layer; `cached_bytes` is the current size of the
+// OS page cache (system-wide). The three I/O columns and `cached_bytes` are
+// only available on Linux and stay empty elsewhere.
+constexpr std::string_view tsvHeader =
+    "elapsed_s\ttimestamp_ms\trss\tcpu_percent\tio_stall_percent"
+    "\tread_bytes\twrite_bytes\tcached_bytes";
+
+// Cumulative I/O counters of this process: bytes actually read from and
+// written to the storage layer (not the page cache).
+struct IoBytes {
+  uint64_t readBytes_;
+  uint64_t writeBytes_;
+};
+
 // Current resident set size (RSS) of this process in bytes.
 std::optional<uint64_t> currentRssBytes();
 
@@ -40,8 +59,29 @@ std::optional<uint64_t> rssBytesFromStatm(std::istream& statm);
 // Total CPU time (user + system) used by this process so far, in seconds.
 std::optional<double> cpuTimeSeconds();
 
-// Turns successive cumulative CPU-time readings into CPU usage as a percentage
-// of one core. Stateful: each `update` is the baseline for the next.
+// Cumulative time (in seconds) in which at least one task, system-wide, was
+// stalled waiting for I/O, from the pressure stall information (PSI). Linux
+// only (and only if the kernel has PSI enabled); `std::nullopt` otherwise.
+std::optional<double> ioStallSeconds();
+
+// Cumulative storage-layer I/O of this process. Linux only.
+std::optional<IoBytes> currentIoBytes();
+
+// Current size of the OS page cache in bytes (system-wide). Linux only.
+std::optional<uint64_t> currentCachedBytes();
+
+#if defined(__linux__)
+// The parsers behind the three readers above, on streams with the format of
+// `/proc/pressure/io`, `/proc/self/io`, and `/proc/meminfo` respectively;
+// `std::nullopt` if the content is malformed.
+std::optional<double> ioStallSecondsFromPressure(std::istream& pressure);
+std::optional<IoBytes> ioBytesFromProcIo(std::istream& io);
+std::optional<uint64_t> cachedBytesFromMeminfo(std::istream& meminfo);
+#endif
+
+// Turns successive cumulative time readings (CPU seconds, or I/O stall
+// seconds) into a usage percentage over the elapsed wall time. Stateful:
+// each `update` is the baseline for the next.
 class CpuPercentTracker {
  public:
   explicit CpuPercentTracker(std::optional<double> initialCpuSeconds)
@@ -57,10 +97,14 @@ class CpuPercentTracker {
   double lastElapsed_ = 0.0;
 };
 
-// One TSV row; a missing `rss` or `cpuPercent` becomes an empty cell.
+// One TSV row (in the order of `tsvHeader`); a missing reading becomes an
+// empty cell (`ioBytes` covers the two cells `read_bytes` and `write_bytes`).
 std::string formatTsvRow(double elapsed, int64_t timestampMs,
                          std::optional<uint64_t> rss,
-                         std::optional<double> cpuPercent);
+                         std::optional<double> cpuPercent,
+                         std::optional<double> ioStallPercent,
+                         std::optional<IoBytes> ioBytes,
+                         std::optional<uint64_t> cachedBytes);
 
 // The two OS readers, as swappable function objects (see
 // `ResourceMonitor::setReadersForTesting`).
@@ -69,14 +113,17 @@ using CpuReader = absl::AnyInvocable<std::optional<double>()>;
 
 }  // namespace resource_monitor
 
-// Samples the RSS and CPU usage of this process on a background thread
-// and appends one TSV row (`elapsed_s`, `timestamp_ms`, `rss`,
-// `cpu_percent`) per interval; failed readings become empty cells. The
-// destructor stops the sampling thread and closes the file.
+// Samples resource usage of this process (and some system-wide I/O and
+// page-cache statistics, see `resource_monitor::tsvHeader`) on a background
+// thread and appends one TSV row per interval; failed readings become empty
+// cells. The destructor stops the sampling thread and closes the file.
 class ResourceMonitor {
  public:
   // `Truncate` starts a fresh file per run (index builds); `Append`
-  // accumulates rows across runs (server restarts).
+  // accumulates rows across runs (server restarts). When appending to a file
+  // whose header does not match the current format (older QLever versions
+  // wrote fewer columns), the old file is renamed to `<path>.old` and a
+  // fresh file is started, so that every file is internally consistent.
   enum class Mode { Truncate, Append };
 
   ResourceMonitor() = default;

--- a/test/ResourceMonitorTest.cpp
+++ b/test/ResourceMonitorTest.cpp
@@ -6,6 +6,7 @@
 // You may not use this file except in compliance with the Apache 2.0 License,
 // which can be found in the `LICENSE` file at the root of the QLever project.
 
+#include <absl/cleanup/cleanup.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
@@ -80,14 +81,81 @@ TEST(ResourceMonitor, RssBytesFromStatmScalesSecondFieldAndRejectsGarbage) {
 }
 #endif
 
+#if defined(__linux__)
+// _____________________________________________________________________________
+TEST(ResourceMonitor, IoStallSecondsFromPressureParsesTheSomeLine) {
+  using ad_utility::resource_monitor::ioStallSecondsFromPressure;
+  // The shape of `/proc/pressure/io`.
+  std::istringstream valid{
+      "some avg10=0.06 avg60=0.20 avg300=0.19 total=32102297014\n"
+      "full avg10=0.04 avg60=0.14 avg300=0.17 total=30474640775\n"};
+  auto seconds = ioStallSecondsFromPressure(valid);
+  ASSERT_TRUE(seconds.has_value());
+  EXPECT_DOUBLE_EQ(seconds.value(), 32102.297014);
+
+  std::istringstream noSomeLine{"full avg10=0.04 total=30474640775\n"};
+  EXPECT_FALSE(ioStallSecondsFromPressure(noSomeLine).has_value());
+  std::istringstream noTotal{"some avg10=0.06 avg60=0.20 avg300=0.19\n"};
+  EXPECT_FALSE(ioStallSecondsFromPressure(noTotal).has_value());
+  std::istringstream garbage{"some avg10=0.06 total=notanumber\n"};
+  EXPECT_FALSE(ioStallSecondsFromPressure(garbage).has_value());
+  std::istringstream empty{""};
+  EXPECT_FALSE(ioStallSecondsFromPressure(empty).has_value());
+}
+
+// _____________________________________________________________________________
+TEST(ResourceMonitor, IoBytesFromProcIoParsesReadAndWriteBytes) {
+  using ad_utility::resource_monitor::ioBytesFromProcIo;
+  // The shape of `/proc/self/io`.
+  std::istringstream valid{
+      "rchar: 3232\nwchar: 111\nsyscr: 55\nsyscw: 66\n"
+      "read_bytes: 12345\nwrite_bytes: 67890\ncancelled_write_bytes: 0\n"};
+  auto bytes = ioBytesFromProcIo(valid);
+  ASSERT_TRUE(bytes.has_value());
+  EXPECT_EQ(bytes.value().readBytes_, 12345u);
+  EXPECT_EQ(bytes.value().writeBytes_, 67890u);
+
+  std::istringstream missingWrite{"read_bytes: 12345\n"};
+  EXPECT_FALSE(ioBytesFromProcIo(missingWrite).has_value());
+  std::istringstream empty{""};
+  EXPECT_FALSE(ioBytesFromProcIo(empty).has_value());
+}
+
+// _____________________________________________________________________________
+TEST(ResourceMonitor, CachedBytesFromMeminfoParsesTheCachedLine) {
+  using ad_utility::resource_monitor::cachedBytesFromMeminfo;
+  // The shape of `/proc/meminfo` (note the `kB` unit suffixes and that
+  // `SwapCached:` must not match).
+  std::istringstream valid{
+      "MemTotal:       197465884 kB\nMemFree:        33285968 kB\n"
+      "SwapCached:     123 kB\nCached:         101672752 kB\n"};
+  auto bytes = cachedBytesFromMeminfo(valid);
+  ASSERT_TRUE(bytes.has_value());
+  EXPECT_EQ(bytes.value(), 101672752ull * 1024);
+
+  std::istringstream noCachedLine{"MemTotal: 197465884 kB\n"};
+  EXPECT_FALSE(cachedBytesFromMeminfo(noCachedLine).has_value());
+  std::istringstream garbage{"Cached: notanumber kB\n"};
+  EXPECT_FALSE(cachedBytesFromMeminfo(garbage).has_value());
+}
+#endif
+
 // _____________________________________________________________________________
 TEST(ResourceMonitor, FormatTsvRowFillsMissingReadingsWithEmptyCells) {
-  EXPECT_EQ(formatTsvRow(1.0, 1000, 2048u, 50.0), "1.0\t1000\t2048\t50.0\n");
-  EXPECT_EQ(formatTsvRow(1.0, 1000, std::nullopt, 50.0), "1.0\t1000\t\t50.0\n");
-  EXPECT_EQ(formatTsvRow(1.0, 1000, 2048u, std::nullopt),
-            "1.0\t1000\t2048\t\n");
-  EXPECT_EQ(formatTsvRow(1.0, 1000, std::nullopt, std::nullopt),
-            "1.0\t1000\t\t\n");
+  using ad_utility::resource_monitor::IoBytes;
+  EXPECT_EQ(formatTsvRow(1.0, 1000, 2048u, 50.0, 3.5, IoBytes{100, 200}, 4096u),
+            "1.0\t1000\t2048\t50.0\t3.5\t100\t200\t4096\n");
+  // Each missing reading becomes an empty cell (a missing `IoBytes` two of
+  // them), and the number of cells never changes.
+  EXPECT_EQ(formatTsvRow(1.0, 1000, std::nullopt, 50.0, std::nullopt,
+                         IoBytes{100, 200}, std::nullopt),
+            "1.0\t1000\t\t50.0\t\t100\t200\t\n");
+  EXPECT_EQ(
+      formatTsvRow(1.0, 1000, 2048u, std::nullopt, 3.5, std::nullopt, 4096u),
+      "1.0\t1000\t2048\t\t3.5\t\t\t4096\n");
+  EXPECT_EQ(formatTsvRow(1.0, 1000, std::nullopt, std::nullopt, std::nullopt,
+                         std::nullopt, std::nullopt),
+            "1.0\t1000\t\t\t\t\t\t\n");
 }
 
 // _____________________________________________________________________________
@@ -176,17 +244,20 @@ TEST(ResourceMonitor, TruncateModeWritesHeader) {
   }
   auto lines = readLines(path);
   ASSERT_EQ(lines.size(), 1u);
-  EXPECT_EQ(lines[0], "elapsed_s\ttimestamp_ms\trss\tcpu_percent");
+  EXPECT_EQ(lines[0],
+            "elapsed_s\ttimestamp_ms\trss\tcpu_percent\tio_stall_percent"
+            "\tread_bytes\twrite_bytes\tcached_bytes");
 }
 
 // _____________________________________________________________________________
 TEST(ResourceMonitor, AppendModeKeepsExistingHeader) {
   auto [path, cleanup] = ad_utility::testing::filenameForTesting();
-  // A log left over from an earlier run: a header plus one data row.
+  // A log left over from an earlier run OF THE SAME FORMAT: the current
+  // header plus one data row.
   {
     std::ofstream existing{path};
-    existing << "elapsed_s\ttimestamp_ms\trss\tcpu_percent\n";
-    existing << "0.0\t1000\t2048\t10.0\n";
+    existing << ad_utility::resource_monitor::tsvHeader << "\n";
+    existing << "0.0\t1000\t2048\t10.0\t0.5\t100\t200\t4096\n";
   }
   {
     ResourceMonitor monitor;
@@ -196,8 +267,39 @@ TEST(ResourceMonitor, AppendModeKeepsExistingHeader) {
   }
   auto lines = readLines(path);
   ASSERT_EQ(lines.size(), 2u);
-  EXPECT_EQ(lines[0], "elapsed_s\ttimestamp_ms\trss\tcpu_percent");
-  EXPECT_EQ(lines[1], "0.0\t1000\t2048\t10.0");
+  EXPECT_EQ(lines[0],
+            "elapsed_s\ttimestamp_ms\trss\tcpu_percent\tio_stall_percent"
+            "\tread_bytes\twrite_bytes\tcached_bytes");
+  EXPECT_EQ(lines[1], "0.0\t1000\t2048\t10.0\t0.5\t100\t200\t4096");
+}
+
+// _____________________________________________________________________________
+TEST(ResourceMonitor, AppendModeRotatesFileOfOlderFormat) {
+  auto [path, cleanup] = ad_utility::testing::filenameForTesting();
+  // A log left over from an older QLever version: fewer columns. Appending
+  // current-format rows to it would produce a file whose rows do not match
+  // its header, so it is moved to `<path>.old` and a fresh file is started.
+  {
+    std::ofstream existing{path};
+    existing << "elapsed_s\ttimestamp_ms\trss\tcpu_percent\n";
+    existing << "0.0\t1000\t2048\t10.0\n";
+  }
+  auto rotated = path;
+  rotated += ".old";
+  absl::Cleanup removeRotated{[&rotated] { fs::remove(rotated); }};
+  {
+    ResourceMonitor monitor;
+    // Long interval so no data row is written; the fresh file holds only
+    // the new header.
+    monitor.start(path, ResourceMonitor::Mode::Append, std::chrono::hours{1});
+  }
+  auto lines = readLines(path);
+  ASSERT_EQ(lines.size(), 1u);
+  EXPECT_EQ(lines[0], ad_utility::resource_monitor::tsvHeader);
+  auto rotatedLines = readLines(rotated);
+  ASSERT_EQ(rotatedLines.size(), 2u);
+  EXPECT_EQ(rotatedLines[0], "elapsed_s\ttimestamp_ms\trss\tcpu_percent");
+  EXPECT_EQ(rotatedLines[1], "0.0\t1000\t2048\t10.0");
 }
 
 // _____________________________________________________________________________
@@ -213,7 +315,9 @@ TEST(ResourceMonitor, AppendModeWritesHeaderWhenFileIsEmptyOrMissing) {
     }
     auto lines = readLines(path);
     ASSERT_EQ(lines.size(), 1u);
-    EXPECT_EQ(lines[0], "elapsed_s\ttimestamp_ms\trss\tcpu_percent");
+    EXPECT_EQ(lines[0],
+              "elapsed_s\ttimestamp_ms\trss\tcpu_percent\tio_stall_percent"
+              "\tread_bytes\twrite_bytes\tcached_bytes");
   };
 
   auto [missing, cleanup1] = ad_utility::testing::filenameForTesting();
@@ -238,12 +342,14 @@ TEST(ResourceMonitor, SamplesWriteWellFormedRows) {
   auto lines = readLines(path);
   // The header plus at least one sampled row.
   ASSERT_GE(lines.size(), 2u);
-  EXPECT_EQ(lines[0], "elapsed_s\ttimestamp_ms\trss\tcpu_percent");
-  // Each data row has the header's four tab-separated columns (three tabs),
-  // even when an individual reading was empty.
+  EXPECT_EQ(lines[0],
+            "elapsed_s\ttimestamp_ms\trss\tcpu_percent\tio_stall_percent"
+            "\tread_bytes\twrite_bytes\tcached_bytes");
+  // Each data row has the header's eight tab-separated columns (seven
+  // tabs), even when an individual reading was empty.
   for (auto it = lines.begin() + 1; it != lines.end(); ++it) {
-    EXPECT_EQ(std::count(it->begin(), it->end(), '\t'), 3)
-        << "row does not have 4 columns: " << *it;
+    EXPECT_EQ(std::count(it->begin(), it->end(), '\t'), 7)
+        << "row does not have 8 columns: " << *it;
   }
 }
 


### PR DESCRIPTION
The resource-usage log so far recorded the RSS and CPU usage of the process. This change appends four columns: `io_stall_percent` (the percentage of wall time in which at least one task, system-wide, was stalled on I/O, from the kernel's pressure stall information), `read_bytes` and `write_bytes` (cumulative bytes the process actually read from and wrote to the storage layer), and `cached_bytes` (the current size of the OS page cache). Together they make it possible to tell CPU contention from I/O contention and page-cache eviction, for example when analyzing the effect of a runtime index rebuild on concurrent queries and updates.

The new columns are read from `/proc` and hence Linux only; on other platforms they stay empty, while the existing RSS and CPU columns keep working on macOS as before. When appending to a log file written by an older QLever version (recognizable by its header), the old file is renamed to `<path>.old` and a fresh file is started, so that every file is internally consistent.

NOTE: The `monitor-queries` TUI of qlever-control currently unpacks exactly four fields per row and needs a small companion change to accept (or use) the new columns.
