### PR TITLE
Fix accidental stripping of columns with `COUNT(DISTINCT *)`

### DIFF
--- a/src/engine/GroupByImpl.cpp
+++ b/src/engine/GroupByImpl.cpp
@@ -310,13 +310,11 @@ GroupByImpl::GroupByImpl(QueryExecutionContext* qec,
   // used in any of the aggregate aliases. Note that a `COUNT(DISTINCT *)`
   // implicitly uses all the visible columns without mentioning any variable
   // explicitly, so in that case no column may be stripped.
-  auto anyAliasReadsAllColumns = [this]() {
-    return ql::ranges::any_of(_aliases, [](const Alias& alias) {
-      return alias._expression.containsExpressionThatReadsAllVisibleColumns();
-    });
-  };
   if (getRuntimeParameter<&RuntimeParameters::stripColumns_>() &&
-      !anyAliasReadsAllColumns()) {
+      !ql::ranges::any_of(
+          _aliases,
+          &sparqlExpression::SparqlExpressionPimpl::readsAllVisibleColumns,
+          &Alias::_expression)) {
     std::set<Variable> usedVariables{_groupByVariables.begin(),
                                      _groupByVariables.end()};
     for (const auto& alias : _aliases) {

--- a/src/engine/GroupByImpl.cpp
+++ b/src/engine/GroupByImpl.cpp
@@ -307,8 +307,16 @@ GroupByImpl::GroupByImpl(QueryExecutionContext* qec,
   }
 
   // The subtrees of a GROUP BY only need to compute columns that are grouped or
-  // used in any of the aggregate aliases.
-  if (getRuntimeParameter<&RuntimeParameters::stripColumns_>()) {
+  // used in any of the aggregate aliases. Note that a `COUNT(DISTINCT *)`
+  // implicitly uses all the visible columns without mentioning any variable
+  // explicitly, so in that case no column may be stripped.
+  auto anyAliasReadsAllColumns = [this]() {
+    return ql::ranges::any_of(_aliases, [](const Alias& alias) {
+      return alias._expression.containsExpressionThatReadsAllVisibleColumns();
+    });
+  };
+  if (getRuntimeParameter<&RuntimeParameters::stripColumns_>() &&
+      !anyAliasReadsAllColumns()) {
     std::set<Variable> usedVariables{_groupByVariables.begin(),
                                      _groupByVariables.end()};
     for (const auto& alias : _aliases) {

--- a/src/engine/sparqlExpressions/CountStarExpression.h
+++ b/src/engine/sparqlExpressions/CountStarExpression.h
@@ -25,6 +25,12 @@ class CountStarExpression : public SparqlExpression {
   // COUNT * technically is an aggregate.
   AggregateStatus isAggregate() const override;
 
+  // A `COUNT(DISTINCT *)` implicitly reads all the visible columns of its
+  // input, so the machinery that strips unused columns has to know about it.
+  // A plain `COUNT(*)` only needs the number of rows, which is unaffected by
+  // stripping columns.
+  bool readsAllVisibleColumns() const override { return distinct_; }
+
   // ___________________________________________________________________________
   std::string getCacheKey(
       [[maybe_unused]] const VariableToColumnMap& varColMap) const override;

--- a/src/engine/sparqlExpressions/SparqlExpression.cpp
+++ b/src/engine/sparqlExpressions/SparqlExpression.cpp
@@ -201,6 +201,17 @@ bool SparqlExpression::worksOnAggregatedData(
 // ________________________________________________________________
 bool SparqlExpression::isExistsExpression() const { return false; }
 
+// _____________________________________________________________________________
+bool SparqlExpression::readsAllVisibleColumns() const { return false; }
+
+// _____________________________________________________________________________
+bool SparqlExpression::containsExpressionThatReadsAllVisibleColumns() const {
+  return readsAllVisibleColumns() ||
+         ql::ranges::any_of(
+             children(),
+             &SparqlExpression::containsExpressionThatReadsAllVisibleColumns);
+}
+
 //______________________________________________________________________________
 template <typename SparqlExpressionT>
 void getExistsExpressionsImpl(SparqlExpressionT& self,

--- a/src/engine/sparqlExpressions/SparqlExpression.cpp
+++ b/src/engine/sparqlExpressions/SparqlExpression.cpp
@@ -202,14 +202,9 @@ bool SparqlExpression::worksOnAggregatedData(
 bool SparqlExpression::isExistsExpression() const { return false; }
 
 // _____________________________________________________________________________
-bool SparqlExpression::readsAllVisibleColumns() const { return false; }
-
-// _____________________________________________________________________________
-bool SparqlExpression::containsExpressionThatReadsAllVisibleColumns() const {
-  return readsAllVisibleColumns() ||
-         ql::ranges::any_of(
-             children(),
-             &SparqlExpression::containsExpressionThatReadsAllVisibleColumns);
+bool SparqlExpression::readsAllVisibleColumns() const {
+  return ql::ranges::any_of(children(),
+                            &SparqlExpression::readsAllVisibleColumns);
 }
 
 //______________________________________________________________________________

--- a/src/engine/sparqlExpressions/SparqlExpression.h
+++ b/src/engine/sparqlExpressions/SparqlExpression.h
@@ -145,6 +145,18 @@ class SparqlExpression {
   // implementation returns `false`.
   virtual bool isExistsExpression() const;
 
+  // Returns true iff evaluating this expression reads all the columns that are
+  // visible in the query body, without mentioning any of the corresponding
+  // variables explicitly (currently only `COUNT(DISTINCT *)` does this).
+  // Default implementation returns `false`. Note that `COUNT(*)` does not
+  // belong here: it only looks at the number of rows, not at their contents.
+  virtual bool readsAllVisibleColumns() const;
+
+  // Return true iff the expression tree contains an expression for which
+  // `readsAllVisibleColumns()` holds. Such expressions inhibit optimizations
+  // that strip columns which no variable in the query refers to.
+  virtual bool containsExpressionThatReadsAllVisibleColumns() const final;
+
   // Return non-null pointers to all `EXISTS` expressions in expression tree.
   // The result is passed in as a reference to simplify the recursive
   // implementation.

--- a/src/engine/sparqlExpressions/SparqlExpression.h
+++ b/src/engine/sparqlExpressions/SparqlExpression.h
@@ -145,17 +145,16 @@ class SparqlExpression {
   // implementation returns `false`.
   virtual bool isExistsExpression() const;
 
-  // Returns true iff evaluating this expression reads all the columns that are
-  // visible in the query body, without mentioning any of the corresponding
-  // variables explicitly (currently only `COUNT(DISTINCT *)` does this).
-  // Default implementation returns `false`. Note that `COUNT(*)` does not
-  // belong here: it only looks at the number of rows, not at their contents.
+  // Returns true iff evaluating this expression (or any of its
+  // subexpressions) reads all the columns that are visible in the query body,
+  // without mentioning any of the corresponding variables explicitly
+  // (currently only `COUNT(DISTINCT *)` does this). Such expressions inhibit
+  // optimizations that strip columns which no variable in the query refers to.
+  // The default implementation only recurses into the children, so an override
+  // has to take care of the recursion itself if it has children. Note that
+  // `COUNT(*)` does not belong here: it only looks at the number of rows, not
+  // at their contents.
   virtual bool readsAllVisibleColumns() const;
-
-  // Return true iff the expression tree contains an expression for which
-  // `readsAllVisibleColumns()` holds. Such expressions inhibit optimizations
-  // that strip columns which no variable in the query refers to.
-  virtual bool containsExpressionThatReadsAllVisibleColumns() const final;
 
   // Return non-null pointers to all `EXISTS` expressions in expression tree.
   // The result is passed in as a reference to simplify the recursive

--- a/src/engine/sparqlExpressions/SparqlExpressionPimpl.cpp
+++ b/src/engine/sparqlExpressions/SparqlExpressionPimpl.cpp
@@ -118,6 +118,12 @@ bool SparqlExpressionPimpl::containsAggregate() const {
   return _pimpl->containsAggregate();
 }
 
+// _____________________________________________________________________________
+bool SparqlExpressionPimpl::containsExpressionThatReadsAllVisibleColumns()
+    const {
+  return _pimpl->containsExpressionThatReadsAllVisibleColumns();
+}
+
 // ______________________________________________________________________________
 SparqlExpressionPimpl SparqlExpressionPimpl::makeVariableExpression(
     const Variable& variable) {

--- a/src/engine/sparqlExpressions/SparqlExpressionPimpl.cpp
+++ b/src/engine/sparqlExpressions/SparqlExpressionPimpl.cpp
@@ -119,9 +119,8 @@ bool SparqlExpressionPimpl::containsAggregate() const {
 }
 
 // _____________________________________________________________________________
-bool SparqlExpressionPimpl::containsExpressionThatReadsAllVisibleColumns()
-    const {
-  return _pimpl->containsExpressionThatReadsAllVisibleColumns();
+bool SparqlExpressionPimpl::readsAllVisibleColumns() const {
+  return _pimpl->readsAllVisibleColumns();
 }
 
 // ______________________________________________________________________________

--- a/src/engine/sparqlExpressions/SparqlExpressionPimpl.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionPimpl.h
@@ -58,11 +58,11 @@ class SparqlExpressionPimpl {
   // SUM, AVG, COUNT, etc. in any form.
   bool containsAggregate() const;
 
-  // Returns true iff this expression contains a subexpression that reads all
+  // Returns true iff this expression or any of its subexpressions reads all
   // the columns that are visible in the query body without explicitly
   // mentioning the corresponding variables (currently only
   // `COUNT(DISTINCT *)`). See `SparqlExpression::readsAllVisibleColumns`.
-  bool containsExpressionThatReadsAllVisibleColumns() const;
+  bool readsAllVisibleColumns() const;
 
   struct VariableAndDistinctness {
     ::Variable variable_;

--- a/src/engine/sparqlExpressions/SparqlExpressionPimpl.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionPimpl.h
@@ -58,6 +58,12 @@ class SparqlExpressionPimpl {
   // SUM, AVG, COUNT, etc. in any form.
   bool containsAggregate() const;
 
+  // Returns true iff this expression contains a subexpression that reads all
+  // the columns that are visible in the query body without explicitly
+  // mentioning the corresponding variables (currently only
+  // `COUNT(DISTINCT *)`). See `SparqlExpression::readsAllVisibleColumns`.
+  bool containsExpressionThatReadsAllVisibleColumns() const;
+
   struct VariableAndDistinctness {
     ::Variable variable_;
     bool isDistinct_;

--- a/test/GroupByTest.cpp
+++ b/test/GroupByTest.cpp
@@ -2490,6 +2490,89 @@ TEST(GroupBy, AddedHavingRows) {
   EXPECT_EQ(table, expected);
 }
 
+// _____________________________________________________________________________
+TEST(GroupBy, CountDistinctStarIsNotAffectedByStrippedColumns) {
+  // `COUNT(DISTINCT *)` reads all the columns that are visible in the query
+  // body, although it doesn't explicitly mention any of the corresponding
+  // variables. The columns of the subtree therefore must not be stripped away
+  // (regression test for #3158). A plain `COUNT(*)` in contrast only looks at
+  // the number of rows, which stripping columns doesn't change.
+  auto* qec = ad_utility::testing::getQec();
+  auto i = IntId;
+  auto V = ad_utility::testing::VocabId;
+  Variable varR{"?r"};
+  Variable varA{"?a"};
+
+  // The input has 8 rows, of which 7 are distinct (the pair `(1, 200)` occurs
+  // twice), and 4 distinct values for `?r`.
+  auto makeInput = []() {
+    return makeIdTableFromVector({{0, 1000},
+                                  {1, 200},
+                                  {2, 300},
+                                  {3, 400},
+                                  {1, 500},
+                                  {1, 700},
+                                  {3, 200},
+                                  {1, 200}});
+  };
+
+  // Run the `GROUP BY` given by `groupByVariables` and `aliases` on the input
+  // above, once with and once without the optimization that strips the columns
+  // which none of the variables in the query refers to. Both runs must yield
+  // the `expected` result.
+  auto expectResult = [&](const std::vector<Variable>& groupByVariables,
+                          const std::vector<Alias>& aliases,
+                          const IdTable& expected,
+                          ad_utility::source_location l =
+                              AD_CURRENT_SOURCE_LOC()) {
+    auto trace = generateLocationTrace(l);
+    for (bool stripColumns : {false, true}) {
+      // The stripping happens in the constructor of `GroupByImpl`, so the
+      // parameter has to be set before creating it.
+      auto cleanup =
+          setRuntimeParameterForTest<&RuntimeParameters::stripColumns_>(
+              stripColumns);
+      auto subtree = ad_utility::makeExecutionTree<ValuesForTesting>(
+          qec, makeInput(), std::vector<std::optional<Variable>>{varR, varA});
+      GroupByImpl groupBy{qec, groupByVariables, aliases, std::move(subtree)};
+      EXPECT_EQ(groupBy.computeResultOnlyForTesting().idTableView(), expected)
+          << "stripColumns = " << stripColumns;
+    }
+  };
+
+  // The case from the issue: `(COUNT(*) AS ?total) (COUNT(DISTINCT *) AS ?d)`
+  // without a `GROUP BY`. Neither alias mentions a variable, so without the fix
+  // both columns were stripped and the distinct count collapsed to 1.
+  expectResult({},
+               {Alias{SparqlExpressionPimpl{makeCountStarExpression(false),
+                                            "COUNT(*) AS ?total"},
+                      Variable{"?total"}},
+                Alias{SparqlExpressionPimpl{makeCountStarExpression(true),
+                                            "COUNT(DISTINCT *) AS ?d"},
+                      Variable{"?d"}}},
+               makeIdTableFromVector({{i(8), i(7)}}));
+
+  // The same, but with the `COUNT(DISTINCT *)` nested inside a larger
+  // expression: `(COUNT(DISTINCT *) + 1 AS ?d)`.
+  expectResult(
+      {},
+      {Alias{SparqlExpressionPimpl{
+                 makeAddExpression(makeCountStarExpression(true),
+                                   std::make_unique<IdExpression>(i(1))),
+                 "COUNT(DISTINCT *) + 1 AS ?d"},
+             Variable{"?d"}}},
+      makeIdTableFromVector({{i(8)}}));
+
+  // Grouping doesn't help either: the group columns alone are not sufficient to
+  // compute the distinct count within a group, so `?a` must be kept as well.
+  expectResult({varR},
+               {Alias{SparqlExpressionPimpl{makeCountStarExpression(true),
+                                            "COUNT(DISTINCT *) AS ?d"},
+                      Variable{"?d"}}},
+               makeIdTableFromVector(
+                   {{V(0), i(1)}, {V(1), i(3)}, {V(2), i(1)}, {V(3), i(2)}}));
+}
+
 TEST(GroupBy, Descriptor) {
   // Group by with variables
   auto* qec = ad_utility::testing::getQec();

--- a/test/GroupByTest.cpp
+++ b/test/GroupByTest.cpp
@@ -2573,6 +2573,56 @@ TEST(GroupBy, CountDistinctStarIsNotAffectedByStrippedColumns) {
                    {{V(0), i(1)}, {V(1), i(3)}, {V(2), i(1)}, {V(3), i(2)}}));
 }
 
+// _____________________________________________________________________________
+TEST(GroupBy, ColumnsThatAreUsedByNoAliasAreStripped) {
+  // The counterpart to the test above: as long as none of the aliases reads all
+  // the visible columns, the columns that are neither grouped nor used by any
+  // of the aliases are stripped from the subtree.
+  auto* qec = ad_utility::testing::getQec();
+  auto i = IntId;
+  auto V = ad_utility::testing::VocabId;
+  Variable varR{"?r"};
+  Variable varA{"?a"};
+  Variable varB{"?b"};
+
+  // `?r` is grouped and `?a` is used by the alias, but `?b` is used by neither,
+  // so only `?b` may be stripped.
+  std::vector<Alias> aliases{
+      Alias{SparqlExpressionPimpl{
+                std::make_unique<CountExpression>(
+                    false, std::make_unique<VariableExpression>(varA)),
+                "COUNT(?a) AS ?c"},
+            Variable{"?c"}}};
+  auto expected = makeIdTableFromVector({{V(0), i(2)}, {V(1), i(1)}});
+
+  using ::testing::Pair;
+  for (bool stripColumns : {false, true}) {
+    // The stripping happens in the constructor of `GroupByImpl`, so the
+    // parameter has to be set before creating it.
+    auto cleanup =
+        setRuntimeParameterForTest<&RuntimeParameters::stripColumns_>(
+            stripColumns);
+    auto subtree = ad_utility::makeExecutionTree<ValuesForTesting>(
+        qec, makeIdTableFromVector({{0, 10, 100}, {1, 20, 200}, {0, 30, 300}}),
+        std::vector<std::optional<Variable>>{varR, varA, varB});
+    GroupByImpl groupBy{qec, {varR}, aliases, std::move(subtree)};
+
+    // `?b` is only visible in the subtree if it wasn't stripped away.
+    auto expectedVariables =
+        stripColumns
+            ? std::vector{Pair(varR, ::testing::_), Pair(varA, ::testing::_)}
+            : std::vector{Pair(varR, ::testing::_), Pair(varA, ::testing::_),
+                          Pair(varB, ::testing::_)};
+    EXPECT_THAT(groupBy.getChildren().at(0)->getVariableColumns(),
+                ::testing::UnorderedElementsAreArray(expectedVariables))
+        << "stripColumns = " << stripColumns;
+
+    // Stripping the unused column doesn't change the result.
+    EXPECT_EQ(groupBy.computeResultOnlyForTesting().idTableView(), expected)
+        << "stripColumns = " << stripColumns;
+  }
+}
+
 TEST(GroupBy, Descriptor) {
   // Group by with variables
   auto* qec = ad_utility::testing::getQec();


### PR DESCRIPTION
With the `strip-columns` optimization enabled, a `COUNT(DISTINCT *)` was evaluated on a table from which all columns had been stripped, because it mentions no variable explicitly. A `DISTINCT *` on a zero-column table always yields one row, so the count was always 1. This change makes the column-stripping machinery aware that `COUNT(DISTINCT *)` implicitly reads all visible columns, in which case no column may be stripped. A plain `COUNT(*)` only needs the number of rows and is unaffected. Fixes #3158.

The problem can be demonstrated with this query on olympics https://qlever.dev/olympics/gzX8qz
```sparql
PREFIX olympics: <http://wallscope.co.uk/ontology/olympics/>
PREFIX medal: <http://wallscope.co.uk/resource/olympics/medal/>
SELECT (COUNT(*) AS ?__global_count) (COUNT(DISTINCT *) AS ?__grouped_count_star) WHERE {
  SELECT ?athlete WHERE {
    ?medal olympics:medal medal:Gold .
    ?medal olympics:athlete ?athlete .
  }
}
```