### PR TITLE
Add runtime parameter `rebuild-max-concurrent-permutation-pairs`

### DIFF
--- a/src/global/RuntimeParameters.cpp
+++ b/src/global/RuntimeParameters.cpp
@@ -31,6 +31,7 @@ RuntimeParameters::RuntimeParameters() {
   add(lazyIndexScanNumThreads_);
   add(rebuildIndexScanNumThreads_);
   add(rebuildPermutationWriterNumThreads_);
+  add(rebuildMaxConcurrentPermutationPairs_);
   add(lazyIndexScanMaxSizeMaterialization_);
   add(useBinsearchTransitivePath_);
   add(groupByHashMapEnabled_);

--- a/src/global/RuntimeParameters.h
+++ b/src/global/RuntimeParameters.h
@@ -80,6 +80,14 @@ struct RuntimeParameters {
   // parameter deliberately leaves untouched.
   SizeT rebuildPermutationWriterNumThreads_{
       1, "rebuild-permutation-writer-num-threads"};
+  // The maximum number of permutation pairs (PSO+POS, SPO+SOP, OPS+OSP, and
+  // the internal PSO+POS) that a runtime index rebuild processes in
+  // parallel. Each pair costs several CPU cores, several GB/s of memory
+  // bandwidth, and L3 cache, so lowering this value is THE knob for trading
+  // rebuild duration against interference with concurrent queries and
+  // updates. A value of 0 means "no limit" (all pairs in parallel).
+  SizeT rebuildMaxConcurrentPermutationPairs_{
+      0, "rebuild-max-concurrent-permutation-pairs"};
   Duration<std::chrono::seconds> defaultQueryTimeout_{std::chrono::seconds(30),
                                                       "default-query-timeout"};
   SizeT lazyIndexScanMaxSizeMaterialization_{

--- a/src/index/IndexRebuilder.cpp
+++ b/src/index/IndexRebuilder.cpp
@@ -10,6 +10,7 @@
 #ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
 #include "index/IndexRebuilder.h"
 
+#include <absl/cleanup/cleanup.h>
 #include <absl/time/clock.h>
 #include <absl/time/time.h>
 
@@ -23,6 +24,7 @@
 #include <boost/asio/use_awaitable.hpp>
 #include <cstdint>
 #include <fstream>
+#include <semaphore>
 #include <string>
 #include <string_view>
 #include <tuple>
@@ -499,6 +501,22 @@ indexRebuilder::IndexRebuildMapping materializeToIndex(
     permutationSettings.push_back({{OPS, OSP}, false});
   }
 
+  // Limit how many of the permutation pairs run in parallel (see the
+  // runtime parameter `rebuild-max-concurrent-permutation-pairs`; 0 means
+  // "no limit"). Each pair task acquires a slot before it starts and
+  // releases it when it is done, so the next pair starts as soon as ANY
+  // running pair finishes (the pairs differ a lot in size). A blocked
+  // `acquire` occupies one pool thread, and each running pair needs two, so
+  // the pool (sized `numberOfPermutations` = two threads per pair) always
+  // has enough threads for `maxConcurrentPairs >= 1`.
+  size_t maxConcurrentPairs = getRuntimeParameter<
+      &RuntimeParameters::rebuildMaxConcurrentPermutationPairs_>();
+  if (maxConcurrentPairs == 0) {
+    maxConcurrentPairs = permutationSettings.size();
+  }
+  std::counting_semaphore<8> pairSlots{static_cast<std::ptrdiff_t>(
+      std::min(maxConcurrentPairs, permutationSettings.size()))};
+
   for (const auto& [permutationEnums, isInternal] : permutationSettings) {
     auto [a, b] = permutationEnums;
     auto getPermutation =
@@ -509,10 +527,17 @@ indexRebuilder::IndexRebuildMapping materializeToIndex(
 
     net::co_spawn(
         threadPool,
-        createPermutationWriterTask(
-            newIndex, getPermutation(a), getPermutation(b), isInternal,
-            locatedTriplesSharedState, localVocabMapping, insertionPositions,
-            blankNodeBlocks, minBlankNodeIndex, cancellationHandle),
+        [&newIndex, getPermutation, a = a, b = b, isInternal,
+         &locatedTriplesSharedState, &localVocabMapping, &insertionPositions,
+         &blankNodeBlocks, minBlankNodeIndex, &cancellationHandle,
+         &pairSlots]() -> boost::asio::awaitable<void> {
+          pairSlots.acquire();
+          absl::Cleanup releaseSlot{[&pairSlots] { pairSlots.release(); }};
+          co_await createPermutationWriterTask(
+              newIndex, getPermutation(a), getPermutation(b), isInternal,
+              locatedTriplesSharedState, localVocabMapping, insertionPositions,
+              blankNodeBlocks, minBlankNodeIndex, cancellationHandle);
+        },
         std::ref(exceptionCollector));
   }
 

--- a/test/index/IndexRebuilderTest.cpp
+++ b/test/index/IndexRebuilderTest.cpp
@@ -535,69 +535,77 @@ TEST(IndexRebuilder, materializeToIndex) {
   for (auto [usePatterns, loadAllPermutations] :
        {std::pair{false, false}, std::pair{false, true},
         std::pair{true, true}}) {
-    ad_utility::testing::TestIndexConfig config;
-    config.turtleInput = "<a> <b> <c> . <d> <e> _:f .";
-    config.loadAllPermutations = loadAllPermutations;
-    config.usePatterns = usePatterns;
-    auto index = ad_utility::testing::makeTestIndex("materializeToIndex",
-                                                    std::move(config));
-    index.deltaTriplesManager().modify<void>([&cancellationHandle, &index](
-                                                 DeltaTriples& deltaTriples) {
-      auto g =
-          toValueId(
-              TripleComponent{ad_utility::triple_component::Iri::fromIriref(
-                  DEFAULT_GRAPH_IRI)},
-              index)
-              .value();
-      deltaTriples.insertTriples(
-          cancellationHandle, {IdTriple<0>{std::array{V(2), V(1), V(0), g}},
-                               IdTriple<0>{std::array{B(1), B(2), B(3), g}}});
-    });
+    // Also exercise the fully sequential processing of the permutation
+    // pairs (`rebuild-max-concurrent-permutation-pairs = 1`); the result
+    // must be the same as with the default (0 = no limit).
+    for (size_t maxConcurrentPairs : {size_t{0}, size_t{1}}) {
+      auto cleanupMaxPairs = setRuntimeParameterForTest<
+          &RuntimeParameters::rebuildMaxConcurrentPermutationPairs_>(
+          maxConcurrentPairs);
+      ad_utility::testing::TestIndexConfig config;
+      config.turtleInput = "<a> <b> <c> . <d> <e> _:f .";
+      config.loadAllPermutations = loadAllPermutations;
+      config.usePatterns = usePatterns;
+      auto index = ad_utility::testing::makeTestIndex("materializeToIndex",
+                                                      std::move(config));
+      index.deltaTriplesManager().modify<void>([&cancellationHandle, &index](
+                                                   DeltaTriples& deltaTriples) {
+        auto g =
+            toValueId(
+                TripleComponent{ad_utility::triple_component::Iri::fromIriref(
+                    DEFAULT_GRAPH_IRI)},
+                index)
+                .value();
+        deltaTriples.insertTriples(
+            cancellationHandle, {IdTriple<0>{std::array{V(2), V(1), V(0), g}},
+                                 IdTriple<0>{std::array{B(1), B(2), B(3), g}}});
+      });
 
-    auto [state, vocab, blankNodes] =
-        index.deltaTriplesManager()
-            .getCurrentLocatedTriplesSharedStateWithVocab();
+      auto [state, vocab, blankNodes] =
+          index.deltaTriplesManager()
+              .getCurrentLocatedTriplesSharedStateWithVocab();
 
-    ql::filesystem::create_directory(baseFolder);
-    absl::Cleanup removeIndexFiles{
-        [&baseFolder] { ql::filesystem::remove_all(baseFolder); }};
+      ql::filesystem::create_directory(baseFolder);
+      absl::Cleanup removeIndexFiles{
+          [&baseFolder] { ql::filesystem::remove_all(baseFolder); }};
 
-    auto sourceDate = index.getImpl().dateOfIndexBuild();
+      auto sourceDate = index.getImpl().dateOfIndexBuild();
 
-    qlever::materializeToIndex(index.getImpl(), newIndexName, state, vocab,
-                               blankNodes, cancellationHandle, logFile);
-    EXPECT_TRUE(ql::filesystem::exists(logFile));
+      qlever::materializeToIndex(index.getImpl(), newIndexName, state, vocab,
+                                 blankNodes, cancellationHandle, logFile);
+      EXPECT_TRUE(ql::filesystem::exists(logFile));
 
-    IndexImpl newIndex{ad_utility::makeUnlimitedAllocator<Id>()};
-    newIndex.usePatterns() = usePatterns;
-    newIndex.loadAllPermutations() = loadAllPermutations;
-    newIndex.createFromOnDiskIndex(newIndexName, false);
+      IndexImpl newIndex{ad_utility::makeUnlimitedAllocator<Id>()};
+      newIndex.usePatterns() = usePatterns;
+      newIndex.loadAllPermutations() = loadAllPermutations;
+      newIndex.createFromOnDiskIndex(newIndexName, false);
 
-    // The rebuilt index gets its own, more recent build date. Both dates are
-    // recorded with second resolution, so the rebuild may happen within the
-    // same second as the original build; hence we only assert "not older".
-    auto parseDate = [](const std::string& date) {
-      absl::Time result;
-      std::string error;
-      EXPECT_TRUE(absl::ParseTime(DATE_OF_INDEX_BUILD_FORMAT, date,
-                                  absl::UTCTimeZone(), &result, &error))
-          << error;
-      return result;
-    };
-    EXPECT_GE(parseDate(newIndex.dateOfIndexBuild()), parseDate(sourceDate));
+      // The rebuilt index gets its own, more recent build date. Both dates are
+      // recorded with second resolution, so the rebuild may happen within the
+      // same second as the original build; hence we only assert "not older".
+      auto parseDate = [](const std::string& date) {
+        absl::Time result;
+        std::string error;
+        EXPECT_TRUE(absl::ParseTime(DATE_OF_INDEX_BUILD_FORMAT, date,
+                                    absl::UTCTimeZone(), &result, &error))
+            << error;
+        return result;
+      };
+      EXPECT_GE(parseDate(newIndex.dateOfIndexBuild()), parseDate(sourceDate));
 
-    EXPECT_EQ(newIndex.getBlankNodeManager()->minIndex_,
-              index.getBlankNodeManager()->minIndex_ +
-                  ad_utility::BlankNodeManager::blockSize_);
-    EXPECT_EQ(newIndex.numTriples().normal, 4);
-    EXPECT_EQ(newIndex.numTriples().internal, usePatterns ? 2 : 0);
-    EXPECT_EQ(newIndex.numDistinctPredicates().normal, 3);
-    EXPECT_EQ(newIndex.numDistinctPredicates().internal, usePatterns ? 1 : 0);
-    if (newIndex.loadAllPermutations()) {
-      EXPECT_EQ(newIndex.numDistinctSubjects().normal, 4);
-      EXPECT_EQ(newIndex.numDistinctSubjects().internal, 0);
-      EXPECT_EQ(newIndex.numDistinctObjects().normal, 4);
-      EXPECT_EQ(newIndex.numDistinctObjects().internal, 0);
+      EXPECT_EQ(newIndex.getBlankNodeManager()->minIndex_,
+                index.getBlankNodeManager()->minIndex_ +
+                    ad_utility::BlankNodeManager::blockSize_);
+      EXPECT_EQ(newIndex.numTriples().normal, 4);
+      EXPECT_EQ(newIndex.numTriples().internal, usePatterns ? 2 : 0);
+      EXPECT_EQ(newIndex.numDistinctPredicates().normal, 3);
+      EXPECT_EQ(newIndex.numDistinctPredicates().internal, usePatterns ? 1 : 0);
+      if (newIndex.loadAllPermutations()) {
+        EXPECT_EQ(newIndex.numDistinctSubjects().normal, 4);
+        EXPECT_EQ(newIndex.numDistinctSubjects().internal, 0);
+        EXPECT_EQ(newIndex.numDistinctObjects().normal, 4);
+        EXPECT_EQ(newIndex.numDistinctObjects().internal, 0);
+      }
     }
   }
 }


### PR DESCRIPTION
The new runtime parameter `rebuild-max-concurrent-permutation-pairs` limits how many of the (up to four) permutation pairs a runtime index rebuild processes at the same time. The limit is realized via the size of the thread pool (two threads per pair), so the next pair starts as soon as any running pair finishes (the pairs differ a lot in size). The default of 0 means "no limit", which is the previous behavior.

This is the knob for trading rebuild duration against interference with concurrent queries and updates. Each pair costs several CPU cores, several GB/s of memory bandwidth, and L3 cache, and these hardware resources (rather than scheduling priorities or disk I/O) are what a rebuild and concurrent queries compete for.

NOTE: Running a live Wikidata server, the phase that writes the new permutations occupies about 20 cores when all pairs run in parallel. On a Ryzen 9 with 16 cores (32 threads), the mean times of concurrent queries and updates are then 2-3x higher during that phase than outside of a rebuild, even with the reduced thread defaults of #3154 and regardless of scheduling priorities. With `rebuild-max-concurrent-permutation-pairs=1`, the problem disappears. Rebuild time increases from 35min to 50min, which is a good trade-off. On a machine with more cores, the default setting is fine.