### PR TITLE
Report blob-loading failures via a status instead of an exception

### DIFF
--- a/src/libqlever/NamedCachedQueryBlobManager.cpp
+++ b/src/libqlever/NamedCachedQueryBlobManager.cpp
@@ -11,6 +11,7 @@
 
 #include <absl/strings/str_cat.h>
 
+#include <cstring>
 #include <string_view>
 
 #include "index/IndexImpl.h"
@@ -49,6 +50,43 @@ constexpr std::string_view blobContentsNotReadableMessage =
     "`Qlever::serializeVocabAndNamedCacheToCompressedBlob`; the blob is "
     "probably corrupted";
 
+// Read the format version from the blob header that starts at `headerStart` in
+// `data`. Only used to include the version in the error message of
+// `NamedCachedQueryBlobManager::skipAndVerifyBlobHeader`, after the header has
+// already been checked for completeness.
+uint16_t readFormatVersionFromHeader(ql::span<const char> data,
+                                     size_t headerStart) {
+  AD_CORRECTNESS_CHECK(data.size() >= headerStart + blobHeaderSize);
+  uint16_t version;
+  std::memcpy(&version, data.data() + headerStart + sizeof(blobMagicBytes),
+              sizeof(version));
+  return version;
+}
+
+// Return the message that describes a non-`ok` blob status. If
+// `foundFormatVersion` is set, it is named in the message for `invalidVersion`;
+// it is not always available, because the buffer that holds the header may
+// already have been released when the message is built.
+std::string blobErrorMessage(NamedCachedQueryBlobManager::BlobStatus status,
+                             std::optional<uint16_t> foundFormatVersion) {
+  using Status = NamedCachedQueryBlobManager::BlobStatus;
+  switch (status) {
+    case Status::notDecompressible:
+    case Status::invalidMagicBytes:
+      return std::string{blobNotReadableMessage};
+    case Status::invalidVersion:
+      return absl::StrCat(
+          "The given blob was written by an incompatible version of QLever (",
+          foundFormatVersion.has_value()
+              ? absl::StrCat("format version ", foundFormatVersion.value())
+              : std::string{"incompatible blob format version"},
+          ", expected ", blobFormatVersion, ")");
+    case Status::ok:
+      break;
+  }
+  AD_FAIL();
+}
+
 // Run `function` and, if it throws, rethrow with `message` prepended. That way,
 // the rather cryptic low-level error messages (in particular those of ZSTD)
 // never reach the user unadorned.
@@ -61,6 +99,71 @@ decltype(auto) rethrowWithContext(std::string_view message,
     AD_THROW(absl::StrCat(message, ". Details: ", e.what()));
   }
 }
+
+// Run `function`, which must be one of the ZSTD calls below, and return
+// `nullopt` if it reports an error. Only the `std::runtime_error`s that
+// `ZstdWrapper` throws are caught; all other exceptions (in particular
+// `std::bad_alloc`, and the `ad_utility::Exception`s of the `AD_..._CHECK`
+// macros) are propagated. `errorDetails` is set to the message of the ZSTD
+// error and is left untouched on success.
+template <typename Function>
+std::optional<std::invoke_result_t<const Function&>> runZstdCall(
+    const Function& function, std::string& errorDetails) {
+  try {
+    return function();
+  } catch (const std::runtime_error& e) {
+    errorDetails = e.what();
+    return std::nullopt;
+  }
+}
+
+// The common implementation of `NamedCachedQueryBlobManager::decompressBlob`
+// and `NamedCachedQueryBlobManager::tryToDecompressBlob`: decompress
+// `compressedBlob`, and return `nullopt` (with `errorDetails` set to the
+// message of the underlying ZSTD error) if that fails.
+std::optional<std::vector<char, NamedCachedQueryBlobManager::BlobAllocator>>
+decompressBlobOrErrorDetails(ql::span<const char> compressedBlob,
+                             ql::pmr::polymorphic_allocator<char> allocator,
+                             std::string& errorDetails) {
+  using BlobAllocator = NamedCachedQueryBlobManager::BlobAllocator;
+  // Read the size of the uncompressed data from the ZSTD frame header (which
+  // always stores it, because `compressBlob` uses the one-shot
+  // `ZSTD_compress`). This also validates that `compressedBlob` starts with a
+  // ZSTD frame at all, so that arbitrary garbage is rejected right here,
+  // instead of being misinterpreted as an (arbitrarily large) size for the
+  // allocation below.
+  auto uncompressedSize = runZstdCall(
+      [&compressedBlob]() {
+        return ZstdWrapper::getUncompressedSize(compressedBlob.data(),
+                                                compressedBlob.size());
+      },
+      errorDetails);
+  if (!uncompressedSize.has_value()) {
+    return std::nullopt;
+  }
+
+  // Decompress into a buffer that is 1. allocated via the caller-provided
+  // `allocator`, 2. aligned to the maximal possible alignment (required for the
+  // zero-copy deserialization), and 3. not needlessly zero-initialized before
+  // the decompression overwrites it (see `BlobAllocator`).
+  std::vector<char, BlobAllocator> uncompressed(
+      uncompressedSize.value(),
+      BlobAllocator{ad_utility::AlignedAllocator<
+          char, ql::pmr::polymorphic_allocator<char>>{allocator}});
+  auto actualUncompressedSize = runZstdCall(
+      [&compressedBlob, &uncompressed]() {
+        return ZstdWrapper::decompressToBuffer(
+            compressedBlob.data(), compressedBlob.size(), uncompressed.data(),
+            uncompressed.size());
+      },
+      errorDetails);
+  if (!actualUncompressedSize.has_value()) {
+    return std::nullopt;
+  }
+  AD_CORRECTNESS_CHECK(actualUncompressedSize.value() ==
+                       uncompressedSize.value());
+  return uncompressed;
+}
 }  // namespace
 
 // _____________________________________________________________________________
@@ -71,26 +174,59 @@ void NamedCachedQueryBlobManager::writeBlobHeader(
 }
 
 // _____________________________________________________________________________
+NamedCachedQueryBlobManager::BlobStatus
+NamedCachedQueryBlobManager::tryToSkipAndVerifyBlobHeader(
+    ad_utility::serialization::ByteBufferReadSerializerT<
+        true, ql::span<const char>>& serializer) noexcept {
+  using Status = BlobStatus;
+  // Explicitly check that the header is complete, so that a truncated blob is
+  // reported as `invalidMagicBytes` instead of making the reads below fail.
+  if (serializer.data().size() - serializer.getCurrentPosition() <
+      blobHeaderSize) {
+    return Status::invalidMagicBytes;
+  }
+  // The reads below cannot throw, because the header is known to be complete
+  // (see above) and no alignment padding is inserted inside the header (see
+  // `blobHeaderSize`). The `catch` is only there to make the guarantee that
+  // this function never throws independent of the implementation details of
+  // the serializer.
+  try {
+    std::decay_t<decltype(blobMagicBytes)> magicBytes{};
+    serializer >> magicBytes;
+    if (magicBytes != blobMagicBytes) {
+      return Status::invalidMagicBytes;
+    }
+    uint16_t version;
+    serializer >> version;
+    if (version != blobFormatVersion) {
+      return Status::invalidVersion;
+    }
+    return Status::ok;
+  } catch (...) {
+    return Status::invalidMagicBytes;
+  }
+}
+
+// _____________________________________________________________________________
 void NamedCachedQueryBlobManager::skipAndVerifyBlobHeader(
     ad_utility::serialization::ByteBufferReadSerializerT<
         true, ql::span<const char>>& serializer) {
-  // Explicitly check that the header is complete, so that a truncated blob is
-  // reported with the message below instead of with the rather cryptic message
-  // of the serializer.
-  AD_CONTRACT_CHECK(
-      serializer.data().size() - serializer.getCurrentPosition() >=
-          blobHeaderSize,
-      blobNotReadableMessage);
-  std::decay_t<decltype(blobMagicBytes)> magicBytes{};
-  serializer >> magicBytes;
-  AD_CONTRACT_CHECK(magicBytes == blobMagicBytes, blobNotReadableMessage);
-  uint16_t version;
-  serializer >> version;
-  AD_CONTRACT_CHECK(
-      version == blobFormatVersion,
-      "The given blob was written by an incompatible version of QLever "
-      "(format version ",
-      version, ", expected ", blobFormatVersion, ")");
+  // Remember where the header starts, so that the incompatible format version
+  // can be read again for the error message below.
+  size_t headerStart = serializer.getCurrentPosition();
+  auto status = tryToSkipAndVerifyBlobHeader(serializer);
+  if (status == BlobStatus::ok) {
+    return;
+  }
+  // For an incompatible format version, name the version that was found in the
+  // message. It can still be read from the buffer, because in that case the
+  // header is complete.
+  std::optional<uint16_t> foundFormatVersion;
+  if (status == BlobStatus::invalidVersion) {
+    foundFormatVersion =
+        readFormatVersionFromHeader(serializer.data(), headerStart);
+  }
+  AD_THROW(blobErrorMessage(status, foundFormatVersion));
 }
 
 // _____________________________________________________________________________
@@ -101,38 +237,27 @@ std::vector<char> NamedCachedQueryBlobManager::compressBlob(
 }
 
 // _____________________________________________________________________________
+std::optional<std::vector<char, NamedCachedQueryBlobManager::BlobAllocator>>
+NamedCachedQueryBlobManager::tryToDecompressBlob(
+    ql::span<const char> compressedBlob,
+    ql::pmr::polymorphic_allocator<char> allocator) {
+  std::string ignoredErrorDetails;
+  return decompressBlobOrErrorDetails(compressedBlob, allocator,
+                                      ignoredErrorDetails);
+}
+
+// _____________________________________________________________________________
 std::vector<char, NamedCachedQueryBlobManager::BlobAllocator>
 NamedCachedQueryBlobManager::decompressBlob(
     ql::span<const char> compressedBlob,
     ql::pmr::polymorphic_allocator<char> allocator) {
-  // Read the size of the uncompressed data from the ZSTD frame header (which
-  // always stores it, because `compressBlob` uses the one-shot
-  // `ZSTD_compress`). This also validates that `compressedBlob` starts with a
-  // ZSTD frame at all, so that arbitrary garbage is rejected right here,
-  // instead of being misinterpreted as an (arbitrarily large) size for the
-  // allocation below.
-  size_t uncompressedSize =
-      rethrowWithContext(blobNotReadableMessage, [&compressedBlob]() {
-        return ZstdWrapper::getUncompressedSize(compressedBlob.data(),
-                                                compressedBlob.size());
-      });
-
-  // Decompress into a buffer that is 1. allocated via the caller-provided
-  // `allocator`, 2. aligned to the maximal possible alignment (required for the
-  // zero-copy deserialization), and 3. not needlessly zero-initialized before
-  // the decompression overwrites it (see `BlobAllocator`).
-  std::vector<char, BlobAllocator> uncompressed(
-      uncompressedSize,
-      BlobAllocator{ad_utility::AlignedAllocator<
-          char, ql::pmr::polymorphic_allocator<char>>{allocator}});
-  auto actualUncompressedSize = rethrowWithContext(
-      blobNotReadableMessage, [&compressedBlob, &uncompressed]() {
-        return ZstdWrapper::decompressToBuffer(
-            compressedBlob.data(), compressedBlob.size(), uncompressed.data(),
-            uncompressed.size());
-      });
-  AD_CORRECTNESS_CHECK(actualUncompressedSize == uncompressedSize);
-  return uncompressed;
+  std::string errorDetails;
+  auto uncompressed =
+      decompressBlobOrErrorDetails(compressedBlob, allocator, errorDetails);
+  if (!uncompressed.has_value()) {
+    AD_THROW(absl::StrCat(blobNotReadableMessage, ". Details: ", errorDetails));
+  }
+  return std::move(uncompressed).value();
 }
 
 // _____________________________________________________________________________
@@ -159,7 +284,8 @@ std::vector<char> NamedCachedQueryBlobManager::serialize(
 }
 
 // _____________________________________________________________________________
-void NamedCachedQueryBlobManager::deserialize(
+NamedCachedQueryBlobManager::BlobStatus
+NamedCachedQueryBlobManager::tryToDeserialize(
     Qlever& qlever, ql::span<const char> compressedBlob,
     ql::pmr::polymorphic_allocator<char> allocator) {
   AD_CONTRACT_CHECK(
@@ -169,9 +295,16 @@ void NamedCachedQueryBlobManager::deserialize(
 
   // Decompress into `deserializedBlobLifetimeExtender_`, which is kept alive
   // for the lifetime of this manager because the vocabulary and named result
-  // cache entries loaded below are zero-copy views directly into it.
-  deserializedBlobLifetimeExtender_.emplace(
-      decompressBlob(compressedBlob, allocator));
+  // cache entries loaded below are zero-copy views directly into it. Note that
+  // moving the buffer into the member does not change the location of its
+  // storage, so the views taken below stay valid.
+  auto uncompressed = tryToDecompressBlob(compressedBlob, allocator);
+  if (!uncompressed.has_value()) {
+    // Nothing of `qlever` has been touched yet, so it is left exactly as it
+    // was.
+    return BlobStatus::notDecompressible;
+  }
+  deserializedBlobLifetimeExtender_.emplace(std::move(uncompressed).value());
 
   // Use a serializer that only borrows a view of
   // `deserializedBlobLifetimeExtender_`, rather than one that owns/moves it, so
@@ -181,7 +314,14 @@ void NamedCachedQueryBlobManager::deserialize(
                                                        ql::span<const char>>
       reader{ql::span<const char>{deserializedBlobLifetimeExtender_.value()}};
 
-  skipAndVerifyBlobHeader(reader);
+  auto headerStatus = tryToSkipAndVerifyBlobHeader(reader);
+  if (headerStatus != BlobStatus::ok) {
+    // Nothing of `qlever` has been touched yet either, so release the buffer
+    // again. That way a rejected blob leaves this manager (and hence `qlever`)
+    // exactly as it was, and another blob can be loaded afterwards.
+    deserializedBlobLifetimeExtender_.reset();
+    return headerStatus;
+  }
 
   auto indexAndViews = qlever.indexAndViewsSnapshot();
   auto& indexImpl = indexAndViews->index_.getImpl();
@@ -203,6 +343,22 @@ void NamedCachedQueryBlobManager::deserialize(
             reader, qlever.allocator_,
             indexAndViews->index_.getLocalVocabContext());
       });
+  return BlobStatus::ok;
+}
+
+// _____________________________________________________________________________
+void NamedCachedQueryBlobManager::deserialize(
+    Qlever& qlever, ql::span<const char> compressedBlob,
+    ql::pmr::polymorphic_allocator<char> allocator) {
+  auto status = tryToDeserialize(qlever, compressedBlob, allocator);
+  if (status != BlobStatus::ok) {
+    // NOTE: The message can only name the category of the failure, not its
+    // details (the underlying ZSTD error, or the format version that was
+    // found), because `tryToDeserialize` reports only a status and has already
+    // released the buffer that held the header. Use `decompressBlob` and
+    // `skipAndVerifyBlobHeader` directly to get those details.
+    AD_THROW(blobErrorMessage(status, std::nullopt));
+  }
 }
 
 }  // namespace qlever

--- a/src/libqlever/NamedCachedQueryBlobManager.h
+++ b/src/libqlever/NamedCachedQueryBlobManager.h
@@ -42,6 +42,23 @@ class NamedCachedQueryBlobManager {
       char,
       ad_utility::AlignedAllocator<char, ql::pmr::polymorphic_allocator<char>>>;
 
+  // The result of loading a blob (see `tryToDeserialize` below). All of these
+  // are detected before any of the actual contents of the blob is read.
+  enum class BlobStatus {
+    // The blob was decompressed and its header is compatible with this version
+    // of QLever.
+    ok,
+    // The blob is not a ZSTD frame written by `compressBlob`, or its compressed
+    // data is corrupted (see `tryToDecompressBlob`).
+    notDecompressible,
+    // The decompressed blob does not start with the expected magic bytes. This
+    // also covers the case that it is too short to hold a complete header.
+    invalidMagicBytes,
+    // The magic bytes are correct, but the format version stored in the blob is
+    // not the one that this version of QLever writes.
+    invalidVersion
+  };
+
  private:
   // In this buffer, the blob passed to `deserialize` is kept alive (in
   // decompressed form) for the lifetime of this manager (and hence of the
@@ -65,9 +82,27 @@ class NamedCachedQueryBlobManager {
   // kept alive for the lifetime of this manager and is allocated via the
   // `allocator` (see `BlobAllocator` above).
   //
+  // Return `ok` on success, and the reason for the rejection if the blob cannot
+  // be decompressed, or if its header is missing or incompatible (see
+  // `BlobStatus`). In those cases, `qlever` is left completely unchanged, so it
+  // can be used as if this function had never been called, and another blob can
+  // be loaded afterwards.
+  //
+  // NOTE: This function is non-throwing only for the failures that are detected
+  // before any of the actual contents of the blob is read (see `BlobStatus`).
+  // Contents that cannot be read behind a valid header still throw, as does a
+  // violation of the preconditions below.
+  //
   // PRECONDITION: Must only be called while no other thread can concurrently
   // access `qlever`, e.g. right after construction and before the first query
-  // is answered. Must not be called more than once on the same manager.
+  // is answered. Must not be called more than once on the same manager, except
+  // after a call that returned a status other than `ok`.
+  BlobStatus tryToDeserialize(Qlever& qlever,
+                              ql::span<const char> compressedBlob,
+                              ql::pmr::polymorphic_allocator<char> allocator);
+
+  // Same as `tryToDeserialize`, but throw a descriptive exception instead of
+  // returning a status.
   void deserialize(Qlever& qlever, ql::span<const char> compressedBlob,
                    ql::pmr::polymorphic_allocator<char> allocator);
 
@@ -80,8 +115,16 @@ class NamedCachedQueryBlobManager {
 
   // Inverse of `compressBlob`: decompress `compressedBlob` into a freshly
   // allocated buffer that uses `allocator` for its storage (see
-  // `BlobAllocator`). Throw with a descriptive message if `compressedBlob` was
-  // not written by `compressBlob`, or is corrupted.
+  // `BlobAllocator`). Return `nullopt` if `compressedBlob` was not written by
+  // `compressBlob`, or is corrupted. Exceptions that do not come from ZSTD (in
+  // particular `std::bad_alloc`, should the frame header state an uncompressed
+  // size that cannot be allocated) are still propagated.
+  static std::optional<std::vector<char, BlobAllocator>> tryToDecompressBlob(
+      ql::span<const char> compressedBlob,
+      ql::pmr::polymorphic_allocator<char> allocator);
+
+  // Same as `tryToDecompressBlob`, but throw with a descriptive message instead
+  // of returning `nullopt`.
   static std::vector<char, BlobAllocator> decompressBlob(
       ql::span<const char> compressedBlob,
       ql::pmr::polymorphic_allocator<char> allocator);
@@ -92,9 +135,19 @@ class NamedCachedQueryBlobManager {
       ad_utility::serialization::AlignedByteBufferWriteSerializer& serializer);
 
   // Read and verify the magic header and format version at the start of a
-  // decompressed blob, advancing `serializer` past them. Throw if the header is
-  // missing, truncated, or has an incompatible format version. Mirrors
+  // decompressed blob, advancing `serializer` past them. Return `ok` if the
+  // header is valid, and the reason for the rejection otherwise (see
+  // `BlobStatus`). Never throw; in particular, a missing or truncated
+  // header is reported as `invalidMagicBytes`. If the result is not `ok`, the
+  // position of the `serializer` is unspecified afterwards. Mirrors
   // `writeBlobHeader`.
+  static BlobStatus tryToSkipAndVerifyBlobHeader(
+      ad_utility::serialization::ByteBufferReadSerializerT<
+          true, ql::span<const char>>& serializer) noexcept;
+
+  // Same as `tryToSkipAndVerifyBlobHeader`, but throw a descriptive exception
+  // instead of returning a status if the header is missing, truncated, or has
+  // an incompatible format version.
   static void skipAndVerifyBlobHeader(
       ad_utility::serialization::ByteBufferReadSerializerT<
           true, ql::span<const char>>& serializer);

--- a/src/libqlever/Qlever.h
+++ b/src/libqlever/Qlever.h
@@ -541,18 +541,31 @@ class Qlever {
   }
 
   // Load a blob previously written by
-  // `serializeVocabAndNamedCacheToCompressedBlob`. For details see
-  // `NamedCachedQueryBlobManager::deserialize`.
+  // `serializeVocabAndNamedCacheToCompressedBlob`, and return a status instead
+  // of throwing if the blob cannot be decompressed, or if its header is missing
+  // or incompatible. For details (in particular which failures are still
+  // reported by an exception) see
+  // `NamedCachedQueryBlobManager::tryToDeserialize`.
   //
   // PRECONDITION: Must only be called while no other thread can concurrently
   // access this instance, e.g. right after construction and before the first
-  // query is answered. Must not be called more than once on the same
-  // instance.
-  void deserializeVocabAndNamedCacheFromCompressedBlob(
+  // query is answered. Must not be called more than once on the same instance,
+  // except after a call that returned a status other than `ok`.
+  NamedCachedQueryBlobManager::BlobStatus
+  tryToDeserializeVocabAndNamedCacheFromCompressedBlob(
       ql::span<const char> blob,
       ql::pmr::polymorphic_allocator<char> allocator = {}) {
     // Note: `polymorphic_allocator` is cheap to copy and has no
     // dedicated move operations.
+    return blobManager_.tryToDeserialize(*this, blob, allocator);
+  }
+
+  // Same as `tryToDeserializeVocabAndNamedCacheFromCompressedBlob`, but throw
+  // instead of returning a status. For details see
+  // `NamedCachedQueryBlobManager::deserialize`.
+  void deserializeVocabAndNamedCacheFromCompressedBlob(
+      ql::span<const char> blob,
+      ql::pmr::polymorphic_allocator<char> allocator = {}) {
     blobManager_.deserialize(*this, blob, allocator);
   }
 

--- a/test/libqlever/NamedCachedQueryBlobManagerTest.cpp
+++ b/test/libqlever/NamedCachedQueryBlobManagerTest.cpp
@@ -51,7 +51,64 @@ class CountingMemoryResource : public ql::pmr::memory_resource {
     return this == &other;
   }
 };
+
+// The serializer that reads a decompressed blob (see
+// `Manager::skipAndVerifyBlobHeader`).
+using BlobReader =
+    ad_utility::serialization::ByteBufferReadSerializerT<true,
+                                                         ql::span<const char>>;
+
+// The magic bytes that `Manager::writeBlobHeader` writes (see
+// `blobMagicBytes`).
+constexpr std::array<char, 8> correctMagicBytes{'Q', 'L', 'V', 'R',
+                                                'B', 'L', 'O', 'B'};
+
+// Return a validly ZSTD-compressed blob whose decompressed contents consist of
+// the given magic bytes followed by the given format version, and nothing else.
+std::vector<char> compressedBlobWithHeader(std::array<char, 8> magicBytes,
+                                           uint16_t formatVersion) {
+  ad_utility::serialization::AlignedByteBufferWriteSerializer writer;
+  writer << magicBytes;
+  writer << formatVersion;
+  auto data = std::move(writer).data();
+  return Manager::compressBlob(ql::span<const char>{data});
+}
 }  // namespace
+
+// Test fixture for the blob header. It provides a helper that checks a given
+// buffer with both the non-throwing `tryToSkipAndVerifyBlobHeader` and the
+// throwing `skipAndVerifyBlobHeader`, so that the two are always tested
+// together and cannot become inconsistent.
+class NamedCachedQueryBlobManagerHeader : public ::testing::Test {
+ protected:
+  using Status = Manager::BlobStatus;
+
+  // Check that verifying the blob header at the start of `data` yields
+  // `expectedStatus` in the non-throwing version, and that the throwing version
+  // either does not throw (if `expectedStatus` is `ok`) or throws an
+  // `ad_utility::Exception` whose message contains `expectedMessage`. Return
+  // the reader that was used for the non-throwing version, so that the caller
+  // can continue reading after the header.
+  static BlobReader expectHeader(
+      ql::span<const char> data, Status expectedStatus,
+      std::string_view expectedMessage = {},
+      ad_utility::source_location loc = AD_CURRENT_SOURCE_LOC()) {
+    auto trace = generateLocationTrace(loc);
+    BlobReader nonThrowingReader{data};
+    EXPECT_EQ(Manager::tryToSkipAndVerifyBlobHeader(nonThrowingReader),
+              expectedStatus);
+    BlobReader throwingReader{data};
+    if (expectedStatus == Status::ok) {
+      EXPECT_TRUE(expectedMessage.empty());
+      EXPECT_NO_THROW(Manager::skipAndVerifyBlobHeader(throwingReader));
+    } else {
+      AD_EXPECT_THROW_WITH_MESSAGE_AND_TYPE(
+          Manager::skipAndVerifyBlobHeader(throwingReader),
+          HasSubstr(std::string{expectedMessage}), ad_utility::Exception);
+    }
+    return nonThrowingReader;
+  }
+};
 
 // _____________________________________________________________________________
 // Test the compression utility and its inverse in isolation, for several
@@ -70,13 +127,20 @@ TEST(NamedCachedQueryBlobManager, compressAndDecompressBlob) {
 
     auto roundTripped = Manager::decompressBlob(compressed, {});
     EXPECT_THAT(roundTripped, ::testing::ElementsAreArray(original));
+
+    // The non-throwing variant yields the same result.
+    auto roundTrippedWithoutThrowing =
+        Manager::tryToDecompressBlob(compressed, {});
+    ASSERT_TRUE(roundTrippedWithoutThrowing.has_value());
+    EXPECT_THAT(roundTrippedWithoutThrowing.value(),
+                ::testing::ElementsAreArray(original));
   }
 }
 
 // _____________________________________________________________________________
 // Test that `writeBlobHeader` and `skipAndVerifyBlobHeader` mirror each other,
 // and that an invalid header is rejected.
-TEST(NamedCachedQueryBlobManager, writeAndVerifyBlobHeader) {
+TEST_F(NamedCachedQueryBlobManagerHeader, writeAndVerifyBlobHeader) {
   ad_utility::serialization::AlignedByteBufferWriteSerializer writer;
   Manager::writeBlobHeader(writer);
   // Append a payload so that we can check the reader is positioned correctly
@@ -84,10 +148,7 @@ TEST(NamedCachedQueryBlobManager, writeAndVerifyBlobHeader) {
   writer << std::string_view{"payload"};
   auto data = std::move(writer).data();
 
-  ad_utility::serialization::ByteBufferReadSerializerT<true,
-                                                       ql::span<const char>>
-      reader{ql::span<const char>{data}};
-  EXPECT_NO_THROW(Manager::skipAndVerifyBlobHeader(reader));
+  auto reader = expectHeader(ql::span<const char>{data}, Status::ok);
   std::string payload;
   reader >> payload;
   EXPECT_EQ(payload, "payload");
@@ -97,17 +158,15 @@ TEST(NamedCachedQueryBlobManager, writeAndVerifyBlobHeader) {
   wrongWriter << std::array<char, 8>{'X', 'X', 'X', 'X', 'X', 'X', 'X', 'X'};
   wrongWriter << uint16_t{1};
   auto wrongData = std::move(wrongWriter).data();
-  ad_utility::serialization::ByteBufferReadSerializerT<true,
-                                                       ql::span<const char>>
-      wrongReader{ql::span<const char>{wrongData}};
-  AD_EXPECT_THROW_WITH_MESSAGE(Manager::skipAndVerifyBlobHeader(wrongReader),
-                               HasSubstr("was not written by"));
+  expectHeader(ql::span<const char>{wrongData}, Status::invalidMagicBytes,
+               "was not written by");
 }
 
 // _____________________________________________________________________________
 // Test that a blob with the correct magic bytes but an incompatible format
 // version is rejected.
-TEST(NamedCachedQueryBlobManager, skipAndVerifyBlobHeaderRejectsWrongVersion) {
+TEST_F(NamedCachedQueryBlobManagerHeader,
+       skipAndVerifyBlobHeaderRejectsWrongVersion) {
   ad_utility::serialization::AlignedByteBufferWriteSerializer writer;
   // The correct magic bytes (see `blobMagicBytes`), followed by a format
   // version that is definitely not the current one.
@@ -115,27 +174,66 @@ TEST(NamedCachedQueryBlobManager, skipAndVerifyBlobHeaderRejectsWrongVersion) {
   writer << uint16_t{63999};
   auto data = std::move(writer).data();
 
-  ad_utility::serialization::ByteBufferReadSerializerT<true,
-                                                       ql::span<const char>>
-      reader{ql::span<const char>{data}};
-  AD_EXPECT_THROW_WITH_MESSAGE(Manager::skipAndVerifyBlobHeader(reader),
-                               HasSubstr("incompatible version"));
+  expectHeader(ql::span<const char>{data}, Status::invalidVersion,
+               "incompatible version");
+  // The message of the throwing version also names the version that was found.
+  expectHeader(ql::span<const char>{data}, Status::invalidVersion,
+               "format version 63999");
 }
 
 // _____________________________________________________________________________
 // Test that a blob with the correct magic bytes but a truncated header is
 // rejected with our own message, instead of with a cryptic message from the
 // serializer.
-TEST(NamedCachedQueryBlobManager, skipAndVerifyBlobHeaderRejectsShortInput) {
+TEST_F(NamedCachedQueryBlobManagerHeader,
+       skipAndVerifyBlobHeaderRejectsShortInput) {
   ad_utility::serialization::AlignedByteBufferWriteSerializer writer;
   writer << std::array<char, 4>{'Q', 'L', 'V', 'R'};
   auto data = std::move(writer).data();
 
-  ad_utility::serialization::ByteBufferReadSerializerT<true,
-                                                       ql::span<const char>>
-      reader{ql::span<const char>{data}};
-  AD_EXPECT_THROW_WITH_MESSAGE(Manager::skipAndVerifyBlobHeader(reader),
-                               HasSubstr("was not written by"));
+  expectHeader(ql::span<const char>{data}, Status::invalidMagicBytes,
+               "was not written by");
+}
+
+// _____________________________________________________________________________
+// Test that a completely empty blob is rejected (and in particular that the
+// non-throwing version does not throw on it).
+TEST_F(NamedCachedQueryBlobManagerHeader,
+       skipAndVerifyBlobHeaderRejectsEmptyInput) {
+  ad_utility::serialization::AlignedByteBufferWriteSerializer writer;
+  auto data = std::move(writer).data();
+  ASSERT_TRUE(data.empty());
+
+  expectHeader(ql::span<const char>{data}, Status::invalidMagicBytes,
+               "was not written by");
+}
+
+// _____________________________________________________________________________
+// Test that the header is also correctly verified if it is not at the very
+// beginning of the buffer, and that the non-throwing version leaves the reader
+// positioned after the header in the `ok` case.
+TEST_F(NamedCachedQueryBlobManagerHeader, verifyBlobHeaderAtNonZeroPosition) {
+  ad_utility::serialization::AlignedByteBufferWriteSerializer writer;
+  writer << uint64_t{42};
+  Manager::writeBlobHeader(writer);
+  auto data = std::move(writer).data();
+
+  BlobReader reader{ql::span<const char>{data}};
+  uint64_t prefix = 0;
+  reader >> prefix;
+  ASSERT_EQ(prefix, 42u);
+  size_t positionBeforeHeader = reader.getCurrentPosition();
+  EXPECT_EQ(Manager::tryToSkipAndVerifyBlobHeader(reader), Status::ok);
+  // The reader has been advanced past the magic bytes and the version, and the
+  // buffer is exhausted.
+  EXPECT_EQ(reader.getCurrentPosition() - positionBeforeHeader, 10u);
+  EXPECT_EQ(reader.getCurrentPosition(), data.size());
+
+  // The throwing version behaves the same on the same input.
+  BlobReader throwingReader{ql::span<const char>{data}};
+  uint64_t prefixAgain = 0;
+  throwingReader >> prefixAgain;
+  EXPECT_NO_THROW(Manager::skipAndVerifyBlobHeader(throwingReader));
 }
 
 // _____________________________________________________________________________
@@ -156,6 +254,10 @@ TEST(NamedCachedQueryBlobManager, decompressBlobRejectsNonZstdInput) {
   AD_EXPECT_THROW_WITH_MESSAGE_AND_TYPE(Manager::decompressBlob(garbage, {}),
                                         HasSubstr("was not written by"),
                                         ad_utility::Exception);
+
+  // The non-throwing variant reports the same inputs as `nullopt`.
+  EXPECT_FALSE(Manager::tryToDecompressBlob(tooShort, {}).has_value());
+  EXPECT_FALSE(Manager::tryToDecompressBlob(garbage, {}).has_value());
 }
 
 // _____________________________________________________________________________
@@ -177,6 +279,11 @@ TEST(NamedCachedQueryBlobManager, decompressBlobRejectsTruncatedInput) {
   AD_EXPECT_THROW_WITH_MESSAGE_AND_TYPE(Manager::decompressBlob(compressed, {}),
                                         HasSubstr("was not written by"),
                                         ad_utility::Exception);
+
+  // The non-throwing variant reports the same input as `nullopt`. Note that the
+  // failure occurs during the decompression itself here, not while reading the
+  // frame header.
+  EXPECT_FALSE(Manager::tryToDecompressBlob(compressed, {}).has_value());
 }
 
 // _____________________________________________________________________________
@@ -311,6 +418,51 @@ TEST(NamedCachedQueryBlobManager, deserializeRejectsInvalidBlob) {
   AD_EXPECT_THROW_WITH_MESSAGE(
       target.deserializeVocabAndNamedCacheFromCompressedBlob(compressedBlob),
       HasSubstr("was not written by"));
+
+  // The non-throwing version reports the same rejection as a status.
+  EXPECT_EQ(target.tryToDeserializeVocabAndNamedCacheFromCompressedBlob(
+                compressedBlob),
+            Manager::BlobStatus::invalidMagicBytes);
+}
+
+// _____________________________________________________________________________
+// Test that a blob that cannot be decompressed at all is rejected by both the
+// throwing and the non-throwing loading function. Note that this failure occurs
+// on the outermost level, before anything of the blob is interpreted.
+TEST(NamedCachedQueryBlobManager, deserializeRejectsBlobThatIsNotAZstdFrame) {
+  // Input that does not start with the ZSTD magic number, and a validly
+  // compressed but truncated blob.
+  std::vector<char> garbage(1024, '\xFF');
+  std::vector<char> truncated = Manager::compressBlob(garbage);
+  truncated.pop_back();
+
+  Qlever target{EngineConfig{}, /*skipLoading=*/true};
+  for (const std::vector<char>& blob : {garbage, truncated}) {
+    AD_EXPECT_THROW_WITH_MESSAGE(
+        target.deserializeVocabAndNamedCacheFromCompressedBlob(blob),
+        HasSubstr("was not written by"));
+    EXPECT_EQ(target.tryToDeserializeVocabAndNamedCacheFromCompressedBlob(blob),
+              Manager::BlobStatus::notDecompressible);
+  }
+}
+
+// _____________________________________________________________________________
+// Test that a blob with the correct magic bytes but an incompatible format
+// version is rejected by both the throwing and the non-throwing loading
+// function.
+TEST(NamedCachedQueryBlobManager,
+     deserializeRejectsBlobWithIncompatibleVersion) {
+  std::vector<char> compressedBlob =
+      compressedBlobWithHeader(correctMagicBytes, uint16_t{63999});
+
+  Qlever target{EngineConfig{}, /*skipLoading=*/true};
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      target.deserializeVocabAndNamedCacheFromCompressedBlob(compressedBlob),
+      HasSubstr("incompatible version"));
+
+  EXPECT_EQ(target.tryToDeserializeVocabAndNamedCacheFromCompressedBlob(
+                compressedBlob),
+            Manager::BlobStatus::invalidVersion);
 }
 
 // _____________________________________________________________________________
@@ -330,6 +482,70 @@ TEST(NamedCachedQueryBlobManager, deserializeRejectsBlobWithInvalidContents) {
   AD_EXPECT_THROW_WITH_MESSAGE(
       target.deserializeVocabAndNamedCacheFromCompressedBlob(compressedBlob),
       HasSubstr("Error while reading the contents of a blob"));
+}
+
+// _____________________________________________________________________________
+// Test that a blob whose header is rejected by
+// `tryToDeserializeVocabAndNamedCacheFromCompressedBlob` leaves the instance
+// completely unchanged, so that a valid blob can still be loaded afterwards,
+// and that a second valid blob is then rejected.
+TEST(NamedCachedQueryBlobManager, tryToDeserializeLeavesInstanceUsable) {
+  std::string basename = gtestCurrentTestName();
+  std::string sourceFilename = basename + ".ttl";
+  {
+    auto ofs = ad_utility::makeOfstream(sourceFilename);
+    ofs << "<retrySubject> <retryPredicate> \"retry literal\".";
+  }
+  absl::Cleanup cleanup = [&sourceFilename] {
+    ad_utility::deleteFile(sourceFilename);
+  };
+  IndexBuilderConfig sourceConfig;
+  sourceConfig.inputFiles_.push_back(
+      {sourceFilename, Filetype::Turtle, std::nullopt});
+  sourceConfig.baseName_ = basename;
+  sourceConfig.vocabType_ = ad_utility::VocabularyType::InMemoryUncompressed;
+  EXPECT_NO_THROW(Qlever::buildIndex(sourceConfig));
+
+  const std::vector<char> compressedBlob = [&sourceConfig]() {
+    Qlever source{EngineConfig{sourceConfig}};
+    source.queryAndPinResultWithName(
+        "blobPin", "SELECT ?s ?o WHERE { ?s <retryPredicate> ?o }");
+    return source.serializeVocabAndNamedCacheToCompressedBlob();
+  }();
+
+  Qlever target{EngineConfig{}, /*skipLoading=*/true};
+
+  // None of an undecompressible, an unrecognized or an incompatible blob
+  // throws, and none of them counts as the one allowed load.
+  std::vector<char> garbage(1024, '\xFF');
+  EXPECT_EQ(
+      target.tryToDeserializeVocabAndNamedCacheFromCompressedBlob(garbage),
+      Manager::BlobStatus::notDecompressible);
+  std::vector<char> bogus(64, 'X');
+  EXPECT_EQ(target.tryToDeserializeVocabAndNamedCacheFromCompressedBlob(
+                Manager::compressBlob(bogus)),
+            Manager::BlobStatus::invalidMagicBytes);
+  EXPECT_EQ(target.tryToDeserializeVocabAndNamedCacheFromCompressedBlob(
+                compressedBlobWithHeader(correctMagicBytes, uint16_t{63999})),
+            Manager::BlobStatus::invalidVersion);
+
+  // The valid blob can still be loaded, and the instance then answers the query
+  // from the named result cache and the vocabulary in the blob.
+  EXPECT_EQ(target.tryToDeserializeVocabAndNamedCacheFromCompressedBlob(
+                compressedBlob),
+            Manager::BlobStatus::ok);
+  EXPECT_EQ(
+      target.query(
+          "SELECT ?s ?o WHERE { SERVICE ql:cached-result-with-name-blobPin {}}",
+          ad_utility::MediaType::tsv),
+      "?s\t?o\n<retrySubject>\t\"retry literal\"\n");
+
+  // After a successful load, a second blob is rejected, also by the
+  // non-throwing version (a violated precondition is not a blob error).
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      target.tryToDeserializeVocabAndNamedCacheFromCompressedBlob(
+          compressedBlob),
+      HasSubstr("must not be called more than once"));
 }
 
 // _____________________________________________________________________________


### PR DESCRIPTION
Loading the vocabulary and the `NamedResultCache` from a compressed blob (`Qlever::deserializeVocabAndNamedCacheFromCompressedBlob`) throws when the blob cannot be decompressed, or when its magic bytes or its format version are incompatible. Some embedders have to load a blob whose provenance they do not control and must never throw — they want to detect an unusable blob and silently fall back to empty results. This PR adds non-throwing variants that return a status instead:

* `NamedCachedQueryBlobManager::tryToDecompressBlob`, which returns `nullopt` instead of throwing. It catches only the `std::runtime_error`s of `ZstdWrapper`, so a `std::bad_alloc` (should the ZSTD frame header state an uncompressed size that cannot be allocated) is still propagated rather than being misreported as a corrupted blob.
* `NamedCachedQueryBlobManager::tryToSkipAndVerifyBlobHeader`, which is `noexcept` and returns a `BlobStatus`.
* `NamedCachedQueryBlobManager::tryToDeserialize` and `Qlever::tryToDeserializeVocabAndNamedCacheFromCompressedBlob`, which perform the whole load and return a `BlobStatus`: `ok`, `notDecompressible`, `invalidMagicBytes`, or `invalidVersion`.

All of those failures are detected *before* any of the actual contents of the blob is read. That makes a useful guarantee possible: on a non-`ok` status the `Qlever` instance is left completely unchanged, so it stays usable and another blob can still be loaded afterwards (covered by a test). Failures while reading the contents behind a valid header still throw; making those non-throwing too would require either a rollback of the partially applied vocabulary configuration or an explicit discard-the-instance contract, and is left for a follow-up.

The throwing `decompressBlob`, `skipAndVerifyBlobHeader` and `deserialize` are now implemented in terms of the new functions, so there is only one implementation of the blob format checks.

### Behavior change

The messages of the throwing functions are unchanged, with one exception: `deserialize` can now only name the *category* of the failure, because all it gets from `tryToDeserialize` is a status. The underlying ZSTD error and the format version that was found no longer appear in its message; `decompressBlob` and `skipAndVerifyBlobHeader` still report both when called directly.

### Tests

`NamedCachedQueryBlobManagerTest.cpp` gains a `NamedCachedQueryBlobManagerHeader` fixture whose helper checks every input with the throwing *and* the non-throwing header function, so the two cannot drift apart. New cases: empty input, a header at a non-zero read position, `tryToDecompressBlob` on non-ZSTD and truncated input, the three rejection statuses at the `Qlever` level, and that any of those rejections leaves the instance able to load a valid blob afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)