### PR TITLE
Run all test binaries in a scratch working directory

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(GoogleTest)
 
-# Needed for creating the `testUil`-library.
+# Needed for creating the `testUtil`-library.
 add_subdirectory(util EXCLUDE_FROM_ALL)
 
 # Link binary ${basename} against QLever's test `main` (which runs the tests
@@ -19,7 +19,7 @@ endfunction()
 
 # Usage: `linkAndDiscoverTest(basename, [additionalLibraries...]`
 # Link the executable `basename` against QLever's test `main`, the threading
-# library, and all `additionLibraries` which are passed as arguments.
+# library, and all `additionalLibraries` which are passed as arguments.
 # Then register the test cases from the executable with `ctest` (see
 # `QLEVER_ONE_TEST_CASE_PER_FILE` in the top-level `CMakeLists.txt` for the two
 # possible regimes).
@@ -56,7 +56,7 @@ if (SINGLE_TEST_BINARY)
     add_executable(QLeverAllUnitTestsMain)
     qlever_target_link_libraries(QLeverAllUnitTestsMain gtest gmock qleverTestMain testUtil ${CMAKE_THREAD_LIBS_INIT})
     # The following line (as opposed to using `gtest_discover_tests`) has the effect that `ctest` will treat all the
-    # unit tests as a single test case and will simply run the executable (using the main function from `qleverTestMain`.
+    # unit tests as a single test case and will simply run the executable (using the main function from `qleverTestMain`).
     # This decreases the runtime overhead per unit tests in particular for sanitizer builds.
     add_test(NAME QLeverAllUnitTests COMMAND $<TARGET_FILE:QLeverAllUnitTestsMain>)
 else ()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,11 +3,12 @@ include(GoogleTest)
 # Needed for creating the `testUil`-library.
 add_subdirectory(util EXCLUDE_FROM_ALL)
 
-# Link binary ${basename} against `gmock_main`, the threading library, the
-# general test utilities and all libraries that are specified as additional
-# arguments.
+# Link binary ${basename} against QLever's test `main` (which runs the tests
+# in a scratch working directory, see `util/QleverTestMain.cpp`), the
+# threading library, the general test utilities and all libraries that are
+# specified as additional arguments.
 function(linkTest basename)
-    qlever_target_link_libraries(${basename} ${ARGN} GTest::gtest GTest::gmock_main ${CMAKE_THREAD_LIBS_INIT} global)
+    qlever_target_link_libraries(${basename} ${ARGN} qleverTestMain GTest::gtest GTest::gmock ${CMAKE_THREAD_LIBS_INIT} global)
 endfunction()
 
 # Add the executable ${basename} that is compiled from the source file
@@ -17,8 +18,8 @@ function(addTest basename)
 endfunction()
 
 # Usage: `linkAndDiscoverTest(basename, [additionalLibraries...]`
-# Link the executable `basename` against `gmock_main`,threading library,
-# and all `additionLibraries` which are passed as arguments.
+# Link the executable `basename` against QLever's test `main`, the threading
+# library, and all `additionLibraries` which are passed as arguments.
 # Then register the test cases from the executable with `ctest` (see
 # `QLEVER_ONE_TEST_CASE_PER_FILE` in the top-level `CMakeLists.txt` for the two
 # possible regimes).
@@ -53,9 +54,9 @@ endfunction()
 if (SINGLE_TEST_BINARY)
     message(STATUS "All tests are linked into a single executable `QLeverAllUnitTestsMain`")
     add_executable(QLeverAllUnitTestsMain)
-    qlever_target_link_libraries(QLeverAllUnitTestsMain gtest gmock_main testUtil ${CMAKE_THREAD_LIBS_INIT})
+    qlever_target_link_libraries(QLeverAllUnitTestsMain gtest gmock qleverTestMain testUtil ${CMAKE_THREAD_LIBS_INIT})
     # The following line (as opposed to using `gtest_discover_tests`) has the effect that `ctest` will treat all the
-    # unit tests as a single test case and will simply run the executable (using the main function from `gtest_main`.
+    # unit tests as a single test case and will simply run the executable (using the main function from `qleverTestMain`.
     # This decreases the runtime overhead per unit tests in particular for sanitizer builds.
     add_test(NAME QLeverAllUnitTests COMMAND $<TARGET_FILE:QLeverAllUnitTestsMain>)
 else ()
@@ -80,7 +81,7 @@ endfunction()
 
 # Usage: `addAndLinkTest[NoLibs](basename, [additionalLibraries...]`
 # Add a GTest/GMock test case that is called `basename` and compiled from a file called
-# `basename.cpp`. All tests are linked against `gmock_main` and the threading library.
+# `basename.cpp`. All tests are linked against `qleverTestMain` and the threading library.
 # additional libraries against which the test case has to be linked can be specified as
 # additional arguments after the `basename`
 
@@ -97,7 +98,7 @@ endfunction()
 
 
 # Add a GTest/GMock test case that is called `basename` and compiled from a file called
-# `basename.cpp`. All tests are linked against `gmock_main` and the threading library.
+# `basename.cpp`. All tests are linked against `qleverTestMain` and the threading library.
 # In contrast to `addLinkAndDiscoverTest` this doesn't let ctest run all subtests individually,
 # but all at once to reduce overhead in the CI pipeline.
 function(addLinkAndRunAsSingleTest basename)

--- a/test/backports/CMakeLists.txt
+++ b/test/backports/CMakeLists.txt
@@ -2,7 +2,7 @@
 add_executable(AlgorithmBackportTests algorithmTest.cpp)
 add_executable(DebugJoinView DebugJoinView.cpp)
 qlever_target_link_libraries(DebugJoinView)
-target_link_libraries(AlgorithmBackportTests GTest::gtest GTest::gmock_main)
+qlever_target_link_libraries(AlgorithmBackportTests qleverTestMain GTest::gtest GTest::gmock)
 gtest_discover_tests(AlgorithmBackportTests AlgorithmBackportTests)
 addLinkAndDiscoverTestNoLibs(ConceptsTest)
 addLinkAndDiscoverTestNoLibs(ShiftTest)

--- a/test/util/CMakeLists.txt
+++ b/test/util/CMakeLists.txt
@@ -1,3 +1,10 @@
 add_library(testUtil IdTableHelpers.cpp ValidatorHelpers.cpp RandomTestHelpers.cpp BenchmarkMeasurementContainerHelpers.cpp IndexTestHelpers.cpp)
 # TODO<c++20> Once there is more support for it, we should be able to do this cheaper with modules.
-qlever_target_link_libraries(testUtil engine global gmock_main)
+qlever_target_link_libraries(testUtil engine global GTest::gtest GTest::gmock)
+
+# The `main` function for all test binaries. It runs the tests in a scratch
+# working directory, so that tests that write files via relative paths do not
+# litter the directory from which the test binary is run (see
+# `QleverTestMain.cpp` for details).
+add_library(qleverTestMain QleverTestMain.cpp)
+qlever_target_link_libraries(qleverTestMain global GTest::gtest GTest::gmock)

--- a/test/util/QleverTestMain.cpp
+++ b/test/util/QleverTestMain.cpp
@@ -1,0 +1,51 @@
+// Copyright 2026 The QLever Authors, in particular:
+//
+// 2026 Hannah Bast <bast@cs.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#include <absl/strings/str_cat.h>
+#include <gmock/gmock.h>
+
+#include <iostream>
+#include <string>
+
+#include "backports/filesystem.h"
+#include "util/Random.h"
+
+// The `main` function for all QLever test binaries (linked instead of
+// `gmock_main`). Before running the tests, change the working directory to a
+// scratch directory that is unique to this process. Many tests create index
+// files and other artifacts via paths that are relative to the working
+// directory. Running such a test binary manually (for example, from the root
+// of a checkout) would otherwise litter the current directory, in particular
+// when the cleanup at the end of a test is skipped because of a crash or an
+// interrupt. On success, the scratch directory is deleted; on failure, it is
+// kept and its path is printed, so that the artifacts of the failed tests can
+// be inspected.
+int main(int argc, char** argv) {
+  ::testing::InitGoogleMock(&argc, argv);
+  namespace fs = ql::filesystem;
+  std::string binaryName =
+      argc > 0 ? fs::path(argv[0]).filename().string() : "unknown";
+  fs::path scratchDirectory =
+      fs::temp_directory_path() / absl::StrCat("qlever-test-", binaryName, "-",
+                                               ad_utility::UuidGenerator{}());
+  fs::create_directories(scratchDirectory);
+  fs::current_path(scratchDirectory);
+  int result = RUN_ALL_TESTS();
+  if (result == 0) {
+    // Leave the scratch directory before deleting it (deleting the working
+    // directory fails on some platforms).
+    fs::current_path(fs::temp_directory_path());
+    ql::error_code errorCode;
+    fs::remove_all(scratchDirectory, errorCode);
+  } else {
+    std::cerr << "Note: test artifacts remain in " << scratchDirectory
+              << std::endl;
+  }
+  return result;
+}

--- a/test/util/QleverTestMain.cpp
+++ b/test/util/QleverTestMain.cpp
@@ -7,45 +7,123 @@
 // You may not use this file except in compliance with the Apache 2.0 License,
 // which can be found in the `LICENSE` file at the root of the QLever project.
 
+#include <absl/strings/match.h>
+#include <absl/strings/numbers.h>
 #include <absl/strings/str_cat.h>
 #include <gmock/gmock.h>
+#include <signal.h>
+#include <unistd.h>
 
+#include <cerrno>
+#include <cstdlib>
 #include <iostream>
 #include <string>
+#include <string_view>
 
 #include "backports/filesystem.h"
 #include "util/Random.h"
+
+namespace fs = ql::filesystem;
+
+// Each scratch directory name starts with this prefix, followed by the id of
+// the process that created it. This way, stale scratch directories (of
+// processes that no longer exist) can be identified and removed; see
+// `removeStaleScratchDirectories` below.
+constexpr std::string_view scratchDirectoryPrefix = "qlever-test-pid";
+
+// Remove the scratch directories left behind by processes that no longer
+// exist. A process cannot remove its scratch directory itself when it crashes
+// or is killed, so instead each test run cleans up after such earlier runs.
+static void removeStaleScratchDirectories(const fs::path& tempDirectory) {
+  for (const auto& entry : ql::directoryRange(tempDirectory)) {
+    std::string name = entry.path().filename().string();
+    if (!absl::StartsWith(name, scratchDirectoryPrefix)) {
+      continue;
+    }
+    size_t pidBegin = scratchDirectoryPrefix.size();
+    size_t pidEnd = name.find('-', pidBegin);
+    int64_t pid;
+    if (pidEnd == std::string::npos ||
+        !absl::SimpleAtoi(name.substr(pidBegin, pidEnd - pidBegin), &pid)) {
+      continue;
+    }
+    // Sending the signal `0` performs only the error checking, in particular,
+    // `ESRCH` means that no process with the given id exists.
+    if (kill(static_cast<pid_t>(pid), 0) == -1 && errno == ESRCH) {
+      ql::error_code errorCode;
+      fs::remove_all(entry.path(), errorCode);
+    }
+  }
+}
 
 // The `main` function for all QLever test binaries (linked instead of
 // `gmock_main`). Before running the tests, change the working directory to a
 // scratch directory that is unique to this process. Many tests create index
 // files and other artifacts via paths that are relative to the working
 // directory. Running such a test binary manually (for example, from the root
-// of a checkout) would otherwise litter the current directory, in particular
-// when the cleanup at the end of a test is skipped because of a crash or an
-// interrupt. On success, the scratch directory is deleted; on failure, it is
-// kept and its path is printed, so that the artifacts of the failed tests can
-// be inspected.
+// of a checkout) would otherwise litter the current directory. The scratch
+// directory is deleted after the tests have run, whether they passed or not.
+// To inspect the artifacts of failed tests, set the environment variable
+// `QLEVER_KEEP_TEST_ARTIFACTS`, then the scratch directory is kept and its
+// path is printed. When the process crashes or is interrupted, it cannot
+// delete its scratch directory, so each test run additionally removes the
+// scratch directories left behind by processes that no longer exist.
 int main(int argc, char** argv) {
+  // In the "threadsafe" death test style, GTest runs each death test in a
+  // child process that executes this `main` function again. Do not create a
+  // scratch directory in that case: GTest changes the working directory of
+  // the child to the directory in which the parent ran its tests, which is
+  // the parent's scratch directory.
+  //
+  // NOTE: This check must happen before `InitGoogleMock`, which removes the
+  // flag from `argv`.
+  for (int i = 1; i < argc; ++i) {
+    if (absl::StartsWith(argv[i], "--gtest_internal_run_death_test")) {
+      ::testing::InitGoogleMock(&argc, argv);
+      return RUN_ALL_TESTS();
+    }
+  }
   ::testing::InitGoogleMock(&argc, argv);
-  namespace fs = ql::filesystem;
   std::string binaryName =
       argc > 0 ? fs::path(argv[0]).filename().string() : "unknown";
+  fs::path tempDirectory = fs::temp_directory_path();
+  try {
+    removeStaleScratchDirectories(tempDirectory);
+  } catch (...) {
+    // A failed cleanup of stale scratch directories should never prevent the
+    // tests from running.
+  }
+  std::string uuid = ad_utility::UuidGenerator{}();
   fs::path scratchDirectory =
-      fs::temp_directory_path() / absl::StrCat("qlever-test-", binaryName, "-",
-                                               ad_utility::UuidGenerator{}());
+      tempDirectory / absl::StrCat(scratchDirectoryPrefix, getpid(), "-",
+                                   binaryName, "-", uuid);
   fs::create_directories(scratchDirectory);
   fs::current_path(scratchDirectory);
   int result = RUN_ALL_TESTS();
-  if (result == 0) {
-    // Leave the scratch directory before deleting it (deleting the working
-    // directory fails on some platforms).
-    fs::current_path(fs::temp_directory_path());
-    ql::error_code errorCode;
-    fs::remove_all(scratchDirectory, errorCode);
-  } else {
-    std::cerr << "Note: test artifacts remain in " << scratchDirectory
+  // Leave the scratch directory before deleting or renaming it (deleting the
+  // working directory fails on some platforms).
+  fs::current_path(tempDirectory);
+  ql::error_code errorCode;
+  if (std::getenv("QLEVER_KEEP_TEST_ARTIFACTS") != nullptr) {
+    // Rename the kept directory such that it no longer matches the pattern
+    // checked by `removeStaleScratchDirectories` (the id of this process
+    // would be reported as no longer existing once the process has exited).
+    fs::path keptDirectory =
+        tempDirectory /
+        absl::StrCat("qlever-test-kept-", binaryName, "-", uuid);
+    fs::rename(scratchDirectory, keptDirectory, errorCode);
+    if (errorCode) {
+      keptDirectory = scratchDirectory;
+    }
+    std::cerr << "Note: test artifacts remain in " << keptDirectory
               << std::endl;
+  } else {
+    fs::remove_all(scratchDirectory, errorCode);
+    if (result != 0) {
+      std::cerr << "Note: the artifacts of the failed tests were deleted; set "
+                   "QLEVER_KEEP_TEST_ARTIFACTS=1 to keep them"
+                << std::endl;
+    }
   }
   return result;
 }


### PR DESCRIPTION
Many tests create index files and other artifacts via paths that are relative to the working directory. Running a test binary manually, for example from the root of a checkout, litters that directory with such files. This change replaces `gmock_main` with a custom `main` function that changes into a scratch directory under the system temp directory before running the tests. The scratch directory is deleted after the tests have run, whether they passed or not. To inspect the artifacts of failed tests, set `QLEVER_KEEP_TEST_ARTIFACTS=1`, then the scratch directory is kept and its path is printed.

NOTE: A crashed or interrupted test run cannot delete its scratch directory. The name of each scratch directory therefore contains the id of the process that created it, and each test run removes the scratch directories of processes that no longer exist.