### PR TITLE
Fix name collisions between the server-integration tests

### DIFF
--- a/test/index/IndexRebuilderTest.cpp
+++ b/test/index/IndexRebuilderTest.cpp
@@ -810,7 +810,7 @@ TEST(IndexRebuilder, serverIntegration) {
   // neither can collide with the directories of another test. It is declared
   // first, so that it is restored and removed last, i.e. after the `server` and
   // the `threadPool` below have been destroyed.
-  auto workingDirectory = ad_utility::testing::useFreshWorkingDirectory();
+  auto cleanup = ad_utility::testing::useFreshWorkingDirectory();
   namespace net = boost::asio;
   net::thread_pool threadPool{1};
 
@@ -1023,7 +1023,7 @@ TEST(IndexRebuilder, serverIntegrationAutomaticRebuild) {
   // The automatic rebuild below uses the default directory names and the checks
   // below inspect all directories with a given prefix, see the comment in
   // `serverIntegration` above for why this needs a fresh working directory.
-  auto workingDirectory = ad_utility::testing::useFreshWorkingDirectory();
+  auto cleanup = ad_utility::testing::useFreshWorkingDirectory();
 
   std::string indexName = gtestCurrentTestName();
   ad_utility::testing::makeTestIndex(indexName, "<a> <b> <c> .");

--- a/test/index/IndexRebuilderTest.cpp
+++ b/test/index/IndexRebuilderTest.cpp
@@ -27,6 +27,7 @@
 
 #include "../ServerTestHelpers.h"
 #include "../util/AsioTestHelpers.h"
+#include "../util/FileTestHelpers.h"
 #include "../util/GTestHelpers.h"
 #include "../util/HttpRequestHelpers.h"
 #include "../util/IdTableHelpers.h"
@@ -803,9 +804,13 @@ void cleanDirsWithPrefix(std::string_view prefix) {
 #ifndef __EMSCRIPTEN__
 TEST(IndexRebuilder, serverIntegration) {
   namespace fs = ql::filesystem;
-  cleanDirsWithPrefix("previous.");
-  cleanDirsWithPrefix("rebuild.");
-  cleanDirsWithPrefix("serverIntegration.");
+  // The rebuilds below use the default names for the temporary directory and
+  // for the directory the old index is moved to, and the checks below inspect
+  // all directories with a given prefix. Use a fresh working directory, so that
+  // neither can collide with the directories of another test. It is declared
+  // first, so that it is restored and removed last, i.e. after the `server` and
+  // the `threadPool` below have been destroyed.
+  auto workingDirectory = ad_utility::testing::useFreshWorkingDirectory();
   namespace net = boost::asio;
   net::thread_pool threadPool{1};
 
@@ -911,8 +916,6 @@ TEST(IndexRebuilder, serverIntegration) {
   expectRequestFailsWith(request6, ::testing::HasSubstr("not a subdirectory"));
 
   threadPool.join();
-  cleanDirsWithPrefix("previous.");
-  cleanDirsWithPrefix("serverIntegration.");
 }
 #endif  // __EMSCRIPTEN__
 
@@ -1017,8 +1020,10 @@ TEST(IndexRebuilder, lazyScanNumThreadsOverride) {
 // library it needs is not built there.
 #ifndef __EMSCRIPTEN__
 TEST(IndexRebuilder, serverIntegrationAutomaticRebuild) {
-  cleanDirsWithPrefix("previous.");
-  cleanDirsWithPrefix("rebuild.");
+  // The automatic rebuild below uses the default directory names and the checks
+  // below inspect all directories with a given prefix, see the comment in
+  // `serverIntegration` above for why this needs a fresh working directory.
+  auto workingDirectory = ad_utility::testing::useFreshWorkingDirectory();
 
   std::string indexName = gtestCurrentTestName();
   ad_utility::testing::makeTestIndex(indexName, "<a> <b> <c> .");
@@ -1117,7 +1122,5 @@ TEST(IndexRebuilder, serverIntegrationAutomaticRebuild) {
                 ::testing::HasSubstr("Automatic index rebuild failed: boom"));
     Server::logAutomaticRebuildFailure(nullptr);
   }
-
-  cleanDirsWithPrefix("previous.");
 }
 #endif  // __EMSCRIPTEN__

--- a/test/libqlever/QleverTest.cpp
+++ b/test/libqlever/QleverTest.cpp
@@ -9,6 +9,7 @@
 
 #include <memory>
 
+#include "../util/FileTestHelpers.h"
 #include "../util/GTestHelpers.h"
 #include "../util/IdTableHelpers.h"
 #include "../util/IndexTestHelpers.h"
@@ -431,27 +432,6 @@ RebuildSetup setUpRebuild(const std::string& baseFolder) {
       std::move(rebuilt), MaterializedViewsManager{rebuiltBase});
   return {std::move(oldBase), std::move(rebuiltBase), std::move(indexAndViews)};
 }
-
-// Create a fresh (empty) directory named after the currently running test and
-// make it the working directory. The returned cleanup first restores the
-// previous working directory and then removes that directory again, so both
-// steps live in a single cleanup to fix their order. Needed by the tests that
-// deal with base names without a directory component, as those are resolved
-// against the working directory.
-[[nodiscard]] auto useFreshWorkingDirectory() {
-  auto oldCwd = ql::filesystem::current_path();
-  std::string folder = gtestCurrentTestName();
-  // Leftovers from a previous run would break the checks for directories that
-  // must not exist yet.
-  ql::filesystem::remove_all(folder);
-  ql::filesystem::create_directory(folder);
-  ql::filesystem::current_path(folder);
-  return absl::Cleanup{
-      [oldCwd = std::move(oldCwd), folder = std::move(folder)] {
-        ql::filesystem::current_path(oldCwd);
-        ql::filesystem::remove_all(folder);
-      }};
-}
 }  // namespace
 
 // _____________________________________________________________________________
@@ -557,7 +537,7 @@ TEST(Qlever, moveRebuiltIndexIntoPlaceWithDirectoryBasename) {
 // bare file names as well, otherwise the base-name prefix substitution of the
 // move fails on the globbed files (vocabulary, views).
 TEST(Qlever, moveRebuiltIndexIntoPlaceWithBareBasename) {
-  auto cleanup = useFreshWorkingDirectory();
+  auto cleanup = ad_utility::testing::useFreshWorkingDirectory();
   ad_utility::testing::makeTestIndex("index", "<a> <b> <c> .");
   ql::filesystem::create_directory("rebuild.tmp");
   Index rebuilt = ad_utility::testing::makeTestIndex(
@@ -595,7 +575,7 @@ TEST(Qlever, moveRebuiltIndexIntoPlaceWithBareBasename) {
 // of that directory has to be skipped (in particular, the working directory
 // itself must not be removed).
 TEST(Qlever, moveRebuiltIndexIntoPlaceWithBareNewIndexSource) {
-  auto cleanup = useFreshWorkingDirectory();
+  auto cleanup = ad_utility::testing::useFreshWorkingDirectory();
   ad_utility::testing::makeTestIndex("index", "<a> <b> <c> .");
   Index rebuilt = ad_utility::testing::makeTestIndex(
       "rebuilt", "<a> <b> <c> . <d> <e> <f> .");
@@ -943,7 +923,7 @@ TEST(LibQlever, clearCache) {
 // to lie inside the directory of the current index (which is the working
 // directory here as the index is served from the bare base name `index`).
 TEST(Qlever, makeIndexRebuildConfig) {
-  auto cleanup = useFreshWorkingDirectory();
+  auto cleanup = ad_utility::testing::useFreshWorkingDirectory();
   Index index = ad_utility::testing::makeTestIndex("index", "<a> <b> <c> .");
   auto makeConfig = [&index](
                         std::optional<std::string> rebuildTmpDir,

--- a/test/util/FileTestHelpers.h
+++ b/test/util/FileTestHelpers.h
@@ -17,6 +17,7 @@
 #include <utility>
 #include <vector>
 
+#include "GTestHelpers.h"
 #include "backports/StartsWithAndEndsWith.h"
 #include "backports/filesystem.h"
 #include "util/Exception.h"
@@ -69,6 +70,30 @@ inline auto makeTemporaryDirectory(std::string_view name) {
     }
   }};
   return std::make_pair(std::move(directory), std::move(cleanup));
+}
+
+// Create a fresh (empty) directory named after the currently running test and
+// make it the working directory. The returned cleanup first restores the
+// previous working directory and then removes that directory again, so both
+// steps live in a single cleanup to fix their order.
+//
+// Use this in tests that deal with base names without a directory component (as
+// those are resolved against the working directory), and in tests that would
+// otherwise be prone to name collisions with other tests, because they create
+// or inspect files whose names they do not fully control.
+[[nodiscard]] inline auto useFreshWorkingDirectory() {
+  auto oldCwd = ql::filesystem::current_path();
+  std::string folder = gtestCurrentTestName();
+  // Leftovers from a previous run would break the checks for directories that
+  // must not exist yet.
+  ql::filesystem::remove_all(folder);
+  ql::filesystem::create_directory(folder);
+  ql::filesystem::current_path(folder);
+  return absl::Cleanup{
+      [oldCwd = std::move(oldCwd), folder = std::move(folder)] {
+        ql::filesystem::current_path(oldCwd);
+        ql::filesystem::remove_all(folder);
+      }};
 }
 }  // namespace ad_utility::testing
 


### PR DESCRIPTION
The tests `IndexRebuilder.serverIntegration` and `IndexRebuilder.serverIntegrationAutomaticRebuild` used default (timestamped) names for their rebuild directories in the shared working directory, and each test also deleted all directories with the prefixes it inspects. When CI ran the two tests concurrently, they collided on these names and deleted each other's directories, which caused spurious CI failures.

Each of these tests now runs in its own fresh working directory, which is named after the test and removed afterwards. The helper `useFreshWorkingDirectory`, which already existed in `QleverTest.cpp`, is moved to `FileTestHelpers.h` for this purpose. As a side effect, the tests no longer leave their index files behind in the directory they are run in.
