### PR TITLE
Fix a false-positive `-Warray-bounds` warning with GCC 12

### DIFF
--- a/test/ConstructTripleGeneratorTest.cpp
+++ b/test/ConstructTripleGeneratorTest.cpp
@@ -395,7 +395,10 @@ TEST(MakeIdCache, emptyTemplate) {
 // `CACHE_ENTRIES_PER_VARIABLE`.
 TEST(MakeIdCache, singleVariable) {
   PreprocessedConstructTemplate tmpl;
-  tmpl.uniqueVariableColumns_ = {0};
+  // Note: Assigning an `initializer_list` of size 1 to a `std::vector` here
+  // would trigger a false-positive `-Warray-bounds` warning with GCC 12 in
+  // optimized builds, hence the explicit `std::vector`.
+  tmpl.uniqueVariableColumns_ = std::vector<ColumnIndex>{0};
   auto cache = ConstructTripleGenerator::makeIdCache(tmpl);
   EXPECT_EQ(cache.capacity(),
             ConstructTripleGenerator::CACHE_ENTRIES_PER_VARIABLE);


### PR DESCRIPTION
In optimized builds, GCC 12 emits a bogus `-Warray-bounds` warning (an error in CI, which builds with `-Werror`) for the assignment of a single-element `initializer_list` to a `std::vector` in `ConstructTripleGeneratorTest.cpp`:

```
/usr/include/c++/12/bits/stl_algobase.h:434:30: error: ‘void* __builtin_memcpy(void*, const void*, long unsigned int)’ forming offset 8 is out of the bounds [0, 8] of object ‘<anonymous>’ with type ‘const long unsigned int [1]’ [-Werror=array-bounds]
...
test/ConstructTripleGeneratorTest.cpp:398:35: note: ‘<anonymous>’ declared here
  398 |   tmpl.uniqueVariableColumns_ = {0};
```

Assigning an explicit `std::vector<ColumnIndex>{0}` instead of the `initializer_list` silences the warning. This was verified locally with a full `Release` build using GCC 12 and the same flags as the CI job (`-Wall -Wextra`). The whole codebase now compiles without a single warning. Note that the GCC 12 job only runs on `master` and in the merge queue, not on PRs.