### PR TITLE
Return HTTP status 403 when the access token is missing or invalid

### DIFF
--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -446,15 +446,15 @@ CPP_template_def(typename RequestT, typename ResponseT)(
   // throw an exception and do not process any part of the query (even if the
   // processing had been allowed without access token).
   bool accessTokenOk = checkAccessToken(parsedHttpRequest.accessToken_);
-  auto requireValidAccessToken = [&accessTokenOk](
-                                     const std::string& actionName) {
-    if (!accessTokenOk) {
-      throw HttpError(
-          http::status::forbidden,
-          absl::StrCat(actionName, " requires a valid access token but no "
-                                   "access token was provided"));
-    }
-  };
+  auto requireValidAccessToken =
+      [&accessTokenOk](const std::string& actionName) {
+        if (!accessTokenOk) {
+          throw HttpError(http::status::forbidden,
+                          absl::StrCat(actionName,
+                                       " requires a valid access token but no "
+                                       "access token was provided"));
+        }
+      };
 
   // Process all URL parameters known to QLever. If there is more than one,
   // QLever processes all of them, but only returns the result from the last

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -391,7 +391,8 @@ void Server::configurePinnedResultWithName(
     return;
   }
   if (!accessTokenOk) {
-    throw std::runtime_error(
+    throw HttpError(
+        http::status::forbidden,
         "Pinning a result with a name requires a valid access token");
   }
   auto getGeoCacheVar = [&]() -> std::optional<Variable> {

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -449,9 +449,10 @@ CPP_template_def(typename RequestT, typename ResponseT)(
   auto requireValidAccessToken = [&accessTokenOk](
                                      const std::string& actionName) {
     if (!accessTokenOk) {
-      throw std::runtime_error(absl::StrCat(
-          actionName,
-          " requires a valid access token but no access token was provided"));
+      throw HttpError(
+          http::status::forbidden,
+          absl::StrCat(actionName, " requires a valid access token but no "
+                                   "access token was provided"));
     }
   };
 
@@ -1495,7 +1496,6 @@ CPP_template_def(typename VisitorT, typename RequestT, typename ResponseT)(
   } catch (const std::exception& e) {
     responseStatus = http::status::internal_server_error;
     exceptionErrorMsg = e.what();
-    // TODO<qup42> this includes missing/wrong access token which should be 403
     metrics_->sparqlErrors_->Add(1, {SparqlErrorType::internal});
   }
   // TODO<qup42> at this stage should probably have a wrapper that takes
@@ -1583,12 +1583,14 @@ bool Server::checkAccessToken(
   }
   const auto accessTokenProvidedMsg = "Access token was provided";
   if (accessToken_.empty()) {
-    throw std::runtime_error(
+    throw HttpError(
+        http::status::forbidden,
         absl::StrCat(accessTokenProvidedMsg,
                      " but server was started without --access-token"));
   } else if (!ad_utility::constantTimeEquals(accessToken.value(),
                                              accessToken_)) {
-    throw std::runtime_error(
+    throw HttpError(
+        http::status::forbidden,
         absl::StrCat(accessTokenProvidedMsg, " but it was invalid"));
   } else {
     AD_LOG_DEBUG << accessTokenProvidedMsg << " and correct" << std::endl;

--- a/test/ServerTest.cpp
+++ b/test/ServerTest.cpp
@@ -43,6 +43,21 @@ auto parseQuery(std::string query,
                                   datasets);
 }
 
+// Expect that `call()` throws an `HttpError` with status 403 Forbidden and
+// with a message that matches `messageMatcher`.
+auto expectForbiddenError = [](auto call, auto messageMatcher,
+                               ad_utility::source_location l =
+                                   ad_utility::source_location::current()) {
+  auto trace = generateLocationTrace(l);
+  try {
+    call();
+    FAIL() << "Expected an `HttpError` to be thrown";
+  } catch (const HttpError& e) {
+    EXPECT_EQ(e.status(), boost::beast::http::status::forbidden);
+    EXPECT_THAT(e.what(), messageMatcher);
+  }
+};
+
 }  // namespace
 TEST(ServerTest, determineResultPinning) {
   EXPECT_THAT(Server::determineResultPinning(
@@ -397,10 +412,12 @@ TEST(ServerTest, configurePinnedResultWithName) {
   // Reset for next test
   qec->pinResultWithName() = std::nullopt;
 
-  // Test with pinNamed but invalid access token - should throw exception
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      Server::configurePinnedResultWithName(pinNamed, std::nullopt,
-                                            std::nullopt, false, *qec),
+  // Pinning without a valid access token is rejected with 403 Forbidden.
+  expectForbiddenError(
+      [&] {
+        Server::configurePinnedResultWithName(pinNamed, std::nullopt,
+                                              std::nullopt, false, *qec);
+      },
       testing::HasSubstr(
           "Pinning a result with a name requires a valid access token"));
 
@@ -461,31 +478,17 @@ TEST(ServerTest, checkAccessToken) {
   Server server{4321, 1, "accessToken", config};
   EXPECT_TRUE(server.checkAccessToken("accessToken"));
 
-  AD_EXPECT_THROW_WITH_MESSAGE_AND_TYPE(
-      server.checkAccessToken("invalidAccessToken"),
-      testing::HasSubstr("Access token was provided but it was invalid"),
-      HttpError);
   // An invalid access token results in a 403 Forbidden response.
-  try {
-    server.checkAccessToken("invalidAccessToken");
-    FAIL() << "Expected an `HttpError` to be thrown";
-  } catch (const HttpError& e) {
-    EXPECT_EQ(e.status(), boost::beast::http::status::forbidden);
-  }
+  expectForbiddenError(
+      [&] { server.checkAccessToken("invalidAccessToken"); },
+      testing::HasSubstr("Access token was provided but it was invalid"));
 
   // Same when the server was started without `--access-token` at all.
   Server serverWithoutToken{4322, 1, "", config};
-  AD_EXPECT_THROW_WITH_MESSAGE_AND_TYPE(
-      serverWithoutToken.checkAccessToken("someToken"),
+  expectForbiddenError(
+      [&] { serverWithoutToken.checkAccessToken("someToken"); },
       testing::HasSubstr("Access token was provided but server was started "
-                         "without --access-token"),
-      HttpError);
-  try {
-    serverWithoutToken.checkAccessToken("someToken");
-    FAIL() << "Expected an `HttpError` to be thrown";
-  } catch (const HttpError& e) {
-    EXPECT_EQ(e.status(), boost::beast::http::status::forbidden);
-  }
+                         "without --access-token"));
 
   // No access token provided at all is not an error here, it just means that
   // operations requiring one are rejected later.

--- a/test/ServerTest.cpp
+++ b/test/ServerTest.cpp
@@ -461,9 +461,35 @@ TEST(ServerTest, checkAccessToken) {
   Server server{4321, 1, "accessToken", config};
   EXPECT_TRUE(server.checkAccessToken("accessToken"));
 
-  AD_EXPECT_THROW_WITH_MESSAGE(
+  AD_EXPECT_THROW_WITH_MESSAGE_AND_TYPE(
       server.checkAccessToken("invalidAccessToken"),
-      testing::HasSubstr("Access token was provided but it was invalid"));
+      testing::HasSubstr("Access token was provided but it was invalid"),
+      HttpError);
+  // An invalid access token results in a 403 Forbidden response.
+  try {
+    server.checkAccessToken("invalidAccessToken");
+    FAIL() << "Expected an `HttpError` to be thrown";
+  } catch (const HttpError& e) {
+    EXPECT_EQ(e.status(), boost::beast::http::status::forbidden);
+  }
+
+  // Same when the server was started without `--access-token` at all.
+  Server serverWithoutToken{4322, 1, "", config};
+  AD_EXPECT_THROW_WITH_MESSAGE_AND_TYPE(
+      serverWithoutToken.checkAccessToken("someToken"),
+      testing::HasSubstr("Access token was provided but server was started "
+                         "without --access-token"),
+      HttpError);
+  try {
+    serverWithoutToken.checkAccessToken("someToken");
+    FAIL() << "Expected an `HttpError` to be thrown";
+  } catch (const HttpError& e) {
+    EXPECT_EQ(e.status(), boost::beast::http::status::forbidden);
+  }
+
+  // No access token provided at all is not an error here, it just means that
+  // operations requiring one are rejected later.
+  EXPECT_FALSE(serverWithoutToken.checkAccessToken(std::nullopt));
 
   config.persistUpdates_ = false;
 


### PR DESCRIPTION
So far, a request with a missing or invalid access token failed with HTTP status 400, or with status 500 when the check happened during the processing of an operation (for example, for an update or when pinning a result). This made it impossible for clients like the QLever UI to distinguish credential problems from other errors.

Such requests now fail with status 403 (Forbidden). The error messages are unchanged.