### PR TITLE
Add option `--rebuild-keep-previous-index-dirs` to `qlever-server`

### DIFF
--- a/e2e/e2e.sh
+++ b/e2e/e2e.sh
@@ -9,9 +9,19 @@ function cleanup_server {
 	cat "$BINARY_DIR/server_log.txt"
 	echo "The Query Log:"
 	cat "$BINARY_DIR/query_log.txt"
+	if [ -f "$BINARY_DIR/server_with_proxy_log.txt" ]; then
+		echo "The Log of the server that uses the proxy:"
+		cat "$BINARY_DIR/server_with_proxy_log.txt"
+	fi
+	if [ -f "$BINARY_DIR/proxy_log.txt" ]; then
+		echo "The Proxy Log:"
+		cat "$BINARY_DIR/proxy_log.txt"
+	fi
 	# Killing 0 sends the signal to all processes in the current
 	# process group
 	kill "$SERVER_PID"
+	[ -n "${SERVER_WITH_PROXY_PID:-}" ] && kill "$SERVER_WITH_PROXY_PID" || true
+	[ -n "${PROXY_PID:-}" ] && kill "$PROXY_PID" || true
 }
 
 function print_usage {
@@ -153,4 +163,56 @@ fi
 
 echo "qlever-server was successfully started, running queries ..."
 $PYTHON_BINARY "$PROJECT_DIR/e2e/queryit.py" "$PROJECT_DIR/e2e/scientists_queries.yaml" "http://localhost:9099" | tee "$BINARY_DIR/query_log.txt" || bail "Querying Server failed"
+
+# Test that federated queries (`SERVICE`) can be routed through an HTTP proxy,
+# configured via the `http_proxy` environment variable. We start a logging
+# proxy and a second server that uses it, and send the second server a
+# federated query whose `SERVICE` part must be answered by the first server.
+# The proxy log then proves that the request actually went through the proxy.
+echo "Testing federated queries through an HTTP proxy ..."
+PROXY_PORT=9097
+PROXY_LOG="$BINARY_DIR/proxy_log.txt"
+rm -f "$PROXY_LOG"
+$PYTHON_BINARY "$PROJECT_DIR/e2e/proxy.py" "$PROXY_PORT" "$PROXY_LOG" > /dev/null &
+PROXY_PID=$!
+
+pushd "$BINARY_DIR"
+env http_proxy="http://localhost:$PROXY_PORT" ./qlever-server -i "$INDEX" -p 9098 -m 1GB --default-query-timeout 30s &> server_with_proxy_log.txt &
+SERVER_WITH_PROXY_PID=$!
+popd
+
+echo "Waiting for the server that uses the proxy to launch and open its port"
+i=0
+until [ $i -eq 60 ] || curl --max-time 1 --output /dev/null --silent http://localhost:9098/; do
+	sleep 1;
+  i=$((i+1));
+done
+[ $i -lt 60 ] || bail "The server that uses the proxy could not be reached"
+
+grep -q "Proxy for outgoing HTTP requests: localhost:$PROXY_PORT" "$BINARY_DIR/server_with_proxy_log.txt" \
+  || bail "The server did not log the configured proxy"
+
+# The result of the federated query (which goes through the proxy) must match
+# the result of the direct query, and the proxy must have seen the `SERVICE`
+# request (a `POST` with an absolute-form target, as required for a relayed
+# plain HTTP request).
+DIRECT_COUNT=$(curl --silent http://localhost:9099/ -H "Accept: text/csv" \
+  --data-urlencode "query=SELECT (COUNT(?s) AS ?count) WHERE { ?s <is-a> <Scientist> }" | tail -1 | tr -d '\r')
+FEDERATED_COUNT=$(curl --silent http://localhost:9098/ -H "Accept: text/csv" \
+  --data-urlencode "query=SELECT (COUNT(?s) AS ?count) WHERE { SERVICE <http://localhost:9099> { ?s <is-a> <Scientist> } }" | tail -1 | tr -d '\r')
+echo "Number of scientists, direct query: ${DIRECT_COUNT}, federated query via the proxy: ${FEDERATED_COUNT}"
+[[ "$DIRECT_COUNT" =~ ^[1-9][0-9]*$ ]] || bail "The direct query failed"
+[ "$DIRECT_COUNT" == "$FEDERATED_COUNT" ] || bail "The federated query through the proxy returned a wrong result"
+grep -q "REQUEST: POST http://localhost:9099/" "$PROXY_LOG" \
+  || bail "The proxy did not see the federated request"
+
+# A malformed proxy URL must fail the server startup with a readable message.
+pushd "$BINARY_DIR"
+if env http_proxy="socks5://proxy:1080" ./qlever-server -i "$INDEX" -p 9096 -m 1GB &> bad_proxy_log.txt; then
+  bail "The server started despite a malformed http_proxy"
+fi
+popd
+grep -q "only supports plain HTTP proxies" "$BINARY_DIR/bad_proxy_log.txt" \
+  || bail "The error message for a malformed http_proxy is missing"
+echo "The HTTP proxy tests passed"
 popd

--- a/e2e/proxy.py
+++ b/e2e/proxy.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Minimal logging HTTP forward proxy for the end-to-end tests: supports
+absolute-form relaying (plain HTTP) and CONNECT tunneling (HTTPS). Logs every
+request line to stdout and to the given log file, so that the test can verify
+that a request actually went through the proxy. Usage: proxy.py PORT LOGFILE"""
+import socket
+import sys
+import threading
+from urllib.parse import urlsplit
+
+LOG_LOCK = threading.Lock()
+LOG_FILE = sys.argv[2] if len(sys.argv) > 2 else "proxy_log.txt"
+
+
+def log(msg):
+    with LOG_LOCK:
+        print(msg, flush=True)
+        with open(LOG_FILE, "a") as f:
+            f.write(msg + "\n")
+
+
+def pump(a, b):
+    try:
+        while True:
+            data = a.recv(65536)
+            if not data:
+                break
+            b.sendall(data)
+    except OSError:
+        pass
+    finally:
+        try:
+            b.shutdown(socket.SHUT_WR)
+        except OSError:
+            pass
+
+
+def relay(client, upstream):
+    t1 = threading.Thread(target=pump, args=(client, upstream))
+    t2 = threading.Thread(target=pump, args=(upstream, client))
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+
+def handle(client, addr):
+    try:
+        client.settimeout(30)
+        # Read the request header.
+        data = b""
+        while b"\r\n\r\n" not in data:
+            chunk = client.recv(65536)
+            if not chunk:
+                return
+            data += chunk
+        header, _, rest = data.partition(b"\r\n\r\n")
+        request_line = header.split(b"\r\n")[0].decode("latin1")
+        log(f"REQUEST: {request_line}")
+        method, target, _version = request_line.split(" ", 2)
+
+        if method == "CONNECT":
+            host, _, port = target.rpartition(":")
+            upstream = socket.create_connection((host.strip("[]"), int(port)), 30)
+            client.sendall(b"HTTP/1.1 200 Connection established\r\n\r\n")
+            relay(client, upstream)
+        else:
+            # Absolute-form plain HTTP relay. A proper proxy client never sends
+            # an origin-form target to a proxy, so reject that.
+            parts = urlsplit(target)
+            if not parts.scheme:
+                log(f"REJECT (origin-form target): {target}")
+                client.sendall(b"HTTP/1.1 400 Bad Request\r\n\r\n")
+                return
+            host = parts.hostname
+            port = parts.port or 80
+            path = parts.path or "/"
+            if parts.query:
+                path += "?" + parts.query
+            # Rewrite the request line to origin form for the upstream server.
+            lines = header.split(b"\r\n")
+            lines[0] = f"{method} {path} HTTP/1.1".encode("latin1")
+            upstream = socket.create_connection((host, port), 30)
+            upstream.sendall(b"\r\n".join(lines) + b"\r\n\r\n" + rest)
+            relay(client, upstream)
+    except Exception as e:
+        log(f"ERROR: {e}")
+    finally:
+        client.close()
+
+
+def main():
+    port = int(sys.argv[1]) if len(sys.argv) > 1 else 3128
+    server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    server.bind(("127.0.0.1", port))
+    server.listen(16)
+    log(f"LISTENING on 127.0.0.1:{port}")
+    while True:
+        client, addr = server.accept()
+        threading.Thread(target=handle, args=(client, addr), daemon=True).start()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ServerMain.cpp
+++ b/src/ServerMain.cpp
@@ -60,7 +60,6 @@ int main(int argc, char** argv) {
   bool noResourceUsageLog = false;
   uint32_t resourceUsageIntervalS = 2;
   std::string rebuildIndexStrategy;
-  std::string rebuildKeepPreviousIndexDirs;
 
   ad_utility::ParameterToProgramOptionFactory optionFactory{
       &globalRuntimeParameters};
@@ -177,8 +176,8 @@ int main(int argc, char** argv) {
       "of index triples, but never below `min` and always at `max` (e.g. "
       "\"automatic:10000:1000000:0.1\").");
   add("rebuild-keep-previous-index-dirs",
-      po::value<std::string>(&rebuildKeepPreviousIndexDirs)
-          ->default_value("original-and-most-recent"),
+      po::value(&config.keepPreviousIndexDirs_)
+          ->default_value(qlever::KeepPreviousIndexDirs::OriginalAndMostRecent),
       "Which `previous.*` index directories to keep after a successful index "
       "rebuild, manual or automatic (each rebuild moves the index that was "
       "served so far into such a directory): \"all\" (keep all of them), "
@@ -362,20 +361,13 @@ int main(int argc, char** argv) {
                 << rebuildIndexStrategy << ")" << std::endl;
   }
 
-  // Resolve the `--rebuild-keep-previous-index-dirs` option, like the
-  // `--rebuild-index-strategy` option above.
-  try {
-    config.keepPreviousIndexDirs_ =
-        qlever::parseKeepPreviousIndexDirs(rebuildKeepPreviousIndexDirs);
-  } catch (const std::exception& e) {
-    AD_LOG_ERROR << "Invalid argument to --rebuild-keep-previous-index-dirs: "
-                 << e.what() << std::endl;
-    return EXIT_FAILURE;
-  }
+  // The `--rebuild-keep-previous-index-dirs` option is parsed directly into
+  // `config.keepPreviousIndexDirs_` (a bad value fails the startup with a
+  // readable message, via the `validate` hook in `EnumWithStrings.h`).
   if (config.keepPreviousIndexDirs_ != qlever::KeepPreviousIndexDirs::All) {
     AD_LOG_INFO << "Cleanup of previous index directories after each rebuild "
                    "enabled (--rebuild-keep-previous-index-dirs "
-                << rebuildKeepPreviousIndexDirs << ")" << std::endl;
+                << config.keepPreviousIndexDirs_ << ")" << std::endl;
   }
 
   try {

--- a/src/ServerMain.cpp
+++ b/src/ServerMain.cpp
@@ -23,6 +23,7 @@
 #include "util/ProgramOptionsHelpers.h"
 #include "util/ReadableNumberFacet.h"
 #include "util/ResourceMonitor.h"
+#include "util/http/HttpProxyConfig.h"
 #include "util/metrics/Metrics.h"
 
 using std::size_t;
@@ -305,6 +306,32 @@ int main(int argc, char** argv) {
     }
     AD_LOG_INFO << "Runtime parameter set from the command line: " << assignment
                 << std::endl;
+  }
+
+  // Read the proxy for outgoing requests (`SERVICE` and `LOAD`) from the
+  // environment. We do this eagerly so that a malformed proxy URL fails the
+  // startup with a readable message, instead of only surfacing on the first
+  // federated query. Only log if a proxy is actually configured, to not add
+  // noise for the common case.
+  try {
+    const auto& proxy = ad_utility::httpProxy::globalProxy();
+    if (proxy.has_value()) {
+      AD_LOG_INFO << "Proxy for outgoing HTTP requests: "
+                  << proxy->asStringForLogging() << std::endl;
+    }
+    // The uppercase `HTTP_PROXY` is deliberately ignored (following `curl`,
+    // see `HttpProxyConfig.h`), but silently doing so would be confusing, so
+    // leave a hint.
+    if (ad_utility::httpProxy::uppercaseHttpProxyIsSetButIgnored()) {
+      AD_LOG_INFO << "The environment variable `HTTP_PROXY` (uppercase) is "
+                     "set, but deliberately ignored; use the lowercase "
+                     "`http_proxy` to configure a proxy for outgoing requests"
+                  << std::endl;
+    }
+  } catch (const std::exception& e) {
+    AD_LOG_ERROR << "Invalid value of the `http_proxy` environment variable: "
+                 << e.what() << std::endl;
+    return EXIT_FAILURE;
   }
 
   // Resolve the `--rebuild-index-strategy` option. A bad value fails the

--- a/src/ServerMain.cpp
+++ b/src/ServerMain.cpp
@@ -59,6 +59,7 @@ int main(int argc, char** argv) {
   bool noResourceUsageLog = false;
   uint32_t resourceUsageIntervalS = 2;
   std::string rebuildIndexStrategy;
+  std::string rebuildKeepPreviousIndexDirs;
 
   ad_utility::ParameterToProgramOptionFactory optionFactory{
       &globalRuntimeParameters};
@@ -174,6 +175,18 @@ int main(int argc, char** argv) {
       "reaches the given `fraction` (a number greater than 0) of the number "
       "of index triples, but never below `min` and always at `max` (e.g. "
       "\"automatic:10000:1000000:0.1\").");
+  add("rebuild-keep-previous-index-dirs",
+      po::value<std::string>(&rebuildKeepPreviousIndexDirs)
+          ->default_value("original-and-most-recent"),
+      "Which `previous.*` index directories to keep after a successful index "
+      "rebuild, manual or automatic (each rebuild moves the index that was "
+      "served so far into such a directory): \"all\" (keep all of them), "
+      "\"none\" (delete all of them), \"original-only\" (keep only the "
+      "oldest), \"most-recent-only\" (keep only the most recently created), "
+      "or \"original-and-most-recent\" (the default, keep both). The choices "
+      "and the default are the same as for the `--keep-previous-index-dirs` "
+      "option of the `qlever rebuild-index` command, which applies the same "
+      "policy on the client side.");
   add("syntax-test-mode",
       optionFactory.getProgramOption<&RuntimeParameters::syntaxTestMode_>(),
       "Make several query patterns that are syntactially valid, but otherwise "
@@ -320,6 +333,22 @@ int main(int argc, char** argv) {
   if (config.rebuildIndexStrategy_.has_value()) {
     AD_LOG_INFO << "Automatic index rebuild enabled (--rebuild-index-strategy "
                 << rebuildIndexStrategy << ")" << std::endl;
+  }
+
+  // Resolve the `--rebuild-keep-previous-index-dirs` option, like the
+  // `--rebuild-index-strategy` option above.
+  try {
+    config.keepPreviousIndexDirs_ =
+        qlever::parseKeepPreviousIndexDirs(rebuildKeepPreviousIndexDirs);
+  } catch (const std::exception& e) {
+    AD_LOG_ERROR << "Invalid argument to --rebuild-keep-previous-index-dirs: "
+                 << e.what() << std::endl;
+    return EXIT_FAILURE;
+  }
+  if (config.keepPreviousIndexDirs_ != qlever::KeepPreviousIndexDirs::All) {
+    AD_LOG_INFO << "Cleanup of previous index directories after each rebuild "
+                   "enabled (--rebuild-keep-previous-index-dirs "
+                << rebuildKeepPreviousIndexDirs << ")" << std::endl;
   }
 
   try {

--- a/src/engine/KeepPreviousIndexDirs.h
+++ b/src/engine/KeepPreviousIndexDirs.h
@@ -1,0 +1,110 @@
+//  Copyright 2026 The QLever Authors, in particular:
+//
+//  2026 Hannah Bast <bast@cs.uni-freiburg.de>, UFR
+//
+//  UFR = University of Freiburg, Chair of Algorithms and Data Structures
+
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#ifndef QLEVER_SRC_ENGINE_KEEPPREVIOUSINDEXDIRS_H
+#define QLEVER_SRC_ENGINE_KEEPPREVIOUSINDEXDIRS_H
+
+#include <absl/strings/str_cat.h>
+
+#include <stdexcept>
+#include <string_view>
+
+#include "util/Exception.h"
+
+namespace qlever {
+
+// Policy for which `previous.*` index directories to keep after a successful
+// index rebuild, configured via the `--rebuild-keep-previous-index-dirs`
+// option of `qlever-server`. Each rebuild moves the index that was served so
+// far into such a directory (see `Qlever::makeIndexRebuildConfig`), so with
+// frequent rebuilds (in particular, automatic ones, see
+// `--rebuild-index-strategy`), these directories accumulate and can take up a
+// lot of disk space. The choices are the same as for the
+// `--keep-previous-index-dirs` option of the `qlever rebuild-index` command
+// (which applies the same policy on the client side): keep all of the
+// directories, none of them, only the original one (the oldest, which
+// contains the index the first rebuild started from), only the most recently
+// created one, or the original and the most recent.
+enum class KeepPreviousIndexDirs {
+  All,
+  None,
+  OriginalOnly,
+  MostRecentOnly,
+  OriginalAndMostRecent
+};
+
+// Parse the value of the `--rebuild-keep-previous-index-dirs` option. Throws
+// `std::runtime_error` for any value that is not one of the five choices.
+inline KeepPreviousIndexDirs parseKeepPreviousIndexDirs(
+    std::string_view value) {
+  if (value == "all") {
+    return KeepPreviousIndexDirs::All;
+  }
+  if (value == "none") {
+    return KeepPreviousIndexDirs::None;
+  }
+  if (value == "original-only") {
+    return KeepPreviousIndexDirs::OriginalOnly;
+  }
+  if (value == "most-recent-only") {
+    return KeepPreviousIndexDirs::MostRecentOnly;
+  }
+  if (value == "original-and-most-recent") {
+    return KeepPreviousIndexDirs::OriginalAndMostRecent;
+  }
+  throw std::runtime_error{
+      absl::StrCat("The value \"", value,
+                   "\" must be one of \"all\", \"none\", \"original-only\", "
+                   "\"most-recent-only\", or \"original-and-most-recent\"")};
+}
+
+// The inverse of `parseKeepPreviousIndexDirs`, for log messages.
+inline std::string_view toString(KeepPreviousIndexDirs policy) {
+  switch (policy) {
+    case KeepPreviousIndexDirs::All:
+      return "all";
+    case KeepPreviousIndexDirs::None:
+      return "none";
+    case KeepPreviousIndexDirs::OriginalOnly:
+      return "original-only";
+    case KeepPreviousIndexDirs::MostRecentOnly:
+      return "most-recent-only";
+    case KeepPreviousIndexDirs::OriginalAndMostRecent:
+      return "original-and-most-recent";
+  }
+  AD_FAIL();
+}
+
+// Decide whether the previous index directory at position `index` should be
+// kept under the given `policy`, where the `numDirs` directories are numbered
+// from the oldest (position 0, the original) to the newest (position
+// `numDirs - 1`, the most recent).
+inline bool keepPreviousIndexDir(KeepPreviousIndexDirs policy, size_t index,
+                                 size_t numDirs) {
+  AD_CONTRACT_CHECK(index < numDirs);
+  bool isOriginal = index == 0;
+  bool isMostRecent = index + 1 == numDirs;
+  switch (policy) {
+    case KeepPreviousIndexDirs::All:
+      return true;
+    case KeepPreviousIndexDirs::None:
+      return false;
+    case KeepPreviousIndexDirs::OriginalOnly:
+      return isOriginal;
+    case KeepPreviousIndexDirs::MostRecentOnly:
+      return isMostRecent;
+    case KeepPreviousIndexDirs::OriginalAndMostRecent:
+      return isOriginal || isMostRecent;
+  }
+  AD_FAIL();
+}
+
+}  // namespace qlever
+
+#endif  // QLEVER_SRC_ENGINE_KEEPPREVIOUSINDEXDIRS_H

--- a/src/engine/KeepPreviousIndexDirs.h
+++ b/src/engine/KeepPreviousIndexDirs.h
@@ -10,14 +10,24 @@
 #ifndef QLEVER_SRC_ENGINE_KEEPPREVIOUSINDEXDIRS_H
 #define QLEVER_SRC_ENGINE_KEEPPREVIOUSINDEXDIRS_H
 
-#include <absl/strings/str_cat.h>
-
-#include <stdexcept>
+#include <array>
 #include <string_view>
+#include <utility>
 
+#include "util/EnumWithStrings.h"
 #include "util/Exception.h"
 
 namespace qlever {
+
+namespace detail {
+enum class KeepPreviousIndexDirsEnum {
+  All,
+  None,
+  OriginalOnly,
+  MostRecentOnly,
+  OriginalAndMostRecent
+};
+}
 
 // Policy for which `previous.*` index directories to keep after a successful
 // index rebuild, configured via the `--rebuild-keep-previous-index-dirs`
@@ -30,56 +40,43 @@ namespace qlever {
 // (which applies the same policy on the client side): keep all of the
 // directories, none of them, only the original one (the oldest, which
 // contains the index the first rebuild started from), only the most recently
-// created one, or the original and the most recent.
-enum class KeepPreviousIndexDirs {
-  All,
-  None,
-  OriginalOnly,
-  MostRecentOnly,
-  OriginalAndMostRecent
+// created one, or the original and the most recent. The `EnumWithStrings`
+// base class provides the conversion from and to these strings (in
+// particular, for the command-line option).
+class KeepPreviousIndexDirs
+    : public ad_utility::EnumWithStrings<KeepPreviousIndexDirs,
+                                         detail::KeepPreviousIndexDirsEnum> {
+ public:
+  using Enum = detail::KeepPreviousIndexDirsEnum;
+
+  static constexpr std::array<std::pair<Enum, std::string_view>, 5>
+      descriptions_{
+          {{Enum::All, "all"},
+           {Enum::None, "none"},
+           {Enum::OriginalOnly, "original-only"},
+           {Enum::MostRecentOnly, "most-recent-only"},
+           {Enum::OriginalAndMostRecent, "original-and-most-recent"}}};
+  static const KeepPreviousIndexDirs All;
+  static const KeepPreviousIndexDirs None;
+  static const KeepPreviousIndexDirs OriginalOnly;
+  static const KeepPreviousIndexDirs MostRecentOnly;
+  static const KeepPreviousIndexDirs OriginalAndMostRecent;
+
+  static constexpr std::string_view typeName() {
+    return "policy for keeping previous index directories";
+  }
+
+  using EnumWithStrings::EnumWithStrings;
 };
 
-// Parse the value of the `--rebuild-keep-previous-index-dirs` option. Throws
-// `std::runtime_error` for any value that is not one of the five choices.
-inline KeepPreviousIndexDirs parseKeepPreviousIndexDirs(
-    std::string_view value) {
-  if (value == "all") {
-    return KeepPreviousIndexDirs::All;
-  }
-  if (value == "none") {
-    return KeepPreviousIndexDirs::None;
-  }
-  if (value == "original-only") {
-    return KeepPreviousIndexDirs::OriginalOnly;
-  }
-  if (value == "most-recent-only") {
-    return KeepPreviousIndexDirs::MostRecentOnly;
-  }
-  if (value == "original-and-most-recent") {
-    return KeepPreviousIndexDirs::OriginalAndMostRecent;
-  }
-  throw std::runtime_error{
-      absl::StrCat("The value \"", value,
-                   "\" must be one of \"all\", \"none\", \"original-only\", "
-                   "\"most-recent-only\", or \"original-and-most-recent\"")};
-}
-
-// The inverse of `parseKeepPreviousIndexDirs`, for log messages.
-inline std::string_view toString(KeepPreviousIndexDirs policy) {
-  switch (policy) {
-    case KeepPreviousIndexDirs::All:
-      return "all";
-    case KeepPreviousIndexDirs::None:
-      return "none";
-    case KeepPreviousIndexDirs::OriginalOnly:
-      return "original-only";
-    case KeepPreviousIndexDirs::MostRecentOnly:
-      return "most-recent-only";
-    case KeepPreviousIndexDirs::OriginalAndMostRecent:
-      return "original-and-most-recent";
-  }
-  AD_FAIL();
-}
+const inline KeepPreviousIndexDirs KeepPreviousIndexDirs::All{Enum::All};
+const inline KeepPreviousIndexDirs KeepPreviousIndexDirs::None{Enum::None};
+const inline KeepPreviousIndexDirs KeepPreviousIndexDirs::OriginalOnly{
+    Enum::OriginalOnly};
+const inline KeepPreviousIndexDirs KeepPreviousIndexDirs::MostRecentOnly{
+    Enum::MostRecentOnly};
+const inline KeepPreviousIndexDirs KeepPreviousIndexDirs::OriginalAndMostRecent{
+    Enum::OriginalAndMostRecent};
 
 // Decide whether the previous index directory at position `index` should be
 // kept under the given `policy`, where the `numDirs` directories are numbered
@@ -90,16 +87,17 @@ inline bool keepPreviousIndexDir(KeepPreviousIndexDirs policy, size_t index,
   AD_CONTRACT_CHECK(index < numDirs);
   bool isOriginal = index == 0;
   bool isMostRecent = index + 1 == numDirs;
-  switch (policy) {
-    case KeepPreviousIndexDirs::All:
+  using enum KeepPreviousIndexDirs::Enum;
+  switch (policy.value()) {
+    case All:
       return true;
-    case KeepPreviousIndexDirs::None:
+    case None:
       return false;
-    case KeepPreviousIndexDirs::OriginalOnly:
+    case OriginalOnly:
       return isOriginal;
-    case KeepPreviousIndexDirs::MostRecentOnly:
+    case MostRecentOnly:
       return isMostRecent;
-    case KeepPreviousIndexDirs::OriginalAndMostRecent:
+    case OriginalAndMostRecent:
       return isOriginal || isMostRecent;
   }
   AD_FAIL();

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -62,6 +62,7 @@ Server::Server(
       noAccessCheck_(noAccessCheck),
       queryThreadPool_{numThreads},
       rebuildIndexStrategy_(config.rebuildIndexStrategy_),
+      keepPreviousIndexDirs_(config.keepPreviousIndexDirs_),
       metricsReader_(std::move(metricsReader)) {
   AD_LOG_INFO << "Initializing server ..." << std::endl;
 
@@ -1711,6 +1712,30 @@ Awaitable<qlever::IndexRebuildConfig> Server::rebuildIndex(
       },
       net::use_awaitable);
   co_await std::move(swapRoutine);
+
+  // The rebuild has succeeded, so apply the configured policy for which
+  // `previous.*` index directories to keep. This runs on the query thread
+  // pool: deleting a large index directory can take a while and must not
+  // block the (single-threaded) update executor. A failure here is only
+  // logged (by `cleanUpPreviousIndexDirs` itself, or by the catch below for
+  // an error while enumerating the directories); it must not fail the
+  // request, because the new index is already in place.
+  if (keepPreviousIndexDirs_ != qlever::KeepPreviousIndexDirs::All) {
+    auto cleanupRoutine = ad_utility::runFunctionOnExecutor(
+        queryThreadPool_.get_executor(),
+        [this, &config] {
+          try {
+            qlever::Qlever::cleanUpPreviousIndexDirs(config.newIndexTarget(),
+                                                     keepPreviousIndexDirs_);
+          } catch (const std::exception& e) {
+            AD_LOG_ERROR << "Failed to clean up the previous index "
+                            "directories: "
+                         << e.what() << std::endl;
+          }
+        },
+        net::use_awaitable);
+    co_await std::move(cleanupRoutine);
+  }
   co_return config;
 }
 

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -1706,8 +1706,14 @@ Awaitable<qlever::IndexRebuildConfig> Server::rebuildIndex(
         // it is only written from this very executor, which has a single
         // thread.
         oldManager.retireOnDiskFiles();
+        // The swap also applies the configured policy for which `previous.*`
+        // index directories to keep. Deleting a directory there blocks this
+        // single-threaded executor for a bit, but the swap blocks updates
+        // anyway, and doing it in the same step avoids an extra executor
+        // hop. A cleanup failure is only logged; it does not fail the
+        // request, because the new index is already in place.
         qlever().swapInRebuiltIndex(index, std::move(rebuildResult), handle,
-                                    config);
+                                    config, keepPreviousIndexDirs_);
         auto now = std::chrono::duration_cast<std::chrono::seconds>(
                        std::chrono::system_clock::now().time_since_epoch())
                        .count();
@@ -1715,23 +1721,6 @@ Awaitable<qlever::IndexRebuildConfig> Server::rebuildIndex(
       },
       net::use_awaitable);
   co_await std::move(swapRoutine);
-
-  // The rebuild has succeeded, so apply the configured policy for which
-  // `previous.*` index directories to keep. This runs on the query thread
-  // pool: deleting a large index directory can take a while and must not
-  // block the (single-threaded) update executor. A failure is only logged
-  // (`cleanUpPreviousIndexDirs` never throws); it must not fail the request,
-  // because the new index is already in place.
-  if (keepPreviousIndexDirs_ != qlever::KeepPreviousIndexDirs::All) {
-    auto cleanupRoutine = ad_utility::runFunctionOnExecutor(
-        queryThreadPool_.get_executor(),
-        [this, &config] {
-          qlever::Qlever::cleanUpPreviousIndexDirs(config.newIndexTarget(),
-                                                   keepPreviousIndexDirs_);
-        },
-        net::use_awaitable);
-    co_await std::move(cleanupRoutine);
-  }
   co_return config;
 }
 

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -1719,22 +1719,15 @@ Awaitable<qlever::IndexRebuildConfig> Server::rebuildIndex(
   // The rebuild has succeeded, so apply the configured policy for which
   // `previous.*` index directories to keep. This runs on the query thread
   // pool: deleting a large index directory can take a while and must not
-  // block the (single-threaded) update executor. A failure here is only
-  // logged (by `cleanUpPreviousIndexDirs` itself, or by the catch below for
-  // an error while enumerating the directories); it must not fail the
-  // request, because the new index is already in place.
+  // block the (single-threaded) update executor. A failure is only logged
+  // (`cleanUpPreviousIndexDirs` never throws); it must not fail the request,
+  // because the new index is already in place.
   if (keepPreviousIndexDirs_ != qlever::KeepPreviousIndexDirs::All) {
     auto cleanupRoutine = ad_utility::runFunctionOnExecutor(
         queryThreadPool_.get_executor(),
         [this, &config] {
-          try {
-            qlever::Qlever::cleanUpPreviousIndexDirs(config.newIndexTarget(),
-                                                     keepPreviousIndexDirs_);
-          } catch (const std::exception& e) {
-            AD_LOG_ERROR << "Failed to clean up the previous index "
-                            "directories: "
-                         << e.what() << std::endl;
-          }
+          qlever::Qlever::cleanUpPreviousIndexDirs(config.newIndexTarget(),
+                                                   keepPreviousIndexDirs_);
         },
         net::use_awaitable);
     co_await std::move(cleanupRoutine);

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -69,6 +69,7 @@ class Server {
   FRIEND_TEST(IndexRebuilder, serverIntegration);
   FRIEND_TEST(IndexRebuilder, serverIntegrationDroppedStateWarnings);
   FRIEND_TEST(IndexRebuilder, serverIntegrationAutomaticRebuild);
+  FRIEND_TEST(IndexRebuilder, serverIntegrationKeepPreviousIndexDirs);
   friend serverTestHelpers::ServerForTesting;
 
  public:

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -18,6 +18,7 @@
 
 #include "backports/filesystem.h"
 #include "engine/ExecuteUpdate.h"
+#include "engine/KeepPreviousIndexDirs.h"
 #include "engine/MaterializedViews.h"
 #include "engine/NamedResultCache.h"
 #include "engine/QueryExecutionContext.h"
@@ -120,6 +121,12 @@ class Server {
   // whenever the strategy says so, see `triggerRebuildIfStrategySaysSo`. Set
   // via the `--rebuild-index-strategy` option of `qlever-server`.
   std::optional<qlever::RebuildIndexStrategy> rebuildIndexStrategy_;
+
+  // Which `previous.*` index directories to keep after a successful rebuild
+  // (manual or automatic), see `KeepPreviousIndexDirs`. Set via the
+  // `--rebuild-keep-previous-index-dirs` option of `qlever-server`.
+  qlever::KeepPreviousIndexDirs keepPreviousIndexDirs_ =
+      qlever::KeepPreviousIndexDirs::OriginalAndMostRecent;
 
   // MetricsReader for serving the /metrics endpoint. `nullptr` when metrics are
   // disabled (--enable-metrics not passed).

--- a/src/libqlever/Qlever.cpp
+++ b/src/libqlever/Qlever.cpp
@@ -570,6 +570,63 @@ IndexRebuildConfig Qlever::makeIndexRebuildConfig(
 }
 
 // ___________________________________________________________________________
+void Qlever::cleanUpPreviousIndexDirs(const std::string& indexBaseName,
+                                      KeepPreviousIndexDirs policy) {
+  namespace fs = ql::filesystem;
+  if (policy == KeepPreviousIndexDirs::All) {
+    return;
+  }
+
+  // Collect the `previous.*` directories in the directory of the index. The
+  // parent path is empty if the base name lies in the working directory
+  // itself.
+  fs::path indexDir = fs::path{indexBaseName}.parent_path();
+  if (indexDir.empty()) {
+    indexDir = fs::current_path();
+  }
+  std::vector<fs::path> previousDirs;
+  for (const auto& entry : fs::directory_iterator{indexDir}) {
+    if (entry.is_directory() &&
+        ql::starts_with(entry.path().filename().string(), "previous.")) {
+      previousDirs.push_back(entry.path());
+    }
+  }
+
+  // Order the directories from the oldest to the newest by the time they were
+  // last written to. Nothing writes into such a directory after the rebuild
+  // that created it, so this is the order in which they were created. Two
+  // rebuilds within the same second can produce equal timestamps (depending
+  // on the filesystem backend); such ties are broken by name, which contains
+  // the build date of the retired index (with a numeric suffix for repeated
+  // dates, see `makeIndexRebuildConfig`) and hence also increases from the
+  // oldest to the newest.
+  auto sortKey = [](const fs::path& dir) {
+    return std::pair{fs::last_write_time(dir), dir.filename().string()};
+  };
+  ql::ranges::sort(previousDirs, std::less{}, sortKey);
+
+  // Keep or delete each directory according to the policy.
+  AD_LOG_INFO << "Checking which of the " << previousDirs.size()
+              << " previous index directories to keep or delete "
+                 "(rebuild-keep-previous-index-dirs = "
+              << toString(policy) << ")" << std::endl;
+  for (size_t i = 0; i < previousDirs.size(); ++i) {
+    const fs::path& dir = previousDirs[i];
+    bool keep = keepPreviousIndexDir(policy, i, previousDirs.size());
+    AD_LOG_INFO << dir.filename().string() << " -> "
+                << (keep ? "KEEP" : "DELETE") << std::endl;
+    if (!keep) {
+      ql::error_code errorCode;
+      fs::remove_all(dir, errorCode);
+      if (errorCode) {
+        AD_LOG_ERROR << "Failed to delete \"" << dir.filename().string()
+                     << "\": " << errorCode.message() << std::endl;
+      }
+    }
+  }
+}
+
+// ___________________________________________________________________________
 void Qlever::moveRebuiltIndexIntoPlace(IndexAndViews& newIndexAndViews,
                                        const IndexRebuildConfig& config) {
   namespace fs = ql::filesystem;

--- a/src/libqlever/Qlever.cpp
+++ b/src/libqlever/Qlever.cpp
@@ -574,11 +574,26 @@ IndexRebuildConfig Qlever::makeIndexRebuildConfig(
 // ___________________________________________________________________________
 void Qlever::cleanUpPreviousIndexDirs(const std::string& indexBaseName,
                                       KeepPreviousIndexDirs policy) {
-  namespace fs = ql::filesystem;
   if (policy == KeepPreviousIndexDirs::All) {
     return;
   }
+  // Nothing in here may throw: when this runs, the rebuild has already
+  // succeeded, so a failure of the cleanup must only be logged. Deletion
+  // failures are handled (and skipped) individually below; the catch covers
+  // everything else (e.g. a failure while enumerating the directories or
+  // opening the log file).
+  try {
+    cleanUpPreviousIndexDirsImpl(indexBaseName, policy);
+  } catch (const std::exception& e) {
+    AD_LOG_ERROR << "Failed to clean up the previous index directories: "
+                 << e.what() << std::endl;
+  }
+}
 
+// ___________________________________________________________________________
+void Qlever::cleanUpPreviousIndexDirsImpl(const std::string& indexBaseName,
+                                          KeepPreviousIndexDirs policy) {
+  namespace fs = ql::filesystem;
   // Collect the `previous.*` directories in the directory of the index. The
   // parent path is empty if the base name lies in the working directory
   // itself.

--- a/src/libqlever/Qlever.cpp
+++ b/src/libqlever/Qlever.cpp
@@ -601,13 +601,8 @@ void Qlever::cleanUpPreviousIndexDirsImpl(const std::string& indexBaseName,
   if (indexDir.empty()) {
     indexDir = fs::current_path();
   }
-  std::vector<fs::path> previousDirs;
-  for (const auto& entry : fs::directory_iterator{indexDir}) {
-    if (entry.is_directory() &&
-        ql::starts_with(entry.path().filename().string(), "previous.")) {
-      previousDirs.push_back(entry.path());
-    }
-  }
+  auto previousDirs =
+      qlever::util::directoriesWithPrefix(indexDir, "previous.");
 
   // Order the directories from the oldest to the newest by the time they were
   // last written to. Nothing writes into such a directory after the rebuild
@@ -627,25 +622,25 @@ void Qlever::cleanUpPreviousIndexDirsImpl(const std::string& indexBaseName,
   // moved into place together with the index), not to the server log.
   auto logFile = ad_utility::makeOfstream(
       absl::StrCat(indexBaseName, REBUILD_INDEX_LOG_SUFFIX), std::ios::app);
-  auto logInfo = [&logFile]() -> std::ostream& {
-    return logFile << ad_utility::Log::getTimeStamp() << " - INFO: ";
+  auto log = [&logFile](std::string_view severity = "INFO") -> std::ostream& {
+    return logFile << ad_utility::Log::getTimeStamp() << " - " << severity
+                   << ": ";
   };
-  logInfo() << "Checking which previous index directories to keep or delete ("
-            << toString(policy) << ")" << std::endl;
+  log() << "Checking which previous index directories to keep or delete ("
+        << policy << ")" << std::endl;
   for (size_t i = 0; i < previousDirs.size(); ++i) {
     const fs::path& dir = previousDirs[i];
     bool keep = keepPreviousIndexDir(policy, i, previousDirs.size());
-    logInfo() << dir.filename().string() << " -> " << (keep ? "KEEP" : "DELETE")
-              << std::endl;
+    log() << dir.filename().string() << " -> " << (keep ? "KEEP" : "DELETE")
+          << std::endl;
     if (!keep) {
       ql::error_code errorCode;
       fs::remove_all(dir, errorCode);
       if (errorCode) {
         // A failed deletion additionally goes to the server log, where
         // operators look for errors.
-        logFile << ad_utility::Log::getTimeStamp() << " - ERROR: "
-                << "Failed to delete \"" << dir.filename().string()
-                << "\": " << errorCode.message() << std::endl;
+        log("ERROR") << "Failed to delete \"" << dir.filename().string()
+                     << "\": " << errorCode.message() << std::endl;
         AD_LOG_ERROR << "Failed to delete \"" << dir.filename().string()
                      << "\": " << errorCode.message() << std::endl;
       }
@@ -655,7 +650,8 @@ void Qlever::cleanUpPreviousIndexDirsImpl(const std::string& indexBaseName,
 
 // ___________________________________________________________________________
 void Qlever::moveRebuiltIndexIntoPlace(IndexAndViews& newIndexAndViews,
-                                       const IndexRebuildConfig& config) {
+                                       const IndexRebuildConfig& config,
+                                       KeepPreviousIndexDirs policy) {
   namespace fs = ql::filesystem;
 
   // Move a `file` whose name starts with `fromBasename` so that its base-name
@@ -730,6 +726,13 @@ void Qlever::moveRebuiltIndexIntoPlace(IndexAndViews& newIndexAndViews,
                 << directoryOfNewIndexSource.string()
                 << "\" in which the new index was built" << std::endl;
   }
+
+  // Apply the configured policy for which `previous.*` index directories to
+  // keep, right after the move that has just retired the old index into such
+  // a directory. A failure is only logged (`cleanUpPreviousIndexDirs` never
+  // throws): the new index is already in place, so the rebuild as a whole has
+  // succeeded.
+  cleanUpPreviousIndexDirs(config.newIndexTarget(), policy);
 }
 
 // ___________________________________________________________________________
@@ -769,7 +772,8 @@ Qlever::RebuildResult Qlever::rebuildIndexToDisk(
 void Qlever::swapInRebuiltIndex(
     const Index& index, RebuildResult rebuildResult,
     const ad_utility::SharedCancellationHandle& handle,
-    const IndexRebuildConfig& config) {
+    const IndexRebuildConfig& config,
+    KeepPreviousIndexDirs keepPreviousIndexDirs) {
   auto& [oldSnapshot, mapping, newIndexAndViews] = rebuildResult;
   auto newSnapshot =
       index.deltaTriplesManager().getCurrentLocatedTriplesSharedState();
@@ -795,7 +799,7 @@ void Qlever::swapInRebuiltIndex(
   // consistently on the old index (the swap below has not happened and open
   // file handles survive the renames), but the on-disk layout has to be
   // repaired manually before the next restart.
-  moveRebuiltIndexIntoPlace(*newIndexAndViews, config);
+  moveRebuiltIndexIntoPlace(*newIndexAndViews, config, keepPreviousIndexDirs);
   swapIndexAndViews(std::move(newIndexAndViews));
   // Clear the query cache, including pinned entries: cached results were
   // computed against the old index, so their `VocabIndex` ids are in the old

--- a/src/libqlever/Qlever.cpp
+++ b/src/libqlever/Qlever.cpp
@@ -30,7 +30,9 @@
 #include "libqlever/QleverTypes.h"
 #include "parser/SparqlParser.h"
 #include "util/Exception.h"
+#include "util/File.h"
 #include "util/FilesystemHelpers.h"
+#include "util/Log.h"
 #include "util/TimeTracer.h"
 #include "util/http/UrlParser.h"
 
@@ -605,20 +607,30 @@ void Qlever::cleanUpPreviousIndexDirs(const std::string& indexBaseName,
   };
   ql::ranges::sort(previousDirs, std::less{}, sortKey);
 
-  // Keep or delete each directory according to the policy.
-  AD_LOG_INFO << "Checking which of the " << previousDirs.size()
-              << " previous index directories to keep or delete "
-                 "(rebuild-keep-previous-index-dirs = "
-              << toString(policy) << ")" << std::endl;
+  // Keep or delete each directory according to the policy. The decisions are
+  // written to the log file of the rebuild that has just finished (which was
+  // moved into place together with the index), not to the server log.
+  auto logFile = ad_utility::makeOfstream(
+      absl::StrCat(indexBaseName, REBUILD_INDEX_LOG_SUFFIX), std::ios::app);
+  auto logInfo = [&logFile]() -> std::ostream& {
+    return logFile << ad_utility::Log::getTimeStamp() << " - INFO: ";
+  };
+  logInfo() << "Checking which previous index directories to keep or delete ("
+            << toString(policy) << ")" << std::endl;
   for (size_t i = 0; i < previousDirs.size(); ++i) {
     const fs::path& dir = previousDirs[i];
     bool keep = keepPreviousIndexDir(policy, i, previousDirs.size());
-    AD_LOG_INFO << dir.filename().string() << " -> "
-                << (keep ? "KEEP" : "DELETE") << std::endl;
+    logInfo() << dir.filename().string() << " -> " << (keep ? "KEEP" : "DELETE")
+              << std::endl;
     if (!keep) {
       ql::error_code errorCode;
       fs::remove_all(dir, errorCode);
       if (errorCode) {
+        // A failed deletion additionally goes to the server log, where
+        // operators look for errors.
+        logFile << ad_utility::Log::getTimeStamp() << " - ERROR: "
+                << "Failed to delete \"" << dir.filename().string()
+                << "\": " << errorCode.message() << std::endl;
         AD_LOG_ERROR << "Failed to delete \"" << dir.filename().string()
                      << "\": " << errorCode.message() << std::endl;
       }

--- a/src/libqlever/Qlever.h
+++ b/src/libqlever/Qlever.h
@@ -670,6 +670,10 @@ class Qlever {
   // 4. Remove the directory that contained `config.newIndexSource()`, which
   //    step 2 has emptied (if it is actually empty). A failure here is only
   //    logged as a warning.
+  // 5. Apply the `policy` for which `previous.*` index directories to keep
+  //    (see `cleanUpPreviousIndexDirs` above), right after step 1 has retired
+  //    the old index into such a directory. The default policy `all` keeps
+  //    everything, i.e. performs no cleanup.
   //
   // Typically, `config.newIndexTarget()` is `config.oldIndexSource()`, i.e. the
   // new index is served from the place of the old index (so that a later
@@ -688,8 +692,9 @@ class Qlever {
   // this function does is string concatenation and moving files around. This
   // function assumes that file handles are never reopened, so moving the files
   // while the file handle is still open is fine in POSIX compliant systems.
-  static void moveRebuiltIndexIntoPlace(IndexAndViews& newIndexAndViews,
-                                        const IndexRebuildConfig& config);
+  static void moveRebuiltIndexIntoPlace(
+      IndexAndViews& newIndexAndViews, const IndexRebuildConfig& config,
+      KeepPreviousIndexDirs policy = KeepPreviousIndexDirs::All);
 
   // The result of the first phase of an index rebuild (see
   // `rebuildIndexToDisk`): a snapshot of the delta triples taken at the start
@@ -732,11 +737,13 @@ class Qlever {
   // Before the swap, `moveRebuiltIndexIntoPlace` is called, which moves the
   // files of the old index to `config.oldIndexTarget()` and the files of the
   // new index from `config.newIndexSource()` to `config.newIndexTarget()` (by
-  // default the place of the old index) and removes the directory in which the
-  // new index was built.
+  // default the place of the old index), removes the directory in which the
+  // new index was built, and applies the policy from `keepPreviousIndexDirs`
+  // for which `previous.*` index directories to keep.
   void swapInRebuiltIndex(const Index& index, RebuildResult rebuildResult,
                           const ad_utility::SharedCancellationHandle& handle,
-                          const IndexRebuildConfig& config);
+                          const IndexRebuildConfig& config,
+                          KeepPreviousIndexDirs keepPreviousIndexDirs);
 #endif
 
   QueryResultCache& cache() { return cache_; }

--- a/src/libqlever/Qlever.h
+++ b/src/libqlever/Qlever.h
@@ -636,9 +636,12 @@ class Qlever {
   // retires the index that was served so far into such a directory, see
   // `makeIndexRebuildConfig`): keep or delete each of them according to
   // `keepPreviousIndexDir`, where the directories are ordered from the oldest
-  // to the newest. Each decision is logged; a directory that cannot be
-  // deleted is logged as an error, but does not make this function throw
-  // (when this is called, the rebuild has already succeeded).
+  // to the newest. Each decision is appended to the `rebuild-index` log of
+  // the index with the base name `indexBaseName` (the log of the rebuild that
+  // has just finished), not to the server log. A directory that cannot be
+  // deleted is additionally logged as an error in the server log, but does
+  // not make this function throw (when this is called, the rebuild has
+  // already succeeded).
   static void cleanUpPreviousIndexDirs(const std::string& indexBaseName,
                                        KeepPreviousIndexDirs policy);
 

--- a/src/libqlever/Qlever.h
+++ b/src/libqlever/Qlever.h
@@ -20,6 +20,7 @@
 #include "backports/filesystem.h"
 #include "backports/memory_resource.h"
 #include "backports/span.h"
+#include "engine/KeepPreviousIndexDirs.h"
 #include "engine/MaterializedViews.h"
 #include "engine/NamedResultCache.h"
 #include "engine/NamedResultCacheSerializer.h"
@@ -259,6 +260,12 @@ struct EngineConfig : CommonConfig {
   // whenever `RebuildIndexStrategy::shouldTriggerRebuild` says so. If `nullopt`
   // (the default), rebuilds are only triggered manually.
   std::optional<RebuildIndexStrategy> rebuildIndexStrategy_ = std::nullopt;
+
+  // Which `previous.*` index directories to keep after a successful index
+  // rebuild (manual or automatic), see `KeepPreviousIndexDirs`. The default
+  // keeps the original and the most recent one.
+  KeepPreviousIndexDirs keepPreviousIndexDirs_ =
+      KeepPreviousIndexDirs::OriginalAndMostRecent;
 
   // If set to true, no permutations will be loaded from disk. This is useful
   // when only queries that don't require accessing the permutations need to be
@@ -623,6 +630,17 @@ class Qlever {
   static IndexRebuildConfig makeIndexRebuildConfig(
       const Index& index, std::optional<std::string> rebuildTmpDir,
       std::optional<std::string> rebuildPreviousIndexDir);
+
+  // Apply the given `policy` to the `previous.*` directories in the directory
+  // of the index with the base name `indexBaseName` (each successful rebuild
+  // retires the index that was served so far into such a directory, see
+  // `makeIndexRebuildConfig`): keep or delete each of them according to
+  // `keepPreviousIndexDir`, where the directories are ordered from the oldest
+  // to the newest. Each decision is logged; a directory that cannot be
+  // deleted is logged as an error, but does not make this function throw
+  // (when this is called, the rebuild has already succeeded).
+  static void cleanUpPreviousIndexDirs(const std::string& indexBaseName,
+                                       KeepPreviousIndexDirs policy);
 
   // Move a freshly rebuilt index into the place of the old one. There are two
   // indices involved, both with base names given by `config`: the old index

--- a/src/libqlever/Qlever.h
+++ b/src/libqlever/Qlever.h
@@ -638,13 +638,20 @@ class Qlever {
   // `keepPreviousIndexDir`, where the directories are ordered from the oldest
   // to the newest. Each decision is appended to the `rebuild-index` log of
   // the index with the base name `indexBaseName` (the log of the rebuild that
-  // has just finished), not to the server log. A directory that cannot be
-  // deleted is additionally logged as an error in the server log, but does
-  // not make this function throw (when this is called, the rebuild has
-  // already succeeded).
+  // has just finished), not to the server log. This function never throws
+  // (when this is called, the rebuild has already succeeded): a directory
+  // that cannot be deleted is logged as an error in the server log and
+  // skipped, and any other filesystem failure is also only logged.
   static void cleanUpPreviousIndexDirs(const std::string& indexBaseName,
                                        KeepPreviousIndexDirs policy);
 
+ private:
+  // The implementation of `cleanUpPreviousIndexDirs` above, which wraps this
+  // function in a try-catch.
+  static void cleanUpPreviousIndexDirsImpl(const std::string& indexBaseName,
+                                           KeepPreviousIndexDirs policy);
+
+ public:
   // Move a freshly rebuilt index into the place of the old one. There are two
   // indices involved, both with base names given by `config`: the old index
   // that is currently being served (at `config.oldIndexSource()`), and the

--- a/src/util/FilesystemHelpers.cpp
+++ b/src/util/FilesystemHelpers.cpp
@@ -99,6 +99,19 @@ size_t deleteFilesInDirectory(
 }
 
 // _____________________________________________________________________________
+std::vector<fs::path> directoriesWithPrefix(const fs::path& directory,
+                                            std::string_view prefix) {
+  std::vector<fs::path> result;
+  for (const auto& entry : ql::directoryRange(directory)) {
+    if (entry.is_directory() &&
+        ql::starts_with(entry.path().filename().string(), prefix)) {
+      result.push_back(entry.path());
+    }
+  }
+  return result;
+}
+
+// _____________________________________________________________________________
 bool isSubdirectoryOf(const std::string& path,
                       const std::string& containerPath) {
   auto normalize = [](const auto& p) {

--- a/src/util/FilesystemHelpers.h
+++ b/src/util/FilesystemHelpers.h
@@ -51,6 +51,12 @@ size_t deleteFilesInDirectory(
     const ql::filesystem::path& directory,
     absl::FunctionRef<bool(const ql::filesystem::path&)> shouldDelete);
 
+// Return the paths of the directories directly contained in `directory` whose
+// name starts with `prefix`, in unspecified order. This is used to enumerate
+// the `previous.*` index directories left behind by index rebuilds.
+std::vector<ql::filesystem::path> directoriesWithPrefix(
+    const ql::filesystem::path& directory, std::string_view prefix);
+
 // Return `true` if the directory from `path1` is a subdirectory of the
 // directory from `path2`; otherwise return `false`.
 //

--- a/src/util/http/CMakeLists.txt
+++ b/src/util/http/CMakeLists.txt
@@ -4,7 +4,7 @@ target_compile_options(mediaTypes PUBLIC -Wno-attributes)
 qlever_target_link_libraries(mediaTypes qlever_util httpParser)
 
 if (NOT REDUCED_FEATURE_SET_FOR_CPP17)
-add_library(http HttpServer.h HttpServer.cpp HttpClient.h HttpClient.cpp HttpUtils.h HttpUtils.cpp UrlParser.h UrlParser.cpp "HttpParser/AcceptHeaderQleverVisitor.h"
+add_library(http HttpServer.h HttpServer.cpp HttpClient.h HttpClient.cpp HttpProxyConfig.cpp HttpUtils.h HttpUtils.cpp UrlParser.h UrlParser.cpp "HttpParser/AcceptHeaderQleverVisitor.h"
         websocket/WebSocketSession.cpp websocket/MessageSender.cpp websocket/QueryToSocketDistributor.cpp
         websocket/QueryHub.cpp websocket/UpdateFetcher.cpp)
 

--- a/src/util/http/HttpClient.cpp
+++ b/src/util/http/HttpClient.cpp
@@ -24,15 +24,90 @@ namespace http = boost::beast::http;
 namespace net = boost::asio;
 using tcp = boost::asio::ip::tcp;
 using ad_utility::httpUtils::Url;
+using Proxy = ad_utility::httpProxy::Proxy;
 
 // Implemented using Boost.Beast, code adapted from
 // https://www.boost.org/doc/libs/master/libs/beast/example/http/client/sync/http_client_sync.cpp
 // https://www.boost.org/doc/libs/master/libs/beast/example/http/client/sync-ssl/http_client_sync_ssl.cpp
 
+namespace {
+// Ask `proxy` to open a tunnel to `host`:`port` over the already connected
+// `socket`, using the `CONNECT` method, and check that it agreed. Throws if the
+// proxy refuses. Must be called before the TLS handshake, so that the handshake
+// happens with the target host and not with the proxy.
+//
+// Note: this is a free function and not a member of `HttpClientImpl`, because
+// the explicit instantiation for the plain-HTTP case at the bottom of this file
+// would instantiate all members, and `beast::tcp_stream` has no `next_layer()`.
+//
+// TODO: Like the `connect` and `handshake` calls in the constructor below,
+// this exchange is blocking and has no timeout, so a proxy that accepts the
+// TCP connection but never answers blocks the calling thread indefinitely
+// (and out of reach of the cancellation handle). The whole connection setup
+// should eventually get a deadline.
+void establishProxyTunnel(tcp::socket& socket, const Proxy& proxy,
+                          std::string_view host, std::string_view port) {
+  // The target of a `CONNECT` request is in authority form, that is
+  // `host:port` with the port always explicit (RFC 9110, 9.3.6).
+  std::string authority = absl::StrCat(host, ":", port);
+  http::request<http::empty_body> request{http::verb::connect, authority, 11};
+  request.set(http::field::host, authority);
+  request.set(http::field::user_agent, BOOST_BEAST_VERSION_STRING);
+  if (!proxy.authorization_.empty()) {
+    request.set(http::field::proxy_authorization, proxy.authorization_);
+  }
+  // Note: deliberately no `prepare_payload()`, which would add a
+  // `Content-Length: 0` that some proxies reject on a `CONNECT`.
+  http::write(socket, request);
+
+  beast::flat_buffer buffer;
+  http::response_parser<http::empty_body> responseParser;
+  // A successful response to `CONNECT` has neither a body nor a
+  // `Content-Length`, because everything after the header belongs to the
+  // tunnel. We must therefore tell the parser not to expect a body; otherwise
+  // it would read until the connection is closed and the tunnel would never be
+  // established.
+  responseParser.skip(true);
+  http::read(socket, buffer, responseParser);
+
+  const auto& response = responseParser.get();
+  unsigned status = response.result_int();
+  if (status < 200 || status >= 300) {
+    throw std::runtime_error(absl::StrCat(
+        "The HTTP proxy <", proxy.host_, ":", proxy.port_,
+        "> refused to open a tunnel to <", authority,
+        "> and responded with: ", status, " ", toStd(response.reason()),
+        status == 407 ? ". Note that credentials for the proxy can be given as "
+                        "part of the proxy URL, as in "
+                        "`http_proxy=http://user:password@proxy:3128`"
+                      : ""));
+  }
+
+  // Any bytes that arrived after the response header already belong to the
+  // tunneled TLS stream, and there is no way to hand a pre-filled buffer to
+  // `ssl::stream`. Proxies do not send anything before the client speaks, so
+  // this should never happen; fail loudly rather than corrupt the handshake.
+  if (buffer.size() != 0) {
+    throw std::runtime_error(absl::StrCat(
+        "The HTTP proxy <", proxy.host_, ":", proxy.port_, "> sent ",
+        buffer.size(),
+        " unexpected byte(s) directly after its response to the CONNECT "
+        "request, which QLever cannot forward into the TLS session"));
+  }
+}
+}  // namespace
+
 // ____________________________________________________________________________
 template <typename StreamType>
 HttpClientImpl<StreamType>::HttpClientImpl(std::string_view host,
-                                           std::string_view port) {
+                                           std::string_view port,
+                                           const std::optional<Proxy>& proxy) {
+  // With a proxy, the TCP connection goes to the proxy, and it is the proxy
+  // that connects to `host`:`port` on our behalf. Everything below is otherwise
+  // identical to the direct case, except for the `CONNECT` tunnel for HTTPS.
+  std::string_view connectHost = proxy.has_value() ? proxy->host_ : host;
+  std::string_view connectPort = proxy.has_value() ? proxy->port_ : port;
+
   // IMPORTANT implementation note: Although we need only `stream_` later, it
   // is important that we also keep `io_context_` and `ssl_context_` alive.
   // Otherwise, we get a nasty and non-deterministic segmentation fault when
@@ -41,8 +116,15 @@ HttpClientImpl<StreamType>::HttpClientImpl(std::string_view host,
   if constexpr (std::is_same_v<StreamType, beast::tcp_stream>) {
     tcp::resolver resolver{ioContext_};
     stream_ = std::make_unique<StreamType>(ioContext_);
-    auto const results = resolver.resolve(host, port);
+    auto const results = resolver.resolve(connectHost, connectPort);
     stream_->connect(results);
+    // No tunnel needed: a plain HTTP request is relayed by the proxy based on
+    // the absolute form of its request target, see `absoluteFormTarget`. The
+    // proxy credentials, however, have to go on every relayed request, see
+    // `sendRequest`.
+    if (proxy.has_value()) {
+      proxyAuthorization_ = proxy->authorization_;
+    }
   } else {
     static_assert(std::is_same_v<StreamType, ssl::stream<tcp::socket>>,
                   "StreamType must be either boost::beast::tcp_stream or "
@@ -51,14 +133,19 @@ HttpClientImpl<StreamType>::HttpClientImpl(std::string_view host,
     ssl_context_->set_verify_mode(ssl::verify_none);
     tcp::resolver resolver{ioContext_};
     stream_ = std::make_unique<StreamType>(ioContext_, *ssl_context_);
+    // Note that the SNI host is the target host, also when going through a
+    // proxy: the TLS session is with the target, the proxy only forwards bytes.
     if (!SSL_set_tlsext_host_name(stream_->native_handle(),
                                   std::string{host}.c_str())) {
       boost::system::error_code ec{static_cast<int>(::ERR_get_error()),
                                    boost::asio::error::get_ssl_category()};
       throw boost::system::system_error{ec};
     }
-    auto const results = resolver.resolve(host, port);
+    auto const results = resolver.resolve(connectHost, connectPort);
     boost::asio::connect(stream_->next_layer(), results.begin(), results.end());
+    if (proxy.has_value()) {
+      establishProxyTunnel(stream_->next_layer(), proxy.value(), host, port);
+    }
     stream_->handshake(ssl::stream_base::client);
   }
 }
@@ -102,6 +189,13 @@ HttpOrHttpsResponse HttpClientImpl<StreamType>::sendRequest(
   request.method(method);
   request.target(target);
   request.set(http::field::host, host);
+  // A relayed plain HTTP request carries the proxy credentials on every
+  // request; the proxy consumes this header and does not forward it (RFC 9110,
+  // 11.7.2). For HTTPS the credentials are sent on the `CONNECT` request
+  // instead, see `establishProxyTunnel`.
+  if (!client->proxyAuthorization_.empty()) {
+    request.set(http::field::proxy_authorization, client->proxyAuthorization_);
+  }
   request.set(http::field::user_agent, BOOST_BEAST_VERSION_STRING);
   request.set(http::field::accept, acceptHeader);
   request.set(http::field::content_type, contentTypeHeader);
@@ -206,14 +300,37 @@ HttpOrHttpsResponse sendHttpOrHttpsRequest(
     ad_utility::SharedCancellationHandle handle, const http::verb& method,
     std::string_view requestData, std::string_view contentTypeHeader,
     std::string_view acceptHeader, size_t maxRedirects) {
+  return sendHttpOrHttpsRequestWithProxy(
+      url, std::move(handle), method, requestData, contentTypeHeader,
+      acceptHeader, maxRedirects, ad_utility::httpProxy::globalProxy());
+}
+
+// ____________________________________________________________________________
+HttpOrHttpsResponse sendHttpOrHttpsRequestWithProxy(
+    const ad_utility::httpUtils::Url& url,
+    ad_utility::SharedCancellationHandle handle, const http::verb& method,
+    std::string_view requestData, std::string_view contentTypeHeader,
+    std::string_view acceptHeader, size_t maxRedirects,
+    const std::optional<Proxy>& proxy) {
   auto sendRequest = [&](const Url& currentUrl,
                          auto ti) -> HttpOrHttpsResponse {
     using Client = typename decltype(ti)::type;
     auto client =
-        std::make_unique<Client>(currentUrl.host(), currentUrl.port());
+        std::make_unique<Client>(currentUrl.host(), currentUrl.port(), proxy);
+    // A plain HTTP request that is relayed by a proxy has to name its target in
+    // absolute form, so that the proxy knows where to relay it to. For HTTPS
+    // the connection is tunneled through the proxy, which then never sees the
+    // request, so the target stays in origin form.
+    std::string target = currentUrl.target();
+    if constexpr (std::is_same_v<Client, HttpClient>) {
+      if (proxy.has_value()) {
+        target = ad_utility::httpProxy::absoluteFormTarget(
+            currentUrl.host(), currentUrl.port(), target);
+      }
+    }
     return Client::sendRequest(std::move(client), method, currentUrl.host(),
-                               currentUrl.target(), handle, requestData,
-                               contentTypeHeader, acceptHeader);
+                               target, handle, requestData, contentTypeHeader,
+                               acceptHeader);
   };
 
   using namespace ad_utility::use_type_identity;

--- a/src/util/http/HttpClient.h
+++ b/src/util/http/HttpClient.h
@@ -17,11 +17,13 @@
 // order of the includes should not matter, and it should certainly not cause
 // segmentation faults.
 
+#include <optional>
 #include <string>
 
 #include "backports/span.h"
 #include "util/CancellationHandle.h"
 #include "util/Generator.h"
+#include "util/http/HttpProxyConfig.h"
 #include "util/http/HttpUtils.h"
 #include "util/http/beast.h"
 
@@ -59,8 +61,17 @@ struct HttpOrHttpsResponse {
 template <typename StreamType>
 class HttpClientImpl {
  public:
-  // The constructor sets up the connection to the client.
-  HttpClientImpl(std::string_view host, std::string_view port);
+  // The constructor sets up the connection to the client. If `proxy` is set,
+  // the TCP connection goes to the proxy instead of to `host`:`port`, and it is
+  // the proxy that connects to `host`:`port` on our behalf. For HTTPS this
+  // requires establishing a tunnel with the `CONNECT` method before the TLS
+  // handshake (see `establishProxyTunnel` in `HttpClient.cpp`). For plain HTTP
+  // nothing else has to happen here, but the request target passed to
+  // `sendRequest` then has to be in absolute form (see `absoluteFormTarget` in
+  // `HttpProxyConfig.h`), which `sendHttpOrHttpsRequest` below takes care of.
+  HttpClientImpl(
+      std::string_view host, std::string_view port,
+      const std::optional<ad_utility::httpProxy::Proxy>& proxy = std::nullopt);
 
   // The destructor closes the connection.
   ~HttpClientImpl();
@@ -71,6 +82,11 @@ class HttpClientImpl {
   // `cppcoro::generator<ql::span<std::byte>>`. The connection can be used
   // for only one request, as the client is moved to the content yielding
   // coroutine.
+  //
+  // Note that `host` only determines the `Host` header; where the request
+  // actually goes was already decided by the constructor. With a proxy, `Host`
+  // hence still names the target server, and `target` has to be in absolute
+  // form, see there.
   static HttpOrHttpsResponse sendRequest(
       std::unique_ptr<HttpClientImpl> client,
       const boost::beast::http::verb& method, std::string_view host,
@@ -94,6 +110,12 @@ class HttpClientImpl {
       workGuard_ = boost::asio::make_work_guard(ioContext_);
   std::unique_ptr<boost::asio::ssl::context> ssl_context_;
   std::unique_ptr<StreamType> stream_;
+  // The value for the `Proxy-Authorization` header of relayed plain HTTP
+  // requests (empty if there is no proxy or it needs no authentication). Only
+  // used for plain HTTP: for HTTPS, the credentials are sent on the `CONNECT`
+  // request instead, and must not appear inside the TLS session, where the
+  // target server would see them.
+  std::string proxyAuthorization_;
 };
 
 // Instantiation for HTTP.
@@ -117,7 +139,8 @@ using SendRequestType = std::function<HttpOrHttpsResponse(
 // The protocol (HTTP or HTTPS) is chosen automatically based on the URL. The
 // `requestBody` is the payload sent for POST requests (default: empty). If
 // `maxRedirects` is greater than 0, the function will automatically follow
-// redirects (301, 302, 307, 308) up to the specified limit.
+// redirects (301, 302, 307, 308) up to the specified limit. All requests are
+// routed through the proxy configured for this process, see `globalProxy()`.
 HttpOrHttpsResponse sendHttpOrHttpsRequest(
     const ad_utility::httpUtils::Url& url,
     ad_utility::SharedCancellationHandle handle,
@@ -125,6 +148,19 @@ HttpOrHttpsResponse sendHttpOrHttpsRequest(
     std::string_view postData = "",
     std::string_view contentTypeHeader = "text/plain",
     std::string_view acceptHeader = "text/plain", size_t maxRedirects = 0);
+
+// Same as above, but route the requests through `proxy` (or directly, if it is
+// `std::nullopt`) instead of through the proxy configured for this process.
+// Mostly useful for tests, as the latter is read from the environment only once
+// per process. Note that this deliberately is not an overload of the above,
+// which could then no longer be converted to a `SendRequestType`.
+HttpOrHttpsResponse sendHttpOrHttpsRequestWithProxy(
+    const ad_utility::httpUtils::Url& url,
+    ad_utility::SharedCancellationHandle handle,
+    const boost::beast::http::verb& method, std::string_view postData,
+    std::string_view contentTypeHeader, std::string_view acceptHeader,
+    size_t maxRedirects,
+    const std::optional<ad_utility::httpProxy::Proxy>& proxy);
 
 #endif
 #endif  // QLEVER_SRC_UTIL_HTTP_HTTPCLIENT_H

--- a/src/util/http/HttpProxyConfig.cpp
+++ b/src/util/http/HttpProxyConfig.cpp
@@ -1,0 +1,167 @@
+//  Copyright 2026 The QLever Authors, in particular:
+//
+//  2026 Robin Textor-Falconi <textorr@informatik.uni-freiburg.de>, UFR
+//
+//  UFR = University of Freiburg, Chair of Algorithms and Data Structures
+
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
+#include "util/http/HttpProxyConfig.h"
+
+#include <absl/strings/ascii.h>
+#include <absl/strings/escaping.h>
+#include <absl/strings/match.h>
+#include <absl/strings/str_cat.h>
+
+#include <boost/url/parse.hpp>
+#include <boost/url/url_view.hpp>
+#include <cstdlib>
+#include <stdexcept>
+
+#include "util/Exception.h"
+
+namespace ad_utility::httpProxy {
+
+namespace {
+// Replace the userinfo part of `url` (anything between the scheme and an `@`)
+// by `<credentials>`, for use in error messages: the URL may contain a proxy
+// password, and the error messages end up in the server log. The heuristic is
+// deliberately conservative: everything up to the last `@` is treated as
+// userinfo, so a password is redacted even when the URL is too malformed to
+// parse.
+std::string redactCredentials(std::string_view url) {
+  size_t atPosition = url.rfind('@');
+  if (atPosition == std::string_view::npos) {
+    return std::string{url};
+  }
+  size_t schemeEnd = url.find("://");
+  size_t userinfoStart =
+      schemeEnd == std::string_view::npos ? 0 : schemeEnd + 3;
+  if (atPosition < userinfoStart) {
+    return std::string{url};
+  }
+  return absl::StrCat(url.substr(0, userinfoStart), "<credentials>",
+                      url.substr(atPosition));
+}
+}  // namespace
+
+// ____________________________________________________________________________
+std::string Proxy::asStringForLogging() const {
+  return absl::StrCat(host_, ":", port_,
+                      authorization_.empty() ? "" : " (with authentication)");
+}
+
+// ____________________________________________________________________________
+std::optional<Proxy> parseProxyUrl(std::string_view proxyUrl) {
+  std::string_view trimmed = absl::StripAsciiWhitespace(proxyUrl);
+  if (trimmed.empty()) {
+    return std::nullopt;
+  }
+
+  // Both `host:port` and `http://host:port` are accepted, as with other tools.
+  // Boost.URL requires a scheme, so add the implied one. We must not do this
+  // when a scheme is already present, because we want to report an unsupported
+  // scheme (e.g. `socks5://`) as such.
+  std::string withScheme = absl::StrContains(trimmed, "://")
+                               ? std::string{trimmed}
+                               : absl::StrCat("http://", trimmed);
+  boost::system::result<boost::urls::url_view> parsed =
+      boost::urls::parse_uri(withScheme);
+  if (parsed.has_error()) {
+    throw std::runtime_error(absl::StrCat(
+        "The proxy URL \"", redactCredentials(proxyUrl),
+        "\" could not be parsed: ", parsed.error().message(),
+        ". Expected a URL of the form [http://][user[:password]@]host[:port]"));
+  }
+  const boost::urls::url_view& url = parsed.value();
+
+  if (url.scheme() != "http") {
+    throw std::runtime_error(absl::StrCat(
+        "The proxy URL \"", redactCredentials(proxyUrl),
+        "\" uses the scheme \"", std::string_view{url.scheme()},
+        R"(", but QLever only supports plain HTTP proxies (scheme "http"). )"
+        "Note that a plain HTTP proxy can still relay HTTPS requests; it is "
+        "only the connection to the proxy itself that must not use TLS."));
+  }
+  if (url.host().empty()) {
+    throw std::runtime_error(absl::StrCat("The proxy URL \"",
+                                          redactCredentials(proxyUrl),
+                                          "\" does not specify a host"));
+  }
+  // A proxy URL is an authority, not a resource; a path, query or fragment
+  // would silently be ignored, so reject it instead of pretending to honor it.
+  if (!url.path().empty() && url.path() != "/") {
+    throw std::runtime_error(
+        absl::StrCat("The proxy URL \"", redactCredentials(proxyUrl),
+                     "\" must not have a path, but has \"", url.path(), "\""));
+  }
+  if (url.has_query() || url.has_fragment()) {
+    throw std::runtime_error(
+        absl::StrCat("The proxy URL \"", redactCredentials(proxyUrl),
+                     "\" must not have a query or fragment"));
+  }
+
+  Proxy proxy;
+  proxy.host_ = url.host();
+  proxy.port_ = url.has_port() ? url.port() : "80";
+  if (url.has_userinfo()) {
+    proxy.authorization_ = absl::StrCat(
+        "Basic ",
+        absl::Base64Escape(absl::StrCat(url.user(), ":", url.password())));
+  }
+  return proxy;
+}
+
+// ____________________________________________________________________________
+std::string absoluteFormTarget(std::string_view host, std::string_view port,
+                               std::string_view target) {
+  AD_CONTRACT_CHECK(absl::StartsWith(target, "/"),
+                    "The request target must be in origin form");
+  std::string portSuffix = port == "80" ? "" : absl::StrCat(":", port);
+  return absl::StrCat("http://", host, portSuffix, target);
+}
+
+// ____________________________________________________________________________
+std::optional<Proxy> proxyFromEnvironment() {
+  const char* value = std::getenv("http_proxy");
+  // Note that `parseProxyUrl` maps the empty string to "no proxy", so a
+  // variable that is set but empty needs no special handling here.
+  return parseProxyUrl(value == nullptr ? "" : value);
+}
+
+// ____________________________________________________________________________
+bool uppercaseHttpProxyIsSetButIgnored() {
+  auto isSetAndNonEmpty = [](const char* name) {
+    const char* value = std::getenv(name);
+    return value != nullptr && !std::string_view{value}.empty();
+  };
+  return isSetAndNonEmpty("HTTP_PROXY") && !isSetAndNonEmpty("http_proxy");
+}
+
+namespace {
+// The proxy for this process. A function-local `static`, so that the
+// environment is read on first use, in a thread-safe way and without any
+// explicit synchronization. If the read throws, the initialization is not
+// complete, so it is simply retried on the next call. The mutable reference is
+// only needed by `resetGlobalProxyForTesting` below; `globalProxy()` adds the
+// constness back.
+std::optional<Proxy>& globalProxyMutableOnlyForTesting() {
+  static std::optional<Proxy> proxy = proxyFromEnvironment();
+  return proxy;
+}
+}  // namespace
+
+// ____________________________________________________________________________
+const std::optional<Proxy>& globalProxy() {
+  return globalProxyMutableOnlyForTesting();
+}
+
+// ____________________________________________________________________________
+void resetGlobalProxyForTesting() {
+  globalProxyMutableOnlyForTesting() = proxyFromEnvironment();
+}
+
+}  // namespace ad_utility::httpProxy
+#endif

--- a/src/util/http/HttpProxyConfig.h
+++ b/src/util/http/HttpProxyConfig.h
@@ -1,0 +1,107 @@
+//  Copyright 2026 The QLever Authors, in particular:
+//
+//  2026 Robin Textor-Falconi <textorr@informatik.uni-freiburg.de>, UFR
+//
+//  UFR = University of Freiburg, Chair of Algorithms and Data Structures
+
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
+#ifndef QLEVER_SRC_UTIL_HTTP_HTTPPROXYCONFIG_H
+#define QLEVER_SRC_UTIL_HTTP_HTTPPROXYCONFIG_H
+
+#include <optional>
+#include <string>
+#include <string_view>
+
+#include "backports/three_way_comparison.h"
+
+// Support for routing QLever's outgoing HTTP requests (`SERVICE` and `LOAD`)
+// through an HTTP proxy, configured via the `http_proxy` environment variable.
+// If a proxy is configured, then *all* outgoing requests go through it, no
+// matter whether they use HTTP or HTTPS, and no matter which host they address.
+// In particular, the other variables that some tools understand (`HTTP_PROXY`,
+// `https_proxy`, `all_proxy`, `no_proxy`) are deliberately not supported.
+namespace ad_utility::httpProxy {
+
+// An HTTP proxy to route outgoing requests through.
+struct Proxy {
+  // Host and port of the proxy itself (not of the request's target).
+  std::string host_;
+  std::string port_;
+  // The value for the `Proxy-Authorization` header, or empty if the proxy
+  // requires no authentication.
+  std::string authorization_;
+
+  // A human-readable description for the startup log. Deliberately does not
+  // contain the credentials encoded in `authorization_`.
+  std::string asStringForLogging() const;
+
+  QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(Proxy, host_, port_,
+                                              authorization_)
+};
+
+// Parse a proxy URL of the form `[http://][user[:password]@]host[:port]`. The
+// port defaults to 80 (unlike `curl`, which defaults to 1080; QLever only
+// supports HTTP proxies, for which 80 is the natural default). Percent-encoded
+// credentials are decoded, and turned into `Proxy::authorization_` as a `Basic`
+// credential.
+//
+// Returns `std::nullopt` if `proxyUrl` is empty or consists only of
+// whitespace, which is the conventional way of saying "use no proxy".
+//
+// Throws `std::runtime_error` if the URL is malformed, has no host, or names a
+// scheme other than `http`. In particular, `https://` (TLS to the proxy
+// itself) and `socks5://` are rejected explicitly, rather than silently
+// treated as a plain HTTP proxy.
+std::optional<Proxy> parseProxyUrl(std::string_view proxyUrl);
+
+// The request target for a plain HTTP request that is relayed by a proxy: the
+// proxy needs to know where to relay the request to, so the target has to be
+// given in absolute form (`http://host:port/path`) instead of in the usual
+// origin form (`/path`), see RFC 9112, 3.2.2. The default port 80 is omitted,
+// as `curl` does, so that no proxy can trip over a redundant `:80`. The
+// `target` must be in origin form, that is, start with a `/` (as
+// `Url::target()` does).
+//
+// Note that this is only needed for plain HTTP. An HTTPS connection is tunneled
+// through the proxy via the `CONNECT` method, so the proxy never sees the
+// request itself and the target stays in origin form.
+std::string absoluteFormTarget(std::string_view host, std::string_view port,
+                               std::string_view target);
+
+// Read the proxy from the `http_proxy` environment variable, or return
+// `std::nullopt` if it is unset or empty (setting it to the empty string is the
+// conventional way of undoing a setting inherited from a parent process).
+// Throws if the variable holds a malformed proxy URL, see `parseProxyUrl`.
+// Exposed mostly for testing; production code should use `globalProxy()` below.
+std::optional<Proxy> proxyFromEnvironment();
+
+// True if the uppercase `HTTP_PROXY` is set in the environment, but the
+// lowercase `http_proxy` is not, so that no proxy is configured at all.
+// Callers can use this to log a hint, so that the deliberate ignoring of the
+// uppercase variable (see the file comment above) does not confuse users.
+bool uppercaseHttpProxyIsSetButIgnored();
+
+// The proxy for this process, read from the environment on first use. Throws if
+// the environment holds a malformed proxy URL; `qlever-server` calls this early
+// during startup so that such a misconfiguration is reported before the index
+// is loaded, rather than on the first federated query.
+//
+// The returned reference stays valid for the rest of the process (but the value
+// it refers to changes if `resetGlobalProxyForTesting` below is called).
+const std::optional<Proxy>& globalProxy();
+
+// Read the environment again and replace the value cached by `globalProxy()`
+// with the result. Only for tests: a test that wants to observe the caching
+// behavior cannot know whether some other test in the same binary has already
+// called `globalProxy()` (all unit tests are linked into a single binary in
+// some configurations). Throws if the environment holds a malformed proxy URL,
+// see `parseProxyUrl`. Must not be called concurrently with `globalProxy()`.
+void resetGlobalProxyForTesting();
+
+}  // namespace ad_utility::httpProxy
+
+#endif  // QLEVER_SRC_UTIL_HTTP_HTTPPROXYCONFIG_H
+#endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -375,6 +375,8 @@ if (NOT _DISABLE_EMSCRIPTEN_PROBLEMATIC_TESTS)
     addLinkAndDiscoverTest(HttpTest Boost::iostreams http)
 endif ()
 
+addLinkAndDiscoverTest(HttpProxyConfigTest http)
+
 addLinkAndDiscoverTestNoLibs(CallFixedSizeTest)
 
 addLinkAndDiscoverTestNoLibs(ConstexprUtilsTest)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -196,6 +196,8 @@ addLinkAndDiscoverTestNoLibs(SortedSequenceTest)
 
 addLinkAndDiscoverTest(RebuildIndexStrategyTest qlever_util)
 
+addLinkAndDiscoverTest(KeepPreviousIndexDirsTest qlever)
+
 addLinkAndDiscoverTest(DeltaTriplesTest index)
 
 addLinkAndDiscoverTest(UpdateMetadataTest index)

--- a/test/HttpProxyConfigTest.cpp
+++ b/test/HttpProxyConfigTest.cpp
@@ -1,0 +1,251 @@
+//  Copyright 2026 The QLever Authors, in particular:
+//
+//  2026 Robin Textor-Falconi <textorr@informatik.uni-freiburg.de>, UFR
+//
+//  UFR = University of Freiburg, Chair of Algorithms and Data Structures
+
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#include <absl/strings/escaping.h>
+#include <absl/strings/str_cat.h>
+#include <gmock/gmock.h>
+
+#include <array>
+#include <cstdlib>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "util/GTestHelpers.h"
+#include "util/http/HttpProxyConfig.h"
+
+using namespace ad_utility::httpProxy;
+using ::testing::HasSubstr;
+using ::testing::Optional;
+
+namespace {
+// Matcher for a `Proxy` with the given host and port and no authentication.
+auto isProxy(std::string_view host, std::string_view port) {
+  return Optional(Proxy{std::string{host}, std::string{port}, ""});
+}
+}  // namespace
+
+// A fixture that clears the proxy-related environment variables, so that the
+// tests are independent of the environment they happen to run in, and restores
+// them afterwards. Note that `HTTP_PROXY` is cleared as well, although it is
+// never read, so that `uppercaseHttpProxyIsIgnored` also holds when it happens
+// to be set in the environment.
+//
+// The cache of `globalProxy()` is reset as well, both before and after each
+// test. Before, because in the configuration where all unit tests are linked
+// into a single binary, an unrelated test that sends an HTTP request may
+// already have called `globalProxy()` and thus fixed its value. After, so that
+// this fixture leaves no trace beyond the restored environment.
+class ProxyEnvironmentTest : public ::testing::Test {
+ private:
+  static constexpr std::array variableNames_{"http_proxy", "HTTP_PROXY"};
+  std::vector<std::pair<std::string, std::string>> savedValues_;
+
+ protected:
+  void SetUp() override {
+    for (const char* name : variableNames_) {
+      if (const char* value = std::getenv(name); value != nullptr) {
+        savedValues_.emplace_back(name, value);
+      }
+      ASSERT_EQ(::unsetenv(name), 0);
+    }
+    resetGlobalProxyForTesting();
+  }
+
+  void TearDown() override {
+    for (const char* name : variableNames_) {
+      ::unsetenv(name);
+    }
+    for (const auto& [name, value] : savedValues_) {
+      ::setenv(name.c_str(), value.c_str(), 1);
+    }
+    resetGlobalProxyForTesting();
+  }
+
+  static void setEnv(const char* name, const char* value) {
+    ASSERT_EQ(::setenv(name, value, 1), 0);
+  }
+};
+
+// _____________________________________________________________________________
+TEST(ParseProxyUrl, emptyValueMeansNoProxy) {
+  EXPECT_EQ(parseProxyUrl(""), std::nullopt);
+  EXPECT_EQ(parseProxyUrl("   "), std::nullopt);
+  EXPECT_EQ(parseProxyUrl("\t\n"), std::nullopt);
+}
+
+// _____________________________________________________________________________
+TEST(ParseProxyUrl, hostAndPort) {
+  EXPECT_THAT(parseProxyUrl("http://proxy.example.org:3128"),
+              isProxy("proxy.example.org", "3128"));
+  // The scheme may be omitted.
+  EXPECT_THAT(parseProxyUrl("proxy.example.org:3128"),
+              isProxy("proxy.example.org", "3128"));
+  // Surrounding whitespace is ignored.
+  EXPECT_THAT(parseProxyUrl("  http://proxy.example.org:3128  "),
+              isProxy("proxy.example.org", "3128"));
+  // A trailing slash is a valid empty path.
+  EXPECT_THAT(parseProxyUrl("http://proxy.example.org:3128/"),
+              isProxy("proxy.example.org", "3128"));
+  // An IP address works as well.
+  EXPECT_THAT(parseProxyUrl("10.0.0.1:8080"), isProxy("10.0.0.1", "8080"));
+}
+
+// _____________________________________________________________________________
+TEST(ParseProxyUrl, portDefaultsTo80) {
+  EXPECT_THAT(parseProxyUrl("http://proxy.example.org"),
+              isProxy("proxy.example.org", "80"));
+  EXPECT_THAT(parseProxyUrl("proxy.example.org"),
+              isProxy("proxy.example.org", "80"));
+}
+
+// _____________________________________________________________________________
+TEST(ParseProxyUrl, credentialsBecomeBasicAuthorization) {
+  auto proxy = parseProxyUrl("http://user:password@proxy.example.org:3128");
+  ASSERT_TRUE(proxy.has_value());
+  EXPECT_EQ(proxy->host_, "proxy.example.org");
+  EXPECT_EQ(proxy->port_, "3128");
+  EXPECT_EQ(proxy->authorization_,
+            absl::StrCat("Basic ", absl::Base64Escape("user:password")));
+
+  // A user without a password is allowed, and yields an empty password.
+  auto userOnly = parseProxyUrl("http://user@proxy.example.org:3128");
+  ASSERT_TRUE(userOnly.has_value());
+  EXPECT_EQ(userOnly->authorization_,
+            absl::StrCat("Basic ", absl::Base64Escape("user:")));
+
+  // Percent-encoded credentials are decoded, so that a password containing
+  // special characters (like `@` or `:`) can be expressed.
+  auto encoded = parseProxyUrl("http://user%40realm:p%3Ass@proxy:3128");
+  ASSERT_TRUE(encoded.has_value());
+  EXPECT_EQ(encoded->authorization_,
+            absl::StrCat("Basic ", absl::Base64Escape("user@realm:p:ss")));
+}
+
+// _____________________________________________________________________________
+TEST(ParseProxyUrl, malformedUrlsAreRejected) {
+  AD_EXPECT_THROW_WITH_MESSAGE(parseProxyUrl("https://proxy:3128"),
+                               HasSubstr("only supports plain HTTP proxies"));
+  AD_EXPECT_THROW_WITH_MESSAGE(parseProxyUrl("socks5://proxy:1080"),
+                               HasSubstr("only supports plain HTTP proxies"));
+  AD_EXPECT_THROW_WITH_MESSAGE(parseProxyUrl("http://proxy:3128/some/path"),
+                               HasSubstr("must not have a path"));
+  AD_EXPECT_THROW_WITH_MESSAGE(parseProxyUrl("http://proxy:3128?a=b"),
+                               HasSubstr("must not have a query or fragment"));
+  AD_EXPECT_THROW_WITH_MESSAGE(parseProxyUrl("http://proxy:3128#frag"),
+                               HasSubstr("must not have a query or fragment"));
+  AD_EXPECT_THROW_WITH_MESSAGE(parseProxyUrl("http://"),
+                               HasSubstr("does not specify a host"));
+  AD_EXPECT_THROW_WITH_MESSAGE(parseProxyUrl("http://proxy:not-a-port"),
+                               HasSubstr("could not be parsed"));
+}
+
+// _____________________________________________________________________________
+TEST(ParseProxyUrl, errorMessagesRedactCredentials) {
+  // The error messages end up in the server log, so they must not contain the
+  // proxy password, no matter which check the URL fails.
+  using ::testing::AllOf;
+  using ::testing::Not;
+  auto redacted = AllOf(HasSubstr("<credentials>"), Not(HasSubstr("secret")));
+  AD_EXPECT_THROW_WITH_MESSAGE(parseProxyUrl("socks5://user:secret@proxy:1080"),
+                               redacted);
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      parseProxyUrl("http://user:secret@proxy:3128/some/path"), redacted);
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      parseProxyUrl("http://user:secret@proxy:not-a-port"), redacted);
+}
+
+// _____________________________________________________________________________
+TEST(Proxy, asStringForLoggingHidesCredentials) {
+  EXPECT_EQ(parseProxyUrl("http://proxy:3128")->asStringForLogging(),
+            "proxy:3128");
+  // The default port is spelled out, so that the log is unambiguous.
+  EXPECT_EQ(parseProxyUrl("proxy")->asStringForLogging(), "proxy:80");
+
+  std::string withAuth =
+      parseProxyUrl("http://user:secret@proxy:3128")->asStringForLogging();
+  EXPECT_THAT(withAuth, HasSubstr("proxy:3128"));
+  EXPECT_THAT(withAuth, HasSubstr("(with authentication)"));
+  // Neither the password nor its encoding may appear in the log.
+  EXPECT_THAT(withAuth, ::testing::Not(HasSubstr("secret")));
+  EXPECT_THAT(withAuth,
+              ::testing::Not(HasSubstr(absl::Base64Escape("user:secret"))));
+}
+
+// _____________________________________________________________________________
+TEST(AbsoluteFormTarget, portIsOmittedOnlyForTheDefault) {
+  EXPECT_EQ(absoluteFormTarget("example.org", "8080", "/sparql?query=X"),
+            "http://example.org:8080/sparql?query=X");
+  EXPECT_EQ(absoluteFormTarget("example.org", "80", "/sparql"),
+            "http://example.org/sparql");
+  // The target must be in origin form.
+  EXPECT_ANY_THROW(absoluteFormTarget("example.org", "80", "sparql"));
+}
+
+// _____________________________________________________________________________
+TEST_F(ProxyEnvironmentTest, unsetOrEmptyMeansNoProxy) {
+  EXPECT_EQ(proxyFromEnvironment(), std::nullopt);
+  // Setting the variable to the empty string is the conventional way of undoing
+  // a proxy setting inherited from a parent process.
+  setEnv("http_proxy", "");
+  EXPECT_EQ(proxyFromEnvironment(), std::nullopt);
+}
+
+// _____________________________________________________________________________
+TEST_F(ProxyEnvironmentTest, proxyIsReadFromHttpProxy) {
+  setEnv("http_proxy", "http://proxy:3128");
+  EXPECT_THAT(proxyFromEnvironment(), isProxy("proxy", "3128"));
+}
+
+// _____________________________________________________________________________
+TEST_F(ProxyEnvironmentTest, uppercaseHttpProxyIsIgnored) {
+  // `HTTP_PROXY` is deliberately not honored, following `curl`: in a CGI
+  // environment it would be settable by a remote client via the `Proxy:`
+  // request header.
+  setEnv("HTTP_PROXY", "http://should-be-ignored:3128");
+  EXPECT_EQ(proxyFromEnvironment(), std::nullopt);
+}
+
+// _____________________________________________________________________________
+TEST_F(ProxyEnvironmentTest, uppercaseHttpProxyHintFiresOnlyWhenIgnored) {
+  EXPECT_FALSE(uppercaseHttpProxyIsSetButIgnored());
+  setEnv("HTTP_PROXY", "http://proxy:3128");
+  EXPECT_TRUE(uppercaseHttpProxyIsSetButIgnored());
+  // As soon as the lowercase variable configures a proxy, the hint would only
+  // be noise.
+  setEnv("http_proxy", "http://proxy:3128");
+  EXPECT_FALSE(uppercaseHttpProxyIsSetButIgnored());
+}
+
+// _____________________________________________________________________________
+TEST_F(ProxyEnvironmentTest, malformedEnvironmentValueThrows) {
+  setEnv("http_proxy", "socks5://proxy:1080");
+  AD_EXPECT_THROW_WITH_MESSAGE(proxyFromEnvironment(),
+                               HasSubstr("only supports plain HTTP proxies"));
+}
+
+// _____________________________________________________________________________
+TEST_F(ProxyEnvironmentTest, globalProxyReadsTheEnvironmentOnFirstUse) {
+  // The fixture has cleared the environment, so there is no proxy. This also
+  // shows that the fixture's reset works: no value cached by an earlier test
+  // (in this file or elsewhere in the same binary) leaks into this one.
+  EXPECT_EQ(globalProxy(), std::nullopt);
+  // Setting the variable now has no effect anymore, the value is already read.
+  setEnv("http_proxy", "http://proxy:3128");
+  EXPECT_EQ(globalProxy(), std::nullopt);
+
+  resetGlobalProxyForTesting();
+  EXPECT_THAT(globalProxy(), isProxy("proxy", "3128"));
+  // Again, a later change of the environment has no effect, although the
+  // environment itself of course reflects it.
+  setEnv("http_proxy", "http://other-proxy:3129");
+  EXPECT_THAT(globalProxy(), isProxy("proxy", "3128"));
+  EXPECT_THAT(proxyFromEnvironment(), isProxy("other-proxy", "3129"));
+}

--- a/test/HttpTest.cpp
+++ b/test/HttpTest.cpp
@@ -2,6 +2,7 @@
 // Chair of Algorithms and Data Structures.
 // Author: Hannah Bast (bast@cs.uni-freiburg.de)
 
+#include <absl/strings/escaping.h>
 #include <absl/strings/str_cat.h>
 #include <gmock/gmock.h>
 
@@ -727,4 +728,198 @@ TYPED_TEST(HttpServerBodyTest, MaterializeBody) {
           EXPECT_EQ(result, expected);
         }));
   }
+}
+
+// _____________________________________________________________________________
+// Tests for routing requests through an HTTP proxy, see `HttpProxyConfig.h`.
+namespace {
+using ad_utility::httpProxy::Proxy;
+
+// An echo handler that reports the request target, the `Host` header, and the
+// `Proxy-Authorization` header, which is what a proxy sees when it relays a
+// plain HTTP request.
+auto makeProxyEchoServer() {
+  auto handler = [](auto req, auto&& send,
+                    auto...) -> boost::asio::awaitable<void> {
+    co_await send(createOkResponse(
+        absl::StrCat(toStd(req.target()), "\n", toStd(req[field::host]), "\n",
+                     toStd(req[field::proxy_authorization])),
+        req, ad_utility::MediaType::textPlain));
+  };
+  return TestHttpServer{std::move(handler)};
+}
+
+// A minimal fake proxy that accepts a single connection, reads one `CONNECT`
+// request from it, remembers the relevant parts of that request, and replies
+// with `response` (which must be a complete HTTP response). It never speaks
+// TLS, so a client that proceeds to the TLS handshake after a successful
+// `CONNECT` will fail there; that is intentional, and lets us verify the
+// tunnel setup itself without a TLS server.
+class FakeConnectProxy {
+ private:
+  net::io_context ioContext_;
+  tcp::acceptor acceptor_{ioContext_, tcp::endpoint{tcp::v4(), 0}};
+  std::string response_;
+  std::string request_;
+  ad_utility::JThread thread_;
+
+ public:
+  explicit FakeConnectProxy(std::string response)
+      : response_{std::move(response)}, thread_{[this]() { runOnce(); }} {}
+
+  unsigned short getPort() const { return acceptor_.local_endpoint().port(); }
+
+  // The method, target, `Host` and `Proxy-Authorization` of the `CONNECT`
+  // request that the client sent. Only valid once the connection has been
+  // handled, so call `join()` first.
+  const std::string& getRequest() const { return request_; }
+
+  void join() {
+    if (thread_.joinable()) {
+      thread_.join();
+    }
+  }
+
+  ~FakeConnectProxy() { join(); }
+
+ private:
+  void runOnce() {
+    boost::system::error_code ec;
+    tcp::socket socket{ioContext_};
+    acceptor_.accept(socket, ec);
+    if (ec) {
+      return;
+    }
+    // Read until the end of the request header. `CONNECT` has no body.
+    beast::flat_buffer buffer;
+    http::request_parser<http::empty_body> parser;
+    parser.skip(true);
+    http::read_header(socket, buffer, parser, ec);
+    if (ec) {
+      return;
+    }
+    request_ = absl::StrCat(toStd(to_string(parser.get().method())), " ",
+                            toStd(parser.get().target()),
+                            "\nhost: ", toStd(parser.get()[field::host]),
+                            "\nproxy-authorization: ",
+                            toStd(parser.get()[field::proxy_authorization]));
+    net::write(socket, net::buffer(response_), ec);
+    // Keep the socket open briefly so the client can attempt its handshake and
+    // observe a TLS error rather than a premature EOF on the read above.
+    socket.shutdown(tcp::socket::shutdown_send, ec);
+  }
+};
+}  // namespace
+
+// A plain HTTP request that is relayed by a proxy connects to the proxy instead
+// of to the target host, and names its target in absolute form while keeping
+// `Host` pointed at the target server.
+TEST(HttpProxy, plainHttpRequestIsRelayedByTheProxy) {
+  auto proxyServer = makeProxyEchoServer();
+  proxyServer.runInOwnThread();
+  auto handle = std::make_shared<ad_utility::CancellationHandle<>>();
+
+  Proxy proxy{"localhost", std::to_string(proxyServer.getPort()), ""};
+  // Note that the target host `example.org` is never contacted; the connection
+  // goes to the proxy, which is our echo server here.
+  auto response = sendHttpOrHttpsRequestWithProxy(
+      Url{"http://example.org:8080/sparql?query=X"}, handle, verb::get, "",
+      "text/plain", "text/plain", 0, proxy);
+  EXPECT_EQ(response.status_, status::ok);
+  EXPECT_EQ(toString(std::move(response.body_)),
+            "http://example.org:8080/sparql?query=X\nexample.org\n");
+}
+
+// Credentials in the proxy configuration are sent as a `Proxy-Authorization`
+// header on every relayed plain HTTP request; the proxy consumes this header
+// and does not forward it (RFC 9110, 11.7.2).
+TEST(HttpProxy, plainHttpRequestSendsProxyAuthorization) {
+  auto proxyServer = makeProxyEchoServer();
+  proxyServer.runInOwnThread();
+  auto handle = std::make_shared<ad_utility::CancellationHandle<>>();
+
+  std::string authorization =
+      absl::StrCat("Basic ", absl::Base64Escape("user:password"));
+  Proxy proxy{"localhost", std::to_string(proxyServer.getPort()),
+              authorization};
+  auto response = sendHttpOrHttpsRequestWithProxy(
+      Url{"http://example.org:8080/sparql"}, handle, verb::get, "",
+      "text/plain", "text/plain", 0, proxy);
+  EXPECT_EQ(response.status_, status::ok);
+  EXPECT_EQ(toString(std::move(response.body_)),
+            absl::StrCat("http://example.org:8080/sparql\nexample.org\n",
+                         authorization));
+}
+
+// For HTTPS, the client first asks the proxy for a tunnel via `CONNECT`. Check
+// that the `CONNECT` request is well-formed (authority-form target with an
+// explicit port, matching `Host`) and that the client proceeds to the TLS
+// handshake after a `200`. The handshake then fails because our fake proxy
+// does not speak TLS, which is exactly how we know we got that far.
+TEST(HttpProxy, httpsRequestEstablishesConnectTunnel) {
+  FakeConnectProxy fakeProxy{"HTTP/1.1 200 Connection established\r\n\r\n"};
+  Proxy proxy{"localhost", std::to_string(fakeProxy.getPort()), ""};
+
+  // The TLS handshake with a non-TLS peer fails, but it must fail *in the
+  // handshake*, not in the tunnel setup: the `200` has to be accepted.
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      HttpsClient("example.org", "443", proxy),
+      ::testing::Not(HasSubstr("refused to open a tunnel")));
+  fakeProxy.join();
+  EXPECT_EQ(fakeProxy.getRequest(),
+            "CONNECT example.org:443\nhost: example.org:443\n"
+            "proxy-authorization: ");
+}
+
+// Credentials in the proxy URL are sent as a `Proxy-Authorization` header on
+// the `CONNECT` request.
+TEST(HttpProxy, connectTunnelSendsProxyAuthorization) {
+  FakeConnectProxy fakeProxy{"HTTP/1.1 200 Connection established\r\n\r\n"};
+  auto proxyWithAuth = ad_utility::httpProxy::parseProxyUrl(
+      absl::StrCat("http://user:password@localhost:", fakeProxy.getPort()));
+  ASSERT_TRUE(proxyWithAuth.has_value());
+
+  EXPECT_ANY_THROW(HttpsClient("example.org", "443", proxyWithAuth.value()));
+  fakeProxy.join();
+  EXPECT_THAT(fakeProxy.getRequest(),
+              HasSubstr(absl::StrCat("proxy-authorization: Basic ",
+                                     absl::Base64Escape("user:password"))));
+}
+
+// If the proxy refuses the tunnel, the error message names the proxy, the
+// target and the status the proxy returned.
+TEST(HttpProxy, connectTunnelRefusedByProxy) {
+  FakeConnectProxy fakeProxy{
+      "HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\n\r\n"};
+  Proxy proxy{"localhost", std::to_string(fakeProxy.getPort()), ""};
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      HttpsClient("example.org", "443", proxy),
+      ::testing::AllOf(HasSubstr("refused to open a tunnel"),
+                       HasSubstr("example.org:443"), HasSubstr("403"),
+                       HasSubstr("Forbidden")));
+}
+
+// A `407` from the proxy additionally hints at how to supply credentials.
+TEST(HttpProxy, connectTunnelRequiresAuthentication) {
+  FakeConnectProxy fakeProxy{
+      "HTTP/1.1 407 Proxy Authentication Required\r\nContent-Length: "
+      "0\r\n\r\n"};
+  Proxy proxy{"localhost", std::to_string(fakeProxy.getPort()), ""};
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      HttpsClient("example.org", "443", proxy),
+      ::testing::AllOf(HasSubstr("407"),
+                       HasSubstr("user:password@proxy:3128")));
+}
+
+// Bytes that follow the response to the `CONNECT` request immediately would
+// already belong to the tunneled TLS session, which we cannot forward into the
+// TLS stream, so this is rejected instead of silently corrupting the handshake.
+TEST(HttpProxy, connectTunnelWithUnexpectedTrailingBytes) {
+  FakeConnectProxy fakeProxy{
+      "HTTP/1.1 200 Connection established\r\n\r\nsurprise"};
+  Proxy proxy{"localhost", std::to_string(fakeProxy.getPort()), ""};
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      HttpsClient("example.org", "443", proxy),
+      ::testing::AllOf(HasSubstr("sent 8 unexpected byte(s)"),
+                       HasSubstr("cannot forward into the TLS session")));
 }

--- a/test/KeepPreviousIndexDirsTest.cpp
+++ b/test/KeepPreviousIndexDirsTest.cpp
@@ -12,9 +12,11 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <chrono>
 #include <fstream>
 #include <iterator>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 #include "backports/filesystem.h"
@@ -25,28 +27,27 @@
 
 using qlever::keepPreviousIndexDir;
 using qlever::KeepPreviousIndexDirs;
-using qlever::parseKeepPreviousIndexDirs;
-using qlever::toString;
 using ::testing::ElementsAre;
 using ::testing::HasSubstr;
 
 // _____________________________________________________________________________
 TEST(KeepPreviousIndexDirs, parse) {
-  EXPECT_EQ(parseKeepPreviousIndexDirs("all"), KeepPreviousIndexDirs::All);
-  EXPECT_EQ(parseKeepPreviousIndexDirs("none"), KeepPreviousIndexDirs::None);
-  EXPECT_EQ(parseKeepPreviousIndexDirs("original-only"),
-            KeepPreviousIndexDirs::OriginalOnly);
-  EXPECT_EQ(parseKeepPreviousIndexDirs("most-recent-only"),
-            KeepPreviousIndexDirs::MostRecentOnly);
-  EXPECT_EQ(parseKeepPreviousIndexDirs("original-and-most-recent"),
+  auto parse = [](std::string_view value) {
+    return KeepPreviousIndexDirs::fromString(value);
+  };
+  EXPECT_EQ(parse("all"), KeepPreviousIndexDirs::All);
+  EXPECT_EQ(parse("none"), KeepPreviousIndexDirs::None);
+  EXPECT_EQ(parse("original-only"), KeepPreviousIndexDirs::OriginalOnly);
+  EXPECT_EQ(parse("most-recent-only"), KeepPreviousIndexDirs::MostRecentOnly);
+  EXPECT_EQ(parse("original-and-most-recent"),
             KeepPreviousIndexDirs::OriginalAndMostRecent);
 }
 
 // _____________________________________________________________________________
 TEST(KeepPreviousIndexDirs, parseErrors) {
   auto expectThrows = [](std::string_view value) {
-    AD_EXPECT_THROW_WITH_MESSAGE(parseKeepPreviousIndexDirs(value),
-                                 HasSubstr("must be one of"));
+    AD_EXPECT_THROW_WITH_MESSAGE(KeepPreviousIndexDirs::fromString(value),
+                                 HasSubstr("is not a valid"));
   };
   expectThrows("");
   expectThrows("some");
@@ -67,11 +68,12 @@ TEST(KeepPreviousIndexDirs, engineConfigDefault) {
 
 // _____________________________________________________________________________
 TEST(KeepPreviousIndexDirs, toStringIsInverseOfParse) {
-  for (auto policy : {KeepPreviousIndexDirs::All, KeepPreviousIndexDirs::None,
-                      KeepPreviousIndexDirs::OriginalOnly,
-                      KeepPreviousIndexDirs::MostRecentOnly,
-                      KeepPreviousIndexDirs::OriginalAndMostRecent}) {
-    EXPECT_EQ(parseKeepPreviousIndexDirs(toString(policy)), policy);
+  for (KeepPreviousIndexDirs policy :
+       {KeepPreviousIndexDirs::All, KeepPreviousIndexDirs::None,
+        KeepPreviousIndexDirs::OriginalOnly,
+        KeepPreviousIndexDirs::MostRecentOnly,
+        KeepPreviousIndexDirs::OriginalAndMostRecent}) {
+    EXPECT_EQ(KeepPreviousIndexDirs::fromString(policy.toString()), policy);
   }
 }
 
@@ -114,10 +116,14 @@ namespace {
 // Create the directory `testDir` (deleting whatever was there before) with
 // five `previous.*` subdirectories (each containing a dummy index file, one
 // of them also a nested subdirectory), a subdirectory whose name does not
-// start with `previous.`, and a regular file whose name does. The
-// `previous.*` subdirectories are created in lexicographic name order, so
-// this order is also their order from oldest to newest (equal timestamps are
-// broken by name, see `Qlever::cleanUpPreviousIndexDirs`).
+// start with `previous.`, and a regular file whose name does. The `previous.*`
+// subdirectories get explicit last-write times that make `previous.a` the
+// oldest and `previous.e` the newest, with a deliberate timestamp tie between
+// `previous.d` and `previous.e` (which the cleanup breaks by name, see
+// `Qlever::cleanUpPreviousIndexDirs`). The times cannot be left implicit:
+// creating the nested subdirectory below modifies `previous.c`, and on a
+// filesystem with fine-grained timestamps that would make `previous.c` the
+// newest directory (observed on the macOS CI runners).
 void setUpPreviousIndexDirs(const ql::filesystem::path& testDir) {
   namespace fs = ql::filesystem;
   fs::remove_all(testDir);
@@ -131,6 +137,24 @@ void setUpPreviousIndexDirs(const ql::filesystem::path& testDir) {
   fs::create_directory(testDir / "previous.c" / "nested");
   fs::create_directory(testDir / "other.dir");
   std::ofstream{testDir / "previous.file"} << "not a directory";
+  // Derive the timestamps from a real one read back from disk, so that this
+  // works with both `std::filesystem` (`file_time_type`) and the
+  // `boost::filesystem` backport (`std::time_t`).
+  auto newest = fs::last_write_time(testDir / "previous.e");
+  // The generic lambda makes the discarded branch dependent, so that each
+  // build only instantiates the branch that matches its timestamp type.
+  auto minutesEarlier = [](auto timestamp, int minutes) {
+    if constexpr (std::is_integral_v<decltype(timestamp)>) {
+      return timestamp - 60 * minutes;
+    } else {
+      return timestamp - std::chrono::minutes(minutes);
+    }
+  };
+  fs::last_write_time(testDir / "previous.a", minutesEarlier(newest, 4));
+  fs::last_write_time(testDir / "previous.b", minutesEarlier(newest, 3));
+  fs::last_write_time(testDir / "previous.c", minutesEarlier(newest, 2));
+  fs::last_write_time(testDir / "previous.d", minutesEarlier(newest, 1));
+  fs::last_write_time(testDir / "previous.e", minutesEarlier(newest, 1));
 }
 
 // Return the names of the entries of `testDir`, sorted.
@@ -147,7 +171,7 @@ std::vector<std::string> entryNames(const ql::filesystem::path& testDir) {
 // _____________________________________________________________________________
 TEST(KeepPreviousIndexDirs, cleanUpPreviousIndexDirs) {
   namespace fs = ql::filesystem;
-  fs::path testDir = "keepPreviousIndexDirsTest.dir";
+  fs::path testDir = absl::StrCat(gtestCurrentTestName(), ".dir");
   // Remove the test directory also when an assertion or an exception exits
   // this test early.
   absl::Cleanup removeTestDir{[&testDir] { fs::remove_all(testDir); }};

--- a/test/KeepPreviousIndexDirsTest.cpp
+++ b/test/KeepPreviousIndexDirsTest.cpp
@@ -7,6 +7,7 @@
 // You may not use this file except in compliance with the Apache 2.0 License,
 // which can be found in the `LICENSE` file at the root of the QLever project.
 
+#include <absl/cleanup/cleanup.h>
 #include <absl/strings/str_cat.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -147,6 +148,9 @@ std::vector<std::string> entryNames(const ql::filesystem::path& testDir) {
 TEST(KeepPreviousIndexDirs, cleanUpPreviousIndexDirs) {
   namespace fs = ql::filesystem;
   fs::path testDir = "keepPreviousIndexDirsTest.dir";
+  // Remove the test directory also when an assertion or an exception exits
+  // this test early.
+  absl::Cleanup removeTestDir{[&testDir] { fs::remove_all(testDir); }};
   // The base name of the index whose directory is cleaned up. The index files
   // themselves do not have to exist for the cleanup.
   std::string baseName = (testDir / "index").string();
@@ -191,6 +195,4 @@ TEST(KeepPreviousIndexDirs, cleanUpPreviousIndexDirs) {
     EXPECT_THAT(logContent, HasSubstr("previous.d -> DELETE"));
     EXPECT_THAT(logContent, HasSubstr("previous.e -> KEEP"));
   }
-
-  fs::remove_all(testDir);
 }

--- a/test/KeepPreviousIndexDirsTest.cpp
+++ b/test/KeepPreviousIndexDirsTest.cpp
@@ -1,0 +1,175 @@
+//  Copyright 2026 The QLever Authors, in particular:
+//
+//  2026 Hannah Bast <bast@cs.uni-freiburg.de>, UFR
+//
+//  UFR = University of Freiburg, Chair of Algorithms and Data Structures
+
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include "backports/filesystem.h"
+#include "engine/KeepPreviousIndexDirs.h"
+#include "libqlever/Qlever.h"
+#include "util/GTestHelpers.h"
+
+using qlever::keepPreviousIndexDir;
+using qlever::KeepPreviousIndexDirs;
+using qlever::parseKeepPreviousIndexDirs;
+using qlever::toString;
+using ::testing::ElementsAre;
+using ::testing::HasSubstr;
+
+// _____________________________________________________________________________
+TEST(KeepPreviousIndexDirs, parse) {
+  EXPECT_EQ(parseKeepPreviousIndexDirs("all"), KeepPreviousIndexDirs::All);
+  EXPECT_EQ(parseKeepPreviousIndexDirs("none"), KeepPreviousIndexDirs::None);
+  EXPECT_EQ(parseKeepPreviousIndexDirs("original-only"),
+            KeepPreviousIndexDirs::OriginalOnly);
+  EXPECT_EQ(parseKeepPreviousIndexDirs("most-recent-only"),
+            KeepPreviousIndexDirs::MostRecentOnly);
+  EXPECT_EQ(parseKeepPreviousIndexDirs("original-and-most-recent"),
+            KeepPreviousIndexDirs::OriginalAndMostRecent);
+}
+
+// _____________________________________________________________________________
+TEST(KeepPreviousIndexDirs, parseErrors) {
+  auto expectThrows = [](std::string_view value) {
+    AD_EXPECT_THROW_WITH_MESSAGE(parseKeepPreviousIndexDirs(value),
+                                 HasSubstr("must be one of"));
+  };
+  expectThrows("");
+  expectThrows("some");
+  expectThrows("original");
+  expectThrows("most-recent");
+  expectThrows("ALL");
+  expectThrows("original-and-most-recent-only");
+}
+
+// _____________________________________________________________________________
+TEST(KeepPreviousIndexDirs, engineConfigDefault) {
+  // The default of the engine configuration matches the default of the
+  // `--rebuild-keep-previous-index-dirs` option of `qlever-server` and of
+  // the `--keep-previous-index-dirs` option of `qlever rebuild-index`.
+  EXPECT_EQ(qlever::EngineConfig{}.keepPreviousIndexDirs_,
+            KeepPreviousIndexDirs::OriginalAndMostRecent);
+}
+
+// _____________________________________________________________________________
+TEST(KeepPreviousIndexDirs, toStringIsInverseOfParse) {
+  for (auto policy : {KeepPreviousIndexDirs::All, KeepPreviousIndexDirs::None,
+                      KeepPreviousIndexDirs::OriginalOnly,
+                      KeepPreviousIndexDirs::MostRecentOnly,
+                      KeepPreviousIndexDirs::OriginalAndMostRecent}) {
+    EXPECT_EQ(parseKeepPreviousIndexDirs(toString(policy)), policy);
+  }
+}
+
+// _____________________________________________________________________________
+TEST(KeepPreviousIndexDirs, keepPreviousIndexDir) {
+  // The directories are numbered from the oldest (position 0, the original)
+  // to the newest (the most recent). Compute the kept positions for four
+  // directories under the given policy.
+  auto keptOfFour = [](KeepPreviousIndexDirs policy) {
+    std::vector<size_t> result;
+    for (size_t i = 0; i < 4; ++i) {
+      if (keepPreviousIndexDir(policy, i, 4)) {
+        result.push_back(i);
+      }
+    }
+    return result;
+  };
+  EXPECT_THAT(keptOfFour(KeepPreviousIndexDirs::All), ElementsAre(0, 1, 2, 3));
+  EXPECT_THAT(keptOfFour(KeepPreviousIndexDirs::None), ElementsAre());
+  EXPECT_THAT(keptOfFour(KeepPreviousIndexDirs::OriginalOnly), ElementsAre(0));
+  EXPECT_THAT(keptOfFour(KeepPreviousIndexDirs::MostRecentOnly),
+              ElementsAre(3));
+  EXPECT_THAT(keptOfFour(KeepPreviousIndexDirs::OriginalAndMostRecent),
+              ElementsAre(0, 3));
+
+  // With a single directory, the original is also the most recent.
+  EXPECT_TRUE(keepPreviousIndexDir(KeepPreviousIndexDirs::OriginalOnly, 0, 1));
+  EXPECT_TRUE(
+      keepPreviousIndexDir(KeepPreviousIndexDirs::MostRecentOnly, 0, 1));
+  EXPECT_TRUE(
+      keepPreviousIndexDir(KeepPreviousIndexDirs::OriginalAndMostRecent, 0, 1));
+  EXPECT_FALSE(keepPreviousIndexDir(KeepPreviousIndexDirs::None, 0, 1));
+
+  // The position must be smaller than the number of directories.
+  EXPECT_THROW(keepPreviousIndexDir(KeepPreviousIndexDirs::All, 1, 1),
+               ad_utility::Exception);
+}
+
+namespace {
+// Create the directory `testDir` (deleting whatever was there before) with
+// five `previous.*` subdirectories (each containing a dummy index file, one
+// of them also a nested subdirectory), a subdirectory whose name does not
+// start with `previous.`, and a regular file whose name does. The
+// `previous.*` subdirectories are created in lexicographic name order, so
+// this order is also their order from oldest to newest (equal timestamps are
+// broken by name, see `Qlever::cleanUpPreviousIndexDirs`).
+void setUpPreviousIndexDirs(const ql::filesystem::path& testDir) {
+  namespace fs = ql::filesystem;
+  fs::remove_all(testDir);
+  fs::create_directory(testDir);
+  for (std::string_view name :
+       {"previous.a", "previous.b", "previous.c", "previous.d", "previous.e"}) {
+    fs::path dir = testDir / name;
+    fs::create_directory(dir);
+    std::ofstream{dir / "index.meta-data.json"} << "{}";
+  }
+  fs::create_directory(testDir / "previous.c" / "nested");
+  fs::create_directory(testDir / "other.dir");
+  std::ofstream{testDir / "previous.file"} << "not a directory";
+}
+
+// Return the names of the entries of `testDir`, sorted.
+std::vector<std::string> entryNames(const ql::filesystem::path& testDir) {
+  std::vector<std::string> result;
+  for (const auto& entry : ql::filesystem::directory_iterator{testDir}) {
+    result.push_back(entry.path().filename().string());
+  }
+  ql::ranges::sort(result);
+  return result;
+}
+}  // namespace
+
+// _____________________________________________________________________________
+TEST(KeepPreviousIndexDirs, cleanUpPreviousIndexDirs) {
+  namespace fs = ql::filesystem;
+  fs::path testDir = "keepPreviousIndexDirsTest.dir";
+  // The base name of the index whose directory is cleaned up. The index files
+  // themselves do not have to exist for the cleanup.
+  std::string baseName = (testDir / "index").string();
+
+  // Apply the given policy to a freshly set up directory and return the
+  // names of the surviving entries.
+  auto survivors = [&](KeepPreviousIndexDirs policy) {
+    setUpPreviousIndexDirs(testDir);
+    qlever::Qlever::cleanUpPreviousIndexDirs(baseName, policy);
+    return entryNames(testDir);
+  };
+
+  // Entries that are not directories or whose name does not start with
+  // `previous.` are never touched.
+  EXPECT_THAT(survivors(KeepPreviousIndexDirs::All),
+              ElementsAre("other.dir", "previous.a", "previous.b", "previous.c",
+                          "previous.d", "previous.e", "previous.file"));
+  EXPECT_THAT(survivors(KeepPreviousIndexDirs::None),
+              ElementsAre("other.dir", "previous.file"));
+  EXPECT_THAT(survivors(KeepPreviousIndexDirs::OriginalOnly),
+              ElementsAre("other.dir", "previous.a", "previous.file"));
+  EXPECT_THAT(survivors(KeepPreviousIndexDirs::MostRecentOnly),
+              ElementsAre("other.dir", "previous.e", "previous.file"));
+  EXPECT_THAT(
+      survivors(KeepPreviousIndexDirs::OriginalAndMostRecent),
+      ElementsAre("other.dir", "previous.a", "previous.e", "previous.file"));
+
+  fs::remove_all(testDir);
+}

--- a/test/KeepPreviousIndexDirsTest.cpp
+++ b/test/KeepPreviousIndexDirsTest.cpp
@@ -13,6 +13,7 @@
 #include <gtest/gtest.h>
 
 #include <chrono>
+#include <cstdio>
 #include <fstream>
 #include <iterator>
 #include <string>
@@ -219,4 +220,49 @@ TEST(KeepPreviousIndexDirs, cleanUpPreviousIndexDirs) {
     EXPECT_THAT(logContent, HasSubstr("previous.d -> DELETE"));
     EXPECT_THAT(logContent, HasSubstr("previous.e -> KEEP"));
   }
+}
+
+// _____________________________________________________________________________
+TEST(KeepPreviousIndexDirs, cleanUpPreviousIndexDirsFailures) {
+  namespace fs = ql::filesystem;
+  fs::path testDir = absl::StrCat(gtestCurrentTestName(), ".dir");
+
+  // A base name in a directory that does not exist makes the enumeration of
+  // the `previous.*` directories fail. The failure must only be logged (when
+  // the cleanup runs, the rebuild has already succeeded), never thrown.
+  EXPECT_NO_THROW(qlever::Qlever::cleanUpPreviousIndexDirs(
+      (testDir / "doesNotExist" / "index").string(),
+      KeepPreviousIndexDirs::None));
+
+  // A directory that cannot be deleted is logged as an error and kept, and
+  // the cleanup continues with the remaining directories. Removing all
+  // permissions from `previous.b` makes the deletion of the file it contains
+  // (and hence the `remove_all`) fail.
+  auto restorePermissions = [&testDir] {
+    ql::error_code ignored;
+    fs::permissions(testDir / "previous.b", fs::perms::owner_all, ignored);
+  };
+  absl::Cleanup removeTestDir{[&testDir, &restorePermissions] {
+    restorePermissions();
+    fs::remove_all(testDir);
+  }};
+  setUpPreviousIndexDirs(testDir);
+  fs::permissions(testDir / "previous.b", ql::filesystem_perms_none);
+  fs::path fileInB = testDir / "previous.b" / "index.meta-data.json";
+  if (FILE* handle = fopen(fileInB.string().c_str(), "r")) {
+    fclose(handle);
+    // This can happen in docker environments (running as root).
+    GTEST_SKIP_("File permissions are not effective in this environment");
+  }
+  qlever::Qlever::cleanUpPreviousIndexDirs((testDir / "index").string(),
+                                           KeepPreviousIndexDirs::None);
+  restorePermissions();
+
+  std::string logName = absl::StrCat("index", REBUILD_INDEX_LOG_SUFFIX);
+  EXPECT_THAT(entryNames(testDir),
+              ElementsAre(logName, "other.dir", "previous.b", "previous.file"));
+  std::ifstream logStream{(testDir / logName).string()};
+  std::string logContent{std::istreambuf_iterator<char>{logStream}, {}};
+  EXPECT_THAT(logContent, HasSubstr("previous.b -> DELETE"));
+  EXPECT_THAT(logContent, HasSubstr("Failed to delete \"previous.b\""));
 }

--- a/test/KeepPreviousIndexDirsTest.cpp
+++ b/test/KeepPreviousIndexDirsTest.cpp
@@ -238,12 +238,12 @@ TEST(KeepPreviousIndexDirs, cleanUpPreviousIndexDirsFailures) {
   // the cleanup continues with the remaining directories. Removing all
   // permissions from `previous.b` makes the deletion of the file it contains
   // (and hence the `remove_all`) fail.
-  auto restorePermissions = [&testDir] {
+  auto makeDirDeletableAgain = [&testDir] {
     ql::error_code ignored;
     fs::permissions(testDir / "previous.b", fs::perms::owner_all, ignored);
   };
-  absl::Cleanup removeTestDir{[&testDir, &restorePermissions] {
-    restorePermissions();
+  absl::Cleanup removeTestDir{[&testDir, &makeDirDeletableAgain] {
+    makeDirDeletableAgain();
     fs::remove_all(testDir);
   }};
   setUpPreviousIndexDirs(testDir);
@@ -256,7 +256,7 @@ TEST(KeepPreviousIndexDirs, cleanUpPreviousIndexDirsFailures) {
   }
   qlever::Qlever::cleanUpPreviousIndexDirs((testDir / "index").string(),
                                            KeepPreviousIndexDirs::None);
-  restorePermissions();
+  makeDirDeletableAgain();
 
   std::string logName = absl::StrCat("index", REBUILD_INDEX_LOG_SUFFIX);
   EXPECT_THAT(entryNames(testDir),

--- a/test/KeepPreviousIndexDirsTest.cpp
+++ b/test/KeepPreviousIndexDirsTest.cpp
@@ -7,15 +7,18 @@
 // You may not use this file except in compliance with the Apache 2.0 License,
 // which can be found in the `LICENSE` file at the root of the QLever project.
 
+#include <absl/strings/str_cat.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <fstream>
+#include <iterator>
 #include <string>
 #include <vector>
 
 #include "backports/filesystem.h"
 #include "engine/KeepPreviousIndexDirs.h"
+#include "global/FileSuffixConstants.h"
 #include "libqlever/Qlever.h"
 #include "util/GTestHelpers.h"
 
@@ -149,12 +152,15 @@ TEST(KeepPreviousIndexDirs, cleanUpPreviousIndexDirs) {
   std::string baseName = (testDir / "index").string();
 
   // Apply the given policy to a freshly set up directory and return the
-  // names of the surviving entries.
+  // names of the surviving entries. For every policy except `all`, the
+  // decisions are appended to the `rebuild-index` log of the index, which
+  // hence appears among the entries.
   auto survivors = [&](KeepPreviousIndexDirs policy) {
     setUpPreviousIndexDirs(testDir);
     qlever::Qlever::cleanUpPreviousIndexDirs(baseName, policy);
     return entryNames(testDir);
   };
+  std::string logName = absl::StrCat("index", REBUILD_INDEX_LOG_SUFFIX);
 
   // Entries that are not directories or whose name does not start with
   // `previous.` are never touched.
@@ -162,14 +168,29 @@ TEST(KeepPreviousIndexDirs, cleanUpPreviousIndexDirs) {
               ElementsAre("other.dir", "previous.a", "previous.b", "previous.c",
                           "previous.d", "previous.e", "previous.file"));
   EXPECT_THAT(survivors(KeepPreviousIndexDirs::None),
-              ElementsAre("other.dir", "previous.file"));
+              ElementsAre(logName, "other.dir", "previous.file"));
   EXPECT_THAT(survivors(KeepPreviousIndexDirs::OriginalOnly),
-              ElementsAre("other.dir", "previous.a", "previous.file"));
+              ElementsAre(logName, "other.dir", "previous.a", "previous.file"));
   EXPECT_THAT(survivors(KeepPreviousIndexDirs::MostRecentOnly),
-              ElementsAre("other.dir", "previous.e", "previous.file"));
-  EXPECT_THAT(
-      survivors(KeepPreviousIndexDirs::OriginalAndMostRecent),
-      ElementsAre("other.dir", "previous.a", "previous.e", "previous.file"));
+              ElementsAre(logName, "other.dir", "previous.e", "previous.file"));
+  EXPECT_THAT(survivors(KeepPreviousIndexDirs::OriginalAndMostRecent),
+              ElementsAre(logName, "other.dir", "previous.a", "previous.e",
+                          "previous.file"));
+
+  // The decisions are written to the `rebuild-index` log of the index (not to
+  // the server log), one line per directory.
+  {
+    std::ifstream logStream{(testDir / logName).string()};
+    std::string logContent{std::istreambuf_iterator<char>{logStream}, {}};
+    EXPECT_THAT(logContent,
+                HasSubstr("Checking which previous index directories to keep "
+                          "or delete (original-and-most-recent)"));
+    EXPECT_THAT(logContent, HasSubstr("previous.a -> KEEP"));
+    EXPECT_THAT(logContent, HasSubstr("previous.b -> DELETE"));
+    EXPECT_THAT(logContent, HasSubstr("previous.c -> DELETE"));
+    EXPECT_THAT(logContent, HasSubstr("previous.d -> DELETE"));
+    EXPECT_THAT(logContent, HasSubstr("previous.e -> KEEP"));
+  }
 
   fs::remove_all(testDir);
 }

--- a/test/index/IndexRebuilderTest.cpp
+++ b/test/index/IndexRebuilderTest.cpp
@@ -4,6 +4,7 @@
 //
 //  UFR = University of Freiburg, Chair of Algorithms and Data Structures
 
+#include <absl/cleanup/cleanup.h>
 #include <absl/strings/str_cat.h>
 #include <absl/strings/str_format.h>
 #include <absl/time/time.h>
@@ -814,6 +815,13 @@ TEST(IndexRebuilder, serverIntegration) {
 
   qlever::EngineConfig config;
   config.baseName_ = indexName;
+  // Keep all previous index directories: this test runs in the shared
+  // working directory, and deleting `previous.*` directories here would
+  // interfere with the other server-integration tests when the tests run
+  // concurrently. The cleanup policy itself is tested by
+  // `serverIntegrationKeepPreviousIndexDirs` below, in a dedicated
+  // subdirectory.
+  config.keepPreviousIndexDirs_ = qlever::KeepPreviousIndexDirs::All;
   constexpr std::string_view accessToken = "accessToken";
   Server server{4321, 1, std::string{accessToken}, config};
 
@@ -936,6 +944,8 @@ TEST(IndexRebuilder, serverIntegrationDroppedStateWarnings) {
   qlever::EngineConfig config;
   config.baseName_ = indexName;
   config.persistUpdates_ = false;
+  // Keep all previous index directories, see `serverIntegration` above.
+  config.keepPreviousIndexDirs_ = qlever::KeepPreviousIndexDirs::All;
 
   // Write a materialized view to disk so it can be preloaded below.
   {
@@ -1026,6 +1036,8 @@ TEST(IndexRebuilder, serverIntegrationAutomaticRebuild) {
   qlever::EngineConfig config;
   config.baseName_ = indexName;
   config.persistUpdates_ = false;
+  // Keep all previous index directories, see `serverIntegration` above.
+  config.keepPreviousIndexDirs_ = qlever::KeepPreviousIndexDirs::All;
   // `min == max == 3` makes the threshold a fixed three delta triples,
   // independent of the index size: trigger an automatic rebuild as soon as the
   // number of delta triples reaches three.
@@ -1119,5 +1131,88 @@ TEST(IndexRebuilder, serverIntegrationAutomaticRebuild) {
   }
 
   cleanDirsWithPrefix("previous.");
+}
+#endif  // __EMSCRIPTEN__
+
+// _____________________________________________________________________________
+// Compiled out under Emscripten like `serverIntegration` above: the `server`
+// library it needs is not built there.
+#ifndef __EMSCRIPTEN__
+TEST(IndexRebuilder, serverIntegrationKeepPreviousIndexDirs) {
+  namespace fs = ql::filesystem;
+  // Run in a dedicated subdirectory: this test creates and deletes
+  // `previous.*` directories, which would interfere with the
+  // server-integration tests above when the tests run concurrently in the
+  // same working directory.
+  fs::path parentDir = fs::current_path();
+  fs::path testDir = parentDir / "IndexRebuilder_keepPreviousIndexDirs.dir";
+  fs::remove_all(testDir);
+  fs::create_directory(testDir);
+  fs::current_path(testDir);
+  absl::Cleanup restoreWorkingDir{[&parentDir, &testDir]() {
+    ql::filesystem::current_path(parentDir);
+    ql::filesystem::remove_all(testDir);
+  }};
+
+  std::string indexName = "IndexRebuilder_keepPreviousIndexDirs";
+  ad_utility::testing::makeTestIndex(indexName, "<a> <b> <c> .");
+
+  qlever::EngineConfig config;
+  config.baseName_ = indexName;
+  config.keepPreviousIndexDirs_ =
+      qlever::KeepPreviousIndexDirs::OriginalAndMostRecent;
+  serverTestHelpers::ServerForTesting server{1, "accessToken", config};
+
+  // Trigger a manual rebuild and wait for it (the request only returns after
+  // the new index has been swapped in and the cleanup has run).
+  auto rebuild = [&server]() {
+    auto request = ad_utility::testing::makeGetRequest(
+        "/?cmd=rebuild-index&access-token=accessToken");
+    auto response = server.process(request);
+    EXPECT_EQ(response.base().result(), boost::beast::http::status::ok);
+  };
+
+  // The names of the `previous.*` directories, sorted. The sort order is the
+  // order from oldest to newest here: the names contain the build date of the
+  // retired index (uniquified with a numeric suffix for rebuilds within the
+  // same second, see `Qlever::makeIndexRebuildConfig`).
+  auto previousDirNames = []() {
+    std::vector<std::string> result;
+    for (const auto& dir : dirsWithPrefix("previous.")) {
+      result.push_back(dir.filename().string());
+    }
+    ql::ranges::sort(result);
+    return result;
+  };
+
+  // After the first rebuild, there is one previous index directory (the
+  // original index the server was started on), which the policy keeps.
+  rebuild();
+  auto afterFirst = previousDirNames();
+  ASSERT_EQ(afterFirst.size(), 1u);
+  std::string originalDir = afterFirst.front();
+
+  // After the second rebuild, the directory added by it is the most recent
+  // one, so both are kept.
+  rebuild();
+  auto afterSecond = previousDirNames();
+  ASSERT_EQ(afterSecond.size(), 2u);
+  EXPECT_EQ(afterSecond.front(), originalDir);
+  std::string middleDir = afterSecond.back();
+
+  // The third rebuild adds another directory, so now the one added by the
+  // second rebuild is neither the original nor the most recent and is
+  // deleted.
+  rebuild();
+  auto afterThird = previousDirNames();
+  ASSERT_EQ(afterThird.size(), 2u);
+  EXPECT_EQ(afterThird.front(), originalDir);
+  EXPECT_NE(afterThird.back(), middleDir);
+
+  // The rebuilt index still answers queries.
+  auto request = ad_utility::testing::makeGetRequest(
+      "/?query=SELECT%20%2A%20WHERE%20%7B%20%3Fs%20%3Fp%20%3Fo%20%7D");
+  auto response = server.process(request);
+  EXPECT_EQ(response.base().result(), boost::beast::http::status::ok);
 }
 #endif  // __EMSCRIPTEN__

--- a/test/index/IndexRebuilderTest.cpp
+++ b/test/index/IndexRebuilderTest.cpp
@@ -796,7 +796,7 @@ void cleanDirsWithPrefix(std::string_view prefix) {
 // the permutation's shared reader, which is used by the query scans, must
 // never carry an override.
 TEST(IndexRebuilder, lazyScanNumThreadsOverride) {
-  auto index = ad_utility::testing::makeTestIndex("lazyScanNumThreadsOverride",
+  auto index = ad_utility::testing::makeTestIndex(gtestCurrentTestName(),
                                                   "<a> <b> <c> .");
   const auto& permutation =
       index.getImpl().getPermutation(Permutation::Enum::PSO);

--- a/test/index/IndexRebuilderTest.cpp
+++ b/test/index/IndexRebuilderTest.cpp
@@ -774,15 +774,7 @@ namespace {
 // Return the directories in the current directory whose name starts with
 // `prefix`.
 std::vector<ql::filesystem::path> dirsWithPrefix(std::string_view prefix) {
-  namespace fs = ql::filesystem;
-  std::vector<fs::path> result;
-  for (const auto& entry : fs::directory_iterator(".")) {
-    if (entry.is_directory() &&
-        ql::starts_with(entry.path().filename().string(), prefix)) {
-      result.push_back(entry.path());
-    }
-  }
-  return result;
+  return qlever::util::directoriesWithPrefix(".", prefix);
 }
 
 // Remove all directories in the current directory whose name starts with
@@ -799,9 +791,48 @@ void cleanDirsWithPrefix(std::string_view prefix) {
 }  // namespace
 
 // _____________________________________________________________________________
-// Compiled out under Emscripten: the `server` library it needs is not built
-// there (see the include of `engine/Server.h` above), and the test hangs
-// under Emscripten anyway (threaded server integration).
+// The thread-count override for the rebuild's scans must be set on the
+// dedicated reader created by `lazyScanWithUnlimitedReader` (and only there);
+// the permutation's shared reader, which is used by the query scans, must
+// never carry an override.
+TEST(IndexRebuilder, lazyScanNumThreadsOverride) {
+  auto index = ad_utility::testing::makeTestIndex("lazyScanNumThreadsOverride",
+                                                  "<a> <b> <c> .");
+  const auto& permutation =
+      index.getImpl().getPermutation(Permutation::Enum::PSO);
+  auto cancellationHandle =
+      std::make_shared<ad_utility::SharedCancellationHandle::element_type>();
+  auto state =
+      index.deltaTriplesManager().getCurrentLocatedTriplesSharedState();
+  ScanSpecification scanSpec{std::nullopt, std::nullopt, std::nullopt};
+  std::array<ColumnIndex, 1> additionalColumns{ADDITIONAL_COLUMN_GRAPH_ID};
+
+  auto scanWithOverride = [&](std::optional<size_t> numThreadsOverride) {
+    return permutation.lazyScanWithUnlimitedReader(
+        permutation.getScanSpecAndBlocks(scanSpec, *state), additionalColumns,
+        cancellationHandle, *state, numThreadsOverride);
+  };
+  auto [reader, scan] = scanWithOverride(3);
+  EXPECT_EQ(reader->lazyScanNumThreadsOverride_, std::optional<size_t>{3});
+  auto [readerDefault, scanDefault] = scanWithOverride(std::nullopt);
+  EXPECT_EQ(readerDefault->lazyScanNumThreadsOverride_, std::nullopt);
+  EXPECT_EQ(permutation.reader().lazyScanNumThreadsOverride_, std::nullopt);
+
+  // Recomputing the statistics with the throttle set must give exactly the
+  // same result as with the default (0, which means "fall back to
+  // `lazy-index-scan-num-threads`"). This exercises the translation of the
+  // runtime parameter to the override at both of its use sites.
+  auto statsDefault = index.getImpl().recomputeStatistics(state);
+  auto cleanup = setRuntimeParameterForTest<
+      &RuntimeParameters::rebuildIndexScanNumThreads_>(2);
+  EXPECT_EQ(index.getImpl().recomputeStatistics(state), statsDefault);
+}
+
+// _____________________________________________________________________________
+// All of the server-integration tests below are compiled out under
+// Emscripten: the `server` library they need is not built there (see the
+// include of `engine/Server.h` above), and the tests hang under Emscripten
+// anyway (threaded server integration).
 #ifndef __EMSCRIPTEN__
 TEST(IndexRebuilder, serverIntegration) {
   namespace fs = ql::filesystem;
@@ -820,12 +851,9 @@ TEST(IndexRebuilder, serverIntegration) {
 
   qlever::EngineConfig config;
   config.baseName_ = indexName;
-  // Keep all previous index directories: this test runs in the shared
-  // working directory, and deleting `previous.*` directories here would
-  // interfere with the other server-integration tests when the tests run
-  // concurrently. The cleanup policy itself is tested by
-  // `serverIntegrationKeepPreviousIndexDirs` below, in a dedicated
-  // subdirectory.
+  // Keep all previous index directories; the checks below expect one
+  // directory per rebuild. The cleanup policy itself is tested by
+  // `serverIntegrationKeepPreviousIndexDirs` below.
   config.keepPreviousIndexDirs_ = qlever::KeepPreviousIndexDirs::All;
   constexpr std::string_view accessToken = "accessToken";
   Server server{4321, 1, std::string{accessToken}, config};
@@ -925,12 +953,8 @@ TEST(IndexRebuilder, serverIntegration) {
 
   threadPool.join();
 }
-#endif  // __EMSCRIPTEN__
 
 // _____________________________________________________________________________
-// Compiled out under Emscripten like `serverIntegration` above: the `server`
-// library it needs is not built there.
-#ifndef __EMSCRIPTEN__
 TEST(IndexRebuilder, serverIntegrationDroppedStateWarnings) {
   SKIP_IF_LOGLEVEL_IS_LOWER(WARN);
   cleanDirsWithPrefix("droppedState.");
@@ -985,50 +1009,8 @@ TEST(IndexRebuilder, serverIntegrationDroppedStateWarnings) {
   threadPool.join();
   cleanDirsWithPrefix("droppedState.");
 }
-#endif  // __EMSCRIPTEN__
 
 // _____________________________________________________________________________
-// The thread-count override for the rebuild's scans must be set on the
-// dedicated reader created by `lazyScanWithUnlimitedReader` (and only there);
-// the permutation's shared reader, which is used by the query scans, must
-// never carry an override.
-TEST(IndexRebuilder, lazyScanNumThreadsOverride) {
-  auto index = ad_utility::testing::makeTestIndex("lazyScanNumThreadsOverride",
-                                                  "<a> <b> <c> .");
-  const auto& permutation =
-      index.getImpl().getPermutation(Permutation::Enum::PSO);
-  auto cancellationHandle =
-      std::make_shared<ad_utility::SharedCancellationHandle::element_type>();
-  auto state =
-      index.deltaTriplesManager().getCurrentLocatedTriplesSharedState();
-  ScanSpecification scanSpec{std::nullopt, std::nullopt, std::nullopt};
-  std::array<ColumnIndex, 1> additionalColumns{ADDITIONAL_COLUMN_GRAPH_ID};
-
-  auto scanWithOverride = [&](std::optional<size_t> numThreadsOverride) {
-    return permutation.lazyScanWithUnlimitedReader(
-        permutation.getScanSpecAndBlocks(scanSpec, *state), additionalColumns,
-        cancellationHandle, *state, numThreadsOverride);
-  };
-  auto [reader, scan] = scanWithOverride(3);
-  EXPECT_EQ(reader->lazyScanNumThreadsOverride_, std::optional<size_t>{3});
-  auto [readerDefault, scanDefault] = scanWithOverride(std::nullopt);
-  EXPECT_EQ(readerDefault->lazyScanNumThreadsOverride_, std::nullopt);
-  EXPECT_EQ(permutation.reader().lazyScanNumThreadsOverride_, std::nullopt);
-
-  // Recomputing the statistics with the throttle set must give exactly the
-  // same result as with the default (0, which means "fall back to
-  // `lazy-index-scan-num-threads`"). This exercises the translation of the
-  // runtime parameter to the override at both of its use sites.
-  auto statsDefault = index.getImpl().recomputeStatistics(state);
-  auto cleanup = setRuntimeParameterForTest<
-      &RuntimeParameters::rebuildIndexScanNumThreads_>(2);
-  EXPECT_EQ(index.getImpl().recomputeStatistics(state), statsDefault);
-}
-
-// _____________________________________________________________________________
-// Compiled out under Emscripten like `serverIntegration` above: the `server`
-// library it needs is not built there.
-#ifndef __EMSCRIPTEN__
 TEST(IndexRebuilder, serverIntegrationAutomaticRebuild) {
   // The automatic rebuild below uses the default directory names and the checks
   // below inspect all directories with a given prefix, see the comment in
@@ -1135,43 +1117,50 @@ TEST(IndexRebuilder, serverIntegrationAutomaticRebuild) {
     Server::logAutomaticRebuildFailure(nullptr);
   }
 }
-#endif  // __EMSCRIPTEN__
-
 // _____________________________________________________________________________
-// Compiled out under Emscripten like `serverIntegration` above: the `server`
-// library it needs is not built there.
-#ifndef __EMSCRIPTEN__
 TEST(IndexRebuilder, serverIntegrationKeepPreviousIndexDirs) {
-  namespace fs = ql::filesystem;
-  // Run in a dedicated subdirectory: this test creates and deletes
+  // Run in a fresh working directory: this test creates and deletes
   // `previous.*` directories, which would interfere with the
   // server-integration tests above when the tests run concurrently in the
-  // same working directory.
-  fs::path parentDir = fs::current_path();
-  fs::path testDir = parentDir / "IndexRebuilder_keepPreviousIndexDirs.dir";
-  fs::remove_all(testDir);
-  fs::create_directory(testDir);
-  fs::current_path(testDir);
-  absl::Cleanup restoreWorkingDir{[&parentDir, &testDir]() {
-    ql::filesystem::current_path(parentDir);
-    ql::filesystem::remove_all(testDir);
-  }};
+  // same working directory. Declared first, so that it is restored and
+  // removed last, i.e. after the `server` and the `threadPool` below have
+  // been destroyed.
+  auto restoreWorkingDir = ad_utility::testing::useFreshWorkingDirectory();
+  namespace net = boost::asio;
+  net::thread_pool threadPool{1};
 
-  std::string indexName = "IndexRebuilder_keepPreviousIndexDirs";
+  std::string indexName = gtestCurrentTestName();
   ad_utility::testing::makeTestIndex(indexName, "<a> <b> <c> .");
 
   qlever::EngineConfig config;
   config.baseName_ = indexName;
   config.keepPreviousIndexDirs_ =
       qlever::KeepPreviousIndexDirs::OriginalAndMostRecent;
-  serverTestHelpers::ServerForTesting server{1, "accessToken", config};
+  Server server{4321, 1, "accessToken", config};
+
+  // Perform the given request on the `threadPool` (like in `serverIntegration`
+  // above) and return the response. NOTE: A fresh, request-local `io_context`
+  // (as used by `ServerForTesting::process`) would be destroyed right after
+  // the response future resolves, while the server-pool thread that posted the
+  // final coroutine resumption can still be inside the signal on that
+  // context's scheduler event; the thread sanitizer reports this as a race
+  // between `pthread_cond_signal` and `pthread_cond_destroy`.
+  auto performRequest = [&server, &threadPool](auto& request) {
+    return net::co_spawn(
+               threadPool,
+               server.onlyForTestingProcess<std::decay_t<decltype(request)>,
+                                            ad_utility::httpUtils::ResponseT>(
+                   request),
+               net::use_future)
+        .get();
+  };
 
   // Trigger a manual rebuild and wait for it (the request only returns after
-  // the new index has been swapped in and the cleanup has run).
-  auto rebuild = [&server]() {
+  // the new index has been swapped in, which includes the cleanup).
+  auto rebuild = [&performRequest]() {
     auto request = ad_utility::testing::makeGetRequest(
         "/?cmd=rebuild-index&access-token=accessToken");
-    auto response = server.process(request);
+    auto response = performRequest(request);
     EXPECT_EQ(response.base().result(), boost::beast::http::status::ok);
   };
 
@@ -1212,10 +1201,17 @@ TEST(IndexRebuilder, serverIntegrationKeepPreviousIndexDirs) {
   EXPECT_EQ(afterThird.front(), originalDir);
   EXPECT_NE(afterThird.back(), middleDir);
 
-  // The rebuilt index still answers queries.
+  // The rebuilt index still answers queries. Unlike the `cmd=rebuild-index`
+  // requests above, a query needs the query hub (for the live runtime
+  // information via websocket).
+  auto queryHub = std::make_shared<ad_utility::websocket::QueryHub>(
+      threadPool.get_executor());
+  server.queryHub_ = queryHub;
   auto request = ad_utility::testing::makeGetRequest(
       "/?query=SELECT%20%2A%20WHERE%20%7B%20%3Fs%20%3Fp%20%3Fo%20%7D");
-  auto response = server.process(request);
+  auto response = performRequest(request);
   EXPECT_EQ(response.base().result(), boost::beast::http::status::ok);
+
+  threadPool.join();
 }
 #endif  // __EMSCRIPTEN__


### PR DESCRIPTION
Each `rebuild-index` moves the index that was served so far into a directory named `previous.<timestamp>`, where the timestamp is the build date of that index. When `rebuild-index` is called repeatedly, these directories accumulate. In particular, this happens with the automatic rebuilds introduced in #3163, which trigger on their own when there are many delta triples.

This change adds the option `--rebuild-keep-previous-index-dirs` to `qlever-server`, which determines which `previous.*` directories to keep and which to delete. The choices are `all` (keep everything, the behavior so far), `none` (keep nothing), `original-only` (keep only the index from the initial index build), `most-recent-only` (keep only the index that was served until the latest rebuild), and `original-and-most-recent` (keep exactly those two, the default). The policy is applied after every successful rebuild, manual or automatic.

NOTE: The option already exists in `qlever rebuild-index`, with the same choices and the same default. But that client-side cleanup is of no use for automatic rebuilds, where no client is involved, which is why `qlever-server` itself has to be able to do it.