### PR TITLE
Don't speculatively apply filters containing EXISTS during join ordering

### DIFF
--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -1417,6 +1417,20 @@ void QueryPlanner::applyFiltersIfPossible(
         continue;
       }
 
+      if constexpr (mode == FilterMode::KeepUnfiltered) {
+        if (!filterAndSubst.filter_.expression_.getExistsExpressions()
+                 .empty()) {
+          // Speculatively applying a filter that contains `EXISTS` to every
+          // candidate subplan multiplies the DP row (the unfiltered plans are
+          // kept alongside) and wraps each candidate in the `ExistsJoin`s for
+          // the filter's argument, which together make planning exponential
+          // in the number of `FILTER (NOT) EXISTS` clauses in a group. Leave
+          // such filters to the final `ReplaceUnfiltered*` passes, which
+          // apply them exactly once per surviving plan.
+          continue;
+        }
+      }
+
       const bool allowSubstitutes = mode == FilterMode::KeepUnfiltered ||
                                     mode == FilterMode::ReplaceUnfiltered;
       if (allowSubstitutes && filterAndSubst.hasSubstitute() &&
@@ -2562,9 +2576,10 @@ QueryPlanner::getJoinColumnsForTransitivePath(const JoinColumns& jcs,
 }
 
 // __________________________________________________________________________________________________________________
-auto QueryPlanner::createJoinWithTransitivePath(
-    const SubtreePlan& a, const SubtreePlan& b,
-    const JoinColumns& jcs) -> std::optional<SubtreePlan> {
+auto QueryPlanner::createJoinWithTransitivePath(const SubtreePlan& a,
+                                                const SubtreePlan& b,
+                                                const JoinColumns& jcs)
+    -> std::optional<SubtreePlan> {
 #ifdef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
   (void)a;
   (void)b;
@@ -2653,9 +2668,10 @@ auto QueryPlanner::createMaterializedViewJoinReplacements(
 }
 
 // ______________________________________________________________________________________
-auto QueryPlanner::createJoinWithHasPredicateScan(
-    const SubtreePlan& a, const SubtreePlan& b,
-    const JoinColumns& jcs) -> std::optional<SubtreePlan> {
+auto QueryPlanner::createJoinWithHasPredicateScan(const SubtreePlan& a,
+                                                  const SubtreePlan& b,
+                                                  const JoinColumns& jcs)
+    -> std::optional<SubtreePlan> {
   // Check if one of the two operations is a HAS_PREDICATE_SCAN.
   // If the join column corresponds to the has-predicate scan's
   // subject column we can use a specialized join that avoids
@@ -2691,9 +2707,10 @@ auto QueryPlanner::createJoinWithHasPredicateScan(
 }
 
 // _____________________________________________________________________
-auto QueryPlanner::createJoinWithPathSearch(
-    const SubtreePlan& a, const SubtreePlan& b,
-    const JoinColumns& jcs) -> std::optional<SubtreePlan> {
+auto QueryPlanner::createJoinWithPathSearch(const SubtreePlan& a,
+                                            const SubtreePlan& b,
+                                            const JoinColumns& jcs)
+    -> std::optional<SubtreePlan> {
   auto aRootOp =
       std::dynamic_pointer_cast<PathSearch>(a._qet->getRootOperation());
   auto bRootOp =

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -2683,6 +2683,25 @@ TEST(QueryPlanner, GroupByRedundantParensAndVariables) {
 }
 
 // ____________________________________________________________________________
+// Regression test: `FILTER (NOT) EXISTS` used to be applied speculatively to
+// every candidate subplan inside the dynamic-programming rounds, which made
+// planning exponential in the number of such filters (each clause roughly
+// quadrupled planning time and memory, OOMing on any index from about four
+// clauses). With the filters deferred to the final filter passes, this plans
+// in milliseconds.
+TEST(QueryPlanner, manyExistsFiltersPlanQuickly) {
+  std::string query =
+      "SELECT ?v WHERE {\n"
+      "  ?v <p1> ?w1 . ?w1 <p2> ?w2 . ?w2 <p3> ?w3 .\n";
+  for (int i = 0; i < 8; ++i) {
+    query += absl::StrCat("  FILTER NOT EXISTS { ?v <q", i, "> ?x", i,
+                          " . FILTER (?x", i, " != ?w1) }\n");
+  }
+  query += "}";
+  EXPECT_NO_THROW(
+      h::parseAndPlan(std::move(query), ad_utility::testing::getQec()));
+}
+
 TEST(QueryPlanner, Exists) {
   auto xyz = h::IndexScanFromStrings("?x", "?y", "?z");
   auto abc = h::IndexScanFromStrings("?a", "?b", "?c");


### PR DESCRIPTION
## Problem

Query planning memory grows ~4× with each `FILTER (NOT) EXISTS` clause in a group, independent of data size. On an **8-triple index** (a linked list), a BGP walking the list plus N exclusion clauses of the form

```sparql
FILTER NOT EXISTS { ?cell rdf:first ?x . FILTER (?x != <...>) }
```

peaks at:

| N | peak RSS | outcome |
|---|----------|---------|
| 0 | 22 MB | ok |
| 2 | 676 MB | ok |
| 3 | 2.7 GB | ok, slow |
| 4 | 5.3 GB | "Operation timed out. Last operation: Query planning" |
| 5 | > 6.4 GB | OOM-killed under `docker --memory=2g` |

Reproduced on master (65f84b43, native macOS arm64) and the `commit-9ec88a0` docker image; same behaviour whether the data is index-loaded or arrives via SPARQL Update.

## Cause

`fillDpTab` calls `applyFiltersIfPossible<FilterMode::KeepUnfiltered>` on every plan of every DP row in every round. For a filter containing `EXISTS` this (a) keeps the unfiltered plans alongside the filtered ones, multiplying the row per clause, and (b) wraps each candidate in the `ExistsJoin`s for the filter's argument via `Filter`'s constructor. `sample` profiles of the server mid-climb show all busy time under `runDynamicProgrammingOnConnectedComponent → merge → createJoinCandidates → Join/Sort construction → Operation::getCacheKey()` string building for the multiplied candidates.

## Fix

In `KeepUnfiltered` mode (the speculative early application inside DP rounds), skip filters whose expression contains `EXISTS`; the final `ReplaceUnfiltered*` passes still apply them exactly once per surviving plan. The repro then plans flat — 22/59/68 MB peak RSS for 0/4/9 clauses — with unchanged plan shapes (`QueryPlanner.Exists` passes unmodified). A regression test plans a query with 8 `NOT EXISTS` clauses, which previously effectively hung.

The speculative early application is a useful optimization for ordinary filters (they shrink intermediates); for EXISTS-filters its cost is exponential and its benefit small, since the `ExistsJoin` only adds a boolean column.

(An alternative considered and discarded: memoizing the planned EXISTS argument per `ExistsExpression`. It does not help this repro — the argument here is a single triple; the cost is the candidate multiplication — and reusing an argument tree planned under one subtree's column order perturbs the `GroupBy(SAMPLE(EXISTS ...))` plan shapes.)

Found while validating ShEx over SPARQL in [shex.js](https://github.com/shexjs/shex.js), where a blank node's neighborhood is pinned down by one exclusion clause per predicate per node; happy to provide more repro detail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Reproducing the table

Everything needed is below; both sides were re-measured with exactly these files (master 65f84b43 vs. this branch, macOS arm64 RelWithDebInfo).

<details><summary><b>data.ttl</b> — a 3-cell linked list (8 triples)</summary>

```ttl
<http://a.example/n1> <http://a.example/p1> _:l0 .
_:l0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://a.example/v1> .
_:l0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:l1 .
_:l1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://a.example/v2> .
_:l1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:l2 .
_:l2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://a.example/v3> .
_:l2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
```
</details>

<details><summary><b>repro.rq</b> — all exclusion clauses commented out = the N=0 row; uncomment <code>clause 1</code> … <code>clause N</code>, top to bottom, to walk the table</summary>

```sparql
PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
# Walks the 3-cell linked list in data.ttl. As given (all clauses commented
# out) this is the N=0 row of the table. Uncomment the FILTER NOT EXISTS
# clauses one at a time, top to bottom, to walk the table: each uncommented
# clause roughly quadruples planning memory, and N=4 times out in
# "Query planning" after allocating ~5 GB. With this PR applied, every row
# stays under ~70 MB.
SELECT ?v WHERE {
  <http://a.example/n1> <http://a.example/p1> ?v0_0 .
  FILTER (isBlank(?v0_0))
  ?v0_0 rdf:first <http://a.example/v1> .
  ?v0_0 rdf:rest ?v0_2 .
  FILTER (isBlank(?v0_2))
  ?v0_2 rdf:first <http://a.example/v2> .
  ?v0_2 rdf:rest ?v0_5 .
  FILTER (isBlank(?v0_5))
  ?v0_5 rdf:first <http://a.example/v3> .
  ?v0_5 rdf:rest rdf:nil .
  # clause 1:
  # FILTER NOT EXISTS { ?v0_0 rdf:first ?x1 . FILTER (!(isIRI(?x1) && str(?x1) = "http://a.example/v1")) }
  # clause 2:
  # FILTER NOT EXISTS { ?v0_0 rdf:rest ?x2 . FILTER (?x2 != ?v0_2) }
  # clause 3:
  # FILTER NOT EXISTS { ?v0_2 rdf:first ?x3 . FILTER (!(isIRI(?x3) && str(?x3) = "http://a.example/v2")) }
  # clause 4:
  # FILTER NOT EXISTS { ?v0_2 rdf:rest ?x4 . FILTER (?x4 != ?v0_5) }
  # clause 5:
  # FILTER NOT EXISTS { ?v0_5 rdf:first ?x5 . FILTER (!(isIRI(?x5) && str(?x5) = "http://a.example/v3")) }
  BIND(?v0_0 AS ?v)
}
```
</details>

```bash
qlever-index -i repro -f data.ttl -F ttl
qlever-server -i repro -p 7001 --no-access-check &

# in a second shell, watch the server's peak RSS:
while sleep 0.2; do ps -o rss= -p $(pgrep -f 'qlever-server -i repro'); done \
  | awk '{ if ($1 > m) { m = $1; printf "peak %d MB\n", m / 1024 } }'

# submit; then uncomment one more clause and repeat (restarting the server
# between rows gives the cleanest numbers, but it spikes either way):
curl http://localhost:7001/ -H 'Content-Type: application/sparql-query' \
     -H 'Accept: application/sparql-results+json' --data-binary @repro.rq
```

Measured with these files on unpatched master, fresh server per row:

| uncommented clauses | peak RSS | outcome |
|---|---|---|
| 0 | 22 MB | ok |
| 1 | 191 MB | ok |
| 2 | 696 MB | ok |
| 3 | 2 730 MB | ok, slow |
| 4 | 5 181 MB | `"Operation timed out. Last operation: Query planning"` |
| 5 | > 6 250 MB | killed by a 6 GB watchdog |

With this PR applied, N=0 and N=5 both peak at **22 MB**.

No-watchdog alternative: run the server under `docker run --memory=2g` (e.g. the `adfreiburg/qlever` image) — from 3 clauses on, the container is OOM-killed mid-planning (`docker inspect -f '{{.State.OOMKilled}}'` → `true`).