### PR TITLE
Fix the Clang build with OpenMP by not capturing structured bindings

### DIFF
--- a/src/engine/ConstructBatchEvaluator.cpp
+++ b/src/engine/ConstructBatchEvaluator.cpp
@@ -100,9 +100,11 @@ EvaluatedVariableValues ConstructBatchEvaluator::evaluateVariableByColumn(
   // so there is no disk I/O to amortize across batches.
   auto missResolved =
       ql::exportIds::idsToStringAndType(index, missIds, localVocab);
+  // NOTE: The init-capture is needed because Clang with `-fopenmp` does not
+  // support capturing a structured binding directly.
   for (auto&& [id, resolved, rows] :
        ::ranges::views::zip(missIds, missResolved, missRows)) {
-    auto evaluate = [&resolved](const Id&) {
+    auto evaluate = [&resolved = resolved](const Id&) {
       return ConstructBatchEvaluator::stringAndTypeToEvaluatedTerm(
           std::move(resolved));
     };

--- a/src/engine/GroupByImpl.cpp
+++ b/src/engine/GroupByImpl.cpp
@@ -1128,7 +1128,9 @@ std::optional<IdTable> GroupByImpl::computeGroupByForJoinWithFullScan() const {
       threeVarSubtree.getRootOperation());
   AD_CORRECTNESS_CHECK(indexScan != nullptr);
 
-  auto getExactCardinality = [&indexScan, &permutation](Id id) {
+  // NOTE: The init-capture is needed because Clang with `-fopenmp` does not
+  // support capturing a structured binding directly.
+  auto getExactCardinality = [&indexScan, &permutation = permutation](Id id) {
     return permutation.getResultSizeOfScan(
         permutation.getScanSpecAndBlocks(
             ScanSpecification{id, std::nullopt, std::nullopt},

--- a/src/engine/Minus.cpp
+++ b/src/engine/Minus.cpp
@@ -155,11 +155,14 @@ IdTable Minus::copyMatchingRows(
   }
   result.resize(nonMatchingIndices.size());
 
+  // NOTE: The init-capture is needed because Clang with `-fopenmp` does not
+  // support capturing a structured binding directly.
   for (const auto& [outputCol, inputCol] :
        ::ranges::views::zip(result.getColumns(), left.getColumns())) {
     ad_utility::chunkedCopy(
-        ql::views::transform(nonMatchingIndices,
-                             [&inputCol](size_t row) { return inputCol[row]; }),
+        ql::views::transform(
+            nonMatchingIndices,
+            [&inputCol = inputCol](size_t row) { return inputCol[row]; }),
         outputCol.begin(), qlever::joinHelpers::CHUNK_SIZE,
         [this]() { checkCancellation(); });
   }

--- a/src/engine/MinusRowHandler.h
+++ b/src/engine/MinusRowHandler.h
@@ -172,12 +172,16 @@ class MinusRowHandler {
     resultTable_.resize(oldSize + indexBuffer_.size());
 
     auto action = [this]() { cancellationHandle_->throwIfCancelled(); };
+    // NOTE: The init-capture is needed because Clang with `-fopenmp` does not
+    // support capturing a structured binding directly.
     for (const auto& [outputColumn, inputColumn] : ::ranges::zip_view(
              resultTable_.getColumns(), inputLeft_.value().getColumns())) {
-      chunkedCopy(ql::views::transform(
-                      indexBuffer_,
-                      [&inputColumn](size_t row) { return inputColumn[row]; }),
-                  outputColumn.begin() + oldSize, CHUNK_SIZE, action);
+      chunkedCopy(
+          ql::views::transform(indexBuffer_,
+                               [&inputColumn = inputColumn](size_t row) {
+                                 return inputColumn[row];
+                               }),
+          outputColumn.begin() + oldSize, CHUNK_SIZE, action);
     }
   }
 };

--- a/src/engine/Operation.cpp
+++ b/src/engine/Operation.cpp
@@ -462,7 +462,13 @@ void Operation::storeToNamedResultCache(const Result& result) {
 
   // If a geo index is to be cached, get the respective column using the
   // given variable and compute the index.
-  auto geoIndex = [&]() -> std::optional<SpatialJoinCachedIndex> {
+  //
+  // NOTE: The init-captures are needed because Clang with `-fopenmp` does not
+  // support capturing a structured binding directly.
+  auto geoIndex =
+      [&, &geoIndexVar = geoIndexVar,
+       &simplificationInMeters =
+           simplificationInMeters]() -> std::optional<SpatialJoinCachedIndex> {
     if (!geoIndexVar.has_value()) {
       return std::nullopt;
     }

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -2600,7 +2600,10 @@ auto QueryPlanner::createJoinWithTransitivePath(
 
   // The left or right side is a transitive path and its join column corresponds
   // to the left side of its input.
-  SubtreePlan plan = [&]() {
+  //
+  // NOTE: The init-captures are needed because Clang with `-fopenmp` does not
+  // support capturing a structured binding directly.
+  SubtreePlan plan = [&, &thisCol = thisCol, &otherCol = otherCol]() {
     if (thisCol == 0) {
       return makeSubtreePlan(
           transPathOperation->bindLeftSide(otherTree, otherCol));

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -361,9 +361,14 @@ auto Server::prepareOperation(
   // Return a factory rather than a ready-made context, so the caller can bind
   // it to whichever snapshot is current when the operation runs (see
   // `processUpdate`).
+  //
+  // NOTE: The init-captures of `pinSubtrees` and `pinResult` are needed
+  // because Clang with `-fopenmp` does not support capturing a structured
+  // binding directly.
   MakeQueryExecutionContext makeQec =
-      [this, sharedMessageSender = std::move(sharedMessageSender), pinSubtrees,
-       pinResult, pinResultWithName = std::move(pinResultWithName),
+      [this, sharedMessageSender = std::move(sharedMessageSender),
+       pinSubtrees = pinSubtrees, pinResult = pinResult,
+       pinResultWithName = std::move(pinResultWithName),
        pinNamedGeoIndex = std::move(pinNamedGeoIndex),
        geoIndexSimplificationInMeters,
        accessTokenOk](SharedIndexAndView indexAndViews) {
@@ -1676,9 +1681,13 @@ Awaitable<qlever::IndexRebuildConfig> Server::rebuildIndex(
   //
   // We don't directly `co_await` because of lifetime issues (bugs) in the
   // Conan setup.
+  //
+  // NOTE: The init-captures of `index` (and of `oldManager` below) are needed
+  // because Clang with `-fopenmp` does not support capturing a structured
+  // binding directly.
   auto coroutine = ad_utility::runFunctionOnExecutor(
       queryThreadPool_.get_executor(),
-      [this, &index, &handle, &config] {
+      [this, &index = index, &handle, &config] {
         return qlever().rebuildIndexToDisk(index, config, handle);
       },
       net::use_awaitable);
@@ -1689,8 +1698,8 @@ Awaitable<qlever::IndexRebuildConfig> Server::rebuildIndex(
   // current index.
   auto swapRoutine = ad_utility::runFunctionOnExecutor(
       updateThreadPool_.get_executor(),
-      [this, &index, &oldManager, rebuildResult = std::move(rebuildResult),
-       &handle, &config]() mutable {
+      [this, &index = index, &oldManager = oldManager,
+       rebuildResult = std::move(rebuildResult), &handle, &config]() mutable {
         // The swap below moves all files of the old index to a different base
         // name and installs the new index at the base name of the old one. Any
         // view file that `oldManager` created after that point would silently

--- a/src/engine/Service.cpp
+++ b/src/engine/Service.cpp
@@ -403,7 +403,11 @@ std::optional<std::string> Service::getSiblingValuesClause() const {
   checkCancellation();
 
   // Creates a single row of the values clause or an empty string on error.
-  auto createValueRow = [&](size_t rowIndex) -> std::string {
+  //
+  // NOTE: The init-capture is needed because Clang with `-fopenmp` does not
+  // support capturing a structured binding directly.
+  auto createValueRow = [&, &siblingResult =
+                                siblingResult](size_t rowIndex) -> std::string {
     std::string row = "(";
     for (const auto& columnIdx : commonColumnIndices) {
       const auto& optStr = idToValueForValuesClause(
@@ -630,7 +634,10 @@ void Service::precomputeSiblingResult(std::shared_ptr<Operation> left,
     return;
   }
 
-  auto addRuntimeInfo = [&](bool siblingUsed) {
+  // NOTE: The init-captures are needed because Clang with `-fopenmp` does not
+  // support capturing a structured binding directly.
+  auto addRuntimeInfo = [&, &service = service,
+                         &sibling = sibling](bool siblingUsed) {
     std::string_view v = siblingUsed ? "yes"sv : "no"sv;
     service->runtimeInfo().addDetail("optimized-with-sibling-result", v);
     sibling->runtimeInfo().addDetail("used-to-optimize-service-sibling", v);

--- a/src/engine/SpatialJoinAlgorithms.cpp
+++ b/src/engine/SpatialJoinAlgorithms.cpp
@@ -130,11 +130,14 @@ SpatialJoinAlgorithms::libspatialjoinParse(
 
   // Iterate over all rows in `idTable` and add the geometries from `column`
   // to the parallel WKT parser.
+  //
+  // NOTE: The init-captures are needed because Clang with `-fopenmp` does not
+  // support capturing a structured binding directly.
   const auto& geoms = idTable->getColumn(column);
   ad_utility::chunkedForLoop<wktParserChunkSizeForCancellationCheck>(
       0, idTable->size(),
-      [&parser, &geoms, &leftOrRightSide, &idTable,
-       &boundingBoxes](size_t row) {
+      [&parser, &geoms, &leftOrRightSide, &idTable = idTable,
+       &boundingBoxes = boundingBoxes](size_t row) {
         parser.addValueIdToQueue(
             geoms[row], row, leftOrRightSide,
             getBoundingBoxFromIdTable(idTable, boundingBoxes, row));
@@ -1108,27 +1111,32 @@ Result SpatialJoinAlgorithms::BoundingBoxAlgorithm() {
     });
 
     std::set<AddedPair> pairs;
-    ql::ranges::for_each(results, [&](Value& res) {
-      size_t rowLeft = res.second.row_;
-      size_t rowRight = i;
-      if (!leftResSmaller) {
-        std::swap(rowLeft, rowRight);
-      }
-      auto distance = computeDist(res.second, entry.value());
-      AD_CORRECTNESS_CHECK(distance.getDatatype() == Datatype::Double);
-      if (distance.getDouble() * 1000 <= maxDist.value()) {
-        // make sure, that no duplicate elements are inserted in the result
-        // table. As duplicates can only occur, when areas are not approximated
-        // as midpoints, the additional runtime can be saved in that case
-        if (useMidpointForAreas_) {
-          addResultTableEntry(&result, idTableLeft, idTableRight, rowLeft,
-                              rowRight, distance);
-        } else if (pairs.insert(AddedPair{rowLeft, rowRight}).second) {
-          addResultTableEntry(&result, idTableLeft, idTableRight, rowLeft,
-                              rowRight, distance);
-        }
-      }
-    });
+    // NOTE: The init-captures are needed because Clang with `-fopenmp` does
+    // not support capturing a structured binding directly.
+    ql::ranges::for_each(
+        results, [&, &idTableLeft = idTableLeft, &idTableRight = idTableRight,
+                  &maxDist = maxDist](Value& res) {
+          size_t rowLeft = res.second.row_;
+          size_t rowRight = i;
+          if (!leftResSmaller) {
+            std::swap(rowLeft, rowRight);
+          }
+          auto distance = computeDist(res.second, entry.value());
+          AD_CORRECTNESS_CHECK(distance.getDatatype() == Datatype::Double);
+          if (distance.getDouble() * 1000 <= maxDist.value()) {
+            // make sure, that no duplicate elements are inserted in the result
+            // table. As duplicates can only occur, when areas are not
+            // approximated as midpoints, the additional runtime can be saved in
+            // that case
+            if (useMidpointForAreas_) {
+              addResultTableEntry(&result, idTableLeft, idTableRight, rowLeft,
+                                  rowRight, distance);
+            } else if (pairs.insert(AddedPair{rowLeft, rowRight}).second) {
+              addResultTableEntry(&result, idTableLeft, idTableRight, rowLeft,
+                                  rowRight, distance);
+            }
+          }
+        });
   }
   auto resTable =
       Result(std::move(result), std::vector<ColumnIndex>{},

--- a/src/engine/TransitivePathImpl.h
+++ b/src/engine/TransitivePathImpl.h
@@ -352,8 +352,10 @@ class TransitivePathImpl : public TransitivePathBase {
     std::optional<ColumnIndex> graphColumn = getActualGraphColumnIndex(tree);
     std::vector<ColumnIndex> columnsWithoutJoinColumns =
         computeColumnsWithoutJoinColumns(joinColumn, cols, graphColumn);
+    // NOTE: The init-capture of `joinColumn` is needed because Clang with
+    // `-fopenmp` does not support capturing a structured binding directly.
     auto columnsToRange = [graphColumn = std::move(graphColumn),
-                           joinColumn](const auto& idTable) {
+                           joinColumn = joinColumn](const auto& idTable) {
       ql::span<const Id> startNodes = idTable.getColumn(joinColumn);
       return graphColumn.has_value()
                  ? InputRangeTypeErased{zipColumns(

--- a/src/engine/idTable/IdTable.h
+++ b/src/engine/idTable/IdTable.h
@@ -837,10 +837,14 @@ class IdTable {
     const size_t oldSize = size();
     resize(numRows() + numInserted);
     // For each column, copy the requested rows into the reserved tail.
+    //
+    // NOTE: The init-capture is needed because Clang with `-fopenmp` does not
+    // support capturing a structured binding directly.
     for (auto&& [destination, source] :
          ::ranges::views::zip(getColumns(), table.getColumns())) {
-      ql::ranges::transform(indices, destination.begin() + oldSize,
-                            [&source](size_t idx) { return source[idx]; });
+      ql::ranges::transform(
+          indices, destination.begin() + oldSize,
+          [&source = source](size_t idx) { return source[idx]; });
     }
   }
 

--- a/src/index/CompressedRelation.cpp
+++ b/src/index/CompressedRelation.cpp
@@ -1070,7 +1070,12 @@ IdTable CompressedRelationReader::getDistinctColIdsAndCounts(
       }
     } else {
       // Multiple `colId`s -> we have to read the block.
-      const auto& optionalBlock = [&]() -> std::optional<DecompressedBlock> {
+      //
+      // NOTE: The init-captures (here and in the other lambdas of this file)
+      // are needed because Clang with `-fopenmp` does not support capturing a
+      // structured binding directly.
+      const auto& optionalBlock = [&, &i = i, &blockMetadata = blockMetadata]()
+          -> std::optional<DecompressedBlock> {
         if (i == 0) {
           return readPossiblyIncompleteBlock(scanSpec, scanConfig,
                                              blockMetadata, std::nullopt,
@@ -1753,13 +1758,15 @@ CPP_template(typename Range)(
   auto checkUniquenessAndOrder = [](const auto& blockPair) {
     const auto& [b1, b2] = blockPair;
     // Blocks must be unique.
-    AD_CONTRACT_CHECK(b1 != b2 && b1.blockIndex_ != b2.blockIndex_, [&] {
-      return createErrorMessage(b1, b2, "Found block metadata duplicates\n");
-    });
+    AD_CONTRACT_CHECK(b1 != b2 && b1.blockIndex_ != b2.blockIndex_,
+                      [&, &b1 = b1, &b2 = b2] {
+                        return createErrorMessage(
+                            b1, b2, "Found block metadata duplicates\n");
+                      });
     // Blocks must adhere to ascending order.
     AD_CONTRACT_CHECK(
         b1.lastTriple_ < b2.lastTriple_ && b1.blockIndex_ < b2.blockIndex_,
-        [&] {
+        [&, &b1 = b1, &b2 = b2] {
           return createErrorMessage(b1, b2,
                                     "Found block metadata order violation\n");
         });
@@ -1785,15 +1792,17 @@ CPP_template(typename Range)(requires ql::ranges::input_range<Range>) static voi
     const auto& [b1, b2] = blockPair;
     // Consecutive blocks must contain equivalent values over the fixed
     // columns.
-    AD_CONTRACT_CHECK(b1.isConsistentWith(b2, firstFreeColIndex), [&] {
-      return createErrorMessage(
-          b1, b2, "Found column inconsistency between two blocks\n");
-    });
+    AD_CONTRACT_CHECK(
+        b1.isConsistentWith(b2, firstFreeColIndex), [&, &b1 = b1, &b2 = b2] {
+          return createErrorMessage(
+              b1, b2, "Found column inconsistency between two blocks\n");
+        });
     // All blocks, except the first and last, must contain consistent column
     // values over their triples up to the first free column.
     if (i > 0) {
       AD_CONTRACT_CHECK(
-          !b1.containsInconsistentTriples(firstFreeColIndex), [&] {
+          !b1.containsInconsistentTriples(firstFreeColIndex),
+          [&, &b1 = b1, &b2 = b2] {
             return createErrorMessage(
                 b1, b2,
                 absl::StrCat("The following First Block contains non-constant "

--- a/src/index/DeltaTriples.cpp
+++ b/src/index/DeltaTriples.cpp
@@ -458,15 +458,20 @@ void DeltaTriples::modifyTriplesImpl(CancellationHandle cancellationHandle,
   AD_EXPENSIVE_CHECK(std::unique(triples.begin(), triples.end()) ==
                      triples.end());
   tracer.beginTrace("removeExistingTriples");
-  ql::erase_if(triples, [&targetMap](const IdTriple<0>& triple) {
+  // NOTE: The init-captures of `targetMap` and `inverseMap` are needed
+  // because Clang with `-fopenmp` does not support capturing a structured
+  // binding directly.
+  ql::erase_if(triples, [&targetMap = targetMap](const IdTriple<0>& triple) {
     return targetMap.contains(triple);
   });
   tracer.endTrace("removeExistingTriples");
   tracer.beginTrace("removeInverseTriples");
-  ql::ranges::for_each(triples, [&inverseMap](const IdTriple<0>& triple) {
-    // Note: if a triple does not exist, `erase` does nothing.
-    inverseMap.erase(triple);
-  });
+  ql::ranges::for_each(triples,
+                       [&inverseMap = inverseMap](const IdTriple<0>& triple) {
+                         // Note: if a triple does not exist, `erase` does
+                         // nothing.
+                         inverseMap.erase(triple);
+                       });
   tracer.endTrace("removeInverseTriples");
   tracer.beginTrace("locatedAndAdd");
 

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -217,7 +217,11 @@ IndexImpl::buildOspWithPatterns(
   // That is, when we are done with the join (which we now explicitly wait
   // for before starting the second generator, see below), the generator is
   // destroyed.
-  auto getLazyPatternScan = [&]() {
+  //
+  // NOTE: The init-capture is needed because Clang with `-fopenmp` does not
+  // support capturing a structured binding directly.
+  auto getLazyPatternScan = [&, &hasPatternPredicateSortedByPSO =
+                                    hasPatternPredicateSortedByPSO]() {
     return lazyScanWithPermutedColumns(hasPatternPredicateSortedByPSO,
                                        std::array<ColumnIndex, 2>{0, 2});
   };

--- a/src/index/IndexRebuilder.cpp
+++ b/src/index/IndexRebuilder.cpp
@@ -575,11 +575,15 @@ indexRebuilder::IndexRebuildMapping materializeToIndex(
   // `wrap()` / `std::ref`; the declaration order here guarantees that.
   ad_utility::ExceptionCollector exceptionCollector;
 
+  // NOTE: The init-captures of `insertionPositions` (instead of capturing the
+  // structured binding directly) are needed because Clang with `-fopenmp` does
+  // not support capturing structured bindings.
   if (index.usePatterns()) {
     net::post(threadPool, exceptionCollector.wrap([&newIndex, &index,
-                                                   &insertionPositions]() {
+                                                   &insertionPositions =
+                                                       insertionPositions]() {
       newIndex.getPatterns() = index.getPatterns().cloneAndRemap(
-          [&insertionPositions](const Id& oldId) {
+          [&insertionPositions = insertionPositions](const Id& oldId) {
             return remapVocabId(oldId, insertionPositions);
           });
       newIndex.writePatternsToFile();
@@ -601,7 +605,8 @@ indexRebuilder::IndexRebuildMapping materializeToIndex(
   for (const auto& [permutationEnums, isInternal] : permutationSettings) {
     auto [a, b] = permutationEnums;
     auto getPermutation =
-        [&index, isInternal](Permutation::Enum permEnum) -> const Permutation& {
+        [&index, isInternal = isInternal](
+            Permutation::Enum permEnum) -> const Permutation& {
       const auto& perm = index.getPermutation(permEnum);
       return isInternal ? perm.internalPermutation() : perm;
     };

--- a/src/libqlever/Qlever.cpp
+++ b/src/libqlever/Qlever.cpp
@@ -794,8 +794,10 @@ void Qlever::swapInRebuiltIndex(
   // the rebuilt index. The triples that were persisted for the old index
   // are not compatible with the freshly built index (their `Id`s refer to
   // the old vocabulary), so they have to be regenerated.
+  // NOTE: The init-captures are needed because Clang with `-fopenmp` does not
+  // support capturing a structured binding directly.
   newIndexAndViews->index_.deltaTriplesManager().modify<void>(
-      [&oldSnapshot, &newSnapshot, &mapping,
+      [&oldSnapshot = oldSnapshot, &newSnapshot, &mapping = mapping,
        &handle](DeltaTriples& deltaTriples) {
         ad_utility::timer::TimeTracer tracer{"swapIndex"};
         deltaTriples.addFromSnapshotDiff(*oldSnapshot, *newSnapshot, mapping,

--- a/src/util/ConfigManager/ConfigManager.cpp
+++ b/src/util/ConfigManager/ConfigManager.cpp
@@ -190,8 +190,11 @@ CPP_template_def(typename Visitor)(
   // Call a wrapper for `vis` with the `HashMapEntry::visit` of every entry.
   ql::ranges::for_each(hashMapEntries, [&vis](const Pair& pair) {
     auto& [jsonPath, hashMapEntry] = pair;
-    hashMapEntry.visit(
-        [&jsonPath, &vis](auto& data) { std::invoke(vis, jsonPath, data); });
+    // NOTE: The init-capture is needed because Clang with `-fopenmp` does not
+    // support capturing a structured binding directly.
+    hashMapEntry.visit([&jsonPath = jsonPath, &vis](auto& data) {
+      std::invoke(vis, jsonPath, data);
+    });
   });
 }
 

--- a/src/util/JoinAlgorithms/JoinAlgorithms.h
+++ b/src/util/JoinAlgorithms/JoinAlgorithms.h
@@ -1217,7 +1217,10 @@ CPP_template(typename Derived, typename LeftSide, typename RightSide,
                                    io(begR, itFromR, endFromR));
     };
 
-    auto addNotFoundRowIndex = [&]() {
+    // NOTE: The init-captures (also in `doJoin` below) are needed because
+    // Clang with `-fopenmp` does not support capturing a structured binding
+    // directly.
+    auto addNotFoundRowIndex = [&, &fullBlockLeft = fullBlockLeft]() {
       if constexpr (DoOptionalJoinOrMinus) {
         return [this, begL = fullBlockLeft.begin()](auto itFromL) {
           AD_CORRECTNESS_CHECK(!hasUndef(rightSide_));
@@ -1235,7 +1238,9 @@ CPP_template(typename Derived, typename LeftSide, typename RightSide,
     // Lambda that binds the common arguments for the various calls below
     // (the inputs and the `rowAdder` are always the same, it is just the
     // UNDEF configuration that is different.
-    auto doJoin = [&](auto&&... args) {
+    auto doJoin = [&, &subrangeLeft = subrangeLeft,
+                   &subrangeRight = subrangeRight, &currentElItL = currentElItL,
+                   &currentElItR = currentElItR](auto&&... args) {
       return static_cast<Derived*>(this)->joinSubranges(
           ql::ranges::subrange{subrangeLeft.begin(), currentElItL},
           ql::ranges::subrange{subrangeRight.begin(), currentElItR},

--- a/test/CompressedRelationsTest.cpp
+++ b/test/CompressedRelationsTest.cpp
@@ -313,7 +313,10 @@ void testCompressedRelations(const Inputs& inputsOriginalBeforeCopy,
   // the `bool` is true if the `col0` is a "large" relation, meaning that the
   // metadata is explicitly stored and not extracted from the compressed data on
   // the fly.
-  auto getMetadataFromId = [&](Id col0) {
+  //
+  // NOTE: The init-capture is needed because Clang with `-fopenmp` does not
+  // support capturing a structured binding directly.
+  auto getMetadataFromId = [&, &metaData = metaData](Id col0) {
     auto it = ql::ranges::lower_bound(metaData, col0, {},
                                       &CompressedRelationMetadata::col0Id_);
     if (it != metaData.end() && it->col0Id_ == col0) {
@@ -482,7 +485,10 @@ TEST(CompressedRelationWriter, getFirstAndLastTriple) {
   // Test that the result of calling `getFirstAndLastTriple` for the index from
   // above with the given `ScanSpecification` matches the given `matcher`.
   using Loc = ad_utility::source_location;
-  auto testFirstAndLastBlock = [&](ScanSpecification spec, auto matcher,
+  // NOTE: The init-capture is needed because Clang with `-fopenmp` does not
+  // support capturing a structured binding directly.
+  auto testFirstAndLastBlock = [&, &readerPtr = readerPtr](
+                                   ScanSpecification spec, auto matcher,
                                    const LocatedTriplesPerBlock& =
                                        emptyLocatedTriples,
                                    Loc loc = AD_CURRENT_SOURCE_LOC()) {
@@ -539,7 +545,10 @@ TEST(CompressedRelationWriter, getFirstAndLastTripleWithUpdates) {
 
   // Test infrastructure.
   using Loc = ad_utility::source_location;
-  auto testFirstAndLastBlock = [&](ScanSpecification spec, auto matcher,
+  // NOTE: The init-capture is needed because Clang with `-fopenmp` does not
+  // support capturing a structured binding directly.
+  auto testFirstAndLastBlock = [&, &readerPtr = readerPtr](
+                                   ScanSpecification spec, auto matcher,
                                    Loc loc = AD_CURRENT_SOURCE_LOC()) {
     auto trace = generateLocationTrace(loc);
     auto blockMetadata =

--- a/test/ConfigManagerTest.cpp
+++ b/test/ConfigManagerTest.cpp
@@ -2503,10 +2503,12 @@ TEST(ConfigManagerTest, ConfigurationDocValidatorAssignment) {
         // Simply insert all the entries.
         ql::ranges::for_each(pairVector, [&assignment](const auto& pair) {
           const auto& [key, validatorVector] = pair;
+          // NOTE: The init-capture is needed because Clang with `-fopenmp`
+          // does not support capturing a structured binding directly.
           ql::ranges::for_each(
               validatorVector,
               [&assignment,
-               &key](const ConfigOptionValidatorManager& validator) {
+               &key = key](const ConfigOptionValidatorManager& validator) {
                 assignment->addEntryUnderKey(key, validator);
               });
         });

--- a/test/ExecuteUpdateTest.cpp
+++ b/test/ExecuteUpdateTest.cpp
@@ -476,9 +476,12 @@ TEST(ExecuteUpdate, transformTriplesTemplate) {
         auto [transformedTriples, localVocab] =
             ExecuteUpdate::transformTriplesTemplate(index, variableColumns,
                                                     triples);
+        // NOTE: The init-capture is needed because Clang with `-fopenmp` does
+        // not support capturing a structured binding directly.
         const auto transformedTriplesMatchers = ad_utility::transform(
             expectedTransformedTriples,
-            [&localVocab, &TripleComponentMatcher](const auto& expectedTriple) {
+            [&localVocab = localVocab,
+             &TripleComponentMatcher](const auto& expectedTriple) {
               return ElementsAre(
                   TripleComponentMatcher(localVocab, expectedTriple.at(0)),
                   TripleComponentMatcher(localVocab, expectedTriple.at(1)),

--- a/test/IoUringManagerTest.cpp
+++ b/test/IoUringManagerTest.cpp
@@ -250,8 +250,10 @@ TYPED_TEST(IoUringManagerTest, MultipleBatchesSequential) {
 
   TypeParam manager(64);
 
-  auto makeAndWait = [&](uint64_t offset, size_t numBytes,
-                         std::string_view expected) {
+  // NOTE: The init-capture is needed because Clang with `-fopenmp` does not
+  // support capturing a structured binding directly.
+  auto makeAndWait = [&, &fd = fd](uint64_t offset, size_t numBytes,
+                                   std::string_view expected) {
     ReadBatchForTesting batch;
     batch.add(offset, numBytes);
     manager.wait(batch.submitTo(manager, fd));

--- a/test/TripleSerializerTest.cpp
+++ b/test/TripleSerializerTest.cpp
@@ -173,12 +173,14 @@ TEST(TripleSerializer, multipleWordSetsInASerializedLocalVocab) {
 
   auto [localVocabOut, mapping] = ad_utility::detail::deserializeLocalVocab(
       reader, qec->getLocalVocabContext());
-  auto fromMapping = [&]() {
+  // NOTE: The init-captures are needed because Clang with `-fopenmp` does not
+  // support capturing a structured binding directly.
+  auto fromMapping = [&mapping = mapping]() {
     return ::ranges::to<std::vector>(
         mapping | ql::views::values |
         ql::views::transform([](Id id) { return *id.getLocalVocabIndex(); }));
   };
-  auto fromMappingOrigin = [&]() {
+  auto fromMappingOrigin = [&mapping = mapping]() {
     return ::ranges::to<std::vector>(
         mapping | ql::views::keys | ql::views::transform([](Id::T id) {
           return *Id::fromBits(id).getLocalVocabIndex();

--- a/test/engine/GroupByHashMapOptimizationTest.cpp
+++ b/test/engine/GroupByHashMapOptimizationTest.cpp
@@ -197,11 +197,13 @@ TEST_F(GroupByHashMapOptimizationTest,
   GroupConcatAggregationData data{";"};
   auto [calc, addValue] = makeCalcAndAddValue(data);
 
-  auto getResultString = [&](bool stripQuotes = true) {
+  // NOTE: The init-captures are needed because Clang with `-fopenmp` does not
+  // support capturing a structured binding directly.
+  auto getResultString = [&, &calc = calc](bool stripQuotes = true) {
     return idToString(calc(), stripQuotes);
   };
 
-  auto addString = [&](std::string_view string) {
+  auto addString = [&, &addValue = addValue](std::string_view string) {
     addValue(idFromString(string));
   };
 
@@ -228,8 +230,8 @@ TEST_F(GroupByHashMapOptimizationTest,
   addString("a");
   EXPECT_EQ(calc(), Id::makeUndefined());
 
-  auto addStringWithLangTag = [&](std::string_view string,
-                                  std::string langTag) {
+  auto addStringWithLangTag = [&, &addValue = addValue](std::string_view string,
+                                                        std::string langTag) {
     using ad_utility::triple_component::Literal;
     auto literal = Literal::literalWithoutQuotes(string, std::move(langTag));
     addValue(Id::makeFromLocalVocabIndex(


### PR DESCRIPTION
Clang rejects every lambda capture of a structured binding in a translation unit that is compiled with `-fopenmp`, with the error "capturing a structured binding is not yet supported in OpenMP" (verified with Clang 18.1.8). This affects all kinds of structured bindings (tuple-like, aggregate, array), no matter whether the binding is declared or captured by value or by reference, and no matter whether the capture is explicit or implicit. Without `-fopenmp` the same code compiles fine.

Since #2953 there are no OpenMP pragmas left in the code. The flag still matters because `-DUSE_PARALLEL=true` adds `-fopenmp` to every translation unit, so that the parallel sort from `__gnu_parallel` can use the OpenMP runtime. A build with Clang and `USE_PARALLEL` therefore currently does not compile.

This PR replaces each affected capture by an equivalent init-capture, for example `&x = x` instead of `&x`, which Clang accepts. The affected captures were found by repeatedly building until no errors remained, which touched 24 files. With this change, a full Release build with Clang 18 and `USE_PARALLEL=true` succeeds and all 3373 unit tests pass.