### PR TITLE
Log how many permutation pairs a `rebuild-index` writes concurrently

### DIFF
--- a/src/index/IndexRebuilder.cpp
+++ b/src/index/IndexRebuilder.cpp
@@ -564,6 +564,11 @@ indexRebuilder::IndexRebuildMapping materializeToIndex(
   if (maxConcurrentPairs == 0 || maxConcurrentPairs > numberOfPairs) {
     maxConcurrentPairs = numberOfPairs;
   }
+  REBUILD_LOG_INFO << "Writing at most " << maxConcurrentPairs << " of the "
+                   << numberOfPairs
+                   << " permutation pairs concurrently (see the runtime "
+                      "parameter `rebuild-max-concurrent-permutation-pairs`)"
+                   << std::endl;
   namespace net = boost::asio;
   net::thread_pool threadPool{patternThreads + 2 * maxConcurrentPairs};
 


### PR DESCRIPTION
The runtime parameter `rebuild-max-concurrent-permutation-pairs` (added in #3169) controls how many permutation pairs a `rebuild-index` writes in parallel. So far, the effective value was not visible anywhere in the logs. One could only infer it indirectly from the CPU usage and the duration of the permutation phase, which recently made it unnecessarily hard to check whether a set parameter was actually applied. With this change, the rebuild log reports the effective concurrency at the beginning of the permutation phase. A typical line looks like this: `Writing at most 1 of the 4 permutation pairs concurrently (see the runtime parameter rebuild-max-concurrent-permutation-pairs)`.
