### PR TITLE
pmr memory resource usage

### DIFF
--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -379,7 +379,7 @@ class Operation {
     return _executionContext;
   }
 
-  const ad_utility::AllocatorWithLimit<Id>& allocator() const {
+  const qlever::Allocator<Id>& allocator() const {
     return getExecutionContext()->getAllocator();
   }
 

--- a/src/engine/QueryExecutionContext.cpp
+++ b/src/engine/QueryExecutionContext.cpp
@@ -23,7 +23,7 @@ std::chrono::milliseconds QueryExecutionContext::websocketUpdateInterval() {
 // _____________________________________________________________________________
 QueryExecutionContext::QueryExecutionContext(
     std::shared_ptr<const Index> index, QueryResultCache* const cache,
-    ad_utility::AllocatorWithLimit<Id> allocator,
+    qlever::Allocator<Id> allocator,
     SortPerformanceEstimator sortPerformanceEstimator,
     NamedResultCache* namedResultCache,
     std::shared_ptr<MaterializedViewsManager> materializedViewsManager,

--- a/src/engine/QueryExecutionContext.h
+++ b/src/engine/QueryExecutionContext.h
@@ -20,6 +20,7 @@
 #include "global/Id.h"
 #include "index/DeltaTriples.h"
 #include "index/Index.h"
+#include "util/Allocator.h"
 #include "util/Cache.h"
 #include "util/ConcurrentCache.h"
 
@@ -107,7 +108,7 @@ class QueryExecutionContext
   enum struct DisableCaching { True, False, FromRuntimeParameter };
   QueryExecutionContext(
       std::shared_ptr<const Index> index, QueryResultCache* const cache,
-      ad_utility::AllocatorWithLimit<Id> allocator,
+      qlever::Allocator<Id> allocator,
       SortPerformanceEstimator sortPerformanceEstimator,
       NamedResultCache* namedResultCache,
       std::shared_ptr<MaterializedViewsManager> materializedViewsManager,
@@ -155,7 +156,7 @@ class QueryExecutionContext
     return _costFactors.getCostFactor(key);
   };
 
-  const ad_utility::AllocatorWithLimit<Id>& getAllocator() const {
+  const qlever::Allocator<Id>& getAllocator() const {
     return _allocator;
   }
 
@@ -261,7 +262,7 @@ class QueryExecutionContext
       _index->deltaTriplesManager().getCurrentLocatedTriplesSharedState()};
   QueryResultCache* const _subtreeCache;
   // allocators are copied but hold shared state
-  ad_utility::AllocatorWithLimit<Id> _allocator;
+  qlever::Allocator<Id> _allocator;
   QueryPlanningCostFactors _costFactors;
   SortPerformanceEstimator _sortPerformanceEstimator;
   std::function<void(std::string)> updateCallback_;

--- a/src/engine/SpatialJoin.cpp
+++ b/src/engine/SpatialJoin.cpp
@@ -42,7 +42,7 @@
 #include "global/ValueId.h"
 #include "parser/ParsedQuery.h"
 #include "rdfTypes/GeoSparqlHelpers.h"
-#include "util/AllocatorWithLimit.h"
+#include "util/Allocator.h"
 #include "util/Exception.h"
 #include "util/MemorySize/MemorySize.h"
 

--- a/src/engine/SpatialJoinAlgorithms.cpp
+++ b/src/engine/SpatialJoinAlgorithms.cpp
@@ -1067,7 +1067,7 @@ Result SpatialJoinAlgorithms::BoundingBoxAlgorithm() {
 
   // build rtree with one child
   bgi::rtree<Value, bgi::quadratic<16>, bgi::indexable<Value>,
-             bgi::equal_to<Value>, ad_utility::AllocatorWithLimit<Value>>
+             bgi::equal_to<Value>, qlever::Allocator<Value>>
       rtree(bgi::quadratic<16>{}, bgi::indexable<Value>{},
             bgi::equal_to<Value>{}, qec_->getAllocator());
   for (size_t i = 0; i < smallerResult->numRows(); i++) {

--- a/src/engine/SpatialJoinAlgorithms.h
+++ b/src/engine/SpatialJoinAlgorithms.h
@@ -25,6 +25,7 @@
 #include "engine/Result.h"
 #include "engine/SpatialJoin.h"
 #include "rdfTypes/GeoSparqlHelpers.h"
+#include "util/Allocator.h"
 #include "util/VectorWithMemoryLimit.h"
 
 namespace BoostGeometryNamespace {

--- a/src/engine/sparqlExpressions/SparqlExpressionTypes.cpp
+++ b/src/engine/sparqlExpressions/SparqlExpressionTypes.cpp
@@ -27,7 +27,7 @@ void PrintTo(const IdOrLocalVocabEntry& var, std::ostream* os) {
 EvaluationContext::EvaluationContext(
     const QueryExecutionContext& qec,
     const VariableToColumnMap& variableToColumnMap, IdTableView<0> inputTable,
-    const ad_utility::AllocatorWithLimit<Id>& allocator, LocalVocab& localVocab,
+    const qlever::Allocator<Id>& allocator, LocalVocab& localVocab,
     ad_utility::SharedCancellationHandle cancellationHandle, TimePoint deadline)
     : _qec{qec},
       _variableToColumnMap{variableToColumnMap},

--- a/src/engine/sparqlExpressions/SparqlExpressionTypes.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionTypes.h
@@ -16,6 +16,7 @@
 #include "engine/sparqlExpressions/SetOfIntervals.h"
 #include "global/Id.h"
 #include "rdfTypes/Variable.h"
+#include "util/Allocator.h"
 #include "util/AllocatorWithLimit.h"
 #include "util/HashSet.h"
 #include "util/TypeTraits.h"
@@ -120,7 +121,7 @@ struct EvaluationContext {
   std::vector<ColumnIndex> _columnsByWhichResultIsSorted;
 
   /// Let the expression evaluation also respect the memory limit.
-  ad_utility::AllocatorWithLimit<Id> _allocator;
+  qlever::Allocator<Id> _allocator;
 
   /// The local vocabulary of the input.
   LocalVocab& _localVocab;
@@ -158,7 +159,7 @@ struct EvaluationContext {
   EvaluationContext(const QueryExecutionContext& qec,
                     const VariableToColumnMap& variableToColumnMap,
                     IdTableView<0> inputTable,
-                    const ad_utility::AllocatorWithLimit<Id>& allocator,
+                    const qlever::Allocator<Id>& allocator,
                     LocalVocab& localVocab,
                     ad_utility::SharedCancellationHandle cancellationHandle,
                     TimePoint deadline);
@@ -167,7 +168,7 @@ struct EvaluationContext {
   EvaluationContext(const QueryExecutionContext& qec,
                     const VariableToColumnMap& variableToColumnMap,
                     const IdTable& inputTable,
-                    const ad_utility::AllocatorWithLimit<Id>& allocator,
+                    const qlever::Allocator<Id>& allocator,
                     LocalVocab& localVocab,
                     ad_utility::SharedCancellationHandle cancellationHandle,
                     TimePoint deadline)


### PR DESCRIPTION
Extend the qlever::Allocator<T> seam (introduced in the previous migration step) to the Engine and Parser modules so that all applicable dynamic allocations in those modules are routed through the configured pmr::memory_resource backend (either the classic AllocatorWithLimit or the new PMR-based allocator selected via QLEVER_ALLOCATOR_BACKEND=pmr).

Engine - allocator propagation chain
  src/engine/QueryExecutionContext.h / .cpp
    - Constructor parameter, _allocator member, and getAllocator() return type changed from ad_utility::AllocatorWithLimit<Id> to qlever::Allocator<Id>.
    - Added explicit #include "util/Allocator.h".

  src/engine/Operation.h
    - allocator() return type changed from ad_utility::AllocatorWithLimit<Id> to qlever::Allocator<Id>.
    - Downstream callers (JoinImpl.cpp, Join.cpp, QueryPlanner.cpp) require no edits: they call allocator() inherited from Operation and already obtain the correct qlever::Allocator type through the updated return type.

Engine - SpatialJoin modules
  src/engine/SpatialJoin.cpp
    - Replaced #include "util/AllocatorWithLimit.h" with #include "util/Allocator.h" to depend directly on the allocator seam rather than the legacy shim.

  src/engine/SpatialJoinAlgorithms.h
    - Added #include "util/Allocator.h" to express the direct dependency on the allocator seam explicitly (previously available only transitively via VectorWithMemoryLimit.h).

  src/engine/SpatialJoinAlgorithms.cpp
    - R-tree template parameter changed from ad_utility::AllocatorWithLimit<Value> to qlever::Allocator<Value> so that the Boost.Geometry R-tree is constructed via the configured memory resource.

Parser - sparqlParser dependency
  src/engine/sparqlExpressions/SparqlExpressionTypes.h / .cpp
    - EvaluationContext::_allocator member type changed from ad_utility::AllocatorWithLimit<Id> to qlever::Allocator<Id>.
    - Both EvaluationContext constructor signatures updated accordingly.
    - Added #include "util/Allocator.h".
    - This is the key dependency of the sparqlParser module: the SparqlQleverVisitor creates EvaluationContext objects whose allocations now route through the configured pmr::memory_resource.

Depends-On: https://github.com/ad-freiburg/qlever/pull/3113