### PR TITLE
pmr memory resource usage

### DIFF
--- a/src/engine/CartesianProductJoin.cpp
+++ b/src/engine/CartesianProductJoin.cpp
@@ -11,6 +11,7 @@
 #include "engine/CartesianProductJoin.h"
 
 #include "engine/CallFixedSize.h"
+#include "util/AllocatorTypes.h"
 #include "util/Views.h"
 
 namespace {
@@ -487,9 +488,12 @@ CartesianProductJoin::makeDistinctTree(
   auto newChildren =
       ::ranges::views::zip(children_,
                            perChildDistinctIndices(distinctIndices)) |
-      ql::views::transform([](const auto& childAndIndices) {
+      ql::views::transform([this](const auto& childAndIndices) {
         const auto& [child, childIndices] = childAndIndices;
-        return QueryExecutionTree::createDistinctTree(child, childIndices);
+        return QueryExecutionTree::createDistinctTree(
+            child, qlever::vector<ColumnIndex>(childIndices.begin(),
+                                               childIndices.end(),
+                                               allocator()));
       }) |
       ::ranges::to<Children>();
   return ad_utility::makeExecutionTree<CartesianProductJoin>(

--- a/src/engine/CountAvailablePredicates.cpp
+++ b/src/engine/CountAvailablePredicates.cpp
@@ -9,6 +9,7 @@
 #include "engine/IndexScan.h"
 #include "global/Pattern.h"
 #include "global/RuntimeParameters.h"
+#include "util/AllocatorTypes.h"
 #include "util/ParallelExecutor.h"
 
 // _____________________________________________________________________________
@@ -17,8 +18,10 @@ CountAvailablePredicates::CountAvailablePredicates(
     size_t subjectColumnIndex, Variable predicateVariable,
     Variable countVariable)
     : Operation(qec),
-      subtree_(QueryExecutionTree::createSortedTree(std::move(subtree),
-                                                    {subjectColumnIndex})),
+      subtree_(QueryExecutionTree::createSortedTree(
+          std::move(subtree),
+          qlever::vector<ColumnIndex>({subjectColumnIndex},
+                                      qec->getAllocator()))),
       subjectColumnIndex_(subjectColumnIndex),
       predicateVariable_(std::move(predicateVariable)),
       countVariable_(std::move(countVariable)) {}

--- a/src/engine/ExistsJoin.cpp
+++ b/src/engine/ExistsJoin.cpp
@@ -15,6 +15,7 @@
 #include "util/ChunkedForLoop.h"
 #include "util/JoinAlgorithms/IndexNestedLoopJoin.h"
 #include "util/JoinAlgorithms/JoinAlgorithms.h"
+#include "util/AllocatorWithLimit.h"
 #include "util/VectorWithMemoryLimit.h"
 
 // _____________________________________________________________________________
@@ -258,7 +259,7 @@ std::shared_ptr<QueryExecutionTree> ExistsJoin::addExistsJoinsToSubtree(
     // the way `QueryExecutionTree::getJoinColumns` expects, so that
     // `ExistsJoin`'s constructor does not have to add an extra `Sort`.
     pq._isInternalSort = IsInternalSort::True;
-    pq._orderBy = subtree->getVariableColumns() | ql::views::keys |
+    auto orderBy = subtree->getVariableColumns() | ql::views::keys |
                   ql::views::filter([&visibleVars = pq.getVisibleVariables()](
                                         const Variable& variable) {
                     return ad_utility::contains(visibleVars, variable);
@@ -267,6 +268,8 @@ std::shared_ptr<QueryExecutionTree> ExistsJoin::addExistsJoinsToSubtree(
                     return VariableOrderKey{variable};
                   }) |
                   ::ranges::to<std::vector>;
+    pq._orderBy = qlever::vector<VariableOrderKey>(
+        orderBy.begin(), orderBy.end(), qec->getAllocator());
     // Ensure we have the same ordering `QueryExecutionTree::getJoinColumns`
     // would produce.
     ql::ranges::sort(pq._orderBy, {},

--- a/src/engine/ExistsJoin.h
+++ b/src/engine/ExistsJoin.h
@@ -7,6 +7,7 @@
 
 #include "engine/Operation.h"
 #include "engine/QueryExecutionTree.h"
+#include "util/AllocatorTypes.h"
 
 // The implementation of an "EXISTS join", which we use to realize the semantics
 // of the SPARQL `EXISTS` function. The join takes two subtrees as input, and
@@ -17,7 +18,7 @@ class ExistsJoin : public Operation {
   // The left and right child.
   std::shared_ptr<QueryExecutionTree> left_;
   std::shared_ptr<QueryExecutionTree> right_;
-  std::vector<std::array<ColumnIndex, 2>> joinColumns_;
+  qlever::vector<std::array<ColumnIndex, 2>> joinColumns_;
 
   // The variable of the added (Boolean) result column.
   Variable existsVariable_;

--- a/src/engine/ExternalValues.cpp
+++ b/src/engine/ExternalValues.cpp
@@ -25,14 +25,14 @@ ExternalValues::ExternalValues(QueryExecutionContext* qec,
                                const parsedQuery::ExternalValuesQuery& query)
     : ExternalValues(
           qec,
-          [&query]() {
+          [&query, qec]() {
             // Check that all variables are unique.
             ad_utility::HashSet<Variable> uniqueVars(query.variables_.begin(),
                                                      query.variables_.end());
             AD_CONTRACT_CHECK(
                 uniqueVars.size() == query.variables_.size(),
                 "Variables in external values query must be unique");
-            parsedQuery::SparqlValues values;
+            parsedQuery::SparqlValues values{qec->getAllocator()};
             values._variables = query.variables_;
             return values;
           }(),

--- a/src/engine/GraphStoreProtocol.cpp
+++ b/src/engine/GraphStoreProtocol.cpp
@@ -106,7 +106,8 @@ ad_utility::triple_component::Iri GraphStoreProtocol::generateNewGraphIri() {
 
 // ____________________________________________________________________________
 ParsedQuery GraphStoreProtocol::transformGet(
-    const GraphOrDefault& graph, const EncodedIriManager* encodedIriManager) {
+    const GraphOrDefault& graph, const EncodedIriManager* encodedIriManager,
+    qlever::Allocator<Id> allocator) {
   // Construct the parsed query from its short equivalent SPARQL Update
   // string. This is easier and also provides e.g. the `_originalString` field.
   auto getQuery = [&graph]() -> std::string {
@@ -118,13 +119,15 @@ ParsedQuery GraphStoreProtocol::transformGet(
       return "CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }";
     }
   };
-  return SparqlParser::parseQuery(encodedIriManager, getQuery());
+  return SparqlParser::parseQuery(encodedIriManager, getQuery(), {},
+                                  std::move(allocator));
 }
 
 // ____________________________________________________________________________
 ParsedQuery GraphStoreProtocol::transformHead(
-    const GraphOrDefault& graph, const EncodedIriManager* encodedIriManager) {
-  auto pq = transformGet(graph, encodedIriManager);
+    const GraphOrDefault& graph, const EncodedIriManager* encodedIriManager,
+    qlever::Allocator<Id> allocator) {
+  auto pq = transformGet(graph, encodedIriManager, std::move(allocator));
   // HEAD does the same as GET except that the response has no body.
   // Overwrite the body to be empty.
   pq.responseMiddleware_ =
@@ -139,7 +142,8 @@ ParsedQuery GraphStoreProtocol::transformHead(
 
 // ____________________________________________________________________________
 ParsedQuery GraphStoreProtocol::transformDelete(const GraphOrDefault& graph,
-                                                const Index& index) {
+                                                const Index& index,
+                                                qlever::Allocator<Id> allocator) {
   // Construct the parsed update from its short equivalent SPARQL Update string.
   // This is easier and also provides e.g. the `_originalString` field.
   auto getUpdate = [&graph]() -> std::string {
@@ -151,7 +155,8 @@ ParsedQuery GraphStoreProtocol::transformDelete(const GraphOrDefault& graph,
     }
   };
   auto update = ad_utility::getSingleElement(SparqlParser::parseUpdate(
-      index.getBlankNodeManager(), &index.encodedIriManager(), getUpdate()));
+      index.getBlankNodeManager(), &index.encodedIriManager(), getUpdate(),
+      {}, std::move(allocator)));
   // DELETE must return 404 if the graph being deleted does not exist (GSP 5.4).
   // With implicit graph existence a graph existed iff triples were actually
   // deleted.

--- a/src/engine/GraphStoreProtocol.h
+++ b/src/engine/GraphStoreProtocol.h
@@ -13,6 +13,7 @@
 #include "parser/Quads.h"
 #include "parser/RdfParser.h"
 #include "parser/SparqlParser.h"
+#include "util/AllocatorTypes.h"
 #include "util/http/HttpUtils.h"
 #include "util/http/ResponseMiddleware.h"
 #include "util/http/UrlParser.h"
@@ -135,7 +136,7 @@ class GraphStoreProtocol {
   CPP_template_2(typename RequestT)(
       requires ad_utility::httpUtils::HttpRequest<RequestT>) static ParsedQuery
       transformPost(const RequestT& rawRequest, const GraphOrDefault& graph,
-                    const Index& index) {
+                    const Index& index, qlever::Allocator<Id> allocator) {
     throwIfRequestBodyEmpty(rawRequest);
     auto triples =
         parseTriples(rawRequest.body(), extractMediatype(rawRequest));
@@ -146,7 +147,7 @@ class GraphStoreProtocol {
     auto convertedTriples =
         convertTriples(effectiveGraph, std::move(triples), bn);
     updateClause::GraphUpdate up{std::move(convertedTriples), {}};
-    ParsedQuery res;
+    ParsedQuery res{std::move(allocator)};
     res._clause = parsedQuery::UpdateClause{std::move(up)};
     if (insertIntoNewGraph) {
       AD_CORRECTNESS_CHECK(
@@ -168,14 +169,14 @@ class GraphStoreProtocol {
   CPP_template_2(typename RequestT)(
       requires ad_utility::httpUtils::HttpRequest<RequestT>) static ParsedQuery
       transformTsop(const RequestT& rawRequest, const GraphOrDefault& graph,
-                    const Index& index) {
+                    const Index& index, qlever::Allocator<Id> allocator) {
     throwIfRequestBodyEmpty(rawRequest);
     auto triples =
         parseTriples(rawRequest.body(), extractMediatype(rawRequest));
     Quads::BlankNodeAdder bn{{}, {}, index.getBlankNodeManager()};
     auto convertedTriples = convertTriples(graph, std::move(triples), bn);
     updateClause::GraphUpdate up{{}, std::move(convertedTriples)};
-    ParsedQuery res;
+    ParsedQuery res{std::move(allocator)};
     res._clause = parsedQuery::UpdateClause{std::move(up)};
     res._originalString = truncatedStringRepresentation("TSOP", rawRequest);
     return res;
@@ -184,21 +185,24 @@ class GraphStoreProtocol {
   // Transform a SPARQL Graph Store Protocol GET to an equivalent ParsedQuery
   // which is a SPARQL Query.
   static ParsedQuery transformGet(const GraphOrDefault& graph,
-                                  const EncodedIriManager* encodedIriManager);
+                                  const EncodedIriManager* encodedIriManager,
+                                  qlever::Allocator<Id> allocator);
   FRIEND_TEST(GraphStoreProtocolTest, transformGet);
 
   // Transform a SPARQL Graph Store Protocol HEAD to an equivalent
   // `ParsedQuery`. The response is the same as for GET but without the body.
   static ParsedQuery transformHead(const GraphOrDefault& graph,
-                                   const EncodedIriManager* encodedIriManager);
+                                   const EncodedIriManager* encodedIriManager,
+                                   qlever::Allocator<Id> allocator);
 
   // Transform a SPARQL Graph Store Protocol PUT to equivalent ParsedQueries
   // which are SPARQL Updates.
   CPP_template_2(typename RequestT)(
-      requires ad_utility::httpUtils::HttpRequest<RequestT>) static std::
+      requires ad_utility::httpUtils::HttpRequest<RequestT>) static qlever::
       vector<ParsedQuery> transformPut(const RequestT& rawRequest,
                                        const GraphOrDefault& graph,
-                                       const Index& index) {
+                                       const Index& index,
+                                       qlever::Allocator<Id> allocator) {
     std::string stringRepresentation =
         truncatedStringRepresentation("PUT", rawRequest);
 
@@ -216,7 +220,8 @@ class GraphStoreProtocol {
     };
 
     ParsedQuery drop = ad_utility::getSingleElement(SparqlParser::parseUpdate(
-        index.getBlankNodeManager(), &index.encodedIriManager(), getDrop()));
+        index.getBlankNodeManager(), &index.encodedIriManager(), getDrop(),
+        {}, allocator));
     drop._originalString = stringRepresentation;
 
     auto triples =
@@ -224,7 +229,7 @@ class GraphStoreProtocol {
     Quads::BlankNodeAdder bn{{}, {}, index.getBlankNodeManager()};
     auto convertedTriples = convertTriples(graph, std::move(triples), bn);
     updateClause::GraphUpdate up{std::move(convertedTriples), {}};
-    ParsedQuery insertData;
+    ParsedQuery insertData{allocator};
     // Interpretation of the very vague GSP 5.3:
     // - 201 Created if a new graph is created
     // - 200 Ok or 204 No Content if an existing graph is modified
@@ -245,44 +250,61 @@ class GraphStoreProtocol {
         });
     insertData._clause = parsedQuery::UpdateClause{std::move(up)};
     insertData._originalString = stringRepresentation;
-    return {std::move(drop), std::move(insertData)};
+    return qlever::vector<ParsedQuery>(
+        {std::move(drop), std::move(insertData)}, allocator);
   }
   FRIEND_TEST(GraphStoreProtocolTest, transformPut);
 
   // Transform a SPARQL Graph Store Protocol DELETE to equivalent ParsedQueries
   // which are SPARQL Updates.
   static ParsedQuery transformDelete(const GraphOrDefault& graph,
-                                     const Index& index);
+                                     const Index& index,
+                                     qlever::Allocator<Id> allocator);
   FRIEND_TEST(GraphStoreProtocolTest, transformDelete);
 
  public:
   // Every Graph Store Protocol request has equivalent SPARQL Query or Update.
   // Transform the Graph Store Protocol request into it's equivalent Query or
-  // Update.
+  // Update. `allocator` is the real allocator that dynamic allocations while
+  // parsing/transforming should be routed through; there is no implicit
+  // unlimited-allocator fallback.
   CPP_template_2(typename RequestT)(
-      requires ad_utility::httpUtils::HttpRequest<RequestT>) static std::
+      requires ad_utility::httpUtils::HttpRequest<RequestT>) static qlever::
       vector<ParsedQuery> transformGraphStoreProtocol(
           ad_utility::url_parser::sparqlOperation::GraphStoreOperation
               operation,
-          const RequestT& rawRequest, const Index& index) {
+          const RequestT& rawRequest, const Index& index,
+          qlever::Allocator<Id> allocator) {
     ad_utility::url_parser::ParsedUrl parsedUrl =
         ad_utility::url_parser::parseRequestTarget(rawRequest.target());
     using enum boost::beast::http::verb;
     std::string_view method = rawRequest.method_string();
     if (method == "GET") {
-      return {transformGet(operation.graph_, &index.encodedIriManager())};
+      return qlever::vector<ParsedQuery>(
+          {transformGet(operation.graph_, &index.encodedIriManager(),
+                       allocator)},
+          allocator);
     } else if (method == "PUT") {
-      return transformPut(rawRequest, operation.graph_, index);
+      return transformPut(rawRequest, operation.graph_, index,
+                          std::move(allocator));
     } else if (method == "DELETE") {
-      return {transformDelete(operation.graph_, index)};
+      return qlever::vector<ParsedQuery>(
+          {transformDelete(operation.graph_, index, allocator)}, allocator);
     } else if (method == "POST") {
-      return {transformPost(rawRequest, operation.graph_, index)};
+      return qlever::vector<ParsedQuery>(
+          {transformPost(rawRequest, operation.graph_, index, allocator)},
+          allocator);
     } else if (method == "TSOP") {
       // TSOP (`POST` backwards) does the inverse of `POST`. It does a `DELETE
       // DATA` of the payload.
-      return {transformTsop(rawRequest, operation.graph_, index)};
+      return qlever::vector<ParsedQuery>(
+          {transformTsop(rawRequest, operation.graph_, index, allocator)},
+          allocator);
     } else if (method == "HEAD") {
-      return {transformHead(operation.graph_, &index.encodedIriManager())};
+      return qlever::vector<ParsedQuery>(
+          {transformHead(operation.graph_, &index.encodedIriManager(),
+                        allocator)},
+          allocator);
     } else if (method == "PATCH") {
       throwNotYetImplementedHTTPMethod("PATCH");
     } else {

--- a/src/engine/GroupByImpl.cpp
+++ b/src/engine/GroupByImpl.cpp
@@ -401,9 +401,9 @@ std::vector<ColumnIndex> GroupByImpl::resultSortedOn() const {
   return sortedOn;
 }
 
-std::vector<ColumnIndex> GroupByImpl::computeSortColumns(
+qlever::vector<ColumnIndex> GroupByImpl::computeSortColumns(
     const QueryExecutionTree* subtree) {
-  vector<ColumnIndex> cols;
+  qlever::vector<ColumnIndex> cols{allocator()};
   // If we have an implicit GROUP BY, where the entire input is a single group,
   // no sorting needs to be done.
   if (_groupByVariables.empty()) {

--- a/src/engine/GroupByImpl.h
+++ b/src/engine/GroupByImpl.h
@@ -24,6 +24,7 @@
 #include "engine/sparqlExpressions/SparqlExpressionPimpl.h"
 #include "engine/sparqlExpressions/SparqlExpressionValueGetters.h"
 #include "parser/Alias.h"
+#include "util/AllocatorTypes.h"
 #include "util/TypeIdentity.h"
 
 // Block size for when using the hash map optimization
@@ -88,7 +89,8 @@ class GroupByImpl : public Operation {
    * @param subtree The QueryExecutionTree that contains the operations
    *                  creating the sorting operation inputs.
    */
-  vector<ColumnIndex> computeSortColumns(const QueryExecutionTree* subtree);
+  qlever::vector<ColumnIndex> computeSortColumns(
+      const QueryExecutionTree* subtree);
 
   vector<QueryExecutionTree*> getChildren() override {
     return {_subtree.get()};

--- a/src/engine/JoinHelpers.h
+++ b/src/engine/JoinHelpers.h
@@ -13,6 +13,7 @@
 #include <optional>
 #include <vector>
 
+#include "backports/span.h"
 #include "engine/AddCombinedRowToTable.h"
 #include "engine/IndexScan.h"
 #include "engine/Operation.h"
@@ -228,7 +229,7 @@ inline bool doesJoinProduceGuaranteedGraphValuesOrUndef(
 // Helper function to check if any of the join columns could potentially contain
 // undef values.
 inline bool joinColumnsAreAlwaysDefined(
-    const std::vector<std::array<ColumnIndex, 2>>& joinColumns,
+    ql::span<const std::array<ColumnIndex, 2>> joinColumns,
     const std::shared_ptr<QueryExecutionTree>& left,
     const std::shared_ptr<QueryExecutionTree>& right) {
   auto alwaysDefHelper = [](const auto& tree, ColumnIndex index) {
@@ -262,7 +263,7 @@ inline std::shared_ptr<const Result> computeResultSkipChild(
 inline bool rightIndexNestedLoopJoinIsPossible(
     const std::shared_ptr<QueryExecutionTree>& left,
     const std::shared_ptr<QueryExecutionTree>& right,
-    const std::vector<std::array<ColumnIndex, 2>>& matchedColumns) {
+    ql::span<const std::array<ColumnIndex, 2>> matchedColumns) {
   auto sort = std::dynamic_pointer_cast<Sort>(left->getRootOperation());
   return sort && left->getSizeEstimate() >= right->getSizeEstimate() &&
          joinColumnsAreAlwaysDefined(matchedColumns, left, right);

--- a/src/engine/JoinImpl.cpp
+++ b/src/engine/JoinImpl.cpp
@@ -31,6 +31,8 @@
 #include "util/Algorithm.h"
 #include "util/Exception.h"
 #include "util/Generators.h"
+#include "util/Allocator.h"
+#include "util/AllocatorTypes.h"
 #include "util/HashMap.h"
 #include "util/Iterators.h"
 #include "util/JoinAlgorithms/JoinAlgorithms.h"
@@ -47,12 +49,16 @@ JoinImpl::JoinImpl(QueryExecutionContext* qec,
                    ColumnIndex t1JoinCol, ColumnIndex t2JoinCol,
                    bool keepJoinColumn,
                    bool allowSwappingChildrenOnlyForTesting)
-    : Operation(qec), keepJoinColumn_{keepJoinColumn} {
+    : Operation(qec),
+      multiplicities_{allocator()},
+      keepJoinColumn_{keepJoinColumn} {
   AD_CONTRACT_CHECK(t1 && t2);
   // Currently all join algorithms require both inputs to be sorted, so we
   // enforce the sorting here.
-  t1 = QueryExecutionTree::createSortedTree(std::move(t1), {t1JoinCol});
-  t2 = QueryExecutionTree::createSortedTree(std::move(t2), {t2JoinCol});
+  t1 = QueryExecutionTree::createSortedTree(
+      std::move(t1), qlever::vector<ColumnIndex>({t1JoinCol}, allocator()));
+  t2 = QueryExecutionTree::createSortedTree(
+      std::move(t2), qlever::vector<ColumnIndex>({t2JoinCol}, allocator()));
 
   // Make the order of the two subtrees deterministic. That way, queries that
   // are identical except for the order of the join operands, are easier to
@@ -189,10 +195,11 @@ Result JoinImpl::computeResult(bool requestLaziness) {
 
 // _____________________________________________________________________________
 VariableToColumnMap JoinImpl::computeVariableToColumnMap() const {
+  std::array<std::array<ColumnIndex, 2>, 1> joinColumns{
+      {{leftJoinCol_, rightJoinCol_}}};
   return makeVarToColMapForJoinOperation(
-      left_->getVariableColumns(), right_->getVariableColumns(),
-      {{leftJoinCol_, rightJoinCol_}}, BinOpType::Join, left_->getResultWidth(),
-      keepJoinColumn_);
+      left_->getVariableColumns(), right_->getVariableColumns(), joinColumns,
+      BinOpType::Join, left_->getResultWidth(), keepJoinColumn_);
 }
 
 // _____________________________________________________________________________
@@ -430,7 +437,8 @@ Result JoinImpl::lazyJoin(std::shared_ptr<const Result> a,
 template <int L_WIDTH, int R_WIDTH, int OUT_WIDTH>
 void JoinImpl::hashJoinImpl(const IdTable& dynA, ColumnIndex jc1,
                             const IdTable& dynB, ColumnIndex jc2,
-                            IdTable* dynRes) {
+                            IdTable* dynRes,
+                            const qlever::Allocator<Id>& allocator) {
   const IdTableView<L_WIDTH> a = dynA.asStaticView<L_WIDTH>();
   const IdTableView<R_WIDTH> b = dynB.asStaticView<R_WIDTH>();
 
@@ -449,13 +457,26 @@ void JoinImpl::hashJoinImpl(const IdTable& dynA, ColumnIndex jc1,
 
   // Puts the rows of the given table into a hash map, with the value of
   // the join column of a row as the key, and returns the hash map.
-  auto idTableToHashMap = [](const auto& table, const ColumnIndex jc) {
+  auto idTableToHashMap = [&allocator](const auto& table,
+                                       const ColumnIndex jc) {
     // This declaration works, because generic lambdas are just syntactic sugar
     // for templates.
     using Table = std::decay_t<decltype(table)>;
-    ad_utility::HashMap<Id, std::vector<typename Table::row_type>> map;
+    using RowType = typename Table::row_type;
+    // Note: We use parenthesized (rather than brace) initialization, because
+    // `std::unordered_map`'s single-allocator constructor is not selected
+    // for brace-init in this context. The implicit converting constructor of
+    // `qlever::Allocator` takes care of adapting the allocator's value type.
+    // Note: The bucket lists are `qlever::vector<RowType>`. Since
+    // `PmrAllocator<T>` has no default constructor, we cannot rely on
+    // `map[...]` (which default-constructs the mapped value on first
+    // access); instead we use `try_emplace` to explicitly construct a new,
+    // allocator-aware bucket only when the key is not yet present.
+    ad_utility::HashMapWithMemoryLimit<Id, qlever::vector<RowType>> map(
+        allocator);
     for (const auto& row : table) {
-      map[row[jc]].push_back(row);
+      map.try_emplace(row[jc], qlever::vector<RowType>{allocator})
+          .first->second.push_back(row);
     }
     return map;
   };
@@ -525,11 +546,13 @@ void JoinImpl::hashJoinImpl(const IdTable& dynA, ColumnIndex jc1,
 
 // ______________________________________________________________________________
 void JoinImpl::hashJoin(const IdTable& dynA, ColumnIndex jc1,
-                        const IdTable& dynB, ColumnIndex jc2, IdTable* dynRes) {
+                        const IdTable& dynB, ColumnIndex jc2, IdTable* dynRes,
+                        const qlever::Allocator<Id>& allocator) {
   ad_utility::callFixedSizeVi(
       (std::array{dynA.numColumns(), dynB.numColumns(), dynRes->numColumns()}),
       [&](auto l, auto r, auto o) {
-        return JoinImpl::hashJoinImpl<l, r, o>(dynA, jc1, dynB, jc2, dynRes);
+        return JoinImpl::hashJoinImpl<l, r, o>(dynA, jc1, dynB, jc2, dynRes,
+                                               allocator);
       });
 }
 
@@ -725,8 +748,9 @@ Result JoinImpl::createEmptyResult() const {
 
 // _____________________________________________________________________________
 ad_utility::JoinColumnMapping JoinImpl::getJoinColumnMapping() const {
-  return ad_utility::JoinColumnMapping{{{leftJoinCol_, rightJoinCol_}},
-                                       left_->getResultWidth(),
+  std::array<std::array<ColumnIndex, 2>, 1> joinColumns{
+      {{leftJoinCol_, rightJoinCol_}}};
+  return ad_utility::JoinColumnMapping{joinColumns, left_->getResultWidth(),
                                        right_->getResultWidth(),
                                        keepJoinColumn_};
 }

--- a/src/engine/JoinImpl.h
+++ b/src/engine/JoinImpl.h
@@ -17,6 +17,8 @@
 #include "engine/IndexScan.h"
 #include "engine/Operation.h"
 #include "engine/QueryExecutionTree.h"
+#include "util/Allocator.h"
+#include "util/AllocatorTypes.h"
 #include "util/JoinAlgorithms/JoinColumnMapping.h"
 #include "util/TypeTraits.h"
 
@@ -33,7 +35,7 @@ class JoinImpl : public Operation {
   bool sizeEstimateComputed_;
   size_t sizeEstimate_;
 
-  std::vector<float> multiplicities_;
+  qlever::vector<float> multiplicities_;
 
   // If set to false, the join column will not be part of the result.
   bool keepJoinColumn_ = true;
@@ -117,7 +119,8 @@ class JoinImpl : public Operation {
    * Otherwise it is not sorted.
    **/
   static void hashJoin(const IdTable& dynA, ColumnIndex jc1,
-                       const IdTable& dynB, ColumnIndex jc2, IdTable* dynRes);
+                       const IdTable& dynB, ColumnIndex jc2, IdTable* dynRes,
+                       const qlever::Allocator<Id>& allocator);
 
   std::string getCacheKeyImpl() const override;
   std::unique_ptr<Operation> cloneImpl() const override;
@@ -185,7 +188,8 @@ class JoinImpl : public Operation {
   template <int L_WIDTH, int R_WIDTH, int OUT_WIDTH>
   static void hashJoinImpl(const IdTable& dynA, ColumnIndex jc1,
                            const IdTable& dynB, ColumnIndex jc2,
-                           IdTable* dynRes);
+                           IdTable* dynRes,
+                           const qlever::Allocator<Id>& allocator);
 
   // Commonly used code for the various known-to-be-empty cases.
   Result createEmptyResult() const;

--- a/src/engine/MaterializedViews.cpp
+++ b/src/engine/MaterializedViews.cpp
@@ -422,9 +422,12 @@ const Variable& MaterializedView::dummyObject() {
 }
 
 // _____________________________________________________________________________
-MaterializedView::MaterializedView(std::string onDiskBase, std::string name)
+MaterializedView::MaterializedView(std::string onDiskBase, std::string name,
+                                   qlever::Allocator<Id> allocator)
     : onDiskBase_{std::move(onDiskBase)},
       name_{std::move(name)},
+      permutation_{std::make_shared<Permutation>(Permutation::Enum::SPO,
+                                                 allocator, name_)},
       locatedTriplesState_{makeEmptyLocatedTriplesState()} {
   AD_CORRECTNESS_CHECK(onDiskBase_ != "",
                        "The index base filename was not set.");
@@ -490,7 +493,8 @@ MaterializedView::MaterializedView(std::string onDiskBase, std::string name)
     // interested in analyzing the query structure, not in converting its
     // components to `ValueId`s.
     EncodedIriManager e;
-    parsedQuery_ = SparqlParser::parseQuery(&e, originalQuery_.value(), {});
+    parsedQuery_ =
+        SparqlParser::parseQuery(&e, originalQuery_.value(), {}, allocator);
 
     // Compute the `BIND`-to-column map.
     coveredBinds_ = materializedViewsQueryAnalysis::extractBindExpressions(
@@ -528,7 +532,8 @@ MaterializedViewsManager::loadViewIntoLockedState(
   if (auto it = state.views_.find(name); it != state.views_.end()) {
     return it->second;
   }
-  auto view = std::make_shared<MaterializedView>(onDiskBase_, name);
+  auto view =
+      std::make_shared<MaterializedView>(onDiskBase_, name, allocator_);
   view->connectPermutationBackReference();
   state.views_.insert({name, view});
   // If we would analyze the view at the time of writing and (de)serialize an
@@ -710,6 +715,7 @@ void MaterializedView::throwIfVariableUsedTwice(
 
 // _____________________________________________________________________________
 SparqlTripleSimple MaterializedView::makeScanConfig(
+    QueryExecutionContext* qec,
     const parsedQuery::MaterializedViewQuery& viewQuery) const {
   AD_CORRECTNESS_CHECK(viewQuery.viewName_ == name_);
   if (viewQuery.childGraphPattern_.has_value()) {
@@ -725,7 +731,7 @@ SparqlTripleSimple MaterializedView::makeScanConfig(
   // contains multiple instances of `MaterializedViewQuery`.
   TripleComponent p{dummyPredicate()};
   TripleComponent o{dummyObject()};
-  AdditionalScanColumns additionalCols;
+  AdditionalScanColumns additionalCols{qec->getAllocator()};
 
   // Assemble which columns should be bound to which variables
   ad_utility::HashSet<Variable> variablesSeen;
@@ -820,7 +826,7 @@ std::shared_ptr<IndexScan> MaterializedView::makeIndexScan(
   // by the user. Therefore despite using hard-coded placeholder variable names,
   // no join occurs if multiple materialized views are requested in a single
   // query.
-  auto scanTriple = makeScanConfig(viewQuery);
+  auto scanTriple = makeScanConfig(qec, viewQuery);
   return qec->makeShared<IndexScan>(
       qec, permutation_, LocatedTriplesSharedState{locatedTriplesState_},
       std::move(scanTriple), IndexScan::Graphs::All(), std::nullopt,
@@ -834,7 +840,7 @@ std::shared_ptr<IndexScan> MaterializedView::makeIndexScan(
   TripleComponent s{dummySubject()};
   TripleComponent p{dummyPredicate()};
   TripleComponent o{dummyObject()};
-  AdditionalScanColumns additionalCols;
+  AdditionalScanColumns additionalCols{qec->getAllocator()};
   for (const auto& [v, i] : varToCol) {
     // This is only correct if the `QueryExecutionTree` uses the cache key and
     // `VariableToColumnMap` of the new `IndexScan`.
@@ -939,7 +945,8 @@ MaterializedView::computeCacheKey(
   // The query needs to be parsed again to take the `EncodedIriManager` into
   // account.
   auto parsedQuery =
-      SparqlParser::parseQuery(&encodedIriManager, originalQuery_.value());
+      SparqlParser::parseQuery(&encodedIriManager, originalQuery_.value(), {},
+                               qec.getAllocator());
   const auto& viewCols = variableToColumnMap();
 
   auto planAndComputeMapping =

--- a/src/engine/MaterializedViews.h
+++ b/src/engine/MaterializedViews.h
@@ -29,6 +29,8 @@
 #include "parser/MaterializedViewQuery.h"
 #include "parser/ParsedQuery.h"
 #include "parser/SparqlTriple.h"
+#include "util/Allocator.h"
+#include "util/AllocatorTypes.h"
 #include "util/HashMap.h"
 #include "util/Synchronized.h"
 
@@ -169,8 +171,7 @@ class MaterializedView : public std::enable_shared_from_this<MaterializedView> {
  private:
   std::string onDiskBase_;
   std::string name_;
-  std::shared_ptr<Permutation> permutation_{std::make_shared<Permutation>(
-      Permutation::Enum::SPO, ad_utility::makeUnlimitedAllocator<Id>(), name_)};
+  std::shared_ptr<Permutation> permutation_;
   VariableToColumnMap varToColMap_;
   std::shared_ptr<LocatedTriplesState> locatedTriplesState_;
   std::optional<std::string> originalQuery_;
@@ -192,8 +193,11 @@ class MaterializedView : public std::enable_shared_from_this<MaterializedView> {
  public:
   // Load a materialized view from disk given the filename components. The
   // constructor will throw an exception if the name is invalid or the view does
-  // not exist.
-  MaterializedView(std::string onDiskBase, std::string name);
+  // not exist. `allocator` is the real allocator that the view's permutation
+  // and internal query analysis are routed through; there is no implicit
+  // unlimited-allocator fallback.
+  MaterializedView(std::string onDiskBase, std::string name,
+                   qlever::Allocator<Id> allocator);
 
   // Connect the permutation's back-reference to this view. Must be called
   // after the `MaterializedView` is managed by a `shared_ptr`.
@@ -240,7 +244,10 @@ class MaterializedView : public std::enable_shared_from_this<MaterializedView> {
   // Given a `MaterializedViewQuery` obtained from a special `SERVICE` or
   // predicate, compute the `SparqlTripleSimple` to be passed to the constructor
   // of `IndexScan` such that the columns requested by the user are returned.
+  // `qec` is used to obtain the (memory-limited) allocator for the additional
+  // scan columns.
   SparqlTripleSimple makeScanConfig(
+      QueryExecutionContext* qec,
       const parsedQuery::MaterializedViewQuery& viewQuery) const;
 
   // Helpers for checking metadata-dependent invariants of
@@ -313,6 +320,10 @@ class MaterializedViewsManager {
  private:
   std::string onDiskBase_;
 
+  // The real allocator that views loaded by this manager are routed through
+  // (see `MaterializedView`'s own `allocator` parameter).
+  qlever::Allocator<Id> allocator_;
+
   // Set by `retireOnDiskFiles` (see there) once the files of the index this
   // manager belongs to have been moved away by an index rebuild, after which
   // this manager must not create or delete any file under `onDiskBase_`
@@ -372,9 +383,12 @@ class MaterializedViewsManager {
       const QueryExecutionContext* qec) const;
 
  public:
-  MaterializedViewsManager() = default;
-  explicit MaterializedViewsManager(std::string onDiskBase)
-      : onDiskBase_{std::move(onDiskBase)} {}
+  MaterializedViewsManager() = delete;
+  explicit MaterializedViewsManager(qlever::Allocator<Id> allocator)
+      : allocator_{std::move(allocator)} {}
+  MaterializedViewsManager(std::string onDiskBase,
+                           qlever::Allocator<Id> allocator)
+      : onDiskBase_{std::move(onDiskBase)}, allocator_{std::move(allocator)} {}
 
   // For use with the default constructor: set the index basename after creation
   // of the `MaterializedViewsManager`. This should only be called once and

--- a/src/engine/Minus.cpp
+++ b/src/engine/Minus.cpp
@@ -21,7 +21,7 @@ using std::string;
 Minus::Minus(QueryExecutionContext* qec,
              std::shared_ptr<QueryExecutionTree> left,
              std::shared_ptr<QueryExecutionTree> right)
-    : Operation{qec} {
+    : Operation{qec}, _matchedColumns{qec->getAllocator()} {
   std::tie(_left, _right, _matchedColumns) =
       QueryExecutionTree::getSortedSubtreesAndJoinColumns(std::move(left),
                                                           std::move(right));
@@ -169,7 +169,7 @@ IdTable Minus::copyMatchingRows(
 // _____________________________________________________________________________
 IdTable Minus::computeMinus(
     const IdTableView<0>& left, const IdTableView<0>& right,
-    const std::vector<std::array<ColumnIndex, 2>>& joinColumns) const {
+    ql::span<const std::array<ColumnIndex, 2>> joinColumns) const {
   if (left.empty()) {
     return IdTable{getResultWidth(), getExecutionContext()->getAllocator()};
   }

--- a/src/engine/Minus.h
+++ b/src/engine/Minus.h
@@ -8,8 +8,10 @@
 #include <array>
 #include <vector>
 
+#include "backports/span.h"
 #include "engine/Operation.h"
 #include "engine/QueryExecutionTree.h"
+#include "util/AllocatorTypes.h"
 #include "util/VectorWithMemoryLimit.h"
 
 class Minus : public Operation {
@@ -18,7 +20,7 @@ class Minus : public Operation {
   std::shared_ptr<QueryExecutionTree> _right;
 
   std::vector<float> _multiplicities;
-  std::vector<std::array<ColumnIndex, 2>> _matchedColumns;
+  qlever::vector<std::array<ColumnIndex, 2>> _matchedColumns;
 
   enum class RowComparison { EQUAL, LEFT_SMALLER, RIGHT_SMALLER };
 
@@ -80,7 +82,7 @@ class Minus : public Operation {
    **/
   IdTable computeMinus(
       const IdTableView<0>& a, const IdTableView<0>& b,
-      const std::vector<std::array<ColumnIndex, 2>>& matchedColumns) const;
+      ql::span<const std::array<ColumnIndex, 2>> matchedColumns) const;
 
  private:
   [[nodiscard]] bool isDeterministicImpl() const override { return true; }

--- a/src/engine/MultiColumnJoin.cpp
+++ b/src/engine/MultiColumnJoin.cpp
@@ -19,7 +19,7 @@ MultiColumnJoin::MultiColumnJoin(QueryExecutionContext* qec,
                                  std::shared_ptr<QueryExecutionTree> t1,
                                  std::shared_ptr<QueryExecutionTree> t2,
                                  bool allowSwappingChildrenOnlyForTesting)
-    : Operation{qec} {
+    : Operation{qec}, _joinColumns{qec->getAllocator()} {
   // Make sure subtrees are ordered so that identical queries can be identified.
   if (allowSwappingChildrenOnlyForTesting &&
       t1->getCacheKey() > t2->getCacheKey()) {
@@ -207,7 +207,7 @@ void MultiColumnJoin::computeSizeEstimateAndMultiplicities() {
 // _______________________________________________________________________
 void MultiColumnJoin::computeMultiColumnJoin(
     const IdTableView<0>& left, const IdTableView<0>& right,
-    const std::vector<std::array<ColumnIndex, 2>>& joinColumns,
+    ql::span<const std::array<ColumnIndex, 2>> joinColumns,
     IdTable* result) {
   // check for trivial cases
   if (left.empty() || right.empty()) {

--- a/src/engine/MultiColumnJoin.h
+++ b/src/engine/MultiColumnJoin.h
@@ -8,15 +8,17 @@
 #include <array>
 #include <vector>
 
+#include "backports/span.h"
 #include "engine/Operation.h"
 #include "engine/QueryExecutionTree.h"
+#include "util/AllocatorTypes.h"
 
 class MultiColumnJoin : public Operation {
  private:
   std::shared_ptr<QueryExecutionTree> _left;
   std::shared_ptr<QueryExecutionTree> _right;
 
-  std::vector<std::array<ColumnIndex, 2>> _joinColumns;
+  qlever::vector<std::array<ColumnIndex, 2>> _joinColumns;
 
   std::vector<float> _multiplicities;
   size_t _sizeEstimate;
@@ -66,7 +68,7 @@ class MultiColumnJoin : public Operation {
    **/
   void computeMultiColumnJoin(
       const IdTableView<0>& left, const IdTableView<0>& right,
-      const std::vector<std::array<ColumnIndex, 2>>& joinColumns,
+      ql::span<const std::array<ColumnIndex, 2>> joinColumns,
       IdTable* resultMightBeUnsorted);
 
  private:

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -19,6 +19,7 @@
 #include "parser/data/LimitOffsetClause.h"
 #include "rdfTypes/Variable.h"
 #include "util/AllocateShared.h"
+#include "util/Allocator.h"
 #include "util/CancellationHandle.h"
 #include "util/CompilerExtensions.h"
 #include "util/CopyableSynchronization.h"

--- a/src/engine/OptionalJoin.cpp
+++ b/src/engine/OptionalJoin.cpp
@@ -335,14 +335,14 @@ void OptionalJoin::computeSizeEstimateAndMultiplicities() {
 // ______________________________________________________________
 auto OptionalJoin::computeImplementationFromIdTables(
     const IdTableView<0>& left, const IdTableView<0>& right,
-    const std::vector<std::array<ColumnIndex, 2>>& joinColumns)
+    ql::span<const std::array<ColumnIndex, 2>> joinColumns)
     -> Implementation {
   auto implementation = Implementation::NoUndef;
   auto anyIsUndefined = [](auto column) {
     return ql::ranges::any_of(column, &Id::isUndefined);
   };
   for (size_t i = 0; i < joinColumns.size(); ++i) {
-    auto [leftCol, rightCol] = joinColumns.at(i);
+    auto [leftCol, rightCol] = joinColumns[i];
     if (anyIsUndefined(right.getColumn(rightCol))) {
       return Implementation::GeneralCase;
     }
@@ -379,7 +379,7 @@ bool OptionalJoin::columnOriginatesFromGraphOrUndef(
 // ______________________________________________________________
 void OptionalJoin::optionalJoin(
     const IdTableView<0>& left, const IdTableView<0>& right,
-    const std::vector<std::array<ColumnIndex, 2>>& joinColumns, IdTable* result,
+    ql::span<const std::array<ColumnIndex, 2>> joinColumns, IdTable* result,
     Implementation implementation) {
   // check for trivial cases
   if (left.empty()) {

--- a/src/engine/OptionalJoin.h
+++ b/src/engine/OptionalJoin.h
@@ -6,8 +6,10 @@
 #ifndef QLEVER_SRC_ENGINE_OPTIONALJOIN_H
 #define QLEVER_SRC_ENGINE_OPTIONALJOIN_H
 
+#include "backports/span.h"
 #include "engine/Operation.h"
 #include "engine/QueryExecutionTree.h"
+#include "util/AllocatorTypes.h"
 
 // Forward declaration
 class IndexScan;
@@ -26,7 +28,7 @@ class OptionalJoin : public Operation {
 
   Implementation implementation_ = Implementation::GeneralCase;
 
-  std::vector<std::array<ColumnIndex, 2>> _joinColumns;
+  qlever::vector<std::array<ColumnIndex, 2>> _joinColumns;
 
   std::vector<float> _multiplicities;
   size_t _sizeEstimate;
@@ -83,7 +85,7 @@ class OptionalJoin : public Operation {
   // value `Id::makeUndefined()` for any entries marked as optional.
   void optionalJoin(
       const IdTableView<0>& left, const IdTableView<0>& right,
-      const std::vector<std::array<ColumnIndex, 2>>& joinColumns,
+      ql::span<const std::array<ColumnIndex, 2>> joinColumns,
       IdTable* dynResult,
       Implementation implementation = Implementation::GeneralCase);
 
@@ -132,7 +134,7 @@ class OptionalJoin : public Operation {
   // and return the appropriate `Implementation`.
   static Implementation computeImplementationFromIdTables(
       const IdTableView<0>& left, const IdTableView<0>& right,
-      const std::vector<std::array<ColumnIndex, 2>>&);
+      ql::span<const std::array<ColumnIndex, 2>>);
 };
 
 #endif  // QLEVER_SRC_ENGINE_OPTIONALJOIN_H

--- a/src/engine/OrderBy.cpp
+++ b/src/engine/OrderBy.cpp
@@ -20,7 +20,7 @@ size_t OrderBy::getResultWidth() const { return subtree_->getResultWidth(); }
 // _____________________________________________________________________________
 OrderBy::OrderBy(QueryExecutionContext* qec,
                  std::shared_ptr<QueryExecutionTree> subtree,
-                 std::vector<std::pair<ColumnIndex, bool>> sortIndices)
+                 SortIndices sortIndices)
     : Operation{qec},
       subtree_{std::move(subtree)},
       sortIndices_{std::move(sortIndices)} {

--- a/src/engine/OrderBy.h
+++ b/src/engine/OrderBy.h
@@ -11,6 +11,7 @@
 
 #include "engine/Operation.h"
 #include "engine/QueryExecutionTree.h"
+#include "util/AllocatorTypes.h"
 
 // The implementation of the SPARQL `ORDER BY` operation.
 //
@@ -24,7 +25,7 @@ class OrderBy : public Operation {
  public:
   // TODO<joka921> This should be `pair<ColumnIndex, IsAscending>`
   // The bool means "isDescending"
-  using SortIndices = std::vector<std::pair<ColumnIndex, bool>>;
+  using SortIndices = qlever::vector<std::pair<ColumnIndex, bool>>;
 
  private:
   std::shared_ptr<QueryExecutionTree> subtree_;

--- a/src/engine/PathSearch.cpp
+++ b/src/engine/PathSearch.cpp
@@ -16,6 +16,7 @@
 #include "engine/QueryExecutionTree.h"
 #include "engine/VariableToColumnMap.h"
 #include "util/Algorithm.h"
+#include "util/AllocatorTypes.h"
 #include "util/AllocatorWithLimit.h"
 
 using namespace pathSearch;
@@ -80,7 +81,9 @@ PathSearch::PathSearch(QueryExecutionContext* qec,
 
   auto startCol = subtree_->getVariableColumn(config_.start_);
   auto endCol = subtree_->getVariableColumn(config_.end_);
-  subtree_ = QueryExecutionTree::createSortedTree(subtree_, {startCol, endCol});
+  subtree_ = QueryExecutionTree::createSortedTree(
+      subtree_,
+      qlever::vector<ColumnIndex>({startCol, endCol}, allocator()));
 
   resultWidth_ = 4 + config_.edgeProperties_.size();
 

--- a/src/engine/QueryExecutionTree.cpp
+++ b/src/engine/QueryExecutionTree.cpp
@@ -201,25 +201,34 @@ QueryExecutionTree::createSortedTreeAnyPermutation(
       sortColumns, [relevantSortedCols](ColumnIndex distinctCol) {
         return ad_utility::contains(relevantSortedCols, distinctCol);
       });
-  return isSorted ? qet : createSortedTree(std::move(qet), sortColumns);
+  if (isSorted) {
+    return qet;
+  }
+  auto allocator = qet->getRootOperation()->allocator();
+  return createSortedTree(
+      std::move(qet),
+      qlever::vector<ColumnIndex>(sortColumns.begin(), sortColumns.end(),
+                                  allocator));
 }
 
 // ________________________________________________________________________________________________________________
 std::shared_ptr<QueryExecutionTree> QueryExecutionTree::createSortedTree(
     std::shared_ptr<QueryExecutionTree> qet,
-    const std::vector<ColumnIndex>& sortColumns, bool explicitSort) {
+    const qlever::vector<ColumnIndex>& sortColumns, bool explicitSort) {
+  std::vector<ColumnIndex> sortColumnsVec(sortColumns.begin(),
+                                          sortColumns.end());
   const auto& rootOperation = qet->getRootOperation();
-  if (rootOperation->isSortedBy(sortColumns)) {
+  if (rootOperation->isSortedBy(sortColumnsVec)) {
     return qet;
   }
-  auto sortedQet = rootOperation->makeSortedTree(sortColumns);
+  auto sortedQet = rootOperation->makeSortedTree(sortColumnsVec);
 
   if (sortedQet.has_value()) {
     AD_CORRECTNESS_CHECK(sortedQet.value() != nullptr);
     AD_CORRECTNESS_CHECK(qet->getVariableColumns() ==
                          sortedQet.value()->getVariableColumns());
     const auto& sortedRootOperation = sortedQet.value()->getRootOperation();
-    AD_CORRECTNESS_CHECK(sortedRootOperation->isSortedBy(sortColumns));
+    AD_CORRECTNESS_CHECK(sortedRootOperation->isSortedBy(sortColumnsVec));
     AD_CORRECTNESS_CHECK(
         sortedRootOperation->getLimitOffset().isUnconstrained(),
         "`LIMIT` and `OFFSET` are applied by "
@@ -235,18 +244,20 @@ std::shared_ptr<QueryExecutionTree> QueryExecutionTree::createSortedTree(
   }
 
   return ad_utility::makeExecutionTree<Sort>(
-      rootOperation->getExecutionContext(), std::move(qet), sortColumns,
+      rootOperation->getExecutionContext(), std::move(qet), sortColumnsVec,
       explicitSort);
 }
 
 // ________________________________________________________________________________________________________________
 std::shared_ptr<QueryExecutionTree> QueryExecutionTree::createDistinctTree(
     std::shared_ptr<QueryExecutionTree> qet,
-    const std::vector<ColumnIndex>& distinctIndices) {
+    const qlever::vector<ColumnIndex>& distinctIndices) {
+  std::vector<ColumnIndex> distinctIndicesVec(distinctIndices.begin(),
+                                              distinctIndices.end());
   const auto& rootOperation = qet->getRootOperation();
   // If the result is already distinct wrt the `distinctIndices`, the `DISTINCT`
   // would be a no-op and we can simply return the tree unchanged.
-  if (rootOperation->isDistinctBy(distinctIndices)) {
+  if (rootOperation->isDistinctBy(distinctIndicesVec)) {
     return qet;
   }
 
@@ -256,7 +267,7 @@ std::shared_ptr<QueryExecutionTree> QueryExecutionTree::createDistinctTree(
   // before applying the limit, because `qet` (and its root operation) may be
   // shared with other query execution trees and `applyLimitOffset` mutates the
   // operation in place.
-  if (distinctIndices.empty()) {
+  if (distinctIndicesVec.empty()) {
     auto limitedQet = qet->clone();
     limitedQet->applyLimitOffset(LimitOffsetClause{._limit = 1});
     return limitedQet;
@@ -264,7 +275,7 @@ std::shared_ptr<QueryExecutionTree> QueryExecutionTree::createDistinctTree(
 
   // Give the root operation the chance to push the `DISTINCT` down into its
   // subtree(s) more efficiently (e.g. `CartesianProductJoin`).
-  auto distinctQet = rootOperation->makeDistinctTree(distinctIndices);
+  auto distinctQet = rootOperation->makeDistinctTree(distinctIndicesVec);
   if (distinctQet.has_value()) {
     AD_CORRECTNESS_CHECK(distinctQet.value() != nullptr);
     // Pushing the `DISTINCT` down must preserve the set of visible variables,
@@ -285,20 +296,22 @@ std::shared_ptr<QueryExecutionTree> QueryExecutionTree::createDistinctTree(
     // layout of the rewritten tree via the variable names before checking.
     std::vector<ColumnIndex> translatedIndices;
     for (const auto& [variable, info] : before) {
-      if (ad_utility::contains(distinctIndices, info.columnIndex_)) {
+      if (ad_utility::contains(distinctIndicesVec, info.columnIndex_)) {
         translatedIndices.push_back(after.at(variable).columnIndex_);
       }
     }
     // The sizes can only match because `distinctIndices` contains no
     // duplicates (a documented precondition of this function).
-    AD_CORRECTNESS_CHECK(translatedIndices.size() == distinctIndices.size());
+    AD_CORRECTNESS_CHECK(translatedIndices.size() ==
+                         distinctIndicesVec.size());
     AD_CORRECTNESS_CHECK(distinctQet.value()->getRootOperation()->isDistinctBy(
         translatedIndices));
     return std::move(distinctQet).value();
   }
 
   return ad_utility::makeExecutionTree<Distinct>(
-      rootOperation->getExecutionContext(), std::move(qet), distinctIndices);
+      rootOperation->getExecutionContext(), std::move(qet),
+      distinctIndicesVec);
 }
 
 // _____________________________________________________________________________
@@ -356,9 +369,10 @@ QueryExecutionTree::makeTreeWithStrippedColumns(
 }
 
 // _____________________________________________________________________________
-std::vector<std::array<ColumnIndex, 2>> QueryExecutionTree::getJoinColumns(
+qlever::vector<std::array<ColumnIndex, 2>> QueryExecutionTree::getJoinColumns(
     const QueryExecutionTree& qetA, const QueryExecutionTree& qetB) {
-  std::vector<std::array<ColumnIndex, 2>> jcs;
+  qlever::vector<std::array<ColumnIndex, 2>> jcs{
+      qetA.getRootOperation()->allocator()};
   const auto& aVarCols = qetA.getVariableColumns();
   const auto& bVarCols = qetB.getVariableColumns();
   for (const auto& aVarCol : aVarCols) {
@@ -379,8 +393,11 @@ std::pair<std::shared_ptr<QueryExecutionTree>,
 QueryExecutionTree::createSortedTrees(
     std::shared_ptr<QueryExecutionTree> qetA,
     std::shared_ptr<QueryExecutionTree> qetB,
-    const std::vector<std::array<ColumnIndex, 2>>& sortColumns) {
-  std::vector<ColumnIndex> sortColumnsA, sortColumnsB;
+    ql::span<const std::array<ColumnIndex, 2>> sortColumns) {
+  auto allocatorA = qetA->getRootOperation()->allocator();
+  auto allocatorB = qetB->getRootOperation()->allocator();
+  qlever::vector<ColumnIndex> sortColumnsA{allocatorA};
+  qlever::vector<ColumnIndex> sortColumnsB{allocatorB};
   for (auto [sortColumnA, sortColumnB] : sortColumns) {
     sortColumnsA.push_back(sortColumnA);
     sortColumnsB.push_back(sortColumnB);

--- a/src/engine/QueryExecutionTree.h
+++ b/src/engine/QueryExecutionTree.h
@@ -11,11 +11,13 @@
 #include <string>
 #include <vector>
 
+#include "backports/span.h"
 #include "engine/Operation.h"
 #include "engine/QueryExecutionContext.h"
 #include "parser/ParsedQuery.h"
 #include "parser/data/Types.h"
 #include "util/AllocateShared.h"
+#include "util/AllocatorTypes.h"
 #include "util/HashSet.h"
 
 // Strongly typed enum for controlling whether stripped variables are explicitly
@@ -188,7 +190,7 @@ class QueryExecutionTree {
   // limit-pushdown optimization is undesired.
   static std::shared_ptr<QueryExecutionTree> createSortedTree(
       std::shared_ptr<QueryExecutionTree> qet,
-      const std::vector<ColumnIndex>& sortColumns, bool explicitSort = false);
+      const qlever::vector<ColumnIndex>& sortColumns, bool explicitSort = false);
 
   // Create a `QueryExecutionTree` that produces the same set of results as
   // applying a `DISTINCT` on the columns `distinctIndices` to `qet`. In order
@@ -206,7 +208,7 @@ class QueryExecutionTree {
   // duplicates.
   static std::shared_ptr<QueryExecutionTree> createDistinctTree(
       std::shared_ptr<QueryExecutionTree> qet,
-      const std::vector<ColumnIndex>& distinctIndices);
+      const qlever::vector<ColumnIndex>& distinctIndices);
 
   // Similar to `createSortedTree` (see directly above), but create the sorted
   // trees for two different trees, the sort columns of which are specified as
@@ -216,7 +218,7 @@ class QueryExecutionTree {
                    std::shared_ptr<QueryExecutionTree>>
   createSortedTrees(std::shared_ptr<QueryExecutionTree> qetA,
                     std::shared_ptr<QueryExecutionTree> qetB,
-                    const std::vector<std::array<ColumnIndex, 2>>& sortColumns);
+                    ql::span<const std::array<ColumnIndex, 2>> sortColumns);
 
   // The return type of the `getSortedTreesAndJoinColumns` function below. It is
   // deliberately stored as a tuple vs. a struct with named members, so that we
@@ -224,7 +226,7 @@ class QueryExecutionTree {
   using SortedTreesAndJoinColumns =
       std::tuple<std::shared_ptr<QueryExecutionTree>,
                  std::shared_ptr<QueryExecutionTree>,
-                 std::vector<std::array<ColumnIndex, 2>>>;
+                 qlever::vector<std::array<ColumnIndex, 2>>>;
 
   // First compute the join columns of the two trees, and then sort the trees by
   // those join columns. Return the sorted trees as well as the join columns.
@@ -246,7 +248,7 @@ class QueryExecutionTree {
   // same variable. The result is sorted by the column indices, so that it is
   // deterministic when called repeatedly. This is important to find a
   // `QueryExecutionTree` in the cache.
-  static std::vector<std::array<ColumnIndex, 2>> getJoinColumns(
+  static qlever::vector<std::array<ColumnIndex, 2>> getJoinColumns(
       const QueryExecutionTree& qetA, const QueryExecutionTree& qetB);
 
   // If the result of this `Operation` is sorted (either because this

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -127,12 +127,14 @@ void assignNodesFilterAndTextLimitIds(QueryPlanner::SubtreePlan& target,
 // _____________________________________________________________________________
 QueryPlanner::QueryPlanner(QueryExecutionContext* qec,
                            CancellationHandle cancellationHandle)
-    : _qec{qec}, cancellationHandle_{std::move(cancellationHandle)} {
+    : _qec{qec},
+      cancellationHandle_{std::move(cancellationHandle)},
+      warnings_{_qec->getAllocator()} {
   AD_CONTRACT_CHECK(cancellationHandle_);
 }
 
 // _____________________________________________________________________________
-std::vector<SubtreePlan> QueryPlanner::createExecutionTrees(ParsedQuery& pq,
+QueryPlanner::PlanVec QueryPlanner::createExecutionTrees(ParsedQuery& pq,
                                                             bool isSubquery) {
   // Store the dataset clause (FROM and FROM NAMED clauses), s.t. we have access
   // to them down the callstack. Subqueries can't have their own dataset clause,
@@ -171,7 +173,7 @@ std::vector<SubtreePlan> QueryPlanner::createExecutionTrees(ParsedQuery& pq,
   textLimit_ = pq._limitOffset.textLimit_;
 
   // Optimize the graph pattern tree
-  std::vector<std::vector<SubtreePlan>> plans;
+  PlanMatrix plans{_qec->getAllocator()};
   plans.push_back(optimize(&pq._rootGraphPattern));
   checkCancellation();
 
@@ -220,7 +222,7 @@ std::vector<SubtreePlan> QueryPlanner::createExecutionTrees(ParsedQuery& pq,
 
   // Now find the cheapest execution plan and store that as the optimal
   // plan for this graph pattern.
-  vector<SubtreePlan>& lastRow = plans.back();
+  PlanVec& lastRow = plans.back();
 
   for (auto& plan : lastRow) {
     // For subqueries the limit has already been applied, for the root query the
@@ -272,7 +274,7 @@ QueryExecutionTree QueryPlanner::createExecutionTree(ParsedQuery& pq,
 }
 
 // _____________________________________________________________________________
-std::vector<SubtreePlan> QueryPlanner::optimize(
+QueryPlanner::PlanVec QueryPlanner::optimize(
     ParsedQuery::GraphPattern* rootPattern) {
   QueryPlanner::GraphPatternPlanner optimizer{*this, rootPattern};
   for (auto& child : rootPattern->_graphPatterns) {
@@ -294,7 +296,8 @@ std::vector<SubtreePlan> QueryPlanner::optimize(
         candidatePlans[0], optimizer.filtersAndSubst_);
     applyTextLimitsIfPossible(candidatePlans[0],
                               TextLimitVec{rootPattern->textLimits_.begin(),
-                                           rootPattern->textLimits_.end()},
+                                           rootPattern->textLimits_.end(),
+                                           _qec->getAllocator()},
                               true);
     checkCancellation();
   }
@@ -303,12 +306,13 @@ std::vector<SubtreePlan> QueryPlanner::optimize(
   if (candidatePlans.empty()) {
     // this case is needed e.g. if we have the empty graph pattern due to a
     // pattern trick
-    return std::vector<SubtreePlan>{};
+    return PlanVec{_qec->getAllocator()};
   } else {
     if (candidatePlans.at(0).empty()) {
       // This happens if either graph pattern is an empty group,
       // or it only consists of a MINUS clause (which then has no effect).
-      std::vector neutralPlans{makeSubtreePlan<NeutralElementOperation>(_qec)};
+      PlanVec neutralPlans{{makeSubtreePlan<NeutralElementOperation>(_qec)},
+                          _qec->getAllocator()};
       // Neutral element can potentially still get filtered out
       applyFiltersIfPossible<FilterMode::ApplyAllFiltersAndReplaceUnfiltered>(
           neutralPlans, optimizer.filtersAndSubst_);
@@ -319,16 +323,17 @@ std::vector<SubtreePlan> QueryPlanner::optimize(
 }
 
 // _____________________________________________________________________________
-std::vector<SubtreePlan> QueryPlanner::getDistinctRow(
+QueryPlanner::PlanVec QueryPlanner::getDistinctRow(
     const p::SelectClause& selectClause,
-    const vector<vector<SubtreePlan>>& dpTab) const {
-  const vector<SubtreePlan>& previous = dpTab[dpTab.size() - 1];
-  vector<SubtreePlan> added;
+    const PlanMatrix& dpTab) const {
+  const PlanVec& previous = dpTab[dpTab.size() - 1];
+  PlanVec added{_qec->getAllocator()};
   added.reserve(previous.size());
   for (const auto& parent : previous) {
     SubtreePlan distinctPlan(_qec);
-    vector<ColumnIndex> keepIndices;
-    ad_utility::HashSet<ColumnIndex> indDone;
+    qlever::vector<ColumnIndex> keepIndices{_qec->getAllocator()};
+    ad_utility::HashSetWithMemoryLimit<ColumnIndex> indDone{
+        _qec->getAllocator()};
     const auto& colMap = parent._qet->getVariableColumns();
     for (const auto& var : selectClause.getSelectedVariables()) {
       // There used to be a special treatment for `?ql_textscore_` variables
@@ -349,15 +354,15 @@ std::vector<SubtreePlan> QueryPlanner::getDistinctRow(
 }
 
 // _____________________________________________________________________________
-std::vector<SubtreePlan> QueryPlanner::getPatternTrickRow(
+QueryPlanner::PlanVec QueryPlanner::getPatternTrickRow(
     const p::SelectClause& selectClause,
-    const vector<vector<SubtreePlan>>& dpTab,
+    const PlanMatrix& dpTab,
     const checkUsePatternTrick::PatternTrickTuple& patternTrickTuple) {
   AD_CORRECTNESS_CHECK(!dpTab.empty());
-  const vector<SubtreePlan>& previous = dpTab.back();
+  const PlanVec& previous = dpTab.back();
   auto aliases = selectClause.getAliases();
 
-  vector<SubtreePlan> added;
+  PlanVec added{_qec->getAllocator()};
 
   Variable predicateVariable = patternTrickTuple.predicate_;
   Variable countVariable =
@@ -380,10 +385,10 @@ std::vector<SubtreePlan> QueryPlanner::getPatternTrickRow(
 }
 
 // _____________________________________________________________________________
-std::vector<SubtreePlan> QueryPlanner::getHavingRow(
-    const ParsedQuery& pq, const vector<vector<SubtreePlan>>& dpTab) const {
-  const vector<SubtreePlan>& previous = dpTab[dpTab.size() - 1];
-  vector<SubtreePlan> added;
+QueryPlanner::PlanVec QueryPlanner::getHavingRow(
+    const ParsedQuery& pq, const PlanMatrix& dpTab) const {
+  const PlanVec& previous = dpTab[dpTab.size() - 1];
+  PlanVec added{_qec->getAllocator()};
   added.reserve(previous.size());
   for (const auto& parent : previous) {
     SubtreePlan filtered = parent;
@@ -397,10 +402,10 @@ std::vector<SubtreePlan> QueryPlanner::getHavingRow(
 }
 
 // _____________________________________________________________________________
-std::vector<SubtreePlan> QueryPlanner::applyPostQueryValues(
+QueryPlanner::PlanVec QueryPlanner::applyPostQueryValues(
     const parsedQuery::Values& values,
-    const std::vector<SubtreePlan>& currentPlans) const {
-  std::vector<SubtreePlan> result;
+    const PlanVec& currentPlans) const {
+  PlanVec result{_qec->getAllocator()};
 
   auto valuesPlan = makeSubtreePlan<::Values>(_qec, values._inlineValues);
   for (auto& plan : currentPlans) {
@@ -412,10 +417,10 @@ std::vector<SubtreePlan> QueryPlanner::applyPostQueryValues(
 }
 
 // _____________________________________________________________________________
-std::vector<SubtreePlan> QueryPlanner::getGroupByRow(
-    const ParsedQuery& pq, const vector<vector<SubtreePlan>>& dpTab) const {
-  const vector<SubtreePlan>& previous = dpTab[dpTab.size() - 1];
-  vector<SubtreePlan> added;
+QueryPlanner::PlanVec QueryPlanner::getGroupByRow(
+    const ParsedQuery& pq, const PlanMatrix& dpTab) const {
+  const PlanVec& previous = dpTab[dpTab.size() - 1];
+  PlanVec added{_qec->getAllocator()};
   added.reserve(previous.size());
   for (auto& parent : previous) {
     // Create a group by operation to determine on which columns the input
@@ -429,7 +434,9 @@ std::vector<SubtreePlan> QueryPlanner::getGroupByRow(
 
     // Inside a `GRAPH ?var {....}` clause,  a `GROUP BY` must implicitly (also)
     // group by the graph variable.
-    auto groupVariables = pq._groupByVariables;
+    // `GroupBy`'s constructor requires a plain `std::vector<Variable>`.
+    std::vector<Variable> groupVariables(pq._groupByVariables.begin(),
+                                         pq._groupByVariables.end());
     if (activeGraphVariable_.has_value()) {
       AD_CORRECTNESS_CHECK(
           !ad_utility::contains(groupVariables, activeGraphVariable_.value()),
@@ -445,16 +452,16 @@ std::vector<SubtreePlan> QueryPlanner::getGroupByRow(
 }
 
 // _____________________________________________________________________________
-std::vector<SubtreePlan> QueryPlanner::getOrderByRow(
-    const ParsedQuery& pq, const vector<vector<SubtreePlan>>& dpTab) const {
-  const vector<SubtreePlan>& previous = dpTab[dpTab.size() - 1];
-  vector<SubtreePlan> added;
+QueryPlanner::PlanVec QueryPlanner::getOrderByRow(
+    const ParsedQuery& pq, const PlanMatrix& dpTab) const {
+  const PlanVec& previous = dpTab[dpTab.size() - 1];
+  PlanVec added{_qec->getAllocator()};
   added.reserve(previous.size());
   for (const auto& parent : previous) {
     SubtreePlan plan(_qec);
     auto& tree = plan._qet;
     assignNodesFilterAndTextLimitIds(plan, parent);
-    vector<std::pair<ColumnIndex, bool>> sortIndices;
+    OrderBy::SortIndices sortIndices{_qec->getAllocator()};
     // Collect the variables of the ORDER BY or INTERNAL SORT BY clause. Ignore
     // variables that are not visible in the query body (according to the
     // SPARQL standard, they are allowed but have no effect).
@@ -473,7 +480,7 @@ std::vector<SubtreePlan> QueryPlanner::getOrderByRow(
     }
 
     if (pq._isInternalSort == IsInternalSort::True) {
-      std::vector<ColumnIndex> sortColumns;
+      qlever::vector<ColumnIndex> sortColumns{_qec->getAllocator()};
       for (auto& [index, isDescending] : sortIndices) {
         AD_CONTRACT_CHECK(!isDescending);
         sortColumns.push_back(index);
@@ -503,7 +510,7 @@ void QueryPlanner::addNodeToTripleGraph(const TripleGraph::Node& node,
   tg._nodeStorage.emplace_back(node);
   auto& addedNode = tg._nodeStorage.back();
   tg._nodeMap[addedNode.id_] = &addedNode;
-  tg._adjLists.emplace_back();
+  tg._adjLists.emplace_back(tg._nodeMap.get_allocator());
   AD_CORRECTNESS_CHECK(tg._adjLists.size() == tg._nodeStorage.size());
   AD_CORRECTNESS_CHECK(tg._adjLists.size() == addedNode.id_ + 1);
   // Now add an edge between the added node and every node sharing a var.
@@ -522,11 +529,17 @@ void QueryPlanner::addNodeToTripleGraph(const TripleGraph::Node& node,
 // _____________________________________________________________________________
 QueryPlanner::TripleGraph QueryPlanner::createTripleGraph(
     const p::BasicGraphPattern* pattern) const {
-  TripleGraph tg;
+  TripleGraph tg{_qec->getAllocator()};
   size_t numNodesInTripleGraph = 0;
-  ad_utility::HashMap<Variable, std::string> optTermForCvar;
-  ad_utility::HashMap<Variable, vector<std::string>> potentialTermsForCvar;
-  vector<const SparqlTriple*> entityTriples;
+  ad_utility::HashMapWithMemoryLimit<Variable, std::string> optTermForCvar{
+      _qec->getAllocator()};
+  // `Index::getIndexOfBestSuitedElTerm` (a shared, non-QueryPlanner-specific
+  // Index API used identically by `TextSearchQuery.cpp`) requires a plain
+  // `std::vector<std::string>`, so this stays `std::vector` rather than
+  // `qlever::vector`.
+  ad_utility::HashMapWithMemoryLimit<Variable, std::vector<std::string>>
+      potentialTermsForCvar{_qec->getAllocator()};
+  qlever::vector<const SparqlTriple*> entityTriples{_qec->getAllocator()};
   // Add one or more nodes for each triple.
   for (auto& t : pattern->_triples) {
     if (t.getSimplePredicate() == CONTAINS_WORD_PREDICATE) {
@@ -544,7 +557,8 @@ QueryPlanner::TripleGraph QueryPlanner::createTripleGraph(
               "with FROM/FROM NAMED clauses.");
         }
         addNodeToTripleGraph(
-            TripleGraph::Node{tg._nodeStorage.size(), t.s_.getVariable(), s, t},
+            TripleGraph::Node{tg._nodeStorage.size(), t.s_.getVariable(), s, t,
+                              _qec->getAllocator()},
             tg);
         numNodesInTripleGraph++;
       }
@@ -552,7 +566,8 @@ QueryPlanner::TripleGraph QueryPlanner::createTripleGraph(
       entityTriples.push_back(&t);
     } else {
       addNodeToTripleGraph(
-          TripleGraph::Node{tg._nodeStorage.size(), t, activeGraphVariable_},
+          TripleGraph::Node{tg._nodeStorage.size(), t, _qec->getAllocator(),
+                            activeGraphVariable_},
           tg);
       numNodesInTripleGraph++;
     }
@@ -570,7 +585,8 @@ QueryPlanner::TripleGraph QueryPlanner::createTripleGraph(
           "statement.");
     }
     addNodeToTripleGraph(TripleGraph::Node(tg._nodeStorage.size(), currentVar,
-                                           optTermForCvar[currentVar], *t),
+                                           optTermForCvar[currentVar], *t,
+                                           _qec->getAllocator()),
                          tg);
     numNodesInTripleGraph++;
   }
@@ -590,16 +606,24 @@ CPP_concept TriplePosition =
                                              SparqlTripleSimple&>;
 
 // Create a `SparqlFilter` that corresponds to the expression `var1==var2`.
-// Used as a helper function below.
-SparqlFilter createEqualFilter(const Variable& var1, const Variable& var2) {
+// Used as a helper function below. `allocator` is routed through to the
+// `FILTER` sub-parse so that, whenever a real (query-execution-bound)
+// allocator is available at the call site, it is used instead of falling
+// back to an unlimited one.
+SparqlFilter createEqualFilter(const Variable& var1, const Variable& var2,
+                               const qlever::Allocator<Id>& allocator) {
   std::string filterString =
       absl::StrCat("FILTER ( ", var1.name(), "=", var2.name(), ")");
 
   ad_utility::BlankNodeManager bn;
   static EncodedIriManager ev;
-  auto result = sparqlParserHelpers::ParserAndVisitor{&bn, &ev, filterString}
-                    .parseTypesafe(&SparqlAutomaticParser::filterR)
-                    .resultOfParse_;
+  auto result =
+      sparqlParserHelpers::ParserAndVisitor{
+          &bn, &ev, filterString, std::nullopt,
+          SparqlQleverVisitor::DisableSomeChecksOnlyForTesting::False,
+          allocator}
+          .parseTypesafe(&SparqlAutomaticParser::filterR)
+          .resultOfParse_;
 
   // The `filter` rule never adds blank nodes.
   AD_CORRECTNESS_CHECK(bn.numBlocksUsed() == 0u);
@@ -612,10 +636,11 @@ SparqlFilter createEqualFilter(const Variable& var1, const Variable& var2) {
 // equality.
 constexpr auto rewriteSingle = CPP_template_lambda()(typename T)(
     T rewritePosition, SparqlTripleSimple& scanTriple, const auto& addFilter,
-    const auto& generateUniqueVarName)(requires TriplePosition<T>) {
+    const auto& generateUniqueVarName,
+    const qlever::Allocator<Id>& allocator)(requires TriplePosition<T>) {
   Variable filterVar = generateUniqueVarName();
   auto& target = std::invoke(rewritePosition, scanTriple).getVariable();
-  addFilter(createEqualFilter(filterVar, target));
+  addFilter(createEqualFilter(filterVar, target, allocator));
   target = filterVar;
 };
 
@@ -626,12 +651,13 @@ constexpr auto rewriteSingle = CPP_template_lambda()(typename T)(
 constexpr auto handleRepeatedVariablesImpl =
     [](const auto& triple, auto& addIndexScan,
        const auto& generateUniqueVarName, const auto& addFilter,
+       const qlever::Allocator<Id>& allocator,
        ql::span<const Permutation::Enum> permutations, auto... rewritePositions)
     -> CPP_ret(void)(
         requires(TriplePosition<decltype(rewritePositions)>&&...)) {
   auto scanTriple = triple;
   (..., rewriteSingle(rewritePositions, scanTriple, addFilter,
-                      generateUniqueVarName));
+                      generateUniqueVarName, allocator));
   for (const auto& permutation : permutations) {
     addIndexScan(permutation, scanTriple);
   }
@@ -667,14 +693,15 @@ void QueryPlanner::indexScanTwoVarsCase(
   // old and the new value for equality for this rewrite. Then also
   // add an index scan for the rewritten triple.
   auto generate = [this]() { return generateUniqueVarName(); };
+  qlever::Allocator<Id> allocator = _qec->getAllocator();
   auto handleRepeatedVariables =
-      [&triple, &addIndexScan, &addFilter, &generate](
+      [&triple, &addIndexScan, &addFilter, &generate, &allocator](
           ql::span<const Permutation::Enum> permutations,
           auto... rewritePositions)
       -> CPP_ret(void)(
           requires(TriplePosition<decltype(rewritePositions)>&&...)) {
     return handleRepeatedVariablesImpl(triple, addIndexScan, generate,
-                                       addFilter, permutations,
+                                       addFilter, allocator, permutations,
                                        rewritePositions...);
   };
 
@@ -717,19 +744,20 @@ void QueryPlanner::indexScanThreeVarsCase(
                     "With only 2 permutations registered (no -a option), "
                     "triples should have at most two variables.");
   auto generate = [this]() { return generateUniqueVarName(); };
+  qlever::Allocator<Id> allocator = _qec->getAllocator();
 
   // Replace the position of the `triple` that is specified by the
   // `rewritePosition` with a new variable, and add a filter, that checks the
   // old and the new value for equality for this rewrite. Then also
   // add an index scan for the rewritten triple.
   auto handleRepeatedVariables =
-      [&triple, &addIndexScan, &addFilter, &generate](
+      [&triple, &addIndexScan, &addFilter, &generate, &allocator](
           ql::span<const Permutation::Enum> permutations,
           auto... rewritePositions)
       -> CPP_ret(void)(
           requires(TriplePosition<decltype(rewritePositions)>&&...)) {
     return handleRepeatedVariablesImpl(triple, addIndexScan, generate,
-                                       addFilter, permutations,
+                                       addFilter, allocator, permutations,
                                        rewritePositions...);
   };
 
@@ -783,10 +811,11 @@ void QueryPlanner::seedFromOrdinaryTriple(
 // _____________________________________________________________________________
 auto QueryPlanner::seedWithScansAndText(
     const QueryPlanner::TripleGraph& tg,
-    const vector<vector<SubtreePlan>>& children,
+    const PlanMatrix& children,
     TextLimitMap& textLimits) -> PlansAndFilters {
-  PlansAndFilters result;
-  vector<SubtreePlan>& seeds = result.plans_;
+  PlansAndFilters result{PlanVec{_qec->getAllocator()},
+                         qlever::vector<SparqlFilter>{_qec->getAllocator()}};
+  PlanVec& seeds = result.plans_;
   // add all child plans as seeds
   uint64_t idShift = tg._nodeMap.size();
   for (const auto& vec : children) {
@@ -868,7 +897,7 @@ auto QueryPlanner::seedWithScansAndText(
     if ((ql::starts_with(input, MAX_DIST_IN_METERS) ||
          ql::starts_with(input, NEAREST_NEIGHBORS)) &&
         ql::ends_with(input, '>')) {
-      parsedQuery::SpatialQuery config{node.triple_};
+      parsedQuery::SpatialQuery config{node.triple_, _qec->getAllocator()};
       auto plan = makeSubtreePlan<SpatialJoin>(
           _qec, config.toSpatialJoinConfiguration(), std::nullopt,
           std::nullopt);
@@ -955,7 +984,7 @@ auto QueryPlanner::seedWithScansAndText(
 
   // If there is no score variable, there is no ql:contains-entity for this text
   // variable, so we don't need a text limit and we can delete the object
-  vector<Variable> toDelete;
+  qlever::vector<Variable> toDelete{_qec->getAllocator()};
   for (const auto& [textVar, textLimitMetaObject] : textLimits) {
     if (textLimitMetaObject.scoreVars_.empty()) {
       toDelete.push_back(textVar);
@@ -977,7 +1006,7 @@ ParsedQuery::GraphPattern QueryPlanner::seedFromPropertyPath(
       [&left, &right](const ad_utility::triple_component::Iri& iri) {
         return seedFromVarOrIri(left, iri, right);
       },
-      [this, &left, &right](const std::vector<PropertyPath>& children,
+      [this, &left, &right](const PropertyPath::ChildrenVec& children,
                             PropertyPath::Modifier modifier) {
         using enum PropertyPath::Modifier;
         switch (modifier) {
@@ -1002,7 +1031,7 @@ ParsedQuery::GraphPattern QueryPlanner::seedFromPropertyPath(
 
 // _____________________________________________________________________________
 ParsedQuery::GraphPattern QueryPlanner::seedFromSequence(
-    const TripleComponent& left, const std::vector<PropertyPath>& paths,
+    const TripleComponent& left, const PropertyPath::ChildrenVec& paths,
     const TripleComponent& right) {
   AD_CORRECTNESS_CHECK(paths.size() > 1);
 
@@ -1029,13 +1058,13 @@ ParsedQuery::GraphPattern QueryPlanner::seedFromSequence(
 
 // _____________________________________________________________________________
 ParsedQuery::GraphPattern QueryPlanner::seedFromAlternative(
-    const TripleComponent& left, const std::vector<PropertyPath>& paths,
+    const TripleComponent& left, const PropertyPath::ChildrenVec& paths,
     const TripleComponent& right) {
   AD_CONTRACT_CHECK(paths.size() > 1,
                     "Tried processing an alternative property path node with 0 "
                     "or 1 children.");
 
-  std::vector<ParsedQuery::GraphPattern> childPlans;
+  qlever::vector<ParsedQuery::GraphPattern> childPlans{_qec->getAllocator()};
   childPlans.reserve(paths.size());
   for (const auto& child : paths) {
     childPlans.push_back(seedFromPropertyPath(left, child, right));
@@ -1067,10 +1096,11 @@ ParsedQuery::GraphPattern QueryPlanner::seedFromTransitive(
 namespace {
 using std::string_view;
 // Split the children of a property path into forward and inverse children.
-std::pair<std::vector<string_view>, std::vector<string_view>> splitChildren(
-    const std::vector<PropertyPath>& children) {
-  std::vector<string_view> forwardIris;
-  std::vector<string_view> inverseIris;
+std::pair<qlever::vector<string_view>, qlever::vector<string_view>>
+splitChildren(const PropertyPath::ChildrenVec& children,
+              const qlever::Allocator<Id>& allocator) {
+  qlever::vector<string_view> forwardIris{allocator};
+  qlever::vector<string_view> inverseIris{allocator};
   for (const auto& child : children) {
     if (auto unwrapped = child.getChildOfInvertedPath()) {
       const PropertyPath& path = unwrapped.value();
@@ -1103,13 +1133,14 @@ void appendNotEqualString(std::ostream& os, std::string_view iri,
 
 // _____________________________________________________________________________
 ParsedQuery::GraphPattern QueryPlanner::seedFromNegated(
-    const TripleComponent& left, const std::vector<PropertyPath>& paths,
+    const TripleComponent& left, const PropertyPath::ChildrenVec& paths,
     const TripleComponent& right) {
   AD_CORRECTNESS_CHECK(!paths.empty());
-  const auto& [forwardIris, inverseIris] = splitChildren(paths);
+  const auto& [forwardIris, inverseIris] =
+      splitChildren(paths, _qec->getAllocator());
   auto makeFilterPattern = [this](const TripleComponent& left,
                                   const TripleComponent& right,
-                                  const std::vector<string_view>& iris) {
+                                  const qlever::vector<string_view>& iris) {
     using namespace sparqlExpression;
     Variable variable = generateUniqueVarName();
     ParsedQuery::GraphPattern pattern = seedFromVarOrIri(left, variable, right);
@@ -1135,8 +1166,10 @@ ParsedQuery::GraphPattern QueryPlanner::seedFromNegated(
   if (forwardIris.empty()) {
     return makeFilterPattern(right, left, inverseIris);
   }
-  return uniteGraphPatterns({makeFilterPattern(left, right, forwardIris),
-                             makeFilterPattern(right, left, inverseIris)});
+  qlever::vector<ParsedQuery::GraphPattern> patterns{_qec->getAllocator()};
+  patterns.push_back(makeFilterPattern(left, right, forwardIris));
+  patterns.push_back(makeFilterPattern(right, left, inverseIris));
+  return uniteGraphPatterns(std::move(patterns));
 }
 
 // _____________________________________________________________________________
@@ -1164,7 +1197,7 @@ ParsedQuery::GraphPattern QueryPlanner::seedFromVarOrIri(
 }
 
 ParsedQuery::GraphPattern QueryPlanner::uniteGraphPatterns(
-    std::vector<ParsedQuery::GraphPattern>&& patterns) {
+    qlever::vector<ParsedQuery::GraphPattern>&& patterns) {
   using GraphPattern = ParsedQuery::GraphPattern;
   // Build a tree of union operations
   auto p = GraphPattern{};
@@ -1224,24 +1257,29 @@ SubtreePlan QueryPlanner::getTextLeafPlan(
 }
 
 // _____________________________________________________________________________
-std::vector<SubtreePlan> QueryPlanner::merge(
-    const vector<SubtreePlan>& a, const vector<SubtreePlan>& b,
-    const QueryPlanner::TripleGraph& tg) const {
+QueryPlanner::PlanVec QueryPlanner::merge(const PlanVec& a, const PlanVec& b,
+                            const QueryPlanner::TripleGraph& tg) const {
   // TODO: Add the following features:
   // If a join is supposed to happen, always check if it happens between
   // a scan with a relatively large result size
   // esp. with an entire relation but also with something like is-a Person
   // If that is the case look at the size estimate for the other side,
   // if that is rather small, replace the join and scan by a combination.
-  ad_utility::HashMap<std::string, vector<SubtreePlan>> candidates;
+  CandidateMap candidates{_qec->getAllocator()};
   // Find all pairs between a and b that are connected by an edge.
   AD_LOG_TRACE << "Considering joins that merge " << a.size() << " and "
                << b.size() << " plans...\n";
   for (const auto& ai : a) {
     for (const auto& bj : b) {
       for (auto& plan : createJoinCandidates(ai, bj, tg)) {
-        candidates[getPruningKey(plan, plan._qet->resultSortedOn())]
-            .emplace_back(std::move(plan));
+        auto key = getPruningKey(
+            plan, plan._qet->getRootOperation()->getResultSortedOn());
+        auto it = candidates.find(key);
+        if (it == candidates.end()) {
+          it = candidates.emplace(std::move(key), PlanVec{_qec->getAllocator()})
+                   .first;
+        }
+        it->second.emplace_back(std::move(plan));
         checkCancellation();
       }
     }
@@ -1253,7 +1291,7 @@ std::vector<SubtreePlan> QueryPlanner::merge(
   // Therefore we mapped plans and use contained triples + ordering var
   // as key.
   AD_LOG_TRACE << "Pruning...\n";
-  vector<SubtreePlan> prunedPlans;
+  PlanVec prunedPlans{_qec->getAllocator()};
 
   auto pruneCandidates = [&](auto& actualCandidates) {
     for (auto& [key, value] : actualCandidates) {
@@ -1265,9 +1303,9 @@ std::vector<SubtreePlan> QueryPlanner::merge(
   };
 
   if (isInTestMode()) {
-    std::vector<std::pair<std::string, vector<SubtreePlan>>> sortedCandidates{
-        ql::make_move_iterator(candidates.begin()),
-        ql::make_move_iterator(candidates.end())};
+    CandidateList sortedCandidates{ql::make_move_iterator(candidates.begin()),
+                                   ql::make_move_iterator(candidates.end()),
+                                   _qec->getAllocator()};
     std::sort(sortedCandidates.begin(), sortedCandidates.end(),
               [](const auto& a, const auto& b) { return a.first < b.first; });
     pruneCandidates(sortedCandidates);
@@ -1318,7 +1356,7 @@ QueryPlanner::JoinColumns QueryPlanner::connected(
   // Check if there is overlap.
   // If so, don't consider them as properly connected.
   if ((a._idsOfIncludedNodes & b._idsOfIncludedNodes) != 0) {
-    return {};
+    return JoinColumns{a._qet->getRootOperation()->allocator()};
   }
 
   // If a substitute is contained, do not use the triple graph. This is because
@@ -1345,7 +1383,7 @@ QueryPlanner::JoinColumns QueryPlanner::connected(
       }
     }
   }
-  return {};
+  return JoinColumns{a._qet->getRootOperation()->allocator()};
 }
 
 // _____________________________________________________________________________
@@ -1357,8 +1395,7 @@ QueryPlanner::JoinColumns QueryPlanner::getJoinColumns(const SubtreePlan& a,
 
 // _____________________________________________________________________________
 std::string QueryPlanner::getPruningKey(
-    const SubtreePlan& plan,
-    const vector<ColumnIndex>& orderedOnColumns) const {
+    const SubtreePlan& plan, ql::span<const ColumnIndex> orderedOnColumns) const {
   // Get the ordered var
   std::ostringstream os;
   const auto& varCols = plan._qet->getVariableColumns();
@@ -1387,7 +1424,7 @@ std::string QueryPlanner::getPruningKey(
 // _____________________________________________________________________________
 template <QueryPlanner::FilterMode mode>
 void QueryPlanner::applyFiltersIfPossible(
-    vector<SubtreePlan>& row,
+    PlanVec& row,
     const FiltersAndOptionalSubstitutes& filters) const {
   // Apply every filter possible.
   // It is possible when,
@@ -1411,7 +1448,7 @@ void QueryPlanner::applyFiltersIfPossible(
 
   // Note: we are first collecting the newly added plans and then adding them
   // in one go. Changing `row` inside the loop would invalidate the iterators.
-  std::vector<SubtreePlan> addedPlans;
+  PlanVec addedPlans{_qec->getAllocator()};
   for (auto& plan : row) {
     for (const auto& [i, filterAndSubst] :
          ::ranges::views::enumerate(filters)) {
@@ -1493,7 +1530,7 @@ void QueryPlanner::applyFiltersIfPossible(
 }
 
 // _____________________________________________________________________________
-void QueryPlanner::applyTextLimitsIfPossible(vector<SubtreePlan>& row,
+void QueryPlanner::applyTextLimitsIfPossible(PlanVec& row,
                                              const TextLimitVec& textLimits,
                                              bool replace) const {
   // Apply text limits if possible.
@@ -1506,7 +1543,7 @@ void QueryPlanner::applyTextLimitsIfPossible(vector<SubtreePlan>& row,
   if (!textLimit_.has_value()) {
     return;
   }
-  std::vector<SubtreePlan> addedPlans;
+  PlanVec addedPlans{_qec->getAllocator()};
   for (auto& plan : row) {
     size_t i = 0;
     for (const auto& [textVar, textLimit] : textLimits) {
@@ -1555,9 +1592,10 @@ void QueryPlanner::applyTextLimitsIfPossible(vector<SubtreePlan>& row,
 
 // _____________________________________________________________________________
 size_t QueryPlanner::findUniqueNodeIds(
-    const std::vector<SubtreePlan>& connectedComponent,
+    const PlanVec& connectedComponent,
     bool allowReplacementPlans) {
-  ad_utility::HashSet<uint64_t> uniqueNodeIds;
+  ad_utility::HashSetWithMemoryLimit<uint64_t> uniqueNodeIds{
+      connectedComponent.get_allocator()};
   auto nodeIds = connectedComponent |
                  ql::views::transform(&SubtreePlan::_idsOfIncludedNodes);
   // Check that all the `_idsOfIncludedNodes` are one-hot encodings of a single
@@ -1572,13 +1610,13 @@ size_t QueryPlanner::findUniqueNodeIds(
 }
 
 // _____________________________________________________________________________
-std::vector<SubtreePlan>
+QueryPlanner::PlanVec
 QueryPlanner::runDynamicProgrammingOnConnectedComponent(
-    std::vector<SubtreePlan> connectedComponent,
+    PlanVec connectedComponent,
     const FiltersAndOptionalSubstitutes& filters,
     const TextLimitVec& textLimits, const TripleGraph& tg,
     ReplacementPlans&& replacementPlans) const {
-  std::vector<std::vector<SubtreePlan>> dpTab;
+  PlanMatrix dpTab{_qec->getAllocator()};
   // find the unique number of nodes in the current connected component
   // (there might be duplicates because we already have multiple candidates
   // for each index scan with different permutations.
@@ -1590,11 +1628,11 @@ QueryPlanner::runDynamicProgrammingOnConnectedComponent(
                  << std::endl;
     applyFiltersIfPossible<FilterMode::KeepUnfiltered>(dpTab.back(), filters);
     applyTextLimitsIfPossible(dpTab.back(), textLimits, false);
-    dpTab.emplace_back();
+    dpTab.emplace_back(_qec->getAllocator());
 
     // Helper to add plans new plans to the current round.
     auto& dpRow = dpTab[k - 1];
-    auto extendDpRow = [&dpRow](std::vector<SubtreePlan>& newPlans) {
+    auto extendDpRow = [&dpRow](PlanVec& newPlans) {
       dpRow.reserve(dpRow.size() + newPlans.size());
       ql::ranges::move(newPlans, std::back_inserter(dpRow));
     };
@@ -1629,8 +1667,8 @@ QueryPlanner::runDynamicProgrammingOnConnectedComponent(
 }
 
 // _____________________________________________________________________________
-size_t QueryPlanner::countSubgraphs(std::vector<const SubtreePlan*> graph,
-                                    const std::vector<SparqlFilter>& filters,
+size_t QueryPlanner::countSubgraphs(qlever::vector<const SubtreePlan*> graph,
+                                    const qlever::vector<SparqlFilter>& filters,
                                     size_t budget) {
   // Remove duplicate plans from `graph`.
   auto getId = [](const SubtreePlan* v) { return v->_idsOfIncludedNodes; };
@@ -1648,7 +1686,15 @@ size_t QueryPlanner::countSubgraphs(std::vector<const SubtreePlan*> graph,
   // is contained in the `filters`, because this will bring the estimate of this
   // function closer to the actual behavior of the DP query planner (it always
   // applies either all possible filters at once, or none of them).
-  std::vector<SubtreePlan> dummyPlansForFilter;
+  PlanVec dummyPlansForFilter{_qec->getAllocator()};
+  // Note: `deduplicatedFilterVariables`/`varSet` are deliberately left as
+  // plain (default-allocator) `ad_utility::HashSet`s: a set-of-sets requires
+  // its element type to be hashable, which `HashSetWithMemoryLimit`
+  // (`std::unordered_set`) does not support out of the box, whereas
+  // `absl::flat_hash_set` does (via `AbslHashValue`). Converting this would
+  // require a custom hasher; the sets here are small and short-lived
+  // (bounded by the number of filters in the query), so this is a deliberate
+  // exception to the allocator-everywhere rule.
   ad_utility::HashSet<ad_utility::HashSet<Variable>>
       deduplicatedFilterVariables;
   for (const auto& filter : filters) {
@@ -1656,7 +1702,7 @@ size_t QueryPlanner::countSubgraphs(std::vector<const SubtreePlan*> graph,
     ad_utility::HashSet<Variable> varSet;
     // We use a `VALUES` clause as the dummy because this operation is the
     // easiest to setup for a number of given variables.
-    parsedQuery::SparqlValues values;
+    parsedQuery::SparqlValues values{_qec->getAllocator()};
     for (auto* var : vars) {
       values._variables.push_back(*var);
       varSet.insert(*var);
@@ -1701,8 +1747,8 @@ size_t QueryPlanner::countSubgraphs(std::vector<const SubtreePlan*> graph,
 }
 
 // _____________________________________________________________________________
-std::vector<SubtreePlan> QueryPlanner::runGreedyPlanningOnConnectedComponent(
-    std::vector<SubtreePlan> connectedComponent,
+QueryPlanner::PlanVec QueryPlanner::runGreedyPlanningOnConnectedComponent(
+    PlanVec connectedComponent,
     const FiltersAndOptionalSubstitutes& filters,
     const TextLimitVec& textLimits, const TripleGraph& tg,
     ReplacementPlans&& replacementPlans) const {
@@ -1726,7 +1772,7 @@ std::vector<SubtreePlan> QueryPlanner::runGreedyPlanningOnConnectedComponent(
 
   // Intermediate variables that will be filled by the `greedyStep` lambda
   // below.
-  using Plans = std::vector<SubtreePlan>;
+  using Plans = PlanVec;
 
   // Perform a single step of greedy query planning.
   // `nextBestPlan` contains the result of the last step of greedy query
@@ -1740,7 +1786,7 @@ std::vector<SubtreePlan> QueryPlanner::runGreedyPlanningOnConnectedComponent(
   // planning is performed, which also establishes the pre-/postconditions.
   auto greedyStep = [this, &tg, &filters, &textLimits,
                      currentPlans = std::move(connectedComponent),
-                     cache = Plans{}](Plans& nextBestPlan, bool isFirstStep,
+                     cache = Plans{_qec->getAllocator()}](Plans& nextBestPlan, bool isFirstStep,
                                       bool isLastStep) mutable {
     checkCancellation();
     // Normally, we already have all combinations of two nodes in `currentPlans`
@@ -1781,7 +1827,7 @@ std::vector<SubtreePlan> QueryPlanner::runGreedyPlanningOnConnectedComponent(
     ql::erase_if(cache, shouldBeErased);
   };
 
-  Plans result;
+  Plans result{_qec->getAllocator()};
   for (size_t i : ad_utility::integerRange(numSeeds - 1)) {
     greedyStep(result, i == 0, i == numSeeds - 2);
   }
@@ -1791,8 +1837,8 @@ std::vector<SubtreePlan> QueryPlanner::runGreedyPlanningOnConnectedComponent(
 
 // _____________________________________________________________________________
 QueryPlanner::FiltersAndOptionalSubstitutes QueryPlanner::seedFilterSubstitutes(
-    const std::vector<SparqlFilter>& filters) {
-  FiltersAndOptionalSubstitutes plans;
+    const qlever::vector<SparqlFilter>& filters) {
+  FiltersAndOptionalSubstitutes plans{_qec->getAllocator()};
   plans.reserve(filters.size());
 
   for (const auto& [i, filterExpression] :
@@ -1819,8 +1865,8 @@ QueryPlanner::FiltersAndOptionalSubstitutes QueryPlanner::seedFilterSubstitutes(
 // _____________________________________________________________________________
 QueryPlanner::FiltersAndOptionalSubstitutes
 QueryPlanner::wrapFiltersWithoutSubstitutes(
-    const std::vector<SparqlFilter>& filters) {
-  FiltersAndOptionalSubstitutes plans;
+    const std::vector<SparqlFilter>& filters, qlever::Allocator<Id> allocator) {
+  FiltersAndOptionalSubstitutes plans{std::move(allocator)};
   plans.reserve(filters.size());
   for (const auto& filter : filters) {
     plans.push_back({filter, std::nullopt});
@@ -1829,9 +1875,9 @@ QueryPlanner::wrapFiltersWithoutSubstitutes(
 }
 
 // _____________________________________________________________________________
-std::vector<std::vector<SubtreePlan>> QueryPlanner::fillDpTab(
-    const QueryPlanner::TripleGraph& tg, vector<SparqlFilter> filters,
-    TextLimitMap& textLimits, const vector<vector<SubtreePlan>>& children,
+QueryPlanner::PlanMatrix QueryPlanner::fillDpTab(
+    const QueryPlanner::TripleGraph& tg, qlever::vector<SparqlFilter> filters,
+    TextLimitMap& textLimits, const PlanMatrix& children,
     ReplacementPlans replacementPlans) {
   auto [initialPlans, additionalFilters] =
       seedWithScansAndText(tg, children, textLimits);
@@ -1848,14 +1894,27 @@ std::vector<std::vector<SubtreePlan>> QueryPlanner::fillDpTab(
   auto componentIndices = QueryGraph::computeConnectedComponents(
       initialPlans, filtersAndOptSubstitutes);
 
-  ad_utility::HashMap<size_t, std::vector<SubtreePlan>> components;
+  // `HashMapWithMemoryLimit` (backed by `std::unordered_map`) is used instead
+  // of the plain `ad_utility::HashMap`, because the latter cannot safely use
+  // `qlever::Allocator` (see `util/HashMap.h`). Note that `PlanVec` is not
+  // default-constructible (its allocator requires a memory limit), so we
+  // cannot rely on `operator[]` to default-construct missing entries and
+  // instead insert them explicitly.
+  ad_utility::HashMapWithMemoryLimit<size_t, PlanVec> components{
+      _qec->getAllocator()};
   for (size_t i = 0; i < componentIndices.size(); ++i) {
-    components[componentIndices.at(i)].push_back(std::move(initialPlans.at(i)));
+    size_t key = componentIndices.at(i);
+    auto it = components.find(key);
+    if (it == components.end()) {
+      it = components.emplace(key, PlanVec{_qec->getAllocator()}).first;
+    }
+    it->second.push_back(std::move(initialPlans.at(i)));
   }
-  vector<vector<SubtreePlan>> lastDpRowFromComponents;
-  TextLimitVec textLimitVec(textLimits.begin(), textLimits.end());
+  PlanMatrix lastDpRowFromComponents{_qec->getAllocator()};
+  TextLimitVec textLimitVec(textLimits.begin(), textLimits.end(),
+                           _qec->getAllocator());
   for (auto& component : components | ql::views::values) {
-    std::vector<const SubtreePlan*> g;
+    qlever::vector<const SubtreePlan*> g{_qec->getAllocator()};
     uint64_t coveredNodes = 0;
     for (const auto& plan : component) {
       g.push_back(&plan);
@@ -1879,9 +1938,9 @@ std::vector<std::vector<SubtreePlan>> QueryPlanner::fillDpTab(
                     ? &QueryPlanner::runGreedyPlanningOnConnectedComponent
                     : &QueryPlanner::runDynamicProgrammingOnConnectedComponent;
 
-    std::vector<SubtreePlan> lastDpRow;
+    PlanVec lastDpRow{_qec->getAllocator()};
 
-    auto addCandidates = [&lastDpRow](std::vector<SubtreePlan> candidates) {
+    auto addCandidates = [&lastDpRow](PlanVec candidates) {
       std::move(candidates.begin(), candidates.end(),
                 std::back_inserter(lastDpRow));
     };
@@ -1892,7 +1951,8 @@ std::vector<std::vector<SubtreePlan>> QueryPlanner::fillDpTab(
       // a baseline plan. This plan may be better than the replacement if a
       // certain sorting is required that the replacement doesn't provide.
       addCandidates(std::invoke(impl, this, component, filtersAndOptSubstitutes,
-                                textLimitVec, tg, ReplacementPlans{}));
+                                textLimitVec, tg,
+                                ReplacementPlans{_qec->getAllocator()}));
 
       // Then remove the plans for the nodes covered by replacement plans and
       // insert the replacement plans.
@@ -1910,7 +1970,7 @@ std::vector<std::vector<SubtreePlan>> QueryPlanner::fillDpTab(
   if (numConnectedComponents == 0) {
     // This happens for example if there is a BIND right at the beginning of the
     // query
-    lastDpRowFromComponents.emplace_back();
+    lastDpRowFromComponents.emplace_back(_qec->getAllocator());
     return lastDpRowFromComponents;
   }
   if (numConnectedComponents == 1) {
@@ -1922,8 +1982,10 @@ std::vector<std::vector<SubtreePlan>> QueryPlanner::fillDpTab(
     return lastDpRowFromComponents;
   }
   // More than one connected component, set up a Cartesian product.
-  std::vector<std::vector<SubtreePlan>> result;
-  result.emplace_back();
+  PlanMatrix result{_qec->getAllocator()};
+  result.emplace_back(_qec->getAllocator());
+  // Plain: constructs a `CartesianProductJoin::Children` below, whose type is
+  // fixed by that out-of-scope engine class.
   std::vector<std::shared_ptr<QueryExecutionTree>> subtrees;
   // We need to manually inform the cartesian produce about
   // its included nodes and filters and text limits to make the
@@ -1961,25 +2023,40 @@ std::vector<std::vector<SubtreePlan>> QueryPlanner::fillDpTab(
 }
 
 // _____________________________________________________________________________
-std::vector<std::pair<QueryPlanner::TripleGraph, std::vector<SparqlFilter>>>
+bool QueryPlanner::TripleGraph::isTextNode(size_t i) const {
+  auto it = _nodeMap.find(i);
+  if (it == _nodeMap.end()) {
+    return false;
+  }
+  const auto& triple = it->second->triple_;
+  auto predicate = triple.getSimplePredicate();
+  return predicate == CONTAINS_ENTITY_PREDICATE ||
+         predicate == CONTAINS_WORD_PREDICATE;
+}
+
+// _____________________________________________________________________________
+qlever::vector<std::pair<QueryPlanner::TripleGraph, qlever::vector<SparqlFilter>>>
 QueryPlanner::TripleGraph::splitAtContextVars(
-    const vector<SparqlFilter>& origFilters,
-    ad_utility::HashMap<std::string, vector<size_t>>& contextVarToTextNodes)
-    const {
-  vector<std::pair<QueryPlanner::TripleGraph, vector<SparqlFilter>>> retVal;
+    const qlever::vector<SparqlFilter>& origFilters,
+    ad_utility::HashMapWithMemoryLimit<std::string, qlever::vector<size_t>>&
+        contextVarToTextNodes) const {
+  qlever::vector<std::pair<QueryPlanner::TripleGraph, qlever::vector<SparqlFilter>>>
+      retVal{_nodeMap.get_allocator()};
   // Recursively split the graph a context nodes.
   // Base-case: No no context nodes, return the graph itself.
   if (contextVarToTextNodes.size() == 0) {
     retVal.emplace_back(make_pair(*this, origFilters));
   } else {
     // Just take the first contextVar and split at it.
-    ad_utility::HashSet<size_t> textNodeIds;
+    ad_utility::HashSetWithMemoryLimit<size_t> textNodeIds{
+        _nodeMap.get_allocator()};
     textNodeIds.insert(contextVarToTextNodes.begin()->second.begin(),
                        contextVarToTextNodes.begin()->second.end());
 
     // For the next iteration / recursive call(s):
     // Leave out the first one because it has been worked on in this call.
-    ad_utility::HashMap<std::string, vector<size_t>> cTMapNextIteration;
+    ad_utility::HashMapWithMemoryLimit<std::string, qlever::vector<size_t>>
+        cTMapNextIteration{_nodeMap.get_allocator()};
     cTMapNextIteration.insert(++contextVarToTextNodes.begin(),
                               contextVarToTextNodes.end());
 
@@ -1999,7 +2076,8 @@ QueryPlanner::TripleGraph::splitAtContextVars(
         // Recursively solve this split
         // (because there may be another context var in it)
         TripleGraph withoutText(*this, reachableNodes);
-        vector<SparqlFilter> filters = pickFilters(origFilters, reachableNodes);
+        qlever::vector<SparqlFilter> filters =
+            pickFilters(origFilters, reachableNodes);
         auto recursiveResult =
             withoutText.splitAtContextVars(filters, cTMapNextIteration);
         retVal.insert(retVal.begin(), recursiveResult.begin(),
@@ -2008,8 +2086,10 @@ QueryPlanner::TripleGraph::splitAtContextVars(
         // Case: The split created two or more non-empty parts.
         // Find all parts so that the number of triples in them plus
         // the number of text triples equals the number of total triples.
-        vector<vector<size_t>> setsOfReachablesNodes;
-        ad_utility::HashSet<size_t> nodesDone;
+        qlever::vector<qlever::vector<size_t>> setsOfReachablesNodes{
+            _nodeMap.get_allocator()};
+        ad_utility::HashSetWithMemoryLimit<size_t> nodesDone{
+            _nodeMap.get_allocator()};
         nodesDone.insert(textNodeIds.begin(), textNodeIds.end());
         nodesDone.insert(reachableNodes.begin(), reachableNodes.end());
         setsOfReachablesNodes.emplace_back(reachableNodes);
@@ -2027,7 +2107,8 @@ QueryPlanner::TripleGraph::splitAtContextVars(
         // vars.
         for (const auto& rNodes : setsOfReachablesNodes) {
           TripleGraph smallerGraph(*this, rNodes);
-          vector<SparqlFilter> filters = pickFilters(origFilters, rNodes);
+          qlever::vector<SparqlFilter> filters =
+              pickFilters(origFilters, rNodes);
           auto recursiveResult =
               smallerGraph.splitAtContextVars(filters, cTMapNextIteration);
           retVal.insert(retVal.begin(), recursiveResult.begin(),
@@ -2040,11 +2121,12 @@ QueryPlanner::TripleGraph::splitAtContextVars(
 }
 
 // _____________________________________________________________________________
-std::vector<size_t> QueryPlanner::TripleGraph::bfsLeaveOut(
-    size_t startNode, ad_utility::HashSet<size_t> leaveOut) const {
-  vector<size_t> res;
-  ad_utility::HashSet<size_t> visited;
-  std::list<size_t> queue;
+qlever::vector<size_t> QueryPlanner::TripleGraph::bfsLeaveOut(
+    size_t startNode,
+    ad_utility::HashSetWithMemoryLimit<size_t> leaveOut) const {
+  qlever::vector<size_t> res{_nodeMap.get_allocator()};
+  ad_utility::HashSetWithMemoryLimit<size_t> visited{_nodeMap.get_allocator()};
+  qlever::list<size_t> queue{_nodeMap.get_allocator()};
   queue.push_back(startNode);
   visited.insert(startNode);
   while (!queue.empty()) {
@@ -2063,11 +2145,12 @@ std::vector<size_t> QueryPlanner::TripleGraph::bfsLeaveOut(
 }
 
 // _____________________________________________________________________________
-std::vector<SparqlFilter> QueryPlanner::TripleGraph::pickFilters(
-    const vector<SparqlFilter>& origFilters,
-    const vector<size_t>& nodes) const {
-  vector<SparqlFilter> ret;
-  ad_utility::HashSet<Variable> coveredVariables;
+qlever::vector<SparqlFilter> QueryPlanner::TripleGraph::pickFilters(
+    const qlever::vector<SparqlFilter>& origFilters,
+    const qlever::vector<size_t>& nodes) const {
+  qlever::vector<SparqlFilter> ret{_nodeMap.get_allocator()};
+  ad_utility::HashSetWithMemoryLimit<Variable> coveredVariables{
+      _nodeMap.get_allocator()};
   for (auto n : nodes) {
     auto& node = *_nodeMap.find(n)->second;
     coveredVariables.insert(node._variables.begin(), node._variables.end());
@@ -2084,24 +2167,32 @@ std::vector<SparqlFilter> QueryPlanner::TripleGraph::pickFilters(
 
 // _____________________________________________________________________________
 QueryPlanner::TripleGraph::TripleGraph(
-    const std::vector<std::pair<Node, std::vector<size_t>>>& init) {
+    const std::vector<std::pair<Node, std::vector<size_t>>>& init,
+    qlever::Allocator<Id> allocator)
+    : _adjLists{allocator}, _nodeMap{allocator}, _nodeStorage{allocator} {
   for (const std::pair<Node, std::vector<size_t>>& p : init) {
     _nodeStorage.push_back(p.first);
     _nodeMap[p.first.id_] = &_nodeStorage.back();
-    _adjLists.push_back(p.second);
+    _adjLists.push_back(qlever::vector<size_t>(p.second.begin(),
+                                               p.second.end(), allocator));
   }
 }
 
 // _____________________________________________________________________________
 QueryPlanner::TripleGraph::TripleGraph(const QueryPlanner::TripleGraph& other,
-                                       vector<size_t> keepNodes) {
-  ad_utility::HashSet<size_t> keep;
+                                       qlever::vector<size_t> keepNodes)
+    : _adjLists{other._nodeMap.get_allocator()},
+      _nodeMap{other._nodeMap.get_allocator()},
+      _nodeStorage{other._nodeMap.get_allocator()} {
+  ad_utility::HashSetWithMemoryLimit<size_t> keep{
+      other._nodeMap.get_allocator()};
   for (auto v : keepNodes) {
     keep.insert(v);
   }
   // Copy nodes to be kept and assign new node id's.
   // Keep information about the id change in a map.
-  ad_utility::HashMap<size_t, size_t> idChange;
+  ad_utility::HashMapWithMemoryLimit<size_t, size_t> idChange{
+      other._nodeMap.get_allocator()};
   for (size_t i = 0; i < other._nodeMap.size(); ++i) {
     if (keep.count(i) > 0) {
       _nodeStorage.push_back(*other._nodeMap.find(i)->second);
@@ -2113,7 +2204,7 @@ QueryPlanner::TripleGraph::TripleGraph(const QueryPlanner::TripleGraph& other,
   // Adjust adjacency lists accordingly.
   for (size_t i = 0; i < other._adjLists.size(); ++i) {
     if (keep.count(i) > 0) {
-      vector<size_t> adjList;
+      qlever::vector<size_t> adjList{other._nodeMap.get_allocator()};
       for (size_t v : other._adjLists[i]) {
         if (keep.count(v) > 0) {
           adjList.push_back(idChange[v]);
@@ -2126,7 +2217,9 @@ QueryPlanner::TripleGraph::TripleGraph(const QueryPlanner::TripleGraph& other,
 
 // _____________________________________________________________________________
 QueryPlanner::TripleGraph::TripleGraph(const TripleGraph& other)
-    : _adjLists(other._adjLists), _nodeMap(), _nodeStorage() {
+    : _adjLists(other._adjLists),
+      _nodeMap{other._nodeMap.get_allocator()},
+      _nodeStorage{other._nodeMap.get_allocator()} {
   for (auto it : other._nodeMap) {
     _nodeStorage.push_back(*it.second);
     _nodeMap[it.first] = &_nodeStorage.back();
@@ -2145,8 +2238,8 @@ QueryPlanner::TripleGraph& QueryPlanner::TripleGraph::operator=(
 }
 
 // _____________________________________________________________________________
-QueryPlanner::TripleGraph::TripleGraph()
-    : _adjLists(), _nodeMap(), _nodeStorage() {}
+QueryPlanner::TripleGraph::TripleGraph(qlever::Allocator<Id> allocator)
+    : _adjLists{allocator}, _nodeMap{allocator}, _nodeStorage(allocator) {}
 
 // _____________________________________________________________________________
 bool QueryPlanner::TripleGraph::isSimilar(
@@ -2161,8 +2254,10 @@ bool QueryPlanner::TripleGraph::isSimilar(
                 << std::endl;
     return false;
   }
-  ad_utility::HashMap<size_t, size_t> id_map;
-  ad_utility::HashMap<size_t, size_t> id_map_reverse;
+  ad_utility::HashMapWithMemoryLimit<size_t, size_t> id_map{
+      _nodeMap.get_allocator()};
+  ad_utility::HashMapWithMemoryLimit<size_t, size_t> id_map_reverse{
+      _nodeMap.get_allocator()};
   for (const Node& n : _nodeStorage) {
     bool hasMatch = false;
     for (const Node& n2 : other._nodeStorage) {
@@ -2193,8 +2288,9 @@ bool QueryPlanner::TripleGraph::isSimilar(
   }
   for (size_t id = 0; id < _adjLists.size(); ++id) {
     size_t other_id = id_map[id];
-    ad_utility::HashSet<size_t> adj_set;
-    ad_utility::HashSet<size_t> other_adj_set;
+    ad_utility::HashSetWithMemoryLimit<size_t> adj_set{_nodeMap.get_allocator()};
+    ad_utility::HashSetWithMemoryLimit<size_t> other_adj_set{
+        _nodeMap.get_allocator()};
     for (size_t a : _adjLists[id]) {
       adj_set.insert(a);
     }
@@ -2234,7 +2330,7 @@ void QueryPlanner::setEnablePatternTrick(bool enablePatternTrick) {
 
 // _________________________________________________________________________________
 size_t QueryPlanner::findCheapestExecutionTree(
-    const std::vector<SubtreePlan>& lastRow) const {
+    const PlanVec& lastRow) const {
   AD_CONTRACT_CHECK(!lastRow.empty());
   checkCancellation();
   auto compare = [this](const auto& a, const auto& b) {
@@ -2251,7 +2347,7 @@ size_t QueryPlanner::findCheapestExecutionTree(
 
 // _________________________________________________________________________________
 size_t QueryPlanner::findSmallestExecutionTree(
-    const std::vector<SubtreePlan>& lastRow) {
+    const PlanVec& lastRow) {
   AD_CONTRACT_CHECK(!lastRow.empty());
   auto compare = [](const auto& a, const auto& b) {
     auto tie = [](const auto& x) {
@@ -2263,7 +2359,7 @@ size_t QueryPlanner::findSmallestExecutionTree(
 }
 
 // _____________________________________________________________________________
-std::vector<SubtreePlan> QueryPlanner::createJoinCandidates(
+QueryPlanner::PlanVec QueryPlanner::createJoinCandidates(
     const SubtreePlan& ain, const SubtreePlan& bin,
     boost::optional<const TripleGraph&> tg) const {
   bool swapForTesting = isInTestMode() && bin.type != SubtreePlan::OPTIONAL &&
@@ -2274,18 +2370,19 @@ std::vector<SubtreePlan> QueryPlanner::createJoinCandidates(
 }
 
 // _____________________________________________________________________________
-std::vector<SubtreePlan> QueryPlanner::createJoinCandidatesAllowEmpty(
+QueryPlanner::PlanVec QueryPlanner::createJoinCandidatesAllowEmpty(
     const SubtreePlan& ain, const SubtreePlan& bin,
     const JoinColumns& jcs) const {
   if (jcs.empty()) {
-    return std::vector{makeSubtreePlan<CartesianProductJoin>(
-        _qec, std::vector{ain._qet, bin._qet})};
+    return PlanVec{{makeSubtreePlan<CartesianProductJoin>(
+                       _qec, std::vector{ain._qet, bin._qet})},
+                  _qec->getAllocator()};
   }
   return createJoinCandidates(ain, bin, jcs);
 }
 
 // _____________________________________________________________________________
-std::vector<SubtreePlan> QueryPlanner::createJoinCandidates(
+QueryPlanner::PlanVec QueryPlanner::createJoinCandidates(
     const SubtreePlan& ain, const SubtreePlan& bin,
     const JoinColumns& jcs) const {
   checkCancellation();
@@ -2293,7 +2390,7 @@ std::vector<SubtreePlan> QueryPlanner::createJoinCandidates(
                         ain._qet->getCacheKey() < bin._qet->getCacheKey();
   const auto& a = !swapForTesting ? ain : bin;
   const auto& b = !swapForTesting ? bin : ain;
-  std::vector<SubtreePlan> candidates;
+  PlanVec candidates{_qec->getAllocator()};
 
   if (jcs.empty()) {
     // The candidates are not connected
@@ -2329,13 +2426,15 @@ std::vector<SubtreePlan> QueryPlanner::createJoinCandidates(
   // further into the query that optional should be resolved by now.
   AD_CONTRACT_CHECK(a.type != SubtreePlan::OPTIONAL);
   if (b.type == SubtreePlan::MINUS) {
-    return {makeSubtreePlan<Minus>(_qec, a._qet, b._qet)};
+    return PlanVec{{makeSubtreePlan<Minus>(_qec, a._qet, b._qet)},
+                  _qec->getAllocator()};
   }
 
   // OPTIONAL JOINS are not symmetric!
   if (b.type == SubtreePlan::OPTIONAL) {
     // Join the two optional columns using an optional join
-    return {makeSubtreePlan<OptionalJoin>(_qec, a._qet, b._qet)};
+    return PlanVec{{makeSubtreePlan<OptionalJoin>(_qec, a._qet, b._qet)},
+                  _qec->getAllocator()};
   }
 
   if (auto opt = createJoinWithPathSearch(a, b, jcs)) {
@@ -2451,9 +2550,9 @@ namespace {
 std::pair<QueryPlanner::JoinColumns, QueryPlanner::JoinColumns>
 mapColumnsInUnion(size_t columnIndex, const Union& unionOperation,
                   const QueryPlanner::JoinColumns& jcs) {
-  QueryPlanner::JoinColumns leftMapping;
+  QueryPlanner::JoinColumns leftMapping{jcs.get_allocator()};
   leftMapping.reserve(jcs.size());
-  QueryPlanner::JoinColumns rightMapping;
+  QueryPlanner::JoinColumns rightMapping{jcs.get_allocator()};
   rightMapping.reserve(jcs.size());
   auto mapColumns = [columnIndex, &unionOperation](
                         bool isLeft, std::array<ColumnIndex, 2> columns)
@@ -2489,11 +2588,11 @@ SubtreePlan cloneWithNewTree(const SubtreePlan& plan,
 // _____________________________________________________________________________________________________________________
 auto QueryPlanner::applyJoinDistributivelyToUnion(
     const SubtreePlan& a, const SubtreePlan& b,
-    const JoinColumns& jcs) const -> std::vector<SubtreePlan> {
+    const JoinColumns& jcs) const -> PlanVec {
   AD_CORRECTNESS_CHECK(!jcs.empty());
   AD_CORRECTNESS_CHECK(a.type == SubtreePlan::BASIC &&
                        b.type == SubtreePlan::BASIC);
-  std::vector<SubtreePlan> candidates{};
+  PlanVec candidates{_qec->getAllocator()};
   // Disable this optimization.
   if (!getRuntimeParameter<&RuntimeParameters::enableDistributiveUnion_>()) {
     return candidates;
@@ -2667,7 +2766,7 @@ auto QueryPlanner::createJoinWithTransitivePath(
 // _____________________________________________________________________________
 auto QueryPlanner::createMaterializedViewJoinReplacements(
     const parsedQuery::BasicGraphPattern& triples) const -> ReplacementPlans {
-  ReplacementPlans plans;
+  ReplacementPlans plans{_qec->getAllocator()};
 
   // Check if the user allows query rewriting.
   // TODO<ullingerc> Do we want to forcefully disable query rewriting if delta
@@ -2704,7 +2803,7 @@ auto QueryPlanner::createMaterializedViewJoinReplacements(
     size_t numCoveredTriples = absl::popcount(coveredTriples);
     // Empty vectors of replacement plans for smaller numbers of triples.
     for (size_t i = plans.size(); i < numCoveredTriples; ++i) {
-      plans.push_back({});
+      plans.push_back(PlanVec{_qec->getAllocator()});
     }
     plans.at(numCoveredTriples - 1).push_back(std::move(plan));
   }
@@ -2842,46 +2941,78 @@ auto QueryPlanner::createJoinWithPathSearch(
 
 // _____________________________________________________________________
 void QueryPlanner::QueryGraph::setupGraph(
-    const std::vector<SubtreePlan>& leafOperations,
+    const PlanVec& leafOperations,
     const FiltersAndOptionalSubstitutes& filtersAndOptionalSubstitutes) {
   // Prepare the `nodes_` vector for the graph. We have one node for each leaf
   // of what later becomes the `QueryExecutionTree`.
   for (const auto& leafOperation : leafOperations) {
-    nodes_.push_back(std::make_shared<Node>(&leafOperation));
+    nodes_.push_back(std::make_shared<Node>(&leafOperation, allocator_));
   }
 
   // Set up a hash map from variables to nodes that contain this variable.
-  const ad_utility::HashMap<Variable, std::vector<Node*>> varToNode = [this]() {
-    ad_utility::HashMap<Variable, std::vector<Node*>> result;
-    for (const auto& node : nodes_) {
-      const auto& variableColumns = node->plan_->_qet->getVariableColumns();
-      // Make sure plans with the same id without variables count as
-      // connected.
-      if (variableColumns.empty()) {
-        // Dummy variable that can not be created using the SPARQL grammar.
-        result[Variable{absl::StrCat("??", node->plan_->_idsOfIncludedNodes),
-                        false}]
-            .push_back(node.get());
-      }
-      for (const auto& var : variableColumns | ql::views::keys) {
-        result[var].push_back(node.get());
-      }
-    }
-    return result;
-  }();
+  const ad_utility::HashMapWithMemoryLimit<Variable, qlever::vector<Node*>>
+      varToNode = [this]() {
+        ad_utility::HashMapWithMemoryLimit<Variable, qlever::vector<Node*>>
+            result{allocator_};
+        // `result[var]` cannot be used directly because the mapped
+        // `qlever::vector<Node*>` is not default-constructible (it always
+        // needs an explicit allocator).
+        auto addNode = [this, &result](const Variable& var, Node* node) {
+          auto it = result.find(var);
+          if (it == result.end()) {
+            it = result.try_emplace(var, qlever::vector<Node*>{allocator_})
+                     .first;
+          }
+          it->second.push_back(node);
+        };
+        for (const auto& node : nodes_) {
+          const auto& variableColumns =
+              node->plan_->_qet->getVariableColumns();
+          // Make sure plans with the same id without variables count as
+          // connected.
+          if (variableColumns.empty()) {
+            // Dummy variable that can not be created using the SPARQL
+            // grammar.
+            addNode(Variable{
+                        absl::StrCat("??", node->plan_->_idsOfIncludedNodes),
+                        false},
+                    node.get());
+          }
+          for (const auto& var : variableColumns | ql::views::keys) {
+            addNode(var, node.get());
+          }
+        }
+        return result;
+      }();
   // Set up a hash map from nodes to their adjacentNodes_. Two nodes are
   // adjacent if they share a variable. The adjacentNodes_ are stored as hash
   // sets so we don't need to worry about duplicates.
-  ad_utility::HashMap<Node*, ad_utility::HashSet<Node*>> adjacentNodes =
-      [&varToNode, &filtersAndOptionalSubstitutes]() {
-        ad_utility::HashMap<Node*, ad_utility::HashSet<Node*>> result;
+  ad_utility::HashMapWithMemoryLimit<Node*,
+                                     ad_utility::HashSetWithMemoryLimit<Node*>>
+      adjacentNodes = [this, &varToNode, &filtersAndOptionalSubstitutes]() {
+        ad_utility::HashMapWithMemoryLimit<
+            Node*, ad_utility::HashSetWithMemoryLimit<Node*>>
+            result{allocator_};
+        // `result[n1]` cannot be used directly because the mapped
+        // `HashSetWithMemoryLimit` is not default-constructible (it always
+        // needs an explicit allocator).
+        auto addEdge = [this, &result](Node* n1, Node* n2) {
+          auto it = result.find(n1);
+          if (it == result.end()) {
+            it = result
+                     .emplace(n1, ad_utility::HashSetWithMemoryLimit<Node*>{
+                                      allocator_})
+                     .first;
+          }
+          it->second.insert(n2);
+        };
         for (auto& nodesThatContainSameVar : varToNode | ql::views::values) {
           // TODO<C++23> Use ql::views::cartesian_product
           for (auto* n1 : nodesThatContainSameVar) {
             for (auto* n2 : nodesThatContainSameVar) {
               if (n1 != n2) {
-                result[n1].insert(n2);
-                result[n2].insert(n1);
+                addEdge(n1, n2);
+                addEdge(n2, n1);
               }
             }
           }
@@ -2929,8 +3060,8 @@ void QueryPlanner::QueryGraph::setupGraph(
                      ::ranges::views::filter([](const auto& pair) {
                        return std::get<0>(pair) != std::get<1>(pair);
                      })) {
-              result[n1].insert(n2);
-              result[n2].insert(n1);
+              addEdge(n1, n2);
+              addEdge(n2, n1);
             }
             first = second;
           }
@@ -2959,8 +3090,8 @@ void QueryPlanner::QueryGraph::dfs(Node* startNode, size_t componentIndex) {
   }
 }
 // _______________________________________________________________
-std::vector<size_t> QueryPlanner::QueryGraph::dfsForAllNodes() {
-  std::vector<size_t> result;
+qlever::vector<size_t> QueryPlanner::QueryGraph::dfsForAllNodes() {
+  qlever::vector<size_t> result{allocator_};
   size_t nextIndex = 0;
   for (const auto& node : nodes_) {
     if (node->visited_) {
@@ -3001,7 +3132,7 @@ qlever::index::GraphFilter<TripleComponent> QueryPlanner::getActiveGraphs()
 // _____________________________________________________________________________
 template <typename Variables>
 bool QueryPlanner::GraphPatternPlanner::handleUnconnectedMinusOrOptional(
-    std::vector<SubtreePlan>& candidates, const Variables& variables) {
+    PlanVec& candidates, const Variables& variables) {
   using enum SubtreePlan::Type;
   bool areVariablesUnconnected = ql::ranges::all_of(
       variables,
@@ -3018,7 +3149,7 @@ bool QueryPlanner::GraphPatternPlanner::handleUnconnectedMinusOrOptional(
   // An OPTIONAL clause that doesn't share any variable with the preceding
   // patterns behaves as if it is joined with the neutral element.
   if (type == OPTIONAL) {
-    auto& newPlans = candidatePlans_.emplace_back();
+    auto& newPlans = candidatePlans_.emplace_back(qec_->getAllocator());
     ql::ranges::for_each(
         candidates, [this, &newPlans](const SubtreePlan& plan) {
           auto joinedPlan = makeSubtreePlan<NeutralOptional>(qec_, plan._qet);
@@ -3036,7 +3167,7 @@ bool QueryPlanner::GraphPatternPlanner::handleUnconnectedMinusOrOptional(
 
 // _____________________________________________________________________________
 void QueryPlanner::GraphPatternPlanner::visitGroupOptionalOrMinus(
-    std::vector<SubtreePlan>&& candidates) {
+    PlanVec&& candidates) {
   // Empty group graph patterns should have been handled previously.
   AD_CORRECTNESS_CHECK(!candidates.empty());
 
@@ -3078,7 +3209,7 @@ void QueryPlanner::GraphPatternPlanner::visitGroupOptionalOrMinus(
   // an optional or minus join.
   optimizeCommutatively();
   AD_CORRECTNESS_CHECK(candidatePlans_.size() == 1);
-  std::vector<SubtreePlan> nextCandidates;
+  PlanVec nextCandidates{qec_->getAllocator()};
   // For each candidate plan, and each plan from the OPTIONAL or MINUS, create
   // a new plan with an optional join. Note that `createJoinCandidates` will
   // whether `b` is from an OPTIONAL or MINUS.
@@ -3111,7 +3242,8 @@ void QueryPlanner::GraphPatternPlanner::visitGroupOptionalOrMinus(
       "patterns");
   auto idx = planner_.findCheapestExecutionTree(nextCandidates);
   candidatePlans_.clear();
-  candidatePlans_.push_back({std::move(nextCandidates[idx])});
+  candidatePlans_.push_back(
+      PlanVec{{std::move(nextCandidates[idx])}, qec_->getAllocator()});
 }
 
 // ____________________________________________________________
@@ -3174,11 +3306,13 @@ void QueryPlanner::GraphPatternPlanner::graphPatternOperationVisitor(Arg& arg) {
     return visitTransitivePath(arg);
   } else if constexpr (std::is_same_v<T, p::Values>) {
     SubtreePlan valuesPlan = makeSubtreePlan<Values>(qec_, arg._inlineValues);
-    visitGroupOptionalOrMinus(std::vector{std::move(valuesPlan)});
+    visitGroupOptionalOrMinus(
+        PlanVec{{std::move(valuesPlan)}, qec_->getAllocator()});
   } else if constexpr (std::is_same_v<T, p::Service>) {
 #ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
     SubtreePlan servicePlan = makeSubtreePlan<Service>(qec_, arg);
-    visitGroupOptionalOrMinus(std::vector{std::move(servicePlan)});
+    visitGroupOptionalOrMinus(
+        PlanVec{{std::move(servicePlan)}, qec_->getAllocator()});
 #else
     throw std::runtime_error(
         "SERVICE is not supported in this restricted version of QLever");
@@ -3186,7 +3320,8 @@ void QueryPlanner::GraphPatternPlanner::graphPatternOperationVisitor(Arg& arg) {
   } else if constexpr (std::is_same_v<T, p::Load>) {
 #ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
     SubtreePlan loadPlan = makeSubtreePlan<Load>(qec_, arg);
-    visitGroupOptionalOrMinus(std::vector{std::move(loadPlan)});
+    visitGroupOptionalOrMinus(
+        PlanVec{{std::move(loadPlan)}, qec_->getAllocator()});
 #else
     throw std::runtime_error(
         "LOAD is not supported in this restricted version of QLever");
@@ -3307,7 +3442,7 @@ void QueryPlanner::GraphPatternPlanner::visitTransitivePath(
       "QLever");
 #else
   auto candidatesIn = planner_.optimize(&arg._childGraphPattern);
-  std::vector<SubtreePlan> candidatesOut;
+  PlanVec candidatesOut{qec_->getAllocator()};
 
   for (auto& sub : candidatesIn) {
     TransitivePathSide left;
@@ -3336,9 +3471,9 @@ void QueryPlanner::GraphPatternPlanner::visitPathSearch(
 
   // The path search requires a child graph pattern
   AD_CORRECTNESS_CHECK(pathQuery.childGraphPattern_.has_value());
-  std::vector<SubtreePlan> candidatesIn =
+  PlanVec candidatesIn =
       planner_.optimize(&pathQuery.childGraphPattern_.value());
-  std::vector<SubtreePlan> candidatesOut;
+  PlanVec candidatesOut{qec_->getAllocator()};
 
   for (auto& sub : candidatesIn) {
     auto pathSearch =
@@ -3360,7 +3495,8 @@ SubtreePlan QueryPlanner::getMaterializedViewIndexScanPlan(
 void QueryPlanner::GraphPatternPlanner::visitMaterializedViewQuery(
     const parsedQuery::MaterializedViewQuery& viewQuery) {
   candidatePlans_.push_back(
-      {planner_.getMaterializedViewIndexScanPlan(viewQuery)});
+      PlanVec{{planner_.getMaterializedViewIndexScanPlan(viewQuery)},
+              qec_->getAllocator()});
 }
 
 // _______________________________________________________________
@@ -3369,13 +3505,13 @@ void QueryPlanner::GraphPatternPlanner::visitSpatialSearch(
   auto config = spatialQuery.toSpatialJoinConfiguration();
 
   // If there is no child graph pattern, we need to construct a neutral element
-  std::vector<SubtreePlan> candidatesIn;
+  PlanVec candidatesIn{qec_->getAllocator()};
   if (spatialQuery.childGraphPattern_.has_value()) {
     candidatesIn = planner_.optimize(&spatialQuery.childGraphPattern_.value());
   } else {
     candidatesIn = {makeSubtreePlan<NeutralElementOperation>(qec_)};
   }
-  std::vector<SubtreePlan> candidatesOut;
+  PlanVec candidatesOut{qec_->getAllocator()};
 
   for (auto& sub : candidatesIn) {
     // This helper function adds a subtree plan to the output candidates, which
@@ -3422,7 +3558,8 @@ void QueryPlanner::GraphPatternPlanner::visitTextSearch(
     return makeSubtreePlan<Op>(this->qec_, std::move(arg));
   };
   for (auto config : textSearchQuery.toConfigs(qec_)) {
-    candidatePlans_.push_back(std::vector{std::visit(visitor, config)});
+    candidatePlans_.push_back(
+        PlanVec{{std::visit(visitor, config)}, qec_->getAllocator()});
   }
 }
 
@@ -3432,7 +3569,8 @@ void QueryPlanner::GraphPatternPlanner::visitExternalValues(
   auto externalValues =
       std::make_shared<ExternalValues>(qec_, externalValuesQuery);
   auto candidate = makeSubtreePlan<ExternalValues>(std::move(externalValues));
-  visitGroupOptionalOrMinus(std::vector{std::move(candidate)});
+  visitGroupOptionalOrMinus(
+      PlanVec{{std::move(candidate)}, qec_->getAllocator()});
 }
 
 // _____________________________________________________________________________
@@ -3441,7 +3579,8 @@ void QueryPlanner::GraphPatternPlanner::visitNamedCachedResult(
   auto candidate =
       SubtreePlan{planner_._qec, planner_._qec->namedResultCache().getOperation(
                                      arg.identifier(), planner_._qec)};
-  visitGroupOptionalOrMinus(std::vector{std::move(candidate)});
+  visitGroupOptionalOrMinus(
+      PlanVec{{std::move(candidate)}, qec_->getAllocator()});
 }
 
 // _______________________________________________________________
@@ -3455,7 +3594,8 @@ void QueryPlanner::GraphPatternPlanner::visitUnion(parsedQuery::Union& arg) {
   // create a new subtree plan
   SubtreePlan candidate =
       makeSubtreePlan<Union>(planner_._qec, left._qet, right._qet);
-  visitGroupOptionalOrMinus(std::vector{std::move(candidate)});
+  visitGroupOptionalOrMinus(
+      PlanVec{{std::move(candidate)}, qec_->getAllocator()});
 }
 
 // _______________________________________________________________
@@ -3487,6 +3627,8 @@ void QueryPlanner::GraphPatternPlanner::visitSubquery(
   // visible.
   auto setSelectedVariables = [&select](SubtreePlan& plan) {
     const auto& selected = select.getSelectedVariables();
+    // Plain: `Operation::makeTreeWithStrippedColumns` takes a plain
+    // `const std::set<Variable>&` as part of its pure-virtual signature.
     std::set<Variable> selectedVariables{selected.begin(), selected.end()};
     if (getRuntimeParameter<&RuntimeParameters::stripColumns_>()) {
       plan._qet = QueryExecutionTree::makeTreeWithStrippedColumns(
@@ -3512,8 +3654,12 @@ void QueryPlanner::GraphPatternPlanner::optimizeCommutatively() {
   auto tg = planner_.createTripleGraph(&candidateTriples_);
   auto lastRow =
       planner_
-          .fillDpTab(tg, rootPattern_->_filters, rootPattern_->textLimits_,
-                     candidatePlans_, std::move(replacementPlans))
+          .fillDpTab(tg,
+                     qlever::vector<SparqlFilter>(rootPattern_->_filters.begin(),
+                                                  rootPattern_->_filters.end(),
+                                                  qec_->getAllocator()),
+                     rootPattern_->textLimits_, candidatePlans_,
+                     std::move(replacementPlans))
           .back();
   candidateTriples_._triples.clear();
   candidatePlans_.clear();
@@ -3528,7 +3674,8 @@ void QueryPlanner::GraphPatternPlanner::visitDescribe(
       planner_.createExecutionTree(describe.whereClause_.get(), true));
   auto describeOp =
       makeSubtreePlan<Describe>(planner_._qec, std::move(tree), describe);
-  candidatePlans_.push_back(std::vector{std::move(describeOp)});
+  candidatePlans_.push_back(
+      PlanVec{{std::move(describeOp)}, qec_->getAllocator()});
   planner_.checkCancellation();
 }
 
@@ -3546,9 +3693,11 @@ QueryPlanner::findApplicableReplacementPlans(
   // triples that can be rewritten. This extracts the replacement plans for the
   // component that is currently being planned.
   bool hasApplicableReplacementPlans = false;
-  ReplacementPlans applicableReplacementPlans;
+  // This is a `static` function without access to a `QueryExecutionContext`,
+  // so we reuse the allocator of the (always valid) input container instead.
+  ReplacementPlans applicableReplacementPlans{allReplacementPlans.get_allocator()};
   for (auto& rPlans : allReplacementPlans) {
-    std::vector<SubtreePlan> applicable;
+    PlanVec applicable{rPlans.get_allocator()};
     for (auto& plan : rPlans) {
       // Nodes covered by plan must be a subset of the covered nodes.
       if ((plan._idsOfIncludedNodes & coveredNodeIds) ==
@@ -3581,7 +3730,7 @@ QueryPlanner::findApplicableReplacementPlans(
 // _______________________________________________________________
 void QueryPlanner::prepareReplacementPlansForGreedyPlanner(
     ReplacementPlans& applicableReplacementPlans,
-    std::vector<SubtreePlan>& connectedComponent) {
+    PlanVec& connectedComponent) {
   // Remove nodes from the `connectedComponent` that are covered by replacement
   // plans.
   for (const auto& plans : applicableReplacementPlans) {

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -16,21 +16,28 @@
 #include <boost/optional.hpp>
 #include <vector>
 
+#include "backports/span.h"
 #include "engine/CheckUsePatternTrick.h"
 #include "engine/QueryExecutionTree.h"
 #include "parser/GraphPattern.h"
 #include "parser/GraphPatternOperation.h"
 #include "parser/ParsedQuery.h"
 #include "parser/data/Types.h"
+#include "util/Allocator.h"
+#include "util/AllocatorTypes.h"
+#include "util/HashMap.h"
+#include "util/HashSet.h"
 
 class QueryPlanner {
+  // Mirrors `parsedQuery::GraphPattern::textLimits_` (`parser/GraphPattern.h`,
+  // out of scope), which is passed in and mutated by reference (not copied),
+  // so this must stay the exact same plain, absl-backed `ad_utility::HashMap`
+  // rather than an allocator-aware map.
   using TextLimitMap =
       ad_utility::HashMap<Variable, parsedQuery::TextLimitMetaObject>;
-  using TextLimitVec =
-      std::vector<std::pair<Variable, parsedQuery::TextLimitMetaObject>>;
   using CancellationHandle = ad_utility::SharedCancellationHandle;
-  template <typename T>
-  using vector = std::vector<T>;
+  using TextLimitVec =
+      qlever::vector<std::pair<Variable, parsedQuery::TextLimitMetaObject>>;
 
   ParsedQuery::DatasetClauses activeDatasetClauses_;
   // The variable of the innermost `GRAPH ?var` clause that the planner
@@ -45,7 +52,7 @@ class QueryPlanner {
           parsedQuery::GroupGraphPattern::GraphVariableBehaviour::ALL;
 
  public:
-  using JoinColumns = std::vector<std::array<ColumnIndex, 2>>;
+  using JoinColumns = qlever::vector<std::array<ColumnIndex, 2>>;
 
   explicit QueryPlanner(QueryExecutionContext* qec,
                         CancellationHandle cancellationHandle);
@@ -59,18 +66,24 @@ class QueryPlanner {
 
   class TripleGraph {
    public:
-    TripleGraph();
+    // `allocator` is the real, query-execution-bound allocator that
+    // `_nodeMap` (and, via `addNodeToTripleGraph`, the individual `Node`s)
+    // are routed through. Every caller that constructs a `TripleGraph` must
+    // supply this explicitly (there is no implicit unlimited-allocator
+    // fallback) -- production code passes `_qec->getAllocator()`, while
+    // tests that have no `QueryExecutionContext` pass a test allocator.
+    explicit TripleGraph(qlever::Allocator<Id> allocator);
 
     TripleGraph(const TripleGraph& other);
 
     TripleGraph& operator=(const TripleGraph& other);
 
-    TripleGraph(const TripleGraph& other, vector<size_t> keepNodes);
+    TripleGraph(const TripleGraph& other, qlever::vector<size_t> keepNodes);
 
     struct Node {
-      Node(size_t id, SparqlTriple t,
+      Node(size_t id, SparqlTriple t, qlever::Allocator<Id> allocator,
            std::optional<Variable> graphVariable = std::nullopt)
-          : id_(id), triple_(std::move(t)) {
+          : id_(id), triple_(std::move(t)), _variables{std::move(allocator)} {
         triple_.forEachVariable(
             [this](const auto& var) { _variables.insert(var); });
         if (graphVariable.has_value()) {
@@ -78,8 +91,9 @@ class QueryPlanner {
         }
       }
 
-      Node(size_t id, Variable cvar, std::string word, SparqlTriple t)
-          : Node(id, std::move(t)) {
+      Node(size_t id, Variable cvar, std::string word, SparqlTriple t,
+           qlever::Allocator<Id> allocator)
+          : Node(id, std::move(t), std::move(allocator), std::nullopt) {
         cvar_ = std::move(cvar);
         wordPart_ = std::move(word);
       }
@@ -114,34 +128,41 @@ class QueryPlanner {
 
       size_t id_;
       SparqlTriple triple_;
-      ad_utility::HashSet<Variable> _variables;
+      ad_utility::HashSetWithMemoryLimit<Variable> _variables;
       std::optional<Variable> cvar_ = std::nullopt;
       std::optional<std::string> wordPart_ = std::nullopt;
     };
 
     // Allows for manually building triple graphs for testing
     explicit TripleGraph(
-        const std::vector<std::pair<Node, std::vector<size_t>>>& init);
+        const std::vector<std::pair<Node, std::vector<size_t>>>& init,
+        qlever::Allocator<Id> allocator);
 
     // Checks for id and order independent equality
     bool isSimilar(const TripleGraph& other) const;
     std::string asString() const;
 
-    vector<vector<size_t>> _adjLists;
-    ad_utility::HashMap<size_t, Node*> _nodeMap;
-    std::list<TripleGraph::Node> _nodeStorage;
+    bool isTextNode(size_t i) const;
 
-    vector<size_t> bfsLeaveOut(size_t startNode,
-                               ad_utility::HashSet<size_t> leaveOut) const;
+    qlever::vector<qlever::vector<size_t>> _adjLists;
+    ad_utility::HashMapWithMemoryLimit<size_t, Node*> _nodeMap;
+    qlever::list<TripleGraph::Node> _nodeStorage;
+
+    qlever::vector<size_t> bfsLeaveOut(
+        size_t startNode,
+        ad_utility::HashSetWithMemoryLimit<size_t> leaveOut) const;
 
    private:
-    vector<std::pair<TripleGraph, vector<SparqlFilter>>> splitAtContextVars(
-        const vector<SparqlFilter>& origFilters,
-        ad_utility::HashMap<std::string, vector<size_t>>& contextVarTotextNodes)
-        const;
+    qlever::vector<std::pair<TripleGraph, qlever::vector<SparqlFilter>>>
+    splitAtContextVars(
+        const qlever::vector<SparqlFilter>& origFilters,
+        ad_utility::HashMapWithMemoryLimit<std::string,
+                                           qlever::vector<size_t>>&
+            contextVarTotextNodes) const;
 
-    vector<SparqlFilter> pickFilters(const vector<SparqlFilter>& origFilters,
-                                     const vector<size_t>& nodes) const;
+    qlever::vector<SparqlFilter> pickFilters(
+        const qlever::vector<SparqlFilter>& origFilters,
+        const qlever::vector<size_t>& nodes) const;
   };
 
   class SubtreePlan {
@@ -190,7 +211,25 @@ class QueryPlanner {
   };
 
   using FiltersAndOptionalSubstitutes =
-      std::vector<FilterAndOptionalSubstitute>;
+      qlever::vector<FilterAndOptionalSubstitute>;
+
+  // A `std::vector<SubtreePlan>` that uses `qlever::Allocator` instead of the
+  // default allocator. We deliberately use a plain `std::vector` here (and
+  // not the non-copyable `ad_utility::VectorWithMemoryLimit`), because plan
+  // vectors are copied in several places while building up the
+  // dynamic-programming table.
+  using PlanVec = qlever::vector<SubtreePlan>;
+  // One row of the dynamic-programming table: one `PlanVec` for each number
+  // of triples that have already been joined so far.
+  using PlanMatrix = qlever::vector<PlanVec>;
+  // Maps a "pruning key" (see `getPruningKey`) to all candidate plans that
+  // share that key, of which only the cheapest one is eventually kept. Uses
+  // `ad_utility::HashMapWithMemoryLimit` (backed by `std::unordered_map`)
+  // instead of the plain `ad_utility::HashMap` (backed by
+  // `absl::flat_hash_map`), because the latter cannot safely use
+  // `qlever::Allocator`, see `util/HashMap.h`.
+  using CandidateMap = ad_utility::HashMapWithMemoryLimit<std::string, PlanVec>;
+  using CandidateList = qlever::vector<std::pair<std::string, PlanVec>>;
 
   // A helper class to find connected components of an RDF query using DFS.
   class QueryGraph {
@@ -199,30 +238,41 @@ class QueryPlanner {
     class Node {
      public:
       const SubtreePlan* plan_;
-      ad_utility::HashSet<Node*> adjacentNodes_{};
+      ad_utility::HashSetWithMemoryLimit<Node*> adjacentNodes_;
       // Was this node already visited during DFS.
       bool visited_ = false;
       // Index of the connected component of this node (will be set to a value
       // >= 0 by the DFS.
       int64_t componentIndex_ = -1;
-      // Construct from a non-owning pointer.
-      explicit Node(const SubtreePlan* plan) : plan_{plan} {}
+      // Construct from a non-owning pointer. `allocator` is the real,
+      // query-execution-bound allocator that `adjacentNodes_` is routed
+      // through (see `QueryGraph::allocator_` below).
+      Node(const SubtreePlan* plan, const qlever::Allocator<Id>& allocator)
+          : plan_{plan}, adjacentNodes_{allocator} {}
     };
     // Storage for all the `Node`s that a graph contains.
-    std::vector<std::shared_ptr<Node>> nodes_;
+    qlever::vector<std::shared_ptr<Node>> nodes_;
 
-    // Default constructor
-    QueryGraph() = default;
+    // The allocator used for all the `HashSetWithMemoryLimit`/
+    // `HashMapWithMemoryLimit` instances built up while computing connected
+    // components. Supplied by the caller of `computeConnectedComponents` (which
+    // always has access to a real, query-execution-bound allocator via the
+    // `PlanVec` it is given), so that this class never has to fall back to an
+    // unlimited allocator itself.
+    qlever::Allocator<Id> allocator_;
+
+    explicit QueryGraph(qlever::Allocator<Id> allocator)
+        : nodes_{allocator}, allocator_{std::move(allocator)} {}
 
    public:
     // Return the indices of the connected component for each of the `node`s.
     // The return value will have exactly the same size as `node`s and
     // `result[i]` will be the index of the connected component of `nodes[i]`.
     // The connected components will be contiguous and start at 0.
-    static std::vector<size_t> computeConnectedComponents(
-        const std::vector<SubtreePlan>& nodes,
+    static qlever::vector<size_t> computeConnectedComponents(
+        const PlanVec& nodes,
         const FiltersAndOptionalSubstitutes& filtersAndOptionalSubstitutes) {
-      QueryGraph graph;
+      QueryGraph graph{nodes.get_allocator()};
       graph.setupGraph(nodes, filtersAndOptionalSubstitutes);
       return graph.dfsForAllNodes();
     }
@@ -231,7 +281,7 @@ class QueryPlanner {
     // The actual implementation of `setupGraph`. First build a
     // graph from the `leafOperations` and then run DFS and return the result.
     void setupGraph(
-        const std::vector<SubtreePlan>& leafOperations,
+        const PlanVec& leafOperations,
         const FiltersAndOptionalSubstitutes& filtersAndOptionalSubstitutes);
 
     // Run a single DFS startint at the `startNode`. All nodes that are
@@ -245,7 +295,7 @@ class QueryPlanner {
     // Run `dfs` repeatedly on nodes that were so far undiscovered until all
     // nodes are discovered, which means that all connected components have been
     // identified. Then return the indices of the connected components.
-    std::vector<size_t> dfsForAllNodes();
+    qlever::vector<size_t> dfsForAllNodes();
   };
 
   TripleGraph createTripleGraph(
@@ -262,7 +312,7 @@ class QueryPlanner {
   // result. This is relevant for subqueries, which are currently optimized
   // independently of the rest of the query, but where it depends on the rest
   // of the query, which ordering of the result is best.
-  std::vector<SubtreePlan> createExecutionTrees(ParsedQuery& pq,
+  PlanVec createExecutionTrees(ParsedQuery& pq,
                                                 bool isSubquery = false);
 
  protected:
@@ -284,9 +334,9 @@ class QueryPlanner {
   // Used to collect warnings (created by the parser or the query planner) which
   // are then passed on to the created `QueryExecutionTree` such that they can
   // be reported as part of the query result if desired.
-  std::vector<std::string> warnings_;
+  qlever::vector<std::string> warnings_;
 
-  std::vector<QueryPlanner::SubtreePlan> optimize(
+  PlanVec optimize(
       ParsedQuery::GraphPattern* rootPattern);
 
   // Add all the possible index scans for the triple represented by the node.
@@ -319,27 +369,27 @@ class QueryPlanner {
    * node in the triple graph (e.g. IndexScans).
    */
   struct PlansAndFilters {
-    std::vector<SubtreePlan> plans_;
-    std::vector<SparqlFilter> filters_;
+    PlanVec plans_;
+    qlever::vector<SparqlFilter> filters_;
   };
 
   PlansAndFilters seedWithScansAndText(
       const TripleGraph& tg,
-      const vector<vector<QueryPlanner::SubtreePlan>>& children,
+      const PlanMatrix& children,
       TextLimitMap& textLimits);
 
   // Function for optimization query rewrites: The function returns pairs of
   // filters with the corresponding substitute subtree plan. This is currently
   // used to translate GeoSPARQL filters to spatial join operations.
   virtual FiltersAndOptionalSubstitutes seedFilterSubstitutes(
-      const std::vector<SparqlFilter>& filters);
+      const qlever::vector<SparqlFilter>& filters);
 
   // Wrap `filters` as `FiltersAndOptionalSubstitutes` without computing any
   // substitutes. This is sufficient for the filter modes that never apply
   // substitutes and avoids constructing throwaway substitute plans (which
   // would also consume internal variable names).
   static FiltersAndOptionalSubstitutes wrapFiltersWithoutSubstitutes(
-      const std::vector<SparqlFilter>& filters);
+      const std::vector<SparqlFilter>& filters, qlever::Allocator<Id> allocator);
 
   // TODO<RobinTF> Extract to dedicated module, this has little to do with
   // actual query planning.
@@ -353,14 +403,14 @@ class QueryPlanner {
   // for further planning. This handles the case for predicates separated by
   // `/`, for example in `SELECT ?x { ?x <a>/<b> ?y }`.
   ParsedQuery::GraphPattern seedFromSequence(
-      const TripleComponent& left, const std::vector<PropertyPath>& paths,
+      const TripleComponent& left, const PropertyPath::ChildrenVec& paths,
       const TripleComponent& right);
 
   // Turn a union of `PropertyPath`s into a `GraphPattern` that can be used for
   // further planning. This handles the case for predicates separated by `|`,
   // for example in `SELECT ?x { ?x <a>|<b> ?y }`.
   ParsedQuery::GraphPattern seedFromAlternative(
-      const TripleComponent& left, const std::vector<PropertyPath>& paths,
+      const TripleComponent& left, const PropertyPath::ChildrenVec& paths,
       const TripleComponent& right);
 
   // Create `GraphPattern` for property paths of the form `<a>+`, `<a>?` or
@@ -373,7 +423,7 @@ class QueryPlanner {
   // Create `GraphPattern` for property paths of the form `!(<a> | ^<b>)` or
   // `!<a>` and similar.
   ParsedQuery::GraphPattern seedFromNegated(
-      const TripleComponent& left, const std::vector<PropertyPath>& paths,
+      const TripleComponent& left, const PropertyPath::ChildrenVec& paths,
       const TripleComponent& right);
   static ParsedQuery::GraphPattern seedFromVarOrIri(
       const TripleComponent& left,
@@ -384,7 +434,7 @@ class QueryPlanner {
 
   // Creates a tree of unions with the given patterns as the trees leaves
   static ParsedQuery::GraphPattern uniteGraphPatterns(
-      std::vector<ParsedQuery::GraphPattern>&& patterns);
+      qlever::vector<ParsedQuery::GraphPattern>&& patterns);
 
   /**
    * @brief Merges two rows of the dp optimization table using various types of
@@ -392,32 +442,31 @@ class QueryPlanner {
    * @return A new row for the dp table that contains plans created by joining
    * the result of a plan in a and a plan in b.
    */
-  vector<SubtreePlan> merge(const vector<SubtreePlan>& a,
-                            const vector<SubtreePlan>& b,
-                            const TripleGraph& tg) const;
+  PlanVec merge(const PlanVec& a, const PlanVec& b,
+                const TripleGraph& tg) const;
 
   // Create `SubtreePlan`s that join `a` and `b` together. The columns are
   // computed automatically.
-  std::vector<SubtreePlan> createJoinCandidates(
+  PlanVec createJoinCandidates(
       const SubtreePlan& a, const SubtreePlan& b,
       boost::optional<const TripleGraph&> tg) const;
 
   // Create `SubtreePlan`s that join `a` and `b` together. The columns are
   // configured by `jcs`.
-  std::vector<SubtreePlan> createJoinCandidates(const SubtreePlan& a,
+  PlanVec createJoinCandidates(const SubtreePlan& a,
                                                 const SubtreePlan& b,
                                                 const JoinColumns& jcs) const;
 
   // Same as `createJoinCandidates(SubtreePlan, SubtreePlan, JoinColumns)`, but
   // creates a cartesian product when `jcs` is empty.
-  std::vector<SubtreePlan> createJoinCandidatesAllowEmpty(
+  PlanVec createJoinCandidatesAllowEmpty(
       const SubtreePlan& a, const SubtreePlan& b, const JoinColumns& jcs) const;
 
   // Whenever a join is applied to a `Union`, add candidates that try applying
   // join to the children of the union directly, which can be more efficient if
   // one of the children has an optimized join, which can happen for
   // `TransitivePath` for example.
-  std::vector<SubtreePlan> applyJoinDistributivelyToUnion(
+  PlanVec applyJoinDistributivelyToUnion(
       const SubtreePlan& a, const SubtreePlan& b, const JoinColumns& jcs) const;
 
   // Return a pair of join columns (the first from the transitive path
@@ -471,34 +520,34 @@ class QueryPlanner {
   // added in round 1 of the dynamic programming algorithm. For the greedy
   // algorithm, the `prepareReplacementPlansForGreedyPlanner` helper handles the
   // necessary steps.
-  using ReplacementPlans = std::vector<std::vector<SubtreePlan>>;
+  using ReplacementPlans = PlanMatrix;
   ReplacementPlans createMaterializedViewJoinReplacements(
       const parsedQuery::BasicGraphPattern& triples) const;
 
-  vector<SubtreePlan> getOrderByRow(
+  PlanVec getOrderByRow(
       const ParsedQuery& pq,
-      const std::vector<std::vector<SubtreePlan>>& dpTab) const;
+      const PlanMatrix& dpTab) const;
 
-  vector<SubtreePlan> getGroupByRow(
+  PlanVec getGroupByRow(
       const ParsedQuery& pq,
-      const std::vector<std::vector<SubtreePlan>>& dpTab) const;
+      const PlanMatrix& dpTab) const;
 
-  vector<SubtreePlan> getDistinctRow(
+  PlanVec getDistinctRow(
       const parsedQuery::SelectClause& selectClause,
-      const vector<vector<SubtreePlan>>& dpTab) const;
+      const PlanMatrix& dpTab) const;
 
-  vector<SubtreePlan> getPatternTrickRow(
+  PlanVec getPatternTrickRow(
       const parsedQuery::SelectClause& selectClause,
-      const vector<vector<SubtreePlan>>& dpTab,
+      const PlanMatrix& dpTab,
       const checkUsePatternTrick::PatternTrickTuple& patternTrickTuple);
 
-  vector<SubtreePlan> getHavingRow(
-      const ParsedQuery& pq, const vector<vector<SubtreePlan>>& dpTab) const;
+  PlanVec getHavingRow(
+      const ParsedQuery& pq, const PlanMatrix& dpTab) const;
 
   // Apply the passed `VALUES` clause to the current plans.
-  std::vector<SubtreePlan> applyPostQueryValues(
+  PlanVec applyPostQueryValues(
       const parsedQuery::Values& values,
-      const std::vector<SubtreePlan>& currentPlans) const;
+      const PlanVec& currentPlans) const;
 
   JoinColumns connected(const SubtreePlan& a, const SubtreePlan& b,
                         boost::optional<const TripleGraph&> tg) const;
@@ -506,7 +555,7 @@ class QueryPlanner {
   static JoinColumns getJoinColumns(const SubtreePlan& a, const SubtreePlan& b);
 
   std::string getPruningKey(const SubtreePlan& plan,
-                            const vector<ColumnIndex>& orderedOnColumns) const;
+                            ql::span<const ColumnIndex> orderedOnColumns) const;
 
   // Configure the behavior of the `applyFiltersIfPossible` function below.
   enum class FilterMode {
@@ -535,14 +584,14 @@ class QueryPlanner {
   };
   template <FilterMode mode = FilterMode::KeepUnfiltered>
   void applyFiltersIfPossible(
-      std::vector<SubtreePlan>& row,
+      PlanVec& row,
       const FiltersAndOptionalSubstitutes& filters) const;
 
   // Apply text limits if possible.
   // A text limit can be applied to a plan if:
   // 1) There is no text operation for the text record column left.
   // 2) The text limit has not already been applied to the plan.
-  void applyTextLimitsIfPossible(std::vector<SubtreePlan>& row,
+  void applyTextLimitsIfPossible(PlanVec& row,
                                  const TextLimitVec& textLimits,
                                  bool replaceInsteadOfAddPlans) const;
 
@@ -603,17 +652,17 @@ class QueryPlanner {
    * Cycles have to be avoided (by previously removing a triple and using
    * it as a filter later on).
    */
-  vector<vector<SubtreePlan>> fillDpTab(
-      const TripleGraph& graph, std::vector<SparqlFilter> fs,
-      TextLimitMap& textLimits, const vector<vector<SubtreePlan>>& children,
+  PlanMatrix fillDpTab(
+      const TripleGraph& graph, qlever::vector<SparqlFilter> fs,
+      TextLimitMap& textLimits, const PlanMatrix& children,
       ReplacementPlans replacementPlans);
 
   // Internal subroutine of `fillDpTab` that  only works on a single connected
   // component of the input. Throws if the subtrees in the `connectedComponent`
   // are not in fact connected (via their variables).
-  std::vector<QueryPlanner::SubtreePlan>
+  PlanVec
   runDynamicProgrammingOnConnectedComponent(
-      std::vector<SubtreePlan> connectedComponent,
+      PlanVec connectedComponent,
       const FiltersAndOptionalSubstitutes& filters,
       const TextLimitVec& textLimits, const TripleGraph& tg,
       ReplacementPlans&& replacementPlans) const;
@@ -621,8 +670,8 @@ class QueryPlanner {
   // Same as `runDynamicProgrammingOnConnectedComponent`, but uses a greedy
   // algorithm that always greedily chooses the smallest result of the possible
   // join operations using the "Greedy Operator Ordering (GOO)" algorithm.
-  std::vector<QueryPlanner::SubtreePlan> runGreedyPlanningOnConnectedComponent(
-      std::vector<SubtreePlan> connectedComponent,
+  PlanVec runGreedyPlanningOnConnectedComponent(
+      PlanVec connectedComponent,
       const FiltersAndOptionalSubstitutes& filters,
       const TextLimitVec& textLimits, const TripleGraph& tg,
       ReplacementPlans&& replacementPlans) const;
@@ -633,9 +682,9 @@ class QueryPlanner {
   // query planner see above.
   // Note: We also need the added filters, because they behave like additional
   // graph nodes wrt the performance of the DP based query planner.
-  size_t countSubgraphs(std::vector<const SubtreePlan*> graph,
-                        const std::vector<SparqlFilter>& filters,
-                        size_t budget);
+  size_t countSubgraphs(qlever::vector<const SubtreePlan*> graph,
+                       const qlever::vector<SparqlFilter>& filters,
+                       size_t budget);
 
   // Creates a SubtreePlan for the given text leaf node in the triple graph.
   // While doing this the TextLimitMetaObjects are created and updated according
@@ -662,7 +711,7 @@ class QueryPlanner {
     // of the graph pattern. Each row stores different plans for the same graph
     // pattern, and plans from different rows can be joined in an arbitrary
     // order.
-    std::vector<std::vector<SubtreePlan>> candidatePlans_{};
+    PlanMatrix candidatePlans_{qec_->getAllocator()};
 
     // Triples from BasicGraphPatterns that can be joined arbitrarily
     // with each other and with the contents of  `candidatePlans_`
@@ -672,6 +721,11 @@ class QueryPlanner {
     // which we have dealt with so far.
     // TODO<joka921> verify that we get no false positives with plans that
     // create no single binding for a variable "by accident".
+    // NOTE: This deliberately stays a plain `ad_utility::HashSet` (not
+    // `HashSetWithMemoryLimit`) because it is passed by reference to
+    // `parsedQuery::BasicGraphPattern::collectAllContainedVariables`
+    // (declared in the out-of-scope `parser/GraphPatternOperation.h`), whose
+    // parameter type is a plain `ad_utility::HashSet<Variable>&`.
     ad_utility::HashSet<Variable> boundVariables_{};
 
     // The filters of the `rootPattern_`, wrapped for `applyFiltersIfPossible`.
@@ -687,8 +741,8 @@ class QueryPlanner {
         : planner_{planner},
           rootPattern_{rootPattern},
           qec_{planner._qec},
-          filtersAndSubst_{
-              wrapFiltersWithoutSubstitutes(rootPattern->_filters)} {}
+          filtersAndSubst_{wrapFiltersWithoutSubstitutes(rootPattern->_filters,
+                                                        qec_->getAllocator())} {}
 
     // This function is called for each of the graph patterns that are contained
     // in the `rootPattern_`. It dispatches to the various `visit...`functions
@@ -718,7 +772,7 @@ class QueryPlanner {
     // `SELECT * { OPTIONAL { ?a ?b ?c }}`, `SELECT * { MINUS { ?a ?b ?c }}` or
     // `SELECT * { ?x ?y ?z . OPTIONAL { ?a ?b ?c }}` need special handling.
     template <typename Variables>
-    bool handleUnconnectedMinusOrOptional(std::vector<SubtreePlan>& candidates,
+    bool handleUnconnectedMinusOrOptional(PlanVec& candidates,
                                           const Variables& variables);
 
     // This function is called for groups, optional, or minus clauses.
@@ -727,7 +781,7 @@ class QueryPlanner {
     // optimization border (The braces are planned individually).
     // The distinction between "normal" groups, OPTIONALs and MINUS clauses
     // is made via the type member of the `SubtreePlan`s.
-    void visitGroupOptionalOrMinus(std::vector<SubtreePlan>&& candidates);
+    void visitGroupOptionalOrMinus(PlanVec&& candidates);
 
     // This function finds a set of candidates that unite all the different
     // `candidatePlans_` and `candidateTriples_`. It then replaces the contents
@@ -754,11 +808,11 @@ class QueryPlanner {
    * first element that has the minimum index is returned.
    */
   size_t findCheapestExecutionTree(
-      const std::vector<SubtreePlan>& lastRow) const;
+      const PlanVec& lastRow) const;
   static size_t findSmallestExecutionTree(
-      const std::vector<SubtreePlan>& lastRow);
+      const PlanVec& lastRow);
   static size_t findUniqueNodeIds(
-      const std::vector<SubtreePlan>& connectedComponent,
+      const PlanVec& connectedComponent,
       bool allowReplacementPlans = false);
 
   // Helper for `fillDpTab` that extracts a subset of possible
@@ -787,7 +841,7 @@ class QueryPlanner {
   // must be disjunctive.
   static void prepareReplacementPlansForGreedyPlanner(
       ReplacementPlans& applicableReplacementPlans,
-      std::vector<SubtreePlan>& connectedComponent);
+      PlanVec& connectedComponent);
 
   /// if this Planner is not associated with a queryExecutionContext we are only
   /// in the unit test mode

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -644,7 +644,7 @@ CPP_template_def(typename RequestT, typename SendT)(
   auto visitOperation =
       [&checkParameter, &accessTokenOk, &request, &send, &parameters,
        &requestTimer, &plannedQuery, &indexAndViews,
-       this](std::vector<ParsedQuery> operations, std::string operationName,
+       this](qlever::vector<ParsedQuery> operations, std::string operationName,
              const std::string operationString,
              SharedTimeTracer tracer = nullptr) -> Awaitable<void> {
     auto timeLimit = verifyUserSubmittedQueryTimeout(
@@ -704,21 +704,25 @@ CPP_template_def(typename RequestT, typename SendT)(
       throw;
     }
   };
-  auto visitQuery = [&index, &visitOperation](Query query) -> Awaitable<void> {
+  auto visitQuery = [this, &index,
+                     &visitOperation](Query query) -> Awaitable<void> {
     // We need to copy the query string because `visitOperation` below also
     // needs it.
     auto parsedQuery = SparqlParser::parseQuery(
-        &index.encodedIriManager(), query.query_, query.datasetClauses_);
+        &index.encodedIriManager(), query.query_, query.datasetClauses_,
+        qlever().allocator());
     if (parsedQuery.hasUpdateClause()) {
       throw std::runtime_error(absl::StrCat(
           "SPARQL QUERY was requested via the HTTP request, but the "
           "following update was sent instead of an query: ",
           ad_utility::truncateOperationString(query.query_)));
     }
-    return visitOperation({std::move(parsedQuery)}, "SPARQL query",
-                          std::move(query.query_));
+    return visitOperation(
+        qlever::vector<ParsedQuery>({std::move(parsedQuery)},
+                                    qlever().allocator()),
+        "SPARQL query", std::move(query.query_));
   };
-  auto visitUpdate = [&index, &visitOperation, &requireValidAccessToken](
+  auto visitUpdate = [this, &index, &visitOperation, &requireValidAccessToken](
                          Update update) -> Awaitable<void> {
     requireValidAccessToken("SPARQL Update");
     // We need to copy the update string because `visitOperation` below also
@@ -727,7 +731,7 @@ CPP_template_def(typename RequestT, typename SendT)(
     tracer->beginTrace("parsing");
     auto parsedUpdates = SparqlParser::parseUpdate(
         index.getBlankNodeManager(), &index.encodedIriManager(), update.update_,
-        update.datasetClauses_);
+        update.datasetClauses_, qlever().allocator());
     tracer->endTrace("parsing");
     if (!ql::ranges::all_of(parsedUpdates, &ParsedQuery::hasUpdateClause)) {
       throw std::runtime_error(absl::StrCat(
@@ -739,13 +743,13 @@ CPP_template_def(typename RequestT, typename SendT)(
                           std::move(update.update_), tracer);
   };
   auto visitGraphStore =
-      [&request, &visitOperation, &requireValidAccessToken,
+      [this, &request, &visitOperation, &requireValidAccessToken,
        &index](GraphStoreOperation operation) -> Awaitable<void> {
     auto tracer = std::make_shared<ad_utility::timer::TimeTracer>("update");
     tracer->beginTrace("parsing");
-    std::vector<ParsedQuery> parsedOperations =
-        GraphStoreProtocol::transformGraphStoreProtocol(std::move(operation),
-                                                        request, index);
+    qlever::vector<ParsedQuery> parsedOperations =
+        GraphStoreProtocol::transformGraphStoreProtocol(
+            std::move(operation), request, index, qlever().allocator());
     tracer->endTrace("parsing");
 
     if (ql::ranges::any_of(parsedOperations, &ParsedQuery::hasUpdateClause)) {
@@ -1252,7 +1256,7 @@ nlohmann::ordered_json Server::createResponseMetadataForUpdate(
 CPP_template_def(typename RequestT, typename SendT)(
     requires ad_utility::httpUtils::HttpRequest<RequestT>)
     Awaitable<void> Server::processUpdate(
-        MakeQueryExecutionContext makeQec, std::vector<ParsedQuery>&& updates,
+        MakeQueryExecutionContext makeQec, qlever::vector<ParsedQuery>&& updates,
         const ad_utility::Timer& requestTimer, SharedTimeTracer outerTracer,
         ad_utility::SharedCancellationHandle cancellationHandle,
         const RequestT& request, SendT&& send, TimeLimit timeLimit,

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -30,6 +30,7 @@
 #include "libqlever/Qlever.h"
 #include "libqlever/QleverTypes.h"
 #include "util/AllocatorWithLimit.h"
+#include "util/AllocatorTypes.h"
 #include "util/ParseException.h"
 #include "util/TypeTraits.h"
 #include "util/http/HttpUtils.h"
@@ -385,7 +386,7 @@ class Server {
   CPP_template(typename RequestT, typename SendT)(
       requires ad_utility::httpUtils::HttpRequest<RequestT>)
       Awaitable<void> processUpdate(
-          MakeQueryExecutionContext makeQec, std::vector<ParsedQuery>&& updates,
+          MakeQueryExecutionContext makeQec, qlever::vector<ParsedQuery>&& updates,
           const ad_utility::Timer& requestTimer, SharedTimeTracer tracer,
           ad_utility::SharedCancellationHandle cancellationHandle,
           const RequestT& request, SendT&& send, TimeLimit timeLimit,

--- a/src/engine/SpatialJoin.cpp
+++ b/src/engine/SpatialJoin.cpp
@@ -278,7 +278,7 @@ size_t SpatialJoin::getResultWidth() const {
     } else {
       // We convert to a set here, because we allow multiple occurrences of
       // variables in payloadVariables_
-      std::vector<Variable> pv = config_.payloadVariables_.getVariables();
+      const auto& pv = config_.payloadVariables_.getVariables();
       absl::flat_hash_set<Variable> pvSet{pv.begin(), pv.end()};
 
       // The payloadVariables_ may contain the right join variable
@@ -505,7 +505,7 @@ PreparedSpatialJoinParams SpatialJoin::prepareJoin() const {
   // taken into account. Also note that here `childLeft_` not `childLeft` is
   // used, because `leftSelectedCols` and `rightSelectedCols` are applied after
   // swapping tables back in case of a `WITHIN` join.
-  std::vector<ColumnIndex> leftSelectedCols;
+  qlever::vector<ColumnIndex> leftSelectedCols{allocator()};
   for (auto [var, colInfo] :
        copySortedByColumnIndex(childLeft_->getVariableColumns())) {
     leftSelectedCols.push_back(colInfo.columnIndex_);
@@ -513,7 +513,7 @@ PreparedSpatialJoinParams SpatialJoin::prepareJoin() const {
 
   // Payload cols and join col
   auto varsAndColInfo = copySortedByColumnIndex(getVarColMapPayloadVars());
-  std::vector<ColumnIndex> rightSelectedCols;
+  qlever::vector<ColumnIndex> rightSelectedCols{allocator()};
   for (const auto& [var, colInfo] : varsAndColInfo) {
     rightSelectedCols.push_back(colInfo.columnIndex_);
   }

--- a/src/engine/SpatialJoin.h
+++ b/src/engine/SpatialJoin.h
@@ -20,6 +20,8 @@
 #include "engine/SpatialJoinConfig.h"
 #include "global/Id.h"
 #include "rdfTypes/Variable.h"
+#include "util/Allocator.h"
+#include "util/AllocatorTypes.h"
 
 using SpatialJoinBoundingBoxColumns =
     std::optional<std::pair<ColumnIndex, ColumnIndex>>;
@@ -33,8 +35,8 @@ struct PreparedSpatialJoinParams {
   std::shared_ptr<const Result> resultRight_;
   ColumnIndex leftJoinCol_;
   ColumnIndex rightJoinCol_;
-  std::vector<ColumnIndex> leftSelectedCols_;
-  std::vector<ColumnIndex> rightSelectedCols_;
+  qlever::vector<ColumnIndex> leftSelectedCols_;
+  qlever::vector<ColumnIndex> rightSelectedCols_;
   size_t numColumns_;
 };
 

--- a/src/engine/TransitivePathBase.cpp
+++ b/src/engine/TransitivePathBase.cpp
@@ -23,6 +23,8 @@
 #include "engine/TransitivePathBinSearch.h"
 #include "engine/TransitivePathHashMap.h"
 #include "engine/Union.h"
+#include "util/AllocatorTypes.h"
+#include "util/MemorySize/MemorySize.h"
 #include "engine/Values.h"
 #include "engine/sparqlExpressions/LiteralExpression.h"
 #include "engine/sparqlExpressions/NaryExpression.h"
@@ -116,7 +118,8 @@ TransitivePathBase::makeIndexScanPair(
   auto c = makeInternalVariable("c");
   auto d = makeInternalVariable("d");
   std::set variables{variable};
-  SparqlTripleSimple::AdditionalScanColumns additionalColumns;
+  SparqlTripleSimple::AdditionalScanColumns additionalColumns{
+      qec->getAllocator()};
   if (graphVariable.has_value()) {
     additionalColumns.emplace_back(ADDITIONAL_COLUMN_GRAPH_ID,
                                    graphVariable.value());
@@ -573,7 +576,7 @@ std::shared_ptr<TransitivePathBase> TransitivePathBase::bindLeftOrRightSide(
   // never re-sort an index scan (which should not happen because we can just
   // take the appropriate index scan in the first place).
   bool useBinSearch = dynamic_cast<const TransitivePathBinSearch*>(this);
-  std::vector<std::shared_ptr<TransitivePathBase>> candidates;
+  qlever::vector<std::shared_ptr<TransitivePathBase>> candidates{allocator()};
   candidates.push_back(makeTransitivePath(getExecutionContext(), subtree_, lhs,
                                           rhs, minDist_, maxDist_, useBinSearch,
                                           activeGraphs_, graphVariable_));

--- a/src/engine/TransitivePathBinSearch.cpp
+++ b/src/engine/TransitivePathBinSearch.cpp
@@ -12,6 +12,7 @@
 #include <utility>
 
 #include "engine/TransitivePathBase.h"
+#include "util/AllocatorTypes.h"
 
 // _____________________________________________________________________________
 BinSearchMap::BinSearchMap(ql::span<const Id> startIds,
@@ -138,7 +139,7 @@ TransitivePathBinSearch::TransitivePathBinSearch(
   auto [startSide, targetSide] = decideDirection();
   auto makeSortColumns = [this, &graphVariable](ColumnIndex first,
                                                 ColumnIndex second) {
-    std::vector<ColumnIndex> sortColumns;
+    qlever::vector<ColumnIndex> sortColumns{allocator()};
     if (graphVariable.has_value()) {
       sortColumns.push_back(subtree_->getVariableColumn(graphVariable.value()));
     }

--- a/src/engine/TransitivePathGraphSearch.h
+++ b/src/engine/TransitivePathGraphSearch.h
@@ -145,7 +145,7 @@ Set depthFirstSearchWithLimit(const GraphSearchProblem<T>& gsp,
   }
 
   sparqlExpression::VectorWithMemoryLimit<std::pair<Id, size_t>> stack{
-      ep.allocator_.as<std::pair<Id, size_t>>()};
+      ep.allocator_};
   ad_utility::HashMapWithMemoryLimit<Id, size_t> marks{ep.allocator_};
 
   stack.emplace_back(gsp.startNode_, 0);

--- a/src/engine/Union.cpp
+++ b/src/engine/Union.cpp
@@ -10,6 +10,7 @@
 #include "backports/span.h"
 #include "engine/CallFixedSize.h"
 #include "engine/SortedUnionImpl.h"
+#include "util/AllocatorTypes.h"
 #include "util/ChunkedForLoop.h"
 
 const size_t Union::NO_COLUMN = std::numeric_limits<size_t>::max();
@@ -63,7 +64,7 @@ Union::Union(QueryExecutionContext* qec,
 
   if (!targetOrder_.empty()) {
     auto computeSortOrder = [this](bool left) {
-      std::vector<ColumnIndex> specificSortOrder;
+      qlever::vector<ColumnIndex> specificSortOrder{allocator()};
       for (ColumnIndex index : targetOrder_) {
         ColumnIndex realIndex = _columnOrigins.at(index).at(!left);
         if (realIndex != NO_COLUMN) {

--- a/src/engine/Values.cpp
+++ b/src/engine/Values.cpp
@@ -28,9 +28,12 @@ Values::Values(QueryExecutionContext* qec, SparqlValues parsedValues)
 // ____________________________________________________________________________
 std::shared_ptr<QueryExecutionTree> makeValuesForSingleValue(
     QueryExecutionContext* qec, Variable variable, TripleComponent value) {
-  return ad_utility::makeExecutionTree<Values>(
-      qec,
-      parsedQuery::SparqlValues{{std::move(variable)}, {{std::move(value)}}});
+  parsedQuery::SparqlValues sparqlValues{qec->getAllocator()};
+  sparqlValues._variables.push_back(std::move(variable));
+  qlever::vector<TripleComponent> row{qec->getAllocator()};
+  row.push_back(std::move(value));
+  sparqlValues._values.push_back(std::move(row));
+  return ad_utility::makeExecutionTree<Values>(qec, std::move(sparqlValues));
 }
 
 // ____________________________________________________________________________

--- a/src/engine/VariableToColumnMap.cpp
+++ b/src/engine/VariableToColumnMap.cpp
@@ -20,7 +20,7 @@ copySortedByColumnIndex(VariableToColumnMap map) {
 // ______________________________________________________________________________
 VariableToColumnMap makeVarToColMapForJoinOperation(
     const VariableToColumnMap& leftVars, const VariableToColumnMap& rightVars,
-    std::vector<std::array<ColumnIndex, 2>> joinColumns, BinOpType binOpType,
+    ql::span<const std::array<ColumnIndex, 2>> joinColumns, BinOpType binOpType,
     size_t leftResultWidth, bool keepJoinColumns) {
   // First come all the variables from the left input. Variables that only
   // appear in the left input always have the same definedness as in the input.

--- a/src/engine/VariableToColumnMap.h
+++ b/src/engine/VariableToColumnMap.h
@@ -5,6 +5,7 @@
 #ifndef QLEVER_SRC_ENGINE_VARIABLETOCOLUMNMAP_H
 #define QLEVER_SRC_ENGINE_VARIABLETOCOLUMNMAP_H
 
+#include "backports/span.h"
 #include "backports/three_way_comparison.h"
 #include "global/Id.h"
 #include "rdfTypes/Variable.h"
@@ -88,7 +89,7 @@ copySortedByColumnIndex(VariableToColumnMap map);
 enum class BinOpType { Join, OptionalJoin };
 VariableToColumnMap makeVarToColMapForJoinOperation(
     const VariableToColumnMap& leftVars, const VariableToColumnMap& rightVars,
-    std::vector<std::array<ColumnIndex, 2>> joinColumns, BinOpType binOpType,
+    ql::span<const std::array<ColumnIndex, 2>> joinColumns, BinOpType binOpType,
     size_t leftResultWidth, bool keepJoinColumns = true);
 
 #endif  // QLEVER_SRC_ENGINE_VARIABLETOCOLUMNMAP_H

--- a/src/engine/spatialJoinAlgorithms/BoundingBoxAlgorithm.cpp
+++ b/src/engine/spatialJoinAlgorithms/BoundingBoxAlgorithm.cpp
@@ -21,7 +21,7 @@ using namespace BoostGeometryNamespace;
 
 // ____________________________________________________________________________
 bool BoundingBoxAlgorithm::isContainedInBoundingBoxes(
-    const std::vector<Box>& boundingBox, Point point) const {
+    const qlever::vector<Box>& boundingBox, Point point) const {
   // correct lon and lat bounds if necessary
   while (point.get<0>() < -180) {
     point.set<0>(point.get<0>() + 360);
@@ -41,7 +41,7 @@ bool BoundingBoxAlgorithm::isContainedInBoundingBoxes(
 }
 
 // ____________________________________________________________________________
-std::vector<Box> BoundingBoxAlgorithm::computeQueryBox(
+qlever::vector<Box> BoundingBoxAlgorithm::computeQueryBox(
     const Point& startPoint, double additionalDist) const {
   const auto& maxDist = maxDist_;
   AD_CORRECTNESS_CHECK(maxDist.has_value(),
@@ -78,7 +78,8 @@ std::vector<Box> BoundingBoxAlgorithm::computeQueryBox(
   auto northPoleReached = isAPoleTouched(upperLatBound).at(0);
 
   if (southPoleReached || northPoleReached) {
-    return {Box(Point(-180.0f, lowerLatBound), Point(180.0f, upperLatBound))};
+    return {{Box(Point(-180.0f, lowerLatBound), Point(180.0f, upperLatBound))},
+            qec_->getAllocator()};
   }
 
   // compute longitude bound. For an explanation of the calculation and the
@@ -105,21 +106,22 @@ std::vector<Box> BoundingBoxAlgorithm::computeQueryBox(
         Box(Point(-180, lowerLatBound), Point(rightLonBound, upperLatBound));
     auto box2 = Box(Point(leftLonBound + 360, lowerLatBound),
                     Point(180, upperLatBound));
-    return {box1, box2};
+    return {{box1, box2}, qec_->getAllocator()};
   } else if (rightLonBound > 180) {
     auto box1 =
         Box(Point(leftLonBound, lowerLatBound), Point(180, upperLatBound));
     auto box2 = Box(Point(-180, lowerLatBound),
                     Point(rightLonBound - 360, upperLatBound));
-    return {box1, box2};
+    return {{box1, box2}, qec_->getAllocator()};
   }
   // default case, when no bound has an "overflow"
-  return {Box(Point(leftLonBound, lowerLatBound),
-              Point(rightLonBound, upperLatBound))};
+  return {{Box(Point(leftLonBound, lowerLatBound),
+               Point(rightLonBound, upperLatBound))},
+          qec_->getAllocator()};
 }
 
 // ____________________________________________________________________________
-std::vector<Box> BoundingBoxAlgorithm::computeQueryBoxForLargeDistances(
+qlever::vector<Box> BoundingBoxAlgorithm::computeQueryBoxForLargeDistances(
     const Point& startPoint) const {
   const auto& maxDist = maxDist_;
   AD_CORRECTNESS_CHECK(maxDist.has_value(),
@@ -164,7 +166,7 @@ std::vector<Box> BoundingBoxAlgorithm::computeQueryBoxForLargeDistances(
     boxCrosses180Longitude = true;
   }
   // compute bounding boxes using the anti bounding box from above
-  std::vector<Box> boxes;
+  qlever::vector<Box> boxes{qec_->getAllocator()};
   if (!northPoleTouched) {
     // add upper bounding box(es)
     if (boxCrosses180Longitude) {
@@ -224,7 +226,7 @@ double BoundingBoxAlgorithm::getMaxDistFromMidpointToAnyPointInsideTheBox(
 }
 
 // ____________________________________________________________________________
-std::vector<Box> BoundingBoxAlgorithm::getQueryBox(
+qlever::vector<Box> BoundingBoxAlgorithm::getQueryBox(
     const std::optional<RtreeEntry>& entry) const {
   if (!entry.value().geoPoint_) {
     auto midpoint = calculateMidpointOfBox(entry.value().boundingBox_.value());
@@ -308,7 +310,7 @@ Result BoundingBoxAlgorithm::run() {
       // skipped
       continue;
     }
-    std::vector<Box> queryBox = getQueryBox(entry);
+    qlever::vector<Box> queryBox = getQueryBox(entry);
 
     results.clear();
 
@@ -316,7 +318,10 @@ Result BoundingBoxAlgorithm::run() {
       rtree.query(bgi::intersects(bbox), std::back_inserter(results));
     });
 
-    std::set<AddedPair> pairs;
+    // Deduplication set for this query point; explicitly constructed with
+    // the configured allocator (rather than default-constructed), since
+    // `PmrAllocator` has no default constructor.
+    qlever::set<AddedPair> pairs{qec_->getAllocator()};
     ql::ranges::for_each(results, [&](Value& res) {
       size_t rowLeft = res.second.row_;
       size_t rowRight = i;

--- a/src/engine/spatialJoinAlgorithms/BoundingBoxAlgorithm.h
+++ b/src/engine/spatialJoinAlgorithms/BoundingBoxAlgorithm.h
@@ -12,6 +12,8 @@
 #define QLEVER_SRC_ENGINE_BOUNDINGBOXALGORITHM_H
 
 #include "engine/spatialJoinAlgorithms/RtreeEntryAlgorithm.h"
+#include "util/Allocator.h"
+#include "util/AllocatorTypes.h"
 
 // Spatial join for `maxDistance` tasks using an r-tree built over the
 // bounding boxes of the smaller input table: for each row of the larger
@@ -25,7 +27,7 @@ class BoundingBoxAlgorithm : public RtreeEntryAlgorithm {
 
   // This function returns true, iff the given point is contained in any of
   // the bounding boxes
-  bool isContainedInBoundingBoxes(const std::vector<Box>& boundingBox,
+  bool isContainedInBoundingBoxes(const qlever::vector<Box>& boundingBox,
                                   Point point) const;
 
   // This function computes the bounding box(es) which represent all points,
@@ -43,8 +45,8 @@ class BoundingBoxAlgorithm : public RtreeEntryAlgorithm {
   // midpoint of the bounding box of the area to any point inside the area.
   // The function getMaxDistFromMidpointToAnyPointInsideTheBox() can be used to
   // calculate it.
-  std::vector<Box> computeQueryBox(const Point& startPoint,
-                                   double additionalDist = 0) const;
+  qlever::vector<Box> computeQueryBox(const Point& startPoint,
+                                      double additionalDist = 0) const;
 
   // this function calculates the maximum distance from the midpoint of the box
   // to any other point, which is contained in the box. If the midpoint has
@@ -63,7 +65,7 @@ class BoundingBoxAlgorithm : public RtreeEntryAlgorithm {
   // gets used, when the usual procedure, would just result in taking a big
   // bounding box, which covers the whole planet (so for extremely large max
   // distances)
-  std::vector<Box> computeQueryBoxForLargeDistances(
+  qlever::vector<Box> computeQueryBoxForLargeDistances(
       const Point& startPoint) const;
 
   // return whether one of the poles is being touched
@@ -74,7 +76,7 @@ class BoundingBoxAlgorithm : public RtreeEntryAlgorithm {
   // query. It returns a `std::vector` because if the box crosses the poles or
   // the -180/180 longitude line, we have to cut them into multiple boxes.
   // If there is more than one box, the boxes are disjoint.
-  std::vector<Box> getQueryBox(const std::optional<RtreeEntry>& entry) const;
+  qlever::vector<Box> getQueryBox(const std::optional<RtreeEntry>& entry) const;
 
   // circumference in meters at the equator (max) and the pole (min) (as the
   // earth is not exactly a sphere the circumference is different. Note that

--- a/src/engine/spatialJoinAlgorithms/LibspatialjoinAlgorithm.cpp
+++ b/src/engine/spatialJoinAlgorithms/LibspatialjoinAlgorithm.cpp
@@ -243,8 +243,17 @@ Result LibspatialjoinAlgorithm::run() {
   // Setup.
   IdTable result{numColumns, qec_->getAllocator()};
   size_t NUM_THREADS = getNumThreads();
-  std::vector<std::vector<std::pair<size_t, size_t>>> results(NUM_THREADS);
-  std::vector<std::vector<double>> resultDists(NUM_THREADS);
+  // The per-thread result buffers can grow arbitrarily large, so both the
+  // outer (indexed by thread) and inner backing storage are routed through
+  // the configured memory resource via `qec_->getAllocator()`. Filled via the
+  // fill-constructor (rather than the count-only one) because
+  // `qlever::vector`'s allocator is not default-constructible.
+  qlever::vector<qlever::vector<std::pair<size_t, size_t>>> results(
+      NUM_THREADS, qlever::vector<std::pair<size_t, size_t>>{qec_->getAllocator()},
+      qec_->getAllocator());
+  qlever::vector<qlever::vector<double>> resultDists(
+      NUM_THREADS, qlever::vector<double>{qec_->getAllocator()},
+      qec_->getAllocator());
   AD_CORRECTNESS_CHECK(config_.getJoinType().has_value());
   auto joinTypeVal = config_.getJoinType().value();
   // Within should be replaced by contains on swapped tables.

--- a/src/engine/spatialJoinAlgorithms/S2PointPolylineAlgorithm.cpp
+++ b/src/engine/spatialJoinAlgorithms/S2PointPolylineAlgorithm.cpp
@@ -55,7 +55,8 @@ Result S2PointPolylineAlgorithm::run() {
     }
     auto s2target = S2ClosestEdgeQuery::PointTarget{toS2Point(p.value())};
 
-    ad_utility::HashMap<size_t, double> deduplicatedSet{};
+    ad_utility::HashMapWithMemoryLimit<size_t, double> deduplicatedSet{
+        qec_->getAllocator()};
     timerS2.cont();
     auto res = s2query.FindClosestEdges(&s2target);
 

--- a/src/engine/spatialJoinAlgorithms/SpatialJoinAlgorithmBase.cpp
+++ b/src/engine/spatialJoinAlgorithms/SpatialJoinAlgorithmBase.cpp
@@ -33,7 +33,7 @@ void SpatialJoinAlgorithmBase::addResultTableEntry(
   // columns given in `sourceColumns`.
   auto addColumns = [&resrow, &rescol, &result](
                         const IdTableView<0>* copyFrom, size_t rowIndCopy,
-                        const std::vector<ColumnIndex>& sourceColumns) {
+                        const qlever::vector<ColumnIndex>& sourceColumns) {
     for (size_t col : sourceColumns) {
       result->at(resrow, rescol) = copyFrom->at(rowIndCopy, col);
       ++rescol;

--- a/src/libqlever/Qlever.cpp
+++ b/src/libqlever/Qlever.cpp
@@ -54,7 +54,7 @@ Qlever::Qlever(const EngineConfig& config, bool skipLoading,
                Allocator<Id> allocator)
     : allocator_{std::move(allocator)},
       indexAndViews_{std::make_shared<IndexAndViews>(
-          Index{allocator_}, MaterializedViewsManager{})},
+          Index{allocator_}, MaterializedViewsManager{allocator_})},
       enablePatternTrick_{!config.noPatterns_},
       disableCaching_{config.disableCaching_} {
   // Set runtime parameters relevant for caching and propagate them to the
@@ -353,7 +353,7 @@ ParsedQueryAndContext Qlever::parseQuery(
 
   auto parsedQuery = SparqlParser::parseQuery(
       &qecPtr->getIndex().getImpl().encodedIriManager(), std::move(query),
-      datasetClauses);
+      datasetClauses, qecPtr->getAllocator());
 
   return ParsedQueryAndContext{std::move(parsedQuery), std::move(qecPtr)};
 }
@@ -614,7 +614,7 @@ Qlever::RebuildResult Qlever::rebuildIndexToDisk(
       materializeToIndex(index, indexBaseName, currentSnapshot, localVocabCopy,
                          ownedBlocks, handle, logFileName);
   auto indexAndViews = std::make_shared<IndexAndViews>(
-      Index{allocator()}, MaterializedViewsManager{});
+      Index{allocator()}, MaterializedViewsManager{allocator()});
   auto& [newIndex, newManager] = *indexAndViews;
   newIndex.usePatterns() = index.usePatterns();
   newIndex.loadAllPermutations() = index.loadAllPermutations();

--- a/src/parser/DatasetClauses.cpp
+++ b/src/parser/DatasetClauses.cpp
@@ -7,20 +7,6 @@
 namespace parsedQuery {
 
 // _____________________________________________________________________________
-DatasetClauses DatasetClauses::fromClauses(
-    const std::vector<DatasetClause>& clauses) {
-  DatasetClauses result;
-  for (auto& [dataset, isNamed] : clauses) {
-    auto& graphs = isNamed ? result.namedGraphs_ : result.defaultGraphs_;
-    if (!graphs.has_value()) {
-      graphs.emplace();
-    }
-    graphs.value().insert(dataset);
-  }
-  return result;
-}
-
-// _____________________________________________________________________________
 DatasetClauses DatasetClauses::fromWithClause(
     const TripleComponent::Iri& withGraph) {
   DatasetClauses result;

--- a/src/parser/DatasetClauses.h
+++ b/src/parser/DatasetClauses.h
@@ -32,8 +32,21 @@ struct DatasetClauses {
 
  public:
   // Divide the dataset clause from `clauses` into default and named graphs,
-  // as needed for a `DatasetClauses` object.
-  static DatasetClauses fromClauses(const std::vector<DatasetClause>& clauses);
+  // as needed for a `DatasetClauses` object. Templated on the container type of
+  // `clauses` so that callers can pass either a `std::vector<DatasetClause>` or
+  // a `qlever::vector<DatasetClause>`.
+  template <typename Range>
+  static DatasetClauses fromClauses(const Range& clauses) {
+    DatasetClauses result;
+    for (auto& [dataset, isNamed] : clauses) {
+      auto& graphs = isNamed ? result.namedGraphs_ : result.defaultGraphs_;
+      if (!graphs.has_value()) {
+        graphs.emplace();
+      }
+      graphs.value().insert(dataset);
+    }
+    return result;
+  }
 
   // Return the `DatasetClauses` that correspond to the `WITH <withGraph>`
   // clause in a SPARQL UPDATE.

--- a/src/parser/ExternalValuesQuery.h
+++ b/src/parser/ExternalValuesQuery.h
@@ -11,6 +11,8 @@
 #define QLEVER_SRC_PARSER_EXTERNALVALUESQUERY_H
 
 #include "parser/MagicServiceQuery.h"
+#include "util/Allocator.h"
+#include "util/AllocatorTypes.h"
 
 class SparqlTriple;
 
@@ -36,13 +38,20 @@ class ExternalValuesException : public std::runtime_error {
 // compatibility with code already deployed by BMW.
 struct ExternalValuesQuery : MagicServiceQuery {
   std::string name_;
-  std::vector<Variable> variables_;
+  qlever::vector<Variable> variables_;
 
-  explicit ExternalValuesQuery(const TripleComponent::Iri& serviceIri)
-      : name_(extractName(serviceIri.toStringRepresentation())) {}
+  // `allocator` is the real, query-execution-bound allocator that
+  // `variables_` is routed through. Every caller that constructs an
+  // `ExternalValuesQuery` must supply this explicitly (there is no implicit
+  // unlimited-allocator fallback).
+  ExternalValuesQuery(const TripleComponent::Iri& serviceIri,
+                      qlever::Allocator<Id> allocator)
+      : name_(extractName(serviceIri.toStringRepresentation())),
+        variables_{std::move(allocator)} {}
 
-  // Default constructor, mainly used for testing.
-  ExternalValuesQuery() = default;
+  // Mainly used for testing.
+  explicit ExternalValuesQuery(qlever::Allocator<Id> allocator)
+      : variables_{std::move(allocator)} {}
 
   // See MagicServiceQuery - processes configuration triples.
   void addParameter(const SparqlTriple& triple) override;

--- a/src/parser/GraphPattern.h
+++ b/src/parser/GraphPattern.h
@@ -10,6 +10,8 @@
 
 #include "parser/data/SparqlFilter.h"
 #include "rdfTypes/Variable.h"
+#include "util/Allocator.h"
+#include "util/AllocatorTypes.h"
 #include "util/HashSet.h"
 
 namespace parsedQuery {
@@ -44,10 +46,12 @@ class GraphPattern {
   // predicate that only returns matching literals if applicable. `variable` is
   // the variable to filter on, `langTags` represent a whitelist of languages,
   // indicating that the desired literals have to be of any of the specified
-  // languages. Return `true` if it could successfully be applied, false
-  // otherwise.
+  // languages. `allocator` is the real, query-execution-bound allocator (when
+  // available) that the rewritten property path is routed through. Return
+  // `true` if it could successfully be applied, false otherwise.
   bool addLanguageFilter(const Variable& variable,
-                         const ad_utility::HashSet<std::string>& langTags);
+                        const ad_utility::HashSet<std::string>& langTags,
+                        qlever::Allocator<Id> allocator);
 
   bool _optional;
 

--- a/src/parser/GraphPatternOperation.cpp
+++ b/src/parser/GraphPatternOperation.cpp
@@ -28,7 +28,7 @@ std::string SparqlValues::variablesToString() const {
 // _____________________________________________________________________________
 std::string SparqlValues::valuesToString() const {
   auto tripleComponentVectorAsValueTuple =
-      [](const std::vector<TripleComponent>& v) -> std::string {
+      [](const qlever::vector<TripleComponent>& v) -> std::string {
     return absl::StrCat(
         "(",
         absl::StrJoin(v, " ",
@@ -39,7 +39,7 @@ std::string SparqlValues::valuesToString() const {
   };
   return absl::StrJoin(
       _values, " ",
-      [&](std::string* out, const std::vector<TripleComponent>& v) {
+      [&](std::string* out, const qlever::vector<TripleComponent>& v) {
         out->append(tripleComponentVectorAsValueTuple(v));
       });
 }
@@ -54,7 +54,8 @@ auto m(Args&&... args) {
 }  // namespace
 
 // Special member functions for the `Subquery` class
-Subquery::Subquery() : _subquery{m()} {}
+Subquery::Subquery(qlever::Allocator<Id> allocator)
+    : _subquery{std::make_unique<ParsedQuery>(std::move(allocator))} {}
 Subquery::Subquery(const ParsedQuery& pq) : _subquery{m(pq)} {}
 Subquery::Subquery(ParsedQuery&& pq) noexcept : _subquery{m(std::move(pq))} {}
 Subquery::Subquery(Subquery&& pq) noexcept

--- a/src/parser/GraphPatternOperation.h
+++ b/src/parser/GraphPatternOperation.h
@@ -24,6 +24,8 @@
 #include "parser/TextSearchQuery.h"
 #include "parser/TripleComponent.h"
 #include "rdfTypes/Variable.h"
+#include "util/Allocator.h"
+#include "util/AllocatorTypes.h"
 #include "util/TransparentFunctors.h"
 #include "util/VisitMixin.h"
 
@@ -43,10 +45,18 @@ class GraphPattern;
 /// the query planner.
 struct SparqlValues {
  public:
+  // `allocator` is the real, query-execution-bound allocator that
+  // `_variables`/`_values` are routed through. Callers must always supply
+  // this explicitly (sourced from a `QueryExecutionContext` where one is
+  // available, or from a test allocator otherwise) -- there is no implicit
+  // unlimited-allocator fallback.
+  explicit SparqlValues(qlever::Allocator<Id> allocator)
+      : _variables{allocator}, _values{allocator} {}
+
   // The variables to which the values will be bound
-  std::vector<Variable> _variables;
+  qlever::vector<Variable> _variables;
   // A table storing the values in their string form
-  std::vector<std::vector<TripleComponent>> _values;
+  qlever::vector<qlever::vector<TripleComponent>> _values;
   // The `_variables` as a string, in the format like so: "?x ?y ?z".
   std::string variablesToString() const;
   // The `_values` as a string, in the format like so: "(<v12> <v12> <v13>)
@@ -92,6 +102,11 @@ struct Values {
   SparqlValues _inlineValues;
   // This value will be overwritten later.
   size_t _id = std::numeric_limits<size_t>::max();
+
+  // Deliberately not `explicit`: a `Values` is constructed implicitly from a
+  // `SparqlValues` in several places (e.g. `Visitor::visitAlternative<Values>`
+  // when parsing `VALUES` clauses).
+  Values(SparqlValues inlineValues) : _inlineValues{std::move(inlineValues)} {}
 };
 
 /// A `GroupGraphPattern` is anything enclosed in `{}`.
@@ -159,7 +174,7 @@ class Subquery {
   // `Subquery` is like a `ParsedQuery`, just with an own type).
   Subquery(const ParsedQuery&);
   Subquery(ParsedQuery&&) noexcept;
-  Subquery();
+  explicit Subquery(qlever::Allocator<Id> allocator);
   ~Subquery();
   Subquery(const Subquery&);
   Subquery(Subquery&&) noexcept;

--- a/src/parser/ParsedQuery.cpp
+++ b/src/parser/ParsedQuery.cpp
@@ -18,6 +18,7 @@
 #include "engine/sparqlExpressions/SparqlExpressionPimpl.h"
 #include "global/RuntimeParameters.h"
 #include "parser/sparqlParser/SparqlQleverVisitor.h"
+#include "util/Allocator.h"
 #include "util/Conversions.h"
 #include "util/TransparentFunctors.h"
 
@@ -246,7 +247,7 @@ const std::vector<Variable>& ParsedQuery::getVisibleVariables() const {
 
 // _____________________________________________________________________________
 void ParsedQuery::registerVariablesVisibleInQueryBody(
-    const vector<Variable>& variables) {
+    ql::span<const Variable> variables) {
   for (const auto& var : variables) {
     registerVariableVisibleInQueryBody(var);
   }
@@ -268,7 +269,8 @@ ParsedQuery::GraphPattern::GraphPattern() : _optional(false) {}
 // __________________________________________________________________________
 bool ParsedQuery::GraphPattern::addLanguageFilter(
     const Variable& variable,
-    const ad_utility::HashSet<std::string>& langTags) {
+    const ad_utility::HashSet<std::string>& langTags,
+    qlever::Allocator<Id> allocator) {
   AD_CORRECTNESS_CHECK(!langTags.empty());
   // Since most literals have an empty language tag we don't create extra
   // triples for them, so we can't use this optimization.
@@ -316,7 +318,7 @@ bool ParsedQuery::GraphPattern::addLanguageFilter(
     AD_CORRECTNESS_CHECK(std::holds_alternative<PropertyPath>(triplePtr->p_));
     auto& predicate = std::get<PropertyPath>(triplePtr->p_);
     AD_CORRECTNESS_CHECK(predicate.isIri());
-    std::vector<PropertyPath> predicates;
+    PropertyPath::ChildrenVec predicates{allocator};
     for (const std::string& langTag : langTags) {
       predicates.push_back(
           PropertyPath::fromIri(ad_utility::convertToLanguageTaggedPredicate(

--- a/src/parser/ParsedQuery.h
+++ b/src/parser/ParsedQuery.h
@@ -14,6 +14,7 @@
 #include <variant>
 #include <vector>
 
+#include "backports/span.h"
 #include "backports/three_way_comparison.h"
 #include "engine/sparqlExpressions/SparqlExpressionPimpl.h"
 #include "parser/Alias.h"
@@ -28,6 +29,8 @@
 #include "parser/data/OrderKey.h"
 #include "parser/data/SolutionModifiers.h"
 #include "parser/data/SparqlFilter.h"
+#include "util/AllocatorTypes.h"
+#include "util/AllocatorWithLimit.h"
 #ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
 #include "util/http/ResponseMiddleware.h"
 #endif
@@ -70,20 +73,28 @@ class ParsedQuery {
   // struct
   struct AskClause : public parsedQuery::ClauseBase {};
 
-  ParsedQuery() = default;
+  // `allocator` is the real, query-execution-bound allocator that
+  // `_havingClauses`/`_orderBy`/`_groupByVariables`/`warnings_` are routed
+  // through. Every caller that constructs a `ParsedQuery` must supply this
+  // explicitly.
+  explicit ParsedQuery(qlever::Allocator<Id> allocator)
+      : _havingClauses{allocator},
+        _orderBy{allocator},
+        _groupByVariables{allocator},
+        warnings_{allocator} {}
 
   GraphPattern _rootGraphPattern;
-  std::vector<SparqlFilter> _havingClauses;
-  std::vector<VariableOrderKey> _orderBy;
+  qlever::vector<SparqlFilter> _havingClauses;
+  qlever::vector<VariableOrderKey> _orderBy;
   IsInternalSort _isInternalSort = IsInternalSort::False;
-  std::vector<Variable> _groupByVariables;
+  qlever::vector<Variable> _groupByVariables;
   LimitOffsetClause _limitOffset{};
   std::string _originalString;
   std::optional<parsedQuery::Values> postQueryValuesClause_ = std::nullopt;
 
   // Contains warnings about queries that are valid according to the SPARQL
   // standard, but are probably semantically wrong.
-  std::vector<std::string> warnings_;
+  qlever::vector<std::string> warnings_;
 
   using HeaderClause =
       std::variant<SelectClause, ConstructClause, UpdateClause, AskClause>;
@@ -145,12 +156,11 @@ class ParsedQuery {
   void registerVariableVisibleInQueryBody(const Variable& variable);
 
   // Add variables, that were found in the query body.
-  void registerVariablesVisibleInQueryBody(
-      const std::vector<Variable>& variables);
+  void registerVariablesVisibleInQueryBody(ql::span<const Variable> variables);
 
   // Return all the warnings that have been added via `addWarning()` or
   // `addWarningOrThrow`.
-  const std::vector<std::string>& warnings() const { return warnings_; }
+  const qlever::vector<std::string>& warnings() const { return warnings_; }
 
   // Add a warning to the query. The warning becomes part of the return value of
   // the `warnings()` function above.

--- a/src/parser/PathQuery.cpp
+++ b/src/parser/PathQuery.cpp
@@ -79,7 +79,7 @@ void PathQuery::addParameter(const SparqlTriple& triple) {
 
 // ____________________________________________________________________________
 std::variant<Variable, std::vector<Id>> PathQuery::toSearchSide(
-    std::vector<TripleComponent> side, const IndexImpl& index) const {
+    qlever::vector<TripleComponent> side, const IndexImpl& index) const {
   if (side.size() == 1 && side[0].isVariable()) {
     return side[0].getVariable();
   } else {
@@ -120,8 +120,10 @@ PathSearchConfiguration PathQuery::toPathSearchConfiguration(
   return PathSearchConfiguration{
       algorithm_,          sources,         targets,
       start_.value(),      end_.value(),    pathColumn_.value(),
-      edgeColumn_.value(), edgeProperties_, cartesian_,
-      numPathsPerTarget_,  maxDepth_};
+      edgeColumn_.value(),
+      std::vector<Variable>(edgeProperties_.begin(), edgeProperties_.end()),
+      cartesian_,          numPathsPerTarget_,
+      maxDepth_};
 }
 
 }  // namespace parsedQuery

--- a/src/parser/PathQuery.h
+++ b/src/parser/PathQuery.h
@@ -11,6 +11,8 @@
 // TODO<joka921> is this the right header where the pathSearchConfiguration
 // should live, or do we need a forward declaration here?
 #include "engine/PathSearch.h"
+#include "util/Allocator.h"
+#include "util/AllocatorTypes.h"
 
 class SparqlTriple;
 
@@ -31,20 +33,25 @@ class PathSearchException : public std::runtime_error {
 // All the error handling for the PathSearch happens in the PathQuery object.
 // Thus, if a PathSearchConfiguration can be constructed, it is valid.
 struct PathQuery : MagicServiceQuery {
-  std::vector<TripleComponent> sources_;
-  std::vector<TripleComponent> targets_;
+  qlever::vector<TripleComponent> sources_;
+  qlever::vector<TripleComponent> targets_;
   std::optional<Variable> start_;
   std::optional<Variable> end_;
   std::optional<Variable> pathColumn_;
   std::optional<Variable> edgeColumn_;
-  std::vector<Variable> edgeProperties_;
+  qlever::vector<Variable> edgeProperties_;
   PathSearchAlgorithm algorithm_;
 
   bool cartesian_ = true;
   std::optional<uint64_t> numPathsPerTarget_ = std::nullopt;
   std::optional<uint64_t> maxDepth_ = std::nullopt;
 
-  PathQuery() = default;
+  // `allocator` is the real, query-execution-bound allocator that
+  // `sources_`/`targets_`/`edgeProperties_` are routed through. Every caller
+  // that constructs a `PathQuery` must supply this explicitly (there is no
+  // implicit unlimited-allocator fallback).
+  explicit PathQuery(qlever::Allocator<Id> allocator)
+      : sources_{allocator}, targets_{allocator}, edgeProperties_{allocator} {}
   PathQuery(PathQuery&& other) noexcept = default;
   PathQuery(const PathQuery& other) = default;
   PathQuery& operator=(const PathQuery& other) = default;
@@ -66,7 +73,7 @@ struct PathQuery : MagicServiceQuery {
    * contains IRIs.
    */
   std::variant<Variable, std::vector<Id>> toSearchSide(
-      std::vector<TripleComponent> side, const IndexImpl& index) const;
+      qlever::vector<TripleComponent> side, const IndexImpl& index) const;
 
   /**
    * @brief Convert this PathQuery into a PathSearchConfiguration object.

--- a/src/parser/PayloadVariables.cpp
+++ b/src/parser/PayloadVariables.cpp
@@ -9,14 +9,16 @@
 #include "util/Exception.h"
 
 // ____________________________________________________________________________
-PayloadVariables::PayloadVariables(std::vector<Variable> variables)
+PayloadVariables::PayloadVariables(qlever::Allocator<Variable> allocator)
+    : variables_{qlever::vector<Variable>{std::move(allocator)}} {}
+
+// ____________________________________________________________________________
+PayloadVariables::PayloadVariables(qlever::vector<Variable> variables)
     : variables_{std::move(variables)} {}
 
 // ____________________________________________________________________________
 PayloadVariables PayloadVariables::all() {
-  PayloadVariables pv{};
-  pv.setToAll();
-  return pv;
+  return PayloadVariables{detail::PayloadAllVariables{}};
 }
 
 // ____________________________________________________________________________
@@ -25,7 +27,7 @@ void PayloadVariables::addVariable(const Variable& variable) {
   // and a variable can be added. If yes, add it.
   auto addVarVisitor = [&](auto& value) {
     using T = std::decay_t<decltype(value)>;
-    if constexpr (std::is_same_v<T, std::vector<Variable>>) {
+    if constexpr (std::is_same_v<T, qlever::vector<Variable>>) {
       value.push_back(variable);
     }
   };
@@ -46,7 +48,7 @@ bool PayloadVariables::empty() const {
     if constexpr (std::is_same_v<T, detail::PayloadAllVariables>) {
       return false;
     } else {
-      static_assert(std::is_same_v<T, std::vector<Variable>>);
+      static_assert(std::is_same_v<T, qlever::vector<Variable>>);
       return value.empty();
     }
   };
@@ -60,12 +62,12 @@ bool PayloadVariables::isAll() const {
 }
 
 // ____________________________________________________________________________
-const std::vector<Variable>& PayloadVariables::getVariables() const {
+const qlever::vector<Variable>& PayloadVariables::getVariables() const {
   // Helper visitor to check if the payload variables has been set to all: then
   // throw, otherwise return the vector
-  auto getVarVisitor = [](const auto& value) -> const std::vector<Variable>& {
+  auto getVarVisitor = [](const auto& value) -> const qlever::vector<Variable>& {
     using T = std::decay_t<decltype(value)>;
-    if constexpr (std::is_same_v<T, std::vector<Variable>>) {
+    if constexpr (std::is_same_v<T, qlever::vector<Variable>>) {
       return value;
     } else {
       AD_THROW(

--- a/src/parser/PayloadVariables.h
+++ b/src/parser/PayloadVariables.h
@@ -8,11 +8,14 @@
 #include <vector>
 
 #include "rdfTypes/Variable.h"
+#include "util/Allocator.h"
+#include "util/AllocatorTypes.h"
 
 namespace detail {
 // Represents the selection of all variables as payload
 struct PayloadAllVariables : std::monostate {
-  bool operator==([[maybe_unused]] const std::vector<Variable>& other) const {
+  bool operator==(
+      [[maybe_unused]] const qlever::vector<Variable>& other) const {
     return false;
   }
 };
@@ -22,13 +25,16 @@ struct PayloadAllVariables : std::monostate {
 // an operation. This is currently used in the spatial search.
 class PayloadVariables {
  public:
-  // Construct an empty payload variables object
-  PayloadVariables() = default;
+  // Construct an empty (not all) payload variables object. `allocator` is the
+  // real allocator that the (initially empty) list of variables is routed
+  // through; there is no implicit unlimited-allocator fallback.
+  explicit PayloadVariables(qlever::Allocator<Variable> allocator);
 
   // Construct a payload variables object from a vector of variables
-  PayloadVariables(std::vector<Variable> variables);
+  PayloadVariables(qlever::vector<Variable> variables);
 
-  // Construct a payload variables object that is set to all
+  // Construct a payload variables object that is set to all. This needs no
+  // allocator: the "all" state never holds a vector.
   static PayloadVariables all();
 
   // Add a variable to the payload variables or do nothing if all variables are
@@ -45,7 +51,7 @@ class PayloadVariables {
   bool isAll() const;
 
   // Returns a vector of variables if all has not been set. Otherwise throws.
-  const std::vector<Variable>& getVariables() const;
+  const qlever::vector<Variable>& getVariables() const;
 
   // For testing: equality operator
   bool operator==(const PayloadVariables& other) const {
@@ -53,8 +59,12 @@ class PayloadVariables {
   }
 
  private:
-  std::variant<detail::PayloadAllVariables, std::vector<Variable>> variables_ =
-      std::vector<Variable>{};
+  // Construct directly in the "all" state, without ever needing a vector (and
+  // therefore without needing an allocator). Used by `all()`.
+  explicit PayloadVariables(detail::PayloadAllVariables tag) : variables_{tag} {}
+
+  std::variant<detail::PayloadAllVariables, qlever::vector<Variable>>
+      variables_;
 };
 
 #endif  // QLEVER_SRC_PARSER_PAYLOADVARIABLES_H

--- a/src/parser/PropertyPath.cpp
+++ b/src/parser/PropertyPath.cpp
@@ -37,26 +37,29 @@ PropertyPath PropertyPath::makeWithLength(PropertyPath child, size_t min,
 }
 
 // _____________________________________________________________________________
-PropertyPath PropertyPath::makeAlternative(std::vector<PropertyPath> children) {
+PropertyPath PropertyPath::makeAlternative(ChildrenVec children) {
   AD_CONTRACT_CHECK(children.size() > 1,
                     "Alternative paths must have at least two children.");
   return PropertyPath{ModifiedPath{std::move(children), Modifier::ALTERNATIVE}};
 }
 
 // _____________________________________________________________________________
-PropertyPath PropertyPath::makeSequence(std::vector<PropertyPath> children) {
+PropertyPath PropertyPath::makeSequence(ChildrenVec children) {
   AD_CONTRACT_CHECK(children.size() > 1,
                     "Sequence paths must have at least two children.");
   return PropertyPath{ModifiedPath{std::move(children), Modifier::SEQUENCE}};
 }
 
 // _____________________________________________________________________________
-PropertyPath PropertyPath::makeInverse(PropertyPath child) {
-  return PropertyPath{ModifiedPath{{std::move(child)}, Modifier::INVERSE}};
+PropertyPath PropertyPath::makeInverse(PropertyPath child,
+                                       qlever::Allocator<Id> allocator) {
+  ChildrenVec children{std::move(allocator)};
+  children.push_back(std::move(child));
+  return PropertyPath{ModifiedPath{std::move(children), Modifier::INVERSE}};
 }
 
 // _____________________________________________________________________________
-PropertyPath PropertyPath::makeNegated(std::vector<PropertyPath> children) {
+PropertyPath PropertyPath::makeNegated(ChildrenVec children) {
   return PropertyPath{ModifiedPath{std::move(children), Modifier::NEGATED}};
 }
 
@@ -131,7 +134,7 @@ bool PropertyPath::isIri() const {
 }
 
 // _____________________________________________________________________________
-const std::vector<PropertyPath>& PropertyPath::getSequence() const {
+const PropertyPath::ChildrenVec& PropertyPath::getSequence() const {
   AD_CONTRACT_CHECK(isSequence());
   return std::get<ModifiedPath>(path_).children_;
 }

--- a/src/parser/PropertyPath.h
+++ b/src/parser/PropertyPath.h
@@ -12,7 +12,10 @@
 
 #include "backports/concepts.h"
 #include "backports/three_way_comparison.h"
+#include "global/Id.h"
 #include "rdfTypes/Iri.h"
+#include "util/Allocator.h"
+#include "util/AllocatorTypes.h"
 #include "util/Exception.h"
 #include "util/OverloadCallOperator.h"
 #include "util/TypeTraits.h"
@@ -31,12 +34,16 @@ class PropertyPath {
     NEGATED
   };
 
+  // The vector type used for the children of alternative, sequence, and
+  // negated property paths.
+  using ChildrenVec = qlever::vector<PropertyPath>;
+
  private:
   // Represent a modified path that can have multiple children and a modifier.
   // This is used to represent sequence paths, alternative paths, inverse paths,
   // and negated paths.
   struct ModifiedPath {
-    std::vector<PropertyPath> children_;
+    ChildrenVec children_;
     Modifier modifier_;
 
     QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(ModifiedPath, children_,
@@ -105,18 +112,19 @@ class PropertyPath {
                                      size_t max);
 
   // Create an alternative property path with the given children.
-  static PropertyPath makeAlternative(std::vector<PropertyPath> children);
+  static PropertyPath makeAlternative(ChildrenVec children);
 
   // Create a sequence property path with the given children.
-  static PropertyPath makeSequence(std::vector<PropertyPath> children);
+  static PropertyPath makeSequence(ChildrenVec children);
 
   // Create an inverse property path with the given child.
-  static PropertyPath makeInverse(PropertyPath child);
+  static PropertyPath makeInverse(PropertyPath child,
+                                  qlever::Allocator<Id> allocator);
 
   // Create a negated property path with the given children, for multiple
   // children the semantics are equivalent to `!(<a> | <b>)`, applying the union
   // before the negation.
-  static PropertyPath makeNegated(std::vector<PropertyPath> children);
+  static PropertyPath makeNegated(ChildrenVec children);
 
   QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(PropertyPath, path_)
 
@@ -136,7 +144,7 @@ class PropertyPath {
 
   // If the path is a sequence, return the children (that is, the parts of the
   // sequence). If the path is not a sequence this will throw.
-  const std::vector<PropertyPath>& getSequence() const;
+  const ChildrenVec& getSequence() const;
 
   // Check if the path is a sequence.
   bool isSequence() const;
@@ -153,7 +161,8 @@ class PropertyPath {
       requires ad_utility::InvocableWithConvertibleReturnType<
           IriFunc, T, const ad_utility::triple_component::Iri&>
           CPP_and ad_utility::InvocableWithConvertibleReturnType<
-              ModifiedPathFunc, T, const std::vector<PropertyPath>&, Modifier>
+              ModifiedPathFunc, T, const ChildrenVec&,
+              Modifier>
               CPP_and ad_utility::InvocableWithConvertibleReturnType<
                   MinMaxPathFunc, T, const PropertyPath&, size_t, size_t>) T
       handlePath(const IriFunc& iriFunc,

--- a/src/parser/Quads.h
+++ b/src/parser/Quads.h
@@ -14,6 +14,8 @@
 #include "parser/SparqlTriple.h"
 #include "parser/UpdateTriples.h"
 #include "parser/data/Types.h"
+#include "util/Allocator.h"
+#include "util/AllocatorTypes.h"
 
 // A class for the intermediate parsing results of `quads`. Provides utilities
 // for converting the quads into the required formats. The Quads/Triples can be
@@ -29,7 +31,21 @@ struct Quads {
   // Free triples are outside a `GRAPH ...` clause.
   ad_utility::sparql_types::Triples freeTriples_{};
   // Graph triples are inside a `GRAPH ...` clause.
-  std::vector<GraphBlock> graphTriples_{};
+  qlever::vector<GraphBlock> graphTriples_;
+
+  // `allocator` is the real, query-execution-bound allocator that
+  // `graphTriples_` is routed through. Used by callers that start out with
+  // empty triples and populate them afterwards.
+  explicit Quads(qlever::Allocator<Id> allocator)
+      : graphTriples_{std::move(allocator)} {}
+
+  // Construct directly from already-allocated free/graph triples (the
+  // allocator is taken from `graphTriples`, which the caller must have
+  // already constructed with a real allocator).
+  Quads(ad_utility::sparql_types::Triples freeTriples,
+        qlever::vector<GraphBlock> graphTriples)
+      : freeTriples_{std::move(freeTriples)},
+        graphTriples_{std::move(graphTriples)} {}
 
   QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(Quads, freeTriples_,
                                               graphTriples_)

--- a/src/parser/SparqlParser.cpp
+++ b/src/parser/SparqlParser.cpp
@@ -19,7 +19,8 @@ auto parseOperation(BnodeMgr bnodeMgr,
                     const EncodedIriManager* encodedIriManager,
                     ContextType* (SparqlAutomaticParser::*f)(void),
                     std::string operation,
-                    const std::vector<DatasetClause>& datasets) {
+                    const std::vector<DatasetClause>& datasets,
+                    qlever::Allocator<Id> allocator) {
   using S = std::string;
   // The second argument is the `PrefixMap` for QLever's internal IRIs.
   // The third argument are the datasets from outside the query, which override
@@ -31,7 +32,9 @@ auto parseOperation(BnodeMgr bnodeMgr,
       {{S{QLEVER_INTERNAL_PREFIX_NAME}, S{QLEVER_INTERNAL_PREFIX_IRI}}},
       datasets.empty()
           ? std::nullopt
-          : std::optional(parsedQuery::DatasetClauses::fromClauses(datasets))};
+          : std::optional(parsedQuery::DatasetClauses::fromClauses(datasets)),
+      SparqlQleverVisitor::DisableSomeChecksOnlyForTesting::False,
+      std::move(allocator)};
   auto resultOfParseAndRemainingText = p.parseTypesafe(f);
   // The query rule ends with <EOF> so the parse always has to consume the whole
   // input. If this is not the case a ParseException should have been thrown at
@@ -44,10 +47,11 @@ auto parseOperation(BnodeMgr bnodeMgr,
 // _____________________________________________________________________________
 ParsedQuery SparqlParser::parseQuery(
     const EncodedIriManager* encodedIriManager, std::string query,
-    const std::vector<DatasetClause>& datasets) {
+    const std::vector<DatasetClause>& datasets,
+    qlever::Allocator<Id> allocator) {
   ad_utility::BlankNodeManager bnodeMgr;
   auto res = parseOperation(&bnodeMgr, encodedIriManager, &AntlrParser::query,
-                            std::move(query), datasets);
+                            std::move(query), datasets, std::move(allocator));
   // Queries never contain blank nodes in the body since they are always turned
   // into internal variables.
   AD_CORRECTNESS_CHECK(bnodeMgr.numBlocksUsed() == 0);
@@ -55,9 +59,10 @@ ParsedQuery SparqlParser::parseQuery(
 }
 
 // _____________________________________________________________________________
-std::vector<ParsedQuery> SparqlParser::parseUpdate(
+qlever::vector<ParsedQuery> SparqlParser::parseUpdate(
     BnodeMgr bnodeMgr, const EncodedIriManager* encodedIriManager,
-    std::string update, const std::vector<DatasetClause>& datasets) {
+    std::string update, const std::vector<DatasetClause>& datasets,
+    qlever::Allocator<Id> allocator) {
   return parseOperation(bnodeMgr, encodedIriManager, &AntlrParser::update,
-                        std::move(update), datasets);
+                        std::move(update), datasets, std::move(allocator));
 }

--- a/src/parser/SparqlParser.h
+++ b/src/parser/SparqlParser.h
@@ -8,6 +8,8 @@
 #include <string>
 
 #include "parser/ParsedQuery.h"
+#include "util/Allocator.h"
+#include "util/AllocatorTypes.h"
 #include "util/BlankNodeManager.h"
 
 // The SPARQL parser used by QLever. The actual parsing is delegated to a parser
@@ -20,13 +22,21 @@ class SparqlParser {
   // overwritten from inside the query (using `FROM`) or update (using `USING`).
   // Passing no datasets means that the datasets are set normally from the
   // query or update.
-  static ParsedQuery parseQuery(
-      const EncodedIriManager* encodedIriManager, std::string query,
-      const std::vector<DatasetClause>& datasets = {});
-  static std::vector<ParsedQuery> parseUpdate(
+  //
+  // `allocator` is the allocator that dynamic allocations performed while
+  // parsing should be routed through. Pass the allocator of an existing
+  // `QueryExecutionContext` (e.g. `qec->getAllocator()`) when one is already
+  // available at the call site; otherwise pass an explicit
+  // `qlever::makeUnlimitedAllocator<Id>()` (there is no implicit default).
+  static ParsedQuery parseQuery(const EncodedIriManager* encodedIriManager,
+                                std::string query,
+                                const std::vector<DatasetClause>& datasets,
+                                qlever::Allocator<Id> allocator);
+  static qlever::vector<ParsedQuery> parseUpdate(
       ad_utility::BlankNodeManager* bnodeManager,
       const EncodedIriManager* encodedIriManager, std::string update,
-      const std::vector<DatasetClause>& datasets = {});
+      const std::vector<DatasetClause>& datasets,
+      qlever::Allocator<Id> allocator);
 };
 
 #endif  // QLEVER_SRC_PARSER_SPARQLPARSER_H

--- a/src/parser/SparqlParserHelpers.cpp
+++ b/src/parser/SparqlParserHelpers.cpp
@@ -24,13 +24,15 @@ ParserAndVisitor::ParserAndVisitor(
     ad_utility::BlankNodeManager* blankNodeManager,
     const EncodedIriManager* encodedIriManager, std::string input,
     std::optional<ParsedQuery::DatasetClauses> datasetClauses,
-    SparqlQleverVisitor::DisableSomeChecksOnlyForTesting disableSomeChecks)
+    SparqlQleverVisitor::DisableSomeChecksOnlyForTesting disableSomeChecks,
+    qlever::Allocator<Id> allocator)
     : Base{unescapeUnicodeSequences(std::move(input)),
            SparqlQleverVisitor{blankNodeManager,
                                encodedIriManager,
                                {},
                                std::move(datasetClauses),
-                               disableSomeChecks}} {}
+                               disableSomeChecks,
+                               std::move(allocator)}} {}
 
 // _____________________________________________________________________________
 ParserAndVisitor::ParserAndVisitor(
@@ -38,9 +40,11 @@ ParserAndVisitor::ParserAndVisitor(
     const EncodedIriManager* encodedIriManager, std::string input,
     SparqlQleverVisitor::PrefixMap prefixes,
     std::optional<ParsedQuery::DatasetClauses> datasetClauses,
-    SparqlQleverVisitor::DisableSomeChecksOnlyForTesting disableSomeChecks)
-    : ParserAndVisitor{blankNodeManager, encodedIriManager, std::move(input),
-                       std::move(datasetClauses), disableSomeChecks} {
+    SparqlQleverVisitor::DisableSomeChecksOnlyForTesting disableSomeChecks,
+    qlever::Allocator<Id> allocator)
+    : ParserAndVisitor{blankNodeManager,       encodedIriManager,
+                       std::move(input),       std::move(datasetClauses),
+                       disableSomeChecks,       std::move(allocator)} {
   visitor_.setPrefixMapManually(std::move(prefixes));
 }
 

--- a/src/parser/SparqlParserHelpers.h
+++ b/src/parser/SparqlParserHelpers.h
@@ -11,6 +11,7 @@
 #include "parser/ParsedQuery.h"
 #include "parser/ParserAndVisitorBase.h"
 #include "sparqlParser/SparqlQleverVisitor.h"
+#include "util/Allocator.h"
 #include "util/BlankNodeManager.h"
 
 namespace sparqlParserHelpers {
@@ -30,16 +31,16 @@ struct ParserAndVisitor : public ParserAndVisitorBase<SparqlQleverVisitor> {
   ParserAndVisitor(
       ad_utility::BlankNodeManager* blankNodeManager,
       const EncodedIriManager* encodedIriManager, std::string input,
-      std::optional<ParsedQuery::DatasetClauses> datasetClauses = std::nullopt,
-      SparqlQleverVisitor::DisableSomeChecksOnlyForTesting disableSomeChecks =
-          SparqlQleverVisitor::DisableSomeChecksOnlyForTesting::False);
+      std::optional<ParsedQuery::DatasetClauses> datasetClauses,
+      SparqlQleverVisitor::DisableSomeChecksOnlyForTesting disableSomeChecks,
+      qlever::Allocator<Id> allocator);
   ParserAndVisitor(
       ad_utility::BlankNodeManager* blankNodeManager,
       const EncodedIriManager* encodedIriManager, std::string input,
       SparqlQleverVisitor::PrefixMap prefixes,
-      std::optional<ParsedQuery::DatasetClauses> datasetClauses = std::nullopt,
-      SparqlQleverVisitor::DisableSomeChecksOnlyForTesting disableSomeChecks =
-          SparqlQleverVisitor::DisableSomeChecksOnlyForTesting::False);
+      std::optional<ParsedQuery::DatasetClauses> datasetClauses,
+      SparqlQleverVisitor::DisableSomeChecksOnlyForTesting disableSomeChecks,
+      qlever::Allocator<Id> allocator);
 };
 }  // namespace sparqlParserHelpers
 

--- a/src/parser/SparqlTriple.h
+++ b/src/parser/SparqlTriple.h
@@ -16,15 +16,20 @@
 #include "parser/TripleComponent.h"
 #include "parser/data/Types.h"
 #include "rdfTypes/Variable.h"
+#include "util/Allocator.h"
+#include "util/AllocatorTypes.h"
 
 // Data container for parsed triples from the where clause.
 // It is templated on the predicate type, see the instantiations below.
 template <typename Predicate>
 class SparqlTripleBase {
  public:
-  using AdditionalScanColumns = std::vector<std::pair<ColumnIndex, Variable>>;
+  using AdditionalScanColumns = qlever::vector<std::pair<ColumnIndex, Variable>>;
   SparqlTripleBase(TripleComponent s, Predicate p, TripleComponent o,
-                   AdditionalScanColumns additionalScanColumns = {})
+                   AdditionalScanColumns additionalScanColumns =
+                       AdditionalScanColumns{
+                           qlever::makeUnlimitedAllocator<
+                               std::pair<ColumnIndex, Variable>>()})
       : s_(std::move(s)),
         p_(std::move(p)),
         o_(std::move(o)),
@@ -40,7 +45,7 @@ class SparqlTripleBase {
   // performing an index scan using this triple.
   // TODO<joka921> On this level we should not store `ColumnIndex`, but the
   // special predicate IRIs that are to be attached here.
-  std::vector<std::pair<ColumnIndex, Variable>> additionalScanColumns_;
+  AdditionalScanColumns additionalScanColumns_;
 };
 
 // A triple where the predicate is a `TripleComponent`, so a fixed entity or a
@@ -54,9 +59,12 @@ class SparqlTripleSimpleWithGraph : public SparqlTripleSimple {
  public:
   using Graph = std::variant<std::monostate, TripleComponent::Iri, Variable>;
 
-  SparqlTripleSimpleWithGraph(TripleComponent s, TripleComponent p,
-                              TripleComponent o, Graph g,
-                              AdditionalScanColumns additionalScanColumns = {})
+  SparqlTripleSimpleWithGraph(
+      TripleComponent s, TripleComponent p, TripleComponent o, Graph g,
+      AdditionalScanColumns additionalScanColumns =
+          AdditionalScanColumns{
+              qlever::makeUnlimitedAllocator<
+                  std::pair<ColumnIndex, Variable>>()})
       : SparqlTripleSimple(std::move(s), std::move(p), std::move(o),
                            std::move(additionalScanColumns)),
         g_{std::move(g)} {}

--- a/src/parser/SpatialQuery.cpp
+++ b/src/parser/SpatialQuery.cpp
@@ -231,12 +231,8 @@ SpatialJoinConfiguration SpatialQuery::toSpatialJoinConfiguration() const {
   }
 
   // Payload variables
-  PayloadVariables pv;
-  if (!childGraphPattern_.has_value()) {
-    pv = PayloadVariables::all();
-  } else {
-    pv = payloadVariables_;
-  }
+  PayloadVariables pv = childGraphPattern_.has_value() ? payloadVariables_
+                                                       : PayloadVariables::all();
 
   // Task specification
   SpatialJoinTask task;
@@ -255,7 +251,9 @@ SpatialJoinConfiguration SpatialQuery::toSpatialJoinConfiguration() const {
 }
 
 // ____________________________________________________________________________
-SpatialQuery::SpatialQuery(const SparqlTriple& triple) {
+SpatialQuery::SpatialQuery(const SparqlTriple& triple,
+                          qlever::Allocator<Id> allocator)
+    : payloadVariables_{std::move(allocator)} {
   auto predicate = triple.getSimplePredicate();
   AD_CONTRACT_CHECK(predicate.has_value(),
                     "The config triple for SpatialJoin must have a special IRI "

--- a/src/parser/SpatialQuery.h
+++ b/src/parser/SpatialQuery.h
@@ -70,7 +70,11 @@ struct SpatialQuery : MagicServiceQuery {
   // declared inside the service (despite confusing semantics).
   bool ignoreMissingRightChild_ = false;
 
-  SpatialQuery() = default;
+  SpatialQuery() = delete;
+  // `allocator` is the real allocator that `payloadVariables_` is routed
+  // through; there is no implicit unlimited-allocator fallback.
+  explicit SpatialQuery(qlever::Allocator<Id> allocator)
+      : payloadVariables_{std::move(allocator)} {}
   SpatialQuery(SpatialQuery&& other) noexcept = default;
   SpatialQuery(const SpatialQuery& other) = default;
   SpatialQuery& operator=(const SpatialQuery& other) = default;
@@ -78,8 +82,9 @@ struct SpatialQuery : MagicServiceQuery {
   ~SpatialQuery() noexcept override = default;
 
   // Alternative constructor for backward compatibility (allows initializing a
-  // SpatialJoin using a magic predicate)
-  explicit SpatialQuery(const SparqlTriple& triple);
+  // SpatialJoin using a magic predicate). `allocator` is routed through the
+  // same way as for the main constructor above.
+  explicit SpatialQuery(const SparqlTriple& triple, qlever::Allocator<Id> allocator);
 
   // See MagicServiceQuery
   void addParameter(const SparqlTriple& triple) override;

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -30,6 +30,7 @@
 #include "engine/sparqlExpressions/NaryExpression.h"
 #include "engine/sparqlExpressions/NowDatetimeExpression.h"
 #include "engine/sparqlExpressions/RandomExpression.h"
+#include "util/MemorySize/MemorySize.h"
 #include "engine/sparqlExpressions/RegexExpression.h"
 #include "engine/sparqlExpressions/RelationalExpressions.h"
 #include "engine/sparqlExpressions/SampleExpression.h"
@@ -94,7 +95,7 @@ namespace {
 // arguments.
 template <typename F, size_t... Idxs>
 ExpressionPtr invokeWithMovedArgs(F& function,
-                                  std::vector<ExpressionPtr>& argList,
+                                  qlever::vector<ExpressionPtr>& argList,
                                   std::index_sequence<Idxs...>) {
   return function(std::move(argList[Idxs])...);
 }
@@ -189,7 +190,7 @@ std::string Visitor::currentTimeAsXsdString() {
 
 // ___________________________________________________________________________
 ExpressionPtr Visitor::processIriFunctionCall(
-    const TripleComponent::Iri& iri, std::vector<ExpressionPtr> argList,
+    const TripleComponent::Iri& iri, qlever::vector<ExpressionPtr> argList,
     const antlr4::ParserRuleContext* ctx) {
   std::string_view functionName = asStringViewUnsafe(iri.getContent());
   std::string_view prefixName;
@@ -412,7 +413,7 @@ void SparqlQleverVisitor::resetStateForMultipleUpdates() {
   // - activeDatasetClauses_: if `datasetsAreFixed_` is true
   _blankNodeCounter = 0;
   numGraphPatterns_ = 0;
-  visibleVariables_ = {};
+  visibleVariables_.clear();
   // When fixed datasets are given for a request (see SPARQL Protocol), these
   // cannot be changed by a SPARQL operation but are also constant for chained
   // updates.
@@ -420,7 +421,7 @@ void SparqlQleverVisitor::resetStateForMultipleUpdates() {
     activeDatasetClauses_ = {};
   }
   prologueString_ = {};
-  parsedQuery_ = {};
+  parsedQuery_ = ParsedQuery{allocator()};
   treatBlankNodesAs_ = TreatBlankNodesAs::InternalVariables;
   allBlankNodeLabels_.clear();
   blankNodeLabelsInCurrentBasicGraphPattern_.clear();
@@ -510,7 +511,7 @@ parsedQuery::BasicGraphPattern Visitor::toGraphPattern(
 
 // ____________________________________________________________________________________
 const parsedQuery::DatasetClauses& SparqlQleverVisitor::setAndGetDatasetClauses(
-    const std::vector<DatasetClause>& clauses) {
+    const qlever::vector<DatasetClause>& clauses) {
   if (!datasetsAreFixed_) {
     activeDatasetClauses_ = parsedQuery::DatasetClauses::fromClauses(clauses);
   }
@@ -518,10 +519,17 @@ const parsedQuery::DatasetClauses& SparqlQleverVisitor::setAndGetDatasetClauses(
 }
 
 // ____________________________________________________________________________________
+qlever::vector<DatasetClause> SparqlQleverVisitor::toPmrDatasetClauses(
+    std::vector<DatasetClause> clauses) const {
+  return qlever::vector<DatasetClause>(clauses.begin(), clauses.end(),
+                                       allocator());
+}
+
+// ____________________________________________________________________________________
 ParsedQuery Visitor::visit(Parser::ConstructQueryContext* ctx) {
-  ParsedQuery query;
+  ParsedQuery query{allocator()};
   query.datasetClauses_ =
-      setAndGetDatasetClauses(visitVector(ctx->datasetClause()));
+      setAndGetDatasetClauses(toPmrDatasetClauses(visitVector(ctx->datasetClause())));
   if (ctx->constructTemplate()) {
     query._clause = visit(ctx->constructTemplate())
                         .value_or(parsedQuery::ConstructClause{});
@@ -544,7 +552,8 @@ ParsedQuery Visitor::visit(Parser::ConstructQueryContext* ctx) {
 
 // ____________________________________________________________________________________
 ParsedQuery Visitor::visit(Parser::DescribeQueryContext* ctx) {
-  auto describeClause = parsedQuery::Describe{};
+  auto describeClause =
+      parsedQuery::Describe{{}, {}, parsedQuery::Subquery{allocator()}};
   auto describedResources = visitVector(ctx->varOrIri());
 
   // Convert the describe resources (variables or IRIs) from the format that the
@@ -564,7 +573,7 @@ ParsedQuery Visitor::visit(Parser::DescribeQueryContext* ctx) {
 
   // Parse the FROM and FROM NAMED clauses.
   describeClause.datasetClauses_ =
-      setAndGetDatasetClauses(visitVector(ctx->datasetClause()));
+      setAndGetDatasetClauses(toPmrDatasetClauses(visitVector(ctx->datasetClause())));
 
   // Parse the WHERE clause and construct a SELECT query from it. For `DESCRIBE
   // *`, add each visible variable as a resource to describe.
@@ -591,7 +600,7 @@ ParsedQuery Visitor::visit(Parser::DescribeQueryContext* ctx) {
   // DESCRIBE), and once in `parsedQuery_.describeClause_.datasetClauses_`
   // (which pertains to the SELECT query that computes the resources to be
   // described).
-  parsedQuery_ = ParsedQuery{};
+  parsedQuery_ = ParsedQuery{allocator()};
   parsedQuery_.addSolutionModifiers(visit(ctx->solutionModifier()),
                                     makeInternalVariableGenerator());
   parsedQuery_._rootGraphPattern._graphPatterns.emplace_back(
@@ -611,7 +620,7 @@ ParsedQuery Visitor::visit(Parser::DescribeQueryContext* ctx) {
 ParsedQuery Visitor::visit(Parser::AskQueryContext* ctx) {
   parsedQuery_._clause = ParsedQuery::AskClause{};
   parsedQuery_.datasetClauses_ =
-      setAndGetDatasetClauses(visitVector(ctx->datasetClause()));
+      setAndGetDatasetClauses(toPmrDatasetClauses(visitVector(ctx->datasetClause())));
   visitWhereClause(ctx->whereClause(), parsedQuery_);
   // NOTE: It can make sense to have solution modifiers with an ASK query, for
   // example, a GROUP BY with a HAVING.
@@ -703,8 +712,8 @@ std::optional<Values> Visitor::visit(Parser::ValuesClauseContext* ctx) {
 }
 
 // ____________________________________________________________________________
-std::vector<ParsedQuery> Visitor::visit(Parser::UpdateContext* ctx) {
-  std::vector<ParsedQuery> updates{};
+qlever::vector<ParsedQuery> Visitor::visit(Parser::UpdateContext* ctx) {
+  qlever::vector<ParsedQuery> updates{allocator()};
 
   AD_CORRECTNESS_CHECK(ctx->prologue().size() >= ctx->update1().size());
   for (size_t i = 0; i < ctx->update1().size(); ++i) {
@@ -727,7 +736,7 @@ std::vector<ParsedQuery> Visitor::visit(Parser::UpdateContext* ctx) {
     ql::ranges::for_each(thisUpdates, [updateStringRepr](ParsedQuery& update) {
       update._originalString = updateStringRepr;
     });
-    ad_utility::appendVector(updates, thisUpdates);
+    ql::ranges::move(thisUpdates, std::back_inserter(updates));
     resetStateForMultipleUpdates();
   }
 
@@ -735,19 +744,47 @@ std::vector<ParsedQuery> Visitor::visit(Parser::UpdateContext* ctx) {
 }
 
 // ____________________________________________________________________________________
-std::vector<ParsedQuery> Visitor::visit(Parser::Update1Context* ctx) {
-  if (ctx->deleteWhere() || ctx->modify() || ctx->clear() || ctx->drop() ||
-      ctx->create() || ctx->copy() || ctx->move() || ctx->add() ||
-      ctx->load()) {
-    return visitAlternative<std::vector<ParsedQuery>>(
-        ctx->deleteWhere(), ctx->modify(), ctx->clear(), ctx->drop(),
-        ctx->create(), ctx->copy(), ctx->move(), ctx->add(), ctx->load());
+qlever::vector<ParsedQuery> Visitor::visit(Parser::Update1Context* ctx) {
+  // `visitAlternative`'s generic single-value-to-vector wrapping (via
+  // `Intermediate{singleValue}`) relies on a default-constructible allocator,
+  // which `qlever::vector` deliberately does not have. The alternatives below
+  // mix single-`ParsedQuery`- and vector-returning `visit` overloads, so they
+  // are dispatched manually instead, threading the real allocator through.
+  auto wrapSingle = [this](ParsedQuery pq) {
+    return qlever::vector<ParsedQuery>({std::move(pq)}, allocator());
+  };
+  if (ctx->deleteWhere()) {
+    return wrapSingle(visit(ctx->deleteWhere()));
+  }
+  if (ctx->modify()) {
+    return wrapSingle(visit(ctx->modify()));
+  }
+  if (ctx->clear()) {
+    return wrapSingle(visit(ctx->clear()));
+  }
+  if (ctx->drop()) {
+    return wrapSingle(visit(ctx->drop()));
+  }
+  if (ctx->create()) {
+    return visit(ctx->create());
+  }
+  if (ctx->copy()) {
+    return visit(ctx->copy());
+  }
+  if (ctx->move()) {
+    return visit(ctx->move());
+  }
+  if (ctx->add()) {
+    return visit(ctx->add());
+  }
+  if (ctx->load()) {
+    return wrapSingle(visit(ctx->load()));
   }
   AD_CORRECTNESS_CHECK(ctx->insertData() || ctx->deleteData());
   parsedQuery_._clause = visitAlternative<parsedQuery::UpdateClause>(
       ctx->insertData(), ctx->deleteData());
   parsedQuery_.datasetClauses_ = activeDatasetClauses_;
-  return {std::move(parsedQuery_)};
+  return qlever::vector<ParsedQuery>({std::move(parsedQuery_)}, allocator());
 }
 
 // ____________________________________________________________________________________
@@ -879,29 +916,30 @@ ParsedQuery Visitor::visit(Parser::DropContext* ctx) {
 }
 
 // ____________________________________________________________________________________
-std::vector<ParsedQuery> Visitor::visit(const Parser::CreateContext*) {
+qlever::vector<ParsedQuery> Visitor::visit(const Parser::CreateContext*) {
   // Create is a no-op because we don't explicitly record the existence of empty
   // graphs.
-  return {};
+  return qlever::vector<ParsedQuery>{allocator()};
 }
 
 // ____________________________________________________________________________________
-std::vector<ParsedQuery> Visitor::visit(Parser::AddContext* ctx) {
+qlever::vector<ParsedQuery> Visitor::visit(Parser::AddContext* ctx) {
   AD_CORRECTNESS_CHECK(ctx->graphOrDefault().size() == 2);
   auto from = visit(ctx->graphOrDefault()[0]);
   auto to = visit(ctx->graphOrDefault()[1]);
 
   if (from == to) {
-    return {};
+    return qlever::vector<ParsedQuery>{allocator()};
   }
 
-  return {makeAdd(from, to)};
+  return qlever::vector<ParsedQuery>({makeAdd(from, to)}, allocator());
 }
 
 // _____________________________________________________________________________
-std::vector<ParsedQuery> Visitor::makeCopy(const GraphOrDefault& from,
-                                           const GraphOrDefault& to) {
-  std::vector<ParsedQuery> updates{makeClear(transformGraph(to))};
+qlever::vector<ParsedQuery> Visitor::makeCopy(const GraphOrDefault& from,
+                                              const GraphOrDefault& to) {
+  qlever::vector<ParsedQuery> updates({makeClear(transformGraph(to))},
+                                      allocator());
   resetStateForMultipleUpdates();
   updates.push_back(makeAdd(from, to));
 
@@ -916,14 +954,14 @@ std::pair<GraphOrDefault, GraphOrDefault> Visitor::visitFromTo(
 }
 
 // ____________________________________________________________________________________
-std::vector<ParsedQuery> Visitor::visit(Parser::MoveContext* ctx) {
+qlever::vector<ParsedQuery> Visitor::visit(Parser::MoveContext* ctx) {
   auto [from, to] = visitFromTo(ctx->graphOrDefault());
 
   if (from == to) {
-    return {};
+    return qlever::vector<ParsedQuery>{allocator()};
   }
 
-  std::vector<ParsedQuery> updates = makeCopy(from, to);
+  qlever::vector<ParsedQuery> updates = makeCopy(from, to);
   resetStateForMultipleUpdates();
   updates.push_back(makeClear(transformGraph(from)));
 
@@ -931,11 +969,11 @@ std::vector<ParsedQuery> Visitor::visit(Parser::MoveContext* ctx) {
 }
 
 // ____________________________________________________________________________________
-std::vector<ParsedQuery> Visitor::visit(Parser::CopyContext* ctx) {
+qlever::vector<ParsedQuery> Visitor::visit(Parser::CopyContext* ctx) {
   auto [from, to] = visitFromTo(ctx->graphOrDefault());
 
   if (from == to) {
-    return {};
+    return qlever::vector<ParsedQuery>{allocator()};
   }
 
   return makeCopy(from, to);
@@ -1013,7 +1051,7 @@ ParsedQuery Visitor::visit(Parser::ModifyContext* ctx) {
 
   AD_CORRECTNESS_CHECK(visibleVariables_.empty());
   parsedQuery_.datasetClauses_ =
-      setAndGetDatasetClauses(visitVector(ctx->usingClause()));
+      setAndGetDatasetClauses(toPmrDatasetClauses(visitVector(ctx->usingClause())));
 
   // If there is no USING clause, but a WITH clause, then the graph specified in
   // the WITH clause is used as the default graph in the WHERE clause of this
@@ -1109,7 +1147,7 @@ Quads Visitor::visit(Parser::QuadDataContext* ctx) {
 Quads Visitor::visit(Parser::QuadsContext* ctx) {
   // The ordering of the individual triplesTemplate and quadsNotTriples is not
   // relevant and also not known.
-  Quads quads;
+  Quads quads{allocator()};
   quads.freeTriples_ = ad_utility::flatten(visitVector(ctx->triplesTemplate()));
   for (auto& [graph, triples] : visitVector(ctx->quadsNotTriples())) {
     quads.graphTriples_.emplace_back(std::move(graph), std::move(triples));
@@ -1160,7 +1198,7 @@ GraphPattern Visitor::visit(Parser::GroupGraphPatternContext* ctx) {
                                      visibleVariablesSoFar.end());
           });
   if (ctx->subSelect()) {
-    auto parsedQuerySoFar = std::exchange(parsedQuery_, ParsedQuery{});
+    auto parsedQuerySoFar = std::exchange(parsedQuery_, ParsedQuery{allocator()});
     auto [subquery, valuesOpt] = visit(ctx->subSelect());
     pattern._graphPatterns.emplace_back(std::move(subquery));
     if (valuesOpt.has_value()) {
@@ -1182,7 +1220,7 @@ GraphPattern Visitor::visit(Parser::GroupGraphPatternContext* ctx) {
     if (auto langFilterData = filter.expression_.getLanguageFilterExpression();
         langFilterData.has_value()) {
       const auto& [variable, language] = langFilterData.value();
-      if (pattern.addLanguageFilter(variable, language)) {
+      if (pattern.addLanguageFilter(variable, language, allocator())) {
         continue;
       }
     }
@@ -1194,7 +1232,7 @@ GraphPattern Visitor::visit(Parser::GroupGraphPatternContext* ctx) {
 Visitor::OperationsAndFilters Visitor::visit(
     Parser::GroupGraphPatternSubContext* ctx) {
   std::vector<GraphPatternOperation> ops;
-  std::vector<SparqlFilter> filters;
+  qlever::vector<SparqlFilter> filters{allocator()};
 
   auto filter = [&filters](SparqlFilter filter) {
     filters.emplace_back(std::move(filter));
@@ -1343,16 +1381,16 @@ GraphPatternOperation Visitor::visit(Parser::ServiceGraphPatternContext* ctx) {
                  varOrIri);
 
   if (serviceIri.toStringRepresentation() == PATH_SEARCH_IRI) {
-    return visitMagicServiceQuery<parsedQuery::PathQuery>(ctx);
+    return visitMagicServiceQuery<parsedQuery::PathQuery>(ctx, allocator());
   } else if (serviceIri.toStringRepresentation() == SPATIAL_SEARCH_IRI) {
-    return visitMagicServiceQuery<parsedQuery::SpatialQuery>(ctx);
+    return visitMagicServiceQuery<parsedQuery::SpatialQuery>(ctx, allocator());
   } else if (serviceIri.toStringRepresentation() == TEXT_SEARCH_IRI) {
     return visitMagicServiceQuery<parsedQuery::TextSearchQuery>(ctx);
   } else if (serviceIri.toStringRepresentation() == EXTERNAL_VALUES_IRI ||
              ql::starts_with(serviceIri.toStringRepresentation(),
                              EXTERNAL_VALUES_IRI_PREFIX)) {
-    return visitMagicServiceQuery<parsedQuery::ExternalValuesQuery>(ctx,
-                                                                    serviceIri);
+    return visitMagicServiceQuery<parsedQuery::ExternalValuesQuery>(
+        ctx, serviceIri, allocator());
   } else if (ql::starts_with(asStringViewUnsafe(serviceIri.getContent()),
                              CACHED_RESULT_WITH_NAME_PREFIX)) {
     return visitMagicServiceQuery<parsedQuery::NamedCachedResult>(ctx,
@@ -1366,7 +1404,7 @@ GraphPatternOperation Visitor::visit(Parser::ServiceGraphPatternContext* ctx) {
   // SERVICE clause to the visible variables so far, but also remember them
   // separately (with duplicates removed) because we need them in `Service.cpp`
   // when computing the result for this operation.
-  std::vector<Variable> visibleVariablesSoFar = std::move(visibleVariables_);
+  auto visibleVariablesSoFar = std::move(visibleVariables_);
   parsedQuery::GraphPattern graphPattern = visit(ctx->groupGraphPattern());
   // Note: The `visit` call in the line above has filled the `visibleVariables_`
   // member with all the variables visible inside the graph pattern.
@@ -1418,7 +1456,7 @@ Visitor::PatternAndVisibleVariables Visitor::visit(
   // variables so far because they might not all be visible in the outer query.
   // Adding appropriately to the visible variables so far is then taken care of
   // in `visit(SubSelectContext*)`.
-  std::vector<Variable> visibleVariablesSoFar = std::move(visibleVariables_);
+  auto visibleVariablesSoFar = std::move(visibleVariables_);
   auto graphPatternWhereClause = visit(ctx->groupGraphPattern());
   // Using `std::exchange` as per Johannes' suggestion. I am slightly irritated
   // that this calls the move constructor AND the move assignment operator for
@@ -1615,7 +1653,7 @@ void Visitor::visit(Parser::PrefixDeclContext* ctx) {
 ParsedQuery Visitor::visit(Parser::SelectQueryContext* ctx) {
   parsedQuery_._clause = visit(ctx->selectClause());
   parsedQuery_.datasetClauses_ =
-      setAndGetDatasetClauses(visitVector(ctx->datasetClause()));
+      setAndGetDatasetClauses(toPmrDatasetClauses(visitVector(ctx->datasetClause())));
   visitWhereClause(ctx->whereClause(), parsedQuery_);
   parsedQuery_.addSolutionModifiers(visit(ctx->solutionModifier()),
                                     makeInternalVariableGenerator());
@@ -1627,8 +1665,9 @@ template <typename Ctx>
 auto Visitor::visitInFreshQueryContext(Ctx* ctx)
     -> FreshQueryContextResult<
         decltype(std::declval<SparqlQleverVisitor&>().visit(ctx))> {
-  auto queryBackup = std::exchange(parsedQuery_, ParsedQuery{});
-  auto variablesBackup = std::exchange(visibleVariables_, {});
+  auto queryBackup = std::exchange(parsedQuery_, ParsedQuery{allocator()});
+  auto variablesBackup =
+      std::exchange(visibleVariables_, qlever::vector<Variable>{allocator()});
   // The visited group starts a basic graph pattern of its own, but the basic
   // graph pattern of the outer query continues afterwards (an `EXISTS` is part
   // of a `FILTER`, which does not end it), so its blank node labels must be
@@ -1638,7 +1677,7 @@ auto Visitor::visitInFreshQueryContext(Ctx* ctx)
   // The restoring assignments are moves and cannot throw, so the cleanup
   // is safe also during stack unwinding.
   static_assert(std::is_nothrow_move_assignable_v<ParsedQuery>);
-  static_assert(std::is_nothrow_move_assignable_v<std::vector<Variable>>);
+  static_assert(std::is_nothrow_move_assignable_v<qlever::vector<Variable>>);
   static_assert(std::is_nothrow_move_assignable_v<
                 decltype(blankNodeLabelsInCurrentBasicGraphPattern_)>);
   absl::Cleanup restoreBackups{
@@ -1832,19 +1871,34 @@ uint64_t Visitor::visit(Parser::TextLimitClauseContext* ctx) {
 
 // ____________________________________________________________________________________
 SparqlValues Visitor::visit(Parser::InlineDataOneVarContext* ctx) {
-  SparqlValues values;
+  SparqlValues values{allocator()};
   values._variables.push_back(visit(ctx->var()));
   for (auto& dataBlockValue : ctx->dataBlockValue()) {
-    values._values.push_back({visit(dataBlockValue)});
+    qlever::vector<TripleComponent> row{allocator()};
+    row.push_back(visit(dataBlockValue));
+    values._values.push_back(std::move(row));
   }
   return values;
 }
 
 // ____________________________________________________________________________________
 SparqlValues Visitor::visit(Parser::InlineDataFullContext* ctx) {
-  SparqlValues values;
-  values._variables = visitVector(ctx->var());
-  values._values = visitVector(ctx->dataBlockSingle());
+  SparqlValues values{allocator()};
+  {
+    auto vars = visitVector(ctx->var());
+    values._variables = qlever::vector<Variable>(
+        std::make_move_iterator(vars.begin()),
+        std::make_move_iterator(vars.end()), allocator());
+  }
+  {
+    auto rows = visitVector(ctx->dataBlockSingle());
+    values._values.reserve(rows.size());
+    for (auto& row : rows) {
+      values._values.emplace_back(
+          std::make_move_iterator(row.begin()),
+          std::make_move_iterator(row.end()), allocator());
+    }
+  }
   if (std::any_of(values._values.begin(), values._values.end(),
                   [numVars = values._variables.size()](const auto& inner) {
                     return inner.size() != numVars;
@@ -1857,12 +1911,15 @@ SparqlValues Visitor::visit(Parser::InlineDataFullContext* ctx) {
 }
 
 // ____________________________________________________________________________________
-std::vector<TripleComponent> Visitor::visit(
+qlever::vector<TripleComponent> Visitor::visit(
     Parser::DataBlockSingleContext* ctx) {
   if (ctx->NIL()) {
-    return {};
+    return qlever::vector<TripleComponent>{allocator()};
   }
-  return visitVector(ctx->dataBlockValue());
+  auto values = visitVector(ctx->dataBlockValue());
+  return qlever::vector<TripleComponent>(
+      std::make_move_iterator(values.begin()),
+      std::make_move_iterator(values.end()), allocator());
 }
 
 // ____________________________________________________________________________________
@@ -1985,11 +2042,11 @@ ExpressionPtr Visitor::visit(Parser::FunctionCallContext* ctx) {
 }
 
 // ____________________________________________________________________________________
-std::vector<Visitor::ExpressionPtr> Visitor::visit(
+qlever::vector<Visitor::ExpressionPtr> Visitor::visit(
     Parser::ArgListContext* ctx) {
   // If no arguments, return empty expression vector.
   if (ctx->NIL()) {
-    return std::vector<ExpressionPtr>{};
+    return qlever::vector<ExpressionPtr>{allocator()};
   }
   // The grammar allows an optional DISTINCT before the argument list (the
   // whole list, not the individual arguments), but we currently don't support
@@ -1999,7 +2056,10 @@ std::vector<Visitor::ExpressionPtr> Visitor::visit(
         ctx, "DISTINCT for the argument lists of an IRI functions is ");
   }
   // Visit the expression of each argument.
-  return visitVector(ctx->expression());
+  auto args = visitVector(ctx->expression());
+  return qlever::vector<ExpressionPtr>(std::make_move_iterator(args.begin()),
+                                       std::make_move_iterator(args.end()),
+                                       allocator());
 }
 
 // ____________________________________________________________________________________
@@ -2328,7 +2388,9 @@ PropertyPath Visitor::visit(Parser::PathAlternativeContext* ctx) {
   if (alternatives.size() == 1) {
     return std::move(alternatives.at(0));
   }
-  return PropertyPath::makeAlternative(std::move(alternatives));
+  return PropertyPath::makeAlternative(PropertyPath::ChildrenVec(
+      std::make_move_iterator(alternatives.begin()),
+      std::make_move_iterator(alternatives.end()), allocator()));
 }
 
 // ____________________________________________________________________________________
@@ -2337,7 +2399,9 @@ PropertyPath Visitor::visit(Parser::PathSequenceContext* ctx) {
   if (sequence.size() == 1) {
     return std::move(sequence.at(0));
   }
-  return PropertyPath::makeSequence(std::move(sequence));
+  return PropertyPath::makeSequence(PropertyPath::ChildrenVec(
+      std::make_move_iterator(sequence.begin()),
+      std::make_move_iterator(sequence.end()), allocator()));
 }
 
 // ____________________________________________________________________________________
@@ -2356,7 +2420,7 @@ PropertyPath Visitor::visit(Parser::PathEltOrInverseContext* ctx) {
   PropertyPath p = visit(ctx->pathElt());
 
   if (ctx->negationOperator) {
-    p = PropertyPath::makeInverse(std::move(p));
+    p = PropertyPath::makeInverse(std::move(p), allocator());
   }
 
   return p;
@@ -2428,7 +2492,10 @@ PropertyPath Visitor::visit(Parser::PathPrimaryContext* ctx) {
 
 // ____________________________________________________________________________________
 PropertyPath Visitor::visit(Parser::PathNegatedPropertySetContext* ctx) {
-  return PropertyPath::makeNegated(visitVector(ctx->pathOneInPropertySet()));
+  auto children = visitVector(ctx->pathOneInPropertySet());
+  return PropertyPath::makeNegated(PropertyPath::ChildrenVec(
+      std::make_move_iterator(children.begin()),
+      std::make_move_iterator(children.end()), allocator()));
 }
 
 // ____________________________________________________________________________________
@@ -2443,7 +2510,7 @@ PropertyPath Visitor::visit(Parser::PathOneInPropertySetContext* ctx) {
   }();
   auto propertyPath = PropertyPath::fromIri(std::move(iri));
   if (ql::starts_with(text, "^")) {
-    return PropertyPath::makeInverse(propertyPath);
+    return PropertyPath::makeInverse(propertyPath, allocator());
   }
   return propertyPath;
 }

--- a/src/parser/sparqlParser/SparqlQleverVisitor.h
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.h
@@ -17,7 +17,10 @@
 #include "engine/sparqlExpressions/StdevExpression.h"
 #include "parser/data/GraphRef.h"
 #include "parser/sparqlParser/DatasetClause.h"
+#include "util/Allocator.h"
+#include "util/AllocatorTypes.h"
 #include "util/HashSet.h"
+#include "util/MemorySize/MemorySize.h"
 #include "util/ParsedUri.h"
 #undef EOF
 #include "parser/Quads.h"
@@ -51,7 +54,7 @@ class SparqlQleverVisitor {
   using PredicateObjectPairsAndTriples =
       ad_utility::sparql_types::PredicateObjectPairsAndTriples;
   using OperationsAndFilters =
-      std::pair<std::vector<GraphPatternOperation>, std::vector<SparqlFilter>>;
+      std::pair<std::vector<GraphPatternOperation>, qlever::vector<SparqlFilter>>;
   using OperationOrFilterAndMaybeTriples =
       std::pair<std::variant<GraphPatternOperation, SparqlFilter>,
                 std::optional<parsedQuery::BasicGraphPattern>>;
@@ -59,7 +62,7 @@ class SparqlQleverVisitor {
   using SubQueryAndMaybeValues =
       std::pair<parsedQuery::Subquery, std::optional<parsedQuery::Values>>;
   using PatternAndVisibleVariables =
-      std::pair<ParsedQuery::GraphPattern, std::vector<Variable>>;
+      std::pair<ParsedQuery::GraphPattern, qlever::vector<Variable>>;
   using SparqlExpressionPimpl = sparqlExpression::SparqlExpressionPimpl;
   using PrefixMap = ad_utility::HashMap<std::string, std::string>;
   using Parser = SparqlAutomaticParser;
@@ -79,6 +82,14 @@ class SparqlQleverVisitor {
   // Needed to efficiently encode common IRIs directly into the ID.
   const EncodedIriManager* encodedIriManager_;
 
+  // The allocator that dynamic allocations performed while parsing should be
+  // routed through. Defaults to an unlimited allocator (backed by the
+  // configured `qlever::Allocator<T>`/`ql::pmr::memory_resource` backend) when
+  // the caller does not have a "real", query-execution-bound allocator
+  // available yet (e.g. when parsing happens before a `QueryExecutionContext`
+  // has been created).
+  qlever::Allocator<Id> allocator_;
+
   // Convert a GraphTerm to TripleComponent with IRI encoding support
   TripleComponent graphTermToTripleComponentWithEncoding(
       const GraphTerm& graphTerm) const;
@@ -91,7 +102,7 @@ class SparqlQleverVisitor {
   // The visible variables in the order in which they are encountered in the
   // query. This may contain duplicates. A variable is added via
   // `addVisibleVariable`.
-  std::vector<Variable> visibleVariables_{};
+  qlever::vector<Variable> visibleVariables_;
 
   // The `FROM` and `FROM NAMED` clauses of the query that is currently
   // being parsed. Those are inherited by certain constructs, which are
@@ -109,7 +120,7 @@ class SparqlQleverVisitor {
   // graph pattern together with the variables that are visible in it.
   struct NamedSubquery {
     ParsedQuery::GraphPattern pattern_;
-    std::vector<Variable> visibleVariables_;
+    qlever::vector<Variable> visibleVariables_;
   };
 
   // The named subqueries that have been defined so far, by name (including
@@ -190,22 +201,34 @@ class SparqlQleverVisitor {
   // If `datasetOverride` contains datasets, then the datasets in
   // the operation itself are ignored. This is used for the datasets from the
   // url parameters which override those in the operation.
+  //
+  // `allocator` is the allocator that dynamic allocations performed while
+  // parsing should be routed through (see `allocator_` above). Callers with
+  // no query-execution-bound allocator available at parse time must pass an
+  // explicit `qlever::makeUnlimitedAllocator<Id>()`.
   explicit SparqlQleverVisitor(
       ad_utility::BlankNodeManager* bnodeManager,
       const EncodedIriManager* encodedIriManager, PrefixMap prefixMap,
       std::optional<ParsedQuery::DatasetClauses> datasetOverride,
-      DisableSomeChecksOnlyForTesting disableSomeChecksOnlyForTesting =
-          DisableSomeChecksOnlyForTesting::False)
+      DisableSomeChecksOnlyForTesting disableSomeChecksOnlyForTesting,
+      qlever::Allocator<Id> allocator)
       : blankNodeManager_{bnodeManager},
         encodedIriManager_{encodedIriManager},
+        allocator_{std::move(allocator)},
+        visibleVariables_{allocator_},
         prefixMap_{std::move(prefixMap)},
-        disableSomeChecksOnlyForTesting_{disableSomeChecksOnlyForTesting} {
+        disableSomeChecksOnlyForTesting_{disableSomeChecksOnlyForTesting},
+        parsedQuery_{allocator_} {
     if (datasetOverride.has_value()) {
       activeDatasetClauses_ = std::move(*datasetOverride);
       datasetsAreFixed_ = true;
     }
     AD_CORRECTNESS_CHECK(blankNodeManager_ != nullptr);
   }
+
+  // The allocator that dynamic allocations performed while parsing should be
+  // routed through, see `allocator_` above.
+  const qlever::Allocator<Id>& allocator() const { return allocator_; }
 
   const PrefixMap& prefixMap() const { return prefixMap_; }
   void setPrefixMapManually(PrefixMap map) { prefixMap_ = std::move(map); }
@@ -311,9 +334,9 @@ class SparqlQleverVisitor {
 
   std::optional<parsedQuery::Values> visit(Parser::ValuesClauseContext* ctx);
 
-  std::vector<ParsedQuery> visit(Parser::UpdateContext* ctx);
+  qlever::vector<ParsedQuery> visit(Parser::UpdateContext* ctx);
 
-  std::vector<ParsedQuery> visit(Parser::Update1Context* ctx);
+  qlever::vector<ParsedQuery> visit(Parser::Update1Context* ctx);
 
   ParsedQuery visit(Parser::LoadContext* ctx);
 
@@ -321,15 +344,15 @@ class SparqlQleverVisitor {
 
   ParsedQuery visit(Parser::DropContext* ctx);
 
-  static std::vector<ParsedQuery> visit(const Parser::CreateContext* ctx);
+  qlever::vector<ParsedQuery> visit(const Parser::CreateContext* ctx);
 
   // Although only 0 or 1 ParsedQuery are ever returned, the vector makes the
   // interface much simpler.
-  std::vector<ParsedQuery> visit(Parser::AddContext* ctx);
+  qlever::vector<ParsedQuery> visit(Parser::AddContext* ctx);
 
-  std::vector<ParsedQuery> visit(Parser::MoveContext* ctx);
+  qlever::vector<ParsedQuery> visit(Parser::MoveContext* ctx);
 
-  std::vector<ParsedQuery> visit(Parser::CopyContext* ctx);
+  qlever::vector<ParsedQuery> visit(Parser::CopyContext* ctx);
 
   updateClause::GraphUpdate visit(Parser::InsertDataContext* ctx);
 
@@ -409,7 +432,7 @@ class SparqlQleverVisitor {
 
   parsedQuery::SparqlValues visit(Parser::InlineDataFullContext* ctx);
 
-  std::vector<TripleComponent> visit(Parser::DataBlockSingleContext* ctx);
+  qlever::vector<TripleComponent> visit(Parser::DataBlockSingleContext* ctx);
 
   TripleComponent visit(Parser::DataBlockValueContext* ctx);
 
@@ -423,7 +446,7 @@ class SparqlQleverVisitor {
 
   ExpressionPtr visit(Parser::FunctionCallContext* ctx);
 
-  std::vector<ExpressionPtr> visit(Parser::ArgListContext* ctx);
+  qlever::vector<ExpressionPtr> visit(Parser::ArgListContext* ctx);
 
   std::vector<ExpressionPtr> visit(Parser::ExpressionListContext* ctx);
 
@@ -646,7 +669,7 @@ class SparqlQleverVisitor {
   struct FreshQueryContextResult {
     Result result_;
     ParsedQuery parsedQuery_;
-    std::vector<Variable> visibleVariables_;
+    qlever::vector<Variable> visibleVariables_;
   };
 
   // Visit the given context with a fresh (initially empty) `parsedQuery_`,
@@ -686,7 +709,7 @@ class SparqlQleverVisitor {
   // Process an IRI function call. This is used in both `visitFunctionCall` and
   // `visitIriOrFunction`.
   static ExpressionPtr processIriFunctionCall(
-      const TripleComponent::Iri& iri, std::vector<ExpressionPtr> argList,
+      const TripleComponent::Iri& iri, qlever::vector<ExpressionPtr> argList,
       const antlr4::ParserRuleContext*);
 
   void addVisibleVariable(Variable var);
@@ -791,7 +814,12 @@ class SparqlQleverVisitor {
   // `datasetsAreFixed_` controls whether the datasets can be modified from
   // inside the query or update. Then returns the currently active datasets.
   const parsedQuery::DatasetClauses& setAndGetDatasetClauses(
-      const std::vector<DatasetClause>& clauses);
+      const qlever::vector<DatasetClause>& clauses);
+
+  // Convert the `std::vector` of dataset clauses produced by `visitVector`
+  // into a `qlever::vector` using the visitor's own allocator.
+  qlever::vector<DatasetClause> toPmrDatasetClauses(
+      std::vector<DatasetClause> clauses) const;
 
   // Construct a `ParsedQuery` that clears the given graph equivalent to
   // `DELETE WHERE { GRAPH graph { ?s ?p ?o } }`.
@@ -805,8 +833,8 @@ class SparqlQleverVisitor {
 
   // Construct `ParsedQuery`s that clear the target graph and then copy all
   // triples from the source graph to the target graph.
-  std::vector<ParsedQuery> makeCopy(const GraphOrDefault& from,
-                                    const GraphOrDefault& to);
+  qlever::vector<ParsedQuery> makeCopy(const GraphOrDefault& from,
+                                      const GraphOrDefault& to);
 
   // Check that there are exactly 2 sub-clauses and returned the result from
   // visiting them.

--- a/src/util/AllocatorTypes.h
+++ b/src/util/AllocatorTypes.h
@@ -1,0 +1,86 @@
+// Copyright 2026 The QLever Authors, in particular:
+//
+// 2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+//
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#ifndef QLEVER_SRC_UTIL_ALLOCATORTYPES_H
+#define QLEVER_SRC_UTIL_ALLOCATORTYPES_H
+
+#include <deque>
+#include <forward_list>
+#include <list>
+#include <map>
+#include <set>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "util/AllocatorPmr.h"
+
+// Short, consistent aliases for standard containers parameterized with
+// QLever's `ql::pmr::memory_resource`-based `ad_utility::PmrAllocator<T>`
+// (see `util/AllocatorPmr.h`). Spelling out
+// `std::vector<T, ad_utility::PmrAllocator<T>>` (etc.) at every use is
+// repetitive and error-prone; prefer these aliases instead.
+namespace qlever {
+
+template <typename T>
+using PmrAllocator = ad_utility::PmrAllocator<T>;
+
+template <typename T>
+using vector = std::vector<T, PmrAllocator<T>>;
+
+template <typename T>
+using deque = std::deque<T, PmrAllocator<T>>;
+
+template <typename T>
+using list = std::list<T, PmrAllocator<T>>;
+
+template <typename T>
+using forward_list = std::forward_list<T, PmrAllocator<T>>;
+
+template <typename T, typename Compare = std::less<T>>
+using set = std::set<T, Compare, PmrAllocator<T>>;
+
+template <typename T, typename Compare = std::less<T>>
+using multiset = std::multiset<T, Compare, PmrAllocator<T>>;
+
+template <typename Key, typename T, typename Compare = std::less<Key>>
+using map = std::map<Key, T, Compare, PmrAllocator<std::pair<const Key, T>>>;
+
+template <typename Key, typename T, typename Compare = std::less<Key>>
+using multimap =
+    std::multimap<Key, T, Compare, PmrAllocator<std::pair<const Key, T>>>;
+
+template <typename T, typename Hash = std::hash<T>,
+          typename KeyEqual = std::equal_to<T>>
+using unordered_set = std::unordered_set<T, Hash, KeyEqual, PmrAllocator<T>>;
+
+template <typename T, typename Hash = std::hash<T>,
+          typename KeyEqual = std::equal_to<T>>
+using unordered_multiset =
+    std::unordered_multiset<T, Hash, KeyEqual, PmrAllocator<T>>;
+
+template <typename Key, typename T, typename Hash = std::hash<Key>,
+          typename KeyEqual = std::equal_to<Key>>
+using unordered_map =
+    std::unordered_map<Key, T, Hash, KeyEqual,
+                       PmrAllocator<std::pair<const Key, T>>>;
+
+template <typename Key, typename T, typename Hash = std::hash<Key>,
+          typename KeyEqual = std::equal_to<Key>>
+using unordered_multimap =
+    std::unordered_multimap<Key, T, Hash, KeyEqual,
+                            PmrAllocator<std::pair<const Key, T>>>;
+
+template <typename CharT, typename Traits = std::char_traits<CharT>>
+using basic_string = std::basic_string<CharT, Traits, PmrAllocator<CharT>>;
+
+using string = basic_string<char>;
+
+}  // namespace qlever
+
+#endif  // QLEVER_SRC_UTIL_ALLOCATORTYPES_H

--- a/src/util/JoinAlgorithms/IndexNestedLoopJoin.h
+++ b/src/util/JoinAlgorithms/IndexNestedLoopJoin.h
@@ -7,6 +7,7 @@
 
 #include <vector>
 
+#include "backports/span.h"
 #include "engine/CallFixedSize.h"
 #include "engine/JoinHelpers.h"
 #include "engine/Result.h"
@@ -240,10 +241,10 @@ class IndexNestedLoopJoin {
   std::shared_ptr<const Result> rightResult_;
 
  public:
-  IndexNestedLoopJoin(std::vector<std::array<ColumnIndex, 2>> joinColumns,
+  IndexNestedLoopJoin(ql::span<const std::array<ColumnIndex, 2>> joinColumns,
                       std::shared_ptr<const Result> leftResult,
                       std::shared_ptr<const Result> rightResult)
-      : joinColumns_{std::move(joinColumns)},
+      : joinColumns_{joinColumns.begin(), joinColumns.end()},
         leftResult_{std::move(leftResult)},
         rightResult_{std::move(rightResult)} {}
 

--- a/src/util/JoinAlgorithms/JoinColumnMapping.h
+++ b/src/util/JoinAlgorithms/JoinColumnMapping.h
@@ -9,6 +9,7 @@
 #include <cstdint>
 #include <vector>
 
+#include "backports/span.h"
 #include "engine/idTable/IdTable.h"
 #include "global/Id.h"
 #include "index/LocalVocab.h"
@@ -71,7 +72,7 @@ class JoinColumnMapping {
   // Construct the mapping from the `joinColumn` (given as pairs of
   // (leftColIndex, rightColIndex)`), and the total number of columns in the
   // left and right input respectively.
-  JoinColumnMapping(const std::vector<std::array<ColumnIndex, 2>>& joinColumns,
+  JoinColumnMapping(ql::span<const std::array<ColumnIndex, 2>> joinColumns,
                     size_t numColsLeft, size_t numColsRight,
                     bool keepJoinColumns = true) {
     permutationResult_.resize(numColsLeft + numColsRight - joinColumns.size());

--- a/test/ExecuteUpdateTest.cpp
+++ b/test/ExecuteUpdateTest.cpp
@@ -48,7 +48,8 @@ TEST(ExecuteUpdate, executeUpdate) {
             std::make_shared<ad_utility::CancellationHandle<>>();
         const std::vector<DatasetClause> datasets = {};
         ad_utility::BlankNodeManager bnm;
-        auto pqs = SparqlParser::parseUpdate(&bnm, encodedIriManager(), update);
+        auto pqs = SparqlParser::parseUpdate(&bnm, encodedIriManager(), update,
+                                             {}, qec.getAllocator());
         index.deltaTriplesManager().modify<void>(
             [&index, &sharedHandle, &pqs, &qec](DeltaTriples& deltaTriples) {
               qec.setLocatedTriplesForEvaluation(
@@ -77,7 +78,7 @@ TEST(ExecuteUpdate, executeUpdate) {
         QueryResultCache cache = QueryResultCache();
         NamedResultCache namedResultCache;
         auto materializedViewsManager =
-            std::make_shared<MaterializedViewsManager>();
+            std::make_shared<MaterializedViewsManager>(ad_utility::testing::makeAllocator());
         QueryExecutionContext qec(index, &cache,
                                   ad_utility::testing::makeAllocator(
                                       ad_utility::MemorySize::megabytes(100)),
@@ -99,7 +100,7 @@ TEST(ExecuteUpdate, executeUpdate) {
         QueryResultCache cache = QueryResultCache();
         NamedResultCache namedResultCache;
         auto materializedViewsManager =
-            std::make_shared<MaterializedViewsManager>();
+            std::make_shared<MaterializedViewsManager>(ad_utility::testing::makeAllocator());
         QueryExecutionContext qec(index, &cache,
                                   ad_utility::testing::makeAllocator(
                                       ad_utility::MemorySize::megabytes(100)),
@@ -236,7 +237,8 @@ TEST(ExecuteUpdate, computeGraphUpdateQuads) {
     auto& index = qec->getIndex();
     DeltaTriples deltaTriples{index};
     ad_utility::BlankNodeManager bnm;
-    auto pqs = SparqlParser::parseUpdate(&bnm, encodedIriManager(), update);
+    auto pqs = SparqlParser::parseUpdate(&bnm, encodedIriManager(), update, {},
+                                         qec->getAllocator());
     std::vector<std::pair<ExecuteUpdate::IdTriplesAndLocalVocab,
                           ExecuteUpdate::IdTriplesAndLocalVocab>>
         results;

--- a/test/ExportQueryExecutionTreesTest.cpp
+++ b/test/ExportQueryExecutionTreesTest.cpp
@@ -2015,8 +2015,8 @@ TEST(ExportQueryExecutionTrees, EncodedIriManagerUsage) {
   auto qec = ad_utility::testing::getQec(std::move(config));
 
   // Parse query with the same EncodedIriManager
-  auto parsedQuery =
-      SparqlParser::parseQuery(encodedIriManager.get(), query, {});
+  auto parsedQuery = SparqlParser::parseQuery(encodedIriManager.get(), query,
+                                              {}, qec->getAllocator());
 
   auto cancellationHandle =
       std::make_shared<ad_utility::CancellationHandle<>>();

--- a/test/ExternalValuesQueryTest.cpp
+++ b/test/ExternalValuesQueryTest.cpp
@@ -13,6 +13,7 @@
 #include "parser/ExternalValuesQuery.h"
 #include "parser/MagicServiceIriConstants.h"
 #include "parser/SparqlTriple.h"
+#include "util/AllocatorTestHelpers.h"
 #include "util/GTestHelpers.h"
 
 namespace {
@@ -46,7 +47,7 @@ static SparqlTriple varTriple(TripleComponent object) {
 
 struct ExternalValuesQueryTest : public ::testing::Test {
  protected:
-  ExternalValuesQuery query;
+  ExternalValuesQuery query{ad_utility::testing::makeAllocator()};
   SparqlTriple defaultIdTriple = idTriple(lit("myId"));
   SparqlTriple defaultVarTriple = varTriple(V{"?x"});
 };
@@ -102,7 +103,7 @@ TEST_F(ExternalValuesQueryTest, addParameterVariableNonVariable) {
 
 // Test addParameter with unknown predicate throws.
 TEST(ExternalValuesQuery, addParameterUnknownPredicate) {
-  ExternalValuesQuery query;
+  ExternalValuesQuery query{ad_utility::testing::makeAllocator()};
   auto triple = makeTriple("<unknown>", Variable{"?x"});
   AD_EXPECT_THROW_WITH_MESSAGE(query.addParameter(triple),
                                HasSubstr("Unknown parameter"));
@@ -132,15 +133,20 @@ TEST_F(ExternalValuesQueryTest, validateMissingVariables) {
 
 // Test the (deprecated) specification of the name via the IRI directly.
 TEST_F(ExternalValuesQueryTest, deprecatedNameSpecification) {
-  query = ExternalValuesQuery{iri(EXTERNAL_VALUES_IRI)};
+  query = ExternalValuesQuery{iri(EXTERNAL_VALUES_IRI),
+                              ad_utility::testing::makeAllocator()};
   EXPECT_TRUE(query.name_.empty());
-  AD_EXPECT_THROW_WITH_MESSAGE(ExternalValuesQuery(iri("<invalidServiceIri>")),
-                               ::testing::HasSubstr("unexpected SERVICE IRI"));
   AD_EXPECT_THROW_WITH_MESSAGE(
-      ExternalValuesQuery(iri(absl::StrCat(EXTERNAL_VALUES_IRI_PREFIX, ">"))),
+      ExternalValuesQuery(iri("<invalidServiceIri>"),
+                          ad_utility::testing::makeAllocator()),
+      ::testing::HasSubstr("unexpected SERVICE IRI"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      ExternalValuesQuery(iri(absl::StrCat(EXTERNAL_VALUES_IRI_PREFIX, ">")),
+                          ad_utility::testing::makeAllocator()),
       ::testing::HasSubstr("must not be empty"));
   ExternalValuesQuery query2(
-      iri(absl::StrCat(EXTERNAL_VALUES_IRI_PREFIX, "blubb>")));
+      iri(absl::StrCat(EXTERNAL_VALUES_IRI_PREFIX, "blubb>")),
+      ad_utility::testing::makeAllocator());
   EXPECT_EQ(query2.name_, "blubb");
 }
 }  // namespace

--- a/test/ExternalValuesTest.cpp
+++ b/test/ExternalValuesTest.cpp
@@ -20,6 +20,7 @@
 #include "engine/idTable/IdTable.h"
 #include "util/IndexTestHelpers.h"
 #include "util/OperationTestHelpers.h"
+#include "util/ParsedQueryTestHelpers.h"
 
 using TC = TripleComponent;
 using ValuesComponents = std::vector<std::vector<TripleComponent>>;
@@ -34,7 +35,9 @@ TEST(ExternalValues, basicMethods) {
   ValuesComponents values{
       {TC{1}, TC{2}, TC{3}}, {TC{5}, TC{2}, TC{3}}, {TC{7}, TC{42}, TC{3}}};
   ExternalValues externalValuesOp(
-      testQec, {{Variable{"?x"}, Variable{"?y"}, Variable{"?z"}}, values},
+      testQec,
+      ad_utility::testing::makeSparqlValues(
+          {Variable{"?x"}, Variable{"?y"}, Variable{"?z"}}, values),
       "test-id");
 
   // Check name.
@@ -62,8 +65,9 @@ TEST(ExternalValues, basicMethods) {
 TEST(ExternalValues, isDeterministic) {
   QueryExecutionContext* testQec = ad_utility::testing::getQec();
   ValuesComponents values{{TC{1}}, {TC{2}}};
-  ExternalValues externalValuesOp(testQec, {{Variable{"?x"}}, values},
-                                  "det-id");
+  ExternalValues externalValuesOp(
+      testQec, ad_utility::testing::makeSparqlValues({Variable{"?x"}}, values),
+      "det-id");
   EXPECT_FALSE(externalValuesOp.isDeterministic());
 }
 
@@ -72,7 +76,10 @@ TEST(ExternalValues, knownEmptyResultWithEmptyValues) {
   auto testQec = ad_utility::testing::getQec();
   ValuesComponents emptyValues{};
   ExternalValues externalValuesOp(
-      testQec, {{Variable{"?x"}, Variable{"?y"}}, emptyValues}, "empty-id");
+      testQec,
+      ad_utility::testing::makeSparqlValues(
+          {Variable{"?x"}, Variable{"?y"}}, emptyValues),
+      "empty-id");
 
   // Should return false even though values are empty.
   EXPECT_FALSE(externalValuesOp.knownEmptyResult());
@@ -89,7 +96,10 @@ TEST(ExternalValues, computeResult) {
   ValuesComponents values{{TC{12}, TC{iri("<x>")}},
                           {TC::UNDEF{}, TC{iri("<y>")}}};
   ExternalValues valuesOperation(
-      testQec, {{Variable{"?x"}, Variable{"?y"}}, values}, "result-test");
+      testQec,
+      ad_utility::testing::makeSparqlValues(
+          {Variable{"?x"}, Variable{"?y"}}, values),
+      "result-test");
 
   auto result = valuesOperation.getResult();
   const auto& table = result->idTableView();
@@ -115,7 +125,9 @@ TEST(ExternalValues, updateValues) {
     }
     ValuesComponents initialValues{{TC{1}, TC{2}}, {TC{3}, TC{4}}};
     ExternalValues externalValuesOp(
-        testQec, {{Variable{"?x"}, Variable{"?y"}}, initialValues},
+        testQec,
+        ad_utility::testing::makeSparqlValues(
+            {Variable{"?x"}, Variable{"?y"}}, initialValues),
         "update-test");
 
     // Check initial size.
@@ -124,8 +136,9 @@ TEST(ExternalValues, updateValues) {
     // Update with new values (same variables).
     ValuesComponents newValues{
         {TC{10}, TC{20}}, {TC{30}, TC{40}}, {TC{50}, TC{60}}};
-    parsedQuery::SparqlValues updatedSparqlValues{
-        {Variable{"?x"}, Variable{"?y"}}, newValues};
+    parsedQuery::SparqlValues updatedSparqlValues =
+        ad_utility::testing::makeSparqlValues(
+            {Variable{"?x"}, Variable{"?y"}}, newValues);
 
     externalValuesOp.updateValues(std::move(updatedSparqlValues));
 
@@ -151,13 +164,16 @@ TEST(ExternalValues, updateValuesFailsWithDifferentVariables) {
   auto testQec = ad_utility::testing::getQec();
   ValuesComponents initialValues{{TC{1}, TC{2}}};
   ExternalValues externalValuesOp(
-      testQec, {{Variable{"?x"}, Variable{"?y"}}, initialValues},
+      testQec,
+      ad_utility::testing::makeSparqlValues(
+          {Variable{"?x"}, Variable{"?y"}}, initialValues),
       "mismatch-test");
 
   // Try to update with different variables - should fail.
   ValuesComponents newValues{{TC{10}, TC{20}, TC{30}}};
-  parsedQuery::SparqlValues wrongSparqlValues{
-      {Variable{"?x"}, Variable{"?y"}, Variable{"?z"}}, newValues};
+  parsedQuery::SparqlValues wrongSparqlValues =
+      ad_utility::testing::makeSparqlValues(
+          {Variable{"?x"}, Variable{"?y"}, Variable{"?z"}}, newValues);
 
   EXPECT_ANY_THROW(externalValuesOp.updateValues(std::move(wrongSparqlValues)));
 }
@@ -167,12 +183,16 @@ TEST(ExternalValues, updateValuesFailsWithDifferentOrder) {
   auto testQec = ad_utility::testing::getQec();
   ValuesComponents initialValues{{TC{1}, TC{2}}};
   ExternalValues externalValuesOp(
-      testQec, {{Variable{"?x"}, Variable{"?y"}}, initialValues}, "order-test");
+      testQec,
+      ad_utility::testing::makeSparqlValues(
+          {Variable{"?x"}, Variable{"?y"}}, initialValues),
+      "order-test");
 
   // Try to update with variables in different order - should fail.
   ValuesComponents newValues{{TC{10}, TC{20}}};
-  parsedQuery::SparqlValues wrongOrderSparqlValues{
-      {Variable{"?y"}, Variable{"?x"}}, newValues};
+  parsedQuery::SparqlValues wrongOrderSparqlValues =
+      ad_utility::testing::makeSparqlValues(
+          {Variable{"?y"}, Variable{"?x"}}, newValues);
 
   EXPECT_ANY_THROW(
       externalValuesOp.updateValues(std::move(wrongOrderSparqlValues)));
@@ -188,7 +208,10 @@ TEST(ExternalValues, clone) {
   ValuesComponents values{{TC{12}, TC{iri("<x>")}},
                           {TC::UNDEF{}, TC{iri("<y>")}}};
   ExternalValues valuesOperation(
-      testQec, {{Variable{"?x"}, Variable{"?y"}}, values}, "clone-test");
+      testQec,
+      ad_utility::testing::makeSparqlValues(
+          {Variable{"?x"}, Variable{"?y"}}, values),
+      "clone-test");
 
   auto clone = valuesOperation.clone();
   ASSERT_TRUE(clone);
@@ -206,7 +229,10 @@ TEST(ExternalValues, getExternalValues) {
   auto testQec = ad_utility::testing::getQec();
   ValuesComponents values{{TC{1}, TC{2}}};
   ExternalValues externalValuesOp(
-      testQec, {{Variable{"?x"}, Variable{"?y"}}, values}, "collect-test");
+      testQec,
+      ad_utility::testing::makeSparqlValues(
+          {Variable{"?x"}, Variable{"?y"}}, values),
+      "collect-test");
 
   std::vector<ExternalValues*> collected;
   externalValuesOp.getExternalValues(collected);

--- a/test/GraphStoreProtocolTest.cpp
+++ b/test/GraphStoreProtocolTest.cpp
@@ -126,12 +126,14 @@ TEST(GraphStoreProtocolTest, transformPostAndTsop) {
   auto index = ad_utility::testing::makeTestIndex(TestIndexConfig{});
   runTests(
       [&index](http::request<http::string_body> request, GraphOrDefault graph) {
-        return GraphStoreProtocol::transformPost(request, graph, index);
+        return GraphStoreProtocol::transformPost(request, graph, index,
+                                                 ad_utility::testing::makeAllocator());
       },
       true);
   runTests(
       [&index](http::request<http::string_body> request, GraphOrDefault graph) {
-        return GraphStoreProtocol::transformTsop(request, graph, index);
+        return GraphStoreProtocol::transformTsop(request, graph, index,
+                                                 ad_utility::testing::makeAllocator());
       },
       false);
 }
@@ -144,7 +146,8 @@ TEST(GraphStoreProtocolTest, transformGet) {
          ad_utility::source_location l = AD_CURRENT_SOURCE_LOC()) {
         auto trace = generateLocationTrace(l);
         EXPECT_THAT(
-            GraphStoreProtocol::transformGet(graph, encodedIriManager()),
+            GraphStoreProtocol::transformGet(graph, encodedIriManager(),
+                                             ad_utility::testing::makeAllocator()),
             matcher);
       };
   expectTransformGet(
@@ -165,7 +168,8 @@ TEST(GraphStoreProtocolTest, transformPut) {
       ad_utility::source_location l = AD_CURRENT_SOURCE_LOC())(
       requires ad_utility::httpUtils::HttpRequest<RequestT>) {
     auto trace = generateLocationTrace(l);
-    EXPECT_THAT(GraphStoreProtocol::transformPut(request, graph, index),
+    EXPECT_THAT(GraphStoreProtocol::transformPut(
+                    request, graph, index, ad_utility::testing::makeAllocator()),
                 testing::ElementsAre(testing::AllOf(dropMatcher, HasMiddleware),
                                      insertMatcher));
   };
@@ -191,13 +195,13 @@ TEST(GraphStoreProtocolTest, transformPut) {
   AD_EXPECT_THROW_WITH_MESSAGE(
       GraphStoreProtocol::transformPut(
           ad_utility::testing::makeRequest(http::verb::put, "/?default"),
-          DEFAULT{}, index),
+          DEFAULT{}, index, ad_utility::testing::makeAllocator()),
       testing::HasSubstr("Mediatype empty or not set."));
   AD_EXPECT_THROW_WITH_MESSAGE(
       GraphStoreProtocol::transformPut(
           ad_utility::testing::makePostRequest(
               "/?default", "application/sparql-results+xml", ""),
-          DEFAULT{}, index),
+          DEFAULT{}, index, ad_utility::testing::makeAllocator()),
       testing::HasSubstr(
           "Mediatype \"application/sparql-results+xml\" is not supported for "
           "SPARQL Graph Store HTTP Protocol in QLever."));
@@ -208,7 +212,7 @@ TEST(GraphStoreProtocolTest, transformPut) {
       GraphStoreProtocol::transformPut(
           ad_utility::testing::makePostRequest(
               "/?default", "application/n-quads", "<a> <b> <c> <d> ."),
-          DEFAULT{}, index),
+          DEFAULT{}, index, ad_utility::testing::makeAllocator()),
       testing::HasSubstr(
           "Mediatype \"application/n-quads\" is not supported for "
           "SPARQL Graph Store HTTP Protocol in QLever."));
@@ -217,7 +221,7 @@ TEST(GraphStoreProtocolTest, transformPut) {
           ad_utility::testing::makePostRequest(
               "/?default", "application/this-media-type-does-not-exist",
               "fantasy"),
-          DEFAULT{}, index),
+          DEFAULT{}, index, ad_utility::testing::makeAllocator()),
       testing::HasSubstr(
           "Not a single media type known to this parser was "
           "detected in \"application/this-media-type-does-not-exist\"."));
@@ -225,7 +229,7 @@ TEST(GraphStoreProtocolTest, transformPut) {
       GraphStoreProtocol::transformPut(
           ad_utility::testing::makePostRequest(
               "/?default", "application/unknown", "fantasy"),
-          DEFAULT{}, index),
+          DEFAULT{}, index, ad_utility::testing::makeAllocator()),
       testing::HasSubstr("Not a single media type known to this parser was "
                          "detected in \"application/unknown\"."));
 }
@@ -238,7 +242,9 @@ TEST(GraphStoreProtocolTest, transformDelete) {
                const testing::Matcher<const ParsedQuery&>& matcher,
                ad_utility::source_location l = AD_CURRENT_SOURCE_LOC()) {
         auto trace = generateLocationTrace(l);
-        EXPECT_THAT(GraphStoreProtocol::transformDelete(graph, index), matcher);
+        EXPECT_THAT(GraphStoreProtocol::transformDelete(
+                        graph, index, ad_utility::testing::makeAllocator()),
+                    matcher);
       };
   expectTransformDelete(DEFAULT{}, ClearGraph(iri(DEFAULT_GRAPH_IRI)));
   expectTransformDelete(iri("<foo>"), ClearGraph(iri("<foo>")));
@@ -247,9 +253,11 @@ TEST(GraphStoreProtocolTest, transformDelete) {
 // _____________________________________________________________________________________________
 TEST(GraphStoreProtocolTest, transformGraphStoreProtocol) {
   auto index = ad_utility::testing::makeTestIndex(TestIndexConfig{});
+  auto allocator = ad_utility::testing::makeAllocator();
   EXPECT_THAT(GraphStoreProtocol::transformGraphStoreProtocol(
                   GraphStoreOperation{DEFAULT{}},
-                  ad_utility::testing::makeGetRequest("/?default"), index),
+                  ad_utility::testing::makeGetRequest("/?default"), index,
+                  allocator),
               testing::ElementsAre(m::ConstructQuery(
                   {{Var{"?s"}, Var{"?p"}, Var{"?o"}}},
                   m::GraphPattern(matchers::Triples({SparqlTriple(
@@ -259,7 +267,7 @@ TEST(GraphStoreProtocolTest, transformGraphStoreProtocol) {
           GraphStoreOperation{DEFAULT{}},
           ad_utility::testing::makePostRequest(
               "/?default", "application/n-triples", "<foo> <bar> <baz> ."),
-          index),
+          index, allocator),
       testing::ElementsAre(m::UpdateClause(
           m::GraphUpdate({}, {{iri("<foo>"), iri("<bar>"), iri("<baz>"),
                                std::monostate{}}}),
@@ -270,7 +278,7 @@ TEST(GraphStoreProtocolTest, transformGraphStoreProtocol) {
                       "TSOP", "/?default",
                       {{http::field::content_type, "application/n-triples"}},
                       "<foo> <bar> <baz> ."),
-                  index),
+                  index, allocator),
               testing::ElementsAre(m::UpdateClause(
                   m::GraphUpdate({{iri("<foo>"), iri("<bar>"), iri("<baz>"),
                                    std::monostate{}}},
@@ -280,7 +288,7 @@ TEST(GraphStoreProtocolTest, transformGraphStoreProtocol) {
       GraphStoreProtocol::transformGraphStoreProtocol(
           GraphStoreOperation{iri("<foo>")},
           ad_utility::testing::makeRequest(http::verb::delete_, "/?graph=foo"),
-          index),
+          index, allocator),
       testing::ElementsAre(ClearGraph(iri("<foo>"))));
   EXPECT_THAT(
       GraphStoreProtocol::transformGraphStoreProtocol(
@@ -288,7 +296,7 @@ TEST(GraphStoreProtocolTest, transformGraphStoreProtocol) {
           ad_utility::testing::makeRequest(
               http::verb::put, "/?graph=foo",
               {{http::field::content_type, "text/turtle"}}, "<a> <b> <c>"),
-          index),
+          index, allocator),
       testing::ElementsAre(
           ClearGraph(iri("<foo>")),
           m::UpdateClause(m::GraphUpdate({}, {{iri("<a>"), iri("<b>"),
@@ -298,17 +306,19 @@ TEST(GraphStoreProtocolTest, transformGraphStoreProtocol) {
                   GraphStoreOperation{iri("<foo>")},
                   ad_utility::testing::makeRequest(http::verb::head,
                                                    "/?graph=foo", {}, ""),
-                  index),
+                  index, allocator),
               testing::ElementsAre(
                   testing::AllOf(GetGraph(iri("<foo>")), HasMiddleware)));
-  auto expectUnsupportedMethod = [&index](const http::verb method,
-                                          ad_utility::source_location l =
-                                              AD_CURRENT_SOURCE_LOC()) {
+  auto expectUnsupportedMethod = [&index, &allocator](
+                                     const http::verb method,
+                                     ad_utility::source_location l =
+                                         AD_CURRENT_SOURCE_LOC()) {
     auto trace = generateLocationTrace(l);
     AD_EXPECT_THROW_WITH_MESSAGE(
         GraphStoreProtocol::transformGraphStoreProtocol(
             GraphStoreOperation{DEFAULT{}},
-            ad_utility::testing::makeRequest(method, "/?default"), index),
+            ad_utility::testing::makeRequest(method, "/?default"), index,
+            allocator),
         testing::HasSubstr(
             absl::StrCat(std::string{boost::beast::http::to_string(method)},
                          " in the SPARQL Graph Store HTTP Protocol")));
@@ -319,12 +329,13 @@ TEST(GraphStoreProtocolTest, transformGraphStoreProtocol) {
           GraphStoreOperation{DEFAULT{}},
           ad_utility::testing::makeRequest(boost::beast::http::verb::connect,
                                            "/?default"),
-          index),
+          index, allocator),
       testing::HasSubstr("Unsupported HTTP method \"CONNECT\""));
   AD_EXPECT_THROW_WITH_MESSAGE(
       GraphStoreProtocol::transformGraphStoreProtocol(
           GraphStoreOperation{DEFAULT{}},
-          ad_utility::testing::makeRequest("PUMPKIN", "/?default"), index),
+          ad_utility::testing::makeRequest("PUMPKIN", "/?default"), index,
+          allocator),
       testing::HasSubstr("Unsupported HTTP method \"PUMPKIN\""));
 }
 
@@ -465,7 +476,8 @@ TEST(GraphStoreProtocolTest, EncodedIriManagerUsage) {
       ad_utility::source_location l = AD_CURRENT_SOURCE_LOC())(
       requires ad_utility::httpUtils::HttpRequest<RequestT>) {
     auto trace = generateLocationTrace(l);
-    EXPECT_THAT(GraphStoreProtocol::transformPost(request, graph, index),
+    EXPECT_THAT(GraphStoreProtocol::transformPost(
+                    request, graph, index, ad_utility::testing::makeAllocator()),
                 matcher);
   };
 
@@ -511,8 +523,8 @@ TEST(GraphStoreProtocolTest, EncodedIriManagerUsage) {
           m::GraphPattern()));
 
   // Test transformGet functionality
-  auto getQuery =
-      GraphStoreProtocol::transformGet(DEFAULT{}, encodedIriManager());
+  auto getQuery = GraphStoreProtocol::transformGet(
+      DEFAULT{}, encodedIriManager(), ad_utility::testing::makeAllocator());
   EXPECT_EQ(getQuery._originalString,
             "CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }");
   EXPECT_TRUE(
@@ -521,8 +533,8 @@ TEST(GraphStoreProtocolTest, EncodedIriManagerUsage) {
   // Test transformGet with specific graph IRI
   auto graphIri =
       ad_utility::triple_component::Iri::fromIriref("<http://example.org/123>");
-  auto graphQuery =
-      GraphStoreProtocol::transformGet(graphIri, encodedIriManager());
+  auto graphQuery = GraphStoreProtocol::transformGet(
+      graphIri, encodedIriManager(), ad_utility::testing::makeAllocator());
   EXPECT_THAT(
       graphQuery._originalString,
       testing::HasSubstr("GRAPH <http://example.org/123> { ?s ?p ?o }"));

--- a/test/GroupByTest.cpp
+++ b/test/GroupByTest.cpp
@@ -8,6 +8,7 @@
 
 #include "./util/GTestHelpers.h"
 #include "./util/IdTableHelpers.h"
+#include "./util/ParsedQueryTestHelpers.h"
 #include "./util/RuntimeParametersTestHelpers.h"
 #include "./util/TripleComponentTestHelpers.h"
 #include "engine/GroupBy.h"
@@ -86,8 +87,8 @@ TEST(GroupBy, getDescriptor) {
       Alias{sparqlExpression::SparqlExpressionPimpl{std::move(expr), "?a"},
             Variable{"?a"}};
 
-  parsedQuery::SparqlValues input;
-  input._variables = {Variable{"?a"}};
+  parsedQuery::SparqlValues input{ad_utility::testing::makeAllocator()};
+  input._variables = toQVec(std::vector{Variable{"?a"}});
   auto* qec = getQec();
   auto values = ad_utility::makeExecutionTree<Values>(qec, input);
 
@@ -103,8 +104,8 @@ TEST(GroupBy, clone) {
       Alias{sparqlExpression::SparqlExpressionPimpl{std::move(expr), "?a"},
             Variable{"?a"}};
 
-  parsedQuery::SparqlValues input;
-  input._variables = {Variable{"?a"}};
+  parsedQuery::SparqlValues input{ad_utility::testing::makeAllocator()};
+  input._variables = toQVec(std::vector{Variable{"?a"}});
   auto* qec = getQec();
   auto values = ad_utility::makeExecutionTree<Values>(qec, input);
 
@@ -383,9 +384,9 @@ TEST_F(GroupByOptimizations, findGroupedVariable) {
       std::make_unique<AvgExpression>(false, makeVariableExpression(varB)));
 
   // Set up the Group By object.
-  parsedQuery::SparqlValues input;
-  input._variables = std::vector{varA, varB};
-  input._values.push_back(std::vector{TC(1.0), TC(3.0)});
+  parsedQuery::SparqlValues input{ad_utility::testing::makeAllocator()};
+  input._variables = toQVec(std::vector{varA, varB});
+  input._values.push_back(toQVec(std::vector{TC(1.0), TC(3.0)}));
   auto values = ad_utility::makeExecutionTree<Values>(
       ad_utility::testing::getQec(), input);
   GroupByImpl groupBy{
@@ -694,16 +695,17 @@ TEST_F(GroupByOptimizations, existsInGroupByAlias) {
 
   auto makeExistsArgument = [](const std::vector<Variable>& variables,
                                const std::vector<std::vector<int64_t>>& rows) {
-    ParsedQuery pq;
-    parsedQuery::Values valuesClause;
-    valuesClause._inlineValues._variables = variables;
+    ParsedQuery pq{ad_utility::testing::makeAllocator()};
+    parsedQuery::Values valuesClause{
+        parsedQuery::SparqlValues{ad_utility::testing::makeAllocator()}};
+    valuesClause._inlineValues._variables = toQVec(variables);
     for (const auto& row : rows) {
       std::vector<TripleComponent> valueRow;
       valueRow.reserve(row.size());
       for (int64_t value : row) {
         valueRow.emplace_back(value);
       }
-      valuesClause._inlineValues._values.push_back(std::move(valueRow));
+      valuesClause._inlineValues._values.push_back(toQVec(std::move(valueRow)));
     }
     pq._rootGraphPattern._graphPatterns.emplace_back(std::move(valuesClause));
     for (const auto& variable : variables) {
@@ -874,7 +876,7 @@ TEST_F(GroupByOptimizations,
       setRuntimeParameterForTest<&RuntimeParameters::groupByHashMapEnabled_>(
           true);
 
-  parsedQuery::SparqlValues input;
+  parsedQuery::SparqlValues input{ad_utility::testing::makeAllocator()};
   using TC = TripleComponent;
 
   // SELECT (?b + AVG(?c) as ?x) (?a AS ?y) WHERE {
@@ -885,10 +887,10 @@ TEST_F(GroupByOptimizations,
   Variable varC = Variable{"?c"};
   Variable varY = Variable{"?y"};
 
-  input._variables = std::vector{varA, varB, varC};
-  input._values.push_back(std::vector{TC(1.0), TC(2.0), TC(3.0)});
-  input._values.push_back(std::vector{TC(1.0), TC(2.0), TC(4.0)});
-  input._values.push_back(std::vector{TC(2.0), TC(2.0), TC(5.0)});
+  input._variables = toQVec(std::vector{varA, varB, varC});
+  input._values.push_back(toQVec(std::vector{TC(1.0), TC(2.0), TC(3.0)}));
+  input._values.push_back(toQVec(std::vector{TC(1.0), TC(2.0), TC(4.0)}));
+  input._values.push_back(toQVec(std::vector{TC(2.0), TC(2.0), TC(5.0)}));
   auto values = ad_utility::makeExecutionTree<Values>(
       ad_utility::testing::getQec(), input);
 
@@ -934,7 +936,7 @@ TEST_F(GroupByOptimizations,
       setRuntimeParameterForTest<&RuntimeParameters::groupByHashMapEnabled_>(
           true);
 
-  parsedQuery::SparqlValues input;
+  parsedQuery::SparqlValues input{ad_utility::testing::makeAllocator()};
   using TC = TripleComponent;
 
   // SELECT (AVG(?c) as ?x) WHERE {
@@ -944,11 +946,11 @@ TEST_F(GroupByOptimizations,
   Variable varB = Variable{"?b"};
   Variable varC = Variable{"?c"};
 
-  input._variables = std::vector{varA, varB, varC};
-  input._values.push_back(std::vector{TC(2.0), TC(2.0), TC(5.0)});
-  input._values.push_back(std::vector{TC(1.0), TC(2.0), TC(3.0)});
-  input._values.push_back(std::vector{TC(1.0), TC(2.0), TC(4.0)});
-  input._values.push_back(std::vector{TC(4.0), TC(1.0), TC(42.0)});
+  input._variables = toQVec(std::vector{varA, varB, varC});
+  input._values.push_back(toQVec(std::vector{TC(2.0), TC(2.0), TC(5.0)}));
+  input._values.push_back(toQVec(std::vector{TC(1.0), TC(2.0), TC(3.0)}));
+  input._values.push_back(toQVec(std::vector{TC(1.0), TC(2.0), TC(4.0)}));
+  input._values.push_back(toQVec(std::vector{TC(4.0), TC(1.0), TC(42.0)}));
 
   auto values = ad_utility::makeExecutionTree<Values>(
       ad_utility::testing::getQec(), input);
@@ -990,7 +992,7 @@ TEST_F(GroupByOptimizations,
       setRuntimeParameterForTest<&RuntimeParameters::groupByHashMapEnabled_>(
           true);
 
-  parsedQuery::SparqlValues input;
+  parsedQuery::SparqlValues input{ad_utility::testing::makeAllocator()};
   using TC = TripleComponent;
 
   // SELECT (AVG(?b) as ?x) WHERE {
@@ -1000,11 +1002,11 @@ TEST_F(GroupByOptimizations,
   Variable varB = Variable{"?b"};
   Variable varC = Variable{"?c"};
 
-  input._variables = std::vector{varA, varB, varC};
-  input._values.push_back(std::vector{TC(2.0), TC(5.0), TC(2.0)});
-  input._values.push_back(std::vector{TC(1.0), TC(3.0), TC(2.0)});
-  input._values.push_back(std::vector{TC(1.0), TC(4.0), TC(2.0)});
-  input._values.push_back(std::vector{TC(4.0), TC(42.0), TC(1.0)});
+  input._variables = toQVec(std::vector{varA, varB, varC});
+  input._values.push_back(toQVec(std::vector{TC(2.0), TC(5.0), TC(2.0)}));
+  input._values.push_back(toQVec(std::vector{TC(1.0), TC(3.0), TC(2.0)}));
+  input._values.push_back(toQVec(std::vector{TC(1.0), TC(4.0), TC(2.0)}));
+  input._values.push_back(toQVec(std::vector{TC(4.0), TC(42.0), TC(1.0)}));
 
   auto values = ad_utility::makeExecutionTree<Values>(
       ad_utility::testing::getQec(), input);
@@ -1045,7 +1047,7 @@ TEST_F(GroupByOptimizations, correctResultForHashMapOptimizationManyVariables) {
       setRuntimeParameterForTest<&RuntimeParameters::groupByHashMapEnabled_>(
           true);
 
-  parsedQuery::SparqlValues input;
+  parsedQuery::SparqlValues input{ad_utility::testing::makeAllocator()};
   using TC = TripleComponent;
 
   // SELECT (AVG(?g) as ?x) WHERE {
@@ -1059,15 +1061,15 @@ TEST_F(GroupByOptimizations, correctResultForHashMapOptimizationManyVariables) {
   Variable varF = Variable{"?f"};
   Variable varG = Variable{"?g"};
 
-  input._variables = std::vector{varA, varB, varC, varD, varE, varF, varG};
-  input._values.push_back(std::vector{TC(2.0), TC(2.0), TC(2.0), TC(2.0),
-                                      TC(2.0), TC(5.0), TC(5.0)});
-  input._values.push_back(std::vector{TC(1.0), TC(2.0), TC(2.0), TC(2.0),
-                                      TC(2.0), TC(5.0), TC(5.0)});
-  input._values.push_back(std::vector{TC(1.0), TC(2.0), TC(2.0), TC(2.0),
-                                      TC(2.0), TC(5.0), TC(3.0)});
-  input._values.push_back(std::vector{TC(4.0), TC(1.0), TC(2.0), TC(2.0),
-                                      TC(2.0), TC(5.0), TC(2.0)});
+  input._variables = toQVec(std::vector{varA, varB, varC, varD, varE, varF, varG});
+  input._values.push_back(toQVec(std::vector{TC(2.0), TC(2.0), TC(2.0), TC(2.0),
+                                      TC(2.0), TC(5.0), TC(5.0)}));
+  input._values.push_back(toQVec(std::vector{TC(1.0), TC(2.0), TC(2.0), TC(2.0),
+                                      TC(2.0), TC(5.0), TC(5.0)}));
+  input._values.push_back(toQVec(std::vector{TC(1.0), TC(2.0), TC(2.0), TC(2.0),
+                                      TC(2.0), TC(5.0), TC(3.0)}));
+  input._values.push_back(toQVec(std::vector{TC(4.0), TC(1.0), TC(2.0), TC(2.0),
+                                      TC(2.0), TC(5.0), TC(2.0)}));
 
   auto values = ad_utility::makeExecutionTree<Values>(
       ad_utility::testing::getQec(), input);
@@ -1117,7 +1119,7 @@ TEST_F(GroupByOptimizations, hashMapOptimizationGroupedVariable) {
       setRuntimeParameterForTest<&RuntimeParameters::groupByHashMapEnabled_>(
           true);
 
-  parsedQuery::SparqlValues input;
+  parsedQuery::SparqlValues input{ad_utility::testing::makeAllocator()};
   using TC = TripleComponent;
 
   // SELECT (?a AS ?x) (?a + COUNT(?b) AS ?y) (?x + AVG(?b) as ?z) WHERE {
@@ -1127,10 +1129,10 @@ TEST_F(GroupByOptimizations, hashMapOptimizationGroupedVariable) {
   Variable varX = Variable{"?x"};
   Variable varB = Variable{"?b"};
 
-  input._variables = std::vector{varA, varB};
-  input._values.push_back(std::vector{TC(1.0), TC(3.0)});
-  input._values.push_back(std::vector{TC(1.0), TC(7.0)});
-  input._values.push_back(std::vector{TC(5.0), TC(4.0)});
+  input._variables = toQVec(std::vector{varA, varB});
+  input._values.push_back(toQVec(std::vector{TC(1.0), TC(3.0)}));
+  input._values.push_back(toQVec(std::vector{TC(1.0), TC(7.0)}));
+  input._values.push_back(toQVec(std::vector{TC(5.0), TC(4.0)}));
   auto values = ad_utility::makeExecutionTree<Values>(
       ad_utility::testing::getQec(), input);
 
@@ -1185,7 +1187,7 @@ TEST_F(GroupByOptimizations, hashMapOptimizationMinMaxSum) {
       setRuntimeParameterForTest<&RuntimeParameters::groupByHashMapEnabled_>(
           true);
 
-  parsedQuery::SparqlValues input;
+  parsedQuery::SparqlValues input{ad_utility::testing::makeAllocator()};
   using TC = TripleComponent;
 
   // SELECT (MIN(?b) as ?x) (MAX(?b) as ?z) (SUM(?b) as ?w) WHERE {
@@ -1197,14 +1199,14 @@ TEST_F(GroupByOptimizations, hashMapOptimizationMinMaxSum) {
   Variable varZ = Variable{"?z"};
   Variable varW = Variable{"?w"};
 
-  input._variables = std::vector{varA, varB};
-  input._values.push_back(std::vector{TC(1.0), TC(42)});
-  input._values.push_back(std::vector{TC(1.0), TC(9.0)});
-  input._values.push_back(std::vector{TC(1.0), TC(3)});
-  input._values.push_back(std::vector{TC(3.0), TC(13.37)});
-  input._values.push_back(std::vector{TC(3.0), TC(1.0)});
-  input._values.push_back(std::vector{TC(3.0), TC(4.0)});
-  input._values.push_back(std::vector<TripleComponent>{TC(4.0), TC::UNDEF{}});
+  input._variables = toQVec(std::vector{varA, varB});
+  input._values.push_back(toQVec(std::vector{TC(1.0), TC(42)}));
+  input._values.push_back(toQVec(std::vector{TC(1.0), TC(9.0)}));
+  input._values.push_back(toQVec(std::vector{TC(1.0), TC(3)}));
+  input._values.push_back(toQVec(std::vector{TC(3.0), TC(13.37)}));
+  input._values.push_back(toQVec(std::vector{TC(3.0), TC(1.0)}));
+  input._values.push_back(toQVec(std::vector{TC(3.0), TC(4.0)}));
+  input._values.push_back(toQVec(std::vector<TripleComponent>{TC(4.0), TC::UNDEF{}}));
   auto qec = ad_utility::testing::getQec();
   auto values = ad_utility::makeExecutionTree<Values>(qec, input);
 
@@ -1390,16 +1392,16 @@ TEST_F(GroupByOptimizations, hashMapOptimizationGroupConcatLocalVocab) {
       setRuntimeParameterForTest<&RuntimeParameters::groupByHashMapEnabled_>(
           true);
 
-  parsedQuery::SparqlValues input;
+  parsedQuery::SparqlValues input{ad_utility::testing::makeAllocator()};
   using TC = TripleComponent;
 
-  input._variables = std::vector{varX, varY};
-  input._values.push_back(std::vector{TC(1.0), TC{lit("B")}});
-  input._values.push_back(std::vector{TC(1.0), TC{lit("A")}});
-  input._values.push_back(std::vector{TC(1.0), TC{lit("C")}});
-  input._values.push_back(std::vector{TC(3.0), TC{lit("g")}});
-  input._values.push_back(std::vector{TC(3.0), TC{lit("h")}});
-  input._values.push_back(std::vector{TC(3.0), TC{lit("f")}});
+  input._variables = toQVec(std::vector{varX, varY});
+  input._values.push_back(toQVec(std::vector{TC(1.0), TC{lit("B")}}));
+  input._values.push_back(toQVec(std::vector{TC(1.0), TC{lit("A")}}));
+  input._values.push_back(toQVec(std::vector{TC(1.0), TC{lit("C")}}));
+  input._values.push_back(toQVec(std::vector{TC(3.0), TC{lit("g")}}));
+  input._values.push_back(toQVec(std::vector{TC(3.0), TC{lit("h")}}));
+  input._values.push_back(toQVec(std::vector{TC(3.0), TC{lit("f")}}));
   auto qec = ad_utility::testing::getQec();
   auto values = ad_utility::makeExecutionTree<Values>(qec, input);
 
@@ -1651,12 +1653,12 @@ TEST_F(GroupByOptimizations, computeGroupByForJoinWithFullScan) {
     Id idOfY = getId("<y>");
     // Set up a `VALUES` clause with three values for `?x`, two of which
     // (`<x>` and `<y>`) actually appear in the test knowledge graph.
-    parsedQuery::SparqlValues sparqlValues;
+    parsedQuery::SparqlValues sparqlValues{ad_utility::testing::makeAllocator()};
     sparqlValues._variables.push_back(varX);
-    sparqlValues._values.emplace_back(std::vector{TripleComponent{iri("<x>")}});
+    sparqlValues._values.emplace_back(toQVec(std::vector{TripleComponent{iri("<x>")}}));
     sparqlValues._values.emplace_back(
-        std::vector{TripleComponent{iri("<xa>")}});
-    sparqlValues._values.emplace_back(std::vector{TripleComponent{iri("<y>")}});
+        toQVec(std::vector{TripleComponent{iri("<xa>")}}));
+    sparqlValues._values.emplace_back(toQVec(std::vector{TripleComponent{iri("<y>")}}));
     auto values = makeExecutionTree<Values>(qec, sparqlValues);
     // Set up a GROUP BY operation for which the optimization can be applied.
     // The last two arguments of the `Join` constructor are the indices of the
@@ -1856,7 +1858,8 @@ TEST_F(GroupByOptimizations,
         Variable{"?x"},
         Variable{"?y"},
         Variable{"?z"},
-        {std::pair<ColumnIndex, Variable>{3, Variable{"?g"}}}};
+        toQVec(std::vector<std::pair<ColumnIndex, Variable>>{
+            {3, Variable{"?g"}}})};
 
     // With graph column this should return 3.
     auto xyzScanNquad = makeExecutionTree<IndexScan>(
@@ -2014,7 +2017,7 @@ struct QecWrapper {
   QueryResultCache cache_{};
   NamedResultCache namedCache_{};
   std::shared_ptr<MaterializedViewsManager> materializedViewsManager_ =
-      std::make_shared<MaterializedViewsManager>();
+      std::make_shared<MaterializedViewsManager>(makeAllocator());
 
   QueryExecutionContext makeQec() {
     return QueryExecutionContext{
@@ -2182,9 +2185,9 @@ TEST(GroupByOptimizationsDeltaTriples, joinWithFullScanCardinalityAfterInsert) {
 
   // Build VALUES (?x) { (<a>) } as the non-full-scan child of the join.
   Variable varX{"?x"};
-  parsedQuery::SparqlValues sparqlValues;
+  parsedQuery::SparqlValues sparqlValues{ad_utility::testing::makeAllocator()};
   sparqlValues._variables.push_back(varX);
-  sparqlValues._values.emplace_back(std::vector{TripleComponent{iri("<a>")}});
+  sparqlValues._values.emplace_back(toQVec(std::vector{TripleComponent{iri("<a>")}}));
   auto values = makeExecutionTree<Values>(&qec, sparqlValues);
 
   // Full scan ?x ?y ?z in SPO order (sorted by subject = ?x).
@@ -2331,7 +2334,7 @@ auto make = [](auto&&... args) -> SparqlExpression::Ptr {
 }  // namespace
 // _____________________________________________________________________________
 TEST(GroupBy, GroupedVariableInExpressions) {
-  parsedQuery::SparqlValues input;
+  parsedQuery::SparqlValues input{ad_utility::testing::makeAllocator()};
   using TC = TripleComponent;
   // Test the following SPARQL query:
   //
@@ -2347,10 +2350,10 @@ TEST(GroupBy, GroupedVariableInExpressions) {
   Variable varA = Variable{"?a"};
   Variable varB = Variable{"?b"};
 
-  input._variables = std::vector{varA, varB};
-  input._values.push_back(std::vector{TC(1.0), TC(3.0)});
-  input._values.push_back(std::vector{TC(1.0), TC(7.0)});
-  input._values.push_back(std::vector{TC(5.0), TC(4.0)});
+  input._variables = toQVec(std::vector{varA, varB});
+  input._values.push_back(toQVec(std::vector{TC(1.0), TC(3.0)}));
+  input._values.push_back(toQVec(std::vector{TC(1.0), TC(7.0)}));
+  input._values.push_back(toQVec(std::vector{TC(5.0), TC(4.0)}));
   auto values = ad_utility::makeExecutionTree<Values>(
       ad_utility::testing::getQec(), input);
 
@@ -2394,7 +2397,7 @@ TEST(GroupBy, GroupedVariableInExpressions) {
 
 // _____________________________________________________________________________
 TEST(GroupBy, AliasResultReused) {
-  parsedQuery::SparqlValues input;
+  parsedQuery::SparqlValues input{ad_utility::testing::makeAllocator()};
   using TC = TripleComponent;
   // Test the following SPARQL query:
   //
@@ -2410,10 +2413,10 @@ TEST(GroupBy, AliasResultReused) {
   Variable varA = Variable{"?a"};
   Variable varB = Variable{"?b"};
 
-  input._variables = std::vector{varA, varB};
-  input._values.push_back(std::vector{TC(1.0), TC(3.0)});
-  input._values.push_back(std::vector{TC(1.0), TC(7.0)});
-  input._values.push_back(std::vector{TC(5.0), TC(4.0)});
+  input._variables = toQVec(std::vector{varA, varB});
+  input._values.push_back(toQVec(std::vector{TC(1.0), TC(3.0)}));
+  input._values.push_back(toQVec(std::vector{TC(1.0), TC(7.0)}));
+  input._values.push_back(toQVec(std::vector{TC(5.0), TC(4.0)}));
   auto values = ad_utility::makeExecutionTree<Values>(
       ad_utility::testing::getQec(), input);
 
@@ -2466,8 +2469,8 @@ TEST(GroupBy, AddedHavingRows) {
       " VALUES (?x ?y) {(0 1) (0 3) (0 5) (1 4) (1 3) } }"
       "GROUP BY ?x HAVING (?count > 2)";
   auto qec = ad_utility::testing::getQec();
-  auto pq =
-      SparqlParser::parseQuery(&qec->getIndex().encodedIriManager(), query);
+  auto pq = SparqlParser::parseQuery(&qec->getIndex().encodedIriManager(),
+                                     query, {}, qec->getAllocator());
   QueryPlanner qp{qec, std::make_shared<ad_utility::CancellationHandle<>>()};
   auto tree = qp.createExecutionTree(pq);
 
@@ -2785,7 +2788,9 @@ TEST(GroupBy, countDistinctGraph) {
     // Regression test for https://github.com/ad-freiburg/qlever/issues/2284
     auto subtree = ad_utility::makeExecutionTree<IndexScan>(
         qec, Permutation::Enum::PSO,
-        SparqlTripleSimple{V{"?s"}, V{"?p"}, V{"?o"}, {{3, V{"?g"}}}});
+        SparqlTripleSimple{V{"?s"}, V{"?p"}, V{"?o"},
+                           toQVec(std::vector<std::pair<ColumnIndex, Variable>>{
+                               {3, V{"?g"}}})});
 
     auto expr0 = std::make_unique<VariableExpression>(Variable{"?g"});
     auto expr1 = std::make_unique<CountExpression>(true, std::move(expr0));
@@ -2803,7 +2808,9 @@ TEST(GroupBy, countDistinctGraph) {
   {
     auto subtree = ad_utility::makeExecutionTree<IndexScan>(
         qec, Permutation::Enum::PSO,
-        SparqlTripleSimple{V{"?s"}, V{"?p"}, V{"?o"}, {{3, V{"?g"}}}},
+        SparqlTripleSimple{V{"?s"}, V{"?p"}, V{"?o"},
+                           toQVec(std::vector<std::pair<ColumnIndex, Variable>>{
+                               {3, V{"?g"}}})},
         IndexScan::Graphs::Blacklist(TripleComponent{
             ad_utility::triple_component::Iri::fromIriref(DEFAULT_GRAPH_IRI)}));
 

--- a/test/HasPredicateScanTest.cpp
+++ b/test/HasPredicateScanTest.cpp
@@ -421,7 +421,8 @@ TEST_F(HasPredicateScanTest, patternTrickAllEntitiesWithDeltaTriples) {
                                  makeAllocator(),
                                  SortPerformanceEstimator{},
                                  &namedResultCache,
-                                 std::make_shared<MaterializedViewsManager>()};
+                                 std::make_shared<MaterializedViewsManager>(
+                                     makeAllocator())};
   };
 
   // Read the `ql:has-pattern` entry of `<z>` (subject, pattern, and the
@@ -440,8 +441,10 @@ TEST_F(HasPredicateScanTest, patternTrickAllEntitiesWithDeltaTriples) {
           Variable{"?s"},
           ad_utility::triple_component::Iri::fromIriref(HAS_PATTERN_PREDICATE),
           Variable{"?p"},
-          {std::pair{ColumnIndex{ADDITIONAL_COLUMN_GRAPH_ID},
-                     Variable{"?g"}}}});
+          SparqlTripleSimple::AdditionalScanColumns{
+              {std::pair{ColumnIndex{ADDITIONAL_COLUMN_GRAPH_ID},
+                        Variable{"?g"}}},
+              qecBefore.getAllocator()}});
   auto before = scanBefore->getResult();
   std::optional<Id> zPattern;
   std::optional<Id> graphOfHasPattern;

--- a/test/JoinTest.cpp
+++ b/test/JoinTest.cpp
@@ -16,6 +16,7 @@
 #include "./util/GTestHelpers.h"
 #include "./util/IdTableHelpers.h"
 #include "./util/JoinHelpers.h"
+#include "./util/ParsedQueryTestHelpers.h"
 #include "engine/CallFixedSize.h"
 #include "engine/IndexScan.h"
 #include "engine/Join.h"
@@ -297,10 +298,11 @@ ExpectedColumns makeExpectedColumns(const VariableToColumnMap& varToColMap,
 std::shared_ptr<QueryExecutionTree> makeValuesForSingleVariable(
     QueryExecutionContext* qec, std::string variable,
     std::vector<TripleComponent> values) {
-  parsedQuery::SparqlValues sparqlValues;
+  parsedQuery::SparqlValues sparqlValues{qec->getAllocator()};
   sparqlValues._variables.emplace_back(std::move(variable));
   for (auto& value : values) {
-    sparqlValues._values.push_back({std::move(value)});
+    sparqlValues._values.push_back(ad_utility::testing::toQVec(
+        std::vector<TripleComponent>{std::move(value)}));
   }
   return ad_utility::makeExecutionTree<Values>(qec, sparqlValues);
 }

--- a/test/LoadTest.cpp
+++ b/test/LoadTest.cpp
@@ -305,7 +305,7 @@ TEST_F(LoadTest, clone) {
 TEST_F(LoadTest, Integration) {
   auto parsedUpdate = SparqlParser::parseUpdate(
       &blankNodeManager_, &testQec->getIndex().encodedIriManager(),
-      "LOAD <https://mundhahs.dev>");
+      "LOAD <https://mundhahs.dev>", {}, testQec->getAllocator());
   ASSERT_THAT(parsedUpdate, testing::SizeIs(1));
   auto qec =
       ad_utility::testing::getQec(ad_utility::testing::TestIndexConfig{});

--- a/test/LocalVocabTest.cpp
+++ b/test/LocalVocabTest.cpp
@@ -32,6 +32,7 @@
 #include "global/Id.h"
 #include "global/Pattern.h"
 #include "util/IndexTestHelpers.h"
+#include "util/ParsedQueryTestHelpers.h"
 
 namespace {
 // Get test collection of words of a given size. The words are all distinct.
@@ -323,19 +324,23 @@ TEST(LocalVocab, propagation) {
   // purposes of this test, we just want something that's not yet in the index,
   // so "x" etc. is just fine (and also different from the "<x>" below).
   auto iri = ad_utility::testing::iri;
+  using ad_utility::testing::makeSparqlValues;
   Values values1(
       testQec,
-      {{Variable{"?x"}, Variable{"?y"}},
-       {{TripleComponent{iri("<xN1>")}, TripleComponent{iri("<yN1>")}},
-        {TripleComponent{iri("<xN1>")}, TripleComponent{iri("<yN2>")}}}});
+      makeSparqlValues(
+          {Variable{"?x"}, Variable{"?y"}},
+          {{TripleComponent{iri("<xN1>")}, TripleComponent{iri("<yN1>")}},
+           {TripleComponent{iri("<xN1>")}, TripleComponent{iri("<yN2>")}}}));
   Values values1copy = values1;
   std::vector<std::string> localVocab1{"<xN1>", "<yN1>", "<yN2>"};
   checkLocalVocab(values1copy, localVocab1);
 
   // VALUES operation that uses an existing literal (from the test index).
   Values values2(
-      testQec, {{Variable{"?x"}, Variable{"?y"}},
-                {{TripleComponent{iri("<x>")}, TripleComponent{iri("<y>")}}}});
+      testQec,
+      makeSparqlValues(
+          {Variable{"?x"}, Variable{"?y"}},
+          {{TripleComponent{iri("<x>")}, TripleComponent{iri("<y>")}}}));
   Values values2copy = values2;
   checkLocalVocab(values2copy, std::vector<std::string>{});
 
@@ -343,9 +348,10 @@ TEST(LocalVocab, propagation) {
   // words in `values1`.
   Values values3(
       testQec,
-      {{Variable{"?x"}, Variable{"?y"}},
-       {{TripleComponent{iri("<xN1>")}, TripleComponent{iri("<yN1>")}},
-        {TripleComponent{iri("<xN2>")}, TripleComponent{iri("<yN3>")}}}});
+      makeSparqlValues(
+          {Variable{"?x"}, Variable{"?y"}},
+          {{TripleComponent{iri("<xN1>")}, TripleComponent{iri("<yN1>")}},
+           {TripleComponent{iri("<xN2>")}, TripleComponent{iri("<yN3>")}}}));
   std::vector<std::string> localVocab13{"<xN1>", "<yN1>", "<yN2>", "<xN2>",
                                         "<yN3>"};
 
@@ -373,7 +379,9 @@ TEST(LocalVocab, propagation) {
 
   // ORDER BY operation (the third argument are the indices of the columns to be
   // sorted, and the sort order; not important for this test).
-  OrderBy orderBy(testQec, qet(values1), {{0, true}, {1, true}});
+  OrderBy orderBy(testQec, qet(values1),
+                 OrderBy::SortIndices({{0, true}, {1, true}},
+                                      testQec->getAllocator()));
   checkLocalVocab(orderBy, localVocab1);
 
   // SORT operation (the third operation is the sort column).
@@ -399,9 +407,11 @@ TEST(LocalVocab, propagation) {
             "GROUP_CONCAT"};
   };
   Values values1b(
-      testQec, {{Variable{"?x"}, Variable{"?y"}},
-                {{TripleComponent{lit("xN1")}, TripleComponent{lit("yN1")}},
-                 {TripleComponent{lit("xN1")}, TripleComponent{lit("yN2")}}}});
+      testQec,
+      makeSparqlValues(
+          {Variable{"?x"}, Variable{"?y"}},
+          {{TripleComponent{lit("xN1")}, TripleComponent{lit("yN1")}},
+           {TripleComponent{lit("xN1")}, TripleComponent{lit("yN2")}}}));
   GroupBy groupBy(
       testQec, {Variable{"?x"}},
       {Alias{groupConcatExpression("?y", "|"), Variable{"?concat"}}},
@@ -461,9 +471,11 @@ TEST(LocalVocab, propagation) {
   checkLocalVocab(hasPredicateScan, localVocab1);
   Values valuesPatternTrick(
       testQec,
-      {{Variable{"?x"}, Variable{"?y"}},
-       {{TripleComponent{iri("<xN1>")}, TripleComponent{Pattern::NoPattern}},
-        {TripleComponent{iri("<xN1>")}, TripleComponent{Pattern::NoPattern}}}});
+      makeSparqlValues(
+          {Variable{"?x"}, Variable{"?y"}},
+          {{TripleComponent{iri("<xN1>")}, TripleComponent{Pattern::NoPattern}},
+           {TripleComponent{iri("<xN1>")},
+            TripleComponent{Pattern::NoPattern}}}));
   CountAvailablePredicates countAvailablePredictes(
       testQec, qet(valuesPatternTrick), 0, Variable{"?y"}, Variable{"?count"});
   checkLocalVocab(countAvailablePredictes, {"<xN1>"});

--- a/test/MaterializedViewsPatternRewriteTest.cpp
+++ b/test/MaterializedViewsPatternRewriteTest.cpp
@@ -18,6 +18,7 @@
 #include "engine/MaterializedViews.h"
 #include "engine/MaterializedViewsQueryAnalysis.h"
 #include "libqlever/Qlever.h"
+#include "util/AllocatorTestHelpers.h"
 #include "util/File.h"
 
 namespace {
@@ -69,7 +70,8 @@ TEST_F(MaterializedViewsPatternRewriteTest, starRewrite) {
                     h::IndexScanFromStrings("?s", "<p2>", "?o2")));
 
   // Write a star structure to the materialized view.
-  MaterializedViewsManager manager{onDiskBase};
+  MaterializedViewsManager manager{onDiskBase,
+                                  ad_utility::testing::makeAllocator()};
   manager.writeViewToDisk(viewName,
                           qlv.parseAndPlanQuery(std::string{simpleStar}));
   qlv.loadMaterializedView(viewName);
@@ -153,7 +155,8 @@ TEST_F(MaterializedViewsPatternRewriteTest, generalPatternRewrite) {
   qlever::EngineConfig config;
   config.baseName_ = onDiskBase;
   qlever::Qlever qlv{config};
-  MaterializedViewsManager manager{onDiskBase};
+  MaterializedViewsManager manager{onDiskBase,
+                                  ad_utility::testing::makeAllocator()};
 
   auto generalPatternView =
       std::bind_front(&viewScanSimple, "generalPatternView");
@@ -219,7 +222,8 @@ TEST_F(MaterializedViewsPatternRewriteTest,
   config.baseName_ = onDiskBase;
   config.loadTextIndex_ = true;
   qlever::Qlever qlv{config};
-  MaterializedViewsManager manager{onDiskBase};
+  MaterializedViewsManager manager{onDiskBase,
+                                  ad_utility::testing::makeAllocator()};
 
   expectNotSuitableForRewrite(
       qlv, manager, "fullTextView",
@@ -368,7 +372,7 @@ TEST_F(MaterializedViewsPatternMatchingTest, restrictingModifiersNotRewritten) {
 // _____________________________________________________________________________
 TEST(MaterializedViewsPatternRewriteRejectionTest,
      emptyGraphPatternNotRewritten) {
-  ParsedQuery parsed;
+  ParsedQuery parsed{ad_utility::testing::makeAllocator()};
   parsed._rootGraphPattern._graphPatterns.emplace_back(
       parsedQuery::BasicGraphPattern{});
 

--- a/test/MaterializedViewsTest.cpp
+++ b/test/MaterializedViewsTest.cpp
@@ -49,6 +49,7 @@
 #include "rdfTypes/GeoPoint.h"
 #include "rdfTypes/Iri.h"
 #include "rdfTypes/Literal.h"
+#include "util/AllocatorTestHelpers.h"
 #include "util/AllocatorWithLimit.h"
 #include "util/CancellationHandle.h"
 #include "util/CompilerWarnings.h"
@@ -228,7 +229,8 @@ TEST_F(MaterializedViewsTest, ParserConfigChecks) {
     auto trace = generateLocationTrace(location);
     EncodedIriManager encodedIriManager;
     AD_EXPECT_THROW_WITH_MESSAGE(
-        SparqlParser::parseQuery(&encodedIriManager, std::move(query), {}),
+        SparqlParser::parseQuery(&encodedIriManager, std::move(query), {},
+                                 ad_utility::testing::makeAllocator()),
         ::testing::HasSubstr(expectedError));
   };
 
@@ -249,7 +251,8 @@ TEST_F(MaterializedViewsTest, ParserConfigChecks) {
 TEST_F(MaterializedViewsTest, MetadataDependentConfigChecks) {
   // Simple materialized view for testing the checks when querying.
   auto plan = qlv().parseAndPlanQuery(simpleWriteQuery_);
-  MaterializedViewsManager manager{testIndexBase_};
+  MaterializedViewsManager manager{testIndexBase_,
+                                  ad_utility::testing::makeAllocator()};
   manager.writeViewToDisk("testView1", plan);
 
   // Helper that parses a query, but doesn't feed it to the `QueryPlanner` but
@@ -263,8 +266,8 @@ TEST_F(MaterializedViewsTest, MetadataDependentConfigChecks) {
 
     // Parse query.
     EncodedIriManager encodedIriManager;
-    auto parsed =
-        SparqlParser::parseQuery(&encodedIriManager, std::move(query), {});
+    auto parsed = SparqlParser::parseQuery(&encodedIriManager, std::move(query),
+                                           {}, ad_utility::testing::makeAllocator());
     ASSERT_TRUE(parsed.hasSelectClause());
     ASSERT_EQ(parsed.children().size(), 1);
 
@@ -400,7 +403,8 @@ TEST_F(MaterializedViewsTest, MetadataDependentConfigChecks) {
 // _____________________________________________________________________________
 TEST_F(MaterializedViewsTest, ColumnPermutation) {
   ENFORCE_LOG_LEVEL_OR_SKIP(INFO);
-  MaterializedViewsManager manager{testIndexBase_};
+  MaterializedViewsManager manager{testIndexBase_,
+                                  ad_utility::testing::makeAllocator()};
 
   // Helper to get all column names from a view via its `VariableToColumnMap`.
   auto columnNames = [](const MaterializedView& view) {
@@ -424,7 +428,8 @@ TEST_F(MaterializedViewsTest, ColumnPermutation) {
         "SELECT ?p ?o (?s AS ?x) ?g { ?s ?p ?o . BIND(3 AS ?g) }";
     manager.writeViewToDisk("testView3",
                             qlv().parseAndPlanQuery(reorderedQuery));
-    MaterializedView view{testIndexBase_, "testView3"};
+    MaterializedView view{testIndexBase_, "testView3",
+                          ad_utility::testing::makeAllocator()};
     EXPECT_EQ(columnNames(view).at(0), V{"?p"});
     const auto& map = view.variableToColumnMap();
     EXPECT_EQ(map.at(V{"?p"}).columnIndex_, 0);
@@ -445,7 +450,8 @@ TEST_F(MaterializedViewsTest, ColumnPermutation) {
     EXPECT_THAT(log_.str(),
                 ::testing::HasSubstr("Query result rows for materialized view "
                                      "\"testView4\" are already sorted"));
-    MaterializedView view{testIndexBase_, "testView4"};
+    MaterializedView view{testIndexBase_, "testView4",
+                          ad_utility::testing::makeAllocator()};
     EXPECT_EQ(columnNames(view).at(0), V{"?p"});
     auto res = qlv().query(
         "PREFIX view: <https://qlever.cs.uni-freiburg.de/materializedView/>"
@@ -460,7 +466,8 @@ TEST_F(MaterializedViewsTest, ColumnPermutation) {
     clearLog();
     manager.writeViewToDisk("testView5",
                             qlv().parseAndPlanQuery("SELECT * { <s1> ?p ?o }"));
-    MaterializedView view{testIndexBase_, "testView5"};
+    MaterializedView view{testIndexBase_, "testView5",
+                          ad_utility::testing::makeAllocator()};
     EXPECT_THAT(columnNames(view),
                 ::testing::ElementsAreArray(std::vector<V>{V{"?p"}, V{"?o"}}));
     EXPECT_THAT(log_.str(), ::testing::HasSubstr("2 empty column(s)"));
@@ -531,7 +538,8 @@ TEST_F(MaterializedViewsTest, ColumnPermutation) {
 
 // _____________________________________________________________________________
 TEST_F(MaterializedViewsTest, InvalidInputToWriter) {
-  MaterializedViewsManager manager{testIndexBase_};
+  MaterializedViewsManager manager{testIndexBase_,
+                                  ad_utility::testing::makeAllocator()};
 
   AD_EXPECT_THROW_WITH_MESSAGE(
       manager.writeViewToDisk("Something Out!of~the.ordinary",
@@ -603,7 +611,8 @@ TEST_F(MaterializedViewsTest, InvalidInputToWriter) {
 
 // _____________________________________________________________________________
 TEST_F(MaterializedViewsTest, ManualConfigurations) {
-  MaterializedViewsManager manager{testIndexBase_};
+  MaterializedViewsManager manager{testIndexBase_,
+                                  ad_utility::testing::makeAllocator()};
   auto plan = qlv().parseAndPlanQuery(simpleWriteQuery_);
   manager.writeViewToDisk("testView1", plan);
   auto view = manager.getView("testView1", nullptr);
@@ -627,7 +636,8 @@ TEST_F(MaterializedViewsTest, ManualConfigurations) {
   EXPECT_THAT(view->originalQuery(),
               ::testing::Optional(::testing::Eq(simpleWriteQuery_)));
 
-  MaterializedViewsManager managerNoBaseName;
+  MaterializedViewsManager managerNoBaseName{
+      ad_utility::testing::makeAllocator()};
   AD_EXPECT_THROW_WITH_MESSAGE(
       managerNoBaseName.getView("testView1", nullptr),
       ::testing::HasSubstr("index base filename was not set"));
@@ -640,6 +650,7 @@ TEST_F(MaterializedViewsTest, ManualConfigurations) {
   auto iri = [](const std::string& ref) {
     return ad_utility::triple_component::Iri::fromIriref(ref);
   };
+  auto qec = getQec();
 
   const V placeholderP{"?_ql_materialized_view_p"};
   const V placeholderO{"?_ql_materialized_view_o"};
@@ -651,8 +662,10 @@ TEST_F(MaterializedViewsTest, ManualConfigurations) {
         iri("<https://qlever.cs.uni-freiburg.de/materializedView/testView1-g>"),
         V{"?o"}}};
 
-    auto t = view->makeScanConfig(query);
-    Triple expected{V{"?s"}, placeholderP, placeholderO, {{3, V{"?o"}}}};
+    auto t = view->makeScanConfig(qec.get(), query);
+    Triple expected{V{"?s"}, placeholderP, placeholderO,
+                    toQVec(std::vector<std::pair<ColumnIndex, Variable>>{
+                        {3, V{"?o"}}})};
     EXPECT_EQ(t, expected);
   }
   {
@@ -668,8 +681,10 @@ TEST_F(MaterializedViewsTest, ManualConfigurations) {
         ::testing::HasSubstr("Unknown parameter"));
     EXPECT_EQ(query.name(), "materialized view query");
 
-    auto t = view->makeScanConfig(query);
-    Triple expected{V{"?s"}, placeholderP, placeholderO, {{3, V{"?o"}}}};
+    auto t = view->makeScanConfig(qec.get(), query);
+    Triple expected{V{"?s"}, placeholderP, placeholderO,
+                    toQVec(std::vector<std::pair<ColumnIndex, Variable>>{
+                        {3, V{"?o"}}})};
     EXPECT_EQ(t, expected);
   }
 
@@ -681,7 +696,7 @@ TEST_F(MaterializedViewsTest, ManualConfigurations) {
         iri("<https://qlever.cs.uni-freiburg.de/materializedView/testView1-o>"),
         V{"?o"}}};
 
-    auto t = view->makeScanConfig(query);
+    auto t = view->makeScanConfig(qec.get(), query);
     Triple expected{V{"?s"}, placeholderP, V{"?o"}};
     EXPECT_EQ(t, expected);
     std::vector<Variable> expectedVars{V{"?s"}, V{"?o"}};
@@ -695,7 +710,7 @@ TEST_F(MaterializedViewsTest, ManualConfigurations) {
         iri("<s1>"),
         iri("<https://qlever.cs.uni-freiburg.de/materializedView/testView1-p>"),
         V{"?p"}}};
-    auto t = view->makeScanConfig(query);
+    auto t = view->makeScanConfig(qec.get(), query);
     Triple expected{iri("<s1>"), V{"?p"}, placeholderO};
     EXPECT_EQ(t, expected);
     std::vector<Variable> expectedVars{V{"?p"}};
@@ -758,7 +773,7 @@ TEST_F(MaterializedViewsTest, ManualConfigurations) {
     query.addParameter(
         SparqlTriple{iri("<config>"), iri("<column-s>"), V{"?x"}});
     AD_EXPECT_THROW_WITH_MESSAGE(
-        view->makeScanConfig(query),
+        view->makeScanConfig(qec.get(), query),
         ::testing::HasSubstr(
             "The first column of a materialized view may not be requested "
             "twice, but '?x' violated this requirement."));
@@ -797,7 +812,8 @@ TEST_F(MaterializedViewsTest, ManualConfigurations) {
           << viewInfo.dump() << std::endl;
     }
     AD_EXPECT_THROW_WITH_MESSAGE(
-        MaterializedView(testIndexBase_, "testView5"),
+        MaterializedView(testIndexBase_, "testView5",
+                         ad_utility::testing::makeAllocator()),
         ::testing::HasSubstr(
             "The materialized view 'testView5' is saved with format version "
             "0, however this version of QLever expects"));
@@ -858,7 +874,8 @@ TEST_F(MaterializedViewsTest, ManualConfigurations) {
   // View with no parsed query is skipped by `QueryPatternCache::analyzeView`.
   {
     qlv().writeMaterializedView("testView7", simpleWriteQuery_);
-    auto view = std::make_shared<MaterializedView>(testIndexBase_, "testView7");
+    auto view = std::make_shared<MaterializedView>(
+        testIndexBase_, "testView7", ad_utility::testing::makeAllocator());
     view->parsedQuery_ = std::nullopt;
     materializedViewsQueryAnalysis::QueryPatternCache c;
     EXPECT_FALSE(c.analyzeView(view, nullptr));
@@ -1129,7 +1146,8 @@ TEST_F(MaterializedViewsTest, serverIntegration) {
 
 // _____________________________________________________________________________
 TEST_F(MaterializedViewsTest, Deletion) {
-  MaterializedViewsManager manager{testIndexBase_};
+  MaterializedViewsManager manager{testIndexBase_,
+                                  ad_utility::testing::makeAllocator()};
   auto plan = qlv().parseAndPlanQuery(simpleWriteQuery_);
 
   // Write and load a view, then delete it.
@@ -1170,7 +1188,8 @@ TEST_F(MaterializedViewsTest, Deletion) {
 // stay usable, so that queries that still hold a snapshot of the old index can
 // finish.
 TEST_F(MaterializedViewsTest, RetireOnDiskFiles) {
-  MaterializedViewsManager manager{testIndexBase_};
+  MaterializedViewsManager manager{testIndexBase_,
+                                  ad_utility::testing::makeAllocator()};
   auto plan = qlv().parseAndPlanQuery(simpleWriteQuery_);
 
   // The view written below deliberately outlives the retirement (a retired
@@ -1217,7 +1236,8 @@ TEST_F(MaterializedViewsTest, RetireOnDiskFiles) {
 
 // _____________________________________________________________________________
 TEST_F(MaterializedViewsTest, DeletionFailureThrows) {
-  MaterializedViewsManager manager{testIndexBase_};
+  MaterializedViewsManager manager{testIndexBase_,
+                                  ad_utility::testing::makeAllocator()};
   auto plan = qlv().parseAndPlanQuery(simpleWriteQuery_);
   manager.writeViewToDisk("testViewBroken", plan);
 
@@ -1259,7 +1279,8 @@ TEST_F(MaterializedViewsTestLarge, LazyScan) {
   auto writePlan = qlv().parseAndPlanQuery(
       "SELECT * { ?s ?p ?o ."
       " VALUES ?g { 1 2 3 4 5 6 7 8 9 10 } }");
-  MaterializedViewsManager manager{testIndexBase_};
+  MaterializedViewsManager manager{testIndexBase_,
+                                  ad_utility::testing::makeAllocator()};
   manager.writeViewToDisk("testView1", writePlan);
   auto view = manager.getView("testView1", nullptr);
   using ViewQuery = parsedQuery::MaterializedViewQuery;
@@ -1313,7 +1334,8 @@ TEST_F(MaterializedViewsTestLarge, LazyScan) {
 // _____________________________________________________________________________
 TEST_F(MaterializedViewsTest, BindToColumnMap) {
   qlv().writeMaterializedView("testView1", simpleWriteQuery_);
-  MaterializedViewsManager manager{testIndexBase_};
+  MaterializedViewsManager manager{testIndexBase_,
+                                  ad_utility::testing::makeAllocator()};
   auto view = manager.getView("testView1", nullptr);
   EXPECT_TRUE(view->parsedQuery().has_value());
 
@@ -1994,7 +2016,8 @@ TEST(MaterializedViewsSpatialJoinTest, FixedValueFilterOnFullyCoveredView) {
 TEST_F(MaterializedViewsTest, JoinBetweenLazyScansWithPlaceholderVars) {
   // Regression test for #2866.
   auto plan = qlv().parseAndPlanQuery(simpleWriteQuery_);
-  MaterializedViewsManager manager{testIndexBase_};
+  MaterializedViewsManager manager{testIndexBase_,
+                                  ad_utility::testing::makeAllocator()};
   manager.writeViewToDisk("testView1", plan);
 
   // Test that the placeholder variable for the third column of both views,
@@ -2075,7 +2098,8 @@ TEST_F(MaterializedViewsTest, GroupByOptimizations) {
       } INTERNAL SORT BY ?s ?p ?o LIMIT 1
     }
   )");
-  MaterializedViewsManager manager{testIndexBase_};
+  MaterializedViewsManager manager{testIndexBase_,
+                                  ad_utility::testing::makeAllocator()};
   manager.writeViewToDisk("groupByTestView", plan);
 
   // Matcher for an `IdTable` containing a single integer.
@@ -2149,7 +2173,8 @@ TEST_F(MaterializedViewsTest,
        GetPermutationForThreeVariableTripleMaterializedView) {
   // Write a three-variable view (writing auto-loads it).
   auto plan = qlv().parseAndPlanQuery("SELECT ?s ?p ?o { ?s ?p ?o }");
-  MaterializedViewsManager manager{testIndexBase_};
+  MaterializedViewsManager manager{testIndexBase_,
+                                  ad_utility::testing::makeAllocator()};
   manager.writeViewToDisk("threeVarPermTestView", plan);
 
   // Create a three-variable scan on the view binding all three columns.

--- a/test/MaterializedViewsTestHelpers.h
+++ b/test/MaterializedViewsTestHelpers.h
@@ -246,7 +246,7 @@ class MaterializedViewsPatternMatchingTest
     qlever::EngineConfig config;
     config.baseName_ = onDiskBase_;
     qlv_.emplace(config);
-    manager_.emplace(onDiskBase_);
+    manager_.emplace(onDiskBase_, qlv_->allocator());
     qec_ = qlv_->createQueryExecutionContext(qlv_->indexAndViewsSnapshot());
   }
 
@@ -266,7 +266,8 @@ class MaterializedViewsPatternMatchingTest
   // Parse `query`'s single basic graph pattern, without going through full
   // query planning.
   parsedQuery::BasicGraphPattern parseTriples(const std::string& query) {
-    auto parsed = SparqlParser::parseQuery(&encodedIriManager_, query, {});
+    auto parsed = SparqlParser::parseQuery(&encodedIriManager_, query, {},
+                                           qlv_->allocator());
     return parsed._rootGraphPattern._graphPatterns.at(0).getBasic();
   }
 

--- a/test/OperationTest.cpp
+++ b/test/OperationTest.cpp
@@ -199,7 +199,7 @@ class OperationTestFixture : public testing::Test {
   QueryResultCache cache;
   NamedResultCache namedCache;
   std::shared_ptr<MaterializedViewsManager> materializedViewsManager =
-      std::make_shared<MaterializedViewsManager>();
+      std::make_shared<MaterializedViewsManager>(makeAllocator());
   QueryExecutionContext qec{
       index,
       &cache,
@@ -503,7 +503,7 @@ TEST(Operation, ensureFailedStatusIsSetWhenGeneratorThrowsException) {
                     TestIndexConfig{}));
   QueryResultCache cache{};
   NamedResultCache namedCache{};
-  auto materializedViewsManager = std::make_shared<MaterializedViewsManager>();
+  auto materializedViewsManager = std::make_shared<MaterializedViewsManager>(makeAllocator());
   QueryExecutionContext context{
       index,
       &cache,
@@ -533,7 +533,7 @@ TEST(Operation, ensureFailedStatusIsSetWhenGeneratorIsCancelled) {
       "ensureFailedStatusIsSetWhenGeneratorIsCancelled", TestIndexConfig{}));
   QueryResultCache cache{};
   NamedResultCache namedCache{};
-  auto materializedViewsManager = std::make_shared<MaterializedViewsManager>();
+  auto materializedViewsManager = std::make_shared<MaterializedViewsManager>(makeAllocator());
   QueryExecutionContext context{
       index,
       &cache,
@@ -570,7 +570,7 @@ TEST(Operation, ensureSignalUpdateIsOnlyCalledEvery50msAndAtTheEnd) {
       "ensureSignalUpdateIsOnlyCalledEvery50msAndAtTheEnd", TestIndexConfig{}));
   QueryResultCache cache{};
   NamedResultCache namedCache{};
-  auto materializedViewsManager = std::make_shared<MaterializedViewsManager>();
+  auto materializedViewsManager = std::make_shared<MaterializedViewsManager>(makeAllocator());
   QueryExecutionContext context{
       index,
       &cache,
@@ -620,7 +620,7 @@ TEST(Operation, ensureSignalUpdateIsCalledAtTheEndOfPartialConsumption) {
                     TestIndexConfig{}));
   QueryResultCache cache{};
   NamedResultCache namedCache{};
-  auto materializedViewsManager = std::make_shared<MaterializedViewsManager>();
+  auto materializedViewsManager = std::make_shared<MaterializedViewsManager>(makeAllocator());
   QueryExecutionContext context{
       index,
       &cache,

--- a/test/OrderByTest.cpp
+++ b/test/OrderByTest.cpp
@@ -19,7 +19,8 @@ using ad_utility::source_location;
 
 namespace {
 // Create an `OrderBy` operation that sorts the `input` by the `sortColumns`.
-OrderBy makeOrderBy(IdTable input, const OrderBy::SortIndices& sortColumns) {
+OrderBy makeOrderBy(IdTable input,
+                    const std::vector<std::pair<ColumnIndex, bool>>& sortColumns) {
   std::vector<std::optional<Variable>> vars;
   auto qec = ad_utility::testing::getQec();
   for (size_t i = 0; i < input.numColumns(); ++i) {
@@ -27,7 +28,9 @@ OrderBy makeOrderBy(IdTable input, const OrderBy::SortIndices& sortColumns) {
   }
   auto subtree = ad_utility::makeExecutionTree<ValuesForTesting>(
       ad_utility::testing::getQec(), std::move(input), vars);
-  return OrderBy{qec, std::move(subtree), sortColumns};
+  return OrderBy{qec, std::move(subtree),
+                OrderBy::SortIndices(sortColumns.begin(), sortColumns.end(),
+                                     qec->getAllocator())};
 }
 
 // Test that the `input`, when being sorted by its 0-th column as its primary
@@ -47,7 +50,7 @@ void testOrderBy(IdTable input, const IdTable& expected,
   AD_CONTRACT_CHECK(input.numRows() == expected.numRows());
   // Set up a vector of `SortIndices`. Those will later be permuted.
   // The second element (`isDescending`) will be correctly set later.
-  OrderBy::SortIndices sortColumns;
+  OrderBy::SortIndices sortColumns{qec->getAllocator()};
   for (size_t i = 0; i < input.numColumns(); ++i) {
     sortColumns.emplace_back(i, false);
   }
@@ -75,7 +78,10 @@ void testOrderBy(IdTable input, const IdTable& expected,
     // Randomly shuffle the input and sort.
     for (size_t i = 0; i < 5; ++i) {
       randomShuffle(permutedInput.begin(), permutedInput.end());
-      OrderBy s = makeOrderBy(permutedInput.clone(), sortColumns);
+      OrderBy s = makeOrderBy(
+          permutedInput.clone(),
+          std::vector<std::pair<ColumnIndex, bool>>(sortColumns.begin(),
+                                                     sortColumns.end()));
       auto result = s.getResult();
       const auto& resultTable = result->idTableView();
       ASSERT_EQ(resultTable, permutedExpected);
@@ -265,7 +271,7 @@ TEST(OrderBy, clone) {
   IdTable permutedInput{2, qec->getAllocator()};
 
   OrderBy orderBy =
-      makeOrderBy(permutedInput.clone(), OrderBy::SortIndices{{0, true}});
+      makeOrderBy(permutedInput.clone(), {{0, true}});
 
   auto clone = orderBy.clone();
   ASSERT_TRUE(clone);

--- a/test/QueryPlannerSpatialJoinTest.cpp
+++ b/test/QueryPlannerSpatialJoinTest.cpp
@@ -16,6 +16,7 @@
 #include "parser/PayloadVariables.h"
 #include "parser/SpatialQuery.h"
 #include "rdfTypes/GeoSparqlHelpers.h"
+#include "util/ParsedQueryTestHelpers.h"
 #include "util/TripleComponentTestHelpers.h"
 
 namespace h = queryPlannerTestHelpers;
@@ -23,6 +24,7 @@ namespace {
 using Var = Variable;
 constexpr auto iri = ad_utility::testing::iri;
 using queryPlannerTestHelpers::NamedTag;
+using ad_utility::testing::toQVec;
 }  // namespace
 using ::testing::HasSubstr;
 
@@ -34,7 +36,7 @@ TEST(QueryPlanner, SpatialJoinService) {
   auto Basel = SpatialJoinAlgorithm::BASELINE;
   auto BBox = SpatialJoinAlgorithm::BOUNDING_BOX;
   auto SJ = SpatialJoinAlgorithm::LIBSPATIALJOIN;
-  PayloadVariables emptyPayload{};
+  PayloadVariables emptyPayload{ad_utility::testing::makeAllocator()};
 
   // Simple base cases
   h::expect(
@@ -316,7 +318,7 @@ TEST(QueryPlanner, SpatialJoinServicePayloadVars) {
       "_:config spatialSearch:payload ?a ."
       "{ ?a <p> ?b } }}",
       h::spatialJoin(-1, 5, V{"?y"}, V{"?b"}, V{"?dist"},
-                     PV{std::vector<V>{V{"?a"}}}, S2, std::nullopt,
+                     PV{toQVec(std::vector<V>{V{"?a"}})}, S2, std::nullopt,
                      std::nullopt, scan("?x", "<p>", "?y"),
                      scan("?a", "<p>", "?b")));
   h::expect(
@@ -333,7 +335,7 @@ TEST(QueryPlanner, SpatialJoinServicePayloadVars) {
       "{ ?a <p> ?a2 . ?a2 <p> ?b } }}",
       h::spatialJoin(
           -1, 5, V{"?y"}, V{"?b"}, V{"?dist"},
-          PV{std::vector<V>{V{"?a"}, V{"?a2"}}}, S2, std::nullopt, std::nullopt,
+          PV{toQVec(std::vector<V>{V{"?a"}, V{"?a2"}})}, S2, std::nullopt, std::nullopt,
           scan("?x", "<p>", "?y"),
           h::Join(scan("?a", "<p>", "?a2"), scan("?a2", "<p>", "?b"))));
 
@@ -353,7 +355,7 @@ TEST(QueryPlanner, SpatialJoinServicePayloadVars) {
       "{ ?a <p> ?a2 . ?a2 <p> ?b } }}",
       h::spatialJoin(
           -1, 5, V{"?y"}, V{"?b"}, V{"?dist"},
-          PV{std::vector<V>{V{"?a"}, V{"?a"}, V{"?b"}, V{"?a2"}}}, S2,
+          PV{toQVec(std::vector<V>{V{"?a"}, V{"?a"}, V{"?b"}, V{"?a2"}})}, S2,
           std::nullopt, std::nullopt, scan("?x", "<p>", "?y"),
           h::Join(scan("?a", "<p>", "?a2"), scan("?a2", "<p>", "?b"))));
 
@@ -560,18 +562,20 @@ TEST(QueryPlanner, SpatialJoinMultipleServiceSharedLeft) {
       // versions are semantically correct.
       ::testing::AnyOf(
           h::spatialJoin(500, 5, V{"?y"}, V{"?c"}, V{"?dc"},
-                         PV{std::vector<V>{V{"?ac"}}}, S2, std::nullopt,
+                         PV{toQVec(std::vector<V>{V{"?ac"}})}, S2, std::nullopt,
                          std::nullopt,
-                         h::spatialJoin(-1, 5, V{"?y"}, V{"?b"}, V{"?db"}, PV{},
+                         h::spatialJoin(-1, 5, V{"?y"}, V{"?b"}, V{"?db"},
+                                        PV{ad_utility::testing::makeAllocator()},
                                         S2, std::nullopt, std::nullopt,
                                         scan("?x", "<p>", "?y"),
                                         scan("?ab", "<p1>", "?b")),
                          scan("?ac", "<p2>", "?c")),
           h::spatialJoin(
-              -1, 5, V{"?y"}, V{"?b"}, V{"?db"}, PV{}, S2, std::nullopt,
+              -1, 5, V{"?y"}, V{"?b"}, V{"?db"},
+              PV{ad_utility::testing::makeAllocator()}, S2, std::nullopt,
               std::nullopt,
               h::spatialJoin(500, 5, V{"?y"}, V{"?c"}, V{"?dc"},
-                             PV{std::vector<V>{V{"?ac"}}}, S2, std::nullopt,
+                             PV{toQVec(std::vector<V>{V{"?ac"}})}, S2, std::nullopt,
                              std::nullopt, scan("?x", "<p>", "?y"),
                              scan("?ac", "<p2>", "?c")),
               scan("?ab", "<p1>", "?b"))));
@@ -1941,14 +1945,15 @@ TEST(QueryPlanner, SpatialJoinLegacyMaxDistanceParsing) {
     TripleComponent subject{Variable{"?subject"}};
     TripleComponent object{Variable{"?object"}};
     if (shouldThrow) {
-      ASSERT_ANY_THROW((parsedQuery::SpatialQuery{
-                            SparqlTriple{subject, iri(distanceIRI), object}})
-                           .toSpatialJoinConfiguration());
+      ASSERT_ANY_THROW(
+          (parsedQuery::SpatialQuery{SparqlTriple{subject, iri(distanceIRI),
+                                                  object},
+                                    qec->getAllocator()})
+              .toSpatialJoinConfiguration());
     } else {
       auto config = parsedQuery::SpatialQuery{
-          SparqlTriple{
-              subject, iri(distanceIRI),
-              object}}.toSpatialJoinConfiguration();
+          SparqlTriple{subject, iri(distanceIRI), object},
+          qec->getAllocator()}.toSpatialJoinConfiguration();
       std::shared_ptr<QueryExecutionTree> spatialJoinOperation =
           ad_utility::makeExecutionTree<SpatialJoin>(qec, config, std::nullopt,
                                                      std::nullopt);

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -20,6 +20,7 @@
 #include "util/ParsedQueryTestHelpers.h"
 #include "util/RuntimeParametersTestHelpers.h"
 #include "util/TripleComponentTestHelpers.h"
+#include "util/AllocatorTestHelpers.h"
 
 namespace h = queryPlannerTestHelpers;
 namespace {
@@ -51,26 +52,30 @@ TEST(QueryPlanner, createTripleGraph) {
     QueryPlanner qp = makeQueryPlanner();
     auto tg = qp.createTripleGraph(
         &pq._rootGraphPattern._graphPatterns[0].getBasic());
-    TripleGraph expected =
-        TripleGraph(std::vector<std::pair<Node, std::vector<size_t>>>(
-            {std::make_pair<Node, vector<size_t>>(
-                 QueryPlanner::TripleGraph::Node(
-                     0, SparqlTriple(Var{"?x"},
-                                     iri("<http://rdf.myprefix.com/myrel>"),
-                                     Var{"?y"})),
-                 {1, 2}),
-             std::make_pair<Node, vector<size_t>>(
-                 QueryPlanner::TripleGraph::Node(
-                     1, SparqlTriple(Var{"?y"},
-                                     iri("<http://rdf.myprefix.com/ns/myrel>"),
-                                     Var{"?z"})),
-                 {0, 2}),
-             std::make_pair<Node, vector<size_t>>(
-                 QueryPlanner::TripleGraph::Node(
-                     2, SparqlTriple(Var{"?y"},
-                                     iri("<http://rdf.myprefix.com/xxx/rel2>"),
-                                     iri("<http://abc.de>"))),
-                 {0, 1})}));
+    TripleGraph expected = TripleGraph(
+        std::vector<std::pair<Node, std::vector<size_t>>>{
+            std::make_pair<Node, vector<size_t>>(
+                QueryPlanner::TripleGraph::Node(
+                    0, SparqlTriple(Var{"?x"},
+                                    iri("<http://rdf.myprefix.com/myrel>"),
+                                    Var{"?y"}),
+                    ad_utility::testing::makeAllocator()),
+                {1, 2}),
+            std::make_pair<Node, vector<size_t>>(
+                QueryPlanner::TripleGraph::Node(
+                    1, SparqlTriple(Var{"?y"},
+                                    iri("<http://rdf.myprefix.com/ns/myrel>"),
+                                    Var{"?z"}),
+                    ad_utility::testing::makeAllocator()),
+                {0, 2}),
+            std::make_pair<Node, vector<size_t>>(
+                QueryPlanner::TripleGraph::Node(
+                    2, SparqlTriple(Var{"?y"},
+                                    iri("<http://rdf.myprefix.com/xxx/rel2>"),
+                                    iri("<http://abc.de>")),
+                    ad_utility::testing::makeAllocator()),
+                {0, 1})},
+        ad_utility::testing::makeAllocator());
 
     ASSERT_TRUE(tg.isSimilar(expected));
   }
@@ -80,20 +85,24 @@ TEST(QueryPlanner, createTripleGraph) {
         parseQuery("SELECT ?x WHERE {?x ?p <X>. ?x ?p2 <Y>. <X> ?p <Y>}");
     QueryPlanner qp = makeQueryPlanner();
     auto tg = qp.createTripleGraph(&pq.children()[0].getBasic());
-    TripleGraph expected =
-        TripleGraph(std::vector<std::pair<Node, std::vector<size_t>>>(
-            {std::make_pair<Node, vector<size_t>>(
-                 QueryPlanner::TripleGraph::Node(
-                     0, SparqlTriple(Var{"?x"}, Var{"?p"}, iri("<X>"))),
-                 {1, 2}),
-             std::make_pair<Node, vector<size_t>>(
-                 QueryPlanner::TripleGraph::Node(
-                     1, SparqlTriple(Var{"?x"}, Var{"?p2"}, iri("<Y>"))),
-                 {0}),
-             std::make_pair<Node, vector<size_t>>(
-                 QueryPlanner::TripleGraph::Node(
-                     2, SparqlTriple(iri("<X>"), Var{"?p"}, iri("<Y>"))),
-                 {0})}));
+    TripleGraph expected = TripleGraph(
+        std::vector<std::pair<Node, std::vector<size_t>>>{
+            std::make_pair<Node, vector<size_t>>(
+                QueryPlanner::TripleGraph::Node(
+                    0, SparqlTriple(Var{"?x"}, Var{"?p"}, iri("<X>")),
+                    ad_utility::testing::makeAllocator()),
+                {1, 2}),
+            std::make_pair<Node, vector<size_t>>(
+                QueryPlanner::TripleGraph::Node(
+                    1, SparqlTriple(Var{"?x"}, Var{"?p2"}, iri("<Y>")),
+                    ad_utility::testing::makeAllocator()),
+                {0}),
+            std::make_pair<Node, vector<size_t>>(
+                QueryPlanner::TripleGraph::Node(
+                    2, SparqlTriple(iri("<X>"), Var{"?p"}, iri("<Y>")),
+                    ad_utility::testing::makeAllocator()),
+                {0})},
+        ad_utility::testing::makeAllocator());
     ASSERT_TRUE(tg.isSimilar(expected));
   }
 
@@ -104,18 +113,21 @@ TEST(QueryPlanner, createTripleGraph) {
     QueryPlanner qp = makeQueryPlanner();
     auto tg = qp.createTripleGraph(&pq.children()[0].getBasic());
 
-    TripleGraph expected =
-        TripleGraph(std::vector<std::pair<Node, std::vector<size_t>>>({
+    TripleGraph expected = TripleGraph(
+        std::vector<std::pair<Node, std::vector<size_t>>>{
             std::make_pair<Node, vector<size_t>>(
                 QueryPlanner::TripleGraph::Node(
-                    0, SparqlTriple(Var{"?x"}, iri("<is-a>"), iri("<Book>"))),
+                    0, SparqlTriple(Var{"?x"}, iri("<is-a>"), iri("<Book>")),
+                    ad_utility::testing::makeAllocator()),
                 {1}),
             std::make_pair<Node, vector<size_t>>(
                 QueryPlanner::TripleGraph::Node(
                     1, SparqlTriple(Var{"?x"}, iri("<Author>"),
-                                    iri("<Anthony_Newman_(Author)>"))),
+                                    iri("<Anthony_Newman_(Author)>")),
+                    ad_utility::testing::makeAllocator()),
                 {0}),
-        }));
+        },
+        ad_utility::testing::makeAllocator());
     ASSERT_TRUE(tg.isSimilar(expected));
   }
 }
@@ -135,12 +147,12 @@ TEST(QueryPlanner, testCpyCtorWithKeepNodes) {
         "2 {s: <X>, p: ?p, o: <Y>} : (0)",
         tg.asString());
     {
-      std::vector<size_t> keep;
+      qlever::vector<size_t> keep{tg._nodeMap.get_allocator()};
       QueryPlanner::TripleGraph tgnew(tg, keep);
       ASSERT_EQ("", tgnew.asString());
     }
     {
-      std::vector<size_t> keep;
+      qlever::vector<size_t> keep{tg._nodeMap.get_allocator()};
       keep.push_back(0);
       keep.push_back(1);
       keep.push_back(2);
@@ -155,14 +167,14 @@ TEST(QueryPlanner, testCpyCtorWithKeepNodes) {
       ASSERT_EQ(1u, tgnew._nodeMap.find(2)->second->_variables.size());
     }
     {
-      std::vector<size_t> keep;
+      qlever::vector<size_t> keep{tg._nodeMap.get_allocator()};
       keep.push_back(0);
       QueryPlanner::TripleGraph tgnew(tg, keep);
       ASSERT_EQ("0 {s: ?x, p: ?p, o: <X>} : ()", tgnew.asString());
       ASSERT_EQ(2u, tgnew._nodeMap.find(0)->second->_variables.size());
     }
     {
-      std::vector<size_t> keep;
+      qlever::vector<size_t> keep{tg._nodeMap.get_allocator()};
       keep.push_back(0);
       keep.push_back(1);
       QueryPlanner::TripleGraph tgnew(tg, keep);
@@ -183,7 +195,8 @@ TEST(QueryPlanner, testBFSLeaveOut) {
     QueryPlanner qp = makeQueryPlanner();
     auto tg = qp.createTripleGraph(&pq.children()[0].getBasic());
     ASSERT_EQ(3u, tg._adjLists.size());
-    ad_utility::HashSet<size_t> lo;
+    ad_utility::HashSetWithMemoryLimit<size_t> lo{
+        ad_utility::testing::makeAllocator()};
     auto out = tg.bfsLeaveOut(0, lo);
     ASSERT_EQ(3u, out.size());
     lo.insert(1);
@@ -202,7 +215,8 @@ TEST(QueryPlanner, testBFSLeaveOut) {
         parseQuery("SELECT ?x WHERE {<A> <B> ?x. ?x <C> ?y. ?y <X> <Y>}");
     QueryPlanner qp = makeQueryPlanner();
     auto tg = qp.createTripleGraph(&pq.children()[0].getBasic());
-    ad_utility::HashSet<size_t> lo;
+    ad_utility::HashSetWithMemoryLimit<size_t> lo{
+        ad_utility::testing::makeAllocator()};
     auto out = tg.bfsLeaveOut(0, lo);
     ASSERT_EQ(3u, out.size());
     lo.insert(1);

--- a/test/QueryPlannerTestHelpers.h
+++ b/test/QueryPlannerTestHelpers.h
@@ -585,8 +585,8 @@ class QueryPlannerWithMockFilterSubstitute : public QueryPlanner {
   using QueryPlanner::QueryPlanner;
 
   FiltersAndOptionalSubstitutes seedFilterSubstitutes(
-      const std::vector<SparqlFilter>& filters) override {
-    FiltersAndOptionalSubstitutes plans;
+      const qlever::vector<SparqlFilter>& filters) override {
+    FiltersAndOptionalSubstitutes plans{getQec()->getAllocator()};
     plans.reserve(filters.size());
 
     const auto equalTo =

--- a/test/SecondaryVocabularyTest.cpp
+++ b/test/SecondaryVocabularyTest.cpp
@@ -485,7 +485,8 @@ struct ContextWithSecondaryVocab {
   QueryResultCache cache_{};
   NamedResultCache namedResultCache_{};
   std::shared_ptr<MaterializedViewsManager> materializedViews_ =
-      std::make_shared<MaterializedViewsManager>();
+      std::make_shared<MaterializedViewsManager>(
+          ad_utility::testing::makeAllocator());
   QueryExecutionContext qec_;
 
   explicit ContextWithSecondaryVocab(std::string indexBasename)
@@ -520,7 +521,8 @@ std::string runQuery(QueryExecutionContext* qec, const std::string& query) {
   static const EncodedIriManager encodedIriManager;
   auto cancellationHandle =
       std::make_shared<ad_utility::CancellationHandle<>>();
-  auto parsedQuery = SparqlParser::parseQuery(&encodedIriManager, query);
+  auto parsedQuery = SparqlParser::parseQuery(&encodedIriManager, query, {},
+                                              qec->getAllocator());
   QueryPlanner queryPlanner{qec, cancellationHandle};
   auto executionTree = queryPlanner.createExecutionTree(parsedQuery);
   ad_utility::Timer timer{ad_utility::Timer::Started};
@@ -553,8 +555,9 @@ void runUpdate(ContextWithSecondaryVocab& context, const std::string& update) {
   auto cancellationHandle =
       std::make_shared<ad_utility::CancellationHandle<>>();
   ad_utility::BlankNodeManager blankNodeManager;
-  auto parsedQueries =
-      SparqlParser::parseUpdate(&blankNodeManager, &encodedIriManager, update);
+  auto parsedQueries = SparqlParser::parseUpdate(
+      &blankNodeManager, &encodedIriManager, update, {},
+      context.qec_.getAllocator());
   context.index_->deltaTriplesManager().modify<void>(
       [&context, &parsedQueries,
        &cancellationHandle](DeltaTriples& deltaTriples) {

--- a/test/ServerTest.cpp
+++ b/test/ServerTest.cpp
@@ -179,7 +179,8 @@ TEST(ServerTest, createResponseMetadata) {
   DeltaTriples deltaTriples{index};
   const std::string update = "INSERT DATA { <b> <c> <d> }";
   ad_utility::BlankNodeManager bnm;
-  auto pqs = SparqlParser::parseUpdate(&bnm, encodedIriManager(), update);
+  auto pqs = SparqlParser::parseUpdate(&bnm, encodedIriManager(), update, {},
+                                       qec->getAllocator());
   EXPECT_THAT(pqs, testing::SizeIs(1));
   ParsedQuery pq = std::move(pqs[0]);
   QueryPlanner qp(qec, handle);

--- a/test/ServiceTest.cpp
+++ b/test/ServiceTest.cpp
@@ -25,6 +25,7 @@
 #include "util/IdTableHelpers.h"
 #include "util/IndexTestHelpers.h"
 #include "util/OperationTestHelpers.h"
+#include "util/ParsedQueryTestHelpers.h"
 #include "util/RuntimeParametersTestHelpers.h"
 #include "util/TripleComponentTestHelpers.h"
 #include "util/http/HttpUtils.h"
@@ -409,15 +410,16 @@ TEST_F(ServiceTest, computeResult) {
     using TC = TripleComponent;
 
     auto sibling = std::make_shared<Values>(
-        testQec, (parsedQuery::SparqlValues){
-                     {Variable{"?x"}, Variable{"?y"}, Variable{"?z"}},
-                     {{TC(iri("<x>")), TC(iri("<y>")), TC(iri("<z>"))},
-                      {TC(iri("<x>")), TC(iri("<y>")), TC(iri("<z2>"))},
-                      {TC(iri("<blu>")), TC(iri("<bla>")), TC(iri("<blo>"))},
-                      // This row will be ignored in the created Values Clause
-                      // as it contains a blank node.
-                      {TC(Id::makeFromBlankNodeIndex(BlankNodeIndex::make(0))),
-                       TC(iri("<bl>")), TC(iri("<ank>"))}}});
+        testQec,
+        ad_utility::testing::makeSparqlValues(
+            {Variable{"?x"}, Variable{"?y"}, Variable{"?z"}},
+            {{TC(iri("<x>")), TC(iri("<y>")), TC(iri("<z>"))},
+             {TC(iri("<x>")), TC(iri("<y>")), TC(iri("<z2>"))},
+             {TC(iri("<blu>")), TC(iri("<bla>")), TC(iri("<blo>"))},
+             // This row will be ignored in the created Values Clause
+             // as it contains a blank node.
+             {TC(Id::makeFromBlankNodeIndex(BlankNodeIndex::make(0))),
+              TC(iri("<bl>")), TC(iri("<ank>"))}}));
 
     auto parsedServiceClause5 = parsedServiceClause;
     parsedServiceClause5.graphPatternAsString_ =
@@ -487,8 +489,8 @@ TEST_F(ServiceTest, computeResultWrapSubqueriesWithSibling) {
   using TC = TripleComponent;
 
   auto sibling = std::make_shared<Values>(
-      testQec,
-      (parsedQuery::SparqlValues){{Variable{"?a"}}, {{TC(iri("<a>"))}}});
+      testQec, ad_utility::testing::makeSparqlValues(
+                   {Variable{"?a"}}, {{TC(iri("<a>"))}}));
 
   parsedQuery::Service parsedServiceClause{
       {Variable{"?a"}},
@@ -864,9 +866,10 @@ TEST_F(ServiceTest, precomputeSiblingResult) {
   auto iri = ad_utility::testing::iri;
   using TC = TripleComponent;
   auto siblingOperation = std::make_shared<MockValues>(
-      testQec, parsedQuery::SparqlValues{{Variable{"?x"}, Variable{"?y"}},
-                                         {{TC(iri("<x>")), TC(iri("<y>"))},
-                                          {TC(iri("<z>")), TC(iri("<a>"))}}});
+      testQec, ad_utility::testing::makeSparqlValues(
+                   {Variable{"?x"}, Variable{"?y"}},
+                   {{TC(iri("<x>")), TC(iri("<y>"))},
+                    {TC(iri("<z>")), TC(iri("<a>"))}}));
   auto sibling = std::make_shared<Sort>(
       testQec, std::make_shared<QueryExecutionTree>(testQec, siblingOperation),
       std::vector<ColumnIndex>{});

--- a/test/SortTest.cpp
+++ b/test/SortTest.cpp
@@ -487,7 +487,8 @@ TEST(Sort, limitOffsetIsNotPropagatedForExplicitSort) {
   auto subtree = ad_utility::makeExecutionTree<ValuesForTesting>(
       qec, std::move(inputTable), vars);
 
-  auto tree = QueryExecutionTree::createSortedTree(subtree, {0}, true);
+  auto tree = QueryExecutionTree::createSortedTree(
+      subtree, qlever::vector<ColumnIndex>({0}, qec->getAllocator()), true);
   auto sort = std::dynamic_pointer_cast<Sort>(tree->getRootOperation());
   ASSERT_NE(sort, nullptr);
   EXPECT_EQ(sort->handlesLimitOffset(), LimitOffsetHandling::NONE);

--- a/test/SparqlExpressionMemberFunctionsTest.cpp
+++ b/test/SparqlExpressionMemberFunctionsTest.cpp
@@ -209,7 +209,7 @@ TEST(SparqlExpressionMemberFunctions, isDeterministic) {
 
   EXPECT_TRUE(NowDatetimeExpression{"2024-06-18T12:00:00"}.isDeterministic());
 
-  ParsedQuery pq;
+  ParsedQuery pq{ad_utility::testing::makeAllocator()};
   EXPECT_TRUE(ExistsExpression{pq}.isDeterministic());
 
   EXPECT_FALSE(makeUniqueBlankNodeExpression()->isDeterministic());

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -2310,7 +2310,7 @@ TEST(SingleUseExpression, simpleMembersForTestCoverage) {
 // `test/engine/ExistsJoinTest.cpp`.
 TEST(ExistsExpression, basicFunctionality) {
   using namespace ::testing;
-  ParsedQuery pq;
+  ParsedQuery pq{ad_utility::testing::makeAllocator()};
   pq.selectClause().addVisibleVariable(Variable{"?testVar42"});
   pq.selectClause().setAsterisk();
   ExistsExpression exists{std::move(pq)};

--- a/test/SparqlParserTest.cpp
+++ b/test/SparqlParserTest.cpp
@@ -26,6 +26,13 @@ auto lit = ad_utility::testing::tripleComponentLiteral;
 auto iri = ad_utility::testing::iri;
 auto iriV = ad_utility::testing::iriV;
 
+auto toChildren = [](std::vector<PropertyPath> children) {
+  return PropertyPath::ChildrenVec(
+      std::make_move_iterator(children.begin()),
+      std::make_move_iterator(children.end()),
+      qlever::makeUnlimitedAllocator<PropertyPath>());
+};
+
 const std::string& getIriString(
     const ad_utility::sparql_types::VarOrPath& varOrPath) {
   const auto& tripleComponent = std::get<PropertyPath>(varOrPath).getIri();
@@ -266,14 +273,14 @@ TEST(ParserTest, testParse) {
     const auto& values2 = std::get<p::Values>(pq.children()[1])._inlineValues;
 
     std::vector<Variable> vvars = {Var{"?a"}};
-    ASSERT_EQ(vvars, values1._variables);
+    ASSERT_EQ(ad_utility::testing::toQVec(vvars), values1._variables);
     std::vector<std::vector<TripleComponent>> vvals = {{iri("<1>")}, {2}};
-    ASSERT_EQ(vvals, values1._values);
+    ASSERT_EQ(ad_utility::testing::toQVecOfVec(vvals), values1._values);
 
     vvars = {Var{"?b"}, Var{"?c"}};
-    ASSERT_EQ(vvars, values2._variables);
+    ASSERT_EQ(ad_utility::testing::toQVec(vvars), values2._variables);
     vvals = {{iri("<1>"), iri("<2>")}, {1, 2}};
-    ASSERT_EQ(vvals, values2._values);
+    ASSERT_EQ(ad_utility::testing::toQVecOfVec(vvals), values2._values);
   }
 
   {
@@ -291,16 +298,16 @@ TEST(ParserTest, testParse) {
     const auto& values2 = std::get<p::Values>(pq.children()[1])._inlineValues;
 
     std::vector<Variable> vvars = {Var{"?a"}};
-    ASSERT_EQ(vvars, values1._variables);
+    ASSERT_EQ(ad_utility::testing::toQVec(vvars), values1._variables);
     std::vector<std::vector<TripleComponent>> vvals = {
         {iri("<Albert_Einstein>")}};
-    ASSERT_EQ(vvals, values1._values);
+    ASSERT_EQ(ad_utility::testing::toQVecOfVec(vvals), values1._values);
 
     vvars = {Var{"?b"}, Var{"?c"}};
-    ASSERT_EQ(vvars, values2._variables);
+    ASSERT_EQ(ad_utility::testing::toQVec(vvars), values2._variables);
     vvals = {{iri("<Marie_Curie>"), iri("<Joseph_Jacobson>")},
              {iri("<Freiherr>"), iri("<Lord_of_the_Isles>")}};
-    ASSERT_EQ(vvals, values2._values);
+    ASSERT_EQ(ad_utility::testing::toQVecOfVec(vvals), values2._values);
   }
 
   {
@@ -325,11 +332,11 @@ TEST(ParserTest, testParse) {
 
     const auto& values1 = std::get<p::Values>(pq.children()[0])._inlineValues;
     std::vector<Variable> vvars = {Var{"?citytype"}};
-    ASSERT_EQ(vvars, values1._variables);
+    ASSERT_EQ(ad_utility::testing::toQVec(vvars), values1._variables);
     std::vector<std::vector<TripleComponent>> vvals = {
         {iri("<http://www.wikidata.org/entity/Q515>")},
         {iri("<http://www.wikidata.org/entity/Q262166>")}};
-    ASSERT_EQ(vvals, values1._values);
+    ASSERT_EQ(ad_utility::testing::toQVecOfVec(vvals), values1._values);
   }
 
   // TODO @joaomarques90: Finish when the required functionalities
@@ -1243,13 +1250,13 @@ TEST(ParserTest, LanguageFilterPostProcessing) {
     // account for that.
     SparqlTriple variantA{
         Var{"?x"},
-        PropertyPath::makeAlternative(
-            {makeTaggedPath("<label>", "de"), makeTaggedPath("<label>", "en")}),
+        PropertyPath::makeAlternative(toChildren(
+            {makeTaggedPath("<label>", "de"), makeTaggedPath("<label>", "en")})),
         Var{"?y"}};
     SparqlTriple variantB{
         Var{"?x"},
-        PropertyPath::makeAlternative(
-            {makeTaggedPath("<label>", "en"), makeTaggedPath("<label>", "de")}),
+        PropertyPath::makeAlternative(toChildren(
+            {makeTaggedPath("<label>", "en"), makeTaggedPath("<label>", "de")})),
         Var{"?y"}};
     EXPECT_THAT(triples,
                 ::testing::ElementsAre(::testing::AnyOf(variantA, variantB)));
@@ -1265,13 +1272,13 @@ TEST(ParserTest, LanguageFilterPostProcessing) {
     // account for that.
     SparqlTriple variantA{
         Var{"?x"},
-        PropertyPath::makeAlternative(
-            {makeTaggedPath("<label>", "de"), makeTaggedPath("<label>", "en")}),
+        PropertyPath::makeAlternative(toChildren(
+            {makeTaggedPath("<label>", "de"), makeTaggedPath("<label>", "en")})),
         Var{"?y"}};
     SparqlTriple variantB{
         Var{"?x"},
-        PropertyPath::makeAlternative(
-            {makeTaggedPath("<label>", "en"), makeTaggedPath("<label>", "de")}),
+        PropertyPath::makeAlternative(toChildren(
+            {makeTaggedPath("<label>", "en"), makeTaggedPath("<label>", "de")})),
         Var{"?y"}};
     EXPECT_THAT(triples,
                 ::testing::ElementsAre(::testing::AnyOf(variantA, variantB)));
@@ -1603,7 +1610,8 @@ TEST(ParserTest, parseWithDatasets) {
       SparqlParser::parseUpdate(&bnm, &ev,
                                 "DELETE { ?x <b> <c> } USING <g> WHERE { ?x ?y "
                                 "?z FILTER EXISTS {?a ?b ?c} }",
-                                {{{iri("<h>"), false}}}),
+                                {{{iri("<h>"), false}}},
+                                ad_utility::testing::makeAllocator()),
       ::testing::HasSubstr("`USING [NAMED]` is disallowed"));
   // Same goes for `WITH`
   AD_EXPECT_THROW_WITH_MESSAGE(
@@ -1611,7 +1619,8 @@ TEST(ParserTest, parseWithDatasets) {
                                 "WITH <g> DELETE { ?x <b> <c> } WHERE { "
                                 "?x ?y ?z "
                                 "FILTER EXISTS {?a ?b ?c} }",
-                                {{{iri("<h>"), false}}}),
+                                {{{iri("<h>"), false}}},
+                                ad_utility::testing::makeAllocator()),
       ::testing::HasSubstr("`WITH` is disallowed"));
   EXPECT_THAT(
       parseQuery(
@@ -1649,7 +1658,8 @@ TEST(ParserTest, parseWithDatasets) {
       SparqlParser::parseUpdate(
           &bnm, &ev, "DELETE WHERE { ?s ?p ?o }; INSERT DATA { <a> <b> <c> }",
           {DatasetClause{iri("<foo>"), false},
-           DatasetClause{iri("<bar>"), true}}),
+           DatasetClause{iri("<bar>"), true}},
+          ad_utility::testing::makeAllocator()),
       testing::ElementsAre(
           m::UpdateClause(
               deleteWhereOp, deleteWherePattern,
@@ -1685,8 +1695,8 @@ TEST(ParserTest, ensureTypeIriDoesntViolateAssertion) {
           m::AsteriskSelect(),
           m::GraphPattern(m::Triples({SparqlTriple{
               TripleComponent{Variable{"?s"}},
-              PropertyPath::makeNegated({PropertyPath::fromIri(
-                  iri("<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>"))}),
+              PropertyPath::makeNegated(toChildren({PropertyPath::fromIri(
+                  iri("<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>"))})),
               TripleComponent{Variable{"?o"}}}}))));
 
   // Other tests for similar variants.
@@ -1696,8 +1706,8 @@ TEST(ParserTest, ensureTypeIriDoesntViolateAssertion) {
           m::AsteriskSelect(),
           m::GraphPattern(m::Triples({SparqlTriple{
               TripleComponent{Variable{"?s"}},
-              PropertyPath::makeNegated({PropertyPath::fromIri(
-                  iri("<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>"))}),
+              PropertyPath::makeNegated(toChildren({PropertyPath::fromIri(
+                  iri("<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>"))})),
               TripleComponent{Variable{"?o"}}}}))));
   EXPECT_THAT(
       parseQuery("SELECT * { ?s !^a ?o }"),
@@ -1705,8 +1715,9 @@ TEST(ParserTest, ensureTypeIriDoesntViolateAssertion) {
           m::AsteriskSelect(),
           m::GraphPattern(m::Triples({SparqlTriple{
               TripleComponent{Variable{"?s"}},
-              PropertyPath::makeNegated({PropertyPath::makeInverse(
+              PropertyPath::makeNegated(toChildren({PropertyPath::makeInverse(
                   PropertyPath::fromIri(iri("<http://www.w3.org/1999/02/"
-                                            "22-rdf-syntax-ns#type>")))}),
+                                            "22-rdf-syntax-ns#type>")),
+                  qlever::makeUnlimitedAllocator<PropertyPath>())})),
               TripleComponent{Variable{"?o"}}}}))));
 }

--- a/test/ValuesTest.cpp
+++ b/test/ValuesTest.cpp
@@ -14,12 +14,14 @@
 #include "engine/idTable/IdTable.h"
 #include "util/IndexTestHelpers.h"
 #include "util/OperationTestHelpers.h"
+#include "util/ParsedQueryTestHelpers.h"
 
 using TC = TripleComponent;
 using ValuesComponents = std::vector<std::vector<TripleComponent>>;
 
 namespace {
 auto iri = ad_utility::testing::iri;
+using ad_utility::testing::makeSparqlValues;
 }
 
 // Check the basic methods of the `Values` clause.
@@ -30,7 +32,9 @@ TEST(Values, basicMethods) {
                           {TC{7}, TC{42}, TC{3}},
                           {TC{7}, TC{42}, TC::UNDEF{}}};
   Values valuesOp(testQec,
-                  {{Variable{"?x"}, Variable{"?y"}, Variable{"?z"}}, values});
+                  makeSparqlValues(
+                      {Variable{"?x"}, Variable{"?y"}, Variable{"?z"}},
+                      values));
   EXPECT_FALSE(valuesOp.knownEmptyResult());
   EXPECT_EQ(valuesOp.getSizeEstimate(), 4u);
   EXPECT_EQ(valuesOp.getCostEstimate(), 4u);
@@ -58,7 +62,8 @@ TEST(Values, basicMethods) {
 // Check some corner cases for an empty VALUES clause.
 TEST(Values, emptyValuesClause) {
   auto testQec = ad_utility::testing::getQec();
-  Values emptyValuesOp(testQec, {});
+  Values emptyValuesOp(testQec,
+                       parsedQuery::SparqlValues{testQec->getAllocator()});
   EXPECT_TRUE(emptyValuesOp.knownEmptyResult());
   // The current implementation always returns `1.0` for nonexisting columns.
   EXPECT_FLOAT_EQ(emptyValuesOp.getMultiplicity(32), 1.0);
@@ -70,7 +75,9 @@ TEST(Values, computeResult) {
   auto testQec = ad_utility::testing::getQec("<x> <x> <x> .");
   ValuesComponents values{{TC{12}, TC{iri("<x>")}},
                           {TC::UNDEF{}, TC{iri("<y>")}}};
-  Values valuesOperation(testQec, {{Variable{"?x"}, Variable{"?y"}}, values});
+  Values valuesOperation(
+      testQec,
+      makeSparqlValues({Variable{"?x"}, Variable{"?y"}}, values));
   auto result = valuesOperation.getResult();
   const auto& table = result->idTableView();
   Id x = ad_utility::testing::makeGetId(testQec->getIndex())("<x>");
@@ -90,7 +97,8 @@ TEST(Values, computeResult) {
 TEST(Values, illegalInput) {
   auto qec = ad_utility::testing::getQec();
   ValuesComponents values{{TC{12}, TC{"<x>"}}, {TC::UNDEF{}}};
-  ASSERT_ANY_THROW(Values(qec, {{Variable{"?x"}, Variable{"?y"}}, values}));
+  ASSERT_ANY_THROW(Values(
+      qec, makeSparqlValues({Variable{"?x"}, Variable{"?y"}}, values)));
 }
 
 // _____________________________________________________________________________
@@ -98,7 +106,9 @@ TEST(Values, clone) {
   auto testQec = ad_utility::testing::getQec("<x> <x> <x> .");
   ValuesComponents values{{TC{12}, TC{iri("<x>")}},
                           {TC::UNDEF{}, TC{iri("<y>")}}};
-  Values valuesOperation(testQec, {{Variable{"?x"}, Variable{"?y"}}, values});
+  Values valuesOperation(
+      testQec,
+      makeSparqlValues({Variable{"?x"}, Variable{"?y"}}, values));
 
   auto clone = valuesOperation.clone();
   ASSERT_TRUE(clone);

--- a/test/VariableToColumnMapTest.cpp
+++ b/test/VariableToColumnMapTest.cpp
@@ -9,6 +9,9 @@
 #include "gtest/gtest.h"
 #include "util/Serializer/ByteBufferSerializer.h"
 
+#include <array>
+#include <vector>
+
 class VariableToColumnMapTest : public ::testing::TestWithParam<bool> {};
 
 // In the right input there are three columns (0, 3, 4) which are not
@@ -25,8 +28,9 @@ TEST_P(VariableToColumnMapTest, gapsInRightCols) {
   rightCols[V{"?a"}] = makePossiblyUndefinedColumn(2);
   rightCols[V{"?b"}] = makeAlwaysDefinedColumn(5);
 
+  std::vector<std::array<ColumnIndex, 2>> jcs{{0, 1}};
   auto joinCols = makeVarToColMapForJoinOperation(
-      leftCols, rightCols, {{0, 1}}, BinOpType::Join, 2, keepJoinCols);
+      leftCols, rightCols, jcs, BinOpType::Join, 2, keepJoinCols);
   VariableToColumnMap expected;
   if (keepJoinCols) {
     expected[V{"?x"}] = makeAlwaysDefinedColumn(0);
@@ -52,8 +56,9 @@ TEST_P(VariableToColumnMapTest, gapsInLeftCols) {
   rightCols[V{"?x"}] = makePossiblyUndefinedColumn(0);
   rightCols[V{"?a"}] = makeAlwaysDefinedColumn(1);
 
+  std::vector<std::array<ColumnIndex, 2>> jcs{{2, 0}};
   auto joinCols = makeVarToColMapForJoinOperation(
-      leftCols, rightCols, {{2, 0}}, BinOpType::Join, 4, keepJoinCols);
+      leftCols, rightCols, jcs, BinOpType::Join, 4, keepJoinCols);
   VariableToColumnMap expected;
   if (keepJoinCols) {
     expected[V{"?x"}] = makeAlwaysDefinedColumn(2);
@@ -79,8 +84,9 @@ TEST_P(VariableToColumnMapTest, mixedJoinAndNonJoinColumns) {
   rightCols[V{"?y"}] = makeAlwaysDefinedColumn(1);
   rightCols[V{"?c"}] = makeAlwaysDefinedColumn(2);
 
+  std::vector<std::array<ColumnIndex, 2>> jcs{{2, 0}, {0, 1}};
   auto joinCols = makeVarToColMapForJoinOperation(
-      leftCols, rightCols, {{2, 0}, {0, 1}}, BinOpType::Join, 4, keepJoinCols);
+      leftCols, rightCols, jcs, BinOpType::Join, 4, keepJoinCols);
   VariableToColumnMap expected;
   if (keepJoinCols) {
     expected[V{"?y"}] = makeAlwaysDefinedColumn(0);
@@ -113,8 +119,9 @@ TEST_P(VariableToColumnMapTest, undefinedJoinColumn) {
   rightCols[V{"?y"}] = makeAlwaysDefinedColumn(2);
   rightCols[V{"?z"}] = makePossiblyUndefinedColumn(1);
 
+  std::vector<std::array<ColumnIndex, 2>> jcs{{0, 0}, {1, 2}, {2, 1}};
   auto joinCols = makeVarToColMapForJoinOperation(
-      leftCols, rightCols, {{0, 0}, {1, 2}, {2, 1}}, BinOpType::Join, 3,
+      leftCols, rightCols, jcs, BinOpType::Join, 3,
       keepJoinCols);
   VariableToColumnMap expected;
   if (keepJoinCols) {
@@ -139,8 +146,9 @@ TEST_P(VariableToColumnMapTest, optionalJoin) {
   rightCols[V{"?y"}] = makeAlwaysDefinedColumn(2);
   rightCols[V{"?a"}] = makeAlwaysDefinedColumn(1);
 
+  std::vector<std::array<ColumnIndex, 2>> jcs{{0, 0}, {1, 2}};
   auto joinCols =
-      makeVarToColMapForJoinOperation(leftCols, rightCols, {{0, 0}, {1, 2}},
+      makeVarToColMapForJoinOperation(leftCols, rightCols, jcs,
                                       BinOpType::OptionalJoin, 2, keepJoinCols);
   VariableToColumnMap expected;
   if (keepJoinCols) {

--- a/test/engine/CartesianProductJoinTest.cpp
+++ b/test/engine/CartesianProductJoinTest.cpp
@@ -813,7 +813,7 @@ TEST(CartesianProductJoin, recomputationIsPreventedAfterApplyingLimit) {
 // _____________________________________________________________________________
 TEST(CartesianProductJoin, distinctIsPushedDownIntoChildren) {
   using Vars = std::vector<std::optional<Variable>>;
-  using SC = std::vector<ColumnIndex>;
+  using SC = qlever::vector<ColumnIndex>;
   auto qec = getQec();
 
   auto left = ad_utility::makeExecutionTree<ValuesForTesting>(
@@ -826,7 +826,8 @@ TEST(CartesianProductJoin, distinctIsPushedDownIntoChildren) {
   // A `DISTINCT` over all columns is pushed into the children: the root stays a
   // `CartesianProductJoin`, each child is made distinct, and no `Distinct` is
   // added on top.
-  auto tree = QueryExecutionTree::createDistinctTree(cartesian, SC{0, 1});
+  auto tree = QueryExecutionTree::createDistinctTree(
+      cartesian, SC({0, 1}, qec->getAllocator()));
   ASSERT_TRUE(std::dynamic_pointer_cast<CartesianProductJoin>(
       tree->getRootOperation()));
   for (auto* child : tree->getRootOperation()->getChildren()) {
@@ -842,7 +843,7 @@ TEST(CartesianProductJoin, distinctIsPushedDownIntoChildren) {
 // _____________________________________________________________________________
 TEST(CartesianProductJoin, distinctIsNoOpWhenChildrenAlreadyDistinct) {
   using TC = TripleComponent;
-  using SC = std::vector<ColumnIndex>;
+  using SC = qlever::vector<ColumnIndex>;
   auto qec = getQec();
 
   // Each full index scan is distinct over its own three columns, so the
@@ -861,12 +862,14 @@ TEST(CartesianProductJoin, distinctIsNoOpWhenChildrenAlreadyDistinct) {
 
   // `DISTINCT *` is a no-op and returns the tree unchanged.
   EXPECT_EQ(
-      QueryExecutionTree::createDistinctTree(cartesian, SC{0, 1, 2, 3, 4, 5}),
+      QueryExecutionTree::createDistinctTree(
+          cartesian, SC({0, 1, 2, 3, 4, 5}, qec->getAllocator())),
       cartesian);
 
   // If only some columns are covered, the product is not distinct, so the
   // `DISTINCT` is pushed down (the root stays a `CartesianProductJoin`).
-  auto tree = QueryExecutionTree::createDistinctTree(cartesian, SC{0, 1, 2});
+  auto tree = QueryExecutionTree::createDistinctTree(
+      cartesian, SC({0, 1, 2}, qec->getAllocator()));
   EXPECT_NE(tree, cartesian);
   EXPECT_TRUE(std::dynamic_pointer_cast<CartesianProductJoin>(
       tree->getRootOperation()));
@@ -875,7 +878,7 @@ TEST(CartesianProductJoin, distinctIsNoOpWhenChildrenAlreadyDistinct) {
 // _____________________________________________________________________________
 TEST(CartesianProductJoin, distinctCollapsesChildWithoutSelectedColumn) {
   using Vars = std::vector<std::optional<Variable>>;
-  using SC = std::vector<ColumnIndex>;
+  using SC = qlever::vector<ColumnIndex>;
   auto qec = getQec();
 
   auto left = ad_utility::makeExecutionTree<ValuesForTesting>(
@@ -888,7 +891,8 @@ TEST(CartesianProductJoin, distinctCollapsesChildWithoutSelectedColumn) {
   // Only `?a` is selected, so the `?b` child contributes no column. It is
   // collapsed to a single row via `LIMIT 1`, while the `?a` child is made
   // distinct; no `Distinct` is added on top.
-  SC distinctIndices{cartesian->getVariableColumn(Variable{"?a"})};
+  SC distinctIndices({cartesian->getVariableColumn(Variable{"?a"})},
+                     qec->getAllocator());
   auto tree =
       QueryExecutionTree::createDistinctTree(cartesian, distinctIndices);
   auto cpj =

--- a/test/engine/DescribeTest.cpp
+++ b/test/engine/DescribeTest.cpp
@@ -38,7 +38,8 @@ TEST(Describe, recursiveBlankNodes) {
       "_:g2 <p>  <o4> ."
       "<s2> <p>   <o> ."
       "_:g4 <p>  _:g5 .");
-  parsedQuery::Describe parsedDescribe;
+  parsedQuery::Describe parsedDescribe{
+      {}, {}, parsedQuery::Subquery{qec->getAllocator()}};
   parsedDescribe.resources_.push_back(TripleComponent::Iri::fromIriref("<s>"));
   Describe describe{qec,
                     ad_utility::makeExecutionTree<NeutralElementOperation>(qec),
@@ -77,7 +78,8 @@ TEST(Describe, describeWithVariable) {
       "<s4> <p2> <o2> .");
 
   // On the above knowledge graph, evaluate `DESCRIBE <s4> ?x { ?x <p> <o> }`.
-  parsedQuery::Describe parsedDescribe;
+  parsedQuery::Describe parsedDescribe{
+      {}, {}, parsedQuery::Subquery{qec->getAllocator()}};
   parsedDescribe.resources_.push_back(TripleComponent::Iri::fromIriref("<s4>"));
   parsedDescribe.resources_.push_back(Variable{"?x"});
   SparqlTripleSimple triple{Variable{"?x"},
@@ -114,7 +116,8 @@ TEST(Describe, describeWithVariable) {
 // return an empty result).
 TEST(Describe, describeWithVariableButNoWhereClause) {
   auto qec = getQec("<s> <p> <o>");
-  parsedQuery::Describe parsedDescribe;
+  parsedQuery::Describe parsedDescribe{
+      {}, {}, parsedQuery::Subquery{qec->getAllocator()}};
   parsedDescribe.resources_.push_back(Variable{"?x"});
   auto noWhere = ad_utility::makeExecutionTree<NeutralElementOperation>(qec);
   Describe describe{qec, noWhere, parsedDescribe};
@@ -137,7 +140,8 @@ TEST(Describe, simpleMembers) {
       "_:g2 <p>  <o4> ."
       "<s2> <p>   <o> ."
       "_:g4 <p>  _:g5 .");
-  parsedQuery::Describe parsedDescribe;
+  parsedQuery::Describe parsedDescribe{
+      {}, {}, parsedQuery::Subquery{qec->getAllocator()}};
   parsedDescribe.resources_.push_back(TripleComponent::Iri::fromIriref("<s>"));
   Describe describe{qec,
                     ad_utility::makeExecutionTree<NeutralElementOperation>(qec),
@@ -184,7 +188,8 @@ TEST(Describe, simpleMembers) {
 // _____________________________________________________________________________
 TEST(Describe, clone) {
   auto qec = getQec();
-  parsedQuery::Describe parsedDescribe;
+  parsedQuery::Describe parsedDescribe{
+      {}, {}, parsedQuery::Subquery{qec->getAllocator()}};
   parsedDescribe.resources_.push_back(TripleComponent::Iri::fromIriref("<s>"));
   Describe describe{qec,
                     ad_utility::makeExecutionTree<NeutralElementOperation>(qec),

--- a/test/engine/ExistsJoinTest.cpp
+++ b/test/engine/ExistsJoinTest.cpp
@@ -837,7 +837,7 @@ TEST(ExistsJoin, addExistsJoinsToSubtreeDoesntCollideForHiddenVariables) {
       qec, makeIdTableFromVector({{0, 1}}),
       std::vector<std::optional<Variable>>{Variable{"?a"}, Variable{"?b"}});
 
-  ParsedQuery query;
+  ParsedQuery query{qec->getAllocator()};
   query._rootGraphPattern._graphPatterns.push_back(
       parsedQuery::BasicGraphPattern{
           {SparqlTriple{TripleComponent{Variable{"?a"}}, iri("<something>"),
@@ -871,7 +871,7 @@ TEST(ExistsJoin, cacheKeyDiffersForDifferentJoinColumns) {
       qec, makeIdTableFromVector({{0, 1}}),
       std::vector<std::optional<Variable>>{Variable{"?a"}, Variable{"?b"}});
 
-  ParsedQuery query;
+  ParsedQuery query{qec->getAllocator()};
   query._rootGraphPattern._graphPatterns.push_back(
       parsedQuery::BasicGraphPattern{
           {SparqlTriple{TripleComponent{Variable{"?a"}}, iri("<something>"),

--- a/test/engine/IndexScanTest.cpp
+++ b/test/engine/IndexScanTest.cpp
@@ -15,6 +15,7 @@
 #include "../util/GTestHelpers.h"
 #include "../util/IdTableHelpers.h"
 #include "../util/IndexTestHelpers.h"
+#include "../util/ParsedQueryTestHelpers.h"
 #include "../util/TripleComponentTestHelpers.h"
 #include "./LazyJoinTestHelpers.h"
 #include "engine/IndexScan.h"
@@ -578,7 +579,8 @@ TEST(IndexScan, getResultSizeOfScanWithDeltaTriples) {
 
   QueryResultCache cache;
   NamedResultCache namedCache;
-  auto materializedViewsManager = std::make_shared<MaterializedViewsManager>();
+  auto materializedViewsManager =
+      std::make_shared<MaterializedViewsManager>(makeAllocator());
   std::unique_ptr<QueryExecutionContext> qec = nullptr;
 
   auto makeScan = [&]() {
@@ -1499,7 +1501,9 @@ TEST(IndexScan, columnOriginatesFromGraphOrUndef) {
   IndexScan scan2{
       qec, Permutation::PSO,
       SparqlTripleSimple{
-          Var{"?x"}, Var{"?y"}, Var{"?z"}, {std::pair{3, Var{"?g"}}}}};
+          Var{"?x"}, Var{"?y"}, Var{"?z"},
+          toQVec(std::vector<std::pair<ColumnIndex, Variable>>{
+              {3, Var{"?g"}}})}};
   EXPECT_TRUE(scan2.columnOriginatesFromGraphOrUndef(Var{"?x"}));
   EXPECT_FALSE(scan2.columnOriginatesFromGraphOrUndef(Var{"?y"}));
   EXPECT_TRUE(scan2.columnOriginatesFromGraphOrUndef(Var{"?z"}));
@@ -2240,7 +2244,9 @@ TEST(IndexScan, additionalVariablesInDescriptor) {
   IndexScan scan2{
       qec, Permutation::PSO,
       SparqlTripleSimple{
-          Var{"?s"}, Var{"?p"}, Var{"?o"}, {std::pair{3, Var{"?g"}}}}};
+          Var{"?s"}, Var{"?p"}, Var{"?o"},
+          toQVec(std::vector<std::pair<ColumnIndex, Variable>>{
+              {3, Var{"?g"}}})}};
   EXPECT_EQ(scan2.getDescriptor(), "IndexScan PSO ?s ?p ?o ?g");
 }
 
@@ -2276,12 +2282,12 @@ TEST(IndexScan, isDistinctBy) {
   // and therefore need not be covered.
   auto scanWithAdditionalColumns = ad_utility::makeExecutionTree<IndexScan>(
       qec, Permutation::Enum::PSO,
-      SparqlTripleSimple{TC{Variable{"?s"}},
-                         TC{Variable{"?p"}},
-                         TC{Variable{"?o"}},
-                         {std::pair{ADDITIONAL_COLUMN_GRAPH_ID, Variable{"?g"}},
-                          std::pair{ADDITIONAL_COLUMN_INDEX_SUBJECT_PATTERN,
-                                    Variable{"?pattern"}}}});
+      SparqlTripleSimple{
+          TC{Variable{"?s"}}, TC{Variable{"?p"}}, TC{Variable{"?o"}},
+          toQVec(std::vector<std::pair<ColumnIndex, Variable>>{
+              {ADDITIONAL_COLUMN_GRAPH_ID, Variable{"?g"}},
+              {ADDITIONAL_COLUMN_INDEX_SUBJECT_PATTERN,
+               Variable{"?pattern"}}})});
   // The columns are `?s`, `?p`, `?o`, `?g`, `?pattern` in this order.
   const auto& scanWithColumnsOp =
       *scanWithAdditionalColumns->getRootOperation();

--- a/test/engine/QueryExecutionTreeTest.cpp
+++ b/test/engine/QueryExecutionTreeTest.cpp
@@ -44,7 +44,8 @@ TEST(QueryExecutionTree, sortedUnionSpecialCase) {
       qec, makeIdTableFromVector({{0}}), Vars{Var{"?a"}});
 
   auto sortedTree = QueryExecutionTree::createSortedTree(
-      ad_utility::makeExecutionTree<Union>(qec, leftT, rightT), {0});
+      ad_utility::makeExecutionTree<Union>(qec, leftT, rightT),
+      qlever::vector<ColumnIndex>({0}, qec->getAllocator()));
 
   // Ensure no `Sort` is added on top
   EXPECT_TRUE(std::dynamic_pointer_cast<Union>(sortedTree->getRootOperation()));
@@ -97,7 +98,7 @@ TEST(QueryExecutionTree, createSortedTreeAnyPermutation) {
 // _____________________________________________________________________________
 TEST(QueryExecutionTree, createDistinctTreeReturnsInputWhenAlreadyDistinct) {
   using Vars = std::vector<std::optional<Variable>>;
-  using SC = std::vector<ColumnIndex>;
+  using SC = qlever::vector<ColumnIndex>;
   auto* qec = getQec();
 
   // When the root operation is already distinct wrt `distinctIndices`, the
@@ -107,14 +108,18 @@ TEST(QueryExecutionTree, createDistinctTreeReturnsInputWhenAlreadyDistinct) {
       qec, makeIdTableFromVector({{0}, {1}}), Vars{Variable{"?x"}});
   values->applyLimitOffset(LimitOffsetClause{._limit = 1});
 
-  EXPECT_EQ(QueryExecutionTree::createDistinctTree(values, SC{0}), values);
-  EXPECT_EQ(QueryExecutionTree::createDistinctTree(values, SC{}), values);
+  EXPECT_EQ(QueryExecutionTree::createDistinctTree(
+                values, SC({0}, qec->getAllocator())),
+            values);
+  EXPECT_EQ(QueryExecutionTree::createDistinctTree(values,
+                                                   SC(qec->getAllocator())),
+            values);
 }
 
 // _____________________________________________________________________________
 TEST(QueryExecutionTree, createDistinctTreeFallbackAddsDistinct) {
   using Vars = std::vector<std::optional<Variable>>;
-  using SC = std::vector<ColumnIndex>;
+  using SC = qlever::vector<ColumnIndex>;
   auto* qec = getQec();
 
   // A generic operation that is not known to be distinct (and cannot push the
@@ -123,16 +128,18 @@ TEST(QueryExecutionTree, createDistinctTreeFallbackAddsDistinct) {
       qec, makeIdTableFromVector({{0, 1}, {0, 1}, {2, 3}}),
       Vars{Variable{"?x"}, Variable{"?y"}});
 
-  auto tree = QueryExecutionTree::createDistinctTree(values, SC{0, 1});
+  auto tree = QueryExecutionTree::createDistinctTree(
+      values, SC({0, 1}, qec->getAllocator()));
   auto distinct = std::dynamic_pointer_cast<Distinct>(tree->getRootOperation());
   ASSERT_TRUE(distinct);
-  EXPECT_EQ(distinct->getDistinctColumns(), (SC{0, 1}));
+  // `Distinct::getDistinctColumns()` returns a plain `std::vector`, not `SC`.
+  EXPECT_EQ(distinct->getDistinctColumns(), (std::vector<ColumnIndex>{0, 1}));
 }
 
 // _____________________________________________________________________________
 TEST(QueryExecutionTree, createDistinctTreeEmptyIndicesUsesLimitOne) {
   using Vars = std::vector<std::optional<Variable>>;
-  using SC = std::vector<ColumnIndex>;
+  using SC = qlever::vector<ColumnIndex>;
   auto* qec = getQec();
 
   auto values = ad_utility::makeExecutionTree<ValuesForTesting>(
@@ -140,7 +147,8 @@ TEST(QueryExecutionTree, createDistinctTreeEmptyIndicesUsesLimitOne) {
 
   // `DISTINCT` over zero columns keeps at most one row and is realized as a
   // `LIMIT 1`, not as a `Distinct`.
-  auto tree = QueryExecutionTree::createDistinctTree(values, SC{});
+  auto tree = QueryExecutionTree::createDistinctTree(values,
+                                                     SC(qec->getAllocator()));
   EXPECT_FALSE(std::dynamic_pointer_cast<Distinct>(tree->getRootOperation()));
   EXPECT_EQ(tree->getRootOperation()->getLimitOffset()._limit, 1u);
 
@@ -211,7 +219,8 @@ TEST(QueryExecutionTree, limitAndOffsetIsPropagatedWhenCreatingSortedTree) {
   auto unionTree = ad_utility::makeExecutionTree<Union>(qec, leftT, rightT);
   unionTree->applyLimitOffset(limitOffset);
 
-  auto sortedTree = QueryExecutionTree::createSortedTree(unionTree, {0});
+  auto sortedTree = QueryExecutionTree::createSortedTree(
+      unionTree, qlever::vector<ColumnIndex>({0}, qec->getAllocator()));
   ASSERT_TRUE(std::dynamic_pointer_cast<Union>(sortedTree->getRootOperation()));
   EXPECT_EQ(sortedTree->getRootOperation()->getLimitOffset(), limitOffset);
 
@@ -221,8 +230,8 @@ TEST(QueryExecutionTree, limitAndOffsetIsPropagatedWhenCreatingSortedTree) {
       qec, makeIdTableFromVector({{1}, {0}}), Vars{Var{"?a"}});
   valuesForTesting->applyLimitOffset(limitOffset);
 
-  auto sortedValues =
-      QueryExecutionTree::createSortedTree(valuesForTesting, {0});
+  auto sortedValues = QueryExecutionTree::createSortedTree(
+      valuesForTesting, qlever::vector<ColumnIndex>({0}, qec->getAllocator()));
   ASSERT_TRUE(
       std::dynamic_pointer_cast<Sort>(sortedValues->getRootOperation()));
   EXPECT_TRUE(

--- a/test/engine/SpatialJoinAlgorithmsTest.cpp
+++ b/test/engine/SpatialJoinAlgorithmsTest.cpp
@@ -15,6 +15,7 @@
 #include <thread>
 #include <variant>
 
+#include "../util/AllocatorTestHelpers.h"
 #include "../util/GTestHelpers.h"
 #include "../util/IndexTestHelpers.h"
 #include "../util/RuntimeParametersTestHelpers.h"
@@ -1075,7 +1076,7 @@ void testBoundingBox(const size_t& maxDistInMeters, const Point& startPoint) {
   // bounding box, is really more than 'maxDistanceInMeters' away from
   // 'startPoint'
   auto checkOutside = [&](const Point& point1, const Point& startPoint,
-                          const std::vector<Box>& bbox,
+                          const qlever::vector<Box>& bbox,
                           BoundingBoxAlgorithm* spatialJoinAlg) {
     // check if the point is contained in any bounding box
     bool within = spatialJoinAlg->isContainedInBoundingBoxes(bbox, point1);
@@ -1090,7 +1091,8 @@ void testBoundingBox(const size_t& maxDistInMeters, const Point& startPoint) {
   BoundingBoxAlgorithm spatialJoinAlgs =
       getDummySpatialJoinAlgsForWrapperTesting(maxDistInMeters);
 
-  std::vector<Box> bbox = spatialJoinAlgs.computeQueryBox(startPoint);
+  std::vector<Box, qlever::Allocator<Box>> bbox =
+      spatialJoinAlgs.computeQueryBox(startPoint);
   // broad grid test
   for (int lon = -180; lon < 180; lon += 20) {
     for (int lat = -90; lat < 90; lat += 20) {
@@ -1169,13 +1171,13 @@ TEST(SpatialJoin, isContainedInBoundingBoxes) {
   // note that none of the boxes is overlapping, therefore we can check, that
   // none of the points which should be contained in one box are contained in
   // another box
-  std::vector<Box> boxes = {
-      Box(Point(20, 40), Point(40, 60)),
-      Box(Point(-180, -20), Point(-150, 30)),  // touching left border
-      Box(Point(50, -30), Point(180, 10)),     // touching right border
-      Box(Point(-30, 50), Point(10, 90)),      // touching north pole
-      Box(Point(-45, -90), Point(0, -45))      // touching south pole
-  };
+  std::vector<Box, qlever::Allocator<Box>> boxes{
+      {Box(Point(20, 40), Point(40, 60)),
+       Box(Point(-180, -20), Point(-150, 30)),  // touching left border
+       Box(Point(50, -30), Point(180, 10)),     // touching right border
+       Box(Point(-30, 50), Point(10, 90)),      // touching north pole
+       Box(Point(-45, -90), Point(0, -45))},    // touching south pole
+      ad_utility::testing::makeAllocator()};
 
   // the first entry in this vector is a vector of points, which is contained
   // in the first box, the second entry contains points, which are contained in
@@ -1204,7 +1206,8 @@ TEST(SpatialJoin, isContainedInBoundingBoxes) {
       for (size_t c = 0; a <= 1; a++) {
         for (size_t d = 0; a <= 1; a++) {
           for (size_t e = 0; a <= 1; a++) {
-            std::vector<Box> toTest;  // the set of bounding boxes
+            std::vector<Box, qlever::Allocator<Box>> toTest{
+                ad_utility::testing::makeAllocator()};  // the set of bounding boxes
             std::vector<std::vector<Point>> shouldBeContained;
             std::vector<std::vector<Point>> shouldNotBeContained;
             if (a == 1) {  // box nr. 0 is contained in the set of boxes

--- a/test/engine/SpatialJoinTest.cpp
+++ b/test/engine/SpatialJoinTest.cpp
@@ -20,6 +20,7 @@
 #include "../util/GTestHelpers.h"
 #include "../util/IdTableHelpers.h"
 #include "../util/IndexTestHelpers.h"
+#include "../util/ParsedQueryTestHelpers.h"
 #include "./SpatialJoinTestHelpers.h"
 #include "./ValuesForTesting.h"
 #include "engine/ExportQueryExecutionTrees.h"
@@ -241,11 +242,13 @@ std::shared_ptr<SpatialJoin> makeSpatialJoinFromValues(
       &encodedIriManager,
       "PREFIX geo: <http://www.opengis.net/ont/geosparql#>\nSELECT ?a {VALUES "
       "(?a) {(\"POLYGON((8.529 47.375, 8.549 47.375, 8.549 47.395, 8.529 "
-      "47.395, 8.529 47.375))\"^^geo:wktLiteral) (\"garbage\") (5) (<>)}}");
+      "47.395, 8.529 47.375))\"^^geo:wktLiteral) (\"garbage\") (5) (<>)}}",
+      {}, qec->getAllocator());
   auto pqRight = SparqlParser::parseQuery(
       &encodedIriManager,
       "PREFIX geo: <http://www.opengis.net/ont/geosparql#>\nSELECT ?b {VALUES "
-      "(?b) {(\"POINT(8.542 47.385)\"^^geo:wktLiteral)}}");
+      "(?b) {(\"POINT(8.542 47.385)\"^^geo:wktLiteral)}}",
+      {}, qec->getAllocator());
   QueryPlanner qp{qec, sharedHandle};
 
   auto leftChild =
@@ -579,7 +582,8 @@ class SpatialJoinVarColParamTest
             // Test the regular and valid payloadVars
             auto exp = makeExpected(leftSideBigChild, rightSideBigChild,
                                     addDist, withObj, withName, withGeo);
-            computeAndCompareVarToColMaps(addDist, payloadVars, exp);
+            computeAndCompareVarToColMaps(
+                addDist, PayloadVariables{toQVec(payloadVars)}, exp);
 
             // Also test the PayloadAllVariables version
             if (withGeo && withObj && (withName || !rightSideBigChild)) {
@@ -591,33 +595,35 @@ class SpatialJoinVarColParamTest
             if (withObj) {
               payloadVars.push_back(Variable{"?obj2"});
               // Variable ?obj2 is now contained twice
-              computeAndCompareVarToColMaps(addDist, payloadVars, exp);
+              computeAndCompareVarToColMaps(
+                  addDist, PayloadVariables{toQVec(payloadVars)}, exp);
               payloadVars.pop_back();
             }
 
             // Test contained right variable in payloadVars
             payloadVars.push_back(Variable{"?point2"});
-            computeAndCompareVarToColMaps(addDist, payloadVars, exp);
+            computeAndCompareVarToColMaps(
+                addDist, PayloadVariables{toQVec(payloadVars)}, exp);
             payloadVars.pop_back();
 
             // Test warnings for unbound variables
             payloadVars.push_back(Variable{"?point1"});
             computeAndCompareVarToColMaps(
-                addDist, payloadVars, exp,
+                addDist, PayloadVariables{toQVec(payloadVars)}, exp,
                 "Variable '?point1' selected as payload to "
                 "spatial join but not present in right child");
             payloadVars.pop_back();
 
             payloadVars.push_back(Variable{"?obj1"});
             computeAndCompareVarToColMaps(
-                addDist, payloadVars, exp,
+                addDist, PayloadVariables{toQVec(payloadVars)}, exp,
                 "Variable '?obj1' selected as payload to "
                 "spatial join but not present in right child");
             payloadVars.pop_back();
 
             payloadVars.push_back(Variable{"?isThereSomebodyHere"});
             computeAndCompareVarToColMaps(
-                addDist, payloadVars, exp,
+                addDist, PayloadVariables{toQVec(payloadVars)}, exp,
                 "Variable '?isThereSomebodyHere' selected as payload to "
                 "spatial join but not present in right child");
             payloadVars.pop_back();
@@ -626,7 +632,7 @@ class SpatialJoinVarColParamTest
             if (addDist) {
               payloadVars.push_back(distVar);
               computeAndCompareVarToColMaps(
-                  addDist, payloadVars, exp,
+                  addDist, PayloadVariables{toQVec(payloadVars)}, exp,
                   "Variable '?distOfTheTwoObjectsAddedInternally' selected "
                   "as payload to spatial join but not present in right "
                   "child");
@@ -701,7 +707,8 @@ TEST(SpatialJoinVarColTest, ChildResultWidth) {
       qec,
       SpatialJoinConfiguration{
           LibSpatialJoinConfig{SpatialJoinType::INTERSECTS}, Variable{"?a"},
-          Variable{"?c"}, std::nullopt, PayloadVariables{{V{"?c"}}},
+          Variable{"?c"}, std::nullopt,
+          PayloadVariables{toQVec(std::vector<V>{V{"?c"}})},
           SpatialJoinAlgorithm::LIBSPATIALJOIN},
       qet1, qet2);
 

--- a/test/engine/SpatialJoinTestHelpers.h
+++ b/test/engine/SpatialJoinTestHelpers.h
@@ -529,8 +529,10 @@ inline BoundingBoxAlgorithm getDummySpatialJoinAlgsForWrapperTesting(
                                    nullptr,
                                    0,
                                    0,
-                                   std::vector<ColumnIndex>{},
-                                   std::vector<ColumnIndex>{},
+                                   qlever::vector<ColumnIndex>{
+                                       qec.value()->getAllocator()},
+                                   qlever::vector<ColumnIndex>{
+                                       qec.value()->getAllocator()},
                                    1};
 
   return {qec.value(), params, spatialJoin->onlyForTestingGetConfig()};

--- a/test/index/IndexFormatConverterTest.cpp
+++ b/test/index/IndexFormatConverterTest.cpp
@@ -367,14 +367,17 @@ TEST_F(IndexFormatConverterTest, convertedMaterializedView) {
   // The version of the on-disk format of the materialized views was raised
   // together with the index format, so the view of the index in the previous
   // format cannot be loaded.
-  AD_EXPECT_THROW_WITH_MESSAGE(MaterializedView(oldBasename_, "testview"),
-                               HasSubstr("saved with format version 1"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      MaterializedView(oldBasename_, "testview",
+                       ad_utility::testing::makeAllocator()),
+      HasSubstr("saved with format version 1"));
 
   convertIndexToCurrentFormat(oldBasename_, newBasename_);
 
   // The converted view can be loaded, which also checks its version, its
   // columns, and its query, and it contains all its rows.
-  MaterializedView view{newBasename_, "testview"};
+  MaterializedView view{newBasename_, "testview",
+                       ad_utility::testing::makeAllocator()};
   EXPECT_EQ(view.permutation()->metaData().totalElements(), 6);
   EXPECT_THAT(view.originalQuery(),
               ::testing::Optional(HasSubstr("<http://example.org/label>")));

--- a/test/joinAlgorithms/JoinColumnMappingTest.cpp
+++ b/test/joinAlgorithms/JoinColumnMappingTest.cpp
@@ -7,6 +7,9 @@
 
 #include <gmock/gmock.h>
 
+#include <array>
+#include <vector>
+
 #include "util/JoinAlgorithms/JoinColumnMapping.h"
 
 using ad_utility::JoinColumnMapping;
@@ -18,7 +21,8 @@ class JoinColumnMappingTest : public ::testing::TestWithParam<bool> {};
 // _____________________________________________________________________________
 TEST_P(JoinColumnMappingTest, SingleJoinColAtBeginningOfLeft) {
   bool keepJoinCols = GetParam();
-  JoinColumnMapping m{{{0, 2}}, 2, 3, keepJoinCols};
+  std::vector<std::array<ColumnIndex, 2>> jcs{{0, 2}};
+  JoinColumnMapping m{jcs, 2, 3, keepJoinCols};
   EXPECT_THAT(m.jcsLeft(), ElementsAre(0));
   EXPECT_THAT(m.jcsRight(), ElementsAre(2));
   EXPECT_THAT(m.permutationLeft(), ElementsAre(0, 1));
@@ -33,7 +37,8 @@ TEST_P(JoinColumnMappingTest, SingleJoinColAtBeginningOfLeft) {
 // _____________________________________________________________________________
 TEST_P(JoinColumnMappingTest, SingleJoinColInMiddleOfLeft) {
   bool keepJoinCols = GetParam();
-  JoinColumnMapping m{{{1, 0}}, 3, 2, keepJoinCols};
+  std::vector<std::array<ColumnIndex, 2>> jcs{{1, 0}};
+  JoinColumnMapping m{jcs, 3, 2, keepJoinCols};
   EXPECT_THAT(m.jcsLeft(), ElementsAre(1));
   EXPECT_THAT(m.jcsRight(), ElementsAre(0));
   EXPECT_THAT(m.permutationLeft(), ElementsAre(1, 0, 2));
@@ -48,7 +53,8 @@ TEST_P(JoinColumnMappingTest, SingleJoinColInMiddleOfLeft) {
 // _____________________________________________________________________________
 TEST_P(JoinColumnMappingTest, MultipleJoinCols) {
   bool keepJoinCols = GetParam();
-  JoinColumnMapping m{{{2, 0}, {1, 3}}, 3, 4, keepJoinCols};
+  std::vector<std::array<ColumnIndex, 2>> jcs{{2, 0}, {1, 3}};
+  JoinColumnMapping m{jcs, 3, 4, keepJoinCols};
   EXPECT_THAT(m.jcsLeft(), ElementsAre(2, 1));
   EXPECT_THAT(m.jcsRight(), ElementsAre(0, 3));
   EXPECT_THAT(m.permutationLeft(), ElementsAre(2, 1, 0));

--- a/test/libqlever/QleverTest.cpp
+++ b/test/libqlever/QleverTest.cpp
@@ -13,6 +13,7 @@
 #include "../util/GTestHelpers.h"
 #include "../util/IdTableHelpers.h"
 #include "../util/IndexTestHelpers.h"
+#include "../util/ParsedQueryTestHelpers.h"
 #include "../util/RuntimeParametersTestHelpers.h"
 #include "backports/filesystem.h"
 #include "engine/ExternalValues.h"
@@ -404,10 +405,13 @@ TEST(LibQlever, externallySpecifiedValues) {
 
     // Supply values and execute the query.
     using TC = TripleComponent;
-    parsedQuery::SparqlValues newValues;
-    newValues._variables = {Variable{"?x"}};
-    newValues._values = {{TC::Iri::fromIriref("<s1>")},
-                         {TC::Iri::fromIriref("<s3>")}};
+    parsedQuery::SparqlValues newValues{qec.getAllocator()};
+    newValues._variables = ad_utility::testing::toQVec(
+        std::vector<Variable>{Variable{"?x"}});
+    newValues._values.push_back(ad_utility::testing::toQVec(
+        std::vector<TripleComponent>{TC::Iri::fromIriref("<s1>")}));
+    newValues._values.push_back(ad_utility::testing::toQVec(
+        std::vector<TripleComponent>{TC::Iri::fromIriref("<s3>")}));
     externalValues[0]->updateValues(std::move(newValues));
 
     auto res = qet.getResult();
@@ -458,7 +462,8 @@ RebuildSetup setUpRebuild(const std::string& baseFolder) {
     ql::filesystem::remove(rebuiltBase + suffix);
   }
   auto indexAndViews = std::make_shared<qlever::Qlever::IndexAndViews>(
-      std::move(rebuilt), MaterializedViewsManager{rebuiltBase});
+      std::move(rebuilt),
+      MaterializedViewsManager{rebuiltBase, ad_utility::testing::makeAllocator()});
   return {std::move(oldBase), std::move(rebuiltBase), std::move(indexAndViews)};
 }
 }  // namespace
@@ -539,10 +544,13 @@ TEST(LibQlever, planQueryOfParsedQueryAndCloneQetInPlace) {
     std::vector<ExternalValues*> values;
     plan.queryExecutionTree().getRootOperation()->getExternalValues(values);
     AD_CONTRACT_CHECK(values.size() == 1);
-    parsedQuery::SparqlValues newValues;
-    newValues._variables = {Variable{"?x"}};
+    parsedQuery::SparqlValues newValues{
+        plan.queryExecutionContext().getAllocator()};
+    newValues._variables = ad_utility::testing::toQVec(
+        std::vector<Variable>{Variable{"?x"}});
     for (const auto& iri : iris) {
-      newValues._values.push_back({TripleComponent::Iri::fromIriref(iri)});
+      newValues._values.push_back(ad_utility::testing::toQVec(
+          std::vector<TripleComponent>{TripleComponent::Iri::fromIriref(iri)}));
     }
     values.at(0)->updateValues(std::move(newValues));
 
@@ -742,7 +750,8 @@ TEST(LibQlever, applyUpdate) {
   ad_utility::BlankNodeManager bnm;
   auto parsedUpdates =
       SparqlParser::parseUpdate(&bnm, ad_utility::testing::encodedIriManager(),
-                                "INSERT DATA { <a> <b> <c> }");
+                                "INSERT DATA { <a> <b> <c> }", {},
+                                engine.allocator());
   ASSERT_THAT(parsedUpdates, SizeIs(1));
   auto plannedUpdate =
       engine.planQuery(engine.bindParsedQuery(std::move(parsedUpdates[0])));
@@ -787,7 +796,8 @@ namespace {
 UpdateMetadata applyUpdateToEngine(Qlever& engine, const std::string& update) {
   ad_utility::BlankNodeManager bnm;
   auto parsedUpdates = SparqlParser::parseUpdate(
-      &bnm, ad_utility::testing::encodedIriManager(), update);
+      &bnm, ad_utility::testing::encodedIriManager(), update, {},
+      engine.allocator());
   AD_CORRECTNESS_CHECK(parsedUpdates.size() == 1);
   auto plannedUpdate =
       engine.planQuery(engine.bindParsedQuery(std::move(parsedUpdates[0])));

--- a/test/parser/GraphPatternAnalysisTest.cpp
+++ b/test/parser/GraphPatternAnalysisTest.cpp
@@ -6,6 +6,7 @@
 
 #include <gmock/gmock.h>
 
+#include "../util/ParsedQueryTestHelpers.h"
 #include "parser/GraphPatternAnalysis.h"
 #include "parser/GraphPatternOperation.h"
 #include "parser/SparqlTriple.h"
@@ -52,34 +53,45 @@ TEST(BasicGraphPatternsInvariantToTest, Values) {
   BasicGraphPatternsInvariantTo invariantTo{counter};
 
   // Test VALUES with exactly one row and no variable overlap.
-  parsedQuery::Values values;
-  values._inlineValues._variables = {Variable{"?a"}, Variable{"?b"}};
-  values._inlineValues._values = {
-      {TripleComponent::Iri::fromIriref("<value1>"),
-       TripleComponent::Iri::fromIriref("<value2>")}};
+  parsedQuery::Values values{
+      parsedQuery::SparqlValues{ad_utility::testing::makeAllocator()}};
+  values._inlineValues._variables =
+      ad_utility::testing::toQVec(std::vector{Variable{"?a"}, Variable{"?b"}});
+  values._inlineValues._values = ad_utility::testing::toQVecOfVec(
+      std::vector<std::vector<TripleComponent>>{
+          {TripleComponent::Iri::fromIriref("<value1>"),
+           TripleComponent::Iri::fromIriref("<value2>")}});
   EXPECT_TRUE(invariantTo(values));
 
   // Test VALUES with one row but with variable overlap.
-  parsedQuery::Values values2;
-  values2._inlineValues._variables = {Variable{"?x"}, Variable{"?b"}};
-  values2._inlineValues._values = {
-      {TripleComponent::Iri::fromIriref("<value1>"),
-       TripleComponent::Iri::fromIriref("<value2>")}};
+  parsedQuery::Values values2{
+      parsedQuery::SparqlValues{ad_utility::testing::makeAllocator()}};
+  values2._inlineValues._variables =
+      ad_utility::testing::toQVec(std::vector{Variable{"?x"}, Variable{"?b"}});
+  values2._inlineValues._values = ad_utility::testing::toQVecOfVec(
+      std::vector<std::vector<TripleComponent>>{
+          {TripleComponent::Iri::fromIriref("<value1>"),
+           TripleComponent::Iri::fromIriref("<value2>")}});
   EXPECT_FALSE(invariantTo(values2));
 
   // Test VALUES with multiple rows (not invariant even without variable
   // overlap).
-  parsedQuery::Values values3;
-  values3._inlineValues._variables = {Variable{"?a"}};
-  values3._inlineValues._values = {
-      {TripleComponent::Iri::fromIriref("<value1>")},
-      {TripleComponent::Iri::fromIriref("<value2>")}};
+  parsedQuery::Values values3{
+      parsedQuery::SparqlValues{ad_utility::testing::makeAllocator()}};
+  values3._inlineValues._variables =
+      ad_utility::testing::toQVec(std::vector{Variable{"?a"}});
+  values3._inlineValues._values = ad_utility::testing::toQVecOfVec(
+      std::vector<std::vector<TripleComponent>>{
+          {TripleComponent::Iri::fromIriref("<value1>")},
+          {TripleComponent::Iri::fromIriref("<value2>")}});
   EXPECT_FALSE(invariantTo(values3));
 
   // Test VALUES with zero rows (not invariant).
-  parsedQuery::Values values4;
-  values4._inlineValues._variables = {Variable{"?a"}};
-  values4._inlineValues._values = {};
+  parsedQuery::Values values4{
+      parsedQuery::SparqlValues{ad_utility::testing::makeAllocator()}};
+  values4._inlineValues._variables =
+      ad_utility::testing::toQVec(std::vector{Variable{"?a"}});
+  values4._inlineValues._values.clear();
   EXPECT_FALSE(invariantTo(values4));
 }
 

--- a/test/parser/NamedSubqueryTest.cpp
+++ b/test/parser/NamedSubqueryTest.cpp
@@ -17,7 +17,8 @@ namespace {
 // Parse the given query and return the resulting `ParsedQuery`.
 ParsedQuery parse(std::string query) {
   static EncodedIriManager encodedIriManager;
-  return SparqlParser::parseQuery(&encodedIriManager, std::move(query));
+  return SparqlParser::parseQuery(&encodedIriManager, std::move(query), {},
+                                  ad_utility::testing::makeAllocator());
 }
 
 // The dataset for the equivalence tests below.
@@ -182,7 +183,8 @@ namespace {
 // Collect the warnings of the given query and of all its (transitive)
 // subqueries.
 std::vector<std::string> allWarnings(const ParsedQuery& query) {
-  std::vector<std::string> warnings = query.warnings();
+  const auto& queryWarnings = query.warnings();
+  std::vector<std::string> warnings(queryWarnings.begin(), queryWarnings.end());
   for (const parsedQuery::Subquery& subquery :
        ad_utility::filterRangeOfVariantsByType<parsedQuery::Subquery>(
            query._rootGraphPattern._graphPatterns)) {

--- a/test/parser/PayloadVariablesTest.cpp
+++ b/test/parser/PayloadVariablesTest.cpp
@@ -5,20 +5,24 @@
 #include <gmock/gmock.h>
 
 #include "../printers/PayloadVariablePrinters.h"
+#include "../util/AllocatorTestHelpers.h"
 #include "../util/GTestHelpers.h"
+#include "../util/ParsedQueryTestHelpers.h"
 #include "gmock/gmock.h"
 #include "parser/PayloadVariables.h"
 #include "rdfTypes/Variable.h"
 
+using ad_utility::testing::toQVec;
+
 namespace {  // anonymous namespace to avoid linker problems
 
 TEST(PayloadVariablesTest, PayloadVariables) {
-  PayloadVariables pv1;
+  PayloadVariables pv1{ad_utility::testing::makeAllocator()};
   ASSERT_TRUE(pv1.empty());
   ASSERT_FALSE(pv1.isAll());
-  ASSERT_EQ(pv1.getVariables(), std::vector<Variable>{});
+  ASSERT_EQ(pv1.getVariables(), toQVec(std::vector<Variable>{}));
 
-  PayloadVariables pv2{std::vector<Variable>{}};
+  PayloadVariables pv2{toQVec(std::vector<Variable>{})};
   ASSERT_EQ(pv1, pv2);
   ASSERT_TRUE(pv2.empty());
   ASSERT_FALSE(pv2.isAll());
@@ -42,22 +46,23 @@ TEST(PayloadVariablesTest, PayloadVariables) {
   ASSERT_TRUE(pv3.isAll());
   ASSERT_FALSE(pv3.empty());
 
-  PayloadVariables pv4{std::vector<Variable>{Variable{"?a"}, Variable{"?b"}}};
+  PayloadVariables pv4{
+      toQVec(std::vector<Variable>{Variable{"?a"}, Variable{"?b"}})};
   ASSERT_FALSE(pv4.isAll());
   ASSERT_FALSE(pv4.empty());
   ASSERT_NE(pv3, pv4);
   ASSERT_NE(pv1, pv4);
   std::vector<Variable> expect4{Variable{"?a"}, Variable{"?b"}};
-  ASSERT_EQ(pv4.getVariables(), expect4);
+  ASSERT_EQ(pv4.getVariables(), toQVec(expect4));
 
-  PayloadVariables pv5;
-  ASSERT_EQ(pv5.getVariables(), std::vector<Variable>{});
+  PayloadVariables pv5{ad_utility::testing::makeAllocator()};
+  ASSERT_EQ(pv5.getVariables(), toQVec(std::vector<Variable>{}));
   pv5.addVariable(Variable{"?var"});
   std::vector<Variable> expect5_step1{Variable{"?var"}};
-  ASSERT_EQ(pv5.getVariables(), expect5_step1);
+  ASSERT_EQ(pv5.getVariables(), toQVec(expect5_step1));
   pv5.addVariable(Variable{"?var2"});
   std::vector<Variable> expect5_step2{Variable{"?var"}, Variable{"?var2"}};
-  ASSERT_EQ(pv5.getVariables(), expect5_step2);
+  ASSERT_EQ(pv5.getVariables(), toQVec(expect5_step2));
   ASSERT_FALSE(pv5.isAll());
   ASSERT_FALSE(pv5.empty());
 };

--- a/test/parser/PropertyPathTest.cpp
+++ b/test/parser/PropertyPathTest.cpp
@@ -13,6 +13,21 @@ auto iri1 = Iri::fromIriref("<http://example.org/path1>");
 auto iri2 = Iri::fromIriref("<http://example.org/path2>");
 
 auto iri = [](std::string_view iriStr) { return Iri::fromIriref(iriStr); };
+
+// Helper that converts a plain `std::vector<PropertyPath>` (as used in
+// brace-init test literals) into the allocator-aware `PropertyPath::ChildrenVec`.
+auto toChildren = [](std::vector<PropertyPath> children) {
+  return PropertyPath::ChildrenVec(
+      std::make_move_iterator(children.begin()),
+      std::make_move_iterator(children.end()),
+      qlever::makeUnlimitedAllocator<PropertyPath>());
+};
+
+// Helper that supplies the (test-only) allocator required by `makeInverse`.
+auto makeInverse = [](PropertyPath child) {
+  return PropertyPath::makeInverse(std::move(child),
+                                   qlever::makeUnlimitedAllocator<PropertyPath>());
+};
 }  // namespace
 
 TEST(PropertyPath, BasicPathEquality) {
@@ -26,31 +41,31 @@ TEST(PropertyPath, BasicPathEquality) {
 
 // _____________________________________________________________________________
 TEST(PropertyPath, ModifiedPathEquality) {
-  auto path1 = PropertyPath::makeInverse(PropertyPath::fromIri(iri1));
-  auto path2 = PropertyPath::makeInverse(PropertyPath::fromIri(iri1));
-  auto path3 = PropertyPath::makeInverse(PropertyPath::fromIri(iri2));
+  auto path1 = makeInverse(PropertyPath::fromIri(iri1));
+  auto path2 = makeInverse(PropertyPath::fromIri(iri1));
+  auto path3 = makeInverse(PropertyPath::fromIri(iri2));
 
   EXPECT_EQ(path1, path2);
   EXPECT_NE(path1, path3);
 
-  auto path4 = PropertyPath::makeAlternative(
-      {PropertyPath::fromIri(iri1), PropertyPath::fromIri(iri2)});
-  auto path5 = PropertyPath::makeAlternative(
-      {PropertyPath::fromIri(iri2), PropertyPath::fromIri(iri1)});
+  auto path4 = PropertyPath::makeAlternative(toChildren(
+      {PropertyPath::fromIri(iri1), PropertyPath::fromIri(iri2)}));
+  auto path5 = PropertyPath::makeAlternative(toChildren(
+      {PropertyPath::fromIri(iri2), PropertyPath::fromIri(iri1)}));
   EXPECT_NE(path4, path5);
 
-  auto path6 = PropertyPath::makeSequence(
-      {PropertyPath::fromIri(iri1), PropertyPath::fromIri(iri2)});
-  auto path7 = PropertyPath::makeSequence(
-      {PropertyPath::fromIri(iri2), PropertyPath::fromIri(iri1)});
+  auto path6 = PropertyPath::makeSequence(toChildren(
+      {PropertyPath::fromIri(iri1), PropertyPath::fromIri(iri2)}));
+  auto path7 = PropertyPath::makeSequence(toChildren(
+      {PropertyPath::fromIri(iri2), PropertyPath::fromIri(iri1)}));
   EXPECT_NE(path6, path7);
   EXPECT_NE(path4, path6);
   EXPECT_NE(path5, path7);
 
-  auto path8 = PropertyPath::makeNegated(
-      {PropertyPath::fromIri(iri1), PropertyPath::fromIri(iri2)});
-  auto path9 = PropertyPath::makeNegated(
-      {PropertyPath::fromIri(iri2), PropertyPath::fromIri(iri1)});
+  auto path8 = PropertyPath::makeNegated(toChildren(
+      {PropertyPath::fromIri(iri1), PropertyPath::fromIri(iri2)}));
+  auto path9 = PropertyPath::makeNegated(toChildren(
+      {PropertyPath::fromIri(iri2), PropertyPath::fromIri(iri1)}));
 
   EXPECT_NE(path8, path9);
   EXPECT_NE(path4, path8);
@@ -58,18 +73,18 @@ TEST(PropertyPath, ModifiedPathEquality) {
   EXPECT_NE(path6, path8);
   EXPECT_NE(path7, path9);
 
-  auto path10 = PropertyPath::makeAlternative(
-      {PropertyPath::fromIri(iri1), PropertyPath::fromIri(iri2)});
+  auto path10 = PropertyPath::makeAlternative(toChildren(
+      {PropertyPath::fromIri(iri1), PropertyPath::fromIri(iri2)}));
 
   EXPECT_EQ(path10, path4);
 
-  auto path11 = PropertyPath::makeSequence(
-      {PropertyPath::fromIri(iri1), PropertyPath::fromIri(iri2)});
+  auto path11 = PropertyPath::makeSequence(toChildren(
+      {PropertyPath::fromIri(iri1), PropertyPath::fromIri(iri2)}));
 
   EXPECT_EQ(path11, path6);
 
-  auto path12 = PropertyPath::makeNegated(
-      {PropertyPath::fromIri(iri1), PropertyPath::fromIri(iri2)});
+  auto path12 = PropertyPath::makeNegated(toChildren(
+      {PropertyPath::fromIri(iri1), PropertyPath::fromIri(iri2)}));
 
   EXPECT_EQ(path12, path8);
 }
@@ -119,7 +134,7 @@ TEST(PropertyPath, MinMaxPathMoveAssignment) {
 // _____________________________________________________________________________
 TEST(PropertyPath, OstreamOutput) {
   auto path1 = PropertyPath::fromIri(iri1);
-  auto path2 = PropertyPath::makeInverse(PropertyPath::fromIri(iri2));
+  auto path2 = makeInverse(PropertyPath::fromIri(iri2));
   auto path3 = PropertyPath::makeWithLength(PropertyPath::fromIri(iri1), 1, 3);
 
   auto streamToString = [](const PropertyPath& path) {
@@ -136,24 +151,24 @@ TEST(PropertyPath, OstreamOutput) {
 // _____________________________________________________________________________
 TEST(PropertyPath, propertyPathsFormatting) {
   {
-    auto path = PropertyPath::makeNegated(
-        {PropertyPath::makeInverse(PropertyPath::fromIri(iri("<a>")))});
+    auto path = PropertyPath::makeNegated(toChildren(
+        {makeInverse(PropertyPath::fromIri(iri("<a>")))}));
     EXPECT_EQ("!((^<a>))", path.asString());
   }
   {
-    auto path = PropertyPath::makeNegated(
-        {PropertyPath::makeInverse(PropertyPath::fromIri(iri("<a>"))),
-         PropertyPath::fromIri(iri("<b>"))});
+    auto path = PropertyPath::makeNegated(toChildren(
+        {makeInverse(PropertyPath::fromIri(iri("<a>"))),
+         PropertyPath::fromIri(iri("<b>"))}));
     EXPECT_EQ("!((^<a>)|<b>)", path.asString());
   }
   {
-    auto path = PropertyPath::makeNegated({});
+    auto path = PropertyPath::makeNegated(toChildren({}));
     EXPECT_EQ("!()", path.asString());
   }
   {
-    auto path = PropertyPath::makeSequence({PropertyPath::fromIri(iri("<a>")),
+    auto path = PropertyPath::makeSequence(toChildren({PropertyPath::fromIri(iri("<a>")),
                                             PropertyPath::fromIri(iri("<a>")),
-                                            PropertyPath::fromIri(iri("<b>"))});
+                                            PropertyPath::fromIri(iri("<b>"))}));
     EXPECT_EQ("<a>/<a>/<b>", path.asString());
   }
 }
@@ -163,16 +178,16 @@ TEST(PropertyPath, getInvertedChild) {
   auto path0 = PropertyPath::fromIri(iri("<a>"));
   EXPECT_FALSE(path0.getChildOfInvertedPath().has_value());
 
-  auto path1 = PropertyPath::makeInverse(path0);
+  auto path1 = makeInverse(path0);
   EXPECT_EQ(path1.getChildOfInvertedPath(), std::optional{path0});
 
-  auto path2 = PropertyPath::makeNegated(
-      {PropertyPath::makeInverse(PropertyPath::fromIri(iri("<a>")))});
+  auto path2 = PropertyPath::makeNegated(toChildren(
+      {makeInverse(PropertyPath::fromIri(iri("<a>")))}));
   EXPECT_FALSE(path2.getChildOfInvertedPath().has_value());
-  auto path3 = PropertyPath::makeAlternative({path1, path2});
+  auto path3 = PropertyPath::makeAlternative(toChildren({path1, path2}));
   EXPECT_FALSE(path3.getChildOfInvertedPath().has_value());
 
-  auto path4 = PropertyPath::makeSequence({path1, path2});
+  auto path4 = PropertyPath::makeSequence(toChildren({path1, path2}));
   EXPECT_FALSE(path4.getChildOfInvertedPath().has_value());
 
   auto path5 = PropertyPath::makeWithLength(path0, 0, 1);
@@ -187,7 +202,7 @@ TEST(PropertyPath, handlePath) {
                   EXPECT_EQ(value, iri("<a>"));
                   return 0;
                 },
-                [](const std::vector<PropertyPath>&, PropertyPath::Modifier) {
+                [](const PropertyPath::ChildrenVec&, PropertyPath::Modifier) {
                   ADD_FAILURE() << "This should not be executed";
                   return 1;
                 },
@@ -197,13 +212,13 @@ TEST(PropertyPath, handlePath) {
                 }),
             0);
 
-  auto path1 = PropertyPath::makeInverse(path0);
+  auto path1 = makeInverse(path0);
   EXPECT_EQ(path1.handlePath<int>(
                 [](const ad_utility::triple_component::Iri&) {
                   ADD_FAILURE() << "This should not be executed";
                   return 0;
                 },
-                [&path0](const std::vector<PropertyPath>& children,
+                [&path0](const PropertyPath::ChildrenVec& children,
                          PropertyPath::Modifier modifier) {
                   EXPECT_EQ(modifier, PropertyPath::Modifier::INVERSE);
                   EXPECT_THAT(children, ::testing::ElementsAre(path0));
@@ -216,14 +231,14 @@ TEST(PropertyPath, handlePath) {
             1);
 
   auto innerPath2 =
-      PropertyPath::makeInverse(PropertyPath::fromIri(iri("<a>")));
-  auto path2 = PropertyPath::makeNegated({innerPath2});
+      makeInverse(PropertyPath::fromIri(iri("<a>")));
+  auto path2 = PropertyPath::makeNegated(toChildren({innerPath2}));
   EXPECT_EQ(path2.handlePath<int>(
                 [](const ad_utility::triple_component::Iri&) {
                   ADD_FAILURE() << "This should not be executed";
                   return 0;
                 },
-                [&innerPath2](const std::vector<PropertyPath>& children,
+                [&innerPath2](const PropertyPath::ChildrenVec& children,
                               PropertyPath::Modifier modifier) {
                   EXPECT_EQ(modifier, PropertyPath::Modifier::NEGATED);
                   EXPECT_THAT(children, ::testing::ElementsAre(innerPath2));
@@ -234,13 +249,13 @@ TEST(PropertyPath, handlePath) {
                   return 2;
                 }),
             1);
-  auto path3 = PropertyPath::makeAlternative({path1, path2});
+  auto path3 = PropertyPath::makeAlternative(toChildren({path1, path2}));
   EXPECT_EQ(path3.handlePath<int>(
                 [](const ad_utility::triple_component::Iri&) {
                   ADD_FAILURE() << "This should not be executed";
                   return 0;
                 },
-                [&path1, &path2](const std::vector<PropertyPath>& children,
+                [&path1, &path2](const PropertyPath::ChildrenVec& children,
                                  PropertyPath::Modifier modifier) {
                   EXPECT_EQ(modifier, PropertyPath::Modifier::ALTERNATIVE);
                   EXPECT_THAT(children, ::testing::ElementsAre(path1, path2));
@@ -252,13 +267,13 @@ TEST(PropertyPath, handlePath) {
                 }),
             1);
 
-  auto path4 = PropertyPath::makeSequence({path1, path2});
+  auto path4 = PropertyPath::makeSequence(toChildren({path1, path2}));
   EXPECT_EQ(path4.handlePath<int>(
                 [](const ad_utility::triple_component::Iri&) {
                   ADD_FAILURE() << "This should not be executed";
                   return 0;
                 },
-                [&path1, &path2](const std::vector<PropertyPath>& children,
+                [&path1, &path2](const PropertyPath::ChildrenVec& children,
                                  PropertyPath::Modifier modifier) {
                   EXPECT_EQ(modifier, PropertyPath::Modifier::SEQUENCE);
                   EXPECT_THAT(children, ::testing::ElementsAre(path1, path2));
@@ -276,7 +291,7 @@ TEST(PropertyPath, handlePath) {
                   ADD_FAILURE() << "This should not be executed";
                   return 0;
                 },
-                [](const std::vector<PropertyPath>&, PropertyPath::Modifier) {
+                [](const PropertyPath::ChildrenVec&, PropertyPath::Modifier) {
                   ADD_FAILURE() << "This should not be executed";
                   return 1;
                 },
@@ -296,17 +311,17 @@ TEST(PropertyPath, Getters) {
   EXPECT_FALSE(path1.isSequence());
   EXPECT_EQ(path1.getIri(), iri1);
 
-  auto path2 = PropertyPath::makeInverse(PropertyPath::fromIri(iri1));
+  auto path2 = makeInverse(PropertyPath::fromIri(iri1));
   EXPECT_FALSE(path2.isIri());
   EXPECT_FALSE(path2.isSequence());
 
-  auto path3 = PropertyPath::makeAlternative(
-      {PropertyPath::fromIri(iri1), PropertyPath::fromIri(iri2)});
+  auto path3 = PropertyPath::makeAlternative(toChildren(
+      {PropertyPath::fromIri(iri1), PropertyPath::fromIri(iri2)}));
   EXPECT_FALSE(path3.isIri());
   EXPECT_FALSE(path3.isSequence());
 
-  auto path4 = PropertyPath::makeSequence(
-      {PropertyPath::fromIri(iri1), PropertyPath::fromIri(iri2)});
+  auto path4 = PropertyPath::makeSequence(toChildren(
+      {PropertyPath::fromIri(iri1), PropertyPath::fromIri(iri2)}));
   EXPECT_FALSE(path4.isIri());
   EXPECT_TRUE(path4.isSequence());
   auto matchIri = [](ad_utility::triple_component::Iri iri)

--- a/test/parser/QuadTest.cpp
+++ b/test/parser/QuadTest.cpp
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 
 #include "../util/GTestHelpers.h"
+#include "../util/ParsedQueryTestHelpers.h"
 #include "./SparqlAntlrParserTestHelpers.h"
 #include "parser/Quads.h"
 
@@ -21,7 +22,7 @@ TEST(QuadTest, getQuads) {
         // test with blank nodes.
         ad_utility::BlankNodeManager manager;
         Quads::BlankNodeAdder bn{{}, {}, &manager};
-        const Quads quads{std::move(triples), std::move(graphs)};
+        const Quads quads{std::move(triples), toQVec(std::move(graphs))};
         auto res = quads.toTriplesWithGraph(std::monostate{}, bn);
         EXPECT_THAT(res.triples_, testing::UnorderedElementsAreArray(expected));
         EXPECT_EQ(manager.numBlocksUsed(), 0);
@@ -57,7 +58,8 @@ TEST(QuadTest, getQuadsWithBlankNodes) {
   std::array tr{bn("a"), bn("b"), bn("a")};
   ad_utility::BlankNodeManager manager;
   Quads::BlankNodeAdder adder{{}, {}, &manager};
-  const Quads quads{{tr}, {}};
+  Quads quads{ad_utility::testing::makeAllocator()};
+  quads.freeTriples_ = {tr};
   auto res = quads.toTriplesWithGraph(std::monostate{}, adder);
   EXPECT_EQ(res.triples_.size(), 1ul);
   const auto& triple = res.triples_.at(0);
@@ -84,7 +86,7 @@ TEST(QuadTest, getOperations) {
              std::vector<parsedQuery::GraphPatternOperation>>& m,
          ad_utility::source_location l = AD_CURRENT_SOURCE_LOC()) {
         auto t = generateLocationTrace(l);
-        const Quads quads{std::move(triples), std::move(graphs)};
+        const Quads quads{std::move(triples), toQVec(std::move(graphs))};
         EXPECT_THAT(quads.toGraphPatternOperations(), m);
       };
   auto TripleOf = [](const GraphTerm& t) -> std::array<GraphTerm, 3> {
@@ -120,10 +122,13 @@ TEST(QuadTest, getOperations) {
 
 TEST(QuadTest, forAllVariables) {
   auto expectForAllVariables =
-      [](Quads quads, const ad_utility::HashSet<Variable>& expectVariables,
+      [](ad_utility::sparql_types::Triples freeTriples,
+         std::vector<Quads::GraphBlock> graphTriples,
+         const ad_utility::HashSet<Variable>& expectVariables,
          ad_utility::source_location l = AD_CURRENT_SOURCE_LOC()) {
         auto t = generateLocationTrace(l);
         ad_utility::HashSet<Variable> calledVariables;
+        Quads quads{std::move(freeTriples), toQVec(std::move(graphTriples))};
         quads.forAllVariables([&calledVariables](const Variable& var) {
           calledVariables.insert(var);
         });
@@ -139,20 +144,20 @@ TEST(QuadTest, forAllVariables) {
                        GraphTerm(Var("?c"))};
   Triple sameVar{GraphTerm(Var("?a")), GraphTerm(Var("?a")),
                  GraphTerm(Var("?a"))};
-  expectForAllVariables({}, {});
-  expectForAllVariables({{noVars}, {}}, {});
-  expectForAllVariables({{differentVars}, {}},
+  expectForAllVariables({}, {}, {});
+  expectForAllVariables({noVars}, {}, {});
+  expectForAllVariables({differentVars}, {},
                         {Var("?a"), Var("?b"), Var("?c")});
-  expectForAllVariables({{sameVar}, {}}, {Var("?a")});
-  expectForAllVariables({{}, {{{TCIri("<a>"), {}}}}}, {});
-  expectForAllVariables({{}, {{{TCIri("<a>"), {noVars}}}}}, {});
-  expectForAllVariables({{}, {{{TCIri("<a>"), {differentVars}}}}},
+  expectForAllVariables({sameVar}, {}, {Var("?a")});
+  expectForAllVariables({}, {{TCIri("<a>"), {}}}, {});
+  expectForAllVariables({}, {{TCIri("<a>"), {noVars}}}, {});
+  expectForAllVariables({}, {{TCIri("<a>"), {differentVars}}},
                         {Var("?a"), Var("?b"), Var("?c")});
-  expectForAllVariables({{}, {{{TCIri("<a>"), {sameVar}}}}}, {Var("?a")});
+  expectForAllVariables({}, {{TCIri("<a>"), {sameVar}}}, {Var("?a")});
   // Even if the graph block is empty, the variable is still omitted.
-  expectForAllVariables({{}, {{{Var("?d"), {}}}}}, {Var("?d")});
+  expectForAllVariables({}, {{Var("?d"), {}}}, {Var("?d")});
   expectForAllVariables(
-      {{noVars, differentVars, sameVar}, {{{Var("?d"), {differentVars}}}}},
+      {noVars, differentVars, sameVar}, {{Var("?d"), {differentVars}}},
       {Var("?a"), Var("?b"), Var("?c"), Var("?d")});
 }
 
@@ -165,9 +170,10 @@ TEST(QuadTest, equalityOfSparqlTripleSimpleWithGraph) {
   auto makeTriple =
       [](std::string_view s, std::string_view p, std::string_view o,
          const Graph& g,
-         Triple::AdditionalScanColumns additionalScanColumns = {}) {
+         std::vector<std::pair<ColumnIndex, Variable>> additionalScanColumns =
+             {}) {
         return Triple{iri(s), iri(p), iri(o), g,
-                      std::move(additionalScanColumns)};
+                      toQVec(std::move(additionalScanColumns))};
       };
   const Graph graph{iri("<d>")};
   const Triple triple = makeTriple("<a>", "<b>", "<c>", graph);

--- a/test/parser/SparqlAntlrParserTest.cpp
+++ b/test/parser/SparqlAntlrParserTest.cpp
@@ -68,8 +68,12 @@ TEST(SparqlParser, Prefix) {
 
   {
     static ad_utility::BlankNodeManager blankNodeManager;
-    ParserAndVisitor p{&blankNodeManager, encodedIriManager(),
-                       "PREFIX wd: <www.wikidata.org/>"};
+    ParserAndVisitor p{&blankNodeManager,
+                      encodedIriManager(),
+                      "PREFIX wd: <www.wikidata.org/>",
+                      std::nullopt,
+                      SparqlQleverVisitor::DisableSomeChecksOnlyForTesting::False,
+                      ad_utility::testing::makeAllocator()};
     auto defaultPrefixes = p.visitor_.prefixMap();
     ASSERT_EQ(defaultPrefixes.size(), 0);
     p.visitor_.visit(p.parser_.prefixDecl());
@@ -679,10 +683,25 @@ TEST(SparqlParser, InlineData) {
 TEST(SparqlParser, propertyPaths) {
   auto expectPathOrVar = ExpectCompleteParse<&Parser::verbPathOrSimple>{};
   auto Iri = &PathIri;
-  auto Sequence = &PropertyPath::makeSequence;
-  auto Alternative = &PropertyPath::makeAlternative;
-  auto Inverse = &PropertyPath::makeInverse;
-  auto Negated = &PropertyPath::makeNegated;
+  auto toChildren = [](std::vector<PropertyPath> children) {
+    return PropertyPath::ChildrenVec(
+        std::make_move_iterator(children.begin()),
+        std::make_move_iterator(children.end()),
+        qlever::makeUnlimitedAllocator<PropertyPath>());
+  };
+  auto Sequence = [&toChildren](std::vector<PropertyPath> children) {
+    return PropertyPath::makeSequence(toChildren(std::move(children)));
+  };
+  auto Alternative = [&toChildren](std::vector<PropertyPath> children) {
+    return PropertyPath::makeAlternative(toChildren(std::move(children)));
+  };
+  auto Inverse = [](PropertyPath child) {
+    return PropertyPath::makeInverse(std::move(child),
+                                     qlever::makeUnlimitedAllocator<PropertyPath>());
+  };
+  auto Negated = [&toChildren](std::vector<PropertyPath> children) {
+    return PropertyPath::makeNegated(toChildren(std::move(children)));
+  };
   auto WithLength = &PropertyPath::makeWithLength;
   size_t max = std::numeric_limits<size_t>::max();
   using PrefixMap = SparqlQleverVisitor::PrefixMap;
@@ -1283,7 +1302,9 @@ TEST(SparqlParser, ConstructQuery) {
 TEST(SparqlParser, ensureExceptionOnInvalidGraphTerm) {
   static ad_utility::BlankNodeManager blankNodeManager;
   SparqlQleverVisitor visitor{
-      &blankNodeManager, encodedIriManager(), {}, std::nullopt};
+      &blankNodeManager, encodedIriManager(), {}, std::nullopt,
+      SparqlQleverVisitor::DisableSomeChecksOnlyForTesting::False,
+      ad_utility::testing::makeAllocator()};
 
   EXPECT_THROW(
       visitor.toGraphPattern({{Var{"?a"}, BlankNode{true, "0"}, Var{"?b"}}}),
@@ -1632,7 +1653,9 @@ TEST(SparqlParser, QuadData) {
   auto expectQuadDataFails = ExpectParseFails<&Parser::quadData>{};
 
   expectQuadData("{ <a> <b> <c> }",
-                 Quads{{{iri("<a>"), iri("<b>"), iri("<c>")}}, {}});
+                 Quads{{{iri("<a>"), iri("<b>"), iri("<c>")}},
+                       ad_utility::testing::toQVec(
+                           std::vector<Quads::GraphBlock>{})});
   expectQuadDataFails("{ <a> <b> ?c }");
   expectQuadDataFails("{ <a> <b> <c> . GRAPH <foo> { <d> ?e <f> } }");
   expectQuadDataFails("{ <a> <b> <c> . ?d <e> <f> } }");
@@ -1725,7 +1748,8 @@ TEST(ParserTest, propertyPathInCollection) {
       "SELECT * { ?s ?p ([:p* 123] [^:r \"hello\"]) }";
   EncodedIriManager encodedIriManager;
   EXPECT_THAT(
-      SparqlParser::parseQuery(&encodedIriManager, std::move(query)),
+      SparqlParser::parseQuery(&encodedIriManager, std::move(query), {},
+                               ad_utility::testing::makeAllocator()),
       m::SelectQuery(
           m::AsteriskSelect(),
           m::GraphPattern(m::Triples(
@@ -1737,7 +1761,8 @@ TEST(ParserTest, propertyPathInCollection) {
                 iri("<http://www.w3.org/1999/02/22-rdf-syntax-ns#nil>")},
                {Var{"?_QLever_internal_variable_1"},
                 PropertyPath::makeInverse(
-                    PropertyPath::fromIri(iri("<http://example.org/r>"))),
+                    PropertyPath::fromIri(iri("<http://example.org/r>")),
+                    qlever::makeUnlimitedAllocator<PropertyPath>()),
                 lit("\"hello\"")},
                {Var{"?_QLever_internal_variable_3"},
                 iri("<http://www.w3.org/1999/02/22-rdf-syntax-ns#first>"),
@@ -1810,7 +1835,12 @@ TEST(SparqlParser, EncodedIriManagerUsage) {
 
   auto parseWithEncoding = [&](const std::string& input) {
     static ad_utility::BlankNodeManager blankNodeManager;
-    return ParserAndVisitor{&blankNodeManager, encodedIriManager.get(), input}
+    return ParserAndVisitor{&blankNodeManager,
+                            encodedIriManager.get(),
+                            input,
+                            std::nullopt,
+                            SparqlQleverVisitor::DisableSomeChecksOnlyForTesting::False,
+                            ad_utility::testing::makeAllocator()}
         .parseTypesafe(&SparqlAutomaticParser::query);
   };
 

--- a/test/parser/SparqlAntlrParserTestHelpers.h
+++ b/test/parser/SparqlAntlrParserTestHelpers.h
@@ -399,12 +399,16 @@ inline auto VariableOrderKeyVariant =
 };
 
 inline auto VariableOrderKeys =
-    [](const std::vector<std::pair<::Variable, bool>>& orderKeys)
-    -> Matcher<const std::vector<::VariableOrderKey>&> {
+    [](const std::vector<std::pair<::Variable, bool>>& orderKeys) {
   std::vector<Matcher<const ::VariableOrderKey&>> matchers;
   for (auto [key, desc] : orderKeys) {
     matchers.push_back(VariableOrderKey(key, desc));
   }
+  // Deliberately not annotated with an explicit `Matcher<const
+  // std::vector<...>&>` return type: `_orderBy` is a `qlever::vector` (a
+  // PMR-allocator-backed container), so the matcher must stay polymorphic
+  // (as returned by `ElementsAreArray`) until it is bound to the concrete
+  // field type inside `AD_FIELD`/`testing::Field`.
   return testing::ElementsAreArray(matchers);
 };
 
@@ -510,8 +514,11 @@ inline auto Values = [](const std::vector<::Variable>& vars,
   using SparqlValues = p::SparqlValues;
   return testing::AllOf(AD_FIELD(
       p::Values, _inlineValues,
-      testing::AllOf(AD_FIELD(SparqlValues, _variables, testing::Eq(vars)),
-                     AD_FIELD(SparqlValues, _values, testing::Eq(values)))));
+      testing::AllOf(
+          AD_FIELD(SparqlValues, _variables,
+                   testing::Eq(ad_utility::testing::toQVec(vars))),
+          AD_FIELD(SparqlValues, _values,
+                   testing::Eq(ad_utility::testing::toQVecOfVec(values))))));
 };
 
 inline auto InlineData =
@@ -659,10 +666,16 @@ inline auto stringMatchesFilter =
 // the given `vector` of `SparqlFilter`s  matches the given
 // `expectedDescriptors`.
 inline auto stringsMatchFilters =
-    [](const std::vector<std::string>& expectedDescriptors)
-    -> Matcher<const std::vector<SparqlFilter>&> {
+    [](const std::vector<std::string>& expectedDescriptors) {
   auto matchers =
       ad_utility::transform(expectedDescriptors, stringMatchesFilter);
+  // Deliberately not annotated with an explicit `Matcher<const
+  // std::vector<SparqlFilter>&>` return type: this is used both for plain
+  // `std::vector<SparqlFilter>` fields (e.g. `SolutionModifiers::
+  // havingClauses_`) and for the `qlever::vector<SparqlFilter>` field
+  // `ParsedQuery::_havingClauses`, so the matcher must stay polymorphic (as
+  // returned by `ElementsAreArray`) until it is bound to the concrete field
+  // type inside `AD_FIELD`/`testing::Field`.
   return testing::ElementsAreArray(matchers);
 };
 
@@ -1235,7 +1248,8 @@ auto parse =
       static ad_utility::BlankNodeManager blankNodeManager;
       ParserAndVisitor p{
           &blankNodeManager,   encodedIriManager(), input,
-          std::move(prefixes), std::move(clauses),  disableSomeChecks};
+          std::move(prefixes), std::move(clauses),  disableSomeChecks,
+          ad_utility::testing::makeAllocator()};
       if (testInsideConstructTemplate) {
         p.visitor_.setParseModeToInsideConstructTemplateForTesting();
       }

--- a/test/util/AllocatorTestHelpers.h
+++ b/test/util/AllocatorTestHelpers.h
@@ -11,8 +11,9 @@
 #include "util/MemorySize/MemorySize.h"
 
 namespace ad_utility::testing {
-// Create a backend-agnostic allocator with the specified memory limit. If no
-// argument is specified, the allocator is unlimited.
+// Create an (effectively unlimited) allocator. Routed through the backend-
+// agnostic `qlever::Allocator` seam so the same tests build and run under both
+// the `limit` and the `pmr` allocator backends.
 inline ad_utility::AllocatorWithLimit<Id> makeAllocator(
     MemorySize memorySize = MemorySize::max()) {
   return qlever::makeAllocatorWithLimit<Id>(memorySize);

--- a/test/util/IndexTestHelpers.cpp
+++ b/test/util/IndexTestHelpers.cpp
@@ -398,7 +398,7 @@ QueryExecutionContext* getQec(const std::string& indexBasenamePrefix,
                 std::make_shared<Index>(makeTestIndex(testIndexBasename, c)),
                 std::make_unique<QueryResultCache>(),
                 std::make_unique<NamedResultCache>(),
-                std::make_shared<MaterializedViewsManager>()});
+                std::make_shared<MaterializedViewsManager>(makeAllocator())});
   }
   return contextMap.at({c, indexBasenamePrefix}).qec_.get();
 }

--- a/test/util/JoinHelpers.h
+++ b/test/util/JoinHelpers.h
@@ -61,8 +61,11 @@ IdTable useJoinFunctionOnIdTables(const IdTableAndJoinColumn& tableA,
 inline auto makeHashJoinLambda() {
   return ad_utility::ApplyAsValueIdentity{
       [](auto /*valueIdentityA*/, auto /*valueIdentityB*/,
-         auto /*valueIdentityC*/,
-         auto&&... args) { return JoinImpl::hashJoin(AD_FWD(args)...); }};
+         auto /*valueIdentityC*/, const IdTable& a, ColumnIndex jc1,
+         const IdTable& b, ColumnIndex jc2, IdTable* result) {
+        return JoinImpl::hashJoin(a, jc1, b, jc2, result,
+                                   ad_utility::testing::makeAllocator());
+      }};
 }
 
 /*

--- a/test/util/ParsedQueryTestHelpers.h
+++ b/test/util/ParsedQueryTestHelpers.h
@@ -10,18 +10,71 @@
 #ifndef QLEVER_TEST_UTIL_PARSEDQUERYTESTHELPERS_H
 #define QLEVER_TEST_UTIL_PARSEDQUERYTESTHELPERS_H
 
+#include <initializer_list>
+#include <iterator>
 #include <string>
 #include <vector>
 
+#include "AllocatorTestHelpers.h"
 #include "IndexTestHelpers.h"
+#include "parser/GraphPatternOperation.h"
 #include "parser/SparqlParser.h"
+#include "util/Allocator.h"
+#include "util/AllocatorTypes.h"
 
 namespace ad_utility::testing {
 // Parse a SPARQL query string into a typed `ParsedQuery` object.
 inline auto parseQuery(std::string query,
-                       const std::vector<DatasetClause>& datasets = {}) {
+                       const std::vector<DatasetClause>& datasets = {},
+                       qlever::Allocator<Id> allocator = makeAllocator()) {
   return SparqlParser::parseQuery(encodedIriManager(), std::move(query),
-                                  datasets);
+                                  datasets, std::move(allocator));
+}
+
+// Convert a plain `std::vector<T>` into a `qlever::vector<T>`.
+template <typename T>
+qlever::vector<T> toQVec(std::vector<T> vec) {
+  return qlever::vector<T>(std::make_move_iterator(vec.begin()),
+                           std::make_move_iterator(vec.end()),
+                           qlever::makeUnlimitedAllocator<T>());
+}
+
+// Overload of `toQVec` for braced-init-list literals (e.g. `{a, b}`), since
+// template argument deduction does not work for `std::initializer_list`
+// arguments when passed as a bare braced list.
+template <typename T>
+qlever::vector<T> toQVec(std::initializer_list<T> ilist) {
+  return qlever::vector<T>(ilist.begin(), ilist.end(),
+                           qlever::makeUnlimitedAllocator<T>());
+}
+
+// Convert a plain `std::vector<std::vector<T>>` into a
+// `qlever::vector<qlever::vector<T>>`.
+template <typename T>
+qlever::vector<qlever::vector<T>> toQVecOfVec(
+    std::vector<std::vector<T>> vec) {
+  qlever::vector<qlever::vector<T>> result{
+      qlever::makeUnlimitedAllocator<qlever::vector<T>>()};
+  result.reserve(vec.size());
+  for (auto& inner : vec) {
+    result.push_back(toQVec(std::move(inner)));
+  }
+  return result;
+}
+
+// Build a `parsedQuery::SparqlValues` object from a plain vector of
+// `variables` and a plain vector of `values` (each inner vector being one
+// row of the `VALUES` clause). Useful in tests, since aggregate- or
+// brace-initializing `SparqlValues` directly with plain vector literals does
+// not compile (its members are allocator-aware and have no default
+// constructor).
+inline parsedQuery::SparqlValues makeSparqlValues(
+    std::vector<Variable> variables,
+    std::vector<std::vector<TripleComponent>> values = {}) {
+  parsedQuery::SparqlValues result{qlever::makeUnlimitedAllocator<Id>()};
+  result._variables = toQVec(std::move(variables));
+  result._values = toQVecOfVec(std::move(values));
+  return result;
 }
 
 }  // namespace ad_utility::testing


### PR DESCRIPTION
Convert dynamic-memory containers in JoinImpl, QueryPlanner, and SpatialJoin(Algorithms) to use qlever::Allocator instead of the default allocator
Fix downstream compile breakage in QueryPlannerTest, SpatialJoinAlgorithmsTest, and SpatialJoinTestHelpers.h caused by the allocator type changes, and resolve a stale-incremental-build ABI mismatch that caused JoinTest runtime crashes.

Verified with a full clean rebuild and complete ctest run
