### PR TITLE
Add the metric `qlever.index.num_triples` and split `qlever.delta_triples` into `inserted` and `deleted`

### DIFF
--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -102,7 +102,9 @@ void Server::initializeServerMetrics(
       [this]() -> int64_t {
         return static_cast<int64_t>(rebuildInProgress_.load());
       },
-      memoryLimit);
+      memoryLimit,
+      [this]() -> int64_t { return indexAndViewsSnapshot()->index_.numTriples().normal; }
+  );
   metrics_->registerCallbacks();
 }
 

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -103,8 +103,9 @@ void Server::initializeServerMetrics(
         return static_cast<int64_t>(rebuildInProgress_.load());
       },
       memoryLimit,
-      [this]() -> int64_t { return indexAndViewsSnapshot()->index_.numTriples().normal; }
-  );
+      [this]() -> int64_t {
+        return indexAndViewsSnapshot()->index_.numTriples().normal;
+      });
   metrics_->registerCallbacks();
 }
 

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -91,8 +91,7 @@ void Server::initializeServerMetrics(
                           .getCurrentLocatedTriplesSharedState()
                           ->counts_;
         AD_CORRECTNESS_CHECK(counts.has_value());
-        auto [ins, del] = counts.value();
-        return ins + del;
+        return counts.value();
       },
       [this]() -> int64_t { return allocator().amountMemoryLeft().getBytes(); },
       [this]() -> int64_t {

--- a/src/util/metrics/ServerMetrics.cpp
+++ b/src/util/metrics/ServerMetrics.cpp
@@ -23,12 +23,14 @@ ServerMetrics::ServerMetrics(
     absl::AnyInvocable<int64_t() const> getCacheUsed,
     absl::AnyInvocable<int64_t() const> getCacheLimit,
     absl::AnyInvocable<int64_t() const> getRebuildInProgress,
-    std::optional<ad_utility::MemorySize> maxMem)
+    std::optional<ad_utility::MemorySize> maxMem,
+    absl::AnyInvocable<int64_t() const> getTotalTriples)
     : getDeltaTriples_(std::move(getDeltaTriples)),
       getMemoryLeft_(std::move(getMemoryLeft)),
       getCacheUsed_(std::move(getCacheUsed)),
       getCacheLimit_(std::move(getCacheLimit)),
-      getRebuildInProgress_(std::move(getRebuildInProgress)) {
+      getRebuildInProgress_(std::move(getRebuildInProgress)),
+      getTotalTriples_(std::move(getTotalTriples)) {
   auto meter = opentelemetry::metrics::Provider::GetMeterProvider()->GetMeter(
       "qlever", "0.0.1");
   buildInfoMetric_ = meter->CreateInt64Gauge(
@@ -75,6 +77,8 @@ ServerMetrics::ServerMetrics(
   rebuildInProgressMetric_ = meter->CreateInt64ObservableGauge(
       "qlever.index.rebuild_in_progress",
       "Whether an index rebuild is currently in progress (1) or not (0)");
+  totalTriplesMetric_ = meter->CreateInt64ObservableGauge(
+      "qlever.total_triples", "Total number of triples in the index");
 
   auto now = std::chrono::duration_cast<std::chrono::seconds>(
                  std::chrono::system_clock::now().time_since_epoch())
@@ -123,6 +127,8 @@ ServerMetrics::~ServerMetrics() {
       &observeCallback<&ServerMetrics::getCacheLimit_>, this);
   rebuildInProgressMetric_->RemoveCallback(
       &observeCallback<&ServerMetrics::getRebuildInProgress_>, this);
+  totalTriplesMetric_->RemoveCallback(
+      &observeCallback<&ServerMetrics::getTotalTriples_>, this);
 }
 
 // _____________________________________________________________________________
@@ -137,6 +143,8 @@ void ServerMetrics::registerCallbacks() {
       &observeCallback<&ServerMetrics::getCacheLimit_>, this);
   rebuildInProgressMetric_->AddCallback(
       &observeCallback<&ServerMetrics::getRebuildInProgress_>, this);
+  totalTriplesMetric_->AddCallback(
+      &observeCallback<&ServerMetrics::getTotalTriples_>, this);
 }
 
 // _____________________________________________________________________________
@@ -148,7 +156,7 @@ void ServerMetrics::observe(opentelemetry::metrics::ObserverResult result,
 }
 
 // _____________________________________________________________________________
-template <absl::AnyInvocable<int64_t() const> ServerMetrics::*Getter>
+template <absl::AnyInvocable<int64_t() const> ServerMetrics::* Getter>
 void ServerMetrics::observeCallback(
     opentelemetry::metrics::ObserverResult result, void* state) {
   const auto& self = *static_cast<const ServerMetrics*>(state);

--- a/src/util/metrics/ServerMetrics.cpp
+++ b/src/util/metrics/ServerMetrics.cpp
@@ -30,9 +30,7 @@ ServerMetrics::ServerMetrics(
       getCacheUsed_(std::move(getCacheUsed)),
       getCacheLimit_(std::move(getCacheLimit)),
       getRebuildInProgress_(std::move(getRebuildInProgress)),
-      getNumTriplesIndex_(std::move(getNumTriplesIndex)),
-      getNumTriplesTotal_(
-          [this]() { return getNumTriplesIndex_() + getDeltaTriples_(); }) {
+      getNumTriplesIndex_(std::move(getNumTriplesIndex)) {
   auto meter = opentelemetry::metrics::Provider::GetMeterProvider()->GetMeter(
       "qlever", "0.0.1");
   buildInfoMetric_ = meter->CreateInt64Gauge(
@@ -82,8 +80,6 @@ ServerMetrics::ServerMetrics(
   numTriplesIndex_ = meter->CreateInt64ObservableGauge(
       "qlever.num_triples.index",
       "Total number of triples in the index (excluding delta triples)");
-  numTriplesTotal_ = meter->CreateInt64ObservableGauge(
-      "qlever.num_triples.total", "Total number of triples");
 
   auto now = std::chrono::duration_cast<std::chrono::seconds>(
                  std::chrono::system_clock::now().time_since_epoch())
@@ -134,8 +130,6 @@ ServerMetrics::~ServerMetrics() {
       &observeCallback<&ServerMetrics::getRebuildInProgress_>, this);
   numTriplesIndex_->RemoveCallback(
       &observeCallback<&ServerMetrics::getNumTriplesIndex_>, this);
-  numTriplesTotal_->RemoveCallback(
-      &observeCallback<&ServerMetrics::getNumTriplesTotal_>, this);
 }
 
 // _____________________________________________________________________________
@@ -152,8 +146,6 @@ void ServerMetrics::registerCallbacks() {
       &observeCallback<&ServerMetrics::getRebuildInProgress_>, this);
   numTriplesIndex_->AddCallback(
       &observeCallback<&ServerMetrics::getNumTriplesIndex_>, this);
-  numTriplesTotal_->AddCallback(
-      &observeCallback<&ServerMetrics::getNumTriplesTotal_>, this);
 }
 
 // _____________________________________________________________________________

--- a/src/util/metrics/ServerMetrics.cpp
+++ b/src/util/metrics/ServerMetrics.cpp
@@ -18,7 +18,7 @@
 
 // _____________________________________________________________________________
 ServerMetrics::ServerMetrics(
-    absl::AnyInvocable<int64_t() const> getDeltaTriples,
+    absl::AnyInvocable<DeltaTriplesCount() const> getDeltaTriples,
     absl::AnyInvocable<int64_t() const> getMemoryLeft,
     absl::AnyInvocable<int64_t() const> getCacheUsed,
     absl::AnyInvocable<int64_t() const> getCacheLimit,
@@ -118,8 +118,7 @@ ServerMetrics::ServerMetrics(
 
 // _____________________________________________________________________________
 ServerMetrics::~ServerMetrics() {
-  deltaTriplesMetric_->RemoveCallback(
-      &observeCallback<&ServerMetrics::getDeltaTriples_>, this);
+  deltaTriplesMetric_->RemoveCallback(&deltaTriplesCallback, this);
   memoryQueryFree_->RemoveCallback(
       &observeCallback<&ServerMetrics::getMemoryLeft_>, this);
   memoryCacheUsed_->RemoveCallback(
@@ -134,8 +133,7 @@ ServerMetrics::~ServerMetrics() {
 
 // _____________________________________________________________________________
 void ServerMetrics::registerCallbacks() {
-  deltaTriplesMetric_->AddCallback(
-      &observeCallback<&ServerMetrics::getDeltaTriples_>, this);
+  deltaTriplesMetric_->AddCallback(&deltaTriplesCallback, this);
   memoryQueryFree_->AddCallback(
       &observeCallback<&ServerMetrics::getMemoryLeft_>, this);
   memoryCacheUsed_->AddCallback(&observeCallback<&ServerMetrics::getCacheUsed_>,
@@ -157,9 +155,28 @@ void ServerMetrics::observe(opentelemetry::metrics::ObserverResult result,
 }
 
 // _____________________________________________________________________________
-template <absl::AnyInvocable<int64_t() const> ServerMetrics::*Getter>
+void ServerMetrics::observe(opentelemetry::metrics::ObserverResult result,
+                            int64_t value, const std::string& label,
+                            const std::string& labelValue) {
+  opentelemetry::nostd::get<opentelemetry::nostd::shared_ptr<
+      opentelemetry::metrics::ObserverResultT<int64_t>>>(result)
+      ->Observe(value, {{label, labelValue}});
+}
+
+// _____________________________________________________________________________
+template <absl::AnyInvocable<int64_t() const> ServerMetrics::* Getter>
 void ServerMetrics::observeCallback(
     opentelemetry::metrics::ObserverResult result, void* state) {
   const auto& self = *static_cast<const ServerMetrics*>(state);
   observe(std::move(result), (self.*Getter)());
+}
+
+// _____________________________________________________________________________
+void ServerMetrics::deltaTriplesCallback(
+    opentelemetry::metrics::ObserverResult result, void* state) {
+  const auto& self = *static_cast<const ServerMetrics*>(state);
+  auto deltaTriples = self.getDeltaTriples_();
+  observe(result, deltaTriples.triplesInserted_, "type", "added");
+  observe(result, deltaTriples.triplesDeleted_, "type", "removed");
+  observe(result, deltaTriples.triplesInserted_ + deltaTriples.triplesDeleted_);
 }

--- a/src/util/metrics/ServerMetrics.cpp
+++ b/src/util/metrics/ServerMetrics.cpp
@@ -24,13 +24,15 @@ ServerMetrics::ServerMetrics(
     absl::AnyInvocable<int64_t() const> getCacheLimit,
     absl::AnyInvocable<int64_t() const> getRebuildInProgress,
     std::optional<ad_utility::MemorySize> maxMem,
-    absl::AnyInvocable<int64_t() const> getTotalTriples)
+    absl::AnyInvocable<int64_t() const> getNumTriplesIndex)
     : getDeltaTriples_(std::move(getDeltaTriples)),
       getMemoryLeft_(std::move(getMemoryLeft)),
       getCacheUsed_(std::move(getCacheUsed)),
       getCacheLimit_(std::move(getCacheLimit)),
       getRebuildInProgress_(std::move(getRebuildInProgress)),
-      getTotalTriples_(std::move(getTotalTriples)) {
+      getNumTriplesIndex_(std::move(getNumTriplesIndex)),
+      getNumTriplesTotal_(
+          [this]() { return getNumTriplesIndex_() + getDeltaTriples_(); }) {
   auto meter = opentelemetry::metrics::Provider::GetMeterProvider()->GetMeter(
       "qlever", "0.0.1");
   buildInfoMetric_ = meter->CreateInt64Gauge(
@@ -77,8 +79,11 @@ ServerMetrics::ServerMetrics(
   rebuildInProgressMetric_ = meter->CreateInt64ObservableGauge(
       "qlever.index.rebuild_in_progress",
       "Whether an index rebuild is currently in progress (1) or not (0)");
-  totalTriplesMetric_ = meter->CreateInt64ObservableGauge(
-      "qlever.total_triples", "Total number of triples in the index");
+  numTriplesIndex_ = meter->CreateInt64ObservableGauge(
+      "qlever.num_triples.index",
+      "Total number of triples in the index (excluding delta triples)");
+  numTriplesTotal_ = meter->CreateInt64ObservableGauge(
+      "qlever.num_triples.total", "Total number of triples");
 
   auto now = std::chrono::duration_cast<std::chrono::seconds>(
                  std::chrono::system_clock::now().time_since_epoch())
@@ -127,8 +132,10 @@ ServerMetrics::~ServerMetrics() {
       &observeCallback<&ServerMetrics::getCacheLimit_>, this);
   rebuildInProgressMetric_->RemoveCallback(
       &observeCallback<&ServerMetrics::getRebuildInProgress_>, this);
-  totalTriplesMetric_->RemoveCallback(
-      &observeCallback<&ServerMetrics::getTotalTriples_>, this);
+  numTriplesIndex_->RemoveCallback(
+      &observeCallback<&ServerMetrics::getNumTriplesIndex_>, this);
+  numTriplesTotal_->RemoveCallback(
+      &observeCallback<&ServerMetrics::getNumTriplesTotal_>, this);
 }
 
 // _____________________________________________________________________________
@@ -143,8 +150,10 @@ void ServerMetrics::registerCallbacks() {
       &observeCallback<&ServerMetrics::getCacheLimit_>, this);
   rebuildInProgressMetric_->AddCallback(
       &observeCallback<&ServerMetrics::getRebuildInProgress_>, this);
-  totalTriplesMetric_->AddCallback(
-      &observeCallback<&ServerMetrics::getTotalTriples_>, this);
+  numTriplesIndex_->AddCallback(
+      &observeCallback<&ServerMetrics::getNumTriplesIndex_>, this);
+  numTriplesTotal_->AddCallback(
+      &observeCallback<&ServerMetrics::getNumTriplesTotal_>, this);
 }
 
 // _____________________________________________________________________________

--- a/src/util/metrics/ServerMetrics.cpp
+++ b/src/util/metrics/ServerMetrics.cpp
@@ -156,7 +156,7 @@ void ServerMetrics::observe(opentelemetry::metrics::ObserverResult result,
 }
 
 // _____________________________________________________________________________
-template <absl::AnyInvocable<int64_t() const> ServerMetrics::* Getter>
+template <absl::AnyInvocable<int64_t() const> ServerMetrics::*Getter>
 void ServerMetrics::observeCallback(
     opentelemetry::metrics::ObserverResult result, void* state) {
   const auto& self = *static_cast<const ServerMetrics*>(state);

--- a/src/util/metrics/ServerMetrics.cpp
+++ b/src/util/metrics/ServerMetrics.cpp
@@ -164,7 +164,7 @@ void ServerMetrics::observe(opentelemetry::metrics::ObserverResult result,
 }
 
 // _____________________________________________________________________________
-template <absl::AnyInvocable<int64_t() const> ServerMetrics::* Getter>
+template <absl::AnyInvocable<int64_t() const> ServerMetrics::*Getter>
 void ServerMetrics::observeCallback(
     opentelemetry::metrics::ObserverResult result, void* state) {
   const auto& self = *static_cast<const ServerMetrics*>(state);

--- a/src/util/metrics/ServerMetrics.h
+++ b/src/util/metrics/ServerMetrics.h
@@ -16,6 +16,7 @@
 
 #include <memory>
 
+#include "index/DeltaTriples.h"
 #include "util/MemorySize/MemorySize.h"
 
 // Owns all OTEL instruments and deregisters observable callbacks on
@@ -42,7 +43,7 @@ class ServerMetrics {
   std::unique_ptr<opentelemetry::metrics::Counter<uint64_t>> httpErrors_;
   std::unique_ptr<opentelemetry::metrics::Gauge<int64_t>> memoryQueryTotal_;
 
-  ServerMetrics(absl::AnyInvocable<int64_t() const> getDeltaTriples,
+  ServerMetrics(absl::AnyInvocable<DeltaTriplesCount() const> getDeltaTriples,
                 absl::AnyInvocable<int64_t() const> getMemoryLeft,
                 absl::AnyInvocable<int64_t() const> getCacheUsed,
                 absl::AnyInvocable<int64_t() const> getCacheLimit,
@@ -52,13 +53,18 @@ class ServerMetrics {
   void registerCallbacks();
 
  private:
-  template <absl::AnyInvocable<int64_t() const> ServerMetrics::*Getter>
+  template <absl::AnyInvocable<int64_t() const> ServerMetrics::* Getter>
   static void observeCallback(opentelemetry::metrics::ObserverResult result,
                               void* state);
+  static void deltaTriplesCallback(
+      opentelemetry::metrics::ObserverResult result, void* state);
   static void observe(opentelemetry::metrics::ObserverResult result,
                       int64_t value);
+  static void observe(opentelemetry::metrics::ObserverResult result,
+                      int64_t value, const std::string& label,
+                      const std::string& labelValue);
 
-  absl::AnyInvocable<int64_t() const> getDeltaTriples_;
+  absl::AnyInvocable<DeltaTriplesCount() const> getDeltaTriples_;
   absl::AnyInvocable<int64_t() const> getMemoryLeft_;
   absl::AnyInvocable<int64_t() const> getCacheUsed_;
   absl::AnyInvocable<int64_t() const> getCacheLimit_;

--- a/src/util/metrics/ServerMetrics.h
+++ b/src/util/metrics/ServerMetrics.h
@@ -47,7 +47,8 @@ class ServerMetrics {
                 absl::AnyInvocable<int64_t() const> getCacheUsed,
                 absl::AnyInvocable<int64_t() const> getCacheLimit,
                 absl::AnyInvocable<int64_t() const> getRebuildInProgress,
-                std::optional<ad_utility::MemorySize> maxMem);
+                std::optional<ad_utility::MemorySize> maxMem,
+                absl::AnyInvocable<int64_t() const> getTotalTriples);
   void registerCallbacks();
 
  private:
@@ -62,6 +63,7 @@ class ServerMetrics {
   absl::AnyInvocable<int64_t() const> getCacheUsed_;
   absl::AnyInvocable<int64_t() const> getCacheLimit_;
   absl::AnyInvocable<int64_t() const> getRebuildInProgress_;
+  absl::AnyInvocable<int64_t() const> getTotalTriples_;
 
   // Observable instruments: SDK invokes callbacks on scrape; RemoveCallback
   // in ~ServerMetrics() blocks until any in-flight callback returns.
@@ -75,6 +77,8 @@ class ServerMetrics {
       memoryCacheLimit_;
   std::shared_ptr<opentelemetry::metrics::ObservableInstrument>
       rebuildInProgressMetric_;
+  std::shared_ptr<opentelemetry::metrics::ObservableInstrument>
+      totalTriplesMetric_;
 };
 
 #endif  // QLEVER_SRC_UTIL_METRICS_SERVERMETRICS_H

--- a/src/util/metrics/ServerMetrics.h
+++ b/src/util/metrics/ServerMetrics.h
@@ -53,7 +53,7 @@ class ServerMetrics {
   void registerCallbacks();
 
  private:
-  template <absl::AnyInvocable<int64_t() const> ServerMetrics::* Getter>
+  template <absl::AnyInvocable<int64_t() const> ServerMetrics::*Getter>
   static void observeCallback(opentelemetry::metrics::ObserverResult result,
                               void* state);
   static void deltaTriplesCallback(

--- a/src/util/metrics/ServerMetrics.h
+++ b/src/util/metrics/ServerMetrics.h
@@ -48,7 +48,7 @@ class ServerMetrics {
                 absl::AnyInvocable<int64_t() const> getCacheLimit,
                 absl::AnyInvocable<int64_t() const> getRebuildInProgress,
                 std::optional<ad_utility::MemorySize> maxMem,
-                absl::AnyInvocable<int64_t() const> getTotalTriples);
+                absl::AnyInvocable<int64_t() const> getNumTriplesIndex);
   void registerCallbacks();
 
  private:
@@ -63,7 +63,8 @@ class ServerMetrics {
   absl::AnyInvocable<int64_t() const> getCacheUsed_;
   absl::AnyInvocable<int64_t() const> getCacheLimit_;
   absl::AnyInvocable<int64_t() const> getRebuildInProgress_;
-  absl::AnyInvocable<int64_t() const> getTotalTriples_;
+  absl::AnyInvocable<int64_t() const> getNumTriplesIndex_;
+  absl::AnyInvocable<int64_t() const> getNumTriplesTotal_;
 
   // Observable instruments: SDK invokes callbacks on scrape; RemoveCallback
   // in ~ServerMetrics() blocks until any in-flight callback returns.
@@ -78,7 +79,9 @@ class ServerMetrics {
   std::shared_ptr<opentelemetry::metrics::ObservableInstrument>
       rebuildInProgressMetric_;
   std::shared_ptr<opentelemetry::metrics::ObservableInstrument>
-      totalTriplesMetric_;
+      numTriplesIndex_;
+  std::shared_ptr<opentelemetry::metrics::ObservableInstrument>
+      numTriplesTotal_;
 };
 
 #endif  // QLEVER_SRC_UTIL_METRICS_SERVERMETRICS_H

--- a/src/util/metrics/ServerMetrics.h
+++ b/src/util/metrics/ServerMetrics.h
@@ -64,7 +64,6 @@ class ServerMetrics {
   absl::AnyInvocable<int64_t() const> getCacheLimit_;
   absl::AnyInvocable<int64_t() const> getRebuildInProgress_;
   absl::AnyInvocable<int64_t() const> getNumTriplesIndex_;
-  absl::AnyInvocable<int64_t() const> getNumTriplesTotal_;
 
   // Observable instruments: SDK invokes callbacks on scrape; RemoveCallback
   // in ~ServerMetrics() blocks until any in-flight callback returns.
@@ -80,8 +79,6 @@ class ServerMetrics {
       rebuildInProgressMetric_;
   std::shared_ptr<opentelemetry::metrics::ObservableInstrument>
       numTriplesIndex_;
-  std::shared_ptr<opentelemetry::metrics::ObservableInstrument>
-      numTriplesTotal_;
 };
 
 #endif  // QLEVER_SRC_UTIL_METRICS_SERVERMETRICS_H

--- a/src/util/metrics/ServerMetrics.h
+++ b/src/util/metrics/ServerMetrics.h
@@ -16,7 +16,7 @@
 
 #include <memory>
 
-#include "index/DeltaTriples.h"
+#include "engine/UpdateMetadata.h"
 #include "util/MemorySize/MemorySize.h"
 
 // Owns all OTEL instruments and deregisters observable callbacks on


### PR DESCRIPTION
So far, the `/metrics` endpoint reported the delta triples only as one number, the sum of the inserted and the deleted triples, and nothing about the size of the index itself. A dashboard that wants to show (an estimate for) the current number of triples had no way to compute it.

This change adds the observable gauge `qlever.index.num_triples` with the number of triples in the index (without the QLever-internal triples and without the delta triples). It is read from the metadata of the index, and is also correct after an index rebuild has swapped in a new index. The gauge `qlever.delta_triples` is additionally reported with a label `type`, with the values `inserted` and `deleted`, next to the unlabeled sum as before. The number of triples visible to queries is then approximately `qlever_index_num_triples + qlever_delta_triples{type="inserted"} - qlever_delta_triples{type="deleted"}`. This is only an approximation, because an insertion of a triple that is already in the index and a deletion of a triple that is not are still counted as delta triples.