### PR TITLE
Marvin io uring param tuning

### DIFF
--- a/src/global/RuntimeParameters.cpp
+++ b/src/global/RuntimeParameters.cpp
@@ -66,7 +66,9 @@ RuntimeParameters::RuntimeParameters() {
   add(vacuumMinimumBlockSize_);
   add(disableCaching_);
   add(logLevel_);
-  add(constructDeduplication_);\n  add(vocabBatchIoRingSize_);\n  add(vocabBatchIoNumManagers_);
+  add(constructDeduplication_);
+  add(vocabBatchIoRingSize_);
+  add(vocabBatchIoNumManagers_);
 
   // Propagate runtime log level changes immediately to the global atomic in
   // Log.h. The action fires once immediately on registration, so the atomic is

--- a/src/global/RuntimeParameters.cpp
+++ b/src/global/RuntimeParameters.cpp
@@ -66,7 +66,7 @@ RuntimeParameters::RuntimeParameters() {
   add(vacuumMinimumBlockSize_);
   add(disableCaching_);
   add(logLevel_);
-  add(constructDeduplication_);
+  add(constructDeduplication_);\n  add(vocabBatchIoRingSize_);\n  add(vocabBatchIoNumManagers_);
 
   // Propagate runtime log level changes immediately to the global atomic in
   // Log.h. The action fires once immediately on registration, so the atomic is

--- a/src/global/RuntimeParameters.cpp
+++ b/src/global/RuntimeParameters.cpp
@@ -1,7 +1,8 @@
-// Copyright 2025 The QLever Authors, in particular:
+// Copyright 2025 - 2026, The QLever Authors, in particular:
 //
-// 2025 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
-// 2025 NN, BMW
+// 2025 - 2026 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+// 2025 - 2026 NN, BMW
+// 2026        Marvin Stoetzel <stoetzem@email.uni-freiburg.de>, UFR
 //
 // UFR = University of Freiburg, Chair of Algorithms and Data Structures
 // BMW =  Bayerische Motoren Werke Aktiengesellschaft (BMW AG)

--- a/src/global/RuntimeParameters.h
+++ b/src/global/RuntimeParameters.h
@@ -248,7 +248,8 @@ struct RuntimeParameters {
   // holds its own io_uring ring, so this bounds the number of concurrent
   // batch vocabulary lookups.  More managers = more parallelism for
   // multi-query workloads, at the cost of memory for rings + registered
-  // buffers.
+  // buffers.  The default value matches NUM_VOCAB_BATCH_IO_MANAGERS
+  // (Constants.h), which this runtime parameter replaces.
   SizeT vocabBatchIoNumManagers_{8, "vocab-batch-io-num-managers"};
 
   // ___________________________________________________________________________

--- a/src/global/RuntimeParameters.h
+++ b/src/global/RuntimeParameters.h
@@ -1,6 +1,9 @@
-//   Copyright 2024, University of Freiburg,
-//   Chair of Algorithms and Data Structures.
-//   Author: Robin Textor-Falconi <textorr@informatik.uni-freiburg.de>
+// Copyright 2024 - 2026, The QLever Authors, in particular:
+//
+// 2024 - 2026 Robin Textor-Falconi <textorr@informatik.uni-freiburg.de>, UFR
+// 2026        Marvin Stoetzel <stoetzem@email.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
 
 #ifndef QLEVER_RUNTIMEPARAMETERS_H
 #define QLEVER_RUNTIMEPARAMETERS_H

--- a/src/global/RuntimeParameters.h
+++ b/src/global/RuntimeParameters.h
@@ -239,6 +239,18 @@ struct RuntimeParameters {
   DeduplicationModeParameter constructDeduplication_{
       DeduplicationMode{DeduplicationMode::None{}}, "construct-deduplication"};
 
+  // Size of the io_uring submission queue (ring size) per batch I/O manager.
+  // Powers of two are preferred; liburing rounds up.  Larger rings increase
+  // in-flight I/O concurrency at the cost of registered buffer memory.
+  SizeT vocabBatchIoRingSize_{256, "vocab-batch-io-ring-size"};
+
+  // Number of persistent BatchIoManager instances in the pool.  Each manager
+  // holds its own io_uring ring, so this bounds the number of concurrent
+  // batch vocabulary lookups.  More managers = more parallelism for
+  // multi-query workloads, at the cost of memory for rings + registered
+  // buffers.
+  SizeT vocabBatchIoNumManagers_{8, "vocab-batch-io-num-managers"};
+
   // ___________________________________________________________________________
   // IMPORTANT NOTE: IF YOU ADD PARAMETERS ABOVE, ALSO REGISTER THEM IN THE
   // CONSTRUCTOR, S.T. THEY CAN ALSO BE ACCESSED VIA THE RUNTIME INTERFACE.

--- a/src/global/RuntimeParameters.h
+++ b/src/global/RuntimeParameters.h
@@ -11,6 +11,7 @@
 #include <algorithm>
 #include <optional>
 
+#include "global/Constants.h"
 #include "util/Log.h"
 #include "util/Parameters.h"
 
@@ -251,9 +252,10 @@ struct RuntimeParameters {
   // holds its own io_uring ring, so this bounds the number of concurrent
   // batch vocabulary lookups.  More managers = more parallelism for
   // multi-query workloads, at the cost of memory for rings + registered
-  // buffers.  The default value matches NUM_VOCAB_BATCH_IO_MANAGERS
-  // (Constants.h), which this runtime parameter replaces.
-  SizeT vocabBatchIoNumManagers_{8, "vocab-batch-io-num-managers"};
+  // buffers.  The default value is the constant `NUM_VOCAB_BATCH_IO_MANAGERS`
+  // (Constants.h), the single source of truth for this value.
+  SizeT vocabBatchIoNumManagers_{NUM_VOCAB_BATCH_IO_MANAGERS,
+                                 "vocab-batch-io-num-managers"};
 
   // ___________________________________________________________________________
   // IMPORTANT NOTE: IF YOU ADD PARAMETERS ABOVE, ALSO REGISTER THEM IN THE

--- a/src/index/vocabulary/CMakeLists.txt
+++ b/src/index/vocabulary/CMakeLists.txt
@@ -10,4 +10,4 @@ add_library(vocabulary VocabularyInMemory.h VocabularyInMemory.cpp
                        VocabularyInMemoryBinSearch.cpp VocabularyInternalExternal.cpp
                        VocabularyOnDisk.cpp SplitVocabulary.cpp GeoVocabulary.cpp PolymorphicVocabulary.cpp
                        Vocabulary.cpp EncodedIriManager.cpp PrefixHeuristic.cpp)
-qlever_target_link_libraries(vocabulary qlever_util rdfTypes)
+qlever_target_link_libraries(vocabulary qlever_util rdfTypes global)

--- a/src/index/vocabulary/VocabularyOnDisk.cpp
+++ b/src/index/vocabulary/VocabularyOnDisk.cpp
@@ -11,6 +11,7 @@
 #include <array>
 
 #include "global/Constants.h"
+#include "global/RuntimeParameters.h"
 #include "util/ExceptionHandling.h"
 #include "util/InputRangeUtils.h"
 #include "util/Iterators.h"
@@ -288,14 +289,10 @@ void VocabularyOnDisk::open(const std::string& filename) {
   size_ = numOffsets - 1;
 
   // Initialize pool of persistent `BatchIoManager`s for `lookupBatch`.
-  // These defaults can be overridden at runtime via the
-  // `vocab-batch-io-ring-size` and `vocab-batch-io-num-managers`
-  // server runtime parameters, which are read by
-  // `QueryExecutionContext` and passed through `Index` to here.
-  // TODO: Wire runtime parameters through the Index → Vocabulary
-  //       initialization path so these aren't compile-time only.
-  size_t numManagers = NUM_VOCAB_BATCH_IO_MANAGERS;
-  size_t ringSize = 256;
+  size_t numManagers =
+      getRuntimeParameter<&RuntimeParameters::vocabBatchIoNumManagers_>();
+  size_t ringSize =
+      getRuntimeParameter<&RuntimeParameters::vocabBatchIoRingSize_>();
   ioManagers_ = std::make_unique<ad_utility::data_structures::ThreadSafeQueue<
       std::unique_ptr<ad_utility::BatchManagerBase>>>(numManagers);
   bool preferIoUring = true;

--- a/src/index/vocabulary/VocabularyOnDisk.cpp
+++ b/src/index/vocabulary/VocabularyOnDisk.cpp
@@ -12,6 +12,7 @@
 
 #include <algorithm>
 #include <array>
+#include <limits>
 
 #include "global/Constants.h"
 #include "global/RuntimeParameters.h"
@@ -167,7 +168,7 @@ std::vector<VocabularyOnDisk::OffsetPair> VocabularyOnDisk::readOffsetPairs(
   // (which bounds the string) as one 16-byte pair from `.offsets`.
   const size_t numIndices = indices.size();
   std::vector<OffsetPair> offsetPairs(numIndices);
-  std::vector sizes(numIndices, sizeof(OffsetPair));
+  std::vector<size_t> sizes(numIndices, sizeof(OffsetPair));
   std::vector<uint64_t> fileOffsets(numIndices);
   std::vector<char*> targets(numIndices);
   for (auto&& [fileOffset, index, target, offsetPair] :
@@ -296,13 +297,19 @@ void VocabularyOnDisk::open(const std::string& filename) {
       getRuntimeParameter<&RuntimeParameters::vocabBatchIoNumManagers_>();
   size_t ringSize =
       getRuntimeParameter<&RuntimeParameters::vocabBatchIoRingSize_>();
+  // A pool without managers would make every `lookupBatch` block forever, and
+  // the batch manager API takes an `unsigned` ring size, so reject values that
+  // do not fit into the `unsigned` range (instead of silently wrapping them).
+  AD_CONTRACT_CHECK(numManagers > 0);
+  AD_CONTRACT_CHECK(ringSize > 0 &&
+                    ringSize <= std::numeric_limits<unsigned>::max());
   ioManagers_ = std::make_unique<ad_utility::data_structures::ThreadSafeQueue<
       std::unique_ptr<ad_utility::BatchManagerBase>>>(numManagers);
   bool preferIoUring = true;
   for (size_t i = 0; i < numManagers; ++i) {
-    // The runtime parameter is a size_t; the batch manager API takes an
-    // unsigned ring size. The default (256) is far below the unsigned
-    // range, and liburing rejects impractically large rings anyway.
+    // The runtime parameter is a `size_t`; the batch manager API takes an
+    // `unsigned` ring size. Values above `UINT_MAX` were rejected above, so
+    // the cast is safe.
     ioManagers_->push(ad_utility::makeBatchManager(
         preferIoUring, static_cast<unsigned>(ringSize)));
   }

--- a/src/index/vocabulary/VocabularyOnDisk.cpp
+++ b/src/index/vocabulary/VocabularyOnDisk.cpp
@@ -1,6 +1,9 @@
-// Copyright 2022, University of Freiburg,
-// Chair of Algorithms and Data Structures.
-// Author: Johannes Kalmbach <johannes.kalmbach@gmail.com>
+// Copyright 2022 - 2026, The QLever Authors, in particular:
+//
+// 2022 - 2026 Johannes Kalmbach <johannes.kalmbach@gmail.com>, UFR
+// 2026        Marvin Stoetzel <stoetzem@email.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
 
 #include "index/vocabulary/VocabularyOnDisk.h"
 

--- a/src/index/vocabulary/VocabularyOnDisk.cpp
+++ b/src/index/vocabulary/VocabularyOnDisk.cpp
@@ -290,16 +290,13 @@ void VocabularyOnDisk::open(const std::string& filename) {
 
   // Initialize pool of persistent `BatchIoManager`s for `lookupBatch`.
   size_t numManagers =
-      getRuntimeParameter<
-          &RuntimeParameters::vocabBatchIoNumManagers_>();
-  size_t ringSize = getRuntimeParameter<
-      &RuntimeParameters::vocabBatchIoRingSize_>();
+      getRuntimeParameter<&RuntimeParameters::vocabBatchIoNumManagers_>();
+  size_t ringSize =
+      getRuntimeParameter<&RuntimeParameters::vocabBatchIoRingSize_>();
   ioManagers_ = std::make_unique<ad_utility::data_structures::ThreadSafeQueue<
-      std::unique_ptr<ad_utility::BatchManagerBase>>>(
-      numManagers);
+      std::unique_ptr<ad_utility::BatchManagerBase>>>(numManagers);
   bool preferIoUring = true;
   for (size_t i = 0; i < numManagers; ++i) {
-    ioManagers_->push(
-        ad_utility::makeBatchManager(preferIoUring, ringSize));
+    ioManagers_->push(ad_utility::makeBatchManager(preferIoUring, ringSize));
   }
 }

--- a/src/index/vocabulary/VocabularyOnDisk.cpp
+++ b/src/index/vocabulary/VocabularyOnDisk.cpp
@@ -11,7 +11,6 @@
 #include <array>
 
 #include "global/Constants.h"
-#include "global/RuntimeParameters.h"
 #include "util/ExceptionHandling.h"
 #include "util/InputRangeUtils.h"
 #include "util/Iterators.h"
@@ -289,10 +288,14 @@ void VocabularyOnDisk::open(const std::string& filename) {
   size_ = numOffsets - 1;
 
   // Initialize pool of persistent `BatchIoManager`s for `lookupBatch`.
-  size_t numManagers =
-      getRuntimeParameter<&RuntimeParameters::vocabBatchIoNumManagers_>();
-  size_t ringSize =
-      getRuntimeParameter<&RuntimeParameters::vocabBatchIoRingSize_>();
+  // These defaults can be overridden at runtime via the
+  // `vocab-batch-io-ring-size` and `vocab-batch-io-num-managers`
+  // server runtime parameters, which are read by
+  // `QueryExecutionContext` and passed through `Index` to here.
+  // TODO: Wire runtime parameters through the Index → Vocabulary
+  //       initialization path so these aren't compile-time only.
+  size_t numManagers = NUM_VOCAB_BATCH_IO_MANAGERS;
+  size_t ringSize = 256;
   ioManagers_ = std::make_unique<ad_utility::data_structures::ThreadSafeQueue<
       std::unique_ptr<ad_utility::BatchManagerBase>>>(numManagers);
   bool preferIoUring = true;

--- a/src/index/vocabulary/VocabularyOnDisk.cpp
+++ b/src/index/vocabulary/VocabularyOnDisk.cpp
@@ -11,6 +11,7 @@
 #include <array>
 
 #include "global/Constants.h"
+#include "global/RuntimeParameters.h"
 #include "util/ExceptionHandling.h"
 #include "util/InputRangeUtils.h"
 #include "util/Iterators.h"
@@ -288,11 +289,17 @@ void VocabularyOnDisk::open(const std::string& filename) {
   size_ = numOffsets - 1;
 
   // Initialize pool of persistent `BatchIoManager`s for `lookupBatch`.
+  size_t numManagers =
+      getRuntimeParameter<
+          &RuntimeParameters::vocabBatchIoNumManagers_>();
+  size_t ringSize = getRuntimeParameter<
+      &RuntimeParameters::vocabBatchIoRingSize_>();
   ioManagers_ = std::make_unique<ad_utility::data_structures::ThreadSafeQueue<
       std::unique_ptr<ad_utility::BatchManagerBase>>>(
-      NUM_VOCAB_BATCH_IO_MANAGERS);
+      numManagers);
   bool preferIoUring = true;
-  for (size_t i = 0; i < NUM_VOCAB_BATCH_IO_MANAGERS; ++i) {
-    ioManagers_->push(ad_utility::makeBatchManager(preferIoUring));
+  for (size_t i = 0; i < numManagers; ++i) {
+    ioManagers_->push(
+        ad_utility::makeBatchManager(preferIoUring, ringSize));
   }
 }

--- a/src/index/vocabulary/VocabularyOnDisk.cpp
+++ b/src/index/vocabulary/VocabularyOnDisk.cpp
@@ -164,7 +164,7 @@ std::vector<VocabularyOnDisk::OffsetPair> VocabularyOnDisk::readOffsetPairs(
   // (which bounds the string) as one 16-byte pair from `.offsets`.
   const size_t numIndices = indices.size();
   std::vector<OffsetPair> offsetPairs(numIndices);
-  std::vector<size_t> sizes(numIndices, sizeof(OffsetPair));
+  std::vector sizes(numIndices, sizeof(OffsetPair));
   std::vector<uint64_t> fileOffsets(numIndices);
   std::vector<char*> targets(numIndices);
   for (auto&& [fileOffset, index, target, offsetPair] :
@@ -297,6 +297,10 @@ void VocabularyOnDisk::open(const std::string& filename) {
       std::unique_ptr<ad_utility::BatchManagerBase>>>(numManagers);
   bool preferIoUring = true;
   for (size_t i = 0; i < numManagers; ++i) {
-    ioManagers_->push(ad_utility::makeBatchManager(preferIoUring, ringSize));
+    // The runtime parameter is a size_t; the batch manager API takes an
+    // unsigned ring size. The default (256) is far below the unsigned
+    // range, and liburing rejects impractically large rings anyway.
+    ioManagers_->push(ad_utility::makeBatchManager(
+        preferIoUring, static_cast<unsigned>(ringSize)));
   }
 }

--- a/test/index/vocabulary/VocabularyOnDiskTest.cpp
+++ b/test/index/vocabulary/VocabularyOnDiskTest.cpp
@@ -16,13 +16,13 @@
 
 #include "../../util/GTestHelpers.h"
 #include "../../util/MmapVectorLegacyFormat.h"
+#include "../../util/RuntimeParametersTestHelpers.h"
 #include "./VocabularyTestHelpers.h"
 #include "backports/algorithm.h"
 #include "index/vocabulary/VocabularyOnDisk.h"
 #include "util/File.h"
 #include "util/Forward.h"
 #include "util/MmapVector.h"
-#include "util/RuntimeParametersTestHelpers.h"
 
 namespace {
 using namespace vocabulary_test;
@@ -364,7 +364,8 @@ TEST(VocabularyOnDisk, BatchIoRuntimeParametersAreValidated) {
   // A ring size above `UINT_MAX` must be rejected instead of being wrapped by
   // the `static_cast<unsigned>` in `open`.
   testInvalid([] {
-    return setRuntimeParameterForTest<&RuntimeParameters::vocabBatchIoRingSize_>(
+    return setRuntimeParameterForTest<
+        &RuntimeParameters::vocabBatchIoRingSize_>(
         static_cast<size_t>(std::numeric_limits<unsigned>::max()) + 1);
   });
 }
@@ -372,10 +373,12 @@ TEST(VocabularyOnDisk, BatchIoRuntimeParametersAreValidated) {
 // With valid runtime parameter values, `open` must create a working manager
 // pool: batch lookups still return the correct results.
 TEST(VocabularyOnDisk, BatchIoRuntimeParametersAreApplied) {
-  auto resetManagers = setRuntimeParameterForTest<
-      &RuntimeParameters::vocabBatchIoNumManagers_>(2);
-  auto resetRingSize = setRuntimeParameterForTest<
-      &RuntimeParameters::vocabBatchIoRingSize_>(128);
+  auto resetManagers =
+      setRuntimeParameterForTest<&RuntimeParameters::vocabBatchIoNumManagers_>(
+          2);
+  auto resetRingSize =
+      setRuntimeParameterForTest<&RuntimeParameters::vocabBatchIoRingSize_>(
+          128);
   auto vocab = createExampleVocabulary();
   std::array<size_t, 8> indices{2, 0, 3, 1, 1, 4, 0, 3};
   auto result = vocab->lookupBatch(indices);

--- a/test/index/vocabulary/VocabularyOnDiskTest.cpp
+++ b/test/index/vocabulary/VocabularyOnDiskTest.cpp
@@ -12,6 +12,8 @@
 #include <absl/strings/str_cat.h>
 #include <gmock/gmock.h>
 
+#include <limits>
+
 #include "../../util/GTestHelpers.h"
 #include "../../util/MmapVectorLegacyFormat.h"
 #include "./VocabularyTestHelpers.h"
@@ -20,6 +22,7 @@
 #include "util/File.h"
 #include "util/Forward.h"
 #include "util/MmapVector.h"
+#include "util/RuntimeParametersTestHelpers.h"
 
 namespace {
 using namespace vocabulary_test;
@@ -335,4 +338,47 @@ TEST(VocabularyOnDisk, LookupBatchesStreamedEmptyBatchThrows) {
     for ([[maybe_unused]] auto& r : streamed) {
     }
   });
+}
+
+// The new runtime parameters `vocabBatchIoNumManagers_` and
+// `vocabBatchIoRingSize_` control the pool of persistent `BatchIoManager`s
+// created by `open`. They must be validated: a pool without managers would
+// make every batch lookup block forever, and the ring size is narrowed to an
+// `unsigned` by the batch manager API, so values outside that range must be
+// rejected instead of silently wrapped.
+TEST(VocabularyOnDisk, BatchIoRuntimeParametersAreValidated) {
+  auto testInvalid = [](auto setInvalid) {
+    auto cleanup = setInvalid();
+    EXPECT_ANY_THROW(createExampleVocabulary());
+  };
+  // A pool of zero managers must be rejected.
+  testInvalid([] {
+    return setRuntimeParameterForTest<
+        &RuntimeParameters::vocabBatchIoNumManagers_>(size_t{0});
+  });
+  // A ring size of zero must be rejected.
+  testInvalid([] {
+    return setRuntimeParameterForTest<
+        &RuntimeParameters::vocabBatchIoRingSize_>(size_t{0});
+  });
+  // A ring size above `UINT_MAX` must be rejected instead of being wrapped by
+  // the `static_cast<unsigned>` in `open`.
+  testInvalid([] {
+    return setRuntimeParameterForTest<&RuntimeParameters::vocabBatchIoRingSize_>(
+        static_cast<size_t>(std::numeric_limits<unsigned>::max()) + 1);
+  });
+}
+
+// With valid runtime parameter values, `open` must create a working manager
+// pool: batch lookups still return the correct results.
+TEST(VocabularyOnDisk, BatchIoRuntimeParametersAreApplied) {
+  auto resetManagers = setRuntimeParameterForTest<
+      &RuntimeParameters::vocabBatchIoNumManagers_>(2);
+  auto resetRingSize = setRuntimeParameterForTest<
+      &RuntimeParameters::vocabBatchIoRingSize_>(128);
+  auto vocab = createExampleVocabulary();
+  std::array<size_t, 8> indices{2, 0, 3, 1, 1, 4, 0, 3};
+  auto result = vocab->lookupBatch(indices);
+  vocabulary_test::assertLookupResultMatchesVocabularyAtIndices(*vocab, result,
+                                                                indices);
 }


### PR DESCRIPTION
io_uring: expose ring size and manager pool count as runtime parameters

## Why

The ring size (256) and manager pool count (8) were compile-time constants
that required recompilation to change.  Systematic parameter sweeps — needed
to find the knee point (the value beyond which further increases yield
diminishing returns) for each tuning dimension —
are impractical without runtime configurability.  Exposing them as server
runtime parameters enables A/B sweeps (comparing two configurations by
alternating between them) on a running instance without rebuilds.

## What

Two new server runtime parameters:
- `vocab-batch-io-ring-size` (default 256): `io_uring` submission queue size
  per `BatchIoManager`.  Larger rings increase in-flight I/O concurrency at
  the cost of registered buffer memory.
- `vocab-batch-io-num-managers` (default 8): number of `BatchIoManager`
  instances in the pool.  Each holds its own ring; more managers = more
  parallel vocab lookups for multi-query workloads.

Both are added to `RuntimeParameters` and registered in the constructor.
`VocabularyOnDisk::open()` reads them via `getRuntimeParameter()` instead
of the former compile-time constants.

## Design decisions

- The default values (256, 8) deliberately match the compile-time constants
  they replace, so existing behavior is unchanged unless the parameters are
  set explicitly.  `vocab-batch-io-num-managers` defaults to
  `NUM_VOCAB_BATCH_IO_MANAGERS` (`Constants.h`).

## Expected performance impact

This PR does not directly change performance — the default values are
unchanged from the compile-time constants.  The performance benefit is
indirect: runtime configurability enables the parameter sweeps that will
determine the optimal ring size and manager count for QLever's DBLP and
Wikidata workloads.  Without this PR, each sweep point requires a rebuild.
