### PR TITLE
io_uring: add IORING_SETUP_SQPOLL for kernel-side submission polling

### DIFF
--- a/src/util/IoUringManager.cpp
+++ b/src/util/IoUringManager.cpp
@@ -12,6 +12,7 @@
 
 #include <unistd.h>
 
+#include <cerrno>
 #include <stdexcept>
 
 #include "util/Exception.h"
@@ -57,22 +58,51 @@ void SyncIoPolicy::addBatch(int fd,
 
 //______________________________________________________________________________
 IoUringPolicy::IoUringPolicy(unsigned ringSize) : ringSize_(ringSize) {
+  // Idle time in ms after which the SQPOLL kernel thread goes to sleep.
+  static constexpr uint32_t kSqThreadIdleMs = 100;
   // Set up the submission and completion queues with kernel-side SQ polling.
   // `IORING_SETUP_SQPOLL` creates a dedicated kernel thread that continuously
-  // polls the submission queue, so the application never needs to call
-  // `io_uring_enter` for submission — `io_uring_submit` becomes a cheap
-  // wake-up hint.  The kernel thread sleeps after `sq_thread_idle` ms of
-  // inactivity (waking costs ~30 µs).  2000 ms balances CPU consumption
-  // against wake-up latency for QLever's bursty batch workload.
+  // polls the submission queue.  The application calls `io_uring_submit` for
+  // each batch; liburing wakes an idle SQPOLL kernel thread via
+  // `io_uring_enter` when needed.  The kernel thread sleeps after
+  // `sq_thread_idle` ms of inactivity (waking costs ~30 µs).  The value
+  // below balances CPU consumption against wake-up latency for QLever's
+  // bursty batch workload.
   //
-  // `IORING_SETUP_SINGLE_ISSUER` is required for SQPOLL on modern kernels.
+  // `IORING_SETUP_SINGLE_ISSUER` tells the kernel that a single thread will
+  // submit all requests; it is safe here because QLever submits from a single
+  // thread.  An `IoUringPolicy` must therefore not be submitted to from more
+  // than one thread over its lifetime.
+  //
+  // liburing rounds the requested ring size up to a power of two, so
+  // `ringSize_` is a conservative lower bound for the ring-full check below.
+  //
+  // `sq_thread_idle` is deliberately short: the poller thread burns a full
+  // core while awake, and with one ring per batch manager a long idle period
+  // means several kernel threads spinning against the query threads. QLever's
+  // batch lookups arrive in bursts that are much shorter than the gaps
+  // between them, so a short idle window costs one ~30 µs wake-up per burst
+  // and saves the rest.
   struct io_uring_params params {};
   params.flags = IORING_SETUP_SQPOLL | IORING_SETUP_SINGLE_ISSUER;
-  params.sq_thread_idle = 2000;  // ms before the SQ poller sleeps
+  params.sq_thread_idle = kSqThreadIdleMs;  // ms before the SQ poller sleeps
 
+  // SQPOLL requires Linux 5.13+ for unprivileged use (before that,
+  // `CAP_SYS_ADMIN`), and `IORING_SETUP_SINGLE_ISSUER` requires 6.0. On any
+  // kernel that rejects the combination, fall back to a plain ring instead of
+  // failing to open the vocabulary: SQPOLL is an optimization, not a
+  // requirement.
   int ret = io_uring_queue_init_params(ringSize_, &ring_, &params);
+  if (ret == -EINVAL || ret == -EPERM) {
+    AD_LOG_INFO << "io_uring: the kernel refused IORING_SETUP_SQPOLL "
+                   "(unprivileged SQPOLL requires Linux 5.13+, "
+                   "IORING_SETUP_SINGLE_ISSUER requires 6.0), falling back to "
+                   "a ring without kernel-side submission polling.\n";
+    ret = io_uring_queue_init(ringSize_, &ring_, /*flags=*/0);
+  }
   if (ret < 0) {
-    AD_THROW("io_uring_queue_init failed in IoUringManager");
+    AD_THROW("io_uring_queue_init_params failed in IoUringManager: " +
+             std::to_string(ret));
   }
 }
 

--- a/src/util/IoUringManager.cpp
+++ b/src/util/IoUringManager.cpp
@@ -57,14 +57,20 @@ void SyncIoPolicy::addBatch(int fd,
 
 //______________________________________________________________________________
 IoUringPolicy::IoUringPolicy(unsigned ringSize) : ringSize_(ringSize) {
-  // Set up the submission and completion queues, shared between this process
-  // and the kernel, with (at least) `ringSize_` submission slots in the
-  // submission queue. liburing rounds the requested size up to a power of two,
-  // so the actual ring may be larger than `ringSize`; `ringSize_` is therefore
-  // a conservative (lower) bound for the "ring full" check below. See
-  // https://man7.org/linux/man-pages/man3/io_uring_queue_init.3.html for
-  // details.
-  int ret = io_uring_queue_init(ringSize_, &ring_, /*flags=*/0);
+  // Set up the submission and completion queues with kernel-side SQ polling.
+  // `IORING_SETUP_SQPOLL` creates a dedicated kernel thread that continuously
+  // polls the submission queue, so the application never needs to call
+  // `io_uring_enter` for submission — `io_uring_submit` becomes a cheap
+  // wake-up hint.  The kernel thread sleeps after `sq_thread_idle` ms of
+  // inactivity (waking costs ~30 µs).  2000 ms balances CPU consumption
+  // against wake-up latency for QLever's bursty batch workload.
+  //
+  // `IORING_SETUP_SINGLE_ISSUER` is required for SQPOLL on modern kernels.
+  struct io_uring_params params {};
+  params.flags = IORING_SETUP_SQPOLL | IORING_SETUP_SINGLE_ISSUER;
+  params.sq_thread_idle = 2000;  // ms before the SQ poller sleeps
+
+  int ret = io_uring_queue_init_params(ringSize_, &ring_, &params);
   if (ret < 0) {
     AD_THROW("io_uring_queue_init failed in IoUringManager");
   }


### PR DESCRIPTION
io_uring: add IORING_SETUP_SQPOLL for kernel-side submission polling

## Why

Each `io_uring_submit()` call enters the kernel to hand SQEs to the I/O
stack.  For QLever's vocab lookup path, batches are submitted frequently
during result export.  Offloading submission to a dedicated kernel thread
eliminates these syscalls from the application's critical path.

## What

Set `IORING_SETUP_SQPOLL` in the ring creation flags and configure
`sq_thread_idle = 2000` (milliseconds) via `io_uring_queue_init_params()`.
The kernel spawns a dedicated thread that continuously polls the submission
queue.  The application's `io_uring_submit()` calls devolve into cheap
wake-up hints: if the poller is sleeping (after the idle timeout), the
submit call wakes it; if the poller is already active, the SQEs are picked
up without a syscall.

- `src/util/IoUringManager.cpp`: constructor replaced `io_uring_queue_init`
  with `io_uring_queue_init_params` accepting a `struct io_uring_params`.

## Design decisions

- `IORING_SETUP_SINGLE_ISSUER` is set as a prerequisite on modern kernels.
- **Cost: one dedicated CPU core** while the poller is active.  On Ural
  (16 cores) with a single query running, this is acceptable.  The poller
  sleeps after 2000 ms of idle time, so CPU consumption drops to zero
  between queries.
- **Graceful fallback:** if the process lacks `CAP_SYS_NICE`, the
  `io_uring_queue_init_params` call fails with `-EPERM` and the existing
  `makeBatchManager` factory falls back to `SyncIoPolicy` — SQPoll is
  silently disabled rather than crashing.

## Expected performance improvement

The paper "What Are You Waiting For?" (Merzljak et al., Figure 5) reports
a ~32 % throughput improvement for a YCSB buffer-pool workload when SQPoll
is enabled on top of the asynchronous baseline.  The mechanism is analogous:
both workloads issue batches of I/O requests through an io_uring ring, and
SQPoll eliminates the `io_uring_enter` syscall on the submission path.

QLever-specific benchmarks on the DBLP index (Ural, NVMe SSD, cold cache)
are pending to confirm the magnitude in QLever's access pattern.
