### PR TITLE
Add `BinaryExpression` as a faster infrastructure for expressions with two operands

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -36,4 +36,6 @@ if (NOT _NO_BENCHMARK)
 
     addAndLinkBenchmark(GroupByHashMapBenchmark engine testUtil gtest gmock)
 
+    addAndLinkBenchmark(SparqlExpressionBenchmark engine testUtil gtest gmock)
+
 endif()

--- a/benchmark/SparqlExpressionBenchmark.cpp
+++ b/benchmark/SparqlExpressionBenchmark.cpp
@@ -1,0 +1,175 @@
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <string>
+
+#include "../test/util/IndexTestHelpers.h"
+#include "engine/sparqlExpressions/LiteralExpression.h"
+#include "engine/sparqlExpressions/NaryExpression.h"
+#include "engine/sparqlExpressions/NaryExpressionImpl.h"
+#include "engine/sparqlExpressions/SparqlExpressionValueGetters.h"
+#include "infrastructure/Benchmark.h"
+#include "infrastructure/BenchmarkMeasurementContainer.h"
+
+namespace sparqlExpression::detail {
+
+// The previous generator-based multiplication implementation. This exists only
+// for comparison with the new production implementation in this benchmark.
+using LegacyMultiply = MakeNumericExpression<std::multiplies<>>;
+NARY_EXPRESSION(LegacyMultiplyExpression, 2,
+                FV<LegacyMultiply, NumericValueGetter>);
+
+}  // namespace sparqlExpression::detail
+
+namespace ad_benchmark {
+namespace {
+
+using sparqlExpression::EvaluationContext;
+using sparqlExpression::ExpressionResult;
+using sparqlExpression::IdExpression;
+using sparqlExpression::SparqlExpression;
+using sparqlExpression::VariableExpression;
+using sparqlExpression::VectorWithMemoryLimit;
+
+// Owns all data referenced by the evaluation context.
+struct NumericExpressionBenchmarkContext {
+  QueryExecutionContext* qec = ad_utility::testing::getQec("");
+  VariableToColumnMap variableToColumnMap;
+  LocalVocab localVocab;
+  IdTable table{qec->getAllocator()};
+
+  EvaluationContext context{
+      *qec,
+      variableToColumnMap,
+      table.asStaticView<0>(),
+      qec->getAllocator(),
+      localVocab,
+      std::make_shared<ad_utility::CancellationHandle<>>(),
+      EvaluationContext::TimePoint::max()};
+
+  explicit NumericExpressionBenchmarkContext(size_t numRows) {
+    table.setNumColumns(2);
+
+    for (size_t i = 0; i < numRows; ++i) {
+      table.push_back({Id::makeFromInt(static_cast<int64_t>(i)),
+                       Id::makeFromInt(static_cast<int64_t>(i + 1))});
+    }
+
+    // Refresh the view after populating the table.
+    context._inputTable = table.asStaticView<0>();
+    context._beginIndex = 0;
+    context._endIndex = table.size();
+
+    variableToColumnMap[Variable{"?left"}] = makeAlwaysDefinedColumn(0);
+    variableToColumnMap[Variable{"?right"}] = makeAlwaysDefinedColumn(1);
+  }
+};
+
+// Create the old generator-based vector–vector multiplication expression.
+SparqlExpression::Ptr makeLegacyVectorVectorExpression() {
+  return std::make_unique<sparqlExpression::detail::LegacyMultiplyExpression>(
+      std::make_unique<VariableExpression>(Variable{"?left"}),
+      std::make_unique<VariableExpression>(Variable{"?right"}));
+}
+
+// Create the old generator-based vector–constant multiplication expression.
+SparqlExpression::Ptr makeLegacyVectorConstantExpression() {
+  return std::make_unique<sparqlExpression::detail::LegacyMultiplyExpression>(
+      std::make_unique<VariableExpression>(Variable{"?left"}),
+      std::make_unique<IdExpression>(Id::makeFromInt(2)));
+}
+
+// Create the new vector–vector multiplication expression.
+SparqlExpression::Ptr makeNewVectorVectorExpression() {
+  return sparqlExpression::makeMultiplyExpression(
+      std::make_unique<VariableExpression>(Variable{"?left"}),
+      std::make_unique<VariableExpression>(Variable{"?right"}));
+}
+
+// Create the new vector–constant multiplication expression.
+SparqlExpression::Ptr makeNewVectorConstantExpression() {
+  return sparqlExpression::makeMultiplyExpression(
+      std::make_unique<VariableExpression>(Variable{"?left"}),
+      std::make_unique<IdExpression>(Id::makeFromInt(2)));
+}
+
+// Evaluate once and verify that the expected result type and size are produced.
+void validateResult(SparqlExpression& expression, EvaluationContext& context,
+                    size_t expectedSize) {
+  ExpressionResult result = expression.evaluate(&context);
+
+  const auto* resultVector = std::get_if<VectorWithMemoryLimit<Id>>(&result);
+
+  AD_CONTRACT_CHECK(resultVector != nullptr);
+  AD_CONTRACT_CHECK(resultVector->size() == expectedSize);
+}
+
+// Evaluate repeatedly without additional validation inside the timed loop.
+void evaluateRepeatedly(SparqlExpression& expression,
+                        EvaluationContext& context, size_t repetitions) {
+  for (size_t repetition = 0; repetition < repetitions; ++repetition) {
+    auto result = expression.evaluate(&context);
+    (void)result;
+  }
+}
+
+}  // namespace
+
+class SparqlExpressionBenchmark : public BenchmarkInterface {
+ public:
+  std::string name() const final {
+    return "SPARQL numeric binary expression benchmark";
+  }
+
+  BenchmarkResults runAllBenchmarks() final {
+    constexpr size_t numRows = 100'000;
+    constexpr size_t repetitions = 50;
+
+    NumericExpressionBenchmarkContext benchmarkContext{numRows};
+
+    auto legacyVectorVector = makeLegacyVectorVectorExpression();
+    auto newVectorVector = makeNewVectorVectorExpression();
+    auto legacyVectorConstant = makeLegacyVectorConstantExpression();
+    auto newVectorConstant = makeNewVectorConstantExpression();
+
+    // Warm up all implementations and validate their result types and sizes.
+    validateResult(*legacyVectorVector, benchmarkContext.context, numRows);
+    validateResult(*newVectorVector, benchmarkContext.context, numRows);
+    validateResult(*legacyVectorConstant, benchmarkContext.context, numRows);
+    validateResult(*newVectorConstant, benchmarkContext.context, numRows);
+
+    BenchmarkResults results{};
+
+    results.addMeasurement(
+        "Legacy multiplication: vector-vector, 100k rows x 50", [&]() {
+          evaluateRepeatedly(*legacyVectorVector, benchmarkContext.context,
+                             repetitions);
+        });
+
+    results.addMeasurement(
+        "BinaryExpression multiplication: vector-vector, 100k rows x 50",
+        [&]() {
+          evaluateRepeatedly(*newVectorVector, benchmarkContext.context,
+                             repetitions);
+        });
+
+    results.addMeasurement(
+        "Legacy multiplication: vector-constant, 100k rows x 50", [&]() {
+          evaluateRepeatedly(*legacyVectorConstant, benchmarkContext.context,
+                             repetitions);
+        });
+
+    results.addMeasurement(
+        "BinaryExpression multiplication: vector-constant, 100k rows x 50",
+        [&]() {
+          evaluateRepeatedly(*newVectorConstant, benchmarkContext.context,
+                             repetitions);
+        });
+
+    return results;
+  }
+};
+
+AD_REGISTER_BENCHMARK(SparqlExpressionBenchmark);
+
+}  // namespace ad_benchmark

--- a/benchmark/SparqlExpressionBenchmark.cpp
+++ b/benchmark/SparqlExpressionBenchmark.cpp
@@ -1,3 +1,12 @@
+// Copyright 2026 The QLever Authors, in particular:
+//
+// 2026 Prashanth Premakumar <prashanthp0703@gmail.com>, UFR
+
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
 #include <cstddef>
 #include <functional>
 #include <memory>

--- a/src/engine/sparqlExpressions/BinaryExpression.h
+++ b/src/engine/sparqlExpressions/BinaryExpression.h
@@ -1,0 +1,175 @@
+#ifndef QLEVER_SRC_ENGINE_SPARQLEXPRESSIONS_BINARYEXPRESSION_H
+#define QLEVER_SRC_ENGINE_SPARQLEXPRESSIONS_BINARYEXPRESSION_H
+
+#include <array>
+
+#include "engine/sparqlExpressions/NaryExpressionImpl.h"
+#include "util/ChunkedForLoop.h"
+
+namespace sparqlExpression::detail {
+
+// Generic infrastructure for binary expressions. The function and value
+// getter(s) are specified using `FunctionAndValueGetters`. A single value
+// getter can be used for both operands, or separate getters can be specified.
+//
+// This is more efficient than the generic `NaryExpression` infrastructure for
+// binary expressions because the operation is applied in direct loops over
+// vector or constant operands, avoiding the generator-based per-element
+// abstraction.
+
+template <typename Function, typename LeftValueGetter,
+          typename RightValueGetter, typename Left, typename Right>
+ExpressionResult evaluateBinaryOperation(Left&& left, Right&& right,
+                                         EvaluationContext* context);
+
+template <typename Function, typename LeftValueGetter,
+          typename RightValueGetter, typename Left, typename Right>
+ExpressionResult evaluateBinaryOperationOnVectorOrConstant(
+    Left&& left, Right&& right, EvaluationContext* context);
+
+template <typename FunctionAndValueGettersT>
+class BinaryExpression;
+
+// Binary expression whose operation and value getters are known at compile
+// time.
+template <typename Function, typename... ValueGetters>
+class BinaryExpression<FunctionAndValueGetters<Function, ValueGetters...>>
+    : public NaryExpressionBase<2> {
+ public:
+  using Base = NaryExpressionBase<2>;
+  using Children = typename Base::Children;
+  using Getters = ValueGetterPack<2, std::tuple<ValueGetters...>>;
+  using LeftValueGetter = std::tuple_element_t<0, Getters>;
+  using RightValueGetter = std::tuple_element_t<1, Getters>;
+  BinaryExpression(SparqlExpression::Ptr lhs, SparqlExpression::Ptr rhs)
+      : Base{Children{std::move(lhs), std::move(rhs)}} {}
+
+  ExpressionResult evaluate(EvaluationContext* context) const override {
+    auto leftResult = this->children_[0]->evaluate(context);
+    auto rightResult = this->children_[1]->evaluate(context);
+
+    auto visitor = [context](auto&& left, auto&& right) -> ExpressionResult {
+      return evaluateBinaryOperation<Function, LeftValueGetter,
+                                     RightValueGetter>(AD_FWD(left),
+                                                       AD_FWD(right), context);
+    };
+
+    return std::visit(visitor, std::move(leftResult), std::move(rightResult));
+  }
+};
+
+// Convert an expression result into either a vector-like or constant
+// representation that can be handled directly by the binary evaluation loop.
+template <typename T>
+decltype(auto) convertToVectorOrConstant(T&& value,
+                                         EvaluationContext* context) {
+  using Type = std::decay_t<T>;
+
+  if constexpr (ad_utility::isSimilar<Type, ad_utility::SetOfIntervals>) {
+    return ad_utility::SetOfIntervals::toIdVector(value, context->size(),
+                                                  context->_allocator);
+  } else if constexpr (ad_utility::isSimilar<Type, ::Variable>) {
+    return getIdsFromVariable(value, context);
+  } else {
+    static_assert(isVectorResult<Type> || isConstantResult<Type>,
+                  "BinaryExpression only supports vectors and constants after "
+                  "conversion");
+    return AD_FWD(value);
+  }
+}
+
+// Convert both operands to the supported representations and evaluate the
+// binary operation.
+template <typename Function, typename LeftValueGetter,
+          typename RightValueGetter, typename Left, typename Right>
+ExpressionResult evaluateBinaryOperation(Left&& left, Right&& right,
+                                         EvaluationContext* context) {
+  decltype(auto) leftConverted =
+      convertToVectorOrConstant(AD_FWD(left), context);
+  decltype(auto) rightConverted =
+      convertToVectorOrConstant(AD_FWD(right), context);
+
+  return evaluateBinaryOperationOnVectorOrConstant<Function, LeftValueGetter,
+                                                   RightValueGetter>(
+      AD_FWD(leftConverted), AD_FWD(rightConverted), context);
+}
+
+// Return a callable that provides the converted value at index `i`. For
+// constant operands, the converted value is computed only once.
+template <typename ValueGetter, typename Operand>
+auto makeIndexedValueGetter(Operand&& operand, EvaluationContext* context) {
+  using OperandType = std::decay_t<Operand>;
+
+  if constexpr (isVectorResult<OperandType>) {
+    AD_CONTRACT_CHECK(operand.size() == context->size());
+
+    // TODO: The generator-based `NaryExpression` infrastructure forwards/moves
+    // individual values into the value getter. Here, indexed vector elements
+    // are passed as lvalues. This is irrelevant for the currently used value
+    // getters, but should be revisited for move-sensitive value types.
+    return [&operand, context](size_t i) {
+      return ValueGetter{}(operand[i], context);
+    };
+  } else {
+    return [value = ValueGetter{}(AD_FWD(operand), context)](
+               size_t) -> decltype(auto) { return (value); };
+  }
+}
+
+// Evaluate a binary operation whose operands are already vectors or constants.
+template <typename Function, typename LeftValueGetter,
+          typename RightValueGetter, typename Left, typename Right>
+ExpressionResult evaluateBinaryOperationOnVectorOrConstant(
+    Left&& left, Right&& right, EvaluationContext* context) {
+  using LeftType = std::decay_t<Left>;
+  using RightType = std::decay_t<Right>;
+
+  Function function;
+
+  // Case 1: constant–constant.
+  if constexpr (isConstantResult<LeftType> && isConstantResult<RightType>) {
+    context->cancellationHandle_->throwIfCancelled();
+    return function(LeftValueGetter{}(AD_FWD(left), context),
+                    RightValueGetter{}(AD_FWD(right), context));
+
+  } else if constexpr ((isVectorResult<LeftType> ||
+                        isConstantResult<LeftType>) &&
+                       (isVectorResult<RightType> ||
+                        isConstantResult<RightType>)) {
+    auto getLeft =
+        makeIndexedValueGetter<LeftValueGetter>(AD_FWD(left), context);
+    auto getRight =
+        makeIndexedValueGetter<RightValueGetter>(AD_FWD(right), context);
+
+    VectorWithMemoryLimit<Id> result{context->_allocator};
+    result.reserve(context->size());
+
+    ad_utility::chunkedForLoop<1000>(
+        0, context->size(),
+        [&](size_t i) { result.push_back(function(getLeft(i), getRight(i))); },
+        [context]() { context->cancellationHandle_->throwIfCancelled(); });
+
+    return result;
+
+  } else {
+    static_assert(ad_utility::alwaysFalse<std::tuple<LeftType, RightType>>,
+                  "Unhandled binary expression operand types");
+  }
+}
+#ifdef _QLEVER_TYPE_ERASED_EXPRESSIONS
+
+#define BINARY_EXPRESSION(Name, ...) NARY_EXPRESSION(Name, 2, __VA_ARGS__)
+
+#else
+
+#define BINARY_EXPRESSION(Name, ...)                  \
+  class Name : public BinaryExpression<__VA_ARGS__> { \
+    using Base = BinaryExpression<__VA_ARGS__>;       \
+    using Base::Base;                                 \
+  }
+
+#endif
+
+}  // namespace sparqlExpression::detail
+
+#endif  // QLEVER_SRC_ENGINE_SPARQLEXPRESSIONS_BINARYEXPRESSION_H

--- a/src/engine/sparqlExpressions/BinaryExpression.h
+++ b/src/engine/sparqlExpressions/BinaryExpression.h
@@ -101,7 +101,7 @@ auto makeIndexedValueGetter(Operand&& operand, EvaluationContext* context) {
   using OperandType = std::decay_t<Operand>;
 
   if constexpr (isVectorResult<OperandType>) {
-    AD_CONTRACT_CHECK(operand.size() == context->size());
+    AD_CORRECTNESS_CHECK(operand.size() == context->size());
 
     // TODO: The generator-based `NaryExpression` infrastructure forwards/moves
     // individual values into the value getter. Here, indexed vector elements

--- a/src/engine/sparqlExpressions/BinaryExpression.h
+++ b/src/engine/sparqlExpressions/BinaryExpression.h
@@ -1,3 +1,12 @@
+// Copyright 2026 The QLever Authors, in particular:
+//
+// 2026 Prashanth Premakumar <prashanthp0703@gmail.com>, UFR
+
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
 #ifndef QLEVER_SRC_ENGINE_SPARQLEXPRESSIONS_BINARYEXPRESSION_H
 #define QLEVER_SRC_ENGINE_SPARQLEXPRESSIONS_BINARYEXPRESSION_H
 
@@ -16,47 +25,6 @@ namespace sparqlExpression::detail {
 // binary expressions because the operation is applied in direct loops over
 // vector or constant operands, avoiding the generator-based per-element
 // abstraction.
-
-template <typename Function, typename LeftValueGetter,
-          typename RightValueGetter, typename Left, typename Right>
-ExpressionResult evaluateBinaryOperation(Left&& left, Right&& right,
-                                         EvaluationContext* context);
-
-template <typename Function, typename LeftValueGetter,
-          typename RightValueGetter, typename Left, typename Right>
-ExpressionResult evaluateBinaryOperationOnVectorOrConstant(
-    Left&& left, Right&& right, EvaluationContext* context);
-
-template <typename FunctionAndValueGettersT>
-class BinaryExpression;
-
-// Binary expression whose operation and value getters are known at compile
-// time.
-template <typename Function, typename... ValueGetters>
-class BinaryExpression<FunctionAndValueGetters<Function, ValueGetters...>>
-    : public NaryExpressionBase<2> {
- public:
-  using Base = NaryExpressionBase<2>;
-  using Children = typename Base::Children;
-  using Getters = ValueGetterPack<2, std::tuple<ValueGetters...>>;
-  using LeftValueGetter = std::tuple_element_t<0, Getters>;
-  using RightValueGetter = std::tuple_element_t<1, Getters>;
-  BinaryExpression(SparqlExpression::Ptr lhs, SparqlExpression::Ptr rhs)
-      : Base{Children{std::move(lhs), std::move(rhs)}} {}
-
-  ExpressionResult evaluate(EvaluationContext* context) const override {
-    auto leftResult = this->children_[0]->evaluate(context);
-    auto rightResult = this->children_[1]->evaluate(context);
-
-    auto visitor = [context](auto&& left, auto&& right) -> ExpressionResult {
-      return evaluateBinaryOperation<Function, LeftValueGetter,
-                                     RightValueGetter>(AD_FWD(left),
-                                                       AD_FWD(right), context);
-    };
-
-    return std::visit(visitor, std::move(leftResult), std::move(rightResult));
-  }
-};
 
 // Convert an expression result into either a vector-like or constant
 // representation that can be handled directly by the binary evaluation loop.
@@ -78,22 +46,6 @@ decltype(auto) convertToVectorOrConstant(T&& value,
   }
 }
 
-// Convert both operands to the supported representations and evaluate the
-// binary operation.
-template <typename Function, typename LeftValueGetter,
-          typename RightValueGetter, typename Left, typename Right>
-ExpressionResult evaluateBinaryOperation(Left&& left, Right&& right,
-                                         EvaluationContext* context) {
-  decltype(auto) leftConverted =
-      convertToVectorOrConstant(AD_FWD(left), context);
-  decltype(auto) rightConverted =
-      convertToVectorOrConstant(AD_FWD(right), context);
-
-  return evaluateBinaryOperationOnVectorOrConstant<Function, LeftValueGetter,
-                                                   RightValueGetter>(
-      AD_FWD(leftConverted), AD_FWD(rightConverted), context);
-}
-
 // Return a callable that provides the converted value at index `i`. For
 // constant operands, the converted value is computed only once.
 template <typename ValueGetter, typename Operand>
@@ -103,10 +55,11 @@ auto makeIndexedValueGetter(Operand&& operand, EvaluationContext* context) {
   if constexpr (isVectorResult<OperandType>) {
     AD_CORRECTNESS_CHECK(operand.size() == context->size());
 
-    // TODO: The generator-based `NaryExpression` infrastructure forwards/moves
-    // individual values into the value getter. Here, indexed vector elements
-    // are passed as lvalues. This is irrelevant for the currently used value
-    // getters, but should be revisited for move-sensitive value types.
+    // TODO<Prashanth0703>: The generator-based `NaryExpression` infrastructure
+    // forwards/moves individual values into the value getter. Here, indexed
+    // vector elements are passed as lvalues. This is irrelevant for the
+    // currently used value getters, but should be revisited for move-sensitive
+    // value types.
     return [&operand, context](size_t i) {
       return ValueGetter{}(operand[i], context);
     };
@@ -156,6 +109,54 @@ ExpressionResult evaluateBinaryOperationOnVectorOrConstant(
                   "Unhandled binary expression operand types");
   }
 }
+
+// Convert both operands to the supported representations and evaluate the
+// binary operation.
+template <typename Function, typename LeftValueGetter,
+          typename RightValueGetter, typename Left, typename Right>
+ExpressionResult evaluateBinaryOperation(Left&& left, Right&& right,
+                                         EvaluationContext* context) {
+  decltype(auto) leftConverted =
+      convertToVectorOrConstant(AD_FWD(left), context);
+  decltype(auto) rightConverted =
+      convertToVectorOrConstant(AD_FWD(right), context);
+
+  return evaluateBinaryOperationOnVectorOrConstant<Function, LeftValueGetter,
+                                                   RightValueGetter>(
+      AD_FWD(leftConverted), AD_FWD(rightConverted), context);
+}
+
+template <typename FunctionAndValueGettersT>
+class BinaryExpression;
+
+// Binary expression whose operation and value getters are known at compile
+// time.
+template <typename Function, typename... ValueGetters>
+class BinaryExpression<FunctionAndValueGetters<Function, ValueGetters...>>
+    : public NaryExpressionBase<2> {
+ public:
+  using Base = NaryExpressionBase<2>;
+  using Children = typename Base::Children;
+  using Getters = ValueGetterPack<2, std::tuple<ValueGetters...>>;
+  using LeftValueGetter = std::tuple_element_t<0, Getters>;
+  using RightValueGetter = std::tuple_element_t<1, Getters>;
+  BinaryExpression(SparqlExpression::Ptr lhs, SparqlExpression::Ptr rhs)
+      : Base{Children{std::move(lhs), std::move(rhs)}} {}
+
+  ExpressionResult evaluate(EvaluationContext* context) const override {
+    auto leftResult = this->children_[0]->evaluate(context);
+    auto rightResult = this->children_[1]->evaluate(context);
+
+    auto visitor = [context](auto&& left, auto&& right) -> ExpressionResult {
+      return evaluateBinaryOperation<Function, LeftValueGetter,
+                                     RightValueGetter>(AD_FWD(left),
+                                                       AD_FWD(right), context);
+    };
+
+    return std::visit(visitor, std::move(leftResult), std::move(rightResult));
+  }
+};
+
 #ifdef _QLEVER_TYPE_ERASED_EXPRESSIONS
 
 #define BINARY_EXPRESSION(Name, ...) NARY_EXPRESSION(Name, 2, __VA_ARGS__)

--- a/src/engine/sparqlExpressions/NaryExpressionImpl.h
+++ b/src/engine/sparqlExpressions/NaryExpressionImpl.h
@@ -16,18 +16,56 @@
 
 namespace sparqlExpression::detail {
 
+// Common storage and metadata handling for expressions with a fixed number of
+// child expressions.
+// Common storage and metadata handling for expressions with a fixed number of
+// child expressions.
+template <size_t N>
+class NaryExpressionBase : public SparqlExpression {
+ protected:
+  using Children = std::array<SparqlExpression::Ptr, N>;
+  Children children_;
+
+  explicit NaryExpressionBase(Children&& children)
+      : children_{std::move(children)} {}
+
+  [[nodiscard]] std::string getCacheKeyForChildren(
+      const VariableToColumnMap& varColMap) const {
+    return absl::StrJoin(
+        children_ | ql::views::transform([&varColMap](const auto& child) {
+          return child->getCacheKey(varColMap);
+        }),
+        "");
+  }
+
+ public:
+  [[nodiscard]] std::string getCacheKey(
+      const VariableToColumnMap& varColMap) const override {
+    return std::string{typeid(*this).name()} +
+           getCacheKeyForChildren(varColMap);
+  }
+
+  // Deterministic iff all children are deterministic.
+  [[nodiscard]] bool isDeterministic() const override {
+    return areChildrenDeterministic();
+  }
+
+ private:
+  ql::span<SparqlExpression::Ptr> childrenImpl() override {
+    return {children_.data(), children_.size()};
+  }
+};
+
 template <typename NaryOperation>
-class NaryExpressionStronglyTyped : public SparqlExpression {
+class NaryExpressionStronglyTyped
+    : public NaryExpressionBase<NaryOperation::N> {
   CPP_assert(isOperation<NaryOperation>);
 
  public:
   static constexpr size_t N = NaryOperation::N;
-  using Children = std::array<SparqlExpression::Ptr, N>;
+  using Base = NaryExpressionBase<N>;
+  using Children = typename Base::Children;
 
- private:
-  Children children_;
-
- public:
   // Construct from an array of `N` child expressions.
   explicit NaryExpressionStronglyTyped(Children&& children);
 
@@ -42,19 +80,7 @@ class NaryExpressionStronglyTyped : public SparqlExpression {
   // __________________________________________________________________________
   ExpressionResult evaluate(EvaluationContext* context) const override;
 
-  // _________________________________________________________________________
-  [[nodiscard]] std::string getCacheKey(
-      const VariableToColumnMap& varColMap) const override;
-
-  // Deterministic iff all children are deterministic.
-  [[nodiscard]] bool isDeterministic() const override {
-    return areChildrenDeterministic();
-  }
-
  private:
-  // _________________________________________________________________________
-  ql::span<SparqlExpression::Ptr> childrenImpl() override;
-
   // Evaluate the `naryOperation` on the `operands` using the `context`.
   // Is deliberately a functor, s.t. we can pass it to `bind_front` etc,
   // although the call operator is overloaded.
@@ -109,7 +135,7 @@ class NaryExpressionStronglyTyped : public SparqlExpression {
 template <typename Op>
 NaryExpressionStronglyTyped<Op>::NaryExpressionStronglyTyped(
     Children&& children)
-    : children_{std::move(children)} {}
+    : Base{std::move(children)} {}
 
 // _____________________________________________________________________________
 
@@ -118,7 +144,7 @@ ExpressionResult NaryExpressionStronglyTyped<NaryOperation>::evaluate(
     EvaluationContext* context) const {
   auto resultsOfChildren = ad_utility::applyFunctionToEachElementOfTuple(
       [context](const auto& child) { return child->evaluate(context); },
-      children_);
+      this->children_);
 
   // A function that only takes several `ExpressionResult`s,
   // and evaluates the expression.
@@ -127,26 +153,6 @@ ExpressionResult NaryExpressionStronglyTyped<NaryOperation>::evaluate(
                        EvaluateOnChildOperands{}, NaryOperation{}, context);
 
   return std::apply(evaluateOnChildrenResults, std::move(resultsOfChildren));
-}
-
-// _____________________________________________________________________________
-template <typename Op>
-ql::span<SparqlExpression::Ptr>
-NaryExpressionStronglyTyped<Op>::childrenImpl() {
-  return {children_.data(), children_.size()};
-}
-
-// __________________________________________________________________________
-template <typename Op>
-[[nodiscard]] std::string NaryExpressionStronglyTyped<Op>::getCacheKey(
-    const VariableToColumnMap& varColMap) const {
-  std::string key = typeid(*this).name();
-  key += absl::StrJoin(
-      children_ | ql::views::transform([&varColMap](const auto& child) {
-        return child->getCacheKey(varColMap);
-      }),
-      "");
-  return key;
 }
 
 // ============================================================================
@@ -164,10 +170,12 @@ template <typename Op>
 // `NaryExpressionTypeErased` class below, then this works, because the value
 // getters become part of the classes name/typeid.
 template <typename Ret, typename... Args>
-class NaryExpressionTypeErasedImpl : public SparqlExpression {
+class NaryExpressionTypeErasedImpl
+    : public NaryExpressionBase<sizeof...(Args)> {
  public:
   static constexpr size_t N = sizeof...(Args);
-  using Children = std::array<SparqlExpression::Ptr, N>;
+  using Base = NaryExpressionBase<N>;
+  using Children = typename Base::Children;
   using Function = std::function<Ret(Args...)>;
 
   // Type-erased `std::function` that converts the `ExpressionResult` variant
@@ -181,7 +189,6 @@ class NaryExpressionTypeErasedImpl : public SparqlExpression {
   using Getters = std::tuple<TypeErasedGetter<Args>...>;
 
  private:
-  Children children_;
   Function function_;
   Getters getters_;
 
@@ -190,7 +197,7 @@ class NaryExpressionTypeErasedImpl : public SparqlExpression {
   // `function` and `getters`.
   explicit NaryExpressionTypeErasedImpl(Function function, Getters getters,
                                         Children&& children)
-      : children_{std::move(children)},
+      : Base{std::move(children)},
         function_{std::move(function)},
         getters_{std::move(getters)} {}
 
@@ -201,7 +208,7 @@ class NaryExpressionTypeErasedImpl : public SparqlExpression {
           return evaluateOnChildrenOperands(context,
                                             child->evaluate(context)...);
         },
-        children_);
+        this->children_);
   }
 
   // _________________________________________________________________________
@@ -209,24 +216,15 @@ class NaryExpressionTypeErasedImpl : public SparqlExpression {
       const VariableToColumnMap& varColMap) const override {
     const auto& signatureId = typeid(*this);
     const auto& functionId = function_.target_type();
+
     std::string key =
         absl::StrCat(signatureId.name(), "_", signatureId.hash_code(), "_",
                      functionId.name(), "_", functionId.hash_code(), "_");
-    for (const auto& child : children_) {
-      key += child->getCacheKey(varColMap);
-    }
-    return key;
-  }
 
-  // Deterministic iff all children are deterministic.
-  [[nodiscard]] bool isDeterministic() const override {
-    return areChildrenDeterministic();
+    return key + this->getCacheKeyForChildren(varColMap);
   }
 
  private:
-  // _________________________________________________________________________
-  ql::span<SparqlExpression::Ptr> childrenImpl() override { return children_; }
-
   // Evaluate the `naryOperation` on the `operands` using the `context`.
   CPP_variadic_template(typename... Operands)(requires(
       ...&& std::is_same_v<ExpressionResult, Operands>)) ExpressionResult
@@ -277,9 +275,9 @@ class NaryExpressionTypeErasedImpl : public SparqlExpression {
 
 // ============================================================================
 // Implementation of `NaryExpressionTypeErased` using the
-// `NaryExpressionTypeErasedImpl` from above: It has the same template argument
-// as `NaryExpression`, but uses type erasure for the function and value
-// getters.
+// `NaryExpressionTypeErasedImpl` from above: It has the same template
+// argument as `NaryExpression`, but uses type erasure for the function and
+// value getters.
 // ============================================================================
 
 // Helper: given a Function type and a tuple of (strongly typed) function
@@ -308,8 +306,8 @@ class NaryExpressionTypeErased;
 
 // Partial specialization for `Operation<N, FV<Function, ValueGetters...>,
 // SpecializedFunctions...>` As that is exactly the pattern the strongly typed
-// `NaryExpression` uses. Note: The `SpezializedFunctions` (which implement more
-// efficient evaluation in some circumstances, but are not required for
+// `NaryExpression` uses. Note: The `SpezializedFunctions` (which implement
+// more efficient evaluation in some circumstances, but are not required for
 // correctness) are ignored in the type-erased case, which is only used during
 // development for cheaper compilation.
 template <size_t N, typename Function, typename... ValueGetters,
@@ -356,13 +354,13 @@ using NaryExpression = NaryExpressionStronglyTyped<Args...>;
     using Base::Base;                                                        \
   }
 
-// Takes a `Function` that returns a numeric value (integral or floating point)
-// and converts it to a function, that takes the same arguments and returns the
-// same result, but the return type is the `NumericValue` variant.
+// Takes a `Function` that returns a numeric value (integral or floating
+// point) and converts it to a function, that takes the same arguments and
+// returns the same result, but the return type is the `NumericValue` variant.
 template <typename Function, bool nanToUndef = false>
 struct NumericIdWrapper {
-  // Note: Sonarcloud suggests `[[no_unique_address]]` for the following member,
-  // but adding it causes an internal compiler error in Clang 16.
+  // Note: Sonarcloud suggests `[[no_unique_address]]` for the following
+  // member, but adding it causes an internal compiler error in Clang 16.
   Function function_{};
   template <typename... Args>
   Id operator()(Args&&... args) const {
@@ -371,9 +369,9 @@ struct NumericIdWrapper {
 };
 
 // Takes a `Function` that takes and returns numeric values (integral or
-// floating point) and converts it to a function, that takes the same arguments
-// and returns the same result, but the arguments and the return type are the
-// `NumericValue` variant.
+// floating point) and converts it to a function, that takes the same
+// arguments and returns the same result, but the arguments and the return
+// type are the `NumericValue` variant.
 template <typename Function, bool NanOrInfToUndef = false>
 struct MakeNumericExpression {
   template <typename... Args>

--- a/src/engine/sparqlExpressions/NaryExpressionImpl.h
+++ b/src/engine/sparqlExpressions/NaryExpressionImpl.h
@@ -18,8 +18,6 @@ namespace sparqlExpression::detail {
 
 // Common storage and metadata handling for expressions with a fixed number of
 // child expressions.
-// Common storage and metadata handling for expressions with a fixed number of
-// child expressions.
 template <size_t N>
 class NaryExpressionBase : public SparqlExpression {
  protected:

--- a/src/engine/sparqlExpressions/NumericBinaryExpressions.cpp
+++ b/src/engine/sparqlExpressions/NumericBinaryExpressions.cpp
@@ -1,15 +1,17 @@
 //  Copyright 2023, University of Freiburg,
 //                  Chair of Algorithms and Data Structures.
 //  Author: Johannes Kalmbach <kalmbacj@cs.uni-freiburg.de>
+#include "engine/sparqlExpressions/BinaryExpression.h"
 #include "engine/sparqlExpressions/NaryExpressionImpl.h"
 #include "engine/sparqlExpressions/SparqlExpressionValueGetters.h"
 #include "global/RuntimeParameters.h"
 
 namespace sparqlExpression {
 namespace detail {
+
 // Multiplication.
 using Multiply = MakeNumericExpression<std::multiplies<>>;
-NARY_EXPRESSION(MultiplyExpression, 2, FV<Multiply, NumericValueGetter>);
+BINARY_EXPRESSION(MultiplyExpression, FV<Multiply, NumericValueGetter>);
 
 // Division.
 //
@@ -29,12 +31,11 @@ struct DivideImpl {
 };
 
 using Divide1 = MakeNumericExpression<DivideImpl, true>;
-NARY_EXPRESSION(DivideExpressionByZeroIsUndef, 2,
-                FV<Divide1, NumericValueGetter>);
+BINARY_EXPRESSION(DivideExpressionByZeroIsUndef,
+                  FV<Divide1, NumericValueGetter>);
 
 using Divide2 = MakeNumericExpression<DivideImpl, false>;
-NARY_EXPRESSION(DivideExpressionByZeroIsNan, 2,
-                FV<Divide2, NumericValueGetter>);
+BINARY_EXPRESSION(DivideExpressionByZeroIsNan, FV<Divide2, NumericValueGetter>);
 
 // _____________________________________________________________________________
 // Addition.
@@ -74,7 +75,7 @@ struct AddImpl {
     return Id::makeUndefined();
   }
 };
-NARY_EXPRESSION(AddExpression, 2, FV<AddImpl, NumericOrDateValueGetter>);
+BINARY_EXPRESSION(AddExpression, FV<AddImpl, NumericOrDateValueGetter>);
 
 // _____________________________________________________________________________
 // Subtraction.
@@ -114,8 +115,8 @@ struct SubtractImpl {
     return Id::makeUndefined();
   }
 };
-NARY_EXPRESSION(SubtractExpression, 2,
-                FV<SubtractImpl, NumericOrDateValueGetter>);
+BINARY_EXPRESSION(SubtractExpression,
+                  FV<SubtractImpl, NumericOrDateValueGetter>);
 
 // _____________________________________________________________________________
 // Power.
@@ -125,7 +126,7 @@ struct PowImpl {
   }
 };
 using Pow = MakeNumericExpression<PowImpl>;
-NARY_EXPRESSION(PowExpression, 2, FV<Pow, NumericValueGetter>);
+BINARY_EXPRESSION(PowExpression, FV<Pow, NumericValueGetter>);
 
 // OR and AND
 // _____________________________________________________________________________

--- a/src/engine/sparqlExpressions/SetOfIntervals.h
+++ b/src/engine/sparqlExpressions/SetOfIntervals.h
@@ -11,7 +11,9 @@
 
 #include "backports/algorithm.h"
 #include "backports/three_way_comparison.h"
+#include "global/Id.h"
 #include "util/Exception.h"
+#include "util/VectorWithMemoryLimit.h"
 
 namespace ad_utility {
 
@@ -81,6 +83,32 @@ struct SetOfIntervals {
                                               size_t targetSize) {
     std::vector<bool> result(targetSize, false);
     toBitVector(a, targetSize, ql::ranges::begin(result));
+    return result;
+  }
+
+  // Transform a `SetOfIntervals` into a vector of boolean `Id`s of size
+  // `targetSize`. The i-th element is true iff i is contained in the set.
+  inline static VectorWithMemoryLimit<Id> toIdVector(
+      const SetOfIntervals& set, size_t targetSize,
+      const VectorWithMemoryLimit<Id>::Allocator& allocator) {
+    VectorWithMemoryLimit<Id> result{allocator};
+    result.reserve(targetSize);
+
+    size_t previousEnd = 0;
+    for (const auto& [begin, end] : set._intervals) {
+      AD_CONTRACT_CHECK(end <= targetSize,
+                        "The size of a `SetOfIntervals` exceeds the total size "
+                        "of the evaluation context.");
+
+      result.insert(result.end(), begin - previousEnd, Id::makeFromBool(false));
+      result.insert(result.end(), end - begin, Id::makeFromBool(true));
+
+      previousEnd = end;
+    }
+
+    result.insert(result.end(), targetSize - previousEnd,
+                  Id::makeFromBool(false));
+
     return result;
   }
 };

--- a/test/SetOfIntervalsTest.cpp
+++ b/test/SetOfIntervalsTest.cpp
@@ -149,3 +149,24 @@ TEST(SetOfIntervals, toBitVector) {
     ASSERT_EQ(elements.contains(i), expanded[i]);
   }
 }
+
+TEST(SetOfIntervals, toIdVector) {
+  auto allocator = makeUnlimitedAllocator<Id>();
+
+  SetOfIntervals intervals{{{1, 3}, {5, 6}}};
+
+  auto result = SetOfIntervals::toIdVector(intervals, 8, allocator);
+
+  VectorWithMemoryLimit<Id> expected{
+      {Id::makeFromBool(false), Id::makeFromBool(true), Id::makeFromBool(true),
+       Id::makeFromBool(false), Id::makeFromBool(false), Id::makeFromBool(true),
+       Id::makeFromBool(false), Id::makeFromBool(false)},
+      allocator};
+
+  ASSERT_EQ(result, expected);
+
+  // An interval must not extend beyond the requested target size.
+  SetOfIntervals tooLarge{{{0, 9}}};
+  ASSERT_THROW(SetOfIntervals::toIdVector(tooLarge, 8, allocator),
+               ad_utility::Exception);
+}

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -466,6 +466,22 @@ TEST(SparqlExpression, logicalOperators) {
   }
 }
 
+// _____________________________________________________________________________
+TEST(SparqlExpression, multiplyExpressionWithVariable) {
+  TestContext testContext;
+
+  auto expression = makeMultiplyExpression(
+      std::make_unique<VariableExpression>(Variable{"?ints"}),
+      std::make_unique<IdExpression>(I(2)));
+
+  V<Id> expected{{I(2), I(0), I(-2)}, testContext.qec->getAllocator()};
+
+  auto result = expression->evaluate(&testContext.context);
+
+  ASSERT_THAT(result, ::testing::VariantWith<V<Id>>(
+                          sparqlExpressionResultMatcher(expected)));
+}
+
 // _____________________________________________________________________________________
 TEST(SparqlExpression, arithmeticOperators) {
   // Test `AddExpression`, `SubtractExpression`, `MultiplyExpression`, and
@@ -539,8 +555,14 @@ TEST(SparqlExpression, arithmeticOperators) {
   testMinus(minus22, mixed, D(2.2));
   testPlus(minus22, mixed, D(-2.2));
 
+  using S = ad_utility::SetOfIntervals;
+  S alternating{{{0, 2}, {3, 4}}};
+  V<Id> alternatingTimes2{{I(2), I(2), I(0), I(2)}, alloc};
+
   testMultiply(times2, mixed, I(2));
   testMultiply(times13, mixed, D(1.3));
+  testMultiply(I(6), I(2), I(3));
+  testMultiply(alternatingTimes2, alternating, I(2));
 
 #ifndef REDUCED_FEATURE_SET_FOR_CPP17
   // Test for `DateTime` - `DateTime`.
@@ -584,6 +606,15 @@ TEST(SparqlExpression, arithmeticOperators) {
   testMultiply(by2, mixed, D(0.5));
   testDivide(times13, mixed, D(1.0 / 1.3));
 
+  V<Id> divisors{{I(2), I(4), D(0.5)}, alloc};
+  V<Id> eightDividedBy{{D(4), D(2), D(16)}, alloc};
+
+  // constant–vector
+  testDivide(eightDividedBy, I(8), divisors);
+
+  // constant–constant
+  testDivide(D(4), I(8), I(2));
+
   // Division by zero is either `UNDEF` or `NaN/infinity`, depending on a
   // runtime parameter.
   V<Id> undef{{U, U, U, U}, alloc};
@@ -595,6 +626,7 @@ TEST(SparqlExpression, arithmeticOperators) {
   testDivide(undef, divByZeroInputsInt, I(0));
   testDivide(undef, divByZeroInputsDouble, D(0));
   testDivide(undef, divByZeroInputsInt, D(0));
+  testDivide(U, I(1), I(0));
 
   auto cleanup =
       setRuntimeParameterForTest<&RuntimeParameters::divisionByZeroIsUndef_>(
@@ -603,6 +635,7 @@ TEST(SparqlExpression, arithmeticOperators) {
   testDivide(nanAndInf, divByZeroInputsInt, I(0));
   testDivide(nanAndInf, divByZeroInputsDouble, D(0));
   testDivide(nanAndInf, divByZeroInputsInt, D(0));
+  testDivide(D(inf), I(1), I(0));
 }
 
 // Test that the unary expression that is specified by the `makeFunction` yields
@@ -1255,6 +1288,9 @@ TEST(SparqlExpression, customNumericFunctions) {
   auto checkPow = std::bind_front(testNaryExpression, &makePowExpression);
   checkPow(Ids{D(1), D(32), U, U}, Ids{I(5), D(2), U, D(0)},
            IdOrLocalVocabEntryVec{I(0), D(5), I(0), lit("abc")});
+  checkPow(Ids{D(4), D(9), U}, Ids{I(2), I(3), U}, I(2));
+  checkPow(Ids{D(1), D(8), U}, I(2), Ids{I(0), I(3), U});
+  checkPow(D(8), I(2), I(3));
 }
 
 // ____________________________________________________________________________


### PR DESCRIPTION
So far, all binary arithmetic expressions (`+`, `-`, `*`, `/`, `POW`) were evaluated via the generic `NaryExpression` infrastructure, which goes through a type-erased generator for each element of each operand. This change adds a `BinaryExpression` class for expressions with exactly two operands, which applies the operation in a direct loop over the two operands, each of which is either a vector or a constant (a variable is read as a non-owning span of its column, and a `SetOfIntervals` is expanded to a vector of booleans first). The five arithmetic expressions above now use it via the new `BINARY_EXPRESSION` macro, which falls back to the type-erased `NaryExpression` when compiling with `CHEAPER_COMPILATION`. The parts that both infrastructures share (children, cache key, determinism) are factored into `NaryExpressionBase`.

In the new `SparqlExpressionBenchmark` (100,000 rows, 50 evaluations), a multiplication of two variables is 1.2 to 1.4 times faster than before and a multiplication of a variable with a constant 1.75 to 2.1 times faster, depending on the machine. Cancellation is checked once per 1,000 elements (`chunkedForLoop`), which was measured to be 2% faster than checking every element.

NOTE: This is a starting point for further optimizations of the expression evaluation, which is the reason for a separate class instead of a special case in `NaryExpression`.