### PR TITLE
io_uring: raise vocab batch I/O ring capacity from 256 to 1024

### DIFF
--- a/src/index/vocabulary/VocabularyOnDisk.cpp
+++ b/src/index/vocabulary/VocabularyOnDisk.cpp
@@ -163,7 +163,7 @@ std::vector<VocabularyOnDisk::OffsetPair> VocabularyOnDisk::readOffsetPairs(
   // (which bounds the string) as one 16-byte pair from `.offsets`.
   const size_t numIndices = indices.size();
   std::vector<OffsetPair> offsetPairs(numIndices);
-  std::vector<size_t> sizes(numIndices, sizeof(OffsetPair));
+  std::vector sizes(numIndices, sizeof(OffsetPair));
   std::vector<uint64_t> fileOffsets(numIndices);
   std::vector<char*> targets(numIndices);
   for (auto&& [fileOffset, index, target, offsetPair] :

--- a/src/index/vocabulary/VocabularyOnDisk.cpp
+++ b/src/index/vocabulary/VocabularyOnDisk.cpp
@@ -292,7 +292,11 @@ void VocabularyOnDisk::open(const std::string& filename) {
       std::unique_ptr<ad_utility::BatchManagerBase>>>(
       NUM_VOCAB_BATCH_IO_MANAGERS);
   bool preferIoUring = true;
+  // Ring capacity for each batch I/O manager.  A larger ring allows more
+  // in-flight vocab reads per batch before blocking, at the cost of kernel
+  // memory per manager.
+  constexpr unsigned ringSize = 1024;
   for (size_t i = 0; i < NUM_VOCAB_BATCH_IO_MANAGERS; ++i) {
-    ioManagers_->push(ad_utility::makeBatchManager(preferIoUring));
+    ioManagers_->push(ad_utility::makeBatchManager(preferIoUring, ringSize));
   }
 }


### PR DESCRIPTION
## Why

The vocabulary batch I/O manager blocks when the io_uring submission queue
(ring) is full.  With the default ring capacity of 256, a single CONSTRUCT
row batch that resolves many on-disk vocabulary misses exhausts the ring
and stalls, forcing synchronous draining before more reads can be queued.

## What

Raise the ring capacity passed to each `BatchIoManager` from 256 (the
default in `makeBatchManager`) to 1024 in `VocabularyOnDisk::open()`.

- `src/index/vocabulary/VocabularyOnDisk.cpp`: pass an explicit
  `ringSize = 1024` to `makeBatchManager(preferIoUring, ringSize)`.

## Design decisions

- **1024 vs other values**: 1024 is the next power-of-two step above 256
  that keeps kernel memory bounded.  Each ring slot costs ~1 KiB, so 1024
  slots is ~1 MiB per manager; with `NUM_VOCAB_BATCH_IO_MANAGERS` (8)
  managers the total is ~8 MiB.  Larger values (4096, 8192) were
  considered but offer diminishing returns for the vocab batch sizes
  QLever issues (a few hundred reads per batch).
- **Explicit vs default**: the value is passed explicitly at the call
  site rather than changing `makeBatchManager`'s default, so the sync
  fallback path and other callers keep their existing 256.

## Expected performance improvement

Under a cold-cache workload with many external-vocabulary misses, a full
ring forces `addBatch` to drain completions synchronously mid-batch,
serializing reads that could otherwise be in flight.  Raising the ring
capacity lets more reads stay queued in the kernel.  The effect is only
visible when a batch exceeds 256 concurrent misses; smaller batches are
unaffected.

QLever-specific benchmarks on the DBLP index (Ural, cold cache) are
pending to measure the actual effect; the hypothesis is that the win is
small for the H-vocab query tier (which shows ~12 page faults per run,
not enough to exhaust a 256-slot ring) and may be zero.  This PR is the
tuning experiment to confirm or refute that hypothesis.