### PR TITLE
io_uring: add IORING_SETUP_DEFER_TASKRUN and IORING_SETUP_SINGLE_ISSUER

### DIFF
--- a/src/util/IoUringManager.cpp
+++ b/src/util/IoUringManager.cpp
@@ -57,14 +57,17 @@ void SyncIoPolicy::addBatch(int fd,
 
 //______________________________________________________________________________
 IoUringPolicy::IoUringPolicy(unsigned ringSize) : ringSize_(ringSize) {
-  // Set up the submission and completion queues, shared between this process
-  // and the kernel, with (at least) `ringSize_` submission slots in the
-  // submission queue. liburing rounds the requested size up to a power of two,
-  // so the actual ring may be larger than `ringSize`; `ringSize_` is therefore
-  // a conservative (lower) bound for the "ring full" check below. See
-  // https://man7.org/linux/man-pages/man3/io_uring_queue_init.3.html for
-  // details.
-  int ret = io_uring_queue_init(ringSize_, &ring_, /*flags=*/0);
+  // Set up the submission and completion queues.  `IORING_SETUP_DEFER_TASKRUN`
+  // prevents the kernel from running task_work (completion processing) on
+  // arbitrary kernel-user transitions (e.g. inside malloc's brk syscall).
+  // Together with `IORING_SETUP_SINGLE_ISSUER` (the required prerequisite),
+  // this confines CQE reaping to explicit `io_uring_enter` calls, eliminating
+  // unwanted preemptions and giving the application full control over when
+  // completions are processed.  See https://man7.org/linux/man-pages/man3/
+  // io_uring_queue_init.3.html for details.
+  int ret = io_uring_queue_init(ringSize_, &ring_,
+                                IORING_SETUP_DEFER_TASKRUN |
+                                    IORING_SETUP_SINGLE_ISSUER);
   if (ret < 0) {
     AD_THROW("io_uring_queue_init failed in IoUringManager");
   }

--- a/src/util/IoUringManager.cpp
+++ b/src/util/IoUringManager.cpp
@@ -12,6 +12,8 @@
 
 #include <unistd.h>
 
+#include <cerrno>
+#include <cstring>
 #include <stdexcept>
 
 #include "util/Exception.h"
@@ -57,19 +59,42 @@ void SyncIoPolicy::addBatch(int fd,
 
 //______________________________________________________________________________
 IoUringPolicy::IoUringPolicy(unsigned ringSize) : ringSize_(ringSize) {
-  // Set up the submission and completion queues.  `IORING_SETUP_DEFER_TASKRUN`
-  // prevents the kernel from running task_work (completion processing) on
-  // arbitrary kernel-user transitions (e.g. inside malloc's brk syscall).
-  // Together with `IORING_SETUP_SINGLE_ISSUER` (the required prerequisite),
-  // this confines CQE reaping to explicit `io_uring_enter` calls, eliminating
-  // unwanted preemptions and giving the application full control over when
-  // completions are processed.  See https://man7.org/linux/man-pages/man3/
-  // io_uring_queue_init.3.html for details.
+  // Set up the submission and completion queues. liburing rounds the
+  // requested `ringSize_` up to a power of two, so `ringSize_` remains a
+  // conservative lower bound for the ring-full check below.
+  // `IORING_SETUP_DEFER_TASKRUN` prevents the kernel from running task_work
+  // (completion processing) on arbitrary kernel-user transitions (e.g. inside
+  // malloc's brk syscall). Together with `IORING_SETUP_SINGLE_ISSUER` (the
+  // required prerequisite), this confines CQE reaping to explicit
+  // `io_uring_enter` calls, eliminating unwanted preemptions and giving the
+  // application full control over when completions are processed. See
+  // https://man7.org/linux/man-pages/man3/io_uring_queue_init.3.html for
+  // details.
+  //
+  // NOTE on `IORING_SETUP_SINGLE_ISSUER`: the ring is bound to the first task
+  // that submits to it, and every later submission must come from that same
+  // task. This is why an `IoUringPolicy` must not be moved between threads
+  // once it has been used; see `VocabularyOnDisk::open`, which hands out one
+  // manager per concurrent lookup and takes it back before another thread can
+  // pick it up.
+  //
+  // Both flags require Linux 5.19. On older kernels (e.g. Ubuntu 22.04 with
+  // Linux 5.15) `io_uring_queue_init` fails with `-EINVAL`, in which case we
+  // retry without them rather than failing outright: the flags are an
+  // optimization, not a requirement.
   int ret = io_uring_queue_init(
       ringSize_, &ring_,
       IORING_SETUP_DEFER_TASKRUN | IORING_SETUP_SINGLE_ISSUER);
+  if (ret == -EINVAL) {
+    AD_LOG_INFO << "io_uring: the kernel does not support "
+                   "IORING_SETUP_DEFER_TASKRUN/IORING_SETUP_SINGLE_ISSUER "
+                   "(Linux 5.19+ is required), falling back to a ring without "
+                   "them.\n";
+    ret = io_uring_queue_init(ringSize_, &ring_, /*flags=*/0);
+  }
   if (ret < 0) {
-    AD_THROW("io_uring_queue_init failed in IoUringManager");
+    AD_THROW("io_uring_queue_init failed in IoUringManager: " +
+             std::string(strerror(-ret)));
   }
 }
 

--- a/src/util/IoUringManager.cpp
+++ b/src/util/IoUringManager.cpp
@@ -65,9 +65,9 @@ IoUringPolicy::IoUringPolicy(unsigned ringSize) : ringSize_(ringSize) {
   // unwanted preemptions and giving the application full control over when
   // completions are processed.  See https://man7.org/linux/man-pages/man3/
   // io_uring_queue_init.3.html for details.
-  int ret = io_uring_queue_init(ringSize_, &ring_,
-                                IORING_SETUP_DEFER_TASKRUN |
-                                    IORING_SETUP_SINGLE_ISSUER);
+  int ret = io_uring_queue_init(
+      ringSize_, &ring_,
+      IORING_SETUP_DEFER_TASKRUN | IORING_SETUP_SINGLE_ISSUER);
   if (ret < 0) {
     AD_THROW("io_uring_queue_init failed in IoUringManager");
   }


### PR DESCRIPTION
## Why

Without `IORING_SETUP_DEFER_TASKRUN`, the kernel runs io_uring task_work
(completion processing) at arbitrary kernel-user transition points, e.g.
inside an unrelated `brk()` syscall triggered by `malloc`.  This causes
unwanted preemptions inside the batch I/O loop and lets completions be
reaped at unpredictable times. A preemption is the kernel involuntarily
suspending the running thread to run other work; inside the batch I/O
loop it delays the next submission and makes completion timing
unpredictable.

## What

Pass `IORING_SETUP_DEFER_TASKRUN | IORING_SETUP_SINGLE_ISSUER` to
`io_uring_queue_init` in `IoUringPolicy::IoUringPolicy`.

- `src/util/IoUringManager.cpp`: add the two setup flags to the queue-init
  call and document the rationale in the comment.

`IORING_SETUP_SINGLE_ISSUER` is the required prerequisite flag that asserts
a single thread submits requests to the ring.

## Design decisions

- **DEFER_TASKRUN** confines CQE reaping to explicit `io_uring_enter` calls,
  giving the batch I/O loop full control over when completions are drained.
  This is the standard best-practice pairing for single-threaded ring users.
- **No SQPOLL/IOPOLL here**: those are separate optimization dimensions
  (kernel-side polling and polled completion) evaluated in other branches.

## Expected performance improvement

The change removes unwanted preemptions but does not by itself reduce I/O
latency or the serialization cost that dominates QLever's vocab path.
Measurements on DBLP/Ural (cold cache) show no measurable change, consistent
with the io_uring optimizations as a whole being a no-op for QLever's
current workload.  This PR is submitted for correctness and best-practice
alignment rather than a measured win.
