### PR TITLE
export: pre-sized, reserved per-row output buffers

### DIFF
--- a/src/engine/ConstructTripleInstantiator.cpp
+++ b/src/engine/ConstructTripleInstantiator.cpp
@@ -10,6 +10,7 @@
 #include "engine/ConstructTripleInstantiator.h"
 
 #include <absl/strings/str_cat.h>
+#include <absl/strings/str_replace.h>
 
 #include "backports/StartsWithAndEndsWith.h"
 #include "engine/ConstructDeduplicator.h"

--- a/src/engine/ConstructTripleInstantiator.cpp
+++ b/src/engine/ConstructTripleInstantiator.cpp
@@ -118,10 +118,104 @@ std::string formatTerm(const EvaluatedTermData& term, bool includeDataType) {
                       ">");
 }
 
+namespace {
+// Returns true iff `formatTerm` (and `appendFormattedTerm`) emit `term` in the
+// fully qualified form `"value"^^<datatype>` as opposed to the short form
+// without quotation marks.
+bool needsDatatypeWrapper(const EvaluatedTermData& term, bool includeDataType) {
+  if (term.rdfTermDataType_ == nullptr) {
+    return false;
+  }
+  const auto* i = static_cast<const char*>(XSD_INT_TYPE);
+  const auto* d = static_cast<const char*>(XSD_DECIMAL_TYPE);
+  const auto* b = static_cast<const char*>(XSD_BOOLEAN_TYPE);
+  // Note: XSD_DOUBLE_TYPE values (for example "NaN", "INF", "-INF") always
+  // include the datatype.
+  return includeDataType ||
+         (term.rdfTermDataType_ != i && term.rdfTermDataType_ != d &&
+          !(term.rdfTermDataType_ == b && term.rdfTermString_.length() > 1));
+}
+
+// Appends the formatted term to `out`, with the same semantics as
+// `formatTerm`, but without materializing an intermediate string.
+void appendFormattedTerm(std::string& out, const EvaluatedTermData& term,
+                         bool includeDataType) {
+  if (!needsDatatypeWrapper(term, includeDataType)) {
+    // IRI, blank node, vocab-indexed literal, or encoded value in its short
+    // form: the string is already in its final form.
+    out.append(term.rdfTermString_);
+    return;
+  }
+  out.push_back('"');
+  out.append(term.rdfTermString_);
+  out.append("\"^^<");
+  out.append(term.rdfTermDataType_);
+  out.push_back('>');
+}
+
+// Returns true iff `RdfEscaping::validRDFLiteralFromNormalized` would have to
+// escape `normLiteral`, i.e. if there are characters between its first and
+// last quote that must be escaped.
+bool needsRDFLiteralEscaping(std::string_view normLiteral) {
+  AD_CONTRACT_CHECK(ql::starts_with(normLiteral, '"'));
+  size_t posSecondQuote = normLiteral.find('"', 1);
+  AD_CONTRACT_CHECK(posSecondQuote != std::string::npos);
+  size_t posLastQuote = normLiteral.rfind('"');
+  // If there are only two quotes (the first and the last, which every
+  // normalized literal has) and no escape sequences, there is nothing to do.
+  return posSecondQuote != posLastQuote ||
+         normLiteral.find_first_of("\\\n\r") != std::string::npos;
+}
+
+// Appends `normLiteral` to `out`, escaping it exactly like
+// `RdfEscaping::validRDFLiteralFromNormalized` does, but without allocating a
+// new string in the common case where no escaping is required.
+void appendValidRDFLiteral(std::string& out, std::string_view normLiteral) {
+  if (!needsRDFLiteralEscaping(normLiteral)) {
+    out.append(normLiteral);
+    return;
+  }
+  // Otherwise escape first all backslashes then all quotes (the order is
+  // important) in the part between the first and the last quote and leave the
+  // rest unchanged.
+  size_t posLastQuote = normLiteral.rfind('"');
+  std::string_view normalizedContent = normLiteral.substr(1, posLastQuote - 1);
+  out.push_back('"');
+  absl::StrAppend(
+      &out,
+      absl::StrReplaceAll(
+          normalizedContent,
+          {{R"(\", R"(\\)"}, {"\n", "\\n"}, {"\r", "\\r"}, {R"(")", R"(\")"}}));
+  out.append(normLiteral.substr(posLastQuote));
+}
+
+// Appends `input` to `out`, escaping it exactly like
+// `RdfEscaping::escapeForCsv` does.
+void appendEscapedForCsv(std::string& out, std::string_view input) {
+  if (input.find_first_of("\"\r\n,") == std::string_view::npos) [[likely]] {
+    out.append(input);
+    return;
+  }
+  out.push_back('"');
+  absl::StrAppend(&out, absl::StrReplaceAll(input, {{"\"", "\"\""}}));
+  out.push_back('"');
+}
+
+// Appends `input` to `out`, escaping it exactly like
+// `RdfEscaping::escapeForTsv` does.
+void appendEscapedForTsv(std::string& out, std::string_view input) {
+  if (input.find_first_of("\n\t") == std::string_view::npos) [[likely]] {
+    out.append(input);
+    return;
+  }
+  absl::StrAppend(&out,
+                  absl::StrReplaceAll(input, {{"\t", " "}, {"\n", "\\n"}}));
+}
+}  // namespace
+
 // _____________________________________________________________________________
 std::string formatTriple(const EvaluatedTriple& evaluatedTriple,
                          const ad_utility::MediaType& format) {
-  // TODO<ms2144>: take a look where we can eliminate string constructions here.
   using enum ad_utility::MediaType;
   static constexpr std::array supportedFormats{turtle, csv, tsv, ntriples};
   AD_CONTRACT_CHECK(ad_utility::contains(supportedFormats, format));
@@ -130,31 +224,91 @@ std::string formatTriple(const EvaluatedTriple& evaluatedTriple,
 
   const bool includeDataType = (format == ntriples);
 
-  std::string s = formatTerm(*subject, includeDataType);
-  std::string p = formatTerm(*predicate, includeDataType);
-  std::string o = formatTerm(*object, includeDataType);
+  // Buffers that are reused across rows: their capacity is retained between
+  // calls, so rows that are not larger than the previous maximum do not
+  // trigger any allocation. The only per-row allocation is the copy of the
+  // assembled row into the return value (which the caller owns). `scratch`
+  // is only used to hold the formatted object term (turtle/ntriples) or the
+  // formatted terms (csv/tsv) before they are appended (and possibly escaped).
+  thread_local std::string buffer;
+  thread_local std::string scratch;
+  buffer.clear();
+  scratch.clear();
+
+  const EvaluatedTermData& s = *subject;
+  const EvaluatedTermData& p = *predicate;
+  const EvaluatedTermData& o = *object;
+
+  // Conservative estimate of the size of the assembled row. It never
+  // under-allocates: an escape sequence replaces a single character by at
+  // most two characters, so reserving an extra copy of the terms that may be
+  // escaped is always sufficient. The over-allocation is bounded by that
+  // escape headroom (plus a small constant for the separators), and the
+  // capacity is retained in the thread-local buffer for subsequent rows.
+  auto formattedTermSize = [&includeDataType](const EvaluatedTermData& term) {
+    size_t size = term.rdfTermString_.size();
+    if (needsDatatypeWrapper(term, includeDataType)) {
+      size += 6 + std::char_traits<char>::length(term.rdfTermDataType_);
+    }
+    return size;
+  };
+  // The formatted object is a literal (and thus subject to escaping) iff it
+  // either carries a datatype wrapper (which always starts with a quote) or
+  // its raw string already starts with a quote.
+  const bool objectIsLiteral = needsDatatypeWrapper(o, includeDataType) ||
+                               ql::starts_with(o.rdfTermString_, '"');
+  size_t estimatedSize =
+      formattedTermSize(s) + formattedTermSize(p) + formattedTermSize(o);
+  if (format == turtle || format == ntriples) {
+    // Only the object can be escaped, and only if it is a literal.
+    if (objectIsLiteral) {
+      estimatedSize += formattedTermSize(o);
+    }
+    estimatedSize += 5;  // two separating spaces + " .\n"
+  } else {
+    // All three terms can be escaped.
+    estimatedSize +=
+        formattedTermSize(s) + formattedTermSize(p) + formattedTermSize(o);
+    estimatedSize += 3;  // two separators + trailing newline
+  }
+  buffer.reserve(estimatedSize);
 
   if (format == turtle || format == ntriples) {
     // Only escape literals (strings starting with "). IRIs and blank nodes
     // are used as-is, avoiding an unnecessary string copy.
-    if (ql::starts_with(o, '"')) {
-      return absl::StrCat(
-          s, " ", p, " ",
-          RdfEscaping::validRDFLiteralFromNormalized(std::move(o)), " .\n");
+    appendFormattedTerm(buffer, s, includeDataType);
+    buffer.push_back(' ');
+    appendFormattedTerm(buffer, p, includeDataType);
+    buffer.push_back(' ');
+    // The object is escaped like a normalized RDF literal if it is a literal.
+    // Format it into the scratch buffer first, because the escaping decision
+    // depends on the formatted form.
+    if (objectIsLiteral) {
+      appendFormattedTerm(scratch, o, includeDataType);
+      appendValidRDFLiteral(buffer, scratch);
+    } else {
+      appendFormattedTerm(buffer, o, includeDataType);
     }
-    return absl::StrCat(s, " ", p, " ", o, " .\n");
-
-  } else if (format == csv) {
-    return absl::StrCat(RdfEscaping::escapeForCsv(std::move(s)), ",",
-                        RdfEscaping::escapeForCsv(std::move(p)), ",",
-                        RdfEscaping::escapeForCsv(std::move(o)), "\n");
-  } else if (format == tsv) {
-    return absl::StrCat(RdfEscaping::escapeForTsv(std::move(s)), "\t",
-                        RdfEscaping::escapeForTsv(std::move(p)), "\t",
-                        RdfEscaping::escapeForTsv(std::move(o)), "\n");
+    buffer.append(" .\n");
   } else {
-    AD_FAIL();  // unreachable
+    AD_CONTRACT_CHECK(format == csv || format == tsv);
+    auto appendEscapedTerm = [&](const EvaluatedTermData& term) {
+      scratch.clear();
+      appendFormattedTerm(scratch, term, includeDataType);
+      if (format == csv) {
+        appendEscapedForCsv(buffer, scratch);
+      } else {
+        appendEscapedForTsv(buffer, scratch);
+      }
+    };
+    appendEscapedTerm(s);
+    buffer.push_back(format == csv ? ',' : '\t');
+    appendEscapedTerm(p);
+    buffer.push_back(format == csv ? ',' : '\t');
+    appendEscapedTerm(o);
+    buffer.push_back('\n');
   }
+  return buffer;
 }
 
 // _____________________________________________________________________________

--- a/src/engine/ConstructTripleInstantiator.cpp
+++ b/src/engine/ConstructTripleInstantiator.cpp
@@ -235,6 +235,9 @@ std::string formatTriple(const EvaluatedTriple& evaluatedTriple,
   // assembled row into the return value (which the caller owns). `scratch`
   // is only used to hold the formatted object term (turtle/ntriples) or the
   // formatted terms (csv/tsv) before they are appended (and possibly escaped).
+  // `thread_local` means one independent buffer per thread: concurrent export
+  // requests on different threads do not share (and thus do not lock) the
+  // buffers, and each thread keeps its capacity across requests.
   thread_local std::string buffer;
   thread_local std::string scratch;
   buffer.clear();

--- a/src/engine/ConstructTripleInstantiator.cpp
+++ b/src/engine/ConstructTripleInstantiator.cpp
@@ -186,7 +186,7 @@ void appendValidRDFLiteral(std::string& out, std::string_view normLiteral) {
   absl::StrAppend(
       &out, absl::StrReplaceAll(
                 normalizedContent,
-                {Replacement{R"(\\)", R"(\\\\)"}, Replacement{"\n", "\\n"},
+                {Replacement{R"(\)", R"(\\)"}, Replacement{"\n", "\\n"},
                  Replacement{"\r", "\\r"}, Replacement{R"(")", R"(\")"}}));
   out.append(normLiteral.substr(posLastQuote));
 }

--- a/src/engine/ConstructTripleInstantiator.cpp
+++ b/src/engine/ConstructTripleInstantiator.cpp
@@ -182,11 +182,12 @@ void appendValidRDFLiteral(std::string& out, std::string_view normLiteral) {
   size_t posLastQuote = normLiteral.rfind('"');
   std::string_view normalizedContent = normLiteral.substr(1, posLastQuote - 1);
   out.push_back('"');
+  using Replacement = std::pair<absl::string_view, absl::string_view>;
   absl::StrAppend(
-      &out,
-      absl::StrReplaceAll(
-          normalizedContent,
-          {{R"(\", R"(\\)"}, {"\n", "\\n"}, {"\r", "\\r"}, {R"(")", R"(\")"}}));
+      &out, absl::StrReplaceAll(
+                normalizedContent,
+                {Replacement{R"(\\)", R"(\\\\)"}, Replacement{"\n", "\\n"},
+                 Replacement{"\r", "\\r"}, Replacement{R"(")", R"(\")"}}));
   out.append(normLiteral.substr(posLastQuote));
 }
 
@@ -198,7 +199,9 @@ void appendEscapedForCsv(std::string& out, std::string_view input) {
     return;
   }
   out.push_back('"');
-  absl::StrAppend(&out, absl::StrReplaceAll(input, {{"\"", "\"\""}}));
+  using Replacement = std::pair<absl::string_view, absl::string_view>;
+  absl::StrAppend(&out,
+                  absl::StrReplaceAll(input, {Replacement{"\"", "\"\""}}));
   out.push_back('"');
 }
 
@@ -209,8 +212,9 @@ void appendEscapedForTsv(std::string& out, std::string_view input) {
     out.append(input);
     return;
   }
-  absl::StrAppend(&out,
-                  absl::StrReplaceAll(input, {{"\t", " "}, {"\n", "\\n"}}));
+  using Replacement = std::pair<absl::string_view, absl::string_view>;
+  absl::StrAppend(&out, absl::StrReplaceAll(input, {Replacement{"\t", " "},
+                                                    Replacement{"\n", "\\n"}}));
 }
 }  // namespace
 

--- a/src/engine/ExportQueryExecutionTrees.cpp
+++ b/src/engine/ExportQueryExecutionTrees.cpp
@@ -562,7 +562,7 @@ STREAMABLE_GENERATOR_TYPE ExportQueryExecutionTrees::selectQueryResultToStream(
         }
       }
       rowBuffer.push_back('\n');
-      STREAMABLE_YIELD(rowBuffer);
+      STREAMABLE_YIELD(std::move(rowBuffer));
       cancellationHandle->throwIfCancelled();
     }
   }

--- a/src/engine/ExportQueryExecutionTrees.cpp
+++ b/src/engine/ExportQueryExecutionTrees.cpp
@@ -461,6 +461,61 @@ ExportQueryExecutionTrees::selectQueryResultBindingsToQLeverJSON(
 }
 
 // _____________________________________________________________________________
+// Assemble one CSV/TSV row into `rowBuffer`, reusing `cellStrings` across all
+// rows of the request.  This helper is NOT a coroutine and holds no state: the
+// two buffers are coroutine-frame locals in the caller and are passed by
+// reference, so their capacity is retained across rows.  They must not be
+// `thread_local` — a coroutine may be suspended and resumed on a different
+// thread, so thread_local state would alias another thread's buffers there.
+template <ad_utility::MediaType format>
+static void assembleCsvRowForStream(
+    std::string& rowBuffer,
+    std::vector<std::optional<std::string>>& cellStrings,
+    const QueryExecutionTree::ColumnIndicesAndTypes& selectedColumnIndices,
+    const TableConstRefWithVocab& tableWithVocab, size_t rowIndex,
+    const Index& index, char separator) {
+  constexpr auto& escapeFunction = format == ad_utility::MediaType::tsv
+                                       ? RdfEscaping::escapeForTsv
+                                       : RdfEscaping::escapeForCsv;
+  // Resolve all cells of the row first, so that the exact size of the row is
+  // known and the row buffer can be reserved exactly once before assembling
+  // the row.
+  cellStrings.clear();
+  cellStrings.resize(selectedColumnIndices.size());
+  size_t estimatedRowSize = 1;  // the trailing newline
+  for (size_t j = 0; j < selectedColumnIndices.size(); ++j) {
+    if (selectedColumnIndices[j].has_value()) {
+      const auto& val = selectedColumnIndices[j].value();
+      Id id = tableWithVocab.idTable()(rowIndex, val.columnIndex_);
+      auto optionalStringAndType =
+          ql::exportIds::idToStringAndType<format ==
+                                           ad_utility::MediaType::csv>(
+              index, id, tableWithVocab.localVocab(), escapeFunction);
+      if (optionalStringAndType.has_value()) [[likely]] {
+        cellStrings[j] = std::move(optionalStringAndType.value().first);
+        estimatedRowSize += cellStrings[j]->size();
+      }
+    }
+    if (j + 1 < selectedColumnIndices.size()) {
+      ++estimatedRowSize;  // the separator
+    }
+  }
+  rowBuffer.clear();
+  // Reserve the exact row size once; this is a no-op unless the current row
+  // is larger than any previous one (the capacity is retained in `rowBuffer`).
+  rowBuffer.reserve(estimatedRowSize);
+  for (size_t j = 0; j < selectedColumnIndices.size(); ++j) {
+    if (cellStrings[j].has_value()) {
+      rowBuffer.append(*cellStrings[j]);
+    }
+    if (j + 1 < selectedColumnIndices.size()) {
+      rowBuffer.push_back(separator);
+    }
+  }
+  rowBuffer.push_back('\n');
+}
+
+// _____________________________________________________________________________
 template <ad_utility::MediaType format>
 STREAMABLE_GENERATOR_TYPE ExportQueryExecutionTrees::selectQueryResultToStream(
     const QueryExecutionTree& qet,
@@ -514,54 +569,20 @@ STREAMABLE_GENERATOR_TYPE ExportQueryExecutionTrees::selectQueryResultToStream(
   STREAMABLE_YIELD(absl::StrJoin(variables, std::string_view{&separator, 1}));
   STREAMABLE_YIELD('\n');
 
-  constexpr auto& escapeFunction =
-      format == tsv ? RdfEscaping::escapeForTsv : RdfEscaping::escapeForCsv;
   uint64_t resultSize = 0;
-  // Buffers that are reused across all rows (and across requests on the same
-  // thread): their capacity is retained, so only rows that are larger than
-  // any previous one trigger a reallocation.
-  thread_local std::string rowBuffer;
-  thread_local std::vector<std::optional<std::string>> cellStrings;
+  // Buffers that are reused across all rows of this request: their capacity
+  // is retained, so only rows that are larger than any previous one trigger
+  // a reallocation.  They are coroutine-frame locals (NOT `thread_local`): a
+  // coroutine may be suspended and resumed on a different thread, so
+  // thread_local state would be unsafe there (see `assembleCsvRowForStream`).
+  std::string rowBuffer;
+  std::vector<std::optional<std::string>> cellStrings;
   for (const auto& [pair, range] :
        getRowIndices(limitAndOffset, *result, resultSize)) {
     for (uint64_t i : range) {
-      // Resolve all cells of the row first, so that the exact size of the row
-      // is known and the row buffer can be reserved exactly once before
-      // assembling the row.
-      cellStrings.clear();
-      cellStrings.resize(selectedColumnIndices.size());
-      size_t estimatedRowSize = 1;  // the trailing newline
-      for (size_t j = 0; j < selectedColumnIndices.size(); ++j) {
-        if (selectedColumnIndices[j].has_value()) {
-          const auto& val = selectedColumnIndices[j].value();
-          Id id = pair.idTable()(i, val.columnIndex_);
-          auto optionalStringAndType =
-              ql::exportIds::idToStringAndType<format == csv>(
-                  qet.getQec()->getIndex(), id, pair.localVocab(),
-                  escapeFunction);
-          if (optionalStringAndType.has_value()) [[likely]] {
-            cellStrings[j] = std::move(optionalStringAndType.value().first);
-            estimatedRowSize += cellStrings[j]->size();
-          }
-        }
-        if (j + 1 < selectedColumnIndices.size()) {
-          ++estimatedRowSize;  // the separator
-        }
-      }
-      rowBuffer.clear();
-      // Reserve the exact row size once; this is a no-op unless the current
-      // row is larger than any previous one (the capacity is retained in
-      // `rowBuffer`).
-      rowBuffer.reserve(estimatedRowSize);
-      for (size_t j = 0; j < selectedColumnIndices.size(); ++j) {
-        if (cellStrings[j].has_value()) {
-          rowBuffer.append(*cellStrings[j]);
-        }
-        if (j + 1 < selectedColumnIndices.size()) {
-          rowBuffer.push_back(separator);
-        }
-      }
-      rowBuffer.push_back('\n');
+      assembleCsvRowForStream<format>(rowBuffer, cellStrings,
+                                      selectedColumnIndices, pair, i,
+                                      qet.getQec()->getIndex(), separator);
       STREAMABLE_YIELD(std::move(rowBuffer));
       cancellationHandle->throwIfCancelled();
     }

--- a/src/engine/ExportQueryExecutionTrees.cpp
+++ b/src/engine/ExportQueryExecutionTrees.cpp
@@ -18,6 +18,7 @@
 
 #include <optional>
 #include <string_view>
+#include <vector>
 
 #include "backports/StartsWithAndEndsWith.h"
 #include "backports/algorithm.h"
@@ -516,9 +517,20 @@ STREAMABLE_GENERATOR_TYPE ExportQueryExecutionTrees::selectQueryResultToStream(
   constexpr auto& escapeFunction =
       format == tsv ? RdfEscaping::escapeForTsv : RdfEscaping::escapeForCsv;
   uint64_t resultSize = 0;
+  // Buffers that are reused across all rows (and across requests on the same
+  // thread): their capacity is retained, so only rows that are larger than
+  // any previous one trigger a reallocation.
+  thread_local std::string rowBuffer;
+  thread_local std::vector<std::optional<std::string>> cellStrings;
   for (const auto& [pair, range] :
        getRowIndices(limitAndOffset, *result, resultSize)) {
     for (uint64_t i : range) {
+      // Resolve all cells of the row first, so that the exact size of the row
+      // is known and the row buffer can be reserved exactly once before
+      // assembling the row.
+      cellStrings.clear();
+      cellStrings.resize(selectedColumnIndices.size());
+      size_t estimatedRowSize = 1;  // the trailing newline
       for (size_t j = 0; j < selectedColumnIndices.size(); ++j) {
         if (selectedColumnIndices[j].has_value()) {
           const auto& val = selectedColumnIndices[j].value();
@@ -528,14 +540,29 @@ STREAMABLE_GENERATOR_TYPE ExportQueryExecutionTrees::selectQueryResultToStream(
                   qet.getQec()->getIndex(), id, pair.localVocab(),
                   escapeFunction);
           if (optionalStringAndType.has_value()) [[likely]] {
-            STREAMABLE_YIELD(optionalStringAndType.value().first);
+            cellStrings[j] = std::move(optionalStringAndType.value().first);
+            estimatedRowSize += cellStrings[j]->size();
           }
         }
         if (j + 1 < selectedColumnIndices.size()) {
-          STREAMABLE_YIELD(separator);
+          ++estimatedRowSize;  // the separator
         }
       }
-      STREAMABLE_YIELD('\n');
+      rowBuffer.clear();
+      // Reserve the exact row size once; this is a no-op unless the current
+      // row is larger than any previous one (the capacity is retained in
+      // `rowBuffer`).
+      rowBuffer.reserve(estimatedRowSize);
+      for (size_t j = 0; j < selectedColumnIndices.size(); ++j) {
+        if (cellStrings[j].has_value()) {
+          rowBuffer.append(*cellStrings[j]);
+        }
+        if (j + 1 < selectedColumnIndices.size()) {
+          rowBuffer.push_back(separator);
+        }
+      }
+      rowBuffer.push_back('\n');
+      STREAMABLE_YIELD(rowBuffer);
       cancellationHandle->throwIfCancelled();
     }
   }

--- a/src/util/stream_generator.h
+++ b/src/util/stream_generator.h
@@ -116,13 +116,16 @@ class stream_generator_promise {
   // implicitly convert to char are not accepted.
   CPP_template(typename CharT)(requires SimilarTo<CharT, char>)
       suspend_sometimes yield_value(CharT value) {
-    std::string_view singleView{&value, 1};
-    // This is only safe to do if we can write into the buffer immediately.
-    AD_CORRECTNESS_CHECK(isBufferLargeEnough(singleView));
-    // Disable false positive warning on GCC.
-    DISABLE_OVERREAD_WARNINGS
-    return yield_value(singleView);
-    GCC_REENABLE_WARNINGS
+    // Write the character directly instead of going through the
+    // `std::string_view` overload: the fortified `memcpy` there triggers a
+    // GCC 11 `-Wstringop-overread` false positive whose warning location is
+    // in the system header (string_fortified.h), so it cannot be suppressed
+    // with a diagnostic pragma. The direct write is always safe: the
+    // correctness check guarantees that at least one byte of buffer capacity
+    // remains.
+    AD_CORRECTNESS_CHECK(currentIndex_ < BUFFER_SIZE);
+    data_[currentIndex_++] = value;
+    return suspend_sometimes{currentIndex_ == BUFFER_SIZE};
   }
 
   // Return true if the overflow has been completely consumed.

--- a/src/util/stream_generator.h
+++ b/src/util/stream_generator.h
@@ -1,7 +1,8 @@
-// Copyright 2021 - 2025 The QLever Authors, in particular:
+// Copyright 2021 - 2026, The QLever Authors, in particular:
 //
 // 2021 Robin Textor-Falconi <textorr@cs.uni-freiburg.de>, UFR
-// 2025 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+// 2025 - 2026 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+// 2026        Marvin Stoetzel <stoetzem@email.uni-freiburg.de>, UFR
 
 // UFR = University of Freiburg, Chair of Algorithms and Data Structures
 

--- a/src/util/stream_generator.h
+++ b/src/util/stream_generator.h
@@ -89,6 +89,12 @@ class stream_generator_promise {
   // this case the buffer will be filled to maximum capacity, so eventually
   // every bit of `value` is written, then the coroutine will be resumed.
   suspend_sometimes yield_value(std::string_view value) noexcept {
+    // GCC 11-15 emit spurious `-Wstringop-overread` warnings for the `memcpy`
+    // calls below when this function is inlined into a large coroutine frame
+    // and the size of `value` cannot be proven to fit into the buffer. The
+    // copies are always safe: `isBufferLargeEnough` guarantees that at most
+    // `value.size()` bytes are read from `value`.
+    DISABLE_OVERREAD_WARNINGS
     if (isBufferLargeEnough(value)) {
       if (!value.empty()) {
         std::memcpy(data_.data() + currentIndex_, value.data(), value.size());
@@ -103,6 +109,7 @@ class stream_generator_promise {
     currentIndex_ = BUFFER_SIZE;
     overflow_ = value.substr(fittingSize);
     return suspend_sometimes{true};
+    GCC_REENABLE_WARNINGS
   }
 
   // Overload so we can also pass char values, template such that all types that


### PR DESCRIPTION
## Why

Export is serialization-bound (run io-uring-real, PR 3208 thread). Per-row
string building in the export path grows buffers incrementally, causing
reallocations and copies under large literal-heavy results.

## What

Pre-size and reserve per-row output buffers:
- Estimate the serialized length of a row (IRI prefix + literal length + escape
  headroom) and `reserve` once per row before formatting.
- Reuse per-thread buffers across rows instead of allocating fresh.

Measurements are in progress on DBLP/Ural (deterministic gate, one concern
per run, interleaved A/B, true cold cache); results and artifacts will be
reported here as soon as they complete.

## Design decisions

- Length estimation is conservative (never under-allocate; over-allocation is
  bounded).
- Keep the public export API unchanged.
- Verify byte-identical output against master for all formats.

## Expected performance improvement

Literal-heavy results (H-vocab families, D3/R1 materializations) should improve
if allocation/reallocation is a measurable share of formatting. Negative
result closes without merge.

