### PR TITLE
Make QLever's C++17 build pedantically clean and enforce it in the CI

### DIFF
--- a/.github/workflows/cpp-17-libqlever.yml
+++ b/.github/workflows/cpp-17-libqlever.yml
@@ -41,6 +41,18 @@ jobs:
 
     env:
       warnings:   ""
+      # Compile QLever's own code with `-pedantic-errors`, so that any use of a
+      # C++20 (or GNU) extension that is not valid C++17 becomes a hard error
+      # instead of a diagnostic that GCC and Clang silently accept. Examples that
+      # this catches are designated initializers, lambda templates, default
+      # member initializers for bit-fields, `auto` function parameters, and
+      # variadic macros that are invoked without any argument for their `...`.
+      # These flags are deliberately passed via
+      # `ADDITIONAL_COMPILER_FLAGS_QLEVER_ONLY` and not via
+      # `ADDITIONAL_COMPILER_FLAGS`, because several of the third-party
+      # dependencies are not pedantically clean (see the comment at the
+      # definition of that variable in `CMakeLists.txt`).
+      pedantic-flags: "-pedantic-errors"
       build-type: Release
       expensive-tests: true
       compiler: gcc
@@ -117,7 +129,7 @@ jobs:
       - name: Configure CMake
         # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
         # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.build-type}} -DCMAKE_TOOLCHAIN_FILE="$(pwd)/toolchains/${{env.compiler}}${{matrix.compiler-version}}.cmake" -DADDITIONAL_COMPILER_FLAGS="${{env.warnings}}" -DUSE_PARALLEL=false -DRUN_EXPENSIVE_TESTS=${{env.expensive-tests}} -DENABLE_EXPENSIVE_CHECKS=true ${{matrix.additional-cmake-options}} -DADDITIONAL_LINKER_FLAGS="-B /usr/bin/mold"
+        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.build-type}} -DCMAKE_TOOLCHAIN_FILE="$(pwd)/toolchains/${{env.compiler}}${{matrix.compiler-version}}.cmake" -DADDITIONAL_COMPILER_FLAGS="${{env.warnings}}" -DADDITIONAL_COMPILER_FLAGS_QLEVER_ONLY="${{env.pedantic-flags}}" -DUSE_PARALLEL=false -DRUN_EXPENSIVE_TESTS=${{env.expensive-tests}} -DENABLE_EXPENSIVE_CHECKS=true ${{matrix.additional-cmake-options}} -DADDITIONAL_LINKER_FLAGS="-B /usr/bin/mold"
 
       - name: Build
         # Build your program with the given configuration

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -665,6 +665,21 @@ if (EMSCRIPTEN)
 endif ()
 FetchContent_MakeAvailable(googletest ctre abseil fsst nlohmann-json antlr range-v3 spatialjoin uriparser opentelemetry-cpp s2 re2)
 
+# Additional compiler flags that are applied to QLever's own targets only, and
+# not to the third-party dependencies that were made available above. This is
+# how the CI enables `-pedantic-errors`: QLever's own code has to be free of
+# pedantic diagnostics, but several of the dependencies (in particular `re2` and
+# `s2`) are not pedantically clean and are not ours to fix. This works because
+# `add_compile_options` only affects targets that are created after the call, and
+# all of QLever's own targets are created below, whereas the dependencies have
+# just been added above. Use `ADDITIONAL_COMPILER_FLAGS` for flags that shall
+# apply to the dependencies as well.
+set(ADDITIONAL_COMPILER_FLAGS_QLEVER_ONLY "" CACHE STRING "Additional compiler flags for QLever's own targets, but not for the third-party dependencies (see the comment in `CMakeLists.txt`)")
+if (ADDITIONAL_COMPILER_FLAGS_QLEVER_ONLY)
+    separate_arguments(ADDITIONAL_COMPILER_FLAGS_QLEVER_ONLY_LIST UNIX_COMMAND "${ADDITIONAL_COMPILER_FLAGS_QLEVER_ONLY}")
+    add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:${ADDITIONAL_COMPILER_FLAGS_QLEVER_ONLY_LIST}>")
+endif ()
+
 # Depending on `BUILD_SHARED_LIBS`, the `antlr4` build creates either a shared or
 # a static library target. Define the alias `antlr4_umbrella` such that the rest
 # of the build can link against the correct one without further case

--- a/src/backports/three_way_comparison.h
+++ b/src/backports/three_way_comparison.h
@@ -39,6 +39,15 @@
  * - QL_DEFINE_CUSTOM_THREEWAY_OPERATOR_LOCAL_CONSTEXPR(Class):
  * Constexpr member version
  *
+ * Note: For a class without any data members, the `members...` argument of the
+ * defaulted macros is empty, and the macro has to be invoked with a trailing
+ * comma, for example `QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(Empty, )`.
+ * Reason: before C++20, a variadic macro requires at least one argument for its
+ * `...` parameter (GCC and Clang accept zero arguments as an extension, but
+ * warn about it with `-Wpedantic` and reject it with `-pedantic-errors`). The
+ * trailing comma supplies a single empty argument and thus makes the invocation
+ * valid C++17. It has no effect on the generated code in either standard mode.
+ *
  * Note: Custom three-way comparison macros assume the presence of a
  * compareThreeWay function (either as a member or free function) that returns
  * a comparison ordering (e.g., ql::strong_ordering, ql::weak_ordering, or

--- a/src/engine/CallFixedSize.h
+++ b/src/engine/CallFixedSize.h
@@ -61,7 +61,7 @@ CPP_variadic_template(typename Int, Int... Is, typename F, typename... Args)(
         Int>) auto applyOnIntegerSequence(ad_utility::ValueSequence<Int, Is...>,
                                           F&& lambda, Args&&... args) {
   return lambda.template operator()<Is...>(AD_FWD(args)...);
-};
+}
 
 // An array with `NumValues` entries of type `Int` that has linkage in C++17
 // mode. It is needed below to deduce a return type.

--- a/src/engine/ConstructTemplatePreprocessor.cpp
+++ b/src/engine/ConstructTemplatePreprocessor.cpp
@@ -45,9 +45,8 @@ std::optional<PreprocessedTerm> ConstructTemplatePreprocessor::preprocessIri(
     const Iri& iri) {
   ValueId dedupId = resolveConstantDedupId(TripleComponent{iri});
   return PrecomputedConstant{
-      .evaluatedTerm_ =
-          std::make_shared<const EvaluatedTermData>(iri.toSparql(), nullptr),
-      .dedupId_ = dedupId};
+      std::make_shared<const EvaluatedTermData>(iri.toSparql(), nullptr),
+      dedupId};
 }
 
 // _____________________________________________________________________________
@@ -69,9 +68,8 @@ ConstructTemplatePreprocessor::preprocessLiteral(const Literal& literal,
           literal.toSparql());
   ValueId dedupId = resolveConstantDedupId(std::move(parsedObject));
   return PrecomputedConstant{
-      .evaluatedTerm_ =
-          std::make_shared<const EvaluatedTermData>(literal.literal(), nullptr),
-      .dedupId_ = dedupId};
+      std::make_shared<const EvaluatedTermData>(literal.literal(), nullptr),
+      dedupId};
 }
 
 // _____________________________________________________________________________
@@ -86,9 +84,8 @@ ConstructTemplatePreprocessor::preprocessVariable(const Variable& variable) {
 // _____________________________________________________________________________
 std::optional<PreprocessedTerm>
 ConstructTemplatePreprocessor::preprocessBlankNode(const BlankNode& blankNode) {
-  return PrecomputedBlankNode{
-      .prefix_ = blankNode.isGenerated() ? "_:g" : "_:u",
-      .suffix_ = absl::StrCat("_", blankNode.label())};
+  return PrecomputedBlankNode{blankNode.isGenerated() ? "_:g" : "_:u",
+                              absl::StrCat("_", blankNode.label())};
 }
 
 // _____________________________________________________________________________

--- a/src/engine/CountConnectedSubgraphs.cpp
+++ b/src/engine/CountConnectedSubgraphs.cpp
@@ -75,7 +75,7 @@ static std::vector<uint8_t> bitsetToVector(uint64_t bitset) {
     }
   }
   return result;
-};
+}
 
 // _____________________________________________________________________________
 std::string toBitsetString(uint64_t x) {

--- a/src/engine/Filter.h
+++ b/src/engine/Filter.h
@@ -44,7 +44,7 @@ class Filter : public Operation {
  public:
   size_t getCostEstimate() override;
 
-  std::shared_ptr<QueryExecutionTree> getSubtree() const { return _subtree; };
+  std::shared_ptr<QueryExecutionTree> getSubtree() const { return _subtree; }
   std::vector<QueryExecutionTree*> getChildren() override {
     return {_subtree.get()};
   }

--- a/src/engine/GroupByHashMapOptimization.h
+++ b/src/engine/GroupByHashMapOptimization.h
@@ -41,7 +41,7 @@ struct AvgAggregationData {
     auto val = ValueGetter{}(AD_FWD(value), ctx);
     std::visit([this](auto val) { valueAdder(val, sum_, error_); }, val);
     count_++;
-  };
+  }
 
   // _____________________________________________________________________________
   [[nodiscard]] ValueId calculateResult(
@@ -130,7 +130,7 @@ struct SumAggregationData {
         doubleValueAdder, intValueAdder, nonNumericValueAdder};
 
     std::visit(sumValueAdder, val);
-  };
+  }
 
   // _____________________________________________________________________________
   [[nodiscard]] ValueId calculateResult(

--- a/src/engine/GroupByImpl.cpp
+++ b/src/engine/GroupByImpl.cpp
@@ -1051,7 +1051,7 @@ GroupByImpl::getPermutationForThreeVariableTriple(
     return indexScan->permutation();
   }
   return {};
-};
+}
 
 // ____________________________________________________________________________
 std::optional<GroupByImpl::OptimizedGroupByData>

--- a/src/engine/IndexScan.cpp
+++ b/src/engine/IndexScan.cpp
@@ -159,7 +159,7 @@ string IndexScan::getCacheKeyImpl() const {
 // _____________________________________________________________________________
 bool IndexScan::resultDoesMatchCacheKey() const {
   return !scanSpecAndBlocksIsPrefiltered_;
-};
+}
 
 // _____________________________________________________________________________
 string IndexScan::getDescriptor() const {
@@ -474,14 +474,14 @@ CompressedRelationReader::IdTableGeneratorInputRange IndexScan::getLazyScan(
       ad_utility::CachingTransformInputRange{
           std::move(lazyScanAllCols), makeApplyColumnSubset(),
           ql::type_identity<LazyScanMetadata>{}}};
-};
+}
 
 // _____________________________________________________________________________
 std::optional<Permutation::MetadataAndBlocks> IndexScan::getMetadataForScan()
     const {
   return permutation().getMetadataAndBlocks(scanSpecAndBlocks_,
                                             locatedTriplesState());
-};
+}
 
 // _____________________________________________________________________________
 std::array<CompressedRelationReader::IdTableGeneratorInputRange, 2>

--- a/src/engine/MaterializedViews.cpp
+++ b/src/engine/MaterializedViews.cpp
@@ -347,13 +347,13 @@ const Variable& MaterializedView::dummySubject() {
 const Variable& MaterializedView::dummyPredicate() {
   static const Variable var{"?_ql_materialized_view_p"};
   return var;
-};
+}
 
 // _____________________________________________________________________________
 const Variable& MaterializedView::dummyObject() {
   static const Variable var{"?_ql_materialized_view_o"};
   return var;
-};
+}
 
 // _____________________________________________________________________________
 MaterializedView::MaterializedView(std::string onDiskBase, std::string name)

--- a/src/engine/MaterializedViews.h
+++ b/src/engine/MaterializedViews.h
@@ -371,7 +371,7 @@ class MaterializedViewsManager {
  public:
   MaterializedViewsManager() = default;
   explicit MaterializedViewsManager(std::string onDiskBase)
-      : onDiskBase_{std::move(onDiskBase)} {};
+      : onDiskBase_{std::move(onDiskBase)} {}
 
   // For use with the default constructor: set the index basename after creation
   // of the `MaterializedViewsManager`. This should only be called once and

--- a/src/engine/MaterializedViewsQueryAnalysis.h
+++ b/src/engine/MaterializedViewsQueryAnalysis.h
@@ -57,6 +57,13 @@ struct StarInfo {
 struct ByCacheKeyInfo {
   ViewPtr view_;
   ad_utility::HashMap<size_t, size_t> colMapping_;
+
+  // Construct from the view and the mapping of its columns.
+  // NOTE: This constructor is explicitly declared (and not only implicitly via
+  // aggregate initialization) because parenthesized initialization of
+  // aggregates is not supported in C++17.
+  ByCacheKeyInfo(ViewPtr view, ad_utility::HashMap<size_t, size_t> colMapping)
+      : view_{std::move(view)}, colMapping_{std::move(colMapping)} {}
 };
 using ByCacheKeyInfoPtr = std::shared_ptr<const ByCacheKeyInfo>;
 

--- a/src/engine/NeutralElementOperation.h
+++ b/src/engine/NeutralElementOperation.h
@@ -20,21 +20,21 @@ class NeutralElementOperation : public Operation {
   // customized by every child class.
   [[nodiscard]] std::string getCacheKeyImpl() const override {
     return "Neutral Element";
-  };
+  }
 
  public:
   [[nodiscard]] std::string getDescriptor() const override {
     return "NeutralElement";
-  };
-  [[nodiscard]] size_t getResultWidth() const override { return 0; };
+  }
+  [[nodiscard]] size_t getResultWidth() const override { return 0; }
   size_t getCostEstimate() override { return 0; }
 
  private:
   uint64_t getSizeEstimateBeforeLimit() override { return 1; }
 
  public:
-  float getMultiplicity(size_t) override { return 0; };
-  bool knownEmptyResult() override { return false; };
+  float getMultiplicity(size_t) override { return 0; }
+  bool knownEmptyResult() override { return false; }
 
   std::unique_ptr<Operation> cloneImpl() const override {
     return std::make_unique<NeutralElementOperation>(_executionContext);
@@ -43,7 +43,7 @@ class NeutralElementOperation : public Operation {
  protected:
   [[nodiscard]] std::vector<ColumnIndex> resultSortedOn() const override {
     return {};
-  };
+  }
 
  private:
   [[nodiscard]] bool isDeterministicImpl() const override { return true; }
@@ -58,7 +58,7 @@ class NeutralElementOperation : public Operation {
   [[nodiscard]] VariableToColumnMap computeVariableToColumnMap()
       const override {
     return {};
-  };
+  }
 };
 
 #endif  // QLEVER_SRC_ENGINE_NEUTRALELEMENTOPERATION_H

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -175,7 +175,7 @@ class Operation {
       [[maybe_unused]] const std::vector<PrefilterVariablePair>& prefilters)
       const {
     return std::nullopt;
-  };
+  }
 
   // Get a unique, not ambiguous string representation for a subtree.
   // This should act like an ID for each subtree.
@@ -461,7 +461,7 @@ class Operation {
   virtual std::optional<std::shared_ptr<QueryExecutionTree>>
   makeTreeWithBindColumn(const parsedQuery::Bind&) const {
     return std::nullopt;
-  };
+  }
 
  protected:
   // The QueryExecutionContext for this particular element.

--- a/src/engine/OptionalJoin.cpp
+++ b/src/engine/OptionalJoin.cpp
@@ -550,7 +550,8 @@ Result OptionalJoin::optionalJoinWithIndexScan(
                std::function<void(IdTable&, LocalVocab&)> yieldTable) {
       auto rowAdder = getRowAdderForJoin(
           *this, _joinColumns.size(), keepJoinColumns_, std::move(yieldTable));
-      auto getLeftAndRightRange = [&]<size_t numJoinCols>() {
+      auto getLeftAndRightRange = [&](auto numJoinColsV) {
+        static constexpr size_t numJoinCols = numJoinColsV;
         auto firstJoinColLeft = _joinColumns.at(0).at(0);
         if constexpr (leftIsMaterialized) {
           auto rightBlocksInternal = rightScan->lazyScanForJoinOfColumnWithScan(
@@ -583,16 +584,14 @@ Result OptionalJoin::optionalJoinWithIndexScan(
         // Note: The `zipperJoinForBlocksWithPotentialUndef` automatically
         // switches to a more efficient implementation if there are no UNDEF
         // values in any of the inputs.
-        auto [leftRange, rightRange] =
-            getLeftAndRightRange.template operator()<1>();
+        auto [leftRange, rightRange] = getLeftAndRightRange(vi<1>);
         zipperJoinForBlocksWithPotentialUndef(
             std::move(leftRange), std::move(rightRange), std::less{}, rowAdder,
             {}, {}, ad_utility::OptionalJoinTag{});
       } else {
         AD_CORRECTNESS_CHECK(implementation_ ==
                              Implementation::OnlyUndefInLastJoinColumnOfLeft);
-        auto [leftRange, rightRange] =
-            getLeftAndRightRange.template operator()<2>();
+        auto [leftRange, rightRange] = getLeftAndRightRange(vi<2>);
         specialOptionalJoinForBlocks(
             std::move(leftRange), std::move(rightRange),
             std::integral_constant<size_t, 2>{}, rowAdder);

--- a/src/engine/PathSearch.cpp
+++ b/src/engine/PathSearch.cpp
@@ -135,7 +135,7 @@ std::vector<QueryExecutionTree*> PathSearch::getChildren() {
   }
 
   return res;
-};
+}
 
 // _____________________________________________________________________________
 std::string PathSearch::getCacheKeyImpl() const {
@@ -162,35 +162,35 @@ std::string PathSearch::getCacheKeyImpl() const {
   }
 
   return std::move(os).str();
-};
+}
 
 // _____________________________________________________________________________
 std::string PathSearch::getDescriptor() const {
   std::ostringstream os;
   os << "PathSearch";
   return std::move(os).str();
-};
+}
 
 // _____________________________________________________________________________
-size_t PathSearch::getResultWidth() const { return resultWidth_; };
+size_t PathSearch::getResultWidth() const { return resultWidth_; }
 
 // _____________________________________________________________________________
 size_t PathSearch::getCostEstimate() {
   // TODO: Figure out a smart way to estimate cost
   return 1000;
-};
+}
 
 // _____________________________________________________________________________
 uint64_t PathSearch::getSizeEstimateBeforeLimit() {
   // TODO: Figure out a smart way to estimate size
   return 1000;
-};
+}
 
 // _____________________________________________________________________________
 float PathSearch::getMultiplicity(size_t col) {
   (void)col;
   return 1;
-};
+}
 
 // _____________________________________________________________________________
 bool PathSearch::knownEmptyResult() {
@@ -200,10 +200,10 @@ bool PathSearch::knownEmptyResult() {
     }
   }
   return false;
-};
+}
 
 // _____________________________________________________________________________
-std::vector<ColumnIndex> PathSearch::resultSortedOn() const { return {}; };
+std::vector<ColumnIndex> PathSearch::resultSortedOn() const { return {}; }
 
 // _____________________________________________________________________________
 void PathSearch::bindSourceSide(std::shared_ptr<QueryExecutionTree> sourcesOp,
@@ -287,12 +287,12 @@ Result PathSearch::computeResult([[maybe_unused]] bool requestLaziness) {
   }
 
   return {std::move(idTable), resultSortedOn(), subRes->getSharedLocalVocab()};
-};
+}
 
 // _____________________________________________________________________________
 VariableToColumnMap PathSearch::computeVariableToColumnMap() const {
   return variableColumns_;
-};
+}
 
 // _____________________________________________________________________________
 std::pair<ql::span<const Id>, ql::span<const Id>>

--- a/src/engine/QueryExecutionContext.h
+++ b/src/engine/QueryExecutionContext.h
@@ -153,7 +153,7 @@ class QueryExecutionContext
 
   [[nodiscard]] double getCostFactor(const std::string& key) const {
     return _costFactors.getCostFactor(key);
-  };
+  }
 
   const ad_utility::AllocatorWithLimit<Id>& getAllocator() const {
     return _allocator;
@@ -218,7 +218,7 @@ class QueryExecutionContext
   // Get a reference to the `MaterializedViewsManager`.
   const MaterializedViewsManager& materializedViewsManager() const {
     return *materializedViewsManager_;
-  };
+  }
 
   // If `pinResultWithName_` is set, then the result of the query that is
   // executed using this context will be stored in the `namedQueryCache()` using

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -603,7 +603,7 @@ SparqlFilter createEqualFilter(const Variable& var1, const Variable& var2) {
   // The `filter` rule never adds blank nodes.
   AD_CORRECTNESS_CHECK(bn.numBlocksUsed() == 0u);
   return result;
-};
+}
 
 // Helper function for `handleRepeatedVariables` below. Replace a single
 // position of the `scanTriple`, denoted by the `rewritePosition` by a new
@@ -1772,7 +1772,7 @@ QueryPlanner::FiltersAndOptionalSubstitutes QueryPlanner::seedFilterSubstitutes(
     }
   }
   return plans;
-};
+}
 
 // _____________________________________________________________________________
 std::vector<std::vector<SubtreePlan>> QueryPlanner::fillDpTab(
@@ -2205,7 +2205,7 @@ size_t QueryPlanner::findCheapestExecutionTree(
     }
   };
   return ql::ranges::min_element(lastRow, compare) - lastRow.begin();
-};
+}
 
 // _________________________________________________________________________________
 size_t QueryPlanner::findSmallestExecutionTree(
@@ -3157,7 +3157,7 @@ void QueryPlanner::GraphPatternPlanner::graphPatternOperationVisitor(Arg& arg) {
     static_assert(std::is_same_v<T, p::BasicGraphPattern>);
     visitBasicGraphPattern(arg);
   }
-};
+}
 
 // _______________________________________________________________
 void QueryPlanner::GraphPatternPlanner::visitBasicGraphPattern(

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -717,7 +717,7 @@ class QueryPlanner {
       auto v = planner_.optimize(pattern);
       auto idx = planner_.findCheapestExecutionTree(v);
       return std::move(v[idx]);
-    };
+    }
   };
 
   /**

--- a/src/engine/SpatialJoinAlgorithms.cpp
+++ b/src/engine/SpatialJoinAlgorithms.cpp
@@ -186,7 +186,7 @@ std::optional<GeoPoint> SpatialJoinAlgorithms::getPoint(
   return id.getDatatype() == Datatype::GeoPoint
              ? std::optional{id.getGeoPoint()}
              : std::nullopt;
-};
+}
 
 // ____________________________________________________________________________
 std::optional<S2Polyline> SpatialJoinAlgorithms::getPolyline(
@@ -269,13 +269,13 @@ double SpatialJoinAlgorithms::computeDist(const size_t geometryIndex1,
   return boost::apply_visitor(ClosestPointVisitor(),
                               geometries_.at(geometryIndex1),
                               geometries_.at(geometryIndex2));
-};
+}
 
 // ____________________________________________________________________________
 size_t SpatialJoinAlgorithms::convertGeoPointToPoint(GeoPoint point) {
   geometries_.emplace_back(Point(point.getLng(), point.getLat()));
   return geometries_.size() - 1;  // index of the last element
-};
+}
 
 // ____________________________________________________________________________
 Id SpatialJoinAlgorithms::computeDist(RtreeEntry& geo1, RtreeEntry& geo2) {

--- a/src/engine/SpatialJoinAlgorithms.cpp
+++ b/src/engine/SpatialJoinAlgorithms.cpp
@@ -220,7 +220,8 @@ std::string_view SpatialJoinAlgorithms::betweenQuotes(
 }
 
 std::optional<size_t> SpatialJoinAlgorithms::getAnyGeometry(
-    const IdTableView<0>* idtable, size_t row, size_t col) {
+    [[maybe_unused]] const IdTableView<0>* idtable, [[maybe_unused]] size_t row,
+    [[maybe_unused]] size_t col) {
 #ifdef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
   throw std::runtime_error("not supported in C++17 mode currently");
 #else
@@ -988,7 +989,8 @@ double SpatialJoinAlgorithms::getMaxDistFromMidpointToAnyPointInsideTheBox(
 
 // ____________________________________________________________________________
 std::optional<RtreeEntry> SpatialJoinAlgorithms::getRtreeEntry(
-    const IdTableView<0>* idTable, const size_t row, const ColumnIndex col) {
+    [[maybe_unused]] const IdTableView<0>* idTable,
+    [[maybe_unused]] const size_t row, [[maybe_unused]] const ColumnIndex col) {
 #ifdef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
   throw std::runtime_error("getRtreeEntry is not supported in this build");
 #else

--- a/src/engine/SpatialJoinParser.cpp
+++ b/src/engine/SpatialJoinParser.cpp
@@ -30,12 +30,12 @@ WKTParser::WKTParser(sj::Sweeper* sweeper, size_t numThreads,
 // _____________________________________________________________________________
 size_t WKTParser::getPrefilterCounter() {
   return ::ranges::accumulate(_numSkipped, 0);
-};
+}
 
 // _____________________________________________________________________________
 size_t WKTParser::getParseCounter() {
   return ::ranges::accumulate(_numParsed, 0);
-};
+}
 
 // _____________________________________________________________________________
 void WKTParser::processQueue(size_t t) {

--- a/src/engine/StripColumns.cpp
+++ b/src/engine/StripColumns.cpp
@@ -44,7 +44,7 @@ StripColumns::StripColumns(QueryExecutionContext* ctx,
     : Operation{ctx},
       child_{std::move(child)},
       subset_{std::move(subset)},
-      varToCol_{std::move(varToCol)} {};
+      varToCol_{std::move(varToCol)} {}
 
 // _____________________________________________________________________________
 std::vector<QueryExecutionTree*> StripColumns::getChildren() {

--- a/src/engine/TransitivePathImpl.h
+++ b/src/engine/TransitivePathImpl.h
@@ -59,7 +59,7 @@ struct TableColumnWithVocab {
     }
   }
 };
-};  // namespace detail
+}  // namespace detail
 
 /**
  * @class TransitivePathImpl
@@ -122,7 +122,7 @@ class TransitivePathImpl : public TransitivePathBase {
     for (auto& pair : result) {
       co_yield pair;
     }
-  };
+  }
 
   /**
    * @brief Compute the transitive hull.

--- a/src/engine/idTable/CompressedExternalIdTable.h
+++ b/src/engine/idTable/CompressedExternalIdTable.h
@@ -921,7 +921,7 @@ class CompressedExternalIdTableSorter
       }
       return blockSizeForOutput;
     }
-  };
+  }
 };
 }  // namespace ad_utility
 

--- a/src/engine/idTable/IdTable.h
+++ b/src/engine/idTable/IdTable.h
@@ -236,12 +236,12 @@ class IdTable {
   CPP_template(typename = void)(
       requires CPP_NOT(isView) CPP_and columnsAreAllocatable CPP_and
           std::is_default_constructible_v<Allocator>) IdTable()
-      : IdTable{NumColumns, Allocator{}} {};
+      : IdTable{NumColumns, Allocator{}} {}
 
   CPP_template(typename = void)(
       requires CPP_NOT(isView)
           CPP_and columnsAreAllocatable) explicit IdTable(Allocator allocator)
-      : IdTable{NumColumns, std::move(allocator)} {};
+      : IdTable{NumColumns, std::move(allocator)} {}
 
   // `IdTables` are expensive to copy, so we disable accidental copies as they
   // are most likely bugs. To explicitly copy an `IdTable`, the `clone()` member

--- a/src/engine/idTable/IdTableRow.h
+++ b/src/engine/idTable/IdTableRow.h
@@ -81,12 +81,12 @@ class Row {
       Row, ad_utility::AccessViaBracketOperator, ad_utility::IsConst::False>;
   using const_iterator = ad_utility::IteratorForAccessOperator<
       Row, ad_utility::AccessViaBracketOperator, ad_utility::IsConst::True>;
-  iterator begin() { return {this, 0}; };
-  iterator end() { return {this, numColumns()}; };
-  const_iterator cbegin() { return {this, 0}; };
-  const_iterator cend() { return {this, numColumns()}; };
-  const_iterator begin() const { return {this, 0}; };
-  const_iterator end() const { return {this, numColumns()}; };
+  iterator begin() { return {this, 0}; }
+  iterator end() { return {this, numColumns()}; }
+  const_iterator cbegin() { return {this, 0}; }
+  const_iterator cend() { return {this, numColumns()}; }
+  const_iterator begin() const { return {this, 0}; }
+  const_iterator end() const { return {this, numColumns()}; }
 
   size_t numColumns() const { return data_.size(); }
   size_t size() const { return numColumns(); }
@@ -226,15 +226,15 @@ class RowReferenceImpl {
         ad_utility::IsConst::True>;
     // Non-const iterators allow non-const access and are therefore only allowed
     // on rvalues.
-    iterator begin() && { return {this, 0}; };
-    iterator end() && { return {this, numColumns()}; };
+    iterator begin() && { return {this, 0}; }
+    iterator end() && { return {this, numColumns()}; }
     // Const iterators are always fine.
-    const_iterator cbegin() const { return {this, 0}; };
-    const_iterator cend() const { return {this, numColumns()}; };
-    const_iterator begin() const& { return {this, 0}; };
-    const_iterator end() const& { return {this, numColumns()}; };
-    const_iterator begin() const&& { return {this, 0}; };
-    const_iterator end() const&& { return {this, numColumns()}; };
+    const_iterator cbegin() const { return {this, 0}; }
+    const_iterator cend() const { return {this, numColumns()}; }
+    const_iterator begin() const& { return {this, 0}; }
+    const_iterator end() const& { return {this, numColumns()}; }
+    const_iterator begin() const&& { return {this, 0}; }
+    const_iterator end() const&& { return {this, numColumns()}; }
 
     // The number of columns that this row contains.
     size_t numColumns() const { return table_->numColumns(); }
@@ -400,10 +400,10 @@ class RowReference
 
   // The iterators are implemented in the base class and can simply be
   // forwarded.
-  typename Base::iterator begin() { return Base::beginImpl(); };
-  typename Base::iterator end() { return Base::endImpl(); };
-  typename Base::const_iterator begin() const { return Base::begin(); };
-  typename Base::const_iterator end() const { return Base::end(); };
+  typename Base::iterator begin() { return Base::beginImpl(); }
+  typename Base::iterator end() { return Base::endImpl(); }
+  typename Base::const_iterator begin() const { return Base::begin(); }
+  typename Base::const_iterator end() const { return Base::end(); }
   // The `cbegin` and `cend` functions are implicitly inherited from `Base`.
 
   // __________________________________________________________________________

--- a/src/engine/sparqlExpressions/AggregateExpression.cpp
+++ b/src/engine/sparqlExpressions/AggregateExpression.cpp
@@ -190,7 +190,7 @@ template class DeviationAggExpression<AvgOperation, StdevFinalOperation>;
 // Explicit instantiations for the other aggregate expressions.
 #define INSTANTIATE_AGG_EXP(Function, ValueGetter) \
   template class AggregateExpression<              \
-      Operation<2, FunctionAndValueGetters<Function, ValueGetter>>>;
+      Operation<2, FunctionAndValueGetters<Function, ValueGetter>>>
 INSTANTIATE_AGG_EXP(AddForSum, NumericValueGetter);
 INSTANTIATE_AGG_EXP(Count, IsValidValueGetter);
 INSTANTIATE_AGG_EXP(MinLambdaForAllTypes, ActualValueGetter);

--- a/src/engine/sparqlExpressions/ConvertToDtypeConstructor.cpp
+++ b/src/engine/sparqlExpressions/ConvertToDtypeConstructor.cpp
@@ -63,7 +63,7 @@ CPP_template(typename T, bool AllowExponentialNotation = true)(
       }
     }
     return Id::makeUndefined();
-  };
+  }
 
   // ___________________________________________________________________________
   template <typename N>

--- a/src/engine/sparqlExpressions/ConvertToDtypeConstructor.cpp
+++ b/src/engine/sparqlExpressions/ConvertToDtypeConstructor.cpp
@@ -76,7 +76,7 @@ CPP_template(typename T, bool AllowExponentialNotation = true)(
     } else {
       return Id::makeFromDouble(resNumber);
     }
-  };
+  }
 
  public:
   ValueId operator()(IntDoubleStr value) const {

--- a/src/engine/sparqlExpressions/DateExpressions.cpp
+++ b/src/engine/sparqlExpressions/DateExpressions.cpp
@@ -99,7 +99,7 @@ struct ExtractTimeComponentImpl {
 
 //______________________________________________________________________________
 struct ExtractEpoch {
-  Id operator()(std::optional<DateYearOrDuration> d) const {
+  Id operator()([[maybe_unused]] std::optional<DateYearOrDuration> d) const {
 #ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
     if (!d.has_value() || !d->isDate()) {
       return Id::makeUndefined();

--- a/src/engine/sparqlExpressions/GeoExpression.cpp
+++ b/src/engine/sparqlExpressions/GeoExpression.cpp
@@ -203,7 +203,7 @@ SparqlExpression::Ptr makeBoundingCoordinateExpression(
     SparqlExpression::Ptr child) {
   return std::make_unique<BoundingCoordinateExpression<RequestedCoordinate>>(
       std::move(child));
-};
+}
 
 // _____________________________________________________________________________
 SparqlExpression::Ptr makeNumGeometriesExpression(SparqlExpression::Ptr child) {
@@ -368,8 +368,8 @@ using Ptr = sparqlExpression::SparqlExpression::Ptr;
 #endif
 #define QL_INSTANTIATE_GEO_RELATION_EXPR(joinType)                            \
   template Ptr                                                                \
-      sparqlExpression::makeGeoRelationExpression<SpatialJoinType::joinType>( \
-          Ptr, Ptr);
+  sparqlExpression::makeGeoRelationExpression<SpatialJoinType::joinType>(Ptr, \
+                                                                         Ptr)
 
 QL_INSTANTIATE_GEO_RELATION_EXPR(INTERSECTS);
 QL_INSTANTIATE_GEO_RELATION_EXPR(CONTAINS);
@@ -386,7 +386,7 @@ QL_INSTANTIATE_GEO_RELATION_EXPR(WITHIN);
 #endif
 #define QL_INSTANTIATE_BOUNDING_COORDINATE_EXPR(RequestedCoordinate) \
   template Ptr sparqlExpression::makeBoundingCoordinateExpression<   \
-      ad_utility::BoundingCoordinate::RequestedCoordinate>(Ptr);
+      ad_utility::BoundingCoordinate::RequestedCoordinate>(Ptr)
 
 QL_INSTANTIATE_BOUNDING_COORDINATE_EXPR(MIN_X);
 QL_INSTANTIATE_BOUNDING_COORDINATE_EXPR(MIN_Y);

--- a/src/engine/sparqlExpressions/NaryExpressionImpl.h
+++ b/src/engine/sparqlExpressions/NaryExpressionImpl.h
@@ -354,7 +354,7 @@ using NaryExpression = NaryExpressionStronglyTyped<Args...>;
   class Name : public NaryExpression<detail::Operation<N, X, __VA_ARGS__>> { \
     using Base = NaryExpression<Operation<N, X, __VA_ARGS__>>;               \
     using Base::Base;                                                        \
-  };
+  }
 
 // Takes a `Function` that returns a numeric value (integral or floating point)
 // and converts it to a function, that takes the same arguments and returns the

--- a/src/engine/sparqlExpressions/PrefilterExpressionIndex.cpp
+++ b/src/engine/sparqlExpressions/PrefilterExpressionIndex.cpp
@@ -1091,7 +1091,7 @@ std::vector<PrefilterExprVariablePair> makePrefilterExpressionVec(
 #define INSTANTIATE_MAKE_PREFILTER(Comparison)                       \
   template std::vector<PrefilterExprVariablePair>                    \
   makePrefilterExpressionVec<Comparison>(const IdOrLocalVocabEntry&, \
-                                         const Variable&, bool, bool);
+                                         const Variable&, bool, bool)
 INSTANTIATE_MAKE_PREFILTER(CompOp::LT);
 INSTANTIATE_MAKE_PREFILTER(CompOp::LE);
 INSTANTIATE_MAKE_PREFILTER(CompOp::GE);

--- a/src/engine/sparqlExpressions/RelationalExpressionHelpers.h
+++ b/src/engine/sparqlExpressions/RelationalExpressionHelpers.h
@@ -158,7 +158,7 @@ CPP_template(typename S)(requires StoresStringOrId<S>) auto makeValueId(
     static_assert(ad_utility::isSimilar<S, LocalVocabEntry>);
     return Id::makeFromLocalVocabIndex(&value);
   }
-};
+}
 
 // Compare two elements that are either strings or IDs in some way (see the
 // `StoresStringOrId` concept) according to the specified comparison (see

--- a/src/engine/sparqlExpressions/SparqlExpression.cpp
+++ b/src/engine/sparqlExpressions/SparqlExpression.cpp
@@ -130,7 +130,7 @@ SparqlExpression::getPrefilterExpressionForMetadata(
     [[maybe_unused]] const LocalVocabContext& context,
     [[maybe_unused]] bool isNegated) const {
   return {};
-};
+}
 
 // _____________________________________________________________________________
 bool SparqlExpression::isConstantExpression() const { return false; }

--- a/src/engine/sparqlExpressions/SparqlExpressionPimpl.cpp
+++ b/src/engine/sparqlExpressions/SparqlExpressionPimpl.cpp
@@ -16,7 +16,7 @@ SparqlExpressionPimpl::SparqlExpressionPimpl(
     std::shared_ptr<SparqlExpression>&& pimpl, std::string descriptor)
     : _pimpl{std::move(pimpl)} {
   _pimpl->descriptor() = std::move(descriptor);
-};
+}
 
 // ___________________________________________________________________________
 SparqlExpressionPimpl::~SparqlExpressionPimpl() = default;

--- a/src/engine/sparqlExpressions/SparqlExpressionValueGetters.cpp
+++ b/src/engine/sparqlExpressions/SparqlExpressionValueGetters.cpp
@@ -459,7 +459,7 @@ std::optional<ad_utility::GeoPointOrWkt> GeoPointOrWktValueGetter::operator()(
     return litOrIri.toStringRepresentation();
   }
   return std::nullopt;
-};
+}
 
 //______________________________________________________________________________
 CPP_template(typename T, typename ValueGetter)(
@@ -608,7 +608,7 @@ CPP_template_out_def(typename RequestedInfo)(
       return std::nullopt;
   }
   AD_FAIL();
-};
+}
 
 //______________________________________________________________________________
 CPP_template_out_def(typename RequestedInfo)(
@@ -626,7 +626,7 @@ CPP_template_out_def(typename RequestedInfo)(
         wktLiteral);
   }
   return std::nullopt;
-};
+}
 
 // Explicit instantiations
 namespace sparqlExpression::detail {
@@ -652,7 +652,7 @@ std::optional<int64_t> IntValueGetter::operator()(
     return id.getInt();
   }
   return std::nullopt;
-};
+}
 
 //______________________________________________________________________________
 template <typename ValueGetter>

--- a/src/engine/sparqlExpressions/StdevExpression.cpp
+++ b/src/engine/sparqlExpressions/StdevExpression.cpp
@@ -79,6 +79,6 @@ ExpressionResult DeviationExpression::evaluate(
 
   auto childRes = child_->evaluate(context);
   return std::visit(impl, std::move(childRes));
-};
+}
 
 }  // namespace sparqlExpression::detail

--- a/src/engine/sparqlExpressions/StringExpressions.cpp
+++ b/src/engine/sparqlExpressions/StringExpressions.cpp
@@ -186,7 +186,7 @@ class SubstrImpl {
   static bool isNan(NumericValue n) {
     auto ptr = std::get_if<double>(&n);
     return ptr != nullptr && std::isnan(*ptr);
-  };
+  }
 
   // Round an integer or floating point to the nearest integer according to the
   // SPARQL standard. This means that -1.5 is rounded to -1.

--- a/src/engine/sparqlExpressions/StringExpressions.cpp
+++ b/src/engine/sparqlExpressions/StringExpressions.cpp
@@ -543,7 +543,8 @@ class ConcatExpression : public detail::VariadicExpression {
 
 // ENCODE_FOR_URI
 struct EncodeForUriImpl {
-  IdOrLiteralOrIri operator()(std::optional<std::string> input) const {
+  IdOrLiteralOrIri operator()(
+      [[maybe_unused]] std::optional<std::string> input) const {
 #ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
     if (!input.has_value()) {
       return Id::makeUndefined();

--- a/src/global/IdTriple.h
+++ b/src/global/IdTriple.h
@@ -42,7 +42,7 @@ struct IdTriple {
 
   CPP_template_2(typename = void)(requires(N == 0)) explicit IdTriple(
       const std::array<Id, NumCols>& idsIn)
-      : data_{idsIn, {}} {};
+      : data_{idsIn, {}} {}
 
   explicit IdTriple(const std::array<Id, NumCols>& idsIn,
                     const Payload& payload)

--- a/src/global/IdTriple.h
+++ b/src/global/IdTriple.h
@@ -46,7 +46,7 @@ struct IdTriple {
 
   explicit IdTriple(const std::array<Id, NumCols>& idsIn,
                     const Payload& payload)
-      : data_{idsIn, payload} {};
+      : data_{idsIn, payload} {}
 
   friend std::ostream& operator<<(std::ostream& os, const IdTriple& triple) {
     os << "IdTriple(";

--- a/src/global/SpecialIds.h
+++ b/src/global/SpecialIds.h
@@ -46,7 +46,7 @@ inline const ad_utility::HashMap<std::string, Id>& specialIds() {
     return result;
   }();
   return ids;
-};
+}
 
 // Return the [lowerBound, upperBound) for the special Ids.
 // This range can be used to filter them out in cases where we want to ignore

--- a/src/global/ValueId.h
+++ b/src/global/ValueId.h
@@ -450,7 +450,8 @@ class ValueId {
 
   // Enable the serialization of `ValueId` in the `ad_utility::serialization`
   // framework.
-  friend void allowTrivialSerialization(ValueId, auto);
+  template <typename T>
+  friend void allowTrivialSerialization(ValueId, T);
 
   // Similar to `std::visit` for `std::variant`. First gets the datatype and
   // then calls `visitor(getTYPE)` where `getTYPE` is the correct getter method

--- a/src/global/ValueIdComparators.h
+++ b/src/global/ValueIdComparators.h
@@ -140,7 +140,7 @@ class RangeFilter {
   Vec _result;
 
  public:
-  explicit RangeFilter(Comparison comparison) : _comparison{comparison} {};
+  explicit RangeFilter(Comparison comparison) : _comparison{comparison} {}
   Vec getResult() && { return std::move(_result); }
 
   // Let X be the set of numbers x for which x _comparison _value is true. The

--- a/src/global/ValueIdComparators.h
+++ b/src/global/ValueIdComparators.h
@@ -149,7 +149,7 @@ class RangeFilter {
   template <typename T>
   void addEqual(T begin, T end) {
     addImpl<Comparison::LE, Comparison::EQ, Comparison::GE>(begin, end);
-  };
+  }
 
   // Analogous to `addEqual`.
   template <typename T>

--- a/src/index/CompressedRelation.cpp
+++ b/src/index/CompressedRelation.cpp
@@ -231,7 +231,7 @@ CompressedRelationReader::asyncParallelBlockGenerator(
                                                  scanConfig_, blockMetadata);
       return std::pair{myIndex,
                        std::optional{std::move(decompressedBlockAndMetadata)}};
-    };
+    }
 
     std::optional<IdTable> get() override {
       if (std::exchange(needsStart_, false)) {
@@ -449,7 +449,7 @@ CompressedRelationReader::lazyScan(
           locatedTriplesPerBlock_);
 
       return result;
-    };
+    }
 
     auto getPrunedBlockAndUpdateDetails(CompressedBlockMetadataIterator it) {
       auto block = getIncompleteBlock(it);
@@ -892,7 +892,7 @@ DecompressedBlock CompressedRelationReader::readPossiblyIncompleteBlock(
 
   // Return the result.
   return result;
-};
+}
 
 // ____________________________________________________________________________
 template <bool exactSize>
@@ -1272,7 +1272,7 @@ size_t CompressedRelationReader::getNumberOfBlockMetadataValues(
                               [](auto acc, const auto& block) {
                                 return acc + ql::ranges::size(block);
                               });
-};
+}
 
 // _____________________________________________________________________________
 std::vector<CompressedBlockMetadata>
@@ -1739,7 +1739,7 @@ CPP_template(typename Range)(
   auto begin = ql::ranges::begin(blockMetadataRange);
   auto end = ql::ranges::end(blockMetadataRange);
   return begin == end || ql::ranges::next(begin) == end;
-};
+}
 
 // _____________________________________________________________________________
 CPP_template(typename Range)(

--- a/src/index/CompressedRelationPermutationWriterImpl.h
+++ b/src/index/CompressedRelationPermutationWriterImpl.h
@@ -157,7 +157,7 @@ struct CompressedRelationWriter::PermutationWriter {
 
     writer1_->smallBlocksCallback_ =
         AddBlockOfSmallRelationsToSwitched{*writer2_};
-  };
+  }
 
   // Constructor for a `PermutationWriter` which writes a single permutation.
   CPP_template(bool doWritePair = WritePair)(requires(!doWritePair))
@@ -174,7 +174,7 @@ struct CompressedRelationWriter::PermutationWriter {
     // column.
     AD_CORRECTNESS_CHECK(permutation_.keys().at(3) == 3);
     AD_CORRECTNESS_CHECK(blocksize_ > 0);
-  };
+  }
 
   // Write a block of a large relation with `writer1` and also push the block
   // into the twin sorter for `writer2`.

--- a/src/index/CompressedRelationPermutationWriterImpl.h
+++ b/src/index/CompressedRelationPermutationWriterImpl.h
@@ -45,7 +45,7 @@ struct CompressedRelationWriter::AddBlockOfSmallRelationsToSwitched {
         blockOfSmallRelations.at(blockOfSmallRelations.numRows() - 1, 0);
     writer_.compressAndWriteBlock(firstCol0, lastCol0,
                                   std::move(blockOfSmallRelations), false);
-  };
+  }
 };
 
 // Helper that handles the queue of callbacks to be called for every block
@@ -195,7 +195,7 @@ struct CompressedRelationWriter::PermutationWriter {
     relation_.clear();
     relation_.reserve(blocksize_);
     ++numBlocksCurrentRel_;
-  };
+  }
 
   // We have encountered the last occurrence of the current relation (value for
   // column 0). Thus we need to write the remaining buffered rows and metadata.
@@ -230,7 +230,7 @@ struct CompressedRelationWriter::PermutationWriter {
     }
     relation_.clear();
     numBlocksCurrentRel_ = 0;
-  };
+  }
 
   // ___________________________________________________________________________
   void logTimers() const {

--- a/src/index/DeltaTriples.h
+++ b/src/index/DeltaTriples.h
@@ -52,6 +52,26 @@ struct LocatedTriplesState {
   // Counts of the external triples. Only set when this is a deep copy, not for
   // references.
   std::optional<DeltaTriplesCount> counts_ = std::nullopt;
+
+  // Construct from the located triples for the external and internal
+  // permutations, the lifetime extender for the local vocab, the index of the
+  // snapshot, and (only for deep copies) the counts of the external triples.
+  // NOTE: This constructor is explicitly declared (and not only implicitly
+  // via aggregate initialization) because parenthesized initialization of
+  // aggregates is not supported in C++17.
+  LocatedTriplesState(
+      LocatedTriplesPerBlockAllPermutations<false> locatedTriplesPerBlock,
+      LocatedTriplesPerBlockAllPermutations<true>
+          internalLocatedTriplesPerBlock,
+      std::optional<LocalVocab::LifetimeExtender> localVocabLifetimeExtender,
+      size_t index, std::optional<DeltaTriplesCount> counts = std::nullopt)
+      : locatedTriplesPerBlock_{std::move(locatedTriplesPerBlock)},
+        internalLocatedTriplesPerBlock_{
+            std::move(internalLocatedTriplesPerBlock)},
+        localVocabLifetimeExtender_{std::move(localVocabLifetimeExtender)},
+        index_{index},
+        counts_{std::move(counts)} {}
+
   // Get `LocatedTriplesPerBlock` objects for the given permutation.
   template <bool isInternal>
   const LocatedTriplesPerBlock& getLocatedTriplesForPermutation(

--- a/src/index/ExportIds.cpp
+++ b/src/index/ExportIds.cpp
@@ -106,7 +106,7 @@ std::optional<Literal> getLiteralOrNullopt(
     return std::move(litOrIri.value().getLiteral());
   }
   return std::nullopt;
-};
+}
 
 // _____________________________________________________________________________
 std::optional<LiteralOrIri> idToLiteralOrIriForEncodedValue(Id id) {
@@ -135,7 +135,7 @@ LiteralOrIri getLiteralOrIriFromWordVocabIndex(const IndexImpl& index, Id id) {
   return LiteralOrIri{
       ad_utility::triple_component::Literal::literalWithoutQuotes(
           index.indexToString(id.getWordVocabIndex()))};
-};
+}
 
 // _____________________________________________________________________________
 std::optional<LiteralOrIri> getLiteralOrIriFromTextRecordIndex(
@@ -143,7 +143,7 @@ std::optional<LiteralOrIri> getLiteralOrIriFromTextRecordIndex(
   return LiteralOrIri{
       ad_utility::triple_component::Literal::literalWithoutQuotes(
           index.getTextExcerpt(id.getTextRecordIndex()))};
-};
+}
 
 // _____________________________________________________________________________
 std::optional<LiteralOrIri> idToLiteralOrIri(const IndexImpl& index, Id id,

--- a/src/index/GraphFilter.h
+++ b/src/index/GraphFilter.h
@@ -29,7 +29,7 @@ class GraphFilter {
  public:
   // Marker type for the "ALL" case.
   struct AllTag {
-    QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(AllTag)
+    QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(AllTag, )
   };
 
   // ALL, WHITELIST, BLACKLIST

--- a/src/index/GraphNameManager.h
+++ b/src/index/GraphNameManager.h
@@ -80,7 +80,7 @@ class GraphNameManager {
   QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(GraphNameManager,
                                               prefixWithoutBraces_,
                                               nextUnallocatedGraph_,
-                                              filenameForPersisting_);
+                                              filenameForPersisting_)
 };
 
 #endif  // QLEVER_SRC_INDEX_GRAPHNAMEMANAGER_H

--- a/src/index/Index.h
+++ b/src/index/Index.h
@@ -54,7 +54,10 @@ class Index {
     static NumNormalAndInternal fromNormal(size_t normal) {
       return {normal, 0};
     }
-    NLOHMANN_DEFINE_TYPE_INTRUSIVE(NumNormalAndInternal, normal, internal);
+    // Note: The expansion of `NLOHMANN_DEFINE_TYPE_INTRUSIVE` ends in complete
+    // `friend` function definitions, so a trailing `;` would be an extra one,
+    // which is ill-formed (and rejected with `-pedantic-errors`).
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE(NumNormalAndInternal, normal, internal)
   };
 
   // Store all information about possible search results from the text index in

--- a/src/index/IndexImpl.Text.cpp
+++ b/src/index/IndexImpl.Text.cpp
@@ -214,7 +214,7 @@ size_t IndexImpl::getSizeOfTextBlocksSum(
         return acc + tbmdAndWordInfo.tbmd_._entityCl._nofElements;
       };
   return std::accumulate(tbmds.begin(), tbmds.end(), size_t{0}, addSizeOfBlock);
-};
+}
 
 // _____________________________________________________________________________
 void IndexImpl::setTextName(const std::string& name) {

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -269,7 +269,7 @@ class IndexImpl {
   // Read necessary meta data into memory and opens file handles.
   void addTextFromOnDiskIndex();
 
-  const auto& getVocab() const { return vocab_; };
+  const auto& getVocab() const { return vocab_; }
   auto& getNonConstVocabForTesting() { return vocab_; }
 
   // Replace the currently loaded vocabulary with a zero-copy view directly
@@ -307,7 +307,7 @@ class IndexImpl {
 
   const ad_utility::AllocatorWithLimit<Id>& allocator() const {
     return allocator_;
-  };
+  }
 
   ad_utility::BlankNodeManager* getBlankNodeManager() const;
 
@@ -415,7 +415,7 @@ class IndexImpl {
 
     // Returns true if the text block contains entries outside of the requested
     // range
-    bool hasToBeFiltered() const { return optIdRange_.has_value(); };
+    bool hasToBeFiltered() const { return optIdRange_.has_value(); }
 
     // The id range of the prefix or word used to retrieve the text block(s). It
     // is only set if computeHasToBeFiltered was determined to be true during
@@ -486,7 +486,7 @@ class IndexImpl {
 
   float getAverageNofEntityContexts() const {
     return textMeta_.getAverageNofEntityContexts();
-  };
+  }
 
   void setKbName(const std::string& name);
 

--- a/src/index/LocalVocabEntry.h
+++ b/src/index/LocalVocabEntry.h
@@ -119,7 +119,7 @@ class alignas(16) LocalVocabEntry
     IdProxy upperBound_;
 
     QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(PositionInVocab, lowerBound_,
-                                                upperBound_);
+                                                upperBound_)
   };
   PositionInVocab positionInVocab() const {
     // Immediately return if we have previously computed and cached the

--- a/src/index/LocatedTriples.cpp
+++ b/src/index/LocatedTriples.cpp
@@ -89,7 +89,7 @@ namespace {
 template <typename Row, template <typename T, T...> typename Tp, size_t... I>
 auto tieHelper(Row& row, Tp<size_t, I...>) {
   return std::tie(row[I]...);
-};
+}
 }  // namespace
 
 // Return a `std::tie` of the relevant entries of a row, according to

--- a/src/index/LocatedTriples.cpp
+++ b/src/index/LocatedTriples.cpp
@@ -255,6 +255,18 @@ IdTable LocatedTriplesPerBlock::mergeTriples(size_t blockIndex,
 }
 
 namespace {
+// Permute the `Id`s of a triple (given as a tuple `ids`, in the order specified
+// by `inverseKeys`) into an array in SPO order. Note: This is a named function
+// template and not a local lambda, because lambdas with an explicit template
+// parameter list are not available in C++17.
+template <typename Ids, size_t... I>
+std::array<Id, 4> permuteIdsToSpo(const qlever::KeyOrder::Array& inverseKeys,
+                                  Ids& ids, std::index_sequence<I...>) {
+  std::array<Id, 4> spo{};
+  ((spo[inverseKeys[I]] = std::get<I>(ids)), ...);
+  return spo;
+}
+
 // Identify the triples to vacuum for a single block by comparing the
 // `locatedTriples` with the `idTable` of the block (which has no updates
 // applied).
@@ -264,11 +276,8 @@ VacuumStatistics processBlockForVacuum(
     std::vector<IdTriple<0>>& allDeletionsToRemove,
     std::vector<IdTriple<0>>& allInsertionsToRemove) {
   auto toSpo = [&inverseKeys](auto& ids) {
-    return IdTriple<0>{[&]<size_t... I>(std::index_sequence<I...>) {
-      std::array<Id, 4> spo{};
-      ((spo[inverseKeys[I]] = std::get<I>(ids)), ...);
-      return spo;
-    }(std::make_index_sequence<4>{})};
+    return IdTriple<0>{
+        permuteIdsToSpo(inverseKeys, ids, std::make_index_sequence<4>{})};
   };
 
   auto ltProj = [](const LocatedTriple& lt)

--- a/src/index/LocatedTriples.h
+++ b/src/index/LocatedTriples.h
@@ -239,7 +239,7 @@ class LocatedTriplesPerBlock {
     }
     AD_CONTRACT_CHECK(originalMetadata_.has_value());
     return *originalMetadata_.value();
-  };
+  }
 
   // Remove all located triples.
   void clear() {
@@ -283,7 +283,7 @@ class LocatedTriplesPerBlock {
          << std::endl;
     }
     return os;
-  };
+  }
 };
 
 // Human-readable representation , which are very useful for debugging.

--- a/src/index/Permutation.h
+++ b/src/index/Permutation.h
@@ -229,7 +229,7 @@ class Permutation {
   const std::string& fileSuffix() const { return fileSuffix_; }
 
   // _______________________________________________________
-  const KeyOrder& keyOrder() const { return keyOrder_; };
+  const KeyOrder& keyOrder() const { return keyOrder_; }
 
   // _______________________________________________________
   const bool& isLoaded() const { return isLoaded_; }

--- a/src/index/TextIndexReadWrite.h
+++ b/src/index/TextIndexReadWrite.h
@@ -347,7 +347,7 @@ class FrequencyEncode {
           FrequencyEncode,
           ql::remove_cvref_t<View>>)) explicit FrequencyEncode(View&& view) {
     initialize(std::forward<View>(view));
-  };
+  }
 
   FrequencyEncode() = delete;
   FrequencyEncode(const FrequencyEncode&) = delete;
@@ -400,7 +400,7 @@ class GapEncode {
       !ranges::same_as<GapEncode, ql::remove_cvref_t<
                                       View>>)) explicit GapEncode(View&& view) {
     initialize(std::forward<View>(view));
-  };
+  }
 
   GapEncode() = delete;
   GapEncode(const GapEncode&) = delete;

--- a/src/index/TextMetaData.h
+++ b/src/index/TextMetaData.h
@@ -114,7 +114,7 @@ class TextMetaData {
 
   void setName(const std::string& name) { _name = name; }
 
-  float getAverageNofEntityContexts() const { return 1.0f; };
+  float getAverageNofEntityContexts() const { return 1.0f; }
 
  private:
   std::vector<uint64_t> _blockUpperBoundWordIds;

--- a/src/index/vocabulary/CompressedVocabulary.h
+++ b/src/index/vocabulary/CompressedVocabulary.h
@@ -362,7 +362,7 @@ CPP_template(typename UnderlyingVocabulary,
   // ____________________________________________________
   static constexpr ad_utility::MemorySize bytes(size_t numBytes) {
     return ad_utility::MemorySize::bytes(numBytes);
-  };
+  }
 
   // _________________________________________________________________
   template <typename T>

--- a/src/index/vocabulary/CompressedVocabulary.h
+++ b/src/index/vocabulary/CompressedVocabulary.h
@@ -357,7 +357,7 @@ CPP_template(typename UnderlyingVocabulary,
     }();
     return compressionWrapper_.decompress(toStringView(*it),
                                           getDecoderIdx(idx));
-  };
+  }
 
   // ____________________________________________________
   static constexpr ad_utility::MemorySize bytes(size_t numBytes) {

--- a/src/index/vocabulary/GeoVocabulary.cpp
+++ b/src/index/vocabulary/GeoVocabulary.cpp
@@ -34,7 +34,7 @@ void GeoVocabulary<V>::open(const std::string& filename) {
         ad_utility::GEOMETRY_INFO_VERSION,
         " as required by this version of QLever. Please rebuild your index."));
   }
-};
+}
 
 // ____________________________________________________________________________
 template <typename V>
@@ -51,7 +51,7 @@ GeoVocabulary<V>::WordWriter::WordWriter(const V& vocabulary,
       geoInfoFile_{getGeoInfoFilename(filename), "w"} {
   // Initialize geo info file with header
   geoInfoFile_.write(&ad_utility::GEOMETRY_INFO_VERSION, geoInfoHeader);
-};
+}
 
 // ____________________________________________________________________________
 template <typename V>
@@ -78,7 +78,7 @@ uint64_t GeoVocabulary<V>::WordWriter::operator()(std::string_view word,
   geoInfoFile_.write(ptr, geoInfoOffset);
 
   return index;
-};
+}
 
 // ____________________________________________________________________________
 template <typename V>

--- a/src/index/vocabulary/PolymorphicVocabulary.h
+++ b/src/index/vocabulary/PolymorphicVocabulary.h
@@ -175,7 +175,7 @@ class PolymorphicVocabulary {
           }
         },
         vocab_);
-  };
+  }
 
   // Checks if any of the underlying vocabularies is a `GeoVocabulary`.
   bool isGeoInfoAvailable() const {

--- a/src/index/vocabulary/SplitVocabulary.h
+++ b/src/index/vocabulary/SplitVocabulary.h
@@ -129,7 +129,7 @@ class SplitVocabulary {
     AD_CORRECTNESS_CHECK(marker < numberOfVocabs &&
                          vocabIndex <= vocabIndexBitMask);
     return vocabIndex | (static_cast<uint64_t>(marker) << markerShift);
-  };
+  }
 
   // Extract the marker from a full 64 bit index.
   static constexpr uint8_t getMarker(uint64_t indexWithMarker) {
@@ -142,7 +142,7 @@ class SplitVocabulary {
   // which vocabulary this word would go)
   static uint8_t getMarkerForWord(const std::string_view& word) {
     return splitFunction_(word);
-  };
+  }
 
   // Helper to detect if a "special" vocabulary is used.
   static constexpr bool isSpecialVocabIndex(uint64_t indexWithMarker) {
@@ -153,7 +153,7 @@ class SplitVocabulary {
   // bits.
   static constexpr uint64_t getVocabIndex(uint64_t indexWithMarker) {
     return indexWithMarker & vocabIndexBitMask;
-  };
+  }
 
   // Close all underlying vocabularies.
   void close();

--- a/src/index/vocabulary/SplitVocabularyImpl.h
+++ b/src/index/vocabulary/SplitVocabularyImpl.h
@@ -72,7 +72,7 @@ SplitVocabulary<SF, SFN, S...>::WordWriter::WordWriter(
         },
         underlyingVocabularies[i]);
   }
-};
+}
 
 // _____________________________________________________________________________
 template <typename SF, typename SFN, typename... S>

--- a/src/index/vocabulary/Vocabulary.cpp
+++ b/src/index/vocabulary/Vocabulary.cpp
@@ -238,7 +238,7 @@ std::optional<ad_utility::GeometryInfo> Vocabulary<S, C, I>::getGeoInfo(
     static_assert(NeverProvidesGeometryInfo<S>);
     return std::nullopt;
   }
-};
+}
 
 // _____________________________________________________________________________
 template <typename S, typename C, typename I>
@@ -251,7 +251,7 @@ bool Vocabulary<S, C, I>::isGeoInfoAvailable() const {
     static_assert(NeverProvidesGeometryInfo<S>);
     return false;
   }
-};
+}
 
 // _____________________________________________________________________________
 template <typename S, typename ComparatorType, typename I>

--- a/src/index/vocabulary/VocabularyTypes.h
+++ b/src/index/vocabulary/VocabularyTypes.h
@@ -274,7 +274,7 @@ class WordWriterBase {
           " bug, or it can happen when an exception was thrown in the"
           " constructor of the subclass."sv);
     }
-  };
+  }
 
   // Calling this function will signal that the last word has been pushed.
   // Implementations might e.g. flush all buffers to disk and close underlying

--- a/src/parser/GraphPatternOperation.h
+++ b/src/parser/GraphPatternOperation.h
@@ -126,7 +126,7 @@ struct GroupGraphPattern {
 struct Optional {
   Optional(GraphPattern child) : _child{std::move(child)} {
     _child._optional = true;
-  };
+  }
   GraphPattern _child;
 };
 

--- a/src/parser/MagicServiceQuery.cpp
+++ b/src/parser/MagicServiceQuery.cpp
@@ -43,7 +43,7 @@ Variable MagicServiceQuery::getVariable(std::string_view parameter,
   }
 
   return object.getVariable();
-};
+}
 
 // ____________________________________________________________________________
 void MagicServiceQuery::setVariable(
@@ -59,7 +59,7 @@ void MagicServiceQuery::setVariable(
   }
 
   existingValue = object.getVariable();
-};
+}
 
 // ____________________________________________________________________________
 std::string_view MagicServiceQuery::extractParameterName(
@@ -80,6 +80,6 @@ std::string_view MagicServiceQuery::extractParameterName(
     paramString.remove_prefix(iri.size());
   }
   return asStringViewUnsafe(paramString);
-};
+}
 
 }  // namespace parsedQuery

--- a/src/parser/MagicServiceQuery.h
+++ b/src/parser/MagicServiceQuery.h
@@ -71,7 +71,7 @@ struct MagicServiceQuery {
   virtual void validate() const {
     // Currently most `MagicServiceQuery` implementations do not make use of
     // this method. Thus it is empty by default.
-  };
+  }
 
   // Helper that returns a readable name for the type of `MagicServiceQuery`.
   virtual std::string_view name() const = 0;

--- a/src/parser/MaterializedViewQuery.cpp
+++ b/src/parser/MaterializedViewQuery.cpp
@@ -96,7 +96,7 @@ MaterializedViewQuery::MaterializedViewQuery(const SparqlTriple& triple) {
 MaterializedViewQuery::MaterializedViewQuery(std::string name,
                                              RequestedColumns requestedColumns)
     : viewName_{std::move(name)},
-      requestedColumns_{std::move(requestedColumns)} {};
+      requestedColumns_{std::move(requestedColumns)} {}
 
 // _____________________________________________________________________________
 ad_utility::HashSet<Variable> MaterializedViewQuery::getVarsToKeep() const {

--- a/src/parser/MaterializedViewQuery.h
+++ b/src/parser/MaterializedViewQuery.h
@@ -70,7 +70,7 @@ struct MaterializedViewQuery : MagicServiceQuery {
 
   constexpr std::string_view name() const override {
     return "materialized view query";
-  };
+  }
 
  private:
   // Internal helpers for shared code between `addParameter` and magic predicate

--- a/src/parser/NamedCachedResult.h
+++ b/src/parser/NamedCachedResult.h
@@ -28,7 +28,7 @@ class NamedCachedResult : public MagicServiceQuery {
   // Return the name of the magic service type.
   constexpr std::string_view name() const override {
     return "named cached result";
-  };
+  }
 
   // Return the name of the named query.
   const std::string& identifier() const;

--- a/src/parser/PathQuery.h
+++ b/src/parser/PathQuery.h
@@ -82,7 +82,7 @@ struct PathQuery : MagicServiceQuery {
   PathSearchConfiguration toPathSearchConfiguration(
       const IndexImpl& index) const;
 
-  constexpr std::string_view name() const override { return "path search"; };
+  constexpr std::string_view name() const override { return "path search"; }
 };
 
 }  // namespace parsedQuery

--- a/src/parser/PayloadVariables.cpp
+++ b/src/parser/PayloadVariables.cpp
@@ -10,14 +10,14 @@
 
 // ____________________________________________________________________________
 PayloadVariables::PayloadVariables(std::vector<Variable> variables)
-    : variables_{std::move(variables)} {};
+    : variables_{std::move(variables)} {}
 
 // ____________________________________________________________________________
 PayloadVariables PayloadVariables::all() {
   PayloadVariables pv{};
   pv.setToAll();
   return pv;
-};
+}
 
 // ____________________________________________________________________________
 void PayloadVariables::addVariable(const Variable& variable) {
@@ -31,12 +31,12 @@ void PayloadVariables::addVariable(const Variable& variable) {
   };
 
   std::visit(addVarVisitor, variables_);
-};
+}
 
 // ____________________________________________________________________________
 void PayloadVariables::setToAll() {
   variables_ = detail::PayloadAllVariables{};
-};
+}
 
 // ____________________________________________________________________________
 bool PayloadVariables::empty() const {
@@ -52,12 +52,12 @@ bool PayloadVariables::empty() const {
   };
 
   return std::visit(emptyVisitor, variables_);
-};
+}
 
 // ____________________________________________________________________________
 bool PayloadVariables::isAll() const {
   return std::holds_alternative<detail::PayloadAllVariables>(variables_);
-};
+}
 
 // ____________________________________________________________________________
 const std::vector<Variable>& PayloadVariables::getVariables() const {
@@ -75,4 +75,4 @@ const std::vector<Variable>& PayloadVariables::getVariables() const {
   };
 
   return std::visit(getVarVisitor, variables_);
-};
+}

--- a/src/parser/PayloadVariables.h
+++ b/src/parser/PayloadVariables.h
@@ -14,7 +14,7 @@ namespace detail {
 struct PayloadAllVariables : std::monostate {
   bool operator==([[maybe_unused]] const std::vector<Variable>& other) const {
     return false;
-  };
+  }
 };
 }  // namespace detail
 
@@ -50,7 +50,7 @@ class PayloadVariables {
   // For testing: equality operator
   bool operator==(const PayloadVariables& other) const {
     return variables_ == other.variables_;
-  };
+  }
 
  private:
   std::variant<detail::PayloadAllVariables, std::vector<Variable>> variables_ =

--- a/src/parser/Quads.cpp
+++ b/src/parser/Quads.cpp
@@ -43,7 +43,7 @@ static std::vector<SparqlTripleSimpleWithGraph> transformTriplesTemplate(
 template <typename T>
 static T expandVariant(const ad_utility::sparql_types::VarOrIri& graph) {
   return std::visit([](const auto& graph) -> T { return graph; }, graph);
-};
+}
 
 // ____________________________________________________________________________________
 updateClause::GraphUpdate::Triples Quads::toTriplesWithGraph(

--- a/src/parser/RdfParser.cpp
+++ b/src/parser/RdfParser.cpp
@@ -1179,7 +1179,7 @@ void RdfParallelParser<T>::parseBatch(size_t parsePosition, Batch batch) {
     errorMessages_.wlock()->emplace_back(parsePosition, e.what());
     tripleCollector_.pushException(std::current_exception());
   }
-};
+}
 
 // _______________________________________________________________________
 template <typename T>
@@ -1227,7 +1227,7 @@ void RdfParallelParser<T>::feedBatchesToParser(
     errorMessages_.wlock()->emplace_back(parsePosition, e.what());
     tripleCollector_.pushException(std::current_exception());
   }
-};
+}
 
 // _______________________________________________________________________
 template <typename T>

--- a/src/parser/RdfParser.h
+++ b/src/parser/RdfParser.h
@@ -416,7 +416,7 @@ class NQuadParser : public TurtleParser<Tokenizer_T> {
   using Base = TurtleParser<Tokenizer_T>;
 
  public:
-  explicit NQuadParser(const EncodedIriManager* ev) : Base{ev} {};
+  explicit NQuadParser(const EncodedIriManager* ev) : Base{ev} {}
   explicit NQuadParser(const EncodedIriManager* ev,
                        TripleComponent defaultGraphId)
       : Base{ev}, defaultGraphId_{std::move(defaultGraphId)} {}
@@ -576,7 +576,7 @@ class RdfStreamParser : public Parser {
 
  public:
   // Default construction needed for tests
-  explicit RdfStreamParser(const EncodedIriManager* ev) : Parser{ev} {};
+  explicit RdfStreamParser(const EncodedIriManager* ev) : Parser{ev} {}
 
   // Construct a parser that reads from an `InputFileSpecification`. The parser
   // creates its own I/O thread and `AsyncBlockSource` internally. The
@@ -636,7 +636,7 @@ class RdfParallelParser : public Parser {
  public:
   using Triple = std::array<std::string, 3>;
   // Default construction needed for tests
-  explicit RdfParallelParser(const EncodedIriManager* ev) : Parser{ev} {};
+  explicit RdfParallelParser(const EncodedIriManager* ev) : Parser{ev} {}
 
   // Construct a parser that reads from an `InputFileSpecification`. The parser
   // creates its own I/O thread and `AsyncBlockSource` internally. The
@@ -738,7 +738,7 @@ class RdfMultifileParser : public RdfParserBase {
  public:
   // Default construction needed for tests
   explicit RdfMultifileParser(const EncodedIriManager* encodedIriManager)
-      : RdfParserBase{encodedIriManager} {};
+      : RdfParserBase{encodedIriManager} {}
 
   // Construct the parser from a type-erased input range of file specifications
   // and eagerly start parsing them on background threads.

--- a/src/parser/SpatialQuery.h
+++ b/src/parser/SpatialQuery.h
@@ -85,7 +85,7 @@ struct SpatialQuery : MagicServiceQuery {
   // Throw if the current configuration is invalid.
   void validate() const override;
 
-  constexpr std::string_view name() const override { return "spatial join"; };
+  constexpr std::string_view name() const override { return "spatial join"; }
 
  private:
   // If `throwCondition` is `true`, throw `SpatialSearchException{message}`.

--- a/src/parser/TextSearchQuery.cpp
+++ b/src/parser/TextSearchQuery.cpp
@@ -69,7 +69,7 @@ std::variant<Variable, FixedEntity> VarOrFixedEntity::makeEntityVariant(
     return FixedEntity(std::move(fixedEntity), std::move(index));
   }
   return std::get<Variable>(entity);
-};
+}
 
 namespace parsedQuery {
 

--- a/src/parser/TextSearchQuery.h
+++ b/src/parser/TextSearchQuery.h
@@ -243,7 +243,7 @@ struct TextSearchQuery : MagicServiceQuery {
 
   constexpr std::string_view name() const override {
     return "full text search";
-  };
+  }
 };
 
 }  // namespace parsedQuery

--- a/src/parser/TripleComponent.h
+++ b/src/parser/TripleComponent.h
@@ -46,7 +46,7 @@ class TripleComponent {
   // Own class for the UNDEF value.
   struct UNDEF {
     // Default equality operator.
-    QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(UNDEF)
+    QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(UNDEF, )
     // Hash to arbitrary (fixed) value. For example, needed in
     // `Values::computeMultiplicities`.
     template <typename H>

--- a/src/parser/data/GraphRef.h
+++ b/src/parser/data/GraphRef.h
@@ -15,18 +15,18 @@ using GraphRef = ad_utility::triple_component::Iri;
 // graph.
 struct DEFAULT {
   // For testing
-  QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(DEFAULT)
+  QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(DEFAULT, )
 };
 // Denotes the target graphs for an operation. Here the target are all named
 // graphs.
 struct NAMED {
   // For testing
-  QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(NAMED)
+  QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(NAMED, )
 };
 // Denotes the target graphs for an operation. Here the target are all graphs.
 struct ALL {
   // For testing
-  QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(ALL)
+  QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(ALL, )
 };
 
 using GraphRefAll = std::variant<GraphRef, DEFAULT, NAMED, ALL>;

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -869,7 +869,7 @@ std::pair<GraphOrDefault, GraphOrDefault> Visitor::visitFromTo(
     std::vector<Parser::GraphOrDefaultContext*> ctxs) {
   AD_CORRECTNESS_CHECK(ctxs.size() == 2);
   return {visit(ctxs[0]), visit(ctxs[1])};
-};
+}
 
 // ____________________________________________________________________________________
 std::vector<ParsedQuery> Visitor::visit(Parser::MoveContext* ctx) {

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -591,10 +591,10 @@ ParsedQuery Visitor::visit(Parser::AskQueryContext* ctx) {
 // ____________________________________________________________________________________
 DatasetClause Visitor::visit(Parser::DatasetClauseContext* ctx) {
   if (ctx->defaultGraphClause()) {
-    return {.dataset_ = visit(ctx->defaultGraphClause()), .isNamed_ = false};
+    return {visit(ctx->defaultGraphClause()), false};
   } else {
     AD_CORRECTNESS_CHECK(ctx->namedGraphClause());
-    return {.dataset_ = visit(ctx->namedGraphClause()), .isNamed_ = true};
+    return {visit(ctx->namedGraphClause()), true};
   }
 }
 
@@ -1502,9 +1502,9 @@ DatasetClause SparqlQleverVisitor::visit(Parser::UsingClauseContext* ctx) {
                 "`using-named-graph-uri` http parameters are used");
   }
   if (ctx->NAMED()) {
-    return {.dataset_ = visit(ctx->iri()), .isNamed_ = true};
+    return {visit(ctx->iri()), true};
   } else {
-    return {.dataset_ = visit(ctx->iri()), .isNamed_ = false};
+    return {visit(ctx->iri()), false};
   }
 }
 

--- a/src/rdfTypes/GeoPoint.cpp
+++ b/src/rdfTypes/GeoPoint.cpp
@@ -20,7 +20,7 @@ GeoPoint::GeoPoint(double lat, double lng) : lat_{lat}, lng_{lng} {
     throw CoordinateOutOfRangeException(lat, true);
   if (lng < -COORDINATE_LNG_MAX || lng > COORDINATE_LNG_MAX || std::isnan(lng))
     throw CoordinateOutOfRangeException(lng, false);
-};
+}
 
 // _____________________________________________________________________________
 GeoPoint::T GeoPoint::toBitRepresentation() const {
@@ -57,7 +57,7 @@ GeoPoint::T GeoPoint::toBitRepresentation() const {
   // Ensure the highest 4 bits are 0
   AD_CORRECTNESS_CHECK((bits & coordinateMaskFreeBits) == 0);
   return bits;
-};
+}
 
 // _____________________________________________________________________________
 std::optional<GeoPoint> GeoPoint::parseFromLiteral(
@@ -72,7 +72,7 @@ std::optional<GeoPoint> GeoPoint::parseFromLiteral(
     }
   }
   return std::nullopt;
-};
+}
 
 // _____________________________________________________________________________
 GeoPoint GeoPoint::fromBitRepresentation(T bits) {
@@ -95,16 +95,16 @@ GeoPoint GeoPoint::fromBitRepresentation(T bits) {
       extractCoordinate(bits, coordinateMaskLng, 0, COORDINATE_LNG_MAX);
 
   return {lat, lng};
-};
+}
 
 // _____________________________________________________________________________
 std::string GeoPoint::toStringRepresentation() const {
   // Extra conversion using std::to_string to get more decimals
   return absl::StrCat("POINT(", std::to_string(getLng()), " ",
                       std::to_string(getLat()), ")");
-};
+}
 
 // _____________________________________________________________________________
 std::pair<std::string, const char*> GeoPoint::toStringAndType() const {
   return std::pair(toStringRepresentation(), GEO_WKT_LITERAL.data());
-};
+}

--- a/src/rdfTypes/GeometryInfo.cpp
+++ b/src/rdfTypes/GeometryInfo.cpp
@@ -47,7 +47,7 @@ GeometryInfo::GeometryInfo(uint8_t wktType, const BoundingBox& boundingBox,
 
   AD_CORRECTNESS_CHECK(numGeometries_ > 0,
                        "Number of geometries must be strictly positive.");
-};
+}
 
 // ____________________________________________________________________________
 std::optional<GeometryInfo> GeometryInfo::fromWktLiteral(std::string_view wkt) {
@@ -83,12 +83,12 @@ std::optional<GeometryInfo> GeometryInfo::fromWktLiteral(std::string_view wkt) {
 }
 
 // ____________________________________________________________________________
-GeometryType::GeometryType(uint8_t type) : type_{type} {};
+GeometryType::GeometryType(uint8_t type) : type_{type} {}
 
 // ____________________________________________________________________________
 MetricLength::MetricLength(double length) : length_{length} {
   AD_CORRECTNESS_CHECK(length_ >= 0, "Metric length must be positive");
-};
+}
 
 // ____________________________________________________________________________
 std::optional<GeometryType> GeometryInfo::getWktType(std::string_view wkt) {
@@ -99,7 +99,7 @@ std::optional<GeometryType> GeometryInfo::getWktType(std::string_view wkt) {
     return std::nullopt;
   }
   return GeometryType{wktType};
-};
+}
 
 // ____________________________________________________________________________
 GeometryInfo GeometryInfo::fromGeoPoint(const GeoPoint& point) {
@@ -159,7 +159,7 @@ BoundingBox::BoundingBox(GeoPoint lowerLeft, GeoPoint upperRight)
           lowerLeft.getLng() <= upperRight.getLng(),
       "Bounding box coordinates invalid: first point must be lower "
       "left and second point must be upper right of a rectangle.");
-};
+}
 
 // ____________________________________________________________________________
 MetricArea GeometryInfo::getMetricArea() const { return metricArea_; }
@@ -183,7 +183,7 @@ std::string BoundingBox::asWkt() const {
 }
 
 // ____________________________________________________________________________
-MetricLength GeometryInfo::getMetricLength() const { return metricLength_; };
+MetricLength GeometryInfo::getMetricLength() const { return metricLength_; }
 
 // ____________________________________________________________________________
 std::optional<MetricLength> GeometryInfo::getMetricLength(
@@ -193,7 +193,7 @@ std::optional<MetricLength> GeometryInfo::getMetricLength(
     return std::nullopt;
   }
   return {detail::computeMetricLength(parsed.value())};
-};
+}
 
 // ____________________________________________________________________________
 MetricArea::MetricArea(double area) : area_{area} {
@@ -218,7 +218,7 @@ double BoundingBox::getBoundingCoordinate() const {
     // versions don't like it.
     AD_FAIL();
   }
-};
+}
 
 // Explicit instantiations
 template double BoundingBox::getBoundingCoordinate<BoundingCoordinate::MIN_X>()
@@ -265,7 +265,7 @@ CPP_template_def(typename RequestedInfo)(requires RequestedInfoT<RequestedInfo>)
   } else {
     static_assert(ad_utility::alwaysFalse<RequestedInfo>);
   }
-};
+}
 
 // Explicit instantiations
 template GeometryInfo GeometryInfo::getRequestedInfo<GeometryInfo>() const;
@@ -297,7 +297,7 @@ CPP_template_def(typename RequestedInfo)(requires RequestedInfoT<RequestedInfo>)
   } else {
     static_assert(ad_utility::alwaysFalse<RequestedInfo>);
   }
-};
+}
 
 // Explicit instantiations
 template std::optional<GeometryInfo>

--- a/src/rdfTypes/GeometryInfo.h
+++ b/src/rdfTypes/GeometryInfo.h
@@ -26,10 +26,10 @@ struct Centroid {
   GeoPoint centroid_;
 
  public:
-  explicit Centroid(GeoPoint centroid) : centroid_{centroid} {};
-  Centroid(double lat, double lng) : centroid_{lat, lng} {};
+  explicit Centroid(GeoPoint centroid) : centroid_{centroid} {}
+  Centroid(double lat, double lng) : centroid_{lat, lng} {}
 
-  GeoPoint centroid() const { return centroid_; };
+  GeoPoint centroid() const { return centroid_; }
 };
 
 // The individual coordinates describing the bounding box.
@@ -80,7 +80,7 @@ struct GeometryType {
  public:
   explicit GeometryType(uint8_t type);
 
-  uint8_t type() const { return type_; };
+  uint8_t type() const { return type_; }
 
   // Returns an IRI without brackets of the OGC Simple Features geometry type.
   std::optional<std::string_view> asIri() const;
@@ -94,13 +94,13 @@ struct NumGeometries {
   uint32_t numGeometries_;
 
  public:
-  NumGeometries(uint32_t numGeometries) : numGeometries_{numGeometries} {};
+  NumGeometries(uint32_t numGeometries) : numGeometries_{numGeometries} {}
 
   uint32_t numGeometries() const { return numGeometries_; }
 
   constexpr bool operator==(const NumGeometries& other) const {
     return numGeometries_ == other.numGeometries_;
-  };
+  }
 };
 
 // Represents the length of the geometry in meters.
@@ -134,7 +134,7 @@ struct MetricArea {
   MetricArea() = default;
 #endif
 
-  double area() const { return area_; };
+  double area() const { return area_; }
 
   bool isValid() const { return !std::isnan(area_); }
 };

--- a/src/rdfTypes/GeometryInfoHelpersImpl.h
+++ b/src/rdfTypes/GeometryInfoHelpersImpl.h
@@ -432,7 +432,7 @@ struct MetricAreaVisitor {
 
   double operator()(const ParsedWkt& geom) const {
     return std::visit(MetricAreaVisitor{}, geom);
-  };
+  }
 };
 
 static constexpr MetricAreaVisitor computeMetricArea;

--- a/src/rdfTypes/GeometryInfoHelpersImpl.h
+++ b/src/rdfTypes/GeometryInfoHelpersImpl.h
@@ -604,7 +604,7 @@ CPP_template(typename Projection)(
       T multi) const {
     ql::ranges::transform(multi, multi.begin(), *this);
     return multi;
-  };
+  }
 
   // Polygons require special treatment for inner (~ a line) and outer
   // boundaries (~ a multi line).

--- a/src/rdfTypes/Variable.h
+++ b/src/rdfTypes/Variable.h
@@ -60,7 +60,7 @@ class Variable {
   QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(Variable, _name)
 
   // The construction of PrefilterExpressions requires a defined < order.
-  bool operator<(const Variable& other) const { return _name < other._name; };
+  bool operator<(const Variable& other) const { return _name < other._name; }
 
   // Make the type hashable for absl, see
   // https://abseil.io/docs/cpp/guides/hash.

--- a/src/util/AllocatorWithLimit.h
+++ b/src/util/AllocatorWithLimit.h
@@ -26,7 +26,7 @@ class AllocationExceedsLimitException : public std::exception {
                                   MemorySize freeMemory)
       : _message{absl::StrCat("Tried to allocate ", requestedMemory.asString(),
                               ", but only ", freeMemory.asString(),
-                              " were available")} {};
+                              " were available")} {}
 
   const char* what() const noexcept override { return _message.c_str(); }
 

--- a/src/util/AsyncStream.h
+++ b/src/util/AsyncStream.h
@@ -72,7 +72,7 @@ struct AsyncStreamGenerator
     if constexpr (logTime) {
       std::invoke(function);
     }
-  };
+  }
 };
 
 }  // namespace detail

--- a/src/util/ConfigManager/ConfigManager.cpp
+++ b/src/util/ConfigManager/ConfigManager.cpp
@@ -859,7 +859,7 @@ void ConfigManager::verifyWithValidators() const {
   ql::ranges::for_each(validators(false), [](auto& validator) {
     validator.get().checkValidator();
   });
-};
+}
 
 // ____________________________________________________________________________
 bool ConfigManager::containsOption(const ConfigOption& opt) const {

--- a/src/util/ConstexprUtils.h
+++ b/src/util/ConstexprUtils.h
@@ -33,7 +33,7 @@ constexpr auto pow(T base, int exponent) {
     result *= base;
   }
   return result;
-};
+}
 
 /*
  * @brief A compile time for loop, which passes the loop index to the
@@ -186,7 +186,7 @@ struct ValueSequenceImpl {};
 
 template <typename T, const T&... values>
 struct ValueSequenceRefImpl {};
-};  // namespace detail
+}  // namespace detail
 
 template <typename T, T... values>
 using ValueSequence = detail::ValueSequenceImpl<T, values...>;
@@ -244,7 +244,7 @@ CPP_template(typename Int, size_t NumIntegers)(
     value /= numValues;
   }
   return res;
-};
+}
 
 // Store the result of `integerToArray` in a `constexpr` variable which has
 // linkage, and can therefore be used in C++17 mode as a `const&` template

--- a/src/util/Date.h
+++ b/src/util/Date.h
@@ -160,22 +160,40 @@ class Date {
   // significant bits. If this is not the case for a platform, then the unit
   // tests will fail. If we need support for such platforms, we have to
   // implement the bitfields manually using bit shifting.
-  uint64_t timeZone_ : numBitsTimeZone = 0;
-  uint64_t second_ : numBitsSecond = 0;
-  uint64_t minute_ : numBitsMinute = 0;
-  uint64_t hour_ : numBitsHour = 0;
-  uint64_t day_ : numBitsDay = 1;
-  uint64_t month_ : numBitsMonth = 1;
-  uint64_t year_ : numBitsYear = 0;
+  uint64_t timeZone_ : numBitsTimeZone;
+  uint64_t second_ : numBitsSecond;
+  uint64_t minute_ : numBitsMinute;
+  uint64_t hour_ : numBitsHour;
+  uint64_t day_ : numBitsDay;
+  uint64_t month_ : numBitsMonth;
+  uint64_t year_ : numBitsYear;
   // These bits (the `numUsedBits` most significant bits) are always zero.
-  uint64_t unusedBits_ : numUnusedBits = 0;
+  uint64_t unusedBits_ : numUnusedBits;
+
+#ifdef QLEVER_CPP_17
+  // We need the default-constructibility for the C++17 version of `bit_cast`.
+ public:
+#endif
+  // Set all the bit-fields above to their default values. Note that we cannot
+  // use default member initializers for this, because those are only allowed
+  // for bit-fields since C++20. All other constructors delegate to this
+  // constructor, such that the bit-fields are always initialized.
+  constexpr Date()
+      : timeZone_(0),
+        second_(0),
+        minute_(0),
+        hour_(0),
+        day_(1),
+        month_(1),
+        year_(0),
+        unusedBits_(0) {}
 
  public:
   struct NoTimeZone {
-    QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(NoTimeZone)
+    QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(NoTimeZone, )
   };
   struct TimeZoneZ {
-    QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(TimeZoneZ)
+    QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(TimeZoneZ, )
   };
   using TimeZone = std::variant<NoTimeZone, TimeZoneZ, int>;
 #ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
@@ -184,7 +202,8 @@ class Date {
   /// Construct a `Date` from values for the different components. If any of the
   /// components is out of range, a `DateOutOfRangeException` is thrown.
   constexpr Date(int year, int month, int day, int hour = -1, int minute = 0,
-                 double second = 0.0, TimeZone timeZone = NoTimeZone{}) {
+                 double second = 0.0, TimeZone timeZone = NoTimeZone{})
+      : Date() {
     setYear(year);
     setMonth(month);
     setDay(day);
@@ -195,11 +214,6 @@ class Date {
     // Suppress the "unused member" warning on clang.
     (void)unusedBits_;
   }
-
-#ifdef QLEVER_CPP_17
-  // We need the default-constructibility for the C++17 version of `bit_cast`.
-  Date() = default;
-#endif
 
   /// Convert the `Date` to a `uint64_t`. This just casts the underlying
   /// representation.

--- a/src/util/DateYearDuration.h
+++ b/src/util/DateYearDuration.h
@@ -93,7 +93,7 @@ class DateYearOrDuration {
   // True iff constructed with `DayTimeDuration`.
   bool isDayTimeDuration() const {
     return bits_ >> numPayloadDurationBits == daytimeDuration;
-  };
+  }
 
   // Return the underlying `Date` object. The behavior is undefined if
   // `isDate()` is `false`.

--- a/src/util/Duration.h
+++ b/src/util/Duration.h
@@ -108,13 +108,13 @@ class DayTimeDuration {
   //
   // To retrieve the initial number of milliseconds, we just subtract
   // boundTotalMilliseconds from totalMilliSeconds_. (line 181-182)
-  uint64_t totalMilliseconds_ : numMillisecondBits = 0;
+  uint64_t totalMilliseconds_ : numMillisecondBits;
 
   // The value of unusedBits_ is relevant w.r.t. to the DateYearOrDuration class
   // for properly shifting a given input value of type dayTimeDuration and
   // thus make it convertible to an intern Id (ValueId) -> The underlying
   // DayTimeDuration and corresponding values can be extracted again.
-  uint64_t unusedBits_ : numUnusedBits = 0;
+  uint64_t unusedBits_ : numUnusedBits;
 
  public:
   // `DurationValue` is used to return all xsd:dayTimeDuration components over
@@ -140,7 +140,10 @@ class DayTimeDuration {
   // duration: `P0DT0H0M0S` (as xsd:dayTimeDuration string).
   constexpr DayTimeDuration(Type signType = Type::Positive, int days = 0,
                             int hours = 0, int minutes = 0,
-                            double seconds = 0.00) {
+                            double seconds = 0.00)
+      // Note: The bit-fields have to be initialized here, because default
+      // member initializers for bit-fields are only allowed since C++20.
+      : totalMilliseconds_(0), unusedBits_(0) {
     setValues(days, hours, minutes, seconds, signType);
   }
 

--- a/src/util/EnumWithStrings.h
+++ b/src/util/EnumWithStrings.h
@@ -77,7 +77,7 @@ CPP_template(typename Derived,
   }
 
   // Constructors.
-  EnumWithStrings() noexcept { check(); };
+  EnumWithStrings() noexcept { check(); }
   // Deliberately implicit, s.t. we can directly construct from the underlying
   // enum.
   QL_EXPLICIT(false) EnumWithStrings(Enum value) : value_{value} { check(); }

--- a/src/util/FsstCompressor.h
+++ b/src/util/FsstCompressor.h
@@ -29,7 +29,7 @@ struct CastToUnsignedPtr {
     using Res = std::conditional_t<ql::concepts::same_as<T, const char*>,
                                    const unsigned char*, unsigned char*>;
     return reinterpret_cast<Res>(ptr);
-  };
+  }
 };
 constexpr CastToUnsignedPtr castToUnsignedPtr{};
 }  // namespace detail

--- a/src/util/Generators.h
+++ b/src/util/Generators.h
@@ -215,6 +215,6 @@ CPP_template(typename T, typename F)(
   return InputRangeTypeErased{std::make_unique<CallbackToRangeAdapter>(
       std::move(functionWithCallback))};
 }
-};  // namespace ad_utility
+}  // namespace ad_utility
 
 #endif  // QLEVER_SRC_UTIL_GENERATORS_H

--- a/src/util/InputRangeUtils.h
+++ b/src/util/InputRangeUtils.h
@@ -204,7 +204,7 @@ struct LoopControl {
   template <typename R>
   static LoopControl yieldAll(R&& r) {
     return LoopControl{InputRangeTypeErased{ad_utility::allView(AD_FWD(r))}};
-  };
+  }
 };
 
 // `loopControlValueT` is a helper variable to get the stored type out of a

--- a/src/util/IoUringManager.h
+++ b/src/util/IoUringManager.h
@@ -148,8 +148,8 @@ struct SyncIoPolicy {
                 BatchHandle handle) const;
 
   void wait(BatchHandle) const {
-      // No-op: `addBatch` already completed all reads synchronously.
-  };
+    // No-op: `addBatch` already completed all reads synchronously.
+  }
 
   // Read exactly `numBytes` bytes from file descriptor `fd` at `fileOffset`
   // (from the start of the file) into `targetBuffer`. Throws exception if the

--- a/src/util/Iterators.h
+++ b/src/util/Iterators.h
@@ -389,7 +389,7 @@ class InputRangeFromGet
     getNextAndStore();
     return Iterator{this};
   }
-  Sentinel end() const { return {}; };
+  Sentinel end() const { return {}; }
 
   using DetailStorage =
       typename DetailsProvider<InputRangeFromGet<ValueType, DetailsType>,

--- a/src/util/JoinAlgorithms/JoinAlgorithms.h
+++ b/src/util/JoinAlgorithms/JoinAlgorithms.h
@@ -487,7 +487,7 @@ struct CompareAllButLastImpl {
       return row | ql::views::take(numColumns_ - 1);
     };
     return comparisonImpl_(dropLast(a), dropLast(b));
-  };
+  }
 };
 
 using CompareAllButLast =

--- a/src/util/JoinAlgorithms/JoinColumnMapping.h
+++ b/src/util/JoinAlgorithms/JoinColumnMapping.h
@@ -117,14 +117,22 @@ class JoinColumnMapping {
 struct GetColsFromTable {
   template <size_t numCols, typename Table>
   decltype(auto) operator()(Table& table) {
-    return [&table]<size_t... I>(std::index_sequence<I...>) {
-      return ::ranges::views::zip(table.getColumn(I)...) |
-             ::ranges::views::transform([](auto&& tuple) {
-               return std::apply(
-                   [](auto&... refs) { return std::array{refs...}; },
-                   AD_FWD(tuple));
-             });
-    }(std::make_index_sequence<numCols>());
+    return getCols(table, std::make_index_sequence<numCols>());
+  }
+
+ private:
+  // Implementation of `operator()` above, with the column indices expanded into
+  // a parameter pack. Note: This is a named function template and not a local
+  // lambda, because lambdas with an explicit template parameter list are not
+  // available in C++17.
+  template <typename Table, size_t... I>
+  static decltype(auto) getCols(Table& table, std::index_sequence<I...>) {
+    return ::ranges::views::zip(table.getColumn(I)...) |
+           ::ranges::views::transform([](auto&& tuple) {
+             return std::apply(
+                 [](auto&... refs) { return std::array{refs...}; },
+                 AD_FWD(tuple));
+           });
   }
 };
 

--- a/src/util/JoinAlgorithms/JoinColumnMapping.h
+++ b/src/util/JoinAlgorithms/JoinColumnMapping.h
@@ -56,7 +56,7 @@ class JoinColumnMapping {
   // column in the left input.
   const std::vector<ColumnIndex>& permutationLeft() const {
     return permutationLeft_;
-  };
+  }
   // The same, but for the right input.
   const std::vector<ColumnIndex>& permutationRight() const {
     return permutationRight_;

--- a/src/util/LazyJsonParser.cpp
+++ b/src/util/LazyJsonParser.cpp
@@ -102,7 +102,7 @@ void LazyJsonParser::parseLiteral(size_t& idx) {
     ++idx;
     if (std::holds_alternative<BeforeArrayPath>(state_)) {
       std::get<BeforeArrayPath>(state_).optLiteral_ =
-          BeforeArrayPath::LiteralView{.start_ = idx, .length_ = 0};
+          BeforeArrayPath::LiteralView{idx, 0};
     }
     inLiteral_ = true;
   }
@@ -180,7 +180,7 @@ size_t LazyJsonParser::parseInArrayPath(size_t& idx) {
   size_t materializeEnd = 0;
 
   auto exitArrayPath = [&]() {
-    state_ = AfterArrayPath{.remainingBraces_ = arrayPath_.size()};
+    state_ = AfterArrayPath{arrayPath_.size()};
     ++idx;
     if (arrayPath_.empty()) {
       materializeEnd = idx;

--- a/src/util/Parameters.h
+++ b/src/util/Parameters.h
@@ -76,7 +76,7 @@ CPP_template(typename Type, typename FromString, typename ToString)(
   /// Construction is only allowed using an initial parameter value
   Parameter() = delete;
   explicit Parameter(Type initialValue, std::string name)
-      : value_{std::move(initialValue)}, name_{std::move(name)} {};
+      : value_{std::move(initialValue)}, name_{std::move(name)} {}
 
   /// Copying is disabled, but moving is ok
   Parameter(const Parameter& rhs) = delete;

--- a/src/util/ParseException.cpp
+++ b/src/util/ParseException.cpp
@@ -50,4 +50,4 @@ ParseException::ParseException(std::string_view cause,
   } else {
     causeWithMetadata_ = cause_;
   }
-};
+}

--- a/src/util/PriorityQueue.h
+++ b/src/util/PriorityQueue.h
@@ -242,7 +242,7 @@ class HeapBasedPQ {
 
     // was the value associated with this handle already deleted because of an
     // erase operation
-    bool isValid() const { return (mData->mScore).index() == 1; };
+    bool isValid() const { return (mData->mScore).index() == 1; }
 
     // does this handle point into the pq or was it popped/erased
     bool isInPq() const { return mData->mIsInPQ; }

--- a/src/util/Serializer/FileSerializer.h
+++ b/src/util/Serializer/FileSerializer.h
@@ -19,7 +19,7 @@ class FileWriteSerializer {
  public:
   using SerializerType = WriteSerializerTag;
 
-  FileWriteSerializer(File&& file) : _file{std::move(file)} {};
+  FileWriteSerializer(File&& file) : _file{std::move(file)} {}
 
   FileWriteSerializer(std::string filename) : _file{filename, "w"} {
     AD_CONTRACT_CHECK(_file.isOpen());
@@ -56,7 +56,7 @@ class FileReadSerializer {
  public:
   using SerializerType = ReadSerializerTag;
 
-  explicit FileReadSerializer(File&& file) : _file{std::move(file)} {};
+  explicit FileReadSerializer(File&& file) : _file{std::move(file)} {}
 
   explicit FileReadSerializer(const std::string& filename)
       : _file{filename, "r"} {
@@ -89,7 +89,7 @@ class CopyableFileReadSerializer {
  public:
   using SerializerType = ReadSerializerTag;
   explicit CopyableFileReadSerializer(std::shared_ptr<File> filePtr)
-      : _file{std::move(filePtr)} {};
+      : _file{std::move(filePtr)} {}
 
   explicit CopyableFileReadSerializer(std::string filename)
       : _file{std::make_shared<File>(filename, "r")} {

--- a/src/util/Serializer/SerializeArrayOrTuple.h
+++ b/src/util/Serializer/SerializeArrayOrTuple.h
@@ -32,7 +32,7 @@ struct IsTriviallySerializable {
   template <typename U>
   constexpr void operator()() const {
     result = result && TriviallySerializable<U>;
-  };
+  }
 };
 
 template <typename T>

--- a/src/util/StringUtils.h
+++ b/src/util/StringUtils.h
@@ -255,7 +255,7 @@ constexpr std::array<char, sz + 1> catImpl(
     }
   }
   return buf;
-};
+}
 // Concatenate the `strings` into a single `std::array<char>` with an
 // additional zero byte at the end.
 // TODO<joka921>: C++17 doesn't support template values. This needs some

--- a/src/util/Synchronized.h
+++ b/src/util/Synchronized.h
@@ -219,7 +219,7 @@ class Synchronized {
                    LockPtr<Synchronized, true, true>>
   rlock() const {
     return LockPtr<Synchronized, true, true>{this};
-  };
+  }
 
   // Return a `Synchronized` that uses a reference to this `Synchronized`'s
   // `_data` and `mutext_`. The reference is a reference of the Base class U.

--- a/src/util/Views.h
+++ b/src/util/Views.h
@@ -497,7 +497,7 @@ struct BufferedAsyncView : InputRangeMixin<BufferedAsyncView<View>> {
       ++i;
     }
     return buffer;
-  };
+  }
 
   void start() {
     it_ = view_.begin();

--- a/src/util/http/HttpClient.cpp
+++ b/src/util/http/HttpClient.cpp
@@ -250,11 +250,9 @@ HttpOrHttpsResponse HttpClientImpl<StreamType>::sendRequest(
     }
   };
 
-  return {.status_ = status,
-          .contentType_ = contentType,
-          .location_ = location,
-          .body_ = getBody(std::move(client), std::move(responseParser),
-                           std::move(buffer), std::move(handle))};
+  return {status, contentType, location,
+          getBody(std::move(client), std::move(responseParser),
+                  std::move(buffer), std::move(handle))};
 }
 
 // ____________________________________________________________________________

--- a/src/util/http/UrlParser.h
+++ b/src/util/http/UrlParser.h
@@ -77,7 +77,7 @@ struct GraphStoreOperation {
 // No operation. This can happen for QLever's custom operations (e.g.
 // `cache-stats`). These requests have no operation but are still valid.
 struct None {
-  QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(None)
+  QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(None, )
 };
 
 using Operation = std::variant<Query, Update, GraphStoreOperation, None>;

--- a/src/util/http/websocket/WebSocketSession.h
+++ b/src/util/http/websocket/WebSocketSession.h
@@ -70,6 +70,6 @@ class WebSocketSession {
   static std::optional<http::response<httpUtils::httpStreams::streamable_body>>
   getErrorResponseIfPathIsInvalid(const http::request<http::string_body>&);
 };
-};  // namespace ad_utility::websocket
+}  // namespace ad_utility::websocket
 
 #endif  // QLEVER_SRC_UTIL_HTTP_WEBSOCKET_WEBSOCKETSESSION_H


### PR DESCRIPTION
### Why

A user who compiles QLever with `-pedantic-errors` runs into hard errors, because the C++17 build so far relied on several C++20 constructs that GCC and Clang accept as extensions in C++17 mode.

The most visible symptom was the variadic macros in `backports/three_way_comparison.h`: for a class **without** data members, they had to be invoked with an ugly trailing comma, e.g. `QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(ClassWithoutMembers,)`. The reason is not a bug in the macro logic, but the preprocessor: before C++20, a variadic macro requires **at least one** argument for its `...` parameter. GCC and Clang accept zero arguments as an extension, but warn about it with `-Wpedantic` and reject it with `-pedantic-errors`. The trailing comma supplies a single empty argument and makes the invocation valid C++17; it has no effect on the generated code in either standard mode (the C++17 expansion becomes `std::tie()`, i.e. an empty tuple, which compares equivalent — exactly what a defaulted C++20 comparison does for a member-less class).

That form is now used consistently at the eight affected call sites in `src/` and documented in the header, so that it does not get "cleaned up" again.

### What else is in here

A `-Wpedantic` build of the whole C++17 configuration revealed 57 further diagnostics in QLever's own sources and 2 hard errors. All of them are fixed:

| Category | Count | Fix |
| --- | --- | --- |
| Zero-argument variadic macro invocation | 8 | Explicit trailing comma, documented in `three_way_comparison.h` |
| Stray `;` after an in-class template function definition | 21 | Removed. Not C++17-specific — ill-formed in every standard version, GCC also reports it in C++20 mode |
| Designated initializers (`{.field_ = x}`) | 14 | Plain aggregate initialization. The order is provably unchanged, because designators have to appear in declaration order anyway |
| Lambda templates (`[]<typename T>(…)`) | 3 | Generic lambdas, or a named function template where the parameter is not deducible |
| Default member initializers for bit-fields | 10 | Initialization in the constructors of `Date` and `DayTimeDuration`. Bit layout and all default values (including `day_ = 1`, `month_ = 1`) are unchanged |
| `auto` function parameter (abbreviated template) | 1 | Spelled-out `template <typename T>` in the friend declaration of `allowTrivialSerialization` in `ValueId` |
| Unused parameters in the reduced feature set | 8 | `[[maybe_unused]]`, since the parameters *are* used in the full configuration |
| **Hard errors:** parenthesized initialization of an aggregate via `std::make_shared` (C++20, P0960) | 2 | Constructors for `LocatedTriplesState` and `ByCacheKeyInfo` |

The two hard errors are pre-existing C++17 regressions that entered `master` recently. They went unnoticed because the `gcc8` job builds with `make -i -k` and only feeds the log to `misc/gcc8_logs_analyzer.py`, whose error categories (`co_await`/`concept`/`requires`/"is not a member of `std`") do not match this pattern. Interestingly the errors only occur with a newer GCC in C++17 mode, not with `gcc-8`, which is why that job stayed green.

### CI and CMake

The `CPP17 libQLever` workflow now compiles QLever's own code with `-pedantic-errors`, so none of the above can come back unnoticed.

The flags are passed through a new CMake variable `ADDITIONAL_COMPILER_FLAGS_QLEVER_ONLY`, which is applied via `add_compile_options()` *after* `FetchContent_MakeAvailable(...)` and therefore only affects QLever's own targets. This is necessary because several dependencies are not pedantically clean (14 diagnostics, all from `re2`'s and `s2`'s own translation units), and they are not ours to fix. `ADDITIONAL_COMPILER_FLAGS` keeps its current meaning of applying to everything.

### Testing

Local verification with `g++-11` (the CI's `gcc-8` cannot be installed on the dev machine, see the caveat below), each time reproducing the workflow's configuration exactly, including the `using enum` rewrite via the `qlever-cpp-17-rewriter` image, and building the `LibQLeverExample` target:

* **C++17 mode** (`REDUCED_FEATURE_SET_FOR_CPP17`, `USE_CPP_17_BACKPORTS`, `CMAKE_CXX_STANDARD=17`, `QLEVER_NO_UNICODE`) with `-pedantic-errors`: 620 translation units, **0 errors, 0 warnings**, and the target links — which it did not do before this PR because of the two `make_shared` errors.
* **C++20 mode** (the other matrix entry, `REDUCED_FEATURE_SET_FOR_CPP17` only) with `-pedantic-errors`: 620 translation units, **0 errors, 0 warnings**.
* A full (non-reduced) C++20 build with `-pedantic-errors`: the 26 test binaries that cover the touched code (`DateYearDurationTest`, `DurationTest`, `DeltaTriplesTest`, `ValueIdTest`, `ValueIdComparatorsTest`, `IdTableTest`, `LazyJsonParserTest`, `MaterializedViewsTest`, `LocatedTriplesTest`, `SerializerTest`, `OptionalJoinTest`, `GroupByTest`, `HttpTest`, `ThreeWayComparisonTest`, `UrlParserTest`, `ConstructTemplatePreprocessorTest`, … ) build without warnings and **all pass**.

**Caveat:** `gcc-8` is not available on the machine this was prepared on, so the `gcc-8` matrix entry of the workflow was not reproduced locally. Its diagnostics in C++17 mode may be a superset of `gcc-11`'s, so that job is the one to watch in this PR's CI run. Note also that the tests cannot be built at all in the `REDUCED_FEATURE_SET_FOR_CPP17` configuration (228 pre-existing errors, mostly from the excluded coroutine-based code) — which is why the workflow only builds `LibQLeverExample` there, and why the test verification above uses the full configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)