### PR TITLE
Replace `{.field_ = ...}` initializers by plain aggregate initialization

### DIFF
--- a/src/engine/ConstructTemplatePreprocessor.cpp
+++ b/src/engine/ConstructTemplatePreprocessor.cpp
@@ -45,9 +45,8 @@ std::optional<PreprocessedTerm> ConstructTemplatePreprocessor::preprocessIri(
     const Iri& iri) {
   ValueId dedupId = resolveConstantDedupId(TripleComponent{iri});
   return PrecomputedConstant{
-      .evaluatedTerm_ =
-          std::make_shared<const EvaluatedTermData>(iri.toSparql(), nullptr),
-      .dedupId_ = dedupId};
+      std::make_shared<const EvaluatedTermData>(iri.toSparql(), nullptr),
+      dedupId};
 }
 
 // _____________________________________________________________________________
@@ -69,9 +68,8 @@ ConstructTemplatePreprocessor::preprocessLiteral(const Literal& literal,
           literal.toSparql());
   ValueId dedupId = resolveConstantDedupId(std::move(parsedObject));
   return PrecomputedConstant{
-      .evaluatedTerm_ =
-          std::make_shared<const EvaluatedTermData>(literal.literal(), nullptr),
-      .dedupId_ = dedupId};
+      std::make_shared<const EvaluatedTermData>(literal.literal(), nullptr),
+      dedupId};
 }
 
 // _____________________________________________________________________________
@@ -86,9 +84,8 @@ ConstructTemplatePreprocessor::preprocessVariable(const Variable& variable) {
 // _____________________________________________________________________________
 std::optional<PreprocessedTerm>
 ConstructTemplatePreprocessor::preprocessBlankNode(const BlankNode& blankNode) {
-  return PrecomputedBlankNode{
-      .prefix_ = blankNode.isGenerated() ? "_:g" : "_:u",
-      .suffix_ = absl::StrCat("_", blankNode.label())};
+  return PrecomputedBlankNode{blankNode.isGenerated() ? "_:g" : "_:u",
+                              absl::StrCat("_", blankNode.label())};
 }
 
 // _____________________________________________________________________________

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -591,10 +591,10 @@ ParsedQuery Visitor::visit(Parser::AskQueryContext* ctx) {
 // ____________________________________________________________________________________
 DatasetClause Visitor::visit(Parser::DatasetClauseContext* ctx) {
   if (ctx->defaultGraphClause()) {
-    return {.dataset_ = visit(ctx->defaultGraphClause()), .isNamed_ = false};
+    return {visit(ctx->defaultGraphClause()), false};
   } else {
     AD_CORRECTNESS_CHECK(ctx->namedGraphClause());
-    return {.dataset_ = visit(ctx->namedGraphClause()), .isNamed_ = true};
+    return {visit(ctx->namedGraphClause()), true};
   }
 }
 
@@ -1502,9 +1502,9 @@ DatasetClause SparqlQleverVisitor::visit(Parser::UsingClauseContext* ctx) {
                 "`using-named-graph-uri` http parameters are used");
   }
   if (ctx->NAMED()) {
-    return {.dataset_ = visit(ctx->iri()), .isNamed_ = true};
+    return {visit(ctx->iri()), true};
   } else {
-    return {.dataset_ = visit(ctx->iri()), .isNamed_ = false};
+    return {visit(ctx->iri()), false};
   }
 }
 

--- a/src/util/LazyJsonParser.cpp
+++ b/src/util/LazyJsonParser.cpp
@@ -102,7 +102,7 @@ void LazyJsonParser::parseLiteral(size_t& idx) {
     ++idx;
     if (std::holds_alternative<BeforeArrayPath>(state_)) {
       std::get<BeforeArrayPath>(state_).optLiteral_ =
-          BeforeArrayPath::LiteralView{.start_ = idx, .length_ = 0};
+          BeforeArrayPath::LiteralView{idx, 0};
     }
     inLiteral_ = true;
   }
@@ -180,7 +180,7 @@ size_t LazyJsonParser::parseInArrayPath(size_t& idx) {
   size_t materializeEnd = 0;
 
   auto exitArrayPath = [&]() {
-    state_ = AfterArrayPath{.remainingBraces_ = arrayPath_.size()};
+    state_ = AfterArrayPath{arrayPath_.size()};
     ++idx;
     if (arrayPath_.empty()) {
       materializeEnd = idx;

--- a/src/util/http/HttpClient.cpp
+++ b/src/util/http/HttpClient.cpp
@@ -250,11 +250,9 @@ HttpOrHttpsResponse HttpClientImpl<StreamType>::sendRequest(
     }
   };
 
-  return {.status_ = status,
-          .contentType_ = contentType,
-          .location_ = location,
-          .body_ = getBody(std::move(client), std::move(responseParser),
-                           std::move(buffer), std::move(handle))};
+  return {status, contentType, location,
+          getBody(std::move(client), std::move(responseParser),
+                  std::move(buffer), std::move(handle))};
 }
 
 // ____________________________________________________________________________


### PR DESCRIPTION
Designated initializers like `{.field_ = value}` are a C++20 feature. GCC and Clang accept them in C++17 mode as an extension, but reject them with `-pedantic-errors`. QLever's `CPP17 libQLever` workflow builds in C++17 mode, and a follow-up change will enable `-pedantic-errors` there. This change replaces the ten affected initializers in four files by plain aggregate initialization. No designated initializers remain under `src/`.

The transformation preserves behavior. C++ requires the designators to appear in declaration order, so the values already matched the member order. No initializer skips a member in the middle of a member list. All affected types are aggregates without user-declared constructors, so the braced initialization was aggregate initialization before and after.

NOTE: This change is one of five that were split out of #3215. The CI change that enables `-pedantic-errors` in the `CPP17 libQLever` workflow will be submitted separately once all of them have been merged. At two call sites the positional form is less readable than the designated form was. A follow-up could introduce named factory functions there.