### PR TITLE
Do not use default member initializers for bit-fields

### DIFF
--- a/src/util/Date.h
+++ b/src/util/Date.h
@@ -160,15 +160,33 @@ class Date {
   // significant bits. If this is not the case for a platform, then the unit
   // tests will fail. If we need support for such platforms, we have to
   // implement the bitfields manually using bit shifting.
-  uint64_t timeZone_ : numBitsTimeZone = 0;
-  uint64_t second_ : numBitsSecond = 0;
-  uint64_t minute_ : numBitsMinute = 0;
-  uint64_t hour_ : numBitsHour = 0;
-  uint64_t day_ : numBitsDay = 1;
-  uint64_t month_ : numBitsMonth = 1;
-  uint64_t year_ : numBitsYear = 0;
+  uint64_t timeZone_ : numBitsTimeZone;
+  uint64_t second_ : numBitsSecond;
+  uint64_t minute_ : numBitsMinute;
+  uint64_t hour_ : numBitsHour;
+  uint64_t day_ : numBitsDay;
+  uint64_t month_ : numBitsMonth;
+  uint64_t year_ : numBitsYear;
   // These bits (the `numUsedBits` most significant bits) are always zero.
-  uint64_t unusedBits_ : numUnusedBits = 0;
+  uint64_t unusedBits_ : numUnusedBits;
+
+#ifdef QLEVER_CPP_17
+  // We need the default-constructibility for the C++17 version of `bit_cast`.
+ public:
+#endif
+  // Set all the bit-fields above to their default values. Note that we cannot
+  // use default member initializers for this, because those are only allowed
+  // for bit-fields since C++20. All other constructors delegate to this
+  // constructor, such that the bit-fields are always initialized.
+  constexpr Date()
+      : timeZone_(0),
+        second_(0),
+        minute_(0),
+        hour_(0),
+        day_(1),
+        month_(1),
+        year_(0),
+        unusedBits_(0) {}
 
  public:
   struct NoTimeZone {
@@ -184,7 +202,8 @@ class Date {
   /// Construct a `Date` from values for the different components. If any of the
   /// components is out of range, a `DateOutOfRangeException` is thrown.
   constexpr Date(int year, int month, int day, int hour = -1, int minute = 0,
-                 double second = 0.0, TimeZone timeZone = NoTimeZone{}) {
+                 double second = 0.0, TimeZone timeZone = NoTimeZone{})
+      : Date() {
     setYear(year);
     setMonth(month);
     setDay(day);
@@ -195,11 +214,6 @@ class Date {
     // Suppress the "unused member" warning on clang.
     (void)unusedBits_;
   }
-
-#ifdef QLEVER_CPP_17
-  // We need the default-constructibility for the C++17 version of `bit_cast`.
-  Date() = default;
-#endif
 
   /// Convert the `Date` to a `uint64_t`. This just casts the underlying
   /// representation.

--- a/src/util/Duration.h
+++ b/src/util/Duration.h
@@ -108,13 +108,13 @@ class DayTimeDuration {
   //
   // To retrieve the initial number of milliseconds, we just subtract
   // boundTotalMilliseconds from totalMilliSeconds_. (line 181-182)
-  uint64_t totalMilliseconds_ : numMillisecondBits = 0;
+  uint64_t totalMilliseconds_ : numMillisecondBits;
 
   // The value of unusedBits_ is relevant w.r.t. to the DateYearOrDuration class
   // for properly shifting a given input value of type dayTimeDuration and
   // thus make it convertible to an intern Id (ValueId) -> The underlying
   // DayTimeDuration and corresponding values can be extracted again.
-  uint64_t unusedBits_ : numUnusedBits = 0;
+  uint64_t unusedBits_ : numUnusedBits;
 
  public:
   // `DurationValue` is used to return all xsd:dayTimeDuration components over
@@ -140,7 +140,10 @@ class DayTimeDuration {
   // duration: `P0DT0H0M0S` (as xsd:dayTimeDuration string).
   constexpr DayTimeDuration(Type signType = Type::Positive, int days = 0,
                             int hours = 0, int minutes = 0,
-                            double seconds = 0.00) {
+                            double seconds = 0.00)
+      // Note: The bit-fields have to be initialized here, because default
+      // member initializers for bit-fields are only allowed since C++20.
+      : totalMilliseconds_(0), unusedBits_(0) {
     setValues(days, hours, minutes, seconds, signType);
   }
 


### PR DESCRIPTION
Default member initializers for bit-fields (`uint64_t x : 4 = 0`) are a C++20 feature. GCC accepts them in C++17 mode only as an extension and warns, and `-pedantic-errors` turns that warning into a hard error. This change moves the defaults of the bit-fields in `Date` and `DayTimeDuration` into constructors. A new `constexpr Date()` sets all eight bit-fields to their previous default values, and the existing value constructor delegates to it, so every construction path still initializes every field. In C++20 mode the new constructor is private, so `Date` remains not default-constructible from the outside. In C++17 mode it is public, because the backported `bit_cast` requires that.

The bit layout, the bit widths, and all default values are unchanged. This matters because both types are part of QLever's binary index format.

NOTE: This change is one of five that were split out of #3215. The CI change that enables `-pedantic-errors` in the `CPP17 libQLever` workflow will be submitted separately once all of them have been merged.