### PR TITLE
Add explicit constructors instead of relying on parenthesized initialization of aggregates

### DIFF
--- a/src/engine/MaterializedViewsQueryAnalysis.h
+++ b/src/engine/MaterializedViewsQueryAnalysis.h
@@ -57,6 +57,13 @@ struct StarInfo {
 struct ByCacheKeyInfo {
   ViewPtr view_;
   ad_utility::HashMap<size_t, size_t> colMapping_;
+
+  // Construct from the view and the mapping of its columns.
+  // NOTE: This constructor is explicitly declared (and not only implicitly via
+  // aggregate initialization) because parenthesized initialization of
+  // aggregates is not supported in C++17.
+  ByCacheKeyInfo(ViewPtr view, ad_utility::HashMap<size_t, size_t> colMapping)
+      : view_{std::move(view)}, colMapping_{std::move(colMapping)} {}
 };
 using ByCacheKeyInfoPtr = std::shared_ptr<const ByCacheKeyInfo>;
 

--- a/src/index/DeltaTriples.h
+++ b/src/index/DeltaTriples.h
@@ -52,6 +52,26 @@ struct LocatedTriplesState {
   // Counts of the external triples. Only set when this is a deep copy, not for
   // references.
   std::optional<DeltaTriplesCount> counts_ = std::nullopt;
+
+  // Construct from the located triples for the external and internal
+  // permutations, the lifetime extender for the local vocab, the index of the
+  // snapshot, and (only for deep copies) the counts of the external triples.
+  // NOTE: This constructor is explicitly declared (and not only implicitly
+  // via aggregate initialization) because parenthesized initialization of
+  // aggregates is not supported in C++17.
+  LocatedTriplesState(
+      LocatedTriplesPerBlockAllPermutations<false> locatedTriplesPerBlock,
+      LocatedTriplesPerBlockAllPermutations<true>
+          internalLocatedTriplesPerBlock,
+      std::optional<LocalVocab::LifetimeExtender> localVocabLifetimeExtender,
+      size_t index, std::optional<DeltaTriplesCount> counts = std::nullopt)
+      : locatedTriplesPerBlock_{std::move(locatedTriplesPerBlock)},
+        internalLocatedTriplesPerBlock_{
+            std::move(internalLocatedTriplesPerBlock)},
+        localVocabLifetimeExtender_{std::move(localVocabLifetimeExtender)},
+        index_{index},
+        counts_{std::move(counts)} {}
+
   // Get `LocatedTriplesPerBlock` objects for the given permutation.
   template <bool isInternal>
   const LocatedTriplesPerBlock& getLocatedTriplesForPermutation(


### PR DESCRIPTION
### What and why

`LocatedTriplesState` (`src/index/DeltaTriples.h`) and `ByCacheKeyInfo`
(`src/engine/MaterializedViewsQueryAnalysis.h`) are aggregates without any
user-declared constructor, and both are created with
`std::make_shared<T>(arg1, arg2, ...)`, that is, with more than one argument:

* `src/index/DeltaTriples.cpp`, in `DeltaTriples::getLocatedTriplesSharedStateCopy()`:
  `std::make_shared<LocatedTriplesState>(...)` with five arguments.
* `src/engine/MaterializedViewsQueryAnalysis.cpp`, in the by-cache-key
  registration in `QueryPatternCache::analyzeView()`:
  `std::make_shared<ByCacheKeyInfo>(...)` with two arguments.

`std::make_shared` initializes the object with *parentheses*, and parenthesized
initialization of an aggregate is a C++20 feature ([P0960](https://wg21.link/p0960)).
In C++17 there is no constructor to call, so **the C++17 build of QLever
currently fails** with

```
error: no matching function for call to 'LocatedTriplesState::LocatedTriplesState(...)'
```

and the analogous error for `ByCacheKeyInfo`. This PR adds an explicit
constructor to each of the two structs, which fixes the C++17 build and also
documents the intended argument order.

### These are recent regressions on `master`

They went unnoticed because the GCC 8 job of the `CPP17 libQLever` workflow
builds with `make -i -k` and only feeds the log to
`misc/gcc8_logs_analyzer.py`, whose error categories
(`co_await`/`concept`/`requires`, "is not a member of `std`") do not match this
pattern. Note also that the errors appear with a *newer* GCC in C++17 mode but
not with GCC 8 itself, which is another reason why that job stayed green.
Extending the log analyzer with a pattern for `no matching function for call to`
would be a sensible follow-up, but is deliberately **not** part of this PR.

### Does adding a constructor break anything?

Adding a user-declared constructor makes a struct a non-aggregate, so all other
construction sites were audited. All of them use *braces*, so they now select
the new constructor instead of doing aggregate initialization, and all of them
keep compiling because the new constructor's last parameter (`counts_`) has a
default argument:

* `src/index/DeltaTriples.h`, default member initializer of
  `DeltaTriples::locatedTriples_`:
  `LocatedTriplesState{ {}, {}, std::nullopt, 0 }` — four arguments.
* `src/engine/MaterializedViews.cpp`, `MaterializedView::makeEmptyLocatedTriplesState()`:
  `LocatedTriplesState{a, b, emptyVocab.getLifetimeExtender(), 0}` — four
  arguments.
* `test/DeltaTriplesTest.cpp` only uses `AD_FIELD(LocatedTriplesState, ...)`
  matchers, which do not construct the type.
* `ByCacheKeyInfo` is constructed nowhere else; it is only ever handled through
  `ByCacheKeyInfoPtr` (`std::shared_ptr<const ByCacheKeyInfo>`).

The default member initializer `counts_ = std::nullopt` is preserved, and the
constructors' parameter lists match the member declaration order.

### Testing

The combined change from which this PR was split was verified with `g++-11` in
the C++17 configuration of the `CPP17 libQLever` workflow (620 translation
units, 0 warnings, 0 errors, and `LibQLeverExample` links — which it did *not*
before, precisely because of the two errors fixed here) and in the C++20
configuration, both with `-pedantic-errors`. In addition, 26 relevant test
binaries — including `DeltaTriplesTest`, `MaterializedViewsTest` and
`LocatedTriplesTest` — were built and passed in a full C++20 build.

### Context

This is one of five PRs split out of #3215, which additionally enables
`-pedantic-errors` for QLever's own targets in the `CPP17 libQLever` workflow.
That CI change will be submitted separately once the split-out PRs are merged.