### PR TITLE
Invoke `QL_DEFINE_DEFAULTED_*` with a trailing comma for classes without data members

### DIFF
--- a/src/backports/three_way_comparison.h
+++ b/src/backports/three_way_comparison.h
@@ -39,6 +39,15 @@
  * - QL_DEFINE_CUSTOM_THREEWAY_OPERATOR_LOCAL_CONSTEXPR(Class):
  * Constexpr member version
  *
+ * Note: For a class without any data members, the `members...` argument of the
+ * defaulted macros is empty, and the macro has to be invoked with a trailing
+ * comma, for example `QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(Empty, )`.
+ * Reason: before C++20, a variadic macro requires at least one argument for its
+ * `...` parameter (GCC and Clang accept zero arguments as an extension, but
+ * warn about it with `-Wpedantic` and reject it with `-pedantic-errors`). The
+ * trailing comma supplies a single empty argument and thus makes the invocation
+ * valid C++17. It has no effect on the generated code in either standard mode.
+ *
  * Note: Custom three-way comparison macros assume the presence of a
  * compareThreeWay function (either as a member or free function) that returns
  * a comparison ordering (e.g., ql::strong_ordering, ql::weak_ordering, or

--- a/src/index/GraphFilter.h
+++ b/src/index/GraphFilter.h
@@ -29,7 +29,7 @@ class GraphFilter {
  public:
   // Marker type for the "ALL" case.
   struct AllTag {
-    QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(AllTag)
+    QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(AllTag, )
   };
 
   // ALL, WHITELIST, BLACKLIST

--- a/src/parser/TripleComponent.h
+++ b/src/parser/TripleComponent.h
@@ -46,7 +46,7 @@ class TripleComponent {
   // Own class for the UNDEF value.
   struct UNDEF {
     // Default equality operator.
-    QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(UNDEF)
+    QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(UNDEF, )
     // Hash to arbitrary (fixed) value. For example, needed in
     // `Values::computeMultiplicities`.
     template <typename H>

--- a/src/parser/data/GraphRef.h
+++ b/src/parser/data/GraphRef.h
@@ -15,18 +15,18 @@ using GraphRef = ad_utility::triple_component::Iri;
 // graph.
 struct DEFAULT {
   // For testing
-  QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(DEFAULT)
+  QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(DEFAULT, )
 };
 // Denotes the target graphs for an operation. Here the target are all named
 // graphs.
 struct NAMED {
   // For testing
-  QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(NAMED)
+  QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(NAMED, )
 };
 // Denotes the target graphs for an operation. Here the target are all graphs.
 struct ALL {
   // For testing
-  QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(ALL)
+  QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(ALL, )
 };
 
 using GraphRefAll = std::variant<GraphRef, DEFAULT, NAMED, ALL>;

--- a/src/util/Date.h
+++ b/src/util/Date.h
@@ -172,10 +172,10 @@ class Date {
 
  public:
   struct NoTimeZone {
-    QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(NoTimeZone)
+    QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(NoTimeZone, )
   };
   struct TimeZoneZ {
-    QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(TimeZoneZ)
+    QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(TimeZoneZ, )
   };
   using TimeZone = std::variant<NoTimeZone, TimeZoneZ, int>;
 #ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17

--- a/src/util/http/UrlParser.h
+++ b/src/util/http/UrlParser.h
@@ -77,7 +77,7 @@ struct GraphStoreOperation {
 // No operation. This can happen for QLever's custom operations (e.g.
 // `cache-stats`). These requests have no operation but are still valid.
 struct None {
-  QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(None)
+  QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(None, )
 };
 
 using Operation = std::variant<Query, Update, GraphStoreOperation, None>;


### PR DESCRIPTION
The variadic `QL_DEFINE_DEFAULTED_*` comparison macros take the class name followed by the list of data members. For a class without data members, that list is empty, so the macros were invoked with zero arguments for the `...` parameter. This is only valid since C++20. GCC and Clang accept it as an extension, but reject it with `-pedantic-errors`.

The eight affected call sites (all member-less tag structs) now pass a single empty argument via a trailing comma, for example `QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(AllTag, )`. This is valid C++17, and the generated code is identical in both standard modes. In C++17, the member list expands to an empty `std::tie()`, and empty tuples always compare equal, exactly like a defaulted C++20 comparison for such a class. In C++20, the member list is not used at all. A comment in `three_way_comparison.h` documents why the trailing comma must stay.

NOTE: This is one of five PRs split out of #3215. The CI change that enables `-pedantic-errors` in the `CPP17 libQLever` workflow will be submitted separately once all of them have been merged.