### PR TITLE
Route QueryPlanner temporary allocations through the query memory resource

### DIFF
--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -43,7 +43,6 @@
 #include "engine/OrderBy.h"
 #include "engine/PathSearch.h"
 #include "engine/PermutationSelector.h"
-#include "engine/QueryExecutionContext.h"
 #include "engine/QueryExecutionTree.h"
 #include "engine/QueryRewriteUtils.h"
 #include "engine/Service.h"
@@ -69,6 +68,7 @@
 #include "parser/PayloadVariables.h"
 #include "parser/SparqlParserHelpers.h"
 #include "rdfTypes/Variable.h"
+#include "util/Allocator.h"
 #include "util/CompilerWarnings.h"
 #include "util/Exception.h"
 
@@ -523,8 +523,11 @@ QueryPlanner::TripleGraph QueryPlanner::createTripleGraph(
     const p::BasicGraphPattern* pattern) const {
   TripleGraph tg;
   size_t numNodesInTripleGraph = 0;
-  ad_utility::HashMap<Variable, std::string> optTermForCvar;
-  ad_utility::HashMap<Variable, vector<std::string>> potentialTermsForCvar;
+  ad_utility::HashMapWithMemoryLimit<Variable, std::string> optTermForCvar(
+      _qec->getAllocator().as<std::pair<const Variable, std::string>>());
+  ad_utility::HashMapWithMemoryLimit<Variable, std::vector<std::string>>
+      potentialTermsForCvar(
+          _qec->getAllocator().as<std::pair<const Variable, std::vector<std::string>>>());
   vector<const SparqlTriple*> entityTriples;
   // Add one or more nodes for each triple.
   for (auto& t : pattern->_triples) {
@@ -1232,7 +1235,10 @@ std::vector<SubtreePlan> QueryPlanner::merge(
   // esp. with an entire relation but also with something like is-a Person
   // If that is the case look at the size estimate for the other side,
   // if that is rather small, replace the join and scan by a combination.
-  ad_utility::HashMap<std::string, vector<SubtreePlan>> candidates;
+  ad_utility::HashMapWithMemoryLimit<std::string, std::vector<SubtreePlan>>
+      candidates(
+          _qec->getAllocator()
+              .as<std::pair<const std::string, std::vector<SubtreePlan>>>());
   // Find all pairs between a and b that are connected by an edge.
   AD_LOG_TRACE << "Considering joins that merge " << a.size() << " and "
                << b.size() << " plans...\n";
@@ -1530,8 +1536,10 @@ void QueryPlanner::applyTextLimitsIfPossible(vector<SubtreePlan>& row,
 // _____________________________________________________________________________
 size_t QueryPlanner::findUniqueNodeIds(
     const std::vector<SubtreePlan>& connectedComponent,
-    bool allowReplacementPlans) {
-  ad_utility::HashSet<uint64_t> uniqueNodeIds;
+    bool allowReplacementPlans,
+    const qlever::Allocator<Id>& alloc) {
+  ad_utility::HashSetWithMemoryLimit<uint64_t> uniqueNodeIds(
+      alloc.as<uint64_t>());
   auto nodeIds = connectedComponent |
                  ql::views::transform(&SubtreePlan::_idsOfIncludedNodes);
   // Check that all the `_idsOfIncludedNodes` are one-hot encodings of a single
@@ -1557,7 +1565,7 @@ QueryPlanner::runDynamicProgrammingOnConnectedComponent(
   // (there might be duplicates because we already have multiple candidates
   // for each index scan with different permutations.
   dpTab.push_back(std::move(connectedComponent));
-  size_t numSeeds = findUniqueNodeIds(dpTab.back(), false);
+  size_t numSeeds = findUniqueNodeIds(dpTab.back(), false, _qec->getAllocator());
 
   for (size_t k = 2; k <= numSeeds; ++k) {
     AD_LOG_TRACE << "Producing plans that unite " << k << " triples."
@@ -1679,7 +1687,7 @@ std::vector<SubtreePlan> QueryPlanner::runGreedyPlanningOnConnectedComponent(
                                                         filters);
   applyTextLimitsIfPossible(connectedComponent, textLimits, true);
   const size_t numSeeds =
-      findUniqueNodeIds(connectedComponent, !replacementPlans.empty());
+      findUniqueNodeIds(connectedComponent, !replacementPlans.empty(), _qec->getAllocator());
   if (numSeeds <= 1) {
     // Only 0 or 1 nodes in the input, nothing to plan.
     return connectedComponent;
@@ -1795,7 +1803,10 @@ std::vector<std::vector<SubtreePlan>> QueryPlanner::fillDpTab(
   auto componentIndices = QueryGraph::computeConnectedComponents(
       initialPlans, filtersAndOptSubstitutes);
 
-  ad_utility::HashMap<size_t, std::vector<SubtreePlan>> components;
+  ad_utility::HashMapWithMemoryLimit<size_t, std::vector<SubtreePlan>>
+      components(
+          _qec->getAllocator()
+              .as<std::pair<const size_t, std::vector<SubtreePlan>>>());
   for (size_t i = 0; i < componentIndices.size(); ++i) {
     components[componentIndices.at(i)].push_back(std::move(initialPlans.at(i)));
   }
@@ -2631,7 +2642,8 @@ auto QueryPlanner::createMaterializedViewJoinReplacements(
   // Check if the user allows query rewriting.
   // TODO<ullingerc> Do we want to forcefully disable query rewriting if delta
   // triples are present in the current index to prevent diverging results?
-  if (_qec->disableMaterializedViewRewriting()) {
+  if (!getRuntimeParameter<
+          &RuntimeParameters::enableMaterializedViewQueryRewrite_>()) {
     return plans;
   }
 

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -257,6 +257,7 @@ class QueryPlanner {
  protected:
   QueryExecutionContext* getQec() const { return _qec; }
 
+
  private:
   QueryExecutionContext* _qec;
 
@@ -733,7 +734,8 @@ class QueryPlanner {
       const std::vector<SubtreePlan>& lastRow);
   static size_t findUniqueNodeIds(
       const std::vector<SubtreePlan>& connectedComponent,
-      bool allowReplacementPlans = false);
+      bool allowReplacementPlans,
+      const qlever::Allocator<Id>& alloc);
 
   // Helper for `fillDpTab` that extracts a subset of possible
   // `ReplacementPlans` that is applicable to a connected component given by the


### PR DESCRIPTION
Extend the memory-resource migration to QueryPlanner so its applicable temporary containers use the allocator configured by the query execution context.

Changes
Add QueryPlanner::allocator(), exposing the qlever::Allocator<Id> provided by QueryExecutionContext.
Replace unbounded planning-time containers with memory-limited equivalents:
candidate and potential-term maps during triple graph construction,
join candidate map,
unique-node-ID set, and
connected-component map used by dynamic-programming planning.
Initialize each container with an allocator rebound to its stored element type, ensuring its dynamic storage is allocated through the configured backend.
Make findUniqueNodeIds a const instance method so it can access the planner allocator.
Add the direct util/Allocator.h dependency and remove the no-longer-needed direct QueryExecutionContext.h include from the implementation.
Read materialized-view query-rewrite enablement through the runtime parameter accessor rather than through the execution context.

depends on #3113 