### PR TITLE
vocab: make lookupBatch reach the on-disk vocabulary

### DIFF
--- a/src/index/vocabulary/CompressedVocabulary.h
+++ b/src/index/vocabulary/CompressedVocabulary.h
@@ -115,12 +115,12 @@ CPP_template(typename UnderlyingVocabulary,
     auto compressed = underlyingVocabulary_.lookupBatch(indices);
     AD_CORRECTNESS_CHECK(compressed->size() == indices.size());
 
-    std::vector<std::string> words;
-    words.reserve(indices.size());
-    for (size_t i = 0; i < indices.size(); ++i) {
-      words.push_back(compressionWrapper_.decompress(
-          (*compressed)[i], getDecoderIdx(indices[i])));
-    }
+    auto words = ::ranges::to_vector(
+        ::ranges::views::zip(indices, *compressed) |
+        ql::views::transform([this](const auto& idxAndWord) {
+          const auto& [idx, word] = idxAndWord;
+          return compressionWrapper_.decompress(word, getDecoderIdx(idx));
+        }));
 
     auto data = std::make_shared<StringVectorVocabBatchLookupData>();
     data->buffer() = std::move(words);

--- a/src/index/vocabulary/CompressedVocabulary.h
+++ b/src/index/vocabulary/CompressedVocabulary.h
@@ -1,9 +1,18 @@
-//  Copyright 2022, University of Freiburg,
-//  Chair of Algorithms and Data Structures.
-//  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+// Copyright 2022 - 2026, The QLever Authors, in particular:
+//
+// 2022 - 2026 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+// 2026        Marvin Stoetzel <stoetzem@email.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+//
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
 
 #ifndef QLEVER_SRC_INDEX_VOCABULARY_COMPRESSEDVOCABULARY_H
 #define QLEVER_SRC_INDEX_VOCABULARY_COMPRESSEDVOCABULARY_H
+
+#include <string>
+#include <vector>
 
 #include "backports/algorithm.h"
 #include "index/ConstantsIndexBuilding.h"
@@ -18,6 +27,7 @@
 #include "util/Serializer/SerializeVector.h"
 #include "util/Serializer/Serializer.h"
 #include "util/TaskQueue.h"
+#include "util/TransparentFunctors.h"
 
 namespace detail {
 
@@ -97,9 +107,27 @@ CPP_template(typename UnderlyingVocabulary,
         });
   }
 
-  //____________________________________________________________________________
+  // Batch-read the compressed words from the underlying vocabulary (which may
+  // itself be on-disk / io_uring), then decompress each word with the decoder
+  // of its block. The result order matches `indices`.
   VocabBatchLookupResult lookupBatch(ql::span<const size_t> indices) const {
-    return ad_utility::vocabulary::sequentialLookupBatch(*this, indices);
+    AD_CONTRACT_CHECK(!indices.empty());
+    auto compressed = underlyingVocabulary_.lookupBatch(indices);
+    AD_CORRECTNESS_CHECK(compressed->size() == indices.size());
+
+    std::vector<std::string> words;
+    words.reserve(indices.size());
+    for (size_t i = 0; i < indices.size(); ++i) {
+      words.push_back(compressionWrapper_.decompress(
+          (*compressed)[i], getDecoderIdx(indices[i])));
+    }
+
+    auto data = std::make_shared<StringVectorVocabBatchLookupData>();
+    data->buffer() = std::move(words);
+    data->views() = ::ranges::to_vector(
+        data->buffer() |
+        ql::views::transform(ad_utility::staticCast<std::string_view>));
+    return StringVectorVocabBatchLookupData::asResult(std::move(data));
   }
 
   //____________________________________________________________________________

--- a/src/index/vocabulary/VocabularyInternalExternal.cpp
+++ b/src/index/vocabulary/VocabularyInternalExternal.cpp
@@ -1,8 +1,20 @@
-// Copyright 2024, University of Freiburg,
-// Chair of Algorithms and Data Structures.
-// Author: Johannes Kalmbach<joka921> (kalmbach@cs.uni-freiburg.de)
+// Copyright 2024 - 2026, The QLever Authors, in particular:
+//
+// 2024 - 2026 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+// 2026        Marvin Stoetzel <stoetzem@email.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+//
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
 
 #include "index/vocabulary/VocabularyInternalExternal.h"
+
+#include <string>
+#include <vector>
+
+#include "backports/algorithm.h"
+#include "util/TransparentFunctors.h"
 
 // _____________________________________________________________________________
 std::string VocabularyInternalExternal::operator[](uint64_t i) const {
@@ -11,6 +23,43 @@ std::string VocabularyInternalExternal::operator[](uint64_t i) const {
     return std::string{fromInternal.value()};
   }
   return externalVocab_[i];
+}
+
+// _____________________________________________________________________________
+VocabBatchLookupResult VocabularyInternalExternal::lookupBatch(
+    ql::span<const size_t> indices) const {
+  AD_CONTRACT_CHECK(!indices.empty());
+
+  std::vector<std::string> words(indices.size());
+  std::vector<size_t> diskIndices;
+  std::vector<size_t> diskSlots;
+  diskIndices.reserve(indices.size());
+  diskSlots.reserve(indices.size());
+
+  for (size_t i = 0; i < indices.size(); ++i) {
+    auto fromInternal = internalVocab_[indices[i]];
+    if (fromInternal.has_value()) {
+      words[i] = std::string{fromInternal.value()};
+    } else {
+      diskSlots.push_back(i);
+      diskIndices.push_back(indices[i]);
+    }
+  }
+
+  if (!diskIndices.empty()) {
+    auto disk = externalVocab_.lookupBatch(diskIndices);
+    AD_CORRECTNESS_CHECK(disk->size() == diskIndices.size());
+    for (size_t k = 0; k < diskSlots.size(); ++k) {
+      words[diskSlots[k]] = std::string{(*disk)[k]};
+    }
+  }
+
+  auto data = std::make_shared<StringVectorVocabBatchLookupData>();
+  data->buffer() = std::move(words);
+  data->views() = ::ranges::to_vector(
+      data->buffer() |
+      ql::views::transform(ad_utility::staticCast<std::string_view>));
+  return StringVectorVocabBatchLookupData::asResult(std::move(data));
 }
 
 // _____________________________________________________________________________

--- a/src/index/vocabulary/VocabularyInternalExternal.cpp
+++ b/src/index/vocabulary/VocabularyInternalExternal.cpp
@@ -49,8 +49,7 @@ VocabBatchLookupResult VocabularyInternalExternal::lookupBatch(
   if (!diskIndices.empty()) {
     auto disk = externalVocab_.lookupBatch(diskIndices);
     AD_CORRECTNESS_CHECK(disk->size() == diskIndices.size());
-    for (auto [slot, word] :
-         ::ranges::views::zip(diskSlots, *disk)) {
+    for (auto [slot, word] : ::ranges::views::zip(diskSlots, *disk)) {
       words[slot] = std::string{word};
     }
   }

--- a/src/index/vocabulary/VocabularyInternalExternal.cpp
+++ b/src/index/vocabulary/VocabularyInternalExternal.cpp
@@ -36,21 +36,22 @@ VocabBatchLookupResult VocabularyInternalExternal::lookupBatch(
   diskIndices.reserve(indices.size());
   diskSlots.reserve(indices.size());
 
-  for (size_t i = 0; i < indices.size(); ++i) {
-    auto fromInternal = internalVocab_[indices[i]];
+  for (auto [i, idx] : ::ranges::views::enumerate(indices)) {
+    auto fromInternal = internalVocab_[idx];
     if (fromInternal.has_value()) {
       words[i] = std::string{fromInternal.value()};
     } else {
       diskSlots.push_back(i);
-      diskIndices.push_back(indices[i]);
+      diskIndices.push_back(idx);
     }
   }
 
   if (!diskIndices.empty()) {
     auto disk = externalVocab_.lookupBatch(diskIndices);
     AD_CORRECTNESS_CHECK(disk->size() == diskIndices.size());
-    for (size_t k = 0; k < diskSlots.size(); ++k) {
-      words[diskSlots[k]] = std::string{(*disk)[k]};
+    for (auto [slot, word] :
+         ::ranges::views::zip(diskSlots, *disk)) {
+      words[slot] = std::string{word};
     }
   }
 

--- a/src/index/vocabulary/VocabularyInternalExternal.h
+++ b/src/index/vocabulary/VocabularyInternalExternal.h
@@ -1,6 +1,12 @@
-// Copyright 2024, University of Freiburg,
-// Chair of Algorithms and Data Structures.
-// Author: Johannes Kalmbach<joka921> (kalmbach@cs.uni-freiburg.de)
+// Copyright 2024 - 2026, The QLever Authors, in particular:
+//
+// 2024 - 2026 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+// 2026        Marvin Stoetzel <stoetzem@email.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+//
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
 
 #ifndef QLEVER_SRC_INDEX_VOCABULARY_VOCABULARYINTERNALEXTERNAL_H
 #define QLEVER_SRC_INDEX_VOCABULARY_VOCABULARYINTERNALEXTERNAL_H
@@ -54,10 +60,10 @@ class VocabularyInternalExternal {
   // vocabulary.
   auto scanAll() const { return externalVocab_.scanAll(); }
 
-  //____________________________________________________________________________
-  VocabBatchLookupResult lookupBatch(ql::span<const size_t> indices) const {
-    return ad_utility::vocabulary::sequentialLookupBatch(*this, indices);
-  }
+  // Resolve `indices` in request order. Words present in `internalVocab_` are
+  // taken from RAM. The remaining indices are resolved in one
+  // `externalVocab_.lookupBatch` call (the on-disk / io_uring path).
+  VocabBatchLookupResult lookupBatch(ql::span<const size_t> indices) const;
 
   //____________________________________________________________________________
   VocabLookupOutput lookupBatchesStreamed(VocabLookupInput input) const {

--- a/src/index/vocabulary/VocabularyInternalExternal.h
+++ b/src/index/vocabulary/VocabularyInternalExternal.h
@@ -62,7 +62,7 @@ class VocabularyInternalExternal {
 
   // Resolve `indices` in request order. Words present in `internalVocab_` are
   // taken from RAM. The remaining indices are resolved in one
-  // `externalVocab_.lookupBatch` call (the on-disk / io_uring path).
+  // `externalVocab_.lookupBatch` call (the on-disk path).
   VocabBatchLookupResult lookupBatch(ql::span<const size_t> indices) const;
 
   //____________________________________________________________________________

--- a/test/index/vocabulary/VocabularyInternalExternalTest.cpp
+++ b/test/index/vocabulary/VocabularyInternalExternalTest.cpp
@@ -4,6 +4,10 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
+#include <string>
+#include <vector>
+
 #include "./VocabularyTestHelpers.h"
 #include "backports/algorithm.h"
 #include "index/vocabulary/VocabularyInternalExternal.h"
@@ -109,6 +113,19 @@ TEST(VocabularyInternalExternal, AccessOperator) {
   testAccessOperatorForUnorderedVocabulary(createVocabulary("AccessOperator1"));
   testAccessOperatorForUnorderedVocabulary(
       createVocabularyFromDisk("AccessOperator2"));
+}
+
+// `lookupBatch` must match `operator[]` in request order, including cache
+// hits (even `i` in the writer: stored in RAM) and misses (odd `i`: disk
+// only), plus reordered and duplicated indices.
+TEST(VocabularyInternalExternal, LookupBatchMatchesAccessOperator) {
+  const std::vector<std::string> words{"alpha", "beta", "gamma", "delta",
+                                       "epsilon"};
+  auto vocab = createVocabulary("LookupBatch")(words);
+  const std::array<size_t, 7> indices{4, 1, 0, 3, 1, 2, 4};
+  auto result = vocab.lookupBatch(indices);
+  assertLookupResultMatchesVocabularyAtIndices(vocab, result, indices);
+  EXPECT_ANY_THROW(vocab.lookupBatch(ql::span<const size_t>{}));
 }
 
 TEST(VocabularyInternalExternal, EmptyVocabulary) {


### PR DESCRIPTION
## WHY

`lookupBatch` on the production on-disk vocabulary types (`OnDiskUncompressed` = `VocabularyInternalExternal`, `OnDiskCompressed` = `CompressedVocabulary` wrapping that) called `sequentialLookupBatch`. That loops `operator[]` per index. The batched I/O path in `VocabularyOnDisk` was therefore never used for a default index.

## WHAT

- `VocabularyInternalExternal::lookupBatch` takes RAM-cached words from `internalVocab_` and resolves the rest with one `externalVocab_.lookupBatch`.
- `CompressedVocabulary::lookupBatch` batch-reads the underlying vocabulary and decompresses each word with its block decoder.
- Result order still matches the requested indices, including duplicates and cache-hit / cache-miss mixes.
- Added a unit test that `lookupBatch` matches `operator[]` on a mixed internal/external vocabulary.

Unicode, polymorphic, split, and geo wrappers already forwarded `lookupBatch`; they now inherit the on-disk path automatically.

## DESIGN DECISIONS

- Cache hits stay in RAM. Sending every index to disk would ignore the internal milestone cache. Misses are the common case on export, and those now share one batched I/O call.
- `CompressedVocabulary` still returns owning strings. Decompression produces new bytes; a single contiguous buffer would reallocate and invalidate views.

## EXPECTED PERFORMANCE IMPROVEMENT

Export paths that already call `idsToStringAndType` (CONSTRUCT today) can issue one batched vocabulary I/O instead of two `pread`s per word. Whether that shows up in wall-clock time depends on the workload (vocabulary I/O vs serialization). This PR only makes that path reachable; it does not add pipelining.