### PR TITLE
export: batch SELECT CSV/TSV vocabulary resolution

### DIFF
--- a/src/engine/ExportQueryExecutionTrees.cpp
+++ b/src/engine/ExportQueryExecutionTrees.cpp
@@ -531,6 +531,30 @@ STREAMABLE_GENERATOR_TYPE ExportQueryExecutionTrees::selectQueryResultToStream(
   // IDs share one `lookupBatch` instead of one syscall per cell.
   static constexpr size_t kIdBatchSize = 1000;
   std::vector<Id> idBatch;
+
+  // Format `numRows` rows of `resolved` (one entry per batch column, in
+  // `batchColIndices` order) into `output`, one line per row with the
+  // column separator between the cells. The output of the whole stream is
+  // the same as if each cell had been yielded individually.
+  auto appendResolvedRows = [&](std::string& output, size_t numRows,
+                                const auto& resolved) {
+    size_t resolvedIdx = 0;
+    for (size_t r = 0; r < numRows; ++r) {
+      for (size_t j = 0; j < selectedColumnIndices.size(); ++j) {
+        if (selectedColumnIndices[j].has_value()) {
+          if (resolved[resolvedIdx].has_value()) [[likely]] {
+            absl::StrAppend(&output, resolved[resolvedIdx].value().first);
+          }
+          ++resolvedIdx;
+        }
+        if (j + 1 < selectedColumnIndices.size()) {
+          output.push_back(separator);
+        }
+      }
+      output.push_back('\n');
+      cancellationHandle->throwIfCancelled();
+    }
+  };
   uint64_t resultSize = 0;
   for (const auto& [pair, range] :
        getRowIndices(limitAndOffset, *result, resultSize)) {
@@ -548,22 +572,9 @@ STREAMABLE_GENERATOR_TYPE ExportQueryExecutionTrees::selectQueryResultToStream(
       }
       auto resolved = ql::exportIds::idsToStringAndType<format == csv>(
           qet.getQec()->getIndex(), idBatch, pair.localVocab(), escapeFunction);
-      size_t resolvedIdx = 0;
-      for (size_t r = 0; r < kIdBatchSize; ++r) {
-        for (size_t j = 0; j < selectedColumnIndices.size(); ++j) {
-          if (selectedColumnIndices[j].has_value()) {
-            if (resolved[resolvedIdx].has_value()) [[likely]] {
-              STREAMABLE_YIELD(resolved[resolvedIdx].value().first);
-            }
-            ++resolvedIdx;
-          }
-          if (j + 1 < selectedColumnIndices.size()) {
-            STREAMABLE_YIELD(separator);
-          }
-        }
-        STREAMABLE_YIELD('\n');
-        cancellationHandle->throwIfCancelled();
-      }
+      std::string output;
+      appendResolvedRows(output, kIdBatchSize, resolved);
+      STREAMABLE_YIELD(std::move(output));
       idBatch.clear();
       rowsInBatch = 0;
     }
@@ -573,22 +584,9 @@ STREAMABLE_GENERATOR_TYPE ExportQueryExecutionTrees::selectQueryResultToStream(
     }
     auto resolved = ql::exportIds::idsToStringAndType<format == csv>(
         qet.getQec()->getIndex(), idBatch, pair.localVocab(), escapeFunction);
-    size_t resolvedIdx = 0;
-    for (size_t r = 0; r < rowsInBatch; ++r) {
-      for (size_t j = 0; j < selectedColumnIndices.size(); ++j) {
-        if (selectedColumnIndices[j].has_value()) {
-          if (resolved[resolvedIdx].has_value()) [[likely]] {
-            STREAMABLE_YIELD(resolved[resolvedIdx].value().first);
-          }
-          ++resolvedIdx;
-        }
-        if (j + 1 < selectedColumnIndices.size()) {
-          STREAMABLE_YIELD(separator);
-        }
-      }
-      STREAMABLE_YIELD('\n');
-      cancellationHandle->throwIfCancelled();
-    }
+    std::string output;
+    appendResolvedRows(output, rowsInBatch, resolved);
+    STREAMABLE_YIELD(std::move(output));
   }
   AD_LOG_DEBUG << "Done creating readable result.\n";
 }

--- a/src/engine/ExportQueryExecutionTrees.cpp
+++ b/src/engine/ExportQueryExecutionTrees.cpp
@@ -18,6 +18,7 @@
 
 #include <optional>
 #include <string_view>
+#include <vector>
 
 #include "backports/StartsWithAndEndsWith.h"
 #include "backports/algorithm.h"
@@ -515,21 +516,71 @@ STREAMABLE_GENERATOR_TYPE ExportQueryExecutionTrees::selectQueryResultToStream(
 
   constexpr auto& escapeFunction =
       format == tsv ? RdfEscaping::escapeForTsv : RdfEscaping::escapeForCsv;
+
+  // Columns that actually contribute an ID. Unbound selected variables stay
+  // empty cells and are not included in the batch.
+  std::vector<size_t> batchColIndices;
+  for (size_t j = 0; j < selectedColumnIndices.size(); ++j) {
+    if (selectedColumnIndices[j].has_value()) {
+      batchColIndices.push_back(j);
+    }
+  }
+  const size_t numBatchCols = batchColIndices.size();
+
+  // Resolve this many result rows per `idsToStringAndType` call so vocabulary
+  // IDs share one `lookupBatch` instead of one syscall per cell.
+  static constexpr size_t kIdBatchSize = 1000;
+  std::vector<Id> idBatch;
   uint64_t resultSize = 0;
   for (const auto& [pair, range] :
        getRowIndices(limitAndOffset, *result, resultSize)) {
+    idBatch.clear();
+    idBatch.reserve(kIdBatchSize * numBatchCols);
+    size_t rowsInBatch = 0;
+
     for (uint64_t i : range) {
+      for (size_t colIdx : batchColIndices) {
+        const auto& col = selectedColumnIndices[colIdx].value();
+        idBatch.push_back(pair.idTable()(i, col.columnIndex_));
+      }
+      if (++rowsInBatch != kIdBatchSize) {
+        continue;
+      }
+      auto resolved = ql::exportIds::idsToStringAndType<format == csv>(
+          qet.getQec()->getIndex(), idBatch, pair.localVocab(), escapeFunction);
+      size_t resolvedIdx = 0;
+      for (size_t r = 0; r < kIdBatchSize; ++r) {
+        for (size_t j = 0; j < selectedColumnIndices.size(); ++j) {
+          if (selectedColumnIndices[j].has_value()) {
+            if (resolved[resolvedIdx].has_value()) [[likely]] {
+              STREAMABLE_YIELD(resolved[resolvedIdx].value().first);
+            }
+            ++resolvedIdx;
+          }
+          if (j + 1 < selectedColumnIndices.size()) {
+            STREAMABLE_YIELD(separator);
+          }
+        }
+        STREAMABLE_YIELD('\n');
+        cancellationHandle->throwIfCancelled();
+      }
+      idBatch.clear();
+      rowsInBatch = 0;
+    }
+
+    if (rowsInBatch == 0) {
+      continue;
+    }
+    auto resolved = ql::exportIds::idsToStringAndType<format == csv>(
+        qet.getQec()->getIndex(), idBatch, pair.localVocab(), escapeFunction);
+    size_t resolvedIdx = 0;
+    for (size_t r = 0; r < rowsInBatch; ++r) {
       for (size_t j = 0; j < selectedColumnIndices.size(); ++j) {
         if (selectedColumnIndices[j].has_value()) {
-          const auto& val = selectedColumnIndices[j].value();
-          Id id = pair.idTable()(i, val.columnIndex_);
-          auto optionalStringAndType =
-              ql::exportIds::idToStringAndType<format == csv>(
-                  qet.getQec()->getIndex(), id, pair.localVocab(),
-                  escapeFunction);
-          if (optionalStringAndType.has_value()) [[likely]] {
-            STREAMABLE_YIELD(optionalStringAndType.value().first);
+          if (resolved[resolvedIdx].has_value()) [[likely]] {
+            STREAMABLE_YIELD(resolved[resolvedIdx].value().first);
           }
+          ++resolvedIdx;
         }
         if (j + 1 < selectedColumnIndices.size()) {
           STREAMABLE_YIELD(separator);

--- a/test/ExportQueryExecutionTreesTest.cpp
+++ b/test/ExportQueryExecutionTreesTest.cpp
@@ -2269,3 +2269,38 @@ INSTANTIATE_TEST_SUITE_P(
         LruWindowParam{5, "abcde"},
         // window 10: all duplicates are caught, 5 unique triples remain.
         LruWindowParam{10, "abcde"}));
+
+// _____________________________________________________________________________
+// A SELECT result with more rows than the internal batching size (1000 rows
+// per `idsToStringAndType` call) must be exported completely: the rows
+// exercise the mid-stream flush of the batch buffer as well as the tail
+// batch after the loop. Both TSV and CSV must contain every row in order.
+TEST(ExportQueryExecutionTrees, SelectQueryMoreThanOneBatchOfRows) {
+  constexpr size_t numRows = 1000 + 3;  // one full batch plus a tail batch
+  const std::string kg = "";
+  const std::string query = [&]() {
+    std::string values;
+    for (size_t i = 0; i < numRows; ++i) {
+      absl::StrAppend(&values, i == 0 ? "(" : " (", i, ")");
+    }
+    return absl::StrCat("SELECT ?x WHERE { VALUES ?x { ", values, " } }");
+  }();
+  const std::string expectedTsv = [&]() {
+    std::string expected = "?x\n";
+    for (size_t i = 0; i < numRows; ++i) {
+      absl::StrAppend(&expected, i, "\n");
+    }
+    return expected;
+  }();
+  const std::string expectedCsv = [&]() {
+    std::string expected = "x\n";
+    for (size_t i = 0; i < numRows; ++i) {
+      absl::StrAppend(&expected, i, "\n");
+    }
+    return expected;
+  }();
+  EXPECT_EQ(runQueryStreamableResult(kg, query, ad_utility::MediaType::tsv),
+            expectedTsv);
+  EXPECT_EQ(runQueryStreamableResult(kg, query, ad_utility::MediaType::csv),
+            expectedCsv);
+}


### PR DESCRIPTION
## WHY

`selectQueryResultToStream` for CSV and TSV called `idToStringAndType` once per Id-table cell. Each `VocabIndex` cell therefore did its own vocabulary lookup. CONSTRUCT already resolves IDs in batches via `idsToStringAndType`. SELECT did not use that API.

## WHAT

- Collect up to 1000 result rows of actually selected columns.
- Resolve the flat ID vector with `idsToStringAndType`.
- Scatter the resolved strings back into the CSV/TSV stream, including empty cells for unbound variables.
- JSON, XML, and binary SELECT formats are unchanged.

Output bytes are intended to match the previous per-cell path. Existing SELECT CSV/TSV export tests cover that.

## DESIGN DECISIONS

- Batch size is 1000 rows, matching the existing CONSTRUCT-side batch helper convention. A runtime parameter is a separate change.
- `STREAMABLE_YIELD` is a coroutine yield, so the flush logic is written inline twice (full batch and remainder) rather than factored into a nested function.

## EXPECTED PERFORMANCE IMPROVEMENT

Vocab-heavy SELECT CSV/TSV under cold cache should issue far fewer vocabulary syscalls (one `lookupBatch` per 1000 rows instead of one lookup per cell). Warm / CPU-bound cases may be within noise.