### PR TITLE
vocab: split-phase lookupBatch and depth-2 CONSTRUCT pipeline

### DIFF
--- a/src/engine/ConstructBatchEvaluator.cpp
+++ b/src/engine/ConstructBatchEvaluator.cpp
@@ -99,7 +99,7 @@ EvaluatedVariableValues ConstructBatchEvaluator::evaluateVariableByColumn(
   // them per block is fine performance-wise: `LocalVocabEntry`s live in RAM,
   // so there is no disk I/O to amortize across batches.
   auto missResolved =
-      ql::exportIds::idsToStringAndType(index, missIds, localVocab);
+      ql::exportIds::idsToStringAndTypeDepth2(index, missIds, localVocab);
   for (auto&& [id, resolved, rows] :
        ::ranges::views::zip(missIds, missResolved, missRows)) {
     auto evaluate = [&resolved](const Id&) {

--- a/src/index/ExportIds.h
+++ b/src/index/ExportIds.h
@@ -350,13 +350,13 @@ idsToStringAndTypeDepth2(
         index, ids, vocabPositions.subspan(subBatchSize));
   }
   finishResolveVocabIndexIds<removeQuotesAndAngleBrackets, returnOnlyLiterals>(
-      index, ids, vocabPositions.subspan(0, subBatchSize),
-      std::move(handleFirst), results, escapeFunction);
+      index, vocabPositions.subspan(0, subBatchSize), std::move(handleFirst),
+      results, escapeFunction);
   if (handleSecond) {
     finishResolveVocabIndexIds<removeQuotesAndAngleBrackets,
                                returnOnlyLiterals>(
-        index, ids, vocabPositions.subspan(subBatchSize),
-        std::move(handleSecond), results, escapeFunction);
+        index, vocabPositions.subspan(subBatchSize), std::move(handleSecond),
+        results, escapeFunction);
   }
   return results;
 }

--- a/src/index/ExportIds.h
+++ b/src/index/ExportIds.h
@@ -252,8 +252,7 @@ inline std::unique_ptr<VocabLookupHandleBase> beginResolveVocabIndexIds(
 template <bool removeQuotesAndAngleBrackets, bool returnOnlyLiterals,
           typename EscapeFunction>
 void finishResolveVocabIndexIds(
-    const Index& index, ql::span<const Id> ids,
-    ql::span<const size_t> positions,
+    const Index& index, ql::span<const size_t> positions,
     std::unique_ptr<VocabLookupHandleBase> handle,
     ql::span<std::optional<std::pair<std::string, const char*>>> results,
     const EscapeFunction& escapeFunction) {
@@ -284,7 +283,7 @@ void resolveVocabIndexIds(
   }));
 
   finishResolveVocabIndexIds<removeQuotesAndAngleBrackets, returnOnlyLiterals>(
-      index, ids, positions, beginResolveVocabIndexIds(index, ids, positions),
+      index, positions, beginResolveVocabIndexIds(index, ids, positions),
       results, escapeFunction);
 }
 

--- a/src/index/ExportIds.h
+++ b/src/index/ExportIds.h
@@ -13,6 +13,7 @@
 #ifndef QLEVER_SRC_INDEX_EXPORTIDS_H
 #define QLEVER_SRC_INDEX_EXPORTIDS_H
 
+#include <memory>
 #include <optional>
 #include <string>
 #include <utility>
@@ -25,6 +26,7 @@
 #include "index/Index.h"
 #include "index/IndexImpl.h"
 #include "index/LocalVocab.h"
+#include "index/vocabulary/VocabularyTypes.h"
 #include "parser/LiteralOrIri.h"
 #include "util/CompilerExtensions.h"
 #include "util/Exception.h"
@@ -237,6 +239,33 @@ void resolveNonVocabIndexIds(
   });
 }
 
+inline std::unique_ptr<VocabLookupHandleBase> beginResolveVocabIndexIds(
+    const Index& index, ql::span<const Id> ids,
+    ql::span<const size_t> positions) {
+  auto rawIndices = ::ranges::to_vector(
+      positions | ql::views::transform([&ids](size_t i) {
+        return static_cast<size_t>(ids[i].getVocabIndex().get());
+      }));
+  return index.getImpl().getVocab().beginLookup(rawIndices);
+}
+
+template <bool removeQuotesAndAngleBrackets, bool returnOnlyLiterals,
+          typename EscapeFunction>
+void finishResolveVocabIndexIds(
+    const Index& index, ql::span<const Id> ids,
+    ql::span<const size_t> positions,
+    std::unique_ptr<VocabLookupHandleBase> handle,
+    ql::span<std::optional<std::pair<std::string, const char*>>> results,
+    const EscapeFunction& escapeFunction) {
+  auto vocabStrings =
+      index.getImpl().getVocab().finishLookup(std::move(handle));
+  for (auto&& [sv, i] : ::ranges::views::zip(*vocabStrings, positions)) {
+    results[i] = literalOrIriToStringAndType<removeQuotesAndAngleBrackets,
+                                             returnOnlyLiterals>(
+        LiteralOrIriView::fromStringRepresentation(sv), escapeFunction);
+  }
+}
+
 // Resolve the `VocabIndex` IDs at `positions` in a single batched vocabulary
 // lookup, writing each result into its slot in `results`.
 template <bool removeQuotesAndAngleBrackets, bool returnOnlyLiterals,
@@ -254,22 +283,9 @@ void resolveVocabIndexIds(
     return ids[i].getDatatype() == Datatype::VocabIndex;
   }));
 
-  // NOTE: The batch is deliberately not sorted by vocabulary position: the
-  // io_uring backend reorders the reads anyway, and only the synchronous
-  // fallback could profit from sequential file access.
-  auto rawIndices = ::ranges::to_vector(
-      positions | ql::views::transform([&ids](size_t i) {
-        return static_cast<size_t>(ids[i].getVocabIndex().get());
-      }));
-  auto vocabStrings = index.getImpl().getVocab().lookupBatch(rawIndices);
-
-  // `vocabStrings` is in the same order as `positions`, so zip scatters each
-  // looked-up string back to the position it came from.
-  for (auto&& [sv, i] : ::ranges::views::zip(*vocabStrings, positions)) {
-    results[i] = literalOrIriToStringAndType<removeQuotesAndAngleBrackets,
-                                             returnOnlyLiterals>(
-        LiteralOrIriView::fromStringRepresentation(sv), escapeFunction);
-  }
+  finishResolveVocabIndexIds<removeQuotesAndAngleBrackets, returnOnlyLiterals>(
+      index, ids, positions, beginResolveVocabIndexIds(index, ids, positions),
+      results, escapeFunction);
 }
 
 // Batch variant of `idToStringAndType`. We cannot assume that the `VocabIndex`
@@ -295,6 +311,54 @@ idsToStringAndType(const Index& index, ql::span<const Id> ids,
   resolveVocabIndexIds<removeQuotesAndAngleBrackets, returnOnlyLiterals>(
       index, ids, positions.vocabIndexIndices_, results, escapeFunction);
 
+  return results;
+}
+
+// Depth-2 pipeline: submit two vocab sub-batches, then consume the first
+// while the second is in flight. Each sub-batch is at most 256 indices so
+// two in-flight batches stay inside the default 512-entry ring.
+constexpr size_t maxVocabIndicesPerSubBatch = 256;
+
+template <bool removeQuotesAndAngleBrackets = false,
+          bool returnOnlyLiterals = false,
+          typename EscapeFunction = ql::identity>
+std::vector<std::optional<std::pair<std::string, const char*>>>
+idsToStringAndTypeDepth2(
+    const Index& index, ql::span<const Id> ids, const LocalVocab& localVocab,
+    const EscapeFunction& escapeFunction = EscapeFunction{}) {
+  std::vector<std::optional<std::pair<std::string, const char*>>> results(
+      ids.size());
+
+  PartitionedIdPositions positions = partitionIdPositions(ids);
+  resolveNonVocabIndexIds<removeQuotesAndAngleBrackets, returnOnlyLiterals>(
+      index, ids, localVocab, positions.nonVocabIndexIndices_, results,
+      escapeFunction);
+
+  const auto vocabPositions =
+      ql::span<const size_t>{positions.vocabIndexIndices_};
+  const size_t numVocabIndices = vocabPositions.size();
+  if (numVocabIndices == 0) {
+    return results;
+  }
+  const size_t subBatchSize = numVocabIndices <= maxVocabIndicesPerSubBatch
+                                  ? numVocabIndices
+                                  : (numVocabIndices + 1) / 2;
+  auto handleFirst = beginResolveVocabIndexIds(
+      index, ids, vocabPositions.subspan(0, subBatchSize));
+  std::unique_ptr<VocabLookupHandleBase> handleSecond;
+  if (subBatchSize < numVocabIndices) {
+    handleSecond = beginResolveVocabIndexIds(
+        index, ids, vocabPositions.subspan(subBatchSize));
+  }
+  finishResolveVocabIndexIds<removeQuotesAndAngleBrackets, returnOnlyLiterals>(
+      index, ids, vocabPositions.subspan(0, subBatchSize),
+      std::move(handleFirst), results, escapeFunction);
+  if (handleSecond) {
+    finishResolveVocabIndexIds<removeQuotesAndAngleBrackets,
+                               returnOnlyLiterals>(
+        index, ids, vocabPositions.subspan(subBatchSize),
+        std::move(handleSecond), results, escapeFunction);
+  }
   return results;
 }
 

--- a/src/index/vocabulary/CompressedVocabulary.h
+++ b/src/index/vocabulary/CompressedVocabulary.h
@@ -11,6 +11,7 @@
 #ifndef QLEVER_SRC_INDEX_VOCABULARY_COMPRESSEDVOCABULARY_H
 #define QLEVER_SRC_INDEX_VOCABULARY_COMPRESSEDVOCABULARY_H
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -111,23 +112,30 @@ CPP_template(typename UnderlyingVocabulary,
   // itself be on-disk / io_uring), then decompress each word with the decoder
   // of its block. The result order matches `indices`.
   VocabBatchLookupResult lookupBatch(ql::span<const size_t> indices) const {
-    AD_CONTRACT_CHECK(!indices.empty());
-    auto compressed = underlyingVocabulary_.lookupBatch(indices);
-    AD_CORRECTNESS_CHECK(compressed->size() == indices.size());
+    return finishLookup(beginLookup(indices));
+  }
 
-    std::vector<std::string> words;
-    words.reserve(indices.size());
-    for (size_t i = 0; i < indices.size(); ++i) {
-      words.push_back(compressionWrapper_.decompress(
-          (*compressed)[i], getDecoderIdx(indices[i])));
+  std::unique_ptr<VocabLookupHandleBase> beginLookup(
+      ql::span<const size_t> indices) const {
+    auto handle = std::make_unique<CompressedLookupHandle>();
+    handle->vocab_ = this;
+    handle->indices_.assign(indices.begin(), indices.end());
+    if constexpr (requires { underlyingVocabulary_.beginLookup(indices); }) {
+      handle->underlyingHandle_ = underlyingVocabulary_.beginLookup(indices);
+    } else {
+      auto eager = std::make_unique<EagerVocabLookupHandle>();
+      eager->result_ = underlyingVocabulary_.lookupBatch(indices);
+      handle->underlyingHandle_ = std::move(eager);
     }
+    return handle;
+  }
 
-    auto data = std::make_shared<StringVectorVocabBatchLookupData>();
-    data->buffer() = std::move(words);
-    data->views() = ::ranges::to_vector(
-        data->buffer() |
-        ql::views::transform(ad_utility::staticCast<std::string_view>));
-    return StringVectorVocabBatchLookupData::asResult(std::move(data));
+  VocabBatchLookupResult finishLookup(
+      std::unique_ptr<VocabLookupHandleBase> handle) const {
+    auto* compressedHandle = static_cast<CompressedLookupHandle*>(handle.get());
+    AD_CONTRACT_CHECK(compressedHandle != nullptr &&
+                      compressedHandle->vocab_ == this);
+    return compressedHandle->finish();
   }
 
   //____________________________________________________________________________
@@ -369,6 +377,27 @@ CPP_template(typename UnderlyingVocabulary,
   }
 
  private:
+  class CompressedLookupHandle : public VocabLookupHandleBase {
+   public:
+    VocabBatchLookupResult finish() override {
+      auto compressed = underlyingHandle_->finish();
+      auto data = std::make_shared<StringVectorVocabBatchLookupData>();
+      data->buffer().reserve(indices_.size());
+      for (size_t i = 0; i < indices_.size(); ++i) {
+        data->buffer().push_back(vocab_->compressionWrapper_.decompress(
+            (*compressed)[i], vocab_->getDecoderIdx(indices_[i])));
+      }
+      data->views() = ::ranges::to_vector(
+          data->buffer() |
+          ql::views::transform(ad_utility::staticCast<std::string_view>));
+      return StringVectorVocabBatchLookupData::asResult(std::move(data));
+    }
+
+    const CompressedVocabulary* vocab_ = nullptr;
+    std::vector<size_t> indices_;
+    std::unique_ptr<VocabLookupHandleBase> underlyingHandle_;
+  };
+
   // Get the correct decoder for the given `idx`.
   size_t getDecoderIdx(size_t idx) const { return idx / NumWordsPerBlock; }
 

--- a/src/index/vocabulary/CompressedVocabulary.h
+++ b/src/index/vocabulary/CompressedVocabulary.h
@@ -109,8 +109,8 @@ CPP_template(typename UnderlyingVocabulary,
   }
 
   // Batch-read the compressed words from the underlying vocabulary (which may
-  // itself be on-disk / io_uring), then decompress each word with the decoder
-  // of its block. The result order matches `indices`.
+  // itself be on-disk), then decompress each word with the decoder of its
+  // block. The result order matches `indices`.
   VocabBatchLookupResult lookupBatch(ql::span<const size_t> indices) const {
     return finishLookup(beginLookup(indices));
   }
@@ -120,6 +120,9 @@ CPP_template(typename UnderlyingVocabulary,
     auto handle = std::make_unique<CompressedLookupHandle>();
     handle->vocab_ = this;
     handle->indices_.assign(indices.begin(), indices.end());
+    // `requires` is a compile-time check: if the underlying vocabulary
+    // supports the split-phase interface itself, delegate the reads to it;
+    // otherwise fall back to an eager in-memory lookup.
     if constexpr (requires { underlyingVocabulary_.beginLookup(indices); }) {
       handle->underlyingHandle_ = underlyingVocabulary_.beginLookup(indices);
     } else {
@@ -379,23 +382,25 @@ CPP_template(typename UnderlyingVocabulary,
  private:
   class CompressedLookupHandle : public VocabLookupHandleBase {
    public:
+    const CompressedVocabulary* vocab_ = nullptr;
+    std::vector<size_t> indices_;
+    std::unique_ptr<VocabLookupHandleBase> underlyingHandle_;
+
     VocabBatchLookupResult finish() override {
       auto compressed = underlyingHandle_->finish();
       auto data = std::make_shared<StringVectorVocabBatchLookupData>();
-      data->buffer().reserve(indices_.size());
-      for (size_t i = 0; i < indices_.size(); ++i) {
-        data->buffer().push_back(vocab_->compressionWrapper_.decompress(
-            (*compressed)[i], vocab_->getDecoderIdx(indices_[i])));
-      }
+      data->buffer() = ::ranges::to_vector(
+          ::ranges::views::zip(indices_, *compressed) |
+          ql::views::transform([this](const auto& idxAndWord) {
+            const auto& [idx, word] = idxAndWord;
+            return vocab_->compressionWrapper_.decompress(
+                word, vocab_->getDecoderIdx(idx));
+          }));
       data->views() = ::ranges::to_vector(
           data->buffer() |
           ql::views::transform(ad_utility::staticCast<std::string_view>));
       return StringVectorVocabBatchLookupData::asResult(std::move(data));
     }
-
-    const CompressedVocabulary* vocab_ = nullptr;
-    std::vector<size_t> indices_;
-    std::unique_ptr<VocabLookupHandleBase> underlyingHandle_;
   };
 
   // Get the correct decoder for the given `idx`.

--- a/src/index/vocabulary/CompressedVocabulary.h
+++ b/src/index/vocabulary/CompressedVocabulary.h
@@ -1,9 +1,18 @@
-//  Copyright 2022, University of Freiburg,
-//  Chair of Algorithms and Data Structures.
-//  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+// Copyright 2022 - 2026, The QLever Authors, in particular:
+//
+// 2022 - 2026 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+// 2026        Marvin Stoetzel <stoetzem@email.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+//
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
 
 #ifndef QLEVER_SRC_INDEX_VOCABULARY_COMPRESSEDVOCABULARY_H
 #define QLEVER_SRC_INDEX_VOCABULARY_COMPRESSEDVOCABULARY_H
+
+#include <string>
+#include <vector>
 
 #include "backports/algorithm.h"
 #include "index/ConstantsIndexBuilding.h"
@@ -18,6 +27,7 @@
 #include "util/Serializer/SerializeVector.h"
 #include "util/Serializer/Serializer.h"
 #include "util/TaskQueue.h"
+#include "util/TransparentFunctors.h"
 
 namespace detail {
 
@@ -97,9 +107,27 @@ CPP_template(typename UnderlyingVocabulary,
         });
   }
 
-  //____________________________________________________________________________
+  // Batch-read the compressed words from the underlying vocabulary (which may
+  // itself be on-disk / io_uring), then decompress each word with the decoder
+  // of its block. The result order matches `indices`.
   VocabBatchLookupResult lookupBatch(ql::span<const size_t> indices) const {
-    return ad_utility::vocabulary::sequentialLookupBatch(*this, indices);
+    AD_CONTRACT_CHECK(!indices.empty());
+    auto compressed = underlyingVocabulary_.lookupBatch(indices);
+    AD_CORRECTNESS_CHECK(compressed->size() == indices.size());
+
+    std::vector<std::string> words;
+    words.reserve(indices.size());
+    for (size_t i = 0; i < indices.size(); ++i) {
+      words.push_back(compressionWrapper_.decompress(
+          (*compressed)[i], getDecoderIdx(indices[i])));
+    }
+
+    auto data = std::make_shared<StringVectorVocabBatchLookupData>();
+    data->buffer() = std::move(words);
+    data->views() = ::ranges::to_vector(
+        data->buffer() |
+        ql::views::transform(ad_utility::staticCast<std::string_view>));
+    return StringVectorVocabBatchLookupData::asResult(std::move(data));
   }
 
   //____________________________________________________________________________

--- a/src/index/vocabulary/PolymorphicVocabulary.cpp
+++ b/src/index/vocabulary/PolymorphicVocabulary.cpp
@@ -54,6 +54,29 @@ VocabBatchLookupResult PolymorphicVocabulary::lookupBatch(
 }
 
 // _____________________________________________________________________________
+std::unique_ptr<VocabLookupHandleBase> PolymorphicVocabulary::beginLookup(
+    ql::span<const size_t> indices) const {
+  return std::visit(
+      [&indices](const auto& vocab) -> std::unique_ptr<VocabLookupHandleBase> {
+        if constexpr (requires { vocab.beginLookup(indices); }) {
+          return vocab.beginLookup(indices);
+        } else {
+          auto handle = std::make_unique<EagerVocabLookupHandle>();
+          handle->result_ = vocab.lookupBatch(indices);
+          return handle;
+        }
+      },
+      vocab_);
+}
+
+// _____________________________________________________________________________
+VocabBatchLookupResult PolymorphicVocabulary::finishLookup(
+    std::unique_ptr<VocabLookupHandleBase> handle) const {
+  AD_CONTRACT_CHECK(handle != nullptr);
+  return handle->finish();
+}
+
+// _____________________________________________________________________________
 VocabLookupOutput PolymorphicVocabulary::lookupBatchesStreamed(
     VocabLookupInput input) const {
   return std::visit(

--- a/src/index/vocabulary/PolymorphicVocabulary.h
+++ b/src/index/vocabulary/PolymorphicVocabulary.h
@@ -14,6 +14,7 @@
 #include <absl/strings/str_cat.h>
 #include <absl/strings/str_join.h>
 
+#include <memory>
 #include <variant>
 
 #include "backports/type_traits.h"
@@ -84,6 +85,11 @@ class PolymorphicVocabulary {
 
   //____________________________________________________________________________
   VocabBatchLookupResult lookupBatch(ql::span<const size_t> indices) const;
+
+  std::unique_ptr<VocabLookupHandleBase> beginLookup(
+      ql::span<const size_t> indices) const;
+  VocabBatchLookupResult finishLookup(
+      std::unique_ptr<VocabLookupHandleBase> handle) const;
 
   //____________________________________________________________________________
   VocabLookupOutput lookupBatchesStreamed(VocabLookupInput input) const;

--- a/src/index/vocabulary/UnicodeVocabulary.h
+++ b/src/index/vocabulary/UnicodeVocabulary.h
@@ -5,6 +5,8 @@
 #ifndef QLEVER_SRC_INDEX_VOCABULARY_UNICODEVOCABULARY_H
 #define QLEVER_SRC_INDEX_VOCABULARY_UNICODEVOCABULARY_H
 
+#include <memory>
+
 #include "index/vocabulary/PolymorphicVocabulary.h"
 #include "index/vocabulary/VocabularyTypes.h"
 
@@ -37,6 +39,23 @@ class UnicodeVocabulary {
   //____________________________________________________________________________
   VocabBatchLookupResult lookupBatch(ql::span<const size_t> indices) const {
     return _underlyingVocabulary.lookupBatch(indices);
+  }
+
+  std::unique_ptr<VocabLookupHandleBase> beginLookup(
+      ql::span<const size_t> indices) const {
+    if constexpr (requires { _underlyingVocabulary.beginLookup(indices); }) {
+      return _underlyingVocabulary.beginLookup(indices);
+    } else {
+      auto handle = std::make_unique<EagerVocabLookupHandle>();
+      handle->result_ = _underlyingVocabulary.lookupBatch(indices);
+      return handle;
+    }
+  }
+
+  VocabBatchLookupResult finishLookup(
+      std::unique_ptr<VocabLookupHandleBase> handle) const {
+    AD_CONTRACT_CHECK(handle != nullptr);
+    return handle->finish();
   }
 
   //____________________________________________________________________________

--- a/src/index/vocabulary/UnicodeVocabulary.h
+++ b/src/index/vocabulary/UnicodeVocabulary.h
@@ -1,6 +1,12 @@
-//  Copyright 2022, University of Freiburg,
-//  Chair of Algorithms and Data Structures.
-//  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+// Copyright 2022 - 2026, The QLever Authors, in particular:
+//
+// 2022 - 2026 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+// 2026        Marvin Stoetzel <stoetzem@email.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+//
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
 
 #ifndef QLEVER_SRC_INDEX_VOCABULARY_UNICODEVOCABULARY_H
 #define QLEVER_SRC_INDEX_VOCABULARY_UNICODEVOCABULARY_H

--- a/src/index/vocabulary/Vocabulary.cpp
+++ b/src/index/vocabulary/Vocabulary.cpp
@@ -308,6 +308,28 @@ VocabBatchLookupResult Vocabulary<S, C, I>::lookupBatch(
 
 // _____________________________________________________________________________
 template <typename S, typename C, typename I>
+std::unique_ptr<VocabLookupHandleBase> Vocabulary<S, C, I>::beginLookup(
+    ql::span<const size_t> indices) const {
+  AD_CONTRACT_CHECK(!indices.empty());
+  if constexpr (requires { vocabulary_.beginLookup(indices); }) {
+    return vocabulary_.beginLookup(indices);
+  } else {
+    auto handle = std::make_unique<EagerVocabLookupHandle>();
+    handle->result_ = vocabulary_.lookupBatch(indices);
+    return handle;
+  }
+}
+
+// _____________________________________________________________________________
+template <typename S, typename C, typename I>
+VocabBatchLookupResult Vocabulary<S, C, I>::finishLookup(
+    std::unique_ptr<VocabLookupHandleBase> handle) const {
+  AD_CONTRACT_CHECK(handle != nullptr);
+  return handle->finish();
+}
+
+// _____________________________________________________________________________
+template <typename S, typename C, typename I>
 VocabLookupOutput Vocabulary<S, C, I>::lookupBatchesStreamed(
     VocabLookupInput input) const {
   return vocabulary_.lookupBatchesStreamed(std::move(input));

--- a/src/index/vocabulary/Vocabulary.cpp
+++ b/src/index/vocabulary/Vocabulary.cpp
@@ -1,9 +1,15 @@
-// Copyright 2025, University of Freiburg,
-// Chair of Algorithms and Data Structures.
-// Authors: Björn Buchhold <buchhold@gmail.com>
-//          Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
-//          Hannah Bast <bast@cs.uni-freiburg.de>
-//          Christoph Ullinger <ullingec@cs.uni-freiburg.de>
+// Copyright 2025 - 2026, The QLever Authors, in particular:
+//
+// 2025 - 2026 Björn Buchhold <buchhold@gmail.com>, UFR
+// 2025 - 2026 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+// 2025 - 2026 Hannah Bast <bast@cs.uni-freiburg.de>, UFR
+// 2025 - 2026 Christoph Ullinger <ullingec@cs.uni-freiburg.de>, UFR
+// 2026        Marvin Stoetzel <stoetzem@email.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+//
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
 
 #include "index/vocabulary/Vocabulary.h"
 

--- a/src/index/vocabulary/Vocabulary.h
+++ b/src/index/vocabulary/Vocabulary.h
@@ -1,11 +1,15 @@
-// Copyright 2011 - 2025
-// University of Freiburg
-// Chair of Algorithms and Data Structures
+// Copyright 2011 - 2026, The QLever Authors, in particular:
 //
-// Authors: Björn Buchhold <buchhold@gmail.com>
-//          Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
-//          Hannah Bast <bast@cs.uni-freiburg.de>
-//          Christoph Ullinger <ullingec@cs.uni-freiburg.de>
+// 2011 - 2026 Björn Buchhold <buchhold@gmail.com>, UFR
+// 2011 - 2026 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+// 2011 - 2026 Hannah Bast <bast@cs.uni-freiburg.de>, UFR
+// 2011 - 2026 Christoph Ullinger <ullingec@cs.uni-freiburg.de>, UFR
+// 2026        Marvin Stoetzel <stoetzem@email.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+//
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
 
 #ifndef QLEVER_SRC_INDEX_VOCABULARY_VOCABULARY_H
 #define QLEVER_SRC_INDEX_VOCABULARY_VOCABULARY_H
@@ -131,6 +135,10 @@ class Vocabulary {
   // Batch lookup: look up multiple indices at once and return their words.
   VocabBatchLookupResult lookupBatch(ql::span<const size_t> indices) const;
 
+  // Split-phase variant of `lookupBatch`. `beginLookup` submits the reads for
+  // `indices` without blocking and returns a handle; `finishLookup` blocks
+  // until those reads have completed and returns the resolved words. This lets
+  // callers overlap vocabulary I/O with their own CPU work.
   std::unique_ptr<VocabLookupHandleBase> beginLookup(
       ql::span<const size_t> indices) const;
   VocabBatchLookupResult finishLookup(

--- a/src/index/vocabulary/Vocabulary.h
+++ b/src/index/vocabulary/Vocabulary.h
@@ -11,6 +11,7 @@
 #define QLEVER_SRC_INDEX_VOCABULARY_VOCABULARY_H
 
 #include <cassert>
+#include <memory>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -129,6 +130,11 @@ class Vocabulary {
 
   // Batch lookup: look up multiple indices at once and return their words.
   VocabBatchLookupResult lookupBatch(ql::span<const size_t> indices) const;
+
+  std::unique_ptr<VocabLookupHandleBase> beginLookup(
+      ql::span<const size_t> indices) const;
+  VocabBatchLookupResult finishLookup(
+      std::unique_ptr<VocabLookupHandleBase> handle) const;
 
   // Streaming variant of batch lookup.
   VocabLookupOutput lookupBatchesStreamed(VocabLookupInput input) const;

--- a/src/index/vocabulary/VocabularyInternalExternal.cpp
+++ b/src/index/vocabulary/VocabularyInternalExternal.cpp
@@ -28,38 +28,61 @@ std::string VocabularyInternalExternal::operator[](uint64_t i) const {
 // _____________________________________________________________________________
 VocabBatchLookupResult VocabularyInternalExternal::lookupBatch(
     ql::span<const size_t> indices) const {
+  return finishLookup(beginLookup(indices));
+}
+
+// _____________________________________________________________________________
+std::unique_ptr<VocabLookupHandleBase> VocabularyInternalExternal::beginLookup(
+    ql::span<const size_t> indices) const {
   AD_CONTRACT_CHECK(!indices.empty());
-
-  std::vector<std::string> words(indices.size());
-  std::vector<size_t> diskIndices;
-  std::vector<size_t> diskSlots;
-  diskIndices.reserve(indices.size());
-  diskSlots.reserve(indices.size());
-
-  for (size_t i = 0; i < indices.size(); ++i) {
-    auto fromInternal = internalVocab_[indices[i]];
+  auto handle = std::make_unique<MixedLookupHandle>();
+  handle->vocab_ = this;
+  handle->numIndices_ = indices.size();
+  std::vector<size_t> externalIndices;
+  externalIndices.reserve(indices.size());
+  handle->internalWords_.reserve(indices.size());
+  handle->internalPositions_.reserve(indices.size());
+  handle->externalPositions_.reserve(indices.size());
+  for (size_t pos = 0; pos < indices.size(); ++pos) {
+    auto fromInternal = internalVocab_[indices[pos]];
     if (fromInternal.has_value()) {
-      words[i] = std::string{fromInternal.value()};
+      handle->internalWords_.emplace_back(*fromInternal);
+      handle->internalPositions_.push_back(pos);
     } else {
-      diskSlots.push_back(i);
-      diskIndices.push_back(indices[i]);
+      externalIndices.push_back(indices[pos]);
+      handle->externalPositions_.push_back(pos);
     }
   }
-
-  if (!diskIndices.empty()) {
-    auto disk = externalVocab_.lookupBatch(diskIndices);
-    AD_CORRECTNESS_CHECK(disk->size() == diskIndices.size());
-    for (size_t k = 0; k < diskSlots.size(); ++k) {
-      words[diskSlots[k]] = std::string{(*disk)[k]};
-    }
+  if (!externalIndices.empty()) {
+    handle->externalHandle_ = externalVocab_.beginLookup(externalIndices);
   }
+  return handle;
+}
 
-  auto data = std::make_shared<StringVectorVocabBatchLookupData>();
-  data->buffer() = std::move(words);
-  data->views() = ::ranges::to_vector(
-      data->buffer() |
-      ql::views::transform(ad_utility::staticCast<std::string_view>));
-  return StringVectorVocabBatchLookupData::asResult(std::move(data));
+// _____________________________________________________________________________
+VocabBatchLookupResult VocabularyInternalExternal::finishLookup(
+    std::unique_ptr<VocabLookupHandleBase> handleBase) const {
+  auto* handle = static_cast<MixedLookupHandle*>(handleBase.get());
+  AD_CONTRACT_CHECK(handle != nullptr && handle->vocab_ == this);
+  return handle->finish();
+}
+
+// _____________________________________________________________________________
+VocabBatchLookupResult VocabularyInternalExternal::MixedLookupHandle::finish() {
+  auto data = std::make_shared<MixedVocabBatchLookupData>();
+  data->internalWords_ = std::move(internalWords_);
+  data->views_.resize(numIndices_);
+  if (externalHandle_) {
+    data->diskResult_ =
+        vocab_->externalVocab_.finishLookup(std::move(externalHandle_));
+  }
+  for (size_t k = 0; k < internalPositions_.size(); ++k) {
+    data->views_[internalPositions_[k]] = data->internalWords_[k];
+  }
+  for (size_t k = 0; k < externalPositions_.size(); ++k) {
+    data->views_[externalPositions_[k]] = (*data->diskResult_)[k];
+  }
+  return MixedVocabBatchLookupData::asResult(std::move(data));
 }
 
 // _____________________________________________________________________________

--- a/src/index/vocabulary/VocabularyInternalExternal.cpp
+++ b/src/index/vocabulary/VocabularyInternalExternal.cpp
@@ -38,24 +38,31 @@ std::unique_ptr<VocabLookupHandleBase> VocabularyInternalExternal::beginLookup(
   auto handle = std::make_unique<MixedLookupHandle>();
   handle->vocab_ = this;
   handle->numIndices_ = indices.size();
+
   std::vector<size_t> externalIndices;
   externalIndices.reserve(indices.size());
   handle->internalWords_.reserve(indices.size());
   handle->internalPositions_.reserve(indices.size());
   handle->externalPositions_.reserve(indices.size());
-  for (size_t pos = 0; pos < indices.size(); ++pos) {
-    auto fromInternal = internalVocab_[indices[pos]];
+
+  // Classify each index: RAM hits are resolved immediately, disk misses are
+  // collected into `externalIndices` for one batched on-disk lookup.
+  for (auto [pos, idx] : ::ranges::views::enumerate(indices)) {
+    auto fromInternal = internalVocab_[idx];
     if (fromInternal.has_value()) {
       handle->internalWords_.emplace_back(*fromInternal);
       handle->internalPositions_.push_back(pos);
     } else {
-      externalIndices.push_back(indices[pos]);
+      externalIndices.push_back(idx);
       handle->externalPositions_.push_back(pos);
     }
   }
+
+  // Submit the reads for all disk misses in one non-blocking `beginLookup`.
   if (!externalIndices.empty()) {
     handle->externalHandle_ = externalVocab_.beginLookup(externalIndices);
   }
+
   return handle;
 }
 
@@ -75,12 +82,14 @@ VocabBatchLookupResult VocabularyInternalExternal::MixedLookupHandle::finish() {
   if (externalHandle_) {
     data->diskResult_ =
         vocab_->externalVocab_.finishLookup(std::move(externalHandle_));
+    for (auto [position, word] :
+         ::ranges::views::zip(externalPositions_, *data->diskResult_)) {
+      data->views_[position] = word;
+    }
   }
-  for (size_t k = 0; k < internalPositions_.size(); ++k) {
-    data->views_[internalPositions_[k]] = data->internalWords_[k];
-  }
-  for (size_t k = 0; k < externalPositions_.size(); ++k) {
-    data->views_[externalPositions_[k]] = (*data->diskResult_)[k];
+  for (auto [position, word] :
+       ::ranges::views::zip(internalPositions_, data->internalWords_)) {
+    data->views_[position] = word;
   }
   return MixedVocabBatchLookupData::asResult(std::move(data));
 }

--- a/src/index/vocabulary/VocabularyInternalExternal.cpp
+++ b/src/index/vocabulary/VocabularyInternalExternal.cpp
@@ -1,8 +1,20 @@
-// Copyright 2024, University of Freiburg,
-// Chair of Algorithms and Data Structures.
-// Author: Johannes Kalmbach<joka921> (kalmbach@cs.uni-freiburg.de)
+// Copyright 2024 - 2026, The QLever Authors, in particular:
+//
+// 2024 - 2026 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+// 2026        Marvin Stoetzel <stoetzem@email.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+//
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
 
 #include "index/vocabulary/VocabularyInternalExternal.h"
+
+#include <string>
+#include <vector>
+
+#include "backports/algorithm.h"
+#include "util/TransparentFunctors.h"
 
 // _____________________________________________________________________________
 std::string VocabularyInternalExternal::operator[](uint64_t i) const {
@@ -11,6 +23,43 @@ std::string VocabularyInternalExternal::operator[](uint64_t i) const {
     return std::string{fromInternal.value()};
   }
   return externalVocab_[i];
+}
+
+// _____________________________________________________________________________
+VocabBatchLookupResult VocabularyInternalExternal::lookupBatch(
+    ql::span<const size_t> indices) const {
+  AD_CONTRACT_CHECK(!indices.empty());
+
+  std::vector<std::string> words(indices.size());
+  std::vector<size_t> diskIndices;
+  std::vector<size_t> diskSlots;
+  diskIndices.reserve(indices.size());
+  diskSlots.reserve(indices.size());
+
+  for (size_t i = 0; i < indices.size(); ++i) {
+    auto fromInternal = internalVocab_[indices[i]];
+    if (fromInternal.has_value()) {
+      words[i] = std::string{fromInternal.value()};
+    } else {
+      diskSlots.push_back(i);
+      diskIndices.push_back(indices[i]);
+    }
+  }
+
+  if (!diskIndices.empty()) {
+    auto disk = externalVocab_.lookupBatch(diskIndices);
+    AD_CORRECTNESS_CHECK(disk->size() == diskIndices.size());
+    for (size_t k = 0; k < diskSlots.size(); ++k) {
+      words[diskSlots[k]] = std::string{(*disk)[k]};
+    }
+  }
+
+  auto data = std::make_shared<StringVectorVocabBatchLookupData>();
+  data->buffer() = std::move(words);
+  data->views() = ::ranges::to_vector(
+      data->buffer() |
+      ql::views::transform(ad_utility::staticCast<std::string_view>));
+  return StringVectorVocabBatchLookupData::asResult(std::move(data));
 }
 
 // _____________________________________________________________________________

--- a/src/index/vocabulary/VocabularyInternalExternal.h
+++ b/src/index/vocabulary/VocabularyInternalExternal.h
@@ -1,6 +1,12 @@
-// Copyright 2024, University of Freiburg,
-// Chair of Algorithms and Data Structures.
-// Author: Johannes Kalmbach<joka921> (kalmbach@cs.uni-freiburg.de)
+// Copyright 2024 - 2026, The QLever Authors, in particular:
+//
+// 2024 - 2026 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+// 2026        Marvin Stoetzel <stoetzem@email.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+//
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
 
 #ifndef QLEVER_SRC_INDEX_VOCABULARY_VOCABULARYINTERNALEXTERNAL_H
 #define QLEVER_SRC_INDEX_VOCABULARY_VOCABULARYINTERNALEXTERNAL_H
@@ -54,10 +60,10 @@ class VocabularyInternalExternal {
   // vocabulary.
   auto scanAll() const { return externalVocab_.scanAll(); }
 
-  //____________________________________________________________________________
-  VocabBatchLookupResult lookupBatch(ql::span<const size_t> indices) const {
-    return ad_utility::vocabulary::sequentialLookupBatch(*this, indices);
-  }
+  // Resolve `indices` in request order. Words present in `internalVocab_` are
+  // taken from RAM. The remaining indices are resolved in one
+  // `externalVocab_.lookupBatch` call (the on-disk / io_uring path).
+  VocabBatchLookupResult lookupBatch(ql::span<const size_t> indices) const;
 
   //____________________________________________________________________________
   VocabLookupOutput lookupBatchesStreamed(VocabLookupInput input) const {

--- a/src/index/vocabulary/VocabularyInternalExternal.h
+++ b/src/index/vocabulary/VocabularyInternalExternal.h
@@ -11,8 +11,10 @@
 #ifndef QLEVER_SRC_INDEX_VOCABULARY_VOCABULARYINTERNALEXTERNAL_H
 #define QLEVER_SRC_INDEX_VOCABULARY_VOCABULARYINTERNALEXTERNAL_H
 
+#include <memory>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include "index/vocabulary/VocabularyInMemoryBinSearch.h"
 #include "index/vocabulary/VocabularyOnDisk.h"
@@ -64,6 +66,14 @@ class VocabularyInternalExternal {
   // taken from RAM. The remaining indices are resolved in one
   // `externalVocab_.lookupBatch` call (the on-disk / io_uring path).
   VocabBatchLookupResult lookupBatch(ql::span<const size_t> indices) const;
+
+  // Split-phase variant: RAM-cached indices are resolved immediately; the
+  // rest are submitted to `externalVocab_.beginLookup` without blocking.
+  std::unique_ptr<VocabLookupHandleBase> beginLookup(
+      ql::span<const size_t> indices) const;
+
+  VocabBatchLookupResult finishLookup(
+      std::unique_ptr<VocabLookupHandleBase> handle) const;
 
   //____________________________________________________________________________
   VocabLookupOutput lookupBatchesStreamed(VocabLookupInput input) const {
@@ -168,6 +178,18 @@ class VocabularyInternalExternal {
   }
 
  private:
+  class MixedLookupHandle : public VocabLookupHandleBase {
+   public:
+    VocabBatchLookupResult finish() override;
+
+    const VocabularyInternalExternal* vocab_ = nullptr;
+    std::unique_ptr<VocabLookupHandleBase> externalHandle_;
+    std::vector<std::string> internalWords_;
+    std::vector<size_t> internalPositions_;
+    std::vector<size_t> externalPositions_;
+    size_t numIndices_ = 0;
+  };
+
   // The common implementation of `lower_bound`, `upper_bound`,
   // `lower_bound_iterator`, and `upper_bound_iterator`. The `boundFunction`
   // must be a lambda, that calls the corresponding function (e.g.

--- a/src/index/vocabulary/VocabularyInternalExternal.h
+++ b/src/index/vocabulary/VocabularyInternalExternal.h
@@ -64,7 +64,7 @@ class VocabularyInternalExternal {
 
   // Resolve `indices` in request order. Words present in `internalVocab_` are
   // taken from RAM. The remaining indices are resolved in one
-  // `externalVocab_.lookupBatch` call (the on-disk / io_uring path).
+  // `externalVocab_.lookupBatch` call (the on-disk path).
   VocabBatchLookupResult lookupBatch(ql::span<const size_t> indices) const;
 
   // Split-phase variant: RAM-cached indices are resolved immediately; the

--- a/src/index/vocabulary/VocabularyOnDisk.cpp
+++ b/src/index/vocabulary/VocabularyOnDisk.cpp
@@ -225,7 +225,7 @@ std::unique_ptr<VocabLookupHandleBase> VocabularyOnDisk::beginLookup(
   handle->offsetBatch_ = handle->manager_->addBatch(offsetsFile_.fd(), sizes,
                                                     fileOffsets, targets);
 
-  returnManagerOnThrow.release();
+  std::move(returnManagerOnThrow).Cancel();
   return handle;
 }
 

--- a/src/index/vocabulary/VocabularyOnDisk.cpp
+++ b/src/index/vocabulary/VocabularyOnDisk.cpp
@@ -1,6 +1,12 @@
-// Copyright 2022, University of Freiburg,
-// Chair of Algorithms and Data Structures.
-// Author: Johannes Kalmbach <johannes.kalmbach@gmail.com>
+// Copyright 2022 - 2026, The QLever Authors, in particular:
+//
+// 2022 - 2026 Johannes Kalmbach <johannes.kalmbach@gmail.com>, UFR
+// 2026        Marvin Stoetzel <stoetzem@email.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+//
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
 
 #include "index/vocabulary/VocabularyOnDisk.h"
 

--- a/src/index/vocabulary/VocabularyOnDisk.cpp
+++ b/src/index/vocabulary/VocabularyOnDisk.cpp
@@ -156,28 +156,6 @@ VocabularyScanRange VocabularyOnDisk::scanAll() const {
 }
 
 // _____________________________________________________________________________
-std::vector<VocabularyOnDisk::OffsetPair> VocabularyOnDisk::readOffsetPairs(
-    ad_utility::BatchManagerBase& manager,
-    ql::span<const size_t> indices) const {
-  // For each requested index `i`, read its offset together with the next offset
-  // (which bounds the string) as one 16-byte pair from `.offsets`.
-  const size_t numIndices = indices.size();
-  std::vector<OffsetPair> offsetPairs(numIndices);
-  std::vector<size_t> sizes(numIndices, sizeof(OffsetPair));
-  std::vector<uint64_t> fileOffsets(numIndices);
-  std::vector<char*> targets(numIndices);
-  for (auto&& [fileOffset, index, target, offsetPair] :
-       ::ranges::views::zip(fileOffsets, indices, targets, offsetPairs)) {
-    AD_CONTRACT_CHECK(index < size());
-    fileOffset = index * sizeof(uint64_t);
-    target = reinterpret_cast<char*>(&offsetPair);
-  }
-  manager.wait(
-      manager.addBatch(offsetsFile_.fd(), sizes, fileOffsets, targets));
-  return offsetPairs;
-}
-
-// _____________________________________________________________________________
 VocabBatchLookupResult VocabularyOnDisk::readStrings(
     ad_utility::BatchManagerBase& manager,
     ql::span<const OffsetPair> offsetPairs) const {
@@ -210,23 +188,98 @@ VocabBatchLookupResult VocabularyOnDisk::readStrings(
 }
 
 // _____________________________________________________________________________
-VocabBatchLookupResult VocabularyOnDisk::lookupBatch(
+std::unique_ptr<VocabLookupHandleBase> VocabularyOnDisk::beginLookup(
     ql::span<const size_t> indices) const {
   AD_CONTRACT_CHECK(!indices.empty());
 
   auto manager = ioManagers_->pop().value();
   // Return the `manager` to the pool on every exit path (including exceptions,
-  // e.g. an out-of-range index in phase 1), so we never leak an `IoManager`
-  // (and its io_uring buffers) out of the pool.
-  absl::Cleanup returnManager{[this, &manager]() {
+  // e.g. an out-of-range index), so we never leak an `IoManager` (and its
+  // io_uring buffers) out of the pool.
+  absl::Cleanup returnManagerOnThrow{[this, &manager]() {
     ad_utility::terminateIfThrows(
         [this, &manager]() { ioManagers_->push(std::move(manager)); },
         "returning the `IoManager` to the pool in "
-        "`VocabularyOnDisk::lookupBatch`");
+        "`VocabularyOnDisk::beginLookup`");
   }};
 
-  auto offsetPairs = readOffsetPairs(*manager, indices);
-  return readStrings(*manager, offsetPairs);
+  auto handle = std::make_unique<LookupHandle>();
+  handle->vocab_ = this;
+  handle->indices_.assign(indices.begin(), indices.end());
+  handle->manager_ = std::move(manager);
+
+  // Submit the offset reads (Phase 1) without waiting for them: the caller
+  // decides when to block (in `finishLookup`), which is what allows the reads
+  // of the next batch to be in flight while the current batch is consumed.
+  const size_t numIndices = handle->indices_.size();
+  handle->offsetPairs_.resize(numIndices);
+  std::vector sizes(numIndices, sizeof(OffsetPair));
+  std::vector<uint64_t> fileOffsets(numIndices);
+  std::vector<char*> targets(numIndices);
+  for (auto&& [fileOffset, index, target, offsetPair] : ::ranges::views::zip(
+           fileOffsets, handle->indices_, targets, handle->offsetPairs_)) {
+    AD_CONTRACT_CHECK(index < size());
+    fileOffset = index * sizeof(uint64_t);
+    target = reinterpret_cast<char*>(&offsetPair);
+  }
+  handle->offsetBatch_ = handle->manager_->addBatch(offsetsFile_.fd(), sizes,
+                                                    fileOffsets, targets);
+
+  returnManagerOnThrow.release();
+  return handle;
+}
+
+// _____________________________________________________________________________
+VocabBatchLookupResult VocabularyOnDisk::finishLookup(
+    std::unique_ptr<VocabLookupHandleBase> handleBase) const {
+  auto* handle = static_cast<LookupHandle*>(handleBase.get());
+  AD_CONTRACT_CHECK(handle != nullptr && handle->vocab_ == this);
+  return handle->finish();
+}
+
+// _____________________________________________________________________________
+VocabBatchLookupResult VocabularyOnDisk::LookupHandle::finish() {
+  // Complete the lookup and hand the `manager` back to the pool on every exit
+  // path (including exceptions, e.g. an I/O error while waiting). The handle
+  // itself (and not `VocabularyOnDisk::finishLookup`) owns the return, because
+  // wrapping vocabularies (e.g. `CompressedVocabulary`) complete the lookup
+  // through the type-erased `VocabLookupHandleBase` interface, where the
+  // concrete `VocabularyOnDisk::finishLookup` cannot be called.
+  absl::Cleanup returnManager{[this]() {
+    ad_utility::terminateIfThrows([this]() { returnManagerToPool(); },
+                                  "returning the `IoManager` to the pool in "
+                                  "`VocabularyOnDisk::LookupHandle::finish`");
+  }};
+  // Wait for the offset reads submitted by `beginLookup`, then read the string
+  // data (Phase 2) and return it.
+  manager_->wait(offsetBatch_);
+  return vocab_->readStrings(*manager_, offsetPairs_);
+}
+
+// _____________________________________________________________________________
+VocabularyOnDisk::LookupHandle::~LookupHandle() {
+  // If `finish` was never called (e.g. an exception was thrown between
+  // `beginLookup` and `finishLookup`), return the `manager` to the pool so the
+  // pool does not leak managers out of its `NUM_VOCAB_BATCH_IO_MANAGERS`
+  // budget. After a successful `finish`, `manager_` is null and this is a
+  // no-op.
+  if (manager_) {
+    ad_utility::terminateIfThrows(
+        [this]() { returnManagerToPool(); },
+        "returning the `IoManager` to the pool in the destructor of "
+        "`VocabularyOnDisk::LookupHandle`");
+  }
+}
+
+// _____________________________________________________________________________
+void VocabularyOnDisk::LookupHandle::returnManagerToPool() {
+  vocab_->ioManagers_->push(std::move(manager_));
+}
+
+// _____________________________________________________________________________
+VocabBatchLookupResult VocabularyOnDisk::lookupBatch(
+    ql::span<const size_t> indices) const {
+  return finishLookup(beginLookup(indices));
 }
 
 // _____________________________________________________________________________

--- a/src/index/vocabulary/VocabularyOnDisk.h
+++ b/src/index/vocabulary/VocabularyOnDisk.h
@@ -1,6 +1,12 @@
-// Copyright 2016, University of Freiburg,
-// Chair of Algorithms and Data Structures.
-// Authors: Johannes Kalmbach <johannes.kalmbach@gmail.com>
+// Copyright 2016 - 2026, The QLever Authors, in particular:
+//
+// 2016 - 2026 Johannes Kalmbach <johannes.kalmbach@gmail.com>, UFR
+// 2026        Marvin Stoetzel <stoetzem@email.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+//
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
 
 #ifndef QLEVER_SRC_INDEX_VOCABULARYONDISK_H
 #define QLEVER_SRC_INDEX_VOCABULARYONDISK_H

--- a/src/index/vocabulary/VocabularyOnDisk.h
+++ b/src/index/vocabulary/VocabularyOnDisk.h
@@ -96,6 +96,19 @@ class VocabularyOnDisk : public VocabularyBinarySearchMixin<VocabularyOnDisk> {
   //____________________________________________________________________________
   VocabBatchLookupResult lookupBatch(ql::span<const size_t> indices) const;
 
+  // Split-phase variant of `lookupBatch`: `beginLookup` submits the offset
+  // reads and returns a handle immediately (without blocking), `finishLookup`
+  // blocks until the lookup is complete and returns the resolved strings. This
+  // lets a caller overlap the I/O of one batch with the CPU work of another
+  // (see the depth-2 pipeline in the CONSTRUCT export path).
+  std::unique_ptr<VocabLookupHandleBase> beginLookup(
+      ql::span<const size_t> indices) const;
+
+  // Complete a lookup started by `beginLookup`. `handle` must be the handle
+  // returned by `beginLookup` on this vocabulary.
+  VocabBatchLookupResult finishLookup(
+      std::unique_ptr<VocabLookupHandleBase> handle) const;
+
   //____________________________________________________________________________
   VocabLookupOutput lookupBatchesStreamed(
       VocabLookupInput rangeOfIndexBatches) const;
@@ -175,10 +188,35 @@ class VocabularyOnDisk : public VocabularyBinarySearchMixin<VocabularyOnDisk> {
     uint64_t nextOffset_;
   };
 
-  // Phase 1 of `lookupBatch`: for each requested index, read its `OffsetPair`
-  // (16 bytes) from the `.offsets` file in a single batched read via `manager`.
-  std::vector<OffsetPair> readOffsetPairs(ad_utility::BatchManagerBase& manager,
-                                          ql::span<const size_t> indices) const;
+  // The state of a split-phase lookup: owns the pooled I/O manager (removed
+  // from the pool by `beginLookup`) and the submitted offset-read batch until
+  // `finish` completes the lookup and returns the manager to the pool.
+  class LookupHandle : public VocabLookupHandleBase {
+   public:
+    // Requires `vocab_`, `manager_`, `indices_`, `offsetBatch_` and
+    // `offsetPairs_` to be set by `VocabularyOnDisk::beginLookup`.
+    VocabBatchLookupResult finish() override;
+
+    // Return the `manager_` to the pool if `finish` was never called (e.g. an
+    // exception was thrown between `beginLookup` and `finishLookup`), so a
+    // manager is never leaked out of the pool.
+    ~LookupHandle() override;
+
+    const VocabularyOnDisk* vocab_ = nullptr;
+    std::unique_ptr<ad_utility::BatchManagerBase> manager_;
+    // The requested indices, owned so the offset reads can be completed after
+    // the caller's span has gone out of scope.
+    std::vector<size_t> indices_;
+    // The batched offset read submitted by `beginLookup`.
+    ad_utility::BatchManagerBase::BatchHandle offsetBatch_ = 0;
+    // The target buffers of the submitted offset read.
+    std::vector<OffsetPair> offsetPairs_;
+
+   private:
+    // Hand the `manager_` back to the pool. Used by `finish` and the
+    // destructor; the handle owns the manager until one of them runs.
+    void returnManagerToPool();
+  };
 
   // Phase 2 of `lookupBatch`: given the `offsetPairs` from phase 1, read the
   // string data from `file_` into one contiguous buffer in a single batched

--- a/src/index/vocabulary/VocabularyTypes.h
+++ b/src/index/vocabulary/VocabularyTypes.h
@@ -239,7 +239,7 @@ VocabLookupOutput lookupBatchesStreamed(const Vocab& vocab,
 // caller's consumption of the previous result. When the caller consumes the
 // yielded result, the device serves the next batch's reads.
 //
-// The generator's `details()` (see `cppcoro::setDetails`) exposes the
+// The generator's `details()` (see `cppcoro::SetDetails`) exposes the
 // `unique_ptr<VocabLookupHandleBase>` of the batch whose reads are currently
 // in flight, i.e. the batch after the one whose result was just yielded. A
 // caller that wants to complete that lookup itself (e.g. right before its own
@@ -270,10 +270,10 @@ lookupBatchesStreamedDepth2(const Vocab& vocab, VocabLookupInput input) {
     // The handle is exposed via the generator's `details()` for callers that
     // want to complete it themselves.
     if (it != end) {
-      co_await cppcoro::setDetails{vocab.beginLookup(*it)};
+      co_await cppcoro::SetDetails{vocab.beginLookup(*it)};
       ++it;
     } else {
-      co_await cppcoro::setDetails{std::unique_ptr<VocabLookupHandleBase>{}};
+      co_await cppcoro::SetDetails{std::unique_ptr<VocabLookupHandleBase>{}};
     }
     // Block until the current batch's reads have completed (they were
     // submitted one iteration earlier). The next batch's reads are already in

--- a/src/index/vocabulary/VocabularyTypes.h
+++ b/src/index/vocabulary/VocabularyTypes.h
@@ -1,6 +1,12 @@
-//  Copyright 2022, University of Freiburg,
-//  Chair of Algorithms and Data Structures.
-//  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+// Copyright 2022 - 2026, The QLever Authors, in particular:
+//
+// 2022 - 2026 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+// 2026        Marvin Stoetzel <stoetzem@email.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+//
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
 
 #ifndef QLEVER_SRC_INDEX_VOCABULARY_VOCABULARYTYPES_H
 #define QLEVER_SRC_INDEX_VOCABULARY_VOCABULARYTYPES_H
@@ -185,7 +191,7 @@ struct EagerVocabLookupHandle : VocabLookupHandleBase {
 };
 
 // Generic sequential fallback implementations of the batch-lookup interface,
-// used by all vocabularies that do not provide a specialized (e.g. io_uring)
+// used by all vocabularies that do not provide a specialized
 // implementation. They simply loop over the indices and issue the ordinary
 // single-word `operator[]` lookups one after another.
 namespace ad_utility::vocabulary {
@@ -270,10 +276,10 @@ lookupBatchesStreamedDepth2(const Vocab& vocab, VocabLookupInput input) {
     // The handle is exposed via the generator's `details()` for callers that
     // want to complete it themselves.
     if (it != end) {
-      co_await cppcoro::SetDetails{vocab.beginLookup(*it)};
+      co_await cppcoro::SetDetails<std::unique_ptr<VocabLookupHandleBase>>{vocab.beginLookup(*it)};
       ++it;
     } else {
-      co_await cppcoro::SetDetails{std::unique_ptr<VocabLookupHandleBase>{}};
+      co_await cppcoro::SetDetails<std::unique_ptr<VocabLookupHandleBase>>{std::unique_ptr<VocabLookupHandleBase>{}};
     }
     // Block until the current batch's reads have completed (they were
     // submitted one iteration earlier). The next batch's reads are already in

--- a/src/index/vocabulary/VocabularyTypes.h
+++ b/src/index/vocabulary/VocabularyTypes.h
@@ -19,6 +19,7 @@
 #include "backports/span.h"
 #include "util/Exception.h"
 #include "util/ExceptionHandling.h"
+#include "util/Generator.h"
 #include "util/Iterators.h"
 #include "util/TransparentFunctors.h"
 #include "util/Views.h"
@@ -225,6 +226,64 @@ VocabLookupOutput lookupBatchesStreamed(const Vocab& vocab,
                            ql::views::transform([&vocab](const auto& indices) {
                              return vocab.lookupBatch(indices);
                            })};
+}
+
+// A depth-2 pipeline over a stream of batches, built from the split-phase
+// lookup interface (`beginLookup`/`finishLookup`): while the caller consumes
+// the result of batch `i`, the reads of batch `i + 1` are already in flight.
+//
+// Iteration protocol: pulling the next element from the returned generator
+// (i) submits the lookup of the batch after the one whose result is about to
+// be produced, and (ii) blocks on the current batch, whose reads were
+// submitted one iteration earlier and have therefore been in flight during the
+// caller's consumption of the previous result. When the caller consumes the
+// yielded result, the device serves the next batch's reads.
+//
+// The generator's `details()` (see `cppcoro::setDetails`) exposes the
+// `unique_ptr<VocabLookupHandleBase>` of the batch whose reads are currently
+// in flight, i.e. the batch after the one whose result was just yielded. A
+// caller that wants to complete that lookup itself (e.g. right before its own
+// CPU-heavy phase) can take it via
+// `vocab.finishLookup(std::move(generator.details()))`; the generator then
+// ends on its next resume. A caller that never touches `details()` works with
+// a plain `for (auto&& result : generator)` loop and the generator completes
+// every lookup itself.
+//
+// The referenced `vocab` must outlive the returned generator.
+template <typename Vocab>
+cppcoro::generator<VocabBatchLookupResult,
+                   std::unique_ptr<VocabLookupHandleBase>>
+lookupBatchesStreamedDepth2(const Vocab& vocab, VocabLookupInput input) {
+  auto owningInput = ad_utility::OwningView{std::move(input)};
+  auto it = owningInput.begin();
+  const auto end = owningInput.end();
+  if (it == end) {
+    co_return;
+  }
+  // Submit the lookup of the first batch; its reads are in flight while the
+  // caller does its own work before pulling the first result.
+  auto currentHandle = vocab.beginLookup(*it);
+  ++it;
+  while (currentHandle) {
+    // Submit the lookup of the NEXT batch before blocking on the current one,
+    // so the device can serve it while the caller consumes the current result.
+    // The handle is exposed via the generator's `details()` for callers that
+    // want to complete it themselves.
+    if (it != end) {
+      co_await cppcoro::setDetails{vocab.beginLookup(*it)};
+      ++it;
+    } else {
+      co_await cppcoro::setDetails{std::unique_ptr<VocabLookupHandleBase>{}};
+    }
+    // Block until the current batch's reads have completed (they were
+    // submitted one iteration earlier). The next batch's reads are already in
+    // flight at this point.
+    co_yield vocab.finishLookup(std::move(currentHandle));
+    // Take over the next batch's handle. If the caller has already consumed it
+    // (via `finishLookup(std::move(generator.details()))`), it is null and the
+    // generator ends.
+    currentHandle = std::move(co_await cppcoro::getDetails);
+  }
 }
 
 }  // namespace ad_utility::vocabulary

--- a/src/index/vocabulary/VocabularyTypes.h
+++ b/src/index/vocabulary/VocabularyTypes.h
@@ -276,10 +276,12 @@ lookupBatchesStreamedDepth2(const Vocab& vocab, VocabLookupInput input) {
     // The handle is exposed via the generator's `details()` for callers that
     // want to complete it themselves.
     if (it != end) {
-      co_await cppcoro::SetDetails<std::unique_ptr<VocabLookupHandleBase>>{vocab.beginLookup(*it)};
+      co_await cppcoro::SetDetails<std::unique_ptr<VocabLookupHandleBase>>{
+          vocab.beginLookup(*it)};
       ++it;
     } else {
-      co_await cppcoro::SetDetails<std::unique_ptr<VocabLookupHandleBase>>{std::unique_ptr<VocabLookupHandleBase>{}};
+      co_await cppcoro::SetDetails<std::unique_ptr<VocabLookupHandleBase>>{
+          std::unique_ptr<VocabLookupHandleBase>{}};
     }
     // Block until the current batch's reads have completed (they were
     // submitted one iteration earlier). The next batch's reads are already in

--- a/src/index/vocabulary/VocabularyTypes.h
+++ b/src/index/vocabulary/VocabularyTypes.h
@@ -234,16 +234,19 @@ VocabLookupOutput lookupBatchesStreamed(const Vocab& vocab,
                            })};
 }
 
+#ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
+
 // A depth-2 pipeline over a stream of batches, built from the split-phase
 // lookup interface (`beginLookup`/`finishLookup`): while the caller consumes
 // the result of batch `i`, the reads of batch `i + 1` are already in flight.
 //
 // Iteration protocol: pulling the next element from the returned generator
-// (i) submits the lookup of the batch after the one whose result is about to
-// be produced, and (ii) blocks on the current batch, whose reads were
-// submitted one iteration earlier and have therefore been in flight during the
-// caller's consumption of the previous result. When the caller consumes the
-// yielded result, the device serves the next batch's reads.
+// 1. submits the lookup of the batch after the one whose result is about to
+//    be produced, and
+// 2. blocks on the current batch, whose reads were submitted one iteration
+//    earlier and have therefore been in flight during the caller's
+//    consumption of the previous result. When the caller consumes the
+//    yielded result, the device serves the next batch's reads.
 //
 // The generator's `details()` (see `cppcoro::SetDetails`) exposes the
 // `unique_ptr<VocabLookupHandleBase>` of the batch whose reads are currently
@@ -293,6 +296,8 @@ lookupBatchesStreamedDepth2(const Vocab& vocab, VocabLookupInput input) {
     currentHandle = std::move(co_await cppcoro::getDetails);
   }
 }
+
+#endif  // QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
 
 }  // namespace ad_utility::vocabulary
 

--- a/src/index/vocabulary/VocabularyTypes.h
+++ b/src/index/vocabulary/VocabularyTypes.h
@@ -131,6 +131,58 @@ using VocabularyScanRange = ad_utility::InputRangeTypeErased<IndexAndWord>;
 struct StringVectorVocabBatchLookupData
     : VocabLookupDataCommonBase<std::vector<std::string>> {};
 
+// A vocabulary batch-lookup result that combines words read from disk via a
+// batched read with words copied from an in-RAM vocabulary (used by
+// `VocabularyInternalExternal`, which serves some indices from its RAM-resident
+// internal vocabulary and the rest from the on-disk vocabulary). Owns the disk
+// result (which keeps the disk-read buffer alive) and one `string_view` per
+// looked-up index: the views for the on-disk words point into that buffer, the
+// views for the RAM-resident words point into the owned `internalWords_`
+// copies.
+struct MixedVocabBatchLookupData {
+  // Owns the disk-read buffer that the on-disk words' views point into.
+  VocabBatchLookupResult diskResult_;
+  // Owned copies of the words that were resolved from the in-RAM vocabulary.
+  std::vector<std::string> internalWords_;
+  // One `string_view` per looked-up index, pointing either into
+  // `internalWords_` or into the buffer owned by `diskResult_`.
+  std::vector<std::string_view> views_;
+  // The span over `views_`, populated by `finalize()` and exposed by
+  // `asResult()`.
+  ql::span<std::string_view> span_;
+
+  static VocabBatchLookupResult asResult(
+      std::shared_ptr<MixedVocabBatchLookupData> self) {
+    self->span_ = ql::span<std::string_view>{self->views_};
+    return std::shared_ptr<ql::span<std::string_view>>(std::move(self),
+                                                       &self->span_);
+  }
+};
+
+// Base class for the state of a split-phase vocabulary lookup, as returned by
+// a vocabulary's `beginLookup` and consumed by its `finishLookup`. The
+// concrete vocabulary stores the state it needs (e.g. the pooled I/O manager
+// and the in-flight read batch, for `VocabularyOnDisk`) in a derived class and
+// implements `finish()`, which blocks until all I/O of the lookup has
+// completed and returns the resolved strings.
+class VocabLookupHandleBase {
+ public:
+  virtual ~VocabLookupHandleBase() = default;
+
+  // Block until every read of the lookup has completed and return the resolved
+  // string representations, in the same order as the indices passed to the
+  // corresponding `beginLookup`.
+  [[nodiscard]] virtual VocabBatchLookupResult finish() = 0;
+};
+
+// A split-phase lookup handle for vocabularies whose lookups complete without
+// any I/O (e.g. fully in-memory vocabularies): `beginLookup` performs the full
+// lookup and `finish` just returns the stored result.
+struct EagerVocabLookupHandle : VocabLookupHandleBase {
+  VocabBatchLookupResult finish() override { return result_; }
+  VocabBatchLookupResult result_;
+};
+
 // Generic sequential fallback implementations of the batch-lookup interface,
 // used by all vocabularies that do not provide a specialized (e.g. io_uring)
 // implementation. They simply loop over the indices and issue the ordinary

--- a/src/util/Generator.h
+++ b/src/util/Generator.h
@@ -141,7 +141,7 @@ class generator_promise {
   }
   SetDetailsAwaiter await_transform(SetDetails<Details> details)
       requires hasDetails {
-    return {*this, details};
+    return {*this, std::move(details)};
   }
 
   Details& details() requires hasDetails {

--- a/src/util/IoUringManager.cpp
+++ b/src/util/IoUringManager.cpp
@@ -12,6 +12,7 @@
 
 #include <unistd.h>
 
+#include <array>
 #include <stdexcept>
 
 #include "util/Exception.h"
@@ -152,26 +153,52 @@ void IoUringPolicy::wait(BatchHandle handle) {
   // Drain completions until this batch is gone. `drainOneCqe` erases a batch as
   // soon as its last read completes, so a present entry always still has
   // outstanding reads.
+  //
+  // To amortize the `io_uring_enter` syscalls (the paper's central point),
+  // each blocking wait is followed by consuming ALL completions that are ready
+  // at that point, not just one. When completions arrive in bursts (e.g. the
+  // two-phase reads of a depth-2 pipeline), this replaces one syscall per CQE
+  // with one syscall per burst.
   while (numInFlightReadRequestsPerBatch_.find(handle) !=
          numInFlightReadRequestsPerBatch_.end()) {
-    drainOneCqe();
+    io_uring_cqe* cqe = nullptr;
+    int ret = io_uring_wait_cqe(&ring_, &cqe);
+    if (ret < 0) {
+      AD_THROW("io_uring_wait_cqe failed in IoUringPolicy");
+    }
+    drainAllReadyCqes();
   }
 }
 
 //______________________________________________________________________________
-void ad_utility::IoUringPolicy::drainOneCqe() {
-  // Block until at least one completion queue entry (CQE) is available.
-  io_uring_cqe* cqe = nullptr;
-  int ret = io_uring_wait_cqe(&ring_, &cqe);
-  if (ret < 0) {
-    AD_THROW("io_uring_wait_cqe failed in IoUringPolicy");
+void IoUringPolicy::drainAllReadyCqes() {
+  // Consume every completion that is ready right now. Each CQE is consumed
+  // (advanced) before its result is processed, so a throwing `processCqe`
+  // cannot leave a half-processed CQE in the ring (which would process it a
+  // second time on the next iteration).
+  constexpr size_t MAX_CQES_PER_ITERATION = 64;
+  std::array<io_uring_cqe*, MAX_CQES_PER_ITERATION> cqes;
+  while (true) {
+    const unsigned numReady =
+        io_uring_peek_batch_cqe(&ring_, cqes.data(), MAX_CQES_PER_ITERATION);
+    if (numReady == 0) {
+      break;
+    }
+    for (unsigned i = 0; i < numReady; ++i) {
+      // Recover the read's result (`cqe->res`) and the request id we stored in
+      // the SQE, then consume the CQE so its slot is freed. Do this before any
+      // throw.
+      const int numBytesRead = cqes[i]->res;
+      const uint64_t requestId = io_uring_cqe_get_data64(cqes[i]);
+      io_uring_cq_advance(&ring_, 1);
+      processCqe(numBytesRead, requestId);
+    }
   }
+}
 
-  // Recover the read's result (`cqe->res`) and the request id we stored in the
-  // SQE, then consume the CQE so its slot is freed. Do this before any throw.
-  const int numBytesRead = cqe->res;
-  const uint64_t requestId = io_uring_cqe_get_data64(cqe);
-  io_uring_cqe_seen(&ring_, cqe);
+//______________________________________________________________________________
+void ad_utility::IoUringPolicy::processCqe(int numBytesRead,
+                                           uint64_t requestId) {
   numInFlightReadRequests_--;
 
   // Every reaped CQE corresponds to exactly one in-flight read whose id we
@@ -201,6 +228,23 @@ void ad_utility::IoUringPolicy::drainOneCqe() {
   if (--it->second == 0) {
     numInFlightReadRequestsPerBatch_.erase(it);
   }
+}
+
+//______________________________________________________________________________
+void ad_utility::IoUringPolicy::drainOneCqe() {
+  // Block until at least one completion queue entry (CQE) is available.
+  io_uring_cqe* cqe = nullptr;
+  int ret = io_uring_wait_cqe(&ring_, &cqe);
+  if (ret < 0) {
+    AD_THROW("io_uring_wait_cqe failed in IoUringPolicy");
+  }
+
+  // Recover the read's result (`cqe->res`) and the request id we stored in the
+  // SQE, then consume the CQE so its slot is freed. Do this before any throw.
+  const int numBytesRead = cqe->res;
+  const uint64_t requestId = io_uring_cqe_get_data64(cqe);
+  io_uring_cqe_seen(&ring_, cqe);
+  processCqe(numBytesRead, requestId);
 }
 
 #endif  // QLEVER_HAS_IO_URING

--- a/src/util/IoUringManager.h
+++ b/src/util/IoUringManager.h
@@ -201,11 +201,22 @@ class IoUringPolicy {
 
   // Maps a read's request id to its metadata. An entry is inserted when the
   // read is prepared in `addBatch` and erased when its completion is reaped in
-  // `drainOneCqe`.
+  // `drainOneCqe` / `processCqe`.
   ad_utility::HashMap<uint64_t, InFlightRead> inFlightReadsByRequestId_;
 
   // Wait for one CQE and update the in-flight bookkeeping.
   void drainOneCqe();
+
+  // Consume and process every completion that is ready right now (without
+  // blocking). Used by `wait` to amortize the `io_uring_enter` syscalls over
+  // bursts of completions.
+  void drainAllReadyCqes();
+
+  // Update the in-flight bookkeeping for one completion. `numBytesRead` and
+  // `requestId` must be the completion's `res` and `user_data`, and the
+  // corresponding CQE must already have been consumed from the ring (so a
+  // throwing validation cannot leave it in the ring).
+  void processCqe(int numBytesRead, uint64_t requestId);
 
  public:
   IoUringPolicy(const IoUringPolicy&) = delete;

--- a/test/VocabularyTest.cpp
+++ b/test/VocabularyTest.cpp
@@ -283,6 +283,30 @@ TEST(VocabularyTest, LookupBatchesStreamedEmptyStreamYieldsNothing) {
   EXPECT_EQ(ql::ranges::distance(streamed), 0);
 }
 
+// The depth-2 streamed lookup (`lookupBatchesStreamedDepth2`) must yield, for
+// each batch and in input order, exactly the same results as the eager
+// `lookupBatch` for that batch's indices. The generator additionally exposes
+// the in-flight handle via `details()`, which is exercised by the caller in
+// `idsToStringAndTypeDepth2`; the plain range-for loop used here completes
+// every lookup inside the generator itself.
+#ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
+TEST(VocabularyTest, LookupBatchesStreamedDepth2) {
+  auto v = createExampleVocabulary();
+  std::vector<std::vector<size_t>> batches{{2, 0}, {3}, {1}};
+  // `VocabLookupInput` takes ownership, so keep a copy to compare against.
+  const auto expectedBatches = batches;
+  auto streamed = ad_utility::vocabulary::lookupBatchesStreamedDepth2(
+      *v, VocabLookupInput{std::move(batches)});
+  auto results = ::ranges::to_vector(streamed);
+  ASSERT_EQ(results.size(), expectedBatches.size());
+  for (const auto& [result, indices] :
+       ::ranges::views::zip(results, expectedBatches)) {
+    vocabulary_test::assertLookupResultMatchesVocabularyAtIndices(*v, result,
+                                                                  indices);
+  }
+}
+#endif  // QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
+
 namespace {
 // Write an `RdfsVocabulary` of the given `type` to an aligned buffer via
 // `writeAsZeroCopyBlob`, read it back via `loadFromZeroCopyDeserializer`, and

--- a/test/index/vocabulary/VocabularyInternalExternalTest.cpp
+++ b/test/index/vocabulary/VocabularyInternalExternalTest.cpp
@@ -142,8 +142,10 @@ TEST(VocabularyInternalExternal, BeginFinishLookupMatchesLookupBatch) {
   auto eager = vocab.lookupBatch(indices);
   auto split = vocab.finishLookup(vocab.beginLookup(indices));
   ASSERT_EQ(eager->size(), split->size());
-  for (size_t i = 0; i < eager->size(); ++i) {
-    EXPECT_EQ((*eager)[i], (*split)[i]) << " at requested slot " << i;
+  for (auto [i, expectedAndActual] :
+       ::ranges::views::enumerate(::ranges::views::zip(*eager, *split))) {
+    const auto& [expected, actual] = expectedAndActual;
+    EXPECT_EQ(expected, actual) << " at requested slot " << i;
   }
 }
 

--- a/test/index/vocabulary/VocabularyInternalExternalTest.cpp
+++ b/test/index/vocabulary/VocabularyInternalExternalTest.cpp
@@ -4,6 +4,10 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
+#include <string>
+#include <vector>
+
 #include "./VocabularyTestHelpers.h"
 #include "backports/algorithm.h"
 #include "index/vocabulary/VocabularyInternalExternal.h"
@@ -109,6 +113,19 @@ TEST(VocabularyInternalExternal, AccessOperator) {
   testAccessOperatorForUnorderedVocabulary(createVocabulary("AccessOperator1"));
   testAccessOperatorForUnorderedVocabulary(
       createVocabularyFromDisk("AccessOperator2"));
+}
+
+// `lookupBatch` must match `operator[]` in request order, including cache
+// hits (even `i` in the writer: stored in RAM) and misses (odd `i`: disk
+// only), plus reordered and duplicated indices.
+TEST(VocabularyInternalExternal, LookupBatchMatchesAccessOperator) {
+  const std::vector<std::string> words{"alpha", "beta", "gamma", "delta",
+                                       "epsilon"};
+  auto vocab = createVocabulary("LookupBatch")(words);
+  const std::array<size_t, 7> indices{4, 1, 0, 3, 1, 2, 4};
+  auto result = vocab.lookupBatch(indices);
+  assertLookupResultMatchesVocabularyAtIndices(vocab, result, indices);
+  EXPECT_ANY_THROW(vocab.lookupBatch(ql::span<const size_t>{}));
 }
 
 TEST(VocabularyInternalExternal, EmptyVocabulary) {

--- a/test/index/vocabulary/VocabularyInternalExternalTest.cpp
+++ b/test/index/vocabulary/VocabularyInternalExternalTest.cpp
@@ -1,6 +1,12 @@
-// Copyright 2024, University of Freiburg,
-// Chair of Algorithms and Data Structures.
-// Author: Johannes Kalmbach <johannes.kalmbach@gmail.com>
+// Copyright 2024 - 2026, The QLever Authors, in particular:
+//
+// 2024 - 2026 Johannes Kalmbach <johannes.kalmbach@gmail.com>, UFR
+// 2026        Marvin Stoetzel <stoetzem@email.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+//
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
 
 #include <gtest/gtest.h>
 

--- a/test/index/vocabulary/VocabularyInternalExternalTest.cpp
+++ b/test/index/vocabulary/VocabularyInternalExternalTest.cpp
@@ -128,6 +128,19 @@ TEST(VocabularyInternalExternal, LookupBatchMatchesAccessOperator) {
   EXPECT_ANY_THROW(vocab.lookupBatch(ql::span<const size_t>{}));
 }
 
+TEST(VocabularyInternalExternal, BeginFinishLookupMatchesLookupBatch) {
+  const std::vector<std::string> words{"alpha", "beta", "gamma", "delta",
+                                       "epsilon"};
+  auto vocab = createVocabulary("BeginFinishLookup")(words);
+  const std::array<size_t, 7> indices{4, 1, 0, 3, 1, 2, 4};
+  auto eager = vocab.lookupBatch(indices);
+  auto split = vocab.finishLookup(vocab.beginLookup(indices));
+  ASSERT_EQ(eager->size(), split->size());
+  for (size_t i = 0; i < eager->size(); ++i) {
+    EXPECT_EQ((*eager)[i], (*split)[i]) << " at requested slot " << i;
+  }
+}
+
 TEST(VocabularyInternalExternal, EmptyVocabulary) {
   testEmptyVocabulary(createVocabulary("EmptyVocabulary"));
 }


### PR DESCRIPTION
## WHY

Even after `lookupBatch` reaches `VocabularyOnDisk`, the call still blocks for offset reads and then for string reads before the caller can do any CPU work. CONSTRUCT export has CPU work (non-vocab IDs, escaping) that can overlap those reads.

## WHAT

- `beginLookup` / `finishLookup` on `VocabularyOnDisk`: submit offset reads, return a handle; finish waits, reads strings, returns the manager to the pool.
- The same split on `VocabularyInternalExternal` (RAM hits eager, disk misses in flight) and `CompressedVocabulary` (decompress on finish).
- `PolymorphicVocabulary` / `Vocabulary` / `UnicodeVocabulary` forward the split, or fall back to an eager handle.
- Batched CQE reaping: one wait drains every ready completion.
- `idsToStringAndTypeDepth2` keeps two vocab sub-batches in flight (cap 256 IDs each, so two fit in the default ring).
- CONSTRUCT cache-miss resolution uses the depth-2 helper.

`lookupBatch` is now `finishLookup(beginLookup(...))` on the production types, so existing callers stay correct.

This branch also contains the companion change that makes `lookupBatch` reach the on-disk vocabulary (opened as a separate PR). Merge that first, or take this PR as the combined stack.

## DESIGN DECISIONS

- Handle destructor returns the pooled I/O manager if finish never ran, so an exception between begin and finish cannot leak a manager.
- Sub-batch cap is 256 because this PR does not change ring capacity. Two in-flight batches stay inside 512 slots.
- In-memory vocabulary types stay eager: there is no I/O to overlap.

## EXPECTED PERFORMANCE IMPROVEMENT

CONSTRUCT export can overlap non-vocab CPU work with vocabulary device I/O. The gain appears only when vocabulary I/O is a real fraction of export time (cold cache, working set larger than RAM). On a warm in-RAM index the change should be within noise.