### PR TITLE
Answer COUNT(DISTINCT ?v) over bound-predicate scans from relation metadata

### DIFF
--- a/src/engine/GroupByImpl.cpp
+++ b/src/engine/GroupByImpl.cpp
@@ -828,10 +828,10 @@ std::optional<IdTable> GroupByImpl::computeGroupByForSingleIndexScan() const {
   // `COUNT(DISTINCT ?v)` from the relation metadata as well, see
   // `computeDistinctCountForTwoVariableScan` below.
   bool countIsDistinct = varAndDistinctness.value().isDistinct_;
-  if (countIsDistinct && (indexScan->numVariables() < 2 ||
-                          indexScan->numVariables() > 3 ||
-                          !indexScan->additionalVariables().empty() ||
-                          !indexScan->getLimitOffset().isUnconstrained())) {
+  if (countIsDistinct &&
+      (indexScan->numVariables() < 2 || indexScan->numVariables() > 3 ||
+       !indexScan->additionalVariables().empty() ||
+       !indexScan->getLimitOffset().isUnconstrained())) {
     return std::nullopt;
   }
 
@@ -918,8 +918,7 @@ std::optional<IdTable> GroupByImpl::computeGroupByForSingleIndexScan() const {
 }
 
 // _____________________________________________________________________________
-std::optional<size_t>
-GroupByImpl::computeDistinctCountForTwoVariableScan(
+std::optional<size_t> GroupByImpl::computeDistinctCountForTwoVariableScan(
     const std::shared_ptr<const IndexScan>& indexScan,
     const Variable& countedVariable) const {
   AD_CORRECTNESS_CHECK(indexScan->numVariables() == 2);
@@ -938,9 +937,8 @@ GroupByImpl::computeDistinctCountForTwoVariableScan(
   const auto& locTriples =
       indexScan->permutation().getLocatedTriplesForPermutation(
           locatedTriplesState());
-  if (!locTriples.isEmpty() ||
-      indexScan->permutation().permutationType() ==
-          Permutation::Type::MATERIALIZED_VIEW) {
+  if (!locTriples.isEmpty() || indexScan->permutation().permutationType() ==
+                                   Permutation::Type::MATERIALIZED_VIEW) {
     return std::nullopt;
   }
 
@@ -950,8 +948,7 @@ GroupByImpl::computeDistinctCountForTwoVariableScan(
   // variable is the second entry of the permuted triple; otherwise we need
   // the permutation that swaps the two variable columns.
   bool countedVariableInColumnOne =
-      permutedTriple[1]->isVariable() &&
-      *permutedTriple[1] == countedVariable;
+      permutedTriple[1]->isVariable() && *permutedTriple[1] == countedVariable;
 
   if (countedVariableInColumnOne) {
     // Fast path: the scan's permutation already has the counted variable in

--- a/src/engine/GroupByImpl.cpp
+++ b/src/engine/GroupByImpl.cpp
@@ -823,9 +823,13 @@ std::optional<IdTable> GroupByImpl::computeGroupByForSingleIndexScan() const {
   }
 
   // Distinct counts are only supported for triples with three variables without
-  // a GRAPH variable and if no `LIMIT`/`OFFSET` clauses are present.
+  // a GRAPH variable and if no `LIMIT`/`OFFSET` clauses are present. For
+  // two-variable scans (one bound column, two variables) we can answer
+  // `COUNT(DISTINCT ?v)` from the relation metadata as well, see
+  // `computeDistinctCountForTwoVariableScan` below.
   bool countIsDistinct = varAndDistinctness.value().isDistinct_;
-  if (countIsDistinct && (indexScan->numVariables() != 3 ||
+  if (countIsDistinct && (indexScan->numVariables() < 2 ||
+                          indexScan->numVariables() > 3 ||
                           !indexScan->additionalVariables().empty() ||
                           !indexScan->getLimitOffset().isUnconstrained())) {
     return std::nullopt;
@@ -847,6 +851,18 @@ std::optional<IdTable> GroupByImpl::computeGroupByForSingleIndexScan() const {
   if (!isVariableBoundInSubtree(var)) {
     // The variable is never bound, so its count is zero.
     return idTableFromInt(0);
+  }
+
+  // For a two-variable scan with a bound first column, `COUNT(DISTINCT ?v)`
+  // is the number of distinct values of `?v` in that relation. The index
+  // stores this information in the relation metadata (and, for blocks that
+  // contain more than one distinct value, computes it by only decompressing
+  // those blocks), so we can answer without a full scan.
+  if (countIsDistinct && indexScan->numVariables() == 2) {
+    if (auto result = computeDistinctCountForTwoVariableScan(indexScan, var)) {
+      return idTableFromInt(result.value());
+    }
+    return std::nullopt;
   }
 
   if (indexScan->numVariables() != 3) {
@@ -901,7 +917,97 @@ std::optional<IdTable> GroupByImpl::computeGroupByForSingleIndexScan() const {
       indexScan->permutation().numTriples()));
 }
 
-// ____________________________________________________________________________
+// _____________________________________________________________________________
+std::optional<size_t>
+GroupByImpl::computeDistinctCountForTwoVariableScan(
+    const std::shared_ptr<const IndexScan>& indexScan,
+    const Variable& countedVariable) const {
+  AD_CORRECTNESS_CHECK(indexScan->numVariables() == 2);
+
+  // The scan is `?a <bound> ?b` (in permutation order), so the first entry of
+  // the permuted triple is the bound column and the other two are variables.
+  const auto& permutedTriple = indexScan->getPermutedTriple();
+  std::optional<Id> col0Id = toValueId(*permutedTriple[0], getIndex());
+  if (!col0Id.has_value()) {
+    return std::nullopt;
+  }
+
+  // The statistics are precomputed at index build time and do not reflect
+  // delta triples from SPARQL updates, so fall back to the general
+  // computation when there are any delta triples or a materialized view.
+  const auto& locTriples =
+      indexScan->permutation().getLocatedTriplesForPermutation(
+          locatedTriplesState());
+  if (!locTriples.isEmpty() ||
+      indexScan->permutation().permutationType() ==
+          Permutation::Type::MATERIALIZED_VIEW) {
+    return std::nullopt;
+  }
+
+  // Determine the permutation in which `countedVariable` is stored in column
+  // 1 (the column whose distinct values `getDistinctCol1IdsAndCounts`
+  // counts). The scan's own permutation already has it there when the counted
+  // variable is the second entry of the permuted triple; otherwise we need
+  // the permutation that swaps the two variable columns.
+  bool countedVariableInColumnOne =
+      permutedTriple[1]->isVariable() &&
+      *permutedTriple[1] == countedVariable;
+
+  if (countedVariableInColumnOne) {
+    // Fast path: the scan's permutation already has the counted variable in
+    // column 1, so we can use it directly.
+    const auto& permutation = indexScan->permutation();
+    auto result = permutation.getDistinctCol1IdsAndCounts(
+        col0Id.value(), cancellationHandle_, locatedTriplesState(),
+        indexScan->getLimitOffset());
+    return result.numRows();
+  }
+
+  // The counted variable is in column 2 of the scan's permutation. We need
+  // the permutation whose column 1 is the counted variable. With exactly one
+  // bound column (col0), the counted variable is one of the other two
+  // positions of the triple, so we select the permutation that puts it into
+  // column 1 while keeping the bound column in column 0.
+  std::optional<Permutation::Enum> targetPermutation = std::nullopt;
+  if (indexScan->predicate().isVariable() &&
+      indexScan->predicate().getVariable() == countedVariable) {
+    // Counted variable is the predicate. The bound column is the subject
+    // (`?s p <o>`, SPO has p in column 1) or the object (`<s> p ?o`, OSP has
+    // p in column 1).
+    if (!indexScan->subject().isVariable()) {
+      targetPermutation = Permutation::SPO;
+    } else if (!indexScan->object().isVariable()) {
+      targetPermutation = Permutation::OSP;
+    }
+  } else if (indexScan->subject().isVariable() &&
+             indexScan->subject().getVariable() == countedVariable) {
+    // Counted variable is the subject. The bound column must be the
+    // predicate (`?s <p> ?o`, PSO has s in column 1).
+    if (!indexScan->predicate().isVariable()) {
+      targetPermutation = Permutation::PSO;
+    }
+  } else if (indexScan->object().isVariable() &&
+             indexScan->object().getVariable() == countedVariable) {
+    // Counted variable is the object. The bound column must be the
+    // predicate (`?s <p> ?o`, POS has o in column 1).
+    if (!indexScan->predicate().isVariable()) {
+      targetPermutation = Permutation::POS;
+    }
+  }
+
+  if (!targetPermutation.has_value()) {
+    return std::nullopt;
+  }
+
+  const auto& permutation =
+      getIndex().getImpl().getPermutation(targetPermutation.value());
+  auto result = permutation.getDistinctCol1IdsAndCounts(
+      col0Id.value(), cancellationHandle_, locatedTriplesState(),
+      indexScan->getLimitOffset());
+  return result.numRows();
+}
+
+// _____________________________________________________________________________
 std::optional<IdTable> GroupByImpl::computeGroupByObjectWithCount() const {
   // The child must be an `IndexScan` with exactly two variables.
   auto indexScan =

--- a/src/engine/GroupByImpl.h
+++ b/src/engine/GroupByImpl.h
@@ -34,6 +34,8 @@ template <size_t IN_WIDTH, size_t OUT_WIDTH>
 class LazyGroupByRange;
 }
 
+class IndexScan;
+
 class GroupByImpl : public Operation {
  public:
   using GroupBlock = std::vector<std::pair<size_t, Id>>;

--- a/src/engine/GroupByImpl.h
+++ b/src/engine/GroupByImpl.h
@@ -199,6 +199,16 @@ class GroupByImpl : public Operation {
   // is computed and returned. If not, an empty optional is returned.
   std::optional<IdTable> computeGroupByForSingleIndexScan() const;
 
+  // Answer `COUNT(DISTINCT ?var)` for a two-variable index scan with a bound
+  // first column from the relation metadata: the number of distinct values
+  // of `?var` in the relation. Returns `std::nullopt` when the shape cannot
+  // be answered this way (e.g. the counted variable is not stored in column
+  // 1 of any suitable permutation, or the permutation has unmerged delta
+  // triples).
+  std::optional<size_t> computeDistinctCountForTwoVariableScan(
+      const std::shared_ptr<const IndexScan>& indexScan,
+      const Variable& countedVariable) const;
+
   // Check if the query represented by this GROUP BY is of the following form:
   //
   //   SELECT ?y (COUNT(?y) as ?count) WHERE {

--- a/test/GroupByTest.cpp
+++ b/test/GroupByTest.cpp
@@ -3335,7 +3335,6 @@ TEST(GroupByOptimizations, distinctCountTwoVariableScanColumnOne) {
   // (POS), so the new metadata fast path answers it directly.
   QecWrapper ctx{std::make_shared<Index>(makeTestIndex(
       "<x> <label3> <a> . <x> <label3> <b> . <y> <label3> <a> ."))};
-  auto getId = makeGetId(*ctx.index_);
   auto qec = ctx.makeQec();
 
   // SELECT (COUNT(DISTINCT ?o) AS ?count) WHERE { ?s <label3> ?o }
@@ -3352,8 +3351,8 @@ TEST(GroupByOptimizations, distinctCountTwoVariableScanColumnOne) {
   GroupByImpl groupBy{&qec, {}, aliases, scan};
 
   // The relation contains the distinct objects <a> and <b> -> count = 2.
-  EXPECT_THAT(groupBy.computeResultOnlyForTesting(false),
-              optionalHasTable({{I(2)}}));
+  auto result = groupBy.computeResultOnlyForTesting(false);
+  EXPECT_EQ(result.idTableView(), makeIdTableFromVector({{I(2)}}));
 }
 
 // _____________________________________________________________________________
@@ -3363,7 +3362,6 @@ TEST(GroupByOptimizations, distinctCountTwoVariableScanColumnTwo) {
   // permutation (where ?s is column 1) to answer from the relation metadata.
   QecWrapper ctx{std::make_shared<Index>(makeTestIndex(
       "<x> <label3> <a> . <x> <label3> <b> . <y> <label3> <a> ."))};
-  auto getId = makeGetId(*ctx.index_);
   auto qec = ctx.makeQec();
 
   // SELECT (COUNT(DISTINCT ?s) AS ?count) WHERE { ?s <label3> ?o }
@@ -3380,6 +3378,6 @@ TEST(GroupByOptimizations, distinctCountTwoVariableScanColumnTwo) {
   GroupByImpl groupBy{&qec, {}, aliases, scan};
 
   // The relation contains the distinct subjects <x> and <y> -> count = 2.
-  EXPECT_THAT(groupBy.computeResultOnlyForTesting(false),
-              optionalHasTable({{I(2)}}));
+  auto result = groupBy.computeResultOnlyForTesting(false);
+  EXPECT_EQ(result.idTableView(), makeIdTableFromVector({{I(2)}}));
 }

--- a/test/GroupByTest.cpp
+++ b/test/GroupByTest.cpp
@@ -3327,3 +3327,59 @@ TEST(GroupBy, BlankNodeInGroupBy) {
   EXPECT_EQ(table(1, 1).getDatatype(), Datatype::BlankNodeIndex);
   EXPECT_NE(table(0, 1), table(1, 1));
 }
+
+// _____________________________________________________________________________
+TEST(GroupByOptimizations, distinctCountTwoVariableScanColumnOne) {
+  // `?s <label3> ?o` with `COUNT(DISTINCT ?o)`: two-variable scan with bound
+  // predicate. The counted variable ?o is column 1 of the scan's permutation
+  // (POS), so the new metadata fast path answers it directly.
+  QecWrapper ctx{std::make_shared<Index>(makeTestIndex(
+      "<x> <label3> <a> . <x> <label3> <b> . <y> <label3> <a> ."))};
+  auto getId = makeGetId(*ctx.index_);
+  auto qec = ctx.makeQec();
+
+  // SELECT (COUNT(DISTINCT ?o) AS ?count) WHERE { ?s <label3> ?o }
+  auto scan = makeExecutionTree<IndexScan>(
+      &qec, Permutation::Enum::POS,
+      SparqlTripleSimple{Variable{"?s"}, iri("<label3>"), Variable{"?o"}});
+  Variable varO{"?o"};
+  auto countDistinctOPimpl = SparqlExpressionPimpl{
+      std::make_unique<CountExpression>(
+          true, std::make_unique<VariableExpression>(varO)),
+      "COUNT(DISTINCT ?o)"};
+  std::vector<Alias> aliases{
+      Alias{std::move(countDistinctOPimpl), Variable{"?count"}}};
+  GroupByImpl groupBy{&qec, {}, aliases, scan};
+
+  // The relation contains the distinct objects <a> and <b> -> count = 2.
+  EXPECT_THAT(groupBy.computeResultOnlyForTesting(false),
+              optionalHasTable({{I(2)}}));
+}
+
+// _____________________________________________________________________________
+TEST(GroupByOptimizations, distinctCountTwoVariableScanColumnTwo) {
+  // `?s <label3> ?o` with `COUNT(DISTINCT ?s)`: the counted variable ?s is
+  // column 2 of the POS permutation, so the helper must select the PSO
+  // permutation (where ?s is column 1) to answer from the relation metadata.
+  QecWrapper ctx{std::make_shared<Index>(makeTestIndex(
+      "<x> <label3> <a> . <x> <label3> <b> . <y> <label3> <a> ."))};
+  auto getId = makeGetId(*ctx.index_);
+  auto qec = ctx.makeQec();
+
+  // SELECT (COUNT(DISTINCT ?s) AS ?count) WHERE { ?s <label3> ?o }
+  auto scan = makeExecutionTree<IndexScan>(
+      &qec, Permutation::Enum::POS,
+      SparqlTripleSimple{Variable{"?s"}, iri("<label3>"), Variable{"?o"}});
+  Variable varS{"?s"};
+  auto countDistinctSPimpl = SparqlExpressionPimpl{
+      std::make_unique<CountExpression>(
+          true, std::make_unique<VariableExpression>(varS)),
+      "COUNT(DISTINCT ?s)"};
+  std::vector<Alias> aliases{
+      Alias{std::move(countDistinctSPimpl), Variable{"?count"}}};
+  GroupByImpl groupBy{&qec, {}, aliases, scan};
+
+  // The relation contains the distinct subjects <x> and <y> -> count = 2.
+  EXPECT_THAT(groupBy.computeResultOnlyForTesting(false),
+              optionalHasTable({{I(2)}}));
+}


### PR DESCRIPTION
## What

`computeGroupByForSingleIndexScan` previously rejected `COUNT(DISTINCT ?v)`
when the child was a two-variable index scan (one bound column, e.g.
`?s <p> ?o`), falling back to a full scan + hash set. The number of
distinct values of the counted variable equals the number of distinct
column-1 values in the bound relation, which `getDistinctCol1IdsAndCounts`
answers from block metadata (uniform blocks counted without
decompression) - the same mechanism `computeGroupByObjectWithCount`
already uses.

## Changes

- `GroupByImpl.cpp/h`: new `computeDistinctCountForTwoVariableScan` -
  uses the scan's own permutation when the counted variable is column 1,
  otherwise selects the permutation whose column 1 is the counted
  variable (PSO/POS/SPO/OSP); falls back to the generic path for delta
  triples or materialized views.
- `test/GroupByTest.cpp`: two new tests (col1 fast path + col2 swap).

## Why it matters

On the SPARQLoscope DBLP-core benchmark, the aggregate category is where
QLever is 33.5x behind Fluree (271.8 ms vs 8.12 ms geomean). QLever
already answers `COUNT(*)`, `COUNT(DISTINCT ?s)` (3-var) and `GROUP BY`
shapes from metadata; this closes the remaining gap for
`COUNT(DISTINCT ?o)` over bound-predicate scans
(`distinct-count-object-*` queries).

## Verification

- Unit tests added; full test suite on Ural via ural-wq.
- Benchmark gate: SPARQLoscope DBLP-core aggregate category before/after.