### PR TITLE
Hash-set semijoin for single-column EXISTS without UNDEF

### DIFF
--- a/src/engine/ExistsJoin.cpp
+++ b/src/engine/ExistsJoin.cpp
@@ -13,6 +13,7 @@
 #include "engine/sparqlExpressions/ExistsExpression.h"
 #include "engine/sparqlExpressions/SparqlExpression.h"
 #include "util/ChunkedForLoop.h"
+#include "util/HashSet.h"
 #include "util/JoinAlgorithms/IndexNestedLoopJoin.h"
 #include "util/JoinAlgorithms/JoinAlgorithms.h"
 #include "util/VectorWithMemoryLimit.h"
@@ -182,6 +183,20 @@ Result ExistsJoin::computeResult(bool requestLaziness) {
                                    &Id::isUndefined));
       });
 
+  // If the join is cheap (no UNDEF values) and there is a single join column,
+  // we can answer the EXISTS test with a hash set instead of the sort-merge
+  // zipper join: build a hash set of the right (subquery) side's join keys
+  // once, then probe each row of the left side for existence. This avoids
+  // sorting both inputs and only materializes the (typically smaller) right
+  // side. This mirrors Fluree's semijoin operator for EXISTS/NOT EXISTS.
+  if (isCheap && numJoinColumns == 1) {
+    auto result =
+        tryHashSetExistsJoin(left, right, leftRes->getSharedLocalVocab());
+    if (result.has_value()) {
+      return std::move(result).value();
+    }
+  }
+
   // Nothing to do for the actual matches.
   auto noopRowAdder = ad_utility::noop;
 
@@ -233,6 +248,46 @@ Result ExistsJoin::computeResult(bool requestLaziness) {
   // The added column only contains Boolean values, and adds no new words to the
   // local vocabulary, so we can use the local vocab from `leftRes`.
   return {std::move(result), resultSortedOn(), leftRes->getSharedLocalVocab()};
+}
+
+// _____________________________________________________________________________
+std::optional<Result> ExistsJoin::tryHashSetExistsJoin(
+    const IdTableView<0>& left, const IdTableView<0>& right,
+    Result::SharedLocalVocabWrapper localVocab) {
+  AD_CORRECTNESS_CHECK(joinColumns_.size() == 1);
+  AD_CORRECTNESS_CHECK(left.numColumns() > 0 && right.numColumns() > 0);
+
+  // Build a hash set of the right (subquery) side's join keys. This is
+  // correct only because the caller has verified that there are no UNDEF
+  // values in the join columns, so a row "exists" iff its join key is in the
+  // set.
+  ad_utility::JoinColumnMapping joinColumnData{joinColumns_, left.numColumns(),
+                                               right.numColumns()};
+  ColumnIndex leftJoinCol = joinColumnData.jcsLeft().front();
+  ColumnIndex rightJoinCol = joinColumnData.jcsRight().front();
+
+  checkCancellation();
+  HashSet<Id> rightKeys;
+  rightKeys.reserve(right.size());
+  for (const auto& row : right) {
+    rightKeys.insert(row[rightJoinCol]);
+  }
+  checkCancellation();
+
+  // Fill the EXISTS column: true for every left row whose join key is in the
+  // set, false otherwise. UNDEF is impossible here (verified by the caller).
+  IdTable result = left.clone();
+  result.addEmptyColumn();
+  decltype(auto) existsCol = result.getColumn(getResultWidth() - 1);
+  ql::ranges::fill(existsCol, Id::makeFromBool(true));
+  size_t idx = 0;
+  for (const auto& row : left) {
+    if (!rightKeys.contains(row[leftJoinCol])) {
+      existsCol[idx] = Id::makeFromBool(false);
+    }
+    ++idx;
+  }
+  return {std::move(result), resultSortedOn(), std::move(localVocab)};
 }
 
 // _____________________________________________________________________________

--- a/src/engine/ExistsJoin.cpp
+++ b/src/engine/ExistsJoin.cpp
@@ -265,7 +265,7 @@ std::optional<IdTable> ExistsJoin::tryHashSetExistsJoin(
   ColumnIndex rightJoinCol = joinColumnData.jcsRight().front();
 
   checkCancellation();
-  HashSet<Id> rightKeys;
+  ad_utility::HashSet<Id> rightKeys;
   rightKeys.reserve(right.size());
   for (const auto& row : right) {
     rightKeys.insert(row[rightJoinCol]);

--- a/src/engine/ExistsJoin.cpp
+++ b/src/engine/ExistsJoin.cpp
@@ -190,10 +190,9 @@ Result ExistsJoin::computeResult(bool requestLaziness) {
   // sorting both inputs and only materializes the (typically smaller) right
   // side. This mirrors Fluree's semijoin operator for EXISTS/NOT EXISTS.
   if (isCheap && numJoinColumns == 1) {
-    auto result =
-        tryHashSetExistsJoin(left, right, leftRes->getSharedLocalVocab());
-    if (result.has_value()) {
-      return std::move(result).value();
+    if (auto result = tryHashSetExistsJoin(left, right)) {
+      return Result{std::move(result).value(), resultSortedOn(),
+                    leftRes->getSharedLocalVocab()};
     }
   }
 
@@ -251,9 +250,8 @@ Result ExistsJoin::computeResult(bool requestLaziness) {
 }
 
 // _____________________________________________________________________________
-std::optional<Result> ExistsJoin::tryHashSetExistsJoin(
-    const IdTableView<0>& left, const IdTableView<0>& right,
-    Result::SharedLocalVocabWrapper localVocab) {
+std::optional<IdTable> ExistsJoin::tryHashSetExistsJoin(
+    const IdTableView<0>& left, const IdTableView<0>& right) {
   AD_CORRECTNESS_CHECK(joinColumns_.size() == 1);
   AD_CORRECTNESS_CHECK(left.numColumns() > 0 && right.numColumns() > 0);
 
@@ -287,7 +285,7 @@ std::optional<Result> ExistsJoin::tryHashSetExistsJoin(
     }
     ++idx;
   }
-  return {std::move(result), resultSortedOn(), std::move(localVocab)};
+  return result;
 }
 
 // _____________________________________________________________________________

--- a/src/engine/ExistsJoin.h
+++ b/src/engine/ExistsJoin.h
@@ -114,10 +114,10 @@ class ExistsJoin : public Operation {
   // (subquery) side's join keys once and probes each row of the left side for
   // existence, so the boolean EXISTS column can be filled without sorting
   // either input. Mirrors Fluree's semijoin operator for EXISTS/NOT EXISTS.
-  // `localVocab` is the local vocab of the left result, propagated unchanged.
-  std::optional<Result> tryHashSetExistsJoin(
-      const IdTableView<0>& left, const IdTableView<0>& right,
-      Result::SharedLocalVocabWrapper localVocab);
+  // Returns the left table with the added boolean column; the caller wraps it
+  // in a `Result` with the correct local vocab.
+  std::optional<IdTable> tryHashSetExistsJoin(const IdTableView<0>& left,
+                                              const IdTableView<0>& right);
 
   Result computeResult(bool requestLaziness) override;
 

--- a/src/engine/ExistsJoin.h
+++ b/src/engine/ExistsJoin.h
@@ -109,6 +109,16 @@ class ExistsJoin : public Operation {
   // `tryLeftIndexNestedLoopJoinIfSuitable`.
   std::optional<Result> tryIndexNestedLoopJoinIfSuitable(bool requestLaziness);
 
+  // Semijoin optimization for the fully materialized case with exactly one
+  // join column and no undef values. Builds a hash set of the right
+  // (subquery) side's join keys once and probes each row of the left side for
+  // existence, so the boolean EXISTS column can be filled without sorting
+  // either input. Mirrors Fluree's semijoin operator for EXISTS/NOT EXISTS.
+  // `localVocab` is the local vocab of the left result, propagated unchanged.
+  std::optional<Result> tryHashSetExistsJoin(
+      const IdTableView<0>& left, const IdTableView<0>& right,
+      Result::SharedLocalVocabWrapper localVocab);
+
   Result computeResult(bool requestLaziness) override;
 
   VariableToColumnMap computeVariableToColumnMap() const override;

--- a/test/engine/ExistsJoinTest.cpp
+++ b/test/engine/ExistsJoinTest.cpp
@@ -969,3 +969,26 @@ TEST(ExistsJoin, resultSortedOn) {
   // Sort would be added if it's not already sorted enough.
   EXPECT_THAT(getSortOrder(biggerWithUndef, {0, 1, 2}), ElementsAre(0, 1, 2));
 }
+
+// _____________________________________________________________________________
+TEST(ExistsJoin, hashSetExistsJoinSingleColumn) {
+  // Single join column, no UNDEF: exercises the hash-set semijoin path.
+  // Left join keys {3,4,5}; right join keys {3,5}. Expected EXISTS:
+  // row0 (3) -> true, row1 (4) -> false, row2 (5) -> true.
+  testExists({{3, 6}, {4, 7}, {5, 8}}, {{3, 15}, {5, 37}}, {true, false, true},
+             1);
+
+  // Right side empty -> every EXISTS is false.
+  auto alloc = ad_utility::testing::makeAllocator();
+  testExistsFromIdTable(makeIdTableFromVector({{3, 6}, {4, 7}}),
+                        IdTable{2, alloc}, {false, false}, 1);
+
+  // All left keys match.
+  testExists({{3, 6}, {4, 7}}, {{3, 15}, {4, 37}, {3, 19}}, {true, true}, 1);
+
+  // Duplicates on both sides: EXISTS is set-theoretic, so duplicates on the
+  // right do not change the result, and duplicates on the left each get the
+  // same boolean.
+  testExists({{3, 6}, {3, 7}, {4, 8}}, {{3, 15}, {3, 19}}, {true, true, false},
+             1);
+}


### PR DESCRIPTION
## What

`ExistsJoin::computeResult` used the sort-merge `zipperJoinWithUndef` for
the fully materialized case. For a single join column with no UNDEF values,
the EXISTS test only needs set membership, not a merge: build a hash set of
the right (subquery) side's join keys once, then probe each left row for
existence and fill the boolean column. This avoids sorting both inputs and
only materializes the typically smaller subquery side.

## Changes

- `ExistsJoin.cpp/h`: new `tryHashSetExistsJoin`; called from the
  materialized path when `isCheap` (no UNDEF) and exactly one join column,
  after the index nested-loop attempts and before the generic zipper.
- `test/engine/ExistsJoinTest.cpp`: dedicated test (match, no-match, empty
  right, duplicates); existing single-join-column `computeResult` cases
  already exercise the path.

## Why it matters

On the SPARQLoscope DBLP-core benchmark, QLever is 15.2x behind Fluree on
existence checks (712.1 ms vs 47.0 ms geomean). Fluree's semijoin operator
turns EXISTS into a single uncorrelated build plus probes; this is the
equivalent optimization for QLever's materialized path.

## Verification

- Unit tests on Ural via ural-wq (GroupByTest/ExistsJoinTest binaries).
- Benchmark gate: SPARQLoscope existence-category before/after.