### PR TITLE
Answer MIN/MAX over a bound-predicate scan from index order

### DIFF
--- a/src/engine/GroupByImpl.cpp
+++ b/src/engine/GroupByImpl.cpp
@@ -1181,6 +1181,9 @@ std::optional<IdTable> GroupByImpl::computeOptimizedGroupByIfPossible() const {
     if (auto result = computeGroupByForFullIndexScan()) {
       return result;
     }
+    if (auto result = computeMinMaxForSingleIndexScan()) {
+      return result;
+    }
   }
   if (auto result = computeGroupByForJoinWithFullScan()) {
     return result;
@@ -1962,6 +1965,113 @@ bool GroupByImpl::isVariableBoundInSubtree(const Variable& variable) const {
 std::unique_ptr<Operation> GroupByImpl::cloneImpl() const {
   return std::make_unique<GroupByImpl>(_executionContext, _groupByVariables,
                                        _aliases, _subtree->clone());
+}
+
+// _____________________________________________________________________________
+namespace {
+// Return the permutation in which `col0` stays bound and `wantedCol1` is
+// stored in column 1, or nullopt if no such permutation exists.
+std::optional<Permutation::Enum> permutationWithWantedCol1(
+    const IndexScan& scan, const Variable& wantedCol1) {
+  const bool predBound = !scan.predicate().isVariable();
+  const bool subjBound = !scan.subject().isVariable();
+  const bool objBound = !scan.object().isVariable();
+  if (scan.subject().isVariable() &&
+      scan.subject().getVariable() == wantedCol1) {
+    if (predBound) {
+      return Permutation::PSO;
+    }
+    if (objBound) {
+      return Permutation::OSP;
+    }
+  } else if (scan.object().isVariable() &&
+             scan.object().getVariable() == wantedCol1) {
+    if (predBound) {
+      return Permutation::POS;
+    }
+    if (subjBound) {
+      return Permutation::SOP;
+    }
+  } else if (scan.predicate().isVariable() &&
+             scan.predicate().getVariable() == wantedCol1) {
+    if (subjBound) {
+      return Permutation::SPO;
+    }
+    if (objBound) {
+      return Permutation::OPS;
+    }
+  }
+  return std::nullopt;
+}
+}  // namespace
+
+// _____________________________________________________________________________
+std::optional<IdTable> GroupByImpl::computeMinMaxForSingleIndexScan() const {
+  if (!_groupByVariables.empty() || _aliases.size() != 1) {
+    return std::nullopt;
+  }
+  const auto* expr = _aliases.front()._expression.getPimpl();
+  const bool isMin =
+      dynamic_cast<const sparqlExpression::MinExpression*>(expr) != nullptr;
+  const bool isMax =
+      dynamic_cast<const sparqlExpression::MaxExpression*>(expr) != nullptr;
+  if (!isMin && !isMax) {
+    return std::nullopt;
+  }
+  auto children = expr->children();
+  if (children.size() != 1) {
+    return std::nullopt;
+  }
+  auto wantedVar = children[0]->getVariableOrNullopt();
+  if (!wantedVar.has_value()) {
+    return std::nullopt;
+  }
+
+  auto indexScan =
+      std::dynamic_pointer_cast<const IndexScan>(_subtree->getRootOperation());
+  if (!indexScan || indexScan->numVariables() != 2 ||
+      !indexScan->graphsToFilter().areAllGraphsAllowed() ||
+      !indexScan->additionalVariables().empty()) {
+    return std::nullopt;
+  }
+
+  const auto& locTriples =
+      indexScan->permutation().getLocatedTriplesForPermutation(
+          locatedTriplesState());
+  if (!locTriples.isEmpty() || indexScan->permutation().permutationType() ==
+                                   Permutation::Type::MATERIALIZED_VIEW) {
+    return std::nullopt;
+  }
+
+  const auto& permutedTriple = indexScan->getPermutedTriple();
+  std::optional<Id> col0Id = toValueId(*permutedTriple[0], getIndex());
+  if (!col0Id.has_value()) {
+    return std::nullopt;
+  }
+
+  auto targetPermutation =
+      permutationWithWantedCol1(*indexScan, wantedVar.value());
+  if (!targetPermutation.has_value()) {
+    return std::nullopt;
+  }
+
+  const auto& permutation =
+      getIndex().getImpl().getPermutation(targetPermutation.value());
+  auto distinctIds = permutation.getDistinctCol1IdsAndCounts(
+      col0Id.value(), cancellationHandle_, locatedTriplesState(),
+      indexScan->getLimitOffset());
+
+  indexScan->updateRuntimeInformationWhenOptimizedOut({});
+
+  IdTable table{1, getExecutionContext()->getAllocator()};
+  if (distinctIds.empty()) {
+    table.push_back({Id::makeUndefined()});
+  } else {
+    const Id value = isMin ? distinctIds(0, 0)
+                           : distinctIds(distinctIds.numRows() - 1, 0);
+    table.push_back({value});
+  }
+  return table;
 }
 
 // _____________________________________________________________________________

--- a/src/engine/GroupByImpl.h
+++ b/src/engine/GroupByImpl.h
@@ -239,6 +239,11 @@ class GroupByImpl : public Operation {
   // (implicit) group.
   std::optional<IdTable> computeCountStar() const;
 
+  // `SELECT (MIN(?v) AS ?m)` or `SELECT (MAX(?v) AS ?m)` over a two-variable
+  // index scan with one bound column. Uses the sorted distinct col1 IDs of
+  // the permutation that stores `?v` in column 1. Empty input yields UNDEF.
+  std::optional<IdTable> computeMinMaxForSingleIndexScan() const;
+
   // Stores information required for substitution of an expression in an
   // expression tree.
   struct ParentAndChildIndex {

--- a/test/GroupByTest.cpp
+++ b/test/GroupByTest.cpp
@@ -3327,3 +3327,45 @@ TEST(GroupBy, BlankNodeInGroupBy) {
   EXPECT_EQ(table(1, 1).getDatatype(), Datatype::BlankNodeIndex);
   EXPECT_NE(table(0, 1), table(1, 1));
 }
+
+// _____________________________________________________________________________
+TEST(GroupByOptimizations, minMaxTwoVariableScan) {
+  // MIN/MAX of the object of `?s <label3> ?o` from the sorted distinct
+  // object IDs (POS). Vocab order is lexicographic: <a> < <b> < <c>.
+  QecWrapper ctx{std::make_shared<Index>(makeTestIndex(
+      "<x> <label3> <b> . <x> <label3> <c> . <y> <label3> <a> ."))};
+  auto qec = ctx.makeQec();
+  auto getId = makeGetId(*ctx.index_);
+  auto idA = getId("<a>");
+  auto idC = getId("<c>");
+
+  auto makeGroupBy = [&](SparqlExpressionPimpl expr) {
+    auto scan = makeExecutionTree<IndexScan>(
+        &qec, Permutation::Enum::PSO,
+        SparqlTripleSimple{Variable{"?s"}, iri("<label3>"), Variable{"?o"}});
+    std::vector<Alias> aliases{Alias{std::move(expr), Variable{"?out"}}};
+    return GroupByImpl{&qec, {}, std::move(aliases), std::move(scan)};
+  };
+
+  EXPECT_THAT(makeGroupBy(makeMinPimpl(Variable{"?o"}))
+                  .computeResultOnlyForTesting(false),
+              optionalHasTable({{idA}}));
+  EXPECT_THAT(makeGroupBy(makeMaxPimpl(Variable{"?o"}))
+                  .computeResultOnlyForTesting(false),
+              optionalHasTable({{idC}}));
+}
+
+// _____________________________________________________________________________
+TEST(GroupByOptimizations, minMaxEmptyRelation) {
+  QecWrapper ctx{std::make_shared<Index>(
+      makeTestIndex("<x> <other> <a> ."))};
+  auto qec = ctx.makeQec();
+  auto scan = makeExecutionTree<IndexScan>(
+      &qec, Permutation::Enum::PSO,
+      SparqlTripleSimple{Variable{"?s"}, iri("<missing>"), Variable{"?o"}});
+  std::vector<Alias> aliases{
+      Alias{makeMinPimpl(Variable{"?o"}), Variable{"?out"}}};
+  GroupByImpl groupBy{&qec, {}, aliases, scan};
+  EXPECT_THAT(groupBy.computeResultOnlyForTesting(false),
+              optionalHasTable({{Id::makeUndefined()}}));
+}


### PR DESCRIPTION
## What

`SELECT (MIN(?v) AS ?m)` / `SELECT (MAX(?v) AS ?m)` over a two-variable
index scan (`?s <p> ?v`) now reads the sorted distinct column-1 IDs of
the permutation that stores `?v` in column 1 (`getDistinctCol1IdsAndCounts`).
Uniform blocks contribute from metadata. An empty relation yields UNDEF
(SPARQL implicit group over an empty multiset).

## Why

On SPARQLoscope DBLP-core, `group-by-implicit-numeric-min/max` is 79 ms
vs Fluree's 0.55 ms, and `group-by-implicit-string-min/max` is 262 ms vs
0.67 ms. Those queries are a single `MIN`/`MAX` over one bound predicate.
QLever already had this metadata walk for `GROUP BY ?o COUNT`; this reuses
it for the extrema.

## Verification

- Unit tests in `GroupByTest` (non-empty min/max and empty relation).
- `GroupByTest` on Ural via ural-wq.