### PR TITLE
Answer COUNT(*) of UNION, empty OPTIONAL, and two-scan joins from metadata

### DIFF
--- a/src/engine/GroupByImpl.cpp
+++ b/src/engine/GroupByImpl.cpp
@@ -15,6 +15,8 @@
 #include "engine/IndexScan.h"
 #include "engine/Join.h"
 #include "engine/LazyGroupBy.h"
+#include "engine/OptionalJoin.h"
+#include "engine/Union.h"
 #include "engine/Sort.h"
 #include "engine/StripColumns.h"
 #include "engine/sparqlExpressions/AggregateExpression.h"
@@ -1965,6 +1967,200 @@ std::unique_ptr<Operation> GroupByImpl::cloneImpl() const {
 }
 
 // _____________________________________________________________________________
+namespace {
+std::optional<Permutation::Enum> permutationWithWantedCol1(
+    const IndexScan& scan, const Variable& wantedCol1) {
+  const bool predBound = !scan.predicate().isVariable();
+  const bool subjBound = !scan.subject().isVariable();
+  const bool objBound = !scan.object().isVariable();
+  if (scan.subject().isVariable() &&
+      scan.subject().getVariable() == wantedCol1) {
+    if (predBound) {
+      return Permutation::PSO;
+    }
+    if (objBound) {
+      return Permutation::OSP;
+    }
+  } else if (scan.object().isVariable() &&
+             scan.object().getVariable() == wantedCol1) {
+    if (predBound) {
+      return Permutation::POS;
+    }
+    if (subjBound) {
+      return Permutation::SOP;
+    }
+  } else if (scan.predicate().isVariable() &&
+             scan.predicate().getVariable() == wantedCol1) {
+    if (subjBound) {
+      return Permutation::SPO;
+    }
+    if (objBound) {
+      return Permutation::OPS;
+    }
+  }
+  return std::nullopt;
+}
+
+std::optional<size_t> exactSizeIfIndexScan(const QueryExecutionTree& tree) {
+  auto scan =
+      std::dynamic_pointer_cast<const IndexScan>(tree.getRootOperation());
+  if (!scan || !scan->graphsToFilter().areAllGraphsAllowed()) {
+    return std::nullopt;
+  }
+  return scan->getLimitOffset().actualSize(scan->getExactSize());
+}
+
+const IndexScan* unwrapIndexScan(const QueryExecutionTree& tree) {
+  const Operation* op = tree.getRootOperation().get();
+  if (const auto* sort = dynamic_cast<const Sort*>(op)) {
+    const auto children = sort->getChildren();
+    if (children.size() != 1) {
+      return nullptr;
+    }
+    op = children[0]->getRootOperation().get();
+  }
+  return dynamic_cast<const IndexScan*>(op);
+}
+}  // namespace
+
+// _____________________________________________________________________________
+std::optional<IdTable> GroupByImpl::computeCountStarFromMetadata() const {
+  auto idTableFromInt = [this](size_t count) {
+    IdTable table{1, getExecutionContext()->getAllocator()};
+    table.push_back({Id::makeFromInt(count)});
+    return table;
+  };
+
+  if (auto* unionOp =
+          dynamic_cast<Union*>(_subtree->getRootOperation().get())) {
+    auto leftSize = exactSizeIfIndexScan(*unionOp->leftChild());
+    auto rightSize = exactSizeIfIndexScan(*unionOp->rightChild());
+    if (!leftSize.has_value() || !rightSize.has_value()) {
+      return std::nullopt;
+    }
+    unionOp->leftChild()->getRootOperation()
+        ->updateRuntimeInformationWhenOptimizedOut({});
+    unionOp->rightChild()->getRootOperation()
+        ->updateRuntimeInformationWhenOptimizedOut({});
+    _subtree->getRootOperation()->updateRuntimeInformationWhenOptimizedOut(
+        {unionOp->leftChild()->getRootOperation()->getRuntimeInfoPointer(),
+         unionOp->rightChild()->getRootOperation()->getRuntimeInfoPointer()});
+    return idTableFromInt(leftSize.value() + rightSize.value());
+  }
+
+  if (auto* optional =
+          dynamic_cast<OptionalJoin*>(_subtree->getRootOperation().get())) {
+    auto children = optional->getChildren();
+    if (children.size() != 2) {
+      return std::nullopt;
+    }
+    if (!children[1]->knownEmptyResult()) {
+      return std::nullopt;
+    }
+    auto leftSize = exactSizeIfIndexScan(*children[0]);
+    if (!leftSize.has_value()) {
+      return std::nullopt;
+    }
+    children[0]->getRootOperation()->updateRuntimeInformationWhenOptimizedOut(
+        {});
+    children[1]->getRootOperation()->updateRuntimeInformationWhenOptimizedOut(
+        {});
+    _subtree->getRootOperation()->updateRuntimeInformationWhenOptimizedOut(
+        {children[0]->getRootOperation()->getRuntimeInfoPointer(),
+         children[1]->getRootOperation()->getRuntimeInfoPointer()});
+    return idTableFromInt(leftSize.value());
+  }
+
+  if (auto* join = dynamic_cast<Join*>(_subtree->getRootOperation().get())) {
+    auto children = join->getChildren();
+    if (children.size() != 2) {
+      return std::nullopt;
+    }
+    const auto* leftScan = unwrapIndexScan(*children[0]);
+    const auto* rightScan = unwrapIndexScan(*children[1]);
+    if (!leftScan || !rightScan) {
+      return std::nullopt;
+    }
+    if (leftScan->numVariables() != 2 || rightScan->numVariables() != 2 ||
+        !leftScan->graphsToFilter().areAllGraphsAllowed() ||
+        !rightScan->graphsToFilter().areAllGraphsAllowed() ||
+        !leftScan->additionalVariables().empty() ||
+        !rightScan->additionalVariables().empty()) {
+      return std::nullopt;
+    }
+    auto joinColumns =
+        QueryExecutionTree::getJoinColumns(*children[0], *children[1]);
+    if (joinColumns.size() != 1) {
+      return std::nullopt;
+    }
+    auto joinVar =
+        children[0]->getVariableAndInfoByColumnIndex(joinColumns[0][0]).first;
+
+    auto distinctCounts = [&](const IndexScan& scan)
+        -> std::optional<IdTable> {
+      const auto& locTriples =
+          scan.permutation().getLocatedTriplesForPermutation(
+              locatedTriplesState());
+      if (!locTriples.isEmpty() || scan.permutation().permutationType() ==
+                                       Permutation::Type::MATERIALIZED_VIEW) {
+        return std::nullopt;
+      }
+      const auto& permutedTriple = scan.getPermutedTriple();
+      std::optional<Id> col0Id = toValueId(*permutedTriple[0], getIndex());
+      if (!col0Id.has_value()) {
+        return std::nullopt;
+      }
+      auto target = permutationWithWantedCol1(scan, joinVar);
+      if (!target.has_value()) {
+        return std::nullopt;
+      }
+      const auto& permutation =
+          getIndex().getImpl().getPermutation(target.value());
+      return permutation.getDistinctCol1IdsAndCounts(
+          col0Id.value(), cancellationHandle_, locatedTriplesState(),
+          scan.getLimitOffset());
+    };
+
+    auto leftCounts = distinctCounts(*leftScan);
+    auto rightCounts = distinctCounts(*rightScan);
+    if (!leftCounts.has_value() || !rightCounts.has_value()) {
+      return std::nullopt;
+    }
+
+    children[0]->getRootOperation()->updateRuntimeInformationWhenOptimizedOut(
+        {});
+    children[1]->getRootOperation()->updateRuntimeInformationWhenOptimizedOut(
+        {});
+    join->updateRuntimeInformationWhenOptimizedOut(
+        {children[0]->getRootOperation()->getRuntimeInfoPointer(),
+         children[1]->getRootOperation()->getRuntimeInfoPointer()});
+
+    const auto& left = leftCounts.value();
+    const auto& right = rightCounts.value();
+    size_t i = 0;
+    size_t j = 0;
+    size_t total = 0;
+    while (i < left.numRows() && j < right.numRows()) {
+      const Id leftId = left(i, 0);
+      const Id rightId = right(j, 0);
+      if (leftId == rightId) {
+        total += static_cast<size_t>(left(i, 1).getInt()) *
+                 static_cast<size_t>(right(j, 1).getInt());
+        ++i;
+        ++j;
+      } else if (leftId < rightId) {
+        ++i;
+      } else {
+        ++j;
+      }
+    }
+    return idTableFromInt(total);
+  }
+
+  return std::nullopt;
+}
+
+// _____________________________________________________________________________
 std::optional<IdTable> GroupByImpl::computeCountStar() const {
   bool isSingleGlobalAggregateFunction =
       _groupByVariables.empty() && _aliases.size() == 1;
@@ -1980,6 +2176,13 @@ std::optional<IdTable> GroupByImpl::computeCountStar() const {
   }();
   if (!singleAggregateIsNonDistinctCountStar) {
     return std::nullopt;
+  }
+
+  if (!getRuntimeParameter<
+          &RuntimeParameters::groupByDisableIndexScanOptimizations_>()) {
+    if (auto result = computeCountStarFromMetadata()) {
+      return result;
+    }
   }
 
   auto childRes = _subtree->getResult(true);

--- a/src/engine/GroupByImpl.cpp
+++ b/src/engine/GroupByImpl.cpp
@@ -16,9 +16,9 @@
 #include "engine/Join.h"
 #include "engine/LazyGroupBy.h"
 #include "engine/OptionalJoin.h"
-#include "engine/Union.h"
 #include "engine/Sort.h"
 #include "engine/StripColumns.h"
+#include "engine/Union.h"
 #include "engine/sparqlExpressions/AggregateExpression.h"
 #include "engine/sparqlExpressions/CountStarExpression.h"
 #include "engine/sparqlExpressions/ExistsExpression.h"
@@ -2011,15 +2011,15 @@ std::optional<size_t> exactSizeIfIndexScan(const QueryExecutionTree& tree) {
 }
 
 const IndexScan* unwrapIndexScan(const QueryExecutionTree& tree) {
-  const Operation* op = tree.getRootOperation().get();
-  if (const auto* sort = dynamic_cast<const Sort*>(op)) {
+  std::shared_ptr<Operation> op = tree.getRootOperation();
+  if (auto* sort = dynamic_cast<Sort*>(op.get())) {
     const auto children = sort->getChildren();
     if (children.size() != 1) {
       return nullptr;
     }
-    op = children[0]->getRootOperation().get();
+    op = children[0]->getRootOperation();
   }
-  return dynamic_cast<const IndexScan*>(op);
+  return dynamic_cast<const IndexScan*>(op.get());
 }
 }  // namespace
 
@@ -2038,9 +2038,11 @@ std::optional<IdTable> GroupByImpl::computeCountStarFromMetadata() const {
     if (!leftSize.has_value() || !rightSize.has_value()) {
       return std::nullopt;
     }
-    unionOp->leftChild()->getRootOperation()
+    unionOp->leftChild()
+        ->getRootOperation()
         ->updateRuntimeInformationWhenOptimizedOut({});
-    unionOp->rightChild()->getRootOperation()
+    unionOp->rightChild()
+        ->getRootOperation()
         ->updateRuntimeInformationWhenOptimizedOut({});
     _subtree->getRootOperation()->updateRuntimeInformationWhenOptimizedOut(
         {unionOp->leftChild()->getRootOperation()->getRuntimeInfoPointer(),
@@ -2096,8 +2098,7 @@ std::optional<IdTable> GroupByImpl::computeCountStarFromMetadata() const {
     auto joinVar =
         children[0]->getVariableAndInfoByColumnIndex(joinColumns[0][0]).first;
 
-    auto distinctCounts = [&](const IndexScan& scan)
-        -> std::optional<IdTable> {
+    auto distinctCounts = [&](const IndexScan& scan) -> std::optional<IdTable> {
       const auto& locTriples =
           scan.permutation().getLocatedTriplesForPermutation(
               locatedTriplesState());

--- a/src/engine/GroupByImpl.h
+++ b/src/engine/GroupByImpl.h
@@ -239,6 +239,11 @@ class GroupByImpl : public Operation {
   // (implicit) group.
   std::optional<IdTable> computeCountStar() const;
 
+  // `COUNT(*)` answered from index metadata without building the child:
+  // bag `UNION` of two index scans, or an inner join of two bound-predicate
+  // scans on one variable (sum of multiplicity products).
+  std::optional<IdTable> computeCountStarFromMetadata() const;
+
   // Stores information required for substitution of an expression in an
   // expression tree.
   struct ParentAndChildIndex {

--- a/test/GroupByTest.cpp
+++ b/test/GroupByTest.cpp
@@ -3349,8 +3349,8 @@ TEST(GroupByOptimizations, countStarTwoPredicateJoin) {
       Alias{SparqlExpressionPimpl{makeCountStarExpression(false), "COUNT(*)"},
             Variable{"?c"}}};
   GroupByImpl groupBy{&qec, {}, aliases, join};
-  EXPECT_THAT(groupBy.computeResultOnlyForTesting(false),
-              optionalHasTable({{I(3)}}));
+  EXPECT_THAT(groupBy.computeResultOnlyForTesting(false).idTableView(),
+              matchesIdTableFromVector({{I(3)}}));
 }
 
 // _____________________________________________________________________________
@@ -3369,8 +3369,8 @@ TEST(GroupByOptimizations, countStarBagUnionOfTwoScans) {
       Alias{SparqlExpressionPimpl{makeCountStarExpression(false), "COUNT(*)"},
             Variable{"?c"}}};
   GroupByImpl groupBy{&qec, {}, aliases, unionOp};
-  EXPECT_THAT(groupBy.computeResultOnlyForTesting(false),
-              optionalHasTable({{I(3)}}));
+  EXPECT_THAT(groupBy.computeResultOnlyForTesting(false).idTableView(),
+              matchesIdTableFromVector({{I(3)}}));
 }
 
 // _____________________________________________________________________________
@@ -3389,6 +3389,6 @@ TEST(GroupByOptimizations, countStarOptionalEmptyRight) {
       Alias{SparqlExpressionPimpl{makeCountStarExpression(false), "COUNT(*)"},
             Variable{"?c"}}};
   GroupByImpl groupBy{&qec, {}, aliases, optional};
-  EXPECT_THAT(groupBy.computeResultOnlyForTesting(false),
-              optionalHasTable({{I(2)}}));
+  EXPECT_THAT(groupBy.computeResultOnlyForTesting(false).idTableView(),
+              matchesIdTableFromVector({{I(2)}}));
 }

--- a/test/GroupByTest.cpp
+++ b/test/GroupByTest.cpp
@@ -14,6 +14,8 @@
 #include "engine/GroupByImpl.h"
 #include "engine/IndexScan.h"
 #include "engine/Join.h"
+#include "engine/OptionalJoin.h"
+#include "engine/Union.h"
 #include "engine/MaterializedViews.h"
 #include "engine/NamedResultCache.h"
 #include "engine/QueryPlanner.h"
@@ -3326,4 +3328,67 @@ TEST(GroupBy, BlankNodeInGroupBy) {
   EXPECT_EQ(table(0, 1).getDatatype(), Datatype::BlankNodeIndex);
   EXPECT_EQ(table(1, 1).getDatatype(), Datatype::BlankNodeIndex);
   EXPECT_NE(table(0, 1), table(1, 1));
+}
+
+// _____________________________________________________________________________
+TEST(GroupByOptimizations, countStarTwoPredicateJoin) {
+  // COUNT(*) of `?s <p1> ?o1 . ?s <p2> ?o2`.
+  // x has 2 p1 and 1 p2; y has 1 p1 and 1 p2; z has only p1. Total = 2+1 = 3.
+  QecWrapper ctx{std::make_shared<Index>(makeTestIndex(
+      "<x> <p1> <a> . <x> <p1> <b> . <x> <p2> <c> . "
+      "<y> <p1> <d> . <y> <p2> <e> . <z> <p1> <f> ."))};
+  auto qec = ctx.makeQec();
+  auto left = makeExecutionTree<IndexScan>(
+      &qec, Permutation::Enum::PSO,
+      SparqlTripleSimple{Variable{"?s"}, iri("<p1>"), Variable{"?o1"}});
+  auto right = makeExecutionTree<IndexScan>(
+      &qec, Permutation::Enum::PSO,
+      SparqlTripleSimple{Variable{"?s"}, iri("<p2>"), Variable{"?o2"}});
+  auto join = makeExecutionTree<Join>(&qec, left, right, 0, 0);
+  std::vector<Alias> aliases{
+      Alias{SparqlExpressionPimpl{makeCountStarExpression(false), "COUNT(*)"},
+            Variable{"?c"}}};
+  GroupByImpl groupBy{&qec, {}, aliases, join};
+  EXPECT_THAT(groupBy.computeResultOnlyForTesting(false),
+              optionalHasTable({{I(3)}}));
+}
+
+// _____________________________________________________________________________
+TEST(GroupByOptimizations, countStarBagUnionOfTwoScans) {
+  QecWrapper ctx{std::make_shared<Index>(makeTestIndex(
+      "<x> <p1> <a> . <y> <p2> <b> . <z> <p2> <c> ."))};
+  auto qec = ctx.makeQec();
+  auto left = makeExecutionTree<IndexScan>(
+      &qec, Permutation::Enum::PSO,
+      SparqlTripleSimple{Variable{"?s"}, iri("<p1>"), Variable{"?o"}});
+  auto right = makeExecutionTree<IndexScan>(
+      &qec, Permutation::Enum::PSO,
+      SparqlTripleSimple{Variable{"?s"}, iri("<p2>"), Variable{"?o"}});
+  auto unionOp = makeExecutionTree<Union>(&qec, left, right);
+  std::vector<Alias> aliases{
+      Alias{SparqlExpressionPimpl{makeCountStarExpression(false), "COUNT(*)"},
+            Variable{"?c"}}};
+  GroupByImpl groupBy{&qec, {}, aliases, unionOp};
+  EXPECT_THAT(groupBy.computeResultOnlyForTesting(false),
+              optionalHasTable({{I(3)}}));
+}
+
+// _____________________________________________________________________________
+TEST(GroupByOptimizations, countStarOptionalEmptyRight) {
+  QecWrapper ctx{std::make_shared<Index>(
+      makeTestIndex("<x> <p1> <a> . <y> <p1> <b> ."))};
+  auto qec = ctx.makeQec();
+  auto left = makeExecutionTree<IndexScan>(
+      &qec, Permutation::Enum::PSO,
+      SparqlTripleSimple{Variable{"?s"}, iri("<p1>"), Variable{"?o1"}});
+  auto right = makeExecutionTree<IndexScan>(
+      &qec, Permutation::Enum::PSO,
+      SparqlTripleSimple{Variable{"?s"}, iri("<missing>"), Variable{"?o2"}});
+  auto optional = makeExecutionTree<OptionalJoin>(&qec, left, right);
+  std::vector<Alias> aliases{
+      Alias{SparqlExpressionPimpl{makeCountStarExpression(false), "COUNT(*)"},
+            Variable{"?c"}}};
+  GroupByImpl groupBy{&qec, {}, aliases, optional};
+  EXPECT_THAT(groupBy.computeResultOnlyForTesting(false),
+              optionalHasTable({{I(2)}}));
 }


### PR DESCRIPTION
## What

`COUNT(*)` (implicit group) now has a metadata path before the generic
materialize-and-count:

1. Bag `UNION` of two index scans: sum of `getExactSize()`.
2. `OPTIONAL` whose right child is known empty: left `getExactSize()`.
3. Inner join of two bound-predicate two-variable scans on one variable:
   zipper of `(join-key, multiplicity)` streams from
   `getDistinctCol1IdsAndCounts`; the count is the sum of products.

## Why

SPARQLoscope DBLP-core `COUNT(*)` queries dominate the join / OPTIONAL /
UNION categories. `join-2-large-large` is 350 ms vs Fluree 0.60 ms.
`union-no-constraint` is 235 ms vs 0.61 ms. Fluree answers those from
directory metadata. QLever was building the join and then counting rows.

## Verification

- Unit tests for the three shapes in `GroupByTest`.
- `GroupByTest` on Ural via ural-wq.