### PR TITLE
Evaluate SUM(f(?v)) once per distinct value

### DIFF
--- a/src/engine/GroupByImpl.cpp
+++ b/src/engine/GroupByImpl.cpp
@@ -1181,6 +1181,9 @@ std::optional<IdTable> GroupByImpl::computeOptimizedGroupByIfPossible() const {
     if (auto result = computeGroupByForFullIndexScan()) {
       return result;
     }
+    if (auto result = computeSumOverDistinctValues()) {
+      return result;
+    }
   }
   if (auto result = computeGroupByForJoinWithFullScan()) {
     return result;
@@ -1962,6 +1965,165 @@ bool GroupByImpl::isVariableBoundInSubtree(const Variable& variable) const {
 std::unique_ptr<Operation> GroupByImpl::cloneImpl() const {
   return std::make_unique<GroupByImpl>(_executionContext, _groupByVariables,
                                        _aliases, _subtree->clone());
+}
+
+// _____________________________________________________________________________
+namespace {
+std::optional<Permutation::Enum> permutationWithWantedCol1(
+    const IndexScan& scan, const Variable& wantedCol1) {
+  const bool predBound = !scan.predicate().isVariable();
+  const bool subjBound = !scan.subject().isVariable();
+  const bool objBound = !scan.object().isVariable();
+  if (scan.subject().isVariable() &&
+      scan.subject().getVariable() == wantedCol1) {
+    if (predBound) {
+      return Permutation::PSO;
+    }
+    if (objBound) {
+      return Permutation::OSP;
+    }
+  } else if (scan.object().isVariable() &&
+             scan.object().getVariable() == wantedCol1) {
+    if (predBound) {
+      return Permutation::POS;
+    }
+    if (subjBound) {
+      return Permutation::SOP;
+    }
+  } else if (scan.predicate().isVariable() &&
+             scan.predicate().getVariable() == wantedCol1) {
+    if (subjBound) {
+      return Permutation::SPO;
+    }
+    if (objBound) {
+      return Permutation::OPS;
+    }
+  }
+  return std::nullopt;
+}
+}  // namespace
+
+// _____________________________________________________________________________
+std::optional<IdTable> GroupByImpl::computeSumOverDistinctValues() const {
+  if (!_groupByVariables.empty() || _aliases.size() != 1) {
+    return std::nullopt;
+  }
+  auto* sum = dynamic_cast<sparqlExpression::SumExpression*>(
+      _aliases.front()._expression.getPimpl());
+  if (!sum) {
+    return std::nullopt;
+  }
+  if (sum->isAggregate() ==
+      sparqlExpression::SparqlExpression::AggregateStatus::DistinctAggregate) {
+    return std::nullopt;
+  }
+  auto sumChildren = sum->children();
+  if (sumChildren.size() != 1) {
+    return std::nullopt;
+  }
+  auto innerVars = sumChildren[0]->getUnaggregatedVariables();
+  if (innerVars.size() != 1) {
+    return std::nullopt;
+  }
+  const Variable& wantedVar = innerVars.front();
+
+  auto indexScan =
+      std::dynamic_pointer_cast<const IndexScan>(_subtree->getRootOperation());
+  if (!indexScan || indexScan->numVariables() != 2 ||
+      !indexScan->graphsToFilter().areAllGraphsAllowed() ||
+      !indexScan->additionalVariables().empty()) {
+    return std::nullopt;
+  }
+  if (!isVariableBoundInSubtree(wantedVar)) {
+    return std::nullopt;
+  }
+
+  const auto& locTriples =
+      indexScan->permutation().getLocatedTriplesForPermutation(
+          locatedTriplesState());
+  if (!locTriples.isEmpty() || indexScan->permutation().permutationType() ==
+                                   Permutation::Type::MATERIALIZED_VIEW) {
+    return std::nullopt;
+  }
+
+  const auto& permutedTriple = indexScan->getPermutedTriple();
+  std::optional<Id> col0Id = toValueId(*permutedTriple[0], getIndex());
+  if (!col0Id.has_value()) {
+    return std::nullopt;
+  }
+  auto targetPermutation = permutationWithWantedCol1(*indexScan, wantedVar);
+  if (!targetPermutation.has_value()) {
+    return std::nullopt;
+  }
+  const auto& permutation =
+      getIndex().getImpl().getPermutation(targetPermutation.value());
+  auto distinctIds = permutation.getDistinctCol1IdsAndCounts(
+      col0Id.value(), cancellationHandle_, locatedTriplesState(),
+      indexScan->getLimitOffset());
+
+  auto colOpt = _subtree->getVariableColumnOrNullopt(wantedVar);
+  if (!colOpt.has_value()) {
+    return std::nullopt;
+  }
+  const ColumnIndex col = colOpt.value();
+
+  IdTable row{indexScan->getResultWidth(),
+              getExecutionContext()->getAllocator()};
+  row.emplace_back();
+  for (ColumnIndex c = 0; c < row.numColumns(); ++c) {
+    row(0, c) = Id::makeUndefined();
+  }
+
+  LocalVocab localVocab;
+  double total = 0.0;
+  bool anyDouble = false;
+  auto* inner = sumChildren[0].get();
+  for (size_t i = 0; i < distinctIds.numRows(); ++i) {
+    row(0, col) = distinctIds(i, 0);
+    const int64_t multiplicity = distinctIds(i, 1).getInt();
+    auto ctx = createEvaluationContext(localVocab, row.asStaticView<0>());
+    ctx._beginIndex = 0;
+    ctx._endIndex = 1;
+    auto evaluated = inner->evaluate(&ctx);
+    bool poisoned = false;
+    std::visit(
+        [&](auto&& value) {
+          using T = std::decay_t<decltype(value)>;
+          if constexpr (std::is_same_v<T, Id>) {
+            if (value.isUndefined()) {
+              poisoned = true;
+              return;
+            }
+            if (value.getDatatype() == Datatype::Int) {
+              total += static_cast<double>(value.getInt()) *
+                       static_cast<double>(multiplicity);
+            } else if (value.getDatatype() == Datatype::Double) {
+              anyDouble = true;
+              total += value.getDouble() * static_cast<double>(multiplicity);
+            } else {
+              poisoned = true;
+            }
+          } else {
+            poisoned = true;
+          }
+        },
+        evaluated);
+    if (poisoned) {
+      IdTable table{1, getExecutionContext()->getAllocator()};
+      table.push_back({Id::makeUndefined()});
+      indexScan->updateRuntimeInformationWhenOptimizedOut({});
+      return table;
+    }
+  }
+
+  indexScan->updateRuntimeInformationWhenOptimizedOut({});
+  IdTable table{1, getExecutionContext()->getAllocator()};
+  if (anyDouble) {
+    table.push_back({Id::makeFromDouble(total)});
+  } else {
+    table.push_back({Id::makeFromInt(static_cast<int64_t>(total))});
+  }
+  return table;
 }
 
 // _____________________________________________________________________________

--- a/src/engine/GroupByImpl.h
+++ b/src/engine/GroupByImpl.h
@@ -239,6 +239,12 @@ class GroupByImpl : public Operation {
   // (implicit) group.
   std::optional<IdTable> computeCountStar() const;
 
+  // `SELECT (SUM(f(?v)) AS ?s)` over a two-variable index scan. Evaluates
+  // `f` once per distinct `?v` and multiplies by that value's multiplicity.
+  // Covers YEAR/MONTH/DAY/STRLEN/STRSTARTS and any other deterministic
+  // single-variable numeric function.
+  std::optional<IdTable> computeSumOverDistinctValues() const;
+
   // Stores information required for substitution of an expression in an
   // expression tree.
   struct ParentAndChildIndex {

--- a/test/GroupByTest.cpp
+++ b/test/GroupByTest.cpp
@@ -3327,3 +3327,44 @@ TEST(GroupBy, BlankNodeInGroupBy) {
   EXPECT_EQ(table(1, 1).getDatatype(), Datatype::BlankNodeIndex);
   EXPECT_NE(table(0, 1), table(1, 1));
 }
+
+// _____________________________________________________________________________
+TEST(GroupByOptimizations, sumYearOverDistinctValues) {
+  QecWrapper ctx{std::make_shared<Index>(makeTestIndex(
+      "<x> <published> \"1999\"^^<http://www.w3.org/2001/XMLSchema#gYear> . "
+      "<y> <published> \"2001\"^^<http://www.w3.org/2001/XMLSchema#gYear> . "
+      "<z> <published> \"1999\"^^<http://www.w3.org/2001/XMLSchema#gYear> ."))};
+  auto qec = ctx.makeQec();
+  auto scan = makeExecutionTree<IndexScan>(
+      &qec, Permutation::Enum::PSO,
+      SparqlTripleSimple{Variable{"?s"}, iri("<published>"), Variable{"?o"}});
+  Variable varO{"?o"};
+  auto sumYear = SparqlExpressionPimpl{
+      std::make_unique<SumExpression>(
+          false, makeYearExpression(makeVariableExpression(varO))),
+      "SUM(YEAR(?o))"};
+  std::vector<Alias> aliases{Alias{std::move(sumYear), Variable{"?sum"}}};
+  GroupByImpl groupBy{&qec, {}, aliases, scan};
+  EXPECT_THAT(groupBy.computeResultOnlyForTesting(false),
+              optionalHasTable({{I(5999)}}));
+}
+
+// _____________________________________________________________________________
+TEST(GroupByOptimizations, sumStrlenOverDistinctValues) {
+  QecWrapper ctx{std::make_shared<Index>(
+      makeTestIndex("<x> <label> \"ab\" . <y> <label> \"abc\" . "
+                    "<z> <label> \"ab\" ."))};
+  auto qec = ctx.makeQec();
+  auto scan = makeExecutionTree<IndexScan>(
+      &qec, Permutation::Enum::PSO,
+      SparqlTripleSimple{Variable{"?s"}, iri("<label>"), Variable{"?o"}});
+  Variable varO{"?o"};
+  auto sumStrlen = SparqlExpressionPimpl{
+      std::make_unique<SumExpression>(
+          false, makeStrlenExpression(makeVariableExpression(varO))),
+      "SUM(STRLEN(?o))"};
+  std::vector<Alias> aliases{Alias{std::move(sumStrlen), Variable{"?sum"}}};
+  GroupByImpl groupBy{&qec, {}, aliases, scan};
+  EXPECT_THAT(groupBy.computeResultOnlyForTesting(false),
+              optionalHasTable({{I(7)}}));
+}


### PR DESCRIPTION
## What

`SELECT (SUM(f(?v)) AS ?s)` over a two-variable bound-predicate scan
evaluates `f` once per distinct `?v` and multiplies by that value's
multiplicity from `getDistinctCol1IdsAndCounts`.

Any deterministic numeric `f` of one variable works: `YEAR`, `DAY`,
`MONTH`, `STRLEN`, `STRSTARTS`, and compositions. One UNDEF poisons
the SUM, matching the existing aggregate.

## Why

SPARQLoscope date queries are `SUM(DAY|MONTH|YEAR(?o))` on
`yearOfPublication` (234 ms vs Fluree 0.7 ms for DAY/MONTH).
`strlen` is `SUM(STRLEN(?o))` on `rdfs:label` (7.1 s vs 105 ms).
The distinct-value fold is Fluree's `fast_string_fold` /
`fast_predicate_scalar_agg`.

## Verification

- Unit tests: `SUM(YEAR)` on gYear triples, `SUM(STRLEN)` on literals.
- `GroupByTest` on Ural via ural-wq.