### PR TITLE
Log "Index ... was unloaded" only for indexes that were loaded from disk

### DIFF
--- a/src/engine/Bind.cpp
+++ b/src/engine/Bind.cpp
@@ -121,7 +121,7 @@ IdTable Bind::cloneSubView(const IdTableView<0>& idTable,
 Result Bind::computeResult(bool requestLaziness) {
   AD_LOG_DEBUG << "Get input to BIND operation..." << std::endl;
   std::shared_ptr<const Result> subRes = _subtree->getResult(requestLaziness);
-  AD_LOG_DEBUG << "Got input to Bind operation." << std::endl;
+  AD_LOG_DEBUG << "Got input to Bind operation" << std::endl;
 
   auto applyBind = [this](IdTable idTable, LocalVocab* localVocab) {
     return computeExpressionBind(localVocab, std::move(idTable),
@@ -156,7 +156,7 @@ Result Bind::computeResult(bool requestLaziness) {
     // new words.
     LocalVocab localVocab = subRes->getCopyOfLocalVocab();
     IdTable result = applyBind(subRes->cloneIdTable(), &localVocab);
-    AD_LOG_DEBUG << "BIND result computation done." << std::endl;
+    AD_LOG_DEBUG << "BIND result computation done" << std::endl;
     return {std::move(result), resultSortedOn(), std::move(localVocab)};
   }
 

--- a/src/engine/CountAvailablePredicates.cpp
+++ b/src/engine/CountAvailablePredicates.cpp
@@ -144,7 +144,7 @@ Result CountAvailablePredicates::computeResult(
     return {std::move(idTable), resultSortedOn(), LocalVocab{}};
   } else {
     std::shared_ptr<const Result> subresult = subtree_->getResult();
-    AD_LOG_DEBUG << "CountAvailablePredicates subresult computation done."
+    AD_LOG_DEBUG << "CountAvailablePredicates subresult computation done"
                  << std::endl;
 
     size_t width = subresult->idTableView().numColumns();
@@ -163,7 +163,7 @@ Result CountAvailablePredicates::computeResult(
 void CountAvailablePredicates::computePatternTrickAllEntities(
     IdTable* dynResult, const CompactVectorOfStrings<Id>& patterns) const {
   IdTableStatic<2> result = std::move(*dynResult).toStatic<2>();
-  AD_LOG_DEBUG << "For all entities." << std::endl;
+  AD_LOG_DEBUG << "For all entities" << std::endl;
   ad_utility::HashMap<Id, size_t> predicateCounts;
   ad_utility::HashMap<size_t, size_t> patternCounts;
   const auto& index = getExecutionContext()->getIndex().getImpl();
@@ -255,7 +255,7 @@ void CountAvailablePredicates::computePatternTrick(
       },
       numThreads);
   AD_LOG_DEBUG << "Using " << patternCounts.size()
-               << " patterns for computing the result." << std::endl;
+               << " patterns for computing the result" << std::endl;
   // the number of predicates counted with patterns
   size_t numPredicatesSubsumedInPatterns = 0;
 

--- a/src/engine/Distinct.cpp
+++ b/src/engine/Distinct.cpp
@@ -100,7 +100,7 @@ Result Distinct::computeResult(bool requestLaziness) {
         ad_utility::callFixedSizeVi(width, [&, self = this](auto width) {
           return self->outOfPlaceDistinct<width>(subRes->idTableView());
         });
-    AD_LOG_DEBUG << "Distinct result computation done." << endl;
+    AD_LOG_DEBUG << "Distinct result computation done" << endl;
     return {std::move(idTable), resultSortedOn(),
             subRes->getSharedLocalVocab()};
   }
@@ -128,7 +128,7 @@ IdTable Distinct::distinct(
     IdTable dynInput,
     std::optional<typename IdTableStatic<WIDTH>::row_type> previousRow) const {
   AD_CONTRACT_CHECK(keepIndices_.size() <= dynInput.numColumns());
-  AD_LOG_DEBUG << "Distinct on " << dynInput.size() << " elements.\n";
+  AD_LOG_DEBUG << "Distinct on " << dynInput.size() << " elements\n";
   IdTableStatic<WIDTH> result = std::move(dynInput).toStatic<WIDTH>();
 
   // Variant of `ql::ranges::unique` that allows to skip the begin rows of
@@ -172,7 +172,7 @@ IdTable Distinct::distinct(
   result.erase(dest, end);
   checkCancellation();
 
-  AD_LOG_DEBUG << "Distinct done.\n";
+  AD_LOG_DEBUG << "Distinct done\n";
   return std::move(result).toDynamic();
 }
 
@@ -180,7 +180,7 @@ IdTable Distinct::distinct(
 template <size_t WIDTH>
 IdTable Distinct::outOfPlaceDistinct(const IdTableView<0>& dynInput) const {
   AD_CONTRACT_CHECK(keepIndices_.size() <= dynInput.numColumns());
-  AD_LOG_DEBUG << "Distinct on " << dynInput.size() << " elements.\n";
+  AD_LOG_DEBUG << "Distinct on " << dynInput.size() << " elements\n";
   auto inputView = dynInput.asStaticView<WIDTH>();
   IdTableStatic<WIDTH> output{dynInput.numColumns(), allocator()};
 
@@ -213,7 +213,7 @@ IdTable Distinct::outOfPlaceDistinct(const IdTableView<0>& dynInput) const {
     } while (begin != end && matchesRow(*begin, begin[-1]));
   }
 
-  AD_LOG_DEBUG << "Distinct done.\n";
+  AD_LOG_DEBUG << "Distinct done\n";
   return std::move(output).toDynamic();
 }
 

--- a/src/engine/ExportQueryExecutionTrees.cpp
+++ b/src/engine/ExportQueryExecutionTrees.cpp
@@ -539,7 +539,7 @@ STREAMABLE_GENERATOR_TYPE ExportQueryExecutionTrees::selectQueryResultToStream(
       cancellationHandle->throwIfCancelled();
     }
   }
-  AD_LOG_DEBUG << "Done creating readable result.\n";
+  AD_LOG_DEBUG << "Done creating readable result\n";
 }
 
 // _____________________________________________________________________________

--- a/src/engine/Filter.cpp
+++ b/src/engine/Filter.cpp
@@ -71,7 +71,7 @@ Result Filter::computeResult(bool requestLaziness) {
 
   if (subRes->isFullyMaterialized()) {
     IdTable result = filterIdTable(subRes->sortedBy(), subRes->idTableView());
-    AD_LOG_DEBUG << "Filter result computation done." << endl;
+    AD_LOG_DEBUG << "Filter result computation done" << endl;
 
     return {std::move(result), resultSortedOn(), subRes->getSharedLocalVocab()};
   }
@@ -108,7 +108,7 @@ Result Filter::computeResult(bool requestLaziness) {
         }
       });
 
-  AD_LOG_DEBUG << "Filter result computation done." << endl;
+  AD_LOG_DEBUG << "Filter result computation done" << endl;
 
   return {std::move(result), resultSortedOn(), std::move(resultLocalVocab)};
 }

--- a/src/engine/GroupByImpl.cpp
+++ b/src/engine/GroupByImpl.cpp
@@ -714,7 +714,7 @@ Result GroupByImpl::computeResult(bool requestLaziness) {
             subresult->idTableView(), groupByCols, aggregates, &localVocab);
       });
 
-  AD_LOG_DEBUG << "GroupBy result computation done." << std::endl;
+  AD_LOG_DEBUG << "GroupBy result computation done" << std::endl;
   return {std::move(idTable), resultSortedOn(), std::move(localVocab)};
 }
 

--- a/src/engine/IndexScan.cpp
+++ b/src/engine/IndexScan.cpp
@@ -322,7 +322,7 @@ IdTable IndexScan::materializedIndexScan() const {
   IdTable idTable = permutation().scan(scanSpecAndBlocks_, additionalColumns(),
                                        cancellationHandle_,
                                        locatedTriplesState(), getLimitOffset());
-  AD_LOG_DEBUG << "IndexScan result computation done.\n";
+  AD_LOG_DEBUG << "IndexScan result computation done\n";
   checkCancellation();
   idTable = makeApplyColumnSubset()(std::move(idTable));
   AD_CORRECTNESS_CHECK(idTable.numColumns() == getResultWidth());

--- a/src/engine/JoinImpl.cpp
+++ b/src/engine/JoinImpl.cpp
@@ -307,7 +307,7 @@ void JoinImpl::computeSizeEstimateAndMultiplicities() {
 
 void JoinImpl::join(const IdTableView<0>& a, const IdTableView<0>& b,
                     IdTable* result) const {
-  AD_LOG_DEBUG << "Performing join between two tables.\n";
+  AD_LOG_DEBUG << "Performing join between two tables\n";
   AD_LOG_DEBUG << "A: width = " << a.numColumns() << ", size = " << a.size()
                << "\n";
   AD_LOG_DEBUG << "B: width = " << b.numColumns() << ", size = " << b.size()
@@ -391,7 +391,7 @@ void JoinImpl::join(const IdTableView<0>& a, const IdTableView<0>& b,
   // the order.
   result->setColumnSubset(joinColumnData.permutationResult());
 
-  AD_LOG_DEBUG << "Join done.\n";
+  AD_LOG_DEBUG << "Join done\n";
   AD_LOG_DEBUG << "Result: width = " << result->numColumns()
                << ", size = " << result->size() << "\n";
 }
@@ -434,7 +434,7 @@ void JoinImpl::hashJoinImpl(const IdTable& dynA, ColumnIndex jc1,
   const IdTableView<L_WIDTH> a = dynA.asStaticView<L_WIDTH>();
   const IdTableView<R_WIDTH> b = dynB.asStaticView<R_WIDTH>();
 
-  AD_LOG_DEBUG << "Performing hashJoin between two tables.\n";
+  AD_LOG_DEBUG << "Performing hashJoin between two tables\n";
   AD_LOG_DEBUG << "A: width = " << a.numColumns() << ", size = " << a.size()
                << "\n";
   AD_LOG_DEBUG << "B: width = " << b.numColumns() << ", size = " << b.size()
@@ -518,7 +518,7 @@ void JoinImpl::hashJoinImpl(const IdTable& dynA, ColumnIndex jc1,
   }
   *dynRes = std::move(result).toDynamic();
 
-  AD_LOG_DEBUG << "HashJoin done.\n";
+  AD_LOG_DEBUG << "HashJoin done\n";
   AD_LOG_DEBUG << "Result: width = " << dynRes->numColumns()
                << ", size = " << dynRes->size() << "\n";
 }

--- a/src/engine/MaterializedViews.cpp
+++ b/src/engine/MaterializedViews.cpp
@@ -470,7 +470,7 @@ MaterializedViewsManager::loadViewIntoLockedState(
   // all views. Therefore query analysis is performed when loading views.
   if (state.queryPatternCache_.analyzeView(view, qec)) {
     AD_LOG_INFO << "The materialized view '" << name
-                << "' was added to the query pattern cache." << std::endl;
+                << "' was added to the query pattern cache" << std::endl;
   }
   return view;
 }

--- a/src/engine/MaterializedViewsQueryAnalysis.cpp
+++ b/src/engine/MaterializedViewsQueryAnalysis.cpp
@@ -345,13 +345,13 @@ bool QueryPatternCache::analyzeView(ViewPtr view, QueryExecutionContext* qec) {
     AD_LOG_INFO << "Materialized view '" << view->name()
                 << "' will not be added to the query pattern cache for "
                    "pattern-based (star/chain) query rewriting. Reason: "
-                << reason << "." << std::endl;
+                << reason << std::endl;
   };
 
   const auto& parsed = view->parsedQuery();
   if (!parsed.has_value()) {
     explainIgnore(
-        "The view was built without remembering the original query string.");
+        "The view was built without remembering the original query string");
     return false;
   }
 
@@ -375,7 +375,7 @@ bool QueryPatternCache::analyzeView(ViewPtr view, QueryExecutionContext* qec) {
       AD_LOG_INFO << "Materialized view '" << view->name()
                   << "' has the same cache key as the already loaded view '"
                   << it->second->view_->name()
-                  << "'. Only the latter can be matched by cache key."
+                  << "'. Only the latter can be matched by cache key"
                   << std::endl;
     }
     return inserted;

--- a/src/engine/MultiColumnJoin.cpp
+++ b/src/engine/MultiColumnJoin.cpp
@@ -72,7 +72,7 @@ Result MultiColumnJoin::computeResult([[maybe_unused]] bool requestLaziness) {
 
   checkCancellation();
 
-  AD_LOG_DEBUG << "MultiColumnJoin subresult computation done." << std::endl;
+  AD_LOG_DEBUG << "MultiColumnJoin subresult computation done" << std::endl;
 
   AD_LOG_DEBUG << "Computing a multi column join between results of size "
                << leftResult->idTableView().size() << " and "

--- a/src/engine/OptionalJoin.cpp
+++ b/src/engine/OptionalJoin.cpp
@@ -172,7 +172,7 @@ Result OptionalJoin::computeResult(bool requestLaziness) {
 
   checkCancellation();
 
-  AD_LOG_DEBUG << "OptionalJoin subresult computation done." << std::endl;
+  AD_LOG_DEBUG << "OptionalJoin subresult computation done" << std::endl;
 
   if (!leftResult->isFullyMaterialized() ||
       !rightResult->isFullyMaterialized()) {
@@ -189,7 +189,7 @@ Result OptionalJoin::computeResult(bool requestLaziness) {
 
   checkCancellation();
 
-  AD_LOG_DEBUG << "OptionalJoin result computation done." << endl;
+  AD_LOG_DEBUG << "OptionalJoin result computation done" << endl;
   // If only one of the two operands has a non-empty local vocabulary, share
   // with that one (otherwise, throws an exception).
   return {std::move(idTable), resultSortedOn(),

--- a/src/engine/OrderBy.cpp
+++ b/src/engine/OrderBy.cpp
@@ -126,7 +126,7 @@ Result OrderBy::computeResult([[maybe_unused]] bool requestLaziness) {
   // We can't check during sort, so reset status here
   cancellationHandle_->resetWatchDogState();
   checkCancellation();
-  AD_LOG_DEBUG << "OrderBy result computation done." << endl;
+  AD_LOG_DEBUG << "OrderBy result computation done" << endl;
   return {std::move(idTable), resultSortedOn(), subRes->getSharedLocalVocab()};
 }
 

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -1560,7 +1560,7 @@ QueryPlanner::runDynamicProgrammingOnConnectedComponent(
   size_t numSeeds = findUniqueNodeIds(dpTab.back(), false);
 
   for (size_t k = 2; k <= numSeeds; ++k) {
-    AD_LOG_TRACE << "Producing plans that unite " << k << " triples."
+    AD_LOG_TRACE << "Producing plans that unite " << k << " triples"
                  << std::endl;
     applyFiltersIfPossible<FilterMode::KeepUnfiltered>(dpTab.back(), filters);
     applyTextLimitsIfPossible(dpTab.back(), textLimits, false);
@@ -2166,7 +2166,7 @@ bool QueryPlanner::TripleGraph::isSimilar(
         AD_LOG_INFO << other.asString() << std::endl;
         AD_LOG_INFO << "The node with id " << id << " is connected to " << a
                     << " in this graph graph but not to the equivalent "
-                       "node in the other graph."
+                       "node in the other graph"
                     << std::endl;
         return false;
       }
@@ -2177,7 +2177,7 @@ bool QueryPlanner::TripleGraph::isSimilar(
         AD_LOG_INFO << other.asString() << std::endl;
         AD_LOG_INFO << "The node with id " << id << " is connected to " << a
                     << " in the other graph graph but not to the equivalent "
-                       "node in this graph."
+                       "node in this graph"
                     << std::endl;
         return false;
       }

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -1512,14 +1512,14 @@ Awaitable<qlever::IndexRebuildConfig> Server::rebuildIndex(
     AD_LOG_WARN << "A text index was loaded for the current index, but text "
                    "search will no longer work after the rebuild completes. "
                    "Restart the server using the original index to re-enable "
-                   "text search."
+                   "text search"
                 << std::endl;
   }
   if (oldManager.hasLoadedViews()) {
     AD_LOG_WARN
         << "Materialized views were loaded for the current index, but they "
            "will no longer be available after the rebuild completes. You'll "
-           "have to recompute them on the rebuilt index."
+           "have to recompute them on the rebuilt index"
         << std::endl;
   }
   // NOTE: We deliberately use the plain `runFunctionOnExecutor` and not

--- a/src/engine/Sort.cpp
+++ b/src/engine/Sort.cpp
@@ -251,7 +251,7 @@ std::optional<std::shared_ptr<QueryExecutionTree>> Sort::makeSortedTree(
   AD_CONTRACT_CHECK(!isSortedBy(sortColumns));
   AD_LOG_DEBUG
       << "Tried to re-sort a subtree that is already sorted by `Sort` with a "
-         "different sort order. This indicates a flaw during query planning."
+         "different sort order. This indicates a flaw during query planning"
       << std::endl;
   return ad_utility::makeExecutionTree<Sort>(_executionContext, subtree_,
                                              sortColumns, explicitSort_);

--- a/src/engine/SortPerformanceEstimator.cpp
+++ b/src/engine/SortPerformanceEstimator.cpp
@@ -100,7 +100,7 @@ auto SortPerformanceEstimator::estimatedSortTime(
   AD_LOG_TRACE << "Closest sample result was " << sampleValuesRows[rowIndex]
                << " rows with " << sampleValuesCols[columnIndex]
                << " columns and an estimate of " << Timer::toSeconds(result)
-               << " seconds." << std::endl;
+               << " seconds" << std::endl;
 
   auto numRowsInSample = static_cast<double>(sampleValuesRows[rowIndex]);
   double rowRatio = static_cast<double>(numRows) / numRowsInSample;
@@ -186,11 +186,11 @@ void SortPerformanceEstimator::computeEstimatesExpensively(
           AD_LOG_WARN
               << "Could not create any estimate for the sorting performance. "
               << "Setting all estimates to 0. This means that no sort "
-              << "operations will be canceled." << std::endl;
+              << "operations will be canceled" << std::endl;
         }
         AD_LOG_TRACE << "Estimated the sort time to be " << std::fixed
                      << std::setprecision(3) << Timer::toSeconds(_samples[i][j])
-                     << " seconds." << std::endl;
+                     << " seconds" << std::endl;
       }
     }
   }

--- a/src/engine/Union.cpp
+++ b/src/engine/Union.cpp
@@ -249,7 +249,7 @@ Result Union::computeResult(bool requestLaziness) {
             resultSortedOn()};
   }
 
-  AD_LOG_DEBUG << "Union subresult computation done." << std::endl;
+  AD_LOG_DEBUG << "Union subresult computation done" << std::endl;
 
   IdTable idTable = computeUnion(subRes1->idTableView(), subRes2->idTableView(),
                                  _columnOrigins);

--- a/src/index/DeltaTriples.cpp
+++ b/src/index/DeltaTriples.cpp
@@ -442,7 +442,7 @@ void DeltaTriples::modifyTriplesImpl(CancellationHandle cancellationHandle,
                                      ad_utility::timer::TimeTracer& tracer) {
   AD_LOG_DEBUG << (insertOrDelete ? "Inserting" : "Deleting") << " "
                << triples.size() << (isInternal ? " internal" : "")
-               << " triples (including idempotent triples)." << std::endl;
+               << " triples (including idempotent triples)" << std::endl;
   auto [targetMap, inverseMap] = [this]() {
     auto& state = getState<isInternal>();
     if constexpr (insertOrDelete) {

--- a/src/index/FTSAlgorithms.cpp
+++ b/src/index/FTSAlgorithms.cpp
@@ -46,6 +46,6 @@ IdTable FTSAlgorithms::filterByRange(const IdRange<WordVocabIndex>& idRange,
   idTableResult.resize(nofResultElements);
 
   AD_LOG_DEBUG << "Filtering by ID range done. Result has "
-               << idTableResult.numRows() << " elements.\n";
+               << idTableResult.numRows() << " elements\n";
   return idTableResult;
 }

--- a/src/index/IdTableUtils.h
+++ b/src/index/IdTableUtils.h
@@ -43,7 +43,7 @@ class IdTableUtils {
                 });
     }
     *tab = std::move(stab).toDynamic();
-    AD_LOG_TRACE << "Sort done.\n";
+    AD_LOG_TRACE << "Sort done\n";
   }
   // The effect of the third template argument is that if C does not have
   // operator() with the specified arguments that returns bool, then this
@@ -55,7 +55,7 @@ class IdTableUtils {
           bool, std::invoke_result_t<C, typename IdTableStatic<WIDTH>::row_type,
                                      typename IdTableStatic<WIDTH>::row_type>>>>
   static void sort(IdTable* tab, C comp) {
-    AD_LOG_DEBUG << "Sorting " << tab->size() << " elements.\n";
+    AD_LOG_DEBUG << "Sorting " << tab->size() << " elements\n";
     IdTableStatic<WIDTH> stab = std::move(*tab).toStatic<WIDTH>();
     if constexpr (USE_PARALLEL_SORT) {
       ad_utility::parallel_sort(stab.begin(), stab.end(), comp,
@@ -64,7 +64,7 @@ class IdTableUtils {
       std::sort(stab.begin(), stab.end(), comp);
     }
     *tab = std::move(stab).toDynamic();
-    AD_LOG_DEBUG << "Sort done.\n";
+    AD_LOG_DEBUG << "Sort done\n";
   }
 
   static void sort(IdTable& idTable, const std::vector<ColumnIndex>& sortCols);

--- a/src/index/Index.cpp
+++ b/src/index/Index.cpp
@@ -18,8 +18,10 @@ Index::Index(Index&&) noexcept = default;
 // See
 // https://stackoverflow.com/questions/13414652/forward-declaration-with-unique-ptr
 Index::~Index() {
-  if (pimpl_) {
-    AD_LOG_INFO << "Index at " << pimpl_->getOnDiskBase() << " was unloaded."
+  // Only log for an index that was actually loaded from disk (e.g. the old
+  // index after a `rebuild-index` swap), not for a freshly built one.
+  if (pimpl_ && pimpl_->wasLoadedFromDisk()) {
+    AD_LOG_INFO << "Index at " << pimpl_->getOnDiskBase() << " was unloaded"
                 << std::endl;
   }
 }

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -1121,7 +1121,7 @@ void IndexImpl::createFromOnDiskIndex(const std::string& onDiskBase,
     AD_LOG_INFO
         << "No permutations were loaded due to `doNotLoadPermutations` "
            "being set to true. Only queries that don't contain any triples "
-           "can be executed."
+           "can be executed"
         << std::endl;
   } else {
     load(pso_, true);
@@ -1161,6 +1161,7 @@ void IndexImpl::createFromOnDiskIndex(const std::string& onDiskBase,
   if (persistUpdatesOnDisk) {
     setFilenamesForPersistentUpdates(true);
   }
+  wasLoadedFromDisk_ = true;
 }
 
 // _____________________________________________________________________________
@@ -1398,7 +1399,7 @@ void IndexImpl::applyConfiguration(const nlohmann::json& configuration) {
                " (PR = "
             << indexFormatVersion.prNumber_
             << ", Date = " << indexFormatVersion.date_.toStringAndType().first
-            << ")." << std::endl;
+            << ")" << std::endl;
       } else {
         AD_LOG_ERROR
             << "The index is too old for this version of QLever. "
@@ -1408,7 +1409,7 @@ void IndexImpl::applyConfiguration(const nlohmann::json& configuration) {
                "this index (PR = "
             << indexFormatVersion.prNumber_
             << ", Date = " << indexFormatVersion.date_.toStringAndType().first
-            << ")." << std::endl;
+            << ")" << std::endl;
       }
       throw std::runtime_error{
           "Incompatible index format, see log message for details"};
@@ -1417,7 +1418,7 @@ void IndexImpl::applyConfiguration(const nlohmann::json& configuration) {
     AD_LOG_ERROR
         << "This index was built before versioning was introduced for "
            "QLever's index format. Please rebuild your index using the "
-           "current version of QLever."
+           "current version of QLever"
         << std::endl;
     throw std::runtime_error{
         "Incompatible index format, see log message for details"};
@@ -1678,7 +1679,7 @@ void IndexImpl::readIndexBuilderSettingsFromFile() {
     parserBatchSize_ = size_t{j["parser-batch-size"]};
     AD_LOG_INFO << "Overriding setting parser-batch-size to "
                 << parserBatchSize_
-                << " This might influence performance during index build."
+                << " This might influence performance during index build"
                 << std::endl;
   }
 

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -131,6 +131,10 @@ class IndexImpl {
   // If false, only PSO and POS permutations are loaded and expected.
   bool loadAllPermutations_ = true;
 
+  // True iff this index was loaded via `createFromOnDiskIndex`, as opposed to
+  // being built by `createFromFiles` or never having been populated at all.
+  bool wasLoadedFromDisk_ = false;
+
   // Pattern trick data
   bool usePatterns_ = false;
   double avgNumDistinctPredicatesPerSubject_;
@@ -577,6 +581,8 @@ class IndexImpl {
   }
 
   bool hasAllPermutations() const { return SPO().isLoaded(); }
+
+  bool wasLoadedFromDisk() const { return wasLoadedFromDisk_; }
 
   // ___________________________________________________________________________
   std::vector<float> getMultiplicities(

--- a/src/index/TextIndexBuilder.cpp
+++ b/src/index/TextIndexBuilder.cpp
@@ -345,7 +345,7 @@ void TextIndexBuilder::createTextIndex(const std::string& filename,
                                        classic, entity));
   classicPostings.clear();
   entityPostings.clear();
-  AD_LOG_DEBUG << "Done creating text index." << std::endl;
+  AD_LOG_DEBUG << "Done creating text index" << std::endl;
   AD_LOG_INFO << "Statistics for text index: " << textMeta_.statistics()
               << std::endl;
 
@@ -548,7 +548,7 @@ void TextIndexBuilder::buildDocsDB(const std::string& docsFileName) const {
   std::ifstream offsetsIn =
       ad_utility::makeIfstream(offsetsFilename, std::ios::binary);
   ofs << offsetsIn.rdbuf();
-  AD_LOG_INFO << "DocsDB done.\n";
+  AD_LOG_INFO << "DocsDB done\n";
 }
 
 #endif

--- a/src/index/TextIndexReadWrite.h
+++ b/src/index/TextIndexReadWrite.h
@@ -255,7 +255,7 @@ void readFreqComprList(OutputIterator iterator, size_t nofElements, off_t from,
     *iterator = transformer(codebook.at(encoded));
     ++iterator;
   });
-  AD_LOG_DEBUG << "Done reading frequency-encoded list.";
+  AD_LOG_DEBUG << "Done reading frequency-encoded list";
 }
 
 /**
@@ -316,7 +316,7 @@ void readGapComprList(OutputIterator iterator, size_t nofElements, off_t from,
     *iterator = transformer(previous);
     ++iterator;
   }
-  AD_LOG_DEBUG << "Done reading gap-encoded list.";
+  AD_LOG_DEBUG << "Done reading gap-encoded list";
 }
 
 }  // namespace textIndexReadWrite

--- a/src/libqlever/Qlever.cpp
+++ b/src/libqlever/Qlever.cpp
@@ -106,7 +106,7 @@ Qlever::Qlever(const EngineConfig& config, bool skipLoading,
       materializedViewsManager.loadView(viewName, qec.get());
     } catch (const std::exception& ex) {
       AD_LOG_ERROR << "Preloading materialized view '" << viewName
-                   << "' failed: " << ex.what() << "." << std::endl;
+                   << "' failed: " << ex.what() << std::endl;
     }
   }
 }

--- a/src/parser/ParallelParseBuffer.h
+++ b/src/parser/ParallelParseBuffer.h
@@ -172,7 +172,7 @@ class ParallelParseBuffer {
         return {false, std::move(buf)};
       }
       if (buf.size() % 10000000 == 0) {
-        AD_LOG_INFO << "Parsed " << buf.size() << " triples." << std::endl;
+        AD_LOG_INFO << "Parsed " << buf.size() << " triples" << std::endl;
       }
     }
     return {true, std::move(buf)};

--- a/src/parser/ParsedQuery.cpp
+++ b/src/parser/ParsedQuery.cpp
@@ -338,7 +338,7 @@ bool ParsedQuery::GraphPattern::addLanguageFilter(
     AD_LOG_DEBUG << "language filter variable " + variable.name() +
                         " did not appear as object in any suitable "
                         "triple. "
-                        "Using literal-to-language predicate instead.\n";
+                        "Using literal-to-language predicate instead\n";
 
     std::vector<BasicGraphPattern> operations;
     for (const auto& langTag : langTags) {

--- a/src/parser/RdfParser.cpp
+++ b/src/parser/RdfParser.cpp
@@ -565,7 +565,7 @@ TripleComponent TurtleParser<T>::literalAndDatatypeToTripleComponentImpl(
         << " could not be parsed as an object of type " << type << sep
         << errorMsg
         << ". It is treated as a plain string literal without datatype "
-           "instead."
+           "instead"
         << std::endl;
     lastParseResult_ = std::move(literal);
   };

--- a/src/rdfTypes/GeometryInfo.cpp
+++ b/src/rdfTypes/GeometryInfo.cpp
@@ -65,7 +65,7 @@ std::optional<GeometryInfo> GeometryInfo::fromWktLiteral(std::string_view wkt) {
   if (!boundingBox.has_value() || !centroid.has_value()) {
     AD_LOG_DEBUG << "The WKT string `" << wkt
                  << "` would lead to an invalid centroid or bounding box. It "
-                    "will thus be treated as an invalid WKT literal."
+                    "will thus be treated as an invalid WKT literal"
                  << std::endl;
     return std::nullopt;
   }
@@ -74,7 +74,7 @@ std::optional<GeometryInfo> GeometryInfo::fromWktLiteral(std::string_view wkt) {
   try {
     area = computeMetricArea(parsed.value());
   } catch (const InvalidPolygonError&) {
-    AD_LOG_DEBUG << "Could not compute area of WKT literal `" << wkt << "`."
+    AD_LOG_DEBUG << "Could not compute area of WKT literal `" << wkt << "`"
                  << std::endl;
   }
 

--- a/src/util/ExceptionHandling.h
+++ b/src/util/ExceptionHandling.h
@@ -186,7 +186,7 @@ class ExceptionCollector {
     AD_LOG_WARN << "`ExceptionCollector` was destroyed without a call to "
                    "`rethrow()` even though an exception was captured. The "
                    "exception will be rethrown now (or logged if rethrowing "
-                   "would call `std::terminate`)."
+                   "would call `std::terminate`)"
                 << std::endl;
     throwIfSafe_(
         [this]() { std::rethrow_exception(std::move(firstException_)); },
@@ -211,7 +211,7 @@ class ExceptionCollector {
                   << ex.what() << std::endl;
     } catch (...) {
       AD_LOG_WARN << "Additional exception of unknown type captured by "
-                     "`ExceptionCollector` while one was already stored."
+                     "`ExceptionCollector` while one was already stored"
                   << std::endl;
     }
   }

--- a/test/IndexTest.cpp
+++ b/test/IndexTest.cpp
@@ -655,7 +655,18 @@ TEST(IndexTest, trivialGettersAndSetters) {
 // _____________________________________________________________________________
 TEST(IndexTest, destructorLogsUnloading) {
   SKIP_IF_LOGLEVEL_IS_LOWER(INFO);
-  // An `Index` that still owns its `IndexImpl` logs on destruction.
+  // An `Index` that was loaded from disk logs on destruction.
+  {
+    std::optional<Index> index;
+    index.emplace(makeTestIndex("destructorLogsUnloading", "<a> <b> <c> ."));
+    auto [cleanup, logStream] = setGlobalLoggingStreamToStringStream();
+    index.reset();
+    EXPECT_THAT(logStream.str(),
+                ::testing::HasSubstr("Index at destructorLogsUnloading was "
+                                     "unloaded"));
+  }
+  // An `Index` that was never loaded from disk (e.g. one that was just built)
+  // stays silent on destruction.
   {
     auto [cleanup, logStream] = setGlobalLoggingStreamToStringStream();
     std::optional<Index> index;
@@ -663,16 +674,15 @@ TEST(IndexTest, destructorLogsUnloading) {
     index->setOnDiskBase("someIndexBase");
     index.reset();
     EXPECT_THAT(logStream.str(),
-                ::testing::HasSubstr("Index at someIndexBase was unloaded"));
+                ::testing::Not(::testing::HasSubstr("was unloaded")));
   }
   // A moved-from `Index` no longer owns an `IndexImpl` and therefore stays
   // silent on destruction. We reset it while `movedInto` is still alive, so no
   // unload message may be logged at that point.
   {
-    auto [cleanup, logStream] = setGlobalLoggingStreamToStringStream();
     std::optional<Index> index;
-    index.emplace(ad_utility::makeUnlimitedAllocator<Id>());
-    index->setOnDiskBase("someIndexBase");
+    index.emplace(makeTestIndex("destructorLogsUnloading2", "<a> <b> <c> ."));
+    auto [cleanup, logStream] = setGlobalLoggingStreamToStringStream();
     Index movedInto{std::move(index).value()};
     index.reset();
     EXPECT_THAT(logStream.str(),


### PR DESCRIPTION
Since #2832, `Index::~Index` logged "Index at <base> was unloaded" for every `Index` that still owned its `IndexImpl`. This also fired at the end of a regular index build, which is confusing. Now the message is only logged for an index that was actually loaded via `createFromOnDiskIndex` (e.g. the old index after a `rebuild-index` swap, or at server shutdown).

While at it, remove the trailing full stop from all log messages that had one, so that they are consistent with the rest of QLever's log output.