### PR TITLE
Join Implementation

### DIFF
--- a/src/engine/AddCombinedRowToTable.h
+++ b/src/engine/AddCombinedRowToTable.h
@@ -20,6 +20,7 @@
 #include "engine/idTable/IdTableConcepts.h"
 #include "global/Id.h"
 #include "index/LocalVocab.h"
+#include "util/Allocator.h"
 #include "util/CancellationHandle.h"
 #include "util/Exception.h"
 #include "util/TransparentFunctors.h"
@@ -33,7 +34,7 @@ namespace ad_utility {
 // (configurable, default value 100'000) is reached, the results are actually
 // written to the table.
 class AddCombinedRowToIdTable {
-  std::vector<size_t> numUndefinedPerColumn_;
+  std::vector<size_t, qlever::Allocator<size_t>> numUndefinedPerColumn_;
   size_t numJoinColumns_;
   // If set to false, then the join columns will not be written to the output.
   // The result table will also have no columns corresponding to the join
@@ -53,8 +54,11 @@ class AddCombinedRowToIdTable {
     size_t targetIndex_;
     std::array<size_t, 2> rowIndices_;
   };
-  // Store the indices that have not yet been written.
-  std::vector<TargetIndexAndRowIndices> indexBuffer_;
+  // Store the indices that have not yet been written. This buffer scales with
+  // the number of rows processed per batch, so it is allocated via the
+  // `qlever::Allocator` seam (see the `allocator` constructor parameter).
+  std::vector<TargetIndexAndRowIndices, qlever::Allocator<TargetIndexAndRowIndices>>
+      indexBuffer_;
 
   // Store the information, which row index from the left input is written to a
   // given index in the output. This is used for OPTIONAL joins where there are
@@ -65,7 +69,8 @@ class AddCombinedRowToIdTable {
   };
 
   // Store the indices of OPTIONAL inputs that have not yet been written.
-  std::vector<TargetIndexAndRowIndex> optionalIndexBuffer_;
+  std::vector<TargetIndexAndRowIndex, qlever::Allocator<TargetIndexAndRowIndex>>
+      optionalIndexBuffer_;
 
   // The total number of optional and non-optional rows that are currently
   // buffered but not yet written to the result. The first row index in the
@@ -88,17 +93,25 @@ class AddCombinedRowToIdTable {
 
  public:
   // Construct from the number of join columns, the two inputs, and the output.
-  // The `bufferSize` can be configured for testing.
+  // The `bufferSize` can be configured for testing. The `allocator` is used for
+  // the internal row-index buffers (`indexBuffer_`/`optionalIndexBuffer_`),
+  // which scale with the number of rows processed per batch; it defaults to an
+  // unlimited allocator so that existing callers that don't pass one are
+  // unaffected.
   explicit AddCombinedRowToIdTable(
       size_t numJoinColumns, IdTableView<0> input1, IdTableView<0> input2,
       IdTable output, CancellationHandle cancellationHandle,
       bool keepJoinColumns = true, size_t bufferSize = 100'000,
-      BlockwiseCallback blockwiseCallback = ad_utility::noop)
-      : numUndefinedPerColumn_(output.numColumns()),
+      BlockwiseCallback blockwiseCallback = ad_utility::noop,
+      qlever::Allocator<Id> allocator = qlever::makeUnlimitedAllocator<Id>())
+      : numUndefinedPerColumn_(output.numColumns(),
+                               allocator.template as<size_t>()),
         numJoinColumns_{numJoinColumns},
         keepJoinColumns_{keepJoinColumns},
         inputLeftAndRight_{std::array{input1, input2}},
         resultTable_{std::move(output)},
+        indexBuffer_{allocator.template as<TargetIndexAndRowIndices>()},
+        optionalIndexBuffer_{allocator.template as<TargetIndexAndRowIndex>()},
         bufferSize_{bufferSize},
         blockwiseCallback_{std::move(blockwiseCallback)},
         cancellationHandle_{std::move(cancellationHandle)} {
@@ -115,12 +128,16 @@ class AddCombinedRowToIdTable {
       size_t numJoinColumns, IdTable output,
       CancellationHandle cancellationHandle, bool keepJoinColumns = true,
       size_t bufferSize = 100'000,
-      BlockwiseCallback blockwiseCallback = ad_utility::noop)
-      : numUndefinedPerColumn_(output.numColumns()),
+      BlockwiseCallback blockwiseCallback = ad_utility::noop,
+      qlever::Allocator<Id> allocator = qlever::makeUnlimitedAllocator<Id>())
+      : numUndefinedPerColumn_(output.numColumns(),
+                               allocator.template as<size_t>()),
         numJoinColumns_{numJoinColumns},
         keepJoinColumns_{keepJoinColumns},
         inputLeftAndRight_{std::nullopt},
         resultTable_{std::move(output)},
+        indexBuffer_{allocator.template as<TargetIndexAndRowIndices>()},
+        optionalIndexBuffer_{allocator.template as<TargetIndexAndRowIndex>()},
         bufferSize_{bufferSize},
         blockwiseCallback_{std::move(blockwiseCallback)},
         cancellationHandle_{std::move(cancellationHandle)} {
@@ -129,7 +146,7 @@ class AddCombinedRowToIdTable {
   }
 
   // Return the number of UNDEF values per column.
-  const std::vector<size_t>& numUndefinedPerColumn() {
+  const std::vector<size_t, qlever::Allocator<size_t>>& numUndefinedPerColumn() {
     flush();
     return numUndefinedPerColumn_;
   }

--- a/src/engine/ExistsJoin.cpp
+++ b/src/engine/ExistsJoin.cpp
@@ -158,8 +158,9 @@ Result ExistsJoin::computeResult(bool requestLaziness) {
 
   // Extract the join columns from both inputs to make the following code
   // easier.
-  ad_utility::JoinColumnMapping joinColumnData{joinColumns_, left.numColumns(),
-                                               right.numColumns()};
+  ad_utility::JoinColumnMapping joinColumnData{
+      joinColumns_, left.numColumns(), right.numColumns(),
+      allocator().template as<ColumnIndex>()};
   IdTableView<0> joinColumnsLeft =
       left.asColumnSubsetView(joinColumnData.jcsLeft());
   IdTableView<0> joinColumnsRight =

--- a/src/engine/JoinHelpers.h
+++ b/src/engine/JoinHelpers.h
@@ -22,6 +22,7 @@
 #include "engine/idTable/IdTable.h"
 #include "index/CompressedRelation.h"
 #include "index/Permutation.h"
+#include "util/Allocator.h"
 #include "util/Exception.h"
 #include "util/Generators.h"
 #include "util/InputRangeUtils.h"
@@ -37,7 +38,8 @@ using namespace ad_utility;
 
 // Forward declaration for `getRowAdderForJoin`.
 
-using OptionalPermutation = std::optional<std::vector<ColumnIndex>>;
+using OptionalPermutation =
+    std::optional<std::vector<ColumnIndex, qlever::Allocator<ColumnIndex>>>;
 
 // _____________________________________________________________________________
 inline void applyPermutation(IdTable& idTable,
@@ -113,7 +115,9 @@ using MaterializedInputView =
 // lazy join algorithms. Note: The `convertGenerator` function above
 // conceptually does exactly the same for lazy inputs.
 inline MaterializedInputView asSingleTableView(
-    const Result& result, const std::vector<ColumnIndex>& permutation) {
+    const Result& result,
+    const std::vector<ColumnIndex, qlever::Allocator<ColumnIndex>>&
+        permutation) {
   return {makeIdTableAndFirstCols<1>(
       result.idTableView().asColumnSubsetView(permutation),
       result.getCopyOfLocalVocab())};
@@ -123,7 +127,9 @@ inline MaterializedInputView asSingleTableView(
 // the lazy result generator. Note that the lifetime of the view is coupled to
 // the lifetime of the result.
 inline std::variant<LazyInputView<1>, MaterializedInputView> resultToView(
-    const Result& result, const std::vector<ColumnIndex>& permutation) {
+    const Result& result,
+    const std::vector<ColumnIndex, qlever::Allocator<ColumnIndex>>&
+        permutation) {
   if (result.isFullyMaterialized()) {
     return asSingleTableView(result, permutation);
   }

--- a/src/engine/JoinImpl.cpp
+++ b/src/engine/JoinImpl.cpp
@@ -748,6 +748,7 @@ ad_utility::JoinColumnMapping JoinImpl::getJoinColumnMapping() const {
   return ad_utility::JoinColumnMapping{{{leftJoinCol_, rightJoinCol_}},
                                        left_->getResultWidth(),
                                        right_->getResultWidth(),
+                                       allocator().template as<ColumnIndex>(),
                                        keepJoinColumn_};
 }
 

--- a/src/engine/JoinImpl.cpp
+++ b/src/engine/JoinImpl.cpp
@@ -47,7 +47,9 @@ JoinImpl::JoinImpl(QueryExecutionContext* qec,
                    ColumnIndex t1JoinCol, ColumnIndex t2JoinCol,
                    bool keepJoinColumn,
                    bool allowSwappingChildrenOnlyForTesting)
-    : Operation(qec), keepJoinColumn_{keepJoinColumn} {
+    : Operation(qec),
+      multiplicities_{allocator().template as<float>()},
+      keepJoinColumn_{keepJoinColumn} {
   AD_CONTRACT_CHECK(t1 && t2);
   // Currently all join algorithms require both inputs to be sorted, so we
   // enforce the sorting here.
@@ -445,17 +447,35 @@ void JoinImpl::hashJoinImpl(const IdTable& dynA, ColumnIndex jc1,
     return;
   }
 
+  // Use the allocator of the result table (which is configured by whoever
+  // requested this join, e.g. `Operation::allocator()`) for the scratch data
+  // structures below as well, so that all dynamic allocations performed by
+  // this hash join are routed through the same (potentially PMR-backed)
+  // memory resource instead of the global heap.
+  auto allocator = dynRes->getAllocator();
+
   IdTableStatic<OUT_WIDTH> result = std::move(*dynRes).toStatic<OUT_WIDTH>();
 
   // Puts the rows of the given table into a hash map, with the value of
   // the join column of a row as the key, and returns the hash map.
-  auto idTableToHashMap = [](const auto& table, const ColumnIndex jc) {
+  auto idTableToHashMap = [&allocator](const auto& table,
+                                       const ColumnIndex jc) {
     // This declaration works, because generic lambdas are just syntactic sugar
     // for templates.
     using Table = std::decay_t<decltype(table)>;
-    ad_utility::HashMap<Id, std::vector<typename Table::row_type>> map;
+    using Row = typename Table::row_type;
+    using RowVector = std::vector<Row, decltype(allocator.as<Row>())>;
+    // `HashMapWithMemoryLimit` (unlike `HashMap`/`absl::flat_hash_map`, see the
+    // comment at its definition) is exception-safe when used with an allocator
+    // that may throw on allocation, which is why it is used here instead.
+    ad_utility::HashMapWithMemoryLimit<Id, RowVector> map{
+        allocator.as<std::pair<const Id, RowVector>>()};
     for (const auto& row : table) {
-      map[row[jc]].push_back(row);
+      auto it = map.find(row[jc]);
+      if (it == map.end()) {
+        it = map.try_emplace(row[jc], RowVector{allocator.as<Row>()}).first;
+      }
+      it->second.push_back(row);
     }
     return map;
   };

--- a/src/engine/JoinImpl.cpp
+++ b/src/engine/JoinImpl.cpp
@@ -329,7 +329,7 @@ void JoinImpl::join(const IdTableView<0>& a, const IdTableView<0>& b,
 
   auto rowAdder = ad_utility::AddCombinedRowToIdTable(
       1, aPermuted, bPermuted, std::move(*result), cancellationHandle_,
-      keepJoinColumn_);
+      keepJoinColumn_, CHUNK_SIZE, ad_utility::noop, allocator());
   auto addRow = [beginLeft = joinColumnL.begin(),
                  beginRight = joinColumnR.begin(),
                  &rowAdder](const auto& itLeft, const auto& itRight) {
@@ -760,7 +760,8 @@ ad_utility::AddCombinedRowToIdTable JoinImpl::makeRowAdder(
       cancellationHandle_,
       keepJoinColumn_,
       CHUNK_SIZE,
-      std::move(callback)};
+      std::move(callback),
+      allocator()};
 }
 
 // _____________________________________________________________________________

--- a/src/engine/JoinImpl.cpp
+++ b/src/engine/JoinImpl.cpp
@@ -471,10 +471,10 @@ void JoinImpl::hashJoinImpl(const IdTable& dynA, ColumnIndex jc1,
     ad_utility::HashMapWithMemoryLimit<Id, RowVector> map{
         allocator.as<std::pair<const Id, RowVector>>()};
     for (const auto& row : table) {
-      auto it = map.find(row[jc]);
-      if (it == map.end()) {
-        it = map.try_emplace(row[jc], RowVector{allocator.as<Row>()}).first;
-      }
+      // `try_emplace` (unlike `map[row[jc]]`) only constructs `RowVector` if
+      // `row[jc]` is a new key, which is required since `RowVector`'s
+      // allocator has no default constructor.
+      auto [it, _] = map.try_emplace(row[jc], RowVector{allocator.as<Row>()});
       it->second.push_back(row);
     }
     return map;

--- a/src/engine/JoinImpl.h
+++ b/src/engine/JoinImpl.h
@@ -12,11 +12,14 @@
 #ifndef QLEVER_SRC_ENGINE_JOINIMPL_H
 #define QLEVER_SRC_ENGINE_JOINIMPL_H
 
+#include <vector>
+
 #include "backports/concepts.h"
 #include "engine/AddCombinedRowToTable.h"
 #include "engine/IndexScan.h"
 #include "engine/Operation.h"
 #include "engine/QueryExecutionTree.h"
+#include "util/Allocator.h"
 #include "util/JoinAlgorithms/JoinColumnMapping.h"
 #include "util/TypeTraits.h"
 
@@ -33,7 +36,7 @@ class JoinImpl : public Operation {
   bool sizeEstimateComputed_;
   size_t sizeEstimate_;
 
-  std::vector<float> multiplicities_;
+  std::vector<float, qlever::Allocator<float>> multiplicities_;
 
   // If set to false, the join column will not be part of the result.
   bool keepJoinColumn_ = true;

--- a/src/engine/Minus.cpp
+++ b/src/engine/Minus.cpp
@@ -21,7 +21,7 @@ using std::string;
 Minus::Minus(QueryExecutionContext* qec,
              std::shared_ptr<QueryExecutionTree> left,
              std::shared_ptr<QueryExecutionTree> right)
-    : Operation{qec} {
+    : Operation{qec}, _multiplicities{allocator().template as<float>()} {
   std::tie(_left, _right, _matchedColumns) =
       QueryExecutionTree::getSortedSubtreesAndJoinColumns(std::move(left),
                                                           std::move(right));
@@ -147,7 +147,8 @@ IdTable Minus::copyMatchingRows(
   AD_CORRECTNESS_CHECK(result.numColumns() == left.numColumns());
 
   // Transform into dense vector of indices.
-  std::vector<size_t> nonMatchingIndices;
+  std::vector<size_t, qlever::Allocator<size_t>> nonMatchingIndices(
+      left.getAllocator().template as<size_t>());
   for (size_t row = 0; row < left.numRows(); ++row) {
     if (keepEntry.at(row) == reference) {
       nonMatchingIndices.push_back(row);
@@ -178,8 +179,9 @@ IdTable Minus::computeMinus(
     return IdTable{left.clone()};
   }
 
-  ad_utility::JoinColumnMapping joinColumnData{joinColumns, left.numColumns(),
-                                               right.numColumns()};
+  ad_utility::JoinColumnMapping joinColumnData{
+      joinColumns, left.numColumns(), right.numColumns(),
+      allocator().template as<ColumnIndex>()};
 
   IdTableView<0> joinColumnsLeft =
       left.asColumnSubsetView(joinColumnData.jcsLeft());
@@ -324,7 +326,8 @@ Result Minus::lazyMinusJoin(std::shared_ptr<const Result> left,
   // Currently only supports a single join column.
   AD_CORRECTNESS_CHECK(_matchedColumns.size() == 1);
 
-  std::vector<ColumnIndex> permutation;
+  std::vector<ColumnIndex, qlever::Allocator<ColumnIndex>> permutation(
+      allocator().template as<ColumnIndex>());
   permutation.resize(_left->getResultWidth());
   ql::ranges::copy(ad_utility::integerRange(permutation.size()),
                    permutation.begin());
@@ -333,15 +336,20 @@ Result Minus::lazyMinusJoin(std::shared_ptr<const Result> left,
   ColumnIndex leftJoinColumn = _matchedColumns.at(0).at(0);
   std::swap(permutation.at(0), permutation.at(leftJoinColumn));
 
+  std::vector<ColumnIndex, qlever::Allocator<ColumnIndex>> rightPermutation(
+      allocator().template as<ColumnIndex>());
+  rightPermutation.push_back(_matchedColumns.at(0).at(1));
+
   auto action =
-      [this, left = std::move(left), right = std::move(right),
-       permutation](std::function<void(IdTable&, LocalVocab&)> yieldTable) {
+      [this, left = std::move(left), right = std::move(right), permutation,
+       rightPermutation](std::function<void(IdTable&, LocalVocab&)>
+                             yieldTable) {
         ad_utility::MinusRowHandler rowAdder{
             _matchedColumns.size(), IdTable{getResultWidth(), allocator()},
             cancellationHandle_, std::move(yieldTable)};
         auto leftRange = qlever::joinHelpers::resultToView(*left, permutation);
-        auto rightRange = qlever::joinHelpers::resultToView(
-            *right, {_matchedColumns.at(0).at(1)});
+        auto rightRange =
+            qlever::joinHelpers::resultToView(*right, rightPermutation);
         std::visit(
             [&rowAdder](auto& leftBlocks, auto& rightBlocks) {
               ad_utility::zipperJoinForBlocksWithPotentialUndef(

--- a/src/engine/Minus.h
+++ b/src/engine/Minus.h
@@ -10,6 +10,7 @@
 
 #include "engine/Operation.h"
 #include "engine/QueryExecutionTree.h"
+#include "util/Allocator.h"
 #include "util/VectorWithMemoryLimit.h"
 
 class Minus : public Operation {
@@ -17,7 +18,7 @@ class Minus : public Operation {
   std::shared_ptr<QueryExecutionTree> _left;
   std::shared_ptr<QueryExecutionTree> _right;
 
-  std::vector<float> _multiplicities;
+  std::vector<float, qlever::Allocator<float>> _multiplicities;
   std::vector<std::array<ColumnIndex, 2>> _matchedColumns;
 
   enum class RowComparison { EQUAL, LEFT_SMALLER, RIGHT_SMALLER };

--- a/src/engine/MultiColumnJoin.cpp
+++ b/src/engine/MultiColumnJoin.cpp
@@ -19,7 +19,7 @@ MultiColumnJoin::MultiColumnJoin(QueryExecutionContext* qec,
                                  std::shared_ptr<QueryExecutionTree> t1,
                                  std::shared_ptr<QueryExecutionTree> t2,
                                  bool allowSwappingChildrenOnlyForTesting)
-    : Operation{qec} {
+    : Operation{qec}, _multiplicities{allocator().template as<float>()} {
   // Make sure subtrees are ordered so that identical queries can be identified.
   if (allowSwappingChildrenOnlyForTesting &&
       t1->getCacheKey() > t2->getCacheKey()) {
@@ -214,8 +214,9 @@ void MultiColumnJoin::computeMultiColumnJoin(
     return;
   }
 
-  ad_utility::JoinColumnMapping joinColumnData{joinColumns, left.numColumns(),
-                                               right.numColumns()};
+  ad_utility::JoinColumnMapping joinColumnData{
+      joinColumns, left.numColumns(), right.numColumns(),
+      allocator().template as<ColumnIndex>()};
 
   IdTableView<0> leftJoinColumns =
       left.asColumnSubsetView(joinColumnData.jcsLeft());

--- a/src/engine/MultiColumnJoin.h
+++ b/src/engine/MultiColumnJoin.h
@@ -10,6 +10,7 @@
 
 #include "engine/Operation.h"
 #include "engine/QueryExecutionTree.h"
+#include "util/Allocator.h"
 
 class MultiColumnJoin : public Operation {
  private:
@@ -18,7 +19,7 @@ class MultiColumnJoin : public Operation {
 
   std::vector<std::array<ColumnIndex, 2>> _joinColumns;
 
-  std::vector<float> _multiplicities;
+  std::vector<float, qlever::Allocator<float>> _multiplicities;
   size_t _sizeEstimate;
   bool _multiplicitiesComputed = false;
 

--- a/src/engine/OptionalJoin.cpp
+++ b/src/engine/OptionalJoin.cpp
@@ -33,6 +33,7 @@ OptionalJoin::OptionalJoin(QueryExecutionContext* qec,
       _left{std::move(t1)},
       _right{std::move(t2)},
       _joinColumns(QueryExecutionTree::getJoinColumns(*_left, *_right)),
+      _multiplicities{allocator().template as<float>()},
       keepJoinColumns_{keepJoinColumns} {
   AD_CORRECTNESS_CHECK(!_joinColumns.empty());
 
@@ -395,7 +396,8 @@ void OptionalJoin::optionalJoin(
   }
 
   ad_utility::JoinColumnMapping joinColumnData{
-      joinColumns, left.numColumns(), right.numColumns(), keepJoinColumns_};
+      joinColumns, left.numColumns(), right.numColumns(),
+      allocator().template as<ColumnIndex>(), keepJoinColumns_};
 
   IdTableView<0> joinColumnsLeft =
       left.asColumnSubsetView(joinColumnData.jcsLeft());
@@ -508,7 +510,7 @@ Result OptionalJoin::lazyOptionalJoin(std::shared_ptr<const Result> left,
   AD_CORRECTNESS_CHECK(_joinColumns.size() == 1);
   ad_utility::JoinColumnMapping joinColMap{
       _joinColumns, _left->getResultWidth(), _right->getResultWidth(),
-      keepJoinColumns_};
+      allocator().template as<ColumnIndex>(), keepJoinColumns_};
 
   auto resultPermutation = joinColMap.permutationResult();
 
@@ -543,7 +545,7 @@ Result OptionalJoin::optionalJoinWithIndexScan(
                            Implementation::OnlyUndefInLastJoinColumnOfLeft);
   ad_utility::JoinColumnMapping joinColMap{
       _joinColumns, _left->getResultWidth(), _right->getResultWidth(),
-      keepJoinColumns_};
+      allocator().template as<ColumnIndex>(), keepJoinColumns_};
 
   auto resultPermutation = joinColMap.permutationResult();
 

--- a/src/engine/OptionalJoin.h
+++ b/src/engine/OptionalJoin.h
@@ -8,6 +8,7 @@
 
 #include "engine/Operation.h"
 #include "engine/QueryExecutionTree.h"
+#include "util/Allocator.h"
 
 // Forward declaration
 class IndexScan;
@@ -28,7 +29,7 @@ class OptionalJoin : public Operation {
 
   std::vector<std::array<ColumnIndex, 2>> _joinColumns;
 
-  std::vector<float> _multiplicities;
+  std::vector<float, qlever::Allocator<float>> _multiplicities;
   size_t _sizeEstimate;
   std::optional<size_t> _costEstimate;
   bool _multiplicitiesComputed = false;

--- a/src/util/JoinAlgorithms/IndexNestedLoopJoin.h
+++ b/src/util/JoinAlgorithms/IndexNestedLoopJoin.h
@@ -11,6 +11,7 @@
 #include "engine/JoinHelpers.h"
 #include "engine/Result.h"
 #include "engine/idTable/IdTable.h"
+#include "util/Allocator.h"
 #include "util/CancellationHandle.h"
 #include "util/ChunkedForLoop.h"
 #include "util/CompilerExtensions.h"
@@ -59,7 +60,8 @@ struct RightFiller {
 // Helper class for `IndexNestedLoopJoin::matchLeft` tracks matches to be used
 // by `OptionalJoin`.
 struct Adder {
-  std::vector<std::array<size_t, 2>> matchingPairs_;
+  std::vector<std::array<size_t, 2>, qlever::Allocator<std::array<size_t, 2>>>
+      matchingPairs_;
   // Should conceptually be bool, but doesn't allow the compiler to use
   // memset in `matchLeft`.
   ad_utility::VectorWithMemoryLimit<char> missingIndices_;
@@ -71,7 +73,8 @@ struct Adder {
                  const ad_utility::AllocatorWithLimit<char>& allocator,
                  ad_utility::SharedCancellationHandle cancellationHandle,
                  size_t numJoinColumns, bool keepJoinColumns)
-      : missingIndices_(size, true, allocator),
+      : matchingPairs_(allocator.template as<std::array<size_t, 2>>()),
+        missingIndices_(size, true, allocator),
         cancellationHandle_{std::move(cancellationHandle)},
         numJoinColumns_{numJoinColumns},
         keepJoinColumns_{keepJoinColumns} {}
@@ -220,7 +223,7 @@ class OptionalJoinRange
 // Helper function for common pattern.
 template <size_t JOIN_COLUMNS, typename IdTableT>
 IdTableView<JOIN_COLUMNS> toStaticView(
-    const IdTableT& idTable, const std::vector<ColumnIndex>& joinColumns) {
+    const IdTableT& idTable, ql::span<const ColumnIndex> joinColumns) {
   static_assert(IdTableLike<IdTableT>);
   return idTable.asColumnSubsetView(joinColumns)
       .template asStaticView<JOIN_COLUMNS>();
@@ -382,7 +385,9 @@ class IndexNestedLoopJoin {
           const IdTableView<0>& leftTable = leftResult_->idTableView();
           size_t numColsLeft = leftTable.numColumns();
           ad_utility::JoinColumnMapping joinColumnData{
-              joinColumns_, numColsLeft, numColsRight, keepJoinColumns};
+              joinColumns_, numColsLeft, numColsRight,
+              leftTable.getAllocator().template as<ColumnIndex>(),
+              keepJoinColumns};
           auto leftTableView = detail::toStaticView<JOIN_COLUMNS>(
               leftTable, joinColumnData.jcsLeft());
           auto matchHelper =

--- a/src/util/JoinAlgorithms/JoinColumnMapping.h
+++ b/src/util/JoinAlgorithms/JoinColumnMapping.h
@@ -13,6 +13,7 @@
 #include "global/Id.h"
 #include "index/LocalVocab.h"
 #include "util/Algorithm.h"
+#include "util/Allocator.h"
 #include "util/TransparentFunctors.h"
 
 namespace ad_utility {
@@ -35,45 +36,62 @@ class JoinColumnMapping {
  private:
   // For a documentation of those members, see the getter function with the same
   // name below.
-  std::vector<ColumnIndex> jcsLeft_;
-  std::vector<ColumnIndex> jcsRight_;
-  std::vector<ColumnIndex> permutationLeft_;
-  std::vector<ColumnIndex> permutationRight_;
-  std::vector<ColumnIndex> permutationResult_;
+  std::vector<ColumnIndex, qlever::Allocator<ColumnIndex>> jcsLeft_;
+  std::vector<ColumnIndex, qlever::Allocator<ColumnIndex>> jcsRight_;
+  std::vector<ColumnIndex, qlever::Allocator<ColumnIndex>> permutationLeft_;
+  std::vector<ColumnIndex, qlever::Allocator<ColumnIndex>> permutationRight_;
+  std::vector<ColumnIndex, qlever::Allocator<ColumnIndex>> permutationResult_;
 
  public:
   // The join columns in the left input. For example if `jcsLeft()` is `[3, 0]`
   // this means that the primary join column is the third column of the left
   // input, and the secondary join column is the 0-th column of the left input.
-  const std::vector<ColumnIndex>& jcsLeft() const { return jcsLeft_; }
+  const std::vector<ColumnIndex, qlever::Allocator<ColumnIndex>>& jcsLeft()
+      const {
+    return jcsLeft_;
+  }
   // The same, but for the right input.
-  const std::vector<ColumnIndex>& jcsRight() const { return jcsRight_; }
+  const std::vector<ColumnIndex, qlever::Allocator<ColumnIndex>>& jcsRight()
+      const {
+    return jcsRight_;
+  }
 
   // This permutation has to be applied to the left input to obtain the column
   // order expected by the join algorithms (see above for details on the
   // different orderings). For example `permutationLeft()[0]` is `jcsLeft_[0]`
   // and `permutationLeft()[numJoinColumns]` is the index of the first non-join
   // column in the left input.
-  const std::vector<ColumnIndex>& permutationLeft() const {
+  const std::vector<ColumnIndex, qlever::Allocator<ColumnIndex>>&
+  permutationLeft() const {
     return permutationLeft_;
   }
   // The same, but for the right input.
-  const std::vector<ColumnIndex>& permutationRight() const {
+  const std::vector<ColumnIndex, qlever::Allocator<ColumnIndex>>&
+  permutationRight() const {
     return permutationRight_;
   }
   // This permutation has to be applied to the result of the join algorithms to
   // obtain the column order that the `Join` subclasses of `Operation` expect.
   // For example, `permutationResult[jcsLeft[0]] = 0`.
-  const std::vector<ColumnIndex>& permutationResult() const {
+  const std::vector<ColumnIndex, qlever::Allocator<ColumnIndex>>&
+  permutationResult() const {
     return permutationResult_;
   }
 
   // Construct the mapping from the `joinColumn` (given as pairs of
   // (leftColIndex, rightColIndex)`), and the total number of columns in the
-  // left and right input respectively.
+  // left and right input respectively. The `allocator` is used for all 5
+  // internal permutation vectors, so that they are routed through the same
+  // (potentially PMR-backed) memory resource as the rest of the operation.
   JoinColumnMapping(const std::vector<std::array<ColumnIndex, 2>>& joinColumns,
                     size_t numColsLeft, size_t numColsRight,
-                    bool keepJoinColumns = true) {
+                    const qlever::Allocator<ColumnIndex>& allocator,
+                    bool keepJoinColumns = true)
+      : jcsLeft_(allocator),
+        jcsRight_(allocator),
+        permutationLeft_(allocator),
+        permutationRight_(allocator),
+        permutationResult_(allocator) {
     permutationResult_.resize(numColsLeft + numColsRight - joinColumns.size());
     for (auto [colA, colB] : joinColumns) {
       permutationResult_.at(colA) = jcsLeft_.size();

--- a/test/AddCombinedRowToTableTest.cpp
+++ b/test/AddCombinedRowToTableTest.cpp
@@ -26,7 +26,13 @@ void testAdder(ad_utility::AddCombinedRowToIdTable& adder,
                IdTable& expectedResult,
                std::vector<size_t> expectedNumUndefined, size_t numJoinColumns,
                bool keepJoinColumns) {
-  auto numUndefined = adder.numUndefinedPerColumn();
+  // `numUndefinedPerColumn()` returns a `qlever::Allocator`-backed vector;
+  // copy it into a plain `std::vector<size_t>` so it can be compared with
+  // `expectedNumUndefined` below (vectors with different allocator types are
+  // not comparable via `operator==`).
+  const auto& numUndefinedRef = adder.numUndefinedPerColumn();
+  std::vector<size_t> numUndefined(numUndefinedRef.begin(),
+                                   numUndefinedRef.end());
   auto result = std::move(adder).resultTable();
   if (!keepJoinColumns) {
     for ([[maybe_unused]] auto i : ad_utility::integerRange(numJoinColumns)) {


### PR DESCRIPTION
- Added custom allocator support to the `multiplicities_` member variable in the JoinImpl class
- Modified the constructor to initialize multiplicities_ with the allocator from the operation's memory context
- Implemented allocator-aware memory management in the hashJoinImpl function:
  - Added logic to extract the allocator from the result table
  - Passed the allocator to the lambda function for hash map construction
- Replaced `ad_utility::HashMap` with `ad_utility::HashMapWithMemoryLimit` for improved exception safety with custom allocators
- Changed row vector storage to use custom-allocated vectors instead of standard vectors
- Updated row insertion logic to use try_emplace for safer allocator-backed insertion
- Added necessary include files: `<vector>` and `util/Allocator.h`
- Fixed constructor initialization to properly initialize allocator members before other member variables

depends on #3113 