### PR TITLE
Marvin staging parallel construct export

### DIFF
--- a/.github/workflows/check_index_version.yml
+++ b/.github/workflows/check_index_version.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
   merge_group:
 
 concurrency:

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -15,7 +15,6 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
   merge_group:
 
 concurrency:
@@ -67,7 +66,7 @@ jobs:
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       # Precompiled headers have to be disabled to make coverage deterministic.
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_TOOLCHAIN_FILE="$(pwd)/toolchains/${{env.compiler}}${{env.compiler-version}}.cmake" -DUSE_PRECOMPILED_HEADERS=OFF -DCMAKE_BUILD_TYPE=${{env.build-type}} -DLOGLEVEL=TIMING -DADDITIONAL_COMPILER_FLAGS="${{env.warnings}} ${{env.asan-flags}} ${{env.ubsan-flags}} ${{env.coverage-flags}}" -DADDITIONAL_LINKER_FLAGS="${{env.coverage-flags}}" -DUSE_PARALLEL=false -DRUN_EXPENSIVE_TESTS=false -DSINGLE_TEST_BINARY=ON -DENABLE_EXPENSIVE_CHECKS=true -DADDITIONAL_LINKER_FLAGS="-fuse-ld=mold"
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_TOOLCHAIN_FILE="$(pwd)/toolchains/${{env.compiler}}${{env.compiler-version}}.cmake" -DUSE_PRECOMPILED_HEADERS=OFF -DCMAKE_BUILD_TYPE=${{env.build-type}} -DLOGLEVEL=TIMING -DBRANCHLESS_LOGGING=ON -DADDITIONAL_COMPILER_FLAGS="${{env.warnings}} ${{env.asan-flags}} ${{env.ubsan-flags}} ${{env.coverage-flags}}" -DADDITIONAL_LINKER_FLAGS="${{env.coverage-flags}}" -DUSE_PARALLEL=false -DRUN_EXPENSIVE_TESTS=false -DSINGLE_TEST_BINARY=ON -DENABLE_EXPENSIVE_CHECKS=true -DADDITIONAL_LINKER_FLAGS="-fuse-ld=mold"
 
     - name: Build
         # Build your program with the given configuration

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
 
 permissions:
   contents: read

--- a/.github/workflows/cpp-17-libqlever.yml
+++ b/.github/workflows/cpp-17-libqlever.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
   merge_group:
 
 concurrency:
@@ -16,48 +15,31 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  # Rewrite the C++20 `using enum` declarations into a form that is also valid
+  # in C++17. The result doesn't depend on the compiler or the Boost version, so
+  # this runs once and the rewritten sources are passed to all the entries of
+  # the `build` matrix below via an artifact. This job has to run directly on
+  # the runner (and not in a `container` like `build`), because it needs Docker.
+  rewrite-using-enum:
     runs-on: ubuntu-24.04
-    # The CMake configure and build commands are platform-agnostic and should work equally
-    # well on Windows or Mac.  You can convert this to a matrix build if you need
-    # cross-platform coverage.
-    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - compiler-version: 11
-            use-keep-going: false
-            use-ignore-errors: false
-            additional-cmake-options: "-DREDUCED_FEATURE_SET_FOR_CPP17=ON"
-          - compiler-version: 8
-            expensive-tests: true
-            use-keep-going: true
-            use-ignore-errors: true
-            # The GCC 8 build additionally exercises the ICU-free (`NO_UNICODE`)
-            # mode, which targets constrained environments without ICU.
-            additional-cmake-options: "-DREDUCED_FEATURE_SET_FOR_CPP17=ON -DUSE_CPP_17_BACKPORTS=ON -DCMAKE_CXX_STANDARD_MANUALLY_OVERRIDDEN=17 -DCOMPILER_VERSION_CHECK_DEACTIVATED=ON -DQLEVER_NO_UNICODE=ON"
-
-
-    env:
-      warnings:   ""
-      build-type: Release
-      expensive-tests: true
-      compiler: gcc
-
     steps:
       - uses: actions/checkout@v7
         with:
           submodules: 'recursive'
-      - name: Install dependencies
-        uses: ./.github/workflows/install-dependencies-ubuntu
-      - name: Install compiler
-        uses: ./.github/workflows/install-compiler-ubuntu
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
         with:
-          compiler: ${{env.compiler}}
-          compiler-version: ${{matrix.compiler-version}}
+          # this might remove tools that are actually needed,
+          # if set to "true" but frees about 6 GB
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: false
+          swap-storage: true
+
       - name: Build the Docker image for the 'using enum' rewriter
-        if: matrix.compiler-version == 8
         run: |
           # The base image ghcr.io/joka921/llvm-cpp-17-rewriter contains a custom
           # clang build with the `backport-using-enum` tool at /opt/llvm/bin/. It
@@ -71,7 +53,6 @@ jobs:
           docker build -f Dockerfiles/Dockerfile.cpp-17-rewriter -t qlever-cpp-17-rewriter:local Dockerfiles
 
       - name: Rewrite C++20 'using enum' for C++17 compatibility
-        if: matrix.compiler-version == 8
         run: |
           # Generate compile_commands.json using the container's clang-21.
           docker run --user "$(id -u):$(id -g)" --rm \
@@ -114,10 +95,113 @@ jobs:
           # Clean up the temporary build directory to save disk space.
           rm -rf ${{github.workspace}}/rewriter-build
 
+      - name: Upload the rewritten sources
+        uses: actions/upload-artifact@v4
+        with:
+          name: rewritten-sources
+          path: src
+          retention-days: 1
+
+  build:
+    needs: rewrite-using-enum
+    runs-on: ubuntu-24.04
+    # Ubuntu 20.04 ships Boost 1.71, the oldest version that QLever supports, in
+    # its standard repositories. Building inside a container of that release is
+    # therefore the simplest way to test against that version: no Boost has to
+    # be built from source or cached. Both matrix entries use it, so the C++17
+    # mode (which is what our users on such old platforms actually compile) is
+    # covered as well.
+    container: ubuntu:20.04
+    # Inside a `container`, the runner falls back to `sh` (which is `dash` on
+    # Ubuntu) as the default shell for `run` steps, instead of the `bash` that
+    # is used for jobs that run directly on the runner. Several steps below use
+    # `bash` syntax (`[[ ... ]]`, `set -o pipefail`), so request `bash`
+    # explicitly. The composite actions that this job uses do the same.
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      fail-fast: false
+      matrix:
+        # The two entries only differ in the compiler and in the C++ standard.
+        # `USE_CPP_17_BACKPORTS` (and with it `boost::filesystem` instead of
+        # `std::filesystem`, see `backports/filesystem.h`) is used in both.
+        include:
+          - compiler-version: 11
+            use-keep-going: false
+            use-ignore-errors: false
+            additional-cmake-options: "-DREDUCED_FEATURE_SET_FOR_CPP17=ON -DUSE_CPP_17_BACKPORTS=ON -DCOMPILER_VERSION_CHECK_DEACTIVATED=ON"
+          - compiler-version: 8
+            expensive-tests: true
+            use-keep-going: true
+            use-ignore-errors: true
+            # Only the GCC 8 build actually lowers the C++ standard to 17, and it
+            # additionally exercises the ICU-free (`NO_UNICODE`) mode, which
+            # targets constrained environments without ICU.
+            additional-cmake-options: "-DREDUCED_FEATURE_SET_FOR_CPP17=ON -DUSE_CPP_17_BACKPORTS=ON -DCMAKE_CXX_STANDARD_MANUALLY_OVERRIDDEN=17 -DCOMPILER_VERSION_CHECK_DEACTIVATED=ON -DQLEVER_NO_UNICODE=ON"
+
+
+    env:
+      warnings:   ""
+      build-type: Release
+      expensive-tests: true
+      compiler: gcc
+
+    # NOTE: The steps below deliberately use paths relative to the workspace
+    # instead of `${{github.workspace}}`. In a container job that expression
+    # still expands to the path on the *host* (`/home/runner/work/qlever/qlever`),
+    # which does not exist inside the container, where the workspace is mounted
+    # at `/__w/qlever/qlever` (the `working-directory` key, in contrast, *is*
+    # translated by the runner, so mixing the two silently used two different
+    # directories). Relative paths are correct in both places.
+    steps:
+      - name: Prepare the container
+        # A bare Ubuntu image has none of these: `actions/checkout` needs `git`
+        # for the submodules, and the composite actions below use `sudo` and
+        # `add-apt-repository`. The steps run as `root`, so `sudo` isn't
+        # available (and isn't needed) yet.
+        #
+        # NOTE: `DEBIAN_FRONTEND=noninteractive` is essential. The install
+        # pulls in `tzdata` as a dependency, whose configuration otherwise
+        # prompts for the time zone and hangs the job forever (only on GitHub
+        # Actions, where stdin of the step stays open; a local `docker run`
+        # with a closed stdin proceeds with the default). Configuring `tzdata`
+        # here once also keeps the later `apt-get` steps of the composite
+        # actions (which run via `sudo` and would not inherit this variable)
+        # from prompting.
+        run: |
+          export DEBIAN_FRONTEND=noninteractive
+          apt-get update
+          apt-get install -y --no-install-recommends ca-certificates git sudo software-properties-common wget
+      - uses: actions/checkout@v7
+        with:
+          submodules: 'recursive'
+      - name: Download the rewritten sources
+        # Replace `src` by the output of the `rewrite-using-enum` job. The
+        # rewritten code is valid C++17 as well as C++20, so both matrix entries
+        # use it.
+        uses: actions/download-artifact@v4
+        with:
+          name: rewritten-sources
+          path: src
+      - name: Install dependencies
+        uses: ./.github/workflows/install-dependencies-ubuntu
+        with:
+          boost-version: "1.71"
+          # Inside a container, the disk space of the host can't be freed.
+          free-disk-space: false
+      - name: Install compiler
+        uses: ./.github/workflows/install-compiler-ubuntu
+        with:
+          compiler: ${{env.compiler}}
+          compiler-version: ${{matrix.compiler-version}}
+          # Ubuntu 20.04 has no `mold` package, so the default linker is used.
+          install-mold: false
+
       - name: Configure CMake
         # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
         # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.build-type}} -DCMAKE_TOOLCHAIN_FILE="$(pwd)/toolchains/${{env.compiler}}${{matrix.compiler-version}}.cmake" -DADDITIONAL_COMPILER_FLAGS="${{env.warnings}}" -DUSE_PARALLEL=false -DRUN_EXPENSIVE_TESTS=${{env.expensive-tests}} -DENABLE_EXPENSIVE_CHECKS=true ${{matrix.additional-cmake-options}} -DADDITIONAL_LINKER_FLAGS="-B /usr/bin/mold"
+        run: cmake -B build -DCMAKE_BUILD_TYPE=${{env.build-type}} -DCMAKE_TOOLCHAIN_FILE="$(pwd)/toolchains/${{env.compiler}}${{matrix.compiler-version}}.cmake" -DADDITIONAL_COMPILER_FLAGS="${{env.warnings}}" -DUSE_PARALLEL=false -DRUN_EXPENSIVE_TESTS=${{env.expensive-tests}} -DENABLE_EXPENSIVE_CHECKS=true ${{matrix.additional-cmake-options}}
 
       - name: Build
         # Build your program with the given configuration
@@ -131,18 +215,18 @@ jobs:
           IGNORE_ERRORS="-i"
           fi
           set -o pipefail # the `tee` will never fail, but the `build` command might. We want to fail if the build fails.
-          cmake --build ${{github.workspace}}/build --target LibQLeverExample --config ${{env.build-type}} -- $IGNORE_ERRORS $KEEP_GOING -j $(nproc) 2>&1 | tee /tmp/build.log
+          cmake --build build --target LibQLeverExample --config ${{env.build-type}} -- $IGNORE_ERRORS $KEEP_GOING -j $(nproc) 2>&1 | tee /tmp/build.log
         id: build
 
       - name: Run gcc8 log analyzer on gcc8 builds
         if: matrix.compiler-version == 8
         run: |
-          python ${{ github.workspace }}/misc/gcc8_logs_analyzer.py /tmp/build.log --on-github
+          python3 misc/gcc8_logs_analyzer.py /tmp/build.log --on-github
         id: gcc8_log_analyzer
       - name: Test
         id: runTest
         if: (matrix.compiler-version == 11)
-        working-directory: ${{github.workspace}}/build/test
+        working-directory: build/test
         # Execute tests defined by the CMake configuration.
         # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-        run: env CTEST_OUTPUT_ON_FAILURE=1 ctest -C ${{matrix.build-type}} -j $(nproc) . -L QleverTest
+        run: env CTEST_OUTPUT_ON_FAILURE=1 ctest -C ${{env.build-type}} -j $(nproc) . -L QleverTest

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,7 +5,6 @@ on:
     branches: [ master ]
     tags: [ 'v*.*.*' ]
   pull_request:
-    branches: [ master ]
 
 env:
   IMAGE: adfreiburg/qlever
@@ -19,8 +18,11 @@ env:
 
 concurrency:
   # When this is not a pull request, then we want all the docker containers to be pushed, we therefore
-  # directly fall back to the commit hash which will be distinct for each push to master.
-  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.sha}}'
+  # directly fall back to the run id which is always distinct.
+  #
+  # NOTE: The commit sha is the same between the tag and commit push, which produce differently
+  # tagged images.
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.run_id}}'
   cancel-in-progress: true
 
 # This workflow is heavily based on https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners .
@@ -47,6 +49,8 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           images: ${{ env.IMAGE }}
+          flavor: &metadata_flavor |
+            latest=false
           # The tag rules are shared with the `docker-merge` job via this YAML
           # anchor, so both jobs derive the same `org.opencontainers.image.version`
           # for the per-arch labels and the multi-arch index annotations.
@@ -57,9 +61,16 @@ jobs:
             type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
             # For pushes to the primary branch, use the normal tags.
             type=raw,value=latest,enable={{is_default_branch}}
-            # Note: this is `pr-` in this step, but the tags are also not used in this step.
-            type=raw,value=pr-${{ steps.pr.outputs.pr_num }},enable={{is_default_branch}}
-            type=sha,prefix=commit-,enable={{is_default_branch}}
+            # `pr_num` is empty in the `build` job (which does not use the tags) and for pushes to
+            # master whose head commit is not the squash-merge of a PR (no "(#<pr>)" suffix). The
+            # non-empty check prevents publishing a bare `pr-` tag in the latter case.
+            #
+            # NOTE: The check is a GitHub expression, which cannot be combined with the
+            # `{{is_default_branch}}` template into a single boolean, so the template is replaced
+            # by its GitHub-expression equivalent.
+            type=raw,value=pr-${{ steps.pr.outputs.pr_num }},enable=${{ github.ref == 'refs/heads/master' && steps.pr.outputs.pr_num != '' }}
+            # Set `priority` higher than `pr-{number}` and `latest` (both 200) to have `commit-{sha}` as the version.
+            type=sha,prefix=commit-,enable={{is_default_branch}},priority=201
             # For pull requests, derive a version from the PR number.
             type=ref,event=pr
       - name: Set up Docker Buildx
@@ -137,6 +148,7 @@ jobs:
           DOCKER_METADATA_ANNOTATIONS_LEVELS: "index"
         with:
           images: ${{ env.IMAGE }}
+          flavor: *metadata_flavor
           # Reuse the tag rules defined in the `build` job (the `image_tags`
           # anchor) so the version is identical in the labels and annotations.
           tags: *image_tags

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
   merge_group:
 
 # The default GITHUB_TOKEN only needs to read the repository here.

--- a/.github/workflows/install-compiler-ubuntu/action.yml
+++ b/.github/workflows/install-compiler-ubuntu/action.yml
@@ -7,6 +7,10 @@ inputs:
   compiler-version:
     description: "the version of the compiler (must be major version)"
     required: true
+  install-mold:
+    description: "Whether to install the `mold` linker. Must be set to false for jobs that run in a `container` of an older distribution (e.g. Ubuntu 20.04), which has no `mold` package"
+    required: false
+    default: "true"
 
 runs:
   using: "composite"
@@ -37,6 +41,13 @@ runs:
     - name: Install gcc8
       if :  inputs.compiler == 'gcc' && inputs.compiler-version == 8
       run:  |
+        # Ubuntu 20.04 (which jobs with a matching `container` run in) has gcc 8
+        # in its standard repositories. On newer releases (like the runner image
+        # itself) the packages have to be downloaded from the Ubuntu 20.04
+        # archive by hand.
+        if sudo apt-get install -y gcc-8 g++-8; then
+          exit 0
+        fi
         wget http://mirrors.kernel.org/ubuntu/pool/universe/g/gcc-8/gcc-8_8.4.0-3ubuntu2_amd64.deb
         wget http://mirrors.edge.kernel.org/ubuntu/pool/universe/g/gcc-8/gcc-8-base_8.4.0-3ubuntu2_amd64.deb
         wget http://mirrors.kernel.org/ubuntu/pool/universe/g/gcc-8/libgcc-8-dev_8.4.0-3ubuntu2_amd64.deb
@@ -49,6 +60,7 @@ runs:
         sudo apt install -y ./libstdc++-8-dev_8.4.0-3ubuntu2_amd64.deb ./g++-8_8.4.0-3ubuntu2_amd64.deb
       shell: bash
     - name: Install mold linker
+      if: inputs.install-mold == 'true'
       shell: bash
       run: |
         sudo apt update

--- a/.github/workflows/install-dependencies-ubuntu/action.yml
+++ b/.github/workflows/install-dependencies-ubuntu/action.yml
@@ -14,11 +14,20 @@ inputs:
     description: "The cmake build version to install if the minimum version is not met"
     required: false
     default: "0"
+  boost-version:
+    description: "The Boost version to install. `latest` installs the most recent version from a PPA, any other value (e.g. `1.71`) installs `libboost<version>-all-dev` from the standard repositories of the distribution that the job runs in. Such old versions have no `Boost::url` and can therefore only be used together with `REDUCED_FEATURE_SET_FOR_CPP17`"
+    required: false
+    default: "latest"
+  free-disk-space:
+    description: "Whether to free disk space on the runner. Must be set to false for jobs that run in a `container`, because the directories that are cleaned up (and the Docker daemon) belong to the host and are not visible from inside the container"
+    required: false
+    default: "true"
 
 runs:
   using: "composite"
   steps:
     - name: Free Disk Space (Ubuntu)
+      if: inputs.free-disk-space == 'true'
       uses: jlumbroso/free-disk-space@main
       with:
           # this might remove tools that are actually needed,
@@ -61,13 +70,29 @@ runs:
 
     - name: Install third-party libraries
       if: inputs.install-third-party-libraries == 'true'
+      # `libssl-dev` is preinstalled on the runner images, but not in a bare
+      # `container` (where its absence fails the CMake configuration with
+      # "Could NOT find OpenSSL").
       run:  |
-        sudo apt-get install -y libicu-dev tzdata libzstd-dev libjemalloc-dev
+        sudo apt-get install -y libicu-dev tzdata libzstd-dev libjemalloc-dev libssl-dev
       shell: bash
 
     - name: Install boost from PPA
-      if: inputs.install-third-party-libraries == 'true'
+      if: inputs.install-third-party-libraries == 'true' && inputs.boost-version == 'latest'
       run: sudo add-apt-repository -y ppa:mhier/libboost-latest && sudo apt update && sudo apt install -y libboost1.83-all-dev libboost-url1.83-dev libboost-container1.83-dev libboost-filesystem1.83-dev
+      shell: bash
+
+    - name: Install Boost ${{inputs.boost-version}}
+      # An explicitly requested (and therefore old) Boost version is taken from
+      # the standard repositories of the distribution that the job runs in, so
+      # the job has to select a matching `container` (Ubuntu 20.04 ships Boost
+      # 1.71, Ubuntu 22.04 ships Boost 1.74). Such old versions don't contain
+      # `Boost::url`, so they can only be used together with
+      # `REDUCED_FEATURE_SET_FOR_CPP17=ON`.
+      if: inputs.install-third-party-libraries == 'true' && inputs.boost-version != 'latest'
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libboost${{inputs.boost-version}}-all-dev
       shell: bash
 
     - name: Install Python packages for E2E tests

--- a/.github/workflows/macos-appleclang-native.yml
+++ b/.github/workflows/macos-appleclang-native.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [master]
   pull_request:
-    branches: [master]
   merge_group:
 
 concurrency:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
   merge_group:
 
 concurrency:

--- a/.github/workflows/native-build-conan.yml
+++ b/.github/workflows/native-build-conan.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
   merge_group:
 
 concurrency:

--- a/.github/workflows/native-build-with-conan-and-emscripten.yml
+++ b/.github/workflows/native-build-with-conan-and-emscripten.yml
@@ -9,7 +9,6 @@ on:
     branches: [ master ]
     tags: [ "v*" ]
   pull_request:
-    branches: [ master ]
   merge_group:
 
 concurrency:

--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
   merge_group:
 
 concurrency:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [master]
   pull_request:
-    branches: [master]
 
 # The default GITHUB_TOKEN only needs to read the repository here.
 permissions:

--- a/.github/workflows/sparql-conformance-new.yml
+++ b/.github/workflows/sparql-conformance-new.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
   merge_group:
 
 permissions:

--- a/.github/workflows/sparql-conformance.yml
+++ b/.github/workflows/sparql-conformance.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
   merge_group:
 
 # The default GITHUB_TOKEN only needs to read the repository here.

--- a/src/engine/ConstructDeduplicator.cpp
+++ b/src/engine/ConstructDeduplicator.cpp
@@ -1,6 +1,6 @@
 // Copyright 2026 The QLever Authors, in particular:
 //
-// 2026 Marvin Stoetzel <marvin.stoetzel@email.uni-freiburg.de>, UFR
+// 2026 Marvin Stoetzel <stoetzem@email.uni-freiburg.de>, UFR
 //
 // UFR = University of Freiburg, Chair of Algorithms and Data Structures
 

--- a/src/engine/ConstructDeduplicator.cpp
+++ b/src/engine/ConstructDeduplicator.cpp
@@ -1,6 +1,6 @@
 // Copyright 2026 The QLever Authors, in particular:
 //
-// 2026 Marvin Stoetzel <stoetzem@email.uni-freiburg.de>, UFR
+// 2026 Marvin Stoetzel <marvin.stoetzel@email.uni-freiburg.de>, UFR
 //
 // UFR = University of Freiburg, Chair of Algorithms and Data Structures
 

--- a/src/engine/ConstructDeduplicator.cpp
+++ b/src/engine/ConstructDeduplicator.cpp
@@ -87,6 +87,11 @@ bool ConstructDeduplicator::isNew(size_t templateTripleIdx,
   if (tmpl.tripleContainsBlankNode_[templateTripleIdx]) {
     return true;
   }
+  // Hold the lock only around the shared ID-space filter and the `dedupVocab_`
+  // re-anchoring. The caller formats the resulting triple to a string outside
+  // this call, i.e. outside the lock, which keeps the parallel export path
+  // from serializing the expensive string formatting.
+  std::lock_guard lock{mutex_};
   // Reset only at a triple boundary, never mid-key (would dangle the key).
   resetIfVocabTooLarge();
   return filter_.insert(makeFullTripleKey(

--- a/src/engine/ConstructDeduplicator.h
+++ b/src/engine/ConstructDeduplicator.h
@@ -1,5 +1,5 @@
 // Copyright 2026 The QLever Authors, in particular:
-// 2026 Marvin Stoetzel <marvin.stoetzel@email.uni-freiburg.de>, UFR
+// 2026 Marvin Stoetzel <stoetzem@email.uni-freiburg.de>, UFR
 //
 // UFR = University of Freiburg, Chair of Algorithms and Data Structures
 

--- a/src/engine/ConstructDeduplicator.h
+++ b/src/engine/ConstructDeduplicator.h
@@ -10,6 +10,7 @@
 #define QLEVER_SRC_ENGINE_CONSTRUCTDEDUPLICATOR_H
 
 #include <functional>
+#include <mutex>
 #include <optional>
 #include <variant>
 
@@ -121,6 +122,10 @@ class ConstructDeduplicator {
 
   // The deduplicator that decides whether a triple was already emitted.
   TripleDeduplicator filter_;
+
+  // Guards the shared deduplication state (`filter_` and `dedupVocab_`) against
+  // concurrent access from the parallel CONSTRUCT export path.
+  mutable std::mutex mutex_;
 
   // Compute the byte threshold that bounds `dedupVocab_` in `Lru` mode:
   // The explicit `maxDedupVocabSize` if given, else a default value that is

--- a/src/engine/ConstructDeduplicator.h
+++ b/src/engine/ConstructDeduplicator.h
@@ -1,5 +1,5 @@
 // Copyright 2026 The QLever Authors, in particular:
-// 2026 Marvin Stoetzel <stoetzem@email.uni-freiburg.de>, UFR
+// 2026 Marvin Stoetzel <marvin.stoetzel@email.uni-freiburg.de>, UFR
 //
 // UFR = University of Freiburg, Chair of Algorithms and Data Structures
 

--- a/src/engine/ConstructTripleGenerator.cpp
+++ b/src/engine/ConstructTripleGenerator.cpp
@@ -104,8 +104,7 @@ auto processTableBatches(const TableWithRange& table, BatchEvalContext context,
   // lambda retain a reference into the by-value `table` parameter.
   auto rowView = table.view_;
   const TableConstRefWithVocab tableWithVocab = table.tableWithVocab_;
-  return ranges::views::chunk(rowView,
-                              ConstructTripleGenerator::BATCH_SIZE) |
+  return ranges::views::chunk(rowView, ConstructTripleGenerator::BATCH_SIZE) |
          ql::views::transform([tableWithVocab, context = std::move(context),
                                tableRowOffset](auto chunkView) {
            return computeBatch(tableWithVocab, chunkView, context,

--- a/src/engine/ConstructTripleGenerator.cpp
+++ b/src/engine/ConstructTripleGenerator.cpp
@@ -98,13 +98,13 @@ CPP_template(typename ChunkView)(requires ranges::range<ChunkView>)
 // non-owning handle (`IdTableView` + `LocalVocab` ref); the underlying result
 // storage must still outlive the whole export, as with every other CONSTRUCT
 // export path.
-auto processTableBatches(TableWithRange table, BatchEvalContext context,
+auto processTableBatches(const TableWithRange& table, BatchEvalContext context,
                          size_t tableRowOffset) {
   // Copy the cheap pieces out first so neither `chunk` nor the transform
   // lambda retain a reference into the by-value `table` parameter.
   auto rowView = table.view_;
   const TableConstRefWithVocab tableWithVocab = table.tableWithVocab_;
-  return ranges::views::chunk(std::move(rowView),
+  return ranges::views::chunk(rowView,
                               ConstructTripleGenerator::BATCH_SIZE) |
          ql::views::transform([tableWithVocab, context = std::move(context),
                                tableRowOffset](auto chunkView) {

--- a/src/engine/ConstructTripleGenerator.cpp
+++ b/src/engine/ConstructTripleGenerator.cpp
@@ -1,6 +1,6 @@
 // Copyright 2026 The QLever Authors, in particular:
 //
-// 2026 Marvin Stoetzel <marvin.stoetzel@email.uni-freiburg.de>, UFR
+// 2026 Marvin Stoetzel <stoetzem@email.uni-freiburg.de>, UFR
 //
 // UFR = University of Freiburg, Chair of Algorithms and Data Structures
 

--- a/src/engine/ConstructTripleGenerator.cpp
+++ b/src/engine/ConstructTripleGenerator.cpp
@@ -1,6 +1,6 @@
 // Copyright 2026 The QLever Authors, in particular:
 //
-// 2026 Marvin Stoetzel <stoetzem@email.uni-freiburg.de>, UFR
+// 2026 Marvin Stoetzel <marvin.stoetzel@email.uni-freiburg.de>, UFR
 //
 // UFR = University of Freiburg, Chair of Algorithms and Data Structures
 

--- a/src/engine/ConstructTripleGenerator.cpp
+++ b/src/engine/ConstructTripleGenerator.cpp
@@ -28,6 +28,17 @@ IdCache ConstructTripleGenerator::makeIdCache(
 
 namespace {
 
+std::shared_ptr<ConstructDeduplicator> makeDeduplicator(
+    const EvaluationConfig& config) {
+  if (config.sharedDeduplicator_) {
+    return config.sharedDeduplicator_;
+  }
+  if (std::holds_alternative<DeduplicationMode::None>(config.mode_.value_)) {
+    return nullptr;
+  }
+  return std::make_shared<ConstructDeduplicator>(config.mode_, config.qec_);
+}
+
 // Bundles the pieces `computeBatch` needs beyond the batch itself.
 struct BatchEvalContext {
   BatchEvalContext(const PreprocessedConstructTemplate& preprocessedTemplate,
@@ -113,11 +124,7 @@ InputRangeTypeErased<EvaluatedTriple> ConstructTripleGenerator::evaluateTables(
       templateTriples, variableColumns, config.index_);
   IdCache cache = makeIdCache(preprocessedTemplate);
 
-  std::shared_ptr<ConstructDeduplicator> deduplicator;
-  if (!std::holds_alternative<DeduplicationMode::None>(config.mode_.value_)) {
-    deduplicator =
-        std::make_shared<ConstructDeduplicator>(config.mode_, config.qec_);
-  }
+  auto deduplicator = makeDeduplicator(config);
 
   auto preprocessedTemplatePtr =
       std::make_shared<const PreprocessedConstructTemplate>(

--- a/src/engine/ConstructTripleGenerator.h
+++ b/src/engine/ConstructTripleGenerator.h
@@ -1,5 +1,5 @@
 // Copyright 2026 The QLever Authors, in particular:
-// 2026 Marvin Stoetzel <marvin.stoetzel@email.uni-freiburg.de>, UFR
+// 2026 Marvin Stoetzel <stoetzem@email.uni-freiburg.de>, UFR
 // UFR = University of Freiburg, Chair of Algorithms and Data Structures
 //
 // You may not use this file except in compliance with the Apache 2.0 License,

--- a/src/engine/ConstructTripleGenerator.h
+++ b/src/engine/ConstructTripleGenerator.h
@@ -24,6 +24,8 @@
 
 namespace qlever::constructExport {
 
+class ConstructDeduplicator;
+
 using ad_utility::InputRangeTypeErased;
 using CancellationHandle = ad_utility::SharedCancellationHandle;
 using Triples = ad_utility::sparql_types::Triples;
@@ -38,6 +40,11 @@ struct EvaluationConfig {
   CancellationHandle cancellationHandle_;
   std::reference_wrapper<const QueryExecutionContext> qec_;
   ad_utility::DeduplicationMode mode_ = ad_utility::DeduplicationMode::none();
+
+  // Deduplicator shared by all chunks of a parallel CONSTRUCT export.
+  // Null means the caller did not share one; `evaluateTables` then creates
+  // a private instance when `mode_` is not `None`.
+  std::shared_ptr<ConstructDeduplicator> sharedDeduplicator_ = nullptr;
 };
 
 // Generates triples from the CONSTRUCT query results by instantiating the

--- a/src/engine/ConstructTripleGenerator.h
+++ b/src/engine/ConstructTripleGenerator.h
@@ -1,5 +1,5 @@
 // Copyright 2026 The QLever Authors, in particular:
-// 2026 Marvin Stoetzel <stoetzem@email.uni-freiburg.de>, UFR
+// 2026 Marvin Stoetzel <marvin.stoetzel@email.uni-freiburg.de>, UFR
 // UFR = University of Freiburg, Chair of Algorithms and Data Structures
 //
 // You may not use this file except in compliance with the Apache 2.0 License,

--- a/src/engine/ExportQueryExecutionTrees.cpp
+++ b/src/engine/ExportQueryExecutionTrees.cpp
@@ -855,15 +855,18 @@ ExportQueryExecutionTrees::constructQueryResultToStream(
 
   if (numThreads <= 1) {
 #ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
-    return constructQueryResultSerial<format>(
+    auto gen = constructQueryResultSerial<format>(
         qet, constructTriples, limitAndOffset, std::move(rowIndices),
         std::move(config), streamableYielder);
+    for (auto&& chunk : gen) {
+      STREAMABLE_YIELD(chunk);
+    }
 #else
     constructQueryResultSerial<format>(qet, constructTriples, limitAndOffset,
                                        std::move(rowIndices), std::move(config),
                                        streamableYielder);
-    return;
 #endif
+    STREAMABLE_RETURN;
   }
 
   if (dedupActive) {
@@ -872,17 +875,19 @@ ExportQueryExecutionTrees::constructQueryResultToStream(
             config.mode_, *qet.getQec());
   }
 #ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
-  return constructQueryResultParallel<format>(
+  auto gen = constructQueryResultParallel<format>(
       qet, constructTriples, limitAndOffset, std::move(rowIndices),
-      std::move(config), numThreads, std::move(cancellationHandle),
-      streamableYielder);
+      std::move(config), numThreads, cancellationHandle, streamableYielder);
+  for (auto&& chunk : gen) {
+    STREAMABLE_YIELD(chunk);
+  }
 #else
   constructQueryResultParallel<format>(
       qet, constructTriples, limitAndOffset, std::move(rowIndices),
       std::move(config), numThreads, std::move(cancellationHandle),
       streamableYielder);
-  return;
 #endif
+  STREAMABLE_RETURN;
 }
 
 // _____________________________________________________________________________

--- a/src/engine/ExportQueryExecutionTrees.cpp
+++ b/src/engine/ExportQueryExecutionTrees.cpp
@@ -41,6 +41,13 @@ namespace {
 using LiteralOrIri = ad_utility::triple_component::LiteralOrIri;
 using Literal = ad_utility::triple_component::Literal;
 
+// `0` for `construct-export-num-threads` means all logical cores.
+size_t resolveConstructExportNumThreads() {
+  const size_t n =
+      getRuntimeParameter<&RuntimeParameters::constructExportNumThreads_>();
+  return n == 0 ? std::max(1u, std::thread::hardware_concurrency()) : n;
+}
+
 // _____________________________________________________________________________
 // Return true iff the `result` is nonempty.
 bool getResultForAsk(const std::shared_ptr<const Result>& result) {
@@ -839,14 +846,11 @@ ExportQueryExecutionTrees::constructQueryResultToStream(
   // whose ID-space filter and `dedupVocab_` re-anchoring are guarded by a
   // mutex (see `ConstructDeduplicator::isNew`); the string formatting happens
   // outside the lock.
-  size_t numThreads =
-      getRuntimeParameter<&RuntimeParameters::constructExportNumThreads_>();
   bool dedupActive =
       !std::holds_alternative<ad_utility::DeduplicationMode::None>(
-          getRuntimeParameter<&RuntimeParameters::constructDeduplication_>().value_);
-  if (numThreads == 0) {
-    numThreads = std::max(1u, std::thread::hardware_concurrency());
-  }
+          getRuntimeParameter<&RuntimeParameters::constructDeduplication_>()
+              .value_);
+  const size_t numThreads = resolveConstructExportNumThreads();
   // Copy the cancellation handle (instead of moving it like the serial path),
   // because the parallel path checks it again while collecting the results.
   auto config = makeConstructEvaluationConfig(qet, cancellationHandle);

--- a/src/engine/ExportQueryExecutionTrees.cpp
+++ b/src/engine/ExportQueryExecutionTrees.cpp
@@ -906,12 +906,13 @@ ExportQueryExecutionTrees::constructQueryResultParallel(
   ad_utility::TaskQueue<false> queue{window, numThreads,
                                      "ConstructExportParallel"};
 
-  for (TableWithRange& block : rowIndices) {
+  for (const TableWithRange& block : rowIndices) {
     std::vector<TableWithRange> chunks =
         splitBlockIntoChunks(block, rowsPerChunk);
     if (chunks.empty()) {
       continue;
     }
+
     std::vector<std::future<std::string>> futures(chunks.size());
     size_t nextSubmit = 0;
     size_t nextGet = 0;

--- a/src/engine/ExportQueryExecutionTrees.cpp
+++ b/src/engine/ExportQueryExecutionTrees.cpp
@@ -854,7 +854,8 @@ ExportQueryExecutionTrees::constructQueryResultToStream(
 
   bool dedupActive =
       !std::holds_alternative<ad_utility::DeduplicationMode::None>(
-          getRuntimeParameter<&RuntimeParameters::constructDeduplication_>().value_);
+          getRuntimeParameter<&RuntimeParameters::constructDeduplication_>()
+              .value_);
   if (dedupActive) {
     // When triple deduplication is active, the chunks share a single
     // deduplicator.

--- a/src/engine/ExportQueryExecutionTrees.cpp
+++ b/src/engine/ExportQueryExecutionTrees.cpp
@@ -854,37 +854,73 @@ ExportQueryExecutionTrees::constructQueryResultToStream(
   auto config = makeConstructEvaluationConfig(qet, cancellationHandle);
 
   if (numThreads <= 1) {
-    // ----- Serial path -----
-    // Serialize the rows with the same generator pipeline as the parallel
-    // path, yielding one triple at a time so that the export stays streaming.
-    auto triples = qlever::constructExport::ConstructTripleGenerator::
-        generateFormattedTriples(constructTriples, qet.getVariableColumns(),
-                                 std::move(rowIndices), limitAndOffset._offset,
-                                 format, config);
-    for (const std::string& triple : triples) {
-      STREAMABLE_YIELD(triple);
-    }
-    STREAMABLE_RETURN;
+#ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
+    return constructQueryResultSerial<format>(
+        qet, constructTriples, limitAndOffset, std::move(rowIndices),
+        std::move(config), streamableYielder);
+#else
+    constructQueryResultSerial<format>(qet, constructTriples, limitAndOffset,
+                                       std::move(rowIndices), std::move(config),
+                                       streamableYielder);
+    return;
+#endif
   }
 
-  // ----- Parallel path -----
-  // When triple deduplication is active, all chunks share one deduplicator so
-  // that duplicate triples are dropped across chunk boundaries as well. The
-  // shared filter is made thread-safe by a mutex (see
-  // `ConstructDeduplicator::isNew`), so the parallel path stays enabled.
   if (dedupActive) {
     config.sharedDeduplicator_ =
         std::make_shared<qlever::constructExport::ConstructDeduplicator>(
             config.mode_, *qet.getQec());
   }
+#ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
+  return constructQueryResultParallel<format>(
+      qet, constructTriples, limitAndOffset, std::move(rowIndices),
+      std::move(config), numThreads, std::move(cancellationHandle),
+      streamableYielder);
+#else
+  constructQueryResultParallel<format>(
+      qet, constructTriples, limitAndOffset, std::move(rowIndices),
+      std::move(config), numThreads, std::move(cancellationHandle),
+      streamableYielder);
+  return;
+#endif
+}
 
+// _____________________________________________________________________________
+template <ad_utility::MediaType format>
+STREAMABLE_GENERATOR_TYPE ExportQueryExecutionTrees::constructQueryResultSerial(
+    const QueryExecutionTree& qet,
+    const ad_utility::sparql_types::Triples& constructTriples,
+    const LimitOffsetClause& limitAndOffset,
+    ad_utility::InputRangeTypeErased<TableWithRange> rowIndices,
+    qlever::constructExport::EvaluationConfig config,
+    [[maybe_unused]] STREAMABLE_YIELDER_TYPE streamableYielder) {
+  auto triples = qlever::constructExport::ConstructTripleGenerator::
+      generateFormattedTriples(constructTriples, qet.getVariableColumns(),
+                               std::move(rowIndices), limitAndOffset._offset,
+                               format, config);
+  for (const std::string& triple : triples) {
+    STREAMABLE_YIELD(triple);
+  }
+  STREAMABLE_RETURN;
+}
+
+// _____________________________________________________________________________
+template <ad_utility::MediaType format>
+STREAMABLE_GENERATOR_TYPE
+ExportQueryExecutionTrees::constructQueryResultParallel(
+    const QueryExecutionTree& qet,
+    const ad_utility::sparql_types::Triples& constructTriples,
+    const LimitOffsetClause& limitAndOffset,
+    ad_utility::InputRangeTypeErased<TableWithRange> rowIndices,
+    qlever::constructExport::EvaluationConfig config, size_t numThreads,
+    CancellationHandle cancellationHandle,
+    [[maybe_unused]] STREAMABLE_YIELDER_TYPE streamableYielder) {
   // Walk lazy WHERE blocks one at a time. Workers may only touch the current
   // block: its IdTable view dies when the generator advances. Each block is
   // cut into contiguous chunks of `BATCH_SIZE` rows and submitted in order
   // to a pool of `numThreads` workers. At most `2 * numThreads` chunk strings
   // are in flight so later chunks of a large block are not all materialized
-  // before the first one is yielded. Chunk size is the generator batch, not
-  // a runtime parameter: a second knob would drift from `IdCache` / lookup.
+  // before the first one is yielded.
   const size_t rowsPerChunk =
       qlever::constructExport::ConstructTripleGenerator::BATCH_SIZE;
   const size_t window = 2 * numThreads;

--- a/src/engine/ExportQueryExecutionTrees.cpp
+++ b/src/engine/ExportQueryExecutionTrees.cpp
@@ -776,7 +776,7 @@ std::vector<TableWithRange> ExportQueryExecutionTrees::splitBlockIntoChunks(
   }
   const uint64_t begin0 = *ql::ranges::begin(block.view_);
   const uint64_t end = begin0 + ql::ranges::size(block.view_);
-  const uint64_t step = static_cast<uint64_t>(rowsPerChunk);
+  const auto step = static_cast<uint64_t>(rowsPerChunk);
   for (uint64_t begin = begin0; begin < end; begin += step) {
     const uint64_t pieceEnd = std::min(end, begin + step);
     chunks.emplace_back(block.tableWithVocab_,

--- a/src/engine/ExportQueryExecutionTrees.cpp
+++ b/src/engine/ExportQueryExecutionTrees.cpp
@@ -16,16 +16,21 @@
 #include <absl/strings/str_cat.h>
 #include <absl/strings/str_replace.h>
 
+#include <future>
 #include <optional>
 #include <string_view>
+#include <thread>
+#include <vector>
 
 #include "backports/StartsWithAndEndsWith.h"
 #include "backports/algorithm.h"
+#include "engine/ConstructDeduplicator.h"
 #include "engine/ConstructTripleGenerator.h"
 #include "global/RuntimeParameters.h"
 #include "index/ExportIds.h"
 #include "rdfTypes/RdfEscaping.h"
 #include "util/ConstexprUtils.h"
+#include "util/TaskQueue.h"
 #include "util/http/MediaTypes.h"
 #include "util/views/TakeUntilInclusiveView.h"
 
@@ -762,6 +767,42 @@ STREAMABLE_GENERATOR_TYPE ExportQueryExecutionTrees::selectQueryResultToStream<
 }
 
 // _____________________________________________________________________________
+std::vector<TableWithRange> ExportQueryExecutionTrees::splitBlockIntoChunks(
+    const TableWithRange& block, size_t rowsPerChunk) {
+  AD_CONTRACT_CHECK(rowsPerChunk > 0);
+  std::vector<TableWithRange> chunks;
+  if (ql::ranges::empty(block.view_)) {
+    return chunks;
+  }
+  const uint64_t begin0 = *ql::ranges::begin(block.view_);
+  const uint64_t end = begin0 + ql::ranges::size(block.view_);
+  const uint64_t step = static_cast<uint64_t>(rowsPerChunk);
+  for (uint64_t begin = begin0; begin < end; begin += step) {
+    const uint64_t pieceEnd = std::min(end, begin + step);
+    chunks.emplace_back(block.tableWithVocab_,
+                        ql::views::iota(begin, pieceEnd));
+  }
+  return chunks;
+}
+
+// _____________________________________________________________________________
+template <ad_utility::MediaType format>
+std::string ExportQueryExecutionTrees::serializeConstructGroup(
+    const ad_utility::sparql_types::Triples& templateTriples,
+    const VariableToColumnMap& variableColumns,
+    ad_utility::InputRangeTypeErased<TableWithRange> rowRange, size_t rowOffset,
+    const qlever::constructExport::EvaluationConfig& config) {
+  std::string output;
+  for (const std::string& triple : qlever::constructExport::
+           ConstructTripleGenerator::generateFormattedTriples(
+               templateTriples, variableColumns, std::move(rowRange), rowOffset,
+               format, config)) {
+    output += triple;
+  }
+  return output;
+}
+
+// _____________________________________________________________________________
 template <ad_utility::MediaType format>
 STREAMABLE_GENERATOR_TYPE
 ExportQueryExecutionTrees::constructQueryResultToStream(
@@ -790,15 +831,96 @@ ExportQueryExecutionTrees::constructQueryResultToStream(
   auto rowIndices = getRowIndices(limitAndOffset, *result, resultSize,
                                   constructTriples.size());
 
-  auto triples = qlever::constructExport::ConstructTripleGenerator::
-      generateFormattedTriples(
-          constructTriples, qet.getVariableColumns(), std::move(rowIndices),
-          limitAndOffset._offset, format,
-          makeConstructEvaluationConfig(qet, std::move(cancellationHandle)));
-
-  for (const std::string& triple : triples) {
-    STREAMABLE_YIELD(triple);
+  // The number of threads for the parallel serialization of the CONSTRUCT
+  // triples.  0 means: use all logical cores.  The parallel path walks lazy
+  // WHERE blocks, cuts each block into contiguous row chunks, and serializes
+  // those chunks on a worker pool. Outputs are yielded in row order.  When
+  // triple deduplication is active, the chunks share a single deduplicator
+  // whose ID-space filter and `dedupVocab_` re-anchoring are guarded by a
+  // mutex (see `ConstructDeduplicator::isNew`); the string formatting happens
+  // outside the lock.
+  size_t numThreads =
+      getRuntimeParameter<&RuntimeParameters::constructExportNumThreads_>();
+  const auto& dedupMode =
+      getRuntimeParameter<&RuntimeParameters::constructDeduplication_>();
+  bool dedupActive =
+      !std::holds_alternative<ad_utility::DeduplicationMode::None>(
+          dedupMode.value_);
+  if (numThreads == 0) {
+    numThreads = std::max(1u, std::thread::hardware_concurrency());
   }
+  // Copy the cancellation handle (instead of moving it like the serial path),
+  // because the parallel path checks it again while collecting the results.
+  auto config = makeConstructEvaluationConfig(qet, cancellationHandle);
+
+  if (numThreads <= 1) {
+    // ----- Serial path -----
+    // Serialize the rows with the same generator pipeline as the parallel
+    // path, yielding one triple at a time so that the export stays streaming.
+    auto triples = qlever::constructExport::ConstructTripleGenerator::
+        generateFormattedTriples(constructTriples, qet.getVariableColumns(),
+                                 std::move(rowIndices), limitAndOffset._offset,
+                                 format, config);
+    for (const std::string& triple : triples) {
+      STREAMABLE_YIELD(triple);
+    }
+    STREAMABLE_RETURN;
+  }
+
+  // ----- Parallel path -----
+  // When triple deduplication is active, all chunks share one deduplicator so
+  // that duplicate triples are dropped across chunk boundaries as well. The
+  // shared filter is made thread-safe by a mutex (see
+  // `ConstructDeduplicator::isNew`), so the parallel path stays enabled.
+  if (dedupActive) {
+    config.sharedDeduplicator_ =
+        std::make_shared<qlever::constructExport::ConstructDeduplicator>(
+            config.mode_, *qet.getQec());
+  }
+
+  // Walk lazy WHERE blocks one at a time. Workers may only touch the current
+  // block: its IdTable view dies when the generator advances. Each block is
+  // cut into contiguous chunks of `BATCH_SIZE` rows and submitted in order
+  // to a pool of `numThreads` workers. At most `2 * numThreads` chunk strings
+  // are in flight so later chunks of a large block are not all materialized
+  // before the first one is yielded. Chunk size is the generator batch, not
+  // a runtime parameter: a second knob would drift from `IdCache` / lookup.
+  const size_t rowsPerChunk =
+      qlever::constructExport::ConstructTripleGenerator::BATCH_SIZE;
+  const size_t window = 2 * numThreads;
+  ad_utility::TaskQueue<false> queue{window, numThreads,
+                                     "ConstructExportParallel"};
+  const auto& templateTriples = constructTriples;
+  const auto& variableColumns = qet.getVariableColumns();
+  const size_t rowOffset = limitAndOffset._offset;
+
+  for (TableWithRange& block : rowIndices) {
+    std::vector<TableWithRange> chunks =
+        splitBlockIntoChunks(block, rowsPerChunk);
+    if (chunks.empty()) {
+      continue;
+    }
+    std::vector<std::future<std::string>> futures(chunks.size());
+    size_t nextSubmit = 0;
+    size_t nextGet = 0;
+    while (nextGet < chunks.size()) {
+      while (nextSubmit < chunks.size() && nextSubmit - nextGet < window) {
+        futures[nextSubmit] = queue.submit(
+            [&templateTriples, &variableColumns, rowOffset, &config,
+             chunk = std::move(chunks[nextSubmit])]() mutable {
+              std::vector<TableWithRange> one{std::move(chunk)};
+              return serializeConstructGroup<format>(
+                  templateTriples, variableColumns,
+                  InputRangeTypeErased(std::move(one)), rowOffset, config);
+            });
+        ++nextSubmit;
+      }
+      cancellationHandle->throwIfCancelled();
+      STREAMABLE_YIELD(std::move(futures[nextGet].get()));
+      ++nextGet;
+    }
+  }
+  STREAMABLE_RETURN;
 }
 
 #ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17

--- a/src/engine/ExportQueryExecutionTrees.cpp
+++ b/src/engine/ExportQueryExecutionTrees.cpp
@@ -847,8 +847,8 @@ ExportQueryExecutionTrees::constructQueryResultToStream(
 
   if (numThreads <= 1) {
     STREAMABLE_YIELD_FROM(constructQueryResultSerial<format>(
-        qet, constructTriples, limitAndOffset, std::move(rowIndices),
-        std::move(config), streamableYielder));
+        qet.getVariableColumns(), constructTriples, limitAndOffset._offset,
+        std::move(rowIndices), std::move(config), streamableYielder));
     STREAMABLE_RETURN;
   }
 
@@ -864,24 +864,24 @@ ExportQueryExecutionTrees::constructQueryResultToStream(
             config.mode_, *qet.getQec());
   }
   STREAMABLE_YIELD_FROM(constructQueryResultParallel<format>(
-      qet, constructTriples, limitAndOffset, std::move(rowIndices),
-      std::move(config), numThreads, cancellationHandle, streamableYielder));
+      qet.getVariableColumns(), constructTriples, limitAndOffset._offset,
+      std::move(rowIndices), std::move(config), numThreads, cancellationHandle,
+      streamableYielder));
   STREAMABLE_RETURN;
 }
 
 // _____________________________________________________________________________
 template <ad_utility::MediaType format>
 STREAMABLE_GENERATOR_TYPE ExportQueryExecutionTrees::constructQueryResultSerial(
-    const QueryExecutionTree& qet,
-    const ad_utility::sparql_types::Triples& constructTriples,
-    const LimitOffsetClause& limitAndOffset,
+    VariableToColumnMap variableColumns,
+    ad_utility::sparql_types::Triples constructTriples, size_t rowOffset,
     ad_utility::InputRangeTypeErased<TableWithRange> rowIndices,
     qlever::constructExport::EvaluationConfig config,
     [[maybe_unused]] STREAMABLE_YIELDER_TYPE streamableYielder) {
   auto triples = qlever::constructExport::ConstructTripleGenerator::
-      generateFormattedTriples(constructTriples, qet.getVariableColumns(),
-                               std::move(rowIndices), limitAndOffset._offset,
-                               format, config);
+      generateFormattedTriples(constructTriples, variableColumns,
+                               std::move(rowIndices), rowOffset, format,
+                               config);
   for (const std::string& triple : triples) {
     STREAMABLE_YIELD(triple);
   }
@@ -892,9 +892,8 @@ STREAMABLE_GENERATOR_TYPE ExportQueryExecutionTrees::constructQueryResultSerial(
 template <ad_utility::MediaType format>
 STREAMABLE_GENERATOR_TYPE
 ExportQueryExecutionTrees::constructQueryResultParallel(
-    const QueryExecutionTree& qet,
-    const ad_utility::sparql_types::Triples& constructTriples,
-    const LimitOffsetClause& limitAndOffset,
+    VariableToColumnMap variableColumns,
+    ad_utility::sparql_types::Triples constructTriples, size_t rowOffset,
     ad_utility::InputRangeTypeErased<TableWithRange> rowIndices,
     qlever::constructExport::EvaluationConfig config, size_t numThreads,
     CancellationHandle cancellationHandle,
@@ -910,9 +909,6 @@ ExportQueryExecutionTrees::constructQueryResultParallel(
   const size_t window = 2 * numThreads;
   ad_utility::TaskQueue<false> queue{window, numThreads,
                                      "ConstructExportParallel"};
-  const auto& templateTriples = constructTriples;
-  const auto& variableColumns = qet.getVariableColumns();
-  const size_t rowOffset = limitAndOffset._offset;
 
   for (TableWithRange& block : rowIndices) {
     std::vector<TableWithRange> chunks =
@@ -926,11 +922,11 @@ ExportQueryExecutionTrees::constructQueryResultParallel(
     while (nextGet < chunks.size()) {
       while (nextSubmit < chunks.size() && nextSubmit - nextGet < window) {
         futures[nextSubmit] = queue.submit(
-            [&templateTriples, &variableColumns, rowOffset, &config,
+            [&constructTriples, &variableColumns, rowOffset, &config,
              chunk = std::move(chunks[nextSubmit])]() mutable {
               std::vector<TableWithRange> one{std::move(chunk)};
               return serializeConstructGroup<format>(
-                  templateTriples, variableColumns,
+                  constructTriples, variableColumns,
                   InputRangeTypeErased(std::move(one)), rowOffset, config);
             });
         ++nextSubmit;

--- a/src/engine/ExportQueryExecutionTrees.cpp
+++ b/src/engine/ExportQueryExecutionTrees.cpp
@@ -841,11 +841,9 @@ ExportQueryExecutionTrees::constructQueryResultToStream(
   // outside the lock.
   size_t numThreads =
       getRuntimeParameter<&RuntimeParameters::constructExportNumThreads_>();
-  const auto& dedupMode =
-      getRuntimeParameter<&RuntimeParameters::constructDeduplication_>();
   bool dedupActive =
       !std::holds_alternative<ad_utility::DeduplicationMode::None>(
-          dedupMode.value_);
+          getRuntimeParameter<&RuntimeParameters::constructDeduplication_>().value_);
   if (numThreads == 0) {
     numThreads = std::max(1u, std::thread::hardware_concurrency());
   }

--- a/src/engine/ExportQueryExecutionTrees.cpp
+++ b/src/engine/ExportQueryExecutionTrees.cpp
@@ -41,13 +41,6 @@ namespace {
 using LiteralOrIri = ad_utility::triple_component::LiteralOrIri;
 using Literal = ad_utility::triple_component::Literal;
 
-// `0` for `construct-export-num-threads` means all logical cores.
-size_t resolveConstructExportNumThreads() {
-  const size_t n =
-      getRuntimeParameter<&RuntimeParameters::constructExportNumThreads_>();
-  return n == 0 ? std::max(1u, std::thread::hardware_concurrency()) : n;
-}
-
 // _____________________________________________________________________________
 // Return true iff the `result` is nonempty.
 bool getResultForAsk(const std::shared_ptr<const Result>& result) {
@@ -841,16 +834,13 @@ ExportQueryExecutionTrees::constructQueryResultToStream(
   // The number of threads for the parallel serialization of the CONSTRUCT
   // triples.  0 means: use all logical cores.  The parallel path walks lazy
   // WHERE blocks, cuts each block into contiguous row chunks, and serializes
-  // those chunks on a worker pool. Outputs are yielded in row order.  When
-  // triple deduplication is active, the chunks share a single deduplicator
-  // whose ID-space filter and `dedupVocab_` re-anchoring are guarded by a
-  // mutex (see `ConstructDeduplicator::isNew`); the string formatting happens
-  // outside the lock.
-  bool dedupActive =
-      !std::holds_alternative<ad_utility::DeduplicationMode::None>(
-          getRuntimeParameter<&RuntimeParameters::constructDeduplication_>()
-              .value_);
-  const size_t numThreads = resolveConstructExportNumThreads();
+  // those chunks on a worker pool. Outputs are yielded in row order.
+
+  size_t numThreads =
+      getRuntimeParameter<&RuntimeParameters::constructExportNumThreads_>();
+  if (numThreads == 0) {
+    numThreads = std::max(1u, std::thread::hardware_concurrency());
+  }
   // Copy the cancellation handle (instead of moving it like the serial path),
   // because the parallel path checks it again while collecting the results.
   auto config = makeConstructEvaluationConfig(qet, cancellationHandle);
@@ -862,7 +852,12 @@ ExportQueryExecutionTrees::constructQueryResultToStream(
     STREAMABLE_RETURN;
   }
 
+  bool dedupActive =
+      !std::holds_alternative<ad_utility::DeduplicationMode::None>(
+          getRuntimeParameter<&RuntimeParameters::constructDeduplication_>().value_);
   if (dedupActive) {
+    // When triple deduplication is active, the chunks share a single
+    // deduplicator.
     config.sharedDeduplicator_ =
         std::make_shared<qlever::constructExport::ConstructDeduplicator>(
             config.mode_, *qet.getQec());

--- a/src/engine/ExportQueryExecutionTrees.cpp
+++ b/src/engine/ExportQueryExecutionTrees.cpp
@@ -845,10 +845,11 @@ ExportQueryExecutionTrees::constructQueryResultToStream(
   // because the parallel path checks it again while collecting the results.
   auto config = makeConstructEvaluationConfig(qet, cancellationHandle);
 
+  ConstructStreamParams streamParams{qet.getVariableColumns(), constructTriples,
+                                     limitAndOffset._offset, std::move(config)};
   if (numThreads <= 1) {
     STREAMABLE_YIELD_FROM(constructQueryResultSerial<format>(
-        qet.getVariableColumns(), constructTriples, limitAndOffset._offset,
-        std::move(rowIndices), std::move(config), streamableYielder));
+        std::move(streamParams), std::move(rowIndices), streamableYielder));
     STREAMABLE_RETURN;
   }
 
@@ -859,29 +860,26 @@ ExportQueryExecutionTrees::constructQueryResultToStream(
   if (dedupActive) {
     // When triple deduplication is active, the chunks share a single
     // deduplicator.
-    config.sharedDeduplicator_ =
+    streamParams.config_.sharedDeduplicator_ =
         std::make_shared<qlever::constructExport::ConstructDeduplicator>(
-            config.mode_, *qet.getQec());
+            streamParams.config_.mode_, *qet.getQec());
   }
   STREAMABLE_YIELD_FROM(constructQueryResultParallel<format>(
-      qet.getVariableColumns(), constructTriples, limitAndOffset._offset,
-      std::move(rowIndices), std::move(config), numThreads, cancellationHandle,
-      streamableYielder));
+      std::move(streamParams), std::move(rowIndices), numThreads,
+      cancellationHandle, streamableYielder));
   STREAMABLE_RETURN;
 }
 
 // _____________________________________________________________________________
 template <ad_utility::MediaType format>
 STREAMABLE_GENERATOR_TYPE ExportQueryExecutionTrees::constructQueryResultSerial(
-    VariableToColumnMap variableColumns,
-    ad_utility::sparql_types::Triples constructTriples, size_t rowOffset,
+    ConstructStreamParams params,
     ad_utility::InputRangeTypeErased<TableWithRange> rowIndices,
-    qlever::constructExport::EvaluationConfig config,
     [[maybe_unused]] STREAMABLE_YIELDER_TYPE streamableYielder) {
   auto triples = qlever::constructExport::ConstructTripleGenerator::
-      generateFormattedTriples(constructTriples, variableColumns,
-                               std::move(rowIndices), rowOffset, format,
-                               config);
+      generateFormattedTriples(params.constructTriples_,
+                               params.variableColumns_, std::move(rowIndices),
+                               params.rowOffset_, format, params.config_);
   for (const std::string& triple : triples) {
     STREAMABLE_YIELD(triple);
   }
@@ -892,11 +890,9 @@ STREAMABLE_GENERATOR_TYPE ExportQueryExecutionTrees::constructQueryResultSerial(
 template <ad_utility::MediaType format>
 STREAMABLE_GENERATOR_TYPE
 ExportQueryExecutionTrees::constructQueryResultParallel(
-    VariableToColumnMap variableColumns,
-    ad_utility::sparql_types::Triples constructTriples, size_t rowOffset,
+    ConstructStreamParams params,
     ad_utility::InputRangeTypeErased<TableWithRange> rowIndices,
-    qlever::constructExport::EvaluationConfig config, size_t numThreads,
-    CancellationHandle cancellationHandle,
+    size_t numThreads, CancellationHandle cancellationHandle,
     [[maybe_unused]] STREAMABLE_YIELDER_TYPE streamableYielder) {
   // Walk lazy WHERE blocks one at a time. Workers may only touch the current
   // block: its IdTable view dies when the generator advances. Each block is
@@ -922,12 +918,12 @@ ExportQueryExecutionTrees::constructQueryResultParallel(
     while (nextGet < chunks.size()) {
       while (nextSubmit < chunks.size() && nextSubmit - nextGet < window) {
         futures[nextSubmit] = queue.submit(
-            [&constructTriples, &variableColumns, rowOffset, &config,
-             chunk = std::move(chunks[nextSubmit])]() mutable {
+            [&params, chunk = std::move(chunks[nextSubmit])]() mutable {
               std::vector<TableWithRange> one{std::move(chunk)};
               return serializeConstructGroup<format>(
-                  constructTriples, variableColumns,
-                  InputRangeTypeErased(std::move(one)), rowOffset, config);
+                  params.constructTriples_, params.variableColumns_,
+                  InputRangeTypeErased(std::move(one)), params.rowOffset_,
+                  params.config_);
             });
         ++nextSubmit;
       }

--- a/src/engine/ExportQueryExecutionTrees.cpp
+++ b/src/engine/ExportQueryExecutionTrees.cpp
@@ -854,18 +854,9 @@ ExportQueryExecutionTrees::constructQueryResultToStream(
   auto config = makeConstructEvaluationConfig(qet, cancellationHandle);
 
   if (numThreads <= 1) {
-#ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
-    auto gen = constructQueryResultSerial<format>(
+    STREAMABLE_YIELD_FROM(constructQueryResultSerial<format>(
         qet, constructTriples, limitAndOffset, std::move(rowIndices),
-        std::move(config), streamableYielder);
-    for (auto&& chunk : gen) {
-      STREAMABLE_YIELD(chunk);
-    }
-#else
-    constructQueryResultSerial<format>(qet, constructTriples, limitAndOffset,
-                                       std::move(rowIndices), std::move(config),
-                                       streamableYielder);
-#endif
+        std::move(config), streamableYielder));
     STREAMABLE_RETURN;
   }
 
@@ -874,19 +865,9 @@ ExportQueryExecutionTrees::constructQueryResultToStream(
         std::make_shared<qlever::constructExport::ConstructDeduplicator>(
             config.mode_, *qet.getQec());
   }
-#ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
-  auto gen = constructQueryResultParallel<format>(
+  STREAMABLE_YIELD_FROM(constructQueryResultParallel<format>(
       qet, constructTriples, limitAndOffset, std::move(rowIndices),
-      std::move(config), numThreads, cancellationHandle, streamableYielder);
-  for (auto&& chunk : gen) {
-    STREAMABLE_YIELD(chunk);
-  }
-#else
-  constructQueryResultParallel<format>(
-      qet, constructTriples, limitAndOffset, std::move(rowIndices),
-      std::move(config), numThreads, std::move(cancellationHandle),
-      streamableYielder);
-#endif
+      std::move(config), numThreads, cancellationHandle, streamableYielder));
   STREAMABLE_RETURN;
 }
 

--- a/src/engine/ExportQueryExecutionTrees.h
+++ b/src/engine/ExportQueryExecutionTrees.h
@@ -235,7 +235,7 @@ class ExportQueryExecutionTrees {
   static std::vector<TableWithRange> splitBlockIntoChunks(
       const TableWithRange& block, size_t rowsPerChunk);
 
-  // Inputs the CONSTRUCT stream coroutines own in their frame.
+  // Inputs the CONSTRUCT-stream-coroutines own in their frame.
   struct ConstructStreamParams {
     VariableToColumnMap variableColumns_;
     ad_utility::sparql_types::Triples constructTriples_;

--- a/src/engine/ExportQueryExecutionTrees.h
+++ b/src/engine/ExportQueryExecutionTrees.h
@@ -234,6 +234,27 @@ class ExportQueryExecutionTrees {
   // Empty blocks yield no chunks.
   static std::vector<TableWithRange> splitBlockIntoChunks(
       const TableWithRange& block, size_t rowsPerChunk);
+
+  // Yield one formatted triple at a time from `rowIndices`.
+  template <ad_utility::MediaType format>
+  static STREAMABLE_GENERATOR_TYPE constructQueryResultSerial(
+      const QueryExecutionTree& qet,
+      const ad_utility::sparql_types::Triples& constructTriples,
+      const LimitOffsetClause& limitAndOffset,
+      ad_utility::InputRangeTypeErased<TableWithRange> rowIndices,
+      qlever::constructExport::EvaluationConfig config,
+      STREAMABLE_YIELDER_ARG_DECL);
+
+  // Format each live WHERE block on a `TaskQueue` of `numThreads` workers.
+  // Join the current block before the generator advances.
+  template <ad_utility::MediaType format>
+  static STREAMABLE_GENERATOR_TYPE constructQueryResultParallel(
+      const QueryExecutionTree& qet,
+      const ad_utility::sparql_types::Triples& constructTriples,
+      const LimitOffsetClause& limitAndOffset,
+      ad_utility::InputRangeTypeErased<TableWithRange> rowIndices,
+      qlever::constructExport::EvaluationConfig config, size_t numThreads,
+      CancellationHandle cancellationHandle, STREAMABLE_YIELDER_ARG_DECL);
 };
 
 #endif  // QLEVER_SRC_ENGINE_EXPORTQUERYEXECUTIONTREES_H

--- a/src/engine/ExportQueryExecutionTrees.h
+++ b/src/engine/ExportQueryExecutionTrees.h
@@ -235,26 +235,29 @@ class ExportQueryExecutionTrees {
   static std::vector<TableWithRange> splitBlockIntoChunks(
       const TableWithRange& block, size_t rowsPerChunk);
 
+  // Inputs the CONSTRUCT stream coroutines own in their frame.
+  struct ConstructStreamParams {
+    VariableToColumnMap variableColumns_;
+    ad_utility::sparql_types::Triples constructTriples_;
+    size_t rowOffset_;
+    qlever::constructExport::EvaluationConfig config_;
+  };
+
   // Yield one formatted triple at a time from `rowIndices`.
-  // Parameters that the coroutine still needs after the first yield are
-  // taken by value so they live in the coroutine frame.
   template <ad_utility::MediaType format>
   static STREAMABLE_GENERATOR_TYPE constructQueryResultSerial(
-      VariableToColumnMap variableColumns,
-      ad_utility::sparql_types::Triples constructTriples, size_t rowOffset,
+      ConstructStreamParams params,
       ad_utility::InputRangeTypeErased<TableWithRange> rowIndices,
-      qlever::constructExport::EvaluationConfig config,
       STREAMABLE_YIELDER_ARG_DECL);
 
   // Format each live WHERE block on a `TaskQueue` of `numThreads` workers.
   // Join the current block before the generator advances.
   template <ad_utility::MediaType format>
   static STREAMABLE_GENERATOR_TYPE constructQueryResultParallel(
-      VariableToColumnMap variableColumns,
-      ad_utility::sparql_types::Triples constructTriples, size_t rowOffset,
+      ConstructStreamParams params,
       ad_utility::InputRangeTypeErased<TableWithRange> rowIndices,
-      qlever::constructExport::EvaluationConfig config, size_t numThreads,
-      CancellationHandle cancellationHandle, STREAMABLE_YIELDER_ARG_DECL);
+      size_t numThreads, CancellationHandle cancellationHandle,
+      STREAMABLE_YIELDER_ARG_DECL);
 };
 
 #endif  // QLEVER_SRC_ENGINE_EXPORTQUERYEXECUTIONTREES_H

--- a/src/engine/ExportQueryExecutionTrees.h
+++ b/src/engine/ExportQueryExecutionTrees.h
@@ -236,11 +236,12 @@ class ExportQueryExecutionTrees {
       const TableWithRange& block, size_t rowsPerChunk);
 
   // Yield one formatted triple at a time from `rowIndices`.
+  // Parameters that the coroutine still needs after the first yield are
+  // taken by value so they live in the coroutine frame.
   template <ad_utility::MediaType format>
   static STREAMABLE_GENERATOR_TYPE constructQueryResultSerial(
-      const QueryExecutionTree& qet,
-      const ad_utility::sparql_types::Triples& constructTriples,
-      const LimitOffsetClause& limitAndOffset,
+      VariableToColumnMap variableColumns,
+      ad_utility::sparql_types::Triples constructTriples, size_t rowOffset,
       ad_utility::InputRangeTypeErased<TableWithRange> rowIndices,
       qlever::constructExport::EvaluationConfig config,
       STREAMABLE_YIELDER_ARG_DECL);
@@ -249,9 +250,8 @@ class ExportQueryExecutionTrees {
   // Join the current block before the generator advances.
   template <ad_utility::MediaType format>
   static STREAMABLE_GENERATOR_TYPE constructQueryResultParallel(
-      const QueryExecutionTree& qet,
-      const ad_utility::sparql_types::Triples& constructTriples,
-      const LimitOffsetClause& limitAndOffset,
+      VariableToColumnMap variableColumns,
+      ad_utility::sparql_types::Triples constructTriples, size_t rowOffset,
       ad_utility::InputRangeTypeErased<TableWithRange> rowIndices,
       qlever::constructExport::EvaluationConfig config, size_t numThreads,
       CancellationHandle cancellationHandle, STREAMABLE_YIELDER_ARG_DECL);

--- a/src/engine/ExportQueryExecutionTrees.h
+++ b/src/engine/ExportQueryExecutionTrees.h
@@ -14,6 +14,8 @@
 #ifndef QLEVER_SRC_ENGINE_EXPORTQUERYEXECUTIONTREES_H
 #define QLEVER_SRC_ENGINE_EXPORTQUERYEXECUTIONTREES_H
 
+#include <vector>
+
 #include "engine/ConstructTripleGenerator.h"
 #include "engine/QueryExecutionTree.h"
 #include "engine/QueryExportTypes.h"
@@ -210,7 +212,28 @@ class ExportQueryExecutionTrees {
   FRIEND_TEST(ExportQueryExecutionTrees,
               ensureGeneratorIsNotConsumedWhenNotRequired);
   FRIEND_TEST(ExportQueryExecutionTrees, verifyQleverJsonContainsValidMetadata);
+  FRIEND_TEST(ExportQueryExecutionTrees, SplitBlockIntoChunks);
+  FRIEND_TEST(ExportQueryExecutionTrees, SerializeConstructGroup);
   FRIEND_TEST(ExportQueryExecutionTrees, compensateForLimitOffsetClause);
+
+  // The per-format serialization body of the CONSTRUCT export: instantiates
+  // `templateTriples` for every row in `rowRange` and serializes each resulting
+  // triple according to `format`, concatenated into a single output string.
+  template <ad_utility::MediaType format>
+  static std::string serializeConstructGroup(
+      const ad_utility::sparql_types::Triples& templateTriples,
+      const VariableToColumnMap& variableColumns,
+      ad_utility::InputRangeTypeErased<TableWithRange> rowRange,
+      size_t rowOffset,
+      const qlever::constructExport::EvaluationConfig& config);
+
+  // Cut one lazy `TableWithRange` into contiguous row chunks of `rowsPerChunk`
+  // rows (the last chunk may be shorter). Production uses
+  // `ConstructTripleGenerator::BATCH_SIZE`. The returned `view_` ranges keep
+  // the original global row indices, which blank-node base IDs depend on.
+  // Empty blocks yield no chunks.
+  static std::vector<TableWithRange> splitBlockIntoChunks(
+      const TableWithRange& block, size_t rowsPerChunk);
 };
 
 #endif  // QLEVER_SRC_ENGINE_EXPORTQUERYEXECUTIONTREES_H

--- a/src/global/RuntimeParameters.cpp
+++ b/src/global/RuntimeParameters.cpp
@@ -1,7 +1,7 @@
-// Copyright 2025 The QLever Authors, in particular:
+// Copyright 2025 - 2026, The QLever Authors, in particular:
 //
-// 2025 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
-// 2025 NN, BMW
+// 2025 - 2026 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+// 2026        Marvin Stoetzel <stoetzem@email.uni-freiburg.de>, UFR
 //
 // UFR = University of Freiburg, Chair of Algorithms and Data Structures
 // BMW =  Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
@@ -25,6 +25,7 @@ RuntimeParameters::RuntimeParameters() {
   add(stripColumns_);
   add(sortEstimateCancellationFactor_);
   add(cacheMaxNumEntries_);
+  add(constructExportNumThreads_);
   add(cacheMaxSize_);
   add(cacheMaxSizeSingleEntry_);
   add(lazyIndexScanQueueSize_);

--- a/src/global/RuntimeParameters.h
+++ b/src/global/RuntimeParameters.h
@@ -232,10 +232,13 @@ struct RuntimeParameters {
                               "log-level"};
 
   // Controls deduplication of triples in CONSTRUCT query results.
-  // "false" (default): no deduplication, every triple is emitted.
-  // "global": a triple is emitted at most once across the entire result.
-  // N (positive integer): deduplicate against the N most recently seen unique
-  // triples (per template triple); bounded memory, partial deduplication.
+  // "none" (default): no duplicate tracking; every valid instantiated result
+  // triple is emitted.
+  // "full": one shared set stores the full triple keys for the whole query;
+  // repeated result triples are suppressed.
+  // "lru:<positive integer>": one shared LRU cache stores at most that many
+  // recently seen unique full triple keys; bounded memory, partial
+  // deduplication.
   DeduplicationModeParameter constructDeduplication_{
       DeduplicationMode{DeduplicationMode::None{}}, "construct-deduplication"};
 

--- a/src/global/RuntimeParameters.h
+++ b/src/global/RuntimeParameters.h
@@ -1,6 +1,9 @@
-//   Copyright 2024, University of Freiburg,
-//   Chair of Algorithms and Data Structures.
-//   Author: Robin Textor-Falconi <textorr@informatik.uni-freiburg.de>
+// Copyright 2024 - 2026, The QLever Authors, in particular:
+//
+// 2024 - 2026 Robin Textor-Falconi <textorr@cs.uni-freiburg.de>, UFR
+// 2026        Marvin Stoetzel <stoetzem@email.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
 
 #ifndef QLEVER_RUNTIMEPARAMETERS_H
 #define QLEVER_RUNTIMEPARAMETERS_H
@@ -50,6 +53,11 @@ struct RuntimeParameters {
   Double sortEstimateCancellationFactor_{3.0,
                                          "sort-estimate-cancellation-factor"};
   SizeT cacheMaxNumEntries_{1000, "cache-max-num-entries"};
+
+  // Threads used to format CONSTRUCT triples in parallel. 0 means all
+  // logical cores, matching `computeInParallelChunks`. The default of 1
+  // keeps the serial generator (one formatted triple per yield).
+  SizeT constructExportNumThreads_{1, "construct-export-num-threads"};
 
   MemorySizeParameter cacheMaxSize_{ad_utility::MemorySize::gigabytes(30),
                                     "cache-max-size"};

--- a/src/util/TaskQueue.h
+++ b/src/util/TaskQueue.h
@@ -24,7 +24,7 @@
 
 namespace ad_utility {
 /**
- * A Queue of tasks, which are executed by a thread pool. Tasks can be enqued
+ * A Queue of tasks, which are executed by a thread pool. Tasks can be enqueued
  * via calls to push(). The destructor, or its manual equivalent finish(),
  * block until all tasks have run to completion.
  * @tparam TrackTimes if set to true, the time that is spent waiting for push()

--- a/src/util/stream_generator.h
+++ b/src/util/stream_generator.h
@@ -411,6 +411,12 @@ class StringBatcher {
 // 5. `STREAMABLE_RETURN` is either `co_return` (in C++20 mode) or `return` (in
 // C++17 mode).
 //
+// 6. `STREAMABLE_YIELD_FROM(expr)` consumes a nested streamable function
+// `expr`. In C++20 mode `expr` returns a `stream_generator` and each chunk
+// is `co_yield`ed. In C++17 mode `expr` is a void call that already invokes
+// `streamableYielder`. The expansion must sit in a streamable function so
+// that `STREAMABLE_YIELD` is valid.
+//
 // To see these macros in action, see the examples in `StringBatcherTest.pp`,
 // and their usage in `ExportQueryExecutionTrees.{h,cpp}`.
 
@@ -421,6 +427,13 @@ using STREAMABLE_YIELDER_TYPE = int;
   [[maybe_unused]] STREAMABLE_YIELDER_TYPE streamableYielder = {}
 #define STREAMABLE_YIELD(...) co_yield __VA_ARGS__
 #define STREAMABLE_RETURN co_return
+#define STREAMABLE_YIELD_FROM(...)          \
+  do {                                      \
+    auto streamableNested = (__VA_ARGS__);  \
+    for (auto&& chunk : streamableNested) { \
+      STREAMABLE_YIELD(chunk);              \
+    }                                       \
+  } while (false)
 
 #else
 
@@ -430,6 +443,10 @@ using STREAMABLE_YIELDER_TYPE =
 #define STREAMABLE_YIELDER_ARG_DECL STREAMABLE_YIELDER_TYPE streamableYielder
 #define STREAMABLE_YIELD(...) streamableYielder(__VA_ARGS__)
 #define STREAMABLE_RETURN return;
+#define STREAMABLE_YIELD_FROM(...) \
+  do {                             \
+    (__VA_ARGS__);                 \
+  } while (false)
 
 #endif  // QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
 

--- a/test/ConstructDeduplicatorTest.cpp
+++ b/test/ConstructDeduplicatorTest.cpp
@@ -8,6 +8,9 @@
 
 #include <gtest/gtest.h>
 
+#include <atomic>
+#include <thread>
+
 #include "engine/ConstructDeduplicator.h"
 #include "index/LocalVocab.h"
 #include "index/LocalVocabEntry.h"
@@ -349,6 +352,49 @@ TEST_F(ConstructDeduplicatorTest, perTripleFilterRejectsNone) {
 // precondition violation.
 TEST_F(ConstructDeduplicatorTest, noneModeIsRejected) {
   EXPECT_ANY_THROW(ConstructDeduplicator(DeduplicationMode::none(), *qec_));
+}
+
+//______________________________________________________________________________
+// The parallel export path shares one `ConstructDeduplicator` across worker
+// threads. `isNew` guards the shared filter and `dedupVocab_` with a mutex, so
+// concurrent calls must not lose or duplicate keys: each distinct key must be
+// reported "new" exactly once, regardless of how the same key submissions are
+// interleaved across threads.
+TEST_F(ConstructDeduplicatorTest, isNewThreadSafeSharedFilter) {
+  constexpr size_t numKeys = 64;
+  constexpr size_t numThreads = 8;
+  std::vector<LocalVocabRow> rows;
+  rows.reserve(numKeys);
+  for (size_t i = 0; i < numKeys; ++i) {
+    rows.push_back(makeLocalVocabRow("literal-" + std::to_string(i)));
+  }
+
+  auto tmpl = makeSingleTripleTemplate();
+  ConstructDeduplicator deduplicator = makeFullDeduplicator();
+
+  // Every thread submits every key, so each distinct key is seen
+  // `numThreads` times in total, but must still be reported "new" exactly once.
+  std::atomic<size_t> totalNew{0};
+  std::vector<std::thread> threads;
+  threads.reserve(numThreads);
+  for (size_t t = 0; t < numThreads; ++t) {
+    threads.emplace_back([&, t]() {
+      size_t localNew = 0;
+      for (size_t i = 0; i < numKeys; ++i) {
+        const LocalVocabRow& row = rows[(i + t) % numKeys];
+        if (deduplicator.isNew(0, 0, tmpl, row.ctx())) {
+          ++localNew;
+        }
+      }
+      totalNew.fetch_add(localNew, std::memory_order_relaxed);
+    });
+  }
+  for (std::thread& thread : threads) {
+    thread.join();
+  }
+  // Each of the `numKeys` distinct keys is reported new exactly once across all
+  // threads; every later submission of the same key is a duplicate.
+  EXPECT_EQ(totalNew.load(), numKeys);
 }
 
 }  // namespace

--- a/test/ConstructDeduplicatorTest.cpp
+++ b/test/ConstructDeduplicatorTest.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 The QLever Authors, in particular:
-// 2026 Marvin Stoetzel <marvin.stoetzel@email.uni-freiburg.de>, UFR
+// 2026 Marvin Stoetzel <stoetzem@email.uni-freiburg.de>, UFR
 //
 // UFR = University of Freiburg, Chair of Algorithms and Data Structures
 

--- a/test/ConstructDeduplicatorTest.cpp
+++ b/test/ConstructDeduplicatorTest.cpp
@@ -1,5 +1,5 @@
 // Copyright 2026 The QLever Authors, in particular:
-// 2026 Marvin Stoetzel <stoetzem@email.uni-freiburg.de>, UFR
+// 2026 Marvin Stoetzel <marvin.stoetzel@email.uni-freiburg.de>, UFR
 //
 // UFR = University of Freiburg, Chair of Algorithms and Data Structures
 

--- a/test/ExportQueryExecutionTreesTest.cpp
+++ b/test/ExportQueryExecutionTreesTest.cpp
@@ -10,7 +10,9 @@
 #include <gmock/gmock.h>
 
 #include <limits>
+#include <tuple>
 
+#include "absl/strings/str_cat.h"
 #include "engine/ExportQueryExecutionTrees.h"
 #include "engine/QueryPlanner.h"
 #include "index/ExportIds.h"
@@ -2274,12 +2276,11 @@ INSTANTIATE_TEST_SUITE_P(
         LruWindowParam{10, "abcde"}));
 
 // ____________________________________________________________________________
-// The parallel CONSTRUCT serialization (construct-export-num-threads > 1)
-// must produce byte-identical output to the serial path, regardless of the
-// number of groups the rows are split into.
+// Parallel CONSTRUCT export. `numThreads` is the `TaskQueue` worker count
+// (software threads). 0 means `hardware_concurrency()`. These sizes do not
+// require that many hardware cores.
 
 namespace {
-// A knowledge graph with `numTriples` triples `<s0> <p> <o0>` ...
 std::string makeConstructKg(size_t numTriples) {
   std::string kg;
   for (size_t i = 0; i < numTriples; ++i) {
@@ -2288,8 +2289,6 @@ std::string makeConstructKg(size_t numTriples) {
   return kg;
 }
 
-// Returns the streamed result of the given CONSTRUCT query for the given
-// media type, with `numThreads` workers. Chunk size is `BATCH_SIZE`.
 std::string constructResultWithThreads(const std::string& kg,
                                        const std::string& query,
                                        ad_utility::MediaType mediaType,
@@ -2298,63 +2297,68 @@ std::string constructResultWithThreads(const std::string& kg,
       &RuntimeParameters::constructExportNumThreads_>(numThreads);
   return runQueryStreamableResult(kg, query, mediaType);
 }
+
+constexpr ad_utility::MediaType kConstructExportMediaTypes[] = {
+    ad_utility::MediaType::tsv, ad_utility::MediaType::turtle,
+    ad_utility::MediaType::ntriples};
+
+constexpr size_t kConstructExportThreadCounts[] = {0, 1, 2, 4, 8};
 }  // namespace
 
-TEST(ExportQueryExecutionTrees, ParallelConstructSerializationMatchesSerial) {
-  using enum ad_utility::MediaType;
-  // More than one `BATCH_SIZE` chunk so several workers get work.
+class ParallelConstructMatchesSerialTest
+    : public ::testing::TestWithParam<
+          std::tuple<ad_utility::MediaType, size_t>> {};
+
+TEST_P(ParallelConstructMatchesSerialTest, MatchesSerial) {
+  const auto [mediaType, numThreads] = GetParam();
   const std::string kg = makeConstructKg(
       qlever::constructExport::ConstructTripleGenerator::BATCH_SIZE + 200);
   const std::string query = "CONSTRUCT {?s ?p ?o} WHERE {?s ?p ?o} ORDER BY ?s";
-  // Reference output from the serial path (default thread count).
-  const std::string expectedTsv = runQueryStreamableResult(kg, query, tsv);
-  const std::string expectedTurtle =
-      runQueryStreamableResult(kg, query, turtle);
-  const std::string expectedNtriples =
-      runQueryStreamableResult(kg, query, ntriples);
-
-  for (size_t numThreads : {size_t{2}, size_t{4}, size_t{8}}) {
-    EXPECT_EQ(constructResultWithThreads(kg, query, tsv, numThreads),
-              expectedTsv)
-        << "numThreads = " << numThreads;
-    EXPECT_EQ(constructResultWithThreads(kg, query, turtle, numThreads),
-              expectedTurtle)
-        << "numThreads = " << numThreads;
-    EXPECT_EQ(constructResultWithThreads(kg, query, ntriples, numThreads),
-              expectedNtriples)
-        << "numThreads = " << numThreads;
-  }
-
-  // numThreads == 0 means "all logical cores" and must also match.
-  EXPECT_EQ(constructResultWithThreads(kg, query, tsv, 0), expectedTsv);
+  const std::string expected = runQueryStreamableResult(kg, query, mediaType);
+  EXPECT_EQ(constructResultWithThreads(kg, query, mediaType, numThreads),
+            expected);
 }
 
-// Blank-node labels in the CONSTRUCT output depend on the global row index
-// (via the row offset). Chunks must keep those indices, also with OFFSET.
-TEST(ExportQueryExecutionTrees, ParallelConstructSerializationBlankNodes) {
+INSTANTIATE_TEST_SUITE_P(
+    ConstructExportMediaAndThreads, ParallelConstructMatchesSerialTest,
+    ::testing::Combine(::testing::ValuesIn(kConstructExportMediaTypes),
+                       ::testing::ValuesIn(kConstructExportThreadCounts)),
+    [](const auto& info) {
+      const auto [mediaType, numThreads] = info.param;
+      return absl::StrCat("mt", static_cast<int>(mediaType), "_t", numThreads);
+    });
+
+class ParallelConstructThreadCountTest
+    : public ::testing::TestWithParam<size_t> {};
+
+TEST_P(ParallelConstructThreadCountTest, BlankNodesNoOffset) {
   using enum ad_utility::MediaType;
   const std::string kg = makeConstructKg(
       qlever::constructExport::ConstructTripleGenerator::BATCH_SIZE + 100);
   const std::string query =
       "CONSTRUCT {?s ?p _:b} WHERE {?s ?p ?o} ORDER BY ?s";
-  const std::string queryWithOffset =
-      "CONSTRUCT {?s ?p _:b} WHERE {?s ?p ?o} ORDER BY ?s LIMIT 60 OFFSET 30";
-  for (const auto& q : {query, queryWithOffset}) {
-    const std::string expected = runQueryStreamableResult(kg, q, turtle);
-    EXPECT_EQ(constructResultWithThreads(kg, q, turtle, 4), expected);
-    std::string parallel = constructResultWithThreads(kg, q, turtle, 4);
-    EXPECT_EQ(parallel, expected);
-    EXPECT_NE(parallel.find("_:u"), std::string::npos);
-  }
+  const std::string expected = runQueryStreamableResult(kg, query, turtle);
+  std::string parallel =
+      constructResultWithThreads(kg, query, turtle, GetParam());
+  EXPECT_EQ(parallel, expected);
+  EXPECT_NE(parallel.find("_:u"), std::string::npos);
 }
 
-// When triple deduplication is active, the parallel path stays enabled: the
-// chunks share one `ConstructDeduplicator`.
-// This test verifies that the output must match the serial path.
-TEST(ExportQueryExecutionTrees, ParallelConstructSerializationWithDedup) {
+TEST_P(ParallelConstructThreadCountTest, BlankNodesWithOffset) {
   using enum ad_utility::MediaType;
-  // Duplicate triples in the result (each ?o appears twice), so deduplication
-  // changes the output.
+  const std::string kg = makeConstructKg(
+      qlever::constructExport::ConstructTripleGenerator::BATCH_SIZE + 100);
+  const std::string query =
+      "CONSTRUCT {?s ?p _:b} WHERE {?s ?p ?o} ORDER BY ?s LIMIT 60 OFFSET 30";
+  const std::string expected = runQueryStreamableResult(kg, query, turtle);
+  std::string parallel =
+      constructResultWithThreads(kg, query, turtle, GetParam());
+  EXPECT_EQ(parallel, expected);
+  EXPECT_NE(parallel.find("_:u"), std::string::npos);
+}
+
+TEST_P(ParallelConstructThreadCountTest, WithDedup) {
+  using enum ad_utility::MediaType;
   std::string kg;
   for (size_t i = 0; i < 50; ++i) {
     absl::StrAppend(&kg, "<s", i, "> <p> <o", i, "> .\n");
@@ -2365,22 +2369,25 @@ TEST(ExportQueryExecutionTrees, ParallelConstructSerializationWithDedup) {
       setRuntimeParameterForTest<&RuntimeParameters::constructDeduplication_>(
           ad_utility::DeduplicationMode::full());
   const std::string expected = runQueryStreamableResult(kg, query, turtle);
-  EXPECT_EQ(constructResultWithThreads(kg, query, turtle, 4), expected);
-  EXPECT_EQ(constructResultWithThreads(kg, query, turtle, 0), expected);
+  EXPECT_EQ(constructResultWithThreads(kg, query, turtle, GetParam()),
+            expected);
 }
 
-// The parallel path must also handle an empty result (no rows to serialize):
-// the output is empty and no worker tasks are submitted.
-TEST(ExportQueryExecutionTrees, ParallelConstructSerializationEmptyResult) {
+TEST_P(ParallelConstructThreadCountTest, EmptyResult) {
   using enum ad_utility::MediaType;
   const std::string kg = makeConstructKg(5);
   const std::string query =
       "CONSTRUCT {?s ?p ?o} WHERE {?s ?p ?o FILTER(?s = <s999>)}";
-  for (size_t numThreads : {size_t{1}, size_t{4}}) {
-    EXPECT_EQ(constructResultWithThreads(kg, query, tsv, numThreads), "");
-    EXPECT_EQ(constructResultWithThreads(kg, query, turtle, numThreads), "");
-  }
+  EXPECT_EQ(constructResultWithThreads(kg, query, tsv, GetParam()), "");
+  EXPECT_EQ(constructResultWithThreads(kg, query, turtle, GetParam()), "");
 }
+
+INSTANTIATE_TEST_SUITE_P(ConstructExportThreadCounts,
+                         ParallelConstructThreadCountTest,
+                         ::testing::ValuesIn(kConstructExportThreadCounts),
+                         [](const auto& info) {
+                           return absl::StrCat("t", info.param);
+                         });
 
 // White-box test for `splitBlockIntoChunks`. `getRowIndices` never yields
 // an empty view, but the function must still handle one.

--- a/test/ExportQueryExecutionTreesTest.cpp
+++ b/test/ExportQueryExecutionTreesTest.cpp
@@ -12,7 +12,6 @@
 #include <limits>
 #include <tuple>
 
-#include "absl/strings/str_cat.h"
 #include "engine/ExportQueryExecutionTrees.h"
 #include "engine/QueryPlanner.h"
 #include "index/ExportIds.h"
@@ -2322,11 +2321,7 @@ TEST_P(ParallelConstructMatchesSerialTest, MatchesSerial) {
 INSTANTIATE_TEST_SUITE_P(
     ConstructExportMediaAndThreads, ParallelConstructMatchesSerialTest,
     ::testing::Combine(::testing::ValuesIn(kConstructExportMediaTypes),
-                       ::testing::ValuesIn(kConstructExportThreadCounts)),
-    [](const auto& info) {
-      const auto [mediaType, numThreads] = info.param;
-      return absl::StrCat("mt", static_cast<int>(mediaType), "_t", numThreads);
-    });
+                       ::testing::ValuesIn(kConstructExportThreadCounts)));
 
 class ParallelConstructThreadCountTest
     : public ::testing::TestWithParam<size_t> {};
@@ -2384,10 +2379,7 @@ TEST_P(ParallelConstructThreadCountTest, EmptyResult) {
 
 INSTANTIATE_TEST_SUITE_P(ConstructExportThreadCounts,
                          ParallelConstructThreadCountTest,
-                         ::testing::ValuesIn(kConstructExportThreadCounts),
-                         [](const auto& info) {
-                           return absl::StrCat("t", info.param);
-                         });
+                         ::testing::ValuesIn(kConstructExportThreadCounts));
 
 // White-box test for `splitBlockIntoChunks`. `getRowIndices` never yields
 // an empty view, but the function must still handle one.

--- a/test/ExportQueryExecutionTreesTest.cpp
+++ b/test/ExportQueryExecutionTreesTest.cpp
@@ -1,10 +1,15 @@
-// Copyright 2023 - 2024, University of Freiburg
-// Chair of Algorithms and Data Structures
-// Authors: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
-//          Robin Textor-Falconi <robintf@cs.uni-freiburg.de>
-//          Hannah Bast <bast@cs.uni-freiburg.de>
+// Copyright 2023 - 2026, The QLever Authors, in particular:
+//
+// 2023 - 2026 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+// 2023 - 2026 Robin Textor-Falconi <textorr@cs.uni-freiburg.de>, UFR
+// 2023 - 2026 Hannah Bast <bast@cs.uni-freiburg.de>, UFR
+// 2026        Marvin Stoetzel <stoetzem@email.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
 
 #include <gmock/gmock.h>
+
+#include <limits>
 
 #include "engine/ExportQueryExecutionTrees.h"
 #include "engine/QueryPlanner.h"
@@ -17,6 +22,7 @@
 #include "util/ParseableDuration.h"
 #include "util/ParsedQueryTestHelpers.h"
 #include "util/RuntimeParametersTestHelpers.h"
+#include "util/TripleComponentTestHelpers.h"
 
 using namespace std::string_literals;
 using namespace std::chrono_literals;
@@ -2266,3 +2272,198 @@ INSTANTIATE_TEST_SUITE_P(
         LruWindowParam{5, "abcde"},
         // window 10: all duplicates are caught, 5 unique triples remain.
         LruWindowParam{10, "abcde"}));
+
+// ____________________________________________________________________________
+// The parallel CONSTRUCT serialization (construct-export-num-threads > 1)
+// must produce byte-identical output to the serial path, regardless of the
+// number of groups the rows are split into.
+
+namespace {
+// A knowledge graph with `numTriples` triples `<s0> <p> <o0>` ...
+std::string makeConstructKg(size_t numTriples) {
+  std::string kg;
+  for (size_t i = 0; i < numTriples; ++i) {
+    absl::StrAppend(&kg, "<s", i, "> <p> <o", i, "> .\n");
+  }
+  return kg;
+}
+
+// Returns the streamed result of the given CONSTRUCT query for the given
+// media type, with `numThreads` workers. Chunk size is `BATCH_SIZE`.
+std::string constructResultWithThreads(const std::string& kg,
+                                       const std::string& query,
+                                       ad_utility::MediaType mediaType,
+                                       size_t numThreads) {
+  auto cleanupThreads = setRuntimeParameterForTest<
+      &RuntimeParameters::constructExportNumThreads_>(numThreads);
+  return runQueryStreamableResult(kg, query, mediaType);
+}
+}  // namespace
+
+TEST(ExportQueryExecutionTrees, ParallelConstructSerializationMatchesSerial) {
+  using enum ad_utility::MediaType;
+  // More than one `BATCH_SIZE` chunk so several workers get work.
+  const std::string kg = makeConstructKg(
+      qlever::constructExport::ConstructTripleGenerator::BATCH_SIZE + 200);
+  const std::string query = "CONSTRUCT {?s ?p ?o} WHERE {?s ?p ?o} ORDER BY ?s";
+  // Reference output from the serial path (default thread count).
+  const std::string expectedTsv = runQueryStreamableResult(kg, query, tsv);
+  const std::string expectedTurtle =
+      runQueryStreamableResult(kg, query, turtle);
+  const std::string expectedNtriples =
+      runQueryStreamableResult(kg, query, ntriples);
+
+  for (size_t numThreads : {size_t{2}, size_t{4}, size_t{8}}) {
+    EXPECT_EQ(constructResultWithThreads(kg, query, tsv, numThreads),
+              expectedTsv)
+        << "numThreads = " << numThreads;
+    EXPECT_EQ(constructResultWithThreads(kg, query, turtle, numThreads),
+              expectedTurtle)
+        << "numThreads = " << numThreads;
+    EXPECT_EQ(constructResultWithThreads(kg, query, ntriples, numThreads),
+              expectedNtriples)
+        << "numThreads = " << numThreads;
+  }
+
+  // numThreads == 0 means "all logical cores" and must also match.
+  EXPECT_EQ(constructResultWithThreads(kg, query, tsv, 0), expectedTsv);
+}
+
+// Blank-node labels in the CONSTRUCT output depend on the global row index
+// (via the row offset). Chunks must keep those indices, also with OFFSET.
+TEST(ExportQueryExecutionTrees, ParallelConstructSerializationBlankNodes) {
+  using enum ad_utility::MediaType;
+  const std::string kg = makeConstructKg(
+      qlever::constructExport::ConstructTripleGenerator::BATCH_SIZE + 100);
+  const std::string query =
+      "CONSTRUCT {?s ?p _:b} WHERE {?s ?p ?o} ORDER BY ?s";
+  const std::string queryWithOffset =
+      "CONSTRUCT {?s ?p _:b} WHERE {?s ?p ?o} ORDER BY ?s LIMIT 60 OFFSET 30";
+  for (const auto& q : {query, queryWithOffset}) {
+    const std::string expected = runQueryStreamableResult(kg, q, turtle);
+    EXPECT_EQ(constructResultWithThreads(kg, q, turtle, 4), expected);
+    std::string parallel = constructResultWithThreads(kg, q, turtle, 4);
+    EXPECT_EQ(parallel, expected);
+    EXPECT_NE(parallel.find("_:u"), std::string::npos);
+  }
+}
+
+// When triple deduplication is active, the parallel path stays enabled: the
+// chunks share one `ConstructDeduplicator`.
+// This test verifies that the output must match the serial path.
+TEST(ExportQueryExecutionTrees, ParallelConstructSerializationWithDedup) {
+  using enum ad_utility::MediaType;
+  // Duplicate triples in the result (each ?o appears twice), so deduplication
+  // changes the output.
+  std::string kg;
+  for (size_t i = 0; i < 50; ++i) {
+    absl::StrAppend(&kg, "<s", i, "> <p> <o", i, "> .\n");
+    absl::StrAppend(&kg, "<s", i, "> <p> <o", i, "> .\n");
+  }
+  const std::string query = "CONSTRUCT {?s ?p ?o} WHERE {?s ?p ?o} ORDER BY ?s";
+  auto cleanupDedup =
+      setRuntimeParameterForTest<&RuntimeParameters::constructDeduplication_>(
+          ad_utility::DeduplicationMode::full());
+  const std::string expected = runQueryStreamableResult(kg, query, turtle);
+  EXPECT_EQ(constructResultWithThreads(kg, query, turtle, 4), expected);
+  EXPECT_EQ(constructResultWithThreads(kg, query, turtle, 0), expected);
+}
+
+// The parallel path must also handle an empty result (no rows to serialize):
+// the output is empty and no worker tasks are submitted.
+TEST(ExportQueryExecutionTrees, ParallelConstructSerializationEmptyResult) {
+  using enum ad_utility::MediaType;
+  const std::string kg = makeConstructKg(5);
+  const std::string query =
+      "CONSTRUCT {?s ?p ?o} WHERE {?s ?p ?o FILTER(?s = <s999>)}";
+  for (size_t numThreads : {size_t{1}, size_t{4}}) {
+    EXPECT_EQ(constructResultWithThreads(kg, query, tsv, numThreads), "");
+    EXPECT_EQ(constructResultWithThreads(kg, query, turtle, numThreads), "");
+  }
+}
+
+// White-box test for `splitBlockIntoChunks`. `getRowIndices` never yields
+// an empty view, but the function must still handle one.
+TEST(ExportQueryExecutionTrees, SplitBlockIntoChunks) {
+  std::vector<IdTable> tables;
+  std::vector<LocalVocab> vocabs;
+  auto makeBlock = [&tables, &vocabs](uint64_t begin, uint64_t end) {
+    tables.push_back(makeIdTableFromVector({{0}}));
+    vocabs.emplace_back();
+    return TableWithRange{
+        TableConstRefWithVocab{tables.back().asStaticView<0>(), vocabs.back()},
+        ql::views::iota(begin, end)};
+  };
+  auto rangesOf = [](const std::vector<TableWithRange>& chunks) {
+    std::vector<std::pair<uint64_t, uint64_t>> ranges;
+    for (const auto& chunk : chunks) {
+      const uint64_t begin = *ql::ranges::begin(chunk.view_);
+      ranges.emplace_back(begin, begin + ql::ranges::size(chunk.view_));
+    }
+    return ranges;
+  };
+
+  {
+    auto chunks =
+        ExportQueryExecutionTrees::splitBlockIntoChunks(makeBlock(0, 10), 3);
+    EXPECT_THAT(rangesOf(chunks),
+                ElementsAre(std::pair<uint64_t, uint64_t>{0, 3},
+                            std::pair<uint64_t, uint64_t>{3, 6},
+                            std::pair<uint64_t, uint64_t>{6, 9},
+                            std::pair<uint64_t, uint64_t>{9, 10}));
+  }
+  {
+    auto chunks = ExportQueryExecutionTrees::splitBlockIntoChunks(
+        makeBlock(100, 105), 10);
+    EXPECT_THAT(rangesOf(chunks),
+                ElementsAre(std::pair<uint64_t, uint64_t>{100, 105}));
+  }
+  {
+    auto chunks =
+        ExportQueryExecutionTrees::splitBlockIntoChunks(makeBlock(0, 0), 4);
+    EXPECT_TRUE(chunks.empty());
+  }
+  EXPECT_ANY_THROW(
+      ExportQueryExecutionTrees::splitBlockIntoChunks(makeBlock(0, 5), 0));
+}
+
+// ____________________________________________________________________________
+// White-box test for `serializeConstructGroup`, the per-format serialization
+// body shared by the workers of the parallel CONSTRUCT export.  It must
+// serialize a single row range exactly as the serial path does, concatenated
+// into one output string.
+TEST(ExportQueryExecutionTrees, SerializeConstructGroup) {
+  using namespace qlever::constructExport;
+  auto qec = ad_utility::testing::getQec("<s> <p> <o> .");
+  const Index& index = qec->getIndex();
+  auto handle =
+      std::make_shared<ad_utility::SharedCancellationHandle::element_type>();
+  EvaluationConfig config{index, std::move(handle), *qec};
+
+  const auto idS = ad_utility::testing::makeGetId(index)("<s>");
+  auto result = std::make_shared<const Result>(
+      makeIdTableFromVector({{idS}}), std::vector<ColumnIndex>{}, LocalVocab{});
+  Triples templateTriples{
+      std::array{GraphTerm{ad_utility::testing::iriV("<s>")},
+                 GraphTerm{ad_utility::testing::iriV("<p>")},
+                 GraphTerm{ad_utility::testing::iriV("<o>")}}};
+  VariableToColumnMap varMap{};
+  auto singleRange = [&result] {
+    TableWithRange twr{
+        TableConstRefWithVocab{result->idTableView(), result->localVocab()},
+        ql::views::iota(uint64_t{0}, uint64_t{1})};
+    return ad_utility::InputRangeTypeErased(
+        std::vector<TableWithRange>{std::move(twr)});
+  };
+
+  const std::string turtleOut =
+      ExportQueryExecutionTrees::serializeConstructGroup<
+          ad_utility::MediaType::turtle>(templateTriples, varMap, singleRange(),
+                                         /*rowOffset=*/0, config);
+  EXPECT_EQ(turtleOut, "<s> <p> <o> .\n");
+
+  const std::string tsvOut = ExportQueryExecutionTrees::serializeConstructGroup<
+      ad_utility::MediaType::tsv>(templateTriples, varMap, singleRange(),
+                                  /*rowOffset=*/0, config);
+  EXPECT_EQ(tsvOut, "<s>\t<p>\t<o>\n");
+}


### PR DESCRIPTION
This PR adds multithreaded CONSTRUCT export.

`--construct-export-num-threads` defaults to `1` (serial generator, one formatted triple per yield). 
`0` uses all logical cores. 
`N >= 2` starts a `TaskQueue` with `N` workers. 
`N` is not capped at the core count. 
Extra workers oversubscribe.

SELECT export is unchanged.

## Design

The WHERE result is requested with getResult(true). 
Each live `IdTable` block is cut into chunks of ConstructTripleGenerator::BATCH_SIZE (1024) rows. 
A `TaskQueue` formats those chunks. 
At most 2 * N chunk strings are in flight. 
Workers finish the current block before the generator advances. 
Outputs are yielded in row order.

When `construct-deduplication` is not none, all chunks share one `ConstructDeduplicator`. 
A mutex covers `isNew` and `dedupVocab_` re-anchoring. 
String formatting runs outside the lock. 
Mode `full` is set-correct. 
Mode `lru:N` is insertion-order sensitive under concurrent `isNew`.

`constructQueryResultToStream` dispatches to `constructQueryResultSerial` or `constructQueryResultParallel`. 
The parent coroutine yields the helper output so the Result stays alive.

## Benchmark
Query:
```
PREFIX wd: <http://www.wikidata.org/entity/>
PREFIX wdt: <http://www.wikidata.org/prop/direct/>
PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>

CONSTRUCT { ?entity rdfs:label ?label }
WHERE {
  ?entity wdt:P31 wd:Q5 .
  ?entity rdfs:label ?label .
  FILTER(LANG(?label) = "en")
}
```
Performance

Same query, construct-deduplication=full, 5 cold interleaved reps. 
Every arm, every rep: 1,302,749,672 bytes, xxh3 cf2bbf8ee8a6414f7a14ff74cec09d1b.


| threads |      median e2e |
|--------------|--------------------------|
|1   | 30.079 | 
| 2   | 21.610 s (1.39×) |
| 8   | 15.892 s (1.89×) |
| 16 | 17.014 s (1.77×) |



Host: Ural, 8 cores / 16 SMT. Lowest median on that host is 8 threads. 
16 threads oversubscribe and are slower than 8.

## Tests

`ParallelConstructMatchesSerialTest` is `{tsv, turtle, ntriples}` × `{0, 1, 2, 4, 8}` worker counts. `ParallelConstructThreadCountTest` covers 
blank nodes without OFFSET, 
blank nodes with OFFSET, 
full dedup, and 
an empty result at those counts.