### PR TITLE
Fix `COALESCE` with aggregates over an empty input

### DIFF
--- a/src/engine/sparqlExpressions/ConditionalExpressions.cpp
+++ b/src/engine/sparqlExpressions/ConditionalExpressions.cpp
@@ -94,6 +94,158 @@ class IfExpression : public IfExpressionImpl {
   }
 };
 
+// Helpers for the implementation of the `COALESCE` expression below.
+namespace {
+// A single value is "unbound" (and is therefore overwritten by the next child
+// of a `COALESCE`) iff it is the UNDEF `Id`.
+bool isUnbound(const IdOrLocalVocabEntry& x) {
+  return std::holds_alternative<Id>(x) && std::get<Id>(x).isUndefined();
+}
+
+// Holds the state while the children of a `COALESCE` are applied one after the
+// other: `result_` are the values bound so far (initially all UNDEF), and
+// `unboundIndices_` are the indices (in ascending order) at which `result_` is
+// still unbound and which the remaining children may therefore still bind.
+class CoalesceEvaluation {
+  // Arbitrarily chosen interval after which to check for cancellation.
+  static constexpr size_t CHUNK_SIZE = 1'000'000;
+
+  EvaluationContext* ctx_;
+  VectorWithMemoryLimit<IdOrLocalVocabEntry> result_;
+  // The indices that are unbound before the current child is applied, and those
+  // that remain unbound after applying it.
+  std::vector<uint64_t> unboundIndices_;
+  std::vector<uint64_t> nextUnboundIndices_;
+
+ public:
+  // Set up the state for an evaluation where nothing is bound yet.
+  explicit CoalesceEvaluation(EvaluationContext* ctx)
+      : ctx_{ctx}, result_{ctx->_allocator} {
+    unboundIndices_.reserve(ctx_->size());
+    nextUnboundIndices_.reserve(ctx_->size());
+    ad_utility::chunkedForLoop<CHUNK_SIZE>(
+        0, ctx_->size(), [this](size_t i) { unboundIndices_.push_back(i); },
+        [this]() { checkCancellation(); });
+    std::fill_n(std::back_inserter(result_), ctx_->size(),
+                IdOrLocalVocabEntry{Id::makeUndefined()});
+    checkCancellation();
+  }
+
+  // True iff no child has bound any result so far. Note that for an empty
+  // evaluation context this is trivially and permanently true, as there is no
+  // result that could be bound in the first place.
+  bool nothingBoundYet() const {
+    return unboundIndices_.size() == ctx_->size();
+  }
+
+  // True iff every result is bound, so that the remaining children of the
+  // `COALESCE` don't have to be evaluated at all.
+  bool allResultsBound() const {
+    return unboundIndices_.empty() && !nothingBoundYet();
+  }
+
+  // Apply a child with a constant result. Returns that constant iff the result
+  // of the whole `COALESCE` is that constant, and `std::nullopt` otherwise.
+  template <typename T>
+  std::optional<IdOrLocalVocabEntry> applyConstantResult(T&& childResult) {
+    using U = decltype(childResult);
+    static_assert(SingleExpressionResult<U> && isConstantResult<U>);
+    IdOrLocalVocabEntry constantResult{AD_FWD(childResult)};
+    if (isUnbound(constantResult)) {
+      // This child binds nothing, so all the unbound indices stay unbound.
+      nextUnboundIndices_ = std::move(unboundIndices_);
+      return std::nullopt;
+    }
+    // If nothing was bound before, then this constant binds *all* the results,
+    // so the whole `COALESCE` evaluates to it.
+    if (nothingBoundYet()) {
+      return constantResult;
+    }
+    // GCC 12 & 13 report the assignment below as potential uninitialized use of
+    // a variable when compiling with -O3, which seems to be a false positive,
+    // so we suppress the warning here. See
+    // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=109561 for more information.
+    DISABLE_UNINITIALIZED_WARNINGS
+    ad_utility::chunkedForLoop<CHUNK_SIZE>(
+        0, unboundIndices_.size(),
+        [this, &constantResult](size_t idx) {
+          result_[unboundIndices_[idx]] = constantResult;
+        },
+        [this]() { checkCancellation(); });
+    GCC_REENABLE_WARNINGS
+    return std::nullopt;
+  }
+
+  // Apply a child that yields one value per row: Write its result at the
+  // indices where the result so far is unbound and the child's result is bound.
+  // While doing so, set up `nextUnboundIndices_` for the next child.
+  template <typename T>
+  void applyVectorResult(T&& childResult) {
+    using U = decltype(childResult);
+    static_assert(!(isConstantResult<U> && SingleExpressionResult<U> &&
+                    std::is_rvalue_reference_v<U>));
+    if (unboundIndices_.empty()) {
+      // There is nothing left to bind. For a nonempty evaluation context we
+      // would have stopped evaluating children already (see `allResultsBound`),
+      // so this can only happen for an empty context, for which this child
+      // simply contributes no value at all.
+      AD_CORRECTNESS_CHECK(nothingBoundYet());
+      return;
+    }
+    auto gen = detail::makeGenerator(AD_FWD(childResult), ctx_->size(), ctx_);
+    // Iterator to the next index where the result so far is unbound.
+    auto unboundIdxIt = unboundIndices_.begin();
+    auto generatorIterator = gen.begin();
+    ad_utility::chunkedForLoop<CHUNK_SIZE>(
+        0, ctx_->size(),
+        [this, &unboundIdxIt, &generatorIterator](size_t i,
+                                                  const auto& breakLoop) {
+          // Skip all the indices where the result is already bound from a
+          // previous child.
+          if (i == *unboundIdxIt) {
+            if (IdOrLocalVocabEntry val{std::move(*generatorIterator)};
+                isUnbound(val)) {
+              nextUnboundIndices_.push_back(i);
+            } else {
+              result_.at(*unboundIdxIt) = std::move(val);
+            }
+            ++unboundIdxIt;
+            if (unboundIdxIt == unboundIndices_.end()) {
+              breakLoop();
+              return;
+            }
+          }
+          ++generatorIterator;
+        },
+        [this]() { checkCancellation(); });
+  }
+
+  // Move on to the next child.
+  void advanceToNextChild() {
+    unboundIndices_ = std::move(nextUnboundIndices_);
+    nextUnboundIndices_.clear();
+    checkCancellation();
+  }
+
+  // The result of the `COALESCE` after all children have been applied.
+  ExpressionResult moveResultOut() && {
+    // Prefer returning a single UNDEF over a vector of UNDEFs if all the
+    // results are unbound. Note that for an empty evaluation context nothing
+    // can ever be bound by a child with a per-row result, so the result there
+    // is UNDEF unless some child had a bound constant value.
+    if (nothingBoundYet()) {
+      return Id::makeUndefined();
+    }
+    return std::move(result_);
+  }
+
+ private:
+  void checkCancellation() const {
+    ctx_->cancellationHandle_->throwIfCancelled();
+  }
+};
+}  // namespace
+
 // The implementation of the COALESCE expression. It (at least currently) has to
 // be done manually as we have no Generic implementation for variadic
 // expressions, as it is the first one.
@@ -113,143 +265,46 @@ class CoalesceExpression : public VariadicExpression {
 
   // _____________________________________________________________
   ExpressionResult evaluate(EvaluationContext* ctx) const override {
-    // Arbitrarily chosen interval after which to check for cancellation.
-    constexpr size_t CHUNK_SIZE = 1'000'000;
+    CoalesceEvaluation evaluation{ctx};
 
-    // Set up one vector with the indices of the elements that are still unbound
-    // so far and one for the indices that remain unbound after applying one of
-    // the children.
-    std::vector<uint64_t> unboundIndices;
-    std::vector<uint64_t> nextUnboundIndices;
-    unboundIndices.reserve(ctx->size());
-    nextUnboundIndices.reserve(ctx->size());
-
-    // Initially all result are unbound.
-    ad_utility::chunkedForLoop<CHUNK_SIZE>(
-        0, ctx->size(),
-        [&unboundIndices](size_t i) { unboundIndices.push_back(i); },
-        [ctx]() { ctx->cancellationHandle_->throwIfCancelled(); });
-    VectorWithMemoryLimit<IdOrLocalVocabEntry> result{ctx->_allocator};
-    std::fill_n(std::back_inserter(result), ctx->size(),
-                IdOrLocalVocabEntry{Id::makeUndefined()});
-    if (result.empty()) {
-      return result;
-    }
-
-    ctx->cancellationHandle_->throwIfCancelled();
-
-    auto isUnbound = [](const IdOrLocalVocabEntry& x) {
-      return std::holds_alternative<Id>(x) && std::get<Id>(x).isUndefined();
-    };
-
-    // The visitors below return an engaged optional iff the whole `COALESCE`
-    // can be short-circuited to a single constant value (see below).
-    auto visitConstantExpressionResult =
-        [&nextUnboundIndices, &unboundIndices, &isUnbound, &result,
-         ctx](auto&& childResult) -> std::optional<IdOrLocalVocabEntry> {
-      using T = decltype(childResult);
-      static_assert(SingleExpressionResult<T> && isConstantResult<T>);
-      IdOrLocalVocabEntry constantResult{AD_FWD(childResult)};
-      if (isUnbound(constantResult)) {
-        nextUnboundIndices = std::move(unboundIndices);
-        return std::nullopt;
-      }
-      // If we have a constant value and no other values are bound so far, we
-      // can directly return the constant value.
-      if (unboundIndices.size() == ctx->size()) {
-        return constantResult;
-      }
-      ad_utility::chunkedForLoop<CHUNK_SIZE>(
-          0, unboundIndices.size(),
-          [&unboundIndices, &result, &constantResult](size_t idx) {
-            // GCC 12 & 13 report this as potential uninitialized
-            // use of a variable when compiling with -O3, which seems to
-            // be a false positive, so we suppress the warning here. See
-            // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=109561 for
-            // more information.
-            DISABLE_UNINITIALIZED_WARNINGS
-            result[unboundIndices[idx]] = constantResult;
-          },
-          [ctx]() { ctx->cancellationHandle_->throwIfCancelled(); });
-      return std::nullopt;
-    };
-    GCC_REENABLE_WARNINGS
-
-    // For a single child result, write the result at the indices where the
-    // result so far is unbound, and the child result is bound. While doing so,
-    // set up the `nextUnboundIndices` vector  for the next step.
-    auto visitVectorExpressionResult = [&result, &unboundIndices,
-                                        &nextUnboundIndices, &ctx,
-                                        &isUnbound](auto&& childResult) {
-      using T = decltype(childResult);
-      static_assert(!(isConstantResult<T> && SingleExpressionResult<T> &&
-                      std::is_rvalue_reference_v<T>));
-      auto gen = detail::makeGenerator(AD_FWD(childResult), ctx->size(), ctx);
-      // Iterator to the next index where the result so far is unbound.
-      auto unboundIdxIt = unboundIndices.begin();
-      AD_CORRECTNESS_CHECK(unboundIdxIt != unboundIndices.end());
-      auto generatorIterator = gen.begin();
-      ad_utility::chunkedForLoop<CHUNK_SIZE>(
-          0, ctx->size(),
-          [&unboundIdxIt, &isUnbound, &nextUnboundIndices, &result,
-           &unboundIndices,
-           &generatorIterator](size_t i, const auto& breakLoop) {
-            // Skip all the indices where the result is already bound from a
-            // previous child.
-            if (i == *unboundIdxIt) {
-              if (IdOrLocalVocabEntry val{std::move(*generatorIterator)};
-                  isUnbound(val)) {
-                nextUnboundIndices.push_back(i);
-              } else {
-                result.at(*unboundIdxIt) = std::move(val);
-              }
-              ++unboundIdxIt;
-              if (unboundIdxIt == unboundIndices.end()) {
-                breakLoop();
-                return;
-              }
-            }
-            ++generatorIterator;
-          },
-          [ctx]() { ctx->cancellationHandle_->throwIfCancelled(); });
-    };
-    auto visitExpressionResult =
-        [&visitConstantExpressionResult, &visitVectorExpressionResult](
+    auto applyChildResult =
+        [&evaluation](
             auto&& childResult) -> std::optional<IdOrLocalVocabEntry> {
       using T = decltype(childResult);
       static_assert(SingleExpressionResult<T> && std::is_rvalue_reference_v<T>);
-      // If the previous expression result is a constant, we can skip the
-      // loop.
       if constexpr (isConstantResult<T>) {
-        return visitConstantExpressionResult(AD_FWD(childResult));
+        return evaluation.applyConstantResult(AD_FWD(childResult));
       } else {
-        visitVectorExpressionResult(AD_FWD(childResult));
+        evaluation.applyVectorResult(AD_FWD(childResult));
         return std::nullopt;
       }
     };
 
-    // Evaluate the children one by one, stopping as soon as all result are
+    // Evaluate the children one by one, stopping as soon as all results are
     // bound.
+    //
+    // NOTE: We must not short-circuit on an *empty* evaluation context before
+    // the children have been consulted. Like every other expression, `COALESCE`
+    // yields a constant whenever its inputs are constant (compare
+    // `getResultSize` for the generic expressions, or `ConcatExpression`), and
+    // it neither knows nor needs to know whether it is evaluated inside a
+    // `GROUP BY`. An empty context arises for an implicit `GROUP BY` (no
+    // `GROUP BY` variables) over an empty input, where all the children are
+    // aggregates that do have a constant value for the empty group (`SUM`
+    // yields `0`, `MIN` yields UNDEF, etc.), so simply evaluating them gives
+    // the correct constant, which `GroupBy` then requires.
     for (const auto& child : childrenVec()) {
       std::optional<IdOrLocalVocabEntry> constantValue =
-          std::visit(visitExpressionResult, child->evaluate(ctx));
+          std::visit(applyChildResult, child->evaluate(ctx));
       if (constantValue.has_value()) {
-        return constantValue.value();
+        return std::move(constantValue).value();
       }
-      unboundIndices = std::move(nextUnboundIndices);
-      nextUnboundIndices.clear();
-      ctx->cancellationHandle_->throwIfCancelled();
-      // Early stopping if no more unbound result remain.
-      if (unboundIndices.empty()) {
+      evaluation.advanceToNextChild();
+      if (evaluation.allResultsBound()) {
         break;
       }
     }
-    // Prefer returning a single UNDEF over a vector of UNDEFs if all results
-    // are unbound.
-    if (unboundIndices.size() == ctx->size()) {
-      return Id::makeUndefined();
-    }
-    return result;
+    return std::move(evaluation).moveResultOut();
   }
 };
 

--- a/test/GroupByTest.cpp
+++ b/test/GroupByTest.cpp
@@ -3435,6 +3435,100 @@ TEST(GroupBy, CoalesceWithAggregatesOfOptionalValues) {
 }
 
 // _____________________________________________________________________________
+// An aggregate that is wrapped inside a `COALESCE` used to make an implicit
+// `GROUP BY` (no `GROUP BY` variables) over an empty input fail, because the
+// `COALESCE` returned an empty vector (the evaluation context has size zero)
+// where `GroupBy` requires a constant.
+TEST(GroupBy, CoalesceWithAggregateOnEmptyImplicitGroup) {
+  auto* qec = getQec();
+  Variable o{"?o"};
+  Id U = Id::makeUndefined();
+
+  // Build `SELECT (COALESCE(makeChildren()...) AS ?c) WHERE { ... }` without a
+  // `GROUP BY` over an input with zero rows.
+  auto makeGroupBy = [qec, &o](const auto& makeChildren, bool inputIsLazy) {
+    std::vector<IdTable> idTables;
+    idTables.push_back(IdTable{1, qec->getAllocator()});
+    auto subtree = ad_utility::makeExecutionTree<ValuesForTesting>(
+        qec, std::move(idTables), std::vector<std::optional<Variable>>{o},
+        inputIsLazy);
+    return GroupByImpl{
+        qec,
+        {},
+        {Alias{SparqlExpressionPimpl{makeCoalesceExpression(makeChildren()),
+                                     "coalesce"},
+               Variable{"?c"}}},
+        std::move(subtree)};
+  };
+
+  // Check the value of that `COALESCE` for both the fully materialized and the
+  // lazy code path (the latter goes through `processEmptyImplicitGroup`).
+  auto expectCoalesce = [qec, &makeGroupBy](const auto& makeChildren,
+                                            Id expected,
+                                            ad_utility::source_location l =
+                                                AD_CURRENT_SOURCE_LOC()) {
+    auto trace = generateLocationTrace(l);
+    auto expectedTable = makeIdTableFromVector({{expected}});
+
+    // The two runs below compute the same subtree, so the cache has to be
+    // cleared in between, else the second run reuses the (materialized)
+    // result of the first one.
+    qec->getQueryTreeCache().clearAll();
+    EXPECT_EQ(makeGroupBy(makeChildren, false)
+                  .computeResultOnlyForTesting(false)
+                  .idTableView(),
+              expectedTable);
+
+    qec->getQueryTreeCache().clearAll();
+    auto groupBy = makeGroupBy(makeChildren, true);
+    auto result = groupBy.computeResultOnlyForTesting(true);
+    ASSERT_FALSE(result.isFullyMaterialized());
+    std::vector<IdTable> tables;
+    for (auto& [idTable, localVocab] : result.idTables()) {
+      tables.push_back(std::move(idTable));
+    }
+    ASSERT_EQ(tables.size(), 1);
+    EXPECT_EQ(tables.at(0), expectedTable);
+  };
+
+  auto sum = [&o]() {
+    return std::make_unique<SumExpression>(
+        false, std::make_unique<VariableExpression>(o));
+  };
+  auto min = [&o]() {
+    return std::make_unique<MinExpression>(
+        false, std::make_unique<VariableExpression>(o));
+  };
+  auto max = [&o]() {
+    return std::make_unique<MaxExpression>(
+        false, std::make_unique<VariableExpression>(o));
+  };
+  auto constant = [](Id id) {
+    return [id]() { return std::make_unique<IdExpression>(id); };
+  };
+  // Turn a set of factories for the individual children into a factory for the
+  // whole vector of children (which has to be created anew for each `GroupBy`).
+  auto children = [](auto... makeChild) {
+    return [makeChild...]() {
+      std::vector<SparqlExpression::Ptr> result;
+      (result.push_back(makeChild()), ...);
+      return result;
+    };
+  };
+
+  // `SUM` of the empty group is `0`, so the first child already binds the
+  // result.
+  expectCoalesce(children(sum, constant(I(1))), I(0));
+  // `MIN` and `MAX` of the empty group are UNDEF, so the fallback is used.
+  expectCoalesce(children(min, constant(I(1))), I(1));
+  expectCoalesce(children(max, constant(I(1))), I(1));
+  // If all the children are unbound, the result is UNDEF.
+  expectCoalesce(children(min, max), U);
+  // A `COALESCE` without any children is always UNDEF.
+  expectCoalesce(children(), U);
+}
+
+// _____________________________________________________________________________
 TEST(GroupBy, BlankNodeInGroupBy) {
   auto* qec = getQec();
   Variable o{"?o"};

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -1862,11 +1862,18 @@ TEST(SparqlExpression, ifAndCoalesce) {
   // If all children are unbound constants, the result is a single UNDEF.
   checkCoalesce(U, std::tuple{U, U});
 
-  // Check COALESCE with no arguments or empty arguments.
-  checkCoalesce(IdOrLocalVocabEntryVec{}, std::tuple{});
-  checkCoalesce(IdOrLocalVocabEntryVec{}, std::tuple{Ids{}});
-  checkCoalesce(IdOrLocalVocabEntryVec{}, std::tuple{Ids{}, Ids{}});
-  checkCoalesce(IdOrLocalVocabEntryVec{}, std::tuple{Ids{}, Ids{}, Ids{}});
+  // Check COALESCE with no arguments or empty arguments. The result is a single
+  // UNDEF and not an empty vector, by the same rule as in the case directly
+  // above: nothing is bound, and for an empty input nothing ever can be. Both
+  // representations are equivalent for an ordinary expression (the number of
+  // result rows is determined by the input, not by this result), but only a
+  // constant is accepted when the `COALESCE` is evaluated as part of an
+  // implicit `GROUP BY` over an empty input, see the
+  // `CoalesceWithAggregateOnEmptyImplicitGroup` test in `GroupByTest.cpp`.
+  checkCoalesce(U, std::tuple{});
+  checkCoalesce(U, std::tuple{Ids{}});
+  checkCoalesce(U, std::tuple{Ids{}, Ids{}});
+  checkCoalesce(U, std::tuple{Ids{}, Ids{}, Ids{}});
 
   auto coalesceExpr = makeCoalesceExpressionVariadic(
       std::make_unique<IriExpression>(iri("<bim>")),


### PR DESCRIPTION
So far, a `COALESCE` over an empty input returned an empty result vector without looking at its arguments. That is wrong when the arguments are aggregates in a `GROUP BY` without group variables, where an empty input still forms one group with one result row, for which the aggregates do have values (`SUM` is `0`, `COUNT` is `0`, `MIN` is unbound, etc.). For example, `SELECT (COALESCE(SUM(?o), 0) AS ?sum) WHERE { ?s <nexistepas> ?o }` failed with "An expression returned an invalid type ... as the result of an aggregation step" or an assertion failure; see #2706 and #2374.

This change evaluates the arguments also for an empty input. The first argument with a bound constant value then determines the result, and the result is a single unbound value if there is none. In particular, fixes #2706.