### PR TITLE
Implement the full vocabulary interface for `VocabularyInMemoryBinSearch`

### DIFF
--- a/src/index/vocabulary/VocabularyInMemoryBinSearch.cpp
+++ b/src/index/vocabulary/VocabularyInMemoryBinSearch.cpp
@@ -75,7 +75,8 @@ WordAndIndex VocabularyInMemoryBinSearch::iteratorToWordAndIndex(
 }
 
 // _____________________________________________________________________________
-std::unique_ptr<WordWriterBase> VocabularyInMemoryBinSearch::makeDiskWriterPtr(
+[[noreturn]] std::unique_ptr<WordWriterBase>
+VocabularyInMemoryBinSearch::makeDiskWriterPtr(
     [[maybe_unused]] const std::string& filename) {
   AD_THROW(
       "A vocabulary with holes cannot be built word by word, because the "

--- a/src/index/vocabulary/VocabularyInMemoryBinSearch.cpp
+++ b/src/index/vocabulary/VocabularyInMemoryBinSearch.cpp
@@ -7,9 +7,19 @@
 using std::string;
 
 // _____________________________________________________________________________
+VocabularyInMemoryBinSearch::IndicesView VocabularyInMemoryBinSearch::indices()
+    const {
+  return std::visit(
+      [](const auto& indices) -> IndicesView {
+        return {indices.data(), indices.size()};
+      },
+      indices_);
+}
+
+// _____________________________________________________________________________
 void VocabularyInMemoryBinSearch::open(const string& fileName) {
   AD_CORRECTNESS_CHECK(
-      words_.size() == 0 && indices_.empty(),
+      words_.size() == 0 && indices().empty(),
       "Calling open on the same vocabulary twice is probably a bug");
   {
     ad_utility::serialization::FileReadSerializer file(fileName);
@@ -17,18 +27,36 @@ void VocabularyInMemoryBinSearch::open(const string& fileName) {
   }
   {
     ad_utility::serialization::FileReadSerializer idFile(fileName + ".ids");
-    idFile >> indices_;
+    idFile >> ownedIndices();
   }
+}
+
+// _____________________________________________________________________________
+std::optional<size_t> VocabularyInMemoryBinSearch::positionOfIndex(
+    uint64_t index) const {
+  auto indices = this->indices();
+  auto it = ql::ranges::lower_bound(indices, index);
+  if (it != indices.end() && *it == index) {
+    return static_cast<size_t>(it - indices.begin());
+  }
+  return std::nullopt;
+}
+
+// _____________________________________________________________________________
+uint64_t VocabularyInMemoryBinSearch::indexAtPosition(size_t position) const {
+  auto indices = this->indices();
+  AD_CORRECTNESS_CHECK(position < indices.size());
+  return indices[position];
 }
 
 // _____________________________________________________________________________
 std::optional<std::string_view> VocabularyInMemoryBinSearch::operator[](
     uint64_t index) const {
-  auto it = ql::ranges::lower_bound(indices_, index);
-  if (it != indices_.end() && *it == index) {
-    return words_[it - indices_.begin()];
+  auto position = positionOfIndex(index);
+  if (!position.has_value()) {
+    return std::nullopt;
   }
-  return std::nullopt;
+  return words_[position.value()];
 }
 
 // _____________________________________________________________________________
@@ -38,17 +66,27 @@ WordAndIndex VocabularyInMemoryBinSearch::iteratorToWordAndIndex(
     return WordAndIndex::end();
   }
   auto idx = static_cast<uint64_t>(it - words_.begin());
-  WordAndIndex result{words_[idx], indices_[idx]};
+  auto indices = this->indices();
+  WordAndIndex result{words_[idx], indices[idx]};
   if (idx > 0) {
-    result.previousIndex() = indices_[idx - 1];
+    result.previousIndex() = indices[idx - 1];
   }
   return result;
 }
 
 // _____________________________________________________________________________
+std::unique_ptr<WordWriterBase> VocabularyInMemoryBinSearch::makeDiskWriterPtr(
+    [[maybe_unused]] const std::string& filename) {
+  AD_THROW(
+      "A vocabulary with holes cannot be built word by word, because the "
+      "`WordWriterBase` interface cannot express the explicit indices. Such a "
+      "vocabulary can only be created by filtering an existing vocabulary.");
+}
+
+// _____________________________________________________________________________
 void VocabularyInMemoryBinSearch::close() {
   words_.clear();
-  indices_.clear();
+  indices_.emplace<Indices>();
 }
 
 // _____________________________________________________________________________

--- a/src/index/vocabulary/VocabularyInMemoryBinSearch.h
+++ b/src/index/vocabulary/VocabularyInMemoryBinSearch.h
@@ -9,6 +9,7 @@
 #include <string_view>
 #include <variant>
 
+#include "backports/algorithm.h"
 #include "backports/span.h"
 #include "index/vocabulary/VocabularyBinarySearchMixin.h"
 #include "index/vocabulary/VocabularyTypes.h"
@@ -36,7 +37,7 @@ class VocabularyInMemoryBinSearch
   // The actual storage. The indices are stored either as an owned vector
   // (after `open()`, or after reading from a regular, non-zero-copy
   // serializer), or as a non-owning view into externally-owned memory (after
-  // `fromZeroCopyDeserializer`), exactly as in `CompactVectorOfStrings`.
+  // `fromZeroCopyDeserializer`).
   Words words_;
   std::variant<Indices, IndicesView> indices_;
 
@@ -97,9 +98,10 @@ class VocabularyInMemoryBinSearch
   // Iterate over all words of the vocabulary in order, together with their
   // (because of the holes, not necessarily contiguous) vocabulary index.
   auto scanAll() const {
-    return ad_utility::integerRange(static_cast<uint64_t>(size())) |
-           ql::views::transform([this](uint64_t position) {
-             return IndexAndWord{indices()[position], words_[position]};
+    return ::ranges::views::zip(indices(), words_) |
+           ql::views::transform([](const auto& indexAndWord) {
+             const auto& [index, word] = indexAndWord;
+             return IndexAndWord{index, word};
            });
   }
 
@@ -139,7 +141,7 @@ class VocabularyInMemoryBinSearch
   // A vocabulary with holes cannot be written via the `WordWriterBase`
   // interface (which cannot express the explicit indices), so this function
   // always throws. Use the nested `WordWriter` above instead.
-  static std::unique_ptr<WordWriterBase> makeDiskWriterPtr(
+  [[noreturn]] static std::unique_ptr<WordWriterBase> makeDiskWriterPtr(
       const std::string& filename);
 
   // Clear the vocabulary.

--- a/src/index/vocabulary/VocabularyInMemoryBinSearch.h
+++ b/src/index/vocabulary/VocabularyInMemoryBinSearch.h
@@ -7,7 +7,9 @@
 
 #include <string>
 #include <string_view>
+#include <variant>
 
+#include "backports/span.h"
 #include "index/vocabulary/VocabularyBinarySearchMixin.h"
 #include "index/vocabulary/VocabularyTypes.h"
 #include "util/Algorithm.h"
@@ -28,11 +30,15 @@ class VocabularyInMemoryBinSearch
   using String = std::basic_string<CharType>;
   using Words = CompactVectorOfStrings<CharType>;
   using Indices = std::vector<uint64_t>;
+  using IndicesView = ql::span<const uint64_t>;
 
  private:
-  // The actual storage.
+  // The actual storage. The indices are stored either as an owned vector
+  // (after `open()`, or after reading from a regular, non-zero-copy
+  // serializer), or as a non-owning view into externally-owned memory (after
+  // `fromZeroCopyDeserializer`), exactly as in `CompactVectorOfStrings`.
   Words words_;
-  Indices indices_;
+  std::variant<Indices, IndicesView> indices_;
 
  public:
   // Construct an empty vocabulary
@@ -43,8 +49,27 @@ class VocabularyInMemoryBinSearch
       VocabularyInMemoryBinSearch&&) noexcept = default;
   VocabularyInMemoryBinSearch(VocabularyInMemoryBinSearch&&) noexcept = default;
 
-  // Const access for the indices.
-  const Indices& indices() const { return indices_; }
+  // Build a vocabulary as a non-owning, zero-copy view directly into the
+  // buffer of `serializer`, which must support zero-copy deserialization (see
+  // `ZeroCopyReadSerializer` in `util/Serializer/Serializer.h`). The returned
+  // vocabulary is only valid as long as the memory backing `serializer`'s
+  // buffer is valid and unchanged. The layout read here exactly matches the one
+  // written by the generic serialization function below.
+  CPP_template(typename S)(
+      requires ad_utility::serialization::ZeroCopyReadSerializer<
+          S>) static VocabularyInMemoryBinSearch
+      fromZeroCopyDeserializer(S& serializer) {
+    VocabularyInMemoryBinSearch result;
+    result.words_ = Words::fromZeroCopyDeserializer(serializer);
+    result.indices_ =
+        ad_utility::serialization::zeroCopyDeserializeToSpan<uint64_t>(
+            serializer);
+    return result;
+  }
+
+  // Const access to the indices, no matter whether they are currently owned or
+  // only viewed.
+  IndicesView indices() const;
 
   // Read the vocabulary from a file. The file must have been created using a
   // `WordWriter`.
@@ -52,13 +77,42 @@ class VocabularyInMemoryBinSearch
 
   // Return the total number of words
   [[nodiscard]] size_t size() const {
-    AD_CORRECTNESS_CHECK(indices_.size() == words_.size());
+    AD_CORRECTNESS_CHECK(indices().size() == words_.size());
     return words_.size();
   }
+
+  // Return the position (i.e. the offset into the words) of the word with the
+  // given vocabulary `index`, or `std::nullopt` if `index` is not contained in
+  // this vocabulary (which can happen because of the "holes", see above).
+  std::optional<size_t> positionOfIndex(uint64_t index) const;
+
+  // Return the vocabulary index of the word at the given `position`. The
+  // `position` must be smaller than `size()`.
+  uint64_t indexAtPosition(size_t position) const;
 
   // Return the word with index `index`. If this index is not part of the
   // vocabulary, return `std::nullopt`.
   std::optional<std::string_view> operator[](uint64_t index) const;
+
+  // Iterate over all words of the vocabulary in order, together with their
+  // (because of the holes, not necessarily contiguous) vocabulary index.
+  auto scanAll() const {
+    return ad_utility::integerRange(static_cast<uint64_t>(size())) |
+           ql::views::transform([this](uint64_t position) {
+             return IndexAndWord{indices()[position], words_[position]};
+           });
+  }
+
+  //____________________________________________________________________________
+  VocabBatchLookupResult lookupBatch(ql::span<const size_t> indices) const {
+    return ad_utility::vocabulary::sequentialLookupBatch(*this, indices);
+  }
+
+  //____________________________________________________________________________
+  VocabLookupOutput lookupBatchesStreamed(VocabLookupInput input) const {
+    return ad_utility::vocabulary::lookupBatchesStreamed(*this,
+                                                         std::move(input));
+  }
 
   // Convert an iterator to a `WordAndIndex`. Required for the mixin.
   WordAndIndex iteratorToWordAndIndex(ql::ranges::iterator_t<Words> it) const;
@@ -82,6 +136,12 @@ class VocabularyInMemoryBinSearch
     void finish();
   };
 
+  // A vocabulary with holes cannot be written via the `WordWriterBase`
+  // interface (which cannot express the explicit indices), so this function
+  // always throws. Use the nested `WordWriter` above instead.
+  static std::unique_ptr<WordWriterBase> makeDiskWriterPtr(
+      const std::string& filename);
+
   // Clear the vocabulary.
   void close();
 
@@ -89,14 +149,24 @@ class VocabularyInMemoryBinSearch
   auto begin() const { return words_.begin(); }
   auto end() const { return words_.end(); }
 
-  // Generic serialization support.
+  // Generic serialization support. Note: Reading always produces a vocabulary
+  // that owns its indices; use `fromZeroCopyDeserializer` (see above) to obtain
+  // a non-owning, zero-copy view.
   AD_SERIALIZE_FRIEND_FUNCTION(VocabularyInMemoryBinSearch) {
-    (void)serializer;
-    (void)arg;
-    throw std::runtime_error(
-        "Generic serialization is not implemented for "
-        "VocabularyInMemoryBinSearch.");
+    serializer | arg.words_;
+    if constexpr (ad_utility::serialization::WriteSerializer<S>) {
+      serializer << arg.indices();
+    } else {
+      auto& indices = arg.indices_.template emplace<Indices>();
+      serializer | indices;
+    }
   }
+
+ private:
+  // Access the owned indices. Throws (via `std::get`) if this vocabulary
+  // currently only views its indices, which is a programming error (a
+  // zero-copy view is read-only).
+  Indices& ownedIndices() { return std::get<Indices>(indices_); }
 };
 
 #endif  // QLEVER_SRC_INDEX_VOCABULARY_VOCABULARYINMEMORYBINSEARCH_H

--- a/src/index/vocabulary/VocabularyInMemoryBinSearch.h
+++ b/src/index/vocabulary/VocabularyInMemoryBinSearch.h
@@ -33,6 +33,14 @@ class VocabularyInMemoryBinSearch
   using Indices = std::vector<uint64_t>;
   using IndicesView = ql::span<const uint64_t>;
 
+  // The holes of this vocabulary are deliberate: such a vocabulary is created
+  // by excluding some of the entries of a larger vocabulary, and is used in
+  // settings where looking up an excluded entry must not throw. Exporting a
+  // word that is not contained therefore yields
+  // `ad_utility::vocabulary::placeholderForMissingVocabIndex` instead of an
+  // exception (see `VocabularyTypes.h`).
+  static constexpr bool replaceOptionalByPlaceholderOnExport = true;
+
  private:
   // The actual storage. The indices are stored either as an owned vector
   // (after `open()`, or after reading from a regular, non-zero-copy

--- a/src/index/vocabulary/VocabularyInternalExternal.h
+++ b/src/index/vocabulary/VocabularyInternalExternal.h
@@ -149,7 +149,7 @@ class VocabularyInternalExternal {
   }
   uint64_t iteratorToIndex(
       ql::ranges::iterator_t<VocabularyInMemoryBinSearch> it) const {
-    return internalVocab_.indices().at(it - internalVocab_.begin());
+    return internalVocab_.indexAtPosition(it - internalVocab_.begin());
   }
 
   // Generic serialization support.

--- a/src/index/vocabulary/VocabularyTypes.h
+++ b/src/index/vocabulary/VocabularyTypes.h
@@ -163,7 +163,7 @@ std::string wordAsStringOrPlaceholder(const Vocab& vocab, uint64_t index) {
     }
     return std::string{word.value()};
   } else {
-    return std::string{word};
+    return std::string{std::move(word)};
   }
 }
 

--- a/src/index/vocabulary/VocabularyTypes.h
+++ b/src/index/vocabulary/VocabularyTypes.h
@@ -14,6 +14,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -149,17 +150,53 @@ inline std::string placeholderForMissingVocabIndex(uint64_t index) {
   return absl::StrCat("<qlever-excluded-vocab-entry-", index, ">");
 }
 
+namespace detail {
+// The implementation of `replaceOptionalByPlaceholderOnExport` below. The
+// primary template covers all vocabularies that don't declare the
+// corresponding member, the partial specialization those that do.
+template <typename Vocab, typename = void>
+struct ReplaceOptionalByPlaceholderOnExportImpl : std::false_type {};
+
+template <typename Vocab>
+struct ReplaceOptionalByPlaceholderOnExportImpl<
+    Vocab, std::void_t<decltype(Vocab::replaceOptionalByPlaceholderOnExport)>>
+    : std::bool_constant<Vocab::replaceOptionalByPlaceholderOnExport> {};
+}  // namespace detail
+
+// Whether the `Vocab` has opted in to reporting a word that it doesn't contain
+// (that is, its `operator[]` returns `std::nullopt`) as
+// `placeholderForMissingVocabIndex` when the words are exported, instead of
+// throwing. A vocabulary opts in by declaring
+// `static constexpr bool replaceOptionalByPlaceholderOnExport = true;`. The
+// default is `false`, because silently reporting a word that is not the one
+// that was asked for is only correct for vocabularies that are deliberately
+// created with holes (see `VocabularyInMemoryBinSearch`).
+template <typename Vocab>
+constexpr bool replaceOptionalByPlaceholderOnExport =
+    detail::ReplaceOptionalByPlaceholderOnExportImpl<Vocab>::value;
+
 // Return `vocab[index]` as a `std::string`. If the `operator[]` of `vocab`
 // returns a `std::optional` (which is the case for vocabularies with holes, see
-// `VocabularyInMemoryBinSearch`) that is `std::nullopt`, return
-// `placeholderForMissingVocabIndex(index)` instead.
+// `VocabularyInMemoryBinSearch`) that is `std::nullopt`, then return
+// `placeholderForMissingVocabIndex(index)` if the `vocab` has opted in to this
+// behavior via `replaceOptionalByPlaceholderOnExport` (see above), and throw
+// otherwise.
 template <typename Vocab>
 std::string wordAsStringOrPlaceholder(const Vocab& vocab, uint64_t index) {
   decltype(auto) word = vocab[index];
   if constexpr (ad_utility::similarToInstantiation<decltype(word),
                                                    std::optional>) {
     if (!word.has_value()) {
-      return placeholderForMissingVocabIndex(index);
+      if constexpr (replaceOptionalByPlaceholderOnExport<Vocab>) {
+        return placeholderForMissingVocabIndex(index);
+      } else {
+        AD_THROW(absl::StrCat(
+            "The index ", index,
+            " is not contained in the vocabulary. If the vocabulary is "
+            "deliberately built with such holes, then it has to declare "
+            "`static constexpr bool replaceOptionalByPlaceholderOnExport = "
+            "true;` to report a placeholder for the missing word instead."));
+      }
     }
     return std::string{word.value()};
   } else {

--- a/src/index/vocabulary/VocabularyTypes.h
+++ b/src/index/vocabulary/VocabularyTypes.h
@@ -5,6 +5,8 @@
 #ifndef QLEVER_SRC_INDEX_VOCABULARY_VOCABULARYTYPES_H
 #define QLEVER_SRC_INDEX_VOCABULARY_VOCABULARYTYPES_H
 
+#include <absl/strings/str_cat.h>
+
 #include <atomic>
 #include <cstdint>
 #include <cstring>
@@ -21,6 +23,7 @@
 #include "util/ExceptionHandling.h"
 #include "util/Iterators.h"
 #include "util/TransparentFunctors.h"
+#include "util/TypeTraits.h"
 #include "util/Views.h"
 
 // The result type for a batch of vocabulary lookups.
@@ -137,9 +140,37 @@ struct StringVectorVocabBatchLookupData
 // single-word `operator[]` lookups one after another.
 namespace ad_utility::vocabulary {
 
+// Return the placeholder that is reported for a vocabulary index that is not
+// contained in a vocabulary with "holes" (see `VocabularyInMemoryBinSearch`).
+// This happens when such a vocabulary was created by excluding some of the
+// entries of a larger vocabulary, but an `Id` that refers to an excluded entry
+// is still looked up.
+inline std::string placeholderForMissingVocabIndex(uint64_t index) {
+  return absl::StrCat("<qlever-excluded-vocab-entry-", index, ">");
+}
+
+// Return `vocab[index]` as a `std::string`. If the `operator[]` of `vocab`
+// returns a `std::optional` (which is the case for vocabularies with holes, see
+// `VocabularyInMemoryBinSearch`) that is `std::nullopt`, return
+// `placeholderForMissingVocabIndex(index)` instead.
+template <typename Vocab>
+std::string wordAsStringOrPlaceholder(const Vocab& vocab, uint64_t index) {
+  decltype(auto) word = vocab[index];
+  if constexpr (ad_utility::similarToInstantiation<decltype(word),
+                                                   std::optional>) {
+    if (!word.has_value()) {
+      return placeholderForMissingVocabIndex(index);
+    }
+    return std::string{word.value()};
+  } else {
+    return std::string{word};
+  }
+}
+
 // Sequential fallback for `lookupBatch`: look up each index individually via
 // `vocab[idx]`, returning one `string_view` per index. Works for any vocabulary
-// whose `operator[]` yields something convertible to `std::string`.
+// whose `operator[]` yields something convertible to `std::string`, or a
+// `std::optional` thereof (see `wordAsStringOrPlaceholder`).
 template <typename Vocab>
 VocabBatchLookupResult sequentialLookupBatch(const Vocab& vocab,
                                              ql::span<const size_t> indices) {
@@ -151,8 +182,9 @@ VocabBatchLookupResult sequentialLookupBatch(const Vocab& vocab,
   // contained strings.
 
   std::vector<std::string> words = ::ranges::to<std::vector<std::string>>(
-      indices | ql::views::transform(
-                    [&vocab](size_t idx) { return std::string{vocab[idx]}; }));
+      indices | ql::views::transform([&vocab](size_t idx) {
+        return wordAsStringOrPlaceholder(vocab, idx);
+      }));
 
   auto data = std::make_shared<StringVectorVocabBatchLookupData>();
   data->buffer() = std::move(words);

--- a/test/index/vocabulary/VocabularyInMemoryBinSearchTest.cpp
+++ b/test/index/vocabulary/VocabularyInMemoryBinSearchTest.cpp
@@ -2,11 +2,13 @@
 // Chair of Algorithms and Data Structures.
 // Author: Johannes Kalmbach <johannes.kalmbach@gmail.com>
 
+#include <absl/cleanup/cleanup.h>
 #include <gtest/gtest.h>
 
 #include "./VocabularyTestHelpers.h"
 #include "index/vocabulary/VocabularyInMemoryBinSearch.h"
 #include "util/Forward.h"
+#include "util/Serializer/ByteBufferSerializer.h"
 
 namespace {
 using namespace vocabulary_test;
@@ -137,4 +139,191 @@ TEST(VocabularyInMemoryBinSearch, ErrorOnNonAscendingIds) {
 
 TEST(VocabularyInMemoryBinSearch, EmptyVocabulary) {
   testEmptyVocabulary(createVocabulary("EmptyVocabulary"));
+}
+
+namespace {
+
+// The words and the (non-contiguous, i.e. with "holes") vocabulary indices that
+// the tests below use. The words are sorted, as the vocabulary requires sorted
+// input at write time.
+const std::vector<std::string> wordsWithHoles{"alpha", "beta", "delta",
+                                              "gamma"};
+const std::vector<uint64_t> indicesWithHoles{0, 3, 4, 9};
+
+// The vocabulary indices that are NOT contained in a vocabulary that was built
+// from `wordsWithHoles` and `indicesWithHoles`, i.e. its "holes".
+const std::vector<uint64_t> missingIndices{1, 2, 5, 6, 7, 8, 10, 12345};
+
+// Create a `VocabularyInMemoryBinSearch` with the given `words` and `indices`
+// via a `WordWriter` that writes to `filename`. The vocabulary keeps all its
+// contents in RAM, so the caller may delete the files as soon as this function
+// has returned.
+VocabularyInMemoryBinSearch createVocabularyWithIndices(
+    const std::string& filename, const std::vector<std::string>& words,
+    const std::vector<uint64_t>& indices) {
+  AD_CORRECTNESS_CHECK(words.size() == indices.size());
+  {
+    VocabularyInMemoryBinSearch::WordWriter writer{filename};
+    for (size_t i = 0; i < words.size(); ++i) {
+      EXPECT_EQ(writer(words.at(i), indices.at(i)), indices.at(i));
+    }
+    writer.finish();
+  }
+  VocabularyInMemoryBinSearch vocabulary;
+  vocabulary.open(filename);
+  return vocabulary;
+}
+
+// Delete the two files (words and indices) that a `WordWriter` for the given
+// `filename` creates. Do not warn about files that were never created.
+void deleteVocabularyFiles(const std::string& filename) {
+  ad_utility::deleteFile(filename, false);
+  ad_utility::deleteFile(filename + ".ids", false);
+}
+
+// Check that the two vocabularies contain exactly the same words with exactly
+// the same vocabulary indices.
+template <typename Vocab1, typename Vocab2>
+void expectVocabulariesAreEqual(const Vocab1& vocab1, const Vocab2& vocab2) {
+  ASSERT_EQ(vocab1.size(), vocab2.size());
+  EXPECT_THAT(vocab2.indices(), ::testing::ElementsAreArray(vocab1.indices()));
+  EXPECT_EQ(vocabulary_test::scanAllToIndexAndWordVector(vocab1.scanAll()),
+            vocabulary_test::scanAllToIndexAndWordVector(vocab2.scanAll()));
+}
+
+// The `{index, word}` pairs that a vocabulary built from `wordsWithHoles` and
+// `indicesWithHoles` is expected to contain.
+std::vector<std::pair<uint64_t, std::string>> expectedIndicesAndWords() {
+  std::vector<std::pair<uint64_t, std::string>> result;
+  for (size_t i = 0; i < wordsWithHoles.size(); ++i) {
+    result.emplace_back(indicesWithHoles.at(i), wordsWithHoles.at(i));
+  }
+  return result;
+}
+
+}  // namespace
+
+// _____________________________________________________________________________
+TEST(VocabularyInMemoryBinSearch, positionOfIndexAndAccessOperator) {
+  std::string filename = gtestCurrentTestName();
+  absl::Cleanup cleanup = [&filename] { deleteVocabularyFiles(filename); };
+  auto vocab =
+      createVocabularyWithIndices(filename, wordsWithHoles, indicesWithHoles);
+
+  ASSERT_EQ(vocab.size(), wordsWithHoles.size());
+  EXPECT_THAT(vocab.indices(), ::testing::ElementsAreArray(indicesWithHoles));
+  for (size_t position = 0; position < wordsWithHoles.size(); ++position) {
+    uint64_t index = indicesWithHoles.at(position);
+    EXPECT_EQ(vocab.positionOfIndex(index), std::optional{position});
+    EXPECT_EQ(vocab.indexAtPosition(position), index);
+    EXPECT_EQ(vocab[index], std::optional{wordsWithHoles.at(position)});
+  }
+
+  // The indices that are not contained (the "holes") have neither a position
+  // nor a word.
+  for (uint64_t index : missingIndices) {
+    EXPECT_EQ(vocab.positionOfIndex(index), std::nullopt);
+    EXPECT_EQ(vocab[index], std::nullopt);
+  }
+
+  // A position that is out of range is a bug and hence throws.
+  EXPECT_THROW(vocab.indexAtPosition(vocab.size()), ad_utility::Exception);
+}
+
+// _____________________________________________________________________________
+TEST(VocabularyInMemoryBinSearch, scanAll) {
+  std::string filename = gtestCurrentTestName();
+  absl::Cleanup cleanup = [&filename] { deleteVocabularyFiles(filename); };
+  auto vocab =
+      createVocabularyWithIndices(filename, wordsWithHoles, indicesWithHoles);
+
+  EXPECT_EQ(vocabulary_test::scanAllToIndexAndWordVector(vocab.scanAll()),
+            expectedIndicesAndWords());
+
+  // An empty vocabulary yields nothing.
+  auto emptyVocab = createVocabularyWithIndices(filename, {}, {});
+  EXPECT_TRUE(vocabulary_test::scanAllToIndexAndWordVector(emptyVocab.scanAll())
+                  .empty());
+}
+
+// _____________________________________________________________________________
+TEST(VocabularyInMemoryBinSearch, lookupBatch) {
+  std::string filename = gtestCurrentTestName();
+  absl::Cleanup cleanup = [&filename] { deleteVocabularyFiles(filename); };
+  auto vocab =
+      createVocabularyWithIndices(filename, wordsWithHoles, indicesWithHoles);
+
+  // Reordered and duplicated indices, all of which are contained.
+  std::vector<size_t> indices{4, 0, 9, 3, 0};
+  vocabulary_test::assertLookupResultMatchesVocabularyAtIndices(
+      vocab, vocab.lookupBatch(indices), indices);
+
+  // The same via the streamed interface.
+  std::vector<std::vector<size_t>> batches{{4, 0}, {9}, {3, 0, 4}};
+  const auto expectedBatches = batches;
+  auto streamed =
+      vocab.lookupBatchesStreamed(VocabLookupInput{std::move(batches)});
+  vocabulary_test::assertStreamedLookupMatchesVocabularyAtIndices(
+      vocab, streamed, expectedBatches);
+
+  // An index that is not contained (one of the "holes") yields a placeholder.
+  std::vector<size_t> indicesWithMissingOnes{0, 5, 9};
+  auto result = vocab.lookupBatch(indicesWithMissingOnes);
+  ASSERT_EQ(result->size(), 3);
+  EXPECT_EQ((*result)[0], "alpha");
+  EXPECT_EQ((*result)[1],
+            ad_utility::vocabulary::placeholderForMissingVocabIndex(5));
+  EXPECT_EQ((*result)[2], "gamma");
+}
+
+// _____________________________________________________________________________
+TEST(VocabularyInMemoryBinSearch, genericSerialization) {
+  std::string filename = gtestCurrentTestName();
+  absl::Cleanup cleanup = [&filename] { deleteVocabularyFiles(filename); };
+  auto vocab =
+      createVocabularyWithIndices(filename, wordsWithHoles, indicesWithHoles);
+
+  ad_utility::serialization::ByteBufferWriteSerializer writeSerializer;
+  writeSerializer << vocab;
+  ASSERT_FALSE(writeSerializer.data().empty());
+
+  VocabularyInMemoryBinSearch readVocab;
+  ad_utility::serialization::ByteBufferReadSerializer readSerializer{
+      std::move(writeSerializer).data()};
+  readSerializer >> readVocab;
+  expectVocabulariesAreEqual(vocab, readVocab);
+
+  // The deserialized vocabulary owns its indices, so it can be closed and read
+  // again.
+  readVocab.close();
+  EXPECT_EQ(readVocab.size(), 0);
+}
+
+// _____________________________________________________________________________
+TEST(VocabularyInMemoryBinSearch, zeroCopyDeserialization) {
+  std::string filename = gtestCurrentTestName();
+  absl::Cleanup cleanup = [&filename] { deleteVocabularyFiles(filename); };
+  auto vocab =
+      createVocabularyWithIndices(filename, wordsWithHoles, indicesWithHoles);
+
+  // The zero-copy read requires an aligned serializer, and reads back exactly
+  // the layout that the generic serialization writes.
+  ad_utility::serialization::AlignedByteBufferWriteSerializer writeSerializer;
+  writeSerializer << vocab;
+  ad_utility::serialization::AlignedByteBufferReadSerializer readSerializer{
+      std::move(writeSerializer).data()};
+  auto view =
+      VocabularyInMemoryBinSearch::fromZeroCopyDeserializer(readSerializer);
+  expectVocabulariesAreEqual(vocab, view);
+  EXPECT_EQ(view[3], std::optional{std::string_view{"beta"}});
+  EXPECT_EQ(view[5], std::nullopt);
+}
+
+// _____________________________________________________________________________
+TEST(VocabularyInMemoryBinSearch, makeDiskWriterPtrThrows) {
+  // A vocabulary with holes cannot be built via the `WordWriterBase` interface,
+  // which cannot express the explicit indices.
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      VocabularyInMemoryBinSearch::makeDiskWriterPtr(gtestCurrentTestName()),
+      ::testing::HasSubstr("cannot be built word by word"));
 }

--- a/test/index/vocabulary/VocabularyTypesTest.cpp
+++ b/test/index/vocabulary/VocabularyTypesTest.cpp
@@ -134,3 +134,75 @@ TEST(PmrVocabBatchLookupData, PmrAsResultEmpty) {
   VocabBatchLookupResult result = PmrVocabBatchLookupData::asResult(data);
   EXPECT_TRUE(result->empty());
 }
+
+namespace {
+// A minimal vocabulary with "holes": its `operator[]` returns `std::nullopt`
+// for odd indices. It does not opt in to the placeholder mechanism (see
+// `replaceOptionalByPlaceholderOnExport` in `VocabularyTypes.h`).
+struct VocabWithHolesThrowing {
+  std::optional<std::string_view> operator[](uint64_t index) const {
+    if (index % 2 == 1) {
+      return std::nullopt;
+    }
+    return "word";
+  }
+};
+
+// The same vocabulary, but opting in to the placeholder mechanism.
+struct VocabWithHolesPlaceholder : VocabWithHolesThrowing {
+  static constexpr bool replaceOptionalByPlaceholderOnExport = true;
+};
+
+// A vocabulary without holes, for which the placeholder mechanism is
+// irrelevant, because its `operator[]` doesn't return a `std::optional`.
+struct VocabWithoutHoles {
+  std::string_view operator[]([[maybe_unused]] uint64_t index) const {
+    return "word";
+  }
+};
+}  // namespace
+
+// _____________________________________________________________________________
+TEST(VocabularyTypes, replaceOptionalByPlaceholderOnExportIsOptIn) {
+  using namespace ad_utility::vocabulary;
+  // Only a vocabulary that explicitly declares the member opts in.
+  static_assert(!replaceOptionalByPlaceholderOnExport<VocabWithHolesThrowing>);
+  static_assert(
+      replaceOptionalByPlaceholderOnExport<VocabWithHolesPlaceholder>);
+  static_assert(!replaceOptionalByPlaceholderOnExport<VocabWithoutHoles>);
+}
+
+// _____________________________________________________________________________
+TEST(VocabularyTypes, wordAsStringOrPlaceholder) {
+  using namespace ad_utility::vocabulary;
+  // Words that are contained are returned as they are, no matter whether the
+  // `operator[]` returns a `std::optional`.
+  EXPECT_EQ(wordAsStringOrPlaceholder(VocabWithHolesThrowing{}, 4), "word");
+  EXPECT_EQ(wordAsStringOrPlaceholder(VocabWithHolesPlaceholder{}, 4), "word");
+  EXPECT_EQ(wordAsStringOrPlaceholder(VocabWithoutHoles{}, 5), "word");
+
+  // A missing word is reported as a placeholder only by the vocabulary that has
+  // opted in, the other one throws.
+  EXPECT_EQ(wordAsStringOrPlaceholder(VocabWithHolesPlaceholder{}, 5),
+            placeholderForMissingVocabIndex(5));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      wordAsStringOrPlaceholder(VocabWithHolesThrowing{}, 5),
+      ::testing::HasSubstr("replaceOptionalByPlaceholderOnExport"));
+}
+
+// _____________________________________________________________________________
+TEST(VocabularyTypes, sequentialLookupBatchWithMissingWords) {
+  using namespace ad_utility::vocabulary;
+  std::vector<size_t> indices{4, 5};
+
+  // The opted-in vocabulary reports the placeholder for the missing word.
+  auto result = sequentialLookupBatch(VocabWithHolesPlaceholder{}, indices);
+  ASSERT_EQ(result->size(), 2u);
+  EXPECT_EQ((*result)[0], "word");
+  EXPECT_EQ((*result)[1], placeholderForMissingVocabIndex(5));
+
+  // The vocabulary that has not opted in throws.
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      sequentialLookupBatch(VocabWithHolesThrowing{}, indices),
+      ::testing::HasSubstr("replaceOptionalByPlaceholderOnExport"));
+}


### PR DESCRIPTION
`VocabularyInMemoryBinSearch` is the in-memory vocabulary that supports "holes". That is, the indices of the contained words are ascending, but not necessarily contiguous. Such a vocabulary arises when a subset of the entries of an existing vocabulary is excluded, which is an upcoming feature. So far, this class implemented only a small part of the vocabulary interface, which made it unusable in most places where a vocabulary is expected. This change adds the missing parts. In particular, such a vocabulary can now be serialized and deserialized (also without copying), scanned in order, and used for batched word lookups. Each of the new parts is covered by a new unit test.

When a lookup asks for an index that falls into a hole, the word is reported as the placeholder `<qlever-excluded-vocab-entry-N>` instead of an exception being thrown. A vocabulary has to explicitly opt in to this behavior. Only this vocabulary does, because its holes are deliberate. Nothing changes for any other vocabulary.