### PR TITLE
Don't use materialized view for degenerate chains and inside `GRAPH` or `FROM`

### DIFF
--- a/src/engine/MaterializedViewsQueryAnalysis.cpp
+++ b/src/engine/MaterializedViewsQueryAnalysis.cpp
@@ -110,6 +110,15 @@ void QueryPatternCache::makeScansFromChainCandidates(
         if (it == simpleChainCache_.end()) {
           continue;
         }
+        // A degenerate/triangular chain (e.g. `?x <p1> ?v . ?v <p2> ?x`) would
+        // require the view's subject and object columns to both be bound to
+        // the same target variable, which `RequestedColumns` cannot express.
+        // Skip it here and let normal join planning handle it instead.
+        if (left.s_.isVariable() &&
+            left.s_.getVariable() == right.o_.getVariable()) {
+          continue;
+        }
+
         for (const auto& chainInfo : *(it->second)) {
           // If the subject of the chain is fixed, but the subject is not the
           // first column of the view, rewriting cannot be applied.

--- a/src/engine/MaterializedViewsQueryAnalysis.cpp
+++ b/src/engine/MaterializedViewsQueryAnalysis.cpp
@@ -110,10 +110,12 @@ void QueryPatternCache::makeScansFromChainCandidates(
         if (it == simpleChainCache_.end()) {
           continue;
         }
-        // A degenerate chain (`?a <p1> ?b . ?b <p2> ?a`) would require adding a
-        // filter on top of the view's `IndexScan`, which is not supported.
-        if (left.s_.isVariable() &&
-            left.s_.getVariable() == right.o_.getVariable()) {
+        // A degenerate chain (`?a <p1> ?b . ?b <p2> ?a` or
+        // `?a <p1> ?b . ?b <p2> ?b`) would require adding a filter on top of
+        // the view's `IndexScan`, which is not supported.
+        if (right.s_ == right.o_ ||
+            (left.s_.isVariable() &&
+             left.s_.getVariable() == right.o_.getVariable())) {
           continue;
         }
 

--- a/src/engine/MaterializedViewsQueryAnalysis.cpp
+++ b/src/engine/MaterializedViewsQueryAnalysis.cpp
@@ -110,9 +110,8 @@ void QueryPatternCache::makeScansFromChainCandidates(
         if (it == simpleChainCache_.end()) {
           continue;
         }
-        // A degenerate chain (`?a <p1> ?b . ?b <p2> ?a`) would require the
-        // adding a filter on top of the view `IndexScan`, which is not
-        // supported.
+        // A degenerate chain (`?a <p1> ?b . ?b <p2> ?a`) would require adding a
+        // filter on top of the view's `IndexScan`, which is not supported.
         if (left.s_.isVariable() &&
             left.s_.getVariable() == right.o_.getVariable()) {
           continue;

--- a/src/engine/MaterializedViewsQueryAnalysis.cpp
+++ b/src/engine/MaterializedViewsQueryAnalysis.cpp
@@ -110,10 +110,9 @@ void QueryPatternCache::makeScansFromChainCandidates(
         if (it == simpleChainCache_.end()) {
           continue;
         }
-        // A degenerate/triangular chain (e.g. `?x <p1> ?v . ?v <p2> ?x`) would
-        // require the view's subject and object columns to both be bound to
-        // the same target variable, which `RequestedColumns` cannot express.
-        // Skip it here and let normal join planning handle it instead.
+        // A degenerate chain (`?a <p1> ?b . ?b <p2> ?a`) would require the
+        // adding a filter on top of the view `IndexScan`, which is not
+        // supported.
         if (left.s_.isVariable() &&
             left.s_.getVariable() == right.o_.getVariable()) {
           continue;

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -2685,6 +2685,19 @@ auto QueryPlanner::createMaterializedViewJoinReplacements(
     return plans;
   }
 
+  // Materialized views usable for pattern-based rewriting are always built
+  // from the plain, unconstrained default graph (a `FROM`/`FROM NAMED` or a
+  // `GRAPH` clause in the view's defining query is already rejected in
+  // `getTriplesForPatternRewrite`). Rewriting triples that are themselves
+  // inside a `GRAPH <g> {...}`/`GRAPH ?g {...}` clause or in a query with an
+  // active `FROM`/`FROM NAMED` clause to such a view would therefore ignore
+  // the actual dataset of the query being planned, so it must be skipped
+  // unless we are in that exact same unconstrained default graph context.
+  if (activeGraphVariable_.has_value() ||
+      activeDatasetClauses_.activeDefaultGraphs().has_value()) {
+    return plans;
+  }
+
   // The `MaterializedViewsManager` provides `IndexScan` instances for all the
   // subsets of `triples` it can rewrite. The individual results do not cover
   // all items of `triples`, instead each has a vector of triple indices it

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -2685,14 +2685,11 @@ auto QueryPlanner::createMaterializedViewJoinReplacements(
     return plans;
   }
 
-  // Materialized views usable for pattern-based rewriting are always built
-  // from the plain, unconstrained default graph (a `FROM`/`FROM NAMED` or a
-  // `GRAPH` clause in the view's defining query is already rejected in
-  // `getTriplesForPatternRewrite`). Rewriting triples that are themselves
-  // inside a `GRAPH <g> {...}`/`GRAPH ?g {...}` clause or in a query with an
-  // active `FROM`/`FROM NAMED` clause to such a view would therefore ignore
-  // the actual dataset of the query being planned, so it must be skipped
-  // unless we are in that exact same unconstrained default graph context.
+  // Materialized view write queries that are allowed for pattern-based
+  // rewriting are guaranteed to use no named graph. Rewriting triples inside a
+  // `GRAPH ... { ... }` clause or in a query with an active `FROM`/`FROM NAMED`
+  // clause would therefore ignore the graph restriction and generate wrong
+  // results.
   if (activeGraphVariable_.has_value() ||
       activeDatasetClauses_.activeDefaultGraphs().has_value()) {
     return plans;

--- a/test/MaterializedViewsTest.cpp
+++ b/test/MaterializedViewsTest.cpp
@@ -1992,25 +1992,21 @@ INSTANTIATE_TEST_SUITE_P(
 
 // _____________________________________________________________________________
 TEST_F(MaterializedViewsChainRewriteContextTest, ChainRewriteContext) {
-  // Regression tests for query contexts where a chain view must not be used
-  // for rewriting: a degenerate/triangular chain (same variable as subject
-  // of the first and object of the second triple, e.g. `?x p1 ?v . ?v p2
-  // ?x`) previously made planning throw instead of falling back to a regular
-  // join; a `GRAPH <g> {...}` clause must not be rewritten to a view scan,
-  // since views only represent the unconstrained default graph.
   qlv().writeMaterializedView("testViewChain", std::string{simpleChain});
   qlv().loadMaterializedView("testViewChain");
 
+  // A degenerate chain (`?a <p1> ?b . ?b <p2> ?a`) must be rejected for
+  // rewriting (thus planned normally).
   qpExpect(qlv(), "SELECT * { ?x <p1> ?v . ?v <p2> ?x }",
            h::MultiColumnJoin(h::IndexScanFromStrings("?x", "<p1>", "?v"),
                               h::IndexScanFromStrings("?v", "<p2>", "?x")));
 
-  // Outside of any `GRAPH` clause, the rewriting is still applied.
+  // Outside of any `GRAPH` clause, rewriting is applied.
   auto chainView = std::bind_front(&viewScanSimple, "testViewChain");
   qpExpect(qlv(), simpleChain, chainView("?s", "?m", "?o"));
 
-  // Inside `GRAPH <g1> {...}`, the triples are scanned normally (restricted
-  // to graph `<g1>`), not replaced by the view.
+  // Inside `GRAPH <g1> {...}`, the triples are scanned restricted to graph
+  // `<g1>` and not replaced by the view without graph constraint.
   qpExpect(
       qlv(), "SELECT * { GRAPH <g1> { ?s <p1> ?m . ?m <p2> ?o } }",
       h::Join(

--- a/test/MaterializedViewsTest.cpp
+++ b/test/MaterializedViewsTest.cpp
@@ -1991,6 +1991,71 @@ INSTANTIATE_TEST_SUITE_P(
         RewriteTestParams{std::string{simpleChainRenamedPlusBind}, 1500}));
 
 // _____________________________________________________________________________
+TEST_F(MaterializedViewsTest, DegenerateChainNotRewritten) {
+  // Regression test: a "degenerate"/triangular chain in the query (the same
+  // variable is both the subject of the first triple and the object of the
+  // second, e.g. `?x <p1> ?v . ?v <p2> ?x`) must not be rewritten using a
+  // chain view, because that would require binding both the view's subject
+  // and object column to the same target variable, which previously made
+  // query planning throw instead of falling back to a regular join.
+  const std::string chainTtl = " <x> <p1> <v> . \n <v> <p2> <x> . \n";
+  const std::string onDiskBase = gtestCurrentTestName();
+  const std::string viewName = "testViewDegenerateChain";
+
+  materializedViewsTestHelpers::makeTestIndex(onDiskBase, chainTtl);
+  auto cleanUp = absl::Cleanup(
+      [&]() { materializedViewsTestHelpers::removeTestIndex(onDiskBase); });
+  qlever::EngineConfig config;
+  config.baseName_ = onDiskBase;
+  qlever::Qlever qlv{config};
+
+  qlv.writeMaterializedView(viewName, std::string{simpleChain});
+  qlv.loadMaterializedView(viewName);
+
+  qpExpect(qlv, "SELECT * { ?x <p1> ?v . ?v <p2> ?x }",
+           h::MultiColumnJoin(h::IndexScanFromStrings("?x", "<p1>", "?v"),
+                              h::IndexScanFromStrings("?v", "<p2>", "?x")));
+}
+
+// _____________________________________________________________________________
+TEST_F(MaterializedViewsTest, ChainRewriteRespectsGraphContext) {
+  // Regression test: a materialized view usable for pattern-based rewriting
+  // always represents data from the plain, unconstrained default graph (a
+  // `FROM`/`FROM NAMED`/`GRAPH` clause in the view's defining query is
+  // already rejected). Triples inside a `GRAPH <g> {...}` clause of the query
+  // being planned must therefore not be replaced by a scan of such a view.
+  const std::string chainTtl =
+      " <s1> <p1> <m2> . \n"
+      " <m2> <p2> <http://example.com/> . \n";
+  const std::string onDiskBase = gtestCurrentTestName();
+  const std::string viewName = "testViewChainGraphContext";
+
+  materializedViewsTestHelpers::makeTestIndex(onDiskBase, chainTtl);
+  auto cleanUp = absl::Cleanup(
+      [&]() { materializedViewsTestHelpers::removeTestIndex(onDiskBase); });
+  qlever::EngineConfig config;
+  config.baseName_ = onDiskBase;
+  qlever::Qlever qlv{config};
+
+  qlv.writeMaterializedView(viewName, std::string{simpleChain});
+  qlv.loadMaterializedView(viewName);
+
+  // Outside of any `GRAPH` clause, the rewriting is still applied.
+  auto chainView = std::bind_front(&viewScanSimple, viewName);
+  qpExpect(qlv, simpleChain, chainView("?s", "?m", "?o"));
+
+  // Inside a `GRAPH <g1> {...}` clause, the triples must still be scanned
+  // normally (restricted to graph `<g1>`), not replaced by the view.
+  qpExpect(
+      qlv, "SELECT * { GRAPH <g1> { ?s <p1> ?m . ?m <p2> ?o } }",
+      h::Join(
+          h::IndexScanFromStrings("?s", "<p1>", "?m", {},
+                                  ad_utility::HashSet<std::string>{"<g1>"}),
+          h::IndexScanFromStrings("?m", "<p2>", "?o", {},
+                                  ad_utility::HashSet<std::string>{"<g1>"})));
+}
+
+// _____________________________________________________________________________
 TEST_F(MaterializedViewsTest, JoinBetweenLazyScansWithPlaceholderVars) {
   // Regression test for #2866.
   auto plan = qlv().parseAndPlanQuery(simpleWriteQuery_);

--- a/test/MaterializedViewsTest.cpp
+++ b/test/MaterializedViewsTest.cpp
@@ -1991,38 +1991,26 @@ INSTANTIATE_TEST_SUITE_P(
         RewriteTestParams{std::string{simpleChainRenamedPlusBind}, 1500}));
 
 // _____________________________________________________________________________
-TEST_F(MaterializedViewsChainRewriteContextTest, DegenerateChainNotRewritten) {
-  // Regression test: a "degenerate"/triangular chain in the query (the same
-  // variable is both the subject of the first triple and the object of the
-  // second, e.g. `?x <p1> ?v . ?v <p2> ?x`) must not be rewritten using a
-  // chain view, because that would require binding both the view's subject
-  // and object column to the same target variable, which previously made
-  // query planning throw instead of falling back to a regular join.
+TEST_F(MaterializedViewsChainRewriteContextTest, ChainRewriteContext) {
+  // Regression tests for query contexts where a chain view must not be used
+  // for rewriting: a degenerate/triangular chain (same variable as subject
+  // of the first and object of the second triple, e.g. `?x p1 ?v . ?v p2
+  // ?x`) previously made planning throw instead of falling back to a regular
+  // join; a `GRAPH <g> {...}` clause must not be rewritten to a view scan,
+  // since views only represent the unconstrained default graph.
   qlv().writeMaterializedView("testViewChain", std::string{simpleChain});
   qlv().loadMaterializedView("testViewChain");
 
   qpExpect(qlv(), "SELECT * { ?x <p1> ?v . ?v <p2> ?x }",
            h::MultiColumnJoin(h::IndexScanFromStrings("?x", "<p1>", "?v"),
                               h::IndexScanFromStrings("?v", "<p2>", "?x")));
-}
-
-// _____________________________________________________________________________
-TEST_F(MaterializedViewsChainRewriteContextTest,
-       ChainRewriteRespectsGraphContext) {
-  // Regression test: a materialized view usable for pattern-based rewriting
-  // always represents data from the plain, unconstrained default graph (a
-  // `FROM`/`FROM NAMED`/`GRAPH` clause in the view's defining query is
-  // already rejected). Triples inside a `GRAPH <g> {...}` clause of the query
-  // being planned must therefore not be replaced by a scan of such a view.
-  qlv().writeMaterializedView("testViewChain", std::string{simpleChain});
-  qlv().loadMaterializedView("testViewChain");
 
   // Outside of any `GRAPH` clause, the rewriting is still applied.
   auto chainView = std::bind_front(&viewScanSimple, "testViewChain");
   qpExpect(qlv(), simpleChain, chainView("?s", "?m", "?o"));
 
-  // Inside a `GRAPH <g1> {...}` clause, the triples must still be scanned
-  // normally (restricted to graph `<g1>`), not replaced by the view.
+  // Inside `GRAPH <g1> {...}`, the triples are scanned normally (restricted
+  // to graph `<g1>`), not replaced by the view.
   qpExpect(
       qlv(), "SELECT * { GRAPH <g1> { ?s <p1> ?m . ?m <p2> ?o } }",
       h::Join(

--- a/test/MaterializedViewsTest.cpp
+++ b/test/MaterializedViewsTest.cpp
@@ -1991,63 +1991,40 @@ INSTANTIATE_TEST_SUITE_P(
         RewriteTestParams{std::string{simpleChainRenamedPlusBind}, 1500}));
 
 // _____________________________________________________________________________
-TEST_F(MaterializedViewsTest, DegenerateChainNotRewritten) {
+TEST_F(MaterializedViewsChainRewriteContextTest, DegenerateChainNotRewritten) {
   // Regression test: a "degenerate"/triangular chain in the query (the same
   // variable is both the subject of the first triple and the object of the
   // second, e.g. `?x <p1> ?v . ?v <p2> ?x`) must not be rewritten using a
   // chain view, because that would require binding both the view's subject
   // and object column to the same target variable, which previously made
   // query planning throw instead of falling back to a regular join.
-  const std::string chainTtl = " <x> <p1> <v> . \n <v> <p2> <x> . \n";
-  const std::string onDiskBase = gtestCurrentTestName();
-  const std::string viewName = "testViewDegenerateChain";
+  qlv().writeMaterializedView("testViewChain", std::string{simpleChain});
+  qlv().loadMaterializedView("testViewChain");
 
-  materializedViewsTestHelpers::makeTestIndex(onDiskBase, chainTtl);
-  auto cleanUp = absl::Cleanup(
-      [&]() { materializedViewsTestHelpers::removeTestIndex(onDiskBase); });
-  qlever::EngineConfig config;
-  config.baseName_ = onDiskBase;
-  qlever::Qlever qlv{config};
-
-  qlv.writeMaterializedView(viewName, std::string{simpleChain});
-  qlv.loadMaterializedView(viewName);
-
-  qpExpect(qlv, "SELECT * { ?x <p1> ?v . ?v <p2> ?x }",
+  qpExpect(qlv(), "SELECT * { ?x <p1> ?v . ?v <p2> ?x }",
            h::MultiColumnJoin(h::IndexScanFromStrings("?x", "<p1>", "?v"),
                               h::IndexScanFromStrings("?v", "<p2>", "?x")));
 }
 
 // _____________________________________________________________________________
-TEST_F(MaterializedViewsTest, ChainRewriteRespectsGraphContext) {
+TEST_F(MaterializedViewsChainRewriteContextTest,
+       ChainRewriteRespectsGraphContext) {
   // Regression test: a materialized view usable for pattern-based rewriting
   // always represents data from the plain, unconstrained default graph (a
   // `FROM`/`FROM NAMED`/`GRAPH` clause in the view's defining query is
   // already rejected). Triples inside a `GRAPH <g> {...}` clause of the query
   // being planned must therefore not be replaced by a scan of such a view.
-  const std::string chainTtl =
-      " <s1> <p1> <m2> . \n"
-      " <m2> <p2> <http://example.com/> . \n";
-  const std::string onDiskBase = gtestCurrentTestName();
-  const std::string viewName = "testViewChainGraphContext";
-
-  materializedViewsTestHelpers::makeTestIndex(onDiskBase, chainTtl);
-  auto cleanUp = absl::Cleanup(
-      [&]() { materializedViewsTestHelpers::removeTestIndex(onDiskBase); });
-  qlever::EngineConfig config;
-  config.baseName_ = onDiskBase;
-  qlever::Qlever qlv{config};
-
-  qlv.writeMaterializedView(viewName, std::string{simpleChain});
-  qlv.loadMaterializedView(viewName);
+  qlv().writeMaterializedView("testViewChain", std::string{simpleChain});
+  qlv().loadMaterializedView("testViewChain");
 
   // Outside of any `GRAPH` clause, the rewriting is still applied.
-  auto chainView = std::bind_front(&viewScanSimple, viewName);
-  qpExpect(qlv, simpleChain, chainView("?s", "?m", "?o"));
+  auto chainView = std::bind_front(&viewScanSimple, "testViewChain");
+  qpExpect(qlv(), simpleChain, chainView("?s", "?m", "?o"));
 
   // Inside a `GRAPH <g1> {...}` clause, the triples must still be scanned
   // normally (restricted to graph `<g1>`), not replaced by the view.
   qpExpect(
-      qlv, "SELECT * { GRAPH <g1> { ?s <p1> ?m . ?m <p2> ?o } }",
+      qlv(), "SELECT * { GRAPH <g1> { ?s <p1> ?m . ?m <p2> ?o } }",
       h::Join(
           h::IndexScanFromStrings("?s", "<p1>", "?m", {},
                                   ad_utility::HashSet<std::string>{"<g1>"}),

--- a/test/MaterializedViewsTest.cpp
+++ b/test/MaterializedViewsTest.cpp
@@ -2001,6 +2001,17 @@ TEST_F(MaterializedViewsChainRewriteContextTest, ChainRewriteContext) {
            h::MultiColumnJoin(h::IndexScanFromStrings("?x", "<p1>", "?v"),
                               h::IndexScanFromStrings("?v", "<p2>", "?x")));
 
+  // The same holds for a degenerate chain where the middle and the end are
+  // the same variable. Planning previously failed with an exception. The
+  // winning plan is not fixed here (the repeated variable is planned as an
+  // internal variable plus an equality filter, and the cache-key based
+  // rewriting may then legitimately replace the join by a scan of the view),
+  // so check that the query is planned and answered correctly instead of
+  // checking the plan.
+  EXPECT_EQ(qlv().query("SELECT ?x ?v { ?x <p1> ?v . ?v <p2> ?v }",
+                        ad_utility::MediaType::tsv),
+            "?x\t?v\n<x2>\t<v2>\n");
+
   // Outside of any `GRAPH` clause, rewriting is applied.
   auto chainView = std::bind_front(&viewScanSimple, "testViewChain");
   qpExpect(qlv(), simpleChain, chainView("?s", "?m", "?o"));

--- a/test/MaterializedViewsTestHelpers.h
+++ b/test/MaterializedViewsTestHelpers.h
@@ -32,6 +32,13 @@ static constexpr std::string_view dummyTurtle = R"(
   <s2> <p3> <http://example.com/> .
 )";
 
+static constexpr std::string_view chainRewriteContextDummyTurtle = R"(
+  <s1> <p1> <m2> .
+  <m2> <p2> <http://example.com/> .
+  <x> <p1> <v> .
+  <v> <p2> <x> .
+)";
+
 static constexpr std::string_view cacheKeyRewriteDummyTurtle = R"(
   @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
   <s1> <p1> "abc" .
@@ -176,6 +183,14 @@ class MaterializedViewsCacheKeyRewriteTest : public MaterializedViewsTest {
  protected:
   std::string getDummyTurtle() const override {
     return std::string{cacheKeyRewriteDummyTurtle};
+  }
+};
+
+// _____________________________________________________________________________
+class MaterializedViewsChainRewriteContextTest : public MaterializedViewsTest {
+ protected:
+  std::string getDummyTurtle() const override {
+    return std::string{chainRewriteContextDummyTurtle};
   }
 };
 

--- a/test/MaterializedViewsTestHelpers.h
+++ b/test/MaterializedViewsTestHelpers.h
@@ -37,6 +37,8 @@ static constexpr std::string_view chainRewriteContextDummyTurtle = R"(
   <m2> <p2> <http://example.com/> .
   <x> <p1> <v> .
   <v> <p2> <x> .
+  <x2> <p1> <v2> .
+  <v2> <p2> <v2> .
 )";
 
 static constexpr std::string_view cacheKeyRewriteDummyTurtle = R"(


### PR DESCRIPTION
So far, the pattern-based rewriting of queries using materialized views was wrong in two cases, both found while testing #3254. A degenerate chain such as `?a <p1> ?b . ?b <p2> ?a` or `?a <p1> ?b . ?b <p2> ?b` made the whole query fail during planning. Triples inside a `GRAPH ... { ... }` clause or in a query with `FROM` or `FROM NAMED` were replaced by a scan of the view, which is not restricted to the given graphs and therefore produced wrong results.

This change excludes both cases from the rewriting. Degenerate chains are now planned as normal joins, and queries with a graph restriction keep their ordinary graph-restricted scans.