### PR TITLE
Add a `static` overload of `IndexImpl::dateOfIndexBuild`

### DIFF
--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -1329,8 +1329,14 @@ void IndexImpl::writeConfiguration() const {
 
 // ____________________________________________________________________________
 std::string IndexImpl::dateOfIndexBuild() const {
-  if (configurationJson_.contains(DATE_OF_INDEX_BUILD_KEY)) {
-    return configurationJson_[DATE_OF_INDEX_BUILD_KEY].get<std::string>();
+  return dateOfIndexBuild(configurationJson_, onDiskBase_);
+}
+
+// ____________________________________________________________________________
+std::string IndexImpl::dateOfIndexBuild(const nlohmann::json& configurationJson,
+                                        const std::string& onDiskBase) {
+  if (configurationJson.contains(DATE_OF_INDEX_BUILD_KEY)) {
+    return configurationJson[DATE_OF_INDEX_BUILD_KEY].get<std::string>();
   }
   // For indexes that were built before the build date was recorded in the
   // configuration, fall back to the last modification time of the
@@ -1341,7 +1347,7 @@ std::string IndexImpl::dateOfIndexBuild() const {
   // C++20), and `std::filesystem` is not available on all toolchains that
   // QLever targets.
   struct stat fileStat {};
-  auto configFilename = onDiskBase_ + CONFIGURATION_FILE;
+  auto configFilename = onDiskBase + CONFIGURATION_FILE;
   AD_CONTRACT_CHECK(stat(configFilename.c_str(), &fileStat) == 0);
   return formatIndexBuildTime(absl::FromTimeT(fileStat.st_mtime));
 }

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -563,6 +563,13 @@ class IndexImpl {
   // build).
   std::string dateOfIndexBuild() const;
 
+  // The same as `dateOfIndexBuild` above, but for an index that is not
+  // loaded: `configurationJson` and `onDiskBase` are the configuration
+  // (`<onDiskBase>.meta-data.json`) and the base name of that index. This is
+  // useful for tooling that inspects an index on disk without loading it.
+  static std::string dateOfIndexBuild(const nlohmann::json& configurationJson,
+                                      const std::string& onDiskBase);
+
   // Format the given time as a UTC timestamp string in the
   // `DATE_OF_INDEX_BUILD_FORMAT` (e.g. `2026-07-12T14:03:52Z`).
   static std::string formatIndexBuildTime(absl::Time time);

--- a/test/IndexTest.cpp
+++ b/test/IndexTest.cpp
@@ -1113,6 +1113,13 @@ TEST(IndexImpl, dateOfIndexBuild) {
       indexImpl.configurationJson_[DATE_OF_INDEX_BUILD_KEY].get<std::string>();
   EXPECT_EQ(indexImpl.dateOfIndexBuild(), storedDate);
 
+  // The `static` overload, which works without a loaded index, returns the
+  // same value when it is given the configuration and the base name of that
+  // index.
+  EXPECT_EQ(IndexImpl::dateOfIndexBuild(indexImpl.configurationJson_,
+                                        indexImpl.onDiskBase_),
+            storedDate);
+
   // The stored value is a valid UTC timestamp in the expected format.
   absl::Time parsed;
   std::string error;
@@ -1135,6 +1142,52 @@ TEST(IndexImpl, dateOfIndexBuild) {
   EXPECT_THAT(absl::Now() - fallbackTime,
               ::testing::AllOf(::testing::Ge(absl::ZeroDuration()),
                                ::testing::Lt(absl::Seconds(2))));
+}
+
+// _____________________________________________________________________________
+TEST(IndexImpl, dateOfIndexBuildStatic) {
+  // The `static` overload of `dateOfIndexBuild` works on an index that is not
+  // loaded, so we can exercise it with an arbitrary configuration and base
+  // name.
+  auto onDiskBase = gtestCurrentTestName();
+  auto configFilename = absl::StrCat(onDiskBase, CONFIGURATION_FILE);
+
+  // If the configuration contains the build date, it is returned verbatim, and
+  // the configuration file doesn't even have to exist.
+  nlohmann::json configuration;
+  configuration[std::string{DATE_OF_INDEX_BUILD_KEY}] = "2026-07-12T14:03:52Z";
+  EXPECT_EQ(IndexImpl::dateOfIndexBuild(configuration, onDiskBase),
+            "2026-07-12T14:03:52Z");
+
+  // If the configuration doesn't contain the build date, the modification time
+  // of the configuration file is used instead. Since the format only has
+  // second precision, we don't compare the timestamp exactly, but check that
+  // it lies within the last second + tolerance.
+  configuration.erase(std::string{DATE_OF_INDEX_BUILD_KEY});
+  {
+    auto configFile = ad_utility::makeOfstream(configFilename);
+    configFile << configuration;
+  }
+  absl::Cleanup cleanup = [&configFilename]() {
+    ad_utility::deleteFile(configFilename);
+  };
+  absl::Time fallbackTime;
+  std::string parseError;
+  ASSERT_TRUE(
+      absl::ParseTime(DATE_OF_INDEX_BUILD_FORMAT,
+                      IndexImpl::dateOfIndexBuild(configuration, onDiskBase),
+                      absl::UTCTimeZone(), &fallbackTime, &parseError))
+      << parseError;
+  EXPECT_THAT(absl::Now() - fallbackTime,
+              ::testing::AllOf(::testing::Ge(absl::ZeroDuration()),
+                               ::testing::Lt(absl::Seconds(2))));
+
+  // If the configuration doesn't contain the build date and there also is no
+  // configuration file to fall back to, the contract check on `stat` fails.
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      IndexImpl::dateOfIndexBuild(configuration,
+                                  absl::StrCat(onDiskBase, ".does-not-exist")),
+      ::testing::HasSubstr("stat(configFilename.c_str(), &fileStat) == 0"));
 }
 
 // _____________________________________________________________________________

--- a/test/IndexTest.cpp
+++ b/test/IndexTest.cpp
@@ -1127,21 +1127,9 @@ TEST(IndexImpl, dateOfIndexBuild) {
                               absl::UTCTimeZone(), &parsed, &error))
       << error;
 
-  // For indexes that were built before the build date was recorded in the
-  // configuration, `dateOfIndexBuild()` falls back to the last modification
-  // time of the configuration file, which was just written. Since the format
-  // only has second precision, we don't compare the timestamp exactly, but
-  // check that it lies within the last second + tolerance.
-  indexImpl.configurationJson_.erase(std::string{DATE_OF_INDEX_BUILD_KEY});
-  absl::Time fallbackTime;
-  std::string parseError;
-  ASSERT_TRUE(absl::ParseTime(DATE_OF_INDEX_BUILD_FORMAT,
-                              indexImpl.dateOfIndexBuild(), absl::UTCTimeZone(),
-                              &fallbackTime, &parseError))
-      << parseError;
-  EXPECT_THAT(absl::Now() - fallbackTime,
-              ::testing::AllOf(::testing::Ge(absl::ZeroDuration()),
-                               ::testing::Lt(absl::Seconds(2))));
+  // The fallback to the modification time of the configuration file (for
+  // indexes that were built before the build date was recorded) is tested in
+  // `dateOfIndexBuildStatic` below.
 }
 
 // _____________________________________________________________________________


### PR DESCRIPTION
Split `IndexImpl::dateOfIndexBuild` into a `static` overload that takes the configuration JSON and the on-disk base name explicitly. The existing member function becomes a one-line forwarder. This lets the build date of an index be read from disk without loading the index, which is useful for tooling that inspects an index in place.

Behavior is unchanged: the body moved verbatim, including the fallback to the modification time of `<base>.meta-data.json` for indexes from before the build date was recorded. New tests cover the new overload.

In particular, this is preparation for #3159.