### PR TITLE
Make the progress output of writing and loading permutations suppressible

### DIFF
--- a/src/index/CompressedRelation.cpp
+++ b/src/index/CompressedRelation.cpp
@@ -1623,10 +1623,11 @@ auto CompressedRelationWriter::createPermutationPair(
 auto CompressedRelationWriter::createPermutation(
     WriterAndCallback writerAndCallback,
     ad_utility::InputRangeTypeErased<IdTableStatic<0>> sortedTriples,
-    qlever::KeyOrder permutation,
-    const PerBlockCallbacks& perBlockCallbacks) -> PermutationSingleResult {
+    qlever::KeyOrder permutation, const PerBlockCallbacks& perBlockCallbacks,
+    bool showProgressBar) -> PermutationSingleResult {
   PermutationWriter<false> permutationWriter{
-      std::move(writerAndCallback), std::move(permutation), perBlockCallbacks};
+      std::move(writerAndCallback), std::move(permutation), perBlockCallbacks,
+      showProgressBar};
   return permutationWriter.writePermutation(std::move(sortedTriples));
 }
 

--- a/src/index/CompressedRelation.h
+++ b/src/index/CompressedRelation.h
@@ -378,10 +378,15 @@ class CompressedRelationWriter {
   // The `permutation` contains the column indices indicating the permutation to
   // be built (as an array, for example `[0, 1, 2]`). The `sortedTriples` must
   // be sorted by this permutation.
+  //
+  // With `showProgressBar` set to `false`, this writes no progress bar of its
+  // own. That is for callers that write several permutations and want to
+  // report the overall progress themselves.
   static PermutationSingleResult createPermutation(
       WriterAndCallback writerAndCallback,
       ad_utility::InputRangeTypeErased<IdTableStatic<0>> sortedTriples,
-      qlever::KeyOrder permutation, const PerBlockCallbacks& perBlockCallbacks);
+      qlever::KeyOrder permutation, const PerBlockCallbacks& perBlockCallbacks,
+      bool showProgressBar = true);
 
  private:
   // Internal helper for `PermutationWriter<true>` (that is, in pair mode).

--- a/src/index/CompressedRelationPermutationWriterImpl.h
+++ b/src/index/CompressedRelationPermutationWriterImpl.h
@@ -128,6 +128,9 @@ struct CompressedRelationWriter::PermutationWriter {
   size_t numTriplesProcessed_ = 0;
   ad_utility::ProgressBar progressBar_{numTriplesProcessed_,
                                        "Triples sorted: "};
+  // Whether the progress bar above is displayed, see the constructor for a
+  // single permutation below.
+  bool showProgressBar_ = true;
 
   // Constructor for a `PermutationWriter` which writes pair of permutations.
   CPP_template(bool doWritePair = WritePair)(requires doWritePair)
@@ -160,15 +163,20 @@ struct CompressedRelationWriter::PermutationWriter {
   }
 
   // Constructor for a `PermutationWriter` which writes a single permutation.
+  // With `showProgressBar` set to `false`, the progress of this writer is not
+  // displayed, which is for callers that display the progress themselves (see
+  // `CompressedRelationWriter::createPermutation`).
   CPP_template(bool doWritePair = WritePair)(requires(!doWritePair))
       PermutationWriter(WriterAndCallback writerAndCallback1,
                         qlever::KeyOrder permutation,
-                        PerBlockCallbacks perBlockCallbacks)
+                        PerBlockCallbacks perBlockCallbacks,
+                        bool showProgressBar = true)
       : permutation_{std::move(permutation)},
         writer1_{std::move(writerAndCallback1.writer_)},
         writeMetadata_{std::move(writerAndCallback1.callback_),
                        writer1_->blocksize()},
-        blockCallbackManager_{std::move(perBlockCallbacks)} {
+        blockCallbackManager_{std::move(perBlockCallbacks)},
+        showProgressBar_{showProgressBar} {
     static_assert(!WritePair);
     // This logic only works for permutations that have the graph as the fourth
     // column.
@@ -281,7 +289,7 @@ struct CompressedRelationWriter::PermutationWriter {
   // ___________________________________________________________________________
   void increaseTripleCounter() {
     ++numTriplesProcessed_;
-    if (progressBar_.update()) {
+    if (showProgressBar_ && progressBar_.update()) {
       AD_LOG_INFO << progressBar_.getProgressString() << std::flush;
     }
   }
@@ -344,7 +352,9 @@ struct CompressedRelationWriter::PermutationWriter {
       blockCallbackManager_.passToBlockCallbacks(std::move(block));
       inputWaitTimer_.cont();
     }
-    AD_LOG_INFO << progressBar_.getFinalProgressString() << std::flush;
+    if (showProgressBar_) {
+      AD_LOG_INFO << progressBar_.getFinalProgressString() << std::flush;
+    }
     inputWaitTimer_.stop();
     if (!relation_.empty() || numBlocksCurrentRel_ > 0) {
       finishRelation();

--- a/src/index/Permutation.cpp
+++ b/src/index/Permutation.cpp
@@ -41,7 +41,8 @@ CompressedRelationReader::ScanSpecAndBlocks Permutation::getScanSpecAndBlocks(
 void Permutation::loadFromDisk(
     const std::string& onDiskBase, bool loadInternalPermutation,
     Type permutationType,
-    ad_utility::HashSet<ColumnIndex> possiblyUndefinedColumns) {
+    ad_utility::HashSet<ColumnIndex> possiblyUndefinedColumns,
+    bool logRegistration) {
   onDiskBase_ = onDiskBase;
   permutationType_ = permutationType;
   if (loadInternalPermutation) {
@@ -49,7 +50,8 @@ void Permutation::loadFromDisk(
     internalPermutation_ =
         std::make_unique<Permutation>(permutation_, allocator_);
     internalPermutation_->loadFromDisk(
-        absl::StrCat(onDiskBase, QLEVER_INTERNAL_INDEX_INFIX), false);
+        absl::StrCat(onDiskBase, QLEVER_INTERNAL_INDEX_INFIX), false,
+        Type::NORMAL, {}, logRegistration);
     internalPermutation_->permutationType_ = Type::INTERNAL;
   }
   possiblyUndefinedColumns_ = std::move(possiblyUndefinedColumns);
@@ -70,8 +72,10 @@ void Permutation::loadFromDisk(
   // internal permutations always use it.
   bool useGraphPostProcessing = permutationType != Type::MATERIALIZED_VIEW;
   reader_.emplace(allocator_, std::move(file), useGraphPostProcessing);
-  AD_LOG_INFO << "Registered " << readableName_
-              << " permutation: " << meta_.statistics() << std::endl;
+  if (logRegistration) {
+    AD_LOG_INFO << "Registered " << readableName_
+                << " permutation: " << meta_.statistics() << std::endl;
+  }
   isLoaded_ = true;
 }
 

--- a/src/index/Permutation.h
+++ b/src/index/Permutation.h
@@ -94,11 +94,17 @@ class Permutation {
   explicit Permutation(Enum permutation, Allocator allocator,
                        std::optional<std::string> readableName = std::nullopt);
 
-  // everything that has to be done when reading an index from disk
+  // Everything that has to be done when reading an index from disk.
+  //
+  // With `logRegistration` set to `false`, the "Registered ... permutation"
+  // message is not logged. That is for callers that load several permutations
+  // and write a progress bar of their own, which such a message would
+  // interrupt.
   void loadFromDisk(
       const std::string& onDiskBase, bool loadInternalPermutation = false,
       Type permutationType = Type::NORMAL,
-      ad_utility::HashSet<ColumnIndex> possiblyUndefinedColumns = {});
+      ad_utility::HashSet<ColumnIndex> possiblyUndefinedColumns = {},
+      bool logRegistration = true);
 
   // Set the original metadata for the delta triples. This also sets the
   // metadata for internal permutation if present.

--- a/test/CompressedRelationsTest.cpp
+++ b/test/CompressedRelationsTest.cpp
@@ -1509,3 +1509,51 @@ TEST(CompressedBlockMetadata, invariantChecks) {
   blocks.front().lastTriple_ = {V(1), V(2), V(3), V(16)};
   EXPECT_TRUE(CompressedBlockMetadata::checkInvariantsForSortedBlocks(blocks));
 }
+
+namespace {
+// Write a small permutation to `filename` and return the log output that was
+// produced while doing so. If `showProgressBar` has a value, then it is
+// explicitly passed to `CompressedRelationWriter::createPermutation`,
+// otherwise the default of that argument is used.
+std::string writePermutationAndCaptureLog(const std::string& filename,
+                                          std::optional<bool> showProgressBar) {
+  auto [logCleanup, logStream] = setGlobalLoggingStreamToStringStream();
+  auto generator = []() -> cppcoro::generator<IdTableStatic<0>> {
+    IdTableStatic<0> buffer{4, ad_utility::testing::makeAllocator()};
+    for (int64_t i = 0; i < 10; ++i) {
+      buffer.push_back(std::vector{V(0), V(i), V(i + 1), V(0)});
+    }
+    co_yield buffer;
+  };
+  auto makeWriterAndCallback = [&filename]() {
+    return CompressedRelationWriter::WriterAndCallback{
+        std::make_unique<CompressedRelationWriter>(
+            4, ad_utility::File{filename, "w"}, 16_B),
+        [](ql::span<const CompressedRelationMetadata>) {}};
+  };
+  if (showProgressBar.has_value()) {
+    CompressedRelationWriter::createPermutation(
+        makeWriterAndCallback(), ad_utility::InputRangeTypeErased{generator()},
+        qlever::KeyOrder{0, 1, 2, 3}, {}, showProgressBar.value());
+  } else {
+    CompressedRelationWriter::createPermutation(
+        makeWriterAndCallback(), ad_utility::InputRangeTypeErased{generator()},
+        qlever::KeyOrder{0, 1, 2, 3}, {});
+  }
+  return logStream.str();
+}
+}  // namespace
+
+// _____________________________________________________________________________
+TEST(CompressedRelationWriter, showProgressBarCanBeDisabled) {
+  SKIP_IF_LOGLEVEL_IS_LOWER(INFO);
+  auto [filename, cleanup] = testFilenameWithCleanup();
+  // By default, the progress bar is written.
+  EXPECT_THAT(writePermutationAndCaptureLog(filename, std::nullopt),
+              ::testing::HasSubstr("Triples sorted"));
+  EXPECT_THAT(writePermutationAndCaptureLog(filename, true),
+              ::testing::HasSubstr("Triples sorted"));
+  // With `showProgressBar` set to `false`, the writer stays silent.
+  EXPECT_THAT(writePermutationAndCaptureLog(filename, false),
+              ::testing::Not(::testing::HasSubstr("Triples sorted")));
+}

--- a/test/CompressedRelationsTest.cpp
+++ b/test/CompressedRelationsTest.cpp
@@ -1511,12 +1511,10 @@ TEST(CompressedBlockMetadata, invariantChecks) {
 }
 
 namespace {
-// Write a small permutation to `filename` and return the log output that was
-// produced while doing so. If `showProgressBar` has a value, then it is
-// explicitly passed to `CompressedRelationWriter::createPermutation`,
-// otherwise the default of that argument is used.
+// Write a small permutation to `filename` with the given `showProgressBar` and
+// return the log output that was produced while doing so.
 std::string writePermutationAndCaptureLog(const std::string& filename,
-                                          std::optional<bool> showProgressBar) {
+                                          bool showProgressBar) {
   auto [logCleanup, logStream] = setGlobalLoggingStreamToStringStream();
   auto generator = []() -> cppcoro::generator<IdTableStatic<0>> {
     IdTableStatic<0> buffer{4, ad_utility::testing::makeAllocator()};
@@ -1525,21 +1523,14 @@ std::string writePermutationAndCaptureLog(const std::string& filename,
     }
     co_yield buffer;
   };
-  auto makeWriterAndCallback = [&filename]() {
-    return CompressedRelationWriter::WriterAndCallback{
-        std::make_unique<CompressedRelationWriter>(
-            4, ad_utility::File{filename, "w"}, 16_B),
-        [](ql::span<const CompressedRelationMetadata>) {}};
-  };
-  if (showProgressBar.has_value()) {
-    CompressedRelationWriter::createPermutation(
-        makeWriterAndCallback(), ad_utility::InputRangeTypeErased{generator()},
-        qlever::KeyOrder{0, 1, 2, 3}, {}, showProgressBar.value());
-  } else {
-    CompressedRelationWriter::createPermutation(
-        makeWriterAndCallback(), ad_utility::InputRangeTypeErased{generator()},
-        qlever::KeyOrder{0, 1, 2, 3}, {});
-  }
+  CompressedRelationWriter::WriterAndCallback writerAndCallback{
+      std::make_unique<CompressedRelationWriter>(
+          4, ad_utility::File{filename, "w"}, 16_B),
+      [](ql::span<const CompressedRelationMetadata>) {}};
+  CompressedRelationWriter::createPermutation(
+      std::move(writerAndCallback),
+      ad_utility::InputRangeTypeErased{generator()},
+      qlever::KeyOrder{0, 1, 2, 3}, {}, showProgressBar);
   return logStream.str();
 }
 }  // namespace
@@ -1548,9 +1539,7 @@ std::string writePermutationAndCaptureLog(const std::string& filename,
 TEST(CompressedRelationWriter, showProgressBarCanBeDisabled) {
   SKIP_IF_LOGLEVEL_IS_LOWER(INFO);
   auto [filename, cleanup] = testFilenameWithCleanup();
-  // By default, the progress bar is written.
-  EXPECT_THAT(writePermutationAndCaptureLog(filename, std::nullopt),
-              ::testing::HasSubstr("Triples sorted"));
+  // With `showProgressBar` set to `true`, the progress bar is written.
   EXPECT_THAT(writePermutationAndCaptureLog(filename, true),
               ::testing::HasSubstr("Triples sorted"));
   // With `showProgressBar` set to `false`, the writer stays silent.

--- a/test/PermutationTest.cpp
+++ b/test/PermutationTest.cpp
@@ -10,8 +10,10 @@
 #include <absl/strings/str_cat.h>
 #include <gmock/gmock.h>
 
+#include "./util/GTestHelpers.h"
 #include "index/ConstantsIndexBuilding.h"
 #include "index/Permutation.h"
+#include "util/IndexTestHelpers.h"
 
 // _____________________________________________________________________________
 TEST(Permutation, fileNames) {
@@ -26,4 +28,41 @@ TEST(Permutation, fileNames) {
                   POS, absl::StrCat("index", QLEVER_INTERNAL_INDEX_INFIX)),
               ::testing::ElementsAre("index.internal.index.pos",
                                      "index.internal.index.pos.meta"));
+}
+
+// _____________________________________________________________________________
+TEST(Permutation, logRegistrationCanBeDisabled) {
+  SKIP_IF_LOGLEVEL_IS_LOWER(INFO);
+  std::string basename = gtestCurrentTestName();
+  // Build an index on disk. The `Index` object itself is not used, but it has
+  // to be kept alive while the permutations below are loaded.
+  Index index = ad_utility::testing::makeTestIndex(
+      basename, "<a> <b> <c> . <a> <b> <d> . <e> <f> <g> .");
+
+  // Load the `PSO` permutation (including its internal permutation) from disk
+  // and return the log output that this produced. If `logRegistration` has a
+  // value, then it is explicitly passed to `loadFromDisk`, otherwise the
+  // default of that argument is used.
+  auto loadAndCaptureLog = [&basename](std::optional<bool> logRegistration) {
+    auto [logCleanup, logStream] = setGlobalLoggingStreamToStringStream();
+    Permutation permutation{Permutation::Enum::PSO,
+                            ad_utility::makeUnlimitedAllocator<Id>()};
+    if (logRegistration.has_value()) {
+      permutation.loadFromDisk(basename, true, Permutation::Type::NORMAL, {},
+                               logRegistration.value());
+    } else {
+      permutation.loadFromDisk(basename, true);
+    }
+    return logStream.str();
+  };
+
+  // By default, the registration is logged.
+  EXPECT_THAT(loadAndCaptureLog(std::nullopt),
+              ::testing::HasSubstr("Registered PSO permutation"));
+  EXPECT_THAT(loadAndCaptureLog(true),
+              ::testing::HasSubstr("Registered PSO permutation"));
+  // With `logRegistration` set to `false`, neither the permutation itself nor
+  // its internal permutation logs its registration.
+  EXPECT_THAT(loadAndCaptureLog(false),
+              ::testing::Not(::testing::HasSubstr("Registered")));
 }

--- a/test/PermutationTest.cpp
+++ b/test/PermutationTest.cpp
@@ -40,25 +40,18 @@ TEST(Permutation, logRegistrationCanBeDisabled) {
       basename, "<a> <b> <c> . <a> <b> <d> . <e> <f> <g> .");
 
   // Load the `PSO` permutation (including its internal permutation) from disk
-  // and return the log output that this produced. If `logRegistration` has a
-  // value, then it is explicitly passed to `loadFromDisk`, otherwise the
-  // default of that argument is used.
-  auto loadAndCaptureLog = [&basename](std::optional<bool> logRegistration) {
+  // with the given `logRegistration` and return the log output that this
+  // produced.
+  auto loadAndCaptureLog = [&basename](bool logRegistration) {
     auto [logCleanup, logStream] = setGlobalLoggingStreamToStringStream();
     Permutation permutation{Permutation::Enum::PSO,
                             ad_utility::makeUnlimitedAllocator<Id>()};
-    if (logRegistration.has_value()) {
-      permutation.loadFromDisk(basename, true, Permutation::Type::NORMAL, {},
-                               logRegistration.value());
-    } else {
-      permutation.loadFromDisk(basename, true);
-    }
+    permutation.loadFromDisk(basename, true, Permutation::Type::NORMAL, {},
+                             logRegistration);
     return logStream.str();
   };
 
-  // By default, the registration is logged.
-  EXPECT_THAT(loadAndCaptureLog(std::nullopt),
-              ::testing::HasSubstr("Registered PSO permutation"));
+  // With `logRegistration` set to `true`, the registration is logged.
   EXPECT_THAT(loadAndCaptureLog(true),
               ::testing::HasSubstr("Registered PSO permutation"));
   // With `logRegistration` set to `false`, neither the permutation itself nor


### PR DESCRIPTION
Two opt-outs for output that a caller may want to produce itself. `CompressedRelationWriter::createPermutation` gains a flag `showProgressBar`, which guards both the periodic and the final "Triples sorted" output of the permutation writer. `Permutation::loadFromDisk` gains a flag `logRegistration`, which guards the "Registered ... permutation" log line and is propagated to the internal permutation. Both are for callers that write or load several permutations and want to report the overall progress themselves rather than have each step print its own output. Both flags default to the current behavior, so nothing changes for existing callers. New tests cover both flags by capturing the log stream.

In particular, this is preparation for #3159.