### PR TITLE
Make the memory limit changeable at runtime via `memory-for-queries`

### DIFF
--- a/src/ServerMain.cpp
+++ b/src/ServerMain.cpp
@@ -84,8 +84,8 @@ int main(int argc, char** argv) {
   add("num-simultaneous-queries,j",
       po::value<NonNegative>(&numSimultaneousQueries)->default_value(1),
       "The number of queries that can be processed simultaneously.");
-  add("memory-max-size,m",
-      optionFactory.getProgramOption<&RuntimeParameters::memoryMaxSize_>(),
+  add("memory-for-queries,m",
+      optionFactory.getProgramOption<&RuntimeParameters::memoryForQueries_>(),
       "Limit on the total amount of memory that can be used for "
       "query processing and caching. If exceeded, query will return with "
       "an error, but the engine will not crash. Can be changed at runtime "
@@ -95,7 +95,7 @@ int main(int argc, char** argv) {
       optionFactory.getProgramOption<&RuntimeParameters::cacheMaxSize_>(),
       "Maximum memory size for all cache entries (pinned and "
       "not pinned). Note that the cache is part of the total memory "
-      "limited by --memory-max-size.");
+      "limited by --memory-for-queries.");
   add("cache-max-size-single-entry,e",
       optionFactory
           .getProgramOption<&RuntimeParameters::cacheMaxSizeSingleEntry_>(),
@@ -268,10 +268,33 @@ int main(int argc, char** argv) {
       "can also be changed while the server is running, via the API. If a "
       "parameter can also be set by one of the dedicated options above, the "
       "value given here wins.");
+  // Deprecated alias for `--memory-for-queries` (the historical name of that
+  // option), kept so that existing scripts continue to work. Deliberately not
+  // part of `options`, so it does not show up in the help message.
+  po::options_description deprecatedOptions;
+  deprecatedOptions.add_options()(
+      "memory-max-size",
+      po::value<ad_utility::MemorySize>()->notifier(
+          [](ad_utility::MemorySize value) {
+            AD_LOG_WARN << "The option --memory-max-size is deprecated, use "
+                           "--memory-for-queries instead"
+                        << std::endl;
+            setRuntimeParameter<&RuntimeParameters::memoryForQueries_>(value);
+          }),
+      "Deprecated alias for --memory-for-queries.");
+  po::options_description allOptions;
+  allOptions.add(options).add(deprecatedOptions);
+
   po::variables_map optionsMap;
 
   try {
-    po::store(po::parse_command_line(argc, argv, options), optionsMap);
+    po::store(po::parse_command_line(argc, argv, allOptions), optionsMap);
+    if (optionsMap.count("memory-max-size") &&
+        !optionsMap["memory-for-queries"].defaulted()) {
+      throw std::runtime_error{
+          "Specify either --memory-for-queries or its deprecated alias "
+          "--memory-max-size, but not both"};
+    }
     if (optionsMap.count("set-runtime-parameter") &&
         ad_utility::contains(
             optionsMap["set-runtime-parameter"].as<std::vector<std::string>>(),
@@ -320,11 +343,11 @@ int main(int argc, char** argv) {
                 << std::endl;
   }
 
-  // The memory limit is bound to the runtime parameter `memory-max-size`
+  // The memory limit is bound to the runtime parameter `memory-for-queries`
   // (settable via `-m` and `--set-runtime-parameter` alike), from which the
   // engine constructs its allocator.
   config.memoryLimit_ =
-      getRuntimeParameter<&RuntimeParameters::memoryMaxSize_>();
+      getRuntimeParameter<&RuntimeParameters::memoryForQueries_>();
 
   // Read the proxy for outgoing requests (`SERVICE` and `LOAD`) from the
   // environment. We do this eagerly so that a malformed proxy URL fails the

--- a/src/ServerMain.cpp
+++ b/src/ServerMain.cpp
@@ -85,12 +85,12 @@ int main(int argc, char** argv) {
       po::value<NonNegative>(&numSimultaneousQueries)->default_value(1),
       "The number of queries that can be processed simultaneously.");
   add("memory-max-size,m",
-      po::value<ad_utility::MemorySize>()
-          ->default_value(DEFAULT_MEM_FOR_QUERIES)
-          ->notifier([&config](auto v) { config.memoryLimit_ = v; }),
+      optionFactory.getProgramOption<&RuntimeParameters::memoryMaxSize_>(),
       "Limit on the total amount of memory that can be used for "
       "query processing and caching. If exceeded, query will return with "
-      "an error, but the engine will not crash.");
+      "an error, but the engine will not crash. Can be changed at runtime "
+      "via the runtime parameter of the same name, where a decrease is "
+      "only possible if the freed part is currently unused.");
   add("cache-max-size,c",
       optionFactory.getProgramOption<&RuntimeParameters::cacheMaxSize_>(),
       "Maximum memory size for all cache entries (pinned and "
@@ -319,6 +319,12 @@ int main(int argc, char** argv) {
     AD_LOG_INFO << "Runtime parameter set from the command line: " << assignment
                 << std::endl;
   }
+
+  // The memory limit is bound to the runtime parameter `memory-max-size`
+  // (settable via `-m` and `--set-runtime-parameter` alike), from which the
+  // engine constructs its allocator.
+  config.memoryLimit_ =
+      getRuntimeParameter<&RuntimeParameters::memoryMaxSize_>();
 
   // Read the proxy for outgoing requests (`SERVICE` and `LOAD`) from the
   // environment. We do this eagerly so that a malformed proxy URL fails the

--- a/src/global/RuntimeParameters.cpp
+++ b/src/global/RuntimeParameters.cpp
@@ -24,6 +24,7 @@ RuntimeParameters::RuntimeParameters() {
 
   add(stripColumns_);
   add(sortEstimateCancellationFactor_);
+  add(memoryMaxSize_);
   add(cacheMaxNumEntries_);
   add(cacheMaxSize_);
   add(cacheMaxSizeSingleEntry_);

--- a/src/global/RuntimeParameters.cpp
+++ b/src/global/RuntimeParameters.cpp
@@ -24,7 +24,7 @@ RuntimeParameters::RuntimeParameters() {
 
   add(stripColumns_);
   add(sortEstimateCancellationFactor_);
-  add(memoryMaxSize_);
+  add(memoryForQueries_);
   add(cacheMaxNumEntries_);
   add(cacheMaxSize_);
   add(cacheMaxSizeSingleEntry_);

--- a/src/global/RuntimeParameters.h
+++ b/src/global/RuntimeParameters.h
@@ -53,11 +53,12 @@ struct RuntimeParameters {
   SizeT cacheMaxNumEntries_{1000, "cache-max-num-entries"};
 
   // The total amount of memory that may be used for query processing and
-  // caching (the `--memory-max-size` option of `qlever-server`). Increasing
-  // it at runtime always succeeds. Decreasing it requires the freed part to
-  // be currently unused, otherwise the change is rejected.
-  MemorySizeParameter memoryMaxSize_{DEFAULT_MEM_FOR_QUERIES,
-                                     "memory-max-size"};
+  // caching (the `--memory-for-queries` option of `qlever-server`, called
+  // `MEMORY_FOR_QUERIES` in a Qleverfile). Increasing it at runtime always
+  // succeeds. Decreasing it requires the freed part to be currently unused,
+  // otherwise the change is rejected.
+  MemorySizeParameter memoryForQueries_{DEFAULT_MEM_FOR_QUERIES,
+                                        "memory-for-queries"};
 
   MemorySizeParameter cacheMaxSize_{ad_utility::MemorySize::gigabytes(30),
                                     "cache-max-size"};

--- a/src/global/RuntimeParameters.h
+++ b/src/global/RuntimeParameters.h
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <optional>
 
+#include "global/Constants.h"
 #include "util/Log.h"
 #include "util/Parameters.h"
 
@@ -50,6 +51,13 @@ struct RuntimeParameters {
   Double sortEstimateCancellationFactor_{3.0,
                                          "sort-estimate-cancellation-factor"};
   SizeT cacheMaxNumEntries_{1000, "cache-max-num-entries"};
+
+  // The total amount of memory that may be used for query processing and
+  // caching (the `--memory-max-size` option of `qlever-server`). Increasing
+  // it at runtime always succeeds. Decreasing it requires the freed part to
+  // be currently unused, otherwise the change is rejected.
+  MemorySizeParameter memoryMaxSize_{DEFAULT_MEM_FOR_QUERIES,
+                                     "memory-max-size"};
 
   MemorySizeParameter cacheMaxSize_{ad_utility::MemorySize::gigabytes(30),
                                     "cache-max-size"};

--- a/src/libqlever/Qlever.cpp
+++ b/src/libqlever/Qlever.cpp
@@ -68,6 +68,23 @@ Qlever::Qlever(const EngineConfig& config, bool skipLoading,
         cache_.setMaxSizeSingleEntry(newValue);
       });
 
+  // Keep the runtime parameter `memory-max-size` in sync with the memory
+  // limit of the allocator: first mirror the limit the allocator was
+  // constructed with (clearing any update action left behind by a previous
+  // instance, so that setting the value cannot fire into a destroyed
+  // instance), then register the action that applies later changes of the
+  // parameter to the allocator. Registering triggers the action once, which
+  // is a no-op here because the values are already in sync.
+  {
+    auto runtimeParameters = globalRuntimeParameters.wlock();
+    runtimeParameters->memoryMaxSize_.clearOnUpdateAction();
+    runtimeParameters->memoryMaxSize_.set(allocator_.memoryLimit());
+    runtimeParameters->memoryMaxSize_.setOnUpdateAction(
+        [this](ad_utility::MemorySize newValue) {
+          allocator_.setMemoryLimit(newValue);
+        });
+  }
+
   // If `skipLoading` is set, we do not touch the on-disk index at all; the
   // instance is expected to be populated later from a blob (see
   // `deserializeVocabAndNamedCacheFromCompressedBlob`).

--- a/src/libqlever/Qlever.cpp
+++ b/src/libqlever/Qlever.cpp
@@ -68,7 +68,7 @@ Qlever::Qlever(const EngineConfig& config, bool skipLoading,
         cache_.setMaxSizeSingleEntry(newValue);
       });
 
-  // Keep the runtime parameter `memory-max-size` in sync with the memory
+  // Keep the runtime parameter `memory-for-queries` in sync with the memory
   // limit of the allocator: first mirror the limit the allocator was
   // constructed with (clearing any update action left behind by a previous
   // instance, so that setting the value cannot fire into a destroyed
@@ -77,9 +77,9 @@ Qlever::Qlever(const EngineConfig& config, bool skipLoading,
   // is a no-op here because the values are already in sync.
   {
     auto runtimeParameters = globalRuntimeParameters.wlock();
-    runtimeParameters->memoryMaxSize_.clearOnUpdateAction();
-    runtimeParameters->memoryMaxSize_.set(allocator_.memoryLimit());
-    runtimeParameters->memoryMaxSize_.setOnUpdateAction(
+    runtimeParameters->memoryForQueries_.clearOnUpdateAction();
+    runtimeParameters->memoryForQueries_.set(allocator_.memoryLimit());
+    runtimeParameters->memoryForQueries_.setOnUpdateAction(
         [this](ad_utility::MemorySize newValue) {
           allocator_.setMemoryLimit(newValue);
         });

--- a/src/util/AllocatorPmr.h
+++ b/src/util/AllocatorPmr.h
@@ -204,6 +204,29 @@ class PmrAllocator {
     return MemorySize::max();
   }
 
+  // The memory limit. If the underlying resource is a `LimitedMemoryResource`
+  // its limit is reported, otherwise "unlimited".
+  [[nodiscard]] MemorySize memoryLimit() const {
+    if (auto* limited = dynamic_cast<LimitedMemoryResource*>(resource_)) {
+      return limited->tracker_.memoryLimit();
+    }
+    return MemorySize::max();
+  }
+
+  // Change the memory limit to `newLimit`, with the same semantics as
+  // `AllocatorWithLimit::setMemoryLimit`. Throws if the underlying resource is
+  // not a `LimitedMemoryResource`, because such a resource enforces no limit
+  // that could be changed.
+  void setMemoryLimit(MemorySize newLimit) {
+    auto* limited = dynamic_cast<LimitedMemoryResource*>(resource_);
+    if (limited == nullptr) {
+      throw std::runtime_error{
+          "The memory limit cannot be changed, because this allocator does not "
+          "enforce one"};
+    }
+    limited->tracker_.setMemoryLimit(newLimit);
+  }
+
   ql::pmr::memory_resource* resource() const { return resource_; }
 
   // Two allocators are equal iff they refer to the same resource.

--- a/src/util/AllocatorWithLimitImpl.h
+++ b/src/util/AllocatorWithLimitImpl.h
@@ -158,6 +158,18 @@ class AllocatorWithLimit {
     return tracker_.amountMemoryLeft();
   }
 
+  /// Return the memory limit that this allocator and all of its copies share.
+  [[nodiscard]] MemorySize memoryLimit() const {
+    return tracker_.memoryLimit();
+  }
+
+  /// Change the shared memory limit to `newLimit`. Increasing always succeeds.
+  /// Decreasing requires the difference to be currently unallocated, otherwise
+  /// an exception is thrown and nothing is changed.
+  void setMemoryLimit(MemorySize newLimit) {
+    tracker_.setMemoryLimit(newLimit);
+  }
+
   template <typename V>
   bool operator==(const AllocatorWithLimit<V>& v) const {
     return tracker_ == v.tracker_;

--- a/src/util/MemoryLimitTracker.h
+++ b/src/util/MemoryLimitTracker.h
@@ -58,10 +58,13 @@ class AllocationExceedsLimitException : public std::exception {
 class AllocationMemoryLeft {
   // Remaining free memory.
   MemorySize free_;
+  // The total pool size (the memory limit). Invariant: `free_ <= total_`,
+  // and `total_ - free_` is the amount currently allocated.
+  MemorySize total_;
 
  public:
   // Constructor from the initial amount of free memory.
-  explicit AllocationMemoryLeft(MemorySize n) : free_(n) {}
+  explicit AllocationMemoryLeft(MemorySize n) : free_(n), total_(n) {}
 
   // Called before memory is allocated.
   bool decrease_if_enough_left_or_return_false(MemorySize n) noexcept {
@@ -85,6 +88,25 @@ class AllocationMemoryLeft {
 
   // Returns the amount of memory still available.
   [[nodiscard]] MemorySize amountMemoryLeft() const { return free_; }
+
+  // Returns the total pool size (the memory limit).
+  [[nodiscard]] MemorySize total() const { return total_; }
+
+  // Change the total pool size (the memory limit) to `newTotal`. Increasing
+  // always succeeds and adds the difference to the free memory. Decreasing
+  // requires the difference to be currently free, otherwise an exception is
+  // thrown and nothing is changed.
+  void setTotal(MemorySize newTotal) {
+    if (newTotal >= total_) {
+      free_ += newTotal - total_;
+    } else if (!decrease_if_enough_left_or_return_false(total_ - newTotal)) {
+      throw std::runtime_error{absl::StrCat(
+          "Cannot reduce the memory limit to ", newTotal.asString(),
+          ", because only ", free_.asString(), " of the current limit of ",
+          total_.asString(), " are unused")};
+    }
+    total_ = newTotal;
+  }
 };
 
 // Threadsafe Wrapper around `AllocationMemoryLeft`.
@@ -237,6 +259,17 @@ class MemoryLimitTracker {
   // Returns the amount of memory still available.
   [[nodiscard]] MemorySize amountMemoryLeft() const {
     return sharedMemoryLeft_.ptr()->wlock()->amountMemoryLeft();
+  }
+
+  // Returns the memory limit (the total pool size).
+  [[nodiscard]] MemorySize memoryLimit() const {
+    return sharedMemoryLeft_.ptr()->wlock()->total();
+  }
+
+  // Change the memory limit to `newLimit`, see `AllocationMemoryLeft::setTotal`
+  // for the semantics.
+  void setMemoryLimit(MemorySize newLimit) {
+    sharedMemoryLeft_.ptr()->wlock()->setTotal(newLimit);
   }
 
   // Compares whether two trackers share the same memory counter.

--- a/src/util/Parameters.h
+++ b/src/util/Parameters.h
@@ -11,6 +11,7 @@
 #include <absl/strings/str_split.h>
 
 #include <optional>
+#include <utility>
 #include <vector>
 
 #include "backports/concepts.h"
@@ -90,13 +91,21 @@ CPP_template(typename Type, typename FromString, typename ToString)(
     set(FromString{}(stringInput));
   }
 
-  /// Set the value.
+  /// Set the value. If the `onUpdateAction` throws (e.g. because the new
+  /// value cannot be applied), the old value is restored before the exception
+  /// is propagated, so that the parameter always reflects the state that was
+  /// actually applied.
   void set(Type newValue) {
     if (parameterConstraint_.has_value()) {
       std::invoke(parameterConstraint_.value(), newValue, name_);
     }
-    value_ = std::move(newValue);
-    triggerOnUpdateAction();
+    Type oldValue = std::exchange(value_, std::move(newValue));
+    try {
+      triggerOnUpdateAction();
+    } catch (...) {
+      value_ = std::move(oldValue);
+      throw;
+    }
   }
 
   const Type& get() const { return value_; }
@@ -108,6 +117,9 @@ CPP_template(typename Type, typename FromString, typename ToString)(
     onUpdateAction_ = std::move(onUpdateAction);
     triggerOnUpdateAction();
   }
+
+  /// Remove a previously set `onUpdateAction` (if any) without triggering it.
+  void clearOnUpdateAction() { onUpdateAction_ = std::nullopt; }
 
   /// Set an constraint that will be executed every time the value changes
   /// and once initially when setting it. It is intended to throw an exception

--- a/test/AllocatorBackendTest.cpp
+++ b/test/AllocatorBackendTest.cpp
@@ -142,6 +142,37 @@ TYPED_TEST(AllocatorBackendTest, ClearOnAllocationHook) {
   alloc.deallocate(p1, 1);
 }
 
+// The memory limit can be changed after construction: increasing always
+// succeeds, decreasing only as long as the difference is currently free.
+// A rejected decrease changes nothing.
+TYPED_TEST(AllocatorBackendTest, SetMemoryLimit) {
+  static_assert(sizeof(int) == 4);
+  auto alloc = TypeParam::makeLimited(20_B);
+  EXPECT_EQ(alloc.memoryLimit(), 20_B);
+
+  int* p = alloc.allocate(3);  // 12 bytes consumed
+  EXPECT_EQ(alloc.amountMemoryLeft(), 8_B);
+
+  alloc.setMemoryLimit(40_B);
+  EXPECT_EQ(alloc.memoryLimit(), 40_B);
+  EXPECT_EQ(alloc.amountMemoryLeft(), 28_B);
+
+  // 16 bytes are enough for the 12 bytes currently allocated.
+  alloc.setMemoryLimit(16_B);
+  EXPECT_EQ(alloc.memoryLimit(), 16_B);
+  EXPECT_EQ(alloc.amountMemoryLeft(), 4_B);
+
+  // 8 bytes are not.
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      alloc.setMemoryLimit(8_B),
+      ::testing::HasSubstr("only 4 B of the current limit of 16 B are unused"));
+  EXPECT_EQ(alloc.memoryLimit(), 16_B);
+  EXPECT_EQ(alloc.amountMemoryLeft(), 4_B);
+
+  alloc.deallocate(p, 3);
+  EXPECT_EQ(alloc.amountMemoryLeft(), 16_B);
+}
+
 // .as<char>() yields an allocator sharing the same budget: consuming bytes
 // through the char allocator reduces the int allocator's amountMemoryLeft().
 TYPED_TEST(AllocatorBackendTest, AsSharesBudget) {

--- a/test/AllocatorPmrTest.cpp
+++ b/test/AllocatorPmrTest.cpp
@@ -17,6 +17,7 @@
 
 #include "backports/memory_resource.h"
 #include "util/AllocatorPmr.h"
+#include "util/GTestHelpers.h"
 #include "util/MemorySize/MemorySize.h"
 
 using ad_utility::makePmrAllocatorFromResource;
@@ -143,12 +144,16 @@ TEST(AllocatorPmr, ResourceIsEqual) {
 }
 
 // ____________________________________________________________________________
-// A plain platform resource (non-owning) enforces no limit.
+// A plain platform resource (non-owning) enforces no limit, so it reports an
+// unlimited memory limit and rejects changing it.
 TEST(AllocatorPmr, FromResourceNoLimit) {
   ql::pmr::monotonic_buffer_resource platformPool;
   auto alloc = makePmrAllocatorFromResource<int>(&platformPool);
   EXPECT_EQ(alloc.resource(), &platformPool);
   EXPECT_EQ(alloc.amountMemoryLeft(), MemorySize::max());
+  EXPECT_EQ(alloc.memoryLimit(), MemorySize::max());
+  AD_EXPECT_THROW_WITH_MESSAGE(alloc.setMemoryLimit(MemorySize::bytes(4)),
+                               ::testing::HasSubstr("does not enforce one"));
   int* p = alloc.allocate(10);
   ASSERT_NE(p, nullptr);
   alloc.deallocate(p, 10);

--- a/test/ParametersTest.cpp
+++ b/test/ParametersTest.cpp
@@ -67,6 +67,26 @@ TEST(Parameter, verifyParameterConstraint) {
 }
 
 // _____________________________________________________________________________
+TEST(Parameter, onUpdateActionThrowIsRolledBack) {
+  Parameter<size_t, szt, toString> parameter{42, "test"};
+
+  // A throwing `onUpdateAction` restores the old value.
+  parameter.setOnUpdateAction([](size_t value) {
+    if (value > 100) {
+      throw std::runtime_error{"Test"};
+    }
+  });
+  EXPECT_NO_THROW(parameter.set(100));
+  EXPECT_THROW(parameter.set(101), std::runtime_error);
+  EXPECT_EQ(parameter.get(), 100);
+
+  // After clearing the action, setting the value triggers nothing.
+  parameter.clearOnUpdateAction();
+  EXPECT_NO_THROW(parameter.set(101));
+  EXPECT_EQ(parameter.get(), 101);
+}
+
+// _____________________________________________________________________________
 TEST(Parameter, verifyDurationParameterSerializationWorks) {
   DurationParameter<std::chrono::seconds> durationParameter{0s, "zeroSeconds"};
   EXPECT_EQ(durationParameter.toString(), "0s");

--- a/test/libqlever/QleverTest.cpp
+++ b/test/libqlever/QleverTest.cpp
@@ -338,6 +338,46 @@ TEST(LibQlever, disableCaching) {
 }
 
 // _____________________________________________________________________________
+// The runtime parameter `memory-max-size` mirrors and controls the memory
+// limit of the engine's allocator.
+TEST(LibQlever, memoryMaxSizeRuntimeParameter) {
+  using namespace ad_utility::memory_literals;
+  EngineConfig ec = buildTestIndex("<s> <p> <o>.");
+  ec.memoryLimit_ = 50_MB;
+  Qlever engine{ec};
+  // Detach the parameter from the engine again before the engine dies, so
+  // that no later test can fire the update action into a destroyed instance.
+  absl::Cleanup cleanup = [] {
+    auto runtimeParameters = globalRuntimeParameters.wlock();
+    runtimeParameters->memoryMaxSize_.clearOnUpdateAction();
+    runtimeParameters->memoryMaxSize_.set(DEFAULT_MEM_FOR_QUERIES);
+  };
+
+  // Constructing the engine has synced the parameter to the configured limit.
+  EXPECT_EQ(getRuntimeParameter<&RuntimeParameters::memoryMaxSize_>(), 50_MB);
+  EXPECT_EQ(engine.allocator().memoryLimit(), 50_MB);
+
+  // Increasing the limit always works.
+  setRuntimeParameter<&RuntimeParameters::memoryMaxSize_>(100_MB);
+  EXPECT_EQ(engine.allocator().memoryLimit(), 100_MB);
+
+  // Decreasing works as long as the freed part is currently unused, i.e. not
+  // below the 32 MB allocated here (plus what the engine itself has
+  // allocated).
+  Id* chunk = engine.allocator().allocate(4'000'000);
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      setRuntimeParameter<&RuntimeParameters::memoryMaxSize_>(20_MB),
+      HasSubstr("Cannot reduce the memory limit"));
+  // The rejected decrease left both the parameter and the limit unchanged.
+  EXPECT_EQ(getRuntimeParameter<&RuntimeParameters::memoryMaxSize_>(), 100_MB);
+  EXPECT_EQ(engine.allocator().memoryLimit(), 100_MB);
+
+  engine.allocator().deallocate(chunk, 4'000'000);
+  setRuntimeParameter<&RuntimeParameters::memoryMaxSize_>(20_MB);
+  EXPECT_EQ(engine.allocator().memoryLimit(), 20_MB);
+}
+
+// _____________________________________________________________________________
 TEST(LibQlever, externallySpecifiedValues) {
   EngineConfig ec = buildTestIndex("<s1> <p> 1 . <s2> <p> 2 . <s3> <p> 3 .");
   // Caching must be disabled for externally specified values.

--- a/test/libqlever/QleverTest.cpp
+++ b/test/libqlever/QleverTest.cpp
@@ -338,9 +338,9 @@ TEST(LibQlever, disableCaching) {
 }
 
 // _____________________________________________________________________________
-// The runtime parameter `memory-max-size` mirrors and controls the memory
+// The runtime parameter `memory-for-queries` mirrors and controls the memory
 // limit of the engine's allocator.
-TEST(LibQlever, memoryMaxSizeRuntimeParameter) {
+TEST(LibQlever, memoryForQueriesRuntimeParameter) {
   using namespace ad_utility::memory_literals;
   EngineConfig ec = buildTestIndex("<s> <p> <o>.");
   ec.memoryLimit_ = 50_MB;
@@ -349,16 +349,17 @@ TEST(LibQlever, memoryMaxSizeRuntimeParameter) {
   // that no later test can fire the update action into a destroyed instance.
   absl::Cleanup cleanup = [] {
     auto runtimeParameters = globalRuntimeParameters.wlock();
-    runtimeParameters->memoryMaxSize_.clearOnUpdateAction();
-    runtimeParameters->memoryMaxSize_.set(DEFAULT_MEM_FOR_QUERIES);
+    runtimeParameters->memoryForQueries_.clearOnUpdateAction();
+    runtimeParameters->memoryForQueries_.set(DEFAULT_MEM_FOR_QUERIES);
   };
 
   // Constructing the engine has synced the parameter to the configured limit.
-  EXPECT_EQ(getRuntimeParameter<&RuntimeParameters::memoryMaxSize_>(), 50_MB);
+  EXPECT_EQ(getRuntimeParameter<&RuntimeParameters::memoryForQueries_>(),
+            50_MB);
   EXPECT_EQ(engine.allocator().memoryLimit(), 50_MB);
 
   // Increasing the limit always works.
-  setRuntimeParameter<&RuntimeParameters::memoryMaxSize_>(100_MB);
+  setRuntimeParameter<&RuntimeParameters::memoryForQueries_>(100_MB);
   EXPECT_EQ(engine.allocator().memoryLimit(), 100_MB);
 
   // Decreasing works as long as the freed part is currently unused, i.e. not
@@ -366,14 +367,15 @@ TEST(LibQlever, memoryMaxSizeRuntimeParameter) {
   // allocated).
   Id* chunk = engine.allocator().allocate(4'000'000);
   AD_EXPECT_THROW_WITH_MESSAGE(
-      setRuntimeParameter<&RuntimeParameters::memoryMaxSize_>(20_MB),
+      setRuntimeParameter<&RuntimeParameters::memoryForQueries_>(20_MB),
       HasSubstr("Cannot reduce the memory limit"));
   // The rejected decrease left both the parameter and the limit unchanged.
-  EXPECT_EQ(getRuntimeParameter<&RuntimeParameters::memoryMaxSize_>(), 100_MB);
+  EXPECT_EQ(getRuntimeParameter<&RuntimeParameters::memoryForQueries_>(),
+            100_MB);
   EXPECT_EQ(engine.allocator().memoryLimit(), 100_MB);
 
   engine.allocator().deallocate(chunk, 4'000'000);
-  setRuntimeParameter<&RuntimeParameters::memoryMaxSize_>(20_MB);
+  setRuntimeParameter<&RuntimeParameters::memoryForQueries_>(20_MB);
   EXPECT_EQ(engine.allocator().memoryLimit(), 20_MB);
 }
 


### PR DESCRIPTION
So far, the total memory limit for query processing and caching could only be fixed at server start via the `-m` option. This change turns it into a runtime parameter, so the limit can also be inspected and changed via the API while the server is running. An increase always succeeds. A decrease is only accepted if the freed part is currently unused, otherwise the change is rejected with a clear message and nothing happens.

The parameter and the long server option are called `memory-for-queries`, in sync with the `MEMORY_FOR_QUERIES` setting of the `qlever` script. The historical spelling `--memory-max-size` keeps working as a deprecated alias. Also, a runtime parameter now rolls back its value when its update action throws, so the reported parameter value always reflects the actually applied state.