### PR TITLE
Fix the quadratic runtime of the `CTRE` tokenizer

### DIFF
--- a/src/parser/TokenizerCtre.h
+++ b/src/parser/TokenizerCtre.h
@@ -344,9 +344,8 @@ class TokenizerCtre : public SkipWhitespaceAndCommentsMixin<TokenizerCtre> {
     template <auto& regex>
     static std::pair<bool, std::string_view> process(
         std::string_view data) noexcept {
-      static constexpr auto ext = grp(regex) + ".*";
-      if (auto m = ctre::match<ext>(data)) {
-        return {true, m.template get<1>().to_view()};
+      if (auto m = ctre::starts_with<regex>(data)) {
+        return {true, m.to_view()};
       } else {
         return {false, std::string_view()};
       }


### PR DESCRIPTION
So far, the `CTRE` tokenizer matched a token by appending `.*` to the token regex and matching against the entire remaining input. Each token match thus cost time proportional to the remaining input, so tokenizing an input of length `n` was quadratic in `n`. The tokenizer now uses `starts_with` provided by `CTRE`, which stops at the end of the token and makes tokenization linear. In a microbenchmark, tokenizing `200 kB` of Turtle-like input goes from `24s` to under `1ms`.