### PR TITLE
Relax the timing bound in `RdfParserTest.stopParsingOnOutsideFailure`

### DIFF
--- a/test/RdfParserTest.cpp
+++ b/test/RdfParserTest.cpp
@@ -1234,7 +1234,10 @@ TEST(RdfParserTest, betterErrorMessageOnMultilineLiteralError) {
 
 // Test that the parallel parser's destructor can be run quickly and without
 // blocking, even when there are still lots of blocks in the pipeline that are
-// currently being parsed.
+// currently being parsed. Draining the pipeline would take on the order of
+// seconds, so the bound below still proves the point but is generous enough
+// for a loaded CI runner (20ms were not, see the frequent spurious failures in
+// August 2026).
 TEST(RdfParserTest, stopParsingOnOutsideFailure) {
 #ifdef _QLEVER_NO_TIMING_TESTS
   GTEST_SKIP_("because _QLEVER_NO_TIMING_TESTS defined");
@@ -1265,7 +1268,7 @@ TEST(RdfParserTest, stopParsingOnOutsideFailure) {
       }();
       timer.cont();
     }
-    EXPECT_LE(timer.msecs(), 20ms);
+    EXPECT_LE(timer.msecs(), 200ms);
   };
   const std::string input = []() {
     std::string singleBlock = "<subject> <predicate> <object> . \n ";


### PR DESCRIPTION
The test checks that destroying a parallel parser does not drain the blocks still in its pipeline, which for that test would take on the order of seconds. The bound of `20ms` for the destructor was regularly exceeded on GitHub's CI runners in the last weeks (`70ms` observed), causing spurious failures. It is now `200ms`, which still proves the point and hopefully provides enough margin.