### PR TITLE
Add `forEachSetBit` utility

### DIFF
--- a/src/util/BitUtils.h
+++ b/src/util/BitUtils.h
@@ -16,6 +16,7 @@
 #include <cmath>
 #include <cstddef>
 #include <exception>
+#include <functional>
 
 #include "util/Exception.h"
 #include "util/TypeTraits.h"
@@ -81,9 +82,9 @@ using unsignedTypeForNumberOfBits =
 // iteration, so unset bits are never visited.
 CPP_template(typename F)(
     requires InvocableWithConvertibleReturnType<
-        F, bool, size_t>) inline void forEachSetBit(uint64_t bits, F&& fn) {
+        F, bool, uint8_t>) inline void forEachSetBit(uint64_t bits, F&& fn) {
   while (bits != 0) {
-    if (!fn(static_cast<size_t>(absl::countr_zero(bits)))) {
+    if (!std::invoke(fn, static_cast<uint8_t>(absl::countr_zero(bits)))) {
       return;
     }
     bits &= bits - 1;

--- a/src/util/BitUtils.h
+++ b/src/util/BitUtils.h
@@ -1,17 +1,27 @@
-//  Copyright 2022, University of Freiburg,
-//  Chair of Algorithms and Data Structures.
-//  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+// Copyright 2022 - 2026 The QLever Authors, in particular:
+//
+// 2022 - 2025 Johannes Kalmbach <kalmbach@informatik.uni-freiburg.de>, UFR
+// 2025 - 2026 Christoph Ullinger <ullingec@informatik.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
 
 #ifndef QLEVER_BITUTILS_H
 #define QLEVER_BITUTILS_H
 
+#include <absl/numeric/bits.h>
+
 #include <cmath>
+#include <cstddef>
 #include <exception>
 
 #include "util/Exception.h"
 #include "util/TypeTraits.h"
 
 namespace ad_utility {
+
 // The return value has 1s for the lowest `numBits` bits, and 0 in all the
 // higher bits.
 constexpr inline uint64_t bitMaskForLowerBits(uint64_t numBits) {
@@ -64,6 +74,21 @@ constexpr auto unsignedTypeForNumberOfBitsImpl() {
 template <uint8_t numBits>
 using unsignedTypeForNumberOfBits =
     decltype(detail::unsignedTypeForNumberOfBitsImpl<numBits>());
+
+// Calls `fn(idx)` for each set bit index of `bits`, from lowest to highest,
+// stopping early (equivalent to `break`) if `fn` returns `false`. Runs in
+// O(popcount(bits)) time: `bits & (bits - 1)` clears the lowest set bit each
+// iteration, so unset bits are never visited.
+CPP_template(typename F)(
+    requires InvocableWithConvertibleReturnType<
+        F, bool, size_t>) inline void forEachSetBit(uint64_t bits, F&& fn) {
+  while (bits != 0) {
+    if (!fn(static_cast<size_t>(absl::countr_zero(bits)))) {
+      return;
+    }
+    bits &= bits - 1;
+  }
+}
 }  // namespace ad_utility
 
 #endif  // QLEVER_BITUTILS_H

--- a/test/BitUtilsTest.cpp
+++ b/test/BitUtilsTest.cpp
@@ -3,6 +3,7 @@
 //  Authors: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
 //           Christoph Ullinger <ullingec@cs.uni-freiburg.de>
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "util/BitUtils.h"
@@ -76,6 +77,30 @@ TEST(BitUtils, bitMaskSize) {
   ASSERT_EQ(bitMaskSizeForValue(0), 0);
   ASSERT_EQ(bitMaskSizeForValue(1), 1);
   ASSERT_EQ(bitMaskSizeForValue(4), 3);
+}
+
+// _____________________________________________________________________________
+TEST(BitUtils, forEachSetBit) {
+  auto collect = [](uint64_t bits) {
+    std::vector<size_t> result;
+    forEachSetBit(bits, [&result](size_t idx) {
+      result.push_back(idx);
+      return true;
+    });
+    return result;
+  };
+
+  EXPECT_THAT(collect(0), ::testing::IsEmpty());
+  EXPECT_THAT(collect(0b1011), ::testing::ElementsAre(0, 1, 3));
+  EXPECT_THAT(collect(uint64_t{1} << 63), ::testing::ElementsAre(63));
+
+  // Stops early when `fn` returns `false`.
+  std::vector<size_t> stoppedEarly;
+  forEachSetBit(0b1111, [&stoppedEarly](size_t idx) {
+    stoppedEarly.push_back(idx);
+    return idx < 1;
+  });
+  EXPECT_THAT(stoppedEarly, ::testing::ElementsAre(0, 1));
 }
 
 }  // namespace

--- a/test/BitUtilsTest.cpp
+++ b/test/BitUtilsTest.cpp
@@ -1,10 +1,14 @@
-//  Copyright 2022 - 2025, University of Freiburg,
-//  Chair of Algorithms and Data Structures.
-//  Authors: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
-//           Christoph Ullinger <ullingec@cs.uni-freiburg.de>
+// Copyright 2022 - 2026 The QLever Authors, in particular:
+//
+// 2022 - 2025 Johannes Kalmbach <kalmbach@informatik.uni-freiburg.de>, UFR
+// 2025 - 2026 Christoph Ullinger <ullingec@informatik.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
 
 #include <gmock/gmock.h>
-#include <gtest/gtest.h>
 
 #include "util/BitUtils.h"
 


### PR DESCRIPTION
There is now a utility function `forEachSetBit` that calls a given function for each set bit index of a 64-bit word, from lowest to highest, in time proportional to the number of set bits. Preparation for #3273.