### PR TITLE
Use a bitmask for the triples covered by a materialized view rewrite plan

### DIFF
--- a/src/engine/MaterializedViewsQueryAnalysis.cpp
+++ b/src/engine/MaterializedViewsQueryAnalysis.cpp
@@ -132,7 +132,8 @@ void QueryPatternCache::makeScansFromChainCandidates(
           result.push_back(
               {makeScanForSingleChain(qec, chainInfo, left.s_, varLeft,
                                       right.o_.getVariable()),
-               {tripleIdxLeft, tripleIdxRight}});
+               (uint64_t{1} << tripleIdxLeft) |
+                   (uint64_t{1} << tripleIdxRight)});
         }
       }
     }
@@ -205,7 +206,7 @@ void QueryPatternCache::makeScansFromStarCandidates(
       if (ql::ranges::includes(queryPredicates,
                                starInfo.arms_ | ql::views::keys)) {
         parsedQuery::MaterializedViewQuery::RequestedColumns cols;
-        std::vector<size_t> coveredTriples;
+        uint64_t coveredTriples = 0;
 
         // The subject must be read.
         cols.insert({starInfo.subject_, subject});
@@ -215,13 +216,13 @@ void QueryPatternCache::makeScansFromStarCandidates(
           size_t idx = predicateToTripleIdx.at(predicate);
           auto queryObject = triples._triples.at(idx).o_;
           cols.insert({object, queryObject});
-          coveredTriples.push_back(idx);
+          coveredTriples |= (uint64_t{1} << idx);
         }
 
         // Construct the `MaterializedViewJoinReplacement`, in particular the
         // `IndexScan`.
-        result.push_back({makeScanForStar(qec, view, std::move(cols)),
-                          std::move(coveredTriples)});
+        result.push_back(
+            {makeScanForStar(qec, view, std::move(cols)), coveredTriples});
       }
     }
   }

--- a/src/engine/MaterializedViewsQueryAnalysis.cpp
+++ b/src/engine/MaterializedViewsQueryAnalysis.cpp
@@ -29,6 +29,12 @@ std::vector<MaterializedViewJoinReplacement>
 QueryPatternCache::makeJoinReplacementIndexScans(
     QueryExecutionContext* qec,
     const parsedQuery::BasicGraphPattern& triples) const {
+  // We do not allow `triples` to contain more than 64 triples, because use a
+  // 64-bit bitmask for them. This is not a problem, because `QueryPlanner` does
+  // not allow graph patterns with more than 64 triples anyway.
+  AD_CONTRACT_CHECK(triples._triples.size() <= 64,
+                    "At most 64 triples allowed at the moment.");
+
   std::vector<MaterializedViewJoinReplacement> result;
 
   // All triples of the form `anything <iri> ?variable` where `<iri>` is covered

--- a/src/engine/MaterializedViewsQueryAnalysis.cpp
+++ b/src/engine/MaterializedViewsQueryAnalysis.cpp
@@ -29,7 +29,7 @@ std::vector<MaterializedViewJoinReplacement>
 QueryPatternCache::makeJoinReplacementIndexScans(
     QueryExecutionContext* qec,
     const parsedQuery::BasicGraphPattern& triples) const {
-  // We do not allow `triples` to contain more than 64 triples, because use a
+  // We do not allow `triples` to contain more than 64 triples, because we use a
   // 64-bit bitmask for them. This is not a problem, because `QueryPlanner` does
   // not allow graph patterns with more than 64 triples anyway.
   AD_CONTRACT_CHECK(triples._triples.size() <= 64,

--- a/src/engine/MaterializedViewsQueryAnalysis.h
+++ b/src/engine/MaterializedViewsQueryAnalysis.h
@@ -10,6 +10,7 @@
 #ifndef QLEVER_SRC_ENGINE_MATERIALIZEDVIEWSQUERYANALYSIS_H_
 #define QLEVER_SRC_ENGINE_MATERIALIZEDVIEWSQUERYANALYSIS_H_
 
+#include <cstdint>
 #include <variant>
 
 #include "engine/VariableToColumnMap.h"
@@ -66,10 +67,9 @@ using ByCacheKeyInfoPtr = std::shared_ptr<const ByCacheKeyInfo>;
 // subset of triples it handles.
 struct MaterializedViewJoinReplacement {
   std::shared_ptr<IndexScan> indexScan_;
-  std::vector<size_t> coveredTriples_;
-
-  // ___________________________________________________________________________
-  size_t numJoins() const { return coveredTriples_.size() - 1; }
+  // Bitmask of covered query triple indices, like
+  // `QueryPlanner::SubtreePlan::_idsOfIncludedNodes`.
+  uint64_t coveredTriples_;
 };
 
 // Cache data structure for the `MaterializedViewsManager`. This object can be

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -1,10 +1,14 @@
-// Copyright 2024, University of Freiburg,
-// Chair of Algorithms and Data Structures.
-// Author:
-//   2015-2017 Björn Buchhold (buchhold@informatik.uni-freiburg.de)
-//   2018-     Johannes Kalmbach (kalmbach@informatik.uni-freiburg.de)
+// Copyright 2015 - 2026 The QLever Authors, in particular:
 //
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+// 2015 - 2017 Björn Buchhold <buchhold@informatik.uni-freiburg.de>, UFR
+// 2018 - 2026 Johannes Kalmbach <kalmbach@informatik.uni-freiburg.de>, UFR
+// 2025 - 2026 Christoph Ullinger <ullingec@informatik.uni-freiburg.de>, UFR
+// 2025        Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
 
 #include "engine/QueryPlanner.h"
 
@@ -2697,8 +2701,8 @@ auto QueryPlanner::createMaterializedViewJoinReplacements(
 
   // The `MaterializedViewsManager` provides `IndexScan` instances for all the
   // subsets of `triples` it can rewrite. The individual results do not cover
-  // all items of `triples`, instead each has a vector of triple indices it
-  // covers.
+  // all items of `triples`, instead each has a bitmask of the triple indices
+  // it covers (matching `_idsOfIncludedNodes`'s representation).
   auto scans = _qec->materializedViewsManager().makeJoinReplacementIndexScans(
       _qec, triples);
   plans.reserve(triples._triples.size());
@@ -2709,14 +2713,13 @@ auto QueryPlanner::createMaterializedViewJoinReplacements(
     auto plan = makeSubtreePlan<IndexScan>(scan);
     // This is equivalent to a join between the covered triples, so we must mark
     // all included nodes.
-    for (auto tripleIdx : coveredTriples) {
-      plan._idsOfIncludedNodes |= (1ULL << tripleIdx);
-    }
+    plan._idsOfIncludedNodes |= coveredTriples;
+    size_t numCoveredTriples = absl::popcount(coveredTriples);
     // Empty vectors of replacement plans for smaller numbers of triples.
-    for (size_t i = plans.size(); i < coveredTriples.size(); ++i) {
+    for (size_t i = plans.size(); i < numCoveredTriples; ++i) {
       plans.push_back({});
     }
-    plans.at(coveredTriples.size() - 1).push_back(std::move(plan));
+    plans.at(numCoveredTriples - 1).push_back(std::move(plan));
   }
   return plans;
 }

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -12,6 +12,7 @@
 
 #include "engine/QueryPlanner.h"
 
+#include <absl/numeric/bits.h>
 #include <absl/strings/str_cat.h>
 #include <absl/strings/str_split.h>
 


### PR DESCRIPTION
Using a bitmask avoids having to convert back and forth between the existing bitmask representation in the query planner and the vector representation used by the materialized view rewriting so far. 

This is a functionally invariant refactoring, in preparation for #3273.