### PR TITLE
Add `isFullTextPseudoPredicate` utility

### DIFF
--- a/src/global/Constants.h
+++ b/src/global/Constants.h
@@ -96,7 +96,7 @@ constexpr inline std::string_view CONTAINS_WORD_PREDICATE =
 
 // Whether `predicate` is one of the full-text pseudo-predicates, which are
 // rewritten into dedicated text operations rather than plain index scans.
-constexpr inline bool isFullTextPseudoPredicate(std::string_view predicate) {
+constexpr bool isFullTextPseudoPredicate(std::string_view predicate) {
   return predicate == CONTAINS_ENTITY_PREDICATE ||
          predicate == CONTAINS_WORD_PREDICATE;
 }

--- a/src/global/Constants.h
+++ b/src/global/Constants.h
@@ -1,8 +1,13 @@
-// Copyright 2023 - 2025, University of Freiburg,
-// Chair of Algorithms and Data Structures.
-// Authors: Björn Buchhold <buchhold@gmail.com> [2014 - 2017]
-//          Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
-//          Hannah Bast <bast@cs.uni-freiburg.de>
+// Copyright 2014 - 2026 The QLever Authors, in particular:
+//
+// 2014 - 2017 Björn Buchhold <buchhold@informatik.uni-freiburg.de>, UFR
+// 2014 - 2026 Hannah Bast <bast@cs.uni-freiburg.de>, UFR
+// 2018 - 2026 Johannes Kalmbach <kalmbach@informatik.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
 
 #ifndef QLEVER_SRC_GLOBAL_CONSTANTS_H
 #define QLEVER_SRC_GLOBAL_CONSTANTS_H
@@ -88,6 +93,13 @@ constexpr inline std::string_view contains_word = "contains-word";
 }  // namespace string_constants::detail
 constexpr inline std::string_view CONTAINS_WORD_PREDICATE =
     makeQleverInternalIriConst<string_constants::detail::contains_word>();
+
+// Whether `predicate` is one of the full-text pseudo-predicates, which are
+// rewritten into dedicated text operations rather than plain index scans.
+constexpr inline bool isFullTextPseudoPredicate(std::string_view predicate) {
+  return predicate == CONTAINS_ENTITY_PREDICATE ||
+         predicate == CONTAINS_WORD_PREDICATE;
+}
 
 namespace string_constants::detail {
 constexpr inline std::string_view text = "text";

--- a/test/ConstantsTest.cpp
+++ b/test/ConstantsTest.cpp
@@ -1,6 +1,12 @@
-//   Copyright 2023, University of Freiburg,
-//   Chair of Algorithms and Data Structures.
-//   Author: Robin Textor-Falconi <textorr@informatik.uni-freiburg.de>
+// Copyright 2023 - 2026 The QLever Authors, in particular:
+//
+// 2023 - 2026 Robin Textor-Falconi <textorr@informatik.uni-freiburg.de>, UFR
+// 2026        Christoph Ullinger <ullingec@informatik.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
 
 #include <gmock/gmock.h>
 
@@ -15,6 +21,7 @@ using namespace std::chrono_literals;
 using ::testing::AllOf;
 using ::testing::HasSubstr;
 
+// _____________________________________________________________________________
 TEST(Constants, testDefaultQueryTimeoutIsStriclyPositive) {
   auto reset =
       setRuntimeParameterForTest<&RuntimeParameters::defaultQueryTimeout_>(
@@ -35,9 +42,19 @@ namespace {
 constexpr std::string_view hi = "hi";
 constexpr std::string_view bye = "-bye";
 }  // namespace
+
+// _____________________________________________________________________________
 TEST(Constants, makeQleverInternalIri) {
   EXPECT_EQ(makeQleverInternalIri("hi", "-bye"),
             (makeQleverInternalIriConst<hi, bye>()));
   EXPECT_EQ(makeQleverInternalIri(hi, bye),
             "<http://qlever.cs.uni-freiburg.de/builtin-functions/hi-bye>");
+}
+
+// _____________________________________________________________________________
+TEST(Constants, isFullTextPseudoPredicate) {
+  EXPECT_TRUE(isFullTextPseudoPredicate(CONTAINS_ENTITY_PREDICATE));
+  EXPECT_TRUE(isFullTextPseudoPredicate(CONTAINS_WORD_PREDICATE));
+  EXPECT_FALSE(
+      isFullTextPseudoPredicate("<http://example.com/normalPredicate>"));
 }


### PR DESCRIPTION
There is now a utility function `isFullTextPseudoPredicate` that checks whether a predicate is one of the full-text pseudo-predicates `ql:contains-entity` and `ql:contains-word`, which several places currently check with hand-written comparisons. Preparation for #3273.