### PR TITLE
Make `getBatch` of the parallel RDF parsers thread safe and remove the `getLine` interface

### DIFF
--- a/src/index/ConstantsIndexBuilding.h
+++ b/src/index/ConstantsIndexBuilding.h
@@ -27,7 +27,7 @@ constexpr inline int NUM_TRIPLES_PER_PARTIAL_VOCAB = 10'000'000;
 constexpr inline size_t PARSER_BATCH_SIZE = 1'000'000;
 
 // That many triples does the turtle parser have to buffer before the call to
-// getline returns (unless our input reaches EOF). This makes parsing from
+// `getBatch` returns (unless our input reaches EOF). This makes parsing from
 // streams faster.
 constexpr inline size_t PARSER_MIN_TRIPLES_AT_ONCE = 10'000;
 

--- a/src/parser/ParallelParseBuffer.h
+++ b/src/parser/ParallelParseBuffer.h
@@ -5,23 +5,11 @@
 #ifndef QLEVER_SRC_PARSER_PARALLELPARSEBUFFER_H
 #define QLEVER_SRC_PARSER_PARALLELPARSEBUFFER_H
 
-#include <array>
-#include <future>
-#include <string>
+#include <memory>
+#include <optional>
 #include <vector>
 
 #include "parser/RdfParser.h"
-#include "util/Log.h"
-
-namespace ad_utility::detail {
-
-template <typename Parser>
-CPP_requires(ParserGetBatchRequires, requires(Parser& p)(p.getBatch()));
-
-template <typename Parser>
-CPP_concept ParserGetBatch = CPP_requires_ref(ParserGetBatchRequires, Parser);
-
-}  // namespace ad_utility::detail
 
 /**
  * A wrapper to make the different Parsers interfaces compatible with the
@@ -41,33 +29,13 @@ class ParserBatcher {
       : m_parser(std::move(p)),
         m_maxNumTriples(maxNumTriples),
         m_exhaustedCallback(c) {}
-  using Triple = std::array<std::string, 3>;
 
-  /**
-   * @brief Parse the next Triple
-   * If we have already parsed the maximum number of triples specified in the
-   * constructor, return std::nullopt. If the parser is exhausted and doesn't
-   * deliver any more triples, call the callback and return std::nullopt. Else
-   * return a optional that contains the next Triple from the parser.
-   * @return
-   */
-  std::optional<TurtleTriple> operator()() {
-    if (m_numTriplesAlreadyParsed >= m_maxNumTriples) {
-      return std::nullopt;
-    }
-    TurtleTriple t;
-    if (m_parser->getLine(t)) {
-      m_numTriplesAlreadyParsed++;
-      return t;
-    } else {
-      m_exhaustedCallback();
-      return std::nullopt;
-    }
-  }
-
-  CPP_member auto getBatch()
-      -> CPP_ret(std::optional<std::vector<TurtleTriple>>)(
-          requires ad_utility::detail::ParserGetBatch<Parser>) {
+  // Parse the next batch of triples. If we have already parsed the maximum
+  // number of triples specified in the constructor, return `std::nullopt`. If
+  // the parser is exhausted and doesn't deliver any more triples, call the
+  // callback and return `std::nullopt`. Else return the next batch of triples
+  // from the parser.
+  std::optional<std::vector<TurtleTriple>> getBatch() {
     if (m_numTriplesAlreadyParsed >= m_maxNumTriples) {
       return std::nullopt;
     }
@@ -84,99 +52,6 @@ class ParserBatcher {
   size_t m_maxNumTriples;
   size_t m_numTriplesAlreadyParsed = 0;
   ExhaustedCallback m_exhaustedCallback;
-};
-
-// A class that holds a parser for a knowledge base file (.nt, .tsv, .ttl, etc)
-// and asynchronously retrieves triples from the file.
-// Can be used to parallelize the parsing and processing of kb files.
-// External interface is similar to a parser, so the usage makes the code simple
-template <class Parser>
-class ParallelParseBuffer {
- public:
-  // Parse from the file at filename.
-  // A batch of bufferSize triples is always parsed in parallel
-  // bigger bufferSizes will increase memory usage whereas smaller sizes might
-  // be inefficient.
-  ParallelParseBuffer(size_t bufferSize, const std::string& filename)
-      : _bufferSize(bufferSize), _p(filename) {
-    // parse the initial batch, before this we cannot do anything
-    std::tie(_isParserValid, _buffer) = parseBatch();
-
-    // already submit the next batch for parallel computation
-    if (_isParserValid) {
-      _fut = std::async(std::launch::async,
-                        &ParallelParseBuffer<Parser>::parseBatch, this);
-    }
-  }
-
-  // Retrieve and return a the next triple from the internal buffer.
-  // If the buffer is exhausted blocks
-  // until the (asynchronous) call to parseBatch has finished. A nullopt
-  // the parser has completely parsed the file.
-  std::optional<std::array<std::string, 3>> getTriple() {
-    // Return our triple in the order the parser handles them to us.
-    // Makes debugging easier.
-    if (_buffer.size() == _bufferPosition && _isParserValid) {
-      // we have to wait for the next parallel batch to be completed.
-      std::tie(_isParserValid, _buffer) = _fut.get();
-      _bufferPosition = 0;
-      if (_isParserValid) {
-        // if possible, directly submit the next parsing job
-        _fut = std::async(std::launch::async,
-                          &ParallelParseBuffer<Parser>::parseBatch, this);
-      }
-    }
-
-    // we now should have some triples in our buffer
-    if (_bufferPosition < _buffer.size()) {
-      return _buffer[_bufferPosition++];
-    } else {
-      // we can only reach this if the buffer is exhausted and there is nothing
-      // more to parse
-      return std::nullopt;
-    }
-  }
-
- private:
-  const size_t _bufferSize;
-  // needed for the ringbuffer-style access
-  size_t _bufferPosition = 0;
-  Parser _p;
-  // becomes false when the parser is done. In this case we still have to
-  // empty our buffer
-  bool _isParserValid = true;
-  std::vector<std::array<std::string, 3>> _buffer;
-  // this future handles the asynchronous parser calls
-  std::future<std::pair<bool, std::vector<std::array<std::string, 3>>>> _fut;
-
-  // this function extracts bufferSize_ many triples from the parser.
-  // If the bool argument is false, the parser is exhausted and further calls
-  // to parseBatch are useless. In this case we probably still have some triples
-  // that were parsed before the parser was done, so we still have to consider
-  // these.
-  std::pair<bool, std::vector<std::array<std::string, 3>>> parseBatch() {
-    AD_LOG_TRACE << "Parsing next batch in parallel" << std::endl;
-    std::vector<std::array<std::string, 3>> buf;
-    // for small knowledge bases on small systems that fit in one
-    // batch (e.g. during tests) the reserve may fail which is not bad in this
-    // case
-    try {
-      buf.reserve(_bufferSize);
-    } catch (const std::bad_alloc&) {
-      buf = std::vector<std::array<std::string, 3>>();
-    }
-    while (buf.size() < _bufferSize) {
-      buf.emplace_back();
-      if (!_p.getLine(buf.back())) {
-        buf.pop_back();
-        return {false, std::move(buf)};
-      }
-      if (buf.size() % 10000000 == 0) {
-        AD_LOG_INFO << "Parsed " << buf.size() << " triples." << std::endl;
-      }
-    }
-    return {true, std::move(buf)};
-  }
 };
 
 #endif  // QLEVER_SRC_PARSER_PARALLELPARSEBUFFER_H

--- a/src/parser/RdfParser.cpp
+++ b/src/parser/RdfParser.cpp
@@ -1280,7 +1280,10 @@ std::optional<std::vector<TurtleTriple>> RdfParallelParser<T>::getBatch() {
       // first error.
       parallelParser_.finish();
       parallelParser_.waitUntilFinished();
-      auto errors = std::move(*errorMessages_.wlock());
+      // NOTE: Copy the error messages instead of moving them. With concurrent
+      // calls to `getBatch`, the queue rethrows its exception to every caller,
+      // so every caller ends up in this catch block and has to see the errors.
+      auto errors = *errorMessages_.rlock();
       const auto& firstError =
           ql::ranges::min_element(errors, {}, ad_utility::first);
       AD_CORRECTNESS_CHECK(firstError != errors.end());

--- a/src/parser/RdfParser.cpp
+++ b/src/parser/RdfParser.cpp
@@ -1152,13 +1152,13 @@ template <typename Batch>
 void RdfParallelParser<T>::parseBatch(size_t parsePosition, Batch batch) {
   try {
     RdfStringParser<T> parser{&this->encodedIriManager(), defaultGraphIri_};
-    this->copyHeaderFrom(*this, parser);
+    parser.setHeader(header_);
     parser.useSimplifiedGrammar();
     parser.setPositionOffset(parsePosition);
     // Ensure that all sub-parsers use the same file-level blank node prefix
     // so that user-specified blank node labels (_:foo) have the same ID
     // across all batches of the same file.
-    parser.setFileBlankNodePrefix(this->fileBlankNodePrefix_);
+    parser.setFileBlankNodePrefix(fileBlankNodePrefix_);
     parser.setInputStream(std::move(batch));
     // TODO: raise error message if a prefix parsing fails;
     std::vector<TurtleTriple> triples = parser.parseAndReturnAllTriples();
@@ -1244,7 +1244,7 @@ void RdfParallelParser<T>::initialize(
       break;
     }
   }
-  this->copyHeaderFrom(std::move(declarationParser), *this);
+  header_ = declarationParser.takeHeader();
   remainingBatchFromInitialization.reserve(remainder.size());
   ql::ranges::copy(remainder,
                    std::back_inserter(remainingBatchFromInitialization));

--- a/src/parser/RdfParser.cpp
+++ b/src/parser/RdfParser.cpp
@@ -1255,7 +1255,7 @@ void RdfParallelParser<T>::initialize(
 // _____________________________________________________________________________
 template <class T>
 std::optional<std::vector<TurtleTriple>> RdfParallelParser<T>::getBatch() {
-  while (true) {
+  for (;;) {
     try {
       auto triples = tripleCollector_.pop();
       // Skip batches that contain no triples. (Theoretically this might happen,

--- a/src/parser/RdfParser.cpp
+++ b/src/parser/RdfParser.cpp
@@ -1161,11 +1161,7 @@ void RdfParallelParser<T>::parseBatch(size_t parsePosition, Batch batch) {
     parser.setFileBlankNodePrefix(fileBlankNodePrefix_);
     parser.setInputStream(std::move(batch));
     // TODO: raise error message if a prefix parsing fails;
-    std::vector<TurtleTriple> triples = parser.parseAndReturnAllTriples();
-
-    tripleCollector_.push([triples = std::move(triples), this]() mutable {
-      triples_ = std::move(triples);
-    });
+    tripleCollector_.push(parser.parseAndReturnAllTriples());
     finishTripleCollectorIfLastBatch();
   } catch (std::exception& e) {
     errorMessages_.wlock()->emplace_back(parsePosition, e.what());
@@ -1259,45 +1255,29 @@ void RdfParallelParser<T>::initialize(
 
 // _____________________________________________________________________________
 template <class T>
-bool RdfParallelParser<T>::processTriples() {
-  // If the current batch is out of triples_ get the next batch of triples.
-  // We need a while loop instead of a simple if in case there is a batch that
-  // contains no triples. (Theoretically this might happen, and it is safer this
-  // way)
-  while (triples_.empty()) {
-    auto optionalTripleTask = [&]() {
-      try {
-        return tripleCollector_.pop();
-      } catch (const std::exception&) {
-        AD_LOG_ERROR << "Error detected during parallel parsing, waiting for "
-                        "workers to finish ..."
-                     << std::endl;
-        // In case of multiple errors in parallel batches, we always report the
-        // first error.
-        parallelParser_.finish();
-        parallelParser_.waitUntilFinished();
-        auto errors = std::move(*errorMessages_.wlock());
-        const auto& firstError =
-            ql::ranges::min_element(errors, {}, ad_utility::first);
-        AD_CORRECTNESS_CHECK(firstError != errors.end());
-        throw std::runtime_error{firstError->second};
-      }
-    }();
-    if (!optionalTripleTask) {
-      // Everything has been parsed
-      return false;
-    }
-    // OptionalTripleTask fills the triples_ vector
-    (*optionalTripleTask)();
-  }
-  return true;
-}
-
-// _______________________________________________________________________
-template <class T>
 std::optional<std::vector<TurtleTriple>> RdfParallelParser<T>::getBatch() {
-  bool triplesRemaining = processTriples();
-  return triplesRemaining ? std::optional{std::move(triples_)} : std::nullopt;
+  // Skip batches that contain no triples. (Theoretically this might happen, and
+  // it is safer this way.) A `nullopt` means that everything has been parsed.
+  std::optional<std::vector<TurtleTriple>> triples;
+  do {
+    try {
+      triples = tripleCollector_.pop();
+    } catch (const std::exception&) {
+      AD_LOG_ERROR << "Error detected during parallel parsing, waiting for "
+                      "workers to finish ..."
+                   << std::endl;
+      // In case of multiple errors in parallel batches, we always report the
+      // first error.
+      parallelParser_.finish();
+      parallelParser_.waitUntilFinished();
+      auto errors = std::move(*errorMessages_.wlock());
+      const auto& firstError =
+          ql::ranges::min_element(errors, {}, ad_utility::first);
+      AD_CORRECTNESS_CHECK(firstError != errors.end());
+      throw std::runtime_error{firstError->second};
+    }
+  } while (triples.has_value() && triples.value().empty());
+  return triples;
 }
 
 // __________________________________________________________

--- a/src/parser/RdfParser.cpp
+++ b/src/parser/RdfParser.cpp
@@ -17,6 +17,7 @@
 #include <ctre-unicode.hpp>
 #include <exception>
 #include <optional>
+#include <utility>
 
 #include "backports/StartsWithAndEndsWith.h"
 #include "engine/CallFixedSize.h"
@@ -1050,92 +1051,83 @@ void RdfStreamParser<T>::initialize(const qlever::InputFileSpecification& spec,
 
 // _____________________________________________________________________________
 template <class T>
-bool RdfStreamParser<T>::getLineImpl(TurtleTriple* triple) {
-  if (triples_.empty()) {
-    // if parsing the line fails because our buffer ends before the end of
-    // the next statement we need to be able to recover
-    TurtleParserBackupState b = backupState();
-    // always try to parse a batch of triples at once to make up for the
-    // relatively expensive backup calls.
-    while (triples_.size() < PARSER_MIN_TRIPLES_AT_ONCE &&
-           !isParserExhausted_) {
-      bool parsedStatement;
-      std::optional<ParseException> ex;
-      // If this buffer reads from a memory-mapped file, then exceptions are
-      // immediately rethrown. If we are reading from a stream in chunks of
-      // bytes, we can try again with a larger buffer.
-      try {
-        parsedStatement = T::statement();
-      } catch (const typename T::ParseException& p) {
-        parsedStatement = false;
-        ex = p;
-      }
+std::optional<std::vector<TurtleTriple>> RdfStreamParser<T>::getBatch() {
+  // If parsing a statement fails because our buffer ends before the end of
+  // that statement, we need to be able to recover.
+  TurtleParserBackupState b = backupState();
+  // Always parse a batch of triples at once to make up for the relatively
+  // expensive backup calls.
+  while (triples_.size() < PARSER_MIN_TRIPLES_AT_ONCE && !isParserExhausted_) {
+    bool parsedStatement;
+    std::optional<ParseException> ex;
+    // If this buffer reads from a memory-mapped file, then exceptions are
+    // immediately rethrown. If we are reading from a stream in chunks of
+    // bytes, we can try again with a larger buffer.
+    try {
+      parsedStatement = T::statement();
+    } catch (const typename T::ParseException& p) {
+      parsedStatement = false;
+      ex = p;
+    }
 
-      if (!parsedStatement) {
-        // we read chunks of memories in a buffered way
-        // try to parse with a larger buffer and repeat the reading process
-        // (maybe the failure was due to statements crossing our block).
-        if (resetStateAndRead(&b)) {
-          // we have successfully extended our buffer
-          if (byteVec_.size() > RDF_PARSER_MAX_TOTAL_BUFFER_SIZE().getBytes()) {
-            std::string_view unparsed = tok_.view();
-            AD_LOG_ERROR << "Could not parse " << PARSER_MIN_TRIPLES_AT_ONCE
-                         << " Within " << RDF_PARSER_MAX_TOTAL_BUFFER_SIZE()
-                         << " of Turtle input\n";
-            AD_LOG_ERROR << "If you really have Turtle input with such a "
-                            "long structure please recompile with adjusted "
-                            "constants in ConstantsIndexCreation.h or "
-                            "decompress your file and "
-                            "use --file-format mmap\n";
-            AD_LOG_INFO << "Logging first 1000 unparsed characters\n";
-            AD_LOG_INFO << unparsed.substr(0, 1000) << std::endl;
-            if (ex.has_value()) {
-              throw ex.value();
-            } else {
-              this->raise(
-                  "Too many bytes parsed without finishing a turtle "
-                  "statement");
-            }
-          }
-          // we have reset our state to a safe position and now have more
-          // bytes to try, so just go to the next iterations
-          continue;
-        } else {
-          // there are no more bytes in the buffer
+    if (!parsedStatement) {
+      // we read chunks of memories in a buffered way
+      // try to parse with a larger buffer and repeat the reading process
+      // (maybe the failure was due to statements crossing our block).
+      if (resetStateAndRead(&b)) {
+        // we have successfully extended our buffer
+        if (byteVec_.size() > RDF_PARSER_MAX_TOTAL_BUFFER_SIZE().getBytes()) {
+          std::string_view unparsed = tok_.view();
+          AD_LOG_ERROR << "Could not parse " << PARSER_MIN_TRIPLES_AT_ONCE
+                       << " Within " << RDF_PARSER_MAX_TOTAL_BUFFER_SIZE()
+                       << " of Turtle input\n";
+          AD_LOG_ERROR << "If you really have Turtle input with such a "
+                          "long structure please recompile with adjusted "
+                          "constants in ConstantsIndexCreation.h or "
+                          "decompress your file and "
+                          "use --file-format mmap\n";
+          AD_LOG_INFO << "Logging first 1000 unparsed characters\n";
+          AD_LOG_INFO << unparsed.substr(0, 1000) << std::endl;
           if (ex.has_value()) {
             throw ex.value();
           } else {
-            // we are at the end of an input stream without an exception
-            // the input is exhausted, but we still may retrieve
-            // triples parsed so far, check if we have indeed parsed through
-            // the complete input
-            tok_.skipWhitespaceAndComments();
-            std::string_view unparsed = tok_.view();
-            if (!unparsed.empty()) {
-              AD_LOG_INFO
-                  << "Parsing of line has Failed, but parseInput is not "
-                     "yet exhausted. Remaining bytes: "
-                  << unparsed.size() << '\n';
-              AD_LOG_INFO << "Logging first 1000 unparsed characters\n";
-              AD_LOG_INFO << unparsed.substr(0, 1000) << std::endl;
-            }
-            isParserExhausted_ = true;
-            break;
+            this->raise(
+                "Too many bytes parsed without finishing a turtle "
+                "statement");
           }
+        }
+        // we have reset our state to a safe position and now have more
+        // bytes to try, so just go to the next iterations
+        continue;
+      } else {
+        // there are no more bytes in the buffer
+        if (ex.has_value()) {
+          throw ex.value();
+        } else {
+          // we are at the end of an input stream without an exception
+          // the input is exhausted, but we still may retrieve
+          // triples parsed so far, check if we have indeed parsed through
+          // the complete input
+          tok_.skipWhitespaceAndComments();
+          std::string_view unparsed = tok_.view();
+          if (!unparsed.empty()) {
+            AD_LOG_INFO << "Parsing of line has Failed, but parseInput is not "
+                           "yet exhausted. Remaining bytes: "
+                        << unparsed.size() << '\n';
+            AD_LOG_INFO << "Logging first 1000 unparsed characters\n";
+            AD_LOG_INFO << unparsed.substr(0, 1000) << std::endl;
+          }
+          isParserExhausted_ = true;
+          break;
         }
       }
     }
   }
 
-  // if we have a triple now we can return it, else we are done parsing.
   if (triples_.empty()) {
-    return false;
+    return std::nullopt;
   }
-
-  // we now have at least one triple, return it.
-  *triple = triples_.back();
-  triples_.pop_back();
-  return true;
+  return std::exchange(triples_, {});
 }
 
 // We will use the  following trick: For a batch that is forwarded to the
@@ -1303,18 +1295,6 @@ bool RdfParallelParser<T>::processTriples() {
 
 // _______________________________________________________________________
 template <class T>
-bool RdfParallelParser<T>::getLineImpl(TurtleTriple* triple) {
-  bool triplesRemaining = processTriples();
-  if (triplesRemaining) {
-    // we now have at least one triple, return it.
-    *triple = std::move(triples_.back());
-    triples_.pop_back();
-  }
-  return triplesRemaining;
-}
-
-// _______________________________________________________________________
-template <class T>
 std::optional<std::vector<TurtleTriple>> RdfParallelParser<T>::getBatch() {
   bool triplesRemaining = processTriples();
   return triplesRemaining ? std::optional{std::move(triples_)} : std::nullopt;
@@ -1367,24 +1347,6 @@ static std::unique_ptr<RdfParserBase> makeSingleRdfParser(
       std::array{input.parseInParallel_ ? 1 : 0,
                  input.filetype_ == qlever::Filetype::Turtle ? 1 : 0},
       makeRdfParserImpl);
-}
-
-// _____________________________________________________________________________
-std::optional<std::vector<TurtleTriple>> RdfParserBase::getBatch() {
-  std::vector<TurtleTriple> result;
-  result.reserve(100'000);
-  for (size_t i = 0; i < 100'000; ++i) {
-    result.emplace_back();
-    bool success = getLine(result.back());
-    if (!success) {
-      result.resize(result.size() - 1);
-      break;
-    }
-  }
-  if (result.empty()) {
-    return std::nullopt;
-  }
-  return result;
 }
 
 // _____________________________________________________________________________
@@ -1447,9 +1409,6 @@ RdfMultifileParser::~RdfMultifileParser() {
       },
       "During the destruction of an RdfMultifileParser");
 }
-
-//______________________________________________________________________________
-bool RdfMultifileParser::getLineImpl(TurtleTriple*) { AD_FAIL(); }
 
 // _____________________________________________________________________________
 std::optional<std::vector<TurtleTriple>> RdfMultifileParser::getBatch() {

--- a/src/parser/RdfParser.cpp
+++ b/src/parser/RdfParser.cpp
@@ -74,8 +74,7 @@ void TurtleParser<Tokenizer_T>::clear() {
   activePredicate_ = TripleComponent::Iri::fromIriref("<>");
   activePrefix_.clear();
 
-  prefixMap_ = {};
-  baseIri_.reset();
+  header_ = {};
 
   tok_.reset(nullptr, 0);
   triples_.clear();
@@ -651,10 +650,10 @@ template <class Tokenizer_T>
 void TurtleParser<Tokenizer_T>::setPrefixOrThrow(
     const std::string& key, const ad_utility::triple_component::Iri& prefix) {
   if (useSimplifiedGrammar_ &&
-      (!prefixMap_.contains(key) || prefixMap_[key] != prefix)) {
+      (!prefixMap().contains(key) || prefixMap()[key] != prefix)) {
     raiseDisallowedPrefixOrBaseError();
   }
-  prefixMap_[key] = prefix;
+  prefixMap()[key] = prefix;
 }
 
 // _____________________________________________________________________________
@@ -663,10 +662,10 @@ void TurtleParser<Tokenizer_T>::setBaseIriOrThrow(
     const ad_utility::triple_component::Iri& iri) {
   qlever::util::ParsedUri uri{asStringViewUnsafe(iri.getContent())};
   if (useSimplifiedGrammar_ &&
-      (!baseIri_.has_value() || baseIri_.value() != uri)) {
+      (!baseIri().has_value() || baseIri().value() != uri)) {
     raiseDisallowedPrefixOrBaseError();
   }
-  baseIri_ = std::move(uri);
+  baseIri() = std::move(uri);
 }
 
 // ______________________________________________________________________
@@ -837,12 +836,12 @@ bool TurtleParser<Tokenizer_T>::check(bool result) const {
 template <class Tokenizer_T>
 TripleComponent::Iri TurtleParser<Tokenizer_T>::expandPrefix(
     const std::string& prefix) {
-  if (!prefixMap_.count(prefix)) {
+  if (!prefixMap().count(prefix)) {
     raise("Prefix " + prefix +
           " was not previously defined using a PREFIX or @prefix "
           "declaration");
   } else {
-    return prefixMap_[prefix];
+    return prefixMap()[prefix];
   }
 }
 
@@ -944,9 +943,9 @@ bool TurtleParser<T>::iriref() {
   }
 
   auto resolveIri = [this](std::string_view iri) {
-    if (baseIri_.has_value()) {
+    if (baseIri().has_value()) {
       lastParseResult_ =
-          TripleComponent::Iri::fromIrirefConsiderBase(iri, baseIri_.value());
+          TripleComponent::Iri::fromIrirefConsiderBase(iri, baseIri().value());
     } else {
       lastParseResult_ = TripleComponent::Iri::fromIriref(iri);
     }
@@ -1152,7 +1151,7 @@ template <typename Batch>
 void RdfParallelParser<T>::parseBatch(size_t parsePosition, Batch batch) {
   try {
     RdfStringParser<T> parser{&this->encodedIriManager(), defaultGraphIri_};
-    parser.setHeader(header_);
+    parser.header() = header_;
     parser.useSimplifiedGrammar();
     parser.setPositionOffset(parsePosition);
     // Ensure that all sub-parsers use the same file-level blank node prefix
@@ -1240,7 +1239,7 @@ void RdfParallelParser<T>::initialize(
       break;
     }
   }
-  header_ = declarationParser.takeHeader();
+  header_ = std::move(declarationParser.header());
   remainingBatchFromInitialization.reserve(remainder.size());
   ql::ranges::copy(remainder,
                    std::back_inserter(remainingBatchFromInitialization));
@@ -1256,12 +1255,16 @@ void RdfParallelParser<T>::initialize(
 // _____________________________________________________________________________
 template <class T>
 std::optional<std::vector<TurtleTriple>> RdfParallelParser<T>::getBatch() {
-  // Skip batches that contain no triples. (Theoretically this might happen, and
-  // it is safer this way.) A `nullopt` means that everything has been parsed.
-  std::optional<std::vector<TurtleTriple>> triples;
-  do {
+  while (true) {
     try {
-      triples = tripleCollector_.pop();
+      auto triples = tripleCollector_.pop();
+      // Skip batches that contain no triples. (Theoretically this might happen,
+      // and it is safer this way.) A `nullopt` means that everything has been
+      // parsed.
+      if (triples.has_value() && triples.value().empty()) {
+        continue;
+      }
+      return triples;
     } catch (const std::exception&) {
       AD_LOG_ERROR << "Error detected during parallel parsing, waiting for "
                       "workers to finish ..."
@@ -1276,8 +1279,7 @@ std::optional<std::vector<TurtleTriple>> RdfParallelParser<T>::getBatch() {
       AD_CORRECTNESS_CHECK(firstError != errors.end());
       throw std::runtime_error{firstError->second};
     }
-  } while (triples.has_value() && triples.value().empty());
-  return triples;
+  }
 }
 
 // __________________________________________________________

--- a/src/parser/RdfParser.h
+++ b/src/parser/RdfParser.h
@@ -85,8 +85,6 @@ class RdfParserBase {
 
   explicit RdfParserBase(const EncodedIriManager* encodedIriManager)
       : encodedIriManager_{encodedIriManager} {}
-  // Wrapper to getLine that is expected by the rest of QLever
-  bool getLine(TurtleTriple& triple) { return getLineImpl(&triple); }
 
   virtual TurtleParserIntegerOverflowBehavior& integerOverflowBehavior() final {
     return integerOverflowBehavior_;
@@ -104,20 +102,13 @@ class RdfParserBase {
     // overridden).
   }
 
-  // Main access method to the parser
-  // If a triple can be parsed (or has previously been parsed and stored
-  // Writes the triple to the argument (format subject, object predicate)
-  // returns true iff a triple can be successfully written, else the triple
-  // value is invalid and the parser is at the end of the input.
-  virtual bool getLineImpl(TurtleTriple* triple) = 0;
-
   // Get the offset (relative to the beginning of the file) of the first byte
   // that has not yet been dealt with by the parser.
   [[nodiscard]] virtual size_t getParsePosition() const = 0;
 
-  // Return a batch of the next 100'000 triples at once. If the parser is
-  // exhausted, return `nullopt`.
-  virtual std::optional<std::vector<TurtleTriple>> getBatch();
+  // Main access method to the parser. Return the next batch of triples, or
+  // `nullopt` if the parser is exhausted.
+  virtual std::optional<std::vector<TurtleTriple>> getBatch() = 0;
 
  protected:
   const auto& encodedIriManager() const { return *encodedIriManager_; }
@@ -441,17 +432,15 @@ CPP_template(typename Parser)(requires ql::concepts::derived_from<
     : public Parser {
  public:
   using Parser::baseIri_;
-  using Parser::getLine;
   using Parser::prefixMap_;
   explicit RdfStringParser(const EncodedIriManager* encodedIriManager)
       : Parser{encodedIriManager} {}
   explicit RdfStringParser(const EncodedIriManager* encodedIriManager,
                            TripleComponent defaultGraph)
       : Parser{encodedIriManager, std::move(defaultGraph)} {}
-  bool getLineImpl(TurtleTriple* triple) override {
-    (void)triple;
+  std::optional<std::vector<TurtleTriple>> getBatch() override {
     throw std::runtime_error(
-        "RdfStringParser doesn't support calls to getLine. Only use "
+        "RdfStringParser doesn't support calls to getBatch. Only use "
         "parseUtf8String() for unit tests\n");
   }
 
@@ -590,7 +579,9 @@ class RdfStreamParser : public Parser {
     initialize(spec, blocksize);
   }
 
-  bool getLineImpl(TurtleTriple* triple) override;
+  // Return the triples that were parsed since the last call, at most
+  // `PARSER_MIN_TRIPLES_AT_ONCE` of them.
+  std::optional<std::vector<TurtleTriple>> getBatch() override;
 
   void initialize(const qlever::InputFileSpecification& spec,
                   ad_utility::MemorySize blocksize);
@@ -603,6 +594,7 @@ class RdfStreamParser : public Parser {
   using Parser::isParserExhausted_;
   using Parser::tok_;
   using Parser::triples_;
+
   // Backup the current state of the turtle parser to a
   // `TurtleParserBackupState` object. This can be used e.g. when parsing from
   // a compressed input and the currently uncompressed buffer is not sufficient
@@ -654,11 +646,6 @@ class RdfParallelParser : public Parser {
     initialize(spec, blocksize);
   }
 
-  // inherit the wrapper overload
-  using Parser::getLine;
-
-  bool getLineImpl(TurtleTriple* triple) override;
-
   std::optional<std::vector<TurtleTriple>> getBatch() override;
 
   void printAndResetQueueStatistics() override {
@@ -694,9 +681,8 @@ class RdfParallelParser : public Parser {
   template <typename Batch>
   void feedBatchesToParser(Batch remainingBatchFromInitialization);
 
-  // Helper function used by `getBatch()` and `getLimeImpl()` to abstract away
-  // common code. Return true if some triples could be collected and false if
-  // the input has been fully consumed.
+  // Wait until `triples_` contains at least one triple. Return true if some
+  // triples could be collected and false if the input has been fully consumed.
   bool processTriples();
 
   using Parser::isParserExhausted_;
@@ -746,10 +732,6 @@ class RdfMultifileParser : public RdfParserBase {
       ad_utility::InputRangeTypeErased<qlever::InputFileSpecification> files,
       const EncodedIriManager* encodedIriManager,
       ad_utility::MemorySize bufferSize = DEFAULT_PARSER_BUFFER_SIZE);
-
-  // This function is needed for the interface, but always throws an exception.
-  // `getBatch` (below) has to be used instead.
-  bool getLineImpl(TurtleTriple* triple) override;
 
   // Retrieve the next batch of triples, or `nullopt` if there are no more
   // batches. There is no guarantee about the order in which batches from

--- a/src/parser/RdfParser.h
+++ b/src/parser/RdfParser.h
@@ -114,6 +114,14 @@ class RdfParserBase {
   const auto& encodedIriManager() const { return *encodedIriManager_; }
 };
 
+// The "header" of an RDF file: the prefixes and the base IRI that are declared
+// at its beginning. The parallel parser parses this once up front and then
+// transfers it to each of the workers that parse the actual triples.
+struct RdfParserHeader {
+  ad_utility::HashMap<std::string, TripleComponent::Iri> prefixMap_;
+  std::optional<qlever::util::ParsedUri> baseIri_;
+};
+
 /**
  * @brief The actual parser class
  *
@@ -231,14 +239,6 @@ class TurtleParser : public RdfParserBase {
   // grammar that can be parsed in parallel. This disallows re-definitions of
   // @base and @prefix as well as usage of multiline literals.
   bool useSimplifiedGrammar_ = false;
-
-  // Unified interface to copy/move data that has been collected by the parallel
-  // parser before sharding out to parallel worker threads.
-  template <typename Source, typename Target>
-  static void copyHeaderFrom(Source&& source, Target& target) {
-    target.prefixMap_ = AD_FWD(source).prefixMap_;
-    target.baseIri_ = AD_FWD(source).baseIri_;
-  }
 
  public:
   explicit TurtleParser(const EncodedIriManager* encodedIriManager)
@@ -375,6 +375,24 @@ class TurtleParser : public RdfParserBase {
   // to ensure that user-specified blank node labels have the same ID across
   // all sub-parsers of the same file.
   void setFileBlankNodePrefix(size_t id) { fileBlankNodePrefix_ = id; }
+
+  // Draw the next blank node prefix. Every parser instance implicitly draws one
+  // of these, the parallel parser additionally draws the prefix that it shares
+  // with all of its sub-parsers (see `setFileBlankNodePrefix`).
+  static size_t nextBlankNodePrefix() { return numParsers_.fetch_add(1); }
+
+  // Move the header (see `RdfParserHeader`) out of this parser. The parser must
+  // not be used for further parsing afterwards.
+  RdfParserHeader takeHeader() {
+    return {std::move(prefixMap_), std::move(baseIri_)};
+  }
+
+  // Set the header (see `RdfParserHeader`) of this parser. Used by the parallel
+  // parser to set up its worker parsers.
+  void setHeader(const RdfParserHeader& header) {
+    prefixMap_ = header.prefixMap_;
+    baseIri_ = header.baseIri_;
+  }
 
  protected:
   FRIEND_TEST(RdfParserTest, prefixedName);
@@ -619,16 +637,18 @@ class RdfStreamParser : public Parser {
 };
 
 /**
- * This class is a TurtleParser that always assumes that
- * its input file is an uncompressed .ttl file that will be read in
- * chunks. Input file can also be a stream like stdin.
+ * This class parses an uncompressed .ttl file (which can also be a stream like
+ * stdin) by reading it in chunks and handing each of those chunks to one of
+ * several worker parsers of type `RdfStringParser<Parser>` that run in
+ * parallel. It does not parse anything itself, it only owns the state that its
+ * workers need (see `RdfParserHeader` and `fileBlankNodePrefix_`) and collects
+ * their results.
  */
 template <typename Parser>
-class RdfParallelParser : public Parser {
+class RdfParallelParser : public RdfParserBase {
  public:
-  using Triple = std::array<std::string, 3>;
   // Default construction needed for tests
-  explicit RdfParallelParser(const EncodedIriManager* ev) : Parser{ev} {}
+  explicit RdfParallelParser(const EncodedIriManager* ev) : RdfParserBase{ev} {}
 
   // Construct a parser that reads from an `InputFileSpecification`. The parser
   // creates its own I/O thread and `AsyncBlockSource` internally. The
@@ -640,7 +660,7 @@ class RdfParallelParser : public Parser {
                         qlever::specialIds().at(DEFAULT_GRAPH_IRI),
                     std::chrono::milliseconds sleepTimeForTesting =
                         std::chrono::milliseconds{0})
-      : Parser{ev, defaultGraphIri},
+      : RdfParserBase{ev},
         defaultGraphIri_{defaultGraphIri},
         sleepTimeForTesting_(sleepTimeForTesting) {
     initialize(spec, blocksize);
@@ -685,9 +705,16 @@ class RdfParallelParser : public Parser {
   // triples could be collected and false if the input has been fully consumed.
   bool processTriples();
 
-  using Parser::isParserExhausted_;
-  using Parser::tok_;
-  using Parser::triples_;
+  // The triples of the batch that is currently being handed out by `getBatch`.
+  std::vector<TurtleTriple> triples_;
+
+  // The header of the input file, parsed once by `initialize` and then set on
+  // each of the worker parsers.
+  RdfParserHeader header_;
+
+  // The blank node prefix that all the workers for this file share, such that
+  // user-specified blank node labels get the same ID across batches.
+  size_t fileBlankNodePrefix_ = Parser::nextBlankNodePrefix();
 
   // Initialized in the call to `initialize`.
   std::optional<qlever::parser::AsyncFileBlockDriver> driver_;

--- a/src/parser/RdfParser.h
+++ b/src/parser/RdfParser.h
@@ -221,16 +221,7 @@ class TurtleParser : public RdfParserBase {
     return header_.prefixMap_;
   }
 
-  const ad_utility::HashMap<std::string, TripleComponent::Iri>& prefixMap()
-      const {
-    return header_.prefixMap_;
-  }
-
   std::optional<qlever::util::ParsedUri>& baseIri() { return header_.baseIri_; }
-
-  const std::optional<qlever::util::ParsedUri>& baseIri() const {
-    return header_.baseIri_;
-  }
 
   // There are turtle constructs that reuse prefixes, subjects and predicates
   // so we have to save the last seen ones.
@@ -398,11 +389,9 @@ class TurtleParser : public RdfParserBase {
   // with all of its sub-parsers (see `setFileBlankNodePrefix`).
   static size_t nextBlankNodePrefix() { return numParsers_.fetch_add(1); }
 
-  // Access the header (see `RdfParserHeader`) of this parser. The mutable
-  // overload is used by the parallel parser to set up its worker parsers.
+  // Access the header (see `RdfParserHeader`) of this parser. This is used
+  // by the parallel parser to set up its worker parsers.
   RdfParserHeader& header() { return header_; }
-
-  const RdfParserHeader& header() const { return header_; }
 
  protected:
   FRIEND_TEST(RdfParserTest, prefixedName);
@@ -657,9 +646,6 @@ class RdfStreamParser : public Parser {
 template <typename Parser>
 class RdfParallelParser : public RdfParserBase {
  public:
-  // Default construction needed for tests
-  explicit RdfParallelParser(const EncodedIriManager* ev) : RdfParserBase{ev} {}
-
   // Construct a parser that reads from an `InputFileSpecification`. The parser
   // creates its own I/O thread and `AsyncBlockSource` internally. The
   // `blocksize` parameter controls the size of the underlying I/O block buffer.

--- a/src/parser/RdfParser.h
+++ b/src/parser/RdfParser.h
@@ -212,8 +212,25 @@ class TurtleParser : public RdfParserBase {
   // `TripleComponent` since it can hold any parsing result, not only objects.
   TripleComponent lastParseResult_;
 
-  ad_utility::HashMap<std::string, TripleComponent::Iri> prefixMap_;
-  std::optional<qlever::util::ParsedUri> baseIri_;
+  // The prefixes and the base IRI that were declared in the input (see
+  // `RdfParserHeader`).
+  RdfParserHeader header_;
+
+  // Access the prefixes and the base IRI that are stored in the header.
+  ad_utility::HashMap<std::string, TripleComponent::Iri>& prefixMap() {
+    return header_.prefixMap_;
+  }
+
+  const ad_utility::HashMap<std::string, TripleComponent::Iri>& prefixMap()
+      const {
+    return header_.prefixMap_;
+  }
+
+  std::optional<qlever::util::ParsedUri>& baseIri() { return header_.baseIri_; }
+
+  const std::optional<qlever::util::ParsedUri>& baseIri() const {
+    return header_.baseIri_;
+  }
 
   // There are turtle constructs that reuse prefixes, subjects and predicates
   // so we have to save the last seen ones.
@@ -381,18 +398,11 @@ class TurtleParser : public RdfParserBase {
   // with all of its sub-parsers (see `setFileBlankNodePrefix`).
   static size_t nextBlankNodePrefix() { return numParsers_.fetch_add(1); }
 
-  // Move the header (see `RdfParserHeader`) out of this parser. The parser must
-  // not be used for further parsing afterwards.
-  RdfParserHeader takeHeader() {
-    return {std::move(prefixMap_), std::move(baseIri_)};
-  }
+  // Access the header (see `RdfParserHeader`) of this parser. The mutable
+  // overload is used by the parallel parser to set up its worker parsers.
+  RdfParserHeader& header() { return header_; }
 
-  // Set the header (see `RdfParserHeader`) of this parser. Used by the parallel
-  // parser to set up its worker parsers.
-  void setHeader(const RdfParserHeader& header) {
-    prefixMap_ = header.prefixMap_;
-    baseIri_ = header.baseIri_;
-  }
+  const RdfParserHeader& header() const { return header_; }
 
  protected:
   FRIEND_TEST(RdfParserTest, prefixedName);
@@ -449,8 +459,8 @@ CPP_template(typename Parser)(requires ql::concepts::derived_from<
                               Parser, RdfParserBase>) class RdfStringParser
     : public Parser {
  public:
-  using Parser::baseIri_;
-  using Parser::prefixMap_;
+  using Parser::baseIri;
+  using Parser::prefixMap;
   explicit RdfStringParser(const EncodedIriManager* encodedIriManager)
       : Parser{encodedIriManager} {}
   explicit RdfStringParser(const EncodedIriManager* encodedIriManager,
@@ -528,10 +538,6 @@ CPP_template(typename Parser)(requires ql::concepts::derived_from<
     tmpToParse_.insert(tmpToParse_.end(), toParse.begin(), toParse.end());
     this->tok_.reset(tmpToParse_.data(), tmpToParse_.size());
   }
-
-  const auto& getPrefixMap() const { return prefixMap_; }
-
-  const auto& getBaseIri() const { return baseIri_; }
 
   // __________________________________________________________
   void setInputStream(qlever::parser::ByteBlock&& toParse) {
@@ -636,14 +642,18 @@ class RdfStreamParser : public Parser {
   std::optional<qlever::parser::AsyncFileBlockDriver> driver_;
 };
 
-/**
- * This class parses an uncompressed .ttl file (which can also be a stream like
- * stdin) by reading it in chunks and handing each of those chunks to one of
- * several worker parsers of type `RdfStringParser<Parser>` that run in
- * parallel. It does not parse anything itself, it only owns the state that its
- * workers need (see `RdfParserHeader` and `fileBlankNodePrefix_`) and collects
- * their results.
- */
+// This class parses an uncompressed file (which can also be a stream like
+// stdin) in parallel. It parses the header (see `RdfParserHeader`) itself, then
+// splits the rest of the input into blocks at statement boundaries (see
+// `detail::findEndOfLastStatement`) and lets several worker parsers of type
+// `RdfStringParser<Parser>` parse those blocks in parallel. Apart from the
+// header it parses nothing itself, it only owns the state that the workers
+// share (the header and `fileBlankNodePrefix_`) and collects their results, in
+// no particular order. Because the workers see neither the other blocks nor the
+// order in which they are parsed, `@base` and `@prefix` may only be declared in
+// the header, and multiline literals are disallowed (a `.` followed by a
+// newline inside such a literal would be mistaken for a statement boundary).
+// The workers enforce this, see `TurtleParser::useSimplifiedGrammar_`.
 template <typename Parser>
 class RdfParallelParser : public RdfParserBase {
  public:

--- a/src/parser/RdfParser.h
+++ b/src/parser/RdfParser.h
@@ -701,13 +701,6 @@ class RdfParallelParser : public RdfParserBase {
   template <typename Batch>
   void feedBatchesToParser(Batch remainingBatchFromInitialization);
 
-  // Wait until `triples_` contains at least one triple. Return true if some
-  // triples could be collected and false if the input has been fully consumed.
-  bool processTriples();
-
-  // The triples of the batch that is currently being handed out by `getBatch`.
-  std::vector<TurtleTriple> triples_;
-
   // The header of the input file, parsed once by `initialize` and then set on
   // each of the worker parsers.
   RdfParserHeader header_;
@@ -737,7 +730,7 @@ class RdfParallelParser : public RdfParserBase {
   // These datastructures are ordered last, such that in the destructor all
   // threads are joined before the other data members (which might be accessed
   // by those threads) are destroyed.
-  ad_utility::data_structures::ThreadSafeQueue<std::function<void()>>
+  ad_utility::data_structures::ThreadSafeQueue<std::vector<TurtleTriple>>
       tripleCollector_{QUEUE_SIZE_AFTER_PARALLEL_PARSING};
   ad_utility::TaskQueue<true> parallelParser_{
       QUEUE_SIZE_BEFORE_PARALLEL_PARSING, NUM_PARALLEL_PARSER_THREADS,

--- a/test/RdfParserTest.cpp
+++ b/test/RdfParserTest.cpp
@@ -1746,7 +1746,7 @@ TEST(RdfParserTest, getBatchRaisesOnTooLargeBufferWithoutPendingException) {
 // triples and then mark itself exhausted while logging the remainder.
 TEST(RdfParserTest, getBatchLogsRemainingUnparsedBytesWhenInputExhausted) {
   using Parser = RdfStreamParser<TurtleParser<Tokenizer>>;
-  std::string filename{"rdfParserGetLineLogsRemainingUnparsedBytes.dat"};
+  std::string filename{absl::StrCat(gtestCurrentTestName(), ".dat")};
   std::string trailingGarbage =
       "@@@invalid trailing bytes that cannot be parsed@@@";
   {

--- a/test/RdfParserTest.cpp
+++ b/test/RdfParserTest.cpp
@@ -113,7 +113,7 @@ std::ostream& operator<<(std::ostream& os, const TurtleTriple& tr) {
 }
 TEST(RdfParserTest, prefixedName) {
   auto runCommonTests = [](auto& parser) {
-    parser.prefixMap_["wd"] = iri("<www.wikidata.org/>");
+    parser.prefixMap()["wd"] = iri("<www.wikidata.org/>");
     parser.setInputStream("wd:Q430 someotherContent");
     ASSERT_TRUE(parser.prefixedName());
     ASSERT_EQ(parser.lastParseResult_, iri("<www.wikidata.org/Q430>"));
@@ -181,12 +181,12 @@ TEST(RdfParserTest, prefixedName) {
 TEST(RdfParserTest, prefixID) {
   auto runCommonTests = [](const auto& checker) {
     auto p = checker("@prefix bla:<www.bla.org/> .");
-    ASSERT_EQ(p.prefixMap_["bla"], iri("<www.bla.org/>"));
+    ASSERT_EQ(p.prefixMap()["bla"], iri("<www.bla.org/>"));
 
     // different spaces that don't change meaning
     std::string s;
     p = checker("@prefix bla: <www.bla.org/>.");
-    ASSERT_EQ(p.prefixMap_["bla"], iri("<www.bla.org/>"));
+    ASSERT_EQ(p.prefixMap()["bla"], iri("<www.bla.org/>"));
 
     // invalid LL1
     ASSERT_THROW(checker("@prefix bla<www.bla.org/>."),
@@ -285,7 +285,7 @@ TEST(RdfParserTest, rdfLiteral) {
   testLiteral(R"("-INF"^^)"s + "<" + XSD_DOUBLE_TYPE + ">", isNegativeInfinity);
 
   auto runCommonTests = [](auto p) {
-    p.prefixMap_["doof"] = iri("<www.doof.org/>");
+    p.prefixMap()["doof"] = iri("<www.doof.org/>");
 
     string s("\"valuePrefixed\"^^doof:sometype");
     p.setInputStream(s);
@@ -418,7 +418,7 @@ TEST(RdfParserTest, base) {
   auto testForGivenParser = [](auto parser) {
     parser.setInputStream("@base <http://www.example.org/path/> .");
     ASSERT_TRUE(parser.base());
-    ASSERT_EQ(TripleComponent::Iri::fromUri(parser.baseIri_.value())
+    ASSERT_EQ(TripleComponent::Iri::fromUri(parser.baseIri().value())
                   .toStringRepresentation(),
               "<http://www.example.org/path/>");
     parser.setInputStream("@base \"no iriref\" .");
@@ -432,7 +432,7 @@ TEST(RdfParserTest, sparqlBase) {
   auto testForGivenParser = [](auto parser) {
     parser.setInputStream("BASE <http://www.example.org/path/> .");
     ASSERT_TRUE(parser.sparqlBase());
-    ASSERT_EQ(TripleComponent::Iri::fromUri(parser.baseIri_.value())
+    ASSERT_EQ(TripleComponent::Iri::fromUri(parser.baseIri().value())
                   .toStringRepresentation(),
               "<http://www.example.org/path/>");
     parser.setInputStream("BASE \"no iriref\" .");
@@ -449,7 +449,7 @@ TEST(RdfParserTest, object) {
     auto pred = iri("<pred>");
     p.activeSubject_ = sub;
     p.activePredicate_ = pred;
-    p.prefixMap_["b"] = iri("<bla/>");
+    p.prefixMap()["b"] = iri("<bla/>");
     string input = " b:input";
     p.setInputStream(input);
     ASSERT_TRUE(p.object());
@@ -574,7 +574,7 @@ TEST(RdfParserTest, numericLiteralErrorBehavior) {
           "<a> <b> \"kartoffelsalat\"^^xsd:double",
           "<a> <b> \"123kartoffel\"^^xsd:decimal"};
       Parser parser{encodedIriManager()};
-      parser.prefixMap_["xsd"] = iri("<http://www.w3.org/2001/XMLSchema#>");
+      parser.prefixMap()["xsd"] = iri("<http://www.w3.org/2001/XMLSchema#>");
       for (const auto& input : inputs) {
         assertParsingFails(parser, input);
       }
@@ -592,7 +592,7 @@ TEST(RdfParserTest, numericLiteralErrorBehavior) {
           9999999999999999999999.0, 99999999999999999999E4,
           99999999999999999999E4};
       Parser parser{encodedIriManager()};
-      parser.prefixMap_["xsd"] = iri("<http://www.w3.org/2001/XMLSchema#>");
+      parser.prefixMap()["xsd"] = iri("<http://www.w3.org/2001/XMLSchema#>");
       testTripleObjects(parser, inputs, expectedObjects);
     }
     {
@@ -605,7 +605,7 @@ TEST(RdfParserTest, numericLiteralErrorBehavior) {
           "<a> <b> \"kartoffelsalat\"^^xsd:integer",
           "<a> <b> \"123kartoffel\"^^xsd:integer"};
       Parser parser{encodedIriManager()};
-      parser.prefixMap_["xsd"] = iri("<http://www.w3.org/2001/XMLSchema#>");
+      parser.prefixMap()["xsd"] = iri("<http://www.w3.org/2001/XMLSchema#>");
       parser.integerOverflowBehavior() =
           TurtleParserIntegerOverflowBehavior::OverflowingToDouble;
       for (const auto& input : nonWorkingInputs) {
@@ -625,7 +625,7 @@ TEST(RdfParserTest, numericLiteralErrorBehavior) {
           "<a> <b> \"kartoffelsalat\"^^xsd:integer",
           "<a> <b> \"123kartoffel\"^^xsd:integer"};
       Parser parser{encodedIriManager()};
-      parser.prefixMap_["xsd"] = iri("<http://www.w3.org/2001/XMLSchema#>");
+      parser.prefixMap()["xsd"] = iri("<http://www.w3.org/2001/XMLSchema#>");
       parser.integerOverflowBehavior() =
           TurtleParserIntegerOverflowBehavior::AllToDouble;
       for (const auto& input : nonWorkingInputs) {
@@ -673,7 +673,7 @@ TEST(RdfParserTest, numericLiteralErrorBehavior) {
           {iri("<a>"), iri("<b>"), 99999999999999999999999.0},
           {iri("<e>"), iri("<f>"), 234}};
       Parser parser{encodedIriManager()};
-      parser.prefixMap_["xsd"] = iri("<http://www.w3.org/2001/XMLSchema#>");
+      parser.prefixMap()["xsd"] = iri("<http://www.w3.org/2001/XMLSchema#>");
       parser.invalidLiteralsAreSkipped() = true;
       parser.integerOverflowBehavior() =
           TurtleParserIntegerOverflowBehavior::OverflowingToDouble;

--- a/test/RdfParserTest.cpp
+++ b/test/RdfParserTest.cpp
@@ -879,16 +879,14 @@ TEST(RdfParserTest, iriref) {
 }
 
 // Parse the file at `filename` using a parser of type `Parser` and return the
-// sorted result. Iff `useBatchInterface` then the `getBatch()` function is used
-// for parsing, else `getLine()` is used. The default size for the parse buffer
-// in the following tests is 1 kB (which is much less than the default value
+// sorted result. The default size for the parse buffer in the following tests
+// is 1 kB (which is much less than the default value
 // `DEFAULT_PARSER_BUFFER_SIZE` defined in `src/global/Constants.h`).
 // `Filetype::Turtle` is hardcoded because all `Parser` instantiations used
 // below are Turtle-based.
 template <typename Parser>
 std::vector<TurtleTriple> parseFromFile(
-    const std::string& filename, bool useBatchInterface,
-    ad_utility::MemorySize bufferSize = 1_kB) {
+    const std::string& filename, ad_utility::MemorySize bufferSize = 1_kB) {
   auto parser = [&]() {
     if constexpr (ad_utility::isSimilar<Parser, RdfMultifileParser>) {
       return Parser{
@@ -904,42 +902,31 @@ std::vector<TurtleTriple> parseFromFile(
   }();
 
   std::vector<TurtleTriple> result;
-  if (useBatchInterface) {
-    while (auto batch = parser.getBatch()) {
-      result.insert(result.end(), batch.value().begin(), batch.value().end());
-      parser.printAndResetQueueStatistics();
-    }
-  } else {
-    TurtleTriple next;
-    while (parser.getLine(next)) {
-      result.push_back(next);
-    }
+  while (auto batch = parser.getBatch()) {
+    result.insert(result.end(), batch.value().begin(), batch.value().end());
+    parser.printAndResetQueueStatistics();
   }
   return result;
 }
 
-// Run a function that takes a bool as the first argument (typically the
-// `useBatchInterface` argument) and possible additional args, and run this
-// function for all the different parsers that can read from a file (stream and
-// parallel parser, with all the combinations of the different tokenizers).
+// Run a function that takes a type identity of the parser as the first argument
+// and possible additional args, and run this function for all the different
+// parsers that can read from a file (stream and parallel parser, with all the
+// combinations of the different tokenizers).
 template <typename Function, typename... Args>
 auto forAllParallelParsers(const Function& function, const Args&... args) {
-  function(ti<RdfParallelParser<TurtleParser<Tokenizer>>>, true, args...);
-  function(ti<RdfParallelParser<TurtleParser<Tokenizer>>>, false, args...);
-  function(ti<RdfParallelParser<TurtleParser<TokenizerCtre>>>, true, args...);
-  function(ti<RdfParallelParser<TurtleParser<TokenizerCtre>>>, false, args...);
+  function(ti<RdfParallelParser<TurtleParser<Tokenizer>>>, args...);
+  function(ti<RdfParallelParser<TurtleParser<TokenizerCtre>>>, args...);
 }
 template <typename Function, typename... Args>
 auto forAllMultifileParsers(const Function& function, const Args&... args) {
-  function(ti<RdfMultifileParser>, true, args...);
+  function(ti<RdfMultifileParser>, args...);
 }
 
 template <typename Function, typename... Args>
 auto forAllParsers(const Function& function, const Args&... args) {
-  function(ti<RdfStreamParser<TurtleParser<Tokenizer>>>, true, args...);
-  function(ti<RdfStreamParser<TurtleParser<Tokenizer>>>, false, args...);
-  function(ti<RdfStreamParser<TurtleParser<TokenizerCtre>>>, true, args...);
-  function(ti<RdfStreamParser<TurtleParser<TokenizerCtre>>>, false, args...);
+  function(ti<RdfStreamParser<TurtleParser<Tokenizer>>>, args...);
+  function(ti<RdfStreamParser<TurtleParser<TokenizerCtre>>>, args...);
   forAllParallelParsers(function, args...);
   forAllMultifileParsers(function, args...);
 }
@@ -958,9 +945,9 @@ TEST(RdfParserTest, TurtleStreamAndParallelParser) {
     }
   }
 
-  auto testWithParser = [&](auto t, bool useBatchInterface) {
+  auto testWithParser = [&](auto t) {
     using Parser = typename decltype(t)::type;
-    auto result = parseFromFile<Parser>(filename, useBatchInterface);
+    auto result = parseFromFile<Parser>(filename);
     EXPECT_THAT(result, ::testing::UnorderedElementsAreArray(expectedTriples));
   };
 
@@ -972,14 +959,13 @@ TEST(RdfParserTest, TurtleStreamAndParallelParser) {
 // _______________________________________________________________________
 TEST(RdfParserTest, emptyInput) {
   std::string filename{"turtleParserEmptyInput.dat"};
-  auto testWithParser = [&](auto t, bool useBatchInterface,
-                            std::string_view input = "") {
+  auto testWithParser = [&](auto t, std::string_view input = "") {
     using Parser = typename decltype(t)::type;
     {
       auto of = ad_utility::makeOfstream(filename);
       of << input;
     }
-    auto result = parseFromFile<Parser>(filename, useBatchInterface);
+    auto result = parseFromFile<Parser>(filename);
     EXPECT_THAT(result, ::testing::ElementsAre());
     ad_utility::deleteFile(filename);
   };
@@ -993,15 +979,14 @@ TEST(RdfParserTest, emptyInput) {
 // ________________________________________________________________________
 TEST(RdfParserTest, multilineComments) {
   std::string filename{"turtleParserMultilineComments.dat"};
-  auto testWithParser = [&](auto t, bool useBatchInterface,
-                            std::string_view input,
+  auto testWithParser = [&](auto t, std::string_view input,
                             const auto& expectedTriples) {
     using Parser = typename decltype(t)::type;
     {
       auto of = ad_utility::makeOfstream(filename);
       of << input;
     }
-    auto result = parseFromFile<Parser>(filename, useBatchInterface);
+    auto result = parseFromFile<Parser>(filename);
     EXPECT_THAT(result, ::testing::UnorderedElementsAreArray(expectedTriples));
     ad_utility::deleteFile(filename);
   };
@@ -1046,16 +1031,14 @@ TEST(RdfParserTest, multilineComments) {
 // actual parsing happens on background threads.
 TEST(RdfParserTest, exceptionPropagation) {
   std::string filename{"turtleParserExceptionPropagation.dat"};
-  auto testWithParser = [&](auto t, bool useBatchInterface,
-                            std::string_view input) {
+  auto testWithParser = [&](auto t, std::string_view input) {
     using Parser = typename decltype(t)::type;
     {
       auto of = ad_utility::makeOfstream(filename);
       of << input;
     }
-    AD_EXPECT_THROW_WITH_MESSAGE(
-        (parseFromFile<Parser>(filename, useBatchInterface)),
-        ::testing::ContainsRegex("Parse error"));
+    AD_EXPECT_THROW_WITH_MESSAGE((parseFromFile<Parser>(filename)),
+                                 ::testing::ContainsRegex("Parse error"));
     ad_utility::deleteFile(filename);
   };
   forAllParsers(testWithParser, "<missing> <object> .");
@@ -1065,8 +1048,7 @@ TEST(RdfParserTest, exceptionPropagation) {
 // propagated.
 TEST(RdfParserTest, exceptionPropagationFileBufferReading) {
   std::string filename{"turtleParserExceptionPropagationFileBufferReading.dat"};
-  auto testWithParser = [&](auto t, bool useBatchInterface,
-                            ad_utility::MemorySize bufferSize,
+  auto testWithParser = [&](auto t, ad_utility::MemorySize bufferSize,
                             std::string_view input) {
     using Parser = typename decltype(t)::type;
     {
@@ -1074,7 +1056,7 @@ TEST(RdfParserTest, exceptionPropagationFileBufferReading) {
       of << input;
     }
     AD_EXPECT_THROW_WITH_MESSAGE(
-        (parseFromFile<Parser>(filename, useBatchInterface, bufferSize)),
+        (parseFromFile<Parser>(filename, bufferSize)),
         ::testing::AllOf(
             ::testing::HasSubstr("No statement boundary"),
             ::testing::HasSubstr("use `--parser-buffer-size`"),
@@ -1094,8 +1076,7 @@ TEST(RdfParserTest, exceptionPropagationFileBufferReading) {
 // an exception
 TEST(RdfParserTest, exceptionOnScatteredPrefixOrBaseInParallelParser) {
   std::string filename{"exceptionOnScatteredPrefixOrBaseInParallelParser.dat"};
-  auto testWithParser = [&](auto t, bool useBatchInterface,
-                            ad_utility::MemorySize bufferSize,
+  auto testWithParser = [&](auto t, ad_utility::MemorySize bufferSize,
                             std::string_view input) {
     using Parser = typename decltype(t)::type;
     {
@@ -1103,7 +1084,7 @@ TEST(RdfParserTest, exceptionOnScatteredPrefixOrBaseInParallelParser) {
       of << input;
     }
     AD_EXPECT_THROW_WITH_MESSAGE(
-        (parseFromFile<Parser>(filename, useBatchInterface, bufferSize)),
+        (parseFromFile<Parser>(filename, bufferSize)),
         ::testing::HasSubstr("'--parallel-parsing false'"));
     ad_utility::deleteFile(filename);
   };
@@ -1172,16 +1153,14 @@ TEST(RdfParserTest,
      noExceptionOnScatteredPrefixOrBaseRedeclarationInParallelParser) {
   std::string filename{
       "noExceptionOnScatteredPrefixOrBaseRedeclarationInParallelParser.dat"};
-  auto testWithParser = [&](auto t, bool useBatchInterface,
-                            ad_utility::MemorySize bufferSize,
+  auto testWithParser = [&](auto t, ad_utility::MemorySize bufferSize,
                             std::string_view input) {
     using Parser = typename decltype(t)::type;
     {
       auto of = ad_utility::makeOfstream(filename);
       of << input;
     }
-    EXPECT_NO_THROW(
-        parseFromFile<Parser>(filename, useBatchInterface, bufferSize));
+    EXPECT_NO_THROW(parseFromFile<Parser>(filename, bufferSize));
     ad_utility::deleteFile(filename);
   };
   std::string_view inputWithScatteredPrefix =
@@ -1210,8 +1189,7 @@ TEST(RdfParserTest,
 // literal parsing error.
 TEST(RdfParserTest, betterErrorMessageOnMultilineLiteralError) {
   std::string filename{"betterErrorMessageOnMultilineLiteralError.dat"};
-  auto testWithParser = [&filename](auto t, bool useBatchInterface,
-                                    ad_utility::MemorySize bufferSize,
+  auto testWithParser = [&filename](auto t, ad_utility::MemorySize bufferSize,
                                     std::string_view input) {
     using Parser = typename decltype(t)::type;
     {
@@ -1219,7 +1197,7 @@ TEST(RdfParserTest, betterErrorMessageOnMultilineLiteralError) {
       of << input;
     }
     AD_EXPECT_THROW_WITH_MESSAGE(
-        (parseFromFile<Parser>(filename, useBatchInterface, bufferSize)),
+        (parseFromFile<Parser>(filename, bufferSize)),
         ::testing::AllOf(::testing::HasSubstr("`--parallel-parsing false`"),
                          ::testing::HasSubstr("multiline string literal")));
     ad_utility::deleteFile(filename);
@@ -1243,8 +1221,7 @@ TEST(RdfParserTest, stopParsingOnOutsideFailure) {
   GTEST_SKIP_("because _QLEVER_NO_TIMING_TESTS defined");
 #endif
   std::string filename{"turtleParserStopParsingOnOutsideFailure.dat"};
-  auto testWithParser = [&](auto t, [[maybe_unused]] bool useBatchInterface,
-                            std::string_view input) {
+  auto testWithParser = [&](auto t, std::string_view input) {
     using Parser = typename decltype(t)::type;
     {
       auto of = ad_utility::makeOfstream(filename);
@@ -1325,11 +1302,10 @@ TEST(RdfParserTest, nQuadParser) {
 }
 
 // _____________________________________________________________________________
-TEST(RdfParserTest, noGetlineInStringParser) {
+TEST(RdfParserTest, noGetBatchInStringParser) {
   auto runTestsForParser = [](auto parser) {
     parser.setInputStream("<x> <p> <o> .");
-    TurtleTriple t;
-    EXPECT_ANY_THROW(parser.getLine(t));
+    EXPECT_ANY_THROW(parser.getBatch());
   };
   runTestsForParser(NQuadRe2Parser{encodedIriManager()});
   runTestsForParser(NQuadCtreParser{encodedIriManager()});
@@ -1338,14 +1314,11 @@ TEST(RdfParserTest, noGetlineInStringParser) {
 }
 
 // _____________________________________________________________________________
-TEST(RdfParserTest, noGetlineInMultifileParsers) {
-  auto runTestsForParser = [](auto t, [[maybe_unused]] bool interface) {
+TEST(RdfParserTest, dummyParsePositionOfMultifileParsers) {
+  auto runTestsForParser = [](auto t) {
     using Parser = typename decltype(t)::type;
     Parser parser{encodedIriManager()};
-    TurtleTriple triple;
-    // Also test the dummy parse position member.
     EXPECT_EQ(parser.getParsePosition(), 0u);
-    EXPECT_ANY_THROW(parser.getLine(triple));
   };
   forAllMultifileParsers(runTestsForParser);
 }
@@ -1388,7 +1361,7 @@ TEST(RdfParserTest, multifileParser) {
     }
     EXPECT_THAT(result, ::testing::UnorderedElementsAreArray(expected));
   };
-  forAllMultifileParsers(impl);
+  forAllMultifileParsers(impl, true);
 }
 
 // _____________________________________________________________________________
@@ -1429,14 +1402,13 @@ TEST(RdfParserTest, payloadSmallerThanInitialChunkSize) {
   // `AsyncStatementBoundaryBlockSource::findRegexNearEnd` function is greater
   // than the total size of the payload.
   std::string filename{"payloadSmallerThanInitialChunkSize.dat"};
-  auto testWithParser = [&](auto t, bool useBatchInterface,
-                            std::string_view input) {
+  auto testWithParser = [&](auto t, std::string_view input) {
     using Parser = typename decltype(t)::type;
     {
       auto of = ad_utility::makeOfstream(filename);
       of << input;
     }
-    auto result = parseFromFile<Parser>(filename, useBatchInterface);
+    auto result = parseFromFile<Parser>(filename);
     EXPECT_THAT(result, ::testing::ElementsAre(TurtleTriple{
                             iri("<http://vocab.getty.edu/aat/300312355>"),
                             iri("<http://www.w3.org/2000/01/rdf-schema#label>"),
@@ -1456,8 +1428,7 @@ TEST(RdfParserTest, payloadSmallerThanInitialChunkSize) {
 // the same internal ID even when it appears in different batches.
 TEST(RdfParserTest, blankNodeLabelsConsistentInParallelParsing) {
   std::string filename{"blankNodeLabelsConsistentInParallelParsing.dat"};
-  auto testWithParser = [&](auto t, bool useBatchInterface,
-                            ad_utility::MemorySize bufferSize) {
+  auto testWithParser = [&](auto t, ad_utility::MemorySize bufferSize) {
     using Parser = typename decltype(t)::type;
     // Create input where the same blank node label appears multiple times,
     // with enough content to ensure batching happens with small buffer size.
@@ -1471,8 +1442,7 @@ _:blank ex:b ex:c .
       auto of = ad_utility::makeOfstream(filename);
       of << input;
     }
-    auto result =
-        parseFromFile<Parser>(filename, useBatchInterface, bufferSize);
+    auto result = parseFromFile<Parser>(filename, bufferSize);
 
     // Find the blank node ID used for _:blank by looking at the first triple
     // where it appears as the object.
@@ -1690,12 +1660,12 @@ TEST(RdfParserTest, parseTriplesObject) {
 }
 
 // _____________________________________________________________________________
-// Exercise the error path in `RdfStreamParser<T>::getLineImpl` that triggers
+// Exercise the error path in `RdfStreamParser<T>::getBatch` that triggers
 // when the internal `byteVec_` grows past `RDF_PARSER_MAX_TOTAL_BUFFER_SIZE`
 // while the last `statement()` attempt threw a `ParseException`. The pending
 // exception is expected to be rethrown and the error log has to mention the
 // offending input.
-TEST(RdfParserTest, getLineRethrowsOnTooLargeBufferWithPendingException) {
+TEST(RdfParserTest, getBatchRethrowsOnTooLargeBufferWithPendingException) {
   using Parser = RdfStreamParser<TurtleParser<Tokenizer>>;
   auto& limit = RDF_PARSER_MAX_TOTAL_BUFFER_SIZE();
   auto oldLimit = limit;
@@ -1718,8 +1688,7 @@ TEST(RdfParserTest, getLineRethrowsOnTooLargeBufferWithPendingException) {
                     filename, qlever::Filetype::Turtle, std::nullopt},
                 ad_utility::MemorySize::bytes(50), encodedIriManager()};
 
-  TurtleTriple triple;
-  EXPECT_THROW(parser.getLine(triple), TurtleParser<Tokenizer>::ParseException);
+  EXPECT_THROW(parser.getBatch(), TurtleParser<Tokenizer>::ParseException);
 
   const std::string log = logStream.str();
   EXPECT_THAT(log, ::testing::HasSubstr("Could not parse"));
@@ -1734,7 +1703,7 @@ TEST(RdfParserTest, getLineRethrowsOnTooLargeBufferWithPendingException) {
 // last `statement()` attempt returned `false` without throwing (a triple with
 // no terminating dot satisfies this). The parser must then synthesize its own
 // `ParseException` via `raise(...)`.
-TEST(RdfParserTest, getLineRaisesOnTooLargeBufferWithoutPendingException) {
+TEST(RdfParserTest, getBatchRaisesOnTooLargeBufferWithoutPendingException) {
   using Parser = RdfStreamParser<TurtleParser<Tokenizer>>;
   auto& limit = RDF_PARSER_MAX_TOTAL_BUFFER_SIZE();
   auto oldLimit = limit;
@@ -1757,9 +1726,8 @@ TEST(RdfParserTest, getLineRaisesOnTooLargeBufferWithoutPendingException) {
                     filename, qlever::Filetype::Turtle, std::nullopt},
                 ad_utility::MemorySize::bytes(50), encodedIriManager()};
 
-  TurtleTriple triple;
   AD_EXPECT_THROW_WITH_MESSAGE(
-      parser.getLine(triple),
+      parser.getBatch(),
       ::testing::HasSubstr(
           "Too many bytes parsed without finishing a turtle statement"));
 
@@ -1776,7 +1744,7 @@ TEST(RdfParserTest, getLineRaisesOnTooLargeBufferWithoutPendingException) {
 // exhausted but `tok_` still has unparsed bytes (and the last `statement()`
 // attempt did not throw). The parser must surface the previously emitted
 // triples and then mark itself exhausted while logging the remainder.
-TEST(RdfParserTest, getLineLogsRemainingUnparsedBytesWhenInputExhausted) {
+TEST(RdfParserTest, getBatchLogsRemainingUnparsedBytesWhenInputExhausted) {
   using Parser = RdfStreamParser<TurtleParser<Tokenizer>>;
   std::string filename{"rdfParserGetLineLogsRemainingUnparsedBytes.dat"};
   std::string trailingGarbage =
@@ -1791,14 +1759,16 @@ TEST(RdfParserTest, getLineLogsRemainingUnparsedBytesWhenInputExhausted) {
   Parser parser{qlever::InputFileSpecification{
                     filename, qlever::Filetype::Turtle, std::nullopt},
                 2_kB, encodedIriManager()};
-  TurtleTriple triple;
-  ASSERT_TRUE(parser.getLine(triple));
+  auto batch = parser.getBatch();
+  ASSERT_TRUE(batch.has_value());
+  ASSERT_EQ(batch.value().size(), 1u);
+  const auto& triple = batch.value().at(0);
   EXPECT_EQ(triple.subject_, iri("<a>"));
   EXPECT_EQ(triple.predicate_, iri("<b>"));
   EXPECT_EQ(triple.object_, iri("<c>"));
   // The parser logs the unparsed trailing bytes, marks itself exhausted, and
-  // returns `false` from subsequent `getLine` calls instead of throwing.
-  EXPECT_FALSE(parser.getLine(triple));
+  // returns `nullopt` from subsequent `getBatch` calls instead of throwing.
+  EXPECT_FALSE(parser.getBatch().has_value());
 
   std::string log = logStream.str();
   EXPECT_THAT(log, ::testing::HasSubstr(


### PR DESCRIPTION
So far, `RdfParallelParser::getBatch` staged each batch in a class member before returning it, so concurrent calls from multiple threads were unsafe. The batches are now returned directly from the internal thread-safe queue. This makes concurrent polling of `getBatch` safe for the parallel and multi-file parsers, in preparation for consuming the parser output from multiple threads.

The unused `getLine` interface is removed, so `getBatch` is now the only access method. The `RdfParallelParser` no longer inherits from the sub-parser type, but directly from `RdfParserBase`, so it no longer carries unused parser members. The long-dead `ParallelParseBuffer` class is also removed.

NOTE: For the non-parallel stream parser, `getBatch` now returns the triples of one internal parse round (about 10,000) instead of accumulating 100,000 of them. This has no measurable effect on the index build time.