### PR TITLE
Encode the geo cell of a WKT literal in the upper bits of its vocabulary index

### DIFF
--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -1492,6 +1492,20 @@ void IndexImpl::applyConfiguration(const nlohmann::json& configuration) {
   loadDataMember("vocabulary-type", vocabType, vocabType);
   vocab_.resetToType(vocabType);
 
+  // The geo cell grid of the geo vocabulary, if the index was built with one
+  // (see `GeoCellGrid`). The vocabulary needs it before it is opened, because
+  // the grid determines how its indices are composed.
+  uint8_t geoCellGridLevel = 0;
+  loadDataMember("geo-cell-grid-level", geoCellGridLevel, geoCellGridLevel);
+  if (geoCellGridLevel > 0) {
+    ad_utility::GeoCellGridScheme geoCellGridScheme =
+        ad_utility::GeoCellGridScheme::Flat;
+    loadDataMember("geo-cell-grid-scheme", geoCellGridScheme,
+                   geoCellGridScheme);
+    vocab_.setGeoCellGrid(
+        ad_utility::GeoCellGrid{geoCellGridLevel, geoCellGridScheme});
+  }
+
   // Initialize BlankNodeManager
   uint64_t numBlankNodesTotal;
   loadDataMember(BLANK_NODE_ALLOCATION_START, numBlankNodesTotal);

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -1495,15 +1495,20 @@ void IndexImpl::applyConfiguration(const nlohmann::json& configuration) {
   // The geo cell grid of the geo vocabulary, if the index was built with one
   // (see `GeoCellGrid`). The vocabulary needs it before it is opened, because
   // the grid determines how its indices are composed.
-  uint8_t geoCellGridLevel = 0;
+  uint64_t geoCellGridLevel = 0;
   loadDataMember("geo-cell-grid-level", geoCellGridLevel, geoCellGridLevel);
   if (geoCellGridLevel > 0) {
+    if (geoCellGridLevel > std::numeric_limits<uint8_t>::max()) {
+      throw std::runtime_error{absl::StrCat(
+          "Invalid value ", geoCellGridLevel,
+          " for the key \"geo-cell-grid-level\" in the `meta-data.json`")};
+    }
     ad_utility::GeoCellGridScheme geoCellGridScheme =
         ad_utility::GeoCellGridScheme::Flat;
     loadDataMember("geo-cell-grid-scheme", geoCellGridScheme,
                    geoCellGridScheme);
-    vocab_.setGeoCellGrid(
-        ad_utility::GeoCellGrid{geoCellGridLevel, geoCellGridScheme});
+    vocab_.setGeoCellGrid(ad_utility::GeoCellGrid{
+        static_cast<uint8_t>(geoCellGridLevel), geoCellGridScheme});
   }
 
   // Initialize BlankNodeManager

--- a/src/index/vocabulary/GeoVocabulary.cpp
+++ b/src/index/vocabulary/GeoVocabulary.cpp
@@ -41,6 +41,8 @@ void GeoVocabulary<V>::open(const std::string& filename) {
         ad_utility::GEOMETRY_INFO_VERSION,
         " as required by this version of QLever. Please rebuild your index."));
   }
+
+  endIndex_ = computeEndIndex();
 }
 
 // ____________________________________________________________________________
@@ -48,6 +50,7 @@ template <typename V>
 void GeoVocabulary<V>::close() {
   literals_.close();
   geoInfoFile_.close();
+  endIndex_ = 0;
 }
 
 // ____________________________________________________________________________
@@ -64,7 +67,7 @@ uint64_t GeoVocabulary<V>::indexFromPosition(uint64_t position,
 
 // ____________________________________________________________________________
 template <typename V>
-uint64_t GeoVocabulary<V>::endIndex() const {
+uint64_t GeoVocabulary<V>::computeEndIndex() const {
   auto numWords = size();
   if (!grid_.has_value() || numWords == 0) {
     return numWords;

--- a/src/index/vocabulary/GeoVocabulary.cpp
+++ b/src/index/vocabulary/GeoVocabulary.cpp
@@ -11,6 +11,7 @@
 #include "index/vocabulary/GeoVocabulary.h"
 
 #include <stdexcept>
+#include <vector>
 
 #include "index/vocabulary/CompressedVocabulary.h"
 #include "index/vocabulary/VocabularyConstraints.h"
@@ -146,11 +147,11 @@ uint64_t GeoVocabulary<V>::WordWriter::operator()(std::string_view word,
     AD_CORRECTNESS_CHECK(index == numWords_);
     // Keep one position free, so that `endIndex` (the past-the-end position
     // combined with the cell of the last word) is always a valid index.
-    AD_CORRECTNESS_CHECK(numWords_ + 1 < grid_->maxNumWords(),
-                         "Too many WKT literals for the configured geo cell "
-                         "grid, please rebuild with a smaller grid level");
+    AD_CONTRACT_CHECK(numWords_ + 1 < grid_->maxNumWords(),
+                      "Too many WKT literals for the configured geo cell "
+                      "grid, please rebuild with a smaller grid level");
     auto cellIndex = cellIndexOfWord(grid_.value(), info, word);
-    AD_CORRECTNESS_CHECK(
+    AD_CONTRACT_CHECK(
         !lastCellIndex_.has_value() || lastCellIndex_.value() <= cellIndex,
         "WKT literals were not passed to the GeoVocabulary in the order of "
         "their geo grid cells");

--- a/src/index/vocabulary/GeoVocabulary.cpp
+++ b/src/index/vocabulary/GeoVocabulary.cpp
@@ -13,6 +13,7 @@
 #include <stdexcept>
 
 #include "index/vocabulary/CompressedVocabulary.h"
+#include "index/vocabulary/VocabularyConstraints.h"
 #include "index/vocabulary/VocabularyInMemory.h"
 #include "index/vocabulary/VocabularyInternalExternal.h"
 #include "rdfTypes/GeoPoint.h"
@@ -21,6 +22,16 @@
 #include "util/File.h"
 
 using ad_utility::GeometryInfo;
+
+// ____________________________________________________________________________
+template <typename V>
+GeoVocabulary<V>::GeoVocabulary() {
+  // The index of a word is computed from its position in the underlying
+  // vocabulary (see `indexFromPosition`), which requires contiguous positions
+  // and a plain `getPositionOfWord`. The vocabularies with "holes" and the
+  // composite vocabularies do not qualify.
+  static_assert(!HasSpecialGetPositionOfWord<V>);
+}
 
 // ____________________________________________________________________________
 template <typename V>

--- a/src/index/vocabulary/GeoVocabulary.cpp
+++ b/src/index/vocabulary/GeoVocabulary.cpp
@@ -1,6 +1,12 @@
-// Copyright 2025, University of Freiburg,
-// Chair of Algorithms and Data Structures.
-// Author: Christoph Ullinger <ullingec@cs.uni-freiburg.de>
+// Copyright 2025 - 2026 The QLever Authors, in particular:
+//
+// 2025 Christoph Ullinger <ullingec@cs.uni-freiburg.de>, UFR
+// 2026 Hannah Bast <bast@cs.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+//
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
 
 #include "index/vocabulary/GeoVocabulary.h"
 
@@ -12,6 +18,7 @@
 #include "rdfTypes/GeoPoint.h"
 #include "rdfTypes/GeometryInfo.h"
 #include "util/Exception.h"
+#include "util/File.h"
 
 using ad_utility::GeometryInfo;
 
@@ -45,10 +52,54 @@ void GeoVocabulary<V>::close() {
 
 // ____________________________________________________________________________
 template <typename V>
-GeoVocabulary<V>::WordWriter::WordWriter(const V& vocabulary,
-                                         const std::string& filename)
+uint64_t GeoVocabulary<V>::indexFromPosition(uint64_t position,
+                                             std::string_view word) const {
+  if (!grid_.has_value()) {
+    return position;
+  }
+  return grid_->indexFromCellAndPosition(
+      cellIndexOfWord(grid_.value(), geoInfoAtPosition(position), word),
+      position);
+}
+
+// ____________________________________________________________________________
+template <typename V>
+uint64_t GeoVocabulary<V>::endIndex() const {
+  auto numWords = size();
+  if (!grid_.has_value() || numWords == 0) {
+    return numWords;
+  }
+  // One past the largest index: the cell of the last word combined with the
+  // past-the-end position.
+  auto lastPosition = numWords - 1;
+  auto lastCell = cellIndexOfWord(
+      grid_.value(), geoInfoAtPosition(lastPosition), literals_[lastPosition]);
+  return grid_->indexFromCellAndPosition(lastCell, numWords);
+}
+
+// ____________________________________________________________________________
+template <typename V>
+VocabBatchLookupResult GeoVocabulary<V>::lookupBatch(
+    ql::span<const size_t> indices) const {
+  if (!grid_.has_value()) {
+    return literals_.lookupBatch(indices);
+  }
+  std::vector<size_t> positions;
+  positions.reserve(indices.size());
+  for (size_t index : indices) {
+    positions.push_back(positionFromIndex(index));
+  }
+  return literals_.lookupBatch(positions);
+}
+
+// ____________________________________________________________________________
+template <typename V>
+GeoVocabulary<V>::WordWriter::WordWriter(
+    const V& vocabulary, const std::string& filename,
+    std::optional<ad_utility::GeoCellGrid> grid)
     : underlyingWordWriter_{vocabulary.makeDiskWriterPtr(filename)},
-      geoInfoFile_{getGeoInfoFilename(filename), "w"} {
+      geoInfoFile_{getGeoInfoFilename(filename), "w"},
+      grid_{grid} {
   // Initialize geo info file with header
   geoInfoFile_.write(&ad_utility::GEOMETRY_INFO_VERSION, geoInfoHeader);
 }
@@ -77,6 +128,22 @@ uint64_t GeoVocabulary<V>::WordWriter::operator()(std::string_view word,
   }
   geoInfoFile_.write(ptr, geoInfoOffset);
 
+  if (grid_.has_value()) {
+    AD_CORRECTNESS_CHECK(index == numWords_);
+    // Keep one position free, so that `endIndex` (the past-the-end position
+    // combined with the cell of the last word) is always a valid index.
+    AD_CORRECTNESS_CHECK(numWords_ + 1 < grid_->maxNumWords(),
+                         "Too many WKT literals for the configured geo cell "
+                         "grid, please rebuild with a smaller grid level");
+    auto cellIndex = cellIndexOfWord(grid_.value(), info, word);
+    AD_CORRECTNESS_CHECK(
+        !lastCellIndex_.has_value() || lastCellIndex_.value() <= cellIndex,
+        "WKT literals were not passed to the GeoVocabulary in the order of "
+        "their geo grid cells");
+    lastCellIndex_ = cellIndex;
+    index = grid_->indexFromCellAndPosition(cellIndex, numWords_);
+  }
+  ++numWords_;
   return index;
 }
 
@@ -112,14 +179,16 @@ GeoVocabulary<V>::WordWriter::~WordWriter() {
 
 // ____________________________________________________________________________
 template <typename V>
-std::optional<GeometryInfo> GeoVocabulary<V>::getGeoInfo(uint64_t index) const {
-  AD_CONTRACT_CHECK(index < size());
+std::optional<GeometryInfo> GeoVocabulary<V>::geoInfoAtPosition(
+    uint64_t position) const {
+  AD_CONTRACT_CHECK(position < size());
   // Allocate the required number of bytes
   std::array<uint8_t, geoInfoOffset> buffer;
   void* ptr = &buffer;
 
   // Read into the buffer
-  geoInfoFile_.read(ptr, geoInfoOffset, geoInfoHeader + index * geoInfoOffset);
+  geoInfoFile_.read(ptr, geoInfoOffset,
+                    geoInfoHeader + position * geoInfoOffset);
 
   // If all bytes are zero, this record on disk represents an invalid geometry.
   // The `GeometryInfo` class makes the guarantee that it can not have an

--- a/src/index/vocabulary/GeoVocabulary.h
+++ b/src/index/vocabulary/GeoVocabulary.h
@@ -16,7 +16,6 @@
 #include <optional>
 #include <string>
 #include <utility>
-#include <vector>
 
 #include "backports/algorithm.h"
 #include "index/vocabulary/VocabularyTypes.h"
@@ -31,9 +30,10 @@
 // regular vocabulary classes it does not only store the strings. Instead it
 // stores both preprocessed and original forms of its input words. Preprocessing
 // includes for example the computation of bounding boxes for accelerated
-// spatial queries. See the `GeometryInfo` class for details. Note: A
-// `GeoVocabulary` is only suitable for WKT literals, therefore it should be
-// used as part of a `SplitVocabulary`.
+// spatial queries. See the `GeometryInfo` class for details.
+//
+// NOTE: A `GeoVocabulary` is only suitable for WKT literals, therefore it
+// should be used as part of a `SplitVocabulary`.
 //
 // With a `GeoCellGrid` (see `setGeoCellGrid`), the index of a word is no
 // longer its position in the vocabulary: the upper bits of the index hold the
@@ -51,6 +51,7 @@ class GeoVocabulary {
   using GeometryInfo = ad_utility::GeometryInfo;
   using GeoCellGrid = ad_utility::GeoCellGrid;
 
+  // The underlying vocabulary, which stores the WKT literals as strings.
   UnderlyingVocabulary literals_;
 
   // The file in which the additional information on the geometries (like
@@ -83,8 +84,9 @@ class GeoVocabulary {
 
  public:
   // The constructor is defined in the `.cpp` file, where it checks the
-  // underlying vocabulary type, so that every instantiation goes through
-  // that check.
+  // underlying vocabulary type of the explicit instantiations (the check
+  // cannot be in this header, because the header of the concept it uses
+  // includes the `SplitVocabulary`, which includes this class).
   GeoVocabulary();
 
   // Load the precomputed `GeometryInfo` object for the literal with
@@ -104,7 +106,7 @@ class GeoVocabulary {
   // building one). Changing the grid of an opened vocabulary would change the
   // meaning of all its indices, so this is an error.
   void setGeoCellGrid(std::optional<GeoCellGrid> grid) {
-    AD_CONTRACT_CHECK(!literals_.size(),
+    AD_CONTRACT_CHECK(!geoInfoFile_.isOpen(),
                       "The geo cell grid must be set before the vocabulary is "
                       "opened");
     grid_ = grid;
@@ -130,13 +132,14 @@ class GeoVocabulary {
   // the upper bound for valid indices).
   uint64_t endIndex() const { return endIndex_; }
 
-  // Forward all the standard operations to the underlying literal vocabulary.
-  // See there for more details.
+  // The standard vocabulary operations. They translate between indices and
+  // positions (see above) and otherwise forward to the underlying vocabulary,
+  // see there for details.
 
   // ___________________________________________________________________________
   decltype(auto) operator[](uint64_t id) const {
     auto position = positionFromIndex(id);
-    AD_CORRECTNESS_CHECK(position < size());
+    AD_CONTRACT_CHECK(position < size());
     return literals_[position];
   }
 
@@ -150,6 +153,10 @@ class GeoVocabulary {
   }
 
   // Iterate over all words together with their index.
+  //
+  // NOTE: With a grid, this reads the geometry info of every word from disk
+  // to compute its index, one small read per word. If a scan of a large
+  // vocabulary with a grid ever matters, read the geometry info in blocks.
   auto scanAll() const {
     return ad_utility::OwningView{literals_.scanAll()} |
            ql::views::transform([this](IndexAndWord indexAndWord) {
@@ -192,8 +199,10 @@ class GeoVocabulary {
   // cell and puts the cell index into the upper bits of the returned indices.
   class WordWriter : public WordWriterBase {
    private:
+    // The writer of the underlying vocabulary, which stores the strings.
     std::unique_ptr<typename UnderlyingVocabulary::WordWriter>
         underlyingWordWriter_;
+    // The file for the geometry info, one record per word.
     ad_utility::File geoInfoFile_;
     // The grid, or `std::nullopt` if the index of a word is its position.
     std::optional<GeoCellGrid> grid_;
@@ -201,6 +210,7 @@ class GeoVocabulary {
     std::optional<GeoCellGrid::CellIndex> lastCellIndex_;
     // The number of words written so far (the position of the next word).
     uint64_t numWords_ = 0;
+    // Counters for the warnings that `finishImpl` prints.
     size_t numInvalidGeometries_ = 0;
     size_t numInvalidPolygonArea_ = 0;
 

--- a/src/index/vocabulary/GeoVocabulary.h
+++ b/src/index/vocabulary/GeoVocabulary.h
@@ -235,7 +235,9 @@ class GeoVocabulary {
   // filename itself, plus the file with the geometry information.
   static FileSuffixes fileSuffixes() {
     FileSuffixes suffixes = UnderlyingVocabulary::fileSuffixes();
-    suffixes.emplace_back(geoInfoSuffix);
+    // NOTE: The explicit `std::string` avoids a false positive
+    // `-Warray-bounds` of GCC 13 for `emplace_back(geoInfoSuffix)`.
+    suffixes.push_back(std::string{geoInfoSuffix});
     return suffixes;
   }
 

--- a/src/index/vocabulary/GeoVocabulary.h
+++ b/src/index/vocabulary/GeoVocabulary.h
@@ -108,11 +108,13 @@ class GeoVocabulary {
 
   // Set the grid. Must be called before `open` (when loading a vocabulary
   // that was built with this grid) or before `makeDiskWriterPtr` (when
-  // building one); it has no effect on an already opened vocabulary.
+  // building one). Changing the grid of an opened vocabulary would change the
+  // meaning of all its indices, so this is an error.
   void setGeoCellGrid(std::optional<GeoCellGrid> grid) {
-    if (!literals_.size()) {
-      grid_ = grid;
-    }
+    AD_CONTRACT_CHECK(!literals_.size(),
+                      "The geo cell grid must be set before the vocabulary is "
+                      "opened");
+    grid_ = grid;
   }
 
   // The grid, or `std::nullopt` if the index of a word is its position.

--- a/src/index/vocabulary/GeoVocabulary.h
+++ b/src/index/vocabulary/GeoVocabulary.h
@@ -19,15 +19,12 @@
 #include <vector>
 
 #include "backports/algorithm.h"
-#include "index/vocabulary/CompressedVocabulary.h"
-#include "index/vocabulary/VocabularyInMemoryBinSearch.h"
 #include "index/vocabulary/VocabularyTypes.h"
 #include "rdfTypes/GeoCellGrid.h"
 #include "rdfTypes/GeometryInfo.h"
 #include "util/ExceptionHandling.h"
 #include "util/File.h"
 #include "util/Serializer/Serializer.h"
-#include "util/TypeTraits.h"
 #include "util/Views.h"
 
 // A `GeoVocabulary` holds Well-Known Text (WKT) literals. In contrast to the
@@ -53,13 +50,6 @@ class GeoVocabulary {
  private:
   using GeometryInfo = ad_utility::GeometryInfo;
   using GeoCellGrid = ad_utility::GeoCellGrid;
-
-  // The index of a word is computed from its position in the underlying
-  // vocabulary (see `indexFromPosition`), so the positions must be contiguous,
-  // which they are not for the vocabularies with "holes".
-  static_assert(!ad_utility::SameAsAny<
-                UnderlyingVocabulary, VocabularyInMemoryBinSearch,
-                CompressedVocabulary<VocabularyInMemoryBinSearch>>);
 
   UnderlyingVocabulary literals_;
 
@@ -92,7 +82,10 @@ class GeoVocabulary {
       sizeof(ad_utility::GEOMETRY_INFO_VERSION);
 
  public:
-  GeoVocabulary() = default;
+  // The constructor is defined in the `.cpp` file, where it checks the
+  // underlying vocabulary type, so that every instantiation goes through
+  // that check.
+  GeoVocabulary();
 
   // Load the precomputed `GeometryInfo` object for the literal with
   // the given index from disk. Return `std::nullopt` for invalid geometries.

--- a/src/index/vocabulary/GeoVocabulary.h
+++ b/src/index/vocabulary/GeoVocabulary.h
@@ -1,19 +1,31 @@
-// Copyright 2025, University of Freiburg,
-// Chair of Algorithms and Data Structures.
-// Author: Christoph Ullinger <ullingec@cs.uni-freiburg.de>
+// Copyright 2025 - 2026 The QLever Authors, in particular:
+//
+// 2025 Christoph Ullinger <ullingec@cs.uni-freiburg.de>, UFR
+// 2026 Hannah Bast <bast@cs.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+//
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
 
 #ifndef QLEVER_SRC_INDEX_VOCABULARY_GEOVOCABULARY_H
 #define QLEVER_SRC_INDEX_VOCABULARY_GEOVOCABULARY_H
 
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
+#include <utility>
+#include <vector>
 
+#include "backports/algorithm.h"
 #include "index/vocabulary/VocabularyTypes.h"
+#include "rdfTypes/GeoCellGrid.h"
 #include "rdfTypes/GeometryInfo.h"
 #include "util/ExceptionHandling.h"
 #include "util/File.h"
 #include "util/Serializer/Serializer.h"
+#include "util/Views.h"
 
 // A `GeoVocabulary` holds Well-Known Text (WKT) literals. In contrast to the
 // regular vocabulary classes it does not only store the strings. Instead it
@@ -22,16 +34,31 @@
 // spatial queries. See the `GeometryInfo` class for details. Note: A
 // `GeoVocabulary` is only suitable for WKT literals, therefore it should be
 // used as part of a `SplitVocabulary`.
+//
+// With a `GeoCellGrid` (see `setGeoCellGrid`), the index of a word is no
+// longer its position in the vocabulary: the upper bits of the index hold the
+// grid cell of the word, the lower `GeoCellGrid::numPositionBits()` bits hold
+// the position. The words must then arrive at the `WordWriter` ordered by
+// their grid cell (a follow-up change lets the `TripleComponentComparator`
+// produce this order), so that all words of one cell form a contiguous index
+// range that can be computed from the cell index alone. This is the basis for
+// the geo cell prefilter of spatial joins. The grid itself is not stored by
+// this class; the index configuration provides it before the vocabulary is
+// opened.
 template <typename UnderlyingVocabulary>
 class GeoVocabulary {
  private:
   using GeometryInfo = ad_utility::GeometryInfo;
+  using GeoCellGrid = ad_utility::GeoCellGrid;
 
   UnderlyingVocabulary literals_;
 
   // The file in which the additional information on the geometries (like
   // bounding box) is stored.
   ad_utility::File geoInfoFile_;
+
+  // The grid, or `std::nullopt` if the index of a word is its position.
+  std::optional<GeoCellGrid> grid_;
 
   // TODO<ullingerc> Possibly add in-memory cache of bounding boxes here
 
@@ -56,7 +83,9 @@ class GeoVocabulary {
 
   // Load the precomputed `GeometryInfo` object for the literal with
   // the given index from disk. Return `std::nullopt` for invalid geometries.
-  std::optional<GeometryInfo> getGeoInfo(uint64_t index) const;
+  std::optional<GeometryInfo> getGeoInfo(uint64_t index) const {
+    return geoInfoAtPosition(positionFromIndex(index));
+  }
 
   // Construct a filename for the geo info file by appending a suffix to the
   // given filename.
@@ -64,24 +93,62 @@ class GeoVocabulary {
     return absl::StrCat(filename, geoInfoSuffix);
   }
 
+  // Set the grid. Must be called before `open` (when loading a vocabulary
+  // that was built with this grid) or before `makeDiskWriterPtr` (when
+  // building one); it has no effect on an already opened vocabulary.
+  void setGeoCellGrid(std::optional<GeoCellGrid> grid) {
+    if (!literals_.size()) {
+      grid_ = grid;
+    }
+  }
+
+  // The grid, or `std::nullopt` if the index of a word is its position.
+  const std::optional<GeoCellGrid>& getGeoCellGrid() const { return grid_; }
+
+  // The position in the vocabulary of the word with the given index (the
+  // identity without a grid).
+  uint64_t positionFromIndex(uint64_t index) const {
+    return grid_.has_value() ? grid_->positionOfIndex(index) : index;
+  }
+
+  // The index of the word at the given position (the identity without a
+  // grid). The grid cell of the word is recomputed from its precomputed
+  // bounding box, or from the word itself if the geometry is invalid, by the
+  // same rule that the `WordWriter` used to assign it.
+  uint64_t indexFromPosition(uint64_t position, std::string_view word) const;
+
+  // The index that is larger than the index of every word in this vocabulary
+  // (used to represent "past the end" positions of binary searches).
+  uint64_t endIndex() const;
+
   // Forward all the standard operations to the underlying literal vocabulary.
   // See there for more details.
 
   // ___________________________________________________________________________
-  decltype(auto) operator[](uint64_t id) const { return literals_[id]; }
+  decltype(auto) operator[](uint64_t id) const {
+    auto position = positionFromIndex(id);
+    AD_CORRECTNESS_CHECK(position < size());
+    return literals_[position];
+  }
 
   //____________________________________________________________________________
-  VocabBatchLookupResult lookupBatch(ql::span<const size_t> indices) const {
-    return literals_.lookupBatch(indices);
-  }
+  VocabBatchLookupResult lookupBatch(ql::span<const size_t> indices) const;
 
   //____________________________________________________________________________
   VocabLookupOutput lookupBatchesStreamed(VocabLookupInput input) const {
-    return literals_.lookupBatchesStreamed(std::move(input));
+    return ad_utility::vocabulary::lookupBatchesStreamed(*this,
+                                                         std::move(input));
   }
 
-  // ___________________________________________________________________________
-  auto scanAll() const { return literals_.scanAll(); }
+  // Iterate over all words together with their index.
+  auto scanAll() const {
+    return ad_utility::OwningView{literals_.scanAll()} |
+           ql::views::transform([this](IndexAndWord indexAndWord) {
+             indexAndWord.index_ =
+                 indexFromPosition(indexAndWord.index_, indexAndWord.word_);
+             return indexAndWord;
+           });
+  }
 
   // ___________________________________________________________________________
   [[nodiscard]] uint64_t size() const { return literals_.size(); }
@@ -90,14 +157,14 @@ class GeoVocabulary {
   template <typename InternalStringType, typename Comparator>
   WordAndIndex lower_bound(const InternalStringType& word,
                            Comparator comparator) const {
-    return literals_.lower_bound(word, comparator);
+    return withIndexFromPosition(literals_.lower_bound(word, comparator));
   }
 
   // ___________________________________________________________________________
   template <typename InternalStringType, typename Comparator>
   WordAndIndex upper_bound(const InternalStringType& word,
                            Comparator comparator) const {
-    return literals_.upper_bound(word, comparator);
+    return withIndexFromPosition(literals_.upper_bound(word, comparator));
   }
 
   // ___________________________________________________________________________
@@ -112,12 +179,19 @@ class GeoVocabulary {
   void open(const std::string& filename);
 
   // Custom word writer, which precomputes and writes geometry info along with
-  // the words.
+  // the words. With a grid, it also checks that the words arrive ordered by
+  // cell and puts the cell index into the upper bits of the returned indices.
   class WordWriter : public WordWriterBase {
    private:
     std::unique_ptr<typename UnderlyingVocabulary::WordWriter>
         underlyingWordWriter_;
     ad_utility::File geoInfoFile_;
+    // The grid, or `std::nullopt` if the index of a word is its position.
+    std::optional<GeoCellGrid> grid_;
+    // The cell of the previous word (only with a grid), to check the order.
+    std::optional<GeoCellGrid::CellIndex> lastCellIndex_;
+    // The number of words written so far (the position of the next word).
+    uint64_t numWords_ = 0;
     size_t numInvalidGeometries_ = 0;
     size_t numInvalidPolygonArea_ = 0;
 
@@ -125,7 +199,7 @@ class GeoVocabulary {
     // Initialize the `geoInfoFile_` by writing its header and open a word
     // writer on the underlying vocabulary.
     WordWriter(const UnderlyingVocabulary& vocabulary,
-               const std::string& filename);
+               const std::string& filename, std::optional<GeoCellGrid> grid);
 
     // Add the next literal to the vocabulary, precompute additional information
     // using `GeometryInfo` and return the literal's new index.
@@ -149,7 +223,7 @@ class GeoVocabulary {
   // ___________________________________________________________________________
   std::unique_ptr<WordWriter> makeDiskWriterPtr(
       const std::string& filename) const {
-    return std::make_unique<WordWriter>(literals_, filename);
+    return std::make_unique<WordWriter>(literals_, filename, grid_);
   }
 
   // ___________________________________________________________________________
@@ -161,6 +235,35 @@ class GeoVocabulary {
     (void)arg;
     throw std::runtime_error(
         "Generic serialization is not implemented for GeoVocabulary.");
+  }
+
+ private:
+  // The grid cell of a word, given its precomputed geometry info (if the
+  // geometry is valid) and the word itself. This single rule is used by the
+  // `WordWriter` to assign the cell and by `indexFromPosition` to recompute
+  // it, so the two always agree.
+  static GeoCellGrid::CellIndex cellIndexOfWord(
+      const GeoCellGrid& grid, const std::optional<GeometryInfo>& info,
+      std::string_view word) {
+    // When the `GeometryInfo` is valid, its bounding box is the one that
+    // `cellIndexFromWktLiteral` would compute, so it can be reused; otherwise
+    // `cellIndexFromWktLiteral` can still assign a regular cell in corner
+    // cases where only parts of the `GeometryInfo` computation failed.
+    return info.has_value()
+               ? grid.cellIndexFromBoundingBox(info->getBoundingBox())
+               : grid.cellIndexFromWktLiteral(word);
+  }
+
+  // The precomputed `GeometryInfo` of the word at the given position.
+  std::optional<GeometryInfo> geoInfoAtPosition(uint64_t position) const;
+
+  // Replace the position in a non-end `WordAndIndex` by the index.
+  WordAndIndex withIndexFromPosition(WordAndIndex wordAndIndex) const {
+    if (wordAndIndex.isEnd() || !grid_.has_value()) {
+      return wordAndIndex;
+    }
+    return {wordAndIndex.word(),
+            indexFromPosition(wordAndIndex.index(), wordAndIndex.word())};
   }
 };
 

--- a/src/index/vocabulary/GeoVocabulary.h
+++ b/src/index/vocabulary/GeoVocabulary.h
@@ -60,6 +60,9 @@ class GeoVocabulary {
   // The grid, or `std::nullopt` if the index of a word is its position.
   std::optional<GeoCellGrid> grid_;
 
+  // See `endIndex`, computed once when the vocabulary is opened.
+  uint64_t endIndex_ = 0;
+
   // TODO<ullingerc> Possibly add in-memory cache of bounding boxes here
 
   // Filename suffix for geometry information file
@@ -118,8 +121,9 @@ class GeoVocabulary {
   uint64_t indexFromPosition(uint64_t position, std::string_view word) const;
 
   // The index that is larger than the index of every word in this vocabulary
-  // (used to represent "past the end" positions of binary searches).
-  uint64_t endIndex() const;
+  // (used to represent "past the end" positions of binary searches, and as
+  // the upper bound for valid indices).
+  uint64_t endIndex() const { return endIndex_; }
 
   // Forward all the standard operations to the underlying literal vocabulary.
   // See there for more details.
@@ -256,6 +260,9 @@ class GeoVocabulary {
 
   // The precomputed `GeometryInfo` of the word at the given position.
   std::optional<GeometryInfo> geoInfoAtPosition(uint64_t position) const;
+
+  // Compute `endIndex_` for the opened vocabulary.
+  uint64_t computeEndIndex() const;
 
   // Replace the position in a non-end `WordAndIndex` by the index.
   WordAndIndex withIndexFromPosition(WordAndIndex wordAndIndex) const {

--- a/src/index/vocabulary/GeoVocabulary.h
+++ b/src/index/vocabulary/GeoVocabulary.h
@@ -19,12 +19,15 @@
 #include <vector>
 
 #include "backports/algorithm.h"
+#include "index/vocabulary/CompressedVocabulary.h"
+#include "index/vocabulary/VocabularyInMemoryBinSearch.h"
 #include "index/vocabulary/VocabularyTypes.h"
 #include "rdfTypes/GeoCellGrid.h"
 #include "rdfTypes/GeometryInfo.h"
 #include "util/ExceptionHandling.h"
 #include "util/File.h"
 #include "util/Serializer/Serializer.h"
+#include "util/TypeTraits.h"
 #include "util/Views.h"
 
 // A `GeoVocabulary` holds Well-Known Text (WKT) literals. In contrast to the
@@ -50,6 +53,13 @@ class GeoVocabulary {
  private:
   using GeometryInfo = ad_utility::GeometryInfo;
   using GeoCellGrid = ad_utility::GeoCellGrid;
+
+  // The index of a word is computed from its position in the underlying
+  // vocabulary (see `indexFromPosition`), so the positions must be contiguous,
+  // which they are not for the vocabularies with "holes".
+  static_assert(!ad_utility::SameAsAny<
+                UnderlyingVocabulary, VocabularyInMemoryBinSearch,
+                CompressedVocabulary<VocabularyInMemoryBinSearch>>);
 
   UnderlyingVocabulary literals_;
 

--- a/src/index/vocabulary/PolymorphicVocabulary.h
+++ b/src/index/vocabulary/PolymorphicVocabulary.h
@@ -79,6 +79,35 @@ class PolymorphicVocabulary {
   // `VocabularyType` has already been set via `resetToType` above.
   void open(const std::string& filename);
 
+  // Forward the geo cell grid to the currently active vocabulary if it is a
+  // `SplitVocabulary` (which forwards it to its `GeoVocabulary`); no-op
+  // otherwise.
+  void setGeoCellGrid(std::optional<ad_utility::GeoCellGrid> grid) {
+    std::visit(
+        [&grid](auto& vocab) {
+          using T = std::decay_t<decltype(vocab)>;
+          if constexpr (isSplitVocabulary<T>) {
+            vocab.setGeoCellGrid(grid);
+          }
+        },
+        vocab_);
+  }
+
+  // The geo cell grid of an underlying `GeoVocabulary`, or `std::nullopt` if
+  // the active vocabulary is not a `SplitVocabulary` holding one with a grid.
+  std::optional<ad_utility::GeoCellGrid> getGeoCellGrid() const {
+    return std::visit(
+        [](const auto& vocab) -> std::optional<ad_utility::GeoCellGrid> {
+          using T = std::decay_t<decltype(vocab)>;
+          if constexpr (isSplitVocabulary<T>) {
+            return vocab.getGeoCellGrid();
+          } else {
+            return std::nullopt;
+          }
+        },
+        vocab_);
+  }
+
   // Close the vocabulary s.t. it consumes no more RAM.
   void close();
 

--- a/src/index/vocabulary/PolymorphicVocabulary.h
+++ b/src/index/vocabulary/PolymorphicVocabulary.h
@@ -86,7 +86,7 @@ class PolymorphicVocabulary {
     std::visit(
         [&grid](auto& vocab) {
           using T = std::decay_t<decltype(vocab)>;
-          if constexpr (isSplitVocabulary<T>) {
+          if constexpr (MaybeProvidesGeoCellGrid<T>) {
             vocab.setGeoCellGrid(grid);
           }
         },
@@ -99,7 +99,7 @@ class PolymorphicVocabulary {
     return std::visit(
         [](const auto& vocab) -> std::optional<ad_utility::GeoCellGrid> {
           using T = std::decay_t<decltype(vocab)>;
-          if constexpr (isSplitVocabulary<T>) {
+          if constexpr (MaybeProvidesGeoCellGrid<T>) {
             return vocab.getGeoCellGrid();
           } else {
             return std::nullopt;

--- a/src/index/vocabulary/SplitVocabulary.h
+++ b/src/index/vocabulary/SplitVocabulary.h
@@ -348,8 +348,8 @@ class SplitVocabulary {
   // plus the corresponding one of the `FilenameSuffixes`.
   void open(const std::string& filename);
 
-  // Forward the geo cell grid to any underlying `GeoVocabulary` (see there
-  // for the effect). No-op if there is none.
+  // Forward the geo cell grid to the underlying `GeoVocabulary`, if there is
+  // one (see there for the effect). No-op otherwise.
   void setGeoCellGrid(std::optional<ad_utility::GeoCellGrid> grid) {
     for (auto& vocab : underlying_) {
       std::visit(
@@ -363,8 +363,9 @@ class SplitVocabulary {
     }
   }
 
-  // The geo cell grid of an underlying `GeoVocabulary`, or `std::nullopt` if
-  // there is none or it has no grid.
+  // The geo cell grid of the underlying `GeoVocabulary` (there is at most
+  // one, see the `static_assert` above), or `std::nullopt` if there is none
+  // or it has no grid.
   std::optional<ad_utility::GeoCellGrid> getGeoCellGrid() const {
     std::optional<ad_utility::GeoCellGrid> result = std::nullopt;
     for (const auto& vocab : underlying_) {
@@ -372,9 +373,7 @@ class SplitVocabulary {
           [&result](const auto& v) {
             using T = std::decay_t<decltype(v)>;
             if constexpr (ad_utility::isInstantiation<T, GeoVocabulary>) {
-              if (v.getGeoCellGrid().has_value()) {
-                result = v.getGeoCellGrid();
-              }
+              result = v.getGeoCellGrid();
             }
           },
           vocab);

--- a/src/index/vocabulary/SplitVocabulary.h
+++ b/src/index/vocabulary/SplitVocabulary.h
@@ -114,6 +114,13 @@ class SplitVocabulary {
   static_assert(!(... || isSplitVocabulary<UnderlyingVocabularies>));
   static_assert(
       !ad_utility::SameAsAny<PolymorphicVocabulary, UnderlyingVocabularies...>);
+  // At most one of the underlying vocabularies may be a `GeoVocabulary`, so
+  // that `setGeoCellGrid` and `getGeoCellGrid` below refer to a unique one.
+  static_assert(
+      (0 + ... +
+       (ad_utility::isInstantiation<UnderlyingVocabularies, GeoVocabulary>
+            ? 1
+            : 0)) <= 1);
 
   // Assuming we only make use of methods that all UnderlyingVocabularies
   // provide, we simplify this class by using an array over a variant instead of

--- a/src/index/vocabulary/SplitVocabulary.h
+++ b/src/index/vocabulary/SplitVocabulary.h
@@ -1,6 +1,12 @@
-// Copyright 2025 University of Freiburg
-// Chair of Algorithms and Data Structures
-// Author: Christoph Ullinger <ullingec@cs.uni-freiburg.de>
+// Copyright 2025 - 2026 The QLever Authors, in particular:
+//
+// 2025 Christoph Ullinger <ullingec@cs.uni-freiburg.de>, UFR
+// 2026 Hannah Bast <bast@cs.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+//
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
 
 #ifndef QLEVER_SRC_INDEX_VOCABULARY_SPLITVOCABULARY_H
 #define QLEVER_SRC_INDEX_VOCABULARY_SPLITVOCABULARY_H
@@ -19,6 +25,7 @@
 #include "global/ValueId.h"
 #include "index/vocabulary/GeoVocabulary.h"
 #include "index/vocabulary/VocabularyTypes.h"
+#include "rdfTypes/GeoCellGrid.h"
 #include "rdfTypes/GeometryInfo.h"
 #include "util/BitUtils.h"
 #include "util/ConstexprUtils.h"
@@ -220,7 +227,13 @@ class SplitVocabulary {
     // Retrieve the word from the indicated underlying vocabulary
     return std::visit(
         [&unmarkedIdx](auto& vocab) {
-          AD_CORRECTNESS_CHECK(unmarkedIdx < vocab.size());
+          // For a `GeoVocabulary` with a geo cell grid, the indices exceed
+          // its size by construction (the cell index is in the upper bits);
+          // it checks the position itself.
+          using T = std::decay_t<decltype(vocab)>;
+          if constexpr (!ad_utility::isInstantiation<T, GeoVocabulary>) {
+            AD_CORRECTNESS_CHECK(unmarkedIdx < vocab.size());
+          }
           // TODO<ullingerc>: How to handle if the different underlying
           // vocabularies return different types (std::string / std::string_view
           // / ...) on their operator[] implementations? A variant will probably
@@ -303,10 +316,21 @@ class SplitVocabulary {
                    word, comparator, marker)
                    .positionOfWord(word);
     if (!pos.has_value()) {
-      auto end =
-          addMarker(std::visit([](auto& v) -> uint64_t { return v.size(); },
-                               underlying_[marker]),
-                    marker);
+      // The word is larger than all words of its vocabulary, so return its
+      // past-the-end index. For a `GeoVocabulary` with a geo cell grid this
+      // is not simply the size (see `GeoVocabulary::endIndex`).
+      auto end = addMarker(
+          std::visit(
+              [](auto& v) -> uint64_t {
+                using T = std::decay_t<decltype(v)>;
+                if constexpr (ad_utility::isInstantiation<T, GeoVocabulary>) {
+                  return v.endIndex();
+                } else {
+                  return v.size();
+                }
+              },
+              underlying_[marker]),
+          marker);
       return {end, end};
     }
     return pos.value();
@@ -331,6 +355,40 @@ class SplitVocabulary {
   // Load from file: open all underlying vocabularies on the given base filename
   // plus the corresponding one of the `FilenameSuffixes`.
   void open(const std::string& filename);
+
+  // Forward the geo cell grid to any underlying `GeoVocabulary` (see there
+  // for the effect). No-op if there is none.
+  void setGeoCellGrid(std::optional<ad_utility::GeoCellGrid> grid) {
+    for (auto& vocab : underlying_) {
+      std::visit(
+          [&grid](auto& v) {
+            using T = std::decay_t<decltype(v)>;
+            if constexpr (ad_utility::isInstantiation<T, GeoVocabulary>) {
+              v.setGeoCellGrid(grid);
+            }
+          },
+          vocab);
+    }
+  }
+
+  // The geo cell grid of an underlying `GeoVocabulary`, or `std::nullopt` if
+  // there is none or it has no grid.
+  std::optional<ad_utility::GeoCellGrid> getGeoCellGrid() const {
+    std::optional<ad_utility::GeoCellGrid> result = std::nullopt;
+    for (const auto& vocab : underlying_) {
+      std::visit(
+          [&result](const auto& v) {
+            using T = std::decay_t<decltype(v)>;
+            if constexpr (ad_utility::isInstantiation<T, GeoVocabulary>) {
+              if (v.getGeoCellGrid().has_value()) {
+                result = v.getGeoCellGrid();
+              }
+            }
+          },
+          vocab);
+    }
+    return result;
+  }
 
   // This word writer writes words to different vocabularies depending on the
   // result of SplitFunction.

--- a/src/index/vocabulary/SplitVocabulary.h
+++ b/src/index/vocabulary/SplitVocabulary.h
@@ -317,20 +317,8 @@ class SplitVocabulary {
                    .positionOfWord(word);
     if (!pos.has_value()) {
       // The word is larger than all words of its vocabulary, so return its
-      // past-the-end index. For a `GeoVocabulary` with a geo cell grid this
-      // is not simply the size (see `GeoVocabulary::endIndex`).
-      auto end = addMarker(
-          std::visit(
-              [](auto& v) -> uint64_t {
-                using T = std::decay_t<decltype(v)>;
-                if constexpr (ad_utility::isInstantiation<T, GeoVocabulary>) {
-                  return v.endIndex();
-                } else {
-                  return v.size();
-                }
-              },
-              underlying_[marker]),
-          marker);
+      // past-the-end index.
+      auto end = addMarker(endIndexOfUnderlying(marker), marker);
       return {end, end};
     }
     return pos.value();
@@ -388,6 +376,22 @@ class SplitVocabulary {
           vocab);
     }
     return result;
+  }
+
+  // The past-the-end index of the underlying vocabulary with the given
+  // `marker`. For a `GeoVocabulary` with a geo cell grid this is not simply
+  // the size (see `GeoVocabulary::endIndex`).
+  uint64_t endIndexOfUnderlying(uint8_t marker) const {
+    return std::visit(
+        [](const auto& v) -> uint64_t {
+          using T = std::decay_t<decltype(v)>;
+          if constexpr (ad_utility::isInstantiation<T, GeoVocabulary>) {
+            return v.endIndex();
+          } else {
+            return v.size();
+          }
+        },
+        underlying_[marker]);
   }
 
   // This word writer writes words to different vocabularies depending on the

--- a/src/index/vocabulary/SplitVocabulary.h
+++ b/src/index/vocabulary/SplitVocabulary.h
@@ -237,10 +237,7 @@ class SplitVocabulary {
           // For a `GeoVocabulary` with a geo cell grid, the indices exceed
           // its size by construction (the cell index is in the upper bits);
           // it checks the position itself.
-          using T = std::decay_t<decltype(vocab)>;
-          if constexpr (!ad_utility::isInstantiation<T, GeoVocabulary>) {
-            AD_CORRECTNESS_CHECK(unmarkedIdx < vocab.size());
-          }
+          AD_CORRECTNESS_CHECK(unmarkedIdx < endIndexOf(vocab));
           // TODO<ullingerc>: How to handle if the different underlying
           // vocabularies return different types (std::string / std::string_view
           // / ...) on their operator[] implementations? A variant will probably
@@ -385,20 +382,22 @@ class SplitVocabulary {
     return result;
   }
 
-  // The past-the-end index of the underlying vocabulary with the given
-  // `marker`. For a `GeoVocabulary` with a geo cell grid this is not simply
-  // the size (see `GeoVocabulary::endIndex`).
+  // The past-the-end index of an underlying vocabulary, which is also the
+  // upper bound for its valid indices. For a `GeoVocabulary` with a geo cell
+  // grid this is not simply the size (see `GeoVocabulary::endIndex`).
+  template <typename V>
+  static uint64_t endIndexOf(const V& vocab) {
+    if constexpr (ad_utility::isInstantiation<V, GeoVocabulary>) {
+      return vocab.endIndex();
+    } else {
+      return vocab.size();
+    }
+  }
+
+  // The same for the underlying vocabulary with the given `marker`.
   uint64_t endIndexOfUnderlying(uint8_t marker) const {
-    return std::visit(
-        [](const auto& v) -> uint64_t {
-          using T = std::decay_t<decltype(v)>;
-          if constexpr (ad_utility::isInstantiation<T, GeoVocabulary>) {
-            return v.endIndex();
-          } else {
-            return v.size();
-          }
-        },
-        underlying_[marker]);
+    return std::visit([](const auto& v) { return endIndexOf(v); },
+                      underlying_[marker]);
   }
 
   // This word writer writes words to different vocabularies depending on the

--- a/src/index/vocabulary/Vocabulary.h
+++ b/src/index/vocabulary/Vocabulary.h
@@ -254,10 +254,11 @@ class Vocabulary {
 
   // Set the geo cell grid of the geo vocabulary (see `GeoVocabulary`), which
   // must happen before the vocabulary is opened. No-op unless the underlying
-  // vocabulary is a `PolymorphicVocabulary` holding a `SplitVocabulary` with
-  // a `GeoVocabulary`.
+  // vocabulary is a `SplitVocabulary` (or a `PolymorphicVocabulary` holding
+  // one) with a `GeoVocabulary`.
   void setGeoCellGrid(std::optional<ad_utility::GeoCellGrid> grid) {
-    if constexpr (std::is_same_v<UnderlyingVocabulary, PolymorphicVocabulary>) {
+    if constexpr (std::is_same_v<UnderlyingVocabulary, PolymorphicVocabulary> ||
+                  isSplitVocabulary<UnderlyingVocabulary>) {
       vocabulary_.getUnderlyingVocabulary().setGeoCellGrid(std::move(grid));
     }
   }
@@ -265,7 +266,8 @@ class Vocabulary {
   // The geo cell grid of the geo vocabulary, or `std::nullopt` if there is
   // none.
   std::optional<ad_utility::GeoCellGrid> getGeoCellGrid() const {
-    if constexpr (std::is_same_v<UnderlyingVocabulary, PolymorphicVocabulary>) {
+    if constexpr (std::is_same_v<UnderlyingVocabulary, PolymorphicVocabulary> ||
+                  isSplitVocabulary<UnderlyingVocabulary>) {
       return vocabulary_.getUnderlyingVocabulary().getGeoCellGrid();
     } else {
       return std::nullopt;

--- a/src/index/vocabulary/Vocabulary.h
+++ b/src/index/vocabulary/Vocabulary.h
@@ -254,11 +254,9 @@ class Vocabulary {
 
   // Set the geo cell grid of the geo vocabulary (see `GeoVocabulary`), which
   // must happen before the vocabulary is opened. No-op unless the underlying
-  // vocabulary is a `SplitVocabulary` (or a `PolymorphicVocabulary` holding
-  // one) with a `GeoVocabulary`.
+  // vocabulary might have a grid (see `MaybeProvidesGeoCellGrid`).
   void setGeoCellGrid(std::optional<ad_utility::GeoCellGrid> grid) {
-    if constexpr (std::is_same_v<UnderlyingVocabulary, PolymorphicVocabulary> ||
-                  isSplitVocabulary<UnderlyingVocabulary>) {
+    if constexpr (MaybeProvidesGeoCellGrid<UnderlyingVocabulary>) {
       vocabulary_.getUnderlyingVocabulary().setGeoCellGrid(std::move(grid));
     }
   }
@@ -266,8 +264,7 @@ class Vocabulary {
   // The geo cell grid of the geo vocabulary, or `std::nullopt` if there is
   // none.
   std::optional<ad_utility::GeoCellGrid> getGeoCellGrid() const {
-    if constexpr (std::is_same_v<UnderlyingVocabulary, PolymorphicVocabulary> ||
-                  isSplitVocabulary<UnderlyingVocabulary>) {
+    if constexpr (MaybeProvidesGeoCellGrid<UnderlyingVocabulary>) {
       return vocabulary_.getUnderlyingVocabulary().getGeoCellGrid();
     } else {
       return std::nullopt;

--- a/src/index/vocabulary/Vocabulary.h
+++ b/src/index/vocabulary/Vocabulary.h
@@ -252,6 +252,26 @@ class Vocabulary {
     }
   }
 
+  // Set the geo cell grid of the geo vocabulary (see `GeoVocabulary`), which
+  // must happen before the vocabulary is opened. No-op unless the underlying
+  // vocabulary is a `PolymorphicVocabulary` holding a `SplitVocabulary` with
+  // a `GeoVocabulary`.
+  void setGeoCellGrid(std::optional<ad_utility::GeoCellGrid> grid) {
+    if constexpr (std::is_same_v<UnderlyingVocabulary, PolymorphicVocabulary>) {
+      vocabulary_.getUnderlyingVocabulary().setGeoCellGrid(std::move(grid));
+    }
+  }
+
+  // The geo cell grid of the geo vocabulary, or `std::nullopt` if there is
+  // none.
+  std::optional<ad_utility::GeoCellGrid> getGeoCellGrid() const {
+    if constexpr (std::is_same_v<UnderlyingVocabulary, PolymorphicVocabulary>) {
+      return vocabulary_.getUnderlyingVocabulary().getGeoCellGrid();
+    } else {
+      return std::nullopt;
+    }
+  }
+
   // Replace the words of the currently held vocabulary with a non-owning,
   // zero-copy view directly into `serializer`'s buffer (see e.g.
   // `VocabularyInMemory::fromZeroCopyDeserializer`). This only works for

--- a/src/index/vocabulary/VocabularyConstraints.h
+++ b/src/index/vocabulary/VocabularyConstraints.h
@@ -62,6 +62,16 @@ CPP_concept MaybeProvidesGeometryInfo =
     std::is_same_v<T, PolymorphicVocabulary> || isSplitVocabulary<T> ||
     ad_utility::isInstantiation<T, GeoVocabulary>;
 
+// This concept states that the given vocabulary implementation `T` might have
+// a geo cell grid (see `GeoVocabulary`), and hence has the member functions
+// `setGeoCellGrid` and `getGeoCellGrid`. As for `MaybeProvidesGeometryInfo`,
+// this is a static property of the type; whether there actually is a grid is
+// only known at runtime.
+template <typename T>
+CPP_concept MaybeProvidesGeoCellGrid =
+    std::is_same_v<T, PolymorphicVocabulary> || isSplitVocabulary<T> ||
+    ad_utility::isInstantiation<T, GeoVocabulary>;
+
 // As a safeguard for the future: This concept states that a vocabulary
 // implementation will never provide precomputed `GeometryInfo` via a
 // `getGeoInfo` method. A vocabulary class should only be added if it can be

--- a/src/rdfTypes/GeoCellGrid.h
+++ b/src/rdfTypes/GeoCellGrid.h
@@ -139,19 +139,21 @@ class GeoCellGrid {
   // must be a pure function of the literal string.
   CellIndex cellIndexFromWktLiteral(std::string_view wktLiteral) const;
 
-  // Combine a cell index and a position into an annotated vocabulary index
-  // and take it apart again. The cell index must be at most `sentinelCell()`
-  // and the position must be smaller than `maxNumWords()`.
-  uint64_t annotateIndex(CellIndex cellIndex, uint64_t position) const {
+  // Combine a cell index and a position into a vocabulary index (the cell
+  // index in the upper bits, the position in the lower bits) and take it
+  // apart again. The cell index must be at most `sentinelCell()` and the
+  // position must be smaller than `maxNumWords()`.
+  uint64_t indexFromCellAndPosition(CellIndex cellIndex,
+                                    uint64_t position) const {
     AD_EXPENSIVE_CHECK(cellIndex <= sentinelCell());
     AD_EXPENSIVE_CHECK(position < maxNumWords());
     return (cellIndex << numPositionBits()) | position;
   }
-  CellIndex cellOfIndex(uint64_t annotatedIndex) const {
-    return annotatedIndex >> numPositionBits();
+  CellIndex cellOfIndex(uint64_t index) const {
+    return index >> numPositionBits();
   }
-  uint64_t positionOfIndex(uint64_t annotatedIndex) const {
-    return annotatedIndex & (maxNumWords() - 1);
+  uint64_t positionOfIndex(uint64_t index) const {
+    return index & (maxNumWords() - 1);
   }
 
   // For the rectangle given by the two corner points, compute closed,

--- a/src/rdfTypes/GeoCellGrid.h
+++ b/src/rdfTypes/GeoCellGrid.h
@@ -19,6 +19,7 @@
 #include "backports/three_way_comparison.h"
 #include "global/ValueId.h"
 #include "rdfTypes/GeometryInfo.h"
+#include "util/BitUtils.h"
 #include "util/EnumWithStrings.h"
 #include "util/Exception.h"
 
@@ -153,7 +154,7 @@ class GeoCellGrid {
     return index >> numPositionBits();
   }
   uint64_t positionOfIndex(uint64_t index) const {
-    return index & (maxNumWords() - 1);
+    return index & ad_utility::bitMaskForLowerBits(numPositionBits());
   }
 
   // For the rectangle given by the two corner points, compute closed,

--- a/test/GeoCellGridTest.cpp
+++ b/test/GeoCellGridTest.cpp
@@ -119,25 +119,25 @@ TEST(GeoCellGrid, cellIndexFromBoundingBoxAndWktLiteral) {
 }
 
 // Test the round trip between a pair of cell index and position and the
-// annotated vocabulary index.
-TEST(GeoCellGrid, annotateIndexRoundtrip) {
+// vocabulary index.
+TEST(GeoCellGrid, indexFromCellAndPositionRoundtrip) {
   GeoCellGrid grid{4};
-  uint64_t annotated = grid.annotateIndex(5, 7);
+  uint64_t index = grid.indexFromCellAndPosition(5, 7);
 
   // `cellOfIndex` and `positionOfIndex` are the two inverses of
-  // `annotateIndex`.
-  EXPECT_EQ(grid.cellOfIndex(annotated), 5u);
-  EXPECT_EQ(grid.positionOfIndex(annotated), 7u);
+  // `indexFromCellAndPosition`.
+  EXPECT_EQ(grid.cellOfIndex(index), 5u);
+  EXPECT_EQ(grid.positionOfIndex(index), 7u);
 
-  // The annotated index has the documented bit layout, with the cell index
-  // above the position.
-  EXPECT_EQ(annotated, (uint64_t{5} << grid.numPositionBits()) | 7);
+  // The index has the documented bit layout, with the cell index above the
+  // position.
+  EXPECT_EQ(index, (uint64_t{5} << grid.numPositionBits()) | 7);
 
   // A cell index above the sentinel or a position that does not fit are
   // caught by the expensive checks.
   if (ad_utility::areExpensiveChecksEnabled) {
-    EXPECT_ANY_THROW(grid.annotateIndex(grid.sentinelCell() + 1, 0));
-    EXPECT_ANY_THROW(grid.annotateIndex(0, grid.maxNumWords()));
+    EXPECT_ANY_THROW(grid.indexFromCellAndPosition(grid.sentinelCell() + 1, 0));
+    EXPECT_ANY_THROW(grid.indexFromCellAndPosition(0, grid.maxNumWords()));
   }
 }
 

--- a/test/IndexTest.cpp
+++ b/test/IndexTest.cpp
@@ -34,6 +34,7 @@
 #include "index/IndexImpl.h"
 #include "index/Permutation.h"
 #include "index/vocabulary/VocabularyType.h"
+#include "rdfTypes/GeoCellGrid.h"
 #include "util/FilesystemHelpers.h"
 #include "util/HashSet.h"
 #include "util/IndexTestHelpers.h"
@@ -452,6 +453,42 @@ TEST(IndexTest, emptyTextIndex) {
         qec->getIndex().getWordPostingsForTerm("*", qec->getAllocator());
     EXPECT_EQ(result.size(), 0);
   }
+}
+
+// Test that the geo cell grid (see `GeoVocabulary`) is read from the index
+// configuration when an index is loaded, with `flat` as the default scheme.
+// NOTE: Building an index with a grid is a follow-up change, so the
+// configuration of an index built without a grid is edited by hand here.
+TEST(IndexTest, geoCellGridFromConfiguration) {
+  ad_utility::testing::TestIndexConfig config{
+      "<a> <p> \"LINESTRING(7 48, 8 49)\"^^<http://www.opengis.net/ont/"
+      "geosparql#wktLiteral> ."};
+  config.vocabularyType = ad_utility::VocabularyType::OnDiskCompressedGeoSplit;
+  auto* qec = ad_utility::testing::getQec(config);
+  const auto& base = qec->getIndex().getOnDiskBase();
+  EXPECT_FALSE(qec->getIndex().getVocab().getGeoCellGrid().has_value());
+
+  auto configFilename = absl::StrCat(base, CONFIGURATION_FILE);
+  auto loadWithConfiguration = [&](const nlohmann::json& additionalKeys) {
+    nlohmann::json configuration;
+    {
+      std::ifstream in{configFilename};
+      in >> configuration;
+    }
+    configuration.update(additionalKeys);
+    {
+      auto out = ad_utility::makeOfstream(configFilename);
+      out << configuration;
+    }
+    Index index{ad_utility::makeUnlimitedAllocator<Id>()};
+    index.createFromOnDiskIndex(base, false);
+    return index.getVocab().getGeoCellGrid();
+  };
+  EXPECT_EQ(loadWithConfiguration({{"geo-cell-grid-level", 2}}),
+            std::optional{ad_utility::GeoCellGrid{2}});
+  EXPECT_EQ(loadWithConfiguration(
+                {{"geo-cell-grid-level", 3}, {"geo-cell-grid-scheme", "flat"}}),
+            std::optional{ad_utility::GeoCellGrid{3}});
 }
 
 // Regression test for #3191.

--- a/test/IndexTest.cpp
+++ b/test/IndexTest.cpp
@@ -489,6 +489,11 @@ TEST(IndexTest, geoCellGridFromConfiguration) {
   EXPECT_EQ(loadWithConfiguration(
                 {{"geo-cell-grid-level", 3}, {"geo-cell-grid-scheme", "flat"}}),
             std::optional{ad_utility::GeoCellGrid{3}});
+
+  // A level that does not fit the grid is rejected.
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      loadWithConfiguration({{"geo-cell-grid-level", 300}}),
+      ::testing::HasSubstr("Invalid value 300"));
 }
 
 // Regression test for #3191.

--- a/test/VocabularyTest.cpp
+++ b/test/VocabularyTest.cpp
@@ -8,9 +8,14 @@
 #include <cstdio>
 #include <vector>
 
+#include "global/Constants.h"
+#include "index/vocabulary/CompressedVocabulary.h"
+#include "index/vocabulary/SplitVocabulary.h"
 #include "index/vocabulary/Vocabulary.h"
+#include "index/vocabulary/VocabularyInternalExternal.h"
 #include "index/vocabulary/VocabularyTestHelpers.h"
 #include "index/vocabulary/VocabularyType.h"
+#include "rdfTypes/GeoCellGrid.h"
 #include "util/GTestHelpers.h"
 #include "util/Serializer/ByteBufferSerializer.h"
 #include "util/json.h"
@@ -87,6 +92,68 @@ RdfsVocabularyHandle createExampleVocabulary(
                               words};
 }
 }  // namespace
+
+// Test that the geo cell grid (see `GeoVocabulary`) is forwarded through the
+// `Vocabulary` to a geo split vocabulary, and that the indices of such a
+// vocabulary carry the grid cell. Other vocabularies have no grid.
+TEST(VocabularyTest, geoCellGrid) {
+  using ad_utility::GeoCellGrid;
+  VocabularyType type{VocabularyType::Enum::OnDiskCompressedGeoSplit};
+  std::string filename = absl::StrCat(gtestCurrentTestName(), ".dat");
+  auto deleteFiles = [&filename, &type]() {
+    for (std::string_view suffix : PolymorphicVocabulary::fileSuffixes(type)) {
+      ad_utility::deleteFile(absl::StrCat(filename, suffix), false);
+    }
+  };
+  deleteFiles();
+  absl::Cleanup cleanup{deleteFiles};
+
+  // With a grid of level 2, the first literal is in cell 3, the other two in
+  // cell 12. The words have to be written in this order.
+  auto wkt = [](std::string_view content) {
+    return absl::StrCat("\"", content, GEO_LITERAL_SUFFIX);
+  };
+  std::string w3 = wkt("LINESTRING(170 -80, 171 -81)");
+  std::string w12 = wkt("LINESTRING(-170 80, -171 81)");
+  std::string w12b = wkt("LINESTRING(-170 80, -172 82)");
+  GeoCellGrid grid{2};
+
+  RdfsVocabulary vocab;
+  vocab.resetToType(type);
+  EXPECT_FALSE(vocab.getGeoCellGrid().has_value());
+  vocab.setGeoCellGrid(grid);
+  EXPECT_EQ(vocab.getGeoCellGrid(), std::optional{grid});
+  {
+    auto writer = vocab.makeWordWriterPtr(filename);
+    writer->readableName() = "test";
+    for (const auto& word : {"<a>", w3.c_str(), w12.c_str(), w12b.c_str()}) {
+      (*writer)(word, false);
+    }
+    writer->finish();
+  }
+  vocab.readFromFile(filename);
+  EXPECT_EQ(vocab.getGeoCellGrid(), std::optional{grid});
+
+  // The WKT literals are found under their cell-carrying indices, the other
+  // word in the main vocabulary.
+  using SGV =
+      SplitGeoVocabulary<CompressedVocabulary<VocabularyInternalExternal>>;
+  auto indexOf = [&grid](uint64_t cell, uint64_t position) {
+    return VocabIndex::make(
+        SGV::addMarker(grid.indexFromCellAndPosition(cell, position), 1));
+  };
+  EXPECT_EQ(vocab[indexOf(3, 0)], w3);
+  EXPECT_EQ(vocab[indexOf(12, 1)], w12);
+  EXPECT_EQ(vocab[indexOf(12, 2)], w12b);
+  VocabIndex idx;
+  ASSERT_TRUE(vocab.getId("<a>", &idx));
+  EXPECT_EQ(vocab[idx], "<a>");
+
+  // A vocabulary that cannot hold a `GeoVocabulary` ignores the grid.
+  TextVocabulary textVocab;
+  textVocab.setGeoCellGrid(grid);
+  EXPECT_FALSE(textVocab.getGeoCellGrid().has_value());
+}
 
 // _____________________________________________________________________________
 TEST(VocabularyTest, getIdForWordTest) {

--- a/test/index/vocabulary/GeoVocabularyTest.cpp
+++ b/test/index/vocabulary/GeoVocabularyTest.cpp
@@ -300,12 +300,15 @@ TEST(GeoVocabularyTest, WordWriterDestructor) {
 
 // Test that a `GeoVocabulary` with a geo cell grid hands out indices with the
 // cell index in the upper bits and translates between indices and positions
-// in all its operations. Templated on the underlying vocabulary, see the
-// `TEST` below.
-template <typename UnderlyingVocabulary>
-void testGeoCellGridIndices(const std::string& fn) {
-  using GV = GeoVocabulary<UnderlyingVocabulary>;
+// in all its operations.
+TYPED_TEST(GeoVocabularyUnderlyingVocabTypedTest, GeoCellGridIndices) {
+  using GV = GeoVocabulary<TypeParam>;
   GeoCellGrid grid{2};
+  const std::string fn = this->filename();
+  auto cleanup = this->getFileCleanup();
+  auto cleanupBad = vocabulary_test::makeVocabFileCleanup<GV>(fn + ".bad");
+  auto cleanupEmpty = vocabulary_test::makeVocabFileCleanup<GV>(fn + ".empty");
+  auto cleanupFull = vocabulary_test::makeVocabFileCleanup<GV>(fn + ".full");
   auto wkt = [](std::string_view content) {
     return absl::StrCat("\"", content, GEO_LITERAL_SUFFIX);
   };
@@ -396,8 +399,20 @@ void testGeoCellGridIndices(const std::string& fn) {
     EXPECT_EQ(wordAndIndex.word(), words[i]);
   }
   // A word larger than all words (same sentinel cell, but lexicographically
-  // larger) yields the past-the-end result.
+  // larger) yields the past-the-end result. `upper_bound` translates the
+  // same way.
   EXPECT_TRUE(geoVocab.lower_bound(wkt("ZZZ"), comparator).isEnd());
+  EXPECT_EQ(geoVocab.upper_bound(w0, comparator).index(), expectedIndices[1]);
+  EXPECT_TRUE(geoVocab.upper_bound(w3, comparator).isEnd());
+
+  // The streamed batch lookup translates the indices, too.
+  std::vector<std::vector<size_t>> batches{
+      {expectedIndices[2]}, {expectedIndices[0], expectedIndices[3]}};
+  const auto expectedBatches = batches;
+  auto streamedResults =
+      geoVocab.lookupBatchesStreamed(VocabLookupInput{std::move(batches)});
+  vocabulary_test::assertStreamedLookupMatchesVocabularyAtIndices(
+      geoVocab, streamedResults, expectedBatches);
 
   // Without the grid, the same files are read with plain positions as
   // indices.
@@ -444,13 +459,6 @@ void testGeoCellGridIndices(const std::string& fn) {
                                  ::testing::HasSubstr("Too many WKT literals"));
     ww->finish();
   }
-}
-
-// Run the test above for both underlying vocabularies of a `GeoVocabulary`.
-TEST(GeoVocabulary, geoCellGridIndices) {
-  testGeoCellGridIndices<VocabularyInMemory>("geocellvocab-test-inmemory.dat");
-  testGeoCellGridIndices<CompressedVocabulary<VocabularyInternalExternal>>(
-      "geocellvocab-test-compressed.dat");
 }
 
 }  // namespace

--- a/test/index/vocabulary/GeoVocabularyTest.cpp
+++ b/test/index/vocabulary/GeoVocabularyTest.cpp
@@ -366,7 +366,7 @@ void testGeoCellGridIndices(const std::string& fn) {
       geoVocab.getGeoInfo(grid.indexFromCellAndPosition(3, words.size())));
 
   // The grid of an opened vocabulary cannot be changed anymore.
-  geoVocab.setGeoCellGrid(std::nullopt);
+  EXPECT_ANY_THROW(geoVocab.setGeoCellGrid(std::nullopt));
   EXPECT_EQ(geoVocab.getGeoCellGrid(), std::optional{grid});
 
   // The past-the-end index is larger than every valid index.

--- a/test/index/vocabulary/GeoVocabularyTest.cpp
+++ b/test/index/vocabulary/GeoVocabularyTest.cpp
@@ -298,4 +298,109 @@ TEST(GeoVocabularyTest, WordWriterDestructor) {
   wordWriter2.reset();
 }
 
+// Test that a `GeoVocabulary` with a geo cell grid hands out indices with the
+// cell index in the upper bits and translates between indices and positions
+// in all its operations.
+TEST(GeoVocabulary, geoCellGridIndices) {
+  using GV = GeoVocabulary<VocabularyInMemory>;
+  GeoCellGrid grid{2};
+  const std::string fn = "geocellvocab-test.dat";
+  auto wkt = [](std::string_view content) {
+    return absl::StrCat("\"", content, "\"", GEO_LITERAL_SUFFIX);
+  };
+
+  // Words in (cell index, lexicographic) order: cell 3, cell 12 (twice), the
+  // sentinel cell (for the unparsable literal).
+  std::string w0 = wkt("POINT(170 -80)");  // cell 3
+  std::string w1 = wkt("POINT(-170 80)");  // cell 12
+  std::string w2 = wkt("POINT(-171 80)");  // cell 12
+  std::string w3 = wkt("NOTAGEOMETRY");    // sentinel (invalid)
+  std::vector<std::string> words{w0, w1, w2, w3};
+  std::vector<uint64_t> expectedIndices{
+      grid.indexFromCellAndPosition(3, 0), grid.indexFromCellAndPosition(12, 1),
+      grid.indexFromCellAndPosition(12, 2),
+      grid.indexFromCellAndPosition(grid.sentinelCell(), 3)};
+
+  // The writer assigns the indices.
+  {
+    GV writeVocab;
+    writeVocab.setGeoCellGrid(grid);
+    auto ww = writeVocab.makeDiskWriterPtr(fn);
+    ww->readableName() = "test";
+    for (size_t i = 0; i < words.size(); ++i) {
+      EXPECT_EQ((*ww)(words[i], false), expectedIndices[i]);
+    }
+    ww->finish();
+  }
+
+  // The grid is not stored with the vocabulary, it has to be set before
+  // opening (the index configuration does this).
+  GV geoVocab;
+  geoVocab.setGeoCellGrid(grid);
+  geoVocab.open(fn);
+  ASSERT_TRUE(geoVocab.getGeoCellGrid().has_value());
+  EXPECT_EQ(geoVocab.getGeoCellGrid().value(), grid);
+  EXPECT_EQ(geoVocab.size(), words.size());
+
+  // Retrieval by index, and the translation between index and position in
+  // both directions (the cell is recomputed from the stored bounding box, or
+  // from the word for the invalid geometry).
+  for (size_t i = 0; i < words.size(); ++i) {
+    EXPECT_EQ(geoVocab[expectedIndices[i]], words[i]);
+    EXPECT_EQ(geoVocab.positionFromIndex(expectedIndices[i]), i);
+    EXPECT_EQ(geoVocab.indexFromPosition(i, words[i]), expectedIndices[i]);
+  }
+  EXPECT_TRUE(geoVocab.getGeoInfo(expectedIndices[0]).has_value());
+  EXPECT_FALSE(geoVocab.getGeoInfo(expectedIndices[3]).has_value());
+
+  // The past-the-end index is larger than every valid index.
+  EXPECT_EQ(geoVocab.endIndex(),
+            grid.indexFromCellAndPosition(grid.sentinelCell(), words.size()));
+
+  // `scanAll` yields the indices.
+  std::vector<uint64_t> scannedIndices;
+  for (const auto& indexAndWord : geoVocab.scanAll()) {
+    scannedIndices.push_back(indexAndWord.index_);
+  }
+  EXPECT_THAT(scannedIndices, ::testing::ElementsAreArray(expectedIndices));
+
+  // Binary search returns the indices. The comparator orders WKT literals by
+  // cell index first; here it is written by hand, in a follow-up change the
+  // `TripleComponentComparator` produces this order.
+  auto comparator = [&grid](std::string_view a, std::string_view b) {
+    auto key = [&grid](std::string_view w) {
+      return std::pair{grid.cellIndexFromWktLiteral(w), w};
+    };
+    return key(a) < key(b);
+  };
+  for (size_t i = 0; i < words.size(); ++i) {
+    auto wordAndIndex = geoVocab.lower_bound(words[i], comparator);
+    ASSERT_FALSE(wordAndIndex.isEnd());
+    EXPECT_EQ(wordAndIndex.index(), expectedIndices[i]);
+    EXPECT_EQ(wordAndIndex.word(), words[i]);
+  }
+
+  // Without the grid, the same files are read with plain positions as
+  // indices.
+  GV plainVocab;
+  plainVocab.open(fn);
+  EXPECT_FALSE(plainVocab.getGeoCellGrid().has_value());
+  EXPECT_EQ(plainVocab.endIndex(), words.size());
+  for (size_t i = 0; i < words.size(); ++i) {
+    EXPECT_EQ(plainVocab[i], words[i]);
+    EXPECT_EQ(plainVocab.indexFromPosition(i, words[i]), i);
+  }
+
+  // Feeding words out of cell order must fail.
+  {
+    GV badVocab;
+    badVocab.setGeoCellGrid(grid);
+    auto ww = badVocab.makeDiskWriterPtr("geocellvocab-test-bad.dat");
+    ww->readableName() = "test";
+    (*ww)(w1, false);
+    EXPECT_ANY_THROW((*ww)(w0, false));
+    ww->finish();
+  }
+}
+
 }  // namespace

--- a/test/index/vocabulary/GeoVocabularyTest.cpp
+++ b/test/index/vocabulary/GeoVocabularyTest.cpp
@@ -353,8 +353,12 @@ void testGeoCellGridIndices(const std::string& fn) {
   }
   EXPECT_TRUE(geoVocab.getGeoInfo(expectedIndices[0]).has_value());
   EXPECT_FALSE(geoVocab.getGeoInfo(expectedIndices[3]).has_value());
+  // NOTE: `lookupBatch` takes `size_t` indices, which is not the same type as
+  // `uint64_t` on all platforms.
+  std::vector<size_t> batchIndices(expectedIndices.begin(),
+                                   expectedIndices.end());
   vocabulary_test::assertLookupResultMatchesVocabularyAtIndices(
-      geoVocab, geoVocab.lookupBatch(expectedIndices), expectedIndices);
+      geoVocab, geoVocab.lookupBatch(batchIndices), batchIndices);
 
   // An index whose position part is out of range is rejected.
   EXPECT_ANY_THROW(geoVocab[grid.indexFromCellAndPosition(3, words.size())]);

--- a/test/index/vocabulary/GeoVocabularyTest.cpp
+++ b/test/index/vocabulary/GeoVocabularyTest.cpp
@@ -300,13 +300,14 @@ TEST(GeoVocabularyTest, WordWriterDestructor) {
 
 // Test that a `GeoVocabulary` with a geo cell grid hands out indices with the
 // cell index in the upper bits and translates between indices and positions
-// in all its operations.
-TEST(GeoVocabulary, geoCellGridIndices) {
-  using GV = GeoVocabulary<VocabularyInMemory>;
+// in all its operations. Templated on the underlying vocabulary, see the
+// `TEST` below.
+template <typename UnderlyingVocabulary>
+void testGeoCellGridIndices(const std::string& fn) {
+  using GV = GeoVocabulary<UnderlyingVocabulary>;
   GeoCellGrid grid{2};
-  const std::string fn = "geocellvocab-test.dat";
   auto wkt = [](std::string_view content) {
-    return absl::StrCat("\"", content, "\"", GEO_LITERAL_SUFFIX);
+    return absl::StrCat("\"", content, GEO_LITERAL_SUFFIX);
   };
 
   // Words in (cell index, lexicographic) order: cell 3, cell 12 (twice), the
@@ -352,6 +353,17 @@ TEST(GeoVocabulary, geoCellGridIndices) {
   }
   EXPECT_TRUE(geoVocab.getGeoInfo(expectedIndices[0]).has_value());
   EXPECT_FALSE(geoVocab.getGeoInfo(expectedIndices[3]).has_value());
+  vocabulary_test::assertLookupResultMatchesVocabularyAtIndices(
+      geoVocab, geoVocab.lookupBatch(expectedIndices), expectedIndices);
+
+  // An index whose position part is out of range is rejected.
+  EXPECT_ANY_THROW(geoVocab[grid.indexFromCellAndPosition(3, words.size())]);
+  EXPECT_ANY_THROW(
+      geoVocab.getGeoInfo(grid.indexFromCellAndPosition(3, words.size())));
+
+  // The grid of an opened vocabulary cannot be changed anymore.
+  geoVocab.setGeoCellGrid(std::nullopt);
+  EXPECT_EQ(geoVocab.getGeoCellGrid(), std::optional{grid});
 
   // The past-the-end index is larger than every valid index.
   EXPECT_EQ(geoVocab.endIndex(),
@@ -379,6 +391,9 @@ TEST(GeoVocabulary, geoCellGridIndices) {
     EXPECT_EQ(wordAndIndex.index(), expectedIndices[i]);
     EXPECT_EQ(wordAndIndex.word(), words[i]);
   }
+  // A word larger than all words (same sentinel cell, but lexicographically
+  // larger) yields the past-the-end result.
+  EXPECT_TRUE(geoVocab.lower_bound(wkt("ZZZ"), comparator).isEnd());
 
   // Without the grid, the same files are read with plain positions as
   // indices.
@@ -395,12 +410,43 @@ TEST(GeoVocabulary, geoCellGridIndices) {
   {
     GV badVocab;
     badVocab.setGeoCellGrid(grid);
-    auto ww = badVocab.makeDiskWriterPtr("geocellvocab-test-bad.dat");
+    auto ww = badVocab.makeDiskWriterPtr(fn + ".bad");
     ww->readableName() = "test";
     (*ww)(w1, false);
     EXPECT_ANY_THROW((*ww)(w0, false));
     ww->finish();
   }
+
+  // The past-the-end index of an empty vocabulary with a grid is 0.
+  {
+    GV emptyVocab;
+    emptyVocab.setGeoCellGrid(grid);
+    emptyVocab.makeDiskWriterPtr(fn + ".empty")->finish();
+    emptyVocab.open(fn + ".empty");
+    EXPECT_EQ(emptyVocab.endIndex(), 0u);
+  }
+
+  // The finest grid leaves only two position bits, so the fourth word does
+  // not fit anymore (one position stays free for the past-the-end index).
+  {
+    GV fullVocab;
+    fullVocab.setGeoCellGrid(GeoCellGrid{28});
+    auto ww = fullVocab.makeDiskWriterPtr(fn + ".full");
+    ww->readableName() = "test";
+    for (size_t i = 0; i < 3; ++i) {
+      (*ww)(w0, false);
+    }
+    AD_EXPECT_THROW_WITH_MESSAGE((*ww)(w0, false),
+                                 ::testing::HasSubstr("Too many WKT literals"));
+    ww->finish();
+  }
+}
+
+// Run the test above for both underlying vocabularies of a `GeoVocabulary`.
+TEST(GeoVocabulary, geoCellGridIndices) {
+  testGeoCellGridIndices<VocabularyInMemory>("geocellvocab-test-inmemory.dat");
+  testGeoCellGridIndices<CompressedVocabulary<VocabularyInternalExternal>>(
+      "geocellvocab-test-compressed.dat");
 }
 
 }  // namespace

--- a/test/index/vocabulary/PolymorphicVocabularyTest.cpp
+++ b/test/index/vocabulary/PolymorphicVocabularyTest.cpp
@@ -245,6 +245,25 @@ TEST(PolymorphicVocabulary, lookupBatchesStreamedMatchesIndividualLookups) {
   }
 }
 
+// The geo cell grid (see `GeoVocabulary`) is forwarded to the underlying
+// vocabulary if that is a `SplitVocabulary` with a `GeoVocabulary`, and
+// ignored otherwise.
+TEST(PolymorphicVocabulary, geoCellGrid) {
+  for (auto vocabType : VocabularyType::all()) {
+    PolymorphicVocabulary vocab;
+    vocab.resetToType(VocabularyType{vocabType});
+    EXPECT_FALSE(vocab.getGeoCellGrid().has_value());
+    ad_utility::GeoCellGrid grid{3};
+    vocab.setGeoCellGrid(grid);
+    bool isGeoSplit =
+        vocabType == VocabularyType::Enum::OnDiskCompressedGeoSplit;
+    EXPECT_EQ(vocab.getGeoCellGrid().has_value(), isGeoSplit);
+    if (isGeoSplit) {
+      EXPECT_EQ(vocab.getGeoCellGrid().value(), grid);
+    }
+  }
+}
+
 // Test a corner case in a `switch` statement.
 TEST(PolymorphicVocabulary, invalidVocabularyType) {
   PolymorphicVocabulary vocab;

--- a/test/index/vocabulary/SplitVocabularyTest.cpp
+++ b/test/index/vocabulary/SplitVocabularyTest.cpp
@@ -492,4 +492,69 @@ TEST(Vocabulary, SplitVocabularyWordWriterDestructor) {
   wordWriter2.reset();
 }
 
+// Test that the indices of a `GeoVocabulary` with a geo cell grid (cell index
+// in the upper bits) pass correctly through a `SplitGeoVocabulary`: they carry
+// the marker bit, exceed the size of the geo vocabulary by construction, and
+// the past-the-end bounds come from `GeoVocabulary::endIndex`.
+TEST(SplitVocabulary, geoCellGridIndicesThroughSplitVocabulary) {
+  using SGV = SplitGeoVocabulary<VocabularyInMemory>;
+  ad_utility::GeoCellGrid grid{2};
+  const std::string fn = "geocellsplitvocab-test.dat";
+  auto wkt = [](std::string_view content) {
+    return absl::StrCat("\"", content, "\"", GEO_LITERAL_SUFFIX);
+  };
+
+  std::string iri = "<http://example.org/a>";
+  std::string wkt3 = wkt("POINT(170 -80)");   // cell 3
+  std::string wkt12 = wkt("POINT(-170 80)");  // cell 12
+
+  // The comparator orders all non-WKT words first, then the WKT literals by
+  // cell index. Here it is written by hand, in a follow-up change the
+  // `TripleComponentComparator` produces this order.
+  auto comparator = [&grid](std::string_view a, std::string_view b) {
+    auto key = [&grid](std::string_view w) {
+      bool isWkt = ad_utility::isWktLiteral(w);
+      return std::tuple{isWkt, isWkt ? grid.cellIndexFromWktLiteral(w) : 0, w};
+    };
+    return key(a) < key(b);
+  };
+
+  // Write the words in the comparator's order.
+  {
+    SGV writeVocab;
+    writeVocab.setGeoCellGrid(grid);
+    auto ww = writeVocab.makeDiskWriterPtr(fn);
+    ww->readableName() = "test";
+    EXPECT_EQ((*ww)(iri, false), 0u);
+    EXPECT_EQ((*ww)(wkt3, false),
+              SGV::addMarker(grid.indexFromCellAndPosition(3, 0), 1));
+    EXPECT_EQ((*ww)(wkt12, false),
+              SGV::addMarker(grid.indexFromCellAndPosition(12, 1), 1));
+    ww->finish();
+  }
+
+  SGV vocab;
+  vocab.setGeoCellGrid(grid);
+  vocab.open(fn);
+
+  // Retrieval by marked index.
+  EXPECT_EQ(vocab[SGV::addMarker(grid.indexFromCellAndPosition(3, 0), 1)],
+            wkt3);
+  EXPECT_EQ(vocab[SGV::addMarker(grid.indexFromCellAndPosition(12, 1), 1)],
+            wkt12);
+  EXPECT_EQ(vocab[0], iri);
+
+  // Exact lookup returns the index and its successor as bounds.
+  auto [lo3, hi3] = vocab.getPositionOfWord(wkt3, comparator);
+  EXPECT_EQ(lo3, SGV::addMarker(grid.indexFromCellAndPosition(3, 0), 1));
+  EXPECT_EQ(hi3, lo3 + 1);
+
+  // A WKT literal that is not in the vocabulary and larger than all entries
+  // gets past-the-end bounds that are larger than every valid index.
+  std::string wktMissing = wkt("NOTAGEOMETRY");  // sentinel cell
+  auto [loM, hiM] = vocab.getPositionOfWord(wktMissing, comparator);
+  EXPECT_EQ(loM, hiM);
+  EXPECT_GT(loM, SGV::addMarker(grid.indexFromCellAndPosition(12, 1), 1));
+}
+
 }  // namespace

--- a/test/index/vocabulary/SplitVocabularyTest.cpp
+++ b/test/index/vocabulary/SplitVocabularyTest.cpp
@@ -501,7 +501,7 @@ TEST(SplitVocabulary, geoCellGridIndicesThroughSplitVocabulary) {
   ad_utility::GeoCellGrid grid{2};
   const std::string fn = "geocellsplitvocab-test.dat";
   auto wkt = [](std::string_view content) {
-    return absl::StrCat("\"", content, "\"", GEO_LITERAL_SUFFIX);
+    return absl::StrCat("\"", content, GEO_LITERAL_SUFFIX);
   };
 
   std::string iri = "<http://example.org/a>";
@@ -534,8 +534,10 @@ TEST(SplitVocabulary, geoCellGridIndicesThroughSplitVocabulary) {
   }
 
   SGV vocab;
+  EXPECT_FALSE(vocab.getGeoCellGrid().has_value());
   vocab.setGeoCellGrid(grid);
   vocab.open(fn);
+  EXPECT_EQ(vocab.getGeoCellGrid(), std::optional{grid});
 
   // Retrieval by marked index.
   EXPECT_EQ(vocab[SGV::addMarker(grid.indexFromCellAndPosition(3, 0), 1)],

--- a/test/index/vocabulary/SplitVocabularyTest.cpp
+++ b/test/index/vocabulary/SplitVocabularyTest.cpp
@@ -494,12 +494,13 @@ TEST(Vocabulary, SplitVocabularyWordWriterDestructor) {
 
 // Test that the indices of a `GeoVocabulary` with a geo cell grid (cell index
 // in the upper bits) pass correctly through a `SplitGeoVocabulary`: they carry
-// the marker bit, exceed the size of the geo vocabulary by construction, and
-// the past-the-end bounds come from `GeoVocabulary::endIndex`.
+// the marker bit, and the past-the-end bounds come from
+// `GeoVocabulary::endIndex`.
 TEST(SplitVocabulary, geoCellGridIndicesThroughSplitVocabulary) {
   using SGV = SplitGeoVocabulary<VocabularyInMemory>;
   ad_utility::GeoCellGrid grid{2};
-  const std::string fn = "geocellsplitvocab-test.dat";
+  const std::string fn = absl::StrCat(gtestCurrentTestName(), ".dat");
+  auto cleanup = vocabulary_test::makeVocabFileCleanup<SGV>(fn);
   auto wkt = [](std::string_view content) {
     return absl::StrCat("\"", content, GEO_LITERAL_SUFFIX);
   };

--- a/test/index/vocabulary/SplitVocabularyTest.cpp
+++ b/test/index/vocabulary/SplitVocabularyTest.cpp
@@ -546,6 +546,11 @@ TEST(SplitVocabulary, geoCellGridIndicesThroughSplitVocabulary) {
             wkt12);
   EXPECT_EQ(vocab[0], iri);
 
+  // An index beyond the past-the-end index of the geo vocabulary is rejected,
+  // even if its position part is valid.
+  EXPECT_ANY_THROW(vocab[SGV::addMarker(
+      grid.indexFromCellAndPosition(grid.sentinelCell(), 0), 1)]);
+
   // Exact lookup returns the index and its successor as bounds.
   auto [lo3, hi3] = vocab.getPositionOfWord(wkt3, comparator);
   EXPECT_EQ(lo3, SGV::addMarker(grid.indexFromCellAndPosition(3, 0), 1));


### PR DESCRIPTION
This change lets a `GeoVocabulary` with a `GeoCellGrid` (see #3311) put the grid cell of each WKT literal into the upper bits of the literal's vocabulary index, with the literal's position in the vocabulary in the lower bits. All literals of one grid cell thereby form a contiguous index range that can be computed from the cell index alone, which is the basis for prefiltering spatial joins by `Id` in follow-up changes. Without a grid, nothing changes.

The `WordWriter` assigns these indices and checks that the literals arrive ordered by cell. Every operation that takes an index strips the cell bits to get the position. The operations that return indices (`lower_bound`, `upper_bound`, `scanAll`) recompute the cell of a literal from its precomputed bounding box in the `.geoinfo` file (or from the literal itself for an invalid geometry), by the same rule the writer used to assign it, That way the vocabulary needs no additional state on disk or in memory. Since the indices are no longer bounded by the size of the vocabulary, a new `endIndex()` provides the past-the-end bound for the binary searches. The `SplitVocabulary`, the `PolymorphicVocabulary`, and the `Vocabulary` pass the grid through, and `IndexImpl` applies it from `meta-data.json` before opening the vocabulary, like the locale and the vocabulary type.

NOTE: This is the next change in the series from #3311 towards #3310. The index build does not use a grid yet: it neither sorts the WKT literals by grid cell, nor gives the writer a grid (so the indices have no cell bits), nor records a grid in `meta-data.json`; the unit tests produce the sort order by hand. Integrating this into the index build is the next change.