### PR TITLE
Add the semantic comparison of the vocabularies of an index

### DIFF
--- a/src/global/ValueIdComparators.h
+++ b/src/global/ValueIdComparators.h
@@ -534,13 +534,13 @@ inline bool areTypesCompatible(Datatype typeA, Datatype typeB) {
 // This is deliberate for now: nothing but a unit test can currently create a
 // secondary vocabulary (see `IndexImpl::setSecondaryVocabForTesting`), so no
 // query is affected. It has to be fixed *before* anything else creates one.
-// The fix requires the semantically correct position of each word of the
-// secondary vocabulary within the main vocabulary, which the secondary
-// vocabulary will store, and it will most likely mean that this function must
-// not use
-// `ValueId::compareThreeWay` (the internal order) for the string types, but a
-// separate, explicitly semantic comparison.
-// TODO<joka921> Implement that comparison in a follow-up PR.
+// That separate, explicitly semantic comparison now exists (see
+// `LocalVocabContext::compareIdsSemantically` and
+// `LocalVocabEntry::compareThreeWaySemantically`), but this function does not
+// use it yet: for the string types it still uses `ValueId::compareThreeWay`,
+// which is the internal order.
+// TODO<joka921> Make this function (and the range filters above) use the
+// semantic comparison in a follow-up PR.
 //
 // NOTE: The secondary vocabulary is not the only source of semantic
 // incorrectness here, it is only the one that this comment is about. Two

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -298,13 +298,23 @@ class IndexImpl {
     return secondaryVocab_.get();
   }
 
-  // Set the secondary vocabulary, see above. NOTE: Tests that need an index
-  // with a secondary vocabulary should not call this directly, but set
-  // `TestIndexConfig::secondaryVocabWords` (see
+  // Set the secondary vocabulary, see above. This also attaches the comparator
+  // of the vocabulary of this index to it, which it needs for the semantic
+  // comparison of its words (see
+  // `SecondaryVocabulary::setMainVocabComparator`).
+  //
+  // NOTE: The vocabulary hence holds a pointer into `vocab_`, so it must not
+  // outlive this `IndexImpl`. This is the same lifetime assumption that
+  // `localVocabContext_` above already makes.
+  //
+  // NOTE: Tests that need an index with a secondary vocabulary should not call
+  // this directly, but set `TestIndexConfig::secondaryVocabWords` (see
   // `test/util/IndexTestHelpers.h`), such that the vocabulary is part of the
   // index right from its creation.
   void setSecondaryVocabForTesting(
-      std::shared_ptr<const SecondaryVocabulary> secondaryVocab) {
+      std::shared_ptr<SecondaryVocabulary> secondaryVocab) {
+    AD_CONTRACT_CHECK(secondaryVocab != nullptr);
+    secondaryVocab->setMainVocabComparator(vocab_.getCaseComparator());
     secondaryVocab_ = std::move(secondaryVocab);
   }
 

--- a/src/index/LocalVocabContext.h
+++ b/src/index/LocalVocabContext.h
@@ -22,18 +22,33 @@ namespace ad_utility {
 class BlankNodeManager;
 }
 
-// The interface that a `LocalVocabEntry` requires from the index it belongs to.
-// A `LocalVocabEntry` stores a word that has to be comparable to the words in
-// the index's vocabulary, no matter whether it is contained in that vocabulary
-// or not. It therefore needs to look up where in the vocabulary the word is
-// stored, or would be stored, which is what this interface provides.
+// The interface to the vocabularies of an index that the comparison of words
+// and `Id`s requires. It serves exactly two purposes:
 //
-// NOTE: This is deliberately restricted to the operations that
-// `LocalVocabEntry` actually performs, and in particular does not expose the
-// vocabulary itself. Comparing two `Id`s calls into `LocalVocabEntry` (see
-// `global/ValueId.h`), so every library that compares `Id`s depends on
-// `LocalVocabEntry`. Keeping this interface abstract and minimal is what allows
-// those libraries to be independent of the (much larger) `index` library.
+// 1. A `LocalVocabEntry` stores a word that has to be comparable to the words
+// in the index's vocabulary, no matter whether it is contained in that
+// vocabulary or not. It therefore needs to look up where in the vocabulary the
+// word is stored, or would be stored, which is what this interface provides.
+//
+// 2. The semantic (that is, by string value) comparison of `Id`s has to compare
+// the words of two `Id`s, and to locate the word of an `Id` in the vocabulary
+// of the main index. See `compareIdsSemantically` and
+// `getSemanticPositionInMainVocab` below.
+//
+// NOTE: The only intended caller of those two functions is
+// `valueIdComparators` (see `global/ValueIdComparators.h`), which does not use
+// them yet: it still compares the `Id`s themselves, which is only semantically
+// correct as long as the index has no secondary vocabulary, see the detailed
+// note at `valueIdComparators::detail::compareIdsImpl`. Making it use these
+// functions is a follow-up PR (the `TODO<joka921>` there).
+//
+// NOTE: This is deliberately restricted to the operations that those two
+// purposes actually require, and in particular does not expose the vocabulary
+// itself. Comparing two `Id`s calls into this interface and into
+// `LocalVocabEntry` (see `global/ValueId.h`), so every library that compares
+// `Id`s depends on both. Keeping this interface abstract and minimal is what
+// allows those libraries to be independent of the (much larger) `index`
+// library.
 //
 // The only implementation of this interface is `LocalVocabContextImpl`. There
 // must be exactly one instance of it per index, because
@@ -62,11 +77,47 @@ class LocalVocabContext {
   // Return the bounds of `word` in the vocabulary, see `VocabBounds`.
   virtual VocabBounds getPositionOfWord(std::string_view word) const = 0;
 
+  // Semantically (that is, by string value) compare the two given `Id`s, both
+  // of which have to be of one of the `ValueId::stringTypes_` (`VocabIndex`,
+  // `LocalVocabIndex`, or `SecondaryVocabIndex`). Return a value less than,
+  // equal to, or greater than zero if `a` is smaller than, equal to, or greater
+  // than `b`.
+  //
+  // NOTE: This is deliberately separate from the comparison of the `Id`s
+  // themselves (`ValueId::compareThreeWay`), which implements the order in
+  // which the index scans emit their `Id`s (the *internal* order). The two
+  // orders differ as soon as the index has a secondary vocabulary (see
+  // `index/vocabulary/SecondaryVocabulary.h`): a word of that vocabulary is
+  // positioned after *all* words of the main vocabulary in the internal order,
+  // no matter what it is, which is exactly what makes such words mergeable into
+  // a scan of the main index, but which has nothing to do with their string
+  // values.
+  //
+  // TODO<joka921> This currently looks up the word of each `Id` in the
+  // vocabularies, which is expensive. Once the secondary vocabulary stores the
+  // position of each of its words in the main vocabulary (see
+  // `index/vocabulary/SecondaryVocabulary.h`), this can compare those positions
+  // instead.
+  virtual int compareIdsSemantically(Id a, Id b) const = 0;
+
+  // Return the position at which the word of the given `Id` is, or would be,
+  // stored in the vocabulary of the main index (see `VocabBounds`). The `Id`
+  // has to be of one of the `ValueId::stringTypes_`. In contrast to
+  // `LocalVocabEntry::positionInVocab()`, this is always a position in the
+  // *main* vocabulary, also for a word that is stored in the secondary
+  // vocabulary, which is what a semantic comparison needs (see
+  // `compareIdsSemantically` above).
+  virtual VocabBounds getSemanticPositionInMainVocab(Id id) const = 0;
+
   // Return true iff this index has a secondary vocabulary at all (see
   // `index/vocabulary/SecondaryVocabulary.h`). This is the cheap check that
   // lets `LocalVocabEntry::compareThreeWay` skip the (expensive) lookup of the
   // position in the vocabulary, which is only needed if there is a secondary
-  // vocabulary.
+  // vocabulary. It is also the check with which `valueIdComparators` will be
+  // able to skip the semantic comparisons above entirely, which is the hotter
+  // of the two use cases: without a secondary vocabulary the internal order of
+  // the `Id`s already is their semantic order, so none of those comparisons is
+  // needed in the first place.
   virtual bool hasSecondaryVocabulary() const = 0;
 
   // Look up `word` in the secondary vocabulary of this index (see
@@ -106,11 +157,11 @@ class LocalVocabContext {
   IdOrVocabBounds lookupWordInVocabularies(std::string_view word) const;
 
   // Return the manager for the blank nodes of this index. NOTE: This is the one
-  // function here that `LocalVocabEntry` itself does not need. It is required
-  // when a complete `LocalVocab` is deserialized (see `deserializeLocalVocab`
-  // in `util/Serializer/TripleSerializer.h`), which has only this interface at
-  // hand, so that the blank node manager would otherwise have to be threaded
-  // through the same call chains a second time.
+  // function here that serves neither of the two purposes described at the top
+  // of this file. It is required when a complete `LocalVocab` is deserialized
+  // (see `deserializeLocalVocab` in `util/Serializer/TripleSerializer.h`),
+  // which has only this interface at hand, so that the blank node manager would
+  // otherwise have to be threaded through the same call chains a second time.
   virtual ad_utility::BlankNodeManager* getBlankNodeManager() const = 0;
 };
 

--- a/src/index/LocalVocabContextImpl.cpp
+++ b/src/index/LocalVocabContextImpl.cpp
@@ -9,6 +9,7 @@
 
 #include "index/LocalVocabContextImpl.h"
 
+#include "index/LocalVocabEntry.h"
 #include "util/Exception.h"
 
 // _____________________________________________________________________________
@@ -22,6 +23,71 @@ int LocalVocabContextImpl::compareWords(std::string_view a,
 auto LocalVocabContextImpl::getPositionOfWord(std::string_view word) const
     -> VocabBounds {
   return vocabulary_->getPositionOfWord(word);
+}
+
+// _____________________________________________________________________________
+std::string LocalVocabContextImpl::getWordOfStringTypedId(Id id) const {
+  switch (id.getDatatype()) {
+    case Datatype::VocabIndex:
+      return std::string{(*vocabulary_)[id.getVocabIndex()]};
+    case Datatype::SecondaryVocabIndex:
+      AD_CORRECTNESS_CHECK(
+          hasSecondaryVocabulary(),
+          "An `Id` of type `SecondaryVocabIndex` can only belong to an index "
+          "that has a secondary vocabulary");
+      return std::string{(**secondaryVocab_)[id.getSecondaryVocabIndex()]};
+    case Datatype::LocalVocabIndex:
+      return id.getLocalVocabIndex()->toStringRepresentation();
+    default:
+      AD_FAIL();
+  }
+}
+
+// _____________________________________________________________________________
+int LocalVocabContextImpl::compareSecondaryVocabIdTo(Id secondaryId,
+                                                     Id other) const {
+  // NOTE: The explicit check is required, because the `*secondaryVocab_` that
+  // the calls below dereference would already be undefined behavior if there is
+  // no secondary vocabulary, no matter in which order the arguments of those
+  // calls are evaluated.
+  AD_CORRECTNESS_CHECK(hasSecondaryVocabulary());
+  auto index = secondaryId.getSecondaryVocabIndex();
+  // If both words are stored in the secondary vocabulary, then compare them by
+  // their indices, which spares us materializing the word of `other` as a
+  // `std::string`.
+  if (other.getDatatype() == Datatype::SecondaryVocabIndex) {
+    return (*secondaryVocab_)
+        ->compareWords(index, other.getSecondaryVocabIndex());
+  }
+  return (*secondaryVocab_)
+      ->compareWordTo(index, getWordOfStringTypedId(other));
+}
+
+// _____________________________________________________________________________
+int LocalVocabContextImpl::compareIdsSemantically(Id a, Id b) const {
+  // Delegate a comparison that involves a word of the secondary vocabulary to
+  // that vocabulary, which is the class that knows how to compare its words.
+  if (a.getDatatype() == Datatype::SecondaryVocabIndex) {
+    return compareSecondaryVocabIdTo(a, b);
+  }
+  if (b.getDatatype() == Datatype::SecondaryVocabIndex) {
+    // The call compares the word of `b` to the word of `a`, which is the
+    // reverse of what we need, so negate the result.
+    return -compareSecondaryVocabIdTo(b, a);
+  }
+  return compareWords(getWordOfStringTypedId(a), getWordOfStringTypedId(b));
+}
+
+// _____________________________________________________________________________
+auto LocalVocabContextImpl::getSemanticPositionInMainVocab(Id id) const
+    -> VocabBounds {
+  // A word that is stored in the vocabulary of the main index sits at exactly
+  // the position of its `Id`, so we can shortcut the lookup.
+  if (id.getDatatype() == Datatype::VocabIndex) {
+    auto index = id.getVocabIndex();
+    return {index, VocabIndex::make(index.get() + 1)};
+  }
+  return getPositionOfWord(getWordOfStringTypedId(id));
 }
 
 // _____________________________________________________________________________

--- a/src/index/LocalVocabContextImpl.h
+++ b/src/index/LocalVocabContextImpl.h
@@ -12,6 +12,7 @@
 
 #include <memory>
 #include <optional>
+#include <string>
 #include <string_view>
 
 #include "global/Id.h"
@@ -56,11 +57,22 @@ class LocalVocabContextImpl : public LocalVocabContext {
 
   int compareWords(std::string_view a, std::string_view b) const override;
   VocabBounds getPositionOfWord(std::string_view word) const override;
+  int compareIdsSemantically(Id a, Id b) const override;
+  VocabBounds getSemanticPositionInMainVocab(Id id) const override;
   bool hasSecondaryVocabulary() const override;
   std::optional<SecondaryVocabIndex> getSecondaryVocabIndex(
       std::string_view word) const override;
   std::optional<Id> encodeAsId(std::string_view word) const override;
   ad_utility::BlankNodeManager* getBlankNodeManager() const override;
+
+ private:
+  // Return the word of the given `Id`, which has to be of one of the
+  // `ValueId::stringTypes_`.
+  std::string getWordOfStringTypedId(Id id) const;
+
+  // Semantically compare the word of `secondaryId`, which has to be of type
+  // `Datatype::SecondaryVocabIndex`, to the word of `other`.
+  int compareSecondaryVocabIdTo(Id secondaryId, Id other) const;
 };
 
 #endif  // QLEVER_SRC_INDEX_LOCALVOCABCONTEXTIMPL_H

--- a/src/index/LocalVocabEntry.cpp
+++ b/src/index/LocalVocabEntry.cpp
@@ -13,11 +13,7 @@
 // ___________________________________________________________________________
 ql::strong_ordering LocalVocabEntry::compareThreeWay(
     const LocalVocabEntry& rhs) const {
-  AD_EXPENSIVE_CHECK(
-      context_ == rhs.context_,
-      "Contexts of LocalVocabEntries have to be identical. If this is not the "
-      "case this means that stale entries associated with an old index are "
-      "falsely carried over somewhere.");
+  checkSameContext(rhs);
   // If the index has a secondary vocabulary, then first compare the positions
   // in the vocabularies, see the documentation of this function in the header
   // for why this is required. Without such a vocabulary the comparison of the
@@ -42,6 +38,15 @@ ql::strong_ordering LocalVocabEntry::compareThreeWay(
                          : ql::strong_ordering::less;
     }
   }
+  // The positions are equal (or the index has no secondary vocabulary), so the
+  // string values decide, which is exactly the semantic comparison.
+  return compareThreeWaySemantically(rhs);
+}
+
+// _____________________________________________________________________________
+ql::strong_ordering LocalVocabEntry::compareThreeWaySemantically(
+    const LocalVocabEntry& rhs) const {
+  checkSameContext(rhs);
   int i = context_->compareWords(toStringRepresentation(),
                                  rhs.toStringRepresentation());
   if (i < 0) {

--- a/src/index/LocalVocabEntry.h
+++ b/src/index/LocalVocabEntry.h
@@ -30,35 +30,39 @@ class LocalVocabContext;
 // vocabulary because we only have to look up the position once per
 // `LocalVocabEntry`, and all subsequent comparisons are cheap.
 //
-// WARNING: The order that `positionInVocab()` and `compareThreeWay()` implement
-// is the order in which the index scans emit their `Id`s (call it the
-// *internal* order, see `ValueId::compareThreeWay`). Without a secondary
-// vocabulary (see `index/vocabulary/SecondaryVocabulary.h`) that order
-// coincides with the semantic (that is, by string value) order, except for the
-// encoded IRIs
-// (see `LocalVocabContext::encodeAsId`), which are ordered by their encoding
-// (a pre-existing deviation that is tracked separately, see the note at
-// `compareThreeWay` below). As soon as an index has such a vocabulary, the two
-// orders differ much more fundamentally: a word of the secondary vocabulary is
-// positioned after *all* words of the main vocabulary, no matter what it is. An
-// entry whose word is stored in the secondary vocabulary therefore compares
-// greater than every word of the main vocabulary, and greater than every entry
-// that is contained in neither vocabulary — even if its string value is
-// smaller. Both `compareThreeWay()` and the `Id` comparison then deviate
-// *silently* from the semantics that SPARQL requires, which breaks all kinds of
-// semantic comparisons (`FILTER`, `ORDER BY`, the range filters and
-// prefilters), see the detailed note at
-// `valueIdComparators::detail::compareIdsImpl`.
+// WARNING: There are two different orders on the words of an index, and this
+// class exposes both of them as two explicitly named comparisons:
 //
-// This is deliberate for now: nothing but a unit test can currently create a
-// secondary vocabulary (see `IndexImpl::setSecondaryVocabForTesting`), so no
-// query is affected. It has to be fixed *before* anything else creates one,
-// most likely by keeping the position in the main vocabulary (which is what a
-// semantic comparison needs, and which can always be computed from the word)
-// separately from the position in the internal order, and by exposing the two
-// orders as two explicitly named comparisons instead of a single
-// `compareThreeWay`.
-// TODO<joka921> Do that in a follow-up PR.
+// 1. The *internal* order (`positionInVocab()` and `compareThreeWay()`) is the
+//    order in which the index scans emit their `Id`s (see
+//    `ValueId::compareThreeWay`). It is what the comparison of two `Id`s
+//    implements, and hence what everything that has to agree with the order of
+//    the index scans (`Join`, `Distinct`, `GroupBy`, the merging of delta
+//    triples into a scan, etc.) has to use.
+// 2. The *semantic* order (`compareThreeWaySemantically()`) compares the words
+//    by their string value, using the collation of the vocabulary of the index.
+//    It is what SPARQL requires for `FILTER`, `ORDER BY`, the range filters,
+//    and the prefilters. NOTE: `valueIdComparators`, which implements those,
+//    does not use it yet, but still compares the `Id`s themselves (that is,
+//    the internal order), which is only semantically correct as long as the
+//    index has no secondary vocabulary; see the detailed note at
+//    `valueIdComparators::detail::compareIdsImpl`.
+//
+// The two orders coincide as long as the index has no secondary vocabulary (see
+// `index/vocabulary/SecondaryVocabulary.h`). As soon as it has one, they differ
+// fundamentally: a word of the secondary vocabulary is positioned after *all*
+// words of the main vocabulary, no matter what it is (which is exactly what
+// makes such words mergeable into a scan of the main index). An entry whose
+// word is stored in the secondary vocabulary therefore is *internally* greater
+// than every word of the main vocabulary, and greater than every entry that is
+// contained in neither vocabulary — even if its string value is smaller.
+//
+// NOTE: There is one deviation of the internal from the semantic order that
+// exists independently of the secondary vocabulary: an encoded IRI (see
+// `LocalVocabContext::encodeAsId`) is internally ordered by its encoding and
+// not by its string value. That deviation is pre-existing and tracked
+// separately, see issue #2448 and the note at
+// `valueIdComparators::detail::compareIdsImpl`.
 class alignas(16) LocalVocabEntry
     : public ad_utility::triple_component::LiteralOrIri {
  public:
@@ -80,8 +84,8 @@ class alignas(16) LocalVocabEntry
   // the first *larger* word in the vocabulary. Note that the position may also
   // be in the secondary vocabulary of the index, in which case it is an `Id` of
   // type `Datatype::SecondaryVocabIndex` — see the warning in the class comment
-  // above for why that makes this position currently unsuitable for semantic
-  // comparisons.
+  // above for why that makes this position unsuitable for semantic
+  // comparisons, which have to use `compareThreeWaySemantically` instead.
   // Note: we store the cache as three separate atomics to avoid mutexes. The
   // downside is, that in parallel code multiple threads might look up the
   // position concurrently, which wastes a bit of resources. However, we don't
@@ -199,15 +203,15 @@ class alignas(16) LocalVocabEntry
 
   // Compare two entries in the internal order (see the warning in the class
   // comment above; in particular this is NOT a semantic comparison as soon as
-  // the index has a secondary vocabulary). If the index has such a secondary
-  // vocabulary, then this first compares the positions in the vocabularies (see
-  // `positionInVocab()`) and only falls back to the comparison of the strings
-  // if those positions are equal. Comparing the strings alone would then not be
-  // a valid strict weak ordering: a word that is stored in the secondary
-  // vocabulary of the index is positioned after all words of the main
-  // vocabulary, so comparing it to a word that is in neither vocabulary has to
-  // yield the same result as comparing the corresponding `Id`s, which are
-  // compared by their positions.
+  // the index has a secondary vocabulary, use `compareThreeWaySemantically`
+  // below for that). If the index has such a secondary vocabulary, then this
+  // first compares the positions in the vocabularies (see `positionInVocab()`)
+  // and only falls back to the comparison of the strings if those positions are
+  // equal. Comparing the strings alone would then not be a valid strict weak
+  // ordering: a word that is stored in the secondary vocabulary of the index is
+  // positioned after all words of the main vocabulary, so comparing it to a
+  // word that is in neither vocabulary has to yield the same result as
+  // comparing the corresponding `Id`s, which are compared by their positions.
   //
   // If the index has no secondary vocabulary, then the comparison of the
   // strings alone already yields the same result as the comparison of the
@@ -227,6 +231,15 @@ class alignas(16) LocalVocabEntry
   // below never looks up the position, no matter which vocabularies exist.
   ql::strong_ordering compareThreeWay(const LocalVocabEntry& rhs) const;
   QL_DEFINE_CUSTOM_THREEWAY_OPERATOR_LOCAL(LocalVocabEntry)
+
+  // Semantically (that is, by string value) compare this entry to `rhs`. In
+  // contrast to `compareThreeWay` above, this NEVER looks at the position in
+  // the vocabularies, but always compares the string values with the collation
+  // of the vocabulary at the `TOTAL` level, which is exactly the semantics that
+  // SPARQL requires. The two comparisons only differ if the index has a
+  // secondary vocabulary; see the class comment above for the details.
+  ql::strong_ordering compareThreeWaySemantically(
+      const LocalVocabEntry& rhs) const;
 
   // Two entries are equal if and only if their string representations are, so
   // forward to the base class instead of going through `compareThreeWay`, which
@@ -256,6 +269,18 @@ class alignas(16) LocalVocabEntry
  private:
   // The expensive case of looking up the position in vocab.
   PositionInVocab positionInVocabExpensiveCase() const;
+
+  // Check that this entry and `rhs` belong to the same index. This is a
+  // precondition of both comparisons above, because entries of different
+  // indices are not comparable at all. NOTE: The check is only performed if the
+  // expensive checks are enabled, hence the `[[maybe_unused]]`.
+  void checkSameContext([[maybe_unused]] const LocalVocabEntry& rhs) const {
+    AD_EXPENSIVE_CHECK(
+        context_ == rhs.context_,
+        "Contexts of LocalVocabEntries have to be identical. If this is not "
+        "the case this means that stale entries associated with an old index "
+        "are falsely carried over somewhere.");
+  }
 };
 
 #endif  // QLEVER_SRC_INDEX_LOCALVOCABENTRY_H

--- a/src/index/vocabulary/SecondaryVocabulary.cpp
+++ b/src/index/vocabulary/SecondaryVocabulary.cpp
@@ -39,3 +39,33 @@ std::optional<SecondaryVocabIndex> SecondaryVocabulary::getId(
   }
   return SecondaryVocabIndex::make(static_cast<uint64_t>(it - words_.begin()));
 }
+
+// _____________________________________________________________________________
+void SecondaryVocabulary::setMainVocabComparator(
+    const TripleComponentComparator& comparator) {
+  mainVocabComparator_ = &comparator;
+}
+
+// _____________________________________________________________________________
+int SecondaryVocabulary::compareWordTo(SecondaryVocabIndex index,
+                                       std::string_view word) const {
+  return mainVocabComparator().compare((*this)[index], word,
+                                       LocaleManager::Level::TOTAL);
+}
+
+// _____________________________________________________________________________
+int SecondaryVocabulary::compareWords(SecondaryVocabIndex a,
+                                      SecondaryVocabIndex b) const {
+  return compareWordTo(a, (*this)[b]);
+}
+
+// _____________________________________________________________________________
+const TripleComponentComparator& SecondaryVocabulary::mainVocabComparator()
+    const {
+  AD_CONTRACT_CHECK(
+      mainVocabComparator_ != nullptr,
+      "A `SecondaryVocabulary` can only compare its words semantically once "
+      "the comparator of the vocabulary of the main index has been set, see "
+      "`SecondaryVocabulary::setMainVocabComparator`");
+  return *mainVocabComparator_;
+}

--- a/src/index/vocabulary/SecondaryVocabulary.h
+++ b/src/index/vocabulary/SecondaryVocabulary.h
@@ -16,6 +16,7 @@
 #include <vector>
 
 #include "global/IndexTypes.h"
+#include "index/vocabulary/StringSortComparator.h"
 
 // The secondary vocabulary of an index. It stores words that were added after
 // the main index was built and that are not part of the vocabulary of that
@@ -27,19 +28,29 @@
 // of the main vocabulary when compared bitwise, which is what makes those
 // words mergeable into a scan of the main index.
 //
+// A *semantic* (that is, by string value) comparison of a word of this
+// vocabulary therefore must not use the `Id`s, but has to go through
+// `compareWordTo` and `compareWords` below.
+//
 // TODO<joka921> This currently is a minimal placeholder that simply holds all
 // its words in RAM and that is only ever filled explicitly by unit tests (see
 // `IndexImpl::setSecondaryVocabForTesting`). The actual implementation stores
 // the words on disk, using the same vocabulary type (and hence the same split
 // into sub-vocabularies) as the main index, and it additionally stores, for
 // each of its words, the position at which that word would be sorted into the
-// main vocabulary. The latter is what a *semantic* (that is, by string value)
-// comparison of an `Id` of this vocabulary with an `Id` of the main vocabulary
-// needs; it follows in the changes that build on this one.
+// main vocabulary. The latter makes the semantic comparisons below cheap: they
+// currently have to look up the words and run the (expensive) collation of the
+// main vocabulary on them, whereas the stored positions can simply be compared
+// to each other and to a `VocabIndex`.
 class SecondaryVocabulary {
  private:
   // The words, in strictly ascending order, see the constructor.
   std::vector<std::string> words_;
+
+  // The comparator of the vocabulary of the main index, see
+  // `setMainVocabComparator`. It is a pointer and not a reference, so that this
+  // class stays assignable, and it is `nullptr` until it has been set.
+  const TripleComponentComparator* mainVocabComparator_ = nullptr;
 
  public:
   SecondaryVocabulary() = default;
@@ -50,10 +61,12 @@ class SecondaryVocabulary {
   // is checked, so that they can be looked up by binary search.
   //
   // NOTE: The actual implementation will instead order its words by the
-  // comparator of the vocabulary of the main index at the `TOTAL` level, which
-  // this placeholder has no access to. The two orders do not agree in general,
-  // so the words that the unit tests use are deliberately chosen such that they
-  // do (see `test/SecondaryVocabularyTest.cpp`).
+  // comparator of the vocabulary of the main index at the `TOTAL` level, and
+  // look them up accordingly. The two orders do not agree in general, so the
+  // words that the unit tests use are deliberately chosen such that they do
+  // (see `test/SecondaryVocabularyTest.cpp`). This only concerns the lookup in
+  // `getId` below; the semantic comparisons are unaffected, because they always
+  // go through `mainVocabComparator_` and never through the order of `words_`.
   explicit SecondaryVocabulary(std::vector<std::string> words);
 
   // Return the number of words.
@@ -65,6 +78,30 @@ class SecondaryVocabulary {
   // Look up `word`. Return its index if it is contained in this vocabulary, and
   // `std::nullopt` otherwise.
   std::optional<SecondaryVocabIndex> getId(std::string_view word) const;
+
+  // Set the comparator of the vocabulary of the main index, which this
+  // vocabulary needs in order to compare its words semantically (that is, by
+  // string value) to the words of that vocabulary. It has to be set before any
+  // of the comparisons below is called. NOTE: This is deliberately a separate
+  // setter and not a constructor argument, because a `SecondaryVocabulary` is
+  // created before it is attached to an index (see
+  // `IndexImpl::setSecondaryVocabForTesting`).
+  void setMainVocabComparator(const TripleComponentComparator& comparator);
+
+  // Semantically compare the word with the given `index` to `word`, using the
+  // comparator of the vocabulary of the main index at the `TOTAL` level (which
+  // is the level at which that vocabulary is sorted). Return a value less than,
+  // equal to, or greater than zero if the word with the given `index` is
+  // smaller than, equal to, or greater than `word`.
+  int compareWordTo(SecondaryVocabIndex index, std::string_view word) const;
+
+  // Semantically compare the words with the given indices, see `compareWordTo`.
+  int compareWords(SecondaryVocabIndex a, SecondaryVocabIndex b) const;
+
+ private:
+  // Return the comparator of the vocabulary of the main index. Fail if it has
+  // not been set yet, see `setMainVocabComparator`.
+  const TripleComponentComparator& mainVocabComparator() const;
 };
 
 #endif  // QLEVER_SRC_INDEX_VOCABULARY_SECONDARYVOCABULARY_H

--- a/test/LocalVocabEntryTest.cpp
+++ b/test/LocalVocabEntryTest.cpp
@@ -19,8 +19,16 @@
 #include "index/LocalVocabContext.h"
 #include "index/LocalVocabEntry.h"
 
-// _____________________________________________________________________________
-TEST(LocalVocabEntry, compareThreeWayRequiresMatchingContexts) {
+// Build two `LocalVocabEntry`s for the same word, but belonging to two
+// different indices, and expect that `comparison(entry1, entry2)` throws,
+// because comparing entries of different contexts is not allowed. The test is
+// skipped if expensive checks are disabled, because the check that produces
+// the error is one of them.
+template <typename Comparison>
+void testComparisonRequiresMatchingContexts(
+    Comparison comparison,
+    ad_utility::source_location l = AD_CURRENT_SOURCE_LOC()) {
+  auto trace = generateLocationTrace(l);
   if constexpr (!ad_utility::areExpensiveChecksEnabled) {
     GTEST_SKIP() << "This test only makes sense with expensive checks enabled.";
   }
@@ -34,9 +42,17 @@ TEST(LocalVocabEntry, compareThreeWayRequiresMatchingContexts) {
       "<x>", index2.getImpl().getLocalVocabContext());
 
   AD_EXPECT_THROW_WITH_MESSAGE(
-      (void)(entry1 < entry2),
+      comparison(entry1, entry2),
       ::testing::HasSubstr(
           "Contexts of LocalVocabEntries have to be identical"));
+}
+
+// _____________________________________________________________________________
+TEST(LocalVocabEntry, compareThreeWayRequiresMatchingContexts) {
+  testComparisonRequiresMatchingContexts(
+      [](const LocalVocabEntry& a, const LocalVocabEntry& b) {
+        (void)(a < b);
+      });
 }
 
 // _____________________________________________________________________________
@@ -134,4 +150,69 @@ TEST(LocalVocabEntry, compareThreeWayOnlyOneEntryIsContainedInVocabulary) {
   // `isContained == false, rhsIsContained == true`.
   EXPECT_EQ(notContained.compareThreeWay(contained), ql::strong_ordering::less);
   EXPECT_LT(notContained, contained);
+}
+
+// _____________________________________________________________________________
+// `compareThreeWaySemantically` compares the string values, whereas
+// `compareThreeWay` implements the internal order, in which a word of the
+// secondary vocabulary is positioned after all words of the main vocabulary,
+// see the class comment of `LocalVocabEntry`.
+TEST(LocalVocabEntry, compareThreeWaySemantically) {
+  using namespace ad_utility::testing;
+  // The two orders only differ if the index has a secondary vocabulary, so
+  // create one. Note that this must not leak into other tests, so build a fresh
+  // index instead of using a shared one.
+  TestIndexConfig config{"<s> <p> <a> . <s> <p> <c> ."};
+  config.secondaryVocabWords = std::vector<std::string>{"<b>"};
+  Index index = makeTestIndex(gtestCurrentTestName(), std::move(config));
+  const auto& ctx = index.getImpl().getLocalVocabContext();
+  ASSERT_TRUE(ctx.hasSecondaryVocabulary());
+  auto entry = [&ctx](std::string_view iriref) {
+    return LocalVocabEntry::fromIriref(iriref, ctx);
+  };
+
+  // `<a>` is a word of the main vocabulary, `<b>` is stored in the secondary
+  // vocabulary, and `<e>` is in neither.
+  LocalVocabEntry entryA = entry("<a>");
+  LocalVocabEntry entryB = entry("<b>");
+  LocalVocabEntry entryE = entry("<e>");
+
+  // Semantically, the entries are ordered by their string values.
+  EXPECT_EQ(entryA.compareThreeWaySemantically(entryB),
+            ql::strong_ordering::less);
+  EXPECT_EQ(entryB.compareThreeWaySemantically(entryE),
+            ql::strong_ordering::less);
+  EXPECT_EQ(entryE.compareThreeWaySemantically(entryB),
+            ql::strong_ordering::greater);
+  EXPECT_EQ(entryB.compareThreeWaySemantically(entryB),
+            ql::strong_ordering::equal);
+  EXPECT_EQ(entryB.compareThreeWaySemantically(entry("<b>")),
+            ql::strong_ordering::equal);
+
+  // Internally, `<b>` is greater than both of the others, because it is
+  // positioned in the secondary vocabulary, and that is also what the
+  // comparison operators (and hence sorting) use.
+  EXPECT_EQ(entryB.compareThreeWay(entryA), ql::strong_ordering::greater);
+  EXPECT_EQ(entryB.compareThreeWay(entryE), ql::strong_ordering::greater);
+  EXPECT_EQ(entryE.compareThreeWay(entryB), ql::strong_ordering::less);
+  EXPECT_LT(entryE, entryB);
+  EXPECT_GT(entryB, entryE);
+
+  // The two orders agree on entries that are not stored in the secondary
+  // vocabulary.
+  EXPECT_EQ(entryA.compareThreeWay(entryE),
+            entryA.compareThreeWaySemantically(entryE));
+  EXPECT_EQ(entryE.compareThreeWay(entryA),
+            entryE.compareThreeWaySemantically(entryA));
+  EXPECT_EQ(entryA.compareThreeWay(entryA), ql::strong_ordering::equal);
+}
+
+// _____________________________________________________________________________
+// Just like `compareThreeWay`, the semantic comparison requires that both
+// entries belong to the same index.
+TEST(LocalVocabEntry, compareThreeWaySemanticallyRequiresMatchingContexts) {
+  testComparisonRequiresMatchingContexts(
+      [](const LocalVocabEntry& a, const LocalVocabEntry& b) {
+        (void)a.compareThreeWaySemantically(b);
+      });
 }

--- a/test/SecondaryVocabularyTest.cpp
+++ b/test/SecondaryVocabularyTest.cpp
@@ -137,6 +137,21 @@ TEST(SecondaryVocabulary, wordsHaveToBeSortedAndDistinct) {
 }
 
 // _____________________________________________________________________________
+// The semantic comparison of the words needs the comparator of the vocabulary
+// of the main index, which a freshly constructed vocabulary does not have yet
+// (`IndexImpl::setSecondaryVocabForTesting` attaches it, see the test below).
+TEST(SecondaryVocabulary, semanticComparisonNeedsTheMainVocabComparator) {
+  SecondaryVocabulary vocab{secondaryVocabWords};
+  auto message =
+      HasSubstr("comparator of the vocabulary of the main index has been set");
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      vocab.compareWordTo(SecondaryVocabIndex::make(0), "<a>"), message);
+  AD_EXPECT_THROW_WITH_MESSAGE(vocab.compareWords(SecondaryVocabIndex::make(0),
+                                                  SecondaryVocabIndex::make(1)),
+                               message);
+}
+
+// _____________________________________________________________________________
 TEST(SecondaryVocabIndex, valueIdBasics) {
   auto id = secondaryVocabId(17);
   EXPECT_EQ(id.getDatatype(), Datatype::SecondaryVocabIndex);
@@ -341,6 +356,164 @@ TEST(SecondaryVocabIndex, localVocabEntryWithoutSecondaryVocabulary) {
   ql::ranges::sort(entries);
   EXPECT_THAT(entries, ::testing::ElementsAre(entry("<a>"), entry("<b>"),
                                               entry("<c>"), entry("<d>")));
+}
+
+// _____________________________________________________________________________
+// The semantic comparison of the words of the secondary vocabulary uses the
+// comparator of the vocabulary of the main index, which the index attaches to
+// the vocabulary when it is set.
+TEST_F(SecondaryVocabIndexTest, semanticComparisonOfWords) {
+  const SecondaryVocabulary* vocab = index_.getImpl().secondaryVocab();
+  ASSERT_NE(vocab, nullptr);
+  auto at = [](uint64_t i) { return SecondaryVocabIndex::make(i); };
+
+  // Compare the words to words of the main vocabulary and to a word that is in
+  // neither vocabulary. The words are `"a"` (index 0), `<b>` (1), and `<d>`
+  // (2), see `secondaryVocabWords`.
+  EXPECT_EQ(vocab->compareWordTo(at(1), "<b>"), 0);
+  EXPECT_LT(vocab->compareWordTo(at(1), "<c>"), 0);
+  EXPECT_GT(vocab->compareWordTo(at(1), "<a>"), 0);
+  EXPECT_LT(vocab->compareWordTo(at(2), "<e>"), 0);
+  EXPECT_GT(vocab->compareWordTo(at(2), "<c>"), 0);
+  // A literal is smaller than every IRI in the order of the main vocabulary.
+  EXPECT_LT(vocab->compareWordTo(at(0), "<a>"), 0);
+
+  // Compare the words to each other.
+  EXPECT_LT(vocab->compareWords(at(0), at(1)), 0);
+  EXPECT_LT(vocab->compareWords(at(1), at(2)), 0);
+  EXPECT_EQ(vocab->compareWords(at(1), at(1)), 0);
+  EXPECT_GT(vocab->compareWords(at(2), at(0)), 0);
+}
+
+// _____________________________________________________________________________
+// The semantic comparison of `Id`s, for all combinations of `VocabIndex`,
+// `LocalVocabIndex`, and `SecondaryVocabIndex`. This is the comparison that
+// SPARQL requires, and it deliberately differs from the *internal* order of the
+// `Id`s, which the second half of this test pins down.
+TEST_F(SecondaryVocabIndexTest, compareIdsSemantically) {
+  // `"a"`, `<b>`, and `<d>` are words of the secondary vocabulary, `<a>`,
+  // `<c>`, and `<p>` are words of the main vocabulary, and `<e>` is in neither.
+  auto entryA = entry("<a>");
+  auto entryB = entry("<b>");
+  auto entryE = entry("<e>");
+  Id idA = getId_("<a>");
+  Id idC = getId_("<c>");
+  Id idP = getId_("<p>");
+  Id secLiteralA = secondaryVocabId(0);
+  Id secB = secondaryVocabId(1);
+  Id secD = secondaryVocabId(2);
+  Id idOfA = idOf(entryA);
+  Id idOfB = idOf(entryB);
+  Id idOfE = idOf(entryE);
+
+  // The sign of the semantic comparison, which is what the assertions below
+  // are on.
+  auto semantic = [this](Id a, Id b) {
+    int result = context_.compareIdsSemantically(a, b);
+    return result < 0 ? -1 : (result > 0 ? 1 : 0);
+  };
+
+  // Two `Id`s of the main vocabulary.
+  EXPECT_EQ(semantic(idA, idC), -1);
+  EXPECT_EQ(semantic(idC, idA), 1);
+  EXPECT_EQ(semantic(idC, idC), 0);
+
+  // An `Id` of the secondary vocabulary against one of the main vocabulary.
+  EXPECT_EQ(semantic(secB, idA), 1);
+  EXPECT_EQ(semantic(secB, idC), -1);
+  EXPECT_EQ(semantic(idA, secB), -1);
+  EXPECT_EQ(semantic(idC, secB), 1);
+  EXPECT_EQ(semantic(secD, idP), -1);
+  // A literal of the secondary vocabulary is smaller than every IRI.
+  EXPECT_EQ(semantic(secLiteralA, idA), -1);
+  EXPECT_EQ(semantic(idA, secLiteralA), 1);
+
+  // Two `Id`s of the secondary vocabulary.
+  EXPECT_EQ(semantic(secB, secD), -1);
+  EXPECT_EQ(semantic(secD, secB), 1);
+  EXPECT_EQ(semantic(secB, secB), 0);
+  EXPECT_EQ(semantic(secLiteralA, secB), -1);
+
+  // A `LocalVocabIndex` whose word is stored in the main vocabulary, one whose
+  // word is stored in the secondary vocabulary, and one whose word is in
+  // neither.
+  EXPECT_EQ(semantic(idOfA, idA), 0);
+  EXPECT_EQ(semantic(idOfB, secB), 0);
+  EXPECT_EQ(semantic(idOfB, idA), 1);
+  EXPECT_EQ(semantic(idOfB, idC), -1);
+  EXPECT_EQ(semantic(idOfB, idOfE), -1);
+  EXPECT_EQ(semantic(idOfE, secB), 1);
+  EXPECT_EQ(semantic(idOfE, secD), 1);
+  EXPECT_EQ(semantic(idOfE, idP), -1);
+  EXPECT_EQ(semantic(idOfE, idOfE), 0);
+
+  // The internal order is a different one: ALL words of the secondary
+  // vocabulary come after ALL words of the main vocabulary, and after all words
+  // that are in neither.
+  for (Id secondary : {secLiteralA, secB, secD}) {
+    SCOPED_TRACE(secondary);
+    for (Id other : {idA, idC, idP, idOfA, idOfE}) {
+      SCOPED_TRACE(other);
+      EXPECT_LT(other, secondary);
+    }
+  }
+  // In particular, the two orders disagree for `<a>` (main vocabulary) versus
+  // `"a"` (secondary vocabulary), and for `<e>` (neither vocabulary) versus
+  // `<b>` (secondary vocabulary).
+  EXPECT_EQ(semantic(secLiteralA, idA), -1);
+  EXPECT_LT(idA, secLiteralA);
+  EXPECT_EQ(semantic(idOfE, secB), 1);
+  EXPECT_LT(idOfE, secB);
+}
+
+// _____________________________________________________________________________
+// `getSemanticPositionInMainVocab` always returns a position in the vocabulary
+// of the MAIN index, also for a word that is stored in the secondary
+// vocabulary. That position is what the binary search in
+// `valueIdComparators::getRangesForId` needs.
+TEST_F(SecondaryVocabIndexTest, getSemanticPositionInMainVocab) {
+  auto entryA = entry("<a>");
+  auto entryB = entry("<b>");
+  auto entryE = entry("<e>");
+  auto positionOf = [this](Id id) {
+    return context_.getSemanticPositionInMainVocab(id);
+  };
+  auto vocabIndexOf = [this](const std::string& word) {
+    return getId_(word).getVocabIndex();
+  };
+
+  // A word of the main vocabulary is at exactly its own position, so the range
+  // consists of that single word. The same holds for a local vocab entry whose
+  // word is stored there.
+  auto positionA = positionOf(getId_("<a>"));
+  EXPECT_EQ(positionA.first, vocabIndexOf("<a>"));
+  EXPECT_EQ(positionA.second, VocabIndex::make(positionA.first.get() + 1));
+  EXPECT_EQ(positionOf(idOf(entryA)), positionA);
+
+  // A word that is not stored in the main vocabulary yields the empty range at
+  // which it would be sorted into that vocabulary. For `<b>`, which is a word
+  // of the secondary vocabulary, that is between `<a>` and `<c>`, no matter
+  // whether it is addressed by its `SecondaryVocabIndex` or by a local vocab
+  // entry.
+  for (Id id : {secondaryVocabId(1), idOf(entryB)}) {
+    SCOPED_TRACE(id);
+    auto position = positionOf(id);
+    EXPECT_EQ(position.first, position.second);
+    EXPECT_GT(position.first.get(), vocabIndexOf("<a>").get());
+    EXPECT_LE(position.first.get(), vocabIndexOf("<c>").get());
+  }
+
+  // For `<e>`, which is in neither vocabulary, it is between `<c>` and `<p>`.
+  auto positionE = positionOf(idOf(entryE));
+  EXPECT_EQ(positionE.first, positionE.second);
+  EXPECT_GT(positionE.first.get(), vocabIndexOf("<c>").get());
+  EXPECT_LE(positionE.first.get(), vocabIndexOf("<p>").get());
+
+  // The literal `"a"` of the secondary vocabulary is positioned before all the
+  // IRIs of the main vocabulary.
+  auto positionLiteral = positionOf(secondaryVocabId(0));
+  EXPECT_EQ(positionLiteral.first, positionLiteral.second);
+  EXPECT_LE(positionLiteral.first.get(), vocabIndexOf("<a>").get());
 }
 
 // _____________________________________________________________________________
@@ -641,10 +814,13 @@ TEST(SecondaryVocabIndex, updateWithWordOfTheSecondaryVocabulary) {
   // value belongs.
   //
   // This is deliberately NOT the order that SPARQL requires, see the detailed
-  // note at `valueIdComparators::detail::compareIdsImpl`. The follow-up PR that
-  // implements the semantic comparison (see the `TODO<joka921>` there) has to
-  // change this expectation to `<a>, <b>, <c>, <e>`. A failure of this
-  // assertion is that fix landing, not a regression.
+  // note at `valueIdComparators::detail::compareIdsImpl`. The semantic
+  // comparison that the fix needs now exists (see
+  // `LocalVocabEntry::compareThreeWaySemantically` and
+  // `LocalVocabContext::compareIdsSemantically`), but `valueIdComparators` does
+  // not use it yet. The follow-up PR that makes it do so has to change this
+  // expectation to `<a>, <b>, <c>, <e>`. A failure of this assertion is that
+  // fix landing, not a regression.
   EXPECT_THAT(objectsOfS(), ElementsAre("<a>", "<c>", "<e>", "<b>"));
 }
 


### PR DESCRIPTION
Since the secondary vocabulary exists, QLever has **two different orders** on the words of an index:

1. The *internal* order, which is the order in which the index scans emit their `Id`s. All words of the secondary vocabulary are positioned after all words of the main vocabulary, no matter what their string values are — which is exactly what makes them mergeable into a scan of the main index.
2. The *semantic* order, which compares the words by their string value using the collation of the vocabulary, and which is the order that SPARQL requires for `FILTER`, `ORDER BY`, the range filters, and the prefilters.

Without a secondary vocabulary the two orders coincide (up to the pre-existing deviation for the encoded IRIs, see #2448); with one they differ fundamentally.

This PR adds the interface for the semantic comparison in `index` and `index/vocabulary`, together with its unit tests, but deliberately does **not** use it yet:

* `SecondaryVocabulary::compareWordTo` and `compareWords` compare its words with the `TripleComponentComparator` of the vocabulary of the main index at the `TOTAL` level. The comparator is attached by `IndexImpl::setSecondaryVocabForTesting` (via the new `setMainVocabComparator`), so the vocabulary must not outlive its index — the same lifetime assumption that `localVocabContext_` already makes.
* `LocalVocabContext::compareIdsSemantically` semantically compares two `Id`s of the string types (`VocabIndex`, `LocalVocabIndex`, `SecondaryVocabIndex`), and `getSemanticPositionInMainVocab` returns the position at which the word of such an `Id` is, or would be, stored in the vocabulary of the *main* index (which is what the binary searches in `valueIdComparators` need).
* `LocalVocabEntry::compareThreeWaySemantically` is the semantic counterpart of `compareThreeWay`; the shared precondition check was factored out into `checkSameContext`.

Making `valueIdComparators` use these functions (and hence fixing the semantics of `FILTER`, `ORDER BY`, the range filters, and the prefilters for indices with a secondary vocabulary) is a follow-up PR. The comments that describe the current state — in particular the `TODO` at `valueIdComparators::detail::compareIdsImpl` — are updated accordingly; the one behavioral expectation that pins down the current (internal) `ORDER BY` order in `SecondaryVocabularyTest.cpp` is left unchanged and still documents that it has to flip in that follow-up.

Note that nothing but a unit test can currently create a secondary vocabulary, so no query is affected either way.