### PR TITLE
Push complete blocks instead of single rows into the external sorters

### DIFF
--- a/src/engine/Sort.cpp
+++ b/src/engine/Sort.cpp
@@ -200,8 +200,8 @@ Result Sort::computeResultExternal(std::vector<IdTable> collectedBlocks,
       sorter->pushBlock(std::move(idTableAndLocalVocab.idTable_));
       mergedLocalVocab.mergeWith(idTableAndLocalVocab.localVocab_);
     } else {
-      // NOTE: `pushBlock` iterates over the rows and calls `push` for each,
-      // which buffers rows and flushes to disk when the buffer is full. This
+      // NOTE: `pushBlock` copies the columns of the input into the sorter's
+      // internal buffer and flushes that buffer to disk when it is full. This
       // avoids having to clone the (potentially large) input table.
       sorter->pushBlock(*it);
     }

--- a/src/engine/idTable/CompressedExternalIdTable.h
+++ b/src/engine/idTable/CompressedExternalIdTable.h
@@ -326,6 +326,28 @@ struct PushBlockCallback {
   }
 };
 
+// The amount of memory that a `CompressedExternalIdTableBase` (see below) with
+// `numColumns` columns requires per row of its block size. The factor of two is
+// there because we store two blocks at the same time: One that is currently
+// being sorted and written to disk in the background, and one that is used to
+// collect rows in the calls to `push`.
+inline size_t blockMemoryPerRow(size_t numColumns) {
+  return numColumns * sizeof(Id) * 2;
+}
+
+// The number of rows per block that a `CompressedExternalIdTableBase` (see
+// below) with `numColumns` columns uses for the given `memory` limit.
+inline size_t blocksizeForMemory(MemorySize memory, size_t numColumns) {
+  return memory.getBytes() / blockMemoryPerRow(numColumns);
+}
+
+// The inverse of `blocksizeForMemory`: the memory limit for which a
+// `CompressedExternalIdTableBase` (see below) with `numColumns` columns uses
+// exactly `blocksize` rows per block.
+inline MemorySize memoryForBlocksize(size_t blocksize, size_t numColumns) {
+  return MemorySize::bytes(blocksize * blockMemoryPerRow(numColumns));
+}
+
 // The common base implementation of `CompressedExternalIdTable` and
 // `CompressedExternalIdTableSorter` (see below). It is implemented as a mixin
 // class.
@@ -355,10 +377,7 @@ CPP_class_template(size_t NumStaticCols,
   MemorySize memory_;
 
   // The number of rows per block in the first phase.
-  // The division by two is there because we store two blocks at the same time:
-  // One that is currently being sorted and written to disk in the background,
-  // and one that is used to collect rows in the calls to `push`.
-  size_t blocksize_{memory_.getBytes() / (numColumns_ * sizeof(Id) * 2)};
+  size_t blocksize_{blocksizeForMemory(memory_, numColumns_)};
   CompressedExternalIdTableWriter writer_;
   std::future<void> compressAndWriteFuture_;
 

--- a/src/engine/idTable/CompressedExternalIdTable.h
+++ b/src/engine/idTable/CompressedExternalIdTable.h
@@ -311,6 +311,21 @@ class CompressedExternalIdTableWriter {
   }
 };
 
+// A callback that pushes complete blocks (instead of single rows) into a
+// `CompressedExternalIdTableBase` (see `makePushBlockCallback` below). This is
+// a named type and not a lambda, such that callers that accept both per-row
+// and per-block callbacks can tell the two apart (see e.g. `liftCallback` in
+// `IndexImpl.cpp`).
+template <typename Table>
+struct PushBlockCallback {
+  Table* table_;
+
+  template <typename Block>
+  void operator()(const Block& block) const {
+    table_->pushBlock(block);
+  }
+};
+
 // The common base implementation of `CompressedExternalIdTable` and
 // `CompressedExternalIdTableSorter` (see below). It is implemented as a mixin
 // class.
@@ -401,8 +416,39 @@ CPP_class_template(size_t NumStaticCols,
     ++numElementsPushed_;
     currentBlock_.push_back(row);
     if (currentBlock_.size() >= blocksize_) {
-      pushBlock(std::move(currentBlock_));
+      transformAndWriteBlock(std::move(currentBlock_));
       resetCurrentBlock(true);
+    }
+  }
+
+  // Add all rows of the `table` (which has to be some kind of `IdTable`) to
+  // the input. This is much more efficient than calling `push` for each of the
+  // rows, because the `IdTable`s are stored column-based: Each column of the
+  // `table` is copied contiguously into the corresponding column of the
+  // internal buffer, instead of scattering each single row over all the
+  // columns. The `table` may be arbitrarily large, it is automatically split
+  // into blocks. The resulting blocks are exactly the same as if `push` had
+  // been called for each row individually.
+  CPP_template(typename Table)(requires IdTableLike<Table>) void pushBlock(
+      const Table& table) {
+    AD_CONTRACT_CHECK(table.numColumns() == numColumns_);
+    const size_t numRows = table.numRows();
+    numElementsPushed_ += numRows;
+    size_t numPushed = 0;
+    while (numPushed < numRows) {
+      // Note: `blocksize_` may be zero for very small memory limits (which
+      // only happens in unit tests), so we always insert at least one row to
+      // guarantee progress.
+      size_t remainingSpace = blocksize_ > currentBlock_.numRows()
+                                  ? blocksize_ - currentBlock_.numRows()
+                                  : 1;
+      size_t numToPush = std::min(remainingSpace, numRows - numPushed);
+      currentBlock_.insertAtEnd(table, numPushed, numPushed + numToPush);
+      numPushed += numToPush;
+      if (currentBlock_.numRows() >= blocksize_) {
+        transformAndWriteBlock(std::move(currentBlock_));
+        resetCurrentBlock(true);
+      }
     }
   }
 
@@ -412,6 +458,14 @@ CPP_class_template(size_t NumStaticCols,
   // Return a lambda that takes a `ValueType` and calls `push` for that value.
   auto makePushCallback() {
     return [self = this](auto&& value) { self->push(AD_FWD(value)); };
+  }
+
+  // Return a callback that takes a complete block and calls `pushBlock` for
+  // it. Prefer this over `makePushCallback` above whenever complete blocks are
+  // available, because pushing a complete block is much more efficient than
+  // pushing its rows one by one (see `pushBlock` above).
+  PushBlockCallback<CompressedExternalIdTableBase> makePushBlockCallback() {
+    return {this};
   }
 
   // Delete the underlying file and reset the sorter. May only be called if no
@@ -442,7 +496,7 @@ CPP_class_template(size_t NumStaticCols,
   // `writer_`. Before compressing, apply the transformation that is specified
   // by the `Impl` via the `transformBlock` function.
   template <typename Transformation = ql::identity>
-  void pushBlock(IdTableStatic<NumStaticCols> block) {
+  void transformAndWriteBlock(IdTableStatic<NumStaticCols> block) {
     waitForFuture();
     if (block.empty()) {
       if (numBlocksPushed_ > 0) {
@@ -464,9 +518,10 @@ CPP_class_template(size_t NumStaticCols,
 
   // If there is less than one complete block (meaning that the number of calls
   // to `push` was `< blocksize_`), apply the transformation to `currentBlock_`
-  // and return `false`. Else, push the `currentBlock_` via `pushBlock_`, block
-  // until the pushing is actually finished, and return `true`. Using this
-  // function allows for an efficient usage of this class for very small inputs.
+  // and return `false`. Else, write the `currentBlock_` via
+  // `transformAndWriteBlock`, block until the writing is actually finished,
+  // and return `true`. Using this function allows for an efficient usage of
+  // this class for very small inputs.
   bool transformAndPushLastBlock() {
     if (!isFirstIteration_) {
       return numBlocksPushed_ != 0;
@@ -490,7 +545,7 @@ CPP_class_template(size_t NumStaticCols,
       blockTransformation_(this->currentBlock_);
       return false;
     }
-    pushBlock(std::move(this->currentBlock_));
+    transformAndWriteBlock(std::move(this->currentBlock_));
     resetCurrentBlock(false);
     waitForFuture();
     return true;
@@ -546,7 +601,7 @@ class CompressedExternalIdTable
       return joinBlocks(InputRangeTypeErased<Block>{lazySingleValueRange(
           [this]() { return std::move(this->currentBlock_); })});
     }
-    this->pushBlock(std::move(this->currentBlock_));
+    this->transformAndWriteBlock(std::move(this->currentBlock_));
     this->resetCurrentBlock(false);
     this->waitForFuture();
     // Stream all blocks through a single background thread (O(1) threads total
@@ -708,12 +763,14 @@ class CompressedExternalIdTableSorter
   // The implementation of the type-erased interface. Push a complete block at
   // once.
   void pushBlock(const IdTableStatic<0>& block) override {
-    pushBlockImpl(block);
+    Base::pushBlock(block);
   }
 
   // The implementation of the type-erased interface. Push a complete block
   // given as a non-owning view at once.
-  void pushBlock(const IdTableView<0>& block) override { pushBlockImpl(block); }
+  void pushBlock(const IdTableView<0>& block) override {
+    Base::pushBlock(block);
+  }
 
   // The implementation of the type-erased interface. Get the sorted blocks as
   // dynamic IdTables.
@@ -723,14 +780,6 @@ class CompressedExternalIdTableSorter
   }
 
  private:
-  // Common implementation for the two `pushBlock` overloads above.
-  template <typename IdTableLike>
-  void pushBlockImpl(const IdTableLike& block) {
-    AD_CONTRACT_CHECK(block.numColumns() == this->numColumns_);
-    ql::ranges::for_each(block,
-                         [ptr = this](const auto& row) { ptr->push(row); });
-  }
-
   template <typename RowGenVectorType, typename CompType>
   struct SortState
       : ad_utility::InputRangeMixin<SortState<RowGenVectorType, CompType>> {

--- a/src/engine/idTable/CompressedExternalIdTable.h
+++ b/src/engine/idTable/CompressedExternalIdTable.h
@@ -326,7 +326,12 @@ struct PushBlockCallback {
   }
 };
 
-// The amount of memory that a `CompressedExternalIdTableBase` (see below) with
+// The conversion between the memory limit and the number of rows per block of
+// a `CompressedExternalIdTableBase` (see below). These functions have rather
+// general names, but are tied to that class, hence the dedicated namespace.
+namespace compressedExternalIdTable {
+
+// The amount of memory that a `CompressedExternalIdTableBase` with
 // `numColumns` columns requires per row of its block size. The factor of two is
 // there because we store two blocks at the same time: One that is currently
 // being sorted and written to disk in the background, and one that is used to
@@ -335,18 +340,20 @@ inline size_t blockMemoryPerRow(size_t numColumns) {
   return numColumns * sizeof(Id) * 2;
 }
 
-// The number of rows per block that a `CompressedExternalIdTableBase` (see
-// below) with `numColumns` columns uses for the given `memory` limit.
+// The number of rows per block that a `CompressedExternalIdTableBase` with
+// `numColumns` columns uses for the given `memory` limit.
 inline size_t blocksizeForMemory(MemorySize memory, size_t numColumns) {
   return memory.getBytes() / blockMemoryPerRow(numColumns);
 }
 
 // The inverse of `blocksizeForMemory`: the memory limit for which a
-// `CompressedExternalIdTableBase` (see below) with `numColumns` columns uses
-// exactly `blocksize` rows per block.
+// `CompressedExternalIdTableBase` with `numColumns` columns uses exactly
+// `blocksize` rows per block.
 inline MemorySize memoryForBlocksize(size_t blocksize, size_t numColumns) {
   return MemorySize::bytes(blocksize * blockMemoryPerRow(numColumns));
 }
+
+}  // namespace compressedExternalIdTable
 
 // The common base implementation of `CompressedExternalIdTable` and
 // `CompressedExternalIdTableSorter` (see below). It is implemented as a mixin
@@ -377,7 +384,8 @@ CPP_class_template(size_t NumStaticCols,
   MemorySize memory_;
 
   // The number of rows per block in the first phase.
-  size_t blocksize_{blocksizeForMemory(memory_, numColumns_)};
+  size_t blocksize_{
+      compressedExternalIdTable::blocksizeForMemory(memory_, numColumns_)};
   CompressedExternalIdTableWriter writer_;
   std::future<void> compressAndWriteFuture_;
 

--- a/src/index/CompressedRelationPermutationWriterImpl.h
+++ b/src/index/CompressedRelationPermutationWriterImpl.h
@@ -194,9 +194,9 @@ struct CompressedRelationWriter::PermutationWriter {
     if constexpr (WritePair) {
       auto twinRelation = relation_.asStaticView<0>();
       twinRelation.swapColumns(c1Idx, c2Idx);
-      for (const auto& row : twinRelation) {
-        twinRelationSorter_.push(row);
-      }
+      // Note: `pushBlock` inserts the columns of the `twinRelation`
+      // contiguously, which is much faster than pushing the rows one by one.
+      twinRelationSorter_.pushBlock(twinRelation);
     }
     writer1_->addBlockForLargeRelation(col0IdCurrentRelation_.value(),
                                        std::move(relation_).toDynamic());

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -928,6 +928,14 @@ auto liftCallback(Callback callback) {
     ql::ranges::for_each(block, callback);
   };
 }
+
+// Callbacks that already work on complete blocks are used as they are. Pushing
+// a complete block into an external sorter is much more efficient than pushing
+// its rows one by one, because the `IdTable`s are stored column-based.
+template <typename Table>
+auto liftCallback(ad_utility::PushBlockCallback<Table> callback) {
+  return callback;
+}
 }  // namespace
 
 // _____________________________________________________________________________
@@ -2017,7 +2025,7 @@ CPP_template_def(typename... NextSorter)(requires(
       };
   size_t numPredicates =
       createPermutationPair(numColumns, AD_FWD(sortedTriples), *pso_, *pos_,
-                            nextSorter.makePushCallback()..., countTriples,
+                            nextSorter.makePushBlockCallback()..., countTriples,
                             determineNextAvailableInternalGraph);
   configurationJson_["num-predicates"] =
       NumNormalAndInternal::fromNormal(numPredicates);
@@ -2064,7 +2072,7 @@ CPP_template_def(typename... NextSorter)(requires(sizeof...(NextSorter) <= 1))
     };
     size_t numSubjects = createPermutationPair(
         numColumns, AD_FWD(sortedTriples), *spo_, *sop_,
-        nextSorter.makePushCallback()..., pushTripleToPatterns);
+        nextSorter.makePushBlockCallback()..., pushTripleToPatterns);
     patternCreator.finish();
     configurationJson_["num-subjects"] =
         NumNormalAndInternal::fromNormal(numSubjects);
@@ -2074,7 +2082,7 @@ CPP_template_def(typename... NextSorter)(requires(sizeof...(NextSorter) <= 1))
     AD_CORRECTNESS_CHECK(sizeof...(nextSorter) == 1);
     size_t numSubjects =
         createPermutationPair(numColumns, AD_FWD(sortedTriples), *spo_, *sop_,
-                              nextSorter.makePushCallback()...);
+                              nextSorter.makePushBlockCallback()...);
     configurationJson_["num-subjects"] =
         NumNormalAndInternal::fromNormal(numSubjects);
     writeConfiguration();
@@ -2092,7 +2100,7 @@ CPP_template_def(typename... NextSorter)(
   // have no fourth argument.
   size_t numObjects =
       createPermutationPair(numColumns, AD_FWD(sortedTriples), *osp_, *ops_,
-                            nextSorter.makePushCallback()...);
+                            nextSorter.makePushBlockCallback()...);
   configurationJson_["num-objects"] =
       NumNormalAndInternal::fromNormal(numObjects);
   configurationJson_["has-all-permutations"] = true;

--- a/test/engine/idTable/CompressedExternalIdTableTest.cpp
+++ b/test/engine/idTable/CompressedExternalIdTableTest.cpp
@@ -18,6 +18,8 @@
 #include "util/ConstexprUtils.h"
 
 using ad_utility::source_location;
+using ad_utility::compressedExternalIdTable::blocksizeForMemory;
+using ad_utility::compressedExternalIdTable::memoryForBlocksize;
 using namespace ad_utility::memory_literals;
 
 namespace {
@@ -245,7 +247,7 @@ TEST(CompressedExternalIdTable, cornerCasesEmptyBlocks) {
   std::string filename = "idTableCompressedSorter.cornerCases.dat";
   ad_utility::EXTERNAL_ID_TABLE_SORTER_IGNORE_MEMORY_LIMIT_FOR_TESTING = true;
   ad_utility::CompressedExternalIdTable<0> writer{
-      filename, NUM_COLS, ad_utility::memoryForBlocksize(blockSize, NUM_COLS),
+      filename, NUM_COLS, memoryForBlocksize(blockSize, NUM_COLS),
       ad_utility::testing::makeAllocator()};
 
   // Push exactly 10 rows. After the 10th row, one full block is written and
@@ -415,8 +417,8 @@ TEST(CompressedExternalIdTable, pushBlockProducesCorrectSortedOutput) {
 TEST(CompressedExternalIdTable, blocksizeAndMemoryAreInverses) {
   for (size_t numColumns : {1u, 2u, 3u, 7u}) {
     for (size_t blocksize : {1u, 2u, 6u, 1000u}) {
-      auto memory = ad_utility::memoryForBlocksize(blocksize, numColumns);
-      EXPECT_EQ(ad_utility::blocksizeForMemory(memory, numColumns), blocksize);
+      auto memory = memoryForBlocksize(blocksize, numColumns);
+      EXPECT_EQ(blocksizeForMemory(memory, numColumns), blocksize);
     }
   }
 }
@@ -491,7 +493,7 @@ void testCompressedExternalIdTablePushBlock(
   ad_utility::EXTERNAL_ID_TABLE_SORTER_IGNORE_MEMORY_LIMIT_FOR_TESTING = true;
   // Choose the memory limit such that exactly 6 rows fit into a single block.
   constexpr size_t blocksize = 6;
-  auto memory = ad_utility::memoryForBlocksize(blocksize, NUM_COLS);
+  auto memory = memoryForBlocksize(blocksize, NUM_COLS);
 
   std::string filename =
       absl::StrCat(gtestCurrentTestName(), ".", NumStaticCols, ".dat");
@@ -528,7 +530,7 @@ TEST(CompressedExternalIdTable, pushBlockEqualsRowWisePush) {
            {1, 17}, {2, 17}, {3, 100}, {10, 100}, {64, 500}}) {
     SCOPED_TRACE(
         absl::StrCat("blocksize = ", blocksize, ", numRows = ", numRows));
-    auto memory = ad_utility::memoryForBlocksize(blocksize, NUM_COLS);
+    auto memory = memoryForBlocksize(blocksize, NUM_COLS);
     IdTable table = createRandomlyFilledIdTable(numRows, NUM_COLS);
     // Test the static as well as the dynamic instantiation of the sorter.
     testPushBlockEqualsRowWisePush<NUM_COLS>(table, memory);
@@ -542,7 +544,7 @@ TEST(CompressedExternalIdTable, pushBlockBlockBoundaries) {
   ad_utility::EXTERNAL_ID_TABLE_SORTER_IGNORE_MEMORY_LIMIT_FOR_TESTING = true;
   // Choose the memory limit such that exactly 8 rows fit into a single block.
   constexpr size_t blocksize = 8;
-  auto memory = ad_utility::memoryForBlocksize(blocksize, NUM_COLS);
+  auto memory = memoryForBlocksize(blocksize, NUM_COLS);
 
   std::string filename = absl::StrCat(gtestCurrentTestName(), ".dat");
   absl::Cleanup cleanup = [&filename] {
@@ -580,7 +582,7 @@ TEST(CompressedExternalIdTable, pushBlockMixedWithSingleRowPushes) {
   ad_utility::EXTERNAL_ID_TABLE_SORTER_IGNORE_MEMORY_LIMIT_FOR_TESTING = true;
   // Choose the memory limit such that exactly 5 rows fit into a single block.
   constexpr size_t blocksize = 5;
-  auto memory = ad_utility::memoryForBlocksize(blocksize, NUM_COLS);
+  auto memory = memoryForBlocksize(blocksize, NUM_COLS);
 
   std::string filename = absl::StrCat(gtestCurrentTestName(), ".dat");
   absl::Cleanup cleanup = [&filename] {
@@ -637,7 +639,7 @@ TEST(CompressedExternalIdTable, pushEmptyBlockIsNoOp) {
   ad_utility::EXTERNAL_ID_TABLE_SORTER_IGNORE_MEMORY_LIMIT_FOR_TESTING = true;
   // Choose the memory limit such that exactly 4 rows fit into a single block.
   constexpr size_t blocksize = 4;
-  auto memory = ad_utility::memoryForBlocksize(blocksize, NUM_COLS);
+  auto memory = memoryForBlocksize(blocksize, NUM_COLS);
 
   std::string filename = absl::StrCat(gtestCurrentTestName(), ".dat");
   absl::Cleanup cleanup = [&filename] {
@@ -701,7 +703,7 @@ TEST(CompressedExternalIdTable, pushBlockCreatesSameBlocksAsRowWisePush) {
     auto trace = generateLocationTrace(l);
     SCOPED_TRACE(
         absl::StrCat("blocksize = ", blocksize, ", numRows = ", numRows));
-    auto memory = ad_utility::memoryForBlocksize(blocksize, NUM_COLS);
+    auto memory = memoryForBlocksize(blocksize, NUM_COLS);
     // Each time `blocksize` rows have accumulated, a block is written to disk.
     // A possible remainder becomes one additional block.
     size_t expectedNumBlocks = (numRows + blocksize - 1) / blocksize;

--- a/test/engine/idTable/CompressedExternalIdTableTest.cpp
+++ b/test/engine/idTable/CompressedExternalIdTableTest.cpp
@@ -244,9 +244,8 @@ TEST(CompressedExternalIdTable, cornerCasesEmptyBlocks) {
   size_t blockSize = 10;
   std::string filename = "idTableCompressedSorter.cornerCases.dat";
   ad_utility::EXTERNAL_ID_TABLE_SORTER_IGNORE_MEMORY_LIMIT_FOR_TESTING = true;
-  size_t blockMemory = blockSize * NUM_COLS * sizeof(Id) * 2;
   ad_utility::CompressedExternalIdTable<0> writer{
-      filename, NUM_COLS, ad_utility::MemorySize::bytes(blockMemory),
+      filename, NUM_COLS, ad_utility::memoryForBlocksize(blockSize, NUM_COLS),
       ad_utility::testing::makeAllocator()};
 
   // Push exactly 10 rows. After the 10th row, one full block is written and
@@ -409,22 +408,20 @@ TEST(CompressedExternalIdTable, pushBlockProducesCorrectSortedOutput) {
   EXPECT_THAT(result, ElementsAreArray(expected));
 }
 
+// `memoryForBlocksize` and `blocksizeForMemory` are inverses of each other, so
+// the tests below can specify the number of rows per block instead of a memory
+// limit.
+// _____________________________________________________________________________
+TEST(CompressedExternalIdTable, blocksizeAndMemoryAreInverses) {
+  for (size_t numColumns : {1u, 2u, 3u, 7u}) {
+    for (size_t blocksize : {1u, 2u, 6u, 1000u}) {
+      auto memory = ad_utility::memoryForBlocksize(blocksize, numColumns);
+      EXPECT_EQ(ad_utility::blocksizeForMemory(memory, numColumns), blocksize);
+    }
+  }
+}
+
 namespace {
-
-// The number of rows per block that a `CompressedExternalIdTableBase` uses for
-// the given memory limit and number of columns. This mirrors the formula
-// `blocksize_ = memory / (numColumns * sizeof(Id) * 2)` from
-// `CompressedExternalIdTable.h`.
-size_t blocksizeForMemory(ad_utility::MemorySize memory, size_t numColumns) {
-  return memory.getBytes() / (numColumns * sizeof(Id) * 2);
-}
-
-// The inverse of `blocksizeForMemory`: the memory limit for which a
-// `CompressedExternalIdTableBase` with `numColumns` columns uses exactly
-// `blocksize` rows per block.
-ad_utility::MemorySize memoryForBlocksize(size_t blocksize, size_t numColumns) {
-  return ad_utility::MemorySize::bytes(blocksize * numColumns * sizeof(Id) * 2);
-}
 
 // Collect the complete sorted output of the `sorter` into a single `IdTable`.
 CopyableIdTable<0> sortedOutput(
@@ -494,8 +491,7 @@ void testCompressedExternalIdTablePushBlock(
   ad_utility::EXTERNAL_ID_TABLE_SORTER_IGNORE_MEMORY_LIMIT_FOR_TESTING = true;
   // Choose the memory limit such that exactly 6 rows fit into a single block.
   constexpr size_t blocksize = 6;
-  auto memory = memoryForBlocksize(blocksize, NUM_COLS);
-  ASSERT_EQ(blocksizeForMemory(memory, NUM_COLS), blocksize);
+  auto memory = ad_utility::memoryForBlocksize(blocksize, NUM_COLS);
 
   std::string filename =
       absl::StrCat(gtestCurrentTestName(), ".", NumStaticCols, ".dat");
@@ -532,8 +528,7 @@ TEST(CompressedExternalIdTable, pushBlockEqualsRowWisePush) {
            {1, 17}, {2, 17}, {3, 100}, {10, 100}, {64, 500}}) {
     SCOPED_TRACE(
         absl::StrCat("blocksize = ", blocksize, ", numRows = ", numRows));
-    auto memory = memoryForBlocksize(blocksize, NUM_COLS);
-    ASSERT_EQ(blocksizeForMemory(memory, NUM_COLS), blocksize);
+    auto memory = ad_utility::memoryForBlocksize(blocksize, NUM_COLS);
     IdTable table = createRandomlyFilledIdTable(numRows, NUM_COLS);
     // Test the static as well as the dynamic instantiation of the sorter.
     testPushBlockEqualsRowWisePush<NUM_COLS>(table, memory);
@@ -547,8 +542,7 @@ TEST(CompressedExternalIdTable, pushBlockBlockBoundaries) {
   ad_utility::EXTERNAL_ID_TABLE_SORTER_IGNORE_MEMORY_LIMIT_FOR_TESTING = true;
   // Choose the memory limit such that exactly 8 rows fit into a single block.
   constexpr size_t blocksize = 8;
-  auto memory = memoryForBlocksize(blocksize, NUM_COLS);
-  ASSERT_EQ(blocksizeForMemory(memory, NUM_COLS), blocksize);
+  auto memory = ad_utility::memoryForBlocksize(blocksize, NUM_COLS);
 
   std::string filename = absl::StrCat(gtestCurrentTestName(), ".dat");
   absl::Cleanup cleanup = [&filename] {
@@ -586,8 +580,7 @@ TEST(CompressedExternalIdTable, pushBlockMixedWithSingleRowPushes) {
   ad_utility::EXTERNAL_ID_TABLE_SORTER_IGNORE_MEMORY_LIMIT_FOR_TESTING = true;
   // Choose the memory limit such that exactly 5 rows fit into a single block.
   constexpr size_t blocksize = 5;
-  auto memory = memoryForBlocksize(blocksize, NUM_COLS);
-  ASSERT_EQ(blocksizeForMemory(memory, NUM_COLS), blocksize);
+  auto memory = ad_utility::memoryForBlocksize(blocksize, NUM_COLS);
 
   std::string filename = absl::StrCat(gtestCurrentTestName(), ".dat");
   absl::Cleanup cleanup = [&filename] {
@@ -644,8 +637,7 @@ TEST(CompressedExternalIdTable, pushEmptyBlockIsNoOp) {
   ad_utility::EXTERNAL_ID_TABLE_SORTER_IGNORE_MEMORY_LIMIT_FOR_TESTING = true;
   // Choose the memory limit such that exactly 4 rows fit into a single block.
   constexpr size_t blocksize = 4;
-  auto memory = memoryForBlocksize(blocksize, NUM_COLS);
-  ASSERT_EQ(blocksizeForMemory(memory, NUM_COLS), blocksize);
+  auto memory = ad_utility::memoryForBlocksize(blocksize, NUM_COLS);
 
   std::string filename = absl::StrCat(gtestCurrentTestName(), ".dat");
   absl::Cleanup cleanup = [&filename] {
@@ -709,8 +701,7 @@ TEST(CompressedExternalIdTable, pushBlockCreatesSameBlocksAsRowWisePush) {
     auto trace = generateLocationTrace(l);
     SCOPED_TRACE(
         absl::StrCat("blocksize = ", blocksize, ", numRows = ", numRows));
-    auto memory = memoryForBlocksize(blocksize, NUM_COLS);
-    ASSERT_EQ(blocksizeForMemory(memory, NUM_COLS), blocksize);
+    auto memory = ad_utility::memoryForBlocksize(blocksize, NUM_COLS);
     // Each time `blocksize` rows have accumulated, a block is written to disk.
     // A possible remainder becomes one additional block.
     size_t expectedNumBlocks = (numRows + blocksize - 1) / blocksize;

--- a/test/engine/idTable/CompressedExternalIdTableTest.cpp
+++ b/test/engine/idTable/CompressedExternalIdTableTest.cpp
@@ -4,6 +4,8 @@
 //
 // UFR = University of Freiburg, Chair of Algorithms and Data Structures
 
+#include <absl/cleanup/cleanup.h>
+#include <absl/strings/str_cat.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
@@ -405,4 +407,337 @@ TEST(CompressedExternalIdTable, pushBlockProducesCorrectSortedOutput) {
 
   using namespace ::testing;
   EXPECT_THAT(result, ElementsAreArray(expected));
+}
+
+namespace {
+
+// The number of rows per block that a `CompressedExternalIdTableBase` uses for
+// the given memory limit and number of columns. This mirrors the formula
+// `blocksize_ = memory / (numColumns * sizeof(Id) * 2)` from
+// `CompressedExternalIdTable.h`.
+size_t blocksizeForMemory(ad_utility::MemorySize memory, size_t numColumns) {
+  return memory.getBytes() / (numColumns * sizeof(Id) * 2);
+}
+
+// The inverse of `blocksizeForMemory`: the memory limit for which a
+// `CompressedExternalIdTableBase` with `numColumns` columns uses exactly
+// `blocksize` rows per block.
+ad_utility::MemorySize memoryForBlocksize(size_t blocksize, size_t numColumns) {
+  return ad_utility::MemorySize::bytes(blocksize * numColumns * sizeof(Id) * 2);
+}
+
+// Collect the complete sorted output of the `sorter` into a single `IdTable`.
+CopyableIdTable<0> sortedOutput(
+    ad_utility::CompressedExternalIdTableSorterTypeErased& sorter) {
+  auto blocks = sorter.getSortedOutput();
+  return idTableFromBlockGenerator(blocks);
+}
+
+// Return a copy of the `table` that is sorted by `SortByOSP`.
+CopyableIdTable<0> sortedCopy(const IdTable& table) {
+  CopyableIdTable<0> result{table.clone()};
+  ql::ranges::sort(result, SortByOSP{});
+  return result;
+}
+
+// Push the rows of the `table` row by row via `push` into one sorter, and in a
+// single call to `pushBlock` into a second, identically configured sorter.
+// Then check that both sorters report the same `size()` and yield exactly the
+// same sorted output.
+template <size_t NumStaticCols>
+void testPushBlockEqualsRowWisePush(
+    const IdTable& table, ad_utility::MemorySize memoryToUse,
+    source_location l = AD_CURRENT_SOURCE_LOC()) {
+  auto trace = generateLocationTrace(l);
+  ad_utility::EXTERNAL_ID_TABLE_SORTER_IGNORE_MEMORY_LIMIT_FOR_TESTING = true;
+  auto alloc = ad_utility::testing::makeAllocator();
+  using Sorter =
+      ad_utility::CompressedExternalIdTableSorter<SortByOSP, NumStaticCols>;
+
+  std::string rowWiseFile =
+      absl::StrCat(gtestCurrentTestName(), ".rowWise.dat");
+  std::string blockWiseFile =
+      absl::StrCat(gtestCurrentTestName(), ".blockWise.dat");
+  // Note: The files are already deleted by the destructor of the underlying
+  // `CompressedExternalIdTableWriter`, so we don't warn if the deletion fails.
+  absl::Cleanup cleanup = [&rowWiseFile, &blockWiseFile] {
+    ad_utility::deleteFile(rowWiseFile, false);
+    ad_utility::deleteFile(blockWiseFile, false);
+  };
+
+  Sorter rowWise{rowWiseFile, table.numColumns(), memoryToUse, alloc};
+  Sorter blockWise{blockWiseFile, table.numColumns(), memoryToUse, alloc};
+
+  for (const auto& row : table) {
+    rowWise.push(row);
+  }
+  blockWise.pushBlock(table);
+
+  EXPECT_EQ(rowWise.size(), table.numRows());
+  EXPECT_EQ(blockWise.size(), rowWise.size());
+
+  auto rowWiseResult = sortedOutput(rowWise);
+  auto blockWiseResult = sortedOutput(blockWise);
+  EXPECT_EQ(blockWiseResult.numRows(), rowWiseResult.numRows());
+  EXPECT_THAT(blockWiseResult, ::testing::ElementsAreArray(rowWiseResult));
+  EXPECT_THAT(blockWiseResult, ::testing::ElementsAreArray(sortedCopy(table)));
+}
+
+// Push several blocks into a (non-sorting) `CompressedExternalIdTable` via
+// `pushBlock` and check that `getRows` yields the rows in exactly the order in
+// which they were pushed.
+template <size_t NumStaticCols>
+void testCompressedExternalIdTablePushBlock(
+    source_location l = AD_CURRENT_SOURCE_LOC()) {
+  auto trace = generateLocationTrace(l);
+  auto alloc = ad_utility::testing::makeAllocator();
+  ad_utility::EXTERNAL_ID_TABLE_SORTER_IGNORE_MEMORY_LIMIT_FOR_TESTING = true;
+  // Choose the memory limit such that exactly 6 rows fit into a single block.
+  constexpr size_t blocksize = 6;
+  auto memory = memoryForBlocksize(blocksize, NUM_COLS);
+  ASSERT_EQ(blocksizeForMemory(memory, NUM_COLS), blocksize);
+
+  std::string filename =
+      absl::StrCat(gtestCurrentTestName(), ".", NumStaticCols, ".dat");
+  absl::Cleanup cleanup = [&filename] {
+    ad_utility::deleteFile(filename, false);
+  };
+  ad_utility::CompressedExternalIdTable<NumStaticCols> writer{
+      filename, NUM_COLS, memory, alloc};
+
+  // The concatenation of all pushed blocks, in the order in which they were
+  // pushed. The block sizes cover the corner cases of an empty block, blocks
+  // that are smaller and larger than the `blocksize`, and a block that exactly
+  // fills a single block.
+  CopyableIdTable<NumStaticCols> expected{NUM_COLS, alloc};
+  for (size_t numRows : {4UL, blocksize, 13UL, 1UL, 0UL, 20UL}) {
+    IdTable block = createRandomlyFilledIdTable(numRows, NUM_COLS);
+    writer.pushBlock(block);
+    expected.insertAtEnd(block);
+  }
+  EXPECT_EQ(writer.size(), expected.numRows());
+
+  auto generator = writer.getRows();
+  auto result = idTableFromRowGenerator<NumStaticCols>(generator, NUM_COLS);
+  EXPECT_THAT(result, ::testing::ElementsAreArray(expected));
+}
+}  // namespace
+
+// _____________________________________________________________________________
+TEST(CompressedExternalIdTable, pushBlockEqualsRowWisePush) {
+  // Test several memory limits that lead to small blocksizes, including the
+  // corner case of a single row per block.
+  for (const auto& [blocksize, numRows] :
+       std::vector<std::pair<size_t, size_t>>{
+           {1, 17}, {2, 17}, {3, 100}, {10, 100}, {64, 500}}) {
+    SCOPED_TRACE(
+        absl::StrCat("blocksize = ", blocksize, ", numRows = ", numRows));
+    auto memory = memoryForBlocksize(blocksize, NUM_COLS);
+    ASSERT_EQ(blocksizeForMemory(memory, NUM_COLS), blocksize);
+    IdTable table = createRandomlyFilledIdTable(numRows, NUM_COLS);
+    // Test the static as well as the dynamic instantiation of the sorter.
+    testPushBlockEqualsRowWisePush<NUM_COLS>(table, memory);
+    testPushBlockEqualsRowWisePush<0>(table, memory);
+  }
+}
+
+// _____________________________________________________________________________
+TEST(CompressedExternalIdTable, pushBlockBlockBoundaries) {
+  auto alloc = ad_utility::testing::makeAllocator();
+  ad_utility::EXTERNAL_ID_TABLE_SORTER_IGNORE_MEMORY_LIMIT_FOR_TESTING = true;
+  // Choose the memory limit such that exactly 8 rows fit into a single block.
+  constexpr size_t blocksize = 8;
+  auto memory = memoryForBlocksize(blocksize, NUM_COLS);
+  ASSERT_EQ(blocksizeForMemory(memory, NUM_COLS), blocksize);
+
+  std::string filename = absl::StrCat(gtestCurrentTestName(), ".dat");
+  absl::Cleanup cleanup = [&filename] {
+    ad_utility::deleteFile(filename, false);
+  };
+
+  auto runTestForNumRows = [&](size_t numRows,
+                               source_location l = AD_CURRENT_SOURCE_LOC()) {
+    auto trace = generateLocationTrace(l);
+    SCOPED_TRACE(absl::StrCat("numRows = ", numRows));
+    ad_utility::CompressedExternalIdTableSorter<SortByOSP, NUM_COLS> sorter{
+        filename, NUM_COLS, memory, alloc};
+    IdTable table = createRandomlyFilledIdTable(numRows, NUM_COLS);
+    sorter.pushBlock(table);
+    EXPECT_EQ(sorter.size(), numRows);
+    auto result = sortedOutput(sorter);
+    EXPECT_EQ(result.numRows(), numRows);
+    EXPECT_THAT(result, ::testing::ElementsAreArray(sortedCopy(table)));
+  };
+
+  runTestForNumRows(0);
+  runTestForNumRows(1);
+  runTestForNumRows(blocksize - 1);
+  runTestForNumRows(blocksize);
+  runTestForNumRows(blocksize + 1);
+  runTestForNumRows(2 * blocksize);
+  runTestForNumRows(2 * blocksize + 1);
+  runTestForNumRows(5 * blocksize);
+  runTestForNumRows(7 * blocksize + 3);
+}
+
+// _____________________________________________________________________________
+TEST(CompressedExternalIdTable, pushBlockMixedWithSingleRowPushes) {
+  auto alloc = ad_utility::testing::makeAllocator();
+  ad_utility::EXTERNAL_ID_TABLE_SORTER_IGNORE_MEMORY_LIMIT_FOR_TESTING = true;
+  // Choose the memory limit such that exactly 5 rows fit into a single block.
+  constexpr size_t blocksize = 5;
+  auto memory = memoryForBlocksize(blocksize, NUM_COLS);
+  ASSERT_EQ(blocksizeForMemory(memory, NUM_COLS), blocksize);
+
+  std::string filename = absl::StrCat(gtestCurrentTestName(), ".dat");
+  absl::Cleanup cleanup = [&filename] {
+    ad_utility::deleteFile(filename, false);
+  };
+  ad_utility::CompressedExternalIdTableSorter<SortByOSP, NUM_COLS> sorter{
+      filename, NUM_COLS, memory, alloc};
+
+  // All rows that have been pushed so far, in the order in which they were
+  // pushed.
+  CopyableIdTable<0> allRows{NUM_COLS, alloc};
+
+  // Push `numRows` random rows one by one via `push`.
+  auto pushRows = [&](size_t numRows) {
+    IdTable table = createRandomlyFilledIdTable(numRows, NUM_COLS);
+    for (const auto& row : table) {
+      sorter.push(row);
+    }
+    allRows.insertAtEnd(table);
+  };
+  // Push a random table with `numRows` rows in a single call to `pushBlock`.
+  auto pushTable = [&](size_t numRows) {
+    IdTable table = createRandomlyFilledIdTable(numRows, NUM_COLS);
+    sorter.pushBlock(table);
+    allRows.insertAtEnd(table);
+  };
+
+  pushRows(3);
+  pushTable(7);
+  pushRows(1);
+  pushTable(0);
+  pushTable(13);
+  pushRows(2);
+  pushTable(blocksize);
+  pushRows(blocksize);
+  pushTable(1);
+
+  EXPECT_EQ(sorter.size(), allRows.numRows());
+  ql::ranges::sort(allRows, SortByOSP{});
+  auto result = sortedOutput(sorter);
+  EXPECT_THAT(result, ::testing::ElementsAreArray(allRows));
+}
+
+// _____________________________________________________________________________
+TEST(CompressedExternalIdTable, pushBlockPreservesOrderInCompressor) {
+  // Test the static as well as the dynamic instantiation.
+  testCompressedExternalIdTablePushBlock<NUM_COLS>();
+  testCompressedExternalIdTablePushBlock<0>();
+}
+
+// _____________________________________________________________________________
+TEST(CompressedExternalIdTable, pushEmptyBlockIsNoOp) {
+  auto alloc = ad_utility::testing::makeAllocator();
+  ad_utility::EXTERNAL_ID_TABLE_SORTER_IGNORE_MEMORY_LIMIT_FOR_TESTING = true;
+  // Choose the memory limit such that exactly 4 rows fit into a single block.
+  constexpr size_t blocksize = 4;
+  auto memory = memoryForBlocksize(blocksize, NUM_COLS);
+  ASSERT_EQ(blocksizeForMemory(memory, NUM_COLS), blocksize);
+
+  std::string filename = absl::StrCat(gtestCurrentTestName(), ".dat");
+  absl::Cleanup cleanup = [&filename] {
+    ad_utility::deleteFile(filename, false);
+  };
+  ad_utility::CompressedExternalIdTableSorter<SortByOSP, NUM_COLS> sorter{
+      filename, NUM_COLS, memory, alloc};
+
+  // Pushing an empty table doesn't change the state of the sorter at all.
+  IdTable emptyTable{NUM_COLS, alloc};
+  sorter.pushBlock(emptyTable);
+  sorter.pushBlock(emptyTable);
+  EXPECT_EQ(sorter.size(), 0U);
+
+  // Pushing after the empty pushes still works. Note that in total fewer than
+  // `blocksize` rows are pushed, so no complete block is ever written to disk
+  // and the sorter takes its "everything fits into a single block" shortcut. If
+  // the empty pushes had created a spurious block, then an internal correctness
+  // check in `transformAndPushLastBlock` would fail here.
+  IdTable table = createRandomlyFilledIdTable(blocksize - 1, NUM_COLS);
+  sorter.pushBlock(table);
+  sorter.pushBlock(emptyTable);
+  EXPECT_EQ(sorter.size(), blocksize - 1);
+
+  auto result = sortedOutput(sorter);
+  EXPECT_EQ(result.numRows(), blocksize - 1);
+  EXPECT_THAT(result, ::testing::ElementsAreArray(sortedCopy(table)));
+}
+
+// _____________________________________________________________________________
+// The block boundaries that are used internally are not directly observable,
+// but the error message of the memory check in the merging phase contains the
+// number of blocks that have to be merged. Use this to verify that `pushBlock`
+// splits its input into exactly the same blocks as repeated calls to `push`.
+TEST(CompressedExternalIdTable, pushBlockCreatesSameBlocksAsRowWisePush) {
+  auto alloc = ad_utility::testing::makeAllocator();
+  // The memory limits below are deliberately too small for the merging phase,
+  // s.t. an exception that contains the number of blocks is thrown.
+  ad_utility::EXTERNAL_ID_TABLE_SORTER_IGNORE_MEMORY_LIMIT_FOR_TESTING = false;
+  absl::Cleanup restoreFlag = [] {
+    ad_utility::EXTERNAL_ID_TABLE_SORTER_IGNORE_MEMORY_LIMIT_FOR_TESTING = true;
+  };
+
+  std::string filename = absl::StrCat(gtestCurrentTestName(), ".dat");
+  absl::Cleanup cleanup = [&filename] {
+    ad_utility::deleteFile(filename, false);
+  };
+
+  using Sorter =
+      ad_utility::CompressedExternalIdTableSorter<SortByOSP, NUM_COLS>;
+  auto consume = [](Sorter& sorter) {
+    auto blocks = sorter.getSortedOutput(std::nullopt);
+    return idTableFromBlockGenerator(blocks);
+  };
+
+  // Note: `numRows` has to be at least `blocksize`, because otherwise no block
+  // at all is written to disk and the merging phase (and with it the memory
+  // check) is skipped completely.
+  auto runTestForBlocksize = [&](size_t blocksize, size_t numRows,
+                                 source_location l = AD_CURRENT_SOURCE_LOC()) {
+    auto trace = generateLocationTrace(l);
+    SCOPED_TRACE(
+        absl::StrCat("blocksize = ", blocksize, ", numRows = ", numRows));
+    auto memory = memoryForBlocksize(blocksize, NUM_COLS);
+    ASSERT_EQ(blocksizeForMemory(memory, NUM_COLS), blocksize);
+    // Each time `blocksize` rows have accumulated, a block is written to disk.
+    // A possible remainder becomes one additional block.
+    size_t expectedNumBlocks = (numRows + blocksize - 1) / blocksize;
+    auto matcher = ::testing::ContainsRegex(
+        absl::StrCat("merging ", expectedNumBlocks, " blocks"));
+
+    IdTable table = createRandomlyFilledIdTable(numRows, NUM_COLS);
+    {
+      Sorter rowWise{filename, NUM_COLS, memory, alloc};
+      for (const auto& row : table) {
+        rowWise.push(row);
+      }
+      AD_EXPECT_THROW_WITH_MESSAGE(consume(rowWise), matcher);
+    }
+    {
+      Sorter blockWise{filename, NUM_COLS, memory, alloc};
+      blockWise.pushBlock(table);
+      AD_EXPECT_THROW_WITH_MESSAGE(consume(blockWise), matcher);
+    }
+  };
+
+  runTestForBlocksize(4, 4);
+  runTestForBlocksize(4, 8);
+  runTestForBlocksize(4, 9);
+  runTestForBlocksize(4, 40);
+  runTestForBlocksize(4, 43);
+  runTestForBlocksize(1, 20);
+  runTestForBlocksize(10, 100);
+  runTestForBlocksize(10, 101);
 }


### PR DESCRIPTION
`IdTable`s are stored column-based, so pushing a single row means writing one `Id` into each of the columns, which are separate allocations. Several places in the index building and query processing did exactly that, although complete blocks were available.

* `CompressedExternalIdTableBase` now has a real bulk insert `pushBlock`, which appends the columns of the input contiguously (via `IdTable::insertAtEnd`) into the internal buffer, splitting the input at exactly the same block boundaries as the row-wise `push` would. The previous `CompressedExternalIdTableSorter::pushBlock` only looked like a bulk interface, but internally called `push` for each row, so all of its callers (`Sort`, `MaterializedViews`, `IndexImpl`) benefit as well. The protected function that compresses and writes a complete block to disk was renamed from `pushBlock` to `transformAndWriteBlock` to free up the name.
* `PermutationWriter::addBlockForLargeRelation` pushes the twin relation as a complete block instead of row by row.
* The per-block callbacks that feed the next permutation's external sorter used `makePushCallback`, which was then lifted to blocks by pushing each row separately. They now use the new `makePushBlockCallback`.

The new `pushBlock` is covered by unit tests that in particular check that it produces exactly the same blocks (and hence the same output) as the row-wise `push`, including the corner cases of empty blocks, blocks smaller/larger than the blocksize, a blocksize of one row, and mixing `push` and `pushBlock`.