### PR TITLE
Write the merged vocabulary and the partial ID maps on a separate thread

### DIFF
--- a/src/index/IndexBuilderTypes.h
+++ b/src/index/IndexBuilderTypes.h
@@ -36,6 +36,36 @@
 #include "util/TupleHelpers.h"
 #include "util/TypeTraits.h"
 
+// Return true if `word` is a blank node. A word is a blank node if it
+// starts with `_:`, or, when `blankNodeIriRegexes` is given, if it is an IRI
+// that is fully matched by one of those regexes.
+//
+// The regexes are matched (via `RE2::FullMatch`) against the full text of the
+// word, *including* the surrounding angle brackets of an IRI. The match has
+// to cover the entire word, so a regex must describe the whole IRI; to allow
+// an arbitrary suffix, end it with `.*`. For example the regex
+// `<https://example\.org/statement/.*>` matches the IRI
+// `<https://example.org/statement/42>`. Only IRIs (words starting with `<`)
+// are ever treated this way; literals are never converted. The regexes are
+// required to describe IRIs (i.e. to start with `<`), which is enforced by
+// `IndexImpl::setBlankNodeIriRegexes`. See also the
+// `--iri-as-blank-node-regexes` option of the index builder.
+inline bool isBlankNode(
+    std::string_view word,
+    const std::vector<std::unique_ptr<re2::RE2>>& blankNodeIriRegexes) {
+  if (ql::starts_with(word, "_:")) {
+    return true;
+  }
+  // Only IRIs (which start with `<`) can be treated as blank nodes; this also
+  // avoids running the regexes for the common case of a literal.
+  if (!ql::starts_with(word, "<")) {
+    return false;
+  }
+  return ql::ranges::any_of(blankNodeIriRegexes, [word](const auto& regex) {
+    return re2::RE2::FullMatch(word, *regex);
+  });
+}
+
 // An IRI or literal together with its index in the global vocabulary. This is
 // used during vocabulary merging.
 //
@@ -50,33 +80,11 @@ struct TripleComponentWithIndex {
   [[nodiscard]] auto& isExternal() { return isExternal_; }
   [[nodiscard]] const auto& iriOrLiteral() const { return iriOrLiteral_; }
   [[nodiscard]] auto& iriOrLiteral() { return iriOrLiteral_; }
-  // Return true if this word is a blank node. A word is a blank node if it
-  // starts with `_:`, or, when `blankNodeIriRegexes` is given, if it is an IRI
-  // that is fully matched by one of those regexes.
-  //
-  // The regexes are matched (via `RE2::FullMatch`) against the full text of the
-  // word, *including* the surrounding angle brackets of an IRI. The match has
-  // to cover the entire word, so a regex must describe the whole IRI; to allow
-  // an arbitrary suffix, end it with `.*`. For example the regex
-  // `<https://example\.org/statement/.*>` matches the IRI
-  // `<https://example.org/statement/42>`. Only IRIs (words starting with `<`)
-  // are ever treated this way; literals are never converted. The regexes are
-  // required to describe IRIs (i.e. to start with `<`), which is enforced by
-  // `IndexImpl::setBlankNodeIriRegexes`. See also the
-  // `--iri-as-blank-node-regexes` option of the index builder.
+  // Return true if this word is a blank node, see the free `isBlankNode`
+  // function above.
   bool isBlankNode(
       const std::vector<std::unique_ptr<re2::RE2>>& blankNodeIriRegexes) const {
-    if (ql::starts_with(iriOrLiteral_, "_:")) {
-      return true;
-    }
-    // Only IRIs (which start with `<`) can be treated as blank nodes; this also
-    // avoids running the regexes for the common case of a literal.
-    if (!ql::starts_with(iriOrLiteral_, "<")) {
-      return false;
-    }
-    return ql::ranges::any_of(blankNodeIriRegexes, [this](const auto& regex) {
-      return re2::RE2::FullMatch(iriOrLiteral_, *regex);
-    });
+    return ::isBlankNode(iriOrLiteral_, blankNodeIriRegexes);
   }
 
   AD_SERIALIZE_FRIEND_FUNCTION(TripleComponentWithIndex) {

--- a/src/index/VocabularyMerger.h
+++ b/src/index/VocabularyMerger.h
@@ -6,8 +6,9 @@
 #define QLEVER_SRC_INDEX_VOCABULARYMERGER_H
 
 #include <memory>
-#include <optional>
 #include <string>
+#include <string_view>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -24,6 +25,7 @@
 #include "util/Serializer/FileSerializer.h"
 #include "util/Serializer/SerializePair.h"
 #include "util/Serializer/SerializeVector.h"
+#include "util/TaskQueue.h"
 #include "util/TypeTraits.h"
 
 // Writes pairs of (partial ID, global ID) incrementally to a file.
@@ -169,6 +171,249 @@ struct VocabularyMetaData {
   const ad_utility::HashMap<std::string, Id>* globalSpecialIds_ =
       &qlever::specialIds();
 };
+// The internal helper types and the individual stages of the merging pipeline
+// (see the comment above `mergeVocabulary` below). None of them is part of the
+// public interface of this header.
+namespace detail {
+
+// Helper `struct` for a word from a partial vocabulary.
+struct QueueWord {
+  QueueWord() = default;
+  QueueWord(TripleComponentWithIndex&& v, size_t file)
+      : entry_(std::move(v)), partialFileId_(file) {}
+  TripleComponentWithIndex entry_;  // the word, its local ID and the
+                                    // information if it will be externalized
+  size_t partialFileId_;  // from which partial vocabulary did this word come
+
+  [[nodiscard]] const bool& isExternal() const { return entry_.isExternal(); }
+  [[nodiscard]] bool& isExternal() { return entry_.isExternal(); }
+
+  [[nodiscard]] const std::string& iriOrLiteral() const {
+    return entry_.iriOrLiteral();
+  }
+
+  [[nodiscard]] std::string& iriOrLiteral() { return entry_.iriOrLiteral(); }
+
+  [[nodiscard]] const auto& id() const { return entry_.index_; }
+};
+
+// Compute the memory footprint of a `QueueWord`, which the parallel merging
+// needs to limit its memory consumption.
+struct SizeOfQueueWord {
+  ad_utility::MemorySize operator()(const QueueWord& q) const {
+    return ad_utility::MemorySize::bytes(sizeof(QueueWord) +
+                                         q.entry_.iriOrLiteral().size());
+  }
+};
+inline constexpr SizeOfQueueWord sizeOfQueueWord{};
+
+// A word that occurs in the merged vocabulary for the first time, together
+// with the information whether it is to be externalized.
+struct UniqueWord {
+  // NOTE: This is a view into one of the `mergedWordBuffers_` of the
+  // `WordBatch` that this word belongs to. Those buffers are deliberately
+  // kept alive until the batch has been written to the vocabulary, such that
+  // the merging thread never has to copy or move a single word.
+  std::string_view word_;
+  bool isExternal_;
+};
+
+// A single entry of one of the partial ID maps, as it is created by the
+// merging thread. NOTE: At that point, the global ID of the corresponding
+// word is not yet known (it is only determined when the word is written to
+// the vocabulary), so the entry instead stores the index of the word within
+// its batch (see `IdMapBatch::globalIds_`).
+struct QueuedIdMapEntry {
+  uint32_t partialFileId_;
+  uint32_t indexOfWordInBatch_;
+  uint64_t localIndex_;
+};
+
+// All the ID map entries of a single batch, together with the global IDs
+// that those entries refer to.
+struct IdMapBatch {
+  std::vector<QueuedIdMapEntry> entries_;
+  // The global IDs of the distinct words of the batch. The element at index
+  // `0` is the global ID of the *last* distinct word of the *previous*
+  // batch, because the first words of a batch may well be further
+  // occurrences of that word.
+  std::vector<Id> globalIds_;
+};
+
+// A batch of merged words, as it is handed from the merging thread to the
+// thread that writes the words to the vocabulary.
+struct WordBatch {
+  std::vector<UniqueWord> uniqueWords_;
+  IdMapBatch idMapBatch_;
+  // The buffers of merged words that back the `string_view`s of the
+  // `uniqueWords_` (see there).
+  std::vector<std::vector<QueueWord>> mergedWordBuffers_;
+};
+
+// Concept for a callback that consumes a complete `WordBatch`.
+template <typename T>
+CPP_concept WordBatchCallback = std::is_invocable_v<const T&, WordBatch>;
+
+// The number of ID map entries (which is the same as the number of merged
+// words) that are collected in a single batch. A single buffer of merged
+// words only contains a rather small number of words (currently 100), which
+// would be much too fine-grained for a task queue.
+inline constexpr size_t idMapEntryBatchSize = 100'000;
+
+// The maximal number of batches that may be waiting in the queue of the
+// pipeline. NOTE: A batch keeps all the merged words alive that it was created
+// from (typically a few megabytes, see `idMapEntryBatchSize`), so this also
+// determines the memory footprint of the pipeline.
+inline constexpr size_t queueSize = 3;
+
+// The first stage of the merging pipeline: eliminate the duplicates from the
+// merged words and collect the distinct words as well as the entries for the
+// partial ID maps in batches.
+//
+// NOTE: This class is used exclusively by the merging thread; the complete
+// `WordBatch`es are the only thing that it hands on to the other stages.
+class WordBatchBuilder {
+ private:
+  // The word that was merged last. It is a view into one of the
+  // `mergedWordBuffers_` of the `currentBatch_`, or, as soon as that batch has
+  // been handed on to the next stage, into `lastWordStorage_`.
+  std::string_view lastWord_;
+  std::string lastWordStorage_;
+  bool hasLastWord_ = false;
+  // Whether any of the occurrences of the `lastWord_` was marked as external.
+  // NOTE: This is only used for the check of the vocabulary order. A word is
+  // written to the vocabulary as soon as its first occurrence is seen, so a
+  // later occurrence can no longer change its `isExternal` flag.
+  bool lastWordIsExternal_ = false;
+  // The index of the `lastWord_` within the `currentBatch_`, where `0` means
+  // that it is the last distinct word of the previous batch (see
+  // `IdMapBatch::globalIds_`).
+  uint32_t indexOfLastWordInBatch_ = 0;
+  // The batch that is currently being filled.
+  WordBatch currentBatch_;
+
+ public:
+  WordBatchBuilder() { startNewBatch(); }
+
+  // Eliminate the duplicates from a `buffer` of merged words and add the
+  // resulting distinct words as well as one ID map entry per word to the
+  // current batch. Whenever a batch is full, it is handed to the
+  // `batchCallback`. The `QueueWord`s must be passed in alphabetical order wrt
+  // the `comparator` (also across multiple calls), which is checked.
+  CPP_template(typename W, typename F)(
+      requires WordComparator<W> CPP_and WordBatchCallback<
+          F>) void addMergedWords(std::vector<QueueWord> buffer,
+                                  const W& comparator, const F& batchCallback);
+
+  // Hand the current (typically only partially filled) batch to the
+  // `batchCallback` and start a new batch. Do nothing if the current batch is
+  // empty.
+  CPP_template(typename F)(requires WordBatchCallback<F>) void flush(
+      const F& batchCallback);
+
+ private:
+  // Reset the `currentBatch_` and allocate its buffers.
+  void startNewBatch();
+};
+
+// The second stage of the merging pipeline: write the distinct words of a
+// batch to the vocabulary (via the word callback) and thereby determine their
+// global IDs.
+//
+// NOTE: This class is used exclusively by the worker thread of the
+// `VocabularyMergePipeline` below.
+class VocabularyWriter {
+ private:
+  // The metadata of the merged vocabulary, which is built up incrementally as
+  // the words are written.
+  VocabularyMetaData metaData_;
+  // The global ID of the word that was written to the vocabulary last (see
+  // `IdMapBatch::globalIds_`).
+  Id lastGlobalId_ = Id::makeUndefined();
+  ad_utility::ProgressBar progressBar_{metaData_.numWordsTotal(),
+                                       "Words merged: "};
+
+ public:
+  // Write the `uniqueWords` to the vocabulary, store their global IDs in the
+  // `idMapBatch`, and return that batch (which is then complete and can be
+  // written to the ID maps).
+  CPP_template(typename C)(requires WordCallback<C>) IdMapBatch
+      writeWordsToVocabulary(
+          const std::vector<UniqueWord>& uniqueWords, IdMapBatch idMapBatch,
+          C& wordCallback,
+          const std::vector<std::unique_ptr<re2::RE2>>& blankNodeIriRegexes);
+
+  // The metadata, which is complete as soon as all the batches have been
+  // written.
+  VocabularyMetaData& metaData() { return metaData_; }
+
+  // Log the final state of the progress bar. This has to be called exactly
+  // once, after the last batch has been written.
+  void logFinalProgress();
+};
+
+// The third stage of the merging pipeline: write the entries of a complete
+// `IdMapBatch` to the partial ID maps, one of which is created per partial
+// vocabulary.
+//
+// NOTE: This class is used exclusively by the worker thread of the
+// `VocabularyMergePipeline` below.
+class IdMapBatchWriter {
+ private:
+  // The ID maps, one per partial vocabulary.
+  std::vector<IdMapWriter> idMaps_;
+
+ public:
+  // Create the ID map for each of the `numFiles` partial vocabularies. The
+  // filenames are `basename + PARTIAL_VOCAB_IDMAP_INFIX + i`.
+  IdMapBatchWriter(const std::string& basename, size_t numFiles);
+
+  // Write all the entries of the `batch` to their respective ID maps.
+  void writeBatch(const IdMapBatch& batch);
+
+  // Close all the ID maps. After this, no more batches may be written.
+  void finish();
+};
+
+// The stages of the merging pipeline that run asynchronously to the merging
+// thread (stages 2 and 3 in the comment above `mergeVocabulary` below).
+//
+// NOTE: The queue has exactly one worker thread, so the batches are processed
+// in exactly the order in which the merging thread creates them, and the state
+// of the individual stages requires no further synchronization.
+class VocabularyMergePipeline {
+ private:
+  // NOTE: The order of the following declarations is important, because the
+  // members are destroyed in the reverse order of their declaration, and the
+  // destructor of the queue blocks until all its pending tasks have been run.
+  // The tasks write to both the `vocabularyWriter_` and the
+  // `idMapBatchWriter_`, so the queue has to be destroyed before them.
+  IdMapBatchWriter idMapBatchWriter_;
+  VocabularyWriter vocabularyWriter_;
+  ad_utility::TaskQueue<false> queue_{
+      queueSize, 1, "Writing the merged vocabulary and the ID maps"};
+
+ public:
+  // Create the pipeline. The `basename` and `numFiles` determine the files of
+  // the partial ID maps (see `IdMapBatchWriter`).
+  VocabularyMergePipeline(const std::string& basename, size_t numFiles)
+      : idMapBatchWriter_{basename, numFiles} {}
+
+  // Asynchronously process a single `batch` of merged words: write its
+  // distinct words to the vocabulary (via the `wordCallback` and the
+  // `blankNodeIriRegexes`), then write its ID map entries and destroy the
+  // merged words that it was created from. Block if the pipeline is busy.
+  CPP_template(typename C)(requires WordCallback<C>) void push(
+      WordBatch batch, C& wordCallback,
+      const std::vector<std::unique_ptr<re2::RE2>>& blankNodeIriRegexes);
+
+  // Wait until all the batches that were pushed have been processed
+  // completely, close the ID maps, and return the metadata of the merged
+  // vocabulary. After this, no more batches may be pushed.
+  VocabularyMetaData finish();
+};
+}  // namespace detail
+
 // _______________________________________________________________
 // Merge the partial vocabularies in the  binary files
 // `basename + PARTIAL_VOCAB_WORDS_INFIX + to_string(i)`
@@ -181,6 +426,24 @@ struct VocabularyMetaData {
 // compiled regexes; IRIs that are fully matched by any of them are treated as
 // blank nodes (see `TripleComponentWithIndex::isBlankNode`). The regexes are
 // compiled by the caller (see `IndexImpl::setBlankNodeIriRegexes`).
+//
+// The merging is organized as a pipeline of two threads, which communicate via
+// a task queue, such that both of them can work concurrently:
+//
+// 1. The thread that calls `mergeVocabulary` obtains the merged words in
+//    sorted order and eliminates the duplicates (a word typically occurs in
+//    many of the partial vocabularies). It collects the distinct words as well
+//    as the entries for the partial ID maps in batches (see
+//    `detail::WordBatchBuilder`) and hands each batch to the second thread.
+// 2. The second thread writes the distinct words of a batch to the vocabulary
+//    (via the `wordCallback`) and thereby determines their global IDs (see
+//    `detail::VocabularyWriter`). It then writes the entries of the partial ID
+//    maps, which only now know their global IDs (see
+//    `detail::IdMapBatchWriter`), and finally destroys the merged words of the
+//    batch (which involves freeing one string per word).
+//
+// The second of those stages is owned by the
+// `detail::VocabularyMergePipeline`.
 template <typename W, typename C>
 auto mergeVocabulary(
     const std::string& basename, size_t numFiles, W comparator, C& wordCallback,
@@ -188,96 +451,6 @@ auto mergeVocabulary(
     const std::vector<std::unique_ptr<re2::RE2>>& blankNodeIriRegexes = {})
     -> CPP_ret(VocabularyMetaData)(
         requires WordComparator<W>&& WordCallback<C>);
-
-// A helper class that implements the `mergeVocabulary` function (see
-// above). Everything in this class is private and only the
-// `mergeVocabulary` function is a friend.
-class VocabularyMerger {
- private:
-  // private data members
-
-  // The result (mostly metadata) which we'll return.
-  VocabularyMetaData metaData_;
-  std::optional<TripleComponentWithIndex> lastTripleComponent_ = std::nullopt;
-  // Whether `lastTripleComponent_` is a blank node. Cached here so that
-  // `isBlankNode` (which may run a set of regexes) is evaluated only once per
-  // distinct word.
-  bool lastTripleComponentIsBlankNode_ = false;
-  // we will store pairs of <partialId, globalId>
-  std::vector<IdMapWriter> idMaps_;
-
-  // Friend declaration for the publicly available function.
-  template <typename W, typename C>
-  friend auto mergeVocabulary(
-      const std::string& basename, size_t numFiles, W comparator,
-      C& wordCallback, ad_utility::MemorySize memoryToUse,
-      const std::vector<std::unique_ptr<re2::RE2>>& blankNodeIriRegexes)
-      -> CPP_ret(VocabularyMetaData)(
-          requires WordComparator<W>&& WordCallback<C>);
-  VocabularyMerger() = default;
-
-  // _______________________________________________________________
-  // The function that performs the actual merge. See the static global
-  // `mergeVocabulary` function for details.
-  template <typename W, typename C>
-  auto mergeVocabulary(
-      const std::string& basename, size_t numFiles, W comparator,
-      C& wordCallback, ad_utility::MemorySize memoryToUse,
-      const std::vector<std::unique_ptr<re2::RE2>>& blankNodeIriRegexes)
-      -> CPP_ret(VocabularyMetaData)(
-          requires WordComparator<W>&& WordCallback<C>);
-
-  // Helper `struct` for a word from a partial vocabulary.
-  struct QueueWord {
-    QueueWord() = default;
-    QueueWord(TripleComponentWithIndex&& v, size_t file)
-        : entry_(std::move(v)), partialFileId_(file) {}
-    TripleComponentWithIndex entry_;  // the word, its local ID and the
-                                      // information if it will be externalized
-    size_t partialFileId_;  // from which partial vocabulary did this word come
-
-    [[nodiscard]] const bool& isExternal() const { return entry_.isExternal(); }
-    [[nodiscard]] bool& isExternal() { return entry_.isExternal(); }
-
-    [[nodiscard]] const std::string& iriOrLiteral() const {
-      return entry_.iriOrLiteral();
-    }
-
-    [[nodiscard]] std::string& iriOrLiteral() { return entry_.iriOrLiteral(); }
-
-    [[nodiscard]] const auto& id() const { return entry_.index_; }
-  };
-
-  struct SizeOfQueueWord {
-    ad_utility::MemorySize operator()(const QueueWord& q) const {
-      return ad_utility::MemorySize::bytes(sizeof(QueueWord) +
-                                           q.entry_.iriOrLiteral().size());
-    }
-  };
-  constexpr static SizeOfQueueWord sizeOfQueueWord{};
-
-  // Write the queue words in the buffer to their corresponding `idMaps`.
-  // The `QueueWord`s must be passed in alphabetical order wrt `lessThan` (also
-  // across multiple calls).
-  // clang-format off
-    CPP_template(typename C, typename L)(
-      requires WordCallback<C> CPP_and ranges::predicate<
-          L, TripleComponentWithIndex, TripleComponentWithIndex>)
-      // clang-format on
-      void writeQueueWordsToIdMap(
-          std::vector<QueueWord>& buffer, C& wordCallback, const L& lessThan,
-          const std::vector<std::unique_ptr<re2::RE2>>& blankNodeIriRegexes,
-          ad_utility::ProgressBar& progressBar);
-
-  // Close all associated files and file-based vectors and reset all internal
-  // variables.
-  void clear() {
-    metaData_ = VocabularyMetaData{};
-    lastTripleComponent_ = std::nullopt;
-    lastTripleComponentIsBlankNode_ = false;
-    idMaps_.clear();
-  }
-};
 
 // ____________________________________________________________________________
 ad_utility::HashMap<Id, Id> IdMapFromPartialIdMapFile(

--- a/src/index/VocabularyMergerImpl.h
+++ b/src/index/VocabularyMergerImpl.h
@@ -6,6 +6,8 @@
 #define QLEVER_SRC_INDEX_VOCABULARYMERGERIMPL_H
 
 #include <future>
+#include <limits>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -25,41 +27,201 @@
 #include "util/Timer.h"
 
 namespace ad_utility::vocabulary_merger {
-// _________________________________________________________________
-template <typename W, typename C>
-auto mergeVocabulary(
-    const std::string& basename, size_t numFiles, W comparator,
-    C& internalWordCallback, ad_utility::MemorySize memoryToUse,
-    const std::vector<std::unique_ptr<re2::RE2>>& blankNodeIriRegexes)
-    -> CPP_ret(VocabularyMetaData)(
-        requires WordComparator<W>&& WordCallback<C>) {
-  VocabularyMerger merger;
-  return merger.mergeVocabulary(basename, numFiles, std::move(comparator),
-                                internalWordCallback, memoryToUse,
-                                blankNodeIriRegexes);
+namespace detail {
+
+// ________________________________________________________________________________
+CPP_template_def(typename W, typename F)(
+    requires WordComparator<W> CPP_and_def WordBatchCallback<
+        F>) void WordBatchBuilder::addMergedWords(std::vector<QueueWord> buffer,
+                                                  const W& comparator,
+                                                  const F& batchCallback) {
+  // NOTE: The buffer is deliberately not consumed, but kept alive as part of
+  // the batch, such that the merged words neither have to be moved nor
+  // destroyed by the merging thread.
+  currentBatch_.mergedWordBuffers_.push_back(std::move(buffer));
+  const auto& words = currentBatch_.mergedWordBuffers_.back();
+
+  auto& entries = currentBatch_.idMapBatch_.entries_;
+
+  // Iterate (avoid duplicates).
+  for (const auto& top : words) {
+    if (!hasLastWord_ || top.iriOrLiteral() != lastWord_) {
+      AD_CORRECTNESS_CHECK(
+          !hasLastWord_ || comparator(lastWord_, lastWordIsExternal_,
+                                      top.iriOrLiteral(), top.isExternal()),
+          "Total vocabulary order violated for ", lastWord_, " and ",
+          top.iriOrLiteral());
+      // NOTE: The word is not written to the vocabulary here, but only
+      // collected in the `currentBatch_`, such that the writing (which also
+      // determines the global ID of the word) happens concurrently to the
+      // merging of the next words.
+      lastWord_ = top.iriOrLiteral();
+      lastWordIsExternal_ = top.isExternal();
+      hasLastWord_ = true;
+      currentBatch_.uniqueWords_.push_back(
+          UniqueWord{lastWord_, top.isExternal()});
+      ++indexOfLastWordInBatch_;
+    } else {
+      // If a word appears with different values for `isExternal`, then we
+      // externalize it.
+      lastWordIsExternal_ = lastWordIsExternal_ || top.isExternal();
+    }
+    // Remember the local index of the word and the distinct word it belongs to;
+    // the actual entry of the ID map is only created (and written) once the
+    // global ID of that distinct word is known.
+    entries.push_back(
+        QueuedIdMapEntry{static_cast<uint32_t>(top.partialFileId_),
+                         indexOfLastWordInBatch_, top.id()});
+  }
+
+  if (entries.size() >= idMapEntryBatchSize) {
+    flush(batchCallback);
+  }
 }
+
+// ________________________________________________________________________________
+CPP_template_def(typename F)(
+    requires WordBatchCallback<
+        F>) void WordBatchBuilder::flush(const F& batchCallback) {
+  if (currentBatch_.idMapBatch_.entries_.empty()) {
+    return;
+  }
+  // The `lastWord_` is a view into one of the buffers that are handed over to
+  // the other threads, so we have to store our own copy of it. NOTE: The `if`
+  // is important: if no new word was merged since the last flush, then the
+  // `lastWord_` already is a view into the `lastWordStorage_`, and assigning a
+  // string from a view into itself is undefined behavior.
+  if (lastWord_.data() != lastWordStorage_.data()) {
+    lastWordStorage_.assign(lastWord_.data(), lastWord_.size());
+    lastWord_ = lastWordStorage_;
+  }
+  batchCallback(std::move(currentBatch_));
+  startNewBatch();
+}
+
+// ________________________________________________________________________________
+inline void WordBatchBuilder::startNewBatch() {
+  // NOTE: A moved-from vector is in a valid but unspecified state, so we have
+  // to explicitly reset the batch.
+  currentBatch_ = WordBatch{};
+  currentBatch_.idMapBatch_.entries_.reserve(idMapEntryBatchSize);
+  // A word typically occurs in several of the partial vocabularies, so most of
+  // the merged words are duplicates. This is only a rough estimate; the vector
+  // grows if it doesn't suffice.
+  currentBatch_.uniqueWords_.reserve(idMapEntryBatchSize / 4);
+  indexOfLastWordInBatch_ = 0;
+}
+
+// ________________________________________________________________________________
+CPP_template_def(typename C)(requires WordCallback<C>)
+    IdMapBatch VocabularyWriter::writeWordsToVocabulary(
+        const std::vector<UniqueWord>& uniqueWords, IdMapBatch idMapBatch,
+        C& wordCallback,
+        const std::vector<std::unique_ptr<re2::RE2>>& blankNodeIriRegexes) {
+  AD_LOG_TIMING << "Start writing a batch of merged words\n";
+
+  // TODO<optimization> If we aim to further speed this up, we could
+  // order all the write requests to _outfile _externalOutfile and all the
+  // idVecs to have a more useful external access pattern.
+  auto& globalIds = idMapBatch.globalIds_;
+  globalIds.resize(uniqueWords.size() + 1);
+  globalIds.at(0) = lastGlobalId_;
+  size_t i = 1;
+  for (const auto& uniqueWord : uniqueWords) {
+    const auto& word = uniqueWord.word_;
+    if (isBlankNode(word, blankNodeIriRegexes)) {
+      globalIds[i] = Id::makeFromBlankNodeIndex(
+          BlankNodeIndex::make(metaData_.getNextBlankNodeIndex()));
+    } else {
+      auto wordIndex = wordCallback(word, uniqueWord.isExternal_);
+      metaData_.addWord(word, wordIndex);
+      globalIds[i] = Id::makeFromVocabIndex(VocabIndex::make(wordIndex));
+    }
+    ++i;
+    if (progressBar_.update()) {
+      AD_LOG_INFO << progressBar_.getProgressString() << std::flush;
+    }
+  }
+  lastGlobalId_ = globalIds.back();
+  return idMapBatch;
+}
+
+// ________________________________________________________________________________
+inline void VocabularyWriter::logFinalProgress() {
+  AD_LOG_INFO << progressBar_.getFinalProgressString() << std::flush;
+}
+
+// ________________________________________________________________________________
+inline IdMapBatchWriter::IdMapBatchWriter(const std::string& basename,
+                                          size_t numFiles) {
+  // The index of the partial vocabulary is stored in a `uint32_t` for each of
+  // the (very many) ID map entries, see `QueuedIdMapEntry`.
+  AD_CORRECTNESS_CHECK(numFiles <= std::numeric_limits<uint32_t>::max());
+  idMaps_.reserve(numFiles);
+  for (size_t i : ad_utility::integerRange(numFiles)) {
+    idMaps_.emplace_back(absl::StrCat(basename, PARTIAL_VOCAB_IDMAP_INFIX, i));
+  }
+}
+
+// ________________________________________________________________________________
+inline void IdMapBatchWriter::writeBatch(const IdMapBatch& batch) {
+  AD_LOG_TIMING << "Start writing a batch of ID map entries\n";
+  const auto& globalIds = batch.globalIds_;
+  for (const auto& entry : batch.entries_) {
+    idMaps_[entry.partialFileId_].push_back(
+        {Id::makeFromVocabIndex(VocabIndex::make(entry.localIndex_)),
+         globalIds[entry.indexOfWordInBatch_]});
+  }
+}
+
+// ________________________________________________________________________________
+inline void IdMapBatchWriter::finish() { idMaps_.clear(); }
+
+// ________________________________________________________________________________
+CPP_template_def(typename C)(
+    requires WordCallback<C>) void VocabularyMergePipeline::
+    push(WordBatch batch, C& wordCallback,
+         const std::vector<std::unique_ptr<re2::RE2>>& blankNodeIriRegexes) {
+  queue_.push([this, batch = std::move(batch), &wordCallback,
+               &blankNodeIriRegexes]() mutable {
+    auto idMapBatch = vocabularyWriter_.writeWordsToVocabulary(
+        batch.uniqueWords_, std::move(batch.idMapBatch_), wordCallback,
+        blankNodeIriRegexes);
+    idMapBatchWriter_.writeBatch(idMapBatch);
+    // The merged words are no longer needed. NOTE: Their destruction (which
+    // involves freeing one string per word) also happens on this thread, and
+    // not on the merging thread.
+  });
+}
+
+// ________________________________________________________________________________
+inline VocabularyMetaData VocabularyMergePipeline::finish() {
+  // NOTE: The order is important, see the declaration of the members.
+  queue_.finish();
+  idMapBatchWriter_.finish();
+  vocabularyWriter_.logFinalProgress();
+  return std::move(vocabularyWriter_.metaData());
+}
+}  // namespace detail
 
 // _________________________________________________________________
 template <typename W, typename C>
-auto VocabularyMerger::mergeVocabulary(
+auto mergeVocabulary(
     const std::string& basename, size_t numFiles, W comparator, C& wordCallback,
     ad_utility::MemorySize memoryToUse,
     const std::vector<std::unique_ptr<re2::RE2>>& blankNodeIriRegexes)
     -> CPP_ret(VocabularyMetaData)(
         requires WordComparator<W>&& WordCallback<C>) {
-  // Return true iff p1 >= p2 according to the lexicographic order of the IRI
-  // or literal.
-  auto lessThan = [&comparator](const TripleComponentWithIndex& t1,
-                                const TripleComponentWithIndex& t2) {
-    return comparator(t1.iriOrLiteral_, t1.isExternal_, t2.iriOrLiteral_,
-                      t2.isExternal_);
-  };
-  auto lessThanForQueue = [&lessThan](const QueueWord& p1,
-                                      const QueueWord& p2) {
-    return lessThan(p1.entry_, p2.entry_);
+  using detail::QueueWord;
+  // Return true iff `p1` is smaller than `p2` according to the order of the
+  // IRI or literal.
+  auto lessThanForQueue = [&comparator](const QueueWord& p1,
+                                        const QueueWord& p2) {
+    return comparator(p1.iriOrLiteral(), p1.isExternal(), p2.iriOrLiteral(),
+                      p2.isExternal());
   };
 
-  // Open and prepare all infiles and file-based output vectors.
+  // Open and prepare all the input files.
   auto makeWordRangeFromFile = [&basename](size_t fileIndex) {
     ad_utility::serialization::FileReadSerializer infile{
         absl::StrCat(basename, PARTIAL_VOCAB_WORDS_INFIX, fileIndex)};
@@ -77,11 +239,18 @@ auto VocabularyMerger::mergeVocabulary(
   };
   std::vector<decltype(makeWordRangeFromFile(0))> generators;
   generators.reserve(numFiles);
-
   for (std::size_t i : ad_utility::integerRange(numFiles)) {
     generators.push_back(makeWordRangeFromFile(i));
-    idMaps_.emplace_back(absl::StrCat(basename, PARTIAL_VOCAB_IDMAP_INFIX, i));
   }
+
+  // The stages of the pipeline. The `batchBuilder` (the first stage) runs on
+  // this thread, the `pipeline` owns the stages that run concurrently to it.
+  detail::VocabularyMergePipeline pipeline{basename, numFiles};
+  detail::WordBatchBuilder batchBuilder;
+  auto batchCallback = [&pipeline, &wordCallback,
+                        &blankNodeIriRegexes](detail::WordBatch batch) {
+    pipeline.push(std::move(batch), wordCallback, blankNodeIriRegexes);
+  };
 
   // Some memory (that is hard to measure exactly) is used for the writing of
   // a batch of merged words, so we only give 80% of the total memory to the
@@ -89,81 +258,16 @@ auto VocabularyMerger::mergeVocabulary(
   // detail.
   auto mergedWords =
       ad_utility::parallelMultiwayMerge<QueueWord, true,
-                                        decltype(sizeOfQueueWord)>(
+                                        decltype(detail::sizeOfQueueWord)>(
           0.8 * memoryToUse, std::move(generators), lessThanForQueue);
-  ad_utility::ProgressBar progressBar{metaData_.numWordsTotal(),
-                                      "Words merged: "};
   for (std::vector<QueueWord>& currentWords : mergedWords) {
-    writeQueueWordsToIdMap(currentWords, wordCallback, lessThan,
-                           blankNodeIriRegexes, progressBar);
+    batchBuilder.addMergedWords(std::move(currentWords), comparator,
+                                batchCallback);
   }
-
-  AD_LOG_INFO << progressBar.getFinalProgressString() << std::flush;
-
-  auto metaData = std::move(metaData_);
-  // completely reset all the inner state
-  clear();
-  return metaData;
-}
-
-// ________________________________________________________________________________
-CPP_template_def(typename C, typename L)(
-    requires WordCallback<C> CPP_and_def
-        ranges::predicate<L, TripleComponentWithIndex,
-                          TripleComponentWithIndex>) void VocabularyMerger::
-    writeQueueWordsToIdMap(
-        std::vector<QueueWord>& buffer, C& wordCallback, const L& lessThan,
-        const std::vector<std::unique_ptr<re2::RE2>>& blankNodeIriRegexes,
-        ad_utility::ProgressBar& progressBar) {
-  AD_LOG_TIMING << "Start writing a batch of merged words\n";
-
-  // Iterate (avoid duplicates).
-  for (auto& top : buffer) {
-    if (!lastTripleComponent_.has_value() ||
-        top.iriOrLiteral() != lastTripleComponent_.value().iriOrLiteral()) {
-      if (lastTripleComponent_.has_value()) {
-        AD_CORRECTNESS_CHECK(lessThan(lastTripleComponent_.value(), top.entry_),
-                             "Total vocabulary order violated for ",
-                             lastTripleComponent_->iriOrLiteral(), " and ",
-                             top.iriOrLiteral());
-      }
-      lastTripleComponent_ =
-          TripleComponentWithIndex{std::move(top.iriOrLiteral()),
-                                   top.isExternal(), metaData_.numWordsTotal()};
-      lastTripleComponentIsBlankNode_ =
-          lastTripleComponent_.value().isBlankNode(blankNodeIriRegexes);
-
-      // TODO<optimization> If we aim to further speed this up, we could
-      // order all the write requests to _outfile _externalOutfile and all the
-      // idVecs to have a more useful external access pattern.
-
-      // Write the new word to the vocabulary.
-      auto& nextWord = lastTripleComponent_.value();
-      if (lastTripleComponentIsBlankNode_) {
-        nextWord.index_ = metaData_.getNextBlankNodeIndex();
-      } else {
-        nextWord.index_ =
-            wordCallback(nextWord.iriOrLiteral(), nextWord.isExternal());
-        metaData_.addWord(nextWord.iriOrLiteral(), nextWord.index_);
-      }
-      if (progressBar.update()) {
-        AD_LOG_INFO << progressBar.getProgressString() << std::flush;
-      }
-    } else {
-      // If a word appears with different values for `isExternal`, then we
-      // externalize it.
-      bool& external = lastTripleComponent_.value().isExternal();
-      external = external || top.isExternal();
-    }
-    const auto& word = lastTripleComponent_.value();
-    Id targetId =
-        lastTripleComponentIsBlankNode_
-            ? Id::makeFromBlankNodeIndex(BlankNodeIndex::make(word.index_))
-            : Id::makeFromVocabIndex(VocabIndex::make(word.index_));
-    // Write pair of local and global ID to buffer.
-    idMaps_[top.partialFileId_].push_back(
-        {Id::makeFromVocabIndex(VocabIndex::make(top.id())), targetId});
-  }
+  // Hand the remaining words to the pipeline and wait until all of them have
+  // actually been written.
+  batchBuilder.flush(batchCallback);
+  return pipeline.finish();
 }
 
 // ____________________________________________________________________________________________________________

--- a/test/VocabularyGeneratorTest.cpp
+++ b/test/VocabularyGeneratorTest.cpp
@@ -4,6 +4,7 @@
 //          Christoph Ullinger <ullingec@cs.uni-freiburg.de>
 
 #include <absl/cleanup/cleanup.h>
+#include <absl/strings/str_format.h>
 #include <gmock/gmock.h>
 #include <re2/re2.h>
 
@@ -412,4 +413,130 @@ TEST(VocabularyGeneratorTest, createInternalMappingFirstWordDuplicates) {
   EXPECT_EQ(0u, res[99]);
   EXPECT_EQ(1u, res[3]);
   EXPECT_EQ(1u, res[55]);
+}
+
+// _____________________________________________________________________________
+// Merge words that occur in *every* partial vocabulary, such that the
+// occurrences of a single word are spread over two consecutive batches of ID
+// map entries. The global ID of such a word is only known after the first of
+// those batches has been written, so this exercises the handover of that ID
+// from one batch to the next.
+TEST(MergeVocabulary, duplicateWordsAcrossBatchBoundaries) {
+  // The entries are currently written in batches of 100000. Three partial
+  // vocabularies with the same 120000 words yield 360000 entries, so we get
+  // several batches, and as 100000 is not divisible by three, the occurrences
+  // of a word are indeed split by a batch boundary.
+  static constexpr size_t numWords = 120'000;
+  static constexpr size_t numFiles = 3;
+  std::string basePath = absl::StrCat(gtestCurrentTestName(), "-");
+  std::vector<std::string> filenames;
+  for (size_t i = 0; i < numFiles; ++i) {
+    filenames.push_back(absl::StrCat(basePath, PARTIAL_VOCAB_WORDS_INFIX, i));
+    filenames.push_back(absl::StrCat(basePath, PARTIAL_VOCAB_IDMAP_INFIX, i));
+  }
+  absl::Cleanup cleanup = [&filenames] {
+    for (const auto& filename : filenames) {
+      ad_utility::deleteFile(filename, false);
+    }
+  };
+
+  // Each of the partial vocabularies contains all the words (zero-padded, such
+  // that their lexicographic order is the same as the order of their indices),
+  // with the local index `i` for the `i`-th word.
+  std::vector<std::string> words;
+  for (size_t i = 0; i < numWords; ++i) {
+    words.push_back(absl::StrFormat("\"word%08d\"", i));
+  }
+  for (size_t i = 0; i < numFiles; ++i) {
+    writePartialVocabularyFile(
+        absl::StrCat(basePath, PARTIAL_VOCAB_WORDS_INFIX, i), words);
+  }
+
+  size_t numWordsInCallback = 0;
+  auto wordCallback = [&numWordsInCallback](std::string_view,
+                                            bool) -> uint64_t {
+    return numWordsInCallback++;
+  };
+  auto result = mergeVocabulary(
+      basePath, numFiles,
+      [](std::string_view a, bool, std::string_view b, bool) {
+        return std::less{}(a, b);
+      },
+      wordCallback, 1_GB);
+  // Each word is written to the vocabulary exactly once.
+  EXPECT_EQ(numWordsInCallback, numWords);
+  EXPECT_EQ(result.numWordsTotal(), numWords);
+
+  // In each of the partial vocabularies, the word with local index `j` is the
+  // word with global id `j`.
+  IdMap expected;
+  for (size_t j = 0; j < numWords; ++j) {
+    expected.emplace_back(V(j), V(j));
+  }
+  for (size_t f = 0; f < numFiles; ++f) {
+    EXPECT_THAT(
+        getIdMapFromFile(absl::StrCat(basePath, PARTIAL_VOCAB_IDMAP_INFIX, f)),
+        ::testing::ElementsAreArray(expected));
+  }
+}
+
+// _____________________________________________________________________________
+// Merge a number of words that is large enough for the ID map entries to be
+// handed to the asynchronous writer in several batches, and check that all the
+// entries arrive in the correct ID map, in the correct order.
+TEST(MergeVocabulary, manyWordsWithSeveralIdMapBatches) {
+  // The entries are currently written in batches of 100000, so this leads to
+  // several batches, of which the last one is only partially filled.
+  static constexpr size_t numWords = 250'000;
+  std::string basePath = absl::StrCat(gtestCurrentTestName(), "-");
+  std::vector<std::string> filenames;
+  for (size_t i = 0; i < 2; ++i) {
+    filenames.push_back(absl::StrCat(basePath, PARTIAL_VOCAB_WORDS_INFIX, i));
+    filenames.push_back(absl::StrCat(basePath, PARTIAL_VOCAB_IDMAP_INFIX, i));
+  }
+  absl::Cleanup cleanup = [&filenames] {
+    for (const auto& filename : filenames) {
+      ad_utility::deleteFile(filename, false);
+    }
+  };
+
+  // The `i`-th word (in sorted order) goes to the partial vocabulary
+  // `i % 2`. The words are zero-padded, such that their lexicographic order is
+  // the same as the order of their indices.
+  std::array<std::vector<std::string>, 2> words;
+  for (size_t i = 0; i < numWords; ++i) {
+    words.at(i % 2).push_back(absl::StrFormat("\"word%08d\"", i));
+  }
+  writePartialVocabularyFile(
+      absl::StrCat(basePath, PARTIAL_VOCAB_WORDS_INFIX, 0), words[0]);
+  writePartialVocabularyFile(
+      absl::StrCat(basePath, PARTIAL_VOCAB_WORDS_INFIX, 1), words[1]);
+
+  // All the words are distinct, so they simply get the vocabulary indices
+  // `0, 1, ...` in sorted order.
+  size_t numWordsInCallback = 0;
+  auto wordCallback = [&numWordsInCallback](std::string_view,
+                                            bool) -> uint64_t {
+    return numWordsInCallback++;
+  };
+  auto result = mergeVocabulary(
+      basePath, 2,
+      [](std::string_view a, bool, std::string_view b, bool) {
+        return std::less{}(a, b);
+      },
+      wordCallback, 1_GB);
+  EXPECT_EQ(numWordsInCallback, numWords);
+  EXPECT_EQ(result.numWordsTotal(), numWords);
+
+  // In the partial vocabulary `f`, the word with local id `j` is the word with
+  // global id `2 * j + f`.
+  for (size_t f = 0; f < 2; ++f) {
+    IdMap expected;
+    for (size_t j = 0; j < words.at(f).size(); ++j) {
+      expected.emplace_back(V(j), V(2 * j + f));
+    }
+    EXPECT_THAT(
+        getIdMapFromFile(absl::StrCat(basePath, PARTIAL_VOCAB_IDMAP_INFIX, f)),
+        ::testing::ElementsAreArray(expected));
+  }
 }


### PR DESCRIPTION
`writeQueueWordsToIdMap` used to do everything at once: the uniquing of the
merged words, the writing of each distinct word to the vocabulary (via the word
callback), and the writing of the resulting (local ID, global ID) pairs to the
partial ID maps. All of this happened on the very same thread that also performs
the (rather expensive) k-way merge of the partial vocabularies, so all of these
steps added up.

The merging is now a pipeline of two threads that communicate via a task queue:

1. The merging thread only eliminates the duplicates and collects the distinct
   words as well as the entries for the partial ID maps in batches of currently
   100000 entries. The distinct words are `string_view`s into the buffers of
   merged words, which are kept alive as part of the batch, such that the
   merging thread never has to copy or move a single word.
2. The second thread writes the distinct words of a batch to the vocabulary,
   then writes the entries of the partial ID maps, and finally destroys the
   merged words of the batch (which involves freeing one string per word).

The global ID of a word is only known once it has been written to the
vocabulary, so an ID map entry does not store that ID, but the index of the
corresponding distinct word within its batch. The global IDs of a batch are
stored in a single vector, of which the element at index `0` is the global ID of
the last distinct word of the *previous* batch, because the first merged words of
a batch may well be further occurrences of that word. The two new tests
(`duplicateWordsAcrossBatchBoundaries` and `manyWordsWithSeveralIdMapBatches`)
cover exactly this handover across a batch boundary.

The state of the pipeline is passed explicitly: each of the stages
(`WordBatchBuilder`, `VocabularyWriter` and `IdMapBatchWriter`) is a separate
class that owns exactly the state that its own thread touches, and the
`VocabularyMergePipeline` is the only place that wires them together. The
`VocabularyMerger` class, which previously held the state of all of this in a
flat set of members, is therefore gone.

This is a self-contained part of a larger change that speeds up the vocabulary
merger. The follow-up will further split the second thread into three (one for
the vocabulary, one for the ID maps, one for the destruction of the merged
words) and speed up the writing of the partial ID map files, which currently
issue one 16-byte write per entry.
