### PR TITLE
Fix another use-after-free, this time in the runtime information callbacks of lazy operations

### DIFF
--- a/src/engine/Operation.cpp
+++ b/src/engine/Operation.cpp
@@ -192,10 +192,19 @@ Result Operation::runComputation(const ad_utility::Timer& timer,
     rti.totalTime_ = timer.msecs();
     rti.originalTotalTime_ = rti.totalTime_;
     rti.originalOperationTime_ = rti.getOperationTime();
+    // NOTE: A lazy result can outlive this operation (for example, when the
+    // worker thread of a lazy join tears down its generators after the query
+    // has already been destroyed), and the following callbacks are then
+    // still called. They therefore hold a `weak_ptr` to this operation and do
+    // nothing if it no longer exists.
     result.runOnNewChunkComputed(
-        [this, vocabStats = LocalVocabTracking{}, ker = knownEmptyResult()](
-            const Result::IdTableVocabPair& pair,
-            std::chrono::microseconds duration) mutable {
+        [this, self = weak_from_this(), vocabStats = LocalVocabTracking{},
+         ker = knownEmptyResult()](const Result::IdTableVocabPair& pair,
+                                   std::chrono::microseconds duration) mutable {
+          auto keepAlive = self.lock();
+          if (!keepAlive) {
+            return;
+          }
           const IdTable& idTable = pair.idTable_;
           AD_CORRECTNESS_CHECK(idTable.empty() || !ker,
                                "Operation returned non-empty result, but "
@@ -216,7 +225,11 @@ Result Operation::runComputation(const ad_utility::Timer& timer,
           }
           signalQueryUpdate(RuntimeInformation::SendPriority::IfDue);
         },
-        [this](Result::GeneratorState state) {
+        [this, self = weak_from_this()](Result::GeneratorState state) {
+          auto keepAlive = self.lock();
+          if (!keepAlive) {
+            return;
+          }
           runtimeInfo().status_ = [state]() {
             using enum Result::GeneratorState;
             switch (state) {
@@ -246,11 +259,15 @@ Result Operation::runComputation(const ad_utility::Timer& timer,
   if (handlesLimitOffset() != LimitOffsetHandling::FULL) {
     AD_CONTRACT_CHECK(!externalLimitApplied_);
     externalLimitApplied_ = !limitOffset_.isUnconstrained();
+    // See the NOTE above `runOnNewChunkComputed` for the `weak_ptr`.
     result.applyLimitOffset(
-        limitOffset_, [this](std::chrono::microseconds limitTime,
-                             const IdTableView<0>& idTable) {
-          updateRuntimeStats(true, idTable.numRows(), idTable.numColumns(),
-                             limitTime);
+        limitOffset_,
+        [this, self = weak_from_this()](std::chrono::microseconds limitTime,
+                                        const IdTableView<0>& idTable) {
+          if (auto keepAlive = self.lock()) {
+            updateRuntimeStats(true, idTable.numRows(), idTable.numColumns(),
+                               limitTime);
+          }
         });
   } else {
     result.assertThatLimitWasRespected(limitOffset_);

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -51,7 +51,7 @@ enum class LimitOffsetHandling {
   FULL
 };
 
-class Operation {
+class Operation : public std::enable_shared_from_this<Operation> {
  private:
   using SharedCancellationHandle = ad_utility::SharedCancellationHandle;
   using Milliseconds = std::chrono::milliseconds;

--- a/test/OperationTest.cpp
+++ b/test/OperationTest.cpp
@@ -442,9 +442,11 @@ TEST(Operation, verifyRuntimeInformationIsUpdatedForLazyOperations) {
   localVocab.getIndexAndAddIfNotContained(LocalVocabEntry{
       ad_utility::triple_component::Literal::literalWithoutQuotes("Test"),
       qec->getLocalVocabContext()});
-  ValuesForTesting valuesForTesting{
-      qec,   std::move(idTablesVector),  {Variable{"?x"}, Variable{"?y"}},
-      false, std::vector<ColumnIndex>{}, std::move(localVocab)};
+  auto valuesForTestingPtr = std::make_shared<ValuesForTesting>(
+      qec, std::move(idTablesVector),
+      std::vector<std::optional<Variable>>{Variable{"?x"}, Variable{"?y"}},
+      false, std::vector<ColumnIndex>{}, std::move(localVocab));
+  auto& valuesForTesting = *valuesForTestingPtr;
 
   ad_utility::Timer timer{ad_utility::Timer::InitialStatus::Started};
   EXPECT_THROW(
@@ -503,7 +505,8 @@ TEST(Operation, ensureFailedStatusIsSetWhenGeneratorThrowsException) {
       &namedCache,
       materializedViewsManager,
       [&](std::string) { signaledUpdate = true; }};
-  AlwaysFailOperation operation{&context};
+  auto operationPtr = std::make_shared<AlwaysFailOperation>(&context);
+  auto& operation = *operationPtr;
   ad_utility::Timer timer{ad_utility::Timer::InitialStatus::Started};
   auto result =
       operation.runComputation(timer, ComputationMode::LAZY_IF_SUPPORTED);
@@ -533,12 +536,13 @@ TEST(Operation, ensureFailedStatusIsSetWhenGeneratorIsCancelled) {
       &namedCache,
       materializedViewsManager,
       [&](std::string) { signaledUpdate = true; }};
-  CustomGeneratorOperation operation{&context, []() -> Result::Generator {
-                                       throw CancellationException{
-                                           CancellationState::MANUAL,
-                                           "Operation was cancelled"};
-                                       co_return;
-                                     }()};
+  auto operationPtr = std::make_shared<CustomGeneratorOperation>(
+      &context, []() -> Result::Generator {
+        throw CancellationException{CancellationState::MANUAL,
+                                    "Operation was cancelled"};
+        co_return;
+      }());
+  auto& operation = *operationPtr;
   ad_utility::Timer timer{ad_utility::Timer::InitialStatus::Started};
   auto result =
       operation.runComputation(timer, ComputationMode::LAZY_IF_SUPPORTED);
@@ -572,7 +576,7 @@ TEST(Operation, ensureSignalUpdateIsOnlyCalledEvery50msAndAtTheEnd) {
       &namedCache,
       materializedViewsManager,
       [&](std::string) { ++updateCallCounter; }};
-  CustomGeneratorOperation operation{
+  auto operationPtr = std::make_shared<CustomGeneratorOperation>(
       &context, [](const IdTable& idTable) -> Result::Generator {
         std::this_thread::sleep_for(50ms);
         co_yield {idTable.clone(), LocalVocab{}};
@@ -585,7 +589,8 @@ TEST(Operation, ensureSignalUpdateIsOnlyCalledEvery50msAndAtTheEnd) {
         // last one
         std::this_thread::sleep_for(30ms);
         co_yield {idTable.clone(), LocalVocab{}};
-      }(idTable)};
+      }(idTable));
+  auto& operation = *operationPtr;
 
   ad_utility::Timer timer{ad_utility::Timer::InitialStatus::Started};
   auto result =
@@ -622,11 +627,12 @@ TEST(Operation, ensureSignalUpdateIsCalledAtTheEndOfPartialConsumption) {
       &namedCache,
       materializedViewsManager,
       [&](std::string) { ++updateCallCounter; }};
-  CustomGeneratorOperation operation{
+  auto operationPtr = std::make_shared<CustomGeneratorOperation>(
       &context, [](const IdTable& idTable) -> Result::Generator {
         co_yield {idTable.clone(), LocalVocab{}};
         co_yield {idTable.clone(), LocalVocab{}};
-      }(idTable)};
+      }(idTable));
+  auto& operation = *operationPtr;
 
   {
     ad_utility::Timer timer{ad_utility::Timer::InitialStatus::Started};
@@ -651,8 +657,10 @@ TEST(Operation, verifyLimitIsProperlyAppliedAndUpdatesRuntimeInfoCorrectly) {
   std::vector<IdTable> idTablesVector{};
   idTablesVector.push_back(makeIdTableFromVector({{3, 4}}));
   idTablesVector.push_back(makeIdTableFromVector({{7, 8}, {9, 123}}));
-  ValuesForTesting valuesForTesting{
-      qec, std::move(idTablesVector), {Variable{"?x"}, Variable{"?y"}}};
+  auto valuesForTestingPtr = std::make_shared<ValuesForTesting>(
+      qec, std::move(idTablesVector),
+      std::vector<std::optional<Variable>>{Variable{"?x"}, Variable{"?y"}});
+  auto& valuesForTesting = *valuesForTestingPtr;
 
   valuesForTesting.applyLimitOffset({._limit = 1, ._offset = 1});
 


### PR DESCRIPTION
In `Operation::runComputation`, a lazily evaluated operation registers callbacks on its `Result` that update the runtime information after each chunk and when the generator finishes. These callbacks captured a raw `this`, but the result generator can outlive the operation. In particular, the worker thread of a lazy join destroys its generators when it finishes, which can be after the query and all its operations are already gone. The generator's destructor then calls the callback on a destroyed operation. This crashed the server behind the osm-planet endpoint several times, each time for a large spatial query with a `SERVICE` call.

The fix is for `Operation` to derive from `std::enable_shared_from_this` and for the callbacks to hold a `weak_ptr`, which they lock while running and which makes them do nothing if the operation no longer exists. Operations are always owned by a `shared_ptr` in their `QueryExecutionTree`, so the unit tests that constructed operations on the stack now own them via a `shared_ptr` as well.