### PR TITLE
Fix another use-after-free, this time in the export of CONSTRUCT queries as QLever JSON

### DIFF
--- a/src/engine/ExportQueryExecutionTrees.cpp
+++ b/src/engine/ExportQueryExecutionTrees.cpp
@@ -277,14 +277,14 @@ ExportQueryExecutionTrees::makeConstructEvaluationConfig(
 auto ExportQueryExecutionTrees::constructQueryResultToStringTriples(
     const QueryExecutionTree& qet,
     const ad_utility::sparql_types::Triples& constructTriples,
-    LimitOffsetClause limitAndOffset, std::shared_ptr<const Result> result,
+    LimitOffsetClause limitAndOffset, const Result& result,
     uint64_t& resultSize, CancellationHandle cancellationHandle) {
   // For each result from the WHERE clause, we produce up to
   // `constructTriples.size()` triples. We do not account for triples that are
   // filtered out because one of the components is UNDEF (it would require
   // materializing the whole result).
   // TODO<joka921> check the complete semantics of LIMIT/OFFSET
-  auto rowIndices = getRowIndices(limitAndOffset, *result, resultSize,
+  auto rowIndices = getRowIndices(limitAndOffset, result, resultSize,
                                   constructTriples.size());
 
   return qlever::constructExport::ConstructTripleGenerator::
@@ -303,11 +303,17 @@ ExportQueryExecutionTrees::constructQueryResultBindingsToQLeverJSON(
     std::shared_ptr<const Result> result, uint64_t& resultSize,
     CancellationHandle cancellationHandle) {
   auto generator = constructQueryResultToStringTriples(
-      qet, constructTriples, limitAndOffset, std::move(result), resultSize,
+      qet, constructTriples, limitAndOffset, *result, resultSize,
       std::move(cancellationHandle));
 
+  // NOTE: The `generator` only borrows the `result`, so the transformation
+  // below owns it. This keeps the `result` alive for as long as the returned
+  // range is iterated, even if it is evicted from the cache in the meantime
+  // (the transformation of a `CachingTransformInputRange` is destroyed after
+  // its view).
   return InputRangeTypeErased(ad_utility::CachingTransformInputRange(
-      std::move(generator), [](QueryExecutionTree::StringTriple& triple) {
+      std::move(generator),
+      [result = std::move(result)](QueryExecutionTree::StringTriple& triple) {
         auto binding = nlohmann::json::array({std::move(triple.subject_),
                                               std::move(triple.predicate_),
                                               std::move(triple.object_)});

--- a/src/engine/ExportQueryExecutionTrees.h
+++ b/src/engine/ExportQueryExecutionTrees.h
@@ -150,7 +150,7 @@ class ExportQueryExecutionTrees {
   static auto constructQueryResultToStringTriples(
       const QueryExecutionTree& qet,
       const ad_utility::sparql_types::Triples& constructTriples,
-      LimitOffsetClause limitAndOffset, std::shared_ptr<const Result> result,
+      LimitOffsetClause limitAndOffset, const Result& result,
       uint64_t& resultSize, CancellationHandle cancellationHandle);
 
   // Helper function that generates the result of a CONSTRUCT query as a
@@ -196,6 +196,8 @@ class ExportQueryExecutionTrees {
       uint64_t& resutSizeTotal, uint64_t resultSizeMultiplicator = 1);
 
  private:
+  FRIEND_TEST(ExportQueryExecutionTrees,
+              constructQueryResultToQLeverJSONKeepsResultAlive);
   FRIEND_TEST(ExportQueryExecutionTrees, getIdTablesReturnsSingletonIterator);
   FRIEND_TEST(ExportQueryExecutionTrees, getIdTablesMirrorsGenerator);
   FRIEND_TEST(ExportQueryExecutionTrees, ensureCorrectSlicingOfSingleIdTable);

--- a/test/ExportQueryExecutionTreesTest.cpp
+++ b/test/ExportQueryExecutionTreesTest.cpp
@@ -1870,6 +1870,49 @@ TEST(ExportQueryExecutionTrees, ensureGeneratorIsNotConsumedWhenNotRequired) {
 }
 
 // _____________________________________________________________________________
+// Regression test: the export of a CONSTRUCT query as QLever JSON has to keep
+// the `Result` alive for as long as the export runs, even if the result is
+// evicted from the cache in the meantime. In an earlier version of the code,
+// the export only borrowed the result, which led to a use-after-free when the
+// cache evicted it during a long export.
+TEST(ExportQueryExecutionTrees,
+     constructQueryResultToQLeverJSONKeepsResultAlive) {
+  auto* qec = ad_utility::testing::getQec("<s> <p> <o1> . <s> <p> <o2>");
+  qec->getQueryTreeCache().clearAll();
+  auto cancellationHandle =
+      std::make_shared<ad_utility::CancellationHandle<>>();
+  QueryPlanner qp{qec, cancellationHandle};
+  auto pq = parseQuery("CONSTRUCT { ?s <q> ?o } WHERE { ?s <p> ?o }");
+  auto qet = qp.createExecutionTree(pq);
+
+  // Compute the (cached) result and keep a `weak_ptr` to track its lifetime.
+  std::shared_ptr<const Result> result = qet.getResult();
+  std::weak_ptr<const Result> weakResult = result;
+  {
+    uint64_t resultSize = 0;
+    auto jsonStream =
+        ExportQueryExecutionTrees::constructQueryResultBindingsToQLeverJSON(
+            qet, pq.constructClause().triples_, pq._limitOffset,
+            std::move(result), resultSize, cancellationHandle);
+
+    // Evict the result from the cache. The export must now hold the last
+    // reference to it.
+    qec->getQueryTreeCache().clearAll();
+    ASSERT_FALSE(weakResult.expired());
+
+    std::vector<std::string> bindings;
+    for (const auto& binding : jsonStream) {
+      bindings.push_back(binding);
+    }
+    EXPECT_EQ(bindings.size(), 2u);
+    EXPECT_EQ(resultSize, 2u);
+    EXPECT_FALSE(weakResult.expired());
+  }
+  // Once the export is destroyed, so is the result.
+  EXPECT_TRUE(weakResult.expired());
+}
+
+// _____________________________________________________________________________
 TEST(ExportQueryExecutionTrees, verifyQleverJsonContainsValidMetadata) {
   std::string_view query =
       "SELECT * WHERE { ?x ?y ?z . FILTER(?y != <p2>) } OFFSET 1 LIMIT 4";


### PR DESCRIPTION
When the result of a `CONSTRUCT` query is exported as QLever JSON, `constructQueryResultToStringTriples` received the `shared_ptr` to the `Result` by value, built a generator that only borrows the result, and then dropped the `shared_ptr` on return. The export thus iterated a result that nobody owned anymore. When the cache evicted that result during the export, which happens under load and in particular while updates are applied, the export read freed memory and eventually crashed the server (tajo on 2026-08-23). The other export formats do not have this problem, because they keep the `shared_ptr` alive for the duration of the export.

The `shared_ptr` is now captured by the transformation that turns the generated triples into JSON, which is destroyed only after the generator. A regression test evicts the result from the cache during the export and checks that it stays alive until the export is finished.