### PR TITLE
Buffer the writing of the `IdMap`s of the vocabulary merger

### DIFF
--- a/src/index/IndexBuilderTypes.h
+++ b/src/index/IndexBuilderTypes.h
@@ -19,6 +19,7 @@
 
 #include <atomic>
 #include <memory>
+#include <string_view>
 #include <vector>
 
 #include "backports/StartsWithAndEndsWith.h"
@@ -37,6 +38,33 @@
 #include "util/TypeTraits.h"
 #include "util/Views.h"
 
+// Return true if `word` is a blank node. A word is a blank node if it starts
+// with `_:`, or, when `blankNodeIriRegexes` is given, if it is an IRI that is
+// fully matched by one of those regexes.
+//
+// The regexes are matched (as a full match, see `ad_utility::RegexSet`)
+// against the full text of the word, *including* the surrounding angle
+// brackets of an IRI. The match has to cover the entire word, so a regex must
+// describe the whole IRI; to allow an arbitrary suffix, end it with `.*`. For
+// example the regex `<https://example\.org/statement/.*>` matches the IRI
+// `<https://example.org/statement/42>`. Only IRIs (words starting with `<`)
+// are ever treated this way; literals are never converted. The regexes are
+// required to describe IRIs (i.e. to start with `<`), which is enforced by
+// `IndexImpl::setBlankNodeIriRegexes`. See also the
+// `--iri-as-blank-node-regexes` option of the index builder.
+inline bool isBlankNode(std::string_view word,
+                        const ad_utility::RegexSet& blankNodeIriRegexes) {
+  if (ql::starts_with(word, "_:")) {
+    return true;
+  }
+  // Only IRIs (which start with `<`) can be treated as blank nodes; this also
+  // avoids running the regexes for the common case of a literal.
+  if (!ql::starts_with(word, "<")) {
+    return false;
+  }
+  return blankNodeIriRegexes.matchesAny(word);
+}
+
 // An IRI or literal together with its index in the global vocabulary. This is
 // used during vocabulary merging.
 //
@@ -51,30 +79,10 @@ struct TripleComponentWithIndex {
   [[nodiscard]] auto& isExternal() { return isExternal_; }
   [[nodiscard]] const auto& iriOrLiteral() const { return iriOrLiteral_; }
   [[nodiscard]] auto& iriOrLiteral() { return iriOrLiteral_; }
-  // Return true if this word is a blank node. A word is a blank node if it
-  // starts with `_:`, or, when `blankNodeIriRegexes` is given, if it is an IRI
-  // that is fully matched by one of those regexes.
-  //
-  // The regexes are matched (as a full match, see `ad_utility::RegexSet`)
-  // against the full text of the word, *including* the surrounding angle
-  // brackets of an IRI. The match has to cover the entire word, so a regex must
-  // describe the whole IRI; to allow an arbitrary suffix, end it with `.*`. For
-  // example the regex `<https://example\.org/statement/.*>` matches the IRI
-  // `<https://example.org/statement/42>`. Only IRIs (words starting with `<`)
-  // are ever treated this way; literals are never converted. The regexes are
-  // required to describe IRIs (i.e. to start with `<`), which is enforced by
-  // `IndexImpl::setBlankNodeIriRegexes`. See also the
-  // `--iri-as-blank-node-regexes` option of the index builder.
+  // Return true if this word is a blank node, see the free `isBlankNode`
+  // function above.
   bool isBlankNode(const ad_utility::RegexSet& blankNodeIriRegexes) const {
-    if (ql::starts_with(iriOrLiteral_, "_:")) {
-      return true;
-    }
-    // Only IRIs (which start with `<`) can be treated as blank nodes; this also
-    // avoids running the regexes for the common case of a literal.
-    if (!ql::starts_with(iriOrLiteral_, "<")) {
-      return false;
-    }
-    return blankNodeIriRegexes.matchesAny(iriOrLiteral_);
+    return ::isBlankNode(iriOrLiteral_, blankNodeIriRegexes);
   }
 
   AD_SERIALIZE_FRIEND_FUNCTION(TripleComponentWithIndex) {

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -710,7 +710,7 @@ auto IndexImpl::convertPartialToGlobalIds(BuildPartialVocabulariesResult& data,
     IdTableStatic<NumColumnsIndexBuilding> triples_;
     IdTableStatic<NumColumnsIndexBuilding> internalTriples_;
   };
-  using Map = ad_utility::HashMap<Id, Id>;
+  using Map = ad_utility::HashMap<VocabIndex, Id>;
 
   ad_utility::TaskQueue<true> lookupQueue(30, 10,
                                           "looking up local to global IDs");
@@ -722,16 +722,13 @@ auto IndexImpl::convertPartialToGlobalIds(BuildPartialVocabulariesResult& data,
   // For all triple elements find their mapping from partial to global ids.
   auto transformTriple = [](Buffer::row_reference& curTriple, auto& idMap) {
     for (auto& id : curTriple) {
-      // TODO<joka92> Since the mapping only maps `VocabIndex->VocabIndex`,
-      // probably the mapping should also be defined as `HashMap<VocabIndex,
-      // VocabIndex>` instead of `HashMap<Id, Id>`
       if (id.getDatatype() != Datatype::VocabIndex) {
         // Check that all the internal, special IDs which we have introduced
         // for performance reasons are eliminated.
         AD_CORRECTNESS_CHECK(id.getDatatype() != Datatype::Undefined);
         continue;
       }
-      auto iterator = idMap.find(id);
+      auto iterator = idMap.find(id.getVocabIndex());
       AD_CORRECTNESS_CHECK(iterator != idMap.end());
       id = iterator->second;
     }

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -720,7 +720,8 @@ auto IndexImpl::convertPartialToGlobalIds(BuildPartialVocabulariesResult& data,
   ad_utility::TaskQueue<true> writeQueue(30, 1, "Writing global Ids to file");
 
   // For all triple elements find their mapping from partial to global ids.
-  auto transformTriple = [](Buffer::row_reference& curTriple, auto& idMap) {
+  auto transformTriple = [](Buffer::row_reference& curTriple,
+                            const auto& idMap) {
     for (auto& id : curTriple) {
       if (id.getDatatype() != Datatype::VocabIndex) {
         // Check that all the internal, special IDs which we have introduced

--- a/src/index/VocabularyMerger.h
+++ b/src/index/VocabularyMerger.h
@@ -11,7 +11,6 @@
 #include <utility>
 #include <vector>
 
-#include "backports/StartsWithAndEndsWith.h"
 #include "backports/algorithm.h"
 #include "engine/idTable/CompressedExternalIdTable.h"
 #include "global/Constants.h"
@@ -19,156 +18,25 @@
 #include "index/ConstantsIndexBuilding.h"
 #include "index/IndexBuilderTypes.h"
 #include "index/vocabulary/Vocabulary.h"
+#include "index/vocabulary_merger/Concepts.h"
+#include "index/vocabulary_merger/IdMap.h"
+#include "index/vocabulary_merger/QueueWord.h"
+#include "index/vocabulary_merger/VocabularyMetaData.h"
 #include "util/HashMap.h"
 #include "util/ProgressBar.h"
 #include "util/Serializer/FileSerializer.h"
-#include "util/Serializer/SerializePair.h"
-#include "util/Serializer/SerializeVector.h"
 #include "util/TypeTraits.h"
-
-// Writes pairs of (partial ID, global ID) incrementally to a file.
-class IdMapWriter {
- private:
-  std::string filename_;
-  using Serializer = ad_utility::serialization::VectorIncrementalSerializer<
-      std::pair<Id, Id>, ad_utility::serialization::FileWriteSerializer>;
-  std::unique_ptr<Serializer> serializer_;
-
- public:
-  explicit IdMapWriter(const std::string& filename) : filename_(filename) {
-    serializer_ = std::make_unique<Serializer>(filename);
-  }
-
-  void push_back(const std::pair<Id, Id>& pair) { serializer_->push(pair); }
-};
-
-// Get a vector of pairs of (partial ID, global ID) deserialized from a file
-// that has previously been written using the `IdMapWriter` class above.
-using IdMap = std::vector<std::pair<Id, Id>>;
-inline IdMap getIdMapFromFile(const std::string& filename) {
-  IdMap idMap;
-  ad_utility::serialization::FileReadSerializer serializer(filename);
-  serializer >> idMap;
-  return idMap;
-}
 
 using TripleVec =
     ad_utility::CompressedExternalIdTable<NumColumnsIndexBuilding>;
 
+// This header is the public interface of the vocabulary merger. The parts of
+// it that are understandable (and testable) on their own live in
+// `src/index/vocabulary_merger/`, and all of them are made available by this
+// header: the `VocabularyMetaData` (the return type of `mergeVocabulary`), the
+// concepts for its callbacks, the `IdMap` types, and the `detail::QueueWord`.
 namespace ad_utility::vocabulary_merger {
-// Concept for a callback that can be called with a `string_view` and a `bool`.
-// If the `bool` is true, then the word is to be stored in the external
-// vocabulary else in the internal vocabulary.
-template <typename T>
-CPP_concept WordCallback =
-    ad_utility::InvocableWithExactReturnType<T, uint64_t, std::string_view,
-                                             bool>;
-// Concept for a callable that compares two `string_view`s with respective
-// `isExternal` flags.
-template <typename T>
-CPP_concept WordComparator =
-    ranges::predicate<T, std::string_view, bool, std::string_view, bool>;
 
-// The result of a call to `mergeVocabulary` (see below).
-struct VocabularyMetaData {
-  // This struct is used to incrementally construct the range of IDs that
-  // correspond to a given prefix. To use it, all the words from the
-  // vocabulary must be passed to the member function `addIfWordMatches` in
-  // sorted order. After that, the range `[begin(), end())` is the range of
-  // all the words that start with the prefix.
-  struct IdRangeForPrefix {
-    explicit IdRangeForPrefix(std::string prefix)
-        : prefix_{std::move(prefix)} {}
-    // Check if `word` starts with the `prefix_`. If so, `wordIndex`
-    // will become part of the range that this struct represents. The function
-    // returns `true` in this case, else `false`. For this to work, all the
-    // words that start with the `prefix_` have to be passed in consecutively
-    // and their indices have to be consecutive and ascending.
-    bool addIfWordMatches(std::string_view word, size_t wordIndex) {
-      if (!ql::starts_with(word, prefix_)) {
-        return false;
-      }
-      if (!beginWasSeen_) {
-        begin_ = Id::makeFromVocabIndex(VocabIndex::make(wordIndex));
-        beginWasSeen_ = true;
-      }
-      end_ = Id::makeFromVocabIndex(VocabIndex::make(wordIndex + 1));
-      return true;
-    }
-
-    Id begin() const { return begin_; }
-    Id end() const { return end_; }
-
-    // Return true if the `id` belongs to this range.
-    bool contains(Id id) const { return begin_ <= id && id < end_; }
-
-   private:
-    Id begin_ = Id::makeUndefined();
-    Id end_ = Id::makeUndefined();
-    std::string prefix_;
-    bool beginWasSeen_ = false;
-  };
-
- public:
-  // This function has to be called for every *DISTINCT* word (IRI or literal,
-  // not blank nodes) and the index, which is assigned to this word by the merge
-  // procedure. It automatically updates the various prefix ranges, the total
-  // number of words, and the mapping of the special IDs.
-  void addWord(std::string_view word, size_t wordIndex) {
-    ++numWordsTotal_;
-    if (langTaggedPredicates_.addIfWordMatches(word, wordIndex)) {
-      return;
-    }
-    if (internalEntities_.addIfWordMatches(word, wordIndex)) {
-      if (globalSpecialIds_->contains(word)) {
-        specialIdMapping_[std::string{word}] =
-            Id::makeFromVocabIndex(VocabIndex::make(wordIndex));
-      }
-    }
-  }
-
-  // Return the index of the next blank node and increment the internal counter
-  // of blank nodes. This has to be called for every distinct blank node that
-  // is encountered.
-  size_t getNextBlankNodeIndex() {
-    auto res = numBlankNodesTotal_;
-    ++numBlankNodesTotal_;
-    return res;
-  }
-
-  // The mapping from the `qlever::specialIds` to their actual IDs.
-  // This is created on the fly by the calls to `addWord`.
-  const auto& specialIdMapping() const { return specialIdMapping_; }
-  // The prefix range for the `@en@<predicate` style predicates.
-  const auto& langTaggedPredicates() const { return langTaggedPredicates_; }
-  // The prefix range for the internal IRIs in the `ql:` namespace.
-  const auto& internalEntities() const { return internalEntities_; }
-  // The number of words for which `addWord()` has been called. Needs to return
-  // a reference to be used in combination with a `ProgressBar`.
-  const size_t& numWordsTotal() const { return numWordsTotal_; }
-
-  // Return true iff the `id` belongs to one of the two ranges that contain
-  // the internal IDs that were added by QLever and were not part of the
-  // input.
-  bool isQleverInternalId(Id id) const {
-    return internalEntities_.contains(id) || langTaggedPredicates_.contains(id);
-  }
-
- private:
-  // The number of distinct words (size of the created vocabulary).
-  size_t numWordsTotal_ = 0;
-  // The number of distinct blank nodes that were found and immediately
-  // converted to an ID without becoming part of the vocabulary.
-  size_t numBlankNodesTotal_ = 0;
-  IdRangeForPrefix langTaggedPredicates_{
-      std::string{ad_utility::languageTaggedPredicatePrefix}};
-  IdRangeForPrefix internalEntities_{
-      std::string{QLEVER_INTERNAL_PREFIX_IRI_WITHOUT_CLOSING_BRACKET}};
-
-  ad_utility::HashMap<std::string, Id> specialIdMapping_;
-  const ad_utility::HashMap<std::string, Id>* globalSpecialIds_ =
-      &qlever::specialIds();
-};
 // _______________________________________________________________
 // Merge the partial vocabularies in the  binary files
 // `basename + PARTIAL_VOCAB_WORDS_INFIX + suffix` for each `suffix` in
@@ -205,8 +73,9 @@ class VocabularyMerger {
   // `isBlankNode` (which may run a set of regexes) is evaluated only once per
   // distinct word.
   bool lastTripleComponentIsBlankNode_ = false;
-  // we will store pairs of <partialId, globalId>
-  std::vector<IdMapWriter> idMaps_;
+  // The partial ID maps, one per partial vocabulary. Each of them maps the
+  // local indices of its partial vocabulary to the global IDs.
+  std::vector<IdMapWriter> idMapWriters_;
 
   // Friend declaration for the publicly available function.
   template <typename W, typename C>
@@ -231,36 +100,10 @@ class VocabularyMerger {
       -> CPP_ret(VocabularyMetaData)(
           requires WordComparator<W>&& WordCallback<C>);
 
-  // Helper `struct` for a word from a partial vocabulary.
-  struct QueueWord {
-    QueueWord() = default;
-    QueueWord(TripleComponentWithIndex&& v, size_t file)
-        : entry_(std::move(v)), partialFileId_(file) {}
-    TripleComponentWithIndex entry_;  // the word, its local ID and the
-                                      // information if it will be externalized
-    size_t partialFileId_;  // from which partial vocabulary did this word come
+  using QueueWord = detail::QueueWord;
 
-    [[nodiscard]] const bool& isExternal() const { return entry_.isExternal(); }
-    [[nodiscard]] bool& isExternal() { return entry_.isExternal(); }
-
-    [[nodiscard]] const std::string& iriOrLiteral() const {
-      return entry_.iriOrLiteral();
-    }
-
-    [[nodiscard]] std::string& iriOrLiteral() { return entry_.iriOrLiteral(); }
-
-    [[nodiscard]] const auto& id() const { return entry_.index_; }
-  };
-
-  struct SizeOfQueueWord {
-    ad_utility::MemorySize operator()(const QueueWord& q) const {
-      return ad_utility::MemorySize::bytes(sizeof(QueueWord) +
-                                           q.entry_.iriOrLiteral().size());
-    }
-  };
-  constexpr static SizeOfQueueWord sizeOfQueueWord{};
-
-  // Write the queue words in the buffer to their corresponding `idMaps`.
+  // Write the queue words in the buffer to their corresponding
+  // `idMapWriters_`.
   // The `QueueWord`s must be passed in alphabetical order wrt `lessThan` (also
   // across multiple calls).
   // clang-format off
@@ -279,12 +122,20 @@ class VocabularyMerger {
     metaData_ = VocabularyMetaData{};
     lastTripleComponent_ = std::nullopt;
     lastTripleComponentIsBlankNode_ = false;
-    idMaps_.clear();
+    // NOTE: The destructor of an `IdMapWriter` also finishes it, but only
+    // an explicit `finish()` can propagate errors as exceptions.
+    for (auto& idMapWriter : idMapWriters_) {
+      idMapWriter.finish();
+    }
+    idMapWriters_.clear();
   }
 };
 
-// ____________________________________________________________________________
-ad_utility::HashMap<Id, Id> IdMapFromPartialIdMapFile(
+// Read the partial ID map from the given file (see `IdMapWriter`) into a hash
+// map. NOTE: The keys are plain `VocabIndex`es, because inside a partial
+// vocabulary a word is always a `VocabIndex`. The values are full `Id`s,
+// because a merged word may also become a blank node (see `isBlankNode`).
+ad_utility::HashMap<VocabIndex, Id> IdMapFromPartialIdMapFile(
     const std::string& filename);
 
 /**

--- a/src/index/VocabularyMerger.h
+++ b/src/index/VocabularyMerger.h
@@ -73,8 +73,9 @@ class VocabularyMerger {
   // `isBlankNode` (which may run a set of regexes) is evaluated only once per
   // distinct word.
   bool lastTripleComponentIsBlankNode_ = false;
-  // The partial ID maps, one per partial vocabulary. Each of them maps the
-  // local indices of its partial vocabulary to the global IDs.
+  // The writers for the partial ID maps, one per partial vocabulary. Each of
+  // them writes the mapping from the local indices of its partial vocabulary
+  // to the global IDs.
   std::vector<IdMapWriter> idMapWriters_;
 
   // Friend declaration for the publicly available function.

--- a/src/index/VocabularyMergerImpl.h
+++ b/src/index/VocabularyMergerImpl.h
@@ -85,8 +85,8 @@ auto VocabularyMerger::mergeVocabulary(
   for (std::size_t i :
        ad_utility::integerRange(partialVocabularySuffixes.size())) {
     generators.push_back(makeWordRangeFromFile(i));
-    idMaps_.emplace_back(absl::StrCat(basename, PARTIAL_VOCAB_IDMAP_INFIX,
-                                      partialVocabularySuffixes.at(i)));
+    idMapWriters_.emplace_back(absl::StrCat(basename, PARTIAL_VOCAB_IDMAP_INFIX,
+                                            partialVocabularySuffixes.at(i)));
   }
 
   // Some memory (that is hard to measure exactly) is used for the writing of
@@ -95,7 +95,7 @@ auto VocabularyMerger::mergeVocabulary(
   // detail.
   auto mergedWords =
       ad_utility::parallelMultiwayMerge<QueueWord, true,
-                                        decltype(sizeOfQueueWord)>(
+                                        decltype(detail::sizeOfQueueWord)>(
           0.8 * memoryToUse, std::move(generators), lessThanForQueue);
   ad_utility::ProgressBar progressBar{metaData_.numWordsTotal(),
                                       "Words merged: "};
@@ -166,9 +166,9 @@ CPP_template_def(typename C, typename L)(
         lastTripleComponentIsBlankNode_
             ? Id::makeFromBlankNodeIndex(BlankNodeIndex::make(word.index_))
             : Id::makeFromVocabIndex(VocabIndex::make(word.index_));
-    // Write pair of local and global ID to buffer.
-    idMaps_[top.partialFileId_].push_back(
-        {Id::makeFromVocabIndex(VocabIndex::make(top.id())), targetId});
+    // Write the mapping from the local index to the global ID to the ID map
+    // of the partial vocabulary that this occurrence of the word came from.
+    idMapWriters_[top.partialFileId_].push_back(IdMapEntry{top.id(), targetId});
   }
 }
 
@@ -280,10 +280,15 @@ void sortVocabVector(ItemVec* vecPtr, StringSortComparator comp,
 }
 
 // _____________________________________________________________________
-inline ad_utility::HashMap<Id, Id> IdMapFromPartialIdMapFile(
+inline ad_utility::HashMap<VocabIndex, Id> IdMapFromPartialIdMapFile(
     const std::string& filename) {
   auto vec = getIdMapFromFile(filename);
-  return ad_utility::HashMap<Id, Id>{vec.begin(), vec.end()};
+  ad_utility::HashMap<VocabIndex, Id> map;
+  map.reserve(vec.size());
+  for (const auto& entry : vec) {
+    map.emplace(VocabIndex::make(entry.localIndex_), entry.globalId_);
+  }
+  return map;
 }
 }  // namespace ad_utility::vocabulary_merger
 

--- a/src/index/VocabularyMergerImpl.h
+++ b/src/index/VocabularyMergerImpl.h
@@ -168,7 +168,8 @@ CPP_template_def(typename C, typename L)(
             : Id::makeFromVocabIndex(VocabIndex::make(word.index_));
     // Write the mapping from the local index to the global ID to the ID map
     // of the partial vocabulary that this occurrence of the word came from.
-    idMapWriters_[top.partialFileId_].push_back(IdMapEntry{top.id(), targetId});
+    idMapWriters_[top.partialFileId_].push_back(
+        IdMapEntry{VocabIndex::make(top.id()), targetId});
   }
 }
 
@@ -286,7 +287,7 @@ inline ad_utility::HashMap<VocabIndex, Id> IdMapFromPartialIdMapFile(
   ad_utility::HashMap<VocabIndex, Id> map;
   map.reserve(vec.size());
   for (const auto& entry : vec) {
-    map.emplace(VocabIndex::make(entry.localIndex_), entry.globalId_);
+    map.emplace(entry.localIndex_, entry.globalId_);
   }
   return map;
 }

--- a/src/index/VocabularyMergerImpl.h
+++ b/src/index/VocabularyMergerImpl.h
@@ -85,8 +85,8 @@ auto VocabularyMerger::mergeVocabulary(
   for (std::size_t i :
        ad_utility::integerRange(partialVocabularySuffixes.size())) {
     generators.push_back(makeWordRangeFromFile(i));
-    idMapWriters_.emplace_back(absl::StrCat(basename, PARTIAL_VOCAB_IDMAP_INFIX,
-                                            partialVocabularySuffixes.at(i)));
+    idMapWriters_.push_back(makeIdMapWriter(absl::StrCat(
+        basename, PARTIAL_VOCAB_IDMAP_INFIX, partialVocabularySuffixes.at(i))));
   }
 
   // Some memory (that is hard to measure exactly) is used for the writing of
@@ -168,7 +168,7 @@ CPP_template_def(typename C, typename L)(
             : Id::makeFromVocabIndex(VocabIndex::make(word.index_));
     // Write the mapping from the local index to the global ID to the ID map
     // of the partial vocabulary that this occurrence of the word came from.
-    idMapWriters_[top.partialFileId_].push_back(
+    idMapWriters_[top.partialFileId_].push(
         IdMapEntry{VocabIndex::make(top.id()), targetId});
   }
 }

--- a/src/index/vocabulary_merger/Concepts.h
+++ b/src/index/vocabulary_merger/Concepts.h
@@ -1,0 +1,35 @@
+// Copyright 2026 The QLever Authors, in particular:
+//
+// 2026 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+//
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#ifndef QLEVER_SRC_INDEX_VOCABULARY_MERGER_CONCEPTS_H
+#define QLEVER_SRC_INDEX_VOCABULARY_MERGER_CONCEPTS_H
+
+#include <cstdint>
+#include <string_view>
+
+#include "backports/algorithm.h"
+#include "backports/concepts.h"
+#include "util/TypeTraits.h"
+
+namespace ad_utility::vocabulary_merger {
+// Concept for a callback that can be called with a `string_view` and a `bool`.
+// If the `bool` is true, then the word is to be stored in the external
+// vocabulary else in the internal vocabulary.
+template <typename T>
+CPP_concept WordCallback =
+    ad_utility::InvocableWithExactReturnType<T, uint64_t, std::string_view,
+                                             bool>;
+// Concept for a callable that compares two `string_view`s with respective
+// `isExternal` flags.
+template <typename T>
+CPP_concept WordComparator =
+    ranges::predicate<T, std::string_view, bool, std::string_view, bool>;
+}  // namespace ad_utility::vocabulary_merger
+
+#endif  // QLEVER_SRC_INDEX_VOCABULARY_MERGER_CONCEPTS_H

--- a/src/index/vocabulary_merger/Concepts.h
+++ b/src/index/vocabulary_merger/Concepts.h
@@ -29,7 +29,7 @@ CPP_concept WordCallback =
 // `isExternal` flags.
 template <typename T>
 CPP_concept WordComparator =
-    ranges::predicate<T, std::string_view, bool, std::string_view, bool>;
+    ::ranges::predicate<T, std::string_view, bool, std::string_view, bool>;
 }  // namespace ad_utility::vocabulary_merger
 
 #endif  // QLEVER_SRC_INDEX_VOCABULARY_MERGER_CONCEPTS_H

--- a/src/index/vocabulary_merger/IdMap.h
+++ b/src/index/vocabulary_merger/IdMap.h
@@ -1,0 +1,149 @@
+// Copyright 2026 The QLever Authors, in particular:
+//
+// 2026 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+//
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#ifndef QLEVER_SRC_INDEX_VOCABULARY_MERGER_IDMAP_H
+#define QLEVER_SRC_INDEX_VOCABULARY_MERGER_IDMAP_H
+
+#include <memory>
+#include <ostream>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include "backports/three_way_comparison.h"
+#include "global/Id.h"
+#include "util/ExceptionHandling.h"
+#include "util/MemorySize/MemorySize.h"
+#include "util/Serializer/BufferedSerializer.h"
+#include "util/Serializer/FileSerializer.h"
+#include "util/Serializer/SerializeVector.h"
+#include "util/Serializer/Serializer.h"
+
+// The part of the vocabulary merger (see `index/VocabularyMerger.h`) that
+// exclusively deals with the mapping from the local indices of a partial
+// vocabulary to the global IDs, and never with the words themselves.
+namespace ad_utility::vocabulary_merger {
+
+// A single entry of an ID map (see `IdMapWriter` below): the index that a word
+// has inside a partial vocabulary, and the global ID that the vocabulary merger
+// has assigned to that word.
+//
+// NOTE: This deliberately is a plain struct and not a `std::pair`. libstdc++'s
+// `std::pair` has user-provided assignment operators and hence is not trivially
+// copyable, which would make a `std::vector` of them neither trivially
+// serializable (it would then be written and read one member at a time) nor
+// bitwise relocatable.
+struct IdMapEntry {
+  // NOTE: The local index deliberately is a plain index and not an `Id`. Inside
+  // a partial vocabulary a word is always a `VocabIndex`, so the datatype bits
+  // of an `Id` would carry no information. Adding them is cheap, but
+  // `Id::makeFromVocabIndex` also checks that the index fits into the available
+  // bits, and that check for each of the (very many) entries would cost
+  // measurable time in the vocabulary merger.
+  uint64_t localIndex_;
+  Id globalId_;
+
+  QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(IdMapEntry, localIndex_,
+                                              globalId_)
+
+  // Enable the serialization of an `IdMapEntry` (and of contiguous ranges of
+  // them) in the `ad_utility::serialization` framework.
+  template <typename T>
+  friend std::true_type allowTrivialSerialization(IdMapEntry, T);
+
+  // Make the output of failed tests readable.
+  friend std::ostream& operator<<(std::ostream& str, const IdMapEntry& entry) {
+    return str << '{' << entry.localIndex_ << ", " << entry.globalId_ << '}';
+  }
+};
+static_assert(
+    ad_utility::serialization::TriviallySerializable<IdMapEntry>,
+    "An `IdMapEntry` has to be trivially serializable, else a whole `IdMap` "
+    "would be written and read one member at a time");
+
+// Writes `IdMapEntry`s incrementally to a file. The entries are buffered and
+// only handed to the file in blocks, because a single entry is only 16 bytes
+// and writing each of them directly to the file would be very inefficient. The
+// resulting file has exactly the format of a serialized `IdMap`.
+class IdMapWriter {
+ public:
+  // The amount of data that is buffered before it is written to the file.
+  // NOTE: There is one `IdMapWriter` per partial vocabulary, of which there can
+  // be thousands, so this must not be too large: it is not only the memory
+  // footprint, but also the cache and TLB pressure of the writes, which are
+  // scattered over all the writers.
+  static constexpr ad_utility::MemorySize bufferSize =
+      ad_utility::MemorySize::kilobytes(16);
+
+ private:
+  using Serializer = ad_utility::serialization::BufferedWriteSerializer<
+      ad_utility::serialization::FileWriteSerializer>;
+  // NOTE: The indirection via the `unique_ptr` makes this class movable, which
+  // is required because the `IdMapWriter`s are stored in a `std::vector`.
+  std::unique_ptr<Serializer> serializer_;
+  // The number of entries that have been pushed so far. It is written to the
+  // beginning of the file by `finish()`.
+  uint64_t numEntries_ = 0;
+
+ public:
+  explicit IdMapWriter(const std::string& filename)
+      : serializer_{std::make_unique<Serializer>(
+            ad_utility::serialization::FileWriteSerializer{filename},
+            bufferSize)} {
+    // Write a placeholder for the number of entries, which is only known once
+    // `finish()` is called.
+    *serializer_ << numEntries_;
+  }
+
+  // This class is move-only. NOTE: There deliberately is no move assignment,
+  // as it would have to deal with the (currently never occurring) case that the
+  // assigned-to writer has not been finished yet.
+  IdMapWriter(const IdMapWriter&) = delete;
+  IdMapWriter& operator=(const IdMapWriter&) = delete;
+  IdMapWriter(IdMapWriter&&) noexcept = default;
+
+  ~IdMapWriter() {
+    ad_utility::terminateIfThrows([this]() { finish(); },
+                                  "The closing of an `IdMapWriter` failed");
+  }
+
+  // Append a single entry.
+  void push_back(const IdMapEntry& entry) {
+    *serializer_ << entry;
+    ++numEntries_;
+  }
+
+  // Flush the buffer, write the total number of entries to the beginning of
+  // the file, and close the file. This is automatically called by the
+  // destructor. After a call to `finish()`, no more calls to `push_back()` are
+  // allowed.
+  void finish() {
+    if (!serializer_) {
+      return;
+    }
+    auto file = std::move(*serializer_).underlyingSerializer();
+    serializer_.reset();
+    file.setSerializationPosition(0);
+    file << numEntries_;
+    file.close();
+  }
+};
+
+// Get the `IdMapEntry`s deserialized from a file that has previously been
+// written using the `IdMapWriter` class above.
+using IdMap = std::vector<IdMapEntry>;
+inline IdMap getIdMapFromFile(const std::string& filename) {
+  IdMap idMap;
+  ad_utility::serialization::FileReadSerializer serializer(filename);
+  serializer >> idMap;
+  return idMap;
+}
+}  // namespace ad_utility::vocabulary_merger
+
+#endif  // QLEVER_SRC_INDEX_VOCABULARY_MERGER_IDMAP_H

--- a/src/index/vocabulary_merger/IdMap.h
+++ b/src/index/vocabulary_merger/IdMap.h
@@ -10,7 +10,6 @@
 #ifndef QLEVER_SRC_INDEX_VOCABULARY_MERGER_IDMAP_H
 #define QLEVER_SRC_INDEX_VOCABULARY_MERGER_IDMAP_H
 
-#include <memory>
 #include <ostream>
 #include <string>
 #include <tuple>
@@ -19,7 +18,6 @@
 #include "backports/three_way_comparison.h"
 #include "global/Id.h"
 #include "global/VocabIndex.h"
-#include "util/ExceptionHandling.h"
 #include "util/MemorySize/MemorySize.h"
 #include "util/Serializer/BufferedSerializer.h"
 #include "util/Serializer/FileSerializer.h"
@@ -68,75 +66,42 @@ static_assert(
     "An `IdMapEntry` has to be trivially serializable, else a whole `IdMap` "
     "would be written and read one member at a time");
 
-// Writes `IdMapEntry`s incrementally to a file. The entries are buffered and
-// only handed to the file in blocks, because a single entry is only 16 bytes
-// and writing each of them directly to the file would be very inefficient. The
-// resulting file has exactly the format of a serialized `IdMap`.
-class IdMapWriter {
- public:
-  // The amount of data that is buffered before it is written to the file.
-  // NOTE: There is one `IdMapWriter` per partial vocabulary, of which there can
-  // be thousands, so this must not be too large: it is not only the memory
-  // footprint, but also the cache and TLB pressure of the writes, which are
-  // scattered over all the writers.
-  static constexpr ad_utility::MemorySize bufferSize =
-      ad_utility::MemorySize::kilobytes(16);
+// The `WriteSerializer` that an `IdMapWriter` (see below) is built on.
+// NOTE: The entries are buffered and only handed to the file in blocks,
+// because a single entry is only 16 bytes and writing each of them directly to
+// the file would be very inefficient.
+using IdMapWriteSerializer = ad_utility::serialization::BufferedWriteSerializer<
+    ad_utility::serialization::FileWriteSerializer>;
 
- private:
-  using Serializer = ad_utility::serialization::BufferedWriteSerializer<
-      ad_utility::serialization::FileWriteSerializer>;
-  // NOTE: The indirection via the `unique_ptr` makes this class movable, which
-  // is required because the `IdMapWriter`s are stored in a `std::vector`.
-  std::unique_ptr<Serializer> serializer_;
-  // The number of entries that have been pushed so far. It is written to the
-  // beginning of the file by `finish()`.
-  uint64_t numEntries_ = 0;
+// The amount of data that an `IdMapWriter` buffers before it is written to the
+// file.
+// NOTE: There is one `IdMapWriter` per partial vocabulary, of which there can
+// be thousands, so this must not be too large: it is not only the memory
+// footprint, but also the cache and TLB pressure of the writes, which are
+// scattered over all the writers.
+constexpr ad_utility::MemorySize idMapWriterBufferSize =
+    ad_utility::MemorySize::kilobytes(16);
 
- public:
-  explicit IdMapWriter(const std::string& filename)
-      : serializer_{std::make_unique<Serializer>(
-            ad_utility::serialization::FileWriteSerializer{filename},
-            bufferSize)} {
-    // Write a placeholder for the number of entries, which is only known once
-    // `finish()` is called.
-    *serializer_ << numEntries_;
-  }
+// Writes `IdMapEntry`s incrementally to a file. The resulting file has exactly
+// the format of a serialized `IdMap` (see below), so it can be read back with
+// `getIdMapFromFile`.
+//
+// Create an `IdMapWriter` with `makeIdMapWriter` below, push the entries with
+// `push`, and call `finish()` (which the destructor also does) to write the
+// total number of entries to the beginning of the file. After a call to
+// `finish()`, no more calls to `push` are allowed.
+using IdMapWriter = ad_utility::serialization::VectorIncrementalSerializer<
+    IdMapEntry, IdMapWriteSerializer>;
 
-  // This class is move-only. NOTE: There deliberately is no move assignment,
-  // as it would have to deal with the (currently never occurring) case that the
-  // assigned-to writer has not been finished yet.
-  IdMapWriter(const IdMapWriter&) = delete;
-  IdMapWriter& operator=(const IdMapWriter&) = delete;
-  IdMapWriter(IdMapWriter&&) noexcept = default;
-
-  ~IdMapWriter() {
-    ad_utility::terminateIfThrows([this]() { finish(); },
-                                  "The closing of an `IdMapWriter` failed");
-  }
-
-  // Append a single entry.
-  void push_back(const IdMapEntry& entry) {
-    *serializer_ << entry;
-    ++numEntries_;
-  }
-
-  // Flush the buffer, write the total number of entries to the beginning of
-  // the file, and close the file. This is automatically called by the
-  // destructor. After a call to `finish()`, no more calls to `push_back()` are
-  // allowed.
-  void finish() {
-    if (!serializer_) {
-      return;
-    }
-    auto file = std::move(*serializer_).underlyingSerializer();
-    serializer_.reset();
-    ad_utility::serialization::serializeAtPosition(file, 0, numEntries_);
-    file.close();
-  }
-};
+// Create an `IdMapWriter` that writes to the file with the given `filename`.
+inline IdMapWriter makeIdMapWriter(const std::string& filename) {
+  return IdMapWriter{IdMapWriteSerializer{
+      ad_utility::serialization::FileWriteSerializer{filename},
+      idMapWriterBufferSize}};
+}
 
 // Get the `IdMapEntry`s deserialized from a file that has previously been
-// written using the `IdMapWriter` class above.
+// written using an `IdMapWriter` (see above).
 using IdMap = std::vector<IdMapEntry>;
 inline IdMap getIdMapFromFile(const std::string& filename) {
   IdMap idMap;

--- a/src/index/vocabulary_merger/IdMap.h
+++ b/src/index/vocabulary_merger/IdMap.h
@@ -18,6 +18,7 @@
 
 #include "backports/three_way_comparison.h"
 #include "global/Id.h"
+#include "global/VocabIndex.h"
 #include "util/ExceptionHandling.h"
 #include "util/MemorySize/MemorySize.h"
 #include "util/Serializer/BufferedSerializer.h"
@@ -40,13 +41,13 @@ namespace ad_utility::vocabulary_merger {
 // serializable (it would then be written and read one member at a time) nor
 // bitwise relocatable.
 struct IdMapEntry {
-  // NOTE: The local index deliberately is a plain index and not an `Id`. Inside
-  // a partial vocabulary a word is always a `VocabIndex`, so the datatype bits
-  // of an `Id` would carry no information. Adding them is cheap, but
-  // `Id::makeFromVocabIndex` also checks that the index fits into the available
-  // bits, and that check for each of the (very many) entries would cost
-  // measurable time in the vocabulary merger.
-  uint64_t localIndex_;
+  // NOTE: The local index deliberately is a `VocabIndex` and not an `Id`.
+  // Inside a partial vocabulary a word is always a `VocabIndex`, so the
+  // datatype bits of an `Id` would carry no information. Adding them is cheap,
+  // but `Id::makeFromVocabIndex` also checks that the index fits into the
+  // available bits, and that check for each of the (very many) entries would
+  // cost measurable time in the vocabulary merger.
+  VocabIndex localIndex_;
   Id globalId_;
 
   QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(IdMapEntry, localIndex_,
@@ -129,8 +130,7 @@ class IdMapWriter {
     }
     auto file = std::move(*serializer_).underlyingSerializer();
     serializer_.reset();
-    file.setSerializationPosition(0);
-    file << numEntries_;
+    ad_utility::serialization::serializeAtPosition(file, 0, numEntries_);
     file.close();
   }
 };

--- a/src/index/vocabulary_merger/QueueWord.h
+++ b/src/index/vocabulary_merger/QueueWord.h
@@ -1,0 +1,57 @@
+// Copyright 2026 The QLever Authors, in particular:
+//
+// 2026 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+//
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#ifndef QLEVER_SRC_INDEX_VOCABULARY_MERGER_QUEUEWORD_H
+#define QLEVER_SRC_INDEX_VOCABULARY_MERGER_QUEUEWORD_H
+
+#include <cstddef>
+#include <string>
+#include <utility>
+
+#include "index/IndexBuilderTypes.h"
+#include "util/MemorySize/MemorySize.h"
+
+// The words that the vocabulary merger (see `index/VocabularyMerger.h`) reads
+// from the partial vocabularies and merges. This is not part of the public
+// interface of that header.
+namespace ad_utility::vocabulary_merger::detail {
+
+// Helper `struct` for a word from a partial vocabulary.
+struct QueueWord {
+  QueueWord() = default;
+  QueueWord(TripleComponentWithIndex&& v, size_t file)
+      : entry_(std::move(v)), partialFileId_(file) {}
+  TripleComponentWithIndex entry_;  // the word, its local ID and the
+                                    // information if it will be externalized
+  size_t partialFileId_;  // from which partial vocabulary did this word come
+
+  [[nodiscard]] const bool& isExternal() const { return entry_.isExternal(); }
+  [[nodiscard]] bool& isExternal() { return entry_.isExternal(); }
+
+  [[nodiscard]] const std::string& iriOrLiteral() const {
+    return entry_.iriOrLiteral();
+  }
+
+  [[nodiscard]] std::string& iriOrLiteral() { return entry_.iriOrLiteral(); }
+
+  [[nodiscard]] const auto& id() const { return entry_.index_; }
+};
+
+// Compute the memory footprint of a `QueueWord`, which the parallel merging
+// needs to limit its memory consumption.
+struct SizeOfQueueWord {
+  ad_utility::MemorySize operator()(const QueueWord& q) const {
+    return ad_utility::MemorySize::bytes(sizeof(QueueWord) +
+                                         q.entry_.iriOrLiteral().size());
+  }
+};
+inline constexpr SizeOfQueueWord sizeOfQueueWord{};
+}  // namespace ad_utility::vocabulary_merger::detail
+
+#endif  // QLEVER_SRC_INDEX_VOCABULARY_MERGER_QUEUEWORD_H

--- a/src/index/vocabulary_merger/QueueWord.h
+++ b/src/index/vocabulary_merger/QueueWord.h
@@ -27,16 +27,12 @@ struct QueueWord {
   QueueWord() = default;
   QueueWord(TripleComponentWithIndex&& v, size_t file)
       : entry_(std::move(v)), partialFileId_(file) {}
-  TripleComponentWithIndex entry_;  // the word, its local ID and the
-                                    // information if it will be externalized
+  // The word, its local ID, and the information whether it will be
+  // externalized.
+  TripleComponentWithIndex entry_;
   size_t partialFileId_;  // from which partial vocabulary did this word come
 
-  [[nodiscard]] const bool& isExternal() const { return entry_.isExternal(); }
   [[nodiscard]] bool& isExternal() { return entry_.isExternal(); }
-
-  [[nodiscard]] const std::string& iriOrLiteral() const {
-    return entry_.iriOrLiteral();
-  }
 
   [[nodiscard]] std::string& iriOrLiteral() { return entry_.iriOrLiteral(); }
 

--- a/src/index/vocabulary_merger/VocabularyMetaData.h
+++ b/src/index/vocabulary_merger/VocabularyMetaData.h
@@ -1,0 +1,132 @@
+// Copyright 2026 The QLever Authors, in particular:
+//
+// 2026 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+//
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#ifndef QLEVER_SRC_INDEX_VOCABULARY_MERGER_VOCABULARYMETADATA_H
+#define QLEVER_SRC_INDEX_VOCABULARY_MERGER_VOCABULARYMETADATA_H
+
+#include <string>
+#include <string_view>
+#include <utility>
+
+#include "backports/StartsWithAndEndsWith.h"
+#include "global/Constants.h"
+#include "global/Id.h"
+#include "global/SpecialIds.h"
+#include "util/HashMap.h"
+
+// NOTE: This class is the return type of `mergeVocabulary` and hence part of
+// the public interface of the vocabulary merger. It only lives in its own
+// header (instead of in `index/VocabularyMerger.h`, which is the user-facing
+// header and which includes this one) because it is understandable and
+// testable on its own.
+namespace ad_utility::vocabulary_merger {
+
+// The result of a call to `mergeVocabulary` (see `index/VocabularyMerger.h`).
+struct VocabularyMetaData {
+  // This struct is used to incrementally construct the range of IDs that
+  // correspond to a given prefix. To use it, all the words from the
+  // vocabulary must be passed to the member function `addIfWordMatches` in
+  // sorted order. After that, the range `[begin(), end())` is the range of
+  // all the words that start with the prefix.
+  struct IdRangeForPrefix {
+    explicit IdRangeForPrefix(std::string prefix)
+        : prefix_{std::move(prefix)} {}
+    // Check if `word` starts with the `prefix_`. If so, `wordIndex`
+    // will become part of the range that this struct represents. The function
+    // returns `true` in this case, else `false`. For this to work, all the
+    // words that start with the `prefix_` have to be passed in consecutively
+    // and their indices have to be consecutive and ascending.
+    bool addIfWordMatches(std::string_view word, size_t wordIndex) {
+      if (!ql::starts_with(word, prefix_)) {
+        return false;
+      }
+      if (!beginWasSeen_) {
+        begin_ = Id::makeFromVocabIndex(VocabIndex::make(wordIndex));
+        beginWasSeen_ = true;
+      }
+      end_ = Id::makeFromVocabIndex(VocabIndex::make(wordIndex + 1));
+      return true;
+    }
+
+    Id begin() const { return begin_; }
+    Id end() const { return end_; }
+
+    // Return true if the `id` belongs to this range.
+    bool contains(Id id) const { return begin_ <= id && id < end_; }
+
+   private:
+    Id begin_ = Id::makeUndefined();
+    Id end_ = Id::makeUndefined();
+    std::string prefix_;
+    bool beginWasSeen_ = false;
+  };
+
+ public:
+  // This function has to be called for every *DISTINCT* word (IRI or literal,
+  // not blank nodes) and the index, which is assigned to this word by the merge
+  // procedure. It automatically updates the various prefix ranges, the total
+  // number of words, and the mapping of the special IDs.
+  void addWord(std::string_view word, size_t wordIndex) {
+    ++numWordsTotal_;
+    if (langTaggedPredicates_.addIfWordMatches(word, wordIndex)) {
+      return;
+    }
+    if (internalEntities_.addIfWordMatches(word, wordIndex)) {
+      if (globalSpecialIds_->contains(word)) {
+        specialIdMapping_[std::string{word}] =
+            Id::makeFromVocabIndex(VocabIndex::make(wordIndex));
+      }
+    }
+  }
+
+  // Return the index of the next blank node and increment the internal counter
+  // of blank nodes. This has to be called for every distinct blank node that
+  // is encountered.
+  size_t getNextBlankNodeIndex() {
+    auto res = numBlankNodesTotal_;
+    ++numBlankNodesTotal_;
+    return res;
+  }
+
+  // The mapping from the `qlever::specialIds` to their actual IDs.
+  // This is created on the fly by the calls to `addWord`.
+  const auto& specialIdMapping() const { return specialIdMapping_; }
+  // The prefix range for the `@en@<predicate` style predicates.
+  const auto& langTaggedPredicates() const { return langTaggedPredicates_; }
+  // The prefix range for the internal IRIs in the `ql:` namespace.
+  const auto& internalEntities() const { return internalEntities_; }
+  // The number of words for which `addWord()` has been called. Needs to return
+  // a reference to be used in combination with a `ProgressBar`.
+  const size_t& numWordsTotal() const { return numWordsTotal_; }
+
+  // Return true iff the `id` belongs to one of the two ranges that contain
+  // the internal IDs that were added by QLever and were not part of the
+  // input.
+  bool isQleverInternalId(Id id) const {
+    return internalEntities_.contains(id) || langTaggedPredicates_.contains(id);
+  }
+
+ private:
+  // The number of distinct words (size of the created vocabulary).
+  size_t numWordsTotal_ = 0;
+  // The number of distinct blank nodes that were found and immediately
+  // converted to an ID without becoming part of the vocabulary.
+  size_t numBlankNodesTotal_ = 0;
+  IdRangeForPrefix langTaggedPredicates_{
+      std::string{ad_utility::languageTaggedPredicatePrefix}};
+  IdRangeForPrefix internalEntities_{
+      std::string{QLEVER_INTERNAL_PREFIX_IRI_WITHOUT_CLOSING_BRACKET}};
+
+  ad_utility::HashMap<std::string, Id> specialIdMapping_;
+  const ad_utility::HashMap<std::string, Id>* globalSpecialIds_ =
+      &qlever::specialIds();
+};
+}  // namespace ad_utility::vocabulary_merger
+
+#endif  // QLEVER_SRC_INDEX_VOCABULARY_MERGER_VOCABULARYMETADATA_H

--- a/src/index/vocabulary_merger/VocabularyMetaData.h
+++ b/src/index/vocabulary_merger/VocabularyMetaData.h
@@ -88,11 +88,7 @@ struct VocabularyMetaData {
   // Return the index of the next blank node and increment the internal counter
   // of blank nodes. This has to be called for every distinct blank node that
   // is encountered.
-  size_t getNextBlankNodeIndex() {
-    auto res = numBlankNodesTotal_;
-    ++numBlankNodesTotal_;
-    return res;
-  }
+  size_t getNextBlankNodeIndex() { return numBlankNodesTotal_++; }
 
   // The mapping from the `qlever::specialIds` to their actual IDs.
   // This is created on the fly by the calls to `addWord`.

--- a/src/util/Serializer/BufferedSerializer.h
+++ b/src/util/Serializer/BufferedSerializer.h
@@ -11,7 +11,9 @@
 #ifndef QLEVER_SRC_UTIL_SERIALIZER_BUFFEREDSERIALIZER_H
 #define QLEVER_SRC_UTIL_SERIALIZER_BUFFEREDSERIALIZER_H
 
+#include <cstdint>
 #include <optional>
+#include <type_traits>
 #include <vector>
 
 #include "backports/span.h"
@@ -124,6 +126,47 @@ CPP_template(typename UnderlyingSerializer,
     UnderlyingSerializer serializer = std::move(underlyingSerializer_.value());
     underlyingSerializer_.reset();
     return serializer;
+  }
+
+  // Return the position at which the next serialized byte will end up in the
+  // underlying serializer. This includes the bytes that are still sitting in
+  // the buffer.
+  //
+  // NOTE: This is only meaningful if the blocks arrive at the underlying
+  // serializer unchanged, which is the case for the
+  // `PassthroughBlockProcessor`, but for example not for the
+  // `CompressingBlockProcessor` (see `CompressedSerializer.h`), where a
+  // position in the buffered stream bears no relation to a position in the
+  // underlying serializer.
+  [[nodiscard]] uint64_t getSerializationPosition() const {
+    static_assert(
+        std::is_same_v<BlockProcessor, PassthroughBlockProcessor>,
+        "`getSerializationPosition` is only supported by a "
+        "`BufferedWriteSerializer` that forwards its blocks unchanged");
+    AD_CORRECTNESS_CHECK(underlyingSerializer_.has_value());
+    return underlyingSerializer_.value().getSerializationPosition() +
+           buffer_.size();
+  }
+
+  // Overload of `serializeAtPosition` (see `Serializer.h`) for a
+  // `BufferedWriteSerializer`. First flush the buffer, such that the
+  // positions can then be handled entirely by the underlying serializer.
+  //
+  // NOTE: This is a hidden friend (and hence only found via ADL) because it
+  // needs access to the buffer and to the underlying serializer, neither of
+  // which is part of the public interface of this class. The same restriction
+  // as for `getSerializationPosition` above applies.
+  template <typename T>
+  friend void serializeAtPosition(BufferedWriteSerializer& serializer,
+                                  uint64_t position, const T& element) {
+    static_assert(
+        std::is_same_v<BlockProcessor, PassthroughBlockProcessor>,
+        "`serializeAtPosition` is only supported by a "
+        "`BufferedWriteSerializer` that forwards its blocks unchanged");
+    serializer.flushBlock();
+    AD_CORRECTNESS_CHECK(serializer.underlyingSerializer_.has_value());
+    serializeAtPosition(serializer.underlyingSerializer_.value(), position,
+                        element);
   }
 
  private:

--- a/src/util/Serializer/SerializeVector.h
+++ b/src/util/Serializer/SerializeVector.h
@@ -12,6 +12,7 @@
 
 #include "backports/span.h"
 #include "util/ExceptionHandling.h"
+#include "util/ResetWhenMoved.h"
 #include "util/Serializer/Serializer.h"
 #include "util/TypeTraits.h"
 #include "util/Views.h"
@@ -110,7 +111,10 @@ CPP_template(typename T, typename Serializer)(
   Serializer _serializer;
   uint64_t _startPosition;
   typename std::vector<T>::size_type _size = 0;
-  bool _isFinished = false;
+  // A moved-from `VectorIncrementalSerializer` must not write anything anymore,
+  // as its serializer has been moved away. The `ResetWhenMoved` takes care of
+  // this, such that the move constructor can simply be defaulted.
+  ad_utility::ResetWhenMoved<bool, true> _isFinished = false;
 
  public:
   explicit VectorIncrementalSerializer(Serializer&& serializer)
@@ -126,16 +130,13 @@ CPP_template(typename T, typename Serializer)(
   VectorIncrementalSerializer(const VectorIncrementalSerializer&) = delete;
   VectorIncrementalSerializer& operator=(const VectorIncrementalSerializer&) =
       delete;
-  VectorIncrementalSerializer(VectorIncrementalSerializer&& other) noexcept(
-      std::is_nothrow_move_constructible_v<Serializer>)
-      : _serializer{std::move(other._serializer)},
-        _startPosition{other._startPosition},
-        _size{other._size},
-        _isFinished{other._isFinished} {
-    // The moved-from object must not write anything anymore, as its serializer
-    // has been moved away.
-    other._isFinished = true;
-  }
+  // The defaulted move constructor has the correct semantics because of the
+  // usage of `ResetWhenMoved` for the `_isFinished` member.
+  //
+  // NOTE: There deliberately is no move assignment operator. It would have to
+  // `finish()` the assigned-to object first (which might already have been
+  // written to), and no caller currently needs it.
+  VectorIncrementalSerializer(VectorIncrementalSerializer&&) = default;
 
   void push(const T& element) {
     _serializer << element;

--- a/src/util/Serializer/SerializeVector.h
+++ b/src/util/Serializer/SerializeVector.h
@@ -130,10 +130,7 @@ CPP_template(typename T, typename Serializer)(
       return;
     }
     _isFinished = true;
-    auto endPosition = _serializer.getSerializationPosition();
-    _serializer.setSerializationPosition(_startPosition);
-    _serializer << _size;
-    _serializer.setSerializationPosition(endPosition);
+    serializeAtPosition(_serializer, _startPosition, _size);
   }
 
   Serializer serializer() && {

--- a/src/util/Serializer/SerializeVector.h
+++ b/src/util/Serializer/SerializeVector.h
@@ -7,9 +7,11 @@
 
 #include <cstdint>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 #include "backports/span.h"
+#include "util/ExceptionHandling.h"
 #include "util/Serializer/Serializer.h"
 #include "util/TypeTraits.h"
 #include "util/Views.h"
@@ -120,6 +122,21 @@ CPP_template(typename T, typename Serializer)(
     alignSerializerForType<T>(_serializer);
   }
 
+  // This class is move-only, as the underlying serializers are.
+  VectorIncrementalSerializer(const VectorIncrementalSerializer&) = delete;
+  VectorIncrementalSerializer& operator=(const VectorIncrementalSerializer&) =
+      delete;
+  VectorIncrementalSerializer(VectorIncrementalSerializer&& other) noexcept(
+      std::is_nothrow_move_constructible_v<Serializer>)
+      : _serializer{std::move(other._serializer)},
+        _startPosition{other._startPosition},
+        _size{other._size},
+        _isFinished{other._isFinished} {
+    // The moved-from object must not write anything anymore, as its serializer
+    // has been moved away.
+    other._isFinished = true;
+  }
+
   void push(const T& element) {
     _serializer << element;
     _size++;
@@ -138,7 +155,11 @@ CPP_template(typename T, typename Serializer)(
     return std::move(_serializer);
   }
 
-  ~VectorIncrementalSerializer() { finish(); }
+  ~VectorIncrementalSerializer() {
+    ad_utility::terminateIfThrows(
+        [this]() { finish(); },
+        "The finishing of a `VectorIncrementalSerializer` failed");
+  }
 };
 
 }  // namespace ad_utility::serialization

--- a/src/util/Serializer/Serializer.h
+++ b/src/util/Serializer/Serializer.h
@@ -362,6 +362,24 @@ CPP_template(typename T, typename S)(
   }
 }
 
+// Serialize the `element` at the given `position` of the `serializer` and
+// restore the serialization position that the `serializer` had before. Use
+// this to fill in a placeholder (for example a size that is only known at the
+// end) that has been written to a fixed position earlier.
+//
+// NOTE: The `serializer` has to support `get/setSerializationPosition`, which
+// not all `WriteSerializer`s do. A `BufferedWriteSerializer` for example does
+// not, because a part of the data might still be sitting in its buffer.
+CPP_template(typename S, typename T)(
+    requires WriteSerializer<S>) void serializeAtPosition(S& serializer,
+                                                          uint64_t position,
+                                                          const T& element) {
+  auto previousPosition = serializer.getSerializationPosition();
+  serializer.setSerializationPosition(position);
+  serializer << element;
+  serializer.setSerializationPosition(previousPosition);
+}
+
 }  // namespace ad_utility::serialization
 
 #endif  // QLEVER_SRC_UTIL_SERIALIZER_SERIALIZER_H

--- a/src/util/Serializer/Serializer.h
+++ b/src/util/Serializer/Serializer.h
@@ -368,8 +368,9 @@ CPP_template(typename T, typename S)(
 // end) that has been written to a fixed position earlier.
 //
 // NOTE: The `serializer` has to support `get/setSerializationPosition`, which
-// not all `WriteSerializer`s do. A `BufferedWriteSerializer` for example does
-// not, because a part of the data might still be sitting in its buffer.
+// not all `WriteSerializer`s do. For a `BufferedWriteSerializer` (which cannot
+// simply seek, because a part of the data might still be sitting in its
+// buffer) there is a dedicated overload in `BufferedSerializer.h`.
 CPP_template(typename S, typename T)(
     requires WriteSerializer<S>) void serializeAtPosition(S& serializer,
                                                           uint64_t position,

--- a/test/SerializerTest.cpp
+++ b/test/SerializerTest.cpp
@@ -1246,3 +1246,102 @@ TEST(BufferedWriteSerializer, IsWriteSerializer) {
   static_assert(
       WriteSerializer<BufferedWriteSerializer<ByteBufferWriteSerializer>>);
 }
+
+// _____________________________________________________________________________
+// The serialization position of a `BufferedWriteSerializer` also accounts for
+// the bytes that are still sitting in its buffer, and `serializeAtPosition`
+// (which first flushes that buffer) can overwrite data that has already been
+// written.
+TEST(BufferedWriteSerializer, SerializeAtPosition) {
+  std::string filename = gtestCurrentTestName();
+  auto cleanup = absl::Cleanup{[&filename]() { deleteFile(filename); }};
+
+  for (MemorySize blockSize : {1_B, 3_B, 64_B, 1024_B}) {
+    uint32_t placeholder = 0;
+    uint32_t trailer = 12345;
+    uint32_t actualValue = 42;
+    {
+      BufferedWriteSerializer writer{FileWriteSerializer{filename}, blockSize};
+      EXPECT_EQ(writer.getSerializationPosition(), 0u);
+      writer << placeholder;
+      // The position advances even for bytes that may still be buffered.
+      EXPECT_EQ(writer.getSerializationPosition(), sizeof(placeholder));
+      writer << trailer;
+      auto positionAfter = writer.getSerializationPosition();
+
+      serializeAtPosition(writer, 0, actualValue);
+      // The position is restored, such that the following bytes are appended.
+      EXPECT_EQ(writer.getSerializationPosition(), positionAfter);
+      writer << trailer;
+    }
+
+    FileReadSerializer reader{filename};
+    uint32_t read = 0;
+    reader >> read;
+    EXPECT_EQ(read, actualValue) << "block size was " << blockSize;
+    reader >> read;
+    EXPECT_EQ(read, trailer) << "block size was " << blockSize;
+    reader >> read;
+    EXPECT_EQ(read, trailer) << "block size was " << blockSize;
+  }
+}
+
+// _____________________________________________________________________________
+// A `VectorIncrementalSerializer` on top of a `BufferedWriteSerializer` writes
+// exactly the same format as one that writes to the file directly, also if the
+// vector does not start at position 0.
+TEST(VectorIncrementalSerializer, WithBufferedWriteSerializer) {
+  std::vector<int> original{9, 7, 5, 3, 1, -1, -3, 5, 5, 6, 67498235, 0, 42};
+  double firstDouble = 42.42;
+  double secondDouble = -13.123;
+  std::string filename = gtestCurrentTestName();
+  auto cleanup = absl::Cleanup{[&filename]() { deleteFile(filename); }};
+
+  using Writer = BufferedWriteSerializer<FileWriteSerializer>;
+  for (MemorySize blockSize : {1_B, 5_B, 64_B, 1024_B}) {
+    {
+      Writer bufferedWriter{FileWriteSerializer{filename}, blockSize};
+      bufferedWriter << firstDouble;
+      VectorIncrementalSerializer<int, Writer> writer{
+          std::move(bufferedWriter)};
+      for (int element : original) {
+        writer.push(element);
+      }
+      bufferedWriter = std::move(writer).serializer();
+      bufferedWriter << secondDouble;
+    }
+
+    FileReadSerializer reader{filename};
+    double doubleRead = 0.0;
+    reader >> doubleRead;
+    EXPECT_EQ(doubleRead, firstDouble) << "block size was " << blockSize;
+    std::vector<int> vectorRead;
+    reader >> vectorRead;
+    EXPECT_EQ(vectorRead, original) << "block size was " << blockSize;
+    reader >> doubleRead;
+    EXPECT_EQ(doubleRead, secondDouble) << "block size was " << blockSize;
+  }
+}
+
+// _____________________________________________________________________________
+// A moved-from `VectorIncrementalSerializer` writes nothing anymore, in
+// particular its destructor doesn't touch the serializer that has been moved
+// away.
+TEST(VectorIncrementalSerializer, MoveConstructor) {
+  std::vector<int> original{1, 2, 3, 4, 5};
+  std::string filename = gtestCurrentTestName();
+  auto cleanup = absl::Cleanup{[&filename]() { deleteFile(filename); }};
+  {
+    VectorIncrementalSerializer<int, FileWriteSerializer> writer{filename};
+    writer.push(original.at(0));
+    auto movedTo = std::move(writer);
+    for (size_t i = 1; i < original.size(); ++i) {
+      movedTo.push(original.at(i));
+    }
+  }
+
+  FileReadSerializer reader{filename};
+  std::vector<int> read;
+  reader >> read;
+  EXPECT_EQ(read, original);
+}

--- a/test/VocabularyGeneratorTest.cpp
+++ b/test/VocabularyGeneratorTest.cpp
@@ -30,21 +30,6 @@
 
 using namespace ad_utility::vocabulary_merger;
 namespace {
-// equality operator used in this test
-bool vocabTestCompare(const IdMap& a, const std::vector<std::pair<Id, Id>>& b) {
-  if (a.size() != b.size()) {
-    return false;
-  }
-
-  for (size_t i = 0; i < a.size(); ++i) {
-    if (a[i] != b[i]) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
 auto V = ad_utility::testing::VocabId;
 
 // Write the given `words` as a partial vocabulary file at `path`, assigning
@@ -82,7 +67,7 @@ class MergeVocabularyTest : public ::testing::Test {
 
   // two std::vectors where we store the expected mapping
   // form partial to global ids;
-  using Mapping = std::vector<std::pair<Id, Id>>;
+  using Mapping = IdMap;
   Mapping _expMapping0;
   Mapping _expMapping1;
 
@@ -158,7 +143,7 @@ class MergeVocabularyTest : public ::testing::Test {
             if (mapping) {
               if (w.isBlankNode({})) {
                 mapping->emplace_back(
-                    V(localIdx),
+                    localIdx,
                     Id::makeFromBlankNodeIndex(BlankNodeIndex::make(globalId)));
               } else {
                 using GeoVocab = SplitGeoVocabulary<
@@ -166,7 +151,7 @@ class MergeVocabularyTest : public ::testing::Test {
                 if (GeoVocab::getMarkerForWord(w.iriOrLiteral()) == 1) {
                   globalId = GeoVocab::addMarker(globalId, 1);
                 }
-                mapping->emplace_back(V(localIdx), V(globalId));
+                mapping->emplace_back(localIdx, V(globalId));
               }
             }
             localIdx++;
@@ -251,10 +236,10 @@ TEST_F(MergeVocabularyTest, mergeVocabulary) {
   // Check that vocabulary has the right form.
   IdMap mapping0 = getIdMapFromFile(_basePath + PARTIAL_VOCAB_IDMAP_INFIX +
                                     std::to_string(0));
-  ASSERT_TRUE(vocabTestCompare(mapping0, _expMapping0));
+  EXPECT_THAT(mapping0, ::testing::ElementsAreArray(_expMapping0));
   IdMap mapping1 = getIdMapFromFile(_basePath + PARTIAL_VOCAB_IDMAP_INFIX +
                                     std::to_string(1));
-  ASSERT_TRUE(vocabTestCompare(mapping1, _expMapping1));
+  EXPECT_THAT(mapping1, ::testing::ElementsAreArray(_expMapping1));
 }
 
 // _____________________________________________________________________________
@@ -341,12 +326,12 @@ TEST(MergeVocabulary, treatIrisAsBlankNodesViaRegex) {
     return Id::makeFromBlankNodeIndex(BlankNodeIndex::make(index));
   };
   IdMap idMap = getIdMapFromFile(idMapFile);
-  EXPECT_THAT(idMap, ::testing::ElementsAreArray(std::vector<std::pair<Id, Id>>{
-                         {V(0), V(0)},     // "bn_lit"
-                         {V(1), V(1)},     // <http://ex/apple>
-                         {V(2), BN(0)},    // <http://ex/bn_1>
-                         {V(3), BN(1)},    // <http://ex/bn_2>
-                         {V(4), V(2)}}));  // <http://ex/cherry>
+  EXPECT_THAT(idMap, ::testing::ElementsAreArray(
+                         IdMap{{0, V(0)},     // "bn_lit"
+                               {1, V(1)},     // <http://ex/apple>
+                               {2, BN(0)},    // <http://ex/bn_1>
+                               {3, BN(1)},    // <http://ex/bn_2>
+                               {4, V(2)}}));  // <http://ex/cherry>
 }
 
 TEST(VocabularyGeneratorTest, createInternalMapping) {

--- a/test/VocabularyGeneratorTest.cpp
+++ b/test/VocabularyGeneratorTest.cpp
@@ -56,10 +56,10 @@ void writePartialVocabularyFile(const std::string& path, const Range& words) {
 class MergeVocabularyTest : public ::testing::Test {
  protected:
   // path of the 2 partial Vocabularies that are used by mergeVocabulary
-  std::string _path0;
-  std::string _path1;
+  std::string path0_;
+  std::string path1_;
   // the base directory for our test
-  std::string _basePath;
+  std::string basePath_;
 
   // The bool means "is in the external vocabulary and not in the internal
   // vocabulary".
@@ -67,31 +67,30 @@ class MergeVocabularyTest : public ::testing::Test {
   ExpectedVocabulary expectedMergedVocabulary_;
   ExpectedVocabulary expectedMergedGeoVocabulary_;
 
-  // two std::vectors where we store the expected mapping
-  // form partial to global ids;
-  IdMap _expMapping0;
-  IdMap _expMapping1;
+  // The two expected ID maps from the partial to the global ids.
+  IdMap expectedIdMap0_;
+  IdMap expectedIdMap1_;
 
   // Constructor. TODO: Better write Setup method because of complex logic which
   // may throw?
   MergeVocabularyTest() {
-    _basePath = std::string("vocabularyGeneratorTestFiles");
+    basePath_ = std::string("vocabularyGeneratorTestFiles");
     // those names are required by mergeVocabulary
-    _path0 = std::string(PARTIAL_VOCAB_WORDS_INFIX + std::to_string(0));
-    _path1 = std::string(PARTIAL_VOCAB_WORDS_INFIX + std::to_string(1));
+    path0_ = std::string(PARTIAL_VOCAB_WORDS_INFIX + std::to_string(0));
+    path1_ = std::string(PARTIAL_VOCAB_WORDS_INFIX + std::to_string(1));
 
     // Create a subdirectory for the test files in the working directory.
-    _basePath = _basePath + "/";
+    basePath_ = basePath_ + "/";
     ql::error_code errorCode;
-    ql::filesystem::create_directories(_basePath, errorCode);
+    ql::filesystem::create_directories(basePath_, errorCode);
     if (errorCode) {
       std::cerr << "Could not create the directory for the test files. This "
                    "might lead to test failures\n";
     }
 
     // Prepend the created directory to the paths.
-    _path0 = _basePath + _path0;
-    _path1 = _basePath + _path1;
+    path0_ = basePath_ + path0_;
+    path1_ = basePath_ + path1_;
 
     // these will be the contents of partial vocabularies, second element of
     // pair is the correct Id which is expected from mergeVocabulary
@@ -129,12 +128,12 @@ class MergeVocabularyTest : public ::testing::Test {
          true}};
 
     // open files for partial Vocabularies
-    ad_utility::serialization::FileWriteSerializer partial0(_path0);
-    ad_utility::serialization::FileWriteSerializer partial1(_path1);
+    ad_utility::serialization::FileWriteSerializer partial0(path0_);
+    ad_utility::serialization::FileWriteSerializer partial1(path1_);
 
     auto writePartialVocabulary = [](auto& partialVocab,
                                      const auto& tripleComponents,
-                                     IdMap* mapping) {
+                                     IdMap* idMap) {
       // write first partial vocabulary
       partialVocab << tripleComponents.size();
       size_t localIdx = 0;
@@ -142,9 +141,9 @@ class MergeVocabularyTest : public ::testing::Test {
         auto globalId = w.index_;
         w.index_ = localIdx;
         partialVocab << w;
-        if (mapping) {
+        if (idMap) {
           if (w.isBlankNode({})) {
-            mapping->push_back(
+            idMap->push_back(
                 {L(localIdx),
                  Id::makeFromBlankNodeIndex(BlankNodeIndex::make(globalId))});
           } else {
@@ -153,22 +152,22 @@ class MergeVocabularyTest : public ::testing::Test {
             if (GeoVocab::getMarkerForWord(w.iriOrLiteral()) == 1) {
               globalId = GeoVocab::addMarker(globalId, 1);
             }
-            mapping->push_back({L(localIdx), V(globalId)});
+            idMap->push_back({L(localIdx), V(globalId)});
           }
         }
         localIdx++;
       }
     };
-    writePartialVocabulary(partial0, words0, &_expMapping0);
+    writePartialVocabulary(partial0, words0, &expectedIdMap0_);
 
-    writePartialVocabulary(partial1, words1, &_expMapping1);
+    writePartialVocabulary(partial1, words1, &expectedIdMap1_);
   }
 
   // __________________________________________________________________
   ~MergeVocabularyTest() {
     // Delete the test files (to debug a test failure, comment this out).
     ql::error_code errorCode;
-    ql::filesystem::remove_all(_basePath, errorCode);
+    ql::filesystem::remove_all(basePath_, errorCode);
   }
 
   // read all bytes from a file (e.g. to check equality of small test files)
@@ -215,7 +214,7 @@ TEST_F(MergeVocabularyTest, mergeVocabulary) {
 
     TripleComponentComparator comparator;
     res = mergeVocabulary(
-        _basePath, {"0", "1"},
+        basePath_, {"0", "1"},
         [&comparator](std::string_view a, bool aIsExternal, std::string_view b,
                       bool bIsExternal) {
           return comparator.isLessInTotalWithExternalFlag(a, aIsExternal, b,
@@ -236,12 +235,12 @@ TEST_F(MergeVocabularyTest, mergeVocabulary) {
   ASSERT_EQ(res.internalEntities().begin(), Id::makeUndefined());
   ASSERT_EQ(res.internalEntities().end(), Id::makeUndefined());
   // Check that vocabulary has the right form.
-  IdMap mapping0 = getIdMapFromFile(_basePath + PARTIAL_VOCAB_IDMAP_INFIX +
-                                    std::to_string(0));
-  EXPECT_THAT(mapping0, ::testing::ElementsAreArray(_expMapping0));
-  IdMap mapping1 = getIdMapFromFile(_basePath + PARTIAL_VOCAB_IDMAP_INFIX +
-                                    std::to_string(1));
-  EXPECT_THAT(mapping1, ::testing::ElementsAreArray(_expMapping1));
+  IdMap idMap0 = getIdMapFromFile(basePath_ + PARTIAL_VOCAB_IDMAP_INFIX +
+                                  std::to_string(0));
+  EXPECT_THAT(idMap0, ::testing::ElementsAreArray(expectedIdMap0_));
+  IdMap idMap1 = getIdMapFromFile(basePath_ + PARTIAL_VOCAB_IDMAP_INFIX +
+                                  std::to_string(1));
+  EXPECT_THAT(idMap1, ::testing::ElementsAreArray(expectedIdMap1_));
 }
 
 // _____________________________________________________________________________

--- a/test/VocabularyGeneratorTest.cpp
+++ b/test/VocabularyGeneratorTest.cpp
@@ -31,6 +31,8 @@
 using namespace ad_utility::vocabulary_merger;
 namespace {
 auto V = ad_utility::testing::VocabId;
+// Shorthand for the local index that a word has inside a partial vocabulary.
+auto L = [](uint64_t index) { return VocabIndex::make(index); };
 
 // Write the given `words` as a partial vocabulary file at `path`, assigning
 // them consecutive local ids `0, 1, ...` in the given order and marking all of
@@ -67,9 +69,8 @@ class MergeVocabularyTest : public ::testing::Test {
 
   // two std::vectors where we store the expected mapping
   // form partial to global ids;
-  using Mapping = IdMap;
-  Mapping _expMapping0;
-  Mapping _expMapping1;
+  IdMap _expMapping0;
+  IdMap _expMapping1;
 
   // Constructor. TODO: Better write Setup method because of complex logic which
   // may throw?
@@ -131,32 +132,33 @@ class MergeVocabularyTest : public ::testing::Test {
     ad_utility::serialization::FileWriteSerializer partial0(_path0);
     ad_utility::serialization::FileWriteSerializer partial1(_path1);
 
-    auto writePartialVocabulary =
-        [](auto& partialVocab, const auto& tripleComponents, Mapping* mapping) {
-          // write first partial vocabulary
-          partialVocab << tripleComponents.size();
-          size_t localIdx = 0;
-          for (auto w : tripleComponents) {
-            auto globalId = w.index_;
-            w.index_ = localIdx;
-            partialVocab << w;
-            if (mapping) {
-              if (w.isBlankNode({})) {
-                mapping->emplace_back(
-                    localIdx,
-                    Id::makeFromBlankNodeIndex(BlankNodeIndex::make(globalId)));
-              } else {
-                using GeoVocab = SplitGeoVocabulary<
-                    CompressedVocabulary<VocabularyInternalExternal>>;
-                if (GeoVocab::getMarkerForWord(w.iriOrLiteral()) == 1) {
-                  globalId = GeoVocab::addMarker(globalId, 1);
-                }
-                mapping->emplace_back(localIdx, V(globalId));
-              }
+    auto writePartialVocabulary = [](auto& partialVocab,
+                                     const auto& tripleComponents,
+                                     IdMap* mapping) {
+      // write first partial vocabulary
+      partialVocab << tripleComponents.size();
+      size_t localIdx = 0;
+      for (auto w : tripleComponents) {
+        auto globalId = w.index_;
+        w.index_ = localIdx;
+        partialVocab << w;
+        if (mapping) {
+          if (w.isBlankNode({})) {
+            mapping->push_back(
+                {L(localIdx),
+                 Id::makeFromBlankNodeIndex(BlankNodeIndex::make(globalId))});
+          } else {
+            using GeoVocab = SplitGeoVocabulary<
+                CompressedVocabulary<VocabularyInternalExternal>>;
+            if (GeoVocab::getMarkerForWord(w.iriOrLiteral()) == 1) {
+              globalId = GeoVocab::addMarker(globalId, 1);
             }
-            localIdx++;
+            mapping->push_back({L(localIdx), V(globalId)});
           }
-        };
+        }
+        localIdx++;
+      }
+    };
     writePartialVocabulary(partial0, words0, &_expMapping0);
 
     writePartialVocabulary(partial1, words1, &_expMapping1);
@@ -327,11 +329,11 @@ TEST(MergeVocabulary, treatIrisAsBlankNodesViaRegex) {
   };
   IdMap idMap = getIdMapFromFile(idMapFile);
   EXPECT_THAT(idMap, ::testing::ElementsAreArray(
-                         IdMap{{0, V(0)},     // "bn_lit"
-                               {1, V(1)},     // <http://ex/apple>
-                               {2, BN(0)},    // <http://ex/bn_1>
-                               {3, BN(1)},    // <http://ex/bn_2>
-                               {4, V(2)}}));  // <http://ex/cherry>
+                         IdMap{{L(0), V(0)},     // "bn_lit"
+                               {L(1), V(1)},     // <http://ex/apple>
+                               {L(2), BN(0)},    // <http://ex/bn_1>
+                               {L(3), BN(1)},    // <http://ex/bn_2>
+                               {L(4), V(2)}}));  // <http://ex/cherry>
 }
 
 TEST(VocabularyGeneratorTest, createInternalMapping) {

--- a/test/VocabularyGeneratorTest.cpp
+++ b/test/VocabularyGeneratorTest.cpp
@@ -32,7 +32,7 @@ using namespace ad_utility::vocabulary_merger;
 namespace {
 auto V = ad_utility::testing::VocabId;
 // Shorthand for the local index that a word has inside a partial vocabulary.
-auto L = [](uint64_t index) { return VocabIndex::make(index); };
+auto L = &VocabIndex::make;
 
 // Write the given `words` as a partial vocabulary file at `path`, assigning
 // them consecutive local ids `0, 1, ...` in the given order and marking all of

--- a/test/index/CMakeLists.txt
+++ b/test/index/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(vocabulary)
+add_subdirectory(vocabulary_merger)
 addLinkAndDiscoverTest(PatternCreatorTest index)
 addLinkAndDiscoverTest(ScanSpecificationTest index)
 addLinkAndDiscoverTestNoLibs(KeyOrderTest)

--- a/test/index/vocabulary_merger/CMakeLists.txt
+++ b/test/index/vocabulary_merger/CMakeLists.txt
@@ -1,0 +1,1 @@
+addLinkAndDiscoverTest(IdMapTest index)

--- a/test/index/vocabulary_merger/IdMapTest.cpp
+++ b/test/index/vocabulary_merger/IdMapTest.cpp
@@ -1,0 +1,99 @@
+// Copyright 2026 The QLever Authors, in particular:
+//
+// 2026 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+//
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#include <absl/cleanup/cleanup.h>
+#include <gmock/gmock.h>
+
+#include <sstream>
+#include <string>
+
+#include "../../util/GTestHelpers.h"
+#include "../../util/IdTestHelpers.h"
+#include "backports/filesystem.h"
+#include "index/vocabulary_merger/IdMap.h"
+#include "util/File.h"
+
+using namespace ad_utility::vocabulary_merger;
+
+namespace {
+auto V = ad_utility::testing::VocabId;
+}  // namespace
+
+// _____________________________________________________________________________
+// Two `IdMapEntry`s are equal if and only if both of their members are equal.
+TEST(IdMapEntry, comparisonAndOutput) {
+  IdMapEntry entry{3, V(4)};
+  EXPECT_EQ(entry, (IdMapEntry{3, V(4)}));
+  EXPECT_NE(entry, (IdMapEntry{4, V(4)}));
+  EXPECT_NE(entry, (IdMapEntry{3, V(5)}));
+
+  // The output consists of the local index and the global ID (which brings its
+  // own `operator<<`), in braces.
+  std::ostringstream stream;
+  stream << entry;
+  EXPECT_THAT(stream.str(), ::testing::StartsWith("{3, "));
+  EXPECT_THAT(stream.str(), ::testing::EndsWith("}"));
+}
+
+// _____________________________________________________________________________
+// Test that an `IdMapWriter` writes exactly the format that
+// `getIdMapFromFile` expects, also for a number of pairs that by far exceeds
+// the internal buffer of the writer.
+TEST(IdMapWriter, writeAndReadBack) {
+  // Far more entries than fit into the internal buffer of the writer, such
+  // that the buffer has to be flushed many times.
+  const size_t numPairs = 200'000;
+  ASSERT_GT(numPairs * 16, 10 * IdMapWriter::bufferSize.getBytes());
+  IdMap expected;
+  expected.reserve(numPairs);
+  for (size_t i = 0; i < numPairs; ++i) {
+    expected.emplace_back(i, V(2 * i + 1));
+  }
+
+  std::string filename = gtestCurrentTestName();
+  absl::Cleanup cleanup = [&filename] { ad_utility::deleteFile(filename); };
+  {
+    IdMapWriter writer{filename};
+    for (const auto& pair : expected) {
+      writer.push_back(pair);
+    }
+  }
+  EXPECT_THAT(getIdMapFromFile(filename),
+              ::testing::ElementsAreArray(expected));
+  // The file consists of the number of entries (8 bytes), followed by the
+  // entries (16 bytes each). This is exactly the format of a serialized
+  // `IdMap`.
+  EXPECT_EQ(ql::filesystem::file_size(filename), 8 + 16 * numPairs);
+}
+
+// _____________________________________________________________________________
+// An `IdMapWriter` to which nothing was pushed yields an empty `IdMap`, and an
+// explicit call to `finish()` makes the file readable before the writer is
+// destroyed (and can be repeated without any effect).
+TEST(IdMapWriter, emptyAndExplicitFinish) {
+  std::string filename = gtestCurrentTestName();
+  absl::Cleanup cleanup = [&filename] { ad_utility::deleteFile(filename); };
+  {
+    IdMapWriter writer{filename};
+    writer.finish();
+    EXPECT_THAT(getIdMapFromFile(filename), ::testing::IsEmpty());
+    writer.finish();
+  }
+  EXPECT_THAT(getIdMapFromFile(filename), ::testing::IsEmpty());
+
+  {
+    IdMapWriter writer{filename};
+    writer.push_back({3, V(4)});
+    writer.finish();
+    EXPECT_THAT(getIdMapFromFile(filename),
+                ::testing::ElementsAre(IdMapEntry{3, V(4)}));
+  }
+  EXPECT_THAT(getIdMapFromFile(filename),
+              ::testing::ElementsAre(IdMapEntry{3, V(4)}));
+}

--- a/test/index/vocabulary_merger/IdMapTest.cpp
+++ b/test/index/vocabulary_merger/IdMapTest.cpp
@@ -23,21 +23,23 @@ using namespace ad_utility::vocabulary_merger;
 
 namespace {
 auto V = ad_utility::testing::VocabId;
+// Shorthand for the local index that a word has inside a partial vocabulary.
+auto L = [](uint64_t index) { return VocabIndex::make(index); };
 }  // namespace
 
 // _____________________________________________________________________________
 // Two `IdMapEntry`s are equal if and only if both of their members are equal.
 TEST(IdMapEntry, comparisonAndOutput) {
-  IdMapEntry entry{3, V(4)};
-  EXPECT_EQ(entry, (IdMapEntry{3, V(4)}));
-  EXPECT_NE(entry, (IdMapEntry{4, V(4)}));
-  EXPECT_NE(entry, (IdMapEntry{3, V(5)}));
+  IdMapEntry entry{L(3), V(4)};
+  EXPECT_EQ(entry, (IdMapEntry{L(3), V(4)}));
+  EXPECT_NE(entry, (IdMapEntry{L(4), V(4)}));
+  EXPECT_NE(entry, (IdMapEntry{L(3), V(5)}));
 
-  // The output consists of the local index and the global ID (which brings its
-  // own `operator<<`), in braces.
+  // The output consists of the local index and the global ID (both of which
+  // bring their own `operator<<`), in braces.
   std::ostringstream stream;
   stream << entry;
-  EXPECT_THAT(stream.str(), ::testing::StartsWith("{3, "));
+  EXPECT_THAT(stream.str(), ::testing::StartsWith("{VocabIndex:3, "));
   EXPECT_THAT(stream.str(), ::testing::EndsWith("}"));
 }
 
@@ -53,7 +55,7 @@ TEST(IdMapWriter, writeAndReadBack) {
   IdMap expected;
   expected.reserve(numPairs);
   for (size_t i = 0; i < numPairs; ++i) {
-    expected.emplace_back(i, V(2 * i + 1));
+    expected.push_back({L(i), V(2 * i + 1)});
   }
 
   std::string filename = gtestCurrentTestName();
@@ -89,11 +91,11 @@ TEST(IdMapWriter, emptyAndExplicitFinish) {
 
   {
     IdMapWriter writer{filename};
-    writer.push_back({3, V(4)});
+    writer.push_back({L(3), V(4)});
     writer.finish();
     EXPECT_THAT(getIdMapFromFile(filename),
-                ::testing::ElementsAre(IdMapEntry{3, V(4)}));
+                ::testing::ElementsAre(IdMapEntry{L(3), V(4)}));
   }
   EXPECT_THAT(getIdMapFromFile(filename),
-              ::testing::ElementsAre(IdMapEntry{3, V(4)}));
+              ::testing::ElementsAre(IdMapEntry{L(3), V(4)}));
 }

--- a/test/index/vocabulary_merger/IdMapTest.cpp
+++ b/test/index/vocabulary_merger/IdMapTest.cpp
@@ -24,7 +24,7 @@ using namespace ad_utility::vocabulary_merger;
 namespace {
 auto V = ad_utility::testing::VocabId;
 // Shorthand for the local index that a word has inside a partial vocabulary.
-auto L = [](uint64_t index) { return VocabIndex::make(index); };
+auto L = &VocabIndex::make;
 }  // namespace
 
 // _____________________________________________________________________________
@@ -51,7 +51,7 @@ TEST(IdMapWriter, writeAndReadBack) {
   // Far more entries than fit into the internal buffer of the writer, such
   // that the buffer has to be flushed many times.
   const size_t numPairs = 200'000;
-  ASSERT_GT(numPairs * 16, 10 * IdMapWriter::bufferSize.getBytes());
+  ASSERT_GT(numPairs * 16, 10 * idMapWriterBufferSize.getBytes());
   IdMap expected;
   expected.reserve(numPairs);
   for (size_t i = 0; i < numPairs; ++i) {
@@ -61,9 +61,9 @@ TEST(IdMapWriter, writeAndReadBack) {
   std::string filename = gtestCurrentTestName();
   absl::Cleanup cleanup = [&filename] { ad_utility::deleteFile(filename); };
   {
-    IdMapWriter writer{filename};
+    auto writer = makeIdMapWriter(filename);
     for (const auto& pair : expected) {
-      writer.push_back(pair);
+      writer.push(pair);
     }
   }
   EXPECT_THAT(getIdMapFromFile(filename),
@@ -82,7 +82,7 @@ TEST(IdMapWriter, emptyAndExplicitFinish) {
   std::string filename = gtestCurrentTestName();
   absl::Cleanup cleanup = [&filename] { ad_utility::deleteFile(filename); };
   {
-    IdMapWriter writer{filename};
+    auto writer = makeIdMapWriter(filename);
     writer.finish();
     EXPECT_THAT(getIdMapFromFile(filename), ::testing::IsEmpty());
     writer.finish();
@@ -90,8 +90,8 @@ TEST(IdMapWriter, emptyAndExplicitFinish) {
   EXPECT_THAT(getIdMapFromFile(filename), ::testing::IsEmpty());
 
   {
-    IdMapWriter writer{filename};
-    writer.push_back({L(3), V(4)});
+    auto writer = makeIdMapWriter(filename);
+    writer.push({L(3), V(4)});
     writer.finish();
     EXPECT_THAT(getIdMapFromFile(filename),
                 ::testing::ElementsAre(IdMapEntry{L(3), V(4)}));


### PR DESCRIPTION
This change is the first of several that refactor the vocabulary merge of the index build so that it can make efficient use of more threads. It contains the preparations that make the actual changes easier to read: the types and concepts of the vocabulary merger (`VocabularyMetaData`, `QueueWord`, the `IdMap` types, the callback concepts) move from `VocabularyMerger.h` into their own headers in `src/index/vocabulary_merger/`, where they can be tested on their own.

The entries of the `IdMap`s (the mapping from the local index of a word in a partial vocabulary to its global `Id`) are now buffered before they are written to their file, instead of one `write` call per 16-byte entry. For that, the `VectorIncrementalSerializer` can now also write through a `BufferedWriteSerializer` (new helper `serializeAtPosition`), and it gets proper move semantics. The key of an `IdMap` entry is now a plain `VocabIndex` instead of an `Id`, which is the precise type (a word in a partial vocabulary is always a `VocabIndex`) and saves the range check of `Id::makeFromVocabIndex` for each of the very many entries.

NOTE: The `IdMap` files are only used during the index build, so there is no change to the on-disk format of an index.