### PR TITLE
Add `unload-materialized-view` command

### DIFF
--- a/src/engine/MaterializedViews.cpp
+++ b/src/engine/MaterializedViews.cpp
@@ -548,15 +548,17 @@ void MaterializedViewsManager::loadView(const std::string& name,
 }
 
 // _____________________________________________________________________________
-void MaterializedViewsManager::unloadViewIfLoaded(
+bool MaterializedViewsManager::unloadViewIfLoaded(
     const std::string& name) const {
   auto lock = loadedViews_.wlock();
-  if (!lock->views_.contains(name)) {
-    return;
+  auto it = lock->views_.find(name);
+  if (it == lock->views_.end()) {
+    return false;
   }
-  lock->queryPatternCache_.removeView(lock->views_.at(name));
-  lock->views_.erase(name);
+  lock->queryPatternCache_.removeView(it->second);
+  lock->views_.erase(it);
   AD_LOG_INFO << "Materialized view \"" << name << "\" unloaded" << std::endl;
+  return true;
 }
 
 // _____________________________________________________________________________

--- a/src/engine/MaterializedViews.cpp
+++ b/src/engine/MaterializedViews.cpp
@@ -556,6 +556,7 @@ void MaterializedViewsManager::unloadViewIfLoaded(
   }
   lock->queryPatternCache_.removeView(lock->views_.at(name));
   lock->views_.erase(name);
+  AD_LOG_INFO << "Materialized view \"" << name << "\" unloaded" << std::endl;
 }
 
 // _____________________________________________________________________________

--- a/src/engine/MaterializedViews.cpp
+++ b/src/engine/MaterializedViews.cpp
@@ -551,12 +551,12 @@ void MaterializedViewsManager::loadView(const std::string& name,
 bool MaterializedViewsManager::unloadViewIfLoaded(
     const std::string& name) const {
   auto lock = loadedViews_.wlock();
-  auto it = lock->views_.find(name);
-  if (it == lock->views_.end()) {
+  auto view = ad_utility::findOptional(lock->views_, name);
+  if (!view.has_value()) {
     return false;
   }
-  lock->queryPatternCache_.removeView(it->second);
-  lock->views_.erase(it);
+  lock->queryPatternCache_.removeView(view.value());
+  lock->views_.erase(name);
   AD_LOG_INFO << "Materialized view \"" << name << "\" unloaded" << std::endl;
   return true;
 }

--- a/src/engine/MaterializedViews.h
+++ b/src/engine/MaterializedViews.h
@@ -421,9 +421,10 @@ class MaterializedViewsManager {
   // used by tests that do not care about it).
   void loadView(const std::string& name, QueryExecutionContext* qec) const;
 
-  // Unload a materialized view if it is loaded. This function is a no-op
-  // otherwise. It is `const` for the same reason described above.
-  void unloadViewIfLoaded(const std::string& name) const;
+  // Unload a materialized view if it is loaded and return `true`. Return
+  // `false` (and do nothing else) if it is not loaded. It is `const` for the
+  // same reason described above.
+  bool unloadViewIfLoaded(const std::string& name) const;
 
   // Delete a materialized view: unload it if loaded and delete all of its files
   // from disk. Throws if the view does not exist.

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -468,6 +468,18 @@ nlohmann::json Server::processDeleteMaterializedView(
 }
 
 // _____________________________________________________________________________
+nlohmann::json Server::processUnloadMaterializedView(
+    const ParamValueMap& parameters) const {
+  auto name =
+      qlever::http_api_helpers::getViewNameParameter(parameters, "Unloading");
+
+  // Fresh snapshot, see `processDeleteMaterializedView` above for why.
+  indexAndViewsSnapshot()->materializedViewsManager_.unloadViewIfLoaded(name);
+
+  return json{{"materialized-view-unloaded", name}};
+}
+
+// _____________________________________________________________________________
 CPP_template_def(typename RequestT)(
     requires ad_utility::httpUtils::HttpRequest<RequestT>)
     Server::ResponseT Server::processPing(std::optional<std::string> msg,
@@ -514,6 +526,7 @@ constexpr std::array commands = {
     CommandMeta{"load-materialized-view", "explicitly load materialized view",
                 true},
     CommandMeta{"delete-materialized-view", "delete materialized view", true},
+    CommandMeta{"unload-materialized-view", "unload materialized view", true},
 };
 
 // Throw a 403 `HttpError` if `accessTokenOk` is false; `actionName` names the
@@ -891,6 +904,11 @@ CPP_template_def(typename RequestT, typename SendT)(
     parsedHttpRequest.operation_ = None{};
   } else if (commandIs("delete-materialized-view")) {
     response = jsonResponse(processDeleteMaterializedView(parameters));
+    // Prevent regular query processing by removing the query from the
+    // request.
+    parsedHttpRequest.operation_ = None{};
+  } else if (commandIs("unload-materialized-view")) {
+    response = jsonResponse(processUnloadMaterializedView(parameters));
     // Prevent regular query processing by removing the query from the
     // request.
     parsedHttpRequest.operation_ = None{};

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -460,8 +460,8 @@ nlohmann::json Server::processDeleteMaterializedView(
   // above for the same pattern), so that the view is deleted from the index
   // that is currently being served and not from a stale one that a concurrent
   // rebuild has swapped out in the meantime. Deleting from a stale manager is
-  // not unsafe (the rebuild called `MaterializedViewsManager::retireOnDiskFiles`
-  // on it, which makes `deleteView` throw), it would just needlessly fail.
+  // not unsafe (rebuild called `MaterializedViewsManager::retireOnDiskFiles` on
+  // it, which makes `deleteView` throw), it would just needlessly fail.
   qlever().deleteMaterializedView(name);
 
   return json{{"materialized-view-deleted", name}};

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -455,14 +455,14 @@ nlohmann::json Server::processDeleteMaterializedView(
   auto name =
       qlever::http_api_helpers::getViewNameParameter(parameters, "Deleting");
 
-  // Snapshot again instead of reusing the snapshot taken at the beginning of
-  // `process()` (see `clear-delta-triples` above for the same pattern), so
-  // that we delete the view from the index that is currently being served
-  // and not from a stale one that a concurrent rebuild has swapped out in the
-  // meantime. Deleting from a stale manager is not unsafe (the rebuild called
-  // `MaterializedViewsManager::retireOnDiskFiles` on it, which makes
-  // `deleteView` throw), it would just needlessly fail.
-  indexAndViewsSnapshot()->materializedViewsManager_.deleteView(name);
+  // `Qlever::deleteMaterializedView` takes a fresh snapshot instead of reusing
+  // the one taken at the beginning of `process()` (see `clear-delta-triples`
+  // above for the same pattern), so that the view is deleted from the index
+  // that is currently being served and not from a stale one that a concurrent
+  // rebuild has swapped out in the meantime. Deleting from a stale manager is
+  // not unsafe (the rebuild called `MaterializedViewsManager::retireOnDiskFiles`
+  // on it, which makes `deleteView` throw), it would just needlessly fail.
+  qlever().deleteMaterializedView(name);
 
   return json{{"materialized-view-deleted", name}};
 }
@@ -473,10 +473,14 @@ nlohmann::json Server::processUnloadMaterializedView(
   auto name =
       qlever::http_api_helpers::getViewNameParameter(parameters, "Unloading");
 
-  // Fresh snapshot, see `processDeleteMaterializedView` above for why.
-  indexAndViewsSnapshot()->materializedViewsManager_.unloadViewIfLoaded(name);
+  // `Qlever::unloadMaterializedView` takes a fresh snapshot for the same reason
+  // as in `processDeleteMaterializedView` above (unloading from a stale
+  // manager would silently leave the view loaded in the served one). Report
+  // whether the view was actually loaded, so that a request with a wrong
+  // name does not look like a success.
+  bool wasLoaded = qlever().unloadMaterializedView(name);
 
-  return json{{"materialized-view-unloaded", name}};
+  return json{{"materialized-view-unloaded", name}, {"was-loaded", wasLoaded}};
 }
 
 // _____________________________________________________________________________

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -232,6 +232,10 @@ class Server {
   // `processLoadMaterializedView` above.
   json processDeleteMaterializedView(const ParamValueMap& parameters) const;
 
+  // Handle an `unload-materialized-view` command: unload the view named in
+  // `parameters` if loaded, keeping its on-disk files (unlike `delete`).
+  json processUnloadMaterializedView(const ParamValueMap& parameters) const;
+
   // Handle the `/ping` endpoint: log the alive check (with or without an
   // accompanying "msg" parameter) and return a fixed confirmation response.
   CPP_template(typename RequestT)(

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -233,7 +233,8 @@ class Server {
   json processDeleteMaterializedView(const ParamValueMap& parameters) const;
 
   // Handle an `unload-materialized-view` command: unload the view named in
-  // `parameters` if loaded, keeping its on-disk files (unlike `delete`).
+  // `parameters` if loaded, keeping its on-disk files (unlike `delete`). The
+  // response tells whether the view was loaded before.
   json processUnloadMaterializedView(const ParamValueMap& parameters) const;
 
   // Handle the `/ping` endpoint: log the alive check (with or without an

--- a/src/libqlever/Qlever.cpp
+++ b/src/libqlever/Qlever.cpp
@@ -435,9 +435,9 @@ bool Qlever::isMaterializedViewLoaded(const std::string& name) const {
 }
 
 // ___________________________________________________________________________
-void Qlever::unloadMaterializedView(const std::string& name) const {
+bool Qlever::unloadMaterializedView(const std::string& name) const {
   const auto indexAndViews = indexAndViewsSnapshot();
-  indexAndViews->materializedViewsManager_.unloadViewIfLoaded(name);
+  return indexAndViews->materializedViewsManager_.unloadViewIfLoaded(name);
 }
 
 // ___________________________________________________________________________

--- a/src/libqlever/Qlever.h
+++ b/src/libqlever/Qlever.h
@@ -540,8 +540,9 @@ class Qlever {
   void loadMaterializedView(std::string name) const;
 
   // Unload a materialized view that was previously loaded via
-  // `loadMaterializedView`. Has no effect if the view is not currently loaded.
-  void unloadMaterializedView(const std::string& name) const;
+  // `loadMaterializedView` and return `true`. Return `false` (and do nothing
+  // else) if the view is not currently loaded.
+  bool unloadMaterializedView(const std::string& name) const;
 
   // Check if a materialized view with the given name is currently loaded.
   bool isMaterializedViewLoaded(const std::string& name) const;

--- a/test/MaterializedViewsTest.cpp
+++ b/test/MaterializedViewsTest.cpp
@@ -999,6 +999,39 @@ TEST_F(MaterializedViewsTest, serverIntegration) {
             "Loading materialized view \"testViewFromHTTP2\" from disk"));
   }
 
+  // Unload a materialized view through a simulated HTTP GET request. Reuse
+  // one server instance so the unload actually observes a loaded view.
+  {
+    auto server = makeServerForTesting(testIndexBase_);
+    responseBodyAsJson(server.process(makeGetRequest(
+        "/?cmd=load-materialized-view&view-name=testViewFromHTTP2"
+        "&access-token=accessToken")));
+
+    clearLog();
+    auto response = responseBodyAsJson(server.process(makeGetRequest(
+        "/?cmd=unload-materialized-view&view-name=testViewFromHTTP2"
+        "&access-token=accessToken")));
+    EXPECT_THAT(response,
+                ::testing::Optional(::testing::Eq(nlohmann::json{
+                    {"materialized-view-unloaded", "testViewFromHTTP2"}})));
+
+    // The view's files remain on disk, unlike deletion.
+    EXPECT_TRUE(ql::filesystem::exists(
+        absl::StrCat(testIndexBase_, ".view.testViewFromHTTP2.viewinfo.json")));
+    EXPECT_THAT(log_.str(),
+                ::testing::HasSubstr(
+                    "Materialized view \"testViewFromHTTP2\" unloaded"));
+  }
+
+  // Test access token check for unloading.
+  {
+    auto request = makeGetRequest(
+        "/?cmd=unload-materialized-view&view-name=testViewFromHTTP2");
+    expectRequiresValidAccessToken("unload-materialized-view", [&] {
+      makeServerForTesting(testIndexBase_).process(request);
+    });
+  }
+
   // Test error message for wrong query type.
   {
     auto request = makePostRequest(

--- a/test/MaterializedViewsTest.cpp
+++ b/test/MaterializedViewsTest.cpp
@@ -625,9 +625,13 @@ TEST_F(MaterializedViewsTest, ManualConfigurations) {
   EXPECT_TRUE(manager.isViewLoaded("testView1"));
   EXPECT_FALSE(manager.isViewLoaded("something"));
 
-  // Unloading a view that is not loaded is a no-op.
-  manager.unloadViewIfLoaded("something");
+  // Unloading a view that is not loaded is a no-op, unloading a loaded view
+  // reports that it was loaded.
+  EXPECT_FALSE(manager.unloadViewIfLoaded("something"));
   EXPECT_FALSE(manager.isViewLoaded("something"));
+  EXPECT_TRUE(manager.unloadViewIfLoaded("testView1"));
+  EXPECT_FALSE(manager.isViewLoaded("testView1"));
+  EXPECT_FALSE(manager.unloadViewIfLoaded("testView1"));
   EXPECT_THAT(view->originalQuery(),
               ::testing::Optional(::testing::Eq(simpleWriteQuery_)));
 
@@ -1013,7 +1017,8 @@ TEST_F(MaterializedViewsTest, serverIntegration) {
         "&access-token=accessToken")));
     EXPECT_THAT(response,
                 ::testing::Optional(::testing::Eq(nlohmann::json{
-                    {"materialized-view-unloaded", "testViewFromHTTP2"}})));
+                    {"materialized-view-unloaded", "testViewFromHTTP2"},
+                    {"was-loaded", true}})));
 
     // The view's files remain on disk, unlike deletion.
     EXPECT_TRUE(ql::filesystem::exists(
@@ -1021,6 +1026,15 @@ TEST_F(MaterializedViewsTest, serverIntegration) {
     EXPECT_THAT(log_.str(),
                 ::testing::HasSubstr(
                     "Materialized view \"testViewFromHTTP2\" unloaded"));
+
+    // Unloading again is a no-op that reports the view as not loaded.
+    response = responseBodyAsJson(server.process(makeGetRequest(
+        "/?cmd=unload-materialized-view&view-name=testViewFromHTTP2"
+        "&access-token=accessToken")));
+    EXPECT_THAT(response,
+                ::testing::Optional(::testing::Eq(nlohmann::json{
+                    {"materialized-view-unloaded", "testViewFromHTTP2"},
+                    {"was-loaded", false}})));
   }
 
   // Test access token check for unloading.


### PR DESCRIPTION
So far, writing, loading and deleting a materialized view was possible via both the HTTP API and `libqlever`, while unloading one was only possible via `libqlever`. With this change, a view can also be unloaded via the HTTP API by requesting `/?cmd=unload-materialized-view&view-name=VIEW_NAME&access-token=ACCESS_TOKEN`. Unlike deletion, this keeps the view's files on disk, so the view can be loaded again later.