### PR TITLE
Automatically load materialized views after successful write

### DIFF
--- a/src/engine/MaterializedViews.cpp
+++ b/src/engine/MaterializedViews.cpp
@@ -139,7 +139,7 @@ void MaterializedViewsManager::writeViewToDisk(
   MaterializedViewWriter writer{onDiskBase_, std::move(name), plannedQuery,
                                 std::move(memoryLimit), std::move(allocator)};
   writer.computeResultAndWritePermutation();
-  loadView(writer.name_, const_cast<QueryExecutionContext*>(writer.qec_.get()));
+  loadView(writer.name_, writer.qec_.get());
 }
 
 // _____________________________________________________________________________
@@ -524,7 +524,7 @@ void MaterializedView::connectPermutationBackReference() {
 std::shared_ptr<MaterializedView>
 MaterializedViewsManager::loadViewIntoLockedState(
     const std::string& name, LoadedViews& state,
-    QueryExecutionContext* qec) const {
+    const QueryExecutionContext* qec) const {
   if (auto it = state.views_.find(name); it != state.views_.end()) {
     return it->second;
   }
@@ -542,8 +542,8 @@ MaterializedViewsManager::loadViewIntoLockedState(
 }
 
 // _____________________________________________________________________________
-void MaterializedViewsManager::loadView(const std::string& name,
-                                        QueryExecutionContext* qec) const {
+void MaterializedViewsManager::loadView(
+    const std::string& name, const QueryExecutionContext* qec) const {
   auto lock = loadedViews_.wlock();
   loadViewIntoLockedState(name, *lock, qec);
 }
@@ -604,7 +604,7 @@ void MaterializedViewsManager::deleteView(const std::string& name) const {
 
 // _____________________________________________________________________________
 std::shared_ptr<const MaterializedView> MaterializedViewsManager::getView(
-    const std::string& name, QueryExecutionContext* qec) const {
+    const std::string& name, const QueryExecutionContext* qec) const {
   auto lock = loadedViews_.wlock();
   return loadViewIntoLockedState(name, *lock, qec);
 }
@@ -921,7 +921,8 @@ std::optional<size_t> MaterializedView::lookupBindTargetColumn(
 
 // _____________________________________________________________________________
 MaterializedView::CacheKeyWithAndWithoutInvariantPatterns
-MaterializedView::computeCacheKey(QueryExecutionContext* qecOriginal) const {
+MaterializedView::computeCacheKey(
+    const QueryExecutionContext* qecOriginal) const {
   if (qecOriginal == nullptr || !originalQuery_.has_value()) {
     return {std::nullopt, std::nullopt};
   }

--- a/src/engine/MaterializedViews.cpp
+++ b/src/engine/MaterializedViews.cpp
@@ -139,6 +139,7 @@ void MaterializedViewsManager::writeViewToDisk(
   MaterializedViewWriter writer{onDiskBase_, std::move(name), plannedQuery,
                                 std::move(memoryLimit), std::move(allocator)};
   writer.computeResultAndWritePermutation();
+  loadView(writer.name_, const_cast<QueryExecutionContext*>(writer.qec_.get()));
 }
 
 // _____________________________________________________________________________

--- a/src/engine/MaterializedViews.h
+++ b/src/engine/MaterializedViews.h
@@ -285,7 +285,7 @@ class MaterializedView : public std::enable_shared_from_this<MaterializedView> {
     std::optional<CacheKeyAndColumnMapping> withoutInvariants_;
   };
   CacheKeyWithAndWithoutInvariantPatterns computeCacheKey(
-      QueryExecutionContext* qec) const;
+      const QueryExecutionContext* qec) const;
 
   // If the materialized view contains a top-level `BIND` statement where the
   // expression matches the given cache key, return the column index of the
@@ -369,7 +369,7 @@ class MaterializedViewsManager {
   // view atomically with loading it, without releasing the lock in between).
   std::shared_ptr<MaterializedView> loadViewIntoLockedState(
       const std::string& name, LoadedViews& state,
-      QueryExecutionContext* qec) const;
+      const QueryExecutionContext* qec) const;
 
  public:
   MaterializedViewsManager() = default;
@@ -419,7 +419,8 @@ class MaterializedViewsManager {
   // `qec` is forwarded to `MaterializedView::computeCacheKey` for cache-key
   // based query rewriting; passing `nullptr` skips that analysis (currently
   // used by tests that do not care about it).
-  void loadView(const std::string& name, QueryExecutionContext* qec) const;
+  void loadView(const std::string& name,
+                const QueryExecutionContext* qec) const;
 
   // Unload a materialized view if it is loaded. This function is a no-op
   // otherwise. It is `const` for the same reason described above.
@@ -433,7 +434,7 @@ class MaterializedViewsManager {
   // is never `nullptr`. If the view does not exist, the function throws. See
   // `loadView` above for details on the use of the `QueryExecutionContext`.
   std::shared_ptr<const MaterializedView> getView(
-      const std::string& name, QueryExecutionContext* qec) const;
+      const std::string& name, const QueryExecutionContext* qec) const;
 
   // The same as `MaterializedView::makeIndexScan` above, but load and use the
   // right view automatically as requested in the `MaterializedViewQuery`.

--- a/src/engine/MaterializedViews.h
+++ b/src/engine/MaterializedViews.h
@@ -458,7 +458,7 @@ class MaterializedViewsManager {
 
   // Write a `MaterializedView` given a valid `name` (consisting only of
   // alphanumerics and hyphens) and a `plannedQuery` to be executed. The query's
-  // result is written to the view.
+  // result is written to the view. The view is then loaded automatically.
   //
   // If a view with the same name is already loaded, it is unloaded before
   // writing.

--- a/src/engine/MaterializedViewsQueryAnalysis.cpp
+++ b/src/engine/MaterializedViewsQueryAnalysis.cpp
@@ -252,7 +252,8 @@ QueryPatternCache::makeJoinReplacementIndexScans(
 }
 
 // _____________________________________________________________________________
-bool QueryPatternCache::analyzeView(ViewPtr view, QueryExecutionContext* qec) {
+bool QueryPatternCache::analyzeView(ViewPtr view,
+                                    const QueryExecutionContext* qec) {
   auto explainIgnore = [&](const std::string& reason) {
     AD_LOG_INFO << "Materialized view '" << view->name()
                 << "' will not be added to the query pattern cache for "

--- a/src/engine/MaterializedViewsQueryAnalysis.h
+++ b/src/engine/MaterializedViewsQueryAnalysis.h
@@ -98,7 +98,7 @@ class QueryPatternCache {
   // Given a materialized view, analyze the query it was created from and
   // populate the cache. This is called from
   // `MaterializedViewsManager::loadView`.
-  bool analyzeView(ViewPtr view, QueryExecutionContext* qec);
+  bool analyzeView(ViewPtr view, const QueryExecutionContext* qec);
 
   // Remove all pointers to a view from this `QueryPatternCache`. This is
   // required for unloading materialized views. A call to this function with a

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -1613,8 +1613,9 @@ void IndexImpl::readIndexBuilderSettingsFromFile() {
                   << std::endl;
     }
     AD_LOG_INFO << "You specified \"locale = " << lang << "_" << country
-                << "\" " << "and \"ignore-punctuation = " << ignorePunctuation
-                << "\"" << std::endl;
+                << "\" "
+                << "and \"ignore-punctuation = " << ignorePunctuation << "\""
+                << std::endl;
 
     if (lang != LOCALE_DEFAULT_LANG || country != LOCALE_DEFAULT_COUNTRY) {
       AD_LOG_WARN

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -1613,9 +1613,8 @@ void IndexImpl::readIndexBuilderSettingsFromFile() {
                   << std::endl;
     }
     AD_LOG_INFO << "You specified \"locale = " << lang << "_" << country
-                << "\" "
-                << "and \"ignore-punctuation = " << ignorePunctuation << "\""
-                << std::endl;
+                << "\" " << "and \"ignore-punctuation = " << ignorePunctuation
+                << "\"" << std::endl;
 
     if (lang != LOCALE_DEFAULT_LANG || country != LOCALE_DEFAULT_COUNTRY) {
       AD_LOG_WARN

--- a/test/MaterializedViewsCacheKeyRewriteTest.cpp
+++ b/test/MaterializedViewsCacheKeyRewriteTest.cpp
@@ -31,7 +31,6 @@ TEST_F(MaterializedViewsCacheKeyRewriteTest, CacheKeyRewrite) {
     auto trace = generateLocationTrace(sourceLocation);
     EXPECT_EQ(getQueryResultAsIdTable(query).numRows(), expectedRows);
     qlv().writeMaterializedView(name, query);
-    qlv().loadMaterializedView(name);
     // The view is always detected if the user query is exactly the view query.
     qpExpect<false>(qlv(), query, qpMatcher);
   };

--- a/test/MaterializedViewsPatternRewriteTest.cpp
+++ b/test/MaterializedViewsPatternRewriteTest.cpp
@@ -425,7 +425,6 @@ TEST_P(MaterializedViewsPatternRewriteTestP, simpleChain) {
 
   // Write a chain structure to the materialized view.
   qlv.writeMaterializedView(viewName, writeQuery);
-  qlv.loadMaterializedView(viewName);
   auto chainView = std::bind_front(&viewScanSimple, viewName);
 
   // With the materialized view loaded, an index scan on the view is performed
@@ -441,7 +440,6 @@ TEST_P(MaterializedViewsPatternRewriteTestP, simpleChain) {
   // If the view is sorted such that the subject of the chain is not the first
   // column, rewriting cannot be applied with a fixed subject.
   qlv.writeMaterializedView(viewName, std::string{simpleChainDifferentSort});
-  qlv.loadMaterializedView(viewName);
   qpExpect(qlv, simpleChainFixed,
            h::Join(h::IndexScanFromStrings("<s2>", "<p1>",
                                            "?_QLever_internal_variable_qp_0"),
@@ -472,7 +470,6 @@ INSTANTIATE_TEST_SUITE_P(
 TEST_F(MaterializedViewsPatternRewriteContextTest,
        DegenerateChainsAndGraphClause) {
   qlv().writeMaterializedView("testViewChain", std::string{simpleChain});
-  qlv().loadMaterializedView("testViewChain");
 
   // A degenerate chain (`?a <p1> ?b . ?b <p2> ?a`) must be rejected for
   // rewriting (thus planned normally).

--- a/test/MaterializedViewsTest.cpp
+++ b/test/MaterializedViewsTest.cpp
@@ -72,17 +72,13 @@ TEST_F(MaterializedViewsTest, Basic) {
   EXPECT_THAT(
       log_.str(),
       ::testing::HasSubstr("Materialized view \"testView1\" written to disk"));
-  EXPECT_FALSE(qlv().isMaterializedViewLoaded("testView1"));
-  qlv().loadMaterializedView("testView1");
   EXPECT_THAT(log_.str(),
               ::testing::HasSubstr(
                   "Loading materialized view \"testView1\" from disk"));
   EXPECT_TRUE(qlv().isMaterializedViewLoaded("testView1"));
 
-  // Overwriting a materialized view automatically unloads it first.
+  // Overwriting a materialized view automatically unloads and reloads it.
   qlv().writeMaterializedView("testView1", simpleWriteQuery_);
-  EXPECT_FALSE(qlv().isMaterializedViewLoaded("testView1"));
-  qlv().loadMaterializedView("testView1");
   EXPECT_TRUE(qlv().isMaterializedViewLoaded("testView1"));
 
   // Test index scan on materialized view.
@@ -164,7 +160,6 @@ TEST_F(MaterializedViewsTest, Basic) {
   // Join between index scan on view and regular index scan.
   qlv().writeMaterializedView(
       "testView2", "SELECT * { ?s <p1> ?o . BIND(42 AS ?g) . BIND(3 AS ?x) }");
-  qlv().loadMaterializedView("testView2");
   {
     auto plannedQuery = qlv().parseAndPlanQuery(R"(
       PREFIX view: <https://qlever.cs.uni-freiburg.de/materializedView/>
@@ -186,12 +181,10 @@ TEST_F(MaterializedViewsTest, ViewReferencingAnotherViewDoesNotDeadlock) {
   // detected and skipped instead (see `MaterializedView::computeCacheKey`).
   // The view must still load successfully and remain usable.
   qlv().writeMaterializedView("baseView", simpleWriteQuery_);
-  qlv().loadMaterializedView("baseView");
   qlv().writeMaterializedView("outerView", R"(
       PREFIX view: <https://qlever.cs.uni-freiburg.de/materializedView/>
       SELECT * { ?s view:baseView-g ?x }
     )");
-  qlv().loadMaterializedView("outerView");
   EXPECT_TRUE(qlv().isMaterializedViewLoaded("outerView"));
 
   auto plannedQuery = qlv().parseAndPlanQuery(R"(
@@ -212,7 +205,6 @@ TEST_F(MaterializedViewsTest, ExplicitReferenceWorksWhenAutoRewriteDisabled) {
   // views. It must not affect an *explicit* reference to a view (via the
   // `view:<name>-<column>` predicate or the `SERVICE` syntax).
   qlv().writeMaterializedView("testView1", simpleWriteQuery_);
-  qlv().loadMaterializedView("testView1");
 
   auto cleanup = setRuntimeParameterForTest<
       &RuntimeParameters::enableMaterializedViewQueryRewrite_>(false);
@@ -821,6 +813,9 @@ TEST_F(MaterializedViewsTest, ManualConfigurations) {
       ad_utility::makeOfstream(metadataFilename)
           << viewInfo.dump() << std::endl;
     }
+    // Force a fresh load from the (now hand-edited) disk file:
+    // `writeViewToDisk` already auto-loaded the view before the edit above.
+    manager.unloadViewIfLoaded("testView6");
     // Load the view: It can be loaded correctly, but does not have an original
     // query set.
     auto view = manager.getView("testView6", nullptr);
@@ -844,6 +839,9 @@ TEST_F(MaterializedViewsTest, ManualConfigurations) {
       ad_utility::makeOfstream(metadataFilename)
           << viewInfo.dump() << std::endl;
     }
+    // Force a fresh load from the (now hand-edited) disk file:
+    // `writeViewToDisk` already auto-loaded the view before the edit above.
+    manager.unloadViewIfLoaded("testView7");
     // Load the view: The view can be loaded correctly, but all columns are
     // possibly undefined because the information is missing.
     auto view = manager.getView("testView7", nullptr);
@@ -1329,7 +1327,6 @@ TEST_F(MaterializedViewsTest, NoDuplicateRemovalOnScan) {
   const std::string dupQuery =
       "SELECT ?s ?p ?o ?g { ?s ?p ?o . VALUES ?g { 1 2 } }";
   qlv().writeMaterializedView("dupView", dupQuery);
-  qlv().loadMaterializedView("dupView");
 
   // Base case: Query the view selecting all 4 columns: we expect exactly the
   // original result.
@@ -1408,7 +1405,6 @@ TEST_F(MaterializedViewsTest, DistinctIsNotDroppedForViewScan) {
   // values of the fourth column `?g` (which we do not select below).
   qlv().writeMaterializedView(
       "dupView", "SELECT ?s ?p ?o ?g { ?s ?p ?o . VALUES ?g { 1 2 } }");
-  qlv().loadMaterializedView("dupView");
 
   constexpr std::string_view distinctQuery = R"(
     PREFIX view: <https://qlever.cs.uni-freiburg.de/materializedView/>
@@ -1448,7 +1444,6 @@ constexpr std::string_view bindWriteQuery =
 // _____________________________________________________________________________
 TEST_F(MaterializedViewsTest, BindRewrite) {
   qlv().writeMaterializedView("bindView", std::string{bindWriteQuery});
-  qlv().loadMaterializedView("bindView");
 
   // We fix the first columns of the `IndexScan` matcher because we are only
   // interested in the additional columns. The number of columns after stripping
@@ -1672,7 +1667,6 @@ TEST_F(MaterializedViewsTest, BindRewrite) {
     qlv().writeMaterializedView(
         "bindView2",
         "SELECT ?a ?b ?c { <s1> <p2> ?a . BIND(2 * ?a AS ?b) BIND(42 AS ?c) }");
-    qlv().loadMaterializedView("bindView2");
     const std::string secondColBind = R"(
       PREFIX view: <https://qlever.cs.uni-freiburg.de/materializedView/>
       SELECT * {
@@ -1824,7 +1818,6 @@ TEST(MaterializedViewsSpatialJoinTest, BoundingBoxBindRewrite) {
 
   // Write geometries view with bounding boxes.
   qlv.writeMaterializedView(viewName, std::string{geoBoundingBoxesViewQuery});
-  qlv.loadMaterializedView(viewName);
 
   // Running the same query for reading that was used for writing results in a
   // single `IndexScan` for all columns of the materialized view.
@@ -1926,7 +1919,6 @@ TEST(MaterializedViewsSpatialJoinTest, FixedValueFilterOnFullyCoveredView) {
       "  ?osm_id geo:hasGeometry ?intermediate .\n"
       "  ?intermediate geo:asWKT ?geometry .\n"
       "}");
-  qlv.loadMaterializedView(viewName);
 
   const std::string query = R"qy(
     PREFIX geo: <http://www.opengis.net/ont/geosparql#>
@@ -2108,11 +2100,10 @@ TEST_F(MaterializedViewsTest, GroupByOptimizations) {
 // _____________________________________________________________________________
 TEST_F(MaterializedViewsTest,
        GetPermutationForThreeVariableTripleMaterializedView) {
-  // Write and load a three-variable view.
+  // Write a three-variable view (writing auto-loads it).
   auto plan = qlv().parseAndPlanQuery("SELECT ?s ?p ?o { ?s ?p ?o }");
   MaterializedViewsManager manager{testIndexBase_};
   manager.writeViewToDisk("threeVarPermTestView", plan);
-  manager.loadView("threeVarPermTestView", nullptr);
 
   // Create a three-variable scan on the view binding all three columns.
   using RCols = parsedQuery::MaterializedViewQuery::RequestedColumns;

--- a/test/MaterializedViewsTestHelpers.h
+++ b/test/MaterializedViewsTestHelpers.h
@@ -372,7 +372,6 @@ inline void expectRewrite(
     source_location sourceLocation = AD_CURRENT_SOURCE_LOC()) {
   auto trace = generateLocationTrace(sourceLocation);
   qlv.writeMaterializedView(std::string{viewName}, std::string{viewQuery});
-  qlv.loadMaterializedView(std::string{viewName});
   qpExpect(qlv, testQuery, matcher, sourceLocation);
 };
 


### PR DESCRIPTION
So far, a materialized view was not loaded automatically after it was successfully written, and thus also not used for query rewriting until it was loaded explicitly via `load-materialized-view`. This was confusing. With this change, a view is loaded automatically right after it has been written. An explicit `load-materialized-view` afterwards is now unnecessary but harmless.

NOTE: Views were deliberately not auto-loaded so far because there was no way to unload a view via the HTTP API. That is now possible via `unload-materialized-view`, see #3353.