### PR TITLE
Add a `--num-threads` option to `qlever-index`

### DIFF
--- a/src/index/ConstantsIndexBuilding.h
+++ b/src/index/ConstantsIndexBuilding.h
@@ -61,14 +61,14 @@ constexpr inline std::string_view PARTIAL_VOCAB_IDMAP_INFIX =
 constexpr inline std::string_view QLEVER_INTERNAL_INDEX_INFIX = ".internal";
 
 // _________________________________________________________________
-// The default value for the total number of threads that the first phase of
-// the index build (parsing the input and building the partial vocabularies)
-// uses: the number of hardware threads of this machine, or `1` if that number
-// cannot be determined. It can be overridden via `--concurrency-level`, see
-// `IndexBuilderMain.cpp`. The threads are divided among the consumers of this
-// value, each of which computes its own share: see `numItemMapThreads` in
-// `IndexImpl.cpp` and `detail::numParserThreads` in `RdfParser.h`.
-inline uint32_t DEFAULT_CONCURRENCY_LEVEL() {
+// The default value for the number of threads that the index build uses for
+// the steps that run in parallel: the number of hardware threads of this
+// machine, or `1` if that number cannot be determined. It can be overridden
+// via `--num-threads`, see `IndexBuilderMain.cpp`. The threads are divided
+// among the consumers of this value, each of which computes its own share:
+// see `numItemMapThreads` in `IndexImpl.cpp` and `detail::numParserThreads`
+// in `RdfParser.h`.
+inline uint32_t DEFAULT_NUM_THREADS() {
   return std::max(1u, std::thread::hardware_concurrency());
 }
 

--- a/src/index/ConstantsIndexBuilding.h
+++ b/src/index/ConstantsIndexBuilding.h
@@ -63,13 +63,36 @@ constexpr inline std::string_view QLEVER_INTERNAL_INDEX_INFIX = ".internal";
 // _________________________________________________________________
 // The default value for the number of threads that the index build uses for
 // the steps that run in parallel: the number of hardware threads of this
-// machine, or `1` if that number cannot be determined. It can be overridden
-// via `--num-threads`, see `IndexBuilderMain.cpp`. The threads are divided
-// among the consumers of this value, each of which computes its own share:
-// see `numItemMapThreads` in `IndexImpl.cpp` and `detail::numParserThreads`
-// in `RdfParser.h`.
-inline uint32_t DEFAULT_NUM_THREADS() {
+// machine (including SMT threads, and regardless of the CPU limits of a
+// container), or `1` if that number cannot be determined. It can be
+// overridden via `--num-threads`, see `IndexBuilderMain.cpp`. The two
+// functions below divide this number between the two steps that currently run
+// in parallel.
+inline uint32_t defaultNumThreads() {
   return std::max(1u, std::thread::hardware_concurrency());
+}
+
+// The number of worker threads that build the partial vocabularies via hash
+// maps, given the total number of threads `numThreads` for the index build.
+// Building the hash maps is roughly half as expensive as parsing, so the item
+// maps get about a third of the threads (the rest goes to the parsers, see
+// `numParserThreads` below). At least two threads are used.
+inline size_t numItemMapThreads(uint32_t numThreads) {
+  return std::max<size_t>(2, (numThreads + 1) / 3);
+}
+
+// The number of threads that a parallel parser uses, given the total number of
+// threads `numThreads` for the index build: the threads that are left after
+// `numItemMapThreads`, but at least two.
+//
+// NOTE: The subtraction is saturating, because on machines with very few
+// hardware threads `numItemMapThreads` may exceed `numThreads`. Because of the
+// minimum of two for both functions, fewer than four threads in total are
+// never used.
+inline size_t numParserThreads(uint32_t numThreads) {
+  return std::max<size_t>(
+      2,
+      numThreads - std::min<size_t>(numThreads, numItemMapThreads(numThreads)));
 }
 
 // Increasing the following two constants increases the RAM usage without much

--- a/src/index/ConstantsIndexBuilding.h
+++ b/src/index/ConstantsIndexBuilding.h
@@ -77,22 +77,24 @@ inline uint32_t defaultNumThreads() {
 // Building the hash maps is roughly half as expensive as parsing, so the item
 // maps get about a third of the threads (the rest goes to the parsers, see
 // `numParserThreads` below). At least two threads are used.
-inline size_t numItemMapThreads(uint32_t numThreads) {
-  return std::max<size_t>(2, (numThreads + 1) / 3);
+inline uint32_t numItemMapThreads(uint32_t numThreads) {
+  return std::max<uint32_t>(2, (numThreads + 1) / 3);
 }
 
-// The number of threads that a parallel parser uses, given the total number of
+// The number of threads that are used for parsing, given the total number of
 // threads `numThreads` for the index build: the threads that are left after
-// `numItemMapThreads`, but at least two.
+// `numItemMapThreads`, but at least two. When several input files are parsed
+// concurrently, these threads are divided among them, see
+// `numParserThreadsPerFile` in `IndexImpl.cpp`.
 //
 // NOTE: The subtraction is saturating, because on machines with very few
 // hardware threads `numItemMapThreads` may exceed `numThreads`. Because of the
 // minimum of two for both functions, fewer than four threads in total are
 // never used.
-inline size_t numParserThreads(uint32_t numThreads) {
-  return std::max<size_t>(
-      2,
-      numThreads - std::min<size_t>(numThreads, numItemMapThreads(numThreads)));
+inline uint32_t numParserThreads(uint32_t numThreads) {
+  return std::max<uint32_t>(
+      2, numThreads -
+             std::min<uint32_t>(numThreads, numItemMapThreads(numThreads)));
 }
 
 // Increasing the following two constants increases the RAM usage without much

--- a/src/index/ConstantsIndexBuilding.h
+++ b/src/index/ConstantsIndexBuilding.h
@@ -5,9 +5,11 @@
 #ifndef QLEVER_SRC_INDEX_CONSTANTSINDEXBUILDING_H
 #define QLEVER_SRC_INDEX_CONSTANTSINDEXBUILDING_H
 
+#include <algorithm>
 #include <atomic>
 #include <cstdint>
 #include <string>
+#include <thread>
 
 #include "util/MemorySize/MemorySize.h"
 
@@ -59,15 +61,16 @@ constexpr inline std::string_view PARTIAL_VOCAB_IDMAP_INFIX =
 constexpr inline std::string_view QLEVER_INTERNAL_INDEX_INFIX = ".internal";
 
 // _________________________________________________________________
-// The degree of parallelism that is used for the index building step, where the
-// unique elements of the vocabulary are identified via hash maps. Typically, 6
-// is a good value. On systems with very few CPUs, a lower value might be
-// beneficial.
-constexpr inline size_t NUM_PARALLEL_ITEM_MAPS = 10;
-
-// The number of threads that are parsing in parallel, when the parallel Turtle
-// parser is used.
-constexpr inline size_t NUM_PARALLEL_PARSER_THREADS = 8;
+// The default value for the total number of threads that the first phase of
+// the index build (parsing the input and building the partial vocabularies)
+// uses: the number of hardware threads of this machine, or `1` if that number
+// cannot be determined. It can be overridden via `--concurrency-level`, see
+// `IndexBuilderMain.cpp`. The threads are divided among the consumers of this
+// value, each of which computes its own share: see `numItemMapThreads` in
+// `IndexImpl.cpp` and `detail::numParserThreads` in `RdfParser.h`.
+inline uint32_t DEFAULT_CONCURRENCY_LEVEL() {
+  return std::max(1u, std::thread::hardware_concurrency());
+}
 
 // Increasing the following two constants increases the RAM usage without much
 // benefit to the performance.

--- a/src/index/IndexBuilderMain.cpp
+++ b/src/index/IndexBuilderMain.cpp
@@ -308,14 +308,11 @@ int main(int argc, char** argv) {
   add("parser-buffer-size,b", po::value(&config.parserBufferSize_),
       "The size of the buffer used for parsing the input files. This must be "
       "large enough to hold a single input triple. Default: 10 MB.");
-  add("concurrency-level",
-      po::value(&config.concurrencyLevel_)
-          ->default_value(DEFAULT_CONCURRENCY_LEVEL()),
-      "The total number of threads used for parsing the input and building the "
-      "partial vocabularies. About a third of them build the partial "
-      "vocabularies and the remaining two thirds parse the input (each of the "
-      "two gets at least two threads). The default is the number of hardware "
-      "threads of this machine.");
+  add("num-threads,j",
+      po::value(&config.numThreads_)->default_value(DEFAULT_NUM_THREADS()),
+      "The number of threads that the index build uses for the steps that run "
+      "in parallel. The default is the number of hardware threads of this "
+      "machine.");
   add("keep-temporary-files,k", po::bool_switch(&config.keepTemporaryFiles_),
       "Do not delete temporary files from index creation for debugging.");
   add("materialized-views", po::value(&materializedViewsJson),

--- a/src/index/IndexBuilderMain.cpp
+++ b/src/index/IndexBuilderMain.cpp
@@ -308,6 +308,14 @@ int main(int argc, char** argv) {
   add("parser-buffer-size,b", po::value(&config.parserBufferSize_),
       "The size of the buffer used for parsing the input files. This must be "
       "large enough to hold a single input triple. Default: 10 MB.");
+  add("concurrency-level",
+      po::value(&config.concurrencyLevel_)
+          ->default_value(DEFAULT_CONCURRENCY_LEVEL()),
+      "The total number of threads used for parsing the input and building the "
+      "partial vocabularies. About a third of them build the partial "
+      "vocabularies and the remaining two thirds parse the input (each of the "
+      "two gets at least two threads). The default is the number of hardware "
+      "threads of this machine.");
   add("keep-temporary-files,k", po::bool_switch(&config.keepTemporaryFiles_),
       "Do not delete temporary files from index creation for debugging.");
   add("materialized-views", po::value(&materializedViewsJson),

--- a/src/index/IndexBuilderMain.cpp
+++ b/src/index/IndexBuilderMain.cpp
@@ -309,10 +309,11 @@ int main(int argc, char** argv) {
       "The size of the buffer used for parsing the input files. This must be "
       "large enough to hold a single input triple. Default: 10 MB.");
   add("num-threads,j",
-      po::value(&config.numThreads_)->default_value(DEFAULT_NUM_THREADS()),
+      po::value(&config.numThreads_)->default_value(defaultNumThreads()),
       "The number of threads that the index build uses for the steps that run "
       "in parallel. The default is the number of hardware threads of this "
-      "machine.");
+      "machine (including SMT threads, and regardless of the CPU limits of a "
+      "container). Values below 4 still use 4 threads.");
   add("keep-temporary-files,k", po::bool_switch(&config.keepTemporaryFiles_),
       "Do not delete temporary files from index creation for debugging.");
   add("materialized-views", po::value(&materializedViewsJson),

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -102,8 +102,8 @@ std::unique_ptr<RdfParserBase> IndexImpl::makeRdfParser(
       memoryLimitIndexBuilding().getBytes() > 0,
       " memory limit for index building must be greater than zero");
   return std::make_unique<RdfMultifileParser>(
-      std::move(files), &encodedIriManager(), concurrencyLevel_,
-      parserBufferSize(), onlyAsciiTurtlePrefixes_);
+      std::move(files), &encodedIriManager(), numThreads_, parserBufferSize(),
+      onlyAsciiTurtlePrefixes_);
 }
 
 // Several helper functions for joining the OSP permutation with the patterns.
@@ -505,14 +505,14 @@ namespace {
 using IdRow = std::array<Id, NumColumnsIndexBuilding>;
 
 // The number of worker threads that build the partial vocabularies via hash
-// maps, given the total number of threads `concurrencyLevel` available for the
-// first phase of the index build (see `DEFAULT_CONCURRENCY_LEVEL`). Building
-// the hash maps is roughly half as expensive as parsing, so the item maps get
-// about a third of the threads and the parsers the remaining two thirds (see
-// `detail::numParserThreads` in `RdfParser.h`, which must agree with the split
-// computed here). At least two threads are used.
-size_t numItemMapThreads(uint32_t concurrencyLevel) {
-  return std::max<size_t>(2, (concurrencyLevel + 1) / 3);
+// maps, given the total number of threads `numThreads` available for the index
+// build (see `DEFAULT_NUM_THREADS`). Building the hash maps is roughly half as
+// expensive as parsing, so the item maps get about a third of the threads and
+// the parsers the remaining two thirds (see `detail::numParserThreads` in
+// `RdfParser.h`, which must agree with the split computed here). At least two
+// threads are used.
+size_t numItemMapThreads(uint32_t numThreads) {
+  return std::max<size_t>(2, (numThreads + 1) / 3);
 }
 }  // namespace
 
@@ -588,9 +588,9 @@ BuildPartialVocabulariesResult IndexImpl::buildPartialVocabularies(
   parser->invalidLiteralsAreSkipped() = turtleParserSkipIllegalLiterals_;
   AD_LOG_INFO << "Parsing input triples and creating partial vocabularies, one "
                  "per batch, using "
-              << numItemMapThreads(concurrencyLevel_) << " worker threads and "
-              << detail::numParserThreads(concurrencyLevel_)
-              << " parser threads ..." << std::endl;
+              << numItemMapThreads(numThreads_) << " worker threads and "
+              << detail::numParserThreads(numThreads_) << " parser threads ..."
+              << std::endl;
 
   // Show progress and statistics for the number of triples parsed. The total
   // number of triples is not known in advance, and the workers report their
@@ -604,7 +604,7 @@ BuildPartialVocabulariesResult IndexImpl::buildPartialVocabularies(
   std::atomic<size_t> numHasWordTriples = 0;
 
   using WorkerResult = BuildPartialVocabulariesResult::WorkerResult;
-  auto tasks = ad_utility::integerRange(numItemMapThreads(concurrencyLevel_)) |
+  auto tasks = ad_utility::integerRange(numItemMapThreads(numThreads_)) |
                ql::views::transform([this, linesPerPartial, &parser, itemAlloc,
                                      &numHasWordTriples,
                                      &progressBar](size_t workerIdx) {

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -503,17 +503,6 @@ namespace {
 // named `IdTriple`, which is a class with a similar purpose defined in
 // `index/IdTriple.h`.
 using IdRow = std::array<Id, NumColumnsIndexBuilding>;
-
-// The number of worker threads that build the partial vocabularies via hash
-// maps, given the total number of threads `numThreads` available for the index
-// build (see `DEFAULT_NUM_THREADS`). Building the hash maps is roughly half as
-// expensive as parsing, so the item maps get about a third of the threads and
-// the parsers the remaining two thirds (see `detail::numParserThreads` in
-// `RdfParser.h`, which must agree with the split computed here). At least two
-// threads are used.
-size_t numItemMapThreads(uint32_t numThreads) {
-  return std::max<size_t>(2, (numThreads + 1) / 3);
-}
 }  // namespace
 
 // _____________________________________________________________________________
@@ -589,7 +578,7 @@ BuildPartialVocabulariesResult IndexImpl::buildPartialVocabularies(
   AD_LOG_INFO << "Parsing input triples and creating partial vocabularies, one "
                  "per batch, using "
               << numItemMapThreads(numThreads_) << " worker threads and "
-              << detail::numParserThreads(numThreads_) << " parser threads ..."
+              << numParserThreads(numThreads_) << " parser threads ..."
               << std::endl;
 
   // Show progress and statistics for the number of triples parsed. The total

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -102,8 +102,8 @@ std::unique_ptr<RdfParserBase> IndexImpl::makeRdfParser(
       memoryLimitIndexBuilding().getBytes() > 0,
       " memory limit for index building must be greater than zero");
   return std::make_unique<RdfMultifileParser>(
-      std::move(files), &encodedIriManager(), parserBufferSize(),
-      onlyAsciiTurtlePrefixes_);
+      std::move(files), &encodedIriManager(), concurrencyLevel_,
+      parserBufferSize(), onlyAsciiTurtlePrefixes_);
 }
 
 // Several helper functions for joining the OSP permutation with the patterns.
@@ -503,6 +503,17 @@ namespace {
 // named `IdTriple`, which is a class with a similar purpose defined in
 // `index/IdTriple.h`.
 using IdRow = std::array<Id, NumColumnsIndexBuilding>;
+
+// The number of worker threads that build the partial vocabularies via hash
+// maps, given the total number of threads `concurrencyLevel` available for the
+// first phase of the index build (see `DEFAULT_CONCURRENCY_LEVEL`). Building
+// the hash maps is roughly half as expensive as parsing, so the item maps get
+// about a third of the threads and the parsers the remaining two thirds (see
+// `detail::numParserThreads` in `RdfParser.h`, which must agree with the split
+// computed here). At least two threads are used.
+size_t numItemMapThreads(uint32_t concurrencyLevel) {
+  return std::max<size_t>(2, (concurrencyLevel + 1) / 3);
+}
 }  // namespace
 
 // _____________________________________________________________________________
@@ -527,11 +538,15 @@ IndexImpl::runPartialVocabularyWorker(
     // That's why we use the `CachingMemoryResource` as an underlying memory
     // pool for the allocator of the hash map to make the allocation and
     // deallocation of these hash maps (that are newly created for each batch)
-    // much cheaper (see `CachingMemoryResource.h`). Note: The division is
-    // deliberate. Reserving space for all the words that a batch could
-    // possibly contain would mean that the memory reserved upfront grows with
-    // the number of workers.
-    itemMap.map_.map_.reserve(5 * linesPerPartial / NUM_PARALLEL_ITEM_MAPS);
+    // much cheaper (see `CachingMemoryResource.h`). NOTE: The factor of one
+    // half is purely empirical. It is the value that this expression
+    // effectively had back when the number of workers was a hard-coded
+    // constant, and reserving that much was measurably faster than reserving
+    // space for all the words that a batch could possibly contain. There is
+    // no deeper reason for this particular number, it just works well in
+    // practice, which is also why it is deliberately independent of the
+    // number of workers.
+    itemMap.map_.map_.reserve(linesPerPartial / 2);
     std::vector<IdRow> localWriter;
     size_t numInputTriples = 0;
     while (numInputTriples < linesPerPartial) {
@@ -572,8 +587,10 @@ BuildPartialVocabulariesResult IndexImpl::buildPartialVocabularies(
   parser->integerOverflowBehavior() = turtleParserIntegerOverflowBehavior_;
   parser->invalidLiteralsAreSkipped() = turtleParserSkipIllegalLiterals_;
   AD_LOG_INFO << "Parsing input triples and creating partial vocabularies, one "
-                 "per batch ..."
-              << std::endl;
+                 "per batch, using "
+              << numItemMapThreads(concurrencyLevel_) << " worker threads and "
+              << detail::numParserThreads(concurrencyLevel_)
+              << " parser threads ..." << std::endl;
 
   // Show progress and statistics for the number of triples parsed. The total
   // number of triples is not known in advance, and the workers report their
@@ -587,7 +604,7 @@ BuildPartialVocabulariesResult IndexImpl::buildPartialVocabularies(
   std::atomic<size_t> numHasWordTriples = 0;
 
   using WorkerResult = BuildPartialVocabulariesResult::WorkerResult;
-  auto tasks = ad_utility::integerRange(NUM_PARALLEL_ITEM_MAPS) |
+  auto tasks = ad_utility::integerRange(numItemMapThreads(concurrencyLevel_)) |
                ql::views::transform([this, linesPerPartial, &parser, itemAlloc,
                                      &numHasWordTriples,
                                      &progressBar](size_t workerIdx) {

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -12,6 +12,7 @@
 #include <absl/time/time.h>
 #include <sys/stat.h>
 
+#include <algorithm>
 #include <atomic>
 #include <cstdio>
 #include <functional>
@@ -93,8 +94,8 @@ IndexBuilderDataAsFirstPermutationSorter IndexImpl::createIdTriplesAndVocab(
 
 // _____________________________________________________________________________
 std::unique_ptr<RdfParserBase> IndexImpl::makeRdfParser(
-    ad_utility::InputRangeTypeErased<qlever::InputFileSpecification> files)
-    const {
+    ad_utility::InputRangeTypeErased<qlever::InputFileSpecification> files,
+    uint32_t numParsingThreadsPerFile) const {
   AD_CONTRACT_CHECK(
       parserBufferSize().getBytes() > 0,
       "The buffer size of the RDF parser must be greater than zero");
@@ -102,8 +103,8 @@ std::unique_ptr<RdfParserBase> IndexImpl::makeRdfParser(
       memoryLimitIndexBuilding().getBytes() > 0,
       " memory limit for index building must be greater than zero");
   return std::make_unique<RdfMultifileParser>(
-      std::move(files), &encodedIriManager(), numThreads_, parserBufferSize(),
-      onlyAsciiTurtlePrefixes_);
+      std::move(files), &encodedIriManager(), numThreads_,
+      numParsingThreadsPerFile, parserBufferSize(), onlyAsciiTurtlePrefixes_);
 }
 
 // Several helper functions for joining the OSP permutation with the patterns.
@@ -387,16 +388,33 @@ void IndexImpl::updateInputFileSpecificationsAndLog(
   }
 }
 
-// _____________________________________________________________________________
-void IndexImpl::createFromFiles(
-    std::vector<Index::InputFileSpecification> files) {
-  updateInputFileSpecificationsAndLog(files, useParallelParser_);
-  createFromFiles(ad_utility::InputRangeTypeErased{std::move(files)});
+// The number of threads that the parser for a single input file gets, given the
+// total number of threads `numThreads` for the index build and the number
+// `numFiles` of input files. An `RdfMultifileParser` parses `numParserThreads`
+// files concurrently (but of course never more files than there are), and the
+// `numParserThreads` are divided evenly among those, such that the total number
+// of threads used for parsing stays roughly the same, no matter how many input
+// files there are. At least one thread is used per file.
+static uint32_t numParserThreadsPerFile(uint32_t numThreads, size_t numFiles) {
+  auto numConcurrentFiles =
+      std::clamp<size_t>(numFiles, 1, numParserThreads(numThreads));
+  return std::max<uint32_t>(1,
+                            numParserThreads(numThreads) / numConcurrentFiles);
 }
 
 // _____________________________________________________________________________
 void IndexImpl::createFromFiles(
-    ad_utility::InputRangeTypeErased<qlever::InputFileSpecification> files) {
+    std::vector<Index::InputFileSpecification> files) {
+  updateInputFileSpecificationsAndLog(files, useParallelParser_);
+  auto numThreadsPerFile = numParserThreadsPerFile(numThreads_, files.size());
+  createFromFiles(ad_utility::InputRangeTypeErased{std::move(files)},
+                  numThreadsPerFile);
+}
+
+// _____________________________________________________________________________
+void IndexImpl::createFromFiles(
+    ad_utility::InputRangeTypeErased<qlever::InputFileSpecification> files,
+    uint32_t numParsingThreadsPerFile) {
   if (!loadAllPermutations_ && usePatterns_) {
     throw std::runtime_error{
         "The patterns can only be built when all 6 permutations are created"};
@@ -411,7 +429,8 @@ void IndexImpl::createFromFiles(
   readIndexBuilderSettingsFromFile();
 
   IndexBuilderDataAsFirstPermutationSorter indexBuilderData =
-      createIdTriplesAndVocab(makeRdfParser(std::move(files)));
+      createIdTriplesAndVocab(
+          makeRdfParser(std::move(files), numParsingThreadsPerFile));
 
   // Write the configuration already at this point, so we have it available in
   // case any of the permutations fail.

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -111,7 +111,7 @@ class IndexImpl {
   // parallel (see `--num-threads` in `IndexBuilderMain.cpp`). Currently, it is
   // divided between the parser threads and the workers that build the partial
   // vocabularies via hash maps.
-  uint32_t numThreads_ = DEFAULT_NUM_THREADS();
+  uint32_t numThreads_ = defaultNumThreads();
   ad_utility::MemorySize blocksizePermutationPerColumn_ =
       UNCOMPRESSED_BLOCKSIZE_COMPRESSED_METADATA_PER_COLUMN;
   nlohmann::json configurationJson_;
@@ -548,9 +548,9 @@ class IndexImpl {
   }
 
   // Set the number of threads for the parallel steps of the index build.
-  // Currently, they are divided between the parser threads (see
-  // `detail::numParserThreads` in `RdfParser.h`) and the workers that build
-  // the partial vocabularies (see `numItemMapThreads` in `IndexImpl.cpp`).
+  // Currently, they are divided between the parser threads and the workers
+  // that build the partial vocabularies (see `numParserThreads` and
+  // `numItemMapThreads` in `ConstantsIndexBuilding.h`).
   void setNumThreads(uint32_t numThreads) {
     AD_CONTRACT_CHECK(numThreads > 0,
                       "The number of threads must be greater than zero");

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -107,11 +107,11 @@ class IndexImpl {
   ad_utility::MemorySize memoryLimitIndexBuilding_ =
       DEFAULT_MEMORY_LIMIT_INDEX_BUILDING;
   ad_utility::MemorySize parserBufferSize_ = DEFAULT_PARSER_BUFFER_SIZE;
-  // The total number of threads used by the first phase of the index build
-  // (see `--concurrency-level` in `IndexBuilderMain.cpp`). It is divided
-  // between the parser threads and the workers that build the partial
+  // The number of threads that the index build uses for the steps that run in
+  // parallel (see `--num-threads` in `IndexBuilderMain.cpp`). Currently, it is
+  // divided between the parser threads and the workers that build the partial
   // vocabularies via hash maps.
-  uint32_t concurrencyLevel_ = DEFAULT_CONCURRENCY_LEVEL();
+  uint32_t numThreads_ = DEFAULT_NUM_THREADS();
   ad_utility::MemorySize blocksizePermutationPerColumn_ =
       UNCOMPRESSED_BLOCKSIZE_COMPRESSED_METADATA_PER_COLUMN;
   nlohmann::json configurationJson_;
@@ -547,14 +547,14 @@ class IndexImpl {
     return parserBufferSize_;
   }
 
-  // Set the total number of threads for the first phase of the index build.
-  // They are divided between the parser threads (see
+  // Set the number of threads for the parallel steps of the index build.
+  // Currently, they are divided between the parser threads (see
   // `detail::numParserThreads` in `RdfParser.h`) and the workers that build
   // the partial vocabularies (see `numItemMapThreads` in `IndexImpl.cpp`).
-  void setConcurrencyLevel(uint32_t concurrencyLevel) {
-    AD_CONTRACT_CHECK(concurrencyLevel > 0,
-                      "The concurrency level must be greater than zero");
-    concurrencyLevel_ = concurrencyLevel;
+  void setNumThreads(uint32_t numThreads) {
+    AD_CONTRACT_CHECK(numThreads > 0,
+                      "The number of threads must be greater than zero");
+    numThreads_ = numThreads;
   }
 
   ad_utility::MemorySize& blocksizePermutationPerColumn() {

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -253,8 +253,13 @@ class IndexImpl {
   // by createFromOnDiskIndex after this call.
   void createFromFiles(std::vector<Index::InputFileSpecification> files);
 
+  // Same as above, but for a lazy range of input files. Because the range is
+  // consumed lazily, the number of input files is not known here and has to be
+  // passed in via `numParsingThreadsPerFile`, see `numParserThreadsPerFile` in
+  // `IndexImpl.cpp`.
   void createFromFiles(
-      ad_utility::InputRangeTypeErased<qlever::InputFileSpecification> files);
+      ad_utility::InputRangeTypeErased<qlever::InputFileSpecification> files,
+      uint32_t numParsingThreadsPerFile);
 
   // Creates an index object from an on disk index that has previously been
   // constructed. Read necessary meta data into memory and opens file handles.
@@ -688,10 +693,11 @@ class IndexImpl {
   // Return a Turtle parser that parses the given files. The parser will be
   // configured to either parse in parallel or not (per input file), and to
   // either use the CTRE-based relaxed parser or not (via the
-  // `ascii-prefixes-only` setting, see `onlyAsciiTurtlePrefixes_`).
+  // `ascii-prefixes-only` setting, see `onlyAsciiTurtlePrefixes_`). Each of the
+  // files is parsed with `numParsingThreadsPerFile` threads.
   std::unique_ptr<RdfParserBase> makeRdfParser(
-      ad_utility::InputRangeTypeErased<qlever::InputFileSpecification> files)
-      const;
+      ad_utility::InputRangeTypeErased<qlever::InputFileSpecification> files,
+      uint32_t numParsingThreadsPerFile) const;
 
   template <typename Func>
   FirstPermutationSorterAndInternalTriplesAsPso convertPartialToGlobalIds(

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -107,6 +107,11 @@ class IndexImpl {
   ad_utility::MemorySize memoryLimitIndexBuilding_ =
       DEFAULT_MEMORY_LIMIT_INDEX_BUILDING;
   ad_utility::MemorySize parserBufferSize_ = DEFAULT_PARSER_BUFFER_SIZE;
+  // The total number of threads used by the first phase of the index build
+  // (see `--concurrency-level` in `IndexBuilderMain.cpp`). It is divided
+  // between the parser threads and the workers that build the partial
+  // vocabularies via hash maps.
+  uint32_t concurrencyLevel_ = DEFAULT_CONCURRENCY_LEVEL();
   ad_utility::MemorySize blocksizePermutationPerColumn_ =
       UNCOMPRESSED_BLOCKSIZE_COMPRESSED_METADATA_PER_COLUMN;
   nlohmann::json configurationJson_;
@@ -542,6 +547,16 @@ class IndexImpl {
     return parserBufferSize_;
   }
 
+  // Set the total number of threads for the first phase of the index build.
+  // They are divided between the parser threads (see
+  // `detail::numParserThreads` in `RdfParser.h`) and the workers that build
+  // the partial vocabularies (see `numItemMapThreads` in `IndexImpl.cpp`).
+  void setConcurrencyLevel(uint32_t concurrencyLevel) {
+    AD_CONTRACT_CHECK(concurrencyLevel > 0,
+                      "The concurrency level must be greater than zero");
+    concurrencyLevel_ = concurrencyLevel;
+  }
+
   ad_utility::MemorySize& blocksizePermutationPerColumn() {
     return blocksizePermutationPerColumn_;
   }
@@ -636,7 +651,7 @@ class IndexImpl {
   IndexBuilderDataAsFirstPermutationSorter createIdTriplesAndVocab(
       std::shared_ptr<RdfParserBase> parser);
 
-  // Parse all triples from `parser` using `NUM_PARALLEL_ITEM_MAPS` worker
+  // Parse all triples from `parser` using `numItemMapThreads` worker
   // threads that work completely independently of each other. Each of them
   // processes batches of `linesPerPartial` triples, and for each batch writes
   // one partial vocabulary file and stores the corresponding ID triples in its

--- a/src/libqlever/Qlever.cpp
+++ b/src/libqlever/Qlever.cpp
@@ -125,7 +125,7 @@ void Qlever::buildIndex(IndexBuilderConfig config) {
   if (config.parserBufferSize_.has_value()) {
     index.parserBufferSize() = config.parserBufferSize_.value();
   }
-  index.getImpl().setConcurrencyLevel(config.concurrencyLevel_);
+  index.getImpl().setNumThreads(config.numThreads_);
 
   // If no text index name was specified, take the part of the wordsfile after
   // the last slash.
@@ -394,9 +394,9 @@ void IndexBuilderConfig::validate() const {
         "\" cannot be used for index building, the supported types are ",
         ad_utility::VocabularyType::getListOfValuesForIndexBuilding()));
   }
-  if (concurrencyLevel_ == 0) {
+  if (numThreads_ == 0) {
     throw std::invalid_argument(
-        "The value of --concurrency-level must be greater than 0");
+        "The value of --num-threads must be greater than 0");
   }
   if (kScoringParam_ < 0) {
     throw std::invalid_argument("The value of bm25-k must be >= 0");

--- a/src/libqlever/Qlever.cpp
+++ b/src/libqlever/Qlever.cpp
@@ -125,6 +125,7 @@ void Qlever::buildIndex(IndexBuilderConfig config) {
   if (config.parserBufferSize_.has_value()) {
     index.parserBufferSize() = config.parserBufferSize_.value();
   }
+  index.getImpl().setConcurrencyLevel(config.concurrencyLevel_);
 
   // If no text index name was specified, take the part of the wordsfile after
   // the last slash.
@@ -392,6 +393,10 @@ void IndexBuilderConfig::validate() const {
         "The vocabulary type \"", vocabType_.toString(),
         "\" cannot be used for index building, the supported types are ",
         ad_utility::VocabularyType::getListOfValuesForIndexBuilding()));
+  }
+  if (concurrencyLevel_ == 0) {
+    throw std::invalid_argument(
+        "The value of --concurrency-level must be greater than 0");
   }
   if (kScoringParam_ < 0) {
     throw std::invalid_argument("The value of bm25-k must be >= 0");

--- a/src/libqlever/Qlever.h
+++ b/src/libqlever/Qlever.h
@@ -100,11 +100,10 @@ struct IndexBuilderConfig : CommonConfig {
   // The default chunk size is large enough for most input sets.
   std::optional<ad_utility::MemorySize> parserBufferSize_;
 
-  // The total number of threads used by the first phase of the index build.
-  // They are divided between the threads that parse the input and the workers
-  // that build the partial vocabularies, where each of these two consumers
-  // computes its own share. Must be greater than zero.
-  uint32_t concurrencyLevel_ = DEFAULT_CONCURRENCY_LEVEL();
+  // The number of threads that the index build uses for the steps that run in
+  // parallel. Each such step derives its own share from this value. Must be
+  // greater than zero.
+  uint32_t numThreads_ = DEFAULT_NUM_THREADS();
 
   // Filename of a JSON file with additional settings. Examples can be seen in
   // https://github.com/ad-freiburg/qlever-control/tree/main/src/qlever/Qleverfiles

--- a/src/libqlever/Qlever.h
+++ b/src/libqlever/Qlever.h
@@ -103,7 +103,7 @@ struct IndexBuilderConfig : CommonConfig {
   // The number of threads that the index build uses for the steps that run in
   // parallel. Each such step derives its own share from this value. Must be
   // greater than zero.
-  uint32_t numThreads_ = DEFAULT_NUM_THREADS();
+  uint32_t numThreads_ = defaultNumThreads();
 
   // Filename of a JSON file with additional settings. Examples can be seen in
   // https://github.com/ad-freiburg/qlever-control/tree/main/src/qlever/Qleverfiles

--- a/src/libqlever/Qlever.h
+++ b/src/libqlever/Qlever.h
@@ -29,6 +29,7 @@
 #include "engine/RebuildIndexStrategy.h"
 #include "engine/UpdateMetadata.h"
 #include "global/RuntimeParameters.h"
+#include "index/ConstantsIndexBuilding.h"
 #include "index/DeltaTriples.h"
 #include "index/Index.h"
 #include "index/IndexRebuilderTypes.h"
@@ -98,6 +99,12 @@ struct IndexBuilderConfig : CommonConfig {
   // or subject with predicate-object list in Turtle) fits into a single chunk.
   // The default chunk size is large enough for most input sets.
   std::optional<ad_utility::MemorySize> parserBufferSize_;
+
+  // The total number of threads used by the first phase of the index build.
+  // They are divided between the threads that parse the input and the workers
+  // that build the partial vocabularies, where each of these two consumers
+  // computes its own share. Must be greater than zero.
+  uint32_t concurrencyLevel_ = DEFAULT_CONCURRENCY_LEVEL();
 
   // Filename of a JSON file with additional settings. Examples can be seen in
   // https://github.com/ad-freiburg/qlever-control/tree/main/src/qlever/Qleverfiles

--- a/src/parser/RdfParser.cpp
+++ b/src/parser/RdfParser.cpp
@@ -1310,7 +1310,7 @@ RdfParallelParser<T>::~RdfParallelParser() {
 template <typename TokenizerT>
 static std::unique_ptr<RdfParserBase> makeSingleRdfParser(
     const qlever::InputFileSpecification& input, const EncodedIriManager* ev,
-    ad_utility::MemorySize bufferSize, uint32_t concurrencyLevel) {
+    ad_utility::MemorySize bufferSize, uint32_t numThreads) {
   auto graph = [input]() -> TripleComponent {
     if (input.defaultGraph_.has_value()) {
       return TripleComponent::Iri::fromIrirefWithoutBrackets(
@@ -1320,7 +1320,7 @@ static std::unique_ptr<RdfParserBase> makeSingleRdfParser(
     }
   };
   auto makeRdfParserImpl = ad_utility::ApplyAsValueIdentity{
-      [&input, &bufferSize, &graph, ev, concurrencyLevel](
+      [&input, &bufferSize, &graph, ev, numThreads](
           auto useParallel,
           auto isTurtleInput) -> std::unique_ptr<RdfParserBase> {
         using InnerParser =
@@ -1328,7 +1328,7 @@ static std::unique_ptr<RdfParserBase> makeSingleRdfParser(
                                NQuadParser<TokenizerT>>;
         if constexpr (useParallel == 1) {
           return std::make_unique<RdfParallelParser<InnerParser>>(
-              input, bufferSize, ev, concurrencyLevel, graph());
+              input, bufferSize, ev, numThreads, graph());
         } else {
           return std::make_unique<RdfStreamParser<InnerParser>>(
               input, bufferSize, ev, graph());
@@ -1352,9 +1352,9 @@ void RdfMultifileParser::parseFileAndPushBatches(
     auto parser =
         useRelaxedParsing_
             ? makeSingleRdfParser<TokenizerCtre>(file, &encodedIriManager(),
-                                                 bufferSize, concurrencyLevel_)
+                                                 bufferSize, numThreads_)
             : makeSingleRdfParser<Tokenizer>(file, &encodedIriManager(),
-                                             bufferSize, concurrencyLevel_);
+                                             bufferSize, numThreads_);
     while (auto batch = parser->getBatch()) {
       bool active = finishedBatchQueue_.push(std::move(batch.value()));
       if (!active) {
@@ -1370,13 +1370,13 @@ void RdfMultifileParser::parseFileAndPushBatches(
 // ______________________________________________________________
 RdfMultifileParser::RdfMultifileParser(
     ad_utility::InputRangeTypeErased<qlever::InputFileSpecification> files,
-    const EncodedIriManager* encodedIriManager, uint32_t concurrencyLevel,
+    const EncodedIriManager* encodedIriManager, uint32_t numThreads,
     ad_utility::MemorySize bufferSize, bool useRelaxedParsing)
     : RdfParserBase(encodedIriManager),
       parsingQueue_{QUEUE_SIZE_BEFORE_PARALLEL_PARSING,
-                    detail::numParserThreads(concurrencyLevel)},
+                    detail::numParserThreads(numThreads)},
       useRelaxedParsing_{useRelaxedParsing},
-      concurrencyLevel_{concurrencyLevel} {
+      numThreads_{numThreads} {
   // Feed all the input files to the `parsingQueue_`.
   auto makeParsers = [files = std::move(files), bufferSize, this]() mutable {
     for (auto& file : files) {

--- a/src/parser/RdfParser.cpp
+++ b/src/parser/RdfParser.cpp
@@ -1374,7 +1374,7 @@ RdfMultifileParser::RdfMultifileParser(
     ad_utility::MemorySize bufferSize, bool useRelaxedParsing)
     : RdfParserBase(encodedIriManager),
       parsingQueue_{QUEUE_SIZE_BEFORE_PARALLEL_PARSING,
-                    detail::numParserThreads(numThreads)},
+                    numParserThreads(numThreads)},
       useRelaxedParsing_{useRelaxedParsing},
       numThreads_{numThreads} {
   // Feed all the input files to the `parsingQueue_`.

--- a/src/parser/RdfParser.cpp
+++ b/src/parser/RdfParser.cpp
@@ -1310,7 +1310,7 @@ RdfParallelParser<T>::~RdfParallelParser() {
 template <typename TokenizerT>
 static std::unique_ptr<RdfParserBase> makeSingleRdfParser(
     const qlever::InputFileSpecification& input, const EncodedIriManager* ev,
-    ad_utility::MemorySize bufferSize) {
+    ad_utility::MemorySize bufferSize, uint32_t concurrencyLevel) {
   auto graph = [input]() -> TripleComponent {
     if (input.defaultGraph_.has_value()) {
       return TripleComponent::Iri::fromIrirefWithoutBrackets(
@@ -1320,16 +1320,19 @@ static std::unique_ptr<RdfParserBase> makeSingleRdfParser(
     }
   };
   auto makeRdfParserImpl = ad_utility::ApplyAsValueIdentity{
-      [&input, &bufferSize, &graph, ev](
+      [&input, &bufferSize, &graph, ev, concurrencyLevel](
           auto useParallel,
           auto isTurtleInput) -> std::unique_ptr<RdfParserBase> {
         using InnerParser =
             std::conditional_t<isTurtleInput == 1, TurtleParser<TokenizerT>,
                                NQuadParser<TokenizerT>>;
-        using Parser =
-            std::conditional_t<useParallel == 1, RdfParallelParser<InnerParser>,
-                               RdfStreamParser<InnerParser>>;
-        return std::make_unique<Parser>(input, bufferSize, ev, graph());
+        if constexpr (useParallel == 1) {
+          return std::make_unique<RdfParallelParser<InnerParser>>(
+              input, bufferSize, ev, concurrencyLevel, graph());
+        } else {
+          return std::make_unique<RdfStreamParser<InnerParser>>(
+              input, bufferSize, ev, graph());
+        }
       }};
 
   // The call to `callFixedSize` lifts runtime integers to compile time
@@ -1346,11 +1349,12 @@ void RdfMultifileParser::parseFileAndPushBatches(
     const qlever::InputFileSpecification& file,
     ad_utility::MemorySize bufferSize) {
   try {
-    auto parser = useRelaxedParsing_
-                      ? makeSingleRdfParser<TokenizerCtre>(
-                            file, &encodedIriManager(), bufferSize)
-                      : makeSingleRdfParser<Tokenizer>(
-                            file, &encodedIriManager(), bufferSize);
+    auto parser =
+        useRelaxedParsing_
+            ? makeSingleRdfParser<TokenizerCtre>(file, &encodedIriManager(),
+                                                 bufferSize, concurrencyLevel_)
+            : makeSingleRdfParser<Tokenizer>(file, &encodedIriManager(),
+                                             bufferSize, concurrencyLevel_);
     while (auto batch = parser->getBatch()) {
       bool active = finishedBatchQueue_.push(std::move(batch.value()));
       if (!active) {
@@ -1366,9 +1370,13 @@ void RdfMultifileParser::parseFileAndPushBatches(
 // ______________________________________________________________
 RdfMultifileParser::RdfMultifileParser(
     ad_utility::InputRangeTypeErased<qlever::InputFileSpecification> files,
-    const EncodedIriManager* encodedIriManager,
+    const EncodedIriManager* encodedIriManager, uint32_t concurrencyLevel,
     ad_utility::MemorySize bufferSize, bool useRelaxedParsing)
-    : RdfParserBase(encodedIriManager), useRelaxedParsing_{useRelaxedParsing} {
+    : RdfParserBase(encodedIriManager),
+      parsingQueue_{QUEUE_SIZE_BEFORE_PARALLEL_PARSING,
+                    detail::numParserThreads(concurrencyLevel)},
+      useRelaxedParsing_{useRelaxedParsing},
+      concurrencyLevel_{concurrencyLevel} {
   // Feed all the input files to the `parsingQueue_`.
   auto makeParsers = [files = std::move(files), bufferSize, this]() mutable {
     for (auto& file : files) {

--- a/src/parser/RdfParser.cpp
+++ b/src/parser/RdfParser.cpp
@@ -1310,7 +1310,7 @@ RdfParallelParser<T>::~RdfParallelParser() {
 template <typename TokenizerT>
 static std::unique_ptr<RdfParserBase> makeSingleRdfParser(
     const qlever::InputFileSpecification& input, const EncodedIriManager* ev,
-    ad_utility::MemorySize bufferSize, uint32_t numThreads) {
+    ad_utility::MemorySize bufferSize, uint32_t numParsingThreads) {
   auto graph = [input]() -> TripleComponent {
     if (input.defaultGraph_.has_value()) {
       return TripleComponent::Iri::fromIrirefWithoutBrackets(
@@ -1320,7 +1320,7 @@ static std::unique_ptr<RdfParserBase> makeSingleRdfParser(
     }
   };
   auto makeRdfParserImpl = ad_utility::ApplyAsValueIdentity{
-      [&input, &bufferSize, &graph, ev, numThreads](
+      [&input, &bufferSize, &graph, ev, numParsingThreads](
           auto useParallel,
           auto isTurtleInput) -> std::unique_ptr<RdfParserBase> {
         using InnerParser =
@@ -1328,7 +1328,7 @@ static std::unique_ptr<RdfParserBase> makeSingleRdfParser(
                                NQuadParser<TokenizerT>>;
         if constexpr (useParallel == 1) {
           return std::make_unique<RdfParallelParser<InnerParser>>(
-              input, bufferSize, ev, numThreads, graph());
+              input, bufferSize, ev, numParsingThreads, graph());
         } else {
           return std::make_unique<RdfStreamParser<InnerParser>>(
               input, bufferSize, ev, graph());
@@ -1349,12 +1349,13 @@ void RdfMultifileParser::parseFileAndPushBatches(
     const qlever::InputFileSpecification& file,
     ad_utility::MemorySize bufferSize) {
   try {
-    auto parser =
-        useRelaxedParsing_
-            ? makeSingleRdfParser<TokenizerCtre>(file, &encodedIriManager(),
-                                                 bufferSize, numThreads_)
-            : makeSingleRdfParser<Tokenizer>(file, &encodedIriManager(),
-                                             bufferSize, numThreads_);
+    auto parser = useRelaxedParsing_
+                      ? makeSingleRdfParser<TokenizerCtre>(
+                            file, &encodedIriManager(), bufferSize,
+                            numParsingThreadsPerFile_)
+                      : makeSingleRdfParser<Tokenizer>(
+                            file, &encodedIriManager(), bufferSize,
+                            numParsingThreadsPerFile_);
     while (auto batch = parser->getBatch()) {
       bool active = finishedBatchQueue_.push(std::move(batch.value()));
       if (!active) {
@@ -1371,12 +1372,13 @@ void RdfMultifileParser::parseFileAndPushBatches(
 RdfMultifileParser::RdfMultifileParser(
     ad_utility::InputRangeTypeErased<qlever::InputFileSpecification> files,
     const EncodedIriManager* encodedIriManager, uint32_t numThreads,
-    ad_utility::MemorySize bufferSize, bool useRelaxedParsing)
+    uint32_t numParsingThreadsPerFile, ad_utility::MemorySize bufferSize,
+    bool useRelaxedParsing)
     : RdfParserBase(encodedIriManager),
       parsingQueue_{QUEUE_SIZE_BEFORE_PARALLEL_PARSING,
                     numParserThreads(numThreads)},
       useRelaxedParsing_{useRelaxedParsing},
-      numThreads_{numThreads} {
+      numParsingThreadsPerFile_{numParsingThreadsPerFile} {
   // Feed all the input files to the `parsingQueue_`.
   auto makeParsers = [files = std::move(files), bufferSize, this]() mutable {
     for (auto& file : files) {

--- a/src/parser/RdfParser.h
+++ b/src/parser/RdfParser.h
@@ -55,6 +55,22 @@ std::optional<size_t> findEndOfLastNewline(std::string_view input);
 // `std::nullopt` if there is no match. Used to split a block of input at a
 // Turtle statement boundary.
 std::optional<size_t> findEndOfLastStatement(std::string_view input);
+
+// The number of threads that a parallel parser uses, given the total number of
+// threads `concurrencyLevel` available for the first phase of the index build
+// (see `DEFAULT_CONCURRENCY_LEVEL`). Parsing is roughly twice as expensive as
+// building the partial vocabularies, so the parsers get about two thirds of
+// the threads and the item maps the remaining third (see `numItemMapThreads`
+// in `IndexImpl.cpp`, which must agree with the split computed here). At least
+// two threads are used.
+inline size_t numParserThreads(uint32_t concurrencyLevel) {
+  size_t numItemMapThreads = std::max<size_t>(2, (concurrencyLevel + 1) / 3);
+  // NOTE: The subtraction is saturating, because on machines with very few
+  // hardware threads `numItemMapThreads` may exceed `concurrencyLevel`.
+  return std::max<size_t>(
+      2,
+      concurrencyLevel - std::min<size_t>(concurrencyLevel, numItemMapThreads));
+}
 }  // namespace detail
 
 struct TurtleTriple {
@@ -653,17 +669,22 @@ class RdfParallelParser : public RdfParserBase {
  public:
   // Construct a parser that reads from an `InputFileSpecification`. The parser
   // creates its own I/O thread and `AsyncBlockSource` internally. The
-  // `blocksize` parameter controls the size of the underlying I/O block buffer.
+  // `blocksize` parameter controls the size of the underlying I/O block buffer,
+  // and `concurrencyLevel` the total number of threads of the index build, of
+  // which this parser uses `detail::numParserThreads` many.
   RdfParallelParser(const qlever::InputFileSpecification& spec,
                     ad_utility::MemorySize blocksize,
-                    const EncodedIriManager* ev,
+                    const EncodedIriManager* ev, uint32_t concurrencyLevel,
                     const TripleComponent& defaultGraphIri =
                         qlever::specialIds().at(DEFAULT_GRAPH_IRI),
                     std::chrono::milliseconds sleepTimeForTesting =
                         std::chrono::milliseconds{0})
       : RdfParserBase{ev},
         defaultGraphIri_{defaultGraphIri},
-        sleepTimeForTesting_(sleepTimeForTesting) {
+        sleepTimeForTesting_(sleepTimeForTesting),
+        parallelParser_{QUEUE_SIZE_BEFORE_PARALLEL_PARSING,
+                        detail::numParserThreads(concurrencyLevel),
+                        "parallel parser"} {
     initialize(spec, blocksize);
   }
 
@@ -733,9 +754,8 @@ class RdfParallelParser : public RdfParserBase {
   // by those threads) are destroyed.
   ad_utility::data_structures::ThreadSafeQueue<std::vector<TurtleTriple>>
       tripleCollector_{QUEUE_SIZE_AFTER_PARALLEL_PARSING};
-  ad_utility::TaskQueue<true> parallelParser_{
-      QUEUE_SIZE_BEFORE_PARALLEL_PARSING, NUM_PARALLEL_PARSER_THREADS,
-      "parallel parser"};
+  // Initialized by the constructor, which is the only one this class has.
+  ad_utility::TaskQueue<true> parallelParser_;
   std::future<void> parseFuture_;
 };
 
@@ -743,18 +763,26 @@ class RdfParallelParser : public RdfParserBase {
 // file is specified by an  `InputFileSpecification`.
 class RdfMultifileParser : public RdfParserBase {
  public:
-  // Default construction needed for tests
-  explicit RdfMultifileParser(const EncodedIriManager* encodedIriManager)
-      : RdfParserBase{encodedIriManager} {}
+  // Construct a parser without any input, which is only useful for testing the
+  // functions that don't depend on the input.
+  RdfMultifileParser(const EncodedIriManager* encodedIriManager,
+                     uint32_t concurrencyLevel)
+      : RdfParserBase{encodedIriManager},
+        parsingQueue_{QUEUE_SIZE_BEFORE_PARALLEL_PARSING,
+                      detail::numParserThreads(concurrencyLevel)},
+        concurrencyLevel_{concurrencyLevel} {}
 
   // Construct the parser from a type-erased input range of file specifications
   // and eagerly start parsing them on background threads. If
   // `useRelaxedParsing` is true, the faster `TokenizerCtre` is used for all
   // files instead of the standard-compliant `Tokenizer` (see the comment on
   // `TurtleParser` above for the limitations of the relaxed mode).
+  // `concurrencyLevel` is the total number of threads of the index build. This
+  // parser parses `detail::numParserThreads` many files concurrently, and
+  // passes the concurrency level on to the parser of each single file.
   RdfMultifileParser(
       ad_utility::InputRangeTypeErased<qlever::InputFileSpecification> files,
-      const EncodedIriManager* encodedIriManager,
+      const EncodedIriManager* encodedIriManager, uint32_t concurrencyLevel,
       ad_utility::MemorySize bufferSize = DEFAULT_PARSER_BUFFER_SIZE,
       bool useRelaxedParsing = false);
 
@@ -787,13 +815,18 @@ class RdfMultifileParser : public RdfParserBase {
   // `parsingQueue_` is declared *after* the `finishedBatchQueue_`, s.t. when
   // destroying the parser, the threads from the `parsingQueue_` are all joined
   // before the `finishedBatchQueue_` (which they are using!) is destroyed.
-  ad_utility::TaskQueue<false> parsingQueue_{QUEUE_SIZE_BEFORE_PARALLEL_PARSING,
-                                             NUM_PARALLEL_PARSER_THREADS};
+  // Initialized by every constructor.
+  ad_utility::TaskQueue<false> parsingQueue_;
 
   // If true, all files are parsed with the relaxed `TokenizerCtre` instead of
   // the standard-compliant `Tokenizer`. Only read by the parsing threads, and
   // never modified after construction.
   bool useRelaxedParsing_ = false;
+
+  // The total number of threads of the index build, passed on to the parser
+  // for a single file. Only read by the parsing threads, and never modified
+  // after construction.
+  uint32_t concurrencyLevel_;
 
   // A thread that feeds the file specifications to the actual parser threads.
   ad_utility::JThread feederThread_;

--- a/src/parser/RdfParser.h
+++ b/src/parser/RdfParser.h
@@ -654,11 +654,14 @@ class RdfParallelParser : public RdfParserBase {
   // Construct a parser that reads from an `InputFileSpecification`. The parser
   // creates its own I/O thread and `AsyncBlockSource` internally. The
   // `blocksize` parameter controls the size of the underlying I/O block buffer,
-  // and `numThreads` the total number of threads of the index build, of which
-  // this parser uses `numParserThreads` many (see `ConstantsIndexBuilding.h`).
+  // and `numParsingThreads` is the number of worker threads that this parser
+  // uses for parsing the blocks. NOTE: This is the number of threads for *this*
+  // parser, not the total number of threads of the index build; for how the
+  // latter is divided, see `ConstantsIndexBuilding.h` and
+  // `numParserThreadsPerFile` in `IndexImpl.cpp`.
   RdfParallelParser(const qlever::InputFileSpecification& spec,
                     ad_utility::MemorySize blocksize,
-                    const EncodedIriManager* ev, uint32_t numThreads,
+                    const EncodedIriManager* ev, uint32_t numParsingThreads,
                     const TripleComponent& defaultGraphIri =
                         qlever::specialIds().at(DEFAULT_GRAPH_IRI),
                     std::chrono::milliseconds sleepTimeForTesting =
@@ -666,8 +669,8 @@ class RdfParallelParser : public RdfParserBase {
       : RdfParserBase{ev},
         defaultGraphIri_{defaultGraphIri},
         sleepTimeForTesting_(sleepTimeForTesting),
-        parallelParser_{QUEUE_SIZE_BEFORE_PARALLEL_PARSING,
-                        numParserThreads(numThreads), "parallel parser"} {
+        parallelParser_{QUEUE_SIZE_BEFORE_PARALLEL_PARSING, numParsingThreads,
+                        "parallel parser"} {
     initialize(spec, blocksize);
   }
 
@@ -753,19 +756,23 @@ class RdfMultifileParser : public RdfParserBase {
       : RdfParserBase{encodedIriManager},
         parsingQueue_{QUEUE_SIZE_BEFORE_PARALLEL_PARSING,
                       numParserThreads(numThreads)},
-        numThreads_{numThreads} {}
+        numParsingThreadsPerFile_{numParserThreads(numThreads)} {}
 
   // Construct the parser from a type-erased input range of file specifications
   // and eagerly start parsing them on background threads. If
   // `useRelaxedParsing` is true, the faster `TokenizerCtre` is used for all
   // files instead of the standard-compliant `Tokenizer` (see the comment on
   // `TurtleParser` above for the limitations of the relaxed mode).
-  // `numThreads` is the total number of threads of the index build. This
-  // parser parses `numParserThreads` many files concurrently, and
-  // passes the number of threads on to the parser of each single file.
+  // `numThreads` is the total number of threads of the index build, of which
+  // this parser uses `numParserThreads` many to parse that many files
+  // concurrently (see `ConstantsIndexBuilding.h`). Each of those files is
+  // parsed with `numParsingThreadsPerFile` threads. That number is computed by
+  // the caller (see `IndexImpl.cpp`), because only the caller knows how many
+  // input files there are, and this parser consumes `files` lazily.
   RdfMultifileParser(
       ad_utility::InputRangeTypeErased<qlever::InputFileSpecification> files,
       const EncodedIriManager* encodedIriManager, uint32_t numThreads,
+      uint32_t numParsingThreadsPerFile,
       ad_utility::MemorySize bufferSize = DEFAULT_PARSER_BUFFER_SIZE,
       bool useRelaxedParsing = false);
 
@@ -806,10 +813,9 @@ class RdfMultifileParser : public RdfParserBase {
   // never modified after construction.
   bool useRelaxedParsing_ = false;
 
-  // The total number of threads of the index build, passed on to the parser
-  // for a single file. Only read by the parsing threads, and never modified
-  // after construction.
-  uint32_t numThreads_;
+  // The number of threads that the parser for a single file gets. Only read by
+  // the parsing threads, and never modified after construction.
+  uint32_t numParsingThreadsPerFile_;
 
   // A thread that feeds the file specifications to the actual parser threads.
   ad_utility::JThread feederThread_;

--- a/src/parser/RdfParser.h
+++ b/src/parser/RdfParser.h
@@ -55,21 +55,6 @@ std::optional<size_t> findEndOfLastNewline(std::string_view input);
 // `std::nullopt` if there is no match. Used to split a block of input at a
 // Turtle statement boundary.
 std::optional<size_t> findEndOfLastStatement(std::string_view input);
-
-// The number of threads that a parallel parser uses, given the total number of
-// threads `numThreads` available for the index build (see
-// `DEFAULT_NUM_THREADS`). Parsing is roughly twice as expensive as building
-// the partial vocabularies, so the parsers get about two thirds of the threads
-// and the item maps the remaining third (see `numItemMapThreads` in
-// `IndexImpl.cpp`, which must agree with the split computed here). At least
-// two threads are used.
-inline size_t numParserThreads(uint32_t numThreads) {
-  size_t numItemMapThreads = std::max<size_t>(2, (numThreads + 1) / 3);
-  // NOTE: The subtraction is saturating, because on machines with very few
-  // hardware threads `numItemMapThreads` may exceed `numThreads`.
-  return std::max<size_t>(
-      2, numThreads - std::min<size_t>(numThreads, numItemMapThreads));
-}
 }  // namespace detail
 
 struct TurtleTriple {
@@ -670,7 +655,7 @@ class RdfParallelParser : public RdfParserBase {
   // creates its own I/O thread and `AsyncBlockSource` internally. The
   // `blocksize` parameter controls the size of the underlying I/O block buffer,
   // and `numThreads` the total number of threads of the index build, of which
-  // this parser uses `detail::numParserThreads` many.
+  // this parser uses `numParserThreads` many (see `ConstantsIndexBuilding.h`).
   RdfParallelParser(const qlever::InputFileSpecification& spec,
                     ad_utility::MemorySize blocksize,
                     const EncodedIriManager* ev, uint32_t numThreads,
@@ -682,8 +667,7 @@ class RdfParallelParser : public RdfParserBase {
         defaultGraphIri_{defaultGraphIri},
         sleepTimeForTesting_(sleepTimeForTesting),
         parallelParser_{QUEUE_SIZE_BEFORE_PARALLEL_PARSING,
-                        detail::numParserThreads(numThreads),
-                        "parallel parser"} {
+                        numParserThreads(numThreads), "parallel parser"} {
     initialize(spec, blocksize);
   }
 
@@ -768,7 +752,7 @@ class RdfMultifileParser : public RdfParserBase {
                      uint32_t numThreads)
       : RdfParserBase{encodedIriManager},
         parsingQueue_{QUEUE_SIZE_BEFORE_PARALLEL_PARSING,
-                      detail::numParserThreads(numThreads)},
+                      numParserThreads(numThreads)},
         numThreads_{numThreads} {}
 
   // Construct the parser from a type-erased input range of file specifications
@@ -777,7 +761,7 @@ class RdfMultifileParser : public RdfParserBase {
   // files instead of the standard-compliant `Tokenizer` (see the comment on
   // `TurtleParser` above for the limitations of the relaxed mode).
   // `numThreads` is the total number of threads of the index build. This
-  // parser parses `detail::numParserThreads` many files concurrently, and
+  // parser parses `numParserThreads` many files concurrently, and
   // passes the number of threads on to the parser of each single file.
   RdfMultifileParser(
       ad_utility::InputRangeTypeErased<qlever::InputFileSpecification> files,

--- a/src/parser/RdfParser.h
+++ b/src/parser/RdfParser.h
@@ -57,19 +57,18 @@ std::optional<size_t> findEndOfLastNewline(std::string_view input);
 std::optional<size_t> findEndOfLastStatement(std::string_view input);
 
 // The number of threads that a parallel parser uses, given the total number of
-// threads `concurrencyLevel` available for the first phase of the index build
-// (see `DEFAULT_CONCURRENCY_LEVEL`). Parsing is roughly twice as expensive as
-// building the partial vocabularies, so the parsers get about two thirds of
-// the threads and the item maps the remaining third (see `numItemMapThreads`
-// in `IndexImpl.cpp`, which must agree with the split computed here). At least
+// threads `numThreads` available for the index build (see
+// `DEFAULT_NUM_THREADS`). Parsing is roughly twice as expensive as building
+// the partial vocabularies, so the parsers get about two thirds of the threads
+// and the item maps the remaining third (see `numItemMapThreads` in
+// `IndexImpl.cpp`, which must agree with the split computed here). At least
 // two threads are used.
-inline size_t numParserThreads(uint32_t concurrencyLevel) {
-  size_t numItemMapThreads = std::max<size_t>(2, (concurrencyLevel + 1) / 3);
+inline size_t numParserThreads(uint32_t numThreads) {
+  size_t numItemMapThreads = std::max<size_t>(2, (numThreads + 1) / 3);
   // NOTE: The subtraction is saturating, because on machines with very few
-  // hardware threads `numItemMapThreads` may exceed `concurrencyLevel`.
+  // hardware threads `numItemMapThreads` may exceed `numThreads`.
   return std::max<size_t>(
-      2,
-      concurrencyLevel - std::min<size_t>(concurrencyLevel, numItemMapThreads));
+      2, numThreads - std::min<size_t>(numThreads, numItemMapThreads));
 }
 }  // namespace detail
 
@@ -670,11 +669,11 @@ class RdfParallelParser : public RdfParserBase {
   // Construct a parser that reads from an `InputFileSpecification`. The parser
   // creates its own I/O thread and `AsyncBlockSource` internally. The
   // `blocksize` parameter controls the size of the underlying I/O block buffer,
-  // and `concurrencyLevel` the total number of threads of the index build, of
-  // which this parser uses `detail::numParserThreads` many.
+  // and `numThreads` the total number of threads of the index build, of which
+  // this parser uses `detail::numParserThreads` many.
   RdfParallelParser(const qlever::InputFileSpecification& spec,
                     ad_utility::MemorySize blocksize,
-                    const EncodedIriManager* ev, uint32_t concurrencyLevel,
+                    const EncodedIriManager* ev, uint32_t numThreads,
                     const TripleComponent& defaultGraphIri =
                         qlever::specialIds().at(DEFAULT_GRAPH_IRI),
                     std::chrono::milliseconds sleepTimeForTesting =
@@ -683,7 +682,7 @@ class RdfParallelParser : public RdfParserBase {
         defaultGraphIri_{defaultGraphIri},
         sleepTimeForTesting_(sleepTimeForTesting),
         parallelParser_{QUEUE_SIZE_BEFORE_PARALLEL_PARSING,
-                        detail::numParserThreads(concurrencyLevel),
+                        detail::numParserThreads(numThreads),
                         "parallel parser"} {
     initialize(spec, blocksize);
   }
@@ -766,23 +765,23 @@ class RdfMultifileParser : public RdfParserBase {
   // Construct a parser without any input, which is only useful for testing the
   // functions that don't depend on the input.
   RdfMultifileParser(const EncodedIriManager* encodedIriManager,
-                     uint32_t concurrencyLevel)
+                     uint32_t numThreads)
       : RdfParserBase{encodedIriManager},
         parsingQueue_{QUEUE_SIZE_BEFORE_PARALLEL_PARSING,
-                      detail::numParserThreads(concurrencyLevel)},
-        concurrencyLevel_{concurrencyLevel} {}
+                      detail::numParserThreads(numThreads)},
+        numThreads_{numThreads} {}
 
   // Construct the parser from a type-erased input range of file specifications
   // and eagerly start parsing them on background threads. If
   // `useRelaxedParsing` is true, the faster `TokenizerCtre` is used for all
   // files instead of the standard-compliant `Tokenizer` (see the comment on
   // `TurtleParser` above for the limitations of the relaxed mode).
-  // `concurrencyLevel` is the total number of threads of the index build. This
+  // `numThreads` is the total number of threads of the index build. This
   // parser parses `detail::numParserThreads` many files concurrently, and
-  // passes the concurrency level on to the parser of each single file.
+  // passes the number of threads on to the parser of each single file.
   RdfMultifileParser(
       ad_utility::InputRangeTypeErased<qlever::InputFileSpecification> files,
-      const EncodedIriManager* encodedIriManager, uint32_t concurrencyLevel,
+      const EncodedIriManager* encodedIriManager, uint32_t numThreads,
       ad_utility::MemorySize bufferSize = DEFAULT_PARSER_BUFFER_SIZE,
       bool useRelaxedParsing = false);
 
@@ -826,7 +825,7 @@ class RdfMultifileParser : public RdfParserBase {
   // The total number of threads of the index build, passed on to the parser
   // for a single file. Only read by the parsing threads, and never modified
   // after construction.
-  uint32_t concurrencyLevel_;
+  uint32_t numThreads_;
 
   // A thread that feeds the file specifications to the actual parser threads.
   ad_utility::JThread feederThread_;

--- a/test/RdfParserTest.cpp
+++ b/test/RdfParserTest.cpp
@@ -914,7 +914,7 @@ TEST(RdfParserTest, iriref) {
 
 // The smallest number of threads that the parsers accept. The tests
 // themselves are already run in parallel, so each parser should use as few
-// threads as possible (which is two, see `detail::numParserThreads`).
+// threads as possible (which is two, see `numParserThreads`).
 constexpr uint32_t minNumThreads = 1;
 
 // Parse the file at `filename` using a parser of type `Parser` and return the
@@ -1920,7 +1920,6 @@ TEST(RdfParserTest, findEndOfLastStatement) {
 
 // _____________________________________________________________________________
 TEST(RdfParserTest, numParserThreads) {
-  using detail::numParserThreads;
   // For sufficiently many threads, the parsers get about two thirds of them,
   // the remaining third goes to the item maps of the index build.
   EXPECT_EQ(numParserThreads(12), 8u);

--- a/test/RdfParserTest.cpp
+++ b/test/RdfParserTest.cpp
@@ -912,6 +912,11 @@ TEST(RdfParserTest, iriref) {
   runTestsForParser(ctreParser());
 }
 
+// The smallest concurrency level that the parsers accept. The tests
+// themselves are already run in parallel, so each parser should use as few
+// threads as possible (which is two, see `detail::numParserThreads`).
+constexpr uint32_t minConcurrencyLevel = 1;
+
 // Parse the file at `filename` using a parser of type `Parser` and return the
 // sorted result. The default size for the parse buffer in the following tests
 // is 1 kB (which is much less than the default value
@@ -922,16 +927,17 @@ template <typename Parser>
 std::vector<TurtleTriple> parseFromFile(
     const std::string& filename, ad_utility::MemorySize bufferSize = 1_kB) {
   auto parser = [&]() {
+    qlever::InputFileSpecification spec{filename, qlever::Filetype::Turtle,
+                                        std::nullopt};
     if constexpr (ad_utility::isSimilar<Parser, RdfMultifileParser>) {
-      return Parser{
-          ad_utility::InputRangeTypeErased{
-              std::vector<qlever::InputFileSpecification>{
-                  {filename, qlever::Filetype::Turtle, std::nullopt}}},
-          encodedIriManager(), bufferSize};
+      return Parser{ad_utility::InputRangeTypeErased{
+                        std::vector<qlever::InputFileSpecification>{spec}},
+                    encodedIriManager(), minConcurrencyLevel, bufferSize};
+    } else if constexpr (ad_utility::isInstantiation<Parser,
+                                                     RdfParallelParser>) {
+      return Parser{spec, bufferSize, encodedIriManager(), minConcurrencyLevel};
     } else {
-      return Parser{qlever::InputFileSpecification{
-                        filename, qlever::Filetype::Turtle, std::nullopt},
-                    bufferSize, encodedIriManager()};
+      return Parser{spec, bufferSize, encodedIriManager()};
     }
   }();
 
@@ -1264,17 +1270,19 @@ TEST(RdfParserTest, stopParsingOnOutsideFailure) {
     ad_utility::Timer timer{ad_utility::Timer::Stopped};
     {
       [[maybe_unused]] Parser parserChild = [&]() {
+        qlever::InputFileSpecification spec{filename, qlever::Filetype::Turtle,
+                                            std::nullopt};
         if constexpr (ad_utility::isSimilar<Parser, RdfMultifileParser>) {
-          return Parser{
-              ad_utility::InputRangeTypeErased{
-                  std::vector<qlever::InputFileSpecification>{
-                      {filename, qlever::Filetype::Turtle, std::nullopt}}},
-              encodedIriManager(), 40_B};
+          return Parser{ad_utility::InputRangeTypeErased{
+                            std::vector<qlever::InputFileSpecification>{spec}},
+                        encodedIriManager(), minConcurrencyLevel, 40_B};
         } else {
-          return Parser{qlever::InputFileSpecification{
-                            filename, qlever::Filetype::Turtle, std::nullopt},
-                        ad_utility::MemorySize::bytes(40), encodedIriManager(),
-                        qlever::specialIds().at(DEFAULT_GRAPH_IRI), 10ms};
+          return Parser{spec,
+                        ad_utility::MemorySize::bytes(40),
+                        encodedIriManager(),
+                        minConcurrencyLevel,
+                        qlever::specialIds().at(DEFAULT_GRAPH_IRI),
+                        10ms};
         }
       }();
       timer.cont();
@@ -1351,7 +1359,7 @@ TEST(RdfParserTest, noGetBatchInStringParser) {
 TEST(RdfParserTest, dummyParsePositionOfMultifileParsers) {
   auto runTestsForParser = [](auto t) {
     using Parser = typename decltype(t)::type;
-    Parser parser{encodedIriManager()};
+    Parser parser{encodedIriManager(), minConcurrencyLevel};
     EXPECT_EQ(parser.getParsePosition(), 0u);
   };
   forAllMultifileParsers(runTestsForParser);
@@ -1388,7 +1396,7 @@ TEST(RdfParserTest, multifileParser) {
     specs.emplace_back(file2, qlever::Filetype::NQuad, "defaultGraphNQ",
                        useParallelParser);
     Parser p{ad_utility::InputRangeTypeErased{std::move(specs)},
-             encodedIriManager()};
+             encodedIriManager(), minConcurrencyLevel};
     std::vector<TurtleTriple> result;
     while (auto batch = p.getBatch()) {
       ql::ranges::copy(batch.value(), std::back_inserter(result));
@@ -1418,7 +1426,7 @@ TEST(RdfParserTest, multifileParserSelectsTokenizer) {
     specs.emplace_back(filename, qlever::Filetype::Turtle, std::nullopt, false);
     RdfMultifileParser parser{
         ad_utility::InputRangeTypeErased{std::move(specs)}, encodedIriManager(),
-        DEFAULT_PARSER_BUFFER_SIZE, useRelaxedParsing};
+        minConcurrencyLevel, DEFAULT_PARSER_BUFFER_SIZE, useRelaxedParsing};
     std::vector<TurtleTriple> result;
     while (auto batch = parser.getBatch()) {
       ql::ranges::copy(batch.value(), std::back_inserter(result));
@@ -1908,4 +1916,23 @@ TEST(RdfParserTest, findEndOfLastStatement) {
   // The last statement end is found.
   EXPECT_THAT(findEndOfLastStatement("a.\nbc.\ndef"), Optional(Eq(7u)));
   EXPECT_THAT(findEndOfLastStatement("a.\n# comment\n"), Optional(Eq(3u)));
+}
+
+// _____________________________________________________________________________
+TEST(RdfParserTest, numParserThreads) {
+  using detail::numParserThreads;
+  // For sufficiently many threads, the parsers get about two thirds of them,
+  // the remaining third goes to the item maps of the index build.
+  EXPECT_EQ(numParserThreads(12), 8u);
+  EXPECT_EQ(numParserThreads(16), 11u);
+  EXPECT_EQ(numParserThreads(9), 6u);
+  EXPECT_EQ(numParserThreads(5), 3u);
+  // At least two threads are used, even if that means using more threads in
+  // total than the concurrency level allows.
+  EXPECT_EQ(numParserThreads(4), 2u);
+  EXPECT_EQ(numParserThreads(1), 2u);
+  // A concurrency level of zero is rejected by
+  // `IndexBuilderConfig::validate()`, but the computation is still
+  // well-defined (in particular, the subtraction doesn't underflow).
+  EXPECT_EQ(numParserThreads(0), 2u);
 }

--- a/test/RdfParserTest.cpp
+++ b/test/RdfParserTest.cpp
@@ -912,10 +912,19 @@ TEST(RdfParserTest, iriref) {
   runTestsForParser(ctreParser());
 }
 
-// The smallest number of threads that the parsers accept. The tests
-// themselves are already run in parallel, so each parser should use as few
-// threads as possible (which is two, see `numParserThreads`).
+// The smallest number of threads that the parsers accept. The tests themselves
+// are already run in parallel, so each parser should use as few threads as
+// possible. NOTE: For an `RdfParallelParser` this is the number of threads that
+// the parser itself uses, for an `RdfMultifileParser` it is the total number of
+// threads of the index build, which is then divided among the input files (see
+// `ConstantsIndexBuilding.h`).
 constexpr uint32_t minNumThreads = 1;
+
+// The number of threads that an `RdfMultifileParser` gives to the parser of a
+// single input file. In production this is computed from the total number of
+// threads and the number of input files, see `numParserThreadsPerFile` in
+// `IndexImpl.cpp`.
+constexpr uint32_t minNumThreadsPerFile = 1;
 
 // Parse the file at `filename` using a parser of type `Parser` and return the
 // sorted result. The default size for the parse buffer in the following tests
@@ -932,7 +941,8 @@ std::vector<TurtleTriple> parseFromFile(
     if constexpr (ad_utility::isSimilar<Parser, RdfMultifileParser>) {
       return Parser{ad_utility::InputRangeTypeErased{
                         std::vector<qlever::InputFileSpecification>{spec}},
-                    encodedIriManager(), minNumThreads, bufferSize};
+                    encodedIriManager(), minNumThreads, minNumThreadsPerFile,
+                    bufferSize};
     } else if constexpr (ad_utility::isInstantiation<Parser,
                                                      RdfParallelParser>) {
       return Parser{spec, bufferSize, encodedIriManager(), minNumThreads};
@@ -1275,7 +1285,8 @@ TEST(RdfParserTest, stopParsingOnOutsideFailure) {
         if constexpr (ad_utility::isSimilar<Parser, RdfMultifileParser>) {
           return Parser{ad_utility::InputRangeTypeErased{
                             std::vector<qlever::InputFileSpecification>{spec}},
-                        encodedIriManager(), minNumThreads, 40_B};
+                        encodedIriManager(), minNumThreads,
+                        minNumThreadsPerFile, 40_B};
         } else {
           return Parser{spec,
                         ad_utility::MemorySize::bytes(40),
@@ -1396,7 +1407,7 @@ TEST(RdfParserTest, multifileParser) {
     specs.emplace_back(file2, qlever::Filetype::NQuad, "defaultGraphNQ",
                        useParallelParser);
     Parser p{ad_utility::InputRangeTypeErased{std::move(specs)},
-             encodedIriManager(), minNumThreads};
+             encodedIriManager(), minNumThreads, minNumThreadsPerFile};
     std::vector<TurtleTriple> result;
     while (auto batch = p.getBatch()) {
       ql::ranges::copy(batch.value(), std::back_inserter(result));
@@ -1425,8 +1436,12 @@ TEST(RdfParserTest, multifileParserSelectsTokenizer) {
     std::vector<qlever::InputFileSpecification> specs;
     specs.emplace_back(filename, qlever::Filetype::Turtle, std::nullopt, false);
     RdfMultifileParser parser{
-        ad_utility::InputRangeTypeErased{std::move(specs)}, encodedIriManager(),
-        minNumThreads, DEFAULT_PARSER_BUFFER_SIZE, useRelaxedParsing};
+        ad_utility::InputRangeTypeErased{std::move(specs)},
+        encodedIriManager(),
+        minNumThreads,
+        minNumThreadsPerFile,
+        DEFAULT_PARSER_BUFFER_SIZE,
+        useRelaxedParsing};
     std::vector<TurtleTriple> result;
     while (auto batch = parser.getBatch()) {
       ql::ranges::copy(batch.value(), std::back_inserter(result));

--- a/test/RdfParserTest.cpp
+++ b/test/RdfParserTest.cpp
@@ -912,10 +912,10 @@ TEST(RdfParserTest, iriref) {
   runTestsForParser(ctreParser());
 }
 
-// The smallest concurrency level that the parsers accept. The tests
+// The smallest number of threads that the parsers accept. The tests
 // themselves are already run in parallel, so each parser should use as few
 // threads as possible (which is two, see `detail::numParserThreads`).
-constexpr uint32_t minConcurrencyLevel = 1;
+constexpr uint32_t minNumThreads = 1;
 
 // Parse the file at `filename` using a parser of type `Parser` and return the
 // sorted result. The default size for the parse buffer in the following tests
@@ -932,10 +932,10 @@ std::vector<TurtleTriple> parseFromFile(
     if constexpr (ad_utility::isSimilar<Parser, RdfMultifileParser>) {
       return Parser{ad_utility::InputRangeTypeErased{
                         std::vector<qlever::InputFileSpecification>{spec}},
-                    encodedIriManager(), minConcurrencyLevel, bufferSize};
+                    encodedIriManager(), minNumThreads, bufferSize};
     } else if constexpr (ad_utility::isInstantiation<Parser,
                                                      RdfParallelParser>) {
-      return Parser{spec, bufferSize, encodedIriManager(), minConcurrencyLevel};
+      return Parser{spec, bufferSize, encodedIriManager(), minNumThreads};
     } else {
       return Parser{spec, bufferSize, encodedIriManager()};
     }
@@ -1275,12 +1275,12 @@ TEST(RdfParserTest, stopParsingOnOutsideFailure) {
         if constexpr (ad_utility::isSimilar<Parser, RdfMultifileParser>) {
           return Parser{ad_utility::InputRangeTypeErased{
                             std::vector<qlever::InputFileSpecification>{spec}},
-                        encodedIriManager(), minConcurrencyLevel, 40_B};
+                        encodedIriManager(), minNumThreads, 40_B};
         } else {
           return Parser{spec,
                         ad_utility::MemorySize::bytes(40),
                         encodedIriManager(),
-                        minConcurrencyLevel,
+                        minNumThreads,
                         qlever::specialIds().at(DEFAULT_GRAPH_IRI),
                         10ms};
         }
@@ -1359,7 +1359,7 @@ TEST(RdfParserTest, noGetBatchInStringParser) {
 TEST(RdfParserTest, dummyParsePositionOfMultifileParsers) {
   auto runTestsForParser = [](auto t) {
     using Parser = typename decltype(t)::type;
-    Parser parser{encodedIriManager(), minConcurrencyLevel};
+    Parser parser{encodedIriManager(), minNumThreads};
     EXPECT_EQ(parser.getParsePosition(), 0u);
   };
   forAllMultifileParsers(runTestsForParser);
@@ -1396,7 +1396,7 @@ TEST(RdfParserTest, multifileParser) {
     specs.emplace_back(file2, qlever::Filetype::NQuad, "defaultGraphNQ",
                        useParallelParser);
     Parser p{ad_utility::InputRangeTypeErased{std::move(specs)},
-             encodedIriManager(), minConcurrencyLevel};
+             encodedIriManager(), minNumThreads};
     std::vector<TurtleTriple> result;
     while (auto batch = p.getBatch()) {
       ql::ranges::copy(batch.value(), std::back_inserter(result));
@@ -1426,7 +1426,7 @@ TEST(RdfParserTest, multifileParserSelectsTokenizer) {
     specs.emplace_back(filename, qlever::Filetype::Turtle, std::nullopt, false);
     RdfMultifileParser parser{
         ad_utility::InputRangeTypeErased{std::move(specs)}, encodedIriManager(),
-        minConcurrencyLevel, DEFAULT_PARSER_BUFFER_SIZE, useRelaxedParsing};
+        minNumThreads, DEFAULT_PARSER_BUFFER_SIZE, useRelaxedParsing};
     std::vector<TurtleTriple> result;
     while (auto batch = parser.getBatch()) {
       ql::ranges::copy(batch.value(), std::back_inserter(result));
@@ -1928,11 +1928,11 @@ TEST(RdfParserTest, numParserThreads) {
   EXPECT_EQ(numParserThreads(9), 6u);
   EXPECT_EQ(numParserThreads(5), 3u);
   // At least two threads are used, even if that means using more threads in
-  // total than the concurrency level allows.
+  // total than `numThreads` allows.
   EXPECT_EQ(numParserThreads(4), 2u);
   EXPECT_EQ(numParserThreads(1), 2u);
-  // A concurrency level of zero is rejected by
-  // `IndexBuilderConfig::validate()`, but the computation is still
-  // well-defined (in particular, the subtraction doesn't underflow).
+  // A value of zero is rejected by `IndexBuilderConfig::validate()`, but the
+  // computation is still well-defined (in particular, the subtraction doesn't
+  // underflow).
   EXPECT_EQ(numParserThreads(0), 2u);
 }

--- a/test/libqlever/QleverTest.cpp
+++ b/test/libqlever/QleverTest.cpp
@@ -235,6 +235,13 @@ TEST(IndexBuilderConfig, validate) {
   AD_EXPECT_THROW_WITH_MESSAGE(c.validate(), HasSubstr("must be between"));
 
   c = IndexBuilderConfig{};
+  c.concurrencyLevel_ = 0;
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      c.validate(), HasSubstr("--concurrency-level must be greater"));
+  c.concurrencyLevel_ = 1;
+  EXPECT_NO_THROW(c.validate());
+
+  c = IndexBuilderConfig{};
   c.wordsfile_ = "blibb";
   AD_EXPECT_THROW_WITH_MESSAGE(c.validate(),
                                HasSubstr("Only specified wordsfile"));

--- a/test/libqlever/QleverTest.cpp
+++ b/test/libqlever/QleverTest.cpp
@@ -235,10 +235,10 @@ TEST(IndexBuilderConfig, validate) {
   AD_EXPECT_THROW_WITH_MESSAGE(c.validate(), HasSubstr("must be between"));
 
   c = IndexBuilderConfig{};
-  c.concurrencyLevel_ = 0;
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      c.validate(), HasSubstr("--concurrency-level must be greater"));
-  c.concurrencyLevel_ = 1;
+  c.numThreads_ = 0;
+  AD_EXPECT_THROW_WITH_MESSAGE(c.validate(),
+                               HasSubstr("--num-threads must be greater"));
+  c.numThreads_ = 1;
   EXPECT_NO_THROW(c.validate());
 
   c = IndexBuilderConfig{};


### PR DESCRIPTION
So far, the numbers of threads that the index build uses for parsing the input (8) and for building the partial vocabularies (10, see #3335) were compile-time constants. This change adds the option `--num-threads` (short `-j`) to `qlever-index`, which defaults to the number of hardware threads of the machine. About two thirds of the threads go to the parsing (at least 2) and the remaining third to the building of the partial vocabularies (at least 2), because parsing is roughly twice as expensive as building the hash maps. With 32 hardware threads, that is 21 threads for the parsing and 11 threads for the partial vocabularies.

NOTE: As before, each input file gets its own parser with the full number of parsing threads, and with several input files, up to that many files are parsed at the same time (with 32 hardware threads: up to 21 files with 21 threads each). The threads for the partial vocabularies are shared by all files. Making `--num-threads` a limit for the whole index build, including the later stages (merging the vocabulary, writing the permutations), is left to a follow-up.