### PR TITLE
Add a lazy `CompressedRelationReader::getDistinctCol0Ids`

### DIFF
--- a/src/index/CMakeLists.txt
+++ b/src/index/CMakeLists.txt
@@ -20,7 +20,7 @@ add_library(index
         IndexMetaData.cpp MetaDataHandler.cpp
         LocatedTriples.cpp Permutation.cpp TextMetaData.cpp
         DocsDB.cpp FTSAlgorithms.cpp
-        CompressedRelation.cpp
+        CompressedRelation.cpp DistinctCol0Ids.cpp
         PatternCreator.cpp ScanSpecification.cpp
         DeltaTriples.cpp TextScoring.cpp TextScoringEnum.cpp TextIndexReadWrite.cpp
         TextIndexBuilder.cpp GraphFilter.cpp IndexRebuilder.cpp GraphNameManager.cpp

--- a/src/index/CompressedRelation.cpp
+++ b/src/index/CompressedRelation.cpp
@@ -14,6 +14,7 @@
 #include "index/CompressedRelationHelpersImpl.h"
 #include "index/CompressedRelationPermutationWriterImpl.h"
 #include "index/ConstantsIndexBuilding.h"
+#include "index/DistinctCol0Ids.h"
 #include "index/GraphComputation.h"
 #include "index/IdTableUtils.h"
 #include "index/LocatedTriples.h"
@@ -987,6 +988,91 @@ size_t CompressedRelationReader::getResultSizeOfScan(
   return lower;
 }
 
+#ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
+// ____________________________________________________________________________
+cppcoro::generator<IdTable, CompressedRelationReader::LazyScanMetadata>
+CompressedRelationReader::getDistinctCol0Ids(
+    ScanSpecAndBlocks scanSpecAndBlocks, bool addGraphColumn,
+    std::optional<std::vector<Id>> idFilter,
+    CancellationHandle cancellationHandle,
+    const LocatedTriplesPerBlock& locatedTriplesPerBlock) const {
+  using namespace distinctCol0Ids;
+  AD_CONTRACT_CHECK(cancellationHandle != nullptr);
+  AD_CONTRACT_CHECK(scanSpecAndBlocks.scanSpec_.firstFreeColIndex() == 0,
+                    "`getDistinctCol0Ids` only supports full scans.");
+  AD_EXPENSIVE_CHECK(!idFilter.has_value() ||
+                     ql::ranges::is_sorted(idFilter.value()));
+
+  ColumnIndices additionalColumns =
+      addGraphColumn ? ColumnIndices{ADDITIONAL_COLUMN_GRAPH_ID}
+                     : ColumnIndices{};
+  // `BlockSelector` needs the graph filter of the scan, in particular its
+  // `canBlockBeSkipped`. Only the filter of the config is used, so the columns
+  // that it computes on the side don't matter here.
+  auto scanConfig = getScanConfig(scanSpecAndBlocks.scanSpec_,
+                                  additionalColumns, locatedTriplesPerBlock);
+  auto [blocksToRead, fromMetadata] =
+      BlockSelector{scanConfig.graphFilter_, addGraphColumn, idFilter,
+                    locatedTriplesPerBlock, allocator_}
+          .select(scanSpecAndBlocks);
+
+  // Let the inner scan write its statistics (most importantly the number of
+  // blocks it actually read) directly into our own details, such that the
+  // consumer of this generator sees them.
+  auto& details = co_await cppcoro::getDetails;
+  details.numBlocksAll_ = scanSpecAndBlocks.sizeBlockMetadata_;
+  auto scan = lazyScan(scanSpecAndBlocks.scanSpec_, std::move(blocksToRead),
+                       std::move(additionalColumns), cancellationHandle,
+                       locatedTriplesPerBlock, {});
+  scan.setDetailsPointer(&details);
+
+  // The IDs are computed by merging two ascending sources: the IDs that are
+  // known from the block metadata alone, and the IDs from the blocks that had
+  // to be read. We process one ID at a time and collect its graph IDs (if
+  // requested) from both sources before appending it to the result.
+  IdCursor fromMetadataCursor{
+      std::move(fromMetadata),
+      addGraphColumn ? std::optional{ColumnIndex{1}} : std::nullopt};
+  IdCursor fromBlocksCursor{
+      [&scan]() { return scan.get(); },
+      addGraphColumn ? std::optional{graphColumnInBlock} : std::nullopt};
+  RequestedIds requestedIds{idFilter};
+
+  GraphSet graphs{allocator_};
+  ad_utility::VectorWithMemoryLimit<Id> sortedGraphs{allocator_};
+  IdTable result = makeResultTable(addGraphColumn, idFilter, allocator_);
+  for (;;) {
+    cancellationHandle->throwIfCancelled();
+    auto id = smallerId(fromMetadataCursor.peek(), fromBlocksCursor.peek());
+    if (!id.has_value()) {
+      break;
+    }
+    graphs.clear();
+    fromMetadataCursor.consumeId(id.value(), graphs);
+    fromBlocksCursor.consumeId(id.value(), graphs);
+    // Blocks that had to be read can contain IDs that weren't requested.
+    if (requestedIds.contains(id.value())) {
+      appendRowsForId(result, id.value(), graphs, sortedGraphs);
+    }
+    if (result.numRows() >= chunkSize) {
+      co_yield std::move(result);
+      result = makeResultTable(addGraphColumn, idFilter, allocator_);
+    }
+  }
+  if (!result.empty()) {
+    co_yield std::move(result);
+  }
+}
+#endif  // QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
+
+// ____________________________________________________________________________
+bool CompressedRelationReader::contentsAreKnownFromMetadata(
+    const CompressedBlockMetadata& block, size_t numColumns,
+    const LocatedTriplesPerBlock& locatedTriples) {
+  return !block.containsInconsistentTriples(numColumns) &&
+         !locatedTriples.containsTriples(block.blockIndex_);
+}
+
 // ____________________________________________________________________________
 IdTable CompressedRelationReader::getDistinctColIdsAndCounts(
     ColumnIndex columnIndex, const ScanSpecAndBlocks& scanSpecAndBlocks,
@@ -1055,12 +1141,10 @@ IdTable CompressedRelationReader::getDistinctColIdsAndCounts(
   // contain more than one different `colId`. For the others, we can determine
   // the count from the metadata.
   for (const auto& [i, blockMetadata] : ranges::views::enumerate(blocks)) {
-    // The `numRows_` metadata shortcut is safe iff all rows of the block
-    // agree on the grouped column AND the block has no delta triples. The
-    // column uniformity is equivalent to `firstTriple_` and `lastTriple_`
-    // agreeing on the first `columnIndex + 1` columns.
-    if (!blockMetadata.containsInconsistentTriples(columnIndex + 1) &&
-        !locatedTriplesPerBlock.containsTriples(blockMetadata.blockIndex_)) {
+    // The `numRows_` metadata shortcut is safe iff all rows of the block agree
+    // on the grouped column AND the block has no delta triples.
+    if (contentsAreKnownFromMetadata(blockMetadata, columnIndex + 1,
+                                     locatedTriplesPerBlock)) {
       // The whole block has the same `colId` and no delta triples ->
       // we get all the information from the metadata.
       Id colId = getMaskedTriple(blockMetadata.firstTriple_)[columnIndex];

--- a/src/index/CompressedRelation.cpp
+++ b/src/index/CompressedRelation.cpp
@@ -1006,9 +1006,11 @@ CompressedRelationReader::getDistinctCol0Ids(
   ColumnIndices additionalColumns =
       addGraphColumn ? ColumnIndices{ADDITIONAL_COLUMN_GRAPH_ID}
                      : ColumnIndices{};
-  // `BlockSelector` needs the graph filter of the scan, in particular its
-  // `canBlockBeSkipped`. Only the filter of the config is used, so the columns
-  // that it computes on the side don't matter here.
+  // Set up the same scan configuration that the actual scan below will use.
+  // Out of that configuration we only need the `graphFilter_`, which knows
+  // which blocks can be skipped entirely and which graphs are allowed; the
+  // columns that `getScanConfig` also computes are only relevant for the scan
+  // itself, which computes them again for its own blocks.
   auto scanConfig = getScanConfig(scanSpecAndBlocks.scanSpec_,
                                   additionalColumns, locatedTriplesPerBlock);
   auto [blocksToRead, fromMetadata] =
@@ -1032,15 +1034,14 @@ CompressedRelationReader::getDistinctCol0Ids(
   // requested) from both sources before appending it to the result.
   IdCursor fromMetadataCursor{
       std::move(fromMetadata),
-      addGraphColumn ? std::optional{ColumnIndex{1}} : std::nullopt};
+      graphColumnIfRequested(addGraphColumn, graphColumnInResult)};
   IdCursor fromBlocksCursor{
       [&scan]() { return scan.get(); },
-      addGraphColumn ? std::optional{graphColumnInBlock} : std::nullopt};
-  RequestedIds requestedIds{idFilter};
+      graphColumnIfRequested(addGraphColumn, graphColumnInBlock)};
+  RequestedIdsCursor requestedIds{idFilter};
 
   GraphSet graphs{allocator_};
-  ad_utility::VectorWithMemoryLimit<Id> sortedGraphs{allocator_};
-  IdTable result = makeResultTable(addGraphColumn, idFilter, allocator_);
+  ResultBuilder result{addGraphColumn, idFilter, allocator_};
   for (;;) {
     cancellationHandle->throwIfCancelled();
     auto id = smallerId(fromMetadataCursor.peek(), fromBlocksCursor.peek());
@@ -1051,19 +1052,34 @@ CompressedRelationReader::getDistinctCol0Ids(
     fromMetadataCursor.consumeId(id.value(), graphs);
     fromBlocksCursor.consumeId(id.value(), graphs);
     // Blocks that had to be read can contain IDs that weren't requested.
-    if (requestedIds.contains(id.value())) {
-      appendRowsForId(result, id.value(), graphs, sortedGraphs);
+    if (requestedIds.advanceTo(id.value())) {
+      result.addId(id.value(), graphs);
     }
-    if (result.numRows() >= chunkSize) {
-      co_yield std::move(result);
-      result = makeResultTable(addGraphColumn, idFilter, allocator_);
+    if (result.chunkIsFull()) {
+      co_yield result.extractChunk();
     }
   }
-  if (!result.empty()) {
-    co_yield std::move(result);
+  if (!result.chunkIsEmpty()) {
+    co_yield result.extractChunk();
   }
 }
 #endif  // QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
+
+// ____________________________________________________________________________
+bool CompressedRelationReader::columnValuesAreKnownFromMetadata(
+    const CompressedBlockMetadata& block, size_t numColumns,
+    const LocatedTriplesPerBlock& locatedTriples) {
+  if (block.containsInconsistentTriples(numColumns)) {
+    return false;
+  }
+  // Each of the delta triples can delete at most one of the block's triples, so
+  // if there are fewer of them than the block has rows, then at least one of
+  // its triples remains. Note that `numTriples` only returns an upper bound
+  // (which is on the safe side here), and that the block that purely consists
+  // of delta triples has `numRows_ == 0` and is thus handled correctly, too.
+  return locatedTriples.numTriples(block.blockIndex_).numDeleted_ <
+         block.numRows_;
+}
 
 // ____________________________________________________________________________
 bool CompressedRelationReader::contentsAreKnownFromMetadata(

--- a/src/index/CompressedRelation.h
+++ b/src/index/CompressedRelation.h
@@ -20,6 +20,7 @@
 #include "parser/data/LimitOffsetClause.h"
 #include "util/CancellationHandle.h"
 #include "util/File.h"
+#include "util/Generator.h"
 #include "util/MemorySize/MemorySize.h"
 #include "util/Serializer/SerializeArrayOrTuple.h"
 #include "util/Serializer/SerializeOptional.h"
@@ -850,6 +851,52 @@ class CompressedRelationReader {
       const LocatedTriplesPerBlock& locatedTriplesPerBlock) const;
 
  public:
+#ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
+  // Lazily compute the distinct `col0Id`s of a full scan of the permutation
+  // that this reader reads from (none of the columns of
+  // `scanSpecAndBlocks.scanSpec_` may be fixed).
+  //
+  // If `addGraphColumn` is false, the yielded `IdTable`s have a single column
+  // that contains the distinct `col0Id`s. If it is true, they have a second
+  // column with the graph IDs, and the pairs of `col0Id` and graph ID are
+  // distinct. In both cases the yielded tables are sorted, and their
+  // concatenation is sorted and free of duplicates.
+  //
+  // If `idFilter` is specified, only `col0Id`s that are contained in it are
+  // returned. It has to be sorted in ascending order and must neither contain
+  // duplicates nor undefined IDs. Blocks that cannot contain any of the
+  // requested IDs are then not read at all.
+  //
+  // Blocks whose contribution can already be determined from their metadata
+  // alone (which is the case for all blocks that only contain a single
+  // `col0Id`) are never read, which makes this much cheaper than a full scan
+  // followed by a `DISTINCT`.
+  //
+  // The `LazyScanMetadata` of the returned generator is that of the inner scan
+  // over the blocks that actually had to be read, with `numBlocksAll_` set to
+  // the total number of blocks of the scan.
+  //
+  // NOTE: This reader and `locatedTriplesPerBlock` have to be kept alive until
+  // the returned generator has been fully consumed.
+  //
+  // The helper classes for the implementation live in `DistinctCol0Ids.h`.
+  cppcoro::generator<IdTable, LazyScanMetadata> getDistinctCol0Ids(
+      ScanSpecAndBlocks scanSpecAndBlocks, bool addGraphColumn,
+      std::optional<std::vector<Id>> idFilter,
+      CancellationHandle cancellationHandle,
+      const LocatedTriplesPerBlock& locatedTriplesPerBlock) const;
+#endif
+
+  // Return true iff the contents of the given block, restricted to its first
+  // `numColumns` columns, are already known from its metadata alone. This
+  // requires that all the triples of the block agree on those columns (which
+  // the metadata knows because it stores the first and the last triple), and
+  // that there are no delta triples for the block, as those might have deleted
+  // some of its triples or added new ones.
+  static bool contentsAreKnownFromMetadata(
+      const CompressedBlockMetadata& block, size_t numColumns,
+      const LocatedTriplesPerBlock& locatedTriples);
+
   // Determine the distinct values and their counts for the column at
   // `columnIndex` (must be 0 or 1). Used for GROUP BY optimizations.
   IdTable getDistinctColIdsAndCounts(

--- a/src/index/CompressedRelation.h
+++ b/src/index/CompressedRelation.h
@@ -868,9 +868,9 @@ class CompressedRelationReader {
   // requested IDs are then not read at all.
   //
   // Blocks whose contribution can already be determined from their metadata
-  // alone (which is the case for all blocks that only contain a single
-  // `col0Id`) are never read, which makes this much cheaper than a full scan
-  // followed by a `DISTINCT`.
+  // alone (which is the case for almost all blocks that only contain a single
+  // `col0Id`, see `columnValuesAreKnownFromMetadata`) are never read, which
+  // makes this much cheaper than a full scan followed by a `DISTINCT`.
   //
   // The `LazyScanMetadata` of the returned generator is that of the inner scan
   // over the blocks that actually had to be read, with `numBlocksAll_` set to
@@ -887,12 +887,31 @@ class CompressedRelationReader {
       const LocatedTriplesPerBlock& locatedTriplesPerBlock) const;
 #endif
 
-  // Return true iff the contents of the given block, restricted to its first
-  // `numColumns` columns, are already known from its metadata alone. This
-  // requires that all the triples of the block agree on those columns (which
-  // the metadata knows because it stores the first and the last triple), and
-  // that there are no delta triples for the block, as those might have deleted
-  // some of its triples or added new ones.
+  // Return true iff the values of the first `numColumns` columns of all the
+  // triples of the given block are already known from its metadata alone,
+  // which is the case iff
+  // 1. All the triples of the block agree on those columns. The metadata knows
+  //    this because it stores the first and the last triple of the block,
+  //    including the delta triples that were inserted into it (see
+  //    `LocatedTriplesPerBlock::updateAugmentedMetadata`), so if those agree,
+  //    then so do all the triples in between.
+  // 2. The block still contains at least one triple. Delta triples might have
+  //    deleted all of them, but we can rule that out if there are fewer delta
+  //    triples for the block than it has rows, as each delta triple can delete
+  //    at most one of them.
+  //
+  // NOTE: The *number* of triples of the block is not known in this case, as
+  // delta triples may have deleted some of them (and inserted others). Use
+  // `contentsAreKnownFromMetadata` if you need that.
+  static bool columnValuesAreKnownFromMetadata(
+      const CompressedBlockMetadata& block, size_t numColumns,
+      const LocatedTriplesPerBlock& locatedTriples);
+
+  // Return true iff the complete contents of the given block, restricted to
+  // its first `numColumns` columns, are already known from its metadata alone,
+  // including the number of triples. In addition to
+  // `columnValuesAreKnownFromMetadata` this requires that there are no delta
+  // triples for the block at all.
   static bool contentsAreKnownFromMetadata(
       const CompressedBlockMetadata& block, size_t numColumns,
       const LocatedTriplesPerBlock& locatedTriples);

--- a/src/index/DistinctCol0Ids.cpp
+++ b/src/index/DistinctCol0Ids.cpp
@@ -33,38 +33,6 @@ std::optional<Id> smallerId(std::optional<Id> first, std::optional<Id> second) {
   return std::min(first.value(), second.value());
 }
 
-// Create an empty table for the result of `getDistinctCol0Ids`, with enough
-// space reserved for one chunk (or for fewer rows if only few IDs were
-// requested).
-IdTable makeResultTable(bool addGraphColumn,
-                        const std::optional<std::vector<Id>>& idFilter,
-                        const CompressedRelationReader::Allocator& allocator) {
-  IdTable table{addGraphColumn ? 2u : 1u, allocator};
-  table.reserve(idFilter.has_value()
-                    ? std::min(chunkSize, idFilter.value().size())
-                    : chunkSize);
-  return table;
-}
-
-// Append the rows for a single distinct `id` to `result`. If `result` has a
-// graph column, one row per graph ID is appended, else a single row.
-void appendRowsForId(IdTable& result, Id id, const GraphSet& graphs,
-                     ad_utility::VectorWithMemoryLimit<Id>& sortedGraphs) {
-  if (result.numColumns() == 1) {
-    result.push_back({id});
-    return;
-  }
-  // The graph IDs have to be sorted. `sortedGraphs` is reused across the
-  // `col0Id`s so that this doesn't allocate for each of them.
-  sortedGraphs.assign(graphs.begin(), graphs.end());
-  ql::ranges::sort(sortedGraphs);
-  // `IdTable`s are stored in column-major order, so we write the two columns
-  // separately instead of row by row.
-  size_t numRows = result.numRows();
-  result.resize(numRows + sortedGraphs.size());
-  ql::ranges::fill(result.getColumn(0).subspan(numRows), id);
-  ql::ranges::copy(sortedGraphs, result.getColumn(1).begin() + numRows);
-}
 // _____________________________________________________________________________
 BlockSelector::BlockSelector(
     const CompressedRelationReader::FilterDuplicatesAndGraphs& filter,
@@ -75,7 +43,7 @@ BlockSelector::BlockSelector(
       addGraphColumn_{addGraphColumn},
       idFilter_{idFilter},
       locatedTriples_{locatedTriples},
-      result_{{}, IdTable{addGraphColumn ? 2u : 1u, allocator}} {}
+      result_{{}, IdTable{numResultColumns(addGraphColumn), allocator}} {}
 
 // _____________________________________________________________________________
 SelectedBlocks BlockSelector::select(
@@ -114,17 +82,22 @@ bool BlockSelector::blockNeedsToBeRead(
     const CompressedBlockMetadata& block) const {
   // We take the single `col0Id` of the block from its metadata, so the block
   // has to be read if it holds several `col0Id`s (we would miss the ones in
-  // between), or if there are delta triples for it, which might have deleted
-  // that `col0Id` or added further ones. Reading the block merges the located
-  // triples in and hence gives us the actual contents.
-  if (!CompressedRelationReader::contentsAreKnownFromMetadata(
+  // between), or if we cannot rule out that all of its triples were deleted by
+  // delta triples. Reading the block merges the located triples in and hence
+  // gives us the actual contents.
+  if (!CompressedRelationReader::columnValuesAreKnownFromMetadata(
           block, 1, locatedTriples_)) {
     return true;
   }
   // At this point the single `col0Id` of the block is known, so we only have to
   // read it if we need graph IDs that the metadata doesn't know, or if we
-  // cannot rule out that the graph filter removes all of its triples.
-  return !block.graphInfo_.has_value() &&
+  // cannot rule out that the graph filter removes all of its triples. Note that
+  // the graph info of a block with delta triples is only an upper bound (the
+  // graph of a deleted triple is still listed there), so it cannot be used to
+  // determine the graphs that actually remain.
+  bool graphsAreKnown = block.graphInfo_.has_value() &&
+                        !locatedTriples_.containsTriples(block.blockIndex_);
+  return !graphsAreKnown &&
          (addGraphColumn_ || !filter_.graphFilter_.areAllGraphsAllowed());
 }
 
@@ -132,8 +105,8 @@ bool BlockSelector::blockNeedsToBeRead(
 void BlockSelector::addToMetadata(Id id, Id graph) {
   IdTable& table = result_.fromMetadata_;
   size_t numRows = table.numRows();
-  if (numRows != 0 && table(numRows - 1, 0) == id &&
-      (!addGraphColumn_ || table(numRows - 1, 1) == graph)) {
+  if (numRows != 0 && table(numRows - 1, idColumn) == id &&
+      (!addGraphColumn_ || table(numRows - 1, graphColumnInResult) == graph)) {
     return;
   }
   if (addGraphColumn_) {
@@ -162,23 +135,28 @@ void BlockSelector::forEachCandidateBlock(
   // The blocks are sorted by their `col0Id`s, so for each of the requested IDs
   // we can binary search the blocks that might contain it.
   for (const auto& blocks : scanSpecAndBlocks.blockMetadata_) {
-    auto block = blocks.begin();
-    auto firstUnhandledBlock = blocks.begin();
+    auto blockIt = blocks.begin();
+    // A single block can contain several of the requested IDs, so the ranges of
+    // candidate blocks of two consecutive requested IDs can overlap. This
+    // iterator keeps track of the first block for which `action` hasn't been
+    // called yet, such that each block is handled at most once.
+    auto firstUnhandledBlockIt = blocks.begin();
     while (id != ids.end()) {
       // Skip all the blocks that only contain smaller `col0Id`s.
-      block = ql::ranges::lower_bound(block, blocks.end(), *id, {}, lastCol0Id);
-      if (block == blocks.end()) {
+      blockIt =
+          ql::ranges::lower_bound(blockIt, blocks.end(), *id, {}, lastCol0Id);
+      if (blockIt == blocks.end()) {
         break;
       }
       // All the blocks that start with a `col0Id` that is not larger than `*id`
       // might contain it. Note that they all end with a `col0Id` that is at
-      // least `*id`, because `block` does and the blocks are sorted.
+      // least `*id`, because `blockIt` does and the blocks are sorted.
       auto end =
-          ql::ranges::upper_bound(block, blocks.end(), *id, {}, firstCol0Id);
+          ql::ranges::upper_bound(blockIt, blocks.end(), *id, {}, firstCol0Id);
       ql::ranges::for_each(
-          ql::ranges::subrange{std::max(block, firstUnhandledBlock), end},
+          ql::ranges::subrange{std::max(blockIt, firstUnhandledBlockIt), end},
           action);
-      firstUnhandledBlock = std::max(firstUnhandledBlock, end);
+      firstUnhandledBlockIt = std::max(firstUnhandledBlockIt, end);
       ++id;
     }
     if (id == ids.end()) {
@@ -188,55 +166,113 @@ void BlockSelector::forEachCandidateBlock(
 }
 
 // _____________________________________________________________________________
-IdCursor::IdCursor(TableSource nextTable,
+IdCursor::IdCursor(TableSource getNextTable,
                    std::optional<ColumnIndex> graphColumn)
-    : nextTable_{std::move(nextTable)}, graphColumn_{graphColumn} {}
+    : getNextTable_{std::move(getNextTable)}, graphColumn_{graphColumn} {}
 
 // _____________________________________________________________________________
 IdCursor::IdCursor(IdTable table, std::optional<ColumnIndex> graphColumn)
     // The single table is the current one right from the start, so the source
     // has nothing left to yield.
-    : nextTable_{[]() -> std::optional<IdTable> { return std::nullopt; }},
+    : getNextTable_{[]() -> std::optional<IdTable> { return std::nullopt; }},
       graphColumn_{graphColumn},
-      table_{std::move(table)} {}
+      currentTable_{std::move(table)} {}
 
 // _____________________________________________________________________________
 std::optional<Id> IdCursor::peek() {
-  while (!table_.has_value() || row_ == table_.value().numRows()) {
+  while (!currentTable_.has_value() ||
+         rowIdx_ == currentTable_.value().numRows()) {
     if (isExhausted_) {
       return std::nullopt;
     }
-    table_ = nextTable_();
-    row_ = 0;
-    isExhausted_ = !table_.has_value();
+    currentTable_ = getNextTable_();
+    rowIdx_ = 0;
+    isExhausted_ = !currentTable_.has_value();
   }
-  return table_.value()(row_, 0);
+  return currentTable_.value()(rowIdx_, idColumn);
 }
 
 // _____________________________________________________________________________
 void IdCursor::consumeId(Id id, GraphSet& graphs) {
   while (peek() == std::optional{id}) {
     if (graphColumn_.has_value()) {
-      graphs.insert(table_.value()(row_, graphColumn_.value()));
+      graphs.insert(currentTable_.value()(rowIdx_, graphColumn_.value()));
     }
-    ++row_;
+    ++rowIdx_;
   }
 }
 
 // _____________________________________________________________________________
-RequestedIds::RequestedIds(const std::optional<std::vector<Id>>& ids)
-    : ids_{ids} {}
+RequestedIdsCursor::RequestedIdsCursor(
+    const std::optional<std::vector<Id>>& ids)
+    : remainingIds_{ids.has_value()
+                        ? std::optional{ql::span<const Id>{ids.value()}}
+                        : std::nullopt} {}
 
 // _____________________________________________________________________________
-bool RequestedIds::contains(Id id) {
-  if (!ids_.has_value()) {
+bool RequestedIdsCursor::advanceTo(Id id) {
+  if (!remainingIds_.has_value()) {
     return true;
   }
-  const auto& ids = ids_.value();
-  while (index_ < ids.size() && ids[index_] < id) {
-    ++index_;
+  auto& remainingIds = remainingIds_.value();
+  // Drop all the requested IDs that are smaller than `id`. They can never be
+  // asked for again, as the `id`s are ascending.
+  auto firstNotSmaller = ql::ranges::lower_bound(remainingIds, id);
+  remainingIds = remainingIds.subspan(firstNotSmaller - remainingIds.begin());
+  return !remainingIds.empty() && remainingIds.front() == id;
+}
+
+// _____________________________________________________________________________
+ResultBuilder::ResultBuilder(
+    bool addGraphColumn, const std::optional<std::vector<Id>>& idFilter,
+    const CompressedRelationReader::Allocator& allocator)
+    : allocator_{allocator},
+      addGraphColumn_{addGraphColumn},
+      // If only few IDs are requested, then a chunk holds at most one row per
+      // requested ID. Note that with the graph column there can be several rows
+      // per ID, but the number of graphs is typically very small, so we don't
+      // bother: reserving slightly too little only costs a reallocation.
+      numRowsToReserve_{idFilter.has_value()
+                            ? std::min(chunkSize, idFilter.value().size())
+                            : chunkSize},
+      currentChunk_{numResultColumns(addGraphColumn), allocator},
+      sortedGraphs_{allocator} {
+  currentChunk_.reserve(numRowsToReserve_);
+}
+
+// _____________________________________________________________________________
+void ResultBuilder::addId(Id id, const GraphSet& graphs) {
+  if (!addGraphColumn_) {
+    currentChunk_.push_back({id});
+    return;
   }
-  return index_ < ids.size() && ids[index_] == id;
+  // The graph IDs have to be sorted.
+  sortedGraphs_.assign(graphs.begin(), graphs.end());
+  ql::ranges::sort(sortedGraphs_);
+  // `IdTable`s are stored in column-major order, so we write the two columns
+  // separately instead of row by row.
+  size_t numRows = currentChunk_.numRows();
+  currentChunk_.resize(numRows + sortedGraphs_.size());
+  ql::ranges::fill(currentChunk_.getColumn(idColumn).subspan(numRows), id);
+  ql::ranges::copy(sortedGraphs_,
+                   currentChunk_.getColumn(graphColumnInResult).begin() +
+                       static_cast<ptrdiff_t>(numRows));
+}
+
+// _____________________________________________________________________________
+bool ResultBuilder::chunkIsFull() const {
+  return currentChunk_.numRows() >= chunkSize;
+}
+
+// _____________________________________________________________________________
+bool ResultBuilder::chunkIsEmpty() const { return currentChunk_.empty(); }
+
+// _____________________________________________________________________________
+IdTable ResultBuilder::extractChunk() {
+  IdTable chunk = std::move(currentChunk_);
+  currentChunk_ = IdTable{numResultColumns(addGraphColumn_), allocator_};
+  currentChunk_.reserve(numRowsToReserve_);
+  return chunk;
 }
 
 }  // namespace distinctCol0Ids

--- a/src/index/DistinctCol0Ids.cpp
+++ b/src/index/DistinctCol0Ids.cpp
@@ -1,0 +1,244 @@
+//  Copyright 2026 The QLever Authors, in particular:
+//
+//  2026 Robin Textor-Falconi <textorr@informatik.uni-freiburg.de>, UFR
+//
+//  UFR = University of Freiburg, Chair of Algorithms and Data Structures
+
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
+
+#include "index/DistinctCol0Ids.h"
+
+#include <algorithm>
+#include <utility>
+
+#include "backports/algorithm.h"
+#include "util/Exception.h"
+
+namespace distinctCol0Ids {
+
+// The smaller of the two IDs, or `std::nullopt` if both of them are
+// `std::nullopt`. Note that the comparison of `std::optional` cannot be used
+// here, as it orders `std::nullopt` BELOW every value, whereas here it means
+// "this source is exhausted" and therefore has to lose against an actual ID.
+std::optional<Id> smallerId(std::optional<Id> first, std::optional<Id> second) {
+  if (!first.has_value()) {
+    return second;
+  }
+  if (!second.has_value()) {
+    return first;
+  }
+  return std::min(first.value(), second.value());
+}
+
+// Create an empty table for the result of `getDistinctCol0Ids`, with enough
+// space reserved for one chunk (or for fewer rows if only few IDs were
+// requested).
+IdTable makeResultTable(bool addGraphColumn,
+                        const std::optional<std::vector<Id>>& idFilter,
+                        const CompressedRelationReader::Allocator& allocator) {
+  IdTable table{addGraphColumn ? 2u : 1u, allocator};
+  table.reserve(idFilter.has_value()
+                    ? std::min(chunkSize, idFilter.value().size())
+                    : chunkSize);
+  return table;
+}
+
+// Append the rows for a single distinct `id` to `result`. If `result` has a
+// graph column, one row per graph ID is appended, else a single row.
+void appendRowsForId(IdTable& result, Id id, const GraphSet& graphs,
+                     ad_utility::VectorWithMemoryLimit<Id>& sortedGraphs) {
+  if (result.numColumns() == 1) {
+    result.push_back({id});
+    return;
+  }
+  // The graph IDs have to be sorted. `sortedGraphs` is reused across the
+  // `col0Id`s so that this doesn't allocate for each of them.
+  sortedGraphs.assign(graphs.begin(), graphs.end());
+  ql::ranges::sort(sortedGraphs);
+  // `IdTable`s are stored in column-major order, so we write the two columns
+  // separately instead of row by row.
+  size_t numRows = result.numRows();
+  result.resize(numRows + sortedGraphs.size());
+  ql::ranges::fill(result.getColumn(0).subspan(numRows), id);
+  ql::ranges::copy(sortedGraphs, result.getColumn(1).begin() + numRows);
+}
+// _____________________________________________________________________________
+BlockSelector::BlockSelector(
+    const CompressedRelationReader::FilterDuplicatesAndGraphs& filter,
+    bool addGraphColumn, const std::optional<std::vector<Id>>& idFilter,
+    const LocatedTriplesPerBlock& locatedTriples,
+    const CompressedRelationReader::Allocator& allocator)
+    : filter_{filter},
+      addGraphColumn_{addGraphColumn},
+      idFilter_{idFilter},
+      locatedTriples_{locatedTriples},
+      result_{{}, IdTable{addGraphColumn ? 2u : 1u, allocator}} {}
+
+// _____________________________________________________________________________
+SelectedBlocks BlockSelector::select(
+    const ScanSpecAndBlocks& scanSpecAndBlocks) && {
+  forEachCandidateBlock(
+      scanSpecAndBlocks,
+      [this](const CompressedBlockMetadata& block) { handleBlock(block); });
+  return std::move(result_);
+}
+
+// _____________________________________________________________________________
+void BlockSelector::handleBlock(const CompressedBlockMetadata& block) {
+  if (filter_.canBlockBeSkipped(block)) {
+    return;
+  }
+  if (blockNeedsToBeRead(block)) {
+    result_.toRead_.push_back(block);
+    return;
+  }
+  Id id = block.firstTriple_.col0Id_;
+  if (!addGraphColumn_) {
+    addToMetadata(id, Id::makeUndefined());
+    return;
+  }
+  AD_CORRECTNESS_CHECK(block.graphInfo_.has_value());
+  const auto& graphFilter = filter_.graphFilter_;
+  ql::ranges::for_each(
+      block.graphInfo_.value() | ql::views::filter([&graphFilter](Id graph) {
+        return graphFilter.isGraphAllowed(graph);
+      }),
+      [this, id](Id graph) { addToMetadata(id, graph); });
+}
+
+// _____________________________________________________________________________
+bool BlockSelector::blockNeedsToBeRead(
+    const CompressedBlockMetadata& block) const {
+  // We take the single `col0Id` of the block from its metadata, so the block
+  // has to be read if it holds several `col0Id`s (we would miss the ones in
+  // between), or if there are delta triples for it, which might have deleted
+  // that `col0Id` or added further ones. Reading the block merges the located
+  // triples in and hence gives us the actual contents.
+  if (!CompressedRelationReader::contentsAreKnownFromMetadata(
+          block, 1, locatedTriples_)) {
+    return true;
+  }
+  // At this point the single `col0Id` of the block is known, so we only have to
+  // read it if we need graph IDs that the metadata doesn't know, or if we
+  // cannot rule out that the graph filter removes all of its triples.
+  return !block.graphInfo_.has_value() &&
+         (addGraphColumn_ || !filter_.graphFilter_.areAllGraphsAllowed());
+}
+
+// _____________________________________________________________________________
+void BlockSelector::addToMetadata(Id id, Id graph) {
+  IdTable& table = result_.fromMetadata_;
+  size_t numRows = table.numRows();
+  if (numRows != 0 && table(numRows - 1, 0) == id &&
+      (!addGraphColumn_ || table(numRows - 1, 1) == graph)) {
+    return;
+  }
+  if (addGraphColumn_) {
+    table.push_back({id, graph});
+  } else {
+    table.push_back({id});
+  }
+}
+
+// _____________________________________________________________________________
+void BlockSelector::forEachCandidateBlock(
+    const ScanSpecAndBlocks& scanSpecAndBlocks,
+    absl::FunctionRef<void(const CompressedBlockMetadata&)> action) const {
+  if (!idFilter_.has_value()) {
+    ql::ranges::for_each(scanSpecAndBlocks.getBlockMetadataView(), action);
+    return;
+  }
+  auto firstCol0Id = [](const CompressedBlockMetadata& metadata) {
+    return metadata.firstTriple_.col0Id_;
+  };
+  auto lastCol0Id = [](const CompressedBlockMetadata& metadata) {
+    return metadata.lastTriple_.col0Id_;
+  };
+  const auto& ids = idFilter_.value();
+  auto id = ids.begin();
+  // The blocks are sorted by their `col0Id`s, so for each of the requested IDs
+  // we can binary search the blocks that might contain it.
+  for (const auto& blocks : scanSpecAndBlocks.blockMetadata_) {
+    auto block = blocks.begin();
+    auto firstUnhandledBlock = blocks.begin();
+    while (id != ids.end()) {
+      // Skip all the blocks that only contain smaller `col0Id`s.
+      block = ql::ranges::lower_bound(block, blocks.end(), *id, {}, lastCol0Id);
+      if (block == blocks.end()) {
+        break;
+      }
+      // All the blocks that start with a `col0Id` that is not larger than `*id`
+      // might contain it. Note that they all end with a `col0Id` that is at
+      // least `*id`, because `block` does and the blocks are sorted.
+      auto end =
+          ql::ranges::upper_bound(block, blocks.end(), *id, {}, firstCol0Id);
+      ql::ranges::for_each(
+          ql::ranges::subrange{std::max(block, firstUnhandledBlock), end},
+          action);
+      firstUnhandledBlock = std::max(firstUnhandledBlock, end);
+      ++id;
+    }
+    if (id == ids.end()) {
+      return;
+    }
+  }
+}
+
+// _____________________________________________________________________________
+IdCursor::IdCursor(TableSource nextTable,
+                   std::optional<ColumnIndex> graphColumn)
+    : nextTable_{std::move(nextTable)}, graphColumn_{graphColumn} {}
+
+// _____________________________________________________________________________
+IdCursor::IdCursor(IdTable table, std::optional<ColumnIndex> graphColumn)
+    // The single table is the current one right from the start, so the source
+    // has nothing left to yield.
+    : nextTable_{[]() -> std::optional<IdTable> { return std::nullopt; }},
+      graphColumn_{graphColumn},
+      table_{std::move(table)} {}
+
+// _____________________________________________________________________________
+std::optional<Id> IdCursor::peek() {
+  while (!table_.has_value() || row_ == table_.value().numRows()) {
+    if (isExhausted_) {
+      return std::nullopt;
+    }
+    table_ = nextTable_();
+    row_ = 0;
+    isExhausted_ = !table_.has_value();
+  }
+  return table_.value()(row_, 0);
+}
+
+// _____________________________________________________________________________
+void IdCursor::consumeId(Id id, GraphSet& graphs) {
+  while (peek() == std::optional{id}) {
+    if (graphColumn_.has_value()) {
+      graphs.insert(table_.value()(row_, graphColumn_.value()));
+    }
+    ++row_;
+  }
+}
+
+// _____________________________________________________________________________
+RequestedIds::RequestedIds(const std::optional<std::vector<Id>>& ids)
+    : ids_{ids} {}
+
+// _____________________________________________________________________________
+bool RequestedIds::contains(Id id) {
+  if (!ids_.has_value()) {
+    return true;
+  }
+  const auto& ids = ids_.value();
+  while (index_ < ids.size() && ids[index_] < id) {
+    ++index_;
+  }
+  return index_ < ids.size() && ids[index_] == id;
+}
+
+}  // namespace distinctCol0Ids
+
+#endif  // QLEVER_REDUCED_FEATURE_SET_FOR_CPP17

--- a/src/index/DistinctCol0Ids.h
+++ b/src/index/DistinctCol0Ids.h
@@ -176,7 +176,8 @@ class RequestedIdsCursor {
 
   // Advance the cursor to `id` and return whether `id` is one of the requested
   // IDs. All the requested IDs that are smaller than `id` are consumed in the
-  // process, so subsequent calls must pass ascending `id`s.
+  // process, so each subsequent call has to pass an `id` that is not smaller
+  // than this one.
   bool advanceTo(Id id);
 };
 

--- a/src/index/DistinctCol0Ids.h
+++ b/src/index/DistinctCol0Ids.h
@@ -19,6 +19,7 @@
 #include <optional>
 #include <vector>
 
+#include "backports/span.h"
 #include "engine/idTable/IdTable.h"
 #include "global/Id.h"
 #include "index/CompressedRelation.h"
@@ -35,15 +36,31 @@ namespace distinctCol0Ids {
 
 using ScanSpecAndBlocks = CompressedRelationReader::ScanSpecAndBlocks;
 
-// The number of rows after which `getDistinctCol0Ids` yields a new `IdTable`.
-// This is only an upper bound to keep the memory usage bounded, the sizes of
-// the yielded tables don't matter otherwise.
-constexpr size_t chunkSize = 100'000;
+// The column that holds the IDs, both in the result and in the tables from
+// which the result is computed.
+constexpr ColumnIndex idColumn = 0;
+
+// The index of the graph column in the result (and in the IDs that are known
+// from the block metadata), if graph IDs were requested.
+constexpr ColumnIndex graphColumnInResult = 1;
 
 // The index of the graph column in the blocks that `getDistinctCol0Ids` reads.
 // The blocks of a full scan always consist of the three triple columns,
 // followed by the graph column (if it was requested).
 constexpr ColumnIndex graphColumnInBlock = 3;
+
+// The number of columns of the result: the IDs, plus the graph IDs if they were
+// requested.
+constexpr size_t numResultColumns(bool addGraphColumn) {
+  return addGraphColumn ? graphColumnInResult + 1 : idColumn + 1;
+}
+
+// The given `graphColumn`, or `std::nullopt` if no graph IDs were requested.
+// Used to set up the `IdCursor`s below.
+constexpr std::optional<ColumnIndex> graphColumnIfRequested(
+    bool addGraphColumn, ColumnIndex graphColumn) {
+  return addGraphColumn ? std::optional{graphColumn} : std::nullopt;
+}
 
 // The classification of the blocks of a full scan by `BlockSelector` below.
 struct SelectedBlocks {
@@ -94,12 +111,15 @@ class BlockSelector {
       absl::FunctionRef<void(const CompressedBlockMetadata&)> action) const;
 };
 
-// Hash and compare graph IDs by their bit representation, which is much
-// cheaper than hashing and comparing `Id`s (whose comparison may have to look
-// into the local vocabulary). The graph IDs of a properly normalized index all
-// have the same datatype, so their bitwise equality coincides with their actual
-// equality. Note that this only affects the deduplication, not the order: the
-// graphs are sorted as `Id`s.
+// Hash and compare graph IDs by their bit representation, which is much cheaper
+// than hashing and comparing `Id`s (whose comparison may have to look into the
+// local vocabulary). This is correct because all the graph IDs that we see come
+// directly from an index (or from the local vocabulary of an update, which is
+// normalized against that index), and in such a normalized setting two
+// different bit representations always denote two different values: an entry
+// that is representable by the vocabulary of the index never appears as a local
+// vocabulary entry, and vice versa. Note that this only affects the
+// deduplication, not the order: the graphs are sorted as `Id`s.
 struct HashGraphIdByBits {
   size_t operator()(Id id) const { return absl::Hash<Id::T>{}(id.getBits()); }
 };
@@ -113,7 +133,7 @@ using GraphSet =
 
 // A cursor over one of the two ascending sources of IDs that
 // `getDistinctCol0Ids` merges. The tables are fetched one at a time by the
-// `nextTable` function, their first column holds the IDs. If `graphColumn` is
+// `getNextTable` function, their `idColumn` holds the IDs. If `graphColumn` is
 // set, that column holds the graph IDs.
 class IdCursor {
  public:
@@ -123,14 +143,14 @@ class IdCursor {
   using TableSource = std::function<std::optional<IdTable>()>;
 
  private:
-  TableSource nextTable_;
+  TableSource getNextTable_;
   std::optional<ColumnIndex> graphColumn_;
-  std::optional<IdTable> table_ = std::nullopt;
-  size_t row_ = 0;
+  std::optional<IdTable> currentTable_ = std::nullopt;
+  size_t rowIdx_ = 0;
   bool isExhausted_ = false;
 
  public:
-  IdCursor(TableSource nextTable, std::optional<ColumnIndex> graphColumn);
+  IdCursor(TableSource getNextTable, std::optional<ColumnIndex> graphColumn);
 
   // A cursor over the rows of a single `table`.
   IdCursor(IdTable table, std::optional<ColumnIndex> graphColumn);
@@ -145,34 +165,65 @@ class IdCursor {
 };
 
 // The IDs that the caller of `getDistinctCol0Ids` requested (all of them if
-// `ids` is `std::nullopt`). The IDs have to be passed to `contains` in
-// ascending order, which makes it run in amortized constant time.
-class RequestedIds {
-  const std::optional<std::vector<Id>>& ids_;
-  size_t index_ = 0;
+// `ids` is `std::nullopt`). The IDs have to be passed to `advanceTo` in
+// ascending order.
+class RequestedIdsCursor {
+  // The requested IDs that haven't been passed to `advanceTo` yet.
+  std::optional<ql::span<const Id>> remainingIds_;
 
  public:
-  explicit RequestedIds(const std::optional<std::vector<Id>>& ids);
+  explicit RequestedIdsCursor(const std::optional<std::vector<Id>>& ids);
 
-  bool contains(Id id);
+  // Advance the cursor to `id` and return whether `id` is one of the requested
+  // IDs. All the requested IDs that are smaller than `id` are consumed in the
+  // process, so subsequent calls must pass ascending `id`s.
+  bool advanceTo(Id id);
 };
 
 // The smaller of the two IDs, or `std::nullopt` if both of them are
 // `std::nullopt`.
 std::optional<Id> smallerId(std::optional<Id> first, std::optional<Id> second);
 
-// Create an empty table for the result of `getDistinctCol0Ids`, with enough
-// space reserved for one chunk (or for fewer rows if only few IDs were
-// requested).
-IdTable makeResultTable(bool addGraphColumn,
-                        const std::optional<std::vector<Id>>& idFilter,
-                        const CompressedRelationReader::Allocator& allocator);
+// Collects the rows of the result of `getDistinctCol0Ids` and hands them out in
+// chunks of bounded size.
+class ResultBuilder {
+  // The number of rows after which a chunk is handed out. This is a soft bound
+  // that only serves to keep the memory usage of a single chunk bounded: all
+  // the rows of a single ID always end up in the same chunk, so a chunk may
+  // exceed this size by the number of graphs of one ID. The sizes of the chunks
+  // don't matter otherwise.
+  static constexpr size_t chunkSize = 100'000;
 
-// Append the rows for a single distinct `id` to `result`. If `result` has a
-// graph column, one row per graph ID is appended, else a single row.
-// `sortedGraphs` is a scratch buffer that is reused across the `col0Id`s.
-void appendRowsForId(IdTable& result, Id id, const GraphSet& graphs,
-                     ad_utility::VectorWithMemoryLimit<Id>& sortedGraphs);
+  CompressedRelationReader::Allocator allocator_;
+  bool addGraphColumn_;
+  size_t numRowsToReserve_;
+  IdTable currentChunk_;
+  // Scratch space for the sorted graph IDs of a single ID. This is a member and
+  // not a local variable of `addId` only to avoid an allocation for each of the
+  // IDs; neither its contents on entry nor the contents that it is left with
+  // are of any interest.
+  ad_utility::VectorWithMemoryLimit<Id> sortedGraphs_;
+
+ public:
+  ResultBuilder(bool addGraphColumn,
+                const std::optional<std::vector<Id>>& idFilter,
+                const CompressedRelationReader::Allocator& allocator);
+
+  // Append the rows for a single distinct `id`. If graph IDs were requested,
+  // one row per graph ID is appended (in ascending order of the graph IDs),
+  // else a single row.
+  void addId(Id id, const GraphSet& graphs);
+
+  // Return true iff the current chunk has reached `chunkSize` rows and should
+  // be handed out via `extractChunk`.
+  bool chunkIsFull() const;
+
+  // Return true iff no rows have been added to the current chunk.
+  bool chunkIsEmpty() const;
+
+  // Hand out the current chunk and start a new one.
+  IdTable extractChunk();
+};
 
 }  // namespace distinctCol0Ids
 

--- a/src/index/DistinctCol0Ids.h
+++ b/src/index/DistinctCol0Ids.h
@@ -1,0 +1,181 @@
+//  Copyright 2026 The QLever Authors, in particular:
+//
+//  2026 Robin Textor-Falconi <textorr@informatik.uni-freiburg.de>, UFR
+//
+//  UFR = University of Freiburg, Chair of Algorithms and Data Structures
+
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
+
+#ifndef QLEVER_SRC_INDEX_DISTINCTCOL0IDS_H
+#define QLEVER_SRC_INDEX_DISTINCTCOL0IDS_H
+
+#include <absl/functional/function_ref.h>
+#include <absl/hash/hash.h>
+
+#include <functional>
+#include <optional>
+#include <vector>
+
+#include "engine/idTable/IdTable.h"
+#include "global/Id.h"
+#include "index/CompressedRelation.h"
+#include "index/LocatedTriples.h"
+#include "index/ScanSpecification.h"
+#include "util/HashSet.h"
+#include "util/VectorWithMemoryLimit.h"
+
+// The helper classes and functions for
+// `CompressedRelationReader::getDistinctCol0Ids` (see `CompressedRelation.h`
+// for its exact semantics). They live in their own translation unit to keep the
+// already very large `CompressedRelation.cpp` from growing even further.
+namespace distinctCol0Ids {
+
+using ScanSpecAndBlocks = CompressedRelationReader::ScanSpecAndBlocks;
+
+// The number of rows after which `getDistinctCol0Ids` yields a new `IdTable`.
+// This is only an upper bound to keep the memory usage bounded, the sizes of
+// the yielded tables don't matter otherwise.
+constexpr size_t chunkSize = 100'000;
+
+// The index of the graph column in the blocks that `getDistinctCol0Ids` reads.
+// The blocks of a full scan always consist of the three triple columns,
+// followed by the graph column (if it was requested).
+constexpr ColumnIndex graphColumnInBlock = 3;
+
+// The classification of the blocks of a full scan by `BlockSelector` below.
+struct SelectedBlocks {
+  // The blocks that have to be read from disk.
+  std::vector<CompressedBlockMetadata> toRead_;
+  // The IDs (and graph IDs, if requested) that are already known from the block
+  // metadata alone, in ascending order of the IDs, possibly with duplicates.
+  IdTable fromMetadata_;
+};
+
+// Split the blocks of a full scan into those that have to be read from disk and
+// those whose contribution to the distinct `col0Id`s is already known from
+// their metadata (see `CompressedRelationReader::getDistinctCol0Ids`).
+class BlockSelector {
+  const CompressedRelationReader::FilterDuplicatesAndGraphs& filter_;
+  bool addGraphColumn_;
+  const std::optional<std::vector<Id>>& idFilter_;
+  const LocatedTriplesPerBlock& locatedTriples_;
+  SelectedBlocks result_;
+
+ public:
+  BlockSelector(
+      const CompressedRelationReader::FilterDuplicatesAndGraphs& filter,
+      bool addGraphColumn, const std::optional<std::vector<Id>>& idFilter,
+      const LocatedTriplesPerBlock& locatedTriples,
+      const CompressedRelationReader::Allocator& allocator);
+
+  // Perform the classification described above.
+  SelectedBlocks select(const ScanSpecAndBlocks& scanSpecAndBlocks) &&;
+
+ private:
+  // Add the given block to `result_`: either to the blocks that have to be
+  // read, or (via `addToMetadata`) to the IDs that are already known.
+  void handleBlock(const CompressedBlockMetadata& block);
+
+  // Return true iff the given block has to be read to determine the IDs (and
+  // graph IDs) that it contributes.
+  bool blockNeedsToBeRead(const CompressedBlockMetadata& block) const;
+
+  // Add the given `id` (together with `graph` if graph IDs are requested) to
+  // `result_.fromMetadata_`, unless it duplicates the previously added row.
+  void addToMetadata(Id id, Id graph);
+
+  // Call `action` for all blocks that might contain one of the requested IDs,
+  // in ascending order.
+  void forEachCandidateBlock(
+      const ScanSpecAndBlocks& scanSpecAndBlocks,
+      absl::FunctionRef<void(const CompressedBlockMetadata&)> action) const;
+};
+
+// Hash and compare graph IDs by their bit representation, which is much
+// cheaper than hashing and comparing `Id`s (whose comparison may have to look
+// into the local vocabulary). The graph IDs of a properly normalized index all
+// have the same datatype, so their bitwise equality coincides with their actual
+// equality. Note that this only affects the deduplication, not the order: the
+// graphs are sorted as `Id`s.
+struct HashGraphIdByBits {
+  size_t operator()(Id id) const { return absl::Hash<Id::T>{}(id.getBits()); }
+};
+struct GraphIdBitsEqual {
+  bool operator()(Id a, Id b) const { return a.getBits() == b.getBits(); }
+};
+
+// The distinct graph IDs of a single `col0Id`.
+using GraphSet =
+    ad_utility::HashSetWithMemoryLimit<Id, HashGraphIdByBits, GraphIdBitsEqual>;
+
+// A cursor over one of the two ascending sources of IDs that
+// `getDistinctCol0Ids` merges. The tables are fetched one at a time by the
+// `nextTable` function, their first column holds the IDs. If `graphColumn` is
+// set, that column holds the graph IDs.
+class IdCursor {
+ public:
+  // Yields the tables of the source one at a time, and `std::nullopt` once the
+  // source is exhausted. It is only invoked from `peek`, at most once per
+  // table, so the indirection of a `std::function` doesn't matter.
+  using TableSource = std::function<std::optional<IdTable>()>;
+
+ private:
+  TableSource nextTable_;
+  std::optional<ColumnIndex> graphColumn_;
+  std::optional<IdTable> table_ = std::nullopt;
+  size_t row_ = 0;
+  bool isExhausted_ = false;
+
+ public:
+  IdCursor(TableSource nextTable, std::optional<ColumnIndex> graphColumn);
+
+  // A cursor over the rows of a single `table`.
+  IdCursor(IdTable table, std::optional<ColumnIndex> graphColumn);
+
+  // The ID of the next row that hasn't been consumed yet, or `std::nullopt` if
+  // all rows have been consumed. Advances to the next table if necessary.
+  std::optional<Id> peek();
+
+  // Consume all the rows that belong to `id`, adding their graph IDs to
+  // `graphs` if this cursor has a graph column.
+  void consumeId(Id id, GraphSet& graphs);
+};
+
+// The IDs that the caller of `getDistinctCol0Ids` requested (all of them if
+// `ids` is `std::nullopt`). The IDs have to be passed to `contains` in
+// ascending order, which makes it run in amortized constant time.
+class RequestedIds {
+  const std::optional<std::vector<Id>>& ids_;
+  size_t index_ = 0;
+
+ public:
+  explicit RequestedIds(const std::optional<std::vector<Id>>& ids);
+
+  bool contains(Id id);
+};
+
+// The smaller of the two IDs, or `std::nullopt` if both of them are
+// `std::nullopt`.
+std::optional<Id> smallerId(std::optional<Id> first, std::optional<Id> second);
+
+// Create an empty table for the result of `getDistinctCol0Ids`, with enough
+// space reserved for one chunk (or for fewer rows if only few IDs were
+// requested).
+IdTable makeResultTable(bool addGraphColumn,
+                        const std::optional<std::vector<Id>>& idFilter,
+                        const CompressedRelationReader::Allocator& allocator);
+
+// Append the rows for a single distinct `id` to `result`. If `result` has a
+// graph column, one row per graph ID is appended, else a single row.
+// `sortedGraphs` is a scratch buffer that is reused across the `col0Id`s.
+void appendRowsForId(IdTable& result, Id id, const GraphSet& graphs,
+                     ad_utility::VectorWithMemoryLimit<Id>& sortedGraphs);
+
+}  // namespace distinctCol0Ids
+
+#endif  // QLEVER_SRC_INDEX_DISTINCTCOL0IDS_H
+
+#endif  // QLEVER_REDUCED_FEATURE_SET_FOR_CPP17

--- a/src/index/Permutation.cpp
+++ b/src/index/Permutation.cpp
@@ -146,6 +146,21 @@ IdTable Permutation::getDistinctCol0IdsAndCounts(
       limitOffset);
 }
 
+#ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
+// ____________________________________________________________________________
+cppcoro::generator<IdTable, CompressedRelationReader::LazyScanMetadata>
+Permutation::getDistinctCol0Ids(
+    const ScanSpecification& scanSpec, bool addGraphColumn,
+    std::optional<std::vector<Id>> idFilter,
+    const CancellationHandle& cancellationHandle,
+    const LocatedTriplesState& locatedTriplesState) const {
+  return reader().getDistinctCol0Ids(
+      getScanSpecAndBlocks(scanSpec, locatedTriplesState), addGraphColumn,
+      std::move(idFilter), cancellationHandle,
+      getLocatedTriplesForPermutation(locatedTriplesState));
+}
+#endif
+
 // _____________________________________________________________________
 auto Permutation::toKeyOrder(Permutation::Enum permutation) -> KeyOrder {
   using enum Permutation::Enum;

--- a/src/index/Permutation.h
+++ b/src/index/Permutation.h
@@ -133,6 +133,21 @@ class Permutation {
       const LocatedTriplesState& locatedTriplesState,
       const LimitOffsetClause& limitOffset) const;
 
+#ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
+  // Lazily compute the distinct `col0Id`s of a full scan of this permutation.
+  // The `scanSpec` must not fix any of the columns, it is only used for its
+  // graph filter. See `CompressedRelationReader::getDistinctCol0Ids` for the
+  // exact semantics of `addGraphColumn` and `idFilter`.
+  //
+  // NOTE: `locatedTriplesState` has to be kept alive until the returned
+  // generator has been fully consumed.
+  cppcoro::generator<IdTable, CompressedRelationReader::LazyScanMetadata>
+  getDistinctCol0Ids(const ScanSpecification& scanSpec, bool addGraphColumn,
+                     std::optional<std::vector<Id>> idFilter,
+                     const CancellationHandle& cancellationHandle,
+                     const LocatedTriplesState& locatedTriplesState) const;
+#endif
+
   // Typedef to propagate the `MetadataAndblocks` and `IdTableGenerator` type.
   using MetadataAndBlocks =
       CompressedRelationReader::ScanSpecAndBlocksAndBounds;

--- a/test/CompressedRelationsTest.cpp
+++ b/test/CompressedRelationsTest.cpp
@@ -998,6 +998,316 @@ TEST(CompressedRelationReader, makeCanBeSkippedForBlock) {
   EXPECT_FALSE(filter.canBlockBeSkipped(metadata));
 }
 
+namespace {
+// Collect all the IDs (and graph IDs) that `getDistinctCol0Ids` yields for the
+// given arguments, together with the number of blocks that had to be read.
+struct DistinctCol0IdsResult {
+  IdTable idTable_;
+  size_t numBlocksRead_;
+  size_t numBlocksAll_;
+};
+DistinctCol0IdsResult getDistinctCol0Ids(
+    const CompressedRelationReader& reader,
+    const CompressedRelationReader::ScanSpecAndBlocks& scanSpecAndBlocks,
+    bool addGraphColumn, std::optional<std::vector<Id>> idFilter,
+    const LocatedTriplesPerBlock& locatedTriples) {
+  auto range = reader.getDistinctCol0Ids(
+      scanSpecAndBlocks, addGraphColumn, std::move(idFilter),
+      std::make_shared<ad_utility::CancellationHandle<>>(), locatedTriples);
+  IdTable result{addGraphColumn ? 2u : 1u,
+                 ad_utility::makeUnlimitedAllocator<Id>()};
+  for (const IdTable& table : range) {
+    result.insertAtEnd(table);
+  }
+  return {std::move(result), range.details().numBlocksRead_,
+          range.details().numBlocksAll_};
+}
+}  // namespace
+
+// _____________________________________________________________________________
+TEST(CompressedRelationReader, getDistinctCol0Ids) {
+  // The first relation is large enough to span several blocks, all but one of
+  // which don't contribute a new `col0Id` and thus don't have to be read. The
+  // other relations are small and are all stored in a single block, which has
+  // to be read because it contains more than one `col0Id`.
+  std::vector<RelationInput> inputs{
+      {1, {}}, {2, {{0, 0}}}, {3, {{0, 0}}}, {4, {{0, 0}}}};
+  for (int i = 0; i < 100; ++i) {
+    inputs.at(0).col1And2_.push_back({0, i});
+  }
+  addGraphColumnIfNecessary(inputs);
+  auto [filename, cleanup] = testFilenameWithCleanup();
+  auto [blocks, metaData, reader] =
+      writeAndOpenRelations(inputs, filename, 64_B);
+  LocatedTriplesPerBlock locatedTriples{};
+  locatedTriples.setOriginalMetadata(blocks);
+  locatedTriples.updateAugmentedMetadata();
+  CompressedRelationReader::ScanSpecAndBlocks scanSpecAndBlocks{
+      ScanSpecification{std::nullopt, std::nullopt, std::nullopt},
+      getBlockMetadataRangesfromVec(blocks)};
+
+  // All the `col0Id`s, without any filter.
+  {
+    auto [result, numBlocksRead, numBlocksAll] = getDistinctCol0Ids(
+        *reader, scanSpecAndBlocks, false, std::nullopt, locatedTriples);
+    checkThatTablesAreEqual(std::vector<RowInput>{{1}, {2}, {3}, {4}}, result);
+    // The blocks of the large relation that only repeat its `col0Id` are not
+    // read at all.
+    EXPECT_LT(numBlocksRead, numBlocksAll);
+    EXPECT_EQ(numBlocksAll, blocks.size());
+  }
+
+  // Only the `col0Id` of the large relation is requested. All of its blocks
+  // contain nothing but that single `col0Id`, so none of them has to be read.
+  {
+    auto [result, numBlocksRead, numBlocksAll] = getDistinctCol0Ids(
+        *reader, scanSpecAndBlocks, false, std::vector{V(1)}, locatedTriples);
+    checkThatTablesAreEqual(std::vector<RowInput>{{1}}, result);
+    EXPECT_EQ(numBlocksRead, 0);
+  }
+
+  // Only a subset of the `col0Id`s is requested, so all the blocks of the large
+  // relation can be skipped.
+  {
+    auto [result, numBlocksRead, numBlocksAll] =
+        getDistinctCol0Ids(*reader, scanSpecAndBlocks, false,
+                           std::vector{V(3), V(17)}, locatedTriples);
+    checkThatTablesAreEqual(std::vector<RowInput>{{3}}, result);
+    // Only the block(s) that hold the small relations have to be read.
+    EXPECT_LE(numBlocksRead, 2);
+  }
+
+  // A filter that matches nothing doesn't read a single block.
+  {
+    auto [result, numBlocksRead, numBlocksAll] = getDistinctCol0Ids(
+        *reader, scanSpecAndBlocks, false, std::vector<Id>{}, locatedTriples);
+    EXPECT_THAT(result, ::testing::IsEmpty());
+    EXPECT_EQ(numBlocksRead, 0);
+  }
+
+  // With the graph column, the pairs of `col0Id` and graph ID are returned. All
+  // the triples of the test input are in the same graph (the dummy graph that
+  // `addGraphColumnIfNecessary` adds).
+  {
+    auto [result, numBlocksRead, numBlocksAll] = getDistinctCol0Ids(
+        *reader, scanSpecAndBlocks, true, std::nullopt, locatedTriples);
+    ASSERT_EQ(result.numColumns(), 2);
+    EXPECT_THAT(result.getColumn(0),
+                ::testing::ElementsAre(V(1), V(2), V(3), V(4)));
+    EXPECT_THAT(result.getColumn(1),
+                ::testing::Each(::testing::Eq(V(103496581))));
+  }
+}
+
+// _____________________________________________________________________________
+TEST(CompressedRelationReader, getDistinctCol0IdsWithGraphFilter) {
+  // Each of the relations consists of a single triple, and the blocks are so
+  // small that each of these triples ends up in its own block. Relation 1 is in
+  // the graph 10, relation 2 in the graph 11, and relation 3 in the graph 12.
+  std::vector<RelationInput> inputs{
+      {1, {{0, 0, 10}}}, {2, {{0, 0, 11}}}, {3, {{0, 0, 12}}}};
+  auto [filename, cleanup] = testFilenameWithCleanup();
+  auto [blocks, metaData, reader] =
+      writeAndOpenRelations(inputs, filename, 8_B);
+  LocatedTriplesPerBlock locatedTriples{};
+  locatedTriples.setOriginalMetadata(blocks);
+  locatedTriples.updateAugmentedMetadata();
+  auto makeScanSpecAndBlocks =
+      [&blocks](ScanSpecification::GraphFilter filter) {
+        return CompressedRelationReader::ScanSpecAndBlocks{
+            ScanSpecification{std::nullopt, std::nullopt, std::nullopt,
+                              LocalVocab{}, std::move(filter)},
+            getBlockMetadataRangesfromVec(blocks)};
+      };
+
+  // The block of relation 2 only contains triples from a graph that the filter
+  // doesn't allow, so it is skipped without being read.
+  {
+    auto scanSpecAndBlocks = makeScanSpecAndBlocks(
+        ScanSpecification::GraphFilter::Whitelist({V(10), V(12), V(13)}));
+    auto [result, numBlocksRead, numBlocksAll] = getDistinctCol0Ids(
+        *reader, scanSpecAndBlocks, false, std::nullopt, locatedTriples);
+    checkThatTablesAreEqual(std::vector<RowInput>{{1}, {3}}, result);
+    // The graphs of all the blocks are known from their metadata, so no block
+    // has to be read.
+    EXPECT_EQ(numBlocksRead, 0);
+  }
+
+  // The same, but with the graph column and a blacklist.
+  {
+    auto scanSpecAndBlocks =
+        makeScanSpecAndBlocks(ScanSpecification::GraphFilter::Blacklist(V(11)));
+    auto [result, numBlocksRead, numBlocksAll] = getDistinctCol0Ids(
+        *reader, scanSpecAndBlocks, true, std::nullopt, locatedTriples);
+    checkThatTablesAreEqual(std::vector<RowInput>{{1, 10}, {3, 12}}, result);
+    EXPECT_EQ(numBlocksRead, 0);
+  }
+
+  // A filter that allows none of the graphs yields an empty result.
+  {
+    auto scanSpecAndBlocks = makeScanSpecAndBlocks(
+        ScanSpecification::GraphFilter::Whitelist({V(13)}));
+    auto [result, numBlocksRead, numBlocksAll] = getDistinctCol0Ids(
+        *reader, scanSpecAndBlocks, false, std::nullopt, locatedTriples);
+    EXPECT_THAT(result, ::testing::IsEmpty());
+    EXPECT_EQ(numBlocksRead, 0);
+  }
+}
+
+// _____________________________________________________________________________
+TEST(CompressedRelationReader, getDistinctCol0IdsWithUnknownGraphsInBlock) {
+  // A single relation with more distinct graphs than the block metadata can
+  // store (`MAX_NUM_GRAPHS_STORED_IN_BLOCK_METADATA`), such that the graphs of
+  // its block are unknown. The graphs are descending in the order in which they
+  // are stored, and the last one is a duplicate.
+  constexpr size_t numGraphs = MAX_NUM_GRAPHS_STORED_IN_BLOCK_METADATA + 5;
+  constexpr int firstGraph = 100;
+  RelationInput relation{1, {}};
+  for (size_t i = 0; i < numGraphs; ++i) {
+    relation.col1And2_.push_back(
+        {static_cast<int>(i), 0, firstGraph + static_cast<int>(numGraphs - i)});
+  }
+  relation.col1And2_.push_back(
+      {static_cast<int>(numGraphs), 0, firstGraph + 1});
+  std::vector<RelationInput> inputs{std::move(relation)};
+
+  auto [filename, cleanup] = testFilenameWithCleanup();
+  // All the triples fit into a single block.
+  auto [blocks, metaData, reader] =
+      writeAndOpenRelations(inputs, filename, 1_kB);
+  ASSERT_EQ(blocks.size(), 1);
+  ASSERT_FALSE(blocks.at(0).graphInfo_.has_value());
+  LocatedTriplesPerBlock locatedTriples{};
+  locatedTriples.setOriginalMetadata(blocks);
+  locatedTriples.updateAugmentedMetadata();
+  auto makeScanSpecAndBlocks =
+      [&blocks](ScanSpecification::GraphFilter filter) {
+        return CompressedRelationReader::ScanSpecAndBlocks{
+            ScanSpecification{std::nullopt, std::nullopt, std::nullopt,
+                              LocalVocab{}, std::move(filter)},
+            getBlockMetadataRangesfromVec(blocks)};
+      };
+
+  // Without a graph filter and without the graph column, the single `col0Id` is
+  // known from the metadata, so the block doesn't have to be read.
+  {
+    auto scanSpecAndBlocks =
+        makeScanSpecAndBlocks(ScanSpecification::GraphFilter::All());
+    auto [result, numBlocksRead, numBlocksAll] = getDistinctCol0Ids(
+        *reader, scanSpecAndBlocks, false, std::nullopt, locatedTriples);
+    checkThatTablesAreEqual(std::vector<RowInput>{{1}}, result);
+    EXPECT_EQ(numBlocksRead, 0);
+  }
+
+  // With the graph column the block has to be read, and the graphs are sorted
+  // and deduplicated.
+  {
+    auto scanSpecAndBlocks =
+        makeScanSpecAndBlocks(ScanSpecification::GraphFilter::All());
+    auto [result, numBlocksRead, numBlocksAll] = getDistinctCol0Ids(
+        *reader, scanSpecAndBlocks, true, std::nullopt, locatedTriples);
+    std::vector<RowInput> expected;
+    for (size_t i = 1; i <= numGraphs; ++i) {
+      expected.push_back({1, firstGraph + static_cast<int>(i)});
+    }
+    checkThatTablesAreEqual(expected, result);
+    EXPECT_EQ(numBlocksRead, 1);
+  }
+
+  // The graph filter cannot be evaluated on the metadata, so the block has to
+  // be read even without the graph column.
+  {
+    auto scanSpecAndBlocks = makeScanSpecAndBlocks(
+        ScanSpecification::GraphFilter::Whitelist({V(firstGraph + 1)}));
+    auto [result, numBlocksRead, numBlocksAll] = getDistinctCol0Ids(
+        *reader, scanSpecAndBlocks, false, std::nullopt, locatedTriples);
+    checkThatTablesAreEqual(std::vector<RowInput>{{1}}, result);
+    EXPECT_EQ(numBlocksRead, 1);
+  }
+}
+
+// _____________________________________________________________________________
+TEST(CompressedRelationReader, getDistinctCol0IdsYieldsSeveralChunks) {
+  // More `col0Id`s than fit into a single chunk of the result.
+  constexpr int numRelations = 100'001;
+  std::vector<RelationInput> inputs;
+  inputs.reserve(numRelations);
+  for (int i = 0; i < numRelations; ++i) {
+    inputs.push_back({i, {{0, 0}}});
+  }
+  addGraphColumnIfNecessary(inputs);
+  auto [filename, cleanup] = testFilenameWithCleanup();
+  auto [blocks, metaData, reader] =
+      writeAndOpenRelations(inputs, filename, 1_MB);
+  LocatedTriplesPerBlock locatedTriples{};
+  locatedTriples.setOriginalMetadata(blocks);
+  locatedTriples.updateAugmentedMetadata();
+  CompressedRelationReader::ScanSpecAndBlocks scanSpecAndBlocks{
+      ScanSpecification{std::nullopt, std::nullopt, std::nullopt},
+      getBlockMetadataRangesfromVec(blocks)};
+
+  auto range = reader->getDistinctCol0Ids(
+      scanSpecAndBlocks, false, std::nullopt,
+      std::make_shared<ad_utility::CancellationHandle<>>(), locatedTriples);
+  size_t numTables = 0;
+  size_t numRows = 0;
+  for (const IdTable& table : range) {
+    ++numTables;
+    numRows += table.numRows();
+  }
+  EXPECT_EQ(numRows, numRelations);
+  EXPECT_GT(numTables, 1);
+}
+
+// _____________________________________________________________________________
+TEST(CompressedRelationReader, getDistinctCol0IdsOnlySupportsFullScans) {
+  std::vector<RelationInput> inputs{{1, {{0, 0}}}};
+  addGraphColumnIfNecessary(inputs);
+  auto [filename, cleanup] = testFilenameWithCleanup();
+  auto [blocks, metaData, reader] =
+      writeAndOpenRelations(inputs, filename, 64_B);
+  CompressedRelationReader::ScanSpecAndBlocks scanSpecAndBlocks{
+      ScanSpecification{V(1), std::nullopt, std::nullopt},
+      getBlockMetadataRangesfromVec(blocks)};
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      getDistinctCol0Ids(*reader, scanSpecAndBlocks, false, std::nullopt,
+                         emptyLocatedTriples),
+      ::testing::HasSubstr("only supports full scans"));
+}
+
+// _____________________________________________________________________________
+TEST(CompressedRelationReader, getDistinctCol0IdsChecksItsPreconditions) {
+  std::vector<RelationInput> inputs{{1, {{0, 0}}}, {2, {{0, 0}}}};
+  addGraphColumnIfNecessary(inputs);
+  auto [filename, cleanup] = testFilenameWithCleanup();
+  auto [blocks, metaData, reader] =
+      writeAndOpenRelations(inputs, filename, 64_B);
+  CompressedRelationReader::ScanSpecAndBlocks scanSpecAndBlocks{
+      ScanSpecification{std::nullopt, std::nullopt, std::nullopt},
+      getBlockMetadataRangesfromVec(blocks)};
+  // The generator is lazy, so the checks only fire once it is consumed.
+  auto consume = [&reader, &scanSpecAndBlocks](
+                     std::optional<std::vector<Id>> idFilter,
+                     CompressedRelationReader::CancellationHandle handle) {
+    for ([[maybe_unused]] const IdTable& table : reader->getDistinctCol0Ids(
+             scanSpecAndBlocks, false, std::move(idFilter), std::move(handle),
+             emptyLocatedTriples)) {
+    }
+  };
+
+  EXPECT_THROW(consume(std::nullopt, nullptr), ad_utility::Exception);
+
+  // The `idFilter` has to be sorted. This is only checked if the expensive
+  // checks are enabled, and violating it without that check is undefined
+  // behavior, so the call is not made at all in that case.
+  if (ad_utility::areExpensiveChecksEnabled) {
+    EXPECT_THROW(consume(std::vector{V(2), V(1)},
+                         std::make_shared<ad_utility::CancellationHandle<>>()),
+                 ad_utility::Exception);
+  }
+}
+
+// _____________________________________________________________________________
 TEST(CompressedRelationReader, getResultSizeImpl) {
   using ScanSpecAndBlocks = CompressedRelationReader::ScanSpecAndBlocks;
   auto index = ad_utility::testing::makeTestIndex("getResultSizeImpl", "");

--- a/test/CompressedRelationsTest.cpp
+++ b/test/CompressedRelationsTest.cpp
@@ -1022,6 +1022,24 @@ DistinctCol0IdsResult getDistinctCol0Ids(
   return {std::move(result), range.details().numBlocksRead_,
           range.details().numBlocksAll_};
 }
+
+// Locate the given `triples` (which are all inserted if `insertOrDelete` is
+// true, and all deleted otherwise) in the given `blocks` and return the
+// resulting `LocatedTriplesPerBlock`, including the augmented block metadata.
+LocatedTriplesPerBlock makeLocatedTriplesPerBlock(
+    const std::vector<CompressedBlockMetadata>& blocks,
+    std::vector<IdTriple<>> triples, bool insertOrDelete) {
+  LocatedTriplesPerBlock locatedTriples;
+  locatedTriples.setOriginalMetadata(blocks);
+  if (!triples.empty()) {
+    locatedTriples.add(LocatedTriple::locateTriplesInPermutation(
+        triples, blocks, {0, 1, 2, 3}, insertOrDelete,
+        std::make_shared<ad_utility::CancellationHandle<>>()));
+    locatedTriples.consolidateAllBlocks();
+  }
+  locatedTriples.updateAugmentedMetadata();
+  return locatedTriples;
+}
 }  // namespace
 
 // _____________________________________________________________________________
@@ -1223,6 +1241,117 @@ TEST(CompressedRelationReader, getDistinctCol0IdsWithUnknownGraphsInBlock) {
         *reader, scanSpecAndBlocks, false, std::nullopt, locatedTriples);
     checkThatTablesAreEqual(std::vector<RowInput>{{1}}, result);
     EXPECT_EQ(numBlocksRead, 1);
+  }
+}
+
+// _____________________________________________________________________________
+TEST(CompressedRelationReader, getDistinctCol0IdsWithDeltaTriples) {
+  // Relation 1 is large enough to span several blocks, each of which contains
+  // nothing but its `col0Id`. The small relations 2 and 3 share a single block.
+  constexpr int numTriplesOfRelation1 = 20;
+  constexpr int graph = 103496581;
+  std::vector<RelationInput> inputs{{1, {}}, {2, {{0, 0}}}, {3, {{0, 0}}}};
+  for (int i = 0; i < numTriplesOfRelation1; ++i) {
+    inputs.at(0).col1And2_.push_back({0, i});
+  }
+  addGraphColumnIfNecessary(inputs);
+  auto [filename, cleanup] = testFilenameWithCleanup();
+  auto [blocks, metaData, reader] =
+      writeAndOpenRelations(inputs, filename, 64_B);
+  ASSERT_GT(blocks.size(), 2);
+  auto tripleOfRelation1 = [](int col2) {
+    return IdTriple<>{{V(1), V(0), V(col2), V(graph)}};
+  };
+
+  // Compute the distinct `col0Id`s in the presence of the given delta triples.
+  auto getIds = [&reader](const LocatedTriplesPerBlock& locatedTriples,
+                          bool addGraphColumn = false,
+                          ScanSpecification::GraphFilter graphFilter =
+                              ScanSpecification::GraphFilter::All()) {
+    CompressedRelationReader::ScanSpecAndBlocks scanSpecAndBlocks{
+        ScanSpecification{std::nullopt, std::nullopt, std::nullopt,
+                          LocalVocab{}, std::move(graphFilter)},
+        getBlockMetadataRangesfromVec(locatedTriples.getAugmentedMetadata())};
+    return getDistinctCol0Ids(*reader, scanSpecAndBlocks, addGraphColumn,
+                              std::nullopt, locatedTriples);
+  };
+
+  // Without any delta triples, only the block of the small relations has to be
+  // read. This is the baseline for the comparisons below.
+  auto noDeltaTriples = makeLocatedTriplesPerBlock(blocks, {}, true);
+  auto baseline = getIds(noDeltaTriples);
+  checkThatTablesAreEqual(std::vector<RowInput>{{1}, {2}, {3}},
+                          baseline.idTable_);
+  EXPECT_LT(baseline.numBlocksRead_, baseline.numBlocksAll_);
+
+  // Deleting a single triple of relation 1 doesn't change that: the block that
+  // the deleted triple belongs to still contains nothing but the `col0Id` 1,
+  // and it has more rows than there are delta triples for it, so it cannot have
+  // become empty.
+  {
+    auto locatedTriples =
+        makeLocatedTriplesPerBlock(blocks, {tripleOfRelation1(5)}, false);
+    auto [result, numBlocksRead, numBlocksAll] = getIds(locatedTriples);
+    checkThatTablesAreEqual(std::vector<RowInput>{{1}, {2}, {3}}, result);
+    EXPECT_EQ(numBlocksRead, baseline.numBlocksRead_);
+  }
+
+  // If all the triples of relation 1 are deleted, then we can no longer rule
+  // out that its blocks have become empty, so they have to be read (and its
+  // `col0Id` then disappears from the result).
+  {
+    std::vector<IdTriple<>> triples;
+    for (int i = 0; i < numTriplesOfRelation1; ++i) {
+      triples.push_back(tripleOfRelation1(i));
+    }
+    auto locatedTriples =
+        makeLocatedTriplesPerBlock(blocks, std::move(triples), false);
+    auto [result, numBlocksRead, numBlocksAll] = getIds(locatedTriples);
+    checkThatTablesAreEqual(std::vector<RowInput>{{2}, {3}}, result);
+    EXPECT_GT(numBlocksRead, baseline.numBlocksRead_);
+  }
+
+  // An inserted triple with a new `col0Id` appears in the result. Its block
+  // then contains more than one `col0Id` (or consists of delta triples only)
+  // and hence has to be read.
+  {
+    auto locatedTriples = makeLocatedTriplesPerBlock(
+        blocks, {IdTriple<>{{V(4), V(0), V(0), V(graph)}}}, true);
+    auto [result, numBlocksRead, numBlocksAll] = getIds(locatedTriples);
+    checkThatTablesAreEqual(std::vector<RowInput>{{1}, {2}, {3}, {4}}, result);
+  }
+
+  // The graphs of a block with delta triples are not known from its metadata
+  // (the graph of a deleted triple is still stored there), so such a block has
+  // to be read if the graph column is requested ...
+  {
+    auto graphBaseline = getIds(noDeltaTriples, true);
+    checkThatTablesAreEqual(
+        std::vector<RowInput>{{1, graph}, {2, graph}, {3, graph}},
+        graphBaseline.idTable_);
+    auto locatedTriples =
+        makeLocatedTriplesPerBlock(blocks, {tripleOfRelation1(5)}, false);
+    auto [result, numBlocksRead, numBlocksAll] = getIds(locatedTriples, true);
+    checkThatTablesAreEqual(
+        std::vector<RowInput>{{1, graph}, {2, graph}, {3, graph}}, result);
+    EXPECT_GT(numBlocksRead, graphBaseline.numBlocksRead_);
+  }
+
+  // ... or if there is a graph filter that would otherwise be evaluated on the
+  // metadata alone.
+  {
+    auto whitelist = [] {
+      return ScanSpecification::GraphFilter::Whitelist({V(graph)});
+    };
+    auto filterBaseline = getIds(noDeltaTriples, false, whitelist());
+    checkThatTablesAreEqual(std::vector<RowInput>{{1}, {2}, {3}},
+                            filterBaseline.idTable_);
+    auto locatedTriples =
+        makeLocatedTriplesPerBlock(blocks, {tripleOfRelation1(5)}, false);
+    auto [result, numBlocksRead, numBlocksAll] =
+        getIds(locatedTriples, false, whitelist());
+    checkThatTablesAreEqual(std::vector<RowInput>{{1}, {2}, {3}}, result);
+    EXPECT_GT(numBlocksRead, filterBaseline.numBlocksRead_);
   }
 }
 

--- a/test/CompressedRelationsTest.cpp
+++ b/test/CompressedRelationsTest.cpp
@@ -1245,6 +1245,75 @@ TEST(CompressedRelationReader, getDistinctCol0IdsWithUnknownGraphsInBlock) {
 }
 
 // _____________________________________________________________________________
+TEST(CompressedRelationReader, getDistinctCol0IdsWithSeveralGraphsInBlock) {
+  // A single relation whose two triples live in the same block, but in two
+  // different graphs. Both of them are stored in the block metadata.
+  std::vector<RelationInput> inputs{{1, {{0, 0, 10}, {1, 0, 11}}}};
+  auto [filename, cleanup] = testFilenameWithCleanup();
+  // All the triples fit into a single block.
+  auto [blocks, metaData, reader] =
+      writeAndOpenRelations(inputs, filename, 1_kB);
+  ASSERT_EQ(blocks.size(), 1);
+  ASSERT_TRUE(blocks.at(0).graphInfo_.has_value());
+  LocatedTriplesPerBlock locatedTriples{};
+  locatedTriples.setOriginalMetadata(blocks);
+  locatedTriples.updateAugmentedMetadata();
+  auto makeScanSpecAndBlocks =
+      [&blocks](ScanSpecification::GraphFilter filter) {
+        return CompressedRelationReader::ScanSpecAndBlocks{
+            ScanSpecification{std::nullopt, std::nullopt, std::nullopt,
+                              LocalVocab{}, std::move(filter)},
+            getBlockMetadataRangesfromVec(blocks)};
+      };
+
+  // Both graphs of the single `col0Id` are known from the metadata, so the
+  // block doesn't have to be read although the `col0Id` appears twice.
+  {
+    auto scanSpecAndBlocks =
+        makeScanSpecAndBlocks(ScanSpecification::GraphFilter::All());
+    auto [result, numBlocksRead, numBlocksAll] = getDistinctCol0Ids(
+        *reader, scanSpecAndBlocks, true, std::nullopt, locatedTriples);
+    checkThatTablesAreEqual(std::vector<RowInput>{{1, 10}, {1, 11}}, result);
+    EXPECT_EQ(numBlocksRead, 0);
+  }
+
+  // The graph filter is also applied to the graphs that come from the metadata.
+  {
+    auto scanSpecAndBlocks = makeScanSpecAndBlocks(
+        ScanSpecification::GraphFilter::Whitelist({V(11)}));
+    auto [result, numBlocksRead, numBlocksAll] = getDistinctCol0Ids(
+        *reader, scanSpecAndBlocks, true, std::nullopt, locatedTriples);
+    checkThatTablesAreEqual(std::vector<RowInput>{{1, 11}}, result);
+    EXPECT_EQ(numBlocksRead, 0);
+  }
+}
+
+// _____________________________________________________________________________
+TEST(CompressedRelationReader, getDistinctCol0IdsWithExhaustedIdFilter) {
+  // Two small relations that share a single block.
+  std::vector<RelationInput> inputs{{1, {{0, 0}}}, {2, {{0, 0}}}};
+  addGraphColumnIfNecessary(inputs);
+  auto [filename, cleanup] = testFilenameWithCleanup();
+  auto [blocks, metaData, reader] =
+      writeAndOpenRelations(inputs, filename, 1_kB);
+  ASSERT_EQ(blocks.size(), 1);
+  LocatedTriplesPerBlock locatedTriples{};
+  locatedTriples.setOriginalMetadata(blocks);
+  locatedTriples.updateAugmentedMetadata();
+  CompressedRelationReader::ScanSpecAndBlocks scanSpecAndBlocks{
+      ScanSpecification{std::nullopt, std::nullopt, std::nullopt},
+      getBlockMetadataRangesfromVec(blocks)};
+
+  // Only the smaller of the two `col0Id`s is requested. The block has to be
+  // read because it contains two `col0Id`s, and the larger one is then
+  // discarded although the requested IDs are already exhausted at that point.
+  auto [result, numBlocksRead, numBlocksAll] = getDistinctCol0Ids(
+      *reader, scanSpecAndBlocks, false, std::vector{V(1)}, locatedTriples);
+  checkThatTablesAreEqual(std::vector<RowInput>{{1}}, result);
+  EXPECT_EQ(numBlocksRead, 1);
+}
+
+// _____________________________________________________________________________
 TEST(CompressedRelationReader, getDistinctCol0IdsWithDeltaTriples) {
   // Relation 1 is large enough to span several blocks, each of which contains
   // nothing but its `col0Id`. The small relations 2 and 3 share a single block.

--- a/test/PermutationTest.cpp
+++ b/test/PermutationTest.cpp
@@ -12,6 +12,7 @@
 
 #include "./util/GTestHelpers.h"
 #include "index/ConstantsIndexBuilding.h"
+#include "index/IndexImpl.h"
 #include "index/Permutation.h"
 #include "util/IndexTestHelpers.h"
 
@@ -59,3 +60,48 @@ TEST(Permutation, logRegistrationCanBeDisabled) {
   EXPECT_THAT(loadAndCaptureLog(false),
               ::testing::Not(::testing::HasSubstr("Registered")));
 }
+
+#ifndef QLEVER_REDUCED_FEATURE_SET_FOR_CPP17
+// _____________________________________________________________________________
+TEST(Permutation, getDistinctCol0Ids) {
+  // `getDistinctCol0Ids` is only a thin wrapper around the corresponding
+  // function of the `CompressedRelationReader` (which is tested in detail in
+  // `CompressedRelationsTest.cpp`), so we only check that all the arguments are
+  // forwarded correctly.
+  Index index = ad_utility::testing::makeTestIndex(
+      gtestCurrentTestName(), "<a> <b> <c> . <a> <b> <d> . <e> <f> <g> .");
+  auto sharedSnapshot =
+      index.deltaTriplesManager().getCurrentLocatedTriplesSharedState();
+  const auto& locatedTriplesState = *sharedSnapshot;
+  const Permutation& pso = index.getImpl().PSO();
+  auto cancellationHandle =
+      std::make_shared<ad_utility::CancellationHandle<>>();
+  ScanSpecification fullScan{std::nullopt, std::nullopt, std::nullopt};
+
+  // Concatenate all the tables that the generator yields.
+  auto getDistinctCol0Ids = [&](std::optional<std::vector<Id>> idFilter) {
+    IdTable result{1, ad_utility::makeUnlimitedAllocator<Id>()};
+    for (const IdTable& table :
+         pso.getDistinctCol0Ids(fullScan, false, std::move(idFilter),
+                                cancellationHandle, locatedTriplesState)) {
+      result.insertAtEnd(table);
+    }
+    return result;
+  };
+
+  // Without a filter, the result has to be the same as that of the eager
+  // `getDistinctCol0IdsAndCounts`, whose first column also holds the distinct
+  // `col0Id`s.
+  IdTable expected = pso.getDistinctCol0IdsAndCounts(cancellationHandle,
+                                                     locatedTriplesState, {});
+  auto getId = ad_utility::testing::makeGetId(index);
+  EXPECT_THAT(getDistinctCol0Ids(std::nullopt).getColumn(0),
+              ::testing::ElementsAreArray(expected.getColumn(0)));
+  EXPECT_THAT(getDistinctCol0Ids(std::nullopt).getColumn(0),
+              ::testing::IsSupersetOf({getId("<b>"), getId("<f>")}));
+
+  // With a filter, only the requested `col0Id`s are returned.
+  EXPECT_THAT(getDistinctCol0Ids(std::vector{getId("<b>")}).getColumn(0),
+              ::testing::ElementsAre(getId("<b>")));
+}
+#endif


### PR DESCRIPTION
Add `CompressedRelationReader::getDistinctCol0Ids` (with a thin wrapper in `Permutation`), which lazily yields the distinct values of the first column of a permutation, optionally together with their graph `Id`s, and optionally restricted to a given sorted list of `Id`s. Blocks whose only value is already known from their metadata (which is the case for almost all blocks of a large relation) are not read at all. When a list of requested `Id`s is given, only the blocks that can contain one of them are considered. Delta triples are taken into account: a block is read whenever it might have become empty or might contain an inserted `Id`, and its graphs are only taken from the metadata if it has no delta triples.

The helper classes live in the new `index/DistinctCol0Ids.h`, so that `CompressedRelation.cpp` does not grow further. The two conditions under which a block's metadata is sufficient (`columnValuesAreKnownFromMetadata`, `contentsAreKnownFromMetadata`) are factored out, and the existing `getDistinctColIdsAndCounts` uses the latter.

NOTE: This is a preparation for the `EmptyPath` operation of #3275, which is the first user of the new function.