### PR TITLE
Extract the first stage of the vocabulary merger into a `WordBatchBuilder`

### DIFF
--- a/src/VocabularyMergerMain.cpp
+++ b/src/VocabularyMergerMain.cpp
@@ -38,10 +38,8 @@ int main(int argc, char** argv) {
   TripleComponentComparator comparator;
   ad_utility::vocabulary_merger::mergeVocabulary(
       basename, partialVocabularySuffixes,
-      [&comparator](std::string_view a, bool aIsExternal, std::string_view b,
-                    bool bIsExternal) {
-        return comparator.isLessInTotalWithExternalFlag(a, aIsExternal, b,
-                                                        bIsExternal);
+      [&comparator](std::string_view a, std::string_view b) {
+        return comparator(a, b, TripleComponentComparator::Level::TOTAL);
       },
       wordCallback, 4_GB);
 }

--- a/src/index/ConstantsIndexBuilding.h
+++ b/src/index/ConstantsIndexBuilding.h
@@ -84,6 +84,27 @@ constexpr inline size_t QUEUE_SIZE_AFTER_PARALLEL_PARSING = 10;
 // performance negatively.
 constexpr inline size_t BLOCKSIZE_VOCABULARY_MERGING = 100;
 
+// The number of index mappings (which is the same as the number of merged
+// words) that are collected in a single batch of the vocabulary merging (see
+// `index/vocabulary_merger/WordBatch.h`). A single buffer of merged words
+// (see `BLOCKSIZE_VOCABULARY_MERGING`) only contains a rather small number of
+// words, which would be much too fine-grained for a task queue.
+constexpr inline size_t VOCAB_MERGER_WORD_BATCH_SIZE = 100'000;
+
+// The maximal total size of the words in a single batch of the vocabulary
+// merging. A batch is handed on as soon as one of this limit and
+// `VOCAB_MERGER_WORD_BATCH_SIZE` is reached, such that a batch of very few but
+// very long words doesn't become too large.
+constexpr inline ad_utility::MemorySize VOCAB_MERGER_WORD_BATCH_MEMORY_SIZE =
+    ad_utility::MemorySize::megabytes(10);
+
+// The maximal number of batches that may be waiting in the queue of the thread
+// that writes the merged vocabulary. NOTE: A batch keeps all the merged words
+// alive that it was created from (at most
+// `VOCAB_MERGER_WORD_BATCH_MEMORY_SIZE`, see there), so this also determines
+// the additional memory footprint of the writing.
+constexpr inline size_t VOCAB_MERGER_WORD_BATCH_QUEUE_SIZE = 3;
+
 // A buffer size used during the second pass of the Index build.
 // It is not const, so we can set it to a much lower value for unit tests to
 // increase the test coverage.

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -645,10 +645,9 @@ IndexBuilderDataAsExternalVector IndexImpl::passFileForVocabulary(
 
   AD_LOG_INFO << "Merging partial vocabularies ..." << std::endl;
   ad_utility::vocabulary_merger::VocabularyMetaData mergeRes = [&]() {
-    auto sortPred = [&cmp = vocab_.getCaseComparator()](
-                        std::string_view a, bool aIsExternal,
-                        std::string_view b, bool bIsExternal) {
-      return cmp.isLessInTotalWithExternalFlag(a, aIsExternal, b, bIsExternal);
+    auto sortPred = [&cmp = vocab_.getCaseComparator()](std::string_view a,
+                                                        std::string_view b) {
+      return cmp(a, b, TripleComponentComparator::Level::TOTAL);
     };
     auto wordCallbackPtr = vocab_.makeWordWriterPtr(onDiskBase_ + VOCAB_SUFFIX);
     auto& wordCallback = *wordCallbackPtr;

--- a/src/index/VocabularyMerger.h
+++ b/src/index/VocabularyMerger.h
@@ -99,8 +99,8 @@ class VocabularyMerger {
   // requires no further synchronization. The queue is deliberately declared
   // last, because its destructor blocks until all its pending tasks have been
   // run, and those tasks access all the members above.
-  ad_utility::TaskQueue<false> wordBatchQueue_{detail::wordBatchQueueSize, 1,
-                                               "Writing the merged vocabulary"};
+  ad_utility::TaskQueue<false> wordBatchQueue_{
+      VOCAB_MERGER_WORD_BATCH_QUEUE_SIZE, 1, "Writing the merged vocabulary"};
 
   // Friend declaration for the publicly available function.
   template <typename W, typename C>

--- a/src/index/VocabularyMerger.h
+++ b/src/index/VocabularyMerger.h
@@ -6,9 +6,7 @@
 #define QLEVER_SRC_INDEX_VOCABULARYMERGER_H
 
 #include <memory>
-#include <optional>
 #include <string>
-#include <utility>
 #include <vector>
 
 #include "backports/algorithm.h"
@@ -22,9 +20,12 @@
 #include "index/vocabulary_merger/IdMap.h"
 #include "index/vocabulary_merger/QueueWord.h"
 #include "index/vocabulary_merger/VocabularyMetaData.h"
+#include "index/vocabulary_merger/WordBatch.h"
+#include "index/vocabulary_merger/WordBatchBuilder.h"
 #include "util/HashMap.h"
 #include "util/ProgressBar.h"
 #include "util/Serializer/FileSerializer.h"
+#include "util/TaskQueue.h"
 #include "util/TypeTraits.h"
 
 using TripleVec =
@@ -34,7 +35,8 @@ using TripleVec =
 // it that are understandable (and testable) on their own live in
 // `src/index/vocabulary_merger/`, and all of them are made available by this
 // header: the `VocabularyMetaData` (the return type of `mergeVocabulary`), the
-// concepts for its callbacks, the `IdMap` types, and the `detail::QueueWord`.
+// concepts for its callbacks, the `IdMap` types, the `detail::QueueWord`, and
+// the first stage of the merging (the `detail::WordBatchBuilder`).
 namespace ad_utility::vocabulary_merger {
 
 // _______________________________________________________________
@@ -50,6 +52,20 @@ namespace ad_utility::vocabulary_merger {
 // compiled regexes; IRIs that are fully matched by any of them are treated as
 // blank nodes (see `TripleComponentWithIndex::isBlankNode`). The regexes are
 // compiled by the caller (see `IndexImpl::setBlankNodeIriRegexes`).
+//
+// The merging is split into two stages, which run on two threads that work
+// concurrently:
+//
+// 1. The thread that calls `mergeVocabulary` obtains the merged words in
+//    sorted order and eliminates the duplicates (a word typically occurs in
+//    many of the partial vocabularies). It collects the distinct words as well
+//    as the index mappings for the partial ID maps in batches (see
+//    `detail::WordBatchBuilder`) and hands each complete batch to the second
+//    thread.
+// 2. The thread of the `wordBatchQueue_` writes the distinct words of a batch
+//    to the vocabulary (via the `wordCallback`), which determines their global
+//    IDs, and then writes the index mappings of that batch to the partial ID
+//    maps (see `VocabularyMerger::writeWordBatch`).
 template <typename W, typename C>
 auto mergeVocabulary(const std::string& basename,
                      const std::vector<std::string>& partialVocabularySuffixes,
@@ -68,15 +84,23 @@ class VocabularyMerger {
 
   // The result (mostly metadata) which we'll return.
   VocabularyMetaData metaData_;
-  std::optional<TripleComponentWithIndex> lastTripleComponent_ = std::nullopt;
-  // Whether `lastTripleComponent_` is a blank node. Cached here so that
-  // `isBlankNode` (which may run a set of regexes) is evaluated only once per
-  // distinct word.
-  bool lastTripleComponentIsBlankNode_ = false;
+  ad_utility::ProgressBar progressBar_{metaData_.numWordsTotal(),
+                                       "Words merged: "};
   // The writers for the partial ID maps, one per partial vocabulary. Each of
   // them writes the mapping from the local indices of its partial vocabulary
   // to the global IDs.
   std::vector<IdMapWriter> idMapWriters_;
+  // The first stage of the merging, which runs on the thread that calls
+  // `mergeVocabulary`.
+  detail::WordBatchBuilder batchBuilder_;
+  // The second stage of the merging. NOTE: The queue has exactly one worker
+  // thread, so the batches are written in exactly the order in which the
+  // `batchBuilder_` creates them, and the state that `writeWordBatch` touches
+  // requires no further synchronization. The queue is deliberately declared
+  // last, because its destructor blocks until all its pending tasks have been
+  // run, and those tasks access all the members above.
+  ad_utility::TaskQueue<false> wordBatchQueue_{detail::wordBatchQueueSize, 1,
+                                               "Writing the merged vocabulary"};
 
   // Friend declaration for the publicly available function.
   template <typename W, typename C>
@@ -103,26 +127,19 @@ class VocabularyMerger {
 
   using QueueWord = detail::QueueWord;
 
-  // Write the queue words in the buffer to their corresponding
-  // `idMapWriters_`.
-  // The `QueueWord`s must be passed in alphabetical order wrt `lessThan` (also
-  // across multiple calls).
-  // clang-format off
-    CPP_template(typename C, typename L)(
-      requires WordCallback<C> CPP_and ranges::predicate<
-          L, TripleComponentWithIndex, TripleComponentWithIndex>)
-      // clang-format on
-      void writeQueueWordsToIdMap(
-          std::vector<QueueWord>& buffer, C& wordCallback, const L& lessThan,
-          const ad_utility::RegexSet& blankNodeIriRegexes,
-          ad_utility::ProgressBar& progressBar);
+  // Write a single complete `batch`: its distinct words to the vocabulary (via
+  // the `wordCallback`), which determines their global IDs, and then its index
+  // mappings to the corresponding `idMapWriters_`.
+  //
+  // NOTE: This is called exclusively by the thread of the `wordBatchQueue_`.
+  CPP_template(typename C)(requires WordCallback<C>) void writeWordBatch(
+      const detail::WordBatch& batch, C& wordCallback,
+      const ad_utility::RegexSet& blankNodeIriRegexes);
 
   // Close all associated files and file-based vectors and reset all internal
   // variables.
   void clear() {
     metaData_ = VocabularyMetaData{};
-    lastTripleComponent_ = std::nullopt;
-    lastTripleComponentIsBlankNode_ = false;
     // NOTE: The destructor of an `IdMapWriter` also finishes it, but only
     // an explicit `finish()` can propagate errors as exceptions.
     for (auto& idMapWriter : idMapWriters_) {

--- a/src/index/VocabularyMerger.h
+++ b/src/index/VocabularyMerger.h
@@ -5,6 +5,8 @@
 #ifndef QLEVER_SRC_INDEX_VOCABULARYMERGER_H
 #define QLEVER_SRC_INDEX_VOCABULARYMERGER_H
 
+#include <atomic>
+#include <exception>
 #include <memory>
 #include <string>
 #include <vector>
@@ -93,6 +95,15 @@ class VocabularyMerger {
   // The first stage of the merging, which runs on the thread that calls
   // `mergeVocabulary`.
   detail::WordBatchBuilder batchBuilder_;
+  // The first exception that `writeWordBatch` threw on the writing thread, if
+  // any, and a flag that says whether that has happened. An exception must not
+  // escape the thread of the `wordBatchQueue_` (that would terminate the
+  // process), so it is stored here and rethrown by `mergeVocabulary` once the
+  // queue has been finished. The flag is checked by both threads, so that the
+  // merging stops early and the batches that are still queued are skipped;
+  // the `exception_ptr` itself is only read after the queue has been joined.
+  std::atomic<bool> writerFailed_{false};
+  std::exception_ptr writerException_;
   // The second stage of the merging. NOTE: The queue has exactly one worker
   // thread, so the batches are written in exactly the order in which the
   // `batchBuilder_` creates them, and the state that `writeWordBatch` touches
@@ -140,6 +151,9 @@ class VocabularyMerger {
   // variables.
   void clear() {
     metaData_ = VocabularyMetaData{};
+    batchBuilder_ = detail::WordBatchBuilder{};
+    writerFailed_ = false;
+    writerException_ = nullptr;
     // NOTE: The destructor of an `IdMapWriter` also finishes it, but only
     // an explicit `finish()` can propagate errors as exceptions.
     for (auto& idMapWriter : idMapWriters_) {

--- a/src/index/VocabularyMergerImpl.h
+++ b/src/index/VocabularyMergerImpl.h
@@ -49,16 +49,11 @@ auto VocabularyMerger::mergeVocabulary(
     const ad_utility::RegexSet& blankNodeIriRegexes)
     -> CPP_ret(VocabularyMetaData)(
         requires WordComparator<W>&& WordCallback<C>) {
-  // Return true iff p1 >= p2 according to the lexicographic order of the IRI
-  // or literal.
-  auto lessThan = [&comparator](const TripleComponentWithIndex& t1,
-                                const TripleComponentWithIndex& t2) {
-    return comparator(t1.iriOrLiteral_, t1.isExternal_, t2.iriOrLiteral_,
-                      t2.isExternal_);
-  };
-  auto lessThanForQueue = [&lessThan](const QueueWord& p1,
-                                      const QueueWord& p2) {
-    return lessThan(p1.entry_, p2.entry_);
+  // Return true iff `p1` is smaller than `p2` according to the order of the
+  // IRI or literal.
+  auto lessThanForQueue = [&comparator](const QueueWord& p1,
+                                        const QueueWord& p2) {
+    return comparator(p1.iriOrLiteral(), p2.iriOrLiteral());
   };
 
   // Open and prepare all infiles and file-based output vectors.
@@ -97,14 +92,27 @@ auto VocabularyMerger::mergeVocabulary(
       ad_utility::parallelMultiwayMerge<QueueWord, true,
                                         decltype(detail::sizeOfQueueWord)>(
           0.8 * memoryToUse, std::move(generators), lessThanForQueue);
-  ad_utility::ProgressBar progressBar{metaData_.numWordsTotal(),
-                                      "Words merged: "};
+  // Hand each complete batch of merged words to the writing thread. NOTE: The
+  // `wordCallback` and the `blankNodeIriRegexes` are captured by reference
+  // into the queued task, so both of them have to stay alive until the
+  // `wordBatchQueue_` has been finished below.
+  auto batchCallback = [this, &wordCallback,
+                        &blankNodeIriRegexes](detail::WordBatch batch) {
+    wordBatchQueue_.push([this, batch = std::move(batch), &wordCallback,
+                          &blankNodeIriRegexes]() mutable {
+      writeWordBatch(batch, wordCallback, blankNodeIriRegexes);
+    });
+  };
   for (std::vector<QueueWord>& currentWords : mergedWords) {
-    writeQueueWordsToIdMap(currentWords, wordCallback, lessThan,
-                           blankNodeIriRegexes, progressBar);
+    batchBuilder_.addMergedWords(std::move(currentWords), comparator,
+                                 batchCallback);
   }
+  // Hand the remaining words (including the one that is still held back) to
+  // the writing thread and wait until all of them have actually been written.
+  batchBuilder_.finish(batchCallback);
+  wordBatchQueue_.finish();
 
-  AD_LOG_INFO << progressBar.getFinalProgressString() << std::flush;
+  AD_LOG_INFO << progressBar_.getFinalProgressString() << std::flush;
 
   auto metaData = std::move(metaData_);
   // completely reset all the inner state
@@ -112,64 +120,43 @@ auto VocabularyMerger::mergeVocabulary(
   return metaData;
 }
 
-// ________________________________________________________________________________
-CPP_template_def(typename C, typename L)(
-    requires WordCallback<C> CPP_and_def
-        ranges::predicate<L, TripleComponentWithIndex,
-                          TripleComponentWithIndex>) void VocabularyMerger::
-    writeQueueWordsToIdMap(std::vector<QueueWord>& buffer, C& wordCallback,
-                           const L& lessThan,
-                           const ad_utility::RegexSet& blankNodeIriRegexes,
-                           ad_utility::ProgressBar& progressBar) {
+// _____________________________________________________________________________
+CPP_template_def(typename C)(requires WordCallback<C>) void VocabularyMerger::
+    writeWordBatch(const detail::WordBatch& batch, C& wordCallback,
+                   const ad_utility::RegexSet& blankNodeIriRegexes) {
   AD_LOG_TIMING << "Start writing a batch of merged words\n";
 
-  // Iterate (avoid duplicates).
-  for (auto& top : buffer) {
-    if (!lastTripleComponent_.has_value() ||
-        top.iriOrLiteral() != lastTripleComponent_.value().iriOrLiteral()) {
-      if (lastTripleComponent_.has_value()) {
-        AD_CORRECTNESS_CHECK(lessThan(lastTripleComponent_.value(), top.entry_),
-                             "Total vocabulary order violated for ",
-                             lastTripleComponent_->iriOrLiteral(), " and ",
-                             top.iriOrLiteral());
-      }
-      lastTripleComponent_ =
-          TripleComponentWithIndex{std::move(top.iriOrLiteral()),
-                                   top.isExternal(), metaData_.numWordsTotal()};
-      lastTripleComponentIsBlankNode_ =
-          lastTripleComponent_.value().isBlankNode(blankNodeIriRegexes);
+  // TODO<optimization> If we aim to further speed this up, we could
+  // order all the write requests to _outfile _externalOutfile and all the
+  // idVecs to have a more useful external access pattern.
 
-      // TODO<optimization> If we aim to further speed this up, we could
-      // order all the write requests to _outfile _externalOutfile and all the
-      // idVecs to have a more useful external access pattern.
-
-      // Write the new word to the vocabulary.
-      auto& nextWord = lastTripleComponent_.value();
-      if (lastTripleComponentIsBlankNode_) {
-        nextWord.index_ = metaData_.getNextBlankNodeIndex();
-      } else {
-        nextWord.index_ =
-            wordCallback(nextWord.iriOrLiteral(), nextWord.isExternal());
-        metaData_.addWord(nextWord.iriOrLiteral(), nextWord.index_);
-      }
-      if (progressBar.update()) {
-        AD_LOG_INFO << progressBar.getProgressString() << std::flush;
-      }
+  // Write the distinct words of the batch to the vocabulary, which determines
+  // their global IDs.
+  std::vector<Id> globalIds;
+  globalIds.reserve(batch.uniqueWords_.size());
+  for (const auto& uniqueWord : batch.uniqueWords_) {
+    const auto& word = uniqueWord.word_;
+    if (isBlankNode(word, blankNodeIriRegexes)) {
+      globalIds.push_back(Id::makeFromBlankNodeIndex(
+          BlankNodeIndex::make(metaData_.getNextBlankNodeIndex())));
     } else {
-      // If a word appears with different values for `isExternal`, then we
-      // externalize it.
-      bool& external = lastTripleComponent_.value().isExternal();
-      external = external || top.isExternal();
+      auto wordIndex = wordCallback(word, uniqueWord.isExternal_);
+      metaData_.addWord(word, wordIndex);
+      globalIds.push_back(Id::makeFromVocabIndex(VocabIndex::make(wordIndex)));
     }
-    const auto& word = lastTripleComponent_.value();
-    Id targetId =
-        lastTripleComponentIsBlankNode_
-            ? Id::makeFromBlankNodeIndex(BlankNodeIndex::make(word.index_))
-            : Id::makeFromVocabIndex(VocabIndex::make(word.index_));
-    // Write the mapping from the local index to the global ID to the ID map
-    // of the partial vocabulary that this occurrence of the word came from.
-    idMapWriters_[top.partialFileId_].push(
-        IdMapEntry{VocabIndex::make(top.id()), targetId});
+    if (progressBar_.update()) {
+      AD_LOG_INFO << progressBar_.getProgressString() << std::flush;
+    }
+  }
+
+  // Write the mapping from the local index to the global ID to the ID map of
+  // the partial vocabulary that each occurrence of a word came from.
+  const auto& localIdxMappings = batch.localIdxMappings_;
+  for (size_t i = 0; i < localIdxMappings.numMappings_; ++i) {
+    const auto& mapping = localIdxMappings.mappings_[i];
+    idMapWriters_[mapping.partialVocabularyIndex_].push(
+        IdMapEntry{mapping.indexOfWordInPartialVocabulary_,
+                   globalIds[mapping.indexOfWordInBatch_]});
   }
 }
 

--- a/src/index/VocabularyMergerImpl.h
+++ b/src/index/VocabularyMergerImpl.h
@@ -5,7 +5,9 @@
 #ifndef QLEVER_SRC_INDEX_VOCABULARYMERGERIMPL_H
 #define QLEVER_SRC_INDEX_VOCABULARYMERGERIMPL_H
 
+#include <cstdint>
 #include <future>
+#include <limits>
 #include <string>
 #include <utility>
 #include <vector>
@@ -76,6 +78,12 @@ auto VocabularyMerger::mergeVocabulary(
   };
   std::vector<decltype(makeWordRangeFromFile(0))> generators;
   generators.reserve(partialVocabularySuffixes.size());
+  // The index of the partial vocabulary that a merged word comes from is
+  // stored in 32 bits (see `detail::LocalIdxToBatchMapping`). NOTE: This check
+  // is done here (and not per merged word, which would be on the hot path of
+  // the merging), because `partialFileId_` is always one of the indices below.
+  AD_CORRECTNESS_CHECK(partialVocabularySuffixes.size() <=
+                       std::numeric_limits<uint32_t>::max());
 
   for (std::size_t i :
        ad_utility::integerRange(partialVocabularySuffixes.size())) {

--- a/src/index/VocabularyMergerImpl.h
+++ b/src/index/VocabularyMergerImpl.h
@@ -108,10 +108,27 @@ auto VocabularyMerger::mergeVocabulary(
                         &blankNodeIriRegexes](detail::WordBatch batch) {
     wordBatchQueue_.push([this, batch = std::move(batch), &wordCallback,
                           &blankNodeIriRegexes]() mutable {
-      writeWordBatch(batch, wordCallback, blankNodeIriRegexes);
+      // An exception must not escape the thread of the queue, see
+      // `writerException_`. Once a batch has failed, the remaining batches
+      // are skipped, because their words could no longer be written
+      // consistently anyway.
+      if (writerFailed_) {
+        return;
+      }
+      try {
+        writeWordBatch(batch, wordCallback, blankNodeIriRegexes);
+      } catch (...) {
+        writerException_ = std::current_exception();
+        writerFailed_ = true;
+      }
     });
   };
   for (std::vector<QueueWord>& currentWords : mergedWords) {
+    // Stop merging as soon as the writing thread has failed, the exception is
+    // rethrown below.
+    if (writerFailed_) {
+      break;
+    }
     batchBuilder_.addMergedWords(std::move(currentWords), comparator,
                                  batchCallback);
   }
@@ -119,6 +136,14 @@ auto VocabularyMerger::mergeVocabulary(
   // the writing thread and wait until all of them have actually been written.
   batchBuilder_.finish(batchCallback);
   wordBatchQueue_.finish();
+  // Propagate an exception from the writing thread to the caller. NOTE: The
+  // queue has been joined, so reading `writerException_` here is safe. The
+  // internal state is not `clear()`ed on this path (the `IdMapWriter`s are
+  // finished by their destructors, which do not throw), so that a failure
+  // of that cleanup cannot hide the original exception.
+  if (writerException_) {
+    std::rethrow_exception(writerException_);
+  }
 
   AD_LOG_INFO << progressBar_.getFinalProgressString() << std::flush;
 

--- a/src/index/vocabulary_merger/Concepts.h
+++ b/src/index/vocabulary_merger/Concepts.h
@@ -25,11 +25,11 @@ template <typename T>
 CPP_concept WordCallback =
     ad_utility::InvocableWithExactReturnType<T, uint64_t, std::string_view,
                                              bool>;
-// Concept for a callable that compares two `string_view`s with respective
-// `isExternal` flags.
+// Concept for a callable that compares two words (represented as
+// `string_view`s) according to the order of the merged vocabulary.
 template <typename T>
 CPP_concept WordComparator =
-    ::ranges::predicate<T, std::string_view, bool, std::string_view, bool>;
+    ::ranges::predicate<T, std::string_view, std::string_view>;
 }  // namespace ad_utility::vocabulary_merger
 
 #endif  // QLEVER_SRC_INDEX_VOCABULARY_MERGER_CONCEPTS_H

--- a/src/index/vocabulary_merger/QueueWord.h
+++ b/src/index/vocabulary_merger/QueueWord.h
@@ -33,8 +33,15 @@ struct QueueWord {
   size_t partialFileId_;  // from which partial vocabulary did this word come
 
   [[nodiscard]] bool& isExternal() { return entry_.isExternal(); }
+  // NOTE: The `const` overloads are needed because the first stage of the
+  // merging (see `index/vocabulary_merger/WordBatchBuilder.h`) only reads the
+  // merged words; it never modifies them.
+  [[nodiscard]] const bool& isExternal() const { return entry_.isExternal(); }
 
   [[nodiscard]] std::string& iriOrLiteral() { return entry_.iriOrLiteral(); }
+  [[nodiscard]] const std::string& iriOrLiteral() const {
+    return entry_.iriOrLiteral();
+  }
 
   [[nodiscard]] const auto& id() const { return entry_.index_; }
 };

--- a/src/index/vocabulary_merger/WordBatch.h
+++ b/src/index/vocabulary_merger/WordBatch.h
@@ -1,0 +1,108 @@
+// Copyright 2026 The QLever Authors, in particular:
+//
+// 2026 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+//
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#ifndef QLEVER_SRC_INDEX_VOCABULARY_MERGER_WORDBATCH_H
+#define QLEVER_SRC_INDEX_VOCABULARY_MERGER_WORDBATCH_H
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <vector>
+
+#include "backports/concepts.h"
+#include "global/VocabIndex.h"
+#include "index/vocabulary_merger/QueueWord.h"
+#include "util/UninitializedAllocator.h"
+
+// A batch of merged words, which is the unit of work that the first stage of
+// the vocabulary merger (see `index/vocabulary_merger/WordBatchBuilder.h`)
+// hands to the stage that writes the words and the partial ID maps. This is
+// not part of the public interface of `index/VocabularyMerger.h`.
+namespace ad_utility::vocabulary_merger::detail {
+
+// A mapping from an `indexOfWordInPartialVocabulary_` (an index of a word in
+// the `partialVocabularyIndex_`-th partial vocabulary) to the corresponding
+// index of the word in a merged batch (`indexOfWordInBatch_`) of words, for
+// which the global ID is not yet known.
+//
+// NOTE: The declaration order deliberately deviates from the logical order of
+// the members, such that the struct is exactly 16 and not 24 bytes large.
+// There is one such mapping per merged word, and they are written scattered
+// over all the partial ID maps, so both the memory footprint and the cache
+// pressure of this struct matter.
+struct LocalIdxToBatchMapping {
+  uint32_t partialVocabularyIndex_;
+  uint32_t indexOfWordInBatch_;
+  VocabIndex indexOfWordInPartialVocabulary_;
+};
+static_assert(sizeof(LocalIdxToBatchMapping) == 16,
+              "The members of a `LocalIdxToBatchMapping` have to be declared "
+              "such that no padding is required, see the comment above");
+
+// All the `LocalIdxToBatchMapping`s for a single batch of merged words. NOTE:
+// We deliberately do not use a plain vector with `push_back`, but a plain
+// array with a manual index for maximal performance (the `push_back` overhead
+// was measurable on the hot path).
+struct LocalIdxToBatchMappings {
+  ad_utility::UninitializedVector<LocalIdxToBatchMapping> mappings_;
+  size_t numMappings_ = 0;
+};
+
+// A unique word from the merged vocabulary (after deduplication between the
+// partial vocabularies has been performed) together with the information
+// whether the word is to be externalized. NOTE: The word is stored in a
+// non-owning `string_view` for performance reasons, so the batch has to keep
+// all the words alive. The only exception is the first word of a batch, see
+// `WordBatch::carriedOverWord_`.
+struct UniqueWord {
+  std::string_view word_;
+  bool isExternal_;
+};
+
+// A batch of merged words, as it is handed from the merging thread to the
+// thread that writes the words to the vocabulary.
+struct WordBatch {
+  std::vector<UniqueWord> uniqueWords_;
+  LocalIdxToBatchMappings localIdxMappings_;
+  // The buffers of merged words that back the `string_view`s of the
+  // `uniqueWords_` (see there).
+  std::vector<std::vector<QueueWord>> mergedWordBuffers_;
+  // The first of the `uniqueWords_` is typically carried over from the
+  // previous batch (see `WordBatchBuilder`), in which case it was merged from
+  // a buffer that belongs to that previous batch and this batch has to own its
+  // own copy of it.
+  //
+  // NOTE: The indirection via the `unique_ptr` is required because a
+  // `WordBatch` is moved several times on its way to the writing thread, which
+  // (because of the short string optimization) would invalidate a
+  // `string_view` into a plain `std::string` member.
+  std::unique_ptr<std::string> carriedOverWord_;
+};
+
+// Concept for a callback that consumes a complete `WordBatch`.
+template <typename T>
+CPP_concept WordBatchCallback = std::is_invocable_v<const T&, WordBatch>;
+
+// The number of index mappings (which is the same as the number of merged
+// words) that are collected in a single batch. A single buffer of merged
+// words only contains a rather small number of words (currently 100), which
+// would be much too fine-grained for a task queue.
+inline constexpr size_t wordBatchSize = 100'000;
+
+// The maximal number of batches that may be waiting in the queue of the
+// writing thread. NOTE: A batch keeps all the merged words alive that it was
+// created from (typically a few megabytes, see `wordBatchSize`), so this also
+// determines the additional memory footprint of the writing.
+inline constexpr size_t wordBatchQueueSize = 3;
+}  // namespace ad_utility::vocabulary_merger::detail
+
+#endif  // QLEVER_SRC_INDEX_VOCABULARY_MERGER_WORDBATCH_H

--- a/src/index/vocabulary_merger/WordBatch.h
+++ b/src/index/vocabulary_merger/WordBatch.h
@@ -48,6 +48,12 @@ static_assert(sizeof(LocalIdxToBatchMapping) == 16,
               "The members of a `LocalIdxToBatchMapping` have to be declared "
               "such that no padding is required, see the comment above");
 
+// The value that is stored in `LocalIdxToBatchMapping::indexOfWordInBatch_` as
+// long as the index of the word within its batch is not yet known (see
+// `WordBatchBuilder::commitPendingWord`). Deliberately not `0`, such that a
+// mapping for which that index was never filled in is easy to spot.
+inline constexpr uint32_t indexOfWordInBatchDummy = 424345;
+
 // All the `LocalIdxToBatchMapping`s for a single batch of merged words. NOTE:
 // We deliberately do not use a plain vector with `push_back`, but a plain
 // array with a manual index for maximal performance (the `push_back` overhead
@@ -91,18 +97,6 @@ struct WordBatch {
 // Concept for a callback that consumes a complete `WordBatch`.
 template <typename T>
 CPP_concept WordBatchCallback = std::is_invocable_v<const T&, WordBatch>;
-
-// The number of index mappings (which is the same as the number of merged
-// words) that are collected in a single batch. A single buffer of merged
-// words only contains a rather small number of words (currently 100), which
-// would be much too fine-grained for a task queue.
-inline constexpr size_t wordBatchSize = 100'000;
-
-// The maximal number of batches that may be waiting in the queue of the
-// writing thread. NOTE: A batch keeps all the merged words alive that it was
-// created from (typically a few megabytes, see `wordBatchSize`), so this also
-// determines the additional memory footprint of the writing.
-inline constexpr size_t wordBatchQueueSize = 3;
 }  // namespace ad_utility::vocabulary_merger::detail
 
 #endif  // QLEVER_SRC_INDEX_VOCABULARY_MERGER_WORDBATCH_H

--- a/src/index/vocabulary_merger/WordBatch.h
+++ b/src/index/vocabulary_merger/WordBatch.h
@@ -50,9 +50,21 @@ static_assert(sizeof(LocalIdxToBatchMapping) == 16,
 
 // The value that is stored in `LocalIdxToBatchMapping::indexOfWordInBatch_` as
 // long as the index of the word within its batch is not yet known (see
-// `WordBatchBuilder::commitPendingWord`). Deliberately not `0`, such that a
-// mapping for which that index was never filled in is easy to spot.
-inline constexpr uint32_t indexOfWordInBatchDummy = 424345;
+// `WordBatchBuilder::commitPendingWord`). Deliberately a bogus bit pattern
+// with the highest bit set (and in particular not `0`), such that a mapping
+// for which that index was never filled in is easy to spot.
+inline constexpr uint32_t indexOfWordInBatchDummy = 0xDEADBEEF;
+
+// The maximal number of distinct words in a single batch. Because of this
+// limit, every actual `indexOfWordInBatch_` is smaller than the
+// `indexOfWordInBatchDummy` above (which has its highest bit set), so the
+// dummy can never be confused with an actual index. NOTE: The limit is checked
+// in `WordBatchBuilder::commitPendingWord`, and it is far larger than the
+// batch sizes that are used in practice (see `VOCAB_MERGER_WORD_BATCH_SIZE`).
+inline constexpr uint32_t maxNumUniqueWordsPerBatch = uint32_t{1} << 31;
+static_assert(maxNumUniqueWordsPerBatch <= indexOfWordInBatchDummy,
+              "The dummy has to be an upper bound for the actual indices of "
+              "the words within a batch, see the comment above");
 
 // All the `LocalIdxToBatchMapping`s for a single batch of merged words. NOTE:
 // We deliberately do not use a plain vector with `push_back`, but a plain
@@ -92,6 +104,25 @@ struct WordBatch {
   // (because of the short string optimization) would invalidate a
   // `string_view` into a plain `std::string` member.
   std::unique_ptr<std::string> carriedOverWord_;
+
+  // Create an empty batch, with the buffers for `numWordsPerBatch` merged
+  // words already allocated.
+  explicit WordBatch(size_t numWordsPerBatch) {
+    // The mappings are stored in a vector with a `default_init_allocator`, so
+    // this `resize` is a plain allocation that doesn't touch the memory.
+    localIdxMappings_.mappings_.resize(numWordsPerBatch);
+    // There is exactly one index mapping per merged word, and the number of
+    // distinct words is at most the number of merged words, so this is an
+    // upper bound for all but the rare batch that slightly overshoots the
+    // `numWordsPerBatch` (a batch is only handed on once a complete buffer of
+    // merged words has been added to it).
+    uniqueWords_.reserve(numWordsPerBatch);
+  }
+
+  // A batch is empty as long as no index mapping has been added to it. NOTE:
+  // There is exactly one index mapping per merged word, so an empty batch also
+  // has no `uniqueWords_`.
+  bool empty() const { return localIdxMappings_.numMappings_ == 0; }
 };
 
 // Concept for a callback that consumes a complete `WordBatch`.

--- a/src/index/vocabulary_merger/WordBatchBuilder.h
+++ b/src/index/vocabulary_merger/WordBatchBuilder.h
@@ -61,7 +61,7 @@ class WordBatchBuilder {
   // vocabulary, so this vector stays small.
   std::vector<LocalIdxToBatchMapping> pendingMappings_;
   // The batch that is currently being filled.
-  WordBatch currentBatch_;
+  WordBatch currentBatch_{VOCAB_MERGER_WORD_BATCH_SIZE};
   // The total size of the words that were merged into the `currentBatch_`
   // (including the duplicates, as the batch keeps all of them alive). NOTE:
   // This is deliberately a plain number of bytes and not an
@@ -69,8 +69,6 @@ class WordBatchBuilder {
   size_t currentBatchWordSizeInBytes_ = 0;
 
  public:
-  WordBatchBuilder() { startNewBatch(); }
-
   // Eliminate the duplicates from a `buffer` of merged words and add the
   // resulting distinct words as well as one index mapping per merged word to
   // the current batch. The last distinct word and its mappings are held back
@@ -174,7 +172,7 @@ CPP_template_def(typename F)(
 CPP_template_def(typename F)(
     requires WordBatchCallback<
         F>) void WordBatchBuilder::flush(const F& batchCallback) {
-  if (currentBatch_.localIdxMappings_.numMappings_ == 0) {
+  if (currentBatch_.empty()) {
     return;
   }
   // The `pendingWord_` is a view into one of the buffers of the current batch,
@@ -210,6 +208,11 @@ inline void WordBatchBuilder::commitPendingWord() {
   }
   auto& uniqueWords = currentBatch_.uniqueWords_;
   uniqueWords.push_back(UniqueWord{pendingWord_, pendingWordIsExternal_});
+  // The index of a word within its batch is stored in 32 bits, and has to stay
+  // below the `indexOfWordInBatchDummy` (see there). NOTE: This check is
+  // performed once per distinct word, so it is not on the hot path of the
+  // merging (which is one iteration per merged word, see `addMergedWords`).
+  AD_CORRECTNESS_CHECK(uniqueWords.size() <= maxNumUniqueWordsPerBatch);
   auto indexOfWordInBatch = static_cast<uint32_t>(uniqueWords.size() - 1);
   for (auto mapping : pendingMappings_) {
     mapping.indexOfWordInBatch_ = indexOfWordInBatch;
@@ -223,19 +226,9 @@ inline void WordBatchBuilder::commitPendingWord() {
 // _____________________________________________________________________________
 inline void WordBatchBuilder::startNewBatch() {
   // NOTE: A moved-from vector is in a valid but unspecified state, so we have
-  // to explicitly reset the batch.
-  currentBatch_ = WordBatch{};
+  // to explicitly reset the batch. Its constructor allocates the buffers.
+  currentBatch_ = WordBatch{VOCAB_MERGER_WORD_BATCH_SIZE};
   currentBatchWordSizeInBytes_ = 0;
-  // The mappings are stored in a vector with a `default_init_allocator`, so
-  // this `resize` is a plain allocation that doesn't touch the memory.
-  currentBatch_.localIdxMappings_.mappings_.resize(
-      VOCAB_MERGER_WORD_BATCH_SIZE);
-  // There is exactly one index mapping per merged word, and the number of
-  // distinct words is at most the number of merged words, so this is an upper
-  // bound for all but the rare batch that slightly overshoots the
-  // `VOCAB_MERGER_WORD_BATCH_SIZE` (a batch is only handed on once a complete
-  // buffer of merged words has been added to it).
-  currentBatch_.uniqueWords_.reserve(VOCAB_MERGER_WORD_BATCH_SIZE);
 }
 }  // namespace ad_utility::vocabulary_merger::detail
 

--- a/src/index/vocabulary_merger/WordBatchBuilder.h
+++ b/src/index/vocabulary_merger/WordBatchBuilder.h
@@ -1,0 +1,226 @@
+// Copyright 2026 The QLever Authors, in particular:
+//
+// 2026 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+//
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#ifndef QLEVER_SRC_INDEX_VOCABULARY_MERGER_WORDBATCHBUILDER_H
+#define QLEVER_SRC_INDEX_VOCABULARY_MERGER_WORDBATCHBUILDER_H
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "backports/concepts.h"
+#include "index/vocabulary_merger/Concepts.h"
+#include "index/vocabulary_merger/QueueWord.h"
+#include "index/vocabulary_merger/WordBatch.h"
+#include "util/Exception.h"
+
+// The first stage of the vocabulary merger (see the comment above
+// `mergeVocabulary` in `index/VocabularyMerger.h`), which is not part of the
+// public interface of that header.
+namespace ad_utility::vocabulary_merger::detail {
+
+// The first stage of the merging: eliminate the duplicates from the merged
+// words and collect the distinct words as well as the index mappings for the
+// partial ID maps in batches.
+//
+// The last distinct word that was merged is deliberately *held back* and only
+// added to a batch once a different word arrives (or once the merging is
+// finished). The reason is that a word may occur in many of the partial
+// vocabularies, possibly with different `isExternal` flags, of which the
+// merged word has to get the logical OR. Only a word that is not added to a
+// batch yet can still be changed that way; as soon as it is, the next stage
+// may already have written it to the vocabulary.
+//
+// NOTE: This class is used exclusively by the merging thread; the complete
+// `WordBatch`es are the only thing that it hands on to the writing thread.
+class WordBatchBuilder {
+ private:
+  // The distinct word that was merged last, which is held back (see the class
+  // comment above). It typically is a view into one of the
+  // `mergedWordBuffers_` of the `currentBatch_`; only if the batch that it was
+  // merged from has already been handed on, it is a view into the
+  // `carriedOverWord_` of the `currentBatch_`.
+  std::string_view pendingWord_;
+  bool hasPendingWord_ = false;
+  // Whether any of the occurrences of the `pendingWord_` that have been seen
+  // so far was marked as external.
+  bool pendingWordIsExternal_ = false;
+  // The index mappings for the occurrences of the `pendingWord_` that have
+  // been seen so far. Their `indexOfWordInBatch_` is only filled in by
+  // `commitPendingWord`. NOTE: A word occurs at most once per partial
+  // vocabulary, so this vector stays small.
+  std::vector<LocalIdxToBatchMapping> pendingMappings_;
+  // The batch that is currently being filled.
+  WordBatch currentBatch_;
+
+ public:
+  WordBatchBuilder() { startNewBatch(); }
+
+  // Eliminate the duplicates from a `buffer` of merged words and add the
+  // resulting distinct words as well as one index mapping per merged word to
+  // the current batch. The last distinct word and its mappings are held back
+  // (see the class comment above). Whenever a batch is full, it is handed to
+  // the `batchCallback`. The `QueueWord`s must be passed in alphabetical order
+  // wrt the `comparator` (also across multiple calls). NOTE: This order is only
+  // checked if the expensive checks are enabled (see `AD_EXPENSIVE_CHECK`),
+  // because the additional comparison per word is rather costly.
+  CPP_template(typename W, typename F)(
+      requires WordComparator<W> CPP_and WordBatchCallback<
+          F>) void addMergedWords(std::vector<QueueWord> buffer,
+                                  const W& comparator, const F& batchCallback);
+
+  // Signal that no more words will be added, and hand the remaining words
+  // (including the word that is still held back, see the class comment) to the
+  // `batchCallback`. After a call to `finish()`, no more words may be added.
+  CPP_template(typename F)(requires WordBatchCallback<F>) void finish(
+      const F& batchCallback);
+
+ private:
+  // Hand the current (typically only partially filled) batch to the
+  // `batchCallback` and start a new batch. Do nothing if the current batch is
+  // empty.
+  CPP_template(typename F)(requires WordBatchCallback<F>) void flush(
+      const F& batchCallback);
+
+  // Add the `pendingWord_` and its `pendingMappings_` to the `currentBatch_`.
+  // This must only be called once it is known that no further occurrence of
+  // that word can arrive. Do nothing if there is no pending word.
+  void commitPendingWord();
+
+  // Reset the `currentBatch_` and allocate its buffers.
+  void startNewBatch();
+};
+
+// _____________________________________________________________________________
+CPP_template_def(typename W,
+                 typename F)(requires WordComparator<W> CPP_and_def
+                                 WordBatchCallback<F>) void WordBatchBuilder::
+    addMergedWords(std::vector<QueueWord> buffer,
+                   [[maybe_unused]] const W& comparator,
+                   const F& batchCallback) {
+  // NOTE: The buffer is deliberately not consumed, but kept alive as part of
+  // the batch, such that the merged words neither have to be moved nor
+  // destroyed by the merging thread.
+  currentBatch_.mergedWordBuffers_.push_back(std::move(buffer));
+  const auto& words = currentBatch_.mergedWordBuffers_.back();
+
+  // Iterate (avoid duplicates).
+  for (const auto& top : words) {
+    if (!hasPendingWord_ || top.iriOrLiteral() != pendingWord_) {
+      AD_EXPENSIVE_CHECK(
+          !hasPendingWord_ || comparator(pendingWord_, top.iriOrLiteral()),
+          "Total vocabulary order violated for ", pendingWord_, " and ",
+          top.iriOrLiteral());
+      // A word that differs from the `pendingWord_` was merged, so no further
+      // occurrence of the latter can arrive and it can be committed.
+      commitPendingWord();
+      pendingWord_ = top.iriOrLiteral();
+      pendingWordIsExternal_ = top.isExternal();
+      hasPendingWord_ = true;
+    } else {
+      // If a word appears with different values for `isExternal`, then we
+      // externalize it. NOTE: This is only correct because the word is still
+      // held back, and hence has not been written to the vocabulary yet.
+      pendingWordIsExternal_ = pendingWordIsExternal_ || top.isExternal();
+    }
+    // Remember the local index of this occurrence of the `pendingWord_`. The
+    // index of the word within its batch is only filled in by
+    // `commitPendingWord`, and the actual entry of the ID map is only created
+    // (and written) once the global ID of the word is known.
+    pendingMappings_.push_back(
+        LocalIdxToBatchMapping{static_cast<uint32_t>(top.partialFileId_), 0,
+                               VocabIndex::make(top.id())});
+  }
+
+  if (currentBatch_.localIdxMappings_.numMappings_ >= wordBatchSize) {
+    flush(batchCallback);
+  }
+}
+
+// _____________________________________________________________________________
+CPP_template_def(typename F)(
+    requires WordBatchCallback<
+        F>) void WordBatchBuilder::finish(const F& batchCallback) {
+  // No further words can arrive, so the word that is held back can now be
+  // committed.
+  commitPendingWord();
+  flush(batchCallback);
+}
+
+// _____________________________________________________________________________
+CPP_template_def(typename F)(
+    requires WordBatchCallback<
+        F>) void WordBatchBuilder::flush(const F& batchCallback) {
+  if (currentBatch_.localIdxMappings_.numMappings_ == 0) {
+    return;
+  }
+  // The `pendingWord_` is a view into one of the buffers of the current batch,
+  // which the writing thread destroys as soon as the batch has been handed on,
+  // so we have to create the copy that the next batch owns *before* handing
+  // the current batch on.
+  std::unique_ptr<std::string> carriedOverWord;
+  if (hasPendingWord_) {
+    carriedOverWord = std::make_unique<std::string>(pendingWord_);
+  }
+  batchCallback(std::move(currentBatch_));
+  startNewBatch();
+  if (carriedOverWord) {
+    pendingWord_ = *carriedOverWord;
+    currentBatch_.carriedOverWord_ = std::move(carriedOverWord);
+  }
+}
+
+// _____________________________________________________________________________
+inline void WordBatchBuilder::commitPendingWord() {
+  if (!hasPendingWord_) {
+    AD_CORRECTNESS_CHECK(pendingMappings_.empty());
+    return;
+  }
+  auto& mappings = currentBatch_.localIdxMappings_.mappings_;
+  size_t& numMappings = currentBatch_.localIdxMappings_.numMappings_;
+  // The mappings are allocated in advance (see `startNewBatch`), so the
+  // following `resize` (which would have to copy the mappings that are already
+  // in the buffer) typically is a no-op, and the writes below are simple
+  // unchecked stores.
+  if (mappings.size() < numMappings + pendingMappings_.size()) {
+    mappings.resize(numMappings + pendingMappings_.size());
+  }
+  auto& uniqueWords = currentBatch_.uniqueWords_;
+  uniqueWords.push_back(UniqueWord{pendingWord_, pendingWordIsExternal_});
+  auto indexOfWordInBatch = static_cast<uint32_t>(uniqueWords.size() - 1);
+  for (auto mapping : pendingMappings_) {
+    mapping.indexOfWordInBatch_ = indexOfWordInBatch;
+    mappings[numMappings] = mapping;
+    ++numMappings;
+  }
+  pendingMappings_.clear();
+  hasPendingWord_ = false;
+}
+
+// _____________________________________________________________________________
+inline void WordBatchBuilder::startNewBatch() {
+  // NOTE: A moved-from vector is in a valid but unspecified state, so we have
+  // to explicitly reset the batch.
+  currentBatch_ = WordBatch{};
+  // The mappings are stored in a vector with a `default_init_allocator`, so
+  // this `resize` is a plain allocation that doesn't touch the memory.
+  currentBatch_.localIdxMappings_.mappings_.resize(wordBatchSize);
+  // There is exactly one index mapping per merged word, and the number of
+  // distinct words is at most the number of merged words, so this is an upper
+  // bound for all but the rare batch that slightly overshoots the
+  // `wordBatchSize` (a batch is only handed on once a complete buffer of
+  // merged words has been added to it).
+  currentBatch_.uniqueWords_.reserve(wordBatchSize);
+}
+}  // namespace ad_utility::vocabulary_merger::detail
+
+#endif  // QLEVER_SRC_INDEX_VOCABULARY_MERGER_WORDBATCHBUILDER_H

--- a/src/index/vocabulary_merger/WordBatchBuilder.h
+++ b/src/index/vocabulary_merger/WordBatchBuilder.h
@@ -18,6 +18,7 @@
 #include <vector>
 
 #include "backports/concepts.h"
+#include "index/ConstantsIndexBuilding.h"
 #include "index/vocabulary_merger/Concepts.h"
 #include "index/vocabulary_merger/QueueWord.h"
 #include "index/vocabulary_merger/WordBatch.h"
@@ -61,6 +62,11 @@ class WordBatchBuilder {
   std::vector<LocalIdxToBatchMapping> pendingMappings_;
   // The batch that is currently being filled.
   WordBatch currentBatch_;
+  // The total size of the words that were merged into the `currentBatch_`
+  // (including the duplicates, as the batch keeps all of them alive). NOTE:
+  // This is deliberately a plain number of bytes and not an
+  // `ad_utility::MemorySize`, because it is updated once per merged word.
+  size_t currentBatchWordSizeInBytes_ = 0;
 
  public:
   WordBatchBuilder() { startNewBatch(); }
@@ -68,11 +74,13 @@ class WordBatchBuilder {
   // Eliminate the duplicates from a `buffer` of merged words and add the
   // resulting distinct words as well as one index mapping per merged word to
   // the current batch. The last distinct word and its mappings are held back
-  // (see the class comment above). Whenever a batch is full, it is handed to
-  // the `batchCallback`. The `QueueWord`s must be passed in alphabetical order
-  // wrt the `comparator` (also across multiple calls). NOTE: This order is only
-  // checked if the expensive checks are enabled (see `AD_EXPENSIVE_CHECK`),
-  // because the additional comparison per word is rather costly.
+  // (see the class comment above). Whenever a batch is full (see
+  // `VOCAB_MERGER_WORD_BATCH_SIZE` and `VOCAB_MERGER_WORD_BATCH_MEMORY_SIZE`),
+  // it is handed to the `batchCallback`. The `QueueWord`s must be passed in
+  // alphabetical order wrt the `comparator` (also across multiple calls). NOTE:
+  // This order is only checked if the expensive checks are enabled (see
+  // `AD_EXPENSIVE_CHECK`), because the additional comparison per word is rather
+  // costly.
   CPP_template(typename W, typename F)(
       requires WordComparator<W> CPP_and WordBatchCallback<
           F>) void addMergedWords(std::vector<QueueWord> buffer,
@@ -132,16 +140,22 @@ CPP_template_def(typename W,
       // held back, and hence has not been written to the vocabulary yet.
       pendingWordIsExternal_ = pendingWordIsExternal_ || top.isExternal();
     }
+    currentBatchWordSizeInBytes_ += top.iriOrLiteral().size();
     // Remember the local index of this occurrence of the `pendingWord_`. The
     // index of the word within its batch is only filled in by
-    // `commitPendingWord`, and the actual entry of the ID map is only created
-    // (and written) once the global ID of the word is known.
-    pendingMappings_.push_back(
-        LocalIdxToBatchMapping{static_cast<uint32_t>(top.partialFileId_), 0,
-                               VocabIndex::make(top.id())});
+    // `commitPendingWord`, so we write the dummy `indexOfWordInBatchDummy` for
+    // now. The actual entry of the ID map is only created (and written) once
+    // the global ID of the word is known.
+    pendingMappings_.push_back(LocalIdxToBatchMapping{
+        static_cast<uint32_t>(top.partialFileId_), indexOfWordInBatchDummy,
+        VocabIndex::make(top.id())});
   }
 
-  if (currentBatch_.localIdxMappings_.numMappings_ >= wordBatchSize) {
+  // A batch is complete as soon as one of the two limits is reached.
+  if (currentBatch_.localIdxMappings_.numMappings_ >=
+          VOCAB_MERGER_WORD_BATCH_SIZE ||
+      currentBatchWordSizeInBytes_ >=
+          VOCAB_MERGER_WORD_BATCH_MEMORY_SIZE.getBytes()) {
     flush(batchCallback);
   }
 }
@@ -211,15 +225,17 @@ inline void WordBatchBuilder::startNewBatch() {
   // NOTE: A moved-from vector is in a valid but unspecified state, so we have
   // to explicitly reset the batch.
   currentBatch_ = WordBatch{};
+  currentBatchWordSizeInBytes_ = 0;
   // The mappings are stored in a vector with a `default_init_allocator`, so
   // this `resize` is a plain allocation that doesn't touch the memory.
-  currentBatch_.localIdxMappings_.mappings_.resize(wordBatchSize);
+  currentBatch_.localIdxMappings_.mappings_.resize(
+      VOCAB_MERGER_WORD_BATCH_SIZE);
   // There is exactly one index mapping per merged word, and the number of
   // distinct words is at most the number of merged words, so this is an upper
   // bound for all but the rare batch that slightly overshoots the
-  // `wordBatchSize` (a batch is only handed on once a complete buffer of
-  // merged words has been added to it).
-  currentBatch_.uniqueWords_.reserve(wordBatchSize);
+  // `VOCAB_MERGER_WORD_BATCH_SIZE` (a batch is only handed on once a complete
+  // buffer of merged words has been added to it).
+  currentBatch_.uniqueWords_.reserve(VOCAB_MERGER_WORD_BATCH_SIZE);
 }
 }  // namespace ad_utility::vocabulary_merger::detail
 

--- a/test/VocabularyGeneratorTest.cpp
+++ b/test/VocabularyGeneratorTest.cpp
@@ -246,6 +246,11 @@ TEST_F(MergeVocabularyTest, mergeVocabulary) {
 
 // _____________________________________________________________________________
 TEST(MergeVocabulary, mergeVocabularyAssertion) {
+  // The violated order is only detected if the expensive checks are enabled
+  // (see `WordBatchBuilder::addMergedWords`).
+  if constexpr (!ad_utility::areExpensiveChecksEnabled) {
+    GTEST_SKIP();
+  }
   auto callback = [](const auto&, bool) { return uint64_t{0}; };
 
   std::string basePath = gtestCurrentTestName();

--- a/test/VocabularyGeneratorTest.cpp
+++ b/test/VocabularyGeneratorTest.cpp
@@ -526,3 +526,39 @@ TEST(MergeVocabulary, externalizationAcrossBatchBoundaries) {
       getIdMapFromFile(absl::StrCat(basePath, PARTIAL_VOCAB_IDMAP_INFIX, 1)),
       ::testing::ElementsAre(IdMapEntry{L(0), V(numWords - 1)}));
 }
+// _____________________________________________________________________________
+// An exception that is thrown while a batch is written (here by the word
+// callback, in practice e.g. by a full disk) happens on the writing thread. It
+// must be propagated to the caller of `mergeVocabulary` and must not terminate
+// the process, and the batches that are still queued must not be written.
+TEST(MergeVocabulary, exceptionFromWritingThreadIsPropagated) {
+  // More words than fit into a single batch (see
+  // `VOCAB_MERGER_WORD_BATCH_SIZE`), so that there is a second batch that
+  // has to be skipped after the first one has failed.
+  static constexpr size_t numWords = 120'000;
+  std::string basePath = absl::StrCat(gtestCurrentTestName(), "-");
+  std::vector<std::string> filenames{
+      absl::StrCat(basePath, PARTIAL_VOCAB_WORDS_INFIX, 0),
+      absl::StrCat(basePath, PARTIAL_VOCAB_IDMAP_INFIX, 0)};
+  absl::Cleanup cleanup = [&filenames] {
+    for (const auto& filename : filenames) {
+      ad_utility::deleteFile(filename, false);
+    }
+  };
+  std::vector<std::string> words;
+  for (size_t i = 0; i < numWords; ++i) {
+    words.push_back(absl::StrFormat("\"word%08d\"", i));
+  }
+  writePartialVocabularyFile(filenames.at(0), words);
+
+  size_t numCalls = 0;
+  auto wordCallback = [&numCalls](std::string_view, bool) -> uint64_t {
+    ++numCalls;
+    throw std::runtime_error{"The vocabulary could not be written"};
+  };
+  AD_EXPECT_THROW_WITH_MESSAGE_AND_TYPE(
+      mergeVocabulary(basePath, {"0"}, std::less{}, wordCallback, 1_GB),
+      ::testing::HasSubstr("could not be written"), std::runtime_error);
+  // The first word of the first batch threw, and the second batch was skipped.
+  EXPECT_EQ(numCalls, 1u);
+}

--- a/test/VocabularyGeneratorTest.cpp
+++ b/test/VocabularyGeneratorTest.cpp
@@ -11,6 +11,7 @@
 #include <cstdlib>
 #include <ctime>
 #include <fstream>
+#include <functional>
 #include <iostream>
 #include <memory>
 #include <string>
@@ -263,12 +264,7 @@ TEST(MergeVocabulary, mergeVocabularyAssertion) {
       absl::StrCat(basePath, PARTIAL_VOCAB_WORDS_INFIX, 1), unorderedWords);
 
   AD_EXPECT_THROW_WITH_MESSAGE_AND_TYPE(
-      mergeVocabulary(
-          basePath, {"0", "1"},
-          [](std::string_view a, std::string_view b) {
-            return std::less{}(a, b);
-          },
-          callback, 1_GB),
+      mergeVocabulary(basePath, {"0", "1"}, std::less{}, callback, 1_GB),
       ::testing::HasSubstr("vocabulary order violated"), ad_utility::Exception);
 }
 
@@ -312,10 +308,8 @@ TEST(MergeVocabulary, treatIrisAsBlankNodesViaRegex) {
   //   partial match it would have wrongly converted `<http://ex/apple>`.
   ad_utility::RegexSet blankNodeIriRegexes{
       {"<http://ex/bn_.*>", "<http://ex/apple"}, "for the test"};
-  mergeVocabulary(
-      basePath, {"0"},
-      [](std::string_view a, std::string_view b) { return std::less{}(a, b); },
-      wordCallback, 1_GB, blankNodeIriRegexes);
+  mergeVocabulary(basePath, {"0"}, std::less{}, wordCallback, 1_GB,
+                  blankNodeIriRegexes);
 
   // Only the two `bn_` IRIs became blank nodes; the two other IRIs and the
   // literal remain in the vocabulary, in sorted order.
@@ -447,10 +441,8 @@ TEST(MergeVocabulary, duplicateWordsAcrossBatchBoundaries) {
                                             bool) -> uint64_t {
     return numWordsInCallback++;
   };
-  auto result = mergeVocabulary(
-      basePath, suffixes,
-      [](std::string_view a, std::string_view b) { return std::less{}(a, b); },
-      wordCallback, 1_GB);
+  auto result =
+      mergeVocabulary(basePath, suffixes, std::less{}, wordCallback, 1_GB);
   // Each word is written to the vocabulary exactly once.
   EXPECT_EQ(numWordsInCallback, numWords);
   EXPECT_EQ(result.numWordsTotal(), numWords);
@@ -521,10 +513,8 @@ TEST(MergeVocabulary, externalizationAcrossBatchBoundaries) {
     vocabulary.emplace_back(word, isExternal);
     return vocabulary.size() - 1;
   };
-  auto result = mergeVocabulary(
-      basePath, {"0", "1"},
-      [](std::string_view a, std::string_view b) { return std::less{}(a, b); },
-      wordCallback, 1_GB);
+  auto result =
+      mergeVocabulary(basePath, {"0", "1"}, std::less{}, wordCallback, 1_GB);
   EXPECT_EQ(result.numWordsTotal(), numWords);
 
   // `"zzz"` is written exactly once, and it is externalized because one of its

--- a/test/VocabularyGeneratorTest.cpp
+++ b/test/VocabularyGeneratorTest.cpp
@@ -4,14 +4,17 @@
 //          Christoph Ullinger <ullingec@cs.uni-freiburg.de>
 
 #include <absl/cleanup/cleanup.h>
+#include <absl/strings/str_format.h>
 #include <gmock/gmock.h>
 
+#include <array>
 #include <cstdlib>
 #include <ctime>
 #include <fstream>
 #include <iostream>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "./util/IdTestHelpers.h"
 #include "backports/StartsWithAndEndsWith.h"
@@ -215,10 +218,8 @@ TEST_F(MergeVocabularyTest, mergeVocabulary) {
     TripleComponentComparator comparator;
     res = mergeVocabulary(
         basePath_, {"0", "1"},
-        [&comparator](std::string_view a, bool aIsExternal, std::string_view b,
-                      bool bIsExternal) {
-          return comparator.isLessInTotalWithExternalFlag(a, aIsExternal, b,
-                                                          bIsExternal);
+        [&comparator](std::string_view a, std::string_view b) {
+          return comparator(a, b, TripleComponentComparator::Level::TOTAL);
         },
         internalVocabularyAction, 1_GB);
   }
@@ -259,7 +260,7 @@ TEST(MergeVocabulary, mergeVocabularyAssertion) {
   AD_EXPECT_THROW_WITH_MESSAGE_AND_TYPE(
       mergeVocabulary(
           basePath, {"0", "1"},
-          [](std::string_view a, bool, std::string_view b, bool) {
+          [](std::string_view a, std::string_view b) {
             return std::less{}(a, b);
           },
           callback, 1_GB),
@@ -308,9 +309,7 @@ TEST(MergeVocabulary, treatIrisAsBlankNodesViaRegex) {
       {"<http://ex/bn_.*>", "<http://ex/apple"}, "for the test"};
   mergeVocabulary(
       basePath, {"0"},
-      [](std::string_view a, bool, std::string_view b, bool) {
-        return std::less{}(a, b);
-      },
+      [](std::string_view a, std::string_view b) { return std::less{}(a, b); },
       wordCallback, 1_GB, blankNodeIriRegexes);
 
   // Only the two `bn_` IRIs became blank nodes; the two other IRIs and the
@@ -396,4 +395,139 @@ TEST(VocabularyGeneratorTest, createInternalMappingFirstWordDuplicates) {
   EXPECT_EQ(0u, res[99]);
   EXPECT_EQ(1u, res[3]);
   EXPECT_EQ(1u, res[55]);
+}
+
+// _____________________________________________________________________________
+// Merge words that occur in *every* partial vocabulary, such that the
+// occurrences of a single word are spread over two consecutive batches of
+// merged words. Such a word is only written to the vocabulary (and hence only
+// gets its global ID) after the first of those batches has been handed to the
+// writing thread, so this exercises the deliberate holding back of the last
+// distinct word by the `WordBatchBuilder`.
+TEST(MergeVocabulary, duplicateWordsAcrossBatchBoundaries) {
+  // The words are currently collected in batches of 100000. Three partial
+  // vocabularies with the same 120000 words yield 360000 index mappings, so we
+  // get several batches, and as 100000 is not divisible by three, the
+  // occurrences of a word are indeed split by a batch boundary.
+  static constexpr size_t numWords = 120'000;
+  static constexpr size_t numFiles = 3;
+  std::string basePath = absl::StrCat(gtestCurrentTestName(), "-");
+  std::vector<std::string> suffixes;
+  std::vector<std::string> filenames;
+  for (size_t i = 0; i < numFiles; ++i) {
+    suffixes.push_back(std::to_string(i));
+    filenames.push_back(absl::StrCat(basePath, PARTIAL_VOCAB_WORDS_INFIX, i));
+    filenames.push_back(absl::StrCat(basePath, PARTIAL_VOCAB_IDMAP_INFIX, i));
+  }
+  absl::Cleanup cleanup = [&filenames] {
+    for (const auto& filename : filenames) {
+      ad_utility::deleteFile(filename, false);
+    }
+  };
+
+  // Each of the partial vocabularies contains all the words (zero-padded, such
+  // that their lexicographic order is the same as the order of their indices),
+  // with the local index `i` for the `i`-th word.
+  std::vector<std::string> words;
+  for (size_t i = 0; i < numWords; ++i) {
+    words.push_back(absl::StrFormat("\"word%08d\"", i));
+  }
+  for (size_t i = 0; i < numFiles; ++i) {
+    writePartialVocabularyFile(
+        absl::StrCat(basePath, PARTIAL_VOCAB_WORDS_INFIX, i), words);
+  }
+
+  size_t numWordsInCallback = 0;
+  auto wordCallback = [&numWordsInCallback](std::string_view,
+                                            bool) -> uint64_t {
+    return numWordsInCallback++;
+  };
+  auto result = mergeVocabulary(
+      basePath, suffixes,
+      [](std::string_view a, std::string_view b) { return std::less{}(a, b); },
+      wordCallback, 1_GB);
+  // Each word is written to the vocabulary exactly once.
+  EXPECT_EQ(numWordsInCallback, numWords);
+  EXPECT_EQ(result.numWordsTotal(), numWords);
+
+  // In each of the partial vocabularies, the word with local index `j` is the
+  // word with global id `j`.
+  IdMap expected;
+  for (size_t j = 0; j < numWords; ++j) {
+    expected.push_back({L(j), V(j)});
+  }
+  for (size_t f = 0; f < numFiles; ++f) {
+    EXPECT_THAT(
+        getIdMapFromFile(absl::StrCat(basePath, PARTIAL_VOCAB_IDMAP_INFIX, f)),
+        ::testing::ElementsAreArray(expected));
+  }
+}
+
+// _____________________________________________________________________________
+// Merge a word that occurs in two partial vocabularies with different
+// `isExternal` flags, such that the two occurrences are split by a batch
+// boundary. The merged word has to become external, which is only correct
+// because the `WordBatchBuilder` holds the word back until no further
+// occurrence of it can arrive.
+TEST(MergeVocabulary, externalizationAcrossBatchBoundaries) {
+  // The last word is the only one that occurs in both partial vocabularies,
+  // and only its occurrence in the second one is marked as external.
+  static constexpr size_t numWords = 100'000;
+  std::string basePath = absl::StrCat(gtestCurrentTestName(), "-");
+  std::vector<std::string> filenames;
+  for (size_t i = 0; i < 2; ++i) {
+    filenames.push_back(absl::StrCat(basePath, PARTIAL_VOCAB_WORDS_INFIX, i));
+    filenames.push_back(absl::StrCat(basePath, PARTIAL_VOCAB_IDMAP_INFIX, i));
+  }
+  absl::Cleanup cleanup = [&filenames] {
+    for (const auto& filename : filenames) {
+      ad_utility::deleteFile(filename, false);
+    }
+  };
+
+  // The first partial vocabulary fills a whole batch and ends with `"zzz"`,
+  // which is the only word of the second partial vocabulary, there marked as
+  // external.
+  {
+    ad_utility::serialization::FileWriteSerializer partialVocab{
+        absl::StrCat(basePath, PARTIAL_VOCAB_WORDS_INFIX, 0)};
+    partialVocab << numWords;
+    for (size_t i = 0; i + 1 < numWords; ++i) {
+      partialVocab << absl::StrFormat("\"word%08d\"", i);
+      partialVocab << false;
+      partialVocab << i;
+    }
+    partialVocab << std::string{"\"zzz\""};
+    partialVocab << false;
+    partialVocab << numWords - 1;
+  }
+  {
+    ad_utility::serialization::FileWriteSerializer partialVocab{
+        absl::StrCat(basePath, PARTIAL_VOCAB_WORDS_INFIX, 1)};
+    partialVocab << size_t{1};
+    partialVocab << std::string{"\"zzz\""};
+    partialVocab << true;
+    partialVocab << size_t{0};
+  }
+
+  std::vector<std::pair<std::string, bool>> vocabulary;
+  auto wordCallback = [&vocabulary](std::string_view word,
+                                    bool isExternal) -> uint64_t {
+    vocabulary.emplace_back(word, isExternal);
+    return vocabulary.size() - 1;
+  };
+  auto result = mergeVocabulary(
+      basePath, {"0", "1"},
+      [](std::string_view a, std::string_view b) { return std::less{}(a, b); },
+      wordCallback, 1_GB);
+  EXPECT_EQ(result.numWordsTotal(), numWords);
+
+  // `"zzz"` is written exactly once, and it is externalized because one of its
+  // two occurrences was.
+  ASSERT_EQ(vocabulary.size(), numWords);
+  EXPECT_THAT(vocabulary.back(), ::testing::Pair("\"zzz\"", true));
+  // Both occurrences of `"zzz"` map to its single global id.
+  EXPECT_THAT(
+      getIdMapFromFile(absl::StrCat(basePath, PARTIAL_VOCAB_IDMAP_INFIX, 1)),
+      ::testing::ElementsAre(IdMapEntry{L(0), V(numWords - 1)}));
 }

--- a/test/index/vocabulary_merger/CMakeLists.txt
+++ b/test/index/vocabulary_merger/CMakeLists.txt
@@ -1,1 +1,3 @@
 addLinkAndDiscoverTest(IdMapTest index)
+
+addLinkAndDiscoverTest(WordBatchBuilderTest index)

--- a/test/index/vocabulary_merger/WordBatchBuilderTest.cpp
+++ b/test/index/vocabulary_merger/WordBatchBuilderTest.cpp
@@ -172,7 +172,7 @@ TEST(WordBatchBuilder, externalizationAcrossBatchBoundary) {
   // Destroy the merged words of the first batch, exactly as the pipeline does
   // once that batch has been written. The held-back word must survive this,
   // because the second batch owns its own copy of it.
-  batches[0] = WordBatch{};
+  batches[0] = WordBatch{0};
 
   // The word was externalized, although its first occurrence (which arrived
   // before the batch boundary) was not marked as external.

--- a/test/index/vocabulary_merger/WordBatchBuilderTest.cpp
+++ b/test/index/vocabulary_merger/WordBatchBuilderTest.cpp
@@ -18,13 +18,13 @@
 #include <vector>
 
 #include "../../util/GTestHelpers.h"
+#include "index/ConstantsIndexBuilding.h"
 #include "index/vocabulary_merger/WordBatchBuilder.h"
 
 using namespace ad_utility::vocabulary_merger;
 using ad_utility::vocabulary_merger::detail::QueueWord;
 using ad_utility::vocabulary_merger::detail::WordBatch;
 using ad_utility::vocabulary_merger::detail::WordBatchBuilder;
-using ad_utility::vocabulary_merger::detail::wordBatchSize;
 using ::testing::Pair;
 
 namespace {
@@ -148,18 +148,20 @@ TEST(WordBatchBuilder, externalizationAcrossBatchBoundary) {
   // Exactly enough distinct words to fill a whole batch, followed by the word
   // that will be split by the batch boundary.
   std::vector<QueueWord> buffer;
-  for (size_t i = 0; i < wordBatchSize; ++i) {
+  for (size_t i = 0; i < VOCAB_MERGER_WORD_BATCH_SIZE; ++i) {
     buffer.push_back(makeQueueWord(fillWord(i), false, 0, i));
   }
-  buffer.push_back(makeQueueWord("\"zzz\"", false, 0, wordBatchSize));
+  buffer.push_back(
+      makeQueueWord("\"zzz\"", false, 0, VOCAB_MERGER_WORD_BATCH_SIZE));
   builder.addMergedWords(std::move(buffer), lessThan, collect);
 
   // The first batch was handed on. It contains exactly the words that can no
   // longer change, i.e. all but the last one.
   ASSERT_EQ(batches.size(), 1u);
-  ASSERT_EQ(batches[0].uniqueWords_.size(), wordBatchSize);
-  EXPECT_EQ(batches[0].uniqueWords_.back().word_, fillWord(wordBatchSize - 1));
-  EXPECT_EQ(mappingsOf(batches[0]).size(), wordBatchSize);
+  ASSERT_EQ(batches[0].uniqueWords_.size(), VOCAB_MERGER_WORD_BATCH_SIZE);
+  EXPECT_EQ(batches[0].uniqueWords_.back().word_,
+            fillWord(VOCAB_MERGER_WORD_BATCH_SIZE - 1));
+  EXPECT_EQ(mappingsOf(batches[0]).size(), VOCAB_MERGER_WORD_BATCH_SIZE);
 
   // Another occurrence of the held-back word, this time marked as external.
   builder.addMergedWords({makeQueueWord("\"zzz\"", true, 1, 0)}, lessThan,
@@ -179,7 +181,8 @@ TEST(WordBatchBuilder, externalizationAcrossBatchBoundary) {
   // Both occurrences are in the second batch and refer to its only word.
   EXPECT_THAT(
       mappingsOf(batches[1]),
-      ::testing::ElementsAre(Mapping{0, 0, wordBatchSize}, Mapping{1, 0, 0}));
+      ::testing::ElementsAre(Mapping{0, 0, VOCAB_MERGER_WORD_BATCH_SIZE},
+                             Mapping{1, 0, 0}));
 }
 
 // _____________________________________________________________________________
@@ -188,7 +191,7 @@ TEST(WordBatchBuilder, externalizationAcrossBatchBoundary) {
 // batch, the words of the batches concatenate to the input, and every
 // occurrence yields exactly one mapping.
 TEST(WordBatchBuilder, severalBatches) {
-  static constexpr size_t numWords = 5 * wordBatchSize / 2;
+  static constexpr size_t numWords = 5 * VOCAB_MERGER_WORD_BATCH_SIZE / 2;
   std::vector<WordBatch> batches;
   auto collect = [&batches](WordBatch batch) {
     batches.push_back(std::move(batch));
@@ -225,6 +228,53 @@ TEST(WordBatchBuilder, severalBatches) {
   }
   EXPECT_EQ(numWordsSeen, numWords);
   EXPECT_EQ(numMappingsSeen, numWords);
+}
+
+// _____________________________________________________________________________
+// A batch is also handed on when the total size of its words reaches
+// `VOCAB_MERGER_WORD_BATCH_MEMORY_SIZE`, long before
+// `VOCAB_MERGER_WORD_BATCH_SIZE` words have been merged.
+TEST(WordBatchBuilder, batchIsAlsoLimitedByTheMemorySize) {
+  std::vector<WordBatch> batches;
+  auto collect = [&batches](WordBatch batch) {
+    batches.push_back(std::move(batch));
+  };
+  WordBatchBuilder builder;
+
+  // Words that are so long that ten of them exceed the memory limit. The
+  // prefix makes them ascending wrt the comparator.
+  static constexpr size_t wordSize =
+      VOCAB_MERGER_WORD_BATCH_MEMORY_SIZE.getBytes() / 10;
+  auto longWord = [](size_t i) {
+    return absl::StrFormat("\"%08d%s\"", i, std::string(wordSize, 'a'));
+  };
+
+  // Hand the words to the builder one at a time, until the first batch is
+  // complete. None of them is a duplicate.
+  size_t numWordsAdded = 0;
+  while (batches.empty()) {
+    builder.addMergedWords(
+        {makeQueueWord(longWord(numWordsAdded), false, 0, numWordsAdded)},
+        lessThan, collect);
+    ++numWordsAdded;
+    ASSERT_LT(numWordsAdded, VOCAB_MERGER_WORD_BATCH_SIZE);
+  }
+  // The batch was handed on because of the size of its words, and it contains
+  // all of them but the one that is still held back.
+  EXPECT_EQ(numWordsAdded, 10u);
+  ASSERT_EQ(batches.size(), 1u);
+  EXPECT_EQ(batches[0].uniqueWords_.size(), numWordsAdded - 1);
+  EXPECT_EQ(mappingsOf(batches[0]).size(), numWordsAdded - 1);
+
+  // The size that is accumulated is reset for the new batch, so the held-back
+  // word alone doesn't immediately complete it.
+  builder.addMergedWords(
+      {makeQueueWord(longWord(numWordsAdded), false, 0, numWordsAdded)},
+      lessThan, collect);
+  EXPECT_EQ(batches.size(), 1u);
+  builder.finish(collect);
+  ASSERT_EQ(batches.size(), 2u);
+  EXPECT_EQ(batches[1].uniqueWords_.size(), 2u);
 }
 
 // _____________________________________________________________________________

--- a/test/index/vocabulary_merger/WordBatchBuilderTest.cpp
+++ b/test/index/vocabulary_merger/WordBatchBuilderTest.cpp
@@ -1,0 +1,247 @@
+// Copyright 2026 The QLever Authors, in particular:
+//
+// 2026 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+//
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#include <absl/strings/str_format.h>
+#include <gmock/gmock.h>
+
+#include <array>
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "../../util/GTestHelpers.h"
+#include "index/vocabulary_merger/WordBatchBuilder.h"
+
+using namespace ad_utility::vocabulary_merger;
+using ad_utility::vocabulary_merger::detail::QueueWord;
+using ad_utility::vocabulary_merger::detail::WordBatch;
+using ad_utility::vocabulary_merger::detail::WordBatchBuilder;
+using ad_utility::vocabulary_merger::detail::wordBatchSize;
+using ::testing::Pair;
+
+namespace {
+// An index mapping of a batch, in the order `(partial vocabulary, index of the
+// word within the batch, index of the word in the partial vocabulary)`.
+using Mapping = std::array<uint64_t, 3>;
+
+// A `WordComparator` that simply compares the words lexicographically.
+constexpr auto lessThan = [](std::string_view a, std::string_view b) {
+  return std::less<>{}(a, b);
+};
+
+// Create the `QueueWord` for the occurrence of `word` with the given
+// `localIndex` in the partial vocabulary `partialFileId`.
+QueueWord makeQueueWord(std::string word, bool isExternal, size_t partialFileId,
+                        uint64_t localIndex) {
+  return QueueWord{
+      TripleComponentWithIndex{std::move(word), isExternal, localIndex},
+      partialFileId};
+}
+
+// The distinct words of a `batch`, each with its `isExternal` flag.
+std::vector<std::pair<std::string, bool>> wordsOf(const WordBatch& batch) {
+  std::vector<std::pair<std::string, bool>> result;
+  for (const auto& uniqueWord : batch.uniqueWords_) {
+    result.emplace_back(uniqueWord.word_, uniqueWord.isExternal_);
+  }
+  return result;
+}
+
+// The valid index mappings of a `batch`.
+std::vector<Mapping> mappingsOf(const WordBatch& batch) {
+  std::vector<Mapping> result;
+  const auto& localIdxMappings = batch.localIdxMappings_;
+  for (size_t i = 0; i < localIdxMappings.numMappings_; ++i) {
+    const auto& mapping = localIdxMappings.mappings_[i];
+    result.push_back(Mapping{mapping.partialVocabularyIndex_,
+                             mapping.indexOfWordInBatch_,
+                             mapping.indexOfWordInPartialVocabulary_.get()});
+  }
+  return result;
+}
+
+// The `i`-th of the words that are used to fill up a whole batch. They are
+// zero-padded, such that their lexicographic order is the order of their
+// indices.
+std::string fillWord(size_t i) { return absl::StrFormat("\"word%08d\"", i); }
+}  // namespace
+
+// _____________________________________________________________________________
+// The duplicates are eliminated, and each occurrence of a word yields one ID
+// index mapping that refers to the distinct word it belongs to.
+TEST(WordBatchBuilder, deduplicationAndMappings) {
+  std::vector<WordBatch> batches;
+  auto collect = [&batches](WordBatch batch) {
+    batches.push_back(std::move(batch));
+  };
+
+  WordBatchBuilder builder;
+  builder.addMergedWords(
+      {makeQueueWord("\"a\"", false, 0, 0), makeQueueWord("\"b\"", false, 0, 1),
+       makeQueueWord("\"b\"", false, 1, 0)},
+      lessThan, collect);
+  // A batch that is not full is only handed on by `finish()`.
+  EXPECT_THAT(batches, ::testing::IsEmpty());
+
+  builder.finish(collect);
+  ASSERT_EQ(batches.size(), 1u);
+  EXPECT_THAT(
+      wordsOf(batches[0]),
+      ::testing::ElementsAre(Pair("\"a\"", false), Pair("\"b\"", false)));
+  EXPECT_THAT(mappingsOf(batches[0]),
+              ::testing::ElementsAre(Mapping{0, 0, 0}, Mapping{0, 1, 1},
+                                     Mapping{1, 1, 0}));
+}
+
+// _____________________________________________________________________________
+// A builder to which no word was added hands on no batch at all.
+TEST(WordBatchBuilder, noWords) {
+  std::vector<WordBatch> batches;
+  auto collect = [&batches](WordBatch batch) {
+    batches.push_back(std::move(batch));
+  };
+  WordBatchBuilder builder;
+  builder.finish(collect);
+  EXPECT_THAT(batches, ::testing::IsEmpty());
+}
+
+// _____________________________________________________________________________
+// If a word occurs with different values for `isExternal`, then the merged
+// word is externalized, no matter in which order the occurrences arrive.
+TEST(WordBatchBuilder, externalizationWithinOneBatch) {
+  for (bool firstIsExternal : {false, true}) {
+    std::vector<WordBatch> batches;
+    auto collect = [&batches](WordBatch batch) {
+      batches.push_back(std::move(batch));
+    };
+    WordBatchBuilder builder;
+    builder.addMergedWords({makeQueueWord("\"a\"", firstIsExternal, 0, 0),
+                            makeQueueWord("\"a\"", !firstIsExternal, 1, 0)},
+                           lessThan, collect);
+    builder.finish(collect);
+    ASSERT_EQ(batches.size(), 1u);
+    EXPECT_THAT(wordsOf(batches[0]),
+                ::testing::ElementsAre(Pair("\"a\"", true)));
+  }
+}
+
+// _____________________________________________________________________________
+// The same, but with the occurrences of the word split by a batch boundary.
+// The last distinct word of a batch is held back exactly for this reason, so
+// the second occurrence still has to change its `isExternal` flag, and both of
+// its index mappings have to end up in the *second* batch.
+TEST(WordBatchBuilder, externalizationAcrossBatchBoundary) {
+  std::vector<WordBatch> batches;
+  auto collect = [&batches](WordBatch batch) {
+    batches.push_back(std::move(batch));
+  };
+  WordBatchBuilder builder;
+
+  // Exactly enough distinct words to fill a whole batch, followed by the word
+  // that will be split by the batch boundary.
+  std::vector<QueueWord> buffer;
+  for (size_t i = 0; i < wordBatchSize; ++i) {
+    buffer.push_back(makeQueueWord(fillWord(i), false, 0, i));
+  }
+  buffer.push_back(makeQueueWord("\"zzz\"", false, 0, wordBatchSize));
+  builder.addMergedWords(std::move(buffer), lessThan, collect);
+
+  // The first batch was handed on. It contains exactly the words that can no
+  // longer change, i.e. all but the last one.
+  ASSERT_EQ(batches.size(), 1u);
+  ASSERT_EQ(batches[0].uniqueWords_.size(), wordBatchSize);
+  EXPECT_EQ(batches[0].uniqueWords_.back().word_, fillWord(wordBatchSize - 1));
+  EXPECT_EQ(mappingsOf(batches[0]).size(), wordBatchSize);
+
+  // Another occurrence of the held-back word, this time marked as external.
+  builder.addMergedWords({makeQueueWord("\"zzz\"", true, 1, 0)}, lessThan,
+                         collect);
+  builder.finish(collect);
+  ASSERT_EQ(batches.size(), 2u);
+
+  // Destroy the merged words of the first batch, exactly as the pipeline does
+  // once that batch has been written. The held-back word must survive this,
+  // because the second batch owns its own copy of it.
+  batches[0] = WordBatch{};
+
+  // The word was externalized, although its first occurrence (which arrived
+  // before the batch boundary) was not marked as external.
+  EXPECT_THAT(wordsOf(batches[1]),
+              ::testing::ElementsAre(Pair("\"zzz\"", true)));
+  // Both occurrences are in the second batch and refer to its only word.
+  EXPECT_THAT(
+      mappingsOf(batches[1]),
+      ::testing::ElementsAre(Mapping{0, 0, wordBatchSize}, Mapping{1, 0, 0}));
+}
+
+// _____________________________________________________________________________
+// Add enough distinct words for several batches and check the invariants that
+// the pipeline relies on: every mapping of a batch refers to a word of that
+// batch, the words of the batches concatenate to the input, and every
+// occurrence yields exactly one mapping.
+TEST(WordBatchBuilder, severalBatches) {
+  static constexpr size_t numWords = 5 * wordBatchSize / 2;
+  std::vector<WordBatch> batches;
+  auto collect = [&batches](WordBatch batch) {
+    batches.push_back(std::move(batch));
+  };
+  WordBatchBuilder builder;
+
+  // Hand the words to the builder in small buffers, as the merging does.
+  std::vector<QueueWord> buffer;
+  for (size_t i = 0; i < numWords; ++i) {
+    buffer.push_back(makeQueueWord(fillWord(i), false, 0, i));
+    if (buffer.size() == 100) {
+      builder.addMergedWords(std::move(buffer), lessThan, collect);
+      buffer.clear();
+    }
+  }
+  builder.addMergedWords(std::move(buffer), lessThan, collect);
+  builder.finish(collect);
+  EXPECT_GE(batches.size(), 3u);
+
+  size_t numWordsSeen = 0;
+  size_t numMappingsSeen = 0;
+  for (const auto& batch : batches) {
+    for (const auto& mapping : mappingsOf(batch)) {
+      // The mapping refers to a word of its own batch, and to the word with
+      // the matching local index.
+      ASSERT_LT(mapping[1], batch.uniqueWords_.size());
+      EXPECT_EQ(batch.uniqueWords_[mapping[1]].word_, fillWord(mapping[2]));
+      ++numMappingsSeen;
+    }
+    for (const auto& uniqueWord : batch.uniqueWords_) {
+      EXPECT_EQ(uniqueWord.word_, fillWord(numWordsSeen));
+      ++numWordsSeen;
+    }
+  }
+  EXPECT_EQ(numWordsSeen, numWords);
+  EXPECT_EQ(numMappingsSeen, numWords);
+}
+
+// _____________________________________________________________________________
+// Words that are not in the order of the comparator are detected (but only if
+// the expensive checks are enabled).
+TEST(WordBatchBuilder, violatedOrderIsDetected) {
+  if constexpr (!ad_utility::areExpensiveChecksEnabled) {
+    GTEST_SKIP();
+  }
+  std::vector<WordBatch> batches;
+  auto collect = [&batches](WordBatch batch) {
+    batches.push_back(std::move(batch));
+  };
+  WordBatchBuilder builder;
+  AD_EXPECT_THROW_WITH_MESSAGE_AND_TYPE(
+      builder.addMergedWords({makeQueueWord("\"b\"", false, 0, 0),
+                              makeQueueWord("\"a\"", false, 0, 1)},
+                             lessThan, collect),
+      ::testing::HasSubstr("vocabulary order violated"), ad_utility::Exception);
+}


### PR DESCRIPTION
This change is the second of several that restructure the vocabulary merge of the index build so that it can use more threads (the first one was #3352). So far, `VocabularyMerger::writeQueueWordsToIdMap` did all the work for one buffer of merged words on the merging thread: eliminate the duplicates, write each distinct word to the vocabulary, and write one entry per merged word to the partial ID maps. This change splits that work into two stages on two threads, so that the writing of one batch overlaps with the merging of the next one:

- The new `detail::WordBatchBuilder` runs on the thread that calls `mergeVocabulary`. It eliminates the duplicates and collects the distinct words together with one index mapping per merged word into a `detail::WordBatch`
- The new `VocabularyMerger::writeWordBatch` runs on the single worker thread of a new `wordBatchQueue_`. It writes the distinct words of a batch to the vocabulary, which determines their global IDs, and then writes the index mappings of that batch to the partial ID maps

The `WordBatchBuilder` holds the last distinct word back until a different word arrives. A word may occur in several partial vocabularies with different `isExternal` flags, and the merged word has to get their logical OR, which is only possible as long as the word has not been handed on to the writing thread. The old code relied on the sort order for this instead (`isLessInTotalWithExternalFlag` put the external occurrence first), so the `WordComparator` now only has to compare the words, which simplifies all of its call sites.

NOTE: The `IdMap` files only exist during the index build, so the on-disk format of an index does not change.