### PR TITLE
Make the graph search cancellation test respect `_NO_TIMING_TESTS`

### DIFF
--- a/test/BenchmarkMeasurementContainerTest.cpp
+++ b/test/BenchmarkMeasurementContainerTest.cpp
@@ -31,7 +31,7 @@ static auto createWaitLambda(std::chrono::milliseconds waitDuration) {
 }
 
 TEST(BenchmarkMeasurementContainerTest, ResultEntry) {
-  QLEVER_SKIP_IF_NO_TIMING_TEST;
+  QLEVER_SKIP_TEST_IF_FLAKY_TIMING;
 
   // There's really no special cases.
   const std::string entryDescriptor{"entry"};
@@ -58,7 +58,7 @@ TEST(BenchmarkMeasurementContainerTest, ResultEntry) {
 }
 
 TEST(BenchmarkMeasurementContainerTest, ResultGroup) {
-  QLEVER_SKIP_IF_NO_TIMING_TEST;
+  QLEVER_SKIP_TEST_IF_FLAKY_TIMING;
   // The function should just wait 0.01 seconds.
   constexpr auto waitTime = 10ms;
   // There's really no special cases.
@@ -131,7 +131,7 @@ static void checkResultTableRow(const ResultTable& table,
 }
 
 TEST(BenchmarkMeasurementContainerTest, ResultTable) {
-  QLEVER_SKIP_IF_NO_TIMING_TEST;
+  QLEVER_SKIP_TEST_IF_FLAKY_TIMING;
   // Looks, if the general form is correct.
   auto checkForm = [](const ResultTable& table, const std::string& name,
                       const std::string& descriptorForLog,

--- a/test/BenchmarkMeasurementContainerTest.cpp
+++ b/test/BenchmarkMeasurementContainerTest.cpp
@@ -31,9 +31,7 @@ static auto createWaitLambda(std::chrono::milliseconds waitDuration) {
 }
 
 TEST(BenchmarkMeasurementContainerTest, ResultEntry) {
-#ifdef _QLEVER_NO_TIMING_TESTS
-  GTEST_SKIP_("because _QLEVER_NO_TIMING_TESTS defined");
-#endif
+  QLEVER_SKIP_IF_NO_TIMING_TEST;
 
   // There's really no special cases.
   const std::string entryDescriptor{"entry"};
@@ -60,9 +58,7 @@ TEST(BenchmarkMeasurementContainerTest, ResultEntry) {
 }
 
 TEST(BenchmarkMeasurementContainerTest, ResultGroup) {
-#ifdef _QLEVER_NO_TIMING_TESTS
-  GTEST_SKIP_("because _QLEVER_NO_TIMING_TESTS defined");
-#endif
+  QLEVER_SKIP_IF_NO_TIMING_TEST;
   // The function should just wait 0.01 seconds.
   constexpr auto waitTime = 10ms;
   // There's really no special cases.
@@ -135,9 +131,7 @@ static void checkResultTableRow(const ResultTable& table,
 }
 
 TEST(BenchmarkMeasurementContainerTest, ResultTable) {
-#ifdef _QLEVER_NO_TIMING_TESTS
-  GTEST_SKIP_("because _QLEVER_NO_TIMING_TESTS defined");
-#endif
+  QLEVER_SKIP_IF_NO_TIMING_TEST;
   // Looks, if the general form is correct.
   auto checkForm = [](const ResultTable& table, const std::string& name,
                       const std::string& descriptorForLog,

--- a/test/CancellationHandleTest.cpp
+++ b/test/CancellationHandleTest.cpp
@@ -171,7 +171,7 @@ TEST(CancellationHandle, ensureObjectLifetimeIsValidWithoutWatchDogStarted) {
 namespace ad_utility {
 
 TEST(CancellationHandle, verifyWatchDogDoesChangeState) {
-  QLEVER_SKIP_IF_NO_TIMING_TEST;
+  QLEVER_SKIP_TEST_IF_FLAKY_TIMING;
   CancellationHandle<ENABLED> handle;
 
   EXPECT_EQ(handle.cancellationState_, NOT_CANCELLED);
@@ -188,7 +188,7 @@ TEST(CancellationHandle, verifyWatchDogDoesChangeState) {
 // _____________________________________________________________________________
 
 TEST(CancellationHandle, verifyWatchDogDoesNotChangeStateAfterCancel) {
-  QLEVER_SKIP_IF_NO_TIMING_TEST;
+  QLEVER_SKIP_TEST_IF_FLAKY_TIMING;
   CancellationHandle<ENABLED> handle;
   handle.startWatchDog();
 

--- a/test/CancellationHandleTest.cpp
+++ b/test/CancellationHandleTest.cpp
@@ -171,9 +171,7 @@ TEST(CancellationHandle, ensureObjectLifetimeIsValidWithoutWatchDogStarted) {
 namespace ad_utility {
 
 TEST(CancellationHandle, verifyWatchDogDoesChangeState) {
-#ifdef _QLEVER_NO_TIMING_TESTS
-  GTEST_SKIP_("because _QLEVER_NO_TIMING_TESTS defined");
-#endif
+  QLEVER_SKIP_IF_NO_TIMING_TEST;
   CancellationHandle<ENABLED> handle;
 
   EXPECT_EQ(handle.cancellationState_, NOT_CANCELLED);
@@ -190,9 +188,7 @@ TEST(CancellationHandle, verifyWatchDogDoesChangeState) {
 // _____________________________________________________________________________
 
 TEST(CancellationHandle, verifyWatchDogDoesNotChangeStateAfterCancel) {
-#ifdef _QLEVER_NO_TIMING_TESTS
-  GTEST_SKIP_("because _QLEVER_NO_TIMING_TESTS defined");
-#endif
+  QLEVER_SKIP_IF_NO_TIMING_TEST;
   CancellationHandle<ENABLED> handle;
   handle.startWatchDog();
 

--- a/test/OperationTest.cpp
+++ b/test/OperationTest.cpp
@@ -554,9 +554,7 @@ TEST(Operation, ensureFailedStatusIsSetWhenGeneratorIsCancelled) {
 
 // _____________________________________________________________________________
 TEST(Operation, ensureSignalUpdateIsOnlyCalledEvery50msAndAtTheEnd) {
-#ifdef _QLEVER_NO_TIMING_TESTS
-  GTEST_SKIP_("because _QLEVER_NO_TIMING_TESTS defined");
-#endif
+  QLEVER_SKIP_IF_NO_TIMING_TEST;
   uint32_t updateCallCounter = 0;
   auto idTable = makeIdTableFromVector({{}});
   auto index = std::make_shared<Index>(makeTestIndex(

--- a/test/OperationTest.cpp
+++ b/test/OperationTest.cpp
@@ -554,7 +554,7 @@ TEST(Operation, ensureFailedStatusIsSetWhenGeneratorIsCancelled) {
 
 // _____________________________________________________________________________
 TEST(Operation, ensureSignalUpdateIsOnlyCalledEvery50msAndAtTheEnd) {
-  QLEVER_SKIP_IF_NO_TIMING_TEST;
+  QLEVER_SKIP_TEST_IF_FLAKY_TIMING;
   uint32_t updateCallCounter = 0;
   auto idTable = makeIdTableFromVector({{}});
   auto index = std::make_shared<Index>(makeTestIndex(

--- a/test/RdfParserTest.cpp
+++ b/test/RdfParserTest.cpp
@@ -1251,9 +1251,7 @@ TEST(RdfParserTest, betterErrorMessageOnMultilineLiteralError) {
 // for a loaded CI runner (20ms were not, see the frequent spurious failures in
 // August 2026).
 TEST(RdfParserTest, stopParsingOnOutsideFailure) {
-#ifdef _QLEVER_NO_TIMING_TESTS
-  GTEST_SKIP_("because _QLEVER_NO_TIMING_TESTS defined");
-#endif
+  QLEVER_SKIP_IF_NO_TIMING_TEST;
   std::string filename{"turtleParserStopParsingOnOutsideFailure.dat"};
   auto testWithParser = [&](auto t, std::string_view input) {
     using Parser = typename decltype(t)::type;

--- a/test/RdfParserTest.cpp
+++ b/test/RdfParserTest.cpp
@@ -1251,7 +1251,7 @@ TEST(RdfParserTest, betterErrorMessageOnMultilineLiteralError) {
 // for a loaded CI runner (20ms were not, see the frequent spurious failures in
 // August 2026).
 TEST(RdfParserTest, stopParsingOnOutsideFailure) {
-  QLEVER_SKIP_IF_NO_TIMING_TEST;
+  QLEVER_SKIP_TEST_IF_FLAKY_TIMING;
   std::string filename{"turtleParserStopParsingOnOutsideFailure.dat"};
   auto testWithParser = [&](auto t, std::string_view input) {
     using Parser = typename decltype(t)::type;

--- a/test/TimerTest.cpp
+++ b/test/TimerTest.cpp
@@ -34,9 +34,7 @@ void testTime(const ad_utility::Timer& timer,
 }
 
 TEST(Timer, BasicWorkflow) {
-#ifdef _QLEVER_NO_TIMING_TESTS
-  GTEST_SKIP_("because _QLEVER_NO_TIMING_TESTS defined");
-#endif
+  QLEVER_SKIP_IF_NO_TIMING_TEST;
   Timer t{Timer::Started};
   ASSERT_TRUE(t.isRunning());
   std::this_thread::sleep_for(10ms);
@@ -87,9 +85,7 @@ TEST(Timer, BasicWorkflow) {
 }
 
 TEST(Timer, InitiallyStopped) {
-#ifdef _QLEVER_NO_TIMING_TESTS
-  GTEST_SKIP_("because _QLEVER_NO_TIMING_TESTS defined");
-#endif
+  QLEVER_SKIP_IF_NO_TIMING_TEST;
   Timer t{Timer::Stopped};
   ASSERT_FALSE(t.isRunning());
   ASSERT_EQ(t.value(), Timer::Duration::zero());
@@ -104,9 +100,7 @@ TEST(Timer, InitiallyStopped) {
 }
 
 TEST(TimeBlockAndLog, TimeBlockAndLog) {
-#ifdef _QLEVER_NO_TIMING_TESTS
-  GTEST_SKIP_("because _QLEVER_NO_TIMING_TESTS defined");
-#endif
+  QLEVER_SKIP_IF_NO_TIMING_TEST;
   std::string s;
   {
     auto callback = [&s](std::chrono::milliseconds msecs,
@@ -121,9 +115,7 @@ TEST(TimeBlockAndLog, TimeBlockAndLog) {
 
 // ____________________________________________________________________________
 TEST(Timer, ThreadSafeTimerSingleThreaded) {
-#ifdef _QLEVER_NO_TIMING_TESTS
-  GTEST_SKIP_("because _QLEVER_NO_TIMING_TESTS defined");
-#endif
+  QLEVER_SKIP_IF_NO_TIMING_TEST;
   ad_utility::timer::ThreadSafeTimer t;
   for (size_t i = 0; i < 10; ++i) {
     auto m = t.startMeasurement();
@@ -139,9 +131,7 @@ TEST(Timer, ThreadSafeTimerSingleThreaded) {
 
 // ____________________________________________________________________________
 TEST(Timer, ThreadSafeTimerMultiThreaded) {
-#ifdef _QLEVER_NO_TIMING_TESTS
-  GTEST_SKIP_("because _QLEVER_NO_TIMING_TESTS defined");
-#endif
+  QLEVER_SKIP_IF_NO_TIMING_TEST;
   ad_utility::timer::ThreadSafeTimer t;
 
   auto f = [&t]() {

--- a/test/TimerTest.cpp
+++ b/test/TimerTest.cpp
@@ -34,7 +34,7 @@ void testTime(const ad_utility::Timer& timer,
 }
 
 TEST(Timer, BasicWorkflow) {
-  QLEVER_SKIP_IF_NO_TIMING_TEST;
+  QLEVER_SKIP_TEST_IF_FLAKY_TIMING;
   Timer t{Timer::Started};
   ASSERT_TRUE(t.isRunning());
   std::this_thread::sleep_for(10ms);
@@ -85,7 +85,7 @@ TEST(Timer, BasicWorkflow) {
 }
 
 TEST(Timer, InitiallyStopped) {
-  QLEVER_SKIP_IF_NO_TIMING_TEST;
+  QLEVER_SKIP_TEST_IF_FLAKY_TIMING;
   Timer t{Timer::Stopped};
   ASSERT_FALSE(t.isRunning());
   ASSERT_EQ(t.value(), Timer::Duration::zero());
@@ -100,7 +100,7 @@ TEST(Timer, InitiallyStopped) {
 }
 
 TEST(TimeBlockAndLog, TimeBlockAndLog) {
-  QLEVER_SKIP_IF_NO_TIMING_TEST;
+  QLEVER_SKIP_TEST_IF_FLAKY_TIMING;
   std::string s;
   {
     auto callback = [&s](std::chrono::milliseconds msecs,
@@ -115,7 +115,7 @@ TEST(TimeBlockAndLog, TimeBlockAndLog) {
 
 // ____________________________________________________________________________
 TEST(Timer, ThreadSafeTimerSingleThreaded) {
-  QLEVER_SKIP_IF_NO_TIMING_TEST;
+  QLEVER_SKIP_TEST_IF_FLAKY_TIMING;
   ad_utility::timer::ThreadSafeTimer t;
   for (size_t i = 0; i < 10; ++i) {
     auto m = t.startMeasurement();
@@ -131,7 +131,7 @@ TEST(Timer, ThreadSafeTimerSingleThreaded) {
 
 // ____________________________________________________________________________
 TEST(Timer, ThreadSafeTimerMultiThreaded) {
-  QLEVER_SKIP_IF_NO_TIMING_TEST;
+  QLEVER_SKIP_TEST_IF_FLAKY_TIMING;
   ad_utility::timer::ThreadSafeTimer t;
 
   auto f = [&t]() {

--- a/test/TransitivePathGraphSearchTest.cpp
+++ b/test/TransitivePathGraphSearchTest.cpp
@@ -259,6 +259,9 @@ TYPED_TEST(GraphSearchTest, graphSearchWithTargetWithLimit) {
 
 // ___________________________________________________________________________
 TEST(GraphSearchTestExtraTests, cancellationCheck) {
+#ifdef _QLEVER_NO_TIMING_TESTS
+  GTEST_SKIP_("because _QLEVER_NO_TIMING_TESTS defined");
+#endif
   // Test that the log message created in
   // `GraphSearchExecutionParams.checkCancellation()` when a cancellation is
   // received will be logged.

--- a/test/TransitivePathGraphSearchTest.cpp
+++ b/test/TransitivePathGraphSearchTest.cpp
@@ -259,7 +259,7 @@ TYPED_TEST(GraphSearchTest, graphSearchWithTargetWithLimit) {
 
 // ___________________________________________________________________________
 TEST(GraphSearchTestExtraTests, cancellationCheck) {
-  QLEVER_SKIP_IF_NO_TIMING_TEST;
+  QLEVER_SKIP_TEST_IF_FLAKY_TIMING;
   // Test that the log message created in
   // `GraphSearchExecutionParams.checkCancellation()` when a cancellation is
   // received will be logged.

--- a/test/TransitivePathGraphSearchTest.cpp
+++ b/test/TransitivePathGraphSearchTest.cpp
@@ -259,9 +259,7 @@ TYPED_TEST(GraphSearchTest, graphSearchWithTargetWithLimit) {
 
 // ___________________________________________________________________________
 TEST(GraphSearchTestExtraTests, cancellationCheck) {
-#ifdef _QLEVER_NO_TIMING_TESTS
-  GTEST_SKIP_("because _QLEVER_NO_TIMING_TESTS defined");
-#endif
+  QLEVER_SKIP_IF_NO_TIMING_TEST;
   // Test that the log message created in
   // `GraphSearchExecutionParams.checkCancellation()` when a cancellation is
   // received will be logged.

--- a/test/util/GTestHelpers.h
+++ b/test/util/GTestHelpers.h
@@ -124,6 +124,18 @@ https://github.com/google/googletest/blob/main/docs/reference/matchers.md#matche
   ad_utility::ScopedLogLevel AD_SCOPED_LOG_LEVEL_NAME(__COUNTER__) { level }
 
 // _____________________________________________________________________________
+// Skip the enclosing test if the `_NO_TIMING_TESTS` CMake option is set. Use
+// this in tests that depend on the actual duration of `sleep` or on similar
+// timings, which are unreliable on some platforms (in particular macOS). Note
+// that the macro has to be used as a statement (with a trailing semicolon).
+#ifdef _QLEVER_NO_TIMING_TESTS
+#define QLEVER_SKIP_IF_NO_TIMING_TEST \
+  GTEST_SKIP() << "because `_QLEVER_NO_TIMING_TESTS` is defined"
+#else
+#define QLEVER_SKIP_IF_NO_TIMING_TEST static_assert(true)
+#endif
+
+// _____________________________________________________________________________
 // Redirect the global logging stream to `stream` and return an `absl::Cleanup`
 // that restores the *previously active* stream when it goes out of scope. Use
 // this in tests that temporarily capture or suppress log output, so the global

--- a/test/util/GTestHelpers.h
+++ b/test/util/GTestHelpers.h
@@ -129,10 +129,10 @@ https://github.com/google/googletest/blob/main/docs/reference/matchers.md#matche
 // timings, which are unreliable on some platforms (in particular macOS). Note
 // that the macro has to be used as a statement (with a trailing semicolon).
 #ifdef _QLEVER_NO_TIMING_TESTS
-#define QLEVER_SKIP_IF_NO_TIMING_TEST \
+#define QLEVER_SKIP_TEST_IF_FLAKY_TIMING \
   GTEST_SKIP() << "because `_QLEVER_NO_TIMING_TESTS` is defined"
 #else
-#define QLEVER_SKIP_IF_NO_TIMING_TEST static_assert(true)
+#define QLEVER_SKIP_TEST_IF_FLAKY_TIMING static_assert(true)
 #endif
 
 // _____________________________________________________________________________


### PR DESCRIPTION
The test `GraphSearchTestExtraTests.cancellationCheck` sleeps for two watchdog intervals and then expects the cancellation handle's watchdog thread to have logged a message. On the macOS CI runners the watchdog thread is sometimes not scheduled in time, so the test fails spuriously. All other tests that depend on `sleep` or thread timing are already skipped when the `_NO_TIMING_TESTS` CMake option is set (which the macOS jobs do), so this test now does the same.

The skip is now expressed by a new macro `QLEVER_SKIP_TEST_IF_FLAKY_TIMING` in `GTestHelpers.h`, which replaces the hand-written `#ifdef _QLEVER_NO_TIMING_TESTS` blocks at the start of the twelve existing timing tests.