### PR TITLE
Allocate the `shared_ptr`s of the query engine via the memory-limited allocator

### DIFF
--- a/src/engine/CartesianProductJoin.cpp
+++ b/src/engine/CartesianProductJoin.cpp
@@ -388,9 +388,9 @@ Result::LazyResult CartesianProductJoin::createLazyConsumer(
   // kept as a non-const `shared_ptr` so it can be updated in-place on each
   // iteration without a new allocation; the implicit conversion to
   // `shared_ptr<const IdTableView<0>>` makes it compatible with `idTables`.
-  auto placeholder = std::make_shared<IdTable>(0, allocator());
+  auto placeholder = makeShared<IdTable>(0, allocator());
   auto placeholderView =
-      std::make_shared<IdTableView<0>>(placeholder->asStaticView<0>());
+      makeShared<IdTableView<0>>(placeholder->asStaticView<0>());
   idTables.push_back(placeholderView);
 
   auto generatedTables = lazyResult->idTables();

--- a/src/engine/ConstructTripleGenerator.cpp
+++ b/src/engine/ConstructTripleGenerator.cpp
@@ -113,14 +113,15 @@ InputRangeTypeErased<EvaluatedTriple> ConstructTripleGenerator::evaluateTables(
       templateTriples, variableColumns, config.index_);
   IdCache cache = makeIdCache(preprocessedTemplate);
 
+  const QueryExecutionContext& qec = config.qec_;
   std::shared_ptr<ConstructDeduplicator> deduplicator;
   if (!std::holds_alternative<DeduplicationMode::None>(config.mode_.value_)) {
     deduplicator =
-        std::make_shared<ConstructDeduplicator>(config.mode_, config.qec_);
+        qec.makeShared<ConstructDeduplicator>(config.mode_, config.qec_);
   }
 
   auto preprocessedTemplatePtr =
-      std::make_shared<const PreprocessedConstructTemplate>(
+      qec.makeShared<const PreprocessedConstructTemplate>(
           std::move(preprocessedTemplate));
 
   auto processTable =

--- a/src/engine/Describe.cpp
+++ b/src/engine/Describe.cpp
@@ -163,7 +163,7 @@ IdTable Describe::makeAndExecuteJoinWithFullIndex(
   using V = Variable;
   auto subjectVar = V{"?subject"};
   auto valuesOp = ad_utility::makeExecutionTree<ExplicitIdTableOperation>(
-      getExecutionContext(), std::make_shared<IdTable>(std::move(input)),
+      getExecutionContext(), makeShared<IdTable>(std::move(input)),
       VariableToColumnMap{
           {subjectVar,
            ColumnIndexAndTypeInfo{0, ColumnIndexAndTypeInfo::AlwaysDefined}}},

--- a/src/engine/ExistsJoin.cpp
+++ b/src/engine/ExistsJoin.cpp
@@ -274,8 +274,7 @@ std::shared_ptr<QueryExecutionTree> ExistsJoin::addExistsJoinsToSubtree(
                          const VariableOrderKey& key) {
                        return columns.at(key.variable_).columnIndex_;
                      });
-    auto tree =
-        std::make_shared<QueryExecutionTree>(qp.createExecutionTree(pq));
+    auto tree = qec->makeShared<QueryExecutionTree>(qp.createExecutionTree(pq));
     // Hide non-visible variables in the subtree, so that they are not
     // accidentally joined, ideally collisions wouldn't happen in the first
     // place, but since we're creating our own instance of `QueryPlanner` we

--- a/src/engine/IndexScan.cpp
+++ b/src/engine/IndexScan.cpp
@@ -880,9 +880,9 @@ Result::LazyResult IndexScan::createPrefilteredIndexScanSide(
        metadata = LazyScanMetadata{}]() mutable {
         // Handle UNDEF case using LoopControl pattern
         if (state->hasUndef()) {
-          auto scan = std::make_shared<
-              CompressedRelationReader::IdTableGeneratorInputRange>(
-              getLazyScan());
+          auto scan =
+              makeShared<CompressedRelationReader::IdTableGeneratorInputRange>(
+                  getLazyScan());
           scan->details().numBlocksAll_ =
               getMetadataForScan().value().sizeBlockMetadata_;
           updateRuntimeInfoForLazyScan(scan->details(), Always);
@@ -945,7 +945,7 @@ std::pair<Result::LazyResult, Result::LazyResult> IndexScan::prefilterTables(
             Result::LazyResult{}};
   }
 
-  auto state = std::make_shared<SharedGeneratorState>(
+  auto state = makeShared<SharedGeneratorState>(
       SharedGeneratorState{std::move(input), joinColumn,
                            std::move(metaBlocks.value()), filterJoinSide});
   return {createPrefilteredJoinSide(state),

--- a/src/engine/JoinHelpers.h
+++ b/src/engine/JoinHelpers.h
@@ -84,7 +84,7 @@ IteratorWithSingleCol<numJoinColumns> convertGeneratorFromScan(
     CompressedRelationReader::IdTableGeneratorInputRange gen, IndexScan& scan) {
   // Store the generator in a wrapper so we can access its details after moving
   auto generatorStorage =
-      std::make_shared<CompressedRelationReader::IdTableGeneratorInputRange>(
+      scan.makeShared<CompressedRelationReader::IdTableGeneratorInputRange>(
           std::move(gen));
 
   using SendPriority = RuntimeInformation::SendPriority;

--- a/src/engine/MaterializedViews.cpp
+++ b/src/engine/MaterializedViews.cpp
@@ -821,7 +821,7 @@ std::shared_ptr<IndexScan> MaterializedView::makeIndexScan(
   // no join occurs if multiple materialized views are requested in a single
   // query.
   auto scanTriple = makeScanConfig(viewQuery);
-  return std::make_shared<IndexScan>(
+  return qec->makeShared<IndexScan>(
       qec, permutation_, LocatedTriplesSharedState{locatedTriplesState_},
       std::move(scanTriple), IndexScan::Graphs::All(), std::nullopt,
       viewQuery.getVarsToKeep());
@@ -858,7 +858,7 @@ std::shared_ptr<IndexScan> MaterializedView::makeIndexScan(
                                 std::move(additionalCols)};
   auto v = varToCol | ql::ranges::views::keys;
   ad_utility::HashSet<Variable> varsToKeep{v.begin(), v.end()};
-  return std::make_shared<IndexScan>(
+  return qec->makeShared<IndexScan>(
       qec, permutation_, LocatedTriplesSharedState{locatedTriplesState_},
       std::move(scanTriple), IndexScan::Graphs::All(), std::nullopt,
       std::move(varsToKeep));

--- a/src/engine/NamedResultCache.cpp
+++ b/src/engine/NamedResultCache.cpp
@@ -17,7 +17,7 @@ std::shared_ptr<ExplicitIdTableOperation> NamedResultCache::getOperation(
   const auto& result = get(name);
   const auto& [table, map, sortedOn, localVocab, cacheKey, geoIndex, allocator,
                blankNodeManager] = *result;
-  auto resultAsOperation = std::make_shared<ExplicitIdTableOperation>(
+  auto resultAsOperation = qec->makeShared<ExplicitIdTableOperation>(
       qec, table, map, sortedOn, localVocab.clone(), cacheKey);
   return resultAsOperation;
 }

--- a/src/engine/Operation.cpp
+++ b/src/engine/Operation.cpp
@@ -317,7 +317,7 @@ std::shared_ptr<const Result> Operation::getResult(
 
   if (isRoot) {
     // Reset runtime info, tests may reuse Operation objects.
-    _runtimeInfo = std::make_shared<RuntimeInformation>();
+    _runtimeInfo = makeShared<RuntimeInformation>();
     // Start with an estimated runtime info which will be updated as we go.
     createRuntimeInfoFromEstimates(getRuntimeInfoPointer());
     signalQueryUpdate(RuntimeInformation::SendPriority::Always);
@@ -360,7 +360,7 @@ std::shared_ptr<const Result> Operation::getResult(
       if (computationMode == ComputationMode::ONLY_IF_CACHED) {
         return nullptr;
       }
-      return std::make_shared<Result>(runComputation(timer, computationMode));
+      return makeShared<Result>(runComputation(timer, computationMode));
     }
 
     auto cacheSetup = [this, &timer, computationMode, &cacheKey, pinResult,

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -22,6 +22,7 @@
 #include "util/CancellationHandle.h"
 #include "util/CompilerExtensions.h"
 #include "util/CopyableSynchronization.h"
+#include "util/Exception.h"
 #include "util/TypeTraits.h"
 
 // forward declaration needed to break dependencies
@@ -73,6 +74,15 @@ class Operation {
       std::chrono::steady_clock::time_point::max();
 
  private:
+  // Return the given `executionContext`, or throw if it is `nullptr` (see the
+  // constructor below).
+  static QueryExecutionContext* checkNotNull(
+      QueryExecutionContext* executionContext) {
+    AD_CONTRACT_CHECK(executionContext != nullptr,
+                      "An `Operation` requires a `QueryExecutionContext`");
+    return executionContext;
+  }
+
   // Holds a precomputed Result of this operation if it is the sibling of a
   // Service operation.
   std::optional<std::shared_ptr<const Result>>
@@ -136,10 +146,11 @@ class Operation {
   // Holds a `PrefilterExpression` with its corresponding `Variable`.
   using PrefilterVariablePair = sparqlExpression::PrefilterExprVariablePair;
 
-  // Constructor. Note that `executionContext` must not be `nullptr`, as it is
-  // required by the default member initializers of the members above.
+  // Constructor. The `executionContext` must not be `nullptr`, as it is
+  // required by the default member initializers of the members above, so it
+  // is checked before those are initialized.
   explicit Operation(QueryExecutionContext* executionContext)
-      : _executionContext(executionContext) {}
+      : _executionContext(checkNotNull(executionContext)) {}
 
   // Destructor.
   virtual ~Operation() {

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -18,6 +18,7 @@
 #include "engine/sparqlExpressions/SparqlExpressionPimpl.h"
 #include "parser/data/LimitOffsetClause.h"
 #include "rdfTypes/Variable.h"
+#include "util/AllocateShared.h"
 #include "util/CancellationHandle.h"
 #include "util/CompilerExtensions.h"
 #include "util/CopyableSynchronization.h"
@@ -56,13 +57,29 @@ class Operation {
   using SharedCancellationHandle = ad_utility::SharedCancellationHandle;
   using Milliseconds = std::chrono::milliseconds;
 
+ protected:
+  // The `QueryExecutionContext` for this particular element. No ownership.
+  //
+  // NOTE: This has to be the first data member of this class, because the
+  // default member initializers of the members below use it (via
+  // `makeShared`), and data members are initialized in declaration order.
+  QueryExecutionContext* _executionContext;
+
+  // Pointer to the cancellation handle of this operation.
+  SharedCancellationHandle cancellationHandle_ =
+      makeShared<SharedCancellationHandle::element_type>();
+
+  std::chrono::steady_clock::time_point deadline_ =
+      std::chrono::steady_clock::time_point::max();
+
+ private:
   // Holds a precomputed Result of this operation if it is the sibling of a
   // Service operation.
   std::optional<std::shared_ptr<const Result>>
       precomputedResultBecauseSiblingOfService_;
 
   std::shared_ptr<RuntimeInformation> _runtimeInfo =
-      std::make_shared<RuntimeInformation>();
+      makeShared<RuntimeInformation>();
 
   // Pointer to the `RuntimeInformation` tree; used in `signalQueryUpdate()`,
   // and reset in `createRuntimeInfoFromEstimates()`.
@@ -119,7 +136,8 @@ class Operation {
   // Holds a `PrefilterExpression` with its corresponding `Variable`.
   using PrefilterVariablePair = sparqlExpression::PrefilterExprVariablePair;
 
-  // Constructor.
+  // Constructor. Note that `executionContext` must not be `nullptr`, as it is
+  // required by the default member initializers of the members above.
   explicit Operation(QueryExecutionContext* executionContext)
       : _executionContext(executionContext) {}
 
@@ -383,6 +401,10 @@ class Operation {
     return getExecutionContext()->getAllocator();
   }
 
+  // Create a `shared_ptr` whose object is allocated using the memory limited
+  // allocator of this query (see `util/AllocateShared.h`).
+  DEFINE_MAKE_SHARED_MEMBER(allocator())
+
   // If the result of this `Operation` is sorted (either because this
   // `Operation` enforces this sorting, or because it preserves the sorting of
   // its children), return the variable that is the primary sort key. Else
@@ -491,10 +513,6 @@ class Operation {
   }
 
  protected:
-  // The QueryExecutionContext for this particular element.
-  // No ownership.
-  QueryExecutionContext* _executionContext;
-
   /**
    * @brief Compute and return the columns on which the result will be sorted
    * @return The columns on which the result will be sorted.
@@ -515,13 +533,6 @@ class Operation {
   }
 
   std::chrono::milliseconds remainingTime() const;
-
-  /// Pointer to the cancellation handle of this operation.
-  SharedCancellationHandle cancellationHandle_ =
-      std::make_shared<SharedCancellationHandle::element_type>();
-
-  std::chrono::steady_clock::time_point deadline_ =
-      std::chrono::steady_clock::time_point::max();
 
   // Get the mapping from variables to column indices. This mapping may only be
   // used internally, because the actually visible variables might be different

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -401,8 +401,9 @@ class Operation {
     return getExecutionContext()->getAllocator();
   }
 
-  // Create a `shared_ptr` whose object is allocated using the memory limited
-  // allocator of this query (see `util/AllocateShared.h`).
+  // define a `makeShared` member function that has the same interface as
+  // `std::make_shared`, but allocates via the `allocator()` (see
+  // `util/AllocateShared.h`).
   DEFINE_MAKE_SHARED_MEMBER(allocator())
 
   // If the result of this `Operation` is sorted (either because this

--- a/src/engine/QueryExecutionContext.h
+++ b/src/engine/QueryExecutionContext.h
@@ -160,8 +160,9 @@ class QueryExecutionContext
     return _allocator;
   }
 
-  // Create a `shared_ptr` whose object is allocated using the memory limited
-  // allocator of this query (see `util/AllocateShared.h`).
+  // define a `makeShared` member function that has the same interface as
+  // `std::make_shared`, but allocates via the `getAllocator()` (see
+  // `util/AllocateShared.h`).
   DEFINE_MAKE_SHARED_MEMBER(getAllocator())
 
   // Serialize the given `runtimeInformation` to a JSON string and send it

--- a/src/engine/QueryExecutionContext.h
+++ b/src/engine/QueryExecutionContext.h
@@ -20,6 +20,7 @@
 #include "global/Id.h"
 #include "index/DeltaTriples.h"
 #include "index/Index.h"
+#include "util/AllocateShared.h"
 #include "util/Cache.h"
 #include "util/ConcurrentCache.h"
 
@@ -158,6 +159,10 @@ class QueryExecutionContext
   const ad_utility::AllocatorWithLimit<Id>& getAllocator() const {
     return _allocator;
   }
+
+  // Create a `shared_ptr` whose object is allocated using the memory limited
+  // allocator of this query (see `util/AllocateShared.h`).
+  DEFINE_MAKE_SHARED_MEMBER(getAllocator())
 
   // Serialize the given `runtimeInformation` to a JSON string and send it
   // using `updateCallback_`. If `sendPriority` is set to `IfDue`, this only

--- a/src/engine/QueryExecutionTree.cpp
+++ b/src/engine/QueryExecutionTree.cpp
@@ -27,7 +27,11 @@ using parsedQuery::SelectClause;
 
 // _____________________________________________________________________________
 QueryExecutionTree::QueryExecutionTree(QueryExecutionContext* const qec)
-    : qec_(qec) {}
+    : qec_(qec) {
+  // A `QueryExecutionTree` always needs a `QueryExecutionContext`, if only to
+  // obtain the memory limited allocator of the query.
+  AD_CONTRACT_CHECK(qec_ != nullptr);
+}
 
 // _____________________________________________________________________________
 std::string QueryExecutionTree::getCacheKey() const {

--- a/src/engine/QueryExecutionTree.h
+++ b/src/engine/QueryExecutionTree.h
@@ -341,9 +341,7 @@ class QueryExecutionTree {
   DEFINE_MAKE_SHARED_MEMBER(qec_->getAllocator())
 
   std::shared_ptr<QueryExecutionTree> clone() const {
-    return rootOperation_
-               ? makeShared<QueryExecutionTree>(qec_, rootOperation_->clone())
-               : makeShared<QueryExecutionTree>(qec_);
+    return makeShared<QueryExecutionTree>(qec_, rootOperation_->clone());
   }
 };
 

--- a/src/engine/QueryExecutionTree.h
+++ b/src/engine/QueryExecutionTree.h
@@ -341,7 +341,10 @@ class QueryExecutionTree {
   DEFINE_MAKE_SHARED_MEMBER(qec_->getAllocator())
 
   std::shared_ptr<QueryExecutionTree> clone() const {
-    return makeShared<QueryExecutionTree>(qec_, rootOperation_->clone());
+    // A tree without a root operation is cloned to another such tree.
+    return rootOperation_
+               ? makeShared<QueryExecutionTree>(qec_, rootOperation_->clone())
+               : makeShared<QueryExecutionTree>(qec_);
   }
 };
 

--- a/src/engine/QueryExecutionTree.h
+++ b/src/engine/QueryExecutionTree.h
@@ -15,6 +15,7 @@
 #include "engine/QueryExecutionContext.h"
 #include "parser/ParsedQuery.h"
 #include "parser/data/Types.h"
+#include "util/AllocateShared.h"
 #include "util/HashSet.h"
 
 // Strongly typed enum for controlling whether stripped variables are explicitly
@@ -334,10 +335,14 @@ class QueryExecutionTree {
     }
   };
 
+  // Create a `shared_ptr` whose object is allocated using the memory limited
+  // allocator of this query (see `util/AllocateShared.h`).
+  DEFINE_MAKE_SHARED_MEMBER(qec_->getAllocator())
+
   std::shared_ptr<QueryExecutionTree> clone() const {
-    return rootOperation_ ? std::make_shared<QueryExecutionTree>(
-                                qec_, rootOperation_->clone())
-                          : std::make_shared<QueryExecutionTree>(qec_);
+    return rootOperation_
+               ? makeShared<QueryExecutionTree>(qec_, rootOperation_->clone())
+               : makeShared<QueryExecutionTree>(qec_);
   }
 };
 
@@ -345,11 +350,14 @@ namespace ad_utility {
 // Create a `QueryExecutionTree` with `Operation` at the root.
 // The `Operation` is created using `qec` and `args...` as constructor
 // arguments.
+//
+// NOTE: Both the tree and the operation are allocated with the memory limited
+// allocator of the query, such that they count towards its memory limit.
 template <typename Operation, typename... Args>
 std::shared_ptr<QueryExecutionTree> makeExecutionTree(
     QueryExecutionContext* qec, Args&&... args) {
-  return std::make_shared<QueryExecutionTree>(
-      qec, std::make_shared<Operation>(qec, AD_FWD(args)...));
+  return qec->makeShared<QueryExecutionTree>(
+      qec, qec->makeShared<Operation>(qec, AD_FWD(args)...));
 }
 }  // namespace ad_utility
 

--- a/src/engine/QueryExecutionTree.h
+++ b/src/engine/QueryExecutionTree.h
@@ -335,8 +335,9 @@ class QueryExecutionTree {
     }
   };
 
-  // Create a `shared_ptr` whose object is allocated using the memory limited
-  // allocator of this query (see `util/AllocateShared.h`).
+  // define a `makeShared` member function that has the same interface as
+  // `std::make_shared`, but allocates via the `qec_->getAllocator()` (see
+  // `util/AllocateShared.h`).
   DEFINE_MAKE_SHARED_MEMBER(qec_->getAllocator())
 
   std::shared_ptr<QueryExecutionTree> clone() const {

--- a/src/engine/QueryRewriteUtils.cpp
+++ b/src/engine/QueryRewriteUtils.cpp
@@ -102,7 +102,7 @@ std::shared_ptr<SpatialJoin> rewriteFilterToSpatialJoin(
 
   auto left = resolveGeoOperand(call.left_, qec, generateUniqueVarName);
   auto right = resolveGeoOperand(call.right_, qec, generateUniqueVarName);
-  return std::make_shared<SpatialJoin>(
+  return qec->makeShared<SpatialJoin>(
       qec,
       SpatialJoinConfiguration{
           std::move(config), std::move(left.variable_),

--- a/src/engine/Service.cpp
+++ b/src/engine/Service.cpp
@@ -680,7 +680,7 @@ void Service::precomputeSiblingResult(std::shared_ptr<Operation> left,
           moveToCachingInputRange(std::move(resultPairs)));
       viewCollection.emplace_back(std::move(generator));
       sibling->precomputedResultBecauseSiblingOfService() =
-          std::make_shared<const Result>(
+          sibling->makeShared<const Result>(
               Result::LazyResult{
                   ad_utility::OwningViewNoConst{std::move(viewCollection)} |
                   ql::views::join},
@@ -693,9 +693,7 @@ void Service::precomputeSiblingResult(std::shared_ptr<Operation> left,
   // The `siblingResult` has been fully materialized, so it can now be
   // used in both sibling and service.
   Result::IdTableVocabPair siblingPair(
-      IdTable{sibling->getResultWidth(),
-              sibling->getExecutionContext()->getAllocator()},
-      LocalVocab{});
+      IdTable{sibling->getResultWidth(), sibling->allocator()}, LocalVocab{});
   siblingPair.idTable_.reserve(rows);
 
   for (auto& pair : resultPairs) {
@@ -704,8 +702,8 @@ void Service::precomputeSiblingResult(std::shared_ptr<Operation> left,
   }
 
   service->siblingInfo_.emplace(
-      std::make_shared<Result>(std::move(siblingPair),
-                               siblingResult->sortedBy()),
+      service->makeShared<Result>(std::move(siblingPair),
+                                  siblingResult->sortedBy()),
       sibling->getExternallyVisibleVariableColumns(), sibling->getCacheKey());
 
   sibling->precomputedResultBecauseSiblingOfService() =

--- a/src/engine/SpatialJoin.cpp
+++ b/src/engine/SpatialJoin.cpp
@@ -71,7 +71,7 @@ SpatialJoin::SpatialJoin(
     AD_CORRECTNESS_CHECK(config_.rightCacheName_.has_value());
 
     auto key = config_.rightCacheName_.value();
-    childRight_ = std::make_shared<QueryExecutionTree>(
+    childRight_ = qec->makeShared<QueryExecutionTree>(
         qec, qec->namedResultCache().getOperation(key, qec));
 
     // Early check that the query was pinned together with a geometry index
@@ -104,13 +104,12 @@ std::shared_ptr<SpatialJoin> SpatialJoin::addChild(
     const Variable& varOfChild) const {
   std::shared_ptr<SpatialJoin> sj;
   if (varOfChild == config_.left_) {
-    sj = std::make_shared<SpatialJoin>(getExecutionContext(), config_,
-                                       std::move(child), childRight_,
-                                       substitutesFilterOp_);
+    sj = makeShared<SpatialJoin>(getExecutionContext(), config_,
+                                 std::move(child), childRight_,
+                                 substitutesFilterOp_);
   } else if (varOfChild == config_.right_) {
-    sj = std::make_shared<SpatialJoin>(getExecutionContext(), config_,
-                                       childLeft_, std::move(child),
-                                       substitutesFilterOp_);
+    sj = makeShared<SpatialJoin>(getExecutionContext(), config_, childLeft_,
+                                 std::move(child), substitutesFilterOp_);
   } else {
     AD_THROW("variable does not match");
   }
@@ -741,7 +740,7 @@ SpatialJoin::cloneWithBoundingBoxColumns() const {
   if (!left.has_value() && !right.has_value()) {
     return std::nullopt;
   }
-  return std::make_shared<SpatialJoin>(
+  return makeShared<SpatialJoin>(
       _executionContext, config_,
       // Potentially unchanged child retrieved with `value_or`.
       left.value_or(childLeft_), right.value_or(childRight_),

--- a/src/engine/TransitivePathBase.cpp
+++ b/src/engine/TransitivePathBase.cpp
@@ -437,11 +437,11 @@ std::shared_ptr<TransitivePathBase> TransitivePathBase::makeTransitivePath(
     size_t maxDist, bool useBinSearch, Graphs activeGraphs,
     const std::optional<Variable>& graphVariable) {
   if (useBinSearch) {
-    return std::make_shared<TransitivePathBinSearch>(
+    return qec->makeShared<TransitivePathBinSearch>(
         qec, std::move(child), std::move(leftSide), std::move(rightSide),
         minDist, maxDist, std::move(activeGraphs), graphVariable);
   } else {
-    return std::make_shared<TransitivePathHashMap>(
+    return qec->makeShared<TransitivePathHashMap>(
         qec, std::move(child), std::move(leftSide), std::move(rightSide),
         minDist, maxDist, std::move(activeGraphs), graphVariable);
   }

--- a/src/libqlever/QleverTypes.h
+++ b/src/libqlever/QleverTypes.h
@@ -76,7 +76,7 @@ struct PlannedQuery {
       : qec_{qec.shared_from_this()},
         parsedQuery_{std::move(pq)},
         queryExecutionTree_{
-            std::make_shared<QueryExecutionTree>(std::move(qet))} {
+            qec.makeShared<QueryExecutionTree>(std::move(qet))} {
     AD_CORRECTNESS_CHECK(qec_.get() == queryExecutionTree_->getQec());
   }
 

--- a/src/util/AllocateShared.h
+++ b/src/util/AllocateShared.h
@@ -1,0 +1,33 @@
+// Copyright 2026 The QLever Authors, in particular:
+//
+// 2026 Robin Textor-Falconi <textorr@informatik.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+//
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#ifndef QLEVER_SRC_UTIL_ALLOCATESHARED_H
+#define QLEVER_SRC_UTIL_ALLOCATESHARED_H
+
+#include <memory>
+
+#include "util/Forward.h"
+
+// Define a member function template `makeShared<T>(args...)` which behaves
+// exactly like `std::make_shared<T>(args...)`, but allocates the object
+// (together with the control block of the `shared_ptr`) using the allocator
+// that the expression `allocatorSnippet` evaluates to. That way the memory
+// limit of a query also applies to the objects that are allocated on the heap
+// while the query is planned and executed.
+//
+// The `allocatorSnippet` is evaluated in the scope of the enclosing class, so
+// it typically refers to one of its members, for example
+// `DEFINE_MAKE_SHARED_MEMBER(qec_->getAllocator())`.
+#define DEFINE_MAKE_SHARED_MEMBER(allocatorSnippet)                    \
+  template <typename T, typename... Args>                              \
+  std::shared_ptr<T> makeShared(Args&&... args) const {                \
+    return std::allocate_shared<T>(allocatorSnippet, AD_FWD(args)...); \
+  }
+
+#endif  // QLEVER_SRC_UTIL_ALLOCATESHARED_H

--- a/test/AllocateSharedTest.cpp
+++ b/test/AllocateSharedTest.cpp
@@ -1,0 +1,77 @@
+// Copyright 2026 The QLever Authors, in particular:
+//
+// 2026 Robin Textor-Falconi <textorr@informatik.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+//
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <memory>
+
+#include "util/AllocateShared.h"
+
+namespace {
+
+// A minimal allocator that forwards to `std::allocator`, but counts the
+// allocations in the counter it points to.
+template <typename T>
+struct CountingAllocator {
+  using value_type = T;
+  size_t* numAllocations_;
+
+  explicit CountingAllocator(size_t* numAllocations)
+      : numAllocations_{numAllocations} {}
+
+  // Allocators have to be convertible between their rebound versions, because
+  // `std::allocate_shared` rebinds the allocator to its internal type.
+  template <typename U>
+  CountingAllocator(const CountingAllocator<U>& other)
+      : numAllocations_{other.numAllocations_} {}
+
+  T* allocate(size_t n) {
+    ++*numAllocations_;
+    return std::allocator<T>{}.allocate(n);
+  }
+  void deallocate(T* pointer, size_t n) {
+    std::allocator<T>{}.deallocate(pointer, n);
+  }
+};
+
+// A class that uses `DEFINE_MAKE_SHARED_MEMBER` just like the classes in the
+// query engine do.
+class ClassWithAllocator {
+ public:
+  explicit ClassWithAllocator(size_t* numAllocations)
+      : allocator_{numAllocations} {}
+
+  // define a `makeShared` member function that has the same interface as
+  // `std::make_shared`, but allocates via the `allocator_` (see
+  // `util/AllocateShared.h`).
+  DEFINE_MAKE_SHARED_MEMBER(allocator_)
+
+ private:
+  CountingAllocator<char> allocator_;
+};
+
+}  // namespace
+
+// _____________________________________________________________________________
+TEST(AllocateShared, makeShared) {
+  size_t numAllocations = 0;
+  // Note: `makeShared` is `const`, so it can be called on a `const` object.
+  const ClassWithAllocator classWithAllocator{&numAllocations};
+
+  // The arguments are perfectly forwarded to the constructor (here: a move-only
+  // argument).
+  auto pointer = classWithAllocator.makeShared<std::unique_ptr<int>>(
+      std::make_unique<int>(42));
+  EXPECT_EQ(**pointer, 42);
+
+  // The object and the control block of the `shared_ptr` were allocated
+  // together via the allocator of the class.
+  EXPECT_EQ(numAllocations, 1);
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -278,6 +278,8 @@ addLinkAndDiscoverTest(VectorWithMemoryLimitTest)
 
 addLinkAndDiscoverTestNoLibs(AllocatorPmrTest)
 
+addLinkAndDiscoverTestNoLibs(AllocateSharedTest)
+
 addLinkAndDiscoverTestNoLibs(AllocatorBackendTest)
 
 addLinkAndDiscoverTestNoLibs(AlignedAllocatorTest)

--- a/test/OperationTest.cpp
+++ b/test/OperationTest.cpp
@@ -56,6 +56,15 @@ void expectRtiHasDimensions(
 }  // namespace
 
 // ________________________________________________
+// _____________________________________________________________________________
+TEST(OperationTest, constructorRequiresQueryExecutionContext) {
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      NeutralElementOperation{nullptr},
+      ::testing::HasSubstr(
+          "An `Operation` requires a `QueryExecutionContext`"));
+}
+
+// _____________________________________________________________________________
 TEST(OperationTest, limitIsRepresentedInCacheKey) {
   LimitOffsetClause l;
   {

--- a/test/engine/QueryExecutionTreeTest.cpp
+++ b/test/engine/QueryExecutionTreeTest.cpp
@@ -4,6 +4,7 @@
 
 #include <gmock/gmock.h>
 
+#include "../util/GTestHelpers.h"
 #include "../util/IdTableHelpers.h"
 #include "../util/IndexTestHelpers.h"
 #include "./ValuesForTesting.h"
@@ -303,4 +304,11 @@ TEST(QueryExecutionTree,
                             ->getRootOperation();
   EXPECT_TRUE(std::dynamic_pointer_cast<IndexScan>(childOperation));
   EXPECT_EQ(childOperation->getLimitOffset(), limitOffset);
+}
+
+// _____________________________________________________________________________
+TEST(QueryExecutionTree, constructorRequiresQueryExecutionContext) {
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      QueryExecutionTree{nullptr},
+      ::testing::HasSubstr("Assertion `qec_ != nullptr` failed."));
 }

--- a/test/engine/QueryExecutionTreeTest.cpp
+++ b/test/engine/QueryExecutionTreeTest.cpp
@@ -312,3 +312,13 @@ TEST(QueryExecutionTree, constructorRequiresQueryExecutionContext) {
       QueryExecutionTree{nullptr},
       ::testing::HasSubstr("Assertion `qec_ != nullptr` failed."));
 }
+
+// _____________________________________________________________________________
+TEST(QueryExecutionTree, cloneOfEmptyTreeIsEmpty) {
+  QueryExecutionTree tree{getQec()};
+  ASSERT_TRUE(tree.isEmpty());
+  auto clone = tree.clone();
+  ASSERT_NE(clone, nullptr);
+  EXPECT_TRUE(clone->isEmpty());
+  EXPECT_EQ(clone->getQec(), tree.getQec());
+}


### PR DESCRIPTION
So far, the objects that the query engine allocates on the heap while a query is planned and executed (the operations and execution trees, results, runtime information, cancellation handles) were created with `std::make_shared`, so their memory did not count towards the memory limit of the query. This change adds the macro `DEFINE_MAKE_SHARED_MEMBER` (in `util/AllocateShared.h`), which defines a member function `makeShared` with the interface of `std::make_shared` that allocates via `std::allocate_shared` with the memory-limited allocator of the query. `Operation`, `QueryExecutionContext`, and `QueryExecutionTree` define such a member, and the callers of `std::make_shared` in the operations now use it. Since the allocator comes from the `QueryExecutionContext`, an `Operation` and a `QueryExecutionTree` now require one, which their constructors check.

NOTE: This is a subset of #3180, split off for easier review.