### PR TITLE
Remove the single-argument constructor of `QueryExecutionTree`

### DIFF
--- a/src/engine/ExistsJoin.cpp
+++ b/src/engine/ExistsJoin.cpp
@@ -274,7 +274,7 @@ std::shared_ptr<QueryExecutionTree> ExistsJoin::addExistsJoinsToSubtree(
                          const VariableOrderKey& key) {
                        return columns.at(key.variable_).columnIndex_;
                      });
-    auto tree = qec->makeShared<QueryExecutionTree>(qp.createExecutionTree(pq));
+    auto tree = qp.createExecutionTree(pq);
     // Hide non-visible variables in the subtree, so that they are not
     // accidentally joined, ideally collisions wouldn't happen in the first
     // place, but since we're creating our own instance of `QueryPlanner` we

--- a/src/engine/MaterializedViews.cpp
+++ b/src/engine/MaterializedViews.cpp
@@ -948,7 +948,7 @@ MaterializedView::computeCacheKey(
     auto handle = std::make_shared<ad_utility::CancellationHandle<>>();
     QueryPlanner qp{&qec, handle};
 
-    std::optional<QueryExecutionTree> executionTree;
+    std::shared_ptr<QueryExecutionTree> executionTree;
     try {
       executionTree = qp.createExecutionTree(parsed);
     } catch (const MaterializedViewConfigException&) {

--- a/src/engine/MaterializedViews.cpp
+++ b/src/engine/MaterializedViews.cpp
@@ -13,6 +13,7 @@
 
 #include <memory>
 #include <nlohmann/json.hpp>
+#include <optional>
 #include <stdexcept>
 
 #include "backports/filesystem.h"
@@ -947,7 +948,7 @@ MaterializedView::computeCacheKey(
     auto handle = std::make_shared<ad_utility::CancellationHandle<>>();
     QueryPlanner qp{&qec, handle};
 
-    QueryExecutionTree executionTree{&qec};
+    std::optional<QueryExecutionTree> executionTree;
     try {
       executionTree = qp.createExecutionTree(parsed);
     } catch (const MaterializedViewConfigException&) {
@@ -960,7 +961,7 @@ MaterializedView::computeCacheKey(
     }
 
     ColumnMapping mapping;
-    for (const auto& [var, col] : executionTree.getVariableColumns()) {
+    for (const auto& [var, col] : executionTree->getVariableColumns()) {
       auto it = viewCols.find(var);
       // Internal variables and variables that are not selected by the
       // materialized view query are not present in the view. Therefore this
@@ -970,7 +971,7 @@ MaterializedView::computeCacheKey(
       }
       mapping.insert({col.columnIndex_, it->second.columnIndex_});
     }
-    return CacheKeyAndColumnMapping{executionTree.getCacheKey(),
+    return CacheKeyAndColumnMapping{executionTree->getCacheKey(),
                                     std::move(mapping)};
   };
 

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -22,6 +22,7 @@
 #include "util/CancellationHandle.h"
 #include "util/CompilerExtensions.h"
 #include "util/CopyableSynchronization.h"
+#include "util/Exception.h"
 #include "util/TypeTraits.h"
 
 // forward declaration needed to break dependencies
@@ -73,6 +74,15 @@ class Operation {
       std::chrono::steady_clock::time_point::max();
 
  private:
+  // Return the given `executionContext`, or throw if it is `nullptr` (see the
+  // constructor below).
+  static QueryExecutionContext* checkNotNull(
+      QueryExecutionContext* executionContext) {
+    AD_CONTRACT_CHECK(executionContext != nullptr,
+                      "An `Operation` requires a `QueryExecutionContext`");
+    return executionContext;
+  }
+
   // Holds a precomputed Result of this operation if it is the sibling of a
   // Service operation.
   std::optional<std::shared_ptr<const Result>>
@@ -136,10 +146,11 @@ class Operation {
   // Holds a `PrefilterExpression` with its corresponding `Variable`.
   using PrefilterVariablePair = sparqlExpression::PrefilterExprVariablePair;
 
-  // Constructor. Note that `executionContext` must not be `nullptr`, as it is
-  // required by the default member initializers of the members above.
+  // Constructor. The `executionContext` must not be `nullptr`, as it is
+  // required by the default member initializers of the members above, so it
+  // is checked before those are initialized.
   explicit Operation(QueryExecutionContext* executionContext)
-      : _executionContext(executionContext) {}
+      : _executionContext(checkNotNull(executionContext)) {}
 
   // Destructor.
   virtual ~Operation() {

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -22,7 +22,6 @@
 #include "util/CancellationHandle.h"
 #include "util/CompilerExtensions.h"
 #include "util/CopyableSynchronization.h"
-#include "util/Exception.h"
 #include "util/TypeTraits.h"
 
 // forward declaration needed to break dependencies
@@ -74,15 +73,6 @@ class Operation {
       std::chrono::steady_clock::time_point::max();
 
  private:
-  // Return the given `executionContext`, or throw if it is `nullptr` (see the
-  // constructor below).
-  static QueryExecutionContext* checkNotNull(
-      QueryExecutionContext* executionContext) {
-    AD_CONTRACT_CHECK(executionContext != nullptr,
-                      "An `Operation` requires a `QueryExecutionContext`");
-    return executionContext;
-  }
-
   // Holds a precomputed Result of this operation if it is the sibling of a
   // Service operation.
   std::optional<std::shared_ptr<const Result>>
@@ -146,11 +136,10 @@ class Operation {
   // Holds a `PrefilterExpression` with its corresponding `Variable`.
   using PrefilterVariablePair = sparqlExpression::PrefilterExprVariablePair;
 
-  // Constructor. The `executionContext` must not be `nullptr`, as it is
-  // required by the default member initializers of the members above, so it
-  // is checked before those are initialized.
+  // Constructor. Note that `executionContext` must not be `nullptr`, as it is
+  // required by the default member initializers of the members above.
   explicit Operation(QueryExecutionContext* executionContext)
-      : _executionContext(checkNotNull(executionContext)) {}
+      : _executionContext(executionContext) {}
 
   // Destructor.
   virtual ~Operation() {

--- a/src/engine/QueryExecutionTree.cpp
+++ b/src/engine/QueryExecutionTree.cpp
@@ -26,11 +26,18 @@ using std::string;
 using parsedQuery::SelectClause;
 
 // _____________________________________________________________________________
-QueryExecutionTree::QueryExecutionTree(QueryExecutionContext* const qec)
-    : qec_(qec) {
+QueryExecutionTree::QueryExecutionTree(QueryExecutionContext* const qec,
+                                       std::shared_ptr<Operation> operation)
+    : qec_{qec}, rootOperation_{std::move(operation)} {
   // A `QueryExecutionTree` always needs a `QueryExecutionContext`, if only to
   // obtain the memory limited allocator of the query.
   AD_CONTRACT_CHECK(qec_ != nullptr);
+  AD_CONTRACT_CHECK(rootOperation_ != nullptr);
+  resultWidth_ = rootOperation_->getResultWidth();
+  cacheKey_ = rootOperation_->getCacheKey();
+  if (!readFromCache()) {
+    readFromMaterializedView();
+  }
 }
 
 // _____________________________________________________________________________
@@ -50,7 +57,6 @@ size_t QueryExecutionTree::getVariableColumn(const Variable& variable) const {
 // _____________________________________________________________________________
 std::optional<size_t> QueryExecutionTree::getVariableColumnOrNullopt(
     const Variable& variable) const {
-  AD_CONTRACT_CHECK(rootOperation_);
   const auto& varCols = getVariableColumns();
   if (!varCols.contains(variable)) {
     return std::nullopt;
@@ -121,7 +127,6 @@ size_t QueryExecutionTree::getSizeEstimate() {
 std::optional<std::shared_ptr<QueryExecutionTree>>
 QueryExecutionTree::getUpdatedQueryExecutionTreeWithPrefilterApplied(
     std::vector<Operation::PrefilterVariablePair> prefilterPairs) const {
-  AD_CONTRACT_CHECK(rootOperation_);
   VariableToColumnMap varToColMap = getVariableColumns();
 
   // Note: Variables that have been stripped are still semantically part of the
@@ -150,7 +155,6 @@ bool QueryExecutionTree::knownEmptyResult() {
 
 // _____________________________________________________________________________
 bool QueryExecutionTree::isVariableCovered(Variable variable) const {
-  AD_CONTRACT_CHECK(rootOperation_);
   return getVariableColumns().contains(variable);
 }
 

--- a/src/engine/QueryExecutionTree.h
+++ b/src/engine/QueryExecutionTree.h
@@ -49,8 +49,6 @@ class QueryExecutionTree {
 
   std::shared_ptr<Operation> getRootOperation() const { return rootOperation_; }
 
-  bool isEmpty() const { return !rootOperation_; }
-
   // Get the column index that the given `variable` will have in the result of
   // this query. Throw if the variable is not part of the `VariableToColumnMap`.
   size_t getVariableColumn(const Variable& variable) const;

--- a/src/engine/QueryExecutionTree.h
+++ b/src/engine/QueryExecutionTree.h
@@ -341,10 +341,7 @@ class QueryExecutionTree {
   DEFINE_MAKE_SHARED_MEMBER(qec_->getAllocator())
 
   std::shared_ptr<QueryExecutionTree> clone() const {
-    // A tree without a root operation is cloned to another such tree.
-    return rootOperation_
-               ? makeShared<QueryExecutionTree>(qec_, rootOperation_->clone())
-               : makeShared<QueryExecutionTree>(qec_);
+    return makeShared<QueryExecutionTree>(qec_, rootOperation_->clone());
   }
 };
 

--- a/src/engine/QueryExecutionTree.h
+++ b/src/engine/QueryExecutionTree.h
@@ -28,24 +28,14 @@ enum class HideStrippedColumns { False, True };
 // operations needed to solve a query.
 class QueryExecutionTree {
  public:
-  explicit QueryExecutionTree(QueryExecutionContext* qec);
   QueryExecutionTree(QueryExecutionContext* qec,
-                     std::shared_ptr<Operation> operation)
-      : QueryExecutionTree(qec) {
-    rootOperation_ = std::move(operation);
-    resultWidth_ = rootOperation_->getResultWidth();
-    cacheKey_ = rootOperation_->getCacheKey();
-    if (!readFromCache()) {
-      readFromMaterializedView();
-    }
-  }
+                     std::shared_ptr<Operation> operation);
 
   std::string getCacheKey() const;
 
   const QueryExecutionContext* getQec() const { return qec_; }
 
   const VariableToColumnMap& getVariableColumns() const {
-    AD_CONTRACT_CHECK(rootOperation_);
     return rootOperation_->getExternallyVisibleVariableColumns();
   }
 

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -326,7 +326,6 @@ std::vector<SubtreePlan> QueryPlanner::getDistinctRow(
   vector<SubtreePlan> added;
   added.reserve(previous.size());
   for (const auto& parent : previous) {
-    SubtreePlan distinctPlan(_qec);
     vector<ColumnIndex> keepIndices;
     ad_utility::HashSet<ColumnIndex> indDone;
     const auto& colMap = parent._qet->getVariableColumns();
@@ -341,9 +340,8 @@ std::vector<SubtreePlan> QueryPlanner::getDistinctRow(
         }
       }
     }
-    distinctPlan._qet =
-        QueryExecutionTree::createDistinctTree(parent._qet, keepIndices);
-    added.push_back(distinctPlan);
+    added.push_back(SubtreePlan{
+        QueryExecutionTree::createDistinctTree(parent._qet, keepIndices)});
   }
   return added;
 }
@@ -418,10 +416,6 @@ std::vector<SubtreePlan> QueryPlanner::getGroupByRow(
   vector<SubtreePlan> added;
   added.reserve(previous.size());
   for (auto& parent : previous) {
-    // Create a group by operation to determine on which columns the input
-    // needs to be sorted
-    SubtreePlan groupByPlan(_qec);
-    assignNodesFilterAndTextLimitIds(groupByPlan, parent);
     std::vector<Alias> aliases;
     if (pq.hasSelectClause()) {
       aliases = pq.selectClause().getAliases();
@@ -437,9 +431,12 @@ std::vector<SubtreePlan> QueryPlanner::getGroupByRow(
           "should have thrown an exception earlier");
       groupVariables.push_back(activeGraphVariable_.value());
     }
-    groupByPlan._qet = makeExecutionTree<GroupBy>(
-        _qec, groupVariables, std::move(aliases), parent._qet);
-    added.push_back(groupByPlan);
+    // Create a group by operation to determine on which columns the input
+    // needs to be sorted
+    SubtreePlan groupByPlan{makeExecutionTree<GroupBy>(
+        _qec, groupVariables, std::move(aliases), parent._qet)};
+    assignNodesFilterAndTextLimitIds(groupByPlan, parent);
+    added.push_back(std::move(groupByPlan));
   }
   return added;
 }
@@ -451,9 +448,6 @@ std::vector<SubtreePlan> QueryPlanner::getOrderByRow(
   vector<SubtreePlan> added;
   added.reserve(previous.size());
   for (const auto& parent : previous) {
-    SubtreePlan plan(_qec);
-    auto& tree = plan._qet;
-    assignNodesFilterAndTextLimitIds(plan, parent);
     vector<std::pair<ColumnIndex, bool>> sortIndices;
     // Collect the variables of the ORDER BY or INTERNAL SORT BY clause. Ignore
     // variables that are not visible in the query body (according to the
@@ -472,24 +466,28 @@ std::vector<SubtreePlan> QueryPlanner::getOrderByRow(
       return previous;
     }
 
-    if (pq._isInternalSort == IsInternalSort::True) {
-      std::vector<ColumnIndex> sortColumns;
-      for (auto& [index, isDescending] : sortIndices) {
-        AD_CONTRACT_CHECK(!isDescending);
-        sortColumns.push_back(index);
+    auto tree = [this, &pq, &parent, &sortIndices]() {
+      if (pq._isInternalSort == IsInternalSort::True) {
+        std::vector<ColumnIndex> sortColumns;
+        for (auto& [index, isDescending] : sortIndices) {
+          AD_CONTRACT_CHECK(!isDescending);
+          sortColumns.push_back(index);
+        }
+        // An explicit `INTERNAL SORT BY` requests the complete sorted result,
+        // so we must not let the `Sort` propagate a `LIMIT`/`OFFSET` to its
+        // subtree.
+        return QueryExecutionTree::createSortedTree(parent._qet, sortColumns,
+                                                    true);
       }
-      // An explicit `INTERNAL SORT BY` requests the complete sorted result, so
-      // we must not let the `Sort` propagate a `LIMIT`/`OFFSET` to its subtree.
-      tree =
-          QueryExecutionTree::createSortedTree(parent._qet, sortColumns, true);
-    } else {
       AD_CONTRACT_CHECK(pq._isInternalSort == IsInternalSort::False);
       // Note: As the internal ordering is different from the semantic ordering
       // needed by `OrderBy`, we always have to instantiate the `OrderBy`
       // operation.
-      tree = makeExecutionTree<OrderBy>(_qec, parent._qet, sortIndices);
-    }
-    added.push_back(plan);
+      return makeExecutionTree<OrderBy>(_qec, parent._qet, sortIndices);
+    }();
+    SubtreePlan plan{std::move(tree)};
+    assignNodesFilterAndTextLimitIds(plan, parent);
+    added.push_back(std::move(plan));
   }
   return added;
 }
@@ -1192,32 +1190,31 @@ SubtreePlan QueryPlanner::getTextLeafPlan(
     TextLimitMap& textLimits) const {
   AD_CONTRACT_CHECK(node.wordPart_.has_value());
   std::string word = node.wordPart_.value();
-  SubtreePlan plan(_qec);
   const auto& cvar = node.cvar_.value();
   if (!textLimits.contains(cvar)) {
     textLimits[cvar] = parsedQuery::TextLimitMetaObject{{}, {}, 0};
   }
-  if (node.triple_.getSimplePredicate() == CONTAINS_ENTITY_PREDICATE) {
+  auto plan = [this, &node, &textLimits, &cvar, &word]() {
+    if (node.triple_.getSimplePredicate() != CONTAINS_ENTITY_PREDICATE) {
+      return makeSubtreePlan<TextIndexScanForWord>(_qec, cvar, word);
+    }
     if (node._variables.size() == 2) {
       // TODO<joka921>: This is not nice, refactor the whole TripleGraph class
       // to make these checks more explicitly.
       Variable evar = *(node._variables.begin()) == cvar
                           ? *(++node._variables.begin())
                           : *(node._variables.begin());
-      plan = makeSubtreePlan<TextIndexScanForEntity>(_qec, cvar, evar, word);
       textLimits[cvar].entityVars_.push_back(evar);
       textLimits[cvar].scoreVars_.push_back(cvar.getEntityScoreVariable(evar));
-    } else {
-      // Fixed entity case
-      AD_CORRECTNESS_CHECK(node._variables.size() == 1);
-      plan = makeSubtreePlan<TextIndexScanForEntity>(
-          _qec, cvar, node.triple_.o_.toString(), word);
-      textLimits[cvar].scoreVars_.push_back(
-          cvar.getEntityScoreVariable(node.triple_.o_.toString()));
+      return makeSubtreePlan<TextIndexScanForEntity>(_qec, cvar, evar, word);
     }
-  } else {
-    plan = makeSubtreePlan<TextIndexScanForWord>(_qec, cvar, word);
-  }
+    // Fixed entity case
+    AD_CORRECTNESS_CHECK(node._variables.size() == 1);
+    textLimits[cvar].scoreVars_.push_back(
+        cvar.getEntityScoreVariable(node.triple_.o_.toString()));
+    return makeSubtreePlan<TextIndexScanForEntity>(
+        _qec, cvar, node.triple_.o_.toString(), word);
+  }();
   textLimits[cvar].idsOfMustBeFinishedOperations_ |= (size_t(1) << node.id_);
   plan._idsOfIncludedNodes |= (size_t(1) << node.id_);
   return plan;

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -433,8 +433,8 @@ std::vector<SubtreePlan> QueryPlanner::getGroupByRow(
     }
     // Create a group by operation to determine on which columns the input
     // needs to be sorted
-    SubtreePlan groupByPlan{makeExecutionTree<GroupBy>(
-        _qec, groupVariables, std::move(aliases), parent._qet)};
+    SubtreePlan groupByPlan = makeSubtreePlan<GroupBy>(
+        _qec, groupVariables, std::move(aliases), parent._qet);
     assignNodesFilterAndTextLimitIds(groupByPlan, parent);
     added.push_back(std::move(groupByPlan));
   }
@@ -466,7 +466,7 @@ std::vector<SubtreePlan> QueryPlanner::getOrderByRow(
       return previous;
     }
 
-    auto tree = [this, &pq, &parent, &sortIndices]() {
+    auto plan = [this, &pq, &parent, &sortIndices]() -> SubtreePlan {
       if (pq._isInternalSort == IsInternalSort::True) {
         std::vector<ColumnIndex> sortColumns;
         for (auto& [index, isDescending] : sortIndices) {
@@ -476,16 +476,15 @@ std::vector<SubtreePlan> QueryPlanner::getOrderByRow(
         // An explicit `INTERNAL SORT BY` requests the complete sorted result,
         // so we must not let the `Sort` propagate a `LIMIT`/`OFFSET` to its
         // subtree.
-        return QueryExecutionTree::createSortedTree(parent._qet, sortColumns,
-                                                    true);
+        return SubtreePlan{QueryExecutionTree::createSortedTree(
+            parent._qet, sortColumns, true)};
       }
       AD_CONTRACT_CHECK(pq._isInternalSort == IsInternalSort::False);
       // Note: As the internal ordering is different from the semantic ordering
       // needed by `OrderBy`, we always have to instantiate the `OrderBy`
       // operation.
-      return makeExecutionTree<OrderBy>(_qec, parent._qet, sortIndices);
+      return makeSubtreePlan<OrderBy>(_qec, parent._qet, sortIndices);
     }();
-    SubtreePlan plan{std::move(tree)};
     assignNodesFilterAndTextLimitIds(plan, parent);
     added.push_back(std::move(plan));
   }
@@ -3436,8 +3435,8 @@ void QueryPlanner::GraphPatternPlanner::visitExternalValues(
 void QueryPlanner::GraphPatternPlanner::visitNamedCachedResult(
     const parsedQuery::NamedCachedResult& arg) {
   auto candidate =
-      SubtreePlan{planner_._qec, planner_._qec->namedResultCache().getOperation(
-                                     arg.identifier(), planner_._qec)};
+      makeSubtreePlan(planner_._qec->namedResultCache().getOperation(
+          arg.identifier(), planner_._qec));
   visitGroupOptionalOrMinus(std::vector{std::move(candidate)});
 }
 

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -250,14 +250,14 @@ std::vector<SubtreePlan> QueryPlanner::createExecutionTrees(ParsedQuery& pq,
 }
 
 // _____________________________________________________________________________
-QueryExecutionTree QueryPlanner::createExecutionTree(ParsedQuery& pq,
-                                                     bool isSubquery) {
+std::shared_ptr<QueryExecutionTree> QueryPlanner::createExecutionTree(
+    ParsedQuery& pq, bool isSubquery) {
   try {
     auto lastRow = createExecutionTrees(pq, isSubquery);
     auto minInd = findCheapestExecutionTree(lastRow);
     AD_LOG_DEBUG << "Done creating execution plan" << std::endl;
-    auto result = std::move(*lastRow[minInd]._qet);
-    auto& rootOperation = *result.getRootOperation();
+    auto result = std::move(lastRow[minInd]._qet);
+    auto& rootOperation = *result->getRootOperation();
     // Collect all the warnings and pass them to the created tree such that
     // they become visible to the user once the query is executed.
     for (const auto& warning : warnings_) {
@@ -3521,8 +3521,7 @@ void QueryPlanner::GraphPatternPlanner::optimizeCommutatively() {
 // _______________________________________________________________
 void QueryPlanner::GraphPatternPlanner::visitDescribe(
     parsedQuery::Describe& describe) {
-  auto tree = std::make_shared<QueryExecutionTree>(
-      planner_.createExecutionTree(describe.whereClause_.get(), true));
+  auto tree = planner_.createExecutionTree(describe.whereClause_.get(), true);
   auto describeOp =
       makeSubtreePlan<Describe>(planner_._qec, std::move(tree), describe);
   candidatePlans_.push_back(std::vector{std::move(describeOp)});

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -148,8 +148,8 @@ class QueryPlanner {
    public:
     enum Type { BASIC, OPTIONAL, MINUS };
 
-    explicit SubtreePlan(QueryExecutionContext* qec)
-        : _qet(std::make_shared<QueryExecutionTree>(qec)) {}
+    explicit SubtreePlan(std::shared_ptr<QueryExecutionTree> qet)
+        : _qet{std::move(qet)} {}
 
     template <typename Operation>
     SubtreePlan(QueryExecutionContext* qec,

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -54,8 +54,8 @@ class QueryPlanner {
 
   // Create the best execution tree for the given query according to the
   // optimization algorithm and cost estimates of the QueryPlanner.
-  QueryExecutionTree createExecutionTree(ParsedQuery& pq,
-                                         bool isSubquery = false);
+  std::shared_ptr<QueryExecutionTree> createExecutionTree(
+      ParsedQuery& pq, bool isSubquery = false);
 
   class TripleGraph {
    public:

--- a/src/libqlever/Qlever.cpp
+++ b/src/libqlever/Qlever.cpp
@@ -308,7 +308,7 @@ PlannedQuery Qlever::planQuery(
 
   qp.setEnablePatternTrick(enablePatternTrick_);
   auto qet = qp.createExecutionTree(parsedQuery);
-  qet.isRoot() = true;
+  qet->isRoot() = true;
   PlannedQuery plannedQuery = {std::move(parsedQuery), std::move(qet), qec};
 
   auto& rootOperation = *plannedQuery.queryExecutionTree().getRootOperation();

--- a/src/libqlever/QleverTypes.h
+++ b/src/libqlever/QleverTypes.h
@@ -71,12 +71,12 @@ struct PlannedQuery {
   std::shared_ptr<QueryExecutionTree> queryExecutionTree_;
 
  public:
-  PlannedQuery(ParsedQuery pq, QueryExecutionTree qet,
+  PlannedQuery(ParsedQuery pq, std::shared_ptr<QueryExecutionTree> qet,
                QueryExecutionContext& qec)
       : qec_{qec.shared_from_this()},
         parsedQuery_{std::move(pq)},
-        queryExecutionTree_{
-            qec.makeShared<QueryExecutionTree>(std::move(qet))} {
+        queryExecutionTree_{std::move(qet)} {
+    AD_CONTRACT_CHECK(queryExecutionTree_ != nullptr);
     AD_CORRECTNESS_CHECK(qec_.get() == queryExecutionTree_->getQec());
   }
 

--- a/test/ExecuteUpdateTest.cpp
+++ b/test/ExecuteUpdateTest.cpp
@@ -59,7 +59,7 @@ TEST(ExecuteUpdate, executeUpdate) {
                 deltaTriples.updateAugmentedMetadata();
                 QueryPlanner qp{&qec, sharedHandle};
                 const auto qet = qp.createExecutionTree(pq);
-                ExecuteUpdate::executeUpdate(index, pq, qet, deltaTriples,
+                ExecuteUpdate::executeUpdate(index, pq, *qet, deltaTriples,
                                              sharedHandle);
               }
             });
@@ -244,11 +244,11 @@ TEST(ExecuteUpdate, computeGraphUpdateQuads) {
       QueryPlanner qp{qec, sharedHandle};
       const auto qet = qp.createExecutionTree(pq);
       UpdateMetadata metadata;
-      auto result = qet.getResult(false);
+      auto result = qet->getResult(false);
       results.push_back(ExecuteUpdate::computeGraphUpdateQuads(
-          index, pq, *result, qet.getVariableColumns(), sharedHandle,
+          index, pq, *result, qet->getVariableColumns(), sharedHandle,
           metadata));
-      ExecuteUpdate::executeUpdate(index, pq, qet, deltaTriples, sharedHandle);
+      ExecuteUpdate::executeUpdate(index, pq, *qet, deltaTriples, sharedHandle);
     }
     return results;
   };

--- a/test/ExportQueryExecutionTreesTest.cpp
+++ b/test/ExportQueryExecutionTreesTest.cpp
@@ -48,7 +48,7 @@ std::string runQueryStreamableResult(
   auto qet = qp.createExecutionTree(pq);
   ad_utility::Timer timer(ad_utility::Timer::Started);
   auto strGenerator = ExportQueryExecutionTrees::computeResult(
-      pq, qet, mediaType, timer, std::move(cancellationHandle));
+      pq, *qet, mediaType, timer, std::move(cancellationHandle));
 
   std::string result;
   for (const auto& block : strGenerator) {
@@ -78,7 +78,7 @@ nlohmann::json runJSONQuery(const std::string& kg, const std::string& query,
   ad_utility::Timer timer{ad_utility::Timer::Started};
   std::string resStr;
   for (auto c : ExportQueryExecutionTrees::computeResult(
-           pq, qet, mediaType, timer, std::move(cancellationHandle))) {
+           pq, *qet, mediaType, timer, std::move(cancellationHandle))) {
     resStr += c;
   }
   return nlohmann::json::parse(resStr);
@@ -1657,7 +1657,7 @@ TEST_P(StreamableMediaTypesFixture, CancellationCancelsStream) {
   ad_utility::Timer timer(ad_utility::Timer::Started);
   EXPECT_ANY_THROW(([&]() {
     [[maybe_unused]] auto generator = ExportQueryExecutionTrees::computeResult(
-        pq, qet, GetParam(), timer, std::move(cancellationHandle));
+        pq, *qet, GetParam(), timer, std::move(cancellationHandle));
   }()));
 }
 
@@ -1889,14 +1889,14 @@ TEST(ExportQueryExecutionTrees, verifyQleverJsonContainsValidMetadata) {
   std::this_thread::sleep_for(1ms);
 
   auto jsonStream = ExportQueryExecutionTrees::computeResultAsQLeverJSON(
-      pq, qet, pq._limitOffset, timer, std::move(cancellationHandle));
+      pq, *qet, pq._limitOffset, timer, std::move(cancellationHandle));
 
   std::string aggregateString{};
   for (std::string_view chunk : jsonStream) {
     aggregateString += chunk;
   }
   nlohmann::json json = nlohmann::json::parse(aggregateString);
-  auto originalRuntimeInfo = qet.getRootOperation()->runtimeInfo();
+  auto originalRuntimeInfo = qet->getRootOperation()->runtimeInfo();
 
   EXPECT_EQ(json["query"], query);
   EXPECT_EQ(json["status"], "OK");
@@ -2029,7 +2029,7 @@ TEST(ExportQueryExecutionTrees, EncodedIriManagerUsage) {
       std::make_shared<ad_utility::CancellationHandle<>>();
   std::string result;
   for (const auto& chunk : ExportQueryExecutionTrees::computeResult(
-           parsedQuery, qet, ad_utility::MediaType::sparqlXml, timer,
+           parsedQuery, *qet, ad_utility::MediaType::sparqlXml, timer,
            std::move(cancellationHandle2))) {
     result += chunk;
   }
@@ -2047,7 +2047,7 @@ TEST(ExportQueryExecutionTrees, EncodedIriManagerUsage) {
       std::make_shared<ad_utility::CancellationHandle<>>();
   std::string tsvResult;
   for (const auto& chunk : ExportQueryExecutionTrees::computeResult(
-           parsedQuery, qet, ad_utility::MediaType::tsv, tsvTimer,
+           parsedQuery, *qet, ad_utility::MediaType::tsv, tsvTimer,
            std::move(cancellationHandle3))) {
     tsvResult += chunk;
   }

--- a/test/GroupByTest.cpp
+++ b/test/GroupByTest.cpp
@@ -2471,7 +2471,7 @@ TEST(GroupBy, AddedHavingRows) {
   QueryPlanner qp{qec, std::make_shared<ad_utility::CancellationHandle<>>()};
   auto tree = qp.createExecutionTree(pq);
 
-  auto res = tree.getResult();
+  auto res = tree->getResult();
 
   // The HAVING is implemented as an alias that creates an internal variable
   // which becomes part of the result, but is not selected by the query.
@@ -2482,7 +2482,7 @@ TEST(GroupBy, AddedHavingRows) {
       {Variable{"?x"}, {0, AlwaysDefined}},
       {Variable{"?count"}, {1, PossiblyUndefined}},
       {Variable{"?_QLever_internal_variable_0"}, {2, PossiblyUndefined}}};
-  EXPECT_THAT(tree.getVariableColumns(),
+  EXPECT_THAT(tree->getVariableColumns(),
               ::testing::UnorderedElementsAreArray(expectedVariables));
   const auto& table = res->idTableView();
   auto i = IntId;

--- a/test/LoadTest.cpp
+++ b/test/LoadTest.cpp
@@ -313,13 +313,13 @@ TEST_F(LoadTest, Integration) {
       std::make_shared<ad_utility::CancellationHandle<>>();
   QueryPlanner qp(qec, cancellationHandle);
   auto executionTree = qp.createExecutionTree(parsedUpdate[0]);
-  Load* load = dynamic_cast<Load*>(executionTree.getRootOperation().get());
+  Load* load = dynamic_cast<Load*>(executionTree->getRootOperation().get());
   ASSERT_THAT(load, testing::NotNull()) << "Root operation is not a Load";
   load->resetGetResultFunctionForTesting(
       getResultFunctionFactory("<a> <b> <c> . <d> <e> <f>",
                                boost::beast::http::status::ok, "text/turtle"));
   DeltaTriples deltaTriples{qec->getIndex()};
-  ExecuteUpdate::executeUpdate(qec->getIndex(), parsedUpdate[0], executionTree,
+  ExecuteUpdate::executeUpdate(qec->getIndex(), parsedUpdate[0], *executionTree,
                                deltaTriples, cancellationHandle);
   EXPECT_THAT(deltaTriples, deltaTriplesTestHelpers::NumTriples(2, 0, 2));
 }

--- a/test/OperationTest.cpp
+++ b/test/OperationTest.cpp
@@ -56,15 +56,6 @@ void expectRtiHasDimensions(
 }  // namespace
 
 // ________________________________________________
-// _____________________________________________________________________________
-TEST(OperationTest, constructorRequiresQueryExecutionContext) {
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      NeutralElementOperation{nullptr},
-      ::testing::HasSubstr(
-          "An `Operation` requires a `QueryExecutionContext`"));
-}
-
-// _____________________________________________________________________________
 TEST(OperationTest, limitIsRepresentedInCacheKey) {
   LimitOffsetClause l;
   {

--- a/test/OperationTest.cpp
+++ b/test/OperationTest.cpp
@@ -55,7 +55,15 @@ void expectRtiHasDimensions(
 }
 }  // namespace
 
-// ________________________________________________
+// _____________________________________________________________________________
+TEST(OperationTest, constructorRequiresQueryExecutionContext) {
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      NeutralElementOperation{nullptr},
+      ::testing::HasSubstr(
+          "An `Operation` requires a `QueryExecutionContext`"));
+}
+
+// _____________________________________________________________________________
 TEST(OperationTest, limitIsRepresentedInCacheKey) {
   LimitOffsetClause l;
   {

--- a/test/QueryPlannerSpatialJoinTest.cpp
+++ b/test/QueryPlannerSpatialJoinTest.cpp
@@ -1127,7 +1127,7 @@ TEST(QueryPlanner, SpatialJoinS2PointPolylineAndCachedIndex) {
     auto qec = ad_utility::testing::getQec(kb);
     qec->pinResultWithName() = {"dummy", std::nullopt};
     auto plan = h::parseAndPlan(pinned, qec);
-    [[maybe_unused]] auto pinResult = plan.getResult();
+    [[maybe_unused]] auto pinResult = plan->getResult();
 
     AD_EXPECT_THROW_WITH_MESSAGE(
         h::expect(testQuery, ::testing::_, qec),
@@ -1139,7 +1139,7 @@ TEST(QueryPlanner, SpatialJoinS2PointPolylineAndCachedIndex) {
     auto qec = ad_utility::testing::getQec(kb);
     qec->pinResultWithName() = {"dummy", V{"?o"}};
     auto plan = h::parseAndPlan(pinned, qec);
-    [[maybe_unused]] auto pinResult = plan.getResult();
+    [[maybe_unused]] auto pinResult = plan->getResult();
 
     h::expect(
         "PREFIX qlss: <https://qlever.cs.uni-freiburg.de/spatialSearch/>"
@@ -1184,7 +1184,7 @@ TEST(QueryPlanner, SpatialJoinS2PointPolylineAndCachedIndex) {
     auto qec = ad_utility::testing::getQec(kb);
     qec->pinResultWithName() = {"dummy", V{"?o"}};
     auto plan = h::parseAndPlan(pinned, qec);
-    [[maybe_unused]] auto pinResult = plan.getResult();
+    [[maybe_unused]] auto pinResult = plan->getResult();
 
     AD_EXPECT_THROW_WITH_MESSAGE(
         h::expect(

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -491,7 +491,7 @@ TEST(QueryExecutionTreeTest, testCyclicQuery) {
       "SELECT ?x ?y ?m WHERE { ?x <Spouse_(or_domestic_partner)> ?y . "
       "?x <Film_performance> ?m . ?y <Film_performance> ?m }");
   QueryPlanner qp = makeQueryPlanner();
-  QueryExecutionTree qet = qp.createExecutionTree(pq);
+  auto qet = qp.createExecutionTree(pq);
 
   // There are four possible outcomes of this test with the same size
   // estimate. It is currently very hard to make the query planning
@@ -584,7 +584,7 @@ qet-width: 3
 }
 )xxx");
 
-  auto actual = strip(qet.getCacheKey());
+  auto actual = strip(qet->getCacheKey());
 
   if (actual != possible1 && actual != possible2 && actual != possible3 &&
       actual != possible4 && actual != possible5) {
@@ -592,7 +592,7 @@ qet-width: 3
     /*
     FAIL() << "query execution tree is none of the possible trees, it is "
               "actually "
-           << qet.getCacheKey() << '\n' << actual << '\n'
+           << qet->getCacheKey() << '\n' << actual << '\n'
            */
   }
 }
@@ -612,9 +612,9 @@ TEST(QueryExecutionTreeTest, testFormerSegfaultTriFilter) {
       "FILTER (?1 != fb:m.018mts)"
       "} LIMIT 300");
   QueryPlanner qp = makeQueryPlanner();
-  QueryExecutionTree qet = qp.createExecutionTree(pq);
-  ASSERT_TRUE(qet.isVariableCovered(Variable{"?1"}));
-  ASSERT_TRUE(qet.isVariableCovered(Variable{"?0"}));
+  auto qet = qp.createExecutionTree(pq);
+  ASSERT_TRUE(qet->isVariableCovered(Variable{"?1"}));
+  ASSERT_TRUE(qet->isVariableCovered(Variable{"?0"}));
 }
 
 TEST(QueryPlanner, testSimpleOptional) {
@@ -4078,9 +4078,9 @@ TEST(QueryPlanner, SubqueryColumnStripping) {
 
     // The root should have no stripped variables (it's not created via
     // makeTreeWithStrippedColumns)
-    EXPECT_THAT(qet, h::HasNoStrippedVariables());
-    EXPECT_THAT(qet, h::hasVariables({"?x", "?y"}));
-    EXPECT_EQ(qet.getResultWidth(), doStrip ? 2 : 4);
+    EXPECT_THAT(*qet, h::HasNoStrippedVariables());
+    EXPECT_THAT(*qet, h::hasVariables({"?x", "?y"}));
+    EXPECT_EQ(qet->getResultWidth(), doStrip ? 2 : 4);
   }
 }
 
@@ -4129,7 +4129,7 @@ TEST(QueryPlanner, NamedCachedResult) {
       "<s> <p> <o>. <s> <p> <o2> . <s2> <p> <o2>. <s3> <p2> <o2>.");
   qec->pinResultWithName() = {"dummyQuery"};
   auto plan = h::parseAndPlan(queryToPin, qec);
-  [[maybe_unused]] auto pinResult = plan.getResult();
+  [[maybe_unused]] auto pinResult = plan->getResult();
 
   query = "SELECT * { SERVICE ql:cached-result-with-name-dummyQuery {}}";
   // We only check the size estimate (which in this case is exact), because

--- a/test/QueryPlannerTestHelpers.h
+++ b/test/QueryPlannerTestHelpers.h
@@ -626,8 +626,8 @@ class QueryPlannerWithMockFilterSubstitute : public QueryPlanner {
 /// Parse the given SPARQL `query`, pass it to a `QueryPlanner` with empty
 /// execution context, and return the resulting `QueryExecutionTree`
 template <typename QueryPlannerClass = QueryPlanner>
-inline QueryExecutionTree parseAndPlan(std::string query,
-                                       QueryExecutionContext* qec) {
+inline std::shared_ptr<QueryExecutionTree> parseAndPlan(
+    std::string query, QueryExecutionContext* qec) {
   ParsedQuery pq = parseQuery(std::move(query));
   // TODO<joka921> make it impossible to pass `nullptr` here, properly mock
   // a queryExecutionContext.
@@ -635,7 +635,7 @@ inline QueryExecutionTree parseAndPlan(std::string query,
       QueryPlannerClass{qec,
                         std::make_shared<ad_utility::CancellationHandle<>>()}
           .createExecutionTree(pq);
-  tree.isRoot() = true;
+  tree->isRoot() = true;
   return tree;
 }
 
@@ -665,9 +665,9 @@ void expectWithGivenBudget(std::string query, MatcherT matcher,
   QueryExecutionContext* qec =
       optQec.has_value() ? *optQec : ad_utility::testing::getQec();
   auto qet = parseAndPlan<QueryPlannerClass>(std::move(query), qec);
-  qet.getRootOperation()->createRuntimeInfoFromEstimates(
-      qet.getRootOperation()->getRuntimeInfoPointer());
-  EXPECT_THAT(qet, matcher);
+  qet->getRootOperation()->createRuntimeInfoFromEstimates(
+      qet->getRootOperation()->getRuntimeInfoPointer());
+  EXPECT_THAT(*qet, matcher);
 }
 
 // Same as `expectWithGivenBudget` but allows multiple budgets to be tested.

--- a/test/SecondaryVocabularyTest.cpp
+++ b/test/SecondaryVocabularyTest.cpp
@@ -526,7 +526,7 @@ std::string runQuery(QueryExecutionContext* qec, const std::string& query) {
   ad_utility::Timer timer{ad_utility::Timer::Started};
   std::string result;
   for (const auto& block : ExportQueryExecutionTrees::computeResult(
-           parsedQuery, executionTree, ad_utility::MediaType::tsv, timer,
+           parsedQuery, *executionTree, ad_utility::MediaType::tsv, timer,
            cancellationHandle)) {
     result += block;
   }
@@ -565,7 +565,7 @@ void runUpdate(ContextWithSecondaryVocab& context, const std::string& update) {
           QueryPlanner queryPlanner{&context.qec_, cancellationHandle};
           auto executionTree = queryPlanner.createExecutionTree(parsedQuery);
           ExecuteUpdate::executeUpdate(*context.index_, parsedQuery,
-                                       executionTree, deltaTriples,
+                                       *executionTree, deltaTriples,
                                        cancellationHandle);
         }
       });

--- a/test/ServerTest.cpp
+++ b/test/ServerTest.cpp
@@ -183,7 +183,7 @@ TEST(ServerTest, createResponseMetadata) {
   EXPECT_THAT(pqs, testing::SizeIs(1));
   ParsedQuery pq = std::move(pqs[0]);
   QueryPlanner qp(qec, handle);
-  QueryExecutionTree qet = qp.createExecutionTree(pq);
+  auto qet = qp.createExecutionTree(pq);
   const qlever::PlannedQuery plannedQuery{std::move(pq), std::move(qet), *qec};
 
   // Execute the update

--- a/test/engine/NamedResultCacheTest.cpp
+++ b/test/engine/NamedResultCacheTest.cpp
@@ -126,14 +126,14 @@ TEST(NamedResultCache, E2E) {
       "SORT BY ?s";
   qec->pinResultWithName() = {"dummyQuery"};
   auto qet = queryPlannerTestHelpers::parseAndPlan(pinnedQuery, qec);
-  [[maybe_unused]] auto pinnedResult = qet.getResult();
+  [[maybe_unused]] auto pinnedResult = qet->getResult();
 
   qec->pinResultWithName() = std::nullopt;
   std::string query =
       "SELECT ?s { SERVICE ql:cached-result-with-name-dummyQuery {}}";
   qet = queryPlannerTestHelpers::parseAndPlan(query, qec);
   // `false` means `not lazy` so `fully materialized`.
-  auto result = qet.getResult(false);
+  auto result = qet->getResult(false);
 
   auto getId = ad_utility::testing::makeGetId(qec->getIndex());
   LocalVocab dummyVocab;
@@ -148,7 +148,7 @@ TEST(NamedResultCache, E2E) {
   EXPECT_THAT(result->sortedBy(), ::testing::ElementsAre(0));
   VariableToColumnMap expectedVars{
       {Variable{"?s"}, makeAlwaysDefinedColumn(0)}};
-  EXPECT_THAT(qet.getVariableColumns(),
+  EXPECT_THAT(qet->getVariableColumns(),
               ::testing::UnorderedElementsAreArray(expectedVars));
 }
 }  // namespace

--- a/test/engine/QueryExecutionTreeTest.cpp
+++ b/test/engine/QueryExecutionTreeTest.cpp
@@ -307,8 +307,15 @@ TEST(QueryExecutionTree,
 }
 
 // _____________________________________________________________________________
-TEST(QueryExecutionTree, constructorRequiresQueryExecutionContext) {
+TEST(QueryExecutionTree, constructorRequiresQecAndRootOperation) {
+  auto* qec = getQec();
+  auto operation = std::make_shared<ValuesForTesting>(
+      qec, makeIdTableFromVector({{3}}),
+      std::vector<std::optional<Variable>>{Variable{"?x"}});
   AD_EXPECT_THROW_WITH_MESSAGE(
-      QueryExecutionTree{nullptr},
+      QueryExecutionTree(nullptr, operation),
       ::testing::HasSubstr("Assertion `qec_ != nullptr` failed."));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      QueryExecutionTree(qec, nullptr),
+      ::testing::HasSubstr("Assertion `rootOperation_ != nullptr` failed."));
 }

--- a/test/engine/QueryExecutionTreeTest.cpp
+++ b/test/engine/QueryExecutionTreeTest.cpp
@@ -312,13 +312,3 @@ TEST(QueryExecutionTree, constructorRequiresQueryExecutionContext) {
       QueryExecutionTree{nullptr},
       ::testing::HasSubstr("Assertion `qec_ != nullptr` failed."));
 }
-
-// _____________________________________________________________________________
-TEST(QueryExecutionTree, cloneOfEmptyTreeIsEmpty) {
-  QueryExecutionTree tree{getQec()};
-  ASSERT_TRUE(tree.isEmpty());
-  auto clone = tree.clone();
-  ASSERT_NE(clone, nullptr);
-  EXPECT_TRUE(clone->isEmpty());
-  EXPECT_EQ(clone->getQec(), tree.getQec());
-}

--- a/test/engine/SpatialJoinCachedIndexTest.cpp
+++ b/test/engine/SpatialJoinCachedIndexTest.cpp
@@ -58,7 +58,7 @@ TEST_P(SpatialJoinCachedIndexTest, Basic) {
   auto qec = ad_utility::testing::getQec(kb);
   qec->pinResultWithName() = {"dummy", Variable{"?o"}};
   auto plan = queryPlannerTestHelpers::parseAndPlan(pinned, qec);
-  [[maybe_unused]] auto pinResult = plan.getResult();
+  [[maybe_unused]] auto pinResult = plan->getResult();
 
   auto& cache = qec->namedResultCache();
   if (shouldSerialize) {
@@ -132,8 +132,8 @@ TEST_P(SpatialJoinCachedIndexTest, UseOfIndexByS2PointPolylineAlgorithm) {
   auto qec = ad_utility::testing::getQec(kb);
   qec->pinResultWithName() = {"dummy", Variable{"?geo2"}};
   auto plan = queryPlannerTestHelpers::parseAndPlan(pinQuery, qec);
-  const auto pinResultCacheKey = plan.getCacheKey();
-  [[maybe_unused]] auto pinResult = plan.getResult();
+  const auto pinResultCacheKey = plan->getCacheKey();
+  [[maybe_unused]] auto pinResult = plan->getResult();
 
   auto& cache = qec->namedResultCache();
   if (shouldSerialize) {
@@ -211,7 +211,7 @@ TEST_P(SpatialJoinCachedIndexSimplificationTest, WithoutSimplification) {
   auto qec = ad_utility::testing::getQec(kb);
   qec->pinResultWithName() = {"idx", Variable{"?o"}};
   auto plan = queryPlannerTestHelpers::parseAndPlan(query, qec);
-  [[maybe_unused]] auto pinResult = plan.getResult();
+  [[maybe_unused]] auto pinResult = plan->getResult();
 
   auto& cache = qec->namedResultCache();
   if (shouldSerialize) {
@@ -240,7 +240,7 @@ TEST_P(SpatialJoinCachedIndexSimplificationTest, WithSimplification) {
   auto qec = ad_utility::testing::getQec(kb);
   qec->pinResultWithName() = {"idx", Variable{"?o"}, 10.0};
   auto plan = queryPlannerTestHelpers::parseAndPlan(query, qec);
-  [[maybe_unused]] auto pinResult = plan.getResult();
+  [[maybe_unused]] auto pinResult = plan->getResult();
 
   auto& cache = qec->namedResultCache();
   if (shouldSerialize) {

--- a/test/engine/SpatialJoinTest.cpp
+++ b/test/engine/SpatialJoinTest.cpp
@@ -248,10 +248,8 @@ std::shared_ptr<SpatialJoin> makeSpatialJoinFromValues(
       "(?b) {(\"POINT(8.542 47.385)\"^^geo:wktLiteral)}}");
   QueryPlanner qp{qec, sharedHandle};
 
-  auto leftChild =
-      std::make_shared<QueryExecutionTree>(qp.createExecutionTree(pqLeft));
-  auto rightChild =
-      std::make_shared<QueryExecutionTree>(qp.createExecutionTree(pqRight));
+  auto leftChild = qp.createExecutionTree(pqLeft);
+  auto rightChild = qp.createExecutionTree(pqRight);
 
   std::shared_ptr<QueryExecutionTree> spatialJoinOperation =
       ad_utility::makeExecutionTree<SpatialJoin>(

--- a/test/libqlever/QleverTest.cpp
+++ b/test/libqlever/QleverTest.cpp
@@ -943,3 +943,15 @@ TEST(Qlever, makeIndexRebuildConfig) {
                                AllOf(HasSubstr("all already exist"),
                                      HasSubstr("rebuild-previous-index-dir")));
 }
+
+// _____________________________________________________________________________
+// A `PlannedQuery` always needs an actual `QueryExecutionTree`, as all of its
+// accessors dereference it.
+TEST(LibQlever, plannedQueryRequiresQueryExecutionTree) {
+  auto* qec = ad_utility::testing::getQec();
+  ParsedQuery parsedQuery = SparqlParser::parseQuery(
+      &qec->getIndex().encodedIriManager(), "SELECT * { ?s ?p ?o }");
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      PlannedQuery(std::move(parsedQuery), nullptr, *qec),
+      HasSubstr("Assertion `queryExecutionTree_ != nullptr` failed."));
+}

--- a/test/parser/NamedSubqueryTest.cpp
+++ b/test/parser/NamedSubqueryTest.cpp
@@ -61,9 +61,9 @@ void expectEquivalent(std::string queryWithNamedSubqueries,
       std::move(queryWithNamedSubqueries), qec);
   auto treeB =
       queryPlannerTestHelpers::parseAndPlan(std::move(expandedQuery), qec);
-  auto rowsA = canonicalResult(treeA);
+  auto rowsA = canonicalResult(*treeA);
   EXPECT_GT(rowsA.size(), 0u);
-  EXPECT_EQ(rowsA, canonicalResult(treeB));
+  EXPECT_EQ(rowsA, canonicalResult(*treeB));
 }
 
 }  // namespace
@@ -169,7 +169,7 @@ TEST(NamedSubquery, repeatedIncludeHasIdenticalCacheKey) {
       " }",
       qec);
   // Descend to the `UNION` and compare the cache keys of its two children.
-  const QueryExecutionTree* unionTree = &tree;
+  const QueryExecutionTree* unionTree = tree.get();
   while (unionTree->getRootOperation()->getChildren().size() == 1) {
     unionTree = unionTree->getRootOperation()->getChildren().at(0);
   }


### PR DESCRIPTION
So far, a `QueryExecutionTree` could be constructed from a `QueryExecutionContext` alone, without a root operation, and `QueryPlanner::createExecutionTree` returned its tree by value, which left the planner's own `SubtreePlan` in a moved-out state. These were the only two ways to end up with a tree whose root operation is `nullptr`, which several methods of the tree then had to check for. This change removes that constructor, `isEmpty()`, and the null checks, and lets `createExecutionTree` return the `shared_ptr` that the planner holds anyway. A `SubtreePlan` is now always created from a complete tree, via the existing `makeSubtreePlan` helpers where an operation is created.

NOTE: Follow-up to #3361, which had guarded against the `nullptr` case instead of ruling it out.