### PR TITLE
Add `ad_utility::CopyOnWritePtr`, a pointer with copy-on-write semantics

### DIFF
--- a/src/util/CopyOnWritePtr.h
+++ b/src/util/CopyOnWritePtr.h
@@ -40,9 +40,11 @@ namespace ad_utility {
 //
 // Otherwise the following can happen: thread A calls `write()` and sees that
 // the pointee is not shared, thread B then creates a copy, and thread A mutates
-// the pointee in place, which thread B now reads. No copy-on-write scheme can
-// prevent this: a copy that is created while a mutation is in progress observes
-// a partially mutated pointee no matter how the decision to clone is made.
+// the pointee in place, which thread B now reads. This is the price of the
+// `isShared()` check: a scheme that clones on every `write()`, mutates the
+// clone, and only then publishes it would not have this problem, but it would
+// also clone on every write, and avoiding exactly that clone when the pointee
+// is not shared is the point of this class.
 //
 // Everything else is safe without further synchronization: reading via any copy
 // (also concurrently with a `write()` on another copy, which operates on a

--- a/src/util/CopyOnWritePtr.h
+++ b/src/util/CopyOnWritePtr.h
@@ -1,0 +1,87 @@
+// Copyright 2026 The QLever Authors, in particular:
+//
+// 2026 Hannah Bast <bast@cs.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+//
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#ifndef QLEVER_SRC_UTIL_COPYONWRITEPTR_H
+#define QLEVER_SRC_UTIL_COPYONWRITEPTR_H
+
+#include <memory>
+#include <utility>
+
+#include "util/Exception.h"
+
+namespace ad_utility {
+
+// A pointer to a `T` with copy-on-write semantics. Copying a `CopyOnWritePtr`
+// is cheap, because the copies share the pointee. Reading is always possible
+// via the `const` accessors. Writing is only possible via `write()`, which
+// clones the pointee first if (and only if) it is shared with another
+// `CopyOnWritePtr`, so that a mutation never affects any copy that was made
+// before. This is the building block for large structures of which frequent
+// snapshots are taken, but where each mutation between two snapshots only
+// touches a small part.
+//
+// A `CopyOnWritePtr` is never null: the default constructor creates a
+// value-initialized `T`. The only exception is a moved-from `CopyOnWritePtr`,
+// which may only be assigned to or destroyed.
+//
+// IMPORTANT: The decision whether to clone is based on the reference count of
+// the pointee. It is therefore undefined behavior to copy a `CopyOnWritePtr`
+// while another thread calls `write()` on a `CopyOnWritePtr` that shares the
+// same pointee. Copies and writes have to be synchronized externally (in QLever
+// typically by the write lock of the structure that owns the
+// `CopyOnWritePtr`s). Reading via different copies is always safe, also
+// concurrently with a `write()` on one of them, because that `write()` operates
+// on a clone.
+template <typename T>
+class CopyOnWritePtr {
+ private:
+  std::shared_ptr<T> ptr_;
+
+ public:
+  // Create a `CopyOnWritePtr` to a value-initialized `T`.
+  CopyOnWritePtr() : ptr_{std::make_shared<T>()} {}
+
+  // Create a `CopyOnWritePtr` to a copy (or a moved-in instance) of the
+  // `value`.
+  explicit CopyOnWritePtr(T value)
+      : ptr_{std::make_shared<T>(std::move(value))} {}
+
+  // Copying shares the pointee (this is the whole point), moving transfers
+  // it and leaves the moved-from `CopyOnWritePtr` null, see the class comment.
+  CopyOnWritePtr(const CopyOnWritePtr&) = default;
+  CopyOnWritePtr& operator=(const CopyOnWritePtr&) = default;
+  CopyOnWritePtr(CopyOnWritePtr&&) noexcept = default;
+  CopyOnWritePtr& operator=(CopyOnWritePtr&&) noexcept = default;
+
+  // Read access. Never clones.
+  const T& operator*() const { return *ptr_; }
+  const T* operator->() const { return ptr_.get(); }
+  const T& read() const { return *ptr_; }
+
+  // Write access. Clones the pointee first if it is shared with another
+  // `CopyOnWritePtr`, so that the other `CopyOnWritePtr`s keep seeing the old
+  // value. See the IMPORTANT note in the class comment for the synchronization
+  // requirements.
+  T& write() {
+    AD_CONTRACT_CHECK(ptr_ != nullptr);
+    if (isShared()) {
+      ptr_ = std::make_shared<T>(*ptr_);
+    }
+    return *ptr_;
+  }
+
+  // Return `true` if the pointee is currently shared with at least one other
+  // `CopyOnWritePtr`, that is, if the next call to `write()` would clone it.
+  // Mostly useful for tests and assertions.
+  bool isShared() const { return ptr_.use_count() > 1; }
+};
+
+}  // namespace ad_utility
+
+#endif  // QLEVER_SRC_UTIL_COPYONWRITEPTR_H

--- a/src/util/CopyOnWritePtr.h
+++ b/src/util/CopyOnWritePtr.h
@@ -11,6 +11,7 @@
 #define QLEVER_SRC_UTIL_COPYONWRITEPTR_H
 
 #include <memory>
+#include <type_traits>
 #include <utility>
 
 #include "util/Exception.h"
@@ -49,6 +50,9 @@ namespace ad_utility {
 // worst causes one unnecessary clone.
 template <typename T>
 class CopyOnWritePtr {
+  static_assert(std::is_copy_constructible_v<T>,
+                "`write()` has to be able to clone the pointee");
+
  private:
   std::shared_ptr<T> ptr_;
 

--- a/src/util/CopyOnWritePtr.h
+++ b/src/util/CopyOnWritePtr.h
@@ -30,14 +30,23 @@ namespace ad_utility {
 // value-initialized `T`. The only exception is a moved-from `CopyOnWritePtr`,
 // which may only be assigned to or destroyed.
 //
-// IMPORTANT: The decision whether to clone is based on the reference count of
-// the pointee. It is therefore undefined behavior to copy a `CopyOnWritePtr`
-// while another thread calls `write()` on a `CopyOnWritePtr` that shares the
-// same pointee. Copies and writes have to be synchronized externally (in QLever
-// typically by the write lock of the structure that owns the
-// `CopyOnWritePtr`s). Reading via different copies is always safe, also
-// concurrently with a `write()` on one of them, because that `write()` operates
-// on a clone.
+// IMPORTANT NOTE: Creating a copy of a `CopyOnWritePtr` and calling `write()`
+// on a `CopyOnWritePtr` that shares the same pointee must never happen
+// concurrently. They have to be synchronized externally, typically by the write
+// lock of the structure that owns the `CopyOnWritePtr`s. For example, the
+// copies for the snapshots of the delta triples are created and the updates
+// are applied under the same lock.
+//
+// Otherwise the following can happen: thread A calls `write()` and sees that
+// the pointee is not shared, thread B then creates a copy, and thread A mutates
+// the pointee in place, which thread B now reads. No copy-on-write scheme can
+// prevent this: a copy that is created while a mutation is in progress observes
+// a partially mutated pointee no matter how the decision to clone is made.
+//
+// Everything else is safe without further synchronization: reading via any copy
+// (also concurrently with a `write()` on another copy, which operates on a
+// clone), and also destroying a copy concurrently with a `write()`, which at
+// worst causes one unnecessary clone.
 template <typename T>
 class CopyOnWritePtr {
  private:

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -403,6 +403,8 @@ addLinkAndDiscoverTestNoLibs(ResetWhenMovedTest)
 
 addLinkAndDiscoverTestNoLibs(NoCopyNoMoveTest)
 
+addLinkAndDiscoverTestNoLibs(CopyOnWritePtrTest)
+
 addLinkAndDiscoverTestSerial(TimerTest)
 
 addLinkAndDiscoverTest(AlgorithmTest)

--- a/test/CopyOnWritePtrTest.cpp
+++ b/test/CopyOnWritePtrTest.cpp
@@ -11,6 +11,7 @@
 
 #include <string>
 #include <type_traits>
+#include <utility>
 #include <vector>
 
 #include "util/CopyOnWritePtr.h"

--- a/test/CopyOnWritePtrTest.cpp
+++ b/test/CopyOnWritePtrTest.cpp
@@ -1,0 +1,153 @@
+// Copyright 2026 The QLever Authors, in particular:
+//
+// 2026 Hannah Bast <bast@cs.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+//
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#include <gmock/gmock.h>
+
+#include <string>
+#include <type_traits>
+#include <vector>
+
+#include "util/CopyOnWritePtr.h"
+
+using ad_utility::CopyOnWritePtr;
+
+// Test that the default constructor creates a value-initialized `T`.
+TEST(CopyOnWritePtr, defaultConstructorValueInitializes) {
+  CopyOnWritePtr<int> ptr;
+  EXPECT_EQ(*ptr, 0);
+  EXPECT_FALSE(ptr.isShared());
+
+  CopyOnWritePtr<std::vector<int>> vec;
+  EXPECT_TRUE(vec->empty());
+}
+
+// Test the constructor from a value and the three read accessors.
+TEST(CopyOnWritePtr, constructFromValueAndRead) {
+  CopyOnWritePtr<std::string> ptr{"hello"};
+  EXPECT_EQ(*ptr, "hello");
+  EXPECT_EQ(ptr.read(), "hello");
+  EXPECT_EQ(ptr->size(), 5u);
+  EXPECT_FALSE(ptr.isShared());
+}
+
+// Test that `write()` mutates in place as long as nobody shares the value.
+TEST(CopyOnWritePtr, writeWithoutCopyDoesNotClone) {
+  CopyOnWritePtr<std::string> ptr{"hello"};
+  const std::string* addressBefore = &*ptr;
+  ptr.write() += " world";
+  EXPECT_EQ(*ptr, "hello world");
+  EXPECT_EQ(&*ptr, addressBefore);
+}
+
+// Test that a copy shares the value until one of the two writes, and that a
+// write then leaves the other one untouched.
+TEST(CopyOnWritePtr, copiesShareUntilWrite) {
+  CopyOnWritePtr<std::string> original{"hello"};
+  CopyOnWritePtr<std::string> copy = original;
+  EXPECT_EQ(&*original, &*copy);
+  EXPECT_TRUE(original.isShared());
+  EXPECT_TRUE(copy.isShared());
+
+  // The write through `copy` clones, so `original` keeps the old value and
+  // neither of the two is shared any more.
+  copy.write() += " world";
+  EXPECT_EQ(*copy, "hello world");
+  EXPECT_EQ(*original, "hello");
+  EXPECT_NE(&*original, &*copy);
+  EXPECT_FALSE(original.isShared());
+  EXPECT_FALSE(copy.isShared());
+
+  // A further write through `copy` therefore mutates in place.
+  const std::string* addressBefore = &*copy;
+  copy.write() += "!";
+  EXPECT_EQ(*copy, "hello world!");
+  EXPECT_EQ(&*copy, addressBefore);
+  EXPECT_EQ(*original, "hello");
+}
+
+// Test the intended usage: snapshots are copies, and each of them keeps the
+// value from the time it was taken while the original is written to.
+TEST(CopyOnWritePtr, writeThroughOriginalKeepsSnapshotsIntact) {
+  CopyOnWritePtr<std::vector<int>> original{std::vector<int>{1, 2, 3}};
+  CopyOnWritePtr<std::vector<int>> snapshot1 = original;
+  original.write().push_back(4);
+  CopyOnWritePtr<std::vector<int>> snapshot2 = original;
+  original.write().push_back(5);
+
+  EXPECT_THAT(*snapshot1, ::testing::ElementsAre(1, 2, 3));
+  EXPECT_THAT(*snapshot2, ::testing::ElementsAre(1, 2, 3, 4));
+  EXPECT_THAT(*original, ::testing::ElementsAre(1, 2, 3, 4, 5));
+
+  // Each write cloned, so none of the three shares its value any more.
+  EXPECT_FALSE(snapshot1.isShared());
+  EXPECT_FALSE(snapshot2.isShared());
+  EXPECT_FALSE(original.isShared());
+}
+
+// Test that with three pointers to one value, a write through one of them
+// clones only that one and the other two keep sharing.
+TEST(CopyOnWritePtr, sharingIsTransitive) {
+  CopyOnWritePtr<int> a{1};
+  CopyOnWritePtr<int> b = a;
+  CopyOnWritePtr<int> c = b;
+  EXPECT_EQ(&*a, &*c);
+
+  b.write() = 2;
+  EXPECT_EQ(*a, 1);
+  EXPECT_EQ(*b, 2);
+  EXPECT_EQ(*c, 1);
+  EXPECT_TRUE(a.isShared());
+  EXPECT_FALSE(b.isShared());
+  EXPECT_TRUE(c.isShared());
+}
+
+// Test that copy assignment makes the target share the value of the source.
+TEST(CopyOnWritePtr, copyAssignmentSharesAgain) {
+  CopyOnWritePtr<int> a{1};
+  CopyOnWritePtr<int> b{2};
+  EXPECT_NE(&*a, &*b);
+
+  b = a;
+  EXPECT_EQ(&*a, &*b);
+  EXPECT_EQ(*b, 1);
+  EXPECT_TRUE(a.isShared());
+}
+
+// Test that moving transfers the pointer without cloning and without
+// affecting the sharing with other copies.
+TEST(CopyOnWritePtr, moveTransfersWithoutCloning) {
+  CopyOnWritePtr<std::string> a{"hello"};
+  CopyOnWritePtr<std::string> copy = a;
+  const std::string* address = &*a;
+
+  CopyOnWritePtr<std::string> b = std::move(a);
+  EXPECT_EQ(&*b, address);
+  EXPECT_TRUE(b.isShared());
+  EXPECT_TRUE(copy.isShared());
+
+  b.write() += " world";
+  EXPECT_EQ(*b, "hello world");
+  EXPECT_EQ(*copy, "hello");
+}
+
+// Check at compile time that `write()` is the only way to get a mutable
+// reference, so that an accidental mutation of a shared value cannot compile.
+TEST(CopyOnWritePtr, onlyWriteGivesMutableAccess) {
+  static_assert(
+      std::is_same_v<decltype(*std::declval<const CopyOnWritePtr<int>&>()),
+                     const int&>);
+  static_assert(
+      std::is_same_v<decltype(std::declval<CopyOnWritePtr<int>&>().read()),
+                     const int&>);
+  static_assert(
+      std::is_same_v<decltype(std::declval<CopyOnWritePtr<int>&>().write()),
+                     int&>);
+  static_assert(!std::is_invocable_v<decltype(&CopyOnWritePtr<int>::write),
+                                     const CopyOnWritePtr<int>&>);
+}

--- a/test/CopyOnWritePtrTest.cpp
+++ b/test/CopyOnWritePtrTest.cpp
@@ -137,6 +137,26 @@ TEST(CopyOnWritePtr, moveTransfersWithoutCloning) {
   EXPECT_EQ(*copy, "hello");
 }
 
+// Test that move assignment transfers the pointer like move construction.
+TEST(CopyOnWritePtr, moveAssignment) {
+  CopyOnWritePtr<std::string> a{"hello"};
+  CopyOnWritePtr<std::string> b{"other"};
+  const std::string* address = &*a;
+  b = std::move(a);
+  EXPECT_EQ(&*b, address);
+  EXPECT_EQ(*b, "hello");
+  EXPECT_FALSE(b.isShared());
+}
+
+// Test that `write()` on a moved-from pointer is rejected instead of
+// dereferencing a null pointer.
+TEST(CopyOnWritePtr, writeOnMovedFromThrows) {
+  CopyOnWritePtr<int> a{1};
+  CopyOnWritePtr<int> b = std::move(a);
+  EXPECT_EQ(*b, 1);
+  EXPECT_ANY_THROW(a.write());
+}
+
 // Check at compile time that `write()` is the only way to get a mutable
 // reference, so that an accidental mutation of a shared value cannot compile.
 TEST(CopyOnWritePtr, onlyWriteGivesMutableAccess) {


### PR DESCRIPTION
A `CopyOnWritePtr<T>` is cheap to copy (the copies share the pointee), gives read access via `const` accessors only, and clones the pointee in `write()` if and only if it is shared with another `CopyOnWritePtr`. A mutation therefore never affects a copy that was made before, and a mutation that bypasses `write()` is a compile error. This is the building block for structures of which frequent snapshots are taken while each update between two snapshots only touches a small part. Our first two use cases for this will be the located triples and the augmented block metadata of the delta triples.

NOTE: The decision whether to clone is based on the reference count, so copies and writes of `CopyOnWritePtr`s that share a pointee have to be synchronized externally. This is the first of several changes split out of #3267.