### PR TITLE
Move the `applyUpdateToEngine` test helper into a shared header

### DIFF
--- a/test/libqlever/QleverTest.cpp
+++ b/test/libqlever/QleverTest.cpp
@@ -14,6 +14,7 @@
 #include "../util/IdTableHelpers.h"
 #include "../util/IndexTestHelpers.h"
 #include "../util/RuntimeParametersTestHelpers.h"
+#include "QleverTestHelpers.h"
 #include "backports/filesystem.h"
 #include "engine/ExternalValues.h"
 #include "engine/MaterializedViews.h"
@@ -779,26 +780,10 @@ TEST(LibQlever, applyUpdate) {
   EXPECT_EQ(engine.cache().numNonPinnedEntries(), 0U);
 }
 
-namespace {
-// Parse and plan `update` and apply it to `engine` via `Qlever::applyUpdate`,
-// returning the metadata. For why the update has to be parsed separately and
-// for the thread-safety caveat of taking the snapshot only here, see the
-// comments in `LibQlever.applyUpdate` above.
-UpdateMetadata applyUpdateToEngine(Qlever& engine, const std::string& update) {
-  ad_utility::BlankNodeManager bnm;
-  auto parsedUpdates = SparqlParser::parseUpdate(
-      &bnm, ad_utility::testing::encodedIriManager(), update);
-  AD_CORRECTNESS_CHECK(parsedUpdates.size() == 1);
-  auto plannedUpdate =
-      engine.planQuery(engine.bindParsedQuery(std::move(parsedUpdates[0])));
-  auto handle = std::make_shared<ad_utility::CancellationHandle<>>();
-  auto snapshot = engine.indexAndViewsSnapshot();
-  return snapshot->index_.deltaTriplesManager().modify<UpdateMetadata>(
-      [&](DeltaTriples& deltaTriples) {
-        return engine.applyUpdate(plannedUpdate, handle, deltaTriples);
-      });
-}
-}  // namespace
+// `applyUpdateToEngine` (used below) is defined in `QleverTestHelpers.h`; see
+// the comment there for why the update has to be parsed separately and for
+// the thread-safety caveat of taking the snapshot only here.
+using ad_utility::testing::applyUpdateToEngine;
 
 // _____________________________________________________________________________
 // Direct counterpart to `ServerTest.clearDeltaTriples`: populate the delta

--- a/test/libqlever/QleverTestHelpers.h
+++ b/test/libqlever/QleverTestHelpers.h
@@ -1,0 +1,59 @@
+// Copyright 2026 The QLever Authors, in particular:
+//
+// 2026 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+//
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#ifndef QLEVER_TEST_LIBQLEVER_QLEVERTESTHELPERS_H
+#define QLEVER_TEST_LIBQLEVER_QLEVERTESTHELPERS_H
+
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "../util/IndexTestHelpers.h"
+#include "engine/UpdateMetadata.h"
+#include "index/DeltaTriples.h"
+#include "libqlever/Qlever.h"
+#include "parser/SparqlParser.h"
+#include "util/BlankNodeManager.h"
+#include "util/CancellationHandle.h"
+#include "util/Exception.h"
+
+namespace ad_utility::testing {
+
+// Parse and plan `update` and apply it to `engine` via `Qlever::applyUpdate`,
+// returning the metadata. `Qlever::parseQuery`/`parseAndPlanQuery` only accept
+// SPARQL queries, not updates (see `SparqlParser::parseQuery` vs.
+// `parseUpdate`), so an update has to be parsed separately and then planned via
+// `Qlever::bindParsedQuery`.
+//
+// NOTE: The snapshot that provides the `DeltaTriples` is taken only here,
+// independently of the one that the update was planned against. In general
+// this is not thread-safe (a concurrent index rebuild between the two calls
+// would violate the precondition of `applyUpdate`), but the tests that use
+// this helper are single-threaded, and `PlannedQuery` currently does not
+// expose the snapshot it was planned against. See the comments in
+// `LibQlever.applyUpdate` in `QleverTest.cpp` for details.
+inline UpdateMetadata applyUpdateToEngine(qlever::Qlever& engine,
+                                          const std::string& update) {
+  ad_utility::BlankNodeManager blankNodeManager;
+  auto parsedUpdates = SparqlParser::parseUpdate(
+      &blankNodeManager, ad_utility::testing::encodedIriManager(), update);
+  AD_CORRECTNESS_CHECK(parsedUpdates.size() == 1);
+  auto plannedUpdate =
+      engine.planQuery(engine.bindParsedQuery(std::move(parsedUpdates[0])));
+  auto handle = std::make_shared<ad_utility::CancellationHandle<>>();
+  auto snapshot = engine.indexAndViewsSnapshot();
+  return snapshot->index_.deltaTriplesManager().modify<UpdateMetadata>(
+      [&](DeltaTriples& deltaTriples) {
+        return engine.applyUpdate(plannedUpdate, handle, deltaTriples);
+      });
+}
+
+}  // namespace ad_utility::testing
+
+#endif  // QLEVER_TEST_LIBQLEVER_QLEVERTESTHELPERS_H


### PR DESCRIPTION
The test helper `applyUpdateToEngine` parses and plans a SPARQL update and applies it to a `Qlever` engine via `Qlever::applyUpdate`. So far it was a file-local function in `QleverTest.cpp`. This change moves it, unchanged apart from a more detailed comment, into the new shared header `test/libqlever/QleverTestHelpers.h`, so that the upcoming tests of the blob manager (#3369) can use it instead of copying it. Test-only change, split out of #3369.