### PR TITLE
Add a diff mechanism for the vocabulary + named cache blob (stacked)

### DIFF
--- a/src/engine/NamedResultCache.cpp
+++ b/src/engine/NamedResultCache.cpp
@@ -8,8 +8,10 @@
 
 #include <algorithm>
 
+#include "backports/algorithm.h"
 #include "engine/NamedResultCacheSerializer.h"
 #include "util/Serializer/FileSerializer.h"
+#include "util/TransparentFunctors.h"
 
 // _____________________________________________________________________________
 std::shared_ptr<ExplicitIdTableOperation> NamedResultCache::getOperation(
@@ -58,4 +60,20 @@ void NamedResultCache::clear() { cache_.wlock()->clearAll(); }
 // _____________________________________________________________________________
 size_t NamedResultCache::numEntries() const {
   return cache_.rlock()->numNonPinnedEntries();
+}
+
+// _____________________________________________________________________________
+std::vector<std::pair<NamedResultCache::Key,
+                      std::shared_ptr<const NamedResultCache::Value>>>
+NamedResultCache::getAllEntries() const {
+  // Note: We need the (non-const) `wlock` here, because the `operator[]` of the
+  // underlying cache is non-const, see the comment in `get` above.
+  auto lock = cache_.wlock();
+  std::vector<std::pair<Key, std::shared_ptr<const Value>>> entries;
+  for (const auto& key : lock->getAllNonpinnedKeys()) {
+    entries.emplace_back(key, (*lock)[key]);
+    AD_CORRECTNESS_CHECK(entries.back().second != nullptr);
+  }
+  ql::ranges::sort(entries, {}, ad_utility::first);
+  return entries;
 }

--- a/src/engine/NamedResultCache.h
+++ b/src/engine/NamedResultCache.h
@@ -97,6 +97,13 @@ class NamedResultCache {
   std::shared_ptr<ExplicitIdTableOperation> getOperation(
       const Key& name, QueryExecutionContext* qec);
 
+  // Get all entries of the cache, sorted by their key. The order is
+  // deterministic (and not the arbitrary order of the underlying hash map), so
+  // that serializing the same contents twice yields the same bytes, which a
+  // byte-level comparison of serialized caches relies on.
+  std::vector<std::pair<Key, std::shared_ptr<const Value>>> getAllEntries()
+      const;
+
   // NOTE: The following two templated serialization functions are defined in
   // the `NamedResultCacheSerializer.h` header which has to be included by the
   // code that actually calls them to not get any undefined references.

--- a/src/engine/NamedResultCache.h
+++ b/src/engine/NamedResultCache.h
@@ -99,8 +99,8 @@ class NamedResultCache {
 
   // Get all entries of the cache, sorted by their key. The order is
   // deterministic (and not the arbitrary order of the underlying hash map), so
-  // that serializing the same contents twice yields the same bytes, which a
-  // byte-level comparison of serialized caches relies on.
+  // that serializing the same contents twice yields the same bytes, which the
+  // diff mechanism of `NamedCachedQueryBlobManager` relies on.
   std::vector<std::pair<Key, std::shared_ptr<const Value>>> getAllEntries()
       const;
 

--- a/src/engine/NamedResultCacheSerializer.h
+++ b/src/engine/NamedResultCacheSerializer.h
@@ -171,9 +171,9 @@ void writeValue(Serializer& serializer, const NamedResultCache::Value& value,
   // `HashMap` serialization.
   //
   // NOTE: The entries are written sorted by the name of the variable, so that
-  // identical contents yield identical bytes (which a byte-level comparison of
-  // serialized caches relies on). The reading side does not depend on the
-  // order.
+  // identical contents yield identical bytes (which the diff mechanism of
+  // `NamedCachedQueryBlobManager` relies on). The reading side does not depend
+  // on the order.
   serializer << value.varToColMap_.size();
   std::vector<const VariableToColumnMap::value_type*> sortedEntries;
   sortedEntries.reserve(value.varToColMap_.size());

--- a/src/engine/NamedResultCacheSerializer.h
+++ b/src/engine/NamedResultCacheSerializer.h
@@ -10,6 +10,7 @@
 #include <boost/math/tools/roots.hpp>
 #include <cstdint>
 
+#include "backports/algorithm.h"
 #include "engine/NamedResultCache.h"
 #include "util/AllocatorWithLimit.h"
 #include "util/Exception.h"
@@ -42,12 +43,7 @@ CPP_template_def(typename Serializer)(
   serializer << namedResultCacheSerializer::detail::magicByte;
   serializer << namedResultCacheSerializer::detail::formatVersion;
 
-  auto lock = cache_.wlock();
-  std::vector<std::pair<Key, std::shared_ptr<const Value>>> entries;
-  for (const auto& key : lock->getAllNonpinnedKeys()) {
-    entries.emplace_back(key, (*lock)[key]);
-    AD_CORRECTNESS_CHECK(entries.back().second != nullptr);
-  }
+  auto entries = getAllEntries();
 
   // Serialize the number of entries.
   serializer << entries.size();
@@ -110,6 +106,106 @@ CPP_template_def(typename Serializer)(
   }
 }
 
+namespace namedResultCacheSerializer {
+// Write `value` to the `serializer`, in exactly the format that the read
+// branch of the serialization of a `NamedResultCache::Value` below reads.
+//
+// The `columns` (a range of ranges of `Id`, one per column of the result) and
+// the `resultSortedOn` are passed separately, so that a caller can write a
+// *rewritten* version of the `value`: a caller may for example replace the
+// `Id`s that refer to local vocab entries by `Id`s of the main or of a
+// persistent vocabulary, which also invalidates a part of the sort order. The
+// `columns` therefore only have to agree with `value.result_` in their number
+// and in the number of rows, which is checked. If `writeLocalVocabWords` is
+// `false`, the words of the local vocab of the `value` are not written (only
+// its blank node blocks, see `serializeLocalVocabWithoutWords`), because such
+// a caller has stored them elsewhere.
+template <typename Serializer, typename Columns>
+void writeValue(Serializer& serializer, const NamedResultCache::Value& value,
+                const Columns& columns,
+                const std::vector<ColumnIndex>& resultSortedOn,
+                bool writeLocalVocabWords) {
+  static_assert(ad_utility::serialization::WriteSerializer<Serializer>);
+  // Serialize the `LocalVocab` first (required for ID remapping).
+  if (writeLocalVocabWords) {
+    ad_utility::detail::serializeLocalVocab(serializer, value.localVocab_);
+  } else {
+    ad_utility::detail::serializeLocalVocabWithoutWords(serializer,
+                                                        value.localVocab_);
+  }
+
+  // Serialize the `IdTable` (uses the `serializeIds` helper which handles
+  // `LocalVocab` IDs).
+  const auto& resultView = ExplicitIdTableOperation::viewOf(value.result_);
+  serializer << resultView.numRows();
+  serializer << resultView.numColumns();
+  AD_CORRECTNESS_CHECK(ql::ranges::size(columns) == resultView.numColumns());
+  for (const auto& col : columns) {
+    // NOTE: Although the code for serialization of a local vocab above is
+    // already incorporated, we currently still let local vocab entries throw
+    // an exception, because there are some caveats in the serialization that
+    // don't work yet, and will only be mitigated in the future. Note that a
+    // caller that has rewritten the `columns` (see above) has already replaced
+    // all such `Id`s, so this check only applies to the `Id`s that are
+    // actually written. NOTE2: Even though we disallow the local vocab, it is
+    // crucial to serialize the local vocab because of possible added blank
+    // node indices, which we do handle correctly, and which also rely on the
+    // local vocab.
+    // TODO<joka921> Mitigate the inconsistencies in the serializer, and then
+    // allow local vocab entries here.
+    AD_CORRECTNESS_CHECK(
+        ql::ranges::find(col, Datatype::LocalVocabIndex, &Id::getDatatype) ==
+            ql::ranges::end(col),
+        "Named result cache entries that contain local vocab entries "
+        "currently cannot be serialized. Note that local vocab entries can "
+        "also occur if SPARQL UPDATE operations have been performed on the "
+        "index before creating the named cached result.");
+    AD_CORRECTNESS_CHECK(ql::ranges::size(col) == resultView.numRows());
+    ad_utility::detail::serializeIds(serializer, col);
+  }
+
+  // Serialize `VariableToColumnMap` manually (`Variable` is not
+  // default-constructible, so we cannot automatically read the hash map from
+  // a serializer, and therefore for consistency we also manually handle the
+  // writing to the serializer, s.t. we do not depend on the internals of
+  // `HashMap` serialization.
+  //
+  // NOTE: The entries are written sorted by the name of the variable, so that
+  // identical contents yield identical bytes (which a byte-level comparison of
+  // serialized caches relies on). The reading side does not depend on the
+  // order.
+  serializer << value.varToColMap_.size();
+  std::vector<const VariableToColumnMap::value_type*> sortedEntries;
+  sortedEntries.reserve(value.varToColMap_.size());
+  for (const auto& entry : value.varToColMap_) {
+    sortedEntries.push_back(&entry);
+  }
+  ql::ranges::sort(sortedEntries, {},
+                   [](const auto* entry) -> const std::string& {
+                     return entry->first.name();
+                   });
+  for (const auto* entry : sortedEntries) {
+    serializer << entry->first;
+    serializer << entry->second;
+  }
+
+  // Serialize `resultSortedOn` (vector of `ColumnIndex`).
+  serializer << resultSortedOn;
+
+  // Serialize `cacheKey` (string).
+  serializer << value.cacheKey_;
+
+  // Serialize the `cachedGeoIndex_`. Note: The `cachedGeoIndex_` is not
+  // default-constructible, so we use manual serialization (see the comment
+  // above for the manual serialization of the `varToColMap_` for details).
+  bool hasGeoIndex = value.cachedGeoIndex_.has_value();
+  serializer << hasGeoIndex;
+  if (hasGeoIndex) {
+    serializer << value.cachedGeoIndex_.value();
+  }
+}
+}  // namespace namedResultCacheSerializer
+
 namespace ad_utility::serialization {
 
 // Serialization for `NamedResultCache::Value`
@@ -118,59 +214,13 @@ namespace ad_utility::serialization {
 AD_SERIALIZE_FUNCTION_WITH_CONSTRAINT(
     (ad_utility::SimilarTo<T, NamedResultCache::Value>)) {
   if constexpr (WriteSerializer<S>) {
-    // Serialize the LocalVocab first (required for ID remapping).
-    ad_utility::detail::serializeLocalVocab(serializer, arg.localVocab_);
-
-    // Serialize the IdTable (uses the `serializeIds` helper which handles
-    // LocalVocab IDs).
+    // Write the value as it is: with the original columns, the original sort
+    // order, and the words of its local vocab (see `writeValue` above for the
+    // cases in which those are replaced).
     const auto& resultView = ExplicitIdTableOperation::viewOf(arg.result_);
-    serializer << resultView.numRows();
-    serializer << resultView.numColumns();
-    for (const auto& col : resultView.getColumns()) {
-      // NOTE: Although the code for serialization of a local vocab above is
-      // already incorporated, we currently still let local vocab entries throw
-      // an exception, because there are some caveats in the serialization that
-      // don't work yet, and will only be mitigated in the future. NOTE2: Even
-      // though we disallow the local vocab, it is crucial to serialize the
-      // local vocab because of possible added blank node indices, which we do
-      // handle correctly, and which also rely on the local vocab.
-      // TODO<joka921> Mitigate the inconsistencies in the serializer, and then
-      // allow local vocab entries here.
-      AD_CORRECTNESS_CHECK(
-          ql::ranges::find(col, Datatype::LocalVocabIndex, &Id::getDatatype) ==
-              col.end(),
-          "Named result cache entries that contain local vocab entries "
-          "currently cannot be serialized. Note that local vocab entries can "
-          "also occur if SPARQL UPDATE operations have been performed on the "
-          "index before creating the named cached result.");
-      ad_utility::detail::serializeIds(serializer, col);
-    }
-
-    // Serialize VariableToColumnMap manually (`Variable` is not
-    // default-constructible, so we cannot automatically read the hash map from
-    // a serializer, and therefore for consistency we also manually handling the
-    // writing to the serializer, s.t. we do not depend on the internals of
-    // HashMap serialization.
-    serializer << arg.varToColMap_.size();
-    for (const auto& [var, colInfo] : arg.varToColMap_) {
-      serializer << var;
-      serializer << colInfo;
-    }
-
-    // Serialize resultSortedOn (vector of ColumnIndex).
-    serializer << arg.resultSortedOn_;
-
-    // Serialize cacheKey (string).
-    serializer << arg.cacheKey_;
-
-    // Serialize the `cachedGeoIndex_`. Note: The `cachedGeoIndex_` is not
-    // default-constructible, so we use manual serialization (see the comment
-    // above for the manual serialization of the `varToColMap_` for details).
-    bool hasGeoIndex = arg.cachedGeoIndex_.has_value();
-    serializer << hasGeoIndex;
-    if (hasGeoIndex) {
-      serializer << arg.cachedGeoIndex_.value();
-    }
+    namedResultCacheSerializer::writeValue(
+        serializer, arg, resultView.getColumns(), arg.resultSortedOn_,
+        /*writeLocalVocabWords=*/true);
   } else {
     // Deserialize the LocalVocab and get the ID mapping.
     AD_CORRECTNESS_CHECK(arg.contextForSerialization_ != nullptr);

--- a/src/engine/NamedResultCacheSerializer.h
+++ b/src/engine/NamedResultCacheSerializer.h
@@ -112,14 +112,14 @@ namespace namedResultCacheSerializer {
 //
 // The `columns` (a range of ranges of `Id`, one per column of the result) and
 // the `resultSortedOn` are passed separately, so that a caller can write a
-// *rewritten* version of the `value`: a caller may for example replace the
-// `Id`s that refer to local vocab entries by `Id`s of the main or of a
-// persistent vocabulary, which also invalidates a part of the sort order. The
+// *rewritten* version of the `value`: `NamedCachedQueryBlobManager` replaces
+// the `Id`s that refer to local vocab entries by `Id`s of the main or the
+// secondary vocabulary, which also invalidates a part of the sort order. The
 // `columns` therefore only have to agree with `value.result_` in their number
 // and in the number of rows, which is checked. If `writeLocalVocabWords` is
 // `false`, the words of the local vocab of the `value` are not written (only
-// its blank node blocks, see `serializeLocalVocabWithoutWords`), because such
-// a caller has stored them elsewhere.
+// its blank node blocks, see `serializeLocalVocabWithoutWords`), because the
+// caller has stored them elsewhere.
 template <typename Serializer, typename Columns>
 void writeValue(Serializer& serializer, const NamedResultCache::Value& value,
                 const Columns& columns,

--- a/src/global/ValueIdComparators.h
+++ b/src/global/ValueIdComparators.h
@@ -531,9 +531,12 @@ inline bool areTypesCompatible(Datatype typeA, Datatype typeB) {
 // (`FILTER`, `ORDER BY`, the range filters above, and the prefilters in
 // `PrefilterExpressionIndex.cpp`) silently yield wrong results.
 //
-// This is deliberate for now: nothing but a unit test can currently create a
-// secondary vocabulary (see `IndexImpl::setSecondaryVocab`), so no
-// query is affected. It has to be fixed *before* anything else creates one.
+// This is deliberate for now: currently only unit tests and
+// `NamedCachedQueryBlobManager::deserialize` (for a blob whose named cache
+// entries contain new words) create a secondary vocabulary (see
+// `IndexImpl::setSecondaryVocab`), so only queries on such a blob-loaded
+// instance are affected, and the resulting inconsistency is accepted there.
+// It has to be fixed *before* anything else creates one.
 // The fix requires the semantically correct position of each word of the
 // secondary vocabulary within the main vocabulary, which the secondary
 // vocabulary will store, and it will most likely mean that this function must

--- a/src/global/ValueIdComparators.h
+++ b/src/global/ValueIdComparators.h
@@ -532,7 +532,7 @@ inline bool areTypesCompatible(Datatype typeA, Datatype typeB) {
 // `PrefilterExpressionIndex.cpp`) silently yield wrong results.
 //
 // This is deliberate for now: nothing but a unit test can currently create a
-// secondary vocabulary (see `IndexImpl::setSecondaryVocabForTesting`), so no
+// secondary vocabulary (see `IndexImpl::setSecondaryVocab`), so no
 // query is affected. It has to be fixed *before* anything else creates one.
 // The fix requires the semantically correct position of each word of the
 // secondary vocabulary within the main vocabulary, which the secondary

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -281,20 +281,23 @@ class IndexImpl {
   // the `Id`s of a secondary vocabulary are only valid for the very vocabulary
   // that they were created for.
   //
-  // TODO<joka921> Nothing sets this yet, except for unit tests. It will be set
-  // when the index is read from disk, together with the persisted data that
-  // the words belong to; until then the only way to obtain a secondary
-  // vocabulary is `setSecondaryVocabForTesting`.
+  // This is currently set only by tests (via
+  // `TestIndexConfig::secondaryVocabWords`, see
+  // `test/util/IndexTestHelpers.h`). It is meant to eventually be set by code
+  // that loads persisted data (e.g. the blobs of `NamedCachedQueryBlobManager`,
+  // in a follow-up change). It has to be set before the first query is
+  // answered (in particular, before any `LocalVocabEntry` computes its position
+  // in the vocabulary, see `positionInVocab()`), and is immutable afterwards.
   const SecondaryVocabulary* secondaryVocab() const {
     return secondaryVocab_.get();
   }
 
-  // Set the secondary vocabulary, see above. NOTE: Tests that need an index
-  // with a secondary vocabulary should not call this directly, but set
-  // `TestIndexConfig::secondaryVocabWords` (see
-  // `test/util/IndexTestHelpers.h`), such that the vocabulary is part of the
-  // index right from its creation.
-  void setSecondaryVocabForTesting(
+  // Set the secondary vocabulary, see above. PRECONDITION: Must only be called
+  // before the first query is answered (e.g. right after construction). NOTE:
+  // This setter is not named `setSecondaryVocabForTesting` even though only
+  // tests currently call it, because it is about to get a non-test caller
+  // (see above).
+  void setSecondaryVocab(
       std::shared_ptr<const SecondaryVocabulary> secondaryVocab) {
     secondaryVocab_ = std::move(secondaryVocab);
   }

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -281,11 +281,10 @@ class IndexImpl {
   // the `Id`s of a secondary vocabulary are only valid for the very vocabulary
   // that they were created for.
   //
-  // This is currently set only by tests (via
-  // `TestIndexConfig::secondaryVocabWords`, see
-  // `test/util/IndexTestHelpers.h`). It is meant to eventually be set by code
-  // that loads persisted data (e.g. the blobs of `NamedCachedQueryBlobManager`,
-  // in a follow-up change). It has to be set before the first query is
+  // This is set either by tests (via `TestIndexConfig::secondaryVocabWords`,
+  // see `test/util/IndexTestHelpers.h`), or by
+  // `NamedCachedQueryBlobManager::deserialize` when the blob that it loads
+  // contains a secondary vocabulary. It has to be set before the first query is
   // answered (in particular, before any `LocalVocabEntry` computes its position
   // in the vocabulary, see `positionInVocab()`), and is immutable afterwards.
   const SecondaryVocabulary* secondaryVocab() const {
@@ -293,10 +292,9 @@ class IndexImpl {
   }
 
   // Set the secondary vocabulary, see above. PRECONDITION: Must only be called
-  // before the first query is answered (e.g. right after construction). NOTE:
-  // This setter is not named `setSecondaryVocabForTesting` even though only
-  // tests currently call it, because it is about to get a non-test caller
-  // (see above).
+  // before the first query is answered (e.g. right after construction, or by
+  // `NamedCachedQueryBlobManager::deserialize` while it is still assembling the
+  // index).
   void setSecondaryVocab(
       std::shared_ptr<const SecondaryVocabulary> secondaryVocab) {
     secondaryVocab_ = std::move(secondaryVocab);

--- a/src/index/LocalVocabEntry.h
+++ b/src/index/LocalVocabEntry.h
@@ -51,7 +51,7 @@ class LocalVocabContext;
 // `valueIdComparators::detail::compareIdsImpl`.
 //
 // This is deliberate for now: nothing but a unit test can currently create a
-// secondary vocabulary (see `IndexImpl::setSecondaryVocabForTesting`), so no
+// secondary vocabulary (see `IndexImpl::setSecondaryVocab`), so no
 // query is affected. It has to be fixed *before* anything else creates one,
 // most likely by keeping the position in the main vocabulary (which is what a
 // semantic comparison needs, and which can always be computed from the word)

--- a/src/index/LocalVocabEntry.h
+++ b/src/index/LocalVocabEntry.h
@@ -50,9 +50,12 @@ class LocalVocabContext;
 // prefilters), see the detailed note at
 // `valueIdComparators::detail::compareIdsImpl`.
 //
-// This is deliberate for now: nothing but a unit test can currently create a
-// secondary vocabulary (see `IndexImpl::setSecondaryVocab`), so no
-// query is affected. It has to be fixed *before* anything else creates one,
+// This is deliberate for now: currently only unit tests and
+// `NamedCachedQueryBlobManager::deserialize` (for a blob whose named cache
+// entries contain new words) create a secondary vocabulary (see
+// `IndexImpl::setSecondaryVocab`), so only queries on such a blob-loaded
+// instance are affected, and the resulting inconsistency is accepted there.
+// It has to be fixed *before* anything else creates one,
 // most likely by keeping the position in the main vocabulary (which is what a
 // semantic comparison needs, and which can always be computed from the word)
 // separately from the position in the internal order, and by exposing the two

--- a/src/index/vocabulary/SecondaryVocabulary.cpp
+++ b/src/index/vocabulary/SecondaryVocabulary.cpp
@@ -15,27 +15,80 @@
 #include "util/Exception.h"
 
 // _____________________________________________________________________________
-SecondaryVocabulary::SecondaryVocabulary(std::vector<std::string> words)
-    : words_{std::move(words)} {
-  AD_CONTRACT_CHECK(ql::ranges::is_sorted(words_),
-                    "The words of a secondary vocabulary have to be sorted");
-  AD_CONTRACT_CHECK(ql::ranges::adjacent_find(words_) == words_.end(),
-                    "The words of a secondary vocabulary have to be distinct");
+SecondaryVocabulary::SecondaryVocabulary(std::vector<std::string> words) {
+  CompactVectorOfStrings<char> segment;
+  segment.build(words);
+  appendSegment(std::move(segment));
 }
+
+// _____________________________________________________________________________
+void SecondaryVocabulary::appendSegment(CompactVectorOfStrings<char> segment) {
+  // Check that the words within `segment` are pairwise distinct, via a sorted
+  // copy of the words (the segment itself may be in arbitrary order).
+  std::vector<std::string_view> wordsOfSegment(segment.begin(), segment.end());
+  ql::ranges::sort(wordsOfSegment);
+  AD_CONTRACT_CHECK(
+      ql::ranges::adjacent_find(wordsOfSegment) == wordsOfSegment.end(),
+      "The words of a secondary vocabulary have to be distinct");
+
+  // Check that none of the words of `segment` is already contained in this
+  // vocabulary. NOTE: This has to happen before `segment` is appended below,
+  // because `getId` must only find the words that were already contained.
+  for (std::string_view word : wordsOfSegment) {
+    AD_CONTRACT_CHECK(
+        !getId(word).has_value(),
+        "The words of a secondary vocabulary have to be distinct");
+  }
+
+  segmentOffsets_.push_back(numWords());
+  segments_.push_back(std::move(segment));
+  rebuildSortedIndices();
+}
+
+// _____________________________________________________________________________
+size_t SecondaryVocabulary::numWords() const {
+  if (segments_.empty()) {
+    return 0;
+  }
+  return segmentOffsets_.back() + segments_.back().size();
+}
+
+// _____________________________________________________________________________
+size_t SecondaryVocabulary::numSegments() const { return segments_.size(); }
 
 // _____________________________________________________________________________
 std::string_view SecondaryVocabulary::operator[](
     SecondaryVocabIndex index) const {
-  AD_CONTRACT_CHECK(index.get() < words_.size());
-  return words_[index.get()];
+  uint64_t globalIndex = index.get();
+  AD_CONTRACT_CHECK(globalIndex < numWords());
+  auto it = ql::ranges::upper_bound(segmentOffsets_, globalIndex);
+  size_t segmentIdx = static_cast<size_t>(it - segmentOffsets_.begin()) - 1;
+  return segments_.at(segmentIdx)[globalIndex - segmentOffsets_[segmentIdx]];
 }
 
 // _____________________________________________________________________________
 std::optional<SecondaryVocabIndex> SecondaryVocabulary::getId(
     std::string_view word) const {
-  auto it = ql::ranges::lower_bound(words_, word);
-  if (it == words_.end() || *it != word) {
+  auto project = [this](uint64_t globalIndex) { return wordAt(globalIndex); };
+  auto it = ql::ranges::lower_bound(sortedIndices_, word, {}, project);
+  if (it == sortedIndices_.end() || project(*it) != word) {
     return std::nullopt;
   }
-  return SecondaryVocabIndex::make(static_cast<uint64_t>(it - words_.begin()));
+  return SecondaryVocabIndex::make(*it);
+}
+
+// _____________________________________________________________________________
+void SecondaryVocabulary::rebuildSortedIndices() {
+  sortedIndices_.clear();
+  sortedIndices_.reserve(numWords());
+  for (uint64_t i = 0; i < numWords(); ++i) {
+    sortedIndices_.push_back(i);
+  }
+  auto project = [this](uint64_t globalIndex) { return wordAt(globalIndex); };
+  ql::ranges::sort(sortedIndices_, {}, project);
+}
+
+// _____________________________________________________________________________
+std::string_view SecondaryVocabulary::wordAt(uint64_t globalIndex) const {
+  return (*this)[SecondaryVocabIndex::make(globalIndex)];
 }

--- a/src/index/vocabulary/SecondaryVocabulary.h
+++ b/src/index/vocabulary/SecondaryVocabulary.h
@@ -33,10 +33,10 @@
 // *segments* (see `appendSegment`). The `Id` of a word is its position in that
 // insertion order (the global index over the concatenation of all segments,
 // in the order in which they were appended), and it never changes when
-// further segments are appended. This is what allows persisted data (in
-// particular the blobs of `NamedCachedQueryBlobManager`, in a follow-up
-// change) to add words incrementally, one segment at a time, without
-// invalidating the `Id`s of the earlier segments.
+// further segments are appended. That is what allows a blob (see
+// `NamedCachedQueryBlobManager`) to add words to the secondary vocabulary
+// incrementally, one segment at a time, without invalidating the `Id`s that
+// were already handed out for the words of the earlier segments.
 //
 // There is no *semantic* (that is, by string value) order among the words of
 // this vocabulary; they compare by their `Id`s alone, which is why all `Id`s
@@ -78,9 +78,8 @@ class SecondaryVocabulary {
   // ones of the previously last segment. None of `segment`'s words may already
   // be contained in this vocabulary (across all of its segments), and the
   // words within `segment` itself have to be pairwise distinct; both of these
-  // are checked. This is the operation that will let persisted data (in
-  // particular the blobs of `NamedCachedQueryBlobManager`, in a follow-up
-  // change) load its segments into the secondary vocabulary of the
+  // are checked. This is the operation that `NamedCachedQueryBlobManager` uses
+  // to load the segments of a blob into the secondary vocabulary of the
   // corresponding index, one segment at a time. NOTE: If `segment` is a
   // zero-copy view (see `CompactVectorOfStrings::fromZeroCopyDeserializer`),
   // the buffer that it points into has to outlive this `SecondaryVocabulary`.

--- a/src/index/vocabulary/SecondaryVocabulary.h
+++ b/src/index/vocabulary/SecondaryVocabulary.h
@@ -33,10 +33,11 @@
 // *segments* (see `appendSegment`). The `Id` of a word is its position in that
 // insertion order (the global index over the concatenation of all segments,
 // in the order in which they were appended), and it never changes when
-// further segments are appended. That is what allows a blob (see
-// `NamedCachedQueryBlobManager`) to add words to the secondary vocabulary
-// incrementally, one segment at a time, without invalidating the `Id`s that
-// were already handed out for the words of the earlier segments.
+// further segments are appended. That is what allows a blob (and a blob diff
+// on top of an existing blob, see `NamedCachedQueryBlobManager`) to add words
+// to the secondary vocabulary incrementally, one segment at a time, without
+// invalidating the `Id`s that were already handed out for the words of the
+// earlier segments.
 //
 // There is no *semantic* (that is, by string value) order among the words of
 // this vocabulary; they compare by their `Id`s alone, which is why all `Id`s
@@ -79,10 +80,11 @@ class SecondaryVocabulary {
   // be contained in this vocabulary (across all of its segments), and the
   // words within `segment` itself have to be pairwise distinct; both of these
   // are checked. This is the operation that `NamedCachedQueryBlobManager` uses
-  // to load the segments of a blob into the secondary vocabulary of the
-  // corresponding index, one segment at a time. NOTE: If `segment` is a
-  // zero-copy view (see `CompactVectorOfStrings::fromZeroCopyDeserializer`),
-  // the buffer that it points into has to outlive this `SecondaryVocabulary`.
+  // to load the segments of a blob (and, for a blob that was reconstructed
+  // from a diff, of the blobs that it was diffed against) into the secondary
+  // vocabulary of the corresponding index. NOTE: If `segment` is a zero-copy
+  // view (see `CompactVectorOfStrings::fromZeroCopyDeserializer`), the buffer
+  // that it points into has to outlive this `SecondaryVocabulary`.
   void appendSegment(CompactVectorOfStrings<char> segment);
 
   // Return the number of words across all segments.

--- a/src/index/vocabulary/SecondaryVocabulary.h
+++ b/src/index/vocabulary/SecondaryVocabulary.h
@@ -10,12 +10,14 @@
 #ifndef QLEVER_SRC_INDEX_VOCABULARY_SECONDARYVOCABULARY_H
 #define QLEVER_SRC_INDEX_VOCABULARY_SECONDARYVOCABULARY_H
 
+#include <cstdint>
 #include <optional>
 #include <string>
 #include <string_view>
 #include <vector>
 
 #include "global/IndexTypes.h"
+#include "util/CompactStringVector.h"
 
 // The secondary vocabulary of an index. It stores words that were added after
 // the main index was built and that are not part of the vocabulary of that
@@ -27,37 +29,68 @@
 // of the main vocabulary when compared bitwise, which is what makes those
 // words mergeable into a scan of the main index.
 //
-// TODO<joka921> This currently is a minimal placeholder that simply holds all
-// its words in RAM and that is only ever filled explicitly by unit tests (see
-// `IndexImpl::setSecondaryVocabForTesting`). The actual implementation stores
-// the words on disk, using the same vocabulary type (and hence the same split
-// into sub-vocabularies) as the main index, and it additionally stores, for
-// each of its words, the position at which that word would be sorted into the
-// main vocabulary. The latter is what a *semantic* (that is, by string value)
-// comparison of an `Id` of this vocabulary with an `Id` of the main vocabulary
-// needs; it follows in the changes that build on this one.
+// The words are kept in RAM, in insertion order, as an append-only sequence of
+// *segments* (see `appendSegment`). The `Id` of a word is its position in that
+// insertion order (the global index over the concatenation of all segments,
+// in the order in which they were appended), and it never changes when
+// further segments are appended. This is what allows persisted data (in
+// particular the blobs of `NamedCachedQueryBlobManager`, in a follow-up
+// change) to add words incrementally, one segment at a time, without
+// invalidating the `Id`s of the earlier segments.
+//
+// There is no *semantic* (that is, by string value) order among the words of
+// this vocabulary; they compare by their `Id`s alone, which is why all `Id`s
+// of this vocabulary compare greater than all `Id`s of the main vocabulary.
+//
+// TODO<joka921> The eventual implementation additionally stores, for each
+// word, the position at which that word would be sorted into the main
+// vocabulary, which a *semantic* comparison of an `Id` of this vocabulary with
+// an `Id` of the main vocabulary needs; it follows in the changes that build
+// on this one.
 class SecondaryVocabulary {
  private:
-  // The words, in strictly ascending order, see the constructor.
-  std::vector<std::string> words_;
+  // The words, stored as an append-only sequence of segments, each of which
+  // holds its words in the order in which they were appended to that segment.
+  std::vector<CompactVectorOfStrings<char>> segments_;
+
+  // For each segment, the global index of its first word, that is, the sum of
+  // the sizes of all the segments that precede it. Has the same number of
+  // elements as `segments_`.
+  std::vector<uint64_t> segmentOffsets_;
+
+  // The global indices of all words, sorted by the word that each of them
+  // refers to (using `std::string_view`'s comparison). Rebuilt whenever a
+  // segment is appended, so that `getId` can look up a word by binary search.
+  std::vector<uint64_t> sortedIndices_;
 
  public:
   SecondaryVocabulary() = default;
 
-  // Create a vocabulary that holds the given `words`, none of which may be
-  // contained in the vocabulary of the main index. The words have to be in
-  // strictly ascending order with respect to `std::string`'s comparison, which
-  // is checked, so that they can be looked up by binary search.
-  //
-  // NOTE: The actual implementation will instead order its words by the
-  // comparator of the vocabulary of the main index at the `TOTAL` level, which
-  // this placeholder has no access to. The two orders do not agree in general,
-  // so the words that the unit tests use are deliberately chosen such that they
-  // do (see `test/SecondaryVocabularyTest.cpp`).
+  // Create a vocabulary that holds the given `words` as a single segment,
+  // none of which may be contained in the vocabulary of the main index. The
+  // words may be in any order, because the `Id` of a word is its position in
+  // `words`; they have to be pairwise distinct, which is checked.
   explicit SecondaryVocabulary(std::vector<std::string> words);
 
-  // Return the number of words.
-  size_t numWords() const { return words_.size(); }
+  // Append `segment` as a new segment of this vocabulary. The `Id`s of all the
+  // words that were already contained in this vocabulary stay unchanged;
+  // `segment`'s words are assigned the global indices that directly follow the
+  // ones of the previously last segment. None of `segment`'s words may already
+  // be contained in this vocabulary (across all of its segments), and the
+  // words within `segment` itself have to be pairwise distinct; both of these
+  // are checked. This is the operation that will let persisted data (in
+  // particular the blobs of `NamedCachedQueryBlobManager`, in a follow-up
+  // change) load its segments into the secondary vocabulary of the
+  // corresponding index, one segment at a time. NOTE: If `segment` is a
+  // zero-copy view (see `CompactVectorOfStrings::fromZeroCopyDeserializer`),
+  // the buffer that it points into has to outlive this `SecondaryVocabulary`.
+  void appendSegment(CompactVectorOfStrings<char> segment);
+
+  // Return the number of words across all segments.
+  size_t numWords() const;
+
+  // Return the number of segments.
+  size_t numSegments() const;
 
   // Return the word with the given index.
   std::string_view operator[](SecondaryVocabIndex index) const;
@@ -65,6 +98,16 @@ class SecondaryVocabulary {
   // Look up `word`. Return its index if it is contained in this vocabulary, and
   // `std::nullopt` otherwise.
   std::optional<SecondaryVocabIndex> getId(std::string_view word) const;
+
+ private:
+  // Rebuild `sortedIndices_` from scratch, sorting the global indices of all
+  // currently contained words by the word that each of them refers to.
+  void rebuildSortedIndices();
+
+  // Return the word with the given global index. Used as the projection that
+  // sorts (and looks up) global indices by the word that each of them refers
+  // to, in `getId` and `rebuildSortedIndices`.
+  std::string_view wordAt(uint64_t globalIndex) const;
 };
 
 #endif  // QLEVER_SRC_INDEX_VOCABULARY_SECONDARYVOCABULARY_H

--- a/src/libqlever/NamedCachedQueryBlobManager.cpp
+++ b/src/libqlever/NamedCachedQueryBlobManager.cpp
@@ -15,13 +15,22 @@
 #include <cstdint>
 #include <string_view>
 #include <type_traits>
+#include <utility>
 
+#include "backports/algorithm.h"
+#include "engine/NamedResultCacheSerializer.h"
 #include "index/IndexImpl.h"
 #include "index/vocabulary/BuildFilteredVocabulary.h"
 #include "index/vocabulary/PolymorphicVocabulary.h"
+#include "index/vocabulary/SecondaryVocabulary.h"
 #include "libqlever/Qlever.h"
+#include "util/CompactStringVector.h"
 #include "util/CompressionUsingZstd/ZstdWrapper.h"
+#include "util/HashMap.h"
 #include "util/Random.h"
+#include "util/Serializer/SerializeArrayOrTuple.h"
+#include "util/Serializer/SerializeString.h"
+#include "util/Serializer/SerializeVector.h"
 #include "util/json.h"
 
 namespace qlever {
@@ -33,7 +42,7 @@ namespace {
 // loading a blob written by an incompatible version of QLever.
 constexpr std::array<char, 8> blobMagicBytes{'Q', 'L', 'V', 'R',
                                              'B', 'L', 'O', 'B'};
-constexpr uint16_t blobFormatVersion = 1;
+constexpr uint16_t blobFormatVersion = 2;
 
 // The number of bytes written by `writeBlobHeader`. Note that no alignment
 // padding is inserted between the two members, because `blobMagicBytes` has an
@@ -56,6 +65,35 @@ constexpr std::string_view blobContentsNotReadableMessage =
     "`Qlever::serializeVocabAndNamedCacheToCompressedBlob`; the blob is "
     "probably corrupted";
 
+// The precondition of `serialize`, see the comment at
+// `NamedCachedQueryBlobManager::serialize`.
+constexpr std::string_view noSecondaryVocabularyMessage =
+    "A blob can only be created from an index without a secondary vocabulary. "
+    "In particular, a `Qlever` instance that was itself loaded from a blob "
+    "whose named cache entries contained new words cannot be used to create "
+    "another blob";
+
+// The alignment to which the beginning of every chunk, and hence also the
+// beginning of every chunk payload, is padded (see
+// `NamedCachedQueryBlobManager::parseBlobLayout` for the chunk format and for
+// why this matters).
+constexpr size_t chunkAlignment = alignof(std::max_align_t);
+using BlobLayout = NamedCachedQueryBlobManager::BlobLayout;
+static_assert(BlobLayout::chunkHeaderSize == chunkAlignment);
+// The chunk header consists of the `uint64_t` size field plus the padding that
+// aligns the payload, so the alignment has to leave room for that size field,
+// and it has to be a multiple of its alignment.
+static_assert(chunkAlignment >= sizeof(uint64_t));
+static_assert(chunkAlignment % alignof(uint64_t) == 0);
+
+// The serializer types that the blob format uses. Note that a blob is written
+// and read with *aligned* serialization, which is what makes the zero-copy
+// deserialization possible.
+using BlobWriter = ad_utility::serialization::AlignedByteBufferWriteSerializer;
+using BlobReader =
+    ad_utility::serialization::ByteBufferReadSerializerT<true,
+                                                         ql::span<const char>>;
+
 // Run `function` and, if it throws, rethrow with `message` prepended. That way,
 // the rather cryptic low-level error messages (in particular those of ZSTD)
 // never reach the user unadorned.
@@ -69,13 +107,134 @@ decltype(auto) rethrowWithContext(std::string_view message,
   }
 }
 
+// The positions that `endChunk` needs to complete a chunk that `beginChunk`
+// has started.
+struct ChunkHandle {
+  // The position of the `uint64_t` size field of the chunk.
+  size_t sizeFieldPosition_;
+  // The position at which the payload of the chunk begins.
+  size_t payloadPosition_;
+};
+
+// Pad the `writer` with zeros up to the next multiple of `chunkAlignment`.
+void padToChunkAlignment(BlobWriter& writer) {
+  ad_utility::serialization::alignSerializerForType<std::max_align_t>(writer);
+}
+
+// Begin a new chunk (see `NamedCachedQueryBlobManager::parseBlobLayout` for the
+// format): pad to the chunk alignment, write a placeholder for the size of the
+// payload, and pad again, so that the payload begins at a multiple of the chunk
+// alignment. The size is only known once the payload has been written, and is
+// patched by `endChunk`.
+[[nodiscard]] ChunkHandle beginChunk(BlobWriter& writer) {
+  padToChunkAlignment(writer);
+  size_t sizeFieldPosition = writer.getCurrentPosition();
+  writer << uint64_t{0};
+  padToChunkAlignment(writer);
+  return {sizeFieldPosition, writer.getCurrentPosition()};
+}
+
+// Complete the chunk that `beginChunk` returned the `handle` for, by patching
+// its size field with the number of payload bytes that have been written since.
+void endChunk(BlobWriter& writer, const ChunkHandle& handle) {
+  uint64_t payloadSize = writer.getCurrentPosition() - handle.payloadPosition_;
+  writer.overwriteBytes(handle.sizeFieldPosition_,
+                        reinterpret_cast<const char*>(&payloadSize),
+                        sizeof(payloadSize));
+}
+
+// Write one complete chunk whose payload is written by `writePayload`.
+template <typename Function>
+void writeChunk(BlobWriter& writer, const Function& writePayload) {
+  auto handle = beginChunk(writer);
+  writePayload(writer);
+  endChunk(writer, handle);
+}
+
+// One chunk, as returned by `readChunk`.
+struct Chunk {
+  BlobLayout::Region region_;
+  ql::span<const char> payload_;
+};
+
+// Read the next chunk from `reader` (which must be positioned at its
+// beginning), and advance the `reader` past it. Note that the payload is a
+// zero-copy view into the buffer of the `reader`, which therefore has to
+// outlive the returned `Chunk` (and everything that is deserialized from it).
+Chunk readChunk(BlobReader& reader) {
+  ad_utility::serialization::alignSerializerForType<std::max_align_t>(reader);
+  size_t regionBegin = reader.getCurrentPosition();
+  uint64_t payloadSize = 0;
+  reader >> payloadSize;
+  ad_utility::serialization::alignSerializerForType<std::max_align_t>(reader);
+  AD_CORRECTNESS_CHECK(reader.getCurrentPosition() ==
+                       regionBegin + BlobLayout::chunkHeaderSize);
+  auto payload = reader.getSpanToBytes(payloadSize);
+  return {{regionBegin, reader.getCurrentPosition()}, payload};
+}
+
+// Return a serializer that reads the `payload` of a chunk. Note that the
+// payload of a chunk begins at a multiple of `chunkAlignment` inside a buffer
+// that is aligned to `chunkAlignment`, so the alignment that the constructor of
+// the returned serializer requires is guaranteed, and the alignment padding
+// inside the payload is at the same offsets as when the payload was written.
+BlobReader makeSubReader(ql::span<const char> payload) {
+  return BlobReader{payload};
+}
+
+// Read a single value of a trivially serializable type `T` that makes up the
+// complete payload of the given `chunk`.
+template <typename T>
+T readScalarChunk(const Chunk& chunk) {
+  auto subReader = makeSubReader(chunk.payload_);
+  T value;
+  subReader >> value;
+  return value;
+}
+
+// Read the next chunk of `reader` (see `readChunk`) and return the result of
+// `readPayload` applied to a sub-reader for its payload (see `makeSubReader`).
+// This discards the chunk's region, so use `readChunk` directly instead when
+// the region is also needed (as it is, for example, when building a
+// `BlobLayout`). Note that this does not break the zero-copy semantics of the
+// payload: the sub-reader that `readPayload` is applied to still spans a view
+// into the buffer of the outer `reader`.
+template <typename Function>
+decltype(auto) readChunkPayload(BlobReader& reader,
+                                const Function& readPayload) {
+  auto chunk = readChunk(reader);
+  auto subReader = makeSubReader(chunk.payload_);
+  return readPayload(subReader);
+}
+
+// The `BlobReader` counterpart of `readScalarChunk(const Chunk&)`: read a
+// single value of a trivially serializable type `T` that makes up the
+// complete payload of the next chunk of `reader`, without keeping that
+// chunk's region.
+template <typename T>
+T readScalarChunk(BlobReader& reader) {
+  return readChunkPayload(reader, [](BlobReader& subReader) {
+    T value;
+    subReader >> value;
+    return value;
+  });
+}
+
+// Write one complete chunk whose payload is the single value `value` of a
+// trivially serializable type `T` (see `writeChunk`).
+template <typename T>
+void writeScalarChunk(BlobWriter& writer, const T& value) {
+  writeChunk(writer,
+             [&value](BlobWriter& payloadWriter) { payloadWriter << value; });
+}
+
 // Write the index metadata JSON and the `vocabulary` of `indexImpl` (which has
-// to be passed separately, see the NOTE below) to `serializer`, omitting all
-// vocabulary entries that match one of the `excludedEntryRegexes` (which must
-// not be empty). The metadata JSON is written with its `"vocabulary-type"` set
-// to the type of the filtered vocabulary, so that the reading side (which
-// applies the metadata JSON before loading the vocabulary) sets up the matching
-// vocabulary implementation.
+// to be passed separately, see the NOTE below) as the first two chunks of a
+// blob, omitting all vocabulary entries that match one of the
+// `excludedEntryRegexes` (which must not be empty). The metadata JSON is
+// written with its `"vocabulary-type"` set to the type of the filtered
+// vocabulary, so that the reading side (which applies the metadata JSON before
+// loading the vocabulary) sets up the matching vocabulary implementation.
 //
 // NOTE: This is a template (with the type of the vocabulary as its parameter),
 // so that the `if constexpr` below actually discards the branch that does not
@@ -84,8 +243,8 @@ decltype(auto) rethrowWithContext(std::string_view message,
 // `PolymorphicVocabulary`.
 template <typename VocabularyImpl>
 void writeMetadataAndFilteredVocabulary(
-    ad_utility::serialization::AlignedByteBufferWriteSerializer& serializer,
-    const IndexImpl& indexImpl, const VocabularyImpl& vocabulary,
+    BlobWriter& writer, const IndexImpl& indexImpl,
+    const VocabularyImpl& vocabulary,
     const std::vector<std::string>& excludedEntryRegexes) {
   // The filtering is implemented for the `PolymorphicVocabulary`, which is the
   // vocabulary implementation that QLever is built with by default (see
@@ -101,7 +260,9 @@ void writeMetadataAndFilteredVocabulary(
                      ".tmp-filtered-blob-vocabulary.", uuidGenerator()));
     nlohmann::json metadata = indexImpl.configurationJson();
     metadata["vocabulary-type"] = filtered.type_;
-    serializer << metadata.dump();
+    writeChunk(writer, [&metadata](BlobWriter& payloadWriter) {
+      payloadWriter << metadata.dump();
+    });
     // NOTE: This writes exactly the same format that
     // `Vocabulary::writeAsZeroCopyBlob` writes (and that
     // `Vocabulary::loadFromZeroCopyDeserializer` reads back), because both use
@@ -111,13 +272,173 @@ void writeMetadataAndFilteredVocabulary(
     // wrapping `UnicodeVocabulary` to begin with, and
     // `Vocabulary::writeAsZeroCopyBlob` explicitly bypasses its own wrapping
     // `UnicodeVocabulary`.
-    serializer << filtered.vocabulary_;
+    writeChunk(writer, [&filtered](BlobWriter& payloadWriter) {
+      payloadWriter << filtered.vocabulary_;
+    });
   } else {
     AD_THROW(
         "Excluding vocabulary entries from a blob is only supported for the "
         "polymorphic vocabulary, but QLever was compiled with "
         "`QLEVER_VOCAB_UNCOMPRESSED_IN_MEMORY`");
   }
+}
+
+// Assign the `Id`s of the secondary vocabulary of a blob (see
+// `index/vocabulary/SecondaryVocabulary.h`) to the words of those local vocab
+// entries that occur in the named cache entries that are written to that blob.
+// Such a word is *new* in the sense that it is not part of the vocabulary of
+// the index, which happens when SPARQL UPDATE operations were applied before
+// the entry was pinned.
+//
+// The new words that `rewrite` encounters are appended in the order in which
+// they are encountered, and together form the single segment that the blob adds
+// to its secondary vocabulary (see `newSegment`).
+class SecondaryVocabularyBuilder {
+ private:
+  // The index in the secondary vocabulary of the blob, for every new word that
+  // has an index so far.
+  ad_utility::HashMap<std::string, uint64_t> wordToIndex_;
+
+  // The new words, in the order in which they were encountered.
+  std::vector<std::string> newWords_;
+
+ public:
+  // Rewrite a single `Id` of a named cache entry. An `Id` that does not refer
+  // to a local vocab entry is returned unchanged. For an `Id` that does, the
+  // position of the word in the vocabularies of the index decides: if the word
+  // is contained in the vocabulary of the main index (or is encodable as an
+  // `EncodedVal`), then the `Id` of that position is used; else the word is
+  // added to the secondary vocabulary of the blob (if it is not already there)
+  // and the corresponding `Id` of type `Datatype::SecondaryVocabIndex` is
+  // used.
+  Id rewrite(Id id) {
+    if (id.getDatatype() != Datatype::LocalVocabIndex) {
+      return id;
+    }
+    const LocalVocabEntry& entry = *id.getLocalVocabIndex();
+    auto [lowerBound, upperBound] = entry.positionInVocab();
+    if (lowerBound != upperBound) {
+      // The word is contained in the vocabulary of the main index, or is
+      // encodable, in which case the position is exactly the `Id` of the word.
+      return Id::fromBits(lowerBound.get());
+    }
+    std::string word = entry.toStringRepresentation();
+    auto iterator = wordToIndex_.find(word);
+    if (iterator == wordToIndex_.end()) {
+      uint64_t index = wordToIndex_.size();
+      iterator = wordToIndex_.emplace(word, index).first;
+      newWords_.push_back(std::move(word));
+    }
+    return Id::makeFromSecondaryVocabIndex(
+        SecondaryVocabIndex::make(iterator->second));
+  }
+
+  // Whether `rewrite` has encountered any new word, and hence whether a segment
+  // of the secondary vocabulary has to be written at all.
+  bool hasNewWords() const { return !newWords_.empty(); }
+
+  // The segment with the new words that `rewrite` has encountered.
+  CompactVectorOfStrings<char> newSegment() const {
+    CompactVectorOfStrings<char> segment;
+    segment.build(newWords_);
+    return segment;
+  }
+};
+
+// The columns of a named cache entry with all `Id`s rewritten (see
+// `SecondaryVocabularyBuilder::rewrite`), together with the sort order that
+// still holds for them.
+struct RewrittenColumns {
+  std::vector<std::vector<Id>> columns_;
+  std::vector<ColumnIndex> resultSortedOn_;
+};
+
+// Rewrite all `Id`s of the given cache entry `value`, see
+// `SecondaryVocabularyBuilder::rewrite`. A column in which at least one `Id`
+// was rewritten is no longer guaranteed to be sorted (the internal order of
+// the `Id`s of a secondary vocabulary is unrelated to the order of the local
+// vocab entries that they replace), so the sort order is truncated before the
+// first such column.
+RewrittenColumns rewriteColumns(const NamedResultCache::Value& value,
+                                SecondaryVocabularyBuilder& builder) {
+  auto view = ExplicitIdTableOperation::viewOf(value.result_);
+  RewrittenColumns result;
+  std::vector<bool> columnWasRewritten;
+  for (const auto& column : view.getColumns()) {
+    std::vector<Id> rewrittenColumn;
+    rewrittenColumn.reserve(column.size());
+    bool wasRewritten = false;
+    for (Id id : column) {
+      Id rewrittenId = builder.rewrite(id);
+      wasRewritten = wasRewritten || rewrittenId != id;
+      rewrittenColumn.push_back(rewrittenId);
+    }
+    result.columns_.push_back(std::move(rewrittenColumn));
+    columnWasRewritten.push_back(wasRewritten);
+  }
+  auto firstRewritten = ql::ranges::find_if(
+      value.resultSortedOn_, [&columnWasRewritten](ColumnIndex column) {
+        return column < columnWasRewritten.size() && columnWasRewritten[column];
+      });
+  result.resultSortedOn_.assign(value.resultSortedOn_.begin(), firstRewritten);
+  return result;
+}
+
+// Collect the words of all local vocab entries that occur in the given cache
+// entry `value` (and hence assign their `Id`s), without producing the
+// rewritten columns. This is the first of the two passes over the cache
+// entries that the writing of a blob needs: only once all words are known can
+// the segment of the secondary vocabulary be written, and that segment
+// precedes the entries in the blob. Doing it this way (instead of keeping the
+// result of `rewriteColumns` for all entries) means that the rewritten columns
+// of only one entry at a time have to be held in memory.
+void collectNewWords(const NamedResultCache::Value& value,
+                     SecondaryVocabularyBuilder& builder) {
+  auto view = ExplicitIdTableOperation::viewOf(value.result_);
+  for (const auto& column : view.getColumns()) {
+    for (Id id : column) {
+      if (id.getDatatype() == Datatype::LocalVocabIndex) {
+        [[maybe_unused]] Id rewrittenId = builder.rewrite(id);
+      }
+    }
+  }
+}
+
+// Run `collectNewWords` (the first pass over the cache entries, see there)
+// over all of `entries`.
+void collectAllNewWords(
+    const std::vector<std::pair<
+        NamedResultCache::Key, std::shared_ptr<const NamedResultCache::Value>>>&
+        entries,
+    SecondaryVocabularyBuilder& builder) {
+  for (const auto& [key, value] : entries) {
+    collectNewWords(*value, builder);
+  }
+}
+
+// Write the payload of the chunk of one entry of the `NamedResultCache`: its
+// `key`, followed by the `value` with all its `Id`s rewritten (see
+// `rewriteColumns`). The words of the local vocab of the `value` are
+// deliberately not written, because they are stored in the secondary
+// vocabulary of the blob instead.
+void writeEntryPayload(BlobWriter& writer, const std::string& key,
+                       const NamedResultCache::Value& value,
+                       SecondaryVocabularyBuilder& builder) {
+  writer << key;
+  auto rewritten = rewriteColumns(value, builder);
+  namedResultCacheSerializer::writeValue(writer, value, rewritten.columns_,
+                                         rewritten.resultSortedOn_,
+                                         /*writeLocalVocabWords=*/false);
+}
+
+// Return a function that writes the payload of the chunk of the named cache
+// entry `key`/`value` (see `writeEntryPayload`), suitable for `writeChunk`.
+auto makeEntryPayloadWriter(const std::string& key,
+                            const NamedResultCache::Value& value,
+                            SecondaryVocabularyBuilder& builder) {
+  return [&key, &value, &builder](BlobWriter& payloadWriter) {
+    writeEntryPayload(payloadWriter, key, value, builder);
+  };
 }
 }  // namespace
 
@@ -194,17 +515,58 @@ NamedCachedQueryBlobManager::decompressBlob(
 }
 
 // _____________________________________________________________________________
+NamedCachedQueryBlobManager::BlobLayout
+NamedCachedQueryBlobManager::parseBlobLayout(
+    ql::span<const char> uncompressedBlob) {
+  BlobReader reader{uncompressedBlob};
+  skipAndVerifyBlobHeader(reader);
+  BlobLayout layout;
+  layout.metadata_ = readChunk(reader).region_;
+  layout.vocabulary_ = readChunk(reader).region_;
+
+  auto segmentCountChunk = readChunk(reader);
+  layout.segmentCount_ = segmentCountChunk.region_;
+  auto numSegments = readScalarChunk<uint64_t>(segmentCountChunk);
+  for (uint64_t i = 0; i < numSegments; ++i) {
+    layout.segments_.push_back(readChunk(reader).region_);
+  }
+
+  auto entryCountChunk = readChunk(reader);
+  layout.entryCount_ = entryCountChunk.region_;
+  auto numEntries = readScalarChunk<uint64_t>(entryCountChunk);
+  for (uint64_t i = 0; i < numEntries; ++i) {
+    auto entryChunk = readChunk(reader);
+    // The key of an entry is stored at the very beginning of its payload.
+    auto subReader = makeSubReader(entryChunk.payload_);
+    std::string key;
+    subReader >> key;
+    layout.entries_.push_back({std::move(key), entryChunk.region_});
+  }
+  return layout;
+}
+
+// _____________________________________________________________________________
 std::vector<char> NamedCachedQueryBlobManager::serialize(
     const Qlever& qlever, const BlobSerializationConfig& config) const {
-  // First serialize everything into an uncompressed, suitably aligned buffer.
-  // The alignment (guaranteed by the `AlignedByteBufferWriteSerializer`) is
-  // required so that the buffer can later be deserialized zero-copy (see
-  // `deserialize`).
-  ad_utility::serialization::AlignedByteBufferWriteSerializer serializer;
-  writeBlobHeader(serializer);
-
   auto indexAndViews = qlever.indexAndViewsSnapshot();
   const auto& indexImpl = indexAndViews->index_.getImpl();
+  AD_CONTRACT_CHECK(indexImpl.secondaryVocab() == nullptr,
+                    noSecondaryVocabularyMessage);
+
+  // The first pass over the cache entries, which assigns the `Id`s of the
+  // secondary vocabulary of the blob to all the words that only exist as local
+  // vocab entries (see `collectNewWords`).
+  auto entries = qlever.namedResultCache_.getAllEntries();
+  SecondaryVocabularyBuilder vocabularyBuilder;
+  collectAllNewWords(entries, vocabularyBuilder);
+
+  // Serialize everything into an uncompressed, suitably aligned buffer. The
+  // alignment (guaranteed by the `AlignedByteBufferWriteSerializer`) is
+  // required so that the buffer can later be deserialized zero-copy (see
+  // `deserialize`).
+  BlobWriter writer;
+  writeBlobHeader(writer);
+
   // Serialize the index metadata JSON together with the vocabulary, so that the
   // blob is self-contained and the loading side can set up the vocabulary
   // configuration without access to the on-disk index. Without excluded
@@ -213,16 +575,36 @@ std::vector<char> NamedCachedQueryBlobManager::serialize(
   // `"vocabulary-type"` entry of the metadata JSON is rewritten to the type of
   // the filtered vocabulary (see `writeMetadataAndFilteredVocabulary`).
   if (config.excludedEntryRegexes_.empty()) {
-    serializer << indexImpl.configurationJson().dump();
-    indexImpl.writeVocabularyToZeroCopyBlob(serializer);
+    writeChunk(writer, [&indexImpl](BlobWriter& payloadWriter) {
+      payloadWriter << indexImpl.configurationJson().dump();
+    });
+    writeChunk(writer, [&indexImpl](BlobWriter& payloadWriter) {
+      indexImpl.writeVocabularyToZeroCopyBlob(payloadWriter);
+    });
   } else {
     writeMetadataAndFilteredVocabulary(
-        serializer, indexImpl, indexImpl.getVocab().getUnderlyingVocabulary(),
+        writer, indexImpl, indexImpl.getVocab().getUnderlyingVocabulary(),
         config.excludedEntryRegexes_);
   }
-  qlever.namedResultCache_.writeToSerializer(serializer);
-  auto uncompressed = std::move(serializer).data();
 
+  // The secondary vocabulary of the blob, which consists of a single segment
+  // with the new words (or of no segment at all, if there are none).
+  uint64_t numSegments = vocabularyBuilder.hasNewWords() ? 1 : 0;
+  writeScalarChunk(writer, numSegments);
+  if (numSegments == 1) {
+    auto segment = vocabularyBuilder.newSegment();
+    writeChunk(writer, [&segment](BlobWriter& payloadWriter) {
+      payloadWriter << segment;
+    });
+  }
+
+  // The entries of the `NamedResultCache`, in the second pass over them.
+  writeScalarChunk(writer, uint64_t{entries.size()});
+  for (const auto& [key, value] : entries) {
+    writeChunk(writer, makeEntryPayloadWriter(key, *value, vocabularyBuilder));
+  }
+
+  auto uncompressed = std::move(writer).data();
   return compressBlob(uncompressed);
 }
 
@@ -245,9 +627,8 @@ void NamedCachedQueryBlobManager::deserialize(
   // `deserializedBlobLifetimeExtender_`, rather than one that owns/moves it, so
   // that the buffer stays owned by `deserializedBlobLifetimeExtender_` for the
   // rest of this manager's lifetime.
-  ad_utility::serialization::ByteBufferReadSerializerT<true,
-                                                       ql::span<const char>>
-      reader{ql::span<const char>{deserializedBlobLifetimeExtender_.value()}};
+  BlobReader reader{
+      ql::span<const char>{deserializedBlobLifetimeExtender_.value()}};
 
   skipAndVerifyBlobHeader(reader);
 
@@ -257,20 +638,59 @@ void NamedCachedQueryBlobManager::deserialize(
   // reading of the contents, so that the user gets a message that names the
   // expected input, instead of a low-level error from deep inside the
   // deserialization.
-  rethrowWithContext(
-      blobContentsNotReadableMessage,
-      [&indexImpl, &reader, &qlever, &indexAndViews]() {
-        // Read and apply the index metadata JSON before loading the vocabulary,
-        // so that the vocabulary is set up with the correct configuration
-        // (locale, comparator, etc.).
-        std::string metadataJson;
-        reader >> metadataJson;
-        indexImpl.applyConfiguration(nlohmann::json::parse(metadataJson));
-        indexImpl.loadVocabularyFromZeroCopyBlob(reader);
-        qlever.namedResultCache_.readFromSerializer(
-            reader, qlever.allocator_,
-            indexAndViews->index_.getLocalVocabContext());
-      });
+  rethrowWithContext(blobContentsNotReadableMessage, [&indexImpl, &reader,
+                                                      &qlever,
+                                                      &indexAndViews]() {
+    // Read and apply the index metadata JSON before loading the vocabulary,
+    // so that the vocabulary is set up with the correct configuration
+    // (locale, comparator, etc.).
+    std::string metadataJson =
+        readChunkPayload(reader, [](BlobReader& subReader) {
+          std::string json;
+          subReader >> json;
+          return json;
+        });
+    indexImpl.applyConfiguration(nlohmann::json::parse(metadataJson));
+
+    readChunkPayload(reader, [&indexImpl](BlobReader& subReader) {
+      indexImpl.loadVocabularyFromZeroCopyBlob(subReader);
+    });
+
+    // The segments of the secondary vocabulary, which have to be appended
+    // in exactly the order in which they are stored, because the `Id` of a
+    // word is its position in the concatenation of all segments.
+    auto numSegments = readScalarChunk<uint64_t>(reader);
+    SecondaryVocabulary secondaryVocabulary;
+    for (uint64_t i = 0; i < numSegments; ++i) {
+      secondaryVocabulary.appendSegment(
+          readChunkPayload(reader, [](BlobReader& subReader) {
+            return CompactVectorOfStrings<char>::fromZeroCopyDeserializer(
+                subReader);
+          }));
+    }
+    if (secondaryVocabulary.numWords() > 0) {
+      indexImpl.setSecondaryVocab(std::make_shared<const SecondaryVocabulary>(
+          std::move(secondaryVocabulary)));
+    }
+
+    // The entries of the `NamedResultCache`.
+    auto numEntries = readScalarChunk<uint64_t>(reader);
+    qlever.namedResultCache_.clear();
+    for (uint64_t i = 0; i < numEntries; ++i) {
+      auto [key, value] = readChunkPayload(
+          reader, [&qlever, &indexAndViews](BlobReader& subReader) {
+            NamedResultCache::Key key;
+            subReader >> key;
+            NamedResultCache::Value value;
+            value.allocatorForSerialization_ = qlever.allocator_;
+            value.contextForSerialization_ =
+                &indexAndViews->index_.getLocalVocabContext();
+            subReader >> value;
+            return std::pair{std::move(key), std::move(value)};
+          });
+      qlever.namedResultCache_.store(key, std::move(value));
+    }
+  });
 }
 
 }  // namespace qlever

--- a/src/libqlever/NamedCachedQueryBlobManager.cpp
+++ b/src/libqlever/NamedCachedQueryBlobManager.cpp
@@ -24,6 +24,7 @@
 #include "index/vocabulary/PolymorphicVocabulary.h"
 #include "index/vocabulary/SecondaryVocabulary.h"
 #include "libqlever/Qlever.h"
+#include "util/BinaryDiff.h"
 #include "util/CompactStringVector.h"
 #include "util/CompressionUsingZstd/ZstdWrapper.h"
 #include "util/HashMap.h"
@@ -65,13 +66,20 @@ constexpr std::string_view blobContentsNotReadableMessage =
     "`Qlever::serializeVocabAndNamedCacheToCompressedBlob`; the blob is "
     "probably corrupted";
 
-// The precondition of `serialize`, see the comment at
+// The message that is reported for any input that is not a diff written by
+// `NamedCachedQueryBlobManager::serializeDiff`.
+constexpr std::string_view diffNotReadableMessage =
+    "The given diff was not written by "
+    "`Qlever::serializeVocabAndNamedCacheDiffToCompressedBlob`, or is "
+    "corrupted";
+
+// The precondition of `serialize` and `serializeDiff`, see the comment at
 // `NamedCachedQueryBlobManager::serialize`.
 constexpr std::string_view noSecondaryVocabularyMessage =
-    "A blob can only be created from an index without a secondary vocabulary. "
-    "In particular, a `Qlever` instance that was itself loaded from a blob "
-    "whose named cache entries contained new words cannot be used to create "
-    "another blob";
+    "A blob (and a diff between two blobs) can only be created from an index "
+    "without a secondary vocabulary. In particular, a `Qlever` instance that "
+    "was itself loaded from a blob whose named cache entries contained new "
+    "words cannot be used to create another blob";
 
 // The alignment to which the beginning of every chunk, and hence also the
 // beginning of every chunk payload, is padded (see
@@ -94,6 +102,19 @@ using BlobReader =
     ad_utility::serialization::ByteBufferReadSerializerT<true,
                                                          ql::span<const char>>;
 
+// The serializer types that a diff (see
+// `NamedCachedQueryBlobManager::serializeDiff`) is written with and read back
+// with. In contrast to a blob, a diff uses plain, unaligned serialization: it
+// is read sequentially and only once, and the bytes that its instructions carry
+// are aligned by the application of the diff, not by the serializer.
+using DiffWriter = ad_utility::serialization::ByteBufferWriteSerializer;
+using DiffReader =
+    ad_utility::serialization::ByteBufferReadSerializerT<false,
+                                                         ql::span<const char>>;
+
+// The type of the buffer that a `BlobWriter` produces.
+using ChunkBytes = BlobWriter::Storage;
+
 // Run `function` and, if it throws, rethrow with `message` prepended. That way,
 // the rather cryptic low-level error messages (in particular those of ZSTD)
 // never reach the user unadorned.
@@ -105,6 +126,58 @@ decltype(auto) rethrowWithContext(std::string_view message,
   } catch (const std::exception& e) {
     AD_THROW(absl::StrCat(message, ". Details: ", e.what()));
   }
+}
+
+// The implementation of `NamedCachedQueryBlobManager::decompressBlob`, with the
+// message that is reported for input that is not a ZSTD frame as a parameter,
+// so that a blob and a diff (which are compressed in exactly the same way) can
+// be rejected with their own respective messages.
+std::vector<char, NamedCachedQueryBlobManager::BlobAllocator>
+decompressWithMessage(ql::span<const char> compressed,
+                      ql::pmr::polymorphic_allocator<char> allocator,
+                      std::string_view notReadableMessage) {
+  using BlobAllocator = NamedCachedQueryBlobManager::BlobAllocator;
+  // Read the size of the uncompressed data from the ZSTD frame header (which
+  // always stores it, because `compressBlob` uses the one-shot
+  // `ZSTD_compress`). This also validates that `compressed` starts with a
+  // ZSTD frame at all, so that arbitrary garbage is rejected right here,
+  // instead of being misinterpreted as an (arbitrarily large) size for the
+  // allocation below.
+  size_t uncompressedSize =
+      rethrowWithContext(notReadableMessage, [&compressed]() {
+        return ZstdWrapper::getUncompressedSize(compressed.data(),
+                                                compressed.size());
+      });
+
+  // Decompress into a buffer that is 1. allocated via the caller-provided
+  // `allocator`, 2. aligned to the maximal possible alignment (required for the
+  // zero-copy deserialization), and 3. not needlessly zero-initialized before
+  // the decompression overwrites it (see `BlobAllocator`).
+  std::vector<char, BlobAllocator> uncompressed(
+      uncompressedSize,
+      BlobAllocator{ad_utility::AlignedAllocator<
+          char, ql::pmr::polymorphic_allocator<char>>{allocator}});
+  auto actualUncompressedSize =
+      rethrowWithContext(notReadableMessage, [&compressed, &uncompressed]() {
+        return ZstdWrapper::decompressToBuffer(
+            compressed.data(), compressed.size(), uncompressed.data(),
+            uncompressed.size());
+      });
+  AD_CORRECTNESS_CHECK(actualUncompressedSize == uncompressedSize);
+  return uncompressed;
+}
+
+// Decompress and deserialize a diff written by
+// `NamedCachedQueryBlobManager::serializeDiff`, and report any input that is
+// not such a diff with `diffNotReadableMessage`.
+ad_utility::BinaryDiff readDiff(ql::span<const char> compressedDiff) {
+  auto uncompressed =
+      decompressWithMessage(compressedDiff, {}, diffNotReadableMessage);
+  DiffReader reader{ql::span<const char>{uncompressed}};
+  ad_utility::BinaryDiff diff;
+  rethrowWithContext(diffNotReadableMessage,
+                     [&reader, &diff]() { reader >> diff; });
+  return diff;
 }
 
 // The positions that `endChunk` needs to complete a chunk that `beginChunk`
@@ -149,6 +222,18 @@ void writeChunk(BlobWriter& writer, const Function& writePayload) {
   auto handle = beginChunk(writer);
   writePayload(writer);
   endChunk(writer, handle);
+}
+
+// Write one complete chunk into a fresh buffer and return its bytes. Because
+// the chunks are position independent (see
+// `NamedCachedQueryBlobManager::parseBlobLayout`), those bytes can be compared
+// to the bytes of the corresponding chunk of a base blob, and be used as they
+// are as the payload of an insert instruction of a diff.
+template <typename Function>
+ChunkBytes chunkBytes(const Function& writePayload) {
+  BlobWriter writer;
+  writeChunk(writer, writePayload);
+  return std::move(writer).data();
 }
 
 // One chunk, as returned by `readChunk`.
@@ -228,6 +313,13 @@ void writeScalarChunk(BlobWriter& writer, const T& value) {
              [&value](BlobWriter& payloadWriter) { payloadWriter << value; });
 }
 
+// The `chunkBytes` counterpart of `writeScalarChunk`.
+template <typename T>
+ChunkBytes scalarChunkBytes(const T& value) {
+  return chunkBytes(
+      [&value](BlobWriter& payloadWriter) { payloadWriter << value; });
+}
+
 // Write the index metadata JSON and the `vocabulary` of `indexImpl` (which has
 // to be passed separately, see the NOTE below) as the first two chunks of a
 // blob, omitting all vocabulary entries that match one of the
@@ -290,19 +382,38 @@ void writeMetadataAndFilteredVocabulary(
 // the index, which happens when SPARQL UPDATE operations were applied before
 // the entry was pinned.
 //
-// The new words that `rewrite` encounters are appended in the order in which
-// they are encountered, and together form the single segment that the blob adds
-// to its secondary vocabulary (see `newSegment`).
+// The words of the segments of a base blob are added first (via
+// `addBaseSegment`), so that they keep the `Id`s that they already have in that
+// base blob. All further words that `rewrite` encounters are appended, in the
+// order in which they are encountered, and form the one new segment that the
+// blob (or the diff) adds (see `newSegment`).
 class SecondaryVocabularyBuilder {
  private:
-  // The index in the secondary vocabulary of the blob, for every new word that
-  // has an index so far.
+  // The global index in the secondary vocabulary of the blob, for every word
+  // that has an index so far (the words of the base segments and the new words
+  // together).
   ad_utility::HashMap<std::string, uint64_t> wordToIndex_;
 
-  // The new words, in the order in which they were encountered.
+  // The words that were not already contained in one of the base segments, in
+  // the order in which they were encountered.
   std::vector<std::string> newWords_;
 
  public:
+  // Add the words of one segment of the base blob. The segments have to be
+  // added in the order in which they appear in that blob, because the `Id` of
+  // a word is its position in the concatenation of all segments.
+  void addBaseSegment(const CompactVectorOfStrings<char>& segment) {
+    AD_CORRECTNESS_CHECK(newWords_.empty());
+    for (std::string_view word : segment) {
+      uint64_t index = wordToIndex_.size();
+      bool wasInserted = wordToIndex_.emplace(word, index).second;
+      AD_CORRECTNESS_CHECK(
+          wasInserted,
+          "The segments of the secondary vocabulary of a blob must not contain "
+          "duplicate words");
+    }
+  }
+
   // Rewrite a single `Id` of a named cache entry. An `Id` that does not refer
   // to a local vocab entry is returned unchanged. For an `Id` that does, the
   // position of the word in the vocabularies of the index decides: if the word
@@ -333,11 +444,13 @@ class SecondaryVocabularyBuilder {
         SecondaryVocabIndex::make(iterator->second));
   }
 
-  // Whether `rewrite` has encountered any new word, and hence whether a segment
-  // of the secondary vocabulary has to be written at all.
+  // Whether `rewrite` has encountered any word that was not already contained
+  // in one of the base segments, and hence whether a new segment has to be
+  // written at all.
   bool hasNewWords() const { return !newWords_.empty(); }
 
-  // The segment with the new words that `rewrite` has encountered.
+  // The new segment, that is, the words that `rewrite` has encountered and
+  // that were not already contained in one of the base segments.
   CompactVectorOfStrings<char> newSegment() const {
     CompactVectorOfStrings<char> segment;
     segment.build(newWords_);
@@ -387,11 +500,11 @@ RewrittenColumns rewriteColumns(const NamedResultCache::Value& value,
 // Collect the words of all local vocab entries that occur in the given cache
 // entry `value` (and hence assign their `Id`s), without producing the
 // rewritten columns. This is the first of the two passes over the cache
-// entries that the writing of a blob needs: only once all words are known can
-// the segment of the secondary vocabulary be written, and that segment
-// precedes the entries in the blob. Doing it this way (instead of keeping the
-// result of `rewriteColumns` for all entries) means that the rewritten columns
-// of only one entry at a time have to be held in memory.
+// entries that the writing of a blob (or of a diff) needs: only once all words
+// are known can the new segment of the secondary vocabulary be written, and
+// that segment precedes the entries in the blob. Doing it this way (instead of
+// keeping the result of `rewriteColumns` for all entries) means that the
+// rewritten columns of only one entry at a time have to be held in memory.
 void collectNewWords(const NamedResultCache::Value& value,
                      SecondaryVocabularyBuilder& builder) {
   auto view = ExplicitIdTableOperation::viewOf(value.result_);
@@ -405,7 +518,7 @@ void collectNewWords(const NamedResultCache::Value& value,
 }
 
 // Run `collectNewWords` (the first pass over the cache entries, see there)
-// over all of `entries`.
+// over all of `entries`. Used by both `serialize` and `serializeDiff`.
 void collectAllNewWords(
     const std::vector<std::pair<
         NamedResultCache::Key, std::shared_ptr<const NamedResultCache::Value>>>&
@@ -432,7 +545,8 @@ void writeEntryPayload(BlobWriter& writer, const std::string& key,
 }
 
 // Return a function that writes the payload of the chunk of the named cache
-// entry `key`/`value` (see `writeEntryPayload`), suitable for `writeChunk`.
+// entry `key`/`value` (see `writeEntryPayload`), suitable for `writeChunk` or
+// `chunkBytes`.
 auto makeEntryPayloadWriter(const std::string& key,
                             const NamedResultCache::Value& value,
                             SecondaryVocabularyBuilder& builder) {
@@ -484,34 +598,8 @@ std::vector<char, NamedCachedQueryBlobManager::BlobAllocator>
 NamedCachedQueryBlobManager::decompressBlob(
     ql::span<const char> compressedBlob,
     ql::pmr::polymorphic_allocator<char> allocator) {
-  // Read the size of the uncompressed data from the ZSTD frame header (which
-  // always stores it, because `compressBlob` uses the one-shot
-  // `ZSTD_compress`). This also validates that `compressedBlob` starts with a
-  // ZSTD frame at all, so that arbitrary garbage is rejected right here,
-  // instead of being misinterpreted as an (arbitrarily large) size for the
-  // allocation below.
-  size_t uncompressedSize =
-      rethrowWithContext(blobNotReadableMessage, [&compressedBlob]() {
-        return ZstdWrapper::getUncompressedSize(compressedBlob.data(),
-                                                compressedBlob.size());
-      });
-
-  // Decompress into a buffer that is 1. allocated via the caller-provided
-  // `allocator`, 2. aligned to the maximal possible alignment (required for the
-  // zero-copy deserialization), and 3. not needlessly zero-initialized before
-  // the decompression overwrites it (see `BlobAllocator`).
-  std::vector<char, BlobAllocator> uncompressed(
-      uncompressedSize,
-      BlobAllocator{ad_utility::AlignedAllocator<
-          char, ql::pmr::polymorphic_allocator<char>>{allocator}});
-  auto actualUncompressedSize = rethrowWithContext(
-      blobNotReadableMessage, [&compressedBlob, &uncompressed]() {
-        return ZstdWrapper::decompressToBuffer(
-            compressedBlob.data(), compressedBlob.size(), uncompressed.data(),
-            uncompressed.size());
-      });
-  AD_CORRECTNESS_CHECK(actualUncompressedSize == uncompressedSize);
-  return uncompressed;
+  return decompressWithMessage(compressedBlob, allocator,
+                               blobNotReadableMessage);
 }
 
 // _____________________________________________________________________________
@@ -609,19 +697,169 @@ std::vector<char> NamedCachedQueryBlobManager::serialize(
 }
 
 // _____________________________________________________________________________
+std::vector<char> NamedCachedQueryBlobManager::serializeDiff(
+    const Qlever& qlever, ql::span<const char> compressedBaseBlob) const {
+  auto indexAndViews = qlever.indexAndViewsSnapshot();
+  const auto& indexImpl = indexAndViews->index_.getImpl();
+  AD_CONTRACT_CHECK(indexImpl.secondaryVocab() == nullptr,
+                    noSecondaryVocabularyMessage);
+
+  auto base = decompressBlob(compressedBaseBlob, {});
+  ql::span<const char> baseSpan{base};
+  BlobLayout layout = parseBlobLayout(baseSpan);
+
+  // The words of the segments of the base blob keep the `Id`s that they have in
+  // that blob, so they are added first.
+  SecondaryVocabularyBuilder vocabularyBuilder;
+  for (const auto& segmentRegion : layout.segments_) {
+    auto subReader = makeSubReader(segmentRegion.payloadSpan(baseSpan));
+    vocabularyBuilder.addBaseSegment(
+        CompactVectorOfStrings<char>::fromZeroCopyDeserializer(subReader));
+  }
+
+  // The first pass over the cache entries, see `collectNewWords`.
+  auto entries = qlever.namedResultCache_.getAllEntries();
+  collectAllNewWords(entries, vocabularyBuilder);
+
+  // The diff, whose alignment is the chunk alignment, so that every chunk that
+  // is copied from the base blob again begins at a multiple of that alignment
+  // in the patched blob, and hence stays readable (see `parseBlobLayout`).
+  ad_utility::BinaryDiff diff{baseSpan, chunkAlignment};
+
+  // Copy the given `region` of the base blob.
+  auto copyRegion = [&diff](const BlobLayout::Region& region) {
+    diff.addCopy(region.begin_, region.size());
+  };
+
+  // Compare the bytes of the given `chunk` to those of the `region` of the base
+  // blob, and copy that region if they are equal, and insert the chunk else.
+  auto copyOrInsert = [&diff, &baseSpan, &copyRegion](
+                          const BlobLayout::Region& region,
+                          const ChunkBytes& chunk) {
+    auto regionBytes = baseSpan.subspan(region.begin_, region.size());
+    if (ql::ranges::equal(regionBytes, chunk)) {
+      copyRegion(region);
+    } else {
+      diff.addInsert(ql::span<const char>{chunk});
+    }
+  };
+
+  // The header, which is the only part of the blob that is not a chunk, and
+  // which is small enough that it is simply inserted.
+  {
+    BlobWriter headerWriter;
+    writeBlobHeader(headerWriter);
+    auto headerBytes = std::move(headerWriter).data();
+    diff.addInsert(ql::span<const char>{headerBytes});
+  }
+
+  // The metadata JSON and the vocabulary never change (a diff may only be
+  // created against a blob that was built from the same index), so they are
+  // always copied. This is the whole point of the diff: the vocabulary is by
+  // far the largest part of a typical blob.
+  copyRegion(layout.metadata_);
+  copyRegion(layout.vocabulary_);
+
+  // The secondary vocabulary: all segments of the base blob are copied, and the
+  // new words (if there are any) are appended as one new segment.
+  uint64_t numSegments =
+      layout.segments_.size() + (vocabularyBuilder.hasNewWords() ? 1 : 0);
+  copyOrInsert(layout.segmentCount_, scalarChunkBytes(numSegments));
+  for (const auto& segmentRegion : layout.segments_) {
+    copyRegion(segmentRegion);
+  }
+  if (vocabularyBuilder.hasNewWords()) {
+    auto segment = vocabularyBuilder.newSegment();
+    auto segmentChunk = chunkBytes(
+        [&segment](BlobWriter& payloadWriter) { payloadWriter << segment; });
+    diff.addInsert(ql::span<const char>{segmentChunk});
+  }
+
+  // The entries of the `NamedResultCache`, in the second pass over them: an
+  // entry whose chunk is byte-identical to the chunk of the entry with the same
+  // key in the base blob is copied, all others are inserted.
+  copyOrInsert(layout.entryCount_, scalarChunkBytes(uint64_t{entries.size()}));
+  ad_utility::HashMap<std::string, BlobLayout::Region> baseEntries;
+  for (const auto& entry : layout.entries_) {
+    baseEntries.emplace(entry.key_, entry.region_);
+  }
+  for (const auto& [key, value] : entries) {
+    auto chunk =
+        chunkBytes(makeEntryPayloadWriter(key, *value, vocabularyBuilder));
+    auto baseEntry = baseEntries.find(key);
+    if (baseEntry != baseEntries.end()) {
+      copyOrInsert(baseEntry->second, chunk);
+    } else {
+      diff.addInsert(ql::span<const char>{chunk});
+    }
+  }
+
+  // Serialize the diff, and compress the result exactly like a blob.
+  DiffWriter diffWriter;
+  diffWriter << diff;
+  auto uncompressedDiff = std::move(diffWriter).data();
+  return compressBlob(uncompressedDiff);
+}
+
+// _____________________________________________________________________________
+std::vector<char, NamedCachedQueryBlobManager::BlobAllocator>
+NamedCachedQueryBlobManager::applyDiffToUncompressedBlob(
+    ql::span<const char> uncompressedBase, ql::span<const char> compressedDiff,
+    ql::pmr::polymorphic_allocator<char> allocator) {
+  // NOTE: `ad_utility::BinaryDiff::apply` verifies that the diff is applied to
+  // exactly the base blob that it was created against, and it inserts the
+  // alignment padding in front of every instruction.
+  return readDiff(compressedDiff)
+      .apply(uncompressedBase,
+             BlobAllocator{ad_utility::AlignedAllocator<
+                 char, ql::pmr::polymorphic_allocator<char>>{allocator}});
+}
+
+// _____________________________________________________________________________
+std::vector<char> NamedCachedQueryBlobManager::applyDiff(
+    ql::span<const char> compressedBaseBlob,
+    ql::span<const char> compressedDiff) {
+  auto base = decompressBlob(compressedBaseBlob, {});
+  auto patched = applyDiffToUncompressedBlob(base, compressedDiff, {});
+  return compressBlob(patched);
+}
+
+// _____________________________________________________________________________
+ad_utility::BinaryDiff::Statistics NamedCachedQueryBlobManager::describeDiff(
+    ql::span<const char> compressedDiff) {
+  return readDiff(compressedDiff).statistics();
+}
+
+// _____________________________________________________________________________
 void NamedCachedQueryBlobManager::deserialize(
     Qlever& qlever, ql::span<const char> compressedBlob,
+    ql::pmr::polymorphic_allocator<char> allocator) {
+  deserialize(qlever, compressedBlob, {}, allocator);
+}
+
+// _____________________________________________________________________________
+void NamedCachedQueryBlobManager::deserialize(
+    Qlever& qlever, ql::span<const char> compressedBlob,
+    ql::span<const ql::span<const char>> compressedDiffs,
     ql::pmr::polymorphic_allocator<char> allocator) {
   AD_CONTRACT_CHECK(
       !deserializedBlobLifetimeExtender_.has_value(),
       "`deserializeVocabAndNamedCacheFromCompressedBlob` must not be called "
       "more than once on the same `Qlever` instance");
 
-  // Decompress into `deserializedBlobLifetimeExtender_`, which is kept alive
+  // Decompress the base blob and apply the diffs to it, one after the other.
+  // Each of them produces a complete blob again, so the intermediate buffer
+  // can be dropped as soon as the next diff has been applied to it.
+  auto uncompressed = decompressBlob(compressedBlob, allocator);
+  for (ql::span<const char> compressedDiff : compressedDiffs) {
+    uncompressed =
+        applyDiffToUncompressedBlob(uncompressed, compressedDiff, allocator);
+  }
+
+  // Keep the result in `deserializedBlobLifetimeExtender_`, which is kept alive
   // for the lifetime of this manager because the vocabulary and named result
   // cache entries loaded below are zero-copy views directly into it.
-  deserializedBlobLifetimeExtender_.emplace(
-      decompressBlob(compressedBlob, allocator));
+  deserializedBlobLifetimeExtender_.emplace(std::move(uncompressed));
 
   // Use a serializer that only borrows a view of
   // `deserializedBlobLifetimeExtender_`, rather than one that owns/moves it, so

--- a/src/libqlever/NamedCachedQueryBlobManager.h
+++ b/src/libqlever/NamedCachedQueryBlobManager.h
@@ -10,6 +10,8 @@
 #ifndef QLEVER_SRC_LIBQLEVER_NAMEDCACHEDQUERYBLOBMANAGER_H
 #define QLEVER_SRC_LIBQLEVER_NAMEDCACHEDQUERYBLOBMANAGER_H
 
+#include <cstddef>
+#include <cstdint>
 #include <optional>
 #include <string>
 #include <vector>
@@ -47,6 +49,33 @@ struct BlobSerializationConfig {
 // than in the `Qlever` class itself) to keep the core `Qlever` class small; a
 // `Qlever` holds one instance of this manager as a member, and this class is a
 // friend of `Qlever` so that it can access its internals.
+//
+// THE CONTENTS OF A BLOB: the index metadata JSON, the vocabulary of the
+// index, the *secondary vocabulary* of the blob (see below), and all entries of
+// the `NamedResultCache`. That is everything that is needed to answer queries
+// on the cached results, so a blob can be loaded by a process that has no
+// access to the on-disk index at all.
+//
+// NEW WORDS: After SPARQL UPDATE operations have been applied to an index,
+// re-pinning the same named queries can yield results that contain *new words*
+// which are not part of the vocabulary of the index (they only live in the
+// local vocab of the result). Store such words in the secondary vocabulary of
+// the blob (see `index/vocabulary/SecondaryVocabulary.h`) and rewrite the `Id`s
+// of the cache entries that refer to them into `Id`s of type
+// `Datatype::SecondaryVocabIndex` (see `serialize`). The secondary vocabulary
+// is an append-only sequence of segments; a blob written by `serialize` has at
+// most one segment, but `deserialize` reads an arbitrary number of them.
+//
+// THE CHUNK FORMAT: Store the individual parts of a blob as *chunks*, each of
+// which begins at an aligned offset (see `parseBlobLayout` for the exact
+// format). The point of that alignment is that the bytes of a chunk are
+// *position independent*, so that a chunk can be copied verbatim from one blob
+// into another one. This is what a follow-up mechanism that writes a *diff*
+// between two blobs (instead of a complete new blob after every update) builds
+// on.
+//
+// PRECONDITION: The index that a blob is created from must not have a secondary
+// vocabulary of its own, see `serialize`.
 class NamedCachedQueryBlobManager {
  public:
   // Allocator for the decompressed blob buffer (see `decompressBlob`). It is
@@ -59,6 +88,53 @@ class NamedCachedQueryBlobManager {
   using BlobAllocator = ad_utility::default_init_allocator<
       char,
       ad_utility::AlignedAllocator<char, ql::pmr::polymorphic_allocator<char>>>;
+
+  // The positions of the individual chunks of an uncompressed blob, as computed
+  // by `parseBlobLayout`. This is what is needed to inspect a blob without
+  // deserializing it (as the tests do), and what a follow-up diff mechanism
+  // will need in order to copy those chunks that did not change byte for byte
+  // from an earlier blob.
+  struct BlobLayout {
+    // The number of bytes that a chunk has in front of its payload (the size
+    // field plus the padding that aligns the payload), see `parseBlobLayout`.
+    static constexpr size_t chunkHeaderSize = alignof(std::max_align_t);
+
+    // The byte region `[begin_, end_)` of one chunk of the blob, where
+    // `begin_` is the (aligned) offset of the chunk's size field and `end_` is
+    // the offset right after the chunk's payload.
+    struct Region {
+      size_t begin_ = 0;
+      size_t end_ = 0;
+
+      // The number of bytes of this region.
+      size_t size() const { return end_ - begin_; }
+
+      // The offset at which the payload of this chunk begins.
+      size_t payloadBegin() const { return begin_ + chunkHeaderSize; }
+
+      // Return the payload of this chunk as a view into `blob`, which has to
+      // be the (already decompressed) blob that this region was obtained from
+      // (via `parseBlobLayout`).
+      ql::span<const char> payloadSpan(ql::span<const char> blob) const {
+        return blob.subspan(payloadBegin(), end_ - payloadBegin());
+      }
+    };
+
+    // One entry of the `NamedResultCache` in the blob, together with the name
+    // under which it is cached (which is stored at the beginning of the
+    // chunk's payload).
+    struct Entry {
+      std::string key_;
+      Region region_;
+    };
+
+    Region metadata_;
+    Region vocabulary_;
+    Region segmentCount_;
+    std::vector<Region> segments_;
+    Region entryCount_;
+    std::vector<Entry> entries_;
+  };
 
  private:
   // In this buffer, the blob passed to `deserialize` is kept alive (in
@@ -76,6 +152,17 @@ class NamedCachedQueryBlobManager {
   // the vocabulary implementation currently in use does not support zero-copy
   // serialization (see `Vocabulary::writeAsZeroCopyBlob`).
   //
+  // The blob consists of a header, followed by a sequence of *chunks* (see
+  // `parseBlobLayout` for the exact format): the index metadata JSON, the
+  // vocabulary, the segments of the secondary vocabulary of the blob, and one
+  // chunk per entry of the `NamedResultCache`.
+  //
+  // Every `Id` of a cache entry that refers to a word that is not part of the
+  // vocabulary of the index (which happens if SPARQL UPDATE operations were
+  // applied before the entry was pinned) is rewritten: the word is stored in
+  // the secondary vocabulary of the blob, and the `Id` becomes an `Id` of type
+  // `Datatype::SecondaryVocabIndex`.
+  //
   // If `config.excludedEntryRegexes_` is not empty, only those vocabulary
   // entries that match none of the regexes are exported (see
   // `BlobSerializationConfig` and `buildFilteredVocabulary`). The type of the
@@ -83,14 +170,18 @@ class NamedCachedQueryBlobManager {
   // recorded in the blob's metadata JSON (key `"vocabulary-type"`), so that
   // `deserialize` picks up the correct vocabulary implementation without any
   // change to the blob format.
+  //
+  // PRECONDITION: The index of `qlever` must not have a secondary vocabulary
+  // of its own (an index that was loaded from a blob does have one as soon as
+  // that blob contained new words).
   std::vector<char> serialize(const Qlever& qlever,
                               const BlobSerializationConfig& config = {}) const;
 
   // Load a blob previously written by `serialize`: decompress it, store it in
-  // the buffer, and then replace `qlever`'s vocabulary and `NamedResultCache`
-  // by the contents of the blob using zero-copy deserialization. The buffer is
-  // kept alive for the lifetime of this manager and is allocated via the
-  // `allocator` (see `BlobAllocator` above).
+  // the buffer, and then replace `qlever`'s vocabulary, secondary vocabulary,
+  // and `NamedResultCache` by the contents of the blob using zero-copy
+  // deserialization. The buffer is kept alive for the lifetime of this manager
+  // and is allocated via the `allocator` (see `BlobAllocator` above).
   //
   // PRECONDITION: Must only be called while no other thread can concurrently
   // access `qlever`, e.g. right after construction and before the first query
@@ -101,6 +192,30 @@ class NamedCachedQueryBlobManager {
   // The following are stateless, self-contained utilities that make up the blob
   // format. They are exposed publicly so that they can be unit-tested in
   // isolation.
+
+  // Compute the positions of the chunks of the given uncompressed blob, which
+  // has to be one written by `serialize`.
+  //
+  // THE CHUNK FORMAT: A blob starts with the header (see `writeBlobHeader`),
+  // followed by a sequence of chunks. Each chunk consists of zero padding up
+  // to the next multiple of `alignof(std::max_align_t)`, a `uint64_t` with the
+  // size of its payload, more zero padding up to the next multiple of
+  // `alignof(std::max_align_t)`, and finally the payload itself. The chunks
+  // are, in this order: the metadata JSON, the vocabulary, the number of
+  // segments of the secondary vocabulary, those segments, the number of
+  // entries of the `NamedResultCache`, and those entries (sorted by their
+  // key).
+  //
+  // The point of the padding is that the payload of every chunk starts at a
+  // multiple of `alignof(std::max_align_t)`. The bytes of a chunk are
+  // therefore *position independent*: because the alignment padding that the
+  // (aligned) serialization inserts inside the payload only depends on the
+  // offsets *within* the payload, the bytes of a chunk can be moved to any
+  // other suitably aligned offset of any suitably aligned buffer, and the
+  // zero-copy deserialization of the payload still works. That is what makes
+  // it possible to assemble a new blob out of chunks that are copied from an
+  // older blob, which is what a follow-up diff mechanism builds on.
+  static BlobLayout parseBlobLayout(ql::span<const char> uncompressedBlob);
 
   // Compress `uncompressedBlob` into a single ZSTD frame.
   static std::vector<char> compressBlob(ql::span<const char> uncompressedBlob);

--- a/src/libqlever/NamedCachedQueryBlobManager.h
+++ b/src/libqlever/NamedCachedQueryBlobManager.h
@@ -19,6 +19,7 @@
 #include "backports/memory_resource.h"
 #include "backports/span.h"
 #include "util/AlignedAllocator.h"
+#include "util/BinaryDiff.h"
 #include "util/Serializer/ByteBufferSerializer.h"
 #include "util/UninitializedAllocator.h"
 
@@ -45,10 +46,11 @@ struct BlobSerializationConfig {
 
 // Serialize and deserialize the vocabulary and the `NamedResultCache` of a
 // `Qlever` instance to and from a single, self-contained, ZSTD-compressed blob
-// (see `serialize`/`deserialize`). The functionality is bundled here (rather
-// than in the `Qlever` class itself) to keep the core `Qlever` class small; a
-// `Qlever` holds one instance of this manager as a member, and this class is a
-// friend of `Qlever` so that it can access its internals.
+// (see `serialize`/`deserialize`), and create and apply *diffs* between two
+// such blobs (see `serializeDiff`/`applyDiff`). The functionality is bundled
+// here (rather than in the `Qlever` class itself) to keep the core `Qlever`
+// class small; a `Qlever` holds one instance of this manager as a member, and
+// this class is a friend of `Qlever` so that it can access its internals.
 //
 // THE CONTENTS OF A BLOB: the index metadata JSON, the vocabulary of the
 // index, the *secondary vocabulary* of the blob (see below), and all entries of
@@ -66,16 +68,38 @@ struct BlobSerializationConfig {
 // is an append-only sequence of segments; a blob written by `serialize` has at
 // most one segment, but `deserialize` reads an arbitrary number of them.
 //
+// THE DIFF WORKFLOW: Instead of writing a complete new blob after every update
+// (which would repeat the whole vocabulary, typically by far the largest part
+// of a blob), a *diff* against an earlier blob can be written:
+//
+//   1. Pin the named queries and write the base blob (`serialize`).
+//   2. Apply the SPARQL UPDATEs, then re-pin the very same named queries.
+//   3. Write a diff against the base blob (`serializeDiff`). It consists of
+//      instructions that copy the unchanged parts (in particular the whole
+//      vocabulary and every cache entry whose result did not change) from the
+//      base blob, and that insert the changed parts.
+//   4. Apply the diff, either to the blob itself (`applyDiff`, which yields a
+//      complete blob that in turn can serve as the base of a further diff), or
+//      while loading it (`deserialize` with a list of diffs).
+//
+// Steps 2 and 3 can be repeated: a diff is always created against, and applied
+// to, a complete blob, so a chain `base + diff1 + diff2 + ...` works. Each
+// diff appends at most one segment to the secondary vocabulary, so that the
+// `Id`s that were assigned to the words of the earlier segments stay valid.
+//
 // THE CHUNK FORMAT: Store the individual parts of a blob as *chunks*, each of
 // which begins at an aligned offset (see `parseBlobLayout` for the exact
 // format). The point of that alignment is that the bytes of a chunk are
 // *position independent*, so that a chunk can be copied verbatim from one blob
-// into another one. This is what a follow-up mechanism that writes a *diff*
-// between two blobs (instead of a complete new blob after every update) builds
-// on.
+// into another one. That is what the diff mechanism builds on: a diff
+// assembles a blob from instructions that copy the unchanged chunks of an
+// earlier blob.
 //
-// PRECONDITION: The index that a blob is created from must not have a secondary
-// vocabulary of its own, see `serialize`.
+// PRECONDITIONS: The index that a blob (or a diff between two blobs) is created
+// from must not have a secondary vocabulary of its own, see `serialize`. A diff
+// must be applied to exactly the blob that it was created against (which is
+// checked via a checksum, see `applyDiff`), and all blobs of such a chain have
+// to come from the same index build.
 class NamedCachedQueryBlobManager {
  public:
   // Allocator for the decompressed blob buffer (see `decompressBlob`). It is
@@ -91,9 +115,9 @@ class NamedCachedQueryBlobManager {
 
   // The positions of the individual chunks of an uncompressed blob, as computed
   // by `parseBlobLayout`. This is what is needed to inspect a blob without
-  // deserializing it (as the tests do), and what a follow-up diff mechanism
-  // will need in order to copy those chunks that did not change byte for byte
-  // from an earlier blob.
+  // deserializing it (as the tests do), and what the creation of a diff needs
+  // in order to copy those chunks that did not change byte for byte from an
+  // earlier blob.
   struct BlobLayout {
     // The number of bytes that a chunk has in front of its payload (the size
     // field plus the padding that aligns the payload), see `parseBlobLayout`.
@@ -138,9 +162,10 @@ class NamedCachedQueryBlobManager {
 
  private:
   // In this buffer, the blob passed to `deserialize` is kept alive (in
-  // decompressed form) for the lifetime of this manager (and hence of the
-  // owning `Qlever` instance), because the loaded vocabulary and named cache
-  // entries are zero-copy views directly into it.
+  // decompressed form, and with all the diffs applied) for the lifetime of
+  // this manager (and hence of the owning `Qlever` instance), because the
+  // loaded vocabulary and named cache entries are zero-copy views directly
+  // into it.
   std::optional<std::vector<char, BlobAllocator>>
       deserializedBlobLifetimeExtender_;
 
@@ -177,15 +202,43 @@ class NamedCachedQueryBlobManager {
   std::vector<char> serialize(const Qlever& qlever,
                               const BlobSerializationConfig& config = {}) const;
 
-  // Load a blob previously written by `serialize`: decompress it, store it in
-  // the buffer, and then replace `qlever`'s vocabulary, secondary vocabulary,
-  // and `NamedResultCache` by the contents of the blob using zero-copy
-  // deserialization. The buffer is kept alive for the lifetime of this manager
-  // and is allocated via the `allocator` (see `BlobAllocator` above).
+  // Write a diff (see the class comment for the workflow) that turns
+  // `compressedBaseBlob` into the blob that `serialize` would currently write
+  // for `qlever`. The result is a serialized, ZSTD-compressed
+  // `ad_utility::BinaryDiff` whose alignment is the chunk alignment of the blob
+  // format (which is what makes the copied chunks position independent, see
+  // `parseBlobLayout`), and it is typically much smaller than a complete blob,
+  // because everything that did not change (in particular the complete
+  // vocabulary) is represented by an instruction that copies it from the base
+  // blob.
+  //
+  // The words that the current cache entries need and that are neither in the
+  // vocabulary of the index nor already in a segment of the secondary
+  // vocabulary of the base blob are appended as one new segment, so that all
+  // `Id`s of the base blob keep their meaning.
+  //
+  // PRECONDITIONS: `compressedBaseBlob` has to be a blob of the current format
+  // version that was built from the same index as `qlever`, and the index of
+  // `qlever` must not have a secondary vocabulary of its own.
+  std::vector<char> serializeDiff(
+      const Qlever& qlever, ql::span<const char> compressedBaseBlob) const;
+
+  // Load a blob previously written by `serialize`, with the `compressedDiffs`
+  // (written by `serializeDiff`) applied to it in the given order: decompress
+  // it, store it in the buffer, and then replace `qlever`'s vocabulary,
+  // secondary vocabulary, and `NamedResultCache` by the contents of the blob
+  // using zero-copy deserialization. The buffer is kept alive for the lifetime
+  // of this manager and is allocated via the `allocator` (see `BlobAllocator`
+  // above).
   //
   // PRECONDITION: Must only be called while no other thread can concurrently
   // access `qlever`, e.g. right after construction and before the first query
   // is answered. Must not be called more than once on the same manager.
+  void deserialize(Qlever& qlever, ql::span<const char> compressedBlob,
+                   ql::span<const ql::span<const char>> compressedDiffs,
+                   ql::pmr::polymorphic_allocator<char> allocator);
+
+  // Same as above, without any diffs.
   void deserialize(Qlever& qlever, ql::span<const char> compressedBlob,
                    ql::pmr::polymorphic_allocator<char> allocator);
 
@@ -193,8 +246,34 @@ class NamedCachedQueryBlobManager {
   // format. They are exposed publicly so that they can be unit-tested in
   // isolation.
 
-  // Compute the positions of the chunks of the given uncompressed blob, which
-  // has to be one written by `serialize`.
+  // Apply `compressedDiff` (written by `serializeDiff`) to
+  // `compressedBaseBlob` and return the resulting *compressed* blob, which is
+  // a complete blob again and can in turn serve as the base of a further diff.
+  // Throw with a descriptive message if `compressedDiff` is not a diff, or was
+  // created against a different base blob (which is detected via the size and
+  // the checksum of the base blob that the diff stores, see
+  // `ad_utility::BinaryDiff`).
+  static std::vector<char> applyDiff(ql::span<const char> compressedBaseBlob,
+                                     ql::span<const char> compressedDiff);
+
+  // Same as `applyDiff`, but on the *uncompressed* base blob, and returning
+  // the *uncompressed* result (allocated via the `allocator`, see
+  // `BlobAllocator`). This is what `deserialize` uses, which needs the
+  // uncompressed blob anyway.
+  static std::vector<char, BlobAllocator> applyDiffToUncompressedBlob(
+      ql::span<const char> uncompressedBase,
+      ql::span<const char> compressedDiff,
+      ql::pmr::polymorphic_allocator<char> allocator);
+
+  // Return a summary of the instructions of `compressedDiff`, see
+  // `ad_utility::BinaryDiff::Statistics`. Throw if `compressedDiff` is not a
+  // diff.
+  static ad_utility::BinaryDiff::Statistics describeDiff(
+      ql::span<const char> compressedDiff);
+
+  // Compute the positions of the chunks of the given uncompressed blob (which
+  // has to be one written by `serialize`, or the result of applying diffs to
+  // such a blob).
   //
   // THE CHUNK FORMAT: A blob starts with the header (see `writeBlobHeader`),
   // followed by a sequence of chunks. Each chunk consists of zero padding up
@@ -214,7 +293,7 @@ class NamedCachedQueryBlobManager {
   // other suitably aligned offset of any suitably aligned buffer, and the
   // zero-copy deserialization of the payload still works. That is what makes
   // it possible to assemble a new blob out of chunks that are copied from an
-  // older blob, which is what a follow-up diff mechanism builds on.
+  // older blob (see `serializeDiff`).
   static BlobLayout parseBlobLayout(ql::span<const char> uncompressedBlob);
 
   // Compress `uncompressedBlob` into a single ZSTD frame.

--- a/src/libqlever/Qlever.h
+++ b/src/libqlever/Qlever.h
@@ -564,6 +564,31 @@ class Qlever {
     return blobManager_.serialize(*this, config);
   }
 
+  // Write a diff that turns `compressedBaseBlob` (a blob previously written by
+  // `serializeVocabAndNamedCacheToCompressedBlob`) into the blob that that
+  // function would currently write for this instance. Use this after SPARQL
+  // UPDATE operations have been applied and the named queries have been
+  // re-pinned: the diff is typically much smaller than a complete blob,
+  // because everything that did not change (in particular the complete
+  // vocabulary) is only referenced, not repeated. For details, and for the
+  // complete workflow, see `NamedCachedQueryBlobManager`.
+  std::vector<char> serializeVocabAndNamedCacheDiffToCompressedBlob(
+      ql::span<const char> compressedBaseBlob) const {
+    return blobManager_.serializeDiff(*this, compressedBaseBlob);
+  }
+
+  // Apply `compressedDiff` (written by
+  // `serializeVocabAndNamedCacheDiffToCompressedBlob`) to
+  // `compressedBaseBlob` and return the resulting compressed blob, which is a
+  // complete blob again and can in turn serve as the base of a further diff.
+  // For details see `NamedCachedQueryBlobManager::applyDiff`.
+  static std::vector<char> applyDiffToCompressedBlob(
+      ql::span<const char> compressedBaseBlob,
+      ql::span<const char> compressedDiff) {
+    return NamedCachedQueryBlobManager::applyDiff(compressedBaseBlob,
+                                                  compressedDiff);
+  }
+
   // Load a blob previously written by
   // `serializeVocabAndNamedCacheToCompressedBlob`. For details see
   // `NamedCachedQueryBlobManager::deserialize`.
@@ -578,6 +603,17 @@ class Qlever {
     // Note: `polymorphic_allocator` is cheap to copy and has no
     // dedicated move operations.
     blobManager_.deserialize(*this, blob, allocator);
+  }
+
+  // Same as above, but with the given `diffs` (written by
+  // `serializeVocabAndNamedCacheDiffToCompressedBlob`) applied to the `blob`
+  // in the given order, which is equivalent to (but cheaper than) applying
+  // them via `applyDiffToCompressedBlob` one after the other and loading the
+  // result.
+  void deserializeVocabAndNamedCacheFromCompressedBlob(
+      ql::span<const char> blob, ql::span<const ql::span<const char>> diffs,
+      ql::pmr::polymorphic_allocator<char> allocator = {}) {
+    blobManager_.deserialize(*this, blob, diffs, allocator);
   }
 
   // Clear the query result cache.

--- a/src/util/BinaryDiff.cpp
+++ b/src/util/BinaryDiff.cpp
@@ -1,0 +1,130 @@
+// Copyright 2026 The QLever Authors, in particular:
+//
+// 2026 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+//
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#include "util/BinaryDiff.h"
+
+namespace ad_utility {
+
+// _____________________________________________________________________________
+BinaryDiff::BinaryDiff(ql::span<const char> base, uint64_t alignment)
+    : alignment_{alignment},
+      baseSize_{base.size()},
+      baseChecksum_{checksum(base)} {
+  AD_CONTRACT_CHECK(isPowerOfTwo(alignment),
+                    "The alignment of a `BinaryDiff` has to be a power of two, "
+                    "but is ",
+                    alignment);
+}
+
+// _____________________________________________________________________________
+void BinaryDiff::addCopy(uint64_t baseOffset, uint64_t length) {
+  AD_CONTRACT_CHECK(baseOffset % alignment_ == 0,
+                    "The offset of a copied range has to be a multiple of the "
+                    "alignment ",
+                    alignment_, ", but is ", baseOffset);
+  AD_CONTRACT_CHECK(baseOffset <= baseSize_ && length <= baseSize_ - baseOffset,
+                    "The copied range [", baseOffset, ", ", baseOffset + length,
+                    ") does not lie within the base of size ", baseSize_);
+  if (!instructions_.empty()) {
+    if (auto* previous = std::get_if<Copy>(&instructions_.back());
+        previous != nullptr &&
+        alignUp(previous->baseOffset_ + previous->length_) == baseOffset) {
+      previous->length_ = baseOffset + length - previous->baseOffset_;
+      return;
+    }
+  }
+  instructions_.push_back(Copy{baseOffset, length});
+}
+
+// _____________________________________________________________________________
+void BinaryDiff::addInsert(std::vector<char> bytes) {
+  instructions_.push_back(Insert{std::move(bytes)});
+}
+
+// _____________________________________________________________________________
+void BinaryDiff::addInsert(ql::span<const char> bytes) {
+  addInsert(std::vector<char>{bytes.begin(), bytes.end()});
+}
+
+// _____________________________________________________________________________
+size_t BinaryDiff::targetSize() const {
+  size_t size = 0;
+  for (const auto& instruction : instructions_) {
+    size = alignUp(size);
+    if (const auto* copy = std::get_if<Copy>(&instruction)) {
+      size += copy->length_;
+    } else {
+      size += std::get<Insert>(instruction).bytes_.size();
+    }
+  }
+  return size;
+}
+
+// _____________________________________________________________________________
+BinaryDiff::Statistics BinaryDiff::statistics() const {
+  Statistics statistics;
+  for (const auto& instruction : instructions_) {
+    if (const auto* copy = std::get_if<Copy>(&instruction)) {
+      ++statistics.numCopyInstructions_;
+      statistics.numCopiedBytes_ += copy->length_;
+    } else {
+      ++statistics.numInsertInstructions_;
+      statistics.numInsertedBytes_ +=
+          std::get<Insert>(instruction).bytes_.size();
+    }
+  }
+  return statistics;
+}
+
+// _____________________________________________________________________________
+uint64_t BinaryDiff::checksum(ql::span<const char> bytes) {
+  uint64_t hash = fnvOffsetBasis;
+  for (char byte : bytes) {
+    hash ^= static_cast<uint64_t>(static_cast<unsigned char>(byte));
+    hash *= 0x100000001b3ULL;
+  }
+  return hash;
+}
+
+// _____________________________________________________________________________
+bool BinaryDiff::isPowerOfTwo(uint64_t alignment) {
+  return alignment > 0 && (alignment & (alignment - 1)) == 0;
+}
+
+// _____________________________________________________________________________
+size_t BinaryDiff::alignUp(size_t offset) const {
+  return (offset + alignment_ - 1) & ~(alignment_ - 1);
+}
+
+// _____________________________________________________________________________
+void BinaryDiff::checkBase(ql::span<const char> base) const {
+  // The size is checked first, because it is much cheaper than the checksum.
+  AD_CONTRACT_CHECK(base.size() == baseSize_, wrongBaseMessage);
+  AD_CONTRACT_CHECK(checksum(base) == baseChecksum_, wrongBaseMessage);
+}
+
+// _____________________________________________________________________________
+void BinaryDiff::checkInstructions(ql::span<const char> base) const {
+  // NOTE: The instructions of a diff that was created via `addCopy` always
+  // fulfill these checks; those of a diff that was deserialized from a
+  // corrupted input might not.
+  for (const auto& instruction : instructions_) {
+    const auto* copy = std::get_if<Copy>(&instruction);
+    if (copy == nullptr) {
+      continue;
+    }
+    AD_CONTRACT_CHECK(copy->baseOffset_ % alignment_ == 0,
+                      invalidInstructionMessage);
+    AD_CONTRACT_CHECK(copy->baseOffset_ <= base.size() &&
+                          copy->length_ <= base.size() - copy->baseOffset_,
+                      invalidInstructionMessage);
+  }
+}
+
+}  // namespace ad_utility

--- a/src/util/BinaryDiff.h
+++ b/src/util/BinaryDiff.h
@@ -1,0 +1,315 @@
+// Copyright 2026 The QLever Authors, in particular:
+//
+// 2026 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+//
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#ifndef QLEVER_SRC_UTIL_BINARYDIFF_H
+#define QLEVER_SRC_UTIL_BINARYDIFF_H
+
+#include <absl/strings/str_cat.h>
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <exception>
+#include <memory>
+#include <string_view>
+#include <type_traits>
+#include <variant>
+#include <vector>
+
+#include "backports/span.h"
+#include "backports/three_way_comparison.h"
+#include "util/Exception.h"
+#include "util/Serializer/SerializeArrayOrTuple.h"
+#include "util/Serializer/SerializeVector.h"
+#include "util/Serializer/Serializer.h"
+
+namespace ad_utility {
+
+// A diff that turns a "base" byte buffer into a "target" byte buffer. It is a
+// sequence of instructions, each of which either copies a range of the base
+// (`Copy`) or inserts literal bytes (`Insert`). A diff is created by
+// constructing it from the base and then appending instructions (see `addCopy`
+// and `addInsert`), and it is applied to a base via `apply`. It can be
+// serialized and deserialized with the QLever serializer framework (see
+// `util/Serializer/Serializer.h`).
+//
+// ALIGNMENT: Before every single instruction, the output of `apply` is padded
+// with zeros up to a multiple of the `alignment` that the diff was created
+// with. This makes it possible to diff a format that consists of aligned,
+// *position-independent* blocks: such a block can be copied to any other
+// suitably aligned offset of the target and still be read back correctly, so
+// that a target buffer can be assembled from blocks of the base buffer. An
+// alignment of 1 means that no padding is inserted, which is the right choice
+// for a format without such alignment requirements.
+//
+// BASE IDENTIFICATION: A diff stores the size and a checksum (see `checksum`)
+// of the base that it was created against, and `apply` verifies both. A diff
+// therefore has to be applied to exactly the base that it was created against;
+// applying it to any other buffer throws instead of silently producing garbage.
+class BinaryDiff {
+ public:
+  // An instruction that copies the bytes `[baseOffset_, baseOffset_ + length_)`
+  // of the base.
+  struct Copy {
+    uint64_t baseOffset_ = 0;
+    uint64_t length_ = 0;
+
+    QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(Copy, baseOffset_, length_)
+  };
+
+  // An instruction that inserts the literal bytes `bytes_`, which are stored
+  // in the diff itself.
+  struct Insert {
+    std::vector<char> bytes_;
+
+    QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(Insert, bytes_)
+  };
+
+  using Instruction = std::variant<Copy, Insert>;
+
+  // A summary of the instructions of a diff, as computed by `statistics()`.
+  // Meant for tests and for logging by the users of this class.
+  struct Statistics {
+    size_t numCopyInstructions_ = 0;
+    size_t numInsertInstructions_ = 0;
+    size_t numCopiedBytes_ = 0;
+    size_t numInsertedBytes_ = 0;
+
+    QL_DEFINE_DEFAULTED_EQUALITY_OPERATOR_LOCAL(Statistics,
+                                                numCopyInstructions_,
+                                                numInsertInstructions_,
+                                                numCopiedBytes_,
+                                                numInsertedBytes_)
+  };
+
+ private:
+  // The kinds of instruction, as stored in the serialization of a diff.
+  enum class InstructionKind : uint8_t { Copy = 0, Insert = 1 };
+
+  // The header that is written at the beginning of the serialization of a
+  // diff, to guard against reading data that is not a diff at all, or that was
+  // written by an incompatible version of QLever.
+  static constexpr std::array<char, 8> magicBytes{'Q', 'L', 'V', 'R',
+                                                  'D', 'I', 'F', 'F'};
+  static constexpr uint16_t formatVersion = 1;
+
+  // The message that is reported for any input that is not the serialization
+  // of a `BinaryDiff`, or that is truncated or otherwise corrupted.
+  static constexpr std::string_view notReadableMessage =
+      "The given input is not a serialized `ad_utility::BinaryDiff`, or is "
+      "corrupted";
+
+  // The message that is reported when a diff is applied to a base other than
+  // the one that it was created against.
+  static constexpr std::string_view wrongBaseMessage =
+      "The given diff was created against a different base (the size or the "
+      "checksum of the base does not match). Note that a diff has to be "
+      "applied to exactly the base that it was created against";
+
+  // The message that is reported when a diff has an instruction that does not
+  // make sense for the given base.
+  static constexpr std::string_view invalidInstructionMessage =
+      "The given diff contains an invalid instruction; it is either corrupted, "
+      "or it was created against a different base";
+
+  // The FNV-1a 64 offset basis, which is the checksum of an empty input, see
+  // `checksum`.
+  static constexpr uint64_t fnvOffsetBasis = 0xcbf29ce484222325ULL;
+
+  uint64_t alignment_ = 1;
+  uint64_t baseSize_ = 0;
+  uint64_t baseChecksum_ = fnvOffsetBasis;
+  std::vector<Instruction> instructions_;
+
+ public:
+  // The default constructor creates an empty diff for an empty base. It is
+  // needed for deserialization; to create a diff, use the constructor below.
+  BinaryDiff() = default;
+
+  // Start a diff that turns `base` into some target. The `alignment` has to be
+  // a power of two (see the class comment for its meaning).
+  BinaryDiff(ql::span<const char> base, uint64_t alignment);
+
+  // Append an instruction that copies the bytes
+  // `[baseOffset, baseOffset + length)` of the base. The `baseOffset` has to be
+  // a multiple of the alignment, and the range has to lie within the base.
+  //
+  // If the previous instruction is a copy of the range that directly precedes
+  // `[baseOffset, ...)` in the base, the two are merged into a single
+  // instruction. This is also done if the two ranges are only contiguous
+  // *modulo* the alignment padding: the bytes between them are the alignment
+  // padding of the second range, which consists of zeros in the base and which
+  // `apply` would insert as zeros anyway, so that merging does not change the
+  // result.
+  void addCopy(uint64_t baseOffset, uint64_t length);
+
+  // Append an instruction that inserts the given literal bytes, which become
+  // part of the diff itself.
+  void addInsert(std::vector<char> bytes);
+  void addInsert(ql::span<const char> bytes);
+
+  // Apply this diff to `base` and return the target. The `base` has to be
+  // exactly the buffer that this diff was created against (which is verified
+  // via its size and checksum, see the class comment); if it is not, or if an
+  // instruction of the diff is invalid for it, throw with a descriptive
+  // message. The returned buffer uses the given `allocator`, which allows
+  // callers to obtain an aligned or a `pmr`-allocated buffer.
+  template <typename Allocator = std::allocator<char>>
+  std::vector<char, Allocator> apply(ql::span<const char> base,
+                                     Allocator allocator = {}) const;
+
+  // The exact size of the buffer that `apply` returns (the sum of the sizes of
+  // all instructions, plus the alignment padding in front of them).
+  size_t targetSize() const;
+
+  // A summary of the instructions of this diff, see `Statistics`.
+  Statistics statistics() const;
+
+  // Simple getters.
+  const std::vector<Instruction>& instructions() const { return instructions_; }
+  uint64_t alignment() const { return alignment_; }
+  uint64_t baseSize() const { return baseSize_; }
+  uint64_t baseChecksum() const { return baseChecksum_; }
+
+  // Compute the FNV-1a 64 bit hash of `bytes`, which is used as the checksum
+  // that ties a diff to the exact base that it was created against. NOTE: This
+  // is not a cryptographic hash; it only guards against accidentally applying a
+  // diff to the wrong (or to a corrupted) base, not against deliberate
+  // tampering.
+  static uint64_t checksum(ql::span<const char> bytes);
+
+  // Serialize and deserialize a diff, see `util/Serializer/Serializer.h`. When
+  // reading, verify the magic bytes and the format version, and report a
+  // truncated or otherwise unreadable input with a descriptive message.
+  AD_SERIALIZE_FRIEND_FUNCTION(BinaryDiff) {
+    namespace ser = ad_utility::serialization;
+    if constexpr (ser::WriteSerializer<S>) {
+      serializer << magicBytes;
+      serializer << formatVersion;
+      serializer << arg.alignment_;
+      serializer << arg.baseSize_;
+      serializer << arg.baseChecksum_;
+      serializer << static_cast<uint64_t>(arg.instructions_.size());
+      for (const auto& instruction : arg.instructions_) {
+        if (const auto* copy = std::get_if<Copy>(&instruction)) {
+          serializer << static_cast<uint8_t>(InstructionKind::Copy);
+          serializer << copy->baseOffset_;
+          serializer << copy->length_;
+        } else {
+          serializer << static_cast<uint8_t>(InstructionKind::Insert);
+          serializer << std::get<Insert>(instruction).bytes_;
+        }
+      }
+    } else {
+      auto readMagicBytes =
+          readOrThrow<std::decay_t<decltype(magicBytes)>>(serializer);
+      AD_CONTRACT_CHECK(readMagicBytes == magicBytes, notReadableMessage);
+      auto version = readOrThrow<uint16_t>(serializer);
+      AD_CONTRACT_CHECK(
+          version == formatVersion,
+          "The given diff was written by an incompatible version of QLever "
+          "(format version ",
+          version, ", expected ", formatVersion, ")");
+      arg.alignment_ = readOrThrow<uint64_t>(serializer);
+      AD_CONTRACT_CHECK(isPowerOfTwo(arg.alignment_), notReadableMessage,
+                        ". Details: the alignment ", arg.alignment_,
+                        " is not a power of two");
+      arg.baseSize_ = readOrThrow<uint64_t>(serializer);
+      arg.baseChecksum_ = readOrThrow<uint64_t>(serializer);
+      auto numInstructions = readOrThrow<uint64_t>(serializer);
+      // NOTE: Deliberately no `reserve`, because `numInstructions` comes from a
+      // possibly corrupted input.
+      arg.instructions_.clear();
+      for (uint64_t i = 0; i < numInstructions; ++i) {
+        arg.instructions_.push_back(readInstruction(serializer));
+      }
+    }
+  }
+
+ private:
+  // Read a single value of type `T`, and report a truncated or otherwise
+  // unreadable input with `notReadableMessage` (instead of with the rather
+  // cryptic message of the serializer).
+  template <typename T, typename S>
+  static T readOrThrow(S& serializer) {
+    try {
+      T value{};
+      serializer >> value;
+      return value;
+    } catch (const std::exception& exception) {
+      AD_THROW(
+          absl::StrCat(notReadableMessage, ". Details: ", exception.what()));
+    }
+  }
+
+  // Read a single instruction, see the `serialize` function above.
+  template <typename S>
+  static Instruction readInstruction(S& serializer) {
+    auto kind = readOrThrow<uint8_t>(serializer);
+    if (kind == static_cast<uint8_t>(InstructionKind::Copy)) {
+      Copy copy;
+      copy.baseOffset_ = readOrThrow<uint64_t>(serializer);
+      copy.length_ = readOrThrow<uint64_t>(serializer);
+      return copy;
+    }
+    if (kind == static_cast<uint8_t>(InstructionKind::Insert)) {
+      return Insert{readOrThrow<std::vector<char>>(serializer)};
+    }
+    AD_THROW(absl::StrCat(notReadableMessage,
+                          ". Details: unknown instruction kind ", kind));
+  }
+
+  // Return true if `alignment` is a power of two, which the alignment of a
+  // `BinaryDiff` always has to be.
+  static bool isPowerOfTwo(uint64_t alignment);
+
+  // Round `offset` up to the next multiple of the alignment.
+  size_t alignUp(size_t offset) const;
+
+  // Throw if `base` is not the base that this diff was created against, see
+  // `apply`.
+  void checkBase(ql::span<const char> base) const;
+
+  // Throw if any instruction of this diff is invalid for `base` (an offset that
+  // is not a multiple of the alignment, or a range that does not lie within
+  // `base`), see `apply`.
+  void checkInstructions(ql::span<const char> base) const;
+};
+
+// _____________________________________________________________________________
+template <typename Allocator>
+std::vector<char, Allocator> BinaryDiff::apply(ql::span<const char> base,
+                                               Allocator allocator) const {
+  checkBase(base);
+  // Validate all instructions before the first byte is written, so that
+  // `targetSize` (which is used for the `reserve` below) cannot be a bogus
+  // value that comes from a corrupted diff.
+  checkInstructions(base);
+  std::vector<char, Allocator> target(std::move(allocator));
+  target.reserve(targetSize());
+  for (const auto& instruction : instructions_) {
+    // Pad with zeros, so that the bytes of the following instruction (which for
+    // a `Copy` came from a multiple of the alignment in the base) again begin
+    // at a multiple of the alignment, see the class comment.
+    target.insert(target.end(), alignUp(target.size()) - target.size(),
+                  char{0});
+    if (const auto* copy = std::get_if<Copy>(&instruction)) {
+      auto copiedBytes = base.subspan(copy->baseOffset_, copy->length_);
+      target.insert(target.end(), copiedBytes.begin(), copiedBytes.end());
+    } else {
+      const auto& bytes = std::get<Insert>(instruction).bytes_;
+      target.insert(target.end(), bytes.begin(), bytes.end());
+    }
+  }
+  return target;
+}
+
+}  // namespace ad_utility
+
+#endif  // QLEVER_SRC_UTIL_BINARYDIFF_H

--- a/src/util/BinaryDiff.h
+++ b/src/util/BinaryDiff.h
@@ -44,9 +44,11 @@ namespace ad_utility {
 // with. This makes it possible to diff a format that consists of aligned,
 // *position-independent* blocks: such a block can be copied to any other
 // suitably aligned offset of the target and still be read back correctly, so
-// that a target buffer can be assembled from blocks of the base buffer. An
-// alignment of 1 means that no padding is inserted, which is the right choice
-// for a format without such alignment requirements.
+// that a target buffer can be assembled from blocks of the base buffer. The
+// chunked blob format of `libqlever/NamedCachedQueryBlobManager.h`, which is
+// what this class was written for, is such a format. An alignment of 1 means
+// that no padding is inserted, which is the right choice for a format without
+// such alignment requirements.
 //
 // BASE IDENTIFICATION: A diff stores the size and a checksum (see `checksum`)
 // of the base that it was created against, and `apply` verifies both. A diff

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -16,7 +16,7 @@ qlever_target_link_libraries(antlrErrorHandling stringUtils antlr4_umbrella)
 
 # The general-purpose utilities. Everything in here may depend on `rdfTypes`,
 # so nothing that `rdfTypes` itself needs must be added to this library.
-add_library(qlever_util RegexSet.cpp ParseableDuration.cpp UnitOfMeasurement.cpp Conversions.cpp Date.cpp DateYearDuration.cpp Duration.cpp CancellationHandle.cpp LazyJsonParser.cpp BlankNodeManager.cpp IoUringManager.cpp FilesystemHelpers.cpp QueryEventLog.cpp ResourceMonitor.cpp)
+add_library(qlever_util BinaryDiff.cpp RegexSet.cpp ParseableDuration.cpp UnitOfMeasurement.cpp Conversions.cpp Date.cpp DateYearDuration.cpp Duration.cpp CancellationHandle.cpp LazyJsonParser.cpp BlankNodeManager.cpp IoUringManager.cpp FilesystemHelpers.cpp QueryEventLog.cpp ResourceMonitor.cpp)
 qlever_target_link_libraries(qlever_util antlrErrorHandling s2 pb_util pb_util_geo pb_util_json rdfTypes antlr4_umbrella)
 
 add_subdirectory(metrics)

--- a/src/util/Serializer/ByteBufferSerializer.h
+++ b/src/util/Serializer/ByteBufferSerializer.h
@@ -42,10 +42,11 @@ class ByteBufferWriteSerializerT : public NoCopy {
 
   // Overwrite the `numBytes` bytes that start at `position` (which have to
   // have been written before) by the `numBytes` bytes at `bytePointer`. This
-  // is needed to patch a field whose value is only known after the data that
-  // it describes has been written, for example the size of a block of data: it
-  // is first written as a placeholder, and patched with this function once the
-  // block is complete.
+  // is needed to patch a size field whose value is only known after the data
+  // that it describes has been written, as in the chunked blob format of
+  // `NamedCachedQueryBlobManager`: the size of a chunk is written as a
+  // placeholder first, and patched with this function once the payload of the
+  // chunk is complete.
   void overwriteBytes(size_t position, const char* bytePointer,
                       size_t numBytes) {
     AD_CONTRACT_CHECK(position + numBytes <= data_.size());

--- a/src/util/Serializer/ByteBufferSerializer.h
+++ b/src/util/Serializer/ByteBufferSerializer.h
@@ -40,6 +40,18 @@ class ByteBufferWriteSerializerT : public NoCopy {
     data_.insert(data_.end(), bytePointer, bytePointer + numBytes);
   }
 
+  // Overwrite the `numBytes` bytes that start at `position` (which have to
+  // have been written before) by the `numBytes` bytes at `bytePointer`. This
+  // is needed to patch a field whose value is only known after the data that
+  // it describes has been written, for example the size of a block of data: it
+  // is first written as a placeholder, and patched with this function once the
+  // block is complete.
+  void overwriteBytes(size_t position, const char* bytePointer,
+                      size_t numBytes) {
+    AD_CONTRACT_CHECK(position + numBytes <= data_.size());
+    std::copy(bytePointer, bytePointer + numBytes, data_.begin() + position);
+  }
+
   void clear() { data_.clear(); }
 
   const Storage& data() const& noexcept { return data_; }

--- a/src/util/Serializer/TripleSerializer.h
+++ b/src/util/Serializer/TripleSerializer.h
@@ -93,6 +93,23 @@ CPP_template(typename Serializer)(
                        ad_utility::dereference);
 }
 
+// Serialize the local vocabulary to the output stream, but without any of its
+// words: write exactly the format of `serializeLocalVocab` above, with the
+// number of words set to zero, such that `deserializeLocalVocab` reads it back
+// as a local vocab that holds only the blank node blocks (and returns an empty
+// mapping). Use this for a caller that stores the words elsewhere, e.g. in a
+// persistent vocabulary, and that has rewritten the `Id`s that refer to those
+// words accordingly, so that the words must not be written a second time here.
+CPP_template(typename Serializer)(
+    requires serialization::WriteSerializer<
+        Serializer>) void serializeLocalVocabWithoutWords(Serializer&
+                                                              serializer,
+                                                          const LocalVocab&
+                                                              vocab) {
+  serializer << vocab.getOwnedLocalBlankNodeBlocks();
+  serializer << uint64_t{0};
+}
+
 // Deserialize the local vocabulary from the input stream.
 CPP_template(typename Serializer)(
     requires serialization::ReadSerializer<Serializer>) std::

--- a/src/util/Serializer/TripleSerializer.h
+++ b/src/util/Serializer/TripleSerializer.h
@@ -97,9 +97,11 @@ CPP_template(typename Serializer)(
 // words: write exactly the format of `serializeLocalVocab` above, with the
 // number of words set to zero, such that `deserializeLocalVocab` reads it back
 // as a local vocab that holds only the blank node blocks (and returns an empty
-// mapping). Use this for a caller that stores the words elsewhere, e.g. in a
-// persistent vocabulary, and that has rewritten the `Id`s that refer to those
-// words accordingly, so that the words must not be written a second time here.
+// mapping). Use this if the caller has stored the words elsewhere, as
+// `NamedCachedQueryBlobManager` does: it moves the words of the local vocab of
+// a named cache entry to the secondary vocabulary of the blob, and rewrites
+// the `Id`s of the entry accordingly, so that the words must not be written a
+// second time here.
 CPP_template(typename Serializer)(
     requires serialization::WriteSerializer<
         Serializer>) void serializeLocalVocabWithoutWords(Serializer&

--- a/test/BinaryDiffTest.cpp
+++ b/test/BinaryDiffTest.cpp
@@ -1,0 +1,449 @@
+// Copyright 2026 The QLever Authors, in particular:
+//
+// 2026 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+//
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "./util/GTestHelpers.h"
+#include "util/AlignedAllocator.h"
+#include "util/BinaryDiff.h"
+#include "util/Serializer/ByteBufferSerializer.h"
+
+using ad_utility::BinaryDiff;
+using Copy = BinaryDiff::Copy;
+using Insert = BinaryDiff::Insert;
+using Instruction = BinaryDiff::Instruction;
+using Statistics = BinaryDiff::Statistics;
+using ad_utility::serialization::ByteBufferReadSerializer;
+using ad_utility::serialization::ByteBufferWriteSerializer;
+using ::testing::ElementsAre;
+using ::testing::HasSubstr;
+using ::testing::IsEmpty;
+
+namespace {
+
+// Convert `bytes` to a `std::string`, so that a mismatch of two buffers is
+// reported readably by GoogleTest.
+template <typename Bytes>
+std::string toString(const Bytes& bytes) {
+  return std::string{bytes.begin(), bytes.end()};
+}
+
+// Convert `string` to a buffer of bytes.
+std::vector<char> toBytes(std::string_view string) {
+  return std::vector<char>{string.begin(), string.end()};
+}
+
+// Shorthands for the expected instructions and statistics of a diff. They are
+// functions (and not braced initializers) because the commas of a braced
+// initializer would be parsed as argument separators of the surrounding test
+// macro.
+Instruction copyInstruction(uint64_t baseOffset, uint64_t length) {
+  return Copy{baseOffset, length};
+}
+Instruction insertInstruction(std::string_view bytes) {
+  return Insert{toBytes(bytes)};
+}
+Statistics statistics(size_t numCopyInstructions, size_t numInsertInstructions,
+                      size_t numCopiedBytes, size_t numInsertedBytes) {
+  return {numCopyInstructions, numInsertInstructions, numCopiedBytes,
+          numInsertedBytes};
+}
+
+// The header of the serialization of a diff, so that the tests below can write
+// diffs "by hand" (see `writeRawDiff`), in particular diffs that the interface
+// of `BinaryDiff` refuses to create.
+struct RawDiffHeader {
+  std::array<char, 8> magicBytes_{'Q', 'L', 'V', 'R', 'D', 'I', 'F', 'F'};
+  uint16_t formatVersion_ = 1;
+  uint64_t alignment_ = 1;
+  uint64_t baseSize_ = 0;
+  uint64_t baseChecksum_ = 0;
+};
+
+// Write the serialization of a diff that consists of the given `header` and of
+// the `numInstructions` instructions that `writeInstructions` writes.
+template <typename WriteInstructions>
+std::vector<char> writeRawDiff(const RawDiffHeader& header,
+                               uint64_t numInstructions,
+                               WriteInstructions writeInstructions) {
+  ByteBufferWriteSerializer writer;
+  writer << header.magicBytes_;
+  writer << header.formatVersion_;
+  writer << header.alignment_;
+  writer << header.baseSize_;
+  writer << header.baseChecksum_;
+  writer << numInstructions;
+  writeInstructions(writer);
+  return std::move(writer).data();
+}
+
+// Return a callable that writes a single copy instruction, for `writeRawDiff`.
+auto writeRawCopy(uint64_t baseOffset, uint64_t length) {
+  return [baseOffset, length](ByteBufferWriteSerializer& writer) {
+    writer << static_cast<uint8_t>(0);
+    writer << baseOffset;
+    writer << length;
+  };
+}
+
+// Deserialize a diff from `bytes`.
+BinaryDiff deserializeDiff(std::vector<char> bytes) {
+  ByteBufferReadSerializer reader{std::move(bytes)};
+  BinaryDiff diff;
+  reader >> diff;
+  return diff;
+}
+
+// Serialize `diff` and immediately deserialize it again.
+BinaryDiff serializeAndDeserialize(const BinaryDiff& diff) {
+  ByteBufferWriteSerializer writer;
+  writer << diff;
+  return deserializeDiff(std::move(writer).data());
+}
+
+}  // namespace
+
+// _____________________________________________________________________________
+TEST(BinaryDiff, alignmentHasToBeAPowerOfTwo) {
+  auto base = toBytes("0123456789");
+  for (uint64_t alignment : {uint64_t{0}, uint64_t{3}, uint64_t{6},
+                             uint64_t{100}, (uint64_t{1} << 63) + 1}) {
+    AD_EXPECT_THROW_WITH_MESSAGE(
+        (BinaryDiff{base, alignment}),
+        HasSubstr("alignment of a `BinaryDiff` has to be a power of two"));
+  }
+  for (uint64_t alignment : {uint64_t{1}, uint64_t{2}, uint64_t{16},
+                             uint64_t{4096}, uint64_t{1} << 63}) {
+    BinaryDiff diff{base, alignment};
+    EXPECT_EQ(diff.alignment(), alignment);
+  }
+}
+
+// _____________________________________________________________________________
+TEST(BinaryDiff, checksum) {
+  // The FNV-1a 64 offset basis, which is the checksum of the empty input.
+  EXPECT_EQ(BinaryDiff::checksum({}), 0xcbf29ce484222325ULL);
+  // The checksum is deterministic, and it differs for different inputs.
+  auto hello = toBytes("hello");
+  EXPECT_EQ(BinaryDiff::checksum(hello), BinaryDiff::checksum(hello));
+  EXPECT_NE(BinaryDiff::checksum(hello),
+            BinaryDiff::checksum(toBytes("hellp")));
+  EXPECT_NE(BinaryDiff::checksum(hello),
+            BinaryDiff::checksum(toBytes("olleh")));
+  EXPECT_NE(BinaryDiff::checksum(hello), BinaryDiff::checksum(toBytes("hell")));
+  // Bytes with the highest bit set are also covered (`char` may be signed).
+  std::vector<char> highBitSet{'\x80'};
+  std::vector<char> zeroByte{'\0'};
+  EXPECT_NE(BinaryDiff::checksum(highBitSet), BinaryDiff::checksum(zeroByte));
+}
+
+// _____________________________________________________________________________
+TEST(BinaryDiff, emptyDiff) {
+  auto base = toBytes("0123456789");
+  BinaryDiff diff{base, 1};
+  EXPECT_EQ(diff.baseSize(), base.size());
+  EXPECT_EQ(diff.baseChecksum(), BinaryDiff::checksum(base));
+  EXPECT_THAT(diff.instructions(), IsEmpty());
+  EXPECT_EQ(diff.targetSize(), 0U);
+  EXPECT_EQ(diff.statistics(), statistics(0, 0, 0, 0));
+  EXPECT_THAT(diff.apply(base), IsEmpty());
+}
+
+// _____________________________________________________________________________
+TEST(BinaryDiff, roundTripWithoutAlignment) {
+  auto base = toBytes("0123456789");
+  BinaryDiff diff{base, 1};
+  diff.addCopy(0, 3);
+  diff.addInsert(toBytes("XY"));
+  diff.addCopy(5, 2);
+  diff.addInsert(toBytes("!"));
+  // With an alignment of one, no padding is inserted between the instructions.
+  EXPECT_THAT(diff.instructions(),
+              ElementsAre(copyInstruction(0, 3), insertInstruction("XY"),
+                          copyInstruction(5, 2), insertInstruction("!")));
+  EXPECT_EQ(diff.targetSize(), 8U);
+  EXPECT_EQ(toString(diff.apply(base)), "012XY56!");
+  EXPECT_EQ(diff.statistics(), statistics(2, 2, 5, 3));
+}
+
+// _____________________________________________________________________________
+TEST(BinaryDiff, roundTripWithAlignment) {
+  // A base that consists of three 16-byte blocks.
+  std::string blockA(16, 'A');
+  std::string blockB(16, 'B');
+  std::string blockC(16, 'C');
+  auto base = toBytes(blockA + blockB + blockC);
+  BinaryDiff diff{base, 16};
+  diff.addCopy(32, 16);
+  diff.addInsert(toBytes("xyz"));
+  diff.addCopy(0, 16);
+  // The insert of three bytes is padded with 13 zeros, so that the copy of
+  // `blockA` again lands at an offset that is a multiple of the alignment.
+  std::string expected = blockC + "xyz" + std::string(13, '\0') + blockA;
+  ASSERT_EQ(expected.size(), 48U);
+  EXPECT_EQ(diff.targetSize(), 48U);
+  EXPECT_EQ(toString(diff.apply(base)), expected);
+  EXPECT_EQ(diff.statistics(), statistics(2, 1, 32, 3));
+}
+
+// _____________________________________________________________________________
+TEST(BinaryDiff, applyUsesTheGivenAllocator) {
+  auto base = toBytes(std::string(64, 'x'));
+  BinaryDiff diff{base, 16};
+  diff.addCopy(0, 64);
+  using Allocator =
+      ad_utility::AlignedAllocator<char, std::allocator<char>, 64>;
+  std::vector<char, Allocator> target = diff.apply<Allocator>(base);
+  EXPECT_EQ(toString(target), std::string(64, 'x'));
+  EXPECT_EQ(reinterpret_cast<uintptr_t>(target.data()) % 64, 0U);
+}
+
+// _____________________________________________________________________________
+TEST(BinaryDiff, mergeOfAdjacentCopies) {
+  auto base = toBytes("0123456789");
+  {
+    // Two directly adjacent copies are merged.
+    BinaryDiff diff{base, 1};
+    diff.addCopy(0, 3);
+    diff.addCopy(3, 4);
+    EXPECT_THAT(diff.instructions(), ElementsAre(copyInstruction(0, 7)));
+    EXPECT_EQ(toString(diff.apply(base)), "0123456");
+  }
+  {
+    // A gap between the two copies prevents the merge.
+    BinaryDiff diff{base, 1};
+    diff.addCopy(0, 3);
+    diff.addCopy(4, 2);
+    EXPECT_THAT(diff.instructions(),
+                ElementsAre(copyInstruction(0, 3), copyInstruction(4, 2)));
+    EXPECT_EQ(toString(diff.apply(base)), "01245");
+  }
+  {
+    // An insert between the two copies prevents the merge.
+    BinaryDiff diff{base, 1};
+    diff.addCopy(0, 3);
+    diff.addInsert(toBytes("-"));
+    diff.addCopy(3, 3);
+    EXPECT_THAT(diff.instructions(),
+                ElementsAre(copyInstruction(0, 3), insertInstruction("-"),
+                            copyInstruction(3, 3)));
+    EXPECT_EQ(toString(diff.apply(base)), "012-345");
+  }
+}
+
+// _____________________________________________________________________________
+TEST(BinaryDiff, mergeOfCopiesThatAreAdjacentModuloPadding) {
+  // A base of two 16-byte blocks, each of which holds ten bytes of payload
+  // followed by six bytes of (zero) alignment padding.
+  std::string firstBlock = std::string(10, 'A') + std::string(6, '\0');
+  std::string secondBlock = std::string(10, 'B') + std::string(6, '\0');
+  {
+    // The two copies are contiguous modulo the alignment padding, and are
+    // therefore merged into a single copy that also covers that padding.
+    auto base = toBytes(firstBlock + secondBlock);
+    BinaryDiff diff{base, 16};
+    diff.addCopy(0, 10);
+    diff.addCopy(16, 10);
+    EXPECT_THAT(diff.instructions(), ElementsAre(copyInstruction(0, 26)));
+    // The result is the same as it would be without the merge, because the
+    // padding in the base consists of zeros.
+    EXPECT_EQ(toString(diff.apply(base)), firstBlock + std::string(10, 'B'));
+  }
+  {
+    // A block that is skipped between the two copies prevents the merge.
+    std::string thirdBlock(16, 'C');
+    auto base = toBytes(firstBlock + secondBlock + thirdBlock);
+    BinaryDiff diff{base, 16};
+    diff.addCopy(0, 10);
+    diff.addCopy(32, 16);
+    EXPECT_THAT(diff.instructions(),
+                ElementsAre(copyInstruction(0, 10), copyInstruction(32, 16)));
+    EXPECT_EQ(toString(diff.apply(base)), firstBlock + thirdBlock);
+  }
+}
+
+// _____________________________________________________________________________
+TEST(BinaryDiff, addCopyChecksItsArguments) {
+  auto base = toBytes(std::string(32, 'x'));
+  BinaryDiff diff{base, 16};
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      diff.addCopy(8, 8),
+      HasSubstr("offset of a copied range has to be a multiple of the "
+                "alignment 16, but is 8"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      diff.addCopy(16, 32),
+      HasSubstr("copied range [16, 48) does not lie within the base of size "
+                "32"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      diff.addCopy(48, 0),
+      HasSubstr("copied range [48, 48) does not lie within the base of size "
+                "32"));
+  EXPECT_THAT(diff.instructions(), IsEmpty());
+  // The complete base may be copied.
+  diff.addCopy(0, 32);
+  EXPECT_EQ(toString(diff.apply(base)), std::string(32, 'x'));
+}
+
+// _____________________________________________________________________________
+TEST(BinaryDiff, applyToTheWrongBase) {
+  auto base = toBytes("0123456789");
+  BinaryDiff diff{base, 1};
+  diff.addCopy(0, 10);
+  const std::string expectedMessage =
+      "created against a different base (the size or the checksum of the base "
+      "does not match)";
+  // A base of a different size.
+  AD_EXPECT_THROW_WITH_MESSAGE(diff.apply(toBytes("012345678")),
+                               HasSubstr(expectedMessage));
+  // A base of the same size, but with different contents.
+  AD_EXPECT_THROW_WITH_MESSAGE(diff.apply(toBytes("012345678X")),
+                               HasSubstr(expectedMessage));
+  // The correct base works.
+  EXPECT_EQ(toString(diff.apply(base)), "0123456789");
+}
+
+// _____________________________________________________________________________
+TEST(BinaryDiff, applyChecksTheInstructions) {
+  auto base = toBytes(std::string(32, 'x'));
+  RawDiffHeader header{};
+  header.alignment_ = 16;
+  header.baseSize_ = base.size();
+  header.baseChecksum_ = BinaryDiff::checksum(base);
+  // A copy whose range does not lie within the base.
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      deserializeDiff(writeRawDiff(header, 1, writeRawCopy(16, 32)))
+          .apply(base),
+      HasSubstr("contains an invalid instruction"));
+  // A copy whose offset is not a multiple of the alignment.
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      deserializeDiff(writeRawDiff(header, 1, writeRawCopy(8, 8))).apply(base),
+      HasSubstr("contains an invalid instruction"));
+  // A valid copy of the same, hand-written shape works.
+  auto validDiff =
+      deserializeDiff(writeRawDiff(header, 1, writeRawCopy(16, 16)));
+  EXPECT_EQ(toString(validDiff.apply(base)), std::string(16, 'x'));
+}
+
+// _____________________________________________________________________________
+TEST(BinaryDiff, serializationRoundTrip) {
+  std::string blockA(16, 'A');
+  std::string blockB(16, 'B');
+  auto base = toBytes(blockA + blockB);
+  BinaryDiff diff{base, 16};
+  diff.addCopy(16, 16);
+  diff.addInsert(toBytes("insert"));
+  diff.addCopy(0, 16);
+  auto deserialized = serializeAndDeserialize(diff);
+  EXPECT_EQ(deserialized.alignment(), diff.alignment());
+  EXPECT_EQ(deserialized.baseSize(), diff.baseSize());
+  EXPECT_EQ(deserialized.baseChecksum(), diff.baseChecksum());
+  EXPECT_EQ(deserialized.instructions(), diff.instructions());
+  EXPECT_EQ(deserialized.targetSize(), diff.targetSize());
+  EXPECT_EQ(toString(deserialized.apply(base)), toString(diff.apply(base)));
+
+  // A diff without instructions also survives the round trip.
+  BinaryDiff emptyDiff{base, 16};
+  auto deserializedEmptyDiff = serializeAndDeserialize(emptyDiff);
+  EXPECT_THAT(deserializedEmptyDiff.instructions(), IsEmpty());
+  EXPECT_EQ(deserializedEmptyDiff.alignment(), 16U);
+  EXPECT_EQ(deserializedEmptyDiff.baseChecksum(), emptyDiff.baseChecksum());
+
+  // A default-constructed diff is the diff of an empty base into an empty
+  // target.
+  auto deserializedDefaultDiff = serializeAndDeserialize(BinaryDiff{});
+  EXPECT_EQ(deserializedDefaultDiff.alignment(), 1U);
+  EXPECT_EQ(deserializedDefaultDiff.baseSize(), 0U);
+  EXPECT_EQ(deserializedDefaultDiff.baseChecksum(), BinaryDiff::checksum({}));
+  EXPECT_THAT(deserializedDefaultDiff.apply({}), IsEmpty());
+}
+
+// _____________________________________________________________________________
+TEST(BinaryDiff, serializationRoundTripWithAnAlignedSerializer) {
+  // A diff can also be written to and read from a serializer that inserts
+  // alignment padding for trivially serializable types.
+  auto base = toBytes(std::string(32, 'A'));
+  BinaryDiff diff{base, 16};
+  diff.addCopy(16, 16);
+  diff.addInsert(toBytes("insert"));
+  ad_utility::serialization::AlignedByteBufferWriteSerializer writer;
+  writer << diff;
+  ad_utility::serialization::AlignedByteBufferReadSerializer reader{
+      std::move(writer).data()};
+  BinaryDiff deserialized;
+  reader >> deserialized;
+  EXPECT_EQ(deserialized.alignment(), diff.alignment());
+  EXPECT_EQ(deserialized.baseSize(), diff.baseSize());
+  EXPECT_EQ(deserialized.baseChecksum(), diff.baseChecksum());
+  EXPECT_EQ(deserialized.instructions(), diff.instructions());
+  EXPECT_EQ(toString(deserialized.apply(base)), toString(diff.apply(base)));
+}
+
+// _____________________________________________________________________________
+TEST(BinaryDiff, deserializationChecksTheInput) {
+  auto base = toBytes("0123456789");
+  BinaryDiff diff{base, 1};
+  diff.addCopy(0, 10);
+  ByteBufferWriteSerializer writer;
+  writer << diff;
+  auto serialized = std::move(writer).data();
+  const std::string notReadableMessage =
+      "not a serialized `ad_utility::BinaryDiff`, or is corrupted";
+
+  // Wrong magic bytes.
+  auto wrongMagicBytes = serialized;
+  wrongMagicBytes.at(4) = 'X';
+  AD_EXPECT_THROW_WITH_MESSAGE(deserializeDiff(wrongMagicBytes),
+                               HasSubstr(notReadableMessage));
+
+  // A wrong format version.
+  RawDiffHeader header{};
+  header.formatVersion_ = 42;
+  auto writeNoInstructions = [](ByteBufferWriteSerializer&) {};
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      deserializeDiff(writeRawDiff(header, 0, writeNoInstructions)),
+      HasSubstr("written by an incompatible version of QLever (format version "
+                "42, expected 1)"));
+
+  // An unknown instruction kind.
+  auto writeUnknownKind = [](ByteBufferWriteSerializer& rawWriter) {
+    rawWriter << static_cast<uint8_t>(7);
+  };
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      deserializeDiff(writeRawDiff(RawDiffHeader{}, 1, writeUnknownKind)),
+      HasSubstr("unknown instruction kind 7"));
+
+  // Truncated input, both inside the header and inside the instructions.
+  for (size_t size :
+       {size_t{0}, size_t{5}, size_t{20}, serialized.size() - 1}) {
+    std::vector<char> truncated{serialized.begin(), serialized.begin() + size};
+    AD_EXPECT_THROW_WITH_MESSAGE(deserializeDiff(truncated),
+                                 HasSubstr(notReadableMessage));
+  }
+
+  // An alignment that is not a power of two.
+  RawDiffHeader invalidAlignmentHeader{};
+  invalidAlignmentHeader.alignment_ = 24;
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      deserializeDiff(
+          writeRawDiff(invalidAlignmentHeader, 0, writeNoInstructions)),
+      HasSubstr("the alignment 24 is not a power of two"));
+
+  // A diff that announces more instructions than it contains.
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      deserializeDiff(writeRawDiff(RawDiffHeader{}, 3, writeNoInstructions)),
+      HasSubstr(notReadableMessage));
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -175,6 +175,8 @@ addLinkAndDiscoverTest(StringUtilsTest qlever_util)
 
 addLinkAndDiscoverTest(RegexSetTest qlever_util)
 
+addLinkAndDiscoverTest(BinaryDiffTest qlever_util)
+
 addLinkAndDiscoverTestNoLibs(ConstexprSmallStringTest)
 
 addLinkAndDiscoverTest(CryptographicHashUtilsTest qlever_util)

--- a/test/SecondaryVocabularyTest.cpp
+++ b/test/SecondaryVocabularyTest.cpp
@@ -33,6 +33,8 @@
 #include "parser/LiteralOrIri.h"
 #include "parser/SparqlParser.h"
 #include "parser/TripleComponent.h"
+#include "util/CompactStringVector.h"
+#include "util/Serializer/ByteBufferSerializer.h"
 
 namespace {
 
@@ -52,23 +54,36 @@ using ::testing::HasSubstr;
 using ::testing::Optional;
 using ::testing::UnorderedElementsAre;
 
-// The words of the secondary vocabulary that the tests below use. In the order
-// of the main vocabulary (see `makeIndexWithSecondaryVocab`), `"a"` is sorted
-// before all of its words, `<b>` between `<a>` and `<c>`, and `<d>` between
-// `<c>` and `<p>`.
-//
-// NOTE: A `SecondaryVocabulary` requires its words to be sorted with respect
-// to `std::string`'s comparison, whereas the actual implementation will use the
-// collation of the vocabulary of the main index (see `SecondaryVocabulary`).
-// These words are deliberately chosen such that the two orders agree: their
-// content is a single ASCII letter, for which the collation is the byte order,
-// and `"` (the first byte of a literal) sorts before `<` (the first byte of an
-// IRI) in both.
+// The words of the secondary vocabulary that the tests below use, in
+// insertion order (which is the order of their `Id`s, see
+// `SecondaryVocabulary`). In the semantic order of the main vocabulary (see
+// `makeIndexWithSecondaryVocab`), `"a"` is sorted before all of its words,
+// `<b>` between `<a>` and `<c>`, and `<d>` between `<c>` and `<p>`.
 const std::vector<std::string> secondaryVocabWords{"\"a\"", "<b>", "<d>"};
 
 // The `Id` of the word of the secondary vocabulary at the given index.
 Id secondaryVocabId(uint64_t index) {
   return Id::makeFromSecondaryVocabIndex(SecondaryVocabIndex::make(index));
+}
+
+// Check that each of `words` is stored in `vocab` at the index equal to its
+// position in `words`, and that `vocab.getId` finds it again at that same
+// index.
+void expectWordsAndIdsMatch(const SecondaryVocabulary& vocab,
+                            const std::vector<std::string>& words) {
+  for (size_t i = 0; i < words.size(); ++i) {
+    SCOPED_TRACE(i);
+    EXPECT_EQ(vocab[SecondaryVocabIndex::make(i)], words.at(i));
+    EXPECT_EQ(vocab.getId(words.at(i)), SecondaryVocabIndex::make(i));
+  }
+}
+
+// Build a `CompactVectorOfStrings<char>` holding `words`, suitable for
+// `SecondaryVocabulary::appendSegment`.
+CompactVectorOfStrings<char> makeSegment(std::vector<std::string> words) {
+  CompactVectorOfStrings<char> segment;
+  segment.build(words);
+  return segment;
 }
 
 // An index whose main vocabulary holds `<a>`, `<c>`, `<p>`, and `<s>`, and
@@ -105,19 +120,14 @@ TEST(SecondaryVocabulary, wordsAndLookup) {
   SecondaryVocabulary vocab{secondaryVocabWords};
   EXPECT_EQ(vocab.numWords(), secondaryVocabWords.size());
   // Each word is stored at its index and is found again by that index.
-  for (size_t i = 0; i < secondaryVocabWords.size(); ++i) {
-    SCOPED_TRACE(i);
-    EXPECT_EQ(vocab[SecondaryVocabIndex::make(i)], secondaryVocabWords.at(i));
-    EXPECT_EQ(vocab.getId(secondaryVocabWords.at(i)),
-              SecondaryVocabIndex::make(i));
-  }
+  expectWordsAndIdsMatch(vocab, secondaryVocabWords);
   // Words that are not contained, before, between, and after the contained
   // ones.
   EXPECT_EQ(vocab.getId("\"A\""), std::nullopt);
   EXPECT_EQ(vocab.getId("<c>"), std::nullopt);
   EXPECT_EQ(vocab.getId("<e>"), std::nullopt);
   AD_EXPECT_THROW_WITH_MESSAGE(vocab[SecondaryVocabIndex::make(3)],
-                               HasSubstr("index.get() < words_.size()"));
+                               HasSubstr("globalIndex < numWords()"));
 
   // A default-constructed vocabulary is empty, which is how an index without a
   // secondary vocabulary behaves.
@@ -127,13 +137,77 @@ TEST(SecondaryVocabulary, wordsAndLookup) {
 }
 
 // _____________________________________________________________________________
-TEST(SecondaryVocabulary, wordsHaveToBeSortedAndDistinct) {
-  // The words are looked up by binary search, so unsorted or duplicate words
-  // are a programming error.
-  AD_EXPECT_THROW_WITH_MESSAGE((SecondaryVocabulary{{"<d>", "<b>"}}),
-                               HasSubstr("have to be sorted"));
+TEST(SecondaryVocabulary, wordsDoNotHaveToBeSortedButHaveToBeDistinct) {
+  // Words may be in any order; they simply get their `Id`s in insertion
+  // order.
+  SecondaryVocabulary vocab{{"<d>", "<b>"}};
+  EXPECT_EQ(vocab[SecondaryVocabIndex::make(0)], "<d>");
+  EXPECT_EQ(vocab[SecondaryVocabIndex::make(1)], "<b>");
+
+  // Duplicate words are still a programming error.
   AD_EXPECT_THROW_WITH_MESSAGE((SecondaryVocabulary{{"<b>", "<b>"}}),
                                HasSubstr("have to be distinct"));
+}
+
+// _____________________________________________________________________________
+TEST(SecondaryVocabulary, appendSegmentKeepsExistingIndicesStable) {
+  SecondaryVocabulary vocab{secondaryVocabWords};
+  ASSERT_EQ(vocab.numWords(), 3);
+  ASSERT_EQ(vocab.numSegments(), 1);
+
+  vocab.appendSegment(makeSegment({"<f>", "<g>"}));
+
+  EXPECT_EQ(vocab.numWords(), 5);
+  EXPECT_EQ(vocab.numSegments(), 2);
+
+  // The indices of the words that were already contained stay unchanged.
+  expectWordsAndIdsMatch(vocab, secondaryVocabWords);
+  // The words of the new segment continue the global index, and `getId` and
+  // `operator[]` work across the segment boundary.
+  EXPECT_EQ(vocab[SecondaryVocabIndex::make(3)], "<f>");
+  EXPECT_EQ(vocab[SecondaryVocabIndex::make(4)], "<g>");
+  EXPECT_EQ(vocab.getId("<f>"), SecondaryVocabIndex::make(3));
+  EXPECT_EQ(vocab.getId("<g>"), SecondaryVocabIndex::make(4));
+}
+
+// _____________________________________________________________________________
+TEST(SecondaryVocabulary, appendSegmentRejectsWordAlreadyContained) {
+  SecondaryVocabulary vocab{secondaryVocabWords};
+  AD_EXPECT_THROW_WITH_MESSAGE(vocab.appendSegment(makeSegment({"<f>", "<b>"})),
+                               HasSubstr("have to be distinct"));
+  // The rejected segment must not have been appended.
+  EXPECT_EQ(vocab.numWords(), secondaryVocabWords.size());
+  EXPECT_EQ(vocab.numSegments(), 1);
+}
+
+// _____________________________________________________________________________
+TEST(SecondaryVocabulary, appendSegmentRejectsInternalDuplicates) {
+  SecondaryVocabulary vocab{};
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      vocab.appendSegment(makeSegment({"<f>", "<g>", "<f>"})),
+      HasSubstr("have to be distinct"));
+  EXPECT_EQ(vocab.numWords(), 0);
+  EXPECT_EQ(vocab.numSegments(), 0);
+}
+
+// _____________________________________________________________________________
+TEST(SecondaryVocabulary, appendZeroCopySegment) {
+  SecondaryVocabulary vocab{secondaryVocabWords};
+
+  auto segment = makeSegment({"<f>", "<g>"});
+  ad_utility::serialization::AlignedByteBufferWriteSerializer writeSerializer;
+  writeSerializer << segment;
+  ad_utility::serialization::AlignedByteBufferReadSerializer readSerializer{
+      std::move(writeSerializer).data()};
+  auto zeroCopySegment =
+      CompactVectorOfStrings<char>::fromZeroCopyDeserializer(readSerializer);
+
+  vocab.appendSegment(std::move(zeroCopySegment));
+  EXPECT_EQ(vocab.numWords(), 5);
+  EXPECT_EQ(vocab.numSegments(), 2);
+  EXPECT_EQ(vocab[SecondaryVocabIndex::make(3)], "<f>");
+  EXPECT_EQ(vocab[SecondaryVocabIndex::make(4)], "<g>");
+  EXPECT_EQ(vocab.getId("<g>"), SecondaryVocabIndex::make(4));
 }
 
 // _____________________________________________________________________________
@@ -453,8 +527,8 @@ TEST_F(SecondaryVocabIndexTest, toValueIdUsesAllVocabularies) {
 
 // _____________________________________________________________________________
 // The same three cases, but for the `TripleComponent` overload that does not
-// add to a local vocabulary. A word of the secondary vocabulary now has an
-// `Id`, so this no longer reports it as "not found".
+// add to a local vocabulary. A word of the secondary vocabulary has an `Id`,
+// so this reports it as found, unlike a word that is in neither vocabulary.
 TEST_F(SecondaryVocabIndexTest, toValueIdWithoutLocalVocab) {
   const IndexImpl& impl = index_.getImpl();
   auto toId = [&impl](std::string_view iriref) {

--- a/test/SerializerTest.cpp
+++ b/test/SerializerTest.cpp
@@ -892,6 +892,53 @@ TEST(ZstdSerializer, RoundtripWithFileSerializer) {
 }
 
 // _____________________________________________________________________________
+TEST(ByteBufferWriteSerializer, overwriteBytes) {
+  ByteBufferWriteSerializer writer;
+  writer << uint32_t{1};
+  // Remember the position of the value that is patched below, and write a
+  // placeholder for it, as a caller would do for a size that is only known
+  // once the data that it describes has been written.
+  size_t position = writer.getCurrentPosition();
+  writer << uint32_t{0};
+  writer << uint32_t{3};
+
+  uint32_t patchedValue = 42;
+  writer.overwriteBytes(position, reinterpret_cast<const char*>(&patchedValue),
+                        sizeof(patchedValue));
+  // The number of bytes is unchanged, only the middle value was replaced.
+  EXPECT_EQ(writer.getCurrentPosition(), 3 * sizeof(uint32_t));
+
+  ByteBufferReadSerializer reader{std::move(writer).data()};
+  uint32_t first, second, third;
+  reader >> first;
+  reader >> second;
+  reader >> third;
+  EXPECT_EQ(first, 1u);
+  EXPECT_EQ(second, 42u);
+  EXPECT_EQ(third, 3u);
+}
+
+// _____________________________________________________________________________
+TEST(ByteBufferWriteSerializer, overwriteBytesOutOfRangeThrows) {
+  ByteBufferWriteSerializer writer;
+  writer << uint32_t{1};
+  uint32_t value = 7;
+  const char* pointer = reinterpret_cast<const char*>(&value);
+
+  // Overwriting exactly the bytes that were written is still allowed.
+  EXPECT_NO_THROW(writer.overwriteBytes(0, pointer, sizeof(value)));
+
+  // Overwriting a single byte past the end throws, as does an overwrite that
+  // starts inside the data but reaches past its end.
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      writer.overwriteBytes(sizeof(value), pointer, 1),
+      ::testing::HasSubstr("position + numBytes <= data_.size()"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      writer.overwriteBytes(1, pointer, sizeof(value)),
+      ::testing::HasSubstr("position + numBytes <= data_.size()"));
+}
+
+// _____________________________________________________________________________
 TEST(ByteBufferReadSerializer, ThrowsWhenReadingPastEnd) {
   ByteBufferWriteSerializer writer;
   int x = 42;

--- a/test/TripleSerializerTest.cpp
+++ b/test/TripleSerializerTest.cpp
@@ -199,6 +199,58 @@ TEST(TripleSerializer, multipleWordSetsInASerializedLocalVocab) {
 }
 
 // _____________________________________________________________________________
+TEST(TripleSerializer, serializeLocalVocabWithoutWords) {
+  auto* qec = ad_utility::testing::getQec();
+  LocalVocab localVocab;
+  auto LV = [&localVocab, qec](std::string_view value) {
+    return Id::makeFromLocalVocabIndex(localVocab.getIndexAndAddIfNotContained(
+        LocalVocabEntry::literalWithoutQuotes(value,
+                                              qec->getLocalVocabContext())));
+  };
+  auto bn = [&]() {
+    return Id::makeFromBlankNodeIndex(
+        localVocab.getBlankNodeIndex(qec->getIndex().getBlankNodeManager()));
+  };
+  // Add words (in two different word sets) as well as blank nodes.
+  std::vector<Id> ids{LV("abc"), LV("def"), bn()};
+  localVocab = localVocab.clone();
+  ids.push_back(LV("ghi"));
+  ids.push_back(bn());
+  ASSERT_EQ(localVocab.size(), 3);
+
+  ad_utility::serialization::ByteBufferWriteSerializer writer;
+  ad_utility::detail::serializeLocalVocabWithoutWords(writer, localVocab);
+  ad_utility::serialization::ByteBufferReadSerializer reader{
+      std::move(writer).data()};
+  auto [localVocabOut, mapping] = ad_utility::detail::deserializeLocalVocab(
+      reader, qec->getLocalVocabContext());
+
+  // None of the words was written, so the deserialized local vocab is empty
+  // and the mapping (from written to deserialized `Id`s) is empty as well.
+  EXPECT_EQ(localVocabOut.size(), 0);
+  EXPECT_THAT(localVocabOut.getAllWordsForTesting(), ::testing::IsEmpty());
+  EXPECT_THAT(mapping, ::testing::IsEmpty());
+
+  // The blank node blocks are written and read back unchanged (but with an
+  // empty block prepended, see the `blankNodesRemapper` test above).
+  auto blankNodeBlocksOriginal = localVocab.getOwnedLocalBlankNodeBlocks();
+  auto blankNodeBlocksDeserialized =
+      localVocabOut.getOwnedLocalBlankNodeBlocks();
+  ASSERT_FALSE(blankNodeBlocksOriginal.empty());
+  ASSERT_EQ(blankNodeBlocksDeserialized.size(),
+            blankNodeBlocksOriginal.size() + 1);
+  EXPECT_TRUE(blankNodeBlocksDeserialized.at(0).blockIndices_.empty());
+  for (size_t i = 0; i < blankNodeBlocksOriginal.size(); ++i) {
+    EXPECT_EQ(blankNodeBlocksOriginal[i].uuid_,
+              blankNodeBlocksDeserialized[i + 1].uuid_)
+        << i;
+    EXPECT_EQ(blankNodeBlocksOriginal[i].blockIndices_,
+              blankNodeBlocksDeserialized[i + 1].blockIndices_)
+        << i;
+  }
+}
+
+// _____________________________________________________________________________
 TEST(TripleSerializer, rethrowsOnInvalidFileAccess) {
   using namespace ::testing;
   auto* qec = ad_utility::testing::getQec();

--- a/test/engine/NamedResultCacheSerializerTest.cpp
+++ b/test/engine/NamedResultCacheSerializerTest.cpp
@@ -4,12 +4,15 @@
 //
 // UFR = University of Freiburg, Chair of Algorithms and Data Structures
 
+#include <absl/strings/str_cat.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "../util/GTestHelpers.h"
 #include "../util/IdTableHelpers.h"
+#include "../util/IdTestHelpers.h"
 #include "../util/IndexTestHelpers.h"
+#include "backports/algorithm.h"
 #include "engine/NamedResultCache.h"
 #include "engine/NamedResultCacheSerializer.h"
 #include "index/LocalVocabEntry.h"
@@ -20,6 +23,7 @@ using ::testing::ElementsAre;
 using ::testing::UnorderedElementsAreArray;
 
 namespace {
+auto V = ad_utility::testing::VocabId;
 
 // Test fixture for NamedResultCacheSerializer tests.
 class NamedResultCacheSerializerTest : public ::testing::Test {
@@ -48,6 +52,31 @@ class NamedResultCacheSerializerTest : public ::testing::Test {
   NamedResultCache::Value serializeAndDeserializeValue(
       const NamedResultCache::Value& value) {
     return serializeAndDeserializeValue(value, alloc_);
+  }
+
+  // Create a simple `Value` with a two-column table, one variable per column,
+  // and the given `cacheKey`.
+  static NamedResultCache::Value makeSimpleValue(std::string cacheKey) {
+    VariableToColumnMap varColMap;
+    varColMap[Variable{"?x"}] = makeAlwaysDefinedColumn(0);
+    varColMap[Variable{"?y"}] = makeAlwaysDefinedColumn(1);
+    return NamedResultCache::Value{std::make_shared<const IdTable>(
+                                       makeIdTableFromVector({{1, 2}, {3, 4}})),
+                                   std::move(varColMap),
+                                   {0},
+                                   LocalVocab{},
+                                   std::move(cacheKey),
+                                   std::nullopt};
+  }
+
+  // Read a `Value` from the given serialized `data`.
+  NamedResultCache::Value deserializeValue(std::vector<char> data) const {
+    ByteBufferReadSerializer readSerializer{std::move(data)};
+    NamedResultCache::Value value;
+    value.allocatorForSerialization_ = ad_utility::makeUnlimitedAllocator<Id>();
+    value.contextForSerialization_ = &qec_->getIndex().getLocalVocabContext();
+    readSerializer >> value;
+    return value;
   }
 };
 
@@ -278,6 +307,142 @@ TEST_F(NamedResultCacheSerializerTest, WrongMagicByteOrFormatVersionThrows) {
           readerWithWrongVersion, ad_utility::makeUnlimitedAllocator<Id>(),
           qec_->getLocalVocabContext()),
       ::testing::HasSubstr("format version"));
+}
+
+// _____________________________________________________________________________
+// Test that `getAllEntries` returns all entries of the cache, sorted by their
+// key, no matter in which order they were stored.
+TEST_F(NamedResultCacheSerializerTest, GetAllEntries) {
+  NamedResultCache cache;
+  EXPECT_THAT(cache.getAllEntries(), ::testing::IsEmpty());
+
+  cache.store("zebra", makeSimpleValue("key-zebra"));
+  cache.store("apple", makeSimpleValue("key-apple"));
+  cache.store("mango", makeSimpleValue("key-mango"));
+
+  auto entries = cache.getAllEntries();
+  ASSERT_EQ(entries.size(), 3);
+  EXPECT_THAT(entries | ql::views::keys,
+              ElementsAre("apple", "mango", "zebra"));
+  // The values are exactly the stored ones (the same objects that `get`
+  // returns).
+  for (const auto& [key, value] : entries) {
+    ASSERT_NE(value, nullptr);
+    EXPECT_EQ(value, cache.get(key));
+    EXPECT_EQ(value->cacheKey_, absl::StrCat("key-", key));
+  }
+}
+
+// _____________________________________________________________________________
+// Test that the serialization is deterministic: identical contents yield
+// identical bytes, also if the `varToColMap_` entries or the cache entries
+// were inserted in a different order.
+TEST_F(NamedResultCacheSerializerTest, SerializationIsDeterministic) {
+  // Create a `Value` with four variables that are inserted in the given
+  // order, but otherwise identical contents.
+  auto makeValue = [](bool reverseInsertionOrder) {
+    std::vector<std::string> names{"?d", "?c", "?b", "?a"};
+    VariableToColumnMap varColMap;
+    for (size_t i = 0; i < names.size(); ++i) {
+      size_t index = reverseInsertionOrder ? names.size() - 1 - i : i;
+      varColMap[Variable{names.at(index)}] = makeAlwaysDefinedColumn(index);
+    }
+    return NamedResultCache::Value{
+        std::make_shared<const IdTable>(
+            makeIdTableFromVector({{0, 1, 2, 3}, {4, 5, 6, 7}})),
+        std::move(varColMap),
+        {0, 1},
+        LocalVocab{},
+        "cache-key",
+        std::nullopt};
+  };
+  auto serializeValue = [](const NamedResultCache::Value& value) {
+    ByteBufferWriteSerializer writer;
+    writer << value;
+    return std::move(writer).data();
+  };
+
+  // Serializing the same value twice yields the same bytes.
+  auto value = makeValue(false);
+  EXPECT_EQ(serializeValue(value), serializeValue(value));
+
+  // Two values that only differ in the insertion order of their
+  // `varToColMap_` entries also yield the same bytes.
+  EXPECT_EQ(serializeValue(makeValue(false)), serializeValue(makeValue(true)));
+
+  // The same holds for a whole cache whose entries were stored in a different
+  // order.
+  auto serializeCache = [](const std::vector<std::string>& names) {
+    NamedResultCache cache;
+    for (const auto& name : names) {
+      cache.store(name, makeSimpleValue(absl::StrCat("key-", name)));
+    }
+    ByteBufferWriteSerializer writer;
+    cache.writeToSerializer(writer);
+    return std::move(writer).data();
+  };
+  EXPECT_EQ(serializeCache({"apple", "mango", "zebra"}),
+            serializeCache({"zebra", "apple", "mango"}));
+}
+
+// _____________________________________________________________________________
+// Test `writeValue` with columns and a sort order that differ from those of
+// the `Value`, and without the words of the local vocab, as a caller that has
+// rewritten the `Id`s to a persistent vocabulary would use it.
+TEST_F(NamedResultCacheSerializerTest, WriteValueWithReplacedColumns) {
+  auto table = makeIdTableFromVector({{0, 7}, {9, 11}, {13, 17}});
+  VariableToColumnMap varColMap;
+  varColMap[Variable{"?x"}] = makeAlwaysDefinedColumn(0);
+  varColMap[Variable{"?y"}] = makePossiblyUndefinedColumn(1);
+  LocalVocab localVocab;
+  localVocab.getIndexAndAddIfNotContained(LocalVocabEntry::fromIriref(
+      "<http://example.org/test>", qec_->getLocalVocabContext()));
+  ASSERT_EQ(localVocab.size(), 1);
+
+  NamedResultCache::Value value{std::make_shared<const IdTable>(table.clone()),
+                                std::move(varColMap),
+                                {0, 1},
+                                std::move(localVocab),
+                                "test-cache-key",
+                                std::nullopt};
+
+  // The replaced columns have the same shape as the table of the `value`, but
+  // different `Id`s. The sort order is shortened, because the replacement
+  // invalidates the sortedness of the second column.
+  std::vector<std::vector<Id>> replacedColumns{{V(1), V(2), V(3)},
+                                               {V(4), V(5), V(6)}};
+  std::vector<ColumnIndex> shortenedSortOrder{0};
+
+  ByteBufferWriteSerializer writer;
+  namedResultCacheSerializer::writeValue(writer, value, replacedColumns,
+                                         shortenedSortOrder,
+                                         /*writeLocalVocabWords=*/false);
+  auto readValue = deserializeValue(std::move(writer).data());
+
+  EXPECT_THAT(ExplicitIdTableOperation::viewOf(readValue.result_),
+              matchesIdTableFromVector({{1, 4}, {2, 5}, {3, 6}}));
+  EXPECT_THAT(readValue.resultSortedOn_, ElementsAre(0));
+  EXPECT_EQ(readValue.cacheKey_, "test-cache-key");
+  EXPECT_THAT(readValue.varToColMap_,
+              UnorderedElementsAreArray(value.varToColMap_));
+  // The words of the local vocab were not written, so the local vocab of the
+  // deserialized value is empty.
+  EXPECT_EQ(readValue.localVocab_.size(), 0);
+  EXPECT_THAT(readValue.localVocab_.getAllWordsForTesting(),
+              ::testing::IsEmpty());
+
+  // The number of the columns and the number of rows in each column have to
+  // agree with the table of the `value`.
+  std::vector<std::vector<Id>> tooFewColumns{{V(1), V(2), V(3)}};
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      namedResultCacheSerializer::writeValue(writer, value, tooFewColumns,
+                                             shortenedSortOrder, false),
+      ::testing::HasSubstr("resultView.numColumns()"));
+  std::vector<std::vector<Id>> tooFewRows{{V(1), V(2)}, {V(4), V(5)}};
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      namedResultCacheSerializer::writeValue(writer, value, tooFewRows,
+                                             shortenedSortOrder, false),
+      ::testing::HasSubstr("resultView.numRows()"));
 }
 
 }  // namespace

--- a/test/engine/StringMappingTest.cpp
+++ b/test/engine/StringMappingTest.cpp
@@ -72,12 +72,11 @@ TEST(StringMapping, flushResolvesSecondaryVocabIds) {
   // `flush` resolves the collected `Id`s via `ql::exportIds::idToLiteralOrIri`,
   // so an `Id` of a secondary vocabulary requires the index to actually have
   // such a vocabulary. Use a fresh index instead of the shared one of `getQec`,
-  // because `setSecondaryVocabForTesting` must not leak into other tests.
+  // because `setSecondaryVocab` must not leak into other tests.
   Index index = ad_utility::testing::makeTestIndex(gtestCurrentTestName(),
                                                    "<a> <b> <c> .");
-  index.getImpl().setSecondaryVocabForTesting(
-      std::make_shared<SecondaryVocabulary>(
-          std::vector<std::string>{"<d>", "<e>"}));
+  index.getImpl().setSecondaryVocab(std::make_shared<SecondaryVocabulary>(
+      std::vector<std::string>{"<d>", "<e>"}));
 
   StringMapping mapping;
   Id vocabId = Id::makeFromVocabIndex(VocabIndex::make(1));

--- a/test/libqlever/NamedCachedQueryBlobManagerTest.cpp
+++ b/test/libqlever/NamedCachedQueryBlobManagerTest.cpp
@@ -71,8 +71,10 @@ class CountingMemoryResource : public ql::pmr::memory_resource {
 // Write the `turtleContents` to a turtle file, build an index from it with the
 // given vocabulary `type`, and return the corresponding `IndexBuilderConfig`.
 // The basename of the index is derived from the name of the currently running
-// test, so that concurrently running tests do not interfere with each other.
-// The turtle input file is deleted again immediately after the index was built.
+// test and the optional `suffix`, so that concurrently running tests do not
+// interfere with each other, and so that a single test can build several
+// distinct indexes. The turtle input file is deleted again immediately after
+// the index was built.
 //
 // NOTE: The default vocabulary type is the in-memory, uncompressed one,
 // because `serializeVocabAndNamedCacheToCompressedBlob` currently requires it
@@ -80,8 +82,9 @@ class CountingMemoryResource : public ql::pmr::memory_resource {
 // `Vocabulary::writeAsZeroCopyBlob`).
 IndexBuilderConfig buildTestIndex(
     std::string_view turtleContents,
-    VocabularyType type = VocabularyType::InMemoryUncompressed) {
-  std::string basename = gtestCurrentTestName();
+    VocabularyType type = VocabularyType::InMemoryUncompressed,
+    std::string_view suffix = "") {
+  std::string basename = absl::StrCat(gtestCurrentTestName(), suffix);
   std::string sourceFilename = absl::StrCat(basename, ".ttl");
   {
     auto ofs = ad_utility::makeOfstream(sourceFilename);
@@ -654,17 +657,21 @@ namespace {
 // The media type in which the tests below export their query results.
 constexpr ad_utility::MediaType tsv = ad_utility::MediaType::tsv;
 
-// The turtle data used by the tests below, which write a blob after an update
-// and inspect the chunk layout of a blob.
+// The turtle data used by the tests below, which write a blob or a diff after
+// an update and inspect the chunk layout of a blob.
 constexpr std::string_view updateTestData =
     "<s1> <p1> \"l1\".\n"
     "<s2> <p1> \"l2\".\n"
     "<s1> <p2> <o1>.";
 
-// The queries whose results the tests below pin (under the names `q1` and
-// `q2`), and the corresponding queries that return those pinned results.
+// The queries whose results the tests below pin (under the names `q1`, `q2`,
+// and `q3`), and the corresponding queries that return those pinned results.
+// NOTE: `q3` returns the same triples as `q2`, but binds the object to a
+// different variable, so that a join of `q1` and `q3` joins on the subject
+// alone.
 constexpr std::string_view sourceQuery1 = "SELECT ?s ?o WHERE { ?s <p1> ?o }";
 constexpr std::string_view sourceQuery2 = "SELECT ?s ?o WHERE { ?s <p2> ?o }";
+constexpr std::string_view sourceQuery3 = "SELECT ?s ?o2 WHERE { ?s <p2> ?o2 }";
 constexpr std::string_view cachedQuery1 =
     "SELECT ?s ?o WHERE { SERVICE ql:cached-result-with-name-q1 {} }";
 constexpr std::string_view cachedQuery2 =
@@ -687,7 +694,9 @@ Qlever makeSourceEngine(const IndexBuilderConfig& builderConfig) {
 }
 
 // Build the test index (`updateTestData`), open a `Qlever` instance on it via
-// `makeSourceEngine`, and pin the queries via `pinSourceQueries`.
+// `makeSourceEngine`, and pin the queries via `pinSourceQueries`. This is the
+// setup that most of the tests below need before they apply their own updates
+// and (re-)pin queries.
 Qlever makePinnedSourceEngine() {
   auto builderConfig = buildTestIndex(updateTestData);
   Qlever source = makeSourceEngine(builderConfig);
@@ -702,11 +711,15 @@ std::pair<std::string, std::string> cachedResultsOf(Qlever& engine) {
           engine.query(std::string{cachedQuery2}, tsv)};
 }
 
-// Load `blob` into a fresh `Qlever` instance that has NO index files on disk at
-// all (constructed with `skipLoading`).
-std::unique_ptr<Qlever> loadBlob(ql::span<const char> blob) {
+// Load `blob`, with the `diffs` applied to it in the given order, into a fresh
+// `Qlever` instance that has NO index files on disk at all (constructed with
+// `skipLoading`).
+std::unique_ptr<Qlever> loadBlob(
+    ql::span<const char> blob,
+    const std::vector<ql::span<const char>>& diffs = {}) {
   auto target = std::make_unique<Qlever>(EngineConfig{}, /*skipLoading=*/true);
-  target->deserializeVocabAndNamedCacheFromCompressedBlob(blob);
+  target->deserializeVocabAndNamedCacheFromCompressedBlob(
+      blob, ql::span<const ql::span<const char>>{diffs});
   return target;
 }
 
@@ -719,6 +732,122 @@ const SecondaryVocabulary& secondaryVocabularyOf(const Qlever& engine) {
   return *secondaryVocabulary;
 }
 }  // namespace
+
+// _____________________________________________________________________________
+// End-to-end test of the diff mechanism: pin two queries, write a base blob,
+// apply an update that inserts triples with words that are not part of the
+// vocabulary of the index (and that deletes one of the triples of the first
+// query), re-pin the very same queries, and write a diff against the base blob.
+// Applying that diff has to yield a blob that produces exactly the same results
+// as the source engine.
+TEST(NamedCachedQueryBlobManager, diffAfterUpdate) {
+  Qlever source = makePinnedSourceEngine();
+  std::vector<char> base = source.serializeVocabAndNamedCacheToCompressedBlob();
+
+  applyUpdateToEngine(source,
+                      "INSERT DATA { <newSubject> <p1> \"new literal\" }");
+  applyUpdateToEngine(source, "DELETE DATA { <s2> <p1> \"l2\" }");
+  pinSourceQueries(source);
+  std::vector<char> diff =
+      source.serializeVocabAndNamedCacheDiffToCompressedBlob(base);
+
+  // The unchanged parts (in particular the vocabulary) are copied from the base
+  // blob, the changed ones are inserted.
+  auto statistics = Manager::describeDiff(diff);
+  EXPECT_GE(statistics.numCopyInstructions_, 1u);
+  EXPECT_GE(statistics.numInsertInstructions_, 1u);
+  EXPECT_GT(statistics.numCopiedBytes_, 0u);
+  EXPECT_GT(statistics.numInsertedBytes_, 0u);
+
+  // The patched blob is a complete blob again, and loading it into a fresh
+  // instance with no index files on disk reproduces the results of the source
+  // engine, including the word that only exists in the secondary vocabulary of
+  // the blob.
+  std::vector<char> patched = Qlever::applyDiffToCompressedBlob(base, diff);
+  auto expected = cachedResultsOf(source);
+  EXPECT_EQ(expected.first,
+            "?s\t?o\n<newSubject>\t\"new literal\"\n<s1>\t\"l1\"\n");
+  EXPECT_EQ(expected.second, "?s\t?o\n<s1>\t<o1>\n");
+
+  auto target = loadBlob(patched);
+  EXPECT_EQ(cachedResultsOf(*target), expected);
+  EXPECT_EQ(secondaryVocabularyOf(*target).numSegments(), 1u);
+
+  // A `FILTER` on the new IRI works in the target, i.e. the `Id` of the
+  // secondary vocabulary is found for the IRI of the query.
+  EXPECT_EQ(target->query("SELECT ?s ?o WHERE { SERVICE "
+                          "ql:cached-result-with-name-q1 {} FILTER(?s = "
+                          "<newSubject>) }",
+                          tsv),
+            "?s\t?o\n<newSubject>\t\"new literal\"\n");
+
+  // Applying the diff while loading the base blob is equivalent to loading the
+  // patched blob.
+  auto targetFromDiff = loadBlob(base, {diff});
+  EXPECT_EQ(cachedResultsOf(*targetFromDiff), expected);
+}
+
+// _____________________________________________________________________________
+// Test that diffs chain: a second update yields a diff against the blob that
+// resulted from the first diff, and the `Id`s that the first diff assigned to
+// the new words stay valid.
+TEST(NamedCachedQueryBlobManager, incrementalDiffs) {
+  Qlever source = makePinnedSourceEngine();
+  source.queryAndPinResultWithName("q3", std::string{sourceQuery3});
+  std::vector<char> base = source.serializeVocabAndNamedCacheToCompressedBlob();
+
+  auto rePinAll = [&source]() {
+    pinSourceQueries(source);
+    source.queryAndPinResultWithName("q3", std::string{sourceQuery3});
+  };
+
+  applyUpdateToEngine(source,
+                      "INSERT DATA { <newSubject> <p1> \"new literal\" }");
+  rePinAll();
+  std::vector<char> diff1 =
+      source.serializeVocabAndNamedCacheDiffToCompressedBlob(base);
+  std::vector<char> patched1 = Qlever::applyDiffToCompressedBlob(base, diff1);
+
+  // The second update adds another new word, and reuses the new IRI of the
+  // first update in a triple of the second query.
+  applyUpdateToEngine(source,
+                      "INSERT DATA { <newSubject> <p2> <anotherNewObject> }");
+  rePinAll();
+  std::vector<char> diff2 =
+      source.serializeVocabAndNamedCacheDiffToCompressedBlob(patched1);
+  std::vector<char> patched2 =
+      Qlever::applyDiffToCompressedBlob(patched1, diff2);
+
+  auto expected = cachedResultsOf(source);
+  auto target1 = loadBlob(patched1);
+  auto target2 = loadBlob(patched2);
+  EXPECT_EQ(cachedResultsOf(*target2), expected);
+  EXPECT_EQ(target2->query(std::string{cachedQuery2}, tsv),
+            "?s\t?o\n<newSubject>\t<anotherNewObject>\n<s1>\t<o1>\n");
+
+  // The second diff appended a second segment to the secondary vocabulary, and
+  // the word of the first segment kept its `Id`.
+  EXPECT_EQ(secondaryVocabularyOf(*target1).numSegments(), 1u);
+  EXPECT_EQ(secondaryVocabularyOf(*target2).numSegments(), 2u);
+  auto idInTarget1 = secondaryVocabularyOf(*target1).getId("<newSubject>");
+  auto idInTarget2 = secondaryVocabularyOf(*target2).getId("<newSubject>");
+  ASSERT_TRUE(idInTarget1.has_value());
+  ASSERT_TRUE(idInTarget2.has_value());
+  EXPECT_EQ(idInTarget1.value().get(), idInTarget2.value().get());
+
+  // A join of two cached results on the new IRI, which only works if that IRI
+  // is represented by the very same `Id` in both of them.
+  EXPECT_EQ(target2->query("SELECT ?s ?o ?o2 WHERE { SERVICE "
+                           "ql:cached-result-with-name-q1 {} SERVICE "
+                           "ql:cached-result-with-name-q3 {} }",
+                           tsv),
+            "?s\t?o\t?o2\n<s1>\t\"l1\"\t<o1>\n<newSubject>\t\"new "
+            "literal\"\t<anotherNewObject>\n");
+
+  // Both diffs can also be applied while loading the base blob.
+  auto targetFromDiffs = loadBlob(base, {diff1, diff2});
+  EXPECT_EQ(cachedResultsOf(*targetFromDiffs), expected);
+}
 
 // _____________________________________________________________________________
 // Test that a complete blob can be written even after an update that introduced
@@ -762,11 +891,55 @@ TEST(NamedCachedQueryBlobManager, newWordsInSecondaryVocabularyOfBlob) {
 }
 
 // _____________________________________________________________________________
-// Test that a blob cannot be created from an index that already has a secondary
-// vocabulary of its own (which in particular is the case for an instance that
-// was itself loaded from a blob that contained new words).
+// Test that a diff which is applied to a base blob other than the one it was
+// created against is rejected, and that input which is not a diff at all is
+// rejected with our own message.
+TEST(NamedCachedQueryBlobManager, applyDiffRejectsWrongInput) {
+  auto builderConfig = buildTestIndex(updateTestData);
+  auto otherBuilderConfig =
+      buildTestIndex("<otherSubject> <otherPredicate> \"other literal\".",
+                     VocabularyType::InMemoryUncompressed, "other");
+
+  std::vector<char> base;
+  std::vector<char> diff;
+  {
+    Qlever source = makeSourceEngine(builderConfig);
+    pinSourceQueries(source);
+    base = source.serializeVocabAndNamedCacheToCompressedBlob();
+    applyUpdateToEngine(source,
+                        "INSERT DATA { <newSubject> <p1> \"new literal\" }");
+    pinSourceQueries(source);
+    diff = source.serializeVocabAndNamedCacheDiffToCompressedBlob(base);
+  }
+
+  // A blob of a completely different index, which the diff was not created
+  // against.
+  std::vector<char> otherBase;
+  {
+    Qlever other = makeSourceEngine(otherBuilderConfig);
+    other.queryAndPinResultWithName(
+        "q1", "SELECT ?s ?o WHERE { ?s <otherPredicate> ?o }");
+    otherBase = other.serializeVocabAndNamedCacheToCompressedBlob();
+  }
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      Qlever::applyDiffToCompressedBlob(otherBase, diff),
+      HasSubstr("checksum of the base does not match"));
+
+  // Garbage is not a diff at all.
+  std::vector<char> garbage(1024, '\xFF');
+  AD_EXPECT_THROW_WITH_MESSAGE(Qlever::applyDiffToCompressedBlob(base, garbage),
+                               HasSubstr("The given diff was not written by"));
+  AD_EXPECT_THROW_WITH_MESSAGE(Manager::describeDiff(garbage),
+                               HasSubstr("The given diff was not written by"));
+}
+
+// _____________________________________________________________________________
+// Test that neither a blob nor a diff can be created from an index that already
+// has a secondary vocabulary of its own (which in particular is the case for an
+// instance that was itself loaded from a blob that contained new words).
 TEST(NamedCachedQueryBlobManager, serializeRejectsSecondaryVocabulary) {
   Qlever source = makePinnedSourceEngine();
+  std::vector<char> base = source.serializeVocabAndNamedCacheToCompressedBlob();
 
   auto snapshot = source.indexAndViewsSnapshot();
   snapshot->index_.getImpl().setSecondaryVocab(
@@ -775,6 +948,9 @@ TEST(NamedCachedQueryBlobManager, serializeRejectsSecondaryVocabulary) {
 
   AD_EXPECT_THROW_WITH_MESSAGE(
       source.serializeVocabAndNamedCacheToCompressedBlob(),
+      HasSubstr("without a secondary vocabulary"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      source.serializeVocabAndNamedCacheDiffToCompressedBlob(base),
       HasSubstr("without a secondary vocabulary"));
 }
 
@@ -818,4 +994,34 @@ TEST(NamedCachedQueryBlobManager, parseBlobLayoutOfFullBlob) {
     previousEnd = region.end_;
   }
   EXPECT_LE(previousEnd, uncompressed.size());
+}
+
+// _____________________________________________________________________________
+// Test that a diff against a base blob whose contents did not change at all
+// reproduces exactly the bytes of that base blob. This is what the position
+// independence of the chunks is about (see
+// `NamedCachedQueryBlobManager::parseBlobLayout`): the complete blob is
+// assembled from instructions that copy the chunks of the base blob to
+// (possibly) different offsets.
+TEST(NamedCachedQueryBlobManager, diffWithoutChanges) {
+  Qlever source = makePinnedSourceEngine();
+  std::vector<char> base = source.serializeVocabAndNamedCacheToCompressedBlob();
+
+  // Re-pin the very same queries, without any update in between.
+  pinSourceQueries(source);
+  std::vector<char> diff =
+      source.serializeVocabAndNamedCacheDiffToCompressedBlob(base);
+
+  // Only the header is inserted; all chunks are copied from the base blob, and
+  // because they are contiguous there, those copies are merged into a single
+  // instruction.
+  auto statistics = Manager::describeDiff(diff);
+  EXPECT_EQ(statistics.numInsertInstructions_, 1u);
+  EXPECT_EQ(statistics.numCopyInstructions_, 1u);
+  EXPECT_EQ(statistics.numInsertedBytes_, 10u);
+
+  auto uncompressedBase = Manager::decompressBlob(base, {});
+  auto uncompressedPatched = Manager::decompressBlob(
+      Qlever::applyDiffToCompressedBlob(base, diff), {});
+  EXPECT_THAT(uncompressedPatched, ElementsAreArray(uncompressedBase));
 }

--- a/test/libqlever/NamedCachedQueryBlobManagerTest.cpp
+++ b/test/libqlever/NamedCachedQueryBlobManagerTest.cpp
@@ -15,6 +15,7 @@
 
 #include <array>
 #include <cstdint>
+#include <memory>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -22,8 +23,12 @@
 #include <vector>
 
 #include "../util/GTestHelpers.h"
+#include "../util/IndexTestHelpers.h"
+#include "QleverTestHelpers.h"
 #include "backports/memory_resource.h"
 #include "backports/span.h"
+#include "index/IndexImpl.h"
+#include "index/vocabulary/SecondaryVocabulary.h"
 #include "index/vocabulary/VocabularyTypes.h"
 #include "libqlever/NamedCachedQueryBlobManager.h"
 #include "libqlever/Qlever.h"
@@ -152,13 +157,22 @@ auto makeBlobReader(ql::span<const char> data) {
       true, ql::span<const char>>{data};
 }
 
-// Decompress the `compressedBlob`, skip its header, and return the index
-// metadata JSON that is stored directly after that header (see
-// `NamedCachedQueryBlobManager::serialize`).
+// Return a read serializer for the payload of the given chunk `region` of the
+// (already decompressed) blob in `data`. Note that the payload of a chunk
+// begins at a multiple of `alignof(std::max_align_t)`, so the returned
+// serializer is properly aligned.
+auto makeChunkPayloadReader(ql::span<const char> data,
+                            const Manager::BlobLayout::Region& region) {
+  return makeBlobReader(region.payloadSpan(data));
+}
+
+// Decompress the `compressedBlob` and return the index metadata JSON that is
+// stored in its first chunk (see
+// `NamedCachedQueryBlobManager::parseBlobLayout`).
 nlohmann::json metadataFromBlob(ql::span<const char> compressedBlob) {
   auto uncompressed = Manager::decompressBlob(compressedBlob, {});
-  auto reader = makeBlobReader(uncompressed);
-  Manager::skipAndVerifyBlobHeader(reader);
+  auto layout = Manager::parseBlobLayout(uncompressed);
+  auto reader = makeChunkPayloadReader(uncompressed, layout.metadata_);
   std::string metadataJson;
   reader >> metadataJson;
   return nlohmann::json::parse(metadataJson);
@@ -629,4 +643,179 @@ TEST(NamedCachedQueryBlobManager, blobWithExcludedEntriesRejectsGeoSplitVocab) {
       source.serializeVocabAndNamedCacheToCompressedBlob(
           excludeConfig({std::string{droppedEntriesRegex}})),
       HasSubstr("on-disk-compressed-geo-split"));
+}
+
+// `applyUpdateToEngine` (used below) is defined in `QleverTestHelpers.h`; see
+// the comment there for why the update has to be parsed separately and for
+// the thread-safety caveat of taking the snapshot only here.
+using ad_utility::testing::applyUpdateToEngine;
+
+namespace {
+// The media type in which the tests below export their query results.
+constexpr ad_utility::MediaType tsv = ad_utility::MediaType::tsv;
+
+// The turtle data used by the tests below, which write a blob after an update
+// and inspect the chunk layout of a blob.
+constexpr std::string_view updateTestData =
+    "<s1> <p1> \"l1\".\n"
+    "<s2> <p1> \"l2\".\n"
+    "<s1> <p2> <o1>.";
+
+// The queries whose results the tests below pin (under the names `q1` and
+// `q2`), and the corresponding queries that return those pinned results.
+constexpr std::string_view sourceQuery1 = "SELECT ?s ?o WHERE { ?s <p1> ?o }";
+constexpr std::string_view sourceQuery2 = "SELECT ?s ?o WHERE { ?s <p2> ?o }";
+constexpr std::string_view cachedQuery1 =
+    "SELECT ?s ?o WHERE { SERVICE ql:cached-result-with-name-q1 {} }";
+constexpr std::string_view cachedQuery2 =
+    "SELECT ?s ?o WHERE { SERVICE ql:cached-result-with-name-q2 {} }";
+
+// Pin the results of `sourceQuery1` and `sourceQuery2` under the names `q1` and
+// `q2`. Note that the pinning has to be repeated after every update, because
+// the results (and not only the query result cache) change.
+void pinSourceQueries(Qlever& engine) {
+  engine.queryAndPinResultWithName("q1", std::string{sourceQuery1});
+  engine.queryAndPinResultWithName("q2", std::string{sourceQuery2});
+}
+
+// Open a `Qlever` instance on the index described by `builderConfig`, with the
+// persisting of updates switched off (the tests apply updates in memory only).
+Qlever makeSourceEngine(const IndexBuilderConfig& builderConfig) {
+  EngineConfig config{builderConfig};
+  config.persistUpdates_ = false;
+  return Qlever{config};
+}
+
+// Build the test index (`updateTestData`), open a `Qlever` instance on it via
+// `makeSourceEngine`, and pin the queries via `pinSourceQueries`.
+Qlever makePinnedSourceEngine() {
+  auto builderConfig = buildTestIndex(updateTestData);
+  Qlever source = makeSourceEngine(builderConfig);
+  pinSourceQueries(source);
+  return source;
+}
+
+// Run the two cached queries (see `cachedQuery1`, `cachedQuery2`) on `engine`
+// and return their results in TSV format.
+std::pair<std::string, std::string> cachedResultsOf(Qlever& engine) {
+  return {engine.query(std::string{cachedQuery1}, tsv),
+          engine.query(std::string{cachedQuery2}, tsv)};
+}
+
+// Load `blob` into a fresh `Qlever` instance that has NO index files on disk at
+// all (constructed with `skipLoading`).
+std::unique_ptr<Qlever> loadBlob(ql::span<const char> blob) {
+  auto target = std::make_unique<Qlever>(EngineConfig{}, /*skipLoading=*/true);
+  target->deserializeVocabAndNamedCacheFromCompressedBlob(blob);
+  return target;
+}
+
+// Return the secondary vocabulary of the index of `engine`, which must have
+// one.
+const SecondaryVocabulary& secondaryVocabularyOf(const Qlever& engine) {
+  const auto* secondaryVocabulary =
+      engine.indexAndViewsSnapshot()->index_.getImpl().secondaryVocab();
+  AD_CONTRACT_CHECK(secondaryVocabulary != nullptr);
+  return *secondaryVocabulary;
+}
+}  // namespace
+
+// _____________________________________________________________________________
+// Test that a complete blob can be written even after an update that introduced
+// new words, which previously threw ("cannot be serialized") because those
+// words only existed as local vocab entries. They are now stored in the
+// secondary vocabulary of the blob, which the loaded instance picks up.
+TEST(NamedCachedQueryBlobManager, fullBlobAfterUpdate) {
+  auto builderConfig = buildTestIndex(updateTestData);
+  Qlever source = makeSourceEngine(builderConfig);
+  applyUpdateToEngine(source,
+                      "INSERT DATA { <newSubject> <p1> \"new literal\" }");
+  pinSourceQueries(source);
+
+  std::vector<char> blob;
+  EXPECT_NO_THROW(blob = source.serializeVocabAndNamedCacheToCompressedBlob());
+  auto target = loadBlob(blob);
+  EXPECT_EQ(cachedResultsOf(*target), cachedResultsOf(source));
+  EXPECT_EQ(secondaryVocabularyOf(*target).numSegments(), 1u);
+}
+
+// _____________________________________________________________________________
+// Test that a word which an update introduced (and which hence is not part of
+// the vocabulary of the index) is found in the secondary vocabulary of the
+// loaded blob, so that a `FILTER` on that word inside a cached result works,
+// i.e. the `Id` of the secondary vocabulary is found for the IRI of the query.
+TEST(NamedCachedQueryBlobManager, newWordsInSecondaryVocabularyOfBlob) {
+  auto builderConfig = buildTestIndex(updateTestData);
+  Qlever source = makeSourceEngine(builderConfig);
+  applyUpdateToEngine(source,
+                      "INSERT DATA { <newSubject> <p1> \"new literal\" }");
+  pinSourceQueries(source);
+  std::vector<char> blob = source.serializeVocabAndNamedCacheToCompressedBlob();
+
+  auto target = loadBlob(blob);
+  EXPECT_TRUE(secondaryVocabularyOf(*target).getId("<newSubject>").has_value());
+  EXPECT_EQ(target->query("SELECT ?s ?o WHERE { SERVICE "
+                          "ql:cached-result-with-name-q1 {} FILTER(?s = "
+                          "<newSubject>) }",
+                          tsv),
+            "?s\t?o\n<newSubject>\t\"new literal\"\n");
+}
+
+// _____________________________________________________________________________
+// Test that a blob cannot be created from an index that already has a secondary
+// vocabulary of its own (which in particular is the case for an instance that
+// was itself loaded from a blob that contained new words).
+TEST(NamedCachedQueryBlobManager, serializeRejectsSecondaryVocabulary) {
+  Qlever source = makePinnedSourceEngine();
+
+  auto snapshot = source.indexAndViewsSnapshot();
+  snapshot->index_.getImpl().setSecondaryVocab(
+      std::make_shared<const SecondaryVocabulary>(
+          std::vector<std::string>{"<aWordThatIsNotInTheIndex>"}));
+
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      source.serializeVocabAndNamedCacheToCompressedBlob(),
+      HasSubstr("without a secondary vocabulary"));
+}
+
+// _____________________________________________________________________________
+// Whitebox test of the chunk layout of a blob: the chunks are found in the
+// expected order, and every one of them begins at a multiple of the alignment
+// that makes them position independent (see
+// `NamedCachedQueryBlobManager::parseBlobLayout`).
+TEST(NamedCachedQueryBlobManager, parseBlobLayoutOfFullBlob) {
+  auto builderConfig = buildTestIndex(updateTestData);
+  std::vector<char> blob;
+  {
+    Qlever source = makeSourceEngine(builderConfig);
+    pinSourceQueries(source);
+    blob = source.serializeVocabAndNamedCacheToCompressedBlob();
+  }
+  auto uncompressed = Manager::decompressBlob(blob, {});
+  auto layout = Manager::parseBlobLayout(uncompressed);
+
+  // No update was applied, so all words are contained in the vocabulary of the
+  // index and the secondary vocabulary of the blob is empty.
+  EXPECT_THAT(layout.segments_, IsEmpty());
+  std::vector<std::string> keys;
+  for (const auto& entry : layout.entries_) {
+    keys.push_back(entry.key_);
+  }
+  EXPECT_THAT(keys, ElementsAre("q1", "q2"));
+
+  std::vector<Manager::BlobLayout::Region> regions{
+      layout.metadata_, layout.vocabulary_, layout.segmentCount_,
+      layout.entryCount_};
+  for (const auto& entry : layout.entries_) {
+    regions.push_back(entry.region_);
+  }
+  size_t previousEnd = 0;
+  for (const Manager::BlobLayout::Region& region : regions) {
+    EXPECT_EQ(region.begin_ % alignof(std::max_align_t), 0u);
+    EXPECT_EQ(region.payloadBegin() % alignof(std::max_align_t), 0u);
+    EXPECT_GT(region.size(), Manager::BlobLayout::chunkHeaderSize);
+    EXPECT_GE(region.begin_, previousEnd);
+    previousEnd = region.end_;
+  }
+  EXPECT_LE(previousEnd, uncompressed.size());
 }

--- a/test/libqlever/QleverTest.cpp
+++ b/test/libqlever/QleverTest.cpp
@@ -14,6 +14,7 @@
 #include "../util/IdTableHelpers.h"
 #include "../util/IndexTestHelpers.h"
 #include "../util/RuntimeParametersTestHelpers.h"
+#include "QleverTestHelpers.h"
 #include "backports/filesystem.h"
 #include "engine/ExternalValues.h"
 #include "engine/MaterializedViews.h"
@@ -779,26 +780,10 @@ TEST(LibQlever, applyUpdate) {
   EXPECT_EQ(engine.cache().numNonPinnedEntries(), 0U);
 }
 
-namespace {
-// Parse and plan `update` and apply it to `engine` via `Qlever::applyUpdate`,
-// returning the metadata. For why the update has to be parsed separately and
-// for the thread-safety caveat of taking the snapshot only here, see the
-// comments in `LibQlever.applyUpdate` above.
-UpdateMetadata applyUpdateToEngine(Qlever& engine, const std::string& update) {
-  ad_utility::BlankNodeManager bnm;
-  auto parsedUpdates = SparqlParser::parseUpdate(
-      &bnm, ad_utility::testing::encodedIriManager(), update);
-  AD_CORRECTNESS_CHECK(parsedUpdates.size() == 1);
-  auto plannedUpdate =
-      engine.planQuery(engine.bindParsedQuery(std::move(parsedUpdates[0])));
-  auto handle = std::make_shared<ad_utility::CancellationHandle<>>();
-  auto snapshot = engine.indexAndViewsSnapshot();
-  return snapshot->index_.deltaTriplesManager().modify<UpdateMetadata>(
-      [&](DeltaTriples& deltaTriples) {
-        return engine.applyUpdate(plannedUpdate, handle, deltaTriples);
-      });
-}
-}  // namespace
+// `applyUpdateToEngine` (used below) is defined in `QleverTestHelpers.h`; see
+// the comment there for why the update has to be parsed separately and for
+// the thread-safety caveat of taking the snapshot only here.
+using ad_utility::testing::applyUpdateToEngine;
 
 // _____________________________________________________________________________
 // Direct counterpart to `ServerTest.clearDeltaTriples`: populate the delta

--- a/test/libqlever/QleverTestHelpers.h
+++ b/test/libqlever/QleverTestHelpers.h
@@ -1,0 +1,59 @@
+// Copyright 2026 The QLever Authors, in particular:
+//
+// 2026 Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>, UFR
+//
+// UFR = University of Freiburg, Chair of Algorithms and Data Structures
+//
+// You may not use this file except in compliance with the Apache 2.0 License,
+// which can be found in the `LICENSE` file at the root of the QLever project.
+
+#ifndef QLEVER_TEST_LIBQLEVER_QLEVERTESTHELPERS_H
+#define QLEVER_TEST_LIBQLEVER_QLEVERTESTHELPERS_H
+
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "../util/IndexTestHelpers.h"
+#include "engine/UpdateMetadata.h"
+#include "index/DeltaTriples.h"
+#include "libqlever/Qlever.h"
+#include "parser/SparqlParser.h"
+#include "util/BlankNodeManager.h"
+#include "util/CancellationHandle.h"
+#include "util/Exception.h"
+
+namespace ad_utility::testing {
+
+// Parse and plan `update` and apply it to `engine` via `Qlever::applyUpdate`,
+// returning the metadata. `Qlever::parseQuery`/`parseAndPlanQuery` only accept
+// SPARQL queries, not updates (see `SparqlParser::parseQuery` vs.
+// `parseUpdate`), so an update has to be parsed separately and then planned via
+// `Qlever::bindParsedQuery`.
+//
+// NOTE: The snapshot that provides the `DeltaTriples` is taken only here,
+// independently of the one that the update was planned against. In general
+// this is not thread-safe (a concurrent index rebuild between the two calls
+// would violate the precondition of `applyUpdate`), but the tests that use
+// this helper are single-threaded, and `PlannedQuery` currently does not
+// expose the snapshot it was planned against. See the comments in
+// `LibQlever.applyUpdate` in `QleverTest.cpp` for details.
+inline UpdateMetadata applyUpdateToEngine(qlever::Qlever& engine,
+                                          const std::string& update) {
+  ad_utility::BlankNodeManager blankNodeManager;
+  auto parsedUpdates = SparqlParser::parseUpdate(
+      &blankNodeManager, ad_utility::testing::encodedIriManager(), update);
+  AD_CORRECTNESS_CHECK(parsedUpdates.size() == 1);
+  auto plannedUpdate =
+      engine.planQuery(engine.bindParsedQuery(std::move(parsedUpdates[0])));
+  auto handle = std::make_shared<ad_utility::CancellationHandle<>>();
+  auto snapshot = engine.indexAndViewsSnapshot();
+  return snapshot->index_.deltaTriplesManager().modify<UpdateMetadata>(
+      [&](DeltaTriples& deltaTriples) {
+        return engine.applyUpdate(plannedUpdate, handle, deltaTriples);
+      });
+}
+
+}  // namespace ad_utility::testing
+
+#endif  // QLEVER_TEST_LIBQLEVER_QLEVERTESTHELPERS_H

--- a/test/util/IndexTestHelpers.cpp
+++ b/test/util/IndexTestHelpers.cpp
@@ -317,9 +317,8 @@ Index makeTestIndex(const std::string& indexBasename, TestIndexConfig c) {
   }
 
   if (c.secondaryVocabWords.has_value()) {
-    index.getImpl().setSecondaryVocabForTesting(
-        std::make_shared<SecondaryVocabulary>(
-            std::move(c.secondaryVocabWords).value()));
+    index.getImpl().setSecondaryVocab(std::make_shared<SecondaryVocabulary>(
+        std::move(c.secondaryVocabWords).value()));
   }
 
   if (c.usePatterns && c.loadAllPermutations) {

--- a/test/util/IndexTestHelpers.h
+++ b/test/util/IndexTestHelpers.h
@@ -84,8 +84,8 @@ struct TestIndexConfig {
   // order is arbitrary, see `SecondaryVocabulary`), and must not be contained
   // in `turtleInput`, because the secondary vocabulary is disjoint from the
   // vocabulary of the main index. NOTE: A secondary vocabulary is currently
-  // only created for testing (see `IndexImpl::setSecondaryVocab`), which is
-  // what this member does.
+  // created either here for testing (see `IndexImpl::setSecondaryVocab`), which
+  // is what this member does, or by `NamedCachedQueryBlobManager::deserialize`.
   std::optional<std::vector<std::string>> secondaryVocabWords = std::nullopt;
 
   // A very typical use case is to only specify the turtle input, and leave all

--- a/test/util/IndexTestHelpers.h
+++ b/test/util/IndexTestHelpers.h
@@ -80,12 +80,12 @@ struct TestIndexConfig {
   // index building.
   bool addHasWordTriples = false;
   // The words of the secondary vocabulary of the index (see
-  // `index/vocabulary/SecondaryVocabulary.h`). They have to be sorted and
-  // distinct, and must not be contained in `turtleInput`, because the
-  // secondary vocabulary is disjoint from the vocabulary of the main index.
-  // NOTE: A secondary vocabulary can currently only be created for testing
-  // (see `IndexImpl::setSecondaryVocabForTesting`), which is what this member
-  // does.
+  // `index/vocabulary/SecondaryVocabulary.h`). They have to be distinct (their
+  // order is arbitrary, see `SecondaryVocabulary`), and must not be contained
+  // in `turtleInput`, because the secondary vocabulary is disjoint from the
+  // vocabulary of the main index. NOTE: A secondary vocabulary is currently
+  // only created for testing (see `IndexImpl::setSecondaryVocab`), which is
+  // what this member does.
   std::optional<std::vector<std::string>> secondaryVocabWords = std::nullopt;
 
   // A very typical use case is to only specify the turtle input, and leave all


### PR DESCRIPTION
## Summary

Last part of the stack split out of #3369. **Stacked on #3373 (chunked blob format) and on #3374 (generic `BinaryDiff`)** (and thus on #3370, #3371, #3372); the diff on GitHub shrinks to this PR's own changes once those are merged.

Add the actual **diff mechanism** for the blob:

- `Qlever::serializeVocabAndNamedCacheDiffToCompressedBlob(baseBlob)` writes a ZSTD-compressed, serialized `ad_utility::BinaryDiff` (with the chunk alignment of the blob as its alignment) against the decompressed base blob. The whole main vocabulary and every cache entry whose chunk is byte-identical to the base are copied; changed or new entries, the counts, and the one new segment of the secondary vocabulary (with the words that are neither in the main vocabulary nor already in a segment of the base) are inserted. Adjacent copies are merged.
- `Qlever::applyDiffToCompressedBlob(base, diff)` applies a diff (padding the output to the chunk alignment before every instruction) and yields a complete blob again, which can serve as the base of the next diff. A diff is refused for a base it was not created against, and invalid instructions are rejected.
- `Qlever::deserializeVocabAndNamedCacheFromCompressedBlob(blob, diffs)` applies a chain of diffs while loading.
- `NamedCachedQueryBlobManager::describeDiff` summarizes a diff (for logging and tests).

Workflow: pin queries → write the base blob → apply updates → re-pin the very same queries (the named cache is cleared by `applyUpdate` and does not store query text) → write the diff against the base → apply it or load with it. Because the secondary vocabulary is append-only, all `Id`s of earlier blobs stay valid across a chain `base + diff1 + diff2`.

### Tests
End-to-end: a diff after an update with new words and a delete (loaded into a fresh instance without index files, also via loading base + diff), incremental diffs (two segments, Id stability, a join of two cached results on a new IRI), rejection of a wrong base and of garbage, a producer with a secondary vocabulary, and a no-change diff that reproduces the base blob byte for byte with a single merged copy instruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)