### PR TITLE
Suppress a ThreadSanitizer false positive in Boost.Asio's executor refcounting

### DIFF
--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -98,6 +98,12 @@ jobs:
 
     runs-on: ${{matrix.runner || 'ubuntu-24.04'}}
 
+    env:
+      # Suppress known ThreadSanitizer false positives in third-party libraries
+      # (see the comments in the file for details). This only affects the job
+      # that builds with `-fsanitize=thread`, all other jobs ignore the variable.
+      TSAN_OPTIONS: "suppressions=${{github.workspace}}/misc/tsan-suppressions.txt"
+
     steps:
       - name: Skip early if conditions are not met
         if: (github.event_name == 'pull_request' && matrix.skipIfPr)

--- a/misc/tsan-suppressions.txt
+++ b/misc/tsan-suppressions.txt
@@ -1,0 +1,20 @@
+# Suppressions for ThreadSanitizer (TSAN). Pass this file to a TSAN-instrumented
+# binary via `TSAN_OPTIONS=suppressions=<path-to-this-file>`. The CI does this
+# in `.github/workflows/native-build.yml`. For the format of this file see
+# https://github.com/google/sanitizers/wiki/ThreadSanitizerSuppressions
+
+# False positive in Boost.Asio (up to and including Boost 1.91). The function
+# `ref_count_down` in `boost/asio/detail/atomic_count.hpp` decrements the
+# reference count of a type-erased executor target (`shared_target_executor`,
+# which is used e.g. when a `strand<any_io_executor>` is stored in an
+# `any_io_executor`, as happens inside `co_spawn`) using a release-only
+# `fetch_sub` followed by an acquire `std::atomic_thread_fence`. TSAN does not
+# model fences. So when two threads drop their references to the same target
+# concurrently, the `delete` by the last one is reported as a data race with
+# the atomic decrement of the other thread. The code itself is correct (it is
+# the same pattern that `boost::shared_ptr` uses). Boost.Asio fixed this in
+# commit 92410f933e ("Fix thread sanitizer warnings due to atomic thread
+# fences"), which is contained in Boost 1.92. Remove the following two entries
+# once the CI uses at least that version.
+race:boost::asio::detail::ref_count_down
+race:boost::asio::execution::detail::shared_target_executor::~shared_target_executor

--- a/misc/tsan-suppressions.txt
+++ b/misc/tsan-suppressions.txt
@@ -16,5 +16,10 @@
 # commit 92410f933e ("Fix thread sanitizer warnings due to atomic thread
 # fences"), which is contained in Boost 1.92. Remove the following two entries
 # once the CI uses at least that version.
+# NOTE: Either entry alone suffices, because a `race:` entry matches any frame
+# of either of the two reported stacks. The second one is a fallback for the
+# case that TSAN cannot restore the stack of the previous access (the
+# decrementing thread), because `ref_count_down` has already returned when the
+# other thread runs `delete`, so it does not appear in the deleting stack.
 race:boost::asio::detail::ref_count_down
 race:boost::asio::execution::detail::shared_target_executor::~shared_target_executor


### PR DESCRIPTION
The thread sanitizer job of the CI sporadically fails in `HttpTest` with a data race that lies entirely inside `Boost.Asio`: one `io_context` thread deletes the type-erased `strand` that `co_spawn` stores in the `any_io_executor` of a finished `session` coroutine, while another thread has just decremented the reference count of that same object. The code is correct. `ref_count_down` in `boost/asio/detail/atomic_count.hpp` uses a release `fetch_sub` followed by an acquire `std::atomic_thread_fence`, the same pattern as `boost::shared_ptr`, but the thread sanitizer does not model fences and therefore never sees the decrement as happening before the delete. `Boost.Asio` fixed this upstream in commit 92410f933e by calling `__tsan_acquire` under the sanitizer, which is contained in Boost 1.92 but not in the 1.83 that the CI uses.

This change adds the file `misc/tsan-suppressions.txt` with two `race:` entries for `ref_count_down` and `~shared_target_executor` (either one suffices, the second is a fallback in case inlining drops a frame) and passes it to every sanitizer-instrumented binary via `TSAN_OPTIONS` at the job level of the native-build workflow, so `ctest`, the benchmark examples and the end-to-end tests are all covered. The other jobs ignore the variable. The file explains why the entries exist and says that they can be removed once the CI uses Boost 1.92 or newer.

NOTE: A standalone program against Boost 1.83 reproduces the identical report, both with two threads dropping copies of one `any_io_executor` and with a `co_spawn` loop that mirrors `HttpServer::listener`. Either entry alone silences it.