### PR TITLE
Exclude the `benchmark` directory from the SonarCloud analysis

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,7 +6,11 @@ sonar.projectName=QLever
 sonar.projectVersion=1.0
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
-sonar.sources=./src,./benchmark
+# Note: The `benchmark` directory is deliberately not analyzed. The benchmarks
+# are not part of the shipped binaries and are typically written quickly and
+# reviewed with less rigor than the rest of the code, so SonarCloud findings
+# there only add noise to the PR reports.
+sonar.sources=./src
 sonar.tests=./test
 sonar.exclusions=src/parser/sparqlParser/generated/*,src/util/http/HttpParser/generated/*, src/util/ConfigManager/generated/*, src/util/MemorySize/generated/*
 


### PR DESCRIPTION
So far, SonarCloud analyzed `src` and `benchmark` (with `test` as test sources). The benchmarks are not part of the shipped binaries and are typically written quickly and reviewed with less rigor than the rest of the code, so SonarCloud findings in them only add noise to the PR reports. This change removes `./benchmark` from `sonar.sources` in `sonar-project.properties`, so that only `src` is analyzed from now on. The CI workflows are unchanged.

NOTE: `sonar-project.properties` is read from the checked-out PR code, so the change takes effect for every PR as soon as it is merged. The analysis of this change itself already ran without the benchmarks.