### PR TITLE
Add `--index-description` and `--text-description` options to `qlever-server`

### DIFF
--- a/src/ServerMain.cpp
+++ b/src/ServerMain.cpp
@@ -132,6 +132,18 @@ int main(int argc, char** argv) {
   add("text,t", po::bool_switch(&config.loadTextIndex_),
       "Also load the text index. The text index must have been built before "
       "using `qlever-index` with options `-d` and `- w`.");
+  add("index-description",
+      po::value<std::string>()->notifier(
+          [&config](const std::string& d) { config.indexDescription_ = d; }),
+      "A description of the index (typically the dataset and its version). "
+      "It is returned by the API (`cmd=stats`, field `name-index`), which is "
+      "used, for example, by the QLever UI. Can also be changed while the "
+      "server is running, via the `index-description` API command.");
+  add("text-description",
+      po::value<std::string>()->notifier(
+          [&config](const std::string& d) { config.textDescription_ = d; }),
+      "A description of the text index, analogous to `--index-description` "
+      "(field `name-text-index`).");
   add("only-pso-and-pos-permutations,o",
       po::bool_switch(&config.onlyPsoAndPos_),
       "Only load the PSO and POS permutations. This disables queries with "

--- a/src/libqlever/Qlever.cpp
+++ b/src/libqlever/Qlever.cpp
@@ -89,6 +89,12 @@ Qlever::Qlever(const EngineConfig& config, bool skipLoading,
   if (config.loadTextIndex_) {
     index.addTextFromOnDiskIndex();
   }
+  if (config.indexDescription_.has_value()) {
+    index.setKbName(config.indexDescription_.value());
+  }
+  if (config.textDescription_.has_value()) {
+    index.setTextName(config.textDescription_.value());
+  }
 
   materializedViewsManager.setOnDiskBase(config.baseName_);
 

--- a/src/libqlever/Qlever.h
+++ b/src/libqlever/Qlever.h
@@ -249,6 +249,14 @@ struct EngineConfig : CommonConfig {
   // Names of materialized views to load from disk during initialization.
   // If a view doesn't exist, a warning is logged and startup continues.
   std::vector<std::string> preloadMaterializedViews_ = {};
+
+  // Descriptions of the index and of the text index. They are returned by the
+  // API (`cmd=stats`, fields `name-index` and `name-text-index`), which is
+  // used, for example, by the QLever UI. If set, they replace the names stored
+  // in the index files. Both can also be changed while the server is running,
+  // via the `index-description` and `text-description` API commands.
+  std::optional<std::string> indexDescription_;
+  std::optional<std::string> textDescription_;
 };
 
 // Class to use QLever as an embedded database, without the HTTP server. See

--- a/test/libqlever/QleverTest.cpp
+++ b/test/libqlever/QleverTest.cpp
@@ -270,6 +270,19 @@ TEST(IndexBuilderConfig, validate) {
 }
 
 // _____________________________________________________________________________
+// The descriptions from the `EngineConfig` replace the names stored in the
+// index files.
+TEST(LibQlever, indexAndTextDescription) {
+  EngineConfig ec = buildTestIndex("<s> <p> <o> .");
+  ec.indexDescription_ = "Some dataset, version 42";
+  ec.textDescription_ = "Some text";
+  Qlever engine{ec};
+  const auto& index = engine.indexAndViewsSnapshot()->index_;
+  EXPECT_EQ(index.getKbName(), "Some dataset, version 42");
+  EXPECT_EQ(index.getTextName(), "Some text");
+}
+
+// _____________________________________________________________________________
 TEST(LibQlever, loadIndexWithoutPermutations) {
   EngineConfig ec = buildTestIndex("<s> <p> <o>. <s2> <p2> \"literal\".");
 


### PR DESCRIPTION
So far, the description of the index (and of the text index) could only be set via the API, once the server was up. That is what `qlever start` did. Anything that restarts the server from its own command line, like Docker's restart policy or a `systemd` unit, therefore lost the descriptions.

With this change, the descriptions can be given on the command line via `--index-description` and `--text-description`. They are then part of the start command and survive any restart. The API commands `index-description` and `text-description` still work for changing them while the server is running.

NOTE: The counterpart in `qlever-control`, which passes the descriptions from the Qleverfile via these options, is qlever-dev/qlever-control#341.